### PR TITLE
Make AutoTargetIgnore upgradeable

### DIFF
--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -259,12 +259,19 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[Desc("Will not get automatically targeted by enemy (like walls)")]
-	class AutoTargetIgnoreInfo : TraitInfo<AutoTargetIgnore> { }
-	class AutoTargetIgnore : IPreventsAutoTarget
+	class AutoTargetIgnoreInfo : ConditionalTraitInfo
 	{
+		public override object Create(ActorInitializer init) { return new AutoTargetIgnore(this); }
+	}
+
+	class AutoTargetIgnore : ConditionalTrait<AutoTargetIgnoreInfo>, IPreventsAutoTarget
+	{
+		public AutoTargetIgnore(AutoTargetIgnoreInfo info)
+			: base(info) { }
+
 		public bool PreventsAutoTarget(Actor self, Actor attacker)
 		{
-			return true;
+			return !IsTraitDisabled;
 		}
 	}
 

--- a/mods/ra/maps/soviet-05/map.yaml
+++ b/mods/ra/maps/soviet-05/map.yaml
@@ -219,7 +219,7 @@ Actors:
 		Location: 69,49
 		Owner: Greece
 		Facing: 32
-	Radar: dome.ignore
+	Radar: dome
 		Location: 70,45
 		Owner: Greece
 	Actor57: fact

--- a/mods/ra/maps/soviet-05/rules.yaml
+++ b/mods/ra/maps/soviet-05/rules.yaml
@@ -82,13 +82,11 @@ APC:
 	Buildable:
 		Prerequisites: ~disabled
 
-DOME.IGNORE:
-	Inherits: DOME
-	RenderSprites:
-		Image: DOME
+DOME:
+	ExternalCondition@lua:
+		Condition: captured
 	AutoTargetIgnore:
-	Buildable:
-		Prerequisites: ~disabled
+		RequiresCondition: !captured
 
 powerproxy.paratroopers:
 	ParatroopersPower:

--- a/mods/ra/maps/soviet-05/soviet05.lua
+++ b/mods/ra/maps/soviet-05/soviet05.lua
@@ -206,14 +206,16 @@ WorldLoaded = function()
 	Trigger.OnDamaged(mcvtransport, Expand)
 
 	Trigger.OnKilled(Radar, function()
-		player.MarkFailedObjective(CaptureObjective)
-	end)
-
-	Trigger.OnCapture(Radar, function(self, captor)
-		if captor.Owner ~= player then
-			return
+		if not player.IsObjectiveCompleted(CaptureObjective) then
+			player.MarkFailedObjective(CaptureObjective)
 		end
 
+		if HoldObjective then
+			player.MarkFailedObjective(HoldObjective)
+		end
+	end)
+
+	Trigger.OnCapture(Radar, function()
 		HoldObjective = player.AddPrimaryObjective("Defend the Radar Dome.")
 		player.MarkCompletedObjective(CaptureObjective)
 
@@ -222,15 +224,12 @@ WorldLoaded = function()
 			ExpansionCheck = true
 		end
 
-		Reinforcements.Reinforce(Greece, ArmorReinfGreece, AlliedCrossroadsToRadarPath , 0, function(soldier)
-			soldier.Hunt()
-		end)
+		Reinforcements.Reinforce(Greece, ArmorReinfGreece, AlliedCrossroadsToRadarPath , 0, IdleHunt)
 
-		Trigger.AfterDelay(1, function()
-			local newRadar = Actor.Create("dome", true, { Owner = player, Location = Radar.Location })
-			newRadar.Health = Radar.Health
-			Radar.Destroy()
-			Trigger.OnKilled(newRadar, function()
+		Radar.GrantCondition("captured")
+		Trigger.ClearAll(Radar)
+		Trigger.AfterDelay(0, function()
+			Trigger.OnRemovedFromWorld(Radar, function()
 				player.MarkFailedObjective(HoldObjective)
 			end)
 		end)


### PR DESCRIPTION
I know that adding more PRs to the milestone is not very helpful, sorry for that.
However I think that this is an easy fix (you could trick the soviet05 mission by selling the radar and thus making it impossible to fail the "defend the radar" objective) and not very hard to test.

Just nuke the borders of the base (not destroying the radar), and then spam the base with tesla coils. They should demolish everything other than the radar. Then sell them off and capture the radar. A small allied force will appear and attack the radar (which shows that it doesn't ignore autotargeting anymore).