### PR TITLE
Read data from *all* connections to the server.

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -185,17 +185,21 @@ namespace OpenRA.Server
 					foreach (var s in checkRead)
 					{
 						if (s == listener.Server)
+						{
 							AcceptConnection();
-						else if (PreConns.Count > 0)
-						{
-							var p = PreConns.SingleOrDefault(c => c.Socket == s);
-							if (p != null) p.ReadData(this);
+							continue;
 						}
-						else if (Conns.Count > 0)
+
+						var preConn = PreConns.SingleOrDefault(c => c.Socket == s);
+						if (preConn != null)
 						{
-							var conn = Conns.SingleOrDefault(c => c.Socket == s);
-							if (conn != null) conn.ReadData(this);
+							preConn.ReadData(this);
+							continue;
 						}
+
+						var conn = Conns.SingleOrDefault(c => c.Socket == s);
+						if (conn != null)
+							conn.ReadData(this);
 					}
 
 					foreach (var t in serverTraits.WithInterface<ITick>())


### PR DESCRIPTION
Fixes #10094 🎉 

This was a really dumb one: the server would ignore all of the "normal" connections if there were any connections waiting in the handshaking (PreConns) list.  If a connection died before completing the handshake, then that would permanently lock the server for everyone else.

This doesn't try to clean up any dead connections in the PreConns list: they will be thrown out when the game switches to the playing state.

Ask on IRC if you want steps to easily trigger the grey-ping issue.  I'm not going to announce them here because they could be used maliciously.
