### PR TITLE
Allow download window to be closed on failed downloads.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
@@ -113,6 +113,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				progressBar.Percentage = 100;
 				getStatusText = () => "Error: " + s;
 				retryButton.IsVisible = () => true;
+				cancelButton.OnClick = Ui.CloseWindow;
 			});
 
 			Action<AsyncCompletedEventArgs> onDownloadComplete = i =>


### PR DESCRIPTION
Fixes #11843. Regression from #11745.
