### PR TITLE
Reduce "nearEnough" leniency for regular move orders

### DIFF
--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -505,7 +505,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			TicksBeforePathing = AverageTicksBeforePathing + self.World.SharedRandom.Next(-SpreadTicksBeforePathing, SpreadTicksBeforePathing);
 
-			self.QueueActivity(new Move(self, currentLocation, WDist.FromCells(8)));
+			self.QueueActivity(new Move(self, currentLocation, WDist.FromCells(4)));
 
 			self.SetTargetLine(Target.FromCell(self.World, currentLocation), Color.Green);
 		}


### PR DESCRIPTION
Units give up if their path is blocked while they're `nearEnough`. 
8 cells is far more lenient than necessary though, halving that to 4 should improve behaviour enough until we have a better fix for this.

This should at least reduce #12395 and #5968 quite a bit.

Some related discussion can be found in #11440.