### PR TITLE
Fix NRE in SmudgeLayer.AddSmudge

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -142,6 +142,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (Game.CosmeticRandom.Next(0, 100) <= Info.SmokePercentage)
 				world.AddFrameEndTask(w => w.Add(new SpriteEffect(world.Map.CenterOfCell(loc), w, Info.SmokeType, Info.SmokeSequence, Info.SmokePalette)));
 
+			// A null Sprite indicates a deleted smudge.
 			if ((!dirty.ContainsKey(loc) || dirty[loc].Sprite == null) && !tiles.ContainsKey(loc))
 			{
 				// No smudge; create a new one
@@ -151,6 +152,7 @@ namespace OpenRA.Mods.Common.Traits
 			else
 			{
 				// Existing smudge; make it deeper
+				// A null Sprite indicates a deleted smudge.
 				var tile = dirty.ContainsKey(loc) && dirty[loc].Sprite != null ? dirty[loc] : tiles[loc];
 				var maxDepth = smudges[tile.Type].Length;
 				if (tile.Depth < maxDepth - 1)
@@ -167,6 +169,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var tile = dirty.ContainsKey(loc) ? dirty[loc] : new Smudge();
 
+			// Setting Sprite to null to indicate a deleted smudge.
 			tile.Sprite = null;
 			dirty[loc] = tile;
 		}
@@ -178,6 +181,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				if (!self.World.FogObscures(kv.Key))
 				{
+					// A null Sprite indicates a deleted smudge.
 					if (kv.Value.Sprite == null)
 						tiles.Remove(kv.Key);
 					else

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -151,7 +151,7 @@ namespace OpenRA.Mods.Common.Traits
 			else
 			{
 				// Existing smudge; make it deeper
-				var tile = dirty.ContainsKey(loc) ? dirty[loc] : tiles[loc];
+				var tile = dirty.ContainsKey(loc) && dirty[loc].Sprite != null ? dirty[loc] : tiles[loc];
 				var maxDepth = smudges[tile.Type].Length;
 				if (tile.Depth < maxDepth - 1)
 				{


### PR DESCRIPTION
The cause for this issue was indeed a regression from #11721.

It turns out that there may be situations\* where the else-branch (the "there already is a smudge here"-case) in `AddSmudge` is taken even though there isn't a smudge (when the location in question is contained in both the `dirty` and `tiles` arrays, but `RemoveSmudges` ran previously for the same location).

In that case, the `Tile` field is null, but gets referenced in that else-branch, producing the NRE.

There are two possible ways to fix this. The first is to set the `Tile` field to a random entry in `RemoveSmudges`, the better way is to check the smudge for the "deleted" marker, which is a `Sprite` field set to `null`.

Fixes #11922.

*Didn't delve too deeply into it, but in my replay a building was sold while oil barrels around it were being blown up, so I assume it's some kind of race condition where `RemoveSmudge` and `AddSmudge` run during the same tick for the same location.
