### PR TITLE
Fix line rendering with depth buffer enabled.

### DIFF
--- a/OpenRA.Game/Graphics/SelectionBarsRenderable.cs
+++ b/OpenRA.Game/Graphics/SelectionBarsRenderable.cs
@@ -48,21 +48,22 @@ namespace OpenRA.Graphics
 		public IRenderable OffsetBy(WVec vec) { return new SelectionBarsRenderable(pos + vec, actor); }
 		public IRenderable AsDecoration() { return this; }
 
-		void DrawExtraBars(WorldRenderer wr, float2 start, float2 end)
+		void DrawExtraBars(WorldRenderer wr, float3 start, float3 end)
 		{
 			foreach (var extraBar in actor.TraitsImplementing<ISelectionBar>())
 			{
 				var value = extraBar.GetValue();
 				if (value != 0 || extraBar.DisplayWhenEmpty)
 				{
-					start.Y += (int)(4 / wr.Viewport.Zoom);
-					end.Y += (int)(4 / wr.Viewport.Zoom);
+					var offset = new float3(0, (int)(4 / wr.Viewport.Zoom), 0);
+					start += offset;
+					end += offset;
 					DrawSelectionBar(wr, start, end, extraBar.GetValue(), extraBar.GetColor());
 				}
 			}
 		}
 
-		void DrawSelectionBar(WorldRenderer wr, float2 start, float2 end, float value, Color barColor)
+		void DrawSelectionBar(WorldRenderer wr, float3 start, float3 end, float value, Color barColor)
 		{
 			var iz = 1 / wr.Viewport.Zoom;
 			var c = Color.FromArgb(128, 30, 30, 30);
@@ -73,7 +74,7 @@ namespace OpenRA.Graphics
 
 			var barColor2 = Color.FromArgb(255, barColor.R / 2, barColor.G / 2, barColor.B / 2);
 
-			var z = float2.Lerp(start, end, value);
+			var z = float3.Lerp(start, end, value);
 			var wcr = Game.Renderer.WorldRgbaColorRenderer;
 			wcr.DrawLine(start + p, end + p, iz, c);
 			wcr.DrawLine(start + q, end + q, iz, c2);
@@ -93,7 +94,7 @@ namespace OpenRA.Graphics
 					health.DamageState == DamageState.Heavy ? Color.Yellow : Color.LimeGreen;
 		}
 
-		void DrawHealthBar(WorldRenderer wr, IHealth health, float2 start, float2 end)
+		void DrawHealthBar(WorldRenderer wr, IHealth health, float3 start, float3 end)
 		{
 			if (health == null || health.IsDead)
 				return;
@@ -112,7 +113,7 @@ namespace OpenRA.Graphics
 				healthColor.G / 2,
 				healthColor.B / 2);
 
-			var z = float2.Lerp(start, end, (float)health.HP / health.MaxHP);
+			var z = float3.Lerp(start, end, (float)health.HP / health.MaxHP);
 
 			var wcr = Game.Renderer.WorldRgbaColorRenderer;
 			wcr.DrawLine(start + p, end + p, iz, c);
@@ -131,7 +132,7 @@ namespace OpenRA.Graphics
 					deltaColor.R / 2,
 					deltaColor.G / 2,
 					deltaColor.B / 2);
-				var zz = float2.Lerp(start, end, (float)health.DisplayHP / health.MaxHP);
+				var zz = float3.Lerp(start, end, (float)health.DisplayHP / health.MaxHP);
 
 				wcr.DrawLine(z + p, zz + p, iz, deltaColor2);
 				wcr.DrawLine(z + q, zz + q, iz, deltaColor);
@@ -147,12 +148,12 @@ namespace OpenRA.Graphics
 
 			var health = actor.TraitOrDefault<IHealth>();
 
-			var screenPos = wr.ScreenPxPosition(pos);
+			var screenPos = wr.Screen3DPxPosition(pos);
 			var bounds = actor.VisualBounds;
-			bounds.Offset(screenPos.X, screenPos.Y);
+			bounds.Offset((int)screenPos.X, (int)screenPos.Y);
 
-			var start = new float2(bounds.Left + 1, bounds.Top);
-			var end = new float2(bounds.Right - 1, bounds.Top);
+			var start = new float3(bounds.Left + 1, bounds.Top, screenPos.Z);
+			var end = new float3(bounds.Right - 1, bounds.Top, screenPos.Z);
 
 			if (DisplayHealth)
 				DrawHealthBar(wr, health, start, end);

