### PR TITLE
Resource spreading, growing and ramp variants

### DIFF
--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
@@ -20,6 +21,16 @@ namespace OpenRA
 {
 	public class TerrainTileInfo
 	{
+		public enum RampSides : byte
+		{
+			None = 0x0,
+			NW = 0x1,
+			NE = 0x2,
+			SE = 0x3,
+			SW = 0x4,
+			ResourceRamp = 0x4,
+		}
+
 		[FieldLoader.Ignore]
 		public readonly byte TerrainType = byte.MaxValue;
 		public readonly byte Height;

--- a/OpenRA.Game/Traits/World/ResourceType.cs
+++ b/OpenRA.Game/Traits/World/ResourceType.cs
@@ -16,6 +16,8 @@ namespace OpenRA.Traits
 {
 	public class ResourceTypeInfo : ITraitInfo
 	{
+		public enum RampType { NW, NE, SW, SE }
+
 		[Desc("Sequence image that holds the different variants.")]
 		public readonly string Image = "resources";
 
@@ -23,6 +25,9 @@ namespace OpenRA.Traits
 		[SequenceReference("Image")]
 		[Desc("Randomly chosen image sequences.")]
 		public readonly string[] Sequences = { };
+
+		[Desc("Image sequences for ramps")]
+		public readonly Dictionary<RampType, string[]> RampSequences;
 
 		[PaletteReference]
 		[Desc("Palette used for rendering the resource sprites.")]
@@ -64,6 +69,18 @@ namespace OpenRA.Traits
 		[Desc("Harvester content pip color.")]
 		public PipType PipColor = PipType.Yellow;
 
+		[Desc("Resource growth rate (seconds per growth)")]
+		public int GrowthRate = 37;
+
+		[Desc("Resource growth percent (% of max density)")]
+		public float GrowthPercent = 0.09f;
+
+		[Desc("Resource spread rate (seconds per spread)")]
+		public int SpreadRate = 37;
+
+		[Desc("Resource spread percent (% of max density)")]
+		public float SpreadPercent = 0.09f;
+
 		public object Create(ActorInitializer init) { return new ResourceType(this, init.World); }
 	}
 
@@ -72,16 +89,34 @@ namespace OpenRA.Traits
 		public readonly ResourceTypeInfo Info;
 		public PaletteReference Palette { get; private set; }
 		public readonly Dictionary<string, Sprite[]> Variants;
+		public readonly Dictionary<ResourceTypeInfo.RampType, Dictionary<string, Sprite[]>> RampVariants;
 
 		public ResourceType(ResourceTypeInfo info, World world)
 		{
 			Info = info;
 			Variants = new Dictionary<string, Sprite[]>();
+			RampVariants = new Dictionary<ResourceTypeInfo.RampType, Dictionary<string, Sprite[]>>();
 			foreach (var v in info.Sequences)
 			{
 				var seq = world.Map.Rules.Sequences.GetSequence(Info.Image, v);
 				var sprites = Exts.MakeArray(seq.Length, x => seq.GetSprite(x));
 				Variants.Add(v, sprites);
+			}
+
+			if (info.RampSequences != null)
+			{
+				foreach (var rv in info.RampSequences)
+				{
+					var v = new Dictionary<string, Sprite[]>();
+					foreach (var u in rv.Value)
+					{
+						var seq = world.Map.Rules.Sequences.GetSequence(Info.Image, u);
+						var sprites = Exts.MakeArray(seq.Length, x => seq.GetSprite(x));
+						v.Add(u, sprites);
+					}
+
+					RampVariants.Add(rv.Key, v);
+				}
 			}
 		}
 

--- a/OpenRA.Game/Traits/World/ResourceType.cs
+++ b/OpenRA.Game/Traits/World/ResourceType.cs
@@ -69,17 +69,17 @@ namespace OpenRA.Traits
 		[Desc("Harvester content pip color.")]
 		public PipType PipColor = PipType.Yellow;
 
-		[Desc("Resource growth rate (seconds per growth)")]
-		public int GrowthRate = 37;
+		[Desc("Resource growth rate (tics per growth)")]
+		public int GrowthRate = 500;
 
 		[Desc("Resource growth percent (% of max density)")]
-		public float GrowthPercent = 0.09f;
+		public int GrowthPercent = 9;
 
-		[Desc("Resource spread rate (seconds per spread)")]
-		public int SpreadRate = 37;
+		[Desc("Resource spread rate (tics per spread)")]
+		public int SpreadRate = 500;
 
 		[Desc("Resource spread percent (% of max density)")]
-		public float SpreadPercent = 0.09f;
+		public int SpreadPercent = 9;
 
 		public object Create(ActorInitializer init) { return new ResourceType(this, init.World); }
 	}

--- a/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (!ResourceType.AllowedTerrainTypes.Contains(terrainType.Type))
 				return false;
 
-			return ResourceType.AllowOnRamps || tileInfo.RampType == 0;
+			return (ResourceType.AllowOnRamps && (TerrainTileInfo.RampSides)tileInfo.RampType <= TerrainTileInfo.RampSides.ResourceRamp) || tileInfo.RampType == 0;
 		}
 
 		public void Tick()

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -226,14 +226,15 @@ namespace OpenRA.Mods.Common.Traits
 				var type = r.Type;
 				if (type != null)
 				{
-					if (--r.GrowthTics <= 0)
+					if ((r.GrowthTics -= 25) <= 0)
 					{
 						r.GrowthTics = type.Info.GrowthRate;
-						if (!world.ActorMap.AnyActorsAt(cell, SubCell.FullCell, a => a.Info.HasTraitInfo<HarvesterInfo>()))
-							AddResource(type, cell, Math.Max(1, (int)(type.Info.GrowthPercent * r.Density)));
+						if (world.SharedRandom.Next() % 100 <= type.Info.GrowthPercent
+							&& !world.ActorMap.AnyActorsAt(cell, SubCell.FullCell, a => a.Info.HasTraitInfo<HarvesterInfo>()))
+								AddResource(type, cell, 1);
 					}
 
-					if (--r.SpreadTics <= 0)
+					if ((r.SpreadTics -= 25) <= 0)
 					{
 						r.SpreadTics = type.Info.SpreadRate;
 
@@ -241,9 +242,10 @@ namespace OpenRA.Mods.Common.Traits
 							for (var v = -1; v < 2; v++)
 							{
 								var c = cell + new CVec(u, v);
-								if (Content.Contains(c) && CanSpawnResourceAt(type, c)
-									&& (type.Info.MaxDensity == 1 || type.Info.SpreadPercent * r.Density > 1))
-										AddResource(type, c, Math.Max(1, (int)(type.Info.SpreadPercent * r.Density)));
+								if (world.SharedRandom.Next() % 100 <= type.Info.SpreadPercent
+									&& Content.Contains(c) && CanSpawnResourceAt(type, c)
+									&& type.Info.MaxDensity == r.Density)
+										AddResource(type, c, Math.Max(1, type.Info.MaxDensity / 2));
 							}
 					}
 				}

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 		public virtual object Create(ActorInitializer init) { return new ResourceLayer(init.Self); }
 	}
 
