### PR TITLE
TD Balance Changes. NME.

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -292,7 +292,7 @@
 		RequiresCondition: hazmatsuits
 	ActorLostNotification:
 	SpawnActorOnDeath:
-		Probability: 10
+		Probability: 5
 		Actor: vice
 		OwnerType: InternalName
 		InternalOwner: Creeps
@@ -811,7 +811,7 @@
 	Husk:
 		AllowedTerrain: Clear, Rough, Road, Tiberium, BlueTiberium, Beach
 	Burns:
-		Interval: 2
+		Interval: 6
 	Targetable:
 		RequiresForceFire: yes
 		TargetTypes: Ground, Husk

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -144,7 +144,7 @@ E6:
 	Mobile:
 		Speed: 56
 	Health:
-		HP: 25
+		HP: 30
 	Passenger:
 		PipType: Yellow
 	EngineerRepair:
@@ -158,13 +158,15 @@ RMBO:
 	Inherits: ^Soldier
 	Inherits@EXPERIENCE: ^GainsExperience
 	Valued:
-		Cost: 1000
+		Cost: 2000
 	Tooltip:
 		Name: Commando
 	Buildable:
 		BuildPaletteOrder: 50
 		Prerequisites: eye, ~techlevel.high
 		Queue: Infantry.GDI
+		BuildDuration: 2000
+		BuildDurationModifier: 40
 		Description: Elite sniper infantry unit.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles
 	Mobile:
 		Speed: 71

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -8,7 +8,7 @@ FACT:
 		Footprint: xxx xxx
 		Dimensions: 3,2
 	Health:
-		HP: 2000
+		HP: 2100
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -156,7 +156,7 @@ PROC:
 		Footprint: _x_ xxx ===
 		Dimensions: 3,3
 	Health:
-		HP: 900
+		HP: 1000
 	RevealsShroud:
 		Range: 6c0
 	Bib:
@@ -170,18 +170,18 @@ PROC:
 	StoresResources:
 		PipColor: Green
 		PipCount: 10
-		Capacity: 2000
+		Capacity: 700
 	Selectable:
 		Bounds: 72,56,0,12
 	CustomSellValue:
-		Value: 500
+		Value: 0
 	FreeActor:
 		Actor: HARV
 		SpawnOffset: 1,2
 		Facing: 64
 	WithResources:
 	Power:
-		Amount: -50
+		Amount: -40
 	ProvidesPrerequisite@buildingname:
 	SelectionDecorations:
 		VisualBounds: 73,72
@@ -202,7 +202,7 @@ SILO:
 		Dimensions: 2,1
 	-GivesBuildableArea:
 	Health:
-		HP: 400
+		HP: 500
 	RevealsShroud:
 		Range: 4c0
 	Bib:
@@ -214,7 +214,7 @@ SILO:
 	StoresResources:
 		PipCount: 10
 		PipColor: Green
-		Capacity: 2000
+		Capacity: 3000
 	-EmitInfantryOnSell:
 	Power:
 		Amount: -10
@@ -240,7 +240,7 @@ PYLE:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 500
+		HP: 600
 	RevealsShroud:
 		Range: 5c0
 	Bib:
@@ -282,7 +282,7 @@ HAND:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 500
+		HP: 600
 	RevealsShroud:
 		Range: 5c0
 	Bib:
@@ -324,7 +324,7 @@ AFLD:
 		Footprint: xxxx xxxx
 		Dimensions: 4,2
 	Health:
-		HP: 1000
+		HP: 1100
 	RevealsShroud:
 		Range: 7c0
 	Bib:
@@ -346,7 +346,7 @@ AFLD:
 		ReadyAudio:
 	ProductionBar:
 	Power:
-		Amount: -30
+		Amount: -50
 	ProvidesPrerequisite@buildingname:
 
 WEAP:
@@ -370,7 +370,7 @@ WEAP:
 	SelectionDecorations:
 		VisualBounds: 72,64,0,-16
 	Health:
-		HP: 1000
+		HP: 1100
 	RevealsShroud:
 		Range: 4c0
 	Bib:
@@ -391,7 +391,7 @@ WEAP:
 		LowPowerSlowdown: 3
 	ProductionBar:
 	Power:
-		Amount: -30
+		Amount: -50
 	ProvidesPrerequisite@buildingname:
 
 HPAD:
@@ -409,7 +409,7 @@ HPAD:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 500
+		HP: 600
 	RevealsShroud:
 		Range: 5c0
 	Exit@1:
@@ -467,7 +467,7 @@ HQ:
 	WithSpriteBody:
 		PauseAnimationWhenDisabled: true
 	Health:
-		HP: 700
+		HP: 800
 	RevealsShroud:
 		Range: 10c0
 	Bib:
@@ -478,7 +478,7 @@ HQ:
 	AirstrikePower:
 		Prerequisites: ~techlevel.superweapons
 		Icon: airstrike
-		ChargeTime: 210
+		ChargeTime: 240
 		SquadSize: 3
 		QuantizedFacings: 8
 		Description: Air Strike
@@ -495,7 +495,7 @@ HQ:
 		CameraActor: camera
 	SupportPowerChargeBar:
 	Power:
-		Amount: -40
+		Amount: -50
 
 FIX:
 	Inherits: ^BaseBuilding
@@ -516,7 +516,7 @@ FIX:
 	SelectionDecorations:
 		VisualBounds: 72,48
 	Health:
-		HP: 700
+		HP: 800
 	RevealsShroud:
 		Range: 5c0
 	Bib:
@@ -559,7 +559,7 @@ EYE:
 	WithSpriteBody:
 		PauseAnimationWhenDisabled: true
 	Health:
-		HP: 1200
+		HP: 1300
 	RevealsShroud:
 		Range: 10c0
 	Bib:
@@ -571,7 +571,7 @@ EYE:
 		Prerequisites: ~techlevel.superweapons
 		Icon: ioncannon
 		Cursor: ioncannon
-		ChargeTime: 180
+		ChargeTime: 270
 		Description: Ion Cannon
 		LongDesc: Initiate an Ion Cannon strike.\nApplies instant damage to a small area.
 		BeginChargeSpeechNotification: IonCannonCharging
@@ -612,15 +612,18 @@ TMPL:
 		PowerdownSound: DisablePower
 	DisabledOverlay:
 	Health:
-		HP: 2000
+		HP: 2100
 	RevealsShroud:
 		Range: 6c0
 	Bib:
+	RenderDetectionCircle:
+	DetectCloaked:
+		Range: 5c0
 	NukePower:
 		Prerequisites: ~techlevel.superweapons
 		Icon: abomb
 		Cursor: nuke
-		ChargeTime: 300
+		ChargeTime: 360
 		Description: Nuclear Strike
 		LongDesc: Launch a tactical nuclear warhead.\nApplies heavy damage over a large area.
 		EndChargeSpeechNotification: NuclearWeaponAvailable
@@ -654,7 +657,7 @@ GUN:
 		Description: Basic Anti-Tank base defense.\n  Strong vs Tanks, vehicles\n  Weak vs Infantry
 	Building:
 	Health:
-		HP: 400
+		HP: 410
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -703,7 +706,7 @@ SAM:
 	Armor:
 		Type: Heavy
 	RevealsShroud:
-		Range: 8c0
+		Range: 6c0
 	Turreted:
 		TurnSpeed: 10
 		InitialFacing: 0
@@ -762,7 +765,7 @@ OBLI:
 	DetectCloaked:
 		Range: 5c0
 	Power:
-		Amount: -150
+		Amount: -90
 
 GTWR:
 	Inherits: ^Defense
@@ -819,7 +822,7 @@ ATWR:
 	RequiresPower:
 	DisabledOverlay:
 	Health:
-		HP: 600
+		HP: 550
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -8,6 +8,8 @@ MCV:
 		BuildPaletteOrder: 100
 		Prerequisites: anyhq, ~techlevel.medium, fix
 		Queue: Vehicle.GDI, Vehicle.Nod
