### PR TITLE
Audio Streaming

### DIFF
--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Player.cs" />
     <Compile Include="Primitives\MergedStream.cs" />
     <Compile Include="Primitives\PlayerDictionary.cs" />
+    <Compile Include="Primitives\ReadOnlyAdapterStream.cs" />
     <Compile Include="Primitives\SegmentStream.cs" />
     <Compile Include="Primitives\SpatiallyPartitioned.cs" />
     <Compile Include="Primitives\ConcurrentCache.cs" />

--- a/OpenRA.Game/Primitives/ReadOnlyAdapterStream.cs
+++ b/OpenRA.Game/Primitives/ReadOnlyAdapterStream.cs
@@ -1,0 +1,89 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace OpenRA.Primitives
+{
+	/// <summary>
+	/// Provides a read-only buffering layer so data can be streamed from sources where reading arbitrary amounts of
+	/// data is difficult.
+	/// </summary>
+	public abstract class ReadOnlyAdapterStream : Stream
+	{
+		readonly Queue<byte> data = new Queue<byte>(1024);
+		readonly Stream baseStream;
+
+		protected ReadOnlyAdapterStream(Stream stream)
+		{
+			if (stream == null)
+				throw new ArgumentNullException("stream");
+			if (!stream.CanRead)
+				throw new ArgumentException("stream must be readable.", "stream");
+
+			baseStream = stream;
+		}
+
+		public sealed override bool CanSeek { get { return false; } }
+		public sealed override bool CanRead { get { return true; } }
+		public sealed override bool CanWrite { get { return false; } }
+
+		public sealed override long Length { get { throw new NotSupportedException(); } }
+		public sealed override long Position
+		{
+			get { throw new NotSupportedException(); }
+			set { throw new NotSupportedException(); }
+		}
+
+		public sealed override long Seek(long offset, SeekOrigin origin) { throw new NotSupportedException(); }
+		public sealed override void SetLength(long value) { throw new NotSupportedException(); }
+		public sealed override void Write(byte[] buffer, int offset, int count) { throw new NotSupportedException(); }
+		public sealed override void Flush() { throw new NotSupportedException(); }
+
+		public sealed override int Read(byte[] buffer, int offset, int count)
+		{
+			var copied = 0;
+			ConsumeData(buffer, offset, count, ref copied);
+
+			var finished = false;
+			while (copied < count && !finished)
+			{
+				finished = BufferData(baseStream, data);
+				ConsumeData(buffer, offset, count, ref copied);
+			}
+
+			return copied;
+		}
+
+		/// <summary>
+		/// Reads data into a buffer, which will be used to satisfy <see cref="Read(byte[], int, int)"/> calls.
+		/// </summary>
+		/// <param name="baseStream">The source stream from which bytes should be read.</param>
+		/// <param name="data">The queue where bytes should be enqueued. Do not dequeue from this buffer.</param>
+		/// <returns>Return true if all data has been read; otherwise, false.</returns>
+		protected abstract bool BufferData(Stream baseStream, Queue<byte> data);
+
+		void ConsumeData(byte[] buffer, int offset, int count, ref int copied)
+		{
+			while (copied < count && data.Count > 0)
+				buffer[offset + copied++] = data.Dequeue();
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+				baseStream.Dispose();
+			base.Dispose(disposing);
+		}
+	}
+}

--- a/OpenRA.Game/Primitives/SegmentStream.cs
+++ b/OpenRA.Game/Primitives/SegmentStream.cs
@@ -21,6 +21,15 @@ namespace OpenRA.Primitives
 		public readonly long BaseOffset;
 		public readonly long BaseCount;
 
+		/// <summary>
+		/// Creates a new <see cref="SegmentStream"/> that wraps a subset of the source stream. This takes ownership of
+		/// the source stream. The <see cref="SegmentStream"/> is dependent on the source and changes its underlying
+		/// position.
+		/// </summary>
+		/// <param name="stream">The source stream, of which only a segment should be exposed. Ownership is transferred
+		/// to the <see cref="SegmentStream"/>.</param>
+		/// <param name="offset">The offset at which the segment starts.</param>
+		/// <param name="count">The length of the segment.</param>
 		public SegmentStream(Stream stream, long offset, long count)
 		{
 			if (stream == null)
@@ -90,7 +99,7 @@ namespace OpenRA.Primitives
 			base.Dispose(disposing);
 		}
 
