### PR TITLE
Production-Exit types w/ Spawning LST outside of SPEN

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Buildings/ClonesProducedUnits.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ClonesProducedUnits.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
 		}
 
-		public void UnitProducedByOther(Actor self, Actor producer, Actor produced)
+		public void UnitProducedByOther(Actor self, Actor producer, Actor produced, string type)
 		{
 			// No recursive cloning!
 			if (producer.Owner != self.Owner || producer.Info.HasTraitInfo<ClonesProducedUnitsInfo>())
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (ci == null || !info.CloneableTypes.Overlaps(ci.Types))
 				return;
 
-			production.Produce(self, produced.Info, faction);
+			production.Produce(self, produced.Info, faction, type);
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Activities;
@@ -38,7 +37,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			this.info = info;
 		}
 
-		public override bool Produce(Actor self, ActorInfo producee, string factionVariant)
+		public override bool Produce(Actor self, ActorInfo producee, string factionVariant, string exitType)
 		{
 			var owner = self.Owner;
 			var aircraftInfo = self.World.Map.Rules.Actors[info.ActorType].TraitInfo<AircraftInfo>();
@@ -51,8 +50,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			var startPos = self.Location + new CVec(owner.World.Map.Bounds.Width, 0);
 			var endPos = new CPos(owner.World.Map.Bounds.Left - 2 * landDistance / 1024, self.Location.Y);
 
-			// Assume a single exit point for simplicity
-			var exit = self.Info.TraitInfos<ExitInfo>().First();
+			var exit = SelectExit(self, producee, exitType);
 
 			foreach (var tower in self.TraitsImplementing<INotifyDelivery>())
 				tower.IncomingDelivery(self);
@@ -79,7 +77,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					foreach (var cargo in self.TraitsImplementing<INotifyDelivery>())
 						cargo.Delivered(self);
 
-					self.World.AddFrameEndTask(ww => DoProduction(self, producee, exit, factionVariant));
+					self.World.AddFrameEndTask(ww => DoProduction(self, producee, exit, factionVariant, exitType));
 					Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.ReadyAudio, self.Owner.Faction.InternalName);
 				}));
 

--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.Activities
 				}
 			}
 
-			var exit = dest.Info.TraitInfos<ExitInfo>().FirstOrDefault();
+			var exit = dest.Info.FirstExitOrDefault(heli.Info.LandingExitType);
 			var offset = (exit != null) ? exit.SpawnOffset : WVec.Zero;
 
 			if (ShouldLandAtBuilding(self, dest))

--- a/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
@@ -32,14 +32,15 @@ namespace OpenRA.Mods.Common.Scripting
 		}
 
 		[ScriptActorPropertyActivity]
-		[Desc("Build a unit, ignoring the production queue. The activity will wait if the exit is blocked.")]
-		public void Produce(string actorType, string factionVariant = null)
+		[Desc("Build a unit, ignoring the production queue. The activity will wait if the exit is blocked.",
+			"If exitType is nil or unavailable, then an exit will be selected based on Buildable info.")]
+		public void Produce(string actorType, string factionVariant = null, string exitType = null)
 		{
 			ActorInfo actorInfo;
 			if (!Self.World.Map.Rules.Actors.TryGetValue(actorType, out actorInfo))
 				throw new LuaException("Unknown actor type '{0}'".F(actorType));
 
-			Self.QueueActivity(new WaitFor(() => p.Produce(Self, actorInfo, factionVariant)));
+			Self.QueueActivity(new WaitFor(() => p.Produce(Self, actorInfo, factionVariant, exitType)));
 		}
 	}
 

--- a/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
+++ b/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
@@ -404,7 +404,7 @@ namespace OpenRA.Mods.Common.Scripting
 			}
 		}
 
