### PR TITLE
Enhance - unify global chat (with lobby chat)

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -565,33 +565,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			lobbyChatUnreadMessages += 1;
 
-			var template = chatTemplate.Clone();
-			var nameLabel = template.Get<LabelWidget>("NAME");
-			var timeLabel = template.Get<LabelWidget>("TIME");
-			var textLabel = template.Get<LabelWidget>("TEXT");
-
-			var name = from + ":";
-			var font = Game.Renderer.Fonts[nameLabel.Font];
-			var nameSize = font.Measure(from);
-
-			var time = DateTime.Now;
-			timeLabel.GetText = () => "{0:D2}:{1:D2}".F(time.Hour, time.Minute);
-
-			nameLabel.GetColor = () => c;
-			nameLabel.GetText = () => name;
-			nameLabel.Bounds.Width = nameSize.X;
-			textLabel.Bounds.X += nameSize.X;
-			textLabel.Bounds.Width -= nameSize.X;
-
-			// Hack around our hacky wordwrap behavior: need to resize the widget to fit the text
-			text = WidgetUtils.WrapText(text, textLabel.Bounds.Width, font);
-			textLabel.GetText = () => text;
-			var dh = font.Measure(text).Y - textLabel.Bounds.Height;
-			if (dh > 0)
-			{
-				textLabel.Bounds.Height += dh;
-				template.Bounds.Height += dh;
-			}
+			var template = (ContainerWidget)chatTemplate.Clone();
+			LobbyUtils.SetupChatLine(template, c, from, text);
 
 			var scrolledToBottom = lobbyChatPanel.ScrolledToBottom;
 			lobbyChatPanel.AddChild(template);

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -517,5 +517,35 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			return address;
 		}
+
+		public static void SetupChatLine(ContainerWidget template, Color c, string from, string text)
+		{
+			var nameLabel = template.Get<LabelWidget>("NAME");
+			var timeLabel = template.Get<LabelWidget>("TIME");
+			var textLabel = template.Get<LabelWidget>("TEXT");
+
+			var name = from + ":";
+			var font = Game.Renderer.Fonts[nameLabel.Font];
+			var nameSize = font.Measure(from);
+
+			var time = DateTime.Now;
+			timeLabel.GetText = () => "{0:D2}:{1:D2}".F(time.Hour, time.Minute);
+
+			nameLabel.GetColor = () => c;
+			nameLabel.GetText = () => name;
+			nameLabel.Bounds.Width = nameSize.X;
+			textLabel.Bounds.X += nameSize.X;
+			textLabel.Bounds.Width -= nameSize.X;
+
+			// Hack around our hacky wordwrap behavior: need to resize the widget to fit the text
+			text = WidgetUtils.WrapText(text, textLabel.Bounds.Width, font);
+			textLabel.GetText = () => text;
+			var dh = font.Measure(text).Y - textLabel.Bounds.Height;
+			if (dh > 0)
+			{
+				textLabel.Bounds.Height += dh;
+				template.Bounds.Height += dh;
+			}
+		}
 	}
 }

--- a/mods/cnc/chrome/lobby-globalchat.yaml
+++ b/mods/cnc/chrome/lobby-globalchat.yaml
@@ -26,10 +26,30 @@ Container@LOBBY_GLOBALCHAT_PANEL:
 					TopBottomSpacing: 4
 					ItemSpacing: 4
 					Children:
-						Label@HISTORY_TEMPLATE:
-							X: 5
-							Width: 530
-							WordWrap: True
+						Container@CHAT_TEMPLATE:
+							X: 2
+							Width: PARENT_RIGHT-27
+							Height: 16
+							Children:
+								Label@TIME:
+									X: 3
+									Width: 50
+									Height: 15
+									VAlign: Top
+									Shadow: True
+								Label@NAME:
+									X: 45
+									Width: 50
+									Height: 15
+									VAlign: Top
+									Shadow: True
+								Label@TEXT:
+									X: 55
+									Width: PARENT_RIGHT - 60
+									Height: 15
+									WordWrap: true
+									VAlign: Top
+									Shadow: True
 				TextField@CHAT_TEXTFIELD:
 					X: 200
 					Y: PARENT_BOTTOM + 5

