### PR TITLE
Fix Sound memory leak, remove Music caching

### DIFF
--- a/OpenRA.Game/Sound/SoundDevice.cs
+++ b/OpenRA.Game/Sound/SoundDevice.cs
@@ -25,6 +25,8 @@ namespace OpenRA
 		void StopAllSounds();
 		void SetListenerPosition(WPos position);
 		void SetSoundVolume(float volume, ISound music, ISound video);
+		void ReleaseSourcePool();
+		void ReleaseSound(ISound sound);
 	}
 
 	public class SoundDevice
@@ -39,7 +41,7 @@ namespace OpenRA
 		}
 	}
 
-	public interface ISoundSource { }
+	public interface ISoundSource : IDisposable { }
 
 	public interface ISound
 	{


### PR DESCRIPTION
1. Fix Sound memory leak causing OutOfMemoryException and high RAM usage on each match start
2. Remove Music caching to avoid unnecessary high RAM usage

Example: 3 times match restart in RA, skipping several music tracks on each start - 327 MB vs 1074 MB:

![obrazok](https://cloud.githubusercontent.com/assets/16348750/26796009/160dcfca-4a28-11e7-9a44-8ae6e52c3244.png)
