### PR TITLE
Lua script augmentable Hacky AI

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -274,8 +274,11 @@ namespace OpenRA
 				World.TraitDict.RemoveActor(this);
 				Disposed = true;
 
-				if (luaInterface != null)
-					luaInterface.Value.OnActorDestroyed();
+				foreach (var luaInterface in luaInterfaces)
+					luaInterface.Value.Value.OnActorDestroyed();
+
+				// Must not clear, some properties like IsDead still needs the context.
+				// luaInterfaces.Clear();
 			});
 		}
 
@@ -377,17 +380,17 @@ namespace OpenRA
 
 		#region Scripting interface
 
-		Lazy<ScriptActorInterface> luaInterface;
+		readonly Dictionary<LuaRuntime, Lazy<ScriptActorInterface>> luaInterfaces = new Dictionary<LuaRuntime, Lazy<ScriptActorInterface>>();
 		public void OnScriptBind(ScriptContext context)
 		{
-			if (luaInterface == null)
-				luaInterface = Exts.Lazy(() => new ScriptActorInterface(context, this));
+			if (!luaInterfaces.ContainsKey(context.Runtime))
+				luaInterfaces.Add(context.Runtime, Exts.Lazy(() => new ScriptActorInterface(context, this)));
 		}
 
 		public LuaValue this[LuaRuntime runtime, LuaValue keyValue]
 		{
-			get { return luaInterface.Value[runtime, keyValue]; }
-			set { luaInterface.Value[runtime, keyValue] = value; }
+			get { return luaInterfaces[runtime].Value[runtime, keyValue]; }
+			set { luaInterfaces[runtime].Value[runtime, keyValue] = value; }
 		}
 
 		public LuaValue Equals(LuaRuntime runtime, LuaValue left, LuaValue right)
@@ -404,9 +407,9 @@ namespace OpenRA
 			return "Actor ({0})".F(this);
 		}
 
-		public bool HasScriptProperty(string name)
+		public bool HasScriptProperty(ScriptContext context, string name)
 		{
-			return luaInterface.Value.ContainsKey(name);
+			return luaInterfaces[context.Runtime].Value.ContainsKey(name);
 		}
 
 		#endregion

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -166,6 +166,7 @@
     <Compile Include="Primitives\SpatiallyPartitioned.cs" />
     <Compile Include="Primitives\ConcurrentCache.cs" />
     <Compile Include="Primitives\ZipFileHelper.cs" />
+    <Compile Include="Scripting\AIScriptContext.cs" />
     <Compile Include="SelectableExts.cs" />
     <Compile Include="Selection.cs" />
     <Compile Include="Server\Connection.cs" />

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -221,17 +221,17 @@ namespace OpenRA
 
 		#region Scripting interface
 
-		Lazy<ScriptPlayerInterface> luaInterface;
+		readonly Dictionary<LuaRuntime, Lazy<ScriptPlayerInterface>> luaInterfaces = new Dictionary<LuaRuntime, Lazy<ScriptPlayerInterface>>();
 		public void OnScriptBind(ScriptContext context)
 		{
-			if (luaInterface == null)
-				luaInterface = Exts.Lazy(() => new ScriptPlayerInterface(context, this));
+			if (!luaInterfaces.ContainsKey(context.Runtime))
+				luaInterfaces.Add(context.Runtime, Exts.Lazy(() => new ScriptPlayerInterface(context, this)));
 		}
 
 		public LuaValue this[LuaRuntime runtime, LuaValue keyValue]
 		{
-			get { return luaInterface.Value[runtime, keyValue]; }
-			set { luaInterface.Value[runtime, keyValue] = value; }
+			get { return luaInterfaces[runtime].Value[runtime, keyValue]; }
+			set { luaInterfaces[runtime].Value[runtime, keyValue] = value; }
 		}
 
 		public LuaValue Equals(LuaRuntime runtime, LuaValue left, LuaValue right)

--- a/OpenRA.Game/Scripting/AIScriptContext.cs
+++ b/OpenRA.Game/Scripting/AIScriptContext.cs
@@ -1,0 +1,44 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using Eluant;
+
+namespace OpenRA.Scripting
+{
+	public sealed class AIScriptContext : ScriptContext
+	{
+		public AIScriptContext(World world, IEnumerable<string> scripts)
+			: base(world, null, scripts)
+		{
+		}
+
+		public void ActivateAI(string factionName, string internalName)
+		{
+			if (FatalErrorOccurred)
+				return;
+
+			using (var activateAI = (LuaFunction)Runtime.Globals["ActivateAI"])
+			{
+				activateAI.Call(factionName, internalName).Dispose();
+			}
+		}
+
+		public LuaVararg CallLuaFunc(string func, params LuaValue[] args)
+		{
+			if (FatalErrorOccurred)
+				return null;
+
+			using (var f = (LuaFunction)Runtime.Globals[func])
+				return f.Call(args);
+		}
+	}
+}

--- a/OpenRA.Game/Scripting/ScriptActorInterface.cs
+++ b/OpenRA.Game/Scripting/ScriptActorInterface.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Scripting
 				return groupCtor.Invoke(args);
 			});
 
-			Bind(objects);
+			Bind(objects, Context is AIScriptContext ? BindAIOnly : BindMissionOnly);
 		}
 
 		public void OnActorDestroyed()

--- a/OpenRA.Game/Scripting/ScriptPlayerInterface.cs
+++ b/OpenRA.Game/Scripting/ScriptPlayerInterface.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Scripting
 				return groupCtor.Invoke(args);
 			});
 
-			Bind(objects);
+			Bind(objects, Context is AIScriptContext ? BindAIOnly : BindMissionOnly);
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Scripting/Properties/ChronosphereProperties.cs
+++ b/OpenRA.Mods.Cnc/Scripting/Properties/ChronosphereProperties.cs
@@ -22,6 +22,7 @@ namespace OpenRA.Mods.Cnc.Scripting
 		public ChronsphereProperties(ScriptContext context, Actor self)
 			: base(context, self) { }
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Chronoshift a group of actors. A duration of 0 will teleport the actors permanently.")]
 		public void Chronoshift(LuaTable unitLocationPairs, int duration = 0, bool killCargo = false)
 		{

--- a/OpenRA.Mods.Cnc/Scripting/Properties/DisguiseProperties.cs
+++ b/OpenRA.Mods.Cnc/Scripting/Properties/DisguiseProperties.cs
@@ -26,12 +26,14 @@ namespace OpenRA.Mods.Cnc.Scripting
 			disguise = Self.Trait<Disguise>();
 		}
 
