### PR TITLE
Extract a common SHA1 helper.

### DIFF
--- a/OpenRA.Game/CryptoUtil.cs
+++ b/OpenRA.Game/CryptoUtil.cs
@@ -1,0 +1,38 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace OpenRA
+{
+	public static class CryptoUtil
+	{
+		public static string SHA1Hash(Stream data)
+		{
+			using (var csp = SHA1.Create())
+				return new string(csp.ComputeHash(data).SelectMany(a => a.ToString("x2")).ToArray());
+		}
+
+		public static string SHA1Hash(byte[] data)
+		{
+			using (var csp = SHA1.Create())
+				return new string(csp.ComputeHash(data).SelectMany(a => a.ToString("x2")).ToArray());
+		}
+
+		public static string SHA1Hash(string data)
+		{
+			return SHA1Hash(Encoding.UTF8.GetBytes(data));
+		}
+	}
+}

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -16,12 +16,8 @@ using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Security.Cryptography;
 using System.Text;
 using OpenRA.FileSystem;
-using OpenRA.Graphics;
-using OpenRA.Network;
-using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Traits;
 
@@ -264,8 +260,7 @@ namespace OpenRA
 
 				// Take the SHA1
 				ms.Seek(0, SeekOrigin.Begin);
-				using (var csp = SHA1.Create())
-					return new string(csp.ComputeHash(ms).SelectMany(a => a.ToString("x2")).ToArray());
+				return CryptoUtil.SHA1Hash(ms);
 			}
 		}
 

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -11,11 +11,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Security.Cryptography;
-using OpenRA.FileSystem;
 using OpenRA.Primitives;
 
 namespace OpenRA
@@ -52,10 +49,7 @@ namespace OpenRA
 				//   (a) loading duplicate data into the application domain, breaking the world.
 				//   (b) crashing if the assembly has already been loaded.
 				// We can't check the internal name of the assembly, so we'll work off the data instead
-				string hash;
-				using (var ms = new MemoryStream(data))
-					using (var csp = SHA1.Create())
-						hash = new string(csp.ComputeHash(data).SelectMany(a => a.ToString("x2")).ToArray());
+				var hash = CryptoUtil.SHA1Hash(data);
 
 				Assembly assembly;
 				if (!ResolvedAssemblies.TryGetValue(hash, out assembly))

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -244,6 +244,7 @@
     <Compile Include="FileSystem\ZipFolder.cs" />
     <Compile Include="Primitives\float3.cs" />
     <Compile Include="InstalledMods.cs" />
+    <Compile Include="CryptoUtil.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FileSystem\D2kSoundResources.cs" />

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
@@ -13,8 +13,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
+using OpenRA;
 using OpenRA.FileFormats;
 using OpenRA.Mods.Common.FileFormats;
 using OpenRA.Widgets;
@@ -507,12 +507,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						return false;
 
 					using (var fileStream = File.OpenRead(filePath))
-					using (var csp = SHA1.Create())
-					{
-						var hash = new string(csp.ComputeHash(fileStream).SelectMany(a => a.ToString("x2")).ToArray());
-						if (hash != kv.Value)
+						if (CryptoUtil.SHA1Hash(fileStream) != kv.Value)
 							return false;
-					}
 				}
 			}
 			catch (Exception)


### PR DESCRIPTION
This removes some duplication by replacing all the DIY sha1 calculations with a set of helpers.

The CryptoUtil class will grow a lot more code for #2265: this is just the first step to reduce the size of future PRs.
