### PR TITLE
Rename stand3 to liedown

### DIFF
--- a/mods/d2k/sequences/infantry.yaml
+++ b/mods/d2k/sequences/infantry.yaml
@@ -32,7 +32,7 @@ light_inf:
 		Facings: -8
 		Transpose: true
 		Tick: 110
-	standup-0: DATA.R8
+	standup: DATA.R8
 		Start: 302
 		Facings: -8
 		Transpose: true
@@ -101,7 +101,7 @@ trooper:
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	standup-0: DATA.R8
+	standup: DATA.R8
 		Start: 554
 		Facings: -8
 		Transpose: true
@@ -154,7 +154,7 @@ engineer:
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	standup-0: DATA.R8
+	standup: DATA.R8
 		Start: 1262
 		Facings: -8
 		Transpose: true
@@ -213,7 +213,7 @@ thumper:
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	standup-0: DATA.R8
+	standup: DATA.R8
 		Start: 1462
 		Facings: -8
 		Transpose: true
@@ -312,7 +312,7 @@ fremen:
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	standup-0: DATA.R8
+	standup: DATA.R8
 		Start: 790
 		Facings: -8
 		Transpose: true
@@ -376,7 +376,7 @@ saboteur:
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	standup-0: DATA.R8
+	standup: DATA.R8
 		Start: 2245
 		Facings: -8
 		Transpose: true
@@ -442,7 +442,7 @@ sardaukar:
 		Facings: -8
 		Transpose: true
 		Tick: 120
-	standup-0: DATA.R8
+	standup: DATA.R8
 		Start: 1026
 		Facings: -8
 		Transpose: true

--- a/mods/ra/sequences/infantry.yaml
+++ b/mods/ra/sequences/infantry.yaml
@@ -30,7 +30,7 @@ e1:
 		Start: 128
 		Length: 2
 		Facings: 8
-	standup-0:
+	standup:
 		Start: 176
 		Length: 2
 		Facings: 8
@@ -868,7 +868,7 @@ gnrl:
 		Start: 104
 		Length: 4
 		Facings: 8
-	standup-0:
+	standup:
 		Start: 136
 		Length: 2
 		Facings: 8

--- a/mods/ra/sequences/infantry.yaml
+++ b/mods/ra/sequences/infantry.yaml
@@ -4,9 +4,6 @@ e1:
 	stand2:
 		Start: 8
 		Facings: 8
-	stand3:
-		Start: 128
-		Length: 16
 	run:
 		Start: 16
 		Length: 6
@@ -29,6 +26,10 @@ e1:
 		Length: 4
 		Facings: 8
 		Tick: 100
+	liedown:
+		Start: 128
+		Length: 2
+		Facings: 8
 	standup-0:
 		Start: 176
 		Length: 2
@@ -94,9 +95,6 @@ sniper:
 		Start: 64
 		Length: 16
 		Facings: 8
-	stand3:
-		Start: 192
-		Length: 16
 	prone-stand:
 		Start: 208
 		Stride: 4
@@ -110,6 +108,10 @@ sniper:
 		Length: 4
 		Facings: 8
 		Tick: 100
+	liedown:
+		Start: 192
+		Length: 2
+		Facings: 8
 	standup:
 		Start: 240
 		Length: 2
@@ -923,9 +925,6 @@ shok:
 		Start: 64
 		Length: 16
 		Facings: 8
-	stand3:
-		Start: 192
-		Length: 16
 	prone-stand:
 		Start: 208
 		Stride: 4
@@ -939,6 +938,10 @@ shok:
 		Length: 4
 		Facings: 8
 		Tick: 120
+	liedown:
+		Start: 192
+		Length: 2
+		Facings: 8
 	standup:
 		Start: 240
 		Length: 2

--- a/mods/ts/sequences/infantry.yaml
+++ b/mods/ts/sequences/infantry.yaml
@@ -44,7 +44,7 @@
 		ShadowStart: 451
 		Tick: 800
 		ZOffset: -511
-	standup-0:
+	standup:
 		Start: 260
 		Length: 2
 		Facings: 8
@@ -318,7 +318,7 @@ medic:
 		ShadowStart: 451
 		Tick: 800
 		ZOffset: -511
-	standup-0:
+	standup:
 		Start: 260
 		Length: 2
 		Facings: 8
@@ -384,7 +384,7 @@ jumpjet:
 		Length: 6
 		Facings: 8
 		ShadowStart: 663
-	standup-0:
+	standup:
 		Start: 260
 		Length: 2
 		Facings: 8
@@ -413,7 +413,7 @@ weedguy:
 		Start: 56
 		Facings: 8
 		ShadowStart: 258
-	standup-0:
+	standup:
 		Start: 112
 		Length: 2
 		Facings: 8


### PR DESCRIPTION
`liedown` appears to be what `stand3` is.
(I also moved `liedown` next to/right above `standup`.)

Closes #11703.
