### PR TITLE
Add an introduction dialog for non-{DEV_VERSION} TS builds.

### DIFF
--- a/OpenRA.Mods.TS/OpenRA.Mods.TS.csproj
+++ b/OpenRA.Mods.TS/OpenRA.Mods.TS.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Effects\AnimatedBeacon.cs" />
     <Compile Include="UtilityCommands\LegacyRulesImporter.cs" />
     <Compile Include="UtilityCommands\LegacySequenceImporter.cs" />
+    <Compile Include="Widgets\Logic\PreReleaseWarningPrompt.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.TS/Widgets/Logic/PreReleaseWarningPrompt.cs
+++ b/OpenRA.Mods.TS/Widgets/Logic/PreReleaseWarningPrompt.cs
@@ -1,0 +1,37 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Mods.Common.Widgets;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.TS.Widgets.Logic
+{
+	public class PreReleaseWarningPrompt : ChromeLogic
+	{
+		static bool promptAccepted;
+
+		[ObjectCreator.UseCtor]
+		public PreReleaseWarningPrompt(Widget widget, World world, ModData modData)
+		{
+			if (!promptAccepted && modData.Manifest.Metadata.Version != "{DEV_VERSION}")
+				widget.Get<ButtonWidget>("CONTINUE_BUTTON").OnClick = () => ShowMainMenu(world);
+			else
+				ShowMainMenu(world);
+		}
+
+		void ShowMainMenu(World world)
+		{
+			promptAccepted = true;
+			Ui.ResetAll();
+			Game.LoadWidget(world, "MAINMENU", Ui.Root, new WidgetArgs());
+		}
+	}
+}

--- a/mods/ts/chrome/mainmenu-prerelease-notification.yaml
+++ b/mods/ts/chrome/mainmenu-prerelease-notification.yaml
@@ -1,0 +1,55 @@
+Background@MAINMENU_PRERELEASE_NOTIFICATION:
+	Logic: PreReleaseWarningPrompt
+	X: (WINDOW_RIGHT - WIDTH)/2
+	Y: (WINDOW_BOTTOM - HEIGHT)/2
+	Width: 520
+	Height: 195
+	Children:
+		Label@PROMPT_TITLE:
+			Width: PARENT_RIGHT
+			Y: 20
+			Height: 25
+			Font: Bold
+			Align: Center
+			Text: Tiberian Sun developer preview
+		Label@PROMPT_TEXT_A:
+			X: 15
+			Y: 50
+			Width: PARENT_RIGHT - 30
+			Height: 16
+			Align: Center
+			Text: This pre-alpha build of OpenRA's Tiberian Sun mod is made available
+		Label@PROMPT_TEXT_B:
+			X: 15
+			Y: 68
+			Width: PARENT_RIGHT - 30
+			Height: 16
+			Align: Center
+			Text: for the community to follow development and as example for modders.
+		Label@PROMPT_TEXT_C:
+			X: 15
+			Y: 104
+			Width: PARENT_RIGHT - 30
+			Height: 16
+			Align: Center
+			Text: Many features are missing or incomplete, performance has not been
+		Label@PROMPT_TEXT_D:
+			X: 15
+			Y: 122
+			Width: PARENT_RIGHT - 30
+			Height: 16
+			Align: Center
+			Text: optimized, and balance will not be addressed until a future beta. 
+		Label@PROMPT_TEXT_E:
+			X: 15
+			Y: 140
+			Width: PARENT_RIGHT - 30
+			Height: 16
+			Align: Center
+		Button@CONTINUE_BUTTON:
+			X: PARENT_RIGHT - WIDTH - 20
+			Y: PARENT_BOTTOM - 45
+			Width: 120
+			Height: 25
+			Text: I Understand
+			Font: Bold

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -147,6 +147,7 @@ ChromeLayout:
 	ra|chrome/ingame-perf.yaml
 	ts|chrome/ingame-debug.yaml
 	ra|chrome/mainmenu.yaml
+	ts|chrome/mainmenu-prerelease-notification.yaml
 	ra|chrome/settings.yaml
 	ra|chrome/credits.yaml
 	ra|chrome/lobby.yaml

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -177,6 +177,7 @@ World:
 	ObjectivesPanel:
 		PanelName: SKIRMISH_STATS
 	LoadWidgetAtGameStart:
+		ShellmapRoot: MAINMENU_PRERELEASE_NOTIFICATION
 
 EditorWorld:
 	Inherits: ^BaseWorld


### PR DESCRIPTION
![dialog](https://cloud.githubusercontent.com/assets/167819/20218579/32316aca-a81d-11e6-80cc-a4d3353f5573.png)

This adds an introduction prompt in preparation for a future oramod release.  Test by running `make version` to change the mod version away from `{DEV_VERSION}`.