+		[ScriptContextAttribute(ScriptContextType.Mission)]
 		[Desc("Disguises as the target actor.")]
 		public void DisguiseAs(Actor target)
 		{
 			disguise.DisguiseAs(target);
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Disguises as the target type with the specified owner.")]
 		public void DisguiseAsType(string actorType, Player newOwner)
 		{

--- a/OpenRA.Mods.Cnc/Scripting/Properties/InfiltrateProperties.cs
+++ b/OpenRA.Mods.Cnc/Scripting/Properties/InfiltrateProperties.cs
@@ -30,6 +30,7 @@ namespace OpenRA.Mods.Cnc.Scripting
 			infiltratesTraits = Self.TraitsImplementing<Infiltrates>().ToArray();
 		}
 
+		[ScriptContextAttribute(ScriptContextType.Mission)]
 		[Desc("Infiltrate the target actor.")]
 		public void Infiltrate(Actor target)
 		{

--- a/OpenRA.Mods.Common/AI/BaseBuilder.cs
+++ b/OpenRA.Mods.Common/AI/BaseBuilder.cs
@@ -13,7 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Support;
+using OpenRA.Scripting;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.AI
@@ -27,6 +27,7 @@ namespace OpenRA.Mods.Common.AI
 		readonly Player player;
 		readonly PowerManager playerPower;
 		readonly PlayerResources playerResources;
+		readonly AIScriptContext context;
 
 		int waitTicks;
 		Actor[] playerBuildings;
@@ -45,7 +46,7 @@ namespace OpenRA.Mods.Common.AI
 
 		Water waterState = Water.NotChecked;
 
-		public BaseBuilder(HackyAI ai, string category, Player p, PowerManager pm, PlayerResources pr)
+		public BaseBuilder(HackyAI ai, string category, Player p, PowerManager pm, PlayerResources pr, AIScriptContext context)
 		{
 			this.ai = ai;
 			world = p.World;
@@ -54,6 +55,7 @@ namespace OpenRA.Mods.Common.AI
 			playerResources = pr;
 			this.category = category;
 			failRetryTicks = ai.Info.StructureProductionResumeDelay;
+			this.context = context;
 		}
 
 		public void Tick()
@@ -132,13 +134,13 @@ namespace OpenRA.Mods.Common.AI
 			{
 				// Production is complete
 				// Choose the placement logic
-				// HACK: HACK HACK HACK
-				// TODO: Derive this from BuildingCommonNames instead
-				var type = BuildingType.Building;
-				if (world.Map.Rules.Actors[currentBuilding.Item].HasTraitInfo<AttackBaseInfo>())
-					type = BuildingType.Defense;
-				else if (world.Map.Rules.Actors[currentBuilding.Item].HasTraitInfo<RefineryInfo>())
-					type = BuildingType.Refinery;
+				var type = BuildingPlacementType.Building;
+				if (ai.Info.BuildingCommonNames.Fragile.Contains(currentBuilding.Item))
+					type = BuildingPlacementType.Fragile;
+				else if (ai.Info.BuildingCommonNames.Defense.Contains(currentBuilding.Item))
+					type = BuildingPlacementType.Defense;
+				else if (ai.Info.BuildingCommonNames.Refinery.Contains(currentBuilding.Item))
+					type = BuildingPlacementType.Refinery;
 
 				var location = ai.ChooseBuildLocation(currentBuilding.Item, true, type);
 				if (location == null)
@@ -198,13 +200,89 @@ namespace OpenRA.Mods.Common.AI
 				.Sum(p => p.Amount) + playerPower.ExcessPower) >= ai.Info.MinimumExcessPower;
 		}
 
+		ActorInfo QueryScript(ProductionQueue queue, IEnumerable<ActorInfo> buildableThings)
+		{
+			var luaParams = context.CreateTable();
+
+			// Lets prepare parameters for lua call.
+			// Modders are free to add more if necessary.
+			// We assert that no buildings have names like nil or none or null.
+			// (Which crazy modders will do that anyway? Unless they are making a mod that is themed computer science/mathematics)
+			luaParams.Add("queue_type", queue.Info.Type.ToLowerInvariant());
+
+			var player_buildings = playerBuildings.Select(pb => pb.Info.Name.ToLowerInvariant()).ToArray();
+			luaParams.Add("player_buildings", player_buildings.ToLuaValue(context));
+
+			var buildable_things = buildableThings.Select(th => th.Name.ToLowerInvariant()).ToArray();
+			luaParams.Add("builable_things", buildable_things.ToLuaValue(context));
+
+			var power = GetProducibleBuilding(ai.Info.BuildingCommonNames.Power, buildableThings,
+				a => a.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(p => p.Amount)); // find the best power plant
+			int powerGen = 0;
+			if (power != null)
+				powerGen = power.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(p => p.Amount);
+
+			// Factions like GLA doesn't have powerplants. Must check.
+			if (power != null && powerGen > 0)
+			{
+				luaParams.Add("power", power.Name);
+				luaParams.Add("power_gen", powerGen);
+			}
+			else
+			{
+				luaParams.Add("power", null);
+				luaParams.Add("power_gen", 0);
+			}
+
+			// excess power information
+			luaParams.Add("excess_power", playerPower.ExcessPower);
+			luaParams.Add("minimum_excess_power", ai.Info.MinimumExcessPower);
+
+			// Finally! Call lua func.
+			var ret = context.CallLuaFunc("BB_choose_building_to_build", luaParams);
+			if (ret == null)
+				return null; // shouldn't happen but just to be sure.
+			if (ret.Count() == 0)
+				return null; // hmmm.. this shouldn't happen either.
+
+			// get ret val and dispose stuff.
+			string n = ret[0].ToString().ToLowerInvariant();
+			ret.Dispose();
+			luaParams.Dispose();
+
+			// decode results for AI.
+			// Modders may not use "nil" as their building name. I'm not sure of a good way to enforce that.
+			if (n == "nil")
+				return null; // lua chose to build nothing.
+
+			if (world.Map.Rules.Actors.ContainsKey(n))
+				return world.Map.Rules.Actors[n];
+
+			// If not found, it can be some errorneous lua input.
+			// However, there is a special keyword that allows AI to do old hacky behavior.
+			if (n != "hacky_fallback")
+				return null;
+
+			// Fall back to hacky selection.
+			return HackyChooseBuildingToBuild(queue, buildableThings);
+		}
+
 		ActorInfo ChooseBuildingToBuild(ProductionQueue queue)
 		{
 			var buildableThings = queue.BuildableItems();
+			if (!buildableThings.Any())
+				return null;
 
-			// This gets used quite a bit, so let's cache it here
+			if (context != null)
+				return QueryScript(queue, buildableThings);
+			else
+				return HackyChooseBuildingToBuild(queue, buildableThings);
+		}
+
+		ActorInfo HackyChooseBuildingToBuild(ProductionQueue queue, IEnumerable<ActorInfo> buildableThings)
+		{
 			var power = GetProducibleBuilding(ai.Info.BuildingCommonNames.Power, buildableThings,
-				a => a.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(p => p.Amount));
+				a => a.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(p => p.Amount)); // find the best power plant
 
 			// First priority is to get out of a low power situation
 			if (playerPower.ExcessPower < ai.Info.MinimumExcessPower)

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Pathfinder;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Scripting;
 using OpenRA.Support;
 using OpenRA.Traits;
 
@@ -57,6 +58,8 @@ namespace OpenRA.Mods.Common.AI
 			public readonly HashSet<string> Production = new HashSet<string>();
 			public readonly HashSet<string> NavalProduction = new HashSet<string>();
 			public readonly HashSet<string> Silo = new HashSet<string>();
+			public readonly HashSet<string> Fragile = new HashSet<string>();
+			public readonly HashSet<string> Defense = new HashSet<string>();
 		}
 
 		[FieldLoader.Require]
