### PR TITLE
Display latency in ingame info

### DIFF
--- a/mods/cnc/chrome/ingame-infostats.yaml
+++ b/mods/cnc/chrome/ingame-infostats.yaml
@@ -34,8 +34,8 @@ Container@SKIRMISH_STATS:
 			Width: 393
 			Children:
 				Label@NAME:
-					X: 10
-					Width: 210
+					X: 15
+					Width: 205
 					Height: 25
 					Text: Player
 					Font: Bold
@@ -83,9 +83,20 @@ Container@SKIRMISH_STATS:
 					Height: 25
 					X: 2
 					Children:
+						Container@LATENCY:
+							Y: 6
+							Width: 11
+							Height: 14
+							Visible: false
+							Children:
+								ColorBlock@LATENCY_COLOR:
+									X: 2
+									Y: 2
+									Width: PARENT_RIGHT - 4
+									Height: PARENT_BOTTOM - 4
 						Label@NAME:
-							X: 10
-							Width: 210
+							X: 15
+							Width: 205
 							Height: 25
 							Shadow: True
 						ClientTooltipRegion@CLIENT_REGION:

--- a/mods/common/chrome/ingame-infostats.yaml
+++ b/mods/common/chrome/ingame-infostats.yaml
@@ -34,8 +34,8 @@ Container@SKIRMISH_STATS:
 			Width: 393
 			Children:
 				Label@NAME:
-					X: 10
-					Width: 210
+					X: 15
+					Width: 205
 					Height: 25
 					Text: Player
 					Font: Bold
@@ -84,9 +84,20 @@ Container@SKIRMISH_STATS:
 					Height: 25
 					X: 2
 					Children:
+						Container@LATENCY:
+							Y: 6
+							Width: 11
+							Height: 14
+							Visible: false
+							Children:
+								ColorBlock@LATENCY_COLOR:
+									X: 2
+									Y: 2
+									Width: PARENT_RIGHT - 4
+									Height: PARENT_BOTTOM - 4
 						Label@NAME:
-							X: 10
-							Width: 210
+							X: 15
+							Width: 205
 							Height: 25
 							Shadow: True
 						ClientTooltipRegion@CLIENT_REGION:

--- a/mods/d2k/chrome/ingame-infostats.yaml
+++ b/mods/d2k/chrome/ingame-infostats.yaml
@@ -34,8 +34,8 @@ Container@SKIRMISH_STATS:
 			Width: 393
 			Children:
 				Label@NAME:
-					X: 10
-					Width: 210
+					X: 15
+					Width: 205
 					Height: 25
 					Text: Player
 					Font: Bold
@@ -84,9 +84,20 @@ Container@SKIRMISH_STATS:
 					Height: 25
 					X: 2
 					Children:
+						Container@LATENCY:
+							Y: 6
+							Width: 11
+							Height: 14
+							Visible: false
+							Children:
+								ColorBlock@LATENCY_COLOR:
+									X: 2
+									Y: 2
+									Width: PARENT_RIGHT - 4
+									Height: PARENT_BOTTOM - 4
 						Label@NAME:
-							X: 10
-							Width: 210
+							X: 15
+							Width: 205
 							Height: 25
 							Shadow: True
 						ClientTooltipRegion@CLIENT_REGION:


### PR DESCRIPTION
It is sometimes asked for displaying latency in game. I looked at it and it is there, only not displayed. (maybe there is a reason for it?)
Adding latency indicator in ingame info stats next to player name like in lobby.

![obrazok](https://cloud.githubusercontent.com/assets/16348750/26574484/d717308c-4521-11e7-9249-726d86b2256c.png)
