### PR TITLE
Add chat tab to multiplayer/replays ingame menu

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -17,7 +17,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public enum IngameInfoPanel { AutoSelect, Map, Objectives, Debug }
+	public enum IngameInfoPanel { AutoSelect, Map, Objectives, Debug, Chat }
 
 	class GameInfoLogic : ChromeLogic
 	{
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				numTabs++;
 				var debugTabButton = widget.Get<ButtonWidget>(string.Concat("BUTTON", numTabs.ToString()));
 				debugTabButton.Text = "Debug";
-				debugTabButton.IsVisible = () => lp != null && numTabs > 1 && !hasError;
+				debugTabButton.IsVisible = () => numTabs > 1 && !hasError;
 				debugTabButton.IsDisabled = () => world.IsGameOver;
 				debugTabButton.OnClick = () => activePanel = IngameInfoPanel.Debug;
 				debugTabButton.IsHighlighted = () => activePanel == IngameInfoPanel.Debug;
@@ -97,6 +97,28 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				if (activePanel == IngameInfoPanel.AutoSelect)
 					activePanel = IngameInfoPanel.Debug;
+			}
+
+			if (world.LobbyInfo.NonBotClients.Count() > 1)
+			{
+				numTabs++;
+				var chatPanelContainer = widget.Get<ContainerWidget>("CHAT_PANEL");
+				var chatTabButton = widget.Get<ButtonWidget>(string.Concat("BUTTON", numTabs.ToString()));
+				chatTabButton.Text = "Chat";
+				chatTabButton.IsVisible = () => numTabs > 1 && !hasError;
+				chatTabButton.IsHighlighted = () => activePanel == IngameInfoPanel.Chat;
+				chatTabButton.OnClick = () =>
+				{
+					activePanel = IngameInfoPanel.Chat;
+					chatPanelContainer.Get<TextFieldWidget>("CHAT_TEXTFIELD").TakeKeyboardFocus();
+				};
+
+				chatPanelContainer.IsVisible = () => activePanel == IngameInfoPanel.Chat;
+
+				Game.LoadWidget(world, "CHAT_CONTAINER", chatPanelContainer, new WidgetArgs() { { "isMenuChat", true } });
+
+				if (activePanel == IngameInfoPanel.AutoSelect)
+					chatTabButton.OnClick();
 			}
 
 			// Handle empty space when tabs aren't displayed

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Mods.Common.Commands;
@@ -39,7 +40,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		bool teamChat;
 
 		[ObjectCreator.UseCtor]
-		public IngameChatLogic(Widget widget, OrderManager orderManager, World world, ModData modData)
+		public IngameChatLogic(Widget widget, OrderManager orderManager, World world, ModData modData, bool isMenuChat)
 		{
 			this.orderManager = orderManager;
 			this.modRules = modData.DefaultRules;
@@ -54,9 +55,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			tabCompletion.Names = orderManager.LobbyInfo.Clients.Select(c => c.Name).Distinct().ToList();
 
 			var chatPanel = (ContainerWidget)widget;
-			chatOverlay = chatPanel.Get<ContainerWidget>("CHAT_OVERLAY");
-			chatOverlayDisplay = chatOverlay.Get<ChatDisplayWidget>("CHAT_DISPLAY");
-			chatOverlay.Visible = false;
+			chatOverlay = chatPanel.GetOrNull<ContainerWidget>("CHAT_OVERLAY");
+			if (chatOverlay != null)
+			{
+				chatOverlayDisplay = chatOverlay.Get<ChatDisplayWidget>("CHAT_DISPLAY");
+				chatOverlay.Visible = false;
+			}
 
 			chatChrome = chatPanel.Get<ContainerWidget>("CHAT_CHROME");
 			chatChrome.Visible = true;
@@ -83,7 +87,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				}
 
 				chatText.Text = "";
