### PR TITLE
Make Tooltip upgradable

### DIFF
--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Traits
 
 		public ITooltipInfo TooltipInfo { get; private set; }
 		public Player TooltipOwner { get; private set; }
-		readonly ITooltip tooltip;
+		readonly ITooltip[] tooltips;
 
 		public int HP { get; private set; }
 		public DamageState DamageState { get; private set; }
@@ -80,7 +80,7 @@ namespace OpenRA.Traits
 			Bounds = self.Bounds;
 			TargetTypes = self.GetEnabledTargetTypes().ToHashSet();
 
-			tooltip = self.TraitsImplementing<ITooltip>().FirstOrDefault();
+			tooltips = self.TraitsImplementing<ITooltip>().ToArray();
 			health = self.TraitOrDefault<IHealth>();
 
 			UpdateVisibility();
@@ -101,6 +101,7 @@ namespace OpenRA.Traits
 				DamageState = health.DamageState;
 			}
 
+			var tooltip = tooltips.FirstOrDefault(Exts.IsTraitEnabled);
 			if (tooltip != null)
 			{
 				TooltipInfo = tooltip.TooltipInfo;

--- a/OpenRA.Mods.Common/Lint/CheckTooltips.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTooltips.cs
@@ -1,0 +1,35 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Lint
+{
+	class CheckTooltips : ILintRulesPass
+	{
+		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		{
+			foreach (var actorInfo in rules.Actors)
+			{
+				var buildable = actorInfo.Value.TraitInfoOrDefault<BuildableInfo>();
+				if (buildable == null)
+					continue;
+
+				var tooltip = actorInfo.Value.TraitInfos<TooltipInfo>().FirstOrDefault(Exts.IsTraitEnabled);
+				if (tooltip == null)
+					emitError("The following buildable actor has no (enabled) Tooltip: " + actorInfo.Key);
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -176,6 +176,7 @@
     <Compile Include="Lint\CheckActorReferences.cs" />
     <Compile Include="Lint\CheckSyncAnnotations.cs" />
     <Compile Include="Lint\CheckTraitPrerequisites.cs" />
+    <Compile Include="Lint\CheckTooltips.cs" />
     <Compile Include="Lint\CheckDeathTypes.cs" />
     <Compile Include="Lint\CheckRangeLimit.cs" />
     <Compile Include="Lint\CheckVoiceReferences.cs" />

--- a/OpenRA.Mods.Common/Traits/Tooltip.cs
+++ b/OpenRA.Mods.Common/Traits/Tooltip.cs
@@ -13,11 +13,9 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public abstract class TooltipInfoBase : ITraitInfo
+	public abstract class TooltipInfoBase : UpgradableTraitInfo
 	{
 		[Translate] public readonly string Name = "";
-
-		public abstract object Create(ActorInitializer init);
 	}
 
 	[Desc("Shown in map editor.")]
@@ -61,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 		public bool IsOwnerRowVisible { get { return ShowOwnerRow; } }
 	}
 
-	public class Tooltip : ITooltip
+	public class Tooltip : UpgradableTrait<TooltipInfo>, ITooltip
 	{
 		readonly Actor self;
 		readonly TooltipInfo info;
@@ -70,6 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Player Owner { get { return self.Owner; } }
 
 		public Tooltip(Actor self, TooltipInfo info)
+			: base(info)
 		{
 			this.self = self;
 			this.info = info;

--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -70,7 +70,9 @@ namespace OpenRA.Mods.Common.Traits
 				Footprint = new ReadOnlyDictionary<CPos, SubCell>(footprint);
 			}
 
-			var tooltip = Info.TraitInfoOrDefault<EditorOnlyTooltipInfo>() as TooltipInfoBase ?? Info.TraitInfoOrDefault<TooltipInfo>();
+			var tooltip = Info.TraitInfos<EditorOnlyTooltipInfo>().FirstOrDefault(Exts.IsTraitEnabled) as TooltipInfoBase
+				?? Info.TraitInfos<TooltipInfo>().FirstOrDefault(Exts.IsTraitEnabled);
+
 			Tooltip = (tooltip == null ? " < " + Info.Name + " >" : tooltip.Name) + "\n" + owner.Name + " (" + owner.Faction + ")"
 				+ "\nID: " + ID + "\nType: " + Info.Name;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -132,7 +132,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					item.Bounds.Height = preview.Bounds.Height + 2 * preview.Bounds.Y;
 					item.IsVisible = () => true;
 
-					var tooltip = actor.TraitInfoOrDefault<EditorOnlyTooltipInfo>() as TooltipInfoBase ?? actor.TraitInfoOrDefault<TooltipInfo>();
+					var tooltip = actor.TraitInfos<EditorOnlyTooltipInfo>().FirstOrDefault(Exts.IsTraitEnabled) as TooltipInfoBase
+						?? actor.TraitInfos<TooltipInfo>().FirstOrDefault(Exts.IsTraitEnabled);
+
 					item.GetTooltipText = () => (tooltip == null ? "Type: " : tooltip.Name + "\nType: ") + actor.Name;
 
 					panel.AddChild(item);

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		static string ActorName(Ruleset rules, string a)
 		{
 			ActorInfo ai;
-			if (rules.Actors.TryGetValue(a.ToLowerInvariant(), out ai) && ai.HasTraitInfo<TooltipInfo>())
+			if (rules.Actors.TryGetValue(a.ToLowerInvariant(), out ai))
 			{
 				var actorTooltip = ai.TraitInfos<TooltipInfo>().FirstOrDefault(Exts.IsTraitEnabled);
 				if (actorTooltip != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (actor == null || actor == lastActor)
 					return;
 
-				var tooltip = actor.TraitInfo<TooltipInfo>();
+				var tooltip = actor.TraitInfos<TooltipInfo>().First(Exts.IsTraitEnabled);
 				var buildable = actor.TraitInfo<BuildableInfo>();
 				var cost = actor.TraitInfo<ValuedInfo>().Cost;
 
@@ -115,7 +115,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			ActorInfo ai;
 			if (rules.Actors.TryGetValue(a.ToLowerInvariant(), out ai) && ai.HasTraitInfo<TooltipInfo>())
-				return ai.TraitInfo<TooltipInfo>().Name;
+			{
+				var actorTooltip = ai.TraitInfos<TooltipInfo>().FirstOrDefault(Exts.IsTraitEnabled);
+				if (actorTooltip != null)
+					return actorTooltip.Name;
+			}
 
 			return a;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -55,14 +55,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (actor == null || actor == lastActor)
 					return;
 
-				var tooltip = actor.TraitInfos<TooltipInfo>().First(Exts.IsTraitEnabled);
+				var tooltip = actor.TraitInfos<TooltipInfo>().FirstOrDefault(Exts.IsTraitEnabled);
+				var name = tooltip != null ? tooltip.Name : actor.Name;
 				var buildable = actor.TraitInfo<BuildableInfo>();
 				var cost = actor.TraitInfo<ValuedInfo>().Cost;
 
-				nameLabel.GetText = () => tooltip.Name;
+				nameLabel.GetText = () => name;
 
 				var hotkey = palette.TooltipIcon.Hotkey;
-				var nameWidth = font.Measure(tooltip.Name).X;
+				var nameWidth = font.Measure(name).X;
 				var hotkeyText = "({0})".F(hotkey.DisplayString());
 				var hotkeyWidth = hotkey.IsValid() ? font.Measure(hotkeyText).X + 2 * nameLabel.Bounds.X : 0;
 				hotkeyLabel.GetText = () => hotkeyText;
@@ -103,7 +104,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				timeLabel.Bounds.X = powerLabel.Bounds.X = costLabel.Bounds.X = timeIcon.Bounds.Right + iconMargin;
 				widget.Bounds.Width = leftWidth + rightWidth + 3 * nameLabel.Bounds.X + timeIcon.Bounds.Width + iconMargin;
 
-				var leftHeight = font.Measure(tooltip.Name).Y + requiresFont.Measure(requiresString).Y + descFont.Measure(descString).Y;
+				var leftHeight = font.Measure(name).Y + requiresFont.Measure(requiresString).Y + descFont.Measure(descString).Y;
 				var rightHeight = font.Measure(powerString).Y + font.Measure(timeString).Y + font.Measure(costString).Y;
 				widget.Bounds.Height = Math.Max(leftHeight, rightHeight) * 3 / 2 + 3 * nameLabel.Bounds.Y;
 

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -191,9 +191,13 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (underCursor != null)
 			{
-				ActorTooltip = underCursor.TraitsImplementing<ITooltip>().First();
-				ActorTooltipExtra = underCursor.TraitsImplementing<IProvideTooltipInfo>().ToArray();
-				TooltipType = WorldTooltipType.Actor;
+				ActorTooltip = underCursor.TraitsImplementing<ITooltip>().FirstOrDefault(Exts.IsTraitEnabled);
+				if (ActorTooltip != null)
+				{
+					ActorTooltipExtra = underCursor.TraitsImplementing<IProvideTooltipInfo>().ToArray();
+					TooltipType = WorldTooltipType.Actor;
+				}
+
 				return;
 			}
 

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -72,6 +72,12 @@ TTNK:
 		Cost: 800
 	Tooltip:
 		Name: Tick Tank
+		UpgradeTypes: deployed
+		UpgradeMaxEnabledLevel: 0
+	Tooltip@DEPLOYED:
+		Name: Tick Tank (deployed)
+		UpgradeTypes: deployed
+		UpgradeMinEnabledLevel: 1
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 60

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -114,6 +114,12 @@ LPST:
 		Cost: 950
 	Tooltip:
 		Name: Mobile Sensor Array
+		UpgradeTypes: deployed
+		UpgradeMaxEnabledLevel: 0
+	Tooltip@DEPLOYED:
+		Name: Mobile Sensor Array (deployed)
+		UpgradeTypes: deployed
+		UpgradeMinEnabledLevel: 1
 	Health:
 		HP: 600
 	Armor:


### PR DESCRIPTION
This allows the tooltip to change via upgrades, for example when an actor is deployed or reaches elite status.
