### PR TITLE
ActorExts.AppearsFriendlyTo Simplification

### DIFF
--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common
 			if (self.EffectiveOwner != null && self.EffectiveOwner.Disguised && !toActor.Info.HasTraitInfo<IgnoresDisguiseInfo>())
 				return toActor.Owner.Stances[self.EffectiveOwner.Owner] == Stance.Ally;
 
-			return stance == Stance.Ally;
+			return false;
 		}
 
 		public static bool AppearsHostileTo(this Actor self, Actor toActor)


### PR DESCRIPTION
If `stance == Stance.Ally` is true, then `ActorExts.AppearsFriendlyTo` returns `true` on line 45; therefore, `stance == Stance.Ally` on line 50 is always `false`. This just simplifies it. (I know that the compiler *might* do that already.)