### PR TITLE
Fix locking an airfield that is rearming aircraft while being sold

### DIFF
--- a/OpenRA.Mods.Common/Activities/Rearm.cs
+++ b/OpenRA.Mods.Common/Activities/Rearm.cs
@@ -59,9 +59,8 @@ namespace OpenRA.Mods.Common.Activities
 				if (!pool.GiveAmmo())
 					continue;
 
-				var wsb = hostBuilding.Trait<WithSpriteBody>();
-				if (wsb.DefaultAnimation.HasSequence("active"))
-					wsb.PlayCustomAnimation(hostBuilding, "active", () => wsb.CancelCustomAnimation(hostBuilding));
+				foreach (var host in hostBuilding.TraitsImplementing<INotifyRearm>())
+					host.Rearming(hostBuilding, self);
 
 				var sound = pool.Info.RearmSound;
 				if (sound != null)

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -453,6 +453,7 @@
     <Compile Include="Traits\Render\WithParachute.cs" />
     <Compile Include="Traits\Render\WithRangeCircle.cs" />
     <Compile Include="Traits\Render\WithRankDecoration.cs" />
+    <Compile Include="Traits\Render\WithRearmAnimation.cs" />
     <Compile Include="Traits\Render\WithRepairAnimation.cs" />
     <Compile Include="Traits\Render\WithRepairOverlay.cs" />
     <Compile Include="Traits\Render\WithResources.cs" />

--- a/OpenRA.Mods.Common/Traits/Render/WithRearmAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRearmAnimation.cs
@@ -1,0 +1,57 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits.Render
+{
+	[Desc("Replaces the building animation when it rearms a unit.")]
+	public class WithRearmAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>
+	{
+		[Desc("Sequence name to use")]
+		[SequenceReference] public readonly string Sequence = "active";
+
+		public readonly bool PauseOnLowPower = false;
+
+		public object Create(ActorInitializer init) { return new WithRearmAnimation(init.Self, this); }
+	}
+
+	public class WithRearmAnimation : INotifyRearm, INotifyBuildComplete, INotifySold
+	{
+		readonly WithRearmAnimationInfo info;
+		readonly WithSpriteBody spriteBody;
+		bool buildComplete;
+
+		public WithRearmAnimation(Actor self, WithRearmAnimationInfo info)
+		{
+			this.info = info;
+			spriteBody = self.TraitOrDefault<WithSpriteBody>();
+		}
+
+		void INotifyRearm.Rearming(Actor self, Actor target)
+		{
+			if (buildComplete && spriteBody != null && !(info.PauseOnLowPower && self.IsDisabled()))
+				spriteBody.PlayCustomAnimation(self, info.Sequence, () => spriteBody.CancelCustomAnimation(self));
+		}
+
+		public void BuildingComplete(Actor self)
+		{
+			buildComplete = true;
+		}
+
+		public void Selling(Actor self)
+		{
+			buildComplete = false;
+		}
+
+		public void Sold(Actor self) { }
+	}
+}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -139,4 +139,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		void ModifyActorPreviewInit(Actor self, TypeDictionary inits);
 	}
+
+	[RequireExplicitImplementation]
+	public interface INotifyRearm { void Rearming(Actor host, Actor other); }
 }

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -358,6 +358,15 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// Add a warning to add WithRearmAnimation to actors that might need it.
+				// Update rule added during prep-1609 stable period, date needs fixing after release.
+				if (engineVersion < 20160918 && depth == 2)
+				{
+					if (node.Key == "RearmBuildings")
+						foreach (var host in node.Value.Value.Split(','))
+							Console.WriteLine("Actor type `{0}` is denoted as a RearmBuilding. Consider adding the `WithRearmAnimation` trait to it.".F(host));
+				}
+
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1116,6 +1116,7 @@ HPAD:
 		ZOffset: 256
 		UpgradeTypes: primary
 		UpgradeMinEnabledLevel: 1
+	WithRearmAnimation:
 
 AFLD:
 	Inherits: ^Building
@@ -1232,6 +1233,7 @@ AFLD:
 		ZOffset: 256
 		UpgradeTypes: primary
 		UpgradeMinEnabledLevel: 1
+	WithRearmAnimation:
 
 POWR:
 	Inherits: ^Building
@@ -1573,6 +1575,7 @@ FIX:
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
 	WithRepairAnimation:
+	WithRearmAnimation:
 	Power:
 		Amount: -30
 	ProvidesPrerequisite@buildingname:


### PR DESCRIPTION
Fixes #12035.

If this is too big for stable, I can file a separate fix that just checks `building.Locked`.
