### PR TITLE
Add Actor Categories and Categories dropdown filter in Map editor

### DIFF
--- a/OpenRA.Mods.Common/Traits/EditorTilesetFilter.cs
+++ b/OpenRA.Mods.Common/Traits/EditorTilesetFilter.cs
@@ -18,6 +18,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public readonly HashSet<string> RequireTilesets = null;
 		public readonly HashSet<string> ExcludeTilesets = null;
+		public readonly string[] Categories;
 	}
 
 	public class EditorTilesetFilter { }

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -137,6 +137,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void InitializeActorPreviews()
 		{
 			panel.RemoveChildren();
+			if (!selectedCategories.Any())
+				return;
 
 			var actors = mapRules.Actors.Where(a => !a.Value.Name.Contains('^'))
 				.Select(a => a.Value);

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -320,10 +320,16 @@ Container@EDITOR_WORLD_ROOT:
 							Width: PARENT_RIGHT
 							Height: 25
 							Font: Bold
-						ScrollPanel@ACTORTEMPLATE_LIST:
-							Y: 24
+						DropDownButton@ACTOR_CATEGORY:
+							Y: 25
 							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM - 24
+							Height: 25
+							Text: Categories
+							Font: Bold
+						ScrollPanel@ACTORTEMPLATE_LIST:
+							Y: 50
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM - 50
 							TopBottomSpacing: 4
 							ItemSpacing: 4
 							Children:
@@ -409,3 +415,29 @@ Container@EDITOR_WORLD_ROOT:
 			Align: Left
 			Font: Bold
 			Contrast: true
+
+ScrollPanel@ACTOR_CATEGORY_FILTER_PANEL:
+	Width: 250
+	Children:
+		Container@SELECT_CATEGORIES_BUTTONS
+			Width: PARENT_RIGHT
+			Height: 30
+			Children:
+				Button@SELECT_ALL:
+					X: 10
+					Y: 2 
+					Width: 100
+					Height: 25
+					Text: Select all
+				Button@SELECT_NONE:
+					X: 120
+					Y: 2
+					Width: 100
+					Height: 25
+					Text: Select none
+		Checkbox@CATEGORY_TEMPLATE:
+			X: 5
+			Y: 5
+			Width: PARENT_RIGHT - 29
+			Height: 22
+			Visible: false

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -897,7 +897,7 @@
 	ScriptTriggers:
 	EditorTilesetFilter:
 		RequireTilesets: DESERT
-		Categories: Rock
+		Categories: Decoration
 
 ^CommonHuskDefaults:
 	Inherits@1: ^SpriteActor

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -232,6 +232,8 @@
 	BodyOrientation:
 		UseClassicFacingFudge: True
 	HitShape:
+	EditorTilesetFilter:
+		Categories: Vehicle
 
 ^Tank:
 	Inherits: ^Vehicle
@@ -294,6 +296,8 @@
 	BodyOrientation:
 		UseClassicFacingFudge: True
 	HitShape:
+	EditorTilesetFilter:
+		Categories: Aircraft
 
 ^Infantry:
 	Inherits@1: ^ExistsInWorld
@@ -395,6 +399,8 @@
 	HitShape:
 		Type: Circle
 			Radius: 128
+	EditorTilesetFilter:
+		Categories: Infantry
 
 ^Soldier:
 	Inherits: ^Infantry
@@ -436,6 +442,8 @@
 	Wanders:
 		MinMoveDelay: 150
 		MaxMoveDelay: 750
+	EditorTilesetFilter:
+		Categories: Civilian infantry
 
 ^ArmedCivilian:
 	Armament:
@@ -502,6 +510,8 @@
 	HitShape:
 		Type: Circle
 			Radius: 128
+	EditorTilesetFilter:
+		Categories: Critter
 
 ^Viceroid:
 	Inherits@1: ^ExistsInWorld
@@ -563,6 +573,8 @@
 	HitShape:
 		Type: Circle
 			Radius: 427
+	EditorTilesetFilter:
+		Categories: Critter
 
 ^Plane:
 	Inherits@1: ^ExistsInWorld
@@ -583,6 +595,8 @@
 	RejectsOrders:
 	Aircraft:
 		CruiseAltitude: 2560
+	EditorTilesetFilter:
+		Categories: Aircraft
 
 ^Ship:
 	Inherits@1: ^ExistsInWorld
@@ -612,6 +626,8 @@
 	Voiced:
 		VoiceSet: VehicleVoice
 	HitShape:
+	EditorTilesetFilter:
+		Categories: Naval
 
 ^Building:
 	Inherits@1: ^ExistsInWorld
@@ -651,6 +667,8 @@
 		GenericName: Structure
 	FrozenUnderFog:
 	Demolishable:
+	EditorTilesetFilter:
+		Categories: Building
 
 ^BaseBuilding:
 	Inherits: ^Building
@@ -685,6 +703,8 @@
 		GenericStancePrefix: false
 		ShowOwnerRow: false
 	FrozenUnderFog:
+	EditorTilesetFilter:
+		Categories: Civilian building
 
 ^CivBuildingHusk:
 	Inherits@1: ^SpriteActor
@@ -699,6 +719,8 @@
 		ShowOwnerRow: false
 	FrozenUnderFog:
 	ScriptTriggers:
+	EditorTilesetFilter:
+		Categories: Husk
 
 ^TechBuilding:
 	Inherits: ^CivBuilding
@@ -714,6 +736,8 @@
 		Range: 3c0
 	Tooltip:
 		ShowOwnerRow: True
+	EditorTilesetFilter:
+		Categories: Tech building
 
 ^CivField:
 	Inherits: ^CivBuilding
@@ -742,6 +766,8 @@
 	WithSpriteBody:
 	FrozenUnderFog:
 	ScriptTriggers:
+	EditorTilesetFilter:
+		Categories: Husk
 
 ^Wall:
 	Inherits@1: ^SpriteActor
@@ -775,6 +801,8 @@
 	ScriptTriggers:
 	Health:
 		HP: 100
+	EditorTilesetFilter:
+		Categories: Wall
 
 ^Tree:
 	Inherits@1: ^SpriteActor
@@ -814,6 +842,8 @@
 	HiddenUnderShroud:
 	ScriptTriggers:
 	HitShape:
+	EditorTilesetFilter:
+		Categories: Tree
 
 ^TreeHusk:
 	Inherits@1: ^SpriteActor
@@ -827,6 +857,8 @@
 		ShowOwnerRow: false
 	FrozenUnderFog:
 	ScriptTriggers:
+	EditorTilesetFilter:
+		Categories: Tree
 
 ^TibTree:
 	Inherits@1: ^SpriteActor
@@ -844,6 +876,8 @@
 		Terrain: Tiberium
 	HiddenUnderShroud:
 	WithMakeAnimation:
+	EditorTilesetFilter:
+		Categories: Resource spawn
 
 ^Rock:
 	Inherits@1: ^SpriteActor
@@ -863,6 +897,7 @@
 	ScriptTriggers:
 	EditorTilesetFilter:
 		RequireTilesets: DESERT
+		Categories: Rock
 
 ^CommonHuskDefaults:
 	Inherits@1: ^SpriteActor
@@ -874,6 +909,8 @@
 		Type: CenterPosition
 	WithFacingSpriteBody:
 	HitShape:
+	EditorTilesetFilter:
+		Categories: Husk
 
 ^Husk:
 	Inherits: ^CommonHuskDefaults
@@ -949,6 +986,8 @@
 		Image: crate
 	WithCrateBody:
 		XmasImages: xcratea, xcrateb, xcratec, xcrated
+	EditorTilesetFilter:
+		Categories: System
 
 ^Defense:
 	Inherits: ^BaseBuilding
@@ -959,6 +998,8 @@
 		RequiredForShortGame: false
 	Targetable:
 		TargetTypes: Ground, C4, Structure, Defense
+	EditorTilesetFilter:
+		Categories: Defense
 
 ^DisabledOverlay:
 	WithColoredOverlay@IDISABLE:

--- a/mods/cnc/rules/misc.yaml
+++ b/mods/cnc/rules/misc.yaml
@@ -45,6 +45,8 @@ mpspawn:
 	RenderSpritesEditorOnly:
 	BodyOrientation:
 		QuantizedFacings: 1
+	EditorTilesetFilter:
+		Categories: System
 
 waypoint:
 	EditorOnlyTooltip:
@@ -56,6 +58,8 @@ waypoint:
 	RenderSpritesEditorOnly:
 	BodyOrientation:
 		QuantizedFacings: 1
+	EditorTilesetFilter:
+		Categories: System
 
 ^fact.colorpicker:
 	Inherits: FACT
@@ -76,6 +80,8 @@ CAMERA:
 	RevealsShroud:
 		Range: 10c0
 		Type: CenterPosition
+	EditorTilesetFilter:
+		Categories: System
 
 CAMERA.small:
 	EditorOnlyTooltip:
@@ -94,6 +100,8 @@ CAMERA.small:
 	RevealsShroud:
 		Range: 6c0
 		Type: CenterPosition
+	EditorTilesetFilter:
+		Categories: System
 
 FLARE:
 	Immobile:
@@ -114,3 +122,5 @@ FLARE:
 	BodyOrientation:
 		QuantizedFacings: 1
 	AutoSelectionSize:
+	EditorTilesetFilter:
+		Categories: System

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -295,11 +295,18 @@ Container@EDITOR_WORLD_ROOT:
 							Width: 220
 							Height: 25
 							Font: Bold
-						ScrollPanel@ACTORTEMPLATE_LIST:
+						DropDownButton@ACTOR_CATEGORY:
 							X: 10
 							Y: 35
-							Width: PARENT_RIGHT - 20
-							Height: PARENT_BOTTOM - 45
+							Width: 220
+							Height: 25
+							Text: Categories
+							Font: Bold
+						ScrollPanel@ACTORTEMPLATE_LIST:
+							X: 10
+							Y: 60
+							Width: 220
+							Height: PARENT_BOTTOM - 70
 							TopBottomSpacing: 4
 							ItemSpacing: 4
 							Children:
@@ -394,3 +401,31 @@ Container@EDITOR_WORLD_ROOT:
 			Align: Left
 			Font: Bold
 			Contrast: true
+
+ScrollPanel@ACTOR_CATEGORY_FILTER_PANEL:
+	Width: 220
+	Children:
+		Container@SELECT_CATEGORIES_BUTTONS
+			Width: 220
+			Height: 29
+			Children:
+				Button@SELECT_ALL:
+					X: 5
+					Y: 2 
+					Width: 90
+					Height: 25
+					Text: Select all
+					Font: Bold
+				Button@SELECT_NONE:
+					X: 100
+					Y: 2
+					Width: 90
+					Height: 25
+					Text: Select none
+					Font: Bold
+		Checkbox@CATEGORY_TEMPLATE:
+			X: 5
+			Y: 5
+			Width: PARENT_RIGHT - 29
+			Height: 20
+			Visible: false

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -25,6 +25,8 @@ spicebloom.spawnpoint:
 	HitShape:
 		Type: Circle
 			Radius: 1
+	EditorTilesetFilter:
+		Categories: System
 
 spicebloom:
 	HiddenUnderShroud:
@@ -59,6 +61,8 @@ spicebloom:
 	HitShape:
 		Type: Circle
 			Radius: 512
+	EditorTilesetFilter:
+		Categories: System
 
 sandworm:
 	Inherits@1: ^SpriteActor

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -198,6 +198,8 @@
 		Duration: 100
 		Radius: 2c512
 	HitShape:
+	EditorTilesetFilter:
+		Categories: Vehicle
 
 ^Tank:
 	Inherits: ^Vehicle
@@ -217,6 +219,8 @@
 	ScriptTriggers:
 	WithFacingSpriteBody:
 	HitShape:
+	EditorTilesetFilter:
+		Categories: Husk
 
 ^VehicleHusk:
 	Inherits: ^Husk
@@ -255,6 +259,8 @@
 		Name: Destroyed Tower
 	ScriptTriggers:
 	HitShape:
+	EditorTilesetFilter:
+		Categories: Husk
 
 ^Infantry:
 	Inherits@1: ^ExistsInWorld
@@ -329,6 +335,8 @@
 	HitShape:
 		Type: Circle
 			Radius: 96
+	EditorTilesetFilter:
+		Categories: Infantry
 
 ^Plane:
 	Inherits@1: ^ExistsInWorld
@@ -345,6 +353,8 @@
 	WithFacingSpriteBody:
 	WithShadow:
 	HitShape:
+	EditorTilesetFilter:
+		Categories: Aircraft
 
 ^Building:
 	Inherits@1: ^ExistsInWorld
@@ -412,6 +422,8 @@
 	RevealOnDeath:
 		Duration: 100
 		Radius: 4c768
+	EditorTilesetFilter:
+		Categories: Building
 
 ^Defense:
 	Inherits: ^Building
@@ -436,6 +448,8 @@
 	RevealOnFire:
 	Targetable:
 		TargetTypes: Ground, C4, Structure, Defense
+	EditorTilesetFilter:
+		Categories: Defense
 
 ^DisabledOverlay:
 	WithColoredOverlay@IDISABLE:

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -136,6 +136,8 @@ crate:
 	Passenger:
 	CustomSelectionSize:
 		CustomBounds: 20,20
+	EditorTilesetFilter:
+		Categories: System
 
 mpspawn:
 	EditorOnlyTooltip:
@@ -147,6 +149,8 @@ mpspawn:
 	WithSpriteBody:
 	BodyOrientation:
 		QuantizedFacings: 1
+	EditorTilesetFilter:
+		Categories: System
 
 waypoint:
 	EditorOnlyTooltip:
@@ -158,6 +162,8 @@ waypoint:
 	WithSpriteBody:
 	BodyOrientation:
 		QuantizedFacings: 1
+	EditorTilesetFilter:
+		Categories: System
 
 ^carryall.colorpicker:
 	Inherits: carryall
@@ -181,6 +187,8 @@ camera:
 	RevealsShroud:
 		Range: 6c768
 		Type: CenterPosition
+	EditorTilesetFilter:
+		Categories: System
 
 wormspawner:
 	EditorOnlyTooltip:
@@ -193,6 +201,8 @@ wormspawner:
 	BodyOrientation:
 		QuantizedFacings: 1
 	WormSpawner:
+	EditorTilesetFilter:
+		Categories: System
 
 upgrade.conyard:
 	AlwaysVisible:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -714,6 +714,8 @@ wall:
 		Type: Rectangle
 			TopLeft: -512, -512
 			BottomRight: 512, 512
+	EditorTilesetFilter:
+		Categories: Wall
 
 medium_gun_turret:
 	Inherits: ^Defense

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -715,7 +715,7 @@ wall:
 			TopLeft: -512, -512
 			BottomRight: 512, 512
 	EditorTilesetFilter:
-		Categories: Wall
+		Categories: Defense
 
 medium_gun_turret:
 	Inherits: ^Defense

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -303,6 +303,8 @@ BARL:
 	-ShakeOnDeath:
 	-SoundOnDamageTransition:
 	-Demolishable:
+	EditorTilesetFilter:
+		Categories: Decoration
 
 BRL3:
 	Inherits: ^TechBuilding
@@ -325,6 +327,8 @@ BRL3:
 	-ShakeOnDeath:
 	-SoundOnDamageTransition:
 	-Demolishable:
+	EditorTilesetFilter:
+		Categories: Decoration
 
 AMMOBOX1:
 	Inherits: ^AmmoBox

--- a/mods/ra/rules/decoration.yaml
+++ b/mods/ra/rules/decoration.yaml
@@ -219,6 +219,7 @@ BOXES01:
 		Name: Boxes
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+		Categories: Decoration
 
 BOXES02:
 	Inherits: ^Tree
@@ -226,6 +227,7 @@ BOXES02:
 		Name: Boxes
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+		Categories: Decoration
 
 BOXES03:
 	Inherits: ^Tree
@@ -233,6 +235,7 @@ BOXES03:
 		Name: Boxes
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+		Categories: Decoration
 
 BOXES04:
 	Inherits: ^Tree
@@ -240,6 +243,7 @@ BOXES04:
 		Name: Boxes
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+		Categories: Decoration
 
 BOXES05:
 	Inherits: ^Tree
@@ -247,6 +251,7 @@ BOXES05:
 		Name: Boxes
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+		Categories: Decoration
 
 BOXES06:
 	Inherits: ^Tree
@@ -254,6 +259,7 @@ BOXES06:
 		Name: Boxes
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+		Categories: Decoration
 
 BOXES07:
 	Inherits: ^Tree
@@ -261,6 +267,7 @@ BOXES07:
 		Name: Boxes
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+		Categories: Decoration
 
 BOXES08:
 	Inherits: ^Tree
@@ -268,6 +275,7 @@ BOXES08:
 		Name: Boxes
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+		Categories: Decoration
 
 BOXES09:
 	Inherits: ^Tree
@@ -275,6 +283,7 @@ BOXES09:
 		Name: Boxes
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+		Categories: Decoration
 
 ICE01:
 	Inherits: ^Tree
@@ -285,6 +294,7 @@ ICE01:
 		Name: Ice Floe
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT, INTERIOR
+		Categories: Decoration
 
 ICE02:
 	Inherits: ^Tree
@@ -295,6 +305,7 @@ ICE02:
 		Name: Ice Floe
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT, INTERIOR
+		Categories: Decoration
 
 ICE03:
 	Inherits: ^Tree
@@ -305,6 +316,7 @@ ICE03:
 		Name: Ice Floe
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT, INTERIOR
+		Categories: Decoration
 
 ICE04:
 	Inherits: ^Tree
@@ -312,6 +324,7 @@ ICE04:
 		Name: Ice Floe
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT, INTERIOR
+		Categories: Decoration
 
 ICE05:
 	Inherits: ^Tree
@@ -319,6 +332,7 @@ ICE05:
 		Name: Ice Floe
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT, INTERIOR
+		Categories: Decoration
 
 ROCK1:
 	Inherits: ^Rock
@@ -368,6 +382,7 @@ UTILPOL1:
 		Name: Utility Pole
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+		Categories: Decoration
 
 UTILPOL2:
 	Inherits: ^Tree
@@ -375,6 +390,7 @@ UTILPOL2:
 		Name: Utility Pole
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT
+		Categories: Decoration
 
 TANKTRAP1:
 	Inherits: ^Rock

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -268,6 +268,8 @@
 	BodyOrientation:
 		UseClassicFacingFudge: True
 	HitShape:
+	EditorTilesetFilter:
+		Categories: Vehicle
 
 ^Tank:
 	Inherits: ^Vehicle
@@ -384,6 +386,8 @@
 	HitShape:
 		Type: Circle
 			Radius: 128
+	EditorTilesetFilter:
+		Categories: Infantry
 
 ^Soldier:
 	Inherits: ^Infantry
@@ -420,6 +424,8 @@
 	Wanders:
 		MinMoveDelay: 150
 		MaxMoveDelay: 750
+	EditorTilesetFilter:
+		Categories: Civilian infantry
 
 ^ArmedCivilian:
 	Inherits@AUTOTARGET: ^AutoTargetGround
@@ -469,6 +475,7 @@
 	MustBeDestroyed:
 	EditorTilesetFilter:
 		ExcludeTilesets: INTERIOR
+		Categories: Naval
 	Voiced:
 		VoiceSet: VehicleVoice
 	WithFacingSpriteBody:
@@ -525,6 +532,8 @@
 	Voiced:
 		VoiceSet: GenericVoice
 	HitShape:
+	EditorTilesetFilter:
+		Categories: Aircraft
 
 ^Plane:
 	Inherits: ^NeutralPlane
@@ -581,6 +590,8 @@
 	Tooltip:
 		GenericName: Structure
 	Demolishable:
+	EditorTilesetFilter:
+		Categories: Building
 
 ^Building:
 	Inherits: ^BasicBuilding
@@ -621,6 +632,8 @@
 	Explodes:
 		Weapon: SmallBuildingExplode
 		EmptyWeapon: SmallBuildingExplode
+	EditorTilesetFilter:
+		Categories: Defense
 
 ^Wall:
 	Inherits@1: ^ExistsInWorld
@@ -654,6 +667,8 @@
 	FrozenUnderFogUpdatedByGps:
 	Health:
 		HP: 100
+	EditorTilesetFilter:
+		Categories: Wall
 
 ^Gate:
 	Inherits: ^BasicBuilding
@@ -677,6 +692,8 @@
 		OpeningSound: cashturn.aud
 		ClosingSound: cashturn.aud
 		TerrainTypes: Clear, Road
+	EditorTilesetFilter:
+		Categories: Gate
 
 ^TechBuilding:
 	Inherits: ^BasicBuilding
@@ -689,6 +706,8 @@
 		Name: Civilian Building
 		GenericVisibility: None
 	FrozenUnderFog:
+	EditorTilesetFilter:
+		Categories: Tech building  
 
 ^FakeBuilding:
 	Inherits: ^Building
@@ -708,6 +727,8 @@
 		ZOffset: 256
 	-EmitInfantryOnSell:
 	-MustBeDestroyed:
+	 EditorTilesetFilter:
+		Categories: Fake
 
 ^InfiltratableFake:
 	Targetable:
@@ -745,6 +766,7 @@
 		Palette: terrain
 	EditorTilesetFilter:
 		ExcludeTilesets: INTERIOR
+		Categories: Civilian building
 	SpawnActorOnDeath@1:
 		Actor: c1
 		Probability: 40
@@ -808,6 +830,7 @@
 	ScriptTriggers:
 	EditorTilesetFilter:
 		ExcludeTilesets: INTERIOR
+		Categories: Tree
 
 ^TreeHusk:
 	Inherits@1: ^SpriteActor
@@ -821,6 +844,8 @@
 		ShowOwnerRow: false
 	FrozenUnderFog:
 	ScriptTriggers:
+	EditorTilesetFilter:
+		Categories: Tree
 
 ^BasicHusk:
 	Inherits@1: ^SpriteActor
@@ -833,6 +858,8 @@
 	ScriptTriggers:
 	WithFacingSpriteBody:
 	HitShape:
+	EditorTilesetFilter:
+		Categories: Husk
 
 ^Husk:
 	Inherits: ^BasicHusk
@@ -869,6 +896,8 @@
 		Spins: False
 		Moves: True
 		Velocity: 86
+	EditorTilesetFilter:
+		Categories: Husk
 
 ^HelicopterHusk:
 	Inherits: ^BasicHusk
@@ -923,6 +952,7 @@
 	ScriptTriggers:
 	EditorTilesetFilter:
 		RequireTilesets: DESERT
+		Categories: Rock
 
 ^DesertCivBuilding:
 	Inherits: ^CivBuilding
@@ -961,6 +991,8 @@
 		ShadowSequence: idle
 		RequiresCondition: parachute
 	ConditionManager:
+	EditorTilesetFilter:
+		Categories: System
 
 ^Mine:
 	Inherits: ^SpriteActor
@@ -989,6 +1021,8 @@
 	Immobile:
 		OccupiesSpace: true
 	HitShape:
+	EditorTilesetFilter:
+		Categories: System
 
 ^DisabledOverlay:
 	WithColoredOverlay@IDISABLE:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -693,7 +693,7 @@
 		ClosingSound: cashturn.aud
 		TerrainTypes: Clear, Road
 	EditorTilesetFilter:
-		Categories: Gate
+		Categories: Wall
 
 ^TechBuilding:
 	Inherits: ^BasicBuilding
@@ -759,6 +759,8 @@
 		Type: Light
 	Targetable:
 		TargetTypes: Ground, DetonateAttack
+	EditorTilesetFilter:
+		Categories: Decoration
 
 ^CivBuilding:
 	Inherits: ^TechBuilding
@@ -952,7 +954,7 @@
 	ScriptTriggers:
 	EditorTilesetFilter:
 		RequireTilesets: DESERT
-		Categories: Rock
+		Categories: Decoration
 
 ^DesertCivBuilding:
 	Inherits: ^CivBuilding

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -195,7 +195,7 @@ FLARE:
 		ShowOwnerRow: false
 	AutoSelectionSize:
 	EditorTilesetFilter:
-		Categories: System
+		Categories: Decoration
 
 MINE:
 	Inherits@1: ^SpriteActor
@@ -395,4 +395,4 @@ CTFLAG:
 	-SelectionDecorations:
 	-Targetable:
 	EditorTilesetFilter:
-		Categories: System
+		Categories: Decoration

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -150,6 +150,8 @@ CAMERA:
 	WithSpriteBody:
 	RenderSpritesEditorOnly:
 		Image: camera
+	EditorTilesetFilter:
+		Categories: System
 
 camera.paradrop:
 	Inherits: CAMERA
@@ -192,6 +194,8 @@ FLARE:
 		Name: Flare
 		ShowOwnerRow: false
 	AutoSelectionSize:
+	EditorTilesetFilter:
+		Categories: System
 
 MINE:
 	Inherits@1: ^SpriteActor
@@ -208,6 +212,8 @@ MINE:
 	RadarColorFromTerrain:
 		Terrain: Ore
 	SeedsResource:
+	EditorTilesetFilter:
+		Categories: Resource spawn
 
 GMINE:
 	Inherits@1: ^SpriteActor
@@ -225,6 +231,8 @@ GMINE:
 		Terrain: Gems
 	SeedsResource:
 		ResourceType: Gems
+	EditorTilesetFilter:
+		Categories: Resource spawn
 
 RAILMINE:
 	Inherits@1: ^SpriteActor
@@ -239,6 +247,7 @@ RAILMINE:
 		Dimensions: 2,1
 	EditorTilesetFilter:
 		ExcludeTilesets: INTERIOR
+		Categories: Civilian building
 
 QUEE:
 	Inherits@1: ^SpriteActor
@@ -253,6 +262,7 @@ QUEE:
 	AppearsOnRadar:
 	EditorTilesetFilter:
 		RequireTilesets: INTERIOR
+		Categories: Critter
 
 LAR1:
 	Inherits@1: ^SpriteActor
@@ -269,6 +279,7 @@ LAR1:
 	AppearsOnRadar:
 	EditorTilesetFilter:
 		RequireTilesets: INTERIOR
+		Categories: Critter
 
 LAR2:
 	Inherits@1: LAR1
@@ -347,6 +358,8 @@ mpspawn:
 	RenderSpritesEditorOnly:
 	BodyOrientation:
 		QuantizedFacings: 1
+	EditorTilesetFilter:
+		Categories: System
 
 waypoint:
 	EditorOnlyTooltip:
@@ -358,6 +371,8 @@ waypoint:
 	RenderSpritesEditorOnly:
 	BodyOrientation:
 		QuantizedFacings: 1
+	EditorTilesetFilter:
+		Categories: System
 
 ^fact.colorpicker:
 	Inherits: FACT
@@ -379,3 +394,5 @@ CTFLAG:
 	-Selectable:
 	-SelectionDecorations:
 	-Targetable:
+	EditorTilesetFilter:
+		Categories: System

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -366,3 +366,5 @@ HUNTER:
 		Palette: pips
 	ActorLostNotification:
 	HitShape:
+	EditorTilesetFilter:
+		Categories: System

--- a/mods/ts/rules/bridges.yaml
+++ b/mods/ts/rules/bridges.yaml
@@ -15,6 +15,8 @@ CABHUT:
 	-SelectionDecorations:
 	-Demolishable:
 	-Explodes:
+	EditorTilesetFilter:
+		Categories: Bridge
 
 ^LowBridgeRamp:
 	AlwaysVisible:
@@ -30,6 +32,8 @@ CABHUT:
 		QuantizedFacings: 1
 	Tooltip:
 		Name: Bridge
+	EditorTilesetFilter:
+		Categories: Bridge
 
 ^LowBridge:
 	Inherits: ^LowBridgeRamp
@@ -172,6 +176,8 @@ LOBRDG_R_SW:
 		OccupiesSpace: false
 	CustomSelectionSize:
 		CustomBounds: 96, 144
+	EditorTilesetFilter:
+		Categories: Bridge
 
 BRIDGE1:
 	Inherits: ^ElevatedBridgePlaceholder

--- a/mods/ts/rules/civilian-structures.yaml
+++ b/mods/ts/rules/civilian-structures.yaml
@@ -714,6 +714,8 @@ CAHOSP:
 		Pieces: 5, 9
 	ThrowsShrapnel@LARGE:
 		Pieces: 2, 4
+	EditorTilesetFilter:
+		Categories: Civilian building
 
 CAPYR01:
 	Inherits: ^CivBuilding
@@ -1263,6 +1265,8 @@ GASPOT:
 		Sequence: idle-lights
 	SelectionDecorations:
 		VisualBounds: 48, 82, 0, -25
+	EditorTilesetFilter:
+		Categories: Civilian building
 
 GALITE:
 	Inherits: ^Building
@@ -1294,6 +1298,8 @@ GALITE:
 	-Cloak@EXTERNALCLOAK:
 	-ExternalCondition@CLOAKGENERATOR:
 	-ExternalCondition@CRATE-CLOAK:
+	EditorTilesetFilter:
+		Categories: Civilian building
 
 TSTLAMP:
 	Inherits: GALITE
@@ -1322,6 +1328,8 @@ GAICBM:
 		TransformSounds: place2.aud
 		NoTransformSounds:
 	-WithDeathAnimation:
+	EditorTilesetFilter:
+		Categories: Vehicle
 
 NAMNTK:
 	Inherits: ^CivBuilding

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -195,6 +195,8 @@
 		Weapons: LargeDebris, LargeDebrisWithTrail
 		Pieces: 1, 2
 		Range: 2c0, 5c0
+	EditorTilesetFilter:
+		Categories: Building
 
 ^Building:
 	Inherits@1: ^BasicBuilding
@@ -236,6 +238,8 @@
 		MaxHeightDelta: 3
 	RenderSprites:
 		Palette: terraindecoration
+	EditorTilesetFilter:
+		Categories: Civilian building
 
 ^OldBase:
 	Inherits: ^CivBuilding
@@ -281,6 +285,8 @@
 		Images: crate
 	CustomSelectionSize:
 		CustomBounds: 24,24
+	EditorTilesetFilter:
+		Categories: System
 
 ^Wall:
 	Inherits@1: ^SpriteActor
@@ -320,6 +326,8 @@
 			TopLeft: -512, -512
 			BottomRight: 512, 512
 			VerticalTopOffset: 768
+	EditorTilesetFilter:
+		Categories: Wall
 
 ^BuildingPlug:
 	AlwaysVisible:
@@ -414,6 +422,8 @@
 	HitShape:
 		Type: Circle
 			Radius: 128
+	EditorTilesetFilter:
+		Categories: Infantry
 
 ^RegularInfantryDeath:
 	WithDeathAnimation@normal:
@@ -519,6 +529,8 @@
 	Wanders:
 		MinMoveDelay: 150
 		MaxMoveDelay: 750
+	EditorTilesetFilter:
+		Categories: Civilian infantry
 
 ^Vehicle:
 	Inherits@2: ^ExistsInWorld
@@ -601,6 +613,8 @@
 	EntersTunnels:
 		Voice: Move
 	HitShape:
+	EditorTilesetFilter:
+		Categories: Vehicle
 
 ^Tank:
 	Inherits: ^Vehicle
@@ -675,6 +689,8 @@
 	WithVoxelBody:
 	RevealOnFire:
 	HitShape:
+	EditorTilesetFilter:
+		Categories: Aircraft
 
 ^Helicopter:
 	Inherits: ^Aircraft
@@ -707,6 +723,8 @@
 		Moves: true
 		Velocity: 86
 	HitShape:
+	EditorTilesetFilter:
+		Categories: Husk
 
 ^Visceroid:
 	Inherits@1: ^ExistsInWorld
@@ -750,6 +768,8 @@
 		Type: Circle
 			Radius: 256
 			VerticalTopOffset: 512
+	EditorTilesetFilter:
+		Categories: Critter
 
 ^BlossomTree:
 	Inherits@1: ^SpriteActor
@@ -769,6 +789,8 @@
 		ResourceType: Tiberium
 		Interval: 55
 	WithIdleAnimation:
+	EditorTilesetFilter:
+		Categories: Resource spawn
 
 ^Tree:
 	Inherits@1: ^SpriteActor
@@ -784,6 +806,8 @@
 		Terrain: Tree
 	Tooltip:
 		Name: Tree
+	EditorTilesetFilter:
+		Categories: Tree
 
 ^Rock:
 	Inherits@1: ^SpriteActor
@@ -799,6 +823,8 @@
 		Terrain: Rock
 	Tooltip:
 		Name: Rock
+	EditorTilesetFilter:
+		Categories: Rock
 
 ^Decoration:
 	Inherits@1: ^SpriteActor
@@ -809,6 +835,8 @@
 	Building:
 		Footprint: x
 		Dimensions: 1, 1
+	EditorTilesetFilter:
+		Categories: Decoration
 
 ^Box:
 	Inherits: ^Decoration
@@ -835,6 +863,8 @@
 	DetectCloaked:
 		Range: 5c0
 	RevealOnFire:
+	EditorTilesetFilter:
+		Categories: Defense
 
 ^Train:
 	Inherits@1: ^EmpDisable
@@ -889,6 +919,8 @@
 		Pieces: 3, 7
 		Range: 2c0, 5c0
 	HitShape:
+	EditorTilesetFilter:
+		Categories: Railway
 
 ^TerrainOverlay:
 	AlwaysVisible:
@@ -908,6 +940,8 @@
 	AutoSelectionSize:
 	ChangesTerrain:
 		TerrainType: Rail
+	EditorTilesetFilter:
+		Categories: Railway
 
 ^Tunnel:
 	RenderSprites:
@@ -925,6 +959,8 @@
 	AlwaysVisible:
 	TunnelEntrance:
 		Dimensions: 3, 3
+	EditorTilesetFilter:
+		Categories: Tunnel
 
 ^Gate:
 	Inherits: ^Building
@@ -960,6 +996,8 @@
 			TopLeft: -512, -512
 			BottomRight: 512, 512
 			VerticalTopOffset: 768
+	EditorTilesetFilter:
+		Categories: Gate
 
 ^Gate_A:
 	Inherits: ^Gate

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -271,6 +271,8 @@
 		Pieces: 1, 3
 	ThrowsShrapnel@LARGE:
 		Pieces: 1, 1
+	EditorTilesetFilter:
+		Categories: Billboard
 
 ^Crate:
 	HiddenUnderFog:
@@ -824,7 +826,7 @@
 	Tooltip:
 		Name: Rock
 	EditorTilesetFilter:
-		Categories: Rock
+		Categories: Decoration
 
 ^Decoration:
 	Inherits@1: ^SpriteActor
@@ -997,7 +999,7 @@
 			BottomRight: 512, 512
 			VerticalTopOffset: 768
 	EditorTilesetFilter:
-		Categories: Gate
+		Categories: Wall
 
 ^Gate_A:
 	Inherits: ^Gate

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -183,6 +183,8 @@ JUMPJET.Husk:
 	WithDeathAnimation@SPLASH:
 		RequiresCondition: water-death
 		FallbackSequence: die-splash
+	EditorTilesetFilter:
+		Categories: Husk
 
 GHOST:
 	Inherits: ^Soldier

--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -8,6 +8,8 @@ mpspawn:
 	WithSpriteBody:
 	BodyOrientation:
 		QuantizedFacings: 1
+	EditorTilesetFilter:
+		Categories: System
 
 waypoint:
 	EditorOnlyTooltip:
@@ -19,6 +21,8 @@ waypoint:
 	WithSpriteBody:
 	BodyOrientation:
 		QuantizedFacings: 1
+	EditorTilesetFilter:
+		Categories: System
 
 ^mmch.colorpicker:
 	Inherits: MMCH
@@ -51,6 +55,8 @@ CAMERA:
 		Type: CenterPosition
 	DetectCloaked:
 		Range: 10c0
+	EditorTilesetFilter:
+		Categories: System
 
 CRATE:
 	Inherits: ^Crate
@@ -94,6 +100,8 @@ CRATE:
 		SelectionShares: 5
 		Condition: crate-speed
 		Notification: 00-i080.aud
+	EditorTilesetFilter:
+		Categories: System
 
 SROCK01:
 	Inherits: ^Rock

--- a/mods/ts/rules/shared-infantry.yaml
+++ b/mods/ts/rules/shared-infantry.yaml
@@ -98,3 +98,5 @@ FLAMEGUY:
 		FallbackSequence: die
 		UseDeathTypeSuffix: false
 	HitShape:
+	EditorTilesetFilter:
+		Categories: System

--- a/mods/ts/rules/trees.yaml
+++ b/mods/ts/rules/trees.yaml
@@ -116,6 +116,8 @@ VEINHOLE:
 		Palette: player
 	WithSpriteBody:
 	AutoSelectionSize:
+	EditorTilesetFilter:
+		Categories: Resource spawn
 
 ^TibFlora:
 	Inherits: ^Tree


### PR DESCRIPTION
Closes #10139

Add Actor categories:
V01:
..EditorTilesetFilter:
....ExcludeTilesets: DESERT
....**Categories: Building, Civilian**

Add Categories dropdown filter in Map editor:

![obrazok](https://cloud.githubusercontent.com/assets/16348750/26562808/3a1a6a80-44ca-11e7-8490-8ea4afd17517.png)

Categories list is combined from all existing categories of all actors.

EditorTilesetFilter can be renamed but due to currently broken Utility, hundreds of changed files (due to renaming or removed comments), I prefer to do it in another PR or at least lately as final commit after review of this PR.

