### PR TITLE
Fix air explosions leaving smudges

### DIFF
--- a/OpenRA.Mods.Common/Warheads/LeaveSmudgeWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/LeaveSmudgeWarhead.cs
@@ -25,10 +25,19 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("Type of smudge to apply to terrain.")]
 		public readonly HashSet<string> SmudgeType = new HashSet<string>();
 
+		[Desc("How close to ground must the impact happen to spawn smudges.")]
+		public readonly WDist AirThreshold = new WDist(128);
+
 		public override void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers)
 		{
 			var world = firedBy.World;
-			var targetTile = world.Map.CellContaining(target.CenterPosition);
+			var pos = target.CenterPosition;
+			var dat = world.Map.DistanceAboveTerrain(pos);
+
+			if (dat > AirThreshold)
+				return;
+
+			var targetTile = world.Map.CellContaining(pos);
 			var smudgeLayers = world.WorldActor.TraitsImplementing<SmudgeLayer>().ToDictionary(x => x.Info.Type);
 
 			var minRange = (Size.Length > 1 && Size[1] > 0) ? Size[1] : 0;


### PR DESCRIPTION
`LeaveSmudgeWarhead` now only spawns smudges if the explosion happened at or below a certain (customizable) altitude.

This might actually even save a tiny bit of performance when weapons that are both AA and AG shoot at air targets, as the warhead won't even scan tiles when exploding above the threshold.