### PR TITLE
Fix LaserZap not being removed if HitAnim is not defined

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -86,6 +86,8 @@ namespace OpenRA.Mods.Common.Projectiles
 			{
 				if (hitanim != null)
 					hitanim.PlayThen(info.HitAnimSequence, () => animationComplete = true);
+				else
+					animationComplete = true;
 
 				args.Weapon.Impact(Target.FromPos(target), args.SourceActor, args.DamageModifiers);
 				doneDamage = true;


### PR DESCRIPTION
This avoids degrading performance over time as well as a possible (albeit unlikely) OutOfMemoryException.

Fixes #12108.
