### PR TITLE
Fix initial high ping - reported high latency on first connection to lobby

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -378,9 +378,6 @@ namespace OpenRA.Server
 				if (Dedicated || !LobbyInfo.IsSinglePlayer)
 					SendMessage("{0} has joined the game.".F(client.Name));
 
-				// Send initial ping
-				SendOrderTo(newConn, "Ping", Game.RunTime.ToString(CultureInfo.InvariantCulture));
-
 				if (Dedicated)
 				{
 					var motdFile = Platform.ResolvePath("^", "motd.txt");
@@ -510,6 +507,10 @@ namespace OpenRA.Server
 							break;
 						}
 
+						if (pingSent < 0)
+							break;
+
+						var ping = Game.RunTime - pingSent;
 						var client = GetClient(conn);
 						if (client == null)
 							return;
@@ -519,7 +520,7 @@ namespace OpenRA.Server
 							return;
 
 						var history = pingFromClient.LatencyHistory.ToList();
-						history.Add(Game.RunTime - pingSent);
+						history.Add(ping);
 
 						// Cap ping history at 5 values (25 seconds)
 						if (history.Count > 5)


### PR DESCRIPTION
Ideally the initial ping could be improved (or ignored?) as it takes much longer and it means after joining lobby, Latency can be displayed worse as actual, e.g. Yellow (rarely Red) first few seconds.

// ping history at 5 values (25 seconds)
-------------------------------------Before   After
Latency: -1, HistoryCount: 0	          ---      (Gray)	   (Gray)	
**Latency: 318, HistoryCount: 1**  ---      (Yellow)    **(Gray)**
Avg Latency: 180, HistoryCount: 2       ---      (Green)	   (Green)
Avg Latency: 146, HistoryCount: 3
Avg Latency: 131, HistoryCount: 4
Avg Latency: 120, HistoryCount: 5
Avg Latency: 70, HistoryCount: 5
Avg Latency: 68, HistoryCount: 5

These are numbers from Skirmish, not sure if it is the same or worse for multiplayer.
The later reported average latencies after first one 318 are still higher due to high first ping time.