-	public class ResourceLayer : IRenderOverlay, IWorldLoaded, ITickRender, INotifyActorDisposing
+	public class ResourceLayer : IRenderOverlay, IWorldLoaded, ITick, ITickRender, INotifyActorDisposing
 	{
 		static readonly CellContents EmptyCell = new CellContents();
 
@@ -36,6 +36,8 @@ namespace OpenRA.Mods.Common.Traits
 		protected readonly CellLayer<CellContents> Content;
 		protected readonly CellLayer<CellContents> RenderContent;
 
+		int ticks;
+
 		public ResourceLayer(Actor self)
 		{
 			world = self.World;
@@ -45,6 +47,8 @@ namespace OpenRA.Mods.Common.Traits
 			RenderContent = new CellLayer<CellContents>(world.Map);
 
 			RenderContent.CellEntryChanged += UpdateSpriteLayers;
+
+			ticks = 0;
 		}
 
 		void UpdateSpriteLayers(CPos cell)
@@ -131,6 +135,8 @@ namespace OpenRA.Mods.Common.Traits
 					var density = int2.Lerp(0, type.Info.MaxDensity, adjacent, 9);
 					var temp = Content[cell];
 					temp.Density = Math.Max(density, 1);
+					temp.GrowthTics = w.SharedRandom.Next() % type.Info.GrowthRate;
+					temp.SpreadTics = w.SharedRandom.Next() % type.Info.SpreadRate;
 
 					// Initialize the RenderContent with the initial map state
 					// because the shroud may not be enabled.
@@ -145,7 +151,20 @@ namespace OpenRA.Mods.Common.Traits
 			var t = RenderContent[cell];
 			if (t.Density > 0)
 			{
-				var sprites = t.Type.Variants[t.Variant];
+				Sprite[] sprites = null;
+				if (t.Type.Variants.ContainsKey(t.Variant))
+					sprites = t.Type.Variants[t.Variant];
+				else
+					foreach (var v in t.Type.RampVariants)
+						if (v.Value.ContainsKey(t.Variant))
+						{
+							sprites = v.Value[t.Variant];
+							break;
+						}
+
+				if (sprites == null)
+					throw new NullReferenceException("Resource sprite variant isn't found: " + t.Variant);
+
 				var frame = int2.Lerp(0, sprites.Length - 1, t.Density, t.Type.Info.MaxDensity);
 				t.Sprite = sprites[frame];
 			}
@@ -155,8 +174,25 @@ namespace OpenRA.Mods.Common.Traits
 			RenderContent[cell] = t;
 		}
 
