### PR TITLE
Remove invalid Background widgets from TD map editor.

### DIFF
--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -77,7 +77,7 @@ Container@NEW_MAP_BG:
 			Font: Bold
 			Key: return
 
-Background@SAVE_MAP_PANEL:
+Container@SAVE_MAP_PANEL:
 	Logic: SaveMapLogic
 	X: (WINDOW_RIGHT - WIDTH)/2
 	Y: (WINDOW_BOTTOM - HEIGHT)/2

--- a/mods/cnc/chrome/mainmenu.yaml
+++ b/mods/cnc/chrome/mainmenu.yaml
@@ -173,7 +173,7 @@ Container@MENU_BACKGROUND:
 							Width: 140
 							Height: 35
 							Text: Back
-				Background@MAP_EDITOR_MENU:
+				Container@MAP_EDITOR_MENU:
 					Width: PARENT_RIGHT
 					Visible: False
 					Children:


### PR DESCRIPTION
Fixes the endless "Could not find collection 'dialog'" debug.log spam.