### PR TITLE
[Installer] Allow an installed (en-US) TFD as Source

### DIFF
--- a/mods/cnc/installer/firstdecade.yaml
+++ b/mods/cnc/installer/firstdecade.yaml
@@ -334,3 +334,336 @@ tfd: C&C The First Decade (English)
 				Offset: 751962554
 				Length: 2229408
 		delete: ^Content/cnc/movies.mix
+tfd-installed: C&C The First Decade (Installed, English)
+	Type: Install
+	RegistryKey: HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Electronic Arts\EA Games\Command and Conquer The First Decade
+	RegistryValue: cc_folder
+	IDFiles:
+		C&C95.exe: 1c413007850277c02f916152fcb7153d2162d5e9
+		CONQUER.MIX: 833e02a09aae694659eb312d3838367f681d1b30
+	Install:
+		copy: .
+			^Content/cnc/conquer.mix: CONQUER.MIX
+			^Content/cnc/desert.mix: DESERT.MIX
+			^Content/cnc/general.mix: GENERAL.MIX
+			^Content/cnc/scores.mix: SCORES.MIX
+			^Content/cnc/sounds.mix: SOUNDS.MIX
+			^Content/cnc/temperat.mix: TEMPERAT.MIX
+			^Content/cnc/winter.mix: WINTER.MIX
+			^Content/cnc/speech.mix: SPEECH.MIX
+			^Content/cnc/tempicnh.mix: TEMPICNH.MIX
+			^Content/cnc/transit.mix: TRANSIT.MIX
+			^Content/cnc/scores-covertops.mix: covert/SCORES.MIX
+		extract-raw: MOVIES.MIX
+			^Content/cnc/movies/airstrk.vqa:
+				Offset: 1266
+				Length: 4444442
+			^Content/cnc/movies/akira.vqa:
+				Offset: 4445708
+				Length: 7803444
+			^Content/cnc/movies/bkground.vqa:
+				Offset: 12249152
+				Length: 15267052
+			^Content/cnc/movies/burdet1.vqa:
+				Offset: 27516204
+				Length: 10410614
+			^Content/cnc/movies/burdet2.vqa:
+				Offset: 37926818
+				Length: 2062190
+			^Content/cnc/movies/gdi4a.vqa:
+				Offset: 39989008
+				Length: 4450582
+			^Content/cnc/movies/gdi4b.vqa:
+				Offset: 44439590
+				Length: 6603530
+			^Content/cnc/movies/gdifina.vqa:
+				Offset: 51043120
+				Length: 12888650
+			^Content/cnc/movies/gdifinb.vqa:
+				Offset: 63931770
+				Length: 17769978
+			^Content/cnc/movies/nod7a.vqa:
+				Offset: 81701748
+				Length: 4740470
+			^Content/cnc/movies/nod7b.vqa:
+				Offset: 86442218
+				Length: 4671402
+			^Content/cnc/movies/visor.vqa:
+				Offset: 91113620
+				Length: 4407162
+			^Content/cnc/movies/turtkill.vqa:
+				Offset: 95520782
+				Length: 3323444
+			^Content/cnc/movies/trtkil_d.vqa:
+				Offset: 98844226
+				Length: 3511836
+			^Content/cnc/movies/trailer.vqa:
+				Offset: 102356062
+				Length: 23163930
+			^Content/cnc/movies/tiberfx.vqa:
+				Offset: 125519992
+				Length: 8735102
+			^Content/cnc/movies/tbrinfo3.vqa:
+				Offset: 134255094
+				Length: 14972046
+			^Content/cnc/movies/tbrinfo2.vqa:
+				Offset: 149227140
+				Length: 16195290
+			^Content/cnc/movies/tbrinfo1.vqa:
+				Offset: 165422430
+				Length: 23479052
+			^Content/cnc/movies/tankkill.vqa:
+				Offset: 188901482
+				Length: 3298978
+			^Content/cnc/movies/tankgo.vqa:
+				Offset: 192200460
+				Length: 1403876
+			^Content/cnc/movies/sundial.vqa:
+				Offset: 193604336
+				Length: 3653636
+			^Content/cnc/movies/stealth.vqa:
+				Offset: 197257972
+				Length: 4521860
+			^Content/cnc/movies/spycrash.vqa:
+				Offset: 201779832
+				Length: 1886288
+			^Content/cnc/movies/sethpre.vqa:
+				Offset: 203666120
+				Length: 10914610
+			^Content/cnc/movies/seige.vqa:
+				Offset: 214580730
+				Length: 2705978
+			^Content/cnc/movies/samsite.vqa:
+				Offset: 217286708
+				Length: 1410418
+			^Content/cnc/movies/samdie.vqa:
+				Offset: 218697126
+				Length: 3741942
+			^Content/cnc/movies/sabotage.vqa:
+				Offset: 222439068
+				Length: 1386202
+			^Content/cnc/movies/retro.vqa:
+				Offset: 223825270
+				Length: 6434382
+			^Content/cnc/movies/refint.vqa:
+				Offset: 230259652
+				Length: 5090040
+			^Content/cnc/movies/podium.vqa:
+				Offset: 235349692
+				Length: 2790664
+			^Content/cnc/movies/planecra.vqa:
+				Offset: 238140356
+				Length: 5085426
+			^Content/cnc/movies/pintle.vqa:
+				Offset: 243225782
+				Length: 2757536
+			^Content/cnc/movies/paratrop.vqa:
+				Offset: 245983318
+				Length: 3180272
+			^Content/cnc/movies/obel.vqa:
+				Offset: 249163590
+				Length: 3851370
+			^Content/cnc/movies/nuke.vqa:
+				Offset: 253014960
+				Length: 3126662
+			^Content/cnc/movies/nodsweep.vqa:
+				Offset: 256141622
+				Length: 3642174
+			^Content/cnc/movies/nodlose.vqa:
+				Offset: 259783796
+				Length: 5148924
+			^Content/cnc/movies/nodflees.vqa:
+				Offset: 264932720
+				Length: 3056426
+			^Content/cnc/movies/nodfinal.vqa:
+				Offset: 267989146
+				Length: 23326586
+			^Content/cnc/movies/nodend4.vqa:
+				Offset: 291315732
+				Length: 25535232
+			^Content/cnc/movies/nodend3.vqa:
+				Offset: 316850964
+				Length: 25725824
+			^Content/cnc/movies/nodend2.vqa:
+				Offset: 342576788
+				Length: 27214048
+			^Content/cnc/movies/nodend1.vqa:
+				Offset: 369790836
+				Length: 27172272
+			^Content/cnc/movies/nod9.vqa:
+				Offset: 396963108
+				Length: 9357980
+			^Content/cnc/movies/nod8.vqa:
+				Offset: 406321088
+				Length: 11597940
+			^Content/cnc/movies/nod6.vqa:
+				Offset: 417919028
+				Length: 5007744
+			^Content/cnc/movies/nod5.vqa:
+				Offset: 422926772
+				Length: 6641700
+			^Content/cnc/movies/nod4b.vqa:
+				Offset: 429568472
+				Length: 3867618
+			^Content/cnc/movies/nod4a.vqa:
+				Offset: 433436090
+				Length: 3838924
+			^Content/cnc/movies/nod3.vqa:
+				Offset: 437275014
+				Length: 3603314
+			^Content/cnc/movies/nod2.vqa:
+				Offset: 440878328
+				Length: 7200720
+			^Content/cnc/movies/nod1pre.vqa:
+				Offset: 448079048
+				Length: 395720
+			^Content/cnc/movies/nod13.vqa:
+				Offset: 448474768
+				Length: 2746626
+			^Content/cnc/movies/nod12.vqa:
+				Offset: 451221394
+				Length: 6576562
+			^Content/cnc/movies/nod11.vqa:
+				Offset: 457797956
+				Length: 4629270
+			^Content/cnc/movies/nod10b.vqa:
+				Offset: 462427226
+				Length: 6386444
+			^Content/cnc/movies/nod10a.vqa:
+				Offset: 468813670
+				Length: 7205632
+			^Content/cnc/movies/nod1.vqa:
+				Offset: 476019302
+				Length: 4663258
+			^Content/cnc/movies/nitejump.vqa:
+				Offset: 480682560
+				Length: 3702838
+			^Content/cnc/movies/napalm.vqa:
+				Offset: 484385398
+				Length: 4004146
+			^Content/cnc/movies/logo.vqa:
+				Offset: 488389544
+				Length: 3562630
+			^Content/cnc/movies/landing.vqa:
+				Offset: 491952174
+				Length: 1617094
+			^Content/cnc/movies/kanepre.vqa:
+				Offset: 493569268
+				Length: 17220712
+			^Content/cnc/movies/intro2.vqa:
+				Offset: 510789980
+				Length: 21058732
+			^Content/cnc/movies/insites.vqa:
+				Offset: 531848712
+				Length: 460482
+			^Content/cnc/movies/hellvaly.vqa:
+				Offset: 532309194
+				Length: 6658950
+			^Content/cnc/movies/gunboat.vqa:
+				Offset: 538968144
+				Length: 3203706
+			^Content/cnc/movies/generic.vqa:
+				Offset: 542171850
+				Length: 1452820
+			^Content/cnc/movies/gdilose.vqa:
+				Offset: 543624670
+				Length: 2097912
+			^Content/cnc/movies/gdiend2.vqa:
+				Offset: 545722582
+				Length: 25242946
+			^Content/cnc/movies/gdiend1.vqa:
+				Offset: 570965528
+				Length: 25311636
+			^Content/cnc/movies/gdi9.vqa:
+				Offset: 596277164
+				Length: 11806994
+			^Content/cnc/movies/gdi8b.vqa:
+				Offset: 608084158
+				Length: 5324410
+			^Content/cnc/movies/gdi8a.vqa:
+				Offset: 613408568
+				Length: 4672548
+			^Content/cnc/movies/gdi7.vqa:
+				Offset: 618081116
+				Length: 4241952
+			^Content/cnc/movies/gdi6.vqa:
+				Offset: 622323068
+				Length: 3959650
+			^Content/cnc/movies/gdi5.vqa:
+				Offset: 626282718
+				Length: 3818244
+			^Content/cnc/movies/gdi3lose.vqa:
+				Offset: 630100962
+				Length: 2265770
+			^Content/cnc/movies/gdi3.vqa:
+				Offset: 632366732
+				Length: 5443848
+			^Content/cnc/movies/gdi2.vqa:
+				Offset: 637810580
+				Length: 7883500
+			^Content/cnc/movies/gdi15.vqa:
+				Offset: 645694080
+				Length: 11684610
+			^Content/cnc/movies/gdi14.vqa:
+				Offset: 657378690
+				Length: 5282770
+			^Content/cnc/movies/gdi13.vqa:
+				Offset: 662661460
+				Length: 6900914
+			^Content/cnc/movies/gdi12.vqa:
+				Offset: 669562374
+				Length: 3669404
+			^Content/cnc/movies/gdi11.vqa:
+				Offset: 673231778
+				Length: 5895754
+			^Content/cnc/movies/gdi10.vqa:
+				Offset: 679127532
+				Length: 5761514
+			^Content/cnc/movies/gdi1.vqa:
+				Offset: 684889046
+				Length: 6341298
+			^Content/cnc/movies/gameover.vqa:
+				Offset: 691230344
+				Length: 2087322
+			^Content/cnc/movies/forestkl.vqa:
+				Offset: 693317666
+				Length: 1500986
+			^Content/cnc/movies/flyy.vqa:
+				Offset: 694818652
+				Length: 1373532
+			^Content/cnc/movies/flag.vqa:
+				Offset: 696192184
+				Length: 4308680
+			^Content/cnc/movies/dino.vqa:
+				Offset: 700500864
+				Length: 1347896
+			^Content/cnc/movies/dessweep.vqa:
+				Offset: 701848760
+				Length: 3563646
+			^Content/cnc/movies/desolat.vqa:
+				Offset: 705412406
+				Length: 8385122
+			^Content/cnc/movies/deskill.vqa:
+				Offset: 713797528
+				Length: 1483634
+			^Content/cnc/movies/desflees.vqa:
+				Offset: 715281162
+				Length: 2698426
+			^Content/cnc/movies/consyard.vqa:
+				Offset: 717979588
+				Length: 7864652
+			^Content/cnc/movies/cc2tease.vqa:
+				Offset: 725844240
+				Length: 12506712
+			^Content/cnc/movies/bombflee.vqa:
+				Offset: 738350952
+				Length: 2859726
+			^Content/cnc/movies/bombaway.vqa:
+				Offset: 741210678
+				Length: 5579588
+			^Content/cnc/movies/bcanyon.vqa:
+				Offset: 746790266
+				Length: 5172288
+			^Content/cnc/movies/banner.vqa:
+				Offset: 751962554
+				Length: 2229408

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -227,22 +227,22 @@ ModContent:
 	Packages:
 		base: Base Game Files
 			TestFiles: ^Content/cnc/conquer.mix, ^Content/cnc/desert.mix, ^Content/cnc/sounds.mix, ^Content/cnc/speech.mix, ^Content/cnc/temperat.mix, ^Content/cnc/tempicnh.mix, ^Content/cnc/winter.mix
