### PR TITLE
Fix Game starts with 1 player on ready

### DIFF
--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -90,9 +90,14 @@ namespace OpenRA.Network
 			return Slots.FirstOrDefault(s => !s.Value.Closed && ClientInSlot(s.Key) == null && s.Value.AllowBots).Key;
 		}
 
-		public bool IsSinglePlayer
+		public IEnumerable<Client> NonBotClients
 		{
-			get { return Clients.Count(c => c.Bot == null) == 1; }
+			get { return Clients.Where(c => c.Bot == null); }
+		}
+
+		public IEnumerable<Client> NonBotPlayers
+		{
+			get { return Clients.Where(c => c.Bot == null && c.Slot != null); }
 		}
 
 		public enum ClientState { NotReady, Invalid, Ready, Disconnected = 1000 }

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -118,7 +118,7 @@ namespace OpenRA.Network
 						if (client != null)
 						{
 							var pause = order.TargetString == "Pause";
-							if (orderManager.World.Paused != pause && world != null && !world.LobbyInfo.IsSinglePlayer)
+							if (orderManager.World.Paused != pause && world != null && world.LobbyInfo.NonBotClients.Count() > 1)
 							{
 								var pausetext = "The game is {0} by {1}".F(pause ? "paused" : "un-paused", client.Name);
 								Game.AddChatLine(Color.White, ServerChatName, pausetext);

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -375,7 +375,7 @@ namespace OpenRA.Server
 				Log.Write("server", "{0} ({1}) has joined the game.",
 					client.Name, newConn.Socket.RemoteEndPoint);
 
-				if (Dedicated || !LobbyInfo.IsSinglePlayer)
+				if (LobbyInfo.NonBotClients.Count() > 1)
 					SendMessage("{0} has joined the game.".F(client.Name));
 
 				// Send initial ping
@@ -392,7 +392,7 @@ namespace OpenRA.Server
 						SendOrderTo(newConn, "Message", motd);
 				}
 
-				if (!LobbyInfo.IsSinglePlayer && Map.DefinesUnsafeCustomRules)
+				if (Map.DefinesUnsafeCustomRules)
 					SendOrderTo(newConn, "Message", "This map contains custom rules. Game experience may change.");
 
 				if (!LobbyInfo.GlobalSettings.EnableSingleplayer)
@@ -679,7 +679,7 @@ namespace OpenRA.Server
 			}
 
 			// HACK: Turn down the latency if there is only one real player
-			if (LobbyInfo.IsSinglePlayer)
+			if (LobbyInfo.NonBotClients.Count() == 1)
 				LobbyInfo.GlobalSettings.OrderLatency = 1;
 
 			SyncLobbyInfo();

--- a/OpenRA.Game/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Game/Traits/Player/DeveloperMode.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace OpenRA.Traits
 {
@@ -113,7 +114,7 @@ namespace OpenRA.Traits
 
 		void INotifyCreated.Created(Actor self)
 		{
-			Enabled = self.World.LobbyInfo.IsSinglePlayer || self.World.LobbyInfo.GlobalSettings
+			Enabled = self.World.LobbyInfo.NonBotPlayers.Count() == 1 || self.World.LobbyInfo.GlobalSettings
 				.OptionOrDefault("cheats", info.Enabled);
 		}
 

--- a/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
@@ -108,7 +108,7 @@ namespace OpenRA.Mods.Common.Scripting
 		}
 
 		[Desc("Returns true if there is only one human player.")]
-		public bool IsSinglePlayer { get { return Context.World.LobbyInfo.IsSinglePlayer; } }
+		public bool IsSinglePlayer { get { return Context.World.LobbyInfo.NonBotPlayers.Count() == 1; } }
 
 		[Desc("Returns the difficulty selected by the player before starting the mission.")]
 		public string Difficulty

--- a/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Server
 				lastPing = Game.RunTime;
 
 				// Ignore client timeout in singleplayer games to make debugging easier
-				if (server.LobbyInfo.IsSinglePlayer && !server.Dedicated)
+				if (server.LobbyInfo.NonBotClients.Count() < 2 && !server.Dedicated)
 					foreach (var c in server.Conns.ToList())
 						server.SendOrderTo(c, "Ping", Game.RunTime.ToString());
 				else

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			chatTraits = world.WorldActor.TraitsImplementing<INotifyChat>().ToArray();
 
 			var players = world.Players.Where(p => p != world.LocalPlayer && !p.NonCombatant && !p.IsBot);
-			disableTeamChat = world.IsReplay || world.LobbyInfo.IsSinglePlayer || (world.LocalPlayer != null && !players.Any(p => p.IsAlliedWith(world.LocalPlayer)));
+			disableTeamChat = world.IsReplay || world.LobbyInfo.NonBotClients.Count() == 1 || (world.LocalPlayer != null && !players.Any(p => p.IsAlliedWith(world.LocalPlayer)));
 			teamChat = !disableTeamChat;
 
 			tabCompletion.Commands = chatTraits.OfType<ChatCommands>().SelectMany(x => x.Commands.Keys).ToList();

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var iop = world.WorldActor.TraitsImplementing<IObjectivesPanel>().FirstOrDefault();
 					var exitDelay = iop != null ? iop.ExitDelay : 0;
 
-					if (world.LobbyInfo.IsSinglePlayer)
+					if (world.LobbyInfo.NonBotClients.Count() == 1)
 					{
 						restartAction = () =>
 						{

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				worldRoot.IsVisible = () => false;
 			}
 
-			if (button.Pause && world.LobbyInfo.IsSinglePlayer)
+			if (button.Pause && world.LobbyInfo.NonBotClients.Count() == 1)
 				world.SetPauseState(true);
 
 			var cachedDisableWorldSounds = Game.Sound.DisableWorldSounds;
@@ -118,7 +118,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (button.DisableWorldSounds)
 					Game.Sound.DisableWorldSounds = cachedDisableWorldSounds;
 
-				if (button.Pause && world.LobbyInfo.IsSinglePlayer)
+				if (button.Pause && world.LobbyInfo.NonBotClients.Count() == 1)
 					world.SetPauseState(cachedPause);
 
 				menuRoot.RemoveChild(currentWidget);

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -322,7 +322,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				startGameButton.IsDisabled = () => configurationDisabled() || map.Status != MapStatus.Available ||
 					orderManager.LobbyInfo.Slots.Any(sl => sl.Value.Required && orderManager.LobbyInfo.ClientInSlot(sl.Key) == null) ||
-					(!orderManager.LobbyInfo.GlobalSettings.EnableSingleplayer && orderManager.LobbyInfo.IsSinglePlayer);
+					(!orderManager.LobbyInfo.GlobalSettings.EnableSingleplayer && orderManager.LobbyInfo.NonBotPlayers.Count() < 2);
 
 				startGameButton.OnClick = () =>
 				{


### PR DESCRIPTION
1. rename Session.IsSinglePlayer to IsSingleHuman for clarity - this is optional, 11 of 12 cases seem to be correct, 1 case where it isn't is fixed in commit 2
2. Lobby - updated auto start on 'Ready' checkbox and on 'Start Game' button to fix case when on dedicated non SinglePlayer server game could be started with only 1 human player and admin as spectator.

~This PR solves this specific case: admin as player or spectator is ready. One of 2 players moves to spectator slot. At this moment 'all' = 1 player is ready and game starts. As it is immediate, this player might not notice and starts playing without opponent.
In general this PR prevents starting game by changing 'Ready' checkbox if there aren't at least 2 players (humans or bots). In case admin might really want to start a game with only 1 player or bot, he can still click 'Start Game'.~