### PR TITLE
Rescale isometric world coordinates to measure 1024 along the cell axes.

### DIFF
--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -24,6 +24,7 @@ namespace OpenRA.Graphics
 			r => ZPosition(r.Pos, r.ZOffset);
 
 		public readonly Size TileSize;
+		public readonly int TileScale;
 		public readonly World World;
 		public readonly Theater Theater;
 		public Viewport Viewport { get; private set; }
@@ -41,6 +42,7 @@ namespace OpenRA.Graphics
 		{
 			World = world;
 			TileSize = World.Map.Grid.TileSize;
+			TileScale = World.Map.Grid.Type == MapGridType.RectangularIsometric ? 1448 : 1024;
 			Viewport = new Viewport(this, world.Map);
 
 			createPaletteReference = CreatePaletteReference;
@@ -216,13 +218,13 @@ namespace OpenRA.Graphics
 		// Conversion between world and screen coordinates
 		public float2 ScreenPosition(WPos pos)
 		{
-			return new float2(TileSize.Width * pos.X / 1024f, TileSize.Height * (pos.Y - pos.Z) / 1024f);
+			return new float2((float)TileSize.Width * pos.X / TileScale, (float)TileSize.Height * (pos.Y - pos.Z) / TileScale);
 		}
 
 		public float3 Screen3DPosition(WPos pos)
 		{
-			var z = ZPosition(pos, 0) * TileSize.Height / 1024f;
-			return new float3(TileSize.Width * pos.X / 1024f, TileSize.Height * (pos.Y - pos.Z) / 1024f, z);
+			var z = ZPosition(pos, 0) * (float)TileSize.Height / TileScale;
+			return new float3((float)TileSize.Width * pos.X / TileScale, (float)TileSize.Height * (pos.Y - pos.Z) / TileScale, z);
 		}
 
 		public int2 ScreenPxPosition(WPos pos)
@@ -243,9 +245,9 @@ namespace OpenRA.Graphics
 		public float3 ScreenVectorComponents(WVec vec)
 		{
 			return new float3(
-				TileSize.Width * vec.X / 1024f,
-				TileSize.Height * (vec.Y - vec.Z) / 1024f,
-				TileSize.Height * vec.Z / 1024f);
+				(float)TileSize.Width * vec.X / TileScale,
+				(float)TileSize.Height * (vec.Y - vec.Z) / TileScale,
+				(float)TileSize.Height * vec.Z / TileScale);
 		}
 
 		// For scaling vectors to pixel sizes in the voxel renderer
@@ -264,7 +266,7 @@ namespace OpenRA.Graphics
 
 		public float ScreenZPosition(WPos pos, int offset)
 		{
-			return ZPosition(pos, offset) * TileSize.Height / 1024f;
+			return ZPosition(pos, offset) * (float)TileSize.Height / TileScale;
 		}
 
 		static int ZPosition(WPos pos, int offset)
@@ -278,7 +280,7 @@ namespace OpenRA.Graphics
 		/// </summary>
 		public WPos ProjectedPosition(int2 screenPx)
 		{
-			return new WPos(1024 * screenPx.X / TileSize.Width, 1024 * screenPx.Y / TileSize.Height, 0);
+			return new WPos(TileScale * screenPx.X / TileSize.Width, TileScale * screenPx.Y / TileSize.Height, 0);
 		}
 
 		public void Dispose()

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -761,8 +761,11 @@ namespace OpenRA
 			// (b) Therefore:
 			//  - ax + by adds (a - b) * 512 + 512 to u
 			//  - ax + by adds (a + b) * 512 + 512 to v
-			var z = Height.Contains(cell) ? 512 * Height[cell] : 0;
-			return new WPos(512 * (cell.X - cell.Y + 1), 512 * (cell.X + cell.Y + 1), z);
+			// (c) u, v coordinates run diagonally to the cell axes, and we define
+			//     1024 as the length projected onto the primary cell axis
+			//  - 512 * sqrt(2) = 724
+			var z = Height.Contains(cell) ? 724 * Height[cell] : 0;
+			return new WPos(724 * (cell.X - cell.Y + 1), 724 * (cell.X + cell.Y + 1), z);
 		}
 
 		public WPos CenterOfSubCell(CPos cell, SubCell subCell)
