### PR TITLE
Fix null reference when fetching Armaments.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -89,6 +89,7 @@ Also thanks to:
     * Lesueur Benjamin (Valkirie)
     * Maarten Meuris (Nyerguds)
     * Mark Olson (markolson)
+    * Markus Hartung (hartmark)
     * Matija Hustic (matija-hustic)
     * Matthew Gatland (mgatland)
     * Matthew Uzzell (MUzzell)

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
@@ -47,9 +47,11 @@ namespace OpenRA.Mods.Cnc.Traits
 			attack.AttackTarget(Target.FromCell(self.World, order.TargetLocation), false, false, true);
 		}
 
-		void INotifyCreated.Created(Actor self)
+		protected override void Created(Actor self)
 		{
 			attack = self.Trait<AttackBase>();
+
+			base.Created(self);
 		}
 
 		void INotifyBurstComplete.FiredBurst(Actor self, Target target, Armament a)

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -60,13 +60,15 @@ namespace OpenRA.Mods.Common.Traits
 			this.self = self;
 		}
 
-		void INotifyCreated.Created(Actor self)
+		protected override void Created(Actor self)
 		{
 			facing = self.TraitOrDefault<IFacing>();
 			building = self.TraitOrDefault<Building>();
 			positionable = self.TraitOrDefault<IPositionable>();
 
 			getArmaments = InitializeGetArmaments(self);
+
+			base.Created(self);
 		}
 
 		protected virtual Func<IEnumerable<Armament>> InitializeGetArmaments(Actor self)

--- a/OpenRA.Mods.Common/Traits/Attack/AttackCharges.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackCharges.cs
@@ -49,9 +49,11 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 		}
 
-		void INotifyCreated.Created(Actor self)
+		protected override void Created(Actor self)
 		{
 			conditionManager = self.TraitOrDefault<ConditionManager>();
+
+			base.Created(self);
 		}
 
 		void ITick.Tick(Actor self)

--- a/OpenRA.Mods.Common/Traits/CashTrickler.cs
+++ b/OpenRA.Mods.Common/Traits/CashTrickler.cs
@@ -45,9 +45,11 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 		}
 
-		void INotifyCreated.Created(Actor self)
+		protected override void Created(Actor self)
 		{
 			resources = self.Owner.PlayerActor.Trait<PlayerResources>();
+
+			base.Created(self);
 		}
 
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 			remainingTime = info.InitialDelay;
 		}
 
-		void INotifyCreated.Created(Actor self)
+		protected override void Created(Actor self)
 		{
 			conditionManager = self.TraitOrDefault<ConditionManager>();
 
@@ -90,6 +90,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (conditionManager != null && cloakedToken == ConditionManager.InvalidConditionToken && !string.IsNullOrEmpty(Info.CloakedCondition))
 					cloakedToken = conditionManager.GrantCondition(self, Info.CloakedCondition);
 			}
+
+			base.Created(self);
 		}
 
 		public bool Cloaked { get { return !IsTraitDisabled && remainingTime <= 0; } }

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -478,9 +478,11 @@ namespace OpenRA.Mods.Common.Traits
 				SetVisualPosition(self, init.Get<CenterPositionInit, WPos>());
 		}
 
-		void INotifyCreated.Created(Actor self)
+		protected override void Created(Actor self)
 		{
 			conditionManager = self.TraitOrDefault<ConditionManager>();
+
+			base.Created(self);
 		}
 
 		// Returns a valid sub-cell

--- a/OpenRA.Mods.Common/Traits/Power/AffectedByPowerOutage.cs
+++ b/OpenRA.Mods.Common/Traits/Power/AffectedByPowerOutage.cs
@@ -40,9 +40,11 @@ namespace OpenRA.Mods.Common.Traits
 		protected override void TraitEnabled(Actor self) { UpdateStatus(self); }
 		protected override void TraitDisabled(Actor self) { Revoke(self); }
 
-		void INotifyCreated.Created(Actor self)
+		protected override void Created(Actor self)
 		{
 			conditionManager = self.TraitOrDefault<ConditionManager>();
+
+			base.Created(self);
 		}
 
 		float ISelectionBar.GetValue()


### PR DESCRIPTION
The game crashes when trying to start in TiberianSun-mod.

After a bit digging it seems that it is because of getArmaments doesn't get set before accessing the property Armaments in the class AttackBase.

I just started hacking in OpenRA, but intuitively the INotifyCreated.Created method should be called quite early before anything else will access the Armaments property.

This is my first pull request in OpenRA