### PR TITLE
Move web urls from user config to mod config.

### DIFF
--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -113,7 +113,7 @@ namespace OpenRA
 			}
 		}
 
-		public void QueryRemoteMapDetails(IEnumerable<string> uids, Action<MapPreview> mapDetailsReceived = null, Action queryFailed = null)
+		public void QueryRemoteMapDetails(string repositoryUrl, IEnumerable<string> uids, Action<MapPreview> mapDetailsReceived = null, Action queryFailed = null)
 		{
 			var maps = uids.Distinct()
 				.Select(uid => previews[uid])
@@ -126,7 +126,7 @@ namespace OpenRA
 			foreach (var p in maps.Values)
 				p.UpdateRemoteSearch(MapStatus.Searching, null);
 
-			var url = Game.Settings.Game.MapRepository + "hash/" + string.Join(",", maps.Keys) + "/yaml";
+			var url = repositoryUrl + "hash/" + string.Join(",", maps.Keys) + "/yaml";
 
 			Action<DownloadDataCompletedEventArgs> onInfoComplete = i =>
 			{

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -123,8 +123,8 @@ namespace OpenRA
 		}
 
 		static readonly CPos[] NoSpawns = new CPos[] { };
-		MapCache cache;
-		ModData modData;
+		readonly MapCache cache;
+		readonly ModData modData;
 
 		public readonly string Uid;
 		public IReadOnlyPackage Package { get; private set; }
@@ -416,7 +416,7 @@ namespace OpenRA
 			innerData = newData;
 		}
 
-		public void Install(Action onSuccess)
+		public void Install(string mapRepositoryUrl, Action onSuccess)
 		{
 			if (Status != MapStatus.DownloadAvailable || !Game.Settings.Game.AllowDownloading)
 				return;
@@ -431,12 +431,11 @@ namespace OpenRA
 			}
 
 			var mapInstallPackage = installLocation.Key as IReadWritePackage;
