### PR TITLE
Move production icon sequence from Tooltip to Buildable

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildable.cs
@@ -34,6 +34,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Force a specific faction variant, overriding the faction of the producing actor.")]
 		public readonly string ForceFaction = null;
 
+		[Desc("Sequence of the actor that contains the icon.")]
+		[SequenceReference] public readonly string Icon = "icon";
+
 		[Desc("Palette used for the production icon.")]
 		[PaletteReference] public readonly string IconPalette = "chrome";
 

--- a/OpenRA.Mods.Common/Traits/Tooltip.cs
+++ b/OpenRA.Mods.Common/Traits/Tooltip.cs
@@ -42,9 +42,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Show the actor's owner and their faction flag")]
 		public readonly bool ShowOwnerRow = true;
 
-		[Desc("Sequence of the actor that contains the cameo.")]
-		public readonly string Icon = "icon";
-
 		public override object Create(ActorInitializer init) { return new Tooltip(init.Self, this); }
 
 		public string TooltipForPlayerStance(Stance stance)

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -400,8 +400,8 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				// Move production description from Tooltip to Buildable
 				if (engineVersion < 20161016)
 				{
-					var tooltipChild = node.Value.Nodes.FirstOrDefault(n => n.Key == "Tooltip");
-					if (tooltipChild != null || (tooltipChild = node.Value.Nodes.FirstOrDefault(n => n.Key == "DisguiseToolTip")) != null)
+					var tooltipChild = node.Value.Nodes.FirstOrDefault(n => n.Key == "Tooltip" || n.Key == "DisguiseToolTip");
+					if (tooltipChild != null)
 					{
 						var descNode = tooltipChild.Value.Nodes.FirstOrDefault(n => n.Key == "Description");
 						if (descNode != null)
@@ -412,6 +412,25 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 							buildableNode.Value.Nodes.Add(descNode);
 							tooltipChild.Value.Nodes.Remove(descNode);
+						}
+					}
+				}
+
+				// Move production icon sequence from Tooltip to Buildable
+				if (engineVersion < 20161022)
+				{
+					var tooltipChild = node.Value.Nodes.FirstOrDefault(n => n.Key == "Tooltip" || n.Key == "DisguiseToolTip");
+					if (tooltipChild != null)
+					{
+						var iconNode = tooltipChild.Value.Nodes.FirstOrDefault(n => n.Key == "Icon");
+						if (iconNode != null)
+						{
+							var buildableNode = node.Value.Nodes.FirstOrDefault(n => n.Key == "Buildable");
+							if (buildableNode == null)
+								node.Value.Nodes.Add(buildableNode = new MiniYamlNode("Buildable", ""));
+
+							buildableNode.Value.Nodes.Add(iconNode);
+							tooltipChild.Value.Nodes.Remove(iconNode);
 						}
 					}
 				}

--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -91,8 +91,8 @@ namespace OpenRA.Mods.Common.Widgets
 
 				var rsi = actor.TraitInfo<RenderSpritesInfo>();
 				var icon = new Animation(world, rsi.GetImage(actor, world.Map.Rules.Sequences, faction));
-				icon.Play(actor.TraitInfo<TooltipInfo>().Icon);
 				var bi = actor.TraitInfo<BuildableInfo>();
+				icon.Play(bi.Icon);
 				var location = new float2(RenderBounds.Location) + new float2(queue.i * (IconWidth + IconSpacing), 0);
 				WidgetUtils.DrawSHPCentered(icon.Image, location + 0.5f * iconSize, worldRenderer.Palette(bi.IconPalette), 0.5f);
 

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -338,9 +338,8 @@ namespace OpenRA.Mods.Common.Widgets
 
 				var rsi = item.TraitInfo<RenderSpritesInfo>();
 				var icon = new Animation(World, rsi.GetImage(item, World.Map.Rules.Sequences, faction));
-				icon.Play(item.TraitInfo<TooltipInfo>().Icon);
-
 				var bi = item.TraitInfo<BuildableInfo>();
