### PR TITLE
[RA] [Balance] Allied Defensive Structures - Increase Cost & Production Time.

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -534,7 +534,9 @@ PBOX:
 		Prerequisites: tent, ~structures.allies, ~techlevel.low
 		Description: Static defense with a fireport for a\ngarrisoned soldier.\nCan detect cloaked units.\n  Strong vs Infantry, Light armor\n  Weak vs Tanks, Aircraft
 	Valued:
-		Cost: 400
+		Cost: 600
+	CustomSellValue:
+		Value: 400
 	Health:
 		HP: 400
 	Armor:
@@ -577,7 +579,9 @@ HBOX:
 		Prerequisites: tent, ~structures.allies, ~techlevel.medium
 		Description: Camouflaged static defense with a fireport\nfor a garrisoned soldier.\nCan detect cloaked units.\n  Strong vs Infantry, Light armor\n  Weak vs Tanks, Aircraft
 	Valued:
-		Cost: 600
+		Cost: 800
+	CustomSellValue:
+		Value: 600
 	Health:
 		HP: 450
 	Armor:
@@ -620,7 +624,7 @@ GUN:
 		Prerequisites: tent, ~structures.allies, ~techlevel.medium
 		Description: Anti-Armor base defense.\nCan detect cloaked units.\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
 	Valued:
-		Cost: 600
+		Cost: 800
 	Tooltip:
 		Name: Turret
 	Building:


### PR DESCRIPTION
- Pillbox cost $600, up from $400
- Camo Pillbox cost $800, up from $600
- Gun Turret cost $800, up from $600

The opinions on this issue is pretty much one sided among both casual and competetive players. Might as well refer to the main discussion thread on topic: http://www.sleipnirstuff.com/forum/viewtopic.php?f=82&t=19825 You'll be able to find the same opinions scattered throughout various balance discussions on the forum. E.g.:
http://www.sleipnirstuff.com/forum/viewtopic.php?f=82&p=298839#298839
http://www.sleipnirstuff.com/forum/viewtopic.php?f=82&t=19845
http://www.sleipnirstuff.com/forum/viewtopic.php?f=82&t=19854

To summarize shortly, the cheap Pillboxes and Gun Turrets simply provides the incentive for Allies players to spam them non-stop throughout games, securing all flanks almost for free preventing counterattacks, expanding with little-to-no risk and quickly fortifying an lone MCV expansion literally within the minute. 

The changes has been playtested on modded maps delivered by Frame Limiter, FiveAces and myself (playtest maps v1.4) on and off stream with a few hunded downloads as well as on a playtest build showcased on stream, with particular feedback on the latter: http://www.sleipnirstuff.com/forum/viewtopic.php?f=82&p=298663#298663

Additionally this specific balance issue has been in context of ideas involving reducing defensive structure's production bonus of multiple MCV's and/or also reducing the custom build time for the MCV itself. These are showing some good promise but hasn't been covered in the same extent as the above. By itself this balance PR is regarded as a step in the right direction.