--- a/mods/cnc/chrome/multiplayer-globalchat.yaml
+++ b/mods/cnc/chrome/multiplayer-globalchat.yaml
@@ -26,10 +26,30 @@ Container@GLOBALCHAT_PANEL:
 					TopBottomSpacing: 4
 					ItemSpacing: 4
 					Children:
-						Label@HISTORY_TEMPLATE:
-							X: 5
-							Width: 530
-							WordWrap: True
+						Container@CHAT_TEMPLATE:
+							X: 2
+							Width: PARENT_RIGHT-27
+							Height: 16
+							Children:
+								Label@TIME:
+									X: 3
+									Width: 50
+									Height: 15
+									VAlign: Top
+									Shadow: True
+								Label@NAME:
+									X: 45
+									Width: 50
+									Height: 15
+									VAlign: Top
+									Shadow: True
+								Label@TEXT:
+									X: 55
+									Width: PARENT_RIGHT - 60
+									Height: 15
+									WordWrap: true
+									VAlign: Top
+									Shadow: True
 				TextField@CHAT_TEXTFIELD:
 					Y: PARENT_BOTTOM - 25
 					Width: 582

--- a/mods/common/chrome/lobby-globalchat.yaml
+++ b/mods/common/chrome/lobby-globalchat.yaml
@@ -26,10 +26,30 @@ Container@LOBBY_GLOBALCHAT_PANEL:
 					TopBottomSpacing: 4
 					ItemSpacing: 4
 					Children:
-						Label@HISTORY_TEMPLATE:
-							X: 5
-							Width: 530
-							WordWrap: True
+						Container@CHAT_TEMPLATE:
+							X: 2
+							Width: PARENT_RIGHT-27
+							Height: 16
+							Children:
+								Label@TIME:
+									X: 3
+									Width: 50
+									Height: 15
+									VAlign: Top
+									Shadow: True
+								Label@NAME:
+									X: 45
+									Width: 50
+									Height: 15
+									VAlign: Top
+									Shadow: True
+								Label@TEXT:
+									X: 55
+									Width: PARENT_RIGHT - 60
+									Height: 15
+									WordWrap: true
+									VAlign: Top
+									Shadow: True
 				TextField@CHAT_TEXTFIELD:
 					X: 205
 					Y: PARENT_BOTTOM - 25

--- a/mods/common/chrome/multiplayer-globalchat.yaml
+++ b/mods/common/chrome/multiplayer-globalchat.yaml
@@ -26,10 +26,30 @@ Container@GLOBALCHAT_PANEL:
 					TopBottomSpacing: 4
 					ItemSpacing: 4
 					Children:
-						Label@HISTORY_TEMPLATE:
-							X: 5
-							Width: 530
-							WordWrap: True
+						Container@CHAT_TEMPLATE:
+							X: 2
+							Width: PARENT_RIGHT-27
+							Height: 16
+							Children:
+								Label@TIME:
+									X: 3
+									Width: 50
+									Height: 15
+									VAlign: Top
+									Shadow: True
+								Label@NAME:
+									X: 45
+									Width: 50
+									Height: 15
+									VAlign: Top
+									Shadow: True
+								Label@TEXT:
+									X: 55
+									Width: PARENT_RIGHT - 60
+									Height: 15
+									WordWrap: true
+									VAlign: Top
+									Shadow: True
 				TextField@CHAT_TEXTFIELD:
 					Y: PARENT_BOTTOM - 25
 					Width: 582

--- a/mods/common/metrics.yaml
+++ b/mods/common/metrics.yaml
@@ -10,8 +10,9 @@ Metrics:
 	ButtonTextShadow: false
 	CheckboxPressedState: false
 	GameStartedColor: FFA500
-	GlobalChatNotificationColor: D3D3D3
+	GlobalChatNotificationColor: FFA500
 	GlobalChatTextColor: FFFFFF
+	GlobalChatPlayerNameColor: 00FF00
 	HotkeyColor: FFFFFF
 	HotkeyColorDisabled: 808080
 	HotkeyFont: Regular


### PR DESCRIPTION
Global chat unified in look with lobby chat, new configurable color of player names in global chat.

Global Chat Before:
![obrazok](https://cloud.githubusercontent.com/assets/16348750/25304352/c1c4e5be-2765-11e7-9b6e-5d05beab48a4.png)

Now:
![obrazok](https://cloud.githubusercontent.com/assets/16348750/25304345/a91558b4-2765-11e7-881a-8a2ce2de251b.png)