### PR TITLE
Allow disabling actor scans in CreateEffectWarhead

### DIFF
--- a/OpenRA.Mods.Common/Lint/CheckTargetHealthRadius.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTargetHealthRadius.cs
@@ -55,8 +55,19 @@ namespace OpenRA.Mods.Common.Lint
 
 					foreach (var warhead in effectWarheads)
 					{
+						// If the TargetSearchRadius is zero, we assume that's intentional and skip testing further.
+						if (warhead.TargetSearchRadius == WDist.Zero)
+							continue;
+
 						// This warhead cannot affect this actor.
 						if (!warhead.ValidTargets.Overlaps(targetable))
+							continue;
+
+						// If ValidImpactTypes contains all base types and InvalidImpactTypes contains None (i.e. matches the respective defaults),
+						// we can assume the warhead will trigger regardless of nearby actors, so we don't need a valid TargetSearchRadius.
+						if (warhead.ValidImpactTypes
+							.HasFlag(ImpactType.Ground | ImpactType.Water | ImpactType.Air | ImpactType.GroundHit | ImpactType.WaterHit | ImpactType.AirHit)
+							&& warhead.InvalidImpactTypes.HasFlag(ImpactType.None))
 							continue;
 
 						if (healthTraits.Where(x => x.Shape.OuterRadius.Length > warhead.TargetSearchRadius.Length).Any())

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -47,14 +47,14 @@ namespace OpenRA.Mods.Common.Warheads
 			// We assume that a TargetSearchRadius of zero is intentional and means we should skip all scans for actor hits.
 			var scanForActors = TargetSearchRadius != WDist.Zero;
 
+			// Matching target actor
+			if (scanForActors && ValidImpactTypes.HasFlag(ImpactType.TargetHit) && GetDirectHit(world, cell, pos, firedBy, true))
+				return ImpactType.TargetHit;
+
 			// Missiles need a margin because they sometimes explode a little above ground
 			// due to their explosion check triggering slightly too early (because of CloseEnough).
 			// TODO: Base ImpactType on target altitude instead of explosion altitude.
 			var airMargin = new WDist(128);
-
-			// Matching target actor
-			if (scanForActors && ValidImpactTypes.HasFlag(ImpactType.TargetHit) && GetDirectHit(world, cell, pos, firedBy, true))
-				return ImpactType.TargetHit;
 
 			var dat = world.Map.DistanceAboveTerrain(pos);
 			var isDirectHit = scanForActors ? GetDirectHit(world, cell, pos, firedBy) : false;

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -44,17 +44,20 @@ namespace OpenRA.Mods.Common.Warheads
 
 		public ImpactType GetImpactType(World world, CPos cell, WPos pos, Actor firedBy)
 		{
+			// We assume that a TargetSearchRadius of zero is intentional and means we should skip all scans for actor hits.
+			var scanForActors = TargetSearchRadius != WDist.Zero;
+
 			// Missiles need a margin because they sometimes explode a little above ground
 			// due to their explosion check triggering slightly too early (because of CloseEnough).
 			// TODO: Base ImpactType on target altitude instead of explosion altitude.
 			var airMargin = new WDist(128);
 
 			// Matching target actor
-			if (ValidImpactTypes.HasFlag(ImpactType.TargetHit) && GetDirectHit(world, cell, pos, firedBy, true))
+			if (scanForActors && ValidImpactTypes.HasFlag(ImpactType.TargetHit) && GetDirectHit(world, cell, pos, firedBy, true))
 				return ImpactType.TargetHit;
 
 			var dat = world.Map.DistanceAboveTerrain(pos);
-			var isDirectHit = GetDirectHit(world, cell, pos, firedBy);
+			var isDirectHit = scanForActors ? GetDirectHit(world, cell, pos, firedBy) : false;
 
 			if (dat.Length > airMargin.Length)
 				return isDirectHit ? ImpactType.AirHit : ImpactType.Air;

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -53,6 +53,7 @@ Flamer:
 		SmudgeType: Scorch
 		InvalidTargets: Structure, Wall
 	Warhead@3Eff: CreateEffect
+		TargetSearchRadius: 0
 		Explosions: small_napalm
 		ImpactSounds: firebl3.aud
 


### PR DESCRIPTION
The `CreateEffectWarhead` only needs to scan for actors to decide the `ImpactType`. In cases where the ImpactType doesn't matter (or where only the terrain matters), we can presumably save some performance during heated battles by not performing redundant scans for actors in the impact vicinity.

As example and test case, I'm applying this to the RA Flamer infantry weapon, because it fires a whopping 15 times per salvo, quickly adding up when many of them fire at the same time.

I didn't see a measurable difference, but that was to be expected as the SpreadDamageWH actor scan and projectile blocking scans are far more expensive and overshadow any tiny gains from this.

The impotant parts are that the warhead and lint rule changes work and the yaml change causes no regression.

Prerequisite for #12513.