### PR TITLE
[D2k] Added the 'Damage' UncloakType to several units

### DIFF
--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -158,6 +158,7 @@ fremen:
 	Cloak:
 		InitialDelay: 85
 		CloakDelay: 85
+		UncloakOn: Attack, Unload, Infiltrate, Demolish, Dock, Damage
 		CloakSound: STEALTH1.WAV
 		UncloakSound: STEALTH2.WAV
 		IsPlayerPalette: true
@@ -251,7 +252,7 @@ saboteur:
 		CloakDelay: 85
 		CloakSound: STEALTH1.WAV
 		UncloakSound: STEALTH2.WAV
-		UncloakOn: Attack, Unload, Infiltrate, Demolish, Move
+		UncloakOn: Attack, Unload, Infiltrate, Demolish, Move, Damage
 		IsPlayerPalette: true
 	Voiced:
 		VoiceSet: SaboteurVoice

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -390,6 +390,7 @@ stealth_raider:
 	Cloak:
 		InitialDelay: 45
 		CloakDelay: 90
+		UncloakOn: Attack, Unload, Infiltrate, Demolish, Dock, Damage
 		CloakSound: STEALTH1.WAV
 		UncloakSound: STEALTH2.WAV
 		IsPlayerPalette: true


### PR DESCRIPTION
Changed: Saboteur, Fremen and Stealth Raider. Closes #12192.
