### PR TITLE
IsInWorld check for contrail

### DIFF
--- a/OpenRA.Mods.Common/Effects/Contrail.cs
+++ b/OpenRA.Mods.Common/Effects/Contrail.cs
@@ -64,7 +64,8 @@ namespace OpenRA.Mods.Common.Effects
 		public void Tick(Actor self)
 		{
 			var local = info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation));
-			trail.Update(self.CenterPosition + body.LocalToWorld(local));
+			if (self.IsInWorld)
+				trail.Update(self.CenterPosition + body.LocalToWorld(local));
 		}
 
 		public IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)


### PR DESCRIPTION
https://www.youtube.com/watch?v=PJb4L7PyyOo

Possible use by RA2 aircraft carriers and V3 rockets. Without IsInWorld check, the update is called for position (0, 0, 0) when the actor is not in world yet, creating graphical glitch.