### PR TITLE
Add tooltips to production statistics #12820

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -220,6 +220,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			template.Get<ObserverProductionIconsWidget>("PRODUCTION_ICONS").GetPlayer = () => player;
 			template.Get<ObserverSupportPowerIconsWidget>("SUPPORT_POWER_ICONS").GetPlayer = () => player;
+			template.IgnoreChildMouseOver = false;
 
 			return template;
 		}

--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -22,11 +22,12 @@ namespace OpenRA.Mods.Common.Widgets
 {
 	public class ObserverProductionIconsWidget : Widget
 	{
+		public readonly string TooltipTemplate = "PRODUCTION_TOOLTIP";
+		public readonly string TooltipContainer;
 		public Func<Player> GetPlayer;
 		readonly World world;
 		readonly WorldRenderer worldRenderer;
 		readonly int timestep;
-		Dictionary<ProductionQueue, Animation> clocks;
 
 		public int IconWidth = 32;
 		public int IconHeight = 24;
@@ -36,6 +37,17 @@ namespace OpenRA.Mods.Common.Widgets
 		public string ClockSequence = "idle";
 		public string ClockPalette = "chrome";
 
+		public ProductionIcon TooltipIcon { get; private set; }
+		public Func<ProductionIcon> GetTooltipIcon;
+
+		Dictionary<ProductionQueue, Animation> clocks;
+		float2 iconSize;
+		Rectangle[] iconRects = new Rectangle[0];
+		ProductionIcon[] icons;
+		Rectangle renderBounds;
+		int lastIconIdx;
+		Lazy<TooltipContainerWidget> tooltipContainer;
+
 		[ObjectCreator.UseCtor]
 		public ObserverProductionIconsWidget(World world, WorldRenderer worldRenderer)
 		{
@@ -43,6 +55,10 @@ namespace OpenRA.Mods.Common.Widgets
 			this.worldRenderer = worldRenderer;
 			clocks = new Dictionary<ProductionQueue, Animation>();
 			timestep = world.IsReplay ? world.WorldActor.Trait<MapOptions>().GameSpeed.Timestep : world.Timestep;
+			GetTooltipIcon = () => TooltipIcon;
+			tooltipContainer = Exts.Lazy(() =>
+				Ui.Root.Get<TooltipContainerWidget>(TooltipContainer));
+			iconSize = new float2(IconWidth, IconHeight);
 		}
 
 		protected ObserverProductionIconsWidget(ObserverProductionIconsWidget other)
@@ -57,10 +73,21 @@ namespace OpenRA.Mods.Common.Widgets
 			IconWidth = other.IconWidth;
 			IconHeight = other.IconHeight;
 			IconSpacing = other.IconSpacing;
+			iconSize = new float2(IconWidth, IconHeight);
 
 			ClockAnimation = other.ClockAnimation;
 			ClockSequence = other.ClockSequence;
 			ClockPalette = other.ClockPalette;
+
+			TooltipIcon = other.TooltipIcon;
+			GetTooltipIcon = () => TooltipIcon;
+
+			TooltipTemplate = other.TooltipTemplate;
+			TooltipContainer = other.TooltipContainer;
+
+			tooltipContainer = Exts.Lazy(() =>
+				Ui.Root.Get<TooltipContainerWidget>(TooltipContainer));
+			renderBounds = Rectangle.Empty;
 		}
 
 		public override void Draw()
@@ -73,15 +100,22 @@ namespace OpenRA.Mods.Common.Widgets
 				.Where(a => a.Actor.Owner == player)
 				.Select((a, i) => new { a.Trait, i });
 
+			if (renderBounds != RenderBounds)
+			{
+				renderBounds = RenderBounds;
+				InitIcons(renderBounds);
+			}
+			else
+				for (var i = 0; i < icons.Length; i++)
+					icons[i].Actor = null;
+
 			foreach (var queue in queues)
+			{
 				if (!clocks.ContainsKey(queue.Trait))
 					clocks.Add(queue.Trait, new Animation(world, ClockAnimation));
 
-			var iconSize = new float2(IconWidth, IconHeight);
-			foreach (var queue in queues)
-			{
 				var current = queue.Trait.CurrentItem();
-				if (current == null)
+				if (current == null || queue.i >= icons.Length)
 					continue;
 
 				var faction = queue.Trait.Actor.Owner.Faction.InternalName;
@@ -93,8 +127,11 @@ namespace OpenRA.Mods.Common.Widgets
 				var icon = new Animation(world, rsi.GetImage(actor, world.Map.Rules.Sequences, faction));
 				var bi = actor.TraitInfo<BuildableInfo>();
 				icon.Play(bi.Icon);
-				var location = new float2(RenderBounds.Location) + new float2(queue.i * (IconWidth + IconSpacing), 0);
+				var location = new float2(iconRects[queue.i].Location);
 				WidgetUtils.DrawSHPCentered(icon.Image, location + 0.5f * iconSize, worldRenderer.Palette(bi.IconPalette), 0.5f);
+
+				icons[queue.i].Actor = actor;
+				icons[queue.i].ProductionQueue = queue.Trait;
 
 				var pio = queue.Trait.Actor.Owner.PlayerActor.TraitsImplementing<IProductionIconOverlay>()
 					.FirstOrDefault(p => p.IsOverlayActive(actor));
@@ -131,6 +168,53 @@ namespace OpenRA.Mods.Common.Widgets
 		public override Widget Clone()
 		{
 			return new ObserverProductionIconsWidget(this);
+		}
+
+		public override void MouseEntered()
+		{
+			if (TooltipContainer != null)
+				tooltipContainer.Value.SetTooltip(TooltipTemplate,
+					new WidgetArgs() { { "player", GetPlayer() }, { "getTooltipIcon", GetTooltipIcon } });
+		}
+
+		public override void MouseExited()
+		{
+			if (TooltipContainer == null)
+				return;
+
+			tooltipContainer.Value.RemoveTooltip();
+		}
+
+		public override void Tick()
+		{
+			if (TooltipIcon != null && iconRects[lastIconIdx].Contains(Viewport.LastMousePos))
+				return;
+
+			for (var i = 0; i < iconRects.Length; i++)
+			{
+				if (iconRects[i].Contains(Viewport.LastMousePos))
+				{
+					lastIconIdx = i;
+					TooltipIcon = icons[i];
+					return;
+				}
+			}
+
+			TooltipIcon = null;
+		}
+
+		void InitIcons(Rectangle renderBounds)
+		{
+			var iconWidthWithSpacing = IconWidth + IconSpacing;
+			var numOfIcons = renderBounds.Width / iconWidthWithSpacing;
+			iconRects = new Rectangle[numOfIcons];
+			icons = new ProductionIcon[numOfIcons];
+
+			for (var i = 0; i < numOfIcons; i++)
+			{
+				iconRects[i] = new Rectangle(renderBounds.X + i * iconWidthWithSpacing, renderBounds.Y, IconWidth, IconHeight);
+				icons[i] = new ProductionIcon();
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -33,6 +33,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public PaletteReference IconDarkenPalette;
 		public float2 Pos;
 		public List<ProductionItem> Queued;
+		public ProductionQueue ProductionQueue;
 	}
 
 	public class ProductionPaletteWidget : Widget
@@ -66,6 +67,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public event Action<int, int> OnIconCountChanged = (a, b) => { };
 
 		public ProductionIcon TooltipIcon { get; private set; }
+		public Func<ProductionIcon> GetTooltipIcon;
 		public readonly World World;
 		readonly OrderManager orderManager;
 
@@ -98,6 +100,7 @@ namespace OpenRA.Mods.Common.Widgets
 			this.orderManager = orderManager;
 			World = world;
 			this.worldRenderer = worldRenderer;
+			GetTooltipIcon = () => TooltipIcon;
 			tooltipContainer = Exts.Lazy(() =>
 				Ui.Root.Get<TooltipContainerWidget>(TooltipContainer));
 
@@ -164,7 +167,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			if (TooltipContainer != null)
 				tooltipContainer.Value.SetTooltip(TooltipTemplate,
-					new WidgetArgs() { { "world", World }, { "palette", this } });
+					new WidgetArgs() { { "player", World.LocalPlayer }, { "getTooltipIcon", GetTooltipIcon } });
 		}
 
 		public override void MouseExited()
@@ -351,7 +354,8 @@ namespace OpenRA.Mods.Common.Widgets
 					IconClockPalette = worldRenderer.Palette(ClockPalette),
 					IconDarkenPalette = worldRenderer.Palette(NotBuildablePalette),
 					Pos = new float2(rect.Location),
-					Queued = CurrentQueue.AllQueued().Where(a => a.Item == item.Name).ToList()
+					Queued = currentQueue.AllQueued().Where(a => a.Item == item.Name).ToList(),
+					ProductionQueue = currentQueue
 				};
 
 				icons.Add(rect, pi);

--- a/mods/cnc/chrome/ingame-observerstats.yaml
+++ b/mods/cnc/chrome/ingame-observerstats.yaml
@@ -457,6 +457,7 @@ Background@INGAME_OBSERVERSTATS_BG:
 									Y: 0
 									Width: 320
 									Height: PARENT_BOTTOM
+									TooltipContainer: TOOLTIP_CONTAINER
 								ObserverSupportPowerIcons@SUPPORT_POWER_ICONS:
 									X: 535
 									Y: 0

--- a/mods/common/chrome/ingame-observerstats.yaml
+++ b/mods/common/chrome/ingame-observerstats.yaml
@@ -457,6 +457,7 @@ Background@INGAME_OBSERVERSTATS_BG:
 									Y: 0
 									Width: 320
 									Height: PARENT_BOTTOM
+									TooltipContainer: TOOLTIP_CONTAINER
 								ObserverSupportPowerIcons@SUPPORT_POWER_ICONS:
 									X: 535
 									Y: 0

--- a/mods/ts/chrome/ingame-observerstats.yaml
+++ b/mods/ts/chrome/ingame-observerstats.yaml
@@ -458,6 +458,7 @@ Background@INGAME_OBSERVERSTATS_BG:
 									Width: 320
 									Height: PARENT_BOTTOM
 									ClockPalette: iconclock
+									TooltipContainer: TOOLTIP_CONTAINER
 								ObserverSupportPowerIcons@SUPPORT_POWER_ICONS:
 									X: 535
 									Y: 0


### PR DESCRIPTION
Tooltip with list of currently produced buildings and units.

![obrazok](https://cloud.githubusercontent.com/assets/16348750/24166583/04481ce0-0e74-11e7-8b34-828fde80224d.png)
