### PR TITLE
TS - Add Tech Levels

### DIFF
--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -4,7 +4,7 @@ E2:
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 20
-		Prerequisites: ~gapile
+		Prerequisites: ~gapile, ~techlevel.low
 		Description: Infantry armed with special explosive discs.\n  Strong vs Buildings, Infantry\n  Weak vs Vehicles, Aircraft
 	Valued:
 		Cost: 200
@@ -37,7 +37,7 @@ MEDIC:
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 70
-		Prerequisites: ~gapile
+		Prerequisites: ~gapile, ~techlevel.low
 		Description: Heals nearby infantry.\n  Unarmed
 	Voiced:
 		VoiceSet: Medic
@@ -73,7 +73,7 @@ JUMPJET:
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 40
-		Prerequisites: ~gapile, garadr
+		Prerequisites: ~gapile, garadr, ~techlevel.medium
 		Description: Airborne soldier.\n  Strong vs Infantry, Aircraft\n  Weak vs Vehicles
 	Voiced:
 		VoiceSet: JumpJet
@@ -177,7 +177,7 @@ GHOST:
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 50
-		Prerequisites: ~gapile, gatech
+		Prerequisites: ~gapile, gatech, ~techlevel.high
 		BuildLimit: 1
 		Description: Elite commando infantry, armed with\na railgun and C4.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles, Aircraft\n  Special Ability: Destroy Building with C4\nMaximum 1 can be trained.
 	Voiced:

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -3,7 +3,7 @@ GAPOWR:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 0
-		Prerequisites: ~structures.gdi
+		Prerequisites: ~structures.gdi, ~techlevel.low
 		Description: Provides power for other structures.
 	Valued:
 		Cost: 300
@@ -65,7 +65,7 @@ GAPILE:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 30
-		Prerequisites: anypower, ~structures.gdi
+		Prerequisites: anypower, ~structures.gdi, ~techlevel.low
 		Description: Produces infantry.
 	Valued:
 		Cost: 300
@@ -128,7 +128,7 @@ GAWEAP:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 50
-		Prerequisites: proc, ~structures.gdi
+		Prerequisites: proc, ~structures.gdi, ~techlevel.low
 		Description: Produces vehicles.
 	Building:
 		Footprint: xxx= xxx= xxx=
@@ -189,7 +189,7 @@ GAHPAD:
 	Buildable:
 		BuildPaletteOrder: 60
 		Queue: Building
-		Prerequisites: garadr, ~structures.gdi
+		Prerequisites: garadr, ~structures.gdi, ~techlevel.medium
 		Description: Produces, rearms and\nrepairs helicopters.
 	Building:
 		Footprint: xx xx
@@ -243,7 +243,7 @@ GADEPT:
 		Name: Service Depot
 	Buildable:
 		BuildPaletteOrder: 80
-		Prerequisites: factory, ~structures.gdi
+		Prerequisites: factory, ~structures.gdi, ~techlevel.medium
 		Queue: Building
 		Description: Repairs vehicles.
 	Building:
@@ -291,7 +291,7 @@ GARADR:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 90
-		Prerequisites: proc, ~structures.gdi
+		Prerequisites: proc, ~structures.gdi, ~techlevel.low
 		Description: Provides an overview of the battlefield.\nCan detect cloaked units.\nRequires power to operate.
 	Valued:
 		Cost: 1000
@@ -340,7 +340,7 @@ GATECH:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 100
-		Prerequisites: gaweap, garadr, ~structures.gdi
+		Prerequisites: gaweap, garadr, ~structures.gdi, ~techlevel.medium
 		Description: Provides access to advanced GDI technologies.
 	Valued:
 		Cost: 1500
@@ -378,7 +378,7 @@ GAPLUG:
 		Bounds: 115,72,0,-12
 	Buildable:
 		BuildPaletteOrder: 100
-		Prerequisites: proc, gatech, ~structures.gdi
+		Prerequisites: proc, gatech, ~structures.gdi, ~techlevel.superweapons
 		Queue: Building
 		Description: Can be upgraded for additional technology.
 	Building:

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -3,7 +3,7 @@ GAWALL:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 20
-		Prerequisites: ~structures.gdi
+		Prerequisites: ~structures.gdi, ~techlevel.low
 		Description: Stops infantry and blocks enemy fire.\nCan NOT be crushed by tanks.
 	-SoundOnDamageTransition:
 	Valued:
