### PR TITLE
Disable DPI scaling on Windows by default

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -119,7 +119,7 @@ namespace OpenRA
 		public int MaxFramerate = 60;
 
 		[Desc("Disable high resolution DPI scaling on Windows operating systems.")]
-		public bool DisableWindowsDPIScaling = false;
+		public bool DisableWindowsDPIScaling = true;
 
 		public int BatchSize = 8192;
 		public int SheetSize = 2048;


### PR DESCRIPTION
We can't fix the graphical glitches that DPI scaling can cause on Windows due to its floating-point nature (at least not quickly/easily), and since we've already received several error reports on this matter, we should disable it by default for now.

Closes #13272.
Closes #13170.