### PR TITLE
Fix GpsDots being displayed when their CenterPosition is shrouded

### DIFF
--- a/OpenRA.Mods.RA/Effects/GpsDot.cs
+++ b/OpenRA.Mods.RA/Effects/GpsDot.cs
@@ -111,7 +111,7 @@ namespace OpenRA.Mods.RA.Effects
 
 			shouldRenderIndicator = !f2.HasRenderables;
 
-			return f2.Visible && !f2.Shrouded;
+			return f2.Visible && !f2.Shrouded && !toPlayer.World.ShroudObscures(self.CenterPosition);
 		}
 
 		FrozenActor FrozenActorForPlayer(Player player)


### PR DESCRIPTION
Prevents things like:
![gpsshroud](https://cloud.githubusercontent.com/assets/7704140/18028673/567e74fa-6c85-11e6-9d0a-52d80de64278.png)