@@ -786,15 +789,15 @@ namespace OpenRA
 				return new CPos(pos.X / 1024, pos.Y / 1024);
 
 			// Convert from world position to isometric cell position:
-			// (a) Subtract (512, 512) to move the rotation center to the middle of the corner cell
-			// (b) Rotate axes by -pi/4
-			// (c) Divide through by sqrt(2) to bring us to an equivalent world pos aligned with u,v axes
-			// (d) Apply an offset so that the integer division by 1024 rounds in the right direction:
-			//      (i) u is always positive, so add 512 (which then partially cancels the -1024 term from the rotation)
-			//     (ii) v can be negative, so we need to be careful about rounding directions.  We add 512 *away from 0* (negative if y > x).
-			// (e) Divide by 1024 to bring into cell coords.
-			var u = (pos.Y + pos.X - 512) / 1024;
-			var v = (pos.Y - pos.X + (pos.Y > pos.X ? 512 : -512)) / 1024;
+			// (a) Subtract ([1/2 cell], [1/2 cell]) to move the rotation center to the middle of the corner cell
+			// (b) Rotate axes by -pi/4 to align the world axes with the cell axes
+			// (c) Apply an offset so that the integer division by [1 cell] rounds in the right direction:
+			//      (i) u is always positive, so add [1/2 cell] (which then partially cancels the -[1 cell] term from the rotation)
+			//     (ii) v can be negative, so we need to be careful about rounding directions.  We add [1/2 cell] *away from 0* (negative if y > x).
+			// (e) Divide by [1 cell] to bring into cell coords.
+			// The world axes are rotated relative to the cell axes, so the standard cell size (1024) is increased by a factor of sqrt(2)
+			var u = (pos.Y + pos.X - 724) / 1448;
+			var v = (pos.Y - pos.X + (pos.Y > pos.X ? 724 : -724)) / 1448;
 			return new CPos(u, v);
 		}
 
@@ -868,19 +871,19 @@ namespace OpenRA
 			Bounds = Rectangle.FromLTRB(tl.U, tl.V, br.U + 1, br.V + 1);
 
 			// Directly calculate the projected map corners in world units avoiding unnecessary
-			// conversions.  This abuses the definition that the width of the cell is always
-			// 1024 units, and that the height of two rows is 2048 for classic cells and 1024
+			// conversions.  This abuses the definition that the width of the cell along the x world axis
+			// is always 1024 or 1448 units, and that the height of two rows is 2048 for classic cells and 724
 			// for isometric cells.
-			var wtop = tl.V * 1024;
-			var wbottom = (br.V + 1) * 1024;
 			if (Grid.Type == MapGridType.RectangularIsometric)
 			{
-				wtop /= 2;
-				wbottom /= 2;
+				ProjectedTopLeft = new WPos(tl.U * 1448, tl.V * 724, 0);
+				ProjectedBottomRight = new WPos(br.U * 1448 - 1, (br.V + 1) * 724 - 1, 0);
 			}
-
-			ProjectedTopLeft = new WPos(tl.U * 1024, wtop, 0);
-			ProjectedBottomRight = new WPos(br.U * 1024 - 1, wbottom - 1, 0);
+			else
+			{
+				ProjectedTopLeft = new WPos(tl.U * 1024, tl.V * 1024, 0);
+				ProjectedBottomRight = new WPos(br.U * 1024 - 1, (br.V + 1) * 1024 - 1, 0);
+			}
 
 			ProjectedCellBounds = new ProjectedCellRegion(this, tl, br);
 		}

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -103,15 +103,14 @@ namespace OpenRA.Mods.Cnc.Traits
 			var mins = new CPos(Math.Min(start.X, end.X), Math.Min(start.Y, end.Y));
 			var maxs = new CPos(Math.Max(start.X, end.X), Math.Max(start.Y, end.Y));
 
-			/* TODO: proper endcaps, if anyone cares (which won't happen unless depth is large) */
-
+			// TODO: proper endcaps, if anyone cares (which won't happen unless depth is large)
 			var p = end - start;
 			var q = new float2(p.Y, -p.X);
 			q = (start != end) ? (1 / q.Length) * q : new float2(1, 0);
 			var c = -float2.Dot(q, new float2(start.X, start.Y));
 
