### PR TITLE
Fix the d2k protected lobby icon being off

### DIFF
--- a/mods/d2k/chrome.yaml
+++ b/mods/d2k/chrome.yaml
@@ -153,8 +153,8 @@ lobby-bits: buttons.png
 	spawn-unclaimed: 158,5,23,22
 	spawn-claimed: 126,5,23,22
 	admin: 186,5,7,5
-	colorpicker: 127,5,23,22
-	huepicker: 194,0,7,15
+	colorpicker: 126,5,23,22
+	huepicker: 193,0,7,15
 	protected: 200,0,12,13
 	protected-disabled: 211,0,12,13
 

--- a/mods/d2k/chrome.yaml
+++ b/mods/d2k/chrome.yaml
@@ -150,8 +150,8 @@ dialog4: dialog.png
 	corner-br: 571,446,6,6
 
 lobby-bits: buttons.png
-	spawn-unclaimed: 159,5,23,22
-	spawn-claimed: 127,5,23,22
+	spawn-unclaimed: 158,5,23,22
+	spawn-claimed: 126,5,23,22
 	admin: 186,5,7,5
 	colorpicker: 127,5,23,22
 	huepicker: 194,0,7,15

--- a/mods/d2k/chrome.yaml
+++ b/mods/d2k/chrome.yaml
@@ -155,8 +155,8 @@ lobby-bits: buttons.png
 	admin: 186,5,7,5
 	colorpicker: 127,5,23,22
 	huepicker: 194,0,7,15
-	protected: 202,0,10,13
-	protected-disabled: 213,0,10,13
+	protected: 200,0,12,13
+	protected-disabled: 211,0,12,13
 
 strategic: buttons.png
 	unowned: 127,5,23,22


### PR DESCRIPTION
Before:
![d2klocka](https://cloud.githubusercontent.com/assets/7704140/19068267/36b8b080-8a22-11e6-9256-7e6daabff126.png)
After:
![d2klockb](https://cloud.githubusercontent.com/assets/7704140/19068272/3a95cb84-8a22-11e6-9116-00cfbe69fd4c.png)
