### PR TITLE
D2K - Fix tile 443

### DIFF
--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -3859,11 +3859,11 @@ Templates:
 		Category: Rock-Cliff
 		Tiles:
 			0: Rock
-			1: Cliff
+			1: Rough
 			2: Cliff
 			3: Cliff
 			4: Cliff
-			5: Cliff
+			5: Rough
 	Template@444:
 		Id: 444
 		Images: BLOXTREE.R8


### PR DESCRIPTION
That cliff tile supposed to allow infantry to pass. You may want to check the original game first, but i'm sure about that.

Image:
![cliff](https://cloud.githubusercontent.com/assets/7933210/21991402/1c622f86-dc1b-11e6-8bd6-af6f4cc37f80.png)