-			/* return all points such that |ax + by + c| < depth */
-
+			// return all points such that |ax + by + c| < depth
+			// HACK: This will return the wrong results for isometric cells
 			for (var i = mins.X; i <= maxs.X; i++)
 				for (var j = mins.Y; j <= maxs.Y; j++)
 					if (Math.Abs(q.X * i + q.Y * j + c) * 1024 < depth.Length)

--- a/OpenRA.Mods.Common/Graphics/VoxelRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/VoxelRenderable.cs
@@ -107,7 +107,9 @@ namespace OpenRA.Mods.Common.Graphics
 			public void Render(WorldRenderer wr)
 			{
 				var groundPos = voxel.pos - new WVec(0, 0, wr.World.Map.DistanceAboveTerrain(voxel.pos).Length);
-				var groundZ = wr.World.Map.Grid.TileSize.Height * (groundPos.Z - voxel.pos.Z) / 1024f;
+				var tileScale = wr.World.Map.Grid.Type == MapGridType.RectangularIsometric ? 1448f : 1024f;
+
+				var groundZ = wr.World.Map.Grid.TileSize.Height * (groundPos.Z - voxel.pos.Z) / tileScale;
 				var pxOrigin = wr.Screen3DPosition(voxel.pos);
 
 				// HACK: We don't have enough texture channels to pass the depth data to the shader

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[SequenceReference] public readonly string Sequence = "harvest";
 
 		[Desc("Position relative to body")]
-		public readonly WVec Offset = WVec.Zero;
+		public readonly WVec LocalOffset = WVec.Zero;
 
 		[PaletteReference] public readonly string Palette = "effect";
 
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			anim.IsDecoration = true;
 			anim.Play(info.Sequence);
 			rs.Add(new AnimationWithOffset(anim,
-				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
+				() => body.LocalToWorld(info.LocalOffset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
 				() => !visible,
 				p => ZOffsetFromCenter(self, p, 0)), info.Palette);
 		}

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -636,8 +636,20 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				}
 
 				if (engineVersion < 20170507)
+				{
 					if (node.Key == "Offset" && parent.Key.StartsWith("WithHarvestOverlay", StringComparison.Ordinal))
 						RenameNodeKey(node, "LocalOffset");
+
+					if (node.Key == "LocalOffset")
+					{
+						var orig = FieldLoader.GetValue<WVec[]>(node.Key, node.Value.Value);
+						var scaled = orig.Select(o => FieldSaver.FormatValue(new WVec(
+							(int)Math.Round(Math.Sqrt(2) * o.X),
+							(int)Math.Round(Math.Sqrt(2) * o.Y),
+							(int)Math.Round(Math.Sqrt(2) * o.Z))));
+						node.Value.Value = scaled.JoinWith(", ");
+					}
+				}
 
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -635,6 +635,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 20170507)
+					if (node.Key == "Offset" && parent.Key.StartsWith("WithHarvestOverlay", StringComparison.Ordinal))
+						RenameNodeKey(node, "LocalOffset");
+
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -110,7 +110,7 @@ MapGrid:
 	EnableDepthBuffer: True
 	Type: RectangularIsometric
 	MaximumTerrainHeight: 16
-	SubCellOffsets: 0,0,0, -256,128,0, 0,-128,0, 256,128,0
+	SubCellOffsets: 0,0,0, -362,181,0, 0,-128,0, 362,181,0
 	DefaultSubCell: 2
 
 Cursors:

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -213,7 +213,7 @@ TRNSPORT:
 		MoveIntoShroud: false
 	Carryall:
 		Voice: Move
-		LocalOffset: 0, 0, -224
+		LocalOffset: 0,0,-317
 	Health:
 		HP: 175
 	Armor:

--- a/mods/ts/rules/civilian-infantry.yaml
+++ b/mods/ts/rules/civilian-infantry.yaml
@@ -14,7 +14,7 @@ WEEDGUY:
 		CrushSound: squishy2.aud
 	Armament:
 		Weapon: FireballLauncher
-		LocalOffset: 224,0,320
+		LocalOffset: 317,0,453
 	TakeCover:
 		ProneOffset: 128,0,-320
 	AttackFrontal:

--- a/mods/ts/rules/civilian-vehicles.yaml
+++ b/mods/ts/rules/civilian-vehicles.yaml
@@ -22,12 +22,12 @@
 		TurnSpeed: 3
 	Armament@PRIMARY:
 		Weapon: 120mmx
