### PR TITLE
Several internal interface cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,9 @@ check-scripts:
 
 check: utility mods
 	@echo
+	@echo "Checking for explicit interface violations..."
+	@mono --debug OpenRA.Utility.exe all --check-explicit-interfaces
+	@echo
 	@echo "Checking for code style violations in OpenRA.Game..."
 	@mono --debug OpenRA.Utility.exe ra --check-code-style OpenRA.Game
 	@echo
@@ -219,9 +222,6 @@ check: utility mods
 	@echo
 	@echo "Checking for code style violations in OpenRA.Test..."
 	@mono --debug OpenRA.Utility.exe ra --check-code-style OpenRA.Test
-	@echo
-	@echo "Checking for explicit interface violations..."
-	@mono --debug OpenRA.Utility.exe all --check-explicit-interfaces
 	@echo
 	@echo "Checking for code style violations in OpenRA.Server..."
 	@mono --debug OpenRA.Utility.exe ra --check-code-style OpenRA.Server

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -143,7 +143,6 @@ namespace OpenRA.Traits
 	public interface INotifyCreated { void Created(Actor self); }
 	public interface INotifyAddedToWorld { void AddedToWorld(Actor self); }
 	public interface INotifyRemovedFromWorld { void RemovedFromWorld(Actor self); }
-	public interface INotifySold { void Selling(Actor self); void Sold(Actor self); }
 	public interface INotifyDamage { void Damaged(Actor self, AttackInfo e); }
 	public interface INotifyDamageStateChanged { void DamageStateChanged(Actor self, AttackInfo e); }
 	public interface INotifyRepair { void Repairing(Actor self, Actor target); }

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -66,20 +66,6 @@ namespace OpenRA.Traits
 		}
 	}
 
-	[Flags]
-	public enum ImpactType
-	{
-		None = 0,
-		Ground = 1,
-		GroundHit = 2,
-		Water = 4,
-		WaterHit = 8,
-		Air = 16,
-		AirHit = 32,
-		TargetTerrain = 64,
-		TargetHit = 128
-	}
-
 	public class AttackInfo
 	{
 		public Damage Damage;

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -319,8 +319,6 @@ namespace OpenRA.Traits
 		bool IsBlocking(Actor self, CPos cell);
 	}
 
-	public interface INotifyBlockingMove { void OnNotifyBlockingMove(Actor self, Actor blocking); }
-
 	public interface IFacing
 	{
 		int TurnSpeed { get; }

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -131,20 +131,11 @@ namespace OpenRA.Traits
 	public interface INotifyRemovedFromWorld { void RemovedFromWorld(Actor self); }
 	public interface INotifyDamage { void Damaged(Actor self, AttackInfo e); }
 	public interface INotifyDamageStateChanged { void DamageStateChanged(Actor self, AttackInfo e); }
-	public interface INotifyRepair { void Repairing(Actor self, Actor target); }
 	public interface INotifyKilled { void Killed(Actor self, AttackInfo e); }
 	public interface INotifyActorDisposing { void Disposing(Actor self); }
 	public interface INotifyAppliedDamage { void AppliedDamage(Actor self, Actor damaged, AttackInfo e); }
-	public interface INotifyBuildComplete { void BuildingComplete(Actor self); }
-	public interface INotifyBuildingPlaced { void BuildingPlaced(Actor self); }
-	public interface INotifyProduction { void UnitProduced(Actor self, Actor other, CPos exit); }
-	public interface INotifyOtherProduction { void UnitProducedByOther(Actor self, Actor producer, Actor produced); }
-	public interface INotifyDelivery { void IncomingDelivery(Actor self); void Delivered(Actor self); }
 	public interface INotifyOwnerChanged { void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner); }
 	public interface INotifyEffectiveOwnerChanged { void OnEffectiveOwnerChanged(Actor self, Player oldEffectiveOwner, Player newEffectiveOwner); }
-	public interface INotifyCapture { void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner); }
-	public interface INotifyInfiltrated { void Infiltrated(Actor self, Actor infiltrator); }
-	public interface INotifyDiscovered { void OnDiscovered(Actor self, Player discoverer, bool playNotification); }
 
 	public interface ISeedableResource { void Seed(Actor self); }
 
@@ -161,15 +152,7 @@ namespace OpenRA.Traits
 		bool HasVoice(Actor self, string voice);
 	}
 
-	public interface IDemolishableInfo : ITraitInfoInterface { bool IsValidTarget(ActorInfo actorInfo, Actor saboteur); }
-	public interface IDemolishable
-	{
-		void Demolish(Actor self, Actor saboteur);
-		bool IsValidTarget(Actor self, Actor saboteur);
-	}
-
 	public interface IStoreResources { int Capacity { get; } }
-	public interface INotifyDocking { void Docked(Actor self, Actor harvester); void Undocked(Actor self, Actor harvester); }
 
 	public interface IEffectiveOwner
 	{
@@ -311,19 +294,6 @@ namespace OpenRA.Traits
 	}
 
 	public interface IFacingInfo : ITraitInfoInterface { int GetInitialFacing(); }
