### PR TITLE
Fix non-selectable support actor health bars.

### DIFF
--- a/mods/cnc/maps/cnc64gdi01/rules.yaml
+++ b/mods/cnc/maps/cnc64gdi01/rules.yaml
@@ -41,6 +41,8 @@ OLDLST:
 	Inherits: LST
 	-WithRoof:
 	-Selectable:
+	SelectionDecorations:
+		RenderSelectionBars: False
 	RejectsOrders:
 	Cargo:
 		Types: disabled

--- a/mods/cnc/maps/funpark01/rules.yaml
+++ b/mods/cnc/maps/funpark01/rules.yaml
@@ -41,6 +41,8 @@ OLDLST:
 	Inherits: LST
 	-WithRoof:
 	-Selectable:
+	SelectionDecorations:
+		RenderSelectionBars: False
 	RejectsOrders:
 	Cargo:
 		Types: disabled

--- a/mods/cnc/maps/gdi01/rules.yaml
+++ b/mods/cnc/maps/gdi01/rules.yaml
@@ -100,6 +100,8 @@ OLDLST:
 	Inherits: LST
 	-WithRoof:
 	-Selectable:
+	SelectionDecorations:
+		RenderSelectionBars: False
 	RejectsOrders:
 	Cargo:
 		Types: disabled

--- a/mods/cnc/maps/gdi02/rules.yaml
+++ b/mods/cnc/maps/gdi02/rules.yaml
@@ -109,6 +109,8 @@ OLDLST:
 	Inherits: LST
 	-WithRoof:
 	-Selectable:
+	SelectionDecorations:
+		RenderSelectionBars: False
 	RejectsOrders:
 	Cargo:
 		Types: disabled

--- a/mods/cnc/maps/gdi06/rules.yaml
+++ b/mods/cnc/maps/gdi06/rules.yaml
@@ -60,6 +60,8 @@ OLDLST:
 	Inherits: LST
 	-WithRoof:
 	-Selectable:
+	SelectionDecorations:
+		RenderSelectionBars: False
 	RejectsOrders:
 	Cargo:
 		Types: disabled

--- a/mods/cnc/maps/gdi07/rules.yaml
+++ b/mods/cnc/maps/gdi07/rules.yaml
@@ -112,6 +112,8 @@ OLDLST:
 	Inherits: LST
 	-WithRoof:
 	-Selectable:
+	SelectionDecorations:
+		RenderSelectionBars: False
 	RejectsOrders:
 	Cargo:
 		Types: disabled

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -590,6 +590,7 @@
 ^CivField:
 	Inherits: ^CivBuilding
 	-Selectable:
+	-SelectionDecorations:
 	Tooltip:
 		GenericName: Field
 	-WithBuildingExplosion:

--- a/mods/ra/maps/allies-05a/rules.yaml
+++ b/mods/ra/maps/allies-05a/rules.yaml
@@ -119,6 +119,7 @@ Colt:
 	AttackTurreted:
 	AutoTarget:
 	-Selectable:
+	-SelectionDecorations:
 	-Huntable:
 
 E1.Autotarget:

--- a/mods/ra/maps/koth-hopes-anchor/rules.yaml
+++ b/mods/ra/maps/koth-hopes-anchor/rules.yaml
@@ -12,6 +12,8 @@ MISS:
 	DamageMultiplier@INVULNERABLE:
 		Modifier: 0
 	-Selectable:
+	SelectionDecorations:
+		RenderSelectionBars: False
 	-Targetable:
 
 Player:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -15,6 +15,8 @@ BADR:
 	Cargo:
 		MaxWeight: 10
 	-Selectable:
+	SelectionDecorations:
+		RenderSelectionBars: False
 	-Voiced:
 	-GainsExperience:
 	Tooltip:
@@ -54,6 +56,8 @@ BADR.Bomber:
 	AmmoPool:
 		Ammo: 7
 	-Selectable:
+	SelectionDecorations:
+		RenderSelectionBars: False
 	-Voiced:
 	-GainsExperience:
 	Tooltip:
@@ -377,6 +381,8 @@ U2:
 		MaximumPitch: 56
 	AttackBomber:
 	-Selectable:
+	SelectionDecorations:
+		RenderSelectionBars: False
 	-Voiced:
 	-Targetable@AIRBORNE:
 	-GainsExperience:

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -240,12 +240,16 @@ V19.Husk:
 		StartSequence: fire-start
 		Sequence: fire-loop
 	-Selectable:
+	SelectionDecorations:
+		RenderSelectionBars: False
 	-Targetable:
 	-Demolishable:
 
 BARL:
 	Inherits: ^TechBuilding
 	-Selectable:
+	SelectionDecorations:
+		RenderSelectionBars: False
 	CustomSelectionSize:
 		CustomBounds: 24,24
 	Health:
@@ -267,6 +271,8 @@ BARL:
 BRL3:
 	Inherits: ^TechBuilding
 	-Selectable:
+	SelectionDecorations:
+		RenderSelectionBars: False
 	CustomSelectionSize:
 		CustomBounds: 24,24
 	Health:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -595,6 +595,8 @@
 ^AmmoBox:
 	Inherits: ^TechBuilding
 	-Selectable:
+	SelectionDecorations:
+		RenderSelectionBars: False
 	CustomSelectionSize:
 		CustomBounds: 24,24
 	Health:
@@ -619,6 +621,7 @@
 ^CivField:
 	Inherits: ^CivBuilding
 	-Selectable:
+	-SelectionDecorations:
 	Tooltip:
 		Name: Field
 	-Targetable:

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -365,4 +365,5 @@ CTFLAG:
 	DamageMultiplier@INVULNERABLE:
 		Modifier: 0
 	-Selectable:
+	-SelectionDecorations:
 	-Targetable:


### PR DESCRIPTION
#11862 had an unintended side-effect of enabling health bar rendering for actors that have the `SelectionDecorations` trait but not `Selectable` (previously it required both).

This goes through and explicitly disables the health bars for _most_ of the actors that didn't show them before, either by removing `SelectionDecorations` completely (fields, flags, and that nasty `Colt` actor) or keeping `SelectionDecorations` but disabling health bars (badgers, C&C landing craft, KOTH capture points, barrels, ammo boxes, oil derrick husks).

This keeps the accidentally enabled health bars for the support chinooks and landing craft in missions: these are normal actors that you just can't control, so I figured it made sense to keep the bars for these.

Fixes #12145.
