### PR TITLE
TD Aircraft Speeds.

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -12,7 +12,7 @@ TRAN:
 	Aircraft:
 		LandWhenIdle: true
 		TurnSpeed: 5
-		Speed: 140
+		Speed: 150
 		InitialFacing: 224
 		LandableTerrainTypes: Clear,Rough,Road,Ore,Beach,Tiberium,BlueTiberium
 		AltitudeVelocity: 0c100
@@ -66,8 +66,8 @@ HELI:
 	Aircraft:
 		RearmBuildings: hpad
 		InitialFacing: 224
-		TurnSpeed: 4
-		Speed: 186
+		TurnSpeed: 7
+		Speed: 180
 	Health:
 		HP: 125
 	Armor:
@@ -125,7 +125,7 @@ ORCA:
 	Aircraft:
 		RearmBuildings: hpad
 		InitialFacing: 224
-		TurnSpeed: 4
+		TurnSpeed: 7
 		Speed: 186
 	Health:
 		HP: 90


### PR DESCRIPTION
Balancing out some of the small things that makes a big difference with the aircraft. Listings below:

Chinook:

Mobile speed increased from 140 to 150.

This is increasing because a number of vehicles catch up to these. (Bikes, APCs, buggies, humvees.)

Increasing the movement of this unit will help to outrun the APCs and other projectiles a little quicker. It also helps to compensate for travel distances. These units are only used in early game because of the enemies lack of AA. Increasing the speed will help their longevity.


Apache mobile speed decreased from 186 to 180.

This is done to prevent these units from chase killing Orcas as their machinegun fire is on point hits with minimal damage. HP remains the same (Orca 90 Apache 125). Orca being lighter in HP allows it to move more quickly while the apache can soak more damage. In air vs air battles the apache tends to win due to their guns vs slow missile fire.


Both Orca and Apache turnspeed increased from 4 to 7.

This is increased on both units because they take a full second before they are able to aim at targets leaving them stationary and taking hits. Increasing this speeds allows them to be what they are ment to be as hit and strike crafts. The turning speed also allows them to hit targets more effectively on the move.

NOTES:

I am still testing the damages of the aircraft. Once the poll ends I will start testing more differences on the maps. So far some feedback has been obtained but need more data. Hearing and watching from many releases ago about buffing or nerfing these air units to much can tip the scales as far as being completely broken to completely worthless. 