### PR TITLE
Fix crash when launching from a different directory than the game binary.

### DIFF
--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -102,14 +102,14 @@ namespace OpenRA
 			path = path.TrimEnd(new char[] { ' ', '\t' });
 
 			// paths starting with ^ are relative to the support dir
-			if (path.StartsWith("^"))
+			if (path.StartsWith("^", StringComparison.Ordinal))
 				path = SupportDir + path.Substring(1);
 
 			// paths starting with . are relative to the game dir
 			if (path == ".")
 				return GameDir;
 
-			if (path.StartsWith("./") || path.StartsWith(".\\"))
+			if (path.StartsWith("./", StringComparison.Ordinal) || path.StartsWith(".\\", StringComparison.Ordinal))
 				path = GameDir + path.Substring(2);
 
 			return path;
@@ -124,10 +124,10 @@ namespace OpenRA
 		/// <summary>Replace the full path prefix with the special notation characters ^ or .</summary>
 		public static string UnresolvePath(string path)
 		{
-			if (path.StartsWith(SupportDir))
+			if (path.StartsWith(SupportDir, StringComparison.Ordinal))
 				path = "^" + path.Substring(SupportDir.Length);
 
-			if (path.StartsWith(GameDir))
+			if (path.StartsWith(GameDir, StringComparison.Ordinal))
 				path = "./" + path.Substring(GameDir.Length);
 
 			return path;

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -39,8 +39,8 @@ namespace OpenRA
 				var kernelName = p.StandardOutput.ReadToEnd();
 				if (kernelName.Contains("Darwin"))
 					return PlatformType.OSX;
-				else
-					return PlatformType.Linux;
+
+				return PlatformType.Linux;
 			}
 			catch { }
 
@@ -82,7 +82,6 @@ namespace OpenRA
 				case PlatformType.OSX:
 					dir += "/Library/Application Support/OpenRA";
 					break;
-				case PlatformType.Linux:
 				default:
 					dir += "/.openra";
 					break;
@@ -101,11 +100,11 @@ namespace OpenRA
 		{
 			path = path.TrimEnd(new char[] { ' ', '\t' });
 
-			// paths starting with ^ are relative to the support dir
+			// Paths starting with ^ are relative to the support dir
 			if (path.StartsWith("^", StringComparison.Ordinal))
 				path = SupportDir + path.Substring(1);
 
-			// paths starting with . are relative to the game dir
+			// Paths starting with . are relative to the game dir
 			if (path == ".")
 				return GameDir;
 

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -106,6 +106,9 @@ namespace OpenRA
 				path = SupportDir + path.Substring(1);
 
 			// paths starting with . are relative to the game dir
+			if (path == ".")
+				return GameDir;
+
 			if (path.StartsWith("./") || path.StartsWith(".\\"))
 				path = GameDir + path.Substring(2);
 


### PR DESCRIPTION
This regression will have been introduced during the FileSystem/oramod refactoring.

This also includes a few other minor fixes to Platform.cs
