### PR TITLE
[RA] GAP effect entry values.

### DIFF
--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -98,6 +98,10 @@ MIG:
 	RevealsShroud:
 		Range: 12c0
 		Type: GroundPosition
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 10c0
+		Type: GroundPosition
 	Armament:
 		Weapon: Maverick
 		LocalOffset: 0,-640,0, 0,640,0
@@ -152,6 +156,10 @@ YAK:
 		Type: Light
 	RevealsShroud:
 		Range: 10c0
+		Type: GroundPosition
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 8c0
 		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: ChainGun.Yak
@@ -212,6 +220,10 @@ TRAN:
 	RevealsShroud:
 		Range: 10c0
 		Type: GroundPosition
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 8c0
+		Type: GroundPosition
 	Aircraft:
 		InitialFacing: 224
 		TurnSpeed: 5
@@ -261,6 +273,10 @@ HELI:
 		Type: Light
 	RevealsShroud:
 		Range: 12c0
+		Type: GroundPosition
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 10c0
 		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: HellfireAA
@@ -315,6 +331,10 @@ HIND:
 		Type: Light
 	RevealsShroud:
 		Range: 10c0
+		Type: GroundPosition
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 8c0
 		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: ChainGun

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -19,6 +19,9 @@ SS:
 		Speed: 71
 	RevealsShroud:
 		Range: 6c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 5c0
 	Targetable:
 		TargetTypes: Ground, Water, Repair
 		RequiresCondition: !underwater
@@ -73,6 +76,9 @@ MSUB:
 		Speed: 42
 	RevealsShroud:
 		Range: 6c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 5c0
 	Targetable:
 		TargetTypes: Ground, Water, Repair
 		RequiresCondition: !underwater
@@ -131,6 +137,9 @@ DD:
 		Speed: 85
 	RevealsShroud:
 		Range: 6c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 5c0
 	Turreted:
 		TurnSpeed: 7
 		Offset: 341,0,128
@@ -177,6 +186,9 @@ CA:
 		Speed: 42
 	RevealsShroud:
 		Range: 7c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 5c0
 	Turreted@PRIMARY:
 		Turret: primary
 		Offset: -864,0,128
@@ -233,6 +245,9 @@ LST:
 		RequiresCondition: !notmobile
 	RevealsShroud:
 		Range: 6c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 5c0
 	SelectionDecorations:
 		VisualBounds: 36,36
 	WithLandingCraftAnimation:
@@ -266,6 +281,9 @@ PT:
 		Speed: 128
 	RevealsShroud:
 		Range: 7c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 5c0
 	Turreted:
 		TurnSpeed: 7
 		Offset: 512,0,0

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -75,6 +75,9 @@ GAP:
 		Type: Wood
 	RevealsShroud:
 		Range: 6c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 5c0
 	Bib:
 		HasMinibib: Yes
 	CreatesShroud:
@@ -304,6 +307,9 @@ IRON:
 		Type: Wood
 	RevealsShroud:
 		Range: 10c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 6c0
 	Bib:
 		HasMinibib: Yes
 	GrantExternalConditionPower@IRONCURTAIN:
@@ -351,6 +357,9 @@ PDOX:
 		Type: Wood
 	RevealsShroud:
 		Range: 10c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 6c0
 	Bib:
 		HasMinibib: Yes
 	ProvidesPrerequisite@germany:
@@ -422,6 +431,9 @@ TSLA:
 		Type: Heavy
 	RevealsShroud:
 		Range: 8c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 6c0
 	Bib:
 		HasMinibib: Yes
 	WithChargeAnimation:
@@ -464,6 +476,9 @@ AGUN:
 		Type: Heavy
 	RevealsShroud:
 		Range: 6c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 5c0
 	Bib:
 		HasMinibib: Yes
 	Turreted:
@@ -513,6 +528,9 @@ DOME:
 		Type: Wood
 	RevealsShroud:
 		Range: 10c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 6c0
 	Bib:
 	ProvidesRadar:
 		RequiresCondition: !jammed && !disabled
