### PR TITLE
Tidied up d2k building build menu icon order

### DIFF
--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -27,6 +27,7 @@ concretea:
 	Valued:
 		Cost: 20
 	Buildable:
+		BuildPaletteOrder: 10
 		BuildDuration: 54
 		BuildDurationModifier: 40
 
@@ -38,6 +39,7 @@ concreteb:
 	Valued:
 		Cost: 50
 	Buildable:
+		BuildPaletteOrder: 40
 		Prerequisites: construction_yard, upgrade.conyard
 		BuildDuration: 81
 		BuildDurationModifier: 40
@@ -112,7 +114,7 @@ wind_trap:
 	Buildable:
 		Queue: Building
 		Prerequisites: construction_yard
-		BuildPaletteOrder: 10
+		BuildPaletteOrder: 20
 		BuildDuration: 180
 		BuildDurationModifier: 40
 		Description: Provides power for other structures
@@ -151,7 +153,7 @@ barracks:
 	Buildable:
 		Prerequisites: construction_yard, wind_trap
 		Queue: Building
-		BuildPaletteOrder: 40
+		BuildPaletteOrder: 50
 		BuildDuration: 231
 		BuildDurationModifier: 40
 		Description: Trains infantry
@@ -225,7 +227,7 @@ refinery:
 	Buildable:
 		Prerequisites: construction_yard, wind_trap
 		Queue: Building
-		BuildPaletteOrder: 20
+		BuildPaletteOrder: 30
 		BuildDuration: 540
 		BuildDurationModifier: 40
 		Description: Harvesters unload Spice here for processing
@@ -280,7 +282,7 @@ silo:
 	Buildable:
 		Prerequisites: construction_yard, refinery
 		Queue: Building
-		BuildPaletteOrder: 30
+		BuildPaletteOrder: 120
 		BuildDuration: 135
 		BuildDurationModifier: 40
 		Description: Stores excess harvested Spice
@@ -327,7 +329,7 @@ light_factory:
 	Buildable:
 		Prerequisites: construction_yard, refinery
 		Queue: Building
-		BuildPaletteOrder: 70
+		BuildPaletteOrder: 60
 		BuildDuration: 277
 		BuildDurationModifier: 40
 		Description: Produces light vehicles
@@ -405,7 +407,7 @@ heavy_factory:
 	Buildable:
 		Prerequisites: construction_yard, refinery
 		Queue: Building
-		BuildPaletteOrder: 100
+		BuildPaletteOrder: 90
 		BuildDuration: 648
 		BuildDurationModifier: 40
 		Description: Produces heavy vehicles
@@ -490,7 +492,7 @@ outpost:
 	Buildable:
 		Prerequisites: construction_yard, barracks, ~techlevel.medium
 		Queue: Building
-		BuildPaletteOrder: 50
+		BuildPaletteOrder: 80
 		BuildDuration: 270
 		BuildDurationModifier: 40
 		Description: Provides a radar map of the battlefield\n  Requires power to operate
@@ -532,7 +534,7 @@ starport:
 	Buildable:
 		Prerequisites: construction_yard, heavy_factory, outpost, ~techlevel.high
 		Queue: Building
-		BuildPaletteOrder: 80
+		BuildPaletteOrder: 70
 		BuildDuration: 540
 		BuildDurationModifier: 40
 		Description: Dropzone for quick reinforcements, at a price.\n  Requires power to operate
@@ -603,7 +605,7 @@ wall:
 	Buildable:
 		Queue: Building
 		Prerequisites: construction_yard, barracks
-		BuildPaletteOrder: 60
+		BuildPaletteOrder: 130
 		BuildDuration: 54
 		BuildDurationModifier: 40
 		Description: Stop units and blocks enemy fire.
@@ -655,7 +657,7 @@ medium_gun_turret:
 	Buildable:
 		Queue: Building
 		Prerequisites: construction_yard, barracks
