### PR TITLE
Add a VERSION file to simplify engine version checks for mods.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,6 +344,7 @@ install-core:
 
 	@$(INSTALL_DATA) "global mix database.dat" "$(DATA_INSTALL_DIR)/global mix database.dat"
 	@$(INSTALL_DATA) "GeoLite2-Country.mmdb.gz" "$(DATA_INSTALL_DIR)/GeoLite2-Country.mmdb.gz"
+	@$(INSTALL_DATA) VERSION "$(DATA_INSTALL_DIR)/VERSION"
 	@$(INSTALL_DATA) AUTHORS "$(DATA_INSTALL_DIR)/AUTHORS"
 	@$(INSTALL_DATA) COPYING "$(DATA_INSTALL_DIR)/COPYING"
 

--- a/Makefile
+++ b/Makefile
@@ -313,7 +313,8 @@ dependencies: $(os-dependencies)
 
 all-dependencies: cli-dependencies windows-dependencies osx-dependencies geoip-dependencies
 
-version: mods/ra/mod.yaml mods/cnc/mod.yaml mods/d2k/mod.yaml mods/ts/mod.yaml mods/modcontent/mod.yaml mods/all/mod.yaml
+version: VERSION mods/ra/mod.yaml mods/cnc/mod.yaml mods/d2k/mod.yaml mods/ts/mod.yaml mods/modcontent/mod.yaml mods/all/mod.yaml
+	@echo "$(VERSION)" > VERSION
 	@for i in $? ; do \
 		awk '{sub("Version:.*$$","Version: $(VERSION)"); print $0}' $${i} > $${i}.tmp && \
 		awk '{sub("/[^/]*: User$$", "/$(VERSION): User"); print $0}' $${i}.tmp > $${i} && \

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -57,6 +57,8 @@ namespace OpenRA
 
 		public static GlobalChat GlobalChat;
 
+		public static string EngineVersion { get; private set; }
+
 		static Task discoverNat;
 
 		public static OrderManager JoinServer(string host, int port, string password, bool recordReplay = true)
@@ -245,6 +247,18 @@ namespace OpenRA
 		internal static void Initialize(Arguments args)
 		{
 			Console.WriteLine("Platform is {0}", Platform.CurrentPlatform);
+
+			// Load the engine version as early as possible so it can be written to exception logs
+			try
+			{
+				EngineVersion = File.ReadAllText(Platform.ResolvePath(Path.Combine(".", "VERSION"))).Trim();
+			}
+			catch { }
+
+			if (string.IsNullOrEmpty(EngineVersion))
+				EngineVersion = "Unknown";
+
+			Console.WriteLine("Engine version is {0}", EngineVersion);
 
 			// Special case handling of Game.Mod argument: if it matches a real filesystem path
 			// then we use this to override the mod search path, and replace it with the mod id

--- a/OpenRA.Game/Support/Program.cs
+++ b/OpenRA.Game/Support/Program.cs
@@ -51,10 +51,13 @@ namespace OpenRA
 			var exceptionName = "exception-" + DateTime.UtcNow.ToString("yyyy-MM-ddTHHmmssZ", CultureInfo.InvariantCulture) + ".log";
 			Log.AddChannel("exception", exceptionName);
 
+			if (Game.EngineVersion != null)
+				Log.Write("exception", "OpenRA engine version {0}", Game.EngineVersion);
+
 			if (Game.ModData != null)
 			{
 				var mod = Game.ModData.Manifest.Metadata;
-				Log.Write("exception", "{0} Mod at Version {1}", mod.Title, mod.Version);
+				Log.Write("exception", "{0} mod version {1}", mod.Title, mod.Version);
 			}
 
 			if (Game.OrderManager != null && Game.OrderManager.World != null && Game.OrderManager.World.Map != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -287,7 +287,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						// Send the mod and engine version to support version-filtered news (update prompts)
 						newsURL += "?version={0}&mod={1}&modversion={2}".F(
-							Uri.EscapeUriString(Game.Mods["modcontent"].Metadata.Version),
+							Uri.EscapeUriString(Game.EngineVersion),
 							Uri.EscapeUriString(Game.ModData.Manifest.Id),
 							Uri.EscapeUriString(Game.ModData.Manifest.Metadata.Version));
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -93,7 +93,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				// so we can't do this inside the input handler.
 				Game.RunAfterTick(() =>
 				{
-					Game.InitializeMod("modcontent", new Arguments(new[] { "Content.Mod=" + modData.Manifest.Id }));
+					var content = modData.Manifest.Get<ModContent>();
+					Game.InitializeMod(content.ContentInstallerMod, new Arguments(new[] { "Content.Mod=" + modData.Manifest.Id }));
 				});
 			};
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
@@ -362,7 +362,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			var queryURL = services.ServerList + "games?version={0}&mod={1}&modversion={2}".F(
-				Uri.EscapeUriString(Game.Mods["modcontent"].Metadata.Version),
+				Uri.EscapeUriString(Game.EngineVersion),
 				Uri.EscapeUriString(Game.ModData.Manifest.Id),
 				Uri.EscapeUriString(Game.ModData.Manifest.Metadata.Version));
 

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,1 @@
+{DEV_VERSION}

--- a/make.ps1
+++ b/make.ps1
@@ -74,6 +74,7 @@ function Version-Command
 	
 	if ($version -ne $null)
 	{
+		$version | out-file ".\VERSION"
 		$mods = @("mods/ra/mod.yaml", "mods/cnc/mod.yaml", "mods/d2k/mod.yaml", "mods/ts/mod.yaml", "mods/modcontent/mod.yaml", "mods/all/mod.yaml")
 		foreach ($mod in $mods)
 		{

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -105,6 +105,7 @@ Section "Game" GAME
 	File "${SRCDIR}\ICSharpCode.SharpZipLib.dll"
 	File "${SRCDIR}\FuzzyLogicLibrary.dll"
 	File "${SRCDIR}\Open.Nat.dll"
+	File "${SRCDIR}\VERSION"
 	File "${SRCDIR}\AUTHORS"
 	File "${SRCDIR}\COPYING"
 	File "${SRCDIR}\README.html"
@@ -215,6 +216,7 @@ Function ${UN}Clean
 	Delete $INSTDIR\FuzzyLogicLibrary.dll
 	Delete $INSTDIR\Open.Nat.dll
 	Delete $INSTDIR\SharpFont.dll
+	Delete $INSTDIR\VERSION
 	Delete $INSTDIR\AUTHORS
 	Delete $INSTDIR\COPYING
 	Delete $INSTDIR\README.html


### PR DESCRIPTION
Dropping support for the `RequiresMod` metadata had an unfortunate side effect of removing the only simple way we had for mods to check/force a specific engine version.  

According to @jrb0001 players with the wrong engine version desyncing games is an ongoing problem for the Crystallized Doom mod, and I need a simple way to query the engine version for the mod template.

This PR introduces a VERSION file in the source/install root that external scripts can read to get the current engine version.  This is also used ingame instead of relying on the `modcontent` mod so that third party mods are no longer forced to ship that if they don't need it.