### PR TITLE
Show 'Failed to save map' error message in dialog box

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -191,19 +191,25 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					}
 
 					map.Save(package);
+
+					// Update the map cache so it can be loaded without restarting the game
+					modData.MapCache[map.Uid].UpdateFromMap(map.Package, selectedDirectory.Folder, selectedDirectory.Classification, null, map.Grid.Type);
+
+					Console.WriteLine("Saved current map at {0}", combinedPath);
+					Ui.CloseWindow();
+
+					onSave(map.Uid);
 				}
-				catch
+				catch (Exception e)
 				{
-					Console.WriteLine("Failed to save map at {0}", combinedPath);
+					Log.Write("debug", "Failed to save map at {0}: {1}", combinedPath, e.Message);
+
+					ConfirmationDialogs.ButtonPrompt(
+						title: "Failed to save map",
+						text: "See debug.log for details.",
+						onConfirm: () => { },
+						confirmText: "Ok");
 				}
-
-				// Update the map cache so it can be loaded without restarting the game
-				modData.MapCache[map.Uid].UpdateFromMap(map.Package, selectedDirectory.Folder, selectedDirectory.Classification, null, map.Grid.Type);
-
-				Console.WriteLine("Saved current map at {0}", combinedPath);
-				Ui.CloseWindow();
-
-				onSave(map.Uid);
 			};
 		}
 	}


### PR DESCRIPTION
Save map error (e.g. map opened in another program) was ignored so user lost all changes without warning.
Now there is error message and user can fix the issue and save again. Optional changes in ConfirmationDialogs support wider texts (e.g. file paths).

Closes #13036.