### PR TITLE
Fix Pre-damaged bridge tiles visually transform to new #13076

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 					yield return Pair.New(Template, 100);
 
 				if (DamagedTemplate != 0)
-					yield return Pair.New(DamagedTemplate, 50);
+					yield return Pair.New(DamagedTemplate, 49);
 
 				if (DestroyedTemplate != 0)
 					yield return Pair.New(DestroyedTemplate, 0);


### PR DESCRIPTION
Fixed DamagedTemplate (e.g. 236) health to 49% (Heavy damage) as current 50% was still Medium so it was refreshed to Template (e.g. 235).