-		protected virtual string ChooseRandomVariant(ResourceType t)
+		protected virtual string ChooseResourceVariant(ResourceType t, TerrainTileInfo.RampSides rampType = TerrainTileInfo.RampSides.None)
 		{
+			if (t.Info.RampSequences != null && rampType > 0 && rampType <= TerrainTileInfo.RampSides.ResourceRamp)
+			{
+				switch (rampType)
+				{
+					case TerrainTileInfo.RampSides.NW:
+						return t.RampVariants[ResourceTypeInfo.RampType.NW].Keys.Random(Game.CosmeticRandom);
+					case TerrainTileInfo.RampSides.NE:
+						return t.RampVariants[ResourceTypeInfo.RampType.NE].Keys.Random(Game.CosmeticRandom);
+					case TerrainTileInfo.RampSides.SE:
+						return t.RampVariants[ResourceTypeInfo.RampType.SE].Keys.Random(Game.CosmeticRandom);
+					case TerrainTileInfo.RampSides.SW:
+						return t.RampVariants[ResourceTypeInfo.RampType.SW].Keys.Random(Game.CosmeticRandom);
+					default:
+						throw new InvalidDataException("Incorrect ramp variant");
+				}
+			}
+
 			return t.Variants.Keys.Random(Game.CosmeticRandom);
 		}
 
@@ -177,6 +213,43 @@ namespace OpenRA.Mods.Common.Traits
 				dirty.Remove(r);
 		}
 
+		public void Tick(Actor self)
+		{
+			if (--ticks > 0)
+				return;
+			ticks = 25;
+
+			// Resource growth and spreading logic
+			foreach (var cell in world.Map.AllCells)
+			{
+				var r = Content[cell];
+				var type = r.Type;
+				if (type != null)
+				{
+					if (--r.GrowthTics <= 0)
+					{
+						r.GrowthTics = type.Info.GrowthRate;
+						if (!world.ActorMap.AnyActorsAt(cell, SubCell.FullCell, a => a.Info.HasTraitInfo<HarvesterInfo>()))
+							AddResource(type, cell, Math.Max(1, (int)(type.Info.GrowthPercent * r.Density)));
+					}
+
+					if (--r.SpreadTics <= 0)
+					{
+						r.SpreadTics = type.Info.SpreadRate;
+
+						for (var u = -1; u < 2; u++)
+							for (var v = -1; v < 2; v++)
+							{
+								var c = cell + new CVec(u, v);
+								if (Content.Contains(c) && CanSpawnResourceAt(type, c)
+									&& (type.Info.MaxDensity == 1 || type.Info.SpreadPercent * r.Density > 1))
+										AddResource(type, c, Math.Max(1, (int)(type.Info.SpreadPercent * r.Density)));
+							}
+					}
+				}
+			}
+		}
+
 		public bool AllowResourceAt(ResourceType rt, CPos cell)
 		{
 			if (!world.Map.Contains(cell))
@@ -195,7 +268,14 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				var tile = world.Map.Tiles[cell];
 				var tileInfo = world.Map.Rules.TileSet.GetTileInfo(tile);
-				if (tileInfo != null && tileInfo.RampType > 0)
+				if (tileInfo != null && tileInfo.RampType > (byte)TerrainTileInfo.RampSides.None)
+						return false;
+			}
+			else
+			{
+				var tile = world.Map.Tiles[cell];
+				var tileInfo = world.Map.Rules.TileSet.GetTileInfo(tile);
+				if (tileInfo != null && tileInfo.RampType > (byte)TerrainTileInfo.RampSides.ResourceRamp)
 					return false;
 			}
 