-		public void UnitProducedByOther(Actor self, Actor producee, Actor produced)
+		public void UnitProducedByOther(Actor self, Actor producee, Actor produced, string type)
 		{
 			if (world.Disposing)
 				return;

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -92,6 +92,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The number of ticks that a airplane will wait to make a new search for an available airport.")]
 		public readonly int NumberOfTicksToVerifyAvailableAirport = 150;
 
+		[Desc("Type of exit used for landing at building.")]
+		public readonly string LandingExitType = null;
+
 		public IReadOnlyDictionary<CPos, SubCell> OccupiedCells(ActorInfo info, CPos location, SubCell subCell = SubCell.Any) { return new ReadOnlyDictionary<CPos, SubCell>(); }
 		bool IOccupySpaceInfo.SharesCell { get { return false; } }
 
@@ -624,7 +627,7 @@ namespace OpenRA.Mods.Common.Traits
 
 						Action enter = () =>
 						{
-							var exit = order.TargetActor.Info.TraitInfos<ExitInfo>().FirstOrDefault();
+							var exit = order.TargetActor.Info.FirstExitOrDefault(Info.LandingExitType);
 							var offset = (exit != null) ? exit.SpawnOffset : WVec.Zero;
 
 							self.QueueActivity(new HeliFly(self, Target.FromPos(order.TargetActor.CenterPosition + offset)));

--- a/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
@@ -9,6 +9,9 @@
  */
 #endregion
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -23,6 +26,9 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly CVec ExitCell = CVec.Zero;
 		public readonly int Facing = -1;
 
+		[Desc("Type tags on this exit.")]
+		public readonly HashSet<string> Types = new HashSet<string>();
+
 		[Desc("AttackMove to a RallyPoint or stay where you are spawned.")]
 		public readonly bool MoveIntoWorld = true;
 
@@ -31,4 +37,40 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public class Exit { }
+
+	public static class ExitExts
+	{
+		public static int CountExits(this ActorInfo info, string type = null)
+		{
+			var all = info.TraitInfos<ExitInfo>();
+			return type == null ? all.Count(e => e.Types.Count == 0) : all.Count(e => e.Types.Contains(type));
+		}
+
+		public static ExitInfo FirstExitOrDefault(this ActorInfo info, string type = null)
+		{
+			var all = info.TraitInfos<ExitInfo>();
+			return type == null ? all.FirstOrDefault(e => e.Types.Count == 0) : all.FirstOrDefault(e => e.Types.Contains(type));
+		}
+
+		public static IEnumerable<ExitInfo> Exits(this ActorInfo info, string type = null)
+		{
+			var all = info.TraitInfos<ExitInfo>();
+			return type == null ? all.Where(e => e.Types.Count == 0) : all.Where(e => e.Types.Contains(type));
+		}
+
+		public static ExitInfo RandomExitOrDefault(this ActorInfo info, World world, string type, Func<ExitInfo, bool> p = null)
+		{
+			var allOfType = Exits(info, type);
+			if (!allOfType.Any())
+				return null;
+
+			var shuffled = allOfType.Shuffle(world.SharedRandom);
+			return p != null ? shuffled.FirstOrDefault(p) : shuffled.First();
+		}
+
+		public static ExitInfo RandomExitOrDefault(this Actor self, string type, Func<ExitInfo, bool> p = null)
+		{
+			return RandomExitOrDefault(self.Info, self.World, type, p);
+		}
+	}
 }

--- a/OpenRA.Mods.Common/Traits/Conditions/ProximityExternalCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ProximityExternalCondition.cs
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Traits
 				tokens[a] = external.GrantCondition(a, self);
 		}
 
