### PR TITLE
Third round of interface moving, making explicit and cleanup

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -233,14 +233,6 @@ namespace OpenRA.Traits
 	}
 
 	public interface IRenderModifier { IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r); }
-	public interface IDamageModifier { int GetDamageModifier(Actor attacker, Damage damage); }
-	public interface ISpeedModifier { int GetSpeedModifier(); }
-	public interface IFirepowerModifier { int GetFirepowerModifier(); }
-	public interface IReloadModifier { int GetReloadModifier(); }
-	public interface IInaccuracyModifier { int GetInaccuracyModifier(); }
-	public interface IRangeModifier { int GetRangeModifier(); }
-	public interface IRangeModifierInfo : ITraitInfoInterface { int GetRangeModifierDefault(); }
-	public interface IPowerModifier { int GetPowerModifier(); }
 	public interface ILoadsPalettes { void LoadPalettes(WorldRenderer wr); }
 	public interface ILoadsPlayerPalettes { void LoadPlayerPalettes(WorldRenderer wr, string playerName, HSLColor playerColor, bool replaceExisting); }
 	public interface IPaletteModifier { void AdjustPalette(IReadOnlyDictionary<string, MutablePalette> b); }

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -321,12 +321,6 @@ namespace OpenRA.Traits
 	public interface INotifyBecomingIdle { void OnBecomingIdle(Actor self); }
 	public interface INotifyIdle { void TickIdle(Actor self); }
 
-	public interface IRenderInfantrySequenceModifier
-	{
-		bool IsModifyingSequence { get; }
-		string SequencePrefix { get; }
-	}
-
 	public interface IRenderAboveWorld { void RenderAboveWorld(Actor self, WorldRenderer wr); }
 	public interface IRenderShroud { void RenderShroud(Shroud shroud, WorldRenderer wr); }
 	public interface IRenderAboveShroud { IEnumerable<IRenderable> RenderAboveShroud(Actor self, WorldRenderer wr); }

--- a/OpenRA.Mods.Cnc/Traits/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/AttackPopupTurreted.cs
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		public int GetDamageModifier(Actor attacker, Damage damage)
+		int IDamageModifier.GetDamageModifier(Actor attacker, Damage damage)
 		{
 			return state == PopupState.Closed ? info.ClosedDamageMultiplier : 100;
 		}

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -447,9 +447,9 @@ namespace OpenRA.Mods.Common.Traits
 				yield return GetPipAt(i);
 		}
 
-		public bool ShouldExplode(Actor self) { return !IsEmpty; }
+		bool IExplodeModifier.ShouldExplode(Actor self) { return !IsEmpty; }
 
-		public int GetSpeedModifier()
+		int ISpeedModifier.GetSpeedModifier()
 		{
 			return 100 - (100 - Info.FullyLoadedSpeed) * contents.Values.Sum() / Info.Capacity;
 		}

--- a/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 			mobile = self.Trait<Mobile>();
 		}
 
-		public void Panic()
+		void Panic()
 		{
 			if (!Panicking)
 				self.CancelActivity();
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 			panicStartedTick = self.World.WorldTick;
 		}
 
-		public void Tick(Actor self)
+		void ITick.Tick(Actor self)
 		{
 			if (!Panicking)
 				return;
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public void TickIdle(Actor self)
+		void INotifyIdle.TickIdle(Actor self)
 		{
 			if (!Panicking)
 				return;
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.Traits
 			mobile.Nudge(self, self, true);
 		}
 
-		public void Damaged(Actor self, AttackInfo e)
+		void INotifyDamage.Damaged(Actor self, AttackInfo e)
 		{
 			if (e.Damage.Value > 0)
 				Panic();
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel) { }
 
-		public int GetSpeedModifier()
+		int ISpeedModifier.GetSpeedModifier()
 		{
 			return Panicking ? info.PanicSpeedModifier : 100;
 		}

--- a/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
@@ -38,8 +38,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Sync] int panicStartedTick;
 		bool Panicking { get { return panicStartedTick > 0; } }
 
