### PR TITLE
D2K - Add more tile types to possible places Crates can spawn

### DIFF
--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -4,7 +4,7 @@ crate:
 		Name: Crate
 	Crate:
 		Lifetime: 120
-		TerrainTypes: Sand, Dune, Rock, SpiceSand
+		TerrainTypes: Sand, Rock, Transition, Spice, SpiceSand, Dune, Concrete
 	GiveCashCrateAction@1:
 		Amount: 750
 		SelectionShares: 25

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -72,7 +72,7 @@ World:
 		Maximum: 2
 		SpawnInterval: 1500
 		WaterChance: 0
-		ValidGround: Sand, Dune, Rock, SpiceSand
+		ValidGround: Sand, Rock, Transition, Spice, SpiceSand, Dune, Concrete
 		InitialSpawnDelay: 1500
 	DomainIndex:
 	WarheadDebugOverlay:


### PR DESCRIPTION
I'm pretty sure crates can spawn on spice, concrete or transition tiles in original game.