### PR TITLE
Further polish d2k tileset - continuation

### DIFF
--- a/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
@@ -406,6 +406,9 @@ namespace OpenRA.Mods.D2k.UtilityCommands
 				for (var i = 0; i < 4; i++)
 					if (tileIndex == indices[i])
 						return new TerrainTile(251, (byte)i);
+
+				if (tileIndex == 322)
+					return new TerrainTile(215, 0);
 			}
 
 			if (tilesetName.ToLower() == "bloxwast.r8")

--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -1538,7 +1538,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 448, 449, 468, 469
 		Size: 2,2
-		Category: Cliff-Ends
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1685,7 +1685,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 356
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Ice-Detail
 		Tiles:
 			0: Sand
 	Template@216:
@@ -1955,7 +1955,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 352, 353, 372, 373
 		Size: 2,2
-		Category: Sand-Detail
+		Category: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -2166,7 +2166,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 2
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Ice-Detail
 		Tiles:
 			0: Cliff
 	Template@273:
@@ -2174,7 +2174,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 3
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 	Template@274:
@@ -2190,7 +2190,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 5
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Ice-Detail
 		Tiles:
 			0: Rough
 	Template@276:
@@ -2265,7 +2265,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 316
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@285:
@@ -2273,7 +2273,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 297
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@286:
@@ -2281,7 +2281,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 338, 339, 358, 359
 		Size: 2,2
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 			1: Sand
@@ -2344,7 +2344,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 351, 371
 		Size: 1,2
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 			1: Sand
@@ -2353,7 +2353,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 391
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@293:
@@ -2361,7 +2361,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 392
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@294:
@@ -2369,7 +2369,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 393
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@295:
@@ -2377,7 +2377,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 352, 372
 		Size: 1,2
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 			1: Sand
@@ -2386,7 +2386,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 353
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@297:
@@ -2394,7 +2394,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 354
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@298:
@@ -2402,7 +2402,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 374
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@299:
@@ -2410,7 +2410,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 373
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@300:
@@ -2418,7 +2418,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 394, 395, 414, 415
 		Size: 2,2
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 			1: Sand
@@ -2534,7 +2534,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 661, 662, 681, 682
 		Size: 2,2
-		Category: Sand-Detail
+		Category: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -2553,7 +2553,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 684
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 	Template@314:
@@ -2577,7 +2577,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 722
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@317:
@@ -2585,7 +2585,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 721
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@318:
@@ -2609,7 +2609,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 701, 702
 		Size: 2,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 			1: Sand
@@ -2618,7 +2618,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 741
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@322:
@@ -2626,7 +2626,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 742
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@323:
@@ -2634,7 +2634,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 743
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@324:
@@ -2642,7 +2642,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 744
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@325:
@@ -2650,7 +2650,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 745, 746
 		Size: 2,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2659,7 +2659,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 747
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@327:
@@ -2667,7 +2667,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 728
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@328:
@@ -2675,7 +2675,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 708
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Dead-Worm
 		Tiles:
 			0: Sand
 	Template@329:
@@ -2683,7 +2683,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 716, 717, 736, 737
 		Size: 2,2
-		Category: Rock-Detail
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2760,7 +2760,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 388
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@337:
@@ -2801,7 +2801,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 289, 290, 309, 310
 		Size: 2,2
-		Category: Sand-Detail
+		Category: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -2823,7 +2823,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 349, 350, 351, 352, 353, 354, 369, 370, 371, 372, 373, 374, 389, 390, 391, 392, 393, 394
 		Size: 6,3
-		Category: Rock-Detail
+		Category: Bridge
 		Tiles:
 			0: Rock
 			1: Cliff
@@ -2848,7 +2848,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 340, 341, 342, 360, 361, 362, 380, 381, 382
 		Size: 3,3
-		Category: Rock-Detail
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2951,7 +2951,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 700
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Ice-Detail
 		Tiles:
 			0: Sand
 	Template@353:
@@ -2959,7 +2959,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 720
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Ice-Detail
 		Tiles:
 			0: Sand
 	Template@354:
@@ -3054,7 +3054,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 164, 165, 184, 185
 		Size: 2,2
-		Category: Rock-Detail
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -3065,7 +3065,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 289, 290
 		Size: 2,1
-		Category: Ice-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 			1: Sand
@@ -3097,7 +3097,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 322
 		Size: 1,1
-		Category: Ice-Detail
+		Category: Sand-Detail
 		Tiles:
 			0: Sand
 	Template@368:
@@ -3105,7 +3105,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 325
 		Size: 1,1
