### PR TITLE
Always make sure to be on the host actor when repairing

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/LayMines.cs
+++ b/OpenRA.Mods.Cnc/Activities/LayMines.cs
@@ -53,11 +53,12 @@ namespace OpenRA.Mods.Cnc.Activities
 				if (rearmTarget == null)
 					return new Wait(20);
 
+				// Add a CloseEnough range of 512 to the Repair activity in order to ensure that we're at the host actor
 				return ActivityUtils.SequenceActivities(
 					new MoveAdjacentTo(self, Target.FromActor(rearmTarget)),
 					movement.MoveTo(self.World.Map.CellContaining(rearmTarget.CenterPosition), rearmTarget),
 					new Rearm(self),
-					new Repair(self, rearmTarget),
+					new Repair(self, rearmTarget, new WDist(512)),
 					this);
 			}
 

--- a/OpenRA.Mods.Common/Activities/Repair.cs
+++ b/OpenRA.Mods.Common/Activities/Repair.cs
@@ -19,16 +19,13 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class Repair : Activity
 	{
+		readonly Health health;
 		readonly RepairsUnits[] allRepairsUnits;
 		readonly Target host;
 		readonly WDist closeEnough;
 
 		int remainingTicks;
-		Health health;
 		bool played = false;
-
-		public Repair(Actor self, Actor host)
-			: this(self, host, WDist.Zero) { }
 
 		public Repair(Actor self, Actor host, WDist closeEnough)
 		{

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -391,8 +391,10 @@ namespace OpenRA.Mods.Common.Traits
 			var name = a.Info.Name;
 			if (Info.RearmBuildings.Contains(name))
 				yield return new Rearm(self);
+
+			// Add a CloseEnough range of 512 to ensure we're at the host actor
 			if (Info.RepairBuildings.Contains(name))
-				yield return new Repair(self, a);
+				yield return new Repair(self, a, new WDist(512));
 		}
 
 		public void ModifyDeathActorInit(Actor self, TypeDictionary init)

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -114,7 +114,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (CanRearmAt(order.TargetActor) && CanRearm())
 				self.QueueActivity(new Rearm(self));
 
-			self.QueueActivity(new Repair(self, order.TargetActor));
+			// Add a CloseEnough range of 512 to ensure we're at the host actor
+			self.QueueActivity(new Repair(self, order.TargetActor, new WDist(512)));
 
 			var rp = order.TargetActor.TraitOrDefault<RallyPoint>();
 			if (rp != null)


### PR DESCRIPTION
Fixes #13357.

The `Rearm` activity is not affected, is it checks directly for the host actor below, while `Repair` gets the host as parameter and only checks for adjacency when `CloseEnough > 0`.