### PR TITLE
Fix Rectangle OuterRadius calculation

### DIFF
--- a/OpenRA.Mods.Common/HitShapes/Capsule.cs
+++ b/OpenRA.Mods.Common/HitShapes/Capsule.cs
@@ -119,6 +119,8 @@ namespace OpenRA.Mods.Common.HitShapes
 			RangeCircleRenderable.DrawRangeCircle(wr, bb, Radius, 1, c, 0, c);
 			wcr.DrawLine(new[] { wr.Screen3DPosition(aa - offset2), wr.Screen3DPosition(bb - offset2) }, 1, c);
 			wcr.DrawLine(new[] { wr.Screen3DPosition(aa + offset2), wr.Screen3DPosition(bb + offset2) }, 1, c);
+
+			RangeCircleRenderable.DrawRangeCircle(wr, actorPos, OuterRadius, 1, Color.LimeGreen, 0, Color.LimeGreen);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/HitShapes/Rectangle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Rectangle.cs
@@ -67,7 +67,10 @@ namespace OpenRA.Mods.Common.HitShapes
 			quadrantSize = (BottomRight - TopLeft) / 2;
 			center = TopLeft + quadrantSize;
 
-			OuterRadius = new WDist(Math.Max(TopLeft.Length, BottomRight.Length));
+			var topRight = new int2(BottomRight.X, TopLeft.Y);
+			var bottomLeft = new int2(TopLeft.X, BottomRight.Y);
+			var corners = new[] { TopLeft, BottomRight, topRight, bottomLeft };
+			OuterRadius = new WDist(corners.Select(x => x.Length).Max());
 
 			combatOverlayVertsTop = new WVec[]
 			{

--- a/OpenRA.Mods.Common/HitShapes/Rectangle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Rectangle.cs
@@ -13,6 +13,7 @@ using System;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Graphics;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.HitShapes
@@ -139,6 +140,8 @@ namespace OpenRA.Mods.Common.HitShapes
 				wcr.DrawPolygon(vertsTop.ToArray(), 1, Color.Yellow);
 				wcr.DrawPolygon(vertsBottom.ToArray(), 1, Color.Yellow);
 			}
+
+			RangeCircleRenderable.DrawRangeCircle(wr, actorPos, OuterRadius, 1, Color.LimeGreen, 0, Color.LimeGreen);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -27,11 +27,15 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class CombatDebugOverlay : IRenderAboveWorld, INotifyDamage, INotifyCreated
 	{
+		static readonly WVec TargetPosHLine = new WVec(0, 128, 0);
+		static readonly WVec TargetPosVLine = new WVec(128, 0, 0);
+
 		readonly DeveloperMode devMode;
 		readonly HealthInfo healthInfo;
 		readonly Lazy<BodyOrientation> coords;
 
 		IBlocksProjectiles[] allBlockers;
+		ITargetablePositions[] targetablePositions;
 
 		public CombatDebugOverlay(Actor self)
 		{
@@ -45,6 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 		void INotifyCreated.Created(Actor self)
 		{
 			allBlockers = self.TraitsImplementing<IBlocksProjectiles>().ToArray();
+			targetablePositions = self.TraitsImplementing<ITargetablePositions>().ToArray();
 		}
 
 		void IRenderAboveWorld.RenderAboveWorld(Actor self, WorldRenderer wr)
@@ -68,6 +73,17 @@ namespace OpenRA.Mods.Common.Traits
 				wcr.DrawLine(ha, hb, iz, hc);
 				TargetLineRenderable.DrawTargetMarker(wr, hc, ha);
 				TargetLineRenderable.DrawTargetMarker(wr, hc, hb);
+			}
+
+			var tc = Color.Lime;
+			var enabledPositions = targetablePositions.Where(Exts.IsTraitEnabled);
+			var positions = enabledPositions.SelectMany(tp => tp.TargetablePositions(self));
+			foreach (var p in positions)
+			{
+				var center = wr.Screen3DPosition(p);
+				TargetLineRenderable.DrawTargetMarker(wr, tc, center);
+				wcr.DrawLine(wr.Screen3DPosition(p - TargetPosHLine), wr.Screen3DPosition(p + TargetPosHLine), iz, tc);
+				wcr.DrawLine(wr.Screen3DPosition(p - TargetPosVLine), wr.Screen3DPosition(p + TargetPosVLine), iz, tc);
 			}
 
 			foreach (var attack in self.TraitsImplementing<AttackBase>().Where(x => !x.IsTraitDisabled))

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -767,7 +767,7 @@ repair_pad:
 	Tooltip:
 		Name: Repair Pad
 	Building:
-		Footprint: =x= =x= ===
+		Footprint: =x= xxx =x=
 		Dimensions: 3,3
 	Health:
 		HP: 3000


### PR DESCRIPTION
It didn't take BottomLeft and TopRight corners into consideration, so it could end up too small depending on the positioning of the shape (see screenshots).

Additionally, this PR
- fixes the D2k repair pad footprint to match the original
- changes the `HitShape` debug overlay color from `Yellow` to `GreenYellow`, to avoid confusion with voxel render debug shapes
- adds debug overlays for `OuterRadius` to `Capsule` and `Rectangle` shapes
- adds debug overlay for `TargetablePositions`

The goal of this PR is to prevent the next revision of #13314 from growing too large.

Before:
![beforefix1](https://cloud.githubusercontent.com/assets/2857877/26379895/cc66d4fe-401b-11e7-9e81-c897d311eed7.png)

After:
![afterfix1](https://cloud.githubusercontent.com/assets/2857877/26379900/d2884016-401b-11e7-83e5-a72ebf6c8153.png)