-		Category: Ice-Detail
+		Category: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@369:
@@ -3113,7 +3113,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 305
 		Size: 1,1
-		Category: Ice-Detail
+		Category: Dead-Worm
 		Tiles:
 			0: Sand
 	Template@370:
@@ -3214,7 +3214,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 353, 354, 373, 374, 393, 394
 		Size: 2,3
-		Category: Ice-Detail
+		Category: Sand-Detail
 		Tiles:
 			0: Transition
 			1: Transition
@@ -3583,7 +3583,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 289, 290, 309, 310
 		Size: 2,2
-		Category: Sand-Detail
+		Category: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -3703,7 +3703,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 578, 579, 598, 599
 		Size: 2,2
-		Category: Sand-Detail
+		Category: Ice-Detail
 		Tiles:
 			0: Transition
 			1: Transition
@@ -3730,7 +3730,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 747
 		Size: 1,1
-		Category: Unidentified
+		Category: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@431:
@@ -3749,7 +3749,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 709
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Dead-Worm
 		Tiles:
 			0: Sand
 	Template@433:
@@ -3774,7 +3774,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 710, 711, 712
 		Size: 3,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Rough
@@ -3877,7 +3877,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 700, 701, 702, 703, 704, 705, 720, 721, 722, 723, 724, 725, 740, 741, 742, 743, 744, 745
 		Size: 6,3
-		Category: Sand-Detail
+		Category: Ice-Detail
 		Tiles:
 			0: SpiceSand
 			1: Sand
@@ -3950,7 +3950,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 712
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Ice-Detail
 		Tiles:
 			0: Sand
 	Template@452:
@@ -3958,7 +3958,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 732
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Ice-Detail
 		Tiles:
 			0: Sand
 	Template@453:
@@ -3966,7 +3966,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 713, 733
 		Size: 1,2
-		Category: Sand-Detail
+		Category: Ice-Detail
 		Tiles:
 			0: Dune
 			1: Dune
@@ -3975,7 +3975,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 734, 735
 		Size: 2,1
-		Category: Sand-Detail
+		Category: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -3984,7 +3984,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 714, 715
 		Size: 2,1
-		Category: Sand-Detail
+		Category: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -3993,7 +3993,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 716, 717, 718, 736, 737, 738
 		Size: 3,2
-		Category: Sand-Detail
+		Category: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -4006,7 +4006,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 739
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Ice-Detail
 		Tiles:
 			0: Sand
 	Template@458:
@@ -4014,7 +4014,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 758, 759
 		Size: 2,1
-		Category: Sand-Detail
+		Category: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -4023,7 +4023,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 652, 653, 672, 673
 		Size: 2,2
-		Category: Sand-Detail
+		Category: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -4071,7 +4071,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 67
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@466:
@@ -4079,7 +4079,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 1
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@467:
@@ -4238,7 +4238,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 305
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 	Template@501:
@@ -4246,7 +4246,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 325
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 	Template@502:
@@ -4254,7 +4254,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 311
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 	Template@503:
@@ -4262,7 +4262,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 312
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 	Template@504:
@@ -4270,7 +4270,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 330
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 	Template@505:
@@ -4278,7 +4278,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 316
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Bridge
 		Tiles:
 			0: Cliff
 	Template@506:
@@ -4286,7 +4286,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 297
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Bridge
 		Tiles:
 			0: Cliff
 	Template@507:
@@ -4294,7 +4294,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 356, 357
 		Size: 2,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4303,7 +4303,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 355
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 	Template@509:
@@ -4311,7 +4311,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 375
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 	Template@510:
@@ -4319,7 +4319,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 395
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 	Template@511:
@@ -4327,7 +4327,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 414, 415, 434, 435
 		Size: 2,2
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4338,7 +4338,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 353, 354, 373, 374, 393, 394
 		Size: 2,3
-		Category: Sand-Detail
+		Category: Bridge
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4351,7 +4351,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 350, 351, 352, 370, 371, 372, 390, 391, 392
 		Size: 3,3
-		Category: Rock-Detail
+		Category: Bridge
 		Tiles:
 			0: Rock
 			1: Rock
@@ -4367,7 +4367,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 347, 348, 349, 367, 368, 369, 387, 388, 389
 		Size: 3,3
-		Category: Rock-Detail
+		Category: Bridge
 		Tiles:
 			0: Sand
 			1: Rough
@@ -4383,7 +4383,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 340, 341, 342, 343, 360, 361, 362, 363, 380, 381, 382, 383
 		Size: 4,3
