### PR TITLE
Draw tactical overlays (beacons, rallypoints, text overlays, order generators) above the shroud.

### DIFF
--- a/OpenRA.Game/Effects/IEffect.cs
+++ b/OpenRA.Game/Effects/IEffect.cs
@@ -19,4 +19,6 @@ namespace OpenRA.Effects
 		void Tick(World world);
 		IEnumerable<IRenderable> Render(WorldRenderer r);
 	}
+
+	public interface IEffectAboveShroud { IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr); }
 }

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -111,9 +111,6 @@ namespace OpenRA.Graphics
 			worldRenderables = worldRenderables.Concat(World.Effects.SelectMany(e => e.Render(this)));
 			worldRenderables = worldRenderables.OrderBy(RenderableScreenZPositionComparisonKey);
 
-			if (World.OrderGenerator != null)
-				worldRenderables = worldRenderables.Concat(World.OrderGenerator.RenderAfterWorld(this, World));
-
 			Game.Renderer.WorldVoxelRenderer.BeginFrame();
 			var renderables = worldRenderables.Select(r => r.PrepareRender(this)).ToList();
 			Game.Renderer.WorldVoxelRenderer.EndFrame();
@@ -185,10 +182,15 @@ namespace OpenRA.Graphics
 				.Where(e => e != null)
 				.SelectMany(e => e.RenderAboveShroud(this));
 
+			var aboveShroudOrderGenerator = SpriteRenderable.None;
+			if (World.OrderGenerator != null)
+				aboveShroudOrderGenerator = World.OrderGenerator.RenderAboveShroud(this, World);
+
 			Game.Renderer.WorldVoxelRenderer.BeginFrame();
 			var finalOverlayRenderables = aboveShroud
 				.Concat(aboveShroudSelected)
 				.Concat(aboveShroudEffects)
+				.Concat(aboveShroudOrderGenerator)
 				.Select(r => r.PrepareRender(this));
 			Game.Renderer.WorldVoxelRenderer.EndFrame();
 

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -194,31 +194,6 @@ namespace OpenRA.Graphics
 					foreach (var r in g)
 						r.RenderDebugGeometry(this);
 
-			if (World.Type == WorldType.Regular)
-			{
-				foreach (var g in World.ScreenMap.ActorsInBox(Viewport.TopLeft, Viewport.BottomRight)
-					.Where(a =>
-						!a.Disposed &&
-						!World.Selection.Contains(a) &&
-						a.Info.HasTraitInfo<SelectableInfo>() &&
-						!World.FogObscures(a)))
-				{
-					if (Game.Settings.Game.StatusBars == StatusBarsType.Standard)
-						new SelectionBarsRenderable(g, false, false).Render(this);
-
-					if (Game.Settings.Game.StatusBars == StatusBarsType.AlwaysShow)
-						new SelectionBarsRenderable(g, true, true).Render(this);
-
-					if (Game.Settings.Game.StatusBars == StatusBarsType.DamageShow)
-					{
-						if (g.GetDamageState() != DamageState.Undamaged)
-							new SelectionBarsRenderable(g, true, true).Render(this);
-						else
-							new SelectionBarsRenderable(g, false, true).Render(this);
-					}
-				}
-			}
-
 			Game.Renderer.Flush();
 		}
 

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -152,9 +152,9 @@ namespace OpenRA.Graphics
 			if (enableDepthBuffer)
 				Game.Renderer.ClearDepthBuffer();
 
-			foreach (var a in World.ActorsWithTrait<IPostRender>())
+			foreach (var a in World.ActorsWithTrait<IRenderAboveWorld>())
 				if (a.Actor.IsInWorld && !a.Actor.Disposed)
-					a.Trait.RenderAfterWorld(this, a.Actor);
+					a.Trait.RenderAboveWorld(a.Actor, this);
 
 			var renderShroud = World.RenderPlayer != null ? World.RenderPlayer.Shroud : null;
 
@@ -162,7 +162,7 @@ namespace OpenRA.Graphics
 				Game.Renderer.ClearDepthBuffer();
 
 			foreach (var a in World.ActorsWithTrait<IRenderShroud>())
-				a.Trait.RenderShroud(this, renderShroud);
+				a.Trait.RenderShroud(renderShroud, this);
 
 			if (devTrait.Value != null && devTrait.Value.ShowDebugGeometry)
 				for (var i = 0; i < renderables.Count; i++)
@@ -174,8 +174,8 @@ namespace OpenRA.Graphics
 			Game.Renderer.DisableScissor();
 
 			var overlayRenderables = World.Selection.Actors.Where(a => !a.Disposed)
-				.SelectMany(a => a.TraitsImplementing<IPostRenderSelection>())
-				.SelectMany(t => t.RenderAfterWorld(this));
+				.SelectMany(a => a.TraitsImplementing<IRenderAboveShroudWhenSelected>()
+					.SelectMany(t => t.RenderAboveShroud(a, this)));
 
 			Game.Renderer.WorldVoxelRenderer.BeginFrame();
 			var finalOverlayRenderables = overlayRenderables.Select(r => r.PrepareRender(this));

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
+using OpenRA.Effects;
 using OpenRA.Traits;
 
 namespace OpenRA.Graphics
@@ -180,8 +181,15 @@ namespace OpenRA.Graphics
 				.SelectMany(a => a.TraitsImplementing<IRenderAboveShroudWhenSelected>()
 					.SelectMany(t => t.RenderAboveShroud(a, this)));
 
+			var aboveShroudEffects = World.Effects.Select(e => e as IEffectAboveShroud)
+				.Where(e => e != null)
+				.SelectMany(e => e.RenderAboveShroud(this));
+
 			Game.Renderer.WorldVoxelRenderer.BeginFrame();
-			var finalOverlayRenderables = aboveShroud.Concat(aboveShroudSelected).Select(r => r.PrepareRender(this));
+			var finalOverlayRenderables = aboveShroud
+				.Concat(aboveShroudSelected)
+				.Concat(aboveShroudEffects)
+				.Select(r => r.PrepareRender(this));
 			Game.Renderer.WorldVoxelRenderer.EndFrame();
 
 			// HACK: Keep old grouping behaviour

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -173,12 +173,15 @@ namespace OpenRA.Graphics
 
 			Game.Renderer.DisableScissor();
 
