### PR TITLE
Fix the ProneOffsets of TakeCover

### DIFF
--- a/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Damage modifiers for each damage type (defined on the warheads) while the unit is prone.")]
 		public readonly Dictionary<string, int> DamageModifiers = new Dictionary<string, int>();
 
-		public readonly WVec ProneOffset = new WVec(85, 0, -171);
+		public readonly WVec ProneOffset = new WVec(500, 0, 0);
 
 		[SequenceReference(null, true)] public readonly string ProneSequencePrefix = "prone-";
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -342,6 +342,7 @@
 		DamageModifiers:
 			Prone50Percent: 50
 		DamageTriggers: TriggerProne
+		ProneOffset: 400,0,0
 	WithInfantryBody:
 		IdleSequences: idle1, idle2
 		StandSequences: stand, stand2

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -40,6 +40,8 @@ E2:
 		Weapon: Grenade
 		LocalOffset: 0,0,427
 		FireDelay: 15
+	TakeCover:
+		ProneOffset: 300,0,-227
 	AttackFrontal:
 	WithInfantryBody:
 		DefaultAttackSequence: throw
@@ -69,6 +71,8 @@ E3:
 		Weapon: Rockets
 		LocalOffset: 256,43,341
 		FireDelay: 5
+	TakeCover:
+		ProneOffset: 180,0,-200
 	AttackFrontal:
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
@@ -94,6 +98,8 @@ E4:
 		LocalOffset: 341,0,256
 		FireDelay: 3
 		MuzzleSequence: muzzle
+	TakeCover:
+		ProneOffset: 190,0,-198
 	AttackFrontal:
 	WithMuzzleOverlay:
 	WithInfantryBody:
@@ -125,6 +131,8 @@ E5:
 		LocalOffset: 341,0,256
 		FireDelay: 3
 		MuzzleSequence: muzzle
+	TakeCover:
+		ProneOffset: 190,0,-190
 	AttackFrontal:
 	WithMuzzleOverlay:
 	-DamagedByTerrain:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -261,6 +261,7 @@
 		DamageModifiers:
 			Prone50Percent: 50
 		DamageTriggers: TriggerProne
+		ProneOffset: 300,0,0
 	WithDeathAnimation:
 		DeathTypes:
 			ExplosionDeath: 1

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -69,6 +69,8 @@ trooper:
 	Armament:
 		Weapon: Bazooka
 		LocalOffset: 128,0,256
+	TakeCover:
+		ProneOffset: 324,0,-204
 	AttackFrontal:
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
@@ -175,6 +177,8 @@ grenadier:
 		Weapon: grenade
 		LocalOffset: 192,0,224
 		FireDelay: 3
+	TakeCover:
+		ProneOffset: 96,100,-64
 	AttackFrontal:
 	WithInfantryBody:
 		DefaultAttackSequence: throw

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -96,6 +96,8 @@ E2:
 		Name: garrisoned
 		Weapon: Grenade
 		FireDelay: 15
+	TakeCover:
+		ProneOffset: 256,64,-331
 	AttackFrontal:
 	WithInfantryBody:
 		DefaultAttackSequence: throw
@@ -129,6 +131,8 @@ E3:
 	Armament@GARRISONED:
 		Name: garrisoned
 		Weapon: Dragon
+	TakeCover:
+		ProneOffset: 384,0,-395
 	AttackFrontal:
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
@@ -153,11 +157,13 @@ E4:
 		HP: 40
 	Armament@PRIMARY:
 		Weapon: Flamer
-		LocalOffset: 427,0,341
+		LocalOffset: 700,0,500
 		FireDelay: 8
 	Armament@GARRISONED:
 		Name: garrisoned
 		Weapon: Flamer
+	TakeCover:
+		ProneOffset: 160,0,-288
 	AttackFrontal:
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
@@ -507,6 +513,8 @@ SHOK:
 	Armament@GARRISONED:
 		Name: garrisoned
 		Weapon: PortaTesla
+	TakeCover:
+		ProneOffset: 227,0,-245
 	AttackFrontal:
 		Voice: Attack
 	AttackMove:

--- a/mods/ts/rules/civilian-infantry.yaml
+++ b/mods/ts/rules/civilian-infantry.yaml
@@ -14,7 +14,9 @@ WEEDGUY:
 		CrushSound: squishy2.aud
 	Armament:
 		Weapon: FireballLauncher
-		LocalOffset: 85,0,384
+		LocalOffset: 224,0,320
+	TakeCover:
+		ProneOffset: 128,0,-320
 	AttackFrontal:
 		Voice: Attack
 	-SpawnActorOnDeath@FLAMEGUY:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -419,6 +419,7 @@
 			Prone100Percent: 100
 			Prone350Percent: 350
 		DamageTriggers: TriggerProne
+		ProneOffset: 300,0,0
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -18,6 +18,8 @@ E2:
 		Weapon: Grenade
 		LocalOffset: 0,0,555
 		FireDelay: 5
+	TakeCover:
+		ProneOffset: 160,128,-555
 	AttackFrontal:
 		Voice: Attack
 	WithInfantryBody:
@@ -192,6 +194,8 @@ GHOST:
 	Armament:
 		Weapon: LtRail
 		LocalOffset: 85,0,384
+	TakeCover:
+		ProneOffset: 256,32,-384
 	Crushable:
 		CrushSound: squishy2.aud
 	AttackFrontal:

--- a/mods/ts/rules/nod-infantry.yaml
+++ b/mods/ts/rules/nod-infantry.yaml
@@ -19,6 +19,8 @@ E3:
 	Armament@PRIMARY:
 		Weapon: Bazooka
 		LocalOffset: 252,0,684
+	TakeCover:
+		ProneOffset: 52,64,-652
 	AttackFrontal:
 		Voice: Attack
 	WithInfantryBody:

--- a/mods/ts/sequences/infantry.yaml
+++ b/mods/ts/sequences/infantry.yaml
@@ -423,21 +423,22 @@ weedguy:
 		Facings: 8
 		ShadowStart: 258
 	prone-attack:
-		Start: 56
+		Start: 64
 		Facings: 8
-		ShadowStart: 258
+		Stride: 6
+		ShadowStart: 288
 	standup:
 		Start: 112
 		Length: 2
 		Facings: 8
 		ShadowStart: 314
 	prone-run:
-		Start: 86
+		Start: 64
 		Length: 6
 		Facings: 8
 		ShadowStart: 288
 	prone-stand:
-		Start: 86
+		Start: 64
 		Facings: 8
 		Stride: 6
 		ShadowStart: 288


### PR DESCRIPTION
On current bleed the bullets of prone infantry are instantly blocked. Also see #12683.