### PR TITLE
Overhaul the HackyAI logic

### DIFF
--- a/OpenRA.Mods.Common/AI/BaseBuilder.cs
+++ b/OpenRA.Mods.Common/AI/BaseBuilder.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.AI
 
 			if (waterState == Water.NotChecked)
 			{
-				if (ai.EnoughWaterToBuildNaval())
+				if (ai.ProviderHasEnoughCells<BaseProvider>(ai.Info.MaxBaseRadius, ai.Info.WaterTerrainTypes))
 					waterState = Water.EnoughWater;
 				else
 				{
@@ -252,7 +252,7 @@ namespace OpenRA.Mods.Common.AI
 			// Only consider building this if there is enough water inside the base perimeter and there are close enough adjacent buildings
 			if (waterState == Water.EnoughWater && ai.Info.NewProductionCashThreshold > 0
 				&& playerResources.Resources > ai.Info.NewProductionCashThreshold
-				&& ai.CloseEnoughToWater())
+				&& ai.ProviderHasEnoughCells<GivesBuildableArea>(ai.Info.CheckForWaterRadius, ai.Info.WaterTerrainTypes))
 			{
 				var navalproduction = GetProducibleBuilding(ai.Info.BuildingCommonNames.NavalProduction, buildableThings);
 				if (navalproduction != null && HasSufficientPowerForActor(navalproduction))
@@ -306,7 +306,7 @@ namespace OpenRA.Mods.Common.AI
 				// and any structure providing buildable area close enough to that water.
 				// TODO: Extend this check to cover any naval structure, not just production.
 				if (ai.Info.BuildingCommonNames.NavalProduction.Contains(name)
-					&& (waterState == Water.NotEnoughWater || !ai.CloseEnoughToWater()))
+					&& (waterState == Water.NotEnoughWater || !ai.ProviderHasEnoughCells<GivesBuildableArea>(ai.Info.MaxBaseRadius, ai.Info.WaterTerrainTypes)))
 					continue;
 
 				// Will this put us into low power?


### PR DESCRIPTION
This PR overhauls the HackyAI logic in some Cases:
-  Replace `EnoughWaterToBuildNaval()` and `CloseEnoughToWater()` with `ProviderHasEnoughCells<T>()`
- Add `Radar` and `TechCenter` to `BuildingCommonNames`
- Replace `FindEnemyConstructionYards()` with `FindEnemyBuildings()`
- Replace `FindAndDeployBackupMcv()` with `FindAndDeployMcv()` and allow random locations on the map for the deployment when the AI has already a Construction Yard.

![deploymcv](https://cloud.githubusercontent.com/assets/2057932/19203796/9b7303ae-8cd9-11e6-825c-8d1d13ef4fd5.png)

![ai_search_a_location](https://cloud.githubusercontent.com/assets/2057932/19203842/d0a8507e-8cd9-11e6-8a4c-6d76759c11dd.png)

![test_normal_mcv](https://cloud.githubusercontent.com/assets/2057932/19222806/f3c7f496-8e60-11e6-80c8-58881146acc2.png)
