### PR TITLE
Fix soviet units not stopping to hunt after being captured in Exodus

### DIFF
--- a/mods/ra/maps/evacuation/rules.yaml
+++ b/mods/ra/maps/evacuation/rules.yaml
@@ -72,6 +72,10 @@ MECH:
 	Buildable:
 		Prerequisites: ~disabled
 
+HIJACKER:
+	Buildable:
+		Prerequisites: ~disabled
+
 SPEN:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/exodus/exodus.lua
+++ b/mods/ra/maps/exodus/exodus.lua
@@ -139,17 +139,18 @@ end
 
 SovietGroupSize = 5
 SpawnSovietUnits = function()
-	local spawnPoint = Utils.Random(SovietEntryPoints)
-	local rallyPoint = Utils.Random(SovietRallyPoints)
-	local route = { spawnPoint.Location, rallyPoint.Location }
 
 	local units = SovietUnits1
 	if DateTime.GameTime >= SovietUnits2Ticks[Difficulty] then
 		units = SovietUnits2
 	end
 
-	local unit = { Utils.Random(units) }
-	Reinforcements.Reinforce(soviets, unit, route)
+	local unitType = Utils.Random(units)
+	local spawnPoint = Utils.Random(SovietEntryPoints)
+	local rallyPoint = Utils.Random(SovietRallyPoints)
+	local actor = Actor.Create(unitType, true, { Owner = soviets, Location = spawnPoint.Location })
+	actor.AttackMove(rallyPoint.Location)
+	IdleHunt(actor)
 
 	local delay = math.max(attackAtFrame - 5, minAttackAtFrame)
 	Trigger.AfterDelay(delay, SpawnSovietUnits)
@@ -187,24 +188,6 @@ IdleHunt = function(unit)
 	Trigger.OnCapture(unit, function()
 		Trigger.ClearAll(unit)
 	end)
-end
-
-ManageSovietUnits = function()
-	Utils.Do(SovietRallyPoints, function(rallyPoint)
-		local radius = WDist.FromCells(8)
-		local units = Map.ActorsInCircle(rallyPoint.CenterPosition, radius, function(actor)
-			return actor.Owner == soviets and actor.HasProperty("Hunt")
-		end)
-
-		if #units > SovietGroupSize then
-			Utils.Do(units, IdleHunt)
-		end
-	end)
-
-	local scatteredUnits = Utils.Where(soviets.GetGroundAttackers(), function(unit)
-		return not Map.IsNamedActor(unit) and unit.IsIdle and unit.HasProperty("Hunt")
-	end)
-	Utils.Do(scatteredUnits, IdleHunt)
 end
 
 AircraftTargets = function()
@@ -297,7 +280,6 @@ end
 
 Tick = function()
 	if DateTime.GameTime % 100 == 0 then
-		ManageSovietUnits()
 		ManageSovietAircraft()
 
 		Utils.Do(humans, function(player)

--- a/mods/ra/maps/exodus/exodus.lua
+++ b/mods/ra/maps/exodus/exodus.lua
@@ -184,6 +184,9 @@ end
 
 IdleHunt = function(unit)
 	Trigger.OnIdle(unit, unit.Hunt)
+	Trigger.OnCapture(unit, function()
+		Trigger.ClearAll(unit)
+	end)
 end
 
 ManageSovietUnits = function()


### PR DESCRIPTION
and makes hijackers unbuildable in Evacuation. I made them unbuildable there because we don't allow building mechanics (which are somewhat the counter parts to hijackers) in this mission as well.
Fixes #12183.

This PR also fixes soviet units not attack moving to their rally point in Exodus, and also removes some code duplication (we don't need to check for idling units inside the Tick function if we can just assign them a hunt trigger directly after they're created).
