### PR TITLE
Mouse wheel zoom without modifier option

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -710,6 +710,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{ "Ctrl", Modifiers.Ctrl },
 				{ "Meta", Modifiers.Meta },
 				{ "Shift", Modifiers.Shift },
+				{ "None", Modifiers.None }
 			};
 
 			Func<string, ScrollItemWidget, ScrollItemWidget> setupItem = (o, itemTemplate) =>


### PR DESCRIPTION
Add new 'Scroll-zoom Modifier' option - None for simpler/faster zooming.
Requested by users, e.g.: https://www.reddit.com/r/openra/comments/60qt61/zoom_on_scroll/