### PR TITLE
Multiply hitpoints and damage by factor 10 in D2k and 100 in other mods

### DIFF
--- a/mods/cnc/maps/funpark01/rules.yaml
+++ b/mods/cnc/maps/funpark01/rules.yaml
@@ -47,7 +47,7 @@ OLDLST:
 
 TREX:
 	Health:
-		HP: 750
+		HP: 75000
 	Mobile:
 		Speed: 34
 	AutoTarget:
@@ -55,7 +55,7 @@ TREX:
 
 TRIC:
 	Health:
-		HP: 700
+		HP: 70000
 	Mobile:
 		Speed: 18
 	AutoTarget:
@@ -63,7 +63,7 @@ TRIC:
 
 STEG:
 	Health:
-		HP: 600
+		HP: 60000
 	Mobile:
 		Speed: 32
 

--- a/mods/cnc/maps/gdi01/rules.yaml
+++ b/mods/cnc/maps/gdi01/rules.yaml
@@ -90,7 +90,7 @@ RMBO:
 
 BOAT:
 	Health:
-		HP: 1500
+		HP: 150000
 	AutoTarget:
 		InitialStance: AttackAnything
 	RejectsOrders:

--- a/mods/cnc/maps/gdi01/weapons.yaml
+++ b/mods/cnc/maps/gdi01/weapons.yaml
@@ -1,7 +1,7 @@
 BoatMissile:
 	Warhead@Bonus: SpreadDamage
 		Spread: 128
-		Damage: 20
+		Damage: 2000
 		Versus:
 			None: 50
 			Wood: 100

--- a/mods/cnc/maps/gdi04a/weapons.yaml
+++ b/mods/cnc/maps/gdi04a/weapons.yaml
@@ -1,3 +1,3 @@
 Tiberium:
 	Warhead@1Dam: SpreadDamage
-		Damage: 6
+		Damage: 600

--- a/mods/cnc/maps/gdi04b/weapons.yaml
+++ b/mods/cnc/maps/gdi04b/weapons.yaml
@@ -1,3 +1,3 @@
 Tiberium:
 	Warhead@1Dam: SpreadDamage
-		Damage: 4
+		Damage: 400

--- a/mods/cnc/maps/gdi04c/rules.yaml
+++ b/mods/cnc/maps/gdi04c/rules.yaml
@@ -40,7 +40,7 @@ Player:
 
 ^CivInfantry:
 	Health:
-		HP: 125
+		HP: 12500
 
 ^Bridge:
 	DamageMultiplier@INVULNERABLE:

--- a/mods/cnc/maps/gdi05a/weapons.yaml
+++ b/mods/cnc/maps/gdi05a/weapons.yaml
@@ -1,3 +1,3 @@
 Tiberium:
 	Warhead@1Dam: SpreadDamage
-		Damage: 4
+		Damage: 400

--- a/mods/cnc/maps/gdi06/rules.yaml
+++ b/mods/cnc/maps/gdi06/rules.yaml
@@ -75,16 +75,17 @@ RMBO:
 		TargetWhenIdle: false
 		TargetWhenDamaged: true
 	Health:
-		HP: 150
+		HP: 15000
 
 RMBO.easy:
 	Inherits: RMBO
 	Health:
-		HP: 300
+		HP: 30000
 	SelfHealing:
 		Delay: 10
 		HealIfBelow: 50
 		DamageCooldown: 200
+		Step: 500
 	RenderSprites:
 		Image: RMBO
 

--- a/mods/cnc/maps/nod07c/rules.yaml
+++ b/mods/cnc/maps/nod07c/rules.yaml
@@ -114,7 +114,7 @@ HQ:
 
 BOAT:
 	Health:
-		HP: 1500
+		HP: 150000
 
 TRAN.IN:
 	Inherits: TRAN

--- a/mods/cnc/maps/nod08a/weapons.yaml
+++ b/mods/cnc/maps/nod08a/weapons.yaml
@@ -4,4 +4,4 @@ Napalm.IN:
 		Image: BOMBLET
 	Warhead@1Dam: SpreadDamage
 		Spread: 1000
-		Damage: 1500
+		Damage: 150000

--- a/mods/cnc/maps/nod08b/rules.yaml
+++ b/mods/cnc/maps/nod08b/rules.yaml
@@ -177,7 +177,7 @@ airstrike.proxy:
 
 BOAT:
 	Health:
-		HP: 1500
+		HP: 150000
 	AutoTarget:
 		InitialStance: AttackAnything
 	RejectsOrders:

--- a/mods/cnc/maps/nod08b/weapons.yaml
+++ b/mods/cnc/maps/nod08b/weapons.yaml
@@ -4,4 +4,4 @@ Napalm.IN:
 		Image: BOMBLET
 	Warhead@1Dam: SpreadDamage
 		Spread: 1000
-		Damage: 1500
+		Damage: 150000

--- a/mods/cnc/maps/nod09/rules.yaml
+++ b/mods/cnc/maps/nod09/rules.yaml
@@ -134,7 +134,7 @@ HQ:
 
 BOAT:
 	Health:
-		HP: 1500
+		HP: 150000
 	AutoTarget:
 		InitialStance: AttackAnything
 	RejectsOrders:
@@ -182,11 +182,12 @@ PROCOUT.IN:
 RMBO.easy:
 	Inherits: RMBO
 	Health:
-		HP: 300
+		HP: 30000
 	SelfHealing:
 		Delay: 10
 		HealIfBelow: 50
 		DamageCooldown: 200
+		Step: 500
 	RenderSprites:
 		Image: RMBO
 

--- a/mods/cnc/maps/the-hot-box/rules.yaml
+++ b/mods/cnc/maps/the-hot-box/rules.yaml
@@ -33,7 +33,7 @@ UNITCRATE:
 
 APC:
 	Health:
-		HP: 1000
+		HP: 100000
 	MustBeDestroyed:
 		RequiredForShortGame: true
 	-AttackMove:

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -17,7 +17,7 @@ TRAN:
 		LandableTerrainTypes: Clear,Rough,Road,Ore,Beach,Tiberium,BlueTiberium
 		AltitudeVelocity: 0c100
 	Health:
-		HP: 90
+		HP: 9000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -72,7 +72,7 @@ HELI:
 		TurnSpeed: 4
 		Speed: 186
 	Health:
-		HP: 125
+		HP: 12500
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -132,7 +132,7 @@ ORCA:
 		TurnSpeed: 4
 		Speed: 186
 	Health:
-		HP: 90
+		HP: 9000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -179,7 +179,7 @@ C17:
 		AirborneUpgrades: airborne
 		MaximumPitch: 36
 	Health:
-		HP: 25
+		HP: 2500
 	Armor:
 		Type: Heavy
 	HiddenUnderFog:
@@ -216,7 +216,7 @@ A10:
 		Repulsable: False
 		AirborneUpgrades: airborne
 	Health:
-		HP: 150
+		HP: 15000
 	Armor:
 		Type: Heavy
 	AttackBomber:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -37,7 +37,7 @@
 		UpgradeTypes: inaccuracy
 		Modifier: 90, 80, 70, 50
 	SelfHealing@ELITE:
-		Step: 2
+		Step: 200
 		Delay: 100
 		HealIfBelow: 100
 		DamageCooldown: 125
@@ -246,7 +246,7 @@
 		CrushSound: squish2.aud
 	Guardable:
 	SelfHealing@HOSPITAL:
-		Step: 5
+		Step: 500
 		Delay: 100
 		HealIfBelow: 100
 		DamageCooldown: 125
@@ -301,7 +301,7 @@
 	Mobile:
 		Speed: 56
 	Health:
-		HP: 25
+		HP: 2500
 	RevealsShroud:
 		Range: 2c0
 	ActorLostNotification:
@@ -328,7 +328,7 @@
 	Inherits@2: ^SpriteActor
 	Huntable:
 	Health:
-		HP: 1000
+		HP: 100000
 		Shape: Circle
 			Radius: 128
 	Armor:
@@ -385,7 +385,7 @@
 	Inherits@2: ^SpriteActor
 	Huntable:
 	Health:
-		HP: 300
+		HP: 30000
 		Shape: Circle
 			Radius: 427
 	Armor:
@@ -534,7 +534,7 @@
 		RequiredForShortGame: true
 	RepairableBuilding:
 		RepairPercent: 40
-		RepairStep: 14
+		RepairStep: 1400
 		PlayerExperience: 15
 	WithDeathAnimation:
 		DeathSequence: dead
@@ -552,7 +552,7 @@
 	Inherits: ^Building
 	-UpgradeManager:
 	Health:
-		HP: 400
+		HP: 40000
 	Tooltip:
 		GenericName: Civilian Building
 		GenericStancePrefix: false
@@ -580,7 +580,7 @@
 		Notification: CivilianBuildingCaptured
 	RepairableBuilding:
 		RepairPercent: 40
-		RepairStep: 14
+		RepairStep: 1400
 		PlayerExperience: 15
 	EngineerRepairable:
 	RevealsShroud:
@@ -646,7 +646,7 @@
 	FrozenUnderFog:
 	ScriptTriggers:
 	Health:
-		HP: 100
+		HP: 10000
 		Shape: Rectangle
 			TopLeft: -512, -512
 			BottomRight: 512, 512
@@ -666,7 +666,7 @@
 	RadarColorFromTerrain:
 		Terrain: Tree
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Wood
 	Targetable:
@@ -742,7 +742,7 @@
 ^CommonHuskDefaults:
 	Inherits@1: ^SpriteActor
 	Health:
-		HP: 140
+		HP: 14000
 	Armor:
 		Type: Light
 	HiddenUnderFog:
@@ -801,7 +801,7 @@
 		RequiresForceFire: yes
 		TargetTypes: Ground, Water
 	Health:
-		HP: 500
+		HP: 50000
 	SoundOnDamageTransition:
 		DamagedSounds: xplos.aud
 		DestroyedSounds: xplobig4.aud

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -11,7 +11,7 @@ E1:
 	Mobile:
 		Speed: 56
 	Health:
-		HP: 50
+		HP: 5000
 	Armament:
 		Weapon: M16
 	AttackFrontal:
@@ -33,7 +33,7 @@ E2:
 	Mobile:
 		Speed: 71
 	Health:
-		HP: 50
+		HP: 5000
 	Armament:
 		Weapon: Grenade
 		LocalOffset: 0,0,427
@@ -59,7 +59,7 @@ E3:
 	Mobile:
 		Speed: 42
 	Health:
-		HP: 45
+		HP: 4500
 	AutoTarget:
 		ScanRadius: 6
 	Armament:
@@ -84,7 +84,7 @@ E4:
 	Mobile:
 		Speed: 56
 	Health:
-		HP: 90
+		HP: 9000
 	Armament:
 		Weapon: Flamethrower
 		LocalOffset: 341,0,256
@@ -114,7 +114,7 @@ E5:
 			BlueTiberium: 90
 				PathingCost: 90
 	Health:
-		HP: 90
+		HP: 9000
 	Armament:
 		Weapon: Chemspray
 		LocalOffset: 341,0,256
@@ -139,7 +139,7 @@ E6:
 	Mobile:
 		Speed: 56
 	Health:
-		HP: 25
+		HP: 2500
 	Passenger:
 		PipType: Yellow
 	EngineerRepair:
@@ -167,7 +167,7 @@ RMBO:
 	Guard:
 		Voice: Move
 	Health:
-		HP: 150
+		HP: 15000
 	Passenger:
 		PipType: Red
 		Voice: Move

--- a/mods/cnc/rules/misc.yaml
+++ b/mods/cnc/rules/misc.yaml
@@ -74,7 +74,7 @@ CAMERA:
 	Immobile:
 		OccupiesSpace: false
 	Health:
-		HP: 1000
+		HP: 100000
 	RevealsShroud:
 		Range: 10c0
 		Type: CenterPosition
@@ -91,7 +91,7 @@ CAMERA.small:
 	Immobile:
 		OccupiesSpace: false
 	Health:
-		HP: 1000
+		HP: 100000
 	RevealsShroud:
 		Range: 6c0
 		Type: CenterPosition

--- a/mods/cnc/rules/ships.yaml
+++ b/mods/cnc/rules/ships.yaml
@@ -5,7 +5,7 @@ BOAT:
 	Tooltip:
 		Name: Gunboat
 	Health:
-		HP: 700
+		HP: 70000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -62,7 +62,7 @@ LST:
 		TurnSpeed: 4
 		Speed: 142
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -9,7 +9,7 @@ FACT:
 		Footprint: xxx xxx
 		Dimensions: 3,2
 	Health:
-		HP: 2000
+		HP: 200000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -107,7 +107,7 @@ NUKE:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 500
+		HP: 50000
 	RevealsShroud:
 		Range: 4c0
 	Bib:
@@ -132,7 +132,7 @@ NUK2:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 700
+		HP: 70000
 	RevealsShroud:
 		Range: 4c0
 	Bib:
@@ -155,7 +155,7 @@ PROC:
 		Footprint: _x_ xxx ===
 		Dimensions: 3,3
 	Health:
-		HP: 900
+		HP: 90000
 	RevealsShroud:
 		Range: 6c0
 	Bib:
@@ -201,7 +201,7 @@ SILO:
 		Dimensions: 2,1
 	-GivesBuildableArea:
 	Health:
-		HP: 400
+		HP: 40000
 	RevealsShroud:
 		Range: 4c0
 	Bib:
@@ -239,7 +239,7 @@ PYLE:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 500
+		HP: 50000
 	RevealsShroud:
 		Range: 5c0
 	Bib:
@@ -281,7 +281,7 @@ HAND:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 500
+		HP: 50000
 	RevealsShroud:
 		Range: 5c0
 	Bib:
@@ -323,7 +323,7 @@ AFLD:
 		Footprint: xxxx xxxx
 		Dimensions: 4,2
 	Health:
-		HP: 1000
+		HP: 100000
 	RevealsShroud:
 		Range: 7c0
 	Bib:
@@ -369,7 +369,7 @@ WEAP:
 	SelectionDecorations:
 		VisualBounds: 72,64,0,-16
 	Health:
-		HP: 1000
+		HP: 100000
 	RevealsShroud:
 		Range: 4c0
 	Bib:
@@ -408,7 +408,7 @@ HPAD:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 500
+		HP: 50000
 	RevealsShroud:
 		Range: 5c0
 	Exit@1:
@@ -418,6 +418,7 @@ HPAD:
 	Reservable:
 	RepairsUnits:
 		PlayerExperience: 25
+		HpPerStep: 1000
 	WithRepairAnimation:
 	RallyPoint:
 	ProductionQueue@GDI:
@@ -466,7 +467,7 @@ HQ:
 	WithSpriteBody:
 		PauseAnimationWhenDisabled: true
 	Health:
-		HP: 700
+		HP: 70000
 	RevealsShroud:
 		Range: 10c0
 	Bib:
@@ -515,7 +516,7 @@ FIX:
 	SelectionDecorations:
 		VisualBounds: 72,48
 	Health:
-		HP: 700
+		HP: 70000
 	RevealsShroud:
 		Range: 5c0
 	Bib:
@@ -524,6 +525,7 @@ FIX:
 	RepairsUnits:
 		Interval: 15
 		PlayerExperience: 25
+		HpPerStep: 1000
 	RallyPoint:
 	WithRepairAnimation:
 	Power:
@@ -558,7 +560,7 @@ EYE:
 	WithSpriteBody:
 		PauseAnimationWhenDisabled: true
 	Health:
-		HP: 1200
+		HP: 120000
 	RevealsShroud:
 		Range: 10c0
 	Bib:
@@ -611,7 +613,7 @@ TMPL:
 		PowerdownSound: DisablePower
 	DisabledOverlay:
 	Health:
-		HP: 2000
+		HP: 200000
 	RevealsShroud:
 		Range: 6c0
 	Bib:
@@ -653,7 +655,7 @@ GUN:
 		BuildDurationModifier: 40
 	Building:
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -698,7 +700,7 @@ SAM:
 	RequiresPower:
 	DisabledOverlay:
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -741,7 +743,7 @@ OBLI:
 	RequiresPower:
 	DisabledOverlay:
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -778,7 +780,7 @@ GTWR:
 		BuildDurationModifier: 40
 	Building:
 	Health:
-		HP: 400
+		HP: 40000
 	RevealsShroud:
 		Range: 7c0
 	Bib:
@@ -818,7 +820,7 @@ ATWR:
 	RequiresPower:
 	DisabledOverlay:
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -906,7 +908,7 @@ BRIK:
 		BuildDuration: 500
 		BuildDurationModifier: 40
 	Health:
-		HP: 250
+		HP: 25000
 	Armor:
 		Type: Heavy
 	BlocksProjectiles:

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -5,7 +5,7 @@ V19:
 		Footprint: x
 		Dimensions: 1,1
 	Health:
-		HP: 1000
+		HP: 100000
 	Tooltip:
 		Name: Oil Derrick
 	SpawnActorOnDeath:
@@ -31,7 +31,7 @@ HOSP:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 2500
+		HP: 250000
 	Tooltip:
 		Name: Hospital
 	SpawnActorOnDeath:
@@ -56,7 +56,7 @@ BIO:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 2500
+		HP: 250000
 	Tooltip:
 		Name: Biological Lab
 		Description: Grants Tiberium immunity to infantry.

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -15,7 +15,7 @@ MCV:
 		Speed: 71
 		Crushes: crate, infantry
 	Health:
-		HP: 1200
+		HP: 120000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -61,7 +61,7 @@ HARV:
 	Mobile:
 		Speed: 85
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -93,7 +93,7 @@ APC:
 		TurnSpeed: 8
 		Speed: 128
 	Health:
-		HP: 210
+		HP: 21000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -140,7 +140,7 @@ ARTY:
 		TurnSpeed: 4
 		Speed: 85
 	Health:
-		HP: 75
+		HP: 7500
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -175,7 +175,7 @@ FTNK:
 		TurnSpeed: 7
 		Speed: 99
 	Health:
-		HP: 270
+		HP: 27000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -208,7 +208,7 @@ BGGY:
 		TurnSpeed: 10
 		Speed: 170
 	Health:
-		HP: 120
+		HP: 12000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -249,7 +249,7 @@ BIKE:
 			BlueTiberium: 35
 			Beach: 35
 	Health:
-		HP: 120
+		HP: 12000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -278,7 +278,7 @@ JEEP:
 		TurnSpeed: 10
 		Speed: 156
 	Health:
-		HP: 160
+		HP: 16000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -312,7 +312,7 @@ LTNK:
 		TurnSpeed: 7
 		Speed: 110
 	Health:
-		HP: 340
+		HP: 34000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -346,7 +346,7 @@ MTNK:
 	Mobile:
 		Speed: 85
 	Health:
-		HP: 450
+		HP: 45000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -384,7 +384,7 @@ HTNK:
 		Speed: 56
 		TurnSpeed: 3
 	Health:
-		HP: 800
+		HP: 80000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -412,6 +412,7 @@ HTNK:
 		Delay: 10
 		HealIfBelow: 50
 		DamageCooldown: 200
+		Step: 500
 	SpawnActorOnDeath:
 		Actor: HTNK.Husk
 	SelectionDecorations:
@@ -432,7 +433,7 @@ MSAM:
 		Speed: 85
 		TurnSpeed: 4
 	Health:
-		HP: 120
+		HP: 12000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -468,7 +469,7 @@ MLRS:
 		Speed: 99
 		TurnSpeed: 7
 	Health:
-		HP: 120
+		HP: 12000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -511,7 +512,7 @@ STNK:
 		Speed: 142
 		Crushes: crate, infantry
 	Health:
-		HP: 150
+		HP: 15000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -542,7 +543,7 @@ MHQ:
 		Name: Mobile HQ
 		Description: Mobile base of operations
 	Health:
-		HP: 200
+		HP: 20000
 	Armor:
 		Type: Light
 	Mobile:

--- a/mods/cnc/weapons/explosions.yaml
+++ b/mods/cnc/weapons/explosions.yaml
@@ -1,7 +1,7 @@
 FlametankExplode:
 	Warhead@1Dam: SpreadDamage
 		Spread: 1c0
-		Damage: 115
+		Damage: 11500
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: big_napalm
@@ -12,7 +12,7 @@ FlametankExplode:
 HeliCrash:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 40
+		Damage: 4000
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: poof
@@ -31,7 +31,7 @@ HeliExplode:
 UnitExplode:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 50
+		Damage: 5000
 		Versus:
 			None: 90
 			Wood: 75
@@ -52,7 +52,7 @@ UnitExplodeShip:
 UnitExplodeSmall:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 40
+		Damage: 4000
 		Versus:
 			None: 90
 			Wood: 75
@@ -68,7 +68,7 @@ UnitExplodeSmall:
 GrenadierExplode:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
-		Damage: 10
+		Damage: 1000
 		Versus:
 			None: 90
 			Wood: 75
@@ -84,7 +84,7 @@ GrenadierExplode:
 Napalm.Crate:
 	Warhead@1Dam: SpreadDamage
 		Spread: 170
-		Damage: 50
+		Damage: 5000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
 			None: 90

--- a/mods/cnc/weapons/largecaliber.yaml
+++ b/mods/cnc/weapons/largecaliber.yaml
@@ -7,7 +7,7 @@
 		Speed: 853
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 25
+		Damage: 2500
 		Versus:
 			None: 25
 			Wood: 75
@@ -30,7 +30,7 @@
 		Speed: 682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 30
+		Damage: 3000
 		Versus:
 			None: 30
 			Wood: 75
@@ -53,7 +53,7 @@
 		Speed: 682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 40
+		Damage: 4000
 		Versus:
 			None: 25
 			Wood: 100
@@ -78,7 +78,7 @@
 		Speed: 682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 40
+		Damage: 4000
 		Versus:
 			None: 25
 			Wood: 100
@@ -101,7 +101,7 @@ TurretGun:
 		Speed: 853
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 40
+		Damage: 4000
 		Versus:
 			None: 20
 			Wood: 25
@@ -129,7 +129,7 @@ ArtilleryShell:
 		Image: 120MM
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
-		Damage: 150
+		Damage: 15000
 		Versus:
 			None: 100
 			Wood: 80

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -16,7 +16,7 @@ Rockets:
 		RangeLimit: 7c204
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 35
+		Damage: 3500
 		ValidTargets: Ground, Air
 		Versus:
 			None: 30
@@ -50,7 +50,7 @@ BikeRockets:
 		RangeLimit: 7c204
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 30
+		Damage: 3000
 		ValidTargets: Ground, Air
 		Versus:
 			None: 25
@@ -85,7 +85,7 @@ OrcaAGMissiles:
 		RangeLimit: 6c0
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 25
+		Damage: 2500
 		ValidTargets: Ground
 		Versus:
 			None: 50
@@ -120,7 +120,7 @@ OrcaAAMissiles:
 		RangeLimit: 6c0
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 25
+		Damage: 2500
 		ValidTargets: Air
 		Versus:
 			Light: 75
@@ -149,7 +149,7 @@ MammothMissiles:
 		RangeLimit: 6c0
 	Warhead@1Dam: SpreadDamage
 		Spread: 298
-		Damage: 45
+		Damage: 4500
 		ValidTargets: Ground, Air
 		Versus:
 			None: 50
@@ -190,7 +190,7 @@ MammothMissiles:
 		Speed: 341
 	Warhead@1Dam: SpreadDamage
 		Spread: 683
-		Damage: 25
+		Damage: 2500
 		ValidTargets: Ground
 		Versus:
 			None: 35
@@ -224,7 +224,7 @@ MammothMissiles:
 		RangeLimit: 8c409
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 60
+		Damage: 6000
 		ValidTargets: Ground, Air
 		Versus:
 			None: 25
@@ -257,7 +257,7 @@ BoatMissile:
 		RangeLimit: 9c614
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
-		Damage: 60
+		Damage: 6000
 		Versus:
 			None: 90
 			Wood: 75
@@ -293,7 +293,7 @@ TowerMissle:
 		RangeLimit: 8c409
 	Warhead@1Dam: SpreadDamage
 		Spread: 683
-		Damage: 25
+		Damage: 2500
 		ValidTargets: Ground
 		Versus:
 			None: 50
@@ -330,7 +330,7 @@ SAMMissile:
 			Wood: 100
 			Light: 100
 			Heavy: 75
-		Damage: 35
+		Damage: 3500
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@3Eff: CreateEffect
 		Explosions: small_building
@@ -352,7 +352,7 @@ HonestJohn:
 		Angle: 88
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
-		Damage: 100
+		Damage: 10000
 		Versus:
 			None: 90
 			Wood: 75
@@ -384,7 +384,7 @@ Patriot:
 		ValidTargets: Air
 		Versus:
 			Heavy: 75
-		Damage: 50
+		Damage: 5000
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@3Eff: CreateEffect
 		Explosions: poof

--- a/mods/cnc/weapons/other.yaml
+++ b/mods/cnc/weapons/other.yaml
@@ -8,7 +8,7 @@ Flamethrower:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
-		Damage: 40
+		Damage: 4000
 		ValidTargets: Ground, Trees
 		InvalidTargets: Wall
 		Versus:
@@ -36,7 +36,7 @@ BigFlamer:
 	BurstDelay: 25
 	Warhead@1Dam: SpreadDamage
 		Spread: 400
-		Damage: 75
+		Damage: 7500
 		InvalidTargets: Wall
 		ValidTargets: Ground, Trees
 		Versus:
@@ -60,7 +60,7 @@ Chemspray:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
-		Damage: 80
+		Damage: 8000
 		Versus:
 			None: 100
 			Wood: 35
@@ -86,7 +86,7 @@ Grenade:
 		Image: BOMB
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
-		Damage: 50
+		Damage: 5000
 		Versus:
 			None: 100
 			Wood: 50
@@ -110,7 +110,7 @@ Napalm:
 		Image: BOMBLET
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
-		Damage: 30
+		Damage: 3000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: Ground, Water, Trees
 		Versus:
@@ -136,7 +136,7 @@ Laser:
 		ZOffset: 2047
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
-		Damage: 360
+		Damage: 36000
 		Versus:
 			Wood: 50
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath
@@ -147,7 +147,7 @@ Laser:
 TiberiumExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 9
-		Damage: 10
+		Damage: 1000
 		Versus:
 			None: 90
 			Wood: 75
@@ -169,7 +169,7 @@ Tail:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 180
+		Damage: 18000
 		Versus:
 			None: 90
 			Wood: 10
@@ -185,7 +185,7 @@ Horn:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 120
+		Damage: 12000
 		Versus:
 			None: 90
 			Wood: 10
@@ -201,7 +201,7 @@ Teeth:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 180
+		Damage: 18000
 		Versus:
 			None: 90
 			Wood: 10
@@ -217,7 +217,7 @@ Claw:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 60
+		Damage: 6000
 		Versus:
 			None: 90
 			Wood: 10

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -113,7 +113,7 @@ M16:
 			None: 100
 			Wood: 25
 			Light: 30
-			Heavy: 15
+			Heavy: 10
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piff

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -8,7 +8,7 @@ Sniper:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
-		Damage: 100
+		Damage: 10000
 		ValidTargets: Infantry
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 
@@ -20,7 +20,7 @@ HighV:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 683
-		Damage: 30
+		Damage: 3000
 		Versus:
 			None: 100
 			Wood: 50
@@ -43,7 +43,7 @@ HeliAGGun:
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
-		Damage: 20
+		Damage: 2000
 		ValidTargets: Ground
 		Versus:
 			None: 100
@@ -67,7 +67,7 @@ HeliAAGun:
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 20
+		Damage: 2000
 		ValidTargets: Air
 		Versus:
 			None: 100
@@ -87,7 +87,7 @@ Pistol:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 1
+		Damage: 100
 		InvalidTargets: Wall
 		Versus:
 			None: 100
@@ -107,7 +107,7 @@ M16:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 15
+		Damage: 1500
 		InvalidTargets: Wall
 		Versus:
 			None: 100
@@ -128,7 +128,7 @@ MachineGun:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 15
+		Damage: 1500
 		InvalidTargets: Wall
 		Versus:
 			None: 100
@@ -148,7 +148,7 @@ Vulcan:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 100
+		Damage: 10000
 		ValidTargets: Ground, Water
 		Versus:
 			None: 100
@@ -168,7 +168,7 @@ APCGun:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 15
+		Damage: 1500
 		ValidTargets: Ground
 		Versus:
 			None: 50
@@ -189,7 +189,7 @@ APCGun.AA:
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 25
+		Damage: 2500
 		ValidTargets: Air
 		Versus:
 			Heavy: 50

--- a/mods/cnc/weapons/superweapons.yaml
+++ b/mods/cnc/weapons/superweapons.yaml
@@ -3,7 +3,7 @@ Atomic:
 	Report: nukemisl.aud
 	Warhead@1Dam_impact: SpreadDamage
 		Spread: 1c0
-		Damage: 150
+		Damage: 15000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: Ground, Air, Trees
 		Versus:
@@ -17,7 +17,7 @@ Atomic:
 		ImpactSounds: nukexplo.aud
 	Warhead@3Dam_areanukea: SpreadDamage
 		Spread: 2c512
-		Damage: 100
+		Damage: 10000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 3
 		ValidTargets: Ground, Air
@@ -40,7 +40,7 @@ Atomic:
 		Delay: 3
 	Warhead@7Dam_areanukeb: SpreadDamage
 		Spread: 3c768
-		Damage: 50
+		Damage: 5000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 6
 		ValidTargets: Ground, Air, Trees
@@ -60,7 +60,7 @@ Atomic:
 		Delay: 6
 	Warhead@10Dam_areanukec: SpreadDamage
 		Spread: 5c0
-		Damage: 20
+		Damage: 2000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 9
 		ValidTargets: Ground, Air, Trees
@@ -83,7 +83,7 @@ IonCannon:
 	ValidTargets: Ground, Air, Trees
 	Warhead@1Dam_impact: SpreadDamage
 		Range: 0, 1c1, 2c1, 2c512
-		Damage: 100
+		Damage: 10000
 		Falloff: 1000, 1000, 250, 100
 		ValidTargets: Ground, Air, Trees
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -6,7 +6,7 @@ carryall.reinforce:
 		Name: Carryall
 		Description: Large winged, planet-bound ship\n  Automatically lifts harvesters.
 	Health:
-		HP: 4800
+		HP: 48000
 	Armor:
 		Type: light
 	Aircraft:
@@ -35,7 +35,7 @@ carryall.reinforce:
 	RenderSprites:
 		Image: carryall
 	SelfHealing:
-		Step: 5
+		Step: 50
 		Delay: 3
 		HealIfBelow: 50
 	Buildable:
@@ -76,7 +76,7 @@ ornithopter:
 	Armament:
 		Weapon: OrniBomb
 	Health:
-		HP: 900
+		HP: 9000
 	Armor:
 		Type: light
 	Aircraft:

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -15,7 +15,7 @@ spicebloom.spawnpoint:
 		Weapon: BloomSpawn
 		EmptyWeapon: BloomSpawn
 	Health:
-		HP: 9999
+		HP: 99990
 		Radius: 1
 	Immobile:
 		OccupiesSpace: false
@@ -42,7 +42,7 @@ spicebloom:
 		Terrain: Spice
 	Immobile:
 	Health:
-		HP: 1
+		HP: 10
 		Radius: 512
 	Targetable:
 		TargetTypes: Ground
@@ -56,7 +56,7 @@ sandworm:
 		Name: Sandworm
 		Description: Attracted by vibrations in the sand.\nWill eat units whole and has a large appetite.
 	Health:
-		HP: 9990
+		HP: 99900
 		Radius: 256
 	Armor:
 		Type: heavy
@@ -120,7 +120,7 @@ sietch:
 		Dimensions: 2,2
 		TerrainTypes: Cliff
 	Health:
-		HP: 6000
+		HP: 60000
 	Armor:
 		Type: wood
 	RevealsShroud:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -111,7 +111,7 @@
 ^Husk:
 	Inherits@1: ^SpriteActor
 	Health:
-		HP: 75
+		HP: 750
 	Armor:
 		Type: light
 	HiddenUnderFog:
@@ -146,7 +146,7 @@
 
 ^TowerHusk:
 	Health:
-		HP: 125
+		HP: 1250
 	Armor:
 		Type: concrete
 	Husk:
@@ -271,6 +271,7 @@
 		Sequences: building, self_destruct, large_explosion
 	RepairableBuilding:
 		PlayerExperience: 25
+		RepairStep: 700
 	EmitInfantryOnSell:
 		ActorTypes: light_inf
 	MustBeDestroyed:

--- a/mods/d2k/rules/husks.yaml
+++ b/mods/d2k/rules/husks.yaml
@@ -1,14 +1,14 @@
 mcv.husk:
 	Inherits: ^VehicleHusk
 	Health:
-		HP: 175
+		HP: 1750
 	Tooltip:
 		Name: Destroyed Mobile Construction Vehicle
 
 harvester.husk:
 	Inherits: ^VehicleHusk
 	Health:
-		HP: 150
+		HP: 1500
 	Tooltip:
 		Name: Destroyed Spice Harvester
 	TransformOnCapture:
@@ -34,7 +34,7 @@ sonic_tank.husk:
 devastator.husk:
 	Inherits: ^VehicleHusk
 	Health:
-		HP: 125
+		HP: 1250
 	TransformOnCapture:
 		IntoActor: devastator
 
@@ -46,7 +46,7 @@ deviator.husk:
 ^combat_tank.husk:
 	Inherits: ^VehicleHusk
 	Health:
-		HP: 100
+		HP: 1000
 	ThrowsParticle@turret:
 		Anim: turret
 

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -11,7 +11,7 @@ light_inf:
 		Name: Light Infantry
 		Description: General-purpose infantry\n  Strong vs Infantry\n  Weak vs Vehicles, Artillery
 	Health:
-		HP: 600
+		HP: 6000
 	Mobile:
 		Speed: 43
 	Armament:
@@ -34,7 +34,7 @@ engineer:
 		Name: Engineer
 		Description: Infiltrates and captures enemy structures\n  Strong vs Buildings\n  Weak vs Everything
 	Health:
-		HP: 500
+		HP: 5000
 	RevealsShroud:
 		Range: 2c768
 	Mobile:
@@ -63,7 +63,7 @@ trooper:
 		Name: Trooper
 		Description: Anti-tank/Anti-aircraft infantry\n  Strong vs Tanks, Aircraft\n  Weak vs Infantry, Artillery
 	Health:
-		HP: 700
+		HP: 7000
 	RevealsShroud:
 		Range: 4c768
 	Mobile:
@@ -90,7 +90,7 @@ thumper:
 		Name: Thumper
 		Description: Attracts nearby worms\n  Unarmed
 	Health:
-		HP: 375
+		HP: 3750
 	RevealsShroud:
 		Range: 2c768
 	Mobile:
@@ -141,7 +141,7 @@ fremen:
 	Valued:
 		Cost: 200	## actually 0, but spawns from support power at Palace
 	Health:
-		HP: 700
+		HP: 7000
 	RevealsShroud:
 		Range: 4c768
 	AutoTarget:
@@ -179,7 +179,7 @@ grenadier:
 		Name: Grenadier
 		Description: Infantry armed with grenades. \n  Strong vs Buildings, Infantry\n  Weak vs Vehicles
 	Health:
-		HP: 600
+		HP: 6000
 	Mobile:
 		Speed: 43
 	Armament:
@@ -208,7 +208,7 @@ sardaukar:
 		Name: Sardaukar
 		Description: Elite assault infantry\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery
 	Health:
-		HP: 1000
+		HP: 10000
 	Mobile:
 		Speed: 31
 	RevealsShroud:
@@ -239,7 +239,7 @@ saboteur:
 		Name: Saboteur
 		Description: Sneaky infantry, armed with explosives\n  Strong vs Buildings\n  Weak vs Everything\n  Special Ability: destroy buildings
 	Health:
-		HP: 400
+		HP: 4000
 	Mobile:
 		Speed: 43
 	Demolition:

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -165,7 +165,7 @@ camera:
 	Immobile:
 		OccupiesSpace: false
 	Health:
-		HP: 1000
+		HP: 10000
 	RevealsShroud:
 		Range: 6c768
 		Type: CenterPosition

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -56,7 +56,7 @@ construction_yard:
 	Selectable:
 		Bounds: 96,64
 	Health:
-		HP: 3000
+		HP: 30000
 	Armor:
 		Type: cy
 	RevealsShroud:
@@ -126,7 +126,7 @@ wind_trap:
 		Dimensions: 2,2
 	Bib:
 	Health:
-		HP: 3000
+		HP: 30000
 	Armor:
 		Type: building
 	RevealsShroud:
@@ -165,7 +165,7 @@ barracks:
 		Dimensions: 2,2
 	Bib:
 	Health:
-		HP: 3200
+		HP: 32000
 	Armor:
 		Type: wood
 	RevealsShroud:
@@ -240,7 +240,7 @@ refinery:
 		Dimensions: 3,2
 	Bib:
 	Health:
-		HP: 3000
+		HP: 30000
 	Armor:
 		Type: building
 	RevealsShroud:
@@ -294,7 +294,7 @@ silo:
 		Adjacent: 4
 	-GivesBuildableArea:
 	Health:
-		HP: 1500
+		HP: 15000
 	Armor:
 		Type: wall
 	RevealsShroud:
@@ -342,7 +342,7 @@ light_factory:
 		Dimensions: 3,2
 	Bib:
 	Health:
-		HP: 3300
+		HP: 33000
 	Armor:
 		Type: light
 	RevealsShroud:
@@ -421,7 +421,7 @@ heavy_factory:
 		Dimensions: 3,3
 	Bib:
 	Health:
-		HP: 3500
+		HP: 35000
 	Armor:
 		Type: wood
 	RevealsShroud:
@@ -507,7 +507,7 @@ outpost:
 		Dimensions: 3,2
 	Bib:
 	Health:
-		HP: 3500
+		HP: 35000
 	Armor:
 		Type: light
 	RevealsShroud:
@@ -546,7 +546,7 @@ starport:
 	Selectable:
 		Bounds: 96,64
 	Health:
-		HP: 3500
+		HP: 35000
 	Armor:
 		Type: building
 	RevealsShroud:
@@ -624,7 +624,7 @@ wall:
 		Adjacent: 7
 		TerrainTypes: Rock, Concrete
 	Health:
-		HP: 2000
+		HP: 20000
 		Shape: Rectangle
 			TopLeft: -512, -512
 			BottomRight: 512, 512
@@ -674,7 +674,7 @@ medium_gun_turret:
 		Bounds: 32,32
 		Priority: 3
 	Health:
-		HP: 2700
+		HP: 27000
 	Armor:
 		Type: heavy
 	RevealsShroud:
@@ -716,7 +716,7 @@ large_gun_turret:
 		Bounds: 32,32
 		Priority: 3
 	Health:
-		HP: 3000
+		HP: 30000
 	Armor:
 		Type: concrete
 	RevealsShroud:
@@ -756,7 +756,7 @@ repair_pad:
 		Footprint: =x= =x= ===
 		Dimensions: 3,3
 	Health:
-		HP: 3000
+		HP: 30000
 	Armor:
 		Type: building
 	RevealsShroud:
@@ -768,7 +768,7 @@ repair_pad:
 	Reservable:
 	RepairsUnits:
 		Interval: 10
-		HpPerStep: 80
+		HpPerStep: 800
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
 	RallyPoint:
@@ -811,7 +811,7 @@ high_tech_factory:
 		Dimensions: 3,3
 	Bib:
 	Health:
-		HP: 3500
+		HP: 35000
 	Armor:
 		Type: wood
 	RevealsShroud:
@@ -875,7 +875,7 @@ research_centre:
 		Dimensions: 3,3
 	Bib:
 	Health:
-		HP: 2500
+		HP: 25000
 	Armor:
 		Type: wood
 	RevealsShroud:
@@ -916,7 +916,7 @@ palace:
 	Bib:
 		HasMinibib: True
 	Health:
-		HP: 4000
+		HP: 40000
 	Armor:
 		Type: wood
 	RevealsShroud:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -15,7 +15,7 @@ mcv:
 		Class: mcv
 		Priority: 3
 	Health:
-		HP: 4500
+		HP: 45000
 	Armor:
 		Type: light
 	Mobile:
@@ -42,7 +42,7 @@ mcv:
 	SelectionDecorations:
 		VisualBounds: 42,42
 	SelfHealing:
-		Step: 5
+		Step: 50
 		Delay: 3
 		HealIfBelow: 50
 
@@ -71,7 +71,7 @@ harvester:
 		SearchFromProcRadius: 30
 		SearchFromOrderRadius: 15
 	Health:
-		HP: 4500
+		HP: 45000
 	Armor:
 		Type: harvester
 	Mobile:
@@ -92,7 +92,7 @@ harvester:
 	SelectionDecorations:
 		VisualBounds: 42,42
 	SelfHealing:
-		Step: 5
+		Step: 50
 		Delay: 3
 		HealIfBelow: 50
 
@@ -112,7 +112,7 @@ trike:
 	Selectable:
 		Class: trike
 	Health:
-		HP: 900
+		HP: 9000
 	Armor:
 		Type: wood
 	Mobile:
@@ -150,7 +150,7 @@ quad:
 		Name: Missile Quad
 		Description: Missile Scout\n Strong vs Vehicles\n  Weak vs Infantry
 	Health:
-		HP: 1100
+		HP: 11000
 	Armor:
 		Type: light
 	Mobile:
@@ -185,7 +185,7 @@ siege_tank:
 		Name: Siege Tank
 		Description: Siege Artillery\n  Strong vs Infantry, Buildings\n  Weak vs Tanks, Aircraft
 	Health:
-		HP: 1200
+		HP: 12000
 	Armor:
 		Type: light
 	Mobile:
@@ -234,7 +234,7 @@ missile_tank:
 		Speed: 64
 		TurnSpeed: 5
 	Health:
-		HP: 1300
+		HP: 13000
 	Armor:
 		Type: wood
 	RevealsShroud:
@@ -269,7 +269,7 @@ sonic_tank:
 		Name: Sonic Tank
 		Description: Fires sonic shocks\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery, Aircraft
 	Health:
-		HP: 3000
+		HP: 30000
 	Armor:
 		Type: light
 	Mobile:
@@ -306,7 +306,7 @@ devastator:
 		Name: Devastator
 		Description: Super Heavy Tank\n  Strong vs Tanks\n  Weak vs Artillery, Aircraft
 	Health:
-		HP: 5000
+		HP: 50000
 	Armor:
 		Type: heavy
 	Mobile:
@@ -333,7 +333,7 @@ devastator:
 	SelectionDecorations:
 		VisualBounds: 44,38,0,0
 	SelfHealing:
-		Step: 5
+		Step: 50
 		Delay: 3
 		HealIfBelow: 50
 
@@ -351,7 +351,7 @@ raider:
 		Name: Raider Trike
 		Description: Improved Scout\n Strong vs Infantry, Light Vehicles
 	Health:
-		HP: 1000
+		HP: 10000
 	Armor:
 		Type: wood
 	Mobile:
@@ -415,7 +415,7 @@ deviator:
 		TurnSpeed: 3
 		Speed: 53
 	Health:
-		HP: 1100
+		HP: 11000
 	Armor:
 		Type: wood
 	RevealsShroud:
@@ -447,7 +447,7 @@ deviator:
 		Name: Combat Tank
 		Description: Main Battle Tank\n  Strong vs Tanks\n  Weak vs Infantry, Aircraft\n \n  Atreides:      +Range\n  Harkonnen: +Health\n  Ordos:         +Speed
 	Health:
-		HP: 2100
+		HP: 21000
 	Armor:
 		Type: heavy
 	Mobile:
@@ -494,7 +494,7 @@ combat_tank_h:
 	Mobile:
 		Speed: 64
 	Health:
-		HP: 2700
+		HP: 27000
 	SpawnActorOnDeath:
 		Actor: combat_tank_h.husk
 
@@ -509,6 +509,6 @@ combat_tank_o:
 	Mobile:
 		Speed: 85
 	Health:
-		HP: 1800
+		HP: 18000
 	SpawnActorOnDeath:
 		Actor: combat_tank_o.husk

--- a/mods/d2k/weapons/debris.yaml
+++ b/mods/d2k/weapons/debris.yaml
@@ -10,7 +10,7 @@ Debris:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 150
+		Damage: 1500
 		Versus:
 			none: 20
 			wall: 50
@@ -45,7 +45,7 @@ Debris2:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 250
+		Damage: 2500
 		Versus:
 			none: 90
 			wall: 5
@@ -80,7 +80,7 @@ Debris3:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 150
+		Damage: 1500
 		Versus:
 			none: 90
 			wall: 5
@@ -115,7 +115,7 @@ Debris4:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 250
+		Damage: 2500
 		Versus:
 			none: 90
 			wall: 5

--- a/mods/d2k/weapons/largeguns.yaml
+++ b/mods/d2k/weapons/largeguns.yaml
@@ -11,7 +11,7 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Falloff: 100, 50, 25, 0
-		Damage: 290
+		Damage: 2900
 		Versus:
 			none: 20
 			wall: 50
@@ -40,7 +40,7 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Falloff: 100, 50, 25, 0
-		Damage: 270
+		Damage: 2700
 		Versus:
 			none: 20
 			wall: 50
@@ -76,7 +76,7 @@ DevBullet:
 	Warhead@1Dam: SpreadDamage
 		Spread: 384
 		Falloff: 100, 50, 25, 0
-		Damage: 650
+		Damage: 6500
 		Versus:
 			none: 50
 			building: 75
@@ -106,7 +106,7 @@ DevBullet:
 	Warhead@1Dam: SpreadDamage
 		Spread: 416
 		Falloff: 100, 65, 35, 20, 0
-		Damage: 450
+		Damage: 4500
 		Versus:
 			none: 125
 			wood: 70

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -14,7 +14,7 @@ Bazooka:
 	Warhead@1Dam: SpreadDamage
 		Spread: 192
 		Falloff: 100, 50, 25, 0
-		Damage: 300
+		Damage: 3000
 		Versus:
 			none: 8
 			wall: 75
@@ -48,7 +48,7 @@ Rocket:
 	Warhead@1Dam: SpreadDamage
 		Spread: 160
 		Falloff: 100, 50, 25, 0
-		Damage: 250
+		Damage: 2500
 		Versus:
 			none: 25
 			building: 50
@@ -90,7 +90,7 @@ TowerMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Falloff: 100, 50, 25, 0
-		Damage: 480
+		Damage: 4800
 		ValidTargets: Ground, Air
 		Versus:
 			none: 15
@@ -132,7 +132,7 @@ mtank_pri:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Falloff: 100, 50, 25, 0
-		Damage: 600
+		Damage: 6000
 		ValidTargets: Ground, Air
 		Versus:
 			none: 15
@@ -173,7 +173,7 @@ DeviatorMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Falloff: 100, 50, 25, 0
-		Damage: 500
+		Damage: 5000
 		Versus:
 			none: 20
 			wall: 20

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -15,7 +15,7 @@ Sound:
 	Warhead@1Dam: SpreadDamage
 		Range: 0, 32
 		Falloff: 100, 100
-		Damage: 150
+		Damage: 1500
 		AffectsParent: false
 		ValidStances: Neutral, Enemy
 		Versus:
@@ -29,8 +29,8 @@ Sound:
 	Warhead@2Dam: SpreadDamage
 		Range: 0, 32
 		Falloff: 50, 50 # Only does half damage to friendly units
-		Damage: 150
 		InvalidTargets: Sonictank # Does not affect friendly sonic tanks at all
+		Damage: 1500
 		AffectsParent: false
 		ValidStances: Ally
 		Versus:
@@ -52,7 +52,7 @@ Heal:
 	Warhead@1Dam: SpreadDamage
 		Spread: 160
 		Falloff: 100, 100, 0
-		Damage: -200
+		Damage: -2000
 		ValidTargets: Infantry
 		DebugOverlayColor: 00FF00
 
@@ -64,7 +64,7 @@ WormJaw:
 		InvalidTargets: Structure, Infantry
 		Spread: 768
 		Falloff: 100, 100, 0
-		Damage: 10000
+		Damage: 100000
 
 OrniBomb:
 	ReloadDelay: 25
@@ -76,7 +76,7 @@ OrniBomb:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 1000 #400 in original, reduce when bombers can do multiple passes
+		Damage: 10000
 		Versus:
 			none: 90
 			wall: 50
@@ -97,7 +97,7 @@ OrniBomb:
 
 Crush:
 	Warhead@1Dam: SpreadDamage
-		Damage: 100
+		Damage: 1000
 		DamageTypes: ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		ImpactSounds: CRUSH1.WAV
@@ -113,7 +113,7 @@ Atomic:
 	Warhead@1Dam: SpreadDamage
 		Spread: 1c0
 		Falloff: 200, 100, 50, 25, 12, 0
-		Damage: 2700	##225 in vanilla but of course is a cluster bomb instead, so damage spread out
+		Damage: 27000
 		Versus:
 			none: 90
 			wall: 50
@@ -133,7 +133,7 @@ CrateNuke:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 500
+		Damage: 5000
 		Versus:
 			none: 90
 			wall: 50
@@ -154,7 +154,7 @@ CrateExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 500
+		Damage: 5000
 		Versus:
 			none: 90
 			wall: 5
@@ -199,7 +199,7 @@ grenade:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 65, 35, 20, 0
-		Damage: 150
+		Damage: 1500
 		Versus:
 			none: 125
 			wood: 70
@@ -220,7 +220,7 @@ GrenDeath:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 150
+		Damage: 1500
 		Versus:
 			none: 125
 			wood: 70
@@ -240,7 +240,7 @@ SardDeath:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Falloff: 100, 50, 25, 0
-		Damage: 300
+		Damage: 3000
 		Versus:
 			none: 15
 			wall: 75
@@ -267,7 +267,7 @@ SpiceExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 75
+		Damage: 750
 		Versus:
 			none: 90
 			wall: 5
@@ -296,7 +296,7 @@ BloomExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 750
+		Damage: 7500
 		Versus:
 			none: 90
 			wall: 5

--- a/mods/d2k/weapons/smallguns.yaml
+++ b/mods/d2k/weapons/smallguns.yaml
@@ -7,7 +7,7 @@ LMG:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Falloff: 100, 50, 25, 0
-		Damage: 125
+		Damage: 1250
 		Versus:
 			wall: 10
 			building: 25
@@ -30,7 +30,7 @@ Fremen_S:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Falloff: 100, 50, 25, 0
-		Damage: 125
+		Damage: 1250
 		Versus:
 			wall: 10
 			building: 25
@@ -54,7 +54,7 @@ M_LMG:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Falloff: 100, 50, 25, 0
-		Damage: 125
+		Damage: 1250
 		Versus:
 			wall: 10
 			building: 25
@@ -77,7 +77,7 @@ M_HMG:
 	Warhead@1Dam: SpreadDamage
 		Spread: 192
 		Falloff: 100, 50, 25, 0
-		Damage: 250
+		Damage: 2500
 		Versus:
 			none: 25
 			building: 50
@@ -100,7 +100,7 @@ Fremen_L:
 	Warhead@1Dam: SpreadDamage
 		Spread: 192
 		Falloff: 100, 50, 25, 0
-		Damage: 250
+		Damage: 2500
 		Versus:
 			none: 25
 			building: 50
@@ -122,7 +122,7 @@ HMG:
 	Warhead@1Dam: SpreadDamage
 		Spread: 160
 		Falloff: 100, 60, 30, 0
-		Damage: 180
+		Damage: 1800
 		Versus:
 			wall: 10
 			building: 25
@@ -145,7 +145,7 @@ HMGo:
 	Warhead@1Dam: SpreadDamage
 		Spread: 160
 		Falloff: 100, 60, 30, 0
-		Damage: 180
+		Damage: 1800
 		Versus:
 			wall: 10
 			building: 25

--- a/mods/ra/maps/allies-01/weapons.yaml
+++ b/mods/ra/maps/allies-01/weapons.yaml
@@ -6,5 +6,5 @@ M60mg:
 	ReloadDelay: 20
 	Burst: 1
 	Warhead: SpreadDamage
-		Damage: 20
+		Damage: 2000
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath

--- a/mods/ra/maps/allies-02/weapons.yaml
+++ b/mods/ra/maps/allies-02/weapons.yaml
@@ -3,5 +3,5 @@ M60mg:
 	ReloadDelay: 20
 	Burst: 1
 	Warhead: SpreadDamage
-		Damage: 20
+		Damage: 2000
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath

--- a/mods/ra/maps/allies-05a/rules.yaml
+++ b/mods/ra/maps/allies-05a/rules.yaml
@@ -103,7 +103,7 @@ Colt:
 		Footprint: _ x
 		Dimensions: 1,2
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/ra/maps/allies-05a/weapons.yaml
+++ b/mods/ra/maps/allies-05a/weapons.yaml
@@ -7,7 +7,7 @@ MissionColt:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
-		Damage: 50
+		Damage: 5000
 		Versus:
 			None: 0
 			Wood: 10

--- a/mods/ra/maps/bomber-john/rules.yaml
+++ b/mods/ra/maps/bomber-john/rules.yaml
@@ -74,7 +74,7 @@ MNLYR:
 		Name: Bomber
 		Description: Lays mines to destroy unwary enemy units.\n  Unarmed
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -100,7 +100,7 @@ MNLYR:
 
 FTUR:
 	Health:
-		HP: 1000
+		HP: 100000
 	Transforms:
 		IntoActor: mnlyr
 		Offset: 0,0
@@ -148,7 +148,7 @@ MINVV:
 	Valued:
 		Cost: 30
 	Health:
-		HP: 200
+		HP: 20000
 	RenderSprites:
 		Image: miner
 	WithSpriteBody:
@@ -156,7 +156,7 @@ MINVV:
 		Name: Bomb
 		Description: Bomb (Hotkey B)
 	SelfHealing:
-		Step: -1
+		Step: -100
 		Delay: 1
 		HealIfBelow: 101
 		DamageCooldown: 0

--- a/mods/ra/maps/center-of-attention-redux-2/rules.yaml
+++ b/mods/ra/maps/center-of-attention-redux-2/rules.yaml
@@ -1,13 +1,13 @@
 OILB.Strong:
 	Inherits: OILB
 	Health:
-		HP: 6000
+		HP: 600000
 	RenderSprites:
 		Image: OILB
 
 OILB.Weak:
 	Inherits: OILB
 	Health:
-		HP: 900
+		HP: 90000
 	RenderSprites:
 		Image: OILB

--- a/mods/ra/maps/desert-shellmap/rules.yaml
+++ b/mods/ra/maps/desert-shellmap/rules.yaml
@@ -91,7 +91,7 @@ Ant:
 	Buildable:
 		Prerequisites: barr
 	Health:
-		HP: 200
+		HP: 20000
 
 E7:
 	-AnnounceOnKill:

--- a/mods/ra/maps/drop-zone-battle-of-tikiaki/rules.yaml
+++ b/mods/ra/maps/drop-zone-battle-of-tikiaki/rules.yaml
@@ -47,7 +47,7 @@ UNITCRATE:
 
 APC:
 	Health:
-		HP: 1000
+		HP: 100000
 	MustBeDestroyed:
 		RequiredForShortGame: true
 	-AttackMove:
@@ -57,7 +57,7 @@ HARV:
 		Name: Bomb Truck
 		Description: Explodes like a damn nuke!
 	Health:
-		HP: 100
+		HP: 10000
 	Explodes:
 		Weapon: CrateNuke
 		EmptyWeapon: CrateNuke
@@ -65,11 +65,11 @@ HARV:
 
 SHOK:
 	Health:
-		HP: 800
+		HP: 80000
 
 DOG:
 	Health:
-		HP: 120
+		HP: 12000
 	Mobile:
 		Speed: 99
 

--- a/mods/ra/maps/drop-zone-battle-of-tikiaki/weapons.yaml
+++ b/mods/ra/maps/drop-zone-battle-of-tikiaki/weapons.yaml
@@ -3,5 +3,5 @@ PortaTesla:
 	Range: 10c0
 	Warhead: SpreadDamage
 		Spread: 42
-		Damage: 80
+		Damage: 8000
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath

--- a/mods/ra/maps/drop-zone-w/rules.yaml
+++ b/mods/ra/maps/drop-zone-w/rules.yaml
@@ -38,7 +38,7 @@ LST:
 	Tooltip:
 		Name: Naval Mobile HQ
 	Health:
-		HP: 1000
+		HP: 100000
 	Mobile:
 		Speed: 170
 	Armament@PRIMARY:

--- a/mods/ra/maps/drop-zone-w/weapons.yaml
+++ b/mods/ra/maps/drop-zone-w/weapons.yaml
@@ -17,7 +17,7 @@
 			Wood: 75
 			Light: 60
 			Heavy: 25
-		Damage: 250
+		Damage: 25000
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@1Eff: CreateEffect
 		Explosions: large_explosion
@@ -49,7 +49,7 @@ SubMissile:
 			None: 40
 			Light: 30
 			Heavy: 30