-			Sources: gdi95, gdi95-linux, nod95, nod95-linux, tfd, origin
+			Sources: gdi95, gdi95-linux, nod95, nod95-linux, tfd, tfd-installed, origin
 			Required: true
 			Download: basefiles
 		music: Base Game Music
 			TestFiles: ^Content/cnc/scores.mix
-			Sources: gdi95, gdi95-linux, nod95, nod95-linux, tfd, origin
+			Sources: gdi95, gdi95-linux, nod95, nod95-linux, tfd, tfd-installed, origin
 			Download: music
 		movies-gdi: GDI Campaign Briefings
 			TestFiles: ^Content/cnc/movies/visor.vqa, ^Content/cnc/movies/turtkill.vqa, ^Content/cnc/movies/trailer.vqa, ^Content/cnc/movies/tbrinfo3.vqa, ^Content/cnc/movies/tbrinfo2.vqa, ^Content/cnc/movies/tbrinfo1.vqa, ^Content/cnc/movies/seige.vqa, ^Content/cnc/movies/samsite.vqa, ^Content/cnc/movies/samdie.vqa, ^Content/cnc/movies/sabotage.vqa, ^Content/cnc/movies/retro.vqa, ^Content/cnc/movies/podium.vqa, ^Content/cnc/movies/planecra.vqa, ^Content/cnc/movies/pintle.vqa, ^Content/cnc/movies/paratrop.vqa, ^Content/cnc/movies/nodsweep.vqa, ^Content/cnc/movies/nodlose.vqa, ^Content/cnc/movies/nodflees.vqa, ^Content/cnc/movies/nod1.vqa, ^Content/cnc/movies/nitejump.vqa, ^Content/cnc/movies/napalm.vqa, ^Content/cnc/movies/logo.vqa, ^Content/cnc/movies/landing.vqa, ^Content/cnc/movies/intro2.vqa, ^Content/cnc/movies/hellvaly.vqa, ^Content/cnc/movies/gunboat.vqa, ^Content/cnc/movies/generic.vqa, ^Content/cnc/movies/gdilose.vqa, ^Content/cnc/movies/gdifinb.vqa, ^Content/cnc/movies/gdifina.vqa, ^Content/cnc/movies/gdiend2.vqa, ^Content/cnc/movies/gdiend1.vqa, ^Content/cnc/movies/gdi9.vqa, ^Content/cnc/movies/gdi8b.vqa, ^Content/cnc/movies/gdi8a.vqa, ^Content/cnc/movies/gdi7.vqa, ^Content/cnc/movies/gdi6.vqa, ^Content/cnc/movies/gdi5.vqa, ^Content/cnc/movies/gdi4b.vqa, ^Content/cnc/movies/gdi4a.vqa, ^Content/cnc/movies/gdi3lose.vqa, ^Content/cnc/movies/gdi3.vqa, ^Content/cnc/movies/gdi2.vqa, ^Content/cnc/movies/gdi15.vqa, ^Content/cnc/movies/gdi14.vqa, ^Content/cnc/movies/gdi13.vqa, ^Content/cnc/movies/gdi12.vqa, ^Content/cnc/movies/gdi11.vqa, ^Content/cnc/movies/gdi10.vqa, ^Content/cnc/movies/gdi1.vqa, ^Content/cnc/movies/gameover.vqa, ^Content/cnc/movies/forestkl.vqa, ^Content/cnc/movies/flyy.vqa, ^Content/cnc/movies/flag.vqa, ^Content/cnc/movies/dino.vqa, ^Content/cnc/movies/desolat.vqa, ^Content/cnc/movies/consyard.vqa, ^Content/cnc/movies/cc2tease.vqa, ^Content/cnc/movies/burdet2.vqa, ^Content/cnc/movies/burdet1.vqa, ^Content/cnc/movies/bombflee.vqa, ^Content/cnc/movies/bombaway.vqa, ^Content/cnc/movies/bkground.vqa, ^Content/cnc/movies/bcanyon.vqa, ^Content/cnc/movies/banner.vqa
