### PR TITLE
Add the possibility to deny spawning actors for dead players

### DIFF
--- a/OpenRA.Mods.Common/ActorInitializer.cs
+++ b/OpenRA.Mods.Common/ActorInitializer.cs
@@ -44,4 +44,13 @@ namespace OpenRA.Mods.Common
 		public FactionInit(string faction) { Faction = faction; }
 		public string Value(World world) { return Faction; }
 	}
+
+	public class EffectiveOwnerInit : IActorInit<Player>
+	{
+		[FieldFromYamlKey] readonly Player value = null;
+
+		public EffectiveOwnerInit() { }
+		public EffectiveOwnerInit(Player owner) { value = owner; }
+		Player IActorInit<Player>.Value(World world) { return value; }
+	}
 }

--- a/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
@@ -106,6 +106,9 @@ namespace OpenRA.Mods.Common.Traits
 				new FactionInit(faction)
 			};
 
+			if (self.EffectiveOwner != null && self.EffectiveOwner.Disguised)
+				td.Add(new EffectiveOwnerInit(self.EffectiveOwner.Owner));
+
 			if (Info.OwnerType == OwnerType.Victim)
 			{
 				// Fall back to InternalOwner if the Victim was defeated,
@@ -115,7 +118,8 @@ namespace OpenRA.Mods.Common.Traits
 				else
 				{
 					td.Add(new OwnerInit(self.World.Players.First(p => p.InternalName == Info.InternalOwner)));
-					td.Add(new EffectiveOwnerInit(self.Owner));
+					if (!td.Contains<EffectiveOwnerInit>())
+						td.Add(new EffectiveOwnerInit(self.Owner));
 				}
 			}
 			else if (Info.OwnerType == OwnerType.Killer)

--- a/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
@@ -36,6 +36,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Map player to use when 'InternalName' is defined on 'OwnerType'.")]
 		public readonly string InternalOwner = "Neutral";
 
+		[Desc("Changes the effective (displayed) owner of the spawned actor to the old owner (victim).")]
+		public readonly bool EffectiveOwnerFromOwner = false;
+
 		[Desc("DeathType that triggers the actor spawn. " +
 			"Leave empty to spawn an actor ignoring the DeathTypes.")]
 		public readonly string DeathType = null;
@@ -108,6 +111,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (self.EffectiveOwner != null && self.EffectiveOwner.Disguised)
 				td.Add(new EffectiveOwnerInit(self.EffectiveOwner.Owner));
+			else if (Info.EffectiveOwnerFromOwner)
+				td.Add(new EffectiveOwnerInit(self.Owner));
 
 			if (Info.OwnerType == OwnerType.Victim)
 			{

--- a/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
@@ -50,6 +50,9 @@ namespace OpenRA.Mods.Common.Traits
 			"lead to unexpected behaviour.")]
 		public readonly CVec Offset = CVec.Zero;
 
+		[Desc("Should an actor spawn after the player has been defeated (e.g. after surrendering)?")]
+		public readonly bool SpawnAfterDefeat = true;
+
 		public override object Create(ActorInitializer init) { return new SpawnActorOnDeath(init, this); }
 	}
 