-		Damage: 400
+		Damage: 40000
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@1Eff: CreateEffect
 		Explosions: large_explosion

--- a/mods/ra/maps/drop-zone/rules.yaml
+++ b/mods/ra/maps/drop-zone/rules.yaml
@@ -47,7 +47,7 @@ UNITCRATE:
 
 APC:
 	Health:
-		HP: 1000
+		HP: 100000
 	MustBeDestroyed:
 		RequiredForShortGame: true
 	-AttackMove:
@@ -57,7 +57,7 @@ HARV:
 		Name: Bomb Truck
 		Description: Explodes like a damn nuke!
 	Health:
-		HP: 100
+		HP: 10000
 	Explodes:
 		Weapon: CrateNuke
 		EmptyWeapon: CrateNuke
@@ -65,11 +65,11 @@ HARV:
 
 SHOK:
 	Health:
-		HP: 800
+		HP: 80000
 
 DOG:
 	Health:
-		HP: 120
+		HP: 12000
 	Mobile:
 		Speed: 99
 

--- a/mods/ra/maps/drop-zone/weapons.yaml
+++ b/mods/ra/maps/drop-zone/weapons.yaml
@@ -3,5 +3,5 @@ PortaTesla:
 	Range: 10c0
 	Warhead: SpreadDamage
 		Spread: 42
-		Damage: 80
+		Damage: 8000
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -112,7 +112,7 @@ Player:
 
 OILB:
 	Health:
-		HP: 3000
+		HP: 300000
 	Armor:
 		Type: Wood
 	Bib:
@@ -133,7 +133,7 @@ MOBILETENT:
 	SelectionDecorations:
 		VisualBounds: 21,21
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Light
 	Mobile:
@@ -155,7 +155,7 @@ MOBILETENT:
 
 TENT:
 	Health:
-		HP: 1000
+		HP: 100000
 	Production:
 		Produces: Infantry, Soldier, Dog, Defense
 	-Sellable:
@@ -183,7 +183,7 @@ PBOX:
 	Valued:
 		Cost: 400
 	Health:
-		HP: 200
+		HP: 20000
 	Armor:
 		Type: Heavy
 	Power:
@@ -259,7 +259,7 @@ SNIPER:
 	Buildable:
 		Prerequisites: barracks
 	Health:
-		HP: 200
+		HP: 20000
 
 SNIPER.soviets:
 	Inherits: SNIPER
@@ -295,17 +295,17 @@ ARTY:
 	Valued:
 		Cost: 600
 	Health:
-		HP: 75
+		HP: 7500
 	RevealsShroud:
 		Range: 7c0
 
 V2RL:
 	Health:
-		HP: 100
+		HP: 10000
 
 4TNK:
 	Health:
-		HP: 2500
+		HP: 250000
 	Mobile:
 		Speed: 56
 	RevealsShroud:
@@ -321,13 +321,13 @@ V2RL:
 		Weapon: napalm
 		EmptyWeapon: napalm
 	SelfHealing:
-		Step: 2
+		Step: 200
 		Delay: 1
 		HealIfBelow: 40
 
 BADR.Bomber:
 	Health:
-		HP: 60
+		HP: 6000
 	Aircraft:
 		Speed: 280
 	AmmoPool:

--- a/mods/ra/maps/fort-lonestar/weapons.yaml
+++ b/mods/ra/maps/fort-lonestar/weapons.yaml
@@ -13,7 +13,7 @@
 		Versus:
 			None: 75
 			Concrete: 100
-		Damage: 150
+		Damage: 15000
 	Warhead@3Eff: CreateEffect
 		Explosions: self_destruct
 
@@ -38,7 +38,7 @@ MammothTusk:
 			Light: 110
 			Heavy: 100
 			Concrete: 200
-		Damage: 250
+		Damage: 25000
 	Warhead@3Eff: CreateEffect
 		Explosions: nuke
 
@@ -65,7 +65,7 @@ TankNapalm:
 			Light: 100
 			Heavy: 100
 			Concrete: 100
-		Damage: 15
+		Damage: 1500
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
@@ -86,7 +86,7 @@ ParaBomb:
 			Wood: 100
 			Light: 60
 			Concrete: 25
-		Damage: 200
+		Damage: 20000
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@3Eff: CreateEffect
 		Explosions: napalm
@@ -111,7 +111,7 @@ ParaBomb:
 			Wood: 100
 			Heavy: 75
 			Concrete: 35
-		Damage: 20
+		Damage: 2000
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@3Eff: CreateEffect
 		Explosions: small_napalm
@@ -134,7 +134,7 @@ FLAK-23:
 			Light: 30
 			Heavy: 40
 			Concrete: 30
-		Damage: 25
+		Damage: 2500
 		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
@@ -158,7 +158,7 @@ SCUD:
 			Wood: 90
 			Light: 80
 			Heavy: 70
-		Damage: 500
+		Damage: 50000
 		AffectsParent: true
 	Warhead@3Eff: CreateEffect
 		Explosions: nuke

--- a/mods/ra/maps/intervention/weapons.yaml
+++ b/mods/ra/maps/intervention/weapons.yaml
@@ -3,5 +3,5 @@ Nike:
 
 Maverick:
 	Warhead@1Dam: SpreadDamage
-		Damage: 175
+		Damage: 17500
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath

--- a/mods/ra/maps/monster-tank-madness/rules.yaml
+++ b/mods/ra/maps/monster-tank-madness/rules.yaml
@@ -56,7 +56,7 @@ PBOX:
 		Name: Super Tank
 		GenericName: Super Tank
 	Health:
-		HP: 20000
+		HP: 2000000
 	Armor:
 		Type: Concrete
 	Mobile:
@@ -89,7 +89,7 @@ PBOX:
 	SpawnActorOnDeath:
 		Actor: 5TNK.Husk
 	SelfHealing:
-		Step: 1
+		Step: 100
 		Delay: 1
 		HealIfBelow: 100
 		DamageCooldown: 150
@@ -106,7 +106,7 @@ PBOX:
 	ThrowsParticle@turret:
 		Anim: turret
 	Health:
-		HP: 2000
+		HP: 200000
 	RenderSprites:
 		Image: 4TNK
 

--- a/mods/ra/maps/monster-tank-madness/weapons.yaml
+++ b/mods/ra/maps/monster-tank-madness/weapons.yaml
@@ -17,7 +17,7 @@ SuperTankPrimary:
 		Image: 120MM
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 50
+		Damage: 5000
 		InvalidTargets: Air, Infantry
 		Versus:
 			None: 20

--- a/mods/ra/maps/soviet-02a/rules.yaml
+++ b/mods/ra/maps/soviet-02a/rules.yaml
@@ -94,7 +94,7 @@ AFLD:
 
 DOG:
 	Health:
-		HP: 25
+		HP: 2500
 	AutoTarget:
 		ScanRadius: 5
 

--- a/mods/ra/maps/soviet-02b/rules.yaml
+++ b/mods/ra/maps/soviet-02b/rules.yaml
@@ -89,6 +89,7 @@ GUN:
 
 FCOM:
 	RepairableBuilding:
+		RepairStep: 700
 
 AFLD:
 	Buildable:
@@ -100,7 +101,7 @@ AFLD:
 
 DOG:
 	Health:
-		HP: 25
+		HP: 2500
 	AutoTarget:
 		ScanRadius: 5
 
@@ -111,13 +112,13 @@ HARV:
 
 BARL:
 	Health:
-		HP: 1
+		HP: 100
 	Explodes:
 		Weapon: MissionBarrelExplode
 
 BRL3:
 	Health:
-		HP: 1
+		HP: 100
 	Explodes:
 		Weapon: MissionBarrelExplode
 

--- a/mods/ra/maps/soviet-02b/weapons.yaml
+++ b/mods/ra/maps/soviet-02b/weapons.yaml
@@ -1,7 +1,7 @@
 MissionBarrelExplode:
 	Warhead@1Dam: SpreadDamage
 		Spread: 600
-		Damage: 100
+		Damage: 10000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 5
 		Versus:

--- a/mods/ra/maps/soviet-03/rules.yaml
+++ b/mods/ra/maps/soviet-03/rules.yaml
@@ -28,23 +28,23 @@ World:
 ^Helicopter:
 	-GivesBounty:
 	Health:
-		HP: 9000
+		HP: 900000
 
 BARL:
 	Health:
-		HP: 1
+		HP: 100
 	Explodes:
 		Weapon: MissionBarrelExplode
 
 BRL3:
 	Health:
-		HP: 1
+		HP: 100
 	Explodes:
 		Weapon: MissionBarrelExplode
 
 FENC:
 	Health:
-		HP: 9000
+		HP: 900000
 
 V01:
 	Cargo:

--- a/mods/ra/maps/soviet-03/weapons.yaml
+++ b/mods/ra/maps/soviet-03/weapons.yaml
@@ -1,7 +1,7 @@
 MissionBarrelExplode:
 	Warhead@1Dam: SpreadDamage
 		Spread: 600
-		Damage: 200
+		Damage: 20000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 5
 		Versus:

--- a/mods/ra/maps/soviet-06a/rules.yaml
+++ b/mods/ra/maps/soviet-06a/rules.yaml
@@ -148,7 +148,7 @@ MNLY.AT:
 
 DOG:
 	Health:
-		HP: 25
+		HP: 2500
 	AutoTarget:
 		ScanRadius: 5
 

--- a/mods/ra/maps/soviet-06b/rules.yaml
+++ b/mods/ra/maps/soviet-06b/rules.yaml
@@ -148,7 +148,7 @@ MNLY.AT:
 
 DOG:
 	Health:
-		HP: 25
+		HP: 2500
 	AutoTarget:
 		ScanRadius: 5
 

--- a/mods/ra/maps/soviet-07/rules.yaml
+++ b/mods/ra/maps/soviet-07/rules.yaml
@@ -21,13 +21,13 @@ World:
 
 BARL:
 	Health:
-		HP: 1
+		HP: 100
 	Explodes:
 		Weapon: MissionBarrelExplodeInterior
 
 BRL3:
 	Health:
-		HP: 1
+		HP: 100
 	Explodes:
 		Weapon: MissionBarrelExplodeInterior
 

--- a/mods/ra/maps/soviet-07/weapons.yaml
+++ b/mods/ra/maps/soviet-07/weapons.yaml
@@ -6,7 +6,7 @@ M1CarbineInterior:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 15
+		Damage: 1500
 		Versus:
 			Wood: 25
 			Light: 30
@@ -31,7 +31,7 @@ FireballLauncherInterior:
 		Image: FB1
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 150
+		Damage: 15000
 		Versus:
 			None: 90
 			Wood: 50
@@ -48,7 +48,7 @@ FireballLauncherInterior:
 MissionBarrelExplodeInterior:
 	Warhead@1Dam: SpreadDamage
 		Spread: 350
-		Damage: 250
+		Damage: 25000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 5
 		Versus:

--- a/mods/ra/maps/survival02/weapons.yaml
+++ b/mods/ra/maps/survival02/weapons.yaml
@@ -7,7 +7,7 @@ ParaBomb:
 		-OpenSequence:
 	Warhead@1Dam: SpreadDamage
 		Spread: 150
-		Damage: 3500
+		Damage: 350000
 		Versus:
 			None: 125
 			Wood: 100

--- a/mods/ra/maps/training-camp/rules.yaml
+++ b/mods/ra/maps/training-camp/rules.yaml
@@ -25,13 +25,13 @@ Player:
 
 OILB:
 	Health:
-		HP: 6000
+		HP: 600000
 
 BARR:
 	Buildable:
 		Prerequisites: ~disabled
 	Health:
-		HP: 5000
+		HP: 500000
 	Production:
 		Produces: Building, Infantry, Soldier, Dog
 	BaseProvider:
@@ -43,7 +43,7 @@ WEAP:
 	Buildable:
 		Prerequisites: ~disabled
 	Health:
-		HP: 10000
+		HP: 1000000
 	Valued:
 		Cost: 2000
 	Power:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -3,7 +3,7 @@ BADR:
 	ParaDrop:
 		DropRange: 4c0
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Light
 	Aircraft:
@@ -42,7 +42,7 @@ BADR.Bomber:
 	Armament:
 		Weapon: ParaBomb
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Light
 	Aircraft:
@@ -90,7 +90,7 @@ MIG:
 		Name: Mig Attack Plane
 		Description: Fast Ground-Attack Plane.\n  Strong vs Buildings, Tanks\n  Weak vs Infantry, Light armor, Aircraft
 	Health:
-		HP: 70
+		HP: 7000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -145,7 +145,7 @@ YAK:
 		Name: Yak Attack Plane
 		Description: Anti-Tanks & Anti-Infantry Plane.\n  Strong vs Infantry, Vehicles\n  Weak vs Aircraft
 	Health:
-		HP: 60
+		HP: 6000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -204,7 +204,7 @@ TRAN:
 		Name: Transport Helicopter
 		Description: Fast Infantry Transport Helicopter.\n  Unarmed
 	Health:
-		HP: 120
+		HP: 12000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -258,7 +258,7 @@ HELI:
 		Name: Longbow
 		Description: Helicopter gunship armed\nwith multi-purpose missiles.\n  Strong vs Tanks, Aircraft\n  Weak vs Infantry
 	Health:
-		HP: 120
+		HP: 12000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -314,7 +314,7 @@ HIND:
 		Name: Hind
 		Description: Helicopter gunship armed\nwith dual chainguns.\n  Strong vs Infantry, Light armor.\n  Weak vs Tanks, Aircraft
 	Health:
-		HP: 100
+		HP: 10000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -364,7 +364,7 @@ HIND:
 U2:
 	Inherits: ^Plane
 	Health:
-		HP: 2000
+		HP: 200000
 	Tooltip:
 		Name: Spy Plane
 	Armor:

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -64,7 +64,7 @@ FCOM:
 	Valued:
 		Cost: 2000
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Wood
 	Tooltip:
@@ -84,7 +84,7 @@ HOSP:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 1000
+		HP: 100000
 	ExternalCapturable:
 	ExternalCapturableBar:
 	EngineerRepairable:
@@ -247,7 +247,7 @@ BARL:
 	CustomSelectionSize:
 		CustomBounds: 24,24
 	Health:
-		HP: 10
+		HP: 1000
 	Explodes:
 		Weapon: BarrelExplode
 	Tooltip:
@@ -268,7 +268,7 @@ BRL3:
 	CustomSelectionSize:
 		CustomBounds: 24,24
 	Health:
-		HP: 10
+		HP: 1000
 	Explodes:
 		Weapon: BarrelExplode
 	Tooltip:
@@ -302,7 +302,7 @@ MISS:
 	Valued:
 		Cost: 2000
 	Health:
-		HP: 400
+		HP: 40000
 	RevealsShroud:
 		Range: 3c0
 	Armor:
@@ -344,7 +344,7 @@ OILB:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 1000
+		HP: 100000
 	RevealsShroud:
 		Range: 3c0
 	ExternalCapturable:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -36,7 +36,7 @@
 		UpgradeTypes: inaccuracy
 		Modifier: 90, 80, 70, 50
 	SelfHealing@ELITE:
-		Step: 2
+		Step: 200
 		Delay: 100
 		HealIfBelow: 100
 		DamageCooldown: 125
@@ -170,7 +170,7 @@
 	Huntable:
 	DrawLineToTarget:
 	Health:
-		HP: 25
+		HP: 2500
 		Shape: Circle
 			Radius: 128
 	Armor:
@@ -225,7 +225,7 @@
 	Tooltip:
 		GenericName: Soldier
 	SelfHealing@HOSPITAL:
-		Step: 5
+		Step: 500
 		Delay: 100
 		HealIfBelow: 100
 		DamageCooldown: 125
@@ -461,6 +461,7 @@
 	GivesBuildableArea:
 	RepairableBuilding:
 		PlayerExperience: 25
+		RepairStep: 700
 	EngineerRepairable:
 	AcceptsSupplies:
 	WithMakeAnimation:
@@ -523,7 +524,7 @@
 	FrozenUnderFog:
 	FrozenUnderFogUpdatedByGps:
 	Health:
-		HP: 100
+		HP: 10000
 		Shape: Rectangle
 			TopLeft: -512, -512
 			BottomRight: 512, 512
@@ -533,7 +534,7 @@
 	Valued:
 		Cost: 250
 	Health:
-		HP: 350
+		HP: 35000
 	Armor:
 		Type: Heavy
 	LineBuildNode:
@@ -556,7 +557,7 @@
 	Inherits: ^BasicBuilding
 	Huntable:
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Wood
 	Tooltip:
@@ -568,7 +569,7 @@
 	Inherits: ^Building
 	-GivesBuildableArea:
 	Health:
-		HP: 100
+		HP: 10000
 	Explodes:
 		Weapon: Demolish
 		DamageThreshold: 90
@@ -589,7 +590,7 @@
 	CustomSelectionSize:
 		CustomBounds: 24,24
 	Health:
-		HP: 10
+		HP: 1000
 	Explodes:
 		Weapon: UnitExplode
 	Tooltip:
@@ -632,7 +633,7 @@
 	RadarColorFromTerrain:
 		Terrain: Tree
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Wood
 	Targetable:
@@ -674,7 +675,7 @@
 ^BasicHusk:
 	Inherits@1: ^SpriteActor
 	Health:
-		HP: 280
+		HP: 28000
 	Armor:
 		Type: Heavy
 	HiddenUnderFog:
@@ -749,7 +750,7 @@
 	CustomSelectionSize:
 		CustomBounds: 96,48
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Concrete
 	AutoTargetIgnore:
@@ -822,7 +823,7 @@
 		DetonateClasses: mine
 		AvoidFriendly: false
 	Health:
-		HP: 100
+		HP: 10000
 		NotifyAppliedDamage: false
 	Armor:
 		Type: Light

--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -15,7 +15,7 @@ FPWR:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Wood
 	Bib:
@@ -49,7 +49,7 @@ SYRF:
 	Valued:
 		Cost: 100
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Light
 	EditorTilesetFilter:
@@ -80,7 +80,7 @@ SPEF:
 	Valued:
 		Cost: 100
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Light
 	EditorTilesetFilter:
@@ -110,7 +110,7 @@ WEAF:
 	Valued:
 		Cost: 200
 	Health:
-		HP: 1500
+		HP: 150000
 	Armor:
 		Type: Wood
 
@@ -136,7 +136,7 @@ DOMF:
 	Valued:
 		Cost: 180
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RequiresPower:
@@ -159,7 +159,7 @@ FIXF:
 		Footprint: _x_ xxx _x_
 		Dimensions: 3,3
 	Health:
-		HP: 800
+		HP: 80000
 	Armor:
 		Type: Wood
 	Bib:
@@ -186,7 +186,7 @@ FAPW:
 		Footprint: xxx xxx
 		Dimensions: 3,2
 	Health:
-		HP: 700
+		HP: 70000
 	Armor:
 		Type: Wood
 	Bib:
@@ -221,7 +221,7 @@ ATEF:
 	Valued:
 		Cost: 150
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Wood
 	RequiresPower:
