### PR TITLE
[RA] Tweak and buff Light Tank's 25mm

### DIFF
--- a/mods/ra/weapons/largecaliber.yaml
+++ b/mods/ra/weapons/largecaliber.yaml
@@ -1,5 +1,5 @@
 25mm:
-	ReloadDelay: 13
+	ReloadDelay: 26
 	Range: 4c0
 	Report: cannon2.aud
 	Projectile: Bullet
@@ -7,11 +7,12 @@
 		Image: 50CAL
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 16
+		Damage: 32
 		Versus:
 			None: 30
 			Wood: 40
-			Heavy: 40
+			Light: 120
+			Heavy: 45
 			Concrete: 30
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@3EffGround: CreateEffect


### PR DESCRIPTION
- Damage vs Heavy Armor: +12.5%
- Damage vs Light Armor +20%
- Rate of fire halved, damage doubled

Taking advantage from the past months' map playtesting I'd like to propose these Light Tank changes for the next playtest.

Following the previous release buff of +1 vision range the Allies has gotten a somewhat useful early-game frontliner providing line-of-sight and a bit of damage soak for the infantry. The Light Tank still has a short expiration date due to its low health and abysmal damage output, as it gets dwarfed as soon as players build up their rocket squads while teching up to either Service Depot or Radar Dome.

The change in damage output was specifically aimed towards allowing Light Tanks to do better job at fighting and zoning out light vehicles and flanking undefended artillery/V2's as well as undeployed MCV's (as with the Mobile Flak). Experience demonstrated that not only was this accomplished to a certain degree but also avoided certain pitfalls such as swarm killing Ore Harvesters due to +12.5% Heavy Armor damage. The Light Tank is still phased out during games but a bit slower and does widens Allies' tech choice a little bit by using Light Tanks as support while teching up to Radar Dome before the Service Depot.

The rate of fire change is something I've always loved to see changed regardless, making the tank feel less like a pea shooter. I understand this was due to better target faster units such as Rangers, Mobile Flaks and APCs but the gain is pretty negligable. Even more so with the proposed damage buffs.
