### PR TITLE
Fix PlatformTests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ obj
 *.CodeAnalysisLog.xml
 *.lastcodeanalysissucceeded
 _ReSharper.*/
+/.vs
 
 # movies
 *.vqa

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -94,12 +94,24 @@ namespace OpenRA
 			return dir + Path.DirectorySeparatorChar;
 		}
 
-		public static string GameDir { get { return AppDomain.CurrentDomain.BaseDirectory; } }
+		public static string GameDir
+		{
+			get
+			{
+				var dir = AppDomain.CurrentDomain.BaseDirectory;
+
+				// Add trailing DirectorySeparator for some buggy AppPool hosts
+				if (!dir.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal))
+					dir += Path.DirectorySeparatorChar;
+
+				return dir;
+			}
+		}
 
 		/// <summary>Replaces special character prefixes with full paths.</summary>
 		public static string ResolvePath(string path)
 		{
-			path = path.TrimEnd(new char[] { ' ', '\t' });
+			path = path.TrimEnd(' ', '\t');
 
 			// Paths starting with ^ are relative to the support dir
 			if (path.StartsWith("^", StringComparison.Ordinal))

--- a/OpenRA.Test/OpenRA.Game/PlatformTest.cs
+++ b/OpenRA.Test/OpenRA.Game/PlatformTest.cs
@@ -39,6 +39,9 @@ namespace OpenRA.Test
 			Assert.That(Platform.ResolvePath("./testpath"),
 				Is.EqualTo(Path.Combine(gameDir, "testpath")));
 
+			Assert.That(Platform.ResolvePath(Path.Combine(".", "Foo.dll")),
+				Is.EqualTo(Path.Combine(gameDir, "Foo.dll")));
+
 			Assert.That(Platform.ResolvePath("testpath"),
 				Is.EqualTo("testpath"));
 		}


### PR DESCRIPTION
Fixed the failing tests in PlatformTest.

The AppDomain.CurrentDomain.BaseDirectory property was a bit of a gotcha because I got a trailing backslash from it when debugging the game, but not in the test.

Perhaps the BUG-comment is redundant, if it is missing the separator we just add it in the property.