-		Category: Rock-Detail
+		Category: Bridge
 		Tiles:
 			0: Cliff
 			1: Sand
@@ -4402,7 +4402,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 717
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 	Template@517:
@@ -4410,7 +4410,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 718
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 	Template@518:
@@ -4418,7 +4418,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 737
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 	Template@519:
@@ -4426,7 +4426,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 738, 739, 758, 759
 		Size: 2,2
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4437,7 +4437,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 652, 653, 672, 673
 		Size: 2,2
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5976,7 +5976,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 362, 363, 364
 		Size: 3,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Rough
@@ -5986,7 +5986,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 607
 		Size: 1,1
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@1078:
@@ -6276,7 +6276,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 289, 290, 309, 310
 		Size: 2,2
-		Category: Sand-Detail
+		Category: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Cliff

--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -3,7 +3,7 @@ General:
 	Id: ARRAKIS
 	SheetSize: 1024
 	Palette: PALETTE.BIN
-	EditorTemplateOrder: Basic, Dune, Sand-Detail, Brick, Sand-Cliff, Cliff-Ends, Cliff-Type-Changer, Rock-Sand-Smooth, Rock-Detail, Rock-Cliff, Rock-Cliff-Rock, Rotten-Base, Dead-Worm, Ice, Ice-Detail, Rock-Cliff-Sand, Sand-Platform, Bridge, Unidentified
+	EditorTemplateOrder: Basic, Dune, Sand-Detail, Rock-Detail, Ice-Detail, Rock-Sand-Smooth, Sand-Sand-Cliff, Sand-Rock-Cliff, Sand-Ice-Cliff, Rock-Rock-Cliff, Rock-Sand-Cliff, Cliff-Type-Changer, Cliff-Ends, Sand-Platform, Bridge, Rotten-Base, Dead-Worm, Unidentified
 	IgnoreTileSpriteOffsets: True
 	HeightDebugColors: 880000
 
@@ -176,7 +176,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 53, 73
 		Size: 1,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Transition
 			1: Transition
@@ -185,7 +185,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 98, 99, 118, 119
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -196,7 +196,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 138, 139, 158, 159
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -207,7 +207,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 136, 137, 156, 157
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -218,7 +218,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 134, 135, 154, 155
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -229,7 +229,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 132, 133, 152, 153
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Sand
 			1: Cliff
@@ -240,7 +240,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 130, 131, 150, 151
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Sand
@@ -251,7 +251,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 128, 129, 148, 149
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -262,7 +262,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 126, 127, 146, 147
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -273,7 +273,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 124, 125, 144, 145
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -284,7 +284,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 122, 123, 142, 143
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -295,7 +295,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 120, 121, 140, 141
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -361,7 +361,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 168, 169, 188, 189
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -372,7 +372,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 166, 167, 186, 187
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -394,7 +394,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 162, 163, 182, 183
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -405,7 +405,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 160, 161, 180, 181
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -416,7 +416,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 202, 203, 222, 223, 242, 243
 		Size: 2,3
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -440,7 +440,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 200, 201, 220, 221, 240, 241
 		Size: 2,3
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Sand
@@ -453,7 +453,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 204, 205, 224, 225, 244, 245
 		Size: 2,3
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Sand
@@ -466,7 +466,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 206, 207, 226, 227, 246, 247
 		Size: 2,3
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -501,7 +501,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 85, 86, 105, 106
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -512,7 +512,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 87, 88, 107, 108
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -523,7 +523,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 89, 90, 109, 110
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -534,7 +534,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 91, 92, 111, 112
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -545,7 +545,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 93, 94, 113, 114
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -622,7 +622,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 211, 212, 213, 231, 232, 233
 		Size: 3,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Sand
 			1: Cliff
@@ -635,7 +635,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 251, 252, 253, 271, 272, 273
 		Size: 3,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Sand
 			1: Cliff
@@ -648,7 +648,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 248, 249, 250, 268, 269, 270
 		Size: 3,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -661,7 +661,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 208, 209, 210, 228, 229, 230
 		Size: 3,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -939,7 +939,7 @@ Templates:
 		Frames: 657, 658, 659, 691
 		Size: 1,1
 		PickAny: True
-		Category: Brick
+		Category: Basic
 		Tiles:
 			0: Concrete
 			1: Concrete
@@ -1030,7 +1030,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 692, 693
 		Size: 2,1
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Sand
@@ -1039,7 +1039,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 689, 690
 		Size: 2,1
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1048,7 +1048,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 674, 694
 		Size: 1,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1057,7 +1057,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 675, 695
 		Size: 1,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Sand
