### PR TITLE
ReplayMetadata style fix

### DIFF
--- a/OpenRA.Game/FileFormats/ReplayMetadata.cs
+++ b/OpenRA.Game/FileFormats/ReplayMetadata.cs
@@ -85,10 +85,10 @@ namespace OpenRA.FileFormats
 				{
 					if (!fs.CanSeek)
 						return null;
-		
+
 					if (fs.Length < 20)
 						return null;
-		
+
 					fs.Seek(-(4 + 4), SeekOrigin.End);
 					var dataLength = fs.ReadInt32();
 					if (fs.ReadInt32() == MetaEndMarker)


### PR DESCRIPTION
Somehow the style issues in #12357 were not caught by Travis (maybe it didn't run?).
They make Travis fail on bleed-based PRs, so this should be merged asap.