### PR TITLE
Rename all "medium" difficulties to "normal"

### DIFF
--- a/mods/ra/maps/intervention/intervention.lua
+++ b/mods/ra/maps/intervention/intervention.lua
@@ -11,7 +11,7 @@ BeachheadTrigger =
 
 Difficulty = Map.LobbyOption("difficulty")
 
-if Difficulty == "medium" then
+if Difficulty == "normal" then
 	BaseRaidInterval = DateTime.Minutes(3)
 	BaseFrontAttackInterval = DateTime.Minutes(3) + DateTime.Seconds(30)
 	BaseRearAttackInterval = DateTime.Minutes(8)

--- a/mods/ra/maps/intervention/rules.yaml
+++ b/mods/ra/maps/intervention/rules.yaml
@@ -11,9 +11,9 @@ World:
 		ID: difficulty
 		Label: Difficulty
 		Values:
-			medium: Medium
+			normal: Normal
 			hard: Hard
-		Default: medium
+		Default: normal
 
 CAMERA:
 	RevealsShroud:

--- a/mods/ra/maps/soviet-04b/soviet04b.lua
+++ b/mods/ra/maps/soviet-04b/soviet04b.lua
@@ -68,7 +68,7 @@ RunInitialActivities = function()
 	Trigger.AfterDelay(DateTime.Minutes(1), ProduceInfantry)
 	Trigger.AfterDelay(DateTime.Minutes(2), ProduceArmor)
 
-	if Map.LobbyOption("difficulty") == "hard" or Map.LobbyOption("difficulty") == "medium" then
+	if Map.LobbyOption("difficulty") == "hard" or Map.LobbyOption("difficulty") == "normal" then
 		Trigger.AfterDelay(DateTime.Seconds(5), ReinfInf)
 	end
 	Trigger.AfterDelay(DateTime.Minutes(1), ReinfInf)
@@ -95,7 +95,7 @@ Tick = function()
 		RCheck = false
 		if Map.LobbyOption("difficulty") == "hard" then
 			Trigger.AfterDelay(DateTime.Seconds(150), ReinfArmor)
-		elseif Map.LobbyOption("difficulty") == "medium" then
+		elseif Map.LobbyOption("difficulty") == "normal" then
 			Trigger.AfterDelay(DateTime.Minutes(5), ReinfArmor)
 		else
 			Trigger.AfterDelay(DateTime.Minutes(8), ReinfArmor)

--- a/mods/ra/maps/soviet-05/soviet05.lua
+++ b/mods/ra/maps/soviet-05/soviet05.lua
@@ -57,7 +57,7 @@ RunInitialActivities = function()
 	ProduceInfantry()
 	Trigger.AfterDelay(DateTime.Minutes(2), ProduceShips)
 
-	if Map.LobbyOption("difficulty") == "hard" or Map.LobbyOption("difficulty") == "medium" then
+	if Map.LobbyOption("difficulty") == "hard" or Map.LobbyOption("difficulty") == "normal" then
 		Trigger.AfterDelay(DateTime.Seconds(25), ReinfInf)
 	end
 	Trigger.AfterDelay(DateTime.Minutes(2), ReinfInf)
@@ -172,7 +172,7 @@ Tick = function()
 		RCheck = true
 		if Map.LobbyOption("difficulty") == "easy" and ReinfCheck then
 			Trigger.AfterDelay(DateTime.Minutes(6), ReinfArmor)
-		elseif Map.LobbyOption("difficulty") == "medium" then
+		elseif Map.LobbyOption("difficulty") == "normal" then
 			Trigger.AfterDelay(DateTime.Minutes(4), ReinfArmor)
 		else
 			Trigger.AfterDelay(DateTime.Minutes(3), ReinfArmor)

--- a/mods/ra/maps/survival01/rules.yaml
+++ b/mods/ra/maps/survival01/rules.yaml
@@ -12,7 +12,7 @@ World:
 		Label: Difficulty
 		Values:
 			easy: Easy
-			medium: Medium
+			normal: Normal
 			hard: Hard
 		Default: easy
 

--- a/mods/ra/maps/survival01/survival01.lua
+++ b/mods/ra/maps/survival01/survival01.lua
@@ -8,7 +8,7 @@ if Difficulty == "easy" then
 	DamageModifier = 0.5
 	LongBowReinforcements = { "heli", "heli" }
 	ParadropArtillery = true
-elseif Difficulty == "medium" then
+elseif Difficulty == "normal" then
 	AttackAtFrameIncrement = DateTime.Seconds(18)
 	AttackAtFrameIncrementInf = DateTime.Seconds(12)
 	TimerTicks = DateTime.Minutes(20)


### PR DESCRIPTION
Fix #11322.

I think the naming in `soviet04b` and `soviet05` was just a copy and paste error.
As those two don't define `medium` as difficulty on bleed, I consider this as an actual bug fix and would like to sneak it into the next release.
