### PR TITLE
Fix spy infiltration cursor giving away fake buildings.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
@@ -69,7 +69,17 @@ namespace OpenRA.Mods.Common.Traits.Render
 			Anim.PlayRepeating(info.Sequence);
 		}
 
-		public virtual bool ShouldRender(Actor self) { return true; }
+		protected virtual bool ShouldRender(Actor self)
+		{
+			if (self.World.RenderPlayer != null)
+			{
+				var stance = self.Owner.Stances[self.World.RenderPlayer];
+				if (!Info.ValidStances.HasStance(stance))
+					return false;
+			}
+
+			return true;
+		}
 
 		IEnumerable<IRenderable> IRenderAboveShroud.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
@@ -85,13 +95,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			if (IsTraitDisabled || self.IsDead || !self.IsInWorld || Anim == null)
 				return Enumerable.Empty<IRenderable>();
-
-			if (self.World.RenderPlayer != null)
-			{
-				var stance = self.Owner.Stances[self.World.RenderPlayer];
-				if (!Info.ValidStances.HasStance(stance))
-					return Enumerable.Empty<IRenderable>();
-			}
 
 			if (!ShouldRender(self) || self.World.FogObscures(self))
 				return Enumerable.Empty<IRenderable>();

--- a/OpenRA.Mods.D2k/Traits/Render/WithDecorationCarryable.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithDecorationCarryable.cs
@@ -31,9 +31,9 @@ namespace OpenRA.Mods.D2k.Traits.Render
 			carryable = self.Trait<Carryable>();
 		}
 
-		public override bool ShouldRender(Actor self)
+		protected override bool ShouldRender(Actor self)
 		{
-			return carryable.Reserved;
+			return carryable.Reserved && base.ShouldRender(self);
 		}
 	}
 }

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Scripting\Properties\ParatroopersProperties.cs" />
     <Compile Include="Traits\Render\WithDisguisingInfantryBody.cs" />
     <Compile Include="ImportRedAlertLegacyMapCommand.cs" />
+    <Compile Include="Traits\Infiltration\InfiltrateForDecoration.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj">

--- a/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForDecoration.cs
+++ b/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForDecoration.cs
@@ -1,0 +1,43 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Traits.Render;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.RA.Traits
+{
+	[Desc("Reveals a decoration sprite to the indicated players when infiltrated.")]
+	class InfiltrateForDecorationInfo : WithDecorationInfo
+	{
+		public override object Create(ActorInitializer init) { return new InfiltrateForDecoration(init.Self, this); }
+	}
+
+	class InfiltrateForDecoration : WithDecoration, INotifyInfiltrated
+	{
+		readonly HashSet<Player> infiltrators = new HashSet<Player>();
+
+		public InfiltrateForDecoration(Actor self, InfiltrateForDecorationInfo info)
+			: base(self, info) { }
+
+		public void Infiltrated(Actor self, Actor infiltrator)
+		{
+			infiltrators.Add(infiltrator.Owner);
+		}
+
+		protected override bool ShouldRender(Actor self)
+		{
+			return self.World.RenderPlayer == null || infiltrators.Any(i =>
+				Info.ValidStances.HasStance(i.Stances[self.World.RenderPlayer]));
+		}
+	}
+}

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -582,6 +582,16 @@
 	-EmitInfantryOnSell:
 	-MustBeDestroyed:
 
+^InfiltratableFake:
+	Targetable:
+		TargetTypes: Ground, Structure, C4, DetonateAttack, SpyInfiltrate
+	InfiltrateForDecoration:
+		RequiresSelection: true
+		Image: pips
+		Sequence: tag-fake
+		ReferencePoint: Top
+		ZOffset: 256
+
 ^AmmoBox:
 	Inherits: ^TechBuilding
 	-Selectable:

--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -1,5 +1,6 @@
 FPWR:
 	Inherits: ^FakeBuilding
+	Inherits@infiltrate: ^InfiltratableFake
 	Buildable:
 		BuildPaletteOrder: 870
 		Queue: Defense
@@ -26,6 +27,7 @@ FPWR:
 
 SYRF:
 	Inherits: ^FakeBuilding
+	Inherits@infiltrate: ^InfiltratableFake
 	Buildable:
 		BuildPaletteOrder: 890
 		Queue: Defense
@@ -38,7 +40,7 @@ SYRF:
 		GenericVisibility: Enemy
 		GenericStancePrefix: False
 	Targetable:
-		TargetTypes: Ground, Water, Structure
+		TargetTypes: Ground, Water, Structure, SpyInfiltrate
 	Building:
 		Footprint: xxx xxx xxx
 		Dimensions: 3,3
@@ -57,8 +59,9 @@ SYRF:
 
 SPEF:
 	Inherits: ^FakeBuilding
+	Inherits@infiltrate: ^InfiltratableFake
 	Targetable:
-		TargetTypes: Ground, Water, Structure
+		TargetTypes: Ground, Water, Structure, SpyInfiltrate
 	Buildable:
 		BuildPaletteOrder: 890
 		Queue: Defense
@@ -88,6 +91,7 @@ SPEF:
 
 WEAF:
 	Inherits: ^FakeBuilding
+	Inherits@infiltrate: ^InfiltratableFake
 	Buildable:
 		BuildPaletteOrder: 920
 		Prerequisites: ~structures.france, ~techlevel.medium
@@ -116,6 +120,7 @@ WEAF:
 
 DOMF:
 	Inherits: ^FakeBuilding
+	Inherits@infiltrate: ^InfiltratableFake
 	Tooltip:
 		Icon: fake-icon
 		Name: Fake Radar Dome
@@ -171,6 +176,7 @@ FIXF:
 
 FAPW:
 	Inherits: ^FakeBuilding
+	Inherits@infiltrate: ^InfiltratableFake
 	Buildable:
 		BuildPaletteOrder: 950
 		Queue: Defense


### PR DESCRIPTION
Fixes #10355.

This is a simple fix for an exploitable bug, so I'd like to see this included in the next playtest.
