### PR TITLE
Enable enemy reveal when attacking friendly units in D2k

### DIFF
--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -91,6 +91,7 @@ ornithopter:
 	SpawnActorOnDeath:
 		Actor: ornithopter.husk
 	RejectsOrders:
+	RevealOnFire:
 
 ornithopter.husk:
 	Inherits: ^AircraftHusk

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -115,6 +115,9 @@ sandworm:
 		MovingInterval: 3
 		RequiresCondition: !attacking
 	ConditionManager:
+	RevealOnFire:
+		Duration: 50
+		Radius: 2c512
 
 sietch:
 	Inherits: ^Building

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -115,8 +115,6 @@ sandworm:
 		MovingInterval: 3
 		RequiresCondition: !attacking
 	ConditionManager:
-	Buildable:
-		Description: Attracted by vibrations in the sand.\nWill eat units whole and has a large appetite.
 
 sietch:
 	Inherits: ^Building

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -166,6 +166,7 @@
 		Sequence: pickup-indicator
 		Offset: -12, -12
 		RequiresCondition: carryall-reserved
+	RevealOnFire:
 
 ^Tank:
 	Inherits: ^Vehicle
@@ -292,6 +293,7 @@
 			Rough: 80
 	Voiced:
 		VoiceSet: InfantryVoice
+	RevealOnFire:
 
 ^Plane:
 	Inherits@1: ^ExistsInWorld
@@ -386,3 +388,4 @@
 		Range: 2c0, 4c0
 	MustBeDestroyed:
 		RequiredForShortGame: false
+	RevealOnFire:

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -44,6 +44,7 @@ engineer:
 		CaptureTypes: building, husk
 		PlayerExperience: 50
 	-AutoTarget:
+	-RevealOnFire:
 	Voiced:
 		VoiceSet: EngineerVoice
 
@@ -78,6 +79,7 @@ trooper:
 thumper:
 	Inherits: ^Infantry
 	-AutoTarget:
+	-RevealOnFire:
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 60
@@ -239,6 +241,7 @@ saboteur:
 		Flashes: 0
 		EnterBehaviour: Suicide
 	-AutoTarget:
+	-RevealOnFire:
 	Cloak:
 		InitialDelay: 85
 		CloakDelay: 85

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -45,6 +45,7 @@ mcv:
 		Step: 5
 		Delay: 3
 		HealIfBelow: 50
+	-RevealOnFire:
 
 harvester:
 	Inherits: ^Vehicle
@@ -95,6 +96,7 @@ harvester:
 		Step: 5
 		Delay: 3
 		HealIfBelow: 50
+	-RevealOnFire:
 
 trike:
 	Inherits: ^Vehicle


### PR DESCRIPTION
We have FoW enabled by default, which the original didn't have, this somewhat helps.
The original also had this (like all WW 2D RTS games).

This also fixes #7621.

I think we should try to squeeze this into the next playtest/release.