### PR TITLE
Refactor TS debris to work more like in the original

### DIFF
--- a/mods/ts/rules/civilian-structures.yaml
+++ b/mods/ts/rules/civilian-structures.yaml
@@ -11,6 +11,10 @@ ABAN01:
 		HP: 600
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
+	ThrowsShrapnel@SMALL:
+		Pieces: 5, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 2, 4
 
 ABAN02:
 	Inherits: ^CivBuilding
@@ -25,6 +29,10 @@ ABAN02:
 		HP: 600
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
+	ThrowsShrapnel@SMALL:
+		Pieces: 5, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 2, 4
 
 ABAN03:
 	Inherits: ^CivBuilding
@@ -39,6 +47,10 @@ ABAN03:
 		HP: 500
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
+	ThrowsShrapnel@SMALL:
+		Pieces: 5, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 2, 4
 
 ABAN04:
 	Inherits: ^CivBuilding
@@ -53,6 +65,10 @@ ABAN04:
 		HP: 400
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
+	ThrowsShrapnel@SMALL:
+		Pieces: 4, 7
+	ThrowsShrapnel@LARGE:
+		Pieces: 2, 3
 
 ABAN05:
 	Inherits: ^CivBuilding
@@ -373,6 +389,10 @@ CA0001:
 		Type: heavy
 	Health:
 		HP: 400
+	ThrowsShrapnel@SMALL:
+		Pieces: 5, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 2, 4
 
 CA0002:
 	Inherits: ^CivBuilding
@@ -385,6 +405,10 @@ CA0002:
 		Type: heavy
 	Health:
 		HP: 400
+	ThrowsShrapnel@SMALL:
+		Pieces: 5, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 2, 4
 
 CA0003:
 	Inherits: ^CivBuilding
@@ -627,6 +651,10 @@ CAARAY:
 		HP: 400
 	RenderSprites:
 		Palette: player
+	ThrowsShrapnel@SMALL:
+		Pieces: 5, 7
+	ThrowsShrapnel@LARGE:
+		Pieces: 2, 4
 
 CAARMR:
 	Inherits: ^CivBuilding
@@ -644,6 +672,10 @@ CAARMR:
 	ProvidesPrerequisite:
 		Prerequisite: barracks.upgraded
 	Capturable:
+	ThrowsShrapnel@SMALL:
+		Pieces: 6, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 3, 4
 
 CACRSH01:
 	Inherits: ^Decoration
@@ -684,6 +716,10 @@ CAHOSP:
 	ProvidesPrerequisite@BuildingName:
 	Buildable:
 		Description: Gives friendly units a medkit to heal themselves.
+	ThrowsShrapnel@SMALL:
+		Pieces: 5, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 2, 4
 
 CAPYR01:
 	Inherits: ^CivBuilding
@@ -712,6 +748,10 @@ CAPYR02:
 		HP: 400
 	EditorTilesetFilter:
 		ExcludeTilesets: SNOW
+	ThrowsShrapnel@SMALL:
+		Pieces: 6, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 3, 4
 
 CAPYR03:
 	Inherits: ^CivBuilding
@@ -726,6 +766,10 @@ CAPYR03:
 		HP: 400
 	EditorTilesetFilter:
 		ExcludeTilesets: SNOW
+	ThrowsShrapnel@SMALL:
+		Pieces: 6, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 3, 4
 
 CITY01:
 	Inherits: ^CivBuilding
@@ -740,6 +784,10 @@ CITY01:
 		HP: 400
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
+	ThrowsShrapnel@SMALL:
+		Pieces: 5, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 2, 4
 
 CITY02:
 	Inherits: ^CivBuilding
@@ -754,6 +802,10 @@ CITY02:
 		HP: 700
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
+	ThrowsShrapnel@SMALL:
+		Pieces: 5, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 2, 4
 
 CITY03:
 	Inherits: ^CivBuilding
@@ -768,6 +820,10 @@ CITY03:
 		HP: 500
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
+	ThrowsShrapnel@SMALL:
+		Pieces: 5, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 2, 4
 
 CITY04:
 	Inherits: ^CivBuilding
@@ -782,6 +838,10 @@ CITY04:
 		HP: 600
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
+	ThrowsShrapnel@SMALL:
+		Pieces: 5, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 2, 4
 
 CITY05:
 	Inherits: ^CivBuilding
