### PR TITLE
Fix asset installation on 32 bit windows and with original RA CDs.

### DIFF
--- a/OpenRA.Mods.Common/ModContent.cs
+++ b/OpenRA.Mods.Common/ModContent.cs
@@ -48,13 +48,18 @@ namespace OpenRA
 			public readonly string RegistryValue;
 
 			public readonly string Title;
-			public readonly Dictionary<string, string> IDFiles;
 
+			[FieldLoader.Ignore] public readonly MiniYaml IDFiles;
 			[FieldLoader.Ignore] public readonly List<MiniYamlNode> Install;
 
 			public ModSource(MiniYaml yaml)
 			{
 				Title = yaml.Value;
+
+				var idFiles = yaml.Nodes.FirstOrDefault(n => n.Key == "IDFiles");
+				if (idFiles != null)
+					IDFiles = idFiles.Value;
+
 				var installNode = yaml.Nodes.FirstOrDefault(n => n.Key == "Install");
 				if (installNode != null)
 					Install = installNode.Value.Nodes;

--- a/OpenRA.Mods.Common/ModContent.cs
+++ b/OpenRA.Mods.Common/ModContent.cs
@@ -43,6 +43,7 @@ namespace OpenRA
 			public readonly SourceType Type = SourceType.Disc;
 
 			// Used to find installation locations for SourceType.Install
+			public readonly string[] RegistryPrefixes = { string.Empty };
 			public readonly string RegistryKey;
 			public readonly string RegistryValue;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
@@ -481,11 +481,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (Platform.CurrentPlatform != PlatformType.Windows)
 					return null;
 
-				var path = Microsoft.Win32.Registry.GetValue(source.RegistryKey, source.RegistryValue, null) as string;
-				if (path == null)
-					return null;
+				foreach (var prefix in source.RegistryPrefixes)
+				{
+					var path = Microsoft.Win32.Registry.GetValue(prefix + source.RegistryKey, source.RegistryValue, null) as string;
+					if (path == null)
+						continue;
 
-				return IsValidSourcePath(path, source) ? path : null;
+					return IsValidSourcePath(path, source) ? path : null;
+				}
+
+				return null;
 			}
 
 			if (source.Type == ModContent.SourceType.Disc)

--- a/mods/cnc/installer/origin.yaml
+++ b/mods/cnc/installer/origin.yaml
@@ -1,6 +1,7 @@
 origin: C&C The Ultimate Collection (Origin version, English)
 	Type: Install
-	RegistryKey: HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\EA Games\CNC and The Covert Operations
+	RegistryPrefixes: HKEY_LOCAL_MACHINE\Software\, HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\
+	RegistryKey: EA Games\CNC and The Covert Operations
 	RegistryValue: Install Dir
 	IDFiles:
 		CNC95Launcher.exe: 1d711adf09ac08738b2599b3092a1b448169b32a

--- a/mods/d2k/installer/gruntmods.yaml
+++ b/mods/d2k/installer/gruntmods.yaml
@@ -1,7 +1,7 @@
-
 gruntmods: Dune 2000: GruntMods Edition
 	Type: Install
-	RegistryKey: HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Dune 2000: Gruntmods Edition
+	RegistryPrefixes: HKEY_LOCAL_MACHINE\Software\, HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\
+	RegistryKey: Dune 2000: Gruntmods Edition
 	IDFiles:
 		Dune 2000/data/BLOXXMAS.R8: afc818feda44f5873e3af07bd2191573ba9965db
 		Dune 2000/data/DATA.R8: 2b229cf4be47104a6214237039a55329f6c45bc9

--- a/mods/ra/installer/allies95.yaml
+++ b/mods/ra/installer/allies95.yaml
@@ -1,6 +1,7 @@
 allied: Red Alert 95 (Allied Disc, English)
 	IDFiles:
-		eahelp.GID: 13a8a4a1e7d9d6d893c38df5a39262c4689aeba5
+		MAIN.MIX: 20ebe16f91ff79be2d672f1db5bae9048ff9357c
+			Length: 4096
 		INSTALL/REDALERT.MIX: 0e58f4b54f44f6cd29fecf8cf379d33cf2d4caef
 	Install:
 		extract-raw: INSTALL/REDALERT.MIX

--- a/mods/ra/installer/origin.yaml
+++ b/mods/ra/installer/origin.yaml
@@ -1,6 +1,7 @@
 ra-origin: C&C The Ultimate Collection (Origin version, English)
 	Type: Install
-	RegistryKey: HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\EA Games\Command and Conquer Red Alert
+	RegistryPrefixes: HKEY_LOCAL_MACHINE\Software\, HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\
+	RegistryKey: EA Games\Command and Conquer Red Alert
 	RegistryValue: Install Dir
 	IDFiles:
 		RA95Launcher.exe: 22bf7a1f9f1c2498823e3216541e6012f291c2c0
@@ -455,9 +456,11 @@ ra-origin: C&C The Ultimate Collection (Origin version, English)
 			^Content/ra/v2/expand/myes1.aud:
 				Offset: 844509702
 				Length: 9073
+
 cnc-origin: Command & Conquer (Origin version, English)
 	Type: Install
-	RegistryKey: HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\EA Games\CNC and The Covert Operations
+	RegistryPrefixes: HKEY_LOCAL_MACHINE\Software\, HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\
+	RegistryKey: EA Games\CNC and The Covert Operations
 	RegistryValue: Install Dir
 	IDFiles:
 		CNC95Launcher.exe: 1d711adf09ac08738b2599b3092a1b448169b32a

--- a/mods/ra/installer/soviet95.yaml
+++ b/mods/ra/installer/soviet95.yaml
@@ -1,6 +1,7 @@
 soviet: Red Alert 95 (Soviet Disc, English)
 	IDFiles:
-		automenu.apm: bb61132a492bfb37069a0139f95671da3655d916
+		MAIN.MIX: 9d108f18560716b684ab8b1da42cc7f3d1b52519
+			Length: 4096
 		INSTALL/REDALERT.MIX: 0e58f4b54f44f6cd29fecf8cf379d33cf2d4caef
 	Install:
 		extract-raw: INSTALL/REDALERT.MIX

--- a/mods/ts/installer/origin.yaml
+++ b/mods/ts/installer/origin.yaml
@@ -1,6 +1,7 @@
 origin: C&C The Ultimate Collection (Origin version, English)
 	Type: Install
-	RegistryKey: HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\EA Games\Command and Conquer Tiberian Sun
+	RegistryPrefixes: HKEY_LOCAL_MACHINE\Software\, HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\
+	RegistryKey: EA Games\Command and Conquer Tiberian Sun
 	RegistryValue: Install Dir
 	IDFiles:
 		TSLauncher.exe: 0b3e8dfd7cb701868eccef3ba3717a1ced802707


### PR DESCRIPTION
Fixes #12316.
Fixes #12473.