### PR TITLE
Connection Failed when trying to join custom map #12881

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
@@ -9,8 +9,8 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Network;
 using OpenRA.Server;
 using OpenRA.Traits;
@@ -29,16 +29,19 @@ namespace OpenRA.Mods.Common.Server
 
 			var options = server.Map.Rules.Actors["player"].TraitInfos<ILobbyOptions>()
 				.Concat(server.Map.Rules.Actors["world"].TraitInfos<ILobbyOptions>())
-				.SelectMany(t => t.LobbyOptions(server.Map.Rules))
-				.ToDictionary(o => o.Id, o => o);
+				.SelectMany(t => t.LobbyOptions(server.Map.Rules));
+
+			var optionNames = new Dictionary<string, string>();
+			foreach (var o in options)
+				optionNames[o.Id] = o.Name;
 
 			foreach (var kv in server.LobbyInfo.GlobalSettings.LobbyOptions)
 			{
 				Session.LobbyOptionState def;
-				LobbyOption option;
+				string optionName;
 				if (!defaults.LobbyOptions.TryGetValue(kv.Key, out def) || kv.Value.Value != def.Value)
-					if (options.TryGetValue(kv.Key, out option))
-						server.SendOrderTo(conn, "Message", option.Name + ": " + kv.Value.Value);
+					if (optionNames.TryGetValue(kv.Key, out optionName))
+						server.SendOrderTo(conn, "Message", optionName + ": " + kv.Value.Value);
 			}
 		}
 	}


### PR DESCRIPTION
_ToDictionary(o => o.Id, o => o)_ failed due to duplicated Rule Id, e.g. PlayerResourcesInfo rules from Player and World, but it seems options from server.Map.Rules aren't needed here, as they are all added in LoadMapSettings function into defaults so I assume it is better to simply remove it than fix the duplicity again here.