### PR TITLE
Disable ToolTip while using support powers #12853

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Orders;
 using OpenRA.Traits;
 using OpenRA.Widgets;
 
@@ -174,6 +175,10 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			TooltipType = WorldTooltipType.None;
 			ActorTooltipExtra = null;
+
+			if (!(world.OrderGenerator is UnitOrderGenerator))
+				return;
+
 			var cell = worldRenderer.Viewport.ViewToWorld(Viewport.LastMousePos);
 			if (!world.Map.Contains(cell))
 				return;


### PR DESCRIPTION
I didn't find an explicit way how to identify we are using support power. There isn't some ISupportPowerOrderGenerator or a flag IsPowerActivated, but disabling tooltip for anything different (like support power) than standard operation seems to work fine.