### PR TITLE
Key IsRepeat - Fix holding ESC pauses game forever

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -207,6 +207,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (world.IsGameOver)
 				resumeButton.GetText = () => "Return to map";
 
+			resumeButton.OnKeyPress = ki => { if (ki.Event == KeyInputEvent.Down && !ki.IsRepeat) resumeButton.OnClick(); };
 			resumeButton.OnClick = closeMenu;
 
 			var panelRoot = widget.GetOrNull("PANEL_ROOT");

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
@@ -40,6 +40,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var blinking = false;
 				var lp = world.LocalPlayer;
 				options.IsDisabled = () => disableSystemButtons;
+				options.OnKeyPress = ki => { if (ki.Event == KeyInputEvent.Down && !ki.IsRepeat) options.OnClick(); };
 				options.OnClick = () =>
 				{
 					blinking = false;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
@@ -133,37 +133,48 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		public bool HandleKeyPress(KeyInput e)
 		{
-			if (e.Event == KeyInputEvent.Down && !e.IsRepeat)
+			if (e.Event == KeyInputEvent.Down)
 			{
 				var h = Hotkey.FromKeyInput(e);
+				var isFirstPress = !e.IsRepeat;
+
 				if (h == Game.Settings.Keys.ObserverCombinedView && !limitViews)
 				{
-					selected = combined;
-					selected.OnClick();
+					if (isFirstPress)
+					{
+						selected = combined;
+						selected.OnClick();
+					}
 
 					return true;
 				}
 
 				if (h == Game.Settings.Keys.ObserverWorldView && !limitViews)
 				{
-					selected = disableShroud;
-					selected.OnClick();
+					if (isFirstPress)
+					{
+						selected = disableShroud;
+						selected.OnClick();
+					}
 
 					return true;
 				}
 
 				if (e.Key >= Keycode.NUMBER_0 && e.Key <= Keycode.NUMBER_9)
 				{
-					var key = (int)e.Key - (int)Keycode.NUMBER_0;
-					var team = teams.Where(t => t.Key == key).SelectMany(s => s);
-					if (!team.Any())
-						return false;
+					if (isFirstPress)
+					{
+						var key = (int)e.Key - (int)Keycode.NUMBER_0;
+						var team = teams.Where(t => t.Key == key).SelectMany(s => s);
+						if (!team.Any())
+							return false;
 
-					if (e.Modifiers == Modifiers.Shift)
-						team = team.Reverse();
+						if (e.Modifiers == Modifiers.Shift)
+							team = team.Reverse();
 
-					selected = team.SkipWhile(t => t.Player != selected.Player).Skip(1).FirstOrDefault() ?? team.FirstOrDefault();
-					selected.OnClick();
+						selected = team.SkipWhile(t => t.Player != selected.Player).Skip(1).FirstOrDefault() ?? team.FirstOrDefault();
+						selected.OnClick();
+					}
 
 					return true;
 				}


### PR DESCRIPTION
Open and close in game menu only on first key press.
Some other hotkeys also modified to apply them only on first key press.

Suggestion: change default ButtonWidget.OnKeyPress from { OnClick(); } to {ki => { if (ki.Event == KeyInputEvent.Down && !ki.IsRepeat) OnClick(); }

Closes #7941