### PR TITLE
Replace the "Debug" prefix by "Battlefield Control" for ingame chat messages

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Drawing;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -21,6 +22,30 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Description of the objective.")]
 		[Translate] public readonly string Objective = "Destroy all opposition!";
+
+		[Desc("Name of the message's announcer.")]
+		public readonly string PlayerVictoriousAnnouncer = "Battlefield Control";
+
+		[Desc("Message to display in front of the victorious player's name.")]
+		public readonly string PlayerVictoriousPrefix = "";
+
+		[Desc("Message to display after the victorious player's name.")]
+		public readonly string PlayerVictoriousSuffix = " is victorious.";
+
+		[Desc("Color of the announcer's name.")]
+		public readonly Color PlayerVictoriousColor = Color.White;
+
+		[Desc("Name of the message's announcer.")]
+		public readonly string PlayerDefeatedAnnouncer = "Battlefield Control";
+
+		[Desc("Message to display in front of the defeated player's name.")]
+		public readonly string PlayerDefeatedPrefix = "";
+
+		[Desc("Message to display after the defeated player's name.")]
+		public readonly string PlayerDefeatedSuffix = " is defeated.";
+
+		[Desc("Color of the announcer's name.")]
+		public readonly Color PlayerDefeatedColor = Color.White;
 
 		public object Create(ActorInitializer init) { return new ConquestVictoryConditions(init.Self, this); }
 	}
@@ -58,7 +83,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void OnPlayerLost(Player player)
 		{
-			Game.Debug("{0} is defeated.", player.PlayerName);
+			Game.AddChatLine(info.PlayerDefeatedColor, info.PlayerDefeatedAnnouncer,
+				info.PlayerDefeatedPrefix + player.PlayerName + info.PlayerDefeatedSuffix);
 
 			foreach (var a in player.World.Actors.Where(a => a.Owner == player))
 				a.Kill(a);
@@ -72,7 +98,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void OnPlayerWon(Player player)
 		{
-			Game.Debug("{0} is victorious.", player.PlayerName);
+			Game.AddChatLine(info.PlayerVictoriousColor, info.PlayerVictoriousAnnouncer,
+				info.PlayerVictoriousPrefix + player.PlayerName + info.PlayerVictoriousSuffix);
 
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -36,6 +37,30 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Description of the objective")]
 		[Translate] public readonly string Objective = "Hold all the strategic positions!";
+
+		[Desc("Name of the message's announcer.")]
+		public readonly string PlayerVictoriousAnnouncer = "Battlefield Control";
+
+		[Desc("Message to display in front of the victorious player's name.")]
+		public readonly string PlayerVictoriousPrefix = "";
+
+		[Desc("Message to display after the victorious player's name.")]
+		public readonly string PlayerVictoriousSuffix = " is victorious.";
+
+		[Desc("Color of the announcer's name.")]
+		public readonly Color PlayerVictoriousColor = Color.White;
+
+		[Desc("Name of the message's announcer.")]
+		public readonly string PlayerDefeatedAnnouncer = "Battlefield Control";
+
+		[Desc("Message to display in front of the defeated player's name.")]
+		public readonly string PlayerDefeatedPrefix = "";
+
+		[Desc("Message to display after the defeated player's name.")]
+		public readonly string PlayerDefeatedSuffix = " is defeated.";
+
+		[Desc("Color of the announcer's name.")]
+		public readonly Color PlayerDefeatedColor = Color.White;
 
 		public object Create(ActorInitializer init) { return new StrategicVictoryConditions(init.Self, this); }
 	}
@@ -103,7 +128,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void OnPlayerLost(Player player)
 		{
-			Game.Debug("{0} is defeated.", player.PlayerName);
+			Game.AddChatLine(info.PlayerDefeatedColor, info.PlayerDefeatedAnnouncer,
+				info.PlayerDefeatedPrefix + player.PlayerName + info.PlayerDefeatedSuffix);
 
 			foreach (var a in player.World.Actors.Where(a => a.Owner == player))
 				a.Kill(a);
@@ -117,7 +143,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void OnPlayerWon(Player player)
 		{
-			Game.Debug("{0} is victorious.", player.PlayerName);
+			Game.AddChatLine(info.PlayerVictoriousColor, info.PlayerVictoriousAnnouncer,
+				info.PlayerVictoriousPrefix + player.PlayerName + info.PlayerVictoriousSuffix);
 
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{

--- a/OpenRA.Mods.Common/Widgets/UnitCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/UnitCommandWidget.cs
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.Common.Widgets
 				return new Order("SetUnitStance", a, false) { ExtraData = (uint)nextStance };
 			});
 
-			Game.Debug("Unit stance set to: {0}".F(nextStance));
+			Game.AddChatLine(Color.White, "Battlefield Control", "Unit stance set to: {0}".F(nextStance));
 
 			return true;
 		}

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -250,12 +250,12 @@ namespace OpenRA.Mods.Common.Widgets
 
 					// Check if selecting actors on the screen has selected new units
 					if (ownUnitsOnScreen.Count > World.Selection.Actors.Count())
-						Game.Debug("Selected across screen");
+						Game.AddChatLine(Color.White, "Battlefield Control", "Selected across screen");
 					else
 					{
 						// Select actors in the world that have highest selection priority
 						ownUnitsOnScreen = SelectActorsInWorld(World, null, player).SubsetWithHighestSelectionPriority().ToList();
-						Game.Debug("Selected across map");
+						Game.AddChatLine(Color.White, "Battlefield Control", "Selected across map");
 					}
 
 					World.Selection.Combine(World, ownUnitsOnScreen, false, false);
@@ -276,12 +276,12 @@ namespace OpenRA.Mods.Common.Widgets
 
 					// Check if selecting actors on the screen has selected new units
 					if (newSelection.Count > World.Selection.Actors.Count())
-						Game.Debug("Selected across screen");
+						Game.AddChatLine(Color.White, "Battlefield Control", "Selected across screen");
 					else
 					{
 						// Select actors in the world that have the same selection class as one of the already selected actors
 						newSelection = SelectActorsInWorld(World, selectedClasses, player).ToList();
-						Game.Debug("Selected across map");
+						Game.AddChatLine(Color.White, "Battlefield Control", "Selected across map");
 					}
 
 					World.Selection.Combine(World, newSelection, true, false);
@@ -369,12 +369,12 @@ namespace OpenRA.Mods.Common.Widgets
 			if (Game.Settings.Sound.Mute)
 			{
 				Game.Sound.MuteAudio();
-				Game.Debug("Audio muted");
+				Game.AddChatLine(Color.White, "Battlefield Control", "Audio muted");
 			}
 			else
 			{
 				Game.Sound.UnmuteAudio();
-				Game.Debug("Audio unmuted");
+				Game.AddChatLine(Color.White, "Battlefield Control", "Audio unmuted");
 			}
 
 			return true;


### PR DESCRIPTION
I also unhardcode the messages inside the `ConquestVictoryConditions` and `StrategicVictoryConditions` traits. Each map can now define custom messages (with a custom announcer "prefix" and color).