### PR TITLE
Add StartBurstReport to WeaponInfo

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -39,8 +39,11 @@ namespace OpenRA.GameRules
 		[Desc("The maximum range the weapon can fire.")]
 		public readonly WDist Range = WDist.Zero;
 
-		[Desc("The sound played when the weapon is fired.")]
+		[Desc("The sound played each time the weapon is fired.")]
 		public readonly string[] Report = null;
+
+		[Desc("Sound played only on first burst in a salvo.")]
+		public readonly string[] StartBurstReport = null;
 
 		[Desc("The sound played when the weapon is reloaded.")]
 		public readonly string[] AfterFireSound = null;

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -247,6 +247,9 @@ namespace OpenRA.Mods.Common.Traits
 					if (args.Weapon.Report != null && args.Weapon.Report.Any())
 						Game.Sound.Play(SoundType.World, args.Weapon.Report.Random(self.World.SharedRandom), self.CenterPosition);
 
+					if (Burst == args.Weapon.Burst && args.Weapon.StartBurstReport != null && args.Weapon.StartBurstReport.Any())
+						Game.Sound.Play(SoundType.World, args.Weapon.StartBurstReport.Random(self.World.SharedRandom), self.CenterPosition);
+
 					foreach (var na in self.TraitsImplementing<INotifyAttack>())
 						na.Attacking(self, target, this, barrel);
 


### PR DESCRIPTION
To play only a single sound at the beginning of a salvo of bursts.

Split from #13041, which can also be used as test-case.