### PR TITLE
Prevent tick tanks from moving when not undeployed.

### DIFF
--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -84,6 +84,7 @@ TTNK:
 		TurnSpeed: 5
 		Speed: 85
 		Crushes: wall, crate, infantry
+		RequiresCondition: !empdisable && undeployed
 	Health:
 		HP: 350
 	Armor:


### PR DESCRIPTION
This fixes an issue discovered by @abcdefg30:

![](https://dl.dropboxusercontent.com/content_link/NETcCpMaolrDOsm8zKnhUInLWOspa4KI6eGQ6czODIKYHGxLlug0WsBDiTYG36wl/file?raw=1&dl=0&duc_id=1Od3Yp0uADQob8huPeTSJzl6haL0XZYm8mwQ3Qv3JFMHUxmQ0oG6TIel3TX0IQP0&size=1280x960&size_mode=3)