### PR TITLE
Reduce aircraft not being targetable at the north edge of the map.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -228,6 +228,15 @@ namespace OpenRA.Mods.Common.Traits
 				repulsionForce += GetRepulsionForce(actor);
 			}
 
+			// Actors outside the map bounds receive an extra nudge towards the center of the map
+			if (!self.World.Map.Contains(self.Location))
+			{
+				// The map bounds are in projected coordinates, which is technically wrong for this,
+				// but we avoid the issues in practice by guessing the middle of the map instead of the edge
+				var center = WPos.Lerp(self.World.Map.ProjectedTopLeft, self.World.Map.ProjectedBottomRight, 1, 2);
+				repulsionForce += new WVec(1024, 0, 0).Rotate(WRot.FromYaw((self.CenterPosition - center).Yaw));
+			}
+
 			if (Info.CanHover)
 				return repulsionForce;
 

--- a/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderFog.cs
@@ -31,7 +31,11 @@ namespace OpenRA.Mods.Common.Traits
 			if (Info.Type == VisibilityType.Footprint)
 				return byPlayer.Shroud.AnyVisible(self.OccupiesSpace.OccupiedCells());
 
-			return byPlayer.Shroud.IsVisible(self.CenterPosition);
+			var pos = self.CenterPosition;
+			if (Info.Type == VisibilityType.GroundPosition)
+				pos -= new WVec(WDist.Zero, WDist.Zero, self.World.Map.DistanceAboveTerrain(pos));
+
+			return byPlayer.Shroud.IsVisible(pos);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderShroud.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderShroud.cs
@@ -44,7 +44,11 @@ namespace OpenRA.Mods.Common.Traits
 			if (Info.Type == VisibilityType.Footprint)
 				return byPlayer.Shroud.AnyExplored(self.OccupiesSpace.OccupiedCells());
 
-			return byPlayer.Shroud.IsExplored(self.CenterPosition);
+			var pos = self.CenterPosition;
+			if (Info.Type == VisibilityType.GroundPosition)
+				pos -= new WVec(WDist.Zero, WDist.Zero, self.World.Map.DistanceAboveTerrain(pos));
+
+			return byPlayer.Shroud.IsExplored(pos);
 		}
 
 		public bool IsVisible(Actor self, Player byPlayer)

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -204,7 +204,7 @@
 		CruisingUpgrades: cruising
 		CanHover: True
 	HiddenUnderFog:
-		Type: CenterPosition
+		Type: GroundPosition
 	ActorLostNotification:
 	Explodes:
 		Weapon: HeliExplode
@@ -500,7 +500,7 @@
 	AppearsOnRadar:
 		UseLocation: yes
 	HiddenUnderFog:
-		Type: CenterPosition
+		Type: GroundPosition
 		AlwaysVisibleStances: None
 	ActorLostNotification:
 	AttackMove:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -299,7 +299,7 @@
 	AppearsOnRadar:
 		UseLocation: true
 	HiddenUnderFog:
-		Type: CenterPosition
+		Type: GroundPosition
 		AlwaysVisibleStances: None
 	ActorLostNotification:
 	AttackMove:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -432,7 +432,7 @@
 		TargetTypes: Air
 		RequiresCondition: airborne
 	HiddenUnderFog:
-		Type: CenterPosition
+		Type: GroundPosition
 	AttackMove:
 	Guard:
 	Guardable:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -571,7 +571,7 @@
 	Voiced:
 		VoiceSet: Heli
 	HiddenUnderFog:
-		Type: CenterPosition
+		Type: GroundPosition
 	AttackMove:
 		Voice: Move
 	ActorLostNotification:
@@ -614,7 +614,7 @@
 	Armor:
 		Type: Heavy
 	HiddenUnderFog:
-		Type: CenterPosition
+		Type: GroundPosition
 	AutoTargetIgnore:
 	ScriptTriggers:
 	Tooltip:


### PR DESCRIPTION
This fixes two of the problems contributing to #9552, fixing the exploit where helicopters at the north edge of the map won't be `AutoTarget`ed by AA.  The problem is reduced (but remains) for fixed-wing aircraft; fixing them properly will require the flight code to predict ahead and turn *before* reaching the edge of the map.