-			var overlayRenderables = World.Selection.Actors.Where(a => !a.Disposed)
+			var aboveShroud = World.ActorsWithTrait<IRenderAboveShroud>().Where(a => a.Actor.IsInWorld && !a.Actor.Disposed)
+				.SelectMany(a => a.Trait.RenderAboveShroud(a.Actor, this));
+
+			var aboveShroudSelected = World.Selection.Actors.Where(a => !a.Disposed)
 				.SelectMany(a => a.TraitsImplementing<IRenderAboveShroudWhenSelected>()
 					.SelectMany(t => t.RenderAboveShroud(a, this)));
 
 			Game.Renderer.WorldVoxelRenderer.BeginFrame();
-			var finalOverlayRenderables = overlayRenderables.Select(r => r.PrepareRender(this));
+			var finalOverlayRenderables = aboveShroud.Concat(aboveShroudSelected).Select(r => r.PrepareRender(this));
 			Game.Renderer.WorldVoxelRenderer.EndFrame();
 
 			// HACK: Keep old grouping behaviour

--- a/OpenRA.Game/Orders/IOrderGenerator.cs
+++ b/OpenRA.Game/Orders/IOrderGenerator.cs
@@ -19,7 +19,7 @@ namespace OpenRA
 		IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi);
 		void Tick(World world);
 		IEnumerable<IRenderable> Render(WorldRenderer wr, World world);
-		IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr, World world);
+		IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world);
 		string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi);
 	}
 }

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Orders
 
 		public virtual void Tick(World world) { }
 		public virtual IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
-		public virtual IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr, World world) { yield break; }
+		public virtual IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
 
 		public virtual string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -374,11 +374,9 @@ namespace OpenRA.Traits
 		string SequencePrefix { get; }
 	}
 
