### PR TITLE
Replace .Single with .First in WithTurretedAttackAnimation

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithTurretedAttackAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurretedAttackAnimation.cs
@@ -54,9 +54,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 			this.info = info;
 			attack = init.Self.Trait<AttackBase>();
 			armament = init.Self.TraitsImplementing<Armament>()
-				.Single(a => a.Info.Name == info.Armament);
+				.First(a => a.Info.Name == info.Armament);
 			wst = init.Self.TraitsImplementing<WithSpriteTurret>()
-				.Single(st => st.Info.Turret == info.Turret);
+				.First(st => st.Info.Turret == info.Turret);
 		}
 
 		void PlayAttackAnimation(Actor self)


### PR DESCRIPTION
`First` is faster than `Single`, and we don't use `Single` anywhere else in our game logic code.

But more importantly, it is entirely possible that mods might want to 'share' an attack anim between two armaments (for example, dual-barreled units might need two armaments to fire from both barrels at the same time), so being forced to give one of them a different name just to avoid a crash is a bit inconvenient.

`WithAttackAnimation` is taken care of in #13350.