-			Sources: gdi95, gdi95-linux, tfd, origin
+			Sources: gdi95, gdi95-linux, tfd, tfd-installed, origin
 		movies-nod: Nod Campaign Briefings
 			TestFiles: ^Content/cnc/movies/visor.vqa, ^Content/cnc/movies/trtkil_d.vqa, ^Content/cnc/movies/trailer.vqa, ^Content/cnc/movies/tiberfx.vqa, ^Content/cnc/movies/tankkill.vqa, ^Content/cnc/movies/tankgo.vqa, ^Content/cnc/movies/sundial.vqa, ^Content/cnc/movies/stealth.vqa, ^Content/cnc/movies/spycrash.vqa, ^Content/cnc/movies/sethpre.vqa, ^Content/cnc/movies/seige.vqa, ^Content/cnc/movies/samsite.vqa, ^Content/cnc/movies/retro.vqa, ^Content/cnc/movies/refint.vqa, ^Content/cnc/movies/obel.vqa, ^Content/cnc/movies/nuke.vqa, ^Content/cnc/movies/nodlose.vqa, ^Content/cnc/movies/nodfinal.vqa, ^Content/cnc/movies/nodend4.vqa, ^Content/cnc/movies/nodend3.vqa, ^Content/cnc/movies/nodend2.vqa, ^Content/cnc/movies/nodend1.vqa, ^Content/cnc/movies/nod9.vqa, ^Content/cnc/movies/nod8.vqa, ^Content/cnc/movies/nod7b.vqa, ^Content/cnc/movies/nod7a.vqa, ^Content/cnc/movies/nod6.vqa, ^Content/cnc/movies/nod5.vqa, ^Content/cnc/movies/nod4b.vqa, ^Content/cnc/movies/nod4a.vqa, ^Content/cnc/movies/nod3.vqa, ^Content/cnc/movies/nod2.vqa, ^Content/cnc/movies/nod1pre.vqa, ^Content/cnc/movies/nod13.vqa, ^Content/cnc/movies/nod12.vqa, ^Content/cnc/movies/nod11.vqa, ^Content/cnc/movies/nod10b.vqa, ^Content/cnc/movies/nod10a.vqa, ^Content/cnc/movies/nod1.vqa, ^Content/cnc/movies/logo.vqa, ^Content/cnc/movies/landing.vqa, ^Content/cnc/movies/kanepre.vqa, ^Content/cnc/movies/intro2.vqa, ^Content/cnc/movies/insites.vqa, ^Content/cnc/movies/generic.vqa, ^Content/cnc/movies/gdi1.vqa, ^Content/cnc/movies/gameover.vqa, ^Content/cnc/movies/forestkl.vqa, ^Content/cnc/movies/flag.vqa, ^Content/cnc/movies/dino.vqa, ^Content/cnc/movies/dessweep.vqa, ^Content/cnc/movies/deskill.vqa, ^Content/cnc/movies/desflees.vqa, ^Content/cnc/movies/consyard.vqa, ^Content/cnc/movies/cc2tease.vqa, ^Content/cnc/movies/bombflee.vqa, ^Content/cnc/movies/bombaway.vqa, ^Content/cnc/movies/bcanyon.vqa, ^Content/cnc/movies/banner.vqa, ^Content/cnc/movies/akira.vqa, ^Content/cnc/movies/airstrk.vqa
