### PR TITLE
Don't show a move flash effect when PBOG nudges a unit.

### DIFF
--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -245,7 +245,8 @@ namespace OpenRA.Mods.Common.Orders
 
 				yield return new Order("Move", blocker.Actor, false)
 				{
-					TargetLocation = blocker.Actor.ClosestCell(availableCells)
+					TargetLocation = blocker.Actor.ClosestCell(availableCells),
+					SuppressVisualFeedback = true
 				};
 			}
 		}


### PR DESCRIPTION
Fixes #12324.