### PR TITLE
[RA] Add shadow to projectiles, alter armament offsets of Chrono Tank, Phase Transport

### DIFF
--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -688,12 +688,12 @@ CTNK:
 	AutoTarget:
 	Armament@PRIMARY:
 		Weapon: APTusk
-		LocalOffset: 0,-171,0
-		LocalYaw: 100
+		LocalOffset: -160,-276,232
+		LocalYaw: 60
 	Armament@SECONDARY:
 		Weapon: APTusk
-		LocalOffset: 0,171,0
-		LocalYaw: -100
+		LocalOffset: -160,276,232
+		LocalYaw: -60
 	AttackFrontal:
 	PortableChrono:
 		ChargeDelay: 300
@@ -759,7 +759,7 @@ STNK:
 		InitialStanceAI: ReturnFire
 	Armament:
 		Weapon: APTusk
-		LocalOffset: 400,0,0
+		LocalOffset: 192,0,176
 	Turreted:
 		TurnSpeed: 5
 	AttackTurreted:

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -5,6 +5,7 @@
 	Projectile: Bullet
 		Speed: 682
 		Image: 120MM
+		Shadow: True
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 40

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -10,6 +10,7 @@
 		ContrailLength: 10
 		Inaccuracy: 128
 		Image: DRAGON
+		Shadow: True
 		HorizontalRateOfTurn: 5
 		RangeLimit: 6c0
 	Warhead@1Dam: SpreadDamage
@@ -301,6 +302,7 @@ SubMissile:
 		LaunchAngle: 120
 		Inaccuracy: 2c938
 		Image: MISSILE
+		Shadow: True
 		TrailImage: smokey
 		ContrailLength: 30
 
@@ -320,11 +322,11 @@ SCUD:
 	Projectile: Bullet
 		Speed: 170
 		Blockable: false
-		Shadow: false
 		TrailImage: smokey
 		TrailDelay: 5
 		Inaccuracy: 213
 		Image: V2
+		Shadow: True
 		LaunchAngle: 62
 	Warhead@1Dam: SpreadDamage
 		Spread: 341


### PR DESCRIPTION
Following up #12685 resolving conflicts after dependencies.

I also added a commit addressing https://github.com/OpenRA/OpenRA/pull/12685#issuecomment-277510924 as to give the Chrono and Phase vehicle armament height in order for them to be able to cast shadows as well. Incidentally I had way too much fun fiddling with the values and ended up with a different set for the Chrono Tank altogether as I found the firing animation to be lacking accuracy with its xyz offset:

This CTNK armament offset aims to make it appear as if the projectiles exists both barrels on its sides from all angles. The current animation makes it so that the exit appears flawed from certain angles and overall the projectile+blowback smog spawns way ahead of the side muzzles. Also the curve of the initial path of the projectile felt slightly exaggerated, clumsy and making the adjustment more difficult.