### PR TITLE
Clean up AttackBase code style.

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/AttackPopupTurreted.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		protected override bool CanAttack(Actor self, Target target)
 		{
-			if (state == PopupState.Transitioning || !building.Value.BuildComplete)
+			if (state == PopupState.Transitioning || !building.BuildComplete)
 				return false;
 
 			if (!base.CanAttack(self, target))

--- a/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			inAttackRange = false;
 
-			var f = facing.Value.Facing;
+			var f = facing.Facing;
 			var delta = target.CenterPosition - self.CenterPosition;
 			var facingToTarget = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : f;
 			facingTarget = Math.Abs(facingToTarget - f) % 256 <= info.FacingTolerance;
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 					continue;
 
 				inAttackRange = true;
-				a.CheckFire(self, facing.Value, bombTarget);
+				a.CheckFire(self, facing, bombTarget);
 			}
 
 			// Guns only fire when approaching the target
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Traits
 
 					var gunPos = self.CenterPosition - new WVec(0, a.MaxRange().Length / 2, 0).Rotate(WRot.FromFacing(f));
 					var gunHeight = self.World.Map.DistanceAboveTerrain(gunPos);
-					a.CheckFire(self, facing.Value, Target.FromPos(gunPos - new WVec(WDist.Zero, WDist.Zero, gunHeight)));
+					a.CheckFire(self, facing, Target.FromPos(gunPos - new WVec(WDist.Zero, WDist.Zero, gunHeight)));
 				}
 			}
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -111,7 +111,7 @@ namespace OpenRA.Mods.Common.Traits
 				a.CheckFire(self, facing, target);
 		}
 
-		public IEnumerable<IOrderTargeter> Orders
+		IEnumerable<IOrderTargeter> IIssueOrder.Orders
 		{
 			get
 			{
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
 			if (order is AttackOrderTargeter)
 			{
@@ -145,7 +145,7 @@ namespace OpenRA.Mods.Common.Traits
 			return null;
 		}
 
-		public virtual void ResolveOrder(Actor self, Order order)
+		void IResolveOrder.ResolveOrder(Actor self, Order order)
 		{
 			var forceAttack = order.OrderString == forceAttackOrderName;
 			if (forceAttack || order.OrderString == attackOrderName)
@@ -159,7 +159,12 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			if (order.OrderString == "Stop")
-				self.CancelActivity();
+				OnStopOrder(self);
+		}
+
+		protected virtual void OnStopOrder(Actor self)
+		{
+			self.CancelActivity();
 		}
 
 		static Target TargetFromOrder(Actor self, Order order)
@@ -184,7 +189,7 @@ namespace OpenRA.Mods.Common.Traits
 			return Target.Invalid;
 		}
 
-		public string VoicePhraseForOrder(Actor self, Order order)
+		string IOrderVoice.VoicePhraseForOrder(Actor self, Order order)
 		{
 			return order.OrderString == attackOrderName || order.OrderString == forceAttackOrderName ? Info.Voice : null;
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -46,12 +46,10 @@ namespace OpenRA.Mods.Common.Traits
 			return new AttackActivity(self, newTarget, allowMove, forceAttack);
 		}
 
-		public override void ResolveOrder(Actor self, Order order)
+		protected override void OnStopOrder(Actor self)
 		{
-			base.ResolveOrder(self, order);
-
-			if (order.OrderString == "Stop")
-				Target = Target.Invalid;
+			Target = Target.Invalid;
+			base.OnStopOrder(self);
 		}
 
 		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!base.CanAttack(self, target))
 				return false;
 
-			var f = facing.Value.Facing;
+			var f = facing.Facing;
 			var delta = target.CenterPosition - self.CenterPosition;
 			var facingToTarget = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : f;
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -92,8 +92,11 @@ namespace OpenRA.Mods.Common.Traits
 			paxFacing = new Dictionary<Actor, IFacing>();
 			paxPos = new Dictionary<Actor, IPositionable>();
 			paxRender = new Dictionary<Actor, RenderSprites>();
+		}
 
-			getArmaments = () => armaments;
+		protected override Func<IEnumerable<Armament>> InitializeGetArmaments(Actor self)
+		{
+			return () => armaments;
 		}
 
 		void INotifyPassengerEntered.OnPassengerEntered(Actor self, Actor passenger)
@@ -117,7 +120,7 @@ namespace OpenRA.Mods.Common.Traits
 		FirePort SelectFirePort(Actor self, WAngle targetYaw)
 		{
 			// Pick a random port that faces the target
-			var bodyYaw = facing.Value != null ? WAngle.FromFacing(facing.Value.Facing) : WAngle.Zero;
+			var bodyYaw = facing != null ? WAngle.FromFacing(facing.Facing) : WAngle.Zero;
 			var indices = Enumerable.Range(0, Info.Ports.Length).Shuffle(self.World.SharedRandom);
 			foreach (var i in indices)
 			{
@@ -155,7 +158,7 @@ namespace OpenRA.Mods.Common.Traits
 				paxFacing[a.Actor].Facing = muzzleFacing;
 				paxPos[a.Actor].SetVisualPosition(a.Actor, pos + PortOffset(self, port));
 
-				var barrel = a.CheckFire(a.Actor, facing.Value, target);
+				var barrel = a.CheckFire(a.Actor, facing, target);
 				if (barrel == null)
 					continue;
 

--- a/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
+++ b/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.D2k.Traits
 				return;
 
 			self.CancelActivity();
-			self.QueueActivity(new SwallowActor(self, target, a, facing.Value));
+			self.QueueActivity(new SwallowActor(self, target, a, facing));
 		}
 	}
 }

--- a/OpenRA.Mods.D2k/Traits/Sandworm.cs
+++ b/OpenRA.Mods.D2k/Traits/Sandworm.cs
@@ -82,11 +82,12 @@ namespace OpenRA.Mods.D2k.Traits
 
 			// If close enough, we don't care about other actors.
 			var target = self.World.FindActorsInCircle(self.CenterPosition, WormInfo.IgnoreNoiseAttackRange)
-				.FirstOrDefault(x => attackTrait.HasAnyValidWeapons(Target.FromActor(x)));
-			if (target != null)
+				.Select(t => Target.FromActor(t))
+				.FirstOrDefault(t => attackTrait.HasAnyValidWeapons(t));
+
+			if (target.Type == TargetType.Actor)
 			{
-				self.CancelActivity();
-				attackTrait.ResolveOrder(self, new Order("Attack", target, true) { TargetActor = target });
+				attackTrait.AttackTarget(target, false, true, false);
 				return;
 			}
 


### PR DESCRIPTION
* Replace `Lazy<T>` deferred trait queries with our newer convention of querying from `INotifyCreated`
* Explicitly implement interfaces.
* Avoid unnecessary direct `ResolveOrder` call from `Sandworm`.