### PR TITLE
Move most UI metrics to common.

### DIFF
--- a/mods/cnc/metrics.yaml
+++ b/mods/cnc/metrics.yaml
@@ -3,26 +3,6 @@
 Metrics:
 	ButtonDepth: 0
 	ButtonFont: Bold
-	ButtonTextColor: FFFFFF
-	ButtonTextColorDisabled: 808080
-	ButtonTextContrast: false
-	ButtonTextShadow: false
-	ButtonTextContrastColorDark: 000000
-	ButtonTextContrastColorLight: 7F7F7F
-	ButtonBaseLine: 0
 	CheckboxPressedState: true
-	HotkeyFont: Regular
-	HotkeyColor: FFFFFF
-	HotkeyColorDisabled: 808080
-	TextfieldFont: Regular
-	TextfieldColor: FFFFFF
-	TextfieldColorDisabled: 808080
-	TextfieldColorInvalid: FFC0C0
-	TextFont: Regular
-	TextColor: FFFFFF
-	TextContrast: false
-	TextShadow: false
-	TextContrastColorDark: 000000
-	TextContrastColorLight: 7F7F7F
-	ColorPickerRemapIndices: 176, 178, 180, 182, 184, 186, 189, 191, 177, 179, 181, 183, 185, 187, 188, 190
 	ColorPickerActorType: ^fact.colorpicker
+	ColorPickerRemapIndices: 176, 178, 180, 182, 184, 186, 189, 191, 177, 179, 181, 183, 185, 187, 188, 190

--- a/mods/common/metrics.yaml
+++ b/mods/common/metrics.yaml
@@ -1,19 +1,42 @@
 Metrics:
-	SpawnFont: TinyBold
-	SpawnColor: FFFFFF
-	SpawnContrastColor: 000000
-	SpawnLabelOffset: 0,1
-	IncompatibleVersionColor: FF0000
-	IncompatibleGameColor: A9A9A9
-	ProtectedGameColor: FF0000
-	IncompatibleProtectedGameColor: 8B0000
-	WaitingGameColor: 00FF00
-	IncompatibleWaitingGameColor: 32CD32
+	ButtonBaseLine: 0
+	ButtonDepth: 1
+	ButtonFont: Regular
+	ButtonTextColor: FFFFFF
+	ButtonTextColorDisabled: 808080
+	ButtonTextContrast: false
+	ButtonTextContrastColorDark: 000000
+	ButtonTextContrastColorLight: 7F7F7F
+	ButtonTextShadow: false
+	CheckboxPressedState: false
 	GameStartedColor: FFA500
-	IncompatibleGameStartedColor: D2691E
-	GlobalChatTextColor: FFFFFF
 	GlobalChatNotificationColor: D3D3D3
-	PlayerStanceColorSelf: 32CD32
+	GlobalChatTextColor: FFFFFF
+	HotkeyColor: FFFFFF
+	HotkeyColorDisabled: 808080
+	HotkeyFont: Regular
+	IncompatibleGameColor: A9A9A9
+	IncompatibleGameStartedColor: D2691E
+	IncompatibleProtectedGameColor: 8B0000
+	IncompatibleVersionColor: FF0000
+	IncompatibleWaitingGameColor: 32CD32
 	PlayerStanceColorAllies: FFFF00
 	PlayerStanceColorEnemies: FF0000
 	PlayerStanceColorNeutrals: D2B48C
+	PlayerStanceColorSelf: 32CD32
+	ProtectedGameColor: FF0000
+	SpawnColor: FFFFFF
+	SpawnContrastColor: 000000
+	SpawnFont: TinyBold
+	SpawnLabelOffset: 0,1
+	TextColor: FFFFFF
+	TextContrast: false
+	TextContrastColorDark: 000000
+	TextContrastColorLight: 7F7F7F
+	TextFont: Regular
+	TextShadow: false
+	TextfieldColor: FFFFFF
+	TextfieldColorDisabled: 808080
+	TextfieldColorInvalid: FFC0C0
+	TextfieldFont: Regular
+	WaitingGameColor: 00FF00

--- a/mods/d2k/metrics.yaml
+++ b/mods/d2k/metrics.yaml
@@ -1,27 +1,4 @@
 # General dumping-ground for UI element sizes, etc.
 Metrics:
-	ButtonDepth: 1
-	ButtonFont: Regular
-	ButtonTextColor: FFFFFF
-	ButtonTextColorDisabled: 808080
-	ButtonTextContrast: false
-	ButtonTextShadow: false
-	ButtonTextContrastColorDark: 000000
-	ButtonTextContrastColorLight: 7F7F7F
-	ButtonBaseLine: 0
-	CheckboxPressedState: false
-	HotkeyFont: Regular
-	HotkeyColor: FFFFFF
-	HotkeyColorDisabled: 808080
-	TextfieldFont: Regular
-	TextfieldColor: FFFFFF
-	TextfieldColorDisabled: 808080
-	TextfieldColorInvalid: FFC0C0
-	TextFont: Regular
-	TextColor: FFFFFF
-	TextContrast: false
-	TextShadow: false
-	TextContrastColorDark: 000000
-	TextContrastColorLight: 7F7F7F
-	ColorPickerRemapIndices: 255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240
 	ColorPickerActorType: ^carryall.colorpicker
