### PR TITLE
Add AutoTargetPriority trait for smarter AutoTarget logic.

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -815,6 +815,7 @@
     <Compile Include="Widgets\Logic\Ingame\CommandBarLogic.cs" />
     <Compile Include="Widgets\Logic\Ingame\StanceSelectorLogic.cs" />
     <Compile Include="Widgets\Logic\ButtonTooltipWithDescHighlightLogic.cs" />
+    <Compile Include="Traits\AutoTargetPriority.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.Common/Traits/AutoTargetPriority.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTargetPriority.cs
@@ -1,0 +1,37 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Specifies the target types and relative priority used by AutoTarget to decide what to target.")]
+	public class AutoTargetPriorityInfo : ConditionalTraitInfo, Requires<AutoTargetInfo>
+	{
+		[Desc("Target types that can be AutoTargeted.")]
+		public readonly HashSet<string> ValidTargets = new HashSet<string> { "Ground", "Water", "Air" };
+
+		[Desc("Target types that can't be AutoTargeted.", "Overrules ValidTargets.")]
+		public readonly HashSet<string> InvalidTargets = new HashSet<string>();
+
+		[Desc("ValidTargets with larger priorities will be AutoTargeted before lower priorities.")]
+		public readonly int Priority = 1;
+
+		public override object Create(ActorInitializer init) { return new AutoTargetPriority(this); }
+	}
+
+	public class AutoTargetPriority : ConditionalTrait<AutoTargetPriorityInfo>
+	{
+		public AutoTargetPriority(AutoTargetPriorityInfo info)
+			: base(info) { }
+	}
+}

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -710,6 +710,18 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// AutoTargetIgnore replaced with AutoTargetPriority and target types
+				if (engineVersion < 20170610)
+				{
+					if (node.Key.StartsWith("AutoTarget", StringComparison.Ordinal) || node.Key.StartsWith("-AutoTarget", StringComparison.Ordinal))
+					{
+						Console.WriteLine("The AutoTarget traits have been reworked to use target types:");
+						Console.WriteLine(" * Actors with AutoTarget must specify one or more AutoTargetPriority traits.");
+						Console.WriteLine(" * The AutoTargetIgnore trait has been removed.");
+						Console.WriteLine("   Append NoAutoTarget to the target types instead.");
+					}
+				}
+
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 

--- a/mods/cnc/maps/gdi06/rules.yaml
+++ b/mods/cnc/maps/gdi06/rules.yaml
@@ -93,6 +93,7 @@ RMBO.easy:
 RMBO.hard:
 	Inherits: RMBO
 	-AutoTarget:
+	-AutoTargetPriority@DEFAULT:
 	-AttackMove:
 	RenderSprites:
 		Image: RMBO

--- a/mods/cnc/maps/nod07a/rules.yaml
+++ b/mods/cnc/maps/nod07a/rules.yaml
@@ -19,7 +19,8 @@ Player:
 		Modifier: 0
 
 ^CivBuilding:
-	AutoTargetIgnore:
+	Targetable:
+		TargetTypes: Ground, C4, Structure, NoAutoTarget
 
 CYCL:
 	Buildable:

--- a/mods/cnc/maps/nod07c/rules.yaml
+++ b/mods/cnc/maps/nod07c/rules.yaml
@@ -153,3 +153,4 @@ ORCA.IN:
 	RenderSprites:
 		Image: ORCA
 	-AutoTarget:
+	-AutoTargetPriority@DEFAULT:

--- a/mods/cnc/maps/nod09/rules.yaml
+++ b/mods/cnc/maps/nod09/rules.yaml
@@ -193,6 +193,7 @@ RMBO.easy:
 RMBO.hard:
 	Inherits: RMBO
 	-AutoTarget:
+	-AutoTargetPriority@DEFAULT:
 	-AttackMove:
 	RenderSprites:
 		Image: RMBO

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -54,6 +54,7 @@ TRAN:
 HELI:
 	Inherits: ^Helicopter
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Valued:
 		Cost: 1200
 	Tooltip:
@@ -103,7 +104,6 @@ HELI:
 	WithMuzzleOverlay:
 	SpawnActorOnDeath:
 		Actor: HELI.Husk
-	AutoTarget:
 	Explodes:
 		Weapon: HeliExplode
 		EmptyWeapon: HeliExplode
@@ -113,6 +113,7 @@ HELI:
 ORCA:
 	Inherits: ^Helicopter
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Valued:
 		Cost: 1200
 	Tooltip:
@@ -150,7 +151,6 @@ ORCA:
 		SelfReloadDelay: 100
 	SpawnActorOnDeath:
 		Actor: ORCA.Husk
-	AutoTarget:
 	Explodes:
 		Weapon: HeliExplode
 		EmptyWeapon: HeliExplode

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -119,6 +119,24 @@
 		RequiresCondition: rank-elite
 		ZOffset: 256
 
+^AutoTargetGround:
+	AutoTarget:
+	AutoTargetPriority@DEFAULT:
+		ValidTargets: Infantry, Vehicle, Water, Structure, Defense
+		InvalidTargets: NoAutoTarget
+
+^AutoTargetAir:
+	AutoTarget:
+	AutoTargetPriority@DEFAULT:
+		ValidTargets: Air
+		InvalidTargets: NoAutoTarget
+
+^AutoTargetAll:
+	AutoTarget:
+	AutoTargetPriority@DEFAULT:
+		ValidTargets: Infantry, Vehicle, Water, Air, Structure, Defense
+		InvalidTargets: NoAutoTarget
+
 ^AcceptsCloakCrate:
 	Cloak:
 		InitialDelay: 15
@@ -344,8 +362,6 @@
 	Tooltip:
 		GenericName: Soldier
 	Guard:
-	AutoTarget:
-		ScanRadius: 4
 	TakeCover:
 		SpeedModifier: 60
 		DamageModifiers:
@@ -391,6 +407,7 @@
 ^DINO:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Huntable:
 	Health:
 		HP: 1000
@@ -449,6 +466,7 @@
 ^Viceroid:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Huntable:
 	Health:
 		HP: 300
@@ -710,7 +728,6 @@
 		Palette: staticterrain
 	WithWallSpriteBody:
 	GivesExperience:
-	AutoTargetIgnore:
 	Sellable:
 		SellSounds: cashturn.aud
 	Guardable:
@@ -758,7 +775,6 @@
 		Image: burn-l
 		MinimumDamageState: Heavy
 		MaximumDamageState: Dead
-	AutoTargetIgnore:
 	HiddenUnderShroud:
 	ScriptTriggers:
 	HitShape:
@@ -820,7 +836,6 @@
 		Type: Light
 	HiddenUnderFog:
 		Type: CenterPosition
-	AutoTargetIgnore:
 	WithFacingSpriteBody:
 	HitShape:
 
@@ -901,7 +916,6 @@
 
 ^Defense:
 	Inherits: ^BaseBuilding
-	AutoTarget:
 	RenderRangeCircle:
 	RenderDetectionCircle:
 	-GivesBuildableArea:

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -1,6 +1,7 @@
 E1:
 	Inherits: ^Soldier
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 100
 	Tooltip:
@@ -13,6 +14,8 @@ E1:
 		Speed: 56
 	Health:
 		HP: 50
+	AutoTarget:
+		ScanRadius: 4
 	Armament:
 		Weapon: M16
 	AttackFrontal:
