### PR TITLE
Implement new charge attack logic for TD/TS obelisks.

### DIFF
--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -90,6 +90,10 @@
     <Compile Include="UtilityCommands\LegacyRulesImporter.cs" />
     <Compile Include="UtilityCommands\LegacySequenceImporter.cs" />
     <Compile Include="Widgets\Logic\PreReleaseWarningPrompt.cs" />
+    <Compile Include="Traits\Attack\AttackTesla.cs" />
+    <Compile Include="Traits\Render\WithTeslaChargeAnimation.cs" />
+    <Compile Include="Traits\Render\WithTeslaChargeOverlay.cs" />
+    <Compile Include="TraitsInterfaces.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj">

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
@@ -11,12 +11,13 @@
 
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.Common.Traits
+namespace OpenRA.Mods.Cnc.Traits
 {
-	[Desc("Charges up before being able to attack.")]
-	class AttackChargeInfo : AttackOmniInfo
+	[Desc("Implements the charge-then-burst attack logic specific to the RA tesla coil.")]
+	class AttackTeslaInfo : AttackOmniInfo
 	{
 		[Desc("How many charges this actor has to attack with, once charged.")]
 		public readonly int MaxCharges = 1;
@@ -33,17 +34,17 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sound to play when actor charges.")]
 		public readonly string ChargeAudio = null;
 
-		public override object Create(ActorInitializer init) { return new AttackCharge(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new AttackTesla(init.Self, this); }
 	}
 
-	class AttackCharge : AttackOmni, ITick, INotifyAttack
+	class AttackTesla : AttackOmni, ITick, INotifyAttack
 	{
-		readonly AttackChargeInfo info;
+		readonly AttackTeslaInfo info;
 
 		[Sync] int charges;
 		[Sync] int timeToRecharge;
 
-		public AttackCharge(Actor self, AttackChargeInfo info)
+		public AttackTesla(Actor self, AttackTeslaInfo info)
 			: base(self, info)
 		{
 			this.info = info;
@@ -79,10 +80,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		class ChargeAttack : Activity
 		{
-			readonly AttackCharge attack;
+			readonly AttackTesla attack;
 			readonly Target target;
 
-			public ChargeAttack(AttackCharge attack, Target target)
+			public ChargeAttack(AttackTesla attack, Target target)
 			{
 				this.attack = attack;
 				this.target = target;
@@ -96,7 +97,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (attack.charges == 0)
 					return this;
 
-				foreach (var notify in self.TraitsImplementing<INotifyCharging>())
+				foreach (var notify in self.TraitsImplementing<INotifyTeslaCharging>())
 					notify.Charging(self, target);
 
 				if (!string.IsNullOrEmpty(attack.info.ChargeAudio))
@@ -108,10 +109,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		class ChargeFire : Activity
 		{
-			readonly AttackCharge attack;
+			readonly AttackTesla attack;
 			readonly Target target;
 
-			public ChargeFire(AttackCharge attack, Target target)
+			public ChargeFire(AttackTesla attack, Target target)
 			{
 				this.attack = attack;
 				this.target = target;

--- a/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeAnimation.cs
@@ -9,31 +9,32 @@
  */
 #endregion
 
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.Common.Traits.Render
+namespace OpenRA.Mods.Cnc.Traits.Render
 {
 	[Desc("This actor displays a charge-up animation before firing.")]
-	public class WithChargeAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<RenderSpritesInfo>
+	public class WithTeslaChargeAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<RenderSpritesInfo>
 	{
 		[Desc("Sequence to use for charge animation.")]
 		[SequenceReference] public readonly string ChargeSequence = "active";
 
-		public object Create(ActorInitializer init) { return new WithChargeAnimation(init, this); }
+		public object Create(ActorInitializer init) { return new WithTeslaChargeAnimation(init, this); }
 	}
 
-	public class WithChargeAnimation : INotifyCharging
+	public class WithTeslaChargeAnimation : INotifyTeslaCharging
 	{
-		readonly WithChargeAnimationInfo info;
+		readonly WithTeslaChargeAnimationInfo info;
 		readonly WithSpriteBody wsb;
 
-		public WithChargeAnimation(ActorInitializer init, WithChargeAnimationInfo info)
+		public WithTeslaChargeAnimation(ActorInitializer init, WithTeslaChargeAnimationInfo info)
 		{
 			this.info = info;
 			wsb = init.Self.Trait<WithSpriteBody>();
 		}
 
-		public void Charging(Actor self, Target target)
+		void INotifyTeslaCharging.Charging(Actor self, Target target)
 		{
 			wsb.PlayCustomAnimation(self, info.ChargeSequence, () => wsb.CancelCustomAnimation(self));
 		}

--- a/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeOverlay.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeOverlay.cs
@@ -10,12 +10,14 @@
 #endregion
 
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.Common.Traits.Render
+namespace OpenRA.Mods.Cnc.Traits.Render
 {
 	[Desc("Rendered together with AttackCharge.")]
-	public class WithChargeOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>
+	public class WithTeslaChargeOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "active";
@@ -26,18 +28,18 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;
 
-		public object Create(ActorInitializer init) { return new WithChargeOverlay(init, this); }
+		public object Create(ActorInitializer init) { return new WithTeslaChargeOverlay(init, this); }
 	}
 
-	public class WithChargeOverlay : INotifyCharging, INotifyDamageStateChanged, INotifySold
+	public class WithTeslaChargeOverlay : INotifyTeslaCharging, INotifyDamageStateChanged, INotifySold
 	{
 		readonly Animation overlay;
 		readonly RenderSprites renderSprites;
-		readonly WithChargeOverlayInfo info;
+		readonly WithTeslaChargeOverlayInfo info;
 
 		bool charging;
 
-		public WithChargeOverlay(ActorInitializer init, WithChargeOverlayInfo info)
+		public WithTeslaChargeOverlay(ActorInitializer init, WithTeslaChargeOverlayInfo info)
 		{
 			this.info = info;
 
@@ -49,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				info.Palette, info.IsPlayerPalette);
 		}
 
-		void INotifyCharging.Charging(Actor self, Target target)
+		void INotifyTeslaCharging.Charging(Actor self, Target target)
 		{
 			charging = true;
 			overlay.PlayThen(RenderSprites.NormalizeSequence(overlay, self.GetDamageState(), info.Sequence), () => charging = false);

--- a/OpenRA.Mods.Cnc/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Cnc/TraitsInterfaces.cs
@@ -1,0 +1,18 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Cnc.Traits
+{
+	[RequireExplicitImplementation]
+	public interface INotifyTeslaCharging { void Charging(Actor self, Target target); }
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -262,7 +262,6 @@
     <Compile Include="Traits\Armor.cs" />
     <Compile Include="Traits\AttackMove.cs" />
     <Compile Include="Traits\Attack\AttackBase.cs" />
-    <Compile Include="Traits\Attack\AttackCharge.cs" />
     <Compile Include="Traits\Attack\AttackFollow.cs" />
     <Compile Include="Traits\Attack\AttackFrontal.cs" />
     <Compile Include="Traits\Attack\AttackGarrisoned.cs" />
@@ -431,8 +430,6 @@
     <Compile Include="Traits\Render\WithSiloAnimation.cs" />
     <Compile Include="Traits\Render\WithBuildingPlacedAnimation.cs" />
     <Compile Include="Traits\Render\WithMakeAnimation.cs" />
-    <Compile Include="Traits\Render\WithChargeAnimation.cs" />
-    <Compile Include="Traits\Render\WithChargeOverlay.cs" />
     <Compile Include="Traits\Render\WithCrateBody.cs" />
     <Compile Include="Traits\Render\WithDamageOverlay.cs" />
     <Compile Include="Traits\Render\WithDeathAnimation.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -799,6 +799,9 @@
     <Compile Include="Traits\World\JumpjetActorLayer.cs" />
     <Compile Include="Traits\World\ElevatedBridgeLayer.cs" />
     <Compile Include="Traits\World\ElevatedBridgePlaceholder.cs" />
+    <Compile Include="Traits\Attack\AttackCharges.cs" />
+    <Compile Include="Traits\Render\WithChargeAnimation.cs" />
+    <Compile Include="Traits\Render\WithChargeOverlay.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.Common/Traits/Attack/AttackCharges.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackCharges.cs
@@ -1,0 +1,84 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Actor must charge up its armaments before firing.")]
+	public class AttackChargesInfo : AttackOmniInfo
+	{
+		[Desc("Amount of charge required to attack.")]
+		public readonly int ChargeLevel = 25;
+
+		[Desc("Amount to increase the charge level each tick with a valid target.")]
+		public readonly int ChargeRate = 1;
+
+		[Desc("Amount to decrease the charge level each tick without a valid target.")]
+		public readonly int DischargeRate = 1;
+
+		[GrantedConditionReference]
+		[Desc("The condition to grant to self while the charge level is greater than zero.")]
+		public readonly string ChargingCondition = null;
+
+		public override object Create(ActorInitializer init) { return new AttackCharges(init.Self, this); }
+	}
+
+	public class AttackCharges : AttackOmni, INotifyCreated, ITick, INotifyAttack, INotifySold
+	{
+		readonly AttackChargesInfo info;
+		ConditionManager conditionManager;
+		int chargingToken = ConditionManager.InvalidConditionToken;
+		bool charging;
+
+		public int ChargeLevel { get; private set; }
+
+		public AttackCharges(Actor self, AttackChargesInfo info)
+			: base(self, info)
+		{
+			this.info = info;
+		}
+
+		void INotifyCreated.Created(Actor self)
+		{
+			conditionManager = self.TraitOrDefault<ConditionManager>();
+		}
+
+		void ITick.Tick(Actor self)
+		{
+			// Stop charging when we lose our target
+			charging &= self.CurrentActivity is SetTarget;
+
+			var delta = charging ? info.ChargeRate : -info.DischargeRate;
+			ChargeLevel = (ChargeLevel + delta).Clamp(0, info.ChargeLevel);
+
+			if (ChargeLevel > 0 && conditionManager != null && !string.IsNullOrEmpty(info.ChargingCondition)
+					&& chargingToken == ConditionManager.InvalidConditionToken)
+				chargingToken = conditionManager.GrantCondition(self, info.ChargingCondition);
+
+			if (ChargeLevel == 0 && conditionManager != null && chargingToken != ConditionManager.InvalidConditionToken)
+				chargingToken = conditionManager.RevokeCondition(self, chargingToken);
+		}
+
+		protected override bool CanAttack(Actor self, Target target)
+		{
+			charging = base.CanAttack(self, target) && IsReachableTarget(target, true);
+			return ChargeLevel >= info.ChargeLevel && charging;
+		}
+
+		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel) { ChargeLevel = 0; }
+		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel) { }
+		void INotifySold.Selling(Actor self) { ChargeLevel = 0; }
+		void INotifySold.Sold(Actor self) { }
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
@@ -14,12 +14,12 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class AttackOmniInfo : AttackBaseInfo
+	public class AttackOmniInfo : AttackBaseInfo
 	{
 		public override object Create(ActorInitializer init) { return new AttackOmni(init.Self, this); }
 	}
 
-	class AttackOmni : AttackBase
+	public class AttackOmni : AttackBase
 	{
 		public AttackOmni(Actor self, AttackOmniInfo info)
 			: base(self, info) { }

--- a/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 			return new SetTarget(this, newTarget);
 		}
 
-		class SetTarget : Activity
+		protected class SetTarget : Activity
 		{
 			readonly Target target;
 			readonly AttackOmni attack;

--- a/OpenRA.Mods.Common/Traits/Render/WithChargeAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithChargeAnimation.cs
@@ -1,0 +1,46 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits.Render
+{
+	[Desc("Render trait that varies the animation frame based on the AttackCharges trait's charge level.")]
+	class WithChargeAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<AttackChargesInfo>
+	{
+		[SequenceReference]
+		[Desc("Sequence to use for the charge levels.")]
+		public readonly string Sequence = "active";
+
+		public object Create(ActorInitializer init) { return new WithChargeAnimation(init.Self, this); }
+	}
+
+	class WithChargeAnimation : INotifyBuildComplete
+	{
+		readonly WithChargeAnimationInfo info;
+		readonly WithSpriteBody wsb;
+		readonly AttackCharges attackCharges;
+
+		public WithChargeAnimation(Actor self, WithChargeAnimationInfo info)
+		{
+			this.info = info;
+			wsb = self.Trait<WithSpriteBody>();
+			attackCharges = self.Trait<AttackCharges>();
+		}
+
+		void INotifyBuildComplete.BuildingComplete(Actor self)
+		{
+			var attackChargesInfo = (AttackChargesInfo)attackCharges.Info;
+			wsb.DefaultAnimation.PlayFetchIndex(wsb.NormalizeSequence(self, info.Sequence),
+				() => int2.Lerp(0, wsb.DefaultAnimation.CurrentSequence.Length, attackCharges.ChargeLevel, attackChargesInfo.ChargeLevel + 1));
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Render/WithChargeOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithChargeOverlay.cs
@@ -1,0 +1,72 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Graphics;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits.Render
+{
+	[Desc("Render overlay that varies the animation frame based on the AttackCharges trait's charge level.")]
+	class WithChargeOverlayInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<RenderSpritesInfo>
+	{
+		[SequenceReference]
+		[Desc("Sequence to use for the charge levels.")]
+		public readonly string Sequence = "active";
+
+		[Desc("Custom palette name")]
+		[PaletteReference("IsPlayerPalette")] public readonly string Palette = null;
+
+		[Desc("Custom palette is a player palette BaseName")]
+		public readonly bool IsPlayerPalette = false;
+
+		public object Create(ActorInitializer init) { return new WithChargeOverlay(init.Self, this); }
+	}
+
+	class WithChargeOverlay : INotifyBuildComplete, INotifySold, INotifyDamageStateChanged
+	{
+		readonly WithChargeOverlayInfo info;
+		readonly Animation overlay;
+		readonly RenderSprites rs;
+		readonly WithSpriteBody wsb;
+
+		bool buildComplete;
+
+		public WithChargeOverlay(Actor self, WithChargeOverlayInfo info)
+		{
+			this.info = info;
+			rs = self.Trait<RenderSprites>();
+			wsb = self.Trait<WithSpriteBody>();
+
+			var attackCharges = self.Trait<AttackCharges>();
+			var attackChargesInfo = (AttackChargesInfo)attackCharges.Info;
+
+			overlay = new Animation(self.World, rs.GetImage(self));
+			overlay.PlayFetchIndex(wsb.NormalizeSequence(self, info.Sequence),
+				() => int2.Lerp(0, overlay.CurrentSequence.Length, attackCharges.ChargeLevel, attackChargesInfo.ChargeLevel + 1));
+
+			rs.Add(new AnimationWithOffset(overlay, null, () => !buildComplete, 1024),
+				info.Palette, info.IsPlayerPalette);
+		}
+
+		void INotifyBuildComplete.BuildingComplete(Actor self)
+		{
+			buildComplete = true;
+		}
+
+		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
+		{
+			overlay.ReplaceAnim(RenderSprites.NormalizeSequence(overlay, e.DamageState, info.Sequence));
+		}
+
+		void INotifySold.Selling(Actor self) { buildComplete = false; }
+		void INotifySold.Sold(Actor self) { }
+	}
+}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -81,7 +81,6 @@ namespace OpenRA.Mods.Common.Traits
 	public interface INotifyBuildingPlaced { void BuildingPlaced(Actor self); }
 	public interface INotifyRepair { void Repairing(Actor self, Actor target); }
 	public interface INotifyBurstComplete { void FiredBurst(Actor self, Target target, Armament a); }
-	public interface INotifyCharging { void Charging(Actor self, Target target); }
 	public interface INotifyChat { bool OnChat(string from, string message); }
 	public interface INotifyProduction { void UnitProduced(Actor self, Actor other, CPos exit); }
 	public interface INotifyOtherProduction { void UnitProducedByOther(Actor self, Actor producer, Actor produced); }

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -818,6 +818,18 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 20170210)
+				{
+					if (node.Key.StartsWith("AttackCharge", StringComparison.Ordinal))
+						RenameNodeKey(node, "AttackTesla");
+
+					if (node.Key.StartsWith("WithChargeOverlay", StringComparison.Ordinal))
+						RenameNodeKey(node, "WithTeslaChargeOverlay");
+
+					if (node.Key.StartsWith("WithChargeAnimation", StringComparison.Ordinal))
+						RenameNodeKey(node, "WithTeslaChargeAnimation");
+				}
+
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -779,7 +779,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				// Rename UpgradeOverlay to WithColoredOverlay
 				if (engineVersion < 20170201)
 					if (node.Key.StartsWith("UpgradeOverlay", StringComparison.Ordinal))
-						RenameNodeKey(node, "WithColoredOverlay" + node.Key.Substring(14));
+						RenameNodeKey(node, "WithColoredOverlay");
 
 				// Remove SpiceBloom.RespawnDelay to get rid of DelayedAction, and rename GrowthDelay to Lifetime
 				if (engineVersion < 20170203)

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -758,15 +758,17 @@ OBLI:
 		Range: 8c0
 	Bib:
 		HasMinibib: Yes
-	WithTeslaChargeAnimation:
+	WithChargeAnimation:
 	Armament:
 		Weapon: Laser
 		LocalOffset: 0,-85,1280
-		FireDelay: 0
-	AttackTesla:
-		ChargeAudio: obelpowr.aud
-		ReloadDelay: 40
-		InitialChargeDelay: 50
+	AttackCharges:
+		ChargeLevel: 50
+		ChargingCondition: charging
+	AmbientSound:
+		RequiresCondition: charging
+		SoundFile: obelpowr.aud
+		Interval: 30, 40
 	-EmitInfantryOnSell:
 	DetectCloaked:
 		Range: 5c0

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -758,12 +758,12 @@ OBLI:
 		Range: 8c0
 	Bib:
 		HasMinibib: Yes
-	WithChargeAnimation:
+	WithTeslaChargeAnimation:
 	Armament:
 		Weapon: Laser
 		LocalOffset: 0,-85,1280
 		FireDelay: 0
-	AttackCharge:
+	AttackTesla:
 		ChargeAudio: obelpowr.aud
 		ReloadDelay: 40
 		InitialChargeDelay: 50

--- a/mods/cnc/weapons/other.yaml
+++ b/mods/cnc/weapons/other.yaml
@@ -80,7 +80,7 @@ Napalm:
 		Explosions: med_napalm
 
 Laser:
-	ReloadDelay: 1
+	ReloadDelay: 40
 	Range: 7c512
 	Report: obelray1.aud
 	Projectile: LaserZap

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -436,11 +436,11 @@ TSLA:
 		Range: 6c0
 	Bib:
 		HasMinibib: Yes
-	WithChargeAnimation:
+	WithTeslaChargeAnimation:
 	Armament:
 		Weapon: TeslaZap
 		LocalOffset: 0,0,896
-	AttackCharge:
+	AttackTesla:
 		ChargeAudio: tslachg2.aud
 		MaxCharges: 3
 		ReloadDelay: 120

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -108,11 +108,14 @@ NAOBEL:
 	Armament:
 		Weapon: ObeliskLaserFire
 		LocalOffset: 1400,210,800
-	AttackTesla:
-		ChargeAudio: obelpowr.aud
-		InitialChargeDelay: 65
-	WithTeslaChargeOverlay:
-		Sequence: active
+	AttackCharges:
+		ChargeLevel: 65
+		ChargingCondition: charging
+	AmbientSound:
+		RequiresCondition: charging
+		SoundFile: obelpowr.aud
+		Interval: 30, 40
+	WithChargeOverlay:
 		Palette: player
 		IsPlayerPalette: true
 	WithIdleOverlay@LIGHTS:

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -108,10 +108,10 @@ NAOBEL:
 	Armament:
 		Weapon: ObeliskLaserFire
 		LocalOffset: 1400,210,800
-	AttackCharge:
+	AttackTesla:
 		ChargeAudio: obelpowr.aud
 		InitialChargeDelay: 65
-	WithChargeOverlay:
+	WithTeslaChargeOverlay:
 		Sequence: active
 		Palette: player
 		IsPlayerPalette: true

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -180,7 +180,7 @@ Proton:
 
 ObeliskLaserFire:
 	Inherits: ^Laser
-	ReloadDelay: 1
+	ReloadDelay: 120
 	Range: 10c512
 	Report: obelray1.aud
 	Warhead@1Dam: SpreadDamage


### PR DESCRIPTION
This implements the chargeup/decay attack logic referred to in #11415.  Moving the charge logic from individual shots to the actor makes physical sense for the obelisks (they're charging up a capacitor bank) and improves gameplay:
* Switching targets doesn't reset the charge level.
* Charge will slowly decay and the recharge time will be much shorter if a unit hops out of and then back into range.
* Players who have nothing better to do can juggle force-attack and stop orders to keep an obelisk ready to fire on short notice.

The tesla coil can't use this new logic (its charge animation and sound effect can't loop), and the burst logic of the old `AttackCharge` trait has nothing to do with charging, so I have renamed that and its associated With* traits and moved them into Mods.Cnc.  I strongly suspect that the tesla coil logic can now be done with our normal attack traits, so somebody should look into removing `AttackTesla` at some point.

Closes #11415.