+	ColorPickerRemapIndices: 255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240

--- a/mods/modchooser/metrics.yaml
+++ b/mods/modchooser/metrics.yaml
@@ -1,27 +1,8 @@
 # General dumping-ground for UI element sizes, etc.
 
 Metrics:
+	ButtonBaseLine: 2
 	ButtonDepth: 0
 	ButtonFont: Bold
-	ButtonTextColor: FFFFFF
-	ButtonTextColorDisabled: 808080
-	ButtonTextContrast: false
-	ButtonTextShadow: false
-	ButtonTextContrastColorDark: 000000
-	ButtonTextContrastColorLight: 7F7F7F
-	ButtonBaseLine: 2
 	CheckboxPressedState: true
-	HotkeyFont: Regular
-	HotkeyColor: FFFFFF
-	HotkeyColorDisabled: 808080
-	TextfieldFont: Regular
-	TextfieldColor: FFFFFF
-	TextfieldColorDisabled: 808080
-	TextfieldColorInvalid: FFC0C0
-	TextFont: Regular
-	TextColor: FFFFFF
-	TextContrast: false
-	TextShadow: false
-	TextContrastColorDark: 000000
-	TextContrastColorLight: 7F7F7F
 	ColorPickerRemapIndices: 176, 178, 180, 182, 184, 186, 189, 191, 177, 179, 181, 183, 185, 187, 188, 190

--- a/mods/modchooser/mod.yaml
+++ b/mods/modchooser/mod.yaml
@@ -31,6 +31,7 @@ LoadScreen: ModChooserLoadScreen
 	Image: ./mods/modchooser/chrome.png
 
 ChromeMetrics:
+	common|metrics.yaml
 	modchooser|metrics.yaml
 
 Fonts:

--- a/mods/ra/metrics.yaml
+++ b/mods/ra/metrics.yaml
@@ -1,37 +1,14 @@
 # General dumping-ground for UI element sizes, etc.
 
 Metrics:
-	ButtonDepth: 1
-	ButtonFont: Regular
-	ButtonTextColor: FFFFFF
-	ButtonTextColorDisabled: 808080
-	ButtonTextContrast: false
-	ButtonTextShadow: false
-	ButtonTextContrastColorDark: 000000
-	ButtonTextContrastColorLight: 7F7F7F
-	ButtonBaseLine: 0
-	CheckboxPressedState: false
-	HotkeyFont: Regular
-	HotkeyColor: FFFFFF
-	HotkeyColorDisabled: 808080
-	TextfieldFont: Regular
-	TextfieldColor: FFFFFF
-	TextfieldColorDisabled: 808080
-	TextfieldColorInvalid: FFC0C0
-	TextFont: Regular
-	TextColor: FFFFFF
-	TextContrast: false
-	TextShadow: false
-	TextContrastColorDark: 000000
-	TextContrastColorLight: 7F7F7F
-	ColorPickerRemapIndices: 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95
 	ColorPickerActorType: ^fact.colorpicker
+	ColorPickerRemapIndices: 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95
 	FactionSuffix-allies: allies
 	FactionSuffix-england: allies
 	FactionSuffix-france: allies
 	FactionSuffix-germany: allies
-	FactionSuffix-soviet: soviet
 	FactionSuffix-russia: soviet
+	FactionSuffix-soviet: soviet
 	FactionSuffix-ukraine: soviet
-	IncompatibleVersionColor: D3D3D3
 	IncompatibleProtectedGameColor: B22222
+	IncompatibleVersionColor: D3D3D3

--- a/mods/ts/metrics.yaml
+++ b/mods/ts/metrics.yaml
@@ -1,27 +1,4 @@
 # General dumping-ground for UI element sizes, etc.
 Metrics:
-	ButtonDepth: 1
-	ButtonFont: Regular
-	ButtonTextColor: FFFFFF
-	ButtonTextColorDisabled: 808080
-	ButtonTextContrast: false
-	ButtonTextShadow: false
-	ButtonTextContrastColorDark: 000000
-	ButtonTextContrastColorLight: 7F7F7F
-	ButtonBaseLine: 0
-	CheckboxPressedState: false
-	HotkeyFont: Regular
-	HotkeyColor: FFFFFF
-	HotkeyColorDisabled: 808080
-	TextfieldFont: Regular
-	TextfieldColor: FFFFFF
-	TextfieldColorDisabled: 808080
-	TextfieldColorInvalid: FFC0C0
-	TextFont: Regular
-	TextColor: FFFFFF
-	TextContrast: false
-	TextShadow: false
-	TextContrastColorDark: 000000
-	TextContrastColorLight: 7F7F7F
-	ColorPickerRemapIndices: 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
 	ColorPickerActorType: ^mmch.colorpicker
+	ColorPickerRemapIndices: 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31


### PR DESCRIPTION
This reduces the odds that a third-party mod will crash due to missing
one of them. Eliminates OpenRA/ra2#291.