@@ -1066,7 +1066,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 677, 697
 		Size: 1,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Rock
@@ -1083,7 +1083,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 678, 679
 		Size: 2,1
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1092,7 +1092,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 698, 699
 		Size: 2,1
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1239,7 +1239,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 600, 601, 602, 620, 621, 622, 640, 641, 642
 		Size: 3,3
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1255,7 +1255,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 603, 604, 623, 624
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1266,7 +1266,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 605, 606, 625, 626
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1277,7 +1277,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 564, 565, 584, 585
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1288,7 +1288,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 566, 567, 586, 587
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1310,7 +1310,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 560, 561, 580, 581
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1343,7 +1343,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 568, 569, 588, 589
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1354,7 +1354,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 570, 571, 590, 591
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1365,7 +1365,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 529, 530, 549, 550
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1376,7 +1376,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 527, 528, 547, 548
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1409,7 +1409,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 520, 521, 522, 540, 541, 542
 		Size: 3,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Sand
 			1: Cliff
@@ -1422,7 +1422,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 480, 481, 482, 500, 501, 502
 		Size: 3,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1446,7 +1446,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 402, 403, 422, 423, 442, 443
 		Size: 2,3
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1470,7 +1470,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 408, 409, 428, 429
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1481,7 +1481,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 410, 411, 430, 431, 450, 451
 		Size: 2,3
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1514,7 +1514,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 454, 455, 474, 475, 494, 495
 		Size: 2,3
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1527,7 +1527,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 489, 490, 509, 510
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1538,7 +1538,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 448, 449, 468, 469
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1549,7 +1549,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 487, 488, 507, 508
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1560,7 +1560,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 446, 447, 466, 467
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1571,7 +1571,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 444, 445, 464, 465
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Rock
@@ -1582,7 +1582,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 456, 457, 476, 477, 496, 497
 		Size: 2,3
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1617,7 +1617,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 418, 419, 438, 439
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1628,7 +1628,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 378, 379, 398, 399
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1639,7 +1639,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 416, 417, 436, 437
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1650,7 +1650,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 376, 377, 396, 397
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1770,7 +1770,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 485, 486, 505, 506
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2035,7 +2035,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 404, 405, 424, 425
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2046,7 +2046,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 406, 407, 426, 427
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2057,7 +2057,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 676, 696
 		Size: 1,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2098,7 +2098,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 511, 512, 513, 531, 532, 533
 		Size: 3,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2111,7 +2111,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 471, 472, 473, 491, 492, 493
 		Size: 3,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -3045,7 +3045,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 97, 117
 		Size: 1,2
-		Category: Ice
+		Category: Sand-Ice-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -3195,7 +3195,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 349, 350, 351, 352, 369, 370, 371, 372, 389, 390, 391, 392
 		Size: 4,3
-		Category: Ice
+		Category: Sand-Ice-Cliff
 		Tiles:
 			0: Cliff
 			1: Ice
@@ -3251,7 +3251,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 539, 559
 		Size: 1,2
-		Category: Unidentified
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -3295,7 +3295,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 700, 701, 720, 721, 740, 741
 		Size: 2,3
-		Category: Ice
+		Category: Sand-Ice-Cliff
 		Tiles:
 			0: Ice
 			1: Cliff
@@ -3308,7 +3308,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 702, 703, 722, 723
 		Size: 2,2
-		Category: Ice
+		Category: Sand-Ice-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -3351,7 +3351,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 704, 705, 724, 725
 		Size: 2,2
-		Category: Ice
+		Category: Sand-Ice-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -3362,7 +3362,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 706, 707, 726, 727, 746, 747
 		Size: 2,3
-		Category: Ice
+		Category: Sand-Ice-Cliff
 		Tiles:
 			0: Cliff
 			1: Ice
@@ -3375,7 +3375,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 708, 709, 728, 729
 		Size: 2,2
-		Category: Ice
+		Category: Sand-Ice-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -3386,7 +3386,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 710, 711, 730, 731
 		Size: 2,2
-		Category: Ice
+		Category: Sand-Ice-Cliff
 		Tiles:
 			0: Ice
 			1: Ice
@@ -3397,7 +3397,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 712, 713, 732, 733
 		Size: 2,2
-		Category: Ice
+		Category: Sand-Ice-Cliff
 		Tiles:
 			0: Ice
 			1: Cliff
@@ -3408,7 +3408,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 714, 715, 734, 735
 		Size: 2,2
-		Category: Ice
+		Category: Sand-Ice-Cliff
 		Tiles:
 			0: Ice
 			1: Ice
