### PR TITLE
More explicit interface cleanups

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -130,7 +130,6 @@ namespace OpenRA.Traits
 	public interface INotifyAddedToWorld { void AddedToWorld(Actor self); }
 	public interface INotifyRemovedFromWorld { void RemovedFromWorld(Actor self); }
 	public interface INotifyDamage { void Damaged(Actor self, AttackInfo e); }
-	public interface INotifyDamageStateChanged { void DamageStateChanged(Actor self, AttackInfo e); }
 	public interface INotifyKilled { void Killed(Actor self, AttackInfo e); }
 	public interface INotifyActorDisposing { void Disposing(Actor self); }
 	public interface INotifyAppliedDamage { void AppliedDamage(Actor self, Actor damaged, AttackInfo e); }

--- a/OpenRA.Mods.Cnc/Traits/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/AttackPopupTurreted.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			return true;
 		}
 
-		public void TickIdle(Actor self)
+		void INotifyIdle.TickIdle(Actor self)
 		{
 			if (state == PopupState.Open && idleTicks++ > info.CloseDelay)
 			{

--- a/OpenRA.Mods.Cnc/Traits/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/AttackPopupTurreted.cs
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		public void BuildingComplete(Actor self)
+		void INotifyBuildComplete.BuildingComplete(Actor self)
 		{
 			if (skippedMakeAnimation)
 			{

--- a/OpenRA.Mods.Cnc/Traits/Render/WithReloadingSpriteTurret.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithReloadingSpriteTurret.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 				ammoSuffix = (initialAmmoStage * reloadStages / ammo).ToString();
 		}
 
-		public override void Tick(Actor self)
+		protected override void Tick(Actor self)
 		{
 			if (Info.AimSequence != null)
 				sequence = Attack.IsAttacking ? Info.AimSequence : Info.Sequence;

--- a/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
+++ b/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
@@ -302,7 +302,7 @@ namespace OpenRA.Mods.Common.Scripting
 			OnCapturedInternal(self);
 		}
 
-		public void Infiltrated(Actor self, Actor infiltrator)
+		void INotifyInfiltrated.Infiltrated(Actor self, Actor infiltrator)
 		{
 			if (world.Disposing)
 				return;

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -139,7 +139,7 @@ namespace OpenRA.Mods.Common.Traits
 			return new WDist(Util.ApplyPercentageModifiers(Weapon.Range.Length, rangeModifiers));
 		}
 
-		public virtual void Created(Actor self)
+		protected virtual void Created(Actor self)
 		{
 			turret = self.TraitsImplementing<Turreted>().FirstOrDefault(t => t.Name == Info.Turret);
 			ammoPool = self.TraitsImplementing<AmmoPool>().FirstOrDefault(la => la.Info.Name == Info.AmmoPoolName);
@@ -147,7 +147,7 @@ namespace OpenRA.Mods.Common.Traits
 			rangeModifiers = self.TraitsImplementing<IRangeModifier>().ToArray().Select(m => m.GetRangeModifier());
 		}
 
-		public virtual void Tick(Actor self)
+		protected virtual void Tick(Actor self)
 		{
 			if (IsTraitDisabled)
 				return;
@@ -166,6 +166,18 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			delayedActions.RemoveAll(a => a.First <= 0);
+		}
+
+		void INotifyCreated.Created(Actor self)
+		{
+			// Split into a protected method to allow subclassing
+			Created(self);
+		}
+
+		void ITick.Tick(Actor self)
+		{
+			// Split into a protected method to allow subclassing
+			Tick(self);
 		}
 
 		protected void ScheduleDelayedAction(int t, Action a)

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -308,7 +308,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public void DamageStateChanged(Actor self, AttackInfo e)
+		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
 		{
 			Do((b, d) => b.UpdateState());
 

--- a/OpenRA.Mods.Common/Traits/ExplosionOnDamageTransition.cs
+++ b/OpenRA.Mods.Common/Traits/ExplosionOnDamageTransition.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 		}
 
-		public void DamageStateChanged(Actor self, AttackInfo e)
+		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
 		{
 			if (!self.IsInWorld)
 				return;

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -111,7 +111,7 @@ namespace OpenRA.Mods.Common.Traits
 				self.QueueActivity(new FindResources(self));
 		}
 
-		public void BuildingComplete(Actor self)
+		void INotifyBuildComplete.BuildingComplete(Actor self)
 		{
 			if (Info.SearchOnCreation)
 				self.QueueActivity(new FindResources(self));

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Traits
 			self.QueueActivity(new CallFunc(() => ChooseNewProc(self, null)));
 		}
 
-		public void Created(Actor self)
+		void INotifyCreated.Created(Actor self)
 		{
 			if (Info.SearchOnCreation)
 				self.QueueActivity(new FindResources(self));
@@ -254,7 +254,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public void TickIdle(Actor self)
+		void INotifyIdle.TickIdle(Actor self)
 		{
 			// Should we be intelligent while idle?
 			if (!idleSmart) return;

--- a/OpenRA.Mods.Common/Traits/Render/WithGateSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithGateSpriteBody.cs
@@ -107,7 +107,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				rb.SetDirty();
 		}
 
-		public void RemovedFromWorld(Actor self)
+		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
 		{
 			UpdateNeighbours(self);
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithGateSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithGateSpriteBody.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	class WithGateSpriteBody : WithSpriteBody, INotifyRemovedFromWorld, INotifyBuildComplete, IWallConnector, ITick
+	class WithGateSpriteBody : WithSpriteBody, INotifyRemovedFromWorld, IWallConnector, ITick
 	{
 		readonly WithGateSpriteBodyInfo gateInfo;
 		readonly Gate gate;
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			UpdateState(self);
 		}
 
-		public override void BuildingComplete(Actor self)
+		protected override void OnBuildComplete(Actor self)
 		{
 			UpdateState(self);
 			UpdateNeighbours(self);

--- a/OpenRA.Mods.Common/Traits/Render/WithGateSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithGateSpriteBody.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return int2.Lerp(0, DefaultAnimation.CurrentSequence.Length - 1, gate.Position, gate.OpenPosition);
 		}
 
-		public override void DamageStateChanged(Actor self, AttackInfo e)
+		protected override void DamageStateChanged(Actor self)
 		{
 			UpdateState(self);
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithSiloAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSiloAnimation.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			playerResources = init.Self.Owner.PlayerActor.Trait<PlayerResources>();
 		}
 
-		public void BuildingComplete(Actor self)
+		void INotifyBuildComplete.BuildingComplete(Actor self)
 		{
 			wsb.DefaultAnimation.PlayFetchIndex(wsb.NormalizeSequence(self, info.Sequence),
 				() => playerResources.ResourceCapacity != 0

--- a/OpenRA.Mods.Common/Traits/Render/WithSiloAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSiloAnimation.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 					: 0);
 		}
 
-		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			playerResources = newOwner.PlayerActor.Trait<PlayerResources>();
 

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -75,10 +75,15 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return RenderSprites.NormalizeSequence(DefaultAnimation, self.GetDamageState(), sequence);
 		}
 
-		// TODO: Get rid of INotifyBuildComplete in favor of using the upgrade system
-		public virtual void BuildingComplete(Actor self)
+		protected virtual void OnBuildComplete(Actor self)
 		{
 			DefaultAnimation.PlayRepeating(NormalizeSequence(self, Info.Sequence));
+		}
+
+		// TODO: Get rid of INotifyBuildComplete in favor of using the upgrade system
+		void INotifyBuildComplete.BuildingComplete(Actor self)
+		{
+			OnBuildComplete(self);
 		}
 
 		public void PlayCustomAnimation(Actor self, string name, Action after = null)

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -117,10 +117,15 @@ namespace OpenRA.Mods.Common.Traits.Render
 			DefaultAnimation.PlayRepeating(NormalizeSequence(self, Info.Sequence));
 		}
 
-		public virtual void DamageStateChanged(Actor self, AttackInfo e)
+		protected virtual void DamageStateChanged(Actor self)
 		{
 			if (DefaultAnimation.CurrentSequence != null)
 				DefaultAnimation.ReplaceAnim(NormalizeSequence(self, DefaultAnimation.CurrentSequence.Name));
+		}
+
+		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
+		{
+			DamageStateChanged(self);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				DefaultAnimation.ReplaceAnim(NormalizeSequence(self, DefaultAnimation.CurrentSequence.Name));
 		}
 
-		public virtual void Tick(Actor self)
+		protected virtual void Tick(Actor self)
 		{
 			if (Info.AimSequence == null)
 				return;
@@ -131,6 +131,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
 		{
 			DamageStateChanged(self);
+		}
+
+		void ITick.Tick(Actor self)
+		{
+			// Split into a protected method to allow subclassing
+			Tick(self);
 		}
 
 		void INotifyBuildComplete.BuildingComplete(Actor self) { buildComplete = true; }

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return RenderSprites.NormalizeSequence(DefaultAnimation, self.GetDamageState(), sequence);
 		}
 
-		public virtual void DamageStateChanged(Actor self, AttackInfo e)
+		protected virtual void DamageStateChanged(Actor self)
 		{
 			if (DefaultAnimation.CurrentSequence != null)
 				DefaultAnimation.ReplaceAnim(NormalizeSequence(self, DefaultAnimation.CurrentSequence.Name));
@@ -126,6 +126,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			var sequence = Attack.IsAttacking ? Info.AimSequence : Info.Sequence;
 			DefaultAnimation.ReplaceAnim(sequence);
+		}
+
+		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
+		{
+			DamageStateChanged(self);
 		}
 
 		void INotifyBuildComplete.BuildingComplete(Actor self) { buildComplete = true; }

--- a/OpenRA.Mods.Common/Traits/Render/WithTurretedSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurretedSpriteBody.cs
@@ -54,9 +54,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 			turreted.QuantizedFacings = DefaultAnimation.CurrentSequence.Facings;
 		}
 
-		public override void DamageStateChanged(Actor self, AttackInfo e)
+		protected override void DamageStateChanged(Actor self)
 		{
-			base.DamageStateChanged(self, e);
+			base.DamageStateChanged(self);
 			turreted.QuantizedFacings = DefaultAnimation.CurrentSequence.Facings;
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			DefaultAnimation.PlayFetchIndex(NormalizeSequence(self, Info.Sequence), () => adjacent);
 		}
 
-		public void Tick(Actor self)
+		void ITick.Tick(Actor self)
 		{
 			if (!dirty)
 				return;

--- a/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			wallInfo = info;
 		}
 
-		public override void DamageStateChanged(Actor self, AttackInfo e)
+		protected override void DamageStateChanged(Actor self)
 		{
 			DefaultAnimation.PlayFetchIndex(NormalizeSequence(self, Info.Sequence), () => adjacent);
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
@@ -136,7 +136,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			dirty = false;
 		}
 
-		public override void BuildingComplete(Actor self)
+		protected override void OnBuildComplete(Actor self)
 		{
 			DefaultAnimation.PlayFetchIndex(NormalizeSequence(self, Info.Sequence), () => adjacent);
 			UpdateNeighbours(self);

--- a/OpenRA.Mods.Common/Traits/Sound/AnnounceOnBuild.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AnnounceOnBuild.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 			this.info = info;
 		}
 
-		public void BuildingComplete(Actor self)
+		void INotifyBuildComplete.BuildingComplete(Actor self)
 		{
 			self.PlayVoice(info.Voice);
 		}

--- a/OpenRA.Mods.Common/Traits/Sound/SoundOnDamageTransition.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/SoundOnDamageTransition.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 			this.info = info;
 		}
 
-		public void DamageStateChanged(Actor self, AttackInfo e)
+		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
 		{
 			var rand = Game.CosmeticRandom;
 

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -70,6 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 		void PreparingAttack(Actor self, Target target, Armament a, Barrel barrel);
 	}
 
+	[RequireExplicitImplementation]
 	public interface INotifyBuildComplete { void BuildingComplete(Actor self); }
 	public interface INotifyBuildingPlaced { void BuildingPlaced(Actor self); }
 	public interface INotifyRepair { void Repairing(Actor self, Actor target); }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -82,10 +82,12 @@ namespace OpenRA.Mods.Common.Traits
 	public interface INotifyDocking { void Docked(Actor self, Actor harvester); void Undocked(Actor self, Actor harvester); }
 	public interface INotifyParachuteLanded { void OnLanded(Actor ignore); }
 	public interface INotifyCapture { void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner); }
