### PR TITLE
TS polishing pass: More depth sorting and starting units

### DIFF
--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -116,7 +116,7 @@ World:
 		ClassName: Light
 		Factions: gdi
 		BaseActor: mcv
-		SupportActors: e1,e1,e1,e2,e2
+		SupportActors: e1,e1,e1,smech
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
 	MPStartUnits@light.nod:
@@ -124,7 +124,7 @@ World:
 		ClassName: Light
 		Factions: nod
 		BaseActor: mcv
-		SupportActors: e1,e1,e1,e3,e3
+		SupportActors: e1,e1,e1,bggy
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
 	MPStartUnits@med.gdi:
@@ -132,7 +132,7 @@ World:
 		ClassName: Medium
 		Factions: gdi
 		BaseActor: mcv
-		SupportActors: e1,e1,e2,jumpjet,smech
+		SupportActors: e1,e1,e2,e2,jumpjet,smech
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
 	MPStartUnits@med.nod:
@@ -140,7 +140,7 @@ World:
 		ClassName: Medium
 		Factions: nod
 		BaseActor: mcv
-		SupportActors: e1,e1,e3,cyborg,bggy
+		SupportActors: e1,e1,e3,e3,cyborg,bggy
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
 	MPStartUnits@heavy.gdi:
@@ -148,7 +148,7 @@ World:
 		ClassName: Heavy
 		Factions: gdi
 		BaseActor: mcv
-		SupportActors: e1,e2,e2,smech,mmch
+		SupportActors: e1,e1,e2,e2,jumpjet,smech,smech,mmch
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
 	MPStartUnits@heavy.nod:
@@ -156,7 +156,7 @@ World:
 		ClassName: Heavy
 		Factions: nod
 		BaseActor: mcv
-		SupportActors: e1,e3,bggy,bike,ttnk
+		SupportActors: e1,e1,e3,e3,cyborg,bggy,bike,ttnk
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
 	MPStartLocations:

--- a/mods/ts/sequences/civilian.yaml
+++ b/mods/ts/sequences/civilian.yaml
@@ -405,7 +405,7 @@ capyr03:
 	Inherits: ^cabase
 	Defaults:
 		Offset: -24, -36, 36
-		DepthSpriteOffset: -24, 0
+		DepthSpriteOffset: -24, 48
 
 ^city4x3:
 	Inherits: ^cabase
@@ -415,6 +415,8 @@ capyr03:
 
 city01:
 	Inherits: ^city4x2
+	Defaults:
+		Offset: -12, -30, 36
 
 city02:
 	Inherits: ^city2x3
@@ -433,6 +435,8 @@ city06:
 
 city07:
 	Inherits: ^city4x2
+	Defaults:
+		Offset: -12, -30, 36
 
 city08:
 	Inherits: ^city2x2
@@ -461,7 +465,7 @@ city15:
 city16:
 	Inherits: ^city4x2
 	Defaults:
-		DepthSpriteOffset: -10, 0
+		Offset: -24, -30, 36
 
 city17:
 	Inherits: ^city4x3

--- a/mods/ts/sequences/civilian.yaml
+++ b/mods/ts/sequences/civilian.yaml
@@ -104,7 +104,7 @@ aban18:
 
 ^bboard1x1:
 	Defaults:
-		Offset: 0, -12
+		Offset: 0, -12, 6
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -114,6 +114,15 @@ aban18:
 ^bboard1x2:
 	Defaults:
 		Offset: 12, -18
+	idle:
+		ShadowStart: 2
+	damaged-idle:
+		Start: 1
+		ShadowStart: 3
+
+^bboard2x1:
+	Defaults:
+		Offset: -12, -18
 	idle:
 		ShadowStart: 2
 	damaged-idle:
@@ -160,13 +169,13 @@ bboard13:
 	Inherits: ^bboard1x1
 
 bboard14:
-	Inherits: ^bboard1x2
+	Inherits: ^bboard2x1
 
 bboard15:
-	Inherits: ^bboard1x2
+	Inherits: ^bboard2x1
 
 bboard16:
-	Inherits: ^bboard1x2
+	Inherits: ^bboard2x1
 
 ^cabase:
 	Defaults:
@@ -187,12 +196,21 @@ bboard16:
 	Inherits: ^cabase
 	Defaults:
 		Offset: 12, -18, 18
+		DepthSpriteOffset: 12, 0
+		UseTilesetCode: true
+
+^ca2x1:
+	Inherits: ^cabase
+	Defaults:
+		Offset: -12, -18, 18
+		DepthSpriteOffset: -12, 0
 		UseTilesetCode: true
 
 ^ca2x3:
 	Inherits: ^cabase
 	Defaults:
 		Offset: 12, -30, 30
+		DepthSpriteOffset: 12, 0
 		UseTilesetCode: true
 
 ^ca3x3:
@@ -244,7 +262,7 @@ ca0012:
 	Inherits: ^ca1x2
 
 ca0013:
-	Inherits: ^ca1x2
+	Inherits: ^ca2x1
 
 ca0014:
 	Inherits: ^ca1x1
@@ -369,21 +387,31 @@ capyr03:
 	Inherits: ^cabase
 	Defaults:
 		Offset: 12, -30, 30