@@ -3692,7 +3692,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 538, 539, 558, 559
 		Size: 2,2
-		Category: Sand-Cliff
+		Category: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -3856,7 +3856,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 607, 608, 609, 627, 628, 629
 		Size: 3,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Rock
 			1: Rough
@@ -4169,7 +4169,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 706, 707, 726, 727
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4180,7 +4180,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 557, 558, 559, 577, 578, 579
 		Size: 3,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4218,7 +4218,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 414, 415, 434, 435
 		Size: 2,2
-		Category: Rock-Cliff
+		Category: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4447,7 +4447,7 @@ Templates:
 		Id: 600
 		Images: t600.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4457,7 +4457,7 @@ Templates:
 		Id: 601
 		Images: t601.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4467,7 +4467,7 @@ Templates:
 		Id: 602
 		Images: t602.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4477,7 +4477,7 @@ Templates:
 		Id: 603
 		Images: t603.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4487,7 +4487,7 @@ Templates:
 		Id: 604
 		Images: t604.tmp
 		Size: 2,3
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4499,7 +4499,7 @@ Templates:
 		Id: 605
 		Images: t605.tmp
 		Size: 2,3
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4511,7 +4511,7 @@ Templates:
 		Id: 606
 		Images: t606.tmp
 		Size: 2,1
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4519,7 +4519,7 @@ Templates:
 		Id: 607
 		Images: t607.tmp
 		Size: 2,1
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4527,7 +4527,7 @@ Templates:
 		Id: 608
 		Images: t608.tmp
 		Size: 1,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4535,7 +4535,7 @@ Templates:
 		Id: 609
 		Images: t609.tmp
 		Size: 1,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4561,7 +4561,7 @@ Templates:
 		Id: 612
 		Images: t612.tmp
 		Size: 3,3
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Rock
 			1: Rock
@@ -4576,7 +4576,7 @@ Templates:
 		Id: 613
 		Images: t613.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4586,7 +4586,7 @@ Templates:
 		Id: 614
 		Images: t614.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4596,7 +4596,7 @@ Templates:
 		Id: 615
 		Images: t615.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4606,7 +4606,7 @@ Templates:
 		Id: 616
 		Images: t616.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4616,7 +4616,7 @@ Templates:
 		Id: 617
 		Images: t617.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4626,7 +4626,7 @@ Templates:
 		Id: 618
 		Images: t618.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4636,7 +4636,7 @@ Templates:
 		Id: 619
 		Images: t619.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4646,7 +4646,7 @@ Templates:
 		Id: 620
 		Images: t620.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4656,7 +4656,7 @@ Templates:
 		Id: 621
 		Images: t621.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4666,7 +4666,7 @@ Templates:
 		Id: 622
 		Images: t622.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4676,7 +4676,7 @@ Templates:
 		Id: 623
 		Images: t623.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4686,7 +4686,7 @@ Templates:
 		Id: 624
 		Images: t624.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4696,7 +4696,7 @@ Templates:
 		Id: 625
 		Images: t625.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4706,7 +4706,7 @@ Templates:
 		Id: 626
 		Images: t626.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4716,7 +4716,7 @@ Templates:
 		Id: 627
 		Images: t627.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4726,7 +4726,7 @@ Templates:
 		Id: 628
 		Images: t628.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4736,7 +4736,7 @@ Templates:
 		Id: 629
 		Images: t629.tmp
 		Size: 2,3
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4748,7 +4748,7 @@ Templates:
 		Id: 630
 		Images: t630.tmp
 		Size: 2,3
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4760,7 +4760,7 @@ Templates:
 		Id: 631
 		Images: t631.tmp
 		Size: 3,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4772,7 +4772,7 @@ Templates:
 		Id: 632
 		Images: t632.tmp
 		Size: 3,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4784,7 +4784,7 @@ Templates:
 		Id: 633
 		Images: t633.tmp
 		Size: 3,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4796,7 +4796,7 @@ Templates:
 		Id: 634
 		Images: t634.tmp
 		Size: 3,2
