### PR TITLE
Disable modifiers on TS alpha palette.

### DIFF
--- a/mods/ts/rules/palettes.yaml
+++ b/mods/ts/rules/palettes.yaml
@@ -57,6 +57,7 @@
 	PaletteFromFile@alpha:
 		Name: alpha
 		Filename: alpha.pal
+		AllowModifiers: false
 	PaletteFromRGBA@shadow:
 		Name: shadow
 		R: 0


### PR DESCRIPTION
This fixes the black rectangle that appears around lightposts when the map fades in or out from black.
