### PR TITLE
D2K - Change tech level of Sardaukar to medium

### DIFF
--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -193,7 +193,7 @@ sardaukar:
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 80
-		Prerequisites: ~barracks.harkonnen, upgrade.barracks, high_tech_factory, ~techlevel.high
+		Prerequisites: ~barracks.harkonnen, upgrade.barracks, high_tech_factory, ~techlevel.medium
 		BuildDuration: 81
 		BuildDurationModifier: 40
 		Description: Elite assault infantry\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery


### PR DESCRIPTION
They are counterpart of Grenadiers and Stealth Raiders and they both have `techlevel.medium`. I think this is left from the times where Sardaukar used to require Palace, which was wrong.