### PR TITLE
Make Radar Dome lose Detect Cloak ability when powered down 

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -520,6 +520,8 @@ DOME:
 	InfiltrateForExploration:
 	DetectCloaked:
 		Range: 10c0
+		UpgradeTypes: powered
+		UpgradeMinEnabledLevel: 1
 	RenderDetectionCircle:
 	Power:
 		Amount: -40


### PR DESCRIPTION
Fixes #12272 

I gave Radar Domes an upgrade "powered" that is revoked when the building is powered down. The linter is complaining because it thinks there's nothing granting the upgrade, which is true. However, it is enabled by default and is disabled by revoking the upgrade.