### PR TITLE
Replace "Debug" prefix with "Battlefield Control" for gameplay notifications.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Drawing;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -58,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void OnPlayerLost(Player player)
 		{
-			Game.Debug("{0} is defeated.", player.PlayerName);
+			Game.AddChatLine(Color.White, "Battlefield Control", player.PlayerName + " is defeated.");
 
 			foreach (var a in player.World.Actors.Where(a => a.Owner == player))
 				a.Kill(a);
@@ -72,7 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void OnPlayerWon(Player player)
 		{
-			Game.Debug("{0} is victorious.", player.PlayerName);
+			Game.AddChatLine(Color.White, "Battlefield Control", player.PlayerName + " is victorious.");
 
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -23,6 +23,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Description of the objective.")]
 		[Translate] public readonly string Objective = "Destroy all opposition!";
 
+		[Desc("Disable the win/loss messages and audio notifications?")]
+		public readonly bool SuppressNotifications = false;
+
 		public object Create(ActorInitializer init) { return new ConquestVictoryConditions(init.Self, this); }
 	}
 
@@ -59,11 +62,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void OnPlayerLost(Player player)
 		{
-			Game.AddChatLine(Color.White, "Battlefield Control", player.PlayerName + " is defeated.");
-
 			foreach (var a in player.World.Actors.Where(a => a.Owner == player))
 				a.Kill(a);
 
+			if (info.SuppressNotifications)
+				return;
+
+			Game.AddChatLine(Color.White, "Battlefield Control", player.PlayerName + " is defeated.");
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)
@@ -73,8 +78,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void OnPlayerWon(Player player)
 		{
-			Game.AddChatLine(Color.White, "Battlefield Control", player.PlayerName + " is victorious.");
+			if (info.SuppressNotifications)
+				return;
 
+			Game.AddChatLine(Color.White, "Battlefield Control", player.PlayerName + " is victorious.");
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -103,7 +104,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void OnPlayerLost(Player player)
 		{
-			Game.Debug("{0} is defeated.", player.PlayerName);
+			Game.AddChatLine(Color.White, "Battlefield Control", player.PlayerName + " is defeated.");
 
 			foreach (var a in player.World.Actors.Where(a => a.Owner == player))
 				a.Kill(a);
@@ -117,7 +118,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void OnPlayerWon(Player player)
 		{
-			Game.Debug("{0} is victorious.", player.PlayerName);
+			Game.AddChatLine(Color.White, "Battlefield Control", player.PlayerName + " is victorious.");
 
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -38,6 +38,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Description of the objective")]
 		[Translate] public readonly string Objective = "Hold all the strategic positions!";
 
+		[Desc("Disable the win/loss messages and audio notifications?")]
+		public readonly bool SuppressNotifications = false;
+
 		public object Create(ActorInitializer init) { return new StrategicVictoryConditions(init.Self, this); }
 	}
 
@@ -104,11 +107,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void OnPlayerLost(Player player)
 		{
-			Game.AddChatLine(Color.White, "Battlefield Control", player.PlayerName + " is defeated.");
-
 			foreach (var a in player.World.Actors.Where(a => a.Owner == player))
 				a.Kill(a);
 
+			if (info.SuppressNotifications)
+				return;
+
+			Game.AddChatLine(Color.White, "Battlefield Control", player.PlayerName + " is defeated.");
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)
@@ -118,8 +123,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void OnPlayerWon(Player player)
 		{
-			Game.AddChatLine(Color.White, "Battlefield Control", player.PlayerName + " is victorious.");
+			if (info.SuppressNotifications)
+				return;
 
+			Game.AddChatLine(Color.White, "Battlefield Control", player.PlayerName + " is victorious.");
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)

--- a/OpenRA.Mods.Common/Widgets/UnitCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/UnitCommandWidget.cs
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.Common.Widgets
 				return new Order("SetUnitStance", a, false) { ExtraData = (uint)nextStance };
 			});
 
-			Game.Debug("Unit stance set to: {0}".F(nextStance));
+			Game.AddChatLine(Color.White, "Battlefield Control", "Unit stance set to: {0}".F(nextStance));
 
 			return true;
 		}

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -369,12 +369,12 @@ namespace OpenRA.Mods.Common.Widgets
 			if (Game.Settings.Sound.Mute)
 			{
 				Game.Sound.MuteAudio();
-				Game.Debug("Audio muted");
+				Game.AddChatLine(Color.White, "Battlefield Control", "Audio muted");
 			}
 			else
 			{
 				Game.Sound.UnmuteAudio();
-				Game.Debug("Audio unmuted");
+				Game.AddChatLine(Color.White, "Battlefield Control", "Audio unmuted");
 			}
 
 			return true;

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -250,12 +250,12 @@ namespace OpenRA.Mods.Common.Widgets
 
 					// Check if selecting actors on the screen has selected new units
 					if (ownUnitsOnScreen.Count > World.Selection.Actors.Count())
-						Game.Debug("Selected across screen");
+						Game.AddChatLine(Color.White, "Battlefield Control", "Selected across screen");
 					else
 					{
 						// Select actors in the world that have highest selection priority
 						ownUnitsOnScreen = SelectActorsInWorld(World, null, player).SubsetWithHighestSelectionPriority().ToList();
-						Game.Debug("Selected across map");
+						Game.AddChatLine(Color.White, "Battlefield Control", "Selected across map");
 					}
 
 					World.Selection.Combine(World, ownUnitsOnScreen, false, false);
@@ -276,12 +276,12 @@ namespace OpenRA.Mods.Common.Widgets
 
 					// Check if selecting actors on the screen has selected new units
 					if (newSelection.Count > World.Selection.Actors.Count())
-						Game.Debug("Selected across screen");
+						Game.AddChatLine(Color.White, "Battlefield Control", "Selected across screen");
 					else
 					{
 						// Select actors in the world that have the same selection class as one of the already selected actors
 						newSelection = SelectActorsInWorld(World, selectedClasses, player).ToList();
-						Game.Debug("Selected across map");
+						Game.AddChatLine(Color.White, "Battlefield Control", "Selected across map");
 					}
 
 					World.Selection.Combine(World, newSelection, true, false);


### PR DESCRIPTION
This also introduces a `SuppressNotifications` flag that maps can use to disable the default messages if they want to display something different using Lua.