### PR TITLE
Fix GPSDots being visible when the unit is not InWorld or dead

### DIFF
--- a/OpenRA.Mods.RA/Effects/GpsDot.cs
+++ b/OpenRA.Mods.RA/Effects/GpsDot.cs
@@ -124,16 +124,14 @@ namespace OpenRA.Mods.RA.Effects
 			if (self.Disposed)
 				world.AddFrameEndTask(w => w.Remove(this));
 
-			if (!self.IsInWorld || self.IsDead)
-				return;
-
 			for (var playerIndex = 0; playerIndex < dotStates.Count; playerIndex++)
 			{
 				var state = dotStates[playerIndex];
 				var shouldRender = false;
-				var targetable = (state.Gps.Granted || state.Gps.GrantedAllies) && IsTargetableBy(world.Players[playerIndex], out shouldRender);
-				state.IsTargetable = targetable;
-				state.ShouldRender = targetable && shouldRender;
+				if (self.IsInWorld && !self.IsDead)
+					state.IsTargetable = (state.Gps.Granted || state.Gps.GrantedAllies) && IsTargetableBy(world.Players[playerIndex], out shouldRender);
+
+				state.ShouldRender = state.IsTargetable && shouldRender;
 			}
 		}
 


### PR DESCRIPTION
It was still visible when e.g. someone loaded a unit into a transport.
![gpsdotbuga](https://cloud.githubusercontent.com/assets/7704140/17906653/93db2560-6978-11e6-9d0b-6401f0976071.png)![gpsdotbugb](https://cloud.githubusercontent.com/assets/7704140/17906646/8c805bb4-6978-11e6-8ad6-0e546f3ff364.png)
![gpsdotbugc](https://cloud.githubusercontent.com/assets/7704140/17906645/8c7be1d8-6978-11e6-8335-d245abf14d26.png)
![gpsdotbugd](https://cloud.githubusercontent.com/assets/7704140/17906648/8c83e734-6978-11e6-9f80-3b15d6534c07.png)![gpsdotbuge](https://cloud.githubusercontent.com/assets/7704140/17906647/8c83a7ba-6978-11e6-9cf3-eacdc078d919.png)
