### PR TITLE
Fix error label not updating and split message into multiple labels

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -356,12 +356,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				if (errorLabel != null)
 				{
-					errorLabelFilename.GetText = () => WidgetUtils.TruncateText(filename, errorLabel.Bounds.Width, errorFont);
 					currentSprites = new Sprite[0];
 					errorLabel.Visible = true;
 
 					if (errorLabelFilename != null)
+					{
+						errorLabelFilename.GetText = () => WidgetUtils.TruncateText(filename, errorLabel.Bounds.Width, errorFont);
 						errorLabelFilename.Visible = true;
+					}
 				}
 
 				Log.AddChannel("assetbrowser", "assetbrowser.log");

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -47,19 +47,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		bool isVideoLoaded = false;
 		int currentFrame;
 
-		LabelWidget errorLabelWidget;
+		LabelWidget errorLabel;
 		LabelWidget errorLabelFilename;
 		SpriteFont errorFont;
-		bool isErrorLabelVisible
-		{
-			get
-			{
-				return errorLabelWidget != null
-					&& errorLabelWidget.Visible
-					&& errorLabelFilename != null
-					&& errorLabelFilename.Visible;
-			}
-		}
+		bool isErrorLabelVisible { get { return errorLabel != null && errorLabel.Visible; } }
 
 		[ObjectCreator.UseCtor]
 		public AssetBrowserLogic(Widget widget, Action onExit, ModData modData, World world, Dictionary<string, MiniYaml> logicArgs)
@@ -105,11 +96,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (playerWidget != null)
 				playerWidget.IsVisible = () => isVideoLoaded && !isErrorLabelVisible;
 
-			errorLabelWidget = panel.GetOrNull<LabelWidget>("ERROR");
-			errorLabelFilename = panel.GetOrNull<LabelWidget>("ERROR_FILENAME");
-
-			if (errorLabelWidget != null && errorLabelFilename != null)
-				errorFont = Game.Renderer.Fonts[errorLabelWidget.Font];
+			errorLabel = panel.GetOrNull<LabelWidget>("ERROR");
+			if (errorLabel != null)
+			{
+				errorFont = Game.Renderer.Fonts[errorLabel.Font];
+				errorLabelFilename = errorLabel.GetOrNull<LabelWidget>("ERROR_FILENAME");
+			}
 
 			var paletteDropDown = panel.GetOrNull<DropDownButtonWidget>("PALETTE_SELECTOR");
 			if (paletteDropDown != null)
@@ -334,8 +326,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (!modData.DefaultFileSystem.Exists(filename))
 				return false;
 
-			if (errorLabelWidget != null)
-				errorLabelWidget.Visible = false;
+			if (errorLabel != null)
+				errorLabel.Visible = false;
 
 			if (errorLabelFilename != null)
 				errorLabelFilename.Visible = false;
