### PR TITLE
Fixed transparency for LaserZap

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		public readonly bool UsePlayerColor = false;
 
-		[Desc("Laser color in (A,)R,G,B.")]
+		[Desc("Laser color.")]
 		public readonly Color Color = Color.Red;
 
 		[Desc("Impact animation.")]

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			if (ticks < info.BeamDuration)
 			{
-				var rc = Color.FromArgb((info.BeamDuration - ticks) * 255 / info.BeamDuration, color);
+				var rc = Color.FromArgb((info.BeamDuration - ticks) * color.A / info.BeamDuration, color);
 				yield return new BeamRenderable(args.Source, info.ZOffset, target - args.Source, info.Shape, info.Width, rc);
 			}
 

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -195,6 +195,7 @@ TurretLaserFire:
 		Width: 50
 		BeamDuration: 5
 		ZOffset: 2047
+		Color: FF000045
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 30


### PR DESCRIPTION
This now allows to set initial transparency values, but still does the fade-out effect. The documentation tag was out-dated. We may be better off explaining value types at a separate place instead of individually.
