### PR TITLE
Fix Player Earnings - building cancellation/selling

### DIFF
--- a/OpenRA.Game/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Game/Traits/Player/PlayerResources.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Traits
 			return true;
 		}
 
-		public void GiveCash(int num)
+		public void GiveCash(int num, bool isRefund = false)
 		{
 			if (Cash < int.MaxValue)
 			{
@@ -113,7 +113,9 @@ namespace OpenRA.Traits
 				}
 			}
 
-			if (Earned < int.MaxValue)
+			if (isRefund)
+				Spent -= num;
+			else if (Earned < int.MaxValue)
 			{
 				try
 				{

--- a/OpenRA.Mods.Common/Activities/Sell.cs
+++ b/OpenRA.Mods.Common/Activities/Sell.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Activities
 			var cost = self.GetSellValue();
 
 			var refund = (cost * sellableInfo.RefundPercent * (health == null ? 1 : health.HP)) / (100 * (health == null ? 1 : health.MaxHP));
-			playerResources.GiveCash(refund);
+			playerResources.GiveCash(refund, true);
 
 			foreach (var ns in self.TraitsImplementing<INotifySold>())
 				ns.Sold(self);

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			// Refund the current item
-			playerResources.GiveCash(queue[0].TotalCost - queue[0].RemainingCost);
+			playerResources.GiveCash(queue[0].TotalCost - queue[0].RemainingCost, true);
 			queue.Clear();
 		}
 
@@ -234,7 +234,7 @@ namespace OpenRA.Mods.Common.Traits
 			while (queue.Count > 0 && BuildableItems().All(b => b.Name != queue[0].Item))
 			{
 				// Refund what's been paid so far
-				playerResources.GiveCash(queue[0].TotalCost - queue[0].RemainingCost);
+				playerResources.GiveCash(queue[0].TotalCost - queue[0].RemainingCost, true);
 				FinishProduction();
 			}
 
@@ -342,7 +342,7 @@ namespace OpenRA.Mods.Common.Traits
 				var item = queue[0];
 
 				// Refund what has been paid
-				playerResources.GiveCash(item.TotalCost - item.RemainingCost);
+				playerResources.GiveCash(item.TotalCost - item.RemainingCost, true);
 				FinishProduction();
 			}
 		}


### PR DESCRIPTION
Fixes #13212.
Building cancellation/selling doesn't increase player earnings.