### PR TITLE
Tweak aircraft resupply behaviour.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// TODO: This should check whether there is ammo left that is actually suitable for the target
 			if (ammoPools.All(x => !x.Info.SelfReloads && !x.HasAmmo()))
-				return ActivityUtils.SequenceActivities(new ReturnToBase(self), this);
+				return ActivityUtils.SequenceActivities(new ReturnToBase(self, aircraft.Info.AbortOnResupply), this);
 
 			if (attackPlane != null)
 				attackPlane.DoAttack(self, target);

--- a/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// If any AmmoPool is depleted and no weapon is valid against target, return to helipad to reload and then resume the activity
 			if (ammoPools.Any(x => !x.Info.SelfReloads && !x.HasAmmo()) && !attackHeli.HasAnyValidWeapons(target))
-				return ActivityUtils.SequenceActivities(new HeliReturnToBase(self), this);
+				return ActivityUtils.SequenceActivities(new HeliReturnToBase(self, helicopter.Info.AbortOnResupply), this);
 
 			var dist = target.CenterPosition - self.CenterPosition;
 

--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -20,11 +20,13 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly Aircraft heli;
 		readonly bool alwaysLand;
+		readonly bool abortOnResupply;
 
-		public HeliReturnToBase(Actor self, bool alwaysLand = true)
+		public HeliReturnToBase(Actor self, bool abortOnResupply, bool alwaysLand = true)
 		{
 			heli = self.Trait<Aircraft>();
 			this.alwaysLand = alwaysLand;
+			this.abortOnResupply = abortOnResupply;
 		}
 
 		public Actor ChooseHelipad(Actor self)
@@ -82,7 +84,7 @@ namespace OpenRA.Mods.Common.Activities
 					new Turn(self, initialFacing),
 					new HeliLand(self, false),
 					new ResupplyAircraft(self),
-					!heli.Info.AbortOnResupply ? NextActivity : null);
+					!abortOnResupply ? NextActivity : null);
 			}
 
 			return ActivityUtils.SequenceActivities(

--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -19,10 +19,12 @@ namespace OpenRA.Mods.Common.Activities
 	public class HeliReturnToBase : Activity
 	{
 		readonly Aircraft heli;
+		readonly bool alwaysLand;
 
-		public HeliReturnToBase(Actor self)
+		public HeliReturnToBase(Actor self, bool alwaysLand = true)
 		{
 			heli = self.Trait<Aircraft>();
+			this.alwaysLand = alwaysLand;
 		}
 
 		public Actor ChooseHelipad(Actor self)
@@ -68,17 +70,36 @@ namespace OpenRA.Mods.Common.Activities
 				}
 			}
 
-			heli.MakeReservation(dest);
-
 			var exit = dest.Info.TraitInfos<ExitInfo>().FirstOrDefault();
 			var offset = (exit != null) ? exit.SpawnOffset : WVec.Zero;
 
+			if (ShouldLandAtBuilding(self, dest))
+			{
+				heli.MakeReservation(dest);
+
+				return ActivityUtils.SequenceActivities(
+					new HeliFly(self, Target.FromPos(dest.CenterPosition + offset)),
+					new Turn(self, initialFacing),
+					new HeliLand(self, false),
+					new ResupplyAircraft(self),
+					NextActivity);
+			}
+
 			return ActivityUtils.SequenceActivities(
 				new HeliFly(self, Target.FromPos(dest.CenterPosition + offset)),
-				new Turn(self, initialFacing),
-				new HeliLand(self, false),
-				new ResupplyAircraft(self),
 				NextActivity);