+		DepthSpriteOffset: 12, 0
+
+^city3x2:
+	Inherits: ^cabase
+	Defaults:
+		Offset: -12, -30, 30
+		DepthSpriteOffset: -12, 0
 
 ^city3x5:
 	Inherits: ^cabase
 	Defaults:
 		Offset: 24, -48, 48
+		DepthSpriteOffset: 24, 0
 
 ^city4x2:
 	Inherits: ^cabase
 	Defaults:
 		Offset: -24, -36, 36
+		DepthSpriteOffset: -24, 0
 
 ^city4x3:
 	Inherits: ^cabase
 	Defaults:
 		Offset: -12, -42, 42
+		DepthSpriteOffset: -12, 0
 
 city01:
 	Inherits: ^city4x2
@@ -392,13 +420,13 @@ city02:
 	Inherits: ^city2x3
 
 city03:
-	Inherits: ^city2x3
+	Inherits: ^city3x2
 
 city04:
-	Inherits: ^city2x3
+	Inherits: ^city3x2
 
 city05:
-	Inherits: ^city2x3
+	Inherits: ^city3x2
 
 city06:
 	Inherits: ^city4x2
@@ -432,6 +460,8 @@ city15:
 
 city16:
 	Inherits: ^city4x2
+	Defaults:
+		DepthSpriteOffset: -10, 0
 
 city17:
 	Inherits: ^city4x3

--- a/mods/ts/sequences/civilian.yaml
+++ b/mods/ts/sequences/civilian.yaml
@@ -27,26 +27,31 @@ ammocrat:
 	Inherits: ^abanbase
 	Defaults:
 		Offset: 36, -42, 42
+		DepthSpriteOffset: 24, 0
 
 ^aban2x6:
 	Inherits: ^abanbase
 	Defaults:
 		Offset: 48, -48, 48
+		DepthSpriteOffset: 36, 0
 
 ^aban3x2:
 	Inherits: ^abanbase
 	Defaults:
 		Offset: -12, -30, 30
+		DepthSpriteOffset: -12, 0
 
 ^aban4x2:
 	Inherits: ^abanbase
 	Defaults:
 		Offset: -24, -36, 36
+		DepthSpriteOffset: -24, 0
 
 ^aban5x3:
 	Inherits: ^abanbase
 	Defaults:
 		Offset: -24, -48, 48
+		DepthSpriteOffset: -24, 0
 
 aban01:
 	Inherits: ^aban2x6

--- a/mods/ts/sequences/civilian.yaml
+++ b/mods/ts/sequences/civilian.yaml
@@ -344,6 +344,7 @@ cacrsh05:
 cahosp:
 	Defaults:
 		DepthSprite: isodepth.shp
+		DepthSpriteOffset: 12, 0
 		UseTilesetCode: true
 		Offset: 12, -42, 42
 	idle:
@@ -547,6 +548,7 @@ gaoldcc6:
 gakodk:
 	Defaults:
 		DepthSprite: isodepth.shp
+		DepthSpriteOffset: -24, 0
 		UseTilesetCode: true
 		Offset: -24, -36, 36
 	idle:
@@ -642,6 +644,7 @@ galite:
 namntk:
 	Defaults:
 		DepthSprite: isodepth.shp
+		DepthSpriteOffset: 24, 0
 		UseTilesetCode: true
 		Offset: 24, -24, 24
 	idle:

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -70,16 +70,19 @@ mpspawn:
 	idle:
 		Length: *
 		ZRamp: 1
+		Offset: 0, 0, 24
 
 waypoint:
 	idle:
 		Length: *
 		ZRamp: 1
+		Offset: 0, 0, 24
 
 camera:
 	idle:
 		Length: *
 		ZRamp: 1
+		Offset: 0, 0, 24
 
 clock:
 	idle: gclock2

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -893,6 +893,7 @@ gaicbm:
 		Offset: 0, -12, 12
 		UseTilesetCode: true
 		DepthSprite: isodepth.shp
+		DepthSpriteOffset: -12, 6
 	idle:
 		ShadowStart: 3
 	damaged-idle:

--- a/mods/ts/sequences/vehicles.yaml
+++ b/mods/ts/sequences/vehicles.yaml
@@ -47,23 +47,22 @@ hvr:
 lpst.gdi:
 	Inherits: ^VehicleOverlays
 	idle: gadpsa
-		Offset: 0, -12
+		DepthSprite: isodepth.shp
+		DepthSpriteOffset: -6, -6
+		Offset: 0, -12, 12
+		UseTilesetCode: true
 		ShadowStart: 3
 	make: gadpsamk
-		Offset: 0, -12
+		DepthSprite: isodepth.shp
+		DepthSpriteOffset: -6, -6
+		Offset: 0, -12, 12
+		UseTilesetCode: true
 		Length: 36
 		ShadowStart: 36
 	icon: sidebar-gdi|lpsticon
 
 lpst.nod:
-	Inherits: ^VehicleOverlays
-	idle: gadpsa
-		Offset: 0, -12
-		ShadowStart: 3
-	make: gadpsamk
-		Offset: 0, -12
-		Length: 36
-		ShadowStart: 36
+	Inherits: lpst.gdi
 	icon: sidebar-nod|lpsticon
 
 repair:


### PR DESCRIPTION
- Fixes depth sorting of editor actors (spawnpoint, waypoint, camera)
- Fixes depth sorting and offsets of several civilian structures
- Increases number of starting units for medium by 1 and for heavy by 2
