### PR TITLE
Fix TargetPosition targeting and give D2k buildings better hit-shapes

### DIFF
--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -100,8 +100,9 @@ namespace OpenRA.Mods.Common.Activities
 			minRange = armaments.Max(a => a.Weapon.MinRange);
 			maxRange = armaments.Min(a => a.MaxRange());
 
+			var pos = self.CenterPosition;
 			var mobile = move as Mobile;
-			if (!Target.IsInRange(self.CenterPosition, maxRange) || Target.IsInRange(self.CenterPosition, minRange)
+			if (!Target.IsInRange(pos, maxRange) || Target.IsInRange(pos, minRange)
 				|| (mobile != null && !mobile.CanInteractWithGroundLayer(self)))
 			{
 				// Try to move within range, drop the target otherwise
@@ -113,7 +114,8 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 			}
 
-			var desiredFacing = (Target.CenterPosition - self.CenterPosition).Yaw.Facing;
+			var targetedPosition = Target.Positions.PositionClosestTo(pos);
+			var desiredFacing = (targetedPosition - pos).Yaw.Facing;
 			if (facing.Facing != desiredFacing)
 			{
 				attackStatus |= AttackStatus.NeedsToTurn;

--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			if (args.GuidedTarget.IsValidFor(args.SourceActor))
 			{
-				var guidedTargetPos = args.GuidedTarget.CenterPosition;
+				var guidedTargetPos = args.GuidedTarget.Positions.PositionClosestTo(args.Source);
 				var targetDistance = new WDist((guidedTargetPos - args.Source).Length);
 
 				// Only continue tracking target if it's within weapon range +

--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -21,6 +21,9 @@ namespace OpenRA.Mods.Common.Projectiles
 	[Desc("Simple, invisible, usually direct-on-target projectile.")]
 	public class InstantHitInfo : IProjectileInfo, IRulesetLoaded<WeaponInfo>
 	{
+		[Desc("Apply warheads directly to center of target actor.")]
+		public readonly bool TargetCenterPosition = false;
+
 		[Desc("Maximum offset at the maximum range.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
 
@@ -57,14 +60,16 @@ namespace OpenRA.Mods.Common.Projectiles
 			this.info = info;
 			source = args.Source;
 
-			if (info.Inaccuracy.Length > 0)
+			if (info.TargetCenterPosition)
+				target = args.GuidedTarget;
+			else if (!info.TargetCenterPosition && info.Inaccuracy.Length > 0)
 			{
 				var inaccuracy = Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
 				var maxOffset = inaccuracy * (args.PassiveTarget - source).Length / args.Weapon.Range.Length;
 				target = Target.FromPos(args.PassiveTarget + WVec.FromPDF(args.SourceActor.World.SharedRandom, 2) * maxOffset / 1024);
 			}
 			else
-				target = args.GuidedTarget;
+				target = Target.FromPos(args.PassiveTarget);
 		}
 
 		public void Tick(World world)

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -128,7 +128,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		{
 			// Beam tracks target
 			if (info.TrackTarget && args.GuidedTarget.IsValidFor(args.SourceActor))
-				target = args.GuidedTarget.CenterPosition;
+				target = args.GuidedTarget.Positions.PositionClosestTo(source);
 
 			// Check for blocking actors
 			WPos blockedPos;

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -799,7 +799,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			// Check if target position should be updated (actor visible & locked on)
 			var newTarPos = targetPosition;
 			if (args.GuidedTarget.IsValidFor(args.SourceActor) && lockOn)
-				newTarPos = args.GuidedTarget.CenterPosition
+				newTarPos = args.GuidedTarget.Positions.PositionClosestTo(args.Source)
 					+ new WVec(WDist.Zero, WDist.Zero, info.AirburstAltitude);
 
 			// Compute target's predicted velocity vector (assuming uniform circular motion)

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -229,7 +229,7 @@ namespace OpenRA.Mods.Common.Traits
 				Source = muzzlePosition(),
 				CurrentSource = muzzlePosition,
 				SourceActor = self,
-				PassiveTarget = target.CenterPosition,
+				PassiveTarget = target.Positions.PositionClosestTo(muzzlePosition()),
 				GuidedTarget = target
 			};
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
@@ -39,7 +39,9 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			var f = facing.Facing;
-			var delta = target.CenterPosition - self.CenterPosition;
+			var pos = self.CenterPosition;
+			var targetedPosition = target.Positions.PositionClosestTo(pos);
+			var delta = targetedPosition - pos;
 			var facingToTarget = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : f;
 
 			if (Math.Abs(facingToTarget - f) % 256 > info.FacingTolerance)

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -146,7 +146,8 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			var pos = self.CenterPosition;
-			var targetYaw = (target.CenterPosition - self.CenterPosition).Yaw;
+			var targetedPosition = target.Positions.PositionClosestTo(pos);
+			var targetYaw = (targetedPosition - pos).Yaw;
 
 			foreach (var a in Armaments)
 			{

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -130,7 +130,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (self.IsDisabled())
 				return false;
 
-			var delta = target.CenterPosition - self.CenterPosition;
+			var pos = self.CenterPosition;
+			var delta = target.Positions.PositionClosestTo(pos) - pos;
 			DesiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : TurretFacing;
 			MoveTurret();
 			return HasAchievedDesiredFacing;

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -338,6 +338,9 @@
 		TargetTypes: Ground, C4, Structure
 	HitShape:
 		UseOccupiedCellsOffsets: true
+		Type: Rectangle
+			TopLeft: -512, -512
+			BottomRight: 512, 512
 	Building:
 		Dimensions: 1,1
 		Footprint: x

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -64,6 +64,10 @@ construction_yard:
 		Bounds: 96,64
 	Health:
 		HP: 3000
+	HitShape:
+		Type: Rectangle
+			TopLeft: -1536, -1024
+			BottomRight: 1536, 1024
 	Armor:
 		Type: cy
 	RevealsShroud:
@@ -134,6 +138,10 @@ wind_trap:
 	Bib:
 	Health:
 		HP: 3000
+	HitShape:
+		Type: Rectangle
+			TopLeft: -1024, -1024
+			BottomRight: 1024, 1024
 	Armor:
 		Type: building
 	RevealsShroud:
@@ -175,6 +183,10 @@ barracks:
 	Bib:
 	Health:
 		HP: 3200
+	HitShape:
+		Type: Rectangle
+			TopLeft: -1024, -1024
+			BottomRight: 1024, 1024
 	Armor:
 		Type: wood
 	RevealsShroud:
@@ -251,6 +263,15 @@ refinery:
 	Bib:
 	Health:
 		HP: 3000
+	HitShape:
+		Type: Rectangle
+			TopLeft: -512, -1024
+			BottomRight: 1536, 0
+	HitShape@BOTTOM:
+		UseOccupiedCellsOffsets: false
+		Type: Rectangle
+			TopLeft: -1536, 0
+			BottomRight: 512, 1024
 	Armor:
 		Type: building
 	RevealsShroud:
@@ -355,6 +376,11 @@ light_factory:
 	Bib:
 	Health:
 		HP: 3300
+	HitShape:
+		TargetableOffsets: -210,608,0
+		Type: Rectangle
+			TopLeft: -1536, -1024
+			BottomRight: 1536, 1024
 	Armor:
 		Type: light
 	RevealsShroud:
@@ -433,6 +459,18 @@ heavy_factory:
 	Bib:
 	Health:
 		HP: 3500
+	HitShape:
+		UseOccupiedCellsOffsets: false
+		TargetableOffsets: 0,0,0, -1680,0,0, 0,1024,0, 0,-1024,0, -1155,-704,0, -1365,832,0
+		Type: Rectangle
+			TopLeft: -1536, -512
+			BottomRight: 1536, 1536
+	HitShape@TOP:
+		UseOccupiedCellsOffsets: false
+		TargetableOffsets: 1680,0,0
+		Type: Rectangle
+			TopLeft: -512, -1536
+			BottomRight: 512, -512
 	Armor:
 		Type: wood
 	RevealsShroud:
@@ -518,6 +556,10 @@ outpost:
 	Bib:
 	Health:
 		HP: 3500
+	HitShape:
+		Type: Rectangle
+			TopLeft: -1536, -1024
+			BottomRight: 1536, 1024
 	Armor:
 		Type: light
 	RevealsShroud:
@@ -563,6 +605,15 @@ starport:
 		Bounds: 96,64
 	Health:
 		HP: 3500
+	HitShape:
+		Type: Rectangle
+			TopLeft: -1536, -1536
+			BottomRight: 1536, 512
+	HitShape@BOTTOM:
+		UseOccupiedCellsOffsets: false
+		Type: Rectangle
+			TopLeft: -512, 512
+			BottomRight: 512, 1536
 	Armor:
 		Type: building
 	RevealsShroud:
@@ -772,6 +823,15 @@ repair_pad:
 		Dimensions: 3,3
 	Health:
 		HP: 3000
+	HitShape:
+		Type: Rectangle
+			TopLeft: -1536, -512
+			BottomRight: 1536, 512
+	HitShape@TOPANDBOTTOM:
+		UseOccupiedCellsOffsets: false
+		Type: Rectangle
+			TopLeft: -512, -1536
+			BottomRight: 512, 1536
 	Armor:
 		Type: building
 	RevealsShroud:
@@ -827,6 +887,18 @@ high_tech_factory:
 	Bib:
 	Health:
 		HP: 3500
+	HitShape:
+		UseOccupiedCellsOffsets: false
+		TargetableOffsets: 0,0,0, -1312,0,0, 0,-1024,0, -1312,-1024,0, 0,1024,0, -1312,1024,0
+		Type: Rectangle
+			TopLeft: -1536, -512
+			BottomRight: 1536, 1536
+	HitShape@TOP:
+		UseOccupiedCellsOffsets: false
+		TargetableOffsets: 1280,0,0
+		Type: Rectangle
+			TopLeft: -512, -1536
+			BottomRight: 512, -512
 	Armor:
 		Type: wood
 	RevealsShroud:
@@ -893,6 +965,18 @@ research_centre:
 	Bib:
 	Health:
 		HP: 2500
+	HitShape:
+		UseOccupiedCellsOffsets: false
+		TargetableOffsets: 0,0,0, -1574,-158,0, 0,-1024,0, -1050,-1024,0, 0,1024,0, -1155,960,0
+		Type: Rectangle
+			TopLeft: -1536, -512
+			BottomRight: 1536, 1536
+	HitShape@TOP:
+		UseOccupiedCellsOffsets: false
+		TargetableOffsets: 1312,0,0
+		Type: Rectangle
+			TopLeft: -512, -1536
+			BottomRight: 512, -512
 	Armor:
 		Type: wood
 	RevealsShroud:
@@ -935,6 +1019,20 @@ palace:
 		HasMinibib: True
 	Health:
 		HP: 4000
+	HitShape:
+		Type: Rectangle
+			TopLeft: -1536, -512
+			BottomRight: 1536, 512
+	HitShape@TOP:
+		UseOccupiedCellsOffsets: false
+		Type: Rectangle
+			TopLeft: -1536, -1536
+			BottomRight: 512, -512
+	HitShape@BOTTOM:
+		UseOccupiedCellsOffsets: false
+		Type: Rectangle
+			TopLeft: -512, 512
+			BottomRight: 1536, 1536
 	Armor:
 		Type: wood
 	RevealsShroud:

--- a/mods/d2k/sequences/structures.yaml
+++ b/mods/d2k/sequences/structures.yaml
@@ -426,32 +426,28 @@ silo.atreides:
 		Offset: -30,-24
 
 hightech.atreides:
+	Defaults:
+		Offset: -48,84
 	idle: DATA.R8
 		Start: 2812
-		Offset: -48,80
 	make: DATA.R8
 		Start: 4538
 		Length: 10
-		Offset: -48,80
 	crumble-overlay: DATA.R8
 		Start: 4548
 		Length: 10
-		Offset: -48,80
 		Tick: 100
 	damaged-idle: DATA.R8
 		Start: 2813
-		Offset: -48,80
 	production-welding: DATA.R8
 		Start: 4878
 		Length: 10
-		Offset: -48,80
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
 	damaged-production-welding: DATA.R8
 		Frames: 4878, 4879, 4880, 4881, 4882, 4884, 4885, 4886, 4887
 		Length: 9
-		Offset: -48,80
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
@@ -937,25 +933,22 @@ silo.harkonnen:
 		Offset: -30,-24
 
 hightech.harkonnen:
+	Defaults:
+		Offset: -48,84
 	idle: DATA.R8
 		Start: 2972
-		Offset: -48,80
 	make: DATA.R8
 		Start: 4538
 		Length: 10
-		Offset: -48,80
 	crumble-overlay: DATA.R8
 		Start: 4548
 		Length: 10
-		Offset: -48,80
 		Tick: 100
 	damaged-idle: DATA.R8
 		Start: 2973
-		Offset: -48,80
 	production-welding: DATA.R8
 		Start: 4888
 		Length: 10
-		Offset: -48,80
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024
@@ -1343,25 +1336,22 @@ silo.ordos:
 		Offset: -30,-24
 
 hightech.ordos:
+	Defaults:
+		Offset: -48,84
 	idle: DATA.R8
 		Start: 3132
-		Offset: -48,80
 	make: DATA.R8
 		Start: 4538
 		Length: 10
-		Offset: -48,80
 	crumble-overlay: DATA.R8
 		Start: 4548
 		Length: 10
-		Offset: -48,80
 		Tick: 100
 	damaged-idle: DATA.R8
 		Start: 3133
-		Offset: -48,80
 	production-welding: DATA.R8
 		Start: 4898
 		Length: 10
-		Offset: -48,80
 		Tick: 200
 		BlendMode: Additive
 		ZOffset: 1024

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -201,6 +201,7 @@ TurretLaserFire:
 
 LaserFence:
 	Projectile: InstantHit
+		TargetCenterPosition: true
 	Warhead@1Dam: TargetDamage
 		DebugOverlayColor: FF0000
 		Damage: 99999

--- a/mods/ts/weapons/healweapons.yaml
+++ b/mods/ts/weapons/healweapons.yaml
@@ -4,6 +4,7 @@
 	Report: healer1.aud
 	ValidTargets: Infantry
 	Projectile: InstantHit
+		TargetCenterPosition: true
 	Warhead@1Dam: TargetDamage
 		DebugOverlayColor: 00FF00
 		Damage: -50


### PR DESCRIPTION
The discussion in #13165 leans towards footprint-based hit-shapes, so I've built on that plus the initial review feedback.
Rather than updating the old PR, I've decided to file this separately (mostly due to the branch name, but also to keep the discussion and actual reviewing a bit separate).

This is basically the spiritual successor to #10383 and actually scavenged some code from there.

The commit count makes this look more intimidating than it really is, only the first 3 commits contain code and the individual yaml commits are small.