@@ -251,7 +251,7 @@ PDOF:
 	Valued:
 		Cost: 150
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	Explodes:
@@ -281,7 +281,7 @@ MSLF:
 	Valued:
 		Cost: 250
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	Explodes:
@@ -311,6 +311,6 @@ FACF:
 	Valued:
 		Cost: 250
 	Health:
-		HP: 1500
+		HP: 150000
 	Armor:
 		Type: Wood

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -16,7 +16,7 @@ DOG:
 	SelectionDecorations:
 		VisualBounds: 12,17,-1,-4
 	Health:
-		HP: 12
+		HP: 1200
 	Mobile:
 		Speed: 99
 		Voice: Move
@@ -59,7 +59,7 @@ E1:
 		Name: Rifle Infantry
 		Description: General-purpose infantry.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft
 	Health:
-		HP: 50
+		HP: 5000
 	Armament@PRIMARY:
 		Weapon: M1Carbine
 	Armament@GARRISONED:
@@ -85,7 +85,7 @@ E2:
 		Name: Grenadier
 		Description: Infantry armed with grenades.\n  Strong vs Buildings, Infantry\n  Weak vs Vehicles, Aircraft
 	Health:
-		HP: 50
+		HP: 5000
 	Mobile:
 		Speed: 71
 	Armament@PRIMARY:
@@ -118,7 +118,7 @@ E3:
 		Name: Rocket Soldier
 		Description: Anti-tank/Anti-aircraft infantry.\n  Strong vs Vehicles, Aircraft\n  Weak vs Infantry
 	Health:
-		HP: 45
+		HP: 4500
 	Armament@PRIMARY:
 		Weapon: RedEye
 		LocalOffset: 0,0,555
@@ -147,7 +147,7 @@ E4:
 		Name: Flamethrower
 		Description: Advanced anti-structure unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles, Aircraft
 	Health:
-		HP: 40
+		HP: 4000
 	Armament@PRIMARY:
 		Weapon: Flamer
 		LocalOffset: 427,0,341
@@ -263,7 +263,7 @@ E7:
 		Name: Tanya
 		Description: Elite commando infantry. Armed with\ndual pistols and C4.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles, Aircraft\n  Special Ability: Destroy Building with C4\nMaximum 1 can be trained.
 	Health:
-		HP: 100
+		HP: 10000
 	Mobile:
 		Speed: 71
 		Voice: Move
@@ -309,7 +309,7 @@ MEDI:
 		Name: Medic
 		Description: Heals nearby infantry.\n  Unarmed
 	Health:
-		HP: 80
+		HP: 8000
 	RevealsShroud:
 		Range: 3c0
 	Passenger:
@@ -340,7 +340,7 @@ MECH:
 		Name: Mechanic
 		Description: Repairs nearby vehicles and restores\nhusks to working condition by capturing them.\n  Unarmed
 	Health:
-		HP: 80
+		HP: 8000
 	Mobile:
 		Voice: Move
 	RevealsShroud:
@@ -450,7 +450,7 @@ HIJACKER:
 		Name: Hijacker
 		Description: Hijacks enemy vehicles.\n  Unarmed
 	Health:
-		HP: 50
+		HP: 5000
 	RevealsShroud:
 		Range: 5c0
 	Passenger:
@@ -489,7 +489,7 @@ SHOK:
 		Name: Shock Trooper
 		Description: Elite infantry with portable tesla coils.\n  Strong vs Infantry, Vehicles\n  Weak vs Aircraft
 	Health:
-		HP: 60
+		HP: 6000
 	Mobile:
 		Voice: Move
 	RevealsShroud:
@@ -528,7 +528,7 @@ SNIPER:
 		BuildPaletteOrder: 80
 		Prerequisites: ~disabled
 	Health:
-		HP: 80
+		HP: 8000
 	Passenger:
 		PipType: Red
 	RevealsShroud:
@@ -571,7 +571,7 @@ Zombie:
 		BuildPaletteOrder: 200
 		Prerequisites: ~bio
 	Health:
-		HP: 250
+		HP: 25000
 	Mobile:
 		Speed: 42
 	AutoTarget:
@@ -603,7 +603,7 @@ Ant:
 	SelectionDecorations:
 		VisualBounds: 30,30,0,-2
 	Health:
-		HP: 750
+		HP: 75000
 		Shape: Circle
 			Radius: 469
 	Mobile:

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -136,7 +136,7 @@ CAMERA:
 	Immobile:
 		OccupiesSpace: false
 	Health:
-		HP: 1000
+		HP: 100000
 	RevealsShroud:
 		Range: 10c0
 		Type: CenterPosition

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -11,7 +11,7 @@ SS:
 		Name: Submarine
 		Description: Submerged anti-ship unit\narmed with torpedoes.\nCan detect other submarines.\n  Strong vs Naval units\n  Weak vs Ground units, Aircraft\n  Special Ability: Submerge
 	Health:
-		HP: 250
+		HP: 25000
 	Armor:
 		Type: Light
 	Mobile:
@@ -67,7 +67,7 @@ MSUB:
 		Name: Missile Submarine
 		Description: Submerged anti-ground unit armed with\nlong-range ballistic missiles.\nCan detect other submarines.\n  Strong vs Buildings, Ground units\n  Weak vs Naval units, Aircraft\n  Special Ability: Submerge
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Light
 	Mobile:
@@ -123,7 +123,7 @@ DD:
 		Name: Destroyer
 		Description: Fast multi-role ship.\nCan detect submarines.\n  Strong vs Naval units, Light armor, Aircraft\n  Weak vs Infantry, Tanks
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -169,7 +169,7 @@ CA:
 		Name: Cruiser
 		Description: Very slow long-range ship.\n  Strong vs Buildings, Ground units\n  Weak vs Naval units, Aircraft
 	Health:
-		HP: 800
+		HP: 80000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -222,7 +222,7 @@ LST:
 		Name: Transport
 		Description: General-purpose naval transport.\nCan carry infantry and tanks.\n  Unarmed
 	Health:
-		HP: 350
+		HP: 35000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -259,7 +259,7 @@ PT:
 		Name: Gunboat
 		Description: Light scout & support ship.\nCan detect submarines.\n  Strong vs Naval units\n  Weak vs Ground units, Aircraft
 	Health:
-		HP: 200
+		HP: 20000
 	Armor:
 		Type: Heavy
 	Mobile:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -14,7 +14,7 @@ MSLO:
 		Footprint: xx
 		Dimensions: 2,1
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -70,7 +70,7 @@ GAP:
 	WithSpriteBody:
 		PauseAnimationWhenDisabled: true
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -109,7 +109,7 @@ SPEN:
 		TerrainTypes: Water
 	-GivesBuildableArea:
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -137,6 +137,7 @@ SPEN:
 	RepairsUnits:
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
+		HpPerStep: 1000
 	RallyPoint:
 	ProductionBar:
 	Power:
@@ -199,7 +200,7 @@ SYRD:
 		TerrainTypes: Water
 	-GivesBuildableArea:
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -227,6 +228,7 @@ SYRD:
 	RepairsUnits:
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
+		HpPerStep: 1000
 	RallyPoint:
 	ProductionBar:
 	Power:
@@ -298,7 +300,7 @@ IRON:
 	SelectionDecorations:
 		VisualBounds: 50,50,0,-12
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -344,7 +346,7 @@ PDOX:
 		PowerdownSound: DisablePower
 	DisabledOverlay:
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -415,7 +417,7 @@ TSLA:
 		PowerdownSound: DisablePower
 	DisabledOverlay:
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -459,7 +461,7 @@ AGUN:
 		PowerdownSound: DisablePower
 	DisabledOverlay:
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -510,7 +512,7 @@ DOME:
 		PowerdownSound: DisablePower
 	DisabledOverlay:
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -538,7 +540,7 @@ PBOX:
 	Valued:
 		Cost: 400
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -583,7 +585,7 @@ HBOX:
 	Valued:
 		Cost: 600
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -631,7 +633,7 @@ GUN:
 		Description: Anti-Armor base defense.\nCan detect cloaked units.\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
 	Building:
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -671,7 +673,7 @@ FTUR:
 		Description: Anti-Infantry base defense.\nCan detect cloaked units.\n  Strong vs Infantry, Light armor\n  Weak vs Tanks, Aircraft
 	Building:
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -714,7 +716,7 @@ SAM:
 	CanPowerDown:
 	DisabledOverlay:
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -757,7 +759,7 @@ ATEK:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -794,7 +796,7 @@ WEAP:
 		Footprint: xxx xxx
 		Dimensions: 3,2
 	Health:
-		HP: 1500
+		HP: 150000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -917,7 +919,7 @@ FACT:
 		Factions: ukraine
 		Prerequisite: structures.ukraine
 	Health:
-		HP: 1500
+		HP: 150000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -975,7 +977,7 @@ PROC:
 	Targetable:
 		TargetTypes: Ground, Structure, C4, DetonateAttack, SpyInfiltrate
 	Health:
-		HP: 900
+		HP: 90000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1022,7 +1024,7 @@ SILO:
 	Building:
 	-GivesBuildableArea:
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1054,7 +1056,7 @@ HPAD:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 800
+		HP: 80000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1132,7 +1134,7 @@ AFLD:
 		Footprint: xxx xxx
 		Dimensions: 3,2
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1250,7 +1252,7 @@ POWR:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1291,7 +1293,7 @@ APWR:
 	SelectionDecorations:
 		VisualBounds: 72,68,0,-10
 	Health:
-		HP: 700
+		HP: 70000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1328,7 +1330,7 @@ STEK:
 		Footprint: xxx xxx
 		Dimensions: 3,2
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1353,7 +1355,7 @@ BARR:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 800
+		HP: 80000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1426,7 +1428,7 @@ KENN:
 	Building:
 	-GivesBuildableArea:
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1475,7 +1477,7 @@ TENT:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 800
+		HP: 80000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1559,7 +1561,7 @@ FIX:
 	SelectionDecorations:
 		VisualBounds: 72,48
 	Health:
-		HP: 800
+		HP: 80000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1572,6 +1574,7 @@ FIX:
 		Interval: 10
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
+		HpPerStep: 1000
 	WithRepairAnimation:
 	Power:
 		Amount: -30
@@ -1591,7 +1594,7 @@ SBAG:
 		Name: Sandbag Wall
 		Description: Stops infantry and light vehicles.\nCan be crushed by tanks.
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Wood
 	LineBuild:
@@ -1616,7 +1619,7 @@ FENC:
 		Name: Wire Fence
 		Description: Stops infantry and light vehicles.\nCan be crushed by tanks.
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Wood
 	LineBuild:
@@ -1644,7 +1647,7 @@ BRIK:
 		DamagedSounds: crmble2.aud
 		DestroyedSounds: kaboom30.aud
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Concrete
 	Crushable:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -10,7 +10,7 @@ V2RL:
 		Name: V2 Rocket
 		Description: Long-range rocket artillery.\n  Strong vs Infantry, Light armor, Buildings\n  Weak vs Tanks, Aircraft
 	Health:
-		HP: 200
+		HP: 20000
 	Armor:
 		Type: Light
 	Mobile:
@@ -43,7 +43,7 @@ V2RL:
 		Name: Light Tank
 		Description: Light Tank, good for scouting.\n  Strong vs Light armor\n  Weak vs Infantry, Tanks, Aircraft
 	Health:
-		HP: 220
+		HP: 22000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -80,7 +80,7 @@ V2RL:
 		Name: Medium Tank
 		Description: Allied Main Battle Tank.\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
 	Health:
-		HP: 450
+		HP: 45000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -119,7 +119,7 @@ V2RL:
 		Name: Heavy Tank
 		Description: Soviet Main Battle Tank, with dual cannons\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
 	Health:
-		HP: 550
+		HP: 55000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -160,7 +160,7 @@ V2RL:
 		Name: Mammoth Tank
 		Description: Big and slow tank, with anti-air capability.\n  Strong vs Vehicles, Infantry, Aircraft\n  Weak vs Nothing
 	Health:
-		HP: 900
+		HP: 90000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -190,7 +190,7 @@ V2RL:
 	SpawnActorOnDeath:
 		Actor: 4TNK.Husk
 	SelfHealing:
-		Step: 1
+		Step: 100
 		Delay: 3
 		HealIfBelow: 50
 		DamageCooldown: 150
@@ -211,7 +211,7 @@ ARTY:
 		Name: Artillery
 		Description: Long-range artillery.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles, Aircraft
 	Health:
-		HP: 100
+		HP: 10000
 	Armor:
 		Type: Light
 	Mobile:
@@ -256,7 +256,7 @@ HARV:
 		SearchFromProcRadius: 30
 		SearchFromOrderRadius: 15
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -275,7 +275,7 @@ HARV:
 		FullActor: HARV.FullHusk
 		FullnessThreshold: 50
 	SelfHealing:
-		Step: 1
+		Step: 100
 		Delay: 25
 		HealIfBelow: 50
 		DamageCooldown: 500
@@ -300,7 +300,7 @@ MCV:
 	SelectionDecorations:
 		VisualBounds: 42,42
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Light
 	Mobile:
@@ -332,7 +332,7 @@ JEEP:
 		Name: Ranger
 		Description: Fast scout & anti-infantry vehicle.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft
 	Health:
-		HP: 150
+		HP: 15000
 	Armor:
 		Type: Light
 	Mobile:
@@ -372,7 +372,7 @@ APC:
 		Name: Armored Personnel Carrier
 		Description: Tough infantry transport.\n  Strong vs Infantry, Light armor\n  Weak vs Tanks, Aircraft
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -409,7 +409,7 @@ MNLY.AP:
 		Name: Minelayer
 		Description: Lays mines to destroy\nunwary enemy units.\nCan detect mines.\n  Unarmed
 	Health:
-		HP: 150
+		HP: 15000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -444,7 +444,7 @@ MNLY.AT:
 		Name: Minelayer
 		Description: Lays mines to destroy\nunwary enemy units.\nCan detect mines.\n  Unarmed
 	Health:
-		HP: 150
+		HP: 15000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -479,7 +479,7 @@ TRUK:
 		Name: Supply Truck
 		Description: Transports cash to other players.\n  Unarmed
 	Health:
-		HP: 110
+		HP: 11000
 	Armor:
 		Type: Light
 	Mobile:
@@ -504,7 +504,7 @@ MGG:
 		Name: Mobile Gap Generator
 		Description: Regenerates the shroud nearby, \nobscuring the area.\n  Unarmed
 	Health:
-		HP: 220
+		HP: 22000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -532,7 +532,7 @@ MRJ:
 		BuildPaletteOrder: 150
 		Prerequisites: atek, ~vehicles.allies, ~techlevel.high
 	Health:
-		HP: 220
+		HP: 22000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -563,7 +563,7 @@ TTNK:
 		Name: Tesla Tank
 		Description: Tank with mounted tesla coil.\n  Strong vs Infantry, Vehicles, Buildings\n  Weak vs Aircraft
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Light
 	Mobile:
@@ -596,7 +596,7 @@ FTRK:
 		Name: Mobile Flak
 		Description: Mobile unit with mounted Flak Cannon.\n  Strong vs Infantry, Light armor, Aircraft\n  Weak vs Tanks
 	Health:
-		HP: 150
+		HP: 15000
 	Armor:
 		Type: Light
 	Mobile:
@@ -638,7 +638,7 @@ DTRK:
 		Name: Demolition Truck
 		Description: Demolition Truck, actively armed with\nnuclear explosives. Has very weak armor.
 	Health:
-		HP: 50
+		HP: 5000
 	Armor:
 		Type: Light
 	Mobile:
@@ -670,7 +670,7 @@ CTNK:
 	SelectionDecorations:
 		VisualBounds: 30,30
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Light
 	Mobile:
@@ -705,7 +705,7 @@ QTNK:
 		Name: MAD Tank
 		Description: Deals seismic damage to nearby vehicles\nand structures.\n  Strong vs Vehicles, Buildings\n  Weak vs Infantry, Aircraft
 	Health:
-		HP: 900
+		HP: 90000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -732,7 +732,7 @@ STNK:
 		Name: Phase Transport
 		Description: Lightly armored infantry transport\nwhich can cloak. Can detect cloaked units.\n  Strong vs Light armor\n  Weak vs Infantry, Tanks, Aircraft
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Light
 	Mobile:

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -2,7 +2,7 @@ CrateNapalm:
 	ValidTargets: Ground, Trees
 	Warhead@1Dam: SpreadDamage
 		Spread: 170
-		Damage: 60
+		Damage: 6000
 		ValidTargets: Ground, Trees
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
@@ -22,7 +22,7 @@ CrateNapalm:
 CrateExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 50
+		Damage: 5000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
 			None: 90
@@ -42,7 +42,7 @@ CrateNuke:
 	ValidTargets: Ground, Trees, Water, Air
 	Warhead@1Dam_impact: SpreadDamage
 		Spread: 1c0
-		Damage: 100
+		Damage: 10000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: Ground, Trees, Water, Air
 		Versus:
@@ -55,7 +55,7 @@ CrateNuke:
 		ImpactSounds: kaboom1.aud
 	Warhead@4Dam_areanuke: SpreadDamage
 		Spread: 1c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 600, 400, 250, 150, 100, 0
 		Delay: 4
 		ValidTargets: Ground, Trees, Water, Air
@@ -79,7 +79,7 @@ MiniNuke:
 	ValidTargets: Ground, Trees, Water, Underwater, Air
 	Warhead@1Dam_impact: SpreadDamage
 		Spread: 1c0
-		Damage: 150
+		Damage: 15000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: Ground, Trees, Water, Air
 		Versus:
@@ -93,7 +93,7 @@ MiniNuke:
 		ImpactSounds: kaboom1.aud
 	Warhead@4Dam_areanuke1: SpreadDamage
 		Spread: 2c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 5
 		ValidTargets: Ground, Trees, Water, Underwater, Air
@@ -109,7 +109,7 @@ MiniNuke:
 		Delay: 5
 	Warhead@7Dam_areanuke2: SpreadDamage
 		Spread: 3c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 10
 		ValidTargets: Ground, Trees, Water, Underwater, Air
@@ -122,7 +122,7 @@ MiniNuke:
 		Delay: 10
 	Warhead@9Dam_areanuke3: SpreadDamage
 		Spread: 4c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 15
 		ValidTargets: Ground, Trees, Water, Underwater
@@ -142,7 +142,7 @@ MiniNuke:
 UnitExplode:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 50
+		Damage: 5000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
 			None: 90
@@ -165,7 +165,7 @@ UnitExplode:
 UnitExplodeShip:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 50
+		Damage: 5000
 		Versus:
 			None: 90
 			Wood: 75
@@ -179,7 +179,7 @@ UnitExplodeShip:
 UnitExplodeSubmarine:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 50
+		Damage: 5000
 		Versus:
 			None: 90
 			Wood: 75
@@ -193,7 +193,7 @@ UnitExplodeSubmarine:
 UnitExplodeSmall:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 40
+		Damage: 4000
 		Versus:
 			None: 90
 			Wood: 75
@@ -215,7 +215,7 @@ UnitExplodeSmall:
 ArtilleryExplode:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 150
+		Damage: 15000
 		Versus:
 			None: 90
 			Wood: 75
@@ -241,7 +241,7 @@ V2Explode:
 BarrelExplode:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 50
