### PR TITLE
Fix the harvesting sequence being invisible in TS

### DIFF
--- a/mods/ts/sequences/vehicles.yaml
+++ b/mods/ts/sequences/vehicles.yaml
@@ -21,6 +21,7 @@ harv.gdi:
 	harvest: harvestr
 		Length: *
 		ZRamp: 1
+		Offset: 0, 0, 3
 	icon: sidebar-gdi|harvicon
 
 harv.nod:
@@ -28,6 +29,7 @@ harv.nod:
 	harvest: harvestr
 		Length: *
 		ZRamp: 1
+		Offset: 0, 0, 3
 	icon: sidebar-nod|harvicon
 
 hvr:


### PR DESCRIPTION
Seems like it was missing since #11904.
With `5` as Offset.Z the overlay doesn't render below Tiberium, and also doesn't cover parts of the harvester.