### PR TITLE
Upgrades overhaul part 3: Timed, external, and stacked conditions.

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -564,7 +564,7 @@
     <Compile Include="Warheads\CreateResourceWarhead.cs" />
     <Compile Include="Warheads\DamageWarhead.cs" />
     <Compile Include="Warheads\DestroyResourceWarhead.cs" />
-    <Compile Include="Warheads\GrantUpgradeWarhead.cs" />
+    <Compile Include="Warheads\GrantExternalConditionWarhead.cs" />
     <Compile Include="Warheads\HealthPercentageDamageWarhead.cs" />
     <Compile Include="Warheads\LeaveSmudgeWarhead.cs" />
     <Compile Include="Warheads\SpreadDamageWarhead.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -480,7 +480,7 @@
     <Compile Include="Traits\Sound\AttackSounds.cs" />
     <Compile Include="Traits\SupplyTruck.cs" />
     <Compile Include="Traits\SupportPowers\AirstrikePower.cs" />
-    <Compile Include="Traits\SupportPowers\GrantUpgradePower.cs" />
+    <Compile Include="Traits\SupportPowers\GrantExternalConditionPower.cs" />
     <Compile Include="Traits\SupportPowers\NukePower.cs" />
     <Compile Include="Traits\SupportPowers\SupportPower.cs" />
     <Compile Include="Traits\SupportPowers\SupportPowerManager.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -307,7 +307,7 @@
     <Compile Include="Traits\Crates\GiveCashCrateAction.cs" />
     <Compile Include="Traits\Crates\GiveMcvCrateAction.cs" />
     <Compile Include="Traits\Crates\GiveUnitCrateAction.cs" />
-    <Compile Include="Traits\Crates\GrantUpgradeCrateAction.cs" />
+    <Compile Include="Traits\Crates\GrantExternalConditionCrateAction.cs" />
     <Compile Include="Traits\Crates\HealUnitsCrateAction.cs" />
     <Compile Include="Traits\Crates\HideMapCrateAction.cs" />
     <Compile Include="Traits\Crates\LevelUpCrateAction.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -417,7 +417,7 @@
     <Compile Include="Traits\Render\RenderVoxels.cs" />
     <Compile Include="Traits\Render\ProductionBar.cs" />
     <Compile Include="Traits\Render\SupportPowerChargeBar.cs" />
-    <Compile Include="Traits\Render\TimedUpgradeBar.cs" />
+    <Compile Include="Traits\Render\TimedConditionBar.cs" />
     <Compile Include="Traits\Render\WithSpriteBarrel.cs" />
     <Compile Include="Traits\Render\WithBuildingExplosion.cs" />
     <Compile Include="Traits\Render\WithAttackAnimation.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -775,6 +775,7 @@
     <Compile Include="Traits\AutoCarryall.cs" />
     <Compile Include="Traits\World\CliffBackImpassabilityLayer.cs" />
     <Compile Include="Traits\Upgrades\GrantCondition.cs" />
+    <Compile Include="Traits\Upgrades\ExternalConditions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -776,6 +776,7 @@
     <Compile Include="Traits\World\CliffBackImpassabilityLayer.cs" />
     <Compile Include="Traits\Upgrades\GrantCondition.cs" />
     <Compile Include="Traits\Upgrades\ExternalConditions.cs" />
