### PR TITLE
Custom Sprite support for mods.

### DIFF
--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -61,7 +61,20 @@ namespace OpenRA.Graphics
 			this.allocateSheet = allocateSheet;
 		}
 
-		public Sprite Add(ISpriteFrame frame) { return Add(frame.Data, frame.Size, 0, frame.Offset); }
+		public Sprite Add(ISpriteFrame frame)
+		{
+			var sprite = Add(frame.Data, frame.Size, 0, frame.Offset);
+			var spriteFrame = frame as ISpecificSpriteFrame;
+
+			if (spriteFrame != null)
+			{
+				sprite = (Sprite) Activator.CreateInstance(spriteFrame.SpriteType, sprite);
+				sprite.Set(spriteFrame);
+			}
+
+			return sprite;
+		}
+
 		public Sprite Add(byte[] src, Size size) { return Add(src, size, 0, float3.Zero); }
 		public Sprite Add(byte[] src, Size size, float zRamp, float3 spriteOffset)
 		{

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Graphics
 
 			if (spriteFrame != null)
 			{
-				sprite = (Sprite) Activator.CreateInstance(spriteFrame.SpriteType, sprite);
+				sprite = (Sprite)Activator.CreateInstance(spriteFrame.SpriteType, sprite);
 				sprite.Set(spriteFrame);
 			}
 

--- a/OpenRA.Game/Graphics/Sprite.cs
+++ b/OpenRA.Game/Graphics/Sprite.cs
@@ -26,6 +26,9 @@ namespace OpenRA.Graphics
 		public readonly float3 FractionalOffset;
 		public readonly float Top, Left, Bottom, Right;
 
+		public Sprite(Sprite sprite)
+			: this(sprite.Sheet, sprite.Bounds, sprite.ZRamp, sprite.Offset, sprite.Channel, sprite.BlendMode) { }
+
 		public Sprite(Sheet sheet, Rectangle bounds, TextureChannel channel)
 			: this(sheet, bounds, 0, float2.Zero, channel) { }
 
@@ -45,6 +48,17 @@ namespace OpenRA.Graphics
 			Top = (float)Math.Min(bounds.Top, bounds.Bottom) / sheet.Size.Height;
 			Right = (float)Math.Max(bounds.Left, bounds.Right) / sheet.Size.Width;
 			Bottom = (float)Math.Max(bounds.Top, bounds.Bottom) / sheet.Size.Height;
+		}
+
+		public virtual Sprite With(Sheet sheet, Rectangle? bounds, float? zRamp, float3? offset, TextureChannel? channel, BlendMode? blendMode)
+		{
+			// Override to keep custom properties.
+			return new Sprite(sheet ?? Sheet, bounds ?? Bounds, zRamp ?? ZRamp, offset ?? Offset, channel ?? Channel, blendMode ?? BlendMode);
+		}
+
+		public virtual void Set(ISpecificSpriteFrame frame)
+		{
+			// Override to populate custom properties.
 		}
 	}
 

--- a/OpenRA.Game/Graphics/SpriteLoader.cs
+++ b/OpenRA.Game/Graphics/SpriteLoader.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
@@ -39,6 +40,11 @@ namespace OpenRA.Graphics
 		float2 Offset { get; }
 		byte[] Data { get; }
 		bool DisableExportPadding { get; }
+	}
+
+	public interface ISpecificSpriteFrame : ISpriteFrame
+	{
+		Type SpriteType { get; }
 	}
 
 	public class SpriteCache

--- a/OpenRA.Game/Graphics/SpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderable.cs
@@ -38,6 +38,7 @@ namespace OpenRA.Graphics
 			this.isDecoration = isDecoration;
 		}
 
+		public Sprite Sprite { get { return sprite; } }
 		public WPos Pos { get { return pos + offset; } }
 		public WVec Offset { get { return offset; } }
 		public PaletteReference Palette { get { return palette; } }

--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -167,7 +167,7 @@ namespace OpenRA.Mods.Common.Graphics
 
 						var subSrc = GetSpriteSrc(modData, tileSet, sequence, animation, sub.Key, sd);
 						var subSprites = cache[subSrc].Select(
-							s => new Sprite(s.Sheet,
+							s => s.With(s.Sheet,
 								FlipRectangle(s.Bounds, subFlipX, subFlipY), ZRamp,
 								new float3(subFlipX ? -s.Offset.X : s.Offset.X, subFlipY ? -s.Offset.Y : s.Offset.Y, s.Offset.Z) + subOffset + offset,
 								s.Channel, blendMode));
@@ -190,7 +190,7 @@ namespace OpenRA.Mods.Common.Graphics
 					// Different sequences may apply different offsets to the same frame
 					var src = GetSpriteSrc(modData, tileSet, sequence, animation, info.Value, d);
 					sprites = cache[src].Select(
-						s => new Sprite(s.Sheet,
+						s => s.With(s.Sheet,
 							FlipRectangle(s.Bounds, flipX, flipY), ZRamp,
 							new float3(flipX ? -s.Offset.X : s.Offset.X, flipY ? -s.Offset.Y : s.Offset.Y, s.Offset.Z) + offset,
 							s.Channel, blendMode)).ToArray();


### PR DESCRIPTION
This allows mods to extend the Sprite class without modifying the OpenRA.Game or OpenRA.Common project.

In my current project, i have per-frame offset-points, which need to be stored for every sprite. With this modification i can implement it purely on the mod-side.