### PR TITLE
Add FlyCircleOnIdle Aircraft trait

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -258,6 +258,7 @@
     <Compile Include="Traits\Air\AttackPlane.cs" />
     <Compile Include="Traits\Air\FlyAwayOnIdle.cs" />
     <Compile Include="Traits\Air\FallsToEarth.cs" />
+    <Compile Include="Traits\Air\FlyCircleOnIdle.cs" />
     <Compile Include="Traits\Air\ReturnOnIdle.cs" />
     <Compile Include="Traits\Armament.cs" />
     <Compile Include="Traits\Armor.cs" />

--- a/OpenRA.Mods.Common/Traits/Air/FlyCircleOnIdle.cs
+++ b/OpenRA.Mods.Common/Traits/Air/FlyCircleOnIdle.cs
@@ -1,0 +1,41 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Fly in circle while idle (on stop,..).")]
+	public class FlyCircleOnIdleInfo : ITraitInfo, Requires<AircraftInfo>
+	{
+		public object Create(ActorInitializer init) { return new FlyCircleOnIdle(init.Self, this); }
+	}
+
+	public class FlyCircleOnIdle : INotifyIdle
+	{
+		readonly AircraftInfo aircraftInfo;
+
+		public FlyCircleOnIdle(Actor self, FlyCircleOnIdleInfo info)
+		{
+			aircraftInfo = self.Info.TraitInfo<AircraftInfo>();
+		}
+
+		public void TickIdle(Actor self)
+		{
+			// We're on the ground, let's stay there.
+			if (self.World.Map.DistanceAboveTerrain(self.CenterPosition).Length < aircraftInfo.MinAirborneAltitude)
+				return;
+
+			self.QueueActivity(new FlyCircle(self));
+		}
+	}
+}


### PR DESCRIPTION
Add FlyCirleOnIdle trait (FlyCirle activity) - the same activity used by Move order when they reach destination

~~Replaced ReturnOnIdle (in RA only atm) by FlyCirleOnIdle trait (FlyCirle activity) - the same activity used by Move order when they reach destination. ReturnOnIdle seems useless, because planes are ordered explicitly to return on "RetunToBase"(F key) or out of ammo, they don't return based on ReturnOnIdle trait. It was used only on a Cancel order (like Stop) where in fact it is wrong.~~