### PR TITLE
[RA] Tweak damage vs Concrete with flamers and E3.

### DIFF
--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -61,7 +61,7 @@ Dragon:
 			None: 10
 			Wood: 75
 			Light: 35
-			Concrete: 20
+			Concrete: 50
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -17,7 +17,7 @@ FireballLauncher:
 			Wood: 50
 			Light: 60
 			Heavy: 25
-			Concrete: 50
+			Concrete: 20
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
@@ -47,7 +47,7 @@ Flamer:
 			Wood: 100
 			Light: 60
 			Heavy: 25
-			Concrete: 50
+			Concrete: 20
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch


### PR DESCRIPTION
- Rocket Soldier: 50%, up from 20%
- Flamethrower: 20%, down from 50%
- Flame Tower: 20%, down from 50%

Comparison with peer units/structures from current release - Destroying 1 cell Wall:

Grenadier: 7 grenades (21s)
Rocket Soldier: 50 shots (1m 38s) (!)
Flame Thrower: 9 shots (22s) (!)
Tesla Trooper: 12 zaps (31s)

Turret: 17 shots (20s)
Tesla Coil: 2 bursts (6 zaps) (7s)
Flame Tower: 3,5 bursts/7 fireballs (10s) (!)

Tesla tank: 5 zaps (19s)
Medium tank: 25 shots (49s)
Heavy tank: 13 shots (36s)

These tweaks originally came from FramLimiter's balance test maps registering some 900 downloads since May this year http://resource.openra.net/maps/uploader/935/. On these maps Wall HP was additionally nerfed to 300HP from 500HP with buffs specifically vs tesla weapons. I adopted the _damage vs_ tweaks for my own round of balance maps, including the latest batch of maps v1.3 still available on the resource site http://resource.openra.net/maps/uploader/78/page/3/ with some 800 downloads from late July.

The pull request is a conservative take from the feedback and experiences drawn from the playtests.

 In short, the Flame Thrower and Tower does an unreasonable amount of damage compared to their peers. We've given a pass on the Grenadier because it functions as a disposable utility unit that doesn't add to any army composition in the game. 

Buffing Rocket Soldier damage vs Walls by a factor of 2,5 isn't overall a gamechanger given the default damaga value but will help Allies gain access to walled off areas early game (compared to Grenadiers) and give armies of _both_ factions (Soviet having early access to Flamethrowers) an equal chance at breaching against Wall spamming with Rocket Soldiers as part of any standard army composition.