@@ -23,6 +26,7 @@ E1:
 E2:
 	Inherits: ^Soldier
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 160
 	Tooltip:
@@ -36,6 +40,8 @@ E2:
 		Speed: 71
 	Health:
 		HP: 50
+	AutoTarget:
+		ScanRadius: 4
 	Armament:
 		Weapon: Grenade
 		LocalOffset: 0,0,427
@@ -53,6 +59,7 @@ E2:
 E3:
 	Inherits: ^Soldier
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Valued:
 		Cost: 300
 	Tooltip:
@@ -80,6 +87,7 @@ E3:
 E4:
 	Inherits: ^Soldier
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 200
 	Tooltip:
@@ -93,6 +101,8 @@ E4:
 		Speed: 56
 	Health:
 		HP: 90
+	AutoTarget:
+		ScanRadius: 4
 	Armament:
 		Weapon: Flamethrower
 		LocalOffset: 341,0,256
@@ -108,6 +118,7 @@ E4:
 E5:
 	Inherits: ^Soldier
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 300
 	Tooltip:
@@ -126,6 +137,8 @@ E5:
 				PathingCost: 90
 	Health:
 		HP: 90
+	AutoTarget:
+		ScanRadius: 4
 	Armament:
 		Weapon: Chemspray
 		LocalOffset: 341,0,256
@@ -160,11 +173,11 @@ E6:
 	Captures:
 		CaptureTypes: building, husk
 		PlayerExperience: 50
-	-AutoTarget:
 
 RMBO:
 	Inherits: ^Soldier
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 2000
 	Tooltip:

--- a/mods/cnc/rules/ships.yaml
+++ b/mods/cnc/rules/ships.yaml
@@ -1,6 +1,7 @@
 BOAT:
 	Inherits: ^Ship
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Valued:
 		Cost: 300
 	Tooltip:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -655,6 +655,7 @@ TMPL:
 
 GUN:
 	Inherits: ^Defense
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 600
 	Tooltip:
@@ -697,6 +698,7 @@ GUN:
 SAM:
 	Inherits: ^Defense
 	Inherits@IDISABLE: ^DisabledOverlay
+	Inherits@AUTOTARGET: ^AutoTargetAir
 	Valued:
 		Cost: 650
 	Tooltip:
@@ -739,6 +741,7 @@ SAM:
 OBLI:
 	Inherits: ^Defense
 	Inherits@IDISABLE: ^DisabledOverlay
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 1500
 	Tooltip:
@@ -782,6 +785,7 @@ OBLI:
 
 GTWR:
 	Inherits: ^Defense
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 600
 	Tooltip:
@@ -818,6 +822,7 @@ GTWR:
 ATWR:
 	Inherits: ^Defense
 	Inherits@IDISABLE: ^DisabledOverlay
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Valued:
 		Cost: 1000
 	Tooltip:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -82,6 +82,7 @@ APC:
 	Inherits: ^Tank
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@CLOAK: ^AcceptsCloakCrate
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Valued:
 		Cost: 550
 	Tooltip:
@@ -119,7 +120,6 @@ APC:
 	AttackTurreted:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
-	AutoTarget:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 5
@@ -132,6 +132,7 @@ ARTY:
 	Inherits: ^Tank
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@CLOAK: ^AcceptsCloakCrate
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 600
 	Tooltip:
@@ -169,6 +170,7 @@ FTNK:
 	Inherits: ^Tank
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@CLOAK: ^AcceptsCloakCrate
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 600
 	Tooltip:
@@ -192,7 +194,6 @@ FTNK:
 		LocalOffset: 512,128,42, 512,-128,42
 		MuzzleSequence: muzzle
 	AttackFrontal:
-	AutoTarget:
 	WithMuzzleOverlay:
 	Explodes:
 		Weapon: FlametankExplode
@@ -204,6 +205,7 @@ BGGY:
 	Inherits: ^Vehicle
 	Inherits@@EXPERIENCE: ^GainsExperience
 	Inherits@CLOAK: ^AcceptsCloakCrate
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 300
 	Tooltip:
@@ -232,7 +234,6 @@ BGGY:
 	AttackTurreted:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
-	AutoTarget:
 	SpawnActorOnDeath:
 		Actor: BGGY.Husk
 
@@ -240,6 +241,7 @@ BIKE:
 	Inherits: ^Vehicle
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@CLOAK: ^AcceptsCloakCrate
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -270,7 +272,6 @@ BIKE:
 		LocalOffset: -128, -170, 170, -128, 170, 170
 		LocalYaw: 100, -100
 	AttackFrontal:
-	AutoTarget:
 	SpawnActorOnDeath:
 		Actor: BIKE.Husk
 
@@ -278,6 +279,7 @@ JEEP:
 	Inherits: ^Vehicle
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@CLOAK: ^AcceptsCloakCrate
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 400
 	Tooltip:
@@ -306,7 +308,6 @@ JEEP:
 	AttackTurreted:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
-	AutoTarget:
 	SpawnActorOnDeath:
 		Actor: JEEP.Husk
 
@@ -314,6 +315,7 @@ LTNK:
 	Inherits: ^Tank
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@CLOAK: ^AcceptsCloakCrate
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 650
 	Tooltip:
@@ -345,7 +347,6 @@ LTNK:
 	AttackTurreted:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
-	AutoTarget:
 	SpawnActorOnDeath:
 		Actor: LTNK.Husk
 
@@ -353,6 +354,7 @@ MTNK:
 	Inherits: ^Tank
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@CLOAK: ^AcceptsCloakCrate
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 800
 	Tooltip:
@@ -381,7 +383,6 @@ MTNK:
 	AttackTurreted:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
-	AutoTarget:
 	SpawnActorOnDeath:
 		Actor: MTNK.Husk
 	SelectionDecorations:
@@ -391,6 +392,7 @@ HTNK:
 	Inherits: ^Tank
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@CLOAK: ^AcceptsCloakCrate
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Valued:
 		Cost: 1500
 	Tooltip:
@@ -428,7 +430,6 @@ HTNK:
 		MuzzleSequence: muzzle
 	AttackTurreted:
 	WithMuzzleOverlay:
-	AutoTarget:
 	SelfHealing:
 		Delay: 10
 		HealIfBelow: 50
@@ -442,6 +443,7 @@ MSAM:
 	Inherits: ^Tank
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@CLOAK: ^AcceptsCloakCrate
+	Inherits@AUTOTARGET: ^AutoTargetAir
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -472,7 +474,6 @@ MSAM:
 	AttackFrontal:
 	WithSpriteTurret:
 		AimSequence: aim
-	AutoTarget:
 	SpawnActorOnDeath:
 		Actor: MSAM.Husk
 
@@ -480,6 +481,7 @@ MLRS:
 	Inherits: ^Tank
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@CLOAK: ^AcceptsCloakCrate
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 600
 	Tooltip:
@@ -523,6 +525,7 @@ MLRS:
 STNK:
 	Inherits: ^Vehicle
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Valued:
 		Cost: 900
 	Tooltip:

--- a/mods/d2k/maps/atreides-05/rules.yaml
+++ b/mods/d2k/maps/atreides-05/rules.yaml
@@ -33,13 +33,17 @@ barracks.harkonnen:
 	Buildable:
 		Prerequisites: ~disabled
 	-MustBeDestroyed:
-	AutoTargetIgnore:
+	Targetable:
+		TargetTypes: Ground, C4, Structure, NoAutoTarget
 
 starport:
 	ExternalCondition@lua:
 		Condition: captured
-	AutoTargetIgnore:
+	Targetable:
+		RequiresCondition: captured
+	Targetable@AUTOTARGET:
 		RequiresCondition: !captured
+		TargetTypes: Ground, C4, Structure, NoAutoTarget
 
 concreteb:
 	Buildable:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -120,6 +120,18 @@
 		RequiresCondition: rank-elite
 		ZOffset: 256
 
+^AutoTargetGround:
+	AutoTarget:
+	AutoTargetPriority@DEFAULT:
+		ValidTargets: Infantry, Vehicle, Water, Structure, Defense
+		InvalidTargets: NoAutoTarget
+
+^AutoTargetAll:
+	AutoTarget:
+	AutoTargetPriority@DEFAULT:
+		ValidTargets: Infantry, Vehicle, Water, Air, Structure, Defense
+		InvalidTargets: NoAutoTarget
+
 ^Vehicle:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^GainsExperience
@@ -190,7 +202,6 @@
 		Type: CenterPosition
 	Tooltip:
 		Name: Wreck
-	AutoTargetIgnore:
 	ScriptTriggers:
 	WithFacingSpriteBody:
 	HitShape:
@@ -278,7 +289,6 @@
 			SmallExplosionDeath: 3
 			BulletDeath: 4
 		CrushedSequence: die-crushed
-	AutoTarget:
 	AttackMove:
 	DrawLineToTarget:
 	Passenger:
@@ -395,7 +405,6 @@
 	Inherits: ^Building
 	WithSpriteTurret:
 	AttackTurreted:
-	AutoTarget:
 	RenderRangeCircle:
 	DetectCloaked:
 		Range: 1c768

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -1,5 +1,6 @@
 light_inf:
 	Inherits: ^Infantry
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 10
@@ -43,13 +44,13 @@ engineer:
 	Captures:
 		CaptureTypes: building, husk
 		PlayerExperience: 50
-	-AutoTarget:
 	-RevealOnFire:
 	Voiced:
 		VoiceSet: EngineerVoice
 
 trooper:
 	Inherits: ^Infantry
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 20
@@ -78,7 +79,6 @@ trooper:
 
 thumper:
 	Inherits: ^Infantry
-	-AutoTarget:
 	-RevealOnFire:
 	Buildable:
 		Queue: Infantry
@@ -121,6 +121,7 @@ thumper:
 
 fremen:
 	Inherits: ^Infantry
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Tooltip:
 		Name: Fremen
 	Buildable:
@@ -164,6 +165,7 @@ fremen:
 
 grenadier:
 	Inherits: ^Infantry
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 80
@@ -194,6 +196,7 @@ grenadier:
 
 sardaukar:
 	Inherits: ^Infantry
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 80
@@ -244,7 +247,6 @@ saboteur:
 		DetonationDelay: 0
 		Flashes: 0
 		EnterBehaviour: Suicide
-	-AutoTarget:
 	-RevealOnFire:
 	Cloak:
 		InitialDelay: 85

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -700,7 +700,6 @@ wall:
 	Targetable:
 		TargetTypes: Ground, Wall
 	WithWallSpriteBody:
-	AutoTargetIgnore:
 	Sellable:
 		SellSounds: CHUNG.WAV
 	Guardable:
@@ -718,6 +717,7 @@ wall:
 
 medium_gun_turret:
 	Inherits: ^Defense
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Building
 		Prerequisites: barracks
@@ -761,6 +761,7 @@ medium_gun_turret:
 large_gun_turret:
 	Inherits: ^Defense
 	Inherits@IDISABLE: ^DisabledOverlay
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Building
 		Prerequisites: outpost, upgrade.conyard, ~techlevel.medium

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -100,6 +100,7 @@ harvester:
 
 trike:
 	Inherits: ^Vehicle
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 10
@@ -131,7 +132,6 @@ trike:
 		LocalOffset: -544,0,0
 		MuzzleSequence: muzzle
 	AttackFrontal:
-	AutoTarget:
 	Explodes:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
@@ -140,6 +140,7 @@ trike:
 
 quad:
 	Inherits: ^Vehicle
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Vehicle
 		Prerequisites: upgrade.light, ~techlevel.medium
@@ -164,7 +165,6 @@ quad:
 		Weapon: Rocket
 		LocalOffset: 128,64,64, 128,-64,64
 	AttackFrontal:
-	AutoTarget:
 	Explodes:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
@@ -175,6 +175,7 @@ quad:
 
 siege_tank:
 	Inherits: ^Tank
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Armor
 		Prerequisites: upgrade.heavy, ~techlevel.medium
@@ -221,6 +222,7 @@ siege_tank:
 
 missile_tank:
 	Inherits: ^Tank
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Tooltip:
 		Name: Missile Tank
 	Buildable:
@@ -259,6 +261,7 @@ missile_tank:
 
 sonic_tank:
 	Inherits: ^Vehicle
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Armor
 		BuildPaletteOrder: 100
@@ -283,7 +286,6 @@ sonic_tank:
 		Weapon: Sound
 		LocalOffset: 600,0,427
 	AttackFrontal:
-	AutoTarget:
 	Explodes:
 		Weapon: UnitExplodeLarge
 		EmptyWeapon: UnitExplodeLarge
@@ -294,6 +296,7 @@ sonic_tank:
 
 devastator:
 	Inherits: ^Tank
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Armor
 		BuildPaletteOrder: 100
@@ -322,7 +325,6 @@ devastator:
 	AttackFrontal:
 	WithMuzzleOverlay:
 		IgnoreOffset: true
-	AutoTarget:
 	Explodes:
 		Weapon: UnitExplodeLarge
 		EmptyWeapon: UnitExplodeLarge
@@ -339,6 +341,7 @@ devastator:
 
 raider:
 	Inherits: ^Vehicle
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 10
@@ -368,7 +371,6 @@ raider:
 		LocalOffset: 170,0,0
 		MuzzleSequence: muzzle
 	AttackFrontal:
-	AutoTarget:
 	Explodes:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
@@ -405,6 +407,7 @@ stealth_raider:
 
 deviator:
 	Inherits: ^Tank
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -441,6 +444,7 @@ deviator:
 
 ^combat_tank:
 	Inherits: ^Tank
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Armor
 		BuildPaletteOrder: 40
@@ -472,7 +476,6 @@ deviator:
 	AttackTurreted:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
-	AutoTarget:
 	Explodes:
 		Weapon: UnitExplodeMed
 		EmptyWeapon: UnitExplodeMed

--- a/mods/ra/maps/allies-01/rules.yaml
+++ b/mods/ra/maps/allies-01/rules.yaml
@@ -42,7 +42,6 @@ EINSTEIN:
 
 C8:
 	Inherits@2: ^ArmedCivilian
-	AutoTarget:
 
 JEEP:
 	Cargo:

--- a/mods/ra/maps/infiltration/rules.yaml
+++ b/mods/ra/maps/infiltration/rules.yaml
@@ -24,9 +24,8 @@ World:
 		Color: FE1100
 
 MISS:
-	AutoTargetIgnore:
 	Targetable:
-		TargetTypes: Ground, C4, DetonateAttack, Structure, MissionObjective
+		TargetTypes: Ground, C4, DetonateAttack, Structure, MissionObjective, NoAutoTarget
 
 LST.Unselectable.UnloadOnly:
 	Inherits: LST
