### PR TITLE
[bleed] Remove AI capturing from TD and RA, and AIs using mechanics and medics in RA

### DIFF
--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -46,17 +46,12 @@ Player:
 			silo: 0%
 			fix: 1%
 			hpad: 2%
-		CapturingActorTypes: e6
-		CapturableActorTypes: fact, fact.gdi, fact.nod, nuke, nuk2, proc, pyle, hand, afld, weap, hpad, hq, fix, eye, tmpl, obli, v19
-		CheckCaptureTargetsForVisibility: false
-		MaximumCaptureTargetOptions: 15
 		UnitsToBuild:
 			e1: 65%
 			e2: 25%
 			e3: 40%
 			e4: 15%
 			e5: 15%
-			e6: 5%
 			harv: 10%
 			bggy: 5%
 			bike: 40%
@@ -72,7 +67,6 @@ Player:
 			orca: 5%
 		UnitLimits:
 			harv: 8
-			e6: 3
 		SquadSize: 15
 		SupportPowerDecision@Airstrike:
 			OrderName: AirstrikePowerInfoOrder

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -41,16 +41,11 @@ Player:
 			stek: 1%
 			fix: 0.1%
 			dome: 10%
-		CapturingActorTypes: e6
-		CapturableActorTypes: mslo, gap, iron, pdox, atek, weap, fact, proc, silo, hpad, afld, powr, apwr, stek, barr, kenn, tent, fix, oilb
-		CheckCaptureTargetsForVisibility: false
-		MaximumCaptureTargetOptions: 15
 		UnitsToBuild:
 			e1: 65%
 			e2: 25%
 			e3: 40%
 			e4: 15%
-			e6: 5%
 			dog: 15%
 			shok: 15%
 			harv: 10%
@@ -67,7 +62,6 @@ Player:
 			stnk: 5%
 		UnitLimits:
 			dog: 4
-			e6: 3
 			harv: 8
 		SquadSize: 20
 		SupportPowerDecision@spyplane:

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -174,8 +174,6 @@ Player:
 			e2: 25%
 			e3: 40%
 			e4: 15%
-			medi: 3%
-			mech: 3%
 			dog: 15%
 			shok: 15%
 			harv: 10%
@@ -201,8 +199,6 @@ Player:
 			pt: 10%
 		UnitLimits:
 			dog: 4
-			medi: 3
-			mech: 3
 			harv: 8
 		SquadSize: 40
 		SupportPowerDecision@spyplane:
@@ -309,8 +305,6 @@ Player:
 			e2: 25%
 			e3: 40%
 			e4: 15%
-			medi: 5%
-			mech: 5%
 			dog: 15%
 			shok: 15%
 			harv: 10%
@@ -336,8 +330,6 @@ Player:
 			pt: 10%
 		UnitLimits:
 			dog: 4
-			medi: 4
-			mech: 4
 			harv: 8
 		SquadSize: 10
 		SupportPowerDecision@spyplane:


### PR DESCRIPTION
The AI unit code didn't see any work or interest this cycle, so this cherry-picks #12212 onto bleed to avoid regressions in the next playtest.

Closes #12206.
~~Closes~~ Works around #11981 for our default mods.