### PR TITLE
Change Game.RunTime to a long to prevent overflow

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -489,6 +489,11 @@ namespace OpenRA
 			return int.TryParse(s, NumberStyles.Integer, NumberFormatInfo.InvariantInfo, out i);
 		}
 
+		public static bool TryParseInt64Invariant(string s, out long i)
+		{
+			return long.TryParse(s, NumberStyles.Integer, NumberFormatInfo.InvariantInfo, out i);
+		}
+
 		public static bool IsTraitEnabled(this object trait)
 		{
 			return trait as IDisabledTrait == null || !(trait as IDisabledTrait).IsTraitDisabled;

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -96,7 +96,7 @@ namespace OpenRA
 
 		// More accurate replacement for Environment.TickCount
 		static Stopwatch stopwatch = Stopwatch.StartNew();
-		public static int RunTime { get { return (int)stopwatch.ElapsedMilliseconds; } }
+		public static long RunTime { get { return stopwatch.ElapsedMilliseconds; } }
 
 		public static int RenderFrame = 0;
 		public static int NetFrameNumber { get { return OrderManager.NetFrameNumber; } }
@@ -735,7 +735,7 @@ namespace OpenRA
 					}
 				}
 				else
-					Thread.Sleep(nextUpdate - now);
+					Thread.Sleep((int)(nextUpdate - now));
 			}
 		}
 

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Graphics
 			}
 		}
 
-		public static int TicksSinceLastMove = 0;
+		public static long TicksSinceLastMove = 0;
 		public static int2 LastMousePos;
 
 		float ClosestTo(float[] collection, float target)

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Network
 		public int LocalFrameNumber;
 		public int FramesAhead = 0;
 
-		public int LastTickTime = Game.RunTime;
+		public long LastTickTime = Game.RunTime;
 
 		public bool GameStarted { get { return NetFrameNumber != 0; } }
 		public IConnection Connection { get; private set; }

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -135,9 +135,9 @@ namespace OpenRA.Network
 		public class ClientPing
 		{
 			public int Index;
-			public int Latency = -1;
-			public int LatencyJitter = -1;
-			public int[] LatencyHistory = { };
+			public long Latency = -1;
+			public long LatencyJitter = -1;
+			public long[] LatencyHistory = { };
 
 			public static ClientPing Deserialize(MiniYaml data)
 			{

--- a/OpenRA.Game/Primitives/ActionQueue.cs
+++ b/OpenRA.Game/Primitives/ActionQueue.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Primitives
 	{
 		readonly List<DelayedAction> actions = new List<DelayedAction>();
 
-		public void Add(Action a, int desiredTime)
+		public void Add(Action a, long desiredTime)
 		{
 			if (a == null)
 				throw new ArgumentNullException("a");
@@ -34,7 +34,7 @@ namespace OpenRA.Primitives
 			}
 		}
 
-		public void PerformActions(int currentTime)
+		public void PerformActions(long currentTime)
 		{
 			DelayedAction[] pendingActions;
 			lock (actions)
@@ -67,10 +67,10 @@ namespace OpenRA.Primitives
 
 	struct DelayedAction : IComparable<DelayedAction>
 	{
-		public readonly int Time;
+		public readonly long Time;
 		public readonly Action Action;
 
-		public DelayedAction(Action action, int time)
+		public DelayedAction(Action action, long time)
 		{
 			Action = action;
 			Time = time;

--- a/OpenRA.Game/Server/Connection.cs
+++ b/OpenRA.Game/Server/Connection.cs
@@ -26,9 +26,9 @@ namespace OpenRA.Server
 		public int Frame = 0;
 		public int MostRecentFrame = 0;
 
-		public int TimeSinceLastResponse { get { return Game.RunTime - lastReceivedTime; } }
+		public long TimeSinceLastResponse { get { return Game.RunTime - lastReceivedTime; } }
 		public bool TimeoutMessageShown = false;
-		int lastReceivedTime = 0;
+		long lastReceivedTime = 0;
 
 		/* client data */
 		public int PlayerIndex;

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -501,8 +501,8 @@ namespace OpenRA.Server
 					break;
 				case "Pong":
 					{
-						int pingSent;
-						if (!OpenRA.Exts.TryParseIntegerInvariant(so.Data, out pingSent))
+						long pingSent;
+						if (!OpenRA.Exts.TryParseInt64Invariant(so.Data, out pingSent))
 						{
 							Log.Write("server", "Invalid order pong payload: {0}", so.Data);
 							break;

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Widgets
 	{
 		public static Widget Root = new RootWidget();
 
-		public static int LastTickTime = Game.RunTime;
+		public static long LastTickTime = Game.RunTime;
 
 		static readonly Stack<Widget> WindowList = new Stack<Widget>();
 

--- a/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Server
 		public void GameStarted(S server) { PingMasterServer(server); }
 		public void GameEnded(S server) { PingMasterServer(server); }
 
-		int lastPing = 0;
+		long lastPing = 0;
 		bool isInitialPing = true;
 
 		volatile bool isBusy;

--- a/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
@@ -24,8 +24,8 @@ namespace OpenRA.Mods.Common.Server
 		// TickTimeout is in microseconds
 		public int TickTimeout { get { return PingInterval * 100; } }
 
-		int lastPing = 0;
-		int lastConnReport = 0;
+		long lastPing = 0;
+		long lastConnReport = 0;
 		bool isInitialPing = true;
 
 		public void Tick(S server)

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -124,7 +124,7 @@ namespace OpenRA.Mods.Common.Widgets
 			tooltipContainer.Value.RemoveTooltip();
 		}
 
-		int lastScrollTime = 0;
+		long lastScrollTime = 0;
 		public override void Draw()
 		{
 			if (IsJoystickScrolling)


### PR DESCRIPTION
Fixes #12073.

Just changed Game.RunTime to a long and kept going until the compiler stopped yelling.
