### PR TITLE
Clean up GPS code.

### DIFF
--- a/OpenRA.Mods.RA/Effects/GpsDot.cs
+++ b/OpenRA.Mods.RA/Effects/GpsDot.cs
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.RA.Effects
 				var state = dotStates[playerIndex];
 				var shouldRender = false;
 				if (self.IsInWorld && !self.IsDead)
-					state.IsTargetable = (state.Gps.Granted || state.Gps.GrantedAllies) && IsTargetableBy(world.Players[playerIndex], out shouldRender);
+					state.IsTargetable = state.Gps.Active && IsTargetableBy(world.Players[playerIndex], out shouldRender);
 
 				state.ShouldRender = state.IsTargetable && shouldRender;
 			}

--- a/OpenRA.Mods.RA/Traits/FrozenUnderFogUpdatedByGps.cs
+++ b/OpenRA.Mods.RA/Traits/FrozenUnderFogUpdatedByGps.cs
@@ -95,8 +95,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		void ActOnFrozenActorForTraits(Traits t, FrozenActorAction action)
 		{
-			if (t.FrozenActorLayer == null || t.GpsWatcher == null ||
-				!t.GpsWatcher.Granted || !t.GpsWatcher.GrantedAllies)
+			if (t.FrozenActorLayer == null || t.GpsWatcher == null || !t.GpsWatcher.Active)
 				return;
 
 			var fa = t.FrozenActorLayer.FromID(self.ActorID);

--- a/OpenRA.Mods.RA/Traits/GpsWatcher.cs
+++ b/OpenRA.Mods.RA/Traits/GpsWatcher.cs
@@ -45,33 +45,30 @@ namespace OpenRA.Mods.RA.Traits
 		public void RemoveSource(Actor source)
 		{
 			sources.Remove(source);
-			RefreshGps(source);
+			Refresh();
 		}
 
 		public void AddSource(Actor source)
 		{
 			sources.Add(source);
-			RefreshGps(source);
+			Refresh();
 		}
 
-		public void Launch(Actor atek, GpsPowerInfo info)
+		public void Launch(Actor source, GpsPowerInfo info)
 		{
-			atek.World.Add(new DelayedAction(info.RevealDelay * 25, () =>
+			source.World.Add(new DelayedAction(info.RevealDelay * 25, () =>
 			{
 				Launched = true;
-				RefreshGps(atek);
+				Refresh();
 			}));
 		}
 
-		public void RefreshGps(Actor atek)
+		void Refresh()
 		{
 			RefreshGranted();
 
-			foreach (var i in atek.World.ActorsWithTrait<GpsWatcher>())
+			foreach (var i in owner.World.ActorsWithTrait<GpsWatcher>())
 				i.Trait.RefreshGranted();
-
-			if ((Granted || GrantedAllies) && atek.Owner.IsAlliedWith(owner))
-				atek.Owner.Shroud.ExploreAll();
 		}
 
 		void RefreshGranted()

--- a/OpenRA.Mods.RA/Traits/GpsWatcher.cs
+++ b/OpenRA.Mods.RA/Traits/GpsWatcher.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		readonly Player owner;
 
-		readonly List<Actor> actors = new List<Actor>();
+		readonly List<Actor> sources = new List<Actor>();
 		readonly HashSet<TraitPair<IOnGpsRefreshed>> notifyOnRefresh = new HashSet<TraitPair<IOnGpsRefreshed>>();
 
 		public GpsWatcher(Player owner)
@@ -42,26 +42,25 @@ namespace OpenRA.Mods.RA.Traits
 			this.owner = owner;
 		}
 
-		public void GpsRemove(Actor atek)
+		public void RemoveSource(Actor source)
 		{
-			actors.Remove(atek);
-			RefreshGps(atek);
+			sources.Remove(source);
+			RefreshGps(source);
 		}
 
-		public void GpsAdd(Actor atek)
+		public void AddSource(Actor source)
 		{
-			actors.Add(atek);
-			RefreshGps(atek);
+			sources.Add(source);
+			RefreshGps(source);
 		}
 
 		public void Launch(Actor atek, GpsPowerInfo info)
 		{
-			atek.World.Add(new DelayedAction(info.RevealDelay * 25,
-				() =>
-				{
-					Launched = true;
-					RefreshGps(atek);
-				}));
+			atek.World.Add(new DelayedAction(info.RevealDelay * 25, () =>
+			{
+				Launched = true;
+				RefreshGps(atek);
+			}));
 		}
 
 		public void RefreshGps(Actor atek)
@@ -80,7 +79,7 @@ namespace OpenRA.Mods.RA.Traits
 			var wasGranted = Granted;
 			var wasGrantedAllies = GrantedAllies;
 
-			Granted = actors.Count > 0 && Launched;
+			Granted = sources.Count > 0 && Launched;
 			GrantedAllies = owner.World.ActorsHavingTrait<GpsWatcher>(g => g.Granted).Any(p => p.Owner.IsAlliedWith(owner));
 
 			if (Granted || GrantedAllies)

--- a/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
@@ -48,11 +48,13 @@ namespace OpenRA.Mods.RA.Traits
 		public override object Create(ActorInitializer init) { return new GpsPower(init.Self, this); }
 	}
 
-	class GpsPower : SupportPower, INotifyKilled, INotifySold, INotifyOwnerChanged, ITick
+	class GpsPower : SupportPower, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyOwnerChanged, ITick
 	{
 		readonly Actor self;
 		readonly GpsPowerInfo info;
+
 		GpsWatcher watcher;
+		bool wasEnabled;
 
 		public GpsPower(Actor self, GpsPowerInfo info)
 			: base(self, info)
@@ -60,7 +62,6 @@ namespace OpenRA.Mods.RA.Traits
 			this.self = self;
 			this.info = info;
 			watcher = self.Owner.PlayerActor.Trait<GpsWatcher>();
-			watcher.AddSource(self);
 		}
 
 		public override void Charged(Actor self, string key)
@@ -84,33 +85,35 @@ namespace OpenRA.Mods.RA.Traits
 			});
 		}
 
