### PR TITLE
Add HiDPI support for OSX/Windows/Linux

### DIFF
--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -43,6 +43,8 @@ namespace OpenRA
 		IShader CreateShader(string name);
 
 		Size WindowSize { get; }
+		float WindowScale { get; }
+		event Action<float, float> OnWindowScaleChanged;
 
 		void Clear();
 		void Present();

--- a/OpenRA.Game/Primitives/Cache.cs
+++ b/OpenRA.Game/Primitives/Cache.cs
@@ -39,6 +39,8 @@ namespace OpenRA.Primitives
 		public bool ContainsKey(T key) { return cache.ContainsKey(key); }
 		public bool TryGetValue(T key, out U value) { return cache.TryGetValue(key, out value); }
 		public int Count { get { return cache.Count; } }
+		public void Clear() { cache.Clear(); }
+
 		public ICollection<T> Keys { get { return cache.Keys; } }
 		public ICollection<U> Values { get { return cache.Values; } }
 		public IEnumerator<KeyValuePair<T, U>> GetEnumerator() { return cache.GetEnumerator(); }

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -86,8 +86,15 @@ namespace OpenRA
 					fontSheetBuilder.Dispose();
 				fontSheetBuilder = new SheetBuilder(SheetType.BGRA);
 				Fonts = modData.Manifest.Fonts.ToDictionary(x => x.Key,
-					x => new SpriteFont(x.Value.First, modData.DefaultFileSystem.Open(x.Value.First).ReadAllBytes(), x.Value.Second, Device.WindowScale, fontSheetBuilder)).AsReadOnly();
+					x => new SpriteFont(x.Value.First, modData.DefaultFileSystem.Open(x.Value.First).ReadAllBytes(),
+										x.Value.Second, Device.WindowScale, fontSheetBuilder)).AsReadOnly();
 			}
+
+			Device.OnWindowScaleChanged += (before, after) =>
+			{
+				foreach (var f in Fonts)
+					f.Value.SetScale(after);
+			};
 		}
 
 		public void InitializeDepthBuffer(MapGrid mapGrid)

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -86,7 +86,7 @@ namespace OpenRA
 					fontSheetBuilder.Dispose();
 				fontSheetBuilder = new SheetBuilder(SheetType.BGRA);
 				Fonts = modData.Manifest.Fonts.ToDictionary(x => x.Key,
-					x => new SpriteFont(x.Value.First, modData.DefaultFileSystem.Open(x.Value.First).ReadAllBytes(), x.Value.Second, fontSheetBuilder)).AsReadOnly();
+					x => new SpriteFont(x.Value.First, modData.DefaultFileSystem.Open(x.Value.First).ReadAllBytes(), x.Value.Second, Device.WindowScale, fontSheetBuilder)).AsReadOnly();
 			}
 		}
 

--- a/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
@@ -141,6 +141,29 @@ namespace OpenRA.Platforms.Default
 			VerifyThreadAffinity();
 			try
 			{
+				// Pixel double the cursor on non-OSX if the window scale is large enough
+				// OSX does this for us automatically
+				if (Platform.CurrentPlatform != PlatformType.OSX && WindowScale > 1.5)
+				{
+					var scaledData = new byte[4 * data.Length];
+					for (var y = 0; y < size.Height * 4; y += 4)
+					{
+						for (var x = 0; x < size.Width * 4; x += 4)
+						{
+							var a = 4 * (y * size.Width + x);
+							var b = 4 * ((y + 1) * size.Width + x);
+							for (var i = 0; i < 4; i++)
+							{
+								scaledData[2 * a + i] = scaledData[2 * a + 4 + i] = data[a + i];
+								scaledData[2 * b + i] = scaledData[2 * b + 4 + i] = data[b + i];
+							}
+						}
+					}
+
+					size = new Size(2 * size.Width, 2 * size.Height);
+					data = scaledData;
+				}
+
 				return new SDL2HardwareCursor(size, data, hotspot);
 			}
 			catch (Exception ex)

--- a/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
@@ -88,6 +88,16 @@ namespace OpenRA.Platforms.Default
 					WindowSize = new Size((int)(SurfaceSize.Width / WindowScale), (int)(SurfaceSize.Height / WindowScale));
 				}
 			}
+			else
+			{
+				float scale = 1;
+				var scaleVariable = Environment.GetEnvironmentVariable("OPENRA_DISPLAY_SCALE");
+				if (scaleVariable != null && float.TryParse(scaleVariable, out scale))
+				{
+					WindowScale = scale;
+					WindowSize = new Size((int)(SurfaceSize.Width / WindowScale), (int)(SurfaceSize.Height / WindowScale));
+				}
+			}
 
 			Console.WriteLine("Using window scale {0:F2}", WindowScale);
 

--- a/OpenRA.Platforms.Default/Sdl2Input.cs
+++ b/OpenRA.Platforms.Default/Sdl2Input.cs
@@ -40,6 +40,16 @@ namespace OpenRA.Platforms.Default
 				 | ((raw & (int)SDL.SDL_Keymod.KMOD_SHIFT) != 0 ? Modifiers.Shift : 0);
 		}
 
