### PR TITLE
Per mod settings #8276

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -333,6 +333,16 @@ namespace OpenRA
 			InitializeMod(modID, args);
 		}
 
+		private static void ValidateModSettings()
+		{
+			var factions = ModData.DefaultRules.Actors.Count > 0 ? ModData.DefaultRules.Actors["world"].TraitInfos<Traits.FactionInfo>() : null;
+			if (factions == null) return;
+			var faction = Settings.Lobby.Faction;
+
+			if (faction != "Random" && !factions.Where(f => f.Selectable).Any(f => f.InternalName == faction))
+				Settings.Lobby.Faction = "Random";
+		}
+
 		public static void InitializeMod(string mod, Arguments args)
 		{
 			// Clear static state if we have switched mods
@@ -409,6 +419,9 @@ namespace OpenRA
 			PerfHistory.Items["batches"].HasNormalTick = false;
 			PerfHistory.Items["render_widgets"].HasNormalTick = false;
 			PerfHistory.Items["render_flip"].HasNormalTick = false;
+
+			Settings.LoadModSettings(mod, Platform.ResolvePath(Path.Combine("^", "settings.{0}.yaml".F(mod))), args);
+			ValidateModSettings();
 
 			JoinLocal();
 

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -157,9 +157,9 @@ namespace OpenRA.Network
 							Name = Game.Settings.Player.Name,
 							PreferredColor = Game.Settings.Player.Color,
 							Color = Game.Settings.Player.Color,
-							Faction = "Random",
+							Faction = Game.Settings.Lobby.Faction,
 							SpawnPoint = 0,
-							Team = 0,
+							Team = Game.Settings.Lobby.Team,
 							State = Session.ClientState.Invalid
 						};
 

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -308,9 +308,9 @@ namespace OpenRA.Server
 					Slot = LobbyInfo.FirstEmptySlot(),
 					PreferredColor = handshake.Client.Color,
 					Color = handshake.Client.Color,
-					Faction = "Random",
+					Faction = handshake.Client.Faction,
 					SpawnPoint = 0,
-					Team = 0,
+					Team = handshake.Client.Team,
 					State = Session.ClientState.Invalid,
 					IsAdmin = !LobbyInfo.Clients.Any(c1 => c1.IsAdmin)
 				};

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -331,9 +331,16 @@ namespace OpenRA
 		public bool ConnectAutomatically = false;
 	}
 
+	public class LobbySettings
+	{
+		public string Faction = "Random";
+		public int Team = 0;
+	}
+
 	public class Settings
 	{
 		string settingsFile;
+		string modSettingsFile;
 
 		public PlayerSettings Player = new PlayerSettings();
 		public GameSettings Game = new GameSettings();
@@ -343,11 +350,15 @@ namespace OpenRA
 		public DebugSettings Debug = new DebugSettings();
 		public KeySettings Keys = new KeySettings();
 		public ChatSettings Chat = new ChatSettings();
+		public LobbySettings Lobby = new LobbySettings();
 
 		public Dictionary<string, object> Sections;
+		public Dictionary<string, object> ModSections;
 
 		public Settings(string file, Arguments args)
 		{
+			FieldLoader.UnknownFieldAction = (s, f) => Console.WriteLine("Ignoring unknown field `{0}` on `{1}`".F(s, f.Name));
+
 			settingsFile = file;
 			Sections = new Dictionary<string, object>()
 			{
@@ -361,33 +372,7 @@ namespace OpenRA
 				{ "Chat", Chat }
 			};
 
-			// Override fieldloader to ignore invalid entries
-			var err1 = FieldLoader.UnknownFieldAction;
-			var err2 = FieldLoader.InvalidValueAction;
-			try
-			{
-				FieldLoader.UnknownFieldAction = (s, f) => Console.WriteLine("Ignoring unknown field `{0}` on `{1}`".F(s, f.Name));
-
-				if (File.Exists(settingsFile))
-				{
-					var yaml = MiniYaml.DictFromFile(settingsFile);
-
-					foreach (var kv in Sections)
-						if (yaml.ContainsKey(kv.Key))
-							LoadSectionYaml(yaml[kv.Key], kv.Value);
-				}
-
-				// Override with commandline args
-				foreach (var kv in Sections)
-					foreach (var f in kv.Value.GetType().GetFields())
-						if (args.Contains(kv.Key + "." + f.Name))
-							FieldLoader.LoadField(kv.Value, f.Name, args.GetValue(kv.Key + "." + f.Name, ""));
-			}
-			finally
-			{
-				FieldLoader.UnknownFieldAction = err1;
-				FieldLoader.InvalidValueAction = err2;
-			}
+			LoadSettings(Sections, settingsFile, args);
 		}
 
 		public void Save()
@@ -397,6 +382,15 @@ namespace OpenRA
 				root.Add(new MiniYamlNode(kv.Key, FieldSaver.SaveDifferences(kv.Value, Activator.CreateInstance(kv.Value.GetType()))));
 
 			root.WriteToFile(settingsFile);
+
+			if (ModSections != null)
+			{
+				root = new List<MiniYamlNode>();
+				foreach (var kv in ModSections)
+					root.Add(new MiniYamlNode(kv.Key, FieldSaver.SaveDifferences(kv.Value, Activator.CreateInstance(kv.Value.GetType()))));
+
+				root.WriteToFile(modSettingsFile);
+			}
 		}
 
 		static string SanitizedName(string dirty)
