### PR TITLE
Upgrades overhaul part 4c: Cargo and Passenger

### DIFF
--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -56,8 +56,13 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string UnloadBlockedCursor = "deploy-blocked";
 
 		[UpgradeGrantedReference]
-		[Desc("The upgrades to grant to self while loading cargo.")]
-		public readonly string[] LoadingUpgrades = { };
+		[Desc("The condition to grant to self while waiting for cargo to load.")]
+		public readonly string LoadingCondition = null;
+
+		[UpgradeGrantedReference]
+		[Desc("Conditions to grant when specified actors are loaded inside the transport.",
+			"A dictionary of [actor id]: [condition].")]
+		public readonly Dictionary<string, string> PassengerConditions = new Dictionary<string, string>();
 
 		public object Create(ActorInitializer init) { return new Cargo(init, this); }
 	}
@@ -69,6 +74,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Actor self;
 		readonly Stack<Actor> cargo = new Stack<Actor>();
 		readonly HashSet<Actor> reserves = new HashSet<Actor>();
+		readonly Dictionary<string, Stack<int>> passengerTokens = new Dictionary<string, Stack<int>>();
 		readonly Lazy<IFacing> facing;
 		readonly bool checkTerrainType;
 
@@ -76,6 +82,7 @@ namespace OpenRA.Mods.Common.Traits
 		int reservedWeight = 0;
 		Aircraft aircraft;
 		UpgradeManager upgradeManager;
+		int loadingToken = UpgradeManager.InvalidConditionToken;
 
 		CPos currentCell;
 		public IEnumerable<CPos> CurrentAdjacentCells { get; private set; }
@@ -193,9 +200,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!HasSpace(w))
 				return false;
 
-			if (reserves.Count == 0)
-				foreach (var u in Info.LoadingUpgrades)
-					upgradeManager.GrantUpgrade(self, u, this);
+			if (upgradeManager != null && loadingToken == UpgradeManager.InvalidConditionToken && !string.IsNullOrEmpty(Info.LoadingCondition))
+				loadingToken = upgradeManager.GrantCondition(self, Info.LoadingCondition);
 
 			reserves.Add(a);
 			reservedWeight += w;
@@ -211,9 +217,8 @@ namespace OpenRA.Mods.Common.Traits
 			reservedWeight -= GetWeight(a);
 			reserves.Remove(a);
 
-			if (reserves.Count == 0)
-				foreach (var u in Info.LoadingUpgrades)
-					upgradeManager.RevokeUpgrade(self, u, this);
+			if (loadingToken != UpgradeManager.InvalidConditionToken)
+				loadingToken = upgradeManager.RevokeCondition(self, loadingToken);
 		}
 
 		public string CursorForOrder(Actor self, Order order)
@@ -251,8 +256,9 @@ namespace OpenRA.Mods.Common.Traits
 			var p = a.Trait<Passenger>();
 			p.Transport = null;
 
-			foreach (var u in p.Info.GrantUpgrades)
-				upgradeManager.RevokeUpgrade(self, u, p);
+			Stack<int> passengerToken;
+			if (passengerTokens.TryGetValue(a.Info.Name, out passengerToken) && passengerToken.Any())
+				upgradeManager.RevokeCondition(self, passengerToken.Pop());
 
 			return a;
 		}
@@ -304,9 +310,8 @@ namespace OpenRA.Mods.Common.Traits
 				reservedWeight -= w;
 				reserves.Remove(a);
 
-				if (reserves.Count == 0)
-					foreach (var u in Info.LoadingUpgrades)
-						upgradeManager.RevokeUpgrade(self, u, this);
+				if (loadingToken != UpgradeManager.InvalidConditionToken)
+					loadingToken = upgradeManager.RevokeCondition(self, loadingToken);
 			}
 
 			// If not initialized then this will be notified in the first tick
@@ -316,8 +321,10 @@ namespace OpenRA.Mods.Common.Traits
 
 			var p = a.Trait<Passenger>();
 			p.Transport = self;
-			foreach (var u in p.Info.GrantUpgrades)
-				upgradeManager.GrantUpgrade(self, u, p);
+
+			string passengerCondition;
+			if (upgradeManager != null && Info.PassengerConditions.TryGetValue(a.Info.Name, out passengerCondition))
+				passengerTokens.GetOrAdd(a.Info.Name).Push(upgradeManager.GrantCondition(self, passengerCondition));
 		}
 
 		void INotifyKilled.Killed(Actor self, AttackInfo e)

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -38,9 +38,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Range from self for looking for an alternate transport (default: 5.5 cells).")]
 		public readonly WDist AlternateTransportScanRange = WDist.FromCells(11) / 2;
 
-		[Desc("Upgrade types to grant to transport.")]
-		[UpgradeGrantedReference] public readonly string[] GrantUpgrades = { };
-
 		[VoiceReference] public readonly string Voice = "Action";
 
 		public object Create(ActorInitializer init) { return new Passenger(this); }

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -574,6 +574,16 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						RenameNodeKey(node, "ProximityExternalCondition");
 						ConvertUpgradesToCondition(parent, node, "Upgrades", "Condition");
 					}
