### PR TITLE
Add RA balance changes to the next playtest/release.

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -583,7 +583,7 @@ HBOX:
 	Valued:
 		Cost: 600
 	Health:
-		HP: 600
+		HP: 450
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -164,7 +164,7 @@ V2RL:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 42
+		Speed: 50
 		Crushes: wall, mine, crate, infantry, heavywall
 	RevealsShroud:
 		Range: 6c0


### PR DESCRIPTION
Partially following #12013 and in spirit of #11995 I'm probing a couple of balance changes aimed for the next playtest or directly to the next release. 

Paraphrasing selection of the list provided in #11995:

**Mammoth Tank:**

Speed 50, up from 42

As pointed to in the forum discussion thread (_not_ the recent poll thread) linked in the PR the speed buff is exactly what is expressed as the most crucial element as to making this unit useful for whatever purpose you want it assigned to. 

Initially the speed boost will reward casual players looking to invest in Mammoth Tanks for its iconic value. Long term this represents a foundation of which additional changes to the Mammoth Tank can be added, given that the current speed **fundamentally cripples** the tank both as an "utility" unit as well as a front line army unit.

**Camo. Pillbox:** 

Health: 450HP down from 600HP

The camo pillbox having cloak and at the same giving the same health/price value as the regular pillbox makes it too beefy and at the same time makes the regular pillbox more or less dormant. This is a very old observation made by a great majority of the community players. The camo. pillbox was super close to being merged in the RA mod as a french exclusive structure #11431. The idea behind it was to further distinguish France as a desceptive faction but also for the regular pillbox to make its way back into the game as a standard defensive structure. As per map playtesting the 450HP c.pillbox accomplished the latter and overall made competetive games a better experience.

**AA Missile Sub:** (**UPDATE**: Removed AAMissileSub commit from the PR.)

Cost: $2000, down from $2400
Damage: 25, down from 30
Added air as a valid target
Visual: Adjusted missile speed and height.

This is an old one but it's really bad that this hasn't made it's way into the game yet. Hamb first exposed this on his twitch a year ago and pretty much got a round of applause. This balance change more or less drowned in the balance discussions raging on before and after the 20151224 holiday release and pretty much remained dormant as focus went more over the fast evolving land battle meta (and naval maps slipping off the radar). However it was brought back in map playtesting from May and despite having limited exposure due to being a Soviet late tech naval unit it did deliver as prmoised - picking off lazy Hinds and Longbows over or close to water and damaging clusters of idling YAKs with the sudden burst of its submissiles. Plays well and fun as hell. The damage and cost was somewhat reduced to gain the unit a little more accessibility and the missile speed/trajectory altered slightly in order for the AA trajectory to look proper vs air.

Closes #11731
