### PR TITLE
Fix GiveUnitCrateAction and SpawnMPUnits being limited to MobileInfo

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -265,7 +265,11 @@ namespace OpenRA.Traits
 	[RequireExplicitImplementation]
 	public interface ISelectionBar { float GetValue(); Color GetColor(); bool DisplayWhenEmpty { get; } }
 
-	public interface IPositionableInfo : ITraitInfoInterface { }
+	public interface IPositionableInfo : ITraitInfoInterface
+	{
+		bool CanEnterCell(World world, Actor self, CPos cell, Actor ignoreActor = null, bool checkTransientActors = true);
+	}
+
 	public interface IPositionable : IOccupySpace
 	{
 		bool IsLeavingCell(CPos location, SubCell subCell = SubCell.Any);

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -265,7 +265,7 @@ namespace OpenRA.Traits
 	[RequireExplicitImplementation]
 	public interface ISelectionBar { float GetValue(); Color GetColor(); bool DisplayWhenEmpty { get; } }
 
-	public interface IPositionableInfo : ITraitInfoInterface
+	public interface IPositionableInfo : IOccupySpaceInfo
 	{
 		bool CanEnterCell(World world, Actor self, CPos cell, Actor ignoreActor = null, bool checkTransientActors = true);
 	}

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -21,7 +21,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class AircraftInfo : ITraitInfo, IPositionableInfo, IFacingInfo, IOccupySpaceInfo, IMoveInfo, ICruiseAltitudeInfo,
+	public class AircraftInfo : ITraitInfo, IPositionableInfo, IFacingInfo, IMoveInfo, ICruiseAltitudeInfo,
 		UsesInit<LocationInit>, UsesInit<FacingInit>
 	{
 		public readonly WDist CruiseAltitude = new WDist(1280);

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -94,6 +94,25 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IReadOnlyDictionary<CPos, SubCell> OccupiedCells(ActorInfo info, CPos location, SubCell subCell = SubCell.Any) { return new ReadOnlyDictionary<CPos, SubCell>(); }
 		bool IOccupySpaceInfo.SharesCell { get { return false; } }
+
+		// Used to determine if an aircraft can spawn landed
+		public bool CanEnterCell(World world, Actor self, CPos cell, Actor ignoreActor = null, bool checkTransientActors = true)
+		{
+			if (!world.Map.Contains(cell))
+				return false;
+
+			var type = world.Map.GetTerrainInfo(cell).Type;
+			if (!LandableTerrainTypes.Contains(type))
+				return false;
+
+			if (world.WorldActor.Trait<BuildingInfluence>().GetBuildingAt(cell) != null)
+				return false;
+
+			if (!checkTransientActors)
+				return true;
+
+			return !world.ActorMap.GetActorsAt(cell).Any(x => x != ignoreActor);
+		}
 	}
 
 	public class Aircraft : ITick, ISync, IFacing, IPositionable, IMove, IIssueOrder, IResolveOrder, IOrderVoice, IDeathActorInitModifier,

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class CrateInfo : ITraitInfo, IPositionableInfo, IOccupySpaceInfo, Requires<RenderSpritesInfo>
+	class CrateInfo : ITraitInfo, IPositionableInfo, Requires<RenderSpritesInfo>
 	{
 		[Desc("Length of time (in seconds) until the crate gets removed automatically. " +
 			"A value of zero disables auto-removal.")]

--- a/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
@@ -97,11 +97,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<CPos> GetSuitableCells(CPos near, string unitName)
 		{
-			var mi = self.World.Map.Rules.Actors[unitName].TraitInfo<MobileInfo>();
+			var ip = self.World.Map.Rules.Actors[unitName].TraitInfo<IPositionableInfo>();
 
 			for (var i = -1; i < 2; i++)
 				for (var j = -1; j < 2; j++)
-					if (mi.CanEnterCell(self.World, self, near + new CVec(i, j)))
+					if (ip.CanEnterCell(self.World, self, near + new CVec(i, j)))
 						yield return near + new CVec(i, j);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -263,11 +263,12 @@ namespace OpenRA.Mods.Common.Traits
 				(current, terrainInfo) => unchecked(current * 31 + terrainInfo.Cost));
 		}
 
-		public bool CanEnterCell(World world, Actor self, CPos cell, Actor ignoreActor = null, CellConditions check = CellConditions.All)
+		public bool CanEnterCell(World world, Actor self, CPos cell, Actor ignoreActor = null, bool checkTransientActors = true)
 		{
 			if (MovementCostForCell(world, cell) == int.MaxValue)
 				return false;
 
+			var check = checkTransientActors ? CellConditions.All : CellConditions.BlockedByMovers;
 			return CanMoveFreelyInto(world, self, cell, ignoreActor, check);
 		}
 
@@ -699,7 +700,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool CanEnterCell(CPos cell, Actor ignoreActor = null, bool checkTransientActors = true)
 		{
-			return Info.CanEnterCell(self.World, self, cell, ignoreActor, checkTransientActors ? CellConditions.All : CellConditions.BlockedByMovers);
+			return Info.CanEnterCell(self.World, self, cell, ignoreActor, checkTransientActors);
 		}
 
 		public bool CanMoveFreelyInto(CPos cell, Actor ignoreActor = null, bool checkTransientActors = true)

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[Desc("Unit is able to move.")]
-	public class MobileInfo : ConditionalTraitInfo, IMoveInfo, IPositionableInfo, IOccupySpaceInfo, IFacingInfo,
+	public class MobileInfo : ConditionalTraitInfo, IMoveInfo, IPositionableInfo, IFacingInfo,
 		UsesInit<FacingInit>, UsesInit<LocationInit>, UsesInit<SubCellInit>
 	{
 		[FieldLoader.LoadUsing("LoadSpeeds", true)]
@@ -381,7 +381,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public class Mobile : ConditionalTrait<MobileInfo>, INotifyCreated, IIssueOrder, IResolveOrder, IOrderVoice, IPositionable, IMove,
-		IFacing, ISync, IDeathActorInitModifier, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyBlockingMove, IActorPreviewInitModifier
+		IFacing, IDeathActorInitModifier, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyBlockingMove, IActorPreviewInitModifier
 	{
 		const int AverageTicksBeforePathing = 5;
 		const int SpreadTicksBeforePathing = 5;

--- a/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
@@ -86,8 +86,9 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var s in unitGroup.SupportActors)
 			{
-				var mi = w.Map.Rules.Actors[s.ToLowerInvariant()].TraitInfo<MobileInfo>();
-				var validCells = supportSpawnCells.Where(c => mi.CanEnterCell(w, null, c));
+				var actorRules = w.Map.Rules.Actors[s.ToLowerInvariant()];
+				var ip = actorRules.TraitInfo<IPositionableInfo>();
+				var validCells = supportSpawnCells.Where(c => ip.CanEnterCell(w, null, c));
 				if (!validCells.Any())
 				{
 					Log.Write("debug", "No cells available to spawn starting unit {0} for player {1}".F(s, p));
@@ -95,7 +96,8 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				var cell = validCells.Random(w.SharedRandom);
-				var subCell = mi.SharesCell ? w.ActorMap.FreeSubCell(cell) : 0;
+				var ios = actorRules.TraitInfo<IOccupySpaceInfo>();
+				var subCell = ios.SharesCell ? w.ActorMap.FreeSubCell(cell) : 0;
 
 				w.CreateActor(s.ToLowerInvariant(), new TypeDictionary
 				{

--- a/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
@@ -96,8 +96,7 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				var cell = validCells.Random(w.SharedRandom);
-				var ios = actorRules.TraitInfo<IOccupySpaceInfo>();
-				var subCell = ios.SharesCell ? w.ActorMap.FreeSubCell(cell) : 0;
+				var subCell = ip.SharesCell ? w.ActorMap.FreeSubCell(cell) : 0;
 
 				w.CreateActor(s.ToLowerInvariant(), new TypeDictionary
 				{


### PR DESCRIPTION
You can now also spawn aircraft and crates.