### PR TITLE
Add AreaBeam target tracking

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		public readonly Color Color = Color.Red;
 
 		[Desc("Beam follows the target.")]
-		public readonly bool TracksTarget = true;
+		public readonly bool TrackTarget = true;
 
 		[Desc("Maximum offset at the maximum range.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		public void Tick(World world)
 		{
 			// Beam tracks target
-			if (info.TracksTarget && args.GuidedTarget.IsValidFor(args.SourceActor))
+			if (info.TrackTarget && args.GuidedTarget.IsValidFor(args.SourceActor))
 				target = args.GuidedTarget.CenterPosition;
 
 			// Check for blocking actors

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -751,14 +751,14 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				}
 
 				// Rename LaserZap BeamDuration to just Duration
-				if (engineVersion < 20161009)
+				if (engineVersion < 20161020)
 				{
 					if (node.Key == "BeamDuration")
 						node.Key = "Duration";
 				}
 
 				// Rename Bullet Angle to LaunchAngle
-				if (engineVersion < 20161016)
+				if (engineVersion < 20161020)
 				{
 					if (node.Key == "Angle")
 						node.Key = "LaunchAngle";
@@ -772,6 +772,13 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						Console.WriteLine("GrantExternalCondition Condition must be manually added to all target actor's ExternalConditions list.");
 						ConvertUpgradesToCondition(parent, node, "Upgrades", "Condition");
 					}
+				}
+
+				// Rename LaserZap TracksTarget to TrackTarget
+				if (engineVersion < 20161217)
+				{
+					if (node.Key == "TracksTarget")
+						node.Key = "TrackTarget";
 				}
 
 				UpgradeWeaponRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -77,6 +77,7 @@ SonicZap:
 		ZOffset: 2047
 		BeyondTargetRange: 0c256
 		Blockable: true
+		TrackTarget: true
 		Color: 50F5FF45
 	Warhead@1Dam: SpreadDamage
 		Range: 0, 32


### PR DESCRIPTION
Adds support for target tracking to `AreaBeam` and enables it on TS Sonic tank weapon.

Closes #10181.
