### PR TITLE
Display team arrangement in Lobby and Replay

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -554,6 +554,33 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 		}
 
+		public static string GetTeamArrangementInfo(IEnumerable<int> teams)
+		{
+			var teamsInfo = "";
+			var noTeamPlayersCount = teams.Count(t => t == 0);
+			var allTeams = teams.Where(t => t != 0).GroupBy(t => t).OrderByDescending(g => g.Count()).ToList();
+			var teamsWithPlayers = allTeams.Where(t => t.Count() > 1).ToList();
+
+			if (noTeamPlayersCount + allTeams.Count > 1 && teamsWithPlayers.Count > 0)
+			{
+				teamsInfo = teamsWithPlayers[0].Count().ToString();
+				for (int i = 1; i < teamsWithPlayers.Count; i++)
+				{
+					teamsInfo += " v {0}".F(teamsWithPlayers[i].Count());
+				}
+
+				var onePlayerTeamsCount = noTeamPlayersCount + allTeams.Count(t => t.Count() == 1);
+				if (onePlayerTeamsCount > 1 && noTeamPlayersCount + allTeams.Count() > 4)
+					teamsInfo += " + " + onePlayerTeamsCount;
+				else
+					teamsInfo += string.Concat(Enumerable.Repeat(" v 1", onePlayerTeamsCount));
+			}
+			else
+				teamsInfo = teams.Count() == 2 ? "1 v 1" : "FFA";
+
+			return teamsInfo;
+		}
+
 		static void HideChildWidget(Widget parent, string widgetId)
 		{
 			var widget = parent.GetOrNull(widgetId);

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -27,6 +27,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	{
 		static Filter filter = new Filter();
 
+		public string TeamArrangementInfo { get; private set; }
+		public Dictionary<CPos, SpawnOccupant> SpawnOccupants { get; private set; }
+
 		readonly Widget panel;
 		readonly ScrollPanelWidget replayList, playerList;
 		readonly ScrollItemWidget playerTemplate, playerHeader;
@@ -78,9 +81,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				{ "orderManager", null },
 				{ "getMap", (Func<MapPreview>)(() => map) },
-				{ "onMouseDown",  (Action<MapPreviewWidget, MapPreview, MouseInput>)((preview, mapPreview, mi) => { }) },
-				{ "getSpawnOccupants", (Func<MapPreview, Dictionary<CPos, SpawnOccupant>>)(mapPreview =>
-					LobbyUtils.GetSpawnOccupants(selectedReplay.GameInfo.Players, mapPreview)) },
+				{ "onMouseDown",  (Action<MapPreviewWidget, MouseInput>)((preview, mi) => { }) },
+				{ "getSpawnOccupants", (Func<Dictionary<CPos, SpawnOccupant>>)(() => SpawnOccupants) },
+				{ "getTeamArrangementInfo", (Func<string>)(() => TeamArrangementInfo) },
+				{ "onMapInstall", () => SpawnOccupants = selectedReplay != null ?
+					LobbyUtils.GetSpawnOccupants(selectedReplay.GameInfo.Players, map) : new Dictionary<CPos, SpawnOccupant>() }
 			});
 
 			var replayDuration = new CachedTransform<ReplayMetadata, string>(r =>
@@ -603,6 +608,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			selectedReplay = replay;
 			map = selectedReplay != null ? selectedReplay.GameInfo.MapPreview : MapCache.UnknownMap;
+			SpawnOccupants = selectedReplay != null ? LobbyUtils.GetSpawnOccupants(selectedReplay.GameInfo.Players, map) : new Dictionary<CPos, SpawnOccupant>();
+			TeamArrangementInfo = selectedReplay != null ? LobbyUtils.GetTeamArrangementInfo(selectedReplay.GameInfo.Players.Select(p => p.Team)) : "";
 
 			if (replay == null)
 				return;

--- a/mods/cnc/chrome/lobby-mappreview.yaml
+++ b/mods/cnc/chrome/lobby-mappreview.yaml
@@ -33,11 +33,11 @@ Container@MAP_PREVIEW:
 					Font: TinyBold
 					Align: Center
 					IgnoreMouseOver: true
-				Label@MAP_AUTHOR:
+				Label@TEAM_ARRANGEMENT:
 					Y: 200
 					Width: PARENT_RIGHT
 					Height: 25
-					Font: Tiny
+					Font: Bold
 					Align: Center
 		Container@MAP_INVALID:
 			Width: PARENT_RIGHT

--- a/mods/common/chrome/lobby-mappreview.yaml
+++ b/mods/common/chrome/lobby-mappreview.yaml
@@ -33,11 +33,11 @@ Container@MAP_PREVIEW:
 					Font: TinyBold
 					Align: Center
 					IgnoreMouseOver: true
-				Label@MAP_AUTHOR:
+				Label@TEAM_ARRANGEMENT:
 					Y: 200
 					Width: PARENT_RIGHT
 					Height: 25
-					Font: Tiny
+					Font: Bold
 					Align: Center
 		Container@MAP_INVALID:
 			Width: PARENT_RIGHT


### PR DESCRIPTION
Display current team arrangement in lobby e.g. 
[ 1 v 1 ], [ FFA ], [ 2 v 2 v 1 v 1], [ 3 v 2 + 3 ]
' + x' means x players without team

![obrazok](https://cloud.githubusercontent.com/assets/16348750/26673295/a6698286-46bc-11e7-90c3-b7ff676f0afc.png)