### PR TITLE
Replace DelayedAction in GpsWatcher with Tick-based solution

### DIFF
--- a/OpenRA.Mods.RA/Effects/GpsSatellite.cs
+++ b/OpenRA.Mods.RA/Effects/GpsSatellite.cs
@@ -18,14 +18,19 @@ namespace OpenRA.Mods.RA.Effects
 {
 	class GpsSatellite : IEffect
 	{
+		readonly Player launcher;
 		readonly Animation anim;
 		readonly string palette;
+		readonly int revealDelay;
 		WPos pos;
+		int tick;
 
-		public GpsSatellite(World world, WPos pos, string image, string sequence, string palette)
+		public GpsSatellite(World world, WPos pos, string image, string sequence, string palette, int revealDelay, Player launcher)
 		{
 			this.palette = palette;
 			this.pos = pos;
+			this.launcher = launcher;
+			this.revealDelay = revealDelay;
 
 			anim = new Animation(world, image);
 			anim.PlayRepeating(sequence);
@@ -36,8 +41,12 @@ namespace OpenRA.Mods.RA.Effects
 			anim.Tick();
 			pos += new WVec(0, 0, 427);
 
-			if (pos.Z > pos.Y)
+			if (++tick > revealDelay)
+			{
+				var watcher = launcher.PlayerActor.Trait<GpsWatcher>();
+				watcher.ReachedOrbit(launcher);
 				world.AddFrameEndTask(w => w.Remove(this));
+			}
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)

--- a/OpenRA.Mods.RA/Effects/SatelliteLaunch.cs
+++ b/OpenRA.Mods.RA/Effects/SatelliteLaunch.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.RA.Effects
 			if (++frame == 19)
 			{
 				var palette = info.SatellitePaletteIsPlayerPalette ? info.SatellitePalette + launcher.Owner.InternalName : info.SatellitePalette;
-				world.AddFrameEndTask(w => w.Add(new GpsSatellite(world, pos, info.SatelliteImage, info.SatelliteSequence, palette)));
+				world.AddFrameEndTask(w => w.Add(new GpsSatellite(world, pos, info.SatelliteImage, info.SatelliteSequence, palette, info.RevealDelay * 25, launcher.Owner)));
 			}
 		}
 

--- a/OpenRA.Mods.RA/Traits/GpsWatcher.cs
+++ b/OpenRA.Mods.RA/Traits/GpsWatcher.cs
@@ -48,30 +48,26 @@ namespace OpenRA.Mods.RA.Traits
 		public void GpsRemove(Actor atek)
 		{
 			actors.Remove(atek);
-			RefreshGps(atek);
+			RefreshGps(atek.Owner);
 		}
 
 		public void GpsAdd(Actor atek)
 		{
 			actors.Add(atek);
-			RefreshGps(atek);
+			RefreshGps(atek.Owner);
 		}
 
-		public void Launch(Actor atek, GpsPowerInfo info)
+		public void ReachedOrbit(Player launcher)
 		{
-			atek.World.Add(new DelayedAction(info.RevealDelay * 25,
-				() =>
-				{
-					Launched = true;
-					RefreshGps(atek);
-				}));
+			Launched = true;
+			RefreshGps(launcher);
 		}
 
-		public void RefreshGps(Actor atek)
+		public void RefreshGps(Player launcher)
 		{
 			RefreshGranted();
 
-			foreach (var i in atek.World.ActorsWithTrait<GpsWatcher>())
+			foreach (var i in launcher.World.ActorsWithTrait<GpsWatcher>())
 				i.Trait.RefreshGranted();
 		}
 

--- a/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.RA/Traits/SupportPowers/GpsPower.cs
@@ -79,8 +79,6 @@ namespace OpenRA.Mods.RA.Traits
 					Info.LaunchSpeechNotification, self.Owner.Faction.InternalName);
 
 				w.Add(new SatelliteLaunch(self, info));
-
-				owner.Launch(self, info);
 			});
 		}
 


### PR DESCRIPTION
This is the first of multiple `DelayedAction`-removing PRs.

GPS is probably amongst the most fragile pieces of code in OpenRA, so this gets its own PR in order to not block easier cases.