-			Sources: nod95, nod95-linux, tfd, origin
+			Sources: nod95, nod95-linux, tfd, tfd-installed, origin
 		music-covertops: Covert Operations Music
 			TestFiles: ^Content/cnc/scores-covertops.mix
-			Sources: covertops, covertops-linux, tfd, origin
+			Sources: covertops, covertops-linux, tfd, tfd-installed, origin
 	Downloads:
 		cnc|installer/downloads.yaml
 	Sources:

--- a/mods/ra/installer/firstdecade.yaml
+++ b/mods/ra/installer/firstdecade.yaml
@@ -446,3 +446,456 @@ tfd: C&C The First Decade (English)
 				Offset: 844509702
 				Length: 9073
 		delete: ^Content/ra/v2/main.mix
+
+tfd-installed: C&C The First Decade (Installed, English)
+	Type: Install
+	RegistryKey: HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Electronic Arts\EA Games\Command and Conquer The First Decade
+	RegistryValue: ra_folder
+	IDFiles:
+		RA95.exe: 24e9b92420e9f5ae5f410e5af189145610bbd093
+		REDALERT.MIX: 0e58f4b54f44f6cd29fecf8cf379d33cf2d4caef
+	Install:
+		copy: .
+			^Content/ra/v2/expand/hires1.mix: HIRES1.MIX
+			^Content/ra/v2/expand/lores1.mix: LORES1.MIX
+			^Content/ra/v2/expand/expand.mix: EXPAND.MIX
+			^Content/ra/v2/expand/expand2.mix: EXPAND2.MIX
+		extract-raw: REDALERT.MIX
+			^Content/ra/v2/hires.mix:
+				Offset: 650612
+				Length: 5817417
+			^Content/ra/v2/local.mix:
+				Offset: 6468029
+				Length: 3829837
+			^Content/ra/v2/lores.mix:
+				Offset: 10297866
+				Length: 754800
+			^Content/ra/v2/speech.mix:
+				Offset: 23042864
+				Length: 2003464
+		extract-raw: MAIN.MIX
+			^Content/ra/v2/movies/aagun.vqa:
+				Offset: 668669829
+				Length: 3295512
+			^Content/ra/v2/movies/aftrmath.vqa:
+				Offset: 671965341
+				Length: 2455774
+			^Content/ra/v2/movies/ally12.vqa:
+				Offset: 430652277
+				Length: 7719544
+			^Content/ra/v2/movies/ally14.vqa:
+				Offset: 438371821
+				Length: 11659080
+			^Content/ra/v2/movies/allyend.vqa:
+				Offset: 450030901
+				Length: 27285692
+			^Content/ra/v2/movies/allymorf.vqa:
+				Offset: 477316593
+				Length: 916964
+			^Content/ra/v2/movies/apcescpe.vqa:
+				Offset: 483950063
+				Length: 1627564
+			^Content/ra/v2/movies/assess.vqa:
+				Offset: 485577627
+				Length: 2929218
+			^Content/ra/v2/movies/battle.vqa:
+				Offset: 488506845
+				Length: 2881110
+			^Content/ra/v2/movies/binoc.vqa:
+				Offset: 491387955
+				Length: 4045856
+			^Content/ra/v2/movies/bmap.vqa:
+				Offset: 495433811
+				Length: 2411294
+			^Content/ra/v2/movies/brdgtilt.vqa:
+				Offset: 497845105
+				Length: 1581318
+			^Content/ra/v2/movies/cronfail.vqa:
+				Offset: 499426423
+				Length: 1717214
+			^Content/ra/v2/movies/crontest.vqa:
+				Offset: 501143637
+				Length: 2036620
+			^Content/ra/v2/movies/destroyr.vqa:
+				Offset: 503180257
+				Length: 2178828
+			^Content/ra/v2/movies/dud.vqa:
+				Offset: 505359085
+				Length: 3110418
+			^Content/ra/v2/movies/elevator.vqa:
+				Offset: 508469503
+				Length: 1741894
+			^Content/ra/v2/movies/flare.vqa:
+				Offset: 511722609
+				Length: 1731744
+			^Content/ra/v2/movies/frozen.vqa:
+				Offset: 513454353
+				Length: 1836994
+			^Content/ra/v2/movies/grvestne.vqa:
+				Offset: 515291347
+				Length: 3155668
+			^Content/ra/v2/movies/landing.vqa:
+				Offset: 518447015
+				Length: 2374106
+			^Content/ra/v2/movies/masasslt.vqa:
+				Offset: 520821121
+				Length: 5354700
+			^Content/ra/v2/movies/mcv.vqa:
+				Offset: 526175821
+				Length: 1296036
+			^Content/ra/v2/movies/mcv_land.vqa:
+				Offset: 527471857
+				Length: 1424358
+			^Content/ra/v2/movies/montpass.vqa:
+				Offset: 528896215
+				Length: 1701852
+			^Content/ra/v2/movies/oildrum.vqa:
+				Offset: 530598067
+				Length: 2430792
+			^Content/ra/v2/movies/overrun.vqa:
+				Offset: 533028859
+				Length: 2174548
+			^Content/ra/v2/movies/prolog.vqa:
+				Offset: 535203407
+				Length: 28658198
+			^Content/ra/v2/movies/redintro.vqa:
+				Offset: 563861605
+				Length: 2269452
+			^Content/ra/v2/movies/shipsink.vqa:
+				Offset: 567961011
+				Length: 3150030
+			^Content/ra/v2/movies/shorbom1.vqa:
+				Offset: 571111041
+				Length: 4046650
+			^Content/ra/v2/movies/shorbom2.vqa:
+				Offset: 575157691
+				Length: 2150364
+			^Content/ra/v2/movies/shorbomb.vqa:
+				Offset: 577308055
+				Length: 6111616
+			^Content/ra/v2/movies/snowbomb.vqa:
+				Offset: 583419671
+				Length: 2465762
+			^Content/ra/v2/movies/soviet1.vqa:
+				Offset: 594906599
+				Length: 24112060
+			^Content/ra/v2/movies/sovtstar.vqa:
+				Offset: 619018659
+				Length: 670794
+			^Content/ra/v2/movies/spy.vqa:
+				Offset: 619689453
+				Length: 1646808
+			^Content/ra/v2/movies/tanya1.vqa:
+				Offset: 621336261
+				Length: 13389684
+			^Content/ra/v2/movies/tanya2.vqa:
+				Offset: 634725945
+				Length: 4103388
+			^Content/ra/v2/movies/toofar.vqa:
+				Offset: 640625425
+				Length: 4244572
+			^Content/ra/v2/movies/trinity.vqa:
+				Offset: 644869997
+				Length: 1669310
+			^Content/ra/v2/movies/ally1.vqa:
+				Offset: 674421115
+				Length: 13536324
+			^Content/ra/v2/movies/ally2.vqa:
+				Offset: 687957439
+				Length: 8014018
+			^Content/ra/v2/movies/ally4.vqa:
+				Offset: 695971457
+				Length: 9441906
+			^Content/ra/v2/movies/ally5.vqa:
+				Offset: 705413363
+				Length: 21900328
+			^Content/ra/v2/movies/ally6.vqa:
+				Offset: 727313691
+				Length: 26454212
+			^Content/ra/v2/movies/ally8.vqa:
+				Offset: 753767903
+				Length: 15401062
+			^Content/ra/v2/movies/ally9.vqa:
+				Offset: 769168965
+				Length: 14901460
+			^Content/ra/v2/movies/ally10.vqa:
+				Offset: 784070425
+				Length: 21506358
+			^Content/ra/v2/movies/ally10b.vqa:
+				Offset: 805576783
+				Length: 2565152
+			^Content/ra/v2/movies/ally11.vqa:
+				Offset: 808142713
+				Length: 13600398
+			^Content/ra/v2/interior.mix:
+				Offset: 821743111
+				Length: 249490
+			^Content/ra/v2/conquer.mix:
+				Offset: 840028549
+				Length: 2192279
+			^Content/ra/v2/allies.mix:
+				Offset: 842220828
+				Length: 319181
+			^Content/ra/v2/temperat.mix:
+				Offset: 842540009
+				Length: 1043672
+			^Content/ra/v2/sounds.mix:
+				Offset: 843583681
+				Length: 1385637
+			^Content/ra/v2/snow.mix:
+				Offset: 844969318
+				Length: 1035716
+			^Content/ra/v2/scores.mix:
+				Offset: 846005034
+				Length: 67742203
+			^Content/ra/v2/russian.mix:
+				Offset: 913747237
+				Length: 274732
+			^Content/ra/v2/movies/double.vqa:
+				Offset: 915739478
+				Length: 1608508
+			^Content/ra/v2/movies/dpthchrg.vqa:
+				Offset: 917347986
+				Length: 3048762
+			^Content/ra/v2/movies/execute.vqa:
+				Offset: 920396748
+				Length: 1511212
+			^Content/ra/v2/movies/flare.vqa:
+				Offset: 921907960
+				Length: 1731744
+			^Content/ra/v2/movies/landing.vqa:
+				Offset: 923639704
+				Length: 2374106
+			^Content/ra/v2/movies/mcvbrdge.vqa:
+				Offset: 926013810
+				Length: 2124412
+			^Content/ra/v2/movies/mig.vqa:
+				Offset: 928138222
+				Length: 6745398
+			^Content/ra/v2/movies/movingin.vqa:
+				Offset: 934883620
+				Length: 1185550
+			^Content/ra/v2/movies/mtnkfact.vqa:
+				Offset: 936069170
+				Length: 3168076
+			^Content/ra/v2/movies/nukestok.vqa:
+				Offset: 939237246
+				Length: 1877536
+			^Content/ra/v2/movies/onthprwl.vqa:
+				Offset: 941114782
+				Length: 2648948
+			^Content/ra/v2/movies/periscop.vqa:
+				Offset: 943763730
+				Length: 2099110
+			^Content/ra/v2/movies/prolog.vqa:
+				Offset: 945862840
+				Length: 28658198
+			^Content/ra/v2/movies/radrraid.vqa:
+				Offset: 974521038
+				Length: 1561740
+			^Content/ra/v2/movies/redintro.vqa:
+				Offset: 976082778
+				Length: 2269452
+			^Content/ra/v2/movies/search.vqa:
+				Offset: 978352230
+				Length: 2298940
+			^Content/ra/v2/movies/sfrozen.vqa:
+				Offset: 980651170
+				Length: 1829954
+			^Content/ra/v2/movies/sitduck.vqa:
+				Offset: 982481124
+				Length: 3650212
+			^Content/ra/v2/movies/slntsrvc.vqa:
+				Offset: 986131336
+				Length: 1774986
+			^Content/ra/v2/movies/snowbomb.vqa:
+				Offset: 987906322
+				Length: 2465762
+			^Content/ra/v2/movies/snstrafe.vqa:
+				Offset: 990372084
+				Length: 2473362
+			^Content/ra/v2/movies/sovbatl.vqa:
+				Offset: 992845446
+				Length: 3439876
+			^Content/ra/v2/movies/sovcemet.vqa:
+				Offset: 996285322
+				Length: 3107928
+			^Content/ra/v2/movies/sovfinal.vqa:
+				Offset: 999393250
+				Length: 35169890
+			^Content/ra/v2/movies/soviet1.vqa:
+				Offset: 1034563140
+				Length: 24112060
+			^Content/ra/v2/movies/soviet2.vqa:
+				Offset: 1058675200
+				Length: 9494814
+			^Content/ra/v2/movies/soviet3.vqa:
+				Offset: 1068170014
+				Length: 17229910
+			^Content/ra/v2/movies/soviet4.vqa:
+				Offset: 1085399924
+				Length: 7236290
+			^Content/ra/v2/movies/soviet5.vqa:
+				Offset: 1092636214
+				Length: 18986154
+			^Content/ra/v2/movies/soviet6.vqa:
+				Offset: 1111622368
+				Length: 6782016
+			^Content/ra/v2/movies/soviet7.vqa:
+				Offset: 1118404384
+				Length: 5637552
+			^Content/ra/v2/movies/soviet8.vqa:
+				Offset: 1124041936
+				Length: 28905880
+			^Content/ra/v2/movies/soviet9.vqa:
+				Offset: 1152947816
+				Length: 31809450
+			^Content/ra/v2/movies/soviet10.vqa:
+				Offset: 1184757266
+				Length: 10102944
+			^Content/ra/v2/movies/soviet11.vqa:
+				Offset: 1194860210
+				Length: 16685840
+			^Content/ra/v2/movies/soviet12.vqa:
+				Offset: 1211546050
+				Length: 11532038
+			^Content/ra/v2/movies/soviet13.vqa:
+				Offset: 1223078088
+				Length: 15210482
+			^Content/ra/v2/movies/soviet14.vqa:
+				Offset: 1238288570
+				Length: 24358232
+			^Content/ra/v2/movies/sovmcv.vqa:
+				Offset: 1262646802
+				Length: 1292126
+			^Content/ra/v2/movies/sovtstar.vqa:
+				Offset: 1263938928
+				Length: 670794
+			^Content/ra/v2/movies/spotter.vqa:
+				Offset: 1264609722
+				Length: 1346422
+			^Content/ra/v2/movies/strafe.vqa:
+				Offset: 1265956144
+				Length: 1226956
+			^Content/ra/v2/movies/take_off.vqa:
+				Offset: 1267183100
+				Length: 1419370
+			^Content/ra/v2/movies/tesla.vqa:
+				Offset: 1268602470
+				Length: 1796092
+			^Content/ra/v2/movies/v2rocket.vqa:
+				Offset: 1270398562
+				Length: 1856524
+			^Content/ra/v2/movies/aagun.vqa:
+				Offset: 1292529084
+				Length: 3295512
+			^Content/ra/v2/movies/airfield.vqa:
+				Offset: 1295824596
+				Length: 2696058
+			^Content/ra/v2/movies/ally1.vqa:
+				Offset: 1298520654
+				Length: 13536324
+			^Content/ra/v2/movies/allymorf.vqa:
+				Offset: 1312056978
+				Length: 916964
+			^Content/ra/v2/movies/averted.vqa:
+				Offset: 1312973942
+				Length: 1902556
+			^Content/ra/v2/movies/beachead.vqa:
+				Offset: 1314876498
+				Length: 4891790
+			^Content/ra/v2/movies/bmap.vqa:
+				Offset: 1319768288
+				Length: 2414312
+			^Content/ra/v2/movies/bombrun.vqa:
+				Offset: 1322182600
+				Length: 5167450
+			^Content/ra/v2/movies/countdwn.vqa:
+				Offset: 1327350050
+				Length: 2005906
+			^Content/ra/v2/movies/cronfail.vqa:
+				Offset: 1329356707
+				Length: 1717214
+			^Content/ra/v2/expand/chrotnk1.aud:
+				Offset: 843615985
+				Length: 22900
+			^Content/ra/v2/expand/fixit1.aud:
+				Offset: 843860963
+				Length: 10707
+			^Content/ra/v2/expand/jburn1.aud:
+				Offset: 844007001
+				Length: 23091
+			^Content/ra/v2/expand/jchrge1.aud:
+				Offset: 844030092
+				Length: 14219
+			^Content/ra/v2/expand/jcrisp1.aud:
+				Offset: 844044311
+				Length: 18211
+			^Content/ra/v2/expand/jdance1.aud:
+				Offset: 844062522
+				Length: 14315
+			^Content/ra/v2/expand/jjuice1.aud:
+				Offset: 844076837
+				Length: 9699
+			^Content/ra/v2/expand/jjump1.aud:
+				Offset: 844086536
+				Length: 8219
+			^Content/ra/v2/expand/jlight1.aud:
+				Offset: 844094755
+				Length: 9875
+			^Content/ra/v2/expand/jpower1.aud:
+				Offset: 844104630
+				Length: 13571
+			^Content/ra/v2/expand/jshock1.aud:
+				Offset: 844118201
+				Length: 14771
+			^Content/ra/v2/expand/jyes1.aud:
+				Offset: 844132972
+				Length: 13795
+			^Content/ra/v2/expand/madchrg2.aud:
+				Offset: 844262883
+				Length: 19782
+			^Content/ra/v2/expand/madexplo.aud:
+				Offset: 844282665
+				Length: 26572
+			^Content/ra/v2/expand/mboss1.aud:
+				Offset: 844314713
+				Length: 20147
+			^Content/ra/v2/expand/mhear1.aud:
+				Offset: 844340048
+				Length: 6714
+			^Content/ra/v2/expand/mhotdig1.aud:
+				Offset: 844346762
+				Length: 10674
+			^Content/ra/v2/expand/mhowdy1.aud:
+				Offset: 844357436
+				Length: 6714
+			^Content/ra/v2/expand/mhuh1.aud:
+				Offset: 844364150
+				Length: 4117
+			^Content/ra/v2/expand/mlaff1.aud:
+				Offset: 844428954
+				Length: 24133
+			^Content/ra/v2/expand/mrise1.aud:
+				Offset: 844466487
+				Length: 13523
+			^Content/ra/v2/expand/mwrench1.aud:
+				Offset: 844480010
+				Length: 10780
+			^Content/ra/v2/expand/myeehaw1.aud:
+				Offset: 844490790
+				Length: 18912
+			^Content/ra/v2/expand/myes1.aud:
+				Offset: 844509702
+				Length: 9073
+
+tfd-installed-cnc-desert: C&C The First Decade (Installed, English)
+	Type: Install
+	RegistryKey: HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Electronic Arts\EA Games\Command and Conquer The First Decade
+	RegistryValue: cc_folder
+	IDFiles:
+		C&C95.exe: 1c413007850277c02f916152fcb7153d2162d5e9
+		CONQUER.MIX: 833e02a09aae694659eb312d3838367f681d1b30
+	Install:
+		copy: .
+			^Content/ra/v2/cnc/desert.mix: DESERT.MIX

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -232,29 +232,29 @@ ModContent:
 	Packages:
 		base: Base Game Files
 			TestFiles: ^Content/ra/v2/allies.mix, ^Content/ra/v2/conquer.mix, ^Content/ra/v2/interior.mix, ^Content/ra/v2/hires.mix, ^Content/ra/v2/lores.mix, ^Content/ra/v2/local.mix, ^Content/ra/v2/speech.mix, ^Content/ra/v2/russian.mix, ^Content/ra/v2/snow.mix, ^Content/ra/v2/sounds.mix, ^Content/ra/v2/temperat.mix
