### PR TITLE
Support skipping stacked condition levels.

### DIFF
--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -455,7 +455,9 @@ namespace OpenRA
 				if (value == null)
 					return Array.CreateInstance(fieldType.GetElementType(), 0);
 
-				var parts = value.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+				var options = field != null && field.HasAttribute<AllowEmptyEntriesAttribute>() ?
+					StringSplitOptions.None : StringSplitOptions.RemoveEmptyEntries;
+				var parts = value.Split(new char[] { ',' }, options);
 
 				var ret = Array.CreateInstance(fieldType.GetElementType(), parts.Length);
 				for (var i = 0; i < parts.Length; i++)
@@ -680,6 +682,13 @@ namespace OpenRA
 		}
 
 		[AttributeUsage(AttributeTargets.Field)]
+		public sealed class AllowEmptyEntriesAttribute : SerializeAttribute
+		{
+			public AllowEmptyEntriesAttribute()
+				: base(allowEmptyEntries: true) { }
+		}
+
+		[AttributeUsage(AttributeTargets.Field)]
 		public sealed class LoadUsingAttribute : SerializeAttribute
 		{
 			public LoadUsingAttribute(string loader, bool required = false)
@@ -702,11 +711,13 @@ namespace OpenRA
 			public bool FromYamlKey;
 			public bool DictionaryFromYamlKey;
 			public bool Required;
+			public bool AllowEmptyEntries;
 
-			public SerializeAttribute(bool serialize = true, bool required = false)
+			public SerializeAttribute(bool serialize = true, bool required = false, bool allowEmptyEntries = false)
 			{
 				Serialize = serialize;
 				Required = required;
+				AllowEmptyEntries = allowEmptyEntries;
 			}
 
 			internal Func<MiniYaml, object> GetLoader(Type type)

--- a/OpenRA.Mods.Common/Traits/Conditions/ConditionManager.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ConditionManager.cs
@@ -153,10 +153,18 @@ namespace OpenRA.Mods.Common.Traits
 				var target = (conditionState.Tokens.Count - 1).Clamp(0, sc.Length);
 				var st = stackedTokens[condition];
 				for (var i = st.Count; i < target; i++)
-					st.Push(GrantCondition(self, sc[i]));
+				{
+					// Empty strings are used to skip unwanted levels
+					var t = !string.IsNullOrEmpty(sc[i]) ? GrantCondition(self, sc[i]) : InvalidConditionToken;
+					st.Push(t);
+				}
 
 				for (var i = st.Count; i > target; i--)
-					RevokeCondition(self, st.Pop());
+				{
+					var t = st.Pop();
+					if (t != InvalidConditionToken)
+						RevokeCondition(self, t);
+				}
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Conditions/StackedCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/StackedCondition.cs
@@ -22,9 +22,11 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Condition = null;
 
 		[FieldLoader.Require]
+		[FieldLoader.AllowEmptyEntries]
 		[GrantedConditionReference]
 		[Desc("Conditions to grant when the monitored condition is granted multiple times.",
-			"The first entry is activated at 2x grants, second entry at 3x grants, and so on.")]
+			"The first entry is activated at 2x grants, second entry at 3x grants, and so on.",
+			"Use empty entries to skip levels.")]
 		public readonly string[] StackedConditions = { };
 	}
 


### PR DESCRIPTION
Testcase is to replace the RA `^IronCurtainable` default and use the iron curtain multiple times on an actor.  The second level will lighten the actor, and the fourth level will darken it.

```yaml
^IronCurtainable:
	UpgradeOverlay@IRONCURTAIN:
		RequiresCondition: invulnerability && !invulnerability2
	UpgradeOverlay@IRONCURTAIN2:
		Palette: highlight
		RequiresCondition: invulnerability2 && !invulnerability4
	UpgradeOverlay@IRONCURTAIN4:
		Palette: shadow
		RequiresCondition: invulnerability4
	DamageMultiplier@IRONCURTAIN:
		RequiresCondition: invulnerability
		Modifier: 0
	TimedConditionBar:
		Condition: invulnerability
	ExternalConditions@INVULNERABILITY:
		Conditions: invulnerability
	StackedCondition@INVULNERABILITY:
		Condition: invulnerability
		StackedConditions: invulnerability2, , invulnerability4
```
