### PR TITLE
TS polishing pass: Ion Cannon, z-sorting, offsets, explosions

### DIFF
--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -401,7 +401,9 @@ GAPLUG:
 		UpgradeTypes: plug.ioncannon
 		UpgradeMinEnabledLevel: 1
 		Icon: ioncannon
-		Effect: ionring
+		Effect: explosion
+		EffectSequence: ionring
+		EffectPalette: effectalpha75
 		WeaponDelay: 0
 		ChargeTime: 510
 		Description: Ion Cannon

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -403,7 +403,7 @@ GAPLUG:
 		Icon: ioncannon
 		Effect: ionring
 		WeaponDelay: 0
-		ChargeTime: 180
+		ChargeTime: 510
 		Description: Ion Cannon
 		LongDesc: Initiate an Ion Cannon strike.\nApplies instant damage to a small area.
 		EndChargeSpeechNotification: IonCannonReady

--- a/mods/ts/rules/nod-infantry.yaml
+++ b/mods/ts/rules/nod-infantry.yaml
@@ -17,7 +17,7 @@ E3:
 		Speed: 42
 	Armament@PRIMARY:
 		Weapon: Bazooka
-		LocalOffset: 128,0,640
+		LocalOffset: 252,0,684
 	AttackFrontal:
 		Voice: Attack
 	WithInfantryBody:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -56,12 +56,12 @@ BIKE:
 		UpgradeTypes: eliteweapon
 		UpgradeMaxEnabledLevel: 0
 		UpgradeMaxAcceptedLevel: 1
-		LocalOffset: -128,-170,213, -128,170,213
+		LocalOffset: -108,-144,360, -108,144,360
 	Armament@ELITE:
 		Weapon: HoverMissile
 		UpgradeTypes: eliteweapon
 		UpgradeMinEnabledLevel: 1
-		LocalOffset: -128,-170,213, -128,170,213
+		LocalOffset: -108,-144,360, -108,144,360
 	AttackFrontal:
 		Voice: Attack
 	AutoTarget:

--- a/mods/ts/rules/palettes.yaml
+++ b/mods/ts/rules/palettes.yaml
@@ -41,6 +41,18 @@
 	PaletteFromFile@effect:
 		Name: effect
 		Filename: anim.pal
+	PaletteFromPaletteWithAlpha@effectalpha25:
+		Name: effectalpha25
+		Alpha: 0.25
+		BasePalette: effect
+	PaletteFromPaletteWithAlpha@effectalpha50:
+		Name: effectalpha50
+		Alpha: 0.5
+		BasePalette: effect
+	PaletteFromPaletteWithAlpha@effectalpha75:
+		Name: effectalpha75
+		Alpha: 0.75
+		BasePalette: effect
 	PaletteFromFile@sidebar:
 		Name: sidebar
 		Filename: sidebar-nod|sidebar.pal

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -132,38 +132,31 @@ explosion:
 	building: twlt070
 		Offset: 0, 0, 36
 	ionring: ring1
-		BlendMode: Additive
 		ZRamp: 1
 		Tick: 100
 	ionbeam: ionbeam
-		Offset: 0,-60
-		BlendMode: Additive
-		Length: *
+		Offset: 0, -60, 60
+		ZRamp: 1
 		Tick: 100
 	ionbeam2: ionbeam
-		Offset: 0,-180
-		BlendMode: Additive
-		Length: *
+		Offset: 0, -180, 60
+		ZRamp: 1
 		Tick: 100
 	ionbeam3: ionbeam
-		Offset: 0,-300
-		BlendMode: Additive
-		Length: *
+		Offset: 0, -300, 60
+		ZRamp: 1
 		Tick: 100
 	ionbeam4: ionbeam
-		Offset: 0,-420
-		BlendMode: Additive
-		Length: *
+		Offset: 0, -420, 60
+		ZRamp: 1
 		Tick: 100
 	ionbeam5: ionbeam
