### PR TITLE
Add bot type field and GrantConditionOnBotOwner

### DIFF
--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -47,12 +47,13 @@ namespace OpenRA
 		public readonly bool Playable = true;
 		public readonly int ClientIndex;
 		public readonly PlayerReference PlayerReference;
+		public readonly bool IsBot;
+		public readonly string BotType;
 
 		/// <summary>The faction (including Random, etc) that was selected in the lobby.</summary>
 		public readonly FactionInfo DisplayFaction;
 
 		public WinState WinState = WinState.Undefined;
-		public bool IsBot;
 		public int SpawnPoint;
 		public bool HasObjectives = false;
 		public bool Spectating;
@@ -94,8 +95,6 @@ namespace OpenRA
 
 		public Player(World world, Session.Client client, PlayerReference pr)
 		{
-			string botType;
-
 			World = world;
 			InternalName = pr.Name;
 			PlayerReference = pr;
@@ -113,7 +112,7 @@ namespace OpenRA
 				else
 					PlayerName = client.Name;
 
-				botType = client.Bot;
+				BotType = client.Bot;
 				Faction = ChooseFaction(world, client.Faction, !pr.LockFaction);
 				DisplayFaction = ChooseDisplayFaction(world, client.Faction);
 			}
@@ -126,7 +125,7 @@ namespace OpenRA
 				NonCombatant = pr.NonCombatant;
 				Playable = pr.Playable;
 				Spectating = pr.Spectating;
-				botType = pr.Bot;
+				BotType = pr.Bot;
 				Faction = ChooseFaction(world, pr.Faction, false);
 				DisplayFaction = ChooseDisplayFaction(world, pr.Faction);
 			}
@@ -137,12 +136,12 @@ namespace OpenRA
 			fogVisibilities = PlayerActor.TraitsImplementing<IFogVisibilityModifier>().ToArray();
 
 			// Enable the bot logic on the host
-			IsBot = botType != null;
+			IsBot = BotType != null;
 			if (IsBot && Game.IsHost)
 			{
-				var logic = PlayerActor.TraitsImplementing<IBot>().FirstOrDefault(b => b.Info.Name == botType);
+				var logic = PlayerActor.TraitsImplementing<IBot>().FirstOrDefault(b => b.Info.Name == BotType);
 				if (logic == null)
-					Log.Write("debug", "Invalid bot type: {0}", botType);
+					Log.Write("debug", "Invalid bot type: {0}", BotType);
 				else
 					logic.Activate(this);
 			}

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -106,8 +106,9 @@ namespace OpenRA
 				Color = client.Color;
 				if (client.Bot != null)
 				{
+					var botInfo = world.Map.Rules.Actors["player"].TraitInfos<IBotInfo>().First(b => b.Type == client.Bot);
 					var botsOfSameType = world.LobbyInfo.Clients.Where(c => c.Bot == client.Bot).ToArray();
-					PlayerName = botsOfSameType.Length == 1 ? client.Bot : "{0} {1}".F(client.Bot, botsOfSameType.IndexOf(client) + 1);
+					PlayerName = botsOfSameType.Length == 1 ? botInfo.Name : "{0} {1}".F(botInfo.Name, botsOfSameType.IndexOf(client) + 1);
 				}
 				else
 					PlayerName = client.Name;