-				CloseChat();
+				if (!isMenuChat)
+					CloseChat();
+
 				return true;
 			};
 
@@ -99,24 +105,35 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return true;
 			};
 
-			chatText.OnEscKey = () => { CloseChat(); return true; };
-
-			var chatClose = chatChrome.Get<ButtonWidget>("CHAT_CLOSE");
-			chatClose.OnClick += CloseChat;
-
-			chatPanel.OnKeyPress = e =>
+			chatText.OnEscKey = () =>
 			{
-				if (e.Event == KeyInputEvent.Up)
-					return false;
+				if (!isMenuChat)
+					CloseChat();
+				else
+					chatText.YieldKeyboardFocus();
 
-				if (!chatChrome.IsVisible() && (e.Key == Keycode.RETURN || e.Key == Keycode.KP_ENTER))
-				{
-					OpenChat();
-					return true;
-				}
-
-				return false;
+				return true;
 			};
+
+			if (!isMenuChat)
+			{
+				var chatClose = chatChrome.Get<ButtonWidget>("CHAT_CLOSE");
+				chatClose.OnClick += CloseChat;
+
+				chatPanel.OnKeyPress = e =>
+				{
+					if (e.Event == KeyInputEvent.Up)
+						return false;
+
+					if (!chatChrome.IsVisible() && (e.Key == Keycode.RETURN || e.Key == Keycode.KP_ENTER))
+					{
+						OpenChat();
+						return true;
+					}
+
+					return false;
+				};
+			}
 
 			chatScrollPanel = chatChrome.Get<ScrollPanelWidget>("CHAT_SCROLLPANEL");
 			chatTemplate = chatScrollPanel.Get<ContainerWidget>("CHAT_TEMPLATE");
@@ -129,23 +146,27 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			orderManager.AddChatLine += AddChatLineWrapper;
 			Game.BeforeGameStart += UnregisterEvents;
 
-			CloseChat();
 			chatText.IsDisabled = () => world.IsReplay && !Game.Settings.Debug.EnableDebugCommandsInReplays;
 
-			var keyListener = chatChrome.Get<LogicKeyListenerWidget>("KEY_LISTENER");
-			keyListener.OnKeyPress = e =>
+			if (!isMenuChat)
 			{
-				if (e.Event == KeyInputEvent.Up || !chatText.IsDisabled())
-					return false;
+				CloseChat();
 
-				if ((e.Key == Keycode.RETURN || e.Key == Keycode.KP_ENTER || e.Key == Keycode.ESCAPE) && e.Modifiers == Modifiers.None)
+				var keyListener = chatChrome.Get<LogicKeyListenerWidget>("KEY_LISTENER");
+				keyListener.OnKeyPress = e =>
 				{
-					CloseChat();
-					return true;
-				}
+					if (e.Event == KeyInputEvent.Up || !chatText.IsDisabled())
+						return false;
 
-				return false;
-			};
+					if ((e.Key == Keycode.RETURN || e.Key == Keycode.KP_ENTER || e.Key == Keycode.ESCAPE) && e.Modifiers == Modifiers.None)
+					{
+						CloseChat();
+						return true;
+					}
+
+					return false;
+				};
+			}
 		}
 
 		bool SwitchTeamChat()
@@ -168,6 +189,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			chatScrollPanel.ScrollToBottom();
 			if (!chatText.IsDisabled())
 				chatText.TakeKeyboardFocus();
+
 			chatOverlay.Visible = false;
 		}
 
@@ -185,7 +207,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void AddChatLine(Color c, string from, string text, bool replayCache)
 		{
-			if (!replayCache)
+			if (!replayCache && chatOverlayDisplay != null)
 				chatOverlayDisplay.AddLine(c, from, text);
 
 			var template = chatTemplate.Clone();

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				};
 			}
 