-
-	[RequireExplicitImplementation]
-	public interface ICrushable
-	{
-		bool CrushableBy(Actor self, Actor crusher, HashSet<string> crushClasses);
-	}
-
-	[RequireExplicitImplementation]
-	public interface INotifyCrushed
-	{
-		void OnCrush(Actor self, Actor crusher, HashSet<string> crushClasses);
-		void WarnCrush(Actor self, Actor crusher, HashSet<string> crushClasses);
-	}
 
 	public interface ITraitInfoInterface { }
 	public interface ITraitInfo : ITraitInfoInterface { object Create(ActorInitializer init); }

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Actor self;
 		public readonly bool SkipMakeAnimation;
 
-		/* shared activity lock: undeploy, sell, capture, etc */
+		// Shared activity lock: undeploy, sell, capture, etc.
 		[Sync] public bool Locked = true;
 
 		public bool Lock()
@@ -181,7 +181,7 @@ namespace OpenRA.Mods.Common.Traits
 			return OccupiedCells().Select(c => self.World.Map.CenterOfCell(c.First));
 		}
 
-		public void Created(Actor self)
+		void INotifyCreated.Created(Actor self)
 		{
 			if (SkipMakeAnimation || !self.Info.HasTraitInfo<WithMakeAnimationInfo>())
 				NotifyBuildingComplete(self);
@@ -199,7 +199,7 @@ namespace OpenRA.Mods.Common.Traits
 				self.World.ScreenMap.Add(self);
 		}
 
-		public void RemovedFromWorld(Actor self)
+		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
 		{
 			self.World.ActorMap.RemoveInfluence(self, this);
 			self.World.ActorMap.RemovePosition(self, this);
@@ -220,7 +220,7 @@ namespace OpenRA.Mods.Common.Traits
 				notify.BuildingComplete(self);
 		}
 
-		public void Selling(Actor self)
+		void INotifySold.Selling(Actor self)
 		{
 			if (Info.RemoveSmudgesOnSell)
 				RemoveSmudges();
@@ -228,9 +228,9 @@ namespace OpenRA.Mods.Common.Traits
 			BuildComplete = false;
 		}
 
-		public void Sold(Actor self) { }
+		void INotifySold.Sold(Actor self) { }
 
-		public void BeforeTransform(Actor self)
+		void INotifyTransform.BeforeTransform(Actor self)
 		{
 			if (Info.RemoveSmudgesOnTransform)
 				RemoveSmudges();
@@ -239,8 +239,8 @@ namespace OpenRA.Mods.Common.Traits
 				Game.Sound.PlayToPlayer(self.Owner, s, self.CenterPosition);
 		}
 
-		public void OnTransform(Actor self) { }
-		public void AfterTransform(Actor self) { }
+		void INotifyTransform.OnTransform(Actor self) { }
+		void INotifyTransform.AfterTransform(Actor self) { }
 
 		public void RemoveSmudges()
 		{

--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.Common.Traits
 				dockedHarv.CancelActivity();
 		}
 
-		public void Tick(Actor self)
+		void ITick.Tick(Actor self)
 		{
 			// Harvester was killed while unloading
 			if (dockedHarv != null && dockedHarv.IsDead)
@@ -128,7 +128,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public void Disposing(Actor self)
+		void INotifyActorDisposing.Disposing(Actor self)
 		{
 			CancelDock(self);
 			foreach (var harv in GetLinkedHarvesters())
@@ -147,7 +147,7 @@ namespace OpenRA.Mods.Common.Traits
 			harv.QueueActivity(new CallFunc(() => harv.Trait<Harvester>().ContinueHarvesting(harv)));
 		}
 
-		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			// Unlink any harvesters
 			foreach (var harv in GetLinkedHarvesters())
@@ -156,7 +156,7 @@ namespace OpenRA.Mods.Common.Traits
 			playerResources = newOwner.PlayerActor.Trait<PlayerResources>();
 		}
 