@@ -28,7 +28,7 @@ GAGATE_A:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 100
-		Prerequisites: gapile, ~structures.gdi
+		Prerequisites: gapile, ~structures.gdi, ~techlevel.low
 	Tooltip:
 		Name: GDI Gate
 
@@ -37,7 +37,7 @@ GAGATE_B:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 100
-		Prerequisites: gapile, ~structures.gdi
+		Prerequisites: gapile, ~structures.gdi, ~techlevel.low
 	Tooltip:
 		Name: GDI Gate
 
@@ -53,7 +53,7 @@ GACTWR:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 30
-		Prerequisites: gapile, ~structures.gdi
+		Prerequisites: gapile, ~structures.gdi, ~techlevel.low
 		Description: Modular tower for base defenses.
 	Building:
 	Selectable:
@@ -143,7 +143,7 @@ GAVULC:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 40
-		Prerequisites: gactwr, gapile, ~structures.gdi
+		Prerequisites: gactwr, gapile, ~structures.gdi, ~techlevel.low
 		Description: Basic base defense.\nDoes not require power to operate.\n  Strong vs Infantry, Light armor\n  Weak vs Aircraft
 	Plug:
 		Type: tower.vulcan
@@ -159,7 +159,7 @@ GAROCK:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 40
-		Prerequisites: gactwr, gapile, ~structures.gdi
+		Prerequisites: gactwr, gapile, ~structures.gdi, ~techlevel.high
 		Description: GDI Advanced base defense.\nDoes not require power to operate.\n  Strong vs Armored ground units\n  Weak vs Aircraft
 	Plug:
 		Type: tower.rocket
@@ -175,7 +175,7 @@ GACSAM:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 40
-		Prerequisites: gactwr, garadr, ~structures.gdi
+		Prerequisites: gactwr, garadr, ~structures.gdi, ~techlevel.medium
 		Description: GDI Anti-Air base defense.\nDoes not require power to operate.\n  Strong vs Aircraft\n  Weak vs Ground units
 	Plug:
 		Type: tower.sam
@@ -191,7 +191,7 @@ GAPOWRUP:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 10
-		Prerequisites: gapowr, ~structures.gdi
+		Prerequisites: gapowr, ~structures.gdi, ~techlevel.medium
 		Description: Provides extra power generation.
 	Plug:
 		Type: powrup
@@ -207,7 +207,7 @@ GAPLUG2:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 1000
-		Prerequisites: gaplug, gatech, gaweap, ~structures.gdi
+		Prerequisites: gaplug, gatech, gaweap, ~structures.gdi, ~techlevel.superweapons
 		Description: Enables use of the hunter-seeker droid.
 	Plug:
 		Type: plug.hunterseeker
@@ -223,7 +223,7 @@ GAPLUG3:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 1000
-		Prerequisites: gaplug, gatech, ~structures.gdi
+		Prerequisites: gaplug, gatech, ~structures.gdi, ~techlevel.superweapons
 		Description: Enables use of the Ion Cannon.
 	Plug:
 		Type: plug.ioncannon

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -8,7 +8,7 @@ APC:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 30
-		Prerequisites: ~gaweap, gapile
+		Prerequisites: ~gaweap, gapile, ~techlevel.medium
 		Description: Armored infantry transport.\nCan move on water.\n  Unarmed
 	Mobile:
 		TurnSpeed: 5
@@ -60,7 +60,7 @@ HVR:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 50
-		Prerequisites: ~gaweap, garadr
+		Prerequisites: ~gaweap, garadr, ~techlevel.high
 		Description: Hovering vehicle armed with\nlong range missiles.\n  Strong vs Vehicles, Aircraft\n  Weak vs Infantry
 	Mobile:
 		Speed: 99
