### PR TITLE
Remove building auto-targeting from Defend stance

### DIFF
--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -424,7 +424,7 @@ Container@PLAYER_WIDGETS:
 					Background: stance-button
 					DisableKeyRepeat: true
 					TooltipText: Defend Stance
-					TooltipDesc: Set the selected units to Defend stance:\n - Units will attack enemy units and structures on sight\n - Units will not move or pursue enemies
+					TooltipDesc: Set the selected units to Defend stance:\n - Units will attack enemy units on sight\n - Units will not move or pursue enemies
 					TooltipContainer: TOOLTIP_CONTAINER
 					Children:
 						Image@ICON:

--- a/mods/cnc/maps/gdi06/rules.yaml
+++ b/mods/cnc/maps/gdi06/rules.yaml
@@ -94,6 +94,7 @@ RMBO.hard:
 	Inherits: RMBO
 	-AutoTarget:
 	-AutoTargetPriority@DEFAULT:
+	-AutoTargetPriority@ATTACKANYTHING:
 	-AttackMove:
 	RenderSprites:
 		Image: RMBO

--- a/mods/cnc/maps/nod07c/rules.yaml
+++ b/mods/cnc/maps/nod07c/rules.yaml
@@ -154,3 +154,4 @@ ORCA.IN:
 		Image: ORCA
 	-AutoTarget:
 	-AutoTargetPriority@DEFAULT:
+	-AutoTargetPriority@ATTACKANYTHING:

--- a/mods/cnc/maps/nod09/rules.yaml
+++ b/mods/cnc/maps/nod09/rules.yaml
@@ -194,6 +194,7 @@ RMBO.hard:
 	Inherits: RMBO
 	-AutoTarget:
 	-AutoTargetPriority@DEFAULT:
+	-AutoTargetPriority@ATTACKANYTHING:
 	-AttackMove:
 	RenderSprites:
 		Image: RMBO

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -149,7 +149,13 @@
 
 ^AutoTargetGround:
 	AutoTarget:
+		AttackAnythingCondition: stance-attackanything
 	AutoTargetPriority@DEFAULT:
+		RequiresCondition: !stance-attackanything
+		ValidTargets: Infantry, Vehicle, Creep, Water, Defense
+		InvalidTargets: NoAutoTarget
+	AutoTargetPriority@ATTACKANYTHING:
+		RequiresCondition: stance-attackanything
 		ValidTargets: Infantry, Vehicle, Creep, Water, Structure, Defense
 		InvalidTargets: NoAutoTarget
 
@@ -161,7 +167,13 @@
 
 ^AutoTargetAll:
 	AutoTarget:
+		AttackAnythingCondition: stance-attackanything
 	AutoTargetPriority@DEFAULT:
+		RequiresCondition: !stance-attackanything
+		ValidTargets: Infantry, Vehicle, Creep, Water, Air, Defense
+		InvalidTargets: NoAutoTarget
+	AutoTargetPriority@ATTACKANYTHING:
+		RequiresCondition: stance-attackanything
 		ValidTargets: Infantry, Vehicle, Creep, Water, Air, Structure, Defense
 		InvalidTargets: NoAutoTarget
 
@@ -945,6 +957,8 @@
 	-GivesBuildableArea:
 	MustBeDestroyed:
 		RequiredForShortGame: false
+	Targetable:
+		TargetTypes: Ground, C4, Structure, Defense
 
 ^DisabledOverlay:
 	WithColoredOverlay@IDISABLE:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -150,7 +150,7 @@
 ^AutoTargetGround:
 	AutoTarget:
 	AutoTargetPriority@DEFAULT:
-		ValidTargets: Infantry, Vehicle, Water, Structure, Defense
+		ValidTargets: Infantry, Vehicle, Creep, Water, Structure, Defense
 		InvalidTargets: NoAutoTarget
 
 ^AutoTargetAir:
@@ -162,7 +162,7 @@
 ^AutoTargetAll:
 	AutoTarget:
 	AutoTargetPriority@DEFAULT:
-		ValidTargets: Infantry, Vehicle, Water, Air, Structure, Defense
+		ValidTargets: Infantry, Vehicle, Creep, Water, Air, Structure, Defense
 		InvalidTargets: NoAutoTarget
 
 ^AcceptsCloakCrate:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -444,7 +444,7 @@ MSAM:
 	Inherits: ^Tank
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@CLOAK: ^AcceptsCloakCrate
-	Inherits@AUTOTARGET: ^AutoTargetAir
+	Inherits@AUTOTARGET: ^AutoTargetGround
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -483,7 +483,7 @@ MLRS:
 	Inherits: ^Tank
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@CLOAK: ^AcceptsCloakCrate
-	Inherits@AUTOTARGET: ^AutoTargetGround
+	Inherits@AUTOTARGET: ^AutoTargetAir
 	Valued:
 		Cost: 600
 	Tooltip:

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -79,7 +79,7 @@ sandworm:
 			SpiceSand: 100
 			Spice: 100
 	Targetable:
-		TargetTypes: Ground
+		TargetTypes: Ground, Creep
 	WithSpriteBody:
 	WithIdleAnimation:
 		Interval: 160

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -122,13 +122,25 @@
 
 ^AutoTargetGround:
 	AutoTarget:
+		AttackAnythingCondition: stance-attackanything
 	AutoTargetPriority@DEFAULT:
+		RequiresCondition: !stance-attackanything
+		ValidTargets: Infantry, Vehicle, Creep, Water, Defense
+		InvalidTargets: NoAutoTarget
+	AutoTargetPriority@ATTACKANYTHING:
+		RequiresCondition: stance-attackanything
 		ValidTargets: Infantry, Vehicle, Creep, Water, Structure, Defense
 		InvalidTargets: NoAutoTarget
 
 ^AutoTargetAll:
 	AutoTarget:
+		AttackAnythingCondition: stance-attackanything
 	AutoTargetPriority@DEFAULT:
+		RequiresCondition: !stance-attackanything
+		ValidTargets: Infantry, Vehicle, Creep, Water, Air, Defense
+		InvalidTargets: NoAutoTarget
+	AutoTargetPriority@ATTACKANYTHING:
+		RequiresCondition: stance-attackanything
 		ValidTargets: Infantry, Vehicle, Creep, Water, Air, Structure, Defense
 		InvalidTargets: NoAutoTarget
 

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -123,13 +123,13 @@
 ^AutoTargetGround:
 	AutoTarget:
 	AutoTargetPriority@DEFAULT:
-		ValidTargets: Infantry, Vehicle, Water, Structure, Defense
+		ValidTargets: Infantry, Vehicle, Creep, Water, Structure, Defense
 		InvalidTargets: NoAutoTarget
 
 ^AutoTargetAll:
 	AutoTarget:
 	AutoTargetPriority@DEFAULT:
-		ValidTargets: Infantry, Vehicle, Water, Air, Structure, Defense
+		ValidTargets: Infantry, Vehicle, Creep, Water, Air, Structure, Defense
 		InvalidTargets: NoAutoTarget
 
 ^Vehicle:

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -200,7 +200,7 @@ Container@PLAYER_WIDGETS:
 					Background: command-button
 					DisableKeyRepeat: true
 					TooltipText: Defend Stance
-					TooltipDesc: Set the selected units to Defend stance:\n - Units will attack enemy units and structures on sight\n - Units will not move or pursue enemies
+					TooltipDesc: Set the selected units to Defend stance:\n - Units will attack enemy units on sight\n - Units will not move or pursue enemies
 					TooltipContainer: TOOLTIP_CONTAINER
 					Children:
 						Image@ICON:

--- a/mods/ra/maps/soviet-07/rules.yaml
+++ b/mods/ra/maps/soviet-07/rules.yaml
@@ -52,3 +52,4 @@ FTUR:
 PBOX:
 	-AutoTarget:
 	-AutoTargetPriority@DEFAULT:
+	-AutoTargetPriority@ATTACKANYTHING:

--- a/mods/ra/rules/campaign-rules.yaml
+++ b/mods/ra/rules/campaign-rules.yaml
@@ -34,6 +34,7 @@ E7.noautotarget:
 	Inherits: E7
 	-AutoTarget:
 	-AutoTargetPriority@DEFAULT:
+	-AutoTargetPriority@ATTACKANYTHING:
 	RenderSprites:
 		Image: E7
 

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -159,7 +159,13 @@
 
 ^AutoTargetGround:
 	AutoTarget:
+		AttackAnythingCondition: stance-attackanything
 	AutoTargetPriority@DEFAULT:
+		RequiresCondition: !stance-attackanything
+		ValidTargets: Infantry, Vehicle, Tank, Water, Underwater, Defense
+		InvalidTargets: NoAutoTarget
+	AutoTargetPriority@ATTACKANYTHING:
+		RequiresCondition: stance-attackanything
 		ValidTargets: Infantry, Vehicle, Tank, Water, Underwater, Structure, Defense
 		InvalidTargets: NoAutoTarget
 
@@ -171,7 +177,13 @@
 
 ^AutoTargetAll:
 	AutoTarget:
+		AttackAnythingCondition: stance-attackanything
 	AutoTargetPriority@DEFAULT:
+		RequiresCondition: !stance-attackanything
+		ValidTargets: Infantry, Vehicle, Tank, Water, Underwater, Air, Defense
+		InvalidTargets: NoAutoTarget
+	AutoTargetPriority@ATTACKANYTHING:
+		RequiresCondition: stance-attackanything
 		ValidTargets: Infantry, Vehicle, Tank, Water, Underwater, Air, Structure, Defense
 		InvalidTargets: NoAutoTarget
 

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -160,7 +160,7 @@
 ^AutoTargetGround:
 	AutoTarget:
 	AutoTargetPriority@DEFAULT:
-		ValidTargets: Infantry, Vehicle, Tank, Water, Structure, Defense
+		ValidTargets: Infantry, Vehicle, Tank, Water, Underwater, Structure, Defense
 		InvalidTargets: NoAutoTarget
 
 ^AutoTargetAir:
@@ -172,7 +172,7 @@
 ^AutoTargetAll:
 	AutoTarget:
 	AutoTargetPriority@DEFAULT:
-		ValidTargets: Infantry, Vehicle, Tank, Water, Air, Structure, Defense
+		ValidTargets: Infantry, Vehicle, Tank, Water, Underwater, Air, Structure, Defense
 		InvalidTargets: NoAutoTarget
 
 ^Vehicle:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -160,7 +160,7 @@
 ^AutoTargetGround:
 	AutoTarget:
 	AutoTargetPriority@DEFAULT:
-		ValidTargets: Infantry, Vehicle, Water, Structure, Defense
+		ValidTargets: Infantry, Vehicle, Tank, Water, Structure, Defense
 		InvalidTargets: NoAutoTarget
 
 ^AutoTargetAir:
@@ -172,7 +172,7 @@
 ^AutoTargetAll:
 	AutoTarget:
 	AutoTargetPriority@DEFAULT:
-		ValidTargets: Infantry, Vehicle, Water, Air, Structure, Defense
+		ValidTargets: Infantry, Vehicle, Tank, Water, Air, Structure, Defense
 		InvalidTargets: NoAutoTarget
 
 ^Vehicle:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -125,7 +125,13 @@
 
 ^AutoTargetGround:
 	AutoTarget:
+		AttackAnythingCondition: stance-attackanything
 	AutoTargetPriority@DEFAULT:
+		RequiresCondition: !stance-attackanything
+		ValidTargets: Infantry, Vehicle, Creep, Water, Defense
+		InvalidTargets: NoAutoTarget
+	AutoTargetPriority@ATTACKANYTHING:
+		RequiresCondition: stance-attackanything
 		ValidTargets: Infantry, Vehicle, Creep, Water, Structure, Defense
 		InvalidTargets: NoAutoTarget
 
@@ -137,7 +143,13 @@
 
 ^AutoTargetAll:
 	AutoTarget:
+		AttackAnythingCondition: stance-attackanything
 	AutoTargetPriority@DEFAULT:
+		RequiresCondition: !stance-attackanything
+		ValidTargets: Infantry, Vehicle, Creep, Water, Air, Defense
+		InvalidTargets: NoAutoTarget
+	AutoTargetPriority@ATTACKANYTHING:
+		RequiresCondition: stance-attackanything
 		ValidTargets: Infantry, Vehicle, Creep, Water, Air, Structure, Defense
 		InvalidTargets: NoAutoTarget
 

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -126,7 +126,7 @@
 ^AutoTargetGround:
 	AutoTarget:
 	AutoTargetPriority@DEFAULT:
-		ValidTargets: Infantry, Vehicle, Water, Structure, Defense
+		ValidTargets: Infantry, Vehicle, Creep, Water, Structure, Defense
 		InvalidTargets: NoAutoTarget
 
 ^AutoTargetAir:
@@ -138,7 +138,7 @@
 ^AutoTargetAll:
 	AutoTarget:
 	AutoTargetPriority@DEFAULT:
-		ValidTargets: Infantry, Vehicle, Water, Air, Structure, Defense
+		ValidTargets: Infantry, Vehicle, Creep, Water, Air, Structure, Defense
 		InvalidTargets: NoAutoTarget
 
 ^BasicBuilding:


### PR DESCRIPTION
In all the original games units did not automatically target structures.  The later games that featured stances added this as part of the "Aggressive / Attack Anything" stance that we partially implemented and then left dangling.  @Mailaender gave this a shot in #3337, but had to back it out in #3467 because our AI logic wasn't smart enough to deal with it.

This feature fell off the radar after that, except for the occasional complaint from players about how awkward it is to use engineers / spies / etc with groups of combat units shooting the things they want to capture/infiltrate/etc.

We now have all the technical pieces in place to do this properly, and it nicely rounds off the targeting and stance changes we are aiming for in the next release.

If players *do* want units to auto-target buildings then they can use the new command bar to easily change stance.  Base defenses are still auto-targeted from both Defend and Attack Anything.