### PR TITLE
Add check for FrozenActor.Actor is null (fixes CanTargetActor crash)

### DIFF
--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -288,7 +288,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			static bool CanTarget(Actor self, Actor target)
 			{
-				if (!target.AppearsFriendlyTo(self))
+				if (target == null || !target.AppearsFriendlyTo(self))
 					return false;
 
 				var carryable = target.TraitOrDefault<Carryable>();

--- a/OpenRA.Mods.Common/Traits/EntersTunnels.cs
+++ b/OpenRA.Mods.Common/Traits/EntersTunnels.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor)
 			{
-				if (target.IsDead)
+				if (target == null || target.IsDead)
 					return false;
 
 				var tunnel = target.TraitOrDefault<TunnelEntrance>();

--- a/OpenRA.Mods.Common/Traits/RevealOnFire.cs
+++ b/OpenRA.Mods.Common/Traits/RevealOnFire.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (target.Type == TargetType.Actor)
 				return target.Actor.Owner;
-			else if (target.Type == TargetType.FrozenActor && !target.FrozenActor.Actor.IsDead)
+			else if (target.Type == TargetType.FrozenActor && target.FrozenActor.Actor != null && !target.FrozenActor.Actor.IsDead)
 				return target.FrozenActor.Actor.Owner;
 
 			return null;


### PR DESCRIPTION
Fixes #13506.

Fixed 3 places with missing FrozenActor.Actor==null check - EnterTunnelOrderTargeter, CarryallPickupOrderTargeter, RevealOnFire.

Example - FrozenActor.Actor=null as proc doesn't exist anymore - would crash:

![obrazok](https://user-images.githubusercontent.com/16348750/27175173-a10455de-51be-11e7-9d6b-82e082fa1f77.png)
