### PR TITLE
Use external mod switching plumbing to restart after settings changes.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -803,11 +803,6 @@ namespace OpenRA
 			state = RunStatus.Success;
 		}
 
-		public static void Restart()
-		{
-			state = RunStatus.Restart;
-		}
-
 		public static void AddChatLine(Color color, string name, string text)
 		{
 			OrderManager.AddChatLine(color, name, text);

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -470,10 +470,8 @@ namespace OpenRA
 		{
 			try
 			{
-				var argsString = mod.LaunchArgs.Append(launchArguments)
-					.Select(a => "\"" + a + "\"").JoinWith(" ");
-
-				var p = Process.Start(mod.LaunchPath, argsString);
+				var args = launchArguments != null ? mod.LaunchArgs.Append(launchArguments) : mod.LaunchArgs;
+				var p = Process.Start(mod.LaunchPath, args.Select(a => "\"" + a + "\"").JoinWith(" "));
 				if (p == null || p.HasExited)
 					onFailed();
 				else
@@ -482,8 +480,10 @@ namespace OpenRA
 					Exit();
 				}
 			}
-			catch
+			catch (Exception e)
 			{
+				Log.Write("debug", "Failed to switch to external mod.");
+				Log.Write("debug", "Error was: " + e.Message);
 				onFailed();
 			}
 		}

--- a/OpenRA.Game/Support/Program.cs
+++ b/OpenRA.Game/Support/Program.cs
@@ -22,7 +22,6 @@ namespace OpenRA
 	{
 		Error = -1,
 		Success = 0,
-		Restart = 1,
 		Running = int.MaxValue
 	}
 
@@ -131,11 +130,7 @@ namespace OpenRA
 		{
 			Game.Initialize(new Arguments(args));
 			GC.Collect();
-			var status = Game.Run();
-			if (status == RunStatus.Restart)
-				using (var p = Process.GetCurrentProcess())
-					Process.Start(Assembly.GetEntryAssembly().Location, p.StartInfo.Arguments);
-			return status;
+			return Game.Run();
 		}
 	}
 }

--- a/OpenRA.GameMonitor/GameMonitor.cs
+++ b/OpenRA.GameMonitor/GameMonitor.cs
@@ -116,7 +116,7 @@ namespace OpenRA
 
 		static void GameProcessExited(object sender, EventArgs e)
 		{
-			if (!(gameProcess.ExitCode == (int)RunStatus.Success || gameProcess.ExitCode == (int)RunStatus.Restart))
+			if (gameProcess.ExitCode != (int)RunStatus.Success)
 				ShowErrorDialog();
 
 			Exit();

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -74,13 +74,21 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					OriginalGraphicsWindowedSize != current.Graphics.WindowedSize ||
 					OriginalGraphicsFullscreenSize != current.Graphics.FullscreenSize ||
 					OriginalServerDiscoverNatDevices != current.Server.DiscoverNatDevices)
+				{
+					Action restart = () =>
+					{
+						var external = Game.ExternalMods[ExternalMod.MakeKey(Game.ModData.Manifest)];
+						Game.SwitchToExternalMod(external, null, closeAndExit);
+					};
+
 					ConfirmationDialogs.ButtonPrompt(
 						title: "Restart Now?",
 						text: "Some changes will not be applied until\nthe game is restarted. Restart now?",
-						onConfirm: Game.Restart,
+						onConfirm: restart,
 						onCancel: closeAndExit,
 						confirmText: "Restart Now",
 						cancelText: "Restart Later");
+				}
 				else
 					closeAndExit();
 			};


### PR DESCRIPTION
This ensures that the correct engine arguments are passed to the game.
Fixes #12787.