### PR TITLE
Fix spurious warnings when the support mods dir doesn't exist.

### DIFF
--- a/OpenRA.Game/InstalledMods.cs
+++ b/OpenRA.Game/InstalledMods.cs
@@ -46,7 +46,11 @@ namespace OpenRA
 			{
 				try
 				{
-					var directory = new DirectoryInfo(Platform.ResolvePath(path));
+					var resolved = Platform.ResolvePath(path);
+					if (!Directory.Exists(resolved))
+						continue;
+
+					var directory = new DirectoryInfo(resolved);
 					foreach (var subdir in directory.EnumerateDirectories())
 						mods.Add(Pair.New(subdir.Name, subdir.FullName));
 


### PR DESCRIPTION
Fixes #12823.
Fixes #12897.