### PR TITLE
TD Balance Changes. 06022017

### DIFF
--- a/mods/cnc/maps/gdi03/rules.yaml
+++ b/mods/cnc/maps/gdi03/rules.yaml
@@ -90,7 +90,9 @@ SAM:
 	Building:
 	Power:
 		Amount: -10
-	-Capturable:
+	-ExternalCapturable:
+		CaptureCompleteTime: 5
+	-ExternalCapturableBar:
 
 HQ:
 	Tooltip:

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -90,8 +90,8 @@ HELI:
 		Ammo: 10
 		PipCount: 5
 		SelfReloads: true
-		ReloadCount: 10
-		SelfReloadDelay: 200
+		ReloadCount: 1
+		SelfReloadDelay: 40
 	WithIdleOverlay@ROTORAIR:
 		Offset: 0,0,85
 		Sequence: rotor

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -615,7 +615,9 @@
 	EngineerRepairable:
 	Sellable:
 		SellSounds: cashturn.aud
-	Capturable:
+	ExternalCapturable:
+		CaptureCompleteTime: 5
+	ExternalCapturableBar:
 	WithMakeAnimation:
 
 ^CivBuilding:
@@ -645,7 +647,9 @@
 
 ^TechBuilding:
 	Inherits: ^CivBuilding
-	Capturable:
+	ExternalCapturable:
+		CaptureCompleteTime: 5
+	ExternalCapturableBar:
 	CaptureNotification:
 		Notification: CivilianBuildingCaptured
 	RepairableBuilding:

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -150,15 +150,19 @@ E6:
 		Queue: Infantry.GDI, Infantry.Nod
 		Description: Damages and captures enemy structures.\n  Unarmed
 	Mobile:
-		Speed: 56
+		Speed: 48
 	Health:
 		HP: 30
 	Passenger:
 		PipType: Yellow
 	EngineerRepair:
 	RepairsBridges:
+	ExternalCaptures:
+		CaptureTypes: building
+		ConsumeActor: True
+		PlayerExperience: 50
 	Captures:
-		CaptureTypes: building, husk
+		CaptureTypes: husk
 		PlayerExperience: 50
 	-AutoTarget:
 

--- a/mods/cnc/rules/misc.yaml
+++ b/mods/cnc/rules/misc.yaml
@@ -17,13 +17,23 @@ CRATE:
 		Weapon: Napalm.Crate
 		SelectionShares: 5
 	GrantExternalConditionCrateAction@cloak:
-		SelectionShares: 5
+		SelectionShares: 3
 		Effect: cloak
 		Condition: cloak-crate-collected
 	GiveMcvCrateAction:
 		SelectionShares: 0
-		NoBaseSelectionShares: 120
+		NoBaseSelectionShares: 50
 		Units: mcv
+	ExplodeCrateAction:
+		Weapon: Atomic
+		SelectionShares: 1
+	GiveUnitCrateAction:
+		Units: vice
+		Owner: Creeps
+		SelectionShares: 10
+	LevelUpCrateAction:
+		Levels: 4
+		SelectionShares: 12
 
 WCRATE:
 	Inherits: ^Crate

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -726,7 +726,7 @@ SAM:
 	WithTurretedSpriteBody:
 	AutoSelectionSize:
 	Armament:
-		Weapon: SAMMissile
+		Weapon: Dragon
 		MuzzleSequence: muzzle
 	AttackPopupTurreted:
 	WithMuzzleOverlay:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -1,7 +1,7 @@
 MCV:
 	Inherits: ^Vehicle
 	Valued:
-		Cost: 4000
+		Cost: 3600
 	Tooltip:
 		Name: Mobile Construction Vehicle
 	Buildable:

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -35,7 +35,7 @@
 Dragon:
 	Inherits: ^MissileWeapon
 	ReloadDelay: 20
