### PR TITLE
Improve out-of-memory logging

### DIFF
--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -48,6 +48,7 @@ namespace OpenRA.Platforms.Default
 
 		// Errors
 		public const int GL_NO_ERROR = 0;
+		public const int GL_OUT_OF_MEMORY = 0x505;
 
 		// BeginMode
 		public const int GL_POINTS = 0;
@@ -489,9 +490,14 @@ namespace OpenRA.Platforms.Default
 			var n = glGetError();
 			if (n != GL_NO_ERROR)
 			{
-				var error = "GL Error: {0}\n{1}".F(n, new StackTrace());
+				var errorText = n == GL_OUT_OF_MEMORY ? "Out Of Memory" : n.ToString();
+				var error = "GL Error: {0}\n{1}".F(errorText, new StackTrace());
 				WriteGraphicsLog(error);
-				throw new InvalidOperationException("OpenGL Error: See graphics.log for details.");
+				const string ExceptionMessage = "OpenGL Error: See graphics.log for details.";
+				if (n == GL_OUT_OF_MEMORY)
+					throw new OutOfMemoryException(ExceptionMessage);
+				else
+					throw new InvalidOperationException(ExceptionMessage);
 			}
 		}
 


### PR DESCRIPTION
Add more detail when an `OutOfMemoryException` is thrown (see #9931).

Also ensure that when OpenGL gives an out-of-memory error, we throw an `OutOfMemoryException` so the improved logging is triggered here too.

Example output (with a pretend error in the OpenGL error handler):

```
Red Alert Mod at Version {DEV_VERSION}
on map e90c1d4ea07b7cbb048a1057a1b0be4f11ecbe90 (Desert Shellmap by Scott_NZ).
Date: 2016-09-11 15:59:00Z
Operating System: Windows (Microsoft Windows NT 6.2.9200.0)
Runtime Version: .NET CLR 4.0.30319.42000
Exception of type `System.OutOfMemoryException`: OpenGL Error: See graphics.log for details.
GC Memory (post-collect)=97,467,976
GC Memory (pre-collect)=162,268,088
Working Set=276,512,768
Private Memory=310,460,416
Virtual Memory=627,970,048
   at OpenRA.Platforms.Default.OpenGL.CheckGLError() in C:\...\OpenRA\OpenRA.Platforms.Default\OpenGL.cs:line 498
   at OpenRA.Platforms.Default.Sdl2GraphicsDevice.Clear() in C:\...\OpenRA\OpenRA.Platforms.Default\Sdl2GraphicsDevice.cs:line 217
   at OpenRA.Renderer.BeginFrame(int2 scroll, Single zoom) in C:\...\OpenRA\OpenRA.Game\Renderer.cs:line 109
   at OpenRA.Game.RenderTick() in C:\...\OpenRA\OpenRA.Game\Game.cs:line 601
   at OpenRA.Game.Loop() in C:\...\OpenRA\OpenRA.Game\Game.cs:line 734
   at OpenRA.Game.Run() in C:\...\OpenRA\OpenRA.Game\Game.cs:line 752
   at OpenRA.Program.Run(String[] args) in C:\...\OpenRA\OpenRA.Game\Support\Program.cs:line 132
   at OpenRA.Program.Main(String[] args) in C:\...\OpenRA\OpenRA.Game\Support\Program.cs:line 40
```