-		Category: Rock-Cliff-Rock
+		Category: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4868,7 +4868,7 @@ Templates:
 		Id: 800
 		Images: t800.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4878,7 +4878,7 @@ Templates:
 		Id: 801
 		Images: t801.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4888,7 +4888,7 @@ Templates:
 		Id: 802
 		Images: t802.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4898,7 +4898,7 @@ Templates:
 		Id: 803
 		Images: t803.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4908,7 +4908,7 @@ Templates:
 		Id: 804
 		Images: t804.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4918,7 +4918,7 @@ Templates:
 		Id: 805
 		Images: t805.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4948,7 +4948,7 @@ Templates:
 		Id: 808
 		Images: t808.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4958,7 +4958,7 @@ Templates:
 		Id: 809
 		Images: t809.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4968,7 +4968,7 @@ Templates:
 		Id: 810
 		Images: t810.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4978,7 +4978,7 @@ Templates:
 		Id: 811
 		Images: t811.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4988,7 +4988,7 @@ Templates:
 		Id: 812
 		Images: t812.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4998,7 +4998,7 @@ Templates:
 		Id: 813
 		Images: t813.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5008,7 +5008,7 @@ Templates:
 		Id: 814
 		Images: t814.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5018,7 +5018,7 @@ Templates:
 		Id: 815
 		Images: t815.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5028,7 +5028,7 @@ Templates:
 		Id: 816
 		Images: t816.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5038,7 +5038,7 @@ Templates:
 		Id: 817
 		Images: t817.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5048,7 +5048,7 @@ Templates:
 		Id: 818
 		Images: t818.tmp
 		Size: 2,1
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5056,7 +5056,7 @@ Templates:
 		Id: 819
 		Images: t819.tmp
 		Size: 2,1
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5064,7 +5064,7 @@ Templates:
 		Id: 820
 		Images: t820.tmp
 		Size: 1,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5072,7 +5072,7 @@ Templates:
 		Id: 821
 		Images: t821.tmp
 		Size: 1,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5080,7 +5080,7 @@ Templates:
 		Id: 822
 		Images: t822.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5090,7 +5090,7 @@ Templates:
 		Id: 823
 		Images: t823.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5100,7 +5100,7 @@ Templates:
 		Id: 824
 		Images: t824.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5110,7 +5110,7 @@ Templates:
 		Id: 825
 		Images: t825.tmp
 		Size: 2,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5120,7 +5120,7 @@ Templates:
 		Id: 826
 		Images: t826.tmp
 		Size: 2,3
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5132,7 +5132,7 @@ Templates:
 		Id: 827
 		Images: t827.tmp
 		Size: 2,3
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5143,7 +5143,7 @@ Templates:
 		Id: 828
 		Images: t828.tmp
 		Size: 2,3
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Transition
@@ -5155,7 +5155,7 @@ Templates:
 		Id: 829
 		Images: t829.tmp
 		Size: 2,3
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5247,7 +5247,7 @@ Templates:
 		Id: 838
 		Images: t838.tmp
 		Size: 3,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5259,7 +5259,7 @@ Templates:
 		Id: 839
 		Images: t839.tmp
 		Size: 3,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5271,7 +5271,7 @@ Templates:
 		Id: 840
 		Images: t840.tmp
 		Size: 3,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5283,7 +5283,7 @@ Templates:
 		Id: 841
 		Images: t841.tmp
 		Size: 3,2
-		Category: Rock-Cliff-Sand
+		Category: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff

--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -385,10 +385,10 @@ Templates:
 		Size: 2,2
 		Category: Rock-Detail
 		Tiles:
-			0: Cliff
-			1: Cliff
-			2: Cliff
-			3: Cliff
+			0: Rough
+			1: Rough
+			2: Rough
+			3: Rough
 	Template@29:
 		Id: 29
 		Images: BLOXBASE.R8
@@ -4240,7 +4240,7 @@ Templates:
 		Size: 1,1
 		Category: Rotten-Base
 		Tiles:
-			0: Cliff
+			0: Rough
 	Template@501:
 		Id: 501
 		Images: BLOXXMAS.R8
@@ -4248,7 +4248,7 @@ Templates:
 		Size: 1,1
 		Category: Rotten-Base
 		Tiles:
-			0: Cliff
+			0: Sand
 	Template@502:
 		Id: 502
 		Images: BLOXXMAS.R8
@@ -4256,7 +4256,7 @@ Templates:
 		Size: 1,1
 		Category: Rotten-Base
 		Tiles:
-			0: Cliff
+			0: Rough
 	Template@503:
 		Id: 503
 		Images: BLOXXMAS.R8
@@ -4264,7 +4264,7 @@ Templates:
 		Size: 1,1
 		Category: Rotten-Base
 		Tiles:
-			0: Cliff
+			0: Rough
 	Template@504:
 		Id: 504
 		Images: BLOXXMAS.R8
@@ -4272,7 +4272,7 @@ Templates:
 		Size: 1,1
 		Category: Rotten-Base
 		Tiles:
-			0: Cliff
+			0: Rough
 	Template@505:
 		Id: 505
 		Images: BLOXXMAS.R8
