### PR TITLE
D2K - Fix Sardaukar's prerequisite

### DIFF
--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -199,7 +199,7 @@ sardaukar:
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 80
-		Prerequisites: ~barracks.harkonnen, palace, ~techlevel.high
+		Prerequisites: ~barracks.harkonnen, upgrade.barracks, high_tech_factory, ~techlevel.high
 		BuildDuration: 81
 		BuildDurationModifier: 40
 	Valued:


### PR DESCRIPTION
In original game Harkonnen Sardaukar requires High Tech Factory, not Palace. Ones that requires palace is Imperial ones, which we don't have as a seperate unit on OpenRA yet.

I tested to be sure about upgrade and it does require barracks upgrade too.
