### PR TITLE
Fix the music resetting from time to time

### DIFF
--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -76,6 +76,7 @@ namespace OpenRA
 		public void Initialize(ISoundLoader[] loaders, IReadOnlyFileSystem fileSystem)
 		{
 			sounds = new Cache<string, ISoundSource>(s => LoadSound(loaders, fileSystem, s));
+			currentSounds = new Dictionary<uint, ISound>();
 			music = null;
 			currentMusic = null;
 			video = null;


### PR DESCRIPTION
Fixes #12024.

Reproduction case: Start a game with many AIs, heavy support and fastest game speed. Let it run a minute and then restart. Continue restarting until you notice the reset.

We didn't clear the `currentSounds` dictionary before, so the contents were carried over into a new world.
