### PR TITLE
Prevent TickRender from running before the world's first Tick.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -567,7 +567,9 @@ namespace OpenRA
 					else
 						PerfHistory.Tick();
 
-					Sync.CheckSyncUnchanged(world, () => world.TickRender(worldRenderer));
+					// Wait until we have done our first world Tick before TickRendering
+					if (orderManager.LocalFrameNumber > 0)
+						Sync.CheckSyncUnchanged(world, () => world.TickRender(worldRenderer));
 				}
 			}
 		}


### PR DESCRIPTION
If one or more clients in a MP game takes significantly longer than the rest to load it will suppress the trait `Tick`s for all the faster clients, but not the `RenderTick`s.  This is a problem, because there are cases where `RenderTick` relies on state that is initialized by `Tick`.

Fixes #11279.

The following patch introduces a simple repro case to help with testing (needs at least two real clients):

``` diff
diff --git a/OpenRA.Game/Game.cs b/OpenRA.Game/Game.cs
index d9ccb31..0ce3098 100644
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -165,6 +165,9 @@ internal static void StartGame(string mapUID, WorldType type)
                        using (new PerfTimer("NewWorld"))
                                OrderManager.World = new World(map, OrderManager, type);

+                       if (!IsHost)
+                               Thread.Sleep(5000);
+
                        worldRenderer = new WorldRenderer(ModData, OrderManager.World);

                        using (new PerfTimer("LoadComplete"))
```
