### PR TITLE
Fix crash when popping up the mod requirements dialog.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallModLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallModLogic.cs
@@ -17,11 +17,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class InstallModLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
-		public InstallModLogic(Widget widget, string modId)
+		public InstallModLogic(Widget widget, Manifest mod)
 		{
 			var panel = widget.Get("INSTALL_MOD_PANEL");
 
-			var mods = Game.Mods[modId].RequiresMods.Where(m => !Game.IsModInstalled(m)).Select(m => "{0} ({1})".F(m.Key, m.Value));
+			var mods = mod.RequiresMods.Where(m => !Game.IsModInstalled(m)).Select(m => "{0} ({1})".F(m.Key, m.Value));
 			var text = string.Join(", ", mods);
 			panel.Get<LabelWidget>("MOD_LIST").Text = text;
 


### PR DESCRIPTION
Fixes #11958, but I have no idea how he triggered it from TD.  A much easier testcase is to try and launch @reaperrr's TDX mod from the bleed mod chooser.
