### PR TITLE
Updated MaxMind.GeoIP to version 2.7.1

### DIFF
--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -38,7 +38,7 @@ if (!(Test-Path "ICSharpCode.SharpZipLib.dll"))
 if (!(Test-Path "MaxMind.GeoIP2.dll"))
 {
 	echo "Fetching MaxMind.GeoIP2 from NuGet."
-	./nuget.exe install MaxMind.GeoIP2 -Version 2.6.0 -ExcludeVersion
+	./nuget.exe install MaxMind.GeoIP2 -Version 2.7.1 -ExcludeVersion
 	cp MaxMind.Db/lib/net45/MaxMind.Db.* .
 	rmdir MaxMind.Db -Recurse
 	cp MaxMind.GeoIP2/lib/net45/MaxMind.GeoIP2* .

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -8,7 +8,7 @@ if (!(Test-Path "nuget.exe"))
 	# Work around PowerShell's Invoke-WebRequest not being available on some versions of PowerShell by using the BCL.
 	# To do that we need to work around further and use absolute paths because DownloadFile is not aware of PowerShell's current directory.
 	$target = Join-Path $pwd.ToString() "nuget.exe"
-	(New-Object System.Net.WebClient).DownloadFile("http://nuget.org/nuget.exe", $target)
+	(New-Object System.Net.WebClient).DownloadFile("https://dist.nuget.org/win-x86-commandline/v3.4.4/NuGet.exe", $target)
 }
 
 if (!(Test-Path "StyleCopPlus.dll"))

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -49,9 +49,9 @@ fi
 
 if [ ! -f MaxMind.GeoIP2.dll ]; then
 	echo "Fetching MaxMind.GeoIP2 from NuGet"
-	get Newtonsoft.Json 8.0.3
-	get MaxMind.Db 2.0.0
-	get MaxMind.GeoIP2 2.6.0
+	get Newtonsoft.Json 9.0.1
+	get MaxMind.Db 2.1.2
+	get MaxMind.GeoIP2 2.7.1
 	cp ./MaxMind.Db/lib/net45/MaxMind.Db.* .
 	rm -rf MaxMind.Db
 	cp ./MaxMind.GeoIP2/lib/net45/MaxMind.GeoIP2* .


### PR DESCRIPTION
as requsted by @rapgro in https://bugzilla.redhat.com/show_bug.cgi?id=1270525#c7

See https://github.com/maxmind/GeoIP2-dotnet/releases and https://github.com/maxmind/MaxMind-DB-Reader-dotnet/releases for a changelog, which seems to indicate this only standardizes and updates build dependencies.