-		LocalOffset: 500,60,360, 500,-85,360
+		LocalOffset: 707,85,509, 707,-120,509
 		MuzzleSequence: muzzle
 		MuzzlePalette: effect-ignore-lighting
 	Armament@SECONDARY:
 		Weapon: MammothTusk
-		LocalOffset: 0,200,410, 0,-200,410
+		LocalOffset: 0,283,580, 0,-283,580
 	AttackTurreted:
 		Voice: Attack
 	AutoTarget:

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -16,7 +16,7 @@ E2:
 		Speed: 56
 	Armament:
 		Weapon: Grenade
-		LocalOffset: 0,0,555
+		LocalOffset: 0,0,785
 		FireDelay: 5
 	TakeCover:
 		ProneOffset: 160,128,-555
@@ -204,7 +204,7 @@ GHOST:
 		Range: 6c0
 	Armament:
 		Weapon: LtRail
-		LocalOffset: 85,0,384
+		LocalOffset: 120,0,543
 	TakeCover:
 		ProneOffset: 256,32,-384
 	Crushable:

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -93,7 +93,7 @@ GACTWR:
 	Armament@VULCPRIMARY:
 		RequiresCondition: tower.vulcan
 		Weapon: VulcanTower
-		LocalOffset: 416,85,960
+		LocalOffset: 588,120,1358
 		MuzzleSequence: muzzle
 		MuzzlePalette: effect-ignore-lighting
 		MuzzleSplitFacings: 8
@@ -101,18 +101,18 @@ GACTWR:
 		RequiresCondition: tower.vulcan
 		Name: secondary
 		Weapon: VulcanTower
-		LocalOffset: 416,-85,960
+		LocalOffset: 588,-120,1358
 		MuzzleSequence: muzzle
 		MuzzlePalette: effect-ignore-lighting
 		MuzzleSplitFacings: 8
 	Armament@ROCKET:
 		RequiresCondition: tower.rocket
 		Weapon: RPGTower
-		LocalOffset: 192,-65,1056
+		LocalOffset: 272,-92,1493
 	Armament@SAM:
 		RequiresCondition: tower.sam
 		Weapon: RedEye2
-		LocalOffset: 384,0,1200
+		LocalOffset: 543,0,1697
 	WithMuzzleOverlay:
 		RequiresCondition: tower.vulcan
 	WithIdleOverlay@LIGHTS:

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -85,7 +85,7 @@ HVR:
 		MaxHeightDelta: 3
 	Armament:
 		Weapon: HoverMissile
-		LocalOffset: 0,171,384, 0,-171,384
+		LocalOffset: 0,242,543, 0,-242,543
 	Turreted:
 		TurnSpeed: 7
 		Offset: -128,0,85
@@ -188,16 +188,16 @@ MMCH:
 		MuzzlePalette: effect-ignore-lighting
 		Recoil: 128
 		RecoilRecovery: 32
-		LocalOffset: 640, 192, 832
+		LocalOffset: 905,272,1177
 	WithMuzzleOverlay:
 	RenderVoxels:
 	WithVoxelBarrel:
-		LocalOffset: -64, 64, 256
+		LocalOffset: -91,91,362
 	AutoTarget:
 	Selectable:
 		Bounds: 30, 42, 0, -8
 	Carryable:
-		LocalOffset: 0, 0, 408
+		LocalOffset: 0,0,577
 
 HMEC:
 	Inherits: ^Tank
@@ -231,17 +231,17 @@ HMEC:
 	AutoTarget:
 	Armament@MISSILES:
 		Weapon: MammothTusk
-		LocalOffset: -172,-260,854, -172,260,854
+		LocalOffset: -243,-368,1208, -243,368,1208
 	Armament@RAILGUN:
 		Weapon: MechRailgun
-		LocalOffset: 260,-220,728, 260,220,728
+		LocalOffset: 368,-311,1030, 368,311,1030
 	-WithVoxelBody:
 	WithVoxelWalkerBody:
 		TickRate: 1
 	Selectable:
 		Bounds: 40, 40, 0, -8
 	Carryable:
-		LocalOffset: 0, 0, 360
+		LocalOffset: 0,0,509
 
 SONIC:
 	Inherits: ^Tank
@@ -272,7 +272,7 @@ SONIC:
 		MaxHeightDelta: 3
 	Armament:
 		Weapon: SonicZap