-		public static long GetOverallNestedOffset(Stream stream, out Stream overallBaseStream)
+		static long GetOverallNestedOffset(Stream stream, out Stream overallBaseStream)
 		{
 			var offset = 0L;
 			overallBaseStream = stream;
@@ -98,6 +107,35 @@ namespace OpenRA.Primitives
 			if (segmentStream != null)
 				offset += segmentStream.BaseOffset + GetOverallNestedOffset(segmentStream.BaseStream, out overallBaseStream);
 			return offset;
+		}
+
+		/// <summary>
+		/// Creates a new <see cref="Stream"/> that wraps a subset of the source stream without taking ownership of it,
+		/// allowing it to be reused by the caller. The <see cref="Stream"/> is independent of the source stream and
+		/// won't affect its position.
+		/// </summary>
+		/// <param name="stream">The source stream, of which only a segment should be exposed. Ownership is retained by
+		/// the caller.</param>
+		/// <param name="offset">The offset at which the segment starts.</param>
+		/// <param name="count">The length of the segment.</param>
+		public static Stream CreateWithoutOwningStream(Stream stream, long offset, int count)
+		{
+			Stream parentStream;
+			var nestedOffset = offset + GetOverallNestedOffset(stream, out parentStream);
+
+			// Special case FileStream - instead of creating an in-memory copy,
+			// just reference the portion of the on-disk file that we need to save memory.
+			// We use GetType instead of 'is' here since we can't handle any derived classes of FileStream.
+			if (parentStream.GetType() == typeof(FileStream))
+			{
+				var path = ((FileStream)parentStream).Name;
+				return new SegmentStream(File.OpenRead(path), nestedOffset, count);
+			}
+
+			// For all other streams, create a copy in memory.
+			// This uses more memory but is the only way in general to ensure the returned streams won't clash.
+			stream.Seek(offset, SeekOrigin.Begin);
+			return new MemoryStream(stream.ReadBytes(count));
 		}
 	}
 }

--- a/OpenRA.Game/Sound/SoundDevice.cs
+++ b/OpenRA.Game/Sound/SoundDevice.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.IO;
 
 namespace OpenRA
 {
@@ -18,6 +19,7 @@ namespace OpenRA
 		SoundDevice[] AvailableDevices();
 		ISoundSource AddSoundSourceFromMemory(byte[] data, int channels, int sampleBits, int sampleRate);
 		ISound Play2D(ISoundSource sound, bool loop, bool relative, WPos pos, float volume, bool attenuateVolume);
+		ISound Play2DStream(Stream stream, int channels, int sampleBits, int sampleRate, bool loop, bool relative, WPos pos, float volume);
 		float Volume { get; set; }
 		void PauseSound(ISound sound, bool paused);
 		void StopSound(ISound sound);
@@ -25,8 +27,6 @@ namespace OpenRA
 		void StopAllSounds();
 		void SetListenerPosition(WPos position);
 		void SetSoundVolume(float volume, ISound music, ISound video);
-		void ReleaseSourcePool();
-		void ReleaseSound(ISound sound);
 	}
 
 	public class SoundDevice
@@ -47,7 +47,7 @@ namespace OpenRA
 	{
 		float Volume { get; set; }
 		float SeekPosition { get; }
-		bool Playing { get; }
+		bool Complete { get; }
 		void SetPosition(WPos pos);
 	}
 }

--- a/OpenRA.Game/StreamExts.cs
+++ b/OpenRA.Game/StreamExts.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace OpenRA
@@ -117,7 +118,17 @@ namespace OpenRA
 		public static byte[] ReadAllBytes(this Stream s)
 		{
 			using (s)
-				return s.ReadBytes((int)(s.Length - s.Position));
+			{
+				if (s.CanSeek)
+					return s.ReadBytes((int)(s.Length - s.Position));
+
+				var bytes = new List<byte>();
+				var buffer = new byte[1024];
+				int count;
+				while ((count = s.Read(buffer, 0, buffer.Length)) > 0)
+					bytes.AddRange(buffer.Take(count));
+				return bytes.ToArray();
+			}
 		}
 
 		public static void Write(this Stream s, byte[] data)