-		public bool IsModifyingSequence { get { return Panicking; } }
-		public string SequencePrefix { get { return info.PanicSequencePrefix; } }
+		bool IRenderInfantrySequenceModifier.IsModifyingSequence { get { return Panicking; } }
+		string IRenderInfantrySequenceModifier.SequencePrefix { get { return info.PanicSequencePrefix; } }
 
 		public ScaredyCat(Actor self, ScaredyCatInfo info)
 		{

--- a/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
@@ -45,8 +45,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Sync] int remainingProneTime = 0;
 		bool IsProne { get { return remainingProneTime > 0; } }
 
-		public bool IsModifyingSequence { get { return IsProne; } }
-		public string SequencePrefix { get { return info.ProneSequencePrefix; } }
+		bool IRenderInfantrySequenceModifier.IsModifyingSequence { get { return IsProne; } }
+		string IRenderInfantrySequenceModifier.SequencePrefix { get { return info.ProneSequencePrefix; } }
 
 		public TakeCover(ActorInitializer init, TakeCoverInfo info)
 			: base(init, info)
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 		}
 
-		public void Damaged(Actor self, AttackInfo e)
+		void INotifyDamage.Damaged(Actor self, AttackInfo e)
 		{
 			if (e.Damage.Value <= 0 || !e.Damage.DamageTypes.Overlaps(info.DamageTriggers))
 				return;
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 			get { return true; }
 		}
 
-		public int GetDamageModifier(Actor attacker, Damage damage)
+		int IDamageModifier.GetDamageModifier(Actor attacker, Damage damage)
 		{
 			if (!IsProne)
 				return 100;
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.Traits
 			return Util.ApplyPercentageModifiers(100, modifierPercentages);
 		}
 
-		public int GetSpeedModifier()
+		int ISpeedModifier.GetSpeedModifier()
 		{
 			return IsProne ? info.SpeedModifier : 100;
 		}

--- a/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.self = self;
 		}
 
-		public int GetDamageModifier(Actor attacker, Damage damage)
+		int IDamageModifier.GetDamageModifier(Actor attacker, Damage damage)
 		{
 			if (attacker.Owner.IsAlliedWith(self.Owner) && damage.Value < 0 && !Info.ModifyHealing)
 				return FullDamage;

--- a/OpenRA.Mods.Common/Traits/Multipliers/DamageMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/DamageMultiplier.cs
@@ -26,6 +26,6 @@ namespace OpenRA.Mods.Common.Traits
 		public DamageMultiplier(DamageMultiplierInfo info, string actorType)
 			: base(info, "DamageMultiplier", actorType) { }
 
-		public int GetDamageModifier(Actor attacker, Damage damage) { return GetModifier(); }
+		int IDamageModifier.GetDamageModifier(Actor attacker, Damage damage) { return GetModifier(); }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Multipliers/FirepowerMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/FirepowerMultiplier.cs
@@ -24,6 +24,6 @@ namespace OpenRA.Mods.Common.Traits
 		public FirepowerMultiplier(FirepowerMultiplierInfo info, string actorType)
 			: base(info, "FirepowerMultiplier", actorType) { }
 
-		public int GetFirepowerModifier() { return GetModifier(); }
+		int IFirepowerModifier.GetFirepowerModifier() { return GetModifier(); }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Multipliers/FirepowerMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/FirepowerMultiplier.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using OpenRA.Traits;
-
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("The firepower of this actor is multiplied based on upgrade level if specified.")]

--- a/OpenRA.Mods.Common/Traits/Multipliers/InaccuracyMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/InaccuracyMultiplier.cs
@@ -24,6 +24,6 @@ namespace OpenRA.Mods.Common.Traits
 		public InaccuracyMultiplier(InaccuracyMultiplierInfo info, string actorType)
 			: base(info, "InaccuracyMultiplier", actorType) { }
 
