### PR TITLE
MsBuild: Post: Fix binaries (LargeAddressAware)

### DIFF
--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -340,21 +340,13 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
-    <Copy
-      SourceFiles="$(TargetPath)"
-      DestinationFolder="$(SolutionDir)"/>
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(SolutionDir)" />
     <!--
         We need to copy OpenRA.Game.pdb (not `.dll.pdb`). This is only necessary on Windows.
         Mono outputs a `.dll.mdb` so we can just append `.mdb` directly.
     -->
-    <Copy
-      SourceFiles="$(TargetDir)$(TargetName).pdb"
-      DestinationFolder="$(SolutionDir)"
-      Condition="'$(OS)' == 'Windows_NT'"/>
-    <Copy
-      SourceFiles="$(TargetPath).mdb"
-      DestinationFolder="$(SolutionDir)"
-      Condition="'$(OS)' == 'Unix'"/>
+    <Copy SourceFiles="$(TargetDir)$(TargetName).pdb" DestinationFolder="$(SolutionDir)" Condition="'$(OS)' == 'Windows_NT'" />
+    <Copy SourceFiles="$(TargetPath).mdb" DestinationFolder="$(SolutionDir)" Condition="'$(OS)' == 'Unix'" />
     <!-- Uncomment these lines when debugging or adding to this target
     <Message Text="DEBUG OS:                     $(OS)"/>
     <Message Text="DEBUG SolutionDir:            $(SolutionDir)"/>
@@ -363,4 +355,11 @@
     <Message Text="DEBUG TargetName:             $(TargetName)"/>
     -->
   </Target>
+  <PropertyGroup>
+    <PostBuildEvent>IF  EXIST  "%25VS140COMNTOOLS%25"  CALL  "%25VS140COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS120COMNTOOLS%25"  CALL  "%25VS120COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS110COMNTOOLS%25"  CALL  "%25VS110COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS100COMNTOOLS%25"  CALL  "%25VS100COMNTOOLS%25vsvars32.bat"
+editbin.exe /LARGEADDRESSAWARE "$(TargetPath)"</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/OpenRA.GameMonitor/OpenRA.GameMonitor.csproj
+++ b/OpenRA.GameMonitor/OpenRA.GameMonitor.csproj
@@ -51,4 +51,11 @@
     <Compile Include="GameMonitor.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>IF  EXIST  "%25VS140COMNTOOLS%25"  CALL  "%25VS140COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS120COMNTOOLS%25"  CALL  "%25VS120COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS110COMNTOOLS%25"  CALL  "%25VS110COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS100COMNTOOLS%25"  CALL  "%25VS100COMNTOOLS%25vsvars32.bat"
+editbin.exe /LARGEADDRESSAWARE "$(TargetPath)"</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -108,22 +108,14 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
-    <MakeDir Directories="$(SolutionDir)mods/cnc/"/>
-    <Copy
-      SourceFiles="$(TargetPath)"
-      DestinationFolder="$(SolutionDir)mods/cnc/"/>
+    <MakeDir Directories="$(SolutionDir)mods/cnc/" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(SolutionDir)mods/cnc/" />
     <!--
         We need to copy OpenRA.Mods.Cnc.pdb (not `.dll.pdb`). This is only necessary on Windows.
         Mono outputs a `.dll.mdb` so we can just append `.mdb` directly.
     -->
-    <Copy
-      SourceFiles="$(TargetDir)$(TargetName).pdb"
-      DestinationFolder="$(SolutionDir)mods/cnc/"
-      Condition="'$(OS)' == 'Windows_NT'"/>
-    <Copy
-      SourceFiles="$(TargetPath).mdb"
-      DestinationFolder="$(SolutionDir)mods/cnc/"
-      Condition="'$(OS)' == 'Unix'"/>
+    <Copy SourceFiles="$(TargetDir)$(TargetName).pdb" DestinationFolder="$(SolutionDir)mods/cnc/" Condition="'$(OS)' == 'Windows_NT'" />
+    <Copy SourceFiles="$(TargetPath).mdb" DestinationFolder="$(SolutionDir)mods/cnc/" Condition="'$(OS)' == 'Unix'" />
     <!-- Uncomment these lines when debugging or adding to this target
     <Message Text="DEBUG OS:                     $(OS)"/>
     <Message Text="DEBUG SolutionDir:            $(SolutionDir)"/>
@@ -132,4 +124,11 @@
     <Message Text="DEBUG TargetName:             $(TargetName)"/>
     -->
   </Target>
