### PR TITLE
Clear previous effects data when generating a new sync report

### DIFF
--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -65,6 +65,8 @@ namespace OpenRA.Network
 			report.SyncedRandom = orderManager.World.SharedRandom.Last;
 			report.TotalCount = orderManager.World.SharedRandom.TotalCount;
 			report.Traits.Clear();
+			report.Effects.Clear();
+
 			foreach (var actor in orderManager.World.ActorsHavingTrait<ISync>())
 				foreach (var syncHash in actor.SyncHashes)
 					if (syncHash.Hash != 0)


### PR DESCRIPTION
Fixes #13499.

Since we reuse the `Report` object, if we don't clear the list, we just keep adding new effects to the list until it explodes. Whoops!