### PR TITLE
[RA] [Balance] Tweak price/production of S.Bags/Fence/Walls

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1657,7 +1657,7 @@ SBAG:
 		Prerequisites: fact, ~structures.allies, ~techlevel.low
 		Description: Stops infantry and light vehicles.\nCan be crushed by tanks.
 	Valued:
-		Cost: 25
+		Cost: 50
 	CustomSellValue:
 		Value: 0
 	Tooltip:
@@ -1682,7 +1682,7 @@ FENC:
 		Prerequisites: fact, ~structures.soviet, ~techlevel.low
 		Description: Stops infantry and light vehicles.\nCan be crushed by tanks.
 	Valued:
-		Cost: 25
+		Cost: 50
 	CustomSellValue:
 		Value: 0
 	Tooltip:
@@ -1707,7 +1707,7 @@ BRIK:
 		Prerequisites: fact, ~techlevel.medium
 		Description: Stop units and blocks enemy fire.
 	Valued:
-		Cost: 100
+		Cost: 200
 	CustomSellValue:
 		Value: 0
 	Tooltip:


### PR DESCRIPTION
Fairly predictable change with positive feedback. The ca. 5s vs 2.5s wall spam made players more anxious weighing wall production against defensive structures specifically when in a base push/defense scenario. Compared to other nerf solutions, the double price/production time increase is also practical given the early game Engineer cap has become a total non-issue, effectively abolishing the need walls to encapsulate the starting MCV (comparatively cost of $800 vs $400).

The strength of the wall remains and is still a bargain with its chain build ability giving you up to 7x500 Concrete HP for just $200 add-ons. Building walls far and wide isn't disrupted but adding additional layers upon an enemy breakthrough is.

Casual players looking to play sim city ought to still to have a good experience using walls with this change.

$25 fence/s.bags just looks a bit bogus both as a price tag and with the visual production indicator. Spending cash on spamming $50 fence/s.bags is fine and looks better IMO.

- - - - - - - - - 

References:

RA Experimental build v2.0-v2.2: http://www.sleipnirstuff.com/forum/viewtopic.php?t=19886
SoS Playtest maps v1.5r: http://www.sleipnirstuff.com/forum/viewtopic.php?t=19944 : http://resource.openra.net/panel/mymaps/page/2