### PR TITLE
Expand Proximity/CellTriggers with an onOwnerChanged method.

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -301,6 +301,8 @@ namespace OpenRA
 				Owner = newOwner;
 				Generation++;
 
+				w.ActorMap.ActorsWithChangedOwner.Add(new Tuple<Actor, Player, Player>(this, oldOwner, newOwner));
+
 				foreach (var t in TraitsImplementing<INotifyOwnerChanged>())
 					t.OnOwnerChanged(this, oldOwner, newOwner);
 

--- a/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
@@ -9,12 +9,10 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
-using OpenRA.Graphics;
 using OpenRA.Mods.Common.Effects;
-using OpenRA.Mods.Common.Graphics;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -67,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			// TODO: Eventually support CellTriggers as well
-			proximityTrigger = self.World.ActorMap.AddProximityTrigger(self.CenterPosition, Info.Range, WDist.Zero, ActorEntered, ActorLeft);
+			proximityTrigger = self.World.ActorMap.AddProximityTrigger(self.CenterPosition, Info.Range, WDist.Zero, ActorEntered, ActorLeft, ActorChangedOwner);
 		}
 
 		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
@@ -103,6 +101,14 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			actorsInRange.Remove(other);
+			UpdateOwnership();
+		}
+
+		void ActorChangedOwner(Tuple<Actor, Player, Player> other)
+		{
+			if (skipTriggerUpdate || !CanBeCapturedBy(other.Item1))
+				return;
+
 			UpdateOwnership();
 		}
 

--- a/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/UpgradeActorsNear.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -64,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void AddedToWorld(Actor self)
 		{
 			cachedPosition = self.CenterPosition;
-			proximityTrigger = self.World.ActorMap.AddProximityTrigger(cachedPosition, cachedRange, cachedVRange, ActorEntered, ActorExited);
+			proximityTrigger = self.World.ActorMap.AddProximityTrigger(cachedPosition, cachedRange, cachedVRange, ActorEntered, ActorExited, ActorChangedOwner);
 		}
 
 		public void RemovedFromWorld(Actor self)
@@ -149,6 +150,26 @@ namespace OpenRA.Mods.Common.Traits
 			if (um != null)
 				foreach (var u in info.Upgrades)
 					um.RevokeUpgrade(a, u, this);
+		}
+
+		void ActorChangedOwner(Tuple<Actor, Player, Player> a)
+		{
+			if (a.Item1 == self || a.Item1.Disposed || self.Disposed)
+				return;
+
+			var um = a.Item1.TraitOrDefault<UpgradeManager>();
+
+			if (info.ValidStances.HasStance(self.Owner.Stances[a.Item2]) && um != null)
+			{
+				foreach (var u in info.Upgrades)
+					um.RevokeUpgrade(a.Item1, u, this);
+			}
+
+			if (info.ValidStances.HasStance(self.Owner.Stances[a.Item3]) && um != null)
+			{
+				foreach (var u in info.Upgrades)
+					um.GrantUpgrade(a.Item1, u, this);
+			}
 		}
 	}
 }


### PR DESCRIPTION
If an actor changes ownership while under the active effect of a
proximity trigger affecting the two players differently, the trigger
misses out to update the actor in the moment of the owner-change
reflecting that and will try to revoke the new owner's states when the
actor later leaves the trigger while leaving the old owner's state
there.

This can crash the game if one of these proximity triggers is an
UpgradeActorsNear, which is supposed to only grant upgrades to the new
owner - it misses granting them but later tries to properly revoke them.

Credits to lucassss for figuring out the underlying issue.

Fixes #11707.