-			Sources: allied, allied-linux, soviet, soviet-linux, tfd, ra-origin
+			Sources: allied, allied-linux, soviet, soviet-linux, tfd, tfd-installed, ra-origin
 			Required: true
 			Download: basefiles
 		aftermathbase: Aftermath Expansion Files
 			TestFiles: ^Content/ra/v2/expand/expand2.mix, ^Content/ra/v2/expand/hires1.mix, ^Content/ra/v2/expand/lores1.mix, ^Content/ra/v2/expand/chrotnk1.aud, ^Content/ra/v2/expand/fixit1.aud, ^Content/ra/v2/expand/jburn1.aud, ^Content/ra/v2/expand/jchrge1.aud, ^Content/ra/v2/expand/jcrisp1.aud, ^Content/ra/v2/expand/jdance1.aud, ^Content/ra/v2/expand/jjuice1.aud, ^Content/ra/v2/expand/jjump1.aud, ^Content/ra/v2/expand/jlight1.aud, ^Content/ra/v2/expand/jpower1.aud, ^Content/ra/v2/expand/jshock1.aud, ^Content/ra/v2/expand/jyes1.aud, ^Content/ra/v2/expand/madchrg2.aud, ^Content/ra/v2/expand/madexplo.aud, ^Content/ra/v2/expand/mboss1.aud, ^Content/ra/v2/expand/mhear1.aud, ^Content/ra/v2/expand/mhotdig1.aud, ^Content/ra/v2/expand/mhowdy1.aud, ^Content/ra/v2/expand/mhuh1.aud, ^Content/ra/v2/expand/mlaff1.aud, ^Content/ra/v2/expand/mrise1.aud, ^Content/ra/v2/expand/mwrench1.aud, ^Content/ra/v2/expand/myeehaw1.aud, ^Content/ra/v2/expand/myes1.aud
