### PR TITLE
Fully support unhardcoded sequences in the voxel render traits

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, Func<WRot> orientation, int facings, PaletteReference p)
 		{
 			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
-			var voxel = VoxelProvider.GetVoxel(image, "idle");
+			var voxel = VoxelProvider.GetVoxel(image, Sequence);
 			yield return new VoxelAnimation(voxel, () => WVec.Zero,
 				() => new[] { body.QuantizeOrientation(orientation(), facings) },
 				() => false, () => 0, ShowShadow);

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelUnloadBody.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelUnloadBody.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.TS.Traits.Render
 			ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, Func<WRot> orientation, int facings, PaletteReference p)
 		{
 			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
-			var voxel = VoxelProvider.GetVoxel(image, "idle");
+			var voxel = VoxelProvider.GetVoxel(image, IdleSequence);
 			yield return new VoxelAnimation(voxel, () => WVec.Zero,
 				() => new[] { body.QuantizeOrientation(orientation(), facings) },
 				() => false, () => 0, ShowShadow);

--- a/OpenRA.Mods.TS/Traits/Render/WithVoxelWalkerBody.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithVoxelWalkerBody.cs
@@ -24,6 +24,8 @@ namespace OpenRA.Mods.TS.Traits.Render
 {
 	public class WithVoxelWalkerBodyInfo : ITraitInfo, IRenderActorPreviewVoxelsInfo,  Requires<RenderVoxelsInfo>, Requires<IMoveInfo>, Requires<IFacingInfo>
 	{
+		public readonly string Sequence = "idle";
+
 		[Desc("The speed of the walker's legs.")]
 		public readonly int TickRate = 5;
 
@@ -34,7 +36,7 @@ namespace OpenRA.Mods.TS.Traits.Render
 		public IEnumerable<VoxelAnimation> RenderPreviewVoxels(
 			ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, Func<WRot> orientation, int facings, PaletteReference p)
 		{
-			var voxel = VoxelProvider.GetVoxel(image, "idle");
+			var voxel = VoxelProvider.GetVoxel(image, Sequence);
 			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
 			var frame = init.Contains<BodyAnimationFrameInit>() ? init.Get<BodyAnimationFrameInit, uint>() : 0;
 
@@ -62,7 +64,7 @@ namespace OpenRA.Mods.TS.Traits.Render
 			var body = self.Trait<BodyOrientation>();
 			var rv = self.Trait<RenderVoxels>();
 
-			var voxel = VoxelProvider.GetVoxel(rv.Image, "idle");
+			var voxel = VoxelProvider.GetVoxel(rv.Image, info.Sequence);
 			frames = voxel.Frames;
 			rv.Add(new VoxelAnimation(voxel, () => WVec.Zero,
 				() => new[] { body.QuantizeOrientation(self, self.Orientation) },


### PR DESCRIPTION
Seems like someone missed unhardcoding the strings in `RenderPreviewVoxels`.
Also unhardcoded the sequence of `WithVoxelWalkerBody`.