@@ -548,6 +566,9 @@ PBOX:
 		Type: Heavy
 	RevealsShroud:
 		Range: 6c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 5c0
 	Bib:
 		HasMinibib: Yes
 	Turreted:
@@ -593,6 +614,9 @@ HBOX:
 		Type: Heavy
 	RevealsShroud:
 		Range: 6c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 5c0
 	Cloak:
 		InitialDelay: 125
 		CloakDelay: 60
@@ -639,6 +663,9 @@ GUN:
 		Type: Heavy
 	RevealsShroud:
 		Range: 7c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 5c0
 	Bib:
 		HasMinibib: Yes
 	Turreted:
@@ -677,6 +704,9 @@ FTUR:
 		Type: Heavy
 	RevealsShroud:
 		Range: 6c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 5c0
 	Bib:
 		HasMinibib: Yes
 	Turreted:
@@ -764,6 +794,9 @@ ATEK:
 		Type: Wood
 	RevealsShroud:
 		Range: 10c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 6c0
 	Bib:
 	GpsPower:
 		Icon: gps
@@ -925,6 +958,9 @@ FACT:
 		Type: Wood
 	RevealsShroud:
 		Range: 5c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	Bib:
 	Production:
 		Produces: Building,Defense
@@ -982,6 +1018,9 @@ PROC:
 		Type: Wood
 	RevealsShroud:
 		Range: 6c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	Bib:
 	Refinery:
 		DockAngle: 64
@@ -1060,6 +1099,9 @@ HPAD:
 		Type: Wood
 	RevealsShroud:
 		Range: 5c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	Bib:
 	Exit@1:
 		SpawnOffset: 0,-256,0
@@ -1139,6 +1181,9 @@ AFLD:
 		Type: Wood
 	RevealsShroud:
 		Range: 7c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	Exit@1:
 		ExitCell: 1,1
 		Facing: 192
@@ -1357,6 +1402,9 @@ BARR:
 		Type: Wood
 	RevealsShroud:
 		Range: 5c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	Bib:
 	RallyPoint:
 	Exit@1:
@@ -1477,6 +1525,9 @@ TENT:
 		Type: Wood
 	RevealsShroud:
 		Range: 5c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	Bib:
 	RallyPoint:
 	Exit@1:
@@ -1561,6 +1612,9 @@ FIX:
 		Type: Wood
 	RevealsShroud:
 		Range: 5c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	Bib:
 		HasMinibib: Yes
 	Reservable:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -17,6 +17,9 @@ V2RL:
 		Speed: 85
 	RevealsShroud:
 		Range: 5c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	Armament:
 		Weapon: SCUD
 	AttackFrontal:
@@ -51,6 +54,9 @@ V2RL:
 		Crushes: wall, mine, crate, infantry
 	RevealsShroud:
 		Range: 5c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	Turreted:
 		TurnSpeed: 7
 	Armament:
@@ -88,6 +94,9 @@ V2RL:
 		Crushes: wall, mine, crate, infantry
 	RevealsShroud:
 		Range: 5c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	Turreted:
 		TurnSpeed: 5
 	Armament:
@@ -127,6 +136,9 @@ V2RL:
 		Crushes: wall, mine, crate, infantry
 	RevealsShroud:
 		Range: 5c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	Turreted:
 		TurnSpeed: 5
 	Armament:
@@ -168,6 +180,9 @@ V2RL:
 		Crushes: wall, mine, crate, infantry, heavywall
 	RevealsShroud:
 		Range: 6c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	Turreted:
 		TurnSpeed: 2
 	Armament@PRIMARY:
@@ -219,6 +234,9 @@ ARTY:
 		Speed: 85
 	RevealsShroud:
 		Range: 5c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	Armament:
 		Weapon: 155mm
 		LocalOffset: 624,0,208