@@ -362,12 +354,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 			catch (Exception ex)
 			{
-				if (errorLabelWidget != null && errorLabelFilename != null)
+				if (errorLabel != null)
 				{
-					errorLabelFilename.GetText = () => WidgetUtils.TruncateText(filename, errorLabelWidget.Bounds.Width, errorFont);
+					errorLabelFilename.GetText = () => WidgetUtils.TruncateText(filename, errorLabel.Bounds.Width, errorFont);
 					currentSprites = new Sprite[0];
-					errorLabelWidget.Visible = true;
-					errorLabelFilename.Visible = true;
+					errorLabel.Visible = true;
+
+					if (errorLabelFilename != null)
+						errorLabelFilename.Visible = true;
 				}
 
 				Log.AddChannel("assetbrowser", "assetbrowser.log");

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -362,7 +362,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 			catch (Exception ex)
 			{
-				if (errorLabelWidget != null)
+				if (errorLabelWidget != null && errorLabelFilename != null)
 				{
 					errorLabelFilename.GetText = () => WidgetUtils.TruncateText(filename, errorLabelWidget.Bounds.Width, errorFont);
 					currentSprites = new Sprite[0];

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		LabelWidget errorLabel;
 		LabelWidget errorLabelFilename;
 		SpriteFont errorFont;
-		bool isErrorLabelVisible { get { return errorLabel != null && errorLabel.Visible; } }
+		bool IsErrorLabelVisible { get { return errorLabel != null && errorLabel.Visible; } }
 
 		[ObjectCreator.UseCtor]
 		public AssetBrowserLogic(Widget widget, Action onExit, ModData modData, World world, Dictionary<string, MiniYaml> logicArgs)
@@ -89,12 +89,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				spriteWidget.GetSprite = () => currentSprites != null ? currentSprites[currentFrame] : null;
 				currentPalette = spriteWidget.Palette;
 				spriteWidget.GetPalette = () => currentPalette;
-				spriteWidget.IsVisible = () => !isVideoLoaded && !isErrorLabelVisible;
+				spriteWidget.IsVisible = () => !isVideoLoaded && !IsErrorLabelVisible;
 			}
 
 			var playerWidget = panel.GetOrNull<VqaPlayerWidget>("PLAYER");
 			if (playerWidget != null)
-				playerWidget.IsVisible = () => isVideoLoaded && !isErrorLabelVisible;
+				playerWidget.IsVisible = () => isVideoLoaded && !IsErrorLabelVisible;
 
 			errorLabel = panel.GetOrNull<LabelWidget>("ERROR");
 			if (errorLabel != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -48,8 +48,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		int currentFrame;
 
 		LabelWidget errorLabelWidget;
+		LabelWidget errorLabelFilename;
 		SpriteFont errorFont;
-		bool IsErrorLabelVisible { get { return errorLabelWidget != null && errorLabelWidget.Visible; } }
+		bool isErrorLabelVisible
+		{
+			get
+			{
+				return errorLabelWidget != null
+					&& errorLabelWidget.Visible
+					&& errorLabelFilename != null
+					&& errorLabelFilename.Visible;
+			}
+		}
 
 		[ObjectCreator.UseCtor]
 		public AssetBrowserLogic(Widget widget, Action onExit, ModData modData, World world, Dictionary<string, MiniYaml> logicArgs)
@@ -88,15 +98,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				spriteWidget.GetSprite = () => currentSprites != null ? currentSprites[currentFrame] : null;
 				currentPalette = spriteWidget.Palette;
 				spriteWidget.GetPalette = () => currentPalette;
-				spriteWidget.IsVisible = () => !isVideoLoaded && !IsErrorLabelVisible;
+				spriteWidget.IsVisible = () => !isVideoLoaded && !isErrorLabelVisible;
 			}
 
 			var playerWidget = panel.GetOrNull<VqaPlayerWidget>("PLAYER");
 			if (playerWidget != null)
-				playerWidget.IsVisible = () => isVideoLoaded && !IsErrorLabelVisible;
+				playerWidget.IsVisible = () => isVideoLoaded && !isErrorLabelVisible;
 
 			errorLabelWidget = panel.GetOrNull<LabelWidget>("ERROR");
-			if (errorLabelWidget != null)
+			errorLabelFilename = panel.GetOrNull<LabelWidget>("ERROR_FILENAME");
+
+			if (errorLabelWidget != null && errorLabelFilename != null)
 				errorFont = Game.Renderer.Fonts[errorLabelWidget.Font];
 
 			var paletteDropDown = panel.GetOrNull<DropDownButtonWidget>("PALETTE_SELECTOR");
@@ -322,7 +334,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (!modData.DefaultFileSystem.Exists(filename))
 				return false;
 
-			errorLabelWidget.Visible = false;
+			if (errorLabelWidget != null)
+				errorLabelWidget.Visible = false;
+
+			if (errorLabelFilename != null)
+				errorLabelFilename.Visible = false;
 
 			try
 			{
@@ -348,11 +364,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				if (errorLabelWidget != null)
 				{
-					errorLabelWidget.Text = WidgetUtils.TruncateText(errorLabelWidget.Text.Replace("{filename}", filename),
-						errorLabelWidget.Bounds.Width, errorFont);
-
+					errorLabelFilename.GetText = () => WidgetUtils.TruncateText(filename, errorLabelWidget.Bounds.Width, errorFont);
 					currentSprites = new Sprite[0];
 					errorLabelWidget.Visible = true;
+					errorLabelFilename.Visible = true;
 				}
 
 				Log.AddChannel("assetbrowser", "assetbrowser.log");

--- a/mods/cnc/chrome/assetbrowser.yaml
+++ b/mods/cnc/chrome/assetbrowser.yaml
@@ -111,7 +111,15 @@ Container@ASSETBROWSER_PANEL:
 							Height: 325
 							Align: Center
 							Visible: false
-							Text: Error displaying {filename} check assetbrowser.log
+							Text: Error displaying file. Read assetbrowser.log for more information.
+							Children:
+								Label@ERROR_FILENAME:
+									X: 5
+									Y: 30
+									Width: 490 - 10
+									Height: 330
+									Align: Center
+									Visible: false
 				Container@FRAME_SELECTOR:
 					X: 190
 					Y: 395

--- a/mods/cnc/chrome/assetbrowser.yaml
+++ b/mods/cnc/chrome/assetbrowser.yaml
@@ -117,7 +117,7 @@ Container@ASSETBROWSER_PANEL:
 									X: 5
 									Y: 30
 									Width: 490 - 10
-									Height: 330
+									Height: 325
 									Align: Center
 									Visible: false
 				Container@FRAME_SELECTOR:

--- a/mods/ra/chrome/assetbrowser.yaml
+++ b/mods/ra/chrome/assetbrowser.yaml
@@ -103,16 +103,18 @@ Background@ASSETBROWSER_PANEL:
 				Label@ERROR:
 					X: 5
 					Width: 490 - 10
-					Height: 300
-					Align: Center
-					Visible: false
-					Text: Error displaying file. Read assetbrowser.log for more information.
-				Label@ERROR_FILENAME:
-					X: 5
-					Width: 490 - 10
 					Height: 330
 					Align: Center
 					Visible: false
+					Text: Error displaying file. Read assetbrowser.log for more information.
+					Children:
+						Label@ERROR_FILENAME:
+							X: 5
+							Y: 30
+							Width: 490 - 10
+							Height: 330
+							Align: Center
+							Visible: false
 		Container@FRAME_SELECTOR:
 			X: 190
 			Y: 425

--- a/mods/ra/chrome/assetbrowser.yaml
+++ b/mods/ra/chrome/assetbrowser.yaml
@@ -103,10 +103,16 @@ Background@ASSETBROWSER_PANEL:
 				Label@ERROR:
 					X: 5
 					Width: 490 - 10
+					Height: 300
+					Align: Center
+					Visible: false
+					Text: Error displaying file. Read assetbrowser.log for more information.
+				Label@ERROR_FILENAME:
+					X: 5
+					Width: 490 - 10
 					Height: 330
 					Align: Center
 					Visible: false
-					Text: Error displaying {filename} check assetbrowser.log
 		Container@FRAME_SELECTOR:
 			X: 190
 			Y: 425


### PR DESCRIPTION
~~Depends on #12296 being merged, or this can be merged and that closed.~~

`{filename}` was being replaced in the string upon first error so it did not exist later to be replaced again by any following errors.

![screen shot 2016-10-23 at 3 50 32 pm](https://cloud.githubusercontent.com/assets/4861023/19629364/6d3d2372-9939-11e6-90b4-fb652ada210b.png)
