### PR TITLE
D2K - Reorder rule files on mod.yaml

### DIFF
--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -34,12 +34,12 @@ Rules:
 	d2k|rules/world.yaml
 	d2k|rules/palettes.yaml
 	d2k|rules/defaults.yaml
+	d2k|rules/infantry.yaml
 	d2k|rules/vehicles.yaml
+	d2k|rules/aircraft.yaml
+	d2k|rules/structures.yaml
 	d2k|rules/starport.yaml
 	d2k|rules/husks.yaml
-	d2k|rules/structures.yaml
-	d2k|rules/aircraft.yaml
-	d2k|rules/infantry.yaml
 	d2k|rules/arrakis.yaml
 
 Sequences:


### PR DESCRIPTION
This effects the order on map editor. I moved the Starport and Husks yaml down because at, least for me, i usually place them instead of normal vehicles and it is annoying. Also moved Aircraft and Infantry up with other normal actors.