### PR TITLE
Fix ConditionManager.GrantCondition doc

### DIFF
--- a/OpenRA.Mods.Common/Traits/Conditions/ConditionManager.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ConditionManager.cs
@@ -129,7 +129,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		/// <summary>Grants a specified condition.</summary>
 		/// <returns>The token that is used to revoke this condition.</returns>
-		/// <param name="external">Validate against the external condition whitelist.</param>
 		/// <param name="duration">Automatically revoke condition after this delay if non-zero.</param>
 		public int GrantCondition(Actor self, string condition, int duration = 0)
 		{


### PR DESCRIPTION
This is a small fix I made to the documentation for `public int GrantCondition(Actor self, string condition, int duration = 0)` in `OpenRA.Mods.Common.Traits.ConditionManager` removing a reference to a parameter already removed by the external conditions refactoring.