### PR TITLE
Throw a lint error or an exception when no player owns the world

### DIFF
--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -22,6 +22,7 @@ namespace OpenRA.Mods.Common.Lint
 		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
 		{
 			var players = new MapPlayers(map.PlayerDefinitions).Players;
+			var worldOwnerFound = false;
 
 			var playerNames = players.Values.Select(p => p.Name).ToHashSet();
 			foreach (var player in players.Values)
@@ -34,9 +35,19 @@ namespace OpenRA.Mods.Common.Lint
 					if (!playerNames.Contains(enemy))
 						emitError("Enemies contains player {0} that is not in list.".F(enemy));
 
-				if (player.OwnsWorld && (player.Enemies.Any() || player.Allies.Any()))
-					emitWarning("The player {0} owning the world should not have any allies or enemies.".F(player.Name));
+				if (player.OwnsWorld)
+				{
+					worldOwnerFound = true;
+					if (player.Enemies.Any() || player.Allies.Any())
+						emitWarning("The player {0} owning the world should not have any allies or enemies.".F(player.Name));
+
+					if (player.Playable)
+						emitError("The player {0} owning the world can't be playable.".F(player.Name));
+				}
 			}
+
+			if (!worldOwnerFound)
+				emitError("Found no player owning the world.");
 
 			var worldActor = map.Rules.Actors["world"];
 

--- a/OpenRA.Mods.Common/Traits/World/CreateMPPlayers.cs
+++ b/OpenRA.Mods.Common/Traits/World/CreateMPPlayers.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Network;
@@ -25,15 +26,23 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var players = new MapPlayers(w.Map.PlayerDefinitions).Players;
 			var worldPlayers = new List<Player>();
+			var worldOwnerFound = false;
 
 			// Create the unplayable map players -- neutral, shellmap, scripted, etc.
 			foreach (var kv in players.Where(p => !p.Value.Playable))
 			{
 				var player = new Player(w, null, kv.Value);
 				worldPlayers.Add(player);
+
 				if (kv.Value.OwnsWorld)
+				{
+					worldOwnerFound = true;
 					w.SetWorldOwner(player);
+				}
 			}
+
+			if (!worldOwnerFound)
+				throw new InvalidOperationException("Map {0} does not define a player actor owning the world.".F(w.Map.Title));
 
 			Player localPlayer = null;
 


### PR DESCRIPTION
Requested in https://github.com/OpenRA/OpenRAModTemplate/pull/3#discussion_r115697809.