### PR TITLE
Enable per-pixel depth calculations in TS

### DIFF
--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -111,6 +111,7 @@ TileSets:
 
 MapGrid:
 	TileSize: 48,24
+	EnableDepthBuffer: True
 	Type: RectangularIsometric
 	MaximumTerrainHeight: 16
 	SubCellOffsets: 0,0,0, -256,128,0, 0,-128,0, 256,128,0

--- a/mods/ts/sequences/civilian.yaml
+++ b/mods/ts/sequences/civilian.yaml
@@ -301,6 +301,7 @@ cabhut:
 		DepthSprite: isodepth.shp
 		UseTilesetCode: true
 		Offset: 0, -12, 12
+		ShadowStart: 1
 
 ^cacrsh:
 	idle:

--- a/mods/ts/sequences/infantry.yaml
+++ b/mods/ts/sequences/infantry.yaml
@@ -1,6 +1,7 @@
 ^BasicInfantry:
 	Defaults:
 		Tick: 80
+		Offset: 0, 0, 16
 	stand:
 		Facings: 8
 		ShadowStart: 292
@@ -182,6 +183,7 @@ civ3:
 cyborg:
 	Defaults:
 		Tick: 80
+		Offset: 0, 0, 16
 	stand:
 		Facings: 8
 		ShadowStart: 370
@@ -225,9 +227,12 @@ cyborg:
 	icon: cybiicon
 
 cyc2:
+	Defaults:
+		Offset: 0, 0, 16
 	stand:
 		Facings: 8
 		ShadowStart: 308
+		Offset: 0, 0, 16
 	run:
 		Start: 8
 		Length: 9
@@ -270,6 +275,7 @@ cyc2:
 medic:
 	Defaults:
 		Tick: 80
+		Offset: 0, 0, 16
 	stand:
 		Facings: 8
 		ShadowStart: 307
@@ -328,6 +334,7 @@ medic:
 jumpjet:
 	Defaults:
 		Tick: 80
+		Offset: 0, 0, 16
 	stand:
 		Facings: 8
 		ShadowStart: 451
@@ -389,6 +396,7 @@ jumpjet:
 weedguy:
 	Defaults: weed
 		Tick: 80
+		Offset: 0, 0, 16
 	stand:
 		Facings: 8
 		ShadowStart: 202
@@ -455,6 +463,7 @@ weedguy:
 doggie:
 	Defaults:
 		Tick: 80
+		Offset: 0, 0, 16
 	stand:
 		Facings: 8
 		ShadowStart: 119
@@ -509,23 +518,27 @@ vissml:
 		Length: 90
 		ShadowStart: 90
 		Tick: 80
+		Offset: 0, 0, 16
 
 vislrg:
 	idle:
 		Length: 90
 		ShadowStart: 90
 		Tick: 80
+		Offset: 0, 0, 16
 	muzzle: vislgatk # TODO: unused
 		Length: 5
 		Facings: 8
 		ShadowStart: 40
 		Tick: 80
+		Offset: 0, 0, 16
 
 flameguy:
 	Defaults:
 		Facings: 8
 		Tick: 80
 		ShadowStart: 148
+		Offset: 0, 0, 16
 	idle:
 	stand:
 	run:

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -1,6 +1,7 @@
 overlay:
 	Defaults: place
-		Offset: 0, -12
+		Offset: 0, -12, 1
+		ZRamp: 1
 	build-valid-snow:
 	build-valid-temperate:
 	build-invalid:
@@ -9,7 +10,8 @@ overlay:
 
 editor-overlay:
 	Defaults: place
-		Offset: 0, -12
+		Offset: 0, -12, 1
+		ZRamp: 1
 	copy:
 	paste:
 		Start: 1
@@ -67,14 +69,17 @@ rank:
 mpspawn:
 	idle:
 		Length: *
+		ZRamp: 1
 
 waypoint:
 	idle:
 		Length: *
+		ZRamp: 1
 
 camera:
 	idle:
 		Length: *
+		ZRamp: 1
 
 clock:
 	idle: gclock2
@@ -281,6 +286,8 @@ moveflsh:
 		Length: *
 		Tick: 30
 		ZOffset: 2047