-		public void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner)
+		void INotifyCapture.OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner)
 		{
 			// Steal any docked harv too
 			if (dockedHarv != null)

--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -168,8 +168,8 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public void Selling(Actor self) { CancelDock(self); }
-		public void Sold(Actor self)
+		void INotifySold.Selling(Actor self) { CancelDock(self); }
+		void INotifySold.Sold(Actor self)
 		{
 			foreach (var harv in GetLinkedHarvesters())
 				harv.Trait.UnlinkProc(harv.Actor, self);

--- a/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 		Actor reservedFor;
 		Aircraft reservedForAircraft;
 
-		public void Tick(Actor self)
+		void ITick.Tick(Actor self)
 		{
 			if (reservedFor == null)
 				return;		/* nothing to do */
@@ -64,13 +64,13 @@ namespace OpenRA.Mods.Common.Traits
 			return res != null && res.reservedForAircraft != null && !res.reservedForAircraft.MayYieldReservation;
 		}
 
-		public void Disposing(Actor self)
+		void INotifyActorDisposing.Disposing(Actor self)
 		{
 			if (reservedForAircraft != null)
 				reservedForAircraft.UnReserve();
 		}
 
-		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			if (reservedForAircraft != null)
 				reservedForAircraft.UnReserve();

--- a/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
@@ -76,9 +76,13 @@ namespace OpenRA.Mods.Common.Traits
 				reservedForAircraft.UnReserve();
 		}
 
-		public void Selling(Actor self) { Sold(self); }
+		void INotifySold.Selling(Actor self)
+		{
+			if (reservedForAircraft != null)
+				reservedForAircraft.UnReserve();
+		}
 
-		public void Sold(Actor self)
+		void INotifySold.Sold(Actor self)
 		{
 			if (reservedForAircraft != null)
 				reservedForAircraft.UnReserve();

--- a/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
@@ -25,12 +25,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ITick.Tick(Actor self)
 		{
+			// Nothing to do.
 			if (reservedFor == null)
-				return;		/* nothing to do */
+				return;
 
 			if (!Target.FromActor(reservedFor).IsValidFor(self))
 			{
-				/* Not likely to arrive now. */
+				// Not likely to arrive now.
 				reservedForAircraft.UnReserve();
 				reservedFor = null;
 				reservedForAircraft = null;
@@ -64,28 +65,17 @@ namespace OpenRA.Mods.Common.Traits
 			return res != null && res.reservedForAircraft != null && !res.reservedForAircraft.MayYieldReservation;
 		}
 
-		void INotifyActorDisposing.Disposing(Actor self)
+		private void UnReserve()
 		{
 			if (reservedForAircraft != null)
 				reservedForAircraft.UnReserve();
 		}
 
-		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
-		{
-			if (reservedForAircraft != null)
-				reservedForAircraft.UnReserve();
-		}
+		void INotifyActorDisposing.Disposing(Actor self) { UnReserve(); }
 
-		void INotifySold.Selling(Actor self)
-		{
-			if (reservedForAircraft != null)
-				reservedForAircraft.UnReserve();
-		}
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner) { UnReserve(); }
 
-		void INotifySold.Sold(Actor self)
-		{
-			if (reservedForAircraft != null)
-				reservedForAircraft.UnReserve();
-		}
+		void INotifySold.Selling(Actor self) { UnReserve(); }
+		void INotifySold.Sold(Actor self) { UnReserve(); }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -422,12 +422,6 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	[RequireExplicitImplementation]
-	public interface INotifyPassengerEntered { void OnPassengerEntered(Actor self, Actor passenger); }
-
-	[RequireExplicitImplementation]
-	public interface INotifyPassengerExited { void OnPassengerExited(Actor self, Actor passenger); }
-
 	public class RuntimeCargoInit : IActorInit<Actor[]>, ISuppressInitExport
 	{
 		[FieldFromYamlKey]

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -356,8 +356,8 @@ namespace OpenRA.Mods.Common.Traits
 			cargo.Clear();
 		}
 
-		public void Selling(Actor self) { }
-		public void Sold(Actor self)
+		void INotifySold.Selling(Actor self) { }
+		void INotifySold.Sold(Actor self)
 		{
 			if (!Info.EjectOnSell || cargo == null)
 				return;

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -124,7 +124,7 @@ namespace OpenRA.Mods.Common.Traits
 			facing = Exts.Lazy(self.TraitOrDefault<IFacing>);
 		}
 
-		public void Created(Actor self)
+		void INotifyCreated.Created(Actor self)
 		{
 			aircraft = self.TraitOrDefault<Aircraft>();
 		}
@@ -320,7 +320,7 @@ namespace OpenRA.Mods.Common.Traits
 				upgradeManager.GrantUpgrade(self, u, p);
 		}
 
-		public void Killed(Actor self, AttackInfo e)
+		void INotifyKilled.Killed(Actor self, AttackInfo e)
 		{
 			if (Info.EjectOnDeath)
 				while (!IsEmpty(self) && CanUnload())
@@ -348,7 +348,7 @@ namespace OpenRA.Mods.Common.Traits
 			cargo.Clear();
 		}
 
-		public void Disposing(Actor self)
+		void INotifyActorDisposing.Disposing(Actor self)
 		{
 			foreach (var c in cargo)
 				c.Dispose();
@@ -377,7 +377,7 @@ namespace OpenRA.Mods.Common.Traits
 			});
 		}
 
-		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			if (cargo == null)
 				return;
@@ -389,7 +389,7 @@ namespace OpenRA.Mods.Common.Traits
 			});
 		}
 
-		public void AddedToWorld(Actor self)
+		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
 			// Force location update to avoid issues when initial spawn is outside map
 			currentCell = self.Location;