@@ -38,7 +37,8 @@ LST.Unselectable.UnloadOnly:
 	Cargo:
 		MaxWeight: 0
 		PipCount: 0
-	AutoTargetIgnore:
+	Targetable:
+		TargetTypes: Ground, Water, Repair, NoAutoTarget
 
 SPY.Strong:
 	Inherits: SPY
@@ -77,7 +77,8 @@ TRUK.Hijackable:
 		PipCount: 5
 		PassengerConditions:
 			spy.strong: mobile
-	AutoTargetIgnore:
+	Targetable:
+		TargetTypes: Ground, Repair, Vehicle, NoAutoTarget
 	-Huntable:
 	ExternalCapturable:
 		Type: MissionObjective

--- a/mods/ra/maps/monster-tank-madness/rules.yaml
+++ b/mods/ra/maps/monster-tank-madness/rules.yaml
@@ -109,6 +109,7 @@ PBOX:
 
 5TNK:
 	Inherits: ^Tank
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Valued:
 		Cost: 10000
 	Tooltip:
@@ -148,7 +149,6 @@ PBOX:
 	AttackTurreted:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
-	AutoTarget:
 	Explodes:
 		Weapon: MiniNuke
 		EmptyWeapon: MiniNuke

--- a/mods/ra/maps/soviet-03/rules.yaml
+++ b/mods/ra/maps/soviet-03/rules.yaml
@@ -17,7 +17,8 @@ World:
 		Default: easy
 
 ^TechBuilding:
-	AutoTargetIgnore:
+	Targetable:
+		TargetTypes: Ground, C4, DetonateAttack, Structure, NoAutoTarget
 
 ^Infantry:
 	-GivesBounty:

--- a/mods/ra/maps/soviet-05/rules.yaml
+++ b/mods/ra/maps/soviet-05/rules.yaml
@@ -85,8 +85,11 @@ APC:
 DOME:
 	ExternalCondition@lua:
 		Condition: captured
-	AutoTargetIgnore:
+	Targetable:
+		RequiresCondition: captured		
+	Targetable@NOAUTOTARGET:
 		RequiresCondition: !captured
+		TargetTypes: Ground, Structure, C4, DetonateAttack, SpyInfiltrate, NoAutoTarget
 
 powerproxy.paratroopers:
 	ParatroopersPower:

--- a/mods/ra/maps/soviet-07/rules.yaml
+++ b/mods/ra/maps/soviet-07/rules.yaml
@@ -51,3 +51,4 @@ FTUR:
 
 PBOX:
 	-AutoTarget:
+	-AutoTargetPriority@DEFAULT:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -81,6 +81,7 @@ BADR.Bomber:
 
 MIG:
 	Inherits: ^Plane
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Aircraft
 		BuildAtProductionType: Plane
@@ -140,6 +141,7 @@ MIG:
 
 YAK:
 	Inherits: ^Plane
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Aircraft
 		BuildAtProductionType: Plane
@@ -257,6 +259,7 @@ TRAN:
 
 HELI:
 	Inherits: ^Helicopter
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Buildable:
 		Queue: Aircraft
 		BuildAtProductionType: Helicopter
@@ -315,6 +318,7 @@ HELI:
 
 HIND:
 	Inherits: ^Helicopter
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Aircraft
 		BuildAtProductionType: Helicopter

--- a/mods/ra/rules/campaign-rules.yaml
+++ b/mods/ra/rules/campaign-rules.yaml
@@ -33,6 +33,7 @@ E7:
 E7.noautotarget:
 	Inherits: E7
 	-AutoTarget:
+	-AutoTargetPriority@DEFAULT:
 	RenderSprites:
 		Image: E7
 

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -1,7 +1,6 @@
 C1:
 	Inherits@1: ^CivInfantry
 	Inherits@2: ^ArmedCivilian
-	AutoTarget:
 
 C2:
 	Inherits: ^CivInfantry
@@ -33,7 +32,6 @@ C6:
 C7:
 	Inherits@1: ^CivInfantry
 	Inherits@2: ^ArmedCivilian
-	AutoTarget:
 	RenderSprites:
 		Image: C1
 
@@ -59,7 +57,6 @@ C10:
 TECN:
 	Inherits@1: ^CivInfantry
 	Inherits@2: ^ArmedCivilian
-	AutoTarget:
 	Tooltip:
 		Name: Technician
 	RenderSprites:
@@ -265,7 +262,8 @@ V19:
 	-SpawnActorOnDeath@3:
 	SpawnActorOnDeath:
 		Actor: V19.Husk
-	AutoTargetIgnore:
+	Targetable:
+		TargetTypes: Ground, C4, DetonateAttack, Structure, NoAutoTarget
 
 V19.Husk:
 	Inherits: ^CivBuilding
@@ -298,11 +296,10 @@ BARL:
 	Tooltip:
 		Name: Explosive Barrel
 		ShowOwnerRow: False
-	AutoTargetIgnore:
 	Armor:
 		Type: None
 	Targetable:
-		TargetTypes: Ground, DemoTruck, Barrel
+		TargetTypes: Ground, DemoTruck, Barrel, NoAutoTarget
 	-ShakeOnDeath:
 	-SoundOnDamageTransition:
 	-Demolishable:
@@ -321,11 +318,10 @@ BRL3:
 	Tooltip:
 		Name: Explosive Barrel
 		ShowOwnerRow: False
-	AutoTargetIgnore:
 	Armor:
 		Type: None
 	Targetable:
-		TargetTypes: Ground, DemoTruck, Barrel
+		TargetTypes: Ground, DemoTruck, Barrel, NoAutoTarget
 	-ShakeOnDeath:
 	-SoundOnDamageTransition:
 	-Demolishable:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -157,6 +157,24 @@
 	ExternalCondition@INVULNERABILITY:
 		Condition: invulnerability
 
+^AutoTargetGround:
+	AutoTarget:
+	AutoTargetPriority@DEFAULT:
+		ValidTargets: Infantry, Vehicle, Water, Structure, Defense
+		InvalidTargets: NoAutoTarget
+
+^AutoTargetAir:
+	AutoTarget:
+	AutoTargetPriority@DEFAULT:
+		ValidTargets: Air
+		InvalidTargets: NoAutoTarget
+
+^AutoTargetAll:
+	AutoTarget:
+	AutoTargetPriority@DEFAULT:
+		ValidTargets: Infantry, Vehicle, Water, Air, Structure, Defense
+		InvalidTargets: NoAutoTarget
+
 ^Vehicle:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^GainsExperience
@@ -359,7 +377,6 @@
 	Inherits: ^Infantry
 	UpdatesPlayerStatistics:
 	MustBeDestroyed:
-	AutoTarget:
 	ProximityCaptor:
 		Types: Infantry
 	TakeCover:
@@ -393,6 +410,7 @@
 		MaxMoveDelay: 750
 
 ^ArmedCivilian:
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Armament:
 		Weapon: Pistol
 	AttackFrontal:
@@ -584,7 +602,6 @@
 		TargetTypes: Ground, C4, DetonateAttack, Structure, Defense
 	MustBeDestroyed:
 		RequiredForShortGame: false
-	AutoTarget:
 	-GivesBuildableArea:
 	-AcceptsDeliveredCash:
 	DrawLineToTarget:
@@ -614,11 +631,10 @@
 	LineBuildNode:
 		Types: wall
 	Targetable:
-		TargetTypes: Ground, DetonateAttack, Wall
+		TargetTypes: Ground, DetonateAttack, Wall, NoAutoTarget
 	RenderSprites:
 		Palette: effect
 	WithWallSpriteBody:
-	AutoTargetIgnore:
 	Sellable:
 		SellSounds: cashturn.aud
 	Guardable:
@@ -704,7 +720,8 @@
 		Weapon: UnitExplode
 	Tooltip:
 		Name: Ammo Box
-	AutoTargetIgnore:
+	Targetable:
+		TargetTypes: Ground, C4, DetonateAttack, Structure, NoAutoTarget
 	Armor:
 		Type: Light
 	Targetable:
@@ -775,7 +792,6 @@
 		Image: burn-l
 		MinimumDamageState: Heavy
 		MaximumDamageState: Dead
-	AutoTargetIgnore:
 	HiddenUnderShroud:
 	ScriptTriggers:
 	EditorTilesetFilter:
@@ -802,7 +818,6 @@
 		Type: Heavy
 	HiddenUnderFog:
 		Type: CenterPosition
-	AutoTargetIgnore:
 	ScriptTriggers:
 	WithFacingSpriteBody:
 	HitShape:
@@ -822,7 +837,7 @@
 	WithColoredOverlay@IDISABLE:
 		Palette: disabled
 	Targetable:
-		TargetTypes: Ground, Husk
+		TargetTypes: Ground, Husk, NoAutoTarget
 		RequiresForceFire: true
 	Chronoshiftable:
 	Tooltip:
@@ -874,7 +889,6 @@
 		HP: 1000
 	Armor:
 		Type: Concrete
-	AutoTargetIgnore:
 	ScriptTriggers:
 	BodyOrientation:
 		QuantizedFacings: 1

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -34,6 +34,8 @@ DOG:
 		Voice: Move
 	AutoTarget:
 		InitialStance: AttackAnything
+	AutoTargetPriority@DEFAULT:
+		Types: Infantry
 	Targetable:
 		TargetTypes: Ground, Infantry
 	WithInfantryBody:
@@ -48,6 +50,7 @@ DOG:
 
 E1:
 	Inherits: ^Soldier
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
@@ -85,6 +88,7 @@ E1R1:
 
 E2:
 	Inherits: ^Soldier
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
@@ -120,6 +124,7 @@ E2:
 
 E3:
 	Inherits: ^Soldier
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
@@ -165,6 +170,7 @@ E3R1:
 
 E4:
 	Inherits: ^Soldier
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
@@ -211,7 +217,6 @@ E6:
 	ExternalCaptures:
 		Type: building
 		PlayerExperience: 25
-	-AutoTarget:
 	Voiced:
 		VoiceSet: EngineerVoice
 	Selectable:
@@ -219,6 +224,7 @@ E6:
 
 SPY:
 	Inherits: ^Soldier
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
@@ -285,6 +291,7 @@ SPY.England:
 
 E7:
 	Inherits: ^Soldier
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
@@ -360,6 +367,9 @@ MEDI:
 		DefaultAttackSequence: heal
 	Voiced:
 		VoiceSet: MedicVoice
+	AutoTarget:
+	AutoTargetPriority@DEFAULT:
+		Types: Infantry
 
 MECH:
 	Inherits: ^Soldier
@@ -398,6 +408,9 @@ MECH:
 		StandSequences: stand
 	Voiced:
 		VoiceSet: MechanicVoice
+	AutoTarget:
+	AutoTargetPriority@DEFAULT:
+		Types: Vehicle
 
 EINSTEIN:
 	Inherits: ^CivInfantry
@@ -463,7 +476,6 @@ THF:
 	Infiltrates:
 		InfiltrateTypes: Cash
 		PlayerExperience: 50
-	-AutoTarget:
 	Voiced:
 		VoiceSet: ThiefVoice
 	WithInfantryBody:
@@ -493,7 +505,6 @@ HIJACKER:
 	Captures:
 		CaptureTypes: vehicle
 		PlayerExperience: 50
-	-AutoTarget:
 	Voiced:
 		VoiceSet: ThiefVoice
 	-TakeCover:
@@ -517,6 +528,7 @@ HIJACKER:
 
 SHOK:
 	Inherits: ^Soldier
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
@@ -577,6 +589,8 @@ SNIPER:
 	AutoTarget:
 		InitialStance: HoldFire
 		InitialStanceAI: ReturnFire
+	AutoTargetPriority@DEFAULT:
+		Types: Infantry
 	Armament@PRIMARY:
 		Weapon: Sniper
 	Armament@GARRISONED:
@@ -606,6 +620,7 @@ SNIPER:
 
 Zombie:
 	Inherits: ^Soldier
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 100
 	Tooltip:
@@ -634,6 +649,7 @@ Zombie:
 
 Ant:
 	Inherits: ^Infantry
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 300
 	Tooltip:

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -207,7 +207,6 @@ MINE:
 	AppearsOnRadar:
 	RadarColorFromTerrain:
 		Terrain: Ore
-	AutoTargetIgnore:
 	SeedsResource:
 
 GMINE:
@@ -224,7 +223,6 @@ GMINE:
 	AppearsOnRadar:
 	RadarColorFromTerrain:
 		Terrain: Gems
-	AutoTargetIgnore:
 	SeedsResource:
 		ResourceType: Gems
 
@@ -239,7 +237,6 @@ RAILMINE:
 	Building:
 		Footprint: xx
 		Dimensions: 2,1
-	AutoTargetIgnore:
 	EditorTilesetFilter:
 		ExcludeTilesets: INTERIOR
 

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -50,6 +50,8 @@ SS:
 	AutoTarget:
 		InitialStance: HoldFire
 		InitialStanceAI: ReturnFire
+	AutoTargetPriority@DEFAULT:
+		Types: Water
 	DetectCloaked:
 		CloakTypes: Underwater
 		Range: 4c0
@@ -61,6 +63,7 @@ SS:
 
 MSUB:
 	Inherits: ^Ship
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Submarine
@@ -126,6 +129,7 @@ MSUB:
 
 DD:
 	Inherits: ^Ship
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Boat
@@ -167,7 +171,6 @@ DD:
 	SelectionDecorations:
 		VisualBounds: 38,38
 	WithSpriteTurret:
-	AutoTarget:
 	DetectCloaked:
 		CloakTypes: Underwater
 		Range: 4c0
@@ -175,6 +178,7 @@ DD:
 
 CA:
 	Inherits: ^Ship
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Boat
@@ -228,7 +232,6 @@ CA:
 		Turret: primary
 	WithSpriteTurret@SECONDARY:
 		Turret: secondary
-	AutoTarget:
 
 LST:
 	Inherits: ^Ship
@@ -270,6 +273,7 @@ LST:
 
 PT:
 	Inherits: ^Ship
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Ship
 		BuildAtProductionType: Boat
@@ -308,7 +312,6 @@ PT:
 	SelectionDecorations:
 		VisualBounds: 36,36
 	WithSpriteTurret:
-	AutoTarget:
 	DetectCloaked:
 		CloakTypes: Underwater
 		Range: 4c0

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -448,6 +448,7 @@ PDOX:
 TSLA:
 	Inherits: ^Defense
 	Inherits@IDISABLE: ^DisabledOverlay
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 80
@@ -493,6 +494,7 @@ TSLA:
 AGUN:
 	Inherits: ^Defense
 	Inherits@IDISABLE: ^DisabledOverlay