-	public interface IPostRender { void RenderAfterWorld(WorldRenderer wr, Actor self); }
-
-	public interface IRenderShroud { void RenderShroud(WorldRenderer wr, Shroud shroud); }
-
-	public interface IPostRenderSelection { IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr); }
+	public interface IRenderAboveWorld { void RenderAboveWorld(Actor self, WorldRenderer wr); }
+	public interface IRenderShroud { void RenderShroud(Shroud shroud, WorldRenderer wr); }
+	public interface IRenderAboveShroudWhenSelected { IEnumerable<IRenderable> RenderAboveShroud(Actor self, WorldRenderer wr); }
 
 	public interface ITargetableInfo : ITraitInfoInterface
 	{

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -376,6 +376,7 @@ namespace OpenRA.Traits
 
 	public interface IRenderAboveWorld { void RenderAboveWorld(Actor self, WorldRenderer wr); }
 	public interface IRenderShroud { void RenderShroud(Shroud shroud, WorldRenderer wr); }
+	public interface IRenderAboveShroud { IEnumerable<IRenderable> RenderAboveShroud(Actor self, WorldRenderer wr); }
 	public interface IRenderAboveShroudWhenSelected { IEnumerable<IRenderable> RenderAboveShroud(Actor self, WorldRenderer wr); }
 
 	public interface ITargetableInfo : ITraitInfoInterface

--- a/OpenRA.Mods.Common/Effects/Beacon.cs
+++ b/OpenRA.Mods.Common/Effects/Beacon.cs
@@ -17,7 +17,7 @@ using OpenRA.Scripting;
 
 namespace OpenRA.Mods.Common.Effects
 {
-	public class Beacon : IEffect, IScriptBindable
+	public class Beacon : IEffect, IScriptBindable, IEffectAboveShroud
 	{
 		static readonly int MaxArrowHeight = 512;
 
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Effects
 			}
 		}
 
-		public void Tick(World world)
+		void IEffect.Tick(World world)
 		{
 			arrowHeight += arrowSpeed;
 			var clamped = arrowHeight.Clamp(0, MaxArrowHeight);
@@ -98,7 +98,9 @@ namespace OpenRA.Mods.Common.Effects
 				clock.Tick();
 		}
 
-		public IEnumerable<IRenderable> Render(WorldRenderer r)
+		IEnumerable<IRenderable> IEffect.Render(WorldRenderer r) { return SpriteRenderable.None; }
+
+		IEnumerable<IRenderable> IEffectAboveShroud.RenderAboveShroud(WorldRenderer r)
 		{
 			if (!owner.IsAlliedWith(owner.World.RenderPlayer))
 				yield break;

--- a/OpenRA.Mods.Common/Effects/FloatingText.cs
+++ b/OpenRA.Mods.Common/Effects/FloatingText.cs
@@ -18,7 +18,7 @@ using OpenRA.Mods.Common.Graphics;
 
 namespace OpenRA.Mods.Common.Effects
 {
-	public class FloatingText : IEffect
+	public class FloatingText : IEffect, IEffectAboveShroud
 	{
 		static readonly WVec Velocity = new WVec(0, 0, 86);
 
@@ -45,7 +45,9 @@ namespace OpenRA.Mods.Common.Effects
 			pos += Velocity;
 		}
 
-		public IEnumerable<IRenderable> Render(WorldRenderer wr)
+		public IEnumerable<IRenderable> Render(WorldRenderer wr) { return SpriteRenderable.None; }
+
+		public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr)
 		{
 			if (wr.World.FogObscures(pos))
 				yield break;

--- a/OpenRA.Mods.Common/Effects/PowerdownIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/PowerdownIndicator.cs
@@ -16,7 +16,7 @@ using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.Common.Effects
 {
-	class PowerdownIndicator : IEffect
+	class PowerdownIndicator : IEffect, IEffectAboveShroud
 	{
 		readonly Actor a;
 		readonly Animation anim;
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Effects
 			anim.PlayRepeating(canPowerDown.Info.IndicatorSequence);
 		}
 
-		public void Tick(World world)
+		void IEffect.Tick(World world)
 		{
 			if (!a.IsInWorld || a.IsDead || !canPowerDown.Disabled)
 				world.AddFrameEndTask(w => w.Remove(this));
@@ -39,7 +39,9 @@ namespace OpenRA.Mods.Common.Effects
 			anim.Tick();
 		}
 
-		public IEnumerable<IRenderable> Render(WorldRenderer wr)
+		IEnumerable<IRenderable> IEffect.Render(WorldRenderer wr) { return SpriteRenderable.None; }
+
+		IEnumerable<IRenderable> IEffectAboveShroud.RenderAboveShroud(WorldRenderer wr)
 		{
 			if (a.Disposed || wr.World.FogObscures(a))
 				return SpriteRenderable.None;

--- a/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
@@ -10,14 +10,13 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Effects;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.Common.Effects
 {
-	class RallyPointIndicator : IEffect
+	class RallyPointIndicator : IEffect, IEffectAboveShroud
 	{
 		readonly Actor building;
 		readonly RallyPoint rp;
@@ -41,7 +40,7 @@ namespace OpenRA.Mods.Common.Effects
 			circles.Play(rp.Info.CirclesSequence);
 		}
 
-		public void Tick(World world)
+		void IEffect.Tick(World world)
 		{
 			flag.Tick();
 			circles.Tick();
@@ -76,7 +75,9 @@ namespace OpenRA.Mods.Common.Effects
 				world.AddFrameEndTask(w => w.Remove(this));
 		}
 
-		public IEnumerable<IRenderable> Render(WorldRenderer wr)
+		IEnumerable<IRenderable> IEffect.Render(WorldRenderer wr) { return SpriteRenderable.None; }
+
+		IEnumerable<IRenderable> IEffectAboveShroud.RenderAboveShroud(WorldRenderer wr)
 		{
 			if (!building.IsInWorld || !building.Owner.IsAlliedWith(building.World.LocalPlayer))
 				return SpriteRenderable.None;

--- a/OpenRA.Mods.Common/Effects/RepairIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RepairIndicator.cs
@@ -17,7 +17,7 @@ using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.Common.Effects
 {
-	class RepairIndicator : IEffect
+	class RepairIndicator : IEffect, IEffectAboveShroud
 	{
 		readonly Actor building;
 		readonly Animation anim;
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Effects
 			CycleRepairer();
 		}
 
-		public void Tick(World world)
+		void IEffect.Tick(World world)
 		{
 			if (!building.IsInWorld || building.IsDead || !rb.Repairers.Any())
 				world.AddFrameEndTask(w => w.Remove(this));
@@ -43,7 +43,9 @@ namespace OpenRA.Mods.Common.Effects
 			anim.Tick();
 		}
 
-		public IEnumerable<IRenderable> Render(WorldRenderer wr)
+		IEnumerable<IRenderable> IEffect.Render(WorldRenderer wr) { return SpriteRenderable.None; }
+
+		IEnumerable<IRenderable> IEffectAboveShroud.RenderAboveShroud(WorldRenderer wr)
 		{
 			if (building.Disposed || rb.Repairers.Count == 0 || wr.World.FogObscures(building))
 				return SpriteRenderable.None;

--- a/OpenRA.Mods.Common/Orders/BeaconOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/BeaconOrderGenerator.cs
@@ -18,13 +18,8 @@ namespace OpenRA.Mods.Common.Orders
 	{
 		public IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
-			if (mi.Button != MouseButton.Left)
-				world.CancelInputMode();
-			else if (!world.ShroudObscures(cell))
-			{
-				world.CancelInputMode();
-				yield return new Order("PlaceBeacon", world.LocalPlayer.PlayerActor, false) { TargetLocation = cell, SuppressVisualFeedback = true };
-			}
+			world.CancelInputMode();
+			yield return new Order("PlaceBeacon", world.LocalPlayer.PlayerActor, false) { TargetLocation = cell, SuppressVisualFeedback = true };
 		}
 
 		public virtual void Tick(World world) { }
@@ -32,7 +27,7 @@ namespace OpenRA.Mods.Common.Orders
 		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr, World world) { yield break; }
 		public string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
-			return !world.ShroudObscures(cell) ? "ability" : "generic-blocked";
+			return "ability";
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Orders/BeaconOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/BeaconOrderGenerator.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Orders
 
 		public virtual void Tick(World world) { }
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
-		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr, World world) { yield break; }
+		public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
 		public string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			return "ability";

--- a/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Orders
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
-		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr, World world) { yield break; }
+		public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
 
 		public string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -148,7 +148,7 @@ namespace OpenRA.Mods.Common.Orders
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
-		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr, World world)
+		public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
 		{
 			var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 			var topLeft = xy - FootprintUtils.AdjustForBuildingSize(buildingInfo);

--- a/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Orders
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
-		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr, World world) { yield break; }
+		public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
 
 		public string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{

--- a/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new BaseProvider(init.Self, this); }
 	}
 
-	public class BaseProvider : ITick, IPostRenderSelection, ISelectionBar
+	public class BaseProvider : ITick, IRenderAboveShroudWhenSelected, ISelectionBar
 	{
 		public readonly BaseProviderInfo Info;
 		readonly DeveloperMode devMode;
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits
 			allyBuildEnabled = self.World.WorldActor.Trait<MapBuildRadius>().AllyBuildRadiusEnabled;
 		}
 
-		public void Tick(Actor self)
+		void ITick.Tick(Actor self)
 		{
 			if (progress > 0)
 				progress--;
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 			return self.Owner == self.World.RenderPlayer || (allyBuildEnabled && self.Owner.IsAlliedWith(self.World.RenderPlayer));
 		}
 
-		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr)
+		public IEnumerable<IRenderable> RangeCircleRenderables(WorldRenderer wr)
 		{
 			// Visible to player and allies
 			if (!ValidRenderPlayer())
@@ -79,6 +79,11 @@ namespace OpenRA.Mods.Common.Traits
 				0,
 				Color.FromArgb(128, Ready() ? Color.White : Color.Red),
 				Color.FromArgb(96, Color.Black));
+		}
+
+		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
+		{
+			return RangeCircleRenderables(wr);
 		}
 
 		float ISelectionBar.GetValue()

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -129,11 +129,9 @@ namespace OpenRA.Mods.Common.Traits
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
 		{
 			if (!RequiresBaseProvider)
-				yield break;
+				return SpriteRenderable.None;
 
-			foreach (var a in w.ActorsWithTrait<BaseProvider>())
-				foreach (var r in a.Trait.RenderAfterWorld(wr))
-					yield return r;
+			return w.ActorsWithTrait<BaseProvider>().SelectMany(a => a.Trait.RangeCircleRenderables(wr));
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new CombatDebugOverlay(init.Self); }
 	}
 
-	public class CombatDebugOverlay : IPostRender, INotifyDamage, INotifyCreated
+	public class CombatDebugOverlay : IRenderAboveWorld, INotifyDamage, INotifyCreated
 	{
 		readonly DeveloperMode devMode;
 		readonly HealthInfo healthInfo;
@@ -42,12 +42,12 @@ namespace OpenRA.Mods.Common.Traits
 			devMode = localPlayer != null ? localPlayer.PlayerActor.Trait<DeveloperMode>() : null;
 		}
 
-		public void Created(Actor self)
+		void INotifyCreated.Created(Actor self)
 		{
 			allBlockers = self.TraitsImplementing<IBlocksProjectiles>().ToArray();
 		}
 
-		public void RenderAfterWorld(WorldRenderer wr, Actor self)
+		void IRenderAboveWorld.RenderAboveWorld(Actor self, WorldRenderer wr)
 		{
 			if (devMode == null || !devMode.ShowCombatGeometry)
 				return;
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public void Damaged(Actor self, AttackInfo e)
+		void INotifyDamage.Damaged(Actor self, AttackInfo e)
 		{
 			if (devMode == null || !devMode.ShowCombatGeometry || e.Damage.Value == 0)
 				return;

--- a/OpenRA.Mods.Common/Traits/ExitsDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/ExitsDebugOverlay.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 		object ITraitInfo.Create(ActorInitializer init) { return new ExitsDebugOverlay(init.Self, this); }
 	}
 
-	public class ExitsDebugOverlay : IPostRender
+	public class ExitsDebugOverlay : IRenderAboveWorld
 	{
 		readonly ExitsDebugOverlayManager manager;
 		readonly ExitsDebugOverlayInfo info;
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 			exits = self.Info.TraitInfos<ExitInfo>().ToArray();
 		}
 
-		void IPostRender.RenderAfterWorld(WorldRenderer wr, Actor self)
+		void IRenderAboveWorld.RenderAboveWorld(Actor self, WorldRenderer wr)
 		{
 			if (manager == null || !manager.Enabled)
 				return;

--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -23,15 +23,17 @@ namespace OpenRA.Mods.Common.Traits
 		public virtual object Create(ActorInitializer init) { return new DrawLineToTarget(init.Self, this); }
 	}
 
-	public class DrawLineToTarget : IPostRenderSelection, INotifySelected, INotifyBecomingIdle
+	public class DrawLineToTarget : IRenderAboveShroudWhenSelected, INotifySelected, INotifyBecomingIdle
 	{
-		Actor self;
-		DrawLineToTargetInfo info;
+		readonly DrawLineToTargetInfo info;
 		List<Target> targets;
 		Color c;
 		int lifetime;
 
-		public DrawLineToTarget(Actor self, DrawLineToTargetInfo info) { this.self = self; this.info = info; }
+		public DrawLineToTarget(Actor self, DrawLineToTargetInfo info)
+		{
+			this.info = info;
+		}
 
 		public void SetTarget(Actor self, Target target, Color c, bool display)
 		{
@@ -51,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 				lifetime = info.Delay;
 		}
 
-		public void Selected(Actor a)
+		void INotifySelected.Selected(Actor a)
 		{
 			if (a.IsIdle)
 				return;
@@ -60,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits
 			lifetime = info.Delay;
 		}
 
-		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
 			var force = Game.GetModifierKeys().HasModifier(Modifiers.Alt);
 			if ((lifetime <= 0 || --lifetime <= 0) && !force)
@@ -81,7 +83,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public void OnBecomingIdle(Actor a)
+		void INotifyBecomingIdle.OnBecomingIdle(Actor a)
 		{
 			if (a.IsIdle)
 				targets = null;

--- a/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public object Create(ActorInitializer init) { return new RenderDebugState(init.Self, this); }
 	}
 
-	class RenderDebugState : INotifyAddedToWorld, INotifyOwnerChanged, IPostRenderSelection
+	class RenderDebugState : INotifyAddedToWorld, INotifyOwnerChanged, IRenderAboveShroudWhenSelected
 	{
 		readonly DeveloperMode devMode;
 		readonly SpriteFont font;
@@ -53,12 +53,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 			ai = self.Owner.PlayerActor.TraitsImplementing<HackyAI>().FirstOrDefault(x => x.IsEnabled);
 		}
 
-		public void AddedToWorld(Actor self)
+		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
 			tagString = self.ToString();
 		}
 
-		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			color = GetColor();
 		}
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return self.EffectiveOwner != null ? self.EffectiveOwner.Owner.Color.RGB : self.Owner.Color.RGB;
 		}
 
