### PR TITLE
Add support for an older/alternative d2k release.

### DIFF
--- a/mods/d2k/installer/d2ka.yaml
+++ b/mods/d2k/installer/d2ka.yaml
@@ -1,4 +1,4 @@
-d2k: Dune 2000 (English)
+d2k-a: Dune 2000 (English)
 	IDFiles:
 		MUSIC/AMBUSH.AUD: bd5926a56a83bc0e49f96037e1f909014ac0772a
 		SETUP/SETUP.Z: 937f5ceb1236bf3f3d4e43929305ffe5004078e7
@@ -854,7 +854,7 @@ d2k: Dune 2000 (English)
 			^Content/d2k/v2/SOUND.RS:
 				Offset: 20559431
 				Length: 1929247
-d2k-linux: Dune 2000 (English)
+d2k-a-linux: Dune 2000 (English)
 	IDFiles:
 		music/ambush.aud: bd5926a56a83bc0e49f96037e1f909014ac0772a
 		setup/setup.z: 937f5ceb1236bf3f3d4e43929305ffe5004078e7

--- a/mods/d2k/installer/d2kb.yaml
+++ b/mods/d2k/installer/d2kb.yaml
@@ -1,0 +1,1712 @@
+d2k-b: Dune 2000 (English)
+	IDFiles:
+		MUSIC/AMBUSH.AUD: bd5926a56a83bc0e49f96037e1f909014ac0772a
+		SETUP/SETUP.Z: 029722e70fb7636f8120028f5c9b6ce81627ff90
+	Install:
+		copy: MOVIES
+			^Content/d2k/v2/Movies/A_BR01_E.VQA: A_BR01_E.VQA
+			^Content/d2k/v2/Movies/A_BR02_E.VQA: A_BR02_E.VQA
+			^Content/d2k/v2/Movies/A_BR03_E.VQA: A_BR03_E.VQA
+			^Content/d2k/v2/Movies/A_BR04_E.VQA: A_BR04_E.VQA
+			^Content/d2k/v2/Movies/A_BR05_E.VQA: A_BR05_E.VQA
+			^Content/d2k/v2/Movies/A_BR06_E.VQA: A_BR06_E.VQA
+			^Content/d2k/v2/Movies/A_BR07_E.VQA: A_BR07_E.VQA
+			^Content/d2k/v2/Movies/A_BR08_E.VQA: A_BR08_E.VQA
+			^Content/d2k/v2/Movies/A_BR09_E.VQA: A_BR09_E.VQA
+			^Content/d2k/v2/Movies/A_FINL_E.VQA: A_FINL_E.VQA
+			^Content/d2k/v2/Movies/A_LOSE_E.VQA: A_LOSE_E.VQA
+			^Content/d2k/v2/Movies/A_MNTG_E.VQA: A_MNTG_E.VQA
+			^Content/d2k/v2/Movies/H_BR01_E.VQA: H_BR01_E.VQA
+			^Content/d2k/v2/Movies/H_BR02_E.VQA: H_BR02_E.VQA
+			^Content/d2k/v2/Movies/H_BR03_E.VQA: H_BR03_E.VQA
+			^Content/d2k/v2/Movies/H_BR04_E.VQA: H_BR04_E.VQA
+			^Content/d2k/v2/Movies/H_BR05_E.VQA: H_BR05_E.VQA
+			^Content/d2k/v2/Movies/H_BR06_E.VQA: H_BR06_E.VQA
+			^Content/d2k/v2/Movies/H_BR07_E.VQA: H_BR07_E.VQA
+			^Content/d2k/v2/Movies/H_BR08_E.VQA: H_BR08_E.VQA
+			^Content/d2k/v2/Movies/H_BR09_E.VQA: H_BR09_E.VQA
+			^Content/d2k/v2/Movies/H_FINL_E.VQA: H_FINL_E.VQA
+			^Content/d2k/v2/Movies/H_LOSE_E.VQA: H_LOSE_E.VQA
+			^Content/d2k/v2/Movies/H_MNTG_E.VQA: H_MNTG_E.VQA
+			^Content/d2k/v2/Movies/O_BR01_E.VQA: O_BR01_E.VQA
+			^Content/d2k/v2/Movies/O_BR02_E.VQA: O_BR02_E.VQA
+			^Content/d2k/v2/Movies/O_BR03_E.VQA: O_BR03_E.VQA
+			^Content/d2k/v2/Movies/O_BR04_E.VQA: O_BR04_E.VQA
+			^Content/d2k/v2/Movies/O_BR05_E.VQA: O_BR05_E.VQA
+			^Content/d2k/v2/Movies/O_BR06_E.VQA: O_BR06_E.VQA
+			^Content/d2k/v2/Movies/O_BR07_E.VQA: O_BR07_E.VQA
+			^Content/d2k/v2/Movies/O_BR08_E.VQA: O_BR08_E.VQA
+			^Content/d2k/v2/Movies/O_BR09_E.VQA: O_BR09_E.VQA
+			^Content/d2k/v2/Movies/O_FINL_E.VQA: O_FINL_E.VQA
+			^Content/d2k/v2/Movies/O_LOSE_E.VQA: O_LOSE_E.VQA
+			^Content/d2k/v2/Movies/O_MNTG_E.VQA: O_MNTG_E.VQA
+			^Content/d2k/v2/Movies/G_INT1_E.VQA: G_INT1_E.VQA
+			^Content/d2k/v2/Movies/G_INT2_E.VQA: G_INT2_E.VQA
+			^Content/d2k/v2/Movies/G_MAPS_E.VQA: G_MAPS_E.VQA
+			^Content/d2k/v2/Movies/G_PLN2_E.VQA: G_PLN2_E.VQA
+			^Content/d2k/v2/Movies/G_PLNT_E.VQA: G_PLNT_E.VQA
+			^Content/d2k/v2/Movies/T_TITL_E.VQA: T_TITL_E.VQA
+		copy: MUSIC
+			^Content/d2k/v2/Music/AMBUSH.AUD: AMBUSH.AUD
+			^Content/d2k/v2/Music/ARAKATAK.AUD: ARAKATAK.AUD
+			^Content/d2k/v2/Music/ATREGAIN.AUD: ATREGAIN.AUD
+			^Content/d2k/v2/Music/ENTORDOS.AUD: ENTORDOS.AUD
+			^Content/d2k/v2/Music/FIGHTPWR.AUD: FIGHTPWR.AUD
+			^Content/d2k/v2/Music/FREMEN.AUD: FREMEN.AUD
+			^Content/d2k/v2/Music/HARK_BAT.AUD: HARK_BAT.AUD
+			^Content/d2k/v2/Music/LANDSAND.AUD: LANDSAND.AUD
+			^Content/d2k/v2/Music/OPTIONS.AUD: OPTIONS.AUD
+			^Content/d2k/v2/Music/PLOTTING.AUD: PLOTTING.AUD
+			^Content/d2k/v2/Music/RISEHARK.AUD: RISEHARK.AUD
+			^Content/d2k/v2/Music/ROBOTIX.AUD: ROBOTIX.AUD
+			^Content/d2k/v2/Music/SCORE.AUD: SCORE.AUD
+			^Content/d2k/v2/Music/SOLDAPPR.AUD: SOLDAPPR.AUD
+			^Content/d2k/v2/Music/SPICESCT.AUD: SPICESCT.AUD
+			^Content/d2k/v2/Music/UNDERCON.AUD: UNDERCON.AUD
+			^Content/d2k/v2/Music/WAITGAME.A: WAITGAME.AUD
+		extract-blast: SETUP/SETUP.Z
+			^Content/d2k/v2/BLOXBAT.R8:
+				Offset: 1156877
+				Length: 512750
+			^Content/d2k/v2/BLOXBASE.R8:
+				Offset: 1669627
+				Length: 497092
+			^Content/d2k/v2/BLOXBGBS.R8:
+				Offset: 4055448
+				Length: 499135
+			^Content/d2k/v2/BLOXICE.R8:
+				Offset: 5524734
+				Length: 514963
+			^Content/d2k/v2/BLOXTREE.R8:
+				Offset: 6994595
+				Length: 509867
+			^Content/d2k/v2/BLOXWAST.R8:
+				Offset: 8455243
+				Length: 508567
+			^Content/d2k/v2/MOUSE.R8:
+				Offset: 14012716
+				Length: 16996
+			^Content/d2k/v2/PALETTE.BIN:
+				Offset: 22938626
+				Length: 815
+			^Content/d2k/v2/FONT.BIN:
+				Offset: 22927686
+				Length: 199
+			^Content/d2k/v2/FONTCOL.FNT:
+				Offset: 13985401
+				Length: 3011
+			^Content/d2k/v2/FONTCOL.FPL:
+				Offset: 13988412
+				Length: 238
+			^Content/d2k/v2/GAMESFX/A_ECONF2.AUD:
+				Offset: 15560530
+				Length: 9647
+			^Content/d2k/v2/GAMESFX/A_ECONF1.AUD:
+				Offset: 15570177
+				Length: 8676
+			^Content/d2k/v2/GAMESFX/A_ECONF3.AUD:
+				Offset: 15578853
+				Length: 9641
+			^Content/d2k/v2/GAMESFX/A_ESEL1.AUD:
+				Offset: 15588494
+				Length: 7371
+			^Content/d2k/v2/GAMESFX/A_ESEL2.AUD:
+				Offset: 15595865
+				Length: 11326
+			^Content/d2k/v2/GAMESFX/A_ESEL3.AUD:
+				Offset: 15607191
+				Length: 11329
+			^Content/d2k/v2/GAMESFX/A_FCONF1.AUD:
+				Offset: 15618520
+				Length: 8964
+			^Content/d2k/v2/GAMESFX/A_FCONF2.AUD:
+				Offset: 15627484
+				Length: 11336
+			^Content/d2k/v2/GAMESFX/A_FCONF3.AUD:
+				Offset: 15638820
+				Length: 14606
+			^Content/d2k/v2/GAMESFX/OI_ENEMY.AUD:
+				Offset: 15653426
+				Length: 27230
+			^Content/d2k/v2/GAMESFX/AI_POWER.AUD:
+				Offset: 15680656
+				Length: 19621
+			^Content/d2k/v2/GAMESFX/AI_PREP.AUD:
+				Offset: 15700277
+				Length: 28781
+			^Content/d2k/v2/GAMESFX/AI_PRMRY.AUD:
+				Offset: 15729058
+				Length: 29703
+			^Content/d2k/v2/GAMESFX/AI_REINF.AUD:
+				Offset: 15758761
+				Length: 29555
+			^Content/d2k/v2/GAMESFX/AI_GANEW.AUD:
+				Offset: 15788316
+				Length: 27961
+			^Content/d2k/v2/GAMESFX/HI_SPORT.AUD:
+				Offset: 15816277
+				Length: 20925
+			^Content/d2k/v2/GAMESFX/OI_GSAVE.AUD:
+				Offset: 15837202
+				Length: 10925
+			^Content/d2k/v2/GAMESFX/OI_GUARD.AUD:
+				Offset: 15848127
+				Length: 8125
+			^Content/d2k/v2/GAMESFX/HI_MAP3B.AUD:
+				Offset: 15856252
+				Length: 26212
+			^Content/d2k/v2/GAMESFX/HI_MAP4A.AUD:
+				Offset: 15882464
+				Length: 27166
+			^Content/d2k/v2/GAMESFX/HI_MAP5A.AUD:
+				Offset: 15909630
+				Length: 31126
+			^Content/d2k/v2/GAMESFX/HI_MAP6A.AUD:
+				Offset: 15940756
+				Length: 33481
+			^Content/d2k/v2/GAMESFX/O_ECONF3.AUD:
+				Offset: 15974237
+				Length: 17265
+			^Content/d2k/v2/GAMESFX/O_SCONF3.AUD:
+				Offset: 15991502
+				Length: 14523
+			^Content/d2k/v2/GAMESFX/O_SSEL1.AUD:
+				Offset: 16006025
+				Length: 18266
+			^Content/d2k/v2/GAMESFX/O_SSEL2.AUD:
+				Offset: 16024291
+				Length: 8467
+			^Content/d2k/v2/GAMESFX/O_SSEL3.AUD:
+				Offset: 16032758
+				Length: 9748
+			^Content/d2k/v2/GAMESFX/O_VCONF1.AUD:
+				Offset: 16042506
+				Length: 14264
+			^Content/d2k/v2/GAMESFX/O_VCONF2.AUD:
+				Offset: 16056770
+				Length: 12087
+			^Content/d2k/v2/GAMESFX/O_VCONF3.AUD:
+				Offset: 16068857
+				Length: 14428
+			^Content/d2k/v2/GAMESFX/OI_MWIN.AUD:
+				Offset: 16083285
+				Length: 16985
+			^Content/d2k/v2/GAMESFX/O_ECONF1.AUD:
+				Offset: 16100270
+				Length: 12638
+			^Content/d2k/v2/GAMESFX/O_ECONF2.AUD:
+				Offset: 16112908
+				Length: 13229
+			^Content/d2k/v2/GAMESFX/OI_NROOM.AUD:
+				Offset: 16126137
+				Length: 26572
+			^Content/d2k/v2/GAMESFX/O_ESEL1.AUD:
+				Offset: 16152709
+				Length: 12085
+			^Content/d2k/v2/GAMESFX/O_ESEL2.AUD:
+				Offset: 16164794
+				Length: 18232
+			^Content/d2k/v2/GAMESFX/O_ESEL3.AUD:
+				Offset: 16183026
+				Length: 8328
+			^Content/d2k/v2/GAMESFX/O_ICONF1.AUD:
+				Offset: 16191354
+				Length: 12497
+			^Content/d2k/v2/GAMESFX/O_ICONF2.AUD:
+				Offset: 16203851
+				Length: 9546
+			^Content/d2k/v2/GAMESFX/O_ICONF3.AUD:
+				Offset: 16213397
+				Length: 17135
+			^Content/d2k/v2/GAMESFX/HI_MAP4B.AUD:
+				Offset: 16230532
+				Length: 26937
+			^Content/d2k/v2/GAMESFX/O_ISEL2.AUD:
+				Offset: 16257469
+				Length: 17940
+			^Content/d2k/v2/GAMESFX/HI_BLOST.AUD:
+				Offset: 16275409
+				Length: 14985
+			^Content/d2k/v2/GAMESFX/HI_BUILD.AUD:
+				Offset: 16290394
+				Length: 9089
+			^Content/d2k/v2/GAMESFX/HI_MAP6B.AUD:
+				Offset: 16299483
+				Length: 28401
+			^Content/d2k/v2/GAMESFX/HI_MAP7A.AUD:
+				Offset: 16327884
+				Length: 23949
+			^Content/d2k/v2/GAMESFX/HI_MAP9.AUD:
+				Offset: 16351833
+				Length: 29489
+			^Content/d2k/v2/GAMESFX/A_VSEL3.AUD:
+				Offset: 16381322
+				Length: 11016
+			^Content/d2k/v2/GAMESFX/AI_1MIN.AUD:
+				Offset: 16392338
+				Length: 27566
+			^Content/d2k/v2/GAMESFX/AI_2MIN.AUD:
+				Offset: 16419904
+				Length: 26539
+			^Content/d2k/v2/GAMESFX/AI_3MIN.AUD:
+				Offset: 16446443
+				Length: 30821
+			^Content/d2k/v2/GAMESFX/O_VSEL1.AUD:
+				Offset: 16477264
+				Length: 7978
+			^Content/d2k/v2/GAMESFX/HI_RUN.AUD:
+				Offset: 16485242
+				Length: 11880
+			^Content/d2k/v2/GAMESFX/A_FSEL1.AUD:
+				Offset: 16497122
+				Length: 8995
+			^Content/d2k/v2/GAMESFX/A_FSEL2.AUD:
+				Offset: 16506117
+				Length: 10120
+			^Content/d2k/v2/GAMESFX/A_FSEL3.AUD:
+				Offset: 16516237
+				Length: 8999
+			^Content/d2k/v2/GAMESFX/A_FSEL4.AUD:
+				Offset: 16525236
+				Length: 6593
+			^Content/d2k/v2/GAMESFX/OI_MAP8A.AUD:
+				Offset: 16531829
+				Length: 34790
+			^Content/d2k/v2/GAMESFX/OI_MAP9A.AUD:
+				Offset: 16566619
+				Length: 35606
+			^Content/d2k/v2/GAMESFX/OI_MEND.AUD:
+				Offset: 16602225
+				Length: 10303
+			^Content/d2k/v2/GAMESFX/OI_MFAIL.AUD:
+				Offset: 16612528
+				Length: 22969
+			^Content/d2k/v2/GAMESFX/AI_4MIN.AUD:
+				Offset: 16635497
+				Length: 31816
+			^Content/d2k/v2/GAMESFX/AI_CANCL.AUD:
+				Offset: 16667313
+				Length: 19585
+			^Content/d2k/v2/GAMESFX/OI_ULOST.AUD:
+				Offset: 16686898
+				Length: 14563
+			^Content/d2k/v2/GAMESFX/OI_UNRDY.AUD:
+				Offset: 16701461
+				Length: 13353
+			^Content/d2k/v2/GAMESFX/O_VSEL3.AUD:
+				Offset: 16714814
+				Length: 9671
+			^Content/d2k/v2/GAMESFX/OI_1MIN.AUD:
+				Offset: 16724485
+				Length: 15031
+			^Content/d2k/v2/GAMESFX/OI_MAP7A.AUD:
+				Offset: 16739516
+				Length: 28368
+			^Content/d2k/v2/GAMESFX/HI_TRAIN.AUD:
+				Offset: 16767884
+				Length: 9649
+			^Content/d2k/v2/GAMESFX/HI_ULOST.AUD:
+				Offset: 16777533
+				Length: 17157
+			^Content/d2k/v2/GAMESFX/HI_UNRDY.AUD:
+				Offset: 16794690
+				Length: 13407
+			^Content/d2k/v2/GAMESFX/OI_MAP2A.AUD:
+				Offset: 16808097
+				Length: 29910
+			^Content/d2k/v2/GAMESFX/HI_REINF.AUD:
+				Offset: 16838007
+				Length: 22890
+			^Content/d2k/v2/GAMESFX/OI_MAP2C.AUD:
+				Offset: 16860897
+				Length: 22923
+			^Content/d2k/v2/GAMESFX/OI_MAP3A.AUD:
+				Offset: 16883820
+				Length: 34017
+			^Content/d2k/v2/GAMESFX/OI_MAP4A.AUD:
+				Offset: 16917837
+				Length: 56714
+			^Content/d2k/v2/GAMESFX/OI_SPORT.AUD:
+				Offset: 16974551
+				Length: 27200
+			^Content/d2k/v2/GAMESFX/OI_UPGOP.AUD:
+				Offset: 17001751
+				Length: 19828
+			^Content/d2k/v2/GAMESFX/OI_UPGRD.AUD:
+				Offset: 17021579
+				Length: 13869
+			^Content/d2k/v2/GAMESFX/OI_WATTK.AUD:
+				Offset: 17035448
+				Length: 14197
+			^Content/d2k/v2/GAMESFX/AI_MONEY.AUD:
+				Offset: 17049645
+				Length: 29136
+			^Content/d2k/v2/GAMESFX/AI_SELL.AUD:
+				Offset: 17078781
+				Length: 26204
+			^Content/d2k/v2/GAMESFX/HI_NEWOP.AUD:
+				Offset: 17104985
+				Length: 24264
+			^Content/d2k/v2/GAMESFX/AI_5MIN.AUD:
+				Offset: 17129249
+				Length: 43921
+			^Content/d2k/v2/GAMESFX/OI_HATTK.AUD:
+				Offset: 17173170
+				Length: 22151
+			^Content/d2k/v2/GAMESFX/H_VSEL2.AUD:
+				Offset: 17195321
+				Length: 12300
+			^Content/d2k/v2/GAMESFX/OI_MAP1B.AUD:
+				Offset: 17207621
+				Length: 21971
+			^Content/d2k/v2/GAMESFX/OI_MAP1C.AUD:
+				Offset: 17229592
+				Length: 22041
+			^Content/d2k/v2/GAMESFX/AI_GSAVE.AUD:
+				Offset: 17251633
+				Length: 21545
+			^Content/d2k/v2/GAMESFX/AI_GUARD.AUD:
+				Offset: 17273178
+				Length: 14344
+			^Content/d2k/v2/GAMESFX/AI_HATTK.AUD:
+				Offset: 17287522
+				Length: 28156
+			^Content/d2k/v2/GAMESFX/AI_HOLD.AUD:
+				Offset: 17315678
+				Length: 16983
+			^Content/d2k/v2/GAMESFX/HI_UPGOP.AUD:
+				Offset: 17332661
+				Length: 19583
+			^Content/d2k/v2/GAMESFX/HI_UPGRD.AUD:
+				Offset: 17352244
+				Length: 12875
+			^Content/d2k/v2/GAMESFX/OI_MAP2B.AUD:
+				Offset: 17365119
+				Length: 20974
+			^Content/d2k/v2/GAMESFX/HI_WSIGN.AUD:
+				Offset: 17386093
+				Length: 14699
+			^Content/d2k/v2/GAMESFX/HI_HATTK.AUD:
+				Offset: 17400792
+				Length: 20919
+			^Content/d2k/v2/GAMESFX/O_SCONF2.AUD:
+				Offset: 17421711
+				Length: 18984
+			^Content/d2k/v2/GAMESFX/HI_HOLD.AUD:
+				Offset: 17440695
+				Length: 11779
+			^Content/d2k/v2/GAMESFX/A_VSEL2.AUD:
+				Offset: 17452474
+				Length: 13980
+			^Content/d2k/v2/GAMESFX/AI_ATACK.AUD:
+				Offset: 17466454
+				Length: 33483
+			^Content/d2k/v2/GAMESFX/AI_BDRDY.AUD:
+				Offset: 17499937
+				Length: 26566
+			^Content/d2k/v2/GAMESFX/AI_BLOST.AUD:
+				Offset: 17526503
+				Length: 25237
+			^Content/d2k/v2/GAMESFX/AI_BUILD.AUD:
+				Offset: 17551740
+				Length: 16072
+			^Content/d2k/v2/GAMESFX/HI_GLOAD.AUD:
+				Offset: 17567812
+				Length: 12037
+			^Content/d2k/v2/GAMESFX/AI_CAPT.AUD:
+				Offset: 17579849
+				Length: 30243
+			^Content/d2k/v2/GAMESFX/AI_DHRDY.AUD:
+				Offset: 17610092
+				Length: 31710
+			^Content/d2k/v2/GAMESFX/AI_DPLOY.AUD:
+				Offset: 17641802
+				Length: 27450
+			^Content/d2k/v2/GAMESFX/AI_ENEMY.AUD:
+				Offset: 17669252
+				Length: 30854
+			^Content/d2k/v2/GAMESFX/A_VCONF1.AUD:
+				Offset: 17700106
+				Length: 10860
+			^Content/d2k/v2/GAMESFX/HI_PLACE.AUD:
+				Offset: 17710966
+				Length: 19337
+			^Content/d2k/v2/GAMESFX/HI_POWER.AUD:
+				Offset: 17730303
+				Length: 15004
+			^Content/d2k/v2/GAMESFX/HI_PREP.AUD:
+				Offset: 17745307
+				Length: 23023
+			^Content/d2k/v2/GAMESFX/HI_PRMRY.AUD:
+				Offset: 17768330
+				Length: 22321
+			^Content/d2k/v2/GAMESFX/OI_MONEY.AUD:
+				Offset: 17790651
+				Length: 21698
+			^Content/d2k/v2/GAMESFX/O_ISEL1.AUD:
+				Offset: 17812349
+				Length: 10282
+			^Content/d2k/v2/GAMESFX/OI_NEWOP.AUD:
+				Offset: 17822631
+				Length: 28615
+			^Content/d2k/v2/GAMESFX/A_VCONF3.AUD:
+				Offset: 17851246
+				Length: 12771
+			^Content/d2k/v2/GAMESFX/A_VSEL1.AUD:
+				Offset: 17864017
+				Length: 9917
+			^Content/d2k/v2/GAMESFX/OI_PLACE.AUD:
+				Offset: 17873934
+				Length: 18502
+			^Content/d2k/v2/GAMESFX/OI_POWER.AUD:
+				Offset: 17892436
+				Length: 12832
+			^Content/d2k/v2/GAMESFX/OI_PREP.AUD:
+				Offset: 17905268
+				Length: 22413
+			^Content/d2k/v2/GAMESFX/OI_PRMRY.AUD:
+				Offset: 17927681
+				Length: 29577
+			^Content/d2k/v2/GAMESFX/OI_REINF.AUD:
+				Offset: 17957258
+				Length: 24798
+			^Content/d2k/v2/GAMESFX/OI_RUN.AUD:
+				Offset: 17982056
+				Length: 14784
+			^Content/d2k/v2/GAMESFX/OI_CAPT.AUD:
+				Offset: 17996840
+				Length: 18526
+			^Content/d2k/v2/GAMESFX/H_ECONF1.AUD:
+				Offset: 18015366
+				Length: 12390
+			^Content/d2k/v2/GAMESFX/O_VSEL2.AUD:
+				Offset: 18027756
+				Length: 11851
+			^Content/d2k/v2/GAMESFX/H_VSEL3.AUD:
+				Offset: 18039607
+				Length: 9867
+			^Content/d2k/v2/GAMESFX/HI_1MIN.AUD:
+				Offset: 18049474
+				Length: 16907
+			^Content/d2k/v2/GAMESFX/HI_2MIN.AUD:
+				Offset: 18066381
+				Length: 17659
+			^Content/d2k/v2/GAMESFX/HI_3MIN.AUD:
+				Offset: 18084040
+				Length: 20337
+			^Content/d2k/v2/GAMESFX/HI_4MIN.AUD:
+				Offset: 18104377
+				Length: 18877
+			^Content/d2k/v2/GAMESFX/HI_5MIN.AUD:
+				Offset: 18123254
+				Length: 30788
+			^Content/d2k/v2/GAMESFX/HI_ABORT.AUD:
+				Offset: 18154042
+				Length: 18322
+			^Content/d2k/v2/GAMESFX/HI_ATACK.AUD:
+				Offset: 18172364
+				Length: 22178
+			^Content/d2k/v2/GAMESFX/HI_NROOM.AUD:
+				Offset: 18194542
+				Length: 24878
+			^Content/d2k/v2/GAMESFX/OI_SILOS.AUD:
+				Offset: 18219420
+				Length: 15741
+			^Content/d2k/v2/GAMESFX/A_FCONF4.AUD:
+				Offset: 18235161
+				Length: 14892
+			^Content/d2k/v2/GAMESFX/OI_MAP5A.AUD:
+				Offset: 18250053
+				Length: 23026
+			^Content/d2k/v2/GAMESFX/OI_MAP6A.AUD:
+				Offset: 18273079
+				Length: 43938
+			^Content/d2k/v2/GAMESFX/HI_CANCL.AUD:
+				Offset: 18317017
+				Length: 10992
+			^Content/d2k/v2/GAMESFX/HI_CAPT.AUD:
+				Offset: 18328009
+				Length: 19514
+			^Content/d2k/v2/GAMESFX/HI_DHRDY.AUD:
+				Offset: 18347523
+				Length: 23895
+			^Content/d2k/v2/GAMESFX/HI_DPLOY.AUD:
+				Offset: 18371418
+				Length: 18626
+			^Content/d2k/v2/GAMESFX/HI_ENEMY.AUD:
+				Offset: 18390044
+				Length: 22564
+			^Content/d2k/v2/GAMESFX/HI_GANEW.AUD:
+				Offset: 18412608
+				Length: 18445
+			^Content/d2k/v2/GAMESFX/OI_DHRDY.AUD:
+				Offset: 18431053
+				Length: 19492
+			^Content/d2k/v2/GAMESFX/HI_GSAVE.AUD:
+				Offset: 18450545
+				Length: 14194
+			^Content/d2k/v2/GAMESFX/HI_GUARD.AUD:
+				Offset: 18464739
+				Length: 8310
+			^Content/d2k/v2/GAMESFX/H_VSEL1.AUD:
+				Offset: 18473049
+				Length: 8332
+			^Content/d2k/v2/GAMESFX/OI_ORDER.AUD:
+				Offset: 18481381
+				Length: 15789
+			^Content/d2k/v2/GAMESFX/G_SCONF1.AUD:
+				Offset: 18497170
+				Length: 9791
+			^Content/d2k/v2/GAMESFX/G_SCONF2.AUD:
+				Offset: 18506961
+				Length: 15099
+			^Content/d2k/v2/GAMESFX/G_SCONF3.AUD:
+				Offset: 18522060
+				Length: 14863
+			^Content/d2k/v2/GAMESFX/G_SSEL1.AUD:
+				Offset: 18536923
+				Length: 9753
+			^Content/d2k/v2/GAMESFX/G_SSEL2.AUD:
+				Offset: 18546676
+				Length: 9329
+			^Content/d2k/v2/GAMESFX/G_SSEL3.AUD:
+				Offset: 18556005
+				Length: 9449
+			^Content/d2k/v2/GAMESFX/OI_SELL.AUD:
+				Offset: 18565454
+				Length: 15600
+			^Content/d2k/v2/GAMESFX/H_ECONF2.AUD:
+				Offset: 18581054
+				Length: 16157
+			^Content/d2k/v2/GAMESFX/H_ECONF3.AUD:
+				Offset: 18597211
+				Length: 13149
+			^Content/d2k/v2/GAMESFX/H_ESEL1.AUD:
+				Offset: 18610360
+				Length: 13928
+			^Content/d2k/v2/GAMESFX/H_ESEL2.AUD:
+				Offset: 18624288
+				Length: 16430
+			^Content/d2k/v2/GAMESFX/AI_MAP2C.AUD:
+				Offset: 18640718
+				Length: 41640
+			^Content/d2k/v2/GAMESFX/AI_MAP3A.AUD:
+				Offset: 18682358
+				Length: 41809
+			^Content/d2k/v2/GAMESFX/AI_MAP4A.AUD:
+				Offset: 18724167
+				Length: 29117
+			^Content/d2k/v2/GAMESFX/AI_MAP5A.AUD:
+				Offset: 18753284
+				Length: 36982
+			^Content/d2k/v2/GAMESFX/AI_MAP6A.AUD:
+				Offset: 18790266
+				Length: 60681
+			^Content/d2k/v2/GAMESFX/HI_BDRDY.AUD:
+				Offset: 18850947
+				Length: 21396
+			^Content/d2k/v2/GAMESFX/AI_MAP8A.AUD:
+				Offset: 18872343
+				Length: 37995
+			^Content/d2k/v2/GAMESFX/AI_MAP9A.AUD:
+				Offset: 18910338
+				Length: 32674
+			^Content/d2k/v2/GAMESFX/AI_MEND.AUD:
+				Offset: 18943012
+				Length: 18399
+			^Content/d2k/v2/GAMESFX/AI_MFAIL.AUD:
+				Offset: 18961411
+				Length: 26359
+			^Content/d2k/v2/GAMESFX/AI_GLOAD.AUD:
+				Offset: 18987770
+				Length: 21335
+			^Content/d2k/v2/GAMESFX/HI_MAP9A.AUD:
+				Offset: 19009105
+				Length: 28418
+			^Content/d2k/v2/GAMESFX/HI_MEND.AUD:
+				Offset: 19037523
+				Length: 9269
+			^Content/d2k/v2/GAMESFX/HI_MFAIL.AUD:
+				Offset: 19046792
+				Length: 19854
+			^Content/d2k/v2/GAMESFX/HI_MONEY.AUD:
+				Offset: 19066646
+				Length: 20038
+			^Content/d2k/v2/GAMESFX/HI_MWIN.AUD:
+				Offset: 19086684
+				Length: 16073
+			^Content/d2k/v2/GAMESFX/HI_WATTK.AUD:
+				Offset: 19102757
+				Length: 14873
+			^Content/d2k/v2/GAMESFX/AI_MAP1A.AUD:
+				Offset: 19117630
+				Length: 41683
+			^Content/d2k/v2/GAMESFX/AI_MAP1B.AUD:
+				Offset: 19159313
+				Length: 34475
+			^Content/d2k/v2/GAMESFX/AI_MAP1C.AUD:
+				Offset: 19193788
+				Length: 34903
+			^Content/d2k/v2/GAMESFX/AI_MAP2A.AUD:
+				Offset: 19228691
+				Length: 59613
+			^Content/d2k/v2/GAMESFX/AI_ABORT.AUD:
+				Offset: 19288304
+				Length: 22150
+			^Content/d2k/v2/GAMESFX/H_ESEL3.AUD:
+				Offset: 19310454
+				Length: 9090
+			^Content/d2k/v2/GAMESFX/AI_SILOS.AUD:
+				Offset: 19319544
+				Length: 21350
+			^Content/d2k/v2/GAMESFX/AI_SPORT.AUD:
+				Offset: 19340894
+				Length: 31478
+			^Content/d2k/v2/GAMESFX/AI_TRAIN.AUD:
+				Offset: 19372372
+				Length: 19876
+			^Content/d2k/v2/GAMESFX/AI_ULOST.AUD:
+				Offset: 19392248
+				Length: 22359
+			^Content/d2k/v2/GAMESFX/AI_MAP7A.AUD:
+				Offset: 19414607
+				Length: 28902
+			^Content/d2k/v2/GAMESFX/AI_UPGOP.AUD:
+				Offset: 19443509
+				Length: 26855
+			^Content/d2k/v2/GAMESFX/AI_UPGRD.AUD:
+				Offset: 19470364
+				Length: 19104
+			^Content/d2k/v2/GAMESFX/AI_WATTK.AUD:
+				Offset: 19489468
+				Length: 24655
+			^Content/d2k/v2/GAMESFX/AI_WSIGN.AUD:
+				Offset: 19514123
+				Length: 23032
+			^Content/d2k/v2/GAMESFX/AI_MAP2B.AUD:
+				Offset: 19537155
+				Length: 35588
+			^Content/d2k/v2/GAMESFX/A_ICONF1.AUD:
+				Offset: 19572743
+				Length: 8945
+			^Content/d2k/v2/GAMESFX/A_ICONF2.AUD:
+				Offset: 19581688
+				Length: 9005
+			^Content/d2k/v2/GAMESFX/A_ICONF3.AUD:
+				Offset: 19590693
+				Length: 9606
+			^Content/d2k/v2/GAMESFX/A_ISEL1.AUD:
+				Offset: 19600299
+				Length: 11671
+			^Content/d2k/v2/GAMESFX/OI_CANCL.AUD:
+				Offset: 19611970
+				Length: 10644
+			^Content/d2k/v2/GAMESFX/H_ISEL2.AUD:
+				Offset: 19622614
+				Length: 10387
+			^Content/d2k/v2/GAMESFX/H_ISEL3.AUD:
+				Offset: 19633001
+				Length: 17225
+			^Content/d2k/v2/GAMESFX/H_VCONF1.AUD:
+				Offset: 19650226
+				Length: 10077
+			^Content/d2k/v2/GAMESFX/H_VCONF2.AUD:
+				Offset: 19660303
+				Length: 13616
+			^Content/d2k/v2/GAMESFX/H_VCONF3.AUD:
+				Offset: 19673919
+				Length: 11251
+			^Content/d2k/v2/GAMESFX/OI_TRAIN.AUD:
+				Offset: 19685170
+				Length: 8144
+			^Content/d2k/v2/GAMESFX/HI_ORDER.AUD:
+				Offset: 19693314
+				Length: 14865
+			^Content/d2k/v2/GAMESFX/OI_WSIGN.AUD:
+				Offset: 19708179
+				Length: 11912
+			^Content/d2k/v2/GAMESFX/OI_BLOST.AUD:
+				Offset: 19720091
+				Length: 19540
+			^Content/d2k/v2/GAMESFX/OI_BUILD.AUD:
+				Offset: 19739631
+				Length: 10246
+			^Content/d2k/v2/GAMESFX/AI_LAUNC.AUD:
+				Offset: 19749877
+				Length: 31148
+			^Content/d2k/v2/GAMESFX/A_ISEL3.AUD:
+				Offset: 19781025
+				Length: 8307
+			^Content/d2k/v2/GAMESFX/A_VCONF2.AUD:
+				Offset: 19789332
+				Length: 14331
+			^Content/d2k/v2/GAMESFX/OI_HOLD.AUD:
+				Offset: 19803663
+				Length: 11295
+			^Content/d2k/v2/GAMESFX/OI_LAUNC.AUD:
+				Offset: 19814958
+				Length: 20437
+			^Content/d2k/v2/GAMESFX/OI_MAP1A.AUD:
+				Offset: 19835395
+				Length: 27739
+			^Content/d2k/v2/GAMESFX/HI_LAUNC.AUD:
+				Offset: 19863134
+				Length: 22200
+			^Content/d2k/v2/GAMESFX/H_ICONF1.AUD:
+				Offset: 19885334
+				Length: 9620
+			^Content/d2k/v2/GAMESFX/H_ICONF2.AUD:
+				Offset: 19894954
+				Length: 13368
+			^Content/d2k/v2/GAMESFX/H_ICONF3.AUD:
+				Offset: 19908322
+				Length: 15612
+			^Content/d2k/v2/GAMESFX/H_ISEL1.AUD:
+				Offset: 19923934
+				Length: 8279
+			^Content/d2k/v2/GAMESFX/A_ISEL2.AUD:
+				Offset: 19932213
+				Length: 11383
+			^Content/d2k/v2/GAMESFX/AI_RUN.AUD:
+				Offset: 19943596
+				Length: 18511
+			^Content/d2k/v2/GAMESFX/HI_SILOS.AUD:
+				Offset: 19962107
+				Length: 14244
+			^Content/d2k/v2/GAMESFX/HI_MAP1A.AUD:
+				Offset: 19976351
+				Length: 24075
+			^Content/d2k/v2/GAMESFX/HI_MAP1B.AUD:
+				Offset: 20000426
+				Length: 26716
+			^Content/d2k/v2/GAMESFX/HI_MAP1C.AUD:
+				Offset: 20027142
+				Length: 21716
+			^Content/d2k/v2/GAMESFX/HI_MAP2A.AUD:
+				Offset: 20048858
+				Length: 32417
+			^Content/d2k/v2/GAMESFX/HI_MAP2B.AUD:
+				Offset: 20081275
+				Length: 33724
+			^Content/d2k/v2/GAMESFX/HI_MAP2C.AUD:
+				Offset: 20114999
+				Length: 21828
+			^Content/d2k/v2/GAMESFX/HI_MAP3A.AUD:
+				Offset: 20136827
+				Length: 30404
+			^Content/d2k/v2/GAMESFX/O_ISEL3.AUD:
+				Offset: 20167231
+				Length: 9862
+			^Content/d2k/v2/GAMESFX/O_SCONF1.AUD:
+				Offset: 20177093
+				Length: 18149
+			^Content/d2k/v2/GAMESFX/OI_2MIN.AUD:
+				Offset: 20195242
+				Length: 14697
+			^Content/d2k/v2/GAMESFX/OI_3MIN.AUD:
+				Offset: 20209939
+				Length: 17316
+			^Content/d2k/v2/GAMESFX/OI_4MIN.AUD:
+				Offset: 20227255
+				Length: 14869
+			^Content/d2k/v2/GAMESFX/OI_5MIN.AUD:
+				Offset: 20242124
+				Length: 29873
+			^Content/d2k/v2/GAMESFX/OI_ABORT.AUD:
+				Offset: 20271997
+				Length: 16335
+			^Content/d2k/v2/GAMESFX/OI_ATACK.AUD:
+				Offset: 20288332
+				Length: 20565
+			^Content/d2k/v2/GAMESFX/OI_BDRDY.AUD:
+				Offset: 20308897
+				Length: 25497
+			^Content/d2k/v2/GAMESFX/HI_SELL.AUD:
+				Offset: 20334394
+				Length: 17142
+			^Content/d2k/v2/GAMESFX/OI_DPLOY.AUD:
+				Offset: 20351536
+				Length: 20120
+			^Content/d2k/v2/GAMESFX/AI_PLACE.AUD:
+				Offset: 20371656
+				Length: 29921
+			^Content/d2k/v2/GAMESFX/OI_GANEW.AUD:
+				Offset: 20401577
+				Length: 14467
+			^Content/d2k/v2/GAMESFX/OI_GLOAD.AUD:
+				Offset: 20416044
+				Length: 10906
+			^Content/d2k/v2/GAMESFX/AI_MWIN.AUD:
+				Offset: 20426950
+				Length: 25959
+			^Content/d2k/v2/GAMESFX/AI_NEWOP.AUD:
+				Offset: 20452909
+				Length: 34175
+			^Content/d2k/v2/GAMESFX/AI_NROOM.AUD:
+				Offset: 20487084
+				Length: 30124
+			^Content/d2k/v2/GAMESFX/AI_ORDER.AUD:
+				Offset: 20517208
+				Length: 21881
+			^Content/d2k/v2/GAMESFX/AI_UNRDY.AUD:
+				Offset: 20539089
+				Length: 20567
+			^Content/d2k/v2/SOUND.RS:
+				Offset: 20559656
+				Length: 1929247
+d2k-b-linux: Dune 2000 (English)
+	IDFiles:
+		music/ambush.aud: bd5926a56a83bc0e49f96037e1f909014ac0772a
+		setup/setup.z: 029722e70fb7636f8120028f5c9b6ce81627ff90
+	Install:
+		copy: movies
+			^Content/d2k/v2/Movies/A_BR01_E.VQA: a_br01_e.vqa
+			^Content/d2k/v2/Movies/A_BR02_E.VQA: a_br02_e.vqa
+			^Content/d2k/v2/Movies/A_BR03_E.VQA: a_br03_e.vqa
+			^Content/d2k/v2/Movies/A_BR04_E.VQA: a_br04_e.vqa
+			^Content/d2k/v2/Movies/A_BR05_E.VQA: a_br05_e.vqa
+			^Content/d2k/v2/Movies/A_BR06_E.VQA: a_br06_e.vqa
+			^Content/d2k/v2/Movies/A_BR07_E.VQA: a_br07_e.vqa
+			^Content/d2k/v2/Movies/A_BR08_E.VQA: a_br08_e.vqa
+			^Content/d2k/v2/Movies/A_BR09_E.VQA: a_br09_e.vqa
+			^Content/d2k/v2/Movies/A_FINL_E.VQA: a_finl_e.vqa
+			^Content/d2k/v2/Movies/A_LOSE_E.VQA: a_lose_e.vqa
+			^Content/d2k/v2/Movies/A_MNTG_E.VQA: a_mntg_e.vqa
+			^Content/d2k/v2/Movies/H_BR01_E.VQA: h_br01_e.vqa
+			^Content/d2k/v2/Movies/H_BR02_E.VQA: h_br02_e.vqa
+			^Content/d2k/v2/Movies/H_BR03_E.VQA: h_br03_e.vqa
+			^Content/d2k/v2/Movies/H_BR04_E.VQA: h_br04_e.vqa
+			^Content/d2k/v2/Movies/H_BR05_E.VQA: h_br05_e.vqa
+			^Content/d2k/v2/Movies/H_BR06_E.VQA: h_br06_e.vqa
+			^Content/d2k/v2/Movies/H_BR07_E.VQA: h_br07_e.vqa
+			^Content/d2k/v2/Movies/H_BR08_E.VQA: h_br08_e.vqa
+			^Content/d2k/v2/Movies/H_BR09_E.VQA: h_br09_e.vqa
+			^Content/d2k/v2/Movies/H_FINL_E.VQA: h_finl_e.vqa
+			^Content/d2k/v2/Movies/H_LOSE_E.VQA: h_lose_e.vqa
+			^Content/d2k/v2/Movies/H_MNTG_E.VQA: h_mntg_e.vqa
+			^Content/d2k/v2/Movies/O_BR01_E.VQA: o_br01_e.vqa
+			^Content/d2k/v2/Movies/O_BR02_E.VQA: o_br02_e.vqa
+			^Content/d2k/v2/Movies/O_BR03_E.VQA: o_br03_e.vqa
+			^Content/d2k/v2/Movies/O_BR04_E.VQA: o_br04_e.vqa
+			^Content/d2k/v2/Movies/O_BR05_E.VQA: o_br05_e.vqa
+			^Content/d2k/v2/Movies/O_BR06_E.VQA: o_br06_e.vqa
+			^Content/d2k/v2/Movies/O_BR07_E.VQA: o_br07_e.vqa
+			^Content/d2k/v2/Movies/O_BR08_E.VQA: o_br08_e.vqa
+			^Content/d2k/v2/Movies/O_BR09_E.VQA: o_br09_e.vqa
+			^Content/d2k/v2/Movies/O_FINL_E.VQA: o_finl_e.vqa
+			^Content/d2k/v2/Movies/O_LOSE_E.VQA: o_lose_e.vqa
+			^Content/d2k/v2/Movies/O_MNTG_E.VQA: o_mntg_e.vqa
+			^Content/d2k/v2/Movies/G_INT1_E.VQA: g_int1_e.vqa
+			^Content/d2k/v2/Movies/G_INT2_E.VQA: g_int2_e.vqa
+			^Content/d2k/v2/Movies/G_MAPS_E.VQA: g_maps_e.vqa
+			^Content/d2k/v2/Movies/G_PLN2_E.VQA: g_pln2_e.vqa
+			^Content/d2k/v2/Movies/G_PLNT_E.VQA: g_plnt_e.vqa
+			^Content/d2k/v2/Movies/T_TITL_E.VQA: t_titl_e.vqa
+		copy: music
+			^Content/d2k/v2/Music/AMBUSH.AUD: ambush.aud
+			^Content/d2k/v2/Music/ARAKATAK.AUD: arakatak.aud
+			^Content/d2k/v2/Music/ATREGAIN.AUD: atregain.aud
+			^Content/d2k/v2/Music/ENTORDOS.AUD: entordos.aud
+			^Content/d2k/v2/Music/FIGHTPWR.AUD: fightpwr.aud
+			^Content/d2k/v2/Music/FREMEN.AUD: fremen.aud
+			^Content/d2k/v2/Music/HARK_BAT.AUD: hark_bat.aud
+			^Content/d2k/v2/Music/LANDSAND.AUD: landsand.aud
+			^Content/d2k/v2/Music/OPTIONS.AUD: options.aud
+			^Content/d2k/v2/Music/PLOTTING.AUD: plotting.aud
+			^Content/d2k/v2/Music/RISEHARK.AUD: risehark.aud
+			^Content/d2k/v2/Music/ROBOTIX.AUD: robotix.aud
+			^Content/d2k/v2/Music/SCORE.AUD: score.aud
+			^Content/d2k/v2/Music/SOLDAPPR.AUD: soldappr.aud
+			^Content/d2k/v2/Music/SPICESCT.AUD: spicesct.aud
+			^Content/d2k/v2/Music/UNDERCON.AUD: undercon.aud
+			^Content/d2k/v2/Music/WAITGAME.A: waitgame.aud
+		extract-blast: setup/setup.z
+			^Content/d2k/v2/BLOXBAT.R8:
+				Offset: 1156877
+				Length: 512750
+			^Content/d2k/v2/BLOXBASE.R8:
+				Offset: 1669627
+				Length: 497092
+			^Content/d2k/v2/BLOXBGBS.R8:
+				Offset: 4055448
+				Length: 499135
+			^Content/d2k/v2/BLOXICE.R8:
+				Offset: 5524734
+				Length: 514963
+			^Content/d2k/v2/BLOXTREE.R8:
+				Offset: 6994595
+				Length: 509867
+			^Content/d2k/v2/BLOXWAST.R8:
+				Offset: 8455243
+				Length: 508567
+			^Content/d2k/v2/MOUSE.R8:
+				Offset: 14012716
+				Length: 16996
+			^Content/d2k/v2/PALETTE.BIN:
+				Offset: 22938626
+				Length: 815
+			^Content/d2k/v2/FONT.BIN:
+				Offset: 22927686
+				Length: 199
+			^Content/d2k/v2/FONTCOL.FNT:
+				Offset: 13985401
+				Length: 3011
+			^Content/d2k/v2/FONTCOL.FPL:
+				Offset: 13988412
+				Length: 238
+			^Content/d2k/v2/GAMESFX/A_ECONF2.AUD:
+				Offset: 15560530
+				Length: 9647
+			^Content/d2k/v2/GAMESFX/A_ECONF1.AUD:
+				Offset: 15570177
+				Length: 8676
+			^Content/d2k/v2/GAMESFX/A_ECONF3.AUD:
+				Offset: 15578853
+				Length: 9641
+			^Content/d2k/v2/GAMESFX/A_ESEL1.AUD:
+				Offset: 15588494
+				Length: 7371
+			^Content/d2k/v2/GAMESFX/A_ESEL2.AUD:
+				Offset: 15595865
+				Length: 11326
+			^Content/d2k/v2/GAMESFX/A_ESEL3.AUD:
+				Offset: 15607191
+				Length: 11329
+			^Content/d2k/v2/GAMESFX/A_FCONF1.AUD:
+				Offset: 15618520
+				Length: 8964
+			^Content/d2k/v2/GAMESFX/A_FCONF2.AUD:
+				Offset: 15627484
+				Length: 11336
+			^Content/d2k/v2/GAMESFX/A_FCONF3.AUD:
+				Offset: 15638820
+				Length: 14606
+			^Content/d2k/v2/GAMESFX/OI_ENEMY.AUD:
+				Offset: 15653426
+				Length: 27230
+			^Content/d2k/v2/GAMESFX/AI_POWER.AUD:
+				Offset: 15680656
+				Length: 19621
+			^Content/d2k/v2/GAMESFX/AI_PREP.AUD:
+				Offset: 15700277
+				Length: 28781
+			^Content/d2k/v2/GAMESFX/AI_PRMRY.AUD:
+				Offset: 15729058
+				Length: 29703
+			^Content/d2k/v2/GAMESFX/AI_REINF.AUD:
+				Offset: 15758761
+				Length: 29555
+			^Content/d2k/v2/GAMESFX/AI_GANEW.AUD:
+				Offset: 15788316
+				Length: 27961
+			^Content/d2k/v2/GAMESFX/HI_SPORT.AUD:
+				Offset: 15816277
+				Length: 20925
+			^Content/d2k/v2/GAMESFX/OI_GSAVE.AUD:
+				Offset: 15837202
+				Length: 10925
+			^Content/d2k/v2/GAMESFX/OI_GUARD.AUD:
+				Offset: 15848127
+				Length: 8125
+			^Content/d2k/v2/GAMESFX/HI_MAP3B.AUD:
+				Offset: 15856252
+				Length: 26212
+			^Content/d2k/v2/GAMESFX/HI_MAP4A.AUD:
+				Offset: 15882464
+				Length: 27166
+			^Content/d2k/v2/GAMESFX/HI_MAP5A.AUD:
+				Offset: 15909630
+				Length: 31126
+			^Content/d2k/v2/GAMESFX/HI_MAP6A.AUD:
+				Offset: 15940756
+				Length: 33481
+			^Content/d2k/v2/GAMESFX/O_ECONF3.AUD:
+				Offset: 15974237
+				Length: 17265
+			^Content/d2k/v2/GAMESFX/O_SCONF3.AUD:
+				Offset: 15991502
+				Length: 14523
+			^Content/d2k/v2/GAMESFX/O_SSEL1.AUD:
+				Offset: 16006025
+				Length: 18266
+			^Content/d2k/v2/GAMESFX/O_SSEL2.AUD:
+				Offset: 16024291
+				Length: 8467
+			^Content/d2k/v2/GAMESFX/O_SSEL3.AUD:
+				Offset: 16032758
+				Length: 9748
+			^Content/d2k/v2/GAMESFX/O_VCONF1.AUD:
+				Offset: 16042506
+				Length: 14264
+			^Content/d2k/v2/GAMESFX/O_VCONF2.AUD:
+				Offset: 16056770
+				Length: 12087
+			^Content/d2k/v2/GAMESFX/O_VCONF3.AUD:
+				Offset: 16068857
+				Length: 14428
+			^Content/d2k/v2/GAMESFX/OI_MWIN.AUD:
+				Offset: 16083285
+				Length: 16985
+			^Content/d2k/v2/GAMESFX/O_ECONF1.AUD:
+				Offset: 16100270
+				Length: 12638
+			^Content/d2k/v2/GAMESFX/O_ECONF2.AUD:
+				Offset: 16112908
+				Length: 13229
+			^Content/d2k/v2/GAMESFX/OI_NROOM.AUD:
+				Offset: 16126137
+				Length: 26572
+			^Content/d2k/v2/GAMESFX/O_ESEL1.AUD:
+				Offset: 16152709
+				Length: 12085
+			^Content/d2k/v2/GAMESFX/O_ESEL2.AUD:
+				Offset: 16164794
+				Length: 18232
+			^Content/d2k/v2/GAMESFX/O_ESEL3.AUD:
+				Offset: 16183026
+				Length: 8328
+			^Content/d2k/v2/GAMESFX/O_ICONF1.AUD:
+				Offset: 16191354
+				Length: 12497
+			^Content/d2k/v2/GAMESFX/O_ICONF2.AUD:
+				Offset: 16203851
+				Length: 9546
+			^Content/d2k/v2/GAMESFX/O_ICONF3.AUD:
+				Offset: 16213397
+				Length: 17135
+			^Content/d2k/v2/GAMESFX/HI_MAP4B.AUD:
+				Offset: 16230532
+				Length: 26937
+			^Content/d2k/v2/GAMESFX/O_ISEL2.AUD:
+				Offset: 16257469
+				Length: 17940
+			^Content/d2k/v2/GAMESFX/HI_BLOST.AUD:
+				Offset: 16275409
+				Length: 14985
+			^Content/d2k/v2/GAMESFX/HI_BUILD.AUD:
+				Offset: 16290394
+				Length: 9089
+			^Content/d2k/v2/GAMESFX/HI_MAP6B.AUD:
+				Offset: 16299483
+				Length: 28401
+			^Content/d2k/v2/GAMESFX/HI_MAP7A.AUD:
+				Offset: 16327884
+				Length: 23949
+			^Content/d2k/v2/GAMESFX/HI_MAP9.AUD:
+				Offset: 16351833
+				Length: 29489
+			^Content/d2k/v2/GAMESFX/A_VSEL3.AUD:
+				Offset: 16381322
+				Length: 11016
+			^Content/d2k/v2/GAMESFX/AI_1MIN.AUD:
+				Offset: 16392338
+				Length: 27566
+			^Content/d2k/v2/GAMESFX/AI_2MIN.AUD:
+				Offset: 16419904
+				Length: 26539
+			^Content/d2k/v2/GAMESFX/AI_3MIN.AUD:
+				Offset: 16446443
+				Length: 30821
+			^Content/d2k/v2/GAMESFX/O_VSEL1.AUD:
+				Offset: 16477264
+				Length: 7978
+			^Content/d2k/v2/GAMESFX/HI_RUN.AUD:
+				Offset: 16485242
+				Length: 11880
+			^Content/d2k/v2/GAMESFX/A_FSEL1.AUD:
+				Offset: 16497122
+				Length: 8995
+			^Content/d2k/v2/GAMESFX/A_FSEL2.AUD:
+				Offset: 16506117
+				Length: 10120
+			^Content/d2k/v2/GAMESFX/A_FSEL3.AUD:
+				Offset: 16516237
+				Length: 8999
+			^Content/d2k/v2/GAMESFX/A_FSEL4.AUD:
+				Offset: 16525236
+				Length: 6593
+			^Content/d2k/v2/GAMESFX/OI_MAP8A.AUD:
+				Offset: 16531829
+				Length: 34790
+			^Content/d2k/v2/GAMESFX/OI_MAP9A.AUD:
+				Offset: 16566619
+				Length: 35606
+			^Content/d2k/v2/GAMESFX/OI_MEND.AUD:
+				Offset: 16602225
+				Length: 10303
+			^Content/d2k/v2/GAMESFX/OI_MFAIL.AUD:
+				Offset: 16612528
+				Length: 22969
+			^Content/d2k/v2/GAMESFX/AI_4MIN.AUD:
+				Offset: 16635497
+				Length: 31816
+			^Content/d2k/v2/GAMESFX/AI_CANCL.AUD:
+				Offset: 16667313
+				Length: 19585
+			^Content/d2k/v2/GAMESFX/OI_ULOST.AUD:
+				Offset: 16686898
+				Length: 14563
+			^Content/d2k/v2/GAMESFX/OI_UNRDY.AUD:
+				Offset: 16701461
+				Length: 13353
+			^Content/d2k/v2/GAMESFX/O_VSEL3.AUD:
+				Offset: 16714814
+				Length: 9671
+			^Content/d2k/v2/GAMESFX/OI_1MIN.AUD:
+				Offset: 16724485
+				Length: 15031
+			^Content/d2k/v2/GAMESFX/OI_MAP7A.AUD:
+				Offset: 16739516
+				Length: 28368
+			^Content/d2k/v2/GAMESFX/HI_TRAIN.AUD:
+				Offset: 16767884
+				Length: 9649
+			^Content/d2k/v2/GAMESFX/HI_ULOST.AUD:
+				Offset: 16777533
+				Length: 17157
+			^Content/d2k/v2/GAMESFX/HI_UNRDY.AUD:
+				Offset: 16794690
+				Length: 13407
+			^Content/d2k/v2/GAMESFX/OI_MAP2A.AUD:
+				Offset: 16808097
+				Length: 29910
+			^Content/d2k/v2/GAMESFX/HI_REINF.AUD:
+				Offset: 16838007
+				Length: 22890
+			^Content/d2k/v2/GAMESFX/OI_MAP2C.AUD:
+				Offset: 16860897
+				Length: 22923
+			^Content/d2k/v2/GAMESFX/OI_MAP3A.AUD:
+				Offset: 16883820
+				Length: 34017
+			^Content/d2k/v2/GAMESFX/OI_MAP4A.AUD:
+				Offset: 16917837
+				Length: 56714
+			^Content/d2k/v2/GAMESFX/OI_SPORT.AUD:
+				Offset: 16974551
+				Length: 27200
+			^Content/d2k/v2/GAMESFX/OI_UPGOP.AUD:
+				Offset: 17001751
+				Length: 19828
+			^Content/d2k/v2/GAMESFX/OI_UPGRD.AUD:
+				Offset: 17021579
+				Length: 13869
+			^Content/d2k/v2/GAMESFX/OI_WATTK.AUD:
+				Offset: 17035448
+				Length: 14197
+			^Content/d2k/v2/GAMESFX/AI_MONEY.AUD:
+				Offset: 17049645
+				Length: 29136
+			^Content/d2k/v2/GAMESFX/AI_SELL.AUD:
+				Offset: 17078781
+				Length: 26204
+			^Content/d2k/v2/GAMESFX/HI_NEWOP.AUD:
+				Offset: 17104985
+				Length: 24264
+			^Content/d2k/v2/GAMESFX/AI_5MIN.AUD:
+				Offset: 17129249
+				Length: 43921
+			^Content/d2k/v2/GAMESFX/OI_HATTK.AUD:
+				Offset: 17173170
+				Length: 22151
+			^Content/d2k/v2/GAMESFX/H_VSEL2.AUD:
+				Offset: 17195321
+				Length: 12300
+			^Content/d2k/v2/GAMESFX/OI_MAP1B.AUD:
+				Offset: 17207621
+				Length: 21971
+			^Content/d2k/v2/GAMESFX/OI_MAP1C.AUD:
+				Offset: 17229592
+				Length: 22041
+			^Content/d2k/v2/GAMESFX/AI_GSAVE.AUD:
+				Offset: 17251633
+				Length: 21545
+			^Content/d2k/v2/GAMESFX/AI_GUARD.AUD:
+				Offset: 17273178
+				Length: 14344
+			^Content/d2k/v2/GAMESFX/AI_HATTK.AUD:
+				Offset: 17287522
+				Length: 28156
+			^Content/d2k/v2/GAMESFX/AI_HOLD.AUD:
+				Offset: 17315678
+				Length: 16983
+			^Content/d2k/v2/GAMESFX/HI_UPGOP.AUD:
+				Offset: 17332661
+				Length: 19583
+			^Content/d2k/v2/GAMESFX/HI_UPGRD.AUD:
+				Offset: 17352244
+				Length: 12875
+			^Content/d2k/v2/GAMESFX/OI_MAP2B.AUD:
+				Offset: 17365119
+				Length: 20974
+			^Content/d2k/v2/GAMESFX/HI_WSIGN.AUD:
+				Offset: 17386093
+				Length: 14699
+			^Content/d2k/v2/GAMESFX/HI_HATTK.AUD:
+				Offset: 17400792
+				Length: 20919
+			^Content/d2k/v2/GAMESFX/O_SCONF2.AUD:
+				Offset: 17421711
+				Length: 18984
+			^Content/d2k/v2/GAMESFX/HI_HOLD.AUD:
+				Offset: 17440695
+				Length: 11779
+			^Content/d2k/v2/GAMESFX/A_VSEL2.AUD:
+				Offset: 17452474
+				Length: 13980
+			^Content/d2k/v2/GAMESFX/AI_ATACK.AUD:
+				Offset: 17466454
+				Length: 33483
+			^Content/d2k/v2/GAMESFX/AI_BDRDY.AUD:
+				Offset: 17499937
+				Length: 26566
+			^Content/d2k/v2/GAMESFX/AI_BLOST.AUD:
+				Offset: 17526503
+				Length: 25237
+			^Content/d2k/v2/GAMESFX/AI_BUILD.AUD:
+				Offset: 17551740
+				Length: 16072
+			^Content/d2k/v2/GAMESFX/HI_GLOAD.AUD:
+				Offset: 17567812
+				Length: 12037
+			^Content/d2k/v2/GAMESFX/AI_CAPT.AUD:
+				Offset: 17579849
+				Length: 30243
+			^Content/d2k/v2/GAMESFX/AI_DHRDY.AUD:
+				Offset: 17610092
+				Length: 31710
+			^Content/d2k/v2/GAMESFX/AI_DPLOY.AUD:
+				Offset: 17641802
+				Length: 27450
+			^Content/d2k/v2/GAMESFX/AI_ENEMY.AUD:
+				Offset: 17669252
+				Length: 30854
+			^Content/d2k/v2/GAMESFX/A_VCONF1.AUD:
+				Offset: 17700106
+				Length: 10860
+			^Content/d2k/v2/GAMESFX/HI_PLACE.AUD:
+				Offset: 17710966
+				Length: 19337
+			^Content/d2k/v2/GAMESFX/HI_POWER.AUD:
+				Offset: 17730303
+				Length: 15004
+			^Content/d2k/v2/GAMESFX/HI_PREP.AUD:
+				Offset: 17745307
+				Length: 23023
+			^Content/d2k/v2/GAMESFX/HI_PRMRY.AUD:
+				Offset: 17768330
+				Length: 22321
+			^Content/d2k/v2/GAMESFX/OI_MONEY.AUD:
+				Offset: 17790651
+				Length: 21698
+			^Content/d2k/v2/GAMESFX/O_ISEL1.AUD:
+				Offset: 17812349
+				Length: 10282
+			^Content/d2k/v2/GAMESFX/OI_NEWOP.AUD:
+				Offset: 17822631
+				Length: 28615
+			^Content/d2k/v2/GAMESFX/A_VCONF3.AUD:
+				Offset: 17851246
+				Length: 12771
+			^Content/d2k/v2/GAMESFX/A_VSEL1.AUD:
+				Offset: 17864017
+				Length: 9917
+			^Content/d2k/v2/GAMESFX/OI_PLACE.AUD:
+				Offset: 17873934
+				Length: 18502
+			^Content/d2k/v2/GAMESFX/OI_POWER.AUD:
+				Offset: 17892436
+				Length: 12832
+			^Content/d2k/v2/GAMESFX/OI_PREP.AUD:
+				Offset: 17905268
+				Length: 22413
+			^Content/d2k/v2/GAMESFX/OI_PRMRY.AUD:
+				Offset: 17927681
+				Length: 29577
+			^Content/d2k/v2/GAMESFX/OI_REINF.AUD:
+				Offset: 17957258
+				Length: 24798
+			^Content/d2k/v2/GAMESFX/OI_RUN.AUD:
+				Offset: 17982056
+				Length: 14784
+			^Content/d2k/v2/GAMESFX/OI_CAPT.AUD:
+				Offset: 17996840
+				Length: 18526
+			^Content/d2k/v2/GAMESFX/H_ECONF1.AUD:
+				Offset: 18015366
+				Length: 12390
+			^Content/d2k/v2/GAMESFX/O_VSEL2.AUD:
+				Offset: 18027756
+				Length: 11851
+			^Content/d2k/v2/GAMESFX/H_VSEL3.AUD:
+				Offset: 18039607
+				Length: 9867
+			^Content/d2k/v2/GAMESFX/HI_1MIN.AUD:
+				Offset: 18049474
+				Length: 16907
+			^Content/d2k/v2/GAMESFX/HI_2MIN.AUD:
+				Offset: 18066381
+				Length: 17659
+			^Content/d2k/v2/GAMESFX/HI_3MIN.AUD:
+				Offset: 18084040
+				Length: 20337
+			^Content/d2k/v2/GAMESFX/HI_4MIN.AUD:
+				Offset: 18104377
+				Length: 18877
+			^Content/d2k/v2/GAMESFX/HI_5MIN.AUD:
+				Offset: 18123254
+				Length: 30788
+			^Content/d2k/v2/GAMESFX/HI_ABORT.AUD:
+				Offset: 18154042
+				Length: 18322
+			^Content/d2k/v2/GAMESFX/HI_ATACK.AUD:
+				Offset: 18172364
+				Length: 22178
+			^Content/d2k/v2/GAMESFX/HI_NROOM.AUD:
+				Offset: 18194542
+				Length: 24878
+			^Content/d2k/v2/GAMESFX/OI_SILOS.AUD:
+				Offset: 18219420
+				Length: 15741
+			^Content/d2k/v2/GAMESFX/A_FCONF4.AUD:
+				Offset: 18235161
+				Length: 14892
+			^Content/d2k/v2/GAMESFX/OI_MAP5A.AUD:
+				Offset: 18250053
+				Length: 23026
+			^Content/d2k/v2/GAMESFX/OI_MAP6A.AUD:
+				Offset: 18273079
+				Length: 43938
+			^Content/d2k/v2/GAMESFX/HI_CANCL.AUD:
+				Offset: 18317017
+				Length: 10992
+			^Content/d2k/v2/GAMESFX/HI_CAPT.AUD:
+				Offset: 18328009
+				Length: 19514
+			^Content/d2k/v2/GAMESFX/HI_DHRDY.AUD:
+				Offset: 18347523
+				Length: 23895
+			^Content/d2k/v2/GAMESFX/HI_DPLOY.AUD:
+				Offset: 18371418
+				Length: 18626
+			^Content/d2k/v2/GAMESFX/HI_ENEMY.AUD:
+				Offset: 18390044
+				Length: 22564
+			^Content/d2k/v2/GAMESFX/HI_GANEW.AUD:
+				Offset: 18412608
+				Length: 18445
+			^Content/d2k/v2/GAMESFX/OI_DHRDY.AUD:
+				Offset: 18431053
+				Length: 19492
+			^Content/d2k/v2/GAMESFX/HI_GSAVE.AUD:
+				Offset: 18450545
+				Length: 14194
+			^Content/d2k/v2/GAMESFX/HI_GUARD.AUD:
+				Offset: 18464739
+				Length: 8310
+			^Content/d2k/v2/GAMESFX/H_VSEL1.AUD:
+				Offset: 18473049
+				Length: 8332
+			^Content/d2k/v2/GAMESFX/OI_ORDER.AUD:
+				Offset: 18481381
+				Length: 15789
+			^Content/d2k/v2/GAMESFX/G_SCONF1.AUD:
+				Offset: 18497170
+				Length: 9791
+			^Content/d2k/v2/GAMESFX/G_SCONF2.AUD:
+				Offset: 18506961
+				Length: 15099
+			^Content/d2k/v2/GAMESFX/G_SCONF3.AUD:
+				Offset: 18522060
+				Length: 14863
+			^Content/d2k/v2/GAMESFX/G_SSEL1.AUD:
+				Offset: 18536923
+				Length: 9753
+			^Content/d2k/v2/GAMESFX/G_SSEL2.AUD:
+				Offset: 18546676
+				Length: 9329
+			^Content/d2k/v2/GAMESFX/G_SSEL3.AUD:
+				Offset: 18556005
+				Length: 9449
+			^Content/d2k/v2/GAMESFX/OI_SELL.AUD:
+				Offset: 18565454
+				Length: 15600
+			^Content/d2k/v2/GAMESFX/H_ECONF2.AUD:
+				Offset: 18581054
+				Length: 16157
+			^Content/d2k/v2/GAMESFX/H_ECONF3.AUD:
+				Offset: 18597211
+				Length: 13149
+			^Content/d2k/v2/GAMESFX/H_ESEL1.AUD:
+				Offset: 18610360
+				Length: 13928
+			^Content/d2k/v2/GAMESFX/H_ESEL2.AUD:
+				Offset: 18624288
+				Length: 16430
+			^Content/d2k/v2/GAMESFX/AI_MAP2C.AUD:
+				Offset: 18640718
+				Length: 41640
+			^Content/d2k/v2/GAMESFX/AI_MAP3A.AUD:
+				Offset: 18682358
+				Length: 41809
+			^Content/d2k/v2/GAMESFX/AI_MAP4A.AUD:
+				Offset: 18724167
+				Length: 29117
+			^Content/d2k/v2/GAMESFX/AI_MAP5A.AUD:
+				Offset: 18753284
+				Length: 36982
+			^Content/d2k/v2/GAMESFX/AI_MAP6A.AUD:
+				Offset: 18790266
+				Length: 60681
+			^Content/d2k/v2/GAMESFX/HI_BDRDY.AUD:
+				Offset: 18850947
+				Length: 21396
+			^Content/d2k/v2/GAMESFX/AI_MAP8A.AUD:
+				Offset: 18872343
+				Length: 37995
+			^Content/d2k/v2/GAMESFX/AI_MAP9A.AUD:
+				Offset: 18910338
+				Length: 32674
+			^Content/d2k/v2/GAMESFX/AI_MEND.AUD:
+				Offset: 18943012
+				Length: 18399
+			^Content/d2k/v2/GAMESFX/AI_MFAIL.AUD:
+				Offset: 18961411
+				Length: 26359
+			^Content/d2k/v2/GAMESFX/AI_GLOAD.AUD:
+				Offset: 18987770
+				Length: 21335
+			^Content/d2k/v2/GAMESFX/HI_MAP9A.AUD:
+				Offset: 19009105
+				Length: 28418
+			^Content/d2k/v2/GAMESFX/HI_MEND.AUD:
+				Offset: 19037523
+				Length: 9269
+			^Content/d2k/v2/GAMESFX/HI_MFAIL.AUD:
+				Offset: 19046792
+				Length: 19854
+			^Content/d2k/v2/GAMESFX/HI_MONEY.AUD:
+				Offset: 19066646
+				Length: 20038
+			^Content/d2k/v2/GAMESFX/HI_MWIN.AUD:
+				Offset: 19086684
+				Length: 16073
+			^Content/d2k/v2/GAMESFX/HI_WATTK.AUD:
+				Offset: 19102757
+				Length: 14873
+			^Content/d2k/v2/GAMESFX/AI_MAP1A.AUD:
+				Offset: 19117630
+				Length: 41683
+			^Content/d2k/v2/GAMESFX/AI_MAP1B.AUD:
+				Offset: 19159313
+				Length: 34475
+			^Content/d2k/v2/GAMESFX/AI_MAP1C.AUD:
+				Offset: 19193788
+				Length: 34903
+			^Content/d2k/v2/GAMESFX/AI_MAP2A.AUD:
+				Offset: 19228691
+				Length: 59613
+			^Content/d2k/v2/GAMESFX/AI_ABORT.AUD:
+				Offset: 19288304
+				Length: 22150
+			^Content/d2k/v2/GAMESFX/H_ESEL3.AUD:
+				Offset: 19310454
+				Length: 9090
+			^Content/d2k/v2/GAMESFX/AI_SILOS.AUD:
+				Offset: 19319544
+				Length: 21350
+			^Content/d2k/v2/GAMESFX/AI_SPORT.AUD:
+				Offset: 19340894
+				Length: 31478
+			^Content/d2k/v2/GAMESFX/AI_TRAIN.AUD:
+				Offset: 19372372
+				Length: 19876
+			^Content/d2k/v2/GAMESFX/AI_ULOST.AUD:
+				Offset: 19392248
+				Length: 22359
+			^Content/d2k/v2/GAMESFX/AI_MAP7A.AUD:
+				Offset: 19414607
+				Length: 28902
+			^Content/d2k/v2/GAMESFX/AI_UPGOP.AUD:
+				Offset: 19443509
+				Length: 26855
+			^Content/d2k/v2/GAMESFX/AI_UPGRD.AUD:
+				Offset: 19470364
+				Length: 19104
+			^Content/d2k/v2/GAMESFX/AI_WATTK.AUD:
+				Offset: 19489468
+				Length: 24655
+			^Content/d2k/v2/GAMESFX/AI_WSIGN.AUD:
+				Offset: 19514123
+				Length: 23032
+			^Content/d2k/v2/GAMESFX/AI_MAP2B.AUD:
+				Offset: 19537155
+				Length: 35588
+			^Content/d2k/v2/GAMESFX/A_ICONF1.AUD:
+				Offset: 19572743
+				Length: 8945
+			^Content/d2k/v2/GAMESFX/A_ICONF2.AUD:
+				Offset: 19581688
+				Length: 9005
+			^Content/d2k/v2/GAMESFX/A_ICONF3.AUD:
+				Offset: 19590693
+				Length: 9606
+			^Content/d2k/v2/GAMESFX/A_ISEL1.AUD:
+				Offset: 19600299
+				Length: 11671
+			^Content/d2k/v2/GAMESFX/OI_CANCL.AUD:
+				Offset: 19611970
+				Length: 10644
+			^Content/d2k/v2/GAMESFX/H_ISEL2.AUD:
+				Offset: 19622614
+				Length: 10387
+			^Content/d2k/v2/GAMESFX/H_ISEL3.AUD:
+				Offset: 19633001
+				Length: 17225
+			^Content/d2k/v2/GAMESFX/H_VCONF1.AUD:
+				Offset: 19650226
+				Length: 10077
+			^Content/d2k/v2/GAMESFX/H_VCONF2.AUD:
+				Offset: 19660303
+				Length: 13616
+			^Content/d2k/v2/GAMESFX/H_VCONF3.AUD:
+				Offset: 19673919
+				Length: 11251
+			^Content/d2k/v2/GAMESFX/OI_TRAIN.AUD:
+				Offset: 19685170
+				Length: 8144
+			^Content/d2k/v2/GAMESFX/HI_ORDER.AUD:
+				Offset: 19693314
+				Length: 14865
+			^Content/d2k/v2/GAMESFX/OI_WSIGN.AUD:
+				Offset: 19708179
+				Length: 11912
+			^Content/d2k/v2/GAMESFX/OI_BLOST.AUD:
+				Offset: 19720091
+				Length: 19540
+			^Content/d2k/v2/GAMESFX/OI_BUILD.AUD:
+				Offset: 19739631
+				Length: 10246
+			^Content/d2k/v2/GAMESFX/AI_LAUNC.AUD:
+				Offset: 19749877
+				Length: 31148
+			^Content/d2k/v2/GAMESFX/A_ISEL3.AUD:
+				Offset: 19781025
+				Length: 8307
+			^Content/d2k/v2/GAMESFX/A_VCONF2.AUD:
+				Offset: 19789332
+				Length: 14331
+			^Content/d2k/v2/GAMESFX/OI_HOLD.AUD:
+				Offset: 19803663
+				Length: 11295
+			^Content/d2k/v2/GAMESFX/OI_LAUNC.AUD:
+				Offset: 19814958
+				Length: 20437
+			^Content/d2k/v2/GAMESFX/OI_MAP1A.AUD:
+				Offset: 19835395
+				Length: 27739
+			^Content/d2k/v2/GAMESFX/HI_LAUNC.AUD:
+				Offset: 19863134
+				Length: 22200
+			^Content/d2k/v2/GAMESFX/H_ICONF1.AUD:
+				Offset: 19885334
+				Length: 9620
+			^Content/d2k/v2/GAMESFX/H_ICONF2.AUD:
+				Offset: 19894954
+				Length: 13368
+			^Content/d2k/v2/GAMESFX/H_ICONF3.AUD:
+				Offset: 19908322
+				Length: 15612
+			^Content/d2k/v2/GAMESFX/H_ISEL1.AUD:
+				Offset: 19923934
+				Length: 8279
+			^Content/d2k/v2/GAMESFX/A_ISEL2.AUD:
+				Offset: 19932213
+				Length: 11383
+			^Content/d2k/v2/GAMESFX/AI_RUN.AUD:
+				Offset: 19943596
+				Length: 18511
+			^Content/d2k/v2/GAMESFX/HI_SILOS.AUD:
+				Offset: 19962107
+				Length: 14244
+			^Content/d2k/v2/GAMESFX/HI_MAP1A.AUD:
+				Offset: 19976351
+				Length: 24075
+			^Content/d2k/v2/GAMESFX/HI_MAP1B.AUD:
+				Offset: 20000426
+				Length: 26716
+			^Content/d2k/v2/GAMESFX/HI_MAP1C.AUD:
+				Offset: 20027142
+				Length: 21716
+			^Content/d2k/v2/GAMESFX/HI_MAP2A.AUD:
+				Offset: 20048858
+				Length: 32417
+			^Content/d2k/v2/GAMESFX/HI_MAP2B.AUD:
+				Offset: 20081275
+				Length: 33724
+			^Content/d2k/v2/GAMESFX/HI_MAP2C.AUD:
+				Offset: 20114999
+				Length: 21828
+			^Content/d2k/v2/GAMESFX/HI_MAP3A.AUD:
+				Offset: 20136827
+				Length: 30404
+			^Content/d2k/v2/GAMESFX/O_ISEL3.AUD:
+				Offset: 20167231
+				Length: 9862
+			^Content/d2k/v2/GAMESFX/O_SCONF1.AUD:
+				Offset: 20177093
+				Length: 18149
+			^Content/d2k/v2/GAMESFX/OI_2MIN.AUD:
+				Offset: 20195242
+				Length: 14697
+			^Content/d2k/v2/GAMESFX/OI_3MIN.AUD:
+				Offset: 20209939
+				Length: 17316
+			^Content/d2k/v2/GAMESFX/OI_4MIN.AUD:
+				Offset: 20227255
+				Length: 14869
+			^Content/d2k/v2/GAMESFX/OI_5MIN.AUD:
+				Offset: 20242124
+				Length: 29873
+			^Content/d2k/v2/GAMESFX/OI_ABORT.AUD:
+				Offset: 20271997
+				Length: 16335
+			^Content/d2k/v2/GAMESFX/OI_ATACK.AUD:
+				Offset: 20288332
+				Length: 20565
+			^Content/d2k/v2/GAMESFX/OI_BDRDY.AUD:
+				Offset: 20308897
+				Length: 25497
+			^Content/d2k/v2/GAMESFX/HI_SELL.AUD:
+				Offset: 20334394
+				Length: 17142
+			^Content/d2k/v2/GAMESFX/OI_DPLOY.AUD:
+				Offset: 20351536
+				Length: 20120
+			^Content/d2k/v2/GAMESFX/AI_PLACE.AUD:
+				Offset: 20371656
+				Length: 29921
+			^Content/d2k/v2/GAMESFX/OI_GANEW.AUD:
+				Offset: 20401577
+				Length: 14467
+			^Content/d2k/v2/GAMESFX/OI_GLOAD.AUD:
+				Offset: 20416044
+				Length: 10906
+			^Content/d2k/v2/GAMESFX/AI_MWIN.AUD:
+				Offset: 20426950
+				Length: 25959
+			^Content/d2k/v2/GAMESFX/AI_NEWOP.AUD:
+				Offset: 20452909
+				Length: 34175
+			^Content/d2k/v2/GAMESFX/AI_NROOM.AUD:
+				Offset: 20487084
+				Length: 30124
+			^Content/d2k/v2/GAMESFX/AI_ORDER.AUD:
+				Offset: 20517208
+				Length: 21881
+			^Content/d2k/v2/GAMESFX/AI_UNRDY.AUD:
+				Offset: 20539089
+				Length: 20567
+			^Content/d2k/v2/SOUND.RS:
+				Offset: 20559656
+				Length: 1929247

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -206,7 +206,7 @@ ModContent:
 	Packages:
 		base: Base Game Files
 			TestFiles: ^Content/d2k/v2/BLOXBASE.R8, ^Content/d2k/v2/BLOXBAT.R8, ^Content/d2k/v2/BLOXBGBS.R8, ^Content/d2k/v2/BLOXICE.R8, ^Content/d2k/v2/BLOXTREE.R8, ^Content/d2k/v2/BLOXWAST.R8, ^Content/d2k/v2/SOUND.RS, ^Content/d2k/v2/PALETTE.BIN, ^Content/d2k/v2/FONT.BIN,  ^Content/d2k/v2/FONTCOL.FNT,  ^Content/d2k/v2/FONTCOL.FPL
-			Sources: d2k, d2k-linux, gruntmods
+			Sources: d2k-a, d2k-a-linux, d2k-b, d2k-b-linux, gruntmods
 			Required: true
 			Download: basefiles
 		patch: 1.06 Patch Content
@@ -216,13 +216,14 @@ ModContent:
 			Download: patch106
 		music: Game Music
 			TestFiles: ^Content/d2k/v2/Music/AMBUSH.AUD
-			Sources: d2k, d2k-linux, gruntmods
+			Sources: d2k-a, d2k-a-linux, d2k-b, d2k-b-linux, gruntmods
 		movies: Campaign Briefings
 			TestFiles: ^Content/d2k/v2/Movies/A_BR01_E.VQA
-			Sources: d2k, d2k-linux
+			Sources: d2k-a, d2k-a-linux, d2k-b, d2k-b-linux
 	Downloads:
 		d2k|installer/downloads.yaml
 	Sources:
-		d2k|installer/d2k.yaml
+		d2k|installer/d2ka.yaml
+		d2k|installer/d2kb.yaml
 		d2k|installer/downloads.yaml
 		d2k|installer/gruntmods.yaml


### PR DESCRIPTION
Closes #12033.  This sets up the metadata that @Sora93 confirmed to work as a new disc type.