-		Offset: 0,-540
-		BlendMode: Additive
-		Length: *
+		Offset: 0, -540, 60
+		ZRamp: 1
 		Tick: 100
 	ionbeam6: ionbeam
-		Offset: 0,-660
-		BlendMode: Additive
-		Length: *
+		Offset: 0, -660, 60
+		ZRamp: 1
 		Tick: 100
 	pulse_explosion: pulsefx2
 		BlendMode: Additive
@@ -423,18 +416,6 @@ clustermissile:
 		Length: *
 	down: null # TODO
 		Length: *
-
-ionbeam:
-	idle:
-		Length: *
-		Offset: 0, -78
-		ZOffset: 1023
-
-ionring: 
-	idle: ring1
-		Length: *
-		ZOffset: -512
-		Tick: 120
 
 ^rock:
 	idle:

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -51,6 +51,7 @@ crate-effects:
 	Defaults:
 		Length: *
 		ZOffset: 2047
+		Offset: 0, 0, 24
 	dollar: money
 	reveal-map: reveal
 	hide-map: shroudx
@@ -211,22 +212,26 @@ discus:
 	idle:
 		Length: *
 		ZOffset: 1023
+		Offset: 0, 0, 12
 
 canister:
 	idle:
 		Length: *
 		ZOffset: 1023
+		Offset: 0, 0, 12
 
 pulsball:
 	idle:
 		Length: *
 		BlendMode: Additive
 		ZOffset: 1023
+		Offset: 0, 0, 24
 
 dragon:
 	idle:
 		Facings: 32
 		ZOffset: 1023
+		Offset: 0, 0, 6
 
 crystal4:
 	idle:
@@ -234,15 +239,18 @@ crystal4:
 		ShadowStart: 15
 		UseTilesetExtension: true
 		ZOffset: 1023
+		Offset: 0, 0, 6
 
 120mm:
 	idle:
 		ZOffset: 1023
+		Offset: 0, 0, 4
 
 torpedo:
 	idle:
 		Length: *
 		ZOffset: 1023
+		Offset: 0, 0, 8
 
 flameall:
 	idle:
@@ -250,42 +258,51 @@ flameall:
 		Facings: -8
 		Tick: 160
 		ZOffset: 1023
+		Offset: 0, 0, 24
 
 largesmoke:
 	idle: lgrysmk1
 		Length: *
 		ZOffset: 1023
+		Offset: 0, 0, 24
 
 smallsmoke:
 	idle: sgrysmk1
 		Length: *
 		ZOffset: 1023
+		Offset: 0, 0, 24
 
 large_smoke_trail:
 	idle: smokey
 		Length: *
 		ZOffset: 1023
+		Offset: 0, 0, 24
 
 small_smoke_trail:
 	idle: smokey2
 		Length: *
 		ZOffset: 1023
+		Offset: 0, 0, 24
 
 largefire:
 	idle: fire1
 		Length: *
+		Offset: 0, 0, 36
 
 mediumfire:
 	idle: fire2
 		Length: *
+		Offset: 0, 0, 24
 
 smallfire:
 	idle: fire3
 		Length: *
+		Offset: 0, 0, 24
 
 tinyfire:
 	idle: fire4
 		Length: *
+		Offset: 0, 0, 24
 
 moveflsh:
 	idle: ring

--- a/mods/ts/weapons/bombsandgrenades.yaml
+++ b/mods/ts/weapons/bombsandgrenades.yaml
@@ -53,6 +53,7 @@ Bomb:
 		DamageTypes: Prone100Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: large_explosion
+		ExplosionPalette: effectalpha75
 		ImpactSounds: expnew09.aud
 		InvalidImpactTypes: Water
 	Warhead@3EffWater: CreateEffect

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -126,6 +126,7 @@ CyCannon:
 		DamageTypes: Prone350Percent, TriggerProne, EnergyDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: large_explosion
