### PR TITLE
Remove unnecessary loading mod exceptions

### DIFF
--- a/OpenRA.Game/ExternalMods.cs
+++ b/OpenRA.Game/ExternalMods.cs
@@ -80,7 +80,7 @@ namespace OpenRA
 					mod.Icon = sheetBuilder.Add(bitmap);
 			}
 
-			mods.Add(ExternalMod.MakeKey(mod), mod);
+			mods[ExternalMod.MakeKey(mod)] = mod;
 		}
 
 		internal void Register(Manifest mod)

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -375,7 +375,10 @@ namespace OpenRA
 			ModData = null;
 
 			if (mod == null)
-				throw new InvalidOperationException("Game.Mod argument missing or mod could not be found.");
+				throw new InvalidOperationException("Game.Mod argument missing.");
+
+			if (!Mods.ContainsKey(mod))
+				throw new InvalidOperationException("Unknown or invalid mod '{0}'.".F(mod));
 
 			Console.WriteLine("Loading mod: {0}", mod);
 

--- a/OpenRA.Game/InstalledMods.cs
+++ b/OpenRA.Game/InstalledMods.cs
@@ -69,26 +69,38 @@ namespace OpenRA
 			try
 			{
 				if (!Directory.Exists(path))
-					throw new InvalidDataException(path + " is not a valid mod package");
+				{
+					Log.Write("debug", path + " is not a valid mod package");
+					return null;
+				}
 
 				package = new Folder(path);
-				if (!package.Contains("mod.yaml"))
-					throw new InvalidDataException(path + " is not a valid mod package");
+				if (package.Contains("mod.yaml"))
+				{
+					var manifest = new Manifest(id, package);
 
-				using (var stream = package.GetStream("icon.png"))
-					if (stream != null)
-						using (var bitmap = new Bitmap(stream))
-							icons[id] = sheetBuilder.Add(bitmap);
+					if (package.Contains("icon.png"))
+					{
+						using (var stream = package.GetStream("icon.png"))
+							if (stream != null)
+								using (var bitmap = new Bitmap(stream))
+									icons[id] = sheetBuilder.Add(bitmap);
+					}
+					else if (!manifest.Metadata.Hidden)
+						Log.Write("debug", "Mod '{0}' is missing 'icon.png'.".F(path));
 
-				return new Manifest(id, package);
+					return manifest;
+				}
 			}
-			catch (Exception)
+			catch (Exception e)
 			{
-				if (package != null)
-					package.Dispose();
-
-				return null;
+				Log.Write("debug", "Load mod '{0}': {1}".F(path, e));
 			}
+
+			if (package != null)
+				package.Dispose();
+
+			return null;
 		}
 
 		Dictionary<string, Manifest> GetInstalledMods(IEnumerable<string> searchPaths, IEnumerable<string> explicitPaths)
@@ -100,9 +112,6 @@ namespace OpenRA
 			foreach (var pair in candidates)
 			{
 				var mod = LoadMod(pair.First, pair.Second);
-
-				// Mods in the support directory and oramod packages (which are listed later
-				// in the CandidateMods list) override mods in the main install.
 				if (mod != null)
 					ret[pair.First] = mod;
 			}


### PR DESCRIPTION
Removed exception "Failed to register currrent mod metadata
System.ArgumentException: An item with the same key has already been added." from debug.log on each OpenRA launch and some loading exceptions in debugger.