### PR TITLE
Utility and server: Get mod search paths from env MOD_SEARCH_PATHS

### DIFF
--- a/OpenRA.Server/Program.cs
+++ b/OpenRA.Server/Program.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using OpenRA.Support;
@@ -42,8 +43,12 @@ namespace OpenRA.Server
 			Game.InitializeSettings(arguments);
 			var settings = Game.Settings.Server;
 
+			var envModSearchPaths = Environment.GetEnvironmentVariable("MOD_SEARCH_PATHS");
+			var modSearchPaths = !string.IsNullOrWhiteSpace(envModSearchPaths) ?
+				FieldLoader.GetValue<string[]>("MOD_SEARCH_PATHS", envModSearchPaths) :
+				new[] { Path.Combine(".", "mods"), Path.Combine("^", "mods") };
+
 			var mod = Game.Settings.Game.Mod;
-			var modSearchPaths = new[] { Path.Combine(".", "mods"), Path.Combine("^", "mods") };
 			var mods = new InstalledMods(modSearchPaths, explicitModPaths);
 
 			// HACK: The engine code *still* assumes that Game.ModData is set

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -45,7 +45,12 @@ namespace OpenRA
 
 			Game.InitializeSettings(Arguments.Empty);
 
-			var modSearchPaths = new[] { Path.Combine(".", "mods"), Path.Combine("^", "mods") };
+			var envModSearchPaths = Environment.GetEnvironmentVariable("MOD_SEARCH_PATHS");
+			var modSearchPaths = (!string.IsNullOrWhiteSpace(envModSearchPaths) ? envModSearchPaths.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+				: new[] { Path.Combine(".", "mods"), Path.Combine("^", "mods") })
+				.Select(path => path.Trim())
+				.ToArray();
+
 			if (args.Length == 0)
 			{
 				PrintUsage(new InstalledMods(modSearchPaths, new string[0]), null);

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -46,10 +46,9 @@ namespace OpenRA
 			Game.InitializeSettings(Arguments.Empty);
 
 			var envModSearchPaths = Environment.GetEnvironmentVariable("MOD_SEARCH_PATHS");
-			var modSearchPaths = (!string.IsNullOrWhiteSpace(envModSearchPaths) ? envModSearchPaths.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
-				: new[] { Path.Combine(".", "mods"), Path.Combine("^", "mods") })
-				.Select(path => path.Trim())
-				.ToArray();
+			var modSearchPaths = !string.IsNullOrWhiteSpace(envModSearchPaths) ?
+				FieldLoader.GetValue<string[]>("MOD_SEARCH_PATHS", envModSearchPaths) :
+				new[] { Path.Combine(".", "mods"), Path.Combine("^", "mods") };
 
 			if (args.Length == 0)
 			{


### PR DESCRIPTION
This will allow thirdparty game developers to write and invoke custom *and shipped* utility commands.

The mod template will want this so it can wrap the utility in a shell script like the example below.

```sh
# utility.sh in the mod template
MODLAUNCHER=$(python -c "import os; print(os.path.realpath('$0'))")
MOD_ROOT=$(dirname "$MODLAUNCHER")
ENGINE_ROOT="$MOD_ROOT/engine"

MOD_SEARCH_PATHS="$ENGINE_ROOT/mods,$MOD_ROOT/mods" mono ./engine/OpenRA.Utility.exe "$@"
```

```sh
$ ./utility.sh
Run `OpenRA.Utility.exe [MOD]` to see a list of available commands.
The available mods are: all, cnc, d2k, modchooser, ra, ts, ra2

$ ./utility.sh ra2 | grep "import.*map"
  --import-ra-map FILENAME
  --import-td-map FILENAME
  --import-ts-map FILENAME
```

```sh
thill@tmba /Users/.../openra $ MOD_SEARCH_PATHS=. orautil
Run `OpenRA.Utility.exe [MOD]` to see a list of available commands.
The available mods are:

thill@tmba /Users/.../openra $ MOD_SEARCH_PATHS=./mods orautil
Run `OpenRA.Utility.exe [MOD]` to see a list of available commands.
The available mods are: all, cnc, d2k, modchooser, ra, ts

thill@tmba /Users/.../openra $ orautil
Run `OpenRA.Utility.exe [MOD]` to see a list of available commands.
The available mods are: all, cnc, d2k, modchooser, ra, ts

thill@tmba /Users/.../openra-ra2 $ MOD_SEARCH_PATHS=$(pwd)/mods,$(pwd)/engine/mods orautil
Run `OpenRA.Utility.exe [MOD]` to see a list of available commands.
The available mods are: ra2, all, cnc, d2k, modchooser, ra, ts

```