### PR TITLE
Lobby give admin

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -223,13 +223,27 @@ namespace OpenRA
 			om = JoinServer(IPAddress.Loopback.ToString(), CreateLocalServer(mapUID), "");
 		}
 
-		public static bool IsHost
+		public static bool IsAdmin
 		{
 			get
 			{
 				var id = OrderManager.Connection.LocalClientId;
 				var client = OrderManager.LobbyInfo.ClientWithIndex(id);
 				return client != null && client.IsAdmin;
+			}
+		}
+
+		public static bool IsHost
+		{
+			get
+			{
+				// todo: implement better detection to determine if we are hosting or connected to dedicated server
+				if (server == null)
+				{
+					return false;
+				}
+
+				return server.State != Server.ServerState.ShuttingDown;
 			}
 		}
 

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -131,7 +131,7 @@ namespace OpenRA
 
 			// Enable the bot logic on the host
 			IsBot = botType != null;
-			if (IsBot && Game.IsHost)
+			if (IsBot && Game.IsAdmin)
 			{
 				var logic = PlayerActor.TraitsImplementing<IBot>().FirstOrDefault(b => b.Info.Name == botType);
 				if (logic == null)

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -521,6 +521,46 @@ namespace OpenRA.Mods.Common.Server
 						return true;
 					}
 				},
+				{ "promote",
+					s =>
+					{
+						if (!client.IsAdmin)
+						{
+							server.SendOrderTo(conn, "Message", "Only the host can promote players.");
+							return true;
+						}
+
+						int promoteClientID;
+						try
+						{
+							Exts.TryParseIntegerInvariant(s, out promoteClientID);
+						}
+						catch
+						{
+							server.SendOrderTo(conn, "Message", "Malformed promote command.");
+							return true;
+						}
+
+						var promoteConn = server.Conns.SingleOrDefault(c => server.GetClient(c) != null && server.GetClient(c).Index == promoteClientID);
+						if (promoteConn == null)
+						{
+							server.SendOrderTo(conn, "Message", "No-one in that slot.");
+							return true;
+						}
+
+						var promoteClient = server.GetClient(promoteConn);
+						client.IsAdmin = false;
+						promoteClient.IsAdmin = true;
+
+						Log.Write("server", "Promoting client {0}.", promoteClientID);
+						server.SendMessage("{0} promoted {1}.".F(client.Name, promoteClient.Name));
+						server.SendOrderTo(promoteConn, "Message", "You have been promoted.");
+
+						server.SyncLobbyClients();
+
+						return true;
+					}
+				},
 				{ "kick",
 					s =>
 					{

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -152,7 +152,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				factions.Add(f.InternalName, new LobbyFaction { Selectable = f.Selectable, Name = f.Name, Side = f.Side, Description = f.Description });
 
 			var gameStarting = false;
-			Func<bool> configurationDisabled = () => !Game.IsHost || gameStarting ||
+			Func<bool> configurationDisabled = () => !Game.IsAdmin || gameStarting ||
 				panel == PanelType.Kick || panel == PanelType.ForceStart ||
 				!Map.RulesLoaded || Map.InvalidCustomRules ||
 				orderManager.LocalClient == null || orderManager.LocalClient.IsReady;
@@ -180,7 +180,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						{ "initialMap", Map.Uid },
 						{ "initialTab", MapClassification.System },
 						{ "onExit", DoNothing },
-						{ "onSelect", Game.IsHost ? onSelect : null },
+						{ "onSelect", Game.IsAdmin ? onSelect : null },
 						{ "filter", MapVisibility.Lobby },
 					});
 				};
@@ -681,7 +681,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					if (template == null || template.Id != emptySlotTemplate.Id)
 						template = emptySlotTemplate.Clone();
 
-					if (Game.IsHost)
+					if (Game.IsAdmin)
 						LobbyUtils.SetupEditableSlotWidget(this, template, slot, client, orderManager);
 					else
 						LobbyUtils.SetupSlotWidget(template, slot, client);
@@ -692,7 +692,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					join.OnClick = () => orderManager.IssueOrder(Order.Command("slot " + key));
 				}
 				else if ((client.Index == orderManager.LocalClient.Index) ||
-						 (client.Bot != null && Game.IsHost))
+						 (client.Bot != null && Game.IsAdmin))
 				{
 					// Editable player in slot
 					if (template == null || template.Id != editablePlayerTemplate.Id)

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -719,6 +719,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					LobbyUtils.SetupClientWidget(template, client, orderManager, client.Bot == null);
 					LobbyUtils.SetupNameWidget(template, slot, client);
+					LobbyUtils.SetupPromoteWidget(template, slot, client, orderManager, lobby);
 					LobbyUtils.SetupKickWidget(template, slot, client, orderManager, lobby,
 						() => panel = PanelType.Kick, () => panel = PanelType.Players);
 					LobbyUtils.SetupColorWidget(template, slot, client);
@@ -766,6 +767,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						template = nonEditableSpectatorTemplate.Clone();
 
 					LobbyUtils.SetupNameWidget(template, null, client);
+					LobbyUtils.SetupPromoteWidget(template, null, client, orderManager, lobby);
 					LobbyUtils.SetupKickWidget(template, null, client, orderManager, lobby,
 						() => panel = PanelType.Kick, () => panel = PanelType.Players);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -330,6 +330,20 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				slot.IsVisible = () => false;
 		}
 
