### PR TITLE
Added Polygon IHitShape

### DIFF
--- a/OpenRA.Mods.Common/HitShapes/Polygon.cs
+++ b/OpenRA.Mods.Common/HitShapes/Polygon.cs
@@ -1,0 +1,125 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Graphics;
+
+namespace OpenRA.Mods.Common.HitShapes
+{
+	public class PolygonShape : IHitShape
+	{
+		public WDist OuterRadius { get; private set; }
+
+		[FieldLoader.Require]
+		public readonly int2[] Points;
+
+		[Desc("Defines the top offset relative to the actor's target point.")]
+		public readonly int VerticalTopOffset = 0;
+
+		[Desc("Defines the bottom offset relative to the actor's target point.")]
+		public readonly int VerticalBottomOffset = 0;
+
+		[Desc("Rotates shape by an angle relative to actor facing. Mostly required for buildings on isometric terrain.",
+			"Mobile actors do NOT need this!")]
+		public readonly WAngle LocalYaw = WAngle.Zero;
+
+		WVec[] combatOverlayVertsTop;
+		WVec[] combatOverlayVertsBottom;
+		int[] squares;
+
+		public PolygonShape() { }
+
+		public PolygonShape(int2[] points) { Points = points; }
+
+		public void Initialize()
+		{
+			if (VerticalTopOffset < VerticalBottomOffset)
+				throw new YamlException("VerticalTopOffset must be equal to or higher than VerticalBottomOffset.");
+
+			OuterRadius = new WDist(Points.Select(x => x.Length).Max());
+			combatOverlayVertsTop = Points.Select(p => new WVec(p.X, p.Y, VerticalTopOffset)).ToArray();
+			combatOverlayVertsBottom = Points.Select(p => new WVec(p.X, p.Y, VerticalBottomOffset)).ToArray();
+			squares = new int[Points.Length];
+			squares[0] = (Points[0] - Points[Points.Length - 1]).LengthSquared;
+			for (var i = 1; i < Points.Length; i++)
+				squares[i] = (Points[i] - Points[i - 1]).LengthSquared;
+		}
+
+		static int DistanceSquaredFromLineSegment(int2 c, int2 a, int2 b, int ab2)
+		{
+			var ac = c - a;
+			int ac2 = ac.LengthSquared;
+			int bc2 = (c - b).LengthSquared;
+
+			// c is closest to point a
+			if (ac2 + ab2 <= bc2)
+				return ac2;
+
+			// c is closest to point b
+			if (bc2 + ab2 <= ac2)
+				return bc2;
+
+			// c is closest to its unknown orthogonal projection (p) onto the line spanned by b with a as the origin
+			var ab = b - a;
+			var ap2 = ac.X * ab.X + ac.Y * ab.Y;
+			var ap = new int2(ab.X * ap2 / ab2, ab.Y * ap2 / ab2);
+			return (ac - ap).LengthSquared; // Length of vector pc squared.
+		}
+
+		public WDist DistanceFromEdge(WVec v)
+		{
+			var p = new int2(v.X, v.Y);
+			var z = Math.Abs(v.Z);
+			if (Points.PolygonContains(p))
+				return new WDist(z);
+
+			var min2 = DistanceSquaredFromLineSegment(p, Points[Points.Length - 1], Points[0], squares[0]);
+			for (var i = 1; i < Points.Length; i++)
+			{
+				var d2 = DistanceSquaredFromLineSegment(p, Points[i - 1], Points[i], squares[i]);
+				if (d2 < min2)
+					min2 = d2;
+			}
+
+			return new WDist(Exts.ISqrt(min2 + z * z));
+		}
+
+		public WDist DistanceFromEdge(WPos pos, Actor actor)
+		{
+			var actorPos = actor.CenterPosition;
+			var orientation = actor.Orientation + WRot.FromYaw(LocalYaw);
+
+			if (pos.Z > actorPos.Z + VerticalTopOffset)
+				return DistanceFromEdge((pos - (actorPos + new WVec(0, 0, VerticalTopOffset))).Rotate(-orientation));
+
+			if (pos.Z < actorPos.Z + VerticalBottomOffset)
+				return DistanceFromEdge((pos - (actorPos + new WVec(0, 0, VerticalBottomOffset))).Rotate(-orientation));
+
+			return DistanceFromEdge((pos - new WPos(actorPos.X, actorPos.Y, pos.Z)).Rotate(-orientation));
+		}
+
+		public void DrawCombatOverlay(WorldRenderer wr, RgbaColorRenderer wcr, Actor actor)
+		{
+			var actorPos = actor.CenterPosition;
+			var orientation = actor.Orientation + WRot.FromYaw(LocalYaw);
+
+			var vertsTop = combatOverlayVertsTop.Select(v => wr.Screen3DPosition(actorPos + v.Rotate(orientation)));
+			var vertsBottom = combatOverlayVertsBottom.Select(v => wr.Screen3DPosition(actorPos + v.Rotate(orientation)));
+			wcr.DrawPolygon(vertsTop.ToArray(), 1, Color.Yellow);
+			wcr.DrawPolygon(vertsBottom.ToArray(), 1, Color.Yellow);
+
+			RangeCircleRenderable.DrawRangeCircle(wr, actorPos, OuterRadius, 1, Color.LimeGreen, 0, Color.LimeGreen);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -170,6 +170,7 @@
     <Compile Include="HitShapes\Rectangle.cs" />
     <Compile Include="HitShapes\Capsule.cs" />
     <Compile Include="HitShapes\Circle.cs" />
+    <Compile Include="HitShapes\Polygon.cs" />
     <Compile Include="Lint\CheckBuildingFootprint.cs" />
     <Compile Include="Lint\CheckAngle.cs" />
     <Compile Include="Lint\CheckSequences.cs" />

--- a/OpenRA.Test/OpenRA.Mods.Common/ShapeTest.cs
+++ b/OpenRA.Test/OpenRA.Mods.Common/ShapeTest.cs
@@ -92,5 +92,155 @@ namespace OpenRA.Test
 			Assert.That(shape.DistanceFromEdge(new WVec(-1000, -400, 0)).Length,
 				Is.EqualTo(877));
 		}
+
+		[TestCase(TestName = "PolygonShape report accurate distance")]
+		public void Polygon()
+		{
+			// Rectangle like above,
+			// Note: The calculations don't match for all, but do have a tolerance of 1.
+			shape = new PolygonShape(new int2[] { new int2(-123, -456), new int2(100, -456), new int2(100, 100), new int2(-123, 100) });
+			shape.Initialize();
+
+			Assert.That(shape.DistanceFromEdge(new WVec(10, 10, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-100, 50, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(0, 200, 0)).Length,
+				Is.EqualTo(100));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(123, 0, 0)).Length,
+				Is.EqualTo(23));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-100, -400, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-1000, -400, 0)).Length,
+				Is.EqualTo(877));
+
+			// Rectangle like above but reverse order
+			// Note: The calculations don't match for all, but do have a tolerance of 1.
+			shape = new PolygonShape(new int2[] { new int2(-123, 100), new int2(100, 100), new int2(100, -456), new int2(-123, -456) });
+			shape.Initialize();
+
+			Assert.That(shape.DistanceFromEdge(new WVec(10, 10, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-100, 50, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(0, 200, 0)).Length,
+				Is.EqualTo(100));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(123, 0, 0)).Length,
+				Is.EqualTo(23));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-100, -400, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-1000, -400, 0)).Length,
+				Is.EqualTo(877));
+
+			// Right triangle taken from above by removing a point
+			shape = new PolygonShape(new int2[] { new int2(-123, -456), new int2(100, -456), new int2(100, 100) });
+			shape.Initialize();
+
+			Assert.That(shape.DistanceFromEdge(new WVec(10, 10, 0)).Length,
+				Is.EqualTo(50));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(99, 10, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(100, 10, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-100, 50, 0)).Length,
+				Is.EqualTo(167));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(0, 200, 0)).Length,
+				Is.EqualTo(141));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(123, 0, 0)).Length,
+				Is.EqualTo(23));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-100, -400, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-1000, -400, 0)).Length,
+				Is.EqualTo(878));
+
+			// Right triangle taken from above but reverse order
+			shape = new PolygonShape(new int2[] { new int2(100, 100), new int2(100, -456), new int2(-123, -456) });
+			shape.Initialize();
+
+			Assert.That(shape.DistanceFromEdge(new WVec(10, 10, 0)).Length,
+				Is.EqualTo(49)); // Differs from above by integer rounding.
+
+			Assert.That(shape.DistanceFromEdge(new WVec(99, 10, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(100, 10, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-100, 50, 0)).Length,
+				Is.EqualTo(167));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(0, 200, 0)).Length,
+				Is.EqualTo(141));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(123, 0, 0)).Length,
+				Is.EqualTo(23));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-100, -400, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-1000, -400, 0)).Length,
+				Is.EqualTo(878));
+
+			// Plus shaped dodecagon
+			shape = new PolygonShape(new int2[] {
+				new int2(-511, -1535), new int2(511, -1535), new int2(511, -511), new int2(1535, -511),
+				new int2(1535, 511), new int2(511, 511), new int2(511, 1535), new int2(-511, 1535),
+				new int2(-511, 511), new int2(-1535, 511), new int2(-1535, -511), new int2(-511, -511)
+			});
+			shape.Initialize();
+
+			Assert.That(shape.DistanceFromEdge(new WVec(10, 10, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-511, -1535, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-512, -1536, 0)).Length,
+				Is.EqualTo(1));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(0, -1535, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(0, 1535, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-1535, 0, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(1535, 0, 0)).Length,
+				Is.EqualTo(0));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-1535, -1535, 0)).Length,
+				Is.EqualTo(1024));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(1535, -1535, 0)).Length,
+				Is.EqualTo(1024));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-1535, 1535, 0)).Length,
+				Is.EqualTo(1024));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(1535, 1535, 0)).Length,
+				Is.EqualTo(1024));
+
+			Assert.That(shape.DistanceFromEdge(new WVec(-500, -1635, 0)).Length,
+				Is.EqualTo(100));
+		}
 	}
 }


### PR DESCRIPTION
Finally created the polygon hit shape. Right now it checks a point against every line segment (edge); I may look into improvements for convex polygons but testing should provided whether or not it would be needed or even very useful.

I didn't actually make use of the new hit-shape in any of the mods.

Closes #11362.