### PR TITLE
Fix a possible crash in the AssetsBrowserLogic

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -322,7 +322,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (!modData.DefaultFileSystem.Exists(filename))
 				return false;
 
-			errorLabelWidget.Visible = false;
+			if (errorLabelWidget != null)
+				errorLabelWidget.Visible = false;
 
 			try
 			{


### PR DESCRIPTION
`errorLabelWidget` might be `null` (we check for `null` on all other occurences as well).

Detected by Coverity.
