### PR TITLE
D2K - Change Thumper's Voice to normal Inf. Voice

### DIFF
--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -114,8 +114,6 @@ thumper:
 		Intensity: 1000
 		Falloff: 0, 0, 0, 100, 100, 100, 25, 11, 6, 4, 3, 2, 1, 0
 		RequiresCondition: deployed
-	Voiced:
-		VoiceSet: EngineerVoice
 
 fremen:
 	Inherits: ^Infantry


### PR DESCRIPTION
They don't use Engineer Voice in original game.