-		public void UnitProducedByOther(Actor self, Actor producer, Actor produced)
+		public void UnitProducedByOther(Actor self, Actor producer, Actor produced, string type)
 		{
 			// If the produced Actor doesn't occupy space, it can't be in range
 			if (produced.OccupiesSpace == null)

--- a/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var p in producers.Where(p => !p.Actor.IsDisabled()))
 			{
-				if (p.Trait.Produce(p.Actor, unit, p.Trait.Faction))
+				if (p.Trait.Produce(p.Actor, unit, p.Trait.Faction, Info.Type))
 				{
 					FinishProduction();
 					return true;

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -377,7 +377,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			var sp = self.TraitsImplementing<Production>().FirstOrDefault(p => p.Info.Produces.Contains(Info.Type));
-			if (sp != null && !self.IsDisabled() && sp.Produce(self, unit, Faction))
+			if (sp != null && !self.IsDisabled() && sp.Produce(self, unit, Faction, developerMode.AllTech ? null : Info.Type))
 			{
 				FinishProduction();
 				return true;

--- a/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Drawing;
-using OpenRA;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -41,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 			rp = self.TraitOrDefault<RallyPoint>();
 		}
 
-		public override bool Produce(Actor self, ActorInfo producee, string factionVariant)
+		public override bool Produce(Actor self, ActorInfo producee, string factionVariant, string exitType)
 		{
 			var aircraftInfo = producee.TraitInfoOrDefault<AircraftInfo>();
 			var mobileInfo = producee.TraitInfoOrDefault<MobileInfo>();
@@ -99,7 +98,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				var notifyOthers = self.World.ActorsWithTrait<INotifyOtherProduction>();
 				foreach (var notify in notifyOthers)
-					notify.Trait.UnitProducedByOther(notify.Actor, self, newUnit);
+					notify.Trait.UnitProducedByOther(notify.Actor, self, newUnit, exitType);
 
 				foreach (var t in newUnit.TraitsImplementing<INotifyBuildComplete>())
 					t.BuildingComplete(newUnit);

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Drawing;
-using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Primitives;
@@ -44,16 +43,15 @@ namespace OpenRA.Mods.Common.Traits
 			rp = Exts.Lazy(() => init.Self.IsDead ? null : init.Self.TraitOrDefault<RallyPoint>());
 		}
 
-		public override bool Produce(Actor self, ActorInfo producee, string factionVariant)
+		public override bool Produce(Actor self, ActorInfo producee, string factionVariant, string exitType)
 		{
 			var owner = self.Owner;
 
-			// Assume a single exit point for simplicity
-			var exit = self.Info.TraitInfos<ExitInfo>().First();
+			var exit = SelectExit(self, producee, exitType);
 
 			// Start a fixed distance away: the width of the map.
 			// This makes the production timing independent of spawnpoint
-			var dropPos = self.Location + exit.ExitCell;
+			var dropPos = exit != null ? self.Location + exit.ExitCell : self.Location;
 			var startPos = dropPos + new CVec(owner.World.Map.Bounds.Width, 0);
 			var endPos = new CPos(owner.World.Map.Bounds.Left - 5, dropPos.Y);
 
@@ -85,7 +83,7 @@ namespace OpenRA.Mods.Common.Traits
 					foreach (var cargo in self.TraitsImplementing<INotifyDelivery>())
 						cargo.Delivered(self);
 
-					self.World.AddFrameEndTask(ww => DoProduction(self, producee, exit, factionVariant));
+					self.World.AddFrameEndTask(ww => DoProduction(self, producee, exit, factionVariant, exitType));
 					Game.Sound.Play(SoundType.World, info.ChuteSound, self.CenterPosition);
 					Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.ReadyAudio, self.Owner.Faction.InternalName);
 				}));
@@ -97,7 +95,7 @@ namespace OpenRA.Mods.Common.Traits
 			return true;
 		}
 
