### PR TITLE
Fix RA 25mm and DepthCharge playing sounds

### DIFF
--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -44,9 +44,9 @@
 			Concrete: 30
 	-Warhead@2Smu: LeaveSmudge
 	Warhead@3Eff: CreateEffect
-		ImpactSounds:
+		-ImpactSounds:
 	Warhead@4EffWater: CreateEffect
-		ImpactSounds:
+		-ImpactSounds:
 
 90mm:
 	Inherits: ^Cannon
@@ -169,6 +169,7 @@ Grenade:
 
 DepthCharge:
 	Inherits: ^Artillery
+	-Report:
 	ReloadDelay: 60
 	Range: 5c0
 	ValidTargets: Underwater

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -191,6 +191,7 @@ DepthCharge:
 	Warhead@4EffWater: CreateEffect
 		Explosions: large_splash
 		ImpactSounds: h2obomb2.aud
+		ValidImpactTypes: Water, WaterHit
 	Warhead@3Eff: CreateEffect
 		Explosions: small_explosion
 		ImpactSounds: kaboom15.aud


### PR DESCRIPTION
25mm explosions and DepthCharge Report should be silent.

Fixes regressions from #12633.