### PR TITLE
Plug slot condition

### DIFF
--- a/OpenRA.Game/Traits/LintAttributes.cs
+++ b/OpenRA.Game/Traits/LintAttributes.cs
@@ -50,6 +50,9 @@ namespace OpenRA.Traits
 	public sealed class GrantedConditionReferenceAttribute : Attribute { }
 
 	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+	public sealed class ProvidedConditionReferenceAttribute : Attribute { }
+
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
 	public sealed class ConsumedConditionReferenceAttribute : Attribute { }
 
 	[AttributeUsage(AttributeTargets.Field)]

--- a/OpenRA.Mods.Common/Traits/Conditions/ConditionManager.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ConditionManager.cs
@@ -59,6 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			int IConditionVariable.AsInt() { return Tokens.Count; }
 			bool IConditionVariable.AsBool() { return Tokens.Count > 0; }
+			IConditionContext IConditionVariable.AsContext() { return EmptyConditionContext.Instance; }
 
 			void INotifyingConditionVariable.Add(Actor self, IConditionConsumer consumer) { Consumers.Add(consumer); }
 		}

--- a/OpenRA.Mods.Common/Traits/Conditions/ConditionalTrait.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ConditionalTrait.cs
@@ -19,8 +19,6 @@ namespace OpenRA.Mods.Common.Traits
 	/// <summary>Use as base class for *Info to subclass of UpgradableTrait. (See UpgradableTrait.)</summary>
 	public abstract class ConditionalTraitInfo : IConditionConsumerInfo, IRulesetLoaded
 	{
-		static readonly IReadOnlyDictionary<string, int> NoConditions = new ReadOnlyDictionary<string, int>(new Dictionary<string, int>());
-
 		[ConsumedConditionReference]
 		[Desc("Boolean expression defining the condition to enable this trait.")]
 		public readonly ConditionExpression RequiresCondition = null;
@@ -34,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
-			EnabledByDefault = RequiresCondition != null ? RequiresCondition.Evaluate(NoConditions) > 0 : true;
+			EnabledByDefault = RequiresCondition == null || RequiresCondition.Evaluate(EmptyConditionContext.Instance) > 0;
 		}
 	}
 
@@ -77,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyCreated.Created(Actor self) { Created(self); }
 
-		void IConditionConsumer.ConditionsChanged(Actor self, IReadOnlyDictionary<string, int> conditions)
+		void IConditionConsumer.ConditionsChanged(Actor self, IConditionContext conditions)
 		{
 			if (Info.RequiresCondition == null)
 				return;

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -110,7 +110,7 @@ namespace OpenRA.Mods.Common.Traits
 	public interface IConditionConsumer
 	{
 		IEnumerable<string> Conditions { get; }
-		void ConditionsChanged(Actor self, IReadOnlyDictionary<string, int> conditions);
+		void ConditionsChanged(Actor self, Support.IConditionContext conditions);
 	}
 
 	public interface INotifyHarvesterAction

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -113,6 +113,13 @@ namespace OpenRA.Mods.Common.Traits
 		void ConditionsChanged(Actor self, Support.IConditionContext conditions);
 	}
 
