### PR TITLE
Add an OpenSequence to the ParaBombs in Survival02

### DIFF
--- a/mods/ra/maps/survival02/weapons.yaml
+++ b/mods/ra/maps/survival02/weapons.yaml
@@ -4,7 +4,7 @@ ParaBomb:
 	Report: chute1.aud
 	Projectile: GravityBomb
 		Image: BOMBLET
-		-OpenSequence:
+		OpenSequence: idle
 	Warhead@1Dam: SpreadDamage
 		Spread: 150
 		Damage: 3500


### PR DESCRIPTION
Fixes #12362. Hopefully once and for all, this was a constant annoyance as it broke every second release because something changed the way yaml merging works. We could also remove the entire custom image instead (which might look even better).

Note that this only hides a yaml merger bug, but as stated above, I'd like to just get rid of this one special case (as this is iirc already the third PR with a fix for that problem).