### PR TITLE
server: Fix server getting wedged after map query with bad minimap

### DIFF
--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -150,9 +150,10 @@ namespace OpenRA
 					foreach (var kv in yaml)
 						maps[kv.Key].UpdateRemoteSearch(MapStatus.DownloadAvailable, kv.Value, mapDetailsReceived);
 				}
-				catch
+				catch (Exception e)
 				{
 					Log.Write("debug", "Can't parse remote map search data:\n{0}", data);
+					Log.Write("debug", "Exception: {0}", e);
 					if (queryFailed != null)
 						queryFailed();
 				}

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -367,7 +367,15 @@ namespace OpenRA
 						spawns[j / 2] = new CPos(r.spawnpoints[j], r.spawnpoints[j + 1]);
 					newData.SpawnPoints = spawns;
 					newData.GridType = r.map_grid_type;
-					newData.Preview = new Bitmap(new MemoryStream(Convert.FromBase64String(r.minimap)));
+					try
+					{
+						newData.Preview = new Bitmap(new MemoryStream(Convert.FromBase64String(r.minimap)));
+					}
+					catch (Exception e)
+					{
+						Log.Write("debug", "Failed parsing mapserver minimap response: {0}", e);
+						newData.Preview = null;
+					}
 
 					var playersString = Encoding.UTF8.GetString(Convert.FromBase64String(r.players_block));
 					newData.Players = new MapPlayers(MiniYaml.FromString(playersString));
@@ -389,7 +397,10 @@ namespace OpenRA
 						return Pair.New(rules, flagged);
 					});
 				}
-				catch (Exception) { }
+				catch (Exception e)
+				{
+					Log.Write("debug", "Failed parsing mapserver response: {0}", e);
+				}
 
 				// Commit updated data before running the callbacks
 				innerData = newData;


### PR DESCRIPTION
If the mapserver returned an unusable minimap blob, we'd end up dropping
the resulting exceptions on the floor, and committing a completely broken
MapPreview, which would then blow up the tail end of the map change
process, and all future ValidateClient calls after players join (which
itself was handled by kicking the player and logging some noise of dubious
value).

Adjusts exception handling in a number of places to log the exception
rather than dropping it on the floor, and makes the mapserver response
parsing tolerant of bogus minimap blobs -- in this case, we'd rather just
have no minimap.

Candidate for stable, as it fixes a bug present in the current release and
the current playtest series.

Signed-off-by: Chris Forbes chrisf@ijw.co.nz
