### PR TITLE
Stop LAN probe on close browser

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
@@ -627,5 +627,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			return false;
 		}
+
+		bool disposed;
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && !disposed)
+			{
+				disposed = true;
+				lanGameProbe.Dispose();
+			}
+
+			base.Dispose(disposing);
+		}
 	}
 }


### PR DESCRIPTION
The LAN probe wasn't disposed, stop it on closing browser.