### PR TITLE
Use CosmeticRandom for picking smudge type.

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -146,7 +146,7 @@ namespace OpenRA.Mods.Common.Traits
 			if ((!dirty.ContainsKey(loc) || dirty[loc].Sprite == null) && !tiles.ContainsKey(loc))
 			{
 				// No smudge; create a new one
-				var st = smudges.Keys.Random(world.SharedRandom);
+				var st = smudges.Keys.Random(Game.CosmeticRandom);
 				dirty[loc] = new Smudge { Type = st, Depth = 0, Sprite = smudges[st][0] };
 			}
 			else


### PR DESCRIPTION
This is a temporary workaround that fixes #12091 until we can rework these traits properly in (hopefully) Next+1 (see #12093).

See #12091 for the repro case.
