### PR TITLE
Add CliffBackImpassabilityLayer to TS.

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -776,6 +776,7 @@
     <Compile Include="ModContent.cs" />
     <Compile Include="Traits\AutoCarryable.cs" />
     <Compile Include="Traits\AutoCarryall.cs" />
+    <Compile Include="Traits\World\CliffBackImpassabilityLayer.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.Common/Traits/World/CliffBackImpassabilityLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/CliffBackImpassabilityLayer.cs
@@ -1,0 +1,49 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Sets a custom terrain type for cells that are obscured by back-facing cliffs.",
+		"This trait replicates the default CliffBackImpassability=2 behaviour from the TS/RA2 rules.ini.")]
+	class CliffBackImpassabilityLayerInfo : ITraitInfo
+	{
+		public readonly string TerrainType = "Impassable";
+
+		public object Create(ActorInitializer init) { return new CliffBackBlockingLayer(this); }
+	}
+
+	class CliffBackBlockingLayer : IWorldLoaded
+	{
+		readonly CliffBackImpassabilityLayerInfo info;
+
+		public CliffBackBlockingLayer(CliffBackImpassabilityLayerInfo info)
+		{
+			this.info = info;
+		}
+
+		public void WorldLoaded(World w, WorldRenderer wr)
+		{
+			var tileType = w.Map.Rules.TileSet.GetTerrainIndex(info.TerrainType);
+			foreach (var uv in w.Map.AllCells.MapCoords)
+			{
+				// All the map cells that visually overlap the current cell
+				var testCells = w.Map.ProjectedCellsCovering(uv)
+					.SelectMany(puv => w.Map.Unproject(puv));
+				if (testCells.Any(x => x.V >= uv.V + 4))
+					w.Map.CustomTerrain[uv] = tileType;
+			}
+		}
+	}
+}

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -59,6 +59,7 @@
 		TerrainType: Veins
 	TerrainGeometryOverlay:
 	ExitsDebugOverlayManager:
+	CliffBackImpassabilityLayer:
 
 World:
 	Inherits: ^BaseWorld


### PR DESCRIPTION
This fixes units from moving deep behind cliffs where they are not supposed to go, and wraps up the set of heightmap improvements that I had planned for this release cycle.