### PR TITLE
Number AI players

### DIFF
--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -105,7 +105,14 @@ namespace OpenRA
 			{
 				ClientIndex = client.Index;
 				Color = client.Color;
-				PlayerName = client.Name;
+				if (client.Bot != null)
+				{
+					var botsOfSameType = world.LobbyInfo.Clients.Where(c => c.Bot == client.Bot).ToArray();
+					PlayerName = botsOfSameType.Length == 1 ? client.Bot : "{0} {1}".F(client.Bot, botsOfSameType.IndexOf(client) + 1);
+				}
+				else
+					PlayerName = client.Name;
+
 				botType = client.Bot;
 				Faction = ChooseFaction(world, client.Faction, !pr.LockFaction);
 				DisplayFaction = ChooseDisplayFaction(world, client.Faction);


### PR DESCRIPTION
Closes #7027.

e.g. AIs ~~'Rush AI n' (slot position)~~ in observer panel (visible also in ~~lobby,~~ tooltips, chat...):

Updated:
![obrazok](https://cloud.githubusercontent.com/assets/16348750/25674739/48f6708c-303c-11e7-9b23-c82146945598.png)



