### PR TITLE
Fix missing array bounds check in Shroud.IsExplored.

### DIFF
--- a/OpenRA.Game/Traits/World/Shroud.cs
+++ b/OpenRA.Game/Traits/World/Shroud.cs
@@ -343,7 +343,8 @@ namespace OpenRA.Traits
 			if (Disabled)
 				return map.Contains(puv);
 
-			return resolvedType[(MPos)puv] > ShroudCellType.Shroud;
+			var uv = (MPos)puv;
+			return resolvedType.Contains(uv) && resolvedType[uv] > ShroudCellType.Shroud;
 		}
 
 		public bool IsVisible(WPos pos)


### PR DESCRIPTION
Fixes #12418.