### PR TITLE
Make TS explosions + muzzle flashes unaffected by global lighting

### DIFF
--- a/mods/ts/rules/civilian-vehicles.yaml
+++ b/mods/ts/rules/civilian-vehicles.yaml
@@ -24,6 +24,7 @@
 		Weapon: 120mmx
 		LocalOffset: 500,60,360, 500,-85,360
 		MuzzleSequence: muzzle
+		MuzzlePalette: effect-ignore-lighting
 	Armament@SECONDARY:
 		Weapon: MammothTusk
 		LocalOffset: 0,200,410, 0,-200,410

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -95,6 +95,7 @@ GACTWR:
 		Weapon: VulcanTower
 		LocalOffset: 416,85,960
 		MuzzleSequence: muzzle
+		MuzzlePalette: effect-ignore-lighting
 		MuzzleSplitFacings: 8
 	Armament@VULCSECONDARY:
 		RequiresCondition: tower.vulcan
@@ -102,6 +103,7 @@ GACTWR:
 		Weapon: VulcanTower
 		LocalOffset: 416,-85,960
 		MuzzleSequence: muzzle
+		MuzzlePalette: effect-ignore-lighting
 		MuzzleSplitFacings: 8
 	Armament@ROCKET:
 		RequiresCondition: tower.rocket

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -185,6 +185,7 @@ MMCH:
 	Armament:
 		Weapon: 120mm
 		MuzzleSequence: muzzle
+		MuzzlePalette: effect-ignore-lighting
 		Recoil: 128
 		RecoilRecovery: 32
 		LocalOffset: 640, 192, 832

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -207,6 +207,7 @@ GAARTY:
 		Weapon: 155mm
 		LocalOffset: 811,0,0
 		MuzzleSequence: muzzle
+		MuzzlePalette: effect-ignore-lighting
 	BodyOrientation:
 		QuantizedFacings: 32
 	RenderVoxels:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -26,6 +26,7 @@ BGGY:
 		Weapon: RaiderCannon
 		LocalOffset: 0,-43,384, 0,43,384
 		MuzzleSequence: muzzle
+		MuzzlePalette: effect-ignore-lighting
 		MuzzleSplitFacings: 8
 	AttackFrontal:
 		Voice: Attack
@@ -102,11 +103,13 @@ TTNK:
 		LocalOffset: 288,0,256
 		RequiresCondition: !rank-elite
 		MuzzleSequence: muzzle
+		MuzzlePalette: effect-ignore-lighting
 	Armament@ELITE:
 		Weapon: 120mmx
 		LocalOffset: 288,0,256
 		RequiresCondition: rank-elite
 		MuzzleSequence: muzzle
+		MuzzlePalette: effect-ignore-lighting
 	WithMuzzleOverlay:
 	RevealsShroud:
 		RequiresCondition: !inside-tunnel
@@ -154,6 +157,7 @@ TTNK:
 		LocalOffset: 384,0,256
 		RequiresCondition: !rank-elite
 		MuzzleSequence: muzzle
+		MuzzlePalette: effect-ignore-lighting
 	Armament@deployedElite:
 		Name: deployed
 		Turret: deployed
@@ -161,6 +165,7 @@ TTNK:
 		LocalOffset: 384,0,256
 		RequiresCondition: rank-elite
 		MuzzleSequence: muzzle
+		MuzzlePalette: effect-ignore-lighting
 	Armor@deployed:
 		Type: Concrete
 		RequiresCondition: deployed

--- a/mods/ts/rules/palettes.yaml
+++ b/mods/ts/rules/palettes.yaml
@@ -41,6 +41,9 @@
 	PaletteFromFile@effect:
 		Name: effect
 		Filename: anim.pal
+	PaletteFromFile@effect-nolite:
+		Name: effect-ignore-lighting
+		Filename: anim.pal
 	PaletteFromPaletteWithAlpha@effectalpha25:
 		Name: effectalpha25
 		Alpha: 0.25
@@ -53,6 +56,18 @@
 		Name: effectalpha75
 		Alpha: 0.75
 		BasePalette: effect
+	PaletteFromPaletteWithAlpha@effect-nolite-alpha25:
+		Name: effect-ignore-lighting-alpha25
+		Alpha: 0.25
+		BasePalette: effect-ignore-lighting
+	PaletteFromPaletteWithAlpha@effect-nolite-alpha50:
+		Name: effect-ignore-lighting-alpha50
+		Alpha: 0.5
+		BasePalette: effect-ignore-lighting
+	PaletteFromPaletteWithAlpha@effect-nolite-alpha75:
+		Name: effect-ignore-lighting-alpha75
+		Alpha: 0.75
+		BasePalette: effect-ignore-lighting
 	PaletteFromFile@sidebar:
 		Name: sidebar
 		Filename: sidebar-nod|sidebar.pal
@@ -127,3 +142,5 @@
 		Alpha: 0.55
 	PlayerHighlightPalette:
 	MenuPaletteEffect:
