### PR TITLE
Add Cancel button to 'Connection Failed' dialog on host disconnect

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Widgets;
 
@@ -103,6 +102,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Ui.CloseWindow();
 				onRetry(password);
 			};
+
+			if (abortButton.Visible && !retryButton.Visible)
+				abortButton.Bounds.X = abortButton.Parent.Bounds.Width / 2 - abortButton.Bounds.Width / 2;
 
 			widget.Get<LabelWidget>("CONNECTING_DESC").GetText = () =>
 				"Could not connect to {0}:{1}".F(orderManager.Host, orderManager.Port);

--- a/OpenRA.Mods.Common/Widgets/Logic/DisconnectWatcherLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/DisconnectWatcherLogic.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				Game.RunAfterTick(() => Ui.OpenWindow("CONNECTIONFAILED_PANEL", new WidgetArgs {
 					{ "orderManager", orderManager },
-					{ "onAbort", null },
+					{ "onAbort", () => { } },
 					{ "onRetry", null }
 				}));
 


### PR DESCRIPTION
Adding 'Cancel' button to 'Connection Failed' dialog. For some reason ESC doesn't work here still. After Cancel click, dialog is closed and OpenRA reacts to next keys like ESC to open Options menu etc. It would be better to open Options menu on closing this dialog however.

On host disconnect, 'Connection Failed' dialog is displayed without a button, doesn't react to any key, OpenRA looks unresponsive. You need to find out you can click on Options button, otherwise players used to kill OpenRA process.

Now:
![obrazok](https://cloud.githubusercontent.com/assets/16348750/26285473/e3c38a38-3e50-11e7-9c7a-4a7d8c7db25e.png)

Before (after clicking on Options button):
![obrazok](https://cloud.githubusercontent.com/assets/16348750/26285477/ea3c32b6-3e50-11e7-863b-b8f961daea10.png)

This isn't the final solution as described here #12314. Is it better than current situation?