+    <Compile Include="Traits\Upgrades\StackedCondition.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.Common/Traits/Carryable.cs
+++ b/OpenRA.Mods.Common/Traits/Carryable.cs
@@ -52,6 +52,8 @@ namespace OpenRA.Mods.Common.Traits
 		protected override void Created(Actor self)
 		{
 			upgradeManager = self.Trait<UpgradeManager>();
+
+			base.Created(self);
 		}
 
 		public virtual void Attached(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/TimedConditionBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/TimedConditionBar.cs
@@ -15,24 +15,24 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Visualizes the remaining time for an upgrade.")]
-	class TimedUpgradeBarInfo : ITraitInfo, Requires<UpgradeManagerInfo>
+	class TimedConditionBarInfo : ITraitInfo, Requires<UpgradeManagerInfo>
 	{
 		[FieldLoader.Require]
-		[Desc("Upgrade that this bar corresponds to")]
-		public readonly string Upgrade = null;
+		[Desc("Condition that this bar corresponds to")]
+		public readonly string Condition = null;
 
 		public readonly Color Color = Color.Red;
 
-		public object Create(ActorInitializer init) { return new TimedUpgradeBar(init.Self, this); }
+		public object Create(ActorInitializer init) { return new TimedConditionBar(init.Self, this); }
 	}
 
-	class TimedUpgradeBar : ISelectionBar, IConditionTimerWatcher
+	class TimedConditionBar : ISelectionBar, IConditionTimerWatcher
 	{
-		readonly TimedUpgradeBarInfo info;
+		readonly TimedConditionBarInfo info;
 		readonly Actor self;
 		float value;
 
-		public TimedUpgradeBar(Actor self, TimedUpgradeBarInfo info)
+		public TimedConditionBar(Actor self, TimedConditionBarInfo info)
 		{
 			this.self = self;
 			this.info = info;
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			value = duration > 0 ? remaining * 1f / duration : 0;
 		}
 
-		string IConditionTimerWatcher.Condition { get { return info.Upgrade; } }
+		string IConditionTimerWatcher.Condition { get { return info.Condition; } }
 
 		float ISelectionBar.GetValue()
 		{

--- a/OpenRA.Mods.Common/Traits/Render/TimedUpgradeBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/TimedUpgradeBar.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public object Create(ActorInitializer init) { return new TimedUpgradeBar(init.Self, this); }
 	}
 
-	class TimedUpgradeBar : ISelectionBar, INotifyCreated
+	class TimedUpgradeBar : ISelectionBar, IConditionTimerWatcher
 	{
 		readonly TimedUpgradeBarInfo info;
 		readonly Actor self;
@@ -38,15 +38,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 			this.info = info;
 		}
 
-		public void Created(Actor self)
+		void IConditionTimerWatcher.Update(int duration, int remaining)
 		{
-			self.Trait<UpgradeManager>().RegisterWatcher(info.Upgrade, Update);
+			value = duration > 0 ? remaining * 1f / duration : 0;
 		}
 
-		public void Update(int duration, int remaining)
-		{
-			value = remaining * 1f / duration;
-		}
+		string IConditionTimerWatcher.Condition { get { return info.Upgrade; } }
 
 		float ISelectionBar.GetValue()
 		{

--- a/OpenRA.Mods.Common/Traits/Upgrades/ExternalConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/ExternalConditions.cs
@@ -1,0 +1,25 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Lists conditions that are accepted from external sources (Lua, warheads, etc).",
+		"Externally granted conditions that aren't explicitly whitelisted will be silently ignored.")]
+	public class ExternalConditionsInfo : TraitInfo<ExternalConditions>
+	{
+		[UpgradeGrantedReference]
+		public readonly string[] Conditions = { };
+	}
+
+	public class ExternalConditions { }
+}

--- a/OpenRA.Mods.Common/Traits/Upgrades/StackedCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Upgrades/StackedCondition.cs
@@ -1,0 +1,32 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Grant additional conditions when a specified condition has been granted multiple times.")]
+	public class StackedConditionInfo : TraitInfo<StackedCondition>
+	{
+		[FieldLoader.Require]
+		[UpgradeUsedReference]
+		[Desc("Condition to monitor.")]
+		public readonly string Condition = null;
+
+		[FieldLoader.Require]
+		[UpgradeGrantedReference]
+		[Desc("Conditions to grant when the monitored condition is granted multiple times.",
+			"The first entry is activated at 2x grants, second entry at 3x grants, and so on.")]
+		public readonly string[] StackedConditions = { };
+	}
+
+	public class StackedCondition { }
+}

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -92,6 +92,14 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			catch { }
 		}
 