-			Sources: aftermath, aftermath-linux, tfd, ra-origin
+			Sources: aftermath, aftermath-linux, tfd, tfd-installed, ra-origin
 			Required: true
 			Download: aftermath
 		cncdesert: C&C Desert Tileset
 			TestFiles: ^Content/ra/v2/cnc/desert.mix
-			Sources: tfd, cnc-origin, cnc95, cnc95-linux
+			Sources: tfd, tfd-installed-cnc-desert, cnc-origin, cnc95, cnc95-linux
 			Required: true
 			Download: cncdesert
 		music: Base Game Music
 			TestFiles: ^Content/ra/v2/scores.mix
-			Sources: allied, allied-linux, soviet, soviet-linux, tfd, ra-origin
+			Sources: allied, allied-linux, soviet, soviet-linux, tfd, tfd-installed, ra-origin
 			Download: music
 		movies-allied: Allied Campaign Briefings
 			TestFiles: ^Content/ra/v2/movies/aagun.vqa, ^Content/ra/v2/movies/aftrmath.vqa, ^Content/ra/v2/movies/ally1.vqa, ^Content/ra/v2/movies/ally10.vqa, ^Content/ra/v2/movies/ally10b.vqa, ^Content/ra/v2/movies/ally11.vqa, ^Content/ra/v2/movies/ally12.vqa, ^Content/ra/v2/movies/ally14.vqa, ^Content/ra/v2/movies/ally2.vqa, ^Content/ra/v2/movies/ally4.vqa, ^Content/ra/v2/movies/ally5.vqa, ^Content/ra/v2/movies/ally6.vqa, ^Content/ra/v2/movies/ally8.vqa, ^Content/ra/v2/movies/ally9.vqa, ^Content/ra/v2/movies/allyend.vqa, ^Content/ra/v2/movies/allymorf.vqa, ^Content/ra/v2/movies/apcescpe.vqa, ^Content/ra/v2/movies/assess.vqa, ^Content/ra/v2/movies/battle.vqa, ^Content/ra/v2/movies/binoc.vqa, ^Content/ra/v2/movies/bmap.vqa, ^Content/ra/v2/movies/brdgtilt.vqa, ^Content/ra/v2/movies/crontest.vqa, ^Content/ra/v2/movies/cronfail.vqa, ^Content/ra/v2/movies/destroyr.vqa, ^Content/ra/v2/movies/dud.vqa, ^Content/ra/v2/movies/elevator.vqa, ^Content/ra/v2/movies/flare.vqa, ^Content/ra/v2/movies/frozen.vqa, ^Content/ra/v2/movies/grvestne.vqa, ^Content/ra/v2/movies/landing.vqa, ^Content/ra/v2/movies/masasslt.vqa, ^Content/ra/v2/movies/mcv.vqa, ^Content/ra/v2/movies/mcv_land.vqa, ^Content/ra/v2/movies/montpass.vqa, ^Content/ra/v2/movies/oildrum.vqa, ^Content/ra/v2/movies/overrun.vqa, ^Content/ra/v2/movies/prolog.vqa, ^Content/ra/v2/movies/redintro.vqa, ^Content/ra/v2/movies/shipsink.vqa, ^Content/ra/v2/movies/shorbom1.vqa, ^Content/ra/v2/movies/shorbom2.vqa, ^Content/ra/v2/movies/shorbomb.vqa, ^Content/ra/v2/movies/snowbomb.vqa, ^Content/ra/v2/movies/soviet1.vqa, ^Content/ra/v2/movies/sovtstar.vqa, ^Content/ra/v2/movies/spy.vqa, ^Content/ra/v2/movies/tanya1.vqa, ^Content/ra/v2/movies/tanya2.vqa, ^Content/ra/v2/movies/toofar.vqa, ^Content/ra/v2/movies/trinity.vqa
