### PR TITLE
Remove legacy FileSystem.OpenPackage(string, IReadOnlyPackage).

### DIFF
--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -81,12 +81,6 @@ namespace OpenRA.FileSystem
 			return null;
 		}
 
-		public IReadOnlyPackage OpenPackage(string filename, IReadOnlyPackage parent)
-		{
-			// TODO: Make legacy callers access the parent package directly
-			return parent.OpenPackage(filename, this);
-		}
-
 		public void Mount(string name, string explicitName = null)
 		{
 			var optional = name.StartsWith("~", StringComparison.Ordinal);

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -92,7 +92,7 @@ namespace OpenRA
 					{
 						using (new Support.PerfTimer(map))
 						{
-							mapPackage = modData.ModFiles.OpenPackage(map, kv.Key);
+							mapPackage = kv.Key.OpenPackage(map, modData.ModFiles);
 							if (mapPackage == null)
 								continue;
 

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -471,7 +471,7 @@ namespace OpenRA
 						Log.Write("debug", "Downloaded map to '{0}'", mapFilename);
 						Game.RunAfterTick(() =>
 						{
-							var package = modData.ModFiles.OpenPackage(mapFilename, mapInstallPackage);
+							var package = mapInstallPackage.OpenPackage(mapFilename, modData.ModFiles);
 							if (package == null)
 								innerData.Status = MapStatus.DownloadError;
 							else

--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						.Select(m => new Map(modData, m.Package)));
 				}
 				else
-					maps.Add(new Map(modData, modData.ModFiles.OpenPackage(args[1], new FileSystem.Folder("."))));
+					maps.Add(new Map(modData, new FileSystem.Folder(".").OpenPackage(args[1], modData.ModFiles)));
 
 				foreach (var testMap in maps)
 				{

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractMapRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractMapRules.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		{
 			var modData = Game.ModData = utility.ModData;
 
-			var map = new Map(modData, modData.ModFiles.OpenPackage(args[1], new Folder(".")));
+			var map = new Map(modData, new Folder(".").OpenPackage(args[1], modData.ModFiles));
 			MergeAndPrint(map, "Rules", map.RuleDefinitions);
 			MergeAndPrint(map, "Sequences", map.SequenceDefinitions);
 			MergeAndPrint(map, "VoxelSequences", map.VoxelSequenceDefinitions);

--- a/OpenRA.Mods.Common/UtilityCommands/GetMapHashCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/GetMapHashCommand.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		[Desc("MAPFILE", "Generate hash of specified oramap file.")]
 		void IUtilityCommand.Run(Utility utility, string[] args)
 		{
-			using (var package = utility.ModData.ModFiles.OpenPackage(args[1], new Folder(".")))
+			using (var package = new Folder(".").OpenPackage(args[1], utility.ModData.ModFiles))
 				Console.WriteLine(Map.ComputeUID(package));
 		}
 	}

--- a/OpenRA.Mods.Common/UtilityCommands/ResizeMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ResizeMapCommand.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		void IUtilityCommand.Run(Utility utility, string[] args)
 		{
 			var modData = Game.ModData = utility.ModData;
-			map = new Map(modData, modData.ModFiles.OpenPackage(args[1], new Folder(".")));
+			map = new Map(modData, new Folder(".").OpenPackage(args[1], modData.ModFiles));
 			Console.WriteLine("Resizing map {0} from {1} to {2},{3}", map.Title, map.MapSize, width, height);
 			map.Resize(width, height);
 

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeMapCommand.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			var modData = Game.ModData = utility.ModData;
 
 			// HACK: We know that maps can only be oramap or folders, which are ReadWrite
-			var package = modData.ModFiles.OpenPackage(args[1], new Folder(".")) as IReadWritePackage;
+			var package = new Folder(".").OpenPackage(args[1], modData.ModFiles) as IReadWritePackage;
 			if (package == null)
 				throw new FileNotFoundException(args[1]);
 

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						{
 							try
 							{
-								using (var mapPackage = modData.ModFiles.OpenPackage(map, package))
+								using (var mapPackage = package.OpenPackage(map, modData.ModFiles))
 								{
 									if (mapPackage != null)
 										UpgradeMapCommand.UpgradeMap(modData, (IReadWritePackage)mapPackage, engineDate);

--- a/OpenRA.Mods.Common/UtilityCommands/Utilities.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/Utilities.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			{
 				try
 				{
-					map = new Map(modData, modData.ModFiles.OpenPackage(mapPath, new Folder(".")));
+					map = new Map(modData, new Folder(".").OpenPackage(mapPath, modData.ModFiles));
 				}
 				catch (InvalidDataException ex)
 				{


### PR DESCRIPTION
Fixes one of the followup items from #13223.