### PR TITLE
Debian packaging lintian clean

### DIFF
--- a/packaging/linux/deb/DEBIAN/control
+++ b/packaging/linux/deb/DEBIAN/control
@@ -7,12 +7,12 @@ Depends: libopenal1, mono-runtime (>= 3.2), libmono-system-core4.0-cil, libmono-
 Section: games
 Priority: extra
 Homepage: http://www.openra.net/
-Description: A multiplayer re-envisioning of early RTS games by Westwood Studios
- .
+Description: Multiplayer re-envisioning of early RTS games by Westwood Studios
  OpenRA is a Libre/Free Real Time Strategy game engine supporting early
  Westwood games like Command & Conquer and Command & Conquer: Red Alert.
  The engine is designed from the ground up to be extremely moddable and
  natively supports user-created maps and mods.
+ .
  Support can be obtained from our IRC channel (#openra on irc.freenode.net),
  our forum (http://www.sleipnirstuff.com/forum/viewforum.php?f=80), and our
  bug tracker (http://bugs.openra.net).

--- a/packaging/linux/deb/buildpackage.sh
+++ b/packaging/linux/deb/buildpackage.sh
@@ -31,6 +31,10 @@ sed "s|/usr/bin|/usr/games|g" "${DEB_BUILD_ROOT}/usr/games/openra" > temp
 mv -f temp "${DEB_BUILD_ROOT}/usr/games/openra"
 chmod 0755 "${DEB_BUILD_ROOT}/usr/games/openra"*
 
+# Link and compress the man pages
+gzip -9n "${DEB_BUILD_ROOT}/usr/share/man/man6/openra.6"
+ln -s openra.6.gz "${DEB_BUILD_ROOT}/usr/share/man/man6/openra-server.6.gz"
+
 # Put the copyright and changelog in /usr/share/doc/openra/
 mkdir -p "${DEB_BUILD_ROOT}/${DOCDIR}"
 cp copyright "${DEB_BUILD_ROOT}/${DOCDIR}/copyright"

--- a/packaging/linux/deb/buildpackage.sh
+++ b/packaging/linux/deb/buildpackage.sh
@@ -61,7 +61,7 @@ sed "s/{VERSION}/$VERSION/" DEBIAN/control | sed "s/{SIZE}/$PACKAGE_SIZE/" > "${
 pushd "${DEB_BUILD_ROOT}" >/dev/null
 
 # Calculate md5sums and clean up the ./usr/ part of them
-find . -type f -not -path "./DEBIAN/*" -print0 | xargs -0 -n1 md5sum | sed 's|\./usr/|/usr/|' > DEBIAN/md5sums
+find . -type f -not -path "./DEBIAN/*" -print0 | xargs -0 -n1 md5sum | sed 's|\./usr/|usr/|' > DEBIAN/md5sums
 chmod 0644 DEBIAN/md5sums
 
 # Replace any dashes in the version string with periods

--- a/packaging/linux/deb/buildpackage.sh
+++ b/packaging/linux/deb/buildpackage.sh
@@ -22,12 +22,14 @@ mkdir "${DEB_BUILD_ROOT}"
 cp -R DEBIAN "${DEB_BUILD_ROOT}"
 cp -R "${LINUX_BUILD_ROOT}/usr" "${DEB_BUILD_ROOT}"
 cp -R Eluant.dll.config "${DEB_BUILD_ROOT}/${LIBDIR}/"
+chmod 0644 "${DEB_BUILD_ROOT}/${LIBDIR}/"*.dll
+chmod 0644 "${DEB_BUILD_ROOT}/${LIBDIR}/"*/**/*.dll
 
 # Binaries go in /usr/games
 mv "${DEB_BUILD_ROOT}/usr/bin/" "${DEB_BUILD_ROOT}/usr/games/"
 sed "s|/usr/bin|/usr/games|g" "${DEB_BUILD_ROOT}/usr/games/openra" > temp
 mv -f temp "${DEB_BUILD_ROOT}/usr/games/openra"
-chmod +x "${DEB_BUILD_ROOT}/usr/games/openra"
+chmod 0755 "${DEB_BUILD_ROOT}/usr/games/openra"*
 
 # Put the copyright and changelog in /usr/share/doc/openra/
 mkdir -p "${DEB_BUILD_ROOT}/${DOCDIR}"

--- a/packaging/linux/deb/buildpackage.sh
+++ b/packaging/linux/deb/buildpackage.sh
@@ -43,8 +43,8 @@ gzip -9 "${DEB_BUILD_ROOT}/${DOCDIR}/AUTHORS"
 DATE=`date -R`
 
 echo -e "openra (${VERSION}) unstable; urgency=low\n" > "${DEB_BUILD_ROOT}/${DOCDIR}/changelog"
-cat "../../../Changelog.md" >> "${DEB_BUILD_ROOT}/${DOCDIR}/changelog"
-echo -e "\n\n-- Paul Chote <paul@chote.net> ${DATE}" >> "${DEB_BUILD_ROOT}/${DOCDIR}/changelog"
+echo -e "  * New upstream release: $TAG" >> "${DEB_BUILD_ROOT}/${DOCDIR}/changelog"
+echo -e "\n -- Paul Chote <paul@chote.net>  ${DATE}" >> "${DEB_BUILD_ROOT}/${DOCDIR}/changelog"
 gzip -9 "${DEB_BUILD_ROOT}/${DOCDIR}/changelog"
 rm "${DEB_BUILD_ROOT}/${LIBDIR}/COPYING"
 

--- a/packaging/linux/deb/buildpackage.sh
+++ b/packaging/linux/deb/buildpackage.sh
@@ -52,6 +52,10 @@ echo -e "\n -- Paul Chote <paul@chote.net>  ${DATE}" >> "${DEB_BUILD_ROOT}/${DOC
 gzip -9 "${DEB_BUILD_ROOT}/${DOCDIR}/changelog"
 rm "${DEB_BUILD_ROOT}/${LIBDIR}/COPYING"
 
+# Nothing should have group writable permissions
+# (These might occur due to difference in umask values.)
+chmod -R g-w "${DEB_BUILD_ROOT}"
+
 # Create the control file
 PACKAGE_SIZE=`du --apparent-size -c "${DEB_BUILD_ROOT}/usr" | grep "total" | awk '{print $1}'`
 sed "s/{VERSION}/$VERSION/" DEBIAN/control | sed "s/{SIZE}/$PACKAGE_SIZE/" > "${DEB_BUILD_ROOT}/DEBIAN/control"

--- a/packaging/linux/deb/buildpackage.sh
+++ b/packaging/linux/deb/buildpackage.sh
@@ -32,9 +32,8 @@ sed "s|/usr/bin|/usr/games|g" "${DEB_BUILD_ROOT}/usr/games/openra" > temp
 mv -f temp "${DEB_BUILD_ROOT}/usr/games/openra"
 chmod 0755 "${DEB_BUILD_ROOT}/usr/games/openra"*
 
-# Link and compress the man pages
+# Compress the man page
 gzip -9n "${DEB_BUILD_ROOT}/usr/share/man/man6/openra.6"
-ln -s openra.6.gz "${DEB_BUILD_ROOT}/usr/share/man/man6/openra-server.6.gz"
 
 # Put the copyright and changelog in /usr/share/doc/openra/
 mkdir -p "${DEB_BUILD_ROOT}/${DOCDIR}"

--- a/packaging/linux/deb/buildpackage.sh
+++ b/packaging/linux/deb/buildpackage.sh
@@ -6,6 +6,7 @@ DEB_BUILD_ROOT=./root
 
 LIBDIR=/usr/lib/openra
 DOCDIR=/usr/share/doc/openra
+LINTIANORDIR=/usr/share/lintian/overrides
 
 E_BADARGS=85
 if [ $# -ne "3" ]
@@ -41,6 +42,10 @@ cp copyright "${DEB_BUILD_ROOT}/${DOCDIR}/copyright"
 cp "${DEB_BUILD_ROOT}/${LIBDIR}/AUTHORS" "${DEB_BUILD_ROOT}/${DOCDIR}"
 gzip -9 "${DEB_BUILD_ROOT}/${DOCDIR}/AUTHORS"
 DATE=`date -R`
+
+# Put the lintian overrides in /usr/share/lintian/overrides/
+mkdir -p "${DEB_BUILD_ROOT}/${LINTIANORDIR}"
+cp openra.lintian-overrides "${DEB_BUILD_ROOT}/${LINTIANORDIR}/openra"
 
 echo -e "openra (${VERSION}) unstable; urgency=low\n" > "${DEB_BUILD_ROOT}/${DOCDIR}/changelog"
 echo -e "  * New upstream release: $TAG" >> "${DEB_BUILD_ROOT}/${DOCDIR}/changelog"

--- a/packaging/linux/deb/openra.lintian-overrides
+++ b/packaging/linux/deb/openra.lintian-overrides
@@ -1,3 +1,4 @@
+# We don't want to have need to add an extra dependency and create symlinks to
+# be able to access the FreeSans font.
 openra: duplicate-font-file usr/lib/openra/mods/common/FreeSans.ttf also in fonts-freefont-ttf
 openra: duplicate-font-file usr/lib/openra/mods/common/FreeSansBold.ttf also in fonts-freefont-ttf
-openra: binary-without-manpage usr/games/openra-server

--- a/packaging/linux/deb/openra.lintian-overrides
+++ b/packaging/linux/deb/openra.lintian-overrides
@@ -1,0 +1,2 @@
+openra: duplicate-font-file usr/lib/openra/mods/common/FreeSans.ttf also in fonts-freefont-ttf
+openra: duplicate-font-file usr/lib/openra/mods/common/FreeSansBold.ttf also in fonts-freefont-ttf

--- a/packaging/linux/deb/openra.lintian-overrides
+++ b/packaging/linux/deb/openra.lintian-overrides
@@ -1,2 +1,3 @@
 openra: duplicate-font-file usr/lib/openra/mods/common/FreeSans.ttf also in fonts-freefont-ttf
 openra: duplicate-font-file usr/lib/openra/mods/common/FreeSansBold.ttf also in fonts-freefont-ttf
+openra: binary-without-manpage usr/games/openra-server


### PR DESCRIPTION
This PR patches up the Debian/Ubuntu packaging as to be valid with respect to the latest Debian packaging standards by means of manual inspection/review (as a Debian developer) and the lintian tool.