-			Sources: allied, allied-linux, tfd, ra-origin
+			Sources: allied, allied-linux, tfd, tfd-installed, ra-origin
 		movies-soviet: Soviet Campaign Briefings
 			TestFiles: ^Content/ra/v2/movies/aagun.vqa, ^Content/ra/v2/movies/cronfail.vqa, ^Content/ra/v2/movies/airfield.vqa, ^Content/ra/v2/movies/ally1.vqa, ^Content/ra/v2/movies/allymorf.vqa, ^Content/ra/v2/movies/averted.vqa, ^Content/ra/v2/movies/beachead.vqa, ^Content/ra/v2/movies/bmap.vqa, ^Content/ra/v2/movies/bombrun.vqa, ^Content/ra/v2/movies/countdwn.vqa, ^Content/ra/v2/movies/double.vqa, ^Content/ra/v2/movies/dpthchrg.vqa, ^Content/ra/v2/movies/execute.vqa, ^Content/ra/v2/movies/flare.vqa, ^Content/ra/v2/movies/landing.vqa, ^Content/ra/v2/movies/mcvbrdge.vqa, ^Content/ra/v2/movies/mig.vqa, ^Content/ra/v2/movies/movingin.vqa, ^Content/ra/v2/movies/mtnkfact.vqa, ^Content/ra/v2/movies/nukestok.vqa, ^Content/ra/v2/movies/onthprwl.vqa, ^Content/ra/v2/movies/periscop.vqa, ^Content/ra/v2/movies/prolog.vqa, ^Content/ra/v2/movies/radrraid.vqa, ^Content/ra/v2/movies/redintro.vqa, ^Content/ra/v2/movies/search.vqa, ^Content/ra/v2/movies/sfrozen.vqa, ^Content/ra/v2/movies/sitduck.vqa, ^Content/ra/v2/movies/slntsrvc.vqa, ^Content/ra/v2/movies/snowbomb.vqa, ^Content/ra/v2/movies/snstrafe.vqa, ^Content/ra/v2/movies/sovbatl.vqa, ^Content/ra/v2/movies/sovcemet.vqa, ^Content/ra/v2/movies/sovfinal.vqa, ^Content/ra/v2/movies/soviet1.vqa, ^Content/ra/v2/movies/soviet10.vqa, ^Content/ra/v2/movies/soviet11.vqa, ^Content/ra/v2/movies/soviet12.vqa, ^Content/ra/v2/movies/soviet13.vqa, ^Content/ra/v2/movies/soviet14.vqa, ^Content/ra/v2/movies/soviet2.vqa, ^Content/ra/v2/movies/soviet3.vqa, ^Content/ra/v2/movies/soviet4.vqa, ^Content/ra/v2/movies/soviet5.vqa, ^Content/ra/v2/movies/soviet6.vqa, ^Content/ra/v2/movies/soviet7.vqa, ^Content/ra/v2/movies/soviet8.vqa, ^Content/ra/v2/movies/soviet9.vqa, ^Content/ra/v2/movies/sovmcv.vqa, ^Content/ra/v2/movies/sovtstar.vqa, ^Content/ra/v2/movies/spotter.vqa, ^Content/ra/v2/movies/strafe.vqa, ^Content/ra/v2/movies/take_off.vqa, ^Content/ra/v2/movies/tesla.vqa, ^Content/ra/v2/movies/v2rocket.vqa