@@ -215,11 +295,14 @@ namespace OpenRA.Mods.Common.Traits
 		CellContents CreateResourceCell(ResourceType t, CPos cell)
 		{
 			world.Map.CustomTerrain[cell] = world.Map.Rules.TileSet.GetTerrainIndex(t.Info.TerrainType);
+			var tile = world.Map.Tiles[cell];
+			var tileInfo = world.Map.Rules.TileSet.GetTileInfo(tile);
+			var rampType = tileInfo != null ? tileInfo.RampType : (byte)0;
 
 			return new CellContents
 			{
 				Type = t,
-				Variant = ChooseRandomVariant(t),
+				Variant = ChooseResourceVariant(t, (TerrainTileInfo.RampSides)rampType),
 			};
 		}
 
@@ -233,6 +316,8 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			cell.Density = Math.Min(cell.Type.Info.MaxDensity, cell.Density + n);
+			cell.GrowthTics = world.SharedRandom.Next() % t.Info.GrowthRate;
+			cell.SpreadTics = world.SharedRandom.Next() % t.Info.SpreadRate;
 			Content[p] = cell;
 
 			dirty.Add(p);
@@ -307,6 +392,10 @@ namespace OpenRA.Mods.Common.Traits
 			public int Density;
 			public string Variant;
 			public Sprite Sprite;
+
+			public int GrowthTics;
+			public int SpreadTics;
+			public int Power;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
@@ -92,7 +92,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var cell = worldRenderer.Viewport.ViewToWorld(Viewport.LastMousePos);
 					var map = worldRenderer.World.Map;
 					var height = map.Height.Contains(cell) ? map.Height[cell] : 0;
-					return "{0},{1}".F(cell, height);
+					var rampType = "0";
+
+					if (world.Map.Tiles.Contains(cell))
+					{
+						var tile = world.Map.Tiles[cell];
+						var tileInfo = world.Map.Rules.TileSet.GetTileInfo(tile);
+
+						if (tileInfo != null && tileInfo.RampType > 0)
+							rampType = tileInfo.RampType.ToString();
+					}
+
+					return "{0},{1},{2}".F(cell, height, rampType);
 				};
 			}
 

--- a/OpenRA.Mods.D2k/Traits/World/D2kEditorResourceLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/D2kEditorResourceLayer.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.D2k.Traits
 			return t;
 		}
 
-		protected override string ChooseRandomVariant(ResourceType t)
+		protected override string ChooseResourceVariant(ResourceType t, TerrainTileInfo.RampSides rampType = TerrainTileInfo.RampSides.None)
 		{
 			return D2kResourceLayer.Variants.Keys.Random(Game.CosmeticRandom);
 		}

--- a/OpenRA.Mods.D2k/Traits/World/D2kResourceLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/D2kResourceLayer.cs
@@ -180,7 +180,7 @@ namespace OpenRA.Mods.D2k.Traits
 			UpdateRenderedTileInner(p + new CVec(1, 1));
 		}
 
-		protected override string ChooseRandomVariant(ResourceType t)
+		protected override string ChooseResourceVariant(ResourceType t, TerrainTileInfo.RampSides rampType = TerrainTileInfo.RampSides.None)
 		{
 			return Variants.Keys.Random(Game.CosmeticRandom);
 		}

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -33,10 +33,10 @@
 			NE: tib15, tib16
 			SE: tib17, tib18
 			SW: tib19, tib20
-		GrowthRate: 37
-		GrowthPercent: 0.09
-		SpreadRate: 37
-		SpreadPercent: 0.09
+		GrowthRate: 500
+		GrowthPercent: 9
+		SpreadRate: 500
+		SpreadPercent: 9
 		MaxDensity: 12
 		ValuePerUnit: 25
 		AllowedTerrainTypes: Clear, Rough, DirtRoad
@@ -55,10 +55,10 @@
 			NE: tib15, tib16
 			SE: tib17, tib18
 			SW: tib19, tib20
-		GrowthRate: 166
-		GrowthPercent: 0.05
-		SpreadRate: 166
-		SpreadPercent: 0.05
+		GrowthRate: 2000
+		GrowthPercent: 5
+		SpreadRate: 2000
+		SpreadPercent: 5
 		MaxDensity: 12
 		ValuePerUnit: 40
 		AllowedTerrainTypes: Clear, Rough, DirtRoad

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -28,10 +28,20 @@
 		ResourceType: 1
 		Palette: greentiberium
 		Sequences: tib01, tib02, tib03, tib04, tib05, tib06, tib07, tib08, tib09, tib10, tib11, tib12
