### PR TITLE
Remove and document slope-specific tiberium artwork.

### DIFF
--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -24,7 +24,7 @@
 	ResourceType@Tiberium:
 		ResourceType: 1
 		Palette: greentiberium
-		Variants: tib01, tib02, tib03, tib04, tib05, tib06, tib07, tib08, tib09, tib10, tib11, tib12, tib13, tib14, tib15, tib16, tib17, tib18, tib19, tib20
+		Variants: tib01, tib02, tib03, tib04, tib05, tib06, tib07, tib08, tib09, tib10, tib11, tib12
 		MaxDensity: 12
 		ValuePerUnit: 50
 		Name: Tiberium
@@ -35,7 +35,7 @@
 	ResourceType@BlueTiberium:
 		ResourceType: 2
 		Palette: bluetiberium
-		Variants: tib01, tib02, tib03, tib04, tib05, tib06, tib07, tib08, tib09, tib10, tib11, tib12, tib13, tib14, tib15, tib16, tib17, tib18, tib19, tib20
+		Variants: tib01, tib02, tib03, tib04, tib05, tib06, tib07, tib08, tib09, tib10, tib11, tib12
 		MaxDensity: 12
 		ValuePerUnit: 100
 		Name: BlueTiberium

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -277,14 +277,14 @@ resources:
 	tib10: tib10
 	tib11: tib11
 	tib12: tib12
-	tib13: tib13
-	tib14: tib14
-	tib15: tib15
-	tib16: tib16
-	tib17: tib17
-	tib18: tib18
-	tib19: tib19
-	tib20: tib20
+	tib13: tib13 # TODO: NW ramp variant, currently unused
+	tib14: tib14 # TODO: NW ramp variant, currently unused
+	tib15: tib15 # TODO: NE ramp variant, currently unused
+	tib16: tib16 # TODO: NE ramp variant, currently unused
+	tib17: tib17 # TODO: SE ramp variant, currently unused
+	tib18: tib18 # TODO: SE ramp variant, currently unused
+	tib19: tib19 # TODO: SW ramp variant, currently unused
+	tib20: tib20 # TODO: SW ramp variant, currently unused
 	veins: veins
 		Length: 1
 		Start: 52


### PR DESCRIPTION
http://www.ppmforums.com/viewtopic.php?p=549033 explains that tib13-20 are used for slopes, and this can be easily confirmed by checking the shapes with the asset browser.

This PR removes these tiles from the Variants list so that they aren't drawn on flat tiles (which gives gappy looking fields).  It also adds some comments for the future when we decide to add ramp support for resources.
