### PR TITLE
Quickfix for Trike armament offset

### DIFF
--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -636,6 +636,7 @@ wall:
 	Crushable:
 		CrushClasses: wall
 	BlocksProjectiles:
+		Height: 512
 	LineBuild:
 		Range: 5
 		NodeTypes: wall, turret

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -123,10 +123,10 @@ trike:
 	WithMuzzleOverlay:
 	Armament@damage:
 		Weapon: HMG
-		LocalOffset: -416,0,0
+		LocalOffset: 180,0,110
 	Armament@muzzle:
 		Weapon: HMG_muzzle
-		LocalOffset: -416,0,0
+		LocalOffset: -544,0,0
 		MuzzleSequence: muzzle
 	AttackFrontal:
 	AutoTarget:


### PR DESCRIPTION
Small fix for #12740

Adjusted the x and z offset from the armament, so that it won't damage a wall in the back of the vehicle.
The offsets for the muzzle stayed the same.

|New offset + combat rendering|
|:------:|
|![screenshot - 2017-02-10 - 20 15 09](https://cloud.githubusercontent.com/assets/20945684/22840517/1ed22dfe-efce-11e6-8a89-17affe0de2c2.png)|

... the white line in the front of the vehicle is for the gun armament, the line in the back is for the muzzle animation