-		public void Killed(Actor self, AttackInfo e) { watcher.RemoveSource(self); }
-
-		public void Selling(Actor self) { }
-		public void Sold(Actor self) { watcher.RemoveSource(self); }
-
 		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
-			watcher.RemoveSource(self);
+			// Note: watcher registration is already handled by removal/addition from world
 			watcher = newOwner.PlayerActor.Trait<GpsWatcher>();
-			watcher.AddSource(self);
+		}
+
+		void INotifyAddedToWorld.AddedToWorld(Actor self)
+		{
+			// Registration will happen in the next tick if needed
+			wasEnabled = false;
+		}
+
+		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
+		{
+			if (wasEnabled)
+				watcher.RemoveSource(self);
 		}
 
 		bool NoActiveRadar { get { return !self.World.ActorsHavingTrait<ProvidesRadar>(r => r.IsActive).Any(a => a.Owner == self.Owner); } }
-		bool wasDisabled;
 
-		public void Tick(Actor self)
+		void ITick.Tick(Actor self)
 		{
-			if (!wasDisabled && (self.IsDisabled() || (info.RequiresActiveRadar && NoActiveRadar)))
-			{
-				wasDisabled = true;
-				watcher.RemoveSource(self);
-			}
-			else if (wasDisabled && !self.IsDisabled() && !(info.RequiresActiveRadar && NoActiveRadar))
-			{
-				wasDisabled = false;
+			var isEnabled = !(self.IsDisabled() || (info.RequiresActiveRadar && NoActiveRadar));
+			if (!wasEnabled && isEnabled)
 				watcher.AddSource(self);
-			}
+			else if (wasEnabled && !isEnabled)
+				watcher.RemoveSource(self);
+
+			wasEnabled = isEnabled;
 		}
 	}
 }


### PR DESCRIPTION
This takes a few small steps towards making the GPS code comprehensible, and then fixes #11955.

The intentional logic changes are:
- Map explore now runs at most once per player, triggered the first time that they or one of their allies' GPSWatcher becomes enabled (previously it would happen every time any player enabled or disabled their gps dots by enabling or disabling a radar or tech center)
- GpsPower &rarr; GPSWatcher updates may be delayed by a tick on capture or building, in exchange for not getting horribly out of sync when capturing while having/not having a radar dome.
- Frozen actor preview removals no longer requires you _and_ an ally to have an active GPS to run (pretty sure this was an unreported bug)
- Activating a GPS will now only refresh your allies' state, not all players.  If this code were sensible this would have no impact on the game, but this code is not sensible.  Beware while testing.

I strongly recommend reviewing commit-by-commit to follow the changes.
