### PR TITLE
Restore sell value of TD refinery.

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -174,7 +174,7 @@ PROC:
 	Selectable:
 		Bounds: 72,56,0,12
 	CustomSellValue:
-		Value: 0
+		Value: 500
 	FreeActor:
 		Actor: HARV
 		SpawnOffset: 1,2


### PR DESCRIPTION
The convention for all buildings in our main mods (and I believe all buildings in all C&C games) is that selling a full health structure will give you back half of its value in cash, and (up to) the rest in infantry.

Balancing is certainly important, and I appreciate @AoAGeneral's work on this, but breaking this convention for the TD refinery sets a precident that doesn't sit well with me.  This brings it back to the standard behaviour ($1000 of the $1500 sticker price is for the harvester, which is not refunded).