### PR TITLE
Fix an inverted check in SupportPowerChargeBar

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/SupportPowerChargeBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SupportPowerChargeBar.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				return 0;
 
 			var viewer = self.World.RenderPlayer ?? self.World.LocalPlayer;
-			if (viewer != null && info.DisplayStances.HasStance(self.Owner.Stances[viewer]))
+			if (viewer != null && !info.DisplayStances.HasStance(self.Owner.Stances[viewer]))
 				return 0;
 
 			return 1 - (float)power.RemainingTime / power.TotalTime;


### PR DESCRIPTION
It showed the charge bar to enemies, but not allies.
You could also notice it missing when selecting the "All Players" view in replays.
