### PR TITLE
WithInfantryBody now supports playing "make" animation

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -443,4 +443,15 @@ namespace OpenRA.Traits
 			return playerName + " " + BoolValues[newValue] + " " + Name + ".";
 		}
 	}
+
+	public interface IPlayCustomAnimation
+	{
+		void PlayCustomAnimation(Actor self, string name, Action after = null);
+		void PlayCustomAnimationRepeating(Actor self, string name);
+		void PlayCustomAnimationBackwards(Actor self, string name, Action after = null);
+		void PlayFetchIndex(Actor self, string name, Func<int> func);
+		void CancelCustomAnimation(Actor self);
+		string BodyName { get; }
+		bool IsAnimDisabled { get; }
+	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -112,6 +112,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public void Attacking(Actor self, Target target, Armament a)
 		{
+			// Custom animations such as Deploy is never to be canceled
+			// otherwise the unit will get stuck in "deploying" state limbo and will never deploy/undeploy again.
+			if (state == AnimationState.PlayingCustomAnimation)
+				return;
+
 			string sequence;
 			if (!Info.AttackSequences.TryGetValue(a.Info.Name, out sequence))
 				sequence = Info.DefaultAttackSequence;

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -46,9 +46,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	public class WithSpriteBody : ConditionalTrait<WithSpriteBodyInfo>, INotifyDamageStateChanged, INotifyBuildComplete
+	public class WithSpriteBody : ConditionalTrait<WithSpriteBodyInfo>, INotifyDamageStateChanged, INotifyBuildComplete, IPlayCustomAnimation
 	{
 		public readonly Animation DefaultAnimation;
+
+		public string BodyName { get { return Info.Name; } }
+
+		public bool IsAnimDisabled { get { return IsTraitDisabled; } }
 
 		public WithSpriteBody(ActorInitializer init, WithSpriteBodyInfo info)
 			: this(init, info, () => 0) { }
@@ -129,6 +133,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
 		{
 			DamageStateChanged(self);
+		}
+
+		public void PlayFetchIndex(Actor self, string name, Func<int> func)
+		{
+			DefaultAnimation.PlayFetchIndex(name, func);
 		}
 	}
 }

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -98,6 +98,7 @@ thumper:
 	Mobile:
 		Speed: 43
 		RequiresCondition: !deployed
+	WithMakeAnimation:
 	GrantConditionOnDeploy:
 		DeployedCondition: deployed
 		Facing: 128

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -97,10 +97,11 @@ thumper:
 		Range: 2c768
 	Mobile:
 		Speed: 43
-		RequiresCondition: !deployed
+		RequiresCondition: undeployed
 	WithMakeAnimation:
 	GrantConditionOnDeploy:
 		DeployedCondition: deployed
+		UndeployedCondition: undeployed
 		Facing: 128
 		AllowedTerrainTypes: Sand, Spice, Dune, SpiceSand
 	WithInfantryBody:

--- a/mods/d2k/sequences/infantry.yaml
+++ b/mods/d2k/sequences/infantry.yaml
@@ -228,6 +228,9 @@ thumper:
 		Facings: -8
 		Transpose: true
 		Tick: 120
+	make: DATA.R8
+		Start: 1458
+		Length: 5
 	thump: DATA.R8
 		Start: 1458
 		Length: 5


### PR DESCRIPTION
Much needed animated infantries with RA2 in mind. (and currently affects D2K thumper)

Since WithSpriteBody and WithInfantryBody have quite a different animation management, it seems suitable to introduce an IPlayCustomAnimation interface for those that provide custom animation logics. Sounds sensible, it has potential to support animated voxel deployer.

To test this, run D2K mod then deploy a thumper. Unfortunately, thumper deploy animation (make sequence in thumper entry) is only 5 frames long and is too short to see. Extend its length for testing purpose if needed. Currently, thumper can move while the lengthy deploy/undeploy animation is playing. That is probably due to GrantConditionOnDeploy not taking away mobility while the animation is playing. (or is it the YAML not using Undeployed for the mobile condition?)

Demo: https://www.youtube.com/watch?v=o4jyIDtD72s

Fixes #12632