--- a/OpenRA.Game/Graphics/SpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderable.cs
@@ -65,14 +65,14 @@ namespace OpenRA.Graphics
 
 		public void RenderDebugGeometry(WorldRenderer wr)
 		{
-			var offset = ScreenPosition(wr) + sprite.Offset.XY;
-			Game.Renderer.WorldRgbaColorRenderer.DrawRect(offset.XY, (offset + sprite.Size).XY, 1 / wr.Viewport.Zoom, Color.Red);
+			var screenOffset = ScreenPosition(wr) + sprite.Offset;
+			Game.Renderer.WorldRgbaColorRenderer.DrawRect(screenOffset, screenOffset + sprite.Size, 1 / wr.Viewport.Zoom, Color.Red);
 		}
 
 		public Rectangle ScreenBounds(WorldRenderer wr)
 		{
-			var offset = ScreenPosition(wr) + sprite.Offset;
-			return new Rectangle((int)offset.X, (int)offset.Y, (int)sprite.Size.X, (int)sprite.Size.Y);
+			var screenOffset = ScreenPosition(wr) + sprite.Offset;
+			return new Rectangle((int)screenOffset.X, (int)screenOffset.Y, (int)sprite.Size.X, (int)sprite.Size.Y);
 		}
 	}
 }

--- a/OpenRA.Game/Graphics/TargetLineRenderable.cs
+++ b/OpenRA.Game/Graphics/TargetLineRenderable.cs
@@ -43,9 +43,9 @@ namespace OpenRA.Graphics
 				return;
 
 			var iz = 1 / wr.Viewport.Zoom;
-			var first = wr.ScreenPxPosition(waypoints.First());
+			var first = wr.Screen3DPosition(waypoints.First());
 			var a = first;
-			foreach (var b in waypoints.Skip(1).Select(pos => wr.ScreenPxPosition(pos)))
+			foreach (var b in waypoints.Skip(1).Select(pos => wr.Screen3DPosition(pos)))
 			{
 				Game.Renderer.WorldRgbaColorRenderer.DrawLine(a, b, iz, color);
 				DrawTargetMarker(wr, color, b);

--- a/OpenRA.Game/Graphics/TargetLineRenderable.cs
+++ b/OpenRA.Game/Graphics/TargetLineRenderable.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Graphics
 			DrawTargetMarker(wr, color, first);
 		}
 
-		public static void DrawTargetMarker(WorldRenderer wr, Color color, float2 location)
+		public static void DrawTargetMarker(WorldRenderer wr, Color color, float3 location)
 		{
 			var iz = 1 / wr.Viewport.Zoom;
 			var offset = new float2(iz, iz);

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -163,10 +163,6 @@ namespace OpenRA.Graphics
 			foreach (var a in World.ActorsWithTrait<IRenderShroud>())
 				a.Trait.RenderShroud(renderShroud, this);
 
-			if (devTrait.Value != null && devTrait.Value.ShowDebugGeometry)
-				for (var i = 0; i < renderables.Count; i++)
-					renderables[i].RenderDebugGeometry(this);
-
 			if (enableDepthBuffer)
 				Game.Renderer.Device.DisableDepthBuffer();
 
@@ -201,9 +197,14 @@ namespace OpenRA.Graphics
 					r.Render(this);
 
 			if (devTrait.Value != null && devTrait.Value.ShowDebugGeometry)
+			{
+				for (var i = 0; i < renderables.Count; i++)
+					renderables[i].RenderDebugGeometry(this);
+
 				foreach (var g in finalOverlayRenderables.GroupBy(prs => prs.GetType()))
 					foreach (var r in g)
 						r.RenderDebugGeometry(this);
+			}
 
 			Game.Renderer.Flush();
 		}
@@ -233,28 +234,34 @@ namespace OpenRA.Graphics
 			return new int2((int)Math.Round(px.X), (int)Math.Round(px.Y));
 		}
 