--- a/OpenRA.Mods.Cnc/FileSystem/MixFile.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/MixFile.cs
@@ -183,23 +183,7 @@ namespace OpenRA.Mods.Cnc.FileSystem
 
 			public Stream GetContent(PackageEntry entry)
 			{
-				Stream parentStream;
-				var baseOffset = dataStart + entry.Offset;
-				var nestedOffset = baseOffset + SegmentStream.GetOverallNestedOffset(s, out parentStream);
-
-				// Special case FileStream - instead of creating an in-memory copy,
-				// just reference the portion of the on-disk file that we need to save memory.
-				// We use GetType instead of 'is' here since we can't handle any derived classes of FileStream.
-				if (parentStream.GetType() == typeof(FileStream))
-				{
-					var path = ((FileStream)parentStream).Name;
-					return new SegmentStream(File.OpenRead(path), nestedOffset, entry.Length);
-				}
-
-				// For all other streams, create a copy in memory.
-				// This uses more memory but is the only way in general to ensure the returned streams won't clash.
-				s.Seek(baseOffset, SeekOrigin.Begin);
-				return new MemoryStream(s.ReadBytes((int)entry.Length));
+				return SegmentStream.CreateWithoutOwningStream(s, dataStart + entry.Offset, (int)entry.Length);
 			}
 
 			public Stream GetStream(string filename)

--- a/OpenRA.Mods.Common/AudioLoaders/AudLoader.cs
+++ b/OpenRA.Mods.Common/AudioLoaders/AudLoader.cs
@@ -56,34 +56,20 @@ namespace OpenRA.Mods.Common.AudioLoaders
 		public int Channels { get { return 1; } }
 		public int SampleBits { get { return 16; } }
 		public int SampleRate { get { return sampleRate; } }
-		public float LengthInSeconds { get { return AudReader.SoundLength(stream); } }
-		public Stream GetPCMInputStream() { return new MemoryStream(rawData.Value); }
-		public void Dispose() { stream.Dispose(); }
+		public float LengthInSeconds { get { return AudReader.SoundLength(sourceStream); } }
+		public Stream GetPCMInputStream() { return audStreamFactory(); }
+		public void Dispose() { sourceStream.Dispose(); }
 
-		int sampleRate;
-		Lazy<byte[]> rawData;
-
-		Stream stream;
+		readonly Stream sourceStream;
+		readonly Func<Stream> audStreamFactory;
+		readonly int sampleRate;
 
 		public AudFormat(Stream stream)
 		{
-			this.stream = stream;
+			sourceStream = stream;
 
-			var position = stream.Position;
-			rawData = Exts.Lazy(() =>
-			{
-				try
-				{
-					byte[] data;
-					if (!AudReader.LoadSound(stream, out data, out sampleRate))
-						throw new InvalidDataException();
-					return data;
-				}
-				finally
-				{
-					stream.Position = position;
-				}
-			});
+			if (!AudReader.LoadSound(stream, out audStreamFactory, out sampleRate))
+				throw new InvalidDataException();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 			if (IsTraitDisabled)
 				return;
 
-			currentSounds.RemoveWhere(s => s == null || !s.Playing);
+			currentSounds.RemoveWhere(s => s == null || s.Complete);
 
 			var pos = self.CenterPosition;
 			if (pos != cachedPosition)

--- a/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
@@ -87,8 +87,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (currentSong == null || musicPlaylist.CurrentSongIsBackground)
 					return "";
 
-				var minutes = (int)Game.Sound.MusicSeekPosition / 60;
-				var seconds = (int)Game.Sound.MusicSeekPosition % 60;
+				var seek = Game.Sound.MusicSeekPosition;
+				var minutes = (int)seek / 60;
+				var seconds = (int)seek % 60;
 				var totalMinutes = currentSong.Length / 60;
 				var totalSeconds = currentSong.Length % 60;
 

--- a/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
+++ b/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
@@ -11,9 +11,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using OpenAL;
 
 namespace OpenRA.Platforms.Default
@@ -37,7 +40,8 @@ namespace OpenRA.Platforms.Default
 			public int FrameStarted;
 			public WPos Pos;
 			public bool IsRelative;
-			public ISoundSource Sound;
+			public OpenAlSoundSource SoundSource;
+			public OpenAlSound Sound;
 		}
 
 		const int MaxInstancesPerFrame = 3;
@@ -45,7 +49,7 @@ namespace OpenRA.Platforms.Default
 		const int GroupDistanceSqr = GroupDistance * GroupDistance;
 		const int PoolSize = 32;
 