@@ -65,6 +68,12 @@ namespace OpenRA.Mods.Common.AI
 
 		[Desc("Human-readable name this bot uses.")]
 		public readonly string Name = "Unnamed Bot";
+
+		[Desc("The Script AI will read and execute")]
+		public readonly string LuaScript;
+
+		[Desc("Build units according to Lua script? (false = old hacky AI behavior).")]
+		public readonly bool EnableLuaUnitProduction = false;
 
 		[Desc("Minimum number of units AI must have before attacking.")]
 		public readonly int SquadSize = 8;
@@ -143,6 +152,9 @@ namespace OpenRA.Mods.Common.AI
 
 		[Desc("Minimum distance in cells from center of the base when checking for building placement.")]
 		public readonly int MinBaseRadius = 2;
+
+		[Desc("Same as MinBaseRadius but for fragile structures to push them further away.")]
+		public readonly int MinFragilePlacementRadius = 8;
 
 		[Desc("Radius in cells around the center of the base to expand.")]
 		public readonly int MaxBaseRadius = 20;
@@ -243,7 +255,7 @@ namespace OpenRA.Mods.Common.AI
 		public object Create(ActorInitializer init) { return new HackyAI(this, init); }
 	}
 
-	public enum BuildingType { Building, Defense, Refinery }
+	public enum BuildingPlacementType { Building, Defense, Refinery, Fragile }
 
 	public sealed class HackyAI : ITick, IBot, INotifyDamage
 	{
@@ -268,7 +280,6 @@ namespace OpenRA.Mods.Common.AI
 		readonly IPathFinder pathfinder;
 
 		readonly Func<Actor, bool> isEnemyUnit;
-		readonly Predicate<Actor> unitCannotBeOrdered;
 		Dictionary<SupportPowerInstance, int> waitingPowers = new Dictionary<SupportPowerInstance, int>();
 		Dictionary<string, SupportPowerDecision> powerDecisions = new Dictionary<string, SupportPowerDecision>();
 
@@ -302,6 +313,9 @@ namespace OpenRA.Mods.Common.AI
 
 		readonly Queue<Order> orders = new Queue<Order>();
 
+		readonly HashSet<Actor> luaOccupiedActors = new HashSet<Actor>();
+		readonly Dictionary<Player, AIScriptContext> luaContexts = new Dictionary<Player, AIScriptContext>();
+
 		public HackyAI(HackyAIInfo info, ActorInitializer init)
 		{
 			Info = info;
@@ -319,12 +333,33 @@ namespace OpenRA.Mods.Common.AI
 					&& !unit.Info.HasTraitInfo<HuskInfo>()
 					&& unit.Info.HasTraitInfo<ITargetableInfo>();
 
-			unitCannotBeOrdered = a => a.Owner != Player || a.IsDead || !a.IsInWorld;
-
 			foreach (var decision in info.PowerDecisions)
 				powerDecisions.Add(decision.OrderName, decision);
 
 			maximumCaptureTargetOptions = Math.Max(1, Info.MaximumCaptureTargetOptions);
+		}
+
+		public void SetLuaOccupied(Actor a, bool occupied)
+		{
+			if (occupied)
+				luaOccupiedActors.Add(a);
+			else
+				luaOccupiedActors.Remove(a);
+		}
+
+		public bool IsLuaOccupied(Actor a)
+		{
+			return luaOccupiedActors.Contains(a);
+		}
+
+		bool UnitCannotBeOrdered(Actor a)
+		{
+			if (a.Owner != Player || a.IsDead || !a.IsInWorld)
+				return true;
+
+			// Actors in luaOccupiedActors are under control of scripted actions and
+			// shouldn't be ordered by the default hacky controller.
+			return IsLuaOccupied(a);
 		}
 
 		public static void BotDebug(string s, params object[] args)
@@ -342,10 +377,25 @@ namespace OpenRA.Mods.Common.AI
 			supportPowerMngr = p.PlayerActor.Trait<SupportPowerManager>();
 			playerResource = p.PlayerActor.Trait<PlayerResources>();
 
+			if (luaContexts.ContainsKey(p))
+			{
+				luaContexts[p].Dispose();
+				luaContexts.Remove(p);
+			}
+
+			AIScriptContext context = null;
+			if (Info.LuaScript != null)
+			{
+				// when no script given, Hacky AI behavior is still in effect and will continue to work as before.
+				string[] scripts = { Info.LuaScript };
+				context = new AIScriptContext(World, scripts); // Create context (not yet activated)
+				luaContexts.Add(p, context);
+			}
+
 			foreach (var building in Info.BuildingQueues)
-				builders.Add(new BaseBuilder(this, building, p, playerPower, playerResource));
+				builders.Add(new BaseBuilder(this, building, p, playerPower, playerResource, context));
 			foreach (var defense in Info.DefenseQueues)
-				builders.Add(new BaseBuilder(this, defense, p, playerPower, playerResource));
+				builders.Add(new BaseBuilder(this, defense, p, playerPower, playerResource, context));
 
 			Random = new MersenneTwister(Game.CosmeticRandom.Next());
 
@@ -513,52 +563,102 @@ namespace OpenRA.Mods.Common.AI
 			return true;
 		}
 
