### PR TITLE
Make RA and TD aircraft reveal shroud from the point on the ground below them.

### DIFF
--- a/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
+++ b/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Lint
 				var ios = actorInfo.Value.TraitInfoOrDefault<IOccupySpaceInfo>();
 				foreach (var rsi in actorInfo.Value.TraitInfos<RevealsShroudInfo>())
 				{
-					if (rsi.Type == VisibilityType.CenterPosition)
+					if (rsi.Type != VisibilityType.Footprint)
 						continue;
 
 					if (ios == null)

--- a/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
+++ b/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Lint
 		{
 			foreach (var actorInfo in rules.Actors)
 			{
-				if (actorInfo.Key.StartsWith("^"))
+				if (actorInfo.Key.StartsWith("^", StringComparison.Ordinal))
 					continue;
 
 				var ios = actorInfo.Value.TraitInfoOrDefault<IOccupySpaceInfo>();

--- a/OpenRA.Mods.Common/Traits/AffectsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/AffectsShroud.cs
@@ -53,7 +53,11 @@ namespace OpenRA.Mods.Common.Traits
 					.SelectMany(kv => Shroud.ProjectedCellsInRange(map, kv.First, range, Info.MaxHeightDelta))
 					.Distinct().ToArray();
 
-			return Shroud.ProjectedCellsInRange(map, self.CenterPosition, range, Info.MaxHeightDelta)
+			var pos = self.CenterPosition;
+			if (Info.Type == VisibilityType.GroundPosition)
+				pos -= new WVec(WDist.Zero, WDist.Zero, self.World.Map.DistanceAboveTerrain(pos));
+
+			return Shroud.ProjectedCellsInRange(map, pos, range, Info.MaxHeightDelta)
 				.ToArray();
 		}
 

--- a/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderShroud.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderShroud.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public enum VisibilityType { Footprint, CenterPosition }
+	public enum VisibilityType { Footprint, CenterPosition, GroundPosition }
 
 	[Desc("The actor stays invisible under the shroud.")]
 	public class HiddenUnderShroudInfo : ITraitInfo, IDefaultVisibilityInfo

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -22,7 +22,7 @@ TRAN:
 		Type: Light
 	RevealsShroud:
 		Range: 10c0
-		Type: CenterPosition
+		Type: GroundPosition
 	WithIdleOverlay@ROTOR1AIR:
 		Offset: 597,0,85
 		Sequence: rotor
@@ -77,7 +77,7 @@ HELI:
 		Type: Light
 	RevealsShroud:
 		Range: 10c0
-		Type: CenterPosition
+		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: HeliAGGun
 		LocalOffset: 128,-213,-85, 128,213,-85
@@ -137,7 +137,7 @@ ORCA:
 		Type: Light
 	RevealsShroud:
 		Range: 10c0
-		Type: CenterPosition
+		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: OrcaAGMissiles
 		LocalOffset: 427,-171,-213, 427,171,-213
@@ -248,7 +248,7 @@ TRAN.Husk:
 		Speed: 140
 	RevealsShroud:
 		Range: 10c0
-		Type: CenterPosition
+		Type: GroundPosition
 	WithIdleOverlay@ROTOR1:
 		Offset: 597,0,85
 		Sequence: rotor
@@ -267,7 +267,7 @@ HELI.Husk:
 		Speed: 186
 	RevealsShroud:
 		Range: 10c0
-		Type: CenterPosition
+		Type: GroundPosition
 	WithIdleOverlay:
 		Offset: 0,0,85
 		Sequence: rotor
@@ -283,6 +283,6 @@ ORCA.Husk:
 		Speed: 186
 	RevealsShroud:
 		Range: 10c0
-		Type: CenterPosition
+		Type: GroundPosition
 	RenderSprites:
 		Image: orca

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -99,7 +99,7 @@ MIG:
 		Type: Light
 	RevealsShroud:
 		Range: 12c0
-		Type: CenterPosition
+		Type: GroundPosition
 	Armament:
 		Weapon: Maverick
 		LocalOffset: 0,-640,0, 0,640,0
@@ -154,7 +154,7 @@ YAK:
 		Type: Light
 	RevealsShroud:
 		Range: 10c0
-		Type: CenterPosition
+		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: ChainGun.Yak
 		LocalOffset: 256,-213,0
@@ -213,7 +213,7 @@ TRAN:
 		Type: Light
 	RevealsShroud:
 		Range: 10c0
-		Type: CenterPosition
+		Type: GroundPosition
 	Aircraft:
 		InitialFacing: 224
 		TurnSpeed: 5
@@ -267,7 +267,7 @@ HELI:
 		Type: Light
 	RevealsShroud:
 		Range: 12c0
-		Type: CenterPosition
+		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: HellfireAA
 		LocalOffset: 0,-213,-85
@@ -323,7 +323,7 @@ HIND:
 		Type: Light
 	RevealsShroud:
 		Range: 10c0
-		Type: CenterPosition
+		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: ChainGun
 		LocalOffset: 85,-213,-85

--- a/mods/ra/rules/husks.yaml
+++ b/mods/ra/rules/husks.yaml
@@ -96,7 +96,7 @@ TRAN.Husk:
 		Sequence: rotor2
 	RevealsShroud:
 		Range: 10c0
-		Type: CenterPosition
+		Type: GroundPosition
 	RenderSprites:
 		Image: tran
 
@@ -149,7 +149,7 @@ MIG.Husk:
 		MinDamage: Undamaged
 	RevealsShroud:
 		Range: 12c0
-		Type: CenterPosition
+		Type: GroundPosition
 	RenderSprites:
 		Image: mig
 
@@ -168,7 +168,7 @@ YAK.Husk:
 		MinDamage: Undamaged
 	RevealsShroud:
 		Range: 10c0
-		Type: CenterPosition
+		Type: GroundPosition
 	RenderSprites:
 		Image: yak
 
@@ -187,7 +187,7 @@ HELI.Husk:
 		MinDamage: Undamaged
 	RevealsShroud:
 		Range: 12c0
-		Type: CenterPosition
+		Type: GroundPosition
 	RenderSprites:
 		Image: heli
 
@@ -205,7 +205,7 @@ HIND.Husk:
 		MinDamage: Undamaged
 	RevealsShroud:
 		Range: 10c0
-		Type: CenterPosition
+		Type: GroundPosition
 	RenderSprites:
 		Image: hind
 


### PR DESCRIPTION
Fixes #12330.