### PR TITLE
Add Visualization chat commands

### DIFF
--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Graphics
 		readonly HardwarePalette palette = new HardwarePalette();
 		readonly Dictionary<string, PaletteReference> palettes = new Dictionary<string, PaletteReference>();
 		readonly TerrainRenderer terrainRenderer;
-		readonly Lazy<DeveloperMode> devTrait;
+		readonly Lazy<DebugVisualizations> debugVis;
 		readonly Func<string, PaletteReference> createPaletteReference;
 		readonly bool enableDepthBuffer;
 
@@ -61,7 +61,7 @@ namespace OpenRA.Graphics
 			Theater = new Theater(world.Map.Rules.TileSet);
 			terrainRenderer = new TerrainRenderer(world, this);
 
-			devTrait = Exts.Lazy(() => world.LocalPlayer != null ? world.LocalPlayer.PlayerActor.Trait<DeveloperMode>() : null);
+			debugVis = Exts.Lazy(() => world.WorldActor.TraitOrDefault<DebugVisualizations>());
 		}
 
 		public void UpdatePalettesForPlayer(string internalName, HSLColor color, bool replaceExisting)
@@ -125,11 +125,11 @@ namespace OpenRA.Graphics
 			if (World.WorldActor.Disposed)
 				return;
 
-			if (devTrait.Value != null)
+			if (debugVis.Value != null)
 			{
-				Game.Renderer.WorldSpriteRenderer.SetDepthPreviewEnabled(devTrait.Value.ShowDepthPreview);
-				Game.Renderer.WorldRgbaSpriteRenderer.SetDepthPreviewEnabled(devTrait.Value.ShowDepthPreview);
-				Game.Renderer.WorldRgbaColorRenderer.SetDepthPreviewEnabled(devTrait.Value.ShowDepthPreview);
+				Game.Renderer.WorldSpriteRenderer.SetDepthPreviewEnabled(debugVis.Value.DepthBuffer);
+				Game.Renderer.WorldRgbaSpriteRenderer.SetDepthPreviewEnabled(debugVis.Value.DepthBuffer);
+				Game.Renderer.WorldRgbaColorRenderer.SetDepthPreviewEnabled(debugVis.Value.DepthBuffer);
 			}
 
 			RefreshPalette();
@@ -196,7 +196,7 @@ namespace OpenRA.Graphics
 				foreach (var r in g)
 					r.Render(this);
 
