### PR TITLE
Make animation traits compatible with multiple sprite bodies - part 1

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
@@ -10,28 +10,32 @@
 #endregion
 
 using System;
+using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
 {
-	[Desc("Replaces the sprite during construction.")]
+	[Desc("Replaces the sprite during construction/deploy/undeploy.")]
 	public class WithMakeAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>
 	{
-		[Desc("Sequence name to use")]
+		[Desc("Sequence name to use.")]
 		[SequenceReference] public readonly string Sequence = "make";
 
 		[GrantedConditionReference]
 		[Desc("The condition to grant to self while the make animation is playing.")]
 		public readonly string Condition = null;
 
+		[Desc("Apply to sprite bodies with these names.")]
+		public readonly string[] BodyNames = { "body" };
+
 		public object Create(ActorInitializer init) { return new WithMakeAnimation(init, this); }
 	}
 
-	public class WithMakeAnimation : INotifyCreated
+	public class WithMakeAnimation : INotifyCreated, INotifyDeployTriggered
 	{
 		readonly WithMakeAnimationInfo info;
-		readonly WithSpriteBody wsb;
+		readonly WithSpriteBody[] wsbs;
 
 		ConditionManager conditionManager;
 		int token = ConditionManager.InvalidConditionToken;
@@ -40,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			this.info = info;
 			var self = init.Self;
-			wsb = self.Trait<WithSpriteBody>();
+			wsbs = self.TraitsImplementing<WithSpriteBody>().Where(w => info.BodyNames.Contains(w.Info.Name)).ToArray();
 		}
 
 		void INotifyCreated.Created(Actor self)
@@ -55,6 +59,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			if (conditionManager != null && !string.IsNullOrEmpty(info.Condition) && token == ConditionManager.InvalidConditionToken)
 				token = conditionManager.GrantCondition(self, info.Condition);
+
+			var wsb = wsbs.FirstOrDefault(Exts.IsTraitEnabled);
+
+			if (wsb == null)
+				return;
 
 			wsb.PlayCustomAnimation(self, info.Sequence, () =>
 			{
@@ -71,6 +80,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (conditionManager != null && !string.IsNullOrEmpty(info.Condition) && token == ConditionManager.InvalidConditionToken)
 				token = conditionManager.GrantCondition(self, info.Condition);
 
+			var wsb = wsbs.FirstOrDefault(Exts.IsTraitEnabled);
+
+			if (wsb == null)
+				return;
+
 			wsb.PlayCustomAnimationBackwards(self, info.Sequence, () =>
 			{
 				if (token != ConditionManager.InvalidConditionToken)
@@ -85,17 +99,70 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			Reverse(self, () =>
 			{
+				var wsb = wsbs.FirstOrDefault(Exts.IsTraitEnabled);
+
 				// HACK: The actor remains alive and active for one tick before the followup activity
 				// (sell/transform/etc) runs. This causes visual glitches that we attempt to minimize
 				// by forcing the animation to frame 0 and regranting the make condition.
 				// These workarounds will break the actor if the followup activity doesn't dispose it!
-				wsb.DefaultAnimation.PlayFetchIndex(info.Sequence, () => 0);
+				if (wsb != null)
+					wsb.DefaultAnimation.PlayFetchIndex(info.Sequence, () => 0);
 
 				if (conditionManager != null && !string.IsNullOrEmpty(info.Condition))
 					token = conditionManager.GrantCondition(self, info.Condition);
 
 				self.QueueActivity(queued, activity);
 			});
+		}
+
+		// TODO: Make this use Forward instead
+		void INotifyDeployTriggered.Deploy(Actor self)
+		{
+			var notified = false;
+
+			foreach (var wsb in wsbs)
+			{
+				if (wsb.IsTraitDisabled)
+					continue;
+
+				var notify = self.TraitsImplementing<INotifyDeployComplete>();
+				wsb.PlayCustomAnimation(self, info.Sequence, () =>
+				{
+					if (notified)
+						return;
+
+					foreach (var n in notify)
+					{
+						n.FinishedDeploy(self);
+						notified = true;
+					}
+				});
+			}
+		}
+
+		// TODO: Make this use Reverse instead
+		void INotifyDeployTriggered.Undeploy(Actor self)
+		{
+			var notified = false;
+
+			foreach (var wsb in wsbs)
+			{
+				if (wsb.IsTraitDisabled)
+					continue;
+
+				var notify = self.TraitsImplementing<INotifyDeployComplete>();
+				wsb.PlayCustomAnimationBackwards(self, info.Sequence, () =>
+				{
+					if (notified)
+						return;
+
+					foreach (var n in notify)
+					{
+						n.FinishedUndeploy(self);
+						notified = true;
+					}
+				});
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -29,6 +29,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Pause animation when actor is disabled.")]
 		public readonly bool PauseAnimationWhenDisabled = false;
 
+		[Desc("Identifier used to assign modifying traits to this sprite body.")]
+		public readonly string Name = "body";
+
 		public override object Create(ActorInitializer init) { return new WithSpriteBody(init, this); }
 
 		public virtual IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -165,7 +165,24 @@ namespace OpenRA.Mods.Common.Traits
 		bool IsOverlayActive(ActorInfo ai);
 	}
 
-	public interface INotifyTransform { void BeforeTransform(Actor self); void OnTransform(Actor self); void AfterTransform(Actor toActor); }
+	public interface INotifyTransform
+	{
+		void BeforeTransform(Actor self);
+		void OnTransform(Actor self);
+		void AfterTransform(Actor toActor);
+	}
+
+	public interface INotifyDeployComplete
+	{
+		void FinishedDeploy(Actor self);
+		void FinishedUndeploy(Actor self);
+	}
+
+	public interface INotifyDeployTriggered
+	{
+		void Deploy(Actor self);
+		void Undeploy(Actor self);
+	}
 
 	public interface IAcceptResourcesInfo : ITraitInfo { }
 	public interface IAcceptResources

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -663,6 +663,22 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// Removed GrantConditionOnDeploy.DeployAnimation and made WithMakeAnimation compatible instead
+				if (engineVersion < 20170510)
+				{
+					var grantCondOnDeploy = node.Value.Nodes.FirstOrDefault(n => n.Key == "GrantConditionOnDeploy");
+					if (grantCondOnDeploy != null)
+					{
+						var deployAnimNode = grantCondOnDeploy.Value.Nodes.FirstOrDefault(n => n.Key == "DeployAnimation");
+						if (deployAnimNode != null)
+						{
+							grantCondOnDeploy.Value.Nodes.Remove(deployAnimNode);
+							Console.WriteLine("DeployAnimation was removed from GrantConditionOnDeploy.");
+							Console.WriteLine("Use WithMakeAnimation instead if a deploy animation is needed.");
+						}
+					}
+				}
+
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -117,10 +117,10 @@ TTNK:
 		MaxHeightDelta: 3
 	RenderSprites:
 		Image: ttnk
+	WithMakeAnimation:
 	GrantConditionOnDeploy:
 		DeployedCondition: deployed
 		UndeployedCondition: undeployed
-		DeployAnimation: make
 		Facing: 160
 		AllowedTerrainTypes: Clear, Road, DirtRoad, Rough
 		DeploySound: place2.aud
@@ -211,10 +211,10 @@ ART2:
 		LightAmbientColor: 0.4, 0.4, 0.4
 	RenderSprites:
 		Image: art2
+	WithMakeAnimation:
 	GrantConditionOnDeploy:
 		DeployedCondition: deployed
 		UndeployedCondition: undeployed
-		DeployAnimation: make
 		Facing: 96
 		AllowedTerrainTypes: Clear, Road, DirtRoad, Rough
 		DeploySound: place2.aud

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -140,6 +140,7 @@ LPST:
 		RequiresCondition: !undeployed
 		Range: 8c0
 		MaxHeightDelta: 3
+	WithMakeAnimation:
 	GrantCondition@PREVIEWWORKAROUND:
 		Condition: real-actor
 	RenderSprites:
@@ -150,7 +151,6 @@ LPST:
 	GrantConditionOnDeploy:
 		DeployedCondition: deployed
 		UndeployedCondition: undeployed
-		DeployAnimation: make
 		Facing: 160
 		AllowedTerrainTypes: Clear, Road, DirtRoad, Rough
 		DeploySound: place2.aud


### PR DESCRIPTION
This adds a Name identifier field to `WithSpriteBody`, which can be used to make animation traits compatible with multiple sprite bodies.
This is then used to make `WithMoveAnimation` and `WithMakeAnimation` compatible with actors that have more than one sprite body (TS artillery and FS Juggernaut, for example).
This allows to remove the deploy animation code from `GrantConditionOnDeploy`.

Split from #13041, which can also be used as test-case (Juggernaut).