-		readonly Dictionary<uint, PoolSlot> sourcePool = new Dictionary<uint, PoolSlot>();
+		readonly Dictionary<uint, PoolSlot> sourcePool = new Dictionary<uint, PoolSlot>(PoolSize);
 		float volume = 1f;
 		IntPtr device;
 		IntPtr context;
@@ -100,6 +104,14 @@ namespace OpenRA.Platforms.Default
 			return new string[] { };
 		}
 
+		internal static int MakeALFormat(int channels, int bits)
+		{
+			if (channels == 1)
+				return bits == 16 ? AL10.AL_FORMAT_MONO16 : AL10.AL_FORMAT_MONO8;
+			else
+				return bits == 16 ? AL10.AL_FORMAT_STEREO16 : AL10.AL_FORMAT_STEREO8;
+		}
+
 		public OpenAlSoundEngine(string deviceName)
 		{
 			if (deviceName != null)
@@ -137,23 +149,27 @@ namespace OpenRA.Platforms.Default
 
 		bool TryGetSourceFromPool(out uint source)
 		{
-			foreach (var kvp in sourcePool)
+			foreach (var kv in sourcePool)
 			{
-				if (!kvp.Value.IsActive)
+				if (!kv.Value.IsActive)
 				{
-					sourcePool[kvp.Key].IsActive = true;
-					source = kvp.Key;
+					sourcePool[kv.Key].IsActive = true;
+					source = kv.Key;
 					return true;
 				}
 			}
 
 			var freeSources = new List<uint>();
-			foreach (var key in sourcePool.Keys)
+			foreach (var kv in sourcePool)
 			{
-				int state;
-				AL10.alGetSourcei(key, AL10.AL_SOURCE_STATE, out state);
-				if (state != AL10.AL_PLAYING && state != AL10.AL_PAUSED)
-					freeSources.Add(key);
+				var sound = kv.Value.Sound;
+				if (sound != null && sound.Complete)
+				{
+					var freeSource = kv.Key;
+					freeSources.Add(freeSource);
+					AL10.alSourceRewind(freeSource);
+					AL10.alSourcei(freeSource, AL10.AL_BUFFER, 0);
+				}
 			}
 
 			if (freeSources.Count == 0)
@@ -162,12 +178,16 @@ namespace OpenRA.Platforms.Default
 				return false;
 			}
 
-			foreach (var i in freeSources)
-				sourcePool[i].IsActive = false;
-
-			sourcePool[freeSources[0]].IsActive = true;
+			foreach (var freeSource in freeSources)
+			{
+				var slot = sourcePool[freeSource];
+				slot.SoundSource = null;
+				slot.Sound = null;
+				slot.IsActive = false;
+			}
 
 			source = freeSources[0];
+			sourcePool[source].IsActive = true;
 			return true;
 		}
 
@@ -176,13 +196,15 @@ namespace OpenRA.Platforms.Default
 			return new OpenAlSoundSource(data, channels, sampleBits, sampleRate);
 		}
 
-		public ISound Play2D(ISoundSource sound, bool loop, bool relative, WPos pos, float volume, bool attenuateVolume)
+		public ISound Play2D(ISoundSource soundSource, bool loop, bool relative, WPos pos, float volume, bool attenuateVolume)
 		{
-			if (sound == null)
+			if (soundSource == null)
 			{
 				Log.Write("sound", "Attempt to Play2D a null `ISoundSource`");
 				return null;
 			}
+
+			var alSoundSource = (OpenAlSoundSource)soundSource;
 
 			var currFrame = Game.LocalTick;
 			var atten = 1f;
@@ -199,7 +221,7 @@ namespace OpenRA.Platforms.Default
 						continue;
 
 					++activeCount;
-					if (s.Sound != sound)
+					if (s.SoundSource != alSoundSource)
 						continue;
 					if (currFrame - s.FrameStarted >= 5)
 						continue;
@@ -225,9 +247,27 @@ namespace OpenRA.Platforms.Default
 			var slot = sourcePool[source];
 			slot.Pos = pos;
 			slot.FrameStarted = currFrame;
-			slot.Sound = sound;
 			slot.IsRelative = relative;
-			return new OpenAlSound(source, ((OpenAlSoundSource)sound).Buffer, loop, relative, pos, volume * atten);
+			slot.SoundSource = alSoundSource;
+			slot.Sound = new OpenAlSound(source, loop, relative, pos, volume * atten, alSoundSource.SampleRate, alSoundSource.Buffer);
+			return slot.Sound;
+		}
+
+		public ISound Play2DStream(Stream stream, int channels, int sampleBits, int sampleRate, bool loop, bool relative, WPos pos, float volume)
+		{
+			var currFrame = Game.LocalTick;
+
+			uint source;
+			if (!TryGetSourceFromPool(out source))
+				return null;
+
+			var slot = sourcePool[source];
+			slot.Pos = pos;
+			slot.FrameStarted = currFrame;
+			slot.IsRelative = relative;
+			slot.SoundSource = null;
+			slot.Sound = new OpenAlStreamingSound(source, loop, relative, pos, volume, channels, sampleBits, sampleRate, stream);
+			return slot.Sound;
 		}
 
 		public float Volume
