### PR TITLE
Color picker update - built-in mod colors and a user palette

### DIFF
--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -61,12 +61,13 @@ namespace OpenRA
 
 		public readonly string[] SoundFormats = { };
 		public readonly string[] SpriteFormats = { };
+        public readonly string[] TeamColorPresets = { };
 
-		readonly string[] reservedModuleNames = { "Metadata", "Folders", "MapFolders", "Packages", "Rules",
+        readonly string[] reservedModuleNames = { "Metadata", "Folders", "MapFolders", "Packages", "Rules",
 			"Sequences", "VoxelSequences", "Cursors", "Chrome", "Assemblies", "ChromeLayout", "Weapons",
 			"Voices", "Notifications", "Music", "Translations", "TileSets", "ChromeMetrics", "Missions",
 			"ServerTraits", "LoadScreen", "Fonts", "SupportsMapsFrom", "SoundFormats", "SpriteFormats",
-			"RequiresMods" };
+			"RequiresMods", "TeamColorPresets" };
 
 		readonly TypeDictionary modules = new TypeDictionary();
 		readonly Dictionary<string, MiniYaml> yaml;
@@ -130,7 +131,10 @@ namespace OpenRA
 
 			if (yaml.ContainsKey("SpriteFormats"))
 				SpriteFormats = FieldLoader.GetValue<string[]>("SpriteFormats", yaml["SpriteFormats"].Value);