+		BuildDuration: 3750
+		BuildDurationModifier: 40
 		Description: Deploys into another Construction Yard.\n  Unarmed
 	Selectable:
 		Priority: 4
@@ -46,6 +48,8 @@ HARV:
 		BuildPaletteOrder: 10
 		Prerequisites: proc
 		Queue: Vehicle.GDI, Vehicle.Nod
+		BuildDuration: 1680
+		BuildDurationModifier: 40
 		Description: Collects Tiberium for processing.\n  Unarmed
 	Selectable:
 		Priority: 7
@@ -60,7 +64,7 @@ HARV:
 	Mobile:
 		Speed: 85
 	Health:
-		HP: 600
+		HP: 625
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -79,7 +83,7 @@ APC:
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@CLOAK: ^AcceptsCloakCrate
 	Valued:
-		Cost: 600
+		Cost: 550
 	Tooltip:
 		Name: APC
 	Buildable:
@@ -89,10 +93,10 @@ APC:
 		Description: Armed infantry transport.\nCan attack Aircraft.\n  Strong vs Vehicles\n  Weak vs Infantry
 	Mobile:
 		TurnSpeed: 8
-		Speed: 128
+		Speed: 132
 		RequiresCondition: !notmobile
 	Health:
-		HP: 210
+		HP: 215
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -256,7 +260,7 @@ BIKE:
 			BlueTiberium: 35
 			Beach: 35
 	Health:
-		HP: 120
+		HP: 110
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -311,13 +315,15 @@ LTNK:
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@CLOAK: ^AcceptsCloakCrate
 	Valued:
-		Cost: 700
+		Cost: 650
 	Tooltip:
 		Name: Light Tank
 	Buildable:
 		BuildPaletteOrder: 40
 		Prerequisites: anyhq, ~techlevel.medium
 		Queue: Vehicle.Nod
+		BuildDuration: 1020
+		BuildDurationModifier: 40
 		Description: Fast, light tank.\n  Strong vs Vehicles, Tanks\n  Weak vs Infantry
 	Mobile:
 		TurnSpeed: 7
@@ -399,7 +405,7 @@ HTNK:
 		Speed: 56
 		TurnSpeed: 3
 	Health:
-		HP: 800
+		HP: 870
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -487,7 +493,7 @@ MLRS:
 		Speed: 99
 		TurnSpeed: 7
 	Health:
-		HP: 120
+		HP: 180
 	Armor:
 		Type: Light
 	RevealsShroud:

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -91,30 +91,12 @@ World:
 		Factions: gdi
 		BaseActor: mcv
 		SupportActors: e1,e1,e1,e1,e1,e3,e3,jeep
-	MPStartUnits@defaultgdib:
-		Class: light
-		ClassName: Light Support
-		Factions: gdi
-		BaseActor: mcv
-		SupportActors: e1,e1,e1,e1,e1,e1,e3,apc
 	MPStartUnits@defaultnoda:
 		Class: light
 		ClassName: Light Support
 		Factions: nod
 		BaseActor: mcv
-		SupportActors: e1,e1,e1,e1,e3,bggy,bike
-	MPStartUnits@defaultnodb:
-		Class: light
-		ClassName: Light Support
-		Factions: nod
-		BaseActor: mcv
-		SupportActors: e1,e1,e1,e3,e3,e3,bggy
-	MPStartUnits@defaultnodc:
-		Class: light
-		ClassName: Light Support
-		Factions: nod
-		BaseActor: mcv
-		SupportActors: e1,e1,e1,e1,e1,e1,e1,e3,bike
+		SupportActors: e1,e1,e1,e1,e1,e1,e3,e3,bggy
 	MPStartUnits@heavynoda:
 		Class: heavy
 		ClassName: Heavy Support

--- a/mods/cnc/weapons/largecaliber.yaml
+++ b/mods/cnc/weapons/largecaliber.yaml
@@ -61,7 +61,7 @@ ArtilleryShell:
 	Inherits: ^BallisticWeapon
 	ReloadDelay: 65
 	Range: 11c0