@@ -397,7 +397,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		bool initialized;
-		public void Tick(Actor self)
+		void ITick.Tick(Actor self)
 		{
 			// Notify initial cargo load
 			if (!initialized)

--- a/OpenRA.Mods.Common/Traits/EmitInfantryOnSell.cs
+++ b/OpenRA.Mods.Common/Traits/EmitInfantryOnSell.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 			correctFaction = factionsList.Count == 0 || factionsList.Contains(self.Owner.Faction.InternalName);
 		}
 
-		public void Selling(Actor self) { }
+		void INotifySold.Selling(Actor self) { }
 
 		void Emit(Actor self)
 		{
@@ -85,6 +85,6 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public void Sold(Actor self) { Emit(self); }
+		void INotifySold.Sold(Actor self) { Emit(self); }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -78,6 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Mobile mobile;
 		Dictionary<ResourceTypeInfo, int> contents = new Dictionary<ResourceTypeInfo, int>();
 		bool idleSmart = true;
+		int idleDuration;
 
 		[Sync] public Actor OwnerLinkedProc = null;
 		[Sync] public Actor LastLinkedProc = null;
@@ -233,7 +234,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public void OnNotifyBlockingMove(Actor self, Actor blocking)
+		void INotifyBlockingMove.OnNotifyBlockingMove(Actor self, Actor blocking)
 		{
 			// I'm blocking someone else from moving to my location:
 			var act = self.GetCurrentActivity();
@@ -253,7 +254,6 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		int idleDuration;
 		public void TickIdle(Actor self)
 		{
 			// Should we be intelligent while idle?

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -770,7 +770,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange) { return new Follow(self, target, minRange, maxRange); }
 		public Activity MoveTo(Func<List<CPos>> pathFunc) { return new Move(self, pathFunc); }
 
-		public void OnNotifyBlockingMove(Actor self, Actor blocking)
+		void INotifyBlockingMove.OnNotifyBlockingMove(Actor self, Actor blocking)
 		{
 			if (self.IsIdle && self.AppearsFriendlyTo(blocking))
 				Nudge(self, blocking, true);

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -118,7 +118,7 @@ namespace OpenRA.Mods.Common.Traits
 			queue.Clear();
 		}
 
-		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			ClearQueue();
 
@@ -138,13 +138,13 @@ namespace OpenRA.Mods.Common.Traits
 			newOwner.PlayerActor.Trait<TechTree>().Update();
 		}
 
-		public void Killed(Actor killed, AttackInfo e) { if (killed == self) { ClearQueue(); Enabled = false; } }
+		void INotifyKilled.Killed(Actor killed, AttackInfo e) { if (killed == self) { ClearQueue(); Enabled = false; } }
 		void INotifySold.Selling(Actor self) { ClearQueue(); Enabled = false; }
 		void INotifySold.Sold(Actor self) { }
 
-		public void BeforeTransform(Actor self) { ClearQueue(); Enabled = false; }
-		public void OnTransform(Actor self) { }
-		public void AfterTransform(Actor self) { }
+		void INotifyTransform.BeforeTransform(Actor self) { ClearQueue(); Enabled = false; }
+		void INotifyTransform.OnTransform(Actor self) { }
+		void INotifyTransform.AfterTransform(Actor self) { }
 
 		void CacheProducibles(Actor playerActor)
 		{

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -139,8 +139,8 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		public void Killed(Actor killed, AttackInfo e) { if (killed == self) { ClearQueue(); Enabled = false; } }
-		public void Selling(Actor self) { ClearQueue(); Enabled = false; }
-		public void Sold(Actor self) { }
+		void INotifySold.Selling(Actor self) { ClearQueue(); Enabled = false; }
+		void INotifySold.Sold(Actor self) { }
 
 		public void BeforeTransform(Actor self) { ClearQueue(); Enabled = false; }
 		public void OnTransform(Actor self) { }

--- a/OpenRA.Mods.Common/Traits/Render/WithChargeOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithChargeOverlay.cs
@@ -49,13 +49,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 				info.Palette, info.IsPlayerPalette);
 		}
 
-		public void Charging(Actor self, Target target)
+		void INotifyCharging.Charging(Actor self, Target target)
 		{
 			charging = true;
 			overlay.PlayThen(RenderSprites.NormalizeSequence(overlay, self.GetDamageState(), info.Sequence), () => charging = false);
 		}
 
-		public void DamageStateChanged(Actor self, AttackInfo e)
+		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
 		{
 			overlay.ReplaceAnim(RenderSprites.NormalizeSequence(overlay, e.DamageState, info.Sequence));
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithChargeOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithChargeOverlay.cs
@@ -60,8 +60,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 			overlay.ReplaceAnim(RenderSprites.NormalizeSequence(overlay, e.DamageState, info.Sequence));
 		}
 