+
+					if (node.Key == "Cargo")
+						ConvertUpgradesToCondition(parent, node, "LoadingUpgrades", "LoadingCondition");
+
+					if (node.Key == "Passenger" && node.Value.Nodes.Any(n => n.Key == "GrantUpgrades"))
+					{
+						Console.WriteLine("Passenger.GrantUpgrades support has been removed.");
+						Console.WriteLine("Define passenger-conditions using Cargo.PassengerConditions on the transports instead.");
+						node.Value.Nodes.RemoveAll(n => n.Key == "GrantUpgrades");
+					}
 				}
 
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);

--- a/mods/cnc/rules/ships.yaml
+++ b/mods/cnc/rules/ships.yaml
@@ -76,4 +76,4 @@ LST:
 		MaxWeight: 5
 		PipCount: 5
 		PassengerFacing: 0
-		LoadingUpgrades: notmobile
+		LoadingCondition: notmobile

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -120,7 +120,7 @@ APC:
 		Types: Infantry
 		MaxWeight: 5
 		PipCount: 5
-		LoadingUpgrades: notmobile
+		LoadingCondition: notmobile
 	SpawnActorOnDeath:
 		Actor: APC.Husk
 

--- a/mods/ra/maps/infiltration/rules.yaml
+++ b/mods/ra/maps/infiltration/rules.yaml
@@ -55,7 +55,6 @@ SPY.Strong:
 	ExternalCaptures:
 		CaptureTypes: MissionObjective
 	Passenger:
-		GrantUpgrades: mobile
 
 DOG.Patrol:
 	Inherits: DOG
@@ -76,6 +75,8 @@ TRUK.Hijackable:
 		Types: Infantry
 		MaxWeight: 5
 		PipCount: 5
+		PassengerConditions:
+			spy.strong: mobile
 	AutoTargetIgnore:
 	-Huntable:
 	ExternalCapturable:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -242,7 +242,7 @@ LST:
 		MaxWeight: 5
 		PipCount: 5
 		PassengerFacing: 0
-		LoadingUpgrades: notmobile
+		LoadingCondition: notmobile
 	-Chronoshiftable:
 
 PT:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -355,7 +355,7 @@ JEEP:
 		Types: Infantry
 		MaxWeight: 1
 		PipCount: 1
-		LoadingUpgrades: notmobile
+		LoadingCondition: notmobile
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 
@@ -391,7 +391,7 @@ APC:
 		Types: Infantry
 		MaxWeight: 5
 		PipCount: 5
-		LoadingUpgrades: notmobile
+		LoadingCondition: notmobile
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 
@@ -752,7 +752,7 @@ STNK:
 		Types: Infantry
 		MaxWeight: 4
 		PipCount: 4
-		LoadingUpgrades: notmobile
+		LoadingCondition: notmobile
 	Cloak:
 		InitialDelay: 125
 		CloakDelay: 250

--- a/mods/ts/rules/civilian-vehicles.yaml
+++ b/mods/ts/rules/civilian-vehicles.yaml
@@ -102,7 +102,7 @@ BUS:
 		MaxWeight: 20
 		PipCount: 5
 		UnloadVoice: Unload
-		LoadingUpgrades: loading
+		LoadingCondition: loading
 		EjectOnDeath: true
 
 PICK:
@@ -126,7 +126,7 @@ PICK:
 		MaxWeight: 2
 		PipCount: 5
 		UnloadVoice: Unload
-		LoadingUpgrades: loading
+		LoadingCondition: loading
 		EjectOnDeath: true
 
 CAR:
@@ -150,7 +150,7 @@ CAR:
 		MaxWeight: 4
 		PipCount: 5
 		UnloadVoice: Unload
-		LoadingUpgrades: loading
+		LoadingCondition: loading
 		EjectOnDeath: true
 
 WINI:
@@ -174,7 +174,7 @@ WINI:
 		MaxWeight: 5
 		PipCount: 5
 		UnloadVoice: Unload
-		LoadingUpgrades: loading
+		LoadingCondition: loading
 		EjectOnDeath: true
 
 LOCOMOTIVE:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -802,7 +802,7 @@
 	Cargo:
 		Types: Infantry
 		UnloadVoice: Unload
-		LoadingUpgrades: loading
+		LoadingCondition: loading
 	Health:
 		HP: 100
 	Armor:

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -28,7 +28,7 @@ APC:
 		MaxWeight: 5
 		PipCount: 5
 		UnloadVoice: Unload
-		LoadingUpgrades: loading
+		LoadingCondition: loading
 		EjectOnDeath: true
 	UpgradeOnTerrain:
 		Upgrades: inwater

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -285,7 +285,7 @@ SAPC:
 		MaxWeight: 5
 		PipCount: 5
 		UnloadVoice: Unload
-		LoadingUpgrades: loading
+		LoadingCondition: loading
 		EjectOnDeath: true
 
 SUBTANK:


### PR DESCRIPTION
Depends on #12406.

The `GrantUpgrades` field on `Passenger` has been moved to `PassengerConditions` on `Cargo`.  This avoids adding the (IMO unnecessary) complexity of external conditions to the cargo code.

Requiring the conditions to be defined for every actor type might be controversial, so an alternative could be to rework the cargo code to support multiple `CargoType`s on a `Passenger`, and then have the conditions keyed on this.

The test case extends the one from #12406 to show how passenger conditions can be stacked for improved bonuses (2x e1 = green, 3x e1 = blue).