### PR TITLE
When changing rally point also make primary #12855

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
@@ -40,6 +40,8 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class PrimaryBuilding : INotifyCreated, IIssueOrder, IResolveOrder
 	{
+		const string OrderID = "PrimaryProducer";
+
 		readonly PrimaryBuildingInfo info;
 		ConditionManager conditionManager;
 		int primaryToken = ConditionManager.InvalidConditionToken;
@@ -58,12 +60,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<IOrderTargeter> IIssueOrder.Orders
 		{
-			get { yield return new DeployOrderTargeter("PrimaryProducer", 1); }
+			get { yield return new DeployOrderTargeter(OrderID, 1); }
 		}
 
 		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
-			if (order.OrderID == "PrimaryProducer")
+			if (order.OrderID == OrderID)
 				return new Order(order.OrderID, self, false);
 
 			return null;
@@ -71,8 +73,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		void IResolveOrder.ResolveOrder(Actor self, Order order)
 		{
-			if (order.OrderString == "PrimaryProducer")
-				SetPrimaryProducer(self, !IsPrimary);
+			var forceRallyPoint = RallyPoint.IsForceSet(order);
+			if (order.OrderString == OrderID || forceRallyPoint)
+				SetPrimaryProducer(self, !IsPrimary || forceRallyPoint);
 		}
 
 		public void SetPrimaryProducer(Actor self, bool isPrimary)


### PR DESCRIPTION
Set PrimaryBuilding together with RallyPoint when Ctrl is pressed for each building which is the only selected building of that type. Ctrl is optional, could be removed to set PrimaryBuilding.

Barracks + Light factory, Ctrl+Right click = RallyPoint + PrimaryBuilding

![rallypointwithprimarybuilding](https://cloud.githubusercontent.com/assets/16348750/24041726/fbc08714-0b0e-11e7-910c-f92842d8723c.jpg)

2 Barracks = only RallyPoint

