### PR TITLE
Move package loaders to mod code.

### DIFF
--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -259,7 +259,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FileSystem\Folder.cs" />
-    <Compile Include="FileSystem\InstallShieldPackage.cs" />
     <Compile Include="FileSystem\ZipFile.cs" />
     <Compile Include="Map\PlayerReference.cs" />
     <Compile Include="Map\TileReference.cs" />
@@ -268,7 +267,6 @@
     <Compile Include="FieldSaver.cs" />
     <Compile Include="Manifest.cs" />
     <Compile Include="Graphics\Vertex.cs" />
-    <Compile Include="FileFormats\Blast.cs" />
     <Compile Include="FileFormats\HvaReader.cs" />
     <Compile Include="FileFormats\PngLoader.cs" />
     <Compile Include="FileFormats\VxlReader.cs" />

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -107,11 +107,8 @@
     <Compile Include="Activities\CallFunc.cs" />
     <Compile Include="Actor.cs" />
     <Compile Include="CacheStorage.cs" />
-    <Compile Include="FileSystem\IdxEntry.cs" />
     <Compile Include="FileSystem\IPackage.cs" />
     <Compile Include="LogProxy.cs" />
-    <Compile Include="FileFormats\IdxReader.cs" />
-    <Compile Include="FileSystem\BagFile.cs" />
     <Compile Include="Map\MapGrid.cs" />
     <Compile Include="Map\MapPlayers.cs" />
     <Compile Include="MPos.cs" />
@@ -263,10 +260,7 @@
   <ItemGroup>
     <Compile Include="FileSystem\Folder.cs" />
     <Compile Include="FileSystem\InstallShieldPackage.cs" />
-    <Compile Include="FileSystem\MixFile.cs" />
-    <Compile Include="FileSystem\Pak.cs" />
     <Compile Include="FileSystem\ZipFile.cs" />
-    <Compile Include="FileSystem\BigFile.cs" />
     <Compile Include="Map\PlayerReference.cs" />
     <Compile Include="Map\TileReference.cs" />
     <Compile Include="Map\TileSet.cs" />
@@ -275,11 +269,6 @@
     <Compile Include="Manifest.cs" />
     <Compile Include="Graphics\Vertex.cs" />
     <Compile Include="FileFormats\Blast.cs" />
-    <Compile Include="FileFormats\Blowfish.cs" />
-    <Compile Include="FileFormats\BlowfishKeyProvider.cs" />
-    <Compile Include="FileFormats\CRC32.cs" />
-    <Compile Include="FileFormats\XccGlobalDatabase.cs" />
-    <Compile Include="FileFormats\XccLocalDatabase.cs" />
     <Compile Include="FileFormats\HvaReader.cs" />
     <Compile Include="FileFormats\PngLoader.cs" />
     <Compile Include="FileFormats\VxlReader.cs" />
@@ -303,7 +292,6 @@
     <Compile Include="Map\MapCache.cs" />
     <Compile Include="Map\MapPreview.cs" />
     <Compile Include="Graphics\HSLColor.cs" />
-    <Compile Include="FileSystem\PackageEntry.cs" />
     <Compile Include="CPos.cs" />
     <Compile Include="CVec.cs" />
     <Compile Include="WAngle.cs" />

