### PR TITLE
Reduce ongoing allocations

### DIFF
--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -52,7 +52,6 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class AutoTarget : ConditionalTrait<AutoTargetInfo>, INotifyIdle, INotifyDamage, ITick, IResolveOrder, ISync
 	{
-		readonly AttackBase[] attackBases;
 		readonly IEnumerable<AttackBase> activeAttackBases;
 		readonly AttackFollow[] attackFollows;
 		[Sync] int nextScanTime = 0;
@@ -68,8 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 			: base(info)
 		{
 			var self = init.Self;
-			attackBases = self.TraitsImplementing<AttackBase>().ToArray();
-			activeAttackBases = attackBases.Where(Exts.IsTraitEnabled);
+			activeAttackBases = self.TraitsImplementing<AttackBase>().ToArray().Where(Exts.IsTraitEnabled);
 
 			if (init.Contains<StanceInit>())
 				Stance = init.Get<StanceInit, UnitStance>();
@@ -107,7 +105,8 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// not a lot we can do about things we can't hurt... although maybe we should automatically run away?
-			if (attackBases.All(a => a.IsTraitDisabled || !a.HasAnyValidWeapons(Target.FromActor(attacker))))
+			var attackerAsTarget = Target.FromActor(attacker);
+			if (!activeAttackBases.Any(a => a.HasAnyValidWeapons(attackerAsTarget)))
 				return;
 
 			// don't retaliate against own units force-firing on us. It's usually not what the player wanted.

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/RotationPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/RotationPaletteEffect.cs
@@ -92,8 +92,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var kvp in palettes)
 			{
-				if ((info.Palettes.Count > 0 && !info.Palettes.Any(kvp.Key.StartsWith))
-					|| (info.ExcludePalettes.Count > 0 && info.ExcludePalettes.Any(kvp.Key.StartsWith)))
+				if ((info.Palettes.Count > 0 && !AnyPaletteNameStartsWith(info.Palettes, kvp.Key))
+					|| (info.ExcludePalettes.Count > 0 && AnyPaletteNameStartsWith(info.ExcludePalettes, kvp.Key)))
 					continue;
 
 				var palette = kvp.Value;
@@ -104,6 +104,16 @@ namespace OpenRA.Mods.Common.Traits
 				for (var i = 0; i < info.RotationRange; i++)
 					palette[info.RotationBase + i] = rotationBuffer[i];
 			}
+		}
+
+		static bool AnyPaletteNameStartsWith(HashSet<string> names, string prefix)
+		{
+			// PERF: Avoid LINQ.
+			foreach (var name in names)
+				if (name.StartsWith(prefix))
+					return true;
+
+			return false;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public int[] SelectionBoxBounds { get { return VisualBounds; } }
 	}
 
-	public class SelectionDecorations : IRenderAboveShroud, ITick
+	public class SelectionDecorations : IRenderAboveShroud, INotifyCreated, ITick
 	{
 		// depends on the order of pips in TraitsInterfaces.cs!
 		static readonly string[] PipStrings = { "pip-empty", "pip-green", "pip-yellow", "pip-red", "pip-gray", "pip-blue", "pip-ammo", "pip-ammoempty" };
@@ -49,12 +49,18 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly SelectionDecorationsInfo Info;
 
 		readonly Animation pipImages;
+		IPips[] pipSources;
 
 		public SelectionDecorations(Actor self, SelectionDecorationsInfo info)
 		{
 			Info = info;
 
 			pipImages = new Animation(self.World, Info.Image);
+		}
+
+		void INotifyCreated.Created(Actor self)
+		{
+			pipSources = self.TraitsImplementing<IPips>().ToArray();
 		}
 
 		IEnumerable<WPos> ActivityTargetPath(Actor self)
@@ -76,8 +82,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 		IEnumerable<IRenderable> IRenderAboveShroud.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
 			if (self.World.FogObscures(self))
-				yield break;
+				return Enumerable.Empty<IRenderable>();
 
+			return DrawDecorations(self, wr);
+		}
+
+		IEnumerable<IRenderable> DrawDecorations(Actor self, WorldRenderer wr)
+		{
 			var selected = self.World.Selection.Contains(self);
 			var regularWorld = self.World.Type == WorldType.Regular;
 			var statusBars = Game.Settings.Game.StatusBars;
@@ -108,21 +119,25 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (self.World.LocalPlayer != null && self.World.LocalPlayer.PlayerActor.Trait<DeveloperMode>().PathDebug)
 				yield return new TargetLineRenderable(ActivityTargetPath(self), Color.Green);
 
+			foreach (var r in DrawPips(self, wr))
+				yield return r;
+		}
+
+		IEnumerable<IRenderable> DrawPips(Actor self, WorldRenderer wr)
+		{
+			if (pipSources.Length == 0)
+				return Enumerable.Empty<IRenderable>();
+
 			var b = self.VisualBounds;
 			var pos = wr.ScreenPxPosition(self.CenterPosition);
 			var bl = wr.Viewport.WorldToViewPx(pos + new int2(b.Left, b.Bottom));
 			var pal = wr.Palette(Info.Palette);
 
-			foreach (var r in DrawPips(self, wr, bl, pal))
-				yield return r;
+			return DrawPips(self, bl, pal);
 		}
 
-		IEnumerable<IRenderable> DrawPips(Actor self, WorldRenderer wr, int2 basePosition, PaletteReference palette)
+		IEnumerable<IRenderable> DrawPips(Actor self, int2 basePosition, PaletteReference palette)
 		{
-			var pipSources = self.TraitsImplementing<IPips>();
-			if (!pipSources.Any())
-				yield break;
-
 			pipImages.PlayRepeating(PipStrings[0]);
 
 			var pipSize = pipImages.Image.Size.XY.ToInt2();


### PR DESCRIPTION
Avoid some common allocation in the main game loop, and also tidy up some code as a side-effect. Hopefully fairly straightforward.

These save 9.7% in the amount of memory allocated when running the RA shellmap.