### PR TITLE
Split a WithAimAnimation from WithAttackAnimation and make both upgradable

### DIFF
--- a/OpenRA.Mods.Common/Lint/CheckAnimations.cs
+++ b/OpenRA.Mods.Common/Lint/CheckAnimations.cs
@@ -1,0 +1,37 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using OpenRA.Mods.Common.Traits.Render;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Lint
+{
+	class CheckAnimations : ILintRulesPass
+	{
+		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		{
+			foreach (var actorInfo in rules.Actors)
+			{
+				var attackAnims = actorInfo.Value.TraitInfos<WithAttackAnimationInfo>().ToList();
+				var aimAnims = actorInfo.Value.TraitInfos<WithAimAnimationInfo>().ToList();
+				if (!attackAnims.Any())
+					continue;
+				if (!aimAnims.Any())
+					continue;
+
+				emitWarning("Actor type {0} defines both WithAttackAnimation and WithAimAnimation, which must not be enabled at the same time!"
+					.F(actorInfo.Key));
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -420,6 +420,7 @@
     <Compile Include="Traits\Render\TimedUpgradeBar.cs" />
     <Compile Include="Traits\Render\WithSpriteBarrel.cs" />
     <Compile Include="Traits\Render\WithBuildingExplosion.cs" />
+    <Compile Include="Traits\Render\WithAimAnimation.cs" />
     <Compile Include="Traits\Render\WithAttackAnimation.cs" />
     <Compile Include="Traits\Render\WithAttackOverlay.cs" />
     <Compile Include="Traits\Render\WithMoveAnimation.cs" />
@@ -705,6 +706,7 @@
     <Compile Include="Traits\World\PaletteFromPlayerPaletteWithAlpha.cs" />
     <Compile Include="Traits\Modifiers\HiddenUnderShroud.cs" />
     <Compile Include="Lint\CheckDefaultVisibility.cs" />
+    <Compile Include="Lint\CheckAnimations.cs" />
     <Compile Include="Traits\Modifiers\AlwaysVisible.cs" />
     <Compile Include="Traits\AffectsShroud.cs" />
     <Compile Include="Traits\CreatesShroud.cs" />

--- a/OpenRA.Mods.Common/Traits/Render/WithAimAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAimAnimation.cs
@@ -1,0 +1,88 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits.Render
+{
+	public class WithAimAnimationInfo : UpgradableTraitInfo, Requires<WithSpriteBodyInfo>, Requires<ArmamentInfo>, Requires<AttackBaseInfo>
+	{
+		[Desc("Armament name")]
+		public readonly string Armament = "primary";
+
+		[Desc("Displayed while targeting.")]
+		[SequenceReference] public readonly string AimSequence = null;
+
+		[Desc("Shown while reloading.")]
+		[SequenceReference(null, true)] public readonly string ReloadPrefix = null;
+
+		public override object Create(ActorInitializer init) { return new WithAimAnimation(init, this); }
+	}
+
+	public class WithAimAnimation : UpgradableTrait<WithAimAnimationInfo>, ITick, INotifyCreated
+	{
+		readonly AttackBase attack;
+		readonly Armament armament;
+		readonly WithSpriteBody[] wsbs;
+
+		public WithAimAnimation(ActorInitializer init, WithAimAnimationInfo info)
+			: base(info)
+		{
+			attack = init.Self.Trait<AttackBase>();
+			armament = init.Self.TraitsImplementing<Armament>()
+				.Single(a => a.Info.Name == info.Armament);
+			wsbs = init.Self.TraitsImplementing<WithSpriteBody>().ToArray();
+		}
+
+		void INotifyCreated.Created(Actor self)
+		{
+			// The way this trait currently works will cancel/override attack animations early,
+			// so prevent modders from enabling both at the same time by throwing an exception.
+			// If they enable one of them later via upgrade, they do so at their own risk.
+			// TODO: Refactor WithSpriteBody and its modifiers in a way that makes WithAimAnimation and WithAttackAnimation compatible with each other.
+			var waa = self.TraitsImplementing<WithAttackAnimation>();
+			if (!IsTraitDisabled && waa.Any(Exts.IsTraitEnabled))
+				throw new YamlException("Actor {0}: WithAimAnimation and WithAttackAnimation must not be enabled at the same time.".F(self.Info.Name));
+		}
+
+		void PlayAimAnimation()
+		{
+			if (string.IsNullOrEmpty(Info.AimSequence) && string.IsNullOrEmpty(Info.ReloadPrefix))
+				return;
+
+			foreach (var wsb in wsbs)
+			{
+				if (wsb.IsTraitDisabled)
+					continue;
+
+				var sequence = wsb.Info.Sequence;
+				if (!string.IsNullOrEmpty(Info.AimSequence) && attack.IsAttacking)
+					sequence = Info.AimSequence;
+
+				var prefix = (armament.IsReloading && !string.IsNullOrEmpty(Info.ReloadPrefix)) ? Info.ReloadPrefix : "";
+
+				if (!string.IsNullOrEmpty(prefix) && sequence != (prefix + sequence))
+					sequence = prefix + sequence;
+
+				wsb.DefaultAnimation.ReplaceAnim(sequence);
+			}
+		}
+
+		void ITick.Tick(Actor self)
+		{
+			if (IsTraitDisabled)
+				return;
+
+			PlayAimAnimation();
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -416,6 +416,17 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// Split WithAimAnimation from WithAttackAnimation.
+				if (engineVersion < 20161016)
+				{
+					if (node.Key == "WithAttackAnimation")
+					{
+						var aimSequence = node.Value.Nodes.FirstOrDefault(n => n.Key == "AimSequence");
+						if (aimSequence != null)
+							node.Key = "WithAimAnimation";
+					}
+				}
+
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -25,7 +25,7 @@ V2RL:
 	AutoTarget:
 	Explodes:
 		Weapon: V2Explode
-	WithAttackAnimation:
+	WithAimAnimation:
 		AimSequence: aim
 		ReloadPrefix: empty-
 	ProducibleWithLevel:


### PR DESCRIPTION
While the `With*SpriteBody`/`With*Animation` interaction might need a refactor to prevent or at least reduce conflicts between multiple animations, for now making `WithAttackAnimation` upgradable + able to handle multiple sprite bodies should be good enough for most mods.

Additionally, I split the aiming animation stuff off to its own trait, because these two aspects didn't really work properly together anyway. This also made the code cleaner and more straightforward.

A nice side-effect of the split is that `WithAttackAnimation` now only plays when the specified armament is used for attacking.

Last but not least, due to their current incompatibility with each other, a lint warning and a yaml exception when both are enabled at actor creation have been added to prevent modders from using them at the same time.

Upgrade rules, lint check and yaml exception have all been tested and worked when I tested them.

Closes #11884 (assuming #11886 is merged before this).