-		BuildPaletteOrder: 90
+		BuildPaletteOrder: 100
 		BuildDuration: 231
 		BuildDurationModifier: 40
 		Description: Defensive structure\n  Strong vs Tanks\n  Weak vs Infantry, Aircraft
@@ -697,7 +699,7 @@ large_gun_turret:
 	Buildable:
 		Queue: Building
 		Prerequisites: construction_yard, outpost, upgrade.conyard, ~techlevel.medium
-		BuildPaletteOrder: 120
+		BuildPaletteOrder: 110
 		BuildDuration: 270
 		BuildDurationModifier: 40
 		Description: Defensive structure\n  Strong vs Infantry, Aircraft\n  Weak vs Tanks\n\n  Requires power to operate
@@ -742,7 +744,7 @@ repair_pad:
 	Buildable:
 		Queue: Building
 		Prerequisites: construction_yard, heavy_factory, upgrade.heavy, ~techlevel.medium
-		BuildPaletteOrder: 130
+		BuildPaletteOrder: 150
 		BuildDuration: 324
 		BuildDurationModifier: 40
 		Description: Repairs vehicles\n Allows construction of MCVs
@@ -789,7 +791,7 @@ high_tech_factory:
 	Buildable:
 		Prerequisites: construction_yard, outpost, ~techlevel.medium
 		Queue: Building
-		BuildPaletteOrder: 110
+		BuildPaletteOrder: 140
 		BuildDuration: 405
 		BuildDurationModifier: 40
 		Description: Unlocks advanced technology
@@ -857,7 +859,7 @@ research_centre:
 	Buildable:
 		Queue: Building
 		Prerequisites: construction_yard, outpost, heavy_factory, upgrade.heavy, ~techlevel.high
-		BuildPaletteOrder: 140
+		BuildPaletteOrder: 160
 		BuildDuration: 270
 		BuildDurationModifier: 40
 		Description: Unlocks experimental tanks
@@ -897,7 +899,7 @@ palace:
 	Buildable:
 		Prerequisites: construction_yard, research_centre, ~techlevel.high
 		Queue: Building
-		BuildPaletteOrder: 150
+		BuildPaletteOrder: 170
 		BuildDuration: 810
 		BuildDurationModifier: 40
 		Description: Unlocks elite infantry

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -15,7 +15,6 @@
 		RemoveInstead: true
 	Buildable:
 		Queue: Building
-		Prerequisites: construction_yard
 		BuildPaletteOrder: 10
 		Description: Provides a strong foundation that prevents\ndamage from the terrain.
 
@@ -40,7 +39,7 @@ concreteb:
 		Cost: 50
 	Buildable:
 		BuildPaletteOrder: 40
-		Prerequisites: construction_yard, upgrade.conyard
+		Prerequisites: upgrade.conyard
 		BuildDuration: 81
 		BuildDurationModifier: 40
 
@@ -113,7 +112,6 @@ wind_trap:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		Prerequisites: construction_yard
 		BuildPaletteOrder: 20
 		BuildDuration: 180
 		BuildDurationModifier: 40
@@ -151,7 +149,7 @@ wind_trap:
 barracks:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: construction_yard, wind_trap
+		Prerequisites: wind_trap
 		Queue: Building
 		BuildPaletteOrder: 50
 		BuildDuration: 231
@@ -225,7 +223,7 @@ barracks:
 refinery:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: construction_yard, wind_trap
+		Prerequisites: wind_trap
 		Queue: Building
 		BuildPaletteOrder: 30
 		BuildDuration: 540
@@ -280,7 +278,7 @@ refinery:
 silo:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: construction_yard, refinery
+		Prerequisites: refinery
 		Queue: Building
 		BuildPaletteOrder: 120
 		BuildDuration: 135
@@ -327,7 +325,7 @@ silo:
 light_factory:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: construction_yard, refinery