-		public void Sold(Actor self) { }
-		public void Selling(Actor self)
+		void INotifySold.Sold(Actor self) { }
+		void INotifySold.Selling(Actor self)
 		{
 			charging = false;
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
@@ -71,8 +71,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 					buildComplete = true)));
 		}
 
-		public void Sold(Actor self) { }
-		public void Selling(Actor self)
+		void INotifySold.Sold(Actor self) { }
+		void INotifySold.Selling(Actor self)
 		{
 			buildComplete = false;
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				anim.Animation.PlayThen(info.Sequence, PlayDockingOverlay);
 		}
 
-		public void BuildingComplete(Actor self)
+		void INotifyBuildComplete.BuildingComplete(Actor self)
 		{
 			self.World.AddFrameEndTask(w => w.Add(new DelayedAction(120, () =>
 					buildComplete = true)));
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			buildComplete = false;
 		}
 
-		public void Docked(Actor self, Actor harvester) { docked = true; PlayDockingOverlay(); }
-		public void Undocked(Actor self, Actor harvester) { docked = false; }
+		void INotifyDocking.Docked(Actor self, Actor harvester) { docked = true; PlayDockingOverlay(); }
+		void INotifyDocking.Undocked(Actor self, Actor harvester) { docked = false; }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleAnimation.cs
@@ -59,11 +59,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 			buildComplete = true;
 		}
 
-		public void Selling(Actor self)
+		void INotifySold.Selling(Actor self)
 		{
 			buildComplete = false;
 		}
 
-		public void Sold(Actor self) { }
+		void INotifySold.Sold(Actor self) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleAnimation.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			ticks = info.Interval;
 		}
 
-		public void Tick(Actor self)
+		void ITick.Tick(Actor self)
 		{
 			if (!buildComplete || IsTraitDisabled)
 				return;
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			}
 		}
 
-		public void BuildingComplete(Actor self)
+		void INotifyBuildComplete.BuildingComplete(Actor self)
 		{
 			buildComplete = true;
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -105,8 +105,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 			buildComplete = true;
 		}
 
-		public void Sold(Actor self) { }
-		public void Selling(Actor self)
+		void INotifySold.Sold(Actor self) { }
+		void INotifySold.Selling(Actor self)
 		{
 			buildComplete = false;
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			rs.Add(anim, info.Palette, info.IsPlayerPalette);
 		}
 
-		public void BuildingComplete(Actor self)
+		void INotifyBuildComplete.BuildingComplete(Actor self)
 		{
 			buildComplete = true;
 		}
@@ -111,15 +111,15 @@ namespace OpenRA.Mods.Common.Traits.Render
 			buildComplete = false;
 		}
 
-		public void BeforeTransform(Actor self)
+		void INotifyTransform.BeforeTransform(Actor self)
 		{
 			buildComplete = false;
 		}
 
-		public void OnTransform(Actor self) { }
-		public void AfterTransform(Actor self) { }
+		void INotifyTransform.OnTransform(Actor self) { }
+		void INotifyTransform.AfterTransform(Actor self) { }
 
-		public void DamageStateChanged(Actor self, AttackInfo e)
+		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
 		{
 			overlay.ReplaceAnim(RenderSprites.NormalizeSequence(overlay, e.DamageState, overlay.CurrentSequence.Name));
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			desiredFrame = door.CurrentSequence.Length - 1;
 		}
 
-		public void Selling(Actor self) { buildComplete = false; }
-		public void Sold(Actor self) { }
+		void INotifySold.Selling(Actor self) { buildComplete = false; }
+		void INotifySold.Sold(Actor self) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
@@ -57,24 +57,24 @@ namespace OpenRA.Mods.Common.Traits.Render
 			renderSprites.Add(new AnimationWithOffset(door, null, () => !buildComplete, offset));
 		}
 
-		public void BuildingComplete(Actor self)
+		void INotifyBuildComplete.BuildingComplete(Actor self)
 		{
 			buildComplete = true;
 		}
 
-		public void Tick(Actor self)
+		void ITick.Tick(Actor self)
 		{
 			if (desiredFrame > 0 && !self.World.ActorMap.GetActorsAt(openExit).Any(a => a != self))
 				desiredFrame = 0;
 		}
 
-		public void DamageStateChanged(Actor self, AttackInfo e)
+		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
 		{
 			if (door.CurrentSequence != null)
 				door.ReplaceAnim(RenderSprites.NormalizeSequence(door, e.DamageState, door.CurrentSequence.Name));
 		}
 
-		public void UnitProduced(Actor self, Actor other, CPos exit)
+		void INotifyProduction.UnitProduced(Actor self, Actor other, CPos exit)
 		{
 			openExit = exit;
 			desiredFrame = door.CurrentSequence.Length - 1;

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
@@ -80,19 +80,19 @@ namespace OpenRA.Mods.Common.Traits.Render
 				throw new InvalidOperationException("Can't find production queues.");
 		}
 
-		public void Created(Actor self)
+		void INotifyCreated.Created(Actor self)
 		{
 			if (buildComplete)
 				SelectQueue(self);
 		}
 
