### PR TITLE
Fix a possible crash in the lua Player.Team property

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -220,10 +220,6 @@ namespace OpenRA.Server
 			}) { IsBackground = true }.Start();
 		}
 
-		/* lobby rework TODO:
-		 *	- "teams together" option for team games -- will eliminate most need
-		 *		for manual spawnpoint choosing.
-		 */
 		int nextPlayerIndex;
 		public int ChooseFreePlayerIndex()
 		{

--- a/OpenRA.Mods.Common/Scripting/Properties/PlayerProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/PlayerProperties.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Scripting
 		{
 			get
 			{
-				var c = Player.World.LobbyInfo.Clients[Player.ClientIndex];
+				var c = Player.World.LobbyInfo.Clients.FirstOrDefault(i => i.Index == Player.ClientIndex);
 				return c != null ? c.Team : 0;
 			}
 		}


### PR DESCRIPTION
Reproduction case:
1. Use a two player map, first put yourself in as spectator.
2. Remove all bots.
3. Add a bot in the first slot. You go into the second.
4. Execute `Utils.Do({ Player.GetPlayer("Multi0"), Player.GetPlayer("Multi1") }, function(p) Media.DisplayMessage("" .. p.Team) end)`.