-			Game.LoadWidget(world, "CHAT_PANEL", worldRoot, new WidgetArgs());
+			Game.LoadWidget(world, "CHAT_PANEL", worldRoot, new WidgetArgs() { { "isMenuChat", false } });
 
 			world.GameOver += () =>
 			{

--- a/mods/cnc/chrome/ingame-info.yaml
+++ b/mods/cnc/chrome/ingame-info.yaml
@@ -39,6 +39,12 @@ Container@GAME_INFO_PANEL:
 					Width: 140
 					Height: 35
 					Visible: False
+				Button@BUTTON4:
+					X: 450
+					Y: 5
+					Width: 140
+					Height: 35
+					Visible: False
 		Background@BACKGROUND:
 			Y: 39
 			Width: PARENT_RIGHT
@@ -52,5 +58,8 @@ Container@GAME_INFO_PANEL:
 				Container@OBJECTIVES_PANEL:
 					Width: PARENT_RIGHT
 				Container@DEBUG_PANEL:
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
+				Container@CHAT_PANEL:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM

--- a/mods/cnc/chrome/ingame-infochat.yaml
+++ b/mods/cnc/chrome/ingame-infochat.yaml
@@ -1,0 +1,46 @@
+Container@CHAT_CONTAINER:
+	Y: 10
+	Width: PARENT_RIGHT
+	Height: PARENT_BOTTOM - 20
+	Logic: IngameChatLogic
+	Children:
+		Container@CHAT_CHROME:
+			X: 15
+			Width: PARENT_RIGHT - 30
+			Height: PARENT_BOTTOM
+			Children:
+				Button@CHAT_MODE:
+					Y: PARENT_BOTTOM - HEIGHT
+					Width: 50
+					Height: 25
+					Text: Team
+					Font: Bold
+				TextField@CHAT_TEXTFIELD:
+					X: 55
+					Y: PARENT_BOTTOM - HEIGHT
+					Width: PARENT_RIGHT - 55
+					Height: 25
+				ScrollPanel@CHAT_SCROLLPANEL:
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM - 30
+					TopBottomSpacing: 2
+					ItemSpacing: 2
+					Children:
+						Container@CHAT_TEMPLATE:
+							X: 2
+							Width: PARENT_RIGHT - 27
+							Height: 16
+							Children:
+								Label@NAME:
+									X: 3
+									Width: 50
+									Height: 15
+									VAlign: Top
+									Shadow: True
+								Label@TEXT:
+									X: 12
+									Width: PARENT_RIGHT - 17
+									Height: 15
+									WordWrap: true
+									VAlign: Top
+									Shadow: True

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -109,6 +109,7 @@ ChromeLayout:
 	cnc|chrome/ingame-chat.yaml
 	cnc|chrome/ingame-menu.yaml
 	cnc|chrome/ingame-debug.yaml
+	cnc|chrome/ingame-infochat.yaml
 	cnc|chrome/ingame-info.yaml
 	cnc|chrome/ingame-infobriefing.yaml
 	cnc|chrome/ingame-infoscripterror.yaml

--- a/mods/common/chrome/ingame-info.yaml
+++ b/mods/common/chrome/ingame-info.yaml
@@ -50,6 +50,13 @@ Container@GAME_INFO_PANEL:
 					Height: 25
 					Font: Bold
 					Visible: False
+				Button@BUTTON4:
+					X: 360
+					Y: 50
+					Width: 120
+					Height: 25
+					Font: Bold
+					Visible: False
 		Container@STATS_PANEL:
 			Y: 65
 		Container@MAP_PANEL:
@@ -60,6 +67,10 @@ Container@GAME_INFO_PANEL:
 			Y: 65
 			Width: PARENT_RIGHT
 		Container@DEBUG_PANEL:
+			Y: 65
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+		Container@CHAT_PANEL:
 			Y: 65
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM

--- a/mods/common/chrome/ingame-infochat.yaml
+++ b/mods/common/chrome/ingame-infochat.yaml
@@ -1,0 +1,46 @@
+Container@CHAT_CONTAINER:
+	Y: 20
+	Width: PARENT_RIGHT
+	Height: PARENT_BOTTOM - 100
+	Logic: IngameChatLogic
+	Children:
+		Container@CHAT_CHROME:
+			X: 20
+			Width: PARENT_RIGHT - 40
+			Height: PARENT_BOTTOM
+			Children:
+				Button@CHAT_MODE:
+					Y: PARENT_BOTTOM - HEIGHT
+					Width: 50
+					Height: 25
+					Text: Team
+					Font: Bold
+				TextField@CHAT_TEXTFIELD:
+					X: 55
+					Y: PARENT_BOTTOM - HEIGHT
+					Width: PARENT_RIGHT - 55
+					Height: 25
+				ScrollPanel@CHAT_SCROLLPANEL:
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM - 30
+					TopBottomSpacing: 2
+					ItemSpacing: 2
+					Children:
+						Container@CHAT_TEMPLATE:
+							X: 2
+							Width: PARENT_RIGHT - 27
+							Height: 16
+							Children:
+								Label@NAME:
+									X: 3
+									Width: 50
+									Height: 15
+									VAlign: Top
+									Shadow: True
+								Label@TEXT:
+									X: 12
+									Width: PARENT_RIGHT - 17
+									Height: 15
+									WordWrap: true
+									VAlign: Top
+									Shadow: True

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -78,6 +78,7 @@ ChromeLayout:
 	d2k|chrome/ingame-player.yaml
 	common|chrome/ingame-perf.yaml
 	common|chrome/ingame-debug.yaml
+	common|chrome/ingame-infochat.yaml
 	d2k|chrome/mainmenu.yaml
 	common|chrome/settings.yaml
 	common|chrome/credits.yaml

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -93,6 +93,7 @@ ChromeLayout:
 	ra|chrome/ingame-player.yaml
 	common|chrome/ingame-perf.yaml
 	common|chrome/ingame-debug.yaml
+	common|chrome/ingame-infochat.yaml
 	common|chrome/mainmenu.yaml
 	common|chrome/settings.yaml
 	common|chrome/credits.yaml

--- a/mods/ts/chrome/ingame-info.yaml
+++ b/mods/ts/chrome/ingame-info.yaml
@@ -50,6 +50,13 @@ Container@GAME_INFO_PANEL:
 					Height: 25
 					Font: Bold
 					Visible: False
+				Button@BUTTON4:
+					X: 360
+					Y: 50
+					Width: 120
+					Height: 25
+					Font: Bold
+					Visible: False
 		Container@STATS_PANEL:
 			Y: 65
 		Container@MAP_PANEL:
@@ -60,6 +67,10 @@ Container@GAME_INFO_PANEL:
 			Y: 65
 			Width: PARENT_RIGHT
 		Container@DEBUG_PANEL:
+			Y: 65
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+		Container@CHAT_PANEL:
 			Y: 65
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -140,6 +140,7 @@ ChromeLayout:
 	ts|chrome/ingame-player.yaml
 	common|chrome/ingame-perf.yaml
 	ts|chrome/ingame-debug.yaml
+	common|chrome/ingame-infochat.yaml
 	common|chrome/mainmenu.yaml
 	ts|chrome/mainmenu-prerelease-notification.yaml
 	common|chrome/settings.yaml


### PR DESCRIPTION
On game over this tab is opened by default so when game ends, this tab is activated and players can read and write before leaving. The chat tab is hidden in case there is only one human player.

![obrazok](https://cloud.githubusercontent.com/assets/16348750/26619782/48d0a3d4-45e0-11e7-8a58-745c09200553.png)

Edit: In the chat tab are also replayed older messages for which we don't store time atm so we could show the time only for new messages so I removed the time for now. If agreed, we could extend chat cache to store also time (sent or received?) and then display it here and/or also in game chat.
