### PR TITLE
Fixed a typo in the message displayed when servers disabled single player matches

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -35,6 +35,8 @@ namespace OpenRA.Server
 
 	public class Server
 	{
+		public readonly string TwoHumansRequiredText = "This server requires at least two human players to start a match.";
+
 		public readonly IPAddress Ip;
 		public readonly int Port;
 		public readonly MersenneTwister Random = new MersenneTwister();
@@ -396,7 +398,7 @@ namespace OpenRA.Server
 					SendOrderTo(newConn, "Message", "This map contains custom rules. Game experience may change.");
 
 				if (!LobbyInfo.GlobalSettings.EnableSingleplayer)
-					SendOrderTo(newConn, "Message", "This server requires at least two human players to start a match.");
+					SendOrderTo(newConn, "Message", TwoHumansRequiredText);
 				else if (Map.Players.Players.Where(p => p.Value.Playable).All(p => !p.Value.AllowBots))
 					SendOrderTo(newConn, "Message", "Bots have been disabled on this map.");
 

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -126,7 +126,7 @@ namespace OpenRA.Mods.Common.Server
 						if (!server.LobbyInfo.GlobalSettings.EnableSingleplayer &&
 							server.LobbyInfo.Clients.Where(c => c.Bot == null && c.Slot != null).Count() == 1)
 						{
-							server.SendOrderTo(conn, "Message", "This server requires at least two human players to start match.");
+							server.SendOrderTo(conn, "Message", server.TwoHumansRequiredText);
 							return true;
 						}
 
@@ -404,7 +404,7 @@ namespace OpenRA.Mods.Common.Server
 								server.SendMessage("This map contains custom rules. Game experience may change.");
 
 							if (!server.LobbyInfo.GlobalSettings.EnableSingleplayer)
-								server.SendMessage("This server requires at least two human players to start match.");
+								server.SendMessage(server.TwoHumansRequiredText);
 							else if (server.Map.Players.Players.Where(p => p.Value.Playable).All(p => !p.Value.AllowBots))
 								server.SendMessage("Bots have been disabled on this map.");
 						};


### PR DESCRIPTION
As reported by @jaZzKCS in Mumble.

``` diff
-"This server requires at least two human players to start match."
+"This server requires at least two human players to start a match."
```
