### PR TITLE
Slim down D2k weapon yamls

### DIFF
--- a/mods/d2k/weapons/debris.yaml
+++ b/mods/d2k/weapons/debris.yaml
@@ -31,20 +31,13 @@ Debris:
 		ImpactSounds: EXPLLG5.WAV
 
 Debris2:
-	ReloadDelay: 60
-	Range: 2c768
+	Inherits: Debris
 	Projectile: Bullet
-		Speed: 32, 96
-		Blockable: false
-		LaunchAngle: 30, 90
-		Inaccuracy: 1c256
 		Image: shrapnel2
 		TrailImage: bazooka_trail
 		TrailPalette: effect75alpha
 		TrailInterval: 2
 	Warhead@1Dam: SpreadDamage
-		Spread: 320
-		Falloff: 100, 60, 30, 15, 0
 		Damage: 250
 		Versus:
 			none: 90
@@ -58,79 +51,24 @@ Debris2:
 			cy: 20
 			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
-	Warhead@2Smu: LeaveSmudge
-		SmudgeType: SandCrater
-		InvalidTargets: Vehicle, Structure
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion
 		ImpactSounds: EXPLLG5.WAV
 
 Debris3:
-	ReloadDelay: 60
-	Range: 2c768
+	Inherits: Debris2
 	Projectile: Bullet
-		Speed: 32, 96
-		Blockable: false
-		LaunchAngle: 30, 90
-		Inaccuracy: 1c256
 		Image: shrapnel3
 		TrailImage: large_trail
-		TrailPalette: effect75alpha
 		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
-		Spread: 320
-		Falloff: 100, 60, 30, 15, 0
 		Damage: 150
-		Versus:
-			none: 90
-			wall: 5
-			building: 65
-			wood: 50
-			light: 40
-			heavy: 30
-			concrete: 100
-			invulnerable: 0
-			cy: 20
-			harvester: 25
-		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
-	Warhead@2Smu: LeaveSmudge
-		SmudgeType: SandCrater
-		InvalidTargets: Vehicle, Structure
-	Warhead@3Eff: CreateEffect
-		Explosions: med_explosion
-		ImpactSounds: EXPLLG5.WAV
 
 Debris4:
-	ReloadDelay: 60
-	Range: 2c768
+	Inherits: Debris2
 	Projectile: Bullet
-		Speed: 32, 96
-		Blockable: false
-		LaunchAngle: 30, 90
-		Inaccuracy: 1c256
 		Image: shrapnel4
 		TrailImage: large_trail
-		TrailPalette: effect75alpha
 		TrailInterval: 1
-	Warhead@1Dam: SpreadDamage
-		Spread: 320
-		Falloff: 100, 60, 30, 15, 0
-		Damage: 250
-		Versus:
-			none: 90
-			wall: 5
-			building: 65
-			wood: 50
-			light: 40
-			heavy: 30
-			concrete: 100
-			invulnerable: 0
-			cy: 20
-			harvester: 25
-		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
-	Warhead@2Smu: LeaveSmudge
-		SmudgeType: SandCrater
-		InvalidTargets: Vehicle, Structure
 	Warhead@3Eff: CreateEffect
 		Explosions: large_explosion
-		ImpactSounds: EXPLLG5.WAV

--- a/mods/d2k/weapons/largeguns.yaml
+++ b/mods/d2k/weapons/largeguns.yaml
@@ -36,8 +36,6 @@
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Damage: 290
-	Warhead@3Eff: CreateEffect
-		ImpactSounds: EXPLSML4.WAV
 
 80mm_A:
 	Inherits: ^Cannon

