### PR TITLE
Prevent duplicate upgrades (plugs) to GDI Upgrade Center (Pluggable Requirements)

### DIFF
--- a/OpenRA.Mods.Common/Traits/Pluggable.cs
+++ b/OpenRA.Mods.Common/Traits/Pluggable.cs
@@ -81,14 +81,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool AcceptsPlug(Actor self, string type)
 		{
-			if (active != null)
-				return false;
-
 			if (!Info.Conditions.ContainsKey(type))
 				return false;
 
 			if (!Info.Requirements.ContainsKey(type))
-			    return true;
+				return active == null;
 
 			return plugTypesAvailability[type];
 		}
@@ -98,6 +95,9 @@ namespace OpenRA.Mods.Common.Traits
 			string condition;
 			if (!Info.Conditions.TryGetValue(type, out condition))
 				return;
+
+			if (conditionToken != ConditionManager.InvalidConditionToken)
+				conditionManager.RevokeCondition(self, conditionToken);
 
 			conditionToken = conditionManager.GrantCondition(self, condition);
 			active = type;

--- a/OpenRA.Mods.Common/Traits/Pluggable.cs
+++ b/OpenRA.Mods.Common/Traits/Pluggable.cs
@@ -10,6 +10,8 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Support;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -20,22 +22,36 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly CVec Offset = CVec.Zero;
 
 		[FieldLoader.Require]
-		[Desc("Conditions to grant for each accepted plug type.")]
+		[Desc("Conditions to grant for each accepted plug type.",
+			"Key is the plug type.",
+			"Value is the condition that is granted when the plug is enabled.")]
 		public readonly Dictionary<string, string> Conditions = null;
+
+		[Desc("Requirements for accepting a plug type.",
+			"Key is the plug type that the requirements applies to.",
+			"Value is the condition expression defining the requirements to place the plug.")]
+		public readonly Dictionary<string, ConditionExpression> Requirements = new Dictionary<string, ConditionExpression>();
 
 		[GrantedConditionReference]
 		public IEnumerable<string> LinterConditions { get { return Conditions.Values; } }
 
+		[ConsumedConditionReference]
+		public IEnumerable<string> ConsumedConditions
+		{
+			get { return Requirements.Values.SelectMany(r => r.Variables).Distinct(); }
+		}
+
 		public object Create(ActorInitializer init) { return new Pluggable(init, this); }
 	}
 
-	public class Pluggable : INotifyCreated
+	public class Pluggable : IConditionConsumer, INotifyCreated
 	{
 		public readonly PluggableInfo Info;
 
 		readonly string initialPlug;
 		ConditionManager conditionManager;
 		int conditionToken = ConditionManager.InvalidConditionToken;
+		Dictionary<string, bool> plugTypesAvailability = null;
 
 		string active;
 
@@ -46,6 +62,13 @@ namespace OpenRA.Mods.Common.Traits
 			var plugInit = init.Contains<PlugsInit>() ? init.Get<PlugsInit, Dictionary<CVec, string>>() : new Dictionary<CVec, string>();
 			if (plugInit.ContainsKey(Info.Offset))
 				initialPlug = plugInit[Info.Offset];
+
+			if (info.Requirements.Count > 0)
+			{
+				plugTypesAvailability = new Dictionary<string, bool>();
+				foreach (var plug in info.Requirements)
+					plugTypesAvailability[plug.Key] = true;
+			}
 		}
 
 		public void Created(Actor self)
@@ -58,7 +81,16 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool AcceptsPlug(Actor self, string type)
 		{
-			return active == null && Info.Conditions.ContainsKey(type);
+			if (active != null)
+				return false;
+
+			if (!Info.Conditions.ContainsKey(type))
+				return false;
+
+			if (!Info.Requirements.ContainsKey(type))
+			    return true;
+
+			return plugTypesAvailability[type];
 		}
 
 		public void EnablePlug(Actor self, string type)
@@ -80,6 +112,14 @@ namespace OpenRA.Mods.Common.Traits
 				conditionToken = conditionManager.RevokeCondition(self, conditionToken);
 
 			active = null;
