### PR TITLE
HackyAI now builds refinery near ore.

### DIFF
--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -562,7 +562,7 @@ namespace OpenRA.Mods.Common.AI
 
 					foreach (var r in nearbyResources)
 					{
-						var found = findPos(r, baseCenter, Info.MinBaseRadius, Info.MaxBaseRadius);
+						var found = findPos(baseCenter, r, Info.MinBaseRadius, Info.MaxBaseRadius);
 						if (found != null)
 							return found;
 					}


### PR DESCRIPTION
For some reason AI always placed its refinery near CY. This fix makes it build near ore/tib patch.