### PR TITLE
Work around Open.Nat installation by nuget failing randomly

### DIFF
--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -86,6 +86,7 @@ fi
 if [ ! -f Open.Nat.dll ]; then
 	echo "Fetching Open.Nat from NuGet"
 	get Open.Nat 2.1.0
+	if [ -d ./Open.NAT ]; then mv Open.NAT Open.Nat; fi
 	cp ./Open.Nat/lib/net45/Open.Nat.dll .
 	rm -rf Open.Nat
 fi


### PR DESCRIPTION
Let's be liberal and just accept both variants. I hope this will finally resolve this for good.

Fixes #12504.