### PR TITLE
Make sure AI can deploy an MCV when it lacks a base.

### DIFF
--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -964,8 +964,12 @@ namespace OpenRA.Mods.Common.AI
 				if (!mcv.IsIdle)
 					continue;
 
+				// If we lack a base, we need to make sure we don't restrict deployment of the MCV to the base!
+				var restrictToBase =
+					Info.RestrictMCVDeploymentFallbackToBase &&
+					CountBuildingByCommonName(Info.BuildingCommonNames.ConstructionYard, Player) > 0;
 				var factType = mcv.Info.TraitInfo<TransformsInfo>().IntoActor;
-				var desiredLocation = ChooseBuildLocation(factType, Info.RestrictMCVDeploymentFallbackToBase, BuildingType.Building);
+				var desiredLocation = ChooseBuildLocation(factType, restrictToBase, BuildingType.Building);
 				if (desiredLocation == null)
 					continue;
 


### PR DESCRIPTION
Fixes #12159.

The `RestrictMCVDeploymentFallbackToBase` flag restricts AI to deploying new MCVs near to the existing conyard (and is true by default). However, if there is no conyard then it obviously cannot find any suitable locations!

The fix is to allow the MCV to deploy anywhere if there is no conyard it can be built near to.