@@ -4280,7 +4280,7 @@ Templates:
 		Size: 1,1
 		Category: Bridge
 		Tiles:
-			0: Cliff
+			0: Rough
 	Template@506:
 		Id: 506
 		Images: BLOXXMAS.R8
@@ -4288,7 +4288,7 @@ Templates:
 		Size: 1,1
 		Category: Bridge
 		Tiles:
-			0: Cliff
+			0: Rough
 	Template@507:
 		Id: 507
 		Images: BLOXXMAS.R8
@@ -4296,8 +4296,8 @@ Templates:
 		Size: 2,1
 		Category: Rotten-Base
 		Tiles:
-			0: Cliff
-			1: Cliff
+			0: Rough
+			1: Rough
 	Template@508:
 		Id: 508
 		Images: BLOXXMAS.R8
@@ -4305,7 +4305,7 @@ Templates:
 		Size: 1,1
 		Category: Rotten-Base
 		Tiles:
-			0: Cliff
+			0: Rough
 	Template@509:
 		Id: 509
 		Images: BLOXXMAS.R8
@@ -4313,7 +4313,7 @@ Templates:
 		Size: 1,1
 		Category: Rotten-Base
 		Tiles:
-			0: Cliff
+			0: Rough
 	Template@510:
 		Id: 510
 		Images: BLOXXMAS.R8
@@ -4321,7 +4321,7 @@ Templates:
 		Size: 1,1
 		Category: Rotten-Base
 		Tiles:
-			0: Cliff
+			0: Rough
 	Template@511:
 		Id: 511
 		Images: BLOXXMAS.R8
@@ -4329,10 +4329,10 @@ Templates:
 		Size: 2,2
 		Category: Rotten-Base
 		Tiles:
-			0: Cliff
-			1: Cliff
-			2: Cliff
-			3: Cliff
+			0: Rough
+			1: Rough
+			2: Rough
+			3: Rough
 	Template@512:
 		Id: 512
 		Images: BLOXXMAS.R8
@@ -4340,12 +4340,12 @@ Templates:
 		Size: 2,3
 		Category: Bridge
 		Tiles:
-			0: Cliff
-			1: Cliff
-			2: Cliff
-			3: Cliff
-			4: Cliff
-			5: Cliff
+			0: Rough
+			1: Rough
+			2: Rough
+			3: Rough
+			4: Rough
+			5: Rough
 	Template@513:
 		Id: 513
 		Images: BLOXXMAS.R8
@@ -4353,15 +4353,15 @@ Templates:
 		Size: 3,3
 		Category: Bridge
 		Tiles:
-			0: Rock
+			0: Cliff
 			1: Rock
-			2: Rock
+			2: Cliff
 			3: Cliff
-			4: Rough
+			4: Transition
 			5: Cliff
-			6: Cliff
+			6: Rough
 			7: Rough
-			8: Cliff
+			8: Rough
 	Template@514:
 		Id: 514
 		Images: BLOXXMAS.R8
@@ -4369,11 +4369,11 @@ Templates:
 		Size: 3,3
 		Category: Bridge
 		Tiles:
-			0: Sand
+			0: Rough
 			1: Rough
-			2: Cliff
+			2: Rough
 			3: Cliff
-			4: Rough
+			4: Transition
 			5: Cliff
 			6: Rock
 			7: Rock
@@ -4386,8 +4386,8 @@ Templates:
 		Category: Bridge
 		Tiles:
 			0: Cliff
-			1: Sand
-			2: Sand
+			1: Cliff
+			2: Cliff
 			3: Cliff
 			4: Transition
 			5: Transition
@@ -4412,7 +4412,7 @@ Templates:
 		Size: 1,1
 		Category: Rotten-Base
 		Tiles:
-			0: Cliff
+			0: Rough
 	Template@518:
 		Id: 518
 		Images: BLOXXMAS.R8
@@ -4428,10 +4428,10 @@ Templates:
 		Size: 2,2
 		Category: Rotten-Base
 		Tiles:
-			0: Cliff
-			1: Cliff
+			0: Sand
+			1: Sand
 			2: Cliff
-			3: Cliff
+			3: Rough
 	Template@520:
 		Id: 520
 		Images: BLOXXMAS.R8
@@ -4442,7 +4442,7 @@ Templates:
 			0: Cliff
 			1: Cliff
 			2: Cliff
-			3: Cliff
+			3: Sand
 	Template@600:
 		Id: 600
 		Images: t600.tmp
