### PR TITLE
Add zoom scaling support to WithDecoration

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
@@ -52,6 +52,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Should this be visible only when selected?")]
 		public readonly bool RequiresSelection = false;
 
+		[Desc("Should this be scaled with zoom level?")]
+		public readonly bool ScaleToZoom = false;
+
 		public override object Create(ActorInitializer init) { return new WithDecoration(init.Self, this); }
 	}
 
@@ -124,7 +127,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 			}
 
 			var pxPos = wr.Viewport.WorldToViewPx(wr.ScreenPxPosition(self.CenterPosition) + boundsOffset) + sizeOffset;
-			return new IRenderable[] { new UISpriteRenderable(Anim.Image, self.CenterPosition, pxPos, Info.ZOffset, wr.Palette(Info.Palette), 1f) };
+			var zoom = Info.ScaleToZoom ? wr.Viewport.Zoom : 1f;
+			return new IRenderable[] { new UISpriteRenderable(Anim.Image, self.CenterPosition, pxPos, Info.ZOffset, wr.Palette(Info.Palette), zoom) };
 		}
 
 		void ITick.Tick(Actor self) { Anim.Tick(); }


### PR DESCRIPTION
This allows modders to use it for things like sprite selection boxes, which can be used to improve performance (sprite decorations cost less render performance than system-drawn lines, at least on my system) or use entirely different art style for selection boxes.

Performance test case: https://github.com/reaperrr/OpenRA/tree/sprite-seldeco

In that test case, with ~390 Minigunners selected, ms/Render went down from ~14.5 to ~12.0 on my system when using a sprite selection box instead of the selection box renderable (local debug compile, performance gains in release would likely be lower).