@@ -139,7 +140,7 @@ namespace OpenRA
 			IsBot = BotType != null;
 			if (IsBot && Game.IsHost)
 			{
-				var logic = PlayerActor.TraitsImplementing<IBot>().FirstOrDefault(b => b.Info.Name == BotType);
+				var logic = PlayerActor.TraitsImplementing<IBot>().FirstOrDefault(b => b.Info.Type == BotType);
 				if (logic == null)
 					Log.Write("debug", "Invalid bot type: {0}", BotType);
 				else

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -337,7 +337,12 @@ namespace OpenRA.Traits
 	public interface IWorldLoaded { void WorldLoaded(World w, WorldRenderer wr); }
 	public interface ICreatePlayers { void CreatePlayers(World w); }
 
-	public interface IBotInfo : ITraitInfoInterface { string Name { get; } }
+	public interface IBotInfo : ITraitInfoInterface
+	{
+		string Type { get; }
+		string Name { get; }
+	}
+
 	public interface IBot
 	{
 		void Activate(Player p);

--- a/OpenRA.Mods.Common/AI/DummyAI.cs
+++ b/OpenRA.Mods.Common/AI/DummyAI.cs
@@ -15,8 +15,14 @@ namespace OpenRA.Mods.Common.AI
 {
 	public sealed class DummyAIInfo : ITraitInfo, IBotInfo
 	{
-		[Desc("Ingame name this bot uses.")]
+		[Desc("Human-readable name this bot uses.")]
 		public readonly string Name = "Unnamed Bot";
+
+		[FieldLoader.Require]
+		[Desc("Internal id for this bot.")]
+		public readonly string Type = null;
+
+		string IBotInfo.Type { get { return Type; } }
 
 		string IBotInfo.Name { get { return Name; } }
 

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -58,7 +58,11 @@ namespace OpenRA.Mods.Common.AI
 			public readonly HashSet<string> Silo = new HashSet<string>();
 		}
 
-		[Desc("Ingame name this bot uses.")]
+		[FieldLoader.Require]
+		[Desc("Internal id for this bot.")]
+		public readonly string Type = null;
+
+		[Desc("Human-readable name this bot uses.")]
 		public readonly string Name = "Unnamed Bot";
 
 		[Desc("Minimum number of units AI must have before attacking.")]
@@ -162,8 +166,6 @@ namespace OpenRA.Mods.Common.AI
 		[Desc("Should the AI repair its buildings if damaged?")]
 		public readonly bool ShouldRepairBuildings = true;
 
-		string IBotInfo.Name { get { return Name; } }
-
 		[Desc("What units to the AI should build.", "What % of the total army must be this type of unit.")]
 		public readonly Dictionary<string, float> UnitsToBuild = null;
 
@@ -232,6 +234,10 @@ namespace OpenRA.Mods.Common.AI
 
 			return ret;
 		}
+
+		string IBotInfo.Type { get { return Type; } }
+
+		string IBotInfo.Name { get { return Name; } }
 
 		public object Create(ActorInitializer init) { return new HackyAI(this, init); }
 	}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -815,6 +815,7 @@
     <Compile Include="Widgets\Logic\Ingame\StanceSelectorLogic.cs" />
     <Compile Include="Widgets\Logic\ButtonTooltipWithDescHighlightLogic.cs" />
     <Compile Include="Traits\AutoTargetPriority.cs" />
+    <Compile Include="Traits\Conditions\GrantConditionOnBotOwner.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -280,12 +280,20 @@ namespace OpenRA.Mods.Common.Server
 							return false;
 						}
 
-						var botType = parts.Skip(2).JoinWith(" ");
-
 						// Invalid slot
 						if (bot != null && bot.Bot == null)
 						{
 							server.SendOrderTo(conn, "Message", "Can't add bots to a slot with another client.");
+							return true;
+						}
+
+						var botType = parts[2];
+						var botInfo = server.Map.Rules.Actors["player"].TraitInfos<IBotInfo>()
+							.FirstOrDefault(b => b.Type == botType);
+
+						if (botInfo == null)
+						{
+							server.SendOrderTo(conn, "Message", "Invalid bot type.");
 							return true;
 						}
 
