### PR TITLE
Fix contrail gets rendered between loading in and loading out position

### DIFF
--- a/OpenRA.Mods.Common/Effects/Contrail.cs
+++ b/OpenRA.Mods.Common/Effects/Contrail.cs
@@ -42,10 +42,11 @@ namespace OpenRA.Mods.Common.Effects
 		public object Create(ActorInitializer init) { return new Contrail(init.Self, this); }
 	}
 
-	class Contrail : ITick, IRender
+	class Contrail : ITick, IRender, INotifyAddedToWorld
 	{
 		readonly ContrailInfo info;
 		readonly BodyOrientation body;
+		readonly Color color;
 
 		// This is a mutable struct, so it can't be readonly.
 		ContrailRenderable trail;
@@ -54,7 +55,7 @@ namespace OpenRA.Mods.Common.Effects
 		{
 			this.info = info;
 
-			var color = info.UsePlayerColor ? ContrailRenderable.ChooseColor(self) : info.Color;
+			color = info.UsePlayerColor ? ContrailRenderable.ChooseColor(self) : info.Color;
 			trail = new ContrailRenderable(self.World, color, info.TrailWidth, info.TrailLength, 0, info.ZOffset);
 
 			body = self.Trait<BodyOrientation>();
@@ -69,6 +70,11 @@ namespace OpenRA.Mods.Common.Effects
 		public IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)
 		{
 			return new IRenderable[] { trail };
+		}
+
+		public void AddedToWorld(Actor self)
+		{
+			trail = new ContrailRenderable(self.World, color, info.TrailWidth, info.TrailLength, 0, info.ZOffset);
 		}
 	}
 }


### PR DESCRIPTION
Closes #12877.

Another option would be to create a new `ContrailRenderable` in `AddedToWorld`, right?