### PR TITLE
Make Explodes conditional and implement TS elite explosions

### DIFF
--- a/OpenRA.Mods.Common/Traits/Explodes.cs
+++ b/OpenRA.Mods.Common/Traits/Explodes.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class ExplodesInfo : ConditionalTraitInfo, Requires<HealthInfo>
 	{
 		[WeaponReference, FieldLoader.Require, Desc("Default weapon to use for explosion if ammo/payload is loaded.")]
-		public readonly string Weapon = "UnitExplode";
+		public readonly string Weapon = null;
 
 		[WeaponReference, Desc("Fallback weapon to use for explosion if empty (no ammo/payload).")]
 		public readonly string EmptyWeapon = "UnitExplode";

--- a/OpenRA.Mods.Common/Traits/Explodes.cs
+++ b/OpenRA.Mods.Common/Traits/Explodes.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 	public enum ExplosionType { Footprint, CenterPosition }
 
 	[Desc("This actor explodes when killed.")]
-	public class ExplodesInfo : ITraitInfo, IRulesetLoaded, Requires<HealthInfo>
+	public class ExplodesInfo : ConditionalTraitInfo, Requires<HealthInfo>
 	{
 		[WeaponReference, FieldLoader.Require, Desc("Default weapon to use for explosion if ammo/payload is loaded.")]
 		public readonly string Weapon = "UnitExplode";
@@ -47,23 +47,24 @@ namespace OpenRA.Mods.Common.Traits
 		public WeaponInfo WeaponInfo { get; private set; }
 		public WeaponInfo EmptyWeaponInfo { get; private set; }
 
-		public object Create(ActorInitializer init) { return new Explodes(this, init.Self); }
-		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
+		public override object Create(ActorInitializer init) { return new Explodes(this, init.Self); }
+		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
 			WeaponInfo = string.IsNullOrEmpty(Weapon) ? null : rules.Weapons[Weapon.ToLowerInvariant()];
 			EmptyWeaponInfo = string.IsNullOrEmpty(EmptyWeapon) ? null : rules.Weapons[EmptyWeapon.ToLowerInvariant()];
+
+			base.RulesetLoaded(rules, ai);
 		}
 	}
 
-	public class Explodes : INotifyKilled, INotifyDamage, INotifyCreated
+	public class Explodes : ConditionalTrait<ExplodesInfo>, INotifyKilled, INotifyDamage, INotifyCreated
 	{
-		readonly ExplodesInfo info;
 		readonly Health health;
 		BuildingInfo buildingInfo;
 
 		public Explodes(ExplodesInfo info, Actor self)
+			: base(info)
 		{
-			this.info = info;
 			health = self.Trait<Health>();
 		}
 
@@ -74,13 +75,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyKilled.Killed(Actor self, AttackInfo e)
 		{
-			if (!self.IsInWorld)
+			if (IsTraitDisabled || !self.IsInWorld)
 				return;
 
-			if (self.World.SharedRandom.Next(100) > info.Chance)
+			if (self.World.SharedRandom.Next(100) > Info.Chance)
 				return;
 
-			if (info.DeathTypes.Count > 0 && !e.Damage.DamageTypes.Overlaps(info.DeathTypes))
+			if (Info.DeathTypes.Count > 0 && !e.Damage.DamageTypes.Overlaps(Info.DeathTypes))
 				return;
 
 			var weapon = ChooseWeaponForExplosion(self);
@@ -90,7 +91,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (weapon.Report != null && weapon.Report.Any())
 				Game.Sound.Play(SoundType.World, weapon.Report.Random(e.Attacker.World.SharedRandom), self.CenterPosition);
 
-			if (info.Type == ExplosionType.Footprint && buildingInfo != null)
+			if (Info.Type == ExplosionType.Footprint && buildingInfo != null)
 			{
 				var cells = FootprintUtils.UnpathableTiles(self.Info.Name, buildingInfo, self.Location);
 				foreach (var c in cells)
@@ -106,16 +107,19 @@ namespace OpenRA.Mods.Common.Traits
 		WeaponInfo ChooseWeaponForExplosion(Actor self)
 		{
 			var shouldExplode = self.TraitsImplementing<IExplodeModifier>().All(a => a.ShouldExplode(self));
-			var useFullExplosion = self.World.SharedRandom.Next(100) <= info.LoadedChance;
-			return (shouldExplode && useFullExplosion) ? info.WeaponInfo : info.EmptyWeaponInfo;
+			var useFullExplosion = self.World.SharedRandom.Next(100) <= Info.LoadedChance;
+			return (shouldExplode && useFullExplosion) ? Info.WeaponInfo : Info.EmptyWeaponInfo;
 		}
 
 		void INotifyDamage.Damaged(Actor self, AttackInfo e)
 		{
-			if (info.DamageThreshold == 0)
+			if (IsTraitDisabled || !self.IsInWorld)
 				return;
 
-			if (health.HP * 100 < info.DamageThreshold * health.MaxHP)
+			if (Info.DamageThreshold == 0)
+				return;
+
+			if (health.HP * 100 < Info.DamageThreshold * health.MaxHP)
 				self.World.AddFrameEndTask(w => self.Kill(e.Attacker));
 		}
 	}

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -282,6 +282,11 @@ SONIC:
 		TurnSpeed: 5
 		Offset: -170,0,0
 	WithVoxelTurret:
+	Explodes:
+		RequiresCondition: !rank-elite
+	Explodes@ELITE:
+		RequiresCondition: rank-elite
+		Weapon: UnitExplode
 
 JUGG:
 	Inherits: ^Tank

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -476,3 +476,8 @@ STNK:
 		InitialStance: HoldFire
 		InitialStanceAI: ReturnFire
 	-MustBeDestroyed:
+	Explodes:
+		RequiresCondition: !rank-elite
+	Explodes@ELITE:
+		RequiresCondition: rank-elite
+		Weapon: UnitExplode

--- a/mods/ts/weapons/explosions.yaml
+++ b/mods/ts/weapons/explosions.yaml
@@ -1,8 +1,8 @@
 ^DamagingExplosion:
 	Warhead@1Dam: SpreadDamage
-		Spread: 192
+		Spread: 256
 		Falloff: 100, 50, 25, 12, 6, 3, 0
-		Damage: 50
+		Damage: 500
 		Versus:
 			None: 90
 			Wood: 75
@@ -10,9 +10,9 @@
 			Heavy: 25
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
-		Explosions: large_twlt
+		Explosions: large_brnl, large_bang, medium_twlt
 		ExplosionPalette: effect-ignore-lighting-alpha75
-		ImpactSounds: expnew09.aud
+		ImpactSounds: expnew09.aud, expnew10.aud, expnew12.aud
 	Warhead@4Smu: LeaveSmudge
 		SmudgeType: MediumCrater
 		InvalidTargets: Building, Wall
@@ -23,6 +23,7 @@ UnitExplode:
 UnitExplodeSmall:
 	Inherits: ^DamagingExplosion
 	Warhead@1Dam: SpreadDamage
+		Spread: 192
 		Damage: 40
 	Warhead@2Eff: CreateEffect
 		Explosions: medium_brnl


### PR DESCRIPTION
And use that to replicate original `EXPLODES` elite ability.
Fixes a part of #13209.

Note: I don't know how exactly the damage was calculated in the original, so my choice was a bit arbitrary and might need some fine-tuning.