### PR TITLE
Fix lint warnings on nsfremen.

### DIFF
--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -270,3 +270,4 @@ nsfremen:
 	RenderSprites:
 		Image: fremen
 	-Cloak:
+	-GrantConditionOnDamageState@UNCLOAK:


### PR DESCRIPTION
Fixes an oversight from #12759.  I didn't even notice that travis hadn't run on that PR.