+		public static void SetupPromoteWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, Widget lobby)
+		{
+			try
+			{
+				var button = parent.Get<ButtonWidget>("PROMOTE");
+				button.IsVisible = () => Game.IsAdmin && !Game.IsHost && c.Index != orderManager.LocalClient.Index;
+				button.OnClick = () => { orderManager.IssueOrder(Order.Command("promote {0}".F(c.Index))); };
+			}
+			catch (InvalidOperationException)
+			{
+				Log.Write("debug", "PROMOTE button widget not found.");
+			}
+		}
+
 		public static void SetupKickWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, Widget lobby, Action before, Action after)
 		{
 			var button = parent.Get<ButtonWidget>("KICK");

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -185,7 +185,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				.Select(a => a.Second + 1)
 				.FirstOrDefault();
 
-			var locals = orderManager.LobbyInfo.Clients.Where(c => c.Index == orderManager.LocalClient.Index || (Game.IsHost && c.Bot != null));
+			var locals = orderManager.LobbyInfo.Clients.Where(c => c.Index == orderManager.LocalClient.Index || (Game.IsAdmin && c.Bot != null));
 			var playerToMove = locals.FirstOrDefault(c => ((selectedSpawn == 0) ^ (c.SpawnPoint == 0) && !c.IsObserver));
 			SetSpawnPoint(orderManager, playerToMove, selectedSpawn);
 		}
@@ -333,7 +333,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		public static void SetupKickWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, Widget lobby, Action before, Action after)
 		{
 			var button = parent.Get<ButtonWidget>("KICK");
-			button.IsVisible = () => Game.IsHost && c.Index != orderManager.LocalClient.Index;
+			button.IsVisible = () => Game.IsAdmin && c.Index != orderManager.LocalClient.Index;
 			button.IsDisabled = () => orderManager.LocalClient.IsReady;
 			Action<bool> okPressed = tempBan => { orderManager.IssueOrder(Order.Command("kick {0} {1}".F(c.Index, tempBan))); after(); };
 			button.OnClick = () =>

--- a/mods/cnc/chrome/lobby-players.yaml
+++ b/mods/cnc/chrome/lobby-players.yaml
@@ -186,6 +186,16 @@ Container@LOBBY_PLAYER_BIN:
 							Y: 0-1
 							Width: 180
 							Height: 25
+						Button@PROMOTE:
+							X: 150
+							Width: 25
+							Height: 25
+							Children:
+								Image:
+									ImageCollection: order-icons
+									ImageName: beacon
+									X: 4
+									Y: 4
 						Button@KICK:
 							X: 180
 							Width: 25
@@ -347,6 +357,16 @@ Container@LOBBY_PLAYER_BIN:
 							Y: 0-1
 							Width: 180
 							Height: 25
+						Button@PROMOTE:
+							X: 150
+							Width: 25
+							Height: 25
+							Children:
+								Image:
+									ImageCollection: order-icons
+									ImageName: beacon
+									X: 4
+									Y: 4
 						Button@KICK:
 							X: 180
 							Width: 25

--- a/mods/common/chrome/lobby-players.yaml
+++ b/mods/common/chrome/lobby-players.yaml
@@ -182,6 +182,13 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 165
 							Height: 25
 							Text: Name
+						Button@PROMOTE:
+							X: 125
+							Y: 2
+							Width: 25
+							Height: 23
+							Text: P
+							Font: Bold
 						Button@KICK:
 							X: 155
 							Y: 2
@@ -338,6 +345,13 @@ Container@LOBBY_PLAYER_BIN:
 							X: 20
 							Y: 0-1
 							Text: Name
+						Button@PROMOTE:
+							X: 125
+							Y: 2
+							Width: 25
+							Height: 23
+							Text: P
+							Font: Bold
 						Button@KICK:
 							X: 155
 							Y: 2

--- a/mods/d2k/chrome/lobby-players.yaml
+++ b/mods/d2k/chrome/lobby-players.yaml
@@ -182,6 +182,13 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 165
 							Height: 25
 							Text: Name
+						Button@PROMOTE:
+							X: 125
+							Y: 2
+							Width: 25
+							Height: 23
+							Text: P
+							Font: Bold
 						Button@KICK:
 							X: 155
 							Y: 2
@@ -338,6 +345,13 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 160
 							Height: 25
 							Text: Name
+						Button@PROMOTE:
+							X: 125
+							Y: 2
+							Width: 25
+							Height: 23
+							Text: P
+							Font: Bold
 						Button@KICK:
 							X: 155
 							Y: 2


### PR DESCRIPTION
this being my first pull request to openra so hello everyone :)

this branch allows players connected to a dedicated server in multiplayer lobby to yield game admin privileges to other connected player, this is done by clicking on a button left to the "kick" button in players view, chosen icon for this button was "beacon" for cnc and letter P (Promote) for others mods,

caveats:
 - tweaked current interfaces a bit to distinguish between players Admin and Host property
 - works only for dedicated servers, does not work for local servers where one of the players is hosting a game, this is by design, since there would be a problem when host yielded admin rights to client and then left server, this leaves client with open server screen and unable to start multiplayer game, even though button becomes available since he is now game admin