-		}
+
+            if (yaml.ContainsKey("TeamColorPresets"))
+                TeamColorPresets = FieldLoader.GetValue<string[]>("TeamColorPresets", yaml["TeamColorPresets"].Value);
+        }
 
 		public void LoadCustomData(ObjectCreator oc)
 		{

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -149,7 +149,8 @@ namespace OpenRA
 		public string Name = "Newbie";
 		public HSLColor Color = new HSLColor(75, 255, 180);
 		public string LastServer = "localhost:1234";
-	}
+        public string[] CustomColors;
+    }
 
 	public class GameSettings
 	{

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -549,6 +549,7 @@
     <Compile Include="UtilityCommands\ExtractSettingsDocsCommand.cs" />
     <Compile Include="UtilityCommands\ExtractZeroBraneStudioLuaAPI.cs" />
     <Compile Include="UtilityCommands\ExtractTraitDocsCommand.cs" />
+    <Compile Include="Widgets\ColorPaletteSwatchWidget.cs" />
     <Compile Include="Widgets\Logic\Ingame\MusicControllerLogic.cs" />
     <Compile Include="Widgets\UnitCommandWidget.cs" />
     <Compile Include="WorldExtensions.cs" />

--- a/OpenRA.Mods.Common/Widgets/ColorPaletteSwatchWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ColorPaletteSwatchWidget.cs
@@ -1,0 +1,89 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets
+{
+	public class ColorPaletteSwatchWidget : BackgroundWidget
+    {
+		public Func<Color> GetColor;
+
+        public Action<MouseInput> OnMouseDown = _ => { };
+        public Action<MouseInput> OnMouseUp = _ => { };
+
+        public Action OnClick = () => { };
+
+        //protected bool CtrlPressed = false;
+
+        public ColorPaletteSwatchWidget()
+		{
+			GetColor = () => Color.White;
+            OnMouseUp = _ => OnClick();
+        }
+
+        public override bool HandleKeyPress(KeyInput e)
+        {
+            //if (e.Key == Keycode.LCTRL)
+            //CtrlPressed = e.Modifiers.HasModifier(Modifiers.Ctrl);
+
+            return false;
+        }
+
+        protected ColorPaletteSwatchWidget(ColorPaletteSwatchWidget widget)
+			: base(widget)
+		{
+			GetColor = widget.GetColor;
+            OnMouseUp = _ => OnClick();
+        }
+
+		public override Widget Clone()
+		{
+			return new ColorPaletteSwatchWidget(this);
+		}
+
+		public override void Draw()
+		{
+			WidgetUtils.FillRectWithColor(RenderBounds, GetColor());
+        }
+
+        public override bool HandleMouseInput(MouseInput mi)
+        {
+            if (mi.Button != MouseButton.Left)
+                return false;
+
+            if (mi.Event == MouseInputEvent.Down && !TakeMouseFocus(mi))
+                return false;
+            
+            if (HasMouseFocus && mi.Event == MouseInputEvent.Up)
+            {
+                // Only fire the onMouseUp event if we successfully lost focus, and were pressed
+                OnMouseUp(mi);
+
+                return YieldMouseFocus(mi);
+            }
+
+            if (mi.Event == MouseInputEvent.Down)
+            {
+                // OnMouseDown returns false if the button shouldn't be pressed
+                OnMouseDown(mi);
+                //Depressed = true;
+                //Game.Sound.PlayNotification(ModRules, null, "Sounds", "ClickSound", null);
+            }
+
+            //return Depressed;
+            return false;
+        }
+
+    }
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
@@ -10,6 +10,9 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
@@ -63,11 +66,187 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			hueSlider.Value = initialColor.H / 255f;
 			onChange(mixer.Color);
-		}
+            
+            
+            // Setup the mod team preset colors
+            int maxCustomColors = 10;
 
-		public static void ShowColorDropDown(DropDownButtonWidget color, ColorPreviewManagerWidget preview, World world)
-		{
-			Action onExit = () =>
+            var clearCustomPaletteButton = widget.GetOrNull<ButtonWidget>("CLEAR_CUSTOM_BUTTON");
+            if (clearCustomPaletteButton != null)
+                clearCustomPaletteButton.OnClick = () =>
+                {
+                    var blankCustomColors = Enumerable.Repeat("FFFFFF", maxCustomColors).ToArray();
+
+                    var playerSettings = Game.Settings.Player;
+                    playerSettings.CustomColors = blankCustomColors;
+
+                    Game.Settings.Save();
+
+                    for (int i = 0; i < maxCustomColors; i++)
+                    {
+                        var swatchName = "COLORCUSTOM" + i;
+                        var swatch = widget.GetOrNull<ColorPaletteSwatchWidget>(swatchName);
+                        swatch.GetColor = () => Color.White;
+                    }
+                };
+
+
+
+            var defaultColorPresets = new Color[]
+            {
+                // RA1 colors
+		        Color.FromArgb(196,176,96),     // C4B060
+		        Color.FromArgb(68,148,228),     // 4494E4
+		        Color.FromArgb(236,0,0),        // EC0000
+		        Color.FromArgb(0,196,0),        // 00C400
+		        Color.FromArgb(252,136,0),      // FC8800
+		        Color.FromArgb(112,112,112),    // 707070
+		        Color.FromArgb(68,144,124),     // 44907C
+		        Color.FromArgb(112,44,36),      // 702C24
+		    };
+
+            // Parse each hex color
+            var presetColors = new List<Color>();
+            var modTeamColors = Game.ModData.Manifest.TeamColorPresets;
+            if (modTeamColors != null && modTeamColors.Length > 0)
+            {
+                foreach (var modTeamColor in modTeamColors)
+                {
+                    Color newColor;
+                    if (HSLColor.TryParseRGB(modTeamColor, out newColor))
+                        presetColors.Add(newColor);
+                }
+            }
+            else
+            {
+                presetColors = defaultColorPresets.ToList();
+            }
+
+
+            // Build the color swatch controls
+
+
+            var addSwatchesAction = new Action<List<Color>, int, int, string, bool>((colorList, x, y, prefix, isEditable) =>
+            {
+                int maxX = 216;
+                int width = 20;
+                int pad = 2;
+                string controlName = prefix;
+
+                for (int i = 0; i < colorList.Count; i++)
+                {
+                    var nameString = controlName + i;
+                    var newSwatch = new ColorPaletteSwatchWidget()
+                    {
+                        Id = nameString,
+                        Width = width.ToString(),
+                        Height = width.ToString(),
+                        X = x.ToString(),
+                        Y = y.ToString()
+                    };
+                    newSwatch.Initialize(new WidgetArgs());
+
+                    int thisIndex = i;
+                    var thisColor = colorList[i];
+                    newSwatch.GetColor = () => thisColor;
+
+                    newSwatch.OnClick = () =>
+                    {
+                        if (isEditable && Game.GetModifierKeys().HasModifier(Modifiers.Ctrl))
+                        {
+                            var playerSettings = Game.Settings.Player;
+
+                            // Set all to white
+                            var blankCustomColors = Enumerable.Repeat("FFFFFF", maxCustomColors).ToArray();
+                            if (playerSettings.CustomColors == null)
+                            {
+                                playerSettings.CustomColors = blankCustomColors;
+                            }
+                            else
+                            {
+                                int savedColorIndex = 0;
+                                foreach (var playerSettingsCustomColor in playerSettings.CustomColors)
+                                {
+                                    blankCustomColors[savedColorIndex] = playerSettingsCustomColor;
+                                    savedColorIndex++;
+                                }
+                            }
+
+                            var newColor = mixer.Color.ToHexString();
+                            if (thisIndex < blankCustomColors.Length)
+                            {
+                                blankCustomColors[thisIndex] = newColor;
+                                var newColorRGB = Color.FromArgb(mixer.Color.RGB.ToArgb());
+                                newSwatch.GetColor = () => newColorRGB;
+                            }
+
+                            playerSettings.CustomColors = blankCustomColors;
+
+                            Game.Settings.Save();
+                        }
+                        else
+                        {
+                            var newColor = newSwatch.GetColor();
+                            mixer.Set(new HSLColor(newColor));
+                        }
+
+                    };
+                    widget.AddChild(newSwatch);
+
+
+                    x += width + pad;
+                    if (x > maxX)
+                    {
+                        x = 5;
+                        y += width + pad;
+                    }
+
+                }
+            });
+
+            int startX = 5;
+            int startY = 158;
+
+            addSwatchesAction(presetColors, startX, startY, "COLORPRESET", false);
+
+
+
+            var defaultCustomColors = new Color[]
+            {
+                /*
+		        Color.FromArgb(255,0,0),
+                */
+		    };
+            defaultCustomColors = Enumerable.Repeat(Color.White, maxCustomColors).ToArray();
+
+            // Parse each hex color
+            var customColors = defaultCustomColors.ToList();
+            var settingsCustomColors = Game.Settings.Player.CustomColors;
+            if (settingsCustomColors != null && settingsCustomColors.Length > 0)
+            {
+                int i = 0;
+                foreach (var customColor in settingsCustomColors)
+                {
+                    if (i >= maxCustomColors)
+                        break;
+
+                    Color newColor;
+                    if (HSLColor.TryParseRGB(customColor, out newColor))
+                        customColors[i] = newColor;
+                    i++;
+                }
+            }
+
+
+            startY = 202;
+            addSwatchesAction(customColors, startX, startY, "COLORCUSTOM", true);
+
+        }
+
+        public static void ShowColorDropDown(DropDownButtonWidget color, ColorPreviewManagerWidget preview, World world)
+
+        {
+            Action onExit = () =>
 			{
 				Game.Settings.Player.Color = preview.Color;
 				Game.Settings.Save();

--- a/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
@@ -67,12 +67,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			hueSlider.Value = initialColor.H / 255f;
 			onChange(mixer.Color);
             
-            
             // Setup the mod team preset colors
             int maxCustomColors = 10;
 
             var clearCustomPaletteButton = widget.GetOrNull<ButtonWidget>("CLEAR_CUSTOM_BUTTON");
-            if (clearCustomPaletteButton != null)
+		    if (clearCustomPaletteButton != null)
+            {
                 clearCustomPaletteButton.OnClick = () =>
                 {
                     var blankCustomColors = Enumerable.Repeat("FFFFFF", maxCustomColors).ToArray();
@@ -89,9 +89,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
                         swatch.GetColor = () => Color.White;
                     }
                 };
-
-
-
+            }
+            
             var defaultColorPresets = new Color[]
             {
                 // RA1 colors
@@ -121,11 +120,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
             {
                 presetColors = defaultColorPresets.ToList();
             }
-
-
+            
             // Build the color swatch controls
-
-
             var addSwatchesAction = new Action<List<Color>, int, int, string, bool>((colorList, x, y, prefix, isEditable) =>
             {
                 int maxX = 216;
@@ -189,18 +185,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
                             var newColor = newSwatch.GetColor();
                             mixer.Set(new HSLColor(newColor));
                         }
-
                     };
+
                     widget.AddChild(newSwatch);
-
-
+                    
                     x += width + pad;
                     if (x > maxX)
                     {
                         x = 5;
                         y += width + pad;
                     }
-
                 }
             });
 