--- a/mods/d2k/weapons/largeguns.yaml
+++ b/mods/d2k/weapons/largeguns.yaml
@@ -1,35 +1,4 @@
-110mm_Gun:
-	ReloadDelay: 35
-	Range: 5c0
-	Report: TURRET1.WAV
-	Projectile: Bullet
-		Speed: 875
-		Blockable: false
-		Shadow: no
-		Inaccuracy: 380
-		Image: 120mm
-	Warhead@1Dam: SpreadDamage
-		Spread: 256
-		Falloff: 100, 50, 25, 0
-		Damage: 290
-		Versus:
-			none: 20
-			wall: 50
-			building: 50
-			wood: 60
-			heavy: 75
-			invulnerable: 0
-			cy: 20
-			harvester: 50
-		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
-	Warhead@2Smu: LeaveSmudge
-		SmudgeType: SandCrater, RockCrater
-		InvalidTargets: Vehicle, Structure
-	Warhead@3Eff: CreateEffect
-		Explosions: small_napalm
-		ImpactSounds: EXPLSML4.WAV
-
-80mm_A:
+^Cannon:
 	ReloadDelay: 50
 	Range: 4c0
 	Report: MEDTANK1.WAV
@@ -57,41 +26,57 @@
 	Warhead@3Eff: CreateEffect
 		Explosions: small_napalm
 
+110mm_Gun:
+	Inherits: ^Cannon
+	ReloadDelay: 35
+	Range: 5c0
+	Report: TURRET1.WAV
+	Projectile: Bullet
+		Speed: 875
+		Blockable: false
+	Warhead@1Dam: SpreadDamage
+		Damage: 290
+	Warhead@3Eff: CreateEffect
+		ImpactSounds: EXPLSML4.WAV
+
+80mm_A:
+	Inherits: ^Cannon
+
 80mm_H:
-	Inherits: 80mm_A
+	Inherits: ^Cannon
 	ReloadDelay: 55
 
 80mm_O:
-	Inherits: 80mm_A
+	Inherits: ^Cannon
 	ReloadDelay: 45
 
 DevBullet:
+	Inherits: ^Cannon
 	ReloadDelay: 75
-	Range: 4c0
 	Report: TANKHVY1.WAV
 	Projectile: Bullet
 		Speed: 281
 		Blockable: true
+		Inaccuracy: 0
 		Image: doubleblastbullet
 	Warhead@1Dam: SpreadDamage
 		Spread: 384
-		Falloff: 100, 50, 25, 0
 		Damage: 650
 		Versus:
 			none: 50
+			wall: 100
 			building: 75
 			wood: 60
+			heavy: 100
 			invulnerable: 0
 			cy: 40
-		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
-	Warhead@2Smu: LeaveSmudge
-		SmudgeType: SandCrater, RockCrater
-		InvalidTargets: Vehicle, Structure
+			harvester: 100
 	Warhead@3Eff: CreateEffect
 		Explosions: shockwave
 		ImpactSounds: EXPLMD1.WAV
 
 155mm:
+	Inherits: ^Cannon
 	ReloadDelay: 80
 	Range: 5c512
 	Report: MORTAR1.WAV
@@ -109,6 +94,8 @@ DevBullet:
 		Damage: 450
 		Versus:
 			none: 125
+			wall: 100
+			building: 100
 			wood: 70
 			light: 30
 			heavy: 20
@@ -116,9 +103,6 @@ DevBullet:
 			cy: 20
 			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
-	Warhead@2Smu: LeaveSmudge
-		SmudgeType: SandCrater, RockCrater
-		InvalidTargets: Vehicle, Structure
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion
 		ImpactSounds: EXPLMD2.WAV

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -1,16 +1,15 @@
-Bazooka:
+^Rocket:
 	ReloadDelay: 40
 	Range: 3c0
 	Report: ROCKET1.WAV
-	Projectile: Missile
+	Projectile: Bullet
+		Blockable: false
 		Speed: 281
 		Inaccuracy: 256
 		Image: RPG
-		HorizontalRateOfTurn: 1
 		TrailImage: bazooka_trail2
 		TrailPalette: effect75alpha
 		TrailInterval: 1
-		RangeLimit: 3c614
 	Warhead@1Dam: SpreadDamage
 		Spread: 192
 		Falloff: 100, 50, 25, 0
