### PR TITLE
Remove CanPowerDown from starports

### DIFF
--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -576,10 +576,6 @@ starport:
 	ProductionBar:
 	PrimaryBuilding:
 		PrimaryCondition: primary
-	RequiresPower:
-	CanPowerDown:
-		PowerupSound: EnablePower
-		PowerdownSound: DisablePower
 	DisabledOverlay:
 	ProvidesPrerequisite@atreides:
 		Prerequisite: starport.atreides


### PR DESCRIPTION
Starports are production facilities and the ability to toggle their power
status conflicts with the expected behaviour from other official OpenRA
mods.

Changelog suggestion: Removed the ability to manually power down
starports.

Related to #10402