-		public int GetInaccuracyModifier() { return GetModifier(); }
+		int IInaccuracyModifier.GetInaccuracyModifier() { return GetModifier(); }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Multipliers/InaccuracyMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/InaccuracyMultiplier.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using OpenRA.Traits;
-
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("The inaccuracy of this actor is multiplied based on upgrade level if specified.")]

--- a/OpenRA.Mods.Common/Traits/Multipliers/PowerMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/PowerMultiplier.cs
@@ -26,9 +26,11 @@ namespace OpenRA.Mods.Common.Traits
 		public PowerMultiplier(Actor self, PowerMultiplierInfo info)
 			: base(info, "PowerMultiplier", self.Info.Name) { power = self.Owner.PlayerActor.Trait<PowerManager>(); }
 
-		public int GetPowerModifier() { return GetModifier(); }
+		int IPowerModifier.GetPowerModifier() { return GetModifier(); }
+
 		protected override void Update(Actor self) { power.UpdateActor(self); }
-		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			power = newOwner.PlayerActor.Trait<PowerManager>();
 		}

--- a/OpenRA.Mods.Common/Traits/Multipliers/RangeMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/RangeMultiplier.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public override object Create(ActorInitializer init) { return new RangeMultiplier(this, init.Self.Info.Name); }
 
-		public int GetRangeModifierDefault()
+		int IRangeModifierInfo.GetRangeModifierDefault()
 		{
 			return BaseLevel > 0 || UpgradeTypes.Length == 0 ? 100 : Modifier[0];
 		}
@@ -29,6 +29,6 @@ namespace OpenRA.Mods.Common.Traits
 		public RangeMultiplier(RangeMultiplierInfo info, string actorType)
 			: base(info, "RangeMultiplier", actorType) { }
 
-		public int GetRangeModifier() { return GetModifier(); }
+		int IRangeModifier.GetRangeModifier() { return GetModifier(); }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Multipliers/RangeMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/RangeMultiplier.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using OpenRA.Traits;
-
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Range of this actor is multiplied based on upgrade level.")]

--- a/OpenRA.Mods.Common/Traits/Multipliers/ReloadDelayMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/ReloadDelayMultiplier.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using OpenRA.Traits;
-
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("The reloading time of this actor is multiplied based on upgrade level if specified.")]

--- a/OpenRA.Mods.Common/Traits/Multipliers/ReloadDelayMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/ReloadDelayMultiplier.cs
@@ -24,6 +24,6 @@ namespace OpenRA.Mods.Common.Traits
 		public ReloadDelayMultiplier(ReloadDelayMultiplierInfo info, string actorType)
 			: base(info, "ReloadDelayMultiplier", actorType) { }
 
-		public int GetReloadModifier() { return GetModifier(); }
+		int IReloadModifier.GetReloadModifier() { return GetModifier(); }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Multipliers/SpeedMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/SpeedMultiplier.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using OpenRA.Traits;
-
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("The speed of this actor is multiplied based on upgrade level if specified.")]

--- a/OpenRA.Mods.Common/Traits/Multipliers/SpeedMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/SpeedMultiplier.cs
@@ -24,6 +24,6 @@ namespace OpenRA.Mods.Common.Traits
 		public SpeedMultiplier(SpeedMultiplierInfo info, string actorType)
 			: base(info, "SpeedMultiplier", actorType) { }
 
-		public int GetSpeedModifier() { return GetModifier(); }
+		int ISpeedModifier.GetSpeedModifier() { return GetModifier(); }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Power/AffectedByPowerOutage.cs
+++ b/OpenRA.Mods.Common/Traits/Power/AffectedByPowerOutage.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool ISelectionBar.DisplayWhenEmpty { get { return false; } }
 
-		public int GetPowerModifier()
+		int IPowerModifier.GetPowerModifier()
 		{
 			return playerPower.PowerOutageRemainingTicks > 0 ? 0 : 100;
 		}
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 			get { return playerPower.PowerOutageRemainingTicks > 0; }
 		}
 