+		// Given base center position and front vector (front vector starts from center and moves in front direction),
+		// find a buildable cell in front semi-circle (or semi-annulus)
+		// This function is currently used for placing structure in rear area.
+		// (if you invert front vector you get rear)
+		CPos? FindPosFront(CPos center, CVec front, int minRange, int maxRange,
+			string actorType, BuildingInfo bi, bool distanceToBaseIsImportant)
+		{
+			// zero vector case. we can't define front or rear.
+			if (front == CVec.Zero)
+				return FindPos(center, center, minRange, maxRange, actorType, bi, distanceToBaseIsImportant);
+
+			var cells = Map.FindTilesInAnnulus(center, minRange, maxRange).Shuffle(Random);
+			foreach (var cell in cells)
+			{
+				var v = cell - center;
+				if (!World.CanPlaceBuilding(actorType, bi, cell, null))
+					continue;
+
+				if (CVec.Dot(front, v) > 0)
+					return cell;
+			}
+
+			// Front is so full of buildings that we can't place anything.
+			return null;
+		}
+
+		// Find the buildable cell that is closest to pos and centered around center
+		CPos? FindPos(CPos center, CPos target, int minRange, int maxRange,
+			string actorType, BuildingInfo bi, bool distanceToBaseIsImportant)
+		{
+			var cells = Map.FindTilesInAnnulus(center, minRange, maxRange);
+
+			// Sort by distance to target if we have one
+			if (center != target)
+				cells = cells.OrderBy(c => (c - target).LengthSquared);
+			else
+				cells = cells.Shuffle(Random);
+
+			foreach (var cell in cells)
+			{
+				if (!World.CanPlaceBuilding(actorType, bi, cell, null))
+					continue;
+
+				if (distanceToBaseIsImportant && !bi.IsCloseEnoughToBase(World, Player, actorType, cell))
+					continue;
+
+				return cell;
+			}
+
+			return null;
+		}
+
 		CPos defenseCenter;
