### PR TITLE
UncloakOn: Damage, Heal, SelfHeal split

### DIFF
--- a/OpenRA.Mods.Common/Activities/Repair.cs
+++ b/OpenRA.Mods.Common/Activities/Repair.cs
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.Common.Activities
 					return this;
 				}
 
-				self.InflictDamage(self, new Damage(-hpToRepair));
+				self.InflictDamage(host.Actor, new Damage(-hpToRepair));
 
 				foreach (var depot in host.Actor.TraitsImplementing<INotifyRepair>())
 					depot.Repairing(host.Actor, self);

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -29,7 +29,8 @@ namespace OpenRA.Mods.Common.Traits
 		Infiltrate = 8,
 		Demolish = 16,
 		Damage = 32,
-		Dock = 64
+		Heal = 64,
+		Dock = 128
 	}
 
 	[Desc("This unit can cloak and uncloak in specific situations.")]
@@ -101,7 +102,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyDamage.Damaged(Actor self, AttackInfo e)
 		{
-			if (Info.UncloakOn.HasFlag(UncloakType.Damage))
+			if (e.Damage.Value == 0)
+				return;
+
+			if (Info.UncloakOn.HasFlag(e.Damage.Value > 0 ? UncloakType.Damage : UncloakType.Heal))
 				Uncloak();
 		}
 

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -30,7 +30,8 @@ namespace OpenRA.Mods.Common.Traits
 		Demolish = 16,
 		Damage = 32,
 		Heal = 64,
-		Dock = 128
+		SelfHeal = 128,
+		Dock = 256
 	}
 
 	[Desc("This unit can cloak and uncloak in specific situations.")]
@@ -42,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Measured in game ticks.")]
 		public readonly int CloakDelay = 30;
 
-		[Desc("Events leading to the actor getting uncloaked. Possible values are: Attack, Move, Unload, Infiltrate, Demolish, Dock and Damage")]
+		[Desc("Events leading to the actor getting uncloaked. Possible values are: Attack, Move, Unload, Infiltrate, Demolish, Dock, Damage, Heal and SelfHeal.")]
 		public readonly UncloakType UncloakOn = UncloakType.Attack
 			| UncloakType.Unload | UncloakType.Infiltrate | UncloakType.Demolish | UncloakType.Dock;
 
@@ -105,7 +106,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (e.Damage.Value == 0)
 				return;
 
-			if (Info.UncloakOn.HasFlag(e.Damage.Value > 0 ? UncloakType.Damage : UncloakType.Heal))
+			var type = e.Damage.Value < 0
+				? (e.Attacker == self ? UncloakType.SelfHeal : UncloakType.Heal)
+				: UncloakType.Damage;
+			if (Info.UncloakOn.HasFlag(type))
 				Uncloak();
 		}
 

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -573,6 +573,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					if (node.Key.StartsWith("DisguiseToolTip", StringComparison.Ordinal))
 						RenameNodeKey(node, "DisguiseTooltip");
 
+				// Split UncloakOn: Damage => Damage, Heal, SelfHeal
+				if (engineVersion < 20170315)
+					if (node.Key.StartsWith("UncloakOn", StringComparison.Ordinal))
+						node.Value.Value = node.Value.Value.Replace("Damage", "Damage, Heal, SelfHeal");
+
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -150,7 +150,7 @@ fremen:
 	Cloak:
 		InitialDelay: 85
 		CloakDelay: 85
-		UncloakOn: Attack, Unload, Infiltrate, Demolish, Dock, Damage
+		UncloakOn: Attack, Unload, Infiltrate, Demolish, Dock, Damage, Heal
 		CloakSound: STEALTH1.WAV
 		UncloakSound: STEALTH2.WAV
 		IsPlayerPalette: true
@@ -251,7 +251,7 @@ saboteur:
 		CloakDelay: 85
 		CloakSound: STEALTH1.WAV
 		UncloakSound: STEALTH2.WAV
-		UncloakOn: Attack, Unload, Infiltrate, Demolish, Move, Damage
+		UncloakOn: Attack, Unload, Infiltrate, Demolish, Move, Damage, Heal
 		IsPlayerPalette: true
 		RequiresCondition: !cloak-force-disabled
 	GrantConditionOnDamageState@UNCLOAK:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -392,7 +392,7 @@ stealth_raider:
 	Cloak:
 		InitialDelay: 45
 		CloakDelay: 90
-		UncloakOn: Attack, Unload, Infiltrate, Demolish, Dock, Damage
+		UncloakOn: Attack, Unload, Infiltrate, Demolish, Dock, Damage, Heal
 		CloakSound: STEALTH1.WAV
 		UncloakSound: STEALTH2.WAV
 		IsPlayerPalette: true

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -117,7 +117,7 @@
 		IsPlayerPalette: true
 		CloakSound: cloak5.aud
 		UncloakSound: cloak5.aud
-		UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage
+		UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage, Heal
 	ExternalCondition@CLOAKGENERATOR:
 		Condition: cloakgenerator
 	ExternalCondition@CRATE-CLOAK:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -395,7 +395,7 @@ STNK:
 		CloakSound: cloak5.aud
 		UncloakSound: cloak5.aud
 		IsPlayerPalette: true
-		UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage
+		UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage, Heal
 		RequiresCondition: !cloak-force-disabled
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled


### PR DESCRIPTION
This PR splits `UncloakOn: Damage` into `UncloakOn: Damage`, `UncloakOn: Heal`, `UncloakOn: SelfHeal`.
`Damage` if damage > 0.
`Heal` if damage < 0 and caused by another actor.
`SelfHeal` if damage < 0 and caused by self (ex. `SelfHealing`).

Fixes #12964 & fixes #12956.