### PR TITLE
Fix explicit oramap path lint checking.

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						.Select(m => new Map(modData, m.Package)));
 				}
 				else
-					maps.Add(new Map(modData, modData.ModFiles.OpenPackage(args[1])));
+					maps.Add(new Map(modData, modData.ModFiles.OpenPackage(args[1], new FileSystem.Folder("."))));
 
 				foreach (var testMap in maps)
 				{


### PR DESCRIPTION
#11482 missed this case.  Fixes #12022.