-		public CPos? ChooseBuildLocation(string actorType, bool distanceToBaseIsImportant, BuildingType type)
+		public CPos? ChooseBuildLocation(string actorType, bool distanceToBaseIsImportant, BuildingPlacementType type)
 		{
 			var bi = Map.Rules.Actors[actorType].TraitInfoOrDefault<BuildingInfo>();
 			if (bi == null)
 				return null;
 
-			// Find the buildable cell that is closest to pos and centered around center
-			Func<CPos, CPos, int, int, CPos?> findPos = (center, target, minRange, maxRange) =>
-			{
-				var cells = Map.FindTilesInAnnulus(center, minRange, maxRange);
-
-				// Sort by distance to target if we have one
-				if (center != target)
-					cells = cells.OrderBy(c => (c - target).LengthSquared);
-				else
-					cells = cells.Shuffle(Random);
-
-				foreach (var cell in cells)
-				{
-					if (!World.CanPlaceBuilding(actorType, bi, cell, null))
-						continue;
-
-					if (distanceToBaseIsImportant && !bi.IsCloseEnoughToBase(World, Player, actorType, cell))
-						continue;
-
-					return cell;
-				}
-
-				return null;
-			};
-
 			var baseCenter = GetRandomBaseCenter();
 
 			switch (type)
 			{
-				case BuildingType.Defense:
+				case BuildingPlacementType.Defense:
+					{
+						// Build near the closest enemy structure
+						var closestEnemy = World.ActorsHavingTrait<Building>().Where(a => !a.Disposed && Player.Stances[a.Owner] == Stance.Enemy)
+							.ClosestTo(World.Map.CenterOfCell(defenseCenter));
 
-					// Build near the closest enemy structure
-					var closestEnemy = World.ActorsHavingTrait<Building>().Where(a => !a.Disposed && Player.Stances[a.Owner] == Stance.Enemy)
-						.ClosestTo(World.Map.CenterOfCell(defenseCenter));
+						var targetCell = closestEnemy != null ? closestEnemy.Location : baseCenter;
+						return FindPos(defenseCenter, targetCell, Info.MinimumDefenseRadius, Info.MaximumDefenseRadius,
+							actorType, bi, distanceToBaseIsImportant);
+					}
 
-					var targetCell = closestEnemy != null ? closestEnemy.Location : baseCenter;
-					return findPos(defenseCenter, targetCell, Info.MinimumDefenseRadius, Info.MaximumDefenseRadius);
+				case BuildingPlacementType.Fragile:
+					{
+						// Build far from the closest enemy structure
+						var closestEnemy = World.ActorsHavingTrait<Building>().Where(a => !a.Disposed && Player.Stances[a.Owner] == Stance.Enemy)
+							.ClosestTo(World.Map.CenterOfCell(defenseCenter));
 
-				case BuildingType.Refinery:
+						CVec direction = CVec.Zero;
+						if (closestEnemy != null)
+							direction = baseCenter - closestEnemy.Location;
+
+						// MinFragilePlacementRadius introduced to push fragile buildings away from base center.
+						// Resilient to nuke.
+						var pos = FindPosFront(baseCenter, direction, Info.MinFragilePlacementRadius, Info.MaxBaseRadius,
+							actorType, bi, distanceToBaseIsImportant);
+						if (pos == null) // rear placement failed but we can still try placing anywhere.
+							pos = FindPos(baseCenter, baseCenter, Info.MinBaseRadius,
+								distanceToBaseIsImportant ? Info.MaxBaseRadius : Map.Grid.MaximumTileSearchRange,
+								actorType, bi, distanceToBaseIsImportant);
+						return pos;
+					}
+
+				case BuildingPlacementType.Refinery:
 
 					// Try and place the refinery near a resource field
 					var nearbyResources = Map.FindTilesInAnnulus(baseCenter, Info.MinBaseRadius, Info.MaxBaseRadius)
@@ -567,16 +667,20 @@ namespace OpenRA.Mods.Common.AI
 
 					foreach (var r in nearbyResources)
 					{
-						var found = findPos(baseCenter, r, Info.MinBaseRadius, Info.MaxBaseRadius);
+						var found = FindPos(baseCenter, r, Info.MinBaseRadius, Info.MaxBaseRadius,
+							actorType, bi, distanceToBaseIsImportant);
 						if (found != null)
 							return found;
 					}
 
 					// Try and find a free spot somewhere else in the base
-					return findPos(baseCenter, baseCenter, Info.MinBaseRadius, Info.MaxBaseRadius);
+					return FindPos(baseCenter, baseCenter, Info.MinBaseRadius, Info.MaxBaseRadius,
+						actorType, bi, distanceToBaseIsImportant);
 
-				case BuildingType.Building:
-					return findPos(baseCenter, baseCenter, Info.MinBaseRadius, distanceToBaseIsImportant ? Info.MaxBaseRadius : Map.Grid.MaximumTileSearchRange);
+				case BuildingPlacementType.Building:
+					return FindPos(baseCenter, baseCenter, Info.MinBaseRadius,
+						distanceToBaseIsImportant ? Info.MaxBaseRadius : Map.Grid.MaximumTileSearchRange,
+						actorType, bi, distanceToBaseIsImportant);
 			}
 
 			// Can't find a build location
@@ -591,9 +695,23 @@ namespace OpenRA.Mods.Common.AI
 			ticks++;
 
 			if (ticks == 1)
+			{
 				InitializeBase(self);
 
-			if (ticks % FeedbackTime == 0)
+				// Activating here. Some variables aren't available in Lua at tick 0.
+				foreach (var kv in luaContexts)
+					kv.Value.ActivateAI(Player.Faction.Name, Player.InternalName);
+			}
+			else
+			{
+				// Don't tick at ticks 0 and 1.
+				if (Info.EnableLuaUnitProduction) // tick each lua AI context only when told so.
+					foreach (var kv in luaContexts)
+						kv.Value.Tick(self);
+			}
+
+			// Fall back to hacky random production when lua production not set.
+			if (!Info.EnableLuaUnitProduction && ticks % FeedbackTime == 0)
 				ProductionUnits(self);
 
 			AssignRolesToIdleUnits(self);
@@ -628,7 +746,7 @@ namespace OpenRA.Mods.Common.AI
 		{
 			Squads.RemoveAll(s => !s.IsValid);
 			foreach (var s in Squads)
-				s.Units.RemoveAll(unitCannotBeOrdered);
+				s.Units.RemoveAll(UnitCannotBeOrdered);
 		}
 
 		// Use of this function requires that one squad of this type. Hence it is a piece of shit
@@ -648,8 +766,8 @@ namespace OpenRA.Mods.Common.AI
 		{
 			CleanSquads();
 
-			activeUnits.RemoveAll(unitCannotBeOrdered);
-			unitsHangingAroundTheBase.RemoveAll(unitCannotBeOrdered);
+			activeUnits.RemoveAll(UnitCannotBeOrdered);
+			unitsHangingAroundTheBase.RemoveAll(UnitCannotBeOrdered);
 
 			if (--rushTicks <= 0)
 			{
@@ -886,7 +1004,9 @@ namespace OpenRA.Mods.Common.AI
 
 				if (AttackOrFleeFuzzy.Rush.CanAttack(ownUnits, enemies))
 				{
-					var target = enemies.Any() ? enemies.Random(Random) : b;
+					Actor target = enemies.Any() ? enemies.Random(Random) : b;
+					//// TODO: make on target selected Lua call
+
 					var rush = GetSquadOfType(SquadType.Rush);
 					if (rush == null)
 						rush = RegisterNewSquad(SquadType.Rush, target);
@@ -988,7 +1108,7 @@ namespace OpenRA.Mods.Common.AI
 				var restrictToBase = Info.RestrictMCVDeploymentFallbackToBase &&
 					CountBuildingByCommonName(Info.BuildingCommonNames.ConstructionYard, Player) > 0;
 
-				var desiredLocation = ChooseBuildLocation(transformsInfo.IntoActor, restrictToBase, BuildingType.Building);
+				var desiredLocation = ChooseBuildLocation(transformsInfo.IntoActor, restrictToBase, BuildingPlacementType.Building);
 				if (desiredLocation == null)
 					continue;
 

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -192,6 +192,7 @@
     <Compile Include="ActorInitializer.cs" />
     <Compile Include="Projectiles\Railgun.cs" />
     <Compile Include="Scripting\Properties\AmmoPoolProperties.cs" />
+    <Compile Include="Scripting\Properties\HackyAIProperties.cs" />
     <Compile Include="ShroudExts.cs" />
     <Compile Include="Orders\BeaconOrderGenerator.cs" />
     <Compile Include="Orders\DeployOrderTargeter.cs" />

--- a/OpenRA.Mods.Common/Scripting/Global/ActorGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ActorGlobal.cs
@@ -22,6 +22,7 @@ namespace OpenRA.Mods.Common.Scripting
 	{
 		public ActorGlobal(ScriptContext context) : base(context) { }
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Create a new actor. initTable specifies a list of key-value pairs that defines the initial parameters for the actor's traits.")]
 		public Actor Create(string type, bool addToWorld, LuaTable initTable)
 		{

--- a/OpenRA.Mods.Common/Scripting/Global/BeaconGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/BeaconGlobal.cs
@@ -25,6 +25,7 @@ namespace OpenRA.Mods.Common.Scripting
 			radarPings = context.World.WorldActor.TraitOrDefault<RadarPings>();
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Creates a new beacon that stays for the specified time at the specified WPos. " +
 			"Does not remove player set beacons, nor gets removed by placing them.")]
 		public Beacon New(Player owner, WPos position, int duration = 30 * 25, bool showRadarPings = true)

--- a/OpenRA.Mods.Common/Scripting/Global/CameraGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/CameraGlobal.cs
@@ -19,6 +19,7 @@ namespace OpenRA.Mods.Common.Scripting
 		public CameraGlobal(ScriptContext context)
 			: base(context) { }
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("The center of the visible viewport.")]
 		public WPos Position
 		{

--- a/OpenRA.Mods.Common/Scripting/Global/FacingGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/FacingGlobal.cs
@@ -20,12 +20,19 @@ namespace OpenRA.Mods.Common.Scripting.Global
 			: base(context) { }
 
 		public int North { get { return 0; } }
+
 		public int NorthWest { get { return 32; } }
+
 		public int West { get { return 64; } }
+
 		public int SouthWest { get { return 96; } }
+
 		public int South { get { return 128; } }
+
 		public int SouthEast { get { return 160; } }
+
 		public int East { get { return 192; } }
+
 		public int NorthEast { get { return 224; } }
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/Global/LightingGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/LightingGlobal.cs
@@ -30,6 +30,7 @@ namespace OpenRA.Mods.Common.Scripting
 			hasLighting = lighting != null;
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Controls the `FlashPaletteEffect` trait.")]
 		public void Flash(string type = null, int ticks = -1)
 		{
@@ -41,24 +42,32 @@ namespace OpenRA.Mods.Common.Scripting
 		public double Red
 		{
 			get { return hasLighting ? lighting.Red : 1d; }
+
+			[ScriptContext(ScriptContextType.Mission)]
 			set { if (hasLighting) lighting.Red = (float)value; }
 		}
 
 		public double Green
 		{
 			get { return hasLighting ? lighting.Green : 1d; }
+
+			[ScriptContext(ScriptContextType.Mission)]
 			set { if (hasLighting) lighting.Green = (float)value; }
 		}
 
 		public double Blue
 		{
 			get { return hasLighting ? lighting.Blue : 1d; }
+
+			[ScriptContext(ScriptContextType.Mission)]
 			set { if (hasLighting) lighting.Blue = (float)value; }
 		}
 
 		public double Ambient
 		{
 			get { return hasLighting ? lighting.Ambient : 1d; }
+
+			[ScriptContext(ScriptContextType.Mission)]
 			set { if (hasLighting) lighting.Ambient = (float)value; }
 		}
 	}

--- a/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
@@ -70,7 +70,6 @@ namespace OpenRA.Mods.Common.Scripting
 			}
 		}
 
-		[Desc("Returns a random cell inside the visible region of the map.")]
 		public CPos RandomCell()
 		{
 			return Context.World.Map.ChooseRandomCell(Context.World.SharedRandom);

--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -37,18 +37,21 @@ namespace OpenRA.Mods.Common.Scripting
 			playlist = world.WorldActor.Trait<MusicPlaylist>();
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Play an announcer voice listed in notifications.yaml")]
 		public void PlaySpeechNotification(Player player, string notification)
 		{
 			Game.Sound.PlayNotification(world.Map.Rules, player, "Speech", notification, player != null ? player.Faction.InternalName : null);
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Play a sound listed in notifications.yaml")]
 		public void PlaySoundNotification(Player player, string notification)
 		{
 			Game.Sound.PlayNotification(world.Map.Rules, player, "Sounds", notification, player != null ? player.Faction.InternalName : null);
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Play a sound file")]
 		public void PlaySound(string file)
 		{
@@ -56,6 +59,7 @@ namespace OpenRA.Mods.Common.Scripting
 			Game.Sound.Play(SoundType.World, file);
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Play track defined in music.yaml or map.yaml, or keep track empty for playing a random song.")]
 		public void PlayMusic(string track = null, LuaFunction func = null)
 		{
@@ -87,6 +91,7 @@ namespace OpenRA.Mods.Common.Scripting
 				playlist.Play(musicInfo);
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Play track defined in music.yaml or map.yaml as background music." +
 			" If music is already playing use Media.StopMusic() to stop it" +
 			" and the background music will start automatically." +
@@ -99,6 +104,7 @@ namespace OpenRA.Mods.Common.Scripting
 			playlist.SetBackgroundMusic(string.IsNullOrEmpty(track) ? null : GetMusicTrack(track));
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		MusicInfo GetMusicTrack(string track)
 		{
 			var music = world.Map.Rules.Music;
@@ -109,12 +115,14 @@ namespace OpenRA.Mods.Common.Scripting
 			return null;
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Stop the current song.")]
 		public void StopMusic()
 		{
 			playlist.Stop();
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Play a VQA video fullscreen. File name has to include the file extension.")]
 		public void PlayMovieFullscreen(string movie, LuaFunction func = null)
 		{
@@ -141,6 +149,7 @@ namespace OpenRA.Mods.Common.Scripting
 			Media.PlayFMVFullscreen(world, movie, onCompleteFullscreen);
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Play a VQA video in the radar window. File name has to include the file extension. " +
 			"Returns true on success, if the movie wasn't found the function returns false and the callback is executed.")]
 		public bool PlayMovieInRadar(string movie, LuaFunction playComplete = null)
@@ -208,6 +217,7 @@ namespace OpenRA.Mods.Common.Scripting
 			Game.Debug(text);
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Display a text message at the specified location.")]
 		public void FloatingText(string text, WPos position, int duration = 30, HSLColor? color = null)
 		{

--- a/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
@@ -28,6 +28,7 @@ namespace OpenRA.Mods.Common.Scripting
 	{
 		public ReinforcementsGlobal(ScriptContext context) : base(context) { }
 
+		[ScriptContext(ScriptContextType.Mission)]
 		Actor CreateActor(Player owner, string actorType, bool addToWorld, CPos? entryLocation = null, CPos? nextLocation = null)
 		{
 			ActorInfo ai;
@@ -62,6 +63,7 @@ namespace OpenRA.Mods.Common.Scripting
 			actor.QueueActivity(move.MoveTo(dest, 2));
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Send reinforcements consisting of multiple units. Supports ground-based, naval and air units. " +
 			"The first member of the entryPath array will be the units' spawnpoint, " +
 			"while the last one will be their destination. If actionFunc is given, " +
@@ -101,6 +103,7 @@ namespace OpenRA.Mods.Common.Scripting
 			return actors.ToArray();
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Send reinforcements in a transport. A transport can be a ground unit (APC etc.), ships and aircraft. " +
 			"The first member of the entryPath array will be the spawnpoint for the transport, " +
 			"while the last one will be its destination. The last member of the exitPath array " +

--- a/OpenRA.Mods.Common/Scripting/Global/TriggerGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/TriggerGlobal.cs
@@ -161,6 +161,7 @@ namespace OpenRA.Mods.Common.Scripting
 			GetScriptTriggers(player.PlayerActor).RegisterCallback(Trigger.OnPlayerLost, func, Context);
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Call a function when this player is assigned a new objective. " +
 			"The callback function will be called as func(Player player, int objectiveID).")]
 		public void OnObjectiveAdded(Player player, LuaFunction func)
@@ -168,6 +169,7 @@ namespace OpenRA.Mods.Common.Scripting
 			GetScriptTriggers(player.PlayerActor).RegisterCallback(Trigger.OnObjectiveAdded, func, Context);
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Call a function when this player completes an objective. " +
 			"The callback function will be called as func(Player player, int objectiveID).")]
 		public void OnObjectiveCompleted(Player player, LuaFunction func)
@@ -175,6 +177,7 @@ namespace OpenRA.Mods.Common.Scripting
 			GetScriptTriggers(player.PlayerActor).RegisterCallback(Trigger.OnObjectiveCompleted, func, Context);
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Call a function when this player fails an objective. " +
 			"The callback function will be called as func(Player player, int objectiveID).")]
 		public void OnObjectiveFailed(Player player, LuaFunction func)
@@ -291,6 +294,7 @@ namespace OpenRA.Mods.Common.Scripting
 			}
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Call a function when a ground-based actor enters this cell footprint. " +
 			"Returns the trigger id for later removal using RemoveFootprintTrigger(int id). " +
 			"The callback function will be called as func(Actor a, int id).")]
@@ -318,6 +322,7 @@ namespace OpenRA.Mods.Common.Scripting
 			return triggerId;
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Call a function when a ground-based actor leaves this cell footprint. " +
 			"Returns the trigger id for later removal using RemoveFootprintTrigger(int id). " +
 			"The callback function will be called as func(Actor a, int id).")]