+				icon.Play(bi.Icon);
 
 				var pi = new ProductionIcon()
 				{

--- a/mods/cnc/rules/civilian.yaml
+++ b/mods/cnc/rules/civilian.yaml
@@ -353,7 +353,6 @@ BARB:
 		Type: Light
 	Tooltip:
 		Name: Barbwire Fence
-		Icon: barbicnh
 	LineBuild:
 		NodeTypes: barbwire
 	LineBuildNode:
@@ -367,7 +366,6 @@ WOOD:
 		Type: Wood
 	Tooltip:
 		Name: Wooden Fence
-		Icon: woodicnh
 	LineBuild:
 		NodeTypes: woodfence
 	LineBuildNode:

--- a/mods/cnc/rules/husks.yaml
+++ b/mods/cnc/rules/husks.yaml
@@ -2,7 +2,6 @@ MCV.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Mobile Construction Vehicle (Destroyed)
-		Icon: mcvicnh
 	TransformOnCapture:
 		IntoActor: mcv
 	RenderSprites:
@@ -12,7 +11,6 @@ HARV.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Harvester (Destroyed)
-		Icon: harvicnh
 	TransformOnCapture:
 		IntoActor: harv
 	RenderSprites:
@@ -22,7 +20,6 @@ APC.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: APC (Destroyed)
-		Icon: apcicnh
 	TransformOnCapture:
 		IntoActor: apc
 	RenderSprites:
@@ -32,7 +29,6 @@ FTNK.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Flame Tank (Destroyed)
-		Icon: ftnkicnh
 	TransformOnCapture:
 		IntoActor: ftnk
 	RenderSprites:
@@ -42,7 +38,6 @@ ARTY.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Artillery (Destroyed)
-		Icon: artyicnh
 	TransformOnCapture:
 		IntoActor: arty
 	RenderSprites:
@@ -52,7 +47,6 @@ BGGY.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Nod Buggy (Destroyed)
-		Icon: bggyicnh
 	TransformOnCapture:
 		IntoActor: bggy
 	RenderSprites:
@@ -62,7 +56,6 @@ BIKE.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Recon Bike (Destroyed)
-		Icon: bikeicnh
 	TransformOnCapture:
 		IntoActor: bike
 	RenderSprites:
@@ -72,7 +65,6 @@ JEEP.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Hum-Vee (Destroyed)
-		Icon: jeepicnh
 	TransformOnCapture:
 		IntoActor: jeep
 	RenderSprites:
@@ -82,7 +74,6 @@ LTNK.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Light Tank (Destroyed)
-		Icon: ltnkicnh
 	ThrowsParticle@turret:
 		Anim: turret
 	TransformOnCapture:
@@ -94,7 +85,6 @@ MTNK.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Medium Tank (Destroyed)
-		Icon: mtnkicnh
 	ThrowsParticle@turret:
 		Anim: turret
 	TransformOnCapture:
@@ -106,7 +96,6 @@ HTNK.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Mammoth Tank (Destroyed)
-		Icon: htnkicnh
 	ThrowsParticle@turret:
 		Anim: turret
 	TransformOnCapture:
@@ -118,7 +107,6 @@ MSAM.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Rocket Launcher (Destroyed)
-		Icon: msamicnh
 	ThrowsParticle@turret:
 		Anim: turret
 	TransformOnCapture:
@@ -130,7 +118,6 @@ MLRS.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Mobile S.A.M. (Destroyed)
-		Icon: mlrsicnh
 	ThrowsParticle@turret:
 		Anim: turret
 	TransformOnCapture:
@@ -142,7 +129,6 @@ STNK.Husk:
 	Inherits: ^Husk
 	Tooltip:
 		Name: Stealth Tank (Destroyed)
-		Icon: stnkicnh
 	TransformOnCapture:
 		IntoActor: stnk
 	RenderSprites:

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -75,8 +75,6 @@ BIO:
 	SpawnActorOnDeath:
 		Actor: BIO.Husk
 	ProvidesPrerequisite@buildingname:
-	Buildable:
-		Description: Grants Tiberium immunity to infantry.
 
 BIO.Husk:
 	Inherits: ^CivBuildingHusk

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -549,8 +549,6 @@
 		OpeningSound: cashturn.aud
 		ClosingSound: cashturn.aud
 		TerrainTypes: Clear, Road
-	Buildable:
-		Description: Automated barrier that opens for allied units.
 
 ^TechBuilding:
 	Inherits: ^BasicBuilding

--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -6,8 +6,8 @@ FPWR:
 		Queue: Defense
 		Prerequisites: ~structures.france, ~techlevel.infonly
 		Description: Looks like a Power Plant.
-	Tooltip:
 		Icon: fake-icon
+	Tooltip:
 		Name: Fake Power Plant
 		GenericName: Power Plant
 		GenericVisibility: Enemy
@@ -33,8 +33,8 @@ SYRF:
 		Queue: Defense
 		Prerequisites: ~structures.france, ~techlevel.medium
 		Description: Looks like a Shipyard.
-	Tooltip:
 		Icon: fake-icon
+	Tooltip:
 		Name: Fake Shipyard
 		GenericName: Shipyard
 		GenericVisibility: Enemy
@@ -67,8 +67,8 @@ SPEF:
 		Queue: Defense
 		Prerequisites: ~disabled
 		Description: Looks like a Sub Pen.
-	Tooltip:
 		Icon: fake-icon
+	Tooltip:
 		Name: Fake Sub Pen
 		GenericName: Sub Pen
 		GenericVisibility: Enemy
@@ -97,8 +97,8 @@ WEAF:
 		Prerequisites: ~structures.france, ~techlevel.medium
 		Queue: Defense
 		Description: Looks like a War Factory.
-	Tooltip:
 		Icon: fake-icon
+	Tooltip:
 		Name: Fake War Factory
 		GenericName: War Factory
 		GenericVisibility: Enemy
@@ -122,7 +122,6 @@ DOMF:
 	Inherits: ^FakeBuilding
 	Inherits@infiltrate: ^InfiltratableFake
 	Tooltip:
-		Icon: fake-icon
 		Name: Fake Radar Dome
 		GenericName: Radar Dome
 		GenericVisibility: Enemy
@@ -132,6 +131,7 @@ DOMF:
 		Queue: Defense
 		Prerequisites: ~structures.france, ~techlevel.medium
 		Description: Looks like a Radar Dome.
+		Icon: fake-icon
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -154,8 +154,8 @@ FIXF:
 		Queue: Defense
 		Prerequisites: ~structures.france, ~techlevel.medium
 		Description: Looks like a Service Depot.
-	Tooltip:
 		Icon: fake-icon
+	Tooltip:
 		Name: Fake Service Depot
 		GenericName: Service Depot
 		GenericVisibility: Enemy
@@ -182,8 +182,8 @@ FAPW:
 		Queue: Defense
 		Prerequisites: ~structures.france, ~techlevel.medium
 		Description: Looks like an Advanced Power Plant.
-	Tooltip:
 		Icon: fake-icon
+	Tooltip:
 		Name: Fake Advanced Power Plant
 		GenericName: Advanced Power Plant
 		GenericVisibility: Enemy
@@ -208,7 +208,6 @@ FAPW:
 ATEF:
 	Inherits: ^FakeBuilding
 	Tooltip:
-		Icon: fake-icon
 		Name: Fake Allied Tech Center
 		GenericName: Allied Tech Center
 		GenericVisibility: Enemy
@@ -218,6 +217,7 @@ ATEF:
 		Queue: Defense
 		Prerequisites: ~structures.france, ~techlevel.high
 		Description: Looks like an Allied Tech Center.
+		Icon: fake-icon
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -236,7 +236,6 @@ ATEF:
 PDOF:
 	Inherits: ^FakeBuilding
 	Tooltip:
-		Icon: fake-icon
 		Name: Fake Chronosphere
 		GenericName: Chronosphere
 		GenericVisibility: Enemy
@@ -247,6 +246,7 @@ PDOF:
 		Prerequisites: ~structures.france, ~techlevel.unrestricted
 		BuildLimit: 1
 		Description: Looks like a Chronosphere.
+		Icon: fake-icon
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -268,7 +268,6 @@ PDOF:
 MSLF:
 	Inherits: ^FakeBuilding
 	Tooltip:
-		Icon: fake-icon
 		Name: Fake Missile Silo
 		GenericName: Missile Silo
 		GenericVisibility: Enemy
@@ -279,6 +278,7 @@ MSLF:
 		Prerequisites: ~structures.france, ~techlevel.unrestricted
 		BuildLimit: 1
 		Description: Looks like a Missile Silo.
+		Icon: fake-icon
 	Building:
 		Footprint: xx
 		Dimensions: 2,1
@@ -302,8 +302,8 @@ FACF:
 		Queue: Defense
 		Prerequisites: ~structures.france, ~techlevel.medium
 		Description: Looks like a Construction Yard.
-	Tooltip:
 		Icon: fake-icon
+	Tooltip:
 		Name: Fake Construction Yard
 		GenericName: Construction Yard
 		GenericVisibility: Enemy


### PR DESCRIPTION
Makes more sense, and saves us some `Tooltip` look-ups which also allows to make the latter upgradable more easily and regression-risk-free.

All yaml changes were done via upgrade rule, but because _all TD husk and barb wire/wood fence icon definitions were bogus_ (never caught due to lack of `SequenceReference`), only the removals were staged for the C&C mod.

Prerequisite for #11984.
