### PR TITLE
D2K - Remove PipType from Engineer and Thumper

### DIFF
--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -39,8 +39,6 @@ engineer:
 		Range: 2c768
 	Mobile:
 		Speed: 31
-	Passenger:
-		PipType: Yellow
 	EngineerRepair:
 	Captures:
 		CaptureTypes: building, husk
@@ -116,8 +114,6 @@ thumper:
 		Intensity: 1000
 		Falloff: 0, 0, 0, 100, 100, 100, 25, 11, 6, 4, 3, 2, 1, 0
 		RequiresCondition: deployed
-	Passenger:
-		PipType: Blue
 	Voiced:
 		VoiceSet: EngineerVoice
 


### PR DESCRIPTION
D2K only have green and empty pips, no blue, no yellow. Well there is no transport units either but they would cause a crash if they was entered one.