### PR TITLE
Fix null being passed through the INotifyAttack interface

### DIFF
--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -156,7 +156,10 @@ namespace OpenRA.Mods.Common.Traits
 				paxPos[a.Actor].SetVisualPosition(a.Actor, pos + PortOffset(self, port));
 
 				var barrel = a.CheckFire(a.Actor, facing.Value, target);
-				if (barrel != null && a.Info.MuzzleSequence != null)
+				if (barrel == null)
+					return;
+
+				if (a.Info.MuzzleSequence != null)
 				{
 					// Muzzle facing is fixed once the firing starts
 					var muzzleAnim = new Animation(self.World, paxRender[a.Actor].GetImage(a.Actor), () => muzzleFacing);

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -31,18 +31,22 @@ namespace OpenRA.Mods.D2k.Activities
 		readonly Sandworm sandworm;
 		readonly ConditionManager conditionManager;
 		readonly WeaponInfo weapon;
+		readonly Armament armament;
 		readonly AttackSwallow swallow;
 		readonly IPositionable positionable;
+		readonly IFacing facing;
 
 		int countdown;
 		CPos burrowLocation;
 		AttackState stance;
 		int attackingToken = ConditionManager.InvalidConditionToken;
 
-		public SwallowActor(Actor self, Target target, WeaponInfo weapon)
+		public SwallowActor(Actor self, Target target, Armament a, IFacing facing)
 		{
 			this.target = target;
-			this.weapon = weapon;
+			this.facing = facing;
+			armament = a;
+			weapon = a.Weapon;
 			sandworm = self.Trait<Sandworm>();
 			positionable = self.Trait<Mobile>();
 			swallow = self.Trait<AttackSwallow>();
@@ -80,11 +84,13 @@ namespace OpenRA.Mods.D2k.Activities
 			foreach (var player in affectedPlayers)
 				self.World.AddFrameEndTask(w => w.Add(new MapNotificationEffect(player, "Speech", swallow.Info.WormAttackNotification, 25, true, attackPosition, Color.Red)));
 
+			var barrel = armament.CheckFire(self, facing, target);
+			if (barrel == null)
+				return false;
+
+			// armament.CheckFire already calls INotifyAttack.PreparingAttack
 			foreach (var notify in self.TraitsImplementing<INotifyAttack>())
-			{
-				notify.PreparingAttack(self, target, null, null);
-				notify.Attacking(self, target, null, null);
-			}
+				notify.Attacking(self, target, armament, barrel);
 
 			return true;
 		}

--- a/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
+++ b/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.D2k.Traits
 				return;
 
 			self.CancelActivity();
-			self.QueueActivity(new SwallowActor(self, target, a.Weapon));
+			self.QueueActivity(new SwallowActor(self, target, a, facing.Value));
 		}
 	}
 }

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -60,11 +60,10 @@ WormJaw:
 	ReloadDelay: 10
 	InvalidTargets: Structure, Infantry
 	Range: 1c512
-	Warhead@1Dam: SpreadDamage
+	Warhead@1Dam: SpreadDamage # HACK: The warhead is needed for targeting
 		InvalidTargets: Structure, Infantry
-		Spread: 768
-		Falloff: 100, 100, 0
-		Damage: 10000
+		Spread: 0
+		Falloff: 0,0
 
 OrniBomb:
 	ReloadDelay: 25


### PR DESCRIPTION
[`SwallowActor` explicitly passes a `null` `Armament` to `INotifyAttack.PreparingAttack`](https://github.com/OpenRA/OpenRA/blob/634faa31deb9e03ed7b49b06c9b6ade0225bcb01/OpenRA.Mods.D2k/Activities/SwallowActor.cs#L96) which then gets redirected in [`WithInfantryBody`](https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs#L128) to its `Attacking` method causing a crash.

I need the explicit `string sequence = null` as I otherwise get a `CS0165` compiler error.

Detected by Coverity.