+		Damage: 5000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 5
 		ValidTargets: Ground, Trees
@@ -264,7 +264,7 @@ BarrelExplode:
 ATMine:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
-		Damage: 400
+		Damage: 40000
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Eff: CreateEffect
@@ -277,7 +277,7 @@ ATMine:
 APMine:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
-		Damage: 400
+		Damage: 40000
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
@@ -290,7 +290,7 @@ APMine:
 OreExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 9
-		Damage: 10
+		Damage: 1000
 		Versus:
 			None: 90
 			Wood: 75

--- a/mods/ra/weapons/largecaliber.yaml
+++ b/mods/ra/weapons/largecaliber.yaml
@@ -7,7 +7,7 @@
 		Image: 50CAL
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 16
+		Damage: 1600
 		Versus:
 			None: 30
 			Wood: 40
@@ -30,7 +30,7 @@
 		Image: 120MM
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 40
+		Damage: 4000
 		Versus:
 			None: 20
 			Wood: 75
@@ -60,7 +60,7 @@
 		Image: 120MM
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 40
+		Damage: 4000
 		Versus:
 			None: 20
 			Wood: 75
@@ -90,7 +90,7 @@
 		Image: 120MM
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 60
+		Damage: 6000
 		InvalidTargets: Air, Infantry
 		Versus:
 			None: 20
@@ -119,7 +119,7 @@ TurretGun:
 		Image: 120MM
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 60
+		Damage: 6000
 		Versus:
 			None: 20
 			Wood: 50
@@ -152,7 +152,7 @@ TurretGun:
 		ContrailLength: 30
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 220
+		Damage: 22000
 		Versus:
 			None: 90
 			Wood: 75
@@ -186,7 +186,7 @@ TurretGun:
 		ContrailLength: 30
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 25
+		Damage: 2500
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
 			None: 60
@@ -215,7 +215,7 @@ TurretGun:
 		Image: 120MM
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 25
+		Damage: 2500
 		Versus:
 			None: 30
 			Wood: 75

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -18,7 +18,7 @@ Maverick:
 		RangeLimit: 14c410
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 70
+		Damage: 7000
 		ValidTargets: Ground, Water
 		Versus:
 			None: 30
@@ -55,7 +55,7 @@ Dragon:
 		RangeLimit: 6c0
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 50
+		Damage: 5000
 		ValidTargets: Ground, Water
 		Versus:
 			None: 10
@@ -94,7 +94,7 @@ HellfireAG:
 		RangeLimit: 8c512
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 60
+		Damage: 6000
 		ValidTargets: Ground, Water
 		Versus:
 			None: 30
@@ -132,7 +132,7 @@ HellfireAA:
 		RangeLimit: 7c0
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 40
+		Damage: 4000
 		ValidTargets: Air
 		Versus:
 			None: 30
@@ -166,7 +166,7 @@ MammothTusk:
 		RangeLimit: 9c614
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
-		Damage: 50
+		Damage: 5000
 		ValidTargets: Air, Infantry
 		Versus:
 			None: 100
@@ -205,7 +205,7 @@ Nike:
 		Speed: 341
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 50
+		Damage: 5000
 		ValidTargets: Air
 		Versus:
 			None: 90
@@ -231,7 +231,7 @@ RedEye:
 		Speed: 298
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 40
+		Damage: 4000
 		ValidTargets: Air
 		Versus:
 			None: 90
@@ -258,7 +258,7 @@ SubMissile:
 		ContrailLength: 30
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 30
+		Damage: 3000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
 			None: 40
@@ -295,7 +295,7 @@ Stinger:
 		CloseEnough: 149
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 30
+		Damage: 3000
 		ValidTargets: Air, Ground, Water
 		Versus:
 			None: 30
@@ -336,7 +336,7 @@ StingerAA:
 		Speed: 255
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 30
+		Damage: 3000
 		ValidTargets: Air, Ground, Water
 		Versus:
 			None: 30
@@ -375,7 +375,7 @@ TorpTube:
 		Palette: shadow
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 180
+		Damage: 18000
 		ValidTargets: Water, Underwater, Bridge
 		Versus:
 			None: 30
@@ -412,7 +412,7 @@ SCUD:
 		Angle: 62
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
-		Damage: 45
+		Damage: 4500
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: Ground, Trees
 		Versus:
@@ -450,7 +450,7 @@ APTusk:
 		RangeLimit: 7c204
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 30
+		Damage: 3000
 		ValidTargets: Ground, Water
 		Versus:
 			None: 25

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -10,7 +10,7 @@ FireballLauncher:
 		Image: FB1
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 150
+		Damage: 15000
 		ValidTargets: Ground, Water, Trees
 		Versus:
 			None: 90
@@ -40,7 +40,7 @@ Flamer:
 		Inaccuracy: 853
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
-		Damage: 8
+		Damage: 800
 		ValidTargets: Ground, Water, Trees
 		Versus:
 			None: 90
@@ -66,7 +66,7 @@ Napalm:
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Spread: 170
-		Damage: 100
+		Damage: 10000
 		ValidTargets: Ground, Water, Trees
 		Versus:
 			None: 90
@@ -98,7 +98,7 @@ Grenade:
 		Image: BOMB
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
-		Damage: 60
+		Damage: 6000
 		Versus:
 			None: 50
 			Wood: 100
@@ -130,7 +130,7 @@ DepthCharge:
 		Inaccuracy: 128
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 80
+		Damage: 8000
 		ValidTargets: Underwater
 		Versus:
 			None: 30
@@ -153,7 +153,7 @@ TeslaZap:
 	Projectile: TeslaZap
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
-		Damage: 100
+		Damage: 10000
 		Versus:
 			None: 1000
 			Wood: 60
@@ -166,7 +166,7 @@ PortaTesla:
 	Projectile: TeslaZap
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
-		Damage: 45
+		Damage: 4500
 		Versus:
 			None: 1000
 		DamageTypes: Prone50Percent, TriggerProne, ElectricityDeath
@@ -178,7 +178,7 @@ TTankZap:
 	Projectile: TeslaZap
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
-		Damage: 100
+		Damage: 10000
 		Versus:
 			None: 1000
 		DamageTypes: Prone50Percent, TriggerProne, ElectricityDeath
@@ -190,7 +190,7 @@ DogJaw:
 	Report: dogg5p.aud
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 100
+		Damage: 10000
 		ValidTargets: Infantry
 		DamageTypes: DefaultDeath
 
@@ -203,7 +203,7 @@ Heal:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: -50
+		Damage: -5000
 		ValidTargets: Infantry
 		DebugOverlayColor: 00FF00
 
@@ -216,13 +216,13 @@ Repair:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: -20
+		Damage: -2000
 		ValidTargets: Repair
 		DebugOverlayColor: 00FF00
 
 Crush:
 	Warhead@1Dam: SpreadDamage
-		Damage: 100
+		Damage: 10000
 		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Eff: CreateEffect
 		ImpactSounds: squishy2.aud
@@ -241,7 +241,7 @@ Claw:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 33
+		Damage: 3300
 		Versus:
 			None: 90
 			Wood: 10
@@ -257,7 +257,7 @@ Mandible:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 60
+		Damage: 6000
 		Versus:
 			None: 90
 			Wood: 10

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -242,7 +242,7 @@ M1Carbine:
 		Versus:
 			Wood: 25
 			Light: 30
-			Heavy: 15
+			Heavy: 10
 			Concrete: 10
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
@@ -265,7 +265,7 @@ M60mg:
 		Versus:
 			Wood: 10
 			Light: 30
-			Heavy: 15
+			Heavy: 10
 			Concrete: 10
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -8,7 +8,7 @@ Colt45:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
-		Damage: 50
+		Damage: 5000
 		ValidTargets: Barrel, Infantry
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
@@ -30,7 +30,7 @@ ZSU-23:
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 12
+		Damage: 1200
 		ValidTargets: Air
 		Versus:
 			None: 30
@@ -49,7 +49,7 @@ Vulcan:
 		Speed: 1c682
 	Warhead@1Dam_1: SpreadDamage
 		Spread: 128
-		Damage: 10
+		Damage: 1000
 		Versus:
 			None: 200
 			Wood: 50
@@ -65,7 +65,7 @@ Vulcan:
 		ValidImpactTypes: Water
 	Warhead@3Dam_2: SpreadDamage
 		Spread: 128
-		Damage: 10
+		Damage: 1000
 		Delay: 2
 		Versus:
 			None: 200
@@ -84,7 +84,7 @@ Vulcan:
 		Delay: 2
 	Warhead@5Dam_3: SpreadDamage
 		Spread: 128
-		Damage: 10
+		Damage: 1000
 		Delay: 4
 		Versus:
 			None: 200
@@ -103,7 +103,7 @@ Vulcan:
 		Delay: 4
 	Warhead@7Dam_4: SpreadDamage
 		Spread: 128
-		Damage: 10
+		Damage: 1000
 		Delay: 6
 		Versus:
 			None: 200
@@ -122,7 +122,7 @@ Vulcan:
 		Delay: 6
 	Warhead@9Dam_5: SpreadDamage
 		Spread: 128
-		Damage: 10
+		Damage: 1000
 		Delay: 8
 		Versus:
 			None: 200
@@ -141,7 +141,7 @@ Vulcan:
 		Delay: 8
 	Warhead@11Dam_6: SpreadDamage
 		Spread: 128
-		Damage: 10
+		Damage: 1000
 		Delay: 10
 		Versus:
 			None: 200
@@ -169,7 +169,7 @@ ChainGun:
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 30
+		Damage: 3000
 		Versus:
 			None: 120
 			Wood: 50
@@ -194,7 +194,7 @@ ChainGun.Yak:
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 40
+		Damage: 4000
 		Versus:
 			Wood: 50
 			Light: 60
@@ -216,7 +216,7 @@ Pistol:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 1
+		Damage: 100
 		Versus:
 			Wood: 50
 			Light: 60
@@ -238,7 +238,7 @@ M1Carbine:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 15
+		Damage: 1500
 		Versus:
 			Wood: 25
 			Light: 30
@@ -261,7 +261,7 @@ M60mg:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 15
+		Damage: 1500
 		Versus:
 			Wood: 10
 			Light: 30
@@ -285,7 +285,7 @@ SilencedPPK:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 150
+		Damage: 15000
 		ValidTargets: Infantry
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
@@ -305,7 +305,7 @@ FLAK-23-AA:
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 20
+		Damage: 2000
 		ValidTargets: Air, Ground, Water
 		Versus:
 			None: 40
@@ -328,7 +328,7 @@ FLAK-23-AG:
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 20
+		Damage: 2000
 		ValidTargets: Air, Ground, Water
 		Versus:
 			None: 40
@@ -354,6 +354,6 @@ Sniper:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
-		Damage: 140
+		Damage: 14000
 		ValidTargets: Infantry
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -9,7 +9,7 @@ ParaBomb:
 		Acceleration: 0
 	Warhead@1Dam: SpreadDamage
 		Spread: 768
-		Damage: 300
+		Damage: 30000
 		Versus:
 			None: 30
 			Wood: 75
@@ -32,7 +32,7 @@ Atomic:
 	ValidTargets: Ground, Trees, Water, Underwater, Air
 	Warhead@1Dam_impact: SpreadDamage
 		Spread: 1c0
-		Damage: 150
+		Damage: 15000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: Ground, Trees, Water, Underwater, Air
 		Versus:
@@ -49,7 +49,7 @@ Atomic:
 		ImpactSounds: kaboom1.aud
 	Warhead@5Dam_areanuke1: SpreadDamage
 		Spread: 2c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 5
 		ValidTargets: Ground, Trees, Water, Underwater, Air
@@ -69,7 +69,7 @@ Atomic:
 		Delay: 5
 	Warhead@9Dam_areanuke2: SpreadDamage
 		Spread: 3c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 10
 		ValidTargets: Ground, Trees, Water, Underwater, Air
@@ -86,7 +86,7 @@ Atomic:
 		Delay: 10
 	Warhead@12Dam_areanuke3: SpreadDamage
 		Spread: 4c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 15
 		ValidTargets: Ground, Trees, Water, Underwater, Air
@@ -103,7 +103,7 @@ Atomic:
 		Delay: 15
 	Warhead@15Dam_areanuke4: SpreadDamage
 		Spread: 5c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 20
 		ValidTargets: Ground, Trees, Water, Underwater, Air

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -11,7 +11,7 @@ DPOD:
 		InitialFacing: 0
 		LandableTerrainTypes: Clear,Road,Rail,DirtRoad,Rough,Tiberium,BlueTiberium,Veins
 	Health:
-		HP: 60
+		HP: 6000
 	Armor:
 		Type: Light
 	Cargo:
@@ -47,7 +47,7 @@ DSHP:
 		LandingSound: dropdwn1.aud
 		IdealSeparation: 1275
 	Health:
-		HP: 200
+		HP: 20000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -82,7 +82,7 @@ ORCA:
 		TakeoffSound: orcaup1.aud
 		LandingSound: orcadwn1.aud
 	Health:
-		HP: 200
+		HP: 20000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -126,7 +126,7 @@ ORCAB:
 		TakeoffSound: orcaup1.aud
 		LandingSound: orcadwn1.aud
 	Health:
-		HP: 260
+		HP: 26000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -173,7 +173,7 @@ ORCATRAN:
 		LandingSound: orcadwn1.aud
 		IdealSeparation: 1275
 	Health:
-		HP: 200
+		HP: 20000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -210,7 +210,7 @@ TRNSPORT:
 		AltitudeVelocity: 64
 		MoveIntoShroud: false
 	Health:
-		HP: 175
+		HP: 17500
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -246,7 +246,7 @@ SCRIN:
 		TakeoffSound: dropup1.aud
 		LandingSound: dropdwn1.aud
 	Health:
-		HP: 280
+		HP: 28000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -287,7 +287,7 @@ APACHE:
 		Speed: 130
 		MoveIntoShroud: false
 	Health:
-		HP: 225
+		HP: 22500
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -326,7 +326,7 @@ HUNTER:
 	Tooltip:
 		Name: Hunter-Seeker Droid
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Light
 	AttackSuicides:

--- a/mods/ts/rules/civilian-infantry.yaml
+++ b/mods/ts/rules/civilian-infantry.yaml
@@ -9,7 +9,7 @@ WEEDGUY:
 	Mobile:
 		Speed: 42
 	Health:
-		HP: 130
+		HP: 13000
 	Crushable:
 		CrushSound: squishy2.aud
 	Armament:
@@ -35,7 +35,7 @@ UMAGON:
 	Mobile:
 		Speed: 71
 	Health:
-		HP: 150
+		HP: 15000
 	Passenger:
 	RevealsShroud:
 		Range: 7c0
@@ -57,7 +57,7 @@ CHAMSPY:
 	Voiced:
 		VoiceSet: Spy
 	Health:
-		HP: 120
+		HP: 12000
 	Mobile:
 		Speed: 85
 	RevealsShroud:
@@ -89,7 +89,7 @@ MUTANT:
 	Voiced:
 		VoiceSet: Mutant
 	Health:
-		HP: 50
+		HP: 5000
 	Mobile:
 		Speed: 56
 	RevealsShroud:
@@ -113,7 +113,7 @@ MWMN:
 	Voiced:
 		VoiceSet: CivilianFemale
 	Health:
-		HP: 50
+		HP: 5000
 	Mobile:
 		Speed: 56
 	RevealsShroud:
@@ -137,7 +137,7 @@ MUTANT3:
 	Voiced:
 		VoiceSet: Mutant
 	Health:
-		HP: 50
+		HP: 5000
 	Mobile:
 		Speed: 56
 	RevealsShroud:
@@ -161,7 +161,7 @@ TRATOS:
 	Voiced:
 		VoiceSet: Tratos
 	Health:
-		HP: 200
+		HP: 20000
 	Mobile:
 		Speed: 71
 	RevealsShroud:
@@ -179,7 +179,7 @@ OXANNA:
 	Voiced:
 		VoiceSet: Oxanna
 	Health:
-		HP: 50
+		HP: 5000
 	Mobile:
 		Speed: 56
 	RevealsShroud:
@@ -197,7 +197,7 @@ SLAV:
 	Voiced:
 		VoiceSet: Slavick
 	Health:
-		HP: 300
+		HP: 30000
 	Mobile:
 		Speed: 56
 	RevealsShroud:
@@ -213,7 +213,7 @@ DOGGIE:
 	Tooltip:
 		Name: Tiberian Fiend
 	Health:
-		HP: 250
+		HP: 25000
 		Shape: Circle
 			Radius: 213
 	Valued:
@@ -247,7 +247,7 @@ VISC_SML:
 		Name: Baby Visceroid
 		Description: infantry transmorgifies into this
 	Health:
-		HP: 200
+		HP: 20000
 	AttackWander:
 		WanderMoveRadius: 2
 		MinMoveDelayInTicks: 30
@@ -261,7 +261,7 @@ VISC_LRG:
 		Name: Adult Visceroid
 		Description: 2 small visceroids combine into this
 	Health:
-		HP: 500
+		HP: 50000
 	Armament:
 		Weapon: SlimeAttack
 	AutoTarget:

--- a/mods/ts/rules/civilian-structures.yaml
+++ b/mods/ts/rules/civilian-structures.yaml
@@ -8,7 +8,7 @@ ABAN01:
 	Armor:
 		Type: wood
 	Health:
-		HP: 600
+		HP: 60000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -22,7 +22,7 @@ ABAN02:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 600
+		HP: 60000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -36,7 +36,7 @@ ABAN03:
 	Armor:
 		Type: wood
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -50,7 +50,7 @@ ABAN04:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -64,7 +64,7 @@ ABAN05:
 	Armor:
 		Type: wood
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -78,7 +78,7 @@ ABAN06:
 	Armor:
 		Type: wood
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -92,7 +92,7 @@ ABAN07:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 350
+		HP: 35000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -106,7 +106,7 @@ ABAN08:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -120,7 +120,7 @@ ABAN09:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 350
+		HP: 35000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -134,7 +134,7 @@ ABAN10:
 	Armor:
 		Type: wood
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -148,7 +148,7 @@ ABAN11:
 	Armor:
 		Type: wood
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -162,7 +162,7 @@ ABAN12:
 	Armor:
 		Type: wood
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -176,7 +176,7 @@ ABAN13:
 	Armor:
 		Type: wood
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -190,7 +190,7 @@ ABAN14:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 300
+		HP: 30000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -204,7 +204,7 @@ ABAN15:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -218,7 +218,7 @@ ABAN16:
 	Armor:
 		Type: wood
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -232,7 +232,7 @@ ABAN17:
 	Armor:
 		Type: wood
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -246,7 +246,7 @@ ABAN18:
 	Armor:
 		Type: wood
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -260,7 +260,7 @@ AMMOCRAT:
 	Armor:
 		Type: none
 	Health:
-		HP: 1
+		HP: 100
 	RenderSprites:
 		Palette: player
 
@@ -372,7 +372,7 @@ CA0001:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 
 CA0002:
 	Inherits: ^CivBuilding
@@ -384,7 +384,7 @@ CA0002:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 
 CA0003:
 	Inherits: ^CivBuilding
