### PR TITLE
Remove DelayedActions from Demolish activity

### DIFF
--- a/OpenRA.Mods.Common/Activities/Demolish.cs
+++ b/OpenRA.Mods.Common/Activities/Demolish.cs
@@ -63,8 +63,7 @@ namespace OpenRA.Mods.Common.Activities
 					building.Lock();
 
 				for (var f = 0; f < flashes; f++)
-					w.Add(new DelayedAction(flashesDelay + f * flashInterval, () =>
-						w.Add(new FlashTarget(target, ticks: flashDuration))));
+					w.Add(new FlashTarget(target, null, flashDuration, flashesDelay + f * flashInterval));
 
 				w.Add(new DelayedAction(delay, () =>
 				{

--- a/OpenRA.Mods.Common/Activities/Demolish.cs
+++ b/OpenRA.Mods.Common/Activities/Demolish.cs
@@ -65,18 +65,8 @@ namespace OpenRA.Mods.Common.Activities
 				for (var f = 0; f < flashes; f++)
 					w.Add(new FlashTarget(target, null, flashDuration, flashesDelay + f * flashInterval));
 
-				w.Add(new DelayedAction(delay, () =>
-				{
-					if (target.IsDead)
-						return;
-
-					var modifiers = target.TraitsImplementing<IDamageModifier>()
-						.Concat(self.Owner.PlayerActor.TraitsImplementing<IDamageModifier>())
-						.Select(t => t.GetDamageModifier(self, null));
-
-					if (Util.ApplyPercentageModifiers(100, modifiers) > 0)
-						demolishables.Do(d => d.Demolish(target, self));
-				}));
+				foreach (var d in demolishables)
+					d.Demolish(target, self, delay);
 			});
 		}
 	}

--- a/OpenRA.Mods.Common/Effects/FlashTarget.cs
+++ b/OpenRA.Mods.Common/Effects/FlashTarget.cs
@@ -21,12 +21,14 @@ namespace OpenRA.Mods.Common.Effects
 		Actor target;
 		Player player;
 		int remainingTicks;
+		int delay;
 
-		public FlashTarget(Actor target, Player asPlayer = null, int ticks = 4)
+		public FlashTarget(Actor target, Player asPlayer = null, int ticks = 4, int delay = 0)
 		{
 			this.target = target;
 			player = asPlayer;
 			remainingTicks = ticks;
+			this.delay = delay;
 			target.World.RemoveAll(effect =>
 			{
 				var flashTarget = effect as FlashTarget;
@@ -36,13 +38,16 @@ namespace OpenRA.Mods.Common.Effects
 
 		public void Tick(World world)
 		{
+			if (--delay >= 0)
+				return;
+
 			if (--remainingTicks == 0 || !target.IsInWorld)
 				world.AddFrameEndTask(w => w.Remove(this));
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (target.IsInWorld && remainingTicks % 2 == 0)
+			if (target.IsInWorld && delay <= 0 && remainingTicks % 2 == 0)
 			{
 				var palette = wr.Palette(player == null ? "highlight" : "highlight" + player.InternalName);
 				return target.Render(wr)

--- a/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
@@ -76,9 +76,9 @@ namespace OpenRA.Mods.Common.Scripting
 
 		[Desc("Render a target flash on the actor. If set, 'asPlayer'",
 			"defines which player palette to use. Duration is in ticks.")]
-		public void Flash(int duration = 4, Player asPlayer = null)
+		public void Flash(int duration = 4, Player asPlayer = null, int delay = 0)
 		{
-			Self.World.Add(new FlashTarget(Self, asPlayer, duration));
+			Self.World.Add(new FlashTarget(Self, asPlayer, duration, delay));
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/BridgeHut.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BridgeHut.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 			Bridge.Do((b, d) => b.Repair(repairer, d, () => repairDirections--));
 		}
 
-		public void Demolish(Actor self, Actor saboteur)
+		void IDemolishable.Demolish(Actor self, Actor saboteur, int delay)
 		{
 			Bridge.Do((b, d) => b.Demolish(saboteur, d));
 		}

--- a/OpenRA.Mods.Common/Traits/Demolishable.cs
+++ b/OpenRA.Mods.Common/Traits/Demolishable.cs
@@ -9,6 +9,8 @@
  */
 #endregion
 
+using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -24,9 +26,12 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new Demolishable(init.Self, this); }
 	}
 
-	public class Demolishable : IDemolishable, IPreventsEjectOnDeath
+	public class Demolishable : IDemolishable, IPreventsEjectOnDeath, ITick
 	{
 		readonly DemolishableInfo info;
+
+		Actor saboteur;
+		int delay;
 
 		public Demolishable(Actor self, DemolishableInfo info)
 		{
@@ -38,14 +43,34 @@ namespace OpenRA.Mods.Common.Traits
 			return info.PreventsEjectOnDeath;
 		}
 
-		public void Demolish(Actor self, Actor saboteur)
+		public void Demolish(Actor self, Actor saboteur, int delay)
 		{
-			self.Kill(saboteur);
+			if (this.delay > 0)
+				return;
+
+			this.delay = delay;
+			this.saboteur = saboteur;
 		}
 
 		public bool IsValidTarget(Actor self, Actor saboteur)
 		{
 			return true;
+		}
+
+		void ITick.Tick(Actor self)
+		{
+			if (self.IsDead)
+				return;
+
+			if (delay == 0 || --delay > 0)
+				return;
+
+			var modifiers = self.TraitsImplementing<IDamageModifier>()
+				.Concat(saboteur.Owner.PlayerActor.TraitsImplementing<IDamageModifier>())
+				.Select(t => t.GetDamageModifier(saboteur, null));
+
+			if (Util.ApplyPercentageModifiers(100, modifiers) > 0)
+				self.Kill(saboteur);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Demolishable.cs
+++ b/OpenRA.Mods.Common/Traits/Demolishable.cs
@@ -71,6 +71,12 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (Util.ApplyPercentageModifiers(100, modifiers) > 0)
 				self.Kill(saboteur);
+			else
+			{
+				var building = self.TraitOrDefault<Building>();
+				if (building != null)
+					building.Unlock();
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits
 	public interface IDemolishableInfo : ITraitInfoInterface { bool IsValidTarget(ActorInfo actorInfo, Actor saboteur); }
 	public interface IDemolishable
 	{
-		void Demolish(Actor self, Actor saboteur);
+		void Demolish(Actor self, Actor saboteur, int delay);
 		bool IsValidTarget(Actor self, Actor saboteur);
 	}
 


### PR DESCRIPTION
By adding delay support to `FlashTarget` and `Demolishable`.

Contributes to #12310.

Fixes #12359.