### PR TITLE
D2K - Fix that Turrets are capturable.

### DIFF
--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -306,6 +306,7 @@
 	RenderRangeCircle:
 	-GivesBuildableArea:
 	-WithMakeAnimation:
+	-Capturable:
 	-WithSpriteBody:
 	WithWallSpriteBody:
 	LineBuildNode:


### PR DESCRIPTION
Small problem, didn't even fell a need to crate issue.

They wasn't capturable in original game.