### PR TITLE
Add Juggernaut to TS

### DIFF
--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -278,3 +278,93 @@ SONIC:
 		Offset: -170,0,0
 	AutoTarget:
 	WithVoxelTurret:
+
+JUGG:
+	Inherits: ^Tank
+	Inherits@SPRITES: ^SpriteActor
+	Inherits@EXPERIENCE: ^GainsExperience
+	Valued:
+		Cost: 950
+	Tooltip:
+		Name: Juggernaut
+		RequiresCondition: !deployed
+	Tooltip@DEPLOYED:
+		Name: Juggernaut (deployed)
+		RequiresCondition: deployed
+	Buildable:
+		Queue: Vehicle
+		BuildPaletteOrder: 100
+		Prerequisites: ~gaweap, garadr, ~techlevel.high
+		Description: Mobile Artillery Mech.\nNeeds to deploy in order to shoot.\n  Strong vs Ground units\n  Weak vs Aircraft
+	Health:
+		HP: 350
+	Armor:
+		Type: Light
+	Mobile:
+		Speed: 71
+		TurnSpeed: 5
+		RequiresCondition: !empdisable && undeployed
+	RevealsShroud:
+		RequiresCondition: !inside-tunnel
+		Range: 9c0
+		MaxHeightDelta: 3
+	RenderVoxels:
+		LightAmbientColor: 0.4, 0.4, 0.4
+	RenderSprites:
+		Image: jugg
+	WithMakeAnimation:
+		BodyNames: body, deployedbody
+	WithFacingSpriteBody:
+		Sequence: stand
+		RequiresCondition: undeployed
+	WithMoveAnimation:
+		MoveSequence: run
+	GrantConditionOnDeploy:
+		DeployedCondition: deployed
+		UndeployedCondition: undeployed
+		Facing: 96
+		AllowedTerrainTypes: Clear, Road, DirtRoad, Rough
+		DeploySound: place2.aud
+		UndeploySound: clicky1.aud
+	GrantCondition@PREVIEWWORKAROUND:
+		Condition: real-actor
+	QuantizeFacingsFromSequence:
+		Sequence: turret
+	WithSpriteBody@deployed:
+		RequiresCondition: !undeployed && real-actor
+		Name: deployedbody
+	Turreted:
+		Turret: deployed
+		TurnSpeed: 5
+		InitialFacing: 96
+		Offset: -153,-17,633
+		RealignDelay: -1
+	WithVoxelBarrel:
+		Armament: deployed
+		LocalOffset: 512,0,362
+		LocalOrientation: 0, 128, 0
+		RequiresCondition: deployed
+	WithSpriteTurret@deployed:
+		Turret: deployed
+		RequiresCondition: deployed
+		Recoils: false
+	AttackTurreted@deployed:
+		Voice: Attack
+		Armaments: deployed
+		RequiresCondition: deployed
+	Armament@deployed:
+		Name: deployed
+		Turret: deployed
+		Weapon: Jugg90mm
+		LocalOffset: 820,203,1386, 820,0,1386, 820,-203,1386
+		RequiresCondition: deployed
+		MuzzleSequence: muzzle
+		MuzzlePalette: effect-ignore-lighting
+	WithMuzzleOverlay:
+	AutoTarget:
+	Carryable:
+		RequiresCondition: undeployed
+	RevealOnFire:
+		ArmamentNames: deployed
+	SelectionDecorations:
+		VisualBounds: 48,40,0,-8

--- a/mods/ts/sequences/vehicles.yaml
+++ b/mods/ts/sequences/vehicles.yaml
@@ -171,6 +171,37 @@ mmch:
 		Offset: 0, 0, 12
 	icon: mmchicon
 
+jugg:
+	Inherits: ^VehicleOverlays
+	icon: juggicon
+	stand: jugger
+		Facings: -8
+		Stride: 15
+		ShadowStart: 120
+		Offset: 0, 0, 12
+	run: jugger
+		Length: 15
+		Facings: -8
+		ShadowStart: 120
+		Offset: 0, 0, 12
+	turret: djugg_a
+		Facings: 32
+		Offset: -4, 0, 12
+	idle: djugg
+		ShadowStart: 3
+		Offset: 0, -12, 12
+	damaged-idle: djugg
+		Start: 1
+		ShadowStart: 4
+		Offset: 0, -12, 12
+	make: djuggmk
+		Length: 18
+		ShadowStart: 18
+		Offset: 0, -12, 12
+	muzzle: gunfire
+		Length: *
+		Offset: 0, 0, 24
+
 gghunt:
 	Inherits: ^VehicleOverlays
 	idle:

--- a/mods/ts/sequences/voxels.yaml
+++ b/mods/ts/sequences/voxels.yaml
@@ -14,6 +14,9 @@ art2:
 	turret: art2tur
 	barrel: art2barl
 
+jugg:
+	barrel: djuggbar
+
 subtank:
 	idle:
 

--- a/mods/ts/weapons/ballisticweapons.yaml
+++ b/mods/ts/weapons/ballisticweapons.yaml
@@ -108,6 +108,25 @@ RPGTower:
 		Explosions: large_explosion
 		ImpactSounds: expnew06.aud
 
+Jugg90mm:
+	Inherits: ^ArtilleryWeapon
+	ReloadDelay: 150
+	Range: 18c0
+	MinRange: 5c0
+	Burst: 3
+	BurstDelay: 3
+	-Report:
+	StartBurstReport: jugger1.aud
+	Projectile: Bullet
+		Speed: 384
+		LaunchAngle: 165
+		Inaccuracy: 2c0
+	Warhead@1Dam: SpreadDamage
+		Damage: 75
+	Warhead@2Eff: CreateEffect
+		Explosions: small_explosion
+		ImpactSounds: expnew13.aud
+
 Grenade:
 	Inherits: ^ArtilleryWeapon
 	ReloadDelay: 60


### PR DESCRIPTION
Collateral changes:
- added `StartBurstReport` support to weapons, because otherwise you'd hear 9(!) shots when the Jugger fires since the soundfile itself is already a triple-shot sound (and yes, this was a bug/design error in original TS/FS)
- added Name field to `WithSpriteBody` to allow assigning modifying traits to specific sprite bodies
- made `WithMoveAnimation` compatible with multiple sprite bodies per actor (to avoid using the `WithInfantryBody` hack for the Juggernaut)
- made `GrantConditionOnDeploy` compatible with multiple sprite bodies per actor and `WithMakeAnimation` work for deploying actors