@@ -21,6 +20,7 @@ Bazooka:
 			building: 40
 			wood: 45
 			light: 70
+			heavy : 100
 			invulnerable: 0
 			cy: 20
 			harvester: 50
@@ -32,52 +32,14 @@ Bazooka:
 		Explosions: tiny_explosion
 		ImpactSounds: EXPLSML1.WAV
 
-Rocket:
-	ReloadDelay: 30
-	Range: 3c512
-	Report: ROCKET1.WAV
-	Projectile: Missile
-		Inaccuracy: 256
-		Image: RPG
-		HorizontalRateOfTurn: 0
-		TrailImage: bazooka_trail2
-		TrailPalette: effect75alpha
-		TrailInterval: 1
-		Speed: 343
-		RangeLimit: 4c204
-	Warhead@1Dam: SpreadDamage
-		Spread: 160
-		Falloff: 100, 50, 25, 0
-		Damage: 250
-		Versus:
-			none: 25
-			building: 50
-			wood: 65
-			heavy: 50
-			invulnerable: 0
-			cy: 20
-			harvester: 50
-		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
-	Warhead@2Smu: LeaveSmudge
-		SmudgeType: SandCrater, RockCrater
-		InvalidTargets: Vehicle, Structure
-	Warhead@3Eff: CreateEffect
-		Explosions: rocket_explosion
-		ExplosionPalette: effect75alpha
-		ImpactSounds: EXPLSML1.WAV
-
-TowerMissile:
+^Missile:
+	Inherits: ^Rocket
 	ReloadDelay: 60
-	Burst: 2
-	BurstDelay: 60
 	Range: 5c512
-	MinRange: 1c0
-	Report: ROCKET1.WAV
-	ValidTargets: Ground, Air
+	MinRange: 0c512
 	Projectile: Missile
-		Blockable: false
 		Shadow: true
-		HorizontalRateOfTurn: 1
+		HorizontalRateOfTurn: 3
 		RangeLimit: 6c614
 		Inaccuracy: 384
 		CruiseAltitude: 1c0
@@ -85,94 +47,89 @@ TowerMissile:
 		VerticalRateOfTurn: 10
 		Image: MISSILE2
 		TrailImage: large_trail
-		TrailInterval: 1
 		Speed: 320
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
-		Falloff: 100, 50, 25, 0
 		Damage: 480
-		ValidTargets: Ground, Air
 		Versus:
 			none: 15
 			wall: 75
 			building: 60
 			wood: 65
 			light: 90
+			heavy: 100
 			invulnerable: 0
 			cy: 30
 			harvester: 50
-		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
-	Warhead@2Smu: LeaveSmudge
-		SmudgeType: SandCrater, RockCrater
-		InvalidTargets: Vehicle, Structure
 	Warhead@3Eff: CreateEffect
 		Explosions: small_explosion
-		ImpactSounds: EXPLSML1.WAV
+
+Bazooka:
+	Inherits: ^Rocket
+
+Rocket:
+	Inherits: ^Rocket
+	ReloadDelay: 30
+	Range: 3c512
+	Projectile: Bullet
+		Speed: 343
+	Warhead@1Dam: SpreadDamage
+		Spread: 160
+		Damage: 250
+		Versus:
+			none: 25
+			wall: 100
+			building: 50
+			wood: 65
+			light: 100
+			heavy: 50
+			invulnerable: 0
+			cy: 20
+			harvester: 50
+	Warhead@3Eff: CreateEffect
+		Explosions: rocket_explosion
+		ExplosionPalette: effect75alpha
+
+TowerMissile:
+	Inherits: ^Missile
+	ReloadDelay: 60
+	Burst: 2
+	BurstDelay: 60
+	ValidTargets: Ground, Air
+	Projectile: Missile
+		HorizontalRateOfTurn: 1
+	Warhead@1Dam: SpreadDamage
+		ValidTargets: Ground, Air
+		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 
 mtank_pri:
+	Inherits: ^Missile
 	ReloadDelay: 115
 	Burst: 2
 	BurstDelay: 115
 	Range: 6c0
-	Report: ROCKET1.WAV
 	ValidTargets: Ground, Air
 	Projectile: Missile
 		Speed: 281
-		RangeLimit: 7c204
-		HorizontalRateOfTurn: 3
-		Blockable: false
-		Shadow: true
-		CruiseAltitude: 1c0
-		MinimumLaunchAngle: 64
-		VerticalRateOfTurn: 10
 		Inaccuracy: 96
-		Image: MISSILE2
-		TrailImage: large_trail
-		TrailInterval: 1
+		RangeLimit: 7c204
 	Warhead@1Dam: SpreadDamage
-		Spread: 256
-		Falloff: 100, 50, 25, 0
 		Damage: 600
 		ValidTargets: Ground, Air
-		Versus:
-			none: 15
-			wall: 75
-			building: 60
-			wood: 65
-			light: 90
-			invulnerable: 0
-			cy: 30
-			harvester: 50
-		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
-	Warhead@2Smu: LeaveSmudge
-		SmudgeType: SandCrater, RockCrater
-		InvalidTargets: Vehicle, Structure
-	Warhead@3Eff: CreateEffect
-		Explosions: small_explosion
-		ImpactSounds: EXPLSML1.WAV
 
 DeviatorMissile:
+	Inherits: ^Missile
 	ReloadDelay: 160
 	Range: 5c0
 	Report: MISSLE1.WAV
 	Projectile: Missile
 		Speed: 281
 		RangeLimit: 6c0
-		HorizontalRateOfTurn: 3
-		Blockable: false
-		Shadow: true
-		Inaccuracy: 384
-		CruiseAltitude: 1c0
-		MinimumLaunchAngle: 64
-		VerticalRateOfTurn: 10
 		Image: MISSILE
 		TrailImage: deviator_trail
 		TrailPalette: deviatorgas
 		TrailUsePlayerPalette: true
-		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
-		Spread: 256
-		Falloff: 100, 50, 25, 0
 		Damage: 500
 		Versus:
 			none: 20
@@ -184,12 +141,11 @@ DeviatorMissile:
 			invulnerable: 0
 			cy: 10
 			harvester: 20
-		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
+	-Warhead@2Smu: LeaveSmudge
 	Warhead@3Eff: CreateEffect
 		Explosions: deviator
 		ExplosionPalette: deviatorgas
 		UsePlayerPalette: true
-		ImpactSounds: EXPLSML1.WAV
 	Warhead@4OwnerChange: ChangeOwner
 		Range: 512
 		Duration: 375

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -130,25 +130,12 @@ Atomic:
 		ImpactSounds: EXPLLG2.WAV
 
 CrateNuke:
+	Inherits: Atomic
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
 		Damage: 500
-		Versus:
-			none: 90
-			wall: 50
-			building: 75
-			wood: 60
-			light: 60
-			heavy: 60
-			invulnerable: 0
-			cy: 25
-			harvester: 60
 		AffectsParent: true
-		DamageTypes: Prone50Percent, TriggerProne, SoundDeath
-	Warhead@2Eff: CreateEffect
-		Explosions: nuke
-		ImpactSounds: EXPLLG2.WAV
 
 CrateExplosion:
 	Warhead@1Dam: SpreadDamage

--- a/mods/d2k/weapons/smallguns.yaml
+++ b/mods/d2k/weapons/smallguns.yaml
@@ -1,4 +1,4 @@
-LMG:
+^MG:
 	ReloadDelay: 30
 	Range: 2c512
 	Report: MGUN2.WAV
@@ -21,143 +21,61 @@ LMG:
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
 
+LMG:
+	Inherits: ^MG
+
 Fremen_S:
+	Inherits: ^MG
 	ReloadDelay: 40