+		ExplosionPalette: effectalpha75
 		ImpactSounds: expnew12.aud
 		InvalidImpactTypes: Water
 	Warhead@3EffWater: CreateEffect

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -125,7 +125,7 @@ CyCannon:
 			Concrete: 80
 		DamageTypes: Prone350Percent, TriggerProne, EnergyDeath
 	Warhead@2Eff: CreateEffect
-		Explosions: large_bang
+		Explosions: large_explosion
 		ImpactSounds: expnew12.aud
 		InvalidImpactTypes: Water
 	Warhead@3EffWater: CreateEffect

--- a/mods/ts/weapons/explosions.yaml
+++ b/mods/ts/weapons/explosions.yaml
@@ -11,6 +11,7 @@ UnitExplode:
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: large_twlt
+		ExplosionPalette: effectalpha75
 		ImpactSounds: expnew09.aud
 	Warhead@4Smu: LeaveSmudge
 		SmudgeType: MediumCrater
@@ -53,6 +54,7 @@ TiberiumExplosion:
 		Size: 1,1
 	Warhead@3Eff: CreateEffect
 		Explosions: large_explosion
+		ExplosionPalette: effectalpha75
 		ImpactSounds: expnew09.aud
 
 SmallDebris:

--- a/mods/ts/weapons/largeguns.yaml
+++ b/mods/ts/weapons/largeguns.yaml
@@ -19,7 +19,7 @@
 			Concrete: 60
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
-		Explosions: medium_clsn
+		Explosions: small_clsn
 		ImpactSounds: expnew14.aud
 		InvalidImpactTypes: Water
 	Warhead@3EffWater: CreateEffect
@@ -48,7 +48,7 @@
 			Concrete: 60
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
-		Explosions: large_clsn
+		Explosions: medium_clsn
 		ImpactSounds: expnew14.aud
 		InvalidImpactTypes: Water
 	Warhead@3EffWater: CreateEffect

--- a/mods/ts/weapons/largeguns.yaml
+++ b/mods/ts/weapons/largeguns.yaml
@@ -119,6 +119,7 @@
 		DamageTypes: Prone100Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: large_explosion
+		ExplosionPalette: effectalpha75
 		ImpactSounds: expnew06.aud
 		InvalidImpactTypes: Water
 	Warhead@3EffWater: CreateEffect

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -77,17 +77,23 @@ IonCannon:
 		Delay: 3
 	Warhead@4Effect: CreateEffect
 		Explosions: ionbeam
-		ImpactSound: ion1.aud
+		ExplosionPalette: effectalpha75
+		ImpactSounds: ion1.aud
 	Warhead@5Effect: CreateEffect
 		Explosions: ionbeam2
+		ExplosionPalette: effectalpha75
 	Warhead@6Effect: CreateEffect
 		Explosions: ionbeam3
+		ExplosionPalette: effectalpha75
 	Warhead@7Effect: CreateEffect
 		Explosions: ionbeam4
+		ExplosionPalette: effectalpha75
 	Warhead@8Effect: CreateEffect
 		Explosions: ionbeam5
+		ExplosionPalette: effectalpha75
 	Warhead@9Effect: CreateEffect
 		Explosions: ionbeam6
+		ExplosionPalette: effectalpha75
 
 EMPulseCannon:
 	ReloadDelay: 100


### PR DESCRIPTION
- Adds alpha versions of effect palette for 25%, 50% and 75% alpha (these 3 were available in the original as well)
- Fixes remaining bugs (sound not playing, z-sorting) and inconsistencies (the original used alpha transparency, not additive blending, original charge time was 8.5 minutes at 15 fps) of Ion Cannon and clean up redundant sequences
- Changes Tick Tank and Titan cannon explosions to match original (they were each one size too large)
- Fixes Cyborg Commando weapon explosion to match original
- Uses 75% alpha for large explosions
- Fixes depth/Z sorting of smoke trails, projectiles and some other misc stuff
- Fixes Armament LocalOffsets for Bazooka and Bike
