### PR TITLE
Merge SpiceBloom RespawnDelay & GrowthDelay into Lifetime

### DIFF
--- a/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		public AmbientSound(Actor self, AmbientSoundInfo info)
 			: base(info)
 		{
-			delay = RandomDelay(self.World, info.Delay);
+			delay = Util.RandomDelay(self.World, info.Delay);
 			loop = Info.Interval.Length == 0 || (Info.Interval.Length == 1 && Info.Interval[0] == 0);
 		}
 
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 			{
 				StartSound(self);
 				if (!loop)
-					delay = RandomDelay(self.World, Info.Interval);
+					delay = Util.RandomDelay(self.World, Info.Interval);
 			}
 		}
 
@@ -89,18 +89,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 			currentSound = null;
 		}
 
-		static int RandomDelay(World world, int[] range)
-		{
-			if (range.Length == 0)
-				return 0;
-
-			if (range.Length == 1)
-				return range[0];
-
-			return world.SharedRandom.Next(range[0], range[1]);
-		}
-
-		protected override void TraitEnabled(Actor self) { delay = RandomDelay(self.World, Info.Delay); }
+		protected override void TraitEnabled(Actor self) { delay = Util.RandomDelay(self.World, Info.Delay); }
 		protected override void TraitDisabled(Actor self) { StopSound(); }
 
 		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self) { StopSound(); }

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -164,5 +164,16 @@ namespace OpenRA.Mods.Common
 				yield return p;
 			}
 		}
+
+		public static int RandomDelay(World world, int[] range)
+		{
+			if (range.Length == 0)
+				return 0;
+
+			if (range.Length == 1)
+				return range[0];
+
+			return world.SharedRandom.Next(range[0], range[1]);
+		}
 	}
 }

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -781,6 +781,26 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					if (node.Key.StartsWith("UpgradeOverlay", StringComparison.Ordinal))
 						RenameNodeKey(node, "WithColoredOverlay" + node.Key.Substring(14));
 
+				// Remove SpiceBloom.RespawnDelay to get rid of DelayedAction, and rename GrowthDelay to Lifetime
+				if (engineVersion < 20170203)
+				{
+					var spiceBloom = node.Value.Nodes.FirstOrDefault(n => n.Key == "SpiceBloom");
+					if (spiceBloom != null)
+					{
+						var respawnDelay = spiceBloom.Value.Nodes.FirstOrDefault(n => n.Key == "RespawnDelay");
+						if (respawnDelay != null)
+						{
+							spiceBloom.Value.Nodes.Remove(respawnDelay);
+							Console.WriteLine("RespawnDelay has been removed from SpiceBloom for technical reasons.");
+							Console.WriteLine("Increase self-kill delay of the spice bloom spawnpoint actor instead.");
+						}
+
+						var growthDelay = spiceBloom.Value.Nodes.FirstOrDefault(n => n.Key == "GrowthDelay");
+						if (growthDelay != null)
+							growthDelay.Key = "Lifetime";
+					}
+				}
+
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 

--- a/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
+++ b/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.D2k.Traits
 			anim.Animation.Play(info.GrowthSequences[0]);
 		}
 
-		public void Tick(Actor self)
+		void ITick.Tick(Actor self)
 		{
 			if (!self.World.Map.Contains(self.Location))
 				return;
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.D2k.Traits
 			}
 		}
 
-		public void Killed(Actor self, AttackInfo e)
+		void INotifyKilled.Killed(Actor self, AttackInfo e)
 		{
 			if (!string.IsNullOrEmpty(info.Weapon))
 				SeedResources(self);

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -4,8 +4,9 @@ spicebloom.spawnpoint:
 	AlwaysVisible:
 	RenderSpritesEditorOnly:
 		Image: spicebloom
+		Palette: effect50alpha
 	WithSpriteBody:
-		Sequence: grow1
+		Sequence: grow3
 	BodyOrientation:
 		QuantizedFacings: 1
 	ConditionManager:

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -1,16 +1,22 @@
 spicebloom.spawnpoint:
-	HiddenUnderShroud:
-		Type: CenterPosition
+	EditorOnlyTooltip:
+		Name: Spice Bloom spawnpoint
+	AlwaysVisible:
+	RenderSpritesEditorOnly:
+		Image: spicebloom
+	WithSpriteBody:
+		Sequence: grow1
 	BodyOrientation:
 		QuantizedFacings: 1
-	RenderSprites:
-		Image: spicebloom
-	SpiceBloom:
-		GrowthTerrainTypes: SpiceSand
-		SpawnActor: spicebloom
-		GrowthSequences: grow0
-		GrowthDelay: 250, 750
-		RespawnDelay: 1, 2
+	ConditionManager:
+	GrantConditionOnTerrain:
+		Condition: clearsand
+		TerrainTypes: SpiceSand
+	KillsSelf:
+		RequiresCondition: clearsand
+		Delay: 1750, 3250
+	SpawnActorOnDeath:
+		Actor: spicebloom
 	Explodes:
 		Weapon: BloomSpawn
 		EmptyWeapon: BloomSpawn

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -22,7 +22,8 @@ spicebloom.spawnpoint:
 		EmptyWeapon: BloomSpawn
 	Health:
 		HP: 9999
-		Radius: 1
+		Shape: Circle
+			Radius: 1
 	Immobile:
 		OccupiesSpace: false
 
@@ -49,7 +50,8 @@ spicebloom:
 	Immobile:
 	Health:
 		HP: 1
-		Radius: 512
+		Shape: Circle
+			Radius: 512
 	Targetable:
 		TargetTypes: Ground
 		RequiresForceFire: true


### PR DESCRIPTION
`RespawnDelay` is redundant (increasing the `spicebloom.spawnpoint`'s lifetime has basically the same effect) and allows us to scrap a `DelayedAction` and simplify the `SpiceBloom` code a little.

Additionally, this adds a new `KillsSelfAfterDelay` trait that allows us to ditch the `SpiceBloom` trait from the spicebloom.spawnpoint and might come in handy for other things in the future.

Contributes to #12310.