@@ -87,7 +90,7 @@ namespace OpenRA.Mods.Common.Traits
 		// Don't add the new actor to the world before all RemovedFromWorld callbacks have run
 		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
 		{
-			if (attackingPlayer == null)
+			if (attackingPlayer == null || (!info.SpawnAfterDefeat && self.Owner.WinState != WinState.Undefined))
 				return;
 
 			var td = new TypeDictionary

--- a/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Linq;
-using OpenRA.Mods.Common.Warheads;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -33,6 +33,8 @@ MCV:
 	BaseBuilding:
 	SpawnActorOnDeath:
 		Actor: MCV.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	SelectionDecorations:
 		VisualBounds: 36,36
 
@@ -71,6 +73,8 @@ HARV:
 		Range: 4c0
 	SpawnActorOnDeath:
 		Actor: HARV.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	WithHarvestAnimation:
 	WithDockingAnimation:
 	Explodes:
@@ -127,6 +131,8 @@ APC:
 		LoadingCondition: notmobile
 	SpawnActorOnDeath:
 		Actor: APC.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 
 ARTY:
 	Inherits: ^Tank
@@ -161,6 +167,8 @@ ARTY:
 		InitialStanceAI: Defend
 	SpawnActorOnDeath:
 		Actor: ARTY.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	Explodes:
 		Weapon: ArtilleryShell
 		EmptyWeapon: UnitExplode
@@ -200,6 +208,8 @@ FTNK:
 		EmptyWeapon: FlametankExplode
 	SpawnActorOnDeath:
 		Actor: FTNK.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 
 BGGY:
 	Inherits: ^Vehicle
@@ -236,6 +246,8 @@ BGGY:
 	WithSpriteTurret:
 	SpawnActorOnDeath:
 		Actor: BGGY.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 
 BIKE:
 	Inherits: ^Vehicle
@@ -274,6 +286,8 @@ BIKE:
 	AttackFrontal:
 	SpawnActorOnDeath:
 		Actor: BIKE.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 
 JEEP:
 	Inherits: ^Vehicle
@@ -310,6 +324,8 @@ JEEP:
 	WithSpriteTurret:
 	SpawnActorOnDeath:
 		Actor: JEEP.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 
 LTNK:
 	Inherits: ^Tank
@@ -349,6 +365,8 @@ LTNK:
 	WithSpriteTurret:
 	SpawnActorOnDeath:
 		Actor: LTNK.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 
 MTNK:
 	Inherits: ^Tank
@@ -385,6 +403,8 @@ MTNK:
 	WithSpriteTurret:
 	SpawnActorOnDeath:
 		Actor: MTNK.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	SelectionDecorations:
 		VisualBounds: 28,28
 
@@ -436,6 +456,8 @@ HTNK:
 		DamageCooldown: 200
 	SpawnActorOnDeath:
 		Actor: HTNK.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	SelectionDecorations:
 		VisualBounds: 34,34,0,-3
 
@@ -476,6 +498,8 @@ MSAM:
 		AimSequence: aim
 	SpawnActorOnDeath:
 		Actor: MSAM.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 
 MLRS:
 	Inherits: ^Tank
@@ -518,6 +542,8 @@ MLRS:
 	RenderRangeCircle:
 	SpawnActorOnDeath:
 		Actor: MLRS.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	ReloadAmmoPool:
 		Delay: 45
 		Count: 1
@@ -564,6 +590,8 @@ STNK:
 	Targetable:
 	SpawnActorOnDeath:
 		Actor: STNK.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	-MustBeDestroyed:
 
 MHQ:
@@ -612,3 +640,5 @@ TRUCK:
 		PlayerExperience: 50
 	SpawnActorOnDeath:
 		Actor: TRUCK.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -37,6 +37,8 @@ mcv:
 		NoTransformNotification: CannotDeploy
 	SpawnActorOnDeath:
 		Actor: mcv.husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	AttractsWorms:
 		Intensity: 700
 	SelectionDecorations:
@@ -85,6 +87,8 @@ harvester:
 		EmptyWeapon: UnitExplodeLarge
 	SpawnActorOnDeath:
 		Actor: harvester.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	WithHarvestOverlay:
 		Palette: effect50alpha
 	WithDockingAnimation:
@@ -220,6 +224,8 @@ siege_tank:
 		Class: siegetank
 	SpawnActorOnDeath:
 		Actor: siege_tank.husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	AttractsWorms:
 		Intensity: 600
 
@@ -260,6 +266,8 @@ missile_tank:
 		Class: missiletank
 	SpawnActorOnDeath:
 		Actor: missile_tank.husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	AttractsWorms:
 		Intensity: 600
 
@@ -296,6 +304,8 @@ sonic_tank:
 		EmptyWeapon: UnitExplodeLarge
 	SpawnActorOnDeath:
 		Actor: sonic_tank.husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	AttractsWorms:
 		Intensity: 600
 
@@ -340,6 +350,8 @@ devastator:
 		RequiresCondition: !overload
 	SpawnActorOnDeath:
 		Actor: devastator.husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	Explodes@OVERLOAD:
 		Weapon: PlasmaExplosion
 		EmptyWeapon: PlasmaExplosion
@@ -466,6 +478,8 @@ deviator:
 		EmptyWeapon: UnitExplodeLarge
 	SpawnActorOnDeath:
 		Actor: deviator.husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	AttractsWorms:
 		Intensity: 600
 
@@ -511,6 +525,9 @@ deviator:
 		Class: combat
 	AttractsWorms:
 		Intensity: 520
+	SpawnActorOnDeath:
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 
 combat_tank_a:
 	Inherits: ^combat_tank

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -83,6 +83,8 @@ V2RL:
 	WithSpriteTurret:
 	SpawnActorOnDeath:
 		Actor: 1TNK.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 
@@ -124,6 +126,8 @@ V2RL:
 	WithSpriteTurret:
 	SpawnActorOnDeath:
 		Actor: 2TNK.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	SelectionDecorations:
 		VisualBounds: 28,28
 	ProducibleWithLevel:
@@ -167,6 +171,8 @@ V2RL:
 	WithSpriteTurret:
 	SpawnActorOnDeath:
 		Actor: 3TNK.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	SelectionDecorations:
 		VisualBounds: 28,28
 	ProducibleWithLevel:
@@ -219,6 +225,8 @@ V2RL:
 	WithSpriteTurret:
 	SpawnActorOnDeath:
 		Actor: 4TNK.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	SelfHealing:
 		Step: 1
 		Delay: 3
@@ -307,6 +315,8 @@ HARV:
 		String: Harvester
 	SpawnActorOnDeath:
 		Actor: HARV.EmptyHusk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 	HarvesterHuskModifier:
 		FullActor: HARV.FullHusk
 		FullnessThreshold: 50
@@ -355,6 +365,8 @@ MCV:
 	BaseBuilding:
 	SpawnActorOnDeath:
 		Actor: MCV.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 
 JEEP:
 	Inherits: ^Vehicle
@@ -537,6 +549,8 @@ MGG:
 	RenderShroudCircle:
 	SpawnActorOnDeath:
 		Actor: MGG.Husk
+		OwnerType: InternalName
+		EffectiveOwnerFromOwner: true
 
 MRJ:
 	Inherits: ^Vehicle


### PR DESCRIPTION
Some maps/mods spawn player controllable actors using `SpawnActorOnDeath`. This leads to some weird results when a player is defeated (e.g. surrenders), as the player is dead, but can still control units. It makes sense to still spawn non-controllable units like husks, imho, so I made this a setting.