### PR TITLE
Fix ObjectCreator assembly resolving on Windows.

### DIFF
--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -217,6 +217,9 @@ namespace OpenRA
 			MapCache.Dispose();
 			if (VoxelLoader != null)
 				VoxelLoader.Dispose();
+
+			if (ObjectCreator != null)
+				ObjectCreator.Dispose();
 		}
 	}
 

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -29,13 +29,6 @@ namespace OpenRA
 		readonly Pair<Assembly, string>[] assemblies;
 		readonly bool isMonoRuntime = Type.GetType("Mono.Runtime") != null;
 
-		public ObjectCreator(Assembly a)
-		{
-			typeCache = new Cache<string, Type>(FindType);
-			ctorCache = new Cache<Type, ConstructorInfo>(GetCtor);
-			assemblies = a.GetNamespaces().Select(ns => Pair.New(a, ns)).ToArray();
-		}
-
 		public ObjectCreator(Manifest manifest, FileSystem.FileSystem modFiles)
 		{
 			typeCache = new Cache<string, Type>(FindType);

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -18,7 +18,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA
 {
-	public class ObjectCreator
+	public sealed class ObjectCreator : IDisposable
 	{
 		// .NET does not support unloading assemblies, so mod libraries will leak across mod changes.
 		// This tracks the assemblies that have been loaded since game start so that we don't load multiple copies
@@ -76,7 +76,6 @@ namespace OpenRA
 
 			AppDomain.CurrentDomain.AssemblyResolve += ResolveAssembly;
 			assemblies = assemblyList.SelectMany(asm => asm.GetNamespaces().Select(ns => Pair.New(asm, ns))).ToArray();
-			AppDomain.CurrentDomain.AssemblyResolve -= ResolveAssembly;
 		}
 
 		Assembly ResolveAssembly(object sender, ResolveEventArgs e)
@@ -84,6 +83,9 @@ namespace OpenRA
 			foreach (var a in AppDomain.CurrentDomain.GetAssemblies())
 				if (a.FullName == e.Name)
 					return a;
+
+			if (assemblies == null)
+				return null;
 
 			return assemblies.Select(a => a.First).FirstOrDefault(a => a.FullName == e.Name);
 		}
@@ -157,6 +159,23 @@ namespace OpenRA
 		{
 			return assemblies.Select(ma => ma.First).Distinct()
 				.SelectMany(ma => ma.GetTypes());
+		}
+
+		~ObjectCreator()
+		{
+			Dispose(false);
+		}
+
+		public void Dispose()
+		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		void Dispose(bool disposing)
+		{
+			if (disposing)
+				AppDomain.CurrentDomain.AssemblyResolve -= ResolveAssembly;
 		}
 
 		[AttributeUsage(AttributeTargets.Constructor)]


### PR DESCRIPTION
This fixes an issue that prevented out-of-tree compiled dlls from loading on Windows/.NET.

It appears that the assembly resolution on Windows is lazier than mono, and in this specific case does not try to resolve the Mods.Common dependency until after we have removed our custom assembly resolver.

This then leads to the following exception:
> Could not load file or assembly 'OpenRA.Mods.Common, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. The system cannot find the file specified.

I don't understand why it fails here but works for our main mod dlls.  The `monodis --assemblyref` references to OpenRA.Game and OpenRA.Mods.Common are the same for both.  In any case, keeping our `ResolveAssembly` override around until we dispose the ObjectCreator seems to fix the issue.

Testcase:
* Check out https://github.com/OpenRA/OpenRAModTemplate/tree/wip on Windows
* Compile the engine and OpenRA.Mods.Example project
* Run the mod using the `launch-game.cmd` script and watch it die
* Change the submodule reference to point to this PR
* Recompile
* Run the mod using the `launch-game.cmd` script and watch it run

Behaviour under mono should not change.

I guess that this explains why third party mods have always insisted on / resorted to hacks to put their dll projects in the main code tree, but I don't understand why it hasn't been reported or seriously discussed as a legitimate engine bug before now.

Requesting reviews from:
* @RoosterDragon, @chrisforbes: You have the most experience in the technical aspects.
* @GraionDilach, @reaperrr: You have the most experience in how this affects third party mods.