### PR TITLE
Let engineers detect mines

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -185,6 +185,9 @@ E6:
 		VoiceSet: EngineerVoice
 	Selectable:
 		Priority: 5
+	DetectCloaked:
+		Range: 4c0
+		CloakTypes: Mine
 
 SPY:
 	Inherits: ^Soldier


### PR DESCRIPTION
The minor part of #11749. The ability to defuse mines will be added in a follow-up PR.
