### PR TITLE
Fix a desync in GpsDot.IsTargetableBy.

### DIFF
--- a/OpenRA.Mods.RA/Effects/GpsDot.cs
+++ b/OpenRA.Mods.RA/Effects/GpsDot.cs
@@ -111,7 +111,7 @@ namespace OpenRA.Mods.RA.Effects
 
 			shouldRenderIndicator = !f2.HasRenderables;
 
-			return f2.Visible && !f2.Shrouded && !toPlayer.World.ShroudObscures(self.CenterPosition);
+			return f2.Visible && !f2.Shrouded && toPlayer.Shroud.IsExplored(self.CenterPosition);
 		}
 
 		FrozenActor FrozenActorForPlayer(Player player)


### PR DESCRIPTION
Fixes #12253, which was introduced by #11901 (Can't indirectly use `RenderPlayer` from synced code! My bad...).  The desync will occur whenever somebody has GPS and somebody else builds a gap generator or is unlucky enough to pick up a hide-map crate and then tries to target the affected building.

This is a critical priority fix (many online RA games are desyncing because of it, hooray for our super-effective playtests!), so if this is still sitting unreviewed by tomorrow night I will merge it and push a new release myself.
