### PR TITLE
D2K - Make AI able to use Fremen SW.

### DIFF
--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -113,6 +113,10 @@ Player:
 				Attractiveness: -10
 				TargetMetric: Value
 				CheckRadius: 7c0
+		SupportPowerDecision@Fremen:
+			OrderName: ProduceActorPower.Fremen
+			Consideration@1:
+				Against: Ally
 	HackyAI@Vidius:
 		Name: Vidious
 		MinimumExcessPower: 60
@@ -227,6 +231,10 @@ Player:
 				Attractiveness: -10
 				TargetMetric: Value
 				CheckRadius: 7c0
+		SupportPowerDecision@Fremen:
+			OrderName: ProduceActorPower.Fremen
+			Consideration@1:
+				Against: Ally
 	HackyAI@Gladius:
 		Name: Gladius
 		MinimumExcessPower: 60
@@ -341,3 +349,8 @@ Player:
 				Attractiveness: -10
 				TargetMetric: Value
 				CheckRadius: 7c0
+		SupportPowerDecision@Fremen:
+			OrderName: ProduceActorPower.Fremen
+			Consideration@1:
+				Against: Ally
+


### PR DESCRIPTION
Values are Random, as this SW is not really a SW to fire at somewhere, i think, any positive value of `Attractiveness:` under `Consideration:` would make the AI fire the SW.

AI uses the Actors that are crated in their Attack Groups as normal.

I didn't add one for Saboteurs, because AI doesn't know how to use them.