### PR TITLE
Tweak SubMissileAA towards more traditional AA.

### DIFF
--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -65,13 +65,13 @@ MSUB:
 		Cost: 2000
 	Tooltip:
 		Name: Missile Submarine
-		Description: Submerged anti-ground siege unit\nwith basic anti-air capabilities.\nCan detect other submarines.\n  Strong vs Buildings, Ground units, Aircraft\n  Weak vs Naval units\n  Special Ability: Submerge
+		Description: Submerged anti-ground siege unit\nwith anti-air capabilities.\nCan detect other submarines.\n  Strong vs Buildings, Ground units, Aircraft\n  Weak vs Naval units\n  Special Ability: Submerge
 	Health:
 		HP: 400
 	Armor:
 		Type: Light
 	Mobile:
-		TurnSpeed: 2
+		TurnSpeed: 3
 		Speed: 42
 	RevealsShroud:
 		Range: 6c0

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -251,7 +251,7 @@ SubMissile:
 	Projectile: Bullet
 		Speed: 162
 		Blockable: false
-		Angle: 105
+		Angle: 120
 		Inaccuracy: 2c938
 		Image: MISSILE
 		TrailImage: smokey
@@ -279,16 +279,16 @@ SubMissile:
 
 SubMissileAA:
 	Inherits: SubMissile
-	Range: 6c0
+	Range: 8c0
 	ValidTargets: Air
 	Projectile: Missile
-		Speed: 162
-		Inaccuracy: 0c938
-		HorizontalRateOfTurn: 1
-		RangeLimit: 7c0
+		Speed: 234
+		Inaccuracy: 0c614
+		HorizontalRateOfTurn: 15
+		RangeLimit: 9c0
 	Warhead@1Dam: SpreadDamage
-		Damage: 20
-		ValidTargets: Air
+		Damage: 15
+		ValidTargets: Air, Ground, Water
 
 Stinger:
 	ReloadDelay: 60


### PR DESCRIPTION
The AA that came with #12106 intended for it to perform as, and recreate, the AA Projectile:Bullet behaviour as proposed originally. I believe now this was a mistake. Regardless of intent, players will likely look upon its vs moving targets to be faulty rather than a feature. Community feedback:
https://www.reddit.com/r/openra/comments/55gx81/ballistic_submarines_aa_useless/
http://www.sleipnirstuff.com/forum/viewtopic.php?f=82&p=298167#298167
Range was lowered to simulate the Projectile:Bullet's effective hits vs close targets and Turn Rate was lowered to deal with visual targeting issues vs moving targets. All in all these compromises should probably be scrapped for the AA MissileSub's first release cycle.

The PR's changes are for the most part modelled after Frame Limiter's SubMissileAA which features a more familiar approach. http://resource.openra.net/maps/16243/ This will make the AA perform better vs YAKs/MiGs and overall more efficient with increased range + speed with a slightly lowered damage output. 

Also, I raised the SubMissile (vs ground) angle just a tiny bit (120, up from 105) for visual sake (originally 165).

Another issue not brought up previously is wether the MissileSub should be able to use its AA and AG at the same time. Currently there's a  seperate reload time for both weapons. **Edit**: Apparently this is the case for all units in ORA. I hadn't noticed.