+	Inherits@AUTOTARGET: ^AutoTargetAir
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 90
@@ -592,6 +594,7 @@ DOME:
 
 PBOX:
 	Inherits: ^Defense
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Tooltip:
 		Name: Pillbox
 	Building:
@@ -640,6 +643,7 @@ PBOX:
 
 HBOX:
 	Inherits: ^Defense
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Tooltip:
 		Name: Camo Pillbox
 	Building:
@@ -695,6 +699,7 @@ HBOX:
 
 GUN:
 	Inherits: ^Defense
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 70
@@ -736,6 +741,7 @@ GUN:
 
 FTUR:
 	Inherits: ^Defense
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 60
@@ -780,6 +786,7 @@ SAM:
 	Inherits: ^Defense
 	Inherits@IDISABLE: ^DisabledOverlay
 	Inherits@shape: ^2x1Shape
+	Inherits@AUTOTARGET: ^AutoTargetAir
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 100

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -1,5 +1,6 @@
 V2RL:
 	Inherits: ^Vehicle
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 80
@@ -25,7 +26,6 @@ V2RL:
 	AttackFrontal:
 	SelectionDecorations:
 		VisualBounds: 28,28
-	AutoTarget:
 	Explodes:
 		Weapon: V2Explode
 	WithAttackAnimation:
@@ -36,6 +36,7 @@ V2RL:
 
 1TNK:
 	Inherits: ^Tank
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 50
@@ -68,7 +69,6 @@ V2RL:
 	AttackTurreted:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
-	AutoTarget:
 	SpawnActorOnDeath:
 		Actor: 1TNK.Husk
 	ProducibleWithLevel:
@@ -76,6 +76,7 @@ V2RL:
 
 2TNK:
 	Inherits: ^Tank
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 110
@@ -108,7 +109,6 @@ V2RL:
 	AttackTurreted:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
-	AutoTarget:
 	SpawnActorOnDeath:
 		Actor: 2TNK.Husk
 	SelectionDecorations:
@@ -118,6 +118,7 @@ V2RL:
 
 3TNK:
 	Inherits: ^Tank
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 120
@@ -150,7 +151,6 @@ V2RL:
 	AttackTurreted:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
-	AutoTarget:
 	SpawnActorOnDeath:
 		Actor: 3TNK.Husk
 	SelectionDecorations:
@@ -160,6 +160,7 @@ V2RL:
 
 4TNK:
 	Inherits: ^Tank
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 180
@@ -201,7 +202,6 @@ V2RL:
 	AttackTurreted:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
-	AutoTarget:
 	SpawnActorOnDeath:
 		Actor: 4TNK.Husk
 	SelfHealing:
@@ -216,6 +216,7 @@ V2RL:
 
 ARTY:
 	Inherits: ^Tank
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 70
@@ -247,7 +248,6 @@ ARTY:
 		Weapon: ArtilleryExplode
 		EmptyWeapon: UnitExplodeSmall
 		LoadedChance: 75
-	AutoTarget:
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 
@@ -340,6 +340,7 @@ MCV:
 
 JEEP:
 	Inherits: ^Vehicle
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 30
@@ -371,7 +372,6 @@ JEEP:
 	AttackTurreted:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
-	AutoTarget:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 1
@@ -382,6 +382,7 @@ JEEP:
 
 APC:
 	Inherits: ^Tank
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 40
@@ -410,7 +411,6 @@ APC:
 		MuzzleSequence: muzzle
 	AttackFrontal:
 	WithMuzzleOverlay:
-	AutoTarget:
 	Cargo:
 		Types: Infantry
 		MaxWeight: 5
@@ -556,6 +556,7 @@ MRJ:
 
 TTNK:
 	Inherits: ^Tank
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 170
@@ -586,12 +587,12 @@ TTNK:
 		Sequence: spinner
 	SelectionDecorations:
 		VisualBounds: 30,30
-	AutoTarget:
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 
 FTRK:
 	Inherits: ^Vehicle
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 60
@@ -629,7 +630,6 @@ FTRK:
 	AttackTurreted:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
-	AutoTarget:
 	SelectionDecorations:
 		VisualBounds: 28,28
 	ProducibleWithLevel:
@@ -666,6 +666,7 @@ DTRK:
 
 CTNK:
 	Inherits: ^Vehicle
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 200
@@ -689,7 +690,6 @@ CTNK:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 4c0
-	AutoTarget:
 	Armament@PRIMARY:
 		Weapon: APTusk
 		LocalOffset: -160,-276,232
@@ -736,6 +736,7 @@ QTNK:
 
 STNK:
 	Inherits: ^Vehicle
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 130

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -1,5 +1,6 @@
 DPOD:
 	Inherits: ^Helicopter
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 10
 	Tooltip:
@@ -29,7 +30,6 @@ DPOD:
 		PipCount: 5
 		PipType: Ammo
 		PipTypeEmpty: AmmoEmpty
-	AutoTarget:
 
 DSHP:
 	Inherits: ^Helicopter
@@ -65,6 +65,7 @@ DSHP:
 ORCA:
 	Inherits: ^Helicopter
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -99,7 +100,6 @@ ORCA:
 		PipCount: 5
 		PipType: Ammo
 		PipTypeEmpty: AmmoEmpty
-	AutoTarget:
 	RenderSprites:
 	SpawnActorOnDeath:
 		Actor: ORCA.Husk
@@ -107,6 +107,7 @@ ORCA:
 ORCAB:
 	Inherits: ^Aircraft
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 1600
 	Tooltip:
@@ -147,7 +148,6 @@ ORCAB:
 		ReloadDelay: 200
 		PipType: Ammo
 		PipTypeEmpty: AmmoEmpty
-	AutoTarget:
 	RenderSprites:
 	Hovers@CRUISING:
 		RequiresCondition: cruising
@@ -230,6 +230,7 @@ TRNSPORT:
 SCRIN:
 	Inherits: ^Aircraft
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 1500
 	Tooltip:
@@ -271,7 +272,6 @@ SCRIN:
 		ReloadCount: 5
 		PipType: Ammo
 		PipTypeEmpty: AmmoEmpty
-	AutoTarget:
 	RenderSprites:
 	DeathSounds:
 	SpawnActorOnDeath:
@@ -280,6 +280,7 @@ SCRIN:
 APACHE:
 	Inherits: ^Helicopter
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -312,7 +313,6 @@ APACHE:
 		PipCount: 4
 		PipType: Ammo
 		PipTypeEmpty: AmmoEmpty
-	AutoTarget:
 	WithIdleOverlay@ROTORAIR:
 		Offset: 85,0,384
 		Sequence: rotor

--- a/mods/ts/rules/civilian-infantry.yaml
+++ b/mods/ts/rules/civilian-infantry.yaml
@@ -29,6 +29,7 @@ UMAGON:
 	Inherits: ^Soldier
 	Inherits@2: ^HealsOnTiberium
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 400
 	Tooltip:
@@ -77,7 +78,6 @@ CHAMSPY:
 		RequiresCondition: disguise
 	Infiltrates:
 		Types: SpyInfiltrate
-	-AutoTarget:
 	-WithInfantryBody:
 	WithDisguisingInfantryBody:
 		IdleSequences: idle1,idle2