+		}
+
+		IEnumerable<string> IConditionConsumer.Conditions { get { return Info.ConsumedConditions; } }
+
+		void IConditionConsumer.ConditionsChanged(Actor self, IReadOnlyDictionary<string, int> conditions)
+		{
+			foreach (var req in Info.Requirements)
+				plugTypesAvailability[req.Key] = req.Value.Evaluate(conditions) != 0;
 		}
 	}
 

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -444,6 +444,9 @@ GAPLUG:
 		Conditions:
 			plug.ioncannon: plug.ioncannona
 			plug.hunterseeker: plug.hunterseekera
+		Requirements:
+			plug.ioncannon: !plug.ioncannonb && !plug.ioncannona && !plug.hunterseekera
+			plug.hunterseeker: !plug.hunterseekerb && !plug.ioncannona && !plug.hunterseekera
 	WithIdleOverlay@ioncannona:
 		RequiresCondition: plug.ioncannona
 		Sequence: idle-ioncannona
@@ -455,6 +458,9 @@ GAPLUG:
 		Conditions:
 			plug.ioncannon: plug.ioncannonb
 			plug.hunterseeker: plug.hunterseekerb
+		Requirements:
+			plug.ioncannon: !plug.ioncannona && !plug.ioncannonb && !plug.hunterseekerb
+			plug.hunterseeker: !plug.hunterseekera && !plug.ioncannonb && !plug.hunterseekerb
 	WithIdleOverlay@ioncannonb:
 		RequiresCondition: plug.ioncannonb
 		Sequence: idle-ioncannonb


### PR DESCRIPTION
While I was looking at the `BooleanExpression`/condition code,  I noticed that the **GDI Upgrade Center** accepts two of the same type of upgrade/plug. This forces the **GDI Upgrade Center** to accept only one **Seeker Control** and only one **Ion Cannon Uplink**.

This PR adds the ability to use `ConditionExpression`s for allowing a plug type instead of checking for an existing plug.

## Tests
### Component Tower armament replacement test
This allows replacing the armament of a Component Tower:
```diff
diff --git a/mods/ts/rules/gdi-support.yaml b/mods/ts/rules/gdi-support.yaml
index 31f5c8723e..8c5977ff73 100644
--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -130,6 +130,10 @@ GACTWR:
 			tower.vulcan: tower.vulcan
 			tower.rocket: tower.rocket
 			tower.sam: tower.sam
+		Requirements:
+			tower.vulcan: !tower.vulcan
+			tower.rocket: !tower.rocket
+			tower.sam: !tower.sam
 	ProvidesPrerequisite@buildingname:
 	SelectionDecorations:
 		VisualBounds: 48, 48, 0, -12
```
### Replace with like upgrade for GDI Upgrade Center Test
This tests that the support powers don't reset their timers.
```diff
diff --git a/mods/ts/rules/gdi-structures.yaml b/mods/ts/rules/gdi-structures.yaml
index a27a7c6d71..10370c7c00 100644
--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -445,8 +445,8 @@ GAPLUG:
 			plug.ioncannon: plug.ioncannona
 			plug.hunterseeker: plug.hunterseekera
 		Requirements:
-			plug.ioncannon: !plug.ioncannonb && !plug.ioncannona && !plug.hunterseekera
-			plug.hunterseeker: !plug.hunterseekerb && !plug.ioncannona && !plug.hunterseekera
+			plug.ioncannon: !plug.ioncannonb
+			plug.hunterseeker: !plug.hunterseekerb
 	WithIdleOverlay@ioncannona:
 		RequiresCondition: plug.ioncannona
 		Sequence: idle-ioncannona
@@ -459,8 +459,8 @@ GAPLUG:
 			plug.ioncannon: plug.ioncannonb
 			plug.hunterseeker: plug.hunterseekerb
 		Requirements:
-			plug.ioncannon: !plug.ioncannona && !plug.ioncannonb && !plug.hunterseekerb
-			plug.hunterseeker: !plug.hunterseekera && !plug.ioncannonb && !plug.hunterseekerb
+			plug.ioncannon: !plug.ioncannona
+			plug.hunterseeker: !plug.hunterseekera
 	WithIdleOverlay@ioncannonb:
 		RequiresCondition: plug.ioncannonb
 		Sequence: idle-ioncannonb
```