### PR TITLE
Add 'Reload aircraft' hotkey (ammo not full) #4950

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -229,6 +229,7 @@ namespace OpenRA
 		public Hotkey DeployKey = new Hotkey(Keycode.F, Modifiers.None);
 		public Hotkey StanceCycleKey = new Hotkey(Keycode.Z, Modifiers.Ctrl);
 		public Hotkey GuardKey = new Hotkey(Keycode.D, Modifiers.None);
+		public Hotkey ReloadKey = new Hotkey(Keycode.G, Modifiers.None);
 
 		public Hotkey ObserverCombinedView = new Hotkey(Keycode.MINUS, Modifiers.None);
 		public Hotkey ObserverWorldView = new Hotkey(Keycode.EQUALS, Modifiers.None);

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -118,6 +118,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class Aircraft : ITick, ISync, IFacing, IPositionable, IMove, IIssueOrder, IResolveOrder, IOrderVoice, IDeathActorInitModifier,
 		INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyActorDisposing, IActorPreviewInitModifier
 	{
+		const uint Reload = 1;
 		static readonly Pair<CPos, SubCell>[] NoCells = { };
 
 		public readonly bool IsPlane;
@@ -660,6 +661,10 @@ namespace OpenRA.Mods.Common.Traits
 			}
 			else if (order.OrderString == "ReturnToBase")
 			{
+				if (order.ExtraData == Reload && self.TraitsImplementing<AmmoPool>()
+					.All(p => p.Info.SelfReloads || p.FullAmmo()))
+					return;
+
 				UnReserve();
 				self.CancelActivity();
 				if (IsPlane)

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -521,7 +521,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{ "ScatterKey", "Scatter" },
 					{ "StanceCycleKey", "Cycle Stance" },
 					{ "DeployKey", "Deploy" },
-					{ "GuardKey", "Guard" }
+					{ "GuardKey", "Guard" },
+					{ "ReloadKey", "Reload aircraft" }
 				};
 
 				var header = ScrollItemWidget.Setup(hotkeyHeader, returnTrue, doNothing);

--- a/OpenRA.Mods.Common/Widgets/UnitCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/UnitCommandWidget.cs
@@ -74,6 +74,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 				if (key == ks.GuardKey)
 					return PerformGuard();
+
+				if (key == ks.ReloadKey)
+					return PerformReload();
 			}
 
 			return false;
@@ -95,8 +98,13 @@ namespace OpenRA.Mods.Common.Widgets
 
 		void PerformKeyboardOrderOnSelection(Func<Actor, Order> f)
 		{
+			PerformKeyboardOrderOnSelection(f, a => a.Owner == world.LocalPlayer && !a.Disposed);
+		}
+
+		void PerformKeyboardOrderOnSelection(Func<Actor, Order> f, Func<Actor, bool> where)
+		{
 			var orders = world.Selection.Actors
-				.Where(a => a.Owner == world.LocalPlayer && !a.Disposed)
+				.Where(where)
 				.Select(f)
 				.ToArray();
 
@@ -126,6 +134,14 @@ namespace OpenRA.Mods.Common.Widgets
 			PerformKeyboardOrderOnSelection(a => new Order("Unload", a, false));
 			PerformKeyboardOrderOnSelection(a => new Order("Detonate", a, false));
 			PerformKeyboardOrderOnSelection(a => new Order("GrantConditionOnDeploy", a, false));
+			return true;
+		}
+
+		bool PerformReload()
+		{
+			// ReturnToBase ExtraData = 1: return to base only if reload needed
+			PerformKeyboardOrderOnSelection(a => new Order("ReturnToBase", a, false) { ExtraData = 1 },
+				a => a.Owner == world.LocalPlayer && !a.Disposed && a.Info.HasTraitInfo<AircraftInfo>());
 			return true;
 		}
 

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -475,12 +475,12 @@ Background@SETTINGS_PANEL:
 							Children:
 								Label@FUNCTION:
 									Y: 0-1
-									Width: PARENT_RIGHT - 84
+									Width: PARENT_RIGHT - 79
 									Height: 25
 									Align: Right
 								HotkeyEntry@HOTKEY:
 									X: PARENT_RIGHT-WIDTH+1
-									Width: 80
+									Width: 75
 									Height: 25
 						Container@PRODUCTION_TEMPLATE:
 							Width: 173


### PR DESCRIPTION
F (Deploy-Return to base) no change - returns all aircraft to base
new 'Reload aircraft' hotkey (G default, can be changed) - returns to base only aircraft which needs reload (not full ammo)

![obrazok](https://cloud.githubusercontent.com/assets/16348750/25041024/4eb9e118-210d-11e7-94a3-b379b2f812ed.png)