@@ -241,25 +281,25 @@ namespace OpenRA.Platforms.Default
 			if (sound == null)
 				return;
 
-			var key = ((OpenAlSound)sound).Source;
+			var source = ((OpenAlSound)sound).Source;
 			int state;
-			AL10.alGetSourcei(key, AL10.AL_SOURCE_STATE, out state);
+			AL10.alGetSourcei(source, AL10.AL_SOURCE_STATE, out state);
 			if (state == AL10.AL_PLAYING && paused)
-				AL10.alSourcePause(key);
+				AL10.alSourcePause(source);
 			else if (state == AL10.AL_PAUSED && !paused)
-				AL10.alSourcePlay(key);
+				AL10.alSourcePlay(source);
 		}
 
 		public void SetAllSoundsPaused(bool paused)
 		{
-			foreach (var key in sourcePool.Keys)
+			foreach (var source in sourcePool.Keys)
 			{
 				int state;
-				AL10.alGetSourcei(key, AL10.AL_SOURCE_STATE, out state);
+				AL10.alGetSourcei(source, AL10.AL_SOURCE_STATE, out state);
 				if (state == AL10.AL_PLAYING && paused)
-					AL10.alSourcePause(key);
+					AL10.alSourcePause(source);
 				else if (state == AL10.AL_PAUSED && !paused)
-					AL10.alSourcePlay(key);
+					AL10.alSourcePlay(source);
 			}
 		}
 
@@ -283,22 +323,14 @@ namespace OpenRA.Platforms.Default
 			if (sound == null)
 				return;
 
-			var key = ((OpenAlSound)sound).Source;
-			int state;
-			AL10.alGetSourcei(key, AL10.AL_SOURCE_STATE, out state);
-			if (state == AL10.AL_PLAYING || state == AL10.AL_PAUSED)
-				AL10.alSourceStop(key);
+			((OpenAlSound)sound).Stop();
 		}
 
 		public void StopAllSounds()
 		{
-			foreach (var key in sourcePool.Keys)
-			{
-				int state;
-				AL10.alGetSourcei(key, AL10.AL_SOURCE_STATE, out state);
-				if (state == AL10.AL_PLAYING || state == AL10.AL_PAUSED)
-					AL10.alSourceStop(key);
-			}
+			foreach (var slot in sourcePool.Values)
+				if (slot.Sound != null)
+					slot.Sound.Stop();
 		}
 
 		public void SetListenerPosition(WPos position)
@@ -309,26 +341,6 @@ namespace OpenRA.Platforms.Default
 			var orientation = new[] { 0f, 0f, 1f, 0f, -1f, 0f };
 			AL10.alListenerfv(AL10.AL_ORIENTATION, orientation);
 			AL10.alListenerf(EFX.AL_METERS_PER_UNIT, .01f);
-		}
-
-		public void ReleaseSourcePool()
-		{
-			foreach (var slot in sourcePool)
-				if (slot.Value.Sound != null)
-					ReleaseSound(slot.Key);
-		}
-
-		public void ReleaseSound(ISound sound)
-		{
-			var openAlSound = sound as OpenAlSound;
-			if (openAlSound != null)
-				ReleaseSound(openAlSound.Source);
-		}
-
-		void ReleaseSound(uint source)
-		{
-			AL10.alSourceStop(source);
-			AL10.alSourcei(source, AL10.AL_BUFFER, 0);
 		}
 
 		~OpenAlSoundEngine()