+		int2 EventPosition(Sdl2GraphicsDevice device, int x, int y)
+		{
+			// On Windows and Linux (X11) events are given in surface coordinates
+			// These must be scaled to our effective window coordinates
+			if (Platform.CurrentPlatform != PlatformType.OSX && device.WindowSize != device.SurfaceSize)
+				return new int2((int)(x / device.WindowScale), (int)(y / device.WindowScale));
+
+			return new int2(x, y);
+		}
+
 		public void PumpInput(Sdl2GraphicsDevice device, IInputHandler inputHandler)
 		{
 			var mods = MakeModifiers((int)SDL.SDL_GetModState());
@@ -88,8 +98,7 @@ namespace OpenRA.Platforms.Default
 							var button = MakeButton(e.button.button);
 							lastButtonBits |= button;
 
-							var pos = new int2(e.button.x, e.button.y);
-
+							var pos = EventPosition(device, e.button.x, e.button.y);
 							inputHandler.OnMouseInput(new MouseInput(
 								MouseInputEvent.Down, button, scrollDelta, pos, mods,
 								MultiTapDetection.DetectFromMouse(e.button.button, pos)));
@@ -108,7 +117,7 @@ namespace OpenRA.Platforms.Default
 							var button = MakeButton(e.button.button);
 							lastButtonBits &= ~button;
 
-							var pos = new int2(e.button.x, e.button.y);
+							var pos = EventPosition(device, e.button.x, e.button.y);
 							inputHandler.OnMouseInput(new MouseInput(
 								MouseInputEvent.Up, button, scrollDelta, pos, mods,
 								MultiTapDetection.InfoFromMouse(e.button.button)));
@@ -118,9 +127,10 @@ namespace OpenRA.Platforms.Default
 
 					case SDL.SDL_EventType.SDL_MOUSEMOTION:
 						{
+							var pos = EventPosition(device, e.motion.x, e.motion.y);
 							pendingMotion = new MouseInput(
 								MouseInputEvent.Move, lastButtonBits, scrollDelta,
-								new int2(e.motion.x, e.motion.y), mods, 0);
+								pos, mods, 0);
 
 							break;
 						}

--- a/OpenRA.Platforms.Default/Sdl2Input.cs
+++ b/OpenRA.Platforms.Default/Sdl2Input.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Platforms.Default
 				 | ((raw & (int)SDL.SDL_Keymod.KMOD_SHIFT) != 0 ? Modifiers.Shift : 0);
 		}
 
-		public void PumpInput(IInputHandler inputHandler)
+		public void PumpInput(Sdl2GraphicsDevice device, IInputHandler inputHandler)
 		{
 			var mods = MakeModifiers((int)SDL.SDL_GetModState());
 			var scrollDelta = 0;
@@ -66,6 +66,11 @@ namespace OpenRA.Platforms.Default
 
 								case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_FOCUS_GAINED:
 									Game.HasInputFocus = true;
+									break;
+
+								// Triggered when moving between displays with different DPI settings
+								case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_SIZE_CHANGED:
+									device.WindowSizeChanged();
 									break;
 							}
 

--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # OpenRA packaging script for Mac OSX
 
-LAUNCHER_TAG="osx-launcher-20160824"
+LAUNCHER_TAG="osx-launcher-20161223"
 
 if [ $# -ne "3" ]; then
 	echo "Usage: `basename $0` tag files-dir outputdir"

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -130,7 +130,7 @@ if (!(Test-Path "SDL2-CS.dll"))
 {
 	echo "Fetching SDL2-CS from GitHub."
 	$target = Join-Path $pwd.ToString() "SDL2-CS.dll"
-	(New-Object System.Net.WebClient).DownloadFile("https://github.com/OpenRA/SDL2-CS/releases/download/20151227/SDL2-CS.dll", $target)
+	(New-Object System.Net.WebClient).DownloadFile("https://github.com/OpenRA/SDL2-CS/releases/download/20161223/SDL2-CS.dll", $target)
 }
 
 if (!(Test-Path "OpenAL-CS.dll"))

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -100,8 +100,8 @@ fi
 
 if [ ! -f SDL2-CS.dll -o ! -f SDL2-CS.dll.config ]; then
 	echo "Fetching SDL2-CS from GitHub."
-	curl -s -L -O https://github.com/OpenRA/SDL2-CS/releases/download/20151227/SDL2-CS.dll
-	curl -s -L -O https://github.com/OpenRA/SDL2-CS/releases/download/20151227/SDL2-CS.dll.config
+	curl -s -L -O https://github.com/OpenRA/SDL2-CS/releases/download/20161223/SDL2-CS.dll
+	curl -s -L -O https://github.com/OpenRA/SDL2-CS/releases/download/20161223/SDL2-CS.dll.config
 fi
 
 if [ ! -f OpenAL-CS.dll -o ! -f OpenAL-CS.dll.config ]; then


### PR DESCRIPTION
There are three parts to this PR:
* Disabling the OS-provided legacy pixel doubling by adding `SDL_WINDOW_ALLOW_HIGHDPI` to the window creation flags.
* Detecting DPI changes when switching between high and low resolution displays and recalculating scissor bounds and font glyphs.  This depends on SDL 2.0.4, which I have packaged in updated versions of [OpenRALauncherOSX](https://github.com/OpenRA/OpenRALauncherOSX/releases/tag/osx-launcher-20161223) and [SDL2-CS](https://github.com/OpenRA/SDL2-CS/releases/tag/20161223).  A future PR could, in principle, add additional hooks to switch between `@1x` and `@2x` UI artwork too.
* Adding a scale factor to decouple font glyph sizes from system point sizes.

The main goal here is the massive improvement in text quality, but this also gives us full detail rendering of the half-zoom state in the editor and takes some baby steps towards #10382.

~~Enabling HiDPI under windows requires P/Invoking a native Win32 API (not sure why SDL2 doesn't do this), and Linux is a giant clusterfuck, so this PR is strictly limited to OSX.~~

Before (click for full resolution):
<img width="1680" src="https://cloud.githubusercontent.com/assets/167819/21463565/f2938e22-c962-11e6-99cb-54b019c06a30.png">

After (click for full resolution):
<img width="1680" src="https://cloud.githubusercontent.com/assets/167819/21463557/d9a8e77c-c962-11e6-8980-42cf5443c320.png">