@@ -345,6 +350,7 @@ namespace OpenRA.Mods.Common.Scripting
 			return triggerId;
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Removes a previously created footprint trigger.")]
 		public void RemoveFootprintTrigger(int id)
 		{

--- a/OpenRA.Mods.Common/Scripting/Global/UserInterfaceGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/UserInterfaceGlobal.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Mods.Common.Scripting.Global
 		public UserInterfaceGlobal(ScriptContext context)
 			: base(context) { }
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Displays a text message at the top center of the screen.")]
 		public void SetMissionText(string text, HSLColor? color = null)
 		{

--- a/OpenRA.Mods.Common/Scripting/Properties/AirstrikeProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/AirstrikeProperties.cs
@@ -27,12 +27,14 @@ namespace OpenRA.Mods.Common.Scripting
 			ap = self.TraitsImplementing<AirstrikePower>().First();
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Activate the actor's Airstrike Power.")]
 		public void SendAirstrike(WPos target, bool randomize = true, int facing = 0)
 		{
 			ap.SendAirstrike(Self, target, randomize, facing);
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Activate the actor's Airstrike Power.")]
 		public void SendAirstrikeFrom(CPos from, CPos to)
 		{

--- a/OpenRA.Mods.Common/Scripting/Properties/AmmoPoolProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/AmmoPoolProperties.cs
@@ -50,6 +50,7 @@ namespace OpenRA.Mods.Common.Scripting
 			return pool.Info.Ammo;
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Adds the specified amount of ammo to the specified ammopool.",
 			"(Use a negative amount to remove ammo.)")]
 		public void Reload(string poolName = "primary", int amount = 1)

--- a/OpenRA.Mods.Common/Scripting/Properties/ConditionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ConditionProperties.cs
@@ -32,6 +32,7 @@ namespace OpenRA.Mods.Common.Scripting
 			externalConditions = self.TraitsImplementing<ExternalCondition>().ToArray();
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Grant an external condition on this actor and return the revocation token.",
 			"Conditions must be defined on an ExternalConditions trait on the actor.",
 			"If duration > 0 the condition will be automatically revoked after the defined number of ticks")]
