### PR TITLE
Don't crash if a replay can't be read.

### DIFF
--- a/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
@@ -77,7 +77,13 @@ namespace OpenRA.Mods.Common.LoadScreens
 			// Load a replay directly
 			if (!string.IsNullOrEmpty(Launch.Replay))
 			{
-				var replayMeta = ReplayMetadata.Read(Launch.Replay);
+				ReplayMetadata replayMeta = null;
+				try
+				{
+					replayMeta = ReplayMetadata.Read(Launch.Replay);
+				}
+				catch { }
+
 				if (ReplayUtils.PromptConfirmReplayCompatibility(replayMeta, Game.LoadShellMap))
 					Game.JoinReplay(Launch.Replay);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
@@ -24,7 +24,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				onCancel = DoNothing;
 
 			if (replayMeta == null)
-				return IncompatibleReplayDialog("outdated engine", null, onCancel);
+			{
+				ConfirmationDialogs.ButtonPrompt("Incompatible Replay", "Replay metadata could not be read.", onCancel: onCancel);
+				return false;
+			}
 
 			var version = replayMeta.GameInfo.Version;
 			if (version == null)


### PR DESCRIPTION
Fixes #12034.

On a related note, our replay-failure error messages need a complete overhaul.  Doing that properly is out of scope for this release.
