### PR TITLE
Allow queueing of BridgeRepair

### DIFF
--- a/OpenRA.Mods.Common/Traits/RepairsBridges.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsBridges.cs
@@ -97,7 +97,6 @@ namespace OpenRA.Mods.Common.Traits
 
 				self.SetTargetLine(Target.FromOrder(self.World, order), Color.Yellow);
 
-				self.CancelActivity();
 				self.QueueActivity(new RepairBridge(self, order.TargetActor, info.EnterBehaviour, info.RepairNotification));
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/RepairsBridges.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsBridges.cs
@@ -95,8 +95,10 @@ namespace OpenRA.Mods.Common.Traits
 				else
 					return;
 
-				self.SetTargetLine(Target.FromOrder(self.World, order), Color.Yellow);
+				if (!order.Queued)
+					self.CancelActivity();
 
+				self.SetTargetLine(Target.FromOrder(self.World, order), Color.Yellow);
 				self.QueueActivity(new RepairBridge(self, order.TargetActor, info.EnterBehaviour, info.RepairNotification));
 			}
 		}


### PR DESCRIPTION
This PR removes CancelActivity() in RepairsBridge trait so that engineers can be queued to take a safer detour path if necessary.

There's a catch though. The last move order just before RepairBridge seems to be ignored for some reason. You have to queue many move orders to see this patch in effect. I think it is a bug coming from Enter.cs + Move.cs which I think is beyond the scope. Hopefully, after activities are refactored, the problem will be gone.

Fixes #13471