### PR TITLE
Fix the close enough check in Repair.cs

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -392,9 +392,9 @@ namespace OpenRA.Mods.Common.Traits
 			if (Info.RearmBuildings.Contains(name))
 				yield return new Rearm(self);
 
-			// Add a CloseEnough range of 512 to ensure we're at the host actor
+			// The ResupplyAircraft activity guarantees that we're on the helipad
 			if (Info.RepairBuildings.Contains(name))
-				yield return new Repair(self, a, new WDist(512));
+				yield return new Repair(self, a, WDist.Zero);
 		}
 
 		public void ModifyDeathActorInit(Actor self, TypeDictionary init)


### PR DESCRIPTION
Fixes #13384.

The problem is that the helicopter doesn't land at the center position, but is [offset](https://github.com/OpenRA/OpenRA/blob/74437ed56ce044bdef2f99e8c26688c33c12d6bd/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs#L79).