@@ -296,7 +304,7 @@ namespace OpenRA.Mods.Common.Server
 							bot = new Session.Client()
 							{
 								Index = server.ChooseFreePlayerIndex(),
-								Name = botType,
+								Name = botInfo.Name,
 								Bot = botType,
 								Slot = parts[0],
 								Faction = "Random",
@@ -319,7 +327,7 @@ namespace OpenRA.Mods.Common.Server
 						else
 						{
 							// Change the type of the existing bot
-							bot.Name = botType;
+							bot.Name = botInfo.Name;
 							bot.Bot = botType;
 						}
 
@@ -366,7 +374,7 @@ namespace OpenRA.Mods.Common.Server
 							//  - Players who now lack a slot are made observers
 							//  - Bots who now lack a slot are dropped
 							//  - Bots who are not defined in the map rules are dropped
-							var botNames = server.Map.Rules.Actors["player"].TraitInfos<IBotInfo>().Select(t => t.Name);
+							var botTypes = server.Map.Rules.Actors["player"].TraitInfos<IBotInfo>().Select(t => t.Type);
 							var slots = server.LobbyInfo.Slots.Keys.ToArray();
 							var i = 0;
 							foreach (var os in oldSlots)
@@ -380,7 +388,7 @@ namespace OpenRA.Mods.Common.Server
 								if (c.Slot != null)
 								{
 									// Remove Bot from slot if slot forbids bots
-									if (c.Bot != null && (!server.Map.Players.Players[c.Slot].AllowBots || !botNames.Contains(c.Bot)))
+									if (c.Bot != null && (!server.Map.Players.Players[c.Slot].AllowBots || !botTypes.Contains(c.Bot)))
 										server.LobbyInfo.Clients.Remove(c);
 									S.SyncClientToPlayerReference(c, server.Map.Players.Players[c.Slot]);
 								}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs
@@ -1,0 +1,64 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Grants a condition to this actor when it is owned by an AI bot.")]
+	public class GrantConditionOnBotOwnerInfo : ITraitInfo
+	{
+		[FieldLoader.Require]
+		[GrantedConditionReference]
+		[Desc("Condition to grant.")]
+		public readonly string Condition = null;
+
+		[FieldLoader.Require]
+		[Desc("Bot types that trigger the condition.")]
+		public readonly string[] Bots = { };
+
+		public object Create(ActorInitializer init) { return new GrantConditionOnBotOwner(init, this); }
+	}
+
+	public class GrantConditionOnBotOwner : INotifyCreated, INotifyOwnerChanged
+	{
+		readonly GrantConditionOnBotOwnerInfo info;
+
+		ConditionManager conditionManager;
+		int conditionToken = ConditionManager.InvalidConditionToken;
+
+		public GrantConditionOnBotOwner(ActorInitializer init, GrantConditionOnBotOwnerInfo info)
+		{
+			this.info = info;
+		}
+
+		void INotifyCreated.Created(Actor self)
+		{
+			conditionManager = self.TraitOrDefault<ConditionManager>();
+			if (conditionManager != null && self.Owner.IsBot && info.Bots.Contains(self.Owner.BotType))
+				conditionToken = conditionManager.GrantCondition(self, info.Condition);
+		}
+
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		{
+			if (conditionManager == null)
+				return;
+
+			if (conditionToken != ConditionManager.InvalidConditionToken)
+				conditionToken = conditionManager.RevokeCondition(self, conditionToken);
+
+			if (info.Bots.Contains(newOwner.BotType))
+				conditionToken = conditionManager.GrantCondition(self, info.Condition);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -808,6 +808,19 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// Bots must now specify an internal type as well as their display name
+				if (engineVersion < 20170707)
+				{
+					if (node.Key.StartsWith("HackyAI", StringComparison.Ordinal) || node.Key.StartsWith("DummyAI", StringComparison.Ordinal))
+					{
+						var nameNode = node.Value.Nodes.FirstOrDefault(n => n.Key == "Name");
+
+						// Just duplicate the name to avoid incompatibility with maps
+						if (nameNode != null)
+							node.Value.Nodes.Add(new MiniYamlNode("Type", nameNode.Value.Value));
+					}
+				}
+
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -199,7 +199,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				slotsButton.OnMouseDown = _ =>
 				{
-					var botNames = map.Rules.Actors["player"].TraitInfos<IBotInfo>().Select(t => t.Name);
+					var botTypes = map.Rules.Actors["player"].TraitInfos<IBotInfo>().Select(t => t.Type);
 					var options = new Dictionary<string, IEnumerable<DropDownOption>>();
 
 					var botController = orderManager.LobbyInfo.Clients.FirstOrDefault(c => c.IsAdmin);
@@ -215,7 +215,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 								{
 									foreach (var slot in orderManager.LobbyInfo.Slots)
 									{
-										var bot = botNames.Random(Game.CosmeticRandom);
+										var bot = botTypes.Random(Game.CosmeticRandom);
 										var c = orderManager.LobbyInfo.ClientInSlot(slot.Key);
 										if (slot.Value.AllowBots == true && (c == null || c.Bot != null))
 											orderManager.IssueOrder(Order.Command("slot_bot {0} {1} {2}".F(slot.Key, botController.Index, bot)));
@@ -621,7 +621,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						if (addBotOnMapLoad)
 						{
 							var slot = orderManager.LobbyInfo.FirstEmptyBotSlot();
-							var bot = currentMap.Rules.Actors["player"].TraitInfos<IBotInfo>().Select(t => t.Name).FirstOrDefault();
+							var bot = currentMap.Rules.Actors["player"].TraitInfos<IBotInfo>().Select(t => t.Type).FirstOrDefault();
 							var botController = orderManager.LobbyInfo.Clients.FirstOrDefault(c => c.IsAdmin);
 							if (slot != null && bot != null)
 								orderManager.IssueOrder(Order.Command("slot_bot {0} {1} {2}".F(slot, botController.Index, bot)));

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -50,13 +50,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var bots = new List<SlotDropDownOption>();
 			if (slot.AllowBots)
 			{
-				foreach (var b in map.Rules.Actors["player"].TraitInfos<IBotInfo>().Select(t => t.Name))
+				foreach (var b in map.Rules.Actors["player"].TraitInfos<IBotInfo>())
 				{
-					var bot = b;
 					var botController = orderManager.LobbyInfo.Clients.FirstOrDefault(c => c.IsAdmin);
-					bots.Add(new SlotDropDownOption(bot,
-						"slot_bot {0} {1} {2}".F(slot.PlayerReference, botController.Index, bot),
-						() => client != null && client.Bot == bot));
+					bots.Add(new SlotDropDownOption(b.Name,
+						"slot_bot {0} {1} {2}".F(slot.PlayerReference, botController.Index, b.Type),
+						() => client != null && client.Bot == b.Type));
 				}
 			}
 

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -1,6 +1,7 @@
 Player:
 	HackyAI@Cabal:
 		Name: Cabal
+		Type: Cabal
 		MinimumExcessPower: 60
 		BuildingCommonNames:
 			ConstructionYard: fact
@@ -122,6 +123,7 @@ Player:
 				CheckRadius: 7c0
 	HackyAI@Watson:
 		Name: Watson
+		Type: Watson
 		MinimumExcessPower: 60
 		BuildingCommonNames:
 			ConstructionYard: fact
@@ -243,6 +245,7 @@ Player:
 				CheckRadius: 7c0
 	HackyAI@HAL9001:
 		Name: HAL 9001
+		Type: HAL 9001
 		MinimumExcessPower: 60
 		BuildingCommonNames:
 			ConstructionYard: fact

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -1,7 +1,7 @@
 Player:
 	HackyAI@Cabal:
 		Name: Cabal
-		Type: Cabal
+		Type: cabal
 		MinimumExcessPower: 60
 		BuildingCommonNames:
 			ConstructionYard: fact
@@ -123,7 +123,7 @@ Player:
 				CheckRadius: 7c0
 	HackyAI@Watson:
 		Name: Watson
-		Type: Watson
+		Type: watson
 		MinimumExcessPower: 60
 		BuildingCommonNames:
 			ConstructionYard: fact
@@ -245,7 +245,7 @@ Player:
 				CheckRadius: 7c0
 	HackyAI@HAL9001:
 		Name: HAL 9001
-		Type: HAL 9001
+		Type: hal9001
 		MinimumExcessPower: 60
 		BuildingCommonNames:
 			ConstructionYard: fact

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -1,7 +1,7 @@
 Player:
 	HackyAI@Omnius:
 		Name: Omnius
-		Type: Omnius
+		Type: omnius
 		MinimumExcessPower: 60
 		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport, Aircraft
@@ -120,7 +120,7 @@ Player:
 				Against: Ally
 	HackyAI@Vidius:
 		Name: Vidious
-		Type: Vidious
+		Type: vidious
 		MinimumExcessPower: 60
 		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport, Aircraft
@@ -241,7 +241,7 @@ Player:
 				Against: Ally
 	HackyAI@Gladius:
 		Name: Gladius
-		Type: Gladius
+		Type: gladius
 		MinimumExcessPower: 60
 		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport, Aircraft

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -1,6 +1,7 @@
 Player:
 	HackyAI@Omnius:
 		Name: Omnius
+		Type: Omnius
 		MinimumExcessPower: 60
 		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport, Aircraft
@@ -119,6 +120,7 @@ Player:
 				Against: Ally
 	HackyAI@Vidius:
 		Name: Vidious
+		Type: Vidious
 		MinimumExcessPower: 60
 		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport, Aircraft
@@ -239,6 +241,7 @@ Player:
 				Against: Ally
 	HackyAI@Gladius:
 		Name: Gladius
+		Type: Gladius
 		MinimumExcessPower: 60
 		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport, Aircraft

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -100,6 +100,7 @@ Player:
 	-HackyAI@TurtleAI:
 	DummyAI@LonestarAI:
 		Name: Lonestar AI
+		Type: Lonestar AI
 
 ^Infantry:
 	Inherits@IC: ^IronCurtainable

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -100,7 +100,7 @@ Player:
 	-HackyAI@TurtleAI:
 	DummyAI@LonestarAI:
 		Name: Lonestar AI
-		Type: Lonestar AI
+		Type: lonestar
 
 ^Infantry:
 	Inherits@IC: ^IronCurtainable

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -1,6 +1,7 @@
 Player:
 	HackyAI@RushAI:
 		Name: Rush AI
+		Type: Rush AI
 		MinimumExcessPower: 40
 		BuildingCommonNames:
 			ConstructionYard: fact
@@ -114,6 +115,7 @@ Player:
 				CheckRadius: 7c0
 	HackyAI@NormalAI:
 		Name: Normal AI
+		Type: Normal AI
 		MinimumExcessPower: 60
 		BuildingCommonNames:
 			ConstructionYard: fact
@@ -245,6 +247,7 @@ Player:
 				CheckRadius: 7c0
 	HackyAI@TurtleAI:
 		Name: Turtle AI
+		Type: Turtle AI
 		MinimumExcessPower: 100
 		BuildingCommonNames:
 			ConstructionYard: fact
@@ -376,6 +379,7 @@ Player:
 				CheckRadius: 7c0
 	HackyAI@NavalAI:
 		Name: Naval AI
+		Type: Naval AI
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -1,7 +1,7 @@
 Player:
 	HackyAI@RushAI:
 		Name: Rush AI
-		Type: Rush AI
+		Type: rush
 		MinimumExcessPower: 40
 		BuildingCommonNames:
 			ConstructionYard: fact
@@ -115,7 +115,7 @@ Player:
 				CheckRadius: 7c0
 	HackyAI@NormalAI:
 		Name: Normal AI
-		Type: Normal AI
+		Type: normal
 		MinimumExcessPower: 60
 		BuildingCommonNames:
 			ConstructionYard: fact
@@ -247,7 +247,7 @@ Player:
 				CheckRadius: 7c0
 	HackyAI@TurtleAI:
 		Name: Turtle AI
-		Type: Turtle AI
+		Type: turtle
 		MinimumExcessPower: 100
 		BuildingCommonNames:
 			ConstructionYard: fact
@@ -379,7 +379,7 @@ Player:
 				CheckRadius: 7c0
 	HackyAI@NavalAI:
 		Name: Naval AI
-		Type: Naval AI
+		Type: naval
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -1,7 +1,7 @@
 Player:
 	HackyAI@TestAI:
 		Name: Test AI
-		Type: Test AI
+		Type: test
 		MinimumExcessPower: 60
 		BuildingCommonNames:
 			ConstructionYard: gacnst

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -1,6 +1,7 @@
 Player:
 	HackyAI@TestAI:
 		Name: Test AI
+		Type: Test AI
 		MinimumExcessPower: 60
 		BuildingCommonNames:
 			ConstructionYard: gacnst


### PR DESCRIPTION
Using the human-readable name as an internal identifier for bots is bad:
* It makes parsing more difficult than necessary (may contain spaces and other special characters).
* They break as soon as we want to translate them.

These are fixed by adding a new internal Type field that is used for client &lrarr; server orders and the `PlayerReference.Bot` field (which isn't used in any of our default maps).

This also adds a new `GrantConditionOnBotOwner` trait that... grants a condition on an actor while it is owned by a bot (big surprise).  This can be used to apply difficulty modifiers or adjust the AutoTarget behaviour.

Testcase: Add the following to RA's `POWR` actor:
```
GrantConditionOnBotOwner:
	Condition: invulnerability
	Bots: rush, naval
```

Power plants built by Rush AI or Naval AI will be unvulnerable until captured by the player.

Closes #7625.