### PR TITLE
TS - Implement some of missing Elite Abilities

### DIFF
--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -188,6 +188,10 @@ MMCH:
 		Recoil: 128
 		RecoilRecovery: 32
 		LocalOffset: 905,272,1177
+	DetectCloaked:
+		Range: 1c768
+		RequiresCondition: rank-elite
+	RenderDetectionCircle:
 	WithMuzzleOverlay:
 	RenderVoxels:
 	WithVoxelBarrel:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -70,6 +70,10 @@ BIKE:
 		LocalOffset: -153,-204,509, -153,204,509
 	AttackFrontal:
 		Voice: Attack
+	DamagedByTerrain@VEINS:
+		RequiresCondition: !inside-tunnel && !rank-elite
+	LeavesTrails@VEINS:
+		RequiresCondition: !inside-tunnel && !rank-elite
 
 TTNK:
 	Inherits: ^Tank
@@ -171,6 +175,10 @@ TTNK:
 	Armor@deployed:
 		Type: Concrete
 		RequiresCondition: deployed
+	DetectCloaked:
+		Range: 1c768
+		RequiresCondition: rank-elite
+	RenderDetectionCircle:
 	Carryable:
 		RequiresCondition: undeployed
 	RevealOnFire:


### PR DESCRIPTION
Fixes some parts of #13209.

> Explodes: and AppearsOnRadar: looks unconditionable, Mobile: doesn't allow multipile instances. So RADAR_INVISIBLE, CRUSHER and EXPLODES are not possible just with .yaml editing.

> SMECH looks like already have ImmuneToVeins=yes and we coded them like so, so it is unnecessary on it.