### PR TITLE
D2K - Make defences detect Cloak

### DIFF
--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -287,7 +287,7 @@
 		Voice: Guard
 	Guardable:
 	DetectCloaked:
-		Range: 1c384
+		Range: 1c768
 	DeathSounds:
 		DeathTypes: ExplosionDeath, SoundDeath, SmallExplosionDeath, BulletDeath
 	MustBeDestroyed:
@@ -378,6 +378,8 @@
 	AttackTurreted:
 	AutoTarget:
 	RenderRangeCircle:
+	DetectCloaked:
+		Range: 1c768
 	-GivesBuildableArea:
 	-WithMakeAnimation:
 	-Capturable:


### PR DESCRIPTION
In original Infantry and Turrets were able to detect cloaked units in 1 cell range including diagonal. Looks like Turrets were missing that on OpenRA. I didn't add Detection Circle as it would be unnecessary for that small range.