### PR TITLE
TD Artillery/MRLS Vision.

### DIFF
--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -149,7 +149,7 @@ ARTY:
 	Armor:
 		Type: Light
 	RevealsShroud:
-		Range: 8c0
+		Range: 5c0
 	Armament:
 		Weapon: ArtilleryShell
 		LocalOffset: 624,0,208
@@ -459,7 +459,7 @@ MSAM:
 	Armor:
 		Type: Light
 	RevealsShroud:
-		Range: 8c0
+		Range: 5c0
 	Turreted:
 		TurnSpeed: 255
 		Offset: -256,0,128


### PR DESCRIPTION
This is changing the vision of Artillery and MRLS from 8c0 to 5c0.

The reason behind this is because we have scouting artillery and MRLS units that have a much larger vision range then infantry and the same vision as hummers and buggies. This turns into games where people build infantry and artillery/MRLS armies and march of death to the enemy. Its more counterable in 1v1 and 2v2 but team games of 3v3+ it becomes incredibly spammy of these units and hard to stop.

http://www.sleipnirstuff.com/forum/viewtopic.php?f=82&p=301205#301205

I was told about a hit scan range issue that is in RA but I haven't found it. The only case of this is the units will fire once scouted and when the scouting unit dies they continue to fire. However, if you do attack move again or the unit that it is firing at dies then it needs to scout again.