### PR TITLE
Polish D2k weapons and add wall explosion

### DIFF
--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -650,9 +650,9 @@ wall:
 		Weapon: WallExplode
 		EmptyWeapon: WallExplode
 	ThrowsShrapnel:
-		Weapons: Debris, Debris3
-		Pieces: 2, 2
-		Range: 2c0, 4c0
+		Weapons: Debris2, Debris3
+		Pieces: 1, 1
+		Range: 1c512, 2c768
 
 medium_gun_turret:
 	Inherits: ^Defense

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -610,9 +610,6 @@ wall:
 		BuildDuration: 54
 		BuildDurationModifier: 40
 		Description: Stop units and blocks enemy fire.
-	SoundOnDamageTransition:
-		DamagedSounds:
-		DestroyedSounds: EXPLSML4.WAV
 	Valued:
 		Cost: 20
 	CustomSellValue:
@@ -649,6 +646,9 @@ wall:
 	Sellable:
 		SellSounds: CHUNG.WAV
 	Guardable:
+	Explodes:
+		Weapon: WallExplode
+		EmptyWeapon: WallExplode
 	ThrowsShrapnel:
 		Weapons: Debris, Debris3
 		Pieces: 2, 2

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -627,7 +627,7 @@ wall:
 			TopLeft: -512, -512
 			BottomRight: 512, 512
 	Armor:
-		Type: none
+		Type: wall
 	RevealsShroud:
 		Range: 2c768
 	Crushable:

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -71,6 +71,7 @@ small_trail:
 		Start: 3988
 		Length: 4
 		Tick: 80
+		BlendMode: Additive
 		ZOffset: 1023
 
 small_trail2:
@@ -78,6 +79,7 @@ small_trail2:
 		Start: 3793
 		Length: 4
 		Tick: 80
+		BlendMode: Additive
 		ZOffset: 1023
 
 bazooka_trail:

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -52,6 +52,11 @@ explosion:
 		Start: 430
 		Length: 12
 		Tick: 1600
+	wall_explosion: DATA.R8
+		Start: 4130
+		Length: 8
+		Tick: 120
+		BlendMode: Alpha
 
 large_trail:
 	idle: DATA.R8

--- a/mods/d2k/weapons/debris.yaml
+++ b/mods/d2k/weapons/debris.yaml
@@ -2,13 +2,14 @@ Debris:
 	ReloadDelay: 60
 	Range: 2c768
 	Projectile: Bullet
-		Speed: 32, 96
+		Speed: 32, 64
 		Blockable: false
-		LaunchAngle: 30, 90
+		LaunchAngle: 128, 192
 		Inaccuracy: 1c256
 		Image: shrapnel
-		BounceCount: 2
-		BounceRangeModifier: 10
+		Shadow: true
+		BounceCount: 3
+		BounceRangeModifier: 20
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
@@ -29,16 +30,15 @@ Debris:
 		SmudgeType: SandCrater
 		InvalidTargets: Vehicle, Structure
 	Warhead@3Eff: CreateEffect
-		Explosions: small_explosion
-		ImpactSounds: EXPLLG5.WAV
+		Explosions: tiny_explosion
 
 Debris2:
 	Inherits: Debris
 	Projectile: Bullet
 		Image: shrapnel2
-		TrailImage: bazooka_trail
+		TrailImage: small_trail
 		TrailPalette: effect75alpha
-		TrailInterval: 2
+		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
 		Damage: 250
 		Versus:
@@ -54,15 +54,13 @@ Debris2:
 			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@3Eff: CreateEffect
-		Explosions: med_explosion
-		ImpactSounds: EXPLLG5.WAV
+		Explosions: small_napalm
 
 Debris3:
 	Inherits: Debris2
 	Projectile: Bullet
 		Image: shrapnel3
-		TrailImage: large_trail
-		TrailInterval: 1
+		TrailImage: small_trail2
 	Warhead@1Dam: SpreadDamage
 		Damage: 150
 
