### PR TITLE
Updated Windows SDL2 to version 2.0.5

### DIFF
--- a/thirdparty/fetch-thirdparty-deps-windows.sh
+++ b/thirdparty/fetch-thirdparty-deps-windows.sh
@@ -19,9 +19,9 @@ function get()
 
 if [ ! -f SDL2.dll ]; then
 	echo "Fetching SDL2 from libsdl.org"
-	wget https://www.libsdl.org/release/SDL2-2.0.4-win32-x86.zip
-	unzip SDL2-2.0.4-win32-x86.zip SDL2.dll
-	rm SDL2-2.0.4-win32-x86.zip
+	wget https://www.libsdl.org/release/SDL2-2.0.5-win32-x86.zip
+	unzip SDL2-2.0.5-win32-x86.zip SDL2.dll
+	rm SDL2-2.0.5-win32-x86.zip
 fi
 
 if [ ! -f freetype6.dll ]; then

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -70,7 +70,7 @@ if (!(Test-Path "windows/SDL2.dll"))
 	echo "Fetching SDL2 from libsdl.org"
 	
 	# Download zip:
-	$zipFileName = "SDL2-2.0.4-win32-x86.zip"
+	$zipFileName = "SDL2-2.0.5-win32-x86.zip"
 	$target = Join-Path $pwd.ToString() $zipFileName
 	(New-Object System.Net.WebClient).DownloadFile("https://www.libsdl.org/release/" + $zipFileName, $target)
 	
@@ -82,7 +82,7 @@ if (!(Test-Path "windows/SDL2.dll"))
 	$destination.Copyhere($zipFile.items())
 	
 	# Remove junk files:
-	rm SDL2-2.0.4-win32-x86.zip
+	rm SDL2-2.0.5-win32-x86.zip
 	rm -path "$currentPath\windows\README-SDL.txt"
 }
 


### PR DESCRIPTION
See https://forums.libsdl.org/viewtopic.php?t=12160 for the changelog.

I noticed several SDL related bugs being reported such as https://github.com/OpenRA/OpenRA/issues/6341 and https://github.com/OpenRA/OpenRA/issues/10172 which should be tested against the new version and otherwise reports towards upstream SDL2 should be filed.

https://github.com/OpenRA/OpenRA/pull/12501 might be affected by this.