### PR TITLE
Fix repair cursor visual feedback target.

### DIFF
--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -46,6 +46,7 @@ namespace OpenRA
 		public uint ExtraData;
 		public bool IsImmediate;
 		public bool SuppressVisualFeedback;
+		public Actor VisualFeedbackTarget;
 
 		public Player Player { get { return Subject != null ? Subject.Owner : null; } }
 

--- a/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Orders
 			if (repairBuilding == null)
 				yield break;
 
-			yield return new Order(orderId, underCursor, false) { TargetActor = repairBuilding };
+			yield return new Order(orderId, underCursor, false) { TargetActor = repairBuilding, VisualFeedbackTarget = underCursor };
 		}
 
 		public void Tick(World world)

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -194,9 +194,10 @@ namespace OpenRA.Mods.Common.Widgets
 
 				if (!flashed && !o.SuppressVisualFeedback)
 				{
-					if (o.TargetActor != null)
+					var visualTargetActor = o.VisualFeedbackTarget ?? o.TargetActor;
+					if (visualTargetActor != null)
 					{
-						world.AddFrameEndTask(w => w.Add(new FlashTarget(o.TargetActor)));
+						world.AddFrameEndTask(w => w.Add(new FlashTarget(visualTargetActor)));
 						flashed = true;
 					}
 					else if (o.TargetLocation != CPos.Zero)


### PR DESCRIPTION
This fixes the repair cursor flashing the repair facility rather than the unit that is clicked on.  The target flashes are there to provide feedback on which unit is clicked, so flashing the wrong actor is bad for polish.