+		Prerequisites: refinery
 		Queue: Building
 		BuildPaletteOrder: 60
 		BuildDuration: 277
@@ -405,7 +403,7 @@ light_factory:
 heavy_factory:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: construction_yard, refinery
+		Prerequisites: refinery
 		Queue: Building
 		BuildPaletteOrder: 90
 		BuildDuration: 648
@@ -490,7 +488,7 @@ outpost:
 		PowerdownSound: DisablePower
 	DisabledOverlay:
 	Buildable:
-		Prerequisites: construction_yard, barracks, ~techlevel.medium
+		Prerequisites: barracks, ~techlevel.medium
 		Queue: Building
 		BuildPaletteOrder: 80
 		BuildDuration: 270
@@ -532,7 +530,7 @@ starport:
 	Tooltip:
 		Name: Starport
 	Buildable:
-		Prerequisites: construction_yard, heavy_factory, outpost, ~techlevel.high
+		Prerequisites: heavy_factory, outpost, ~techlevel.high
 		Queue: Building
 		BuildPaletteOrder: 70
 		BuildDuration: 540
@@ -604,7 +602,7 @@ wall:
 	HiddenUnderShroud:
 	Buildable:
 		Queue: Building
-		Prerequisites: construction_yard, barracks
+		Prerequisites: barracks
 		BuildPaletteOrder: 130
 		BuildDuration: 54
 		BuildDurationModifier: 40
@@ -656,7 +654,7 @@ medium_gun_turret:
 	Inherits: ^Defense
 	Buildable:
 		Queue: Building
-		Prerequisites: construction_yard, barracks
+		Prerequisites: barracks
 		BuildPaletteOrder: 100
 		BuildDuration: 231
 		BuildDurationModifier: 40
@@ -698,7 +696,7 @@ large_gun_turret:
 	Inherits: ^Defense
 	Buildable:
 		Queue: Building
-		Prerequisites: construction_yard, outpost, upgrade.conyard, ~techlevel.medium
+		Prerequisites: outpost, upgrade.conyard, ~techlevel.medium
 		BuildPaletteOrder: 110
 		BuildDuration: 270
 		BuildDurationModifier: 40
@@ -743,7 +741,7 @@ repair_pad:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		Prerequisites: construction_yard, heavy_factory, upgrade.heavy, ~techlevel.medium
+		Prerequisites: heavy_factory, upgrade.heavy, ~techlevel.medium
 		BuildPaletteOrder: 150
 		BuildDuration: 324
 		BuildDurationModifier: 40
@@ -789,7 +787,7 @@ repair_pad:
 high_tech_factory:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: construction_yard, outpost, ~techlevel.medium
+		Prerequisites: outpost, ~techlevel.medium
 		Queue: Building
 		BuildPaletteOrder: 140
 		BuildDuration: 405
@@ -858,7 +856,7 @@ research_centre:
 	Inherits: ^Building
 	Buildable:
 		Queue: Building
-		Prerequisites: construction_yard, outpost, heavy_factory, upgrade.heavy, ~techlevel.high
+		Prerequisites: outpost, heavy_factory, upgrade.heavy, ~techlevel.high
 		BuildPaletteOrder: 160
 		BuildDuration: 270
 		BuildDurationModifier: 40
@@ -897,7 +895,7 @@ research_centre:
 palace:
 	Inherits: ^Building
 	Buildable:
-		Prerequisites: construction_yard, research_centre, ~techlevel.high
+		Prerequisites: research_centre, ~techlevel.high
 		Queue: Building
 		BuildPaletteOrder: 170
 		BuildDuration: 810


### PR DESCRIPTION
Supersedes #11856.

It's just #11856 with @CH4Code's suggestions applied, so I'm carrying over my +1 from that PR.

![d2k-menu](https://cloud.githubusercontent.com/assets/2857877/21594292/2675d202-d121-11e6-8959-814224a9527f.png)
