### PR TITLE
Catch and ignore BeaconLib errors, stop Beacon on closing server browser

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
@@ -634,5 +634,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			return false;
 		}
+
+		bool disposed;
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && !disposed)
+			{
+				disposed = true;
+				if (lanGameProbe != null)
+					lanGameProbe.Dispose();
+			}
+
+			base.Dispose(disposing);
+		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
@@ -112,9 +112,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Game.LoadWidget(null, "GLOBALCHAT_PANEL", widget.Get("GLOBALCHAT_ROOT"), new WidgetArgs());
 
 			lanGameLocations = new List<BeaconLocation>();
-			lanGameProbe = new Probe("OpenRALANGame");
-			lanGameProbe.BeaconsUpdated += locations => lanGameLocations = locations;
-			lanGameProbe.Start();
+			try
+			{
+				lanGameProbe = new Probe("OpenRALANGame");
+				lanGameProbe.BeaconsUpdated += locations => lanGameLocations = locations;
+				lanGameProbe.Start();
+			}
+			catch (Exception ex)
+			{
+				Log.Write("debug", "BeaconLib.Probe: " + ex.Message);
+			}
 
 			RefreshServerList();
 


### PR DESCRIPTION
Fixes #13348

There is another PR to update BeaconLib to support also frameworks with missing AllowNatTraversal, which I assume is not mandatory for this feature.
+
The LAN probe wasn't disposed, stop it on closing browser.