### PR TITLE
Conditional (External)Capturable

### DIFF
--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -717,13 +717,33 @@ namespace OpenRA.Mods.Common.AI
 
 			var capturableTargetOptions = targetOptions
 				.Select(a => new CaptureTarget<CapturableInfo>(a, "CaptureActor"))
-				.Where(target => target.Info != null && capturers.Any(capturer => target.Info.CanBeTargetedBy(capturer, target.Actor.Owner)))
+				.Where(target =>
+				{
+					if (target.Info == null)
+						return false;
+
+					var capturable = target.Actor.TraitOrDefault<Capturable>();
+					if (capturable == null)
+						return false;
+
+					return capturers.Any(capturer => capturable.CanBeTargetedBy(capturer, target.Actor.Owner));
+				})
 				.OrderByDescending(target => target.Actor.GetSellValue())
 				.Take(maximumCaptureTargetOptions);
 
 			var externalCapturableTargetOptions = targetOptions
 				.Select(a => new CaptureTarget<ExternalCapturableInfo>(a, "ExternalCaptureActor"))
-				.Where(target => target.Info != null && capturers.Any(capturer => target.Info.CanBeTargetedBy(capturer, target.Actor.Owner)))
+				.Where(target =>
+				{
+					if (target.Info == null)
+						return false;
+
+					var externalCapturable = target.Actor.TraitOrDefault<ExternalCapturable>();
+					if (externalCapturable == null)
+						return false;
+
+					return capturers.Any(capturer => externalCapturable.CanBeTargetedBy(capturer, target.Actor.Owner));
+				})
 				.OrderByDescending(target => target.Actor.GetSellValue())
 				.Take(maximumCaptureTargetOptions);
 

