### PR TITLE
Refactor Shroud and shroud-modifying traits

### DIFF
--- a/OpenRA.Mods.Common/Traits/AffectsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/AffectsShroud.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 				.ToArray();
 		}
 
-		public void Tick(Actor self)
+		void ITick.Tick(Actor self)
 		{
 			if (!self.IsInWorld)
 				return;
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public void AddedToWorld(Actor self)
+		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
 			var centerPosition = self.CenterPosition;
 			var projectedPos = centerPosition - new WVec(0, centerPosition.Z, centerPosition.Z);
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.Traits
 				AddCellsToPlayerShroud(self, p, cells);
 		}
 
-		public void RemovedFromWorld(Actor self)
+		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
 		{
 			foreach (var p in self.World.Players)
 				RemoveCellsFromPlayerShroud(self, p);

--- a/OpenRA.Mods.Common/Traits/AffectsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/AffectsShroud.cs
@@ -14,30 +14,29 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public abstract class AffectsShroudInfo : ITraitInfo
+	public abstract class AffectsShroudInfo : UpgradableTraitInfo
 	{
 		public readonly WDist Range = WDist.Zero;
 
 		[Desc("Possible values are CenterPosition (measure range from the center) and ",
 			"Footprint (measure range from the footprint)")]
 		public readonly VisibilityType Type = VisibilityType.Footprint;
-
-		public abstract object Create(ActorInitializer init);
 	}
 
-	public abstract class AffectsShroud : ITick, ISync, INotifyAddedToWorld, INotifyRemovedFromWorld
+	public abstract class AffectsShroud : UpgradableTrait<AffectsShroudInfo>, ITick, ISync, INotifyAddedToWorld, INotifyRemovedFromWorld
 	{
 		static readonly PPos[] NoCells = { };
 
-		readonly AffectsShroudInfo info;
 		[Sync] CPos cachedLocation;
 		[Sync] bool cachedDisabled;
+		[Sync] bool cachedTraitDisabled;
 
 		protected abstract void AddCellsToPlayerShroud(Actor self, Player player, PPos[] uv);
 		protected abstract void RemoveCellsFromPlayerShroud(Actor self, Player player);
 		protected virtual bool IsDisabled(Actor self) { return false; }
 
-		public AffectsShroud(Actor self, AffectsShroudInfo info) { this.info = info; }
+		public AffectsShroud(Actor self, AffectsShroudInfo info)
+			: base(info) { }
 
 		PPos[] ProjectedCells(Actor self)
 		{
@@ -46,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (range == WDist.Zero)
 				return NoCells;
 
-			if (info.Type == VisibilityType.Footprint)
+			if (Info.Type == VisibilityType.Footprint)
 				return self.OccupiesSpace.OccupiedCells()
 					.SelectMany(kv => Shroud.ProjectedCellsInRange(map, kv.First, range))
 					.Distinct().ToArray();
@@ -64,12 +63,14 @@ namespace OpenRA.Mods.Common.Traits
 			var projectedPos = centerPosition - new WVec(0, centerPosition.Z, centerPosition.Z);
 			var projectedLocation = self.World.Map.CellContaining(projectedPos);
 			var disabled = IsDisabled(self);
+			var traitDisabled = IsTraitDisabled;
 
-			if (cachedLocation == projectedLocation && cachedDisabled == disabled)
+			if (cachedLocation == projectedLocation && traitDisabled == cachedTraitDisabled && cachedDisabled == disabled)
 				return;
 
 			cachedLocation = projectedLocation;
 			cachedDisabled = disabled;
+			cachedTraitDisabled = traitDisabled;
 
 			var cells = ProjectedCells(self);
 			foreach (var p in self.World.Players)
@@ -85,7 +86,9 @@ namespace OpenRA.Mods.Common.Traits
 			var projectedPos = centerPosition - new WVec(0, centerPosition.Z, centerPosition.Z);
 			cachedLocation = self.World.Map.CellContaining(projectedPos);
 			cachedDisabled = IsDisabled(self);
+			cachedTraitDisabled = IsTraitDisabled;
 			var cells = ProjectedCells(self);
+
 			foreach (var p in self.World.Players)
 				AddCellsToPlayerShroud(self, p, cells);
 		}
@@ -96,6 +99,6 @@ namespace OpenRA.Mods.Common.Traits
 				RemoveCellsFromPlayerShroud(self, p);
 		}
 
-		public WDist Range { get { return cachedDisabled ? WDist.Zero : info.Range; } }
+		public WDist Range { get { return (cachedDisabled || cachedTraitDisabled) ? WDist.Zero : Info.Range; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/CreatesShroud.cs
+++ b/OpenRA.Mods.Common/Traits/CreatesShroud.cs
@@ -20,8 +20,15 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public CreatesShroud(Actor self, CreatesShroudInfo info)
 			: base(self, info) { }
-		protected override void AddCellsToPlayerShroud(Actor self, Player p, PPos[] uv) { p.Shroud.AddProjectedShroudGeneration(self, uv); }
-		protected override void RemoveCellsFromPlayerShroud(Actor self, Player p) { p.Shroud.RemoveShroudGeneration(self); }
+
+		protected override void AddCellsToPlayerShroud(Actor self, Player p, PPos[] uv)
+		{
+			if (!self.Owner.IsAlliedWith(p))
+				p.Shroud.AddProjectedShroudGeneration(this, uv);
+		}
+
+		protected override void RemoveCellsFromPlayerShroud(Actor self, Player p) { p.Shroud.RemoveShroudGeneration(this); }
+
 		protected override bool IsDisabled(Actor self) { return self.IsDisabled(); }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/CreatesShroud.cs
+++ b/OpenRA.Mods.Common/Traits/CreatesShroud.cs
@@ -9,22 +9,31 @@
  */
 #endregion
 
+using OpenRA.Traits;
+
 namespace OpenRA.Mods.Common.Traits
 {
 	public class CreatesShroudInfo : AffectsShroudInfo
 	{
+		[Desc("Stance the watching player needs to see the generated shroud.")]
+		public readonly Stance ValidStances = Stance.Neutral | Stance.Enemy;
+
 		public override object Create(ActorInitializer init) { return new CreatesShroud(init.Self, this); }
 	}
 
 	public class CreatesShroud : AffectsShroud
 	{
+		readonly CreatesShroudInfo info;
+
 		public CreatesShroud(Actor self, CreatesShroudInfo info)
-			: base(self, info) { }
+			: base(self, info) { this.info = info; }
 
 		protected override void AddCellsToPlayerShroud(Actor self, Player p, PPos[] uv)
 		{
-			if (!self.Owner.IsAlliedWith(p))
-				p.Shroud.AddProjectedShroudGeneration(this, uv);
+			if (!info.ValidStances.HasStance(p.Stances[self.Owner]))
+				return;
+
+			p.Shroud.AddProjectedShroudGeneration(this, uv);
 		}
 
 		protected override void RemoveCellsFromPlayerShroud(Actor self, Player p) { p.Shroud.RemoveShroudGeneration(this); }

--- a/OpenRA.Mods.Common/Traits/RevealsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/RevealsShroud.cs
@@ -20,7 +20,13 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public RevealsShroud(Actor self, RevealsShroudInfo info)
 			: base(self, info) { }
-		protected override void AddCellsToPlayerShroud(Actor self, Player p, PPos[] uv) { p.Shroud.AddProjectedVisibility(self, uv); }
-		protected override void RemoveCellsFromPlayerShroud(Actor self, Player p) { p.Shroud.RemoveVisibility(self); }
+
+		protected override void AddCellsToPlayerShroud(Actor self, Player p, PPos[] uv)
+		{
+			if (self.Owner.IsAlliedWith(p))
+				p.Shroud.AddProjectedVisibility(this, uv);
+		}
+
+		protected override void RemoveCellsFromPlayerShroud(Actor self, Player p) { p.Shroud.RemoveVisibility(this); }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/RevealsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/RevealsShroud.cs
@@ -9,22 +9,31 @@
  */
 #endregion
 
+using OpenRA.Traits;
+
 namespace OpenRA.Mods.Common.Traits
 {
 	public class RevealsShroudInfo : AffectsShroudInfo
 	{
+		[Desc("Stance the watching player needs to see the shroud removed.")]
+		public readonly Stance ValidStances = Stance.Ally;
+
 		public override object Create(ActorInitializer init) { return new RevealsShroud(init.Self, this); }
 	}
 
 	public class RevealsShroud : AffectsShroud
 	{
+		readonly RevealsShroudInfo info;
+
 		public RevealsShroud(Actor self, RevealsShroudInfo info)
-			: base(self, info) { }
+			: base(self, info) { this.info = info; }
 
 		protected override void AddCellsToPlayerShroud(Actor self, Player p, PPos[] uv)
 		{
-			if (self.Owner.IsAlliedWith(p))
-				p.Shroud.AddProjectedVisibility(this, uv);
+			if (!info.ValidStances.HasStance(p.Stances[self.Owner]))
+				return;
+
+			p.Shroud.AddProjectedVisibility(this, uv);
 		}
 
 		protected override void RemoveCellsFromPlayerShroud(Actor self, Player p) { p.Shroud.RemoveVisibility(this); }


### PR DESCRIPTION
To support upgradability of `AffectsShroud`-derivatives and improve flexibility of `Shroud` itself.

Code changes split from #12267 (which serves as test-case until this is merged).