+		RampSequences:
+			NW: tib13, tib14
+			NE: tib15, tib16
+			SE: tib17, tib18
+			SW: tib19, tib20
+		GrowthRate: 37
+		GrowthPercent: 0.09
+		SpreadRate: 37
+		SpreadPercent: 0.09
 		MaxDensity: 12
 		ValuePerUnit: 25
 		AllowedTerrainTypes: Clear, Rough, DirtRoad
 		AllowUnderActors: true
+		AllowOnRamps: true
 		TerrainType: Tiberium
 	ResourceType@BlueTiberium:
 		Type: BlueTiberium
@@ -40,10 +50,20 @@
 		ResourceType: 2
 		Palette: bluetiberium
 		Sequences: tib01, tib02, tib03, tib04, tib05, tib06, tib07, tib08, tib09, tib10, tib11, tib12
+		RampSequences:
+			NW: tib13, tib14
+			NE: tib15, tib16
+			SE: tib17, tib18
+			SW: tib19, tib20
+		GrowthRate: 166
+		GrowthPercent: 0.05
+		SpreadRate: 166
+		SpreadPercent: 0.05
 		MaxDensity: 12
 		ValuePerUnit: 40
 		AllowedTerrainTypes: Clear, Rough, DirtRoad
 		AllowUnderActors: true
+		AllowOnRamps: true
 		TerrainType: BlueTiberium
 	ResourceType@Veins:
 		Type: Veins
@@ -52,10 +72,16 @@
 		ResourceType: 3
 		Palette: player
 		Sequences: veins
+		RampSequences:
+			NW: veinsnw1, veinsnw2
+			NE: veinsne1, veinsne2
+			SE: veinsse1, veinsse2
+			SW: veinssw1, veinssw2
 		MaxDensity: 1
 		ValuePerUnit: 0
 		AllowedTerrainTypes: Clear, Rough, DirtRoad
 		AllowUnderActors: true
+		AllowOnRamps: true
 		TerrainType: Veins
 	TerrainGeometryOverlay:
 	ExitsDebugOverlayManager:

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -343,18 +343,66 @@ resources:
 	tib10: tib10
 	tib11: tib11
 	tib12: tib12
-	tib13: tib13 # TODO: NW ramp variant, currently unused
-	tib14: tib14 # TODO: NW ramp variant, currently unused
-	tib15: tib15 # TODO: NE ramp variant, currently unused
-	tib16: tib16 # TODO: NE ramp variant, currently unused
-	tib17: tib17 # TODO: SE ramp variant, currently unused
-	tib18: tib18 # TODO: SE ramp variant, currently unused
-	tib19: tib19 # TODO: SW ramp variant, currently unused
-	tib20: tib20 # TODO: SW ramp variant, currently unused
+	tib13: tib13
+	tib14: tib14
+	tib15: tib15
+	tib16: tib16
+	tib17: tib17
+	tib18: tib18
+	tib19: tib19
+	tib20: tib20
 	veins: veins
 		Length: 1
 		Start: 52
-		ShadowStart: -1
+		ShadowStart: 112
+		Tick: 180
+		Offset: 0, -12, 2.5
+	veinsnw1: veins
+		Length: 1
+		Start: 53
+		ShadowStart: 113
+		Tick: 180
+		Offset: 0, -12, 2.5
+	veinsnw2: veins
+		Length: 1
+		Start: 54
+		ShadowStart: 114
+		Tick: 180
+		Offset: 0, -12, 2.5
+	veinsne1: veins
+		Length: 1
+		Start: 55
+		ShadowStart: 115
+		Tick: 180
+		Offset: 0, -12, 2.5
+	veinsne2: veins
+		Length: 1
+		Start: 56
+		ShadowStart: 116
+		Tick: 180
+		Offset: 0, -12, 2.5
+	veinsse1: veins
+		Length: 1
+		Start: 57
+		ShadowStart: 117
+		Tick: 180
+		Offset: 0, -12, 2.5
+	veinsse2: veins
+		Length: 1
+		Start: 58
+		ShadowStart: 118
+		Tick: 180
+		Offset: 0, -12, 2.5
+	veinssw1: veins
+		Length: 1
+		Start: 59
+		ShadowStart: 119
+		Tick: 180
+		Offset: 0, -12, 2.5
+	veinssw2: veins
+		Length: 1
+		Start: 60
+		ShadowStart: 120
 		Tick: 180
 		Offset: 0, -12, 2.5
 


### PR DESCRIPTION
Again, what the title says. I've added resource spreading and growth (still doesn't work with veins, but it will be soon) and added support for ramp sprites of resources.
To add a ramp sprites a new ResourceType.RampSequences YAML field was added. It allows to add any NW, NE, SE and SW ramp resource sprite variants.
