### PR TITLE
Added ShpTS, TmpTD to d2k|SpriteFormats in mod.yaml

### DIFF
--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -173,7 +173,7 @@ SupportsMapsFrom: d2k
 
 SoundFormats: Aud, Wav
 
-SpriteFormats: R8, ShpTD, TmpRA
+SpriteFormats: R8, ShpTD, TmpRA, TmpTD, ShpTS
 
 SpriteSequenceFormat: DefaultSpriteSequence
 


### PR DESCRIPTION
This is the intersection of SpriteFormats in ra/mod.yaml and cnc/mod.yaml added to d2k/mod.yaml.
It homogenizes used  SpriteFormats among mods and allows use of shp(TS) in d2k, which is important for people working with SHP Builder 3.37. 