### PR TITLE
 Remove bogus LZRange field and unnecessary ParaDrop definition

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -165,8 +165,6 @@ ORCA:
 
 C17:
 	Inherits: ^Plane
-	ParaDrop:
-		LZRange: 1
 	Tooltip:
 		Name: Supply Aircraft
 		Description: Drops vehicle reinforcements on Airstrips


### PR DESCRIPTION
Looks like `LZRange` was removed from the code long ago.
