### PR TITLE
[Lint] Report when Maps contains invalid custom rules. 

### DIFF
--- a/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
+++ b/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
@@ -31,6 +31,9 @@ namespace OpenRA.Mods.Common.Lint
 
 			if (!map.Categories.Any())
 				emitError("Map does not define any categories.");
+
+			if (map.InvalidCustomRules)
+				emitError("Map contains invalid custom rules.");
 		}
 	}
 }


### PR DESCRIPTION
This prevents the loading of default rules when loading (custom) Rules fails.
