### PR TITLE
Add tooltips to map resources.

### DIFF
--- a/OpenRA.Game/Traits/World/ResourceType.cs
+++ b/OpenRA.Game/Traits/World/ResourceType.cs
@@ -17,11 +17,12 @@ namespace OpenRA.Traits
 	public class ResourceTypeInfo : ITraitInfo
 	{
 		[Desc("Sequence image that holds the different variants.")]
-		public readonly string Sequence = "resources";
+		public readonly string Image = "resources";
 
-		[SequenceReference("Sequence")]
+		[FieldLoader.Require]
+		[SequenceReference("Image")]
 		[Desc("Randomly chosen image sequences.")]
-		public readonly string[] Variants = { };
+		public readonly string[] Sequences = { };
 
 		[PaletteReference]
 		[Desc("Palette used for rendering the resource sprites.")]
@@ -38,10 +39,15 @@ namespace OpenRA.Traits
 
 		[FieldLoader.Require]
 		[Desc("Resource identifier used by other traits.")]
+		public readonly string Type = null;
+
+		[FieldLoader.Require]
+		[Desc("Resource name used by tooltips.")]
 		public readonly string Name = null;
 
+		[FieldLoader.Require]
 		[Desc("Terrain type used to determine unit movement and minimap colors.")]
-		public readonly string TerrainType = "Ore";
+		public readonly string TerrainType = null;
 
 		[Desc("Terrain types that this resource can spawn on.")]
 		public readonly HashSet<string> AllowedTerrainTypes = new HashSet<string>();
@@ -71,9 +77,9 @@ namespace OpenRA.Traits
 		{
 			Info = info;
 			Variants = new Dictionary<string, Sprite[]>();
-			foreach (var v in info.Variants)
+			foreach (var v in info.Sequences)
 			{
-				var seq = world.Map.Rules.Sequences.GetSequence(Info.Sequence, v);
+				var seq = world.Map.Rules.Sequences.GetSequence(Info.Image, v);
 				var sprites = Exts.MakeArray(seq.Length, x => seq.GetSprite(x));
 				Variants.Add(v, sprites);
 			}

--- a/OpenRA.Game/Traits/World/ResourceType.cs
+++ b/OpenRA.Game/Traits/World/ResourceType.cs
@@ -16,21 +16,46 @@ namespace OpenRA.Traits
 {
 	public class ResourceTypeInfo : ITraitInfo
 	{
+		[Desc("Sequence image that holds the different variants.")]
 		public readonly string Sequence = "resources";
-		[SequenceReference("Sequence")] public readonly string[] Variants = { };
-		[PaletteReference] public readonly string Palette = TileSet.TerrainPaletteInternalName;
+
+		[SequenceReference("Sequence")]
+		[Desc("Randomly chosen image sequences.")]
+		public readonly string[] Variants = { };
+
+		[PaletteReference]
+		[Desc("Palette used for rendering the resource sprites.")]
+		public readonly string Palette = TileSet.TerrainPaletteInternalName;
+
+		[Desc("Resource index used in the binary map data.")]
 		public readonly int ResourceType = 1;
 
+		[Desc("Credit value of a single resource unit.")]
 		public readonly int ValuePerUnit = 0;
+
+		[Desc("Maximum number of resource units allowed in a single cell.")]
 		public readonly int MaxDensity = 10;
+
+		[FieldLoader.Require]
+		[Desc("Resource identifier used by other traits.")]
 		public readonly string Name = null;
+
+		[Desc("Terrain type used to determine unit movement and minimap colors.")]
 		public readonly string TerrainType = "Ore";
 
+		[Desc("Terrain types that this resource can spawn on.")]
 		public readonly HashSet<string> AllowedTerrainTypes = new HashSet<string>();
+
+		[Desc("Allow resource to spawn under Mobile actors.")]
 		public readonly bool AllowUnderActors = false;
+
+		[Desc("Allow resource to spawn under Buildings.")]
 		public readonly bool AllowUnderBuildings = false;
+
+		[Desc("Allow resource to spawn on ramp tiles.")]
 		public readonly bool AllowOnRamps = false;
 
+		[Desc("Harvester content pip color.")]
 		public PipType PipColor = PipType.Yellow;
 
 		public object Create(ActorInitializer init) { return new ResourceType(this, init.World); }

--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Common
 				return false;
 
 			// Can the harvester collect this kind of resource?
-			if (!harvInfo.Resources.Contains(resType.Info.Name))
+			if (!harvInfo.Resources.Contains(resType.Info.Type))
 				return false;
 
 			if (territory != null)

--- a/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (underCursor != null)
 				editorWidget.SetTooltip(underCursor.Tooltip);
 			else if (mapResources.Contains(cell) && resources.TryGetValue(mapResources[cell].Type, out type))
-				editorWidget.SetTooltip(type.Info.Name);
+				editorWidget.SetTooltip(type.Info.Type);
 			else
 				editorWidget.SetTooltip(null);
 

--- a/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Widgets
 			preview.GetScale = () => worldRenderer.Viewport.Zoom;
 			preview.IsVisible = () => editorWidget.CurrentBrush == this;
 
-			var variant = resource.Variants.FirstOrDefault();
+			var variant = resource.Sequences.FirstOrDefault();
 			var sequence = wr.World.Map.Rules.Sequences.GetSequence("resources", variant);
 			var sprite = sequence.GetSprite(resource.MaxDensity - 1);
 			preview.GetSprite = () => sprite;

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -478,7 +478,7 @@ namespace OpenRA.Mods.Common.Traits
 				var res = self.World.WorldActor.Trait<ResourceLayer>().GetRenderedResource(location);
 				var info = self.Info.TraitInfo<HarvesterInfo>();
 
-				if (res == null || !info.Resources.Contains(res.Info.Name))
+				if (res == null || !info.Resources.Contains(res.Info.Type))
 					return false;
 
 				cursor = "harvest";

--- a/OpenRA.Mods.Common/Traits/SeedsResource.cs
+++ b/OpenRA.Mods.Common/Traits/SeedsResource.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 
 			resourceType = self.World.WorldActor.TraitsImplementing<ResourceType>()
-				.FirstOrDefault(t => t.Info.Name == info.ResourceType);
+				.FirstOrDefault(t => t.Info.Type == info.ResourceType);
 
 			if (resourceType == null)
 				throw new InvalidOperationException("No such resource type `{0}`".F(info.ResourceType));

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -367,6 +367,25 @@ namespace OpenRA.Mods.Common.UtilityCommands
 							Console.WriteLine("Actor type `{0}` is denoted as a RearmBuilding. Consider adding the `WithRearmAnimation` trait to it.".F(host));
 				}
 
+				// Resource type properties were renamed, and support for tooltips added
+				if (engineVersion < 20160925)
+				{
+					if (node.Key.StartsWith("ResourceType"))
+					{
+						var image = node.Value.Nodes.FirstOrDefault(n => n.Key == "Sequence");
+						if (image != null)
+							image.Key = "Image";
+
+						var sequences = node.Value.Nodes.FirstOrDefault(n => n.Key == "Variants");
+						if (sequences != null)
+							sequences.Key = "Sequences";
+
+						var name = node.Value.Nodes.FirstOrDefault(n => n.Key == "Name");
+						if (name != null)
+							node.Value.Nodes.Add(new MiniYamlNode("Type", name.Value.Value));
+					}
+				}
+
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 

--- a/OpenRA.Mods.Common/Warheads/CreateResourceWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateResourceWarhead.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Warheads
 			var allCells = world.Map.FindTilesInAnnulus(targetTile, minRange, Size[0]);
 
 			var resourceType = world.WorldActor.TraitsImplementing<ResourceType>()
-				.FirstOrDefault(t => t.Info.Name == AddsResourceType);
+				.FirstOrDefault(t => t.Info.Type == AddsResourceType);
 
 			if (resourceType == null)
 				Log.Write("debug", "Warhead defines an invalid resource type '{0}'".F(AddsResourceType));

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				layerPreview.IsVisible = () => true;
 				layerPreview.GetPalette = () => resource.Palette;
 
-				var variant = resource.Variants.FirstOrDefault();
+				var variant = resource.Sequences.FirstOrDefault();
 				var sequence = rules.Sequences.GetSequence("resources", variant);
 				var frame = sequence.Frames != null ? sequence.Frames.Last() : resource.MaxDensity - 1;
 				layerPreview.GetSprite = () => sequence.GetSprite(frame);
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				newResourcePreviewTemplate.Bounds.Height = tileSize.Height + (layerPreview.Bounds.Y * 2);
 
 				newResourcePreviewTemplate.IsVisible = () => true;
-				newResourcePreviewTemplate.GetTooltipText = () => resource.Name;
+				newResourcePreviewTemplate.GetTooltipText = () => resource.Type;
 
 				layerTemplateList.AddChild(newResourcePreviewTemplate);
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
@@ -57,6 +57,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					case WorldTooltipType.Unexplored:
 						labelText = "Unrevealed Terrain";
 						break;
+					case WorldTooltipType.Resource:
+						labelText = viewport.ResourceTooltip.Info.Name;
+						break;
 					case WorldTooltipType.Actor:
 						{
 							o = viewport.ActorTooltip.Owner;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				switch (viewport.TooltipType)
 				{
 					case WorldTooltipType.Unexplored:
-						labelText = "Unexplored Terrain";
+						labelText = "Unrevealed Terrain";
 						break;
 					case WorldTooltipType.Actor:
 						{

--- a/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
+++ b/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.D2k.Traits
 			self = init.Self;
 
 			resLayer = self.World.WorldActor.Trait<ResourceLayer>();
-			resType = self.World.WorldActor.TraitsImplementing<ResourceType>().First(t => t.Info.Name == info.ResourceType);
+			resType = self.World.WorldActor.TraitsImplementing<ResourceType>().First(t => t.Info.Type == info.ResourceType);
 
 			var render = self.Trait<RenderSprites>();
 			anim = new AnimationWithOffset(new Animation(init.Self.World, render.GetImage(self)), null, () => self.IsDead);

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -26,25 +26,27 @@
 		InternalName: nod
 		Description: Brotherhood of Nod\nThe Brotherhood is a religious cult centered around their leader Kane\nand the alien substance Tiberium. They utilize stealth technology\nand guerilla tactics to defeat those who oppose them.
 	ResourceType@green-tib:
+		Type: Tiberium
+		Name: Tiberium
+		PipColor: Green
 		ResourceType: 1
 		Palette: staticterrain
 		TerrainType: Tiberium
-		Variants: ti1,ti2,ti3,ti4,ti5,ti6,ti7,ti8,ti9,ti10,ti11,ti12
+		Sequences: ti1,ti2,ti3,ti4,ti5,ti6,ti7,ti8,ti9,ti10,ti11,ti12
 		MaxDensity: 12
 		ValuePerUnit: 35
-		Name: Tiberium
-		PipColor: Green
 		AllowedTerrainTypes: Clear,Road
 		AllowUnderActors: true
 	ResourceType@blue-tib:
+		Type: BlueTiberium
+		Name: Tiberium
+		PipColor: Blue
 		ResourceType: 2
 		Palette: bluetiberium
 		TerrainType: BlueTiberium
-		Variants: bti1,bti2,bti3,bti4,bti5,bti6,bti7,bti8,bti9,bti10,bti11,bti12
+		Sequences: bti1,bti2,bti3,bti4,bti5,bti6,bti7,bti8,bti9,bti10,bti11,bti12
 		MaxDensity: 12
 		ValuePerUnit: 60
-		Name: BlueTiberium
-		PipColor: Blue
 		AllowedTerrainTypes: Clear,Road
 		AllowUnderActors: true
 

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -44,14 +44,15 @@
 		InternalName: smuggler
 		Selectable: false
 	ResourceType@Spice:
+		Type: Spice
+		Name: Spice
+		PipColor: green
 		ResourceType: 1
 		Palette: d2k
 		TerrainType: Spice
-		Variants: spice
+		Sequences: spice
 		MaxDensity: 20
 		ValuePerUnit: 25
-		Name: Spice
-		PipColor: green
 		AllowedTerrainTypes: SpiceSand
 		AllowUnderActors: true
 

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -65,27 +65,29 @@
 		Side: Random
 		Description: A random Soviet country.
 	ResourceType@ore:
+		Type: Ore
+		Name: Valuable Minerals
+		PipColor: Yellow
 		ResourceType: 1
+		TerrainType: Ore
 		Palette: player
-		Variants: gold01,gold02,gold03,gold04
+		Sequences: gold01,gold02,gold03,gold04
 		MaxDensity: 12
 		ValuePerUnit: 25
-		Name: Ore
-		PipColor: Yellow
 		AllowedTerrainTypes: Clear,Road
 		AllowUnderActors: true
-		TerrainType: Ore
 	ResourceType@gem:
+		Type: Gems
+		Name: Valuable Minerals
+		PipColor: Red
 		ResourceType: 2
+		TerrainType: Gems
 		Palette: player
-		Variants: gem01,gem02,gem03,gem04
+		Sequences: gem01,gem02,gem03,gem04
 		MaxDensity: 3
 		ValuePerUnit: 50
-		Name: Gems
-		PipColor: Red
 		AllowedTerrainTypes: Clear,Road
 		AllowUnderActors: true
-		TerrainType: Gems
 
 World:
 	Inherits: ^BaseWorld

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -22,35 +22,38 @@
 		Name: Nod
 		InternalName: nod
 	ResourceType@Tiberium:
-		ResourceType: 1
-		Palette: greentiberium
-		Variants: tib01, tib02, tib03, tib04, tib05, tib06, tib07, tib08, tib09, tib10, tib11, tib12
-		MaxDensity: 12
-		ValuePerUnit: 50
+		Type: Tiberium
 		Name: Tiberium
 		PipColor: Green
+		ResourceType: 1
+		Palette: greentiberium
+		Sequences: tib01, tib02, tib03, tib04, tib05, tib06, tib07, tib08, tib09, tib10, tib11, tib12
+		MaxDensity: 12
+		ValuePerUnit: 50
 		AllowedTerrainTypes: Clear, Rough, DirtRoad
 		AllowUnderActors: true
 		TerrainType: Tiberium
 	ResourceType@BlueTiberium:
+		Type: BlueTiberium
+		Name: Tiberium
+		PipColor: Blue
 		ResourceType: 2
 		Palette: bluetiberium
-		Variants: tib01, tib02, tib03, tib04, tib05, tib06, tib07, tib08, tib09, tib10, tib11, tib12
+		Sequences: tib01, tib02, tib03, tib04, tib05, tib06, tib07, tib08, tib09, tib10, tib11, tib12
 		MaxDensity: 12
 		ValuePerUnit: 100
-		Name: BlueTiberium
-		PipColor: Blue
 		AllowedTerrainTypes: Clear, Rough, DirtRoad
 		AllowUnderActors: true
 		TerrainType: BlueTiberium
 	ResourceType@Veins:
-		ResourceType: 3
-		Palette: player
-		Variants: veins
-		MaxDensity: 1
-		ValuePerUnit: 0
+		Type: Veins
 		Name: Veins
 		PipColor: Red
+		ResourceType: 3
+		Palette: player
+		Sequences: veins
+		MaxDensity: 1
+		ValuePerUnit: 0
 		AllowedTerrainTypes: Clear
 		AllowUnderActors: true
 		TerrainType: Veins


### PR DESCRIPTION
This adds a small bit of polish from the original games (but oddly only RA and D2K).  Also fixes `ResourceType` trait field naming and adds [Desc]s, and changes the shroud tooltip to match the original games.

![screen shot 2016-09-25 at 16 54 08](https://cloud.githubusercontent.com/assets/167819/18816471/a4a56778-8342-11e6-9db5-f82bca25d58f.png)