-			Sources: soviet, soviet-linux, tfd, ra-origin
+			Sources: soviet, soviet-linux, tfd, tfd-installed, ra-origin
 		music-counterstrike: Counterstrike Music
 			TestFiles: ^Content/ra/v2/expand/araziod.aud, ^Content/ra/v2/expand/backstab.aud, ^Content/ra/v2/expand/chaos2.aud, ^Content/ra/v2/expand/shut_it.aud, ^Content/ra/v2/expand/2nd_hand.aud, ^Content/ra/v2/expand/twinmix1.aud, ^Content/ra/v2/expand/under3.aud, ^Content/ra/v2/expand/vr2.aud, 
 			Sources: counterstrike, counterstrike-linux, ra-origin

--- a/mods/ts/installer/firstdecade.yaml
+++ b/mods/ts/installer/firstdecade.yaml
@@ -54,3 +54,56 @@ tfd: C&C The First Decade (English)
 				Offset: 73056940
 				Length: 2037606
 		delete: ^Content/ts/tibsun.mix
+
+tfd-installed: C&C The First Decade (Installed, English)
+	Type: Install
+	RegistryKey: HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Electronic Arts\EA Games\Command and Conquer The First Decade
+	RegistryValue: ts_folder
+	IDFiles:
+		README.TXT: f2810b540fce8f3880250213ee08c57780d81c20
+	Install:
+		copy: .
+			^Content/ts/scores.mix: SCORES.MIX
+		extract-raw: TIBSUN.MIX
+			^Content/ts/cache.mix:
+				Offset: 300
+				Length: 169176
+			^Content/ts/conquer.mix:
+				Offset: 169484
+				Length: 5700088
+			^Content/ts/isosnow.mix:
+				Offset: 5869580
+				Length: 7624750
+			^Content/ts/isotemp.mix:
+				Offset: 13494332
+				Length: 8617646
+			^Content/ts/local.mix:
+				Offset: 22111980
+				Length: 18044736
+			^Content/ts/sidec01.mix:
+				Offset: 40156716
+				Length: 998476
+			^Content/ts/sidec02.mix:
+				Offset: 41155196
+				Length: 1039996
+			^Content/ts/snow.mix:
+				Offset: 56104508
+				Length: 2087806
+			^Content/ts/sno.mix:
+				Offset: 58192316
+				Length: 7826
+			^Content/ts/sounds.mix:
+				Offset: 58200156
+				Length: 3224136
+			^Content/ts/speech01.mix:
+				Offset: 61424300
+				Length: 6028236
+			^Content/ts/speech02.mix:
+				Offset: 67452540
+				Length: 5596628
+			^Content/ts/tem.mix:
+				Offset: 73049180
+				Length: 7746
+			^Content/ts/temperat.mix:
+				Offset: 73056940
+				Length: 2037606

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -268,12 +268,12 @@ ModContent:
 	Packages:
 		base: Base Game Files
 			TestFiles: ^Content/ts/cache.mix, ^Content/ts/conquer.mix, ^Content/ts/isosnow.mix, ^Content/ts/isotemp.mix, ^Content/ts/local.mix, ^Content/ts/sidec01.mix, ^Content/ts/sidec02.mix, ^Content/ts/sno.mix, ^Content/ts/snow.mix, ^Content/ts/sounds.mix, ^Content/ts/speech01.mix, ^Content/ts/tem.mix, ^Content/ts/temperat.mix
-			Sources: tibsun, tibsun-linux, tfd, origin
+			Sources: tibsun, tibsun-linux, tfd, tfd-installed, origin
 			Required: true
 			Download: basefiles
 		music: Base Game Music
 			TestFiles: ^Content/ts/scores.mix
-			Sources: tibsun, tibsun-linux, tfd, origin
+			Sources: tibsun, tibsun-linux, tfd, tfd-installed, origin
 			Download: music
 	Downloads:
 		ts|installer/downloads.yaml


### PR DESCRIPTION
This PR allows us to use an existing Installation of "The First Decade" from Harddisk Like: C:\Games\TFD\
Further PRs will enable to use existing Installations From Harddiscs:
- TS + Firestorm (1999) Release Discs (GD and Nod, Firestorm discs)
- RA2 + Yuri

For Reviewers: Steps:
- Install a clean US TFD (the normal way via the DVD-Installer (Setup.exe) )
- remove the DVD from the Drive and remove the OpenRA Content or rename the folders
- Let OpenRA try to install the wished MOD Content.
  -> OpenRA should find via registry the Content in the Location where you installed your TFD:
  "Ex: D:\Games\TFD-Instal\bla bla"

This PR allows us a way to install RA2 and YURI ... 
