### PR TITLE
Implement a workaround for the mono 5.0 cursor enumerator bug.

### DIFF
--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -139,8 +139,15 @@ namespace OpenRA.Orders
 			if (mi.Modifiers.HasModifier(Modifiers.Alt))
 				modifiers |= TargetModifiers.ForceMove;
 
+			// The Select(x => x) is required to work around an issue on mono 5.0
+			// where calling OrderBy* on SelectManySingleSelectorIterator can in some
+			// circumstances (which we were unable to identify) replace entries in the
+			// enumeration with duplicates of other entries.
+			// Other action that replace the SelectManySingleSelectorIterator with a
+			// different enumerator type (e.g. .Where(true) or .ToList()) also work.
 			var orders = self.TraitsImplementing<IIssueOrder>()
 				.SelectMany(trait => trait.Orders.Select(x => new { Trait = trait, Order = x }))
+				.Select(x => x)
 				.OrderByDescending(x => x.Order.OrderPriority);
 
 			for (var i = 0; i < 2; i++)


### PR DESCRIPTION
Closes #13135.

My debugging suggests that the issue only happens when we have a `SelectMany().OrderBy()`, which we only use here and in a few places that do rendering (PBOG, Carryalls, editor actor previews).  I didn't notice any obvious issues with those, so I am reasonably confident based on the information at hand that we shouldn't have other more subtle (e.g. desync) bugs.