@@ -5996,8 +5996,8 @@ Templates:
 		Size: 2,1
 		Category: Sand-Detail
 		Tiles:
-			0: Cliff
-			1: Cliff
+			0: Rough
+			1: Rough
 	Template@1079:
 		Id: 1079
 		Images: BLOXBAT.R8
@@ -6110,7 +6110,7 @@ Templates:
 		Size: 2,2
 		Category: Bridge
 		Tiles:
-			0: Cliff
+			0: Rock
 			1: Cliff
 			2: Rock
 			3: Transition
@@ -6122,7 +6122,7 @@ Templates:
 		Category: Bridge
 		Tiles:
 			0: Cliff
-			1: Cliff
+			1: Rock
 			2: Transition
 			3: Rock
 	Template@1093:
@@ -6134,7 +6134,7 @@ Templates:
 		Tiles:
 			0: Rock
 			1: Transition
-			2: Cliff
+			2: Rock
 			3: Cliff
 	Template@1094:
 		Id: 1094
@@ -6146,7 +6146,7 @@ Templates:
 			0: Transition
 			1: Rock
 			2: Cliff
-			3: Cliff
+			3: Rock
 	Template@1095:
 		Id: 1095
 		Images: BLOXXMAS.R8
@@ -6178,7 +6178,7 @@ Templates:
 		Tiles:
 			0: Cliff
 			1: Transition
-			2: Cliff
+			2: Rock
 			3: Rock
 	Template@1098:
 		Id: 1098
@@ -6190,7 +6190,7 @@ Templates:
 			0: Transition
 			1: Cliff
 			2: Rock
-			3: Cliff
+			3: Rock
 	Template@1099:
 		Id: 1099
 		Images: BLOXXMAS.R8
@@ -6216,7 +6216,7 @@ Templates:
 		Size: 1,2
 		Category: Bridge
 		Tiles:
-			0: Cliff
+			0: Rough
 			1: Rough
 	Template@1102:
 		Id: 1102
@@ -6225,7 +6225,7 @@ Templates:
 		Size: 1,2
 		Category: Bridge
 		Tiles:
-			0: Cliff
+			0: Rough
 			1: Rough
 	Template@1103:
 		Id: 1103
@@ -6253,7 +6253,7 @@ Templates:
 		Category: Bridge
 		Tiles:
 			0: Rough
-			1: Cliff
+			1: Rough
 	Template@1106:
 		Id: 1106
 		Images: BLOXXMAS.R8
@@ -6262,7 +6262,7 @@ Templates:
 		Category: Bridge
 		Tiles:
 			0: Rough
-			1: Cliff
+			1: Rough
 	Template@1107:
 		Id: 1107
 		Images: BLOXTREE.R8
@@ -6278,10 +6278,10 @@ Templates:
 		Size: 2,2
 		Category: Rotten-Base
 		Tiles:
-			0: Cliff
-			1: Cliff
-			2: Cliff
-			3: Cliff
+			0: Rough
+			1: Rough
+			2: Rough
+			3: Rough
 	Template@1109:
 		Id: 1109
 		Images: BLOXXMAS.R8
@@ -6289,8 +6289,8 @@ Templates:
 		Size: 2,1
 		Category: Bridge
 		Tiles:
-			0: Cliff
-			1: Cliff
+			0: Rough
+			1: Rough
 	Template@1110:
 		Id: 1110
 		Images: BLOXXMAS.R8
@@ -6298,8 +6298,8 @@ Templates:
 		Size: 2,1
 		Category: Bridge
 		Tiles:
-			0: Cliff
-			1: Cliff
+			0: Rough
+			1: Rough
 	Template@1111:
 		Id: 1111
 		Images: BLOXXMAS.R8
@@ -6307,8 +6307,8 @@ Templates:
 		Size: 2,1
 		Category: Bridge
 		Tiles:
-			0: Cliff
-			1: Cliff
+			0: Rough
+			1: Rough
 	Template@1112:
 		Id: 1112
 		Images: BLOXXMAS.R8
@@ -6316,5 +6316,5 @@ Templates:
 		Size: 2,1
 		Category: Bridge
 		Tiles:
-			0: Cliff
-			1: Cliff
+			0: Rough
+			1: Rough


### PR DESCRIPTION
Depends on/Hijacks #12868.

- implements Items comments on passability on Bridges and some Sand-Detail terrain.
- fixes the map importer for the terrain tiling error Item mentioned.
- renames and reorders terrain categories: To be uniform (XXX-YYY-Cliff), similar categories adjacent to each other, moves most used categories to top.
- moves tiles into appropriate categories