### PR TITLE
Include dates in crash/sync log filenames.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -71,9 +72,8 @@ namespace OpenRA
 
 		static string TimestampedFilename(bool includemilliseconds = false)
 		{
-			return includemilliseconds
-			? DateTime.UtcNow.ToString("OpenRA-yyyy-MM-ddTHHmmssfffZ")
-			: DateTime.UtcNow.ToString("OpenRA-yyyy-MM-ddTHHmmssZ");
+			var format = includemilliseconds ? "yyyy-MM-ddTHHmmssfffZ" : "yyyy-MM-ddTHHmmssZ";
+			return "OpenRA-" + DateTime.UtcNow.ToString(format, CultureInfo.InvariantCulture);
 		}
 
 		static void JoinInner(OrderManager om)

--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -18,6 +18,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Network
 {
+	using System.Globalization;
 	using NamesValuesPair = Pair<string[], object[]>;
 
 	class SyncReport
@@ -92,7 +93,7 @@ namespace OpenRA.Network
 
 		internal void DumpSyncReport(int frame, IEnumerable<FrameData.ClientOrder> orders)
 		{
-			var reportName = "syncreport-" + DateTime.UtcNow.ToString("yyyy-MM-ddTHHmmssZ") + ".log";
+			var reportName = "syncreport-" + DateTime.UtcNow.ToString("yyyy-MM-ddTHHmmssZ", CultureInfo.InvariantCulture) + ".log";
 			Log.AddChannel("sync", reportName);
 
 			foreach (var r in syncReports)

--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -92,7 +92,8 @@ namespace OpenRA.Network
 
 		internal void DumpSyncReport(int frame, IEnumerable<FrameData.ClientOrder> orders)
 		{
-			Log.AddChannel("sync", "syncreport.log");
+			var reportName = "syncreport-" + DateTime.UtcNow.ToString("yyyy-MM-ddTHHmmssZ") + ".log";
+			Log.AddChannel("sync", reportName);
 
 			foreach (var r in syncReports)
 			{

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -152,6 +152,7 @@ namespace OpenRA.Server
 					Map = settings.Map,
 					ServerName = settings.Name,
 					EnableSingleplayer = settings.EnableSingleplayer || !dedicated,
+					GameUid = Guid.NewGuid().ToString()
 				}
 			};
 

--- a/OpenRA.Game/Support/Program.cs
+++ b/OpenRA.Game/Support/Program.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -48,7 +49,7 @@ namespace OpenRA
 
 		static void FatalError(Exception ex)
 		{
-			var exceptionName = "exception-" + DateTime.UtcNow.ToString("yyyy-MM-ddTHHmmssZ") + ".log";
+			var exceptionName = "exception-" + DateTime.UtcNow.ToString("yyyy-MM-ddTHHmmssZ", CultureInfo.InvariantCulture) + ".log";
 			Log.AddChannel("exception", exceptionName);
 
 			if (Game.ModData != null)

--- a/OpenRA.Game/Support/Program.cs
+++ b/OpenRA.Game/Support/Program.cs
@@ -48,7 +48,8 @@ namespace OpenRA
 
 		static void FatalError(Exception ex)
 		{
-			Log.AddChannel("exception", "exception.log");
+			var exceptionName = "exception-" + DateTime.UtcNow.ToString("yyyy-MM-ddTHHmmssZ") + ".log";
+			Log.AddChannel("exception", exceptionName);
 
 			if (Game.ModData != null)
 			{


### PR DESCRIPTION
This builds on #11985/#12056 by giving the sync and exception logs unique filenames.  This makes it easier to identify and grab older logs, with the tradeoff of making the logs dir more cluttered for people like ourselves who regularly crash the game.

This also fixes a regression from #4138, which broke the GameUID written to the syncreports.  If the log renames are controversial then we should at least take this fix.
