### PR TITLE
Fix integer overflows in Wangle.ArcTan.

### DIFF
--- a/OpenRA.Game/WAngle.cs
+++ b/OpenRA.Game/WAngle.cs
@@ -91,11 +91,13 @@ namespace OpenRA
 			var ax = Math.Abs(x);
 
 			// Find the closest angle that satisfies y = x*tan(theta)
-			var bestVal = int.MaxValue;
+			// Uses a long to store bestVal to eliminate integer overflow issues in the common cases
+			// (may still fail for unrealistically large ax and ay)
+			var bestVal = long.MaxValue;
 			var bestAngle = 0;
 			for (var i = 0; i < 256; i += stride)
 			{
-				var val = Math.Abs(1024 * ay - ax * TanTable[i]);
+				var val = Math.Abs(1024 * ay - (long)ax * TanTable[i]);
 				if (val < bestVal)
 				{
 					bestVal = val;


### PR DESCRIPTION
Fixes #10549.
Fixes #12101.

It turns out that specific `WVec` values would overflow `1024 * ay - ax * TanTable[i]` and give a value _exactly_ equal to `int.MinValue`.  This would then trigger the seemingly impossible "Negating the minimum value of a twos complement number is invalid" exception.

This fixes the problem by using a long for the intermediate value to avoid the overflow for realistic input values.

Simple repro case: add `Console.WriteLine("{0}", new WVec(-39936,72106,0).Yaw);` somewhere in the code.