-			if (devTrait.Value != null && devTrait.Value.ShowDebugGeometry)
+			if (debugVis.Value != null && debugVis.Value.RenderGeometry)
 			{
 				for (var i = 0; i < renderables.Count; i++)
 					renderables[i].RenderDebugGeometry(this);

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -181,7 +181,6 @@
     <Compile Include="Sync.cs" />
     <Compile Include="TraitDictionary.cs" />
     <Compile Include="Traits\LintAttributes.cs" />
-    <Compile Include="Traits\Player\DeveloperMode.cs" />
     <Compile Include="Traits\Player\PlayerResources.cs" />
     <Compile Include="Traits\Selectable.cs" />
     <Compile Include="Traits\Target.cs" />

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -190,6 +190,7 @@
     <Compile Include="Traits\World\ResourceType.cs" />
     <Compile Include="Traits\World\ScreenShaker.cs" />
     <Compile Include="Traits\World\Shroud.cs" />
+    <Compile Include="Traits\World\DebugVisualizations.cs" />
     <Compile Include="World.cs" />
     <Compile Include="WorldUtils.cs" />
     <Compile Include="VoiceExts.cs" />

--- a/OpenRA.Game/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Game/Traits/Player/DeveloperMode.cs
@@ -47,18 +47,6 @@ namespace OpenRA.Traits
 		[Desc("Enable the path debug overlay by default.")]
 		public bool PathDebug;
 
-		[Desc("Enable the combat geometry overlay by default.")]
-		public bool ShowCombatGeometry;
-
-		[Desc("Enable the debug geometry overlay by default.")]
-		public bool ShowDebugGeometry;
-
-		[Desc("Enable the depth buffer overlay by default.")]
-		public bool ShowDepthPreview;
-
-		[Desc("Enable the actor tags overlay by default.")]
-		public bool ShowActorTags;
-
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
 		{
 			yield return new LobbyBooleanOption("cheats", "Debug Menu", Enabled, Locked);
@@ -88,12 +76,6 @@ namespace OpenRA.Traits
 		public bool UnlimitedPower { get { return Enabled && unlimitedPower; } }
 		public bool BuildAnywhere { get { return Enabled && buildAnywhere; } }
 
-		// Client side only
-		public bool ShowCombatGeometry;
-		public bool ShowDebugGeometry;
-		public bool ShowDepthPreview;
-		public bool ShowActorTags;
-
 		bool enableAll;
 
 		public DeveloperMode(DeveloperModeInfo info)
@@ -105,11 +87,6 @@ namespace OpenRA.Traits
 			pathDebug = info.PathDebug;
 			unlimitedPower = info.UnlimitedPower;
 			buildAnywhere = info.BuildAnywhere;
-
-			ShowCombatGeometry = info.ShowCombatGeometry;
-			ShowDebugGeometry = info.ShowDebugGeometry;
-			ShowDepthPreview = info.ShowDepthPreview;
-			ShowActorTags = info.ShowActorTags;
 		}
 
 		void INotifyCreated.Created(Actor self)

--- a/OpenRA.Game/Traits/World/DebugVisualizations.cs
+++ b/OpenRA.Game/Traits/World/DebugVisualizations.cs
@@ -1,0 +1,24 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+namespace OpenRA.Traits
+{
+	[Desc("Enables visualization commands. Attach this to the world actor.")]
+	public class DebugVisualizationsInfo : TraitInfo<DebugVisualizations> { }
+
+	public class DebugVisualizations
+	{
+		public bool CombatGeometry;
+		public bool RenderGeometry;
+		public bool DepthBuffer;
+		public bool ActorTags;
+	}
+}

--- a/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
@@ -1,0 +1,70 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using OpenRA.Graphics;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Commands
+{
+	[Desc("Enables visualization commands via the chatbox. Attach this to the world actor.")]
+	public class DebugVisualizationCommandsInfo : TraitInfo<DebugVisualizationCommands> { }
+
+	public class DebugVisualizationCommands : IChatCommand, IWorldLoaded
+	{
+		DebugVisualizations debugVis;
+
+		public void WorldLoaded(World w, WorldRenderer wr)
+		{
+			var world = w;
+			debugVis = world.WorldActor.TraitOrDefault<DebugVisualizations>();
+
+			if (debugVis == null)
+				return;
+
+			var console = world.WorldActor.Trait<ChatCommands>();
+			var help = world.WorldActor.Trait<HelpCommand>();
+
+			Action<string, string> register = (name, helpText) =>
+			{
+				console.RegisterCommand(name, this);
+				help.RegisterHelp(name, helpText);
+			};
+
+			register("showcombatgeometry", "toggles combat geometry overlay.");
+			register("showrendergeometry", "toggles render geometry overlay.");
+			register("showdepthbuffer", "toggles depth buffer overlay.");
+			register("showactortags", "toggles actor tags overlay.");
+		}
+
+		public void InvokeCommand(string name, string arg)
+		{
+			switch (name)
+			{
+				case "showcombatgeometry":
+					debugVis.CombatGeometry ^= true;
+					break;
+
+				case "showrendergeometry":
+					debugVis.RenderGeometry ^= true;
+					break;
+
+				case "showdepthbuffer":
+					debugVis.DepthBuffer ^= true;
+					break;
+
+				case "showactortags":
+					debugVis.ActorTags ^= true;
+					break;
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -297,6 +297,7 @@
     <Compile Include="Traits\CommandBarBlacklist.cs" />
     <Compile Include="Traits\Health.cs" />
     <Compile Include="Traits\HitShape.cs" />
+    <Compile Include="Traits\Player\DeveloperMode.cs" />
     <Compile Include="Traits\PowerTooltip.cs" />
     <Compile Include="Traits\Render\VeteranProductionIconOverlay.cs" />
     <Compile Include="Traits\Capturable.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -157,6 +157,7 @@
     <Compile Include="Commands\DevCommands.cs" />
     <Compile Include="Commands\HelpCommand.cs" />
     <Compile Include="Commands\PlayerCommands.cs" />
+    <Compile Include="Commands\DebugVisualizationCommands.cs" />
     <Compile Include="Graphics\ActorPreview.cs" />
     <Compile Include="Graphics\BeamRenderable.cs" />
     <Compile Include="Graphics\ContrailRenderable.cs" />

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
@@ -30,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		static readonly WVec TargetPosHLine = new WVec(0, 128, 0);
 		static readonly WVec TargetPosVLine = new WVec(128, 0, 0);
 
-		readonly DeveloperMode devMode;
+		readonly DebugVisualizations debugVis;
 		readonly HealthInfo healthInfo;
 		readonly Lazy<BodyOrientation> coords;
 
@@ -42,8 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 			healthInfo = self.Info.TraitInfoOrDefault<HealthInfo>();
 			coords = Exts.Lazy(self.Trait<BodyOrientation>);
 
-			var localPlayer = self.World.LocalPlayer;
-			devMode = localPlayer != null ? localPlayer.PlayerActor.Trait<DeveloperMode>() : null;
+			debugVis = self.World.WorldActor.TraitOrDefault<DebugVisualizations>();
 		}
 
 		void INotifyCreated.Created(Actor self)
@@ -54,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void IRenderAboveWorld.RenderAboveWorld(Actor self, WorldRenderer wr)
 		{
-			if (devMode == null || !devMode.ShowCombatGeometry)
+			if (debugVis == null || !debugVis.CombatGeometry)
 				return;
 
 			var wcr = Game.Renderer.WorldRgbaColorRenderer;
@@ -132,7 +130,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyDamage.Damaged(Actor self, AttackInfo e)
 		{
-			if (devMode == null || !devMode.ShowCombatGeometry || e.Damage.Value == 0)
+			if (debugVis == null || !debugVis.CombatGeometry || e.Damage.Value == 0)
 				return;
 
 			if (healthInfo == null)

--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
@@ -11,8 +11,9 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Traits;
 
-namespace OpenRA.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Attach this to the player actor.")]
 	public class DeveloperModeInfo : ITraitInfo, ILobbyOptions

--- a/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 	class CustomTerrainDebugOverlay : IWorldLoaded, IChatCommand, IRender
 	{
 		const string CommandName = "debugcustomterrain";
-		const string CommandDesc = "Toggles the custom terrain debug overlay.";
+		const string CommandDesc = "toggles the custom terrain debug overlay.";
 
 		public bool Enabled;
 

--- a/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 	class RenderDebugState : INotifyAddedToWorld, INotifyOwnerChanged, IRenderAboveShroudWhenSelected
 	{
-		readonly DeveloperMode devMode;
+		readonly DebugVisualizations debugVis;
 		readonly SpriteFont font;
 		readonly Actor self;
 		readonly WVec offset;
@@ -48,8 +48,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			color = GetColor();
 			font = Game.Renderer.Fonts[info.Font];
 
-			var localPlayer = self.World.LocalPlayer;
-			devMode = localPlayer != null ? localPlayer.PlayerActor.Trait<DeveloperMode>() : null;
+			debugVis = self.World.WorldActor.TraitOrDefault<DebugVisualizations>();
 			ai = self.Owner.PlayerActor.TraitsImplementing<HackyAI>().FirstOrDefault(x => x.IsEnabled);
 		}
 
@@ -70,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
-			if (devMode == null || !devMode.ShowActorTags)
+			if (debugVis == null || !debugVis.ActorTags)
 				yield break;
 
 			yield return new TextRenderable(font, self.CenterPosition - offset, 0, color, tagString);

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class TerrainGeometryOverlay : IRenderAboveWorld, IWorldLoaded, IChatCommand
 	{
 		const string CommandName = "terrainoverlay";
-		const string CommandDesc = "Toggles the terrain geometry overlay";
+		const string CommandDesc = "toggles the terrain geometry overlay.";
 
 		public bool Enabled;
 

--- a/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
@@ -25,12 +25,9 @@ namespace OpenRA.Mods.Common.Warheads
 		{
 			var world = firedBy.World;
 
-			if (world.LocalPlayer != null)
-			{
-				var devMode = world.LocalPlayer.PlayerActor.TraitOrDefault<DeveloperMode>();
-				if (devMode != null && devMode.ShowCombatGeometry)
-					world.WorldActor.Trait<WarheadDebugOverlay>().AddImpact(pos, Spread, DebugOverlayColor);
-			}
+			var debugVis = world.WorldActor.TraitOrDefault<DebugVisualizations>();
+			if (debugVis != null && debugVis.CombatGeometry)
+				world.WorldActor.Trait<WarheadDebugOverlay>().AddImpact(pos, Spread, DebugOverlayColor);
 
 			var range = Spread[0];
 			var hitActors = world.FindActorsInCircle(pos, range);

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -54,12 +54,9 @@ namespace OpenRA.Mods.Common.Warheads
 		{
 			var world = firedBy.World;
 
-			if (world.LocalPlayer != null)
-			{
-				var devMode = world.LocalPlayer.PlayerActor.TraitOrDefault<DeveloperMode>();
-				if (devMode != null && devMode.ShowCombatGeometry)
-					world.WorldActor.Trait<WarheadDebugOverlay>().AddImpact(pos, Range, DebugOverlayColor);
-			}
+			var debugVis = world.WorldActor.TraitOrDefault<DebugVisualizations>();
+			if (debugVis != null && debugVis.CombatGeometry)
+				world.WorldActor.Trait<WarheadDebugOverlay>().AddImpact(pos, Range, DebugOverlayColor);
 
 			// This only finds actors where the center is within the search radius,
 			// so we need to search beyond the maximum spread to account for actors with large health radius

--- a/OpenRA.Mods.Common/Warheads/TargetDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/TargetDamageWarhead.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -33,12 +32,9 @@ namespace OpenRA.Mods.Common.Warheads
 			var world = firedBy.World;
 			var debugOverlayRange = new[] { WDist.Zero, new WDist(128) };
 
-			if (world.LocalPlayer != null)
-			{
-				var devMode = world.LocalPlayer.PlayerActor.TraitOrDefault<DeveloperMode>();
-				if (devMode != null && devMode.ShowCombatGeometry)
-					world.WorldActor.Trait<WarheadDebugOverlay>().AddImpact(pos, debugOverlayRange, DebugOverlayColor);
-			}
+			var debugVis = world.WorldActor.TraitOrDefault<DebugVisualizations>();
+			if (debugVis != null && debugVis.CombatGeometry)
+				world.WorldActor.Trait<WarheadDebugOverlay>().AddImpact(pos, debugOverlayRange, DebugOverlayColor);
 		}
 
 		public override void DoImpact(Actor victim, Actor firedBy, IEnumerable<int> damageModifiers)
@@ -53,8 +49,9 @@ namespace OpenRA.Mods.Common.Warheads
 			if (world.LocalPlayer != null)
 			{
 				var debugOverlayRange = new[] { WDist.Zero, new WDist(128) };
-				var devMode = world.LocalPlayer.PlayerActor.TraitOrDefault<DeveloperMode>();
-				if (devMode != null && devMode.ShowCombatGeometry)
+
+				var debugVis = world.WorldActor.TraitOrDefault<DebugVisualizations>();
+				if (debugVis != null && debugVis.CombatGeometry)
 					world.WorldActor.Trait<WarheadDebugOverlay>().AddImpact(victim.CenterPosition, debugOverlayRange, DebugOverlayColor);
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/DebugMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/DebugMenuLogic.cs
@@ -21,6 +21,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		public DebugMenuLogic(Widget widget, World world)
 		{
 			var devTrait = world.LocalPlayer.PlayerActor.Trait<DeveloperMode>();
+			var debugVis = world.WorldActor.TraitOrDefault<DebugVisualizations>();
 
 			var visibilityCheckbox = widget.GetOrNull<CheckboxWidget>("DISABLE_VISIBILITY_CHECKS");
 			if (visibilityCheckbox != null)
@@ -63,15 +64,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var showCombatCheckbox = widget.GetOrNull<CheckboxWidget>("SHOW_COMBATOVERLAY");
 			if (showCombatCheckbox != null)
 			{
-				showCombatCheckbox.IsChecked = () => devTrait.ShowCombatGeometry;
-				showCombatCheckbox.OnClick = () => devTrait.ShowCombatGeometry ^= true;
+				showCombatCheckbox.Disabled = debugVis == null;
+				showCombatCheckbox.IsChecked = () => debugVis != null && debugVis.CombatGeometry;
+				showCombatCheckbox.OnClick = () => debugVis.CombatGeometry ^= true;
 			}
 
 			var showGeometryCheckbox = widget.GetOrNull<CheckboxWidget>("SHOW_GEOMETRY");
 			if (showGeometryCheckbox != null)
 			{
-				showGeometryCheckbox.IsChecked = () => devTrait.ShowDebugGeometry;
-				showGeometryCheckbox.OnClick = () => devTrait.ShowDebugGeometry ^= true;
+				showGeometryCheckbox.Disabled = debugVis == null;
+				showGeometryCheckbox.IsChecked = () => debugVis != null && debugVis.RenderGeometry;
+				showGeometryCheckbox.OnClick = () => debugVis.RenderGeometry ^= true;
 			}
 
 			var terrainGeometryTrait = world.WorldActor.Trait<TerrainGeometryOverlay>();
@@ -85,8 +88,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var showDepthPreviewCheckbox = widget.GetOrNull<CheckboxWidget>("SHOW_DEPTH_PREVIEW");
 			if (showDepthPreviewCheckbox != null)
 			{
-				showDepthPreviewCheckbox.IsChecked = () => devTrait.ShowDepthPreview;
-				showDepthPreviewCheckbox.OnClick = () => devTrait.ShowDepthPreview ^= true;
+				showDepthPreviewCheckbox.Disabled = debugVis == null;
+				showDepthPreviewCheckbox.IsChecked = () => debugVis != null && debugVis.DepthBuffer;
+				showDepthPreviewCheckbox.OnClick = () => debugVis.DepthBuffer ^= true;
 			}
 
 			var allTechCheckbox = widget.GetOrNull<CheckboxWidget>("ENABLE_TECH");
@@ -123,8 +127,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var showActorTagsCheckbox = widget.GetOrNull<CheckboxWidget>("SHOW_ACTOR_TAGS");
 			if (showActorTagsCheckbox != null)
 			{
-				showActorTagsCheckbox.IsChecked = () => devTrait.ShowActorTags;
-				showActorTagsCheckbox.OnClick = () => devTrait.ShowActorTags ^= true;
+				showActorTagsCheckbox.Disabled = debugVis == null;
+				showActorTagsCheckbox.IsChecked = () => debugVis != null && debugVis.ActorTags;
+				showActorTagsCheckbox.OnClick = () => debugVis.ActorTags ^= true;
 			}
 
 			var showCustomTerrainCheckbox = widget.GetOrNull<CheckboxWidget>("SHOW_CUSTOMTERRAIN_OVERLAY");

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameRadarDisplayLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameRadarDisplayLogic.cs
@@ -11,8 +11,8 @@
 
 using System.Drawing;
 using System.Linq;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Radar;
-using OpenRA.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -6,6 +6,7 @@
 	MusicPlaylist:
 		VictoryMusic: win1
 		DefeatMusic: nod_map1
+	DebugVisualizations:
 	TerrainGeometryOverlay:
 	ShroudRenderer:
 		ShroudVariants: typea, typeb, typec, typed
@@ -54,6 +55,7 @@ World:
 	Inherits: ^BaseWorld
 	ChatCommands:
 	DevCommands:
+	DebugVisualizationCommands:
 	PlayerCommands:
 	HelpCommand:
 	ScreenShaker:

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -7,6 +7,7 @@
 		VictoryMusic: score
 		DefeatMusic: score
 	TerrainGeometryOverlay:
+	DebugVisualizations:
 	ShroudRenderer:
 		ShroudVariants: shrouda, shroudb, shroudc, shroudd
 		FogVariants: foga, fogb, fogc, fogd
@@ -64,6 +65,7 @@ World:
 	Inherits: ^BaseWorld
 	ChatCommands:
 	DevCommands:
+	DebugVisualizationCommands:
 	PlayerCommands:
 	HelpCommand:
 	ScreenShaker:

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -7,6 +7,7 @@
 		VictoryMusic: score
 		DefeatMusic: map
 	TerrainGeometryOverlay:
+	DebugVisualizations:
 	ShroudRenderer:
 		FogVariants: shroud
 		Index: 255, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 20, 40, 56, 65, 97, 130, 148, 194, 24, 33, 66, 132, 28, 41, 67, 134, 1, 2, 4, 8, 3, 6, 12, 9, 7, 14, 13, 11, 5, 10, 15, 255
@@ -93,6 +94,7 @@ World:
 	Inherits: ^BaseWorld
 	ChatCommands:
 	DevCommands:
+	DebugVisualizationCommands:
 	PlayerCommands:
 	HelpCommand:
 	ScreenShaker:

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -61,6 +61,7 @@
 		AllowUnderActors: true
 		TerrainType: Veins
 	TerrainGeometryOverlay:
+	DebugVisualizations:
 	ExitsDebugOverlayManager:
 	CliffBackImpassabilityLayer:
 	SubterraneanActorLayer:
@@ -70,6 +71,7 @@ World:
 	Inherits: ^BaseWorld
 	ChatCommands:
 	DevCommands:
+	DebugVisualizationCommands:
 	PlayerCommands:
 	HelpCommand:
 	BuildingInfluence:


### PR DESCRIPTION
New visualization chat commands - showcombatgeometry, showdebuggeometry, showdepthpreview, showactortags - available also for spectators.

Show Unit Paths (DevPathDebug chat command) is in Visualization section, but is also player command, so not available for spectators.
Were already available: terrainoverlay, debugcustomterrain.

To enable these 4 options in Debug window, World needs VisualizationMode trait. To enable also chat commands, World needs also VisualizationCommands trait.

Closes #13252