### PR TITLE
Search for the Next free closest Proc

### DIFF
--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -165,7 +165,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// Find all refineries and their occupancy count:
 			var refs = self.World.ActorsWithTrait<IAcceptResources>()
-				.Where(r => r.Actor != ignore && r.Actor.Owner == self.Owner && IsAcceptableProcType(r.Actor))
+				.Where(r => r.Actor != ignore && r.Actor.Owner == self.Owner && r.Trait.AllowDocking && IsAcceptableProcType(r.Actor))
 				.Select(r => new {
 					Location = r.Actor.Location + r.Trait.DeliveryOffset,
 					Actor = r.Actor,
@@ -183,8 +183,8 @@ namespace OpenRA.Mods.Common.Traits
 
 					var occupancy = refs[loc].Occupancy;
 
-					// 4 harvesters clogs up the refinery's delivery location:
-					if (occupancy >= 3)
+					// 3 harvesters clogs up the refinery's delivery location:
+					if (occupancy >= 2)
 						return Constants.InvalidNode;
 
 					// Prefer refineries with less occupancy (multiplier is to offset distance cost):


### PR DESCRIPTION
This enables Harvesters to use the next closest and free Refinery as like in the originals 
