### PR TITLE
Restore graphical look of the TS Ion Cannon.

### DIFF
--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -401,7 +401,8 @@ GAPLUG:
 		UpgradeTypes: plug.ioncannon
 		UpgradeMinEnabledLevel: 1
 		Icon: ioncannon
-		Effect: ionbeam
+		Effect: ionring
+		WeaponDelay: 0
 		ChargeTime: 180
 		Description: Ion Cannon
 		LongDesc: Initiate an Ion Cannon strike.\nApplies instant damage to a small area.

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -126,7 +126,37 @@ explosion:
 	building: twlt070
 	ionring: ring1
 		BlendMode: Additive
-		Tick: 120
+		Tick: 100
+	ionbeam: ionbeam
+		Offset: 0,-60
+		BlendMode: Additive
+		Length: *
+		Tick: 100
+	ionbeam2: ionbeam
+		Offset: 0,-180
+		BlendMode: Additive
+		Length: *
+		Tick: 100
+	ionbeam3: ionbeam
+		Offset: 0,-300
+		BlendMode: Additive
+		Length: *
+		Tick: 100
+	ionbeam4: ionbeam
+		Offset: 0,-420
+		BlendMode: Additive
+		Length: *
+		Tick: 100
+	ionbeam5: ionbeam
+		Offset: 0,-540
+		BlendMode: Additive
+		Length: *
+		Tick: 100
+	ionbeam6: ionbeam
+		Offset: 0,-660
+		BlendMode: Additive
+		Length: *
+		Tick: 100
 	pulse_explosion: pulsefx2
 		BlendMode: Additive
 		Tick: 80
@@ -365,11 +395,18 @@ clustermissile:
 		Length: *
 	down: null # TODO
 		Length: *
+
 ionbeam:
 	idle:
 		Length: *
 		Offset: 0, -78
 		ZOffset: 1023
+
+ionring: 
+	idle: ring1
+		Length: *
+		ZOffset: -512
+		Tick: 120
 
 trock01:
 	idle:

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -63,21 +63,31 @@ IonCannon:
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: Ground, Air
 		DamageTypes: Prone100Percent, TriggerProne, EnergyDeath
-	Warhead@2Eff_impact: CreateEffect
-		Explosions: ionring
-		ImpactSounds: ion1.aud
-	Warhead@3Dam_area: SpreadDamage
+	Warhead@2Dam_area: SpreadDamage
 		Spread: 1c0
 		Damage: 250
 		Falloff: 100, 50, 25, 0
 		Delay: 3
 		ValidTargets: Ground, Air
 		DamageTypes: Prone50Percent, TriggerProne, EnergyDeath
-	Warhead@4Smu_area: LeaveSmudge
+	Warhead@3Smu_area: LeaveSmudge
 		SmudgeType: SmallScorch
 		InvalidTargets: Vehicle, Building, Wall
 		Size: 2
 		Delay: 3
+	Warhead@4Effect: CreateEffect
+		Explosions: ionbeam
+		ImpactSound: ion1.aud
+	Warhead@5Effect: CreateEffect
+		Explosions: ionbeam2
+	Warhead@6Effect: CreateEffect
+		Explosions: ionbeam3
+	Warhead@7Effect: CreateEffect
+		Explosions: ionbeam4
+	Warhead@8Effect: CreateEffect
+		Explosions: ionbeam5
+	Warhead@9Effect: CreateEffect
+		Explosions: ionbeam6
 
 EMPulseCannon:
 	ReloadDelay: 100


### PR DESCRIPTION
I defined the ion ring as the main effect of the weapon because that way it appears in the center of the targetted cell, and in order to make the beam I had to code it as many explosion effects, using many instances of it while also using the offset tag on the sequence. 
![ioncannonpolish](https://cloud.githubusercontent.com/assets/11763228/17867954/88d4bb80-687a-11e6-991f-b8cdd2829d6e.gif)

see here https://www.youtube.com/watch?v=YnJlb-Zorz8 0:40.
