### PR TITLE
Fix aircraft reservation madness

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -19,6 +19,7 @@ namespace OpenRA.Mods.Common.Activities
 	public class FlyAttack : Activity
 	{
 		readonly Target target;
+		readonly Aircraft aircraft;
 		readonly AttackPlane attackPlane;
 		readonly AmmoPool[] ammoPools;
 
@@ -28,6 +29,7 @@ namespace OpenRA.Mods.Common.Activities
 		public FlyAttack(Actor self, Target target)
 		{
 			this.target = target;
+			aircraft = self.Trait<Aircraft>();
 			attackPlane = self.TraitOrDefault<AttackPlane>();
 			ammoPools = self.TraitsImplementing<AmmoPool>().ToArray();
 			ticksUntilTurn = attackPlane.AttackPlaneInfo.AttackTurnDelay;
@@ -56,6 +58,10 @@ namespace OpenRA.Mods.Common.Activities
 					inner = ActivityUtils.SequenceActivities(new FlyTimed(ticksUntilTurn, self), new Fly(self, target), new FlyTimed(ticksUntilTurn, self));
 				else
 					inner = ActivityUtils.SequenceActivities(new Fly(self, target), new FlyTimed(ticksUntilTurn, self));
+
+				// HACK: This needs to be done in this round-about way because TakeOff doesn't behave as expected when it doesn't have a NextActivity.
+				if (self.World.Map.DistanceAboveTerrain(self.CenterPosition).Length < aircraft.Info.MinAirborneAltitude)
+					inner = ActivityUtils.SequenceActivities(new TakeOff(self), inner);
 			}
 
 			inner = ActivityUtils.RunActivity(self, inner);

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -40,10 +40,9 @@ namespace OpenRA.Mods.Common.Activities
 			if (!target.IsValidFor(self))
 				return NextActivity;
 
-			// Move to the next activity only if all ammo pools are depleted and none reload automatically
 			// TODO: This should check whether there is ammo left that is actually suitable for the target
 			if (ammoPools.All(x => !x.Info.SelfReloads && !x.HasAmmo()))
-				return ActivityUtils.SequenceActivities(new ReturnToBase(self), NextActivity);
+				return ActivityUtils.SequenceActivities(new ReturnToBase(self), this);
 
 			if (attackPlane != null)
 				attackPlane.DoAttack(self, target);

--- a/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
@@ -65,9 +65,9 @@ namespace OpenRA.Mods.Common.Activities
 				return ActivityUtils.SequenceActivities(new HeliFly(self, newTarget));
 			}
 
-			// If any AmmoPool is depleted and no weapon is valid against target, return to helipad to reload and then move to next activity
+			// If any AmmoPool is depleted and no weapon is valid against target, return to helipad to reload and then resume the activity
 			if (ammoPools.Any(x => !x.Info.SelfReloads && !x.HasAmmo()) && !attackHeli.HasAnyValidWeapons(target))
-				return ActivityUtils.SequenceActivities(new HeliReturnToBase(self), NextActivity);
+				return ActivityUtils.SequenceActivities(new HeliReturnToBase(self), this);
 
 			var dist = target.CenterPosition - self.CenterPosition;
 

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -104,13 +104,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		UpgradeManager um;
 		IDisposable reservation;
-		Actor reservedActor;
 		IEnumerable<int> speedModifiers;
 
 		[Sync] public int Facing { get; set; }
 		[Sync] public WPos CenterPosition { get; private set; }
 		public CPos TopLeft { get { return self.World.Map.CellContaining(CenterPosition); } }
 		public int TurnSpeed { get { return Info.TurnSpeed; } }
+		public Actor ReservedActor { get; private set; }
+		public bool MayYieldReservation;
 
 		bool airborne;
 		bool cruising;
@@ -190,7 +191,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (reservation != null)
 			{
-				var distanceFromReservationActor = (reservedActor.CenterPosition - self.CenterPosition).HorizontalLength;
+				var distanceFromReservationActor = (ReservedActor.CenterPosition - self.CenterPosition).HorizontalLength;
 				if (distanceFromReservationActor < Info.WaitDistanceFromResupplyBase.Length)
 					return WVec.Zero;
 			}
@@ -277,7 +278,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (reservable != null)
 			{
 				reservation = reservable.Reserve(target, self, this);
-				reservedActor = target;
+				ReservedActor = target;
 			}
 		}
 
@@ -288,7 +289,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			reservation.Dispose();
 			reservation = null;
-			reservedActor = null;
+			ReservedActor = null;
+			MayYieldReservation = false;
 
 			if (self.World.Map.DistanceAboveTerrain(CenterPosition).Length <= Info.LandAltitude.Length)
 				self.QueueActivity(new TakeOff(self));
@@ -614,8 +616,6 @@ namespace OpenRA.Mods.Common.Traits
 
 				self.QueueActivity(new ResupplyAircraft(self));
 			}
-			else
-				UnReserve();
 		}
 
 		#endregion

--- a/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
@@ -29,11 +29,19 @@ namespace OpenRA.Mods.Common.Traits
 				return;		/* nothing to do */
 
 			if (!Target.FromActor(reservedFor).IsValidFor(self))
-				reservedFor = null;		/* not likely to arrive now. */
+			{
+				/* Not likely to arrive now. */
+				reservedForAircraft.UnReserve();
+				reservedFor = null;
+				reservedForAircraft = null;
+			}
 		}
 
 		public IDisposable Reserve(Actor self, Actor forActor, Aircraft forAircraft)
 		{
+			if (reservedForAircraft != null && reservedForAircraft.MayYieldReservation)
+				reservedForAircraft.UnReserve();
+
 			reservedFor = forActor;
 			reservedForAircraft = forAircraft;
 
@@ -53,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 		public static bool IsReserved(Actor a)
 		{
 			var res = a.TraitOrDefault<Reservable>();
-			return res != null && res.reservedFor != null;
+			return res != null && res.reservedForAircraft != null && !res.reservedForAircraft.MayYieldReservation;
 		}
 
 		public void Disposing(Actor self)


### PR DESCRIPTION
Fixes #11953.
Fixes #5995.
Fixes #7545.
Fixes #7481.

The important part of this change is the `MayYieldReservation` flag on `Aircraft`. It is set after an aircraft finished resupplying, and will cause it to be kicked off the airfield by the `Reservable` trait if another aircraft tries to get a reservation.

One change wrt to bleed that I couldn't find a solution for is that producing a plane will block the newly-built plane as long as the other one is still resupplying, but will cause both to take off once its done.

Even with this change, there can still (rarely) arise situations where airfields will get locked by a reservation. From the way it looked in my tests, it seemed that the aircraft that took the reservation was unable to find the proper approach to land on the airfield. I didn't yet look deeper into it, as it seemed unrelated to the issue being dealt with by this PR.
