### PR TITLE
Naval units (RepairableNear) units repaired with Repair cursor #12361

### DIFF
--- a/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
@@ -49,17 +49,27 @@ namespace OpenRA.Mods.Common.Orders
 			if (underCursor.Owner != world.LocalPlayer)
 				yield break;
 
+			Actor repairBuilding = null;
+			var orderId = "Repair";
+
 			// Test for generic Repairable (used on units).
 			var repairable = underCursor.TraitOrDefault<Repairable>();
-			if (repairable == null)
-				yield break;
+			if (repairable != null)
+				repairBuilding = repairable.FindRepairBuilding(underCursor);
+			else
+			{
+				var repairableNear = underCursor.TraitOrDefault<RepairableNear>();
+				if (repairableNear != null)
+				{
+					orderId = "RepairNear";
+					repairBuilding = repairableNear.FindRepairBuilding(underCursor);
+				}
+			}
 
-			// Find a building to repair at.
-			var repairBuilding = repairable.FindRepairBuilding(underCursor);
 			if (repairBuilding == null)
 				yield break;
 
-			yield return new Order("Repair", underCursor, false) { TargetActor = repairBuilding };
+			yield return new Order(orderId, underCursor, false) { TargetActor = repairBuilding };
 		}
 
 		public void Tick(World world)

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Traits;
@@ -83,6 +84,18 @@ namespace OpenRA.Mods.Common.Traits
 
 				self.SetTargetLine(target, Color.Green, false);
 			}
+		}
+
+		public Actor FindRepairBuilding(Actor self)
+		{
+			var repairBuilding = self.World.ActorsWithTrait<RepairsUnits>()
+				.Where(a => !a.Actor.IsDead && a.Actor.IsInWorld
+					&& a.Actor.Owner.IsAlliedWith(self.Owner) &&
+					info.Buildings.Contains(a.Actor.Info.Name))
+				.OrderBy(p => (self.Location - p.Actor.Location).LengthSquared);
+
+			// Worst case FirstOrDefault() will return a TraitPair<null, null>, which is OK.
+			return repairBuilding.FirstOrDefault().Actor;
 		}
 	}
 }


### PR DESCRIPTION
Repair cursor now supports also RepairableNear units - ships, submarines - in addition to Repairable vehicles.