+		Offset: 0, 0, 48
+		ZRamp: 1
 
 wake:
 	idle: wake2

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -128,9 +128,12 @@ explosion:
 	Defaults:
 		Length: *
 		ZOffset: 511
+		Offset: 0, 0, 24
 	building: twlt070
+		Offset: 0, 0, 36
 	ionring: ring1
 		BlendMode: Additive
+		ZRamp: 1
 		Tick: 100
 	ionbeam: ionbeam
 		Offset: 0,-60
@@ -164,16 +167,20 @@ explosion:
 		Tick: 100
 	pulse_explosion: pulsefx2
 		BlendMode: Additive
+		ZRamp: 1
 		Tick: 80
 	small_watersplash: h2o_exp2
 	large_watersplash: h2o_exp1
+		Offset: 0, 0, 39
 	water_piff: w_piff
 	water_piffs: w_piffs
 	piff: piff
 	piffs: piffpiff
 	small_explosion: explosml
 	medium_explosion: explomed
+		Offset: 0, 0, 27
 	large_explosion: explolrg
+		Offset: 0, 0, 31
 	tiny_bang: s_bang16
 	small_bang: s_bang24
 	medium_bang: s_bang34
@@ -182,20 +189,26 @@ explosion:
 	small_brnl: s_brnl30
 	medium_brnl: s_brnl40
 	large_brnl: s_brnl58
+		Offset: 0, 0, 30
 	tiny_tumu: s_tumu22
 	small_tumu: s_tumu30
 	medium_tumu: s_tumu42
 	large_tumu: s_tumu60
+		Offset: 0, 0, 31
 	tiny_clsn: s_clsn16
 	small_clsn: s_clsn22
 	medium_clsn: s_clsn30
 	large_clsn: s_clsn42
 	verylarge_clsn: s_clsn58
+		Offset: 0, 0, 30
 	tiny_twlt: twlt026
 	small_twlt: twlt036
 	medium_twlt: twlt050
+		Offset: 0, 0, 26
 	large_twlt: twlt070
+		Offset: 0, 0, 36
 	verylarge_twlt: twlt100
+		Offset: 0, 0, 51
 	tiny_grey_explosion: xgrysml1
 	small_grey_explosion: xgrysml2
 	medium_grey_explosion: xgrymed1

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -294,13 +294,15 @@ wake:
 		Length: *
 		Tick: 180
 		ZOffset: -512
+		ZRamp: 1
+		Offset: 0, 0, 1
 
 resources:
 	Defaults:
 		UseTilesetExtension: true
 		Length: 12
 		ShadowStart: 12
-		Offset: 0, -12
+		Offset: 0, -12, 1.5
 		ZRamp: 1
 	tib01: tib01
 	tib02: tib02

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -45,7 +45,7 @@ crate:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
-		Offset: 0, -10
+		Offset: 0, -10, 10
 
 crate-effects:
 	Defaults:

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -602,7 +602,8 @@ tracks16:
 
 ^tuntop:
 	idle:
-		Offset: 0, -13
+		Offset: 0, -13, 42
+		ZRamp: 1
 		UseTilesetExtension: true
 		ShadowStart: 1
 

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -333,7 +333,8 @@ shroud:
 smallscorches:
 	Defaults:
 		UseTilesetExtension: true
-		Offset: 0, -12
+		Offset: 0, -12, 1
+		ZRamp: 1
 	sc1: burnt01
 	sc2: burnt02
 	sc3: burnt03
@@ -344,7 +345,8 @@ smallscorches:
 mediumscorches:
 	Defaults:
 		UseTilesetExtension: true
-		Offset: 0, -18
+		Offset: 0, -18, 1
+		ZRamp: 1
 	sc7: burnt07
 	sc8: burnt08
 	sc9: burnt09
@@ -353,14 +355,16 @@ mediumscorches:
 largescorches:
 	Defaults:
 		UseTilesetExtension: true
-		Offset: 0, -24
+		Offset: 0, -24, 1
+		ZRamp: 1
 	sc11: burnt11
 	sc12: burnt12
 
 smallcraters:
 	Defaults:
 		UseTilesetExtension: true
