### PR TITLE
Abort installation if .NET 4.5 isn't installed.

### DIFF
--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -152,15 +152,8 @@ Section "-DotNet" DotNet
 	IfErrors error 0
 	IntCmp $0 1 done error done
 	error:
-		MessageBox MB_YESNO ".NET Framework v4.5 or later is required to run OpenRA. $\n \
-		Do you wish for the installer to launch your web browser in order to download and install it?" \
-		IDYES download IDNO error2
-	download:
-		ExecShell "open" "http://www.microsoft.com/en-us/download/details.aspx?id=30653"
-		Goto done
-	error2:
-		MessageBox MB_OK "Installation will continue, but be aware that OpenRA will not run unless .NET v4.5 \
-		or later is installed."
+		MessageBox MB_OK ".NET Framework v4.5 or later is required to run OpenRA."
+		Abort
 	done:
 SectionEnd
 


### PR DESCRIPTION
Closes #12256.