@@ -46,6 +47,7 @@ namespace OpenRA.Mods.Common.Scripting
 			return external.GrantCondition(Self, this, duration);
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Revoke a condition using the token returned by GrantCondition.")]
 		public void RevokeCondition(int token)
 		{
@@ -61,6 +63,7 @@ namespace OpenRA.Mods.Common.Scripting
 				.Any(t => t.Info.Condition == condition && t.CanGrantCondition(Self, this));
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Grant an upgrade to this actor. DEPRECATED! Will be removed.")]
 		public void GrantUpgrade(string upgrade)
 		{
@@ -68,6 +71,7 @@ namespace OpenRA.Mods.Common.Scripting
 			legacyShim.GetOrAdd(upgrade).Push(GrantCondition(upgrade));
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Revoke an upgrade that was previously granted using GrantUpgrade. DEPRECATED! Will be removed.")]
 		public void RevokeUpgrade(string upgrade)
 		{
@@ -79,6 +83,7 @@ namespace OpenRA.Mods.Common.Scripting
 			RevokeCondition(tokens.Pop());
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Grant a limited-time upgrade to this actor. DEPRECATED! Will be removed.")]
 		public void GrantTimedUpgrade(string upgrade, int duration)
 		{

--- a/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
@@ -71,9 +71,10 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Test whether an actor has a specific property.")]
 		public bool HasProperty(string name)
 		{
-			return Self.HasScriptProperty(name);
+			return Self.HasScriptProperty(Context, name);
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Render a target flash on the actor. If set, 'asPlayer'",
 			"defines which player palette to use. Duration is in ticks.")]
 		public void Flash(int duration = 4, Player asPlayer = null)
@@ -115,6 +116,7 @@ namespace OpenRA.Mods.Common.Scripting
 			}
 		}
 
+		// AI and Misison safe but it would be cheating!
 		[ScriptActorPropertyActivity]
 		[Desc("Instantly moves the actor to the specified cell.")]
 		public void Teleport(CPos cell)

--- a/OpenRA.Mods.Common/Scripting/Properties/HackyAIProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/HackyAIProperties.cs
@@ -1,0 +1,45 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Mods.Common.AI;
+using OpenRA.Scripting;
+
+namespace OpenRA.Mods.Common.Scripting
+{
+	[ScriptPropertyGroup("HackyAI")]
+	public class HackyAIProperties : ScriptActorProperties
+	{
+		readonly HackyAI hackyAI;
+
+		public HackyAIProperties(ScriptContext context, Actor self)
+			: base(context, self)
+		{
+			hackyAI = self.Owner.PlayerActor.TraitsImplementing<HackyAI>().Where(b => b.IsEnabled).FirstOrDefault();
+		}
+
+		[ScriptContext(ScriptContextType.AI)]
+		[ScriptActorPropertyActivity]
+		[Desc("Mark this actor as occupied by lua scripting and disable control from Hacky AI.")]
+		public bool HackyAIOccupied
+		{
+			get
+			{
+				return hackyAI.IsLuaOccupied(Self);
+			}
+
+			set
+			{
+				hackyAI.SetLuaOccupied(Self, value);
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Scripting/Properties/HealthProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/HealthProperties.cs
@@ -29,6 +29,7 @@ namespace OpenRA.Mods.Common.Scripting
 		public int Health
 		{
 			get { return health.HP; }
+
 			set { health.InflictDamage(Self, Self, new Damage(health.HP - value), true); }
 		}
 

--- a/OpenRA.Mods.Common/Scripting/Properties/MissionObjectiveProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/MissionObjectiveProperties.cs
@@ -27,6 +27,7 @@ namespace OpenRA.Mods.Common.Scripting
 			mo = player.PlayerActor.Trait<MissionObjectives>();
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[ScriptActorPropertyActivity]
 		[Desc("Add a primary mission objective for this player. The function returns the " +
 			"ID of the newly created objective, so that it can be referred to later.")]
@@ -35,6 +36,7 @@ namespace OpenRA.Mods.Common.Scripting
 			return mo.Add(Player, description, ObjectiveType.Primary);
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[ScriptActorPropertyActivity]
 		[Desc("Add a secondary mission objective for this player. The function returns the " +
 			"ID of the newly created objective, so that it can be referred to later.")]
@@ -43,6 +45,7 @@ namespace OpenRA.Mods.Common.Scripting
 			return mo.Add(Player, description, ObjectiveType.Secondary);
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[ScriptActorPropertyActivity]
 		[Desc("Mark an objective as completed.  This needs the objective ID returned " +
 			"by AddObjective as argument.  When this player has completed all primary " +
@@ -55,6 +58,7 @@ namespace OpenRA.Mods.Common.Scripting
 			mo.MarkCompleted(Player, id);
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[ScriptActorPropertyActivity]
 		[Desc("Mark an objective as failed.  This needs the objective ID returned " +
 			"by AddObjective as argument.  Secondary objectives do not have any " +
@@ -67,6 +71,7 @@ namespace OpenRA.Mods.Common.Scripting
 			mo.MarkFailed(Player, id);
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[ScriptActorPropertyActivity]
 		[Desc("Returns true if the objective has been successfully completed, false otherwise.")]
 		public bool IsObjectiveCompleted(int id)
@@ -77,6 +82,7 @@ namespace OpenRA.Mods.Common.Scripting
 			return mo.Objectives[id].State == ObjectiveState.Completed;
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[ScriptActorPropertyActivity]
 		[Desc("Returns true if the objective has been failed, false otherwise.")]
 		public bool IsObjectiveFailed(int id)
@@ -87,6 +93,7 @@ namespace OpenRA.Mods.Common.Scripting
 			return mo.Objectives[id].State == ObjectiveState.Failed;
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[ScriptActorPropertyActivity]
 		[Desc("Returns the description of an objective.")]
 		public string GetObjectiveDescription(int id)
@@ -97,6 +104,7 @@ namespace OpenRA.Mods.Common.Scripting
 			return mo.Objectives[id].Description;
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[ScriptActorPropertyActivity]
 		[Desc("Returns the type of an objective.")]
 		public string GetObjectiveType(int id)
@@ -107,6 +115,7 @@ namespace OpenRA.Mods.Common.Scripting
 			return mo.Objectives[id].Type == ObjectiveType.Primary ? "Primary" : "Secondary";
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[ScriptActorPropertyActivity]
 		[Desc("Returns true if this player has lost all units/actors that have " +
 			"the MustBeDestroyed trait (according to the short game option).")]

--- a/OpenRA.Mods.Common/Scripting/Properties/ParatroopersProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ParatroopersProperties.cs
@@ -27,12 +27,14 @@ namespace OpenRA.Mods.Common.Scripting
 			pp = self.TraitsImplementing<ParatroopersPower>().First();
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Activate the actor's Paratroopers Power. Returns the dropped units.")]
 		public Actor[] SendParatroopers(WPos target, bool randomize = true, int facing = 0)
 		{
 			return pp.SendParatroopers(Self, target, randomize, facing);
 		}
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Activate the actor's Paratroopers Power. Returns the dropped units.")]
 		public Actor[] SendParatroopersFrom(CPos from, CPos to)
 		{

--- a/OpenRA.Mods.Common/Scripting/Properties/PlayerExperienceProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/PlayerExperienceProperties.cs
@@ -34,6 +34,7 @@ namespace OpenRA.Mods.Common.Scripting
 				return exp.Experience;
 			}
 
+			[ScriptContext(ScriptContextType.Mission)]
 			set
 			{
 				exp.GiveExperience(value - exp.Experience);

--- a/OpenRA.Mods.Common/Scripting/Properties/PowerProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/PowerProperties.cs
@@ -48,6 +48,7 @@ namespace OpenRA.Mods.Common.Scripting
 		}
 
 		[Desc("Triggers low power for the chosen amount of ticks.")]
+		[ScriptContext(ScriptContextType.Mission)]
 		public void TriggerPowerOutage(int ticks)
 		{
 			pm.TriggerPowerOutage(ticks);

--- a/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
@@ -266,6 +266,9 @@ namespace OpenRA.Mods.Common.Scripting
 
 		BuildableInfo GetBuildableInfo(string actorType)
 		{
+			if (!Player.World.Map.Rules.Actors.ContainsKey(actorType))
+				throw new LuaException("Actor of type {0} is invalid".F(actorType));
+
 			var ri = Player.World.Map.Rules.Actors[actorType];
 			var bi = ri.TraitInfoOrDefault<BuildableInfo>();
 

--- a/OpenRA.Mods.Common/Scripting/Properties/ResourceProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ResourceProperties.cs
@@ -40,6 +40,8 @@ namespace OpenRA.Mods.Common.Scripting
 		public int Cash
 		{
 			get { return pr.Cash; }
+
+			[ScriptContext(ScriptContextType.Mission)]
 			set { pr.Cash = Math.Max(0, value); }
 		}
 	}

--- a/OpenRA.Mods.Common/Scripting/Properties/TransportProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/TransportProperties.cs
@@ -34,6 +34,7 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Specifies the amount of passengers.")]
 		public int PassengerCount { get { return cargo.Passengers.Count(); } }
 
+		[ScriptContext(ScriptContextType.Mission)]
 		[Desc("Teleport an existing actor inside this transport.")]
 		public void LoadPassenger(Actor a) { cargo.Load(Self, a); }
 

--- a/lua/scriptwrapper.lua
+++ b/lua/scriptwrapper.lua
@@ -19,11 +19,12 @@ local PrintStackTrace = function(msg)
 	return stp.stacktrace("", 2) .. "\nError message\n===============\n" .. msg .. "\n==============="
 end
 
-local TryRunSandboxed = function(fn)
-	local success, err = xpcall(function() sandbox.run(fn, {env = environment, quota = MaxUserScriptInstructions}) end, PrintStackTrace)
+local TryRunSandboxed = function(fn, ...)
+	local success, err = xpcall(function() return sandbox.run(fn, {env = environment, quota = MaxUserScriptInstructions}, arg) end, PrintStackTrace)
 	if not success then
 		FatalError(err)
 	end
+    return err -- Actually, the correct result on success.
 end
 
 WorldLoaded = function()
@@ -32,9 +33,21 @@ WorldLoaded = function()
 	end
 end
 
+ActivateAI = function(faction_name, internal_name)
+	if environment.ActivateAI ~= nil then
+		TryRunSandboxed(environment.ActivateAI, faction_name, internal_name)
+	end
+end
+
 Tick = function()
 	if environment.Tick ~= nil then
 		TryRunSandboxed(environment.Tick)
+	end
+end
+
+BB_choose_building_to_build = function(params)
+	if environment.BB_choose_building_to_build ~= nil then
+		return TryRunSandboxed(environment.BB_choose_building_to_build, params)
 	end
 end
 


### PR DESCRIPTION
This PR could start addressing these issues:

Lua scriptable AI #4947
AI base Planing #6696
Create low-level generic mission AI in LUA #11187

I made a Lua script so that...
0. Hacky AI still works without any Lua script as it did before for mods in develpoment.
1. AI can be developed as if it were making maps with a lot of triggers.
2. BaseBuilder part of the HackyAI to query the Lua script what to build next. This implements build orders. I made 4 for Soviets and Allies. When all BO is built, HackyAI builds what ever it likes by falling back to Hacky behavior. If carefully scripted, it can pause builds too! (Not implemented)
3. At each Tick() of the HackyAI, it also Ticks Lua script's Tick(), which controls the unit production. I made a basic implementation of team, task, taskforce (units that do the actions). Current Lua script will build any team it can build in Random. (It does rebuild MCV or build harvesters, siege weapons based on conditions though). By default, teams have no task specified. In this case, HackyAI will take control of it and do hacky movements with it.
4. I have a working team that does specified actions. (APC+2 flamer load then attack proc demo: https://www.youtube.com/watch?v=yTzaKHBBzFE&feature=youtu.be) Currently, this is the only one with complex task as a proof of concept.
5. Even at this point it starts to feel like AI development in RA2 :)
6. https://www.youtube.com/watch?v=s_c_LWUK_iQ&feature=youtu.be : See demo of a full game

WIth this PR, modders can control what AI will build in what order and in what condition, what they will do. This will satisfy a lot of modders.

Oh yeah, forgot mention. I want to know how to expose information specified in HackyAIInfo to Lua script. Currently, some things, such as detecting enemy base defenses have hard coded actor names in the Lua script.