### PR TITLE
Allow specific mods to be launched from MD/XS >= 6.1 gui.

### DIFF
--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -42,6 +42,8 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <PlatformTarget>x86</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+    <StartArguments>Game.Mod=ra</StartArguments>
+    <Commandlineparameters>Game.Mod=ra</Commandlineparameters>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <DebugSymbols>true</DebugSymbols>
@@ -53,6 +55,24 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Optimize>true</Optimize>
+    <StartArguments>Game.Mod=ra</StartArguments>
+    <Commandlineparameters>Game.Mod=ra</Commandlineparameters>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'Default' ">
+    <StartAction>Project</StartAction>
+    <StartArguments>Game.Mod=ra</StartArguments>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'Dune 2000' ">
+    <StartAction>Project</StartAction>
+    <StartArguments>Game.Mod=d2k</StartArguments>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'Tiberian Dawn' ">
+    <StartAction>Project</StartAction>
+    <StartArguments>Game.Mod=cnc</StartArguments>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'Tiberian Sun' ">
+    <StartAction>Project</StartAction>
+    <StartArguments>Game.Mod=ts</StartArguments>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
This is the first of a couple of tweaks to prepare for the removal of the ingame mod chooser.  The mod to launch can be selected from the VS/MD GUI as shown (we can't get rid of the base OpenRA.Game configuration, so that will now always launch RA).

![screen shot 2017-03-05 at 12 25 06](https://cloud.githubusercontent.com/assets/167819/23587186/d9894434-019e-11e7-9290-780dff5ddd02.png)

![screen shot 2017-03-05 at 12 24 26](https://cloud.githubusercontent.com/assets/167819/23587185/d9884ba6-019e-11e7-9c80-1670ad61b4be.png)