@@ -796,6 +856,10 @@ CITY05:
 		HP: 600
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
+	ThrowsShrapnel@SMALL:
+		Pieces: 5, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 2, 4
 
 CITY06:
 	Inherits: ^CivBuilding
@@ -810,6 +874,10 @@ CITY06:
 		HP: 500
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
+	ThrowsShrapnel@SMALL:
+		Pieces: 7, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 3, 4
 
 CITY07:
 	Inherits: ^CivBuilding
@@ -824,6 +892,10 @@ CITY07:
 		HP: 400
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
+	ThrowsShrapnel@SMALL:
+		Pieces: 7, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 3, 4
 
 CITY08:
 	Inherits: ^CivBuilding
@@ -936,6 +1008,10 @@ CITY15:
 		HP: 500
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
+	ThrowsShrapnel@SMALL:
+		Pieces: 7, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 3, 4
 
 CITY16:
 	Inherits: ^CivBuilding
@@ -950,6 +1026,10 @@ CITY16:
 		HP: 500
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
+	ThrowsShrapnel@SMALL:
+		Pieces: 7, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 3, 4
 
 CITY17:
 	Inherits: ^CivBuilding
@@ -964,6 +1044,10 @@ CITY17:
 		HP: 300
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
+	ThrowsShrapnel@SMALL:
+		Pieces: 7, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 3, 4
 
 CITY18:
 	Inherits: ^CivBuilding
@@ -978,6 +1062,10 @@ CITY18:
 		HP: 600
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
+	ThrowsShrapnel@SMALL:
+		Pieces: 8, 12
+	ThrowsShrapnel@LARGE:
+		Pieces: 5, 7
 
 CITY19:
 	Inherits: ^CivBuilding
@@ -1059,6 +1147,10 @@ CTDAM:
 		Sequence: idle-water
 	Buildable:
 		Description: Provides power for other structures
+	ThrowsShrapnel@SMALL:
+		Pieces: 5, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 2, 4
 
 CTVEGA:
 	Inherits: ^CivBuilding
@@ -1073,6 +1165,10 @@ CTVEGA:
 		HP: 100
 	EditorTilesetFilter:
 		ExcludeTilesets: SNOW
+	ThrowsShrapnel@SMALL:
+		Pieces: 7, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 3, 4
 
 GAKODK:
 	Inherits: ^CivBuilding
@@ -1330,6 +1426,10 @@ NTPYRA:
 		Palette: player
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
+	ThrowsShrapnel@SMALL:
+		Pieces: 7, 9
+	ThrowsShrapnel@LARGE:
+		Pieces: 3, 5
 
 UFO:
 	Inherits: ^CivBuilding
@@ -1350,3 +1450,7 @@ UFO:
 		RequireTilesets: TEMPERATE
 	SelectionDecorations:
 		VisualBounds: 144, 72, 0, 0
+	ThrowsShrapnel@SMALL:
+		Pieces: 9, 12
+	ThrowsShrapnel@LARGE:
+		Pieces: 6, 8

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -144,6 +144,14 @@
 	Guardable:
 		Range: 3c0
 	Demolishable:
+	ThrowsShrapnel@SMALL:
+		Weapons: SmallDebris
+		Pieces: 2, 4
+		Range: 2c0, 5c0
+	ThrowsShrapnel@LARGE:
+		Weapons: LargeDebris, LargeDebrisWithTrail
+		Pieces: 1, 2
+		Range: 2c0, 5c0
 
 ^Building:
 	Inherits@1: ^BasicBuilding
@@ -168,10 +176,10 @@
 	Sellable:
 		SellSounds: cashturn.aud
 	WithMakeAnimation:
-	ThrowsShrapnel:
-		Weapons: LargeDebris
-		Pieces: 3, 7
-		Range: 2c0, 5c0
+	ThrowsShrapnel@SMALL:
+		Pieces: 3, 5
+	ThrowsShrapnel@LARGE:
+		Pieces: 2, 3
 
 ^CivBuilding:
 	Inherits: ^BasicBuilding
@@ -200,6 +208,10 @@
 		HP: 400
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
+	ThrowsShrapnel@SMALL:
+		Pieces: 1, 3
+	ThrowsShrapnel@LARGE:
+		Pieces: 1, 1
 
 ^Crate:
 	HiddenUnderFog:

--- a/mods/ts/weapons/explosions.yaml
+++ b/mods/ts/weapons/explosions.yaml
@@ -56,21 +56,6 @@ TiberiumExplosion:
 		Explosions: large_explosion
 	-Warhead@4Smu: LeaveSmudge
 
-SmallDebris:
-	ReloadDelay: 60
-	Range: 4c0
-	Projectile: Bullet
-		Speed: 50, 125
-		LaunchAngle: 45, 135
-		Image: dbrissm
-		Sequences: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
-		Shadow: true
-
-LargeDebris:
-	Inherits: SmallDebris
-	Projectile: Bullet
-		Image: dbrislg
-
 Demolish:
 	Warhead@1Dam: SpreadDamage
 		DamageTypes: DefaultDeath

--- a/mods/ts/weapons/otherweapons.yaml
+++ b/mods/ts/weapons/otherweapons.yaml
@@ -107,17 +107,59 @@ Veins:
 		Explosions: veins
 		ExplosionPalette: player
 
-SmallDebris:
-	ReloadDelay: 60
-	Range: 4c0
+^Debris:
+	Range: 5c0
 	Projectile: Bullet
-		Speed: 50, 125
-		LaunchAngle: 45, 135
+		Speed: 64, 128
+		LaunchAngle: 80, 192
 		Image: dbrissm
 		Sequences: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
 		Shadow: true
+		Blockable: false
+	Warhead@1Dam: SpreadDamage
+		Spread: 200
+		Falloff: 100, 100, 0
+		Damage: 10
+		Versus:
+			None: 100
+			Wood: 85
+			Light: 70
+			Heavy: 35
+			Concrete: 28
+		DamageTypes: Prone100Percent, TriggerProne, ExplosionDeath
+	Warhead@2Eff: CreateEffect
+		Explosions: tiny_twlt
+		ExplosionPalette: effectalpha75
+		InvalidImpactTypes: Water
+	Warhead@3EffWater: CreateEffect
+		Explosions: small_watersplash
+		ExplosionPalette: player
+		ImpactSounds: ssplash3.aud
+		ValidImpactTypes: Water
+	Warhead@4Smu: LeaveSmudge
+		SmudgeType: SmallScorch
+		InvalidTargets: Vehicle, Building, Wall
+
+SmallDebris:
+	Inherits: ^Debris
 
 LargeDebris:
-	Inherits: SmallDebris
+	Inherits: ^Debris
 	Projectile: Bullet
 		Image: dbrislg
+		Sequences: 2, 3, 4, 6, 7, 9, 10
+	Warhead@1Dam: SpreadDamage
+		Spread: 320
+		Damage: 20
+	Warhead@2Eff: CreateEffect
+		Explosions: small_twlt
+		ImpactSounds: expnew06.aud
+	Warhead@4Smu: LeaveSmudge
+		SmudgeType: MediumCrater
+
+LargeDebrisWithTrail:
+	Inherits: LargeDebris
+	Projectile: Bullet
+		Sequences: 1, 5, 8
+		TrailImage: small_smoke_trail
+		TrailInterval: 1

--- a/mods/ts/weapons/otherweapons.yaml
+++ b/mods/ts/weapons/otherweapons.yaml
@@ -106,3 +106,18 @@ Veins:
 	Warhead@Effect: CreateEffect
 		Explosions: veins
 		ExplosionPalette: player
+
+SmallDebris:
+	ReloadDelay: 60
+	Range: 4c0
+	Projectile: Bullet
+		Speed: 50, 125
+		LaunchAngle: 45, 135
+		Image: dbrissm
+		Sequences: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+		Shadow: true
+
+LargeDebris:
+	Inherits: SmallDebris
+	Projectile: Bullet
+		Image: dbrislg


### PR DESCRIPTION
In TS, debris weren't cosmetic and explosion-less like in RA2, they exploded on impact and dealt damage.
Also, some of them had trails.

This PR tries to approximate the original flight characteristics, damage and visuals as closely as possible.

Remaining differences to original game:
- small debris did not play an explosion effect and sound in the original, but that was due to a typo by Westwood. I enabled the explosion animation (`twlt026`), but not the sound, since `expnew05.aud` is quite annoying.
- all debris additionally displayed and alpha glow on impact.