### PR TITLE
[RA] Change WF Cost to $1650

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -829,7 +829,7 @@ WEAP:
 		Prerequisites: proc, ~techlevel.low
 		Description: Produces vehicles.
 	Valued:
-		Cost: 2000
+		Cost: 1650 
 	Tooltip:
 		Name: War Factory
 	Building:


### PR DESCRIPTION
Following #12739, I suggest that the build time of the secondary MCV (first MCV produced out of the War Factory) should be normalized by reducing the cost of the WF to $1650 (8s build time reduction). 

The purpose of the 40s MCV in my mods was not to punish early expansions, but to discourage building MCVs en masse. I noted that a side effect of this change was that the pace of the game was much slower and that early, basepushing MCVs with tesla/turret camping was much stronger. After reviewing the replays, I've concluded that the extra 8s on the secondary MCV was to blame for much of this. 

The longer build time of the secondary MCV allowed players to place an extra barracks before they could expand. This caused an approximate 10-15% increased rate of infantry production, which caused the player's money to disappear more quickly. This enlarged gap between income and production has made Tesla / Turret camping with the secondary MCV more cost effective, as compared to the 32s MCV. With the increased rate of infantry production, the delayed income from the expansion, and the cost-efficiency of a large basepush, the games were stuck in a low-eco scenario and thus made the games heavily dependent on this secondary MCV base push. These games were tested with players of all calibers, and these effects were especially noticeable on smaller maps. 

I have been testing a $1600 WF with a $2500, 40s, 75 move speed MCV for nearly a month now with promising results. The WF change in particular realigns the scaling of economy relative to the scaling of infantry by enabling earlier harvester production to produce enough extra money to fend off a base push. The downside of this change is that the starting ore patches will dry up earlier, but in the case of basepushing, this is actually a positive change because you get to mine more of your money **before** the Tesla / Turret camping starts. In addition, this change could also pave the way to make high tech a more feasible option. 



