### PR TITLE
Fix obelisk targeting.

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Implements the charge-then-burst attack logic specific to the RA tesla coil.")]
-	class AttackTeslaInfo : AttackOmniInfo
+	class AttackTeslaInfo : AttackBaseInfo
 	{
 		[Desc("How many charges this actor has to attack with, once charged.")]
 		public readonly int MaxCharges = 1;
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new AttackTesla(init.Self, this); }
 	}
 
-	class AttackTesla : AttackOmni, ITick, INotifyAttack
+	class AttackTesla : AttackBase, ITick, INotifyAttack
 	{
 		readonly AttackTeslaInfo info;
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
@@ -26,23 +26,25 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack)
 		{
-			return new SetTarget(this, newTarget);
+			return new SetTarget(this, newTarget, allowMove);
 		}
 
 		protected class SetTarget : Activity
 		{
 			readonly Target target;
 			readonly AttackOmni attack;
+			readonly bool allowMove;
 
-			public SetTarget(AttackOmni attack, Target target)
+			public SetTarget(AttackOmni attack, Target target, bool allowMove)
 			{
 				this.target = target;
 				this.attack = attack;
+				this.allowMove = allowMove;
 			}
 
 			public override Activity Tick(Actor self)
 			{
-				if (IsCanceled || !target.IsValidFor(self))
+				if (IsCanceled || !target.IsValidFor(self) || !attack.IsReachableTarget(target, allowMove))
 					return NextActivity;
 
 				attack.DoAttack(self, target);


### PR DESCRIPTION
Fixes #12926.

`AttackTesla` (which is the renamed version of the trait the obelisk used to use) was able to drop targets because it indirectly checked reachability via [this check](https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs#L94).  We don't want to use the full CanAttack here because that would cancel the target completely thanks to our different chargeup logic.

Only the first commit needs to be cherry picked to prep.

No other actors / traits use AttackOmni, so there is minimal risk of regressions elsewhere.