+  <PropertyGroup>
+    <PostBuildEvent>IF  EXIST  "%25VS140COMNTOOLS%25"  CALL  "%25VS140COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS120COMNTOOLS%25"  CALL  "%25VS120COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS110COMNTOOLS%25"  CALL  "%25VS110COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS100COMNTOOLS%25"  CALL  "%25VS100COMNTOOLS%25vsvars32.bat"
+editbin.exe /LARGEADDRESSAWARE "$(TargetPath)"</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -776,22 +776,14 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
-    <MakeDir Directories="$(SolutionDir)mods/common/"/>
-    <Copy
-      SourceFiles="$(TargetPath)"
-      DestinationFolder="$(SolutionDir)mods/common/"/>
+    <MakeDir Directories="$(SolutionDir)mods/common/" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(SolutionDir)mods/common/" />
     <!--
         We need to copy OpenRA.Mods.Common.pdb (not `.dll.pdb`). This is only necessary on Windows.
         Mono outputs a `.dll.mdb` so we can just append `.mdb` directly.
     -->
-    <Copy
-      SourceFiles="$(TargetDir)$(TargetName).pdb"
-      DestinationFolder="$(SolutionDir)mods/common/"
-      Condition="'$(OS)' == 'Windows_NT'"/>
-    <Copy
-      SourceFiles="$(TargetPath).mdb"
-      DestinationFolder="$(SolutionDir)mods/common/"
-      Condition="'$(OS)' == 'Unix'"/>
+    <Copy SourceFiles="$(TargetDir)$(TargetName).pdb" DestinationFolder="$(SolutionDir)mods/common/" Condition="'$(OS)' == 'Windows_NT'" />
+    <Copy SourceFiles="$(TargetPath).mdb" DestinationFolder="$(SolutionDir)mods/common/" Condition="'$(OS)' == 'Unix'" />
     <!-- Uncomment these lines when debugging or adding to this target
     <Message Text="DEBUG OS:                     $(OS)"/>
     <Message Text="DEBUG SolutionDir:            $(SolutionDir)"/>
@@ -800,4 +792,11 @@
     <Message Text="DEBUG TargetName:             $(TargetName)"/>
     -->
   </Target>
+  <PropertyGroup>
+    <PostBuildEvent>IF  EXIST  "%25VS140COMNTOOLS%25"  CALL  "%25VS140COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS120COMNTOOLS%25"  CALL  "%25VS120COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS110COMNTOOLS%25"  CALL  "%25VS110COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS100COMNTOOLS%25"  CALL  "%25VS100COMNTOOLS%25vsvars32.bat"
+editbin.exe /LARGEADDRESSAWARE "$(TargetPath)"</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj
+++ b/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj
@@ -125,22 +125,14 @@ cd "$(SolutionDir)"</PostBuildEvent>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
-    <MakeDir Directories="$(SolutionDir)mods/d2k/"/>
-    <Copy
-      SourceFiles="$(TargetPath)"
-      DestinationFolder="$(SolutionDir)mods/d2k/"/>
+    <MakeDir Directories="$(SolutionDir)mods/d2k/" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(SolutionDir)mods/d2k/" />
     <!--
         We need to copy OpenRA.Mods.D2k.pdb (not `.dll.pdb`). This is only necessary on Windows.
         Mono outputs a `.dll.mdb` so we can just append `.mdb` directly.
     -->
-    <Copy
-      SourceFiles="$(TargetDir)$(TargetName).pdb"
-      DestinationFolder="$(SolutionDir)mods/d2k/"
-      Condition="'$(OS)' == 'Windows_NT'"/>
-    <Copy
-      SourceFiles="$(TargetPath).mdb"
-      DestinationFolder="$(SolutionDir)mods/d2k/"
-      Condition="'$(OS)' == 'Unix'"/>
+    <Copy SourceFiles="$(TargetDir)$(TargetName).pdb" DestinationFolder="$(SolutionDir)mods/d2k/" Condition="'$(OS)' == 'Windows_NT'" />
+    <Copy SourceFiles="$(TargetPath).mdb" DestinationFolder="$(SolutionDir)mods/d2k/" Condition="'$(OS)' == 'Unix'" />
     <!-- Uncomment these lines when debugging or adding to this target
     <Message Text="DEBUG OS:                     $(OS)"/>
     <Message Text="DEBUG SolutionDir:            $(SolutionDir)"/>

