### PR TITLE
Fix/Disable Edge scroll while standard (middle mouse) scroll

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -141,7 +141,7 @@ namespace OpenRA.Mods.Common.Widgets
 				var scroll = (joystickScrollEnd.Value - joystickScrollStart.Value).ToFloat2() * rate;
 				worldRenderer.Viewport.Scroll(scroll, false);
 			}
-			else
+			else if (!isStandardScrolling)
 			{
 				edgeDirections = ScrollDirection.None;
 				if (Game.Settings.Game.ViewportEdgeScroll && Game.HasInputFocus)


### PR DESCRIPTION
Fixes this issue - you're scrolling map (e.g. Rock in image below) with mouse middle button to right and it starts scrolling in opposite direction when you are near border though you still keep middle button and move your mouse to right.

![obrazok](https://cloud.githubusercontent.com/assets/16348750/24875306/f8f5dc10-1e27-11e7-9809-87eb77fa2c9e.png)