-			var modData = Game.ModData;
 			new Thread(() =>
 			{
 				// Request the filename from the server
 				// Run in a worker thread to avoid network delays
-				var mapUrl = Game.Settings.Game.MapRepository + Uid;
+				var mapUrl = mapRepositoryUrl + Uid;
 				var mapFilename = string.Empty;
 				try
 				{

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -51,8 +51,6 @@ namespace OpenRA
 		[Desc("Locks the game with a password.")]
 		public string Password = "";
 
-		public string MasterServer = "http://master.openra.net/";
-
 		[Desc("Allow users to enable NAT discovery for external IP detection and automatic port forwarding.")]
 		public bool DiscoverNatDevices = false;
 
@@ -175,13 +173,11 @@ namespace OpenRA
 		public bool DrawTargetLine = true;
 
 		public bool AllowDownloading = true;
-		public string MapRepository = "http://resource.openra.net/map/";
 
 		public bool AllowZoom = true;
 		public Modifiers ZoomModifier = Modifiers.Ctrl;
 
 		public bool FetchNews = true;
-		public string NewsUrl = "http://master.openra.net/gamenews";
 
 		public MPGameFilters MPGameFilters = MPGameFilters.Waiting | MPGameFilters.Empty | MPGameFilters.Protected | MPGameFilters.Started;
 	}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -799,6 +799,7 @@
     <Compile Include="Traits\Attack\AttackCharges.cs" />
     <Compile Include="Traits\Render\WithChargeAnimation.cs" />
     <Compile Include="Traits\Render\WithChargeOverlay.cs" />
+    <Compile Include="WebServices.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -420,7 +420,8 @@ namespace OpenRA.Mods.Common.Server
 						else if (server.Settings.QueryMapRepository)
 						{
 							server.SendOrderTo(conn, "Message", "Searching for map on the Resource Center...");
-							server.ModData.MapCache.QueryRemoteMapDetails(new[] { s }, selectMap, queryFailed);
+							var mapRepository = server.ModData.Manifest.Get<WebServices>().MapRepository;
+							server.ModData.MapCache.QueryRemoteMapDetails(mapRepository, new[] { s }, selectMap, queryFailed);
 						}
 						else
 							queryFailed();

--- a/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
@@ -70,11 +70,12 @@ namespace OpenRA.Mods.Common.Server
 					var url = "ping?port={0}&name={1}&state={2}&players={3}&bots={4}&mods={5}&map={6}&maxplayers={7}&spectators={8}&protected={9}&clients={10}";
 					if (isInitialPing) url += "&new=1";
 
+					var serverList = server.ModData.Manifest.Get<WebServices>().ServerList;
 					using (var wc = new WebClient())
 					{
 						wc.Proxy = null;
 						var masterResponse = wc.DownloadData(
-							server.Settings.MasterServer + url.F(
+							serverList + url.F(
 							server.Settings.ExternalPort, Uri.EscapeUriString(server.Settings.Name),
 							(int)server.State,
 							numPlayers,

--- a/OpenRA.Mods.Common/WebServices.cs
+++ b/OpenRA.Mods.Common/WebServices.cs
@@ -1,0 +1,22 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA
+{
+	public class WebServices : IGlobalModData
+	{
+		public readonly string ServerList = "http://master.openra.net/";
+		public readonly string MapRepository = "http://resource.openra.net/map/";
+		public readonly string GameNews = "http://master.openra.net/gamenews";
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -36,6 +36,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly bool skirmishMode;
 		readonly Ruleset modRules;
 		readonly World shellmapWorld;
+		readonly WebServices services;
 
 		enum PanelType { Players, Options, Music, Kick, ForceStart }
 		PanelType panel = PanelType.Players;
@@ -116,6 +117,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			// TODO: This needs to be reworked to support per-map tech levels, bots, etc.
 			this.modRules = modData.DefaultRules;
 			shellmapWorld = worldRenderer.World;
+
+			services = modData.Manifest.Get<WebServices>();
 
 			orderManager.AddChatLine += AddChatLine;
 			Game.LobbyInfoChanged += UpdateCurrentMap;
@@ -655,7 +658,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			else if (Map.Status == MapStatus.DownloadAvailable)
 				LoadMapPreviewRules(Map);
 			else if (Game.Settings.Game.AllowDownloading)
-				modData.MapCache.QueryRemoteMapDetails(new[] { uid }, LoadMapPreviewRules);
+				modData.MapCache.QueryRemoteMapDetails(services.MapRepository, new[] { uid }, LoadMapPreviewRules);
 		}
 
 		void UpdatePlayerList()

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyMapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyMapPreviewLogic.cs
@@ -24,6 +24,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[ObjectCreator.UseCtor]
 		internal LobbyMapPreviewLogic(Widget widget, ModData modData, OrderManager orderManager, LobbyLogic lobby)
 		{
+			var mapRepository = modData.Manifest.Get<WebServices>().MapRepository;
+
 			var available = widget.GetOrNull("MAP_AVAILABLE");
 			if (available != null)
 			{
@@ -109,11 +111,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var install = download.GetOrNull<ButtonWidget>("MAP_INSTALL");
 				if (install != null)
 				{
-					install.OnClick = () => lobby.Map.Install(() =>
+					install.OnClick = () => lobby.Map.Install(mapRepository, () =>
 					{
 						lobby.Map.PreloadRules();
 						Game.RunAfterTick(() => orderManager.IssueOrder(Order.Command("state {0}".F(Session.ClientState.NotReady))));
 					});
+
 					install.IsHighlighted = () => installHighlighted;
 				}
 			}
@@ -178,9 +181,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					retry.OnClick = () =>
 					{
 						if (lobby.Map.Status == MapStatus.DownloadError)
-							lobby.Map.Install(() => orderManager.IssueOrder(Order.Command("state {0}".F(Session.ClientState.NotReady))));
+							lobby.Map.Install(mapRepository, () => orderManager.IssueOrder(Order.Command("state {0}".F(Session.ClientState.NotReady))));
 						else if (lobby.Map.Status == MapStatus.Unavailable)
-							modData.MapCache.QueryRemoteMapDetails(new[] { lobby.Map.Uid });
+							modData.MapCache.QueryRemoteMapDetails(mapRepository, new[] { lobby.Map.Uid });
 					};
 
 					retry.GetText = () => lobby.Map.Status == MapStatus.DownloadError ? "Retry Install" : "Retry Search";

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -235,6 +235,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			Game.OnRemoteDirectConnect += OnRemoteDirectConnect;
 
+			var newsURL = modData.Manifest.Get<WebServices>().GameNews;
+
 			// System information opt-out prompt
 			var sysInfoPrompt = widget.Get("SYSTEM_INFO_PROMPT");
 			sysInfoPrompt.IsVisible = () => menuType == MenuType.SystemInfoPrompt;
@@ -263,14 +265,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					Game.Settings.Debug.SystemInformationVersionPrompt = SystemInformationVersion;
 					Game.Settings.Save();
 					SwitchMenu(MenuType.Main);
-					LoadAndDisplayNews(newsBG);
+					LoadAndDisplayNews(newsURL, newsBG);
 				};
 			}
 			else
-				LoadAndDisplayNews(newsBG);
+				LoadAndDisplayNews(newsURL, newsBG);
 		}
 
-		void LoadAndDisplayNews(Widget newsBG)
+		void LoadAndDisplayNews(string newsURL, Widget newsBG)
 		{
 			if (newsBG != null)
 			{
@@ -285,7 +287,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					if (!fetchedNews)
 					{
 						// Send the mod and engine version to support version-filtered news (update prompts)
-						var newsURL = Game.Settings.Game.NewsUrl + "?version={0}&mod={1}&modversion={2}".F(
+						newsURL += "?version={0}&mod={1}&modversion={2}".F(
 							Uri.EscapeUriString(Game.Mods["modchooser"].Metadata.Version),
 							Uri.EscapeUriString(Game.ModData.Manifest.Id),
 							Uri.EscapeUriString(Game.ModData.Manifest.Metadata.Version));

--- a/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
@@ -38,6 +38,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly Color gameStartedColor;
 		readonly Color incompatibleGameColor;
 		readonly ModData modData;
+		readonly WebServices services;
 
 		GameServer currentServer;
 		MapPreview currentMap;
@@ -69,6 +70,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			this.modData = modData;
 			this.onStart = onStart;
 			this.onExit = onExit;
+
+			services = modData.Manifest.Get<WebServices>();
 
 			incompatibleVersionColor = ChromeMetrics.Get<Color>("IncompatibleVersionColor");
 			incompatibleGameColor = ChromeMetrics.Get<Color>("IncompatibleGameColor");
@@ -322,7 +325,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Game.RunAfterTick(() => RefreshServerListInner(games));
 			};
 
-			var queryURL = Game.Settings.Server.MasterServer + "games?version={0}&mod={1}&modversion={2}".F(
+			var queryURL = services.ServerList + "games?version={0}&mod={1}&modversion={2}".F(
 				Uri.EscapeUriString(Game.Mods["modchooser"].Metadata.Version),
 				Uri.EscapeUriString(Game.ModData.Manifest.Id),
 				Uri.EscapeUriString(Game.ModData.Manifest.Metadata.Version));
@@ -476,7 +479,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				// Search for any unknown maps
 				if (Game.Settings.Game.AllowDownloading)
-					modData.MapCache.QueryRemoteMapDetails(games.Where(g => !Filtered(g)).Select(g => g.Map));
+					modData.MapCache.QueryRemoteMapDetails(services.MapRepository, games.Where(g => !Filtered(g)).Select(g => g.Map));
 
 				foreach (var row in rows)
 					serverList.AddChild(row);


### PR DESCRIPTION
This PR moves the master server, game news, and map repository URLs from settings.yaml into a new `WebServices` block in mod.yaml.  The defaults are set so that yaml does not need to be explicitly defined.

This makes it possible for third party mods to run their own services, and improves our forward compatibility if we ever need to change these ourselves in the future.

Unfortunately we can't include the global chat here without giving that a major rewrite.