-		public override void DoProduction(Actor self, ActorInfo producee, ExitInfo exitinfo, string factionVariant)
+		public override void DoProduction(Actor self, ActorInfo producee, ExitInfo exitinfo, string factionVariant, string type)
 		{
 			var exit = CPos.Zero;
 			var exitLocation = CPos.Zero;
@@ -161,7 +159,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				var notifyOthers = self.World.ActorsWithTrait<INotifyOtherProduction>();
 				foreach (var notify in notifyOthers)
-					notify.Trait.UnitProducedByOther(notify.Actor, self, newUnit);
+					notify.Trait.UnitProducedByOther(notify.Actor, self, newUnit, type);
 
 				foreach (var t in newUnit.TraitsImplementing<INotifyBuildComplete>())
 					t.BuildingComplete(newUnit);

--- a/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (sp != null)
 				foreach (var name in info.Actors)
-					activated |= sp.Produce(self, self.World.Map.Rules.Actors[name], faction);
+					activated |= sp.Produce(self, self.World.Map.Rules.Actors[name], faction, info.Type);
 
 			if (activated)
 				Game.Sound.PlayNotification(self.World.Map.Rules, manager.Self.Owner, "Speech", info.ReadyAudio, self.Owner.Faction.InternalName);

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Traits
 	public interface INotifyBurstComplete { void FiredBurst(Actor self, Target target, Armament a); }
 	public interface INotifyChat { bool OnChat(string from, string message); }
 	public interface INotifyProduction { void UnitProduced(Actor self, Actor other, CPos exit); }
-	public interface INotifyOtherProduction { void UnitProducedByOther(Actor self, Actor producer, Actor produced); }
+	public interface INotifyOtherProduction { void UnitProducedByOther(Actor self, Actor producer, Actor produced, string type); }
 	public interface INotifyDelivery { void IncomingDelivery(Actor self); void Delivered(Actor self); }
 	public interface INotifyDocking { void Docked(Actor self, Actor harvester); void Undocked(Actor self, Actor harvester); }
 	public interface INotifyParachute { void OnParachute(Actor self); void OnLanded(Actor self, Actor ignore); }

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -248,9 +248,11 @@ PYLE:
 	Exit@1:
 		SpawnOffset: -426,85,0
 		ExitCell: 0,1
+		Type: Infantry.GDI
 	Exit@2:
 		SpawnOffset: 298,298,0
 		ExitCell: 1,1
+		Type: Infantry.GDI
 	Production:
 		Produces: Infantry.GDI
 	ProductionQueue:
@@ -291,6 +293,7 @@ HAND:
 	Exit@1:
 		SpawnOffset: 512,1024,0
 		ExitCell: 1,2
+		Type: Infantry.Nod
 	Production:
 		Produces: Infantry.Nod
 	ProductionQueue:
@@ -335,6 +338,7 @@ AFLD:
 	Exit@1:
 		SpawnOffset: -1024,0,0
 		ExitCell: 3,1
+		Type: Vehicle.Nod
 	ProductionAirdrop:
 		Produces: Vehicle.Nod
 	WithDeliveryAnimation:
@@ -382,6 +386,7 @@ WEAP:
 		SpawnOffset: -512,-512,0
 		ExitCell: 0,1
 		ExitDelay: 3
+		Type: Vehicle.GDI
 	Production:
 		Produces: Vehicle.GDI
 	ProductionQueue:
@@ -414,6 +419,7 @@ HPAD:
 		Range: 5c0
 	Exit@1:
 		SpawnOffset: 0,-256,0
+		Type: Aircraft.GDI, Aircraft.Nod
 	Production:
 		Produces: Aircraft.GDI, Aircraft.Nod
 	Reservable:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -180,9 +180,11 @@ barracks:
 	Exit@1:
 		SpawnOffset: 352,576,0
 		ExitCell: 0,2
+		Type: Infantry
 	Exit@2:
 		SpawnOffset: 512,480,0
 		ExitCell: 1,2
+		Type: Infantry
 	Production:
 		Produces: Infantry
 	PrimaryBuilding:
@@ -363,6 +365,7 @@ light_factory:
 	Exit@1:
 		SpawnOffset: 544,-224,0
 		ExitCell: 2,1
+		Type: Vehicle
 	Production:
 		Produces: Vehicle
 	PrimaryBuilding:
@@ -434,6 +437,7 @@ heavy_factory:
 	Exit@1:
 		SpawnOffset: 256,192,0
 		ExitCell: 0,2
+		Type: Armor
 	Production:
 		Produces: Armor
 	PrimaryBuilding:
@@ -565,9 +569,11 @@ starport:
 	Exit@1:
 		SpawnOffset: 0,-480,0
 		ExitCell: 2,2
+		Type: Starport
 	Exit@2:
 		SpawnOffset: 0,-480,0
 		ExitCell: 0,2
+		Type: Starport
 	ProductionAirdrop:
 		Produces: Starport
 		ActorType: frigate
@@ -812,6 +818,7 @@ high_tech_factory:
 	Exit:
 		SpawnOffset: 0,0,728
 		ExitCell: 0,0
+		Type: Aircraft
 	Building:
 		Footprint: _x_ xxx xxx
 		Dimensions: 3,3
@@ -991,12 +998,15 @@ palace:
 	Exit@1:
 		SpawnOffset: -704,768,0
 		ExitCell: -1,2
+		Type: Palace
 	Exit@2:
 		SpawnOffset: -704,768,0
 		ExitCell: -1,3
+		Type: Palace
 	Exit@3:
 		SpawnOffset: -704,768,0
 		ExitCell: 0,3
+		Type: Palace
 	Production:
 		Produces: Palace
 	CanPowerDown:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -430,6 +430,7 @@
 		RepairBuildings: fix
 		RearmBuildings: afld
 		AirborneCondition: airborne
+		LandingExitType: Helicopter
 	Targetable@GROUND:
 		TargetTypes: Ground, Repair, Vehicle
 		RequiresCondition: !airborne
@@ -476,6 +477,7 @@
 		RearmBuildings: hpad
 		CanHover: True
 		CruisingCondition: cruising
+		LandingExitType: Helicopter
 	GpsDot:
 		String: Helicopter
 	Hovers@CRUISING:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -127,18 +127,42 @@ SPEN:
 		SpawnOffset: 0,-213,0
 		Facing: 96
 		ExitCell: -1,2
+		Types: Submarine
 	Exit@2:
 		SpawnOffset: 0,-213,0
 		Facing: 160
 		ExitCell: 3,2
+		Types: Submarine
 	Exit@3:
 		SpawnOffset: 0,0,0
 		Facing: 32
 		ExitCell: 0,0
+		Types: Submarine
 	Exit@4:
 		SpawnOffset: 0,0,0
 		Facing: 224
 		ExitCell: 2,0
+		Types: Submarine
+	Exit@b1:
+		SpawnOffset: -1024,1024,0
+		Facing: 160
+		ExitCell: 0,2
+		Types: Ship
+	Exit@b2:
+		SpawnOffset: 1024,1024,0
+		Facing: 224
+		ExitCell: 2,2
+		Types: Ship
+	Exit@b3:
+		SpawnOffset: -1024,-1024,0
+		Facing: 96
+		ExitCell: 0,0
+		Types: Ship
+	Exit@b4:
+		SpawnOffset: 1024,-1024,0
+		Facing: 32
+		ExitCell: 2,0
+		Types: Ship
 	Production:
 		Produces: Ship, Submarine
 	PrimaryBuilding:
@@ -217,18 +241,22 @@ SYRD:
 		SpawnOffset: -1024,1024,0
 		Facing: 160
 		ExitCell: 0,2
+		Types: Ship
 	Exit@2:
 		SpawnOffset: 1024,1024,0
 		Facing: 224
 		ExitCell: 2,2
+		Types: Ship
 	Exit@3:
 		SpawnOffset: -1024,-1024,0
 		Facing: 96
 		ExitCell: 0,0
+		Types: Ship
 	Exit@4:
 		SpawnOffset: 1024,-1024,0
 		Facing: 32
 		ExitCell: 2,0
+		Types: Ship
 	Production:
 		Produces: Ship, Boat
 	PrimaryBuilding:
@@ -852,6 +880,7 @@ WEAP:
 	Exit@1:
 		SpawnOffset: 213,-128,0
 		ExitCell: 1,2
+		Types: Vehicle
 	Production:
 		Produces: Vehicle
 	ProvidesPrerequisite@allies:
@@ -1119,6 +1148,7 @@ HPAD:
 		ExitCell: 0,0
 		MoveIntoWorld: false
 		Facing: 224
+		Types: Helicopter, Aircraft
 	RallyPoint:
 	Production:
 		Produces: Aircraft, Helicopter
@@ -1199,6 +1229,7 @@ AFLD:
 		ExitCell: 1,1
 		Facing: 192
 		MoveIntoWorld: false
+		Types: Plane, Aircraft
 	RallyPoint:
 	Production:
 		Produces: Aircraft, Plane
@@ -1430,9 +1461,11 @@ BARR:
 	Exit@1:
 		SpawnOffset: -170,810,0
 		ExitCell: 1,2
+		Types: Soldier, Infantry
 	Exit@2:
 		SpawnOffset: -725,640,0
 		ExitCell: 0,2
+		Types: Soldier, Infantry
 	Production:
 		Produces: Infantry, Soldier
 	PrimaryBuilding:
@@ -1505,9 +1538,11 @@ KENN:
 	Exit@1:
 		SpawnOffset: -280,400,0
 		ExitCell: 0,1
+		Types: Dog, Infantry
 	Exit@2:
 		SpawnOffset: -280,400,0
 		ExitCell: -1,0
+		Types: Dog, Infantry
 	Production:
 		Produces: Infantry, Dog
 	PrimaryBuilding:
@@ -1553,9 +1588,11 @@ TENT:
 	Exit@1:
 		SpawnOffset: -42,810,0
 		ExitCell: 1,2
+		Types: Soldier, Infantry
 	Exit@2:
 		SpawnOffset: -725,640,0
 		ExitCell: 0,2
+		Types: Soldier, Infantry
 	Production:
 		Produces: Infantry, Soldier
 	PrimaryBuilding:

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -92,6 +92,7 @@ GAPILE:
 	Exit@1:
 		SpawnOffset: -256,1024,0
 		ExitCell: 2,2
+		Type: Infantry
 	ExitsDebugOverlay:
 	Production:
 		Produces: Infantry
@@ -150,6 +151,7 @@ GAWEAP:
 		SpawnOffset: -384,-384,0
 		ExitCell: 3,1
 		ExitDelay: 5
+		Type: Vehicle
 	ExitsDebugOverlay:
 	Production:
 		Produces: Vehicle
@@ -201,6 +203,7 @@ GAHPAD:
 		MaxHeightDelta: 3
 	Exit@1:
 		SpawnOffset: 0,-256,0
+		Type: Air
 	ExitsDebugOverlay:
 	RallyPoint:
 		Palette: mouse
@@ -429,6 +432,7 @@ GAPLUG:
 	Production:
 		Produces: HunterSeeker
 	Exit@1:
+		Type: HunterSeeker
 	ExitsDebugOverlay:
 	SupportPowerChargeBar:
 	Power:

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -105,6 +105,7 @@ NAHAND:
 	Exit@1:
 		SpawnOffset: 384,768,0
 		ExitCell: 3,2
+		Type: Infantry
 	ExitsDebugOverlay:
 	RallyPoint:
 		Offset: 3,3
@@ -165,6 +166,7 @@ NAWEAP:
 		SpawnOffset: -384,-384,0
 		ExitCell: 3,1
 		ExitDelay: 5
+		Type: Vehicle
 	ExitsDebugOverlay:
 	Production:
 		Produces: Vehicle
@@ -212,6 +214,7 @@ NAHPAD:
 		MaxHeightDelta: 3
 	Exit@1:
 		SpawnOffset: 0,-256,0
+		Type: Air
 	ExitsDebugOverlay:
 	RallyPoint:
 		Palette: mouse
@@ -368,4 +371,5 @@ NATMPL:
 	Production:
 		Produces: HunterSeeker
 	Exit@1:
+		Type: HunterSeeker
 	ExitsDebugOverlay:


### PR DESCRIPTION
Transport (and boats with the cheat) spawn outside of the submarine pen. I plan on using `ExitInfo.Type` in `Targetable` as a source of targetable positions for matching targeting type(s) for enter activities while other traits such as possibly `Building`, possibly `TargetablePositions`, and/or possibly `Health` provide targetable positions for attack activities, etc.