### PR TITLE
Add Starting Building support

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/MPStartUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/MPStartUnits.cs
@@ -32,6 +32,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("A group of units ready to defend or scout.")]
 		public readonly string[] SupportActors = { };
 
+		[Desc("A group of buildings to be placed at start.")]
+		public readonly string[] SupportBuildings = { };
+
 		[Desc("Inner radius for spawning support actors")]
 		public readonly int InnerSupportRadius = 2;
 

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -162,6 +162,47 @@ World:
 		SupportActors: e1,e1,e1,e3,e3,apc,ftrk,3tnk,3tnk
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
+	MPStartUnits@cyardonly:
+		Class: cyardonly
+		ClassName: Con. Yard Only
+		Factions: allies, england, france, germany, soviet, russia, ukraine
+		BaseActor: fact
+	MPStartUnits@smallbaseallied:
+		Class: smallbase
+		ClassName: Small Base
+		Factions: allies, england, france, germany
+		BaseActor: fact
+		SupportActors: e1,e1,e3,jeep
+		SupportBuildings: powr, tent, proc, silo, pbox
+		InnerSupportRadius: 4
+		OuterSupportRadius: 7
+	MPStartUnits@smallbasesoviet:
+		Class: smallbase
+		ClassName: Small Base
+		Factions: soviet, russia, ukraine
+		BaseActor: fact
+		SupportActors: e1,e1,e3,apc
+		SupportBuildings: powr, barr, proc, silo, ftur
+		InnerSupportRadius: 4
+		OuterSupportRadius: 7
+	MPStartUnits@bigbaseallied:
+		Class: bigbase
+		ClassName: Big Base
+		Factions: allies, england, france, germany
+		BaseActor: fact
+		SupportActors: e1,e1,e1,e3,e3,jeep,1tnk,2tnk
+		SupportBuildings: powr, powr, tent, proc, silo, silo, silo, pbox, gun, agun, hpad
+		InnerSupportRadius: 4
+		OuterSupportRadius: 7
+	MPStartUnits@bigbasesoviet:
+		Class: bigbase
+		ClassName: Big Base
+		Factions: soviet, russia, ukraine
+		BaseActor: fact
+		SupportActors: e1,e1,e1,e3,e3,apc,ftrk,3tnk
+		SupportBuildings: powr, powr, barr, proc, silo, silo, silo, ftur, ftur, sam, afld
+		InnerSupportRadius: 4
+		OuterSupportRadius: 7
 	MPStartLocations:
 	SpawnMPUnits:
 	PathFinder:


### PR DESCRIPTION
Fixes #13264.

I'm not sure if a seperate `SupportBuildings:` tag is required or i could add support to have buildings in to `SupportActors:`, i couldn't manage to do the latter so gone with first.

I added some MPStartUnits with buildings to `ra` mod as testcase.