### PR TITLE
D2K - Remove Sonic Tanks' immunity to other friendly Sonic Tanks.

### DIFF
--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -291,8 +291,6 @@ sonic_tank:
 		Actor: sonic_tank.husk
 	AttractsWorms:
 		Intensity: 600
-	Targetable:
-		TargetTypes: Ground, Vehicle, C4, Sonictank
 
 devastator:
 	Inherits: ^Tank

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -30,7 +30,6 @@ Sound:
 		Range: 0, 32
 		Falloff: 50, 50 # Only does half damage to friendly units
 		Damage: 150
-		InvalidTargets: Sonictank # Does not affect friendly sonic tanks at all
 		AffectsParent: false
 		ValidStances: Ally
 		Versus:


### PR DESCRIPTION
This was not the case in Original D2K, i think it was only in Dune 2.

![sonics damage each other](https://cloud.githubusercontent.com/assets/7933210/24329630/ca9b2324-120c-11e7-8cf2-fae4358d3b08.png)

http://www.sleipnirstuff.com/forum/viewtopic.php?f=82&t=20015&start=24