### PR TITLE
TD Aircraft Changes. SAM fix.

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -67,7 +67,7 @@ HELI:
 		RearmBuildings: hpad
 		InitialFacing: 224
 		TurnSpeed: 7
-		Speed: 180
+		Speed: 175
 	Health:
 		HP: 125
 	Armor:
@@ -90,8 +90,8 @@ HELI:
 		Ammo: 10
 		PipCount: 5
 		SelfReloads: true
-		ReloadCount: 10
-		SelfReloadDelay: 200
+		ReloadCount: 2
+		SelfReloadDelay: 40
 	WithIdleOverlay@ROTORAIR:
 		Offset: 0,0,85
 		Sequence: rotor
@@ -147,7 +147,7 @@ ORCA:
 		PipCount: 6
 		SelfReloads: true
 		ReloadCount: 2
-		SelfReloadDelay: 100
+		SelfReloadDelay: 60
 	SpawnActorOnDeath:
 		Actor: ORCA.Husk
 	AutoTarget:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -721,7 +721,7 @@ SAM:
 	WithTurretedSpriteBody:
 	AutoSelectionSize:
 	Armament:
-		Weapon: SAMMissile
+		Weapon: Dragon
 		MuzzleSequence: muzzle
 	AttackPopupTurreted:
 	WithMuzzleOverlay:

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -93,10 +93,10 @@ OrcaAGMissiles:
 		Speed: 256
 		RangeLimit: 6c0
 	Warhead@1Dam: SpreadDamage
-		Damage: 25
+		Damage: 30
 		ValidTargets: Ground
 		Versus:
-			None: 50
+			None: 45
 			Wood: 100
 			Light: 100
 			Heavy: 75

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -62,7 +62,7 @@ HeliAGGun:
 			None: 100
 			Wood: 50
 			Light: 75
-			Heavy: 25
+			Heavy: 40
 
 HeliAAGun:
 	Inherits: HeliAGGun


### PR DESCRIPTION
Orca:

SelfReloadDelay is now 60 instead of 100.

Damage is 30 instead of 25.

Damage vs none is 45 instead of 50.

Apache:

SelfReloadDelay is now 40 instead of 200.

Reload count is now 2 instead of 10.

Damage vs heavy is now 40 instead of 25.

Movement speed is now 175 instead of 180.

---------

Orca changes were added to be effective armor killers. Currently they lack firepower to make this happen. Increasing their over all damage compensates this while also increasing their reload speed. Reducing the infantry damages helps to keep them from being infantry killers.

Apaches reload is being fixed up. 200 is way to long for their damage focus so enabling a 40 tick at just 2 instead of 10 allows them to burst fire for longer which allows more damage. They still lacked vs armor however so an increase was done to make them effective herassments vs harvesters and APC plays. The movement speed was reduced slightly due to them moving to fast still and catching Orcas and just slight turns.

-----------

SAM:

It now has the correct missile. (I didn't swap it in the original fix. Go me.) -- Switch to Dragon instead of SAMMissile.

Ill do a re-open fix for the SAM on a seperate PR. Closing this for now on discussion relations.