+	GlobalLightingPaletteEffect:
+		ExcludePalettes: cursor, chrome, colorpicker, fog, shroud, alpha, effect-ignore-lighting, effect-ignore-lighting-alpha25, effect-ignore-lighting-alpha50, effect-ignore-lighting-alpha75

--- a/mods/ts/weapons/ballisticweapons.yaml
+++ b/mods/ts/weapons/ballisticweapons.yaml
@@ -21,7 +21,7 @@
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: medium_clsn
-		ExplosionPalette: effectalpha75
+		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew14.aud
 		InvalidImpactTypes: Water
 	Warhead@3EffWater: CreateEffect

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -105,7 +105,7 @@ SonicZap:
 		ValidTargets: Ground
 	Warhead@2Eff: CreateEffect
 		Explosions: large_explosion
-		ExplosionPalette: effectalpha75
+		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew12.aud
 		InvalidImpactTypes: Water
 	Warhead@3EffWater: CreateEffect

--- a/mods/ts/weapons/explosions.yaml
+++ b/mods/ts/weapons/explosions.yaml
@@ -11,7 +11,7 @@
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: large_twlt
-		ExplosionPalette: effectalpha75
+		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew09.aud
 	Warhead@4Smu: LeaveSmudge
 		SmudgeType: MediumCrater
@@ -34,7 +34,7 @@ UnitExplodeSmall:
 BuildingExplosions:
 	Warhead@1Eff: CreateEffect
 		Explosions: building, large_bang, large_brnl, verylarge_clsn, large_tumu
-		ExplosionPalette: effectalpha75
+		ExplosionPalette: effect-ignore-lighting-alpha75
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: MediumCrater
 
@@ -61,5 +61,5 @@ Demolish:
 		DamageTypes: DefaultDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: large_twlt
-		ExplosionPalette: effectalpha75
+		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew09.aud

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -35,6 +35,7 @@
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: small_clsn
+		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew12.aud
 		InvalidImpactTypes: Water
 	Warhead@3EffWater: CreateEffect

--- a/mods/ts/weapons/otherweapons.yaml
+++ b/mods/ts/weapons/otherweapons.yaml
@@ -47,7 +47,7 @@ Bomb:
 		DamageTypes: Prone100Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: large_explosion
-		ExplosionPalette: effectalpha75
+		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew09.aud
 		InvalidImpactTypes: Water
 	Warhead@3EffWater: CreateEffect
@@ -130,7 +130,7 @@ Veins:
 		DamageTypes: Prone100Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: tiny_twlt
-		ExplosionPalette: effectalpha75
+		ExplosionPalette: effect-ignore-lighting-alpha75
 		InvalidImpactTypes: Water
 	Warhead@3EffWater: CreateEffect
 		Explosions: small_watersplash

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -77,23 +77,23 @@ IonCannon:
 		Delay: 3
 	Warhead@4Effect: CreateEffect
 		Explosions: ionbeam
-		ExplosionPalette: effectalpha75
+		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: ion1.aud
 	Warhead@5Effect: CreateEffect
 		Explosions: ionbeam2
-		ExplosionPalette: effectalpha75
+		ExplosionPalette: effect-ignore-lighting-alpha75
 	Warhead@6Effect: CreateEffect
 		Explosions: ionbeam3
-		ExplosionPalette: effectalpha75
+		ExplosionPalette: effect-ignore-lighting-alpha75
 	Warhead@7Effect: CreateEffect
 		Explosions: ionbeam4
-		ExplosionPalette: effectalpha75
+		ExplosionPalette: effect-ignore-lighting-alpha75
 	Warhead@8Effect: CreateEffect
 		Explosions: ionbeam5
-		ExplosionPalette: effectalpha75
+		ExplosionPalette: effect-ignore-lighting-alpha75
 	Warhead@9Effect: CreateEffect
 		Explosions: ionbeam6
-		ExplosionPalette: effectalpha75
+		ExplosionPalette: effect-ignore-lighting-alpha75
 
 EMPulseCannon:
 	ReloadDelay: 100
@@ -107,6 +107,7 @@ EMPulseCannon:
 		Image: pulsball
 	Warhead@1Eff: CreateEffect
 		Explosions: pulse_explosion
+		ExplosionPalette: effect-ignore-lighting-alpha75
 	Warhead@emp: GrantExternalCondition
 		Range: 4c0
 		Duration: 250
@@ -124,6 +125,7 @@ ClusterMissile:
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@SoundEffect0: CreateEffect
 		Explosions: large_explosion
+		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew19.aud
 	Warhead@ResourceDestruction0: DestroyResource
 		Size: 1


### PR DESCRIPTION
The new `effect-ignore-lighting` palette and its derivatives are not affected by global lighting, making weapon effects light up fully even on darker maps (except pistol/rifle/machine gun piffs, since that is presumably meant to be dust kicked up).

~Disclaimer: Mammoth Tank and GDI Component Tower need that yaml work-around until `WithMuzzleOverlay` is fixed (#10763), and yes, I already tried and failed to fix it.~