### PR TITLE
D2K - Fix tile 195

### DIFF
--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -1461,7 +1461,7 @@ Templates:
 		Size: 2,2
 		Category: Rock-Cliff
 		Tiles:
-			0: Transition
+			0: Cliff
 			1: Cliff
 			2: Cliff
 			3: Cliff


### PR DESCRIPTION
Noticed while making Ordos 4. This needs to be completely unpassable.