### PR TITLE
Fix TS economy to match original

### DIFF
--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -14,6 +14,7 @@ Player:
 			Mcv: mcv
 		BuildingLimits:
 			proc: 4
+			gasilo: 2
 			gapowr: 8
 			napowr: 8
 			gapile: 1

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -146,6 +146,7 @@ GASILO:
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
 	StoresResources:
+		PipColor: Green
 		PipCount: 5
 		Capacity: 1500
 	Power:

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -81,8 +81,8 @@ PROC:
 		DiscardExcessResources: true
 	StoresResources:
 		PipColor: Green
-		PipCount: 15
-		Capacity: 3000
+		PipCount: 10
+		Capacity: 2000
 	CustomSellValue:
 		Value: 600
 	FreeActor:

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -59,7 +59,9 @@ HARV:
 		DeliveryBuildings: proc
 		Capacity: 28
 		Resources: Tiberium, BlueTiberium
-		BaleUnloadDelay: 1
+		BaleLoadDelay: 15
+		BaleUnloadDelay: 15
+		FullyLoadedSpeed: 100
 		SearchFromProcRadius: 36
 		SearchFromOrderRadius: 18
 		HarvestVoice: Attack

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -29,7 +29,7 @@
 		Palette: greentiberium
 		Sequences: tib01, tib02, tib03, tib04, tib05, tib06, tib07, tib08, tib09, tib10, tib11, tib12
 		MaxDensity: 12
-		ValuePerUnit: 50
+		ValuePerUnit: 25
 		AllowedTerrainTypes: Clear, Rough, DirtRoad
 		AllowUnderActors: true
 		TerrainType: Tiberium
@@ -41,7 +41,7 @@
 		Palette: bluetiberium
 		Sequences: tib01, tib02, tib03, tib04, tib05, tib06, tib07, tib08, tib09, tib10, tib11, tib12
 		MaxDensity: 12
-		ValuePerUnit: 100
+		ValuePerUnit: 40
 		AllowedTerrainTypes: Clear, Rough, DirtRoad
 		AllowUnderActors: true
 		TerrainType: BlueTiberium


### PR DESCRIPTION
This PR
- fixes refinery storage capacity to match TS
- fixes tib silo storage pip to use green color
- fixes values of green and blue tib to match TS
- fixes harvester load/dump delays to match TS
- fixes harvester to not get slowed down by being loaded to match TS
- limits the number of silos AI can build to 2

**Note1**: The default values for harvester loading and dump rate mentioned on ModEnc don't seem to be correct (or are unused unless the fields are listed in rules.ini), according to my own testing, both harvesting and unloading seems to happen at 15 simulation frames per 'bale' in the original, or 1 second at 15 fps.
**Note2**: Harvesters still harvest faster than in the original, because we're lacking TS' acceleration/decceleration system, which effectively slowed harvesters quite a bit in the original (they never drove at full speed when moving from tiberium patch to tiberium patch, or when approaching/leaving the refinery).
**Note3**: TS had an alternate blue tiberium with identical graphics, but lower value (Aboreus, value 30), that some original maps may actually have used (only seen a tiny bit on Grand Canyon so far, though).
**Note4**: With the huge reduction in tib value and harvest speed, I considered 2 silos more than enough for the AI, it'll probably be completely broke most of the time anyway.

Fixes #12915.
Fixes #12916.