-		public void BuildingComplete(Actor self)
+		void INotifyBuildComplete.BuildingComplete(Actor self)
 		{
 			buildComplete = true;
 			SelectQueue(self);
 		}
 
-		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			self.World.AddFrameEndTask(w => SelectQueue(self));
 		}
@@ -103,7 +103,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			buildComplete = false;
 		}
 
-		public void DamageStateChanged(Actor self, AttackInfo e)
+		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
 		{
 			overlay.ReplaceAnim(RenderSprites.NormalizeSequence(overlay, e.DamageState, overlay.CurrentSequence.Name));
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
@@ -97,8 +97,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 			self.World.AddFrameEndTask(w => SelectQueue(self));
 		}
 
-		public void Sold(Actor self) { }
-		public void Selling(Actor self)
+		void INotifySold.Sold(Actor self) { }
+		void INotifySold.Selling(Actor self)
 		{
 			buildComplete = false;
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithRearmAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRearmAnimation.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				spriteBody.PlayCustomAnimation(self, info.Sequence, () => spriteBody.CancelCustomAnimation(self));
 		}
 
-		public void BuildingComplete(Actor self)
+		void INotifyBuildComplete.BuildingComplete(Actor self)
 		{
 			buildComplete = true;
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithRearmAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRearmAnimation.cs
@@ -47,11 +47,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 			buildComplete = true;
 		}
 
-		public void Selling(Actor self)
+		void INotifySold.Selling(Actor self)
 		{
 			buildComplete = false;
 		}
 
-		public void Sold(Actor self) { }
+		void INotifySold.Sold(Actor self) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairAnimation.cs
@@ -36,13 +36,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 			spriteBody = self.TraitOrDefault<WithSpriteBody>();
 		}
 
-		public void Repairing(Actor self, Actor target)
+		void INotifyRepair.Repairing(Actor self, Actor target)
 		{
 			if (buildComplete && spriteBody != null && !(info.PauseOnLowPower && self.IsDisabled()))
 				spriteBody.PlayCustomAnimation(self, info.Sequence, () => spriteBody.CancelCustomAnimation(self));
 		}
 
-		public void BuildingComplete(Actor self)
+		void INotifyBuildComplete.BuildingComplete(Actor self)
 		{
 			buildComplete = true;
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairAnimation.cs
@@ -47,11 +47,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 			buildComplete = true;
 		}
 
-		public void Selling(Actor self)
+		void INotifySold.Selling(Actor self)
 		{
 			buildComplete = false;
 		}
 
-		public void Sold(Actor self) { }
+		void INotifySold.Sold(Actor self) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			rs.Add(anim, info.Palette, info.IsPlayerPalette);
 		}
 
-		public void BuildingComplete(Actor self)
+		void INotifyBuildComplete.BuildingComplete(Actor self)
 		{
 			self.World.AddFrameEndTask(w => w.Add(new DelayedAction(120, () =>
 				buildComplete = true)));
@@ -71,12 +71,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 			buildComplete = false;
 		}
 
-		public void DamageStateChanged(Actor self, AttackInfo e)
+		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
 		{
 			overlay.ReplaceAnim(RenderSprites.NormalizeSequence(overlay, e.DamageState, overlay.CurrentSequence.Name));
 		}
 
-		public void Repairing(Actor self, Actor host)
+		void INotifyRepair.Repairing(Actor self, Actor host)
 		{
 			visible = true;
 			overlay.PlayThen(overlay.CurrentSequence.Name, () => visible = false);

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
@@ -65,8 +65,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 				buildComplete = true)));
 		}
 
-		public void Sold(Actor self) { }
-		public void Selling(Actor self)
+		void INotifySold.Sold(Actor self) { }
+		void INotifySold.Selling(Actor self)
 		{
 			buildComplete = false;
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithResources.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResources.cs
@@ -50,18 +50,18 @@ namespace OpenRA.Mods.Common.Traits.Render
 			rs.Add(anim);
 		}
 
-		public void BuildingComplete(Actor self)
+		void INotifyBuildComplete.BuildingComplete(Actor self)
 		{
 			buildComplete = true;
 		}
 
-		public void DamageStateChanged(Actor self, AttackInfo e)
+		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
 		{
 			if (anim.Animation.CurrentSequence != null)
 				anim.Animation.ReplaceAnim(wsb.NormalizeSequence(self, info.Sequence));
 		}
 
-		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			playerResources = newOwner.PlayerActor.Trait<PlayerResources>();
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithResources.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResources.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			playerResources = newOwner.PlayerActor.Trait<PlayerResources>();
 		}
 
-		public void Selling(Actor self) { rs.Remove(anim); }
-		public void Sold(Actor self) { }
+		void INotifySold.Selling(Actor self) { rs.Remove(anim); }
+		void INotifySold.Sold(Actor self) { }
 	}
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -43,6 +43,26 @@ namespace OpenRA.Mods.Common.Traits
 		void Sold(Actor self);
 	}
 