+		}
+
+		bool ShouldLandAtBuilding(Actor self, Actor dest)
+		{
+			if (alwaysLand)
+				return true;
+
+			if (heli.Info.RepairBuildings.Contains(dest.Info.Name) && self.GetDamageState() != DamageState.Undamaged)
+				return true;
+
+			return heli.Info.RearmBuildings.Contains(dest.Info.Name) && self.TraitsImplementing<AmmoPool>()
+					.Any(p => !p.Info.SelfReloads && !p.FullAmmo());
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Activities
 					new Turn(self, initialFacing),
 					new HeliLand(self, false),
 					new ResupplyAircraft(self),
-					NextActivity);
+					!heli.Info.AbortOnResupply ? NextActivity : null);
 			}
 
 			return ActivityUtils.SequenceActivities(

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -22,13 +22,15 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly Aircraft plane;
 		readonly AircraftInfo planeInfo;
+		readonly bool alwaysLand;
 		bool isCalculated;
 		Actor dest;
 		WPos w1, w2, w3;
 
-		public ReturnToBase(Actor self, Actor dest = null)
+		public ReturnToBase(Actor self, Actor dest = null, bool alwaysLand = true)
 		{
 			this.dest = dest;
+			this.alwaysLand = alwaysLand;
 			plane = self.Trait<Aircraft>();
 			planeInfo = self.Info.TraitInfo<AircraftInfo>();
 		}
@@ -50,8 +52,6 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (dest == null)
 				return;
-
-			plane.MakeReservation(dest);
 
 			var landPos = dest.CenterPosition;
 			var altitude = planeInfo.CruiseAltitude.Length;
@@ -94,6 +94,18 @@ namespace OpenRA.Mods.Common.Activities
 			isCalculated = true;
 		}
 
+		bool ShouldLandAtBuilding(Actor self, Actor dest)
+		{
+			if (alwaysLand)
+				return true;
+
+			if (planeInfo.RepairBuildings.Contains(dest.Info.Name) && self.GetDamageState() != DamageState.Undamaged)
+				return true;
+
+			return planeInfo.RearmBuildings.Contains(dest.Info.Name) && self.TraitsImplementing<AmmoPool>()
+					.Any(p => !p.Info.SelfReloads && !p.FullAmmo());
+		}
+
 		public override Activity Tick(Actor self)
 		{
 			if (IsCanceled || self.IsDead)
@@ -128,8 +140,15 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Fix a problem when the airplane is send to resupply near the airport
 			landingProcedures.Add(new Fly(self, Target.FromPos(w3), WDist.Zero, new WDist(turnRadius / 2)));
-			landingProcedures.Add(new Land(self, Target.FromActor(dest)));
-			landingProcedures.Add(new ResupplyAircraft(self));
+
+			if (ShouldLandAtBuilding(self, dest))
+			{
+				plane.MakeReservation(dest);
+
+				landingProcedures.Add(new Land(self, Target.FromActor(dest)));
+				landingProcedures.Add(new ResupplyAircraft(self));
+			}
+
 			landingProcedures.Add(NextActivity);
 
 			return ActivityUtils.SequenceActivities(landingProcedures.ToArray());

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -149,7 +149,8 @@ namespace OpenRA.Mods.Common.Activities
 				landingProcedures.Add(new ResupplyAircraft(self));
 			}
 
-			landingProcedures.Add(NextActivity);
+			if (!planeInfo.AbortOnResupply)
+				landingProcedures.Add(NextActivity);
 
 			return ActivityUtils.SequenceActivities(landingProcedures.ToArray());
 		}

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -23,14 +23,16 @@ namespace OpenRA.Mods.Common.Activities
 		readonly Aircraft plane;
 		readonly AircraftInfo planeInfo;
 		readonly bool alwaysLand;
+		readonly bool abortOnResupply;
 		bool isCalculated;
 		Actor dest;
 		WPos w1, w2, w3;
 
-		public ReturnToBase(Actor self, Actor dest = null, bool alwaysLand = true)
+		public ReturnToBase(Actor self, bool abortOnResupply, Actor dest = null, bool alwaysLand = true)
 		{
 			this.dest = dest;
 			this.alwaysLand = alwaysLand;
+			this.abortOnResupply = abortOnResupply;
 			plane = self.Trait<Aircraft>();
 			planeInfo = self.Info.TraitInfo<AircraftInfo>();
 		}
@@ -149,7 +151,7 @@ namespace OpenRA.Mods.Common.Activities
 				landingProcedures.Add(new ResupplyAircraft(self));
 			}
 
-			if (!planeInfo.AbortOnResupply)
+			if (!abortOnResupply)
 				landingProcedures.Add(NextActivity);
 
 			return ActivityUtils.SequenceActivities(landingProcedures.ToArray());

--- a/OpenRA.Mods.Common/Scripting/Properties/AircraftProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/AircraftProperties.cs
@@ -42,9 +42,9 @@ namespace OpenRA.Mods.Common.Scripting
 		public void ReturnToBase(Actor airfield = null)
 		{
 			if (isPlane)
-				Self.QueueActivity(new ReturnToBase(Self, airfield));
+				Self.QueueActivity(new ReturnToBase(Self, false, airfield));
 			else
-				Self.QueueActivity(new HeliReturnToBase(Self));
+				Self.QueueActivity(new HeliReturnToBase(Self, false));
 		}
 
 		[ScriptActorPropertyActivity]

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool TurnToLand = false;
 
 		[Desc("Does this actor cancel its previous activity after resupplying?")]
