### PR TITLE
Smarter warhead/projectile victim scans

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using OpenRA.Effects;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
@@ -22,7 +23,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Projectiles
 {
-	public class BulletInfo : IProjectileInfo
+	public class BulletInfo : IProjectileInfo, IRulesetLoaded
 	{
 		[Desc("Projectile speed in WDist / tick, two values indicate variable velocity.")]
 		public readonly WDist[] Speed = { new WDist(17) };
@@ -57,9 +58,6 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Width of projectile (used for finding blocking actors).")]
 		public readonly WDist Width = new WDist(1);
 
-		[Desc("Extra search radius beyond path for blocking actors.")]
-		public readonly WDist TargetExtraSearchRadius = new WDist(1536);
-
 		[Desc("Arc in WAngles, two values indicate variable arc.")]
 		public readonly WAngle[] LaunchAngle = { WAngle.Zero };
 
@@ -92,7 +90,21 @@ namespace OpenRA.Mods.Common.Projectiles
 		public readonly int ContrailDelay = 1;
 		public readonly WDist ContrailWidth = new WDist(64);
 
+		[Desc("Extra search radius beyond path for blocking actors.")]
+		public WDist TargetExtraSearchRadius = WDist.Zero;
+
 		public IProjectile Create(ProjectileArgs args) { return new Bullet(this, args); }
+
+		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
+		{
+			var validActors = rules.Actors.Where(a => a.Value.TraitInfos<HealthInfo>().Any()).ToList();
+
+			// TODO: Make this handle multiple Health traits per actor
+			var largestHealthRadius = validActors.Max(a => a.Value.TraitInfo<HealthInfo>().Shape.OuterRadius);
+
+			if (TargetExtraSearchRadius == WDist.Zero)
+				TargetExtraSearchRadius = largestHealthRadius;
+		}
 	}
 
 	public class Bullet : IProjectile, ISync

--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
@@ -18,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Projectiles
 {
 	[Desc("Simple invisible direct on target projectile.")]
-	public class InstantHitInfo : IProjectileInfo
+	public class InstantHitInfo : IProjectileInfo, IRulesetLoaded
 	{
 		[Desc("Maximum offset at the maximum range.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
@@ -29,10 +30,22 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("The width of the projectile.")]
 		public readonly WDist Width = new WDist(1);
 
-		[Desc("Extra search radius beyond projectile width. Required to ensure affecting actors with large health radius.")]
-		public readonly WDist TargetExtraSearchRadius = new WDist(1536);
+		[Desc("Scan radius for victims beyond projectile width. If set to zero (default), it will automatically scale to the largest health shape.",
+			"Custom overrides should not be necessary under normal circumstances.")]
+		public WDist TargetExtraSearchRadius = WDist.Zero;
 
 		public IProjectile Create(ProjectileArgs args) { return new InstantHit(this, args); }
+
+		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
+		{
+			var validActors = rules.Actors.Where(a => a.Value.TraitInfos<HealthInfo>().Any()).ToList();
+
+			// TODO: Make this handle multiple Health traits per actor
+			var largestHealthRadius = validActors.Max(a => a.Value.TraitInfo<HealthInfo>().Shape.OuterRadius);
+
+			if (TargetExtraSearchRadius == WDist.Zero)
+				TargetExtraSearchRadius = largestHealthRadius;
+		}
 	}
 
 	public class InstantHit : IProjectile

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -250,8 +250,8 @@
 	Health:
 		Shape: Rectangle
 			RotateToIsometry: true
-			TopLeft: -384, -384
-			BottomRight: 384, 384
+			TopLeft: -363, -363
+			BottomRight: 363, 363
 			VerticalTopOffset: 512
 
 ^BuildingPlug:
@@ -857,6 +857,12 @@
 
 ^Gate_A:
 	Inherits: ^Gate
+	Health:
+		Shape: Rectangle
+			RotateToIsometry: true
+			TopLeft: -363, -1090
+			BottomRight: 363, 1090
+			VerticalTopOffset: 640
 	Gate:
 		Dimensions: 3,1
 		Footprint: xxx
@@ -867,6 +873,12 @@
 
 ^Gate_B:
 	Inherits: ^Gate
+	Health:
+		Shape: Rectangle
+			RotateToIsometry: true
+			TopLeft: -1090, -363
+			BottomRight: 1090, 363
+			VerticalTopOffset: 640
 	Gate:
 		Dimensions: 1,3
 		Footprint: x x x


### PR DESCRIPTION
Instead of a fixed `TargetExtraSearchRadius` that is added unconditionally, all affected warheads and projectiles now look up the rules for the largest health shape, and add exactly that value by default (the old, static behaviour can still be enforced by setting a custom override value).

This way, modders don't have to find and set an optimal value themselves.

As an example how much this can help performance during heated battles, launch the RA mod, build 50 flamethrowers and make them shoot at the exact same time, on bleed and on this branch. The lag spike on the performance graph should be nearly 3 times as high on bleed vs. this PR, because the projectile is `Blockable` and the largest outer health radius in RA is only `543 WDist` (compared to the old default overscan of `1536`).

Closes #12574.