### PR TITLE
Fix dedicated server crash with AllowPortForward.

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -138,7 +138,8 @@ namespace OpenRA.Server
 
 			randomSeed = (int)DateTime.Now.ToBinary();
 
-			if (Settings.AllowPortForward)
+			// UPnP is only supported for servers created by the game client.
+			if (!dedicated && Settings.AllowPortForward)
 				UPnP.ForwardPort(Settings.ListenPort, Settings.ExternalPort).Wait();
 
 			foreach (var trait in modData.Manifest.ServerTraits)
@@ -209,7 +210,7 @@ namespace OpenRA.Server
 					if (State == ServerState.ShuttingDown)
 					{
 						EndGame();
-						if (Settings.AllowPortForward)
+						if (!dedicated && Settings.AllowPortForward)
 							UPnP.RemovePortForward().Wait();
 						break;
 					}

--- a/launch-dedicated.cmd
+++ b/launch-dedicated.cmd
@@ -7,12 +7,11 @@ set Mod=ra
 set ListenPort=1234
 set ExternalPort=1234
 set AdvertiseOnline=True
-set AllowPortForward=False
 set EnableSingleplayer=False
 set Password=""
 
 :loop
 
-OpenRA.Server.exe Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.ExternalPort=%ExternalPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.AllowPortForward=%AllowPortForward% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password%
+OpenRA.Server.exe Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.ExternalPort=%ExternalPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password%
 
 goto loop

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -11,13 +11,12 @@ Mod="${Mod:-"ra"}"
 ListenPort="${ListenPort:-"1234"}"
 ExternalPort="${ExternalPort:-"1234"}"
 AdvertiseOnline="${AdvertiseOnline:-"True"}"
-AllowPortForward="${AllowPortForward:-"False"}"
 EnableSingleplayer="${EnableSingleplayer:-"False"}"
 Password="${Password:-""}"
 
 while true; do
      mono --debug OpenRA.Server.exe Game.Mod=$Mod \
      Server.Name="$Name" Server.ListenPort=$ListenPort Server.ExternalPort=$ExternalPort \
-     Server.AdvertiseOnline=$AdvertiseOnline Server.AllowPortForward=$AllowPortForward \
+     Server.AdvertiseOnline=$AdvertiseOnline \
      Server.EnableSingleplayer=$EnableSingleplayer Server.Password=$Password
 done


### PR DESCRIPTION
UPnP is provided as a convenience for players who want to spin up a temporary server ingame.  We don't (and have no intention to) support it for dedicated servers, and will crash if someone tries to launch a dedicated server with `AllowPortForward=true` (because the UPnP state has not been initialized).

This fixes #12263 by force-disabling the UPnP calls on dedicated servers.
