### PR TITLE
Fix jumpjet flying death animations

### DIFF
--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -165,6 +165,17 @@ JUMPJET.Husk:
 	AutoSelectionSize:
 	WithSpriteBody:
 		Sequence: die-falling
+	Health:
+	ConditionManager:
+	GrantConditionOnTerrain:
+		TerrainTypes: Water
+		Condition: water-death
+	WithDeathAnimation:
+		RequiresCondition: !water-death
+		FallbackSequence: die-flying
+	WithDeathAnimation@SPLASH:
+		RequiresCondition: water-death
+		FallbackSequence: die-splash
 
 GHOST:
 	Inherits: ^Soldier

--- a/mods/ts/sequences/infantry.yaml
+++ b/mods/ts/sequences/infantry.yaml
@@ -375,6 +375,8 @@ jumpjet:
 		Start: 445
 		Length: 6
 		ShadowStart: 896
+	die-splash: h2o_exp2
+		Length: *
 	die-exploding: s_bang34
 		Length: *
 	die-crushed:


### PR DESCRIPTION
This fixes a regression from #12999 (Jumpjet husks didn't have the `Health` trait, so it span forever) and hooks up the splat/spash animations when it hits the ground.