+	public interface INotifyingConditionVariable : Support.IConditionVariable { void Add(Actor self, IConditionConsumer consumer); }
+
+	public interface INotifyingConditionVariableProvider
+	{
+		IEnumerable<KeyValuePair<string, INotifyingConditionVariable>> Provided { get; }
+	}
+
 	public interface INotifyHarvesterAction
 	{
 		void MovingToResources(Actor self, CPos targetCell, Activity next);

--- a/OpenRA.Test/OpenRA.Game/ConditionExpressionTest.cs
+++ b/OpenRA.Test/OpenRA.Game/ConditionExpressionTest.cs
@@ -21,11 +21,14 @@ namespace OpenRA.Test
 	[TestFixture]
 	public class ConditionExpressionTest
 	{
-		IReadOnlyDictionary<string, int> testValues = new ReadOnlyDictionary<string, int>(new Dictionary<string, int>()
+		ConditionContext testValues = new ConditionContext
 		{
-			{ "one", 1 },
-			{ "five", 5 }
-		});
+			{ "True", new BoolConditionVariable(true) },
+			{ "False", new BoolConditionVariable(false) },
+			{ "zero", new NumberConditionVariable(0) },
+			{ "one", new NumberConditionVariable(1) },
+			{ "five", new NumberConditionVariable(5) }
+		};
 
 		void AssertFalse(string expression)
 		{
@@ -69,6 +72,9 @@ namespace OpenRA.Test
 		[TestCase(TestName = "Variables")]
 		public void TestVariables()
 		{
+			AssertValue("True", 1);
+			AssertValue("False", 0);
+			AssertValue("zero", 0);
 			AssertValue("one", 1);
 			AssertValue("five", 5);
 		}

--- a/OpenRA.Test/OpenRA.Game/ConditionExpressionTest.cs
+++ b/OpenRA.Test/OpenRA.Game/ConditionExpressionTest.cs
@@ -27,7 +27,21 @@ namespace OpenRA.Test
 			{ "False", new BoolConditionVariable(false) },
 			{ "zero", new NumberConditionVariable(0) },
 			{ "one", new NumberConditionVariable(1) },
-			{ "five", new NumberConditionVariable(5) }
+			{ "five", new NumberConditionVariable(5) },
+			{ "emptyContext", new ConditionContext() },
+			{ "context", new ConditionContext
+				{
+					{ "false", new BoolConditionVariable(false) },
+					{ "zero", new NumberConditionVariable(0) },
+					{ "six", new NumberConditionVariable(6) },
+					{ "subContext", new ConditionContext
+						{
+							{ "False", new BoolConditionVariable(false) },
+							{ "True", new BoolConditionVariable(true) }
+						}
+					}
+				}
+			}
 		};
 
 		void AssertFalse(string expression)
@@ -77,6 +91,13 @@ namespace OpenRA.Test
 			AssertValue("zero", 0);
 			AssertValue("one", 1);
 			AssertValue("five", 5);
+			AssertValue("emptyContext", 0);
+			AssertValue("context", 4);
+			AssertValue("!context.zero", 1);
+			AssertValue("context.six", 6);
+			AssertValue("context.seven", 0);
+			AssertValue("!context.subContext.False", 1);
+			AssertValue("!context.subContext.True", 0);
 		}
 
 		[TestCase(TestName = "Boolean Constants")]
@@ -340,6 +361,9 @@ namespace OpenRA.Test
 			AssertParseFailure("1 <", "Missing value or sub-expression at end for `<` operator");
 			AssertParseFailure("-1a", "Number -1 and variable merged at index 0");
 			AssertParseFailure("-", "Missing value or sub-expression at end for `-` operator");
+			AssertParseFailure("context.false", "`.` operator at index 7 requires a property name as its right operand.");
+			AssertParseFailure("false.true", "`.` operator at index 5 requires a property name as its right operand.");
+			AssertParseFailure("false.six", "`.` operator at index 5 requires a variable as its left operand.");
 		}
 
 		[TestCase(TestName = "Undefined symbols are treated as `false` (0) values")]

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -37,24 +37,26 @@ GAPOWR:
 	ScalePowerWithHealth:
 	DisabledOverlay:
 	Pluggable@pluga:
+		ConditionVariable: pluga
 		Offset: 0,1
 		Conditions:
-			powrup: powrup.a
+			powrup: powrup
 	Power@pluga:
-		RequiresCondition: powrup.a
+		RequiresCondition: pluga.powrup
 		Amount: 50
 	WithIdleOverlay@pluga:
-		RequiresCondition: powrup.a
+		RequiresCondition: pluga.powrup
 		Sequence: idle-powrupa
 	Pluggable@plugb:
+		ConditionVariable: plugb
 		Offset: 1,1
 		Conditions:
-			powrup: powrup.b
+			powrup: powrup
 	WithIdleOverlay@plugb:
-		RequiresCondition: powrup.b
+		RequiresCondition: plugb.powrup
 		Sequence: idle-powrupb
 	Power@plugb:
