### PR TITLE
Load debug symbols for mods if they are loaded from the filesystem

### DIFF
--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using OpenRA.Primitives;
@@ -54,7 +55,14 @@ namespace OpenRA
 				Assembly assembly;
 				if (!ResolvedAssemblies.TryGetValue(hash, out assembly))
 				{
-					assembly = Assembly.Load(data);
+					using (Stream stream = modFiles.Open(path))
+					{
+						if (stream.GetType() == typeof(FileStream))
+							assembly = Assembly.LoadFile(((FileStream)stream).Name);
+						else
+							assembly = Assembly.Load(data);
+					}
+
 					ResolvedAssemblies.Add(hash, assembly);
 				}
 

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -63,8 +63,8 @@ namespace OpenRA
 					if (isMonoRuntime)
 						hasSymbols = modFiles.TryOpen(path + ".mdb", out symbolStream);
 
-					// .NET and newer mono versions can load portable .pdb files.
-					if (!hasSymbols)
+					// .NET uses .pdb files.
+					else
 						hasSymbols = modFiles.TryOpen(path.Substring(0, path.Length - 4) + ".pdb", out symbolStream);
 
 					assembly = hasSymbols ? Assembly.Load(data, symbolStream.ReadAllBytes()) : Assembly.Load(data);

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -58,6 +58,8 @@ namespace OpenRA
 					Stream debugStream = null;
 					if (modFiles.TryOpen(path + ".mdb", out debugStream))
 						assembly = Assembly.Load(data, debugStream.ReadAllBytes());
+					else if (modFiles.TryOpen(path + ".pdb", out debugStream))
+						assembly = Assembly.Load(data, debugStream.ReadAllBytes());
 					else
 						assembly = Assembly.Load(data);
 					ResolvedAssemblies.Add(hash, assembly);

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -55,14 +55,11 @@ namespace OpenRA
 				Assembly assembly;
 				if (!ResolvedAssemblies.TryGetValue(hash, out assembly))
 				{
-					using (Stream stream = modFiles.Open(path))
-					{
-						if (stream.GetType() == typeof(FileStream))
-							assembly = Assembly.LoadFile(((FileStream)stream).Name);
-						else
-							assembly = Assembly.Load(data);
-					}
-
+					Stream debugStream = null;
+					if (modFiles.TryOpen(path + ".mdb", out debugStream))
+						assembly = Assembly.Load(data, debugStream.ReadAllBytes());
+					else
+						assembly = Assembly.Load(data);
 					ResolvedAssemblies.Add(hash, assembly);
 				}
 

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -56,9 +56,9 @@ namespace OpenRA
 				if (!ResolvedAssemblies.TryGetValue(hash, out assembly))
 				{
 					Stream debugStream = null;
-					if (modFiles.TryOpen(path + ".mdb", out debugStream))
+					if (Type.GetType("Mono.Runtime") != null && modFiles.TryOpen(path + ".mdb", out debugStream))
 						assembly = Assembly.Load(data, debugStream.ReadAllBytes());
-					else if (modFiles.TryOpen(path + ".pdb", out debugStream))
+					else if (modFiles.TryOpen(path.Substring(0, path.Length - 4) + ".pdb", out debugStream))
 						assembly = Assembly.Load(data, debugStream.ReadAllBytes());
 					else
 						assembly = Assembly.Load(data);


### PR DESCRIPTION
This change is needed to debug mod code in monodevelop with sources instead of disassemly.