### PR TITLE
Increase the left margin of the ingame-menu team line.

### DIFF
--- a/mods/cnc/chrome/ingame-infostats.yaml
+++ b/mods/cnc/chrome/ingame-infostats.yaml
@@ -67,7 +67,7 @@ Container@SKIRMISH_STATS:
 					Visible: false
 					Children:
 						Label@TEAM:
-							X: 2
+							X: 6
 							Y: 0-2
 							Width: 160
 							Height: 20

--- a/mods/d2k/chrome/ingame-infostats.yaml
+++ b/mods/d2k/chrome/ingame-infostats.yaml
@@ -68,7 +68,7 @@ Container@SKIRMISH_STATS:
 					Visible: false
 					Children:
 						Label@TEAM:
-							X: 2
+							X: 6
 							Y: 0-2
 							Width: 160
 							Height: 20

--- a/mods/ra/chrome/ingame-infostats.yaml
+++ b/mods/ra/chrome/ingame-infostats.yaml
@@ -68,7 +68,7 @@ Container@SKIRMISH_STATS:
 					Visible: false
 					Children:
 						Label@TEAM:
-							X: 2
+							X: 6
 							Y: 0-2
 							Width: 160
 							Height: 20


### PR DESCRIPTION
The "Team" line in the ingame menu does not have a large enough left margin.  This adds a few more px to improve polish.
