### PR TITLE
D2K - Some description work

### DIFF
--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -39,7 +39,7 @@ carryall.reinforce:
 	Buildable:
 		BuildDuration: 648
 		BuildDurationModifier: 40
-		Description: Large winged, planet-bound ship\n  Automatically lifts harvesters.
+		Description: Large winged, planet-bound ship\n  Automatically lifts harvesters from and to Spice.\n  Lifts vehicles to Repair Pads when ordered.
 
 carryall:
 	Inherits: carryall.reinforce
@@ -69,8 +69,6 @@ frigate:
 		PipCount: 10
 	FlyAwayOnIdle:
 	RejectsOrders:
-	Buildable:
-		Description: Supply spacecraft
 
 ornithopter:
 	Inherits: ^Plane

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -57,7 +57,7 @@ trooper:
 		Prerequisites: upgrade.barracks, ~techlevel.medium
 		BuildDuration: 73
 		BuildDurationModifier: 40
-		Description: Anti-tank/Anti-aircraft infantry\n  Strong vs Tanks, Aircraft\n  Weak vs Infantry, Artillery
+		Description: Anti-tank infantry\n  Strong vs Tanks\n  Weak vs Infantry, Artillery
 	Valued:
 		Cost: 90
 	Tooltip:
@@ -84,7 +84,7 @@ thumper:
 		Prerequisites: upgrade.barracks, ~techlevel.high
 		BuildDuration: 108
 		BuildDurationModifier: 40
-		Description: Attracts nearby worms\n  Unarmed
+		Description: Attracts nearby worms when deployed\n  Unarmed
 	Valued:
 		Cost: 200
 	Tooltip:
@@ -129,7 +129,7 @@ fremen:
 		Queue: Infantry
 		BuildPaletteOrder: 100
 		Prerequisites: ~disabled
-		Description: Elite sniper infantry unit\n  Strong vs Infantry\n  Weak vs Vehicles\n  Special Ability: Invisibility
+		Description: Elite infantry unit armed with assault rifles and rockets\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery\n  Special Ability: Invisibility
 	Mobile:
 		Speed: 43
 	Valued:
@@ -257,7 +257,7 @@ nsfremen:
 	Buildable:
 		BuildPaletteOrder: 105
 		Prerequisites: ~disabled
-		Description: Elite sniper infantry unit\n  Strong vs Infantry\n  Weak vs Vehicles
+		Description: Elite infantry unit armed with assault rifles and rockets\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery
 	RenderSprites:
 		Image: fremen
 	-Cloak:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -119,7 +119,7 @@ wind_trap:
 		BuildPaletteOrder: 20
 		BuildDuration: 180
 		BuildDurationModifier: 40
-		Description: Provides power for other structures
+		Description: Provides power for other structures.
 	Selectable:
 		Bounds: 64,64
 	Valued:
@@ -158,7 +158,7 @@ barracks:
 		BuildPaletteOrder: 50
 		BuildDuration: 231
 		BuildDurationModifier: 40
-		Description: Trains infantry
+		Description: Trains infantry.
 	Selectable:
 		Bounds: 64,64
 	Valued:
@@ -232,7 +232,7 @@ refinery:
 		BuildPaletteOrder: 30
 		BuildDuration: 540
 		BuildDurationModifier: 40
-		Description: Harvesters unload Spice here for processing
+		Description: Harvesters unload Spice here for processing.
 	Selectable:
 		Bounds: 96,64
 	Valued:
@@ -287,7 +287,7 @@ silo:
 		BuildPaletteOrder: 120
 		BuildDuration: 135
 		BuildDurationModifier: 40
-		Description: Stores excess harvested Spice
+		Description: Stores excess harvested Spice.
 	Selectable:
 		Bounds: 32,32
 	Valued:
@@ -334,7 +334,7 @@ light_factory:
 		BuildPaletteOrder: 60
 		BuildDuration: 277
 		BuildDurationModifier: 40
-		Description: Produces light vehicles
+		Description: Produces light vehicles.
 	Selectable:
 		Bounds: 96,64
 	Valued:
@@ -412,7 +412,7 @@ heavy_factory:
 		BuildPaletteOrder: 90
 		BuildDuration: 648
 		BuildDurationModifier: 40
