### PR TITLE
Throw a more detailed error message when creating invalid frozen actors

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -95,6 +95,8 @@ namespace OpenRA.Traits
 	public interface ITick { void Tick(Actor self); }
 	public interface ITickRender { void TickRender(WorldRenderer wr, Actor self); }
 	public interface IRender { IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr); }
+
+	public interface IAutoSelectionSizeInfo : ITraitInfoInterface { }
 	public interface IAutoSelectionSize { int2 SelectionSize(Actor self); }
 
 	public interface IIssueOrder

--- a/OpenRA.Mods.Cnc/Traits/Render/WithVoxelUnloadBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithVoxelUnloadBody.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits.Render
 {
-	public class WithVoxelUnloadBodyInfo : ITraitInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>
+	public class WithVoxelUnloadBodyInfo : ITraitInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>, IAutoSelectionSizeInfo
 	{
 		[Desc("Voxel sequence name to use when docked to a refinery.")]
 		public readonly string UnloadSequence = "unload";

--- a/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
@@ -22,7 +22,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits.Render
 {
-	public class WithVoxelWalkerBodyInfo : ITraitInfo, IRenderActorPreviewVoxelsInfo,  Requires<RenderVoxelsInfo>, Requires<IMoveInfo>, Requires<IFacingInfo>
+	public class WithVoxelWalkerBodyInfo : ITraitInfo, IRenderActorPreviewVoxelsInfo,  Requires<RenderVoxelsInfo>, Requires<IMoveInfo>, Requires<IFacingInfo>,
+		IAutoSelectionSizeInfo
 	{
 		public readonly string Sequence = "idle";
 

--- a/OpenRA.Mods.Common/Traits/CustomSelectionSize.cs
+++ b/OpenRA.Mods.Common/Traits/CustomSelectionSize.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Special case trait for actors that need to define targetable area and screen map bounds manually.")]
-	public class CustomSelectionSizeInfo : ITraitInfo
+	public class CustomSelectionSizeInfo : ITraitInfo, IAutoSelectionSizeInfo
 	{
 		[FieldLoader.Require]
 		public readonly int[] CustomBounds = null;

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -18,10 +18,16 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor will remain visible (but not updated visually) under fog, once discovered.")]
-	public class FrozenUnderFogInfo : ITraitInfo, Requires<BuildingInfo>, IDefaultVisibilityInfo
+	public class FrozenUnderFogInfo : ITraitInfo, Requires<BuildingInfo>, IDefaultVisibilityInfo, IRulesetLoaded
 	{
 		[Desc("Players with these stances can always see the actor.")]
 		public readonly Stance AlwaysVisibleStances = Stance.Ally;
+
+		void IRulesetLoaded<ActorInfo>.RulesetLoaded(Ruleset rules, ActorInfo info)
+		{
+			if (!info.HasTraitInfo<SelectableInfo>() && !info.HasTraitInfo<IAutoSelectionSizeInfo>())
+				throw new YamlException("Cannot create a frozen actor for actor type '{0}' with empty bounds (no selection size given).".F(info.Name));
+		}
 
 		public object Create(ActorInitializer init) { return new FrozenUnderFog(init, this); }
 	}
@@ -61,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 			footprint = footprintCells.SelectMany(c => map.ProjectedCellsCovering(c.ToMPos(map))).ToArray();
 		}
 
-		public void Created(Actor self)
+		void INotifyCreated.Created(Actor self)
 		{
 			frozenStates = new PlayerDictionary<FrozenState>(self.World, (player, playerIndex) =>
 			{

--- a/OpenRA.Mods.Common/Traits/Render/AutoSelectionSize.cs
+++ b/OpenRA.Mods.Common/Traits/Render/AutoSelectionSize.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Automatically calculates the targetable area and screen map boundaries from the sprite size.")]
-	public class AutoSelectionSizeInfo : ITraitInfo, Requires<RenderSpritesInfo>
+	public class AutoSelectionSizeInfo : ITraitInfo, Requires<RenderSpritesInfo>, IAutoSelectionSizeInfo
 	{
 		public object Create(ActorInitializer init) { return new AutoSelectionSize(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Also returns a default selection size that is calculated automatically from the voxel dimensions.")]
-	public class WithVoxelBodyInfo : ConditionalTraitInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>
+	public class WithVoxelBodyInfo : ConditionalTraitInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>, IAutoSelectionSizeInfo
 	{
 		public readonly string Sequence = "idle";
 


### PR DESCRIPTION
Before it crashed with an exception like this:
```
Exception of type `System.ArgumentException`: Bounds of actor concreteb 38 (invalid) are empty.
Parametername: bounds
```

I think this error message is more helpful, as it immediately tells you that `FrozenUnderFog` is part of the problem, so that you can decide if you either remove that or fix the bounds of the actor.