+	public interface IDemolishableInfo : ITraitInfoInterface { bool IsValidTarget(ActorInfo actorInfo, Actor saboteur); }
+	public interface IDemolishable
+	{
+		void Demolish(Actor self, Actor saboteur);
+		bool IsValidTarget(Actor self, Actor saboteur);
+	}
+
+	[RequireExplicitImplementation]
+	public interface ICrushable
+	{
+		bool CrushableBy(Actor self, Actor crusher, HashSet<string> crushClasses);
+	}
+
+	[RequireExplicitImplementation]
+	public interface INotifyCrushed
+	{
+		void OnCrush(Actor self, Actor crusher, HashSet<string> crushClasses);
+		void WarnCrush(Actor self, Actor crusher, HashSet<string> crushClasses);
+	}
+
 	[RequireExplicitImplementation]
 	public interface INotifyAttack
 	{
@@ -50,10 +70,20 @@ namespace OpenRA.Mods.Common.Traits
 		void PreparingAttack(Actor self, Target target, Armament a, Barrel barrel);
 	}
 
+	public interface INotifyBuildComplete { void BuildingComplete(Actor self); }
+	public interface INotifyBuildingPlaced { void BuildingPlaced(Actor self); }
+	public interface INotifyRepair { void Repairing(Actor self, Actor target); }
 	public interface INotifyBurstComplete { void FiredBurst(Actor self, Target target, Armament a); }
 	public interface INotifyCharging { void Charging(Actor self, Target target); }
 	public interface INotifyChat { bool OnChat(string from, string message); }
+	public interface INotifyProduction { void UnitProduced(Actor self, Actor other, CPos exit); }
+	public interface INotifyOtherProduction { void UnitProducedByOther(Actor self, Actor producer, Actor produced); }
+	public interface INotifyDelivery { void IncomingDelivery(Actor self); void Delivered(Actor self); }
+	public interface INotifyDocking { void Docked(Actor self, Actor harvester); void Undocked(Actor self, Actor harvester); }
 	public interface INotifyParachuteLanded { void OnLanded(Actor ignore); }
+	public interface INotifyCapture { void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner); }
+	public interface INotifyInfiltrated { void Infiltrated(Actor self, Actor infiltrator); }
+	public interface INotifyDiscovered { void OnDiscovered(Actor self, Player discoverer, bool playNotification); }
 	public interface IRenderActorPreviewInfo : ITraitInfo { IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init); }
 	public interface ICruiseAltitudeInfo : ITraitInfo { WDist GetCruiseAltitude(); }
 

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -50,6 +50,9 @@ namespace OpenRA.Mods.Common.Traits
 	public interface IRenderActorPreviewInfo : ITraitInfo { IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init); }
 	public interface ICruiseAltitudeInfo : ITraitInfo { WDist GetCruiseAltitude(); }
 
+	[RequireExplicitImplementation]
+	public interface INotifyBlockingMove { void OnNotifyBlockingMove(Actor self, Actor blocking); }
+
 	public interface IUpgradable
 	{
 		IEnumerable<string> UpgradeTypes { get; }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -60,6 +60,12 @@ namespace OpenRA.Mods.Common.Traits
 	[RequireExplicitImplementation]
 	public interface INotifyBlockingMove { void OnNotifyBlockingMove(Actor self, Actor blocking); }
 
+	[RequireExplicitImplementation]
+	public interface INotifyPassengerEntered { void OnPassengerEntered(Actor self, Actor passenger); }
+
+	[RequireExplicitImplementation]
+	public interface INotifyPassengerExited { void OnPassengerExited(Actor self, Actor passenger); }
+
 	public interface IUpgradable
 	{
 		IEnumerable<string> UpgradeTypes { get; }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -37,6 +37,13 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[RequireExplicitImplementation]
+	public interface INotifySold
+	{
+		void Selling(Actor self);
+		void Sold(Actor self);
+	}
+
+	[RequireExplicitImplementation]
 	public interface INotifyAttack
 	{
 		void Attacking(Actor self, Target target, Armament a, Barrel barrel);

--- a/OpenRA.Mods.Common/Warheads/Warhead.cs
+++ b/OpenRA.Mods.Common/Warheads/Warhead.cs
@@ -9,12 +9,27 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Warheads
 {
+	[Flags]
+	public enum ImpactType
+	{
+		None = 0,
+		Ground = 1,
+		GroundHit = 2,
+		Water = 4,
+		WaterHit = 8,
+		Air = 16,
+		AirHit = 32,
+		TargetTerrain = 64,
+		TargetHit = 128
+	}
+
 	[Desc("Base warhead class. This can be used to derive other warheads from.")]
 	public abstract class Warhead : IWarhead
 	{
@@ -32,6 +47,7 @@ namespace OpenRA.Mods.Common.Warheads
 
 		[Desc("Delay in ticks before applying the warhead effect.", "0 = instant (old model).")]
 		public readonly int Delay = 0;
+
 		int IWarhead.Delay { get { return Delay; } }
 
 		[Desc("The color used for this warhead's visualization in the world's `WarheadDebugOverlay` trait.")]

--- a/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
@@ -75,8 +75,8 @@ namespace OpenRA.Mods.D2k.Traits.Render
 				buildComplete = true)));
 		}
 
-		public void Sold(Actor self) { }
-		public void Selling(Actor self)
+		void INotifySold.Sold(Actor self) { }
+		void INotifySold.Selling(Actor self)
 		{
 			buildComplete = false;
 		}

--- a/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.D2k.Traits.Render
 				anim.Animation.PlayThen(info.Sequence, PlayDeliveryOverlay);
 		}
 
