### PR TITLE
Fix the positioning of the mute label in the TD music player

### DIFF
--- a/mods/cnc/chrome/lobby-music.yaml
+++ b/mods/cnc/chrome/lobby-music.yaml
@@ -32,7 +32,7 @@ Container@LOBBY_MUSIC_BIN:
 			Height: PARENT_BOTTOM
 			Children:
 				Label@MUTE_LABEL:
-					X: 25
+					X: 60
 					Y: 10
 					Width: 300
 					Height: 20

--- a/mods/cnc/chrome/music.yaml
+++ b/mods/cnc/chrome/music.yaml
@@ -193,8 +193,8 @@ Container@MUSIC_PANEL:
 			Height: 35
 			Text: Back
 		Label@MUTE_LABEL:
-			X: 165
-			Y: 399
+			X: 100
+			Y: 337
 			Width: 300
 			Height: 20
 			Font: Small

--- a/mods/ra/chrome/lobby-music.yaml
+++ b/mods/ra/chrome/lobby-music.yaml
@@ -32,7 +32,7 @@ Container@LOBBY_MUSIC_BIN:
 			Height: PARENT_BOTTOM
 			Children:
 				Label@MUTE_LABEL:
-					X: 25
+					X: 45
 					Y: 10
 					Width: 300
 					Height: 20


### PR DESCRIPTION
Fixes #11894.

![tdmute2](https://cloud.githubusercontent.com/assets/7704140/18032930/4ff09cee-6d16-11e6-8637-9262871f7f7f.png)

For reference, the outdated look:
![tdmute](https://cloud.githubusercontent.com/assets/7704140/18029662/5a92f7fa-6c9e-11e6-9314-a6954196e6aa.png)