-		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			playerPower = newOwner.PlayerActor.Trait<PowerManager>();
 		}

--- a/OpenRA.Mods.Common/Traits/Power/CanPowerDown.cs
+++ b/OpenRA.Mods.Common/Traits/Power/CanPowerDown.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool Disabled { get { return disabled; } }
 
-		public void ResolveOrder(Actor self, Order order)
+		void IResolveOrder.ResolveOrder(Actor self, Order order)
 		{
 			if (!IsTraitDisabled && order.OrderString == "PowerDown")
 			{
@@ -72,12 +72,12 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public int GetPowerModifier()
+		int IPowerModifier.GetPowerModifier()
 		{
 			return !IsTraitDisabled && disabled ? 0 : 100;
 		}
 
-		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			power = newOwner.PlayerActor.Trait<PowerManager>();
 		}
@@ -86,6 +86,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (!disabled || !Info.CancelWhenDisabled)
 				return;
+
 			disabled = false;
 
 			if (Info.PowerupSound != null)

--- a/OpenRA.Mods.Common/Traits/Power/ScalePowerWithHealth.cs
+++ b/OpenRA.Mods.Common/Traits/Power/ScalePowerWithHealth.cs
@@ -30,13 +30,14 @@ namespace OpenRA.Mods.Common.Traits
 			health = self.Trait<Health>();
 		}
 
-		public int GetPowerModifier()
+		int IPowerModifier.GetPowerModifier()
 		{
 			return 100 * health.HP / health.MaxHP;
 		}
 
-		public void Damaged(Actor self, AttackInfo e) { power.UpdateActor(self); }
-		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		void INotifyDamage.Damaged(Actor self, AttackInfo e) { power.UpdateActor(self); }
+
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			power = newOwner.PlayerActor.Trait<PowerManager>();
 		}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -205,6 +205,8 @@ namespace OpenRA.Mods.Common.Traits
 
 	[RequireExplicitImplementation]
 	public interface IDamageModifier { int GetDamageModifier(Actor attacker, Damage damage); }
+
+	[RequireExplicitImplementation]
 	public interface ISpeedModifier { int GetSpeedModifier(); }
 	public interface IFirepowerModifier { int GetFirepowerModifier(); }
 	public interface IReloadModifier { int GetReloadModifier(); }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -223,5 +223,6 @@ namespace OpenRA.Mods.Common.Traits
 	[RequireExplicitImplementation]
 	public interface IRangeModifierInfo : ITraitInfoInterface { int GetRangeModifierDefault(); }
 
+	[RequireExplicitImplementation]
 	public interface IPowerModifier { int GetPowerModifier(); }
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -202,4 +202,13 @@ namespace OpenRA.Mods.Common.Traits
 		bool IsModifyingSequence { get; }
 		string SequencePrefix { get; }
 	}
+
+	public interface IDamageModifier { int GetDamageModifier(Actor attacker, Damage damage); }
+	public interface ISpeedModifier { int GetSpeedModifier(); }
+	public interface IFirepowerModifier { int GetFirepowerModifier(); }
+	public interface IReloadModifier { int GetReloadModifier(); }
+	public interface IInaccuracyModifier { int GetInaccuracyModifier(); }
+	public interface IRangeModifier { int GetRangeModifier(); }
+	public interface IRangeModifierInfo : ITraitInfoInterface { int GetRangeModifierDefault(); }
+	public interface IPowerModifier { int GetPowerModifier(); }
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -217,7 +217,11 @@ namespace OpenRA.Mods.Common.Traits
 
 	[RequireExplicitImplementation]
 	public interface IInaccuracyModifier { int GetInaccuracyModifier(); }
+
+	[RequireExplicitImplementation]
 	public interface IRangeModifier { int GetRangeModifier(); }
+	[RequireExplicitImplementation]
 	public interface IRangeModifierInfo : ITraitInfoInterface { int GetRangeModifierDefault(); }