-		public void BuildingComplete(Actor self)
+		void INotifyBuildComplete.BuildingComplete(Actor self)
 		{
 			self.World.AddFrameEndTask(w => w.Add(new DelayedAction(120, () =>
 				buildComplete = true)));
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.D2k.Traits.Render
 			buildComplete = false;
 		}
 
-		public void IncomingDelivery(Actor self) { delivering = true; PlayDeliveryOverlay(); }
-		public void Delivered(Actor self) { delivering = false; }
+		void INotifyDelivery.IncomingDelivery(Actor self) { delivering = true; PlayDeliveryOverlay(); }
+		void INotifyDelivery.Delivered(Actor self) { delivering = false; }
 	}
 }

--- a/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForDecoration.cs
+++ b/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForDecoration.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForExploration.cs
+++ b/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForExploration.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.RA.Traits

--- a/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForSupportPower.cs
+++ b/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForSupportPower.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.RA.Traits
 			});
 		}
 
-		public void Killed(Actor self, AttackInfo e) { RemoveGps(self); }
+		void INotifyKilled.Killed(Actor self, AttackInfo e) { RemoveGps(self); }
 
 		void INotifySold.Selling(Actor self) { }
 		void INotifySold.Sold(Actor self) { RemoveGps(self); }
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.RA.Traits
 			owner.GpsRemove(self);
 		}
 
-		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			RemoveGps(self);
 			owner = newOwner.PlayerActor.Trait<GpsWatcher>();
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.RA.Traits
 		bool NoActiveRadar { get { return !self.World.ActorsHavingTrait<ProvidesRadar>(r => r.IsActive).Any(a => a.Owner == self.Owner); } }
 		bool wasDisabled;
 
-		public void Tick(Actor self)
+		void ITick.Tick(Actor self)
 		{
 			if (!wasDisabled && (self.IsDisabled() || (info.RequiresActiveRadar && NoActiveRadar)))
 			{

--- a/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
@@ -86,8 +86,8 @@ namespace OpenRA.Mods.RA.Traits
 
 		public void Killed(Actor self, AttackInfo e) { RemoveGps(self); }
 
-		public void Selling(Actor self) { }
-		public void Sold(Actor self) { RemoveGps(self); }
+		void INotifySold.Selling(Actor self) { }
+		void INotifySold.Sold(Actor self) { RemoveGps(self); }
 
 		void RemoveGps(Actor self)
 		{

--- a/make.ps1
+++ b/make.ps1
@@ -164,6 +164,8 @@ elseif ($command -eq "check")
 {
 	if (Test-Path OpenRA.Utility.exe)
 	{
+		echo "Checking for explicit interface violations..."
+		./OpenRA.Utility.exe all --check-explicit-interfaces
 		echo "Checking for code style violations in OpenRA.Platforms.Default..."
 		./OpenRA.Utility.exe cnc --check-code-style OpenRA.Platforms.Default
 		echo "Checking for code style violations in OpenRA.GameMonitor..."
@@ -184,8 +186,6 @@ elseif ($command -eq "check")
 		./OpenRA.Utility.exe cnc --check-code-style OpenRA.Utility
 		echo "Checking for code style violations in OpenRA.Test..."
 		./OpenRA.Utility.exe cnc --check-code-style OpenRA.Test
-		echo "Checking for explicit interface violations..."
-		./OpenRA.Utility.exe all --check-explicit-interfaces
 	}
 	else
 	{


### PR DESCRIPTION
This PR 
- moves the check for explicit interface implementation violation to the start of `make check` so you don't have to wait for other style checks to finish
- moves several trait interfaces with no remaining ties to `Game` to `Mods.Common`
- makes two of the moved interfaces require explicit implementation
- explicitly implements interfaces where possible for the traits I had to touch
- moves warhead `ImpactTypes` to `Warhead`
- performs some additional minor style cleanups

All in all, the numbers of changed files and changed lines look far worse than they really are, because pretty much all of the changes are about moving stuff around or making interfaces explicit and would get caught at compile or `make check` if I messed up somewhere.
