### PR TITLE
Display error in Asset Browser instead of crashing

### DIFF
--- a/mods/cnc/chrome/assetbrowser.yaml
+++ b/mods/cnc/chrome/assetbrowser.yaml
@@ -105,6 +105,13 @@ Container@ASSETBROWSER_PANEL:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							AspectRatio: 1
+						Label@ERROR:
+							X: 5
+							Width: 490 - 10
+							Height: 325
+							Align: Center
+							Visible: false
+							Text: Error displaying {filename} check assetbrowser.log
 				Container@FRAME_SELECTOR:
 					X: 190
 					Y: 395

--- a/mods/ra/chrome/assetbrowser.yaml
+++ b/mods/ra/chrome/assetbrowser.yaml
@@ -100,6 +100,13 @@ Background@ASSETBROWSER_PANEL:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM
 					AspectRatio: 1
+				Label@ERROR:
+					X: 5
+					Width: 490 - 10
+					Height: 330
+					Align: Center
+					Visible: false
+					Text: Error displaying {filename} check assetbrowser.log
 		Container@FRAME_SELECTOR:
 			X: 190
 			Y: 425


### PR DESCRIPTION
![screen shot 2016-09-24 at 11 29 17 am](https://cloud.githubusercontent.com/assets/4861023/18809761/3706e51e-824a-11e6-90af-2b49cfb9e3c2.png)

In `assetbrowser.log`:

```
Error reading phrohdoh-really-long-name-seriously-this-is-way-too-much.shp:
 Attempted to read past the end of the stream.
  at OpenRA.StreamExts.ReadBytes (System.IO.Stream s, System.Byte[] buffer, System.Int32 offset, System.Int32 count) [0x00046] in /Users/thill/projects/play/openra/OpenRA.Game//StreamExts.cs:42 
  at OpenRA.StreamExts.ReadBytes (System.IO.Stream s, System.Int32 count) [0x00023] in /Users/thill/projects/play/openra/OpenRA.Game//StreamExts.cs:26 
  at OpenRA.StreamExts.ReadUInt16 (System.IO.Stream s) [0x00003] in /Users/thill/projects/play/openra/OpenRA.Game//StreamExts.cs:63 
  at OpenRA.Mods.Common.SpriteLoaders.ShpD2Loader.IsShpD2 (System.IO.Stream s) [0x00008] in <fb94b0ec366a43839817021eba866762>:0 
  at OpenRA.Mods.Common.SpriteLoaders.ShpD2Loader.TryParseSprite (System.IO.Stream s, OpenRA.Graphics.ISpriteFrame[]& frames) [0x00001] in <fb94b0ec366a43839817021eba866762>:0 
  at OpenRA.Graphics.SpriteLoader.GetFrames (System.IO.Stream stream, OpenRA.Graphics.ISpriteLoader[] loaders) [0x00013] in /Users/thill/projects/play/openra/OpenRA.Game//Graphics/SpriteLoader.cs:125 
  at OpenRA.Graphics.SpriteLoader.GetFrames (OpenRA.FileSystem.IReadOnlyFileSystem fileSystem, System.String filename, OpenRA.Graphics.ISpriteLoader[] loaders) [0x0000c] in /Users/thill/projects/play/openra/OpenRA.Game//Graphics/SpriteLoader.cs:113 
  at OpenRA.Graphics.SpriteLoader.GetSprites (OpenRA.FileSystem.IReadOnlyFileSystem fileSystem, System.String filename, OpenRA.Graphics.ISpriteLoader[] loaders, OpenRA.Graphics.SheetBuilder sheetBuilder) [0x00011] in /Users/thill/projects/play/openra/OpenRA.Game//Graphics/SpriteLoader.cs:106 
  at OpenRA.Graphics.SpriteCache.LoadSprite (System.String filename, System.Collections.Generic.List`1[T] cache) [0x00014] in /Users/thill/projects/play/openra/OpenRA.Game//Graphics/SpriteLoader.cs:61 
  at OpenRA.Graphics.SpriteCache.get_Item (System.String filename) [0x00020] in /Users/thill/projects/play/openra/OpenRA.Game//Graphics/SpriteLoader.cs:73 
  at OpenRA.Mods.Common.Widgets.Logic.AssetBrowserLogic.LoadAsset (System.String filename) [0x00111] in <fb94b0ec366a43839817021eba866762>:0 
```