+		static void RenameNodeKey(MiniYamlNode node, string key)
+		{
+			var parts = node.Key.Split('@');
+			node.Key = key;
+			if (parts.Length > 1)
+				node.Key += "@" + parts[1];
+		}
+
 		internal static void UpgradeActorRules(ModData modData, int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
 		{
 			var addNodes = new List<MiniYamlNode>();
@@ -118,10 +126,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						if (s != null)
 							s.Key = "Image";
 
-						var parts = node.Key.Split('@');
-						node.Key = "WithDamageOverlay";
-						if (parts.Length > 1)
-							node.Key += "@" + parts[1];
+						RenameNodeKey(node, "WithDamageOverlay");
 					}
 				}
 
@@ -135,13 +140,9 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				if (engineVersion < 20160611)
 				{
 					// Deprecated WithSpriteRotorOverlay
-					if (depth == 1 && node.Key.StartsWith("WithSpriteRotorOverlay"))
+					if (depth == 1 && node.Key.StartsWith("WithSpriteRotorOverlay", StringComparison.Ordinal))
 					{
-						var parts = node.Key.Split('@');
-						node.Key = "WithIdleOverlay";
-						if (parts.Length > 1)
-							node.Key += "@" + parts[1];
-
+						RenameNodeKey(node, "WithIdleOverlay");
 						Console.WriteLine("The 'WithSpriteRotorOverlay' trait has been removed.");
 						Console.WriteLine("Its functionality can be fully replicated with 'WithIdleOverlay' + upgrades.");
 						Console.WriteLine("Look at the helicopters in our RA / C&C1  mods for implementation details.");

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -100,6 +100,20 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				node.Key += "@" + parts[1];
 		}
 
+		static void ConvertUpgradesToCondition(MiniYamlNode parent, MiniYamlNode node, string upgradesKey, string conditionKey)
+		{
+			var upgradesNode = node.Value.Nodes.FirstOrDefault(n => n.Key == upgradesKey);
+			if (upgradesNode != null)
+			{
+				var conditions = FieldLoader.GetValue<string[]>("", upgradesNode.Value.Value);
+				if (conditions.Length > 1)
+					Console.WriteLine("Unable to automatically migrate {0}:{1} {2} to {3}. This must be corrected manually",
+						parent.Key, node.Key, upgradesKey, conditionKey);
+				else
+					upgradesNode.Key = conditionKey;
+			}
+		}
+
 		internal static void UpgradeActorRules(ModData modData, int engineVersion, ref List<MiniYamlNode> nodes, MiniYamlNode parent, int depth)
 		{
 			var addNodes = new List<MiniYamlNode>();
@@ -283,13 +297,8 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 				if (engineVersion < 20160818)
 				{
-					if (depth == 1 && node.Key.StartsWith("UpgradeOnDamage"))
-					{
-						var parts = node.Key.Split('@');
-						node.Key = "UpgradeOnDamageState";
-						if (parts.Length > 1)
-							node.Key += "@" + parts[1];
-					}
+					if (depth == 1 && node.Key.StartsWith("UpgradeOnDamage", StringComparison.Ordinal))
+						RenameNodeKey(node, "UpgradeOnDamageState");
 				}
 
 				// DisplayTimer was replaced by DisplayTimerStances
@@ -436,7 +445,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
-				// Rename Replaced upgrade consumers with conditions
+				// Replaced upgrade consumers with conditions
 				if (engineVersion < 20161117)
 				{
 					var upgradeTypesNode = node.Value.Nodes.FirstOrDefault(n => n.Key == "UpgradeTypes");
@@ -481,21 +490,45 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				if (engineVersion < 20161119)
 				{
 					// Migrated carryalls over to new conditions system
-					var carryableUpgradesNode = node.Value.Nodes.FirstOrDefault(n => n.Key == "CarryableUpgrades");
-					if (carryableUpgradesNode != null)
-					{
-						var conditions = FieldLoader.GetValue<string[]>("", carryableUpgradesNode.Value.Value);
-						if (conditions.Length > 1)
-							Console.WriteLine("Unable to automatically migrate {0}:{1} CarryableUpgrades to CarriedCondition. This must be corrected manually",
-								parent.Key, node.Key);
-						else
-							carryableUpgradesNode.Key = "CarriedCondition";
-					}
+					ConvertUpgradesToCondition(parent, node, "CarryableUpgrades", "CarriedCondition");
 
 					if (node.Key == "WithDecorationCarryable")
 					{
 						node.Key = "WithDecoration@CARRYALL";
 						node.Value.Nodes.Add(new MiniYamlNode("RequiresCondition", "carryall-reserved"));
+					}
+				}
+
+				if (engineVersion < 20161120)
+				{
+					if (node.Key.StartsWith("TimedUpgradeBar", StringComparison.Ordinal))
+					{
+						RenameNodeKey(node, "TimedConditionBar");
+						ConvertUpgradesToCondition(parent, node, "Upgrade", "Condition");
+					}
+
+					if (node.Key.StartsWith("GrantUpgradePower", StringComparison.Ordinal))
+					{
+						Console.WriteLine("GrantUpgradePower Condition must be manually added to all target actor's ExternalConditions list.");
+						RenameNodeKey(node, "GrantExternalConditionPower");
+						ConvertUpgradesToCondition(parent, node, "Upgrades", "Condition");
+
+						var soundNode = node.Value.Nodes.FirstOrDefault(n => n.Key == "GrantUpgradeSound");
+						if (soundNode != null)
+							soundNode.Key = "OnFireSound";
+						else
+							node.Value.Nodes.Add(new MiniYamlNode("OnFireSound", "ironcur9.aud"));
+
+						var sequenceNode = node.Value.Nodes.FirstOrDefault(n => n.Key == "GrantUpgradeSequence");
+						if (sequenceNode != null)
+							sequenceNode.Key = "Sequence";
+					}
+
+					if (node.Key.StartsWith("GrantUpgradeCrateAction", StringComparison.Ordinal))
+					{
+						Console.WriteLine("GrantUpgradeCrateAction Condition must be manually added to all target actor's ExternalConditions list.");
+						RenameNodeKey(node, "GrantExternalConditionCrateAction");
+						ConvertUpgradesToCondition(parent, node, "Upgrades", "Condition");
 					}
 				}
 
@@ -566,6 +599,16 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				{
 					if (node.Key == "Angle")
 						node.Key = "LaunchAngle";
+				}
+
+				if (engineVersion < 20161120)
+				{
+					if (node.Key.StartsWith("Warhead", StringComparison.Ordinal) && node.Value.Value == "GrantUpgrade")
+					{
+						node.Value.Value = "GrantExternalCondition";
+						Console.WriteLine("GrantExternalCondition Condition must be manually added to all target actor's ExternalConditions list.");
+						ConvertUpgradesToCondition(parent, node, "Upgrades", "Condition");
+					}
 				}
 
 				UpgradeWeaponRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);

--- a/OpenRA.Mods.Common/Warheads/GrantExternalConditionWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/GrantExternalConditionWarhead.cs
@@ -10,19 +10,18 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Warheads
 {
-	public class GrantUpgradeWarhead : Warhead
+	public class GrantExternalConditionWarhead : Warhead
 	{
-		[UpgradeGrantedReference]
-		[Desc("The upgrades to apply.")]
-		public readonly string[] Upgrades = { };
+		[FieldLoader.Require]
+		[Desc("The condition to apply. Must be included in the target actor's ExternalConditions list.")]
+		public readonly string Condition = null;
 
-		[Desc("Duration of the upgrade (in ticks). Set to 0 for a permanent upgrade.")]
+		[Desc("Duration of the condition (in ticks). Set to 0 for a permanent condition.")]
 		public readonly int Duration = 0;
 
 		public readonly WDist Range = WDist.FromCells(1);
@@ -38,22 +37,10 @@ namespace OpenRA.Mods.Common.Warheads
 					continue;
 
 				var um = a.TraitOrDefault<UpgradeManager>();
-				if (um == null)
-					continue;
 
-				foreach (var u in Upgrades)
-				{
-					if (Duration > 0)
-					{
-						if (um.AcknowledgesUpgrade(a, u))
-							um.GrantTimedUpgrade(a, u, Duration, firedBy, Upgrades.Count(upg => upg == u));
-					}
-					else
-					{
-						if (um.AcceptsUpgrade(a, u))
-							um.GrantUpgrade(a, u, this);
-					}
-				}
+				// Condition token is ignored because we never revoke this condition.
+				if (um != null && um.AcceptsExternalCondition(a, Condition))
+					um.GrantCondition(a, Condition, true, Duration);
 			}
 		}
 	}

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -159,6 +159,8 @@
 		CloakSound: trans1.aud
 		UncloakSound: trans1.aud
 		RequiresCondition: cloak
+	ExternalConditions@CLOAK:
+		Conditions: cloak
 	MustBeDestroyed:
 	Voiced:
 		VoiceSet: VehicleVoice

--- a/mods/cnc/rules/misc.yaml
+++ b/mods/cnc/rules/misc.yaml
@@ -16,10 +16,10 @@ CRATE:
 	ExplodeCrateAction@fire:
 		Weapon: Napalm.Crate
 		SelectionShares: 5
-	GrantUpgradeCrateAction@cloak:
+	GrantExternalConditionCrateAction@cloak:
 		SelectionShares: 5
 		Effect: cloak
-		Upgrades: cloak
+		Condition: cloak
 	GiveMcvCrateAction:
 		SelectionShares: 0
 		NoBaseSelectionShares: 120

--- a/mods/ra/maps/bomber-john/rules.yaml
+++ b/mods/ra/maps/bomber-john/rules.yaml
@@ -119,7 +119,7 @@ FTUR:
 		BeginChargeSound: chrochr1.aud
 		EndChargeSound: chrordy1.aud
 		Range: 3
-	GrantUpgradePower@IRONCURTAIN:
+	GrantExternalConditionPower@IRONCURTAIN:
 		Icon: invuln
 		ChargeTime: 30
 		Description: Invulnerability
@@ -129,8 +129,9 @@ FTUR:
 		BeginChargeSound: ironchg1.aud
 		EndChargeSound: ironrdy1.aud
 		Range: 1
-		Upgrades: invulnerability
-		GrantUpgradeSequence: idle
+		Condition: invulnerability
+		Sequence: idle
+		OnFireSound: ironcur9.aud
 	Power:
 		Amount: 0
 
@@ -186,7 +187,7 @@ T17:
 		Duration: 999999
 		KillCargo: yes
 		Range: 3
-	GrantUpgradePower@IRONCURTAIN:
+	GrantExternalConditionPower@IRONCURTAIN:
 		Icon: invuln
 		ChargeTime: 30
 		Description: Invulnerability
@@ -196,5 +197,6 @@ T17:
 		BeginChargeSound: ironchg1.aud
 		EndChargeSound: ironrdy1.aud
 		Range: 1
-		Upgrades: invulnerability
-		GrantUpgradeSequence: idle
+		Condition: invulnerability
+		Sequence: idle
+		OnFireSound: ironcur9.aud

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -69,11 +69,11 @@ FORTCRATE:
 	GiveUnitCrateAction@e7:
 		Units: e7
 		SelectionShares: 10
-	GrantUpgradeCrateAction@ironcurtain:
+	GrantExternalConditionCrateAction@ironcurtain:
 		SelectionShares: 10
 		Effect: invuln
 		Notification: ironcur9.aud
-		Upgrades: invulnerability
+		Condition: invulnerability
 		Duration: 1200
 	ExplodeCrateAction@bigboom:
 		Weapon: SCUD

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -15,7 +15,7 @@
 
 ^GainsExperience:
 	GainsExperience:
-		Upgrades:		
+		Upgrades:
 			200: rank-veteran-1
 			400: rank-veteran-2
 			800: rank-veteran-3
@@ -121,8 +121,10 @@
 	DamageMultiplier@IRONCURTAIN:
 		RequiresCondition: invulnerability
 		Modifier: 0
-	TimedUpgradeBar:
-		Upgrade: invulnerability
+	TimedConditionBar:
+		Condition: invulnerability
+	ExternalConditions@INVULNERABILITY:
+		Conditions: invulnerability
 
 ^Vehicle:
 	Inherits@1: ^ExistsInWorld

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -90,11 +90,11 @@ CRATE:
 		Units: e1,e1,e4,e4,e3,e3,e3
 		ValidFactions: soviet, russia, ukraine
 		TimeDelay: 4500
-	GrantUpgradeCrateAction@invuln:
+	GrantExternalConditionCrateAction@invuln:
 		SelectionShares: 5
 		Effect: invuln
 		Notification: ironcur9.aud
-		Upgrades: invulnerability
+		Condition: invulnerability
 		Duration: 600
 
 MONEYCRATE:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -303,7 +303,7 @@ IRON:
 		Range: 10c0
 	Bib:
 		HasMinibib: Yes
-	GrantUpgradePower@IRONCURTAIN:
+	GrantExternalConditionPower@IRONCURTAIN:
 		Icon: invuln
 		ChargeTime: 120
 		Description: Invulnerability
@@ -314,7 +314,8 @@ IRON:
 		BeginChargeSpeechNotification: IronCurtainCharging
 		EndChargeSpeechNotification: IronCurtainReady
 		DisplayRadarPing: True
-		Upgrades: invulnerability
+		Condition: invulnerability
+		OnFireSound: ironcur9.aud
 	SupportPowerChargeBar:
 	Power:
 		Amount: -200

--- a/mods/ts/rules/civilian-vehicles.yaml
+++ b/mods/ts/rules/civilian-vehicles.yaml
@@ -102,7 +102,7 @@ BUS:
 		MaxWeight: 20
 		PipCount: 5
 		UnloadVoice: Unload
-		LoadingUpgrades: notmobile
+		LoadingUpgrades: loading
 		EjectOnDeath: true
 
 PICK:
@@ -126,7 +126,7 @@ PICK:
 		MaxWeight: 2
 		PipCount: 5
 		UnloadVoice: Unload
-		LoadingUpgrades: notmobile
+		LoadingUpgrades: loading
 		EjectOnDeath: true
 
 CAR:
@@ -150,7 +150,7 @@ CAR:
 		MaxWeight: 4
 		PipCount: 5
 		UnloadVoice: Unload
-		LoadingUpgrades: notmobile
+		LoadingUpgrades: loading
 		EjectOnDeath: true
 
 WINI:
@@ -174,7 +174,7 @@ WINI:
 		MaxWeight: 5
 		PipCount: 5
 		UnloadVoice: Unload
-		LoadingUpgrades: notmobile
+		LoadingUpgrades: loading
 		EjectOnDeath: true
 
 LOCOMOTIVE:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -64,6 +64,8 @@
 		ReferencePoint: Bottom, Right
 		RequiresCondition: rank-elite
 		ZOffset: 256
+	ExternalConditions@CRATES:
+		Conditions: crate-firepower, crate-damage, crate-speed, crate-cloak
 
 ^EmpDisable:
 	UpgradeOverlay@EMPDISABLE:
@@ -71,8 +73,8 @@
 		Palette: disabled
 	DisableOnUpgrade@EMPDISABLE:
 		RequiresCondition: empdisable
-	TimedUpgradeBar@EMPDISABLE:
-		Upgrade: empdisable
+	TimedConditionBar@EMPDISABLE:
+		Condition: empdisable
 		Color: FFFFFF
 	WithIdleOverlay@EMPDISABLE:
 		Sequence: emp-overlay
@@ -83,6 +85,8 @@
 	PowerMultiplier@EMPDISABLE:
 		RequiresCondition: empdisable
 		Modifier: 0
+	ExternalConditions@EMPDISABLE:
+		Conditions: empdisable
 
 ^EmpDisableMobile:
 	Inherits: ^EmpDisable
@@ -639,7 +643,6 @@
 	Mobile:
 		Speed: 113
 		TurnSpeed: 16
-		Crushes: crate
 		SharesCell: no
 		TerrainSpeeds:
 			Clear: 90

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -87,7 +87,7 @@
 ^EmpDisableMobile:
 	Inherits: ^EmpDisable
 	Mobile:
-		RequiresCondition: !notmobile
+		RequiresCondition: !empdisable && !deployed && !loading
 
 ^Cloakable:
 	Cloak@CLOAKGENERATOR:
@@ -795,7 +795,7 @@
 	Cargo:
 		Types: Infantry
 		UnloadVoice: Unload
-		LoadingUpgrades: notmobile
+		LoadingUpgrades: loading
 	Health:
 		HP: 100
 	Armor:

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -28,7 +28,7 @@ APC:
 		MaxWeight: 5
 		PipCount: 5
 		UnloadVoice: Unload
-		LoadingUpgrades: notmobile
+		LoadingUpgrades: loading
 		EjectOnDeath: true
 	UpgradeOnTerrain:
 		Upgrades: inwater

--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -74,24 +74,24 @@ CRATE:
 		SelectionShares: 0
 		NoBaseSelectionShares: 100
 		Units: mcv
-	GrantUpgradeCrateAction@cloak:
+	GrantExternalConditionCrateAction@cloak:
 		SelectionShares: 5
 		Effect: stealth
-		Upgrades: crate-cloak
+		Condition: crate-cloak
 		Notification: cloak5.aud
-	GrantUpgradeCrateAction@firepower:
+	GrantExternalConditionCrateAction@firepower:
 		SelectionShares: 5
 		Effect: firepower
-		Upgrades: crate-firepower
+		Condition: crate-firepower
 		Notification: 00-i070.aud
-	GrantUpgradeCrateAction@armor:
+	GrantExternalConditionCrateAction@armor:
 		SelectionShares: 5
 		Effect: armor
-		Upgrades: crate-damage
+		Condition: crate-damage
 		Notification: 00-i068.aud
-	GrantUpgradeCrateAction@speed:
+	GrantExternalConditionCrateAction@speed:
 		SelectionShares: 5
-		Upgrades: crate-speed
+		Condition: crate-speed
 		Notification: 00-i080.aud
 
 SROCK01:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -106,7 +106,7 @@ TTNK:
 	RenderSprites:
 		Image: ttnk
 	DeployToUpgrade:
-		DeployedUpgrades: deployed, notmobile
+		DeployedUpgrades: deployed
 		UndeployedUpgrades: undeployed
 		DeployAnimation: make
 		Facing: 160
@@ -285,7 +285,7 @@ SAPC:
 		MaxWeight: 5
 		PipCount: 5
 		UnloadVoice: Unload
-		LoadingUpgrades: notmobile
+		LoadingUpgrades: loading
 		EjectOnDeath: true
 
 SUBTANK:

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -138,7 +138,7 @@ LPST:
 			gdi: lpst.gdi
 			nod: lpst.nod
 	DeployToUpgrade:
-		DeployedUpgrades: deployed, notmobile
+		DeployedUpgrades: deployed
 		UndeployedUpgrades: undeployed
 		DeployAnimation: make
 		Facing: 160

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -107,10 +107,10 @@ EMPulseCannon:
 		Image: pulsball
 	Warhead@1Eff: CreateEffect
 		Explosions: pulse_explosion
-	Warhead@emp: GrantUpgrade
+	Warhead@emp: GrantExternalCondition
 		Range: 4c0
 		Duration: 250
-		Upgrades: empdisable
+		Condition: empdisable
 
 ClusterMissile:
 	ValidTargets: Ground, Water, Air

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -110,7 +110,7 @@ EMPulseCannon:
 	Warhead@emp: GrantUpgrade
 		Range: 4c0
 		Duration: 250
-		Upgrades: empdisable, notmobile
+		Upgrades: empdisable
 
 ClusterMissile:
 	ValidTargets: Ground, Water, Air


### PR DESCRIPTION
The third step towards #12380.  Depends on #12396, #12381.

This PR does three major things:
* Reimplement timed conditions in a serialization-friendly way for the future.
* Externally granted conditions must be explicitly whitelisted for each actor type on the `UpgradeManager`.  This is required to accurately lint the conditions.
* Stacked condition bonuses can be defined on the `UpgradeManager`, and give a concise way to 
deal with stacking effects mainly from external sources.

I've ported the three easy external granters to the new setup. Lua and UAN will get their own PRs next, so remain shimmed for now.

The last commit demonstrates condition stacking by changing the color of the iron curtain to green then blue with 2 then 3 stacked applications.