@@ -115,7 +115,7 @@ SMECH:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 10
-		Prerequisites: ~gaweap
+		Prerequisites: ~gaweap, ~techlevel.low
 		Description: Anti-personnel walker.\n  Strong vs Infantry, Light armor\n  Weak vs Vehicles, Aircraft
 	Mobile:
 		TurnSpeed: 5
@@ -158,7 +158,7 @@ MMCH:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 30
-		Prerequisites: ~gaweap
+		Prerequisites: ~gaweap, ~techlevel.medium
 		Description: General purpose mechanized walker.\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
 	Mobile:
 		TurnSpeed: 5
@@ -209,7 +209,7 @@ HMEC:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 80
-		Prerequisites: ~gaweap, gatech
+		Prerequisites: ~gaweap, gatech, ~techlevel.high
 		BuildLimit: 1
 		Description: Slow heavy walker.\nArmed with dual railguns and rocket launchers.\n  Strong vs Infantry, Vehicles, Aircraft and Buildings\n  Weak vs Nothing\nMaximum 1 can be built.
 	Mobile:
@@ -253,7 +253,7 @@ SONIC:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 70
-		Prerequisites: ~gaweap, gatech
+		Prerequisites: ~gaweap, gatech, ~techlevel.high
 		Description: Armored high-tech vehicle with\nlong range and sonic armament.\n  Strong vs Infantry, Vehicles, Buildings\n  Weak vs Aircraft
 	Targetable:
 		TargetTypes: Ground, Vehicle, Repair, Disruptor

--- a/mods/ts/rules/nod-infantry.yaml
+++ b/mods/ts/rules/nod-infantry.yaml
@@ -4,7 +4,7 @@ E3:
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 20
-		Prerequisites: ~nahand
+		Prerequisites: ~nahand, ~techlevel.low
 		Description: Anti-tank infantry.\n  Strong vs Vehicles, Aircraft, Buildings\n  Weak vs Infantry
 	Valued:
 		Cost: 250
@@ -40,7 +40,7 @@ CYBORG:
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 40
-		Prerequisites: ~nahand
+		Prerequisites: ~nahand, ~techlevel.medium
 		Description: Cybernetic infantry unit.\n  Strong vs Infantry, Light armor\n  Weak vs Vehicles, Aircraft
 	Selectable:
 		Bounds: 16,31,0,-10
@@ -74,7 +74,7 @@ CYC2:
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 50
-		Prerequisites: ~nahand, natmpl
+		Prerequisites: ~nahand, natmpl, ~techlevel.high
 		BuildLimit: 1
 		Description: Elite cybernetic infantry unit.\n  Strong vs Infantry, Vehicles, Buildings\n  Weak vs Aircraft\nMaximum 1 can be trained.
 	Selectable:
@@ -104,7 +104,7 @@ MHIJACK:
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 60
-		Prerequisites: ~nahand, natmpl
+		Prerequisites: ~nahand, natmpl, ~techlevel.high
 		Description: Hijacks enemy vehicles.\n  Unarmed
 	Valued:
 		Cost: 1850

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -3,7 +3,7 @@ NAPOWR:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 0
-		Prerequisites: ~structures.nod
+		Prerequisites: ~structures.nod, ~techlevel.low
 		Description: Provides power for other structures.
 	Valued:
 		Cost: 300
@@ -42,7 +42,7 @@ NAAPWR:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 5
-		Prerequisites: factory, ~structures.nod
+		Prerequisites: factory, ~structures.nod, ~techlevel.medium
 		Description: Provides twice as much power as\nthe normal Power Plant.
 	Valued:
 		Cost: 500
@@ -81,7 +81,7 @@ NAHAND:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 30
-		Prerequisites: anypower, ~structures.nod
+		Prerequisites: anypower, ~structures.nod, ~techlevel.low
 		Description: Produces infantry.
 	Valued:
 		Cost: 300
@@ -142,7 +142,7 @@ NAWEAP:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 50
-		Prerequisites: proc, ~structures.nod
+		Prerequisites: proc, ~structures.nod, ~techlevel.low
 		Description: Produces vehicles.
 	Building:
 		Footprint: xxx= xxx= xxx=
@@ -199,7 +199,7 @@ NAHPAD:
 	Buildable:
 		BuildPaletteOrder: 60
 		Queue: Building
