### PR TITLE
Global chat name is reset when connecting

### DIFF
--- a/OpenRA.Game/GlobalChat.cs
+++ b/OpenRA.Game/GlobalChat.cs
@@ -106,8 +106,6 @@ namespace OpenRA.Chat
 			client.OnDevoice += (_, e) => SetUserVoiced(e.Whom, false);
 			client.OnPart += OnPart;
 			client.OnQuit += OnQuit;
-
-			TrySetNickname(Game.Settings.Player.Name);
 		}
 
 		void SetUserOp(string whom, bool isOp)


### PR DESCRIPTION
removed TrySetNickname(Game.Settings.Player.Name) in GlobalChat ctor overwriting Chat.Nickname. instead of removing, it could be replaced by TrySetNickname(Game.Settings.Chat.Nickname)

Closes #12325.