### PR TITLE
Fix RangeMultiplier regression.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Multipliers/RangeMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/RangeMultiplier.cs
@@ -12,20 +12,22 @@
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Modifies the range of weapons fired by this actor.")]
-	public class RangeMultiplierInfo : ConditionalTraitInfo
+	public class RangeMultiplierInfo : ConditionalTraitInfo, IRangeModifierInfo
 	{
 		[FieldLoader.Require]
 		[Desc("Percentage modifier to apply.")]
 		public readonly int Modifier = 100;
 
 		public override object Create(ActorInitializer init) { return new RangeMultiplier(this); }
+
+		int IRangeModifierInfo.GetRangeModifierDefault() { return EnabledByDefault ? Modifier : 100; }
 	}
 
-	public class RangeMultiplier : ConditionalTrait<RangeMultiplierInfo>, IRangeModifierInfo
+	public class RangeMultiplier : ConditionalTrait<RangeMultiplierInfo>, IRangeModifier
 	{
 		public RangeMultiplier(RangeMultiplierInfo info)
 			: base(info) { }
 
-		int IRangeModifierInfo.GetRangeModifierDefault() { return IsTraitDisabled ? 100 : Info.Modifier; }
+		int IRangeModifier.GetRangeModifier() { return IsTraitDisabled ? 100 : Info.Modifier; }
 	}
 }


### PR DESCRIPTION
The Default suffix was incosistent with the others and wasn't applied everywhere - case in point https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Traits/Armament.cs#L149 - which made it broken.