-		Prerequisites: naradr, ~structures.nod
+		Prerequisites: naradr, ~structures.nod, ~techlevel.medium
 		Description: Produces, rearms and\nrepairs helicopters.
 	Building:
 		Footprint: xx xx
@@ -250,7 +250,7 @@ NARADR:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 90
-		Prerequisites: proc, ~structures.nod
+		Prerequisites: proc, ~structures.nod, ~techlevel.low
 		Description: Provides an overview of the battlefield.\nCan detect cloaked units.\nRequires power to operate.
 	Valued:
 		Cost: 1000
@@ -299,7 +299,7 @@ NATECH:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 100
-		Prerequisites: naweap, naradr, ~structures.nod
+		Prerequisites: naweap, naradr, ~structures.nod, ~techlevel.medium
 		Description: Provides access to advanced Nod technologies.
 	Valued:
 		Cost: 1500
@@ -332,7 +332,7 @@ NATMPL:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 200
-		Prerequisites: natech, ~structures.nod
+		Prerequisites: natech, ~structures.nod, ~techlevel.high
 		Description: Provides access to advanced Nod technologies.
 	ProvidesPrerequisite@buildingname:
 	Valued:
@@ -359,6 +359,7 @@ NATMPL:
 	ProduceActorPower:
 		Description: Hunter Seeker
 		LongDesc: Releases a drone that will acquire and destroy an enemy target.
+		Prerequisites: ~techlevel.superweapons
 		Icon: hunterseeker
 		Actors: hunter
 		Type: HunterSeeker
@@ -376,7 +377,7 @@ NASTLH:
 		Name: Stealth Generator
 	Buildable:
 		BuildPaletteOrder: 80
-		Prerequisites: proc, natech, ~structures.nod
+		Prerequisites: proc, natech, ~structures.nod, ~techlevel.high
 		Queue: Building
 		Description: Generates a cloaking field\nto hide your forces from the enemy.
 	Building:
@@ -421,7 +422,7 @@ NAWAST:
 		Name: Waste Refinery
 	Buildable:
 		BuildPaletteOrder: 110
-		Prerequisites: namisl, ~structures.nod
+		Prerequisites: namisl, ~structures.nod, ~techlevel.superweapons
 		Queue: Building
 		BuildLimit: 1
 		Description: Processes Veins\ninto useable resources.\nMaximum 1 can be built.

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -3,7 +3,7 @@ NAWALL:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 1001
-		Prerequisites: ~structures.nod
+		Prerequisites: ~structures.nod, ~techlevel.low
 		Description: Stops infantry and blocks enemy fire.\nCan NOT be crushed by tanks.
 	-SoundOnDamageTransition:
 	Valued:
@@ -28,7 +28,7 @@ NAGATE_A:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 100
-		Prerequisites: nahand, ~structures.nod
+		Prerequisites: nahand, ~structures.nod, ~techlevel.low
 	Tooltip:
 		Name: Nod Gate
 
@@ -37,7 +37,7 @@ NAGATE_B:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 100
-		Prerequisites: nahand, ~structures.nod
+		Prerequisites: nahand, ~structures.nod, ~techlevel.low
 	Tooltip:
 		Name: Nod Gate
 
@@ -49,7 +49,7 @@ NALASR:
 		Name: Laser Turret
 	Buildable:
 		Queue: Defense
-		Prerequisites: nahand, ~structures.nod
+		Prerequisites: nahand, ~structures.nod, ~techlevel.low
 		BuildPaletteOrder: 50
 		Description: Basic base defense.\nRequires power to operate.\n  Strong vs Ground units\n  Weak vs Aircraft
 	Building:
@@ -90,7 +90,7 @@ NAOBEL:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 90
-		Prerequisites: natech, ~structures.nod
+		Prerequisites: natech, ~structures.nod, ~techlevel.high
 		Description: Advanced base defense.\nRequires power to operate.\n  Strong vs Ground units\n  Weak vs Aircraft
 	Building:
 		Footprint: xx xx
@@ -133,7 +133,7 @@ NASAM:
 		Name: S.A.M. Site
 	Buildable:
 		Queue: Defense
