### PR TITLE
Add engine plumbing to support externally developed mods.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -379,15 +379,11 @@ namespace OpenRA
 			ModData = new ModData(Mods[mod], Mods, true);
 			ExternalMods.Register(ModData.Manifest);
 
+			if (!ModData.LoadScreen.BeforeLoad())
+				return;
+
 			using (new PerfTimer("LoadMaps"))
 				ModData.MapCache.LoadMaps();
-
-			// Mod assets are missing!
-			if (!ModData.LoadScreen.RequiredContentIsInstalled())
-			{
-				InitializeMod("modchooser", new Arguments());
-				return;
-			}
 
 			ModData.InitializeLoaders(ModData.DefaultFileSystem);
 			Renderer.InitializeFonts(ModData);

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -314,7 +314,11 @@ namespace OpenRA
 
 			GlobalChat = new GlobalChat();
 
-			var modSearchPaths = new[] { Path.Combine(".", "mods"), Path.Combine("^", "mods") };
+			var modSearchArg = args.GetValue("Engine.ModSearchPaths", null);
+			var modSearchPaths = modSearchArg != null ?
+				FieldLoader.GetValue<string[]>("Engine.ModsPath", modSearchArg) :
+				new[] { Path.Combine(".", "mods"), Path.Combine("^", "mods") };
+
 			Mods = new InstalledMods(modSearchPaths, explicitModPaths);
 			Console.WriteLine("Internal mods:");
 			foreach (var mod in Mods)

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -249,10 +249,10 @@ namespace OpenRA
 			// Special case handling of Game.Mod argument: if it matches a real filesystem path
 			// then we use this to override the mod search path, and replace it with the mod id
 			var modArgument = args.GetValue("Game.Mod", null);
-			string customModPath = null;
+			var explicitModPaths = new string[0];
 			if (modArgument != null && (File.Exists(modArgument) || Directory.Exists(modArgument)))
 			{
-				customModPath = modArgument;
+				explicitModPaths = new[] { modArgument };
 				args.ReplaceValue("Game.Mod", Path.GetFileNameWithoutExtension(modArgument));
 			}
 
@@ -314,7 +314,8 @@ namespace OpenRA
 
 			GlobalChat = new GlobalChat();
 
-			Mods = new InstalledMods(customModPath);
+			var modSearchPaths = new[] { Path.Combine(".", "mods"), Path.Combine("^", "mods") };
+			Mods = new InstalledMods(modSearchPaths, explicitModPaths);
 			Console.WriteLine("Internal mods:");
 			foreach (var mod in Mods)
 				Console.WriteLine("\t{0}: {1} ({2})", mod.Key, mod.Value.Metadata.Title, mod.Value.Metadata.Version);

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -368,8 +368,8 @@ namespace OpenRA
 			ModData = null;
 
 			// Fall back to default if the mod doesn't exist or has missing prerequisites.
-			if (!IsModInstalled(mod))
-				mod = new GameSettings().Mod;
+			if (mod == null || !IsModInstalled(mod))
+				mod = args.GetValue("Engine.DefaultMod", "modchooser");
 
 			Console.WriteLine("Loading mod: {0}", mod);
 			Settings.Game.Mod = mod;

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -222,9 +222,19 @@ namespace OpenRA
 
 	public interface ILoadScreen : IDisposable
 	{
+		/// <summary>Initializes the loadscreen with yaml data from the LoadScreen block in mod.yaml.</summary>
 		void Init(ModData m, Dictionary<string, string> info);
+
+		/// <summary>Called at arbitrary times during mod load to rerender the loadscreen.</summary>
 		void Display();
-		bool RequiredContentIsInstalled();
+
+		/// <summary>
+		/// Called before loading the mod assets.
+		/// Returns false if mod loading should be aborted (e.g. switching to another mod instead).
+		/// </summary>
+		bool BeforeLoad();
+
+		/// <summary>Called when the engine expects to connect to a server/replay or load the shellmap.</summary>
 		void StartGame(Arguments args);
 	}
 }

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -153,8 +153,8 @@ namespace OpenRA
 
 	public class GameSettings
 	{
-		[Desc("Load a specific mod on startup. Shipped ones include: ra, cnc and d2k")]
-		public string Mod = "modchooser";
+		[Desc("Load a specific mod on startup.")]
+		public string Mod = null;
 		public string PreviousMod = "ra";
 
 		public string Platform = "Default";

--- a/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
@@ -109,12 +109,23 @@ namespace OpenRA.Mods.Common.LoadScreens
 			GC.SuppressFinalize(this);
 		}
 
