### PR TITLE
[RA] AA Missile Sub + Tweak

### DIFF
--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -62,7 +62,7 @@ MSUB:
 		BuildPaletteOrder: 60
 		Prerequisites: ~spen, stek, ~techlevel.high
 	Valued:
-		Cost: 2400
+		Cost: 2000
 	Tooltip:
 		Name: Missile Submarine
 		Description: Submerged anti-ground unit armed with\nlong-range ballistic missiles.\nCan detect other submarines.\n  Strong vs Buildings, Ground units\n  Weak vs Naval units, Aircraft\n  Special Ability: Submerge
@@ -71,7 +71,7 @@ MSUB:
 	Armor:
 		Type: Light
 	Mobile:
-		TurnSpeed: 3
+		TurnSpeed: 2
 		Speed: 42
 	RevealsShroud:
 		Range: 6c0
@@ -91,8 +91,12 @@ MSUB:
 		UncloakSound: subshow1.aud
 		WhileCloakedUpgrades: underwater
 		Palette: submerged
-	Armament:
+	Armament@PRIMARY:
 		Weapon: SubMissile
+		LocalOffset: 0,-171,0, 0,171,0
+		FireDelay: 2
+	Armament@SECONDARY:
+		Weapon: SubMissileAA
 		LocalOffset: 0,-171,0, 0,171,0
 		FireDelay: 2
 	AttackFrontal:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -65,7 +65,7 @@ MSUB:
 		Cost: 2000
 	Tooltip:
 		Name: Missile Submarine
-		Description: Submerged anti-ground unit armed with\nlong-range ballistic missiles.\nCan detect other submarines.\n  Strong vs Buildings, Ground units\n  Weak vs Naval units, Aircraft\n  Special Ability: Submerge
+		Description: Submerged anti-ground siege unit\nwith basic anti-air capabilities.\nCan detect other submarines.\n  Strong vs Buildings, Ground units, Aircraft\n  Weak vs Naval units\n  Special Ability: Submerge
 	Health:
 		HP: 400
 	Armor:

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -249,16 +249,16 @@ SubMissile:
 	Burst: 2
 	Report: missile6.aud
 	Projectile: Bullet
-		Speed: 102
+		Speed: 162
 		Blockable: false
-		Angle: 165
+		Angle: 105
 		Inaccuracy: 2c938
 		Image: MISSILE
 		TrailImage: smokey
 		ContrailLength: 30
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 30
+		Damage: 25
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
 			None: 40
@@ -276,6 +276,19 @@ SubMissile:
 		Explosions: large_splash
 		ImpactSounds: splash9.aud
 		ValidImpactTypes: Water
+
+SubMissileAA:
+	Inherits: SubMissile
+	Range: 6c0
+	ValidTargets: Air
+	Projectile: Missile
+		Speed: 162
+		Inaccuracy: 0c938
+		HorizontalRateOfTurn: 1
+		RangeLimit: 7c0
+	Warhead@1Dam: SpreadDamage
+		Damage: 20
+		ValidTargets: Air
 
 Stinger:
 	ReloadDelay: 60


### PR DESCRIPTION
Remade AA weaponry off the proposed at #12040

Overall it mostly behaves as if the projectile:bullet AA was cut down to range 6c0 - meaning it's mostly effective vs stationary air targets and performs poorly vs moving targets. 
- At close range 1 unit has a high probability of killing an idle Hind with 1 burst, low probability vs Longbow. At max range there's a lower probability of killing an idle Hind with 1 burst. 
- In a wolf pack Missile Subs does pretty well against idling groups of YAKs/MiGs albeit with unpredictable damage results.

Quoting comments https://github.com/OpenRA/OpenRA/commit/86ad7576cefa51e7fcb1042af546b703bed2b002

This commit brings with it the altered Speed + Angle proposed in the predecessing balance PR #12040 for the primary armament. Originally it was altered to address visually the AA capability of the projectile:bullet but it also had the side effect of being more visually pleasing compared to the very high altitude path of the projectile. With no objections I'd like to bring it along with the next Missile Sub PR.

Turnspeed reduction (2 from 3) addressing targeting behavior vs idling YAKs/MiGs. The unit dances a bit when trying to face these particular targets in-between shots. Issue mostly visual. This is the case regardless of what AA projectile is assigned to the unit. Although YAKs/MiGs are poor targets for the SubMissileAA it still ought to look decent since players will do this anyway from time to time.

If possible, a solution would be for trait like https://github.com/OpenRA/OpenRA/wiki/Traits#attackfrontal to allow the SubMissileAA weapon to fire from ca. 20-30 degrees off it's front facing the target, and retain the normal SubMissiles requirement of having the unit directly facing the target. As per discussion with @chrisforbes  this is something that might require a bit of extra code work. This is a fix beyond my reach so I'm currently submitting this PR as-is with the (less than satisfactory) turnspeed reduction.
