### PR TITLE
IsInWorld check for contrail

### DIFF
--- a/OpenRA.Mods.Common/Effects/Contrail.cs
+++ b/OpenRA.Mods.Common/Effects/Contrail.cs
@@ -64,7 +64,10 @@ namespace OpenRA.Mods.Common.Effects
 		public void Tick(Actor self)
 		{
 			var local = info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation));
-			trail.Update(self.CenterPosition + body.LocalToWorld(local));
+			if (self.IsInWorld)
+				trail.Update(self.CenterPosition + body.LocalToWorld(local));
+			else
+				trail.Reset();
 		}
 
 		public IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)

--- a/OpenRA.Mods.Common/Graphics/ContrailRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/ContrailRenderable.cs
@@ -106,6 +106,12 @@ namespace OpenRA.Mods.Common.Graphics
 				length++;
 		}
 
+		public void Reset()
+		{
+			length = 0;
+			next = 0;
+		}
+
 		public static Color ChooseColor(Actor self)
 		{
 			var ownerColor = Color.FromArgb(255, self.Owner.Color.RGB);


### PR DESCRIPTION
https://youtu.be/PJb4L7PyyOo

Possible use by aircraft carriers and V3 rockets. When units with contrail is contained in another actor, without IsInWorld check, Update() is still called and causes graphical glitch when they are launched.