### PR TITLE
Give a proper error when a file is not found

### DIFF
--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -267,9 +267,15 @@ namespace OpenRA.FileSystem
 			if (s != null)
 				return true;
 
+			// The file should be in an explicit package (but we couldn't find it)
+			// Thus don't try to find it using the filename (which contains the invalid '|' char)
+			// This can be removed once the TODO below is resolved
+			if (explicitSplit > 0)
+				return false;
+
 			// Ask each package individually
 			// TODO: This fallback can be removed once the filesystem cleanups are complete
-			var	package = mountedPackages.Keys.LastOrDefault(x => x.Contains(filename));
+			var package = mountedPackages.Keys.LastOrDefault(x => x.Contains(filename));
 			if (package != null)
 			{
 				s = package.GetStream(filename);

--- a/OpenRA.Game/FileSystem/Folder.cs
+++ b/OpenRA.Game/FileSystem/Folder.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -47,7 +48,7 @@ namespace OpenRA.FileSystem
 		public bool Contains(string filename)
 		{
 			var combined = Path.Combine(path, filename);
-			return combined.StartsWith(path) && File.Exists(combined);
+			return combined.StartsWith(path, StringComparison.Ordinal) && File.Exists(combined);
 		}
 
 		public void Update(string filename, byte[] contents)


### PR DESCRIPTION
This solves the quite annoying bug that inexistent files cause an "Illegal character in path" `System.ArgumentException`:
```
System.ArgumentException: Illegal character in path
   at System.IO.Path.CheckInvalidPathChars(String path, Boolean checkAdditional)
   at System.IO.Path.Combine(String path1, String path2)
   at OpenRA.FileSystem.Folder.Contains(String filename) in \OpenRA\OpenRA.Game\FileSystem\Folder.cs:Line 53.
   at OpenRA.FileSystem.FileSystem.<>c__DisplayClass13.<TryOpen>b__12(IReadOnlyPackage x) in \OpenRA\OpenRA.Game\FileSystem\FileSystem.cs:Line 268.
   at System.Linq.Enumerable.LastOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
   at OpenRA.FileSystem.FileSystem.TryOpen(String filename, Stream& s) in \OpenRA\OpenRA.Game\FileSystem\FileSystem.cs:Line 268.
   at OpenRA.FileSystem.FileSystem.Open(String filename) in \OpenRA\OpenRA.Game\FileSystem\FileSystem.cs:Line 227.
   at OpenRA.ObjectCreator..ctor(Manifest manifest, FileSystem modFiles) in \OpenRA\OpenRA.Game\ObjectCreator.cs:Line 46.
   at OpenRA.ModData..ctor(Manifest mod, InstalledMods mods, Boolean useLoadScreen) in \OpenRA\OpenRA.Game\ModData.cs:Line 58.
   at OpenRA.Game.InitializeMod(String mod, Arguments args) in \OpenRA\OpenRA.Game\Game.cs:Line 372.
   at OpenRA.Game.Initialize(Arguments args) in \OpenRA\OpenRA.Game\Game.cs:Line 321.
   at OpenRA.Program.Run(String[] args) in \OpenRA\OpenRA.Game\Support\Program.cs:Line 132.
   at OpenRA.Program.Main(String[] args) in \OpenRA\OpenRA.Game\Support\Program.cs:Line 35.
```

Where instead it should give an `System.IO.FileNotFoundException` (as it does with this PR):
```
System.IO.FileNotFoundException: File not found: cnc|OpenRA.Mods.Cnc2.dll
   at OpenRA.FileSystem.FileSystem.Open(String filename) in \OpenRA\OpenRA.Game\FileSystem\FileSystem.cs:Line 228.
   at OpenRA.ObjectCreator..ctor(Manifest manifest, FileSystem modFiles) in \OpenRA\OpenRA.Game\ObjectCreator.cs:Line 46.
   at OpenRA.ModData..ctor(Manifest mod, InstalledMods mods, Boolean useLoadScreen) in \OpenRA\OpenRA.Game\ModData.cs:Line 58.
   at OpenRA.Game.InitializeMod(String mod, Arguments args) in \OpenRA\OpenRA.Game\Game.cs:Line 372.
   at OpenRA.Game.Initialize(Arguments args) in \OpenRA\OpenRA.Game\Game.cs:Line 321.
   at OpenRA.Program.Run(String[] args) in \OpenRA\OpenRA.Game\Support\Program.cs:Line 132.
   at OpenRA.Program.Main(String[] args) in \OpenRA\OpenRA.Game\Support\Program.cs:Line 35.
```

This PR also prints some error messages into `debug.log` which should make finding the error even easier:
```
File cnc|OpenRA.Mods.Cnc2.dll not found in \Documents\OpenRA\Content/ra/v2/.
File cnc|OpenRA.Mods.Cnc2.dll not found in \Documents\OpenRA\Content/ra/v2/expand.
File cnc|OpenRA.Mods.Cnc2.dll not found in \Documents\OpenRA\Content/ra/v2/cnc.
File cnc|OpenRA.Mods.Cnc2.dll not found in \Documents\OpenRA\Content/ra/v2/movies.
File cnc|OpenRA.Mods.Cnc2.dll not found in \Documents\OpenRA\bleed\OpenRA\.
File cnc|OpenRA.Mods.Cnc2.dll not found in \Documents\OpenRA\bleed\OpenRA\mods\ra.
File cnc|OpenRA.Mods.Cnc2.dll not found in \Documents\OpenRA\bleed\OpenRA\mods\cnc.
File cnc|OpenRA.Mods.Cnc2.dll not found in \Documents\OpenRA\bleed\OpenRA\mods/common.
File cnc|OpenRA.Mods.Cnc2.dll not found in \Documents\OpenRA\bleed\OpenRA\mods\ra\bits.
File cnc|OpenRA.Mods.Cnc2.dll not found in \Documents\OpenRA\bleed\OpenRA\mods\ra\bits/desert.
File cnc|OpenRA.Mods.Cnc2.dll not found in \Documents\OpenRA\bleed\OpenRA\mods\ra\uibits.
```

Testcase I used:
```diff
diff --git a/mods/ra/mod.yaml b/mods/ra/mod.yaml
index f82e7e1..65e040c 100644
--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -81,7 +81,7 @@ Chrome:
 Assemblies:
        common|OpenRA.Mods.Common.dll
        ra|OpenRA.Mods.RA.dll
-       cnc|OpenRA.Mods.Cnc.dll
+       cnc|OpenRA.Mods.Cnc2.dll

 ChromeLayout:
        ra|chrome/ingame.yaml
```

I quite sure that this is not the fix we actually want. However I don't know off the top of my head how to handle the situation differently.