### PR TITLE
Allow the missile to snap at the target at reach.

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -136,6 +136,10 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Explodes when leaving the following terrain type, e.g., Water for torpedoes.")]
 		public readonly string BoundToTerrainType = "";
 
+		[Desc("Allow the missile to snap to the target, meaning jumping to the target immediately when",
+			"the missile enters the radius of the current speed around the target.")]
+		public readonly bool AllowSnapping = false;
+
 		[Desc("Explodes when inside this proximity radius to target.",
 			"Note: If this value is lower than the missile speed, this check might",
 			"not trigger fast enough, causing the missile to fly past the target.")]
@@ -813,7 +817,10 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			// Move the missile
 			var lastPos = pos;
-			pos += move;
+			if (info.AllowSnapping && state != States.Freefall && relTarDist < move.Length)
+				pos = targetPosition + offset;
+			else
+				pos += move;
 
 			// Check for walls or other blocking obstacles
 			var shouldExplode = false;

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -20,6 +20,7 @@
 		MaximumLaunchAngle: 192
 		VerticalRateOfTurn: 16
 		CruiseAltitude: 1c512
+		AllowSnapping: true
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 25


### PR DESCRIPTION
This is basically a bugfix against the circling-missile-bug gen2 anti-air missiles are so susceptible, due to the targets being too fast to the missile, so it keeps circling around the aircraft.

It's optional however because gen1 mods are balanced around semiaccurate missiles and I don't want to affect that balance, TS also had accurate missiles though which is why it's enabled there.