### PR TITLE
Fix and improve AmbientSound trait

### DIFF
--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -133,8 +133,8 @@ namespace OpenRA
 		public ISound Play(SoundType type, string name, WPos pos, float volumeModifier) { return Play(type, null, name, false, pos, volumeModifier); }
 		public ISound PlayToPlayer(SoundType type, Player player, string name) { return Play(type, player, name, true, WPos.Zero, 1f); }
 		public ISound PlayToPlayer(SoundType type, Player player, string name, WPos pos) { return Play(type, player, name, false, pos, 1f); }
-		public ISound PlayLooped(SoundType type, string name) { return PlayLooped(type, name, WPos.Zero); }
-		public ISound PlayLooped(SoundType type, string name, WPos pos) { return Play(type, null, name, true, pos, 1f, true); }
+		public ISound PlayLooped(SoundType type, string name) { return Play(type, null, name, true, WPos.Zero, 1f, true); }
+		public ISound PlayLooped(SoundType type, string name, WPos pos) { return Play(type, null, name, false, pos, 1f, true); }
 
 		public void PlayVideo(byte[] raw, int channels, int sampleBits, int sampleRate)
 		{

--- a/OpenRA.Game/Sound/SoundDevice.cs
+++ b/OpenRA.Game/Sound/SoundDevice.cs
@@ -46,5 +46,6 @@ namespace OpenRA
 		float Volume { get; set; }
 		float SeekPosition { get; }
 		bool Playing { get; }
+		void SetPosition(WPos pos);
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
@@ -19,56 +19,90 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		[FieldLoader.Require]
 		public readonly string SoundFile = null;
 
-		[Desc("Interval between playing the sound (in ticks).")]
-		public readonly int Interval = 0;
+		[Desc("Initial delay (in ticks) before playing the sound for the first time.",
+			"Two values indicate a random delay range.")]
+		public readonly int[] Delay = { 0 };
+
+		[Desc("Interval between playing the sound (in ticks).",
+			"Two values indicate a random delay range.")]
+		public readonly int[] Interval = { 0 };
 
 		public override object Create(ActorInitializer init) { return new AmbientSound(init.Self, this); }
 	}
 
-	class AmbientSound : ConditionalTrait<AmbientSoundInfo>, ITick
+	class AmbientSound : ConditionalTrait<AmbientSoundInfo>, ITick, INotifyRemovedFromWorld
 	{
+		readonly bool loop;
 		ISound currentSound;
-		bool wasDisabled = true;
-		int interval;
+		WPos cachedPosition;
+		int delay;
 
 		public AmbientSound(Actor self, AmbientSoundInfo info)
 			: base(info)
 		{
-			interval = info.Interval;
+			delay = RandomDelay(self.World, info.Delay);
+			loop = Info.Interval.Length == 0 || (Info.Interval.Length == 1 && Info.Interval[0] == 0);
 		}
 
-		public void Tick(Actor self)
+		void ITick.Tick(Actor self)
 		{
 			if (IsTraitDisabled)
-			{
-				Game.Sound.StopSound(currentSound);
-				currentSound = null;
-				wasDisabled = true;
 				return;
+
+			var pos = self.CenterPosition;
+			if (currentSound != null && pos != cachedPosition)
+			{
+				currentSound.SetPosition(pos);
+				cachedPosition = pos;
 			}
 
-			if (wasDisabled && Info.Interval <= 0)
+			if (delay < 0)
+				return;
+
+			if (--delay < 0)
 			{
-				if (self.OccupiesSpace != null)
-					currentSound = Game.Sound.PlayLooped(SoundType.World, Info.SoundFile, self.CenterPosition);
-				else
-					currentSound = Game.Sound.PlayLooped(SoundType.World, Info.SoundFile);
+				StartSound(self);
+				if (!loop)
+					delay = RandomDelay(self.World, Info.Interval);
 			}
-
-			wasDisabled = false;
-
-			if (Info.Interval <= 0)
-				return;
-
-			if (interval-- > 0)
-				return;
-
-			interval = Info.Interval;
-
-			if (self.OccupiesSpace != null)
-				Game.Sound.Play(SoundType.World, Info.SoundFile, self.CenterPosition);
-			else
-				Game.Sound.Play(SoundType.World, Info.SoundFile);
 		}
+
+		void StartSound(Actor self)
+		{
+			if (self.OccupiesSpace != null)
+			{
+				cachedPosition = self.CenterPosition;
+				currentSound = loop ? Game.Sound.PlayLooped(SoundType.World, Info.SoundFile, cachedPosition) :
+					Game.Sound.Play(SoundType.World, Info.SoundFile, self.CenterPosition);
+			}
+			else
+				currentSound = loop ? Game.Sound.PlayLooped(SoundType.World, Info.SoundFile) :
+					Game.Sound.Play(SoundType.World, Info.SoundFile);
+		}
+
+		void StopSound()
+		{
+			if (currentSound == null)
+				return;
+
+			Game.Sound.StopSound(currentSound);
+			currentSound = null;
+		}
+
+		static int RandomDelay(World world, int[] range)
+		{
+			if (range.Length == 0)
+				return 0;
+
+			if (range.Length == 1)
+				return range[0];
+
+			return world.SharedRandom.Next(range[0], range[1]);
+		}
+
+		protected override void TraitEnabled(Actor self) { delay = RandomDelay(self.World, Info.Delay); }
+		protected override void TraitDisabled(Actor self) { StopSound(); }
+
+		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self) { StopSound(); }
 	}
 }

--- a/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
+++ b/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
@@ -405,5 +405,10 @@ namespace OpenRA.Platforms.Default
 				return state == AL10.AL_PLAYING;
 			}
 		}
+
+		public void SetPosition(WPos pos)
+		{
+			AL10.alSource3f(Source, AL10.AL_POSITION, pos.X, pos.Y, pos.Z);
+		}
 	}
 }


### PR DESCRIPTION
This fixes the following:
* Sound position is wrong for looped playback.
* Sound doesn't follow the actor when they move.
* Sound doesn't stop when the actor is removed from the world.
* Sound waits for an `Info.Interval` before playing for the first time.
* Code style.

It also adds support for random delays and intervals.

For a testcase, add the following to the ra mig or yak:
```yaml
AmbientSound:
	RequiresCondition: airborne
	SoundFile: dogw3px.aud
	Delay: 100
	Interval: 10, 50
```

Planes should randomly woof while airborne.