### PR TITLE
FixHeader.exe: Add Platform detection support

### DIFF
--- a/packaging/fixheader.cs
+++ b/packaging/fixheader.cs
@@ -21,16 +21,30 @@ namespace fixheader
 
 		static void Main(string[] args)
 		{
+			if (args.Length == 0)
+			{
+				Console.WriteLine("Syntax: fixheader <FILE>");
+				return;
+			}
+
+			var osPlatform = Environment.OSVersion.Platform;
+
 			Console.WriteLine("fixheader {0}", args[0]);
 			data = File.ReadAllBytes(args[0]);
 			peOffset = BitConverter.ToInt32(data, 0x3c);
-			var corHeaderRva = BitConverter.ToInt32(data, peOffset + 20 + 100 + 14 * 8);
-			var corHeaderOffset = RvaToOffset(corHeaderRva);
 
-			data[corHeaderOffset + 16] |= 2;
+			if (osPlatform == PlatformID.MacOSX || osPlatform == PlatformID.Unix)
+			{
+				var corHeaderRva = BitConverter.ToInt32(data, peOffset + 20 + 100 + 14 * 8);
+				var corHeaderOffset = RvaToOffset(corHeaderRva);
+				data[corHeaderOffset + 16] |= 2;
+			}
 
-			// Set Flag "Application can handle large (>2GB) addresses (/LARGEADDRESSAWARE)"
-			data[peOffset + 4 + 18] |= 0x20;
+			if (osPlatform != PlatformID.MacOSX && osPlatform != PlatformID.Unix)
+			{
+				// Set Flag "Application can handle large (>2GB) addresses (/LARGEADDRESSAWARE)"
+				data[peOffset + 4 + 18] |= 0x20;
+			}
 
 			File.WriteAllBytes(args[0], data);
 		}


### PR DESCRIPTION
This allows Fixheader.exe to do thing on the specified platform:
- CorHeader on Mono (Unix & OSX)
- LargeAddressAware flag (Windows)
- prevent crash when on missing arguments
  closes #12207
  closes #12125
- But Keep in Mind you have to run it against all DLLs and Exe files
