### PR TITLE
Fix Heli goes to pad if SD is occupied #12991

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -601,7 +601,15 @@ namespace OpenRA.Mods.Common.Traits
 				if (!order.Queued)
 					UnReserve();
 
-				if (Reservable.IsReserved(order.TargetActor))
+				var targetReserved = Reservable.IsReserved(order.TargetActor);
+
+				// If the target for repair is reserved then drop the order
+				if (targetReserved && Info.RepairBuildings.Contains(order.TargetActor.Info.Name))
+					return;
+
+				// If the target for reloading is reserved then automatically redirect to a different valid reload actor
+				// HACK: Repair and reload behaviour is inconsistent and one should be changed
+				if (targetReserved)
 				{
 					if (IsPlane)
 						self.QueueActivity(new ReturnToBase(self, Info.AbortOnResupply));


### PR DESCRIPTION
If target is reserved Repair building, do nothing instead of searching for next HeliBase. So it doesn't fly away and you can send it again to repair. 
Not changed - if target is reserved Rearm building (HeliBase), go to next free HeliBase like so far.

See #12991 for additional explanation.