### PR TITLE
Remove the TopBottomSpacing from the score screen player list

### DIFF
--- a/mods/cnc/chrome/ingame-infostats.yaml
+++ b/mods/cnc/chrome/ingame-infostats.yaml
@@ -57,7 +57,6 @@ Container@SKIRMISH_STATS:
 			Y: 105
 			Width: 482
 			Height: 255
-			TopBottomSpacing: 5
 			ItemSpacing: 5
 			Children:
 				ScrollItem@TEAM_TEMPLATE:

--- a/mods/d2k/chrome/ingame-infostats.yaml
+++ b/mods/d2k/chrome/ingame-infostats.yaml
@@ -57,7 +57,6 @@ Container@SKIRMISH_STATS:
 			Y: 105
 			Width: 482
 			Height: 265
-			TopBottomSpacing: 5
 			ItemSpacing: 5
 			Children:
 				ScrollItem@TEAM_TEMPLATE:

--- a/mods/ra/chrome/ingame-infostats.yaml
+++ b/mods/ra/chrome/ingame-infostats.yaml
@@ -57,7 +57,6 @@ Container@SKIRMISH_STATS:
 			Y: 105
 			Width: 482
 			Height: 265
-			TopBottomSpacing: 5
 			ItemSpacing: 5
 			Children:
 				ScrollItem@TEAM_TEMPLATE:


### PR DESCRIPTION
Fixes #11988.

![marginsd2k](https://cloud.githubusercontent.com/assets/7704140/18273619/79cf973e-743e-11e6-87a9-c784735c789e.png)
![marginstd](https://cloud.githubusercontent.com/assets/7704140/18273620/7a789b04-743e-11e6-9fdc-bccaed49e319.png)

Looks both okay at the top and at the bottom (imho).
![marginsra](https://cloud.githubusercontent.com/assets/7704140/18273694/df8c383e-743e-11e6-8205-53f690f3b9cd.png)

(TS uses the RA chrome.)