-		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
 			if (devMode == null || !devMode.ShowActorTags)
 				yield break;

--- a/OpenRA.Mods.Common/Traits/Render/RenderDetectionCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDetectionCircle.cs
@@ -35,19 +35,17 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public object Create(ActorInitializer init) { return new RenderDetectionCircle(init.Self, this); }
 	}
 
-	class RenderDetectionCircle : ITick, IPostRenderSelection
+	class RenderDetectionCircle : ITick, IRenderAboveShroudWhenSelected
 	{
 		readonly RenderDetectionCircleInfo info;
-		readonly Actor self;
 		WAngle lineAngle;
 
 		public RenderDetectionCircle(Actor self, RenderDetectionCircleInfo info)
 		{
 			this.info = info;
-			this.self = self;
 		}
 
-		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
 			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				yield break;
@@ -71,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				info.ContrastColor);
 		}
 
-		public void Tick(Actor self)
+		void ITick.Tick(Actor self)
 		{
 			lineAngle += info.UpdateLineTick;
 		}

--- a/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
@@ -32,23 +32,24 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
 		{
 			if (range == WDist.Zero)
-				yield break;
+				return SpriteRenderable.None;
 
-			yield return new RangeCircleRenderable(
+			var localRange = new RangeCircleRenderable(
 				centerPosition,
 				range,
 				0,
 				Color.FromArgb(128, Color.Yellow),
 				Color.FromArgb(96, Color.Black));
 
-			foreach (var a in w.ActorsWithTrait<RenderRangeCircle>())
-				if (a.Actor.Owner.IsAlliedWith(w.RenderPlayer))
-					if (a.Actor.Info.TraitInfo<RenderRangeCircleInfo>().RangeCircleType == RangeCircleType)
-						foreach (var r in a.Trait.RenderAfterWorld(wr))
-							yield return r;
+			var otherRanges = w.ActorsWithTrait<RenderRangeCircle>()
+				.Where(a => a.Trait.Info.RangeCircleType == RangeCircleType)
+				.SelectMany(a => a.Trait.RangeCircleRenderables(wr));
+
+			return otherRanges.Append(localRange);
 		}
 
-		public object Create(ActorInitializer init) { return new RenderRangeCircle(init.Self); }
+		public object Create(ActorInitializer init) { return new RenderRangeCircle(init.Self, this); }
+
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
 			var armaments = ai.TraitInfos<ArmamentInfo>().Where(a => a.UpgradeMinEnabledLevel == 0);
@@ -60,18 +61,21 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	class RenderRangeCircle : IPostRenderSelection
+	class RenderRangeCircle : IRenderAboveShroudWhenSelected
 	{
+		public readonly RenderRangeCircleInfo Info;
 		readonly Actor self;
 		readonly AttackBase attack;
 
-		public RenderRangeCircle(Actor self)
+		public RenderRangeCircle(Actor self, RenderRangeCircleInfo info)
 		{
+			Info = info;
+
 			this.self = self;
 			attack = self.Trait<AttackBase>();
 		}
 
-		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr)
+		public IEnumerable<IRenderable> RangeCircleRenderables(WorldRenderer wr)
 		{
 			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				yield break;
@@ -86,6 +90,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 				0,
 				Color.FromArgb(128, Color.Yellow),
 				Color.FromArgb(96, Color.Black));
+		}
+
+		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
+		{
+			return RangeCircleRenderables(wr);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
@@ -55,17 +55,15 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithDecoration(init.Self, this); }
 	}
 
