### PR TITLE
Remove hardcoded buildComplete delay in some overlays

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
@@ -67,8 +67,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		void INotifyBuildComplete.BuildingComplete(Actor self)
 		{
-			self.World.AddFrameEndTask(w => w.Add(new DelayedAction(120, () =>
-					buildComplete = true)));
+			buildComplete = true;
 		}
 
 		void INotifySold.Sold(Actor self) { }

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
@@ -61,8 +61,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		void INotifyBuildComplete.BuildingComplete(Actor self)
 		{
-			self.World.AddFrameEndTask(w => w.Add(new DelayedAction(120, () =>
-				buildComplete = true)));
+			buildComplete = true;
 		}
 
 		void INotifySold.Sold(Actor self) { }

--- a/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
@@ -71,8 +71,7 @@ namespace OpenRA.Mods.D2k.Traits.Render
 
 		void INotifyBuildComplete.BuildingComplete(Actor self)
 		{
-			self.World.AddFrameEndTask(w => w.Add(new DelayedAction(120, () =>
-				buildComplete = true)));
+			buildComplete = true;
 		}
 
 		void INotifySold.Sold(Actor self) { }


### PR DESCRIPTION
There certainly was and possibly still is some issue this was trying to work around, but unless it's a deal-breaker, we should rather try to fix that issue directly instead of keeping some uncommented magical work-around.

I couldn't spot any regressions in a D2k skirmish, all 3 overlays worked as intended there.

Contributes to #12310.