@@ -208,16 +202,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
             int startY = 158;
 
             addSwatchesAction(presetColors, startX, startY, "COLORPRESET", false);
-
-
-
-            var defaultCustomColors = new Color[]
-            {
-                /*
-		        Color.FromArgb(255,0,0),
-                */
-		    };
-            defaultCustomColors = Enumerable.Repeat(Color.White, maxCustomColors).ToArray();
+            
+            var defaultCustomColors = Enumerable.Repeat(Color.White, maxCustomColors).ToArray();
 
             // Parse each hex color
             var customColors = defaultCustomColors.ToList();
@@ -236,15 +222,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
                     i++;
                 }
             }
-
-
+            
             startY = 202;
             addSwatchesAction(customColors, startX, startY, "COLORCUSTOM", true);
-
         }
 
         public static void ShowColorDropDown(DropDownButtonWidget color, ColorPreviewManagerWidget preview, World world)
-
         {
             Action onExit = () =>
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
@@ -10,6 +10,9 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
@@ -63,11 +66,170 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			hueSlider.Value = initialColor.H / 255f;
 			onChange(mixer.Color);
-		}
+            
+            // Setup the mod team preset colors
+            int maxCustomColors = 10;
 
-		public static void ShowColorDropDown(DropDownButtonWidget color, ColorPreviewManagerWidget preview, World world)
-		{
-			Action onExit = () =>
+            var clearCustomPaletteButton = widget.GetOrNull<ButtonWidget>("CLEAR_CUSTOM_BUTTON");
+		    if (clearCustomPaletteButton != null)
+            {
+                clearCustomPaletteButton.OnClick = () =>
+                {
+                    var blankCustomColors = Enumerable.Repeat("FFFFFF", maxCustomColors).ToArray();
+
+                    var playerSettings = Game.Settings.Player;
+                    playerSettings.CustomColors = blankCustomColors;
+
+                    Game.Settings.Save();
+
+                    for (int i = 0; i < maxCustomColors; i++)
+                    {
+                        var swatchName = "COLORCUSTOM" + i;
+                        var swatch = widget.GetOrNull<ColorPaletteSwatchWidget>(swatchName);
+                        swatch.GetColor = () => Color.White;
+                    }
+                };
+            }
+            
+            var defaultColorPresets = new Color[]
+            {
+                // RA1 colors
+		        Color.FromArgb(196,176,96),     // C4B060
+		        Color.FromArgb(68,148,228),     // 4494E4
+		        Color.FromArgb(236,0,0),        // EC0000
+		        Color.FromArgb(0,196,0),        // 00C400
+		        Color.FromArgb(252,136,0),      // FC8800
+		        Color.FromArgb(112,112,112),    // 707070
+		        Color.FromArgb(68,144,124),     // 44907C
+		        Color.FromArgb(112,44,36),      // 702C24
+		    };
+
+            // Parse each hex color
+            var presetColors = new List<Color>();
+            var modTeamColors = Game.ModData.Manifest.TeamColorPresets;
+            if (modTeamColors != null && modTeamColors.Length > 0)
+            {
+                foreach (var modTeamColor in modTeamColors)
+                {
+                    Color newColor;
+                    if (HSLColor.TryParseRGB(modTeamColor, out newColor))
+                        presetColors.Add(newColor);
+                }
+            }
+            else
+            {
+                presetColors = defaultColorPresets.ToList();
+            }
+            
+            // Build the color swatch controls
+            var addSwatchesAction = new Action<List<Color>, int, int, string, bool>((colorList, x, y, prefix, isEditable) =>
+            {
+                int maxX = 216;
+                int width = 20;
+                int pad = 2;
+                string controlName = prefix;
+
+                for (int i = 0; i < colorList.Count; i++)
+                {
+                    var nameString = controlName + i;
+                    var newSwatch = new ColorPaletteSwatchWidget()
+                    {
+                        Id = nameString,
+                        Width = width.ToString(),
+                        Height = width.ToString(),
+                        X = x.ToString(),
+                        Y = y.ToString()
+                    };
+                    newSwatch.Initialize(new WidgetArgs());
+
+                    int thisIndex = i;
+                    var thisColor = colorList[i];
+                    newSwatch.GetColor = () => thisColor;
+
+                    newSwatch.OnClick = () =>
+                    {
+                        if (isEditable && Game.GetModifierKeys().HasModifier(Modifiers.Ctrl))
+                        {
+                            var playerSettings = Game.Settings.Player;
+
+                            // Set all to white
+                            var blankCustomColors = Enumerable.Repeat("FFFFFF", maxCustomColors).ToArray();
+                            if (playerSettings.CustomColors == null)
+                            {
+                                playerSettings.CustomColors = blankCustomColors;
+                            }
+                            else
+                            {
+                                int savedColorIndex = 0;
+                                foreach (var playerSettingsCustomColor in playerSettings.CustomColors)
+                                {
+                                    blankCustomColors[savedColorIndex] = playerSettingsCustomColor;
+                                    savedColorIndex++;
+                                }
+                            }
+
+                            var newColor = mixer.Color.ToHexString();
+                            if (thisIndex < blankCustomColors.Length)
+                            {
+                                blankCustomColors[thisIndex] = newColor;
+                                var newColorRGB = Color.FromArgb(mixer.Color.RGB.ToArgb());
+                                newSwatch.GetColor = () => newColorRGB;
+                            }
+
+                            playerSettings.CustomColors = blankCustomColors;
+
+                            Game.Settings.Save();
+                        }
+                        else
+                        {
+                            var newColor = newSwatch.GetColor();
+                            mixer.Set(new HSLColor(newColor));
+                        }
+                    };
+
+                    widget.AddChild(newSwatch);
+                    
+                    x += width + pad;
+                    if (x > maxX)
+                    {
+                        x = 5;
+                        y += width + pad;
+                    }
+                }
+            });
+
+            int startX = 5;
+            int startY = 158;
+
+            addSwatchesAction(presetColors, startX, startY, "COLORPRESET", false);
+            
+            var defaultCustomColors = Enumerable.Repeat(Color.White, maxCustomColors).ToArray();
+
+            // Parse each hex color
+            var customColors = defaultCustomColors.ToList();
+            var settingsCustomColors = Game.Settings.Player.CustomColors;
+            if (settingsCustomColors != null && settingsCustomColors.Length > 0)
+            {
+                int i = 0;
+                foreach (var customColor in settingsCustomColors)
+                {
+                    if (i >= maxCustomColors)
+                        break;
+
+                    Color newColor;
+                    if (HSLColor.TryParseRGB(customColor, out newColor))
+                        customColors[i] = newColor;
+                    i++;
+                }
+            }
+            
+            startY = 202;
+            addSwatchesAction(customColors, startX, startY, "COLORCUSTOM", true);
+        }
+
+        public static void ShowColorDropDown(DropDownButtonWidget color, ColorPreviewManagerWidget preview, World world)
+        {
+            Action onExit = () =>
 			{
 				Game.Settings.Player.Color = preview.Color;
 				Game.Settings.Save();

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -192,6 +192,8 @@ SoundFormats: Aud, Wav
 
 SpriteFormats: ShpTD, TmpTD, ShpTS, TmpRA
 
+TeamColorPresets: FCFC54, F40000, 007070, D47810, 54FC54, A4A4BC
+
 SpriteSequenceFormat: TilesetSpecificSpriteSequence
 	TilesetExtensions:
 		TEMPERAT: .tem

--- a/mods/common/chrome/color-picker.yaml
+++ b/mods/common/chrome/color-picker.yaml
@@ -2,7 +2,7 @@ Background@COLOR_CHOOSER:
 	Logic: ColorPickerLogic
 	Background: dialog2
 	Width: 326
-	Height: 140
+	Height: 230
 	Children:
 		Button@RANDOM_BUTTON:
 			Key: tab
@@ -42,3 +42,23 @@ Background@COLOR_CHOOSER:
 			Y: 21
 			Width: 80
 			Height: 73
+		Label@PRESETCOLORSLABEL:
+			X: 5
+			Y: 146
+			Text: Preset Colors
+			Align: Left
+			Width: PARENT_RIGHT
+		Label@CUSTOMCOLORSLABEL:
+			X: 5
+			Y: 190
+			Text: Custom Colors (Ctrl+click to set)
+			Align: Left
+			Width: PARENT_RIGHT
+		Button@CLEAR_CUSTOM_BUTTON:
+			Key: tab
+			X: 250
+			Y: 200
+			Width: 70
+			Height: 25
+			Text: Clear
+			Font: Bold

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -196,6 +196,8 @@ SoundFormats: Aud, Wav
 
 SpriteFormats: ShpD2, ShpTD, TmpRA, TmpTD, ShpTS
 
+TeamColorPresets: C4B060, 4494E4, EC0000, 00C400, FC8800, 707070, 44907C, 702C24
+
 SpriteSequenceFormat: TilesetSpecificSpriteSequence
 	TilesetExtensions:
 		TEMPERAT: .tem


### PR DESCRIPTION
Hi,

I had a go at updating the color picker. Now it has: 

- A set of preset color swatches for RA1 and TD, (defined in mod.yaml: TeamColorPresets: C4B060, 4494E4, ....)

- A user-defined palette defined in settings.yaml (Player: CustomColors: 3B99CA, A33BCA, ....)

![openra color picker](https://cloud.githubusercontent.com/assets/1639681/24783881/69daa73c-1b92-11e7-8972-703ef7709b2f.jpg)

This is my first time contributing to this project so hopefully I have done it correctly and haven't broken any rules.

I'd also like to know what preset colors were available in d2k, TS, and RA2 so I can add them into the mod.yaml for each of these mods. Does anyone happen to know?

Cheers