### PR TITLE
Fix issuing orders when releasing RMB after joystick-scrolling

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -215,7 +215,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var blockedDirections = worldRenderer.Viewport.GetBlockedDirections();
 
-			if (IsJoystickScrolling)
+			if (IsJoystickScrolling || isStandardScrolling)
 			{
 				foreach (var dir in JoystickCursors)
 					if (blockedDirections.Includes(dir.Key))

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -35,6 +35,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public int EdgeCornerScrollThreshold = 35;
 
 		int2? joystickScrollStart, joystickScrollEnd;
+		bool isStandardScrolling;
 
 		static readonly Dictionary<ScrollDirection, string> ScrollCursors = new Dictionary<ScrollDirection, string>
 		{
@@ -287,9 +288,18 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				if (mi.Event == MouseInputEvent.Move)
 				{
+					isStandardScrolling = true;
 					var d = scrollType == MouseScrollType.Inverted ? -1 : 1;
 					worldRenderer.Viewport.Scroll((Viewport.LastMousePos - mi.Location) * d, false);
 					return true;
+				}
+				else if (mi.Event == MouseInputEvent.Up)
+				{
+					var wasStandardScrolling = isStandardScrolling;
+					isStandardScrolling = false;
+
+					if (wasStandardScrolling)
+						return true;
 				}
 			}
 

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -305,7 +305,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 				if (mi.Event == MouseInputEvent.Up)
 				{
-					var wasJoystickScrolling = IsJoystickScrolling;
+					var wasJoystickScrolling = joystickScrollStart.HasValue && joystickScrollEnd.HasValue;
 
 					joystickScrollStart = joystickScrollEnd = null;
 					YieldMouseFocus(mi);

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -203,9 +203,6 @@ Container@EDITOR_WORLD_ROOT:
 	Logic: LoadIngamePerfLogic, MapEditorLogic
 	Children:
 		Container@PERF_ROOT:
-		ViewportController:
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
 		EditorViewportController@MAP_EDITOR:
 			Width: WINDOW_RIGHT
 			Height: WINDOW_BOTTOM
@@ -218,6 +215,10 @@ Container@EDITOR_WORLD_ROOT:
 					Visible: false
 				ActorPreview@DRAG_ACTOR_PREVIEW:
 					Visible: false
+		ViewportController:
+			Width: WINDOW_RIGHT
+			Height: WINDOW_BOTTOM
+			IgnoreMouseOver: True
 		Background@RADAR_BG:
 			X: WINDOW_RIGHT-255
 			Y: 5

--- a/mods/ra/chrome/editor.yaml
+++ b/mods/ra/chrome/editor.yaml
@@ -194,12 +194,6 @@ Container@EDITOR_WORLD_ROOT:
 	Logic: LoadIngamePerfLogic, MapEditorLogic
 	Children:
 		Container@PERF_ROOT:
-		ViewportController:
-			X: 0
-			Y: 0
-			Width: WINDOW_RIGHT
-			Height: WINDOW_BOTTOM
-			TooltipContainer: TOOLTIP_CONTAINER
 		EditorViewportController@MAP_EDITOR:
 			Width: WINDOW_RIGHT
 			Height: WINDOW_BOTTOM
@@ -212,6 +206,10 @@ Container@EDITOR_WORLD_ROOT:
 					Visible: false
 				Sprite@DRAG_LAYER_PREVIEW:
 					Visible: false
+		ViewportController:
+			Width: WINDOW_RIGHT
+			Height: WINDOW_BOTTOM
+			IgnoreMouseOver: True
 		Background@RADAR_BG:
 			X: WINDOW_RIGHT-255
 			Y: 5


### PR DESCRIPTION
Fixes #11849.

Please test this properly, there may be regressions lurking here which I haven't found yet or am unable to find since my use of the controls is different from how other people use theirs. (I never ran into the original bug in the first place, for example.) 