-	MinRange: 2c896
+	MinRange: 3c0
 	Report: tnkfire2.aud
 	Projectile: Bullet
 		Speed: 204

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -31,6 +31,37 @@
 		Explosions: small_frag
 		ImpactSounds: xplos.aud
 
+Dragon:
+	Inherits: ^MissileWeapon
+	ReloadDelay: 20
+	Range: 12c0
+	Report: rocket2.aud
+	ValidTargets: Air
+	Burst: 2
+	BurstDelay: 5
+	Projectile: Missile
+		Speed: 426
+		Arm: 0
+		Blockable: false
+		TrailImage: smokey
+		ContrailLength: 8
+		Inaccuracy: 128
+		Image: DRAGON
+		HorizontalRateOfTurn: 20
+		RangeLimit: 15c0
+	Warhead@1Dam: SpreadDamage
+		Spread: 128
+		Damage: 35
+		ValidTargets: Air
+		Versus:
+			None: 100
+			Wood: 100
+			Light: 100
+			Heavy: 75
+	Warhead@3Eff: CreateEffect
+		Explosions: small_building
+		ImpactSounds: xplos.aud
+
 Rockets:
 	Inherits: ^MissileWeapon
 
@@ -43,7 +74,7 @@ BikeRockets:
 		Speed: 213
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 30
+		Damage: 31
 		Versus:
 			None: 25
 			Wood: 75
@@ -114,7 +145,7 @@ MammothMissiles:
 227mm:
 	Inherits: ^MissileWeapon
 	ReloadDelay: 100
-	Range: 12c0
+	Range: 11c0
 	MinRange: 3c0
 	Burst: 4
 	BurstDelay: 4
@@ -132,7 +163,7 @@ MammothMissiles:
 		Damage: 25
 		ValidTargets: Ground
 		Versus:
-			None: 35
+			None: 25
 			Wood: 60
 			Light: 100
 			Heavy: 50

--- a/mods/cnc/weapons/other.yaml
+++ b/mods/cnc/weapons/other.yaml
@@ -12,10 +12,10 @@
 		ValidTargets: Ground, Water, Trees
 		InvalidTargets: Wall
 		Versus:
-			None: 100
+			None: 110
 			Wood: 100
 			Light: 100
-			Heavy: 20
+			Heavy: 10
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
@@ -53,10 +53,10 @@ Chemspray:
 		Spread: 256
 		Damage: 80
 		Versus:
-			None: 100
+			None: 70
 			Wood: 35
 			Light: 75
-			Heavy: 50
+			Heavy: 75
 		DamageTypes: Prone50Percent, TriggerProne, TiberiumDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
@@ -73,7 +73,7 @@ Grenade:
 		Speed: 140
 		Blockable: false
 		LaunchAngle: 62
-		Inaccuracy: 213
+		Inaccuracy: 813
 		Image: BOMB
 	Warhead@1Dam: SpreadDamage
 		Spread: 341

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -3,9 +3,9 @@ Sniper:
 	ValidTargets: Ground, Infantry
 	InvalidTargets: Vehicle, Water, Structure, Wall, Husk
 	ReloadDelay: 40
-	Range: 6c0
+	Range: 8c0
 	Projectile: Bullet
-		Speed: 1c682
+		Speed: 5c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 100
@@ -126,7 +126,7 @@ APCGun:
 		Versus:
 			None: 50
 			Wood: 50
-			Light: 105
+			Light: 100
 			Heavy: 50
 		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Eff: CreateEffect

--- a/mods/cnc/weapons/superweapons.yaml
+++ b/mods/cnc/weapons/superweapons.yaml
@@ -17,8 +17,8 @@ Atomic:
 		ImpactSounds: nukexplo.aud
 	Warhead@3Dam_areanukea: SpreadDamage
 		Spread: 2c512
-		Damage: 100
-		Falloff: 1000, 368, 135, 50, 18, 7, 0
+		Damage: 110
+		Falloff: 1000, 700, 500, 300, 150, 50, 0
 		Delay: 3
 		ValidTargets: Ground, Air
 		Versus:


### PR DESCRIPTION
Add detection to temple of Nod.
(Nice to have detection then stealthers sneaking by it)

