### PR TITLE
D2K - Remove the unused "TargetTypes: Air" from ornithopter

### DIFF
--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -74,7 +74,6 @@ frigate:
 
 ornithopter:
 	Inherits: ^Plane
-		TargetTypes: Air
 	AttackBomber:
 	Armament:
 		Weapon: OrniBomb


### PR DESCRIPTION
Looks like someone forgot it when removing `Targetable:` trait from it.

In original game Ornithopter is targetable, but as our ornistrike sytem isn't same as original, i think it is good to keep them untargetable for now.