@@ -341,6 +359,9 @@ JEEP:
 		RequiresCondition: !notmobile
 	RevealsShroud:
 		Range: 8c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	Turreted:
 		TurnSpeed: 10
 		Offset: 0,0,85
@@ -380,6 +401,9 @@ APC:
 		RequiresCondition: !notmobile
 	RevealsShroud:
 		Range: 5c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	Armament:
 		Weapon: M60mg
 		LocalOffset: 0,0,171
@@ -415,6 +439,9 @@ MNLY:
 		Crushes: wall, mine, crate, infantry
 	RevealsShroud:
 		Range: 5c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	Minelayer:
 		Mine: MINV
 	MineImmune:
@@ -477,6 +504,9 @@ MGG:
 		Sequence: spinner
 	RevealsShroud:
 		Range: 6c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	CreatesShroud:
 		Range: 6c0
 	RenderShroudCircle:
@@ -540,6 +570,9 @@ TTNK:
 		Crushes: wall, mine, crate, infantry
 	RevealsShroud:
 		Range: 7c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 6c0
 	Armament:
 		Weapon: TTankZap
 		LocalOffset: 0,0,213
@@ -573,6 +606,9 @@ FTRK:
 		Speed: 128
 	RevealsShroud:
 		Range: 6c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	Turreted:
 		TurnSpeed: 10
 		Offset: -298,0,298
@@ -646,6 +682,9 @@ CTNK:
 		Crushes: wall, mine, crate, infantry
 	RevealsShroud:
 		Range: 6c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	AutoTarget:
 	Armament@PRIMARY:
 		Weapon: APTusk
@@ -681,6 +720,9 @@ QTNK:
 		Crushes: wall, mine, crate, infantry
 	RevealsShroud:
 		Range: 6c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	SelectionDecorations:
 		VisualBounds: 44,38,0,-4
 	MadTank:
@@ -709,6 +751,9 @@ STNK:
 		RequiresCondition: !notmobile
 	RevealsShroud:
 		Range: 7c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	AutoTarget:
 		InitialStance: HoldFire
 		InitialStanceAI: ReturnFire


### PR DESCRIPTION
Recommendations for specific generated GAP shroud values following #12307 


GAP GENERATOR EFFECT (loss of vision range) VERSUS:
 
- Infantry: None
- Aircraft: -2
- Naval units:   Capped at 5
- Vehicles:   Capped at 4,            exceptions: Mobile Radar Jammer, Tesla Tank (capped at 6)
- Structures:   Capped at 4,         exceptions: Radar Dome, Tech Center (capped at 6)
- Defensives:   Capped at 5,        exceptions: Chronosphere, Iron Curtain, Tesla Coil (capped at 6)

Exposed on "playtest builds" GAP Experimental v1, Experimental v2.0, v2.1, v2.2 with limited results.

http://www.sleipnirstuff.com/forum/viewtopic.php?t=19843
http://www.sleipnirstuff.com/forum/viewtopic.php?t=19886

The GAP effects were added among other balance changes that sought to bring the game further away from base crawling/pushing/turtling thus the GAP gen and MGG were very low priority, resulting in only a handful of specific cases of use out of apprx. 16 hours of streamed showcasing, no reports from feedback outside showcasing. The limited situations where the GAP effect was in play showed a definite effect in support of the user's defensive structure, limiting the opponent's base push by extending extra vision from one side. Sporadic examples of vehicle based armies entering poor engagements vs other armies or base fortifications coupled with the GAP defense structure or an MGG.

Initial values set by pure hypothesis. Real valuable data won't be possible until the GAP effect is part of the official release/playtest in order to make prolonged playtesting available. The initial values was set intentionally "soft" as not to break game balance and at the same time allow for the overall player base to experience generated GAP shroud with the next release/playtest. The values' effectiveness in game-play is in the dark but due to the natural unpredictability of gameplay development the appearance of more GAP generators, MGG's during the next release cycle is at least plausible.