### PR TITLE
Fix crash when actors with multiple RevealsShroud target a dead frozen actor.

### DIFF
--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -91,8 +91,11 @@ namespace OpenRA.Mods.Common
 			if (move != null)
 			{
 				// Move within sight range of the frozen actor
-				var sight = self.TraitOrDefault<RevealsShroud>();
-				var range = sight != null ? sight.Range : WDist.FromCells(2);
+				var range = self.TraitsImplementing<RevealsShroud>()
+					.Where(s => !s.IsTraitDisabled)
+					.Select(s => s.Range)
+					.Append(WDist.FromCells(2))
+					.Max();
 
 				self.QueueActivity(move.MoveWithinRange(Target.FromPos(frozen.CenterPosition), range));
 			}


### PR DESCRIPTION
This should fix the crash that @SoScared and co encountered in their gapgen playtest stream.