### PR TITLE
Fix the floating text for bounties of actors not being InWorld showing up

### DIFF
--- a/OpenRA.Mods.Common/Traits/GivesBounty.cs
+++ b/OpenRA.Mods.Common/Traits/GivesBounty.cs
@@ -65,15 +65,15 @@ namespace OpenRA.Mods.Common.Traits
 			return (slevel > 0) ? slevel * info.LevelMod : 100;
 		}
 
-		int GetBountyValue(Actor self, int percentage)
+		int GetBountyValue(Actor self)
 		{
 			// Divide by 10000 because of GetMultiplier and info.Percentage.
-			return self.GetSellValue() * GetMultiplier() * percentage / 10000;
+			return self.GetSellValue() * GetMultiplier() * info.Percentage / 10000;
 		}
 
 		int GetDisplayedBountyValue(Actor self)
 		{
-			var bounty = GetBountyValue(self, info.Percentage);
+			var bounty = GetBountyValue(self);
 			if (cargo == null)
 				return bounty;
 
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.ShowBounty && self.IsInWorld && displayedBounty > 0 && e.Attacker.Owner.IsAlliedWith(self.World.RenderPlayer))
 				e.Attacker.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, e.Attacker.Owner.Color.RGB, FloatingText.FormatCashTick(displayedBounty), 30)));
 
-			e.Attacker.Owner.PlayerActor.Trait<PlayerResources>().GiveCash(GetBountyValue(self, info.Percentage));
+			e.Attacker.Owner.PlayerActor.Trait<PlayerResources>().GiveCash(GetBountyValue(self));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/GivesBounty.cs
+++ b/OpenRA.Mods.Common/Traits/GivesBounty.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Traits
 			// 2 hundreds because of GetMultiplier and info.Percentage.
 			var bounty = cost * GetMultiplier(self) * info.Percentage / 10000;
 
-			if (info.ShowBounty && bounty > 0 && e.Attacker.Owner.IsAlliedWith(self.World.RenderPlayer))
+			if (info.ShowBounty && self.IsInWorld && bounty > 0 && e.Attacker.Owner.IsAlliedWith(self.World.RenderPlayer))
 				e.Attacker.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, e.Attacker.Owner.Color.RGB, FloatingText.FormatCashTick(bounty), 30)));
 
 			e.Attacker.Owner.PlayerActor.Trait<PlayerResources>().GiveCash(bounty);

--- a/OpenRA.Mods.Common/Traits/GivesBounty.cs
+++ b/OpenRA.Mods.Common/Traits/GivesBounty.cs
@@ -38,19 +38,26 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new GivesBounty(init.Self, this); }
 	}
 
-	class GivesBounty : INotifyKilled
+	class GivesBounty : INotifyKilled, INotifyCreated
 	{
 		readonly GivesBountyInfo info;
+		GainsExperience gainsExp;
+		Cargo cargo;
 
 		public GivesBounty(Actor self, GivesBountyInfo info)
 		{
 			this.info = info;
 		}
 
-		int GetMultiplier(Actor self)
+		void INotifyCreated.Created(Actor self)
 		{
-			// returns 100's as 1, so as to keep accuracy for longer.
-			var gainsExp = self.TraitOrDefault<GainsExperience>();
+			gainsExp = self.TraitOrDefault<GainsExperience>();
+			cargo = self.TraitOrDefault<Cargo>();
+		}
+
+		// Returns 100's as 1, so as to keep accuracy for longer.
+		int GetMultiplier()
+		{
 			if (gainsExp == null)
 				return 100;
 
@@ -61,13 +68,12 @@ namespace OpenRA.Mods.Common.Traits
 		int GetBountyValue(Actor self, int percentage)
 		{
 			// Divide by 10000 because of GetMultiplier and info.Percentage.
-			return self.GetSellValue() * GetMultiplier(self) * percentage / 10000;
+			return self.GetSellValue() * GetMultiplier() * percentage / 10000;
 		}
 
 		int GetDisplayedBountyValue(Actor self)
 		{
 			var bounty = GetBountyValue(self, info.Percentage);
-			var cargo = self.TraitOrDefault<Cargo>();
 			if (cargo == null)
 				return bounty;
 


### PR DESCRIPTION
Before you could see the text at the location the unit was removed from world.

![gpsbounty](https://cloud.githubusercontent.com/assets/7704140/17906949/c232ed70-6979-11e6-9128-26ddebd2f5a8.png)
