### PR TITLE
ScrollPanelWidget - Fix frame end task race condition

### DIFF
--- a/OpenRA.Game/Primitives/IObservableCollection.cs
+++ b/OpenRA.Game/Primitives/IObservableCollection.cs
@@ -16,11 +16,11 @@ namespace OpenRA.Primitives
 {
 	public interface IObservableCollection
 	{
-		event Action<object> OnAdd;
-		event Action<object> OnRemove;
-		event Action<int> OnRemoveAt;
-		event Action<object, object> OnSet;
-		event Action OnRefresh;
+		event Action<IObservableCollection, object> OnAdd;
+		event Action<IObservableCollection, object> OnRemove;
+		event Action<IObservableCollection, int> OnRemoveAt;
+		event Action<IObservableCollection, object, object> OnSet;
+		event Action<IObservableCollection> OnRefresh;
 		IEnumerable ObservedItems { get; }
 	}
 }

--- a/OpenRA.Game/Primitives/ObservableCollection.cs
+++ b/OpenRA.Game/Primitives/ObservableCollection.cs
@@ -18,15 +18,15 @@ namespace OpenRA.Primitives
 {
 	public class ObservableCollection<T> : Collection<T>, IObservableCollection
 	{
-		public event Action<object> OnAdd = k => { };
+		public event Action<IObservableCollection, object> OnAdd = (x, k) => { };
 
 		// TODO Workaround for https://github.com/OpenRA/OpenRA/issues/6101
 		#pragma warning disable 67
-		public event Action<object> OnRemove = k => { };
+		public event Action<IObservableCollection, object> OnRemove = (x, k) => { };
 		#pragma warning restore
-		public event Action<int> OnRemoveAt = i => { };
-		public event Action<object, object> OnSet = (o, n) => { };
-		public event Action OnRefresh = () => { };
+		public event Action<IObservableCollection, int> OnRemoveAt = (x, i) => { };
+		public event Action<IObservableCollection, object, object> OnSet = (x, o, n) => { };
+		public event Action<IObservableCollection> OnRefresh = x => { };
 
 		public ObservableCollection() { }
 		public ObservableCollection(IList<T> list) : base(list) { }
@@ -35,25 +35,25 @@ namespace OpenRA.Primitives
 		{
 			var old = this[index];
 			base.SetItem(index, item);
-			OnSet(old, item);
+			OnSet(this, old, item);
 		}
 
 		protected override void InsertItem(int index, T item)
 		{
 			base.InsertItem(index, item);
-			OnAdd(item);
+			OnAdd(this, item);
 		}
 
 		protected override void ClearItems()
 		{
 			base.ClearItems();
-			OnRefresh();
+			OnRefresh(this);
 		}
 
 		protected override void RemoveItem(int index)
 		{
 			base.RemoveItem(index);
-			OnRemoveAt(index);
+			OnRemoveAt(this, index);
 		}
 
 		public IEnumerable ObservedItems

--- a/OpenRA.Game/Primitives/ObservableDictionary.cs
+++ b/OpenRA.Game/Primitives/ObservableDictionary.cs
@@ -33,19 +33,19 @@ namespace OpenRA.Primitives
 	{
 		protected IDictionary<TKey, TValue> innerDict;
 
-		public event Action<object> OnAdd = k => { };
-		public event Action<object> OnRemove = k => { };
+		public event Action<IObservableCollection, object> OnAdd = (x, k) => { };
+		public event Action<IObservableCollection, object> OnRemove = (x, k) => { };
 
 		// TODO Workaround for https://github.com/OpenRA/OpenRA/issues/6101
 		#pragma warning disable 67
-		public event Action<int> OnRemoveAt = i => { };
-		public event Action<object, object> OnSet = (o, n) => { };
+		public event Action<IObservableCollection, int> OnRemoveAt = (x, i) => { };
+		public event Action<IObservableCollection, object, object> OnSet = (x, o, n) => { };
 		#pragma warning restore
-		public event Action OnRefresh = () => { };
+		public event Action<IObservableCollection> OnRefresh = x => { };
 
 		protected void FireOnRefresh()
 		{
-			OnRefresh();
+			OnRefresh(this);
 		}
 
 		protected ObservableDictionary() { }
@@ -58,14 +58,14 @@ namespace OpenRA.Primitives
 		public virtual void Add(TKey key, TValue value)
 		{
 			innerDict.Add(key, value);
-			OnAdd(key);
+			OnAdd(this, key);
 		}
 
 		public bool Remove(TKey key)
 		{
 			var found = innerDict.Remove(key);
 			if (found)
-				OnRemove(key);
+				OnRemove(this, key);
 			return found;
 		}
 
@@ -91,7 +91,7 @@ namespace OpenRA.Primitives
 		public void Clear()
 		{
 			innerDict.Clear();
-			OnRefresh();
+			OnRefresh(this);
 		}
 
 		public int Count

--- a/OpenRA.Game/Primitives/ObservableList.cs
+++ b/OpenRA.Game/Primitives/ObservableList.cs
@@ -19,19 +19,19 @@ namespace OpenRA.Primitives
 	{
 		protected IList<T> innerList;
 
-		public event Action<object> OnAdd = k => { };
-		public event Action<object> OnRemove = k => { };
+		public event Action<IObservableCollection, object> OnAdd = (x, k) => { };
+		public event Action<IObservableCollection, object> OnRemove = (x, k) => { };
 
 		// TODO Workaround for https://github.com/OpenRA/OpenRA/issues/6101
 		#pragma warning disable 67
-		public event Action<int> OnRemoveAt = i => { };
-		public event Action<object, object> OnSet = (o, n) => { };
+		public event Action<IObservableCollection, int> OnRemoveAt = (x, i) => { };
+		public event Action<IObservableCollection, object, object> OnSet = (x, o, n) => { };
 		#pragma warning restore
-		public event Action OnRefresh = () => { };
+		public event Action<IObservableCollection> OnRefresh = x => { };
 
 		protected void FireOnRefresh()
 		{
-			OnRefresh();
+			OnRefresh(this);
 		}
 
 		public ObservableList()
@@ -42,14 +42,14 @@ namespace OpenRA.Primitives
 		public virtual void Add(T item)
 		{
 			innerList.Add(item);
-			OnAdd(item);
+			OnAdd(this, item);
 		}
 
 		public bool Remove(T item)
 		{
 			var found = innerList.Remove(item);
 			if (found)
-				OnRemove(item);
+				OnRemove(this, item);
 
 			return found;
 		}
@@ -57,13 +57,13 @@ namespace OpenRA.Primitives
 		public void Clear()
 		{
 			innerList.Clear();
-			OnRefresh();
+			OnRefresh(this);
 		}
 
 		public void Insert(int index, T item)
 		{
 			innerList.Insert(index, item);
-			OnRefresh();
+			OnRefresh(this);
 		}
 
 		public int Count { get { return innerList.Count; } }
@@ -73,7 +73,7 @@ namespace OpenRA.Primitives
 		public void RemoveAt(int index)
 		{
 			innerList.RemoveAt(index);
-			OnRemoveAt(index);
+			OnRemoveAt(this, index);
 		}
 
 		public T this[int index]
@@ -87,7 +87,7 @@ namespace OpenRA.Primitives
 			{
 				var oldValue = innerList[index];
 				innerList[index] = value;
-				OnSet(oldValue, value);
+				OnSet(this, oldValue, value);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
@@ -374,9 +374,15 @@ namespace OpenRA.Mods.Common.Widgets
 			});
 		}
 
-		void BindingAdd(object item)
+		void BindingAdd(IObservableCollection col, object item)
 		{
-			Game.RunAfterTick(() => BindingAddImpl(item));
+			Game.RunAfterTick(() =>
+			{
+				if (collection != col)
+					return;
+
+				BindingAddImpl(item);
+			});
 		}
 
 		void BindingAddImpl(object item)
@@ -393,30 +399,40 @@ namespace OpenRA.Mods.Common.Widgets
 				ScrollToBottom();
 		}
 
-		void BindingRemove(object item)
+		void BindingRemove(IObservableCollection col, object item)
 		{
 			Game.RunAfterTick(() =>
 			{
+				if (collection != col)
+					return;
+
 				var widget = Children.FirstOrDefault(w => widgetItemEquals(w, item));
 				if (widget != null)
 					RemoveChild(widget);
 			});
 		}
 
-		void BindingRemoveAt(int index)
+		void BindingRemoveAt(IObservableCollection col, int index)
 		{
 			Game.RunAfterTick(() =>
 			{
+				if (collection != col)
+					return;
+
 				if (index < 0 || index >= Children.Count)
 					return;
+
 				RemoveChild(Children[index]);
 			});
 		}
 
-		void BindingSet(object oldItem, object newItem)
+		void BindingSet(IObservableCollection col, object oldItem, object newItem)
 		{
 			Game.RunAfterTick(() =>
 			{
+				if (collection != col)
+					return;
+
 				var newWidget = makeWidget(newItem);
 				newWidget.Parent = this;
 
@@ -433,10 +449,13 @@ namespace OpenRA.Mods.Common.Widgets
 			});
 		}
 
-		void BindingRefresh()
+		void BindingRefresh(IObservableCollection col)
 		{
 			Game.RunAfterTick(() =>
 			{
+				if (collection != col)
+					return;
+
 				RemoveChildren();
 				foreach (var item in collection.ObservedItems)
 					BindingAddImpl(item);


### PR DESCRIPTION
This fixes #12271, which seems to be caused by a race condition. The global chat history or nickname panel has a chance to pass in `null` for `Game.GlobalChat.History` or `Game.GlobalChat.Users` during binding. What this will do is set `collection = null`, and `BindingRefresh()` would get caught with an NRE. What's interesting to me is it seemed like:
- Event bindings on `collection` are being cleared.
- `Collection` is being set null.
- For some reason, the event `BindingRefresh` still gets called, even though this event is not bound if `c == null` (I am assuming RunAfterTick causes this behavior).

I didn't go with adding a null check inside of `BindingRefresh` since it felt like a symptom of the problem, and I'm starting to get familiar with the scroll panel widget. 
