### PR TITLE
[RA] Rename Shipyard and Transport Helicopter

### DIFF
--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -206,7 +206,7 @@ TRAN:
 	Valued:
 		Cost: 900
 	Tooltip:
-		Name: Transport Helicopter
+		Name: Chinook
 	Health:
 		HP: 120
 	Armor:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -189,7 +189,7 @@ SYRD:
 	Valued:
 		Cost: 1000
 	Tooltip:
-		Name: Shipyard
+		Name: Naval Yard
 	Targetable:
 		TargetTypes: Ground, Water, Structure, C4, DetonateAttack, SpyInfiltrate
 	Building:


### PR DESCRIPTION
Adresses #12197 of which don't need meddling with SHP files.

- Shipyard -> Naval Yard

Because it's a Naval Yard in the build tab and it's called Naval Yard by players. #5992

- Transport Helicopter -> Chinook

Same reasoning as above.