--- a/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
+++ b/OpenRA.Mods.RA/OpenRA.Mods.RA.csproj
@@ -137,22 +137,14 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
-    <MakeDir Directories="$(SolutionDir)mods/ra/"/>
-    <Copy
-      SourceFiles="$(TargetPath)"
-      DestinationFolder="$(SolutionDir)mods/ra/"/>
+    <MakeDir Directories="$(SolutionDir)mods/ra/" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(SolutionDir)mods/ra/" />
     <!--
         We need to copy OpenRA.Mods.RA.pdb (not `.dll.pdb`). This is only necessary on Windows.
         Mono outputs a `.dll.mdb` so we can just append `.mdb` directly.
     -->
-    <Copy
-      SourceFiles="$(TargetDir)$(TargetName).pdb"
-      DestinationFolder="$(SolutionDir)mods/ra/"
-      Condition="'$(OS)' == 'Windows_NT'"/>
-    <Copy
-      SourceFiles="$(TargetPath).mdb"
-      DestinationFolder="$(SolutionDir)mods/ra/"
-      Condition="'$(OS)' == 'Unix'"/>
+    <Copy SourceFiles="$(TargetDir)$(TargetName).pdb" DestinationFolder="$(SolutionDir)mods/ra/" Condition="'$(OS)' == 'Windows_NT'" />
+    <Copy SourceFiles="$(TargetPath).mdb" DestinationFolder="$(SolutionDir)mods/ra/" Condition="'$(OS)' == 'Unix'" />
     <!-- Uncomment these lines when debugging or adding to this target
     <Message Text="DEBUG OS:                     $(OS)"/>
     <Message Text="DEBUG SolutionDir:            $(SolutionDir)"/>
@@ -161,4 +153,11 @@
     <Message Text="DEBUG TargetName:             $(TargetName)"/>
     -->
   </Target>
+  <PropertyGroup>
+    <PostBuildEvent>IF  EXIST  "%25VS140COMNTOOLS%25"  CALL  "%25VS140COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS120COMNTOOLS%25"  CALL  "%25VS120COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS110COMNTOOLS%25"  CALL  "%25VS110COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS100COMNTOOLS%25"  CALL  "%25VS100COMNTOOLS%25vsvars32.bat"
+editbin.exe /LARGEADDRESSAWARE "$(TargetPath)"</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/OpenRA.Mods.TS/OpenRA.Mods.TS.csproj
+++ b/OpenRA.Mods.TS/OpenRA.Mods.TS.csproj
@@ -73,22 +73,14 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
-    <MakeDir Directories="$(SolutionDir)mods/ts/"/>
-    <Copy
-      SourceFiles="$(TargetPath)"
-      DestinationFolder="$(SolutionDir)mods/ts/"/>
+    <MakeDir Directories="$(SolutionDir)mods/ts/" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(SolutionDir)mods/ts/" />
     <!--
         We need to copy OpenRA.Mods.TS.pdb (not `.dll.pdb`). This is only necessary on Windows.
         Mono outputs a `.dll.mdb` so we can just append `.mdb` directly.
     -->
-    <Copy
-      SourceFiles="$(TargetDir)$(TargetName).pdb"
-      DestinationFolder="$(SolutionDir)mods/ts/"
-      Condition="'$(OS)' == 'Windows_NT'"/>
-    <Copy
-      SourceFiles="$(TargetPath).mdb"
-      DestinationFolder="$(SolutionDir)mods/ts/"
-      Condition="'$(OS)' == 'Unix'"/>
+    <Copy SourceFiles="$(TargetDir)$(TargetName).pdb" DestinationFolder="$(SolutionDir)mods/ts/" Condition="'$(OS)' == 'Windows_NT'" />
+    <Copy SourceFiles="$(TargetPath).mdb" DestinationFolder="$(SolutionDir)mods/ts/" Condition="'$(OS)' == 'Unix'" />
     <!-- Uncomment these lines when debugging or adding to this target
     <Message Text="DEBUG OS:                     $(OS)"/>
     <Message Text="DEBUG SolutionDir:            $(SolutionDir)"/>
@@ -97,4 +89,11 @@
     <Message Text="DEBUG TargetName:             $(TargetName)"/>
     -->
   </Target>