@@ -451,6 +445,52 @@ namespace OpenRA
 			};
 
 			FieldLoader.Load(section, yaml);
+		}
+
+		internal void LoadModSettings(string mod, string settingsFile, Arguments args)
+		{
+			modSettingsFile = settingsFile;
+			ModSections = new Dictionary<string, object>()
+			{
+				{ "Player", Player },
+				{ "Lobby", Lobby },
+				{ "Server", Server },
+				{ "Keys", Keys }
+			};
+
+			LoadSettings(ModSections, modSettingsFile, args);
+		}
+
+		private void LoadSettings(Dictionary<string, object> sections, string settingsFile, Arguments args)
+		{
+			// Override fieldloader to ignore invalid entries
+			var err1 = FieldLoader.UnknownFieldAction;
+			var err2 = FieldLoader.InvalidValueAction;
+			try
+			{
+				if (File.Exists(settingsFile))
+				{
+					var yaml = MiniYaml.DictFromFile(settingsFile);
+
+					foreach (var kv in sections)
+						if (yaml.ContainsKey(kv.Key))
+							LoadSectionYaml(yaml[kv.Key], kv.Value);
+				}
+
+				if (args != null)
+				{
+					// Override with commandline args
+					foreach (var kv in sections)
+						foreach (var f in kv.Value.GetType().GetFields())
+							if (args.Contains(kv.Key + "." + f.Name))
+								FieldLoader.LoadField(kv.Value, f.Name, args.GetValue(kv.Key + "." + f.Name, ""));
+				}
+			}
+			finally
+			{
+				FieldLoader.UnknownFieldAction = err1;
+				FieldLoader.InvalidValueAction = err2;
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -81,7 +81,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				var item = ScrollItemWidget.Setup(itemTemplate,
 					() => client.Team == ii,
-					() => orderManager.IssueOrder(Order.Command("team {0} {1}".F(client.Index, ii))));
+					() =>
+					{
+						orderManager.IssueOrder(Order.Command("team {0} {1}".F(client.Index, ii)));
+						Game.Settings.Lobby.Team = ii;
+						Game.Settings.Save();
+					});
 				item.Get<LabelWidget>("LABEL").GetText = () => ii == 0 ? "-" : ii.ToString();
 				return item;
 			};
@@ -112,7 +117,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				var item = ScrollItemWidget.Setup(itemTemplate,
 					() => client.Faction == factionId,
-					() => orderManager.IssueOrder(Order.Command("faction {0} {1}".F(client.Index, factionId))));
+					() =>
+					{
+						orderManager.IssueOrder(Order.Command("faction {0} {1}".F(client.Index, factionId)));
+						Game.Settings.Lobby.Faction = factionId;
+						Game.Settings.Save();
+					});
 				var faction = factions[factionId];
 				item.Get<LabelWidget>("LABEL").GetText = () => faction.Name;
 				var flag = item.Get<ImageWidget>("FLAG");


### PR DESCRIPTION
Added support for per mod settings in settings._mod_.yaml file. Currently supported options:

Player - Name, Color, LastServer (MP Direct IP Address:port)
Faction, Team (1 Faction for both Skirmish and Multiplayer)
Hotkeys
Server - all options from settings.yaml (MP Create Game name, port, map,...)