--- a/OpenRA.Mods.Cnc/FileFormats/Blowfish.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/Blowfish.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-namespace OpenRA.FileFormats
+namespace OpenRA.Mods.Cnc.FileFormats
 {
 	class Blowfish
 	{

--- a/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
@@ -12,7 +12,7 @@
 using System;
 using System.Linq;
 
-namespace OpenRA.FileFormats
+namespace OpenRA.Mods.Cnc.FileFormats
 {
 	/* TODO: Convert this direct C port into readable code. */
 

--- a/OpenRA.Mods.Cnc/FileFormats/CRC32.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/CRC32.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-namespace OpenRA.FileFormats
+namespace OpenRA.Mods.Cnc.FileFormats
 {
 	/// <summary>
 	/// Static class that uses a lookup table to calculates CRC32

--- a/OpenRA.Mods.Cnc/FileFormats/IdxEntry.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/IdxEntry.cs
@@ -9,10 +9,9 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.IO;
 
-namespace OpenRA.FileSystem
+namespace OpenRA.Mods.Cnc.FileFormats
 {
 	public class IdxEntry
 	{

--- a/OpenRA.Mods.Cnc/FileFormats/IdxReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/IdxReader.cs
@@ -11,9 +11,8 @@
 
 using System.Collections.Generic;
 using System.IO;
-using OpenRA.FileSystem;
 
-namespace OpenRA.FileFormats
+namespace OpenRA.Mods.Cnc.FileFormats
 {
 	public class IdxReader
 	{

--- a/OpenRA.Mods.Cnc/FileFormats/XccGlobalDatabase.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/XccGlobalDatabase.cs
@@ -13,7 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 
-namespace OpenRA.FileFormats
+namespace OpenRA.Mods.Cnc.FileFormats
 {
 	public class XccGlobalDatabase : IDisposable
 	{

--- a/OpenRA.Mods.Cnc/FileFormats/XccLocalDatabase.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/XccLocalDatabase.cs
@@ -14,7 +14,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 
-namespace OpenRA.FileFormats
+namespace OpenRA.Mods.Cnc.FileFormats
 {
 	public class XccLocalDatabase
 	{

--- a/OpenRA.Mods.Cnc/FileSystem/BagFile.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/BagFile.cs
@@ -13,10 +13,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using OpenRA.FileFormats;
+using OpenRA.FileSystem;
+using OpenRA.Mods.Cnc.FileFormats;
 using OpenRA.Primitives;
+using FS = OpenRA.FileSystem.FileSystem;
 
-namespace OpenRA.FileSystem
+namespace OpenRA.Mods.Cnc.FileSystem
 {
 	public class AudioBagLoader : IPackageLoader
 	{
@@ -109,7 +111,7 @@ namespace OpenRA.FileSystem
 				return index.ContainsKey(filename);
 			}
 
-			public IReadOnlyPackage OpenPackage(string filename, FileSystem context)
+			public IReadOnlyPackage OpenPackage(string filename, FS context)
 			{
 				// Not implemented
 				return null;
@@ -121,7 +123,7 @@ namespace OpenRA.FileSystem
 			}
 		}
 
-		bool IPackageLoader.TryParsePackage(Stream s, string filename, FileSystem context, out IReadOnlyPackage package)
+		bool IPackageLoader.TryParsePackage(Stream s, string filename, FS context, out IReadOnlyPackage package)
 		{
 			if (!filename.EndsWith(".bag", StringComparison.InvariantCultureIgnoreCase))
 			{

--- a/OpenRA.Mods.Cnc/FileSystem/BigFile.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/BigFile.cs
@@ -12,8 +12,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using OpenRA.FileSystem;
+using FS = OpenRA.FileSystem.FileSystem;
 
-namespace OpenRA.FileSystem
+namespace OpenRA.Mods.Cnc.FileSystem
 {
 	public class BigLoader : IPackageLoader
 	{
@@ -97,7 +99,7 @@ namespace OpenRA.FileSystem
 				return index.ContainsKey(filename);
 			}
 
-			public IReadOnlyPackage OpenPackage(string filename, FileSystem context)
+			public IReadOnlyPackage OpenPackage(string filename, FS context)
 			{
 				// Not implemented
 				return null;
@@ -109,7 +111,7 @@ namespace OpenRA.FileSystem
 			}
 		}
 
-		bool IPackageLoader.TryParsePackage(Stream s, string filename, FileSystem context, out IReadOnlyPackage package)
+		bool IPackageLoader.TryParsePackage(Stream s, string filename, FS context, out IReadOnlyPackage package)
 		{
 			// Take a peek at the file signature
 			var signature = s.ReadASCII(4);

--- a/OpenRA.Mods.Cnc/FileSystem/MixFile.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/MixFile.cs
@@ -14,9 +14,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using OpenRA.FileFormats;
+using OpenRA.FileSystem;
+using OpenRA.Mods.Cnc.FileFormats;
 using OpenRA.Primitives;
+using FS = OpenRA.FileSystem.FileSystem;
 
-namespace OpenRA.FileSystem
+namespace OpenRA.Mods.Cnc.FileSystem
 {
 	public class MixLoader : IPackageLoader
 	{
@@ -222,7 +225,7 @@ namespace OpenRA.FileSystem
 				return index.ContainsKey(filename);
 			}
 
-			public IReadOnlyPackage OpenPackage(string filename, FileSystem context)
+			public IReadOnlyPackage OpenPackage(string filename, FS context)
 			{
 				IReadOnlyPackage package;
 				var childStream = GetStream(filename);
@@ -242,7 +245,7 @@ namespace OpenRA.FileSystem
 			}
 		}
 
-		bool IPackageLoader.TryParsePackage(Stream s, string filename, FileSystem context, out IReadOnlyPackage package)
+		bool IPackageLoader.TryParsePackage(Stream s, string filename, FS context, out IReadOnlyPackage package)
 		{
 			if (!filename.EndsWith(".mix", StringComparison.InvariantCultureIgnoreCase))
 			{

--- a/OpenRA.Mods.Cnc/FileSystem/PackageEntry.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/PackageEntry.cs
@@ -13,9 +13,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using OpenRA.FileFormats;
+using OpenRA.Mods.Cnc.FileFormats;
 
-namespace OpenRA.FileSystem
+namespace OpenRA.Mods.Cnc.FileSystem
 {
 	public enum PackageHashType { Classic, CRC32 }
 

--- a/OpenRA.Mods.Cnc/FileSystem/Pak.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/Pak.cs
@@ -12,8 +12,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using OpenRA.FileSystem;
+using FS = OpenRA.FileSystem.FileSystem;
 
-namespace OpenRA.FileSystem
+namespace OpenRA.Mods.Cnc.FileSystem
 {
 	public class PakFileLoader : IPackageLoader
 	{
@@ -77,7 +79,7 @@ namespace OpenRA.FileSystem
 				return index.ContainsKey(filename);
 			}
 
-			public IReadOnlyPackage OpenPackage(string filename, FileSystem context)
+			public IReadOnlyPackage OpenPackage(string filename, FS context)
 			{
 				// Not implemented
 				return null;
@@ -89,7 +91,7 @@ namespace OpenRA.FileSystem
 			}
 		}
 
-		bool IPackageLoader.TryParsePackage(Stream s, string filename, FileSystem context, out IReadOnlyPackage package)
+		bool IPackageLoader.TryParsePackage(Stream s, string filename, FS context, out IReadOnlyPackage package)
 		{
 			if (!filename.EndsWith(".pak", StringComparison.InvariantCultureIgnoreCase))
 			{

--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -134,6 +134,19 @@
     <Compile Include="UtilityCommands\ImportRedAlertLegacyMapCommand.cs" />
     <Compile Include="Traits\Infiltration\InfiltrateForDecoration.cs" />
     <Compile Include="TraitsInterfaces.cs" />
+    <Compile Include="FileSystem\BagFile.cs" />
+    <Compile Include="FileSystem\BigFile.cs" />
+    <Compile Include="FileSystem\MixFile.cs" />
+    <Compile Include="FileSystem\PackageEntry.cs" />
+    <Compile Include="FileSystem\Pak.cs" />
+    <Compile Include="UtilityCommands\ListMixContentsCommand.cs" />
+    <Compile Include="FileFormats\Blowfish.cs" />
+    <Compile Include="FileFormats\BlowfishKeyProvider.cs" />
+    <Compile Include="FileFormats\IdxEntry.cs" />
+    <Compile Include="FileFormats\IdxReader.cs" />
+    <Compile Include="FileFormats\XccGlobalDatabase.cs" />
+    <Compile Include="FileFormats\XccLocalDatabase.cs" />
+    <Compile Include="FileFormats\CRC32.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OpenRA.Game\OpenRA.Game.csproj">

--- a/OpenRA.Mods.Cnc/UtilityCommands/ListMixContentsCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ListMixContentsCommand.cs
@@ -13,10 +13,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using OpenRA.FileFormats;
-using OpenRA.FileSystem;
+using OpenRA.Mods.Cnc.FileFormats;
+using OpenRA.Mods.Cnc.FileSystem;
 
-namespace OpenRA.Mods.Common.UtilityCommands
+namespace OpenRA.Mods.Cnc.UtilityCommands
 {
 	class ListMixContents : IUtilityCommand
 	{

--- a/OpenRA.Mods.Common/FileFormats/Blast.cs
+++ b/OpenRA.Mods.Common/FileFormats/Blast.cs
@@ -15,7 +15,7 @@
 using System;
 using System.IO;
 
-namespace OpenRA.FileFormats
+namespace OpenRA.Mods.Common.FileFormats
 {
 	public static class Blast
 	{

--- a/OpenRA.Mods.Common/FileSystem/InstallShieldPackage.cs
+++ b/OpenRA.Mods.Common/FileSystem/InstallShieldPackage.cs
@@ -9,12 +9,13 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.IO;
-using OpenRA.FileFormats;
+using OpenRA.FileSystem;
+using OpenRA.Mods.Common.FileFormats;
+using FS = OpenRA.FileSystem.FileSystem;
 
-namespace OpenRA.FileSystem
+namespace OpenRA.Mods.Common.FileSystem
 {
 	public class InstallShieldLoader : IPackageLoader
 	{
@@ -121,7 +122,7 @@ namespace OpenRA.FileSystem
 				return ret;
 			}
 
-			public IReadOnlyPackage OpenPackage(string filename, FileSystem context)
+			public IReadOnlyPackage OpenPackage(string filename, FS context)
 			{
 				// Not implemented
 				return null;
@@ -140,7 +141,7 @@ namespace OpenRA.FileSystem
 			}
 		}
 
-		bool IPackageLoader.TryParsePackage(Stream s, string filename, FileSystem context, out IReadOnlyPackage package)
+		bool IPackageLoader.TryParsePackage(Stream s, string filename, FS context, out IReadOnlyPackage package)
 		{
 			// Take a peek at the file signature
 			var signature = s.ReadUInt32();

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -760,7 +760,6 @@
     <Compile Include="Widgets\Logic\Installation\ModContentDiscTooltipLogic.cs" />
     <Compile Include="Widgets\Logic\Installation\InstallFromDiscLogic.cs" />
     <Compile Include="Widgets\Logic\Installation\ModContentPromptLogic.cs" />
-    <Compile Include="UtilityCommands\ListMixContentsCommand.cs" />
     <Compile Include="UtilityCommands\ListMSCabContentsCommand.cs" />
     <Compile Include="FileFormats\MSCabCompression.cs" />
     <Compile Include="Traits\World\ScriptLobbyDropdown.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -807,6 +807,8 @@
     <Compile Include="Traits\Conditions\LineBuildSegmentExternalCondition.cs" />
     <Compile Include="Traits\EntersTunnels.cs" />
     <Compile Include="Traits\TunnelEntrance.cs" />
+    <Compile Include="FileSystem\InstallShieldPackage.cs" />
+    <Compile Include="FileFormats\Blast.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.FileSystem;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.UtilityCommands
@@ -82,7 +83,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						.Select(m => new Map(modData, m.Package)));
 				}
 				else
-					maps.Add(new Map(modData, new FileSystem.Folder(".").OpenPackage(args[1], modData.ModFiles)));
+					maps.Add(new Map(modData, new Folder(".").OpenPackage(args[1], modData.ModFiles)));
 
 				foreach (var testMap in maps)
 				{

--- a/OpenRA.Mods.Common/UtilityCommands/ListInstallShieldContentsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ListInstallShieldContentsCommand.cs
@@ -11,7 +11,7 @@
 
 using System;
 using System.IO;
-using OpenRA.FileSystem;
+using OpenRA.Mods.Common.FileSystem;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.FileSystem;
 using OpenRA.Widgets;
+using FS = OpenRA.FileSystem.FileSystem;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
@@ -37,7 +38,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var modObjectCreator = new ObjectCreator(mod, Game.Mods);
 			var modPackageLoaders = modObjectCreator.GetLoaders<IPackageLoader>(mod.PackageFormats, "package");
-			var modFileSystem = new FileSystem.FileSystem(Game.Mods, modPackageLoaders);
+			var modFileSystem = new FS(Game.Mods, modPackageLoaders);
 			modFileSystem.LoadFromManifest(mod);
 
 			var sourceYaml = MiniYaml.Load(modFileSystem, content.Sources, null);

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentPromptLogic.cs
@@ -13,6 +13,7 @@ using System;
 using System.Linq;
 using OpenRA.FileSystem;
 using OpenRA.Widgets;
+using FS = OpenRA.FileSystem.FileSystem;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
@@ -58,7 +59,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				var modObjectCreator = new ObjectCreator(mod, Game.Mods);
 				var modPackageLoaders = modObjectCreator.GetLoaders<IPackageLoader>(mod.PackageFormats, "package");
-				var modFileSystem = new FileSystem.FileSystem(Game.Mods, modPackageLoaders);
+				var modFileSystem = new FS(Game.Mods, modPackageLoaders);
 				modFileSystem.LoadFromManifest(mod);
 
 				var downloadYaml = MiniYaml.Load(modFileSystem, content.Downloads, null);


### PR DESCRIPTION
This is the final followup item from #13223.

This also marks a notable milestone: our core engine is now, except for the voxel loader, completely clean of format loaders or other algorithms used by the original games.