### PR TITLE
Remove invalid cell check from Parachutable.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -64,9 +64,6 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			var cell = self.Location;
-			if (self.World.Map.Contains(cell))
-				return;
-
 			if (positionable.CanEnterCell(cell, self))
 				return;
 


### PR DESCRIPTION
I'm not quite sure what the logic was here, maybe this was meant to be inverted?  In any case, `positionable.CanEnterCell` already accounts for the map bounds so it isn't needed here.

Fixes #11959.
