### PR TITLE
Bug fix: Trying to deploy concrete walls on moving units #12372

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -75,9 +75,10 @@ namespace OpenRA.Mods.Common.Traits
 				if (os == "LineBuild")
 				{
 					var playSounds = true;
+					Actor building = null;
 					foreach (var t in BuildingUtils.GetLineBuildCells(w, order.TargetLocation, order.TargetString, buildingInfo))
 					{
-						var building = w.CreateActor(order.TargetString, new TypeDictionary
+						building = w.CreateActor(order.TargetString, new TypeDictionary
 						{
 							new LocationInit(t),
 							new OwnerInit(order.Player),
@@ -90,6 +91,9 @@ namespace OpenRA.Mods.Common.Traits
 
 						playSounds = false;
 					}
+
+					if (building == null)
+						return;
 				}
 				else if (os == "PlacePlug")
 				{


### PR DESCRIPTION
This PR resolves issue #12372 "deploying a (single) concrete wall on top of a moving unit stops the wall from being placed, and takes away the money I spent on the wall" for LineBuild orders.