-	public interface INotifyInfiltrated { void Infiltrated(Actor self, Actor infiltrator); }
 	public interface INotifyDiscovered { void OnDiscovered(Actor self, Player discoverer, bool playNotification); }
 	public interface IRenderActorPreviewInfo : ITraitInfo { IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init); }
 	public interface ICruiseAltitudeInfo : ITraitInfo { WDist GetCruiseAltitude(); }
+
+	[RequireExplicitImplementation]
+	public interface INotifyInfiltrated { void Infiltrated(Actor self, Actor infiltrator); }
 
 	[RequireExplicitImplementation]
 	public interface INotifyBlockingMove { void OnNotifyBlockingMove(Actor self, Actor blocking); }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -72,6 +72,10 @@ namespace OpenRA.Mods.Common.Traits
 
 	[RequireExplicitImplementation]
 	public interface INotifyBuildComplete { void BuildingComplete(Actor self); }
+
+	[RequireExplicitImplementation]
+	public interface INotifyDamageStateChanged { void DamageStateChanged(Actor self, AttackInfo e); }
+
 	public interface INotifyBuildingPlaced { void BuildingPlaced(Actor self); }
 	public interface INotifyRepair { void Repairing(Actor self, Actor target); }
 	public interface INotifyBurstComplete { void FiredBurst(Actor self, Target target, Armament a); }