@@ -396,7 +396,7 @@ CA0003:
 	Armor:
 		Type: light
 	Health:
-		HP: 300
+		HP: 30000
 
 CA0004:
 	Inherits: ^CivBuilding
@@ -408,7 +408,7 @@ CA0004:
 	Armor:
 		Type: light
 	Health:
-		HP: 300
+		HP: 30000
 
 CA0005:
 	Inherits: ^CivBuilding
@@ -420,7 +420,7 @@ CA0005:
 	Armor:
 		Type: light
 	Health:
-		HP: 300
+		HP: 30000
 
 CA0006:
 	Inherits: ^CivBuilding
@@ -432,7 +432,7 @@ CA0006:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 300
+		HP: 30000
 
 CA0007:
 	Inherits: ^CivBuilding
@@ -444,7 +444,7 @@ CA0007:
 	Armor:
 		Type: light
 	Health:
-		HP: 400
+		HP: 40000
 
 CA0008:
 	Inherits: ^CivBuilding
@@ -456,7 +456,7 @@ CA0008:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 
 CA0009:
 	Inherits: ^CivBuilding
@@ -468,7 +468,7 @@ CA0009:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 
 CA0010:
 	Inherits: ^CivBuilding
@@ -480,7 +480,7 @@ CA0010:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 300
+		HP: 30000
 
 CA0011:
 	Inherits: ^CivBuilding
@@ -492,7 +492,7 @@ CA0011:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 200
+		HP: 20000
 
 CA0012:
 	Inherits: ^CivBuilding
@@ -504,7 +504,7 @@ CA0012:
 	Armor:
 		Type: light
 	Health:
-		HP: 100
+		HP: 10000
 
 CA0013:
 	Inherits: ^CivBuilding
@@ -516,7 +516,7 @@ CA0013:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 300
+		HP: 30000
 
 CA0014:
 	Inherits: ^CivBuilding
@@ -528,7 +528,7 @@ CA0014:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 300
+		HP: 30000
 
 CA0015:
 	Inherits: ^CivBuilding
@@ -540,7 +540,7 @@ CA0015:
 	Armor:
 		Type: light
 	Health:
-		HP: 300
+		HP: 30000
 
 CA0016:
 	Inherits: ^CivBuilding
@@ -552,7 +552,7 @@ CA0016:
 	Armor:
 		Type: light
 	Health:
-		HP: 300
+		HP: 30000
 
 CA0017:
 	Inherits: ^CivBuilding
@@ -564,7 +564,7 @@ CA0017:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 300
+		HP: 30000
 
 CA0018:
 	Inherits: ^CivBuilding
@@ -576,7 +576,7 @@ CA0018:
 	Armor:
 		Type: light
 	Health:
-		HP: 200
+		HP: 20000
 
 CA0019:
 	Inherits: ^CivBuilding
@@ -588,7 +588,7 @@ CA0019:
 	Armor:
 		Type: light
 	Health:
-		HP: 200
+		HP: 20000
 
 CA0020:
 	Inherits: ^CivBuilding
@@ -600,7 +600,7 @@ CA0020:
 	Armor:
 		Type: light
 	Health:
-		HP: 200
+		HP: 20000
 
 CA0021:
 	Inherits: ^CivBuilding
@@ -612,7 +612,7 @@ CA0021:
 	Armor:
 		Type: light
 	Health:
-		HP: 200
+		HP: 20000
 
 CAARAY:
 	Inherits: ^CivBuilding
@@ -624,7 +624,7 @@ CAARAY:
 	Armor:
 		Type: concrete
 	Health:
-		HP: 400
+		HP: 40000
 	RenderSprites:
 		Palette: player
 
@@ -638,7 +638,7 @@ CAARMR:
 	Armor:
 		Type: concrete
 	Health:
-		HP: 800
+		HP: 80000
 	RenderSprites:
 		Palette: player
 	ProvidesPrerequisite:
@@ -654,7 +654,7 @@ CABHUT:
 		Footprint: x
 		Dimensions: 1, 1
 	Health:
-		HP: 2000
+		HP: 200000
 	RenderSprites:
 		Palette: player
 
@@ -665,7 +665,7 @@ CACRSH01:
 	Armor:
 		Type: concrete
 	Health:
-		HP: 400
+		HP: 40000
 
 CACRSH02:
 	Inherits: CACRSH01
@@ -690,7 +690,7 @@ CAHOSP:
 	Armor:
 		Type: concrete
 	Health:
-		HP: 800
+		HP: 80000
 	RenderSprites:
 		Palette: player
 	Capturable:
@@ -707,7 +707,7 @@ CAPYR01:
 	Armor:
 		Type: concrete
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: SNOW
 
@@ -721,7 +721,7 @@ CAPYR02:
 	Armor:
 		Type: concrete
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: SNOW
 
@@ -735,7 +735,7 @@ CAPYR03:
 	Armor:
 		Type: concrete
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: SNOW
 
@@ -749,7 +749,7 @@ CITY01:
 	Armor:
 		Type: wood
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -763,7 +763,7 @@ CITY02:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 700
+		HP: 70000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -777,7 +777,7 @@ CITY03:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -791,7 +791,7 @@ CITY04:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 600
+		HP: 60000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -805,7 +805,7 @@ CITY05:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 600
+		HP: 60000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -819,7 +819,7 @@ CITY06:
 	Armor:
 		Type: concrete
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -833,7 +833,7 @@ CITY07:
 	Armor:
 		Type: wood
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -847,7 +847,7 @@ CITY08:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 300
+		HP: 30000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -861,7 +861,7 @@ CITY09:
 	Armor:
 		Type: wood
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -875,7 +875,7 @@ CITY10:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 300
+		HP: 30000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -889,7 +889,7 @@ CITY11:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -903,7 +903,7 @@ CITY12:
 	Armor:
 		Type: concrete
 	Health:
-		HP: 600
+		HP: 60000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -917,7 +917,7 @@ CITY13:
 	Armor:
 		Type: wood
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -931,7 +931,7 @@ CITY14:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 600
+		HP: 60000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -945,7 +945,7 @@ CITY15:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -959,7 +959,7 @@ CITY16:
 	Armor:
 		Type: wood
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -973,7 +973,7 @@ CITY17:
 	Armor:
 		Type: wood
 	Health:
-		HP: 300
+		HP: 30000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -987,7 +987,7 @@ CITY18:
 	Armor:
 		Type: concrete
 	Health:
-		HP: 600
+		HP: 60000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -1001,7 +1001,7 @@ CITY19:
 	Armor:
 		Type: wood
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -1015,7 +1015,7 @@ CITY20:
 	Armor:
 		Type: wood
 	Health:
-		HP: 250
+		HP: 25000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -1029,7 +1029,7 @@ CITY21:
 	Armor:
 		Type: none
 	Health:
-		HP: 100
+		HP: 10000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -1043,7 +1043,7 @@ CITY22:
 	Armor:
 		Type: none
 	Health:
-		HP: 100
+		HP: 10000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -1061,7 +1061,7 @@ CTDAM:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 1000
+		HP: 100000
 	ProvidesPrerequisite:
 		Prerequisite: anypower
 	EditorTilesetFilter:
@@ -1081,7 +1081,7 @@ CTVEGA:
 	Armor:
 		Type: none
 	Health:
-		HP: 100
+		HP: 10000
 	EditorTilesetFilter:
 		ExcludeTilesets: SNOW
 
@@ -1095,7 +1095,7 @@ GAKODK:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 1500
+		HP: 150000
 	RenderSprites:
 		Palette: player
 	WithIdleOverlay@LARGELIGHTS:
@@ -1115,7 +1115,7 @@ GAOLDCC1:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 	RenderSprites:
 		Palette: player
 
@@ -1129,7 +1129,7 @@ GAOLDCC2:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 	RenderSprites:
 		Palette: player
 
@@ -1143,7 +1143,7 @@ GAOLDCC3:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 	RenderSprites:
 		Palette: player
 
@@ -1157,7 +1157,7 @@ GAOLDCC4:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 	RenderSprites:
 		Palette: player
 
@@ -1171,7 +1171,7 @@ GAOLDCC5:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 	RenderSprites:
 		Palette: player
 
@@ -1185,7 +1185,7 @@ GAOLDCC6:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 	RenderSprites:
 		Palette: player
 
@@ -1206,7 +1206,7 @@ GASAND:
 		Name: Sandbags
 		Description: Stops infantry and light vehicles.\nCan be crushed by tanks.
 	Health:
-		HP: 250
+		HP: 25000
 	Armor:
 		Type: Light
 	LineBuild:
@@ -1235,7 +1235,7 @@ GASPOT:
 	Armor:
 		Type: wood
 	Health:
-		HP: 400
+		HP: 40000
 	RevealsShroud:
 		Range: 6c0
 	WithIdleOverlay@LIGHTS:
@@ -1254,14 +1254,13 @@ GALITE:
 	-WithMakeAnimation:
 	-WithDeathAnimation:
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Wood
 	RevealsShroud:
 		Range: 2c0
 	Power:
 		Amount: 0
-# TODO: should use terrain lighting instead, depends on https://github.com/OpenRA/OpenRA/issues/3605
 	WithIdleOverlay@LIGHTING:
 		Sequence: lighting
 		Palette: alpha
@@ -1290,7 +1289,7 @@ GAICBM:
 		Name: Deployed ICBM
 	-GivesBuildableArea:
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1313,7 +1312,7 @@ NAMNTK:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 1500
+		HP: 150000
 	RenderSprites:
 		Palette: player
 	WithIdleOverlay@LIGHTS:
@@ -1331,7 +1330,7 @@ NTPYRA:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 1500
+		HP: 150000
 	RenderSprites:
 		Palette: player
 	WithIdleOverlay@LIGHTS:
@@ -1349,7 +1348,7 @@ UFO:
 	Tooltip:
 		Name: Scrin Ship
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Heavy
 	EditorTilesetFilter:

--- a/mods/ts/rules/civilian-vehicles.yaml
+++ b/mods/ts/rules/civilian-vehicles.yaml
@@ -9,7 +9,7 @@
 		TurnSpeed: 5
 		Crushes: wall, crate, infantry
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -30,6 +30,7 @@
 		Delay: 10
 		HealIfBelow: 50
 		DamageCooldown: 200
+		Step: 500
 	WithVoxelTurret:
 	WithVoxelBarrel:
 	WithMuzzleOverlay:
@@ -41,7 +42,7 @@
 	Tooltip:
 		Name: Truck
 	Health:
-		HP: 200
+		HP: 20000
 	Armor:
 		Type: Light
 	Mobile:
@@ -62,7 +63,7 @@ ICBM:
 	Tooltip:
 		Name: Ballistic Missile Launcher
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Light
 	Mobile:
@@ -88,7 +89,7 @@ BUS:
 		TurnSpeed: 5
 		Speed: 113
 	Health:
-		HP: 100
+		HP: 10000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -111,7 +112,7 @@ PICK:
 		TurnSpeed: 5
 		Speed: 113
 	Health:
-		HP: 100
+		HP: 10000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -134,7 +135,7 @@ CAR:
 		TurnSpeed: 5
 		Speed: 113
 	Health:
-		HP: 100
+		HP: 10000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -157,7 +158,7 @@ WINI:
 		TurnSpeed: 5
 		Speed: 113
 	Health:
-		HP: 200
+		HP: 20000
 	Armor:
 		Type: Light
 	RevealsShroud:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -33,7 +33,7 @@
 		UpgradeTypes: reload
 		Modifier: 90, 75
 	SelfHealing@ELITE:
-		Step: 2
+		Step: 200
 		Delay: 100
 		HealIfBelow: 100
 		DamageCooldown: 125
@@ -128,6 +128,7 @@
 	RepairableBuilding:
 		IndicatorPalette: mouse
 		PlayerExperience: 25
+		RepairStep: 700
 	WithDeathAnimation:
 		DeathSequence: dead
 		UseDeathTypeSuffix: false
@@ -152,7 +153,7 @@
 	Inherits: ^BasicBuilding
 	-UpdatesPlayerStatistics:
 	Health:
-		HP: 900
+		HP: 90000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -170,7 +171,7 @@
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -243,7 +244,7 @@
 	Huntable:
 	DrawLineToTarget:
 	Health:
-		HP: 50
+		HP: 5000
 		Shape: Circle
 			Radius: 128
 			VerticalTopOffset: 512
@@ -298,7 +299,7 @@
 		Voice: Move
 	Guardable:
 	SelfHealing@HOSPITAL:
-		Step: 5
+		Step: 500
 		Delay: 100
 		HealIfBelow: 100
 		DamageCooldown: 125
@@ -597,7 +598,7 @@
 		AirborneUpgrades: airborne
 		CruisingUpgrades: cruising
 	Health:
-		HP: 280
+		HP: 28000
 	Armor:
 		Type: Heavy
 	HiddenUnderFog:
@@ -783,7 +784,7 @@
 		UnloadVoice: Unload
 		LoadingUpgrades: notmobile
 	Health:
-		HP: 100
+		HP: 10000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -840,7 +841,7 @@
 	Valued:
 		Cost: 250
 	Health:
-		HP: 350
+		HP: 35000
 	Armor:
 		Type: Heavy
 	LineBuildNode:

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -10,7 +10,7 @@ E2:
 		Name: Disc Thrower
 		Description: Infantry armed with special explosive discs.\n  Strong vs Buildings, Infantry\n  Weak vs Vehicles, Aircraft
 	Health:
-		HP: 150
+		HP: 15000
 	Mobile:
 		Speed: 56
 	Armament:
@@ -42,7 +42,7 @@ MEDIC:
 	Mobile:
 		Speed: 56
 	Health:
-		HP: 125
+		HP: 12500
 	Crushable:
 		CrushSound: squishy2.aud
 	Armament:
@@ -56,6 +56,7 @@ MEDIC:
 		AttackSequence: heal
 	SelfHealing:
 		Delay: 60
+		Step: 500
 	Passenger:
 		PipType: Red
 
@@ -75,7 +76,7 @@ JUMPJET:
 	Mobile:
 		Speed: 56
 	Health:
-		HP: 120
+		HP: 12000
 	Armor:
 		Type: Light
 	Passenger:
@@ -113,7 +114,7 @@ GHOST:
 	Mobile:
 		Speed: 56
 	Health:
-		HP: 200
+		HP: 20000
 	Passenger:
 	RevealsShroud:
 		Range: 6c0

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -15,7 +15,7 @@ GAPOWR:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 750
+		HP: 75000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -82,7 +82,7 @@ GAPILE:
 	Selectable:
 		Bounds: 88, 48, 0, -8
 	Health:
-		HP: 800
+		HP: 80000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -138,7 +138,7 @@ GAWEAP:
 	Selectable:
 		Bounds: 154, 96, -2, -12
 	Health:
-		HP: 1000
+		HP: 100000
 	RevealsShroud:
 		Range: 4c0
 	Armor:
@@ -196,7 +196,7 @@ GAHPAD:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 600
+		HP: 60000
 	RevealsShroud:
 		Range: 5c0
 	Exit@1:
@@ -211,6 +211,7 @@ GAHPAD:
 	Reservable:
 	RepairsUnits:
 		PlayerExperience: 15
+		HpPerStep: 1000
 	ProductionBar:
 	WithIdleOverlay@PLATFORM:
 		Sequence: idle-platform
@@ -252,12 +253,13 @@ GADEPT:
 	Selectable:
 		Bounds: 96, 64, -6, -6
 	Health:
-		HP: 1100
+		HP: 110000
 	RevealsShroud:
 		Range: 5c0
 	Reservable:
 	RepairsUnits:
 		PlayerExperience: 15
+		HpPerStep: 1000
 	RallyPoint:
 		Palette: mouse
 		IsPlayerPalette: false
@@ -304,7 +306,7 @@ GARADR:
 	Selectable:
 		Bounds: 96, 48, 0, -6
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RequiresPower:
@@ -349,7 +351,7 @@ GATECH:
 	Selectable:
 		Bounds: 110, 60, 3, -4
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -391,7 +393,7 @@ GAPLUG:
 	WithIdleOverlay@STRIP:
 		Sequence: idle-strip
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RevealsShroud:

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -13,7 +13,7 @@ GAWALL:
 		Name: Concrete Wall
 		Description: Stops infantry and blocks enemy fire.\nCan NOT be crushed by tanks.
 	Health:
-		HP: 225
+		HP: 22500
 	Armor:
 		Type: Concrete
 	BlocksProjectiles:
@@ -60,7 +60,7 @@ GACTWR:
 		Bounds: 48, 36, 0, -6
 	DisabledOverlay:
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Light
 	BlocksProjectiles:

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -15,7 +15,7 @@ APC:
 		TerrainSpeeds:
 			Water: 80
 	Health:
-		HP: 200
+		HP: 20000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -70,7 +70,7 @@ HVR:
 			BlueTiberium: 100
 			Veins: 100
 	Health:
-		HP: 230
+		HP: 23000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -112,7 +112,7 @@ SMECH:
 		TurnSpeed: 5
 		Speed: 99
 	Health:
-		HP: 175
+		HP: 17500
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -154,7 +154,7 @@ MMCH:
 		Speed: 56
 		Crushes: wall, crate, infantry
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -200,8 +200,9 @@ HMEC:
 		Speed: 42
 		Crushes: wall, crate, infantry
 	Health:
-		HP: 800
+		HP: 80000
 	SelfHealing:
+		Step: 500
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -239,7 +240,7 @@ SONIC:
 		Speed: 56
 		Crushes: wall, crate, infantry
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -46,7 +46,7 @@ CAMERA:
 	Immobile:
 		OccupiesSpace: false
 	Health:
-		HP: 1000
+		HP: 100000
 	RevealsShroud:
 		Range: 10c0
 		Type: CenterPosition

--- a/mods/ts/rules/nod-infantry.yaml
+++ b/mods/ts/rules/nod-infantry.yaml
@@ -12,7 +12,7 @@ E3:
 	Voiced:
 		VoiceSet: Rocket
 	Health:
-		HP: 100
+		HP: 10000
 	Mobile:
 		Speed: 42
 	Armament@PRIMARY:
@@ -45,7 +45,7 @@ CYBORG:
 	Mobile:
 		Speed: 56
 	Health:
-		HP: 300
+		HP: 30000
 	Passenger:
 	RevealsShroud:
 		Range: 5c0
@@ -79,7 +79,7 @@ CYC2:
 	Mobile:
 		Speed: 56
 	Health:
-		HP: 500
+		HP: 50000
 	Passenger:
 	RevealsShroud:
 		Range: 7c0
@@ -109,7 +109,7 @@ MHIJACK:
 	Voiced:
 		VoiceSet: Hijacker
 	Health:
-		HP: 300
+		HP: 30000
 	Mobile:
 		Speed: 99
 	-Crushable:

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -17,7 +17,7 @@ NAPOWR:
 	Selectable:
 		Bounds: 88, 48, 2, -6
 	Health:
-		HP: 750
+		HP: 75000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -55,7 +55,7 @@ NAAPWR:
 	Selectable:
 		Bounds: 100, 54, 0, -4
 	Health:
-		HP: 750
+		HP: 75000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -93,7 +93,7 @@ NAHAND:
 	Selectable:
 		Bounds: 116, 60, 3, -6
 	Health:
-		HP: 800
+		HP: 80000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -147,7 +147,7 @@ NAWEAP:
 	Selectable:
 		Bounds: 149, 80, -3, -10
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -201,7 +201,7 @@ NAHPAD:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 600
+		HP: 60000
 	RevealsShroud:
 		Range: 5c0
 	Exit@1:
@@ -216,6 +216,7 @@ NAHPAD:
 	Reservable:
 	RepairsUnits:
 		PlayerExperience: 15
+		HpPerStep: 1000
 	ProductionBar:
 	WithIdleOverlay@PLATFORM:
 		Sequence: idle-platform
@@ -259,7 +260,7 @@ NARADR:
 	Selectable:
 		Bounds: 96, 48, 0, -6
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RequiresPower:
@@ -304,7 +305,7 @@ NATECH:
 	Selectable:
 		Bounds: 86, 48, 0, -4
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -336,7 +337,7 @@ NATMPL:
 	Selectable:
 		Bounds: 134, 120, 12, -12
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -372,7 +373,7 @@ NASTLH:
 		Footprint: xxx xxx
 		Dimensions: 3,2
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -419,7 +420,7 @@ NAWAST:
 	Selectable:
 		Bounds: 100, 60, 5, -5
 	Health:
-		HP: 400
+		HP: 40000
 	RevealsShroud:
 		Range: 6c0
 	TiberianSunRefinery:

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -13,7 +13,7 @@ NAWALL:
 		Name: Concrete Wall
 		Description: Stops infantry and blocks enemy fire.\nCan NOT be crushed by tanks.
 	Health:
-		HP: 225
+		HP: 22500
 	Armor:
 		Type: Concrete
 	BlocksProjectiles:
@@ -57,7 +57,7 @@ NALASR:
 		Bounds: 40, 30, -8, -6
 	DisabledOverlay:
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -100,7 +100,7 @@ NAOBEL:
 	RequiresPower:
 	DisabledOverlay:
 	Health:
-		HP: 725
+		HP: 72500
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -138,7 +138,7 @@ NASAM:
 	RequiresPower:
 	DisabledOverlay:
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Wood
 	BodyOrientation:
@@ -166,7 +166,7 @@ GAARTY:
 	Tooltip:
 		Name: Deployed Artillery
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -214,7 +214,7 @@ NAMISL:
 	Selectable:
 		Bounds: 75,48
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RevealsShroud:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -13,7 +13,7 @@ BGGY:
 		TurnSpeed: 8
 		Speed: 142
 	Health:
-		HP: 220
+		HP: 22000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -46,7 +46,7 @@ BIKE:
 		TurnSpeed: 8
 		Speed: 170
 	Health:
-		HP: 150
+		HP: 15000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -82,7 +82,7 @@ TTNK:
 		Speed: 85
 		Crushes: wall, crate, infantry
 	Health:
-		HP: 350
+		HP: 35000
 	Armor:
 		Type: Light
 		UpgradeTypes: undeployed
@@ -178,7 +178,7 @@ ART2:
 		BuildPaletteOrder: 100
 		Prerequisites: ~naweap, naradr
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Light
 	Mobile:
@@ -207,7 +207,7 @@ REPAIR:
 		Name: Mobile Repair Vehicle
 		Description: Repairs nearby vehicles.\n  Unarmed
 	Health:
-		HP: 200
+		HP: 20000
 	Mobile:
 		Speed: 85
 		TurnSpeed: 5
@@ -247,11 +247,12 @@ WEED:
 		Speed: 71
 		TurnSpeed: 5
 	Health:
-		HP: 600
+		HP: 60000
 	SelfHealing:
 		Delay: 10
 		HealIfBelow: 50
 		DamageCooldown: 200
+		Step: 500
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -278,7 +279,7 @@ SAPC:
 		TurnSpeed: 5
 		Speed: 71
 	Health:
-		HP: 175
+		HP: 17500
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -307,7 +308,7 @@ SUBTANK:
 		Speed: 71
 		Crushes: wall, crate, infantry
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -334,7 +335,7 @@ STNK:
 		Speed: 85
 		Crushes: wall, crate, infantry
 	Health:
-		HP: 180
+		HP: 18000
 	Armor:
 		Type: Light
 	RevealsShroud:

--- a/mods/ts/rules/shared-infantry.yaml
+++ b/mods/ts/rules/shared-infantry.yaml
@@ -10,7 +10,7 @@ E1:
 		Name: Light Infantry
 		Description: General-purpose infantry.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft
 	Health:
-		HP: 125
+		HP: 12500
 	Mobile:
 		Speed: 71
 	Armament@PRIMARY:
@@ -50,7 +50,7 @@ ENGINEER:
 	Mobile:
 		Speed: 56
 	Health:
-		HP: 500
+		HP: 50000
 	Passenger:
 		PipType: Yellow
 	EngineerRepair:
@@ -88,9 +88,9 @@ FLAMEGUY:
 	WithInfantryBody:
 		IdleSequences: run
 	Health:
-		HP: 160
+		HP: 16000
 	SelfHealing:
-		Step: -10
+		Step: -1000
 		HealIfBelow: 101
 	ScaredyCat:
 	WithDeathAnimation:

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -9,7 +9,7 @@ GACNST:
 		BuildPaletteOrder: 1000
 		Prerequisites: ~disabled
 	Health:
-		HP: 1500
+		HP: 150000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -70,7 +70,7 @@ PROC:
 	Selectable:
 		Bounds: 134, 96, 0, -12
 	Health:
-		HP: 900
+		HP: 90000
 	RevealsShroud:
 		Range: 6c0
 	TiberianSunRefinery:
@@ -124,7 +124,7 @@ GASILO:
 		Bounds: 80, 48, -5, 0
 	-GivesBuildableArea:
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Wood
 	RevealsShroud:

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -17,7 +17,7 @@ NAPULS:
 	RequiresPower:
 	DisabledOverlay:
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -12,7 +12,7 @@ MCV:
 	Selectable:
 		Priority: 3
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Light
 	Mobile:
@@ -72,11 +72,12 @@ HARV:
 			BlueTiberium: 80
 			Veins: 80
 	Health:
-		HP: 1000
+		HP: 100000
 	SelfHealing:
 		Delay: 10
 		HealIfBelow: 50
 		DamageCooldown: 200
+		Step: 500
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -114,7 +115,7 @@ LPST:
 		Name: Mobile Sensor Array
 		Description: Can detect cloaked and subterranean\nunits when deployed.\n  Unarmed
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Wood
 	Mobile:

--- a/mods/ts/weapons/bombsandgrenades.yaml
+++ b/mods/ts/weapons/bombsandgrenades.yaml
@@ -10,7 +10,7 @@ Grenade:
 		Image: DISCUS
 	Warhead@1Dam: SpreadDamage
 		Spread: 171
-		Damage: 40
+		Damage: 4000
 		Versus:
 			None: 100
 			Wood: 85
@@ -43,7 +43,7 @@ Bomb:
 		Palette: ra
 	Warhead@1Dam: SpreadDamage
 		Spread: 298
-		Damage: 160
+		Damage: 16000
 		Versus:
 			None: 200
 			Wood: 90
@@ -77,7 +77,7 @@ RPGTower:
 		Palette: player
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 110
+		Damage: 11000
 		Versus:
 			None: 30
 			Wood: 75

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -13,7 +13,7 @@ LtRail:
 	Warhead@1Dam: SpreadDamage
 		Range: 0, 32
 		Falloff: 100, 100
-		Damage: 150
+		Damage: 15000
 		InfDeath: 6
 		AffectsParent: false
 		ValidStances: Neutral, Enemy
@@ -27,7 +27,7 @@ LtRail:
 	Warhead@2Dam: SpreadDamage
 		Range: 0, 32
 		Falloff: 50, 50 # Only does half damage to friendly units
-		Damage: 150
+		Damage: 15000
 		InfDeath: 6
 		AffectsParent: false
 		ValidStances: Ally
@@ -55,7 +55,7 @@ MechRailgun:
 		Color: 00FFFFC8
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
-		Damage: 200
+		Damage: 20000
 		Versus:
 			None: 200
 			Wood: 175
@@ -81,7 +81,7 @@ SonicZap:
 	Warhead@1Dam: SpreadDamage
 		Range: 0, 32
 		Falloff: 100, 100
-		Damage: 8
+		Damage: 800
 		AffectsParent: false
 		ValidStances: Neutral, Enemy
 		Versus:
@@ -91,8 +91,8 @@ SonicZap:
 	Warhead@2Dam: SpreadDamage
 		Range: 0, 32
 		Falloff: 50, 50
-		Damage: 8
 		InvalidTargets: Disruptor # Does not affect friendly disruptors at all
+		Damage: 800
 		AffectsParent: false
 		ValidStances: Ally
 		Versus:
@@ -115,7 +115,7 @@ CyCannon:
 		Speed: 384
 	Warhead@1Dam: SpreadDamage
 		Spread: 43
-		Damage: 120
+		Damage: 12000
 		ValidTargets: Ground
 		Versus:
 			None: 350
@@ -153,7 +153,7 @@ Proton:
 		RangeLimit: 35
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 20
+		Damage: 2000
 		ValidTargets: Ground
 		Versus:
 			None: 25
@@ -184,7 +184,7 @@ ObeliskLaserFire:
 		ZOffset: 2047
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
-		Damage: 250
+		Damage: 25000
 		DamageTypes: Prone60Percent, TriggerProne, EnergyDeath
 
 TurretLaserFire:
@@ -197,5 +197,5 @@ TurretLaserFire:
 		ZOffset: 2047
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
-		Damage: 30
+		Damage: 3000
 		DamageTypes: Prone60Percent, TriggerProne, EnergyDeath

--- a/mods/ts/weapons/explosions.yaml
+++ b/mods/ts/weapons/explosions.yaml
@@ -1,7 +1,7 @@
 UnitExplode:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 50
+		Damage: 5000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
 			None: 90
@@ -19,7 +19,7 @@ UnitExplode:
 UnitExplodeSmall:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 40
+		Damage: 4000
 		Versus:
 			None: 90
 			Wood: 75
@@ -41,7 +41,7 @@ CyborgExplode:
 TiberiumExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 9
-		Damage: 10
+		Damage: 1000
 		Versus:
 			None: 90
 			Wood: 75

--- a/mods/ts/weapons/healweapons.yaml
+++ b/mods/ts/weapons/healweapons.yaml
@@ -8,7 +8,7 @@ Heal:
 	Warhead@1Dam: SpreadDamage
 		DebugOverlayColor: 00FF00
 		Spread: 213
-		Damage: -50
+		Damage: -5000
 		ValidTargets: Infantry
 
 Repair:
@@ -21,5 +21,5 @@ Repair:
 	Warhead@1Dam: SpreadDamage
 		DebugOverlayColor: 00FF00
 		Spread: 213
-		Damage: -50
+		Damage: -5000
 		ValidTargets: Repair

--- a/mods/ts/weapons/largeguns.yaml
+++ b/mods/ts/weapons/largeguns.yaml
@@ -10,7 +10,7 @@
 		Palette: ra
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 36
+		Damage: 3600
 		Versus:
 			None: 25
 			Wood: 65
@@ -39,7 +39,7 @@
 		Speed: 1c512
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 70
+		Damage: 7000
 		Versus:
 			None: 25
 			Wood: 65
@@ -74,7 +74,7 @@
 		Palette: ra
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 50
+		Damage: 5000
 		Versus:
 			None: 25
 			Wood: 65
@@ -109,7 +109,7 @@
 	MinRange: 5c0
 	Warhead@1Dam: SpreadDamage
 		Spread: 298
-		Damage: 150
+		Damage: 15000
 		Versus:
 			None: 100
 			Wood: 85

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -18,7 +18,7 @@ Bazooka:
 		Speed: 384
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 25
+		Damage: 2500
 		ValidTargets: Ground, Air
 		Versus:
 			None: 25
@@ -65,7 +65,7 @@ HoverMissile:
 		Speed: 384
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 30
+		Damage: 3000
 		ValidTargets: Ground, Air
 		Versus:
 			None: 25
@@ -111,7 +111,7 @@ MammothTusk:
 		Speed: 384
 	Warhead@1Dam: SpreadDamage
 		Spread: 171
-		Damage: 40
+		Damage: 4000
 		ValidTargets: Air
 		Versus:
 			None: 100
@@ -152,7 +152,7 @@ BikeMissile:
 		Speed: 384
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
-		Damage: 40
+		Damage: 4000
 		ValidTargets: Ground
 		Versus:
 			None: 25
@@ -195,7 +195,7 @@ Dragon:
 		Speed: 384
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 30
+		Damage: 3000
 		ValidTargets: Ground, Air
 		Versus:
 			None: 25
@@ -242,7 +242,7 @@ Hellfire:
 		Speed: 384
 	Warhead@1Dam: SpreadDamage
 		Spread: 85
-		Damage: 30
+		Damage: 3000
 		ValidTargets: Ground
 		Versus:
 			None: 30
@@ -288,7 +288,7 @@ RedEye2:
 		Speed: 384
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 33
+		Damage: 3300
 		ValidTargets: Air
 		DamageTypes: SmallExplosionDeath
 	Warhead@2Eff: CreateEffect

--- a/mods/ts/weapons/otherweapons.yaml
+++ b/mods/ts/weapons/otherweapons.yaml
@@ -10,7 +10,7 @@ FireballLauncher:
 	BurstDelay: 5
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
-		Damage: 25
+		Damage: 2500
 		Versus:
 			None: 600
 			Wood: 148
@@ -35,7 +35,7 @@ FiendShard:
 		Angle: 60
 		Palette: greentiberium
 	Warhead@1Dam: SpreadDamage
-		Damage: 35
+		Damage: 3500
 		Versus:
 			Light: 60
 			Heavy: 40
@@ -54,7 +54,7 @@ SlimeAttack:
 	Projectile: Bullet
 		Speed: 426
 	Warhead@1Dam: SpreadDamage
-		Damage: 100
+		Damage: 10000
 		Versus:
 			Light: 60
 			Heavy: 40
@@ -65,7 +65,7 @@ Veins:
 	ReloadDelay: 16
 	Warhead@Damage: SpreadDamage
 		Spread: 42
-		Damage: 5
+		Damage: 500
 		DamageTypes: BulletDeath
 	Warhead@Effect: CreateEffect
 		Explosions: veins

--- a/mods/ts/weapons/smallguns.yaml
+++ b/mods/ts/weapons/smallguns.yaml
@@ -6,7 +6,7 @@ Minigun:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 8
+		Damage: 800
 		Versus:
 			Wood: 60
 			Light: 40
@@ -29,7 +29,7 @@ M1Carbine:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 15
+		Damage: 1500
 		Versus:
 			Wood: 60
 			Light: 40
@@ -52,7 +52,7 @@ Vulcan:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 20
+		Damage: 2000
 		Versus:
 			Wood: 60
 			Light: 40
@@ -76,7 +76,7 @@ Vulcan2:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 50
+		Damage: 5000
 		Versus:
 			None: 100
 			Wood: 60
@@ -101,7 +101,7 @@ Vulcan3:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 10
+		Damage: 1000
 		Versus:
 			Wood: 60
 			Light: 40
@@ -124,7 +124,7 @@ VulcanTower:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 18
+		Damage: 1800
 		Versus:
 			Wood: 60
 			Light: 40
@@ -148,7 +148,7 @@ JumpCannon:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 15
+		Damage: 1500
 		Versus:
 			Wood: 60
 			Light: 40
@@ -171,7 +171,7 @@ AssaultCannon:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 40
+		Damage: 4000
 		Versus:
 			Wood: 60
 			Light: 40
@@ -196,7 +196,7 @@ RaiderCannon:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 40
+		Damage: 4000
 		Versus:
 			Wood: 60
 			Light: 40
@@ -220,7 +220,7 @@ HarpyClaw:
 	ValidTargets: Ground, Air
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 60
+		Damage: 6000
 		ValidTargets: Ground, Air
 		Versus:
 			Wood: 60
@@ -244,7 +244,7 @@ Pistola:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 2
+		Damage: 200
 		Versus:
 			Wood: 60
 			Light: 40
@@ -267,7 +267,7 @@ Sniper:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
-		Damage: 150
+		Damage: 15000
 		Versus:
 			None: 100
 			Wood: 5

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -17,7 +17,7 @@ MultiCluster:
 		Speed: 384
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 65
+		Damage: 6500
 		ValidTargets: Ground
 		Versus:
 			None: 25
@@ -45,7 +45,7 @@ SuicideBomb:
 	Report: hunter2.aud
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
-		Damage: 110
+		Damage: 11000
 		Falloff: 10000, 3680, 1350, 500, 180, 70, 0
 		Versus:
 			None: 90
@@ -59,7 +59,7 @@ IonCannon:
 	ValidTargets: Ground, Air
 	Warhead@1Dam_impact: SpreadDamage
 		Spread: 1c0
-		Damage: 100
+		Damage: 10000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: Ground, Air
 		DamageTypes: Prone100Percent, TriggerProne, EnergyDeath
@@ -68,7 +68,7 @@ IonCannon:
 		ImpactSounds: ion1.aud
 	Warhead@3Dam_area: SpreadDamage
 		Spread: 1c0
-		Damage: 250
+		Damage: 25000
 		Falloff: 100, 50, 25, 0
 		Delay: 3
 		ValidTargets: Ground, Air
@@ -100,7 +100,7 @@ ClusterMissile:
 	ValidTargets: Ground, Water, Air
 	Warhead@ImpactDamage0: SpreadDamage
 		Spread: 1c0
-		Damage: 150
+		Damage: 15000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: Ground, Water, Air
 		Versus:
@@ -117,7 +117,7 @@ ClusterMissile:
 		Size: 1
 	Warhead@ClusterDamage1: SpreadDamage
 		Spread: 2c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 5
 		ValidTargets: Ground, Water, Air
@@ -134,7 +134,7 @@ ClusterMissile:
 		Delay: 5
 	Warhead@ClusterDamage2: SpreadDamage
 		Spread: 3c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 10
 		ValidTargets: Ground, Water, Air
@@ -151,7 +151,7 @@ ClusterMissile:
 		Delay: 10
 	Warhead@ClusterDamage3: SpreadDamage
 		Spread: 4c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 15
 		ValidTargets: Ground, Water, Air
@@ -168,7 +168,7 @@ ClusterMissile:
 		Delay: 15
 	Warhead@ClusterDamage4: SpreadDamage
 		Spread: 5c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 20
 		ValidTargets: Ground, Water, Air


### PR DESCRIPTION
This should pretty much fix all rounding issues with damage percentages, versus values etc.

Closes #11719.
Fixes #11850.
Properly fixes #11425 (the TD Jeep + Buggy were still affected).

_Note:_ This _will_ somewhat affect balancing, as several weapons' damage versus specific armor types won't be rounded down nearly as much as before, in some cases increasing effective damage by as much as 50% against these armor types (effective damage of some RA/TD miniguns vs. Heavy goes up from 1 to 150 compared to pre-#11460 bleed, for example).

At least a certain amount of testing will have to go into this PR.
