### PR TITLE
Remove duplicated "Prerequisites: ~disabled" fields from the TD campaign

### DIFF
--- a/mods/cnc/maps/gdi07/rules.yaml
+++ b/mods/cnc/maps/gdi07/rules.yaml
@@ -84,10 +84,6 @@ BOAT:
 	Buildable:
 		Prerequisites: ~disabled
 
-LST:
-	Buildable:
-		Prerequisites: ~disabled
-
 FTNK:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/cnc/maps/nod02a/rules.yaml
+++ b/mods/cnc/maps/nod02a/rules.yaml
@@ -185,14 +185,6 @@ HARV.Husk:
 	RenderSprites:
 		PlayerPalette: player
 
-LST:
-	Buildable:
-		Prerequisites: ~disabled
-
-C17:
-	Buildable:
-		Prerequisites: ~disabled
-
 SAM:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/cnc/maps/nod02b/rules.yaml
+++ b/mods/cnc/maps/nod02b/rules.yaml
@@ -75,14 +75,6 @@ MCV:
 	Buildable:
 		Prerequisites: ~disabled
 
-LST:
-	Buildable:
-		Prerequisites: ~disabled
-
-C17:
-	Buildable:
-		Prerequisites: ~disabled
-
 SAM:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/cnc/maps/nod04a/rules.yaml
+++ b/mods/cnc/maps/nod04a/rules.yaml
@@ -96,14 +96,6 @@ MCV:
 	Buildable:
 		Prerequisites: ~disabled
 
-LST:
-	Buildable:
-		Prerequisites: ~disabled
-
-C17:
-	Buildable:
-		Prerequisites: ~disabled
-
 SAM:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/cnc/maps/nod05/rules.yaml
+++ b/mods/cnc/maps/nod05/rules.yaml
@@ -71,14 +71,6 @@ MCV:
 	Buildable:
 		Prerequisites: ~disabled
 
-LST:
-	Buildable:
-		Prerequisites: ~disabled
-
-C17:
-	Buildable:
-		Prerequisites: ~disabled
-
 GTWR:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/cnc/maps/nod06c/rules.yaml
+++ b/mods/cnc/maps/nod06c/rules.yaml
@@ -95,14 +95,6 @@ MCV:
 	Buildable:
 		Prerequisites: ~disabled
 
-LST:
-	Buildable:
-		Prerequisites: ~disabled
-
-C17:
-	Buildable:
-		Prerequisites: ~disabled
-
 GTWR:
 	Buildable:
 		Prerequisites: ~disabled


### PR DESCRIPTION
`LST`s are already [disabled by default](https://github.com/OpenRA/OpenRA/blob/bleed/mods/cnc/rules/ships.yaml#L47) and [`C17`s](https://github.com/OpenRA/OpenRA/blob/bleed/mods/cnc/rules/aircraft.yaml#L166) are not buildable at all.
