### PR TITLE
Minor removal of rules duplication in ts yaml

### DIFF
--- a/mods/ts/rules/civilian-structures.yaml
+++ b/mods/ts/rules/civilian-structures.yaml
@@ -714,8 +714,6 @@ CAHOSP:
 	Capturable:
 	CaptureNotification:
 	ProvidesPrerequisite@BuildingName:
-	Buildable:
-		Description: Gives friendly units a medkit to heal themselves.
 	ThrowsShrapnel@SMALL:
 		Pieces: 5, 9
 	ThrowsShrapnel@LARGE:
@@ -1145,8 +1143,6 @@ CTDAM:
 		Sequence: idle-lights
 	WithIdleOverlay@WATER:
 		Sequence: idle-water
-	Buildable:
-		Description: Provides power for other structures
 	ThrowsShrapnel@SMALL:
 		Pieces: 5, 9
 	ThrowsShrapnel@LARGE:
@@ -1249,10 +1245,6 @@ GASAND:
 
 GASPOT:
 	Inherits: ^Building
-	Buildable:
-		Queue: Defense
-		Prerequisites: ~disabled
-		Description: Civilian Building
 	Valued:
 		Cost: 300
 	Tooltip:
@@ -1301,10 +1293,6 @@ GALITE:
 		Palette: alpha
 	Selectable:
 		Bounds: 24, 24, 0, -4
-	Buildable:
-		Queue: Defense
-		Prerequisites: ~disabled
-		Description: Civilian Building
 	SelectionDecorations:
 		VisualBounds: 25, 35, 0, -12
 	-Cloak@EXTERNALCLOAK:
@@ -1315,8 +1303,6 @@ TSTLAMP:
 	RenderSprites:
 		Image: galite
 	Tooltip:
-	Buildable:
-		Description: light post with alpha blending
 
 GAICBM:
 	Inherits: ^Building

--- a/mods/ts/rules/civilian-structures.yaml
+++ b/mods/ts/rules/civilian-structures.yaml
@@ -1191,88 +1191,34 @@ GAKODK:
 		Sequence: small-lights
 
 GAOLDCC1:
-	Inherits: ^CivBuilding
+	Inherits: ^OldBase
 	Tooltip:
 		Name: Old Construction Yard
-	Building:
-		Footprint: xx xx
-		Dimensions: 2, 2
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
-	RenderSprites:
-		Palette: player
 
 GAOLDCC2:
-	Inherits: ^CivBuilding
+	Inherits: ^OldBase
 	Tooltip:
 		Name: Old Temple
-	Building:
-		Footprint: xx xx
-		Dimensions: 2, 2
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
-	RenderSprites:
-		Palette: player
 
 GAOLDCC3:
-	Inherits: ^CivBuilding
+	Inherits: ^OldBase
 	Tooltip:
 		Name: Old Weapons Factory
-	Building:
-		Footprint: xx xx
-		Dimensions: 2, 2
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
-	RenderSprites:
-		Palette: player
 
 GAOLDCC4:
-	Inherits: ^CivBuilding
+	Inherits: ^OldBase
 	Tooltip:
 		Name: Old Refinery
-	Building:
-		Footprint: xx xx
-		Dimensions: 2, 2
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
-	RenderSprites:
-		Palette: player
 
 GAOLDCC5:
-	Inherits: ^CivBuilding
+	Inherits: ^OldBase
 	Tooltip:
 		Name: Old Advanced Power Plant
-	Building:
-		Footprint: xx xx
-		Dimensions: 2, 2
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
-	RenderSprites:
-		Palette: player
 
 GAOLDCC6:
-	Inherits: ^CivBuilding
+	Inherits: ^OldBase
 	Tooltip:
 		Name: Old Silos
-	Building:
-		Footprint: xx xx
-		Dimensions: 2, 2
-	Armor:
-		Type: heavy
-	Health:
-		HP: 400
-	RenderSprites:
-		Palette: player
 
 GASAND:
 	Inherits: ^Wall

--- a/mods/ts/rules/civilian-structures.yaml
+++ b/mods/ts/rules/civilian-structures.yaml
@@ -1306,6 +1306,7 @@ GASPOT:
 	Buildable:
 		Queue: Defense
 		Prerequisites: ~disabled
+		Description: Civilian Building
 	Valued:
 		Cost: 300
 	Tooltip:
@@ -1357,6 +1358,7 @@ GALITE:
 	Buildable:
 		Queue: Defense
 		Prerequisites: ~disabled
+		Description: Civilian Building
 	SelectionDecorations:
 		VisualBounds: 25, 35, 0, -12
 	-Cloak@EXTERNALCLOAK:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -191,11 +191,8 @@
 	RevealsShroud:
 		Range: 4c0
 		MaxHeightDelta: 3
-	Tooltip:
 	RenderSprites:
 		Palette: terraindecoration
-	Buildable:
-		Description: Civilian Building
 
 ^CivBillboard:
 	Inherits: ^CivBuilding

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -205,6 +205,8 @@
 		HP: 400
 	RenderSprites:
 		Palette: player
+	-Cloak@EXTERNALCLOAK:
+	-ExternalConditions@EXTERNALCLOAK:
 
 ^CivBillboard:
 	Inherits: ^CivBuilding

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -194,6 +194,18 @@
 	RenderSprites:
 		Palette: terraindecoration
 
+^OldBase:
+	Inherits: ^CivBuilding
+	Building:
+		Footprint: xx xx
+		Dimensions: 2, 2
+	Armor:
+		Type: heavy
+	Health:
+		HP: 400
+	RenderSprites:
+		Palette: player
+
 ^CivBillboard:
 	Inherits: ^CivBuilding
 	Building:


### PR DESCRIPTION
The main motivation was to remove the cloak from those old base buildings (as it looks bogus).