### PR TITLE
Fix grenadier explodes trait

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -100,7 +100,7 @@ E2:
 	WithInfantryBody:
 		DefaultAttackSequence: throw
 	Explodes:
-		Weapon: UnitExplodeSmall
+		Weapon: UnitExplode
 		Chance: 50
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded


### PR DESCRIPTION
Issue: #10114

Changes the grenadiers `Explodes:` trait to a more constant behavior.

Without PR:
- Weapon loaded -> Small explosion
- Weapon empty/unloaded -> Normal explosion

With PR:
- Weapon loaded -> Normal explosion
- Weapon empty/unloaded -> Normal explosion

 Ping @SoScared