### PR TITLE
Fix aircrafts trying to fetch the reservation of dead host actors

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/ResupplyAircraft.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ResupplyAircraft.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Activities
 				return ActivityUtils.SequenceActivities(
 					aircraft.GetResupplyActivities(host)
 					.Append(new CallFunc(() => aircraft.UnReserve()))
-					.Append(new WaitFor(() => NextActivity != null || Reservable.IsReserved(host)))
+					.Append(new WaitFor(() => NextActivity != null || host.IsDead || Reservable.IsReserved(host)))
 					.Append(new TakeOff(self))
 					.Append(NextActivity).ToArray());
 


### PR DESCRIPTION
Fixes #5671.

Also fixes crashes like:

```
Shattered Paradise Mod at Version {DEV_VERSION}
on map e8173880b4155082ff803a369e36c8d847ca6b88 (No where to run by Westwood Studios).
Date: 2016-08-31 22:21:11Z
Operating System: Windows (Microsoft Windows NT 6.2.9200.0)
Runtime Version: .NET CLR 4.0.30319.42000
Exception of type `System.InvalidOperationException`: Attempted to get trait from destroyed object (nahpad 638 (not in world))
   at OpenRA.TraitDictionary.CheckDestroyed(Actor actor) in \SP 20160829\OpenRA.Game\TraitDictionary.cs:Line 83.
   at OpenRA.TraitDictionary.GetOrDefault[T](Actor actor) in \SP 20160829\OpenRA.Game\TraitDictionary.cs:Line 94.
   at OpenRA.Actor.TraitOrDefault[T]() in \SP 20160829\OpenRA.Game\Actor.cs:Line 252.
   at OpenRA.Mods.Common.Traits.Reservable.IsReserved(Actor a)
   at OpenRA.Mods.Common.Activities.ResupplyAircraft.<>c__DisplayClass2.<Tick>b__1()
   at OpenRA.Mods.Common.Activities.WaitFor.Tick(Actor self)
   at OpenRA.Traits.ActivityUtils.RunActivity(Actor self, Activity act) in \SP 20160829\OpenRA.Game\Traits\ActivityUtils.cs:Line 37.
   at OpenRA.Actor.Tick() in \SP 20160829\OpenRA.Game\Actor.cs:Line 164.
   at OpenRA.World.Tick() in \SP 20160829\OpenRA.Game\World.cs:Line 339.
   at OpenRA.Game.InnerLogicTick(OrderManager orderManager) in \SP 20160829\OpenRA.Game\Game.cs:Line 561.
   at OpenRA.Game.LogicTick() in \SP 20160829\OpenRA.Game\Game.cs:Line 586.
   at OpenRA.Game.Loop() in \SP 20160829\OpenRA.Game\Game.cs:Line 713.
   at OpenRA.Game.Run() in \SP 20160829\OpenRA.Game\Game.cs:Line 753.
   at OpenRA.Program.Run(String[] args) in \SP 20160829\OpenRA.Game\Support\Program.cs:Line 119.
   at OpenRA.Program.Main(String[] args) in \SP 20160829\OpenRA.Game\Support\Program.cs:Line 40.
```
