### PR TITLE
TD Commando ScanRadius.

### DIFF
--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -189,7 +189,7 @@ RMBO:
 	RevealsShroud:
 		Range: 6c0
 	AutoTarget:
-		ScanRadius: 6
+		ScanRadius: 8
 	Demolition:
 		DetonationDelay: 45
 		Voice: Demolish


### PR DESCRIPTION
Changed ScanRadius trait on Commando from 6 to 8.

Makes it so the Commando fires at a range of 8 instead of 6 when attack moving.