### PR TITLE
Improve CreateEffectWarhead support for alpha/reflection/shadow

### DIFF
--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -31,6 +31,9 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("Remap explosion effect to player color, if art supports it.")]
 		public readonly bool UsePlayerPalette = false;
 
+		[Desc("Display explosion effect at ground level, regardless of explosion altitude.")]
+		public readonly bool ForceDisplayAtGroundLevel = false;
+
 		[Desc("List of sounds that can be played on impact.")]
 		public readonly string[] ImpactSounds = new string[0];
 
@@ -119,7 +122,15 @@ namespace OpenRA.Mods.Common.Warheads
 
 			var explosion = Explosions.RandomOrDefault(Game.CosmeticRandom);
 			if (Image != null && explosion != null)
+			{
+				if (ForceDisplayAtGroundLevel)
+				{
+					var dat = world.Map.DistanceAboveTerrain(pos);
+					pos = new WPos(pos.X, pos.Y, pos.Z - dat.Length);
+				}
+
 				world.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, w, Image, explosion, palette)));
+			}
 
 			var impactSound = ImpactSounds.RandomOrDefault(Game.CosmeticRandom);
 			if (impactSound != null)

--- a/mods/ts/weapons/ballisticweapons.yaml
+++ b/mods/ts/weapons/ballisticweapons.yaml
@@ -149,5 +149,5 @@ Grenade:
 			Concrete: 28
 		DamageTypes: Prone70Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
-		Explosions: large_grey_explosion
+		Explosions: small_grey_explosion
 		ImpactSounds: expnew13.aud

--- a/mods/ts/weapons/explosions.yaml
+++ b/mods/ts/weapons/explosions.yaml
@@ -42,6 +42,7 @@ CyborgExplode:
 	Warhead@1Eff: CreateEffect
 		Explosions: medium_bang
 		ImpactSounds: expnew10.aud
+		ExplosionPalette: effect-ignore-lighting-alpha75
 
 TiberiumExplosion:
 	Inherits: ^DamagingExplosion
@@ -54,6 +55,7 @@ TiberiumExplosion:
 		Size: 1,1
 	Warhead@2Eff: CreateEffect
 		Explosions: large_explosion
+		ExplosionPalette: effect-ignore-lighting-alpha75
 	-Warhead@4Smu: LeaveSmudge
 
 Demolish:


### PR DESCRIPTION
Adds `ForceDisplayAtGroundLevel` aiming at making it easier for modders to add alpha glow effects, water reflections, shadows etc. to explosions.

Not really applicable to TS yet due to #13430, unfortunately.