+  <PropertyGroup>
+    <PostBuildEvent>IF  EXIST  "%25VS140COMNTOOLS%25"  CALL  "%25VS140COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS120COMNTOOLS%25"  CALL  "%25VS120COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS110COMNTOOLS%25"  CALL  "%25VS110COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS100COMNTOOLS%25"  CALL  "%25VS100COMNTOOLS%25vsvars32.bat"
+editbin.exe /LARGEADDRESSAWARE "$(TargetPath)"</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/OpenRA.Platforms.Default/OpenRA.Platforms.Default.csproj
+++ b/OpenRA.Platforms.Default/OpenRA.Platforms.Default.csproj
@@ -66,4 +66,11 @@
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
+  <PropertyGroup>
+    <PostBuildEvent>IF  EXIST  "%25VS140COMNTOOLS%25"  CALL  "%25VS140COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS120COMNTOOLS%25"  CALL  "%25VS120COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS110COMNTOOLS%25"  CALL  "%25VS110COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS100COMNTOOLS%25"  CALL  "%25VS100COMNTOOLS%25vsvars32.bat"
+editbin.exe /LARGEADDRESSAWARE "$(TargetPath)"</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/OpenRA.Server/OpenRA.Server.csproj
+++ b/OpenRA.Server/OpenRA.Server.csproj
@@ -88,6 +88,13 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>IF  EXIST  "%25VS140COMNTOOLS%25"  CALL  "%25VS140COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS120COMNTOOLS%25"  CALL  "%25VS120COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS110COMNTOOLS%25"  CALL  "%25VS110COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS100COMNTOOLS%25"  CALL  "%25VS100COMNTOOLS%25vsvars32.bat"
+editbin.exe /LARGEADDRESSAWARE "$(TargetPath)"</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/OpenRA.Test/OpenRA.Test.csproj
+++ b/OpenRA.Test/OpenRA.Test.csproj
@@ -75,6 +75,13 @@
     <None Include="App.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>IF  EXIST  "%25VS140COMNTOOLS%25"  CALL  "%25VS140COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS120COMNTOOLS%25"  CALL  "%25VS120COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS110COMNTOOLS%25"  CALL  "%25VS110COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS100COMNTOOLS%25"  CALL  "%25VS100COMNTOOLS%25vsvars32.bat"
+editbin.exe /LARGEADDRESSAWARE "$(TargetPath)"</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/OpenRA.Utility/OpenRA.Utility.csproj
+++ b/OpenRA.Utility/OpenRA.Utility.csproj
@@ -88,6 +88,13 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>IF  EXIST  "%25VS140COMNTOOLS%25"  CALL  "%25VS140COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS120COMNTOOLS%25"  CALL  "%25VS120COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS110COMNTOOLS%25"  CALL  "%25VS110COMNTOOLS%25vsvars32.bat"
+IF  EXIST  "%25VS100COMNTOOLS%25"  CALL  "%25VS100COMNTOOLS%25vsvars32.bat"
+editbin.exe /LARGEADDRESSAWARE "$(TargetPath)"</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Add editbin.exe as Postbuild event to make binaries able to use more than 2GB on Windows

```
....
_CopyAppConfigFile:
  Die Datei wird von "App.config" in "..\OpenRA.Test.dll.config" kopiert.
CopyFilesToOutputDirectory:
  Die Datei wird von "obj\x86\Debug\OpenRA.Test.dll" in "..\OpenRA.Test.dll" kopiert.
  OpenRA.Test -> D:\Projekte\OpenRA\OpenRA.Test.dll
  Die Datei wird von "obj\x86\Debug\OpenRA.Test.pdb" in "..\OpenRA.Test.pdb" kopiert.
PostBuildEvent:
  IF  EXIST  "%VS140COMNTOOLS%"  CALL  "%VS140COMNTOOLS%vsvars32.bat"
  IF  EXIST  "%VS120COMNTOOLS%"  CALL  "%VS120COMNTOOLS%vsvars32.bat"
  IF  EXIST  "%VS110COMNTOOLS%"  CALL  "%VS110COMNTOOLS%vsvars32.bat"
  IF  EXIST  "%VS100COMNTOOLS%"  CALL  "%VS100COMNTOOLS%vsvars32.bat"
  editbin.exe /LARGEADDRESSAWARE "D:\Projekte\OpenRA\OpenRA.Test.dll"
  Microsoft (R) COFF/PE Editor Version 14.00.24213.1
  Copyright (C) Microsoft Corporation.  All rights reserved.

Die Erstellung des Projekts "D:\Projekte\OpenRA\OpenRA.Test\OpenRA.Test.csproj" ist abgeschlossen, Rebuild Ziel(e).

Die Erstellung des Projekts "D:\Projekte\OpenRA\OpenRA.sln" ist abgeschlossen, Rebuild Ziel(e).


Der Buildvorgang wurde erfolgreich ausgeführt.
    0 Warnung(en)
    0 Fehler

Verstrichene Zeit 00:00:22.25
Build succeeded.
D:\Projekte\OpenRA [msbuild-postbuild-laa ≡]>
```
