### PR TITLE
Fix the LocalOffset of the AA Gun

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -473,7 +473,7 @@ AGUN:
 	WithTurretedSpriteBody:
 	Armament:
 		Weapon: ZSU-23
-		LocalOffset: 432,150,-30, 432,-150,-30
+		LocalOffset: 520,100,450, 520,-150,450
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleOverlay:

--- a/mods/ra/sequences/structures.yaml
+++ b/mods/ra/sequences/structures.yaml
@@ -408,7 +408,6 @@ agun:
 	muzzle: gunfire2
 		Start: 1
 		Length: 4
-		Offset: 0,-13
 	bib: mbAGUN
 		Length: *
 		UseTilesetExtension: true


### PR DESCRIPTION
On current bleed the AA Gun does no damage, because of the negative offset and [this](https://github.com/OpenRA/OpenRA/pull/12571/files#diff-4c577bf984806db0c357e453be598a22R230) check.
I changed the offsets to:
![aagunoffset](https://cloud.githubusercontent.com/assets/7704140/22611655/1442edd6-ea6c-11e6-931a-2ec81e0854f6.png)
