### PR TITLE
Change Aircraft.IsMoving to be true only when moving horizontally

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -308,6 +308,7 @@ namespace OpenRA.Traits
 		Activity VisualMove(Actor self, WPos fromPos, WPos toPos);
 		CPos NearestMoveableCell(CPos target);
 		bool IsMoving { get; set; }
+		bool IsMovingVertically { get; set; }
 		bool CanEnterTargetNow(Actor self, Target target);
 	}
 

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -115,13 +115,13 @@ namespace OpenRA.Mods.Common.Traits
 		public int TurnSpeed { get { return Info.TurnSpeed; } }
 		public Actor ReservedActor { get; private set; }
 		public bool MayYieldReservation { get; private set; }
-		public bool IsMovingVertically { get; private set; }
 
 		bool airborne;
 		bool cruising;
 		bool firstTick = true;
 
 		bool isMoving;
+		bool isMovingVertically;
 		WPos cachedPosition;
 
 		public Aircraft(ActorInitializer init, AircraftInfo info)
@@ -182,7 +182,7 @@ namespace OpenRA.Mods.Common.Traits
 			var oldCachedPosition = cachedPosition;
 			cachedPosition = self.CenterPosition;
 			isMoving = (oldCachedPosition - cachedPosition).HorizontalLengthSquared != 0;
-			IsMovingVertically = (oldCachedPosition - cachedPosition).VerticalLengthSquared != 0;
+			isMovingVertically = (oldCachedPosition - cachedPosition).VerticalLengthSquared != 0;
 
 			Repulse();
 		}
@@ -494,6 +494,8 @@ namespace OpenRA.Mods.Common.Traits
 		public CPos NearestMoveableCell(CPos cell) { return cell; }
 
 		public bool IsMoving { get { return isMoving; } set { } }
+
+		public bool IsMovingVertically { get { return isMovingVertically; } set { } }
 
 		public bool CanEnterTargetNow(Actor self, Target target)
 		{

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -118,6 +118,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool airborne;
 		bool cruising;
+		bool firstTick = true;
 
 		public Aircraft(ActorInitializer init, AircraftInfo info)
 		{
@@ -154,7 +155,6 @@ namespace OpenRA.Mods.Common.Traits
 				OnCruisingAltitudeReached();
 		}
 
-		bool firstTick = true;
 		public virtual void Tick(Actor self)
 		{
 			if (firstTick)

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -115,10 +115,14 @@ namespace OpenRA.Mods.Common.Traits
 		public int TurnSpeed { get { return Info.TurnSpeed; } }
 		public Actor ReservedActor { get; private set; }
 		public bool MayYieldReservation { get; private set; }
+		public bool IsMovingVertically { get; private set; }
 
 		bool airborne;
 		bool cruising;
 		bool firstTick = true;
+
+		bool isMoving;
+		WPos cachedPosition;
 
 		public Aircraft(ActorInitializer init, AircraftInfo info)
 		{
@@ -142,6 +146,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			um = self.TraitOrDefault<UpgradeManager>();
 			speedModifiers = self.TraitsImplementing<ISpeedModifier>().ToArray().Select(sm => sm.GetSpeedModifier());
+			cachedPosition = self.CenterPosition;
 		}
 
 		public void AddedToWorld(Actor self)
@@ -173,6 +178,11 @@ namespace OpenRA.Mods.Common.Traits
 
 				self.QueueActivity(new TakeOff(self));
 			}
+
+			var oldCachedPosition = cachedPosition;
+			cachedPosition = self.CenterPosition;
+			isMoving = (oldCachedPosition - cachedPosition).HorizontalLengthSquared != 0;
+			IsMovingVertically = (oldCachedPosition - cachedPosition).VerticalLengthSquared != 0;
 
 			Repulse();
 		}
@@ -483,7 +493,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public CPos NearestMoveableCell(CPos cell) { return cell; }
 
-		public bool IsMoving { get { return self.World.Map.DistanceAboveTerrain(CenterPosition).Length > 0; } set { } }
+		public bool IsMoving { get { return isMoving; } set { } }
 
 		public bool CanEnterTargetNow(Actor self, Target target)
 		{

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -266,12 +266,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected void ReserveSpawnBuilding()
 		{
-			/* HACK: not spawning in the air, so try to assoc. with our afld. */
-			var afld = GetActorBelow();
-			if (afld == null)
+			// HACK: Not spawning in the air, so try to associate with our spawner.
+			var spawner = GetActorBelow();
+			if (spawner == null)
 				return;
 
-			MakeReservation(afld);
+			MakeReservation(spawner);
 		}
 
 		public void MakeReservation(Actor target)

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -327,6 +327,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Actor self;
 		readonly Lazy<IEnumerable<int>> speedModifiers;
 		public bool IsMoving { get; set; }
+		public bool IsMovingVertically { get { return false; } set { } }
 
 		int facing;
 		CPos fromCell, toCell;

--- a/OpenRA.Mods.Common/Traits/Render/WithMoveAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMoveAnimation.cs
@@ -27,24 +27,16 @@ namespace OpenRA.Mods.Common.Traits.Render
 		readonly IMove movement;
 		readonly WithSpriteBody wsb;
 
-		WPos cachedPosition;
-
 		public WithMoveAnimation(ActorInitializer init, WithMoveAnimationInfo info)
 		{
 			this.info = info;
 			movement = init.Self.Trait<IMove>();
 			wsb = init.Self.Trait<WithSpriteBody>();
-
-			cachedPosition = init.Self.CenterPosition;
 		}
 
 		public void Tick(Actor self)
 		{
-			var oldCachedPosition = cachedPosition;
-			cachedPosition = self.CenterPosition;
-
-			// Flying units set IsMoving whenever they are airborne, which isn't enough for our purposes
-			var isMoving = movement.IsMoving && !self.IsDead && (oldCachedPosition - cachedPosition).HorizontalLengthSquared != 0;
+			var isMoving = movement.IsMoving && !self.IsDead;
 			if (isMoving ^ (wsb.DefaultAnimation.CurrentSequence.Name != info.MoveSequence))
 				return;
 


### PR DESCRIPTION
This gets rid of the overly simplistic "above ground = moving" assumption aircraft currently make, removing the need to work around it in other places.

In case we need a vertical movement check later, I added `IsMovingVertically` as a precaution.

Prerequisite for #11886.
