### PR TITLE
TD Flame infantry spread.

### DIFF
--- a/mods/cnc/weapons/other.yaml
+++ b/mods/cnc/weapons/other.yaml
@@ -7,7 +7,7 @@
 	Projectile: Bullet
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
-		Spread: 341
+		Spread: 468
 		Damage: 40
 		ValidTargets: Ground, Water, Trees
 		InvalidTargets: Wall


### PR DESCRIPTION
Increases the flame infantry attack spread from 341 to 468.

This allows the flame infantry to have a wider cone attack as the previous 10 damage increase helped. They still however lacked the wide attack spread needed on massive infantry assaults. Their attack spread matches that of grenadiers and a lot of armaments (Artillery) and being a frontal unit can use a slight increase to help with this.

Units going prone still takes three hits to kill infantry (two for e3 and anyone standing).