-		public bool RequiredContentIsInstalled()
+		public bool BeforeLoad()
 		{
+			// If a ModContent section is defined then we need to make sure that the
+			// required content is installed or switch to the defined content installer.
+			if (!modData.Manifest.Contains<ModContent>())
+				return true;
+
 			var content = modData.Manifest.Get<ModContent>();
-			return content.Packages
+			var contentInstalled = content.Packages
 				.Where(p => p.Value.Required)
 				.All(p => p.Value.TestFiles.All(f => File.Exists(Platform.ResolvePath(f))));
+
+			if (contentInstalled)
+				return true;
+
+			Game.InitializeMod(content.ContentInstallerMod, new Arguments());
+			return false;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/LoadScreens/ModChooserLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/ModChooserLoadScreen.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.LoadScreens
 				sprite.Sheet.Dispose();
 		}
 
-		public bool RequiredContentIsInstalled()
+		public bool BeforeLoad()
 		{
 			return true;
 		}

--- a/OpenRA.Mods.Common/ModContent.cs
+++ b/OpenRA.Mods.Common/ModContent.cs
@@ -85,6 +85,7 @@ namespace OpenRA
 		public readonly string InstallPromptMessage;
 		public readonly string QuickDownload;
 		public readonly string HeaderMessage;
+		public readonly string ContentInstallerMod = "modchooser";
 
 		[FieldLoader.LoadUsing("LoadPackages")]
 		public readonly Dictionary<string, ModPackage> Packages = new Dictionary<string, ModPackage>();

--- a/OpenRA.Server/Program.cs
+++ b/OpenRA.Server/Program.cs
@@ -30,10 +30,10 @@ namespace OpenRA.Server
 			// Special case handling of Game.Mod argument: if it matches a real filesystem path
 			// then we use this to override the mod search path, and replace it with the mod id
 			var modArgument = arguments.GetValue("Game.Mod", null);
-			string customModPath = null;
+			var explicitModPaths = new string[0];
 			if (modArgument != null && (File.Exists(modArgument) || Directory.Exists(modArgument)))
 			{
-				customModPath = modArgument;
+				explicitModPaths = new[] { modArgument };
 				arguments.ReplaceValue("Game.Mod", Path.GetFileNameWithoutExtension(modArgument));
 			}
 
@@ -43,7 +43,8 @@ namespace OpenRA.Server
 			var settings = Game.Settings.Server;
 
 			var mod = Game.Settings.Game.Mod;
-			var mods = new InstalledMods(customModPath);
+			var modSearchPaths = new[] { Path.Combine(".", "mods"), Path.Combine("^", "mods") };
+			var mods = new InstalledMods(modSearchPaths, explicitModPaths);
 
 			// HACK: The engine code *still* assumes that Game.ModData is set
 			var modData = Game.ModData = new ModData(mods[mod], mods);

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -47,19 +47,20 @@ namespace OpenRA
 
 			if (args.Length == 0)
 			{
-				PrintUsage(new InstalledMods(null), null);
+				PrintUsage(new InstalledMods(new string[0], new string[0]), null);
 				return;
 			}
 
 			var modId = args[0];
-			string customModPath = null;
+			var explicitModPaths = new string[0];
 			if (File.Exists(modId) || Directory.Exists(modId))
 			{
-				customModPath = modId;
+				explicitModPaths = new[] { modId };
 				modId = Path.GetFileNameWithoutExtension(modId);
 			}
 
-			var mods = new InstalledMods(customModPath);
+			var modSearchPaths = new[] { Path.Combine(".", "mods"), Path.Combine("^", "mods") };
+			var mods = new InstalledMods(modSearchPaths, explicitModPaths);
 			if (!mods.Keys.Contains(modId))
 			{
 				PrintUsage(mods, null);


### PR DESCRIPTION
This implements the next step towards #11813 and #12554 by adding plumbing to support externally developed mods:

* The `Engine.DefaultMod` launch argument allows mods to override the hardcoded switch to the modchooser when a mod isn't available.
* The `ModContent` section in mod.yaml is no longer required, and can now customize the behaviour when assets aren't available.
* The `Engine.ModSearchPaths` launch argument allows mods to override where the engine looks for mods.

These are used by the new [pchote/OpenRAModTemplate](https://github.com/pchote/OpenRAModTemplate) repository (which i'll move to the OpenRA org once this has been merged) which sets up a development/runtime/(eventually) packaging environment for third party mods.

Depends on #12600.  The first real commit in this PR is 5fcebb2.