@@ -344,6 +356,8 @@ namespace OpenRA.Platforms.Default
 
 		void Dispose(bool disposing)
 		{
+			StopAllSounds();
+
 			if (context != IntPtr.Zero)
 			{
 				ALC10.alcMakeContextCurrent(IntPtr.Zero);
@@ -365,19 +379,13 @@ namespace OpenRA.Platforms.Default
 		bool disposed;
 
 		public uint Buffer { get { return buffer; } }
-
-		static int MakeALFormat(int channels, int bits)
-		{
-			if (channels == 1)
-				return bits == 16 ? AL10.AL_FORMAT_MONO16 : AL10.AL_FORMAT_MONO8;
-			else
-				return bits == 16 ? AL10.AL_FORMAT_STEREO16 : AL10.AL_FORMAT_STEREO8;
-		}
+		public int SampleRate { get; private set; }
 
 		public OpenAlSoundSource(byte[] data, int channels, int sampleBits, int sampleRate)
 		{
+			SampleRate = sampleRate;
 			AL10.alGenBuffers(new IntPtr(1), out buffer);
-			AL10.alBufferData(buffer, MakeALFormat(channels, sampleBits), data, new IntPtr(data.Length), new IntPtr(sampleRate));
+			AL10.alBufferData(buffer, OpenAlSoundEngine.MakeALFormat(channels, sampleBits), data, new IntPtr(data.Length), new IntPtr(sampleRate));
 		}
 
 		protected virtual void Dispose(bool disposing)
@@ -404,54 +412,267 @@ namespace OpenRA.Platforms.Default
 	class OpenAlSound : ISound
 	{
 		public readonly uint Source;
-		float volume;
+		protected readonly float SampleRate;
 
-		public OpenAlSound(uint source, uint buffer, bool looping, bool relative, WPos pos, float volume)
+		public OpenAlSound(uint source, bool looping, bool relative, WPos pos, float volume, int sampleRate, uint buffer)
+			: this(source, looping, relative, pos, volume, sampleRate)
+		{
+			AL10.alSourcei(source, AL10.AL_BUFFER, (int)buffer);
+			AL10.alSourcePlay(source);
+		}
+
+		protected OpenAlSound(uint source, bool looping, bool relative, WPos pos, float volume, int sampleRate)
 		{
 			Source = source;
+			SampleRate = sampleRate;
 			Volume = volume;
 
 			AL10.alSourcef(source, AL10.AL_PITCH, 1f);
 			AL10.alSource3f(source, AL10.AL_POSITION, pos.X, pos.Y, pos.Z);
 			AL10.alSource3f(source, AL10.AL_VELOCITY, 0f, 0f, 0f);
-			AL10.alSourcei(source, AL10.AL_BUFFER, (int)buffer);
 			AL10.alSourcei(source, AL10.AL_LOOPING, looping ? 1 : 0);
 			AL10.alSourcei(source, AL10.AL_SOURCE_RELATIVE, relative ? 1 : 0);
 
 			AL10.alSourcef(source, AL10.AL_REFERENCE_DISTANCE, 6826);
 			AL10.alSourcef(source, AL10.AL_MAX_DISTANCE, 136533);
-			AL10.alSourcePlay(source);
 		}
 
 		public float Volume
 		{
-			get { return volume; }
-			set { AL10.alSourcef(Source, AL10.AL_GAIN, volume = value); }
+			get { float volume; AL10.alGetSourcef(Source, AL10.AL_GAIN, out volume); return volume; }
+			set { AL10.alSourcef(Source, AL10.AL_GAIN, value); }
 		}
 
-		public float SeekPosition
+		public virtual float SeekPosition
 		{
 			get
 			{
-				int pos;
-				AL10.alGetSourcei(Source, AL11.AL_SAMPLE_OFFSET, out pos);
-				return pos / 22050f;
+				int sampleOffset;
+				AL10.alGetSourcei(Source, AL11.AL_SAMPLE_OFFSET, out sampleOffset);
+				return sampleOffset / SampleRate;
 			}
 		}
 
-		public bool Playing
+		public virtual bool Complete
 		{
 			get
 			{
 				int state;
 				AL10.alGetSourcei(Source, AL10.AL_SOURCE_STATE, out state);
-				return state == AL10.AL_PLAYING;
+				return state == AL10.AL_STOPPED;
 			}
 		}
 
 		public void SetPosition(WPos pos)
 		{
 			AL10.alSource3f(Source, AL10.AL_POSITION, pos.X, pos.Y, pos.Z);
+		}
+
+		protected void StopSource()
+		{
+			int state;
+			AL10.alGetSourcei(Source, AL10.AL_SOURCE_STATE, out state);
+			if (state == AL10.AL_PLAYING || state == AL10.AL_PAUSED)
+				AL10.alSourceStop(Source);
+		}
+
+		public virtual void Stop()
+		{
+			StopSource();
+			AL10.alSourcei(Source, AL10.AL_BUFFER, 0);
+		}
+	}
+
+	class OpenAlStreamingSound : OpenAlSound
+	{
+		const int BufferCount = 3;
+		const int BufferSizeInSecs = 1;
+		readonly object bufferDequeueLock = new object();
+		readonly CancellationTokenSource cts = new CancellationTokenSource();
+		readonly Task streamTask;
+		readonly Stack<uint> freeBuffers = new Stack<uint>(BufferCount);
+		int totalSamplesPlayed;
+
+		public OpenAlStreamingSound(uint source, bool looping, bool relative, WPos pos, float volume, int channels, int sampleBits, int sampleRate, Stream stream)
+			: base(source, looping, relative, pos, volume, sampleRate)
+		{
+			streamTask = Task.Run(async () =>
+			{
+				var format = OpenAlSoundEngine.MakeALFormat(channels, sampleBits);
+				var bytesPerSample = sampleBits / 8;
+
+				var buffers = new uint[BufferCount];
+				AL10.alGenBuffers(new IntPtr(buffers.Length), buffers);
+				try
+				{
+					foreach (var buffer in buffers)
+						freeBuffers.Push(buffer);
+					var data = new byte[sampleRate * bytesPerSample * BufferSizeInSecs];
+					var streamEnd = false;
+
+					while (!streamEnd && !cts.IsCancellationRequested)
+					{
+						// Fill the data array as fully as possible.
+						var count = await ReadFillingBuffer(stream, data);
+						streamEnd = count < data.Length;
+
+						// Fill a buffer and queue it for playback.
+						var nextBuffer = freeBuffers.Pop();
+						AL10.alBufferData(nextBuffer, format, data, new IntPtr(count), new IntPtr(sampleRate));
+						AL10.alSourceQueueBuffers(source, new IntPtr(1), ref nextBuffer);
+
+						lock (cts)
+						{
+							if (!cts.IsCancellationRequested)
+							{
+								// Once we have at least one buffer filled, we can actually start.
+								// If streaming fell behind, the source will have stopped,
+								// we also need to play it in this case to resume audio.
+								int state;
+								AL10.alGetSourcei(source, AL10.AL_SOURCE_STATE, out state);
+								if (state == AL10.AL_INITIAL || state == AL10.AL_STOPPED)
+								{
+									// If we resume playback from the stopped state, it resets to the beginning!
+									// To avoid replaying the same audio, we need to dequeue the processed buffers first.
+									if (state == AL10.AL_STOPPED)
+										DequeueBuffers();
+
+									AL10.alSourcePlay(source);
+								}
+							}
+						}
+
+						// Try and dequeue buffers as they become available to be reused.
+						// When the stream ends, wait for all the buffers to be processed
+						while (freeBuffers.Count < (streamEnd ? buffers.Length : 1))
+						{
+							await Task.Delay(TimeSpan.FromSeconds(BufferSizeInSecs), cts.Token).ConfigureAwait(false);
+							DequeueBuffers();
+						}
+					}
+				}
+				catch (TaskCanceledException)
+				{
+					// Streaming has been cancelled, we'll need to perform some cleanup.
+				}
+				finally
+				{
+					// If we never actually started the source, we need to start it and then stop it.
+					// Otherwise it is left in the initial state and never returned to the source pool.
+					int state;
+					AL10.alGetSourcei(Source, AL10.AL_SOURCE_STATE, out state);
+					if (state == AL10.AL_INITIAL)
+						AL10.alSourcePlay(Source);
+
+					// Ensure the source is stopped, which will mark all buffers as processed.
+					// Dequeue these, so they can then be freed.
+					AL10.alSourceStop(Source);
+					lock (bufferDequeueLock)
+					{
+						int buffersProcessed;
+						AL10.alGetSourcei(source, AL10.AL_BUFFERS_PROCESSED, out buffersProcessed);
+						for (var i = 0; i < buffersProcessed; i++)
+						{
+							var dequeued = 0U;
+							AL10.alSourceUnqueueBuffers(source, new IntPtr(1), ref dequeued);
+						}
+					}
+
+					AL10.alDeleteBuffers(new IntPtr(buffers.Length), buffers);
+					stream.Dispose();
+				}
+			}).ContinueWith(task =>
+			{
+				Game.RunAfterTick(() =>
+				{
+					throw new Exception("Failed to stream a sound.", task.Exception);
+				});
+			}, TaskContinuationOptions.OnlyOnFaulted);
+		}
+
+		async Task<int> ReadFillingBuffer(Stream stream, byte[] buffer)
+		{
+			var offset = 0;
+			int count;
+			while (offset < buffer.Length &&
+				(count = await stream.ReadAsync(buffer, offset, buffer.Length - offset, cts.Token).ConfigureAwait(false)) > 0)
+				offset += count;
+			return offset;
+		}
+
+		void DequeueBuffers()
+		{
+			lock (bufferDequeueLock)
+			{
+				// Check for any processed buffers, and dequeue them for reuse.
+				int buffersProcessed;
+				AL10.alGetSourcei(Source, AL10.AL_BUFFERS_PROCESSED, out buffersProcessed);
+				for (var i = 0; i < buffersProcessed; i++)
+				{
+					// Dequeue a processed buffer, so we can reuse it.
+					var dequeued = 0U;
+					AL10.alSourceUnqueueBuffers(Source, new IntPtr(1), ref dequeued);
+					freeBuffers.Push(dequeued);
+
+					// When we remove a buffer, we need to account for this to calculate the overall seek position.
+					// The final buffer in the track may be shorter then BufferSizeInSecs, so we'll need to check how
+					// many bytes are actually in each buffer to avoid adding too much at the end.
+					int byteSize;
+					AL10.alGetBufferi(dequeued, AL10.AL_SIZE, out byteSize);
+
+					int bitRate;
+					AL10.alGetBufferi(dequeued, AL10.AL_BITS, out bitRate);
+
+					totalSamplesPlayed += byteSize / (bitRate / 8);
+				}
+			}
+		}
+
+		public override void Stop()
+		{
+			lock (cts)
+			{
+				StopSource();
+				cts.Cancel();
+			}
+
+			try
+			{
+				streamTask.Wait();
+			}
+			catch (AggregateException)
+			{
+			}
+		}
+
+		public override float SeekPosition
+		{
+			get
+			{
+				// Stop buffers being dequeued whilst we calculate the seek position.
+				lock (bufferDequeueLock)
+				{
+					int sampleOffset;
+					AL10.alGetSourcei(Source, AL11.AL_SAMPLE_OFFSET, out sampleOffset);
+
+					int state;
+					AL10.alGetSourcei(Source, AL10.AL_SOURCE_STATE, out state);
+
+					// If the source is not stopped, add the current offset to the total offset and return that.
+					if (state != AL10.AL_STOPPED)
+						return (sampleOffset + totalSamplesPlayed) / SampleRate;
+
+					// If the source stopped, the current offset will have been reset to 0.
+					// We'll need to dequeue any buffers played first and then return the total.
+					DequeueBuffers();
+					return totalSamplesPlayed / SampleRate;
+				}
+			}
+		}
+
+		public override bool Complete
+		{
+			get { return streamTask.IsCompleted; }
 		}
 	}
 }


### PR DESCRIPTION
Fixes #8593.

Music is now streamed! Changing music tracks no longer causes a lag spike or freezes the UI.

- Adds support for streaming in our audio engine via `Play2DStream`.
- Our sound manager now chooses to stream music, rather than caching it fully in memory (other sounds still use the caching mechanism).
- `AudFormat` is updated to support streaming, rather than having to load all the data into memory and expose a `MemoryStream`.

While testing, please listen out for:
- Choppy music (e.g. gaps in playback)
- Glitchy music (e.g. the music track seems to skip backwards a second or two and replay itself)
- Incorrect music (e.g. you try playing a music track and it plays another sound effect instead)

Other things to note:
- When you play a music track, it may take a few seconds to start. This is normal.
- If you switch music tracks several times really quickly, you will still be able to freeze the UI. This is a known limitation.

Finally, it would probably be worth also updating `VocFormat` and `WavFormat` in a similar way to support streaming audio - otherwise those formats won't benefit. Once my brain is less fried I may get to it.