-		Description: Produces heavy vehicles
+		Description: Produces heavy vehicles.
 	Selectable:
 		Bounds: 96,68,0,12
 	Valued:
@@ -497,7 +497,7 @@ outpost:
 		BuildPaletteOrder: 80
 		BuildDuration: 270
 		BuildDurationModifier: 40
-		Description: Provides a radar map of the battlefield\n  Requires power to operate
+		Description: Provides a radar map of the battlefield.\n  Requires power to operate.
 	Selectable:
 		Bounds: 96,72,0,-8
 	Valued:
@@ -542,7 +542,7 @@ starport:
 		BuildPaletteOrder: 70
 		BuildDuration: 540
 		BuildDurationModifier: 40
-		Description: Dropzone for quick reinforcements, at a price.\n  Requires power to operate
+		Description: Dropzone for quick reinforcements, at a price.
 	Valued:
 		Cost: 1500
 	Building:
@@ -661,7 +661,7 @@ medium_gun_turret:
 		BuildPaletteOrder: 100
 		BuildDuration: 231
 		BuildDurationModifier: 40
-		Description: Defensive structure\n  Strong vs Tanks\n  Weak vs Infantry, Aircraft
+		Description: Defensive structure.\n  Strong vs Tanks\n  Weak vs Infantry, Aircraft
 	Valued:
 		Cost: 550
 	Tooltip:
@@ -703,7 +703,7 @@ large_gun_turret:
 		BuildPaletteOrder: 110
 		BuildDuration: 270
 		BuildDurationModifier: 40
-		Description: Defensive structure\n  Strong vs Infantry, Aircraft\n  Weak vs Tanks\n\n  Requires power to operate
+		Description: Defensive structure.\n  Strong vs Infantry, Aircraft\n  Weak vs Tanks\n\n  Requires power to operate.
 	Valued:
 		Cost: 750
 	Tooltip:
@@ -748,7 +748,7 @@ repair_pad:
 		BuildPaletteOrder: 150
 		BuildDuration: 324
 		BuildDurationModifier: 40
-		Description: Repairs vehicles\n Allows construction of MCVs
+		Description: Repairs vehicles.\n Allows construction of MCVs
 	Valued:
 		Cost: 800
 	Tooltip:
@@ -795,7 +795,7 @@ high_tech_factory:
 		BuildPaletteOrder: 140
 		BuildDuration: 405
 		BuildDurationModifier: 40
-		Description: Unlocks advanced technology
+		Description: Unlocks advanced technology.
 	Selectable:
 		Bounds: 96,68,0,12
 	Valued:
@@ -863,7 +863,7 @@ research_centre:
 		BuildPaletteOrder: 160
 		BuildDuration: 270
 		BuildDurationModifier: 40
-		Description: Unlocks experimental tanks
+		Description: Unlocks advanced tanks.
 	Selectable:
 		Bounds: 96,64,0,16
 	Valued:
@@ -903,7 +903,7 @@ palace:
 		BuildPaletteOrder: 170
 		BuildDuration: 810
 		BuildDurationModifier: 40
-		Description: Unlocks elite infantry
+		Description: Unlocks elite infantry and weapons.
 	Selectable:
 		Bounds: 96,96
 	Valued:
@@ -958,7 +958,7 @@ palace:
 		ActivationSequence:
 	ProduceActorPower@fremen:
 		Description: Recruit Fremen
-		LongDesc: Elite sniper infantry unit                       \n  Strong vs Infantry\n  Weak vs Vehicles\n  Special Ability: Invisibility
+		LongDesc: Elite infantry unit armed with assault rifles and rockets\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery\n  Special Ability: Invisibility
 		Icon: fremen
 		Prerequisites: ~techlevel.superweapons, ~palace.fremen
 		Actors: fremen, fremen
@@ -969,7 +969,7 @@ palace:
 		OrderName: ProduceActorPower.Fremen
 	ProduceActorPower@saboteur:
 		Description: Recruit Saboteur
-		LongDesc: Sneaky infantry, armed with explosives           \n  Strong vs Buildings\n  Weak vs Everything\n  Special Ability: destroy buildings
+		LongDesc: Sneaky infantry, armed with explosives\n  Strong vs Buildings\n  Weak vs Everything\n  Special Ability: destroy buildings
 		Icon: saboteur
 		Prerequisites: ~techlevel.superweapons, ~palace.saboteur
 		Actors: saboteur

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -104,7 +104,7 @@ trike:
 		Prerequisites: ~light.regulartrikes
 		BuildDuration: 194
 		BuildDurationModifier: 40