@@ -86,6 +86,7 @@ MUTANT:
 	Inherits: ^Soldier
 	Inherits@2: ^HealsOnTiberium
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 100
 	Tooltip:
@@ -111,6 +112,7 @@ MWMN:
 	Inherits: ^Soldier
 	Inherits@2: ^HealsOnTiberium
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 100
 	Tooltip:
@@ -136,6 +138,7 @@ MUTANT3:
 	Inherits: ^Soldier
 	Inherits@2: ^HealsOnTiberium
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 100
 	Tooltip:
@@ -172,7 +175,6 @@ TRATOS:
 		Speed: 71
 	RevealsShroud:
 		Range: 4c0
-	-AutoTarget:
 	WithInfantryBody:
 		DefaultAttackSequence:
 
@@ -190,7 +192,6 @@ OXANNA:
 		Speed: 56
 	RevealsShroud:
 		Range: 4c0
-	-AutoTarget:
 	WithInfantryBody:
 		DefaultAttackSequence: attack
 
@@ -208,12 +209,12 @@ SLAV:
 		Speed: 56
 	RevealsShroud:
 		Range: 4c0
-	-AutoTarget:
 	WithInfantryBody:
 		DefaultAttackSequence: attack
 
 CIV1:
 	Inherits: ^CivilianInfantry
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	WithInfantryBody:
 		DefaultAttackSequence: attack
 	Armament:
@@ -223,10 +224,10 @@ CIV1:
 
 CIV2:
 	Inherits: ^CivilianInfantry
-	-AutoTarget:
 
 CIV3:
 	Inherits: ^CivilianInfantry
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	WithInfantryBody:
 		DefaultAttackSequence: attack
 	Armament:

--- a/mods/ts/rules/civilian-vehicles.yaml
+++ b/mods/ts/rules/civilian-vehicles.yaml
@@ -2,6 +2,7 @@
 	Inherits: ^Tank
 	Inherits@VOXELS: ^VoxelActor
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Valued:
 		Cost: 1700
 	Tooltip:
@@ -30,7 +31,6 @@
 		LocalOffset: 0,283,580, 0,-283,580
 	AttackTurreted:
 		Voice: Attack
-	AutoTarget:
 	SelfHealing:
 		Delay: 10
 		HealIfBelow: 50

--- a/mods/ts/rules/critters.yaml
+++ b/mods/ts/rules/critters.yaml
@@ -53,6 +53,7 @@ VISC_SML:
 VISC_LRG:
 	Inherits: ^Visceroid
 	Inherits@CRATESTATS: ^CrateStatModifiers
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Tooltip:
 		Name: Adult Visceroid
 	Health:
@@ -82,6 +83,7 @@ VISC_LRG:
 JFISH:
 	Inherits: ^Visceroid
 	Inherits@CRATESTATS: ^CrateStatModifiers
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Tooltip:
 		Name: Tiberium Floater
 	Health:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -123,6 +123,24 @@
 	ExternalCondition@CRATE-CLOAK:
 		Condition: crate-cloak
 
+^AutoTargetGround:
+	AutoTarget:
+	AutoTargetPriority@DEFAULT:
+		ValidTargets: Infantry, Vehicle, Water, Structure, Defense
+		InvalidTargets: NoAutoTarget
+
+^AutoTargetAir:
+	AutoTarget:
+	AutoTargetPriority@DEFAULT:
+		ValidTargets: Air
+		InvalidTargets: NoAutoTarget
+
+^AutoTargetAll:
+	AutoTarget:
+	AutoTargetPriority@DEFAULT:
+		ValidTargets: Infantry, Vehicle, Water, Air, Structure, Defense
+		InvalidTargets: NoAutoTarget
+
 ^BasicBuilding:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
@@ -278,7 +296,6 @@
 		TargetTypes: Ground, Wall, C4
 	WithWallSpriteBody:
 		Type: wall
-	AutoTargetIgnore:
 	Sellable:
 		SellSounds: cashturn.aud
 	Demolishable:
@@ -348,7 +365,6 @@
 	QuantizeFacingsFromSequence:
 		Sequence: stand
 	WithInfantryBody:
-	AutoTarget:
 	AttackMove:
 		Voice: Move
 	Passenger:
@@ -671,7 +687,6 @@
 		Type: Heavy
 	HiddenUnderFog:
 		Type: GroundPosition
-	AutoTargetIgnore:
 	ScriptTriggers:
 	Tooltip:
 		GenericName: Destroyed Aircraft
@@ -801,7 +816,6 @@
 ^Defense:
 	Inherits: ^Building
 	-GivesBuildableArea:
-	AutoTarget:
 	RenderRangeCircle:
 	RenderDetectionCircle:
 	RevealsShroud:

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -1,6 +1,7 @@
 E2:
 	Inherits: ^Soldier
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 20
@@ -57,6 +58,9 @@ MEDIC:
 		ForceTargetStances: None
 		Cursor: heal
 		OutsideRangeCursor: heal
+	AutoTarget:
+	AutoTargetPriority@DEFAULT:
+		ValidTargets: Infantry
 	AttackFrontal:
 	WithInfantryBody:
 		DefaultAttackSequence: heal
@@ -68,6 +72,7 @@ MEDIC:
 JUMPJET:
 	Inherits: ^Soldier
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 600
 	Tooltip:
@@ -152,7 +157,6 @@ JUMPJET.Husk:
 	Aircraft:
 	HiddenUnderFog:
 		Type: GroundPosition
-	AutoTargetIgnore:
 	ScriptTriggers:
 	Tooltip:
 		Name: Jumpjet Infantry
@@ -184,6 +188,7 @@ GHOST:
 	Inherits: ^Soldier
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@2: ^HealsOnTiberium
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 1750
 	Tooltip:

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -44,6 +44,7 @@ GAGATE_B:
 GACTWR:
 	Inherits: ^Defense
 	Inherits@IDISABLE: ^DisabledOverlay
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	-WithSpriteBody:
 	WithWallSpriteBody:
 		Type: wall

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -51,6 +51,7 @@ HVR:
 	Inherits: ^Vehicle
 	Inherits@VOXELS: ^VoxelActor
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Valued:
 		Cost: 900
 	Tooltip:
@@ -89,7 +90,6 @@ HVR:
 		Offset: -128,0,85
 	AttackTurreted:
 		Voice: Attack
-	AutoTarget:
 	WithVoxelTurret:
 	Hovers:
 	LeavesTrails:
@@ -106,6 +106,7 @@ HVR:
 SMECH:
 	Inherits: ^Vehicle
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -128,7 +129,6 @@ SMECH:
 		MaxHeightDelta: 3
 	AttackFrontal:
 		Voice: Attack
-	AutoTarget:
 	Armament:
 		Weapon: AssaultCannon
 	Voiced:
@@ -149,6 +149,7 @@ SMECH:
 MMCH:
 	Inherits: ^Tank
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 800
 	Tooltip:
@@ -191,7 +192,6 @@ MMCH:
 	RenderVoxels:
 	WithVoxelBarrel:
 		LocalOffset: -91,91,362
-	AutoTarget:
 	Selectable:
 		Bounds: 30, 42, 0, -8
 	Carryable:
@@ -201,6 +201,7 @@ HMEC:
 	Inherits: ^Tank
 	Inherits@VOXELS: ^VoxelActor
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Valued:
 		Cost: 3000
 	Tooltip:
@@ -226,7 +227,6 @@ HMEC:
 		MaxHeightDelta: 3
 	AttackFrontal:
 		Voice: Attack
-	AutoTarget:
 	Armament@MISSILES:
 		Weapon: MammothTusk
 		LocalOffset: -243,-368,1208, -243,368,1208
@@ -245,6 +245,7 @@ SONIC:
 	Inherits: ^Tank
 	Inherits@VOXELS: ^VoxelActor
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 1300
 	Tooltip:
@@ -276,13 +277,13 @@ SONIC:
 	Turreted:
 		TurnSpeed: 5
 		Offset: -170,0,0
-	AutoTarget:
 	WithVoxelTurret:
 
 JUGG:
 	Inherits: ^Tank
 	Inherits@SPRITES: ^SpriteActor
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 950
 	Tooltip:
@@ -361,7 +362,6 @@ JUGG:
 		MuzzleSequence: muzzle
 		MuzzlePalette: effect-ignore-lighting
 	WithMuzzleOverlay:
-	AutoTarget:
 	Carryable:
 		RequiresCondition: undeployed
 	RevealOnFire:

--- a/mods/ts/rules/nod-infantry.yaml
+++ b/mods/ts/rules/nod-infantry.yaml
@@ -1,6 +1,7 @@
 E3:
 	Inherits: ^Soldier
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 30
@@ -33,6 +34,7 @@ E3:
 CYBORG:
 	Inherits: ^Cyborg
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Armor:
 		Type: Light
 	Valued:
@@ -67,6 +69,7 @@ CYBORG:
 CYC2:
 	Inherits: ^Cyborg
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Armor:
 		Type: Heavy
 	Valued:
@@ -125,4 +128,3 @@ MHIJACK:
 		PlayerExperience: 50
 	RevealsShroud:
 		Range: 6c0
-	-AutoTarget:

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -148,6 +148,7 @@ NAFNCE:
 NALASR:
 	Inherits: ^Defense
 	Inherits@IDISABLE: ^DisabledOverlay
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 300
 	Tooltip:
@@ -188,6 +189,7 @@ NALASR:
 NAOBEL:
 	Inherits: ^Defense
 	Inherits@IDISABLE: ^DisabledOverlay
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 1500
 	Tooltip:
@@ -233,6 +235,7 @@ NAOBEL:
 NASAM:
 	Inherits: ^Defense
 	Inherits@IDISABLE: ^DisabledOverlay
+	Inherits@AUTOTARGET: ^AutoTargetAir
 	Valued:
 		Cost: 500
 	Tooltip:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -2,6 +2,7 @@ BGGY:
 	Inherits: ^Vehicle
 	Inherits@VOXELS: ^VoxelActor
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -30,7 +31,6 @@ BGGY:
 		MuzzleSplitFacings: 8
 	AttackFrontal:
 		Voice: Attack
-	AutoTarget:
 	WithMuzzleOverlay:
 	-DamagedByTerrain@VEINS:
 	-LeavesTrails@VEINS:
@@ -39,6 +39,7 @@ BIKE:
 	Inherits: ^Vehicle
 	Inherits@VOXELS: ^VoxelActor
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Valued:
 		Cost: 600
 	Tooltip:
@@ -69,12 +70,12 @@ BIKE:
 		LocalOffset: -153,-204,509, -153,204,509
 	AttackFrontal:
 		Voice: Attack
-	AutoTarget:
 
 TTNK:
 	Inherits: ^Tank
 	Inherits@VOXELS: ^VoxelActor
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 800
 	Tooltip:
@@ -170,7 +171,6 @@ TTNK:
 	Armor@deployed:
 		Type: Concrete
 		RequiresCondition: deployed
-	AutoTarget:
 	Carryable:
 		RequiresCondition: undeployed
 	RevealOnFire:
@@ -182,6 +182,7 @@ ART2:
 	Inherits: ^Tank
 	Inherits@VOXELS: ^VoxelActor
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 975
 	Tooltip:
@@ -252,7 +253,6 @@ ART2:
 		MuzzleSequence: muzzle
 		MuzzlePalette: effect-ignore-lighting
 	WithMuzzleOverlay:
-	AutoTarget:
 	Carryable:
 		RequiresCondition: undeployed
 	RevealOnFire:
@@ -287,6 +287,9 @@ REPAIR:
 		ForceTargetStances: None
 	AttackFrontal:
 		Voice: Attack
+	AutoTarget:
+	AutoTargetPriority@DEFAULT:
+		ValidTargets: Vehicles
 
 WEED:
 	Inherits: ^Tank
@@ -379,6 +382,7 @@ SUBTANK:
 	Inherits: ^Tank
 	Inherits@VOXELS: ^VoxelActor
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 750
 	Tooltip:
@@ -413,7 +417,6 @@ SUBTANK:
 		Weapon: FireballLauncher
 	AttackFrontal:
 		Voice: Attack
-	AutoTarget:
 	WithVoxelBody:
 		RequiresCondition: !submerged
 	Targetable:
@@ -423,6 +426,7 @@ STNK:
 	Inherits: ^Tank
 	Inherits@VOXELS: ^VoxelActor
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetAll
 	Valued:
 		Cost: 1100
 	Tooltip:

--- a/mods/ts/rules/shared-infantry.yaml
+++ b/mods/ts/rules/shared-infantry.yaml
@@ -1,6 +1,7 @@
 E1:
 	Inherits: ^Soldier
 	Inherits@EXPERIENCE: ^GainsExperience
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 10
@@ -59,7 +60,6 @@ ENGINEER:
 	Captures:
 		CaptureTypes: building
 		PlayerExperience: 50
-	-AutoTarget:
 	RenderSprites:
 		Image: engineer.gdi
 		FactionImages:

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -22,7 +22,6 @@ NAPULS:
 		Type: Heavy
 	RevealsShroud:
 		Range: 8c0
-	-AutoTarget:
 	Turreted:
 		TurnSpeed: 10
 		InitialFacing: 224


### PR DESCRIPTION
This reworks our AutoTarget logic to add support for explicit target prioritization.

Some potential future use cases:
* Adding target prioritization to improve AI micromanagement, together with #13382.  E.g. "Hard AI" owned rocket troopers will attack tanks before infantry (see testcase commit).
* Implementing the proper C&C stance logic, together with #13371.  Units in the AttackAnything stance autotarget non-defense structures, but units in the Defense stance don't.
* Implementing the cut [threat rating node upgrade](http://cnc.wikia.com/wiki/Threat_Rating_Node_upgrade) in TS.

Performance-wise, i'm hoping this will roughly balance out -- we need to do a bit extra work per actor to query the target types, but actors that make use of the priorities win a lot by being able to skip actors of a lower priority before doing the weapon checks.

Unfortunately the haphazard spray of `AutoTarget` overrides across our default mod/map rules means that we can't implement a proper upgrade rule for this.  I took this opportunity to clean up our AutoTarget definitions across all four mods.

The [pchote/autotarget-types-testcase](https://github.com/pchote/OpenRA/commits/autotarget-types-testcase) branch has two throwaway testcases for the new behaviour:
* Player controlled units will prioritize vehicles or tanks based on their damage type, illustrating the prioritization logic.
* Iron curtained units will stop AutoTargeting everything, illustrating the condition support.

Closes #3581.
Closes #10625.