-		Offset: 0, -12
+		Offset: 0, -12, 1
+		ZRamp: 1
 	cr1: crater01
 	cr2: crater02
 	cr3: crater03
@@ -371,7 +375,8 @@ smallcraters:
 mediumcraters:
 	Defaults:
 		UseTilesetExtension: true
-		Offset: 0, -12
+		Offset: 0, -12, 1
+		ZRamp: 1
 	cr7: crater07
 	cr8: crater08
 	cr9: crater09
@@ -380,7 +385,8 @@ mediumcraters:
 largecraters:
 	Defaults:
 		UseTilesetExtension: true
-		Offset: 0, -24
+		Offset: 0, -24, 1
+		ZRamp: 1
 	cr11: crater11
 	cr12: crater12
 

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -43,7 +43,7 @@ gacnst:
 		Length: 10
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 37
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -101,7 +101,7 @@ gapowr:
 		ShadowStart: 20
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 25
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -154,7 +154,7 @@ gapile:
 		ShadowStart: 20
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 25
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -252,7 +252,7 @@ gaweap:
 		-DepthSprite:
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 23
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -288,13 +288,13 @@ napowr:
 		ShadowStart: 19
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 25
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
 		-DepthSprite:
 	icon: npwricon
-		Offset: 0, 0
+		Offset: 0, 0, 25
 		UseTilesetCode: false
 		-DepthSprite:
 
@@ -325,7 +325,7 @@ naapwr:
 		ShadowStart: 19
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 31
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -371,7 +371,7 @@ nahand:
 		ShadowStart: 15
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 31
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -454,7 +454,7 @@ naweap:
 		-DepthSprite:
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 31
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -490,7 +490,7 @@ naradr:
 		ShadowStart: 20
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 25
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -525,7 +525,7 @@ natech:
 		ShadowStart: 18
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 25
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -562,7 +562,7 @@ natmpl:
 		ShadowStart: 17
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 43
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -600,7 +600,7 @@ garadr:
 		ShadowStart: 20
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 25
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -637,7 +637,7 @@ gatech:
 		ShadowStart: 20
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 31
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -719,7 +719,7 @@ gagate_a:
 		Length: 9
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 25
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -763,7 +763,7 @@ gagate_b:
 		Length: 9
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 25
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -812,7 +812,7 @@ nagate_a:
 		Length: 6
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 25
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -857,7 +857,7 @@ nagate_b:
 		Length: 6
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 25
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -900,7 +900,7 @@ gaicbm:
 		ShadowStart: 4
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 13
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -925,7 +925,7 @@ gaarty:
 		UseTilesetCode: false
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 13
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -960,7 +960,7 @@ naobel:
 		ShadowStart: 19
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 25
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -989,7 +989,7 @@ nalasr:
 		ShadowStart: 21
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 13
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -1026,7 +1026,7 @@ nasam:
 		Offset: 0, -12, 12
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 2
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -1055,7 +1055,7 @@ napuls.gdi:
 		ShadowStart: 20
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 25
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -1086,7 +1086,7 @@ napuls.nod:
 		ShadowStart: 20
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 25
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -1123,7 +1123,7 @@ nastlh:
 		ShadowStart: 20
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 31
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -1197,7 +1197,7 @@ gactwr:
 		UseTilesetCode: false
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 13
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -1276,7 +1276,7 @@ gahpad:
 		DepthSprite: isodepth.shp
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 2
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -1341,7 +1341,7 @@ nahpad:
 		DepthSprite: isodepth.shp
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 2
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -1400,7 +1400,7 @@ proc.gdi:
 		-DepthSprite:
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 21
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -1461,7 +1461,7 @@ proc.nod:
 		-DepthSprite:
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 21
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -1526,7 +1526,7 @@ nawast:
 		Offset: 0, -36, 3
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 25
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -1573,7 +1573,7 @@ gasilo.gdi:
 		ShadowStart: 20
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 25
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -1620,7 +1620,7 @@ gasilo.nod:
 		ShadowStart: 20
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 25
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -1687,7 +1687,7 @@ gadept.gdi:
 		ShadowStart: 10
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 37
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -1754,7 +1754,7 @@ gadept.nod:
 		ShadowStart: 10
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 37
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -1794,7 +1794,7 @@ namisl:
 		Tick: 80
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 25
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive
@@ -1863,7 +1863,7 @@ gaplug:
 		ShadowStart: 17
 	emp-overlay: emp_fx01
 		Length: *
