### PR TITLE
Replaced by #12974 - Unify ingame message prefixes. #12923

### DIFF
--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -18,7 +18,9 @@ namespace OpenRA.Network
 {
 	static class UnitOrders
 	{
-		static Player FindPlayerByClient(this World world, Session.Client c)
+    private const string BattlefieldControlChatName = "Battlefield Control";
+
+    static Player FindPlayerByClient(this World world, Session.Client c)
 		{
 			/* TODO: this is still a hack.
 			 * the cases we're trying to avoid are the extra players on the host's client -- Neutral, other MapPlayers,..*/
@@ -57,7 +59,7 @@ namespace OpenRA.Network
 					}
 
 				case "Message": // Server message
-					Game.AddChatLine(Color.White, "Server", order.TargetString);
+					Game.AddChatLine(Color.White, BattlefieldControlChatName, order.TargetString);
 					break;
 
 				case "Disconnected": /* reports that the target player disconnected */
@@ -105,7 +107,7 @@ namespace OpenRA.Network
 							break;
 						}
 
-						Game.AddChatLine(Color.White, "Server", "The game has started.");
+						Game.AddChatLine(Color.White, BattlefieldControlChatName, "The game has started.");
 						Game.StartGame(orderManager.LobbyInfo.GlobalSettings.Map, WorldType.Regular);
 						break;
 					}
@@ -119,7 +121,7 @@ namespace OpenRA.Network
 							if (orderManager.World.Paused != pause && world != null && !world.LobbyInfo.IsSinglePlayer)
 							{
 								var pausetext = "The game is {0} by {1}".F(pause ? "paused" : "un-paused", client.Name);
-								Game.AddChatLine(Color.White, "", pausetext);
+								Game.AddChatLine(Color.White, BattlefieldControlChatName, pausetext);
 							}
 
 							orderManager.World.Paused = pause;


### PR DESCRIPTION
Used  "Battlefield Control" instead of "Server" or ""