### PR TITLE
Fix player joins resetting the server timestep.

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -821,8 +821,8 @@ namespace OpenRA.Mods.Common.Server
 				if (o.Id == "gamespeed")
 				{
 					var speed = server.ModData.Manifest.Get<GameSpeeds>().Speeds[value];
-					server.LobbyInfo.GlobalSettings.Timestep = speed.Timestep;
-					server.LobbyInfo.GlobalSettings.OrderLatency = speed.OrderLatency;
+					gs.Timestep = speed.Timestep;
+					gs.OrderLatency = speed.OrderLatency;
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #12243.  This is another critical priority fix that I'm going to include in the `release-20161019` hotfix release tomorrow.
