### PR TITLE
Fix the AmbientSound still playing when the actor is not in world

### DIFF
--- a/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
@@ -30,6 +30,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		ISound currentSound;
 		bool wasDisabled = true;
 		int interval;
+		WPos cachedPosition;
 
 		public AmbientSound(AmbientSoundInfo info)
 			: base(info)
@@ -47,13 +48,21 @@ namespace OpenRA.Mods.Common.Traits.Sound
 
 			if (Info.Interval <= 0)
 			{
-				if (!wasDisabled)
+				var moved = self.OccupiesSpace != null && cachedPosition != self.CenterPosition;
+				if (!wasDisabled && !moved)
 					return;
 
 				wasDisabled = false;
 
-				if (self.OccupiesSpace != null)
+				if (moved)
+				{
+					// Otherwise the sound never gets stopped when the actor is on the move
+					Game.Sound.StopSound(currentSound);
+					currentSound = null;
+
+					cachedPosition = self.CenterPosition;
 					currentSound = Game.Sound.PlayLooped(Info.SoundFile, self.CenterPosition);
+				}
 				else
 					currentSound = Game.Sound.PlayLooped(Info.SoundFile);
 

--- a/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		[Desc("Interval between playing the sound (in ticks).")]
 		public readonly int Interval = 0;
 
-		public override object Create(ActorInitializer init) { return new AmbientSound(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new AmbientSound(this); }
 	}
 
 	class AmbientSound : UpgradableTrait<AmbientSoundInfo>, ITick
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		bool wasDisabled = true;
 		int interval;
 
-		public AmbientSound(Actor self, AmbientSoundInfo info)
+		public AmbientSound(AmbientSoundInfo info)
 			: base(info)
 		{
 			interval = info.Interval;
@@ -47,18 +47,20 @@ namespace OpenRA.Mods.Common.Traits.Sound
 				return;
 			}
 
-			if (wasDisabled && Info.Interval <= 0)
+			if (Info.Interval <= 0)
 			{
+				if (!wasDisabled)
+					return;
+
+				wasDisabled = false;
+
 				if (self.OccupiesSpace != null)
 					currentSound = Game.Sound.PlayLooped(Info.SoundFile, self.CenterPosition);
 				else
 					currentSound = Game.Sound.PlayLooped(Info.SoundFile);
-			}
 
-			wasDisabled = false;
-
-			if (Info.Interval <= 0)
 				return;
+			}
 
 			if (interval-- > 0)
 				return;

--- a/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		public override object Create(ActorInitializer init) { return new AmbientSound(this); }
 	}
 
-	class AmbientSound : UpgradableTrait<AmbientSoundInfo>, ITick
+	class AmbientSound : UpgradableTrait<AmbientSoundInfo>, ITick, INotifyRemovedFromWorld
 	{
 		ISound currentSound;
 		bool wasDisabled = true;
@@ -39,11 +39,9 @@ namespace OpenRA.Mods.Common.Traits.Sound
 
 		public void Tick(Actor self)
 		{
-			if (IsTraitDisabled)
+			if (IsTraitDisabled || !self.IsInWorld)
 			{
-				Game.Sound.StopSound(currentSound);
-				currentSound = null;
-				wasDisabled = true;
+				StopSound();
 				return;
 			}
 
@@ -71,6 +69,18 @@ namespace OpenRA.Mods.Common.Traits.Sound
 				Game.Sound.Play(Info.SoundFile, self.CenterPosition);
 			else
 				Game.Sound.Play(Info.SoundFile);
+		}
+
+		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
+		{
+			StopSound();
+		}
+
+		void StopSound()
+		{
+			Game.Sound.StopSound(currentSound);
+			currentSound = null;
+			wasDisabled = true;
 		}
 	}
 }


### PR DESCRIPTION
Also fixes the origin of the sound not being updated for moving actors.
Imho we should really remove the "hack" when interval is zero. It's just a mess, sounds awful and blocks expanding the features of that trait. You could also use the length of the sound track as interval anyways.