artillery minimum range increase from 2c896 to 3c0.

mammoth tank HP increase from 800 to 870.
(Dies by medium tank spams and e3 a little to easily from recent changes. With a longer build time they fall prey to mass numbers.)

ion time increase from 3:00 to 4:30.
(Ion strikes go off a little to fast. Mammoth armies take about 2:00 to build back up. By the time base attacks happen close to 3:00)

nuke timer from 5 to 6.
(Because the nuke damage has been buffed)

nuke damage spread fallout increased from 1000, 368, 135, 50, 18, 7, 0
to 1000, 700, 500, 300, 150, 50, 0
(Nuke damage spread was to weak. Barely killing a power plant where it lands just a few cells away from base hit)

nuke spread damage increased from 100 to 110. (First spread modifier)
(See line above)

a10 timer increased from 3:30 to 4:00.
(Timer increased because they were going off a little to fast still. These planes kill infantry builds as it is.)

MSAM HP from 120 to 180.
(To weak vs air. Missiles drain takes a few seconds to reload and then sniped within that time. Specially since dedicated AA)

Commando weapon range increased from 6c0 to 8c0.
(They had the same range as e3 and minigunners were able to close distances on them extremely fast. Take note they shoot farther then their vision range.)

Commando weapon projectile speed increased from 1c682 to 5c682.
(This was super annoying. You fire a shot and the infantry doesn't die because bullet travel to slow. Increased this fixed the problem.)

Commando price increase from 1000 to 2000.
(Extremely cheap when buffed. Increased price to match their power.)

Commando build time increased from 24 to 32. (2000 Build duration)
(Build time a little to fast. Compensates this with multiple barracks.)

Husks interval timer increased from 2 to 6.
(Husks blow up to fast to capture anything. Kept on low timer to prevent vehicle block. Only possible way is to have an engineer in an APC ready. Which Nod is unable to have APCs.)

Bike damage increase from 30 to 31.
(HP changes on harvs, structures, and mammoth. A very small change leading to a decent buff. Granting a 2 damage increase with constant hits)

Chem damage vs none reduced from 100 to 70.
(Chems performing a little to well by themselves. Having mixed units is a better solution. IE: My recent flame tank chem trooper mix)

Chem damage vs armor increased from 50 to 75.
(Chems performed a little to weak vs armor. Doing less damage then infantry and getting squashed by medium tanks and light tanks. This will make players think twice about squashing tactics. Also more damage vs armored defenses.)

Grenadier accuracy reduced from 213 to 813. (Makes them miss a lot more).
(Grenadiers were to accurate and unable to kill infantry packs. Looking at CNC95 and RA in ORA they miss their targets as well. Having them miss spreads their AoE damage and able to take out infantry packs. Players maye want to think of spreading infantry when fighting grenadiers)

Flamer damage vs armor reduced from 20 to 10. (Flame infantry)
(To much damage to APCs and light tanks)

Flamer damage vs none increased from 100 to 110. (Flame infantry.)
(Made them stronger vs infantry to balance out vs chems. Makes them a strong viable choice.)

Harv build timer increase from 24 to 27. (1680 build timer)
(Harv spamming is like a disease. Its gotten to strong to quickly. Increasing their timer slightly also increases other viable builds.)

Harvester HP increase from 600 to 625.
(Both medium tanks and bikes doing a little to much damage. Compensates slightly for build timer)

Refinery power reduced from 50 to 40.
(Offers more build choices. Opening barracks becomes stronger then going strip/factory all the time. Both openings strong strats just requires scouting.)

Refinery sell no longer refunds.
(Includes with the harv spamming. Gave 250 back which counted towards buggy/bike money. IE: PP > Ref > Strip (Strip makes 2-3 buggies 2 bikes then a harv) > Ref (Sell ref gain harv) > Strip (Because power only 30) > PP

Refinery tiberium hold reduced from 2000 to 700.
(This has had no impact to force people to build silos. But it opts people to protect refineries rather then "Lost a ref. Meh. Got 3 others.". Losing a ref now loses earned money. If it holds money. Also prevents sell trick to save power.)

Silo hold increase from 2000 to 3000.
(Compensate for Refinery. Also has extra HP now. See below.)

AGT HP from 600 to 550.
(Way to strong when it came to units coming to these in mass amounts. Also hard for artillery units to shell due to small box size and HP pool.)

Light Tank price reduced from 700 to 650.
(700 was a bit to high. 650 seems to hit the right spot but left build time as is. 0:17)

Visceroid spawn reduce from 10 to 5.
(This was a weird one. Infantry dieing in tiberium was at a good spot. But for some reason when chems kill infantry it would create 2-3 visceroids. Then those visceroids would create 2-3 at a time. RNG issue so was reduced.)

Increase all building HP by 100.
(Help balance vs medium tanks, bikes, light tanks, chems, grenadiers, air units, and stealth tanks.)

Gun turret HP increase from 400 to 410.
(This is taking baby steps. I want them a little tougher vs medium tanks but not at the point of RA style. Same logic as obrakmann taking baby steps with MCV.)

Starting units adjusted.
(This created a big problem in competitive scenes. Having early units is good to prevent infantry rushes. But starting with a bike/apc while your opponent starts with a hummer/buggy is to off balancing.)

MCV build time decreased from 1:36 to 1:00. (3750)
(Price unchanged. Takes a little to long in team games and some 1v1 scenarios to get one built. Also now drains money faster to compensate)

Engineer HP increase from 25 to 30.
(Dies a little to quick hummers/buggies. Same kill time as minigunner (If takes a hit while standing)

APC HP increase from 210 to 215.
(These are dieing a little to fast and weak vs certian units. IE: buggies/hummers and bikes. Tested vs light tanks and more optimal. Baby steps.)

APC Damage vs light decreased from 105 to 100.
(I don't want them killing bikes to fast now that they are cheaper.)

APC cost decreased from 600 to 550.
(APCs for infantry builds as GDI was waaaaay to expensive. Having a slightly faster build timer of 0:14 instead of 0:15 will help too. Helps to withstand early onslaught of Nod. Keep note bikes still 0:12 timer)

(Created new Sam weapon Dragon from RA e3 AA. Reason: Shared weapon with AGT.)

Samsite range increased from 8c0 to 12c0.
(Dedicated AA. Keep note: Longer range = longer time to kill a unit and able to escape. Closer it is the faster air units die.)

Samsite spread damage decreased from 682 to 128.
(To much AoE damage)

Samsite range limit increased from 9c614 to 15co.
(Missiles would die out within its own range circle.)

Samsite reveal shroud decreased from 8c0 to 6c0.
(Prevents the RA logic of build an AA in front of your base and all good. You need units/structures to make good use of its range.)

Samsite now fires two shots at a time.
(Increases damage and intuitive to home base of CNC95.)

Recon Bike HP decreased from 120 to 110.
(Takes to long to kill these units when vs minigunners and light vehicle types. APCs taking to long to kill these.)

Airstrip/Weapon Factory power increased from 30 to 50.
(Increased like a disease. Nod players going with an extremely fast 4 strip build without com center. GDI maxing at 3 factories with non stop vehicles. Infantry became to weak.)

Communication Center power increased from 40 to 50.
(See above.)

APC movement speed increased from 128 to 132.
(A little to slow vs light tanks and dealing with buggies. Buggies being faster still they are able to get a few extra shots off. Provides better base entry.)

MRLS range reduced from 12c0 to 11c0.
(Out ranging Nod artillery. Extremely accurate as is and to strong vs several units. Shorter range allows faster vehicles to reach them better.)

MRLS damage vs none reduced from 35 to 25.
(To much damage vs infantry. Specially to e3.)

Obelisk power reduced from 150 to 90.
(Having to build an adv power plant after each Obelisk is put up is insane. Two Obelisk = 180 now and adv power plant is 200.)

Pulled from https://github.com/OpenRA/OpenRA/pull/12507 rebasing didn't work. Was also deleted contemplating time. Reference http://www.sleipnirstuff.com/forum/viewtopic.php?f=82&t=17430