### PR TITLE
D2K - Fix tiles 99 and 100

### DIFF
--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -989,7 +989,7 @@ Templates:
 		Size: 1,1
 		Category: Rock-Detail
 		Tiles:
-			0: Rock
+			0: Rough
 	Template@100:
 		Id: 100
 		Images: BLOXBASE.R8
@@ -997,7 +997,7 @@ Templates:
 		Size: 1,1
 		Category: Rock-Detail
 		Tiles:
-			0: Rock
+			0: Rough
 	Template@101:
 		Id: 101
 		Images: BLOXBASE.R8


### PR DESCRIPTION
Sorry for doing those slowly with different PRs.

Those are found on Sietch Tabr and Habbanya Erg. It is clear that those should be unbuildable and infantry only.