-		Description: Fast scout\n Strong vs Infantry\n Weak vs Tanks, Aircraft
+		Description: Fast scout\n  Strong vs Infantry\n  Weak vs Tanks
 	Valued:
 		Cost: 300
 	Tooltip:
@@ -144,7 +144,7 @@ quad:
 		BuildPaletteOrder: 20
 		BuildDuration: 277
 		BuildDurationModifier: 40
-		Description: Missile Scout\n Strong vs Vehicles\n  Weak vs Infantry
+		Description: Missile Scout\n  Strong vs Vehicles\n  Weak vs Infantry
 	Valued:
 		Cost: 400
 	Tooltip:
@@ -179,7 +179,7 @@ siege_tank:
 		BuildPaletteOrder: 50
 		BuildDuration: 324
 		BuildDurationModifier: 40
-		Description: Siege Artillery\n  Strong vs Infantry, Buildings\n  Weak vs Tanks, Aircraft
+		Description: Siege Artillery\n  Strong vs Infantry, Buildings\n  Weak vs Tanks
 	Valued:
 		Cost: 700
 	Tooltip:
@@ -263,7 +263,7 @@ sonic_tank:
 		Prerequisites: ~heavy.atreides, research_centre, ~techlevel.high
 		BuildDuration: 486
 		BuildDurationModifier: 40
-		Description: Fires sonic shocks\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery, Aircraft
+		Description: Fires sonic shocks\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -300,7 +300,7 @@ devastator:
 		Prerequisites: ~heavy.harkonnen, research_centre, ~techlevel.high
 		BuildDuration: 540
 		BuildDurationModifier: 40
-		Description: Super Heavy Tank\n  Strong vs Tanks\n  Weak vs Artillery, Aircraft
+		Description: Super Heavy Tank\n  Strong vs Tanks\n  Weak vs Artillery
 	Valued:
 		Cost: 1050
 	Tooltip:
@@ -345,7 +345,7 @@ raider:
 		Prerequisites: ~light.ordos
 		BuildDuration: 194
 		BuildDurationModifier: 40
-		Description: Improved Scout\n Strong vs Infantry, Light Vehicles
+		Description: Improved Scout\n  Strong vs Infantry, Light Vehicles\n  Weak vs Tanks
 	Valued:
 		Cost: 350
 	Tooltip:
@@ -382,7 +382,7 @@ stealth_raider:
 		BuildPaletteOrder: 30
 		BuildDuration: 194	## Copied from Raider, not included in conversion. Both have same "BuildSpeed" in TibEd
 		BuildDurationModifier: 40
-		Description: Invisible Raider Trike\n Strong vs Infantry, Light Vehicles
+		Description: Invisible Raider Trike\n  Strong vs Infantry, Light Vehicles\n  Weak vs Tanks
 	Valued:
 		Cost: 400
 	Tooltip:
@@ -442,7 +442,7 @@ deviator:
 		BuildPaletteOrder: 40
 		BuildDuration: 373
 		BuildDurationModifier: 40
-		Description: Main Battle Tank\n  Strong vs Tanks\n  Weak vs Infantry, Aircraft\n \n  Atreides:      +Range\n  Harkonnen:  +Health\n  Ordos:          +Speed
+		Description: Main Battle Tank\n  Strong vs Tanks\n  Weak vs Infantry
 	Valued:
 		Cost: 700
 	Tooltip:


### PR DESCRIPTION
Added about that Carryalls carry vehicles to repair pad to Carryall's Desc.

Removed unnecessary/wrong `Aircraft` from weak vs and strong vss

Added `when deployed` to thumper's desc.

Changed Freman's Desc, "armed with assault rifles and rockets" is a term from [Description of original game](http://www.mediafire.com/view/69sbi6wozu2kx82/Freman.png#).

Added dots after strucuture descs.

Added `Weak vs Tanks` to desc of Raider and Stealth Raider.

Fixed Combat Tank desc's Side Specific info. It is no longer true.

Removed `Requires power to operate` from Starport.

Removed Frigate's desc. It is unneseccary as it is unbuildable.