### PR TITLE
Tweak TS sprite mechs visuals

### DIFF
--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -190,7 +190,7 @@ MMCH:
 		MuzzlePalette: effect-ignore-lighting
 		Recoil: 128
 		RecoilRecovery: 32
-		LocalOffset: 905,272,1177
+		LocalOffset: 1024,272,1216
 	DetectCloaked:
 		Range: 1c768
 		RequiresCondition: rank-elite
@@ -198,7 +198,7 @@ MMCH:
 	WithMuzzleOverlay:
 	RenderVoxels:
 	WithVoxelBarrel:
-		LocalOffset: -91,91,362
+		LocalOffset: 0,51,256
 	Selectable:
 		Bounds: 30, 42, 0, -8
 	Carryable:

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -140,7 +140,7 @@ SMECH:
 	WithAttackAnimation:
 		AttackSequence: shoot
 	WithMoveAnimation:
-		MoveSequence: run
+		MoveSequence: walk
 	Selectable:
 		Bounds: 20, 32, 0, -8
 	-DamagedByTerrain@VEINS:
@@ -174,7 +174,10 @@ MMCH:
 	BodyOrientation:
 		QuantizedFacings: 32
 		UseClassicPerspectiveFudge: False
-	WithInfantryBody:
+	WithFacingSpriteBody:
+		Sequence: stand
+	WithMoveAnimation:
+		MoveSequence: walk
 	Turreted:
 		TurnSpeed: 5
 	AttackTurreted:
@@ -323,7 +326,7 @@ JUGG:
 		Sequence: stand
 		RequiresCondition: undeployed
 	WithMoveAnimation:
-		MoveSequence: run
+		MoveSequence: walk
 	GrantConditionOnDeploy:
 		DeployedCondition: deployed
 		UndeployedCondition: undeployed

--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -27,8 +27,8 @@ waypoint:
 		InitialFacing: 160
 	Turreted:
 		InitialFacing: 160
-	WithInfantryBody:
-		StandSequences: run
+	WithFacingSpriteBody:
+		Sequence: walk
 	RenderVoxels:
 		Image: mmch
 		Palette: colorpicker

--- a/mods/ts/sequences/vehicles.yaml
+++ b/mods/ts/sequences/vehicles.yaml
@@ -159,11 +159,12 @@ mmch:
 		Stride: 15
 		ShadowStart: 152
 		Offset: 0, 0, 12
-	run:
+	walk:
 		Length: 15
 		Facings: -8
 		ShadowStart: 152
 		Offset: 0, 0, 12
+		Tick: 60
 	turret:
 		Start: 120
 		Facings: -32
@@ -181,11 +182,12 @@ jugg:
 		Stride: 15
 		ShadowStart: 120
 		Offset: 0, 0, 12
-	run: jugger
+	walk: jugger
 		Length: 15
 		Facings: -8
 		ShadowStart: 120
 		Offset: 0, 0, 12
+		Tick: 60
 	turret: djugg_a
 		Facings: 32
 		Offset: -4, 0, 12
@@ -219,16 +221,17 @@ smech:
 		Start: 96
 		Facings: -8
 		ShadowStart: 232
-	run:
+	walk:
 		Facings: -8
 		Length: 12
 		ShadowStart: 136
+		Tick: 48
 	shoot:
 		Start: 104
 		Length: 4
 		Facings: -8
 		ShadowStart: 240
-		Tick: 100
+		Tick: 80
 	icon: smchicon
 
 trucka:

--- a/mods/ts/weapons/ballisticweapons.yaml
+++ b/mods/ts/weapons/ballisticweapons.yaml
@@ -44,6 +44,7 @@
 	Inherits: ^Cannon
 	ReloadDelay: 80
 	Projectile: Bullet
+		-Image:
 		Speed: 1c512
 		Blockable: false
 		LaunchAngle: 0


### PR DESCRIPTION
- renames 'run' sequence to 'walk'
- replaces the no-longer-necessary WithInfantryBody on the Titan
- adjusts Tick rates of walk anims and Wolverine attack anim
- fixes barrel, armament offsets of Titan and disables bullet image on `120mm`