### PR TITLE
Fixed a crash when no sync report is available

### DIFF
--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -92,12 +92,13 @@ namespace OpenRA.Network
 
 		internal void DumpSyncReport(int frame, IEnumerable<FrameData.ClientOrder> orders)
 		{
+			Log.AddChannel("sync", "syncreport.log");
+
 			foreach (var r in syncReports)
 			{
 				if (r.Frame == frame)
 				{
 					var mod = Game.ModData.Manifest.Metadata;
-					Log.AddChannel("sync", "syncreport.log");
 					Log.Write("sync", "Player: {0} ({1} {2} {3})", Game.Settings.Player.Name, Platform.CurrentPlatform, Environment.OSVersion, Platform.RuntimeVersion);
 					Log.Write("sync", "Game ID: {0} (Mod: {1} at Version {2})", orderManager.LobbyInfo.GlobalSettings.GameUid, mod.Title, mod.Version);
 					Log.Write("sync", "Sync for net frame {0} -------------", r.Frame);


### PR DESCRIPTION
Followup of https://github.com/OpenRA/OpenRA/pull/11985. Fixes https://github.com/OpenRA/OpenRA/issues/12055.
