### PR TITLE
Allow load screens to override StartGame.

### DIFF
--- a/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.LoadScreens
 			Game.Renderer.EndFrame(new NullInputHandler());
 		}
 
-		public void StartGame(Arguments args)
+		public virtual void StartGame(Arguments args)
 		{
 			Launch = new LaunchArguments(args);
 			Ui.ResetAll();


### PR DESCRIPTION
This allows loadscreens to do this:

````
private bool started;
public override void StartGame(Arguments args)
{
	base.StartGame(args);
	started = true;
}
````

resulting in the loadscreen to know wether its displayed the first time (engine start) or another time (match start)