### PR TITLE
Add support for sending messages to certain teams or players with lua

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -188,14 +188,16 @@ namespace OpenRA.Mods.Common.Scripting
 			return true;
 		}
 
-		[Desc("Display a text message to the player.")]
-		public void DisplayMessage(string text, string prefix = "Mission", HSLColor? color = null)
+		[Desc("Display a text message to all players.")]
+		public void DisplayMessage(string text, string prefix = "Mission", HSLColor? color = null, int team = 0)
 		{
 			if (string.IsNullOrEmpty(text))
 				return;
 
 			Color c = color.HasValue ? HSLColor.RGBFromHSL(color.Value.H / 255f, color.Value.S / 255f, color.Value.L / 255f) : Color.White;
-			Game.AddChatLine(c, prefix, text);
+
+			if (team == 0 || (world.LocalPlayer != null && world.LobbyInfo.ClientWithIndex(world.LocalPlayer.ClientIndex).Team == team))
+				Game.AddChatLine(c, prefix, text);
 		}
 
 		[Desc("Displays a debug message to the player, if \"Show Map Debug Messages\" is checked in the settings.")]

--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -200,6 +200,13 @@ namespace OpenRA.Mods.Common.Scripting
 				Game.AddChatLine(c, prefix, text);
 		}
 
+		[Desc("Display a text message only to one player.")]
+		public void PrivateMessage(Player player, string text, string prefix = "Mission [Private]", HSLColor? color = null)
+		{
+			if (Context.World.LocalPlayer == player)
+				DisplayMessage(text, prefix, color);
+		}
+
 		[Desc("Displays a debug message to the player, if \"Show Map Debug Messages\" is checked in the settings.")]
 		public void Debug(string text)
 		{


### PR DESCRIPTION
This extends the normal `DisplayMessage` to include a team parameter (0 means to everyone).
And secondly adds a new method for sending private messages which accepts a player parameter.
