### PR TITLE
Remove the bogus Health property from CAMERA

### DIFF
--- a/mods/cnc/rules/misc.yaml
+++ b/mods/cnc/rules/misc.yaml
@@ -73,8 +73,6 @@ CAMERA:
 		QuantizedFacings: 1
 	Immobile:
 		OccupiesSpace: false
-	Health:
-		HP: 1000
 	RevealsShroud:
 		Range: 10c0
 		Type: CenterPosition

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -164,8 +164,6 @@ camera:
 		QuantizedFacings: 1
 	Immobile:
 		OccupiesSpace: false
-	Health:
-		HP: 1000
 	RevealsShroud:
 		Range: 6c768
 		Type: CenterPosition

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -135,8 +135,6 @@ CAMERA:
 	AlwaysVisible:
 	Immobile:
 		OccupiesSpace: false
-	Health:
-		HP: 1000
 	RevealsShroud:
 		Range: 10c0
 		Type: CenterPosition

--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -45,8 +45,6 @@ CAMERA:
 		QuantizedFacings: 1
 	Immobile:
 		OccupiesSpace: false
-	Health:
-		HP: 1000
 	RevealsShroud:
 		Range: 10c0
 		Type: CenterPosition


### PR DESCRIPTION
It just doesn't make sense and does not appear to be used anyway.

Removing this just fixes bugs, like for example that yak's try to target them in our lua missions:
`camera 471 is an invalid target for yak 473!`
(This can cause the game to freeze when a player has only cameras left.)
