### PR TITLE
Fix the make.ps1 clean command not removing all files

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -42,6 +42,9 @@ function Clean-Command
 		rm mods/*/*.dll
 		rm *.pdb
 		rm mods/*/*.pdb
+		rm *.exe
+		rm ./*/bin -r
+		rm ./*/obj -r
 		if (Test-Path thirdparty/download/)
 		{
 			rmdir thirdparty/download -Recurse -Force


### PR DESCRIPTION
Those are marked for removal in the [`Makefile`](https://github.com/OpenRA/OpenRA/blob/bleed/Makefile#L308).