### PR TITLE
Upgrade RejectsOrders

### DIFF
--- a/OpenRA.Mods.Common/Traits/RejectsOrders.cs
+++ b/OpenRA.Mods.Common/Traits/RejectsOrders.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -20,7 +21,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Explicit list of rejected orders. Leave empty to reject all minus those listed under Except.")]
 		public readonly HashSet<string> Reject = new HashSet<string>();
 
-		[Desc("List of orders that should *not* be rejected.")]
+		[Desc("List of orders that should *not* be rejected.",
+			"Also overrides other instances of this trait's Reject fields.")]
 		public readonly HashSet<string> Except = new HashSet<string>();
 
 		public override object Create(ActorInitializer init) { return new RejectsOrders(this); }
@@ -39,8 +41,8 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public static bool AcceptsOrder(this Actor self, string orderString)
 		{
-			var r = self.TraitOrDefault<RejectsOrders>();
-			return r == null || r.IsTraitDisabled || (r.Reject.Count > 0 && !r.Reject.Contains(orderString)) || r.Except.Contains(orderString);
+			var r = self.TraitsImplementing<RejectsOrders>().Where(Exts.IsTraitEnabled).ToList();
+			return !r.Any() || r.Any(t => t.Reject.Any() && !t.Reject.Contains(orderString)) || r.Any(t => t.Except.Contains(orderString));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/RejectsOrders.cs
+++ b/OpenRA.Mods.Common/Traits/RejectsOrders.cs
@@ -17,7 +17,10 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Can be used to make a unit partly uncontrollable by the player.")]
 	public class RejectsOrdersInfo : ConditionalTraitInfo
 	{
-		[Desc("Possible values include Attack, AttackMove, Guard, Move.")]
+		[Desc("Explicit list of rejected orders. Leave empty to reject all minus those listed under Except.")]
+		public readonly HashSet<string> Reject = new HashSet<string>();
+
+		[Desc("List of orders that should *not* be rejected.")]
 		public readonly HashSet<string> Except = new HashSet<string>();
 
 		public override object Create(ActorInitializer init) { return new RejectsOrders(this); }
@@ -25,6 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class RejectsOrders : ConditionalTrait<RejectsOrdersInfo>
 	{
+		public HashSet<string> Reject { get { return Info.Reject; } }
 		public HashSet<string> Except { get { return Info.Except; } }
 
 		public RejectsOrders(RejectsOrdersInfo info)
@@ -36,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 		public static bool AcceptsOrder(this Actor self, string orderString)
 		{
 			var r = self.TraitOrDefault<RejectsOrders>();
-			return r == null || r.IsTraitDisabled || r.Except.Contains(orderString);
+			return r == null || r.IsTraitDisabled || (r.Reject.Count > 0 && !r.Reject.Contains(orderString)) || r.Except.Contains(orderString);
 		}
 	}
 }


### PR DESCRIPTION
Adds explicit `Rejects` list and makes `RejectsOrders` multi-trait compatible.

Split from #12924.