### PR TITLE
Allow actors to target CenterPosition

### DIFF
--- a/OpenRA.Mods.Cnc/Projectiles/TeslaZap.cs
+++ b/OpenRA.Mods.Cnc/Projectiles/TeslaZap.cs
@@ -36,6 +36,9 @@ namespace OpenRA.Mods.Cnc.Projectiles
 
 		public readonly bool TrackTarget = true;
 
+		[Desc("Ignore any other targetable positions and aim directly at center of target actor.")]
+		public readonly bool TargetCenterPosition = false;
+
 		public IProjectile Create(ProjectileArgs args) { return new TeslaZap(this, args); }
 	}
 
@@ -64,7 +67,7 @@ namespace OpenRA.Mods.Cnc.Projectiles
 
 			// Zap tracks target
 			if (info.TrackTarget && args.GuidedTarget.IsValidFor(args.SourceActor))
-				target = args.GuidedTarget.Positions.PositionClosestTo(args.Source);
+				target = info.TargetCenterPosition ? args.GuidedTarget.CenterPosition : args.GuidedTarget.Positions.PositionClosestTo(args.Source);
 
 			if (damageDuration-- > 0)
 				args.Weapon.Impact(Target.FromPos(target), args.SourceActor, args.DamageModifiers);

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 			}
 
-			var targetedPosition = Target.Positions.PositionClosestTo(pos);
+			var targetedPosition = attack.Info.AttackTargetCenter ? Target.CenterPosition : Target.Positions.PositionClosestTo(pos);
 			var desiredFacing = (targetedPosition - pos).Yaw.Facing;
 			if (facing.Facing != desiredFacing)
 			{

--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -57,6 +57,9 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Does the beam follow the target.")]
 		public readonly bool TrackTarget = false;
 
+		[Desc("Ignore any other targetable positions and aim directly at center of target actor.")]
+		public readonly bool TargetCenterPosition = false;
+
 		[Desc("Should the beam be visually rendered? False = Beam is invisible.")]
 		public readonly bool RenderBeam = true;
 
@@ -157,7 +160,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			if (args.GuidedTarget.IsValidFor(args.SourceActor))
 			{
-				var guidedTargetPos = args.GuidedTarget.Positions.PositionClosestTo(args.Source);
+				var guidedTargetPos = info.TargetCenterPosition ? args.GuidedTarget.CenterPosition : args.GuidedTarget.Positions.PositionClosestTo(args.Source);
 				var targetDistance = new WDist((guidedTargetPos - args.Source).Length);
 
 				// Only continue tracking target if it's within weapon range +

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -49,6 +49,9 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Beam can be blocked.")]
 		public readonly bool Blockable = false;
 
+		[Desc("Ignore any other targetable positions and aim directly at center of target actor.")]
+		public readonly bool TargetCenterPosition = false;
+
 		[Desc("Draw a second beam (for 'glow' effect).")]
 		public readonly bool SecondaryBeam = false;
 
@@ -128,7 +131,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		{
 			// Beam tracks target
 			if (info.TrackTarget && args.GuidedTarget.IsValidFor(args.SourceActor))
-				target = args.GuidedTarget.Positions.PositionClosestTo(source);
+				target = info.TargetCenterPosition ? args.GuidedTarget.CenterPosition : args.GuidedTarget.Positions.PositionClosestTo(source);
 
 			// Check for blocking actors
 			WPos blockedPos;

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -137,6 +137,9 @@ namespace OpenRA.Mods.Common.Projectiles
 			"the missile enters the radius of the current speed around the target.")]
 		public readonly bool AllowSnapping = false;
 
+		[Desc("Ignore any other targetable positions and aim directly at center of target actor.")]
+		public readonly bool TargetCenterPosition = false;
+
 		[Desc("Explodes when inside this proximity radius to target.",
 			"Note: If this value is lower than the missile speed, this check might",
 			"not trigger fast enough, causing the missile to fly past the target.")]
@@ -799,7 +802,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			// Check if target position should be updated (actor visible & locked on)
 			var newTarPos = targetPosition;
 			if (args.GuidedTarget.IsValidFor(args.SourceActor) && lockOn)
-				newTarPos = args.GuidedTarget.Positions.PositionClosestTo(args.Source)
+				newTarPos = (info.TargetCenterPosition ? args.GuidedTarget.CenterPosition : args.GuidedTarget.Positions.PositionClosestTo(args.Source))
 					+ new WVec(WDist.Zero, WDist.Zero, info.AirburstAltitude);
 
 			// Compute target's predicted velocity vector (assuming uniform circular motion)

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -102,6 +102,8 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly Barrel[] Barrels;
 
 		readonly Actor self;
+		readonly AttackBase[] attackTraits;
+		AttackBase attack;
 		Turreted turret;
 		AmmoPool ammoPool;
 		BodyOrientation coords;
@@ -134,6 +136,7 @@ namespace OpenRA.Mods.Common.Traits
 				barrels.Add(new Barrel { Offset = WVec.Zero, Yaw = WAngle.Zero });
 
 			Barrels = barrels.ToArray();
+			attackTraits = self.TraitsImplementing<AttackBase>().Where(a => a.Info.Armaments.Contains(Info.Name)).ToArray();
 		}
 
 		public virtual WDist MaxRange()
