### PR TITLE
Expose Bullet's reached-ground-altitude check to yaml.

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -63,6 +63,10 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Arc in WAngles, two values indicate variable arc.")]
 		public readonly WAngle[] LaunchAngle = { WAngle.Zero };
 
+		[Desc("Altitude where this bullet should explode when reached.",
+			"Negative values allow this bullet to pass cliffs and terrain bumps.")]
+		public readonly WDist ExplodeUnderThisAltitude = WDist.Zero;
+
 		[Desc("Up to how many times does this bullet bounce when touching ground without hitting a target.",
 			"0 implies exploding on contact with the originally targeted position.")]
 		public readonly int BounceCount = 0;
@@ -226,8 +230,8 @@ namespace OpenRA.Mods.Common.Projectiles
 			// Flight length reached / exceeded
 			shouldExplode |= flightLengthReached && !shouldBounce;
 
-			// Driving into cell with higher height level
-			shouldExplode |= world.Map.DistanceAboveTerrain(pos).Length < 0;
+			// Driving into cell with different height level
+			shouldExplode |= world.Map.DistanceAboveTerrain(pos) < info.ExplodeUnderThisAltitude;
 
 			// After first bounce, check for targets each tick
 			if (remainingBounces < info.BounceCount)


### PR DESCRIPTION
Followup of https://github.com/OpenRA/OpenRA/pull/12571#pullrequestreview-17810191.

The funsies part is that apparently TS works fine already with the default value because the firing offsets are properly set up and AS doesn't work due to my lack of effort of setting them up. Values like from -192 to -1536, while working, will allow units to fire up to cliffs, which is quite close to TS with the default value already (explosions happen even higher than WW ones I think).

I guess either the LaunchAngle of 62/75 are too high in TS either OpenRA as an engine is more susceptible to firingoffset height than the WW engines were.