### PR TITLE
Server now sends his ipv4 and ipv6.

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Server
 			{
 				try
 				{
-					var url = "ping?port={0}&name={1}&state={2}&players={3}&bots={4}&mods={5}&map={6}&maxplayers={7}&spectators={8}&protected={9}&clients={10}";
+					var url = "ping?port={0}&name={1}&state={2}&players={3}&bots={4}&mods={5}&map={6}&maxplayers={7}&spectators={8}&protected={9}&clients={10}&ipv4={11}&ipv6={12}";
 					if (isInitialPing) url += "&new=1";
 
 					using (var wc = new WebClient())
@@ -84,7 +84,8 @@ namespace OpenRA.Mods.Common.Server
 							numSlots,
 							numSpectators,
 							passwordProtected,
-							string.Join(",", clients)));
+							string.Join(",", clients),
+							GetIpV4(wc), Uri.EscapeUriString(GetIpV6(wc))));
 
 						if (isInitialPing)
 						{
@@ -114,6 +115,16 @@ namespace OpenRA.Mods.Common.Server
 			};
 
 			a.BeginInvoke(null, null);
+		}
+
+		private String GetIpV4(WebClient wc)
+		{
+			return wc.DownloadString("http://v4.ipv6-test.com/api/myip.php");
+		}
+
+		private string GetIpV6(WebClient wc)
+		{
+			return wc.DownloadString("http://v6.ipv6-test.com/api/myip.php");
 		}
 	}
 }


### PR DESCRIPTION
An user might have one or two ip adresses: ipv4 and ipv6. Some of them (like me) are using Dual-Stick-Lite. Resulting in a shared ipv4, and dedicated ipv6. While unable to host games when missing ipv4 or having a shared ipv4 address, this PR allows you to actualy provide both.

The MasterServer now has to evaluate this and store both of them instead of only the default REMOTE_ADDR - which btw is always ipv4 currently due to missing ipv6 DNS entries. But even if these entries would exist, users like me will still connect using the shared ipv4 - resulting in never being able to host at all without this addition.

After this PR is accepted, i will make another PR for the master server to support these new parameters and handle ipv4 and ipv6.

Sidenote: Might be a good idea to detect whether the player can connect to ipv4 and ipv6 adressed and filtering them in the lobby (or marking them with "you are missing ipvx support")