-		RequiresCondition: powrup.b
+		RequiresCondition: plugb.powrup
 		Amount: 50
 	ProvidesPrerequisite@buildingname:
 	SelectionDecorations:
@@ -405,7 +407,7 @@ GAPLUG:
 		MaxHeightDelta: 3
 	IonCannonPower:
 		Cursor: ioncannon
-		RequiresCondition: pluga.ioncannon || plugb.ioncannon
+		RequiresCondition: ioncannon
 		Icon: ioncannon
 		Effect: explosion
 		EffectSequence: ionring
@@ -419,7 +421,7 @@ GAPLUG:
 		DisplayRadarPing: True
 		CameraActor: camera
 	ProduceActorPower:
-		RequiresCondition: pluga.hunterseeker || plugb.hunterseeker
+		RequiresCondition: hunterseeker
 		Description: Hunter Seeker
 		LongDesc: Releases a drone that will acquire and destroy an enemy target.
 		Icon: hunterseeker
@@ -434,33 +436,33 @@ GAPLUG:
 	Power:
 		Amount: -150
 	Power@ioncannon:
-		RequiresCondition: pluga.ioncannon || plugb.ioncannon
+		RequiresCondition: ioncannon
 		Amount: -100
 	Power@hunterseeker:
-		RequiresCondition: pluga.hunterseeker || plugb.hunterseeker
+		RequiresCondition: hunterseeker
 		Amount: -50
 	Pluggable@pluga:
 		ConditionVariable: pluga
 		Offset: 0,2
 		Conditions:
-			plug.ioncannon: pluga.ioncannon
-			plug.hunterseeker: pluga.hunterseeker
-	WithIdleOverlay@ioncannona:
+			plug.ioncannon: ioncannon
+			plug.hunterseeker: hunterseeker
+	WithIdleOverlay@pluga.ioncannon:
 		RequiresCondition: pluga.ioncannon
 		Sequence: idle-ioncannona
-	WithIdleOverlay@hunterseekera:
+	WithIdleOverlay@pluga.hunterseeker:
 		RequiresCondition: pluga.hunterseeker
 		Sequence: idle-hunterseekera
 	Pluggable@plugb:
 		ConditionVariable: plugb
 		Offset: 1,2
 		Conditions:
-			plug.ioncannon: plugb.ioncannon
-			plug.hunterseeker: plugb.hunterseeker
-	WithIdleOverlay@ioncannonb:
+			plug.ioncannon: ioncannon
+			plug.hunterseeker: hunterseeker
+	WithIdleOverlay@plugb.ioncannon:
 		RequiresCondition: plugb.ioncannon
 		Sequence: idle-ioncannonb
-	WithIdleOverlay@hunterseekerb:
+	WithIdleOverlay@plugb.hunterseeker:
 		RequiresCondition: plugb.hunterseeker
 		Sequence: idle-hunterseekerb
 	ProvidesPrerequisite@buildingname:

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -405,7 +405,7 @@ GAPLUG:
 		MaxHeightDelta: 3
 	IonCannonPower:
 		Cursor: ioncannon
-		RequiresCondition: plug.ioncannona || plug.ioncannonb
+		RequiresCondition: pluga.ioncannon || plugb.ioncannon
 		Icon: ioncannon
 		Effect: explosion
 		EffectSequence: ionring
@@ -419,7 +419,7 @@ GAPLUG:
 		DisplayRadarPing: True
 		CameraActor: camera
 	ProduceActorPower:
-		RequiresCondition: plug.hunterseekera || plug.hunterseekerb
+		RequiresCondition: pluga.hunterseeker || plugb.hunterseeker
 		Description: Hunter Seeker
 		LongDesc: Releases a drone that will acquire and destroy an enemy target.
 		Icon: hunterseeker
@@ -434,32 +434,34 @@ GAPLUG:
 	Power:
 		Amount: -150
 	Power@ioncannon:
-		RequiresCondition: plug.ioncannona || plug.ioncannonb
+		RequiresCondition: pluga.ioncannon || plugb.ioncannon
 		Amount: -100
 	Power@hunterseeker:
-		RequiresCondition: plug.hunterseekera || plug.hunterseekerb
+		RequiresCondition: pluga.hunterseeker || plugb.hunterseeker
 		Amount: -50
 	Pluggable@pluga:
+		ConditionVariable: pluga
 		Offset: 0,2
 		Conditions:
-			plug.ioncannon: plug.ioncannona
-			plug.hunterseeker: plug.hunterseekera
+			plug.ioncannon: pluga.ioncannon
+			plug.hunterseeker: pluga.hunterseeker
 	WithIdleOverlay@ioncannona:
-		RequiresCondition: plug.ioncannona
+		RequiresCondition: pluga.ioncannon
 		Sequence: idle-ioncannona
 	WithIdleOverlay@hunterseekera:
-		RequiresCondition: plug.hunterseekera
+		RequiresCondition: pluga.hunterseeker
 		Sequence: idle-hunterseekera
 	Pluggable@plugb:
+		ConditionVariable: plugb
 		Offset: 1,2
 		Conditions:
-			plug.ioncannon: plug.ioncannonb
-			plug.hunterseeker: plug.hunterseekerb
+			plug.ioncannon: plugb.ioncannon
+			plug.hunterseeker: plugb.hunterseeker
 	WithIdleOverlay@ioncannonb:
-		RequiresCondition: plug.ioncannonb
+		RequiresCondition: plugb.ioncannon
 		Sequence: idle-ioncannonb
 	WithIdleOverlay@hunterseekerb:
-		RequiresCondition: plug.hunterseekerb
+		RequiresCondition: plugb.hunterseeker
 		Sequence: idle-hunterseekerb
 	ProvidesPrerequisite@buildingname:
 	SelectionDecorations:

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -128,9 +128,9 @@ GACTWR:
 	Pluggable:
 		ConditionVariable: tower
 		Conditions:
-			tower.vulcan: tower.vulcan
-			tower.rocket: tower.rocket
-			tower.sam: tower.sam
+			tower.vulcan: vulcan
+			tower.rocket: rocket
+			tower.sam: sam
 	ProvidesPrerequisite@buildingname:
 	SelectionDecorations:
 		VisualBounds: 48, 48, 0, -12

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -68,12 +68,12 @@ GACTWR:
 	BodyOrientation:
 		QuantizedFacings: 32
 	DetectCloaked:
-		RequiresCondition: tower.vulcan || tower.rocket || tower.sam
+		RequiresCondition: tower
 	Turreted:
 		TurnSpeed: 10
 		InitialFacing: 224
 	AttackTurreted:
-		RequiresCondition: tower.vulcan || tower.rocket || tower.sam
+		RequiresCondition: tower
 	CanPowerDown:
 		IndicatorPalette: mouse
 		PowerupSpeech: EnablePower
@@ -120,12 +120,13 @@ GACTWR:
 	Power@base:
 		Amount: -10
 	Power@turrets:
-		RequiresCondition: tower.vulcan || tower.rocket || tower.sam
+		RequiresCondition: tower
 		Amount: -20
 	Power@samextra:
 		RequiresCondition: tower.sam
 		Amount: -10
 	Pluggable:
+		ConditionVariable: tower
 		Conditions:
 			tower.vulcan: tower.vulcan
 			tower.rocket: tower.rocket


### PR DESCRIPTION
This is part of a bigger condition expression framework setup that I'm working on. I was hoping to get it into the next release because of planned changes to multipliers and `GainsExperience` which are already overhauled. This is just the bare framework for that with `Plug` slots. I would at least like the conditions for the Upgrade center renamed to match as an example of how they should be named for future compatibility with the dot condition expression operator.

If this is rejected from the next release, then just create a small PR renaming the plug conditions to plug{a,b}.{ioncannon,hunterseeker}

I picked a bad commit for rolling back my ConditionVariables branch. I thought a checked each commit, oh well.

A more up to date version is at https://github.com/atlimit8/OpenRA/tree/ConditionVariables.