### PR TITLE
Added distinction between RA minelayers

### DIFF
--- a/mods/ra/maps/allies-03a/rules.yaml
+++ b/mods/ra/maps/allies-03a/rules.yaml
@@ -136,7 +136,7 @@ MCV:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY.AP:
+MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 

--- a/mods/ra/maps/allies-05a/rules.yaml
+++ b/mods/ra/maps/allies-05a/rules.yaml
@@ -161,7 +161,7 @@ MCV:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY.AP:
+MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 

--- a/mods/ra/maps/evacuation/rules.yaml
+++ b/mods/ra/maps/evacuation/rules.yaml
@@ -152,11 +152,11 @@ APC:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY.AP:
+MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY.AT:
+MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 

--- a/mods/ra/maps/evacuation/rules.yaml
+++ b/mods/ra/maps/evacuation/rules.yaml
@@ -156,10 +156,6 @@ MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY:
-	Buildable:
-		Prerequisites: ~disabled
-
 TRUK:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/exodus/rules.yaml
+++ b/mods/ra/maps/exodus/rules.yaml
@@ -142,10 +142,6 @@ MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY:
-	Buildable:
-		Prerequisites: ~disabled
-
 TRUK:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/exodus/rules.yaml
+++ b/mods/ra/maps/exodus/rules.yaml
@@ -138,11 +138,11 @@ APC:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY.AP:
+MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY.AT:
+MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 

--- a/mods/ra/maps/infiltration/rules.yaml
+++ b/mods/ra/maps/infiltration/rules.yaml
@@ -193,10 +193,6 @@ MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY:
-	Buildable:
-		Prerequisites: ~disabled
-
 TTNK:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/infiltration/rules.yaml
+++ b/mods/ra/maps/infiltration/rules.yaml
@@ -189,11 +189,11 @@ APC:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY.AP:
+MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY.AT:
+MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 

--- a/mods/ra/maps/intervention/rules.yaml
+++ b/mods/ra/maps/intervention/rules.yaml
@@ -159,11 +159,11 @@ MGG:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY.AT:
+MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY.AP:
+MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 

--- a/mods/ra/maps/intervention/rules.yaml
+++ b/mods/ra/maps/intervention/rules.yaml
@@ -163,10 +163,6 @@ MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY:
-	Buildable:
-		Prerequisites: ~disabled
-
 MRJ:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/monster-tank-madness/rules.yaml
+++ b/mods/ra/maps/monster-tank-madness/rules.yaml
@@ -212,11 +212,11 @@ MCV:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY.AP:
+MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY.AT:
+MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 

--- a/mods/ra/maps/monster-tank-madness/rules.yaml
+++ b/mods/ra/maps/monster-tank-madness/rules.yaml
@@ -216,10 +216,6 @@ MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY:
-	Buildable:
-		Prerequisites: ~disabled
-
 TTNK:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/soviet-05/map.yaml
+++ b/mods/ra/maps/soviet-05/map.yaml
@@ -405,7 +405,7 @@ Actors:
 		SubCell: 1
 		Facing: 96
 		TurretFacing: 192
-	Minelayer: mnly.at
+	Minelayer: mnly
 		Owner: GoodGuy
 		Location: 67,45
 		Facing: 92

--- a/mods/ra/maps/soviet-06a/rules.yaml
+++ b/mods/ra/maps/soviet-06a/rules.yaml
@@ -142,7 +142,7 @@ GAP:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY.AT:
+MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 

--- a/mods/ra/maps/soviet-06b/rules.yaml
+++ b/mods/ra/maps/soviet-06b/rules.yaml
@@ -142,7 +142,7 @@ GAP:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY.AT:
+MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 

--- a/mods/ra/maps/survival01/rules.yaml
+++ b/mods/ra/maps/survival01/rules.yaml
@@ -108,10 +108,6 @@ MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY:
-	Buildable:
-		Prerequisites: ~disabled
-
 TTNK:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/survival01/rules.yaml
+++ b/mods/ra/maps/survival01/rules.yaml
@@ -104,11 +104,11 @@ MCV:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY.AP:
+MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY.AT:
+MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 

--- a/mods/ra/maps/survival02/rules.yaml
+++ b/mods/ra/maps/survival02/rules.yaml
@@ -86,10 +86,6 @@ MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY:
-	Buildable:
-		Prerequisites: ~disabled
-
 TTNK:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/survival02/rules.yaml
+++ b/mods/ra/maps/survival02/rules.yaml
@@ -82,11 +82,11 @@ MCV:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY.AP:
+MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY.AT:
+MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 

--- a/mods/ra/maps/training-camp/rules.yaml
+++ b/mods/ra/maps/training-camp/rules.yaml
@@ -256,10 +256,6 @@ MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY:
-	Buildable:
-		Prerequisites: ~disabled
-
 TRUK:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/training-camp/rules.yaml
+++ b/mods/ra/maps/training-camp/rules.yaml
@@ -252,11 +252,11 @@ MCV:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY.AP:
+MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 
-MNLY.AT:
+MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -403,7 +403,7 @@ MNLY.AP:
 		Queue: Vehicle
 		BuildPaletteOrder: 110
 		Prerequisites: fix, ~vehicles.soviet, ~techlevel.medium
-		Description: Lays mines to destroy\nunwary enemy units.\nCan detect mines.\n  Unarmed
+		Description: Lays anti-personnel mines to destroy\nunwary enemy soldiers.\nCan detect mines.\n  Unarmed
 	Valued:
 		Cost: 800
 	Tooltip:
@@ -438,7 +438,7 @@ MNLY.AT:
 		Queue: Vehicle
 		BuildPaletteOrder: 100
 		Prerequisites: fix, ~vehicles.allies, ~techlevel.medium
-		Description: Lays mines to destroy\nunwary enemy units.\nCan detect mines.\n  Unarmed
+		Description: Lays anti-tank mines to destroy\nunwary enemy units.\nCan detect mines.\n  Unarmed
 	Valued:
 		Cost: 800
 	Tooltip:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -72,7 +72,7 @@ V2RL:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 120
+		BuildPaletteOrder: 110
 		Prerequisites: fix, ~vehicles.allies, ~techlevel.medium
 		Description: Allied Main Battle Tank.\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
 	Valued:
@@ -111,7 +111,7 @@ V2RL:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 130
+		BuildPaletteOrder: 120
 		Prerequisites: fix, ~vehicles.soviet, ~techlevel.medium
 		Description: Soviet Main Battle Tank, with dual cannons\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
 	Valued:
@@ -150,7 +150,7 @@ V2RL:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 190
+		BuildPaletteOrder: 180
 		Prerequisites: fix, stek, ~vehicles.soviet, ~techlevel.high
 		BuildDuration: 2500
 		BuildDurationModifier: 40
@@ -397,48 +397,13 @@ APC:
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 
-MNLY.AP:
-	Inherits: ^Tank
-	Buildable:
-		Queue: Vehicle
-		BuildPaletteOrder: 110
-		Prerequisites: fix, ~vehicles.soviet, ~techlevel.medium
-		Description: Lays anti-personnel mines to destroy\nunwary enemy soldiers.\nCan detect mines.\n  Unarmed
-	Valued:
-		Cost: 800
-	Tooltip:
-		Name: Minelayer
-	Health:
-		HP: 150
-	Armor:
-		Type: Heavy
-	Mobile:
-		Speed: 128
-		Crushes: wall, mine, crate, infantry
-	RevealsShroud:
-		Range: 5c0
-	Minelayer:
-		Mine: MINP
-	MineImmune:
-	AmmoPool:
-		Ammo: 5
-		RearmSound: minelay1.aud
-	DetectCloaked:
-		Range: 5c0
-		CloakTypes: Mine
-	RenderDetectionCircle:
-	Explodes:
-		Weapon: APMine
-	RenderSprites:
-		Image: MNLY
-
-MNLY.AT:
+MNLY:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 100
-		Prerequisites: fix, ~vehicles.allies, ~techlevel.medium
-		Description: Lays anti-tank mines to destroy\nunwary enemy units.\nCan detect mines.\n  Unarmed
+		Prerequisites: fix, ~techlevel.medium
+		Description: Lays mines to destroy\nunwary enemy units.\nCan detect mines.\n  Unarmed
 	Valued:
 		Cost: 800
 	Tooltip:
@@ -496,7 +461,7 @@ MGG:
 	Inherits: ^Vehicle
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 160
+		BuildPaletteOrder: 150
 		Prerequisites: atek, ~vehicles.france, ~techlevel.high
 		Description: Regenerates the shroud nearby, \nobscuring the area.\n  Unarmed
 	Valued:
@@ -528,7 +493,7 @@ MRJ:
 		Name: Mobile Radar Jammer
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 150
+		BuildPaletteOrder: 140
 		Prerequisites: atek, ~vehicles.allies, ~techlevel.high
 		Description: Jams nearby enemy radar domes\nand deflects incoming missiles.\nCan detect cloaked units.\n  Unarmed
 	Health:
@@ -555,7 +520,7 @@ TTNK:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 180
+		BuildPaletteOrder: 170
 		Prerequisites: tsla, stek, ~vehicles.russia, ~techlevel.high
 		Description: Tank with mounted tesla coil.\n  Strong vs Infantry, Vehicles, Buildings\n  Weak vs Aircraft
 	Valued:
@@ -630,7 +595,7 @@ DTRK:
 	Inherits: ^Vehicle
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 170
+		BuildPaletteOrder: 160
 		Prerequisites: stek, ~vehicles.ukraine, ~techlevel.high
 		Description: Demolition Truck, actively armed with\nnuclear explosives. Has very weak armor.
 	Valued:
@@ -660,7 +625,7 @@ CTNK:
 	Inherits: ^Vehicle
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 210
+		BuildPaletteOrder: 200
 		Prerequisites: atek, ~vehicles.germany, ~techlevel.high
 		Description: Chrono Tank, teleports to areas within range.\n  Strong vs Vehicles, Buildings\n  Weak vs Infantry, Aircraft\n  Special ability: Can teleport
 	Valued:
@@ -697,7 +662,7 @@ QTNK:
 	Inherits: ^Tank
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 200
+		BuildPaletteOrder: 190
 		Prerequisites: fix, stek, ~vehicles.soviet, ~techlevel.high
 		Description: Deals seismic damage to nearby vehicles\nand structures.\n  Strong vs Vehicles, Buildings\n  Weak vs Infantry, Aircraft
 	Valued:
@@ -724,7 +689,7 @@ STNK:
 	Inherits: ^Vehicle
 	Buildable:
 		Queue: Vehicle
-		BuildPaletteOrder: 140
+		BuildPaletteOrder: 130
 		Prerequisites: atek, ~vehicles.england, ~techlevel.high
 		Description: Lightly armored infantry transport\nwhich can cloak. Can detect cloaked units.\n  Strong vs Light armor\n  Weak vs Infantry, Tanks, Aircraft
 	Valued:


### PR DESCRIPTION
Changed tooltip for allied and soviet minelayer, making clear which one lays anti-personnel or anti-tank mines. In "release-20161019", two minelayers look the same in the menu, which creates problems if you capture a factory from opposing faction.