### PR TITLE
Make MP start units facings customizable

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/MPStartUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/MPStartUnits.cs
@@ -37,6 +37,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Outer radius for spawning support actors")]
 		public readonly int OuterSupportRadius = 4;
+
+		[Desc("Initial facing of BaseActor. -1 means random.")]
+		public readonly int BaseActorFacing = 128;
+
+		[Desc("Initial facing of SupportActors. -1 means random.")]
+		public readonly int SupportActorsFacing = -1;
 	}
 
 	public class MPStartUnits { }

--- a/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 					new LocationInit(sp),
 					new OwnerInit(p),
 					new SkipMakeAnimsInit(),
-					new FacingInit(128),
+					new FacingInit(unitGroup.BaseActorFacing < 0 ? w.SharedRandom.Next(256) : unitGroup.BaseActorFacing),
 				});
 			}
 
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.Traits
 					new OwnerInit(p),
 					new LocationInit(cell),
 					new SubCellInit(subCell),
-					new FacingInit(w.SharedRandom.Next(256))
+					new FacingInit(unitGroup.SupportActorsFacing < 0 ? w.SharedRandom.Next(256) : unitGroup.SupportActorsFacing)
 				});
 			}
 		}


### PR DESCRIPTION
There might be modders or mappers who prefer different initial facing settings than the hardcoded ones.