### PR TITLE
Log an error when no cells are available to spawn starting units

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
@@ -89,7 +89,10 @@ namespace OpenRA.Mods.Common.Traits
 				var mi = w.Map.Rules.Actors[s.ToLowerInvariant()].TraitInfo<MobileInfo>();
 				var validCells = supportSpawnCells.Where(c => mi.CanEnterCell(w, null, c));
 				if (!validCells.Any())
-					throw new InvalidOperationException("No cells available to spawn starting unit {0}".F(s));
+				{
+					Log.Write("debug", "No cells available to spawn starting unit {0} for player {1}".F(s, p));
+					continue;
+				}
 
 				var cell = validCells.Random(w.SharedRandom);
 				var subCell = mi.SharesCell ? w.ActorMap.FreeSubCell(cell) : 0;


### PR DESCRIPTION
Instead of crashing the game, we now just omit actors we can't spawn.

Easily testable with http://resource.openra.net/maps/16553/.