@@ -190,6 +193,10 @@ namespace OpenRA.Mods.Common.Traits
 		// The world coordinate model uses Actor.Orientation
 		public virtual Barrel CheckFire(Actor self, IFacing facing, Target target)
 		{
+			attack = attackTraits.FirstOrDefault(Exts.IsTraitEnabled);
+			if (attack == null)
+				return null;
+
 			if (IsReloading)
 				return null;
 
@@ -229,7 +236,7 @@ namespace OpenRA.Mods.Common.Traits
 				Source = muzzlePosition(),
 				CurrentSource = muzzlePosition,
 				SourceActor = self,
-				PassiveTarget = target.Positions.PositionClosestTo(muzzlePosition()),
+				PassiveTarget = attack.Info.AttackTargetCenter ? target.CenterPosition : target.Positions.PositionClosestTo(muzzlePosition()),
 				GuidedTarget = target
 			};
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -24,6 +24,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Armament names")]
 		public readonly string[] Armaments = { "primary", "secondary" };
 
+		[Desc("Attack the target's center, instead of the closest targetable offset.")]
+		public readonly bool AttackTargetCenter = false;
+
 		public readonly string Cursor = null;
 
 		public readonly string OutsideRangeCursor = null;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var f = facing.Facing;
 			var pos = self.CenterPosition;
-			var targetedPosition = target.Positions.PositionClosestTo(pos);
+			var targetedPosition = Info.AttackTargetCenter ? target.CenterPosition : target.Positions.PositionClosestTo(pos);
 			var delta = targetedPosition - pos;
 			var facingToTarget = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : f;
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -146,7 +146,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			var pos = self.CenterPosition;
-			var targetedPosition = target.Positions.PositionClosestTo(pos);
+			var targetedPosition = Info.AttackTargetCenter ? target.CenterPosition : target.Positions.PositionClosestTo(pos);
 			var targetYaw = (targetedPosition - pos).Yaw;
 
 			foreach (var a in Armaments)

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -131,7 +131,8 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			var pos = self.CenterPosition;
-			var delta = target.Positions.PositionClosestTo(pos) - pos;
+			var targetPos = attack != null && attack.Info.AttackTargetCenter ? target.CenterPosition : target.Positions.PositionClosestTo(pos);
+			var delta = targetPos - pos;
 			DesiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : TurretFacing;
 			MoveTurret();
 			return HasAchievedDesiredFacing;

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -156,6 +156,7 @@ ARTY:
 		LocalOffset: 624,0,208
 		MuzzleSequence: muzzle
 	AttackFrontal:
+		AttackTargetCenter: true
 	WithMuzzleOverlay:
 	AutoTarget:
 		InitialStanceAI: Defend
@@ -472,6 +473,7 @@ MSAM:
 		Weapon: 227mm
 		LocalOffset: 213,-128,0, 213,128,0
 	AttackFrontal:
+		AttackTargetCenter: true
 	WithSpriteTurret:
 		AimSequence: aim
 	SpawnActorOnDeath:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -113,6 +113,7 @@ MSUB:
 		LocalOffset: 0,-171,0, 0,171,0
 		FireDelay: 2
 	AttackFrontal:
+		AttackTargetCenter: true
 	SelectionDecorations:
 		VisualBounds: 44,44
 	AutoTarget:
@@ -225,6 +226,7 @@ CA:
 		RecoilRecovery: 34
 		MuzzleSequence: muzzle
 	AttackTurreted:
+		AttackTargetCenter: true
 	WithMuzzleOverlay:
 	SelectionDecorations:
 		VisualBounds: 44,44

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -243,6 +243,7 @@ ARTY:
 		LocalOffset: 624,0,208
 		MuzzleSequence: muzzle
 	AttackFrontal:
+		AttackTargetCenter: true
 	WithMuzzleOverlay:
 	Explodes:
 		Weapon: ArtilleryExplode

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -353,6 +353,7 @@ JUGG:
 		Voice: Attack
 		Armaments: deployed
 		RequiresCondition: deployed
+		AttackTargetCenter: true
 	Armament@deployed:
 		Name: deployed
 		Turret: deployed


### PR DESCRIPTION
For very inaccurate weapons with high range, it makes more sense to shoot at the center of targets regardless of any closer targetable positions.

Applied to artillery actors in RA, TD and TS (see respective commits).

Note that this *does* decrease their effective firing range vs. larger buildings, so it's basically a trade-off of more average damage for less average range vs buildings larger than a single cell.

Closes #13496.