### PR TITLE
Clean up ClientPings when a player drops from the server.

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -563,6 +563,7 @@ namespace OpenRA.Server
 				DispatchOrdersToClients(toDrop, 0, new ServerOrder("Disconnected", "").Serialize());
 
 				LobbyInfo.Clients.RemoveAll(c => c.Index == toDrop.PlayerIndex);
+				LobbyInfo.ClientPings.RemoveAll(p => p.Index == toDrop.PlayerIndex);
 
 				// Client was the server admin
 				// TODO: Reassign admin for game in progress via an order


### PR DESCRIPTION
Fixes #12072.

The easiest way to test this is to add `System.Console.WriteLine(order.TargetString);` to the top of `UnitOrders.ProcessOrder` and then join/disconnect from a server a few times.  Before the fix you'll see all the orphaned ping objects be sent to your client.  After the fix you won't.
