### PR TITLE
Fix missing-failing logging of Ruleset (Yaml)Exceptions

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -391,9 +391,9 @@ namespace OpenRA
 			}
 			catch (Exception e)
 			{
+				Log.Write("debug", "Failed to load rules for {0} with error {1}", Title, e);
 				InvalidCustomRules = true;
 				Rules = Ruleset.LoadDefaultsForTileSet(modData, Tileset);
-				Log.Write("debug", "Failed to load rules for {0} with error {1}", Title, e.Message);
 			}
 
 			Rules.Sequences.Preload();


### PR DESCRIPTION
Fixes missing log for exception e.g.:
Failed to load rules for Desert Shellmap with error System.AggregateException: One or more errors occurred. ---> OpenRA.YamlException: Actor type v2rl: Trait name Mobile: Required property missing: TerrainSpeeds

Abstract actor's trait with missing fields is ignored and this error/warning wasn't logged - added now to debug.log:
^vehicle: Trait name Mobile: Required property missing: TerrainSpeeds