-		public readonly bool AbortOnResupply = false;
+		public readonly bool AbortOnResupply = true;
 
 		public readonly WDist LandAltitude = WDist.Zero;
 

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -69,6 +69,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Does this actor need to turn before landing?")]
 		public readonly bool TurnToLand = false;
 
+		[Desc("Does this actor cancel its previous activity after resupplying?")]
+		public readonly bool AbortOnResupply = false;
+
 		public readonly WDist LandAltitude = WDist.Zero;
 
 		[Desc("How fast this actor ascends or descends when using horizontal take off/landing.")]

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -618,9 +618,9 @@ namespace OpenRA.Mods.Common.Traits
 				UnReserve();
 				self.CancelActivity();
 				if (IsPlane)
-					self.QueueActivity(new ReturnToBase(self));
+					self.QueueActivity(new ReturnToBase(self, null, false));
 				else
-					self.QueueActivity(new HeliReturnToBase(self));
+					self.QueueActivity(new HeliReturnToBase(self, false));
 
 				self.QueueActivity(new ResupplyAircraft(self));
 			}

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -621,8 +621,6 @@ namespace OpenRA.Mods.Common.Traits
 					self.QueueActivity(new ReturnToBase(self, null, false));
 				else
 					self.QueueActivity(new HeliReturnToBase(self, false));
-
-				self.QueueActivity(new ResupplyAircraft(self));
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -562,9 +562,9 @@ namespace OpenRA.Mods.Common.Traits
 				if (Reservable.IsReserved(order.TargetActor))
 				{
 					if (IsPlane)
-						self.QueueActivity(new ReturnToBase(self));
+						self.QueueActivity(new ReturnToBase(self, Info.AbortOnResupply));
 					else
-						self.QueueActivity(new HeliReturnToBase(self));
+						self.QueueActivity(new HeliReturnToBase(self, Info.AbortOnResupply));
 				}
 				else
 				{
@@ -573,7 +573,7 @@ namespace OpenRA.Mods.Common.Traits
 					if (IsPlane)
 					{
 						self.QueueActivity(order.Queued, ActivityUtils.SequenceActivities(
-							new ReturnToBase(self, order.TargetActor),
+							new ReturnToBase(self, Info.AbortOnResupply, order.TargetActor),
 							new ResupplyAircraft(self)));
 					}
 					else
@@ -621,9 +621,9 @@ namespace OpenRA.Mods.Common.Traits
 				UnReserve();
 				self.CancelActivity();
 				if (IsPlane)
-					self.QueueActivity(new ReturnToBase(self, null, false));
+					self.QueueActivity(new ReturnToBase(self, Info.AbortOnResupply, null, false));
 				else
-					self.QueueActivity(new HeliReturnToBase(self, false));
+					self.QueueActivity(new HeliReturnToBase(self, Info.AbortOnResupply, false));
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Air/ReturnOnIdle.cs
+++ b/OpenRA.Mods.Common/Traits/Air/ReturnOnIdle.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 			var airfield = ReturnToBase.ChooseAirfield(self, true);
 			if (airfield != null)
 			{
-				self.QueueActivity(new ReturnToBase(self, airfield));
+				self.QueueActivity(new ReturnToBase(self, aircraftInfo.AbortOnResupply, airfield));
 				self.QueueActivity(new ResupplyAircraft(self));
 			}
 			else


### PR DESCRIPTION
This implements two changes to hopefully wrap up our aircraft resupply ordeal (for this release cycle, at least):
1.  When the "return to base" hotkey is used all aircraft will return to base, but only those that can be resupplied will land on helipads.  This avoids the annoying dance (particularly in TD, where helipads are only used for repairing) where loaded/repaired helicopters will touch-and-go on the pad, wasting time that could be used resupplying those that actually need it.
2.  @e1d1s1 has been arguing (#11979, #11982) that aircraft continuing their attacks after resupplying is a gameplay regression, and i'm now inclined to agree.  This adds an `AbortOnResupply` flag to disable this feature, and enables it by default.
