### PR TITLE
D2K - Fix Low Repair and Terrain Damage.

### DIFF
--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -337,6 +337,7 @@
 		Weapon: BuildingExplode
 		EmptyWeapon: BuildingExplode
 	RepairableBuilding:
+		RepairStep: 50
 		PlayerExperience: 25
 	EmitInfantryOnSell:
 		ActorTypes: light_inf
@@ -354,7 +355,7 @@
 	WithCrumbleOverlay:
 	Demolishable:
 	DamagedByTerrain:
-		Damage: 10
+		Damage: 50
 		DamageInterval: 100
 		Terrain: Rock
 		DamageThreshold: 50


### PR DESCRIPTION
Fixes #12570.

I think 8x works fine, but need your opinions. Doing calculations was not a good way as there are 2x to 10x amounts of HPs for structures when compared to RA.