### PR TITLE
Implement experience multipliers.

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -361,6 +361,8 @@
     <Compile Include="Traits\Passenger.cs" />
     <Compile Include="Traits\Multipliers\DamageMultiplier.cs" />
     <Compile Include="Traits\Multipliers\FirepowerMultiplier.cs" />
+    <Compile Include="Traits\Multipliers\GainsExperienceMultiplier.cs" />
+    <Compile Include="Traits\Multipliers\GivesExperienceMultiplier.cs" />
     <Compile Include="Traits\Multipliers\InaccuracyMultiplier.cs" />
     <Compile Include="Traits\Multipliers\ReloadDelayMultiplier.cs" />
     <Compile Include="Traits\Multipliers\SpeedMultiplier.cs" />

--- a/OpenRA.Mods.Common/Traits/GivesExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GivesExperience.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -54,9 +55,16 @@ namespace OpenRA.Mods.Common.Traits
 				? info.Experience
 				: valued != null ? valued.Cost : 0;
 
+			var experienceModifier = self.TraitsImplementing<IGivesExperienceModifier>().Select(x => x.GetGivesExperienceModifier());
+			Util.ApplyPercentageModifiers(exp, experienceModifier);
+
 			var killer = e.Attacker.TraitOrDefault<GainsExperience>();
 			if (killer != null)
-				killer.GiveExperience(Util.ApplyPercentageModifiers(exp, new[] { info.ActorExperienceModifier }));
+			{
+				var killerExperienceModifier = e.Attacker.TraitsImplementing<IGainsExperienceModifier>()
+					.Select(x => x.GetGainsExperienceModifier()).Append(info.ActorExperienceModifier);
+				killer.GiveExperience(Util.ApplyPercentageModifiers(exp, killerExperienceModifier));
+			}
 
 			var attackerExp = e.Attacker.Owner.PlayerActor.TraitOrDefault<PlayerExperience>();
 			if (attackerExp != null)

--- a/OpenRA.Mods.Common/Traits/Multipliers/GainsExperienceMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/GainsExperienceMultiplier.cs
@@ -1,0 +1,36 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Modifies the experience gathered by this actor.")]
+	public class GainsExperienceMultiplierInfo : ConditionalTraitInfo
+	{
+		[FieldLoader.Require]
+		[Desc("Percentage modifier to apply.")]
+		public readonly int Modifier = 100;
+
+		public override object Create(ActorInitializer init) { return new GainsExperienceMultiplier(this); }
+	}
+
+	public class GainsExperienceMultiplier : ConditionalTrait<GainsExperienceMultiplierInfo>, IGainsExperienceModifier
+	{
+		public GainsExperienceMultiplier(GainsExperienceMultiplierInfo info)
+			: base(info) { }
+
+		int IGainsExperienceModifier.GetGainsExperienceModifier()
+		{
+			return IsTraitDisabled ? 100 : Info.Modifier;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Multipliers/GivesExperienceMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/GivesExperienceMultiplier.cs
@@ -1,0 +1,36 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Modifies the experience given by this actor.")]
+	public class GivesExperienceMultiplierInfo : ConditionalTraitInfo
+	{
+		[FieldLoader.Require]
+		[Desc("Percentage modifier to apply.")]
+		public readonly int Modifier = 100;
+
+		public override object Create(ActorInitializer init) { return new GivesExperienceMultiplier(this); }
+	}
+
+	public class GivesExperienceMultiplier : ConditionalTrait<GivesExperienceMultiplierInfo>, IGivesExperienceModifier
+	{
+		public GivesExperienceMultiplier(GivesExperienceMultiplierInfo info)
+			: base(info) { }
+
+		int IGivesExperienceModifier.GetGivesExperienceModifier()
+		{
+			return IsTraitDisabled ? 100 : Info.Modifier;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -227,4 +227,10 @@ namespace OpenRA.Mods.Common.Traits
 
 	[RequireExplicitImplementation]
 	public interface IPowerModifier { int GetPowerModifier(); }
+
+	[RequireExplicitImplementation]
+	public interface IGivesExperienceModifier { int GetGivesExperienceModifier(); }
+
+	[RequireExplicitImplementation]
+	public interface IGainsExperienceModifier { int GetGainsExperienceModifier(); }
 }


### PR DESCRIPTION
Requested by Crystallized Doom basically, but it was something I also wanted to add on my own anyway.

Implement two interfaces for experience multiplying both on giver (for things like increasing ranked-up actor's experience worth) and receiver side (for things like Generals's USA Advanced Training upgrade).

For a testcase, see http://resource.openra.net/maps/18262/.