### PR TITLE
RA - Define Badger's cameo on the sequence file

### DIFF
--- a/mods/ra/sequences/aircraft.yaml
+++ b/mods/ra/sequences/aircraft.yaml
@@ -70,3 +70,4 @@ u2:
 badr:
 	idle:
 		Facings: 16
+	icon: badricon


### PR DESCRIPTION
Fixes #12870. Badger has a cameo in game files. I don't see a reason why it is not defined here.