### PR TITLE
D2k extended upgradetooltips

### DIFF
--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -88,7 +88,7 @@ thumper:
 	Valued:
 		Cost: 200
 	Tooltip:
-		Name: Thumper
+		Name: Thumper Infantry
 	Health:
 		HP: 375
 	RevealsShroud:

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -191,7 +191,7 @@ upgrade.conyard:
 		BuildLimit: 1
 		BuildDuration: 590
 		BuildDurationModifier: 40
-		Description: Unlocks new construction options
+		Description: Unlocks additional construction options \n(Large Concrete Slab, Rocket Turret)
 	Valued:
 		Cost: 1000
 	RenderSprites:
@@ -213,7 +213,7 @@ upgrade.barracks:
 		BuildLimit: 1
 		BuildDuration: 290
 		BuildDurationModifier: 40
-		Description: Unlocks additional infantry
+		Description: Unlocks additional infantry \n(Trooper, Engineer, Thumper Infantry)    \n\nRequired to unlock faction specific infantry \n(Atreides: Grenadier, Harkonnen: Sardaukar)
 	Valued:
 		Cost: 500
 	RenderSprites:
@@ -236,7 +236,7 @@ upgrade.light:
 		BuildLimit: 1
 		BuildDuration: 215
 		BuildDurationModifier: 40
-		Description: Unlocks additional light units
+		Description: Unlocks additional light unit \n(Missile Quad) \n\nRequired to unlock faction specific light unit \n(Ordos: Stealth Raider Trike)
 	Valued:
 		Cost: 400
 	RenderSprites:
@@ -259,7 +259,7 @@ upgrade.heavy:
 		BuildLimit: 1
 		BuildDuration: 380
 		BuildDurationModifier: 40
-		Description: Unlocks advanced technology and heavy weapons
+		Description: Unlocks additional construction options    \n(Repair Pad, IX Research Centre) \n\nUnlocks additional heavy units \n(Siege Tank, Missile Tank, MCV)
 	Valued:
 		Cost: 800
 	RenderSprites:
@@ -282,7 +282,7 @@ upgrade.hightech:
 		BuildLimit: 1
 		BuildDuration: 720
 		BuildDurationModifier: 40
-		Description: Unlocks the Air Strike superweapon
+		Description: Unlocks the Atreides Air Strike superweapon
 	Valued:
 		Cost: 1500
 	RenderSprites:

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -259,7 +259,7 @@ upgrade.heavy:
 		BuildLimit: 1
 		BuildDuration: 380
 		BuildDurationModifier: 40
-		Description: Unlocks additional construction options    \n(Repair Pad, IX Research Centre) \n\nUnlocks additional heavy units \n(Siege Tank, Missile Tank, MCV)
+		Description: Unlocks additional construction options    \n(Repair Pad, IX Research Center) \n\nUnlocks additional heavy units \n(Siege Tank, Missile Tank, MCV)
 	Valued:
 		Cost: 800
 	RenderSprites:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -23,6 +23,8 @@ concretea:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
+	Tooltip:
+		Name: Concrete Slab
 	Valued:
 		Cost: 20
 	Buildable:
@@ -35,6 +37,8 @@ concreteb:
 	Building:
 		Footprint: xxx xxx xxx
 		Dimensions: 3,3
+	Tooltip:
+		Name: Large Concrete Slab
 	Valued:
 		Cost: 50
 	Buildable:
@@ -866,7 +870,7 @@ research_centre:
 	Valued:
 		Cost: 1000
 	Tooltip:
-		Name: Ix Lab
+		Name: IX Research Center
 	Building:
 		Footprint: _x_ xxx xxx
 		Dimensions: 3,3

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -442,7 +442,7 @@ deviator:
 		BuildPaletteOrder: 40
 		BuildDuration: 373
 		BuildDurationModifier: 40
-		Description: Main Battle Tank\n  Strong vs Tanks\n  Weak vs Infantry, Aircraft\n \n  Atreides:      +Range\n  Harkonnen: +Health\n  Ordos:         +Speed
+		Description: Main Battle Tank\n  Strong vs Tanks\n  Weak vs Infantry, Aircraft\n \n  Atreides:      +Range\n  Harkonnen:  +Health\n  Ordos:          +Speed
 	Valued:
 		Cost: 700
 	Tooltip:


### PR DESCRIPTION
PR for #12069 

Quite simple changes to the d2k yaml-files.

I added also a small fix for the combat tank tooltip:

Before            |  Now          
:-------------------------:|:-------------------------:
![openra-2017-01-05t221338150z](https://cloud.githubusercontent.com/assets/20945684/21699596/c5cddfc0-d39c-11e6-8fc0-b4bf89fbc2de.png)  |  ![openra-2017-01-05t214147078z](https://cloud.githubusercontent.com/assets/20945684/21699508/53f7133a-d39c-11e6-9e47-ee2d7d70f664.png)


If unwanted it will be deleted.