-	Range: 12c0
+	Range: 10c0
 	Report: rocket2.aud
 	ValidTargets: Air
 	Burst: 2
@@ -43,7 +43,7 @@ Dragon:
 	Projectile: Missile
 		Speed: 426
 		HorizontalRateOfTurn: 20
-		RangeLimit: 15c0
+		RangeLimit: 12c0
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: Air
 		Versus:
@@ -84,7 +84,7 @@ OrcaAGMissiles:
 		Speed: 256
 		RangeLimit: 6c0
 	Warhead@1Dam: SpreadDamage
-		Damage: 25
+		Damage: 28
 		ValidTargets: Ground
 		Versus:
 			None: 50

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -113,6 +113,17 @@ MachineGun:
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
 
+MachineGunH:
+	Inherits: ^LightMG
+	Burst: 5
+	Report: mgun11.aud
+	Warhead@1Dam: SpreadDamage
+		Versus:
+			Wood: 10
+			Light: 55
+	Warhead@2Eff: CreateEffect
+		Explosions: piffs
+
 APCGun:
 	ReloadDelay: 18
 	Range: 5c0


### PR DESCRIPTION
-Orca damage increased from 25 to 28.

In the current release they lack the damage needed for vs armor and structures. A slight increase helps with this without giving them to much power.

-Apache ammo reload reduced from 200 to 40.

Mainly the problem of camping over a field or area and having instant reloads. Since infantry has recently become more popular in TD this has become an issue. Its also a problem that when the Apache fires a single shot the ticker comes into affect. Often times a full clip reloads before its fire all of its shots.

-Apache ammo reload amount reduced from 10 to 1.

Compensates for the Orca and also gives the Apache a longer burst fire effect.

-Sam now fires two missiles.

Increases Sam damage as they are purely AA only. (Also some CNC95 nostalgia to boot.)

-Sam range increase from 8c0 to 10c0.

Slightly increase to give them some potency in their AA. Being at a range of 8 was fairly small to cover areas such as a tiberium field or the center of the base.

-Sam range limit from 9c614 to 12c0.

Compensation for the longer missile travel before air can escape. (Seperates from shared weapon with AGT)

-Engineer now externally captures. (Except husks)

See notes below.

-Engineer movement speed reduced from 56 to 48.

Engineers moving at the same speed as a minigunner was not only odd but a bit strong in getting to places and making escapes. Slight slightly faster then E3.

-MCV cost reduced from 4000 to 3600.

The price on the MCV here has a slight reduction due to a queueing problem. Currently the start construction of the 4000 amount drains slowly until it reaches about 0:32 and then drains much to quickly making expansions impossible. Reducing this to 3600 makes this more managable while at the sametime prevents them building like candy.

-Humvee damag vs light increased from 50 to 55.

This was increased for two reasons. The first is for bike and buggy spams. The second is the humvee costs 400 compared to the buggy at 300. HP is a nice boost but it didn't compensate well vs bikes as often times players go APC builds with infantry. This gives humvees a bit more strength for their price. (Also seperates shared weapon)

-Crates got some love.

-Cloak chance from 5 to 3.

-MCV no base chance from 120 to 50. (This was super strong as demonstrated by DanRobzProbz)

-Atomic explosion now can occure with a chance of 1. (CNC95)

-Viceroids now appear from crate spawns with a chance of 10. (CNC95)

-Crate veterancy added. Chance of 12 to give max rank veterancy.

The reason for the max veterancy is to give more emphasis on "CRATE!" and rushing to grab it. (Also gives risk vs reward. Do you really want to grab that crate next to your MCV with commando or mammoth tank?)

---------

External capture for engineers is added. Double engineer capture was non existant not because of the bug but because of their cost. netting 1000 just to capture an enemy structure plus the cost for transportation made this suicidal to try. Makes this strategy more optimal and adding a 5 second timer for capture is better then instant capture much like CNC95 had issues with. They still instantly capture husks without external capture.