### PR TITLE
FixHeader: Add support for "/LargeAddressAware"

### DIFF
--- a/packaging/fixheader.cs
+++ b/packaging/fixheader.cs
@@ -29,6 +29,9 @@ namespace fixheader
 
 			data[corHeaderOffset + 16] |= 2;
 
+			// Set Flag "Application can handle large (>2GB) addresses (/LARGEADDRESSAWARE)"
+			data[peOffset + 4 + 18] |= 0x20;
+
 			File.WriteAllBytes(args[0], data);
 		}
 


### PR DESCRIPTION
closes #12125 Thanks to @chrisforbes who explained me the PE Header Layout =)
closes https://github.com/OpenRA/ra2/issues/304

To test:
- use VS `dumpbin.exe` in:

```
`C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin> .\dumpbin.exe /HEADERS <OpenRA.Game.exe-path>
```

the output should be:

```
FILE HEADER VALUES
             14C machine (x86)
               3 number of sections
        57EEF3CA time date stamp Sat Oct  1 01:22:50 2016
               0 file pointer to symbol table
               0 number of symbols
              E0 size of optional header
             122 characteristics
                   Executable
                   Application can handle large (>2GB) addresses <---- here
                   32 bit word machine
```
- or use PE Explorer (look for the checkbox) next to the red square under characteristics

![pe_explorer](https://cloud.githubusercontent.com/assets/2057932/19009820/07b5fc04-8778-11e6-98a9-0339a7f3d53e.png)