-		LocalOffset: -50,0,410
+		LocalOffset: -71,0,580
 	AttackTurreted:
 		Voice: Attack
 	Turreted:

--- a/mods/ts/rules/nod-infantry.yaml
+++ b/mods/ts/rules/nod-infantry.yaml
@@ -18,7 +18,7 @@ E3:
 		Speed: 42
 	Armament@PRIMARY:
 		Weapon: Bazooka
-		LocalOffset: 252,0,684
+		LocalOffset: 356,0,967
 	TakeCover:
 		ProneOffset: 52,64,-652
 	AttackFrontal:
@@ -90,7 +90,7 @@ CYC2:
 		Range: 7c0
 	Armament:
 		Weapon: CyCannon
-		LocalOffset: 170,85,683
+		LocalOffset: 240,120,966
 	AttackFrontal:
 		Voice: Attack
 	SelectionDecorations:

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -175,7 +175,7 @@ NALASR:
 	AttackTurreted:
 	Armament:
 		Weapon: TurretLaserFire
-		LocalOffset: 352, 0, 224
+		LocalOffset: 498,0,317
 	RenderVoxels:
 	WithVoxelTurret:
 	Power:
@@ -211,7 +211,7 @@ NAOBEL:
 		Range: 8c0
 	Armament:
 		Weapon: ObeliskLaserFire
-		LocalOffset: 1400,210,800
+		LocalOffset: 1980,297,1131
 	AttackCharges:
 		ChargeLevel: 65
 		ChargingCondition: charging
@@ -261,7 +261,7 @@ NASAM:
 		Recoils: false
 	Armament:
 		Weapon: RedEye2
-		LocalOffset: 384,0,576
+		LocalOffset: 543,0,815
 	Power:
 		Amount: -30
 	SelectionDecorations:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -24,7 +24,7 @@ BGGY:
 		MaxHeightDelta: 3
 	Armament:
 		Weapon: RaiderCannon
-		LocalOffset: 0,-43,384, 0,43,384
+		LocalOffset: 0,-61,543, 0,61,543
 		MuzzleSequence: muzzle
 		MuzzlePalette: effect-ignore-lighting
 		MuzzleSplitFacings: 8
@@ -62,11 +62,11 @@ BIKE:
 	Armament@PRIMARY:
 		Weapon: BikeMissile
 		RequiresCondition: !rank-elite
-		LocalOffset: -108,-144,360, -108,144,360
+		LocalOffset: -153,-204,509, -153,204,509
 	Armament@ELITE:
 		Weapon: HoverMissile
 		RequiresCondition: rank-elite
-		LocalOffset: -108,-144,360, -108,144,360
+		LocalOffset: -153,-204,509, -153,204,509
 	AttackFrontal:
 		Voice: Attack
 	AutoTarget:
@@ -100,13 +100,13 @@ TTNK:
 		RequiresCondition: undeployed
 	Armament@PRIMARY:
 		Weapon: 90mm
-		LocalOffset: 288,0,256
+		LocalOffset: 407,0,362
 		RequiresCondition: !rank-elite
 		MuzzleSequence: muzzle
 		MuzzlePalette: effect-ignore-lighting
 	Armament@ELITE:
 		Weapon: 120mmx
-		LocalOffset: 288,0,256
+		LocalOffset: 407,0,362
 		RequiresCondition: rank-elite
 		MuzzleSequence: muzzle
 		MuzzlePalette: effect-ignore-lighting
@@ -142,7 +142,7 @@ TTNK:
 		RealignDelay: -1
 	WithVoxelBarrel:
 		Armament: deployed
-		LocalOffset: 128, 0, 256
+		LocalOffset: 181,0,362
 		RequiresCondition: deployed
 	WithVoxelTurret@deployed:
 		Turret: deployed
@@ -155,7 +155,7 @@ TTNK:
 		Name: deployed
 		Turret: deployed
 		Weapon: 90mm
-		LocalOffset: 384,0,256
+		LocalOffset: 543,0,362
 		RequiresCondition: !rank-elite
 		MuzzleSequence: muzzle
 		MuzzlePalette: effect-ignore-lighting
@@ -163,7 +163,7 @@ TTNK:
 		Name: deployed
 		Turret: deployed
 		Weapon: 120mmx
