### PR TITLE
Fix Service Depot Rally point path finding

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -285,7 +285,7 @@ namespace OpenRA.Traits
 	public interface IMove
 	{
 		Activity MoveTo(CPos cell, int nearEnough);
-		Activity MoveTo(CPos cell, Actor ignoredActor);
+		Activity MoveTo(CPos cell, Actor ignoreActor);
 		Activity MoveWithinRange(Target target, WDist range);
 		Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange);
 		Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange);

--- a/OpenRA.Mods.Common/Pathfinder/BasePathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/BasePathSearch.cs
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 		public IPathSearch WithIgnoredActor(Actor b)
 		{
-			Graph.IgnoredActor = b;
+			Graph.IgnoreActor = b;
 			return this;
 		}
 

--- a/OpenRA.Mods.Common/Pathfinder/PathFinderUnitPathCacheDecorator.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathFinderUnitPathCacheDecorator.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			this.cacheStorage = cacheStorage;
 		}
 
-		public List<CPos> FindUnitPath(CPos source, CPos target, Actor self)
+		public List<CPos> FindUnitPath(CPos source, CPos target, Actor self, Actor ignoreActor)
 		{
 			using (new PerfSample("Pathfinder"))
 			{
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 				if (cachedPath != null)
 					return cachedPath;
 
-				var pb = pathFinder.FindUnitPath(source, target, self);
+				var pb = pathFinder.FindUnitPath(source, target, self, ignoreActor);
 
 				cacheStorage.Store(key, pb);
 

--- a/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 		bool InReverse { get; set; }
 
-		Actor IgnoredActor { get; set; }
+		Actor IgnoreActor { get; set; }
 
 		World World { get; }
 
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		public Func<CPos, int> CustomCost { get; set; }
 		public int LaneBias { get; set; }
 		public bool InReverse { get; set; }
-		public Actor IgnoredActor { get; set; }
+		public Actor IgnoreActor { get; set; }
 
 		readonly CellConditions checkConditions;
 		readonly MobileInfo mobileInfo;
@@ -171,7 +171,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 		int GetCostToNode(CPos destNode, CVec direction)
 		{
-			var movementCost = mobileInfo.MovementCostToEnterCell(worldMovementInfo, Actor, destNode, IgnoredActor, checkConditions);
+			var movementCost = mobileInfo.MovementCostToEnterCell(worldMovementInfo, Actor, destNode, IgnoreActor, checkConditions);
 			if (movementCost != int.MaxValue && !(CustomBlock != null && CustomBlock(destNode)))
 				return CalculateCellCost(destNode, direction, movementCost);
 

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -453,7 +453,7 @@ namespace OpenRA.Mods.Common.Traits
 			return new HeliFly(self, Target.FromCell(self.World, cell));
 		}
 
-		public Activity MoveTo(CPos cell, Actor ignoredActor)
+		public Activity MoveTo(CPos cell, Actor ignoreActor)
 		{
 			if (IsPlane)
 				return new FlyAndContinueWithCirclesWhenIdle(self, Target.FromCell(self.World, cell));

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -914,7 +914,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Activity ScriptedMove(CPos cell) { return new Move(self, cell); }
 		public Activity MoveTo(CPos cell, int nearEnough) { return new Move(self, cell, WDist.FromCells(nearEnough)); }
-		public Activity MoveTo(CPos cell, Actor ignoredActor) { return new Move(self, cell, ignoredActor); }
+		public Activity MoveTo(CPos cell, Actor ignoreActor) { return new Move(self, cell, WDist.Zero, ignoreActor); }
 		public Activity MoveWithinRange(Target target, WDist range) { return new MoveWithinRange(self, target, WDist.Zero, range); }
 		public Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange) { return new MoveWithinRange(self, target, minRange, maxRange); }
 		public Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange) { return new Follow(self, target, minRange, maxRange); }

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 		/// Calculates a path for the actor from source to destination
 		/// </summary>
 		/// <returns>A path from start to target</returns>
-		List<CPos> FindUnitPath(CPos source, CPos target, Actor self);
+		List<CPos> FindUnitPath(CPos source, CPos target, Actor self, Actor ignoreActor);
 
 		List<CPos> FindUnitPathToRange(CPos source, SubCell srcSub, WPos target, WDist range, Actor self);
 
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.world = world;
 		}
 
-		public List<CPos> FindUnitPath(CPos source, CPos target, Actor self)
+		public List<CPos> FindUnitPath(CPos source, CPos target, Actor self, Actor ignoreActor)
 		{
 			var mi = self.Info.TraitInfo<MobileInfo>();
 
@@ -74,8 +74,8 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			List<CPos> pb;
-			using (var fromSrc = PathSearch.FromPoint(world, mi, self, target, source, true))
-			using (var fromDest = PathSearch.FromPoint(world, mi, self, source, target, true).Reverse())
+			using (var fromSrc = PathSearch.FromPoint(world, mi, self, target, source, true).WithIgnoredActor(ignoreActor))
+			using (var fromDest = PathSearch.FromPoint(world, mi, self, source, target, true).WithIgnoredActor(ignoreActor).Reverse())
 				pb = FindBidiPath(fromSrc, fromDest);
 
 			CheckSanePath2(pb, source, target);


### PR DESCRIPTION
Fix -Repaired unit moved towards Rally point but stopped on first obstacle instead of finding path like with Move order or with Production Rally Point.

Fixes #3757, #12965