### PR TITLE
Allowed spectators to multi select units during replay or spectating

### DIFF
--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -89,7 +89,7 @@ namespace OpenRA
 
 		public bool IsSpectating
 		{
-			get { return IsReplay || LocalPlayer == null && RenderPlayer == null; }
+			get { return IsReplay || (LocalPlayer == null && RenderPlayer == null); }
 		}
 
 		void SetLocalPlayer(Player localPlayer)

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -87,6 +87,11 @@ namespace OpenRA
 			get { return OrderManager.Connection is ReplayConnection; }
 		}
 
+		public bool IsSpectating
+		{
+			get { return IsReplay || LocalPlayer == null && RenderPlayer == null; }
+		}
+
 		void SetLocalPlayer(Player localPlayer)
 		{
 			if (localPlayer == null)

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Mods.Common.Widgets
 						var unit = World.ScreenMap.ActorsAt(mousePos)
 							.WithHighestSelectionPriority(mousePos);
 
-						if (unit != null && unit.Owner == (World.RenderPlayer ?? World.LocalPlayer))
+						if (unit != null && unit.Owner == (World.RenderPlayer ?? World.LocalPlayer) || World.IsSpectating)
 						{
 							var s = unit.TraitOrDefault<Selectable>();
 							if (s != null)

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Mods.Common.Widgets
 						var unit = World.ScreenMap.ActorsAt(mousePos)
 							.WithHighestSelectionPriority(mousePos);
 
-						if (unit != null && unit.Owner == (World.RenderPlayer ?? World.LocalPlayer) || World.IsSpectating)
+						if (unit != null && ((unit.Owner == (World.RenderPlayer ?? World.LocalPlayer)) || World.IsSpectating))
 						{
 							var s = unit.TraitOrDefault<Selectable>();
 							if (s != null)


### PR DESCRIPTION
Small change to allow spectators during a live match or a replay to multiselect units.

Closes: #9492 #13255 