-		LocalOffset: 384,0,256
+		LocalOffset: 543,0,362
 		RequiresCondition: rank-elite
 		MuzzleSequence: muzzle
 		MuzzlePalette: effect-ignore-lighting
@@ -233,7 +233,7 @@ ART2:
 		RealignDelay: -1
 	WithVoxelBarrel:
 		Armament: deployed
-		LocalOffset: 0,0,-256
+		LocalOffset: 0,0,-362
 		RequiresCondition: deployed
 	WithVoxelTurret@deployed:
 		Turret: deployed
@@ -246,7 +246,7 @@ ART2:
 		Name: deployed
 		Turret: deployed
 		Weapon: 155mm
-		LocalOffset: 811,0,0
+		LocalOffset: 1147,0,0
 		RequiresCondition: deployed
 		MuzzleSequence: muzzle
 		MuzzlePalette: effect-ignore-lighting
@@ -456,7 +456,7 @@ STNK:
 		ValidDamageStates: Critical
 	Armament:
 		Weapon: Dragon
-		LocalOffset: 213,43,298, 213,-43,298
+		LocalOffset: 301,61,421, 301,-61,421
 	AttackFrontal:
 		Voice: Attack
 	AutoTarget:

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -29,7 +29,7 @@ NAPULS:
 	AttackTurreted:
 	Armament:
 		Weapon: EMPulseCannon
-		LocalOffset: 150,0,1250
+		LocalOffset: 212,0,1768
 		LocalYaw: 0,100
 	WithSpriteTurret:
 		Sequence: turret

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -95,7 +95,7 @@ HARV:
 	Explodes:
 		Weapon: TiberiumExplosion
 	WithHarvestOverlay:
-		LocalOffset: 384,0,0
+		LocalOffset: 543,0,0
 		Palette: effect
 	SelectionDecorations:
 		VisualBounds: 36,36

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -95,7 +95,7 @@ HARV:
 	Explodes:
 		Weapon: TiberiumExplosion
 	WithHarvestOverlay:
-		Offset: 384,0,0
+		LocalOffset: 384,0,0
 		Palette: effect
 	SelectionDecorations:
 		VisualBounds: 36,36

--- a/mods/ts/weapons/ballisticweapons.yaml
+++ b/mods/ts/weapons/ballisticweapons.yaml
@@ -114,7 +114,7 @@ Grenade:
 	Range: 4c512
 	-Report:
 	Projectile: Bullet
-		Speed: 160
+		Speed: 226
 		Blockable: true
 		Shadow: true
 		LaunchAngle: 60

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -18,8 +18,8 @@
 		Acceleration: 6
 		MinimumLaunchAngle: 128
 		MaximumLaunchAngle: 192
-		VerticalRateOfTurn: 16
-		CruiseAltitude: 1c512
+		VerticalRateOfTurn: 11
+		CruiseAltitude: 2c124
 		AllowSnapping: true
 	Warhead@1Dam: SpreadDamage
 		Spread: 108


### PR DESCRIPTION
On current bleed ranges are measured horizontally on the screen, so a 2c512 range gives a circle intersecting with the corners of the cells to the left/right.

![screen shot 2017-05-06 at 15 05 11](https://cloud.githubusercontent.com/assets/167819/25773936/9125cf94-327e-11e7-96c3-3bfc3af6322e.png)

This is counterintuitive because most people expect ranges to be measured down the cell axis, meaning that the above should be closer to 3c512.

This PR rescales the World &lrarr; Cell coordinate transformations for RectangularIsometric mods down by a factor of sqrt(2) so that the size running down the world axes is 1024 instead.

A 2c512 range (5 cell diameter) now matches intuition: 
![screen shot 2017-05-06 at 17 05 03](https://cloud.githubusercontent.com/assets/167819/25773940/9fb99af4-327e-11e7-911a-b6f7afe7715c.png)


This issue has been known for a long time (but I can't find the issue # for it), but has been blocked on a combination of lack of interest, ugly upstream code that hardcoded transforms, and downstream breakage.  Most of our ugly code has now been rewritten, and downstream breakage is mitigated by decoupling mod releases from specific engine versions.

I have included upgrade rules for the `LocalOffset`s, but have left speeds, ranges, etc untouched because these are already correct (were previously wrong) for the TS mod.  Third party mods will need to rescale these values if they want to keep their current balance statistics.