### PR TITLE
Throw an InvalidOperationException when a mod manifest references a bogus package

### DIFF
--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -121,7 +121,11 @@ namespace OpenRA.FileSystem
 					modPackages.Add(package);
 				}
 				else
+				{
 					package = OpenPackage(name);
+					if (package == null)
+						throw new InvalidOperationException("Could not open package '{0}', file not found or its format is not supported.".F(name));
+				}
 
 				Mount(package, explicitName);
 			}


### PR DESCRIPTION
Closes #12789

---

Bogus packages are packages that:
  * Cannot be located on disk
  * Are of an unsupported format

---

This should be merged because it takes us from
```
Exception of type `System.ArgumentNullException`: Value cannot be null.
Parameter name: key
  at System.ThrowHelper.ThrowArgumentNullException (System.ExceptionArgument argument) [0x00006] in <829ce140006e4cad9124766ee7f51179>:0
  at System.Collections.Generic.Dictionary`2[TKey,TValue].FindEntry (TKey key) [0x0000b] in <829ce140006e4cad9124766ee7f51179>:0
  at System.Collections.Generic.Dictionary`2[TKey,TValue].TryGetValue (TKey key, TValue& value) [0x00000] in <829ce140006e4cad9124766ee7f51179>:0
  at OpenRA.FileSystem.FileSystem.Mount (OpenRA.FileSystem.IReadOnlyPackage package, System.String explicitName) [0x00004] in <f7acde33042c4e48b81a545ce4cfd61b>:0
```
to
```
Exception of type `System.InvalidOperationException`: Could not open package 'foo.bar', there is no support for this format.
  at OpenRA.FileSystem.FileSystem.Mount (System.String name, System.String explicitName) [0x000b8] in /Users/thill/projects/play/openra/OpenRA.Game//FileSystem/FileSystem.cs:127
```

when an unsupported filetype is added to the packages list in a mod manifest.

---

### How to test this:

1) Add a `foo.bar` package reference to RA's manifest.
2) Create the `foo.bar` file in RA's content directory.
3) Launch the RA mod.