### PR TITLE
Fixed an ore truck glitch #12715

### DIFF
--- a/OpenRA.Mods.Common/Activities/DeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverResources.cs
@@ -76,6 +76,9 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				isDocking = true;
 				iao.OnDock(self, this);
+
+				// Run what OnDock queued.
+				return NextActivity;
 			}
 
 			return ActivityUtils.SequenceActivities(new Wait(10), this);


### PR DESCRIPTION
I encountered #12715 while making slave miner and this time, I got it fixed.

https://youtu.be/S4kc_d4OW4Y : How to reproduce the glitch
https://youtu.be/rIqEVKnc0hA : Demo of fixed harvester

I don't understand why the bug is here in the first place though.
So there are 2 instances of FindResources in the memory for reasons I don't understand.
The dock activities are queued in the wrong instance and glitches for that just one case of being at the dock already.