### PR TITLE
Fix case sensitive error when copying NAT dll

### DIFF
--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -86,7 +86,7 @@ fi
 if [ ! -f Open.Nat.dll ]; then
 	echo "Fetching Open.Nat from NuGet"
 	get Open.NAT 2.1.0
-	cp ./Open.NAT/lib/net45/Open.Nat.dll .
+	cp ./Open.Nat/lib/net45/Open.Nat.dll .
 	rm -rf Open.NAT
 fi
 


### PR DESCRIPTION
This patch fixes a problem when making dependencies on Linux Debian 8.6.
' cp: could not evaluate « ./Open.NAT/lib/net45/Open.Nat.dll » '

I fixed the source directory name which is Open.Nat on my system when downloaded with nuget.