### PR TITLE
Rework external capture -> production interaction

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
@@ -27,11 +27,13 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new BaseProvider(init.Self, this); }
 	}
 
-	public class BaseProvider : ITick, IRenderAboveShroudWhenSelected, ISelectionBar
+	public class BaseProvider : ITick, INotifyCreated, IRenderAboveShroudWhenSelected, ISelectionBar
 	{
 		public readonly BaseProviderInfo Info;
 		readonly DeveloperMode devMode;
 		readonly Actor self;
+
+		Building building;
 
 		int total;
 		int progress;
@@ -44,6 +46,11 @@ namespace OpenRA.Mods.Common.Traits
 			devMode = self.Owner.PlayerActor.Trait<DeveloperMode>();
 			progress = total = info.InitialDelay;
 			allyBuildEnabled = self.World.WorldActor.Trait<MapBuildRadius>().AllyBuildRadiusEnabled;
+		}
+
+		void INotifyCreated.Created(Actor self)
+		{
+			building = self.TraitOrDefault<Building>();
 		}
 
 		void ITick.Tick(Actor self)
@@ -59,6 +66,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool Ready()
 		{
+			if (building != null && building.Locked)
+				return false;
+
 			return devMode.FastBuild || progress == 0;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
@@ -55,9 +55,6 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				if (x.Actor.Owner == self.Owner && x.Trait.Info.Produces.Contains(Info.Type))
 				{
-					var b = x.Actor.TraitOrDefault<Building>();
-					if (b != null && b.Locked)
-						continue;
 					isActive = true;
 					break;
 				}

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public object Create(ActorInitializer init) { return new WithBuildingPlacedAnimation(init.Self, this); }
 	}
 
-	public class WithBuildingPlacedAnimation : INotifyBuildingPlaced, INotifyBuildComplete
+	public class WithBuildingPlacedAnimation : INotifyBuildingPlaced, INotifyBuildComplete, INotifySold, INotifyTransform
 	{
 		readonly WithBuildingPlacedAnimationInfo info;
 		readonly WithSpriteBody wsb;
@@ -39,6 +39,20 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			buildComplete = true;
 		}
+
+		public void Sold(Actor self) { }
+		public void Selling(Actor self)
+		{
+			buildComplete = false;
+		}
+
+		public void BeforeTransform(Actor self)
+		{
+			buildComplete = false;
+		}
+
+		public void OnTransform(Actor self) { }
+		public void AfterTransform(Actor self) { }
 
 		public void BuildingPlaced(Actor self)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
@@ -35,26 +35,26 @@ namespace OpenRA.Mods.Common.Traits.Render
 			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>();
 		}
 
-		public void BuildingComplete(Actor self)
+		void INotifyBuildComplete.BuildingComplete(Actor self)
 		{
 			buildComplete = true;
 		}
 
-		public void Sold(Actor self) { }
-		public void Selling(Actor self)
+		void INotifySold.Sold(Actor self) { }
+		void INotifySold.Selling(Actor self)
 		{
 			buildComplete = false;
 		}
 
-		public void BeforeTransform(Actor self)
+		void INotifyTransform.BeforeTransform(Actor self)
 		{
 			buildComplete = false;
 		}
 
-		public void OnTransform(Actor self) { }
-		public void AfterTransform(Actor self) { }
+		void INotifyTransform.OnTransform(Actor self) { }
+		void INotifyTransform.AfterTransform(Actor self) { }
 
-		public void BuildingPlaced(Actor self)
+		void INotifyBuildingPlaced.BuildingPlaced(Actor self)
 		{
 			if (buildComplete)
 				wsb.PlayCustomAnimation(self, info.Sequence, () => wsb.CancelCustomAnimation(self));

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
@@ -55,32 +55,32 @@ namespace OpenRA.Mods.Common.Traits.Render
 			rs.Add(anim, info.Palette, info.IsPlayerPalette);
 		}
 
-		public void BuildingComplete(Actor self)
+		void INotifyBuildComplete.BuildingComplete(Actor self)
 		{
 			buildComplete = true;
 			visible = false;
 		}
 
-		public void Sold(Actor self) { }
-		public void Selling(Actor self)
+		void INotifySold.Sold(Actor self) { }
+		void INotifySold.Selling(Actor self)
 		{
 			buildComplete = false;
 		}
 
-		public void BeforeTransform(Actor self)
+		void INotifyTransform.BeforeTransform(Actor self)
 		{
 			buildComplete = false;
 		}
 
-		public void OnTransform(Actor self) { }
-		public void AfterTransform(Actor self) { }
+		void INotifyTransform.OnTransform(Actor self) { }
+		void INotifyTransform.AfterTransform(Actor self) { }
 
-		public void DamageStateChanged(Actor self, AttackInfo e)
+		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
 		{
 			overlay.ReplaceAnim(RenderSprites.NormalizeSequence(overlay, e.DamageState, overlay.CurrentSequence.Name));
 		}
 
-		public void BuildingPlaced(Actor self)
+		void INotifyBuildingPlaced.BuildingPlaced(Actor self)
 		{
 			visible = true;
 			overlay.PlayThen(overlay.CurrentSequence.Name, () => visible = false);


### PR DESCRIPTION
Fixes #8122, which was a side-effect of an incorrect fix for a bug that triggered when a building was placed while a construction yard was being sold.  Also fixes #8146 and resolves #8704.

First off, this _properly_ fixes the sell-place-animation bug by adding proper checks to `WithBuildingPlacedAnimation`. It then changes `BaseProvider` to disable building placement around a locked construction yard, and `Production` to disable units from being produced from locked factories.  Finally, it removes the tech-disabling hack that causes #8122.

In practice this should give the following gameplay changes in RA:
- When capturing is triggered on a player's only construction yard: production of structures will continue but they cannot be placed around it (previously: construction was cancelled)
- When capturing is triggered on a construction yard, and the player has multiple: structures cannot be placed around the locked yard (previously: could be placed there)
- When capturing is triggered on a player's only factory: production of units will continue but they will stop at the "Ready" phase, like when the exit is blocked (previously: construction was cancelled)
- When capturing is triggered on a factory, and the player has multiple: units will not come out of the locked factory, even if it is the primary (previously: they would).

Mods that don't use external capturing shouldn't be affected, because locking is only otherwise used as part of things that permanently disable the actor (transform, sell, instant capture).
