### PR TITLE
Grenadier death explosion fixed

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -114,6 +114,7 @@ E2:
 		DefaultAttackSequence: throw
 	Explodes:
 		Weapon: UnitExplodeSmall
+		EmptyWeapon: UnitExplodeSmall
 		Chance: 50
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded


### PR DESCRIPTION
During his "empty ammo" state the Grenadier uses the incorrect weapon for his death explosion. I explained it more in-depth during the commit:

- When the Grenadier throws his grenade he enters a state of being "empty" for a while (until his ammo is replenished and he can throw again). If he is killed and explodes upon death during this "empty state" the Explodes trait will use "EmptyWeapon" instead of "Weapon".

- EmptyWeapon has however not been set to anything in infantry.yaml and therefore defaults to "UnitExplode" - an explosion that is over 12 times stronger than "UnitExplodeSmall" and covers a larger area.

- What this commit does is make sure the Grenadier's death explosion will always have the same strength. My reasoning is that it was probably never intended for the bang to be so strong in the first place, especially since it happens when the unit has no ammo loaded.

This is something I disovered when making the so-called ["overhaul"](http://www.sleipnirstuff.com/forum/viewtopic.php?f=82&t=19940) and thought it would be perfect as a test commit since it's such a simple fix yet can have a big impact on gameplay. Using GitHub is relatively unfamiliar for me so I'm still learning the ropes.