### PR TITLE
[RA] Increase Nuke Damage vs Trees

### DIFF
--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -58,20 +58,27 @@ CrateNuke:
 		Damage: 60
 		Falloff: 1000, 600, 400, 250, 150, 100, 0
 		Delay: 4
-		ValidTargets: Ground, Trees, Water, Air
+		ValidTargets: Ground, Water, Air
 		Versus:
 			Concrete: 25
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
-	Warhead@5Res_areanuke: DestroyResource
+	Warhead@5Dam_areanuke: SpreadDamage
+		Spread: 1c0
+		Damage: 120
+		Falloff: 1000, 600, 400, 250, 150, 100, 0
+		Delay: 4
+		ValidTargets: Trees
+		DamageTypes: Incendiary
+	Warhead@6Res_areanuke: DestroyResource
 		Size: 5,4
 		Delay: 4
-	Warhead@6Smu_areanuke: LeaveSmudge
+	Warhead@7Smu_areanuke: LeaveSmudge
 		SmudgeType: Scorch
 		InvalidTargets: Vehicle, Tank, Structure, Wall, Trees
 		Size: 5,4
 		Delay: 4
-	Warhead@7Eff_areanuke: CreateEffect
+	Warhead@8Eff_areanuke: CreateEffect
 		ImpactSounds: kaboom22.aud
 		Delay: 4
 
@@ -112,28 +119,42 @@ MiniNuke:
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 10
-		ValidTargets: Ground, Trees, Water, Underwater, Air
+		ValidTargets: Ground, Water, Underwater, Air
 		Versus:
 			Concrete: 25
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
-	Warhead@8Res_areanuke2: DestroyResource
+	Warhead@8Dam_areanuke2: SpreadDamage
+		Spread: 3c0
+		Damage: 120
+		Falloff: 1000, 368, 135, 50, 18, 7, 0
+		Delay: 10
+		ValidTargets: Trees
+		DamageTypes: Incendiary
+	Warhead@9Res_areanuke2: DestroyResource
 		Size: 3
 		Delay: 10
-	Warhead@9Dam_areanuke3: SpreadDamage
+	Warhead@10Dam_areanuke3: SpreadDamage
 		Spread: 4c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 15
-		ValidTargets: Ground, Trees, Water, Underwater
+		ValidTargets: Ground, Water, Underwater
 		Versus:
 			Concrete: 25
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
-	Warhead@10Res_areanuke3: DestroyResource
+	Warhead@11Dam_areanuke3: SpreadDamage
+		Spread: 4c0
+		Damage: 180
+		Falloff: 1000, 368, 135, 50, 18, 7, 0
+		Delay: 15
+		ValidTargets: Trees
+		DamageTypes: Incendiary
+	Warhead@12Res_areanuke3: DestroyResource
 		Size: 4
 		Delay: 15
-	Warhead@11Smu_areanuke3: LeaveSmudge
+	Warhead@13Smu_areanuke3: LeaveSmudge
 		SmudgeType: Scorch
 		InvalidTargets: Vehicle, Tank, Structure, Wall, Trees
 		Size: 4

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -72,48 +72,69 @@ Atomic:
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 10
-		ValidTargets: Ground, Trees, Water, Underwater, Air
+		ValidTargets: Ground, Water, Underwater, Air
 		Versus:
 			Concrete: 25
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
-	Warhead@10Res_areanuke2: DestroyResource
+	Warhead@10Dam_areanuke2: SpreadDamage
+		Spread: 3c0
+		Damage: 120
+		Falloff: 1000, 368, 135, 50, 18, 7, 0
+		Delay: 15
+		ValidTargets: Trees
+		DamageTypes: Incendiary
+	Warhead@11Res_areanuke2: DestroyResource
 		Size: 3
 		Delay: 10
-	Warhead@11Smu_areanuke2: LeaveSmudge
+	Warhead@12Smu_areanuke2: LeaveSmudge
 		SmudgeType: Scorch
 		InvalidTargets: Vehicle, Tank, Structure, Wall, Husk, Trees
 		Size: 3
 		Delay: 10
-	Warhead@12Dam_areanuke3: SpreadDamage
+	Warhead@13Dam_areanuke3: SpreadDamage
 		Spread: 4c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 15
-		ValidTargets: Ground, Trees, Water, Underwater, Air
+		ValidTargets: Ground, Water, Underwater, Air
 		Versus:
 			Concrete: 25
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
-	Warhead@13Res_areanuke3: DestroyResource
+	Warhead@14Dam_areanuke3: SpreadDamage
+		Spread: 4c0
+		Damage: 120
+		Falloff: 1000, 368, 135, 50, 18, 7, 0
+		Delay: 15
+		ValidTargets: Trees
+		DamageTypes: Incendiary
+	Warhead@15Res_areanuke3: DestroyResource
 		Size: 4
 		Delay: 15
-	Warhead@14Smu_areanuke3: LeaveSmudge
+	Warhead@16Smu_areanuke3: LeaveSmudge
 		SmudgeType: Scorch
 		InvalidTargets: Vehicle, Tank, Structure, Wall, Husk, Trees
 		Size: 4
 		Delay: 15
-	Warhead@15Dam_areanuke4: SpreadDamage
+	Warhead@17Dam_areanuke4: SpreadDamage
 		Spread: 5c0
 		Damage: 60
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 20
-		ValidTargets: Ground, Trees, Water, Underwater, Air
+		ValidTargets: Ground, Water, Underwater, Air
 		Versus:
 			Concrete: 25
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
-	Warhead@16Res_areanuke4: DestroyResource
+	Warhead@18Dam_areanuke4: SpreadDamage
+		Spread: 5c0
+		Damage: 120
+		Falloff: 1000, 368, 135, 50, 18, 7, 0
+		Delay: 20
+		ValidTargets: Trees
+		DamageTypes: Incendiary
+	Warhead@19Res_areanuke4: DestroyResource
 		Size: 5
 		Delay: 20
-	Warhead@17Smu_areanuke4: LeaveSmudge
+	Warhead@20Smu_areanuke4: LeaveSmudge
 		SmudgeType: Scorch
 		InvalidTargets: Vehicle, Tank, Structure, Wall, Husk, Trees
 		Size: 5


### PR DESCRIPTION
An offshoot of #12236

Nuke _does_ turn trees to 'burnt' at a certain range for various nuke weapons. #12236 came after an observation that it didn't, reason being that the range in which trees does burn out is relatively small and so the experience in-game could give the same impression simply because nuke targets are generally not in vicinity of trees/forest.

I added additional warheads to the nuke, nuketruck and cratenuke to add a few extra cells worth of damage. Respectively it adds approximately 3, 2 and 1 cells of further burnt damage. A trivial matter really but the nuke feels more physically impactful that way. 

I've isolated `Trees` to their own `Warhead@areanuke` for simplicity sake.

Range comparison, a-bomb:
![nuke1](https://cloud.githubusercontent.com/assets/2715583/21082364/5df7ba68-bfda-11e6-8c3d-e18b5adfd488.jpg)

I also took into account the effect vs effect on units/structures so as to make it visually consistent, E.g. a-bomb:
![nuke2](https://cloud.githubusercontent.com/assets/2715583/21082384/b978906a-bfda-11e6-8a3a-692a7c3452a4.jpg)

I couldn't leave the nukecrate alone. In the bleed it only burns down trees within 1 cell range. In this PR:
![nukecrate](https://cloud.githubusercontent.com/assets/2715583/21082417/5093ac46-bfdb-11e6-8276-2c190ec3f89a.png)

