### PR TITLE
Allow keeping empty selection bars visible

### DIFF
--- a/OpenRA.Game/Graphics/SelectionBarsRenderable.cs
+++ b/OpenRA.Game/Graphics/SelectionBarsRenderable.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Graphics
 			foreach (var extraBar in actor.TraitsImplementing<ISelectionBar>())
 			{
 				var value = extraBar.GetValue();
-				if (value != 0)
+				if (value != 0 || extraBar.DisplayWhenEmpty)
 				{
 					start.Y += (int)(4 / wr.Viewport.Zoom);
 					end.Y += (int)(4 / wr.Viewport.Zoom);

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -280,7 +280,7 @@ namespace OpenRA.Traits
 	public interface IPips { IEnumerable<PipType> GetPips(Actor self); }
 
 	[RequireExplicitImplementation]
-	public interface ISelectionBar { float GetValue(); Color GetColor(); }
+	public interface ISelectionBar { float GetValue(); Color GetColor(); bool DisplayWhenEmpty { get; } }
 
 	public interface IPositionableInfo : ITraitInfoInterface { }
 	public interface IPositionable : IOccupySpace

--- a/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
@@ -95,5 +95,6 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		Color ISelectionBar.GetColor() { return Color.Purple; }
+		bool ISelectionBar.DisplayWhenEmpty { get { return false; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/ExternalCapturableBar.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCapturableBar.cs
@@ -39,5 +39,6 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		Color ISelectionBar.GetColor() { return Color.Orange; }
+		bool ISelectionBar.DisplayWhenEmpty { get { return false; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Power/AffectedByPowerOutage.cs
+++ b/OpenRA.Mods.Common/Traits/Power/AffectedByPowerOutage.cs
@@ -42,6 +42,8 @@ namespace OpenRA.Mods.Common.Traits
 			return Color.Yellow;
 		}
 
+		bool ISelectionBar.DisplayWhenEmpty { get { return false; } }
+
 		public int GetPowerModifier()
 		{
 			return playerPower.PowerOutageRemainingTicks > 0 ? 0 : 100;

--- a/OpenRA.Mods.Common/Traits/Render/ProductionBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/ProductionBar.cs
@@ -81,6 +81,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 
 		Color ISelectionBar.GetColor() { return info.Color; }
+		bool ISelectionBar.DisplayWhenEmpty { get { return false; } }
 
 		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/SupportPowerChargeBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SupportPowerChargeBar.cs
@@ -53,6 +53,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 
 		Color ISelectionBar.GetColor() { return info.Color; }
+		bool ISelectionBar.DisplayWhenEmpty { get { return false; } }
 
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/TimedUpgradeBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/TimedUpgradeBar.cs
@@ -57,5 +57,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 
 		Color ISelectionBar.GetColor() { return info.Color; }
+		bool ISelectionBar.DisplayWhenEmpty { get { return false; } }
 	}
 }

--- a/OpenRA.Mods.D2k/Traits/TemporaryOwnerManager.cs
+++ b/OpenRA.Mods.D2k/Traits/TemporaryOwnerManager.cs
@@ -79,5 +79,7 @@ namespace OpenRA.Mods.D2k.Traits
 		{
 			return info.BarColor;
 		}
+
+		bool ISelectionBar.DisplayWhenEmpty { get { return false; } }
 	}
 }

--- a/OpenRA.Mods.RA/Traits/Chronoshiftable.cs
+++ b/OpenRA.Mods.RA/Traits/Chronoshiftable.cs
@@ -128,6 +128,7 @@ namespace OpenRA.Mods.RA.Traits
 		}
 
 		Color ISelectionBar.GetColor() { return info.TimeBarColor; }
+		bool ISelectionBar.DisplayWhenEmpty { get { return false; } }
 
 		public void ModifyDeathActorInit(Actor self, TypeDictionary init)
 		{

--- a/OpenRA.Mods.RA/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.RA/Traits/PortableChrono.cs
@@ -118,6 +118,7 @@ namespace OpenRA.Mods.RA.Traits
 		}
 
 		Color ISelectionBar.GetColor() { return Color.Magenta; }
+		bool ISelectionBar.DisplayWhenEmpty { get { return false; } }
 	}
 
 	class PortableChronoOrderTargeter : IOrderTargeter


### PR DESCRIPTION
External mods might want to display bars even when they are empty.

In my example, I want a bar displaying heat level stay visible even if the current heat level is zero.
