### PR TITLE
Reverse making friendly units aware of friendly mines.

### DIFF
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -907,6 +907,7 @@
 		CrushClasses: mine
 		DetonateClasses: mine
 		AvoidFriendly: false
+		BlockFriendly: false
 	Health:
 		HP: 100
 		NotifyAppliedDamage: false


### PR DESCRIPTION
Adressing https://github.com/OpenRA/OpenRA/pull/12337#issuecomment-285991709

I believe the new mines change represents a potential pitfall. My thoughts on it could be wrong but if they're not it could have very serious ramifications for the game balance the next release cycle. Not worth throwing in blind.

With #12337 players can add the property onto modded maps. Units being aware of friendly mines have been discussed up and down among players in the recent past so I'm positive we'll see it with community playtesters sooner or later.