### PR TITLE
Support subtraction of two CPos in Lua

### DIFF
--- a/OpenRA.Game/CPos.cs
+++ b/OpenRA.Game/CPos.cs
@@ -83,11 +83,24 @@ namespace OpenRA
 		public LuaValue Subtract(LuaRuntime runtime, LuaValue left, LuaValue right)
 		{
 			CPos a;
-			CVec b;
-			if (!left.TryGetClrValue(out a) || !right.TryGetClrValue(out b))
-				throw new LuaException("Attempted to call CPos.Subtract(CPos, CVec) with invalid arguments ({0}, {1})".F(left.WrappedClrType().Name, right.WrappedClrType().Name));
+			var rightType = right.WrappedClrType();
+			if (!left.TryGetClrValue(out a))
+				throw new LuaException("Attempted to call CPos.Subtract(CPos, (CPos|CVec)) with invalid arguments ({0}, {1})".F(left.WrappedClrType().Name, rightType.Name));
 
-			return new LuaCustomClrObject(a - b);
+			if (rightType == typeof(CPos))
+			{
+				CPos b;
+				right.TryGetClrValue(out b);
+				return new LuaCustomClrObject(a - b);
+			}
+			else if (rightType == typeof(CVec))
+			{
+				CVec b;
+				right.TryGetClrValue(out b);
+				return new LuaCustomClrObject(a - b);
+			}
+
+			throw new LuaException("Attempted to call CPos.Subtract(CPos, (CPos|CVec)) with invalid arguments ({0}, {1})".F(left.WrappedClrType().Name, rightType.Name));
 		}
 
 		public LuaValue Equals(LuaRuntime runtime, LuaValue left, LuaValue right)


### PR DESCRIPTION
Fixes #11667, based off of [WPos already supporting this](https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Game/WPos.cs#L93). I also tweaked the exception text as well (if this is fine, WPos could get updated too).

For testing I dropped this in the WorldLoaded function on a scripted map:

```
local pos1 = CPos.New(10, 10)
local vec1 = CVec.New(5, 5)
local a = pos1 - vec1
Media.DisplayMessage("CPos{10,10} - CVec{5,5} >> expected {5,5}, actual {" .. a.X .. "," .. a.Y .. "}")

local pos2 = CPos.New(10, 10)
local pos3 = CPos.New(5, 5)
local b = pos2 - pos3
Media.DisplayMessage("CPos{10,10} - CPos{5,5} >> expected {5,5}, actual {" .. b.X .. "," .. b.Y .. "}")
```
