### PR TITLE
Add Unit stance hotkeys

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -223,7 +223,10 @@ namespace OpenRA
 		public Hotkey StopKey = new Hotkey(Keycode.S, Modifiers.None);
 		public Hotkey ScatterKey = new Hotkey(Keycode.X, Modifiers.Ctrl);
 		public Hotkey DeployKey = new Hotkey(Keycode.F, Modifiers.None);
-		public Hotkey StanceCycleKey = new Hotkey(Keycode.Z, Modifiers.Ctrl);
+		public Hotkey StanceHoldFireKey = new Hotkey(Keycode.F, Modifiers.Alt);
+		public Hotkey StanceReturnFireKey = new Hotkey(Keycode.D, Modifiers.Alt);
+		public Hotkey StanceDefendKey = new Hotkey(Keycode.S, Modifiers.Alt);
+		public Hotkey StanceAttackAnythingKey = new Hotkey(Keycode.A, Modifiers.Alt);
 		public Hotkey GuardKey = new Hotkey(Keycode.D, Modifiers.None);
 
 		public Hotkey ObserverCombinedView = new Hotkey(Keycode.MINUS, Modifiers.None);

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -519,7 +519,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{ "AttackMoveKey", "Attack Move" },
 					{ "StopKey", "Stop" },
 					{ "ScatterKey", "Scatter" },
-					{ "StanceCycleKey", "Cycle Stance" },
 					{ "DeployKey", "Deploy" },
 					{ "GuardKey", "Guard" }
 				};
@@ -530,6 +529,24 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				foreach (var kv in hotkeys)
 					BindHotkeyPref(kv, ks, unitTemplate, hotkeyList);
+			}
+
+			// Unit stance
+			{
+				var hotkeys = new Dictionary<string, string>()
+				{
+					{ "StanceHoldFireKey", "Hold fire" },
+					{ "StanceReturnFireKey", "Return fire" },
+					{ "StanceDefendKey", "Defend" },
+					{ "StanceAttackAnythingKey", "Attack anything" }
+				};
+
+				var header = ScrollItemWidget.Setup(hotkeyHeader, returnTrue, doNothing);
+				header.Get<LabelWidget>("LABEL").GetText = () => "Unit Stance Commands";
+				hotkeyList.AddChild(header);
+
+				foreach (var kv in hotkeys)
+					BindHotkeyPref(kv, ks, globalTemplate, hotkeyList);
 			}
 
 			// Production
@@ -582,7 +599,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				};
 
 				var header = ScrollItemWidget.Setup(hotkeyHeader, returnTrue, doNothing);
-				header.Get<LabelWidget>("LABEL").GetText = () => "Developer commands";
+				header.Get<LabelWidget>("LABEL").GetText = () => "Developer Commands";
 				hotkeyList.AddChild(header);
 
 				foreach (var kv in hotkeys)
@@ -600,7 +617,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				};
 
 				var header = ScrollItemWidget.Setup(hotkeyHeader, returnTrue, doNothing);
-				header.Get<LabelWidget>("LABEL").GetText = () => "Music commands";
+				header.Get<LabelWidget>("LABEL").GetText = () => "Music Commands";
 				hotkeyList.AddChild(header);
 
 				foreach (var kv in hotkeys)

--- a/OpenRA.Mods.Common/Widgets/UnitCommandWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/UnitCommandWidget.cs
@@ -69,8 +69,9 @@ namespace OpenRA.Mods.Common.Widgets
 				if (key == ks.DeployKey)
 					return PerformDeploy();
 
-				if (key == ks.StanceCycleKey)
-					return PerformStanceCycle();
+				var stanceKeyIdx = new Hotkey[] { ks.StanceHoldFireKey, ks.StanceReturnFireKey, ks.StanceDefendKey, ks.StanceAttackAnythingKey }.IndexOf(key);
+				if (stanceKeyIdx > -1)
+					return SetUnitStance((UnitStance)stanceKeyIdx);
 
 				if (key == ks.GuardKey)
 					return PerformGuard();
@@ -129,36 +130,18 @@ namespace OpenRA.Mods.Common.Widgets
 			return true;
 		}
 
-		bool PerformStanceCycle()
+		bool SetUnitStance(UnitStance unitStance)
 		{
-			var actor = world.Selection.Actors
-				.Where(a => a.Owner == world.LocalPlayer && !a.Disposed)
-				.Select(a => Pair.New(a, a.TraitOrDefault<AutoTarget>()))
-				.FirstOrDefault(a => a.Second != null);
-
-			if (actor.First == null)
-				return true;
-
-			var ati = actor.First.Info.TraitInfoOrDefault<AutoTargetInfo>();
-			if (ati == null || !ati.EnableStances)
-				return false;
-
-			var stances = Enum<UnitStance>.GetValues();
-			var nextStance = stances.Concat(stances)
-				.SkipWhile(s => s != actor.Second.PredictedStance)
-				.Skip(1)
-				.First();
-
 			PerformKeyboardOrderOnSelection(a =>
 			{
 				var at = a.TraitOrDefault<AutoTarget>();
 				if (at != null)
-					at.PredictedStance = nextStance;
+					at.PredictedStance = unitStance;
 
-				return new Order("SetUnitStance", a, false) { ExtraData = (uint)nextStance };
+				return new Order("SetUnitStance", a, false) { ExtraData = (uint)unitStance };
 			});
 
-			Game.AddChatLine(Color.White, "Battlefield Control", "Unit stance set to: {0}".F(nextStance));
+			Game.AddChatLine(Color.White, "Battlefield Control", "Unit stance set to: {0}".F(unitStance));
 
 			return true;
 		}


### PR DESCRIPTION
Add hotkeys for Unit stances. 'Cycle stances' is kept atm and default for new hotkeys is Unknown, so no impact for players. IMO 'Cycle stances' could be removed.