### PR TITLE
Add message to fixheader.exe target if Mono isn't installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,6 +291,7 @@ server: $(server_TARGET)
 
 # Patches binary headers to work around a mono bug
 fixheader.exe: packaging/fixheader.cs
+	@command -v $(CSC) >/dev/null || (echo "Mono is not installed. Please install Mono from http://www.mono-project.com/download/ before building OpenRA."; exit 1)
 	@echo CSC fixheader.exe
 	@$(CSC) packaging/fixheader.cs $(CSFLAGS) -out:fixheader.exe -t:exe $(COMMON_LIBS:%=-r:%)
 


### PR DESCRIPTION
Hopefully this will help with issues like https://github.com/OpenRA/ra2/issues/301