### PR TITLE
[RA] Balance changes for next playtest/release.

### DIFF
--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -96,7 +96,7 @@ MIG:
 	Armor:
 		Type: Light
 	RevealsShroud:
-		Range: 12c0
+		Range: 13c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -155,7 +155,7 @@ YAK:
 	Armor:
 		Type: Light
 	RevealsShroud:
-		Range: 10c0
+		Range: 11c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -54,6 +54,8 @@ E1:
 		BuildPaletteOrder: 10
 		Prerequisites: ~barracks, ~techlevel.infonly
 		Description: General-purpose infantry.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft
+	Selectable:
+		Class: E1
 	Valued:
 		Cost: 100
 	Tooltip:
@@ -71,6 +73,15 @@ E1:
 		DefaultAttackSequence: shoot
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded
+
+E1R1:
+	Inherits: E1
+	RenderSprites:
+		Image: E1
+	ProducibleWithLevel:
+		Prerequisites: techlevel.infonly
+		InitialLevels: 1
+	-Buildable:
 
 E2:
 	Inherits: ^Soldier
@@ -113,6 +124,8 @@ E3:
 		BuildPaletteOrder: 30
 		Prerequisites: ~barracks, ~techlevel.infonly
 		Description: Anti-tank/Anti-aircraft infantry.\n  Strong vs Vehicles, Aircraft\n  Weak vs Infantry
+	Selectable:
+		Class: E3
 	Valued:
 		Cost: 300
 	Tooltip:
@@ -136,6 +149,15 @@ E3:
 		Prerequisites: barracks.upgraded
 	AutoTarget:
 		ScanRadius: 5
+
+E3R1:
+	Inherits: E3
+	RenderSprites:
+		Image: E3
+	ProducibleWithLevel:
+		Prerequisites: techlevel.infonly
+		InitialLevels: 1
+	-Buildable:
 
 E4:
 	Inherits: ^Soldier

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -789,7 +789,7 @@ ATEK:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 400
+		HP: 600
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1238,7 +1238,7 @@ AFLD:
 		ChargeTime: 360
 		Description: Paratroopers
 		LongDesc: A Badger drops a squad of infantry\nanywhere on the map.
-		DropItems: E1,E1,E1,E3,E3
+		DropItems: E1R1,E1R1,E1R1,E3R1,E3R1
 		SelectTargetSpeechNotification: SelectTarget
 		AllowImpassableCells: false
 		QuantizedFacings: 8
@@ -1397,7 +1397,7 @@ BARR:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 800
+		HP: 600
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1520,7 +1520,7 @@ TENT:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 800
+		HP: 600
 	Armor:
 		Type: Wood
 	RevealsShroud:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -306,7 +306,7 @@ MCV:
 		Queue: Vehicle
 		BuildPaletteOrder: 90
 		Prerequisites: fix, ~techlevel.medium
-		BuildDuration: 2000
+		BuildDuration: 2500
 		BuildDurationModifier: 40
 		Description: Deploys into another Construction Yard.\n  Unarmed
 	Valued:
@@ -488,6 +488,8 @@ MGG:
 		Queue: Vehicle
 		BuildPaletteOrder: 150
 		Prerequisites: atek, ~vehicles.france, ~techlevel.high
+		BuildDuration: 1500
+		BuildDurationModifier: 40
 		Description: Regenerates the shroud nearby, \nobscuring the area.\n  Unarmed
 	Valued:
 		Cost: 1200
@@ -516,13 +518,15 @@ MGG:
 MRJ:
 	Inherits: ^Vehicle
 	Valued:
-		Cost: 800
+		Cost: 1100
 	Tooltip:
 		Name: Mobile Radar Jammer
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 140
 		Prerequisites: atek, ~vehicles.allies, ~techlevel.high
+		BuildDuration: 1370
+		BuildDurationModifier: 40
 		Description: Jams nearby enemy radar domes\nand deflects incoming missiles.\nCan detect cloaked units.\n  Unarmed
 	Health:
 		HP: 220
@@ -531,24 +535,24 @@ MRJ:
 	Mobile:
 		Speed: 85
 	RevealsShroud:
-		Range: 6c0
+		Range: 7c0
 	WithIdleOverlay@SPINNER:
 		Sequence: spinner
 		Offset: -256,0,256
 	ProximityExternalCondition@JAMMER:
-		Range: 15c0
+		Range: 18c0
 		ValidStances: Enemy, Neutral
 		Condition: jammed
 	WithRangeCircle@JAMMER:
 		Type: jammer
-		Range: 15c0
+		Range: 18c0
 		Color: 0000FF80
 	JamsMissiles:
-		Range: 4c0
+		Range: 5c0
 		DeflectionStances: Neutral, Enemy
 	RenderJammerCircle:
 	DetectCloaked:
-		Range: 6c0
+		Range: 7c0
 
 TTNK:
 	Inherits: ^Tank

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -29,19 +29,19 @@
 
 25mm:
 	Inherits: ^Cannon
-	ReloadDelay: 13
+	ReloadDelay: 22
 	Range: 4c0
 	Report: cannon2.aud
 	Projectile: Bullet
 		Speed: 853
 		Image: 50CAL
 	Warhead@1Dam: SpreadDamage
-		Damage: 16
+		Damage: 27
 		Versus:
 			None: 30
 			Wood: 40
-			Light: 100
-			Heavy: 40
+			Light: 110
+			Heavy: 45
 			Concrete: 30
 	-Warhead@2Smu: LeaveSmudge
 	Warhead@3Eff: CreateEffect

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -172,14 +172,14 @@ RedEye:
 Stinger:
 	Inherits: ^AntiGroundMissile
 	ReloadDelay: 60
-	Range: 9c0
+	Range: 7c512
 	Burst: 2
 	BurstDelay: 0
 	Projectile: Missile
 		Arm: 3
 		Inaccuracy: 0
 		HorizontalRateOfTurn: 20
-		RangeLimit: 10c819
+		RangeLimit: 9c512
 		Speed: 170
 		CloseEnough: 149
 	Warhead@1Dam: SpreadDamage

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -25,7 +25,7 @@ FireballLauncher:
 	Burst: 2
 	BurstDelay: 20
 	Projectile: Bullet
-		Speed: 204
+		Speed: 250
 		TrailImage: fb2
 		Image: FB1
 


### PR DESCRIPTION
**Added values from pre-release1019 playtesting - Frame Limiter's (Mar-Sep, 2016) playtests and SoS playtests (v1-v1.42).**

**Allies Tech Center**
Health: 600HP, up from 400HP

**Flame Tower**
Projectile speed: 250, up from 204

**Light Tank (25mm)**
ReloadDelay: 22, up from 13 (+70%)
Damage: 27, up from 16 (+70%)
Damage vs Heavy: 45, up from 40
Damage vs Light: 110, up from 100
*Actual change with damage output: https://github.com/OpenRA/OpenRA/pull/12739#issuecomment-279234199

**Mobile Radar Jammer**
Cost: $1100, up from $800
Custom build time: 22 seconds (default is 27 sec at $1100, 20 sec at $800)
Missile Jammer range: 5c, up from 4c
Radar Jammer range: 18c, up from 15c
Vision range: 7c, up from 6c
Cloak Detection range: 7c, up from 6c

**Mobile Gap Generator**
Custom build time: 24 seconds, down from 29 seconds

**Destroyer (Stinger, StingerAA)**
Missile range: 7c512, down from 9c
Missile tracking: 9c512, down from 10c819

**Paradrop**
Infantry drops with +1 Veterancy

- - - - - - - - -

**Added values as of Frame Limiter's (Mar-Sep, 2016) playtests and GAP Experimental build playtesting.**

**YAK**
Vision range: 11c, up from 10c

**MiG**
Vision range: 13c, up from 12c

- - - - - - - - -

- **Added values as of OMnom's TechCostEdit (v3 - v4.4) and RA Experimental build v2.0.**

**Barracks/Tent**
Health: 600HP, down from 800HP

- - - - - - - - -

- **Added values as of OMnom's MCVEdit (v1-v4.0) and RA Experimental build v2.0.**

**MCV**
Custom build time: 40 seconds, up from 32 seconds

- - - - - - - - - 

Comment: With exception to the MRJ and MGG the changes above has consistently provided for better games over periods of time. Values added from post-release1019 has the benefit of being tested by multiple community members and are represented in this PR as a lower common denominator.

It is of the opinion of this author that balance changes beyond these are natured more high-risk-high-reward and/or could benefit of being layered upon the above with future playtesting.

With regards to the Paradrop veterancy the code doesn't follow any known coding standards regarding added traits and new units (E1R1, E3R1).

- - - - - - - - - 

References:

GAP Experimental build: http://www.sleipnirstuff.com/forum/viewtopic.php?t=19843
RA Experimental build v2.0-v2.2: http://www.sleipnirstuff.com/forum/viewtopic.php?t=19886
OMnom's Playtest maps: http://www.sleipnirstuff.com/forum/viewtopic.php?t=19877
SoS Playtest maps v1.5: http://www.sleipnirstuff.com/forum/viewtopic.php?t=19944