+
 	public interface IPowerModifier { int GetPowerModifier(); }
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -220,6 +220,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	[RequireExplicitImplementation]
 	public interface IRangeModifier { int GetRangeModifier(); }
+
 	[RequireExplicitImplementation]
 	public interface IRangeModifierInfo : ITraitInfoInterface { int GetRangeModifierDefault(); }
 

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -203,6 +203,7 @@ namespace OpenRA.Mods.Common.Traits
 		string SequencePrefix { get; }
 	}
 
+	[RequireExplicitImplementation]
 	public interface IDamageModifier { int GetDamageModifier(Actor attacker, Damage damage); }
 	public interface ISpeedModifier { int GetSpeedModifier(); }
 	public interface IFirepowerModifier { int GetFirepowerModifier(); }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -208,6 +208,8 @@ namespace OpenRA.Mods.Common.Traits
 
 	[RequireExplicitImplementation]
 	public interface ISpeedModifier { int GetSpeedModifier(); }
+
+	[RequireExplicitImplementation]
 	public interface IFirepowerModifier { int GetFirepowerModifier(); }
 	public interface IReloadModifier { int GetReloadModifier(); }
 	public interface IInaccuracyModifier { int GetInaccuracyModifier(); }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -211,6 +211,8 @@ namespace OpenRA.Mods.Common.Traits
 
 	[RequireExplicitImplementation]
 	public interface IFirepowerModifier { int GetFirepowerModifier(); }
+
+	[RequireExplicitImplementation]
 	public interface IReloadModifier { int GetReloadModifier(); }
 	public interface IInaccuracyModifier { int GetInaccuracyModifier(); }
 	public interface IRangeModifier { int GetRangeModifier(); }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -195,4 +195,11 @@ namespace OpenRA.Mods.Common.Traits
 
 	[RequireExplicitImplementation]
 	public interface INotifyRearm { void Rearming(Actor host, Actor other); }
+
+	[RequireExplicitImplementation]
+	public interface IRenderInfantrySequenceModifier
+	{
+		bool IsModifyingSequence { get; }
+		string SequencePrefix { get; }
+	}
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -214,6 +214,8 @@ namespace OpenRA.Mods.Common.Traits
 
 	[RequireExplicitImplementation]
 	public interface IReloadModifier { int GetReloadModifier(); }
+
+	[RequireExplicitImplementation]
 	public interface IInaccuracyModifier { int GetInaccuracyModifier(); }
 	public interface IRangeModifier { int GetRangeModifier(); }
 	public interface IRangeModifierInfo : ITraitInfoInterface { int GetRangeModifierDefault(); }

--- a/OpenRA.Mods.TS/Traits/Render/WithPermanentInjury.cs
+++ b/OpenRA.Mods.TS/Traits/Render/WithPermanentInjury.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.TS.Traits.Render
@@ -29,15 +30,15 @@ namespace OpenRA.Mods.TS.Traits.Render
 
 		bool isInjured;
 
-		public bool IsModifyingSequence { get { return isInjured; } }
-		public string SequencePrefix { get { return info.InjuredSequencePrefix; } }
+		bool IRenderInfantrySequenceModifier.IsModifyingSequence { get { return isInjured; } }
+		string IRenderInfantrySequenceModifier.SequencePrefix { get { return info.InjuredSequencePrefix; } }
 
 		public WithPermanentInjury(ActorInitializer init, WithPermanentInjuryInfo info)
 		{
 			this.info = info;
 		}
 
-		public void Damaged(Actor self, AttackInfo e)
+		void INotifyDamage.Damaged(Actor self, AttackInfo e)
 		{
 			if (e.DamageState == info.TriggeringDamageStage)
 				isInjured = true;


### PR DESCRIPTION
Moves `IRenderInfantrySequenceModifier`, all combat Modifier interfaces and the `IPowerModifier` interface to mod code and makes them require explicit implementation.

This probably concludes the moving of interfaces for now.
Further follow-ups will likely just make interface implementations explicit in more places.
