### PR TITLE
Prevent attacking units from knowing that a frozen building is dead

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -103,6 +103,7 @@ Also thanks to:
     * Nukem
     * Okunev Yu Dmitry (xaionaro)
     * Olaf van der Spek
+    * Ori Bar (tohava)
     * Paolo Chiodi (paolochiodi)
     * Paul Dovydaitis (pdovy)
     * Pavlos Touboulidis (pav)

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -72,6 +72,10 @@ namespace OpenRA.Traits
 					if (actor.Generation != generation)
 						return TargetType.Invalid;
 				}
+				else if (type == TargetType.FrozenActor && !frozen.Visible)
+				{
+					return TargetType.Invalid;
+				}
 
 				return type;
 			}

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -78,10 +78,11 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 
 			var type = Target.Type;
-			if (!Target.IsValidFor(self) || type == TargetType.FrozenActor)
+			if (!Target.IsValidFor(self))
 				return NextActivity;
 
-			if (attack.Info.AttackRequiresEnteringCell && !positionable.CanEnterCell(Target.Actor.Location, null, false))
+			var positionableLoc = self.World.Map.CellContaining(Target.CenterPosition);
+			if (attack.Info.AttackRequiresEnteringCell && !positionable.CanEnterCell(positionableLoc, null, false))
 				return NextActivity;
 
 			// Drop the target if it moves under the shroud / fog.

--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -80,24 +80,7 @@ namespace OpenRA.Mods.Common
 			// Flashes the frozen proxy
 			self.SetTargetLine(frozen, targetLine, true);
 
-			// Target is still alive - resolve the real order
-			if (frozen.Actor != null && frozen.Actor.IsInWorld)
-				return Target.FromActor(frozen.Actor);
-
-			if (!order.Queued)
-				self.CancelActivity();
-
-			var move = self.TraitOrDefault<IMove>();
-			if (move != null)
-			{
-				// Move within sight range of the frozen actor
-				var sight = self.TraitOrDefault<RevealsShroud>();
-				var range = sight != null ? sight.Range : WDist.FromCells(2);
-
-				self.QueueActivity(move.MoveWithinRange(Target.FromPos(frozen.CenterPosition), range));
-			}
-
-			return Target.Invalid;
+			return Target.FromFrozenActor(frozen);
 		}
 
 		public static void NotifyBlocker(this Actor self, IEnumerable<Actor> blockers)


### PR DESCRIPTION
Prevent units attacking a frozen building from magically knowing whether it is destroyed or not. (Note: I'm aware that this patch is not perfect yet. If you will tell me what else needs to be fixed, I will fix it).