### PR TITLE
 Replaced the AlliedMissiles boolean on JamsMissiles by a Stances field

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -396,7 +396,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			if ((tp.Actor.CenterPosition - pos).HorizontalLengthSquared > tp.Trait.Range.LengthSquared)
 				return false;
 
-			if (tp.Actor.Owner.Stances[args.SourceActor.Owner] == Stance.Ally && !tp.Trait.AlliedMissiles)
+			if (!tp.Actor.Owner.Stances[args.SourceActor.Owner].HasStance(tp.Trait.DeflectionStances))
 				return false;
 
 			return tp.Actor.World.SharedRandom.Next(100 / tp.Trait.Chance) == 0;

--- a/OpenRA.Mods.Common/Traits/JamsMissiles.cs
+++ b/OpenRA.Mods.Common/Traits/JamsMissiles.cs
@@ -13,10 +13,16 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[Desc("This actor deflects missiles.")]
 	public class JamsMissilesInfo : ITraitInfo
 	{
+		[Desc("Range of the deflection.")]
 		public readonly WDist Range = WDist.Zero;
-		public readonly bool AlliedMissiles = true;
+
+		[Desc("What diplomatic stances are affected.")]
+		public readonly Stance DeflectionStances = Stance.Ally | Stance.Neutral | Stance.Enemy;
+
+		[Desc("Chance of deflecting missiles.")]
 		public readonly int Chance = 100;
 
 		public object Create(ActorInitializer init) { return new JamsMissiles(this); }
@@ -27,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly JamsMissilesInfo info;
 
 		public WDist Range { get { return info.Range; } }
-		public bool AlliedMissiles { get { return info.AlliedMissiles; } }
+		public Stance DeflectionStances { get { return info.DeflectionStances; } }
 		public int Chance { get { return info.Chance; } }
 
 		public JamsMissiles(JamsMissilesInfo info) { this.info = info; }

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -344,6 +344,20 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					node.Value.Nodes.RemoveAll(n => n.Key == "PathfinderDebugOverlay");
 				}
 
+				// AlliedMissiles on JamsMissiles was changed from a boolean to a Stances field and renamed
+				if (engineVersion < 20160827)
+				{
+					if (node.Key == "JamsMissiles")
+					{
+						var alliedMissiles = node.Value.Nodes.FirstOrDefault(n => n.Key == "AlliedMissiles");
+						if (alliedMissiles != null)
+						{
+							alliedMissiles.Value.Value = FieldLoader.GetValue<bool>("AlliedMissiles", alliedMissiles.Value.Value) ? "Ally, Neutral, Enemy" : "Neutral, Enemy";
+							alliedMissiles.Key = "DeflectionStances";
+						}
+					}
+				}
+
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -546,7 +546,7 @@ MRJ:
 		Range: 15c0
 	JamsMissiles:
 		Range: 4c0
-		AlliedMissiles: False
+		DeflectionStances: Neutral, Enemy
 	RenderJammerCircle:
 	DetectCloaked:
 		Range: 6c0


### PR DESCRIPTION
Fixes the first part of #9382. (`JamsRadar` will be updated in another PR.)
