### PR TITLE
Allow multiple terrain (tile) categories

### DIFF
--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -84,7 +84,7 @@ namespace OpenRA
 		public readonly int[] Frames;
 		public readonly int2 Size;
 		public readonly bool PickAny;
-		public readonly string Category;
+		public readonly string[] Categories;
 		public readonly string Palette;
 
 		readonly TerrainTileInfo[] tileInfo;

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -818,7 +818,17 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		{
 			foreach (var node in nodes)
 			{
-				// Add rules here
+				// Renamed Category to Categories in Template.
+				if (engineVersion < 20170623)
+				{
+					if (node.Key == "Template" || node.Key.StartsWith("Template@", StringComparison.Ordinal))
+					{
+						var category = node.Value.Nodes.FirstOrDefault(n => n.Key == "Category");
+						if (category != null)
+							category.Key = "Categories";
+					}
+				}
+
 				UpgradeTileset(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
@@ -56,9 +56,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			panel.RemoveChildren();
 
-			var tileIds = tileset.Templates
-				.Where(t => t.Value.Category == category)
-				.Select(t => t.Value.Id);
+			var categoryTiles = tileset.Templates.Where(t => t.Value.Categories.Contains(category)).Select(t => t.Value).ToList();
+			var tileIds = categoryTiles.Where(t => t.Categories[0] == category)
+				.Concat(categoryTiles.Where(t => t.Categories[0] != category))
+				.Select(t => t.Id);
 
 			foreach (var t in tileIds)
 			{

--- a/mods/cnc/tilesets/desert.yaml
+++ b/mods/cnc/tilesets/desert.yaml
@@ -68,7 +68,7 @@ Templates:
 		Images: clear1.des
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -91,7 +91,7 @@ Templates:
 		Images: clear1.des
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -113,7 +113,7 @@ Templates:
 		Images: clear1.des
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -135,14 +135,14 @@ Templates:
 		Id: 1
 		Images: w1.des
 		Size: 1,1
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Water
 	Template@13:
 		Id: 13
 		Images: s01.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -152,7 +152,7 @@ Templates:
 		Id: 14
 		Images: s02.des
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -164,7 +164,7 @@ Templates:
 		Id: 15
 		Images: s03.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -174,7 +174,7 @@ Templates:
 		Id: 16
 		Images: s04.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -184,7 +184,7 @@ Templates:
 		Id: 17
 		Images: s05.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -194,7 +194,7 @@ Templates:
 		Id: 18
 		Images: s06.des
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Rock
@@ -205,7 +205,7 @@ Templates:
 		Id: 19
 		Images: s07.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -215,7 +215,7 @@ Templates:
 		Id: 20
 		Images: s08.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -225,7 +225,7 @@ Templates:
 		Id: 21
 		Images: s09.des
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -237,7 +237,7 @@ Templates:
 		Id: 22
 		Images: s10.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -247,7 +247,7 @@ Templates:
 		Id: 23
 		Images: s11.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -257,7 +257,7 @@ Templates:
 		Id: 24
 		Images: s12.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -267,7 +267,7 @@ Templates:
 		Id: 25
 		Images: s13.des
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Rock
@@ -279,7 +279,7 @@ Templates:
 		Id: 26
 		Images: s14.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -288,7 +288,7 @@ Templates:
 		Id: 27
 		Images: s15.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -298,7 +298,7 @@ Templates:
 		Id: 28
 		Images: s16.des
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			2: Rock
@@ -308,7 +308,7 @@ Templates:
 		Id: 29
 		Images: s17.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -318,7 +318,7 @@ Templates:
 		Id: 30
 		Images: s18.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -328,7 +328,7 @@ Templates:
 		Id: 31
 		Images: s19.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -338,7 +338,7 @@ Templates:
 		Id: 32
 		Images: s20.des
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			1: Clear
 			2: Rock
@@ -349,7 +349,7 @@ Templates:
 		Id: 33
 		Images: s21.des
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -357,7 +357,7 @@ Templates:
 		Id: 34
 		Images: s22.des
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -365,7 +365,7 @@ Templates:
 		Id: 35
 		Images: s23.des
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Rock
@@ -377,7 +377,7 @@ Templates:
 		Id: 36
 		Images: s24.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -387,7 +387,7 @@ Templates:
 		Id: 37
 		Images: s25.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -397,7 +397,7 @@ Templates:
 		Id: 38
 		Images: s26.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -407,7 +407,7 @@ Templates:
 		Id: 39
 		Images: s27.des
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -419,7 +419,7 @@ Templates:
 		Id: 40
 		Images: s28.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -428,7 +428,7 @@ Templates:
 		Id: 41
 		Images: s29.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -438,7 +438,7 @@ Templates:
 		Id: 42
 		Images: s30.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -448,7 +448,7 @@ Templates:
 		Id: 43
 		Images: s31.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -458,7 +458,7 @@ Templates:
 		Id: 44
 		Images: s32.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -467,7 +467,7 @@ Templates:
 		Id: 45
 		Images: s33.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -477,7 +477,7 @@ Templates:
 		Id: 46
 		Images: s34.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -487,7 +487,7 @@ Templates:
 		Id: 47
 		Images: s35.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -497,7 +497,7 @@ Templates:
 		Id: 48
 		Images: s36.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -507,7 +507,7 @@ Templates:
 		Id: 49
 		Images: s37.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -517,7 +517,7 @@ Templates:
 		Id: 50
 		Images: s38.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -527,7 +527,7 @@ Templates:
 		Id: 53
 		Images: sh20.des
 		Size: 4,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: Rock
@@ -537,7 +537,7 @@ Templates:
 		Id: 54
 		Images: sh21.des
 		Size: 3,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Rock
 			1: Clear
@@ -546,7 +546,7 @@ Templates:
 		Id: 55
 		Images: sh22.des
 		Size: 6,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Rock
 			2: Rock
@@ -561,7 +561,7 @@ Templates:
 		Id: 56
 		Images: sh23.des
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -571,35 +571,35 @@ Templates:
 		Id: 57
 		Images: br1.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Tree
 	Template@58:
 		Id: 58
 		Images: br2.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Tree
 	Template@59:
 		Id: 59
 		Images: br3.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Tree
 	Template@60:
 		Id: 60
 		Images: br4.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Tree
 	Template@61:
 		Id: 61
 		Images: br5.des
 		Size: 3,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Tree
 			1: Tree
@@ -611,7 +611,7 @@ Templates:
 		Id: 62
 		Images: br6.des
 		Size: 2,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Tree
 			1: Tree
@@ -621,7 +621,7 @@ Templates:
 		Id: 63
 		Images: br7.des
 		Size: 2,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Tree
 			1: Tree
@@ -631,7 +631,7 @@ Templates:
 		Id: 64
 		Images: br8.des
 		Size: 3,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Tree
 			1: Tree
@@ -643,7 +643,7 @@ Templates:
 		Id: 65
 		Images: br9.des
 		Size: 3,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Tree
 			1: Tree
@@ -655,7 +655,7 @@ Templates:
 		Id: 66
 		Images: br10.des
 		Size: 2,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Tree
 			1: Tree
@@ -665,35 +665,35 @@ Templates:
 		Id: 67
 		Images: p01.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 	Template@68:
 		Id: 68
 		Images: p02.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 	Template@69:
 		Id: 69
 		Images: p03.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 	Template@70:
 		Id: 70
 		Images: p04.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 	Template@71:
 		Id: 71
 		Images: p05.des
 		Size: 2,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -703,7 +703,7 @@ Templates:
 		Id: 72
 		Images: p06.des
 		Size: 6,4
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -724,7 +724,7 @@ Templates:
 		Id: 73
 		Images: p07.des
 		Size: 4,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -737,7 +737,7 @@ Templates:
 		Id: 76
 		Images: sh17.des
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -747,7 +747,7 @@ Templates:
 		Id: 77
 		Images: sh18.des
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -757,7 +757,7 @@ Templates:
 		Id: 78
 		Images: sh19.des
 		Size: 3,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Rock
 			2: Clear
@@ -768,14 +768,14 @@ Templates:
 		Id: 82
 		Images: b1.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@83:
 		Id: 83
 		Images: b2.des
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -783,28 +783,28 @@ Templates:
 		Id: 85
 		Images: b4.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@86:
 		Id: 86
 		Images: b5.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@87:
 		Id: 87
 		Images: b6.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@93:
 		Id: 93
 		Images: d01.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -813,7 +813,7 @@ Templates:
 		Id: 94
 		Images: d02.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -823,7 +823,7 @@ Templates:
 		Id: 95
 		Images: d03.des
 		Size: 1,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Clear
@@ -831,7 +831,7 @@ Templates:
 		Id: 96
 		Images: d04.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -840,7 +840,7 @@ Templates:
 		Id: 97
 		Images: d05.des
 		Size: 3,4
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -854,7 +854,7 @@ Templates:
 		Id: 98
 		Images: d06.des
 		Size: 2,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			2: Road
@@ -865,7 +865,7 @@ Templates:
 		Id: 99
 		Images: d07.des
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -876,7 +876,7 @@ Templates:
 		Id: 100
 		Images: d08.des
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			3: Clear
@@ -886,7 +886,7 @@ Templates:
 		Id: 101
 		Images: d09.des
 		Size: 4,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Clear
@@ -902,7 +902,7 @@ Templates:
 		Id: 102
 		Images: d10.des
 		Size: 4,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Rock
@@ -914,7 +914,7 @@ Templates:
 		Id: 103
 		Images: d11.des
 		Size: 2,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -924,7 +924,7 @@ Templates:
 		Id: 104
 		Images: d12.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -933,7 +933,7 @@ Templates:
 		Id: 105
 		Images: d13.des
 		Size: 4,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -948,7 +948,7 @@ Templates:
 		Id: 106
 		Images: d14.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -962,7 +962,7 @@ Templates:
 		Id: 107
 		Images: d15.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -976,7 +976,7 @@ Templates:
 		Id: 108
 		Images: d16.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -991,7 +991,7 @@ Templates:
 		Id: 109
 		Images: d17.des
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1003,7 +1003,7 @@ Templates:
 		Id: 110
 		Images: d18.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1018,7 +1018,7 @@ Templates:
 		Id: 111
 		Images: d19.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1033,7 +1033,7 @@ Templates:
 		Id: 112
 		Images: d20.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1047,7 +1047,7 @@ Templates:
 		Id: 113
 		Images: d21.des
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Rock
 			1: Road
@@ -1059,7 +1059,7 @@ Templates:
 		Id: 114
 		Images: d22.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			3: Road
@@ -1072,7 +1072,7 @@ Templates:
 		Id: 115
 		Images: d23.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -1085,7 +1085,7 @@ Templates:
 		Id: 116
 		Images: d24.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1098,7 +1098,7 @@ Templates:
 		Id: 117
 		Images: d25.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1111,7 +1111,7 @@ Templates:
 		Id: 118
 		Images: d26.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Clear
@@ -1119,7 +1119,7 @@ Templates:
 		Id: 119
 		Images: d27.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Clear
@@ -1127,7 +1127,7 @@ Templates:
 		Id: 120
 		Images: d28.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1136,7 +1136,7 @@ Templates:
 		Id: 121
 		Images: d29.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1145,7 +1145,7 @@ Templates:
 		Id: 122
 		Images: d30.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1154,7 +1154,7 @@ Templates:
 		Id: 123
 		Images: d31.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Clear
@@ -1163,7 +1163,7 @@ Templates:
 		Id: 124
 		Images: d32.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1172,7 +1172,7 @@ Templates:
 		Id: 125
 		Images: d33.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1181,7 +1181,7 @@ Templates:
 		Id: 126
 		Images: d34.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1194,7 +1194,7 @@ Templates:
 		Id: 127
 		Images: d35.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1207,7 +1207,7 @@ Templates:
 		Id: 128
 		Images: d36.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			3: Clear
@@ -1215,7 +1215,7 @@ Templates:
 		Id: 129
 		Images: d37.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			3: Clear
@@ -1223,7 +1223,7 @@ Templates:
 		Id: 130
 		Images: d38.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1232,7 +1232,7 @@ Templates:
 		Id: 131
 		Images: d39.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1241,7 +1241,7 @@ Templates:
 		Id: 132
 		Images: d40.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1250,7 +1250,7 @@ Templates:
 		Id: 133
 		Images: d41.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Wall
 			2: Road
@@ -1259,7 +1259,7 @@ Templates:
 		Id: 134
 		Images: d42.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -1268,7 +1268,7 @@ Templates:
 		Id: 135
 		Images: d43.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -1277,7 +1277,7 @@ Templates:
 		Id: 149
 		Images: rv14.des
 		Size: 4,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1295,7 +1295,7 @@ Templates:
 		Id: 150
 		Images: rv15.des
 		Size: 4,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1313,7 +1313,7 @@ Templates:
 		Id: 151
 		Images: rv16.des
 		Size: 6,4
-		Category: River
+		Categories: River
 		Tiles:
 			2: Rock
 			3: Rock
@@ -1338,7 +1338,7 @@ Templates:
 		Id: 152
 		Images: rv17.des
 		Size: 6,5
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1367,7 +1367,7 @@ Templates:
 		Id: 153
 		Images: rv18.des
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1386,7 +1386,7 @@ Templates:
 		Id: 154
 		Images: rv19.des
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			1: Rock
 			2: River
@@ -1406,7 +1406,7 @@ Templates:
 		Id: 155
 		Images: rv20.des
 		Size: 6,8
-		Category: River
+		Categories: River
 		Tiles:
 			2: Clear
 			3: Rock
@@ -1447,7 +1447,7 @@ Templates:
 		Id: 156
 		Images: rv21.des
 		Size: 5,8
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1480,7 +1480,7 @@ Templates:
 		Id: 157
 		Images: rv22.des
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			1: Clear
 			2: Clear
@@ -1494,7 +1494,7 @@ Templates:
 		Id: 158
 		Images: rv23.des
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1509,7 +1509,7 @@ Templates:
 		Id: 159
 		Images: rv24.des
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1523,7 +1523,7 @@ Templates:
 		Id: 160
 		Images: rv25.des
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Tree
 			1: River
@@ -1538,7 +1538,7 @@ Templates:
 		Id: 161
 		Images: ford1.des
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: River
@@ -1553,7 +1553,7 @@ Templates:
 		Id: 162
 		Images: ford2.des
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Road
@@ -1568,7 +1568,7 @@ Templates:
 		Id: 163
 		Images: falls1.des
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Rock
@@ -1583,7 +1583,7 @@ Templates:
 		Id: 164
 		Images: falls2.des
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1595,7 +1595,7 @@ Templates:
 		Id: 169
 		Images: bridge3.des
 		Size: 6,5
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			3: Clear
 			4: Road
@@ -1623,7 +1623,7 @@ Templates:
 		Id: 170
 		Images: bridge3d.des
 		Size: 6,5
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			3: Clear
 			4: Road
@@ -1651,7 +1651,7 @@ Templates:
 		Id: 171
 		Images: bridge4.des
 		Size: 6,4
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Road
 			2: Clear
@@ -1679,7 +1679,7 @@ Templates:
 		Id: 172
 		Images: bridge4d.des
 		Size: 6,4
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Road
 			2: Clear
@@ -1707,7 +1707,7 @@ Templates:
 		Id: 173
 		Images: sh24.des
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Rock
 			1: River
@@ -1722,7 +1722,7 @@ Templates:
 		Id: 174
 		Images: sh25.des
 		Size: 3,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: River
@@ -1734,7 +1734,7 @@ Templates:
 		Id: 175
 		Images: sh26.des
 		Size: 3,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: Rock
@@ -1745,7 +1745,7 @@ Templates:
 		Id: 176
 		Images: sh27.des
 		Size: 4,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: River
@@ -1755,7 +1755,7 @@ Templates:
 		Id: 177
 		Images: sh28.des
 		Size: 3,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: River
@@ -1764,7 +1764,7 @@ Templates:
 		Id: 178
 		Images: sh29.des
 		Size: 6,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: River
@@ -1779,7 +1779,7 @@ Templates:
 		Id: 179
 		Images: sh30.des
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: River
@@ -1788,7 +1788,7 @@ Templates:
 		Id: 180
 		Images: sh31.des
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: River
@@ -1803,35 +1803,35 @@ Templates:
 		Id: 188
 		Images: sh36.des
 		Size: 1,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 	Template@189:
 		Id: 189
 		Images: sh37.des
 		Size: 1,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 	Template@190:
 		Id: 190
 		Images: sh38.des
 		Size: 1,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 	Template@191:
 		Id: 191
 		Images: sh39.des
 		Size: 1,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 	Template@192:
 		Id: 192
 		Images: sh40.des
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: River
@@ -1846,7 +1846,7 @@ Templates:
 		Id: 193
 		Images: sh41.des
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -1861,7 +1861,7 @@ Templates:
 		Id: 194
 		Images: sh42.des
 		Size: 1,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: River
@@ -1869,7 +1869,7 @@ Templates:
 		Id: 195
 		Images: sh43.des
 		Size: 1,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: Clear
@@ -1878,7 +1878,7 @@ Templates:
 		Id: 196
 		Images: sh44.des
 		Size: 1,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: Clear
@@ -1887,7 +1887,7 @@ Templates:
 		Id: 197
 		Images: sh45.des
 		Size: 1,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: River
@@ -1895,7 +1895,7 @@ Templates:
 		Id: 198
 		Images: sh46.des
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1910,7 +1910,7 @@ Templates:
 		Id: 199
 		Images: sh47.des
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: Rock
@@ -1923,7 +1923,7 @@ Templates:
 		Id: 200
 		Images: sh48.des
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			3: River
@@ -1934,7 +1934,7 @@ Templates:
 		Id: 201
 		Images: sh49.des
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Water
 			2: River
@@ -1948,7 +1948,7 @@ Templates:
 		Id: 202
 		Images: sh50.des
 		Size: 4,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Water
 			2: River
@@ -1962,7 +1962,7 @@ Templates:
 		Id: 203
 		Images: sh51.des
 		Size: 4,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: Water
@@ -1977,7 +1977,7 @@ Templates:
 		Id: 204
 		Images: sh52.des
 		Size: 4,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: River
@@ -1991,7 +1991,7 @@ Templates:
 		Id: 205
 		Images: sh53.des
 		Size: 4,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -2009,7 +2009,7 @@ Templates:
 		Id: 206
 		Images: sh54.des
 		Size: 3,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Tree
@@ -2021,7 +2021,7 @@ Templates:
 		Id: 207
 		Images: sh55.des
 		Size: 3,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: Rock
@@ -2033,7 +2033,7 @@ Templates:
 		Id: 208
 		Images: sh56.des
 		Size: 3,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Water
 			2: River
@@ -2044,7 +2044,7 @@ Templates:
 		Id: 209
 		Images: sh57.des
 		Size: 3,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			3: River
@@ -2054,7 +2054,7 @@ Templates:
 		Id: 210
 		Images: sh58.des
 		Size: 2,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			2: River
@@ -2065,7 +2065,7 @@ Templates:
 		Id: 211
 		Images: sh59.des
 		Size: 2,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: River
@@ -2077,7 +2077,7 @@ Templates:
 		Id: 212
 		Images: sh60.des
 		Size: 2,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: River
@@ -2089,7 +2089,7 @@ Templates:
 		Id: 213
 		Images: sh61.des
 		Size: 2,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: Clear
@@ -2100,7 +2100,7 @@ Templates:
 		Id: 214
 		Images: sh62.des
 		Size: 6,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: River
@@ -2112,7 +2112,7 @@ Templates:
 		Id: 215
 		Images: sh63.des
 		Size: 4,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: River
@@ -2122,14 +2122,14 @@ Templates:
 		Id: 217
 		Images: b06.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@219:
 		Id: 219
 		Images: p08.des
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rough
 			1: Rough
@@ -2137,7 +2137,7 @@ Templates:
 		Id: 220
 		Images: p09.des
 		Size: 1,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2145,7 +2145,7 @@ Templates:
 		Id: 221
 		Images: p10.des
 		Size: 3,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -2157,7 +2157,7 @@ Templates:
 		Id: 222
 		Images: cliffsl1.des
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2165,7 +2165,7 @@ Templates:
 		Id: 223
 		Images: cliffsl2.des
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2173,7 +2173,7 @@ Templates:
 		Id: 224
 		Images: cliffsl3.des
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2181,7 +2181,7 @@ Templates:
 		Id: 225
 		Images: cliffsl4.des
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock

--- a/mods/cnc/tilesets/jungle.yaml
+++ b/mods/cnc/tilesets/jungle.yaml
@@ -68,7 +68,7 @@ Templates:
 		Images: clear1.jun
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -91,7 +91,7 @@ Templates:
 		Images: clear1.jun
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -113,7 +113,7 @@ Templates:
 		Images: clear1.jun
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -135,14 +135,14 @@ Templates:
 		Id: 1
 		Images: w1.jun
 		Size: 1,1
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Water
 	Template@2:
 		Id: 2
 		Images: w2.jun
 		Size: 2,2
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Water
 			1: Water
@@ -152,7 +152,7 @@ Templates:
 		Id: 3
 		Images: sh1.jun
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -167,7 +167,7 @@ Templates:
 		Id: 4
 		Images: sh2.jun
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -182,14 +182,14 @@ Templates:
 		Id: 5
 		Images: sh3.jun
 		Size: 1,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 	Template@6:
 		Id: 6
 		Images: sh4.jun
 		Size: 2,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: River
@@ -197,7 +197,7 @@ Templates:
 		Id: 7
 		Images: sh5.jun
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -212,7 +212,7 @@ Templates:
 		Id: 8
 		Images: sh11.jun
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: River
@@ -227,7 +227,7 @@ Templates:
 		Id: 9
 		Images: sh12.jun
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -242,7 +242,7 @@ Templates:
 		Id: 10
 		Images: sh13.jun
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -257,7 +257,7 @@ Templates:
 		Id: 11
 		Images: sh14.jun
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: River
@@ -272,7 +272,7 @@ Templates:
 		Id: 12
 		Images: sh15.jun
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: River
 			2: River
@@ -286,7 +286,7 @@ Templates:
 		Id: 13
 		Images: s01.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -296,7 +296,7 @@ Templates:
 		Id: 14
 		Images: s02.jun
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -308,7 +308,7 @@ Templates:
 		Id: 15
 		Images: s03.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -318,7 +318,7 @@ Templates:
 		Id: 16
 		Images: s04.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -328,7 +328,7 @@ Templates:
 		Id: 17
 		Images: s05.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -338,7 +338,7 @@ Templates:
 		Id: 18
 		Images: s06.jun
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Rock
@@ -349,7 +349,7 @@ Templates:
 		Id: 19
 		Images: s07.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -359,7 +359,7 @@ Templates:
 		Id: 20
 		Images: s08.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -369,7 +369,7 @@ Templates:
 		Id: 21
 		Images: s09.jun
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -381,7 +381,7 @@ Templates:
 		Id: 22
 		Images: s10.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -391,7 +391,7 @@ Templates:
 		Id: 23
 		Images: s11.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -401,7 +401,7 @@ Templates:
 		Id: 24
 		Images: s12.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -411,7 +411,7 @@ Templates:
 		Id: 25
 		Images: s13.jun
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Rock
@@ -423,7 +423,7 @@ Templates:
 		Id: 26
 		Images: s14.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -432,7 +432,7 @@ Templates:
 		Id: 27
 		Images: s15.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -442,7 +442,7 @@ Templates:
 		Id: 28
 		Images: s16.jun
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			2: Rock
@@ -452,7 +452,7 @@ Templates:
 		Id: 29
 		Images: s17.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Clear
@@ -462,7 +462,7 @@ Templates:
 		Id: 30
 		Images: s18.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Clear
@@ -472,7 +472,7 @@ Templates:
 		Id: 31
 		Images: s19.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Clear
@@ -482,7 +482,7 @@ Templates:
 		Id: 32
 		Images: s20.jun
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			1: Clear
 			2: Rock
@@ -493,7 +493,7 @@ Templates:
 		Id: 33
 		Images: s21.jun
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -501,7 +501,7 @@ Templates:
 		Id: 34
 		Images: s22.jun
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -509,7 +509,7 @@ Templates:
 		Id: 35
 		Images: s23.jun
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Rock
@@ -521,7 +521,7 @@ Templates:
 		Id: 36
 		Images: s24.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -531,7 +531,7 @@ Templates:
 		Id: 37
 		Images: s25.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -541,7 +541,7 @@ Templates:
 		Id: 38
 		Images: s26.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -551,7 +551,7 @@ Templates:
 		Id: 39
 		Images: s27.jun
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -563,7 +563,7 @@ Templates:
 		Id: 40
 		Images: s28.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -572,7 +572,7 @@ Templates:
 		Id: 41
 		Images: s29.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -582,7 +582,7 @@ Templates:
 		Id: 42
 		Images: s30.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -592,7 +592,7 @@ Templates:
 		Id: 43
 		Images: s31.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Clear
@@ -602,7 +602,7 @@ Templates:
 		Id: 44
 		Images: s32.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -611,7 +611,7 @@ Templates:
 		Id: 45
 		Images: s33.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -621,7 +621,7 @@ Templates:
 		Id: 46
 		Images: s34.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -631,7 +631,7 @@ Templates:
 		Id: 47
 		Images: s35.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -641,7 +641,7 @@ Templates:
 		Id: 48
 		Images: s36.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -651,7 +651,7 @@ Templates:
 		Id: 49
 		Images: s37.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -661,7 +661,7 @@ Templates:
 		Id: 50
 		Images: s38.jun
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -671,7 +671,7 @@ Templates:
 		Id: 51
 		Images: sh32.jun
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Clear
@@ -686,7 +686,7 @@ Templates:
 		Id: 52
 		Images: sh33.jun
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -701,35 +701,35 @@ Templates:
 		Id: 67
 		Images: p01.jun
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 	Template@68:
 		Id: 68
 		Images: p02.jun
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 	Template@69:
 		Id: 69
 		Images: p03.jun
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 	Template@70:
 		Id: 70
 		Images: p04.jun
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 	Template@73:
 		Id: 73
 		Images: p07.jun
 		Size: 4,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -743,7 +743,7 @@ Templates:
 		Id: 74
 		Images: p08.jun
 		Size: 3,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -755,7 +755,7 @@ Templates:
 		Id: 75
 		Images: sh16.jun
 		Size: 3,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: Water
@@ -767,7 +767,7 @@ Templates:
 		Id: 76
 		Images: sh17.jun
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -777,7 +777,7 @@ Templates:
 		Id: 77
 		Images: sh18.jun
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -787,7 +787,7 @@ Templates:
 		Id: 79
 		Images: p13.jun
 		Size: 3,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 			1: Wall
@@ -799,7 +799,7 @@ Templates:
 		Id: 80
 		Images: p14.jun
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 			1: Wall
@@ -807,14 +807,14 @@ Templates:
 		Id: 82
 		Images: b1.jun
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@83:
 		Id: 83
 		Images: b2.jun
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -822,7 +822,7 @@ Templates:
 		Id: 84
 		Images: b3.jun
 		Size: 3,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -831,7 +831,7 @@ Templates:
 		Id: 88
 		Images: sh6.jun
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -846,7 +846,7 @@ Templates:
 		Id: 89
 		Images: sh7.jun
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: River
@@ -856,7 +856,7 @@ Templates:
 		Id: 90
 		Images: sh8.jun
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -871,7 +871,7 @@ Templates:
 		Id: 91
 		Images: sh9.jun
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -886,7 +886,7 @@ Templates:
 		Id: 92
 		Images: sh10.jun
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: Clear
@@ -896,7 +896,7 @@ Templates:
 		Id: 93
 		Images: d01.jun
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -905,7 +905,7 @@ Templates:
 		Id: 94
 		Images: d02.jun
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -915,7 +915,7 @@ Templates:
 		Id: 95
 		Images: d03.jun
 		Size: 1,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Clear
@@ -923,7 +923,7 @@ Templates:
 		Id: 96
 		Images: d04.jun
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -932,7 +932,7 @@ Templates:
 		Id: 97
 		Images: d05.jun
 		Size: 3,4
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -946,7 +946,7 @@ Templates:
 		Id: 98
 		Images: d06.jun
 		Size: 2,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			2: Road
@@ -957,7 +957,7 @@ Templates:
 		Id: 99
 		Images: d07.jun
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -968,7 +968,7 @@ Templates:
 		Id: 100
 		Images: d08.jun
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			3: Clear
@@ -978,7 +978,7 @@ Templates:
 		Id: 101
 		Images: d09.jun
 		Size: 4,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Clear
@@ -994,7 +994,7 @@ Templates:
 		Id: 102
 		Images: d10.jun
 		Size: 4,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Rock
@@ -1006,7 +1006,7 @@ Templates:
 		Id: 103
 		Images: d11.jun
 		Size: 2,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1016,7 +1016,7 @@ Templates:
 		Id: 104
 		Images: d12.jun
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -1025,7 +1025,7 @@ Templates:
 		Id: 105
 		Images: d13.jun
 		Size: 4,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1040,7 +1040,7 @@ Templates:
 		Id: 106
 		Images: d14.jun
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1054,7 +1054,7 @@ Templates:
 		Id: 107
 		Images: d15.jun
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1068,7 +1068,7 @@ Templates:
 		Id: 108
 		Images: d16.jun
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1083,7 +1083,7 @@ Templates:
 		Id: 109
 		Images: d17.jun
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1095,7 +1095,7 @@ Templates:
 		Id: 110
 		Images: d18.jun
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1110,7 +1110,7 @@ Templates:
 		Id: 111
 		Images: d19.jun
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1125,7 +1125,7 @@ Templates:
 		Id: 112
 		Images: d20.jun
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1139,7 +1139,7 @@ Templates:
 		Id: 113
 		Images: d21.jun
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Rock
 			1: Road
@@ -1151,7 +1151,7 @@ Templates:
 		Id: 114
 		Images: d22.jun
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			3: Road
@@ -1164,7 +1164,7 @@ Templates:
 		Id: 115
 		Images: d23.jun
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -1177,7 +1177,7 @@ Templates:
 		Id: 116
 		Images: d24.jun
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1190,7 +1190,7 @@ Templates:
 		Id: 117
 		Images: d25.jun
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1203,7 +1203,7 @@ Templates:
 		Id: 118
 		Images: d26.jun
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Clear
@@ -1211,7 +1211,7 @@ Templates:
 		Id: 119
 		Images: d27.jun
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Clear
@@ -1219,7 +1219,7 @@ Templates:
 		Id: 120
 		Images: d28.jun
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1228,7 +1228,7 @@ Templates:
 		Id: 121
 		Images: d29.jun
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1237,7 +1237,7 @@ Templates:
 		Id: 122
 		Images: d30.jun
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1246,7 +1246,7 @@ Templates:
 		Id: 123
 		Images: d31.jun
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Clear
@@ -1255,7 +1255,7 @@ Templates:
 		Id: 124
 		Images: d32.jun
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1264,7 +1264,7 @@ Templates:
 		Id: 125
 		Images: d33.jun
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1273,7 +1273,7 @@ Templates:
 		Id: 126
 		Images: d34.jun
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1286,7 +1286,7 @@ Templates:
 		Id: 127
 		Images: d35.jun
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1299,7 +1299,7 @@ Templates:
 		Id: 128
 		Images: d36.jun
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			3: Clear
@@ -1307,7 +1307,7 @@ Templates:
 		Id: 129
 		Images: d37.jun
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			3: Clear
@@ -1315,7 +1315,7 @@ Templates:
 		Id: 130
 		Images: d38.jun
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1324,7 +1324,7 @@ Templates:
 		Id: 131
 		Images: d39.jun
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1333,7 +1333,7 @@ Templates:
 		Id: 132
 		Images: d40.jun
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1342,7 +1342,7 @@ Templates:
 		Id: 133
 		Images: d41.jun
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Wall
 			2: Road
@@ -1351,7 +1351,7 @@ Templates:
 		Id: 134
 		Images: d42.jun
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -1360,7 +1360,7 @@ Templates:
 		Id: 135
 		Images: d43.jun
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -1369,7 +1369,7 @@ Templates:
 		Id: 136
 		Images: rv01.jun
 		Size: 5,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Rock
@@ -1389,7 +1389,7 @@ Templates:
 		Id: 137
 		Images: rv02.jun
 		Size: 5,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1408,7 +1408,7 @@ Templates:
 		Id: 138
 		Images: rv03.jun
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1427,7 +1427,7 @@ Templates:
 		Id: 139
 		Images: rv04.jun
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			2: Wall
 			3: Clear
@@ -1445,7 +1445,7 @@ Templates:
 		Id: 140
 		Images: rv05.jun
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: River
@@ -1460,7 +1460,7 @@ Templates:
 		Id: 141
 		Images: rv06.jun
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1472,7 +1472,7 @@ Templates:
 		Id: 142
 		Images: rv07.jun
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1484,7 +1484,7 @@ Templates:
 		Id: 143
 		Images: rv08.jun
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1494,7 +1494,7 @@ Templates:
 		Id: 144
 		Images: rv09.jun
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1504,7 +1504,7 @@ Templates:
 		Id: 145
 		Images: rv10.jun
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: River
 			1: River
@@ -1514,7 +1514,7 @@ Templates:
 		Id: 146
 		Images: rv11.jun
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: River
 			1: River
@@ -1524,7 +1524,7 @@ Templates:
 		Id: 147
 		Images: rv12.jun
 		Size: 3,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: River
@@ -1542,7 +1542,7 @@ Templates:
 		Id: 148
 		Images: rv13.jun
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			2: Clear
 			3: Clear
@@ -1562,7 +1562,7 @@ Templates:
 		Id: 161
 		Images: ford1.jun
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: River
@@ -1577,7 +1577,7 @@ Templates:
 		Id: 162
 		Images: ford2.jun
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Road
@@ -1592,7 +1592,7 @@ Templates:
 		Id: 163
 		Images: falls1.jun
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Rock
@@ -1607,7 +1607,7 @@ Templates:
 		Id: 164
 		Images: falls2.jun
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1619,7 +1619,7 @@ Templates:
 		Id: 165
 		Images: bridge1.jun
 		Size: 4,4
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			2: Clear
 			3: Road
@@ -1639,7 +1639,7 @@ Templates:
 		Id: 166
 		Images: bridge1d.jun
 		Size: 4,4
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			2: Clear
 			3: Road
@@ -1659,7 +1659,7 @@ Templates:
 		Id: 167
 		Images: bridge2.jun
 		Size: 5,5
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Road
 			1: Clear
@@ -1686,7 +1686,7 @@ Templates:
 		Id: 168
 		Images: bridge2d.jun
 		Size: 5,5
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Road
 			1: Clear
@@ -1713,7 +1713,7 @@ Templates:
 		Id: 186
 		Images: sh34.jun
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1728,7 +1728,7 @@ Templates:
 		Id: 187
 		Images: sh35.jun
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: River
@@ -1743,7 +1743,7 @@ Templates:
 		Id: 188
 		Images: a10cr.tem
 		Size: 4,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			1: Tree
 			2: Tree
@@ -1756,7 +1756,7 @@ Templates:
 		Id: 189
 		Images: cliffsl1.jun
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1764,7 +1764,7 @@ Templates:
 		Id: 190
 		Images: cliffsl2.jun
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1772,7 +1772,7 @@ Templates:
 		Id: 191
 		Images: cliffsl3.jun
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1780,7 +1780,7 @@ Templates:
 		Id: 192
 		Images: cliffsl4.jun
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock

--- a/mods/cnc/tilesets/snow.yaml
+++ b/mods/cnc/tilesets/snow.yaml
@@ -68,7 +68,7 @@ Templates:
 		Images: clear1.sno
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -95,7 +95,7 @@ Templates:
 		Images: clear1.sno
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -121,7 +121,7 @@ Templates:
 		Images: clear1.sno
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -147,14 +147,14 @@ Templates:
 		Id: 1
 		Images: w1.sno
 		Size: 1,1
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Water
 	Template@2:
 		Id: 2
 		Images: w2.sno
 		Size: 2,2
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Water
 			1: Water
@@ -164,7 +164,7 @@ Templates:
 		Id: 3
 		Images: sh1.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -179,7 +179,7 @@ Templates:
 		Id: 4
 		Images: sh2.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -194,14 +194,14 @@ Templates:
 		Id: 5
 		Images: sh3.sno
 		Size: 1,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 	Template@6:
 		Id: 6
 		Images: sh4.sno
 		Size: 2,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: River
@@ -209,7 +209,7 @@ Templates:
 		Id: 7
 		Images: sh5.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -224,7 +224,7 @@ Templates:
 		Id: 8
 		Images: sh11.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: River
@@ -239,7 +239,7 @@ Templates:
 		Id: 9
 		Images: sh12.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -254,7 +254,7 @@ Templates:
 		Id: 10
 		Images: sh13.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -269,7 +269,7 @@ Templates:
 		Id: 11
 		Images: sh14.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: River
@@ -284,7 +284,7 @@ Templates:
 		Id: 12
 		Images: sh15.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: River
 			2: River
@@ -298,7 +298,7 @@ Templates:
 		Id: 13
 		Images: s01.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -308,7 +308,7 @@ Templates:
 		Id: 14
 		Images: s02.sno
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -320,7 +320,7 @@ Templates:
 		Id: 15
 		Images: s03.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -330,7 +330,7 @@ Templates:
 		Id: 16
 		Images: s04.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -340,7 +340,7 @@ Templates:
 		Id: 17
 		Images: s05.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -350,7 +350,7 @@ Templates:
 		Id: 18
 		Images: s06.sno
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Rock
@@ -361,7 +361,7 @@ Templates:
 		Id: 19
 		Images: s07.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -371,7 +371,7 @@ Templates:
 		Id: 20
 		Images: s08.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -381,7 +381,7 @@ Templates:
 		Id: 21
 		Images: s09.sno
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -393,7 +393,7 @@ Templates:
 		Id: 22
 		Images: s10.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -403,7 +403,7 @@ Templates:
 		Id: 23
 		Images: s11.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -413,7 +413,7 @@ Templates:
 		Id: 24
 		Images: s12.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -423,7 +423,7 @@ Templates:
 		Id: 25
 		Images: s13.sno
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Rock
@@ -435,7 +435,7 @@ Templates:
 		Id: 26
 		Images: s14.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -444,7 +444,7 @@ Templates:
 		Id: 27
 		Images: s15.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -454,7 +454,7 @@ Templates:
 		Id: 28
 		Images: s16.sno
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			2: Rock
@@ -464,7 +464,7 @@ Templates:
 		Id: 29
 		Images: s17.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Clear
@@ -474,7 +474,7 @@ Templates:
 		Id: 30
 		Images: s18.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Clear
@@ -484,7 +484,7 @@ Templates:
 		Id: 31
 		Images: s19.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Clear
@@ -494,7 +494,7 @@ Templates:
 		Id: 32
 		Images: s20.sno
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			1: Clear
 			2: Rock
@@ -505,7 +505,7 @@ Templates:
 		Id: 33
 		Images: s21.sno
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -513,7 +513,7 @@ Templates:
 		Id: 34
 		Images: s22.sno
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -521,7 +521,7 @@ Templates:
 		Id: 35
 		Images: s23.sno
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Rock
@@ -533,7 +533,7 @@ Templates:
 		Id: 36
 		Images: s24.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -543,7 +543,7 @@ Templates:
 		Id: 37
 		Images: s25.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -553,7 +553,7 @@ Templates:
 		Id: 38
 		Images: s26.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -563,7 +563,7 @@ Templates:
 		Id: 39
 		Images: s27.sno
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -575,7 +575,7 @@ Templates:
 		Id: 40
 		Images: s28.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -584,7 +584,7 @@ Templates:
 		Id: 41
 		Images: s29.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -594,7 +594,7 @@ Templates:
 		Id: 42
 		Images: s30.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -604,7 +604,7 @@ Templates:
 		Id: 43
 		Images: s31.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Clear
@@ -614,7 +614,7 @@ Templates:
 		Id: 44
 		Images: s32.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -623,7 +623,7 @@ Templates:
 		Id: 45
 		Images: s33.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -633,7 +633,7 @@ Templates:
 		Id: 46
 		Images: s34.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -643,7 +643,7 @@ Templates:
 		Id: 47
 		Images: s35.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -653,7 +653,7 @@ Templates:
 		Id: 48
 		Images: s36.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -663,7 +663,7 @@ Templates:
 		Id: 49
 		Images: s37.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -673,7 +673,7 @@ Templates:
 		Id: 50
 		Images: s38.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -683,7 +683,7 @@ Templates:
 		Id: 51
 		Images: sh32.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Clear
@@ -698,7 +698,7 @@ Templates:
 		Id: 52
 		Images: sh33.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -713,35 +713,35 @@ Templates:
 		Id: 67
 		Images: p01.sno
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 	Template@68:
 		Id: 68
 		Images: p02.sno
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 	Template@69:
 		Id: 69
 		Images: p03.sno
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 	Template@70:
 		Id: 70
 		Images: p04.sno
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 	Template@73:
 		Id: 73
 		Images: p07.sno
 		Size: 4,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -755,7 +755,7 @@ Templates:
 		Id: 74
 		Images: p08.sno
 		Size: 3,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -767,7 +767,7 @@ Templates:
 		Id: 75
 		Images: sh16.sno
 		Size: 3,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: Water
@@ -779,7 +779,7 @@ Templates:
 		Id: 76
 		Images: sh17.sno
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -789,7 +789,7 @@ Templates:
 		Id: 77
 		Images: sh18.sno
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -799,7 +799,7 @@ Templates:
 		Id: 79
 		Images: p13.sno
 		Size: 3,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 			1: Wall
@@ -811,7 +811,7 @@ Templates:
 		Id: 80
 		Images: p14.sno
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 			1: Wall
@@ -819,14 +819,14 @@ Templates:
 		Id: 82
 		Images: b1.sno
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@83:
 		Id: 83
 		Images: b2.sno
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -834,7 +834,7 @@ Templates:
 		Id: 84
 		Images: b3.sno
 		Size: 3,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -843,7 +843,7 @@ Templates:
 		Id: 88
 		Images: sh6.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -858,7 +858,7 @@ Templates:
 		Id: 89
 		Images: sh7.sno
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: River
@@ -868,7 +868,7 @@ Templates:
 		Id: 90
 		Images: sh8.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -883,7 +883,7 @@ Templates:
 		Id: 91
 		Images: sh9.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -898,7 +898,7 @@ Templates:
 		Id: 92
 		Images: sh10.sno
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: Clear
@@ -908,7 +908,7 @@ Templates:
 		Id: 93
 		Images: d01.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -917,7 +917,7 @@ Templates:
 		Id: 94
 		Images: d02.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -927,7 +927,7 @@ Templates:
 		Id: 95
 		Images: d03.sno
 		Size: 1,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Clear
@@ -935,7 +935,7 @@ Templates:
 		Id: 96
 		Images: d04.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -944,7 +944,7 @@ Templates:
 		Id: 97
 		Images: d05.sno
 		Size: 3,4
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -958,7 +958,7 @@ Templates:
 		Id: 98
 		Images: d06.sno
 		Size: 2,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			2: Road
@@ -969,7 +969,7 @@ Templates:
 		Id: 99
 		Images: d07.sno
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -980,7 +980,7 @@ Templates:
 		Id: 100
 		Images: d08.sno
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			3: Clear
@@ -990,7 +990,7 @@ Templates:
 		Id: 101
 		Images: d09.sno
 		Size: 4,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1006,7 +1006,7 @@ Templates:
 		Id: 102
 		Images: d10.sno
 		Size: 4,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Rock
@@ -1018,7 +1018,7 @@ Templates:
 		Id: 103
 		Images: d11.sno
 		Size: 2,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1028,7 +1028,7 @@ Templates:
 		Id: 104
 		Images: d12.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -1037,7 +1037,7 @@ Templates:
 		Id: 105
 		Images: d13.sno
 		Size: 4,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1052,7 +1052,7 @@ Templates:
 		Id: 106
 		Images: d14.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1066,7 +1066,7 @@ Templates:
 		Id: 107
 		Images: d15.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1080,7 +1080,7 @@ Templates:
 		Id: 108
 		Images: d16.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1095,7 +1095,7 @@ Templates:
 		Id: 109
 		Images: d17.sno
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1107,7 +1107,7 @@ Templates:
 		Id: 110
 		Images: d18.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1122,7 +1122,7 @@ Templates:
 		Id: 111
 		Images: d19.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1137,7 +1137,7 @@ Templates:
 		Id: 112
 		Images: d20.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1151,7 +1151,7 @@ Templates:
 		Id: 113
 		Images: d21.sno
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Rock
 			1: Road
@@ -1163,7 +1163,7 @@ Templates:
 		Id: 114
 		Images: d22.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			3: Road
@@ -1176,7 +1176,7 @@ Templates:
 		Id: 115
 		Images: d23.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -1189,7 +1189,7 @@ Templates:
 		Id: 116
 		Images: d24.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1202,7 +1202,7 @@ Templates:
 		Id: 117
 		Images: d25.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1215,7 +1215,7 @@ Templates:
 		Id: 118
 		Images: d26.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Clear
@@ -1223,7 +1223,7 @@ Templates:
 		Id: 119
 		Images: d27.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Clear
@@ -1231,7 +1231,7 @@ Templates:
 		Id: 120
 		Images: d28.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1240,7 +1240,7 @@ Templates:
 		Id: 121
 		Images: d29.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1249,7 +1249,7 @@ Templates:
 		Id: 122
 		Images: d30.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1258,7 +1258,7 @@ Templates:
 		Id: 123
 		Images: d31.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Clear
@@ -1267,7 +1267,7 @@ Templates:
 		Id: 124
 		Images: d32.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1276,7 +1276,7 @@ Templates:
 		Id: 125
 		Images: d33.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1285,7 +1285,7 @@ Templates:
 		Id: 126
 		Images: d34.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1298,7 +1298,7 @@ Templates:
 		Id: 127
 		Images: d35.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1311,7 +1311,7 @@ Templates:
 		Id: 128
 		Images: d36.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			3: Clear
@@ -1319,7 +1319,7 @@ Templates:
 		Id: 129
 		Images: d37.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			3: Clear
@@ -1327,7 +1327,7 @@ Templates:
 		Id: 130
 		Images: d38.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1336,7 +1336,7 @@ Templates:
 		Id: 131
 		Images: d39.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1345,7 +1345,7 @@ Templates:
 		Id: 132
 		Images: d40.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1354,7 +1354,7 @@ Templates:
 		Id: 133
 		Images: d41.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Wall
 			2: Road
@@ -1363,7 +1363,7 @@ Templates:
 		Id: 134
 		Images: d42.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -1372,7 +1372,7 @@ Templates:
 		Id: 135
 		Images: d43.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -1381,7 +1381,7 @@ Templates:
 		Id: 136
 		Images: rv01.sno
 		Size: 5,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Rock
@@ -1401,7 +1401,7 @@ Templates:
 		Id: 137
 		Images: rv02.sno
 		Size: 5,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1420,7 +1420,7 @@ Templates:
 		Id: 138
 		Images: rv03.sno
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1439,7 +1439,7 @@ Templates:
 		Id: 139
 		Images: rv04.sno
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			2: Wall
 			3: Clear
@@ -1457,7 +1457,7 @@ Templates:
 		Id: 140
 		Images: rv05.sno
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: River
@@ -1472,7 +1472,7 @@ Templates:
 		Id: 141
 		Images: rv06.sno
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1484,7 +1484,7 @@ Templates:
 		Id: 142
 		Images: rv07.sno
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1496,7 +1496,7 @@ Templates:
 		Id: 143
 		Images: rv08.sno
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1506,7 +1506,7 @@ Templates:
 		Id: 144
 		Images: rv09.sno
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1516,7 +1516,7 @@ Templates:
 		Id: 145
 		Images: rv10.sno
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: River
 			1: River
@@ -1526,7 +1526,7 @@ Templates:
 		Id: 146
 		Images: rv11.sno
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: River
 			1: River
@@ -1536,7 +1536,7 @@ Templates:
 		Id: 147
 		Images: rv12.sno
 		Size: 3,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: River
@@ -1554,7 +1554,7 @@ Templates:
 		Id: 148
 		Images: rv13.sno
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			2: Clear
 			3: Clear
@@ -1574,7 +1574,7 @@ Templates:
 		Id: 161
 		Images: ford1.sno
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: River
@@ -1589,7 +1589,7 @@ Templates:
 		Id: 162
 		Images: ford2.sno
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Road
@@ -1604,7 +1604,7 @@ Templates:
 		Id: 163
 		Images: falls1.sno
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Rock
@@ -1619,7 +1619,7 @@ Templates:
 		Id: 164
 		Images: falls2.sno
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1631,7 +1631,7 @@ Templates:
 		Id: 165
 		Images: bridge1.sno
 		Size: 4,4
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			2: Clear
 			3: Road
@@ -1651,7 +1651,7 @@ Templates:
 		Id: 166
 		Images: bridge1d.sno
 		Size: 4,4
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			2: Clear
 			3: Road
@@ -1671,7 +1671,7 @@ Templates:
 		Id: 167
 		Images: bridge2.sno
 		Size: 5,5
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Road
 			1: Clear
@@ -1698,7 +1698,7 @@ Templates:
 		Id: 168
 		Images: bridge2d.sno
 		Size: 5,5
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Road
 			1: Clear
@@ -1725,7 +1725,7 @@ Templates:
 		Id: 186
 		Images: sh34.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1740,7 +1740,7 @@ Templates:
 		Id: 187
 		Images: sh35.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: River
@@ -1755,7 +1755,7 @@ Templates:
 		Id: 189
 		Images: cliffsl1.sno
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1763,7 +1763,7 @@ Templates:
 		Id: 190
 		Images: cliffsl2.sno
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1771,7 +1771,7 @@ Templates:
 		Id: 191
 		Images: cliffsl3.sno
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1779,7 +1779,7 @@ Templates:
 		Id: 192
 		Images: cliffsl4.sno
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock

--- a/mods/cnc/tilesets/temperat.yaml
+++ b/mods/cnc/tilesets/temperat.yaml
@@ -68,7 +68,7 @@ Templates:
 		Images: clear1.tem
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -91,7 +91,7 @@ Templates:
 		Images: clear1.tem
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -113,7 +113,7 @@ Templates:
 		Images: clear1.tem
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -135,14 +135,14 @@ Templates:
 		Id: 1
 		Images: w1.tem
 		Size: 1,1
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Water
 	Template@2:
 		Id: 2
 		Images: w2.tem
 		Size: 2,2
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Water
 			1: Water
@@ -152,7 +152,7 @@ Templates:
 		Id: 3
 		Images: sh1.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -167,7 +167,7 @@ Templates:
 		Id: 4
 		Images: sh2.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -182,14 +182,14 @@ Templates:
 		Id: 5
 		Images: sh3.tem
 		Size: 1,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 	Template@6:
 		Id: 6
 		Images: sh4.tem
 		Size: 2,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: River
@@ -197,7 +197,7 @@ Templates:
 		Id: 7
 		Images: sh5.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -212,7 +212,7 @@ Templates:
 		Id: 8
 		Images: sh11.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: River
@@ -227,7 +227,7 @@ Templates:
 		Id: 9
 		Images: sh12.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -242,7 +242,7 @@ Templates:
 		Id: 10
 		Images: sh13.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -257,7 +257,7 @@ Templates:
 		Id: 11
 		Images: sh14.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: River
@@ -272,7 +272,7 @@ Templates:
 		Id: 12
 		Images: sh15.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: River
 			2: River
@@ -286,7 +286,7 @@ Templates:
 		Id: 13
 		Images: s01.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -296,7 +296,7 @@ Templates:
 		Id: 14
 		Images: s02.tem
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -308,7 +308,7 @@ Templates:
 		Id: 15
 		Images: s03.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -318,7 +318,7 @@ Templates:
 		Id: 16
 		Images: s04.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -328,7 +328,7 @@ Templates:
 		Id: 17
 		Images: s05.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -338,7 +338,7 @@ Templates:
 		Id: 18
 		Images: s06.tem
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Rock
@@ -349,7 +349,7 @@ Templates:
 		Id: 19
 		Images: s07.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -359,7 +359,7 @@ Templates:
 		Id: 20
 		Images: s08.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -369,7 +369,7 @@ Templates:
 		Id: 21
 		Images: s09.tem
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -381,7 +381,7 @@ Templates:
 		Id: 22
 		Images: s10.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -391,7 +391,7 @@ Templates:
 		Id: 23
 		Images: s11.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -401,7 +401,7 @@ Templates:
 		Id: 24
 		Images: s12.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -411,7 +411,7 @@ Templates:
 		Id: 25
 		Images: s13.tem
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Rock
@@ -423,7 +423,7 @@ Templates:
 		Id: 26
 		Images: s14.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -432,7 +432,7 @@ Templates:
 		Id: 27
 		Images: s15.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -442,7 +442,7 @@ Templates:
 		Id: 28
 		Images: s16.tem
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			2: Rock
@@ -452,7 +452,7 @@ Templates:
 		Id: 29
 		Images: s17.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Clear
@@ -462,7 +462,7 @@ Templates:
 		Id: 30
 		Images: s18.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Clear
@@ -472,7 +472,7 @@ Templates:
 		Id: 31
 		Images: s19.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Clear
@@ -482,7 +482,7 @@ Templates:
 		Id: 32
 		Images: s20.tem
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			1: Clear
 			2: Rock
@@ -493,7 +493,7 @@ Templates:
 		Id: 33
 		Images: s21.tem
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -501,7 +501,7 @@ Templates:
 		Id: 34
 		Images: s22.tem
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -509,7 +509,7 @@ Templates:
 		Id: 35
 		Images: s23.tem
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Rock
@@ -521,7 +521,7 @@ Templates:
 		Id: 36
 		Images: s24.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -531,7 +531,7 @@ Templates:
 		Id: 37
 		Images: s25.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -541,7 +541,7 @@ Templates:
 		Id: 38
 		Images: s26.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -551,7 +551,7 @@ Templates:
 		Id: 39
 		Images: s27.tem
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -563,7 +563,7 @@ Templates:
 		Id: 40
 		Images: s28.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -572,7 +572,7 @@ Templates:
 		Id: 41
 		Images: s29.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -582,7 +582,7 @@ Templates:
 		Id: 42
 		Images: s30.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -592,7 +592,7 @@ Templates:
 		Id: 43
 		Images: s31.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Clear
@@ -602,7 +602,7 @@ Templates:
 		Id: 44
 		Images: s32.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -611,7 +611,7 @@ Templates:
 		Id: 45
 		Images: s33.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -621,7 +621,7 @@ Templates:
 		Id: 46
 		Images: s34.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -631,7 +631,7 @@ Templates:
 		Id: 47
 		Images: s35.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -641,7 +641,7 @@ Templates:
 		Id: 48
 		Images: s36.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -651,7 +651,7 @@ Templates:
 		Id: 49
 		Images: s37.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -661,7 +661,7 @@ Templates:
 		Id: 50
 		Images: s38.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -671,7 +671,7 @@ Templates:
 		Id: 51
 		Images: sh32.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Clear
@@ -686,7 +686,7 @@ Templates:
 		Id: 52
 		Images: sh33.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -701,35 +701,35 @@ Templates:
 		Id: 67
 		Images: p01.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 	Template@68:
 		Id: 68
 		Images: p02.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 	Template@69:
 		Id: 69
 		Images: p03.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 	Template@70:
 		Id: 70
 		Images: p04.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 	Template@73:
 		Id: 73
 		Images: p07.tem
 		Size: 4,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -743,7 +743,7 @@ Templates:
 		Id: 74
 		Images: p08.tem
 		Size: 3,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -755,7 +755,7 @@ Templates:
 		Id: 75
 		Images: sh16.tem
 		Size: 3,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: Water
@@ -767,7 +767,7 @@ Templates:
 		Id: 76
 		Images: sh17.tem
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -777,7 +777,7 @@ Templates:
 		Id: 77
 		Images: sh18.tem
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -787,7 +787,7 @@ Templates:
 		Id: 79
 		Images: p13.tem
 		Size: 3,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 			1: Wall
@@ -799,7 +799,7 @@ Templates:
 		Id: 80
 		Images: p14.tem
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 			1: Wall
@@ -807,14 +807,14 @@ Templates:
 		Id: 82
 		Images: b1.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@83:
 		Id: 83
 		Images: b2.tem
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -822,7 +822,7 @@ Templates:
 		Id: 84
 		Images: b3.tem
 		Size: 3,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -831,7 +831,7 @@ Templates:
 		Id: 88
 		Images: sh6.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -846,7 +846,7 @@ Templates:
 		Id: 89
 		Images: sh7.tem
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: River
@@ -856,7 +856,7 @@ Templates:
 		Id: 90
 		Images: sh8.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -871,7 +871,7 @@ Templates:
 		Id: 91
 		Images: sh9.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -886,7 +886,7 @@ Templates:
 		Id: 92
 		Images: sh10.tem
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: Clear
@@ -896,7 +896,7 @@ Templates:
 		Id: 93
 		Images: d01.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -905,7 +905,7 @@ Templates:
 		Id: 94
 		Images: d02.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -915,7 +915,7 @@ Templates:
 		Id: 95
 		Images: d03.tem
 		Size: 1,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Clear
@@ -923,7 +923,7 @@ Templates:
 		Id: 96
 		Images: d04.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -932,7 +932,7 @@ Templates:
 		Id: 97
 		Images: d05.tem
 		Size: 3,4
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -946,7 +946,7 @@ Templates:
 		Id: 98
 		Images: d06.tem
 		Size: 2,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			2: Road
@@ -957,7 +957,7 @@ Templates:
 		Id: 99
 		Images: d07.tem
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -968,7 +968,7 @@ Templates:
 		Id: 100
 		Images: d08.tem
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			3: Clear
@@ -978,7 +978,7 @@ Templates:
 		Id: 101
 		Images: d09.tem
 		Size: 4,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Clear
@@ -994,7 +994,7 @@ Templates:
 		Id: 102
 		Images: d10.tem
 		Size: 4,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Rock
@@ -1006,7 +1006,7 @@ Templates:
 		Id: 103
 		Images: d11.tem
 		Size: 2,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1016,7 +1016,7 @@ Templates:
 		Id: 104
 		Images: d12.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -1025,7 +1025,7 @@ Templates:
 		Id: 105
 		Images: d13.tem
 		Size: 4,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1040,7 +1040,7 @@ Templates:
 		Id: 106
 		Images: d14.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1054,7 +1054,7 @@ Templates:
 		Id: 107
 		Images: d15.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1068,7 +1068,7 @@ Templates:
 		Id: 108
 		Images: d16.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1083,7 +1083,7 @@ Templates:
 		Id: 109
 		Images: d17.tem
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1095,7 +1095,7 @@ Templates:
 		Id: 110
 		Images: d18.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1110,7 +1110,7 @@ Templates:
 		Id: 111
 		Images: d19.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1125,7 +1125,7 @@ Templates:
 		Id: 112
 		Images: d20.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1139,7 +1139,7 @@ Templates:
 		Id: 113
 		Images: d21.tem
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Rock
 			1: Road
@@ -1151,7 +1151,7 @@ Templates:
 		Id: 114
 		Images: d22.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			3: Road
@@ -1164,7 +1164,7 @@ Templates:
 		Id: 115
 		Images: d23.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -1177,7 +1177,7 @@ Templates:
 		Id: 116
 		Images: d24.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1190,7 +1190,7 @@ Templates:
 		Id: 117
 		Images: d25.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1203,7 +1203,7 @@ Templates:
 		Id: 118
 		Images: d26.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Clear
@@ -1211,7 +1211,7 @@ Templates:
 		Id: 119
 		Images: d27.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Clear
@@ -1219,7 +1219,7 @@ Templates:
 		Id: 120
 		Images: d28.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1228,7 +1228,7 @@ Templates:
 		Id: 121
 		Images: d29.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1237,7 +1237,7 @@ Templates:
 		Id: 122
 		Images: d30.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1246,7 +1246,7 @@ Templates:
 		Id: 123
 		Images: d31.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Clear
@@ -1255,7 +1255,7 @@ Templates:
 		Id: 124
 		Images: d32.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1264,7 +1264,7 @@ Templates:
 		Id: 125
 		Images: d33.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1273,7 +1273,7 @@ Templates:
 		Id: 126
 		Images: d34.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1286,7 +1286,7 @@ Templates:
 		Id: 127
 		Images: d35.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1299,7 +1299,7 @@ Templates:
 		Id: 128
 		Images: d36.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			3: Clear
@@ -1307,7 +1307,7 @@ Templates:
 		Id: 129
 		Images: d37.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			3: Clear
@@ -1315,7 +1315,7 @@ Templates:
 		Id: 130
 		Images: d38.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1324,7 +1324,7 @@ Templates:
 		Id: 131
 		Images: d39.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1333,7 +1333,7 @@ Templates:
 		Id: 132
 		Images: d40.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1342,7 +1342,7 @@ Templates:
 		Id: 133
 		Images: d41.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Wall
 			2: Road
@@ -1351,7 +1351,7 @@ Templates:
 		Id: 134
 		Images: d42.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -1360,7 +1360,7 @@ Templates:
 		Id: 135
 		Images: d43.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -1369,7 +1369,7 @@ Templates:
 		Id: 136
 		Images: rv01.tem
 		Size: 5,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Rock
@@ -1389,7 +1389,7 @@ Templates:
 		Id: 137
 		Images: rv02.tem
 		Size: 5,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1408,7 +1408,7 @@ Templates:
 		Id: 138
 		Images: rv03.tem
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1427,7 +1427,7 @@ Templates:
 		Id: 139
 		Images: rv04.tem
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			2: Wall
 			3: Clear
@@ -1445,7 +1445,7 @@ Templates:
 		Id: 140
 		Images: rv05.tem
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: River
@@ -1460,7 +1460,7 @@ Templates:
 		Id: 141
 		Images: rv06.tem
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1472,7 +1472,7 @@ Templates:
 		Id: 142
 		Images: rv07.tem
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1484,7 +1484,7 @@ Templates:
 		Id: 143
 		Images: rv08.tem
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1494,7 +1494,7 @@ Templates:
 		Id: 144
 		Images: rv09.tem
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1504,7 +1504,7 @@ Templates:
 		Id: 145
 		Images: rv10.tem
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: River
 			1: River
@@ -1514,7 +1514,7 @@ Templates:
 		Id: 146
 		Images: rv11.tem
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: River
 			1: River
@@ -1524,7 +1524,7 @@ Templates:
 		Id: 147
 		Images: rv12.tem
 		Size: 3,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: River
@@ -1542,7 +1542,7 @@ Templates:
 		Id: 148
 		Images: rv13.tem
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			2: Clear
 			3: Clear
@@ -1562,7 +1562,7 @@ Templates:
 		Id: 161
 		Images: ford1.tem
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: River
@@ -1577,7 +1577,7 @@ Templates:
 		Id: 162
 		Images: ford2.tem
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Road
@@ -1592,7 +1592,7 @@ Templates:
 		Id: 163
 		Images: falls1.tem
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Rock
@@ -1607,7 +1607,7 @@ Templates:
 		Id: 164
 		Images: falls2.tem
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1619,7 +1619,7 @@ Templates:
 		Id: 165
 		Images: bridge1.tem
 		Size: 4,4
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			2: Clear
 			3: Road
@@ -1639,7 +1639,7 @@ Templates:
 		Id: 166
 		Images: bridge1d.tem
 		Size: 4,4
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			2: Clear
 			3: Road
@@ -1659,7 +1659,7 @@ Templates:
 		Id: 167
 		Images: bridge2.tem
 		Size: 5,5
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Road
 			1: Clear
@@ -1686,7 +1686,7 @@ Templates:
 		Id: 168
 		Images: bridge2d.tem
 		Size: 5,5
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Road
 			1: Clear
@@ -1713,7 +1713,7 @@ Templates:
 		Id: 186
 		Images: sh34.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1728,7 +1728,7 @@ Templates:
 		Id: 187
 		Images: sh35.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: River
@@ -1743,7 +1743,7 @@ Templates:
 		Id: 188
 		Images: a10cr.tem
 		Size: 4,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			1: Tree
 			2: Tree
@@ -1756,7 +1756,7 @@ Templates:
 		Id: 189
 		Images: cliffsl1.tem
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1764,7 +1764,7 @@ Templates:
 		Id: 190
 		Images: cliffsl2.tem
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1772,7 +1772,7 @@ Templates:
 		Id: 191
 		Images: cliffsl3.tem
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1780,7 +1780,7 @@ Templates:
 		Id: 192
 		Images: cliffsl4.tem
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock

--- a/mods/cnc/tilesets/winter.yaml
+++ b/mods/cnc/tilesets/winter.yaml
@@ -68,7 +68,7 @@ Templates:
 		Images: clear1.win
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -91,7 +91,7 @@ Templates:
 		Images: clear1.win
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -113,7 +113,7 @@ Templates:
 		Images: clear1.win
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -135,14 +135,14 @@ Templates:
 		Id: 1
 		Images: w1.win
 		Size: 1,1
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Water
 	Template@2:
 		Id: 2
 		Images: w2.win
 		Size: 2,2
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Water
 			1: Water
@@ -152,7 +152,7 @@ Templates:
 		Id: 3
 		Images: sh1.win
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -167,7 +167,7 @@ Templates:
 		Id: 4
 		Images: sh2.win
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -182,14 +182,14 @@ Templates:
 		Id: 5
 		Images: sh3.win
 		Size: 1,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 	Template@6:
 		Id: 6
 		Images: sh4.win
 		Size: 2,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: River
@@ -197,7 +197,7 @@ Templates:
 		Id: 7
 		Images: sh5.win
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -212,7 +212,7 @@ Templates:
 		Id: 8
 		Images: sh11.win
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: River
@@ -227,7 +227,7 @@ Templates:
 		Id: 9
 		Images: sh12.win
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -242,7 +242,7 @@ Templates:
 		Id: 10
 		Images: sh13.win
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -257,7 +257,7 @@ Templates:
 		Id: 11
 		Images: sh14.win
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: River
@@ -272,7 +272,7 @@ Templates:
 		Id: 12
 		Images: sh15.win
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: River
 			2: River
@@ -286,7 +286,7 @@ Templates:
 		Id: 13
 		Images: s01.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -296,7 +296,7 @@ Templates:
 		Id: 14
 		Images: s02.win
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -308,7 +308,7 @@ Templates:
 		Id: 15
 		Images: s03.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -318,7 +318,7 @@ Templates:
 		Id: 16
 		Images: s04.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -328,7 +328,7 @@ Templates:
 		Id: 17
 		Images: s05.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -338,7 +338,7 @@ Templates:
 		Id: 18
 		Images: s06.win
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Rock
@@ -349,7 +349,7 @@ Templates:
 		Id: 19
 		Images: s07.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -359,7 +359,7 @@ Templates:
 		Id: 20
 		Images: s08.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -369,7 +369,7 @@ Templates:
 		Id: 21
 		Images: s09.win
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -381,7 +381,7 @@ Templates:
 		Id: 22
 		Images: s10.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -391,7 +391,7 @@ Templates:
 		Id: 23
 		Images: s11.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -401,7 +401,7 @@ Templates:
 		Id: 24
 		Images: s12.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -411,7 +411,7 @@ Templates:
 		Id: 25
 		Images: s13.win
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Rock
@@ -423,7 +423,7 @@ Templates:
 		Id: 26
 		Images: s14.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -432,7 +432,7 @@ Templates:
 		Id: 27
 		Images: s15.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -442,7 +442,7 @@ Templates:
 		Id: 28
 		Images: s16.win
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			2: Rock
@@ -452,7 +452,7 @@ Templates:
 		Id: 29
 		Images: s17.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Clear
@@ -462,7 +462,7 @@ Templates:
 		Id: 30
 		Images: s18.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Clear
@@ -472,7 +472,7 @@ Templates:
 		Id: 31
 		Images: s19.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Clear
@@ -482,7 +482,7 @@ Templates:
 		Id: 32
 		Images: s20.win
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			1: Clear
 			2: Rock
@@ -493,7 +493,7 @@ Templates:
 		Id: 33
 		Images: s21.win
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -501,7 +501,7 @@ Templates:
 		Id: 34
 		Images: s22.win
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -509,7 +509,7 @@ Templates:
 		Id: 35
 		Images: s23.win
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Rock
@@ -521,7 +521,7 @@ Templates:
 		Id: 36
 		Images: s24.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -531,7 +531,7 @@ Templates:
 		Id: 37
 		Images: s25.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -541,7 +541,7 @@ Templates:
 		Id: 38
 		Images: s26.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -551,7 +551,7 @@ Templates:
 		Id: 39
 		Images: s27.win
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -563,7 +563,7 @@ Templates:
 		Id: 40
 		Images: s28.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -572,7 +572,7 @@ Templates:
 		Id: 41
 		Images: s29.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -582,7 +582,7 @@ Templates:
 		Id: 42
 		Images: s30.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Clear
@@ -592,7 +592,7 @@ Templates:
 		Id: 43
 		Images: s31.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Clear
 			1: Clear
@@ -602,7 +602,7 @@ Templates:
 		Id: 44
 		Images: s32.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -611,7 +611,7 @@ Templates:
 		Id: 45
 		Images: s33.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -621,7 +621,7 @@ Templates:
 		Id: 46
 		Images: s34.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -631,7 +631,7 @@ Templates:
 		Id: 47
 		Images: s35.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -641,7 +641,7 @@ Templates:
 		Id: 48
 		Images: s36.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -651,7 +651,7 @@ Templates:
 		Id: 49
 		Images: s37.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -661,7 +661,7 @@ Templates:
 		Id: 50
 		Images: s38.win
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -671,7 +671,7 @@ Templates:
 		Id: 51
 		Images: sh32.win
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Clear
@@ -686,7 +686,7 @@ Templates:
 		Id: 52
 		Images: sh33.win
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -701,7 +701,7 @@ Templates:
 		Id: 73
 		Images: p07.win
 		Size: 4,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -715,7 +715,7 @@ Templates:
 		Id: 74
 		Images: p08.win
 		Size: 3,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -727,7 +727,7 @@ Templates:
 		Id: 75
 		Images: sh16.win
 		Size: 3,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: Water
@@ -739,7 +739,7 @@ Templates:
 		Id: 76
 		Images: sh17.win
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -749,7 +749,7 @@ Templates:
 		Id: 77
 		Images: sh18.win
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -759,7 +759,7 @@ Templates:
 		Id: 79
 		Images: p13.win
 		Size: 3,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 			1: Wall
@@ -771,7 +771,7 @@ Templates:
 		Id: 80
 		Images: p14.win
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Wall
 			1: Wall
@@ -779,7 +779,7 @@ Templates:
 		Id: 81
 		Images: p15.win
 		Size: 4,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -791,14 +791,14 @@ Templates:
 		Id: 82
 		Images: b1.win
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@83:
 		Id: 83
 		Images: b2.win
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -806,7 +806,7 @@ Templates:
 		Id: 84
 		Images: b3.win
 		Size: 3,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -815,7 +815,7 @@ Templates:
 		Id: 88
 		Images: sh6.win
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -830,7 +830,7 @@ Templates:
 		Id: 89
 		Images: sh7.win
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: River
@@ -840,7 +840,7 @@ Templates:
 		Id: 90
 		Images: sh8.win
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -855,7 +855,7 @@ Templates:
 		Id: 91
 		Images: sh9.win
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -870,7 +870,7 @@ Templates:
 		Id: 92
 		Images: sh10.win
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: Clear
@@ -880,7 +880,7 @@ Templates:
 		Id: 93
 		Images: d01.win
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -889,7 +889,7 @@ Templates:
 		Id: 94
 		Images: d02.win
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -899,7 +899,7 @@ Templates:
 		Id: 95
 		Images: d03.win
 		Size: 1,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Clear
@@ -907,7 +907,7 @@ Templates:
 		Id: 96
 		Images: d04.win
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -916,7 +916,7 @@ Templates:
 		Id: 97
 		Images: d05.win
 		Size: 3,4
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -930,7 +930,7 @@ Templates:
 		Id: 98
 		Images: d06.win
 		Size: 2,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			2: Road
@@ -941,7 +941,7 @@ Templates:
 		Id: 99
 		Images: d07.win
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -952,7 +952,7 @@ Templates:
 		Id: 100
 		Images: d08.win
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			3: Clear
@@ -962,7 +962,7 @@ Templates:
 		Id: 101
 		Images: d09.win
 		Size: 4,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Clear
@@ -978,7 +978,7 @@ Templates:
 		Id: 102
 		Images: d10.win
 		Size: 4,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Rock
@@ -990,7 +990,7 @@ Templates:
 		Id: 103
 		Images: d11.win
 		Size: 2,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1000,7 +1000,7 @@ Templates:
 		Id: 104
 		Images: d12.win
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -1009,7 +1009,7 @@ Templates:
 		Id: 105
 		Images: d13.win
 		Size: 4,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1024,7 +1024,7 @@ Templates:
 		Id: 106
 		Images: d14.win
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1038,7 +1038,7 @@ Templates:
 		Id: 107
 		Images: d15.win
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1052,7 +1052,7 @@ Templates:
 		Id: 108
 		Images: d16.win
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1067,7 +1067,7 @@ Templates:
 		Id: 109
 		Images: d17.win
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1079,7 +1079,7 @@ Templates:
 		Id: 110
 		Images: d18.win
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1094,7 +1094,7 @@ Templates:
 		Id: 111
 		Images: d19.win
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1109,7 +1109,7 @@ Templates:
 		Id: 112
 		Images: d20.win
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1123,7 +1123,7 @@ Templates:
 		Id: 113
 		Images: d21.win
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Rock
 			1: Road
@@ -1135,7 +1135,7 @@ Templates:
 		Id: 114
 		Images: d22.win
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			3: Road
@@ -1148,7 +1148,7 @@ Templates:
 		Id: 115
 		Images: d23.win
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -1161,7 +1161,7 @@ Templates:
 		Id: 116
 		Images: d24.win
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1174,7 +1174,7 @@ Templates:
 		Id: 117
 		Images: d25.win
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1187,7 +1187,7 @@ Templates:
 		Id: 118
 		Images: d26.win
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Clear
@@ -1195,7 +1195,7 @@ Templates:
 		Id: 119
 		Images: d27.win
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Clear
@@ -1203,7 +1203,7 @@ Templates:
 		Id: 120
 		Images: d28.win
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1212,7 +1212,7 @@ Templates:
 		Id: 121
 		Images: d29.win
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1221,7 +1221,7 @@ Templates:
 		Id: 122
 		Images: d30.win
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1230,7 +1230,7 @@ Templates:
 		Id: 123
 		Images: d31.win
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Clear
@@ -1239,7 +1239,7 @@ Templates:
 		Id: 124
 		Images: d32.win
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1248,7 +1248,7 @@ Templates:
 		Id: 125
 		Images: d33.win
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1257,7 +1257,7 @@ Templates:
 		Id: 126
 		Images: d34.win
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1270,7 +1270,7 @@ Templates:
 		Id: 127
 		Images: d35.win
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1283,7 +1283,7 @@ Templates:
 		Id: 128
 		Images: d36.win
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			3: Clear
@@ -1291,7 +1291,7 @@ Templates:
 		Id: 129
 		Images: d37.win
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			3: Clear
@@ -1299,7 +1299,7 @@ Templates:
 		Id: 130
 		Images: d38.win
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1308,7 +1308,7 @@ Templates:
 		Id: 131
 		Images: d39.win
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1317,7 +1317,7 @@ Templates:
 		Id: 132
 		Images: d40.win
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1326,7 +1326,7 @@ Templates:
 		Id: 133
 		Images: d41.win
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Wall
 			2: Road
@@ -1335,7 +1335,7 @@ Templates:
 		Id: 134
 		Images: d42.win
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -1344,7 +1344,7 @@ Templates:
 		Id: 135
 		Images: d43.win
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -1353,7 +1353,7 @@ Templates:
 		Id: 136
 		Images: rv01.win
 		Size: 5,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Rock
@@ -1373,7 +1373,7 @@ Templates:
 		Id: 137
 		Images: rv02.win
 		Size: 5,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1392,7 +1392,7 @@ Templates:
 		Id: 138
 		Images: rv03.win
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1411,7 +1411,7 @@ Templates:
 		Id: 139
 		Images: rv04.win
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			2: Wall
 			3: Clear
@@ -1429,7 +1429,7 @@ Templates:
 		Id: 140
 		Images: rv05.win
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: River
@@ -1444,7 +1444,7 @@ Templates:
 		Id: 141
 		Images: rv06.win
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1456,7 +1456,7 @@ Templates:
 		Id: 142
 		Images: rv07.win
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1468,7 +1468,7 @@ Templates:
 		Id: 143
 		Images: rv08.win
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1478,7 +1478,7 @@ Templates:
 		Id: 144
 		Images: rv09.win
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1488,7 +1488,7 @@ Templates:
 		Id: 145
 		Images: rv10.win
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: River
 			1: River
@@ -1498,7 +1498,7 @@ Templates:
 		Id: 146
 		Images: rv11.win
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: River
 			1: River
@@ -1508,7 +1508,7 @@ Templates:
 		Id: 147
 		Images: rv12.win
 		Size: 3,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: River
@@ -1526,7 +1526,7 @@ Templates:
 		Id: 148
 		Images: rv13.win
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			2: Clear
 			3: Clear
@@ -1546,7 +1546,7 @@ Templates:
 		Id: 161
 		Images: ford1.win
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: River
@@ -1561,7 +1561,7 @@ Templates:
 		Id: 162
 		Images: ford2.win
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Road
@@ -1576,7 +1576,7 @@ Templates:
 		Id: 163
 		Images: falls1.win
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Rock
@@ -1591,7 +1591,7 @@ Templates:
 		Id: 164
 		Images: falls2.win
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1603,7 +1603,7 @@ Templates:
 		Id: 165
 		Images: bridge1.win
 		Size: 4,4
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			2: Clear
 			3: Road
@@ -1623,7 +1623,7 @@ Templates:
 		Id: 166
 		Images: bridge1d.win
 		Size: 4,4
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			2: Clear
 			3: Road
@@ -1643,7 +1643,7 @@ Templates:
 		Id: 167
 		Images: bridge2.win
 		Size: 5,5
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Road
 			1: Clear
@@ -1670,7 +1670,7 @@ Templates:
 		Id: 168
 		Images: bridge2d.win
 		Size: 5,5
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Road
 			1: Clear
@@ -1697,7 +1697,7 @@ Templates:
 		Id: 181
 		Images: p16.win
 		Size: 2,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1707,7 +1707,7 @@ Templates:
 		Id: 182
 		Images: p17.win
 		Size: 4,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			2: Clear
 			3: Clear
@@ -1719,7 +1719,7 @@ Templates:
 		Id: 183
 		Images: p18.win
 		Size: 4,3
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1733,7 +1733,7 @@ Templates:
 		Id: 184
 		Images: p19.win
 		Size: 6,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			2: Clear
 			3: Clear
@@ -1747,7 +1747,7 @@ Templates:
 		Id: 185
 		Images: p20.win
 		Size: 4,3
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1761,7 +1761,7 @@ Templates:
 		Id: 186
 		Images: sh34.win
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1776,7 +1776,7 @@ Templates:
 		Id: 187
 		Images: sh35.win
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: River
@@ -1791,7 +1791,7 @@ Templates:
 		Id: 189
 		Images: cliffsl1.win
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1799,7 +1799,7 @@ Templates:
 		Id: 190
 		Images: cliffsl2.win
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1807,7 +1807,7 @@ Templates:
 		Id: 191
 		Images: cliffsl3.win
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1815,7 +1815,7 @@ Templates:
 		Id: 192
 		Images: cliffsl4.win
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock

--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -68,7 +68,7 @@ Templates:
 		Frames: 0, 8, 9, 48, 49, 50, 51, 52, 68, 69, 70, 71, 72
 		Size: 1,1
 		PickAny: True
-		Category: Basic
+		Categories: Basic
 		Tiles:
 			0: SpiceSand
 			1: SpiceSand
@@ -88,7 +88,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 10, 11, 30, 31
 		Size: 2,2
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Sand
 			1: Dune
@@ -99,7 +99,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 12, 13, 32, 33
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -110,7 +110,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 14, 15, 34, 35
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -121,7 +121,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 16, 17, 36, 37
 		Size: 2,2
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Sand
 			1: Dune
@@ -132,7 +132,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 18, 19, 38, 39
 		Size: 2,2
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 			1: Sand
@@ -143,7 +143,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 58, 59, 78, 79
 		Size: 2,2
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 			1: Dune
@@ -154,7 +154,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 56, 57, 76, 77
 		Size: 2,2
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 			1: Dune
@@ -165,7 +165,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 54, 55, 74, 75
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -176,7 +176,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 53, 73
 		Size: 1,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Transition
 			1: Transition
@@ -185,7 +185,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 98, 99, 118, 119
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -196,7 +196,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 138, 139, 158, 159
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -207,7 +207,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 136, 137, 156, 157
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -218,7 +218,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 134, 135, 154, 155
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -229,7 +229,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 132, 133, 152, 153
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Sand
 			1: Cliff
@@ -240,7 +240,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 130, 131, 150, 151
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Sand
@@ -251,7 +251,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 128, 129, 148, 149
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -262,7 +262,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 126, 127, 146, 147
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -273,7 +273,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 124, 125, 144, 145
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -284,7 +284,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 122, 123, 142, 143
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -295,7 +295,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 120, 121, 140, 141
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -306,7 +306,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 178, 179, 198, 199
 		Size: 2,2
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 			1: Transition
@@ -317,7 +317,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 176, 177, 196, 197
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -328,7 +328,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 174, 175, 194, 195
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -339,7 +339,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 172, 173, 192, 193
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -350,7 +350,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 170, 171, 190, 191
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -361,7 +361,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 168, 169, 188, 189
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -372,7 +372,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 166, 167, 186, 187
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -383,7 +383,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 164, 165, 184, 185
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -394,7 +394,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 162, 163, 182, 183
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -405,7 +405,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 160, 161, 180, 181
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -416,7 +416,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 202, 203, 222, 223, 242, 243
 		Size: 2,3
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -429,7 +429,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 260, 261, 280, 281
 		Size: 2,2
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 			1: Transition
@@ -440,7 +440,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 200, 201, 220, 221, 240, 241
 		Size: 2,3
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Sand
@@ -453,7 +453,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 204, 205, 224, 225, 244, 245
 		Size: 2,3
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Sand
@@ -466,7 +466,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 206, 207, 226, 227, 246, 247
 		Size: 2,3
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -479,7 +479,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 262, 263, 282, 283
 		Size: 2,2
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 			1: Transition
@@ -490,7 +490,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 264, 265, 284, 285
 		Size: 2,2
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 			1: Transition
@@ -501,7 +501,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 85, 86, 105, 106
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -512,7 +512,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 87, 88, 107, 108
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -523,7 +523,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 89, 90, 109, 110
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -534,7 +534,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 91, 92, 111, 112
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -545,7 +545,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 93, 94, 113, 114
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -556,7 +556,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 95, 96, 115, 116
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -567,7 +567,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 218, 219, 238, 239
 		Size: 2,2
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 			1: Transition
@@ -578,7 +578,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 258, 259, 278, 279
 		Size: 2,2
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Sand
 			1: Transition
@@ -589,7 +589,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 256, 257, 276, 277
 		Size: 2,2
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 			1: Transition
@@ -600,7 +600,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 216, 217, 236, 237
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -611,7 +611,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 214, 215, 234, 235
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -622,7 +622,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 211, 212, 213, 231, 232, 233
 		Size: 3,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Sand
 			1: Cliff
@@ -635,7 +635,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 251, 252, 253, 271, 272, 273
 		Size: 3,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Sand
 			1: Cliff
@@ -648,7 +648,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 248, 249, 250, 268, 269, 270
 		Size: 3,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -661,7 +661,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 208, 209, 210, 228, 229, 230
 		Size: 3,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -674,7 +674,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 266, 267, 286, 287
 		Size: 2,2
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Sand
 			1: Transition
@@ -685,7 +685,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 322
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@59:
@@ -693,7 +693,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 302
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 	Template@60:
@@ -701,7 +701,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 288
 		Size: 1,1
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Sand
 	Template@61:
@@ -709,7 +709,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 308
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 	Template@62:
@@ -717,7 +717,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 328
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 	Template@63:
@@ -725,7 +725,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 329
 		Size: 1,1
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 	Template@64:
@@ -733,7 +733,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 330
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 	Template@65:
@@ -741,7 +741,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 289, 290, 309, 310
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -752,7 +752,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 331
 		Size: 1,1
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 	Template@67:
@@ -760,7 +760,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 332
 		Size: 1,1
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 	Template@68:
@@ -768,7 +768,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 298, 299
 		Size: 2,1
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -777,7 +777,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 317, 318
 		Size: 2,1
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 			1: Transition
@@ -786,7 +786,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 338, 339, 358, 359
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -797,7 +797,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 337
 		Size: 1,1
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 	Template@72:
@@ -805,7 +805,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 336
 		Size: 1,1
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 	Template@73:
@@ -813,7 +813,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 335
 		Size: 1,1
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 	Template@74:
@@ -821,7 +821,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 313, 333
 		Size: 1,2
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 			1: Transition
@@ -830,7 +830,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 314, 334
 		Size: 1,2
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 			1: Transition
@@ -839,7 +839,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 315
 		Size: 1,1
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 	Template@77:
@@ -847,7 +847,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 291, 292
 		Size: 2,1
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 			1: Transition
@@ -856,7 +856,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 293, 294
 		Size: 2,1
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 			1: Transition
@@ -865,7 +865,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 295, 296
 		Size: 2,1
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 			1: Transition
@@ -874,7 +874,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 719
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Cliff
 	Template@81:
@@ -882,7 +882,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 718
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Cliff
 	Template@82:
@@ -890,7 +890,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 738
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 	Template@83:
@@ -898,7 +898,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 739
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 	Template@84:
@@ -906,7 +906,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 737
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 	Template@85:
@@ -914,7 +914,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 717
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 	Template@86:
@@ -922,7 +922,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 716
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 	Template@87:
@@ -930,7 +930,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 736
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 	Template@88:
@@ -939,7 +939,7 @@ Templates:
 		Frames: 657, 658, 659, 691
 		Size: 1,1
 		PickAny: True
-		Category: Basic
+		Categories: Basic
 		Tiles:
 			0: Concrete
 			1: Concrete
@@ -950,7 +950,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 685
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 	Template@94:
@@ -958,7 +958,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 661, 662, 681, 682
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rock
@@ -969,7 +969,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 660, 680
 		Size: 1,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rock
@@ -978,7 +978,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 619, 639
 		Size: 1,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 			1: Rock
@@ -987,7 +987,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 538
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 	Template@100:
@@ -995,7 +995,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 539
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 	Template@101:
@@ -1003,7 +1003,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 557, 558, 559, 577, 578, 579, 597, 598, 599
 		Size: 3,3
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -1019,7 +1019,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 652, 653, 672, 673
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 			1: Cliff
@@ -1030,7 +1030,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 692, 693
 		Size: 2,1
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Sand
@@ -1039,7 +1039,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 689, 690
 		Size: 2,1
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1048,7 +1048,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 674, 694
 		Size: 1,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1057,7 +1057,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 675, 695
 		Size: 1,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Sand
@@ -1066,7 +1066,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 677, 697
 		Size: 1,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Rock
@@ -1075,7 +1075,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 697
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 	Template@110:
@@ -1083,7 +1083,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 678, 679
 		Size: 2,1
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1092,7 +1092,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 698, 699
 		Size: 2,1
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1101,7 +1101,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 715, 735
 		Size: 1,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -1110,7 +1110,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 711, 712, 713, 714, 731, 732, 733, 734
 		Size: 4,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rock
@@ -1125,7 +1125,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 709, 710, 729, 730
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -1136,7 +1136,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 708
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 	Template@116:
@@ -1144,7 +1144,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 728
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@117:
@@ -1152,7 +1152,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 706, 707, 726, 727
 		Size: 2,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Sand
@@ -1163,7 +1163,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 700, 701, 702, 720, 721, 722
 		Size: 3,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -1176,7 +1176,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 703, 704, 723, 724
 		Size: 2,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -1187,7 +1187,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 705, 725
 		Size: 1,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -1196,7 +1196,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 746, 747
 		Size: 2,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -1205,7 +1205,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 744, 745
 		Size: 2,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -1214,7 +1214,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 743
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@124:
@@ -1222,7 +1222,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 742
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@125:
@@ -1230,7 +1230,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 740, 741
 		Size: 2,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -1239,7 +1239,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 600, 601, 602, 620, 621, 622, 640, 641, 642
 		Size: 3,3
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1255,7 +1255,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 603, 604, 623, 624
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1266,7 +1266,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 605, 606, 625, 626
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1277,7 +1277,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 564, 565, 584, 585
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1288,7 +1288,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 566, 567, 586, 587
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1299,7 +1299,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 562, 563, 582, 583
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1310,7 +1310,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 560, 561, 580, 581
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1321,7 +1321,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 607, 608, 627, 628
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1332,7 +1332,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 609, 610, 629, 630
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Cliff
 			1: Rock
@@ -1343,7 +1343,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 568, 569, 588, 589
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1354,7 +1354,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 570, 571, 590, 591
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1365,7 +1365,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 529, 530, 549, 550
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1376,7 +1376,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 527, 528, 547, 548
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1387,7 +1387,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 525, 526, 545, 546
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1398,7 +1398,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 523, 524, 543, 544
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1409,7 +1409,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 520, 521, 522, 540, 541, 542
 		Size: 3,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Sand
 			1: Cliff
@@ -1422,7 +1422,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 480, 481, 482, 500, 501, 502
 		Size: 3,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1435,7 +1435,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 440, 441, 460, 461
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1446,7 +1446,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 402, 403, 422, 423, 442, 443
 		Size: 2,3
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1459,7 +1459,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 400, 401, 420, 421
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1470,7 +1470,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 408, 409, 428, 429
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1481,7 +1481,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 410, 411, 430, 431, 450, 451
 		Size: 2,3
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1494,7 +1494,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 412, 413, 432, 433
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Transition
@@ -1505,7 +1505,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 452, 453
 		Size: 2,1
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1514,7 +1514,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 454, 455, 474, 475, 494, 495
 		Size: 2,3
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1527,7 +1527,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 489, 490, 509, 510
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1538,7 +1538,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 448, 449, 468, 469
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1549,7 +1549,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 487, 488, 507, 508
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1560,7 +1560,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 446, 447, 466, 467
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1571,7 +1571,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 444, 445, 464, 465
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Rock
@@ -1582,7 +1582,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 456, 457, 476, 477, 496, 497
 		Size: 2,3
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1595,7 +1595,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 498, 499, 518, 519
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1606,7 +1606,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 458, 459, 478, 479
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1617,7 +1617,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 418, 419, 438, 439
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1628,7 +1628,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 378, 379, 398, 399
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1639,7 +1639,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 416, 417, 436, 437
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1650,7 +1650,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 376, 377, 396, 397
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1661,7 +1661,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 414, 415, 434, 435
 		Size: 2,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1672,7 +1672,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 354, 355, 374, 375, 394, 395
 		Size: 2,3
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -1685,7 +1685,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 356
 		Size: 1,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 	Template@216:
@@ -1693,7 +1693,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 347, 348, 367, 368, 387, 388
 		Size: 2,3
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 			1: Sand
@@ -1706,7 +1706,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 386
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 	Template@218:
@@ -1714,7 +1714,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 345, 346, 365, 366
 		Size: 2,2
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1725,7 +1725,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 343, 344, 363, 364
 		Size: 2,2
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 			1: Sand
@@ -1736,7 +1736,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 340, 341, 342, 360, 361, 362
 		Size: 3,2
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1749,7 +1749,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 380, 381, 382
 		Size: 3,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1759,7 +1759,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 483, 484, 503, 504
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Transition
@@ -1770,7 +1770,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 485, 486, 505, 506
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1781,7 +1781,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 83, 84, 103, 104
 		Size: 2,2
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 			1: Dune
@@ -1792,7 +1792,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 28
 		Size: 1,1
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 	Template@229:
@@ -1800,7 +1800,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 26, 27, 46, 47
 		Size: 2,2
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 			1: Sand
@@ -1811,7 +1811,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 65, 66
 		Size: 2,1
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 			1: Dune
@@ -1820,7 +1820,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 63, 64
 		Size: 2,1
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 			1: Dune
@@ -1829,7 +1829,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 22, 23, 42, 43
 		Size: 2,2
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 			1: Dune
@@ -1840,7 +1840,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 60
 		Size: 1,1
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 	Template@234:
@@ -1848,7 +1848,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 61
 		Size: 1,1
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 	Template@235:
@@ -1856,7 +1856,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 62
 		Size: 1,1
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 	Template@236:
@@ -1864,7 +1864,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 82
 		Size: 1,1
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 	Template@237:
@@ -1872,7 +1872,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 102
 		Size: 1,1
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 	Template@238:
@@ -1880,7 +1880,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 101
 		Size: 1,1
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 	Template@239:
@@ -1888,7 +1888,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 100
 		Size: 1,1
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 	Template@240:
@@ -1896,7 +1896,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 80
 		Size: 1,1
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 	Template@241:
@@ -1904,7 +1904,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 81
 		Size: 1,1
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 	Template@242:
@@ -1912,7 +1912,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 21
 		Size: 1,1
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 	Template@243:
@@ -1920,7 +1920,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 41
 		Size: 1,1
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 	Template@244:
@@ -1928,7 +1928,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 40
 		Size: 1,1
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 	Template@245:
@@ -1936,7 +1936,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 20
 		Size: 1,1
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 	Template@246:
@@ -1944,7 +1944,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 24, 25, 44, 45
 		Size: 2,2
-		Category: Dune
+		Categories: Dune
 		Tiles:
 			0: Dune
 			1: Dune
@@ -1955,7 +1955,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 352, 353, 372, 373
 		Size: 2,2
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -1966,7 +1966,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 392, 393
 		Size: 2,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -1975,7 +1975,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 390
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@250:
@@ -1983,7 +1983,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 389
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 	Template@251:
@@ -1991,7 +1991,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 349, 350, 369, 370
 		Size: 2,2
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Rough
 			1: Cliff
@@ -2002,7 +2002,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 254, 255, 274, 275
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2013,7 +2013,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 514, 515, 534, 535
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2024,7 +2024,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 516, 517, 536, 537
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2035,7 +2035,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 404, 405, 424, 425
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2046,7 +2046,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 406, 407, 426, 427
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2057,7 +2057,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 676, 696
 		Size: 1,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2066,7 +2066,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 303
 		Size: 1,1
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 	Template@260:
@@ -2074,7 +2074,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 304
 		Size: 1,1
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 	Template@261:
@@ -2082,7 +2082,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 324
 		Size: 1,1
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 	Template@262:
@@ -2090,7 +2090,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 323
 		Size: 1,1
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 	Template@263:
@@ -2098,7 +2098,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 511, 512, 513, 531, 532, 533
 		Size: 3,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2111,7 +2111,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 471, 472, 473, 491, 492, 493
 		Size: 3,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2125,7 +2125,7 @@ Templates:
 		Frames: 306, 307, 552, 553, 554, 555, 556, 572, 573, 574, 575, 576, 592, 593, 594, 595, 596
 		Size: 1,1
 		PickAny: True
-		Category: Basic
+		Categories: Basic
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2149,7 +2149,7 @@ Templates:
 		Images: BLOXBASE.R8
 		Frames: 326, 327
 		Size: 2,1
-		Category: Rock-Sand-Smooth
+		Categories: Rock-Sand-Smooth
 		Tiles:
 			0: Transition
 			1: Transition
@@ -2158,7 +2158,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 1
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Cliff
 	Template@272:
@@ -2166,7 +2166,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 2
 		Size: 1,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Cliff
 	Template@273:
@@ -2174,7 +2174,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 3
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 	Template@274:
@@ -2182,7 +2182,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 4
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@275:
@@ -2190,7 +2190,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 5
 		Size: 1,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Rough
 	Template@276:
@@ -2198,7 +2198,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 6
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Cliff
 	Template@277:
@@ -2206,7 +2206,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 322
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Cliff
 	Template@278:
@@ -2214,7 +2214,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 165
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 	Template@279:
@@ -2222,7 +2222,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 164
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 	Template@280:
@@ -2230,7 +2230,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 184
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 	Template@281:
@@ -2238,7 +2238,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 305
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 	Template@282:
@@ -2246,7 +2246,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 325
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 	Template@283:
@@ -2254,7 +2254,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 289, 290, 309, 310
 		Size: 2,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -2265,7 +2265,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 316
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@285:
@@ -2273,7 +2273,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 297
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@286:
@@ -2281,7 +2281,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 338, 339, 358, 359
 		Size: 2,2
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 			1: Sand
@@ -2292,7 +2292,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 340, 341, 360, 361, 380, 381
 		Size: 2,3
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -2305,7 +2305,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 342, 343, 362, 363, 382, 383
 		Size: 2,3
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -2318,7 +2318,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 344, 345, 364, 365, 384, 385
 		Size: 2,3
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -2331,7 +2331,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 349, 350, 369, 370, 389, 390
 		Size: 2,3
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Sand
@@ -2344,7 +2344,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 351, 371
 		Size: 1,2
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 			1: Sand
@@ -2353,7 +2353,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 391
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@293:
@@ -2361,7 +2361,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 392
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@294:
@@ -2369,7 +2369,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 393
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@295:
@@ -2377,7 +2377,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 352, 372
 		Size: 1,2
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 			1: Sand
@@ -2386,7 +2386,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 353
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@297:
@@ -2394,7 +2394,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 354
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@298:
@@ -2402,7 +2402,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 374
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@299:
@@ -2410,7 +2410,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 373
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@300:
@@ -2418,7 +2418,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 394, 395, 414, 415
 		Size: 2,2
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 			1: Sand
@@ -2429,7 +2429,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 434, 435
 		Size: 2,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -2438,7 +2438,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 355, 375
 		Size: 1,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -2447,7 +2447,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 356, 357
 		Size: 2,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -2456,7 +2456,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 462, 463
 		Size: 2,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2465,7 +2465,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 551
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 	Template@306:
@@ -2473,7 +2473,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 607, 608, 627, 628
 		Size: 2,2
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Rough
 			1: Cliff
@@ -2484,7 +2484,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 609, 610, 629, 630
 		Size: 2,2
-		Category: Dead-Worm
+		Categories: Dead-Worm
 		Tiles:
 			0: Sand
 			1: Sand
@@ -2495,7 +2495,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 652, 653, 672, 673
 		Size: 2,2
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2506,7 +2506,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 713, 714, 715, 733, 734, 735
 		Size: 3,2
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 			1: Cliff
@@ -2519,7 +2519,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 709, 710, 711, 712, 729, 730, 731, 732
 		Size: 4,2
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2534,7 +2534,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 661, 662, 681, 682
 		Size: 2,2
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -2545,7 +2545,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 683
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 	Template@313:
@@ -2553,7 +2553,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 684
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 	Template@314:
@@ -2561,7 +2561,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 703
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 	Template@315:
@@ -2569,7 +2569,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 723
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 	Template@316:
@@ -2577,7 +2577,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 722
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@317:
@@ -2585,7 +2585,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 721
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@318:
@@ -2593,7 +2593,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 720
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 	Template@319:
@@ -2601,7 +2601,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 700
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 	Template@320:
@@ -2609,7 +2609,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 701, 702
 		Size: 2,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 			1: Sand
@@ -2618,7 +2618,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 741
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@322:
@@ -2626,7 +2626,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 742
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@323:
@@ -2634,7 +2634,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 743
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@324:
@@ -2642,7 +2642,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 744
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@325:
@@ -2650,7 +2650,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 745, 746
 		Size: 2,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2659,7 +2659,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 747
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@327:
@@ -2667,7 +2667,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 728
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@328:
@@ -2675,7 +2675,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 708
 		Size: 1,1
-		Category: Dead-Worm
+		Categories: Dead-Worm
 		Tiles:
 			0: Sand
 	Template@329:
@@ -2683,7 +2683,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 716, 717, 736, 737
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2694,7 +2694,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 538, 539, 558, 559
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -2705,7 +2705,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 578, 579, 598, 599
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -2716,7 +2716,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 718, 719, 738, 739, 758, 759
 		Size: 2,3
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -2729,7 +2729,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 704, 705, 724, 725
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2740,7 +2740,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 706, 707, 726, 727
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2751,7 +2751,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 660, 680
 		Size: 1,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -2760,7 +2760,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 388
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@337:
@@ -2768,7 +2768,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 346, 347, 348, 366, 367, 368
 		Size: 3,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -2781,7 +2781,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 386, 387
 		Size: 2,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -2790,7 +2790,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 164, 165, 184, 185
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -2801,7 +2801,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 289, 290, 309, 310
 		Size: 2,2
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -2812,7 +2812,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 338, 339, 358, 359
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -2823,7 +2823,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 349, 350, 351, 352, 353, 354, 369, 370, 371, 372, 373, 374, 389, 390, 391, 392, 393, 394
 		Size: 6,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Cliff
@@ -2848,7 +2848,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 340, 341, 342, 360, 361, 362, 380, 381, 382
 		Size: 3,3
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2864,7 +2864,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 363, 364, 383, 384
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2875,7 +2875,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 343, 344
 		Size: 2,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2884,7 +2884,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 345, 346
 		Size: 2,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2893,7 +2893,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 365, 366, 367, 368, 385, 386, 387, 388
 		Size: 4,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -2908,7 +2908,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 414, 415, 434, 435
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rock
@@ -2919,7 +2919,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 607, 608, 609, 627, 628, 629
 		Size: 3,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -2932,7 +2932,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 610
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 	Template@351:
@@ -2940,7 +2940,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 652, 653, 672, 673
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -2951,7 +2951,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 700
 		Size: 1,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 	Template@353:
@@ -2959,7 +2959,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 720
 		Size: 1,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 	Template@354:
@@ -2967,7 +2967,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 701, 702, 703, 721, 722, 723, 741, 742, 743
 		Size: 3,3
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -2983,7 +2983,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 724, 725, 744, 745
 		Size: 2,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -2994,7 +2994,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 726, 727, 746, 747
 		Size: 2,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -3005,7 +3005,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 734, 735
 		Size: 2,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -3014,7 +3014,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 716, 717, 736, 737
 		Size: 2,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -3025,7 +3025,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 718, 719, 738, 739
 		Size: 2,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Sand
@@ -3036,7 +3036,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 758, 759
 		Size: 2,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -3045,7 +3045,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 97, 117
 		Size: 1,2
-		Category: Sand-Ice-Cliff
+		Categories: Sand-Ice-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -3054,7 +3054,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 164, 165, 184, 185
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -3065,7 +3065,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 289, 290
 		Size: 2,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 			1: Sand
@@ -3074,7 +3074,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 309, 310, 311, 312, 355, 356, 357, 358, 1, 2, 3, 4, 5, 6, 7, 8
 		Size: 4,4
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -3097,7 +3097,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 322
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 	Template@368:
@@ -3105,7 +3105,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 325
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@369:
@@ -3113,7 +3113,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 305
 		Size: 1,1
-		Category: Dead-Worm
+		Categories: Dead-Worm
 		Tiles:
 			0: Sand
 	Template@370:
@@ -3121,7 +3121,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 297
 		Size: 1,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 	Template@371:
@@ -3129,7 +3129,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 375, 395, 415, 435
 		Size: 1,4
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Cliff
 			1: Sand
@@ -3140,7 +3140,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 414, 434
 		Size: 1,2
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -3149,7 +3149,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 340, 341, 342, 343, 344, 345, 360, 361, 362, 363, 364, 365, 380, 381, 382, 383, 384, 385
 		Size: 6,3
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -3174,7 +3174,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 366, 367, 368, 386, 387, 388
 		Size: 3,2
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -3187,7 +3187,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 346
 		Size: 1,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 	Template@376:
@@ -3195,7 +3195,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 349, 350, 351, 352, 369, 370, 371, 372, 389, 390, 391, 392
 		Size: 4,3
-		Category: Sand-Ice-Cliff
+		Categories: Sand-Ice-Cliff
 		Tiles:
 			0: Cliff
 			1: Ice
@@ -3214,7 +3214,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 353, 354, 373, 374, 393, 394
 		Size: 2,3
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Transition
 			1: Transition
@@ -3227,7 +3227,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 462
 		Size: 1,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Cliff
 	Template@380:
@@ -3235,7 +3235,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 463
 		Size: 1,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Rough
 	Template@381:
@@ -3243,7 +3243,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 551
 		Size: 1,1
-		Category: Unidentified
+		Categories: Unidentified
 		Tiles:
 			0: Sand
 	Template@383:
@@ -3251,7 +3251,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 539, 559
 		Size: 1,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -3260,7 +3260,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 557, 558, 577, 578, 597, 598
 		Size: 2,3
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -3273,7 +3273,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 607, 608, 627, 628
 		Size: 2,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -3284,7 +3284,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 609, 610, 629, 630
 		Size: 2,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Sand
@@ -3295,7 +3295,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 700, 701, 720, 721, 740, 741
 		Size: 2,3
-		Category: Sand-Ice-Cliff
+		Categories: Sand-Ice-Cliff
 		Tiles:
 			0: Ice
 			1: Cliff
@@ -3308,7 +3308,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 702, 703, 722, 723
 		Size: 2,2
-		Category: Sand-Ice-Cliff
+		Categories: Sand-Ice-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -3319,7 +3319,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 742
 		Size: 1,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Cliff
 	Template@390:
@@ -3327,7 +3327,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 743
 		Size: 1,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 	Template@391:
@@ -3335,7 +3335,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 744
 		Size: 1,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 	Template@392:
@@ -3343,7 +3343,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 745
 		Size: 1,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 	Template@393:
@@ -3351,7 +3351,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 704, 705, 724, 725
 		Size: 2,2
-		Category: Sand-Ice-Cliff
+		Categories: Sand-Ice-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -3362,7 +3362,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 706, 707, 726, 727, 746, 747
 		Size: 2,3
-		Category: Sand-Ice-Cliff
+		Categories: Sand-Ice-Cliff
 		Tiles:
 			0: Cliff
 			1: Ice
@@ -3375,7 +3375,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 708, 709, 728, 729
 		Size: 2,2
-		Category: Sand-Ice-Cliff
+		Categories: Sand-Ice-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -3386,7 +3386,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 710, 711, 730, 731
 		Size: 2,2
-		Category: Sand-Ice-Cliff
+		Categories: Sand-Ice-Cliff
 		Tiles:
 			0: Ice
 			1: Ice
@@ -3397,7 +3397,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 712, 713, 732, 733
 		Size: 2,2
-		Category: Sand-Ice-Cliff
+		Categories: Sand-Ice-Cliff
 		Tiles:
 			0: Ice
 			1: Cliff
@@ -3408,7 +3408,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 714, 715, 734, 735
 		Size: 2,2
-		Category: Sand-Ice-Cliff
+		Categories: Sand-Ice-Cliff
 		Tiles:
 			0: Ice
 			1: Ice
@@ -3419,7 +3419,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 716, 717
 		Size: 2,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -3428,7 +3428,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 736, 737
 		Size: 2,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -3437,7 +3437,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 718, 719, 738, 739, 758, 759
 		Size: 2,3
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -3450,7 +3450,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 660, 661, 662
 		Size: 3,1
-		Category: Unidentified
+		Categories: Unidentified
 		Tiles:
 			0: Rough
 			1: Sand
@@ -3460,7 +3460,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 680, 681
 		Size: 2,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -3469,7 +3469,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 682, 683
 		Size: 2,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -3478,7 +3478,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 684, 685
 		Size: 2,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -3487,7 +3487,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 652, 653
 		Size: 2,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -3496,7 +3496,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 672, 673
 		Size: 2,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -3505,7 +3505,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 6
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@409:
@@ -3513,7 +3513,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 7
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@410:
@@ -3521,7 +3521,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 67
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 	Template@411:
@@ -3529,7 +3529,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 97, 117
 		Size: 1,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -3538,7 +3538,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 340, 341, 360, 361
 		Size: 2,2
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -3549,7 +3549,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 342, 343, 344, 362, 363, 364
 		Size: 3,2
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -3562,7 +3562,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 1, 2, 3, 4, 5
 		Size: 5,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3574,7 +3574,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 305, 325
 		Size: 1,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -3583,7 +3583,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 289, 290, 309, 310
 		Size: 2,2
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -3594,7 +3594,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 311, 312
 		Size: 2,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Transition
 			1: Transition
@@ -3603,7 +3603,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 316
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 	Template@419:
@@ -3611,7 +3611,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 297
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 	Template@420:
@@ -3619,7 +3619,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 319
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 	Template@421:
@@ -3627,7 +3627,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 338, 339, 358, 359
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -3638,7 +3638,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 374, 375, 394, 395
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3649,7 +3649,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 414, 415, 434, 435
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3660,7 +3660,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 349, 350, 351, 352, 353, 354
 		Size: 6,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3673,7 +3673,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 355, 356, 357
 		Size: 3,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3683,7 +3683,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 462, 463
 		Size: 2,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3692,7 +3692,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 538, 539, 558, 559
 		Size: 2,2
-		Category: Sand-Sand-Cliff
+		Categories: Sand-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -3703,7 +3703,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 578, 579, 598, 599
 		Size: 2,2
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Transition
 			1: Transition
@@ -3714,7 +3714,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 700, 701, 702, 720, 721, 722, 740, 741, 742
 		Size: 3,3
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -3730,7 +3730,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 747
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@431:
@@ -3738,7 +3738,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 707, 708, 727, 728
 		Size: 2,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -3749,7 +3749,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 709
 		Size: 1,1
-		Category: Dead-Worm
+		Categories: Dead-Worm
 		Tiles:
 			0: Sand
 	Template@433:
@@ -3757,7 +3757,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 729
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Cliff
 	Template@434:
@@ -3765,7 +3765,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 730, 731
 		Size: 2,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -3774,7 +3774,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 710, 711, 712
 		Size: 3,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Rough
@@ -3784,7 +3784,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 718, 719, 738, 739, 758, 759
 		Size: 2,3
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -3797,7 +3797,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 732
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 	Template@438:
@@ -3805,7 +3805,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 713, 714, 733, 734
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3816,7 +3816,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 715, 716, 717, 735, 736, 737
 		Size: 3,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3829,7 +3829,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 652, 653, 672, 673
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3840,7 +3840,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 610
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 	Template@442:
@@ -3848,7 +3848,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 630
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 	Template@443:
@@ -3856,7 +3856,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 607, 608, 609, 627, 628, 629
 		Size: 3,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Rock
 			1: Rough
@@ -3869,7 +3869,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 551
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 	Template@445:
@@ -3877,7 +3877,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 700, 701, 702, 703, 704, 705, 720, 721, 722, 723, 724, 725, 740, 741, 742, 743, 744, 745
 		Size: 6,3
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: SpiceSand
 			1: Sand
@@ -3902,7 +3902,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 683, 684, 685
 		Size: 3,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Dune
 			1: Dune
@@ -3912,7 +3912,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 746, 747
 		Size: 2,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 			1: Dune
@@ -3921,7 +3921,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 708, 709, 728, 729
 		Size: 2,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Dune
 			1: Dune
@@ -3932,7 +3932,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 710, 711
 		Size: 2,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 			1: Dune
@@ -3941,7 +3941,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 730, 731
 		Size: 2,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -3950,7 +3950,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 712
 		Size: 1,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 	Template@452:
@@ -3958,7 +3958,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 732
 		Size: 1,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 	Template@453:
@@ -3966,7 +3966,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 713, 733
 		Size: 1,2
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Dune
 			1: Dune
@@ -3975,7 +3975,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 734, 735
 		Size: 2,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -3984,7 +3984,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 714, 715
 		Size: 2,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -3993,7 +3993,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 716, 717, 718, 736, 737, 738
 		Size: 3,2
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -4006,7 +4006,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 739
 		Size: 1,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 	Template@458:
@@ -4014,7 +4014,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 758, 759
 		Size: 2,1
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -4023,7 +4023,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 652, 653, 672, 673
 		Size: 2,2
-		Category: Ice-Detail
+		Categories: Ice-Detail
 		Tiles:
 			0: Sand
 			1: Sand
@@ -4034,7 +4034,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 345, 346, 365, 366
 		Size: 2,2
-		Category: Dead-Worm
+		Categories: Dead-Worm
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4045,7 +4045,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 355, 356, 357, 358, 359, 373, 374, 375, 338, 339
 		Size: 5,2
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4062,7 +4062,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 97, 117
 		Size: 1,2
-		Category: Dead-Worm
+		Categories: Dead-Worm
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4071,7 +4071,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 67
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@466:
@@ -4079,7 +4079,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 1
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@467:
@@ -4087,7 +4087,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 2, 3
 		Size: 2,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Cliff
 			1: Sand
@@ -4096,7 +4096,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 4
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Cliff
 	Template@469:
@@ -4104,7 +4104,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 5
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Cliff
 	Template@470:
@@ -4112,7 +4112,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 6, 7
 		Size: 2,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4121,7 +4121,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 312
 		Size: 1,1
-		Category: Dead-Worm
+		Categories: Dead-Worm
 		Tiles:
 			0: Sand
 	Template@472:
@@ -4129,7 +4129,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 310, 311
 		Size: 2,1
-		Category: Dead-Worm
+		Categories: Dead-Worm
 		Tiles:
 			0: Sand
 			1: Sand
@@ -4138,7 +4138,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 309
 		Size: 1,1
-		Category: Dead-Worm
+		Categories: Dead-Worm
 		Tiles:
 			0: Sand
 	Template@474:
@@ -4146,7 +4146,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 349, 350, 351, 352, 369, 370, 371, 372, 389, 390, 391, 392, 385, 386, 387, 388
 		Size: 4,4
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 			1: Cliff
@@ -4169,7 +4169,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 706, 707, 726, 727
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4180,7 +4180,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 557, 558, 559, 577, 578, 579
 		Size: 3,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4193,7 +4193,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 619, 639
 		Size: 1,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -4202,7 +4202,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 305
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 	Template@479:
@@ -4210,7 +4210,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 325
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 	Template@481:
@@ -4218,7 +4218,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 414, 415, 434, 435
 		Size: 2,2
-		Category: Sand-Rock-Cliff
+		Categories: Sand-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4229,7 +4229,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 538, 539
 		Size: 2,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -4238,7 +4238,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 305
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Rough
 	Template@501:
@@ -4246,7 +4246,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 325
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@502:
@@ -4254,7 +4254,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 311
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Rough
 	Template@503:
@@ -4262,7 +4262,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 312
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Rough
 	Template@504:
@@ -4270,7 +4270,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 330
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Rough
 	Template@505:
@@ -4278,7 +4278,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 316
 		Size: 1,1
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 	Template@506:
@@ -4286,7 +4286,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 297
 		Size: 1,1
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 	Template@507:
@@ -4294,7 +4294,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 356, 357
 		Size: 2,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Rough
 			1: Rough
@@ -4303,7 +4303,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 355
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Rough
 	Template@509:
@@ -4311,7 +4311,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 375
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Rough
 	Template@510:
@@ -4319,7 +4319,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 395
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Rough
 	Template@511:
@@ -4327,7 +4327,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 414, 415, 434, 435
 		Size: 2,2
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Rough
 			1: Rough
@@ -4338,7 +4338,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 353, 354, 373, 374, 393, 394
 		Size: 2,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 			1: Rough
@@ -4351,7 +4351,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 350, 351, 352, 370, 371, 372, 390, 391, 392
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Cliff
 			1: Rock
@@ -4367,7 +4367,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 347, 348, 349, 367, 368, 369, 387, 388, 389
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 			1: Rough
@@ -4383,7 +4383,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 340, 341, 342, 343, 360, 361, 362, 363, 380, 381, 382, 383
 		Size: 4,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4402,7 +4402,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 717
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 	Template@517:
@@ -4410,7 +4410,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 718
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Rough
 	Template@518:
@@ -4418,7 +4418,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 737
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 	Template@519:
@@ -4426,7 +4426,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 738, 739, 758, 759
 		Size: 2,2
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 			1: Sand
@@ -4437,7 +4437,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 652, 653, 672, 673
 		Size: 2,2
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4447,7 +4447,7 @@ Templates:
 		Id: 600
 		Images: t600.tmp
 		Size: 2,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4457,7 +4457,7 @@ Templates:
 		Id: 601
 		Images: t601.tmp
 		Size: 2,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4467,7 +4467,7 @@ Templates:
 		Id: 602
 		Images: t602.tmp
 		Size: 2,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4477,7 +4477,7 @@ Templates:
 		Id: 603
 		Images: t603.tmp
 		Size: 2,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4487,7 +4487,7 @@ Templates:
 		Id: 604
 		Images: t604.tmp
 		Size: 2,3
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4499,7 +4499,7 @@ Templates:
 		Id: 605
 		Images: t605.tmp
 		Size: 2,3
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4511,7 +4511,7 @@ Templates:
 		Id: 606
 		Images: t606.tmp
 		Size: 2,1
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4519,7 +4519,7 @@ Templates:
 		Id: 607
 		Images: t607.tmp
 		Size: 2,1
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4527,7 +4527,7 @@ Templates:
 		Id: 608
 		Images: t608.tmp
 		Size: 1,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4535,7 +4535,7 @@ Templates:
 		Id: 609
 		Images: t609.tmp
 		Size: 1,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4543,7 +4543,7 @@ Templates:
 		Id: 610
 		Images: t610.tmp
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4553,7 +4553,7 @@ Templates:
 		Id: 611
 		Images: t611.tmp
 		Size: 2,1
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4561,7 +4561,7 @@ Templates:
 		Id: 612
 		Images: t612.tmp
 		Size: 3,3
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Rock
 			1: Rock
@@ -4576,7 +4576,7 @@ Templates:
 		Id: 613
 		Images: t613.tmp
 		Size: 2,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4586,7 +4586,7 @@ Templates:
 		Id: 614
 		Images: t614.tmp
 		Size: 2,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4596,7 +4596,7 @@ Templates:
 		Id: 615
 		Images: t615.tmp
 		Size: 2,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4606,7 +4606,7 @@ Templates:
 		Id: 616
 		Images: t616.tmp
 		Size: 2,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4616,7 +4616,7 @@ Templates:
 		Id: 617
 		Images: t617.tmp
 		Size: 2,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4626,7 +4626,7 @@ Templates:
 		Id: 618
 		Images: t618.tmp
 		Size: 2,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4636,7 +4636,7 @@ Templates:
 		Id: 619
 		Images: t619.tmp
 		Size: 2,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4646,7 +4646,7 @@ Templates:
 		Id: 620
 		Images: t620.tmp
 		Size: 2,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4656,7 +4656,7 @@ Templates:
 		Id: 621
 		Images: t621.tmp
 		Size: 2,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4666,7 +4666,7 @@ Templates:
 		Id: 622
 		Images: t622.tmp
 		Size: 2,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4676,7 +4676,7 @@ Templates:
 		Id: 623
 		Images: t623.tmp
 		Size: 2,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4686,7 +4686,7 @@ Templates:
 		Id: 624
 		Images: t624.tmp
 		Size: 2,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4696,7 +4696,7 @@ Templates:
 		Id: 625
 		Images: t625.tmp
 		Size: 2,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4706,7 +4706,7 @@ Templates:
 		Id: 626
 		Images: t626.tmp
 		Size: 2,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4716,7 +4716,7 @@ Templates:
 		Id: 627
 		Images: t627.tmp
 		Size: 2,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4726,7 +4726,7 @@ Templates:
 		Id: 628
 		Images: t628.tmp
 		Size: 2,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4736,7 +4736,7 @@ Templates:
 		Id: 629
 		Images: t629.tmp
 		Size: 2,3
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4748,7 +4748,7 @@ Templates:
 		Id: 630
 		Images: t630.tmp
 		Size: 2,3
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4760,7 +4760,7 @@ Templates:
 		Id: 631
 		Images: t631.tmp
 		Size: 3,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4772,7 +4772,7 @@ Templates:
 		Id: 632
 		Images: t632.tmp
 		Size: 3,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4784,7 +4784,7 @@ Templates:
 		Id: 633
 		Images: t633.tmp
 		Size: 3,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4796,7 +4796,7 @@ Templates:
 		Id: 634
 		Images: t634.tmp
 		Size: 3,2
-		Category: Rock-Rock-Cliff
+		Categories: Rock-Rock-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4808,7 +4808,7 @@ Templates:
 		Id: 635
 		Images: t635.tmp
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4818,7 +4818,7 @@ Templates:
 		Id: 636
 		Images: t636.tmp
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4828,7 +4828,7 @@ Templates:
 		Id: 637
 		Images: t637.tmp
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4838,7 +4838,7 @@ Templates:
 		Id: 638
 		Images: t638.tmp
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4848,7 +4848,7 @@ Templates:
 		Id: 639
 		Images: t639.tmp
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4858,7 +4858,7 @@ Templates:
 		Id: 640
 		Images: t640.tmp
 		Size: 2,2
-		Category: Cliff-Ends
+		Categories: Cliff-Ends
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4868,7 +4868,7 @@ Templates:
 		Id: 800
 		Images: t800.tmp
 		Size: 2,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4878,7 +4878,7 @@ Templates:
 		Id: 801
 		Images: t801.tmp
 		Size: 2,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4888,7 +4888,7 @@ Templates:
 		Id: 802
 		Images: t802.tmp
 		Size: 2,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4898,7 +4898,7 @@ Templates:
 		Id: 803
 		Images: t803.tmp
 		Size: 2,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4908,7 +4908,7 @@ Templates:
 		Id: 804
 		Images: t804.tmp
 		Size: 2,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4918,7 +4918,7 @@ Templates:
 		Id: 805
 		Images: t805.tmp
 		Size: 2,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4928,7 +4928,7 @@ Templates:
 		Id: 806
 		Images: t806.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4938,7 +4938,7 @@ Templates:
 		Id: 807
 		Images: t807.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4948,7 +4948,7 @@ Templates:
 		Id: 808
 		Images: t808.tmp
 		Size: 2,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4958,7 +4958,7 @@ Templates:
 		Id: 809
 		Images: t809.tmp
 		Size: 2,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4968,7 +4968,7 @@ Templates:
 		Id: 810
 		Images: t810.tmp
 		Size: 2,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4978,7 +4978,7 @@ Templates:
 		Id: 811
 		Images: t811.tmp
 		Size: 2,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4988,7 +4988,7 @@ Templates:
 		Id: 812
 		Images: t812.tmp
 		Size: 2,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -4998,7 +4998,7 @@ Templates:
 		Id: 813
 		Images: t813.tmp
 		Size: 2,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5008,7 +5008,7 @@ Templates:
 		Id: 814
 		Images: t814.tmp
 		Size: 2,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5018,7 +5018,7 @@ Templates:
 		Id: 815
 		Images: t815.tmp
 		Size: 2,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5028,7 +5028,7 @@ Templates:
 		Id: 816
 		Images: t816.tmp
 		Size: 2,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5038,7 +5038,7 @@ Templates:
 		Id: 817
 		Images: t817.tmp
 		Size: 2,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5048,7 +5048,7 @@ Templates:
 		Id: 818
 		Images: t818.tmp
 		Size: 2,1
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5056,7 +5056,7 @@ Templates:
 		Id: 819
 		Images: t819.tmp
 		Size: 2,1
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5064,7 +5064,7 @@ Templates:
 		Id: 820
 		Images: t820.tmp
 		Size: 1,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5072,7 +5072,7 @@ Templates:
 		Id: 821
 		Images: t821.tmp
 		Size: 1,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5080,7 +5080,7 @@ Templates:
 		Id: 822
 		Images: t822.tmp
 		Size: 2,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5090,7 +5090,7 @@ Templates:
 		Id: 823
 		Images: t823.tmp
 		Size: 2,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5100,7 +5100,7 @@ Templates:
 		Id: 824
 		Images: t824.tmp
 		Size: 2,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5110,7 +5110,7 @@ Templates:
 		Id: 825
 		Images: t825.tmp
 		Size: 2,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5120,7 +5120,7 @@ Templates:
 		Id: 826
 		Images: t826.tmp
 		Size: 2,3
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5132,7 +5132,7 @@ Templates:
 		Id: 827
 		Images: t827.tmp
 		Size: 2,3
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5143,7 +5143,7 @@ Templates:
 		Id: 828
 		Images: t828.tmp
 		Size: 2,3
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Transition
@@ -5155,7 +5155,7 @@ Templates:
 		Id: 829
 		Images: t829.tmp
 		Size: 2,3
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5167,7 +5167,7 @@ Templates:
 		Id: 830
 		Images: t830.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5177,7 +5177,7 @@ Templates:
 		Id: 831
 		Images: t831.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5187,7 +5187,7 @@ Templates:
 		Id: 832
 		Images: t832.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5197,7 +5197,7 @@ Templates:
 		Id: 833
 		Images: t833.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5207,7 +5207,7 @@ Templates:
 		Id: 834
 		Images: t834.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5217,7 +5217,7 @@ Templates:
 		Id: 835
 		Images: t835.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5227,7 +5227,7 @@ Templates:
 		Id: 836
 		Images: t836.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5237,7 +5237,7 @@ Templates:
 		Id: 837
 		Images: t837.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5247,7 +5247,7 @@ Templates:
 		Id: 838
 		Images: t838.tmp
 		Size: 3,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5259,7 +5259,7 @@ Templates:
 		Id: 839
 		Images: t839.tmp
 		Size: 3,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5271,7 +5271,7 @@ Templates:
 		Id: 840
 		Images: t840.tmp
 		Size: 3,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5283,7 +5283,7 @@ Templates:
 		Id: 841
 		Images: t841.tmp
 		Size: 3,2
-		Category: Rock-Sand-Cliff
+		Categories: Rock-Sand-Cliff
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5295,7 +5295,7 @@ Templates:
 		Id: 842
 		Images: t842.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5305,7 +5305,7 @@ Templates:
 		Id: 843
 		Images: t843.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5315,7 +5315,7 @@ Templates:
 		Id: 844
 		Images: t844.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5325,7 +5325,7 @@ Templates:
 		Id: 845
 		Images: t845.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5335,7 +5335,7 @@ Templates:
 		Id: 846
 		Images: t846.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5345,7 +5345,7 @@ Templates:
 		Id: 847
 		Images: t847.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5355,7 +5355,7 @@ Templates:
 		Id: 848
 		Images: t848.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5365,7 +5365,7 @@ Templates:
 		Id: 849
 		Images: t849.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5375,7 +5375,7 @@ Templates:
 		Id: 850
 		Images: t850.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5385,7 +5385,7 @@ Templates:
 		Id: 851
 		Images: t851.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5395,7 +5395,7 @@ Templates:
 		Id: 852
 		Images: t852.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5405,7 +5405,7 @@ Templates:
 		Id: 853
 		Images: t853.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5415,7 +5415,7 @@ Templates:
 		Id: 854
 		Images: t854.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5425,7 +5425,7 @@ Templates:
 		Id: 855
 		Images: t855.tmp
 		Size: 2,2
-		Category: Cliff-Type-Changer
+		Categories: Cliff-Type-Changer
 		Tiles:
 			0: Cliff
 			1: Cliff
@@ -5435,119 +5435,119 @@ Templates:
 		Id: 1000
 		Images: t1000.tmp
 		Size: 1,1
-		Category: Sand-Platform
+		Categories: Sand-Platform
 		Tiles:
 			0: Cliff
 	Template@1001:
 		Id: 1001
 		Images: t1001.tmp
 		Size: 1,1
-		Category: Sand-Platform
+		Categories: Sand-Platform
 		Tiles:
 			0: Cliff
 	Template@1002:
 		Id: 1002
 		Images: t1002.tmp
 		Size: 1,1
-		Category: Sand-Platform
+		Categories: Sand-Platform
 		Tiles:
 			0: Cliff
 	Template@1003:
 		Id: 1003
 		Images: t1003.tmp
 		Size: 1,1
-		Category: Sand-Platform
+		Categories: Sand-Platform
 		Tiles:
 			0: Cliff
 	Template@1004:
 		Id: 1004
 		Images: t1004.tmp
 		Size: 1,1
-		Category: Sand-Platform
+		Categories: Sand-Platform
 		Tiles:
 			0: Cliff
 	Template@1005:
 		Id: 1005
 		Images: t1005.tmp
 		Size: 1,1
-		Category: Sand-Platform
+		Categories: Sand-Platform
 		Tiles:
 			0: Cliff
 	Template@1006:
 		Id: 1006
 		Images: t1006.tmp
 		Size: 1,1
-		Category: Sand-Platform
+		Categories: Sand-Platform
 		Tiles:
 			0: Cliff
 	Template@1007:
 		Id: 1007
 		Images: t1007.tmp
 		Size: 1,1
-		Category: Sand-Platform
+		Categories: Sand-Platform
 		Tiles:
 			0: Cliff
 	Template@1008:
 		Id: 1008
 		Images: t1008.tmp
 		Size: 1,1
-		Category: Sand-Platform
+		Categories: Sand-Platform
 		Tiles:
 			0: Cliff
 	Template@1009:
 		Id: 1009
 		Images: t1009.tmp
 		Size: 1,1
-		Category: Sand-Platform
+		Categories: Sand-Platform
 		Tiles:
 			0: Cliff
 	Template@1010:
 		Id: 1010
 		Images: t1010.tmp
 		Size: 1,1
-		Category: Sand-Platform
+		Categories: Sand-Platform
 		Tiles:
 			0: Cliff
 	Template@1011:
 		Id: 1011
 		Images: t1011.tmp
 		Size: 1,1
-		Category: Sand-Platform
+		Categories: Sand-Platform
 		Tiles:
 			0: Cliff
 	Template@1012:
 		Id: 1012
 		Images: t1012.tmp
 		Size: 1,1
-		Category: Sand-Platform
+		Categories: Sand-Platform
 		Tiles:
 			0: Cliff
 	Template@1013:
 		Id: 1013
 		Images: t1013.tmp
 		Size: 1,1
-		Category: Sand-Platform
+		Categories: Sand-Platform
 		Tiles:
 			0: Cliff
 	Template@1014:
 		Id: 1014
 		Images: t1014.tmp
 		Size: 1,1
-		Category: Sand-Platform
+		Categories: Sand-Platform
 		Tiles:
 			0: Cliff
 	Template@1015:
 		Id: 1015
 		Images: t1015.tmp
 		Size: 1,1
-		Category: Sand-Platform
+		Categories: Sand-Platform
 		Tiles:
 			0: Cliff
 	Template@1016:
 		Id: 1016
 		Images: t1016.tmp
 		Size: 2,1
-		Category: Sand-Platform
+		Categories: Sand-Platform
 		Tiles:
 			0: Rock
 			1: Rock
@@ -5555,14 +5555,14 @@ Templates:
 		Id: 1017
 		Images: t1017.tmp
 		Size: 1,1
-		Category: Sand-Platform
+		Categories: Sand-Platform
 		Tiles:
 			0: Rock
 	Template@1018:
 		Id: 1018
 		Images: t1018.tmp
 		Size: 1,1
-		Category: Sand-Platform
+		Categories: Sand-Platform
 		Tiles:
 			0: Rock
 	Template@1019:
@@ -5570,7 +5570,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 29
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 	Template@1020:
@@ -5578,7 +5578,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 617, 618, 637, 638
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 			1: Rock
@@ -5589,7 +5589,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 345
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1022:
@@ -5597,7 +5597,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 393, 394, 470, 395
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -5607,7 +5607,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 353, 354
 		Size: 1,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -5616,7 +5616,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 373
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1025:
@@ -5624,7 +5624,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 367, 368, 387, 388
 		Size: 2, 2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -5635,7 +5635,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 371
 		Size: 1, 1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1027:
@@ -5643,7 +5643,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 383, 384
 		Size: 2, 1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -5652,7 +5652,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 391
 		Size: 1, 1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1029:
@@ -5660,7 +5660,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 372
 		Size: 1, 1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1030:
@@ -5668,7 +5668,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 385
 		Size: 1, 1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1031:
@@ -5676,7 +5676,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 710, 711, 730, 630
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -5686,7 +5686,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 709, 729
 		Size: 1,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -5695,7 +5695,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 714, 715
 		Size: 2,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -5704,7 +5704,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 611, 612, 613, 631, 632, 633
 		Size: 3,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 			1: Rock
@@ -5717,7 +5717,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 614, 615, 616, 634, 635, 636, 654, 655, 656
 		Size: 3,3
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 			1: Rock
@@ -5733,7 +5733,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 684, 685, 704, 705
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -5744,7 +5744,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 662, 630, 682, 683
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			2: Rough
@@ -5754,7 +5754,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 359
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Cliff
 	Template@1041:
@@ -5762,7 +5762,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 339
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Cliff
 	Template@1042:
@@ -5770,7 +5770,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 319
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Cliff
 	Template@1043:
@@ -5778,7 +5778,7 @@ Templates:
 		Images: BLOXICE.R8
 		Frames: 538
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 	Template@1046:
@@ -5786,7 +5786,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 700
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1047:
@@ -5794,7 +5794,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 681
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1048:
@@ -5802,7 +5802,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 661
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1049:
@@ -5810,7 +5810,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 680
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1050:
@@ -5818,7 +5818,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 392
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1051:
@@ -5826,7 +5826,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 393
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1052:
@@ -5834,7 +5834,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 346, 366
 		Size: 1,2
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -5843,7 +5843,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 365
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1054:
@@ -5851,7 +5851,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 386
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1055:
@@ -5859,7 +5859,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 639
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 	Template@1057:
@@ -5867,7 +5867,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 382
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Cliff
 	Template@1058:
@@ -5875,7 +5875,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 393, 394, 470, 395
 		Size: 2,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -5885,7 +5885,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 660
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1060:
@@ -5893,7 +5893,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 164, 165, 184, 185
 		Size: 2,2
-		Category: Dead-Worm
+		Categories: Dead-Worm
 		Tiles:
 			0: Sand
 			1: Sand
@@ -5904,7 +5904,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 382
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1062:
@@ -5912,7 +5912,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 368
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1063:
@@ -5920,7 +5920,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 380
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1064:
@@ -5928,7 +5928,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 290
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1068:
@@ -5936,7 +5936,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 367
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 	Template@1069:
@@ -5944,7 +5944,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 381
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1070:
@@ -5952,7 +5952,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 343
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1074:
@@ -5960,7 +5960,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 289
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 	Template@1075:
@@ -5968,7 +5968,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 344
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Sand
 	Template@1076:
@@ -5976,7 +5976,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 362, 363, 364
 		Size: 3,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Cliff
 			1: Rough
@@ -5986,7 +5986,7 @@ Templates:
 		Images: BLOXWAST.R8
 		Frames: 607
 		Size: 1,1
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Sand
 	Template@1078:
@@ -5994,7 +5994,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 311, 312
 		Size: 2,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -6003,7 +6003,7 @@ Templates:
 		Images: BLOXBAT.R8
 		Frames: 185
 		Size: 1,1
-		Category: Sand-Detail
+		Categories: Sand-Detail
 		Tiles:
 			0: Rough
 	Template@1080:
@@ -6011,7 +6011,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 713, 733
 		Size: 1,2
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -6020,7 +6020,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 712
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 	Template@1082:
@@ -6028,7 +6028,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 728
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 	Template@1083:
@@ -6036,7 +6036,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 707, 708
 		Size: 2,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -6045,7 +6045,7 @@ Templates:
 		Images: BLOXBGBS.R8
 		Frames: 731, 732
 		Size: 2,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rough
 			1: Rough
@@ -6054,7 +6054,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 344, 345
 		Size: 2,1
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Cliff
 			1: Transition
@@ -6063,7 +6063,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 345, 346
 		Size: 2,1
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Transition
 			1: Cliff
@@ -6072,7 +6072,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 364, 365
 		Size: 2,1
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Cliff
 			1: Transition
@@ -6081,7 +6081,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 365, 366
 		Size: 2,1
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Transition
 			1: Cliff
@@ -6090,7 +6090,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 384, 385
 		Size: 2,1
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Cliff
 			1: Transition
@@ -6099,7 +6099,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 385, 386
 		Size: 2,1
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Transition
 			1: Cliff
@@ -6108,7 +6108,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 1, 340, 2, 360
 		Size: 2,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Cliff
@@ -6119,7 +6119,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 343, 4, 363, 5
 		Size: 2,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Cliff
 			1: Rock
@@ -6130,7 +6130,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 2, 360, 3, 380
 		Size: 2,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Transition
@@ -6141,7 +6141,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 363, 5, 383, 6
 		Size: 2,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Transition
 			1: Rock
@@ -6152,7 +6152,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 350, 351, 370, 371
 		Size: 2,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Cliff
 			1: Rock
@@ -6163,7 +6163,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 351, 352, 371, 372
 		Size: 2,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Cliff
@@ -6174,7 +6174,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 367, 368, 387, 388
 		Size: 2,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Cliff
 			1: Transition
@@ -6185,7 +6185,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 368, 369, 388, 389
 		Size: 2,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Transition
 			1: Cliff
@@ -6196,7 +6196,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 341, 361
 		Size: 1,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Cliff
 			1: Transition
@@ -6205,7 +6205,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 342, 362
 		Size: 1,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Cliff
 			1: Transition
@@ -6214,7 +6214,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 353, 373
 		Size: 1,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 			1: Rough
@@ -6223,7 +6223,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 354, 374
 		Size: 1,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 			1: Rough
@@ -6232,7 +6232,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 361, 381
 		Size: 1,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Transition
 			1: Cliff
@@ -6241,7 +6241,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 362, 382
 		Size: 1,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Transition
 			1: Cliff
@@ -6250,7 +6250,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 297, 393
 		Size: 1,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 			1: Rough
@@ -6259,7 +6259,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 316, 394
 		Size: 1,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 			1: Rough
@@ -6268,7 +6268,7 @@ Templates:
 		Images: BLOXTREE.R8
 		Frames: 381
 		Size: 1,1
-		Category: Rock-Detail
+		Categories: Rock-Detail
 		Tiles:
 			0: Rock
 	Template@1108:
@@ -6276,7 +6276,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 289, 290, 309, 310
 		Size: 2,2
-		Category: Rotten-Base
+		Categories: Rotten-Base
 		Tiles:
 			0: Rough
 			1: Rough
@@ -6287,7 +6287,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 347, 348
 		Size: 2,1
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 			1: Rough
@@ -6296,7 +6296,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 348, 349
 		Size: 2,1
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 			1: Rough
@@ -6305,7 +6305,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 390, 391
 		Size: 2,1
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 			1: Rough
@@ -6314,7 +6314,7 @@ Templates:
 		Images: BLOXXMAS.R8
 		Frames: 391, 392
 		Size: 2,1
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 			1: Rough

--- a/mods/ra/tilesets/desert.yaml
+++ b/mods/ra/tilesets/desert.yaml
@@ -78,7 +78,7 @@ Templates:
 		Images: clear1.des
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -101,7 +101,7 @@ Templates:
 		Images: clear1.des
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -123,14 +123,14 @@ Templates:
 		Id: 256
 		Images: w1.des
 		Size: 1,1
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Water
 	Template@257:
 		Id: 257
 		Images: sh17.des
 		Size: 2,2
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Water
 			1: Water
@@ -140,7 +140,7 @@ Templates:
 		Id: 258
 		Images: sh18.des
 		Size: 2,2
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Water
 			1: Water
@@ -150,7 +150,7 @@ Templates:
 		Id: 180
 		Images: s01.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -160,7 +160,7 @@ Templates:
 		Id: 181
 		Images: s02.des
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rough
@@ -172,7 +172,7 @@ Templates:
 		Id: 182
 		Images: s03.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -182,7 +182,7 @@ Templates:
 		Id: 183
 		Images: s04.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -192,7 +192,7 @@ Templates:
 		Id: 184
 		Images: s05.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -202,7 +202,7 @@ Templates:
 		Id: 185
 		Images: s06.des
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rough
 			1: Rock
@@ -213,7 +213,7 @@ Templates:
 		Id: 186
 		Images: s07.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -223,7 +223,7 @@ Templates:
 		Id: 187
 		Images: s08.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -233,7 +233,7 @@ Templates:
 		Id: 188
 		Images: s09.des
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -245,7 +245,7 @@ Templates:
 		Id: 189
 		Images: s10.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -255,7 +255,7 @@ Templates:
 		Id: 190
 		Images: s11.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -265,7 +265,7 @@ Templates:
 		Id: 191
 		Images: s12.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -275,7 +275,7 @@ Templates:
 		Id: 192
 		Images: s13.des
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -287,7 +287,7 @@ Templates:
 		Id: 193
 		Images: s14.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rough
@@ -296,7 +296,7 @@ Templates:
 		Id: 194
 		Images: s15.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -306,7 +306,7 @@ Templates:
 		Id: 195
 		Images: s16.des
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rough
 			2: Rock
@@ -316,7 +316,7 @@ Templates:
 		Id: 196
 		Images: s17.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -326,7 +326,7 @@ Templates:
 		Id: 197
 		Images: s18.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -336,7 +336,7 @@ Templates:
 		Id: 198
 		Images: s19.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -346,7 +346,7 @@ Templates:
 		Id: 199
 		Images: s20.des
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			1: Rock
 			2: Rock
@@ -357,7 +357,7 @@ Templates:
 		Id: 200
 		Images: s21.des
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -365,7 +365,7 @@ Templates:
 		Id: 202
 		Images: s22.des
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -373,7 +373,7 @@ Templates:
 		Id: 203
 		Images: s23.des
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -385,7 +385,7 @@ Templates:
 		Id: 204
 		Images: s24.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -395,7 +395,7 @@ Templates:
 		Id: 205
 		Images: s25.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -405,7 +405,7 @@ Templates:
 		Id: 206
 		Images: s26.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -415,7 +415,7 @@ Templates:
 		Id: 207
 		Images: s27.des
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -427,7 +427,7 @@ Templates:
 		Id: 208
 		Images: s28.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -436,7 +436,7 @@ Templates:
 		Id: 209
 		Images: s29.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -446,7 +446,7 @@ Templates:
 		Id: 210
 		Images: s30.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -456,7 +456,7 @@ Templates:
 		Id: 211
 		Images: s31.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rough
@@ -466,7 +466,7 @@ Templates:
 		Id: 212
 		Images: s32.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -475,7 +475,7 @@ Templates:
 		Id: 213
 		Images: s33.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -485,7 +485,7 @@ Templates:
 		Id: 214
 		Images: s34.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -495,7 +495,7 @@ Templates:
 		Id: 215
 		Images: s35.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -505,7 +505,7 @@ Templates:
 		Id: 216
 		Images: s36.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -515,7 +515,7 @@ Templates:
 		Id: 217
 		Images: s37.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -525,7 +525,7 @@ Templates:
 		Id: 218
 		Images: s38.des
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -535,14 +535,14 @@ Templates:
 		Id: 2
 		Images: b01.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@3:
 		Id: 3
 		Images: b02.des
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -550,63 +550,63 @@ Templates:
 		Id: 4
 		Images: b03.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@5:
 		Id: 5
 		Images: b04.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@6:
 		Id: 6
 		Images: b05.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@7:
 		Id: 7
 		Images: b06.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@14:
 		Id: 14
 		Images: br01.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Tree
 	Template@15:
 		Id: 15
 		Images: br02.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Tree
 	Template@16:
 		Id: 16
 		Images: br03.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Tree
 	Template@17:
 		Id: 17
 		Images: br04.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Tree
 	Template@18:
 		Id: 18
 		Images: br05.des
 		Size: 3,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Tree
 			1: Tree
@@ -618,7 +618,7 @@ Templates:
 		Id: 19
 		Images: br06.des
 		Size: 2,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Tree
 			1: Tree
@@ -628,7 +628,7 @@ Templates:
 		Id: 20
 		Images: br07.des
 		Size: 2,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Tree
 			1: Tree
@@ -638,7 +638,7 @@ Templates:
 		Id: 21
 		Images: br08.des
 		Size: 3,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Tree
 			1: Tree
@@ -650,7 +650,7 @@ Templates:
 		Id: 22
 		Images: br09.des
 		Size: 3,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Tree
 			1: Tree
@@ -662,7 +662,7 @@ Templates:
 		Id: 23
 		Images: br10.des
 		Size: 2,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Tree
 			1: Tree
@@ -672,35 +672,35 @@ Templates:
 		Id: 35
 		Images: p01.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@36:
 		Id: 36
 		Images: p02.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@37:
 		Id: 37
 		Images: p03.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rough
 	Template@38:
 		Id: 38
 		Images: p04.des
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@39:
 		Id: 39
 		Images: p05.des
 		Size: 2,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -710,7 +710,7 @@ Templates:
 		Id: 40
 		Images: p06.des
 		Size: 6,4
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -731,7 +731,7 @@ Templates:
 		Id: 41
 		Images: p07.des
 		Size: 4,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rough
 			1: Rough
@@ -744,7 +744,7 @@ Templates:
 		Id: 42
 		Images: p08.des
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rough
 			1: Rough
@@ -752,7 +752,7 @@ Templates:
 		Id: 43
 		Images: p09.des
 		Size: 1,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -760,7 +760,7 @@ Templates:
 		Id: 44
 		Images: p10.des
 		Size: 3,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -772,21 +772,21 @@ Templates:
 		Id: 73
 		Images: rv26.des
 		Size: 1,1
-		Category: River
+		Categories: River
 		Tiles:
 			0: River
 	Template@74:
 		Id: 74
 		Images: rv27.des
 		Size: 1,1
-		Category: River
+		Categories: River
 		Tiles:
 			0: River
 	Template@296:
 		Id: 296
 		Images: rvm01.des
 		Size: 2,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -798,7 +798,7 @@ Templates:
 		Id: 297
 		Images: rvm02.des
 		Size: 1,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -807,7 +807,7 @@ Templates:
 		Id: 298
 		Images: rvm03.des
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -819,7 +819,7 @@ Templates:
 		Id: 299
 		Images: rvm04.des
 		Size: 3,1
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -828,7 +828,7 @@ Templates:
 		Id: 60
 		Images: rv14.des
 		Size: 4,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -846,7 +846,7 @@ Templates:
 		Id: 61
 		Images: rv15.des
 		Size: 4,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -864,7 +864,7 @@ Templates:
 		Id: 62
 		Images: rv16.des
 		Size: 6,4
-		Category: River
+		Categories: River
 		Tiles:
 			2: Rock
 			3: Rock
@@ -889,7 +889,7 @@ Templates:
 		Id: 63
 		Images: rv17.des
 		Size: 6,5
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -918,7 +918,7 @@ Templates:
 		Id: 64
 		Images: rv18.des
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -937,7 +937,7 @@ Templates:
 		Id: 65
 		Images: rv19.des
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			1: Rock
 			2: River
@@ -957,7 +957,7 @@ Templates:
 		Id: 66
 		Images: rv20.des
 		Size: 6,8
-		Category: River
+		Categories: River
 		Tiles:
 			2: Clear
 			3: Rock
@@ -998,7 +998,7 @@ Templates:
 		Id: 67
 		Images: rv21.des
 		Size: 5,8
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1031,7 +1031,7 @@ Templates:
 		Id: 69
 		Images: rv22.des
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			1: Clear
 			2: Clear
@@ -1045,7 +1045,7 @@ Templates:
 		Id: 70
 		Images: rv23.des
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1060,7 +1060,7 @@ Templates:
 		Id: 71
 		Images: rv24.des
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1074,7 +1074,7 @@ Templates:
 		Id: 72
 		Images: rv25.des
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Tree
 			1: River
@@ -1089,7 +1089,7 @@ Templates:
 		Id: 100
 		Images: dt01.des
 		Size: 4,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1107,7 +1107,7 @@ Templates:
 		Id: 101
 		Images: dt02.des
 		Size: 2,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1121,7 +1121,7 @@ Templates:
 		Id: 102
 		Images: dt03.des
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rough
 			1: Tree
@@ -1136,7 +1136,7 @@ Templates:
 		Id: 103
 		Images: dt04.des
 		Size: 3,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1153,7 +1153,7 @@ Templates:
 		Id: 75
 		Images: rc01.des
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1165,7 +1165,7 @@ Templates:
 		Id: 76
 		Images: rc02.des
 		Size: 2,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1177,7 +1177,7 @@ Templates:
 		Id: 77
 		Images: rc03.des
 		Size: 2,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1189,7 +1189,7 @@ Templates:
 		Id: 78
 		Images: rc04.des
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1201,7 +1201,7 @@ Templates:
 		Id: 79
 		Images: falls2.des
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -1213,7 +1213,7 @@ Templates:
 		Id: 80
 		Images: falls1.des
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1228,7 +1228,7 @@ Templates:
 		Id: 90
 		Images: ford1.des
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: River
@@ -1243,7 +1243,7 @@ Templates:
 		Id: 91
 		Images: ford2.des
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Clear
 			1: Road
@@ -1258,21 +1258,21 @@ Templates:
 		Id: 164
 		Images: d44.des
 		Size: 1,1
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 	Template@165:
 		Id: 165
 		Images: d45.des
 		Size: 1,1
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 	Template@120:
 		Id: 120
 		Images: d01.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -1281,7 +1281,7 @@ Templates:
 		Id: 121
 		Images: d02.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1291,7 +1291,7 @@ Templates:
 		Id: 122
 		Images: d03.des
 		Size: 1,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1299,7 +1299,7 @@ Templates:
 		Id: 123
 		Images: d04.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1308,7 +1308,7 @@ Templates:
 		Id: 124
 		Images: d05.des
 		Size: 3,4
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -1322,7 +1322,7 @@ Templates:
 		Id: 125
 		Images: d06.des
 		Size: 2,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			2: Road
@@ -1333,7 +1333,7 @@ Templates:
 		Id: 126
 		Images: d07.des
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1344,7 +1344,7 @@ Templates:
 		Id: 127
 		Images: d08.des
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			3: Clear
@@ -1354,7 +1354,7 @@ Templates:
 		Id: 128
 		Images: d09.des
 		Size: 4,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1370,7 +1370,7 @@ Templates:
 		Id: 129
 		Images: d10.des
 		Size: 4,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1382,7 +1382,7 @@ Templates:
 		Id: 130
 		Images: d11.des
 		Size: 2,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1392,7 +1392,7 @@ Templates:
 		Id: 500
 		Images: d12.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -1401,7 +1401,7 @@ Templates:
 		Id: 501
 		Images: d13.des
 		Size: 4,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1416,7 +1416,7 @@ Templates:
 		Id: 502
 		Images: d14.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1430,7 +1430,7 @@ Templates:
 		Id: 503
 		Images: d15.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1444,7 +1444,7 @@ Templates:
 		Id: 135
 		Images: d16.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1459,7 +1459,7 @@ Templates:
 		Id: 136
 		Images: d17.des
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1471,7 +1471,7 @@ Templates:
 		Id: 137
 		Images: d18.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1486,7 +1486,7 @@ Templates:
 		Id: 138
 		Images: d19.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1501,7 +1501,7 @@ Templates:
 		Id: 139
 		Images: d20.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1515,7 +1515,7 @@ Templates:
 		Id: 140
 		Images: d21.des
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1527,7 +1527,7 @@ Templates:
 		Id: 141
 		Images: d22.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			3: Road
@@ -1540,7 +1540,7 @@ Templates:
 		Id: 142
 		Images: d23.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -1553,7 +1553,7 @@ Templates:
 		Id: 143
 		Images: d24.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1566,7 +1566,7 @@ Templates:
 		Id: 144
 		Images: d25.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1579,7 +1579,7 @@ Templates:
 		Id: 145
 		Images: d26.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Clear
@@ -1587,7 +1587,7 @@ Templates:
 		Id: 146
 		Images: d27.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Clear
@@ -1595,7 +1595,7 @@ Templates:
 		Id: 147
 		Images: d28.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1604,7 +1604,7 @@ Templates:
 		Id: 148
 		Images: d29.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1613,7 +1613,7 @@ Templates:
 		Id: 149
 		Images: d30.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -1622,7 +1622,7 @@ Templates:
 		Id: 151
 		Images: d31.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Clear
@@ -1631,7 +1631,7 @@ Templates:
 		Id: 152
 		Images: d32.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1640,7 +1640,7 @@ Templates:
 		Id: 153
 		Images: d33.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1649,7 +1649,7 @@ Templates:
 		Id: 154
 		Images: d34.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1662,7 +1662,7 @@ Templates:
 		Id: 155
 		Images: d35.des
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1675,7 +1675,7 @@ Templates:
 		Id: 156
 		Images: d36.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			3: Clear
@@ -1683,7 +1683,7 @@ Templates:
 		Id: 157
 		Images: d37.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			3: Clear
@@ -1691,7 +1691,7 @@ Templates:
 		Id: 158
 		Images: d38.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1700,7 +1700,7 @@ Templates:
 		Id: 159
 		Images: d39.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1709,7 +1709,7 @@ Templates:
 		Id: 160
 		Images: d40.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1718,7 +1718,7 @@ Templates:
 		Id: 161
 		Images: d41.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -1727,7 +1727,7 @@ Templates:
 		Id: 162
 		Images: d42.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -1736,7 +1736,7 @@ Templates:
 		Id: 163
 		Images: d43.des
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -1745,7 +1745,7 @@ Templates:
 		Id: 300
 		Images: wc01.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1755,7 +1755,7 @@ Templates:
 		Id: 301
 		Images: wc02.des
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rough
@@ -1767,7 +1767,7 @@ Templates:
 		Id: 302
 		Images: wc03.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1777,7 +1777,7 @@ Templates:
 		Id: 303
 		Images: wc04.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1787,7 +1787,7 @@ Templates:
 		Id: 304
 		Images: wc05.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1797,7 +1797,7 @@ Templates:
 		Id: 305
 		Images: wc06.des
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rough
 			1: Rock
@@ -1808,7 +1808,7 @@ Templates:
 		Id: 306
 		Images: wc07.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1818,7 +1818,7 @@ Templates:
 		Id: 307
 		Images: wc08.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1828,7 +1828,7 @@ Templates:
 		Id: 308
 		Images: wc09.des
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1840,7 +1840,7 @@ Templates:
 		Id: 309
 		Images: wc10.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1850,7 +1850,7 @@ Templates:
 		Id: 310
 		Images: wc11.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1860,7 +1860,7 @@ Templates:
 		Id: 311
 		Images: wc12.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1870,7 +1870,7 @@ Templates:
 		Id: 312
 		Images: wc13.des
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1882,7 +1882,7 @@ Templates:
 		Id: 313
 		Images: wc14.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Beach
@@ -1891,7 +1891,7 @@ Templates:
 		Id: 314
 		Images: wc15.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1901,7 +1901,7 @@ Templates:
 		Id: 315
 		Images: wc16.des
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Water
 			2: Rock
@@ -1911,7 +1911,7 @@ Templates:
 		Id: 316
 		Images: wc17.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1921,7 +1921,7 @@ Templates:
 		Id: 317
 		Images: wc18.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1931,7 +1931,7 @@ Templates:
 		Id: 318
 		Images: wc19.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1941,7 +1941,7 @@ Templates:
 		Id: 319
 		Images: wc20.des
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			1: River
 			2: Rock
@@ -1952,7 +1952,7 @@ Templates:
 		Id: 320
 		Images: wc21.des
 		Size: 1,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1960,7 +1960,7 @@ Templates:
 		Id: 321
 		Images: wc22.des
 		Size: 2,1
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1968,7 +1968,7 @@ Templates:
 		Id: 322
 		Images: wc23.des
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1980,7 +1980,7 @@ Templates:
 		Id: 323
 		Images: wc24.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1990,7 +1990,7 @@ Templates:
 		Id: 324
 		Images: wc25.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2000,7 +2000,7 @@ Templates:
 		Id: 325
 		Images: wc26.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2010,7 +2010,7 @@ Templates:
 		Id: 326
 		Images: wc27.des
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2022,7 +2022,7 @@ Templates:
 		Id: 327
 		Images: wc28.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2031,7 +2031,7 @@ Templates:
 		Id: 328
 		Images: wc29.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2041,7 +2041,7 @@ Templates:
 		Id: 329
 		Images: wc30.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2051,7 +2051,7 @@ Templates:
 		Id: 330
 		Images: wc31.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: River
@@ -2061,7 +2061,7 @@ Templates:
 		Id: 331
 		Images: wc32.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2070,7 +2070,7 @@ Templates:
 		Id: 332
 		Images: wc33.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2080,7 +2080,7 @@ Templates:
 		Id: 333
 		Images: wc34.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2090,7 +2090,7 @@ Templates:
 		Id: 334
 		Images: wc35.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2100,7 +2100,7 @@ Templates:
 		Id: 335
 		Images: wc36.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2110,7 +2110,7 @@ Templates:
 		Id: 336
 		Images: wc37.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2120,7 +2120,7 @@ Templates:
 		Id: 337
 		Images: wc38.des
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2130,7 +2130,7 @@ Templates:
 		Id: 338
 		Images: wc39.des
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2142,7 +2142,7 @@ Templates:
 		Id: 339
 		Images: wc40.des
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2154,7 +2154,7 @@ Templates:
 		Id: 340
 		Images: wc41.des
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2166,7 +2166,7 @@ Templates:
 		Id: 341
 		Images: wc42.des
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2178,7 +2178,7 @@ Templates:
 		Id: 342
 		Images: wc43.des
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2190,7 +2190,7 @@ Templates:
 		Id: 343
 		Images: wc44.des
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2202,7 +2202,7 @@ Templates:
 		Id: 344
 		Images: wc45.des
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2214,7 +2214,7 @@ Templates:
 		Id: 345
 		Images: wc46.des
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2226,7 +2226,7 @@ Templates:
 		Id: 346
 		Images: falls3.des
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: River
@@ -2238,7 +2238,7 @@ Templates:
 		Id: 347
 		Images: falls4.des
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2250,7 +2250,7 @@ Templates:
 		Id: 400
 		Images: sh19.des
 		Size: 3,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Rock
 			2: Clear
@@ -2261,7 +2261,7 @@ Templates:
 		Id: 401
 		Images: sh20.des
 		Size: 4,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Rock
@@ -2271,7 +2271,7 @@ Templates:
 		Id: 402
 		Images: sh21.des
 		Size: 3,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Rock
 			1: Beach
@@ -2280,7 +2280,7 @@ Templates:
 		Id: 403
 		Images: sh22.des
 		Size: 6,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Rock
 			2: Rock
@@ -2295,7 +2295,7 @@ Templates:
 		Id: 404
 		Images: sh23.des
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -2305,7 +2305,7 @@ Templates:
 		Id: 405
 		Images: sh24.des
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Rock
 			1: River
@@ -2320,7 +2320,7 @@ Templates:
 		Id: 406
 		Images: sh25.des
 		Size: 3,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2332,7 +2332,7 @@ Templates:
 		Id: 407
 		Images: sh26.des
 		Size: 3,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2343,7 +2343,7 @@ Templates:
 		Id: 408
 		Images: sh27.des
 		Size: 4,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2353,7 +2353,7 @@ Templates:
 		Id: 409
 		Images: sh28.des
 		Size: 3,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2362,7 +2362,7 @@ Templates:
 		Id: 410
 		Images: sh29.des
 		Size: 6,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2377,7 +2377,7 @@ Templates:
 		Id: 411
 		Images: sh30.des
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2386,7 +2386,7 @@ Templates:
 		Id: 412
 		Images: sh31.des
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: River
@@ -2401,35 +2401,35 @@ Templates:
 		Id: 413
 		Images: sh36.des
 		Size: 1,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 	Template@414:
 		Id: 414
 		Images: sh37.des
 		Size: 1,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 	Template@415:
 		Id: 415
 		Images: sh38.des
 		Size: 1,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 	Template@416:
 		Id: 416
 		Images: sh39.des
 		Size: 1,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 	Template@417:
 		Id: 417
 		Images: sh40.des
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Beach
@@ -2444,7 +2444,7 @@ Templates:
 		Id: 418
 		Images: sh41.des
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -2459,7 +2459,7 @@ Templates:
 		Id: 419
 		Images: sh42.des
 		Size: 1,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2467,7 +2467,7 @@ Templates:
 		Id: 420
 		Images: sh43.des
 		Size: 1,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Clear
@@ -2476,7 +2476,7 @@ Templates:
 		Id: 421
 		Images: sh44.des
 		Size: 1,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Clear
@@ -2485,7 +2485,7 @@ Templates:
 		Id: 441
 		Images: sh64.des
 		Size: 2,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: River
 			1: Rough
@@ -2497,7 +2497,7 @@ Templates:
 		Id: 422
 		Images: sh45.des
 		Size: 1,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2505,7 +2505,7 @@ Templates:
 		Id: 423
 		Images: sh46.des
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -2520,7 +2520,7 @@ Templates:
 		Id: 442
 		Images: sh65.des
 		Size: 2,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Rough
 			1: River
@@ -2532,7 +2532,7 @@ Templates:
 		Id: 424
 		Images: sh47.des
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Rock
@@ -2545,7 +2545,7 @@ Templates:
 		Id: 425
 		Images: sh48.des
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			3: Beach
@@ -2556,7 +2556,7 @@ Templates:
 		Id: 426
 		Images: sh49.des
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Water
 			2: Beach
@@ -2570,7 +2570,7 @@ Templates:
 		Id: 427
 		Images: sh50.des
 		Size: 4,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Water
 			2: Water
@@ -2584,7 +2584,7 @@ Templates:
 		Id: 428
 		Images: sh51.des
 		Size: 4,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Water
@@ -2599,7 +2599,7 @@ Templates:
 		Id: 429
 		Images: sh52.des
 		Size: 4,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Beach
@@ -2613,7 +2613,7 @@ Templates:
 		Id: 430
 		Images: sh53.des
 		Size: 4,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Clear
@@ -2631,7 +2631,7 @@ Templates:
 		Id: 431
 		Images: sh54.des
 		Size: 3,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Tree
@@ -2643,7 +2643,7 @@ Templates:
 		Id: 432
 		Images: sh55.des
 		Size: 3,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2655,7 +2655,7 @@ Templates:
 		Id: 433
 		Images: sh56.des
 		Size: 3,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Water
 			2: River
@@ -2666,7 +2666,7 @@ Templates:
 		Id: 434
 		Images: sh57.des
 		Size: 3,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			3: Beach
@@ -2676,7 +2676,7 @@ Templates:
 		Id: 435
 		Images: sh58.des
 		Size: 2,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			2: Beach
@@ -2687,7 +2687,7 @@ Templates:
 		Id: 436
 		Images: sh59.des
 		Size: 2,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Beach
@@ -2699,7 +2699,7 @@ Templates:
 		Id: 437
 		Images: sh60.des
 		Size: 2,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Beach
@@ -2711,7 +2711,7 @@ Templates:
 		Id: 438
 		Images: sh61.des
 		Size: 2,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Clear
@@ -2723,7 +2723,7 @@ Templates:
 		Id: 439
 		Images: sh62.des
 		Size: 6,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2735,7 +2735,7 @@ Templates:
 		Id: 440
 		Images: sh63.des
 		Size: 4,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2745,7 +2745,7 @@ Templates:
 		Id: 600
 		Images: f01.des
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 			1: Road
@@ -2760,7 +2760,7 @@ Templates:
 		Id: 601
 		Images: f02.des
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2775,7 +2775,7 @@ Templates:
 		Id: 602
 		Images: f03.des
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2790,7 +2790,7 @@ Templates:
 		Id: 603
 		Images: f04.des
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Clear
 			1: Beach
@@ -2805,7 +2805,7 @@ Templates:
 		Id: 604
 		Images: f05.des
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2820,7 +2820,7 @@ Templates:
 		Id: 605
 		Images: f06.des
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2835,7 +2835,7 @@ Templates:
 		Id: 620
 		Images: bridge1.des
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Bridge
@@ -2849,7 +2849,7 @@ Templates:
 		Id: 621
 		Images: bridge1h.des
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Bridge
@@ -2863,7 +2863,7 @@ Templates:
 		Id: 622
 		Images: bridge1d.des
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2877,7 +2877,7 @@ Templates:
 		Id: 623
 		Images: bridge1x.des
 		Size: 6,4
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2898,7 +2898,7 @@ Templates:
 		Id: 624
 		Images: bridge2.des
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Bridge
@@ -2912,7 +2912,7 @@ Templates:
 		Id: 625
 		Images: bridge2h.des
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Bridge
@@ -2926,7 +2926,7 @@ Templates:
 		Id: 626
 		Images: bridge2d.des
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2940,7 +2940,7 @@ Templates:
 		Id: 627
 		Images: bridge2x.des
 		Size: 6,4
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Road
 			2: Road
@@ -2961,7 +2961,7 @@ Templates:
 		Id: 235
 		Images: br1a.des
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Bridge
@@ -2974,7 +2974,7 @@ Templates:
 		Id: 236
 		Images: br1b.des
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Bridge
@@ -2987,7 +2987,7 @@ Templates:
 		Id: 237
 		Images: br1c.des
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3000,7 +3000,7 @@ Templates:
 		Id: 238
 		Images: br2a.des
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Bridge
@@ -3012,7 +3012,7 @@ Templates:
 		Id: 239
 		Images: br2b.des
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Bridge
@@ -3024,7 +3024,7 @@ Templates:
 		Id: 240
 		Images: br2c.des
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: River
 			1: River
@@ -3036,7 +3036,7 @@ Templates:
 		Id: 241
 		Images: br3a.des
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Bridge
@@ -3047,7 +3047,7 @@ Templates:
 		Id: 242
 		Images: br3b.des
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Bridge
@@ -3058,7 +3058,7 @@ Templates:
 		Id: 243
 		Images: br3c.des
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3069,7 +3069,7 @@ Templates:
 		Id: 244
 		Images: br3d.des
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: River
 			1: Rock
@@ -3080,7 +3080,7 @@ Templates:
 		Id: 245
 		Images: br3e.des
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Water
 			1: Water
@@ -3091,7 +3091,7 @@ Templates:
 		Id: 246
 		Images: br3f.des
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Water
 			1: Water
@@ -3102,7 +3102,7 @@ Templates:
 		Id: 380
 		Images: br1x.des
 		Size: 5,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3114,7 +3114,7 @@ Templates:
 		Id: 381
 		Images: br2x.des
 		Size: 5,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Beach
 			5: Rock
@@ -3127,7 +3127,7 @@ Templates:
 		Id: 382
 		Images: cliffsl1.des
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3135,7 +3135,7 @@ Templates:
 		Id: 383
 		Images: cliffsl2.des
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3143,7 +3143,7 @@ Templates:
 		Id: 384
 		Images: cliffsl3.des
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3151,7 +3151,7 @@ Templates:
 		Id: 385
 		Images: cliffsl4.des
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3159,7 +3159,7 @@ Templates:
 		Id: 386
 		Images: cliffsw1.des
 		Size: 1,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3167,7 +3167,7 @@ Templates:
 		Id: 387
 		Images: cliffsw2.des
 		Size: 1,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3175,7 +3175,7 @@ Templates:
 		Id: 388
 		Images: cliffsw3.des
 		Size: 2,1
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3183,7 +3183,7 @@ Templates:
 		Id: 389
 		Images: cliffsw4.des
 		Size: 2,1
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock

--- a/mods/ra/tilesets/interior.yaml
+++ b/mods/ra/tilesets/interior.yaml
@@ -43,7 +43,7 @@ Templates:
 		Images: clear1.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: ClearNoSmudges
 			1: ClearNoSmudges
@@ -66,7 +66,7 @@ Templates:
 		Images: clear1.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: ClearNoSmudges
 			1: ClearNoSmudges
@@ -88,161 +88,161 @@ Templates:
 		Id: 329
 		Images: wall0001.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@330:
 		Id: 330
 		Images: wall0002.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@331:
 		Id: 331
 		Images: wall0003.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@332:
 		Id: 332
 		Images: wall0004.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@333:
 		Id: 333
 		Images: wall0005.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@334:
 		Id: 334
 		Images: wall0006.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@335:
 		Id: 335
 		Images: wall0007.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@336:
 		Id: 336
 		Images: wall0008.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@337:
 		Id: 337
 		Images: wall0009.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@338:
 		Id: 338
 		Images: wall0010.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@339:
 		Id: 339
 		Images: wall0011.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@340:
 		Id: 340
 		Images: wall0012.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@341:
 		Id: 341
 		Images: wall0013.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@342:
 		Id: 342
 		Images: wall0014.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@343:
 		Id: 343
 		Images: wall0015.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@344:
 		Id: 344
 		Images: wall0016.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@345:
 		Id: 345
 		Images: wall0017.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@346:
 		Id: 346
 		Images: wall0018.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@347:
 		Id: 347
 		Images: wall0019.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@348:
 		Id: 348
 		Images: wall0020.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@349:
 		Id: 349
 		Images: wall0021.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@350:
 		Id: 350
 		Images: wall0022.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@351:
 		Id: 351
 		Images: wall0023.int
 		Size: 2,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			1: Wall
@@ -251,7 +251,7 @@ Templates:
 		Id: 352
 		Images: wall0024.int
 		Size: 2,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			1: Wall
@@ -260,7 +260,7 @@ Templates:
 		Id: 353
 		Images: wall0025.int
 		Size: 2,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			1: Wall
@@ -269,7 +269,7 @@ Templates:
 		Id: 354
 		Images: wall0026.int
 		Size: 2,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			1: Wall
@@ -278,7 +278,7 @@ Templates:
 		Id: 355
 		Images: wall0027.int
 		Size: 2,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			1: Wall
@@ -287,7 +287,7 @@ Templates:
 		Id: 356
 		Images: wall0028.int
 		Size: 2,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			1: Wall
@@ -296,7 +296,7 @@ Templates:
 		Id: 357
 		Images: wall0029.int
 		Size: 2,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			1: Wall
@@ -305,7 +305,7 @@ Templates:
 		Id: 358
 		Images: wall0030.int
 		Size: 2,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			1: Wall
@@ -314,7 +314,7 @@ Templates:
 		Id: 359
 		Images: wall0031.int
 		Size: 2,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			2: Wall
@@ -323,7 +323,7 @@ Templates:
 		Id: 360
 		Images: wall0032.int
 		Size: 2,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			2: Wall
@@ -332,7 +332,7 @@ Templates:
 		Id: 361
 		Images: wall0033.int
 		Size: 2,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			2: Wall
@@ -341,7 +341,7 @@ Templates:
 		Id: 362
 		Images: wall0034.int
 		Size: 2,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			2: Wall
@@ -350,7 +350,7 @@ Templates:
 		Id: 363
 		Images: wall0035.int
 		Size: 2,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			1: Wall
 			2: Wall
@@ -359,7 +359,7 @@ Templates:
 		Id: 364
 		Images: wall0036.int
 		Size: 2,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			1: Wall
 			2: Wall
@@ -368,7 +368,7 @@ Templates:
 		Id: 365
 		Images: wall0037.int
 		Size: 2,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			1: Wall
 			2: Wall
@@ -377,7 +377,7 @@ Templates:
 		Id: 366
 		Images: wall0038.int
 		Size: 2,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			1: Wall
 			2: Wall
@@ -386,7 +386,7 @@ Templates:
 		Id: 367
 		Images: wall0039.int
 		Size: 2,3
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			2: Wall
@@ -396,7 +396,7 @@ Templates:
 		Id: 368
 		Images: wall0040.int
 		Size: 2,3
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			2: Wall
@@ -406,7 +406,7 @@ Templates:
 		Id: 369
 		Images: wall0041.int
 		Size: 2,3
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			1: Wall
 			2: Wall
@@ -416,7 +416,7 @@ Templates:
 		Id: 370
 		Images: wall0042.int
 		Size: 2,3
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			1: Wall
 			2: Wall
@@ -426,7 +426,7 @@ Templates:
 		Id: 371
 		Images: wall0043.int
 		Size: 3,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			1: Wall
 			3: Wall
@@ -436,7 +436,7 @@ Templates:
 		Id: 372
 		Images: wall0044.int
 		Size: 3,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			1: Wall
 			3: Wall
@@ -446,7 +446,7 @@ Templates:
 		Id: 373
 		Images: wall0045.int
 		Size: 3,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			1: Wall
 			3: Wall
@@ -456,7 +456,7 @@ Templates:
 		Id: 374
 		Images: wall0046.int
 		Size: 3,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			1: Wall
 			3: Wall
@@ -466,7 +466,7 @@ Templates:
 		Id: 375
 		Images: wall0047.int
 		Size: 3,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			1: Wall
@@ -476,7 +476,7 @@ Templates:
 		Id: 376
 		Images: wall0048.int
 		Size: 3,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			1: Wall
@@ -486,7 +486,7 @@ Templates:
 		Id: 377
 		Images: wall0049.int
 		Size: 3,3
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			1: Wall
 			3: Wall
@@ -498,7 +498,7 @@ Templates:
 		Images: flor0001.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -517,7 +517,7 @@ Templates:
 		Images: flor0002.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -536,7 +536,7 @@ Templates:
 		Images: flor0003.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -555,7 +555,7 @@ Templates:
 		Images: flor0004.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -574,7 +574,7 @@ Templates:
 		Images: flor0005.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -593,7 +593,7 @@ Templates:
 		Images: flor0006.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -612,7 +612,7 @@ Templates:
 		Images: flor0007.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -630,14 +630,14 @@ Templates:
 		Id: 384
 		Images: xtra0001.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Wall
 	Template@385:
 		Id: 385
 		Images: xtra0002.int
 		Size: 2,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			1: Clear
@@ -645,14 +645,14 @@ Templates:
 		Id: 386
 		Images: xtra0003.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@387:
 		Id: 387
 		Images: xtra0004.int
 		Size: 1,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			1: Clear
@@ -660,14 +660,14 @@ Templates:
 		Id: 388
 		Images: xtra0005.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@389:
 		Id: 389
 		Images: xtra0006.int
 		Size: 2,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			1: Clear
@@ -675,14 +675,14 @@ Templates:
 		Id: 390
 		Images: xtra0007.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@391:
 		Id: 391
 		Images: xtra0008.int
 		Size: 1,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			1: Clear
@@ -690,28 +690,28 @@ Templates:
 		Id: 392
 		Images: xtra0009.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@393:
 		Id: 393
 		Images: xtra0010.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@394:
 		Id: 394
 		Images: xtra0011.int
 		Size: 1,1
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 	Template@395:
 		Id: 395
 		Images: xtra0012.int
 		Size: 1,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			1: Clear
@@ -719,7 +719,7 @@ Templates:
 		Id: 396
 		Images: xtra0013.int
 		Size: 1,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			1: Clear
@@ -727,7 +727,7 @@ Templates:
 		Id: 397
 		Images: xtra0014.int
 		Size: 3,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Clear
 			1: Wall
@@ -739,7 +739,7 @@ Templates:
 		Id: 398
 		Images: xtra0015.int
 		Size: 3,2
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			1: Wall
@@ -751,7 +751,7 @@ Templates:
 		Id: 399
 		Images: xtra0016.int
 		Size: 2,4
-		Category: Wall
+		Categories: Wall
 		Tiles:
 			0: Wall
 			1: Wall
@@ -766,7 +766,7 @@ Templates:
 		Images: strp0001.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -785,7 +785,7 @@ Templates:
 		Images: strp0002.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -803,63 +803,63 @@ Templates:
 		Id: 320
 		Images: strp0003.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@321:
 		Id: 321
 		Images: strp0004.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@322:
 		Id: 322
 		Images: strp0005.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@323:
 		Id: 323
 		Images: strp0006.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@324:
 		Id: 324
 		Images: strp0007.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@325:
 		Id: 325
 		Images: strp0008.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@326:
 		Id: 326
 		Images: strp0009.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@327:
 		Id: 327
 		Images: strp0010.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@328:
 		Id: 328
 		Images: strp0011.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@253:
@@ -867,7 +867,7 @@ Templates:
 		Images: arro0001.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -880,7 +880,7 @@ Templates:
 		Images: arro0002.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -893,7 +893,7 @@ Templates:
 		Images: arro0004.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -906,7 +906,7 @@ Templates:
 		Images: arro0005.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -919,7 +919,7 @@ Templates:
 		Images: arro0006.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -931,63 +931,63 @@ Templates:
 		Id: 259
 		Images: arro0007.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@260:
 		Id: 260
 		Images: arro0008.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@261:
 		Id: 261
 		Images: arro0009.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@262:
 		Id: 262
 		Images: arro0010.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@263:
 		Id: 263
 		Images: arro0011.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@264:
 		Id: 264
 		Images: arro0012.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@265:
 		Id: 265
 		Images: arro0013.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@266:
 		Id: 266
 		Images: arro0014.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@267:
 		Id: 267
 		Images: arro0015.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@275:
@@ -995,7 +995,7 @@ Templates:
 		Images: gflr0001.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1015,7 +1015,7 @@ Templates:
 		Images: gflr0002.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1035,7 +1035,7 @@ Templates:
 		Images: gflr0003.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1055,7 +1055,7 @@ Templates:
 		Images: gflr0004.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1075,7 +1075,7 @@ Templates:
 		Images: gflr0005.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1095,7 +1095,7 @@ Templates:
 		Images: gstr0001.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1108,7 +1108,7 @@ Templates:
 		Images: gstr0002.int
 		Size: 1,1
 		PickAny: True
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1122,62 +1122,62 @@ Templates:
 		Id: 282
 		Images: gstr0003.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@283:
 		Id: 283
 		Images: gstr0004.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@284:
 		Id: 284
 		Images: gstr0005.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@285:
 		Id: 285
 		Images: gstr0006.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@286:
 		Id: 286
 		Images: gstr0007.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@287:
 		Id: 287
 		Images: gstr0008.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@288:
 		Id: 288
 		Images: gstr0009.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@289:
 		Id: 289
 		Images: gstr0010.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear
 	Template@290:
 		Id: 290
 		Images: gstr0011.int
 		Size: 1,1
-		Category: Floor
+		Categories: Floor
 		Tiles:
 			0: Clear

--- a/mods/ra/tilesets/snow.yaml
+++ b/mods/ra/tilesets/snow.yaml
@@ -73,7 +73,7 @@ Templates:
 		Images: clear1.sno
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -100,7 +100,7 @@ Templates:
 		Images: clear1.sno
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -126,14 +126,14 @@ Templates:
 		Id: 1
 		Images: w1.sno
 		Size: 1,1
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Water
 	Template@2:
 		Id: 2
 		Images: w2.sno
 		Size: 2,2
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Water
 			1: Water
@@ -143,7 +143,7 @@ Templates:
 		Id: 3
 		Images: sh01.sno
 		Size: 4,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			3: Rock
 			5: Clear
@@ -160,7 +160,7 @@ Templates:
 		Id: 4
 		Images: sh02.sno
 		Size: 5,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			4: Clear
 			8: Beach
@@ -181,7 +181,7 @@ Templates:
 		Id: 5
 		Images: sh03.sno
 		Size: 3,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			2: Clear
 			4: Beach
@@ -196,7 +196,7 @@ Templates:
 		Id: 6
 		Images: sh04.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -211,7 +211,7 @@ Templates:
 		Id: 7
 		Images: sh05.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Rock
@@ -226,7 +226,7 @@ Templates:
 		Id: 8
 		Images: sh06.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -241,7 +241,7 @@ Templates:
 		Id: 9
 		Images: sh07.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -256,7 +256,7 @@ Templates:
 		Id: 10
 		Images: sh08.sno
 		Size: 1,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -264,7 +264,7 @@ Templates:
 		Id: 11
 		Images: sh09.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: River
@@ -279,7 +279,7 @@ Templates:
 		Id: 12
 		Images: sh10.sno
 		Size: 5,6
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			5: Beach
@@ -300,7 +300,7 @@ Templates:
 		Id: 13
 		Images: sh11.sno
 		Size: 4,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Clear
@@ -319,7 +319,7 @@ Templates:
 		Id: 14
 		Images: sh12.sno
 		Size: 3,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Clear
@@ -336,7 +336,7 @@ Templates:
 		Id: 15
 		Images: sh13.sno
 		Size: 6,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Rock
@@ -360,7 +360,7 @@ Templates:
 		Id: 16
 		Images: sh14.sno
 		Size: 4,4
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -378,7 +378,7 @@ Templates:
 		Id: 17
 		Images: sh15.sno
 		Size: 5,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -394,7 +394,7 @@ Templates:
 		Id: 18
 		Images: sh16.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Beach
@@ -409,7 +409,7 @@ Templates:
 		Id: 19
 		Images: sh17.sno
 		Size: 2,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Clear
@@ -417,7 +417,7 @@ Templates:
 		Id: 20
 		Images: sh18.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -432,7 +432,7 @@ Templates:
 		Id: 21
 		Images: sh19.sno
 		Size: 4,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Water
 			2: Beach
@@ -453,7 +453,7 @@ Templates:
 		Id: 22
 		Images: sh20.sno
 		Size: 5,4
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			2: Water
 			3: Beach
@@ -472,7 +472,7 @@ Templates:
 		Id: 23
 		Images: sh21.sno
 		Size: 5,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Water
 			2: Beach
@@ -489,7 +489,7 @@ Templates:
 		Id: 24
 		Images: sh22.sno
 		Size: 6,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			6: Water
@@ -512,7 +512,7 @@ Templates:
 		Id: 25
 		Images: sh23.sno
 		Size: 5,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Water
@@ -536,7 +536,7 @@ Templates:
 		Id: 26
 		Images: sh24.sno
 		Size: 3,4
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Water
@@ -550,7 +550,7 @@ Templates:
 		Id: 27
 		Images: sh25.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -565,7 +565,7 @@ Templates:
 		Id: 28
 		Images: sh26.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -580,7 +580,7 @@ Templates:
 		Id: 29
 		Images: sh27.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Rock
 			1: Rock
@@ -595,7 +595,7 @@ Templates:
 		Id: 30
 		Images: sh28.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Rock
 			2: Rock
@@ -609,7 +609,7 @@ Templates:
 		Id: 31
 		Images: sh29.sno
 		Size: 1,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Clear
@@ -617,7 +617,7 @@ Templates:
 		Id: 32
 		Images: sh30.sno
 		Size: 3,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: River
@@ -629,7 +629,7 @@ Templates:
 		Id: 33
 		Images: sh31.sno
 		Size: 6,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			3: Water
 			4: Water
@@ -657,7 +657,7 @@ Templates:
 		Id: 34
 		Images: sh32.sno
 		Size: 4,4
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			2: Water
 			3: Water
@@ -674,7 +674,7 @@ Templates:
 		Id: 35
 		Images: sh33.sno
 		Size: 3,4
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Water
 			2: Beach
@@ -689,7 +689,7 @@ Templates:
 		Id: 36
 		Images: sh34.sno
 		Size: 6,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			3: Clear
 			4: Beach
@@ -711,7 +711,7 @@ Templates:
 		Id: 37
 		Images: sh35.sno
 		Size: 4,4
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			2: Beach
 			3: Water
@@ -728,7 +728,7 @@ Templates:
 		Id: 38
 		Images: sh36.sno
 		Size: 4,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Beach
 			2: Beach
@@ -743,7 +743,7 @@ Templates:
 		Id: 39
 		Images: sh37.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Beach
 			2: Water
@@ -757,7 +757,7 @@ Templates:
 		Id: 40
 		Images: sh38.sno
 		Size: 2,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Beach
@@ -765,7 +765,7 @@ Templates:
 		Id: 41
 		Images: sh39.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Rock
 			1: Beach
@@ -780,7 +780,7 @@ Templates:
 		Id: 42
 		Images: sh40.sno
 		Size: 5,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Beach
@@ -801,7 +801,7 @@ Templates:
 		Id: 43
 		Images: sh41.sno
 		Size: 4,4
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Water
@@ -819,7 +819,7 @@ Templates:
 		Id: 44
 		Images: sh42.sno
 		Size: 4,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -834,7 +834,7 @@ Templates:
 		Id: 45
 		Images: sh43.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -849,7 +849,7 @@ Templates:
 		Id: 46
 		Images: sh44.sno
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Beach
@@ -859,7 +859,7 @@ Templates:
 		Id: 47
 		Images: sh45.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Beach
@@ -874,7 +874,7 @@ Templates:
 		Id: 48
 		Images: sh46.sno
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: River
@@ -884,7 +884,7 @@ Templates:
 		Id: 49
 		Images: sh47.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			3: Beach
@@ -896,7 +896,7 @@ Templates:
 		Id: 50
 		Images: sh48.sno
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -906,7 +906,7 @@ Templates:
 		Id: 51
 		Images: sh49.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Water
@@ -921,7 +921,7 @@ Templates:
 		Id: 52
 		Images: sh50.sno
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -931,7 +931,7 @@ Templates:
 		Id: 53
 		Images: sh51.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Beach
@@ -944,7 +944,7 @@ Templates:
 		Id: 54
 		Images: sh52.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Clear
 			2: Clear
@@ -957,7 +957,7 @@ Templates:
 		Id: 55
 		Images: sh53.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Clear
@@ -971,7 +971,7 @@ Templates:
 		Id: 56
 		Images: sh54.sno
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Beach
@@ -983,14 +983,14 @@ Templates:
 		Id: 57
 		Images: sh55.sno
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@58:
 		Id: 58
 		Images: sh56.sno
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -998,7 +998,7 @@ Templates:
 		Id: 135
 		Images: s01.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1008,7 +1008,7 @@ Templates:
 		Id: 136
 		Images: s02.sno
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rough
@@ -1020,7 +1020,7 @@ Templates:
 		Id: 137
 		Images: s03.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1030,7 +1030,7 @@ Templates:
 		Id: 138
 		Images: s04.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1040,7 +1040,7 @@ Templates:
 		Id: 139
 		Images: s05.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1050,7 +1050,7 @@ Templates:
 		Id: 140
 		Images: s06.sno
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rough
 			1: Rock
@@ -1061,7 +1061,7 @@ Templates:
 		Id: 141
 		Images: s07.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1071,7 +1071,7 @@ Templates:
 		Id: 142
 		Images: s08.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1081,7 +1081,7 @@ Templates:
 		Id: 143
 		Images: s09.sno
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1093,7 +1093,7 @@ Templates:
 		Id: 144
 		Images: s10.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1103,7 +1103,7 @@ Templates:
 		Id: 145
 		Images: s11.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1113,7 +1113,7 @@ Templates:
 		Id: 146
 		Images: s12.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1123,7 +1123,7 @@ Templates:
 		Id: 147
 		Images: s13.sno
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1135,7 +1135,7 @@ Templates:
 		Id: 148
 		Images: s14.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rough
@@ -1144,7 +1144,7 @@ Templates:
 		Id: 149
 		Images: s15.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1154,7 +1154,7 @@ Templates:
 		Id: 150
 		Images: s16.sno
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rough
 			2: Rock
@@ -1164,7 +1164,7 @@ Templates:
 		Id: 151
 		Images: s17.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1174,7 +1174,7 @@ Templates:
 		Id: 152
 		Images: s18.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1184,7 +1184,7 @@ Templates:
 		Id: 153
 		Images: s19.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1194,7 +1194,7 @@ Templates:
 		Id: 154
 		Images: s20.sno
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			1: Rock
 			2: Rock
@@ -1205,7 +1205,7 @@ Templates:
 		Id: 155
 		Images: s21.sno
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1213,7 +1213,7 @@ Templates:
 		Id: 156
 		Images: s22.sno
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1221,7 +1221,7 @@ Templates:
 		Id: 157
 		Images: s23.sno
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1233,7 +1233,7 @@ Templates:
 		Id: 158
 		Images: s24.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1243,7 +1243,7 @@ Templates:
 		Id: 159
 		Images: s25.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1253,7 +1253,7 @@ Templates:
 		Id: 160
 		Images: s26.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1263,7 +1263,7 @@ Templates:
 		Id: 161
 		Images: s27.sno
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1275,7 +1275,7 @@ Templates:
 		Id: 162
 		Images: s28.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1284,7 +1284,7 @@ Templates:
 		Id: 163
 		Images: s29.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1294,7 +1294,7 @@ Templates:
 		Id: 164
 		Images: s30.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1304,7 +1304,7 @@ Templates:
 		Id: 165
 		Images: s31.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rough
@@ -1314,7 +1314,7 @@ Templates:
 		Id: 166
 		Images: s32.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1323,7 +1323,7 @@ Templates:
 		Id: 167
 		Images: s33.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1333,7 +1333,7 @@ Templates:
 		Id: 168
 		Images: s34.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1343,7 +1343,7 @@ Templates:
 		Id: 169
 		Images: s35.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1353,7 +1353,7 @@ Templates:
 		Id: 170
 		Images: s36.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1363,7 +1363,7 @@ Templates:
 		Id: 171
 		Images: s37.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1373,7 +1373,7 @@ Templates:
 		Id: 172
 		Images: s38.sno
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1383,7 +1383,7 @@ Templates:
 		Id: 59
 		Images: wc01.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1393,7 +1393,7 @@ Templates:
 		Id: 60
 		Images: wc02.sno
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rough
@@ -1405,7 +1405,7 @@ Templates:
 		Id: 61
 		Images: wc03.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1415,7 +1415,7 @@ Templates:
 		Id: 62
 		Images: wc04.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1425,7 +1425,7 @@ Templates:
 		Id: 63
 		Images: wc05.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1435,7 +1435,7 @@ Templates:
 		Id: 64
 		Images: wc06.sno
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rough
 			1: Rock
@@ -1446,7 +1446,7 @@ Templates:
 		Id: 65
 		Images: wc07.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1456,7 +1456,7 @@ Templates:
 		Id: 66
 		Images: wc08.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1466,7 +1466,7 @@ Templates:
 		Id: 67
 		Images: wc09.sno
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1478,7 +1478,7 @@ Templates:
 		Id: 68
 		Images: wc10.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1488,7 +1488,7 @@ Templates:
 		Id: 69
 		Images: wc11.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1498,7 +1498,7 @@ Templates:
 		Id: 70
 		Images: wc12.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1508,7 +1508,7 @@ Templates:
 		Id: 71
 		Images: wc13.sno
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1520,7 +1520,7 @@ Templates:
 		Id: 72
 		Images: wc14.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Beach
@@ -1530,7 +1530,7 @@ Templates:
 		Id: 73
 		Images: wc15.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1540,7 +1540,7 @@ Templates:
 		Id: 74
 		Images: wc16.sno
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Water
 			2: Rock
@@ -1550,7 +1550,7 @@ Templates:
 		Id: 75
 		Images: wc17.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1560,7 +1560,7 @@ Templates:
 		Id: 76
 		Images: wc18.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1570,7 +1570,7 @@ Templates:
 		Id: 77
 		Images: wc19.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1580,7 +1580,7 @@ Templates:
 		Id: 78
 		Images: wc20.sno
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			1: River
 			2: Rock
@@ -1591,7 +1591,7 @@ Templates:
 		Id: 79
 		Images: wc21.sno
 		Size: 1,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1599,7 +1599,7 @@ Templates:
 		Id: 80
 		Images: wc22.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1609,7 +1609,7 @@ Templates:
 		Id: 81
 		Images: wc23.sno
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1621,7 +1621,7 @@ Templates:
 		Id: 82
 		Images: wc24.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1631,7 +1631,7 @@ Templates:
 		Id: 83
 		Images: wc25.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1641,7 +1641,7 @@ Templates:
 		Id: 84
 		Images: wc26.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1651,7 +1651,7 @@ Templates:
 		Id: 85
 		Images: wc27.sno
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1663,7 +1663,7 @@ Templates:
 		Id: 86
 		Images: wc28.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1672,7 +1672,7 @@ Templates:
 		Id: 87
 		Images: wc29.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1682,7 +1682,7 @@ Templates:
 		Id: 88
 		Images: wc30.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1692,7 +1692,7 @@ Templates:
 		Id: 89
 		Images: wc31.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: River
@@ -1702,7 +1702,7 @@ Templates:
 		Id: 90
 		Images: wc32.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1711,7 +1711,7 @@ Templates:
 		Id: 91
 		Images: wc33.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1721,7 +1721,7 @@ Templates:
 		Id: 92
 		Images: wc34.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1731,7 +1731,7 @@ Templates:
 		Id: 93
 		Images: wc35.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1741,7 +1741,7 @@ Templates:
 		Id: 94
 		Images: wc36.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1751,7 +1751,7 @@ Templates:
 		Id: 95
 		Images: wc37.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1761,7 +1761,7 @@ Templates:
 		Id: 96
 		Images: wc38.sno
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1771,7 +1771,7 @@ Templates:
 		Id: 173
 		Images: d01.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -1780,7 +1780,7 @@ Templates:
 		Id: 174
 		Images: d02.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1790,7 +1790,7 @@ Templates:
 		Id: 175
 		Images: d03.sno
 		Size: 1,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1798,7 +1798,7 @@ Templates:
 		Id: 176
 		Images: d04.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1807,7 +1807,7 @@ Templates:
 		Id: 177
 		Images: d05.sno
 		Size: 3,4
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -1821,7 +1821,7 @@ Templates:
 		Id: 178
 		Images: d06.sno
 		Size: 2,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			2: Road
@@ -1832,7 +1832,7 @@ Templates:
 		Id: 179
 		Images: d07.sno
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1843,7 +1843,7 @@ Templates:
 		Id: 180
 		Images: d08.sno
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			3: Clear
@@ -1853,7 +1853,7 @@ Templates:
 		Id: 181
 		Images: d09.sno
 		Size: 4,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1869,7 +1869,7 @@ Templates:
 		Id: 182
 		Images: d10.sno
 		Size: 4,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Rock
@@ -1881,7 +1881,7 @@ Templates:
 		Id: 183
 		Images: d11.sno
 		Size: 2,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1891,7 +1891,7 @@ Templates:
 		Id: 184
 		Images: d12.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -1900,7 +1900,7 @@ Templates:
 		Id: 185
 		Images: d13.sno
 		Size: 4,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1915,7 +1915,7 @@ Templates:
 		Id: 186
 		Images: d14.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1929,7 +1929,7 @@ Templates:
 		Id: 187
 		Images: d15.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1943,7 +1943,7 @@ Templates:
 		Id: 188
 		Images: d16.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1958,7 +1958,7 @@ Templates:
 		Id: 189
 		Images: d17.sno
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1970,7 +1970,7 @@ Templates:
 		Id: 190
 		Images: d18.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1985,7 +1985,7 @@ Templates:
 		Id: 191
 		Images: d19.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -2000,7 +2000,7 @@ Templates:
 		Id: 192
 		Images: d20.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -2014,7 +2014,7 @@ Templates:
 		Id: 193
 		Images: d21.sno
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Rock
 			1: Road
@@ -2026,7 +2026,7 @@ Templates:
 		Id: 194
 		Images: d22.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			3: Road
@@ -2039,7 +2039,7 @@ Templates:
 		Id: 195
 		Images: d23.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -2052,7 +2052,7 @@ Templates:
 		Id: 196
 		Images: d24.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -2065,7 +2065,7 @@ Templates:
 		Id: 197
 		Images: d25.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -2078,7 +2078,7 @@ Templates:
 		Id: 198
 		Images: d26.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Road
@@ -2086,7 +2086,7 @@ Templates:
 		Id: 199
 		Images: d27.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Road
@@ -2094,7 +2094,7 @@ Templates:
 		Id: 200
 		Images: d28.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -2103,7 +2103,7 @@ Templates:
 		Id: 201
 		Images: d29.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -2112,7 +2112,7 @@ Templates:
 		Id: 202
 		Images: d30.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -2121,7 +2121,7 @@ Templates:
 		Id: 203
 		Images: d31.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Road
@@ -2130,7 +2130,7 @@ Templates:
 		Id: 204
 		Images: d32.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -2139,7 +2139,7 @@ Templates:
 		Id: 205
 		Images: d33.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Road
@@ -2148,7 +2148,7 @@ Templates:
 		Id: 206
 		Images: d34.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Road
@@ -2161,7 +2161,7 @@ Templates:
 		Id: 207
 		Images: d35.sno
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Road
@@ -2174,7 +2174,7 @@ Templates:
 		Id: 208
 		Images: d36.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			3: Road
@@ -2182,7 +2182,7 @@ Templates:
 		Id: 209
 		Images: d37.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			3: Road
@@ -2190,7 +2190,7 @@ Templates:
 		Id: 210
 		Images: d38.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -2199,7 +2199,7 @@ Templates:
 		Id: 211
 		Images: d39.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -2208,7 +2208,7 @@ Templates:
 		Id: 212
 		Images: d40.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -2217,7 +2217,7 @@ Templates:
 		Id: 213
 		Images: d41.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Rock
 			2: Road
@@ -2226,7 +2226,7 @@ Templates:
 		Id: 214
 		Images: d42.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			2: Road
@@ -2235,7 +2235,7 @@ Templates:
 		Id: 215
 		Images: d43.sno
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -2244,21 +2244,21 @@ Templates:
 		Id: 227
 		Images: d44.sno
 		Size: 1,1
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 	Template@228:
 		Id: 228
 		Images: d45.sno
 		Size: 1,1
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 	Template@231:
 		Id: 231
 		Images: rc01.sno
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2268,7 +2268,7 @@ Templates:
 		Id: 232
 		Images: rc02.sno
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2278,7 +2278,7 @@ Templates:
 		Id: 233
 		Images: rc03.sno
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2288,7 +2288,7 @@ Templates:
 		Id: 234
 		Images: rc04.sno
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2298,7 +2298,7 @@ Templates:
 		Id: 112
 		Images: rv01.sno
 		Size: 5,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2318,7 +2318,7 @@ Templates:
 		Id: 113
 		Images: rv02.sno
 		Size: 5,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2337,7 +2337,7 @@ Templates:
 		Id: 114
 		Images: rv03.sno
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rough
@@ -2356,7 +2356,7 @@ Templates:
 		Id: 115
 		Images: rv04.sno
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			2: Rock
 			3: Rough
@@ -2374,7 +2374,7 @@ Templates:
 		Id: 116
 		Images: rv05.sno
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: River
@@ -2389,7 +2389,7 @@ Templates:
 		Id: 117
 		Images: rv06.sno
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -2401,7 +2401,7 @@ Templates:
 		Id: 118
 		Images: rv07.sno
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2413,7 +2413,7 @@ Templates:
 		Id: 119
 		Images: rv08.sno
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -2423,7 +2423,7 @@ Templates:
 		Id: 120
 		Images: rv09.sno
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Clear
@@ -2433,7 +2433,7 @@ Templates:
 		Id: 121
 		Images: rv10.sno
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: River
 			1: River
@@ -2443,7 +2443,7 @@ Templates:
 		Id: 122
 		Images: rv11.sno
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: River
 			1: River
@@ -2453,7 +2453,7 @@ Templates:
 		Id: 123
 		Images: rv12.sno
 		Size: 3,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: River
@@ -2471,7 +2471,7 @@ Templates:
 		Id: 124
 		Images: rv13.sno
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			2: Clear
 			3: Rough
@@ -2491,7 +2491,7 @@ Templates:
 		Id: 229
 		Images: rv14.sno
 		Size: 1,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -2499,7 +2499,7 @@ Templates:
 		Id: 230
 		Images: rv15.sno
 		Size: 2,1
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -2507,7 +2507,7 @@ Templates:
 		Id: 235
 		Images: br1a.sno
 		Size: 4,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Rock
 			2: Bridge
@@ -2522,7 +2522,7 @@ Templates:
 		Id: 236
 		Images: br1b.sno
 		Size: 4,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Rock
 			2: Rough
@@ -2537,7 +2537,7 @@ Templates:
 		Id: 237
 		Images: br1c.sno
 		Size: 4,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Rock
 			2: Rock
@@ -2552,7 +2552,7 @@ Templates:
 		Id: 238
 		Images: br2a.sno
 		Size: 5,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Rock
 			2: Bridge
@@ -2568,7 +2568,7 @@ Templates:
 		Id: 239
 		Images: br2b.sno
 		Size: 5,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Rock
 			2: Rough
@@ -2584,7 +2584,7 @@ Templates:
 		Id: 240
 		Images: br2c.sno
 		Size: 5,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Water
 			2: Water
@@ -2600,7 +2600,7 @@ Templates:
 		Id: 241
 		Images: br3a.sno
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Bridge
@@ -2611,7 +2611,7 @@ Templates:
 		Id: 242
 		Images: br3b.sno
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Bridge
@@ -2622,7 +2622,7 @@ Templates:
 		Id: 243
 		Images: br3c.sno
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2633,7 +2633,7 @@ Templates:
 		Id: 244
 		Images: br3d.sno
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: River
 			1: Rock
@@ -2644,7 +2644,7 @@ Templates:
 		Id: 245
 		Images: br3e.sno
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Water
 			1: Water
@@ -2655,7 +2655,7 @@ Templates:
 		Id: 246
 		Images: br3f.sno
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Water
 			1: Water
@@ -2666,7 +2666,7 @@ Templates:
 		Id: 380
 		Images: br1x.sno
 		Size: 5,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			3: Road
@@ -2677,7 +2677,7 @@ Templates:
 		Id: 381
 		Images: br2x.sno
 		Size: 5,1
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Road
 			4: Beach
@@ -2685,7 +2685,7 @@ Templates:
 		Id: 131
 		Images: bridge1.sno
 		Size: 5,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Rock
 			2: Bridge
@@ -2701,7 +2701,7 @@ Templates:
 		Id: 132
 		Images: bridge1d.sno
 		Size: 5,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Rock
 			2: Rock
@@ -2717,7 +2717,7 @@ Templates:
 		Id: 378
 		Images: bridge1h.sno
 		Size: 5,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Rock
 			2: Rough
@@ -2733,7 +2733,7 @@ Templates:
 		Id: 382
 		Images: bridge1x.sno
 		Size: 5,4
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			2: Clear
 			3: Road
@@ -2747,7 +2747,7 @@ Templates:
 		Id: 133
 		Images: bridge2.sno
 		Size: 5,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Bridge
@@ -2762,7 +2762,7 @@ Templates:
 		Id: 134
 		Images: bridge2d.sno
 		Size: 5,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2777,7 +2777,7 @@ Templates:
 		Id: 379
 		Images: bridge2h.sno
 		Size: 5,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Rough
@@ -2792,7 +2792,7 @@ Templates:
 		Id: 383
 		Images: bridge2x.sno
 		Size: 5,5
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Road
 			1: Road
@@ -2811,7 +2811,7 @@ Templates:
 		Id: 247
 		Images: f01.sno
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 			1: Road
@@ -2826,7 +2826,7 @@ Templates:
 		Id: 248
 		Images: f02.sno
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2841,7 +2841,7 @@ Templates:
 		Id: 249
 		Images: f03.sno
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2856,7 +2856,7 @@ Templates:
 		Id: 250
 		Images: f04.sno
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Clear
 			1: Beach
@@ -2871,7 +2871,7 @@ Templates:
 		Id: 251
 		Images: f05.sno
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2886,7 +2886,7 @@ Templates:
 		Id: 252
 		Images: f06.sno
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2901,7 +2901,7 @@ Templates:
 		Id: 129
 		Images: ford1.sno
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 			1: River
@@ -2916,7 +2916,7 @@ Templates:
 		Id: 130
 		Images: ford2.sno
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 			1: Rough
@@ -2931,7 +2931,7 @@ Templates:
 		Id: 125
 		Images: falls1.sno
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2946,7 +2946,7 @@ Templates:
 		Id: 126
 		Images: falls1a.sno
 		Size: 3,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Water
 			1: River
@@ -2961,7 +2961,7 @@ Templates:
 		Id: 127
 		Images: falls2.sno
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2973,7 +2973,7 @@ Templates:
 		Id: 128
 		Images: falls2a.sno
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2985,14 +2985,14 @@ Templates:
 		Id: 97
 		Images: b1.sno
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@98:
 		Id: 98
 		Images: b2.sno
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3000,7 +3000,7 @@ Templates:
 		Id: 99
 		Images: b3.sno
 		Size: 3,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3009,56 +3009,56 @@ Templates:
 		Id: 216
 		Images: rf01.sno
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@217:
 		Id: 217
 		Images: rf02.sno
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@218:
 		Id: 218
 		Images: rf03.sno
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@219:
 		Id: 219
 		Images: rf04.sno
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@220:
 		Id: 220
 		Images: rf05.sno
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@221:
 		Id: 221
 		Images: rf06.sno
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@222:
 		Id: 222
 		Images: rf07.sno
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@223:
 		Id: 223
 		Images: rf08.sno
 		Size: 1,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3066,7 +3066,7 @@ Templates:
 		Id: 224
 		Images: rf09.sno
 		Size: 1,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3074,7 +3074,7 @@ Templates:
 		Id: 225
 		Images: rf10.sno
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rough
 			1: Rough
@@ -3082,7 +3082,7 @@ Templates:
 		Id: 226
 		Images: rf11.sno
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3090,35 +3090,35 @@ Templates:
 		Id: 103
 		Images: p01.sno
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@104:
 		Id: 104
 		Images: p02.sno
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@105:
 		Id: 105
 		Images: p03.sno
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@106:
 		Id: 106
 		Images: p04.sno
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@107:
 		Id: 107
 		Images: p07.sno
 		Size: 4,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rough
 			1: Clear
@@ -3132,7 +3132,7 @@ Templates:
 		Id: 108
 		Images: p08.sno
 		Size: 3,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -3144,7 +3144,7 @@ Templates:
 		Id: 109
 		Images: p13.sno
 		Size: 3,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3156,7 +3156,7 @@ Templates:
 		Id: 110
 		Images: p14.sno
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3164,7 +3164,7 @@ Templates:
 		Id: 401
 		Images: cliffsl1.sno
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3172,7 +3172,7 @@ Templates:
 		Id: 402
 		Images: cliffsl2.sno
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3180,7 +3180,7 @@ Templates:
 		Id: 403
 		Images: cliffsl3.sno
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3188,7 +3188,7 @@ Templates:
 		Id: 404
 		Images: cliffsl4.sno
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3196,7 +3196,7 @@ Templates:
 		Id: 405
 		Images: cliffsw1.sno
 		Size: 1,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3204,7 +3204,7 @@ Templates:
 		Id: 406
 		Images: cliffsw2.sno
 		Size: 1,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3212,7 +3212,7 @@ Templates:
 		Id: 407
 		Images: cliffsw3.sno
 		Size: 2,1
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3220,7 +3220,7 @@ Templates:
 		Id: 408
 		Images: cliffsw4.sno
 		Size: 2,1
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock

--- a/mods/ra/tilesets/temperat.yaml
+++ b/mods/ra/tilesets/temperat.yaml
@@ -74,7 +74,7 @@ Templates:
 		Images: clear1.tem
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -97,7 +97,7 @@ Templates:
 		Images: clear1.tem
 		Size: 1,1
 		PickAny: True
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Clear
 			1: Clear
@@ -119,14 +119,14 @@ Templates:
 		Id: 1
 		Images: w1.tem
 		Size: 1,1
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Water
 	Template@2:
 		Id: 2
 		Images: w2.tem
 		Size: 2,2
-		Category: Terrain
+		Categories: Terrain
 		Tiles:
 			0: Water
 			1: Water
@@ -136,7 +136,7 @@ Templates:
 		Id: 3
 		Images: sh01.tem
 		Size: 4,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			3: Rock
 			5: Clear
@@ -153,7 +153,7 @@ Templates:
 		Id: 4
 		Images: sh02.tem
 		Size: 5,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			4: Clear
 			8: Beach
@@ -174,7 +174,7 @@ Templates:
 		Id: 5
 		Images: sh03.tem
 		Size: 3,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			2: Clear
 			4: Beach
@@ -189,7 +189,7 @@ Templates:
 		Id: 6
 		Images: sh04.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -204,7 +204,7 @@ Templates:
 		Id: 7
 		Images: sh05.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Rock
@@ -219,7 +219,7 @@ Templates:
 		Id: 8
 		Images: sh06.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -234,7 +234,7 @@ Templates:
 		Id: 9
 		Images: sh07.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -249,7 +249,7 @@ Templates:
 		Id: 10
 		Images: sh08.tem
 		Size: 1,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -257,7 +257,7 @@ Templates:
 		Id: 11
 		Images: sh09.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: River
@@ -272,7 +272,7 @@ Templates:
 		Id: 12
 		Images: sh10.tem
 		Size: 5,6
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			5: Beach
@@ -293,7 +293,7 @@ Templates:
 		Id: 13
 		Images: sh11.tem
 		Size: 4,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Clear
@@ -312,7 +312,7 @@ Templates:
 		Id: 14
 		Images: sh12.tem
 		Size: 3,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Clear
@@ -329,7 +329,7 @@ Templates:
 		Id: 15
 		Images: sh13.tem
 		Size: 6,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Rock
@@ -353,7 +353,7 @@ Templates:
 		Id: 16
 		Images: sh14.tem
 		Size: 4,4
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -371,7 +371,7 @@ Templates:
 		Id: 17
 		Images: sh15.tem
 		Size: 5,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -387,7 +387,7 @@ Templates:
 		Id: 18
 		Images: sh16.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Beach
@@ -402,7 +402,7 @@ Templates:
 		Id: 19
 		Images: sh17.tem
 		Size: 2,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Clear
@@ -410,7 +410,7 @@ Templates:
 		Id: 20
 		Images: sh18.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -425,7 +425,7 @@ Templates:
 		Id: 21
 		Images: sh19.tem
 		Size: 4,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Water
 			2: Beach
@@ -446,7 +446,7 @@ Templates:
 		Id: 22
 		Images: sh20.tem
 		Size: 5,4
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			2: Water
 			3: Beach
@@ -465,7 +465,7 @@ Templates:
 		Id: 23
 		Images: sh21.tem
 		Size: 5,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Water
 			2: Beach
@@ -482,7 +482,7 @@ Templates:
 		Id: 24
 		Images: sh22.tem
 		Size: 6,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			6: Water
@@ -505,7 +505,7 @@ Templates:
 		Id: 25
 		Images: sh23.tem
 		Size: 5,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Water
@@ -529,7 +529,7 @@ Templates:
 		Id: 26
 		Images: sh24.tem
 		Size: 3,4
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Water
@@ -543,7 +543,7 @@ Templates:
 		Id: 27
 		Images: sh25.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -558,7 +558,7 @@ Templates:
 		Id: 28
 		Images: sh26.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -573,7 +573,7 @@ Templates:
 		Id: 29
 		Images: sh27.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Rock
 			1: Rock
@@ -588,7 +588,7 @@ Templates:
 		Id: 30
 		Images: sh28.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Rock
 			2: Rock
@@ -602,7 +602,7 @@ Templates:
 		Id: 31
 		Images: sh29.tem
 		Size: 1,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Clear
@@ -610,7 +610,7 @@ Templates:
 		Id: 32
 		Images: sh30.tem
 		Size: 3,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: River
@@ -622,7 +622,7 @@ Templates:
 		Id: 33
 		Images: sh31.tem
 		Size: 6,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			3: Water
 			4: Water
@@ -650,7 +650,7 @@ Templates:
 		Id: 34
 		Images: sh32.tem
 		Size: 4,4
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			2: Water
 			3: Water
@@ -667,7 +667,7 @@ Templates:
 		Id: 35
 		Images: sh33.tem
 		Size: 3,4
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Water
 			2: Beach
@@ -682,7 +682,7 @@ Templates:
 		Id: 36
 		Images: sh34.tem
 		Size: 6,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			3: Clear
 			4: Beach
@@ -704,7 +704,7 @@ Templates:
 		Id: 37
 		Images: sh35.tem
 		Size: 4,4
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			2: Beach
 			3: Water
@@ -721,7 +721,7 @@ Templates:
 		Id: 38
 		Images: sh36.tem
 		Size: 4,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Beach
 			2: Beach
@@ -736,7 +736,7 @@ Templates:
 		Id: 39
 		Images: sh37.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Beach
 			2: Water
@@ -750,7 +750,7 @@ Templates:
 		Id: 40
 		Images: sh38.tem
 		Size: 2,1
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Beach
@@ -758,7 +758,7 @@ Templates:
 		Id: 41
 		Images: sh39.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Rock
 			1: Beach
@@ -773,7 +773,7 @@ Templates:
 		Id: 42
 		Images: sh40.tem
 		Size: 5,5
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Beach
@@ -794,7 +794,7 @@ Templates:
 		Id: 43
 		Images: sh41.tem
 		Size: 4,4
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Water
@@ -812,7 +812,7 @@ Templates:
 		Id: 44
 		Images: sh42.tem
 		Size: 4,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -827,7 +827,7 @@ Templates:
 		Id: 45
 		Images: sh43.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -842,7 +842,7 @@ Templates:
 		Id: 46
 		Images: sh44.tem
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Beach
@@ -852,7 +852,7 @@ Templates:
 		Id: 47
 		Images: sh45.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Beach
@@ -867,7 +867,7 @@ Templates:
 		Id: 48
 		Images: sh46.tem
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: River
@@ -877,7 +877,7 @@ Templates:
 		Id: 49
 		Images: sh47.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			3: Beach
@@ -889,7 +889,7 @@ Templates:
 		Id: 50
 		Images: sh48.tem
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Water
@@ -899,7 +899,7 @@ Templates:
 		Id: 51
 		Images: sh49.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Water
@@ -914,7 +914,7 @@ Templates:
 		Id: 52
 		Images: sh50.tem
 		Size: 2,2
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Beach
@@ -924,7 +924,7 @@ Templates:
 		Id: 53
 		Images: sh51.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Clear
 			1: Beach
@@ -937,7 +937,7 @@ Templates:
 		Id: 54
 		Images: sh52.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			1: Clear
 			2: Clear
@@ -950,7 +950,7 @@ Templates:
 		Id: 55
 		Images: sh53.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Beach
 			1: Clear
@@ -964,7 +964,7 @@ Templates:
 		Id: 56
 		Images: sh54.tem
 		Size: 3,3
-		Category: Beach
+		Categories: Beach
 		Tiles:
 			0: Water
 			1: Beach
@@ -976,14 +976,14 @@ Templates:
 		Id: 57
 		Images: sh55.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@58:
 		Id: 58
 		Images: sh56.tem
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -991,7 +991,7 @@ Templates:
 		Id: 135
 		Images: s01.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1001,7 +1001,7 @@ Templates:
 		Id: 136
 		Images: s02.tem
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rough
@@ -1013,7 +1013,7 @@ Templates:
 		Id: 137
 		Images: s03.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1023,7 +1023,7 @@ Templates:
 		Id: 138
 		Images: s04.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1033,7 +1033,7 @@ Templates:
 		Id: 139
 		Images: s05.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1043,7 +1043,7 @@ Templates:
 		Id: 140
 		Images: s06.tem
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rough
 			1: Rock
@@ -1054,7 +1054,7 @@ Templates:
 		Id: 141
 		Images: s07.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1064,7 +1064,7 @@ Templates:
 		Id: 142
 		Images: s08.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1074,7 +1074,7 @@ Templates:
 		Id: 143
 		Images: s09.tem
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1086,7 +1086,7 @@ Templates:
 		Id: 144
 		Images: s10.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1096,7 +1096,7 @@ Templates:
 		Id: 145
 		Images: s11.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1106,7 +1106,7 @@ Templates:
 		Id: 146
 		Images: s12.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1116,7 +1116,7 @@ Templates:
 		Id: 147
 		Images: s13.tem
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1128,7 +1128,7 @@ Templates:
 		Id: 148
 		Images: s14.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rough
@@ -1137,7 +1137,7 @@ Templates:
 		Id: 149
 		Images: s15.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1147,7 +1147,7 @@ Templates:
 		Id: 150
 		Images: s16.tem
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rough
 			2: Rock
@@ -1157,7 +1157,7 @@ Templates:
 		Id: 151
 		Images: s17.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1167,7 +1167,7 @@ Templates:
 		Id: 152
 		Images: s18.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1177,7 +1177,7 @@ Templates:
 		Id: 153
 		Images: s19.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1187,7 +1187,7 @@ Templates:
 		Id: 154
 		Images: s20.tem
 		Size: 2,3
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			1: Rock
 			2: Rock
@@ -1198,7 +1198,7 @@ Templates:
 		Id: 155
 		Images: s21.tem
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1206,7 +1206,7 @@ Templates:
 		Id: 156
 		Images: s22.tem
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1214,7 +1214,7 @@ Templates:
 		Id: 157
 		Images: s23.tem
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1226,7 +1226,7 @@ Templates:
 		Id: 158
 		Images: s24.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1236,7 +1236,7 @@ Templates:
 		Id: 159
 		Images: s25.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1246,7 +1246,7 @@ Templates:
 		Id: 160
 		Images: s26.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1256,7 +1256,7 @@ Templates:
 		Id: 161
 		Images: s27.tem
 		Size: 3,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1268,7 +1268,7 @@ Templates:
 		Id: 162
 		Images: s28.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1277,7 +1277,7 @@ Templates:
 		Id: 163
 		Images: s29.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1287,7 +1287,7 @@ Templates:
 		Id: 164
 		Images: s30.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1297,7 +1297,7 @@ Templates:
 		Id: 165
 		Images: s31.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rough
@@ -1307,7 +1307,7 @@ Templates:
 		Id: 166
 		Images: s32.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1316,7 +1316,7 @@ Templates:
 		Id: 167
 		Images: s33.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1326,7 +1326,7 @@ Templates:
 		Id: 168
 		Images: s34.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1336,7 +1336,7 @@ Templates:
 		Id: 169
 		Images: s35.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1346,7 +1346,7 @@ Templates:
 		Id: 170
 		Images: s36.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1356,7 +1356,7 @@ Templates:
 		Id: 171
 		Images: s37.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1366,7 +1366,7 @@ Templates:
 		Id: 172
 		Images: s38.tem
 		Size: 2,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1376,7 +1376,7 @@ Templates:
 		Id: 59
 		Images: wc01.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1386,7 +1386,7 @@ Templates:
 		Id: 60
 		Images: wc02.tem
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rough
@@ -1398,7 +1398,7 @@ Templates:
 		Id: 61
 		Images: wc03.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1408,7 +1408,7 @@ Templates:
 		Id: 62
 		Images: wc04.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1418,7 +1418,7 @@ Templates:
 		Id: 63
 		Images: wc05.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1428,7 +1428,7 @@ Templates:
 		Id: 64
 		Images: wc06.tem
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rough
 			1: Rock
@@ -1439,7 +1439,7 @@ Templates:
 		Id: 65
 		Images: wc07.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1449,7 +1449,7 @@ Templates:
 		Id: 66
 		Images: wc08.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1459,7 +1459,7 @@ Templates:
 		Id: 67
 		Images: wc09.tem
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1471,7 +1471,7 @@ Templates:
 		Id: 68
 		Images: wc10.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1481,7 +1481,7 @@ Templates:
 		Id: 69
 		Images: wc11.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1491,7 +1491,7 @@ Templates:
 		Id: 70
 		Images: wc12.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1501,7 +1501,7 @@ Templates:
 		Id: 71
 		Images: wc13.tem
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1513,7 +1513,7 @@ Templates:
 		Id: 72
 		Images: wc14.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Beach
@@ -1523,7 +1523,7 @@ Templates:
 		Id: 73
 		Images: wc15.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1533,7 +1533,7 @@ Templates:
 		Id: 74
 		Images: wc16.tem
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Water
 			2: Rock
@@ -1543,7 +1543,7 @@ Templates:
 		Id: 75
 		Images: wc17.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1553,7 +1553,7 @@ Templates:
 		Id: 76
 		Images: wc18.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1563,7 +1563,7 @@ Templates:
 		Id: 77
 		Images: wc19.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1573,7 +1573,7 @@ Templates:
 		Id: 78
 		Images: wc20.tem
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			1: River
 			2: Rock
@@ -1584,7 +1584,7 @@ Templates:
 		Id: 79
 		Images: wc21.tem
 		Size: 1,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1592,7 +1592,7 @@ Templates:
 		Id: 80
 		Images: wc22.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1602,7 +1602,7 @@ Templates:
 		Id: 81
 		Images: wc23.tem
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1614,7 +1614,7 @@ Templates:
 		Id: 82
 		Images: wc24.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1624,7 +1624,7 @@ Templates:
 		Id: 83
 		Images: wc25.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1634,7 +1634,7 @@ Templates:
 		Id: 84
 		Images: wc26.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1644,7 +1644,7 @@ Templates:
 		Id: 85
 		Images: wc27.tem
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1656,7 +1656,7 @@ Templates:
 		Id: 86
 		Images: wc28.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1665,7 +1665,7 @@ Templates:
 		Id: 87
 		Images: wc29.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1675,7 +1675,7 @@ Templates:
 		Id: 88
 		Images: wc30.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1685,7 +1685,7 @@ Templates:
 		Id: 89
 		Images: wc31.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: River
@@ -1695,7 +1695,7 @@ Templates:
 		Id: 90
 		Images: wc32.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1704,7 +1704,7 @@ Templates:
 		Id: 91
 		Images: wc33.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1714,7 +1714,7 @@ Templates:
 		Id: 92
 		Images: wc34.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1724,7 +1724,7 @@ Templates:
 		Id: 93
 		Images: wc35.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1734,7 +1734,7 @@ Templates:
 		Id: 94
 		Images: wc36.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1744,7 +1744,7 @@ Templates:
 		Id: 95
 		Images: wc37.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1754,7 +1754,7 @@ Templates:
 		Id: 96
 		Images: wc38.tem
 		Size: 2,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -1764,7 +1764,7 @@ Templates:
 		Id: 173
 		Images: d01.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -1773,7 +1773,7 @@ Templates:
 		Id: 174
 		Images: d02.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1783,7 +1783,7 @@ Templates:
 		Id: 175
 		Images: d03.tem
 		Size: 1,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1791,7 +1791,7 @@ Templates:
 		Id: 176
 		Images: d04.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1800,7 +1800,7 @@ Templates:
 		Id: 177
 		Images: d05.tem
 		Size: 3,4
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -1814,7 +1814,7 @@ Templates:
 		Id: 178
 		Images: d06.tem
 		Size: 2,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			2: Road
@@ -1825,7 +1825,7 @@ Templates:
 		Id: 179
 		Images: d07.tem
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1836,7 +1836,7 @@ Templates:
 		Id: 180
 		Images: d08.tem
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			3: Clear
@@ -1846,7 +1846,7 @@ Templates:
 		Id: 181
 		Images: d09.tem
 		Size: 4,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Clear
@@ -1862,7 +1862,7 @@ Templates:
 		Id: 182
 		Images: d10.tem
 		Size: 4,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Rock
@@ -1874,7 +1874,7 @@ Templates:
 		Id: 183
 		Images: d11.tem
 		Size: 2,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1884,7 +1884,7 @@ Templates:
 		Id: 184
 		Images: d12.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -1893,7 +1893,7 @@ Templates:
 		Id: 185
 		Images: d13.tem
 		Size: 4,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1908,7 +1908,7 @@ Templates:
 		Id: 186
 		Images: d14.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -1922,7 +1922,7 @@ Templates:
 		Id: 187
 		Images: d15.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1936,7 +1936,7 @@ Templates:
 		Id: 188
 		Images: d16.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1951,7 +1951,7 @@ Templates:
 		Id: 189
 		Images: d17.tem
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -1963,7 +1963,7 @@ Templates:
 		Id: 190
 		Images: d18.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1978,7 +1978,7 @@ Templates:
 		Id: 191
 		Images: d19.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			1: Road
@@ -1993,7 +1993,7 @@ Templates:
 		Id: 192
 		Images: d20.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Clear
@@ -2007,7 +2007,7 @@ Templates:
 		Id: 193
 		Images: d21.tem
 		Size: 3,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Rock
 			1: Road
@@ -2019,7 +2019,7 @@ Templates:
 		Id: 194
 		Images: d22.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			3: Road
@@ -2032,7 +2032,7 @@ Templates:
 		Id: 195
 		Images: d23.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Clear
@@ -2045,7 +2045,7 @@ Templates:
 		Id: 196
 		Images: d24.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -2058,7 +2058,7 @@ Templates:
 		Id: 197
 		Images: d25.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -2071,7 +2071,7 @@ Templates:
 		Id: 198
 		Images: d26.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Road
@@ -2079,7 +2079,7 @@ Templates:
 		Id: 199
 		Images: d27.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Road
@@ -2087,7 +2087,7 @@ Templates:
 		Id: 200
 		Images: d28.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -2096,7 +2096,7 @@ Templates:
 		Id: 201
 		Images: d29.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -2105,7 +2105,7 @@ Templates:
 		Id: 202
 		Images: d30.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -2114,7 +2114,7 @@ Templates:
 		Id: 203
 		Images: d31.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Road
@@ -2123,7 +2123,7 @@ Templates:
 		Id: 204
 		Images: d32.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Clear
 			2: Road
@@ -2132,7 +2132,7 @@ Templates:
 		Id: 205
 		Images: d33.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Road
@@ -2141,7 +2141,7 @@ Templates:
 		Id: 206
 		Images: d34.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Road
@@ -2154,7 +2154,7 @@ Templates:
 		Id: 207
 		Images: d35.tem
 		Size: 3,3
-		Category: Road
+		Categories: Road
 		Tiles:
 			1: Road
 			2: Road
@@ -2167,7 +2167,7 @@ Templates:
 		Id: 208
 		Images: d36.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			3: Road
@@ -2175,7 +2175,7 @@ Templates:
 		Id: 209
 		Images: d37.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			3: Road
@@ -2183,7 +2183,7 @@ Templates:
 		Id: 210
 		Images: d38.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -2192,7 +2192,7 @@ Templates:
 		Id: 211
 		Images: d39.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -2201,7 +2201,7 @@ Templates:
 		Id: 212
 		Images: d40.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			1: Road
@@ -2210,7 +2210,7 @@ Templates:
 		Id: 213
 		Images: d41.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Rock
 			2: Road
@@ -2219,7 +2219,7 @@ Templates:
 		Id: 214
 		Images: d42.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 			2: Road
@@ -2228,7 +2228,7 @@ Templates:
 		Id: 215
 		Images: d43.tem
 		Size: 2,2
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Clear
 			2: Road
@@ -2237,21 +2237,21 @@ Templates:
 		Id: 227
 		Images: d44.tem
 		Size: 1,1
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 	Template@228:
 		Id: 228
 		Images: d45.tem
 		Size: 1,1
-		Category: Road
+		Categories: Road
 		Tiles:
 			0: Road
 	Template@231:
 		Id: 231
 		Images: rc01.tem
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2261,7 +2261,7 @@ Templates:
 		Id: 232
 		Images: rc02.tem
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2271,7 +2271,7 @@ Templates:
 		Id: 233
 		Images: rc03.tem
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2281,7 +2281,7 @@ Templates:
 		Id: 234
 		Images: rc04.tem
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2291,7 +2291,7 @@ Templates:
 		Id: 112
 		Images: rv01.tem
 		Size: 5,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2311,7 +2311,7 @@ Templates:
 		Id: 113
 		Images: rv02.tem
 		Size: 5,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2330,7 +2330,7 @@ Templates:
 		Id: 114
 		Images: rv03.tem
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rough
@@ -2349,7 +2349,7 @@ Templates:
 		Id: 115
 		Images: rv04.tem
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			2: Rock
 			3: Rough
@@ -2367,7 +2367,7 @@ Templates:
 		Id: 116
 		Images: rv05.tem
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: River
@@ -2382,7 +2382,7 @@ Templates:
 		Id: 117
 		Images: rv06.tem
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -2394,7 +2394,7 @@ Templates:
 		Id: 118
 		Images: rv07.tem
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2406,7 +2406,7 @@ Templates:
 		Id: 119
 		Images: rv08.tem
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -2416,7 +2416,7 @@ Templates:
 		Id: 120
 		Images: rv09.tem
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: Clear
@@ -2426,7 +2426,7 @@ Templates:
 		Id: 121
 		Images: rv10.tem
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: River
 			1: River
@@ -2436,7 +2436,7 @@ Templates:
 		Id: 122
 		Images: rv11.tem
 		Size: 2,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: River
 			1: River
@@ -2446,7 +2446,7 @@ Templates:
 		Id: 123
 		Images: rv12.tem
 		Size: 3,4
-		Category: River
+		Categories: River
 		Tiles:
 			0: Clear
 			1: River
@@ -2464,7 +2464,7 @@ Templates:
 		Id: 124
 		Images: rv13.tem
 		Size: 4,4
-		Category: River
+		Categories: River
 		Tiles:
 			2: Clear
 			3: Rough
@@ -2484,7 +2484,7 @@ Templates:
 		Id: 229
 		Images: rv14.tem
 		Size: 1,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -2492,7 +2492,7 @@ Templates:
 		Id: 230
 		Images: rv15.tem
 		Size: 2,1
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: River
@@ -2500,7 +2500,7 @@ Templates:
 		Id: 235
 		Images: br1a.tem
 		Size: 4,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Rock
 			2: Bridge
@@ -2515,7 +2515,7 @@ Templates:
 		Id: 236
 		Images: br1b.tem
 		Size: 4,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Rock
 			2: Rough
@@ -2530,7 +2530,7 @@ Templates:
 		Id: 237
 		Images: br1c.tem
 		Size: 4,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Rock
 			2: Rock
@@ -2545,7 +2545,7 @@ Templates:
 		Id: 238
 		Images: br2a.tem
 		Size: 5,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Rock
 			2: Bridge
@@ -2561,7 +2561,7 @@ Templates:
 		Id: 239
 		Images: br2b.tem
 		Size: 5,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Rock
 			2: Rough
@@ -2577,7 +2577,7 @@ Templates:
 		Id: 240
 		Images: br2c.tem
 		Size: 5,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Water
 			2: Water
@@ -2593,7 +2593,7 @@ Templates:
 		Id: 241
 		Images: br3a.tem
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Bridge
@@ -2604,7 +2604,7 @@ Templates:
 		Id: 242
 		Images: br3b.tem
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Bridge
@@ -2615,7 +2615,7 @@ Templates:
 		Id: 243
 		Images: br3c.tem
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2626,7 +2626,7 @@ Templates:
 		Id: 244
 		Images: br3d.tem
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: River
 			1: Rock
@@ -2637,7 +2637,7 @@ Templates:
 		Id: 245
 		Images: br3e.tem
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Water
 			1: Water
@@ -2648,7 +2648,7 @@ Templates:
 		Id: 246
 		Images: br3f.tem
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Water
 			1: Water
@@ -2659,7 +2659,7 @@ Templates:
 		Id: 380
 		Images: br1x.tem
 		Size: 5,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			3: Road
@@ -2670,7 +2670,7 @@ Templates:
 		Id: 381
 		Images: br2x.tem
 		Size: 5,1
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Road
 			4: Beach
@@ -2678,7 +2678,7 @@ Templates:
 		Id: 131
 		Images: bridge1.tem
 		Size: 5,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Rock
 			2: Bridge
@@ -2694,7 +2694,7 @@ Templates:
 		Id: 132
 		Images: bridge1d.tem
 		Size: 5,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Rock
 			2: Rock
@@ -2710,7 +2710,7 @@ Templates:
 		Id: 378
 		Images: bridge1h.tem
 		Size: 5,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Rock
 			2: Rough
@@ -2728,7 +2728,7 @@ Templates:
 		Id: 382
 		Images: bridge1x.tem
 		Size: 5,4
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			2: Clear
 			3: Bridge
@@ -2742,7 +2742,7 @@ Templates:
 		Id: 133
 		Images: bridge2.tem
 		Size: 5,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Bridge
@@ -2757,7 +2757,7 @@ Templates:
 		Id: 134
 		Images: bridge2d.tem
 		Size: 5,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2772,7 +2772,7 @@ Templates:
 		Id: 379
 		Images: bridge2h.tem
 		Size: 5,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Rough
@@ -2787,7 +2787,7 @@ Templates:
 		Id: 383
 		Images: bridge2x.tem
 		Size: 5,5
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Bridge
 			1: Bridge
@@ -2806,7 +2806,7 @@ Templates:
 		Id: 247
 		Images: f01.tem
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 			1: Road
@@ -2821,7 +2821,7 @@ Templates:
 		Id: 248
 		Images: f02.tem
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2836,7 +2836,7 @@ Templates:
 		Id: 249
 		Images: f03.tem
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2851,7 +2851,7 @@ Templates:
 		Id: 250
 		Images: f04.tem
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Clear
 			1: Beach
@@ -2866,7 +2866,7 @@ Templates:
 		Id: 251
 		Images: f05.tem
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2881,7 +2881,7 @@ Templates:
 		Id: 252
 		Images: f06.tem
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Beach
 			1: Beach
@@ -2896,7 +2896,7 @@ Templates:
 		Id: 129
 		Images: ford1.tem
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 			1: River
@@ -2911,7 +2911,7 @@ Templates:
 		Id: 130
 		Images: ford2.tem
 		Size: 3,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 			1: Rough
@@ -2926,7 +2926,7 @@ Templates:
 		Id: 125
 		Images: falls1.tem
 		Size: 3,3
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2941,7 +2941,7 @@ Templates:
 		Id: 126
 		Images: falls1a.tem
 		Size: 3,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Water
 			1: River
@@ -2956,7 +2956,7 @@ Templates:
 		Id: 127
 		Images: falls2.tem
 		Size: 3,2
-		Category: River
+		Categories: River
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2968,7 +2968,7 @@ Templates:
 		Id: 128
 		Images: falls2a.tem
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2980,14 +2980,14 @@ Templates:
 		Id: 97
 		Images: b1.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@98:
 		Id: 98
 		Images: b2.tem
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -2995,7 +2995,7 @@ Templates:
 		Id: 99
 		Images: b3.tem
 		Size: 3,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3004,56 +3004,56 @@ Templates:
 		Id: 216
 		Images: rf01.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@217:
 		Id: 217
 		Images: rf02.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@218:
 		Id: 218
 		Images: rf03.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@219:
 		Id: 219
 		Images: rf04.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@220:
 		Id: 220
 		Images: rf05.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@221:
 		Id: 221
 		Images: rf06.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@222:
 		Id: 222
 		Images: rf07.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@223:
 		Id: 223
 		Images: rf08.tem
 		Size: 1,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3061,7 +3061,7 @@ Templates:
 		Id: 224
 		Images: rf09.tem
 		Size: 1,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3069,7 +3069,7 @@ Templates:
 		Id: 225
 		Images: rf10.tem
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rough
 			1: Rough
@@ -3077,7 +3077,7 @@ Templates:
 		Id: 226
 		Images: rf11.tem
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3085,35 +3085,35 @@ Templates:
 		Id: 103
 		Images: p01.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@104:
 		Id: 104
 		Images: p02.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@105:
 		Id: 105
 		Images: p03.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@106:
 		Id: 106
 		Images: p04.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@107:
 		Id: 107
 		Images: p07.tem
 		Size: 4,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rough
 			1: Clear
@@ -3127,7 +3127,7 @@ Templates:
 		Id: 108
 		Images: p08.tem
 		Size: 3,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Clear
 			1: Clear
@@ -3139,7 +3139,7 @@ Templates:
 		Id: 109
 		Images: p13.tem
 		Size: 3,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3151,7 +3151,7 @@ Templates:
 		Id: 110
 		Images: p14.tem
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3159,14 +3159,14 @@ Templates:
 		Id: 500
 		Images: sh57.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@502:
 		Id: 502
 		Images: sh58.tem
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3174,7 +3174,7 @@ Templates:
 		Id: 503
 		Images: sh59.tem
 		Size: 2,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3182,7 +3182,7 @@ Templates:
 		Id: 504
 		Images: sh60.tem
 		Size: 1,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3190,21 +3190,21 @@ Templates:
 		Id: 505
 		Images: sh61.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@506:
 		Id: 506
 		Images: sh62.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@507:
 		Id: 507
 		Images: sh63.tem
 		Size: 2,2
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3214,14 +3214,14 @@ Templates:
 		Id: 508
 		Images: sh64.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rock
 	Template@519:
 		Id: 519
 		Images: sbridge1x.tem
 		Size: 3,4
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Clear
 			1: Road
@@ -3233,7 +3233,7 @@ Templates:
 		Id: 520
 		Images: sbridge1.tem
 		Size: 3,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: River
 			1: Road
@@ -3245,7 +3245,7 @@ Templates:
 		Id: 521
 		Images: sbridge1h.tem
 		Size: 3,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: River
 			1: Road
@@ -3257,7 +3257,7 @@ Templates:
 		Id: 522
 		Images: sbridge1d.tem
 		Size: 3,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: River
 			1: Rock
@@ -3269,7 +3269,7 @@ Templates:
 		Id: 523
 		Images: sbridge3.tem
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Rock
 			2: Road
@@ -3282,7 +3282,7 @@ Templates:
 		Id: 524
 		Images: sbridge3h.tem
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Rock
 			2: Road
@@ -3295,7 +3295,7 @@ Templates:
 		Id: 525
 		Images: sbridge3d.tem
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Rock
 			2: Rock
@@ -3308,7 +3308,7 @@ Templates:
 		Id: 526
 		Images: sbridge3x.tem
 		Size: 4,4
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			1: Clear
 			2: Clear
@@ -3322,7 +3322,7 @@ Templates:
 		Id: 527
 		Images: sbridge4.tem
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Road
@@ -3335,7 +3335,7 @@ Templates:
 		Id: 528
 		Images: sbridge4h.tem
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Road
@@ -3348,7 +3348,7 @@ Templates:
 		Id: 529
 		Images: sbridge4d.tem
 		Size: 4,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3361,7 +3361,7 @@ Templates:
 		Id: 530
 		Images: sbridge4x.tem
 		Size: 5,5
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Road
 			1: Clear
@@ -3381,7 +3381,7 @@ Templates:
 		Id: 531
 		Images: sbridge2.tem
 		Size: 2,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: River
 			1: River
@@ -3393,7 +3393,7 @@ Templates:
 		Id: 532
 		Images: sbridge2h.tem
 		Size: 2,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: River
 			1: River
@@ -3405,7 +3405,7 @@ Templates:
 		Id: 533
 		Images: sbridge2d.tem
 		Size: 2,3
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: River
 			1: River
@@ -3417,7 +3417,7 @@ Templates:
 		Id: 534
 		Images: sbridge2x.tem
 		Size: 4,4
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Clear
 			3: Rock
@@ -3433,7 +3433,7 @@ Templates:
 		Id: 550
 		Images: sccnr.tem
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3445,7 +3445,7 @@ Templates:
 		Id: 551
 		Images: sccnl.tem
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3457,7 +3457,7 @@ Templates:
 		Id: 552
 		Images: sccsr.tem
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3469,7 +3469,7 @@ Templates:
 		Id: 553
 		Images: sccsl.tem
 		Size: 2,3
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3481,7 +3481,7 @@ Templates:
 		Id: 554
 		Images: sccln.tem
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3493,7 +3493,7 @@ Templates:
 		Id: 555
 		Images: sccls.tem
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3505,7 +3505,7 @@ Templates:
 		Id: 556
 		Images: sccrn.tem
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3517,7 +3517,7 @@ Templates:
 		Id: 557
 		Images: sccrs.tem
 		Size: 3,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3529,70 +3529,70 @@ Templates:
 		Id: 580
 		Images: deca.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rough
 	Template@581:
 		Id: 581
 		Images: decb.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rough
 	Template@582:
 		Id: 582
 		Images: decc.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rough
 	Template@583:
 		Id: 583
 		Images: decc.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rough
 	Template@584:
 		Id: 584
 		Images: decd.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rough
 	Template@585:
 		Id: 585
 		Images: dece.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rough
 	Template@586:
 		Id: 586
 		Images: decf.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rough
 	Template@587:
 		Id: 587
 		Images: decg.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rough
 	Template@588:
 		Id: 588
 		Images: dech.tem
 		Size: 1,1
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rough
 	Template@590:
 		Id: 590
 		Images: fjord1.tem
 		Size: 1,2
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 			1: Rough
@@ -3600,7 +3600,7 @@ Templates:
 		Id: 591
 		Images: fjord2.tem
 		Size: 2,1
-		Category: Bridge
+		Categories: Bridge
 		Tiles:
 			0: Rough
 			1: Rough
@@ -3608,7 +3608,7 @@ Templates:
 		Id: 400
 		Images: hill01.tem
 		Size: 4,3
-		Category: Debris
+		Categories: Debris
 		Tiles:
 			0: Rough
 			1: Rough
@@ -3626,7 +3626,7 @@ Templates:
 		Id: 401
 		Images: cliffsl1.tem
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3634,7 +3634,7 @@ Templates:
 		Id: 402
 		Images: cliffsl2.tem
 		Size: 1,2
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3642,7 +3642,7 @@ Templates:
 		Id: 403
 		Images: cliffsl3.tem
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3650,7 +3650,7 @@ Templates:
 		Id: 404
 		Images: cliffsl4.tem
 		Size: 2,1
-		Category: Cliffs
+		Categories: Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3658,7 +3658,7 @@ Templates:
 		Id: 405
 		Images: cliffsw1.tem
 		Size: 1,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3666,7 +3666,7 @@ Templates:
 		Id: 406
 		Images: cliffsw2.tem
 		Size: 1,2
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3674,7 +3674,7 @@ Templates:
 		Id: 407
 		Images: cliffsw3.tem
 		Size: 2,1
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock
@@ -3682,7 +3682,7 @@ Templates:
 		Id: 408
 		Images: cliffsw4.tem
 		Size: 2,1
-		Category: Water Cliffs
+		Categories: Water Cliffs
 		Tiles:
 			0: Rock
 			1: Rock

--- a/mods/ts/tilesets/snow.yaml
+++ b/mods/ts/tilesets/snow.yaml
@@ -82,7 +82,7 @@ Terrain:
 # Automatically generated. DO NOT EDIT!
 Templates:
 	Template@0:
-		Category: Clear
+		Categories: Clear
 		Id: 0
 		Images: clear01.sno, clear01a.sno, clear01b.sno, clear01c.sno, clear01d.sno, clear01e.sno, clear01f.sno, clear01g.sno
 		Size: 1, 1
@@ -93,7 +93,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1:
-		Category: Misc Buildings
+		Categories: Misc Buildings
 		Id: 1
 		Images: bld01.sno
 		Size: 1, 1
@@ -104,7 +104,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@2:
-		Category: Misc Buildings
+		Categories: Misc Buildings
 		Id: 2
 		Images: bld02.sno
 		Size: 2, 2
@@ -130,7 +130,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@3:
-		Category: Misc Buildings
+		Categories: Misc Buildings
 		Id: 3
 		Images: bld03.sno
 		Size: 3, 3
@@ -181,7 +181,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@4:
-		Category: Clear
+		Categories: Clear
 		Id: 4
 		Images: snow01.sno, snow01a.sno, snow01b.sno, snow01c.sno
 		Size: 1, 1
@@ -192,7 +192,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@5:
-		Category: Clear
+		Categories: Clear
 		Id: 5
 		Images: snow02.sno
 		Size: 1, 1
@@ -203,7 +203,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@6:
-		Category: Clear
+		Categories: Clear
 		Id: 6
 		Images: snow03.sno
 		Size: 1, 1
@@ -214,7 +214,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@7:
-		Category: Clear
+		Categories: Clear
 		Id: 7
 		Images: snow04.sno
 		Size: 1, 1
@@ -225,7 +225,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@8:
-		Category: Cliff Pieces
+		Categories: Cliff Pieces
 		Id: 8
 		Images: clif01.sno
 		Size: 1, 1
@@ -236,7 +236,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@9:
-		Category: Cliff Pieces
+		Categories: Cliff Pieces
 		Id: 9
 		Images: clif02.sno
 		Size: 1, 1
@@ -247,7 +247,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@10:
-		Category: Ice Flow
+		Categories: Ice Flow
 		Id: 10
 		Images: flow01.sno
 		Size: 9, 7
@@ -433,7 +433,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@11:
-		Category: House
+		Categories: House
 		Id: 11
 		Images: house01.sno
 		Size: 2, 2
@@ -459,7 +459,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@12:
-		Category: Blank
+		Categories: Blank
 		Id: 12
 		Images: blank01.sno
 		Size: 1, 1
@@ -470,7 +470,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@40:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 40
 		Images: slope01.sno, slope01a.sno, slope01b.sno, slope01c.sno
 		Size: 1, 1
@@ -482,7 +482,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@41:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 41
 		Images: slope02.sno, slope02a.sno, slope02b.sno, slope02c.sno
 		Size: 1, 1
@@ -494,7 +494,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@42:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 42
 		Images: slope03.sno, slope03a.sno, slope03b.sno, slope03c.sno
 		Size: 1, 1
@@ -506,7 +506,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@43:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 43
 		Images: slope04.sno, slope04a.sno, slope04b.sno, slope04c.sno
 		Size: 1, 1
@@ -518,7 +518,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@44:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 44
 		Images: slope05.sno, slope05a.sno, slope05b.sno, slope05c.sno
 		Size: 1, 1
@@ -530,7 +530,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@45:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 45
 		Images: slope06.sno, slope06a.sno, slope06b.sno, slope06c.sno
 		Size: 1, 1
@@ -542,7 +542,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@46:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 46
 		Images: slope07.sno, slope07a.sno, slope07b.sno, slope07c.sno
 		Size: 1, 1
@@ -554,7 +554,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@47:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 47
 		Images: slope08.sno, slope08a.sno, slope08b.sno, slope08c.sno
 		Size: 1, 1
@@ -566,7 +566,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@48:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 48
 		Images: slope09.sno, slope09a.sno, slope09b.sno, slope09c.sno
 		Size: 1, 1
@@ -578,7 +578,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@49:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 49
 		Images: slope10.sno, slope10a.sno, slope10b.sno, slope10c.sno
 		Size: 1, 1
@@ -590,7 +590,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@50:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 50
 		Images: slope11.sno, slope11a.sno, slope11b.sno, slope11c.sno
 		Size: 1, 1
@@ -602,7 +602,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@51:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 51
 		Images: slope12.sno, slope12a.sno, slope12b.sno, slope12c.sno
 		Size: 1, 1
@@ -614,7 +614,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@52:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 52
 		Images: slope13.sno, slope13a.sno, slope13b.sno, slope13c.sno
 		Size: 1, 1
@@ -626,7 +626,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@53:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 53
 		Images: slope14.sno, slope14a.sno, slope14b.sno, slope14c.sno
 		Size: 1, 1
@@ -638,7 +638,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@54:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 54
 		Images: slope15.sno, slope15a.sno, slope15b.sno, slope15c.sno
 		Size: 1, 1
@@ -650,7 +650,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@55:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 55
 		Images: slope16.sno, slope16a.sno, slope16b.sno, slope16c.sno
 		Size: 1, 1
@@ -662,7 +662,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@56:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 56
 		Images: slope17.sno
 		Size: 1, 1
@@ -674,7 +674,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@57:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 57
 		Images: slope18.sno
 		Size: 1, 1
@@ -686,7 +686,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@58:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 58
 		Images: slope19.sno
 		Size: 1, 1
@@ -698,7 +698,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@59:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 59
 		Images: slope20.sno
 		Size: 1, 1
@@ -710,7 +710,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@60:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 60
 		Images: cliff01.sno
 		Size: 2, 3
@@ -738,7 +738,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@61:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 61
 		Images: cliff02.sno
 		Size: 1, 2
@@ -755,7 +755,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@62:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 62
 		Images: cliff03.sno
 		Size: 2, 3
@@ -783,7 +783,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@63:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 63
 		Images: cliff04.sno
 		Size: 2, 3
@@ -811,7 +811,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@64:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 64
 		Images: cliff05.sno
 		Size: 2, 2
@@ -839,7 +839,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@65:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 65
 		Images: cliff06.sno
 		Size: 2, 2
@@ -867,7 +867,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@66:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 66
 		Images: cliff07.sno
 		Size: 2, 2
@@ -895,7 +895,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@67:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 67
 		Images: cliff08.sno
 		Size: 1, 2
@@ -912,7 +912,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@68:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 68
 		Images: cliff09.sno
 		Size: 2, 2
@@ -934,7 +934,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@69:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 69
 		Images: cliff10.sno
 		Size: 2, 2
@@ -956,7 +956,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@70:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 70
 		Images: cliff11.sno
 		Size: 2, 2
@@ -978,7 +978,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@71:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 71
 		Images: cliff12.sno
 		Size: 1, 1
@@ -989,7 +989,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@72:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 72
 		Images: cliff13.sno
 		Size: 1, 1
@@ -1000,7 +1000,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@73:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 73
 		Images: cliff14.sno
 		Size: 1, 1
@@ -1011,7 +1011,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@74:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 74
 		Images: cliff15.sno
 		Size: 2, 2
@@ -1039,7 +1039,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@75:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 75
 		Images: cliff16.sno
 		Size: 2, 2
@@ -1067,7 +1067,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@76:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 76
 		Images: cliff17.sno
 		Size: 2, 2
@@ -1095,7 +1095,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@77:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 77
 		Images: cliff18.sno
 		Size: 2, 1
@@ -1112,7 +1112,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@78:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 78
 		Images: cliff19.sno
 		Size: 3, 2
@@ -1140,7 +1140,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@79:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 79
 		Images: cliff20.sno
 		Size: 3, 2
@@ -1168,7 +1168,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@80:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 80
 		Images: cliff21.sno
 		Size: 3, 2
@@ -1196,7 +1196,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@81:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 81
 		Images: cliff22.sno
 		Size: 2, 1
@@ -1213,7 +1213,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@82:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 82
 		Images: cliff23.sno
 		Size: 2, 1
@@ -1231,7 +1231,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@83:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 83
 		Images: cliff24.sno
 		Size: 2, 1
@@ -1249,7 +1249,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@84:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 84
 		Images: cliff25.sno
 		Size: 2, 1
@@ -1267,7 +1267,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@85:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 85
 		Images: cliff26.sno
 		Size: 1, 1
@@ -1279,7 +1279,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@86:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 86
 		Images: cliff27.sno
 		Size: 2, 2
@@ -1303,7 +1303,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@87:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 87
 		Images: cliff28.sno
 		Size: 2, 2
@@ -1327,7 +1327,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@88:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 88
 		Images: cliff29.sno
 		Size: 1, 1
@@ -1339,7 +1339,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@89:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 89
 		Images: cliff30.sno
 		Size: 1, 1
@@ -1351,7 +1351,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@90:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 90
 		Images: cliff31.sno
 		Size: 2, 2
@@ -1375,7 +1375,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@91:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 91
 		Images: cliff32.sno
 		Size: 2, 2
@@ -1399,7 +1399,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@92:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 92
 		Images: cliff33.sno, cliff33a.sno
 		Size: 1, 1
@@ -1411,7 +1411,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@93:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 93
 		Images: cliff34.sno, cliff34a.sno
 		Size: 1, 1
@@ -1423,7 +1423,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@94:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 94
 		Images: cliff35.sno
 		Size: 1, 2
@@ -1441,7 +1441,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@95:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 95
 		Images: cliff36.sno
 		Size: 1, 2
@@ -1459,7 +1459,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@96:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 96
 		Images: cliff37.sno
 		Size: 1, 2
@@ -1477,7 +1477,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@97:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 97
 		Images: cliff38.sno
 		Size: 1, 1
@@ -1489,7 +1489,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@98:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 98
 		Images: cliff39.sno
 		Size: 1, 1
@@ -1501,7 +1501,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@99:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 99
 		Images: cliff40.sno
 		Size: 1, 1
@@ -1513,7 +1513,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@100:
-		Category: Civilian Buildings
+		Categories: Civilian Buildings
 		Id: 100
 		Images: civ01.sno
 		Size: 3, 3
@@ -1564,7 +1564,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@101:
-		Category: Civilian Buildings
+		Categories: Civilian Buildings
 		Id: 101
 		Images: civ02.sno
 		Size: 1, 2
@@ -1580,7 +1580,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@102:
-		Category: Civilian Buildings
+		Categories: Civilian Buildings
 		Id: 102
 		Images: civ03.sno
 		Size: 1, 1
@@ -1591,7 +1591,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@103:
-		Category: Civilian Buildings
+		Categories: Civilian Buildings
 		Id: 103
 		Images: civ04.sno
 		Size: 1, 2
@@ -1607,7 +1607,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@104:
-		Category: Civilian Buildings
+		Categories: Civilian Buildings
 		Id: 104
 		Images: civ05.sno
 		Size: 2, 2
@@ -1628,7 +1628,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@105:
-		Category: Civilian Buildings
+		Categories: Civilian Buildings
 		Id: 105
 		Images: civ06.sno
 		Size: 3, 3
@@ -1664,7 +1664,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@106:
-		Category: Civilian Buildings
+		Categories: Civilian Buildings
 		Id: 106
 		Images: civ07.sno
 		Size: 1, 1
@@ -1675,7 +1675,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@107:
-		Category: Civilian Buildings
+		Categories: Civilian Buildings
 		Id: 107
 		Images: civ08.sno
 		Size: 1, 2
@@ -1691,7 +1691,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@108:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 108
 		Images: shore01.sno
 		Size: 2, 2
@@ -1717,7 +1717,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@109:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 109
 		Images: shore02.sno
 		Size: 2, 2
@@ -1743,7 +1743,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@110:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 110
 		Images: shore03.sno
 		Size: 2, 2
@@ -1769,7 +1769,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@111:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 111
 		Images: shore04.sno
 		Size: 1, 2
@@ -1785,7 +1785,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@112:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 112
 		Images: shore05.sno
 		Size: 2, 3
@@ -1821,7 +1821,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@113:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 113
 		Images: shore06.sno
 		Size: 2, 3
@@ -1857,7 +1857,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@114:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 114
 		Images: shore07.sno
 		Size: 2, 2
@@ -1883,7 +1883,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@115:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 115
 		Images: shore08.sno
 		Size: 2, 2
@@ -1909,7 +1909,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@116:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 116
 		Images: shore09.sno
 		Size: 2, 2
@@ -1935,7 +1935,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@117:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 117
 		Images: shore10.sno
 		Size: 2, 2
@@ -1961,7 +1961,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@118:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 118
 		Images: shore11.sno
 		Size: 2, 2
@@ -1987,7 +1987,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@119:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 119
 		Images: shore12.sno
 		Size: 2, 1
@@ -2003,7 +2003,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@120:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 120
 		Images: shore13.sno
 		Size: 3, 2
@@ -2039,7 +2039,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@121:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 121
 		Images: shore14.sno
 		Size: 3, 2
@@ -2075,7 +2075,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@122:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 122
 		Images: shore15.sno
 		Size: 2, 2
@@ -2101,7 +2101,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@123:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 123
 		Images: shore16.sno
 		Size: 2, 2
@@ -2127,7 +2127,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@124:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 124
 		Images: shore17.sno
 		Size: 2, 2
@@ -2153,7 +2153,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@125:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 125
 		Images: shore18.sno
 		Size: 2, 2
@@ -2179,7 +2179,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@126:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 126
 		Images: shore19.sno
 		Size: 2, 2
@@ -2205,7 +2205,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@127:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 127
 		Images: shore20.sno
 		Size: 1, 2
@@ -2221,7 +2221,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@128:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 128
 		Images: shore21.sno
 		Size: 2, 3
@@ -2257,7 +2257,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@129:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 129
 		Images: shore22.sno
 		Size: 2, 3
@@ -2293,7 +2293,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@130:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 130
 		Images: shore23.sno
 		Size: 2, 2
@@ -2319,7 +2319,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@131:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 131
 		Images: shore24.sno
 		Size: 2, 2
@@ -2345,7 +2345,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@132:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 132
 		Images: shore25.sno
 		Size: 2, 2
@@ -2371,7 +2371,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@133:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 133
 		Images: shore26.sno
 		Size: 2, 2
@@ -2397,7 +2397,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@134:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 134
 		Images: shore27.sno
 		Size: 2, 2
@@ -2423,7 +2423,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@135:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 135
 		Images: shore28.sno
 		Size: 2, 1
@@ -2439,7 +2439,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@136:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 136
 		Images: shore29.sno
 		Size: 3, 2
@@ -2475,7 +2475,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@137:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 137
 		Images: shore30.sno
 		Size: 3, 2
@@ -2511,7 +2511,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@138:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 138
 		Images: shore31.sno
 		Size: 2, 2
@@ -2537,7 +2537,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@139:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 139
 		Images: shore32.sno
 		Size: 2, 2
@@ -2563,7 +2563,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@140:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 140
 		Images: shore33.sno
 		Size: 2, 2
@@ -2589,7 +2589,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@141:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 141
 		Images: shore34.sno
 		Size: 2, 2
@@ -2615,7 +2615,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@142:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 142
 		Images: shore35.sno
 		Size: 2, 2
@@ -2641,7 +2641,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@143:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 143
 		Images: shore36.sno
 		Size: 2, 2
@@ -2667,7 +2667,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@144:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 144
 		Images: shore37.sno
 		Size: 2, 2
@@ -2693,7 +2693,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@145:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 145
 		Images: shore38.sno
 		Size: 2, 2
@@ -2719,7 +2719,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@146:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 146
 		Images: shore39.sno
 		Size: 2, 2
@@ -2745,7 +2745,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@147:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 147
 		Images: shore40.sno
 		Size: 2, 2
@@ -2771,7 +2771,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@148:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 148
 		Images: shore41.sno
 		Size: 6, 4
@@ -2882,7 +2882,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@149:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 149
 		Images: shore42.sno
 		Size: 9, 5
@@ -3038,7 +3038,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@150:
-		Category: Rough lat
+		Categories: Rough lat
 		Id: 150
 		Images: ruff01.sno, ruff01a.sno, ruff01b.sno, ruff01c.sno, ruff01d.sno, ruff01e.sno, ruff01f.sno, ruff01g.sno
 		Size: 1, 1
@@ -3049,7 +3049,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@151:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 151
 		Images: clat01.sno, clat01a.sno
 		Size: 1, 1
@@ -3060,7 +3060,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@152:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 152
 		Images: clat02.sno, clat02a.sno
 		Size: 1, 1
@@ -3071,7 +3071,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@153:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 153
 		Images: clat03.sno, clat03a.sno
 		Size: 1, 1
@@ -3082,7 +3082,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@154:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 154
 		Images: clat04.sno, clat04a.sno
 		Size: 1, 1
@@ -3093,7 +3093,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@155:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 155
 		Images: clat05.sno, clat05a.sno
 		Size: 1, 1
@@ -3104,7 +3104,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@156:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 156
 		Images: clat06.sno, clat06a.sno
 		Size: 1, 1
@@ -3115,7 +3115,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@157:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 157
 		Images: clat07.sno, clat07a.sno
 		Size: 1, 1
@@ -3126,7 +3126,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@158:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 158
 		Images: clat08.sno, clat08a.sno
 		Size: 1, 1
@@ -3137,7 +3137,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@159:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 159
 		Images: clat09.sno, clat09a.sno
 		Size: 1, 1
@@ -3148,7 +3148,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@160:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 160
 		Images: clat10.sno, clat10a.sno
 		Size: 1, 1
@@ -3159,7 +3159,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@161:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 161
 		Images: clat11.sno, clat11a.sno
 		Size: 1, 1
@@ -3170,7 +3170,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@162:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 162
 		Images: clat12.sno, clat12a.sno
 		Size: 1, 1
@@ -3181,7 +3181,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@163:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 163
 		Images: clat13.sno, clat13a.sno
 		Size: 1, 1
@@ -3192,7 +3192,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@164:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 164
 		Images: clat14.sno, clat14a.sno
 		Size: 1, 1
@@ -3203,7 +3203,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@165:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 165
 		Images: clat15.sno, clat15a.sno
 		Size: 1, 1
@@ -3214,7 +3214,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@166:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 166
 		Images: clat16.sno, clat16a.sno
 		Size: 1, 1
@@ -3225,7 +3225,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@167:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 167
 		Images: wcliff01.sno
 		Size: 2, 3
@@ -3253,7 +3253,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@168:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 168
 		Images: wcliff02.sno
 		Size: 1, 2
@@ -3270,7 +3270,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@169:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 169
 		Images: wcliff03.sno
 		Size: 2, 3
@@ -3298,7 +3298,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@170:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 170
 		Images: wcliff04.sno
 		Size: 2, 3
@@ -3326,7 +3326,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@171:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 171
 		Images: wcliff05.sno
 		Size: 2, 2
@@ -3354,7 +3354,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@172:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 172
 		Images: wcliff06.sno
 		Size: 2, 2
@@ -3382,7 +3382,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@173:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 173
 		Images: wcliff07.sno
 		Size: 2, 2
@@ -3410,7 +3410,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@174:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 174
 		Images: wcliff08.sno
 		Size: 1, 2
@@ -3427,7 +3427,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@175:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 175
 		Images: wcliff09.sno
 		Size: 2, 2
@@ -3449,7 +3449,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@176:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 176
 		Images: wcliff10.sno
 		Size: 2, 2
@@ -3476,7 +3476,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@177:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 177
 		Images: wcliff11.sno
 		Size: 2, 2
@@ -3498,7 +3498,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@178:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 178
 		Images: wcliff12.sno
 		Size: 1, 1
@@ -3509,7 +3509,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@179:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 179
 		Images: wcliff13.sno
 		Size: 1, 1
@@ -3520,7 +3520,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@180:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 180
 		Images: wcliff14.sno
 		Size: 1, 1
@@ -3531,7 +3531,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@181:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 181
 		Images: wcliff15.sno
 		Size: 2, 2
@@ -3559,7 +3559,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@182:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 182
 		Images: wcliff16.sno
 		Size: 2, 2
@@ -3587,7 +3587,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@183:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 183
 		Images: wcliff17.sno
 		Size: 2, 2
@@ -3615,7 +3615,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@184:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 184
 		Images: wcliff18.sno
 		Size: 2, 1
@@ -3632,7 +3632,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@185:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 185
 		Images: wcliff19.sno
 		Size: 3, 2
@@ -3660,7 +3660,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@186:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 186
 		Images: wcliff20.sno
 		Size: 3, 2
@@ -3688,7 +3688,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@187:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 187
 		Images: wcliff21.sno
 		Size: 3, 2
@@ -3716,7 +3716,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@188:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 188
 		Images: wcliff22.sno
 		Size: 2, 1
@@ -3733,7 +3733,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@189:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 189
 		Images: wcliff23.sno
 		Size: 2, 3
@@ -3766,7 +3766,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@190:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 190
 		Images: wcliff24.sno
 		Size: 1, 2
@@ -3782,7 +3782,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@191:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 191
 		Images: wcliff25.sno
 		Size: 2, 1
@@ -3798,7 +3798,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@192:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 192
 		Images: wcliff26.sno
 		Size: 2, 1
@@ -3814,7 +3814,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@193:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 193
 		Images: wcliff27.sno
 		Size: 1, 2
@@ -3830,7 +3830,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@194:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 194
 		Images: wcliff28.sno
 		Size: 3, 2
@@ -3863,7 +3863,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@195:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 195
 		Images: droadc01.sno
 		Size: 3, 2
@@ -3894,7 +3894,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@196:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 196
 		Images: droadc02.sno
 		Size: 2, 2
@@ -3920,7 +3920,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@197:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 197
 		Images: droadc03.sno
 		Size: 2, 2
@@ -3946,7 +3946,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@198:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 198
 		Images: droadc04.sno
 		Size: 2, 2
@@ -3967,7 +3967,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@199:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 199
 		Images: droadc05.sno
 		Size: 2, 2
@@ -3993,7 +3993,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@200:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 200
 		Images: droadc06.sno
 		Size: 3, 2
@@ -4024,7 +4024,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@201:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 201
 		Images: droadc07.sno
 		Size: 2, 3
@@ -4055,7 +4055,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@202:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 202
 		Images: droadc08.sno
 		Size: 2, 2
@@ -4081,7 +4081,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@203:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 203
 		Images: droadc09.sno
 		Size: 2, 2
@@ -4107,7 +4107,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@204:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 204
 		Images: droadc10.sno
 		Size: 2, 2
@@ -4133,7 +4133,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@205:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 205
 		Images: droadc11.sno
 		Size: 3, 2
@@ -4164,7 +4164,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@206:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 206
 		Images: droadc12.sno
 		Size: 3, 2
@@ -4195,7 +4195,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@207:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 207
 		Images: droadc13.sno
 		Size: 2, 3
@@ -4231,7 +4231,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@208:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 208
 		Images: droadc14.sno
 		Size: 2, 2
@@ -4257,7 +4257,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@209:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 209
 		Images: droadc15.sno
 		Size: 2, 2
@@ -4278,7 +4278,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@210:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 210
 		Images: droadc16.sno
 		Size: 2, 2
@@ -4299,7 +4299,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@211:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 211
 		Images: droadc17.sno
 		Size: 3, 2
@@ -4335,7 +4335,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@212:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 212
 		Images: droadc18.sno
 		Size: 2, 2
@@ -4356,7 +4356,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@213:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 213
 		Images: droadc19.sno
 		Size: 2, 2
@@ -4382,7 +4382,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@214:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 214
 		Images: droadc20.sno
 		Size: 3, 2
@@ -4413,7 +4413,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@215:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 215
 		Images: droadc21.sno
 		Size: 2, 2
@@ -4439,7 +4439,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@216:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 216
 		Images: droadc22.sno
 		Size: 2, 2
@@ -4460,7 +4460,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@217:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 217
 		Images: droadc23.sno
 		Size: 2, 3
@@ -4486,7 +4486,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@218:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 218
 		Images: droadc24.sno
 		Size: 2, 3
@@ -4517,7 +4517,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@219:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 219
 		Images: droadj01.sno
 		Size: 2, 2
@@ -4543,7 +4543,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@220:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 220
 		Images: droadj02.sno
 		Size: 2, 2
@@ -4569,7 +4569,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@221:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 221
 		Images: droadj03.sno
 		Size: 2, 2
@@ -4595,7 +4595,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@222:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 222
 		Images: droadj04.sno
 		Size: 2, 2
@@ -4621,7 +4621,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@223:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 223
 		Images: droadj05.sno
 		Size: 2, 2
@@ -4647,7 +4647,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@224:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 224
 		Images: droadj06.sno
 		Size: 3, 3
@@ -4688,7 +4688,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@225:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 225
 		Images: droadj07.sno
 		Size: 3, 3
@@ -4724,7 +4724,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@226:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 226
 		Images: droadj08.sno
 		Size: 3, 3
@@ -4760,7 +4760,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@227:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 227
 		Images: droadj09.sno
 		Size: 3, 3
@@ -4801,7 +4801,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@228:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 228
 		Images: droadj10.sno
 		Size: 3, 3
@@ -4842,7 +4842,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@229:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 229
 		Images: droadj11.sno
 		Size: 4, 4
@@ -4913,7 +4913,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@230:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 230
 		Images: droads01.sno
 		Size: 4, 4
@@ -4964,7 +4964,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@231:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 231
 		Images: droads02.sno
 		Size: 4, 4
@@ -5015,7 +5015,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@232:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 232
 		Images: droads03.sno
 		Size: 4, 4
@@ -5066,7 +5066,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@233:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 233
 		Images: droads04.sno
 		Size: 4, 4
@@ -5132,7 +5132,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@234:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 234
 		Images: droads05.sno
 		Size: 3, 3
@@ -5168,7 +5168,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@235:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 235
 		Images: droads06.sno
 		Size: 2, 2
@@ -5189,7 +5189,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@236:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 236
 		Images: droads07.sno
 		Size: 2, 2
@@ -5210,7 +5210,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@237:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 237
 		Images: droads08.sno
 		Size: 4, 4
@@ -5256,7 +5256,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@238:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 238
 		Images: droads09.sno
 		Size: 4, 3
@@ -5307,7 +5307,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@239:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 239
 		Images: droads10.sno
 		Size: 3, 3
@@ -5343,7 +5343,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@240:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 240
 		Images: droads11.sno
 		Size: 4, 4
@@ -5394,7 +5394,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@241:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 241
 		Images: droads12.sno
 		Size: 3, 4
@@ -5445,7 +5445,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@242:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 242
 		Images: droads13.sno
 		Size: 3, 3
@@ -5481,7 +5481,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@243:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 243
 		Images: droads14.sno
 		Size: 5, 3
@@ -5537,7 +5537,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@244:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 244
 		Images: droads15.sno
 		Size: 3, 5
@@ -5593,7 +5593,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@245:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 245
 		Images: droads16.sno
 		Size: 2, 4
@@ -5629,7 +5629,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@246:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 246
 		Images: droads17.sno
 		Size: 4, 2
@@ -5675,7 +5675,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@247:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 247
 		Images: droads18.sno
 		Size: 4, 2
@@ -5721,7 +5721,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@248:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 248
 		Images: droads19.sno
 		Size: 4, 2
@@ -5767,7 +5767,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@249:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 249
 		Images: droads20.sno
 		Size: 4, 2
@@ -5813,7 +5813,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@250:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 250
 		Images: droads21.sno
 		Size: 3, 2
@@ -5849,7 +5849,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@251:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 251
 		Images: droads22.sno
 		Size: 2, 2
@@ -5875,7 +5875,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@252:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 252
 		Images: droads23.sno
 		Size: 1, 2
@@ -5891,7 +5891,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@253:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 253
 		Images: droads24.sno
 		Size: 1, 2
@@ -5907,7 +5907,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@254:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 254
 		Images: droads25.sno
 		Size: 3, 2
@@ -5943,7 +5943,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@255:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 255
 		Images: droads26.sno
 		Size: 2, 2
@@ -5969,7 +5969,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@256:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 256
 		Images: droads27.sno
 		Size: 3, 3
@@ -6010,7 +6010,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@257:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 257
 		Images: droads28.sno
 		Size: 3, 2
@@ -6046,7 +6046,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@258:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 258
 		Images: droads29.sno
 		Size: 2, 2
@@ -6072,7 +6072,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@259:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 259
 		Images: droads30.sno
 		Size: 2, 2
@@ -6098,7 +6098,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@260:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 260
 		Images: droads31.sno
 		Size: 4, 3
@@ -6144,7 +6144,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@261:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 261
 		Images: droads32.sno
 		Size: 4, 3
@@ -6190,7 +6190,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@262:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 262
 		Images: droads33.sno
 		Size: 4, 2
@@ -6236,7 +6236,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@263:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 263
 		Images: droads34.sno
 		Size: 4, 4
@@ -6287,7 +6287,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@264:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 264
 		Images: droads35.sno
 		Size: 4, 4
@@ -6338,7 +6338,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@265:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 265
 		Images: droads36.sno
 		Size: 4, 4
@@ -6389,7 +6389,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@266:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 266
 		Images: droads37.sno
 		Size: 4, 4
@@ -6440,7 +6440,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@267:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 267
 		Images: droads38.sno
 		Size: 3, 3
@@ -6476,7 +6476,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@268:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 268
 		Images: droads39.sno
 		Size: 2, 2
@@ -6497,7 +6497,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@269:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 269
 		Images: droads40.sno
 		Size: 2, 2
@@ -6518,7 +6518,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@270:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 270
 		Images: droads41.sno
 		Size: 4, 4
@@ -6569,7 +6569,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@271:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 271
 		Images: droads42.sno
 		Size: 4, 5
@@ -6625,7 +6625,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@272:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 272
 		Images: droads43.sno
 		Size: 3, 3
@@ -6661,7 +6661,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@273:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 273
 		Images: droads44.sno
 		Size: 4, 4
@@ -6712,7 +6712,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@274:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 274
 		Images: droads45.sno
 		Size: 2, 3
@@ -6748,7 +6748,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@275:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 275
 		Images: droads46.sno
 		Size: 3, 3
@@ -6784,7 +6784,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@276:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 276
 		Images: droads47.sno
 		Size: 5, 3
@@ -6845,7 +6845,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@277:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 277
 		Images: droads48.sno
 		Size: 3, 5
@@ -6901,7 +6901,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@278:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 278
 		Images: droads49.sno
 		Size: 4, 4
@@ -6952,7 +6952,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@279:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 279
 		Images: droads50.sno
 		Size: 2, 4
@@ -6998,7 +6998,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@280:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 280
 		Images: droads51.sno
 		Size: 2, 4
@@ -7044,7 +7044,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@281:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 281
 		Images: droads52.sno
 		Size: 2, 4
@@ -7090,7 +7090,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@282:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 282
 		Images: droads53.sno
 		Size: 2, 4
@@ -7136,7 +7136,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@283:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 283
 		Images: droads54.sno
 		Size: 2, 3
@@ -7172,7 +7172,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@284:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 284
 		Images: droads55.sno
 		Size: 2, 2
@@ -7198,7 +7198,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@285:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 285
 		Images: droads56.sno
 		Size: 2, 1
@@ -7214,7 +7214,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@286:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 286
 		Images: droads57.sno
 		Size: 2, 1
@@ -7230,7 +7230,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@287:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 287
 		Images: droads58.sno
 		Size: 2, 4
@@ -7276,7 +7276,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@288:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 288
 		Images: droads59.sno
 		Size: 3, 3
@@ -7317,7 +7317,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@289:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 289
 		Images: droads60.sno
 		Size: 2, 3
@@ -7348,7 +7348,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@290:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 290
 		Images: droads61.sno
 		Size: 2, 4
@@ -7389,7 +7389,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@291:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 291
 		Images: droads62.sno
 		Size: 2, 4
@@ -7435,7 +7435,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@292:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 292
 		Images: droads63.sno
 		Size: 2, 2
@@ -7461,7 +7461,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@293:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 293
 		Images: droads64.sno
 		Size: 3, 4
@@ -7507,7 +7507,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@294:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 294
 		Images: droads65.sno
 		Size: 3, 4
@@ -7553,7 +7553,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@295:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 295
 		Images: droads66.sno
 		Size: 2, 3
@@ -7584,7 +7584,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@296:
-		Category: Bridges
+		Categories: Bridges
 		Id: 296
 		Images: ovrps01.sno
 		Size: 3, 5
@@ -7673,7 +7673,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@297:
-		Category: Bridges
+		Categories: Bridges
 		Id: 297
 		Images: ovrps02.sno
 		Size: 3, 5
@@ -7762,7 +7762,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@298:
-		Category: Bridges
+		Categories: Bridges
 		Id: 298
 		Images: ovrps03.sno
 		Size: 2, 5
@@ -7826,7 +7826,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@299:
-		Category: Bridges
+		Categories: Bridges
 		Id: 299
 		Images: ovrps04.sno
 		Size: 5, 3
@@ -7915,7 +7915,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@300:
-		Category: Bridges
+		Categories: Bridges
 		Id: 300
 		Images: ovrps05.sno
 		Size: 5, 3
@@ -8004,7 +8004,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@301:
-		Category: Bridges
+		Categories: Bridges
 		Id: 301
 		Images: ovrps06.sno
 		Size: 5, 2
@@ -8068,7 +8068,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@302:
-		Category: Bridges
+		Categories: Bridges
 		Id: 302
 		Images: ovrps07.sno
 		Size: 2, 5
@@ -8127,7 +8127,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@303:
-		Category: Bridges
+		Categories: Bridges
 		Id: 303
 		Images: ovrps08.sno
 		Size: 2, 5
@@ -8186,7 +8186,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@304:
-		Category: Bridges
+		Categories: Bridges
 		Id: 304
 		Images: ovrps09.sno
 		Size: 2, 5
@@ -8245,7 +8245,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@305:
-		Category: Bridges
+		Categories: Bridges
 		Id: 305
 		Images: ovrps10.sno
 		Size: 2, 5
@@ -8304,7 +8304,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@306:
-		Category: Bridges
+		Categories: Bridges
 		Id: 306
 		Images: ovrps11.sno
 		Size: 2, 5
@@ -8360,7 +8360,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@307:
-		Category: Bridges
+		Categories: Bridges
 		Id: 307
 		Images: ovrps12.sno
 		Size: 5, 2
@@ -8419,7 +8419,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@308:
-		Category: Bridges
+		Categories: Bridges
 		Id: 308
 		Images: ovrps13.sno
 		Size: 5, 2
@@ -8473,7 +8473,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@309:
-		Category: Bridges
+		Categories: Bridges
 		Id: 309
 		Images: ovrps14.sno
 		Size: 5, 2
@@ -8532,7 +8532,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@310:
-		Category: Bridges
+		Categories: Bridges
 		Id: 310
 		Images: ovrps15.sno
 		Size: 5, 2
@@ -8586,7 +8586,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@311:
-		Category: Bridges
+		Categories: Bridges
 		Id: 311
 		Images: ovrps16.sno
 		Size: 5, 2
@@ -8642,7 +8642,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@312:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 312
 		Images: proad01.sno, proad01a.sno, proad01b.sno, proad01c.sno
 		Size: 1, 3
@@ -8663,7 +8663,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@313:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 313
 		Images: proad02.sno, proad02a.sno, proad02b.sno, proad02c.sno
 		Size: 3, 1
@@ -8684,7 +8684,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@314:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 314
 		Images: proad03.sno
 		Size: 3, 3
@@ -8735,7 +8735,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@315:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 315
 		Images: proad04.sno
 		Size: 3, 3
@@ -8786,7 +8786,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@316:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 316
 		Images: proad05.sno
 		Size: 3, 3
@@ -8837,7 +8837,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@317:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 317
 		Images: proad06.sno
 		Size: 3, 3
@@ -8888,7 +8888,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@318:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 318
 		Images: proad07.sno
 		Size: 3, 3
@@ -8939,7 +8939,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@319:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 319
 		Images: proad08.sno
 		Size: 3, 3
@@ -8990,7 +8990,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@320:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 320
 		Images: proad09.sno
 		Size: 3, 3
@@ -9041,7 +9041,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@321:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 321
 		Images: proad10.sno
 		Size: 4, 3
@@ -9107,7 +9107,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@322:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 322
 		Images: proad11.sno
 		Size: 4, 3
@@ -9173,7 +9173,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@323:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 323
 		Images: proad12.sno
 		Size: 4, 3
@@ -9239,7 +9239,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@324:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 324
 		Images: proad13.sno
 		Size: 3, 4
@@ -9305,7 +9305,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@325:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 325
 		Images: proad14.sno
 		Size: 3, 4
@@ -9371,7 +9371,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@326:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 326
 		Images: proad15.sno
 		Size: 3, 4
@@ -9437,7 +9437,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@327:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 327
 		Images: proad16.sno
 		Size: 4, 5
@@ -9523,7 +9523,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@328:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 328
 		Images: proad17.sno
 		Size: 4, 4
@@ -9599,7 +9599,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@329:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 329
 		Images: proad18.sno
 		Size: 4, 5
@@ -9685,7 +9685,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@330:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 330
 		Images: proad19.sno
 		Size: 5, 4
@@ -9771,7 +9771,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@331:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 331
 		Images: proad20.sno
 		Size: 4, 4
@@ -9847,7 +9847,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@332:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 332
 		Images: proad21.sno
 		Size: 5, 4
@@ -9933,7 +9933,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@333:
-		Category: Water
+		Categories: Water
 		Id: 333
 		Images: water01.sno
 		Size: 2, 2
@@ -9959,7 +9959,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@334:
-		Category: Water
+		Categories: Water
 		Id: 334
 		Images: water02.sno
 		Size: 2, 2
@@ -9985,7 +9985,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@335:
-		Category: Water
+		Categories: Water
 		Id: 335
 		Images: water03.sno
 		Size: 2, 2
@@ -10011,7 +10011,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@336:
-		Category: Water
+		Categories: Water
 		Id: 336
 		Images: water04.sno
 		Size: 2, 2
@@ -10037,7 +10037,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@337:
-		Category: Water
+		Categories: Water
 		Id: 337
 		Images: water05.sno
 		Size: 2, 2
@@ -10063,7 +10063,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@338:
-		Category: Water
+		Categories: Water
 		Id: 338
 		Images: water06.sno
 		Size: 2, 2
@@ -10089,7 +10089,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@339:
-		Category: Water
+		Categories: Water
 		Id: 339
 		Images: water07.sno
 		Size: 2, 2
@@ -10115,7 +10115,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@340:
-		Category: Water
+		Categories: Water
 		Id: 340
 		Images: water08.sno
 		Size: 2, 2
@@ -10141,7 +10141,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@341:
-		Category: Water
+		Categories: Water
 		Id: 341
 		Images: water09.sno
 		Size: 1, 1
@@ -10152,7 +10152,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@342:
-		Category: Water
+		Categories: Water
 		Id: 342
 		Images: water10.sno
 		Size: 1, 1
@@ -10163,7 +10163,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@343:
-		Category: Water
+		Categories: Water
 		Id: 343
 		Images: water11.sno
 		Size: 1, 1
@@ -10174,7 +10174,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@344:
-		Category: Water
+		Categories: Water
 		Id: 344
 		Images: water12.sno
 		Size: 1, 1
@@ -10185,7 +10185,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@345:
-		Category: Water
+		Categories: Water
 		Id: 345
 		Images: water13.sno
 		Size: 1, 1
@@ -10196,7 +10196,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@346:
-		Category: Water
+		Categories: Water
 		Id: 346
 		Images: water14.sno
 		Size: 1, 1
@@ -10207,7 +10207,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@387:
-		Category: Dirt Road Slopes
+		Categories: Dirt Road Slopes
 		Id: 387
 		Images: drslpe01.sno
 		Size: 1, 2
@@ -10225,7 +10225,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@388:
-		Category: Dirt Road Slopes
+		Categories: Dirt Road Slopes
 		Id: 388
 		Images: drslpe02.sno
 		Size: 1, 2
@@ -10243,7 +10243,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@389:
-		Category: Dirt Road Slopes
+		Categories: Dirt Road Slopes
 		Id: 389
 		Images: drslpe03.sno
 		Size: 2, 1
@@ -10261,7 +10261,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@390:
-		Category: Dirt Road Slopes
+		Categories: Dirt Road Slopes
 		Id: 390
 		Images: drslpe04.sno
 		Size: 2, 1
@@ -10279,7 +10279,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@391:
-		Category: Dirt Road Slopes
+		Categories: Dirt Road Slopes
 		Id: 391
 		Images: drslpe05.sno
 		Size: 1, 2
@@ -10297,7 +10297,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@392:
-		Category: Dirt Road Slopes
+		Categories: Dirt Road Slopes
 		Id: 392
 		Images: drslpe06.sno
 		Size: 1, 2
@@ -10315,7 +10315,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@393:
-		Category: Dirt Road Slopes
+		Categories: Dirt Road Slopes
 		Id: 393
 		Images: drslpe07.sno
 		Size: 2, 1
@@ -10333,7 +10333,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@394:
-		Category: Dirt Road Slopes
+		Categories: Dirt Road Slopes
 		Id: 394
 		Images: drslpe08.sno
 		Size: 2, 1
@@ -10351,7 +10351,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@403:
-		Category: Slope Set Pieces
+		Categories: Slope Set Pieces
 		Id: 403
 		Images: ramp01.sno
 		Size: 3, 4
@@ -10421,7 +10421,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@404:
-		Category: Slope Set Pieces
+		Categories: Slope Set Pieces
 		Id: 404
 		Images: ramp02.sno
 		Size: 3, 4
@@ -10491,7 +10491,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@405:
-		Category: Slope Set Pieces
+		Categories: Slope Set Pieces
 		Id: 405
 		Images: ramp03.sno
 		Size: 4, 3
@@ -10561,7 +10561,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@406:
-		Category: Slope Set Pieces
+		Categories: Slope Set Pieces
 		Id: 406
 		Images: ramp04.sno
 		Size: 4, 3
@@ -10631,7 +10631,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@407:
-		Category: Slope Set Pieces
+		Categories: Slope Set Pieces
 		Id: 407
 		Images: ramp05.sno
 		Size: 3, 4
@@ -10700,7 +10700,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@408:
-		Category: Slope Set Pieces
+		Categories: Slope Set Pieces
 		Id: 408
 		Images: ramp06.sno
 		Size: 3, 4
@@ -10750,7 +10750,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@409:
-		Category: Slope Set Pieces
+		Categories: Slope Set Pieces
 		Id: 409
 		Images: ramp07.sno
 		Size: 2, 2
@@ -10776,7 +10776,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@410:
-		Category: Slope Set Pieces
+		Categories: Slope Set Pieces
 		Id: 410
 		Images: ramp08.sno
 		Size: 4, 3
@@ -10845,7 +10845,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@411:
-		Category: Slope Set Pieces
+		Categories: Slope Set Pieces
 		Id: 411
 		Images: ramp09.sno
 		Size: 4, 3
@@ -10895,7 +10895,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@412:
-		Category: Slope Set Pieces
+		Categories: Slope Set Pieces
 		Id: 412
 		Images: ramp10.sno
 		Size: 2, 2
@@ -10921,7 +10921,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@423:
-		Category: Dead Oil Tanker
+		Categories: Dead Oil Tanker
 		Id: 423
 		Images: tanker01.sno
 		Size: 5, 8
@@ -11055,7 +11055,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@424:
-		Category: Ruins
+		Categories: Ruins
 		Id: 424
 		Images: ruin01.sno
 		Size: 3, 3
@@ -11096,7 +11096,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@435:
-		Category: Waterfalls
+		Categories: Waterfalls
 		Id: 435
 		Images: w-a-01.sno
 		Size: 2, 4
@@ -11146,7 +11146,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@436:
-		Category: Waterfalls
+		Categories: Waterfalls
 		Id: 436
 		Images: w-a-02.sno
 		Size: 1, 4
@@ -11174,7 +11174,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@437:
-		Category: Waterfalls
+		Categories: Waterfalls
 		Id: 437
 		Images: w-a-03.sno
 		Size: 2, 4
@@ -11224,7 +11224,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@438:
-		Category: Waterfalls
+		Categories: Waterfalls
 		Id: 438
 		Images: w-a-04.sno
 		Size: 2, 4
@@ -11274,7 +11274,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@439:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 439
 		Images: ice0101.sno
 		Size: 1, 1
@@ -11285,7 +11285,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@440:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 440
 		Images: ice0102.sno
 		Size: 1, 1
@@ -11296,7 +11296,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@441:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 441
 		Images: ice0103.sno
 		Size: 1, 1
@@ -11307,7 +11307,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@442:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 442
 		Images: ice0104.sno
 		Size: 1, 1
@@ -11318,7 +11318,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@443:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 443
 		Images: ice0105.sno
 		Size: 1, 1
@@ -11329,7 +11329,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@444:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 444
 		Images: ice0106.sno
 		Size: 1, 1
@@ -11340,7 +11340,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@445:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 445
 		Images: ice0107.sno
 		Size: 1, 1
@@ -11351,7 +11351,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@446:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 446
 		Images: ice0108.sno
 		Size: 1, 1
@@ -11362,7 +11362,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@447:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 447
 		Images: ice0109.sno
 		Size: 1, 1
@@ -11373,7 +11373,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@448:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 448
 		Images: ice0110.sno
 		Size: 1, 1
@@ -11384,7 +11384,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@449:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 449
 		Images: ice0111.sno
 		Size: 1, 1
@@ -11395,7 +11395,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@450:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 450
 		Images: ice0112.sno
 		Size: 1, 1
@@ -11406,7 +11406,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@451:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 451
 		Images: ice0113.sno
 		Size: 1, 1
@@ -11417,7 +11417,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@452:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 452
 		Images: ice0114.sno
 		Size: 1, 1
@@ -11428,7 +11428,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@453:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 453
 		Images: ice0115.sno
 		Size: 1, 1
@@ -11439,7 +11439,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@454:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 454
 		Images: ice0116.sno
 		Size: 1, 1
@@ -11450,7 +11450,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@455:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 455
 		Images: ice0117.sno
 		Size: 1, 1
@@ -11461,7 +11461,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@456:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 456
 		Images: ice0118.sno
 		Size: 1, 1
@@ -11472,7 +11472,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@457:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 457
 		Images: ice0119.sno
 		Size: 1, 1
@@ -11483,7 +11483,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@458:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 458
 		Images: ice0120.sno
 		Size: 1, 1
@@ -11494,7 +11494,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@459:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 459
 		Images: ice0121.sno
 		Size: 1, 1
@@ -11505,7 +11505,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@460:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 460
 		Images: ice0122.sno
 		Size: 1, 1
@@ -11516,7 +11516,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@461:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 461
 		Images: ice0123.sno
 		Size: 1, 1
@@ -11527,7 +11527,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@462:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 462
 		Images: ice0124.sno
 		Size: 1, 1
@@ -11538,7 +11538,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@463:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 463
 		Images: ice0125.sno
 		Size: 1, 1
@@ -11549,7 +11549,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@464:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 464
 		Images: ice0126.sno
 		Size: 1, 1
@@ -11560,7 +11560,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@465:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 465
 		Images: ice0127.sno
 		Size: 1, 1
@@ -11571,7 +11571,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@466:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 466
 		Images: ice0128.sno
 		Size: 1, 1
@@ -11582,7 +11582,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@467:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 467
 		Images: ice0129.sno
 		Size: 1, 1
@@ -11593,7 +11593,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@468:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 468
 		Images: ice0130.sno
 		Size: 1, 1
@@ -11604,7 +11604,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@469:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 469
 		Images: ice0131.sno
 		Size: 1, 1
@@ -11615,7 +11615,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@470:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 470
 		Images: ice0132.sno
 		Size: 1, 1
@@ -11626,7 +11626,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@471:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 471
 		Images: ice0133.sno
 		Size: 1, 1
@@ -11637,7 +11637,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@472:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 472
 		Images: ice0134.sno
 		Size: 1, 1
@@ -11648,7 +11648,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@473:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 473
 		Images: ice0135.sno
 		Size: 1, 1
@@ -11659,7 +11659,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@474:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 474
 		Images: ice0136.sno
 		Size: 1, 1
@@ -11670,7 +11670,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@475:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 475
 		Images: ice0137.sno
 		Size: 1, 1
@@ -11681,7 +11681,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@476:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 476
 		Images: ice0138.sno
 		Size: 1, 1
@@ -11692,7 +11692,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@477:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 477
 		Images: ice0139.sno
 		Size: 1, 1
@@ -11703,7 +11703,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@478:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 478
 		Images: ice0140.sno
 		Size: 1, 1
@@ -11714,7 +11714,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@479:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 479
 		Images: ice0141.sno
 		Size: 1, 1
@@ -11725,7 +11725,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@480:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 480
 		Images: ice0142.sno
 		Size: 1, 1
@@ -11736,7 +11736,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@481:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 481
 		Images: ice0143.sno
 		Size: 1, 1
@@ -11747,7 +11747,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@482:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 482
 		Images: ice0144.sno
 		Size: 1, 1
@@ -11758,7 +11758,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@483:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 483
 		Images: ice0145.sno
 		Size: 1, 1
@@ -11769,7 +11769,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@484:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 484
 		Images: ice0146.sno
 		Size: 1, 1
@@ -11780,7 +11780,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@485:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 485
 		Images: ice0147.sno
 		Size: 1, 1
@@ -11791,7 +11791,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@486:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 486
 		Images: ice0148.sno
 		Size: 1, 1
@@ -11802,7 +11802,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@487:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 487
 		Images: ice0149.sno
 		Size: 1, 1
@@ -11813,7 +11813,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@488:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 488
 		Images: ice0150.sno
 		Size: 1, 1
@@ -11824,7 +11824,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@489:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 489
 		Images: ice0151.sno
 		Size: 1, 1
@@ -11835,7 +11835,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@490:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 490
 		Images: ice0152.sno
 		Size: 1, 1
@@ -11846,7 +11846,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@491:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 491
 		Images: ice0153.sno
 		Size: 1, 1
@@ -11857,7 +11857,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@492:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 492
 		Images: ice0154.sno
 		Size: 1, 1
@@ -11868,7 +11868,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@493:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 493
 		Images: ice0155.sno
 		Size: 1, 1
@@ -11879,7 +11879,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@494:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 494
 		Images: ice0156.sno
 		Size: 1, 1
@@ -11890,7 +11890,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@495:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 495
 		Images: ice0157.sno
 		Size: 1, 1
@@ -11901,7 +11901,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@496:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 496
 		Images: ice0158.sno
 		Size: 1, 1
@@ -11912,7 +11912,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@497:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 497
 		Images: ice0159.sno
 		Size: 1, 1
@@ -11923,7 +11923,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@498:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 498
 		Images: ice0160.sno
 		Size: 1, 1
@@ -11934,7 +11934,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@499:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 499
 		Images: ice0161.sno
 		Size: 1, 1
@@ -11945,7 +11945,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@500:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 500
 		Images: ice0162.sno
 		Size: 1, 1
@@ -11956,7 +11956,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@501:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 501
 		Images: ice0163.sno
 		Size: 1, 1
@@ -11967,7 +11967,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@502:
-		Category: Ice 01
+		Categories: Ice 01
 		Id: 502
 		Images: ice0164.sno
 		Size: 1, 1
@@ -11978,7 +11978,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@503:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 503
 		Images: ice0201.sno
 		Size: 1, 1
@@ -11989,7 +11989,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@504:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 504
 		Images: ice0202.sno
 		Size: 1, 1
@@ -12000,7 +12000,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@505:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 505
 		Images: ice0203.sno
 		Size: 1, 1
@@ -12011,7 +12011,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@506:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 506
 		Images: ice0204.sno
 		Size: 1, 1
@@ -12022,7 +12022,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@507:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 507
 		Images: ice0205.sno
 		Size: 1, 1
@@ -12033,7 +12033,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@508:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 508
 		Images: ice0206.sno
 		Size: 1, 1
@@ -12044,7 +12044,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@509:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 509
 		Images: ice0207.sno
 		Size: 1, 1
@@ -12055,7 +12055,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@510:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 510
 		Images: ice0208.sno
 		Size: 1, 1
@@ -12066,7 +12066,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@511:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 511
 		Images: ice0209.sno
 		Size: 1, 1
@@ -12077,7 +12077,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@512:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 512
 		Images: ice0210.sno
 		Size: 1, 1
@@ -12088,7 +12088,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@513:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 513
 		Images: ice0211.sno
 		Size: 1, 1
@@ -12099,7 +12099,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@514:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 514
 		Images: ice0212.sno
 		Size: 1, 1
@@ -12110,7 +12110,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@515:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 515
 		Images: ice0213.sno
 		Size: 1, 1
@@ -12121,7 +12121,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@516:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 516
 		Images: ice0214.sno
 		Size: 1, 1
@@ -12132,7 +12132,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@517:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 517
 		Images: ice0215.sno
 		Size: 1, 1
@@ -12143,7 +12143,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@518:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 518
 		Images: ice0216.sno
 		Size: 1, 1
@@ -12154,7 +12154,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@519:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 519
 		Images: ice0217.sno
 		Size: 1, 1
@@ -12165,7 +12165,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@520:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 520
 		Images: ice0218.sno
 		Size: 1, 1
@@ -12176,7 +12176,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@521:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 521
 		Images: ice0219.sno
 		Size: 1, 1
@@ -12187,7 +12187,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@522:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 522
 		Images: ice0220.sno
 		Size: 1, 1
@@ -12198,7 +12198,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@523:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 523
 		Images: ice0221.sno
 		Size: 1, 1
@@ -12209,7 +12209,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@524:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 524
 		Images: ice0222.sno
 		Size: 1, 1
@@ -12220,7 +12220,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@525:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 525
 		Images: ice0223.sno
 		Size: 1, 1
@@ -12231,7 +12231,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@526:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 526
 		Images: ice0224.sno
 		Size: 1, 1
@@ -12242,7 +12242,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@527:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 527
 		Images: ice0225.sno
 		Size: 1, 1
@@ -12253,7 +12253,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@528:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 528
 		Images: ice0226.sno
 		Size: 1, 1
@@ -12264,7 +12264,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@529:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 529
 		Images: ice0227.sno
 		Size: 1, 1
@@ -12275,7 +12275,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@530:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 530
 		Images: ice0228.sno
 		Size: 1, 1
@@ -12286,7 +12286,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@531:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 531
 		Images: ice0229.sno
 		Size: 1, 1
@@ -12297,7 +12297,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@532:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 532
 		Images: ice0230.sno
 		Size: 1, 1
@@ -12308,7 +12308,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@533:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 533
 		Images: ice0231.sno
 		Size: 1, 1
@@ -12319,7 +12319,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@534:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 534
 		Images: ice0232.sno
 		Size: 1, 1
@@ -12330,7 +12330,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@535:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 535
 		Images: ice0233.sno
 		Size: 1, 1
@@ -12341,7 +12341,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@536:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 536
 		Images: ice0234.sno
 		Size: 1, 1
@@ -12352,7 +12352,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@537:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 537
 		Images: ice0235.sno
 		Size: 1, 1
@@ -12363,7 +12363,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@538:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 538
 		Images: ice0236.sno
 		Size: 1, 1
@@ -12374,7 +12374,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@539:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 539
 		Images: ice0237.sno
 		Size: 1, 1
@@ -12385,7 +12385,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@540:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 540
 		Images: ice0238.sno
 		Size: 1, 1
@@ -12396,7 +12396,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@541:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 541
 		Images: ice0239.sno
 		Size: 1, 1
@@ -12407,7 +12407,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@542:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 542
 		Images: ice0240.sno
 		Size: 1, 1
@@ -12418,7 +12418,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@543:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 543
 		Images: ice0241.sno
 		Size: 1, 1
@@ -12429,7 +12429,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@544:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 544
 		Images: ice0242.sno
 		Size: 1, 1
@@ -12440,7 +12440,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@545:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 545
 		Images: ice0243.sno
 		Size: 1, 1
@@ -12451,7 +12451,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@546:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 546
 		Images: ice0244.sno
 		Size: 1, 1
@@ -12462,7 +12462,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@547:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 547
 		Images: ice0245.sno
 		Size: 1, 1
@@ -12473,7 +12473,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@548:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 548
 		Images: ice0246.sno
 		Size: 1, 1
@@ -12484,7 +12484,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@549:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 549
 		Images: ice0247.sno
 		Size: 1, 1
@@ -12495,7 +12495,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@550:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 550
 		Images: ice0248.sno
 		Size: 1, 1
@@ -12506,7 +12506,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@551:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 551
 		Images: ice0249.sno
 		Size: 1, 1
@@ -12517,7 +12517,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@552:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 552
 		Images: ice0250.sno
 		Size: 1, 1
@@ -12528,7 +12528,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@553:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 553
 		Images: ice0251.sno
 		Size: 1, 1
@@ -12539,7 +12539,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@554:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 554
 		Images: ice0252.sno
 		Size: 1, 1
@@ -12550,7 +12550,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@555:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 555
 		Images: ice0253.sno
 		Size: 1, 1
@@ -12561,7 +12561,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@556:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 556
 		Images: ice0254.sno
 		Size: 1, 1
@@ -12572,7 +12572,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@557:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 557
 		Images: ice0255.sno
 		Size: 1, 1
@@ -12583,7 +12583,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@558:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 558
 		Images: ice0256.sno
 		Size: 1, 1
@@ -12594,7 +12594,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@559:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 559
 		Images: ice0257.sno
 		Size: 1, 1
@@ -12605,7 +12605,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@560:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 560
 		Images: ice0258.sno
 		Size: 1, 1
@@ -12616,7 +12616,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@561:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 561
 		Images: ice0259.sno
 		Size: 1, 1
@@ -12627,7 +12627,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@562:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 562
 		Images: ice0260.sno
 		Size: 1, 1
@@ -12638,7 +12638,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@563:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 563
 		Images: ice0261.sno
 		Size: 1, 1
@@ -12649,7 +12649,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@564:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 564
 		Images: ice0262.sno
 		Size: 1, 1
@@ -12660,7 +12660,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@565:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 565
 		Images: ice0263.sno
 		Size: 1, 1
@@ -12671,7 +12671,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@566:
-		Category: Ice 02
+		Categories: Ice 02
 		Id: 566
 		Images: ice0264.sno
 		Size: 1, 1
@@ -12682,7 +12682,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@567:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 567
 		Images: ice0301.sno
 		Size: 1, 1
@@ -12693,7 +12693,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@568:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 568
 		Images: ice0302.sno
 		Size: 1, 1
@@ -12704,7 +12704,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@569:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 569
 		Images: ice0303.sno
 		Size: 1, 1
@@ -12715,7 +12715,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@570:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 570
 		Images: ice0304.sno
 		Size: 1, 1
@@ -12726,7 +12726,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@571:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 571
 		Images: ice0305.sno
 		Size: 1, 1
@@ -12737,7 +12737,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@572:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 572
 		Images: ice0306.sno
 		Size: 1, 1
@@ -12748,7 +12748,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@573:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 573
 		Images: ice0307.sno
 		Size: 1, 1
@@ -12759,7 +12759,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@574:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 574
 		Images: ice0308.sno
 		Size: 1, 1
@@ -12770,7 +12770,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@575:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 575
 		Images: ice0309.sno
 		Size: 1, 1
@@ -12781,7 +12781,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@576:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 576
 		Images: ice0310.sno
 		Size: 1, 1
@@ -12792,7 +12792,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@577:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 577
 		Images: ice0311.sno
 		Size: 1, 1
@@ -12803,7 +12803,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@578:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 578
 		Images: ice0312.sno
 		Size: 1, 1
@@ -12814,7 +12814,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@579:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 579
 		Images: ice0313.sno
 		Size: 1, 1
@@ -12825,7 +12825,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@580:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 580
 		Images: ice0314.sno
 		Size: 1, 1
@@ -12836,7 +12836,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@581:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 581
 		Images: ice0315.sno
 		Size: 1, 1
@@ -12847,7 +12847,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@582:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 582
 		Images: ice0316.sno
 		Size: 1, 1
@@ -12858,7 +12858,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@583:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 583
 		Images: ice0317.sno
 		Size: 1, 1
@@ -12869,7 +12869,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@584:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 584
 		Images: ice0318.sno
 		Size: 1, 1
@@ -12880,7 +12880,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@585:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 585
 		Images: ice0319.sno
 		Size: 1, 1
@@ -12891,7 +12891,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@586:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 586
 		Images: ice0320.sno
 		Size: 1, 1
@@ -12902,7 +12902,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@587:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 587
 		Images: ice0321.sno
 		Size: 1, 1
@@ -12913,7 +12913,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@588:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 588
 		Images: ice0322.sno
 		Size: 1, 1
@@ -12924,7 +12924,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@589:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 589
 		Images: ice0323.sno
 		Size: 1, 1
@@ -12935,7 +12935,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@590:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 590
 		Images: ice0324.sno
 		Size: 1, 1
@@ -12946,7 +12946,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@591:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 591
 		Images: ice0325.sno
 		Size: 1, 1
@@ -12957,7 +12957,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@592:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 592
 		Images: ice0326.sno
 		Size: 1, 1
@@ -12968,7 +12968,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@593:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 593
 		Images: ice0327.sno
 		Size: 1, 1
@@ -12979,7 +12979,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@594:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 594
 		Images: ice0328.sno
 		Size: 1, 1
@@ -12990,7 +12990,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@595:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 595
 		Images: ice0329.sno
 		Size: 1, 1
@@ -13001,7 +13001,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@596:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 596
 		Images: ice0330.sno
 		Size: 1, 1
@@ -13012,7 +13012,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@597:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 597
 		Images: ice0331.sno
 		Size: 1, 1
@@ -13023,7 +13023,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@598:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 598
 		Images: ice0332.sno
 		Size: 1, 1
@@ -13034,7 +13034,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@599:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 599
 		Images: ice0333.sno
 		Size: 1, 1
@@ -13045,7 +13045,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@600:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 600
 		Images: ice0334.sno
 		Size: 1, 1
@@ -13056,7 +13056,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@601:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 601
 		Images: ice0335.sno
 		Size: 1, 1
@@ -13067,7 +13067,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@602:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 602
 		Images: ice0336.sno
 		Size: 1, 1
@@ -13078,7 +13078,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@603:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 603
 		Images: ice0337.sno
 		Size: 1, 1
@@ -13089,7 +13089,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@604:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 604
 		Images: ice0338.sno
 		Size: 1, 1
@@ -13100,7 +13100,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@605:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 605
 		Images: ice0339.sno
 		Size: 1, 1
@@ -13111,7 +13111,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@606:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 606
 		Images: ice0340.sno
 		Size: 1, 1
@@ -13122,7 +13122,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@607:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 607
 		Images: ice0341.sno
 		Size: 1, 1
@@ -13133,7 +13133,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@608:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 608
 		Images: ice0342.sno
 		Size: 1, 1
@@ -13144,7 +13144,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@609:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 609
 		Images: ice0343.sno
 		Size: 1, 1
@@ -13155,7 +13155,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@610:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 610
 		Images: ice0344.sno
 		Size: 1, 1
@@ -13166,7 +13166,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@611:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 611
 		Images: ice0345.sno
 		Size: 1, 1
@@ -13177,7 +13177,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@612:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 612
 		Images: ice0346.sno
 		Size: 1, 1
@@ -13188,7 +13188,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@613:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 613
 		Images: ice0347.sno
 		Size: 1, 1
@@ -13199,7 +13199,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@614:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 614
 		Images: ice0348.sno
 		Size: 1, 1
@@ -13210,7 +13210,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@615:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 615
 		Images: ice0349.sno
 		Size: 1, 1
@@ -13221,7 +13221,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@616:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 616
 		Images: ice0350.sno
 		Size: 1, 1
@@ -13232,7 +13232,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@617:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 617
 		Images: ice0351.sno
 		Size: 1, 1
@@ -13243,7 +13243,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@618:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 618
 		Images: ice0352.sno
 		Size: 1, 1
@@ -13254,7 +13254,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@619:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 619
 		Images: ice0353.sno
 		Size: 1, 1
@@ -13265,7 +13265,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@620:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 620
 		Images: ice0354.sno
 		Size: 1, 1
@@ -13276,7 +13276,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@621:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 621
 		Images: ice0355.sno
 		Size: 1, 1
@@ -13287,7 +13287,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@622:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 622
 		Images: ice0356.sno
 		Size: 1, 1
@@ -13298,7 +13298,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@623:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 623
 		Images: ice0357.sno
 		Size: 1, 1
@@ -13309,7 +13309,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@624:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 624
 		Images: ice0358.sno
 		Size: 1, 1
@@ -13320,7 +13320,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@625:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 625
 		Images: ice0359.sno
 		Size: 1, 1
@@ -13331,7 +13331,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@626:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 626
 		Images: ice0360.sno
 		Size: 1, 1
@@ -13342,7 +13342,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@627:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 627
 		Images: ice0361.sno
 		Size: 1, 1
@@ -13353,7 +13353,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@628:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 628
 		Images: ice0362.sno
 		Size: 1, 1
@@ -13364,7 +13364,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@629:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 629
 		Images: ice0363.sno
 		Size: 1, 1
@@ -13375,7 +13375,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@630:
-		Category: Ice 03
+		Categories: Ice 03
 		Id: 630
 		Images: ice0364.sno
 		Size: 1, 1
@@ -13386,7 +13386,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@631:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 631
 		Images: ishore01.sno
 		Size: 1, 1
@@ -13397,7 +13397,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@632:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 632
 		Images: ishore02.sno
 		Size: 1, 1
@@ -13408,7 +13408,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@633:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 633
 		Images: ishore03.sno
 		Size: 1, 1
@@ -13419,7 +13419,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@634:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 634
 		Images: ishore04.sno
 		Size: 1, 1
@@ -13430,7 +13430,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@635:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 635
 		Images: ishore05.sno
 		Size: 1, 1
@@ -13441,7 +13441,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@636:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 636
 		Images: ishore06.sno
 		Size: 1, 1
@@ -13452,7 +13452,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@637:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 637
 		Images: ishore07.sno
 		Size: 1, 1
@@ -13463,7 +13463,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@638:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 638
 		Images: ishore08.sno
 		Size: 1, 1
@@ -13474,7 +13474,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@639:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 639
 		Images: ishore09.sno
 		Size: 1, 1
@@ -13485,7 +13485,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@640:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 640
 		Images: ishore10.sno
 		Size: 1, 1
@@ -13496,7 +13496,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@641:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 641
 		Images: ishore11.sno
 		Size: 1, 1
@@ -13507,7 +13507,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@642:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 642
 		Images: ishore12.sno
 		Size: 1, 1
@@ -13518,7 +13518,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@643:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 643
 		Images: ishore13.sno
 		Size: 1, 1
@@ -13529,7 +13529,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@644:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 644
 		Images: ishore14.sno
 		Size: 1, 1
@@ -13540,7 +13540,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@645:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 645
 		Images: ishore15.sno
 		Size: 1, 1
@@ -13551,7 +13551,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@646:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 646
 		Images: ishore16.sno
 		Size: 1, 1
@@ -13562,7 +13562,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@647:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 647
 		Images: ishore17.sno
 		Size: 1, 1
@@ -13573,7 +13573,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@648:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 648
 		Images: ishore18.sno
 		Size: 1, 1
@@ -13584,7 +13584,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@649:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 649
 		Images: ishore19.sno
 		Size: 1, 1
@@ -13595,7 +13595,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@650:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 650
 		Images: ishore20.sno
 		Size: 1, 1
@@ -13606,7 +13606,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@651:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 651
 		Images: ishore21.sno
 		Size: 1, 1
@@ -13617,7 +13617,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@652:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 652
 		Images: ishore22.sno
 		Size: 1, 1
@@ -13628,7 +13628,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@653:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 653
 		Images: ishore23.sno
 		Size: 1, 1
@@ -13639,7 +13639,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@654:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 654
 		Images: ishore24.sno
 		Size: 1, 1
@@ -13650,7 +13650,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@655:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 655
 		Images: ishore25.sno
 		Size: 1, 1
@@ -13661,7 +13661,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@656:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 656
 		Images: ishore26.sno
 		Size: 1, 1
@@ -13672,7 +13672,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@657:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 657
 		Images: ishore27.sno
 		Size: 1, 1
@@ -13683,7 +13683,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@658:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 658
 		Images: ishore28.sno
 		Size: 1, 1
@@ -13694,7 +13694,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@659:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 659
 		Images: ishore29.sno
 		Size: 1, 1
@@ -13705,7 +13705,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@660:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 660
 		Images: ishore30.sno
 		Size: 1, 1
@@ -13716,7 +13716,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@661:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 661
 		Images: ishore31.sno
 		Size: 1, 1
@@ -13727,7 +13727,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@662:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 662
 		Images: ishore32.sno
 		Size: 1, 1
@@ -13738,7 +13738,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@663:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 663
 		Images: ishore33.sno
 		Size: 1, 1
@@ -13749,7 +13749,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@664:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 664
 		Images: ishore34.sno
 		Size: 1, 1
@@ -13760,7 +13760,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@665:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 665
 		Images: ishore35.sno
 		Size: 1, 1
@@ -13771,7 +13771,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@666:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 666
 		Images: ishore36.sno
 		Size: 1, 1
@@ -13782,7 +13782,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@667:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 667
 		Images: ishore37.sno
 		Size: 1, 1
@@ -13793,7 +13793,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@668:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 668
 		Images: ishore38.sno
 		Size: 1, 1
@@ -13804,7 +13804,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@669:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 669
 		Images: ishore39.sno
 		Size: 1, 1
@@ -13815,7 +13815,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@670:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 670
 		Images: ishore40.sno
 		Size: 1, 1
@@ -13826,7 +13826,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@671:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 671
 		Images: ishore41.sno
 		Size: 1, 1
@@ -13837,7 +13837,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@672:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 672
 		Images: ishore42.sno
 		Size: 1, 1
@@ -13848,7 +13848,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@673:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 673
 		Images: ishore43.sno
 		Size: 1, 1
@@ -13859,7 +13859,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@674:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 674
 		Images: ishore44.sno
 		Size: 1, 1
@@ -13870,7 +13870,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@675:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 675
 		Images: ishore45.sno
 		Size: 1, 1
@@ -13881,7 +13881,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@676:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 676
 		Images: ishore46.sno
 		Size: 1, 1
@@ -13892,7 +13892,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@677:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 677
 		Images: ishore47.sno
 		Size: 1, 1
@@ -13903,7 +13903,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@678:
-		Category: Ice shore
+		Categories: Ice shore
 		Id: 678
 		Images: ishore48.sno
 		Size: 1, 1
@@ -13914,7 +13914,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@679:
-		Category: Waterfalls-B
+		Categories: Waterfalls-B
 		Id: 679
 		Images: w-b-01.sno
 		Size: 4, 2
@@ -13964,7 +13964,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@680:
-		Category: Waterfalls-B
+		Categories: Waterfalls-B
 		Id: 680
 		Images: w-b-02.sno
 		Size: 4, 1
@@ -13992,7 +13992,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@681:
-		Category: Waterfalls-B
+		Categories: Waterfalls-B
 		Id: 681
 		Images: w-b-03.sno
 		Size: 4, 2
@@ -14042,7 +14042,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@682:
-		Category: Waterfalls-B
+		Categories: Waterfalls-B
 		Id: 682
 		Images: w-b-04.sno
 		Size: 4, 2
@@ -14092,7 +14092,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@683:
-		Category: Waterfalls-C
+		Categories: Waterfalls-C
 		Id: 683
 		Images: w-c-01.sno
 		Size: 2, 2
@@ -14116,7 +14116,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@684:
-		Category: Waterfalls-C
+		Categories: Waterfalls-C
 		Id: 684
 		Images: w-c-02.sno
 		Size: 1, 1
@@ -14128,7 +14128,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@685:
-		Category: Waterfalls-C
+		Categories: Waterfalls-C
 		Id: 685
 		Images: w-c-03.sno
 		Size: 2, 1
@@ -14146,7 +14146,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@686:
-		Category: Waterfalls-C
+		Categories: Waterfalls-C
 		Id: 686
 		Images: w-c-04.sno
 		Size: 2, 2
@@ -14170,7 +14170,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@687:
-		Category: Waterfalls-D
+		Categories: Waterfalls-D
 		Id: 687
 		Images: w-d-01.sno
 		Size: 2, 2
@@ -14194,7 +14194,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@688:
-		Category: Waterfalls-D
+		Categories: Waterfalls-D
 		Id: 688
 		Images: w-d-02.sno
 		Size: 1, 1
@@ -14206,7 +14206,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@689:
-		Category: Waterfalls-D
+		Categories: Waterfalls-D
 		Id: 689
 		Images: w-d-03.sno
 		Size: 1, 2
@@ -14224,7 +14224,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@690:
-		Category: Waterfalls-D
+		Categories: Waterfalls-D
 		Id: 690
 		Images: w-d-04.sno
 		Size: 2, 2
@@ -14248,7 +14248,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@691:
-		Category: Paved Road Ends
+		Categories: Paved Road Ends
 		Id: 691
 		Images: p_end01.sno
 		Size: 1, 3
@@ -14269,7 +14269,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@692:
-		Category: Paved Road Ends
+		Categories: Paved Road Ends
 		Id: 692
 		Images: p_end02.sno
 		Size: 3, 1
@@ -14290,7 +14290,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@693:
-		Category: Paved Road Ends
+		Categories: Paved Road Ends
 		Id: 693
 		Images: p_end03.sno
 		Size: 1, 3
@@ -14311,7 +14311,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@694:
-		Category: Paved Road Ends
+		Categories: Paved Road Ends
 		Id: 694
 		Images: p_end04.sno
 		Size: 3, 1
@@ -14332,7 +14332,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@695:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 695
 		Images: tovrps01.sno
 		Size: 3, 5
@@ -14421,7 +14421,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@696:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 696
 		Images: tovrps02.sno
 		Size: 3, 5
@@ -14510,7 +14510,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@697:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 697
 		Images: tovrps03.sno
 		Size: 2, 5
@@ -14574,7 +14574,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@698:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 698
 		Images: tovrps04.sno
 		Size: 5, 3
@@ -14663,7 +14663,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@699:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 699
 		Images: tovrps05.sno
 		Size: 5, 3
@@ -14752,7 +14752,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@700:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 700
 		Images: tovrps06.sno
 		Size: 5, 2
@@ -14816,7 +14816,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@701:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 701
 		Images: tovrps07.sno
 		Size: 2, 5
@@ -14875,7 +14875,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@702:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 702
 		Images: tovrps08.sno
 		Size: 2, 5
@@ -14934,7 +14934,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@703:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 703
 		Images: tovrps09.sno
 		Size: 2, 5
@@ -14993,7 +14993,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@704:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 704
 		Images: tovrps10.sno
 		Size: 2, 5
@@ -15052,7 +15052,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@705:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 705
 		Images: tovrps11.sno
 		Size: 2, 5
@@ -15108,7 +15108,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@706:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 706
 		Images: tovrps12.sno
 		Size: 5, 2
@@ -15167,7 +15167,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@707:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 707
 		Images: tovrps13.sno
 		Size: 5, 2
@@ -15221,7 +15221,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@708:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 708
 		Images: tovrps14.sno
 		Size: 5, 2
@@ -15280,7 +15280,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@709:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 709
 		Images: tovrps15.sno
 		Size: 5, 2
@@ -15334,7 +15334,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@710:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 710
 		Images: tovrps16.sno
 		Size: 5, 2
@@ -15390,7 +15390,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@711:
-		Category: Rough ground
+		Categories: Rough ground
 		Id: 711
 		Images: rough01.sno
 		Size: 9, 7
@@ -15576,7 +15576,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@712:
-		Category: Rough ground
+		Categories: Rough ground
 		Id: 712
 		Images: rough02.sno
 		Size: 4, 4
@@ -15632,7 +15632,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@713:
-		Category: Rough ground
+		Categories: Rough ground
 		Id: 713
 		Images: rough03.sno
 		Size: 5, 3
@@ -15693,7 +15693,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@714:
-		Category: Rough ground
+		Categories: Rough ground
 		Id: 714
 		Images: rough04.sno
 		Size: 4, 3
@@ -15739,7 +15739,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@715:
-		Category: Rough ground
+		Categories: Rough ground
 		Id: 715
 		Images: rough05.sno
 		Size: 3, 5
@@ -15805,7 +15805,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@716:
-		Category: Rough ground
+		Categories: Rough ground
 		Id: 716
 		Images: rough06.sno
 		Size: 4, 4
@@ -15876,7 +15876,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@717:
-		Category: Rough ground
+		Categories: Rough ground
 		Id: 717
 		Images: rough07.sno
 		Size: 3, 3
@@ -15922,7 +15922,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@718:
-		Category: Rough ground
+		Categories: Rough ground
 		Id: 718
 		Images: rough08.sno
 		Size: 6, 10
@@ -16038,7 +16038,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@719:
-		Category: Rough ground
+		Categories: Rough ground
 		Id: 719
 		Images: rough09.sno
 		Size: 8, 3
@@ -16124,7 +16124,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@720:
-		Category: Rough ground
+		Categories: Rough ground
 		Id: 720
 		Images: rough10.sno
 		Size: 3, 4
@@ -16170,7 +16170,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@721:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 721
 		Images: rmpfx01.sno, rmpfx01a.sno, rmpfx01b.sno, rmpfx01c.sno
 		Size: 1, 1
@@ -16182,7 +16182,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@722:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 722
 		Images: rmpfx02.sno, rmpfx02a.sno, rmpfx02b.sno, rmpfx02c.sno
 		Size: 1, 1
@@ -16194,7 +16194,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@723:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 723
 		Images: rmpfx03.sno, rmpfx03a.sno, rmpfx03b.sno, rmpfx03c.sno
 		Size: 1, 1
@@ -16206,7 +16206,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@724:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 724
 		Images: rmpfx04.sno, rmpfx04a.sno, rmpfx04b.sno, rmpfx04c.sno
 		Size: 1, 1
@@ -16218,7 +16218,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@725:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 725
 		Images: rmpfx05.sno, rmpfx05a.sno, rmpfx05b.sno, rmpfx05c.sno
 		Size: 1, 1
@@ -16230,7 +16230,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@726:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 726
 		Images: rmpfx06.sno, rmpfx06a.sno, rmpfx06b.sno, rmpfx06c.sno
 		Size: 1, 1
@@ -16242,7 +16242,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@727:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 727
 		Images: rmpfx07.sno, rmpfx07a.sno, rmpfx07b.sno, rmpfx07c.sno
 		Size: 1, 1
@@ -16254,7 +16254,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@728:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 728
 		Images: rmpfx08.sno, rmpfx08a.sno, rmpfx08b.sno, rmpfx08c.sno
 		Size: 1, 1
@@ -16266,7 +16266,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@729:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 729
 		Images: rmpfx09.sno, rmpfx09a.sno, rmpfx09b.sno, rmpfx09c.sno
 		Size: 1, 1
@@ -16278,7 +16278,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@730:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 730
 		Images: rmpfx10.sno, rmpfx10a.sno, rmpfx10b.sno, rmpfx10c.sno
 		Size: 1, 1
@@ -16290,7 +16290,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@731:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 731
 		Images: rmpfx11.sno, rmpfx11a.sno, rmpfx11b.sno, rmpfx11c.sno
 		Size: 1, 1
@@ -16302,7 +16302,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@732:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 732
 		Images: rmpfx12.sno, rmpfx12a.sno, rmpfx12b.sno, rmpfx12c.sno
 		Size: 1, 1
@@ -16314,7 +16314,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@745:
-		Category: Water slopes
+		Categories: Water slopes
 		Id: 745
 		Images: wslope01.sno
 		Size: 1, 4
@@ -16344,7 +16344,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@746:
-		Category: Water slopes
+		Categories: Water slopes
 		Id: 746
 		Images: wslope02.sno
 		Size: 4, 1
@@ -16374,7 +16374,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@747:
-		Category: Water slopes
+		Categories: Water slopes
 		Id: 747
 		Images: wslope03.sno
 		Size: 1, 4
@@ -16404,7 +16404,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@748:
-		Category: Water slopes
+		Categories: Water slopes
 		Id: 748
 		Images: wslope04.sno
 		Size: 4, 1
@@ -16434,7 +16434,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@749:
-		Category: Paved Road Slopes
+		Categories: Paved Road Slopes
 		Id: 749
 		Images: prslpe01.sno
 		Size: 1, 3
@@ -16458,7 +16458,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@750:
-		Category: Paved Road Slopes
+		Categories: Paved Road Slopes
 		Id: 750
 		Images: prslpe02.sno
 		Size: 3, 1
@@ -16482,7 +16482,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@751:
-		Category: Paved Road Slopes
+		Categories: Paved Road Slopes
 		Id: 751
 		Images: prslpe03.sno
 		Size: 1, 3
@@ -16506,7 +16506,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@752:
-		Category: Paved Road Slopes
+		Categories: Paved Road Slopes
 		Id: 752
 		Images: prslpe04.sno
 		Size: 3, 1
@@ -16530,7 +16530,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@753:
-		Category: Monorail Slopes
+		Categories: Monorail Slopes
 		Id: 753
 		Images: tslope01.sno
 		Size: 1, 1
@@ -16542,7 +16542,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@754:
-		Category: Monorail Slopes
+		Categories: Monorail Slopes
 		Id: 754
 		Images: tslope02.sno
 		Size: 1, 1
@@ -16554,7 +16554,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@755:
-		Category: Monorail Slopes
+		Categories: Monorail Slopes
 		Id: 755
 		Images: tslope03.sno
 		Size: 1, 1
@@ -16566,7 +16566,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@756:
-		Category: Monorail Slopes
+		Categories: Monorail Slopes
 		Id: 756
 		Images: tslope04.sno
 		Size: 1, 1
@@ -16578,7 +16578,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@772:
-		Category: Tunnels
+		Categories: Tunnels
 		Id: 772
 		Images: tunnel01.sno
 		Size: 3, 5
@@ -16659,7 +16659,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@773:
-		Category: Tunnels
+		Categories: Tunnels
 		Id: 773
 		Images: tunnel02.sno
 		Size: 5, 3
@@ -16740,7 +16740,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@774:
-		Category: Tunnels
+		Categories: Tunnels
 		Id: 774
 		Images: tunnel03.sno
 		Size: 3, 4
@@ -16806,7 +16806,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@775:
-		Category: Tunnels
+		Categories: Tunnels
 		Id: 775
 		Images: tunnel04.sno
 		Size: 4, 3
@@ -16872,7 +16872,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@776:
-		Category: Tunnel Side
+		Categories: Tunnel Side
 		Id: 776
 		Images: tunnex01.sno
 		Size: 3, 1
@@ -16894,7 +16894,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@777:
-		Category: Tunnel Side
+		Categories: Tunnel Side
 		Id: 777
 		Images: tunnex02.sno
 		Size: 1, 3
@@ -16915,7 +16915,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@778:
-		Category: TrackTunnel Floor
+		Categories: TrackTunnel Floor
 		Id: 778
 		Images: tunnet01.sno
 		Size: 3, 5
@@ -16996,7 +16996,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@779:
-		Category: TrackTunnel Floor
+		Categories: TrackTunnel Floor
 		Id: 779
 		Images: tunnet02.sno
 		Size: 5, 3
@@ -17077,7 +17077,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@780:
-		Category: TrackTunnel Floor
+		Categories: TrackTunnel Floor
 		Id: 780
 		Images: tunnet03.sno
 		Size: 3, 4
@@ -17143,7 +17143,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@781:
-		Category: TrackTunnel Floor
+		Categories: TrackTunnel Floor
 		Id: 781
 		Images: tunnet04.sno
 		Size: 4, 3
@@ -17209,7 +17209,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@987:
-		Category: Destroyable Cliffs
+		Categories: Destroyable Cliffs
 		Id: 987
 		Images: dcliff01.sno
 		Size: 6, 4
@@ -17325,7 +17325,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@988:
-		Category: Destroyable Cliffs
+		Categories: Destroyable Cliffs
 		Id: 988
 		Images: dcliff02.sno
 		Size: 4, 6
@@ -17441,7 +17441,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@989:
-		Category: Rock LAT
+		Categories: Rock LAT
 		Id: 989
 		Images: rock01.sno, rock01a.sno, rock01b.sno, rock01c.sno, rock01d.sno, rock01e.sno, rock01f.sno, rock01g.sno
 		Size: 1, 1
@@ -17452,7 +17452,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@990:
-		Category: Rock/Clear LAT
+		Categories: Rock/Clear LAT
 		Id: 990
 		Images: rlat01.sno, rlat01a.sno
 		Size: 1, 1
@@ -17463,7 +17463,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@991:
-		Category: Rock/Clear LAT
+		Categories: Rock/Clear LAT
 		Id: 991
 		Images: rlat02.sno, rlat02a.sno
 		Size: 1, 1
@@ -17474,7 +17474,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@992:
-		Category: Rock/Clear LAT
+		Categories: Rock/Clear LAT
 		Id: 992
 		Images: rlat03.sno, rlat03a.sno
 		Size: 1, 1
@@ -17485,7 +17485,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@993:
-		Category: Rock/Clear LAT
+		Categories: Rock/Clear LAT
 		Id: 993
 		Images: rlat04.sno, rlat04a.sno
 		Size: 1, 1
@@ -17496,7 +17496,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@994:
-		Category: Rock/Clear LAT
+		Categories: Rock/Clear LAT
 		Id: 994
 		Images: rlat05.sno, rlat05a.sno
 		Size: 1, 1
@@ -17507,7 +17507,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@995:
-		Category: Rock/Clear LAT
+		Categories: Rock/Clear LAT
 		Id: 995
 		Images: rlat06.sno, rlat06a.sno
 		Size: 1, 1
@@ -17518,7 +17518,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@996:
-		Category: Rock/Clear LAT
+		Categories: Rock/Clear LAT
 		Id: 996
 		Images: rlat07.sno, rlat07a.sno
 		Size: 1, 1
@@ -17529,7 +17529,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@997:
-		Category: Rock/Clear LAT
+		Categories: Rock/Clear LAT
 		Id: 997
 		Images: rlat08.sno, rlat08a.sno
 		Size: 1, 1
@@ -17540,7 +17540,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@998:
-		Category: Rock/Clear LAT
+		Categories: Rock/Clear LAT
 		Id: 998
 		Images: rlat09.sno, rlat09a.sno
 		Size: 1, 1
@@ -17551,7 +17551,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@999:
-		Category: Rock/Clear LAT
+		Categories: Rock/Clear LAT
 		Id: 999
 		Images: rlat10.sno, rlat10a.sno
 		Size: 1, 1
@@ -17562,7 +17562,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1000:
-		Category: Rock/Clear LAT
+		Categories: Rock/Clear LAT
 		Id: 1000
 		Images: rlat11.sno, rlat11a.sno
 		Size: 1, 1
@@ -17573,7 +17573,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1001:
-		Category: Rock/Clear LAT
+		Categories: Rock/Clear LAT
 		Id: 1001
 		Images: rlat12.sno, rlat12a.sno
 		Size: 1, 1
@@ -17584,7 +17584,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1002:
-		Category: Rock/Clear LAT
+		Categories: Rock/Clear LAT
 		Id: 1002
 		Images: rlat13.sno, rlat13a.sno
 		Size: 1, 1
@@ -17595,7 +17595,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1003:
-		Category: Rock/Clear LAT
+		Categories: Rock/Clear LAT
 		Id: 1003
 		Images: rlat14.sno, rlat14a.sno
 		Size: 1, 1
@@ -17606,7 +17606,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1004:
-		Category: Rock/Clear LAT
+		Categories: Rock/Clear LAT
 		Id: 1004
 		Images: rlat15.sno, rlat15a.sno
 		Size: 1, 1
@@ -17617,7 +17617,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1005:
-		Category: Rock/Clear LAT
+		Categories: Rock/Clear LAT
 		Id: 1005
 		Images: rlat16.sno, rlat16a.sno
 		Size: 1, 1
@@ -17628,7 +17628,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1006:
-		Category: Grey
+		Categories: Grey
 		Id: 1006
 		Images: grey01.sno, grey01a.sno, grey01b.sno, grey01c.sno, grey01d.sno, grey01e.sno, grey01f.sno, grey01g.sno
 		Size: 1, 1
@@ -17639,7 +17639,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1007:
-		Category: Grey/Clear LAT
+		Categories: Grey/Clear LAT
 		Id: 1007
 		Images: glat01.sno, glat01a.sno
 		Size: 1, 1
@@ -17650,7 +17650,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1008:
-		Category: Grey/Clear LAT
+		Categories: Grey/Clear LAT
 		Id: 1008
 		Images: glat02.sno, glat02a.sno
 		Size: 1, 1
@@ -17661,7 +17661,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1009:
-		Category: Grey/Clear LAT
+		Categories: Grey/Clear LAT
 		Id: 1009
 		Images: glat03.sno, glat03a.sno
 		Size: 1, 1
@@ -17672,7 +17672,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1010:
-		Category: Grey/Clear LAT
+		Categories: Grey/Clear LAT
 		Id: 1010
 		Images: glat04.sno, glat04a.sno
 		Size: 1, 1
@@ -17683,7 +17683,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1011:
-		Category: Grey/Clear LAT
+		Categories: Grey/Clear LAT
 		Id: 1011
 		Images: glat05.sno, glat05a.sno
 		Size: 1, 1
@@ -17694,7 +17694,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1012:
-		Category: Grey/Clear LAT
+		Categories: Grey/Clear LAT
 		Id: 1012
 		Images: glat06.sno, glat06a.sno
 		Size: 1, 1
@@ -17705,7 +17705,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1013:
-		Category: Grey/Clear LAT
+		Categories: Grey/Clear LAT
 		Id: 1013
 		Images: glat07.sno, glat07a.sno
 		Size: 1, 1
@@ -17716,7 +17716,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1014:
-		Category: Grey/Clear LAT
+		Categories: Grey/Clear LAT
 		Id: 1014
 		Images: glat08.sno, glat08a.sno
 		Size: 1, 1
@@ -17727,7 +17727,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1015:
-		Category: Grey/Clear LAT
+		Categories: Grey/Clear LAT
 		Id: 1015
 		Images: glat09.sno, glat09a.sno
 		Size: 1, 1
@@ -17738,7 +17738,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1016:
-		Category: Grey/Clear LAT
+		Categories: Grey/Clear LAT
 		Id: 1016
 		Images: glat10.sno, glat10a.sno
 		Size: 1, 1
@@ -17749,7 +17749,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1017:
-		Category: Grey/Clear LAT
+		Categories: Grey/Clear LAT
 		Id: 1017
 		Images: glat11.sno, glat11a.sno
 		Size: 1, 1
@@ -17760,7 +17760,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1018:
-		Category: Grey/Clear LAT
+		Categories: Grey/Clear LAT
 		Id: 1018
 		Images: glat12.sno, glat12a.sno
 		Size: 1, 1
@@ -17771,7 +17771,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1019:
-		Category: Grey/Clear LAT
+		Categories: Grey/Clear LAT
 		Id: 1019
 		Images: glat13.sno, glat13a.sno
 		Size: 1, 1
@@ -17782,7 +17782,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1020:
-		Category: Grey/Clear LAT
+		Categories: Grey/Clear LAT
 		Id: 1020
 		Images: glat14.sno, glat14a.sno
 		Size: 1, 1
@@ -17793,7 +17793,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1021:
-		Category: Grey/Clear LAT
+		Categories: Grey/Clear LAT
 		Id: 1021
 		Images: glat15.sno, glat15a.sno
 		Size: 1, 1
@@ -17804,7 +17804,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1022:
-		Category: Grey/Clear LAT
+		Categories: Grey/Clear LAT
 		Id: 1022
 		Images: glat16.sno, glat16a.sno
 		Size: 1, 1
@@ -17815,7 +17815,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1023:
-		Category: DirtTrackTunnel Floor
+		Categories: DirtTrackTunnel Floor
 		Id: 1023
 		Images: dtunnt01.sno
 		Size: 3, 5
@@ -17896,7 +17896,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1024:
-		Category: DirtTrackTunnel Floor
+		Categories: DirtTrackTunnel Floor
 		Id: 1024
 		Images: dtunnt02.sno
 		Size: 5, 3
@@ -17977,7 +17977,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1025:
-		Category: DirtTrackTunnel Floor
+		Categories: DirtTrackTunnel Floor
 		Id: 1025
 		Images: dtunnt03.sno
 		Size: 3, 4
@@ -18043,7 +18043,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1026:
-		Category: DirtTrackTunnel Floor
+		Categories: DirtTrackTunnel Floor
 		Id: 1026
 		Images: dtunnt04.sno
 		Size: 4, 3
@@ -18109,7 +18109,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1027:
-		Category: DirtTunnel Floor
+		Categories: DirtTunnel Floor
 		Id: 1027
 		Images: dtunn01.sno
 		Size: 3, 5
@@ -18190,7 +18190,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1028:
-		Category: DirtTunnel Floor
+		Categories: DirtTunnel Floor
 		Id: 1028
 		Images: dtunn02.sno
 		Size: 5, 3
@@ -18271,7 +18271,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1029:
-		Category: DirtTunnel Floor
+		Categories: DirtTunnel Floor
 		Id: 1029
 		Images: dtunn03.sno
 		Size: 3, 4
@@ -18337,7 +18337,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1030:
-		Category: DirtTunnel Floor
+		Categories: DirtTunnel Floor
 		Id: 1030
 		Images: dtunn04.sno
 		Size: 4, 3
@@ -18403,7 +18403,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1031:
-		Category: Pavement (Use for LAT)
+		Categories: Pavement (Use for LAT)
 		Id: 1031
 		Images: pvclr01.sno, pvclr01a.sno, pvclr01b.sno, pvclr01c.sno, pvclr01d.sno, pvclr01e.sno, pvclr01f.sno, pvclr01g.sno
 		Size: 1, 1
@@ -18414,7 +18414,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1032:
-		Category: Pavement
+		Categories: Pavement
 		Id: 1032
 		Images: pave01.sno
 		Size: 1, 1
@@ -18425,7 +18425,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1033:
-		Category: Pavement
+		Categories: Pavement
 		Id: 1033
 		Images: pave02.sno
 		Size: 1, 1
@@ -18436,7 +18436,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1034:
-		Category: Pavement
+		Categories: Pavement
 		Id: 1034
 		Images: pave03.sno
 		Size: 1, 1
@@ -18447,7 +18447,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1035:
-		Category: Pavement
+		Categories: Pavement
 		Id: 1035
 		Images: pave04.sno
 		Size: 1, 1
@@ -18458,7 +18458,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1036:
-		Category: Pavement
+		Categories: Pavement
 		Id: 1036
 		Images: pave05.sno
 		Size: 2, 2
@@ -18484,7 +18484,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1037:
-		Category: Pavement
+		Categories: Pavement
 		Id: 1037
 		Images: pave06.sno
 		Size: 2, 2
@@ -18510,7 +18510,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1038:
-		Category: Pavement
+		Categories: Pavement
 		Id: 1038
 		Images: pave07.sno
 		Size: 2, 2
@@ -18536,7 +18536,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1039:
-		Category: Pavement
+		Categories: Pavement
 		Id: 1039
 		Images: pave08.sno
 		Size: 2, 2
@@ -18562,7 +18562,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1040:
-		Category: Pavement
+		Categories: Pavement
 		Id: 1040
 		Images: pave09.sno
 		Size: 2, 2
@@ -18588,7 +18588,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1041:
-		Category: Pavement
+		Categories: Pavement
 		Id: 1041
 		Images: pave10.sno
 		Size: 2, 2
@@ -18614,7 +18614,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1042:
-		Category: Pavement
+		Categories: Pavement
 		Id: 1042
 		Images: pave11.sno
 		Size: 2, 2
@@ -18640,7 +18640,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1043:
-		Category: Pavement
+		Categories: Pavement
 		Id: 1043
 		Images: pave12.sno
 		Size: 2, 2
@@ -18666,7 +18666,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1044:
-		Category: Pavement
+		Categories: Pavement
 		Id: 1044
 		Images: pave13.sno
 		Size: 2, 2
@@ -18692,7 +18692,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1045:
-		Category: Pavement
+		Categories: Pavement
 		Id: 1045
 		Images: pave14.sno
 		Size: 2, 2
@@ -18718,7 +18718,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1046:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 1046
 		Images: plat01.sno, plat01a.sno
 		Size: 1, 1
@@ -18729,7 +18729,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1047:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 1047
 		Images: plat02.sno, plat02a.sno
 		Size: 1, 1
@@ -18740,7 +18740,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1048:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 1048
 		Images: plat03.sno, plat03a.sno
 		Size: 1, 1
@@ -18751,7 +18751,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1049:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 1049
 		Images: plat04.sno, plat04a.sno
 		Size: 1, 1
@@ -18762,7 +18762,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1050:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 1050
 		Images: plat05.sno, plat05a.sno
 		Size: 1, 1
@@ -18773,7 +18773,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1051:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 1051
 		Images: plat06.sno, plat06a.sno
 		Size: 1, 1
@@ -18784,7 +18784,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1052:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 1052
 		Images: plat07.sno, plat07a.sno
 		Size: 1, 1
@@ -18795,7 +18795,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1053:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 1053
 		Images: plat08.sno, plat08a.sno
 		Size: 1, 1
@@ -18806,7 +18806,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1054:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 1054
 		Images: plat09.sno, plat09a.sno
 		Size: 1, 1
@@ -18817,7 +18817,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1055:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 1055
 		Images: plat10.sno, plat10a.sno
 		Size: 1, 1
@@ -18828,7 +18828,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1056:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 1056
 		Images: plat11.sno, plat11a.sno
 		Size: 1, 1
@@ -18839,7 +18839,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1057:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 1057
 		Images: plat12.sno, plat12a.sno
 		Size: 1, 1
@@ -18850,7 +18850,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1058:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 1058
 		Images: plat13.sno, plat13a.sno
 		Size: 1, 1
@@ -18861,7 +18861,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1059:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 1059
 		Images: plat14.sno, plat14a.sno
 		Size: 1, 1
@@ -18872,7 +18872,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1060:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 1060
 		Images: plat15.sno, plat15a.sno
 		Size: 1, 1
@@ -18883,7 +18883,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1061:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 1061
 		Images: plat16.sno, plat16a.sno
 		Size: 1, 1

--- a/mods/ts/tilesets/temperate.yaml
+++ b/mods/ts/tilesets/temperate.yaml
@@ -82,7 +82,7 @@ Terrain:
 # Automatically generated. DO NOT EDIT!
 Templates:
 	Template@0:
-		Category: Clear
+		Categories: Clear
 		Id: 0
 		Images: clear01.tem, clear01a.tem, clear01b.tem, clear01c.tem, clear01d.tem, clear01e.tem, clear01f.tem, clear01g.tem
 		Size: 1, 1
@@ -93,7 +93,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1:
-		Category: Misc Buildings
+		Categories: Misc Buildings
 		Id: 1
 		Images: bld01.tem
 		Size: 1, 1
@@ -104,7 +104,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@2:
-		Category: Misc Buildings
+		Categories: Misc Buildings
 		Id: 2
 		Images: bld02.tem
 		Size: 2, 2
@@ -130,7 +130,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@3:
-		Category: Misc Buildings
+		Categories: Misc Buildings
 		Id: 3
 		Images: bld03.tem
 		Size: 3, 3
@@ -181,7 +181,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@4:
-		Category: Clear
+		Categories: Clear
 		Id: 4
 		Images: snow01.tem, snow01a.tem, snow01b.tem, snow01c.tem
 		Size: 1, 1
@@ -192,7 +192,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@5:
-		Category: Clear
+		Categories: Clear
 		Id: 5
 		Images: snow02.tem
 		Size: 1, 1
@@ -203,7 +203,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@6:
-		Category: Clear
+		Categories: Clear
 		Id: 6
 		Images: snow03.tem
 		Size: 1, 1
@@ -214,7 +214,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@7:
-		Category: Clear
+		Categories: Clear
 		Id: 7
 		Images: snow04.tem
 		Size: 1, 1
@@ -225,7 +225,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@8:
-		Category: Cliff Pieces
+		Categories: Cliff Pieces
 		Id: 8
 		Images: clif01.tem
 		Size: 1, 1
@@ -236,7 +236,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@9:
-		Category: Cliff Pieces
+		Categories: Cliff Pieces
 		Id: 9
 		Images: clif02.tem
 		Size: 1, 1
@@ -247,7 +247,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@10:
-		Category: Ice Flow
+		Categories: Ice Flow
 		Id: 10
 		Images: flow01.tem
 		Size: 9, 7
@@ -433,7 +433,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@11:
-		Category: House
+		Categories: House
 		Id: 11
 		Images: house01.tem
 		Size: 2, 2
@@ -459,7 +459,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@12:
-		Category: Blank
+		Categories: Blank
 		Id: 12
 		Images: blank01.tem
 		Size: 1, 1
@@ -470,7 +470,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@40:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 40
 		Images: slope01.tem, slope01a.tem, slope01b.tem, slope01c.tem
 		Size: 1, 1
@@ -482,7 +482,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@41:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 41
 		Images: slope02.tem, slope02a.tem, slope02b.tem, slope02c.tem
 		Size: 1, 1
@@ -494,7 +494,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@42:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 42
 		Images: slope03.tem, slope03a.tem, slope03b.tem, slope03c.tem
 		Size: 1, 1
@@ -506,7 +506,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@43:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 43
 		Images: slope04.tem, slope04a.tem, slope04b.tem, slope04c.tem
 		Size: 1, 1
@@ -518,7 +518,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@44:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 44
 		Images: slope05.tem, slope05a.tem, slope05b.tem, slope05c.tem
 		Size: 1, 1
@@ -530,7 +530,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@45:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 45
 		Images: slope06.tem, slope06a.tem, slope06b.tem, slope06c.tem
 		Size: 1, 1
@@ -542,7 +542,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@46:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 46
 		Images: slope07.tem, slope07a.tem, slope07b.tem, slope07c.tem
 		Size: 1, 1
@@ -554,7 +554,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@47:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 47
 		Images: slope08.tem, slope08a.tem, slope08b.tem, slope08c.tem
 		Size: 1, 1
@@ -566,7 +566,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@48:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 48
 		Images: slope09.tem, slope09a.tem, slope09b.tem, slope09c.tem
 		Size: 1, 1
@@ -578,7 +578,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@49:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 49
 		Images: slope10.tem, slope10a.tem, slope10b.tem, slope10c.tem
 		Size: 1, 1
@@ -590,7 +590,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@50:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 50
 		Images: slope11.tem, slope11a.tem, slope11b.tem, slope11c.tem
 		Size: 1, 1
@@ -602,7 +602,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@51:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 51
 		Images: slope12.tem, slope12a.tem, slope12b.tem, slope12c.tem
 		Size: 1, 1
@@ -614,7 +614,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@52:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 52
 		Images: slope13.tem, slope13a.tem, slope13b.tem, slope13c.tem
 		Size: 1, 1
@@ -626,7 +626,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@53:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 53
 		Images: slope14.tem, slope14a.tem, slope14b.tem, slope14c.tem
 		Size: 1, 1
@@ -638,7 +638,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@54:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 54
 		Images: slope15.tem, slope15a.tem, slope15b.tem, slope15c.tem
 		Size: 1, 1
@@ -650,7 +650,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@55:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 55
 		Images: slope16.tem, slope16a.tem, slope16b.tem, slope16c.tem
 		Size: 1, 1
@@ -662,7 +662,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@56:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 56
 		Images: slope17.tem
 		Size: 1, 1
@@ -674,7 +674,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@57:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 57
 		Images: slope18.tem
 		Size: 1, 1
@@ -686,7 +686,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@58:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 58
 		Images: slope19.tem
 		Size: 1, 1
@@ -698,7 +698,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@59:
-		Category: Ice Ramps
+		Categories: Ice Ramps
 		Id: 59
 		Images: slope20.tem
 		Size: 1, 1
@@ -710,7 +710,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@60:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 60
 		Images: cliff01.tem
 		Size: 2, 3
@@ -738,7 +738,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@61:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 61
 		Images: cliff02.tem
 		Size: 1, 2
@@ -755,7 +755,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@62:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 62
 		Images: cliff03.tem
 		Size: 2, 3
@@ -783,7 +783,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@63:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 63
 		Images: cliff04.tem
 		Size: 2, 3
@@ -811,7 +811,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@64:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 64
 		Images: cliff05.tem
 		Size: 2, 2
@@ -839,7 +839,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@65:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 65
 		Images: cliff06.tem
 		Size: 2, 2
@@ -867,7 +867,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@66:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 66
 		Images: cliff07.tem
 		Size: 2, 2
@@ -895,7 +895,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@67:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 67
 		Images: cliff08.tem
 		Size: 1, 2
@@ -912,7 +912,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@68:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 68
 		Images: cliff09.tem
 		Size: 2, 2
@@ -934,7 +934,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@69:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 69
 		Images: cliff10.tem
 		Size: 2, 2
@@ -956,7 +956,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@70:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 70
 		Images: cliff11.tem
 		Size: 2, 2
@@ -978,7 +978,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@71:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 71
 		Images: cliff12.tem
 		Size: 1, 1
@@ -989,7 +989,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@72:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 72
 		Images: cliff13.tem
 		Size: 1, 1
@@ -1000,7 +1000,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@73:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 73
 		Images: cliff14.tem
 		Size: 1, 1
@@ -1011,7 +1011,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@74:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 74
 		Images: cliff15.tem
 		Size: 2, 2
@@ -1039,7 +1039,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@75:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 75
 		Images: cliff16.tem
 		Size: 2, 2
@@ -1067,7 +1067,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@76:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 76
 		Images: cliff17.tem
 		Size: 2, 2
@@ -1095,7 +1095,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@77:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 77
 		Images: cliff18.tem
 		Size: 2, 1
@@ -1112,7 +1112,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@78:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 78
 		Images: cliff19.tem
 		Size: 3, 2
@@ -1140,7 +1140,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@79:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 79
 		Images: cliff20.tem
 		Size: 3, 2
@@ -1168,7 +1168,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@80:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 80
 		Images: cliff21.tem
 		Size: 3, 2
@@ -1196,7 +1196,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@81:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 81
 		Images: cliff22.tem
 		Size: 2, 1
@@ -1213,7 +1213,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@82:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 82
 		Images: cliff23.tem
 		Size: 2, 1
@@ -1231,7 +1231,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@83:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 83
 		Images: cliff24.tem
 		Size: 2, 1
@@ -1249,7 +1249,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@84:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 84
 		Images: cliff25.tem
 		Size: 2, 1
@@ -1267,7 +1267,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@85:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 85
 		Images: cliff26.tem
 		Size: 1, 1
@@ -1279,7 +1279,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@86:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 86
 		Images: cliff27.tem
 		Size: 2, 2
@@ -1303,7 +1303,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@87:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 87
 		Images: cliff28.tem
 		Size: 2, 2
@@ -1327,7 +1327,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@88:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 88
 		Images: cliff29.tem
 		Size: 1, 1
@@ -1339,7 +1339,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@89:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 89
 		Images: cliff30.tem
 		Size: 1, 1
@@ -1351,7 +1351,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@90:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 90
 		Images: cliff31.tem
 		Size: 2, 2
@@ -1375,7 +1375,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@91:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 91
 		Images: cliff32.tem
 		Size: 2, 2
@@ -1399,7 +1399,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@92:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 92
 		Images: cliff33.tem, cliff33a.tem
 		Size: 1, 1
@@ -1411,7 +1411,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@93:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 93
 		Images: cliff34.tem, cliff34a.tem
 		Size: 1, 1
@@ -1423,7 +1423,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@94:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 94
 		Images: cliff35.tem
 		Size: 1, 2
@@ -1441,7 +1441,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@95:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 95
 		Images: cliff36.tem
 		Size: 1, 2
@@ -1459,7 +1459,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@96:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 96
 		Images: cliff37.tem
 		Size: 1, 2
@@ -1477,7 +1477,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@97:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 97
 		Images: cliff38.tem
 		Size: 1, 1
@@ -1489,7 +1489,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@98:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 98
 		Images: cliff39.tem
 		Size: 1, 1
@@ -1501,7 +1501,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@99:
-		Category: Cliff Set
+		Categories: Cliff Set
 		Id: 99
 		Images: cliff40.tem
 		Size: 1, 1
@@ -1513,7 +1513,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@100:
-		Category: Civilian Buildings
+		Categories: Civilian Buildings
 		Id: 100
 		Images: civ01.tem
 		Size: 3, 3
@@ -1564,7 +1564,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@101:
-		Category: Civilian Buildings
+		Categories: Civilian Buildings
 		Id: 101
 		Images: civ02.tem
 		Size: 1, 2
@@ -1580,7 +1580,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@102:
-		Category: Civilian Buildings
+		Categories: Civilian Buildings
 		Id: 102
 		Images: civ03.tem
 		Size: 1, 1
@@ -1591,7 +1591,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@103:
-		Category: Civilian Buildings
+		Categories: Civilian Buildings
 		Id: 103
 		Images: civ04.tem
 		Size: 1, 2
@@ -1607,7 +1607,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@104:
-		Category: Civilian Buildings
+		Categories: Civilian Buildings
 		Id: 104
 		Images: civ05.tem
 		Size: 2, 2
@@ -1628,7 +1628,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@105:
-		Category: Civilian Buildings
+		Categories: Civilian Buildings
 		Id: 105
 		Images: civ06.tem
 		Size: 3, 3
@@ -1664,7 +1664,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@106:
-		Category: Civilian Buildings
+		Categories: Civilian Buildings
 		Id: 106
 		Images: civ07.tem
 		Size: 1, 1
@@ -1675,7 +1675,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@107:
-		Category: Civilian Buildings
+		Categories: Civilian Buildings
 		Id: 107
 		Images: civ08.tem
 		Size: 1, 2
@@ -1691,7 +1691,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@108:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 108
 		Images: shore01.tem
 		Size: 2, 2
@@ -1717,7 +1717,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@109:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 109
 		Images: shore02.tem
 		Size: 2, 2
@@ -1743,7 +1743,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@110:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 110
 		Images: shore03.tem
 		Size: 2, 2
@@ -1769,7 +1769,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@111:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 111
 		Images: shore04.tem
 		Size: 1, 2
@@ -1785,7 +1785,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@112:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 112
 		Images: shore05.tem
 		Size: 2, 3
@@ -1821,7 +1821,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@113:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 113
 		Images: shore06.tem
 		Size: 2, 3
@@ -1857,7 +1857,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@114:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 114
 		Images: shore07.tem
 		Size: 2, 2
@@ -1883,7 +1883,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@115:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 115
 		Images: shore08.tem
 		Size: 2, 2
@@ -1909,7 +1909,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@116:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 116
 		Images: shore09.tem
 		Size: 2, 2
@@ -1935,7 +1935,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@117:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 117
 		Images: shore10.tem
 		Size: 2, 2
@@ -1961,7 +1961,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@118:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 118
 		Images: shore11.tem
 		Size: 2, 2
@@ -1987,7 +1987,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@119:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 119
 		Images: shore12.tem
 		Size: 2, 1
@@ -2003,7 +2003,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@120:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 120
 		Images: shore13.tem
 		Size: 3, 2
@@ -2039,7 +2039,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@121:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 121
 		Images: shore14.tem
 		Size: 3, 2
@@ -2075,7 +2075,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@122:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 122
 		Images: shore15.tem
 		Size: 2, 2
@@ -2101,7 +2101,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@123:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 123
 		Images: shore16.tem
 		Size: 2, 2
@@ -2127,7 +2127,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@124:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 124
 		Images: shore17.tem
 		Size: 2, 2
@@ -2153,7 +2153,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@125:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 125
 		Images: shore18.tem
 		Size: 2, 2
@@ -2179,7 +2179,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@126:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 126
 		Images: shore19.tem
 		Size: 2, 2
@@ -2205,7 +2205,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@127:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 127
 		Images: shore20.tem
 		Size: 1, 2
@@ -2221,7 +2221,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@128:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 128
 		Images: shore21.tem
 		Size: 2, 3
@@ -2257,7 +2257,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@129:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 129
 		Images: shore22.tem
 		Size: 2, 3
@@ -2293,7 +2293,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@130:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 130
 		Images: shore23.tem
 		Size: 2, 2
@@ -2319,7 +2319,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@131:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 131
 		Images: shore24.tem
 		Size: 2, 2
@@ -2345,7 +2345,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@132:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 132
 		Images: shore25.tem
 		Size: 2, 2
@@ -2371,7 +2371,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@133:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 133
 		Images: shore26.tem
 		Size: 2, 2
@@ -2397,7 +2397,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@134:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 134
 		Images: shore27.tem
 		Size: 2, 2
@@ -2423,7 +2423,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@135:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 135
 		Images: shore28.tem
 		Size: 2, 1
@@ -2439,7 +2439,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@136:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 136
 		Images: shore29.tem
 		Size: 3, 2
@@ -2475,7 +2475,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@137:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 137
 		Images: shore30.tem
 		Size: 3, 2
@@ -2511,7 +2511,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@138:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 138
 		Images: shore31.tem
 		Size: 2, 2
@@ -2537,7 +2537,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@139:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 139
 		Images: shore32.tem
 		Size: 2, 2
@@ -2563,7 +2563,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@140:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 140
 		Images: shore33.tem
 		Size: 2, 2
@@ -2589,7 +2589,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@141:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 141
 		Images: shore34.tem
 		Size: 2, 2
@@ -2615,7 +2615,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@142:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 142
 		Images: shore35.tem
 		Size: 2, 2
@@ -2641,7 +2641,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@143:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 143
 		Images: shore36.tem
 		Size: 2, 2
@@ -2667,7 +2667,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@144:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 144
 		Images: shore37.tem
 		Size: 2, 2
@@ -2693,7 +2693,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@145:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 145
 		Images: shore38.tem
 		Size: 2, 2
@@ -2719,7 +2719,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@146:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 146
 		Images: shore39.tem
 		Size: 2, 2
@@ -2745,7 +2745,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@147:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 147
 		Images: shore40.tem
 		Size: 2, 2
@@ -2771,7 +2771,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@148:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 148
 		Images: shore41.tem
 		Size: 6, 4
@@ -2882,7 +2882,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@149:
-		Category: Shore Pieces
+		Categories: Shore Pieces
 		Id: 149
 		Images: shore42.tem
 		Size: 9, 5
@@ -3038,7 +3038,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@150:
-		Category: Rough LAT tile
+		Categories: Rough LAT tile
 		Id: 150
 		Images: ruff01.tem, ruff01a.tem, ruff01b.tem, ruff01c.tem, ruff01d.tem, ruff01e.tem, ruff01f.tem, ruff01g.tem
 		Size: 1, 1
@@ -3049,7 +3049,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@151:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 151
 		Images: clat01.tem, clat01a.tem
 		Size: 1, 1
@@ -3060,7 +3060,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@152:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 152
 		Images: clat02.tem, clat02a.tem
 		Size: 1, 1
@@ -3071,7 +3071,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@153:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 153
 		Images: clat03.tem, clat03a.tem
 		Size: 1, 1
@@ -3082,7 +3082,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@154:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 154
 		Images: clat04.tem, clat04a.tem
 		Size: 1, 1
@@ -3093,7 +3093,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@155:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 155
 		Images: clat05.tem, clat05a.tem
 		Size: 1, 1
@@ -3104,7 +3104,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@156:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 156
 		Images: clat06.tem, clat06a.tem
 		Size: 1, 1
@@ -3115,7 +3115,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@157:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 157
 		Images: clat07.tem, clat07a.tem
 		Size: 1, 1
@@ -3126,7 +3126,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@158:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 158
 		Images: clat08.tem, clat08a.tem
 		Size: 1, 1
@@ -3137,7 +3137,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@159:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 159
 		Images: clat09.tem, clat09a.tem
 		Size: 1, 1
@@ -3148,7 +3148,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@160:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 160
 		Images: clat10.tem, clat10a.tem
 		Size: 1, 1
@@ -3159,7 +3159,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@161:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 161
 		Images: clat11.tem, clat11a.tem
 		Size: 1, 1
@@ -3170,7 +3170,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@162:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 162
 		Images: clat12.tem, clat12a.tem
 		Size: 1, 1
@@ -3181,7 +3181,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@163:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 163
 		Images: clat13.tem, clat13a.tem
 		Size: 1, 1
@@ -3192,7 +3192,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@164:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 164
 		Images: clat14.tem, clat14a.tem
 		Size: 1, 1
@@ -3203,7 +3203,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@165:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 165
 		Images: clat15.tem, clat15a.tem
 		Size: 1, 1
@@ -3214,7 +3214,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@166:
-		Category: Clear/Rough LAT
+		Categories: Clear/Rough LAT
 		Id: 166
 		Images: clat16.tem, clat16a.tem
 		Size: 1, 1
@@ -3225,7 +3225,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@167:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 167
 		Images: wcliff01.tem
 		Size: 2, 3
@@ -3253,7 +3253,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@168:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 168
 		Images: wcliff02.tem
 		Size: 1, 2
@@ -3270,7 +3270,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@169:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 169
 		Images: wcliff03.tem
 		Size: 2, 3
@@ -3298,7 +3298,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@170:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 170
 		Images: wcliff04.tem
 		Size: 2, 3
@@ -3326,7 +3326,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@171:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 171
 		Images: wcliff05.tem
 		Size: 2, 2
@@ -3354,7 +3354,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@172:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 172
 		Images: wcliff06.tem
 		Size: 2, 2
@@ -3382,7 +3382,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@173:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 173
 		Images: wcliff07.tem
 		Size: 2, 2
@@ -3410,7 +3410,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@174:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 174
 		Images: wcliff08.tem
 		Size: 1, 2
@@ -3427,7 +3427,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@175:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 175
 		Images: wcliff09.tem
 		Size: 2, 2
@@ -3449,7 +3449,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@176:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 176
 		Images: wcliff10.tem
 		Size: 2, 2
@@ -3476,7 +3476,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@177:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 177
 		Images: wcliff11.tem
 		Size: 2, 2
@@ -3498,7 +3498,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@178:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 178
 		Images: wcliff12.tem
 		Size: 1, 1
@@ -3509,7 +3509,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@179:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 179
 		Images: wcliff13.tem
 		Size: 1, 1
@@ -3520,7 +3520,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@180:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 180
 		Images: wcliff14.tem
 		Size: 1, 1
@@ -3531,7 +3531,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@181:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 181
 		Images: wcliff15.tem
 		Size: 2, 2
@@ -3559,7 +3559,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@182:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 182
 		Images: wcliff16.tem
 		Size: 2, 2
@@ -3587,7 +3587,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@183:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 183
 		Images: wcliff17.tem
 		Size: 2, 2
@@ -3615,7 +3615,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@184:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 184
 		Images: wcliff18.tem
 		Size: 2, 1
@@ -3632,7 +3632,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@185:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 185
 		Images: wcliff19.tem
 		Size: 3, 2
@@ -3660,7 +3660,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@186:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 186
 		Images: wcliff20.tem
 		Size: 3, 2
@@ -3688,7 +3688,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@187:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 187
 		Images: wcliff21.tem
 		Size: 3, 2
@@ -3716,7 +3716,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@188:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 188
 		Images: wcliff22.tem
 		Size: 2, 1
@@ -3733,7 +3733,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@189:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 189
 		Images: wcliff23.tem
 		Size: 2, 3
@@ -3766,7 +3766,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@190:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 190
 		Images: wcliff24.tem
 		Size: 1, 2
@@ -3782,7 +3782,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@191:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 191
 		Images: wcliff25.tem
 		Size: 2, 1
@@ -3798,7 +3798,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@192:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 192
 		Images: wcliff26.tem
 		Size: 2, 1
@@ -3814,7 +3814,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@193:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 193
 		Images: wcliff27.tem
 		Size: 1, 2
@@ -3830,7 +3830,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@194:
-		Category: Cliff/Water pieces
+		Categories: Cliff/Water pieces
 		Id: 194
 		Images: wcliff28.tem
 		Size: 3, 2
@@ -3863,7 +3863,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@195:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 195
 		Images: droadc01.tem
 		Size: 3, 2
@@ -3894,7 +3894,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@196:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 196
 		Images: droadc02.tem
 		Size: 2, 2
@@ -3920,7 +3920,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@197:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 197
 		Images: droadc03.tem
 		Size: 2, 2
@@ -3946,7 +3946,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@198:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 198
 		Images: droadc04.tem
 		Size: 2, 2
@@ -3967,7 +3967,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@199:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 199
 		Images: droadc05.tem
 		Size: 2, 2
@@ -3993,7 +3993,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@200:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 200
 		Images: droadc06.tem
 		Size: 3, 2
@@ -4024,7 +4024,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@201:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 201
 		Images: droadc07.tem
 		Size: 2, 3
@@ -4055,7 +4055,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@202:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 202
 		Images: droadc08.tem
 		Size: 2, 2
@@ -4081,7 +4081,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@203:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 203
 		Images: droadc09.tem
 		Size: 2, 2
@@ -4107,7 +4107,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@204:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 204
 		Images: droadc10.tem
 		Size: 2, 2
@@ -4133,7 +4133,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@205:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 205
 		Images: droadc11.tem
 		Size: 3, 2
@@ -4164,7 +4164,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@206:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 206
 		Images: droadc12.tem
 		Size: 3, 2
@@ -4195,7 +4195,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@207:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 207
 		Images: droadc13.tem
 		Size: 2, 3
@@ -4231,7 +4231,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@208:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 208
 		Images: droadc14.tem
 		Size: 2, 2
@@ -4257,7 +4257,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@209:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 209
 		Images: droadc15.tem
 		Size: 2, 2
@@ -4278,7 +4278,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@210:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 210
 		Images: droadc16.tem
 		Size: 2, 2
@@ -4299,7 +4299,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@211:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 211
 		Images: droadc17.tem
 		Size: 3, 2
@@ -4335,7 +4335,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@212:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 212
 		Images: droadc18.tem
 		Size: 2, 2
@@ -4356,7 +4356,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@213:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 213
 		Images: droadc19.tem
 		Size: 2, 2
@@ -4382,7 +4382,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@214:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 214
 		Images: droadc20.tem
 		Size: 3, 2
@@ -4413,7 +4413,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@215:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 215
 		Images: droadc21.tem
 		Size: 2, 2
@@ -4439,7 +4439,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@216:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 216
 		Images: droadc22.tem
 		Size: 2, 2
@@ -4460,7 +4460,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@217:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 217
 		Images: droadc23.tem
 		Size: 2, 3
@@ -4486,7 +4486,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@218:
-		Category: Bendy Dirt Roads
+		Categories: Bendy Dirt Roads
 		Id: 218
 		Images: droadc24.tem
 		Size: 2, 3
@@ -4517,7 +4517,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@219:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 219
 		Images: droadj01.tem
 		Size: 2, 2
@@ -4543,7 +4543,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@220:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 220
 		Images: droadj02.tem
 		Size: 2, 2
@@ -4569,7 +4569,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@221:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 221
 		Images: droadj03.tem
 		Size: 2, 2
@@ -4595,7 +4595,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@222:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 222
 		Images: droadj04.tem
 		Size: 2, 2
@@ -4621,7 +4621,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@223:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 223
 		Images: droadj05.tem
 		Size: 2, 2
@@ -4647,7 +4647,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@224:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 224
 		Images: droadj06.tem
 		Size: 3, 3
@@ -4688,7 +4688,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@225:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 225
 		Images: droadj07.tem
 		Size: 3, 3
@@ -4724,7 +4724,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@226:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 226
 		Images: droadj08.tem
 		Size: 3, 3
@@ -4760,7 +4760,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@227:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 227
 		Images: droadj09.tem
 		Size: 3, 3
@@ -4801,7 +4801,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@228:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 228
 		Images: droadj10.tem
 		Size: 3, 3
@@ -4842,7 +4842,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@229:
-		Category: Dirt Road Junctions
+		Categories: Dirt Road Junctions
 		Id: 229
 		Images: droadj11.tem
 		Size: 4, 4
@@ -4913,7 +4913,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@230:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 230
 		Images: droads01.tem
 		Size: 4, 4
@@ -4964,7 +4964,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@231:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 231
 		Images: droads02.tem
 		Size: 4, 4
@@ -5015,7 +5015,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@232:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 232
 		Images: droads03.tem
 		Size: 4, 4
@@ -5066,7 +5066,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@233:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 233
 		Images: droads04.tem
 		Size: 4, 4
@@ -5132,7 +5132,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@234:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 234
 		Images: droads05.tem
 		Size: 3, 3
@@ -5168,7 +5168,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@235:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 235
 		Images: droads06.tem
 		Size: 2, 2
@@ -5189,7 +5189,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@236:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 236
 		Images: droads07.tem
 		Size: 2, 2
@@ -5210,7 +5210,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@237:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 237
 		Images: droads08.tem
 		Size: 4, 4
@@ -5256,7 +5256,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@238:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 238
 		Images: droads09.tem
 		Size: 4, 3
@@ -5307,7 +5307,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@239:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 239
 		Images: droads10.tem
 		Size: 3, 3
@@ -5343,7 +5343,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@240:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 240
 		Images: droads11.tem
 		Size: 4, 4
@@ -5394,7 +5394,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@241:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 241
 		Images: droads12.tem
 		Size: 3, 4
@@ -5445,7 +5445,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@242:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 242
 		Images: droads13.tem
 		Size: 3, 3
@@ -5481,7 +5481,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@243:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 243
 		Images: droads14.tem
 		Size: 5, 3
@@ -5537,7 +5537,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@244:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 244
 		Images: droads15.tem
 		Size: 3, 5
@@ -5593,7 +5593,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@245:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 245
 		Images: droads16.tem
 		Size: 2, 4
@@ -5629,7 +5629,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@246:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 246
 		Images: droads17.tem
 		Size: 4, 2
@@ -5675,7 +5675,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@247:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 247
 		Images: droads18.tem
 		Size: 4, 2
@@ -5721,7 +5721,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@248:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 248
 		Images: droads19.tem
 		Size: 4, 2
@@ -5767,7 +5767,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@249:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 249
 		Images: droads20.tem
 		Size: 4, 2
@@ -5813,7 +5813,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@250:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 250
 		Images: droads21.tem
 		Size: 3, 2
@@ -5849,7 +5849,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@251:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 251
 		Images: droads22.tem
 		Size: 2, 2
@@ -5875,7 +5875,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@252:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 252
 		Images: droads23.tem
 		Size: 1, 2
@@ -5891,7 +5891,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@253:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 253
 		Images: droads24.tem
 		Size: 1, 2
@@ -5907,7 +5907,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@254:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 254
 		Images: droads25.tem
 		Size: 3, 2
@@ -5943,7 +5943,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@255:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 255
 		Images: droads26.tem
 		Size: 2, 2
@@ -5969,7 +5969,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@256:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 256
 		Images: droads27.tem
 		Size: 3, 3
@@ -6010,7 +6010,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@257:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 257
 		Images: droads28.tem
 		Size: 3, 2
@@ -6046,7 +6046,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@258:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 258
 		Images: droads29.tem
 		Size: 2, 2
@@ -6072,7 +6072,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@259:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 259
 		Images: droads30.tem
 		Size: 2, 2
@@ -6098,7 +6098,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@260:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 260
 		Images: droads31.tem
 		Size: 4, 3
@@ -6144,7 +6144,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@261:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 261
 		Images: droads32.tem
 		Size: 4, 3
@@ -6190,7 +6190,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@262:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 262
 		Images: droads33.tem
 		Size: 4, 2
@@ -6236,7 +6236,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@263:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 263
 		Images: droads34.tem
 		Size: 4, 4
@@ -6287,7 +6287,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@264:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 264
 		Images: droads35.tem
 		Size: 4, 4
@@ -6338,7 +6338,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@265:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 265
 		Images: droads36.tem
 		Size: 4, 4
@@ -6389,7 +6389,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@266:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 266
 		Images: droads37.tem
 		Size: 4, 4
@@ -6440,7 +6440,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@267:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 267
 		Images: droads38.tem
 		Size: 3, 3
@@ -6476,7 +6476,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@268:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 268
 		Images: droads39.tem
 		Size: 2, 2
@@ -6497,7 +6497,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@269:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 269
 		Images: droads40.tem
 		Size: 2, 2
@@ -6518,7 +6518,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@270:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 270
 		Images: droads41.tem
 		Size: 4, 4
@@ -6569,7 +6569,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@271:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 271
 		Images: droads42.tem
 		Size: 4, 5
@@ -6625,7 +6625,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@272:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 272
 		Images: droads43.tem
 		Size: 3, 3
@@ -6661,7 +6661,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@273:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 273
 		Images: droads44.tem
 		Size: 4, 4
@@ -6712,7 +6712,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@274:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 274
 		Images: droads45.tem
 		Size: 2, 3
@@ -6748,7 +6748,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@275:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 275
 		Images: droads46.tem
 		Size: 3, 3
@@ -6784,7 +6784,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@276:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 276
 		Images: droads47.tem
 		Size: 5, 3
@@ -6845,7 +6845,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@277:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 277
 		Images: droads48.tem
 		Size: 3, 5
@@ -6901,7 +6901,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@278:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 278
 		Images: droads49.tem
 		Size: 4, 4
@@ -6952,7 +6952,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@279:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 279
 		Images: droads50.tem
 		Size: 2, 4
@@ -6998,7 +6998,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@280:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 280
 		Images: droads51.tem
 		Size: 2, 4
@@ -7044,7 +7044,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@281:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 281
 		Images: droads52.tem
 		Size: 2, 4
@@ -7090,7 +7090,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@282:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 282
 		Images: droads53.tem
 		Size: 2, 4
@@ -7136,7 +7136,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@283:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 283
 		Images: droads54.tem
 		Size: 2, 3
@@ -7172,7 +7172,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@284:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 284
 		Images: droads55.tem
 		Size: 2, 2
@@ -7198,7 +7198,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@285:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 285
 		Images: droads56.tem
 		Size: 2, 1
@@ -7214,7 +7214,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@286:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 286
 		Images: droads57.tem
 		Size: 2, 1
@@ -7230,7 +7230,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@287:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 287
 		Images: droads58.tem
 		Size: 2, 4
@@ -7276,7 +7276,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@288:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 288
 		Images: droads59.tem
 		Size: 3, 3
@@ -7317,7 +7317,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@289:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 289
 		Images: droads60.tem
 		Size: 2, 3
@@ -7348,7 +7348,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@290:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 290
 		Images: droads61.tem
 		Size: 2, 4
@@ -7389,7 +7389,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@291:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 291
 		Images: droads62.tem
 		Size: 2, 4
@@ -7435,7 +7435,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@292:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 292
 		Images: droads63.tem
 		Size: 2, 2
@@ -7461,7 +7461,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@293:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 293
 		Images: droads64.tem
 		Size: 3, 4
@@ -7507,7 +7507,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@294:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 294
 		Images: droads65.tem
 		Size: 3, 4
@@ -7553,7 +7553,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@295:
-		Category: Straight Dirt Roads
+		Categories: Straight Dirt Roads
 		Id: 295
 		Images: droads66.tem
 		Size: 2, 3
@@ -7584,7 +7584,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@296:
-		Category: Bridges
+		Categories: Bridges
 		Id: 296
 		Images: ovrps01.tem
 		Size: 3, 5
@@ -7673,7 +7673,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@297:
-		Category: Bridges
+		Categories: Bridges
 		Id: 297
 		Images: ovrps02.tem
 		Size: 3, 5
@@ -7762,7 +7762,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@298:
-		Category: Bridges
+		Categories: Bridges
 		Id: 298
 		Images: ovrps03.tem
 		Size: 2, 5
@@ -7826,7 +7826,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@299:
-		Category: Bridges
+		Categories: Bridges
 		Id: 299
 		Images: ovrps04.tem
 		Size: 5, 3
@@ -7915,7 +7915,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@300:
-		Category: Bridges
+		Categories: Bridges
 		Id: 300
 		Images: ovrps05.tem
 		Size: 5, 3
@@ -8004,7 +8004,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@301:
-		Category: Bridges
+		Categories: Bridges
 		Id: 301
 		Images: ovrps06.tem
 		Size: 5, 2
@@ -8068,7 +8068,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@302:
-		Category: Bridges
+		Categories: Bridges
 		Id: 302
 		Images: ovrps07.tem
 		Size: 2, 5
@@ -8127,7 +8127,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@303:
-		Category: Bridges
+		Categories: Bridges
 		Id: 303
 		Images: ovrps08.tem
 		Size: 2, 5
@@ -8186,7 +8186,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@304:
-		Category: Bridges
+		Categories: Bridges
 		Id: 304
 		Images: ovrps09.tem
 		Size: 2, 5
@@ -8245,7 +8245,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@305:
-		Category: Bridges
+		Categories: Bridges
 		Id: 305
 		Images: ovrps10.tem
 		Size: 2, 5
@@ -8304,7 +8304,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@306:
-		Category: Bridges
+		Categories: Bridges
 		Id: 306
 		Images: ovrps11.tem
 		Size: 2, 5
@@ -8360,7 +8360,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@307:
-		Category: Bridges
+		Categories: Bridges
 		Id: 307
 		Images: ovrps12.tem
 		Size: 5, 2
@@ -8414,7 +8414,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@308:
-		Category: Bridges
+		Categories: Bridges
 		Id: 308
 		Images: ovrps13.tem
 		Size: 5, 2
@@ -8468,7 +8468,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@309:
-		Category: Bridges
+		Categories: Bridges
 		Id: 309
 		Images: ovrps14.tem
 		Size: 5, 2
@@ -8522,7 +8522,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@310:
-		Category: Bridges
+		Categories: Bridges
 		Id: 310
 		Images: ovrps15.tem
 		Size: 5, 2
@@ -8576,7 +8576,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@311:
-		Category: Bridges
+		Categories: Bridges
 		Id: 311
 		Images: ovrps16.tem
 		Size: 5, 2
@@ -8630,7 +8630,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@312:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 312
 		Images: proad01.tem, proad01a.tem, proad01b.tem, proad01c.tem
 		Size: 1, 3
@@ -8651,7 +8651,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@313:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 313
 		Images: proad02.tem, proad02a.tem, proad02b.tem, proad02c.tem
 		Size: 3, 1
@@ -8672,7 +8672,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@314:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 314
 		Images: proad03.tem
 		Size: 3, 3
@@ -8723,7 +8723,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@315:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 315
 		Images: proad04.tem
 		Size: 3, 3
@@ -8774,7 +8774,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@316:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 316
 		Images: proad05.tem
 		Size: 3, 3
@@ -8825,7 +8825,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@317:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 317
 		Images: proad06.tem
 		Size: 3, 3
@@ -8876,7 +8876,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@318:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 318
 		Images: proad07.tem
 		Size: 3, 3
@@ -8927,7 +8927,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@319:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 319
 		Images: proad08.tem
 		Size: 3, 3
@@ -8978,7 +8978,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@320:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 320
 		Images: proad09.tem
 		Size: 3, 3
@@ -9029,7 +9029,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@321:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 321
 		Images: proad10.tem
 		Size: 4, 3
@@ -9095,7 +9095,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@322:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 322
 		Images: proad11.tem
 		Size: 4, 3
@@ -9161,7 +9161,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@323:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 323
 		Images: proad12.tem
 		Size: 4, 3
@@ -9227,7 +9227,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@324:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 324
 		Images: proad13.tem
 		Size: 3, 4
@@ -9293,7 +9293,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@325:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 325
 		Images: proad14.tem
 		Size: 3, 4
@@ -9359,7 +9359,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@326:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 326
 		Images: proad15.tem
 		Size: 3, 4
@@ -9425,7 +9425,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@327:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 327
 		Images: proad16.tem
 		Size: 4, 5
@@ -9511,7 +9511,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@328:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 328
 		Images: proad17.tem
 		Size: 4, 4
@@ -9587,7 +9587,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@329:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 329
 		Images: proad18.tem
 		Size: 4, 5
@@ -9673,7 +9673,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@330:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 330
 		Images: proad19.tem
 		Size: 5, 4
@@ -9759,7 +9759,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@331:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 331
 		Images: proad20.tem
 		Size: 4, 4
@@ -9835,7 +9835,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@332:
-		Category: Paved Roads
+		Categories: Paved Roads
 		Id: 332
 		Images: proad21.tem
 		Size: 5, 4
@@ -9921,7 +9921,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@333:
-		Category: Water
+		Categories: Water
 		Id: 333
 		Images: water01.tem
 		Size: 2, 2
@@ -9947,7 +9947,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@334:
-		Category: Water
+		Categories: Water
 		Id: 334
 		Images: water02.tem
 		Size: 2, 2
@@ -9973,7 +9973,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@335:
-		Category: Water
+		Categories: Water
 		Id: 335
 		Images: water03.tem
 		Size: 2, 2
@@ -9999,7 +9999,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@336:
-		Category: Water
+		Categories: Water
 		Id: 336
 		Images: water04.tem
 		Size: 2, 2
@@ -10025,7 +10025,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@337:
-		Category: Water
+		Categories: Water
 		Id: 337
 		Images: water05.tem
 		Size: 2, 2
@@ -10051,7 +10051,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@338:
-		Category: Water
+		Categories: Water
 		Id: 338
 		Images: water06.tem
 		Size: 2, 2
@@ -10077,7 +10077,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@339:
-		Category: Water
+		Categories: Water
 		Id: 339
 		Images: water07.tem
 		Size: 2, 2
@@ -10103,7 +10103,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@340:
-		Category: Water
+		Categories: Water
 		Id: 340
 		Images: water08.tem
 		Size: 2, 2
@@ -10129,7 +10129,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@341:
-		Category: Water
+		Categories: Water
 		Id: 341
 		Images: water09.tem
 		Size: 1, 1
@@ -10140,7 +10140,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@342:
-		Category: Water
+		Categories: Water
 		Id: 342
 		Images: water10.tem
 		Size: 1, 1
@@ -10151,7 +10151,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@343:
-		Category: Water
+		Categories: Water
 		Id: 343
 		Images: water11.tem
 		Size: 1, 1
@@ -10162,7 +10162,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@344:
-		Category: Water
+		Categories: Water
 		Id: 344
 		Images: water12.tem
 		Size: 1, 1
@@ -10173,7 +10173,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@345:
-		Category: Water
+		Categories: Water
 		Id: 345
 		Images: water13.tem
 		Size: 1, 1
@@ -10184,7 +10184,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@346:
-		Category: Water
+		Categories: Water
 		Id: 346
 		Images: water14.tem
 		Size: 1, 1
@@ -10195,7 +10195,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@387:
-		Category: Dirt Road Slopes
+		Categories: Dirt Road Slopes
 		Id: 387
 		Images: drslpe01.tem
 		Size: 1, 2
@@ -10213,7 +10213,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@388:
-		Category: Dirt Road Slopes
+		Categories: Dirt Road Slopes
 		Id: 388
 		Images: drslpe02.tem
 		Size: 1, 2
@@ -10231,7 +10231,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@389:
-		Category: Dirt Road Slopes
+		Categories: Dirt Road Slopes
 		Id: 389
 		Images: drslpe03.tem
 		Size: 2, 1
@@ -10249,7 +10249,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@390:
-		Category: Dirt Road Slopes
+		Categories: Dirt Road Slopes
 		Id: 390
 		Images: drslpe04.tem
 		Size: 2, 1
@@ -10267,7 +10267,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@391:
-		Category: Dirt Road Slopes
+		Categories: Dirt Road Slopes
 		Id: 391
 		Images: drslpe05.tem
 		Size: 1, 2
@@ -10285,7 +10285,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@392:
-		Category: Dirt Road Slopes
+		Categories: Dirt Road Slopes
 		Id: 392
 		Images: drslpe06.tem
 		Size: 1, 2
@@ -10303,7 +10303,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@393:
-		Category: Dirt Road Slopes
+		Categories: Dirt Road Slopes
 		Id: 393
 		Images: drslpe07.tem
 		Size: 2, 1
@@ -10321,7 +10321,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@394:
-		Category: Dirt Road Slopes
+		Categories: Dirt Road Slopes
 		Id: 394
 		Images: drslpe08.tem
 		Size: 2, 1
@@ -10339,7 +10339,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@403:
-		Category: Slope Set Pieces
+		Categories: Slope Set Pieces
 		Id: 403
 		Images: ramp01.tem
 		Size: 3, 4
@@ -10409,7 +10409,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@404:
-		Category: Slope Set Pieces
+		Categories: Slope Set Pieces
 		Id: 404
 		Images: ramp02.tem
 		Size: 3, 4
@@ -10479,7 +10479,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@405:
-		Category: Slope Set Pieces
+		Categories: Slope Set Pieces
 		Id: 405
 		Images: ramp03.tem
 		Size: 4, 3
@@ -10549,7 +10549,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@406:
-		Category: Slope Set Pieces
+		Categories: Slope Set Pieces
 		Id: 406
 		Images: ramp04.tem
 		Size: 4, 3
@@ -10619,7 +10619,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@407:
-		Category: Slope Set Pieces
+		Categories: Slope Set Pieces
 		Id: 407
 		Images: ramp05.tem
 		Size: 3, 4
@@ -10688,7 +10688,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@408:
-		Category: Slope Set Pieces
+		Categories: Slope Set Pieces
 		Id: 408
 		Images: ramp06.tem
 		Size: 3, 4
@@ -10738,7 +10738,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@409:
-		Category: Slope Set Pieces
+		Categories: Slope Set Pieces
 		Id: 409
 		Images: ramp07.tem
 		Size: 2, 2
@@ -10764,7 +10764,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@410:
-		Category: Slope Set Pieces
+		Categories: Slope Set Pieces
 		Id: 410
 		Images: ramp08.tem
 		Size: 4, 3
@@ -10833,7 +10833,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@411:
-		Category: Slope Set Pieces
+		Categories: Slope Set Pieces
 		Id: 411
 		Images: ramp09.tem
 		Size: 4, 3
@@ -10883,7 +10883,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@412:
-		Category: Slope Set Pieces
+		Categories: Slope Set Pieces
 		Id: 412
 		Images: ramp10.tem
 		Size: 2, 2
@@ -10909,7 +10909,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@423:
-		Category: Dead Oil Tanker
+		Categories: Dead Oil Tanker
 		Id: 423
 		Images: tanker01.tem
 		Size: 5, 8
@@ -11043,7 +11043,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@424:
-		Category: Ruins
+		Categories: Ruins
 		Id: 424
 		Images: ruin01.tem
 		Size: 3, 3
@@ -11084,7 +11084,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@435:
-		Category: Waterfalls
+		Categories: Waterfalls
 		Id: 435
 		Images: w-a-01.tem
 		Size: 2, 4
@@ -11134,7 +11134,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@436:
-		Category: Waterfalls
+		Categories: Waterfalls
 		Id: 436
 		Images: w-a-02.tem
 		Size: 1, 4
@@ -11162,7 +11162,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@437:
-		Category: Waterfalls
+		Categories: Waterfalls
 		Id: 437
 		Images: w-a-03.tem
 		Size: 2, 4
@@ -11212,7 +11212,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@438:
-		Category: Waterfalls
+		Categories: Waterfalls
 		Id: 438
 		Images: w-a-04.tem
 		Size: 2, 4
@@ -11262,7 +11262,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@439:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 439
 		Images: des0101.tem
 		Size: 1, 1
@@ -11273,7 +11273,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@440:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 440
 		Images: des0102.tem
 		Size: 1, 1
@@ -11284,7 +11284,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@441:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 441
 		Images: des0103.tem
 		Size: 1, 1
@@ -11295,7 +11295,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@442:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 442
 		Images: des0104.tem
 		Size: 1, 1
@@ -11306,7 +11306,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@443:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 443
 		Images: des0105.tem
 		Size: 1, 1
@@ -11317,7 +11317,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@444:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 444
 		Images: des0106.tem
 		Size: 1, 1
@@ -11328,7 +11328,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@445:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 445
 		Images: des0107.tem
 		Size: 1, 1
@@ -11339,7 +11339,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@446:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 446
 		Images: des0108.tem
 		Size: 1, 1
@@ -11350,7 +11350,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@447:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 447
 		Images: des0109.tem
 		Size: 1, 1
@@ -11361,7 +11361,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@448:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 448
 		Images: des0110.tem
 		Size: 1, 1
@@ -11372,7 +11372,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@449:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 449
 		Images: des0111.tem
 		Size: 1, 1
@@ -11383,7 +11383,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@450:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 450
 		Images: des0112.tem
 		Size: 1, 1
@@ -11394,7 +11394,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@451:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 451
 		Images: des0113.tem
 		Size: 1, 1
@@ -11405,7 +11405,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@452:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 452
 		Images: des0114.tem
 		Size: 1, 1
@@ -11416,7 +11416,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@453:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 453
 		Images: des0115.tem
 		Size: 1, 1
@@ -11427,7 +11427,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@454:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 454
 		Images: des0116.tem
 		Size: 1, 1
@@ -11438,7 +11438,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@455:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 455
 		Images: des0117.tem
 		Size: 1, 1
@@ -11449,7 +11449,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@456:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 456
 		Images: des0118.tem
 		Size: 1, 1
@@ -11460,7 +11460,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@457:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 457
 		Images: des0119.tem
 		Size: 1, 1
@@ -11471,7 +11471,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@458:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 458
 		Images: des0120.tem
 		Size: 1, 1
@@ -11482,7 +11482,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@459:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 459
 		Images: des0121.tem
 		Size: 1, 1
@@ -11493,7 +11493,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@460:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 460
 		Images: des0122.tem
 		Size: 1, 1
@@ -11504,7 +11504,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@461:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 461
 		Images: des0123.tem
 		Size: 1, 1
@@ -11515,7 +11515,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@462:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 462
 		Images: des0124.tem
 		Size: 1, 1
@@ -11526,7 +11526,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@463:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 463
 		Images: des0125.tem
 		Size: 1, 1
@@ -11537,7 +11537,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@464:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 464
 		Images: des0126.tem
 		Size: 1, 1
@@ -11548,7 +11548,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@465:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 465
 		Images: des0127.tem
 		Size: 1, 1
@@ -11559,7 +11559,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@466:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 466
 		Images: des0128.tem
 		Size: 1, 1
@@ -11570,7 +11570,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@467:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 467
 		Images: des0129.tem
 		Size: 1, 1
@@ -11581,7 +11581,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@468:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 468
 		Images: des0130.tem
 		Size: 1, 1
@@ -11592,7 +11592,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@469:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 469
 		Images: des0131.tem
 		Size: 1, 1
@@ -11603,7 +11603,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@470:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 470
 		Images: des0132.tem
 		Size: 1, 1
@@ -11614,7 +11614,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@471:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 471
 		Images: des0133.tem
 		Size: 1, 1
@@ -11625,7 +11625,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@472:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 472
 		Images: des0134.tem
 		Size: 1, 1
@@ -11636,7 +11636,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@473:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 473
 		Images: des0135.tem
 		Size: 1, 1
@@ -11647,7 +11647,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@474:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 474
 		Images: des0136.tem
 		Size: 1, 1
@@ -11658,7 +11658,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@475:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 475
 		Images: des0137.tem
 		Size: 1, 1
@@ -11669,7 +11669,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@476:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 476
 		Images: des0138.tem
 		Size: 1, 1
@@ -11680,7 +11680,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@477:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 477
 		Images: des0139.tem
 		Size: 1, 1
@@ -11691,7 +11691,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@478:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 478
 		Images: des0140.tem
 		Size: 1, 1
@@ -11702,7 +11702,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@479:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 479
 		Images: des0141.tem
 		Size: 1, 1
@@ -11713,7 +11713,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@480:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 480
 		Images: des0142.tem
 		Size: 1, 1
@@ -11724,7 +11724,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@481:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 481
 		Images: des0143.tem
 		Size: 1, 1
@@ -11735,7 +11735,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@482:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 482
 		Images: des0144.tem
 		Size: 1, 1
@@ -11746,7 +11746,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@483:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 483
 		Images: des0145.tem
 		Size: 1, 1
@@ -11757,7 +11757,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@484:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 484
 		Images: des0146.tem
 		Size: 1, 1
@@ -11768,7 +11768,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@485:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 485
 		Images: des0147.tem
 		Size: 1, 1
@@ -11779,7 +11779,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@486:
-		Category: Ground 01
+		Categories: Ground 01
 		Id: 486
 		Images: des0148.tem
 		Size: 1, 1
@@ -11790,7 +11790,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@487:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 487
 		Images: des0201.tem
 		Size: 1, 1
@@ -11801,7 +11801,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@488:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 488
 		Images: des0202.tem
 		Size: 1, 1
@@ -11812,7 +11812,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@489:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 489
 		Images: des0203.tem
 		Size: 1, 1
@@ -11823,7 +11823,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@490:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 490
 		Images: des0204.tem
 		Size: 1, 1
@@ -11834,7 +11834,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@491:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 491
 		Images: des0205.tem
 		Size: 1, 1
@@ -11845,7 +11845,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@492:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 492
 		Images: des0206.tem
 		Size: 1, 1
@@ -11856,7 +11856,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@493:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 493
 		Images: des0207.tem
 		Size: 1, 1
@@ -11867,7 +11867,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@494:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 494
 		Images: des0208.tem
 		Size: 1, 1
@@ -11878,7 +11878,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@495:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 495
 		Images: des0209.tem
 		Size: 1, 1
@@ -11889,7 +11889,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@496:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 496
 		Images: des0210.tem
 		Size: 1, 1
@@ -11900,7 +11900,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@497:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 497
 		Images: des0211.tem
 		Size: 1, 1
@@ -11911,7 +11911,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@498:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 498
 		Images: des0212.tem
 		Size: 1, 1
@@ -11922,7 +11922,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@499:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 499
 		Images: des0213.tem
 		Size: 1, 1
@@ -11933,7 +11933,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@500:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 500
 		Images: des0214.tem
 		Size: 1, 1
@@ -11944,7 +11944,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@501:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 501
 		Images: des0215.tem
 		Size: 1, 1
@@ -11955,7 +11955,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@502:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 502
 		Images: des0216.tem
 		Size: 1, 1
@@ -11966,7 +11966,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@503:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 503
 		Images: des0217.tem
 		Size: 1, 1
@@ -11977,7 +11977,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@504:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 504
 		Images: des0218.tem
 		Size: 1, 1
@@ -11988,7 +11988,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@505:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 505
 		Images: des0219.tem
 		Size: 1, 1
@@ -11999,7 +11999,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@506:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 506
 		Images: des0220.tem
 		Size: 1, 1
@@ -12010,7 +12010,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@507:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 507
 		Images: des0221.tem
 		Size: 1, 1
@@ -12021,7 +12021,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@508:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 508
 		Images: des0222.tem
 		Size: 1, 1
@@ -12032,7 +12032,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@509:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 509
 		Images: des0223.tem
 		Size: 1, 1
@@ -12043,7 +12043,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@510:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 510
 		Images: des0224.tem
 		Size: 1, 1
@@ -12054,7 +12054,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@511:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 511
 		Images: des0225.tem
 		Size: 1, 1
@@ -12065,7 +12065,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@512:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 512
 		Images: des0226.tem
 		Size: 1, 1
@@ -12076,7 +12076,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@513:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 513
 		Images: des0227.tem
 		Size: 1, 1
@@ -12087,7 +12087,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@514:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 514
 		Images: des0228.tem
 		Size: 1, 1
@@ -12098,7 +12098,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@515:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 515
 		Images: des0229.tem
 		Size: 1, 1
@@ -12109,7 +12109,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@516:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 516
 		Images: des0230.tem
 		Size: 1, 1
@@ -12120,7 +12120,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@517:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 517
 		Images: des0231.tem
 		Size: 1, 1
@@ -12131,7 +12131,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@518:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 518
 		Images: des0232.tem
 		Size: 1, 1
@@ -12142,7 +12142,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@519:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 519
 		Images: des0233.tem
 		Size: 1, 1
@@ -12153,7 +12153,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@520:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 520
 		Images: des0234.tem
 		Size: 1, 1
@@ -12164,7 +12164,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@521:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 521
 		Images: des0235.tem
 		Size: 1, 1
@@ -12175,7 +12175,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@522:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 522
 		Images: des0236.tem
 		Size: 1, 1
@@ -12186,7 +12186,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@523:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 523
 		Images: des0237.tem
 		Size: 1, 1
@@ -12197,7 +12197,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@524:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 524
 		Images: des0238.tem
 		Size: 1, 1
@@ -12208,7 +12208,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@525:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 525
 		Images: des0239.tem
 		Size: 1, 1
@@ -12219,7 +12219,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@526:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 526
 		Images: des0240.tem
 		Size: 1, 1
@@ -12230,7 +12230,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@527:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 527
 		Images: des0241.tem
 		Size: 1, 1
@@ -12241,7 +12241,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@528:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 528
 		Images: des0242.tem
 		Size: 1, 1
@@ -12252,7 +12252,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@529:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 529
 		Images: des0243.tem
 		Size: 1, 1
@@ -12263,7 +12263,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@530:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 530
 		Images: des0244.tem
 		Size: 1, 1
@@ -12274,7 +12274,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@531:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 531
 		Images: des0245.tem
 		Size: 1, 1
@@ -12285,7 +12285,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@532:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 532
 		Images: des0246.tem
 		Size: 1, 1
@@ -12296,7 +12296,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@533:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 533
 		Images: des0247.tem
 		Size: 1, 1
@@ -12307,7 +12307,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@534:
-		Category: Ground 02
+		Categories: Ground 02
 		Id: 534
 		Images: des0248.tem
 		Size: 1, 1
@@ -12318,7 +12318,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@535:
-		Category: Sand
+		Categories: Sand
 		Id: 535
 		Images: sandy01.tem, sandy01a.tem, sandy01b.tem, sandy01c.tem, sandy01d.tem, sandy01e.tem, sandy01f.tem, sandy01g.tem
 		Size: 1, 1
@@ -12329,7 +12329,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@536:
-		Category: Sand/Clear LAT
+		Categories: Sand/Clear LAT
 		Id: 536
 		Images: dlat01.tem, dlat01a.tem
 		Size: 1, 1
@@ -12340,7 +12340,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@537:
-		Category: Sand/Clear LAT
+		Categories: Sand/Clear LAT
 		Id: 537
 		Images: dlat02.tem, dlat02a.tem
 		Size: 1, 1
@@ -12351,7 +12351,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@538:
-		Category: Sand/Clear LAT
+		Categories: Sand/Clear LAT
 		Id: 538
 		Images: dlat03.tem, dlat03a.tem
 		Size: 1, 1
@@ -12362,7 +12362,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@539:
-		Category: Sand/Clear LAT
+		Categories: Sand/Clear LAT
 		Id: 539
 		Images: dlat04.tem, dlat04a.tem
 		Size: 1, 1
@@ -12373,7 +12373,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@540:
-		Category: Sand/Clear LAT
+		Categories: Sand/Clear LAT
 		Id: 540
 		Images: dlat05.tem, dlat05a.tem
 		Size: 1, 1
@@ -12384,7 +12384,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@541:
-		Category: Sand/Clear LAT
+		Categories: Sand/Clear LAT
 		Id: 541
 		Images: dlat06.tem, dlat06a.tem
 		Size: 1, 1
@@ -12395,7 +12395,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@542:
-		Category: Sand/Clear LAT
+		Categories: Sand/Clear LAT
 		Id: 542
 		Images: dlat07.tem, dlat07a.tem
 		Size: 1, 1
@@ -12406,7 +12406,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@543:
-		Category: Sand/Clear LAT
+		Categories: Sand/Clear LAT
 		Id: 543
 		Images: dlat08.tem, dlat08a.tem
 		Size: 1, 1
@@ -12417,7 +12417,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@544:
-		Category: Sand/Clear LAT
+		Categories: Sand/Clear LAT
 		Id: 544
 		Images: dlat09.tem, dlat09a.tem
 		Size: 1, 1
@@ -12428,7 +12428,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@545:
-		Category: Sand/Clear LAT
+		Categories: Sand/Clear LAT
 		Id: 545
 		Images: dlat10.tem, dlat10a.tem
 		Size: 1, 1
@@ -12439,7 +12439,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@546:
-		Category: Sand/Clear LAT
+		Categories: Sand/Clear LAT
 		Id: 546
 		Images: dlat11.tem, dlat11a.tem
 		Size: 1, 1
@@ -12450,7 +12450,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@547:
-		Category: Sand/Clear LAT
+		Categories: Sand/Clear LAT
 		Id: 547
 		Images: dlat12.tem, dlat12a.tem
 		Size: 1, 1
@@ -12461,7 +12461,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@548:
-		Category: Sand/Clear LAT
+		Categories: Sand/Clear LAT
 		Id: 548
 		Images: dlat13.tem, dlat13a.tem
 		Size: 1, 1
@@ -12472,7 +12472,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@549:
-		Category: Sand/Clear LAT
+		Categories: Sand/Clear LAT
 		Id: 549
 		Images: dlat14.tem, dlat14a.tem
 		Size: 1, 1
@@ -12483,7 +12483,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@550:
-		Category: Sand/Clear LAT
+		Categories: Sand/Clear LAT
 		Id: 550
 		Images: dlat15.tem, dlat15a.tem
 		Size: 1, 1
@@ -12494,7 +12494,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@551:
-		Category: Sand/Clear LAT
+		Categories: Sand/Clear LAT
 		Id: 551
 		Images: dlat16.tem, dlat16a.tem
 		Size: 1, 1
@@ -12505,7 +12505,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@552:
-		Category: Rough ground
+		Categories: Rough ground
 		Id: 552
 		Images: rough01.tem
 		Size: 9, 7
@@ -12691,7 +12691,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@553:
-		Category: Rough ground
+		Categories: Rough ground
 		Id: 553
 		Images: rough02.tem
 		Size: 4, 4
@@ -12747,7 +12747,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@554:
-		Category: Rough ground
+		Categories: Rough ground
 		Id: 554
 		Images: rough03.tem
 		Size: 5, 3
@@ -12808,7 +12808,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@555:
-		Category: Rough ground
+		Categories: Rough ground
 		Id: 555
 		Images: rough04.tem
 		Size: 4, 3
@@ -12854,7 +12854,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@556:
-		Category: Rough ground
+		Categories: Rough ground
 		Id: 556
 		Images: rough05.tem
 		Size: 3, 5
@@ -12920,7 +12920,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@557:
-		Category: Rough ground
+		Categories: Rough ground
 		Id: 557
 		Images: rough06.tem
 		Size: 4, 4
@@ -12991,7 +12991,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@558:
-		Category: Rough ground
+		Categories: Rough ground
 		Id: 558
 		Images: rough07.tem
 		Size: 3, 3
@@ -13037,7 +13037,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@559:
-		Category: Rough ground
+		Categories: Rough ground
 		Id: 559
 		Images: rough08.tem
 		Size: 6, 10
@@ -13153,7 +13153,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@560:
-		Category: Rough ground
+		Categories: Rough ground
 		Id: 560
 		Images: rough09.tem
 		Size: 8, 3
@@ -13239,7 +13239,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@561:
-		Category: Rough ground
+		Categories: Rough ground
 		Id: 561
 		Images: rough10.tem
 		Size: 3, 4
@@ -13285,7 +13285,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@562:
-		Category: Paved Road Ends
+		Categories: Paved Road Ends
 		Id: 562
 		Images: p_end01.tem
 		Size: 1, 3
@@ -13306,7 +13306,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@563:
-		Category: Paved Road Ends
+		Categories: Paved Road Ends
 		Id: 563
 		Images: p_end02.tem
 		Size: 3, 1
@@ -13327,7 +13327,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@564:
-		Category: Paved Road Ends
+		Categories: Paved Road Ends
 		Id: 564
 		Images: p_end03.tem
 		Size: 1, 3
@@ -13348,7 +13348,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@565:
-		Category: Paved Road Ends
+		Categories: Paved Road Ends
 		Id: 565
 		Images: p_end04.tem
 		Size: 3, 1
@@ -13369,7 +13369,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@566:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 566
 		Images: tovrps01.tem
 		Size: 3, 5
@@ -13458,7 +13458,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@567:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 567
 		Images: tovrps02.tem
 		Size: 3, 5
@@ -13547,7 +13547,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@568:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 568
 		Images: tovrps03.tem
 		Size: 2, 5
@@ -13611,7 +13611,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@569:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 569
 		Images: tovrps04.tem
 		Size: 5, 3
@@ -13700,7 +13700,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@570:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 570
 		Images: tovrps05.tem
 		Size: 5, 3
@@ -13789,7 +13789,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@571:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 571
 		Images: tovrps06.tem
 		Size: 5, 2
@@ -13853,7 +13853,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@572:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 572
 		Images: tovrps07.tem
 		Size: 2, 5
@@ -13912,7 +13912,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@573:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 573
 		Images: tovrps08.tem
 		Size: 2, 5
@@ -13971,7 +13971,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@574:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 574
 		Images: tovrps09.tem
 		Size: 2, 5
@@ -14030,7 +14030,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@575:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 575
 		Images: tovrps10.tem
 		Size: 2, 5
@@ -14089,7 +14089,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@576:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 576
 		Images: tovrps11.tem
 		Size: 2, 5
@@ -14145,7 +14145,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@577:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 577
 		Images: tovrps12.tem
 		Size: 5, 2
@@ -14204,7 +14204,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@578:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 578
 		Images: tovrps13.tem
 		Size: 5, 2
@@ -14258,7 +14258,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@579:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 579
 		Images: tovrps14.tem
 		Size: 5, 2
@@ -14317,7 +14317,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@580:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 580
 		Images: tovrps15.tem
 		Size: 5, 2
@@ -14371,7 +14371,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@581:
-		Category: TrainBridges
+		Categories: TrainBridges
 		Id: 581
 		Images: tovrps16.tem
 		Size: 5, 2
@@ -14427,7 +14427,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@582:
-		Category: Pavement
+		Categories: Pavement
 		Id: 582
 		Images: pave01.tem
 		Size: 1, 1
@@ -14438,7 +14438,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@583:
-		Category: Pavement
+		Categories: Pavement
 		Id: 583
 		Images: pave02.tem
 		Size: 1, 1
@@ -14449,7 +14449,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@584:
-		Category: Pavement
+		Categories: Pavement
 		Id: 584
 		Images: pave03.tem
 		Size: 1, 1
@@ -14460,7 +14460,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@585:
-		Category: Pavement
+		Categories: Pavement
 		Id: 585
 		Images: pave04.tem
 		Size: 1, 1
@@ -14471,7 +14471,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@586:
-		Category: Pavement
+		Categories: Pavement
 		Id: 586
 		Images: pave05.tem
 		Size: 2, 2
@@ -14497,7 +14497,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@587:
-		Category: Pavement
+		Categories: Pavement
 		Id: 587
 		Images: pave06.tem
 		Size: 2, 2
@@ -14523,7 +14523,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@588:
-		Category: Pavement
+		Categories: Pavement
 		Id: 588
 		Images: pave07.tem
 		Size: 2, 2
@@ -14549,7 +14549,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@589:
-		Category: Pavement
+		Categories: Pavement
 		Id: 589
 		Images: pave08.tem
 		Size: 2, 2
@@ -14575,7 +14575,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@590:
-		Category: Pavement
+		Categories: Pavement
 		Id: 590
 		Images: pave09.tem
 		Size: 2, 2
@@ -14601,7 +14601,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@591:
-		Category: Pavement
+		Categories: Pavement
 		Id: 591
 		Images: pave10.tem
 		Size: 2, 2
@@ -14627,7 +14627,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@592:
-		Category: Pavement
+		Categories: Pavement
 		Id: 592
 		Images: pave11.tem
 		Size: 2, 2
@@ -14653,7 +14653,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@593:
-		Category: Pavement
+		Categories: Pavement
 		Id: 593
 		Images: pave12.tem
 		Size: 2, 2
@@ -14679,7 +14679,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@594:
-		Category: Pavement
+		Categories: Pavement
 		Id: 594
 		Images: pave13.tem
 		Size: 2, 2
@@ -14705,7 +14705,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@595:
-		Category: Pavement
+		Categories: Pavement
 		Id: 595
 		Images: pave14.tem
 		Size: 2, 2
@@ -14731,7 +14731,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@596:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 596
 		Images: plat01.tem, plat01a.tem
 		Size: 1, 1
@@ -14742,7 +14742,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@597:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 597
 		Images: plat02.tem, plat02a.tem
 		Size: 1, 1
@@ -14753,7 +14753,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@598:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 598
 		Images: plat03.tem, plat03a.tem
 		Size: 1, 1
@@ -14764,7 +14764,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@599:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 599
 		Images: plat04.tem, plat04a.tem
 		Size: 1, 1
@@ -14775,7 +14775,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@600:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 600
 		Images: plat05.tem, plat05a.tem
 		Size: 1, 1
@@ -14786,7 +14786,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@601:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 601
 		Images: plat06.tem, plat06a.tem
 		Size: 1, 1
@@ -14797,7 +14797,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@602:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 602
 		Images: plat07.tem, plat07a.tem
 		Size: 1, 1
@@ -14808,7 +14808,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@603:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 603
 		Images: plat08.tem, plat08a.tem
 		Size: 1, 1
@@ -14819,7 +14819,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@604:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 604
 		Images: plat09.tem, plat09a.tem
 		Size: 1, 1
@@ -14830,7 +14830,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@605:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 605
 		Images: plat10.tem, plat10a.tem
 		Size: 1, 1
@@ -14841,7 +14841,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@606:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 606
 		Images: plat11.tem, plat11a.tem
 		Size: 1, 1
@@ -14852,7 +14852,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@607:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 607
 		Images: plat12.tem, plat12a.tem
 		Size: 1, 1
@@ -14863,7 +14863,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@608:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 608
 		Images: plat13.tem, plat13a.tem
 		Size: 1, 1
@@ -14874,7 +14874,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@609:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 609
 		Images: plat14.tem, plat14a.tem
 		Size: 1, 1
@@ -14885,7 +14885,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@610:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 610
 		Images: plat15.tem, plat15a.tem
 		Size: 1, 1
@@ -14896,7 +14896,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@611:
-		Category: Pavement/Clear LAT
+		Categories: Pavement/Clear LAT
 		Id: 611
 		Images: plat16.tem, plat16a.tem
 		Size: 1, 1
@@ -14907,7 +14907,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@612:
-		Category: Paved road bits
+		Categories: Paved road bits
 		Id: 612
 		Images: proadc01.tem
 		Size: 1, 1
@@ -14918,7 +14918,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@613:
-		Category: Paved road bits
+		Categories: Paved road bits
 		Id: 613
 		Images: proadc02.tem
 		Size: 1, 1
@@ -14929,7 +14929,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@614:
-		Category: Paved road bits
+		Categories: Paved road bits
 		Id: 614
 		Images: proadc03.tem
 		Size: 1, 1
@@ -14940,7 +14940,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@615:
-		Category: Paved road bits
+		Categories: Paved road bits
 		Id: 615
 		Images: proadc04.tem
 		Size: 1, 1
@@ -14951,7 +14951,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@616:
-		Category: Paved road bits
+		Categories: Paved road bits
 		Id: 616
 		Images: proadc05.tem
 		Size: 1, 1
@@ -14962,7 +14962,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@617:
-		Category: Paved road bits
+		Categories: Paved road bits
 		Id: 617
 		Images: proadc06.tem
 		Size: 1, 1
@@ -14973,7 +14973,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@618:
-		Category: Paved road bits
+		Categories: Paved road bits
 		Id: 618
 		Images: proadc07.tem
 		Size: 1, 1
@@ -14984,7 +14984,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@619:
-		Category: Paved road bits
+		Categories: Paved road bits
 		Id: 619
 		Images: proadc08.tem
 		Size: 1, 1
@@ -14995,7 +14995,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@620:
-		Category: Paved road bits
+		Categories: Paved road bits
 		Id: 620
 		Images: proadc09.tem
 		Size: 1, 1
@@ -15006,7 +15006,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@621:
-		Category: Paved road bits
+		Categories: Paved road bits
 		Id: 621
 		Images: proadc10.tem
 		Size: 1, 1
@@ -15017,7 +15017,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@622:
-		Category: Paved road bits
+		Categories: Paved road bits
 		Id: 622
 		Images: proadc11.tem
 		Size: 1, 1
@@ -15028,7 +15028,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@623:
-		Category: Paved road bits
+		Categories: Paved road bits
 		Id: 623
 		Images: proadc12.tem
 		Size: 1, 1
@@ -15039,7 +15039,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@624:
-		Category: Paved road bits
+		Categories: Paved road bits
 		Id: 624
 		Images: proadc13.tem
 		Size: 1, 3
@@ -15060,7 +15060,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@625:
-		Category: Paved road bits
+		Categories: Paved road bits
 		Id: 625
 		Images: proadc14.tem
 		Size: 3, 1
@@ -15081,7 +15081,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@626:
-		Category: Green
+		Categories: Green
 		Id: 626
 		Images: green01.tem, green01a.tem, green01b.tem, green01c.tem, green01d.tem, green01e.tem, green01f.tem, green01g.tem
 		Size: 1, 1
@@ -15092,7 +15092,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@627:
-		Category: Green/Clear LAT
+		Categories: Green/Clear LAT
 		Id: 627
 		Images: glat01.tem, glat01a.tem
 		Size: 1, 1
@@ -15103,7 +15103,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@628:
-		Category: Green/Clear LAT
+		Categories: Green/Clear LAT
 		Id: 628
 		Images: glat02.tem, glat02a.tem
 		Size: 1, 1
@@ -15114,7 +15114,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@629:
-		Category: Green/Clear LAT
+		Categories: Green/Clear LAT
 		Id: 629
 		Images: glat03.tem, glat03a.tem
 		Size: 1, 1
@@ -15125,7 +15125,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@630:
-		Category: Green/Clear LAT
+		Categories: Green/Clear LAT
 		Id: 630
 		Images: glat04.tem, glat04a.tem
 		Size: 1, 1
@@ -15136,7 +15136,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@631:
-		Category: Green/Clear LAT
+		Categories: Green/Clear LAT
 		Id: 631
 		Images: glat05.tem, glat05a.tem
 		Size: 1, 1
@@ -15147,7 +15147,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@632:
-		Category: Green/Clear LAT
+		Categories: Green/Clear LAT
 		Id: 632
 		Images: glat06.tem, glat06a.tem
 		Size: 1, 1
@@ -15158,7 +15158,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@633:
-		Category: Green/Clear LAT
+		Categories: Green/Clear LAT
 		Id: 633
 		Images: glat07.tem, glat07a.tem
 		Size: 1, 1
@@ -15169,7 +15169,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@634:
-		Category: Green/Clear LAT
+		Categories: Green/Clear LAT
 		Id: 634
 		Images: glat08.tem, glat08a.tem
 		Size: 1, 1
@@ -15180,7 +15180,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@635:
-		Category: Green/Clear LAT
+		Categories: Green/Clear LAT
 		Id: 635
 		Images: glat09.tem, glat09a.tem
 		Size: 1, 1
@@ -15191,7 +15191,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@636:
-		Category: Green/Clear LAT
+		Categories: Green/Clear LAT
 		Id: 636
 		Images: glat10.tem, glat10a.tem
 		Size: 1, 1
@@ -15202,7 +15202,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@637:
-		Category: Green/Clear LAT
+		Categories: Green/Clear LAT
 		Id: 637
 		Images: glat11.tem, glat11a.tem
 		Size: 1, 1
@@ -15213,7 +15213,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@638:
-		Category: Green/Clear LAT
+		Categories: Green/Clear LAT
 		Id: 638
 		Images: glat12.tem, glat12a.tem
 		Size: 1, 1
@@ -15224,7 +15224,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@639:
-		Category: Green/Clear LAT
+		Categories: Green/Clear LAT
 		Id: 639
 		Images: glat13.tem, glat13a.tem
 		Size: 1, 1
@@ -15235,7 +15235,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@640:
-		Category: Green/Clear LAT
+		Categories: Green/Clear LAT
 		Id: 640
 		Images: glat14.tem, glat14a.tem
 		Size: 1, 1
@@ -15246,7 +15246,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@641:
-		Category: Green/Clear LAT
+		Categories: Green/Clear LAT
 		Id: 641
 		Images: glat15.tem, glat15a.tem
 		Size: 1, 1
@@ -15257,7 +15257,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@642:
-		Category: Green/Clear LAT
+		Categories: Green/Clear LAT
 		Id: 642
 		Images: glat16.tem, glat16a.tem
 		Size: 1, 1
@@ -15268,7 +15268,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@643:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 643
 		Images: rmpfx01.tem, rmpfx01a.tem, rmpfx01b.tem, rmpfx01c.tem
 		Size: 1, 1
@@ -15280,7 +15280,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@644:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 644
 		Images: rmpfx02.tem, rmpfx02a.tem, rmpfx02b.tem, rmpfx02c.tem
 		Size: 1, 1
@@ -15292,7 +15292,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@645:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 645
 		Images: rmpfx03.tem, rmpfx03a.tem, rmpfx03b.tem, rmpfx03c.tem
 		Size: 1, 1
@@ -15304,7 +15304,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@646:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 646
 		Images: rmpfx04.tem, rmpfx04a.tem, rmpfx04b.tem, rmpfx04c.tem
 		Size: 1, 1
@@ -15316,7 +15316,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@647:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 647
 		Images: rmpfx05.tem, rmpfx05a.tem, rmpfx05b.tem, rmpfx05c.tem
 		Size: 1, 1
@@ -15328,7 +15328,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@648:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 648
 		Images: rmpfx06.tem, rmpfx06a.tem, rmpfx06b.tem, rmpfx06c.tem
 		Size: 1, 1
@@ -15340,7 +15340,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@649:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 649
 		Images: rmpfx07.tem, rmpfx07a.tem, rmpfx07b.tem, rmpfx07c.tem
 		Size: 1, 1
@@ -15352,7 +15352,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@650:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 650
 		Images: rmpfx08.tem, rmpfx08a.tem, rmpfx08b.tem, rmpfx08c.tem
 		Size: 1, 1
@@ -15364,7 +15364,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@651:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 651
 		Images: rmpfx09.tem, rmpfx09a.tem, rmpfx09b.tem, rmpfx09c.tem
 		Size: 1, 1
@@ -15376,7 +15376,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@652:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 652
 		Images: rmpfx10.tem, rmpfx10a.tem, rmpfx10b.tem, rmpfx10c.tem
 		Size: 1, 1
@@ -15388,7 +15388,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@653:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 653
 		Images: rmpfx11.tem, rmpfx11a.tem, rmpfx11b.tem, rmpfx11c.tem
 		Size: 1, 1
@@ -15400,7 +15400,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@654:
-		Category: Ramp edge fixup
+		Categories: Ramp edge fixup
 		Id: 654
 		Images: rmpfx12.tem, rmpfx12a.tem, rmpfx12b.tem, rmpfx12c.tem
 		Size: 1, 1
@@ -15412,7 +15412,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@667:
-		Category: Water slopes
+		Categories: Water slopes
 		Id: 667
 		Images: wslope01.tem
 		Size: 1, 4
@@ -15442,7 +15442,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@668:
-		Category: Water slopes
+		Categories: Water slopes
 		Id: 668
 		Images: wslope02.tem
 		Size: 4, 1
@@ -15472,7 +15472,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@669:
-		Category: Water slopes
+		Categories: Water slopes
 		Id: 669
 		Images: wslope03.tem
 		Size: 1, 4
@@ -15502,7 +15502,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@670:
-		Category: Water slopes
+		Categories: Water slopes
 		Id: 670
 		Images: wslope04.tem
 		Size: 4, 1
@@ -15532,7 +15532,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@671:
-		Category: Pavement (Use for LAT)
+		Categories: Pavement (Use for LAT)
 		Id: 671
 		Images: pvclr01.tem, pvclr01a.tem, pvclr01b.tem, pvclr01c.tem, pvclr01d.tem, pvclr01e.tem, pvclr01f.tem, pvclr01g.tem
 		Size: 1, 1
@@ -15543,7 +15543,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@672:
-		Category: Paved Road Slopes
+		Categories: Paved Road Slopes
 		Id: 672
 		Images: prslpe01.tem
 		Size: 1, 3
@@ -15567,7 +15567,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@673:
-		Category: Paved Road Slopes
+		Categories: Paved Road Slopes
 		Id: 673
 		Images: prslpe02.tem
 		Size: 3, 1
@@ -15591,7 +15591,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@674:
-		Category: Paved Road Slopes
+		Categories: Paved Road Slopes
 		Id: 674
 		Images: prslpe03.tem
 		Size: 1, 3
@@ -15615,7 +15615,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@675:
-		Category: Paved Road Slopes
+		Categories: Paved Road Slopes
 		Id: 675
 		Images: prslpe04.tem
 		Size: 3, 1
@@ -15639,7 +15639,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@676:
-		Category: Monorail Slopes
+		Categories: Monorail Slopes
 		Id: 676
 		Images: tslope01.tem
 		Size: 1, 1
@@ -15651,7 +15651,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@677:
-		Category: Monorail Slopes
+		Categories: Monorail Slopes
 		Id: 677
 		Images: tslope02.tem
 		Size: 1, 1
@@ -15663,7 +15663,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@678:
-		Category: Monorail Slopes
+		Categories: Monorail Slopes
 		Id: 678
 		Images: tslope03.tem
 		Size: 1, 1
@@ -15675,7 +15675,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@679:
-		Category: Monorail Slopes
+		Categories: Monorail Slopes
 		Id: 679
 		Images: tslope04.tem
 		Size: 1, 1
@@ -15687,7 +15687,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@680:
-		Category: Waterfalls-B
+		Categories: Waterfalls-B
 		Id: 680
 		Images: w-b-01.tem
 		Size: 4, 2
@@ -15737,7 +15737,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@681:
-		Category: Waterfalls-B
+		Categories: Waterfalls-B
 		Id: 681
 		Images: w-b-02.tem
 		Size: 4, 1
@@ -15765,7 +15765,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@682:
-		Category: Waterfalls-B
+		Categories: Waterfalls-B
 		Id: 682
 		Images: w-b-03.tem
 		Size: 4, 2
@@ -15815,7 +15815,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@683:
-		Category: Waterfalls-B
+		Categories: Waterfalls-B
 		Id: 683
 		Images: w-b-04.tem
 		Size: 4, 2
@@ -15865,7 +15865,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@684:
-		Category: Waterfalls-C
+		Categories: Waterfalls-C
 		Id: 684
 		Images: w-c-01.tem
 		Size: 2, 2
@@ -15889,7 +15889,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@685:
-		Category: Waterfalls-C
+		Categories: Waterfalls-C
 		Id: 685
 		Images: w-c-02.tem
 		Size: 1, 1
@@ -15901,7 +15901,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@686:
-		Category: Waterfalls-C
+		Categories: Waterfalls-C
 		Id: 686
 		Images: w-c-03.tem
 		Size: 2, 1
@@ -15919,7 +15919,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@687:
-		Category: Waterfalls-C
+		Categories: Waterfalls-C
 		Id: 687
 		Images: w-c-04.tem
 		Size: 2, 2
@@ -15943,7 +15943,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@688:
-		Category: Waterfalls-D
+		Categories: Waterfalls-D
 		Id: 688
 		Images: w-d-01.tem
 		Size: 2, 2
@@ -15967,7 +15967,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@689:
-		Category: Waterfalls-D
+		Categories: Waterfalls-D
 		Id: 689
 		Images: w-d-02.tem
 		Size: 1, 1
@@ -15979,7 +15979,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@690:
-		Category: Waterfalls-D
+		Categories: Waterfalls-D
 		Id: 690
 		Images: w-d-03.tem
 		Size: 1, 2
@@ -15997,7 +15997,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@691:
-		Category: Waterfalls-D
+		Categories: Waterfalls-D
 		Id: 691
 		Images: w-d-04.tem
 		Size: 2, 2
@@ -16021,7 +16021,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@707:
-		Category: Tunnel Floor
+		Categories: Tunnel Floor
 		Id: 707
 		Images: tunnel01.tem
 		Size: 3, 5
@@ -16102,7 +16102,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@708:
-		Category: Tunnel Floor
+		Categories: Tunnel Floor
 		Id: 708
 		Images: tunnel02.tem
 		Size: 5, 3
@@ -16183,7 +16183,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@709:
-		Category: Tunnel Floor
+		Categories: Tunnel Floor
 		Id: 709
 		Images: tunnel03.tem
 		Size: 3, 4
@@ -16249,7 +16249,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@710:
-		Category: Tunnel Floor
+		Categories: Tunnel Floor
 		Id: 710
 		Images: tunnel04.tem
 		Size: 4, 3
@@ -16315,7 +16315,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@711:
-		Category: Tunnel Side
+		Categories: Tunnel Side
 		Id: 711
 		Images: tunnex01.tem
 		Size: 3, 1
@@ -16337,7 +16337,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@712:
-		Category: Tunnel Side
+		Categories: Tunnel Side
 		Id: 712
 		Images: tunnex02.tem
 		Size: 1, 3
@@ -16359,7 +16359,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@713:
-		Category: TrackTunnel Floor
+		Categories: TrackTunnel Floor
 		Id: 713
 		Images: tunnet01.tem
 		Size: 3, 5
@@ -16440,7 +16440,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@714:
-		Category: TrackTunnel Floor
+		Categories: TrackTunnel Floor
 		Id: 714
 		Images: tunnet02.tem
 		Size: 5, 3
@@ -16521,7 +16521,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@715:
-		Category: TrackTunnel Floor
+		Categories: TrackTunnel Floor
 		Id: 715
 		Images: tunnet03.tem
 		Size: 3, 4
@@ -16587,7 +16587,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@716:
-		Category: TrackTunnel Floor
+		Categories: TrackTunnel Floor
 		Id: 716
 		Images: tunnet04.tem
 		Size: 4, 3
@@ -16653,7 +16653,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@717:
-		Category: Destroyable Cliffs
+		Categories: Destroyable Cliffs
 		Id: 717
 		Images: dcliff01.tem
 		Size: 6, 4
@@ -16769,7 +16769,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@718:
-		Category: Destroyable Cliffs
+		Categories: Destroyable Cliffs
 		Id: 718
 		Images: dcliff02.tem
 		Size: 4, 6
@@ -16885,7 +16885,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@719:
-		Category: Water Caves
+		Categories: Water Caves
 		Id: 719
 		Images: wcave01.tem
 		Size: 2, 2
@@ -16913,7 +16913,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@720:
-		Category: Water Caves
+		Categories: Water Caves
 		Id: 720
 		Images: wcave02.tem
 		Size: 2, 2
@@ -16941,7 +16941,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@721:
-		Category: Water Caves
+		Categories: Water Caves
 		Id: 721
 		Images: wcave03.tem
 		Size: 1, 2
@@ -16958,7 +16958,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@722:
-		Category: Water Caves
+		Categories: Water Caves
 		Id: 722
 		Images: wcave04.tem
 		Size: 2, 2
@@ -16986,7 +16986,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@723:
-		Category: Water Caves
+		Categories: Water Caves
 		Id: 723
 		Images: wcave05.tem
 		Size: 2, 2
@@ -17014,7 +17014,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@724:
-		Category: Water Caves
+		Categories: Water Caves
 		Id: 724
 		Images: wcave06.tem
 		Size: 2, 2
@@ -17042,7 +17042,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@725:
-		Category: Water Caves
+		Categories: Water Caves
 		Id: 725
 		Images: wcave07.tem
 		Size: 2, 1
@@ -17059,7 +17059,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@726:
-		Category: Water Caves
+		Categories: Water Caves
 		Id: 726
 		Images: wcave08.tem
 		Size: 2, 2
@@ -17087,7 +17087,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@940:
-		Category: Scrin Wreckage
+		Categories: Scrin Wreckage
 		Id: 940
 		Images: scrin01.tem
 		Size: 6, 7
@@ -17249,7 +17249,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@941:
-		Category: Scrin Wreckage
+		Categories: Scrin Wreckage
 		Id: 941
 		Images: scrin02.tem
 		Size: 5, 5
@@ -17337,7 +17337,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@942:
-		Category: Scrin Wreckage
+		Categories: Scrin Wreckage
 		Id: 942
 		Images: scrin03.tem
 		Size: 9, 8
@@ -17579,7 +17579,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@943:
-		Category: Scrin Wreckage
+		Categories: Scrin Wreckage
 		Id: 943
 		Images: scrin04.tem
 		Size: 8, 6
@@ -17625,7 +17625,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@944:
-		Category: Scrin Wreckage
+		Categories: Scrin Wreckage
 		Id: 944
 		Images: scrin05.tem
 		Size: 8, 6
@@ -17816,7 +17816,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@945:
-		Category: Scrin Wreckage
+		Categories: Scrin Wreckage
 		Id: 945
 		Images: scrin06.tem
 		Size: 7, 10
@@ -18057,7 +18057,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@952:
-		Category: DirtTrackTunnel Floor
+		Categories: DirtTrackTunnel Floor
 		Id: 952
 		Images: dtunnt01.tem
 		Size: 3, 5
@@ -18138,7 +18138,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@953:
-		Category: DirtTrackTunnel Floor
+		Categories: DirtTrackTunnel Floor
 		Id: 953
 		Images: dtunnt02.tem
 		Size: 5, 3
@@ -18219,7 +18219,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@954:
-		Category: DirtTrackTunnel Floor
+		Categories: DirtTrackTunnel Floor
 		Id: 954
 		Images: dtunnt03.tem
 		Size: 3, 4
@@ -18285,7 +18285,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@955:
-		Category: DirtTrackTunnel Floor
+		Categories: DirtTrackTunnel Floor
 		Id: 955
 		Images: dtunnt04.tem
 		Size: 4, 3
@@ -18351,7 +18351,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@956:
-		Category: DirtTunnel Floor
+		Categories: DirtTunnel Floor
 		Id: 956
 		Images: dtunn01.tem
 		Size: 3, 5
@@ -18432,7 +18432,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@957:
-		Category: DirtTunnel Floor
+		Categories: DirtTunnel Floor
 		Id: 957
 		Images: dtunn02.tem
 		Size: 5, 3
@@ -18513,7 +18513,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@958:
-		Category: DirtTunnel Floor
+		Categories: DirtTunnel Floor
 		Id: 958
 		Images: dtunn03.tem
 		Size: 3, 4
@@ -18579,7 +18579,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@959:
-		Category: DirtTunnel Floor
+		Categories: DirtTunnel Floor
 		Id: 959
 		Images: dtunn04.tem
 		Size: 4, 3
@@ -18645,7 +18645,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@960:
-		Category: Crystal LAT tile
+		Categories: Crystal LAT tile
 		Id: 960
 		Images: crys01.tem, crys01a.tem, crys01b.tem, crys01c.tem, crys01d.tem, crys01e.tem, crys01f.tem, crys01g.tem
 		Size: 1, 1
@@ -18656,7 +18656,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@961:
-		Category: Clear Crystal LAT
+		Categories: Clear Crystal LAT
 		Id: 961
 		Images: cylat01.tem, cylat01a.tem
 		Size: 1, 1
@@ -18667,7 +18667,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@962:
-		Category: Clear Crystal LAT
+		Categories: Clear Crystal LAT
 		Id: 962
 		Images: cylat02.tem, cylat02a.tem
 		Size: 1, 1
@@ -18678,7 +18678,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@963:
-		Category: Clear Crystal LAT
+		Categories: Clear Crystal LAT
 		Id: 963
 		Images: cylat03.tem, cylat03a.tem
 		Size: 1, 1
@@ -18689,7 +18689,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@964:
-		Category: Clear Crystal LAT
+		Categories: Clear Crystal LAT
 		Id: 964
 		Images: cylat04.tem, cylat04a.tem
 		Size: 1, 1
@@ -18700,7 +18700,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@965:
-		Category: Clear Crystal LAT
+		Categories: Clear Crystal LAT
 		Id: 965
 		Images: cylat05.tem, cylat05a.tem
 		Size: 1, 1
@@ -18711,7 +18711,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@966:
-		Category: Clear Crystal LAT
+		Categories: Clear Crystal LAT
 		Id: 966
 		Images: cylat06.tem, cylat06a.tem
 		Size: 1, 1
@@ -18722,7 +18722,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@967:
-		Category: Clear Crystal LAT
+		Categories: Clear Crystal LAT
 		Id: 967
 		Images: cylat07.tem, cylat07a.tem
 		Size: 1, 1
@@ -18733,7 +18733,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@968:
-		Category: Clear Crystal LAT
+		Categories: Clear Crystal LAT
 		Id: 968
 		Images: cylat08.tem, cylat08a.tem
 		Size: 1, 1
@@ -18744,7 +18744,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@969:
-		Category: Clear Crystal LAT
+		Categories: Clear Crystal LAT
 		Id: 969
 		Images: cylat09.tem, cylat09a.tem
 		Size: 1, 1
@@ -18755,7 +18755,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@970:
-		Category: Clear Crystal LAT
+		Categories: Clear Crystal LAT
 		Id: 970
 		Images: cylat10.tem, cylat10a.tem
 		Size: 1, 1
@@ -18766,7 +18766,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@971:
-		Category: Clear Crystal LAT
+		Categories: Clear Crystal LAT
 		Id: 971
 		Images: cylat11.tem, cylat11a.tem
 		Size: 1, 1
@@ -18777,7 +18777,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@972:
-		Category: Clear Crystal LAT
+		Categories: Clear Crystal LAT
 		Id: 972
 		Images: cylat12.tem, cylat12a.tem
 		Size: 1, 1
@@ -18788,7 +18788,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@973:
-		Category: Clear Crystal LAT
+		Categories: Clear Crystal LAT
 		Id: 973
 		Images: cylat13.tem, cylat13a.tem
 		Size: 1, 1
@@ -18799,7 +18799,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@974:
-		Category: Clear Crystal LAT
+		Categories: Clear Crystal LAT
 		Id: 974
 		Images: cylat14.tem, cylat14a.tem
 		Size: 1, 1
@@ -18810,7 +18810,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@975:
-		Category: Clear Crystal LAT
+		Categories: Clear Crystal LAT
 		Id: 975
 		Images: cylat15.tem, cylat15a.tem
 		Size: 1, 1
@@ -18821,7 +18821,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@976:
-		Category: Clear Crystal LAT
+		Categories: Clear Crystal LAT
 		Id: 976
 		Images: cylat16.tem, cylat16a.tem
 		Size: 1, 1
@@ -18832,7 +18832,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@977:
-		Category: Swampy
+		Categories: Swampy
 		Id: 977
 		Images: swamp01.tem, swamp01a.tem, swamp01b.tem, swamp01c.tem, swamp01d.tem, swamp01e.tem, swamp01f.tem, swamp01g.tem
 		Size: 1, 1
@@ -18843,7 +18843,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@978:
-		Category: Swampy
+		Categories: Swampy
 		Id: 978
 		Images: swamp02.tem
 		Size: 2, 2
@@ -18869,7 +18869,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@979:
-		Category: Swampy
+		Categories: Swampy
 		Id: 979
 		Images: swamp03.tem
 		Size: 2, 2
@@ -18895,7 +18895,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@980:
-		Category: Swampy
+		Categories: Swampy
 		Id: 980
 		Images: swamp04.tem
 		Size: 2, 2
@@ -18921,7 +18921,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@981:
-		Category: Swampy
+		Categories: Swampy
 		Id: 981
 		Images: swamp05.tem
 		Size: 1, 1
@@ -18932,7 +18932,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@982:
-		Category: Swampy
+		Categories: Swampy
 		Id: 982
 		Images: swamp06.tem
 		Size: 1, 1
@@ -18943,7 +18943,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@983:
-		Category: Swampy
+		Categories: Swampy
 		Id: 983
 		Images: swamp07.tem
 		Size: 1, 1
@@ -18954,7 +18954,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@984:
-		Category: Swampy
+		Categories: Swampy
 		Id: 984
 		Images: swamp08.tem
 		Size: 1, 1
@@ -18965,7 +18965,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@985:
-		Category: Swampy
+		Categories: Swampy
 		Id: 985
 		Images: swamp09.tem
 		Size: 1, 1
@@ -18976,7 +18976,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@986:
-		Category: Swampy LAT
+		Categories: Swampy LAT
 		Id: 986
 		Images: slat01.tem, slat01a.tem
 		Size: 1, 1
@@ -18987,7 +18987,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@987:
-		Category: Swampy LAT
+		Categories: Swampy LAT
 		Id: 987
 		Images: slat02.tem, slat02a.tem
 		Size: 1, 1
@@ -18998,7 +18998,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@988:
-		Category: Swampy LAT
+		Categories: Swampy LAT
 		Id: 988
 		Images: slat03.tem, slat03a.tem
 		Size: 1, 1
@@ -19009,7 +19009,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@989:
-		Category: Swampy LAT
+		Categories: Swampy LAT
 		Id: 989
 		Images: slat04.tem, slat04a.tem
 		Size: 1, 1
@@ -19020,7 +19020,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@990:
-		Category: Swampy LAT
+		Categories: Swampy LAT
 		Id: 990
 		Images: slat05.tem, slat05a.tem
 		Size: 1, 1
@@ -19031,7 +19031,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@991:
-		Category: Swampy LAT
+		Categories: Swampy LAT
 		Id: 991
 		Images: slat06.tem, slat06a.tem
 		Size: 1, 1
@@ -19042,7 +19042,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@992:
-		Category: Swampy LAT
+		Categories: Swampy LAT
 		Id: 992
 		Images: slat07.tem, slat07a.tem
 		Size: 1, 1
@@ -19053,7 +19053,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@993:
-		Category: Swampy LAT
+		Categories: Swampy LAT
 		Id: 993
 		Images: slat08.tem, slat08a.tem
 		Size: 1, 1
@@ -19064,7 +19064,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@994:
-		Category: Swampy LAT
+		Categories: Swampy LAT
 		Id: 994
 		Images: slat09.tem, slat09a.tem
 		Size: 1, 1
@@ -19075,7 +19075,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@995:
-		Category: Swampy LAT
+		Categories: Swampy LAT
 		Id: 995
 		Images: slat10.tem, slat10a.tem
 		Size: 1, 1
@@ -19086,7 +19086,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@996:
-		Category: Swampy LAT
+		Categories: Swampy LAT
 		Id: 996
 		Images: slat11.tem, slat11a.tem
 		Size: 1, 1
@@ -19097,7 +19097,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@997:
-		Category: Swampy LAT
+		Categories: Swampy LAT
 		Id: 997
 		Images: slat12.tem, slat12a.tem
 		Size: 1, 1
@@ -19108,7 +19108,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@998:
-		Category: Swampy LAT
+		Categories: Swampy LAT
 		Id: 998
 		Images: slat13.tem, slat13a.tem
 		Size: 1, 1
@@ -19119,7 +19119,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@999:
-		Category: Swampy LAT
+		Categories: Swampy LAT
 		Id: 999
 		Images: slat14.tem, slat14a.tem
 		Size: 1, 1
@@ -19130,7 +19130,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1000:
-		Category: Swampy LAT
+		Categories: Swampy LAT
 		Id: 1000
 		Images: slat15.tem, slat15a.tem
 		Size: 1, 1
@@ -19141,7 +19141,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1001:
-		Category: Swampy LAT
+		Categories: Swampy LAT
 		Id: 1001
 		Images: slat16.tem, slat16a.tem
 		Size: 1, 1
@@ -19152,7 +19152,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1002:
-		Category: Blue Mold
+		Categories: Blue Mold
 		Id: 1002
 		Images: blue01.tem, blue01a.tem, blue01b.tem, blue01c.tem, blue01d.tem, blue01e.tem, blue01f.tem, blue01g.tem
 		Size: 1, 1
@@ -19163,7 +19163,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1003:
-		Category: Blue Mold LAT
+		Categories: Blue Mold LAT
 		Id: 1003
 		Images: blat01.tem, blat01a.tem
 		Size: 1, 1
@@ -19174,7 +19174,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1004:
-		Category: Blue Mold LAT
+		Categories: Blue Mold LAT
 		Id: 1004
 		Images: blat02.tem, blat02a.tem
 		Size: 1, 1
@@ -19185,7 +19185,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1005:
-		Category: Blue Mold LAT
+		Categories: Blue Mold LAT
 		Id: 1005
 		Images: blat03.tem, blat03a.tem
 		Size: 1, 1
@@ -19196,7 +19196,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1006:
-		Category: Blue Mold LAT
+		Categories: Blue Mold LAT
 		Id: 1006
 		Images: blat04.tem, blat04a.tem
 		Size: 1, 1
@@ -19207,7 +19207,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1007:
-		Category: Blue Mold LAT
+		Categories: Blue Mold LAT
 		Id: 1007
 		Images: blat05.tem, blat05a.tem
 		Size: 1, 1
@@ -19218,7 +19218,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1008:
-		Category: Blue Mold LAT
+		Categories: Blue Mold LAT
 		Id: 1008
 		Images: blat06.tem, blat06a.tem
 		Size: 1, 1
@@ -19229,7 +19229,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1009:
-		Category: Blue Mold LAT
+		Categories: Blue Mold LAT
 		Id: 1009
 		Images: blat07.tem, blat07a.tem
 		Size: 1, 1
@@ -19240,7 +19240,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1010:
-		Category: Blue Mold LAT
+		Categories: Blue Mold LAT
 		Id: 1010
 		Images: blat08.tem, blat08a.tem
 		Size: 1, 1
@@ -19251,7 +19251,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1011:
-		Category: Blue Mold LAT
+		Categories: Blue Mold LAT
 		Id: 1011
 		Images: blat09.tem, blat09a.tem
 		Size: 1, 1
@@ -19262,7 +19262,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1012:
-		Category: Blue Mold LAT
+		Categories: Blue Mold LAT
 		Id: 1012
 		Images: blat10.tem, blat10a.tem
 		Size: 1, 1
@@ -19273,7 +19273,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1013:
-		Category: Blue Mold LAT
+		Categories: Blue Mold LAT
 		Id: 1013
 		Images: blat11.tem, blat11a.tem
 		Size: 1, 1
@@ -19284,7 +19284,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1014:
-		Category: Blue Mold LAT
+		Categories: Blue Mold LAT
 		Id: 1014
 		Images: blat12.tem, blat12a.tem
 		Size: 1, 1
@@ -19295,7 +19295,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1015:
-		Category: Blue Mold LAT
+		Categories: Blue Mold LAT
 		Id: 1015
 		Images: blat13.tem, blat13a.tem
 		Size: 1, 1
@@ -19306,7 +19306,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1016:
-		Category: Blue Mold LAT
+		Categories: Blue Mold LAT
 		Id: 1016
 		Images: blat14.tem, blat14a.tem
 		Size: 1, 1
@@ -19317,7 +19317,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1017:
-		Category: Blue Mold LAT
+		Categories: Blue Mold LAT
 		Id: 1017
 		Images: blat15.tem, blat15a.tem
 		Size: 1, 1
@@ -19328,7 +19328,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1018:
-		Category: Blue Mold LAT
+		Categories: Blue Mold LAT
 		Id: 1018
 		Images: blat16.tem, blat16a.tem
 		Size: 1, 1
@@ -19339,7 +19339,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1019:
-		Category: Crystal Cliff
+		Categories: Crystal Cliff
 		Id: 1019
 		Images: ccliff01.tem
 		Size: 2, 2
@@ -19367,7 +19367,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1020:
-		Category: Crystal Cliff
+		Categories: Crystal Cliff
 		Id: 1020
 		Images: ccliff02.tem
 		Size: 2, 2
@@ -19395,7 +19395,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1021:
-		Category: Crystal Cliff
+		Categories: Crystal Cliff
 		Id: 1021
 		Images: ccliff03.tem
 		Size: 2, 2
@@ -19417,7 +19417,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1022:
-		Category: Crystal Cliff
+		Categories: Crystal Cliff
 		Id: 1022
 		Images: ccliff04.tem
 		Size: 1, 1
@@ -19428,7 +19428,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1023:
-		Category: Crystal Cliff
+		Categories: Crystal Cliff
 		Id: 1023
 		Images: ccliff05.tem
 		Size: 2, 2
@@ -19456,7 +19456,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1024:
-		Category: Crystal Cliff
+		Categories: Crystal Cliff
 		Id: 1024
 		Images: ccliff06.tem
 		Size: 2, 2
@@ -19484,7 +19484,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1025:
-		Category: Kodiak Crash
+		Categories: Kodiak Crash
 		Id: 1025
 		Images: crash01.tem
 		Size: 6, 9
@@ -19705,7 +19705,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1026:
-		Category: Kodiak Crash
+		Categories: Kodiak Crash
 		Id: 1026
 		Images: crash02.tem
 		Size: 4, 3
@@ -19751,7 +19751,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1027:
-		Category: Kodiak Crash
+		Categories: Kodiak Crash
 		Id: 1027
 		Images: crash03.tem
 		Size: 12, 9
@@ -20102,7 +20102,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1028:
-		Category: Kodiak Crash
+		Categories: Kodiak Crash
 		Id: 1028
 		Images: crash04.tem
 		Size: 6, 4
@@ -20198,7 +20198,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1029:
-		Category: Kodiak Crash
+		Categories: Kodiak Crash
 		Id: 1029
 		Images: crash05.tem
 		Size: 8, 4
@@ -20292,7 +20292,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1030:
-		Category: Kodiak Crash
+		Categories: Kodiak Crash
 		Id: 1030
 		Images: crash06.tem
 		Size: 8, 5
@@ -20386,7 +20386,7 @@ Templates:
 				ZOffset: -12
 				ZRamp: 0
 	Template@1031:
-		Category: Kodiak Crash
+		Categories: Kodiak Crash
 		Id: 1031
 		Images: crash07.tem
 		Size: 7, 6


### PR DESCRIPTION
Allow multiple categories for tiles as requested here #13303 to display some tiles in more categories in Map editor.
At the beginning of each list by category are all tiles where first/main category is the selected one and then appended remaining tiles to the list so current order won't be affected. 