### PR TITLE
Add oramod file association for Windows, Linux, and OSX.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -439,6 +439,7 @@ install-linux-mime:
 	@$(INSTALL_DIR) "$(DESTDIR)$(datadir)/applications"
 	@$(INSTALL_DATA) packaging/linux/openra-join-servers.desktop "$(DESTDIR)$(datadir)/applications"
 	@$(INSTALL_DATA) packaging/linux/openra-replays.desktop "$(DESTDIR)$(datadir)/applications"
+	@$(INSTALL_DATA) packaging/linux/openra-launch-mod.desktop "$(DESTDIR)$(datadir)/applications"
 
 install-linux-appdata:
 	@$(INSTALL_DIR) "$(DESTDIR)$(datadir)/appdata/"
@@ -484,6 +485,9 @@ uninstall:
 	@-$(RM_F) "$(BIN_INSTALL_DIR)/openra"
 	@-$(RM_F) "$(BIN_INSTALL_DIR)/openra-server"
 	@-$(RM_F) "$(DESTDIR)$(datadir)/applications/openra.desktop"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/applications/openra-join-servers.desktop"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/applications/openra-launch-mod.desktop"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/applications/openra-join-servers.desktop"
 	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/16x16/apps/openra.png"
 	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/32x32/apps/openra.png"
 	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/48x48/apps/openra.png"

--- a/packaging/linux/openra-launch-mod.desktop
+++ b/packaging/linux/openra-launch-mod.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=OpenRA
+GenericName=Real Time Strategy Game
+Comment=Reimagining of early Westwood Games
+Icon=openra
+Exec=openra Game.Mod=%f
+Terminal=false
+NoDisplay=true
+Categories=Game;StrategyGame;
+MimeType=application/x-openra-mod;

--- a/packaging/linux/openra-mimeinfo.xml
+++ b/packaging/linux/openra-mimeinfo.xml
@@ -8,6 +8,13 @@
     <glob weight="60" pattern="*.orarep"/>
   </mime-type>
 
+  <mime-type type="application/x-openra-mod">
+    <icon name="openra" />
+    <generic-icon name="applications-games"/>
+    <comment>OpenRA Mod</comment>
+    <glob weight="60" pattern="*.oramod"/>
+  </mime-type>
+
   <mime-type type="x-scheme-handler/openra">
     <icon name="openra" />
     <generic-icon name="applications-games"/>

--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # OpenRA packaging script for Mac OSX
 
-LAUNCHER_TAG="osx-launcher-20150412"
+LAUNCHER_TAG="osx-launcher-20160824"
 
 if [ $# -ne "3" ]; then
 	echo "Usage: `basename $0` tag files-dir outputdir"

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -60,7 +60,12 @@ Section "-Reg" Reg
 	WriteRegStr HKLM "Software\Classes\.orarep" "" "OpenRA_replay"
 	WriteRegStr HKLM "Software\Classes\OpenRA_replay\DefaultIcon" "" "$INSTDIR\OpenRA.ico,0"
 	WriteRegStr HKLM "Software\Classes\OpenRA_replay\Shell\Open\Command" "" "$INSTDIR\OpenRA.exe Launch.Replay=$\"%1$\""
-	
+
+	; oramod file association
+	WriteRegStr HKLM "Software\Classes\.oramod" "" "OpenRA_mod"
+	WriteRegStr HKLM "Software\Classes\OpenRA_mod\DefaultIcon" "" "$INSTDIR\OpenRA.ico,0"
+	WriteRegStr HKLM "Software\Classes\OpenRA_mod\Shell\Open\Command" "" "$INSTDIR\OpenRA.exe Game.Mod=$\"%1$\""
+
 	; OpenRA URL Scheme
 	WriteRegStr HKLM "Software\Classes\openra" "" "URL:OpenRA scheme"
 	WriteRegStr HKLM "Software\Classes\openra" "URL Protocol" ""


### PR DESCRIPTION
This makes it possible to double-click-run an oramod file.  Builds on the support added in #11771.
