### PR TITLE
Prevent Harvester from getting deadlocked

### DIFF
--- a/OpenRA.Mods.Common/Activities/FindResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindResources.cs
@@ -103,7 +103,7 @@ namespace OpenRA.Mods.Common.Activities
 				foreach (var n in notify)
 					n.MovingToResources(self, closestHarvestablePosition.Value, this);
 
-				return ActivityUtils.SequenceActivities(mobile.MoveTo(closestHarvestablePosition.Value, 1), new HarvestResource(self), this);
+				return ActivityUtils.SequenceActivities(mobile.MoveTo(closestHarvestablePosition.Value, 2), new HarvestResource(self), this);
 			}
 		}
 


### PR DESCRIPTION
- Related to issue #12817. It occurs very frequently when AI builds many harvesters. After this fix, I never saw AI harvester getting stuck. I only verified it with AIs so I'm not sure if this fixes issues with ally harvesters. (but probably will)
- Also, harvesters can get stuck when trying to harvest a tib/ore patch underneath a friendly unit. Especially true when AI has a rally point set on ore. Harvester will not mine until the unit is removed for its use as attacking force. I don't think Notifying blocker is a good solution as they might be standing there to protect the harvesters. In this fix, harvesters take such cells as un-harvestable cell.

- This is the behavior of RA1 and CNC1 harvesters. I can make units stand on tib patch so that the tib patch underneath will start growing and eventually spread to adjacent cells., effectively making the units my own blossom tree :)