### PR TITLE
Always wait for input before ending the windows make script

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -246,16 +246,12 @@ switch ($command)
 	Default { echo ("Invalid command '{0}'" -f $command) }
 }
 
-#In case the script was called without any parameters we keep the window open 
-if ($args.Length -eq 0)
+echo "Press enter to continue."
+while ($true)
 {
-	echo "Press enter to continue."
-	while ($true)
+	if ([System.Console]::KeyAvailable)
 	{
-		if ([System.Console]::KeyAvailable)
-		{
-			break
-		}
-		Start-Sleep -Milliseconds 50
+		break
 	}
+	Start-Sleep -Milliseconds 50
 }


### PR DESCRIPTION
This is needed for https://github.com/OpenRA/OpenRAModTemplate/pull/3, as OpenRA's make script would close without the user being able to see the output.