### PR TITLE
Better Support for Multiple Condition Expressions in a Trait

### DIFF
--- a/OpenRA.Mods.Common/Traits/Pluggable.cs
+++ b/OpenRA.Mods.Common/Traits/Pluggable.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Traits;
 
@@ -44,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new Pluggable(init, this); }
 	}
 
-	public class Pluggable : IConditionConsumer, INotifyCreated
+	public class Pluggable : IObservesVariables, INotifyCreated
 	{
 		public readonly PluggableInfo Info;
 
@@ -114,12 +115,12 @@ namespace OpenRA.Mods.Common.Traits
 			active = null;
 		}
 
-		IEnumerable<string> IConditionConsumer.Conditions { get { return Info.ConsumedConditions; } }
-
-		void IConditionConsumer.ConditionsChanged(Actor self, IReadOnlyDictionary<string, int> conditions)
+		IEnumerable<VariableObserver> IObservesVariables.GetVariableObservers()
 		{
 			foreach (var req in Info.Requirements)
-				plugTypesAvailability[req.Key] = req.Value.Evaluate(conditions);
+				yield return new VariableObserver(
+					(self, variables) => plugTypesAvailability[req.Key] = req.Value.Evaluate(variables),
+					req.Value.Variables);
 		}
 	}
 

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -105,12 +105,23 @@ namespace OpenRA.Mods.Common.Traits
 	public interface INotifyPassengerExited { void OnPassengerExited(Actor self, Actor passenger); }
 
 	[RequireExplicitImplementation]
-	public interface IConditionConsumerInfo : ITraitInfo { }
+	public interface IObservesVariablesInfo : ITraitInfo { }
 
-	public interface IConditionConsumer
+	public delegate void VariableObserverNotifier(Actor self, IReadOnlyDictionary<string, int> variables);
+	public struct VariableObserver
 	{
-		IEnumerable<string> Conditions { get; }
-		void ConditionsChanged(Actor self, IReadOnlyDictionary<string, int> conditions);
+		public VariableObserverNotifier Notifier;
+		public IEnumerable<string> Variables;
+		public VariableObserver(VariableObserverNotifier notifier, IEnumerable<string> variables)
+		{
+			Notifier = notifier;
+			Variables = variables;
+		}
+	}
+
+	public interface IObservesVariables
+	{
+		IEnumerable<VariableObserver> GetVariableObservers();
 	}
 
 	public interface INotifyHarvesterAction


### PR DESCRIPTION
Replaces IConditionConsumer with variable observer delegates for handling multiple condition expressions by traits.

~This is cherry-picked from #12955 (Remove IDisable - part 1) and was cherry-picked for #13057 (Grant Condition Integers) as well. Delegates are a simple to use mechanism for handling multiple `ConditionExpression`s. In most cases, a trait class defines a method for each `ConditionExpression`.~