### PR TITLE
Fix yaml merging (again).

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -68,6 +68,9 @@ namespace OpenRA.GameRules
 
 		public WeaponInfo(string name, MiniYaml content)
 		{
+			// Resolve any weapon-level yaml inheritance or removals
+			// HACK: The "Defaults" sequence syntax prevents us from doing this generally during yaml parsing
+			content.Nodes = MiniYaml.Merge(new[] { content.Nodes });
 			FieldLoader.Load(this, content);
 		}
 

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -302,7 +302,7 @@ namespace OpenRA
 
 			foreach (var n in node.Nodes)
 			{
-				if (n.Key == "Inherits" || n.Key.StartsWith("Inherits@"))
+				if (n.Key == "Inherits" || n.Key.StartsWith("Inherits@", StringComparison.Ordinal))
 				{
 					MiniYaml parent;
 					if (!tree.TryGetValue(n.Value.Value, out parent))
@@ -317,7 +317,7 @@ namespace OpenRA
 					foreach (var r in ResolveInherits(n.Key, parent, tree, inherited))
 						MergeIntoResolved(r, resolved, tree, inherited);
 				}
-				else if (n.Key.StartsWith("-"))
+				else if (n.Key.StartsWith("-", StringComparison.Ordinal))
 				{
 					var removed = n.Key.Substring(1);
 					if (resolved.RemoveAll(r => r.Key == removed) == 0)


### PR DESCRIPTION
Node removal was previously only run on the first level children unless they require additional merging.  This propagates it further down the tree.

Fixes #12362.
Fixes #12519.