### PR TITLE
Fix (Vehicle) pathing to next walled tile

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -74,11 +74,16 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			List<CPos> pb;
-			using (var fromSrc = PathSearch.FromPoint(world, mi, self, target, source, true).WithIgnoredActor(ignoreActor))
-			using (var fromDest = PathSearch.FromPoint(world, mi, self, source, target, true).WithIgnoredActor(ignoreActor).Reverse())
-				pb = FindBidiPath(fromSrc, fromDest);
+			if ((target - source).Length > 1)
+			{
+				using (var fromSrc = PathSearch.FromPoint(world, mi, self, target, source, true).WithIgnoredActor(ignoreActor))
+				using (var fromDest = PathSearch.FromPoint(world, mi, self, source, target, true).WithIgnoredActor(ignoreActor).Reverse())
+					pb = FindBidiPath(fromSrc, fromDest);
 
-			CheckSanePath2(pb, source, target);
+				CheckSanePath2(pb, source, target);
+			}
+			else
+				pb = new List<CPos>() { target, source };
 
 			return pb;
 		}


### PR DESCRIPTION
Fixes #6989

With 2 nearby cells and only 1 path between them, vehicle didn't move as starting graph points aren't closed and after expanding e.g. from the source cell to target cell, the path wasn't found. I don't know if there is better solution (e.g. should be source/target points Closed?), but this is at least simple/safe solution.
It could be also applied for FindUnitPathToRange function.