### PR TITLE
Fix AP/AT mines being visible under fog

### DIFF
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -815,8 +815,7 @@
 ^Mine:
 	Inherits: ^SpriteActor
 	WithSpriteBody:
-	HiddenUnderShroud:
-		Type: CenterPosition
+	HiddenUnderFog:
 	Mine:
 		CrushClasses: mine
 		DetonateClasses: mine
@@ -831,6 +830,7 @@
 		UncloakSound:
 		Palette:
 		CloakTypes: Mine
+		InitialDelay: 0
 	Tooltip:
 		Name: Mine
 	Targetable:


### PR DESCRIPTION
Fixes #7995. Mines now won't show up under fog when planted, and also removed their cloak delay so freshly planted mines under visible minelayers don't appear.
