### PR TITLE
Revert "Update Mono to version 4.6.0"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # see travis-ci.org for details
 
 language: csharp
-mono: 4.6.0
+mono: 4.4.2
 
 # http://docs.travis-ci.com/user/migrating-from-legacy
 sudo: false


### PR DESCRIPTION
The mono 4.6 compiler breaks compatibility with mono < 4.4 runtimes, and the upstream [bug report](https://bugzilla.xamarin.com/show_bug.cgi?id=36942) has been closed as "RESOLVED ANSWERED" so this appears to be a WONTFIX.

Reverting back to mono 4.4 restores compatibility with older runtimes until we decide to increase our minimum requirements to mono 4.4 / .NET 4.6.

Fixes #12166.  