--- a/OpenRA.Mods.Common/Activities/CaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/CaptureActor.cs
@@ -36,12 +36,12 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected override bool CanReserve(Actor self)
 		{
-			return !capturable.BeingCaptured && capturable.Info.CanBeTargetedBy(self, actor.Owner);
+			return !capturable.BeingCaptured && capturable.CanBeTargetedBy(self, actor.Owner);
 		}
 
 		protected override void OnInside(Actor self)
 		{
-			if (actor.IsDead || capturable.BeingCaptured)
+			if (actor.IsDead || capturable.BeingCaptured || capturable.IsTraitDisabled)
 				return;
 
 			if (building != null && !building.Lock())

--- a/OpenRA.Mods.Common/Traits/Capturable.cs
+++ b/OpenRA.Mods.Common/Traits/Capturable.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor can be captured by a unit with Captures: trait.")]
-	public class CapturableInfo : ITraitInfo
+	public class CapturableInfo : ConditionalTraitInfo
 	{
 		[Desc("Type listed under Types in Captures: trait of actors that can capture this).")]
 		public readonly string Type = "building";
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int CaptureThreshold = 50;
 		public readonly bool CancelActivity = false;
 
-		public object Create(ActorInitializer init) { return new Capturable(this); }
+		public override object Create(ActorInitializer init) { return new Capturable(this); }
 
 		public bool CanBeTargetedBy(Actor captor, Player owner)
 		{
@@ -50,11 +50,11 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class Capturable : INotifyCapture
+	public class Capturable : ConditionalTrait<CapturableInfo>, INotifyCapture
 	{
-		public readonly CapturableInfo Info;
 		public bool BeingCaptured { get; private set; }
-		public Capturable(CapturableInfo info) { Info = info; }
+		public Capturable(CapturableInfo info)
+			: base(info) { }
 
 		public void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner)
 		{
@@ -67,6 +67,14 @@ namespace OpenRA.Mods.Common.Traits
 				foreach (var t in self.TraitsImplementing<IResolveOrder>())
 					t.ResolveOrder(self, stop);
 			}
+		}
+
+		public bool CanBeTargetedBy(Actor captor, Player owner)
+		{
+			if (IsTraitDisabled)
+				return false;
+
+			return Info.CanBeTargetedBy(captor, owner);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Captures.cs
+++ b/OpenRA.Mods.Common/Traits/Captures.cs
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor)
 			{
-				var c = target.Info.TraitInfoOrDefault<CapturableInfo>();
+				var c = target.TraitOrDefault<Capturable>();
 				if (c == null || !c.CanBeTargetedBy(self, target.Owner))
 				{
 					cursor = capturesInfo.EnterBlockedCursor;
@@ -109,15 +109,18 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				var health = target.Trait<Health>();
-				var lowEnoughHealth = health.HP <= c.CaptureThreshold * health.MaxHP / 100;
+				var lowEnoughHealth = health.HP <= c.Info.CaptureThreshold * health.MaxHP / 100;
 
 				cursor = !capturesInfo.Sabotage || lowEnoughHealth || target.Owner.NonCombatant
 					? capturesInfo.EnterCursor : capturesInfo.SabotageCursor;
+
 				return true;
 			}
 
 			public override bool CanTargetFrozenActor(Actor self, FrozenActor target, TargetModifiers modifiers, ref string cursor)
 			{
+				// TODO: This doesn't account for disabled traits.
+				// Actors with FrozenUnderFog should not disable the Capturable trait.
 				var c = target.Info.TraitInfoOrDefault<CapturableInfo>();
 				if (c == null || !c.CanBeTargetedBy(self, target.Owner))
 				{

--- a/OpenRA.Mods.Common/Traits/ExternalCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCapturable.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor can be captured by a unit with ExternalCaptures: trait.")]
-	public class ExternalCapturableInfo : ITraitInfo
+	public class ExternalCapturableInfo : ConditionalTraitInfo
 	{
 		[Desc("Type of actor (the ExternalCaptures: trait defines what Types it can capture).")]
 		public readonly string Type = "building";
@@ -49,21 +49,20 @@ namespace OpenRA.Mods.Common.Traits
 			return true;
 		}
 
-		public object Create(ActorInitializer init) { return new ExternalCapturable(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new ExternalCapturable(init.Self, this); }
 	}
 
-	public class ExternalCapturable : ITick, ISync, IPreventsAutoTarget
+	public class ExternalCapturable : ConditionalTrait<ExternalCapturableInfo>, ITick, ISync, IPreventsAutoTarget
 	{
 		[Sync] public int CaptureProgressTime = 0;
 		[Sync] public Actor Captor;
 		private Actor self;
-		public ExternalCapturableInfo Info;
 		public bool CaptureInProgress { get { return Captor != null; } }
 
 		public ExternalCapturable(Actor self, ExternalCapturableInfo info)
+			: base(info)
 		{
 			this.self = self;
-			Info = info;
 		}
 
 		public void BeginCapture(Actor captor)
@@ -98,6 +97,14 @@ namespace OpenRA.Mods.Common.Traits
 		public bool PreventsAutoTarget(Actor self, Actor attacker)
 		{
 			return Info.PreventsAutoTarget && Captor != null && attacker.AppearsFriendlyTo(Captor);
+		}
+
+		public bool CanBeTargetedBy(Actor captor, Player owner)
+		{
+			if (IsTraitDisabled)
+				return false;
+
+			return Info.CanBeTargetedBy(captor, owner);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/ExternalCaptures.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCaptures.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (order.Target.Type == TargetType.Actor)
 			{
 				var c = order.TargetActor.TraitOrDefault<ExternalCapturable>();
-				return c != null && !c.CaptureInProgress && c.Info.CanBeTargetedBy(self, order.TargetActor.Owner);
+				return c != null && !c.CaptureInProgress && c.CanBeTargetedBy(self, order.TargetActor.Owner);
 			}
 
 			return false;
@@ -118,7 +118,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var c = target.TraitOrDefault<ExternalCapturable>();
 
-			var canTargetActor = c != null && !c.CaptureInProgress && c.Info.CanBeTargetedBy(self, target.Owner);
+			var canTargetActor = c != null && !c.CaptureInProgress && c.CanBeTargetedBy(self, target.Owner);
 			var capturesInfo = self.Trait<ExternalCaptures>().Info;
 			cursor = canTargetActor ? capturesInfo.CaptureCursor : capturesInfo.CaptureBlockedCursor;
 			return canTargetActor;
@@ -126,6 +126,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override bool CanTargetFrozenActor(Actor self, FrozenActor target, TargetModifiers modifiers, ref string cursor)
 		{
+			// TODO: This doesn't account for disabled traits.
+			// Actors with FrozenUnderFog should not disable the ExternalCapturable trait.
 			var c = target.Info.TraitInfoOrDefault<ExternalCapturableInfo>();
 
 			var canTargetActor = c != null && c.CanBeTargetedBy(self, target.Owner);


### PR DESCRIPTION
Capturable and External capturable are now conditional. Potentially, Building.Lock() can be replaced by this modification, not applied in this PR at the moment.

Needed for "mind control" system in RA2. Suppose there is a building-mind-controller of player A.  It will capture the structure of player B. Then the third player C decides to capture it with an engineer.  The building will be C's, for now. But if the mind controller dies, at the time of mind control, it was A's so the building will be returned to A's. (Can't hard code this situation to transfer ownership on mind control because in Kane's Wrath, a mind controller can snatch what someone has already controlled so capturing isn't the only way of ownership change for units that are already mind controlled)

To prevent that, OnOwnerChange notifier must be modified to deliver extra information on what activity changed the ownership so that eventually A's mind controller knows who the building should be returned to.

Another way is to forbid the capture of mind controlled buildings by making Capturable traits conditional.