### PR TITLE
Add forward movement support to GravityBomb

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
@@ -34,10 +34,11 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		[PaletteReference] public readonly string ShadowPalette = "shadow";
 
-		public readonly WDist Speed = WDist.Zero;
+		[Desc("Projectile movement vector per tick (forward, right, up), use negative values for opposite directions.")]
+		public readonly WVec Velocity = WVec.Zero;
 
-		[Desc("Value added to speed every tick.")]
-		public readonly WDist Acceleration = new WDist(15);
+		[Desc("Value added to Velocity every tick.")]
+		public readonly WVec Acceleration = new WVec(0, 0, -15);
 
 		public IProjectile Create(ProjectileArgs args) { return new GravityBomb(this, args); }
 	}
@@ -47,17 +48,18 @@ namespace OpenRA.Mods.Common.Projectiles
 		readonly GravityBombInfo info;
 		readonly Animation anim;
 		readonly ProjectileArgs args;
+		readonly WVec acceleration;
 		[Sync] WVec velocity;
 		[Sync] WPos pos;
-		[Sync] WVec acceleration;
 
 		public GravityBomb(GravityBombInfo info, ProjectileArgs args)
 		{
 			this.info = info;
 			this.args = args;
 			pos = args.Source;
-			velocity = new WVec(WDist.Zero, WDist.Zero, -info.Speed);
-			acceleration = new WVec(WDist.Zero, WDist.Zero, info.Acceleration);
+			var convertedVelocity = new WVec(info.Velocity.Y, -info.Velocity.X, info.Velocity.Z);
+			velocity = convertedVelocity.Rotate(WRot.FromFacing(args.Facing));
+			acceleration = new WVec(info.Acceleration.Y, -info.Acceleration.X, info.Acceleration.Z);
 
 			if (!string.IsNullOrEmpty(info.Image))
 			{
@@ -72,7 +74,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		public void Tick(World world)
 		{
-			velocity -= acceleration;
+			velocity += acceleration;
 			pos += velocity;
 
 			if (pos.Z <= args.PassiveTarget.Z)

--- a/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
@@ -74,8 +74,8 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		public void Tick(World world)
 		{
-			velocity += acceleration;
 			pos += velocity;
+			velocity += acceleration;
 
 			if (pos.Z <= args.PassiveTarget.Z)
 			{

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -624,6 +624,29 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						node.Key = "TrackTarget";
 				}
 
+				// Refactor GravityBomb Speed WDist to Velocity WVec and Acceleration from vertical WDist to vector
+				if (engineVersion < 20170329)
+				{
+					var projectile = node.Value.Nodes.FirstOrDefault(n => n.Key == "Projectile");
+					if (projectile != null && projectile.Value.Value == "GravityBomb")
+					{
+						var speedNode = projectile.Value.Nodes.FirstOrDefault(x => x.Key == "Speed");
+						if (speedNode != null)
+						{
+							var oldWDistSpeed = FieldLoader.GetValue<string>("Speed", speedNode.Value.Value);
+							speedNode.Value.Value = "0, 0, -" + oldWDistSpeed;
+							speedNode.Key = "Velocity";
+						}
+
+						var accelNode = projectile.Value.Nodes.FirstOrDefault(x => x.Key == "Acceleration");
+						if (accelNode != null)
+						{
+							var oldWDistAccel = FieldLoader.GetValue<string>("Acceleration", accelNode.Value.Value);
+							accelNode.Value.Value = "0, 0, -" + oldWDistAccel;
+						}
+					}
+				}
+
 				UpgradeWeaponRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -55,8 +55,8 @@ OrniBomb:
 	Range: 2c0
 	Projectile: GravityBomb
 		Image: BOMBS
-		Speed: 64
-		Acceleration: 0
+		Velocity: 0, 0, -64
+		Acceleration: 0, 0, 0
 		Shadow: true
 	Warhead@1Dam: SpreadDamage
 		Spread: 320

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -5,8 +5,8 @@ ParaBomb:
 	Projectile: GravityBomb
 		Image: PARABOMB
 		OpenSequence: open
-		Speed: 86
-		Acceleration: 0
+		Velocity: 0, 0, -86
+		Acceleration: 0, 0, 0
 	Warhead@1Dam: SpreadDamage
 		Spread: 768
 		Damage: 300

--- a/mods/ts/weapons/otherweapons.yaml
+++ b/mods/ts/weapons/otherweapons.yaml
@@ -26,10 +26,11 @@ FireballLauncher:
 Bomb:
 	ReloadDelay: 60
 	Burst: 5
-	BurstDelay: 5
-	Range: 2c0
+	BurstDelay: 6
+	Range: 2c512
 	Projectile: GravityBomb
-		Speed: 170
+		Velocity: 72, 0, -90
+		Acceleration: 0, 0, -8
 		Image: 120mm
 		Shadow: true
 		Palette: ra


### PR DESCRIPTION
Used to make TS Orca Bomber bombs behave more like in the original.