@@ -71,6 +69,3 @@ Debris4:
 	Projectile: Bullet
 		Image: shrapnel4
 		TrailImage: large_trail
-		TrailInterval: 1
-	Warhead@3Eff: CreateEffect
-		Explosions: large_explosion

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -72,7 +72,7 @@ Rocket:
 	ReloadDelay: 30
 	Range: 3c512
 	Projectile: Bullet
-		Speed: 343
+		Speed: 352
 	Warhead@1Dam: SpreadDamage
 		Spread: 160
 		Damage: 250

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -46,7 +46,7 @@
 		VerticalRateOfTurn: 10
 		Image: MISSILE2
 		TrailImage: large_trail
-		Speed: 320
+		Speed: 288
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 480
@@ -110,7 +110,6 @@ mtank_pri:
 	Range: 6c0
 	ValidTargets: Ground, Air
 	Projectile: Missile
-		Speed: 281
 		Inaccuracy: 96
 		RangeLimit: 7c204
 	Warhead@1Dam: SpreadDamage
@@ -123,7 +122,6 @@ DeviatorMissile:
 	Range: 5c0
 	Report: MISSLE1.WAV
 	Projectile: Missile
-		Speed: 281
 		RangeLimit: 6c0
 		Image: MISSILE
 		TrailImage: deviator_trail

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -30,7 +30,6 @@
 		InvalidTargets: Vehicle, Structure
 	Warhead@3Eff: CreateEffect
 		Explosions: tiny_explosion
-		ImpactSounds: EXPLSML1.WAV
 
 ^Missile:
 	Inherits: ^Rocket
@@ -63,6 +62,7 @@
 			harvester: 50
 	Warhead@3Eff: CreateEffect
 		Explosions: small_explosion
+		ImpactSounds: EXPLSML1.WAV
 
 Bazooka:
 	Inherits: ^Rocket
@@ -146,6 +146,7 @@ DeviatorMissile:
 		Explosions: deviator
 		ExplosionPalette: deviatorgas
 		UsePlayerPalette: true
+		-ImpactSounds:
 	Warhead@4OwnerChange: ChangeOwner
 		Range: 512
 		Duration: 375

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -164,9 +164,9 @@ grenade:
 	ReloadDelay: 50
 	Range: 4c0
 	Projectile: Bullet
-		Speed: 256
+		Speed: 160
 		Blockable: false
-		LaunchAngle: 75
+		LaunchAngle: 128
 		Inaccuracy: 416
 		Image: grenade
 		Shadow: true
@@ -188,7 +188,7 @@ grenade:
 		InvalidTargets: Vehicle, Structure
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion
-		ImpactSounds: EXPLLG5.WAV
+		ImpactSounds: EXPLMD2.WAV
 
 GrenDeath:
 	Warhead@1Dam: SpreadDamage

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -160,6 +160,11 @@ BuildingExplode:
 	Warhead@1Eff: CreateEffect
 		Explosions: building, self_destruct, large_explosion
 
+WallExplode:
+	Warhead@1Eff: CreateEffect
+		Explosions: wall_explosion
+		ImpactSounds: EXPLHG1.WAV
+
 grenade:
 	ReloadDelay: 50
 	Range: 4c0

--- a/mods/d2k/weapons/smallguns.yaml
+++ b/mods/d2k/weapons/smallguns.yaml
@@ -29,7 +29,6 @@ Fremen_S:
 	Report: FREMODD1.WAV
 	Warhead@2Eff: CreateEffect
 		Explosions: small_explosion
-		ImpactSounds: EXPLSML2.WAV
 
 M_LMG:
 	Inherits: ^MG


### PR DESCRIPTION
Closes #12766.
Closes #12768.

Note: The missile tank and missile turret weapons didn't have explosion sounds in the original, either, but I left them enabled here because... well, there would be almost no weapon explosion sounds otherwise.

Adding to Next milestone because it's fairly uncontroversial polish and easy to review/test.