-		Offset: 0, 0
+		Offset: 0, 0, 31
 		UseTilesetCode: false
 		ZOffset: 512
 		BlendMode: Additive

--- a/mods/ts/sequences/trees.yaml
+++ b/mods/ts/sequences/trees.yaml
@@ -116,3 +116,4 @@ veinhole:
 		ShadowStart: 1
 		UseTilesetExtension: true
 		Offset: 0,-60
+		ZRamp: 1

--- a/mods/ts/sequences/trees.yaml
+++ b/mods/ts/sequences/trees.yaml
@@ -1,7 +1,7 @@
 ^tibtree:
 	Defaults:
 		UseTilesetExtension: true
-		Offset: 0, -12
+		Offset: 0, -12, 12
 	idle:
 		ShadowStart: 11
 	active:
@@ -21,7 +21,7 @@ tibtre03:
 
 bigblue:
 	Defaults:
-		Offset: 0, -12
+		Offset: 0, -12, 12
 	idle: bigblue2
 		ShadowStart: 10
 	active: bigblue2
@@ -34,7 +34,7 @@ bigblue:
 	idle:
 		ShadowStart: 1
 		UseTilesetExtension: true
-		Offset: 0, -12
+		Offset: 0, -12, 12
 
 tree01:
 	Inherits: ^tree

--- a/mods/ts/sequences/vehicles.yaml
+++ b/mods/ts/sequences/vehicles.yaml
@@ -115,15 +115,15 @@ ttnk:
 	Inherits: ^VehicleOverlays
 	idle: gatick
 		ShadowStart: 3
-		Offset: 0, -12
+		Offset: 0, -12, 12
 	damaged-idle: gatick
 		Start: 1
 		ShadowStart: 4
-		Offset: 0, -12
+		Offset: 0, -12, 12
 	make: gatickmk
 		Length: 24
 		ShadowStart: 24
-		Offset: 0, -12
+		Offset: 0, -12, 12
 	muzzle: gunfire
 		Length: *
 	icon: tickicon

--- a/mods/ts/sequences/vehicles.yaml
+++ b/mods/ts/sequences/vehicles.yaml
@@ -1,5 +1,6 @@
 ^VehicleOverlays:
 	emp-overlay: emp_fx01
+		Offset: 0, 0, 24
 		Length: *
 		BlendMode: Additive
 	veins: veinatac

--- a/mods/ts/sequences/vehicles.yaml
+++ b/mods/ts/sequences/vehicles.yaml
@@ -138,13 +138,16 @@ mmch:
 		Facings: -8
 		Stride: 15
 		ShadowStart: 152
+		Offset: 0, 0, 12
 	run:
 		Length: 15
 		Facings: -8
 		ShadowStart: 152
+		Offset: 0, 0, 12
 	turret:
 		Start: 120
 		Facings: -32
+		Offset: 0, 0, 12
 	muzzle: gunfire
 		Length: *
 	icon: mmchicon

--- a/mods/ts/sequences/vehicles.yaml
+++ b/mods/ts/sequences/vehicles.yaml
@@ -24,12 +24,14 @@ harv.gdi:
 	Inherits: ^VehicleOverlays
 	harvest: harvestr
 		Length: *
+		ZRamp: 1
 	icon: sidebar-gdi|harvicon
 
 harv.nod:
 	Inherits: ^VehicleOverlays
 	harvest: harvestr
 		Length: *
+		ZRamp: 1
 	icon: sidebar-nod|harvicon
 
 hvr:


### PR DESCRIPTION
This PR sets up the depth metadata for the remaining cases that I could find, and sets `EnableDepthBuffer: True` for good.

There are probably more cases that i've forgotten, but they will be easier to find, test, and fix with the new rendering method enabled.

Obligatory promo shot:
![ts-teaser](https://cloud.githubusercontent.com/assets/167819/18029248/ce01ae3e-6c8a-11e6-8e0d-f25a63e47e9b.png)