-		Prerequisites: naradr, ~structures.nod
+		Prerequisites: naradr, ~structures.nod, ~techlevel.medium
 		BuildPaletteOrder: 60
 		Description: Nod Anti-Air base defense.\nRequires power to operate.\n  Strong vs Aircraft\n  Weak vs Ground units
 	Selectable:
@@ -228,7 +228,7 @@ NAMISL:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 100
-		Prerequisites: natech, ~structures.nod
+		Prerequisites: natech, ~structures.nod, ~techlevel.superweapons
 		BuildLimit: 1
 		Description: Launches a devastating missile\nat a target location.\nRequires power to operate.\nMaximum 1 can be built.
 	Valued:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -9,7 +9,7 @@ BGGY:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 40
-		Prerequisites: ~naweap
+		Prerequisites: ~naweap, ~techlevel.low
 		Description: Fast scout and anti-infantry vehicle.\n  Strong vs Infantry, Light armor\n  Weak vs Vehicles, Aircraft
 	Mobile:
 		TurnSpeed: 8
@@ -45,7 +45,7 @@ BIKE:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 30
-		Prerequisites: ~naweap
+		Prerequisites: ~naweap, ~techlevel.low
 		Description: Fast scout vehicle, armed with\nrockets.\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
 	Mobile:
 		TurnSpeed: 8
@@ -85,7 +85,7 @@ TTNK:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 60
-		Prerequisites: ~naweap
+		Prerequisites: ~naweap, ~techlevel.medium
 		Description: Nod's main battle tank.\nCan deploy to gain extra protection.\n  Strong vs Vehicles\n  Weak vs Infantry, Aircraft
 	Mobile:
 		TurnSpeed: 5
@@ -181,7 +181,7 @@ ART2:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 100
-		Prerequisites: ~naweap, naradr
+		Prerequisites: ~naweap, naradr, ~techlevel.high
 		Description: Mobile Artillery.\nNeeds to deploy in order to shoot.\n  Strong vs Ground units\n  Weak vs Aircraft
 	Health:
 		HP: 300
@@ -209,7 +209,7 @@ REPAIR:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 70
-		Prerequisites: ~naweap
+		Prerequisites: ~naweap, ~techlevel.medium
 		Description: Repairs nearby vehicles.\n  Unarmed
 	Valued:
 		Cost: 1000
@@ -243,7 +243,7 @@ WEED:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 100
-		Prerequisites: ~naweap, nawast
+		Prerequisites: ~naweap, nawast, ~techlevel.superweapons
 		Description: Collects veins for processing.\n  Unarmed
 	Harvester:
 		DeliveryBuildings: nawast
@@ -285,7 +285,7 @@ SAPC:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 30
-		Prerequisites: ~naweap, natech
+		Prerequisites: ~naweap, natech, ~techlevel.medium
 		Description: Troop transport that can move\nunderground to avoid detection.\n  Unarmed
 	Mobile:
 		TurnSpeed: 5
@@ -331,7 +331,7 @@ SUBTANK:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 40
-		Prerequisites: ~naweap, natech
+		Prerequisites: ~naweap, natech, ~techlevel.high
 		Description: Subterranean Flame Tank.\nIs able to move underground.\n  Strong vs Infantry, Buildings\n  Weak vs Tanks, Aircraft
 	Mobile:
 		TurnSpeed: 6
@@ -374,7 +374,7 @@ STNK:
 		Name: Stealth Tank
 	Buildable:
 		BuildPaletteOrder: 90
-		Prerequisites: ~naweap, natech
+		Prerequisites: ~naweap, natech, ~techlevel.high
 		Queue: Vehicle
 		Description: Lightly armoured tank equipped with a personal\nstealth generator. Armed with missiles.\nCan be spotted by infantry at close range.\n  Strong vs Vehicles, Aircraft\n  Weak vs Infantry
 	Mobile:

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -51,5 +51,21 @@ Player:
 	HarvesterAttackNotifier:
 	PlayerStatistics:
 	PlaceSimpleBeacon:
+	ProvidesTechPrerequisite@low:
+		Name: Low
+		Prerequisites: techlevel.low
+		Id: low
+	ProvidesTechPrerequisite@medium:
+		Name: Medium
+		Prerequisites: techlevel.low, techlevel.medium
+		Id: medium
+	ProvidesTechPrerequisite@nosuper:
+		Name: No Powers
+		Prerequisites: techlevel.low, techlevel.medium, techlevel.high
+		Id: nopowers
+	ProvidesTechPrerequisite@all:
+		Name: Unrestricted
+		Prerequisites: techlevel.low, techlevel.medium, techlevel.high, techlevel.superweapons
+		Id: unrestricted
 	ResourceStorageWarning:
 	PlayerExperience:

--- a/mods/ts/rules/shared-infantry.yaml
+++ b/mods/ts/rules/shared-infantry.yaml
@@ -4,7 +4,7 @@ E1:
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 10
-		Prerequisites: ~barracks
+		Prerequisites: ~barracks, ~techlevel.low
 		Description: General-purpose infantry.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft
 	Valued:
 		Cost: 120
@@ -41,7 +41,7 @@ ENGINEER:
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 30
-		Prerequisites: ~barracks
+		Prerequisites: ~barracks, ~techlevel.low
 		Description: Infiltrates and captures enemy structures.\n  Unarmed
 	Voiced:
 		VoiceSet: Engineer

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -63,7 +63,7 @@ PROC:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 20
-		Prerequisites: anypower
+		Prerequisites: anypower, ~techlevel.low
 		Description: Processes raw Tiberium\ninto useable resources.
 	Building:
 		Footprint: xxx= xx== xxx=
@@ -115,7 +115,7 @@ GASILO:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 70
-		Prerequisites: proc
+		Prerequisites: proc, ~techlevel.low
 		Description: Stores excess Tiberium.
 	Valued:
 		Cost: 150

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -7,7 +7,7 @@ NAPULS:
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 90
-		Prerequisites: radar
+		Prerequisites: radar, ~techlevel.superweapons
 		Description: Disables mechanical units in an area.\nRequires power to operate.
 	Building:
 		Footprint: xx xx

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -4,7 +4,7 @@ MCV:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 110
-		Prerequisites: ~factory, tech
+		Prerequisites: ~factory, tech, ~techlevel.medium
 		Description: Deploys into another Construction Yard.\n  Unarmed
 	Valued:
 		Cost: 2000
@@ -50,7 +50,7 @@ HARV:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 10
-		Prerequisites: ~factory, proc
+		Prerequisites: ~factory, proc, ~techlevel.low
 		Description: Collects Tiberium for processing.\n  Unarmed
 	Selectable:
 		Priority: 7
@@ -114,7 +114,7 @@ LPST:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 100
-		Prerequisites: ~factory, radar
+		Prerequisites: ~factory, radar, ~techlevel.medium
 		Description: Can detect cloaked and subterranean\nunits when deployed.\n  Unarmed
 	Valued:
 		Cost: 950


### PR DESCRIPTION
Fixes #5416.

Currently it is like that:

Low: Power, Barracks, Ref, Silo, WFac, Radar, Wall, Gate, Vulcan, Laser Tower, Rifleman, Grenadier, Rocket Soldier, Medic, Engineer, Harvester, Wolverine, Buggy, Cycle.

On Low, Radar is available but only provides Radar. It doesn't enable any unit.

Medium: Adv. Power, Power Turbine, Tech Center, Repair Pad, Helipad, SAM, Jumpjet, Cyborg, APCs, Tick Tank, Titan, Sensor Array, MCV, MRV, Harpy, Carryall, Orca Fighter.

On Medium, Tech Center  is available but only provides prerequisites for MCV, nothing else.

NoSW: Temple of Nod, Stealth Generator, RPG Cannon, Obelisk, Mutant Hijacker, Cyborg Commando, Ghost Stalker, Mammoth Mk.II, Distruptor, MLRS, Artillery, Stealth Tank, Banshee, Orca Bomber.

Full Tech: Upgrade Center, Tiberium Waste Facility, EMP Cannon, Plugs, Missile Silo, Weed Eater.