### PR TITLE
Fix a crash in CheckSequences when the sprite image is null

### DIFF
--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -82,7 +82,13 @@ namespace OpenRA.Mods.Common.Lint
 										{
 											foreach (var imageOverride in LintExts.GetFieldValues(traitInfo, imageField, emitError))
 											{
-												if (!string.IsNullOrEmpty(imageOverride) && sequenceDefinitions.All(s => s.Key != imageOverride.ToLowerInvariant()))
+												if (string.IsNullOrEmpty(imageOverride))
+												{
+													emitWarning("Custom sprite image of actor {0} is null.".F(actorInfo.Value.Name));
+													continue;
+												}
+
+												if (sequenceDefinitions.All(s => s.Key != imageOverride.ToLowerInvariant()))
 													emitError("Custom sprite image {0} from actor {1} has no sequence definition.".F(imageOverride, actorInfo.Value.Name));
 												else
 													CheckDefintions(imageOverride, sequenceReference, actorInfo, sequence, faction, field, traitInfo);

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -91,7 +91,7 @@ namespace OpenRA.Mods.Common.Lint
 												if (sequenceDefinitions.All(s => s.Key != imageOverride.ToLowerInvariant()))
 													emitError("Custom sprite image {0} from actor {1} has no sequence definition.".F(imageOverride, actorInfo.Value.Name));
 												else
-													CheckDefintions(imageOverride, sequenceReference, actorInfo, sequence, faction, field, traitInfo);
+													CheckDefinitions(imageOverride, sequenceReference, actorInfo, sequence, faction, field, traitInfo);
 											}
 										}
 									}
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Lint
 										foreach (var sequenceProvider in sequenceProviders)
 										{
 											var image = renderInfo.GetImage(actorInfo.Value, sequenceProvider, faction);
-											CheckDefintions(image, sequenceReference, actorInfo, sequence, faction, field, traitInfo);
+											CheckDefinitions(image, sequenceReference, actorInfo, sequence, faction, field, traitInfo);
 										}
 									}
 								}
@@ -153,7 +153,7 @@ namespace OpenRA.Mods.Common.Lint
 			}
 		}
 
-		void CheckDefintions(string image, SequenceReferenceAttribute sequenceReference,
+		void CheckDefinitions(string image, SequenceReferenceAttribute sequenceReference,
 			KeyValuePair<string, ActorInfo> actorInfo, string sequence, string faction, FieldInfo field, ITraitInfo traitInfo)
 		{
 			var definitions = sequenceDefinitions.FirstOrDefault(n => n.Key == image.ToLowerInvariant());


### PR DESCRIPTION
`CheckDefintions` will crash when `imageOverride` is `null` anyway.