### PR TITLE
Remove Game.RunAfterDelay from SwallowActor

### DIFF
--- a/OpenRA.Mods.Common/Effects/MapNotificationEffect.cs
+++ b/OpenRA.Mods.Common/Effects/MapNotificationEffect.cs
@@ -1,0 +1,65 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Drawing;
+using OpenRA.Effects;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Effects
+{
+	public class MapNotificationEffect : IEffect
+	{
+		readonly RadarPings radarPings;
+
+		readonly WPos pos;
+		readonly Player player;
+		readonly int duration;
+		readonly string category;
+		readonly string notification;
+		readonly bool visible;
+		readonly Color color;
+
+		int remainingDelay;
+
+		public MapNotificationEffect(Player player, string category, string notification, int delay,
+			bool pingVisible, WPos pos, Color pingColor, int pingDuration = 50)
+		{
+			this.player = player;
+			remainingDelay = delay;
+			this.category = category;
+			this.notification = notification;
+			this.pos = pos;
+			duration = pingDuration;
+			visible = pingVisible;
+			color = pingColor;
+
+			radarPings = player.World.WorldActor.TraitOrDefault<RadarPings>();
+		}
+
+		public void Tick(World world)
+		{
+			if (remainingDelay-- > 0)
+				return;
+
+			Game.Sound.PlayNotification(player.World.Map.Rules, player, category, notification, player.Faction.InternalName);
+
+			if (visible && radarPings != null && player == player.World.RenderPlayer)
+				radarPings.Add(() => true, pos, color, duration);
+
+			world.AddFrameEndTask(w => w.Remove(this));
+		}
+
+		public IEnumerable<IRenderable> Render(WorldRenderer wr) { return SpriteRenderable.None; }
+	}
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Effects\RevealShroudEffect.cs" />
     <Compile Include="Effects\FlashTarget.cs" />
     <Compile Include="Effects\FloatingText.cs" />
+    <Compile Include="Effects\MapNotificationEffect.cs" />
     <Compile Include="Effects\PowerdownIndicator.cs" />
     <Compile Include="Effects\RallyPointIndicator.cs" />
     <Compile Include="Effects\RepairIndicator.cs" />


### PR DESCRIPTION
RunAfterDelay might be potentially problematic for savegame support.
A delay of 1 second isn't enough to justify some work-around, in my opinion, it's easier to just play the notification and radar ping immediately.