-	public class WithDecoration : UpgradableTrait<WithDecorationInfo>, ITick, IRender, IPostRenderSelection
+	public class WithDecoration : UpgradableTrait<WithDecorationInfo>, ITick, IRender, IRenderAboveShroudWhenSelected
 	{
 		protected readonly Animation Anim;
 
 		readonly string image;
-		readonly Actor self;
 
 		public WithDecoration(Actor self, WithDecorationInfo info)
 			: base(info)
 		{
-			this.self = self;
 			image = info.Image ?? self.Info.Name;
 			Anim = new Animation(self.World, image, () => self.World.Paused);
 			Anim.PlayRepeating(info.Sequence);
@@ -73,14 +71,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public virtual bool ShouldRender(Actor self) { return true; }
 
-		public IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRender.Render(Actor self, WorldRenderer wr)
 		{
-			return !Info.RequiresSelection ? RenderInner(self, wr) : Enumerable.Empty<IRenderable>();
+			return !Info.RequiresSelection ? RenderInner(self, wr) : SpriteRenderable.None;
 		}
 
-		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
-			return Info.RequiresSelection ? RenderInner(self, wr) : Enumerable.Empty<IRenderable>();
+			return Info.RequiresSelection ? RenderInner(self, wr) : SpriteRenderable.None;
 		}
 
 		IEnumerable<IRenderable> RenderInner(Actor self, WorldRenderer wr)
@@ -129,6 +127,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return new IRenderable[] { new UISpriteRenderable(Anim.Image, self.CenterPosition, pxPos, Info.ZOffset, wr.Palette(Info.Palette), 1f) };
 		}
 
-		public void Tick(Actor self) { Anim.Tick(); }
+		void ITick.Tick(Actor self) { Anim.Tick(); }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
@@ -52,14 +52,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			foreach (var a in w.ActorsWithTrait<WithRangeCircle>())
 				if (a.Trait.Info.Type == Type)
-					foreach (var r in a.Trait.RenderRangeCircle(wr))
+					foreach (var r in a.Trait.RenderRangeCircle(a.Actor, wr))
 						yield return r;
 		}
 
 		public object Create(ActorInitializer init) { return new WithRangeCircle(init.Self, this); }
 	}
 
-	class WithRangeCircle : IPostRenderSelection, IPostRender
+	class WithRangeCircle : IRenderAboveShroudWhenSelected, IRenderAboveWorld
 	{
 		public readonly WithRangeCircleInfo Info;
 		readonly Actor self;
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			}
 		}
 
-		public IEnumerable<IRenderable> RenderRangeCircle(WorldRenderer wr)
+		public IEnumerable<IRenderable> RenderRangeCircle(Actor self, WorldRenderer wr)
 		{
 			if (Info.Visible == RangeCircleVisibility.WhenSelected && Visible)
 				yield return new RangeCircleRenderable(
@@ -92,12 +92,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 			yield break;
 		}
 
-		IEnumerable<IRenderable> IPostRenderSelection.RenderAfterWorld(WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
-			return RenderRangeCircle(wr);
+			return RenderRangeCircle(self, wr);
 		}
 
-		void IPostRender.RenderAfterWorld(WorldRenderer wr, Actor self)
+		void IRenderAboveWorld.RenderAboveWorld(Actor self, WorldRenderer wr)
 		{
 			if (Info.Visible == RangeCircleVisibility.Always && Visible)
 				RangeCircleRenderable.DrawRangeCircle(

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
@@ -35,22 +35,19 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public object Create(ActorInitializer init) { return new WithSpriteControlGroupDecoration(init.Self, this); }
 	}
 
-	public class WithSpriteControlGroupDecoration : IPostRenderSelection
+	public class WithSpriteControlGroupDecoration : IRenderAboveShroudWhenSelected
 	{
 		public readonly WithSpriteControlGroupDecorationInfo Info;
-
-		readonly Actor self;
 		readonly Animation pipImages;
 
 		public WithSpriteControlGroupDecoration(Actor self, WithSpriteControlGroupDecorationInfo info)
 		{
-			this.self = self;
 			Info = info;
 
 			pipImages = new Animation(self.World, Info.Image);
 		}
 
-		IEnumerable<IRenderable> IPostRenderSelection.RenderAfterWorld(WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
 			if (self.World.FogObscures(self))
 				yield break;
@@ -59,11 +56,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 				yield break;
 
 			var pal = wr.Palette(Info.Palette);
-			foreach (var r in DrawControlGroup(wr, self, pal))
+			foreach (var r in DrawControlGroup(self, wr, pal))
 				yield return r;
 		}
 
-		IEnumerable<IRenderable> DrawControlGroup(WorldRenderer wr, Actor self, PaletteReference palette)
+		IEnumerable<IRenderable> DrawControlGroup(Actor self, WorldRenderer wr, PaletteReference palette)
 		{
 			var group = self.World.Selection.GetControlGroupForActor(self);
 			if (group == null)

--- a/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
@@ -47,17 +47,15 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public object Create(ActorInitializer init) { return new WithTextControlGroupDecoration(init.Self, this); }
 	}
 
-	public class WithTextControlGroupDecoration : IPostRenderSelection, INotifyCapture
+	public class WithTextControlGroupDecoration : IRenderAboveShroudWhenSelected, INotifyCapture
 	{
 		readonly WithTextControlGroupDecorationInfo info;
 		readonly SpriteFont font;
-		readonly Actor self;
 
 		Color color;
 
 		public WithTextControlGroupDecoration(Actor self, WithTextControlGroupDecorationInfo info)
 		{
-			this.self = self;
 			this.info = info;
 
 			if (!Game.Renderer.Fonts.TryGetValue(info.Font, out font))
@@ -66,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			color = info.UsePlayerColor ? self.Owner.Color.RGB : info.Color;
 		}
 
-		IEnumerable<IRenderable> IPostRenderSelection.RenderAfterWorld(WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
 			if (self.World.FogObscures(self))
 				yield break;
@@ -74,11 +72,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (self.Owner != wr.World.LocalPlayer)
 				yield break;
 
-			foreach (var r in DrawControlGroup(wr, self))
+			foreach (var r in DrawControlGroup(self, wr))
 				yield return r;
 		}
 
-		IEnumerable<IRenderable> DrawControlGroup(WorldRenderer wr, Actor self)
+		IEnumerable<IRenderable> DrawControlGroup(Actor self, WorldRenderer wr)
 		{
 			var group = self.World.Selection.GetControlGroupForActor(self);
 			if (group == null)

--- a/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
@@ -54,34 +54,28 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	public class WithTextDecoration : UpgradableTrait<WithTextDecorationInfo>, IRender, IPostRenderSelection, INotifyCapture
+	public class WithTextDecoration : UpgradableTrait<WithTextDecorationInfo>, IRender, IRenderAboveShroudWhenSelected, INotifyCapture
 	{
-		readonly Actor self;
 		readonly SpriteFont font;
-
 		Color color;
 
 		public WithTextDecoration(Actor self, WithTextDecorationInfo info)
 			: base(info)
 		{
-			this.self = self;
-
-			if (!Game.Renderer.Fonts.TryGetValue(info.Font, out font))
-				throw new YamlException("Font '{0}' is not listed in the mod.yaml's Fonts section".F(info.Font));
-
+			font = Game.Renderer.Fonts[info.Font];
 			color = Info.UsePlayerColor ? self.Owner.Color.RGB : Info.Color;
 		}
 
 		public virtual bool ShouldRender(Actor self) { return true; }
 
-		public IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRender.Render(Actor self, WorldRenderer wr)
 		{
-			return !Info.RequiresSelection ? RenderInner(self, wr) : Enumerable.Empty<IRenderable>();
+			return !Info.RequiresSelection ? RenderInner(self, wr) : SpriteRenderable.None;
 		}
 
-		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
-			return Info.RequiresSelection ? RenderInner(self, wr) : Enumerable.Empty<IRenderable>();
+			return Info.RequiresSelection ? RenderInner(self, wr) : SpriteRenderable.None;
 		}
 
 		IEnumerable<IRenderable> RenderInner(Actor self, WorldRenderer wr)

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantUpgradePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantUpgradePower.cs
@@ -141,7 +141,7 @@ namespace OpenRA.Mods.Common.Traits
 					world.CancelInputMode();
 			}
 
-			public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr, World world)
+			public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
 			{
 				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 				foreach (var unit in power.UnitsInRange(xy))

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -291,7 +291,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
-		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr, World world) { yield break; }
+		public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
 		public string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			return world.Map.Contains(cell) ? cursor : "generic-blocked";

--- a/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 		public virtual object Create(ActorInitializer init) { return new EditorSelectionLayer(init.Self, this); }
 	}
 
-	public class EditorSelectionLayer : IWorldLoaded, IPostRender
+	public class EditorSelectionLayer : IWorldLoaded, IRenderAboveWorld
 	{
 		readonly EditorSelectionLayerInfo info;
 		readonly Map map;
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 			pasteSprite = map.Rules.Sequences.GetSequence(info.Image, info.PasteSequence).GetSprite(0);
 		}
 
-		public void WorldLoaded(World w, WorldRenderer wr)
+		void IWorldLoaded.WorldLoaded(World w, WorldRenderer wr)
 		{
 			if (w.Type != WorldType.Editor)
 				return;
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 			CopyRegion = PasteRegion = null;
 		}
 
-		public void RenderAfterWorld(WorldRenderer wr, Actor self)
+		void IRenderAboveWorld.RenderAboveWorld(Actor self, WorldRenderer wr)
 		{
 			if (wr.World.Type != WorldType.Editor)
 				return;

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -151,7 +151,7 @@ namespace OpenRA.Mods.Common.Traits
 			notVisibleEdges = info.UseExtendedIndex ? Edges.AllSides : Edges.AllCorners;
 		}
 
-		public void WorldLoaded(World w, WorldRenderer wr)
+		void IWorldLoaded.WorldLoaded(World w, WorldRenderer wr)
 		{
 			// Initialize tile cache
 			// This includes the region outside the visible area to cover any sprites peeking outside the map
@@ -230,7 +230,7 @@ namespace OpenRA.Mods.Common.Traits
 			cellsDirty.UnionWith(cells);
 		}
 
-		public void RenderShroud(WorldRenderer wr, Shroud shroud)
+		void IRenderShroud.RenderShroud(Shroud shroud, WorldRenderer wr)
 		{
 			if (currentShroud != shroud)
 			{

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -20,14 +20,14 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Renders a debug overlay showing the terrain cells. Attach this to the world actor.")]
 	public class TerrainGeometryOverlayInfo : TraitInfo<TerrainGeometryOverlay> { }
 
-	public class TerrainGeometryOverlay : IPostRender, IWorldLoaded, IChatCommand
+	public class TerrainGeometryOverlay : IRenderAboveWorld, IWorldLoaded, IChatCommand
 	{
 		const string CommandName = "terrainoverlay";
 		const string CommandDesc = "Toggles the terrain geometry overlay";
 
 		public bool Enabled;
 
-		public void WorldLoaded(World w, WorldRenderer wr)
+		void IWorldLoaded.WorldLoaded(World w, WorldRenderer wr)
 		{
 			var console = w.WorldActor.TraitOrDefault<ChatCommands>();
 			var help = w.WorldActor.TraitOrDefault<HelpCommand>();
@@ -39,13 +39,13 @@ namespace OpenRA.Mods.Common.Traits
 			help.RegisterHelp(CommandName, CommandDesc);
 		}
 
-		public void InvokeCommand(string name, string arg)
+		void IChatCommand.InvokeCommand(string name, string arg)
 		{
 			if (name == CommandName)
 				Enabled ^= true;
 		}
 
-		public void RenderAfterWorld(WorldRenderer wr, Actor self)
+		void IRenderAboveWorld.RenderAboveWorld(Actor self, WorldRenderer wr)
 		{
 			if (!Enabled)
 				return;

--- a/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new WarheadDebugOverlay(this); }
 	}
 
-	public class WarheadDebugOverlay : IPostRender
+	public class WarheadDebugOverlay : IRenderAboveWorld
 	{
 		class WHImpact
 		{
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 			impacts.Add(new WHImpact(pos, range, info.DisplayDuration, color));
 		}
 
-		public void RenderAfterWorld(WorldRenderer wr, Actor self)
+		void IRenderAboveWorld.RenderAboveWorld(Actor self, WorldRenderer wr)
 		{
 			foreach (var i in impacts)
 			{

--- a/OpenRA.Mods.Common/Traits/World/WeatherOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/WeatherOverlay.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new WeatherOverlay(init.World, this); }
 	}
 
-	public class WeatherOverlay : ITick, IPostRender
+	public class WeatherOverlay : ITick, IRenderAboveWorld
 	{
 		readonly WeatherOverlayInfo info;
 		readonly World world;
@@ -201,7 +201,7 @@ namespace OpenRA.Mods.Common.Traits
 			tempParticle.SwingOffset += tempParticle.SwingDirection * tempParticle.SwingSpeed;
 		}
 
-		public void Tick(Actor self)
+		void ITick.Tick(Actor self)
 		{
 			windTickCountdown--;
 		}
@@ -298,7 +298,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public void RenderAfterWorld(WorldRenderer wr, Actor self)
+		void IRenderAboveWorld.RenderAboveWorld(Actor self, WorldRenderer wr)
 		{
 			if (!world.Paused)
 				UpdateWeatherOverlay(wr);

--- a/OpenRA.Mods.RA/Traits/Minelayer.cs
+++ b/OpenRA.Mods.RA/Traits/Minelayer.cs
@@ -31,23 +31,20 @@ namespace OpenRA.Mods.RA.Traits
 		public object Create(ActorInitializer init) { return new Minelayer(init.Self); }
 	}
 
-	public class Minelayer : IIssueOrder, IResolveOrder, IPostRenderSelection, ISync
+	public class Minelayer : IIssueOrder, IResolveOrder, IRenderAboveShroudWhenSelected, ISync
 	{
 		/* TODO: [Sync] when sync can cope with arrays! */
 		public CPos[] Minefield = null;
-		readonly Actor self;
 		readonly Sprite tile;
 		[Sync] CPos minefieldStart;
 
 		public Minelayer(Actor self)
 		{
-			this.self = self;
-
 			var tileset = self.World.Map.Tileset.ToLowerInvariant();
 			tile = self.World.Map.Rules.Sequences.GetSequence("overlay", "build-valid-{0}".F(tileset)).GetSprite(0);
 		}
 
-		public IEnumerable<IOrderTargeter> Orders
+		IEnumerable<IOrderTargeter> IIssueOrder.Orders
 		{
 			get
 			{
@@ -56,7 +53,7 @@ namespace OpenRA.Mods.RA.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
 			switch (order.OrderID)
 			{
@@ -75,7 +72,7 @@ namespace OpenRA.Mods.RA.Traits
 			}
 		}
 
-		public void ResolveOrder(Actor self, Order order)
+		void IResolveOrder.ResolveOrder(Actor self, Order order)
 		{
 			if (order.OrderString == "BeginMinefield")
 				minefieldStart = order.TargetLocation;
@@ -121,7 +118,7 @@ namespace OpenRA.Mods.RA.Traits
 						yield return new CPos(i, j);
 		}
 
-		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
 			if (self.Owner != self.World.LocalPlayer || Minefield == null)
 				yield break;

--- a/OpenRA.Mods.RA/Traits/Minelayer.cs
+++ b/OpenRA.Mods.RA/Traits/Minelayer.cs
@@ -181,7 +181,7 @@ namespace OpenRA.Mods.RA.Traits
 
 			CPos lastMousePos;
 			public IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
-			public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr, World world)
+			public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
 			{
 				if (!minelayers.Any())
 					yield break;
@@ -194,7 +194,7 @@ namespace OpenRA.Mods.RA.Traits
 				var pal = wr.Palette(TileSet.TerrainPaletteInternalName);
 				foreach (var c in minefield)
 				{
-					var tile = movement.CanEnterCell(c, null, false) ? tileOk : tileBlocked;
+					var tile = movement.CanEnterCell(c, null, false) && !world.ShroudObscures(c) ? tileOk : tileBlocked;
 					yield return new SpriteRenderable(tile, world.Map.CenterOfCell(c),
 						WVec.Zero, -511, pal, 1f, true);
 				}

--- a/OpenRA.Mods.RA/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.RA/Traits/PortableChrono.cs
@@ -194,7 +194,7 @@ namespace OpenRA.Mods.RA.Traits
 			yield break;
 		}
 
-		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr, World world)
+		public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
 		{
 			if (!self.IsInWorld || self.Owner != self.World.LocalPlayer)
 				yield break;

--- a/OpenRA.Mods.RA/Traits/Render/RenderJammerCircle.cs
+++ b/OpenRA.Mods.RA/Traits/Render/RenderJammerCircle.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.RA.Traits
 {
 	// TODO: remove all the Render*Circle duplication
-	class RenderJammerCircleInfo : ITraitInfo, IPlaceBuildingDecorationInfo
+	class RenderJammerCircleInfo : TraitInfo<RenderJammerCircle>, IPlaceBuildingDecorationInfo
 	{
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
 		{
@@ -48,20 +48,14 @@ namespace OpenRA.Mods.RA.Traits
 
 			foreach (var a in w.ActorsWithTrait<RenderJammerCircle>())
 				if (a.Actor.Owner.IsAlliedWith(w.RenderPlayer))
-					foreach (var r in a.Trait.RenderAfterWorld(wr))
+					foreach (var r in a.Trait.RenderAboveShroud(a.Actor, wr))
 						yield return r;
 		}
-
-		public object Create(ActorInitializer init) { return new RenderJammerCircle(init.Self); }
 	}
 
-	class RenderJammerCircle : IPostRenderSelection
+	class RenderJammerCircle : IRenderAboveShroudWhenSelected
 	{
-		Actor self;
-
-		public RenderJammerCircle(Actor self) { this.self = self; }
-
-		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr)
+		public IEnumerable<IRenderable> RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
 			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				yield break;

--- a/OpenRA.Mods.RA/Traits/Render/RenderShroudCircle.cs
+++ b/OpenRA.Mods.RA/Traits/Render/RenderShroudCircle.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Common.Traits;
@@ -18,33 +19,27 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Traits
 {
-	class RenderShroudCircleInfo : ITraitInfo, IPlaceBuildingDecorationInfo
+	class RenderShroudCircleInfo : TraitInfo<RenderShroudCircle>, IPlaceBuildingDecorationInfo
 	{
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
 		{
-			yield return new RangeCircleRenderable(
+			var localRange = new RangeCircleRenderable(
 				centerPosition,
 				ai.TraitInfo<CreatesShroudInfo>().Range,
 				0,
 				Color.FromArgb(128, Color.Cyan),
 				Color.FromArgb(96, Color.Black));
 
-			foreach (var a in w.ActorsWithTrait<RenderShroudCircle>())
-				if (a.Actor.Owner.IsAlliedWith(w.RenderPlayer))
-					foreach (var r in a.Trait.RenderAfterWorld(wr))
-						yield return r;
-		}
+			var otherRanges = w.ActorsWithTrait<RenderShroudCircle>()
+				.SelectMany(a => a.Trait.RangeCircleRenderables(a.Actor, wr));
 
-		public object Create(ActorInitializer init) { return new RenderShroudCircle(init.Self); }
+			return otherRanges.Append(localRange);
+		}
 	}
 
-	class RenderShroudCircle : IPostRenderSelection
+	class RenderShroudCircle : IRenderAboveShroudWhenSelected
 	{
-		Actor self;
-
-		public RenderShroudCircle(Actor self) { this.self = self; }
-
-		public IEnumerable<IRenderable> RenderAfterWorld(WorldRenderer wr)
+		public IEnumerable<IRenderable> RangeCircleRenderables(Actor self, WorldRenderer wr)
 		{
 			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				yield break;
@@ -55,6 +50,11 @@ namespace OpenRA.Mods.RA.Traits
 				0,
 				Color.FromArgb(128, Color.Cyan),
 				Color.FromArgb(96, Color.Black));
+		}
+
+		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
+		{
+			return RangeCircleRenderables(self, wr);
 		}
 	}
 }

--- a/OpenRA.Mods.TS/Effects/AnimatedBeacon.cs
+++ b/OpenRA.Mods.TS/Effects/AnimatedBeacon.cs
@@ -18,7 +18,7 @@ using OpenRA.Scripting;
 
 namespace OpenRA.Mods.TS.Effects
 {
-	public class AnimatedBeacon : IEffect
+	public class AnimatedBeacon : IEffect, IEffectAboveShroud
 	{
 		readonly Player owner;
 		readonly WPos position;
@@ -43,19 +43,21 @@ namespace OpenRA.Mods.TS.Effects
 				owner.World.Add(new DelayedAction(duration, () => owner.World.Remove(this)));
 		}
 
-		public void Tick(World world)
+		void IEffect.Tick(World world)
 		{
 			if (beacon != null)
 				beacon.Tick();
 		}
 
-		public IEnumerable<IRenderable> Render(WorldRenderer r)
+		IEnumerable<IRenderable> IEffect.Render(WorldRenderer r) { return SpriteRenderable.None; }
+
+		IEnumerable<IRenderable> IEffectAboveShroud.RenderAboveShroud(WorldRenderer r)
 		{
 			if (beacon == null)
-				return Enumerable.Empty<IRenderable>();
+				return SpriteRenderable.None;
 
 			if (!owner.IsAlliedWith(owner.World.RenderPlayer))
-				return Enumerable.Empty<IRenderable>();
+				return SpriteRenderable.None;
 
 			var palette = r.Palette(isPlayerPalette ? beaconPalette + owner.InternalName : beaconPalette);
 			return beacon.Render(position, palette);

--- a/OpenRA.Mods.TS/Traits/SupportPowers/AttackOrderPower.cs
+++ b/OpenRA.Mods.TS/Traits/SupportPowers/AttackOrderPower.cs
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.TS.Traits
 
 		IEnumerable<IRenderable> IOrderGenerator.Render(WorldRenderer wr, World world) { yield break; }
 
-		IEnumerable<IRenderable> IOrderGenerator.RenderAfterWorld(WorldRenderer wr, World world)
+		IEnumerable<IRenderable> IOrderGenerator.RenderAboveShroud(WorldRenderer wr, World world)
 		{
 			foreach (var a in instance.Instances.Where(i => !i.Self.IsDisabled()))
 			{


### PR DESCRIPTION
These things can be thought of like scribbles on top of a video feed, so drawing them behind the shroud doesn't make a lot of sense – it leads to inconsistencies in the classic mods, and downright bogus rendering in the heightmap-enabled mods when we turn on the z-buffer (the overlays can clip behind the terrain as shown in the screenshot below).
- Fixes #6106.
- Makes render circles / selection boxes from order generators render above the shroud like they do everywhere else (I don't think we have a ticket for this issue).
- Works towards #7520.
- Removes duplication/hacks from the health bar rendering.
- Fixes some code style issues.

![line](https://cloud.githubusercontent.com/assets/167819/17865728/8b3a639a-689b-11e6-95ae-509702ba37ca.png)