-	Range: 2c512
 	Report: FREMODD1.WAV
-	Projectile: Bullet
-		Speed: 1c256
-	Warhead@1Dam: SpreadDamage
-		Spread: 128
-		Falloff: 100, 50, 25, 0
-		Damage: 125
-		Versus:
-			wall: 10
-			building: 25
-			wood: 75
-			light: 40
-			heavy: 20
-			invulnerable: 0
-			cy: 20
-			harvester: 25
-		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: small_explosion
 		ImpactSounds: EXPLSML2.WAV
 
 M_LMG:
+	Inherits: ^MG
 	ReloadDelay: 40
-	Range: 2c512
-	Report: MGUN2.WAV
-	Projectile: Bullet
-		Speed: 1c256
-	Warhead@1Dam: SpreadDamage
-		Spread: 128
-		Falloff: 100, 50, 25, 0
-		Damage: 125
-		Versus:
-			wall: 10
-			building: 25
-			wood: 75
-			light: 40
-			heavy: 20
-			invulnerable: 0
-			cy: 20
-			harvester: 25
-		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
-	Warhead@2Eff: CreateEffect
-		Explosions: piffs
 
 M_HMG:
+	Inherits: ^MG
 	ReloadDelay: 40
 	Range: 3c512
 	Report: 20MMGUN1.WAV
-	Projectile: Bullet
-		Speed: 1c256
 	Warhead@1Dam: SpreadDamage
 		Spread: 192
-		Falloff: 100, 50, 25, 0
 		Damage: 250
 		Versus:
 			none: 25
+			wall: 100
 			building: 50
 			wood: 65
+			light: 100
 			heavy: 50
 			invulnerable: 0
 			cy: 20
 			harvester: 50
-		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
-	Warhead@2Eff: CreateEffect
-		Explosions: piffs
 
 Fremen_L:
-	ReloadDelay: 40
-	Delay: 5
-	Range: 3c512
+	Inherits: M_HMG
 	Report: BAZOOK2.WAV
-	Projectile: Bullet
-		Speed: 1c256
 	Warhead@1Dam: SpreadDamage
-		Spread: 192
-		Falloff: 100, 50, 25, 0
-		Damage: 250
-		Versus:
-			none: 25
-			building: 50
-			wood: 65
-			heavy: 50
-			invulnerable: 0
-			cy: 20
-			harvester: 50
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: small_explosion
 
 HMG:
+	Inherits: ^MG
 	ReloadDelay: 20
 	Range: 3c0
 	Report: 20MMGUN1.WAV
-	Projectile: Bullet
-		Speed: 1c256
 	Warhead@1Dam: SpreadDamage
 		Spread: 160
 		Falloff: 100, 60, 30, 0
 		Damage: 180
-		Versus:
-			wall: 10
-			building: 25
-			wood: 75
-			light: 40
-			heavy: 20
-			invulnerable: 0
-			cy: 20
-			harvester: 25
-		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
-	Warhead@2Eff: CreateEffect
-		Explosions: piffs
 
 HMGo:
+	Inherits: HMG
 	ReloadDelay: 18
-	Range: 3c0
-	Report: 20MMGUN1.WAV
-	Projectile: Bullet
-		Speed: 1c256
-	Warhead@1Dam: SpreadDamage
-		Spread: 160
-		Falloff: 100, 60, 30, 0
-		Damage: 180
-		Versus:
-			wall: 10
-			building: 25
-			wood: 75
-			light: 40
-			heavy: 20
-			invulnerable: 0
-			cy: 20
-			harvester: 25
-		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
-	Warhead@2Eff: CreateEffect
-		Explosions: piffs
 
 HMG_muzzle:
 	ReloadDelay: 16


### PR DESCRIPTION
This downsizes the weapon yaml files and makes it a bit easier to apply wider-scale changes like #12513 later.

With regard to missile commit: `^Rocket` = small + unguided, `^Missile` = larger + guided.