### PR TITLE
Uncloak on damage by default

### DIFF
--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Events leading to the actor getting uncloaked. Possible values are: Attack, Move, Unload, Infiltrate, Demolish, Dock and Damage")]
 		public readonly UncloakType UncloakOn = UncloakType.Attack
-			| UncloakType.Unload | UncloakType.Infiltrate | UncloakType.Demolish | UncloakType.Dock;
+			| UncloakType.Unload | UncloakType.Infiltrate | UncloakType.Demolish | UncloakType.Dock | UncloakType.Damage;
 
 		public readonly string CloakSound = null;
 		public readonly string UncloakSound = null;


### PR DESCRIPTION
Not doing so is a regression compared to pre-20160508 releases and probably unexpected behaviour for the majority of modders.

All actors in the shipping mods which are _not_ supposed to uncloak on damage are already overriding the default at yaml level, so there aren't any regressions to expect on that end.

Fixes #12192.