--- a/OpenRA.Mods.D2k/Traits/Render/WithCrumbleOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithCrumbleOverlay.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.D2k.Traits.Render
 			rs.Add(anim, info.Palette, info.IsPlayerPalette);
 		}
 
-		public void BuildingComplete(Actor self)
+		void INotifyBuildComplete.BuildingComplete(Actor self)
 		{
 			buildComplete = true;
 		}

--- a/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForCash.cs
+++ b/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForCash.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.RA.Traits
 
 		public InfiltrateForCash(InfiltrateForCashInfo info) { this.info = info; }
 
-		public void Infiltrated(Actor self, Actor infiltrator)
+		void INotifyInfiltrated.Infiltrated(Actor self, Actor infiltrator)
 		{
 			var targetResources = self.Owner.PlayerActor.Trait<PlayerResources>();
 			var spyResources = infiltrator.Owner.PlayerActor.Trait<PlayerResources>();

--- a/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForDecoration.cs
+++ b/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForDecoration.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.RA.Traits
 		public InfiltrateForDecoration(Actor self, InfiltrateForDecorationInfo info)
 			: base(self, info) { }
 
-		public void Infiltrated(Actor self, Actor infiltrator)
+		void INotifyInfiltrated.Infiltrated(Actor self, Actor infiltrator)
 		{
 			infiltrators.Add(infiltrator.Owner);
 		}

--- a/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForExploration.cs
+++ b/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForExploration.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.RA.Traits
 
 	class InfiltrateForExploration : INotifyInfiltrated
 	{
-		public void Infiltrated(Actor self, Actor infiltrator)
+		void INotifyInfiltrated.Infiltrated(Actor self, Actor infiltrator)
 		{
 			infiltrator.Owner.Shroud.Explore(self.Owner.Shroud);
 			if (!self.Owner.HasFogVisibility)

--- a/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForPowerOutage.cs
+++ b/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForPowerOutage.cs
@@ -32,12 +32,12 @@ namespace OpenRA.Mods.RA.Traits
 			playerPower = self.Owner.PlayerActor.Trait<PowerManager>();
 		}
 
-		public void Infiltrated(Actor self, Actor infiltrator)
+		void INotifyInfiltrated.Infiltrated(Actor self, Actor infiltrator)
 		{
 			playerPower.TriggerPowerOutage(info.Duration);
 		}
 
-		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			playerPower = self.Owner.PlayerActor.Trait<PowerManager>();
 		}

--- a/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForSupportPower.cs
+++ b/OpenRA.Mods.RA/Traits/Infiltration/InfiltrateForSupportPower.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.RA.Traits
 			this.info = info;
 		}
 
-		public void Infiltrated(Actor self, Actor infiltrator)
+		void INotifyInfiltrated.Infiltrated(Actor self, Actor infiltrator)
 		{
 			infiltrator.World.AddFrameEndTask(w => w.CreateActor(info.Proxy, new TypeDictionary
 			{


### PR DESCRIPTION
Follow-up to #12268.

This one might need at least a bit of testing for potential regressions on sprite bodies, sprite turrets and armaments, though in my own testing I didn't encounter any issues.

To make up for it, the diff is a lot smaller this time.
- moves `INotifyDamageStateChanged` to mod code
- makes explicit interface implementation mandatory for the above and `INotifyBuildComplete`
- adresses a few more cases that previously made implicit interfaces overridable, preventing explicit implementations
- some more misc 'collateral' explicit implementations
