### PR TITLE
Add support for using launch-game.cmd with parameters

### DIFF
--- a/launch-game.cmd
+++ b/launch-game.cmd
@@ -1,18 +1,28 @@
 @echo off
 title OpenRA
+for %%x in (%*) do (
+  if "%%~x" EQU "Game.Mod" (goto launch)
+)
+
 :choosemod
 set /P mod=Select mod (ra, cnc, d2k, ts) or --exit: 
 if /I "%mod%" EQU "--exit" (exit)
-if /I "%mod%" EQU "ra" (goto launch)
-if /I "%mod%" EQU "cnc" (goto launch)
-if /I "%mod%" EQU "ts" (goto launch)
-if /I "%mod%" EQU "d2k" (goto launch)
+if /I "%mod%" EQU "ra" (goto launchmod)
+if /I "%mod%" EQU "cnc" (goto launchmod)
+if /I "%mod%" EQU "ts" (goto launchmod)
+if /I "%mod%" EQU "d2k" (goto launchmod)
 echo.
 echo Unknown mod: %mod%
 echo.
 goto choosemod
+
+:launchmod
+OpenRA.Game.exe Game.Mod=%mod% %*
+goto end
 :launch
-OpenRA.Game.exe Game.Mod=%mod%
+OpenRA.Game.exe %*
+
+:end
 if %errorlevel% neq 0 goto crashdialog
 exit
 :crashdialog

--- a/launch-game.cmd
+++ b/launch-game.cmd
@@ -24,7 +24,7 @@ OpenRA.Game.exe %*
 
 :end
 if %errorlevel% neq 0 goto crashdialog
-exit
+exit /b
 :crashdialog
 echo ----------------------------------------
 echo OpenRA has encountered a fatal error.


### PR DESCRIPTION
Follow-up of #13033.
You can now specify the mod when calling `launch-game.cmd` from the command line.