-		// For scaling vectors to pixel sizes in the voxel renderer
-		public void ScreenVectorComponents(WVec vec, out float x, out float y, out float z)
+		public float3 Screen3DPxPosition(WPos pos)
 		{
-			x = TileSize.Width * vec.X / 1024f;
-			y = TileSize.Height * (vec.Y - vec.Z) / 1024f;
-			z = TileSize.Height * vec.Z / 1024f;
+			// Round to nearest pixel
+			var px = Screen3DPosition(pos);
+			return new float3((float)Math.Round(px.X), (float)Math.Round(px.Y), px.Z);
+		}
+
+		// For scaling vectors to pixel sizes in the voxel renderer
+		public float3 ScreenVectorComponents(WVec vec)
+		{
+			return new float3(
+				TileSize.Width * vec.X / 1024f,
+				TileSize.Height * (vec.Y - vec.Z) / 1024f,
+				TileSize.Height * vec.Z / 1024f);
 		}
 
 		// For scaling vectors to pixel sizes in the voxel renderer
 		public float[] ScreenVector(WVec vec)
 		{
-			float x, y, z;
-			ScreenVectorComponents(vec, out x, out y, out z);
-			return new[] { x, y, z, 1f };
+			var xyz = ScreenVectorComponents(vec);
+			return new[] { xyz.X, xyz.Y, xyz.Z, 1f };
 		}
 
 		public int2 ScreenPxOffset(WVec vec)
 		{
 			// Round to nearest pixel
-			float x, y, z;
-			ScreenVectorComponents(vec, out x, out y, out z);
-			return new int2((int)Math.Round(x), (int)Math.Round(y));
+			var xyz = ScreenVectorComponents(vec);
+			return new int2((int)Math.Round(xyz.X), (int)Math.Round(xyz.Y));
 		}
 
 		public float ScreenZPosition(WPos pos, int offset)

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -127,6 +127,7 @@ namespace OpenRA.Graphics
 			{
 				Game.Renderer.WorldSpriteRenderer.SetDepthPreviewEnabled(devTrait.Value.ShowDepthPreview);
 				Game.Renderer.WorldRgbaSpriteRenderer.SetDepthPreviewEnabled(devTrait.Value.ShowDepthPreview);
+				Game.Renderer.WorldRgbaColorRenderer.SetDepthPreviewEnabled(devTrait.Value.ShowDepthPreview);
 			}
 
 			RefreshPalette();

--- a/OpenRA.Game/Primitives/float3.cs
+++ b/OpenRA.Game/Primitives/float3.cs
@@ -37,6 +37,14 @@ namespace OpenRA
 		public static float3 operator /(float3 a, float3 b) { return new float3(a.X / b.X, a.Y / b.Y, a.Z / b.Z); }
 		public static float3 operator /(float3 a, float b) { return new float3(a.X / b, a.Y / b, a.Z / b); }
 
+		public static float3 Lerp(float3 a, float3 b, float t)
+		{
+			return new float3(
+				float2.Lerp(a.X, b.X, t),
+				float2.Lerp(a.Y, b.Y, t),
+				float2.Lerp(a.Z, b.Z, t));
+		}
+
 		public static bool operator ==(float3 me, float3 other) { return me.X == other.X && me.Y == other.Y && me.Z == other.Z; }
 		public static bool operator !=(float3 me, float3 other) { return !(me == other); }
 		public override int GetHashCode() { return X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode(); }

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -119,7 +119,7 @@ namespace OpenRA
 				lastResolution = Resolution;
 				RgbaSpriteRenderer.SetViewportParams(Resolution, 0f, 0f, 1f, int2.Zero);
 				SpriteRenderer.SetViewportParams(Resolution, 0f, 0f, 1f, int2.Zero);
-				RgbaColorRenderer.SetViewportParams(Resolution, 1f, int2.Zero);
+				RgbaColorRenderer.SetViewportParams(Resolution, 0f, 0f, 1f, int2.Zero);
 			}
 
 			// If zoom evaluates as different due to floating point weirdness that's OK, setting the parameters again is harmless.
@@ -130,7 +130,7 @@ namespace OpenRA
 				WorldRgbaSpriteRenderer.SetViewportParams(Resolution, depthScale, depthOffset, zoom, scroll);
 				WorldSpriteRenderer.SetViewportParams(Resolution, depthScale, depthOffset, zoom, scroll);
 				WorldVoxelRenderer.SetViewportParams(Resolution, zoom, scroll);
-				WorldRgbaColorRenderer.SetViewportParams(Resolution, zoom, scroll);
+				WorldRgbaColorRenderer.SetViewportParams(Resolution, depthScale, depthOffset, zoom, scroll);
 			}
 		}
 

--- a/OpenRA.Game/Widgets/WidgetUtils.cs
+++ b/OpenRA.Game/Widgets/WidgetUtils.cs
@@ -70,7 +70,9 @@ namespace OpenRA.Widgets
 
 		public static void FillEllipseWithColor(Rectangle r, Color c)
 		{
-			Game.Renderer.RgbaColorRenderer.FillEllipse(new RectangleF(r.X, r.Y, r.Width, r.Height), c);
+			var tl = new float2(r.Left, r.Top);
+			var br = new float2(r.Right, r.Bottom);
+			Game.Renderer.RgbaColorRenderer.FillEllipse(tl, br, c);
 		}
 
 		public static int[] GetBorderSizes(string collection)

--- a/OpenRA.Mods.Common/Graphics/BeamRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/BeamRenderable.cs
@@ -55,16 +55,16 @@ namespace OpenRA.Mods.Common.Graphics
 			{
 				var delta = length * width.Length / (2 * vecLength);
 				var corner = new WVec(-delta.Y, delta.X, delta.Z);
-				var a = wr.ScreenPosition(pos - corner);
-				var b = wr.ScreenPosition(pos + corner);
-				var c = wr.ScreenPosition(pos + corner + length);
-				var d = wr.ScreenPosition(pos - corner + length);
+				var a = wr.Screen3DPosition(pos - corner);
+				var b = wr.Screen3DPosition(pos + corner);
+				var c = wr.Screen3DPosition(pos + corner + length);
+				var d = wr.Screen3DPosition(pos - corner + length);
 				Game.Renderer.WorldRgbaColorRenderer.FillRect(a, b, c, d, color);
 			}
 			else
 			{
-				var start = wr.ScreenPosition(pos);
-				var end = wr.ScreenPosition(pos + length);
+				var start = wr.Screen3DPosition(pos);
+				var end = wr.Screen3DPosition(pos + length);
 				var screenWidth = wr.ScreenVector(new WVec(width, WDist.Zero, WDist.Zero))[0];
 				Game.Renderer.WorldRgbaColorRenderer.DrawLine(start, end, screenWidth, color);
 			}

--- a/OpenRA.Mods.Common/Graphics/ContrailRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/ContrailRenderable.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Graphics
 				var nextColor = Exts.ColorLerp(i * 1f / (length - 4), color, Color.Transparent);
 
 				if (!world.FogObscures(curPos) && !world.FogObscures(nextPos))
-					wcr.DrawLine(wr.ScreenPosition(curPos), wr.ScreenPosition(nextPos), screenWidth, curColor, nextColor);
+					wcr.DrawLine(wr.Screen3DPosition(curPos), wr.Screen3DPosition(nextPos), screenWidth, curColor, nextColor);
 
 				curPos = nextPos;
 				curColor = nextColor;

--- a/OpenRA.Mods.Common/Graphics/DetectionCircleRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/DetectionCircleRenderable.cs
@@ -67,13 +67,13 @@ namespace OpenRA.Mods.Common.Graphics
 		public void Render(WorldRenderer wr)
 		{
 			var wcr = Game.Renderer.WorldRgbaColorRenderer;
-			var center = wr.ScreenPosition(centerPosition);
+			var center = wr.Screen3DPosition(centerPosition);
 
 			for (var i = 0; i < trailCount; i++)
 			{
 				var angle = trailAngle - new WAngle(i * (trailSeparation.Angle <= 512 ? 1 : -1));
 				var length = radius.Length * new WVec(angle.Cos(), angle.Sin(), 0) / 1024;
-				var end = wr.ScreenPosition(centerPosition + length);
+				var end = wr.Screen3DPosition(centerPosition + length);
 				var alpha = color.A - i * color.A / trailCount;
 
 				wcr.DrawLine(center, end, 3, Color.FromArgb(alpha, contrastColor));

--- a/OpenRA.Mods.Common/Graphics/RangeCircleRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/RangeCircleRenderable.cs
@@ -58,8 +58,8 @@ namespace OpenRA.Mods.Common.Graphics
 			var offset = new WVec(radius.Length, 0, 0);
 			for (var i = 0; i < RangeCircleSegments; i++)
 			{
-				var a = wr.ScreenPosition(centerPosition + offset.Rotate(RangeCircleStartRotations[i]));
-				var b = wr.ScreenPosition(centerPosition + offset.Rotate(RangeCircleEndRotations[i]));
+				var a = wr.Screen3DPosition(centerPosition + offset.Rotate(RangeCircleStartRotations[i]));
+				var b = wr.Screen3DPosition(centerPosition + offset.Rotate(RangeCircleEndRotations[i]));
 
 				if (contrastWidth > 0)
 					wcr.DrawLine(a, b, contrastWidth / wr.Viewport.Zoom, contrastColor);

--- a/OpenRA.Mods.Common/Graphics/SelectionBoxRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBoxRenderable.cs
@@ -45,11 +45,11 @@ namespace OpenRA.Mods.Common.Graphics
 		public void Render(WorldRenderer wr)
 		{
 			var iz = 1 / wr.Viewport.Zoom;
-			var screenPos = wr.ScreenPxPosition(pos);
+			var screenPos = wr.Screen3DPxPosition(pos);
 			var tl = screenPos + new float2(visualBounds.Left, visualBounds.Top);
 			var br = screenPos + new float2(visualBounds.Right, visualBounds.Bottom);
-			var tr = new float2(br.X, tl.Y);
-			var bl = new float2(tl.X, br.Y);
+			var tr = new float3(br.X, tl.Y, screenPos.Z);
+			var bl = new float3(tl.X, br.Y, screenPos.Z);
 			var u = new float2(4 * iz, 0);
 			var v = new float2(0, 4 * iz);
 

--- a/OpenRA.Mods.Common/Graphics/TextRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/TextRenderable.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Graphics
 		public void RenderDebugGeometry(WorldRenderer wr)
 		{
 			var size = font.Measure(text).ToFloat2();
-			var offset = wr.ScreenPxPosition(pos) - 0.5f * size;
+			var offset = wr.Screen3DPxPosition(pos) - 0.5f * size;
 			Game.Renderer.WorldRgbaColorRenderer.DrawRect(offset, offset + size, 1 / wr.Viewport.Zoom, Color.Red);
 		}
 

--- a/OpenRA.Mods.Common/Graphics/VoxelRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/VoxelRenderable.cs
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.Common.Graphics
 			{
 				var groundPos = voxel.pos - new WVec(0, 0, wr.World.Map.DistanceAboveTerrain(voxel.pos).Length);
 				var groundZ = wr.World.Map.Grid.TileSize.Height * (groundPos.Z - voxel.pos.Z) / 1024f;
-				var pxOrigin = wr.ScreenPosition(voxel.pos);
+				var pxOrigin = wr.Screen3DPosition(voxel.pos);
 				var shadowOrigin = pxOrigin - groundZ * (new float2(renderProxy.ShadowDirection, 1));
 				var iz = 1 / wr.Viewport.Zoom;
 
@@ -141,13 +141,12 @@ namespace OpenRA.Mods.Common.Graphics
 				var c = Color.Purple;
 				var psb = renderProxy.ProjectedShadowBounds;
 
-				// TODO: add float3 support to WorldRgbaColorRenderer
 				Game.Renderer.WorldRgbaColorRenderer.DrawPolygon(new[]
 				{
-					shadowOrigin + psb[1].XY,
-					shadowOrigin + psb[3].XY,
-					shadowOrigin + psb[0].XY,
-					shadowOrigin + psb[2].XY
+					shadowOrigin + psb[1],
+					shadowOrigin + psb[3],
+					shadowOrigin + psb[0],
+					shadowOrigin + psb[2]
 				}, iz, c);
 
 				// Draw voxel bounding box
@@ -161,9 +160,7 @@ namespace OpenRA.Mods.Common.Graphics
 					var worldTransform = v.RotationFunc().Reverse().Aggregate(scaleTransform,
 						(x, y) => OpenRA.Graphics.Util.MatrixMultiply(x, OpenRA.Graphics.Util.MakeFloatMatrix(y.AsMatrix())));
 
-					float sx, sy, sz;
-					wr.ScreenVectorComponents(v.OffsetFunc(), out sx, out sy, out sz);
-					var pxPos = pxOrigin + new float2(sx, sy);
+					var pxPos = pxOrigin + wr.ScreenVectorComponents(v.OffsetFunc());
 					var screenTransform = OpenRA.Graphics.Util.MatrixMultiply(cameraTransform, worldTransform);
 					DrawBoundsBox(pxPos, screenTransform, bounds, iz, Color.Yellow);
 				}
@@ -172,15 +169,15 @@ namespace OpenRA.Mods.Common.Graphics
 			static readonly uint[] CornerXIndex = new uint[] { 0, 0, 0, 0, 3, 3, 3, 3 };
 			static readonly uint[] CornerYIndex = new uint[] { 1, 1, 4, 4, 1, 1, 4, 4 };
 			static readonly uint[] CornerZIndex = new uint[] { 2, 5, 2, 5, 2, 5, 2, 5 };
-			static void DrawBoundsBox(float2 pxPos, float[] transform, float[] bounds, float width, Color c)
+			static void DrawBoundsBox(float3 pxPos, float[] transform, float[] bounds, float width, Color c)
 			{
 				var wcr = Game.Renderer.WorldRgbaColorRenderer;
-				var corners = new float2[8];
+				var corners = new float3[8];
 				for (var i = 0; i < 8; i++)
 				{
 					var vec = new float[] { bounds[CornerXIndex[i]], bounds[CornerYIndex[i]], bounds[CornerZIndex[i]], 1 };
 					var screen = OpenRA.Graphics.Util.MatrixVectorMultiply(transform, vec);
-					corners[i] = pxPos + new float2(screen[0], screen[1]);
+					corners[i] = pxPos + new float3(screen[0], screen[1], screen[2]);
 				}
 
 				// Front face
@@ -221,9 +218,7 @@ namespace OpenRA.Mods.Common.Graphics
 					var worldTransform = v.RotationFunc().Reverse().Aggregate(scaleTransform,
 						(x, y) => OpenRA.Graphics.Util.MatrixMultiply(x, OpenRA.Graphics.Util.MakeFloatMatrix(y.AsMatrix())));
 
-					float sx, sy, sz;
-					wr.ScreenVectorComponents(v.OffsetFunc(), out sx, out sy, out sz);
-					var pxPos = pxOrigin + new float3(sx, sy, sz);
+					var pxPos = pxOrigin + wr.ScreenVectorComponents(v.OffsetFunc());
 					var screenTransform = OpenRA.Graphics.Util.MatrixMultiply(cameraTransform, worldTransform);
 
 					for (var i = 0; i < 8; i++)

--- a/OpenRA.Mods.Common/HitShapes/Capsule.cs
+++ b/OpenRA.Mods.Common/HitShapes/Capsule.cs
@@ -112,13 +112,13 @@ namespace OpenRA.Mods.Common.HitShapes
 			var c = Color.Yellow;
 			RangeCircleRenderable.DrawRangeCircle(wr, a, Radius, 1, c, 0, c);
 			RangeCircleRenderable.DrawRangeCircle(wr, b, Radius, 1, c, 0, c);
-			wcr.DrawLine(new[] { wr.ScreenPosition(a - offset1), wr.ScreenPosition(b - offset1) }, 1, c);
-			wcr.DrawLine(new[] { wr.ScreenPosition(a + offset1), wr.ScreenPosition(b + offset1) }, 1, c);
+			wcr.DrawLine(new[] { wr.Screen3DPosition(a - offset1), wr.Screen3DPosition(b - offset1) }, 1, c);
+			wcr.DrawLine(new[] { wr.Screen3DPosition(a + offset1), wr.Screen3DPosition(b + offset1) }, 1, c);
 
 			RangeCircleRenderable.DrawRangeCircle(wr, aa, Radius, 1, c, 0, c);
 			RangeCircleRenderable.DrawRangeCircle(wr, bb, Radius, 1, c, 0, c);
-			wcr.DrawLine(new[] { wr.ScreenPosition(aa - offset2), wr.ScreenPosition(bb - offset2) }, 1, c);
-			wcr.DrawLine(new[] { wr.ScreenPosition(aa + offset2), wr.ScreenPosition(bb + offset2) }, 1, c);
+			wcr.DrawLine(new[] { wr.Screen3DPosition(aa - offset2), wr.Screen3DPosition(bb - offset2) }, 1, c);
+			wcr.DrawLine(new[] { wr.Screen3DPosition(aa + offset2), wr.Screen3DPosition(bb + offset2) }, 1, c);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/HitShapes/Rectangle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Rectangle.cs
@@ -129,16 +129,16 @@ namespace OpenRA.Mods.Common.HitShapes
 				var positions = targetablePositions.SelectMany(tp => tp.TargetablePositions(actor));
 				foreach (var pos in positions)
 				{
-					var vertsTop = combatOverlayVertsTop.Select(v => wr.ScreenPosition(pos + v.Rotate(orientation)));
-					var vertsBottom = combatOverlayVertsBottom.Select(v => wr.ScreenPosition(pos + v.Rotate(orientation)));
+					var vertsTop = combatOverlayVertsTop.Select(v => wr.Screen3DPosition(pos + v.Rotate(orientation)));
+					var vertsBottom = combatOverlayVertsBottom.Select(v => wr.Screen3DPosition(pos + v.Rotate(orientation)));
 					wcr.DrawPolygon(vertsTop.ToArray(), 1, Color.Yellow);
 					wcr.DrawPolygon(vertsBottom.ToArray(), 1, Color.Yellow);
 				}
 			}
 			else
 			{
-				var vertsTop = combatOverlayVertsTop.Select(v => wr.ScreenPosition(actorPos + v.Rotate(orientation)));
-				var vertsBottom = combatOverlayVertsBottom.Select(v => wr.ScreenPosition(actorPos + v.Rotate(orientation)));
+				var vertsTop = combatOverlayVertsTop.Select(v => wr.Screen3DPosition(actorPos + v.Rotate(orientation)));
+				var vertsBottom = combatOverlayVertsBottom.Select(v => wr.Screen3DPosition(actorPos + v.Rotate(orientation)));
 				wcr.DrawPolygon(vertsTop.ToArray(), 1, Color.Yellow);
 				wcr.DrawPolygon(vertsBottom.ToArray(), 1, Color.Yellow);
 			}

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -63,8 +63,8 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				var hc = Color.Orange;
 				var height = new WVec(0, 0, blockers.Max(b => b.BlockingHeight.Length));
-				var ha = wr.ScreenPosition(self.CenterPosition);
-				var hb = wr.ScreenPosition(self.CenterPosition + height);
+				var ha = wr.Screen3DPosition(self.CenterPosition);
+				var hb = wr.Screen3DPosition(self.CenterPosition + height);
 				wcr.DrawLine(ha, hb, iz, hc);
 				TargetLineRenderable.DrawTargetMarker(wr, hc, ha);
 				TargetLineRenderable.DrawTargetMarker(wr, hc, hb);
@@ -89,9 +89,9 @@ namespace OpenRA.Mods.Common.Traits
 					var da = coords.Value.LocalToWorld(new WVec(224, 0, 0).Rotate(WRot.FromYaw(p.Yaw + p.Cone)).Rotate(bodyOrientation));
 					var db = coords.Value.LocalToWorld(new WVec(224, 0, 0).Rotate(WRot.FromYaw(p.Yaw - p.Cone)).Rotate(bodyOrientation));
 
-					var o = wr.ScreenPosition(pos);
-					var a = wr.ScreenPosition(pos + da * 224 / da.Length);
-					var b = wr.ScreenPosition(pos + db * 224 / db.Length);
+					var o = wr.Screen3DPosition(pos);
+					var a = wr.Screen3DPosition(pos + da * 224 / da.Length);
+					var b = wr.Screen3DPosition(pos + db * 224 / db.Length);
 					wcr.DrawLine(o, a, iz, c);
 					wcr.DrawLine(o, b, iz, c);
 				}
@@ -106,8 +106,8 @@ namespace OpenRA.Mods.Common.Traits
 					var muzzle = self.CenterPosition + a.MuzzleOffset(self, b);
 					var dirOffset = new WVec(0, -224, 0).Rotate(a.MuzzleOrientation(self, b));
 
-					var sm = wr.ScreenPosition(muzzle);
-					var sd = wr.ScreenPosition(muzzle + dirOffset);
+					var sm = wr.Screen3DPosition(muzzle);
+					var sd = wr.Screen3DPosition(muzzle + dirOffset);
 					wcr.DrawLine(sm, sd, iz, c);
 					TargetLineRenderable.DrawTargetMarker(wr, c, sm);
 				}

--- a/OpenRA.Mods.Common/Traits/ExitsDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/ExitsDebugOverlay.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.Traits
 						continue;
 
 					var exitCellCenter = self.World.Map.CenterOfCell(exitCells[i]);
-					rgbaRenderer.DrawLine(wr.ScreenPosition(spawnPos), wr.ScreenPosition(exitCellCenter), 1f, self.Owner.Color.RGB);
+					rgbaRenderer.DrawLine(wr.Screen3DPosition(spawnPos), wr.Screen3DPosition(exitCellCenter), 1f, self.Owner.Color.RGB);
 				}
 			}
 	    }

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 				var corners = map.Grid.CellCorners[ramp];
 				var color = corners.Select(c => colors[height + c.Z / 512]).ToArray();
 				var pos = map.CenterOfCell(uv.ToCPos(map));
-				var screen = corners.Select(c => wr.ScreenPxPosition(pos + c).ToFloat2()).ToArray();
+				var screen = corners.Select(c => wr.Screen3DPxPosition(pos + c)).ToArray();
 				var width = (uv == mouseCell ? 3 : 1) / wr.Viewport.Zoom;
 
 				// Colors change between points, so render separately
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var puv in map.ProjectedCellsCovering(mouseCell))
 			{
 				var pos = map.CenterOfCell(((MPos)puv).ToCPos(map));
-				var screen = projectedCorners.Select(c => wr.ScreenPxPosition(pos + c - new WVec(0, 0, pos.Z)).ToFloat2()).ToArray();
+				var screen = projectedCorners.Select(c => wr.Screen3DPxPosition(pos + c - new WVec(0, 0, pos.Z))).ToArray();
 				for (var i = 0; i < 4; i++)
 				{
 					var j = (i + 1) % 4;

--- a/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
@@ -73,8 +73,9 @@ namespace OpenRA.Mods.Common.Traits
 
 				foreach (var r in i.Range)
 				{
-					var tl = wr.ScreenPosition(i.CenterPosition - new WVec(r.Length, r.Length, 0));
-					var br = wr.ScreenPosition(i.CenterPosition + new WVec(r.Length, r.Length, 0));
+					var tl = wr.Screen3DPosition(i.CenterPosition - new WVec(r.Length, r.Length, 0));
+					var br = wr.Screen3DPosition(i.CenterPosition + new WVec(r.Length, r.Length, 0));
+
 					Game.Renderer.WorldRgbaColorRenderer.FillEllipse(tl, br, Color.FromArgb((int)alpha, i.Color));
 
 					alpha -= rangeStep;

--- a/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
@@ -75,9 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					var tl = wr.ScreenPosition(i.CenterPosition - new WVec(r.Length, r.Length, 0));
 					var br = wr.ScreenPosition(i.CenterPosition + new WVec(r.Length, r.Length, 0));
-					var rect = RectangleF.FromLTRB(tl.X, tl.Y, br.X, br.Y);
-
-					Game.Renderer.WorldRgbaColorRenderer.FillEllipse(rect, Color.FromArgb((int)alpha, i.Color));
+					Game.Renderer.WorldRgbaColorRenderer.FillEllipse(tl, br, Color.FromArgb((int)alpha, i.Color));
 
 					alpha -= rangeStep;
 				}

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -54,7 +54,9 @@ namespace OpenRA.Mods.Common.Widgets
 			if (IsValidDragbox)
 			{
 				// Render actors in the dragbox
-				Game.Renderer.WorldRgbaColorRenderer.DrawRect(dragStart, mousePos,
+				var a = new float3(dragStart.X, dragStart.Y, dragStart.Y);
+				var b = new float3(mousePos.X, mousePos.Y, mousePos.Y);
+				Game.Renderer.WorldRgbaColorRenderer.DrawRect(a, b,
 					1 / worldRenderer.Viewport.Zoom, Color.White);
 				foreach (var u in SelectActorsInBoxWithDeadzone(World, dragStart, mousePos))
 					DrawRollover(u);

--- a/glsl/color.frag
+++ b/glsl/color.frag
@@ -1,6 +1,18 @@
 varying vec4 vColor;
+uniform bool EnableDepthPreview;
 
 void main()
 {
-	gl_FragColor = vColor;
+	float depth = gl_FragCoord.z;
+
+	// Convert to window coords
+	gl_FragDepth = 0.5 * depth + 0.5;
+
+	if (EnableDepthPreview)
+	{
+		// Front of the depth buffer is at 0, but we want to render it as bright
+		gl_FragColor = vec4(vec3(1.0 - gl_FragDepth), 1.0);
+	}
+	else
+		gl_FragColor = vColor;
 }

--- a/glsl/color.vert
+++ b/glsl/color.vert
@@ -1,5 +1,5 @@
-uniform vec2 Scroll;
-uniform vec2 r1, r2;
+uniform vec3 Scroll;
+uniform vec3 r1, r2;
 
 attribute vec4 aVertexPosition;
 attribute vec4 aVertexTexCoord;
@@ -7,7 +7,6 @@ varying vec4 vColor;
 
 void main()
 {
-	vec2 p = (aVertexPosition.xy - Scroll.xy)*r1 + r2;
-	gl_Position = vec4(p.x,p.y,0,1);
+	gl_Position = vec4((aVertexPosition.xyz - Scroll.xyz) * r1 + r2, 1);  
 	vColor = aVertexTexCoord;
 } 


### PR DESCRIPTION
This, together with #11862,  implement the final engine changes (that I'm aware of) to support the depth buffer in the gen2 mods.  The remaining changes should be limited to the mod yaml – setting correct offsets and ramps to stop actors from clipping below the terrain.

Closes #7520.

To simplify testing my [depthbuffer-part-two](https://github.com/pchote/OpenRA/tree/depthbuffer-part-two) branch merges this with #11862 and includes a commit that enables the depth buffer in TS.  There should be no visible changes in the classic mods.
