### PR TITLE
Revert changes from #11460

### DIFF
--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -113,7 +113,7 @@ M16:
 			None: 100
 			Wood: 25
 			Light: 30
-			Heavy: 15
+			Heavy: 10
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piff

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -242,7 +242,7 @@ M1Carbine:
 		Versus:
 			Wood: 25
 			Light: 30
-			Heavy: 15
+			Heavy: 10
 			Concrete: 10
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
@@ -265,7 +265,7 @@ M60mg:
 		Versus:
 			Wood: 10
 			Light: 30
-			Heavy: 15
+			Heavy: 10
 			Concrete: 10
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect


### PR DESCRIPTION
Reverts the minigunner / RA Jeep damage vs. heavy armor to previous values.

Closes #11850.
