### PR TITLE
Add "Fast" game speed to all mods

### DIFF
--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -209,6 +209,10 @@ GameSpeeds:
 		Name: Normal
 		Timestep: 40
 		OrderLatency: 3
+	fast:
+		Name: Fast
+		Timestep: 35
+		OrderLatency: 4
 	faster:
 		Name: Faster
 		Timestep: 30

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -186,6 +186,10 @@ GameSpeeds:
 		Name: Normal
 		Timestep: 40
 		OrderLatency: 3
+	fast:
+		Name: Fast
+		Timestep: 35
+		OrderLatency: 4
 	faster:
 		Name: Faster
 		Timestep: 30

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -212,6 +212,10 @@ GameSpeeds:
 		Name: Normal
 		Timestep: 40
 		OrderLatency: 3
+	fast:
+		Name: Fast
+		Timestep: 35
+		OrderLatency: 4
 	faster:
 		Name: Faster
 		Timestep: 30

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -246,6 +246,10 @@ GameSpeeds:
 		Name: Normal
 		Timestep: 40
 		OrderLatency: 3
+	fast:
+		Name: Fast
+		Timestep: 35
+		OrderLatency: 4
 	faster:
 		Name: Faster
 		Timestep: 30


### PR DESCRIPTION
Sitting smack in the middle between "Normal" and "Faster", except for order delay (which is same as Faster to avoid rejected/dropped orders).

Closes #12509.