### PR TITLE
Add weapon strafing support and implement it on RA Yak

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -39,6 +39,12 @@ namespace OpenRA.GameRules
 		[Desc("The maximum range the weapon can fire.")]
 		public readonly WDist Range = WDist.Zero;
 
+		[Desc("First burst is aimed at this offset relative to target position.")]
+		public readonly WVec FirstBurstTargetOffset = WVec.Zero;
+
+		[Desc("Each burst after the first lands by this offset away from the previous burst.")]
+		public readonly WVec FollowingBurstTargetOffset = WVec.Zero;
+
 		[Desc("The sound played each time the weapon is fired.")]
 		public readonly string[] Report = null;
 

--- a/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class AttackBomber : AttackBase, ITick, ISync, INotifyRemovedFromWorld
 	{
-		AttackBomberInfo info;
+		readonly AttackBomberInfo info;
 		[Sync] Target target;
 		[Sync] bool inAttackRange;
 		[Sync] bool facingTarget = true;
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 		}
 
-		public void Tick(Actor self)
+		void ITick.Tick(Actor self)
 		{
 			var bombHeight = self.World.Map.DistanceAboveTerrain(self.CenterPosition);
 			var bombTarget = Target.FromPos(self.CenterPosition - new WVec(WDist.Zero, WDist.Zero, bombHeight));
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void SetTarget(World w, WPos pos) { target = Target.FromPos(pos); }
 
-		public void RemovedFromWorld(Actor self)
+		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
 		{
 			OnRemovedFromWorld(self);
 		}

--- a/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
@@ -18,11 +18,6 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public class AttackBomberInfo : AttackBaseInfo
 	{
-		[Desc("Armament name")]
-		public readonly string Bombs = "primary";
-
-		[Desc("Armament name")]
-		public readonly string Guns = "secondary";
 		public readonly int FacingTolerance = 2;
 
 		public override object Create(ActorInitializer init) { return new AttackBomber(init.Self, this); }
@@ -47,8 +42,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ITick.Tick(Actor self)
 		{
-			var bombHeight = self.World.Map.DistanceAboveTerrain(self.CenterPosition);
-			var bombTarget = Target.FromPos(self.CenterPosition - new WVec(WDist.Zero, WDist.Zero, bombHeight));
+			var dat = self.World.Map.DistanceAboveTerrain(target.CenterPosition);
+			target = Target.FromPos(target.CenterPosition - new WVec(WDist.Zero, WDist.Zero, dat));
 			var wasInAttackRange = inAttackRange;
 			var wasFacingTarget = facingTarget;
 
@@ -59,30 +54,13 @@ namespace OpenRA.Mods.Common.Traits
 			var facingToTarget = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : f;
 			facingTarget = Math.Abs(facingToTarget - f) % 256 <= info.FacingTolerance;
 
-			// Bombs drop anywhere in range
-			foreach (var a in Armaments.Where(a => a.Info.Name == info.Bombs))
+			foreach (var a in Armaments)
 			{
 				if (!target.IsInRange(self.CenterPosition, a.MaxRange()))
 					continue;
 
 				inAttackRange = true;
-				a.CheckFire(self, facing, bombTarget);
-			}
-
-			// Guns only fire when approaching the target
-			if (facingTarget)
-			{
-				foreach (var a in Armaments.Where(a => a.Info.Name == info.Guns))
-				{
-					if (!target.IsInRange(self.CenterPosition, a.MaxRange()))
-						continue;
-
-					inAttackRange = true;
-
-					var gunPos = self.CenterPosition - new WVec(0, a.MaxRange().Length / 2, 0).Rotate(WRot.FromFacing(f));
-					var gunHeight = self.World.Map.DistanceAboveTerrain(gunPos);
-					a.CheckFire(self, facing, Target.FromPos(gunPos - new WVec(WDist.Zero, WDist.Zero, gunHeight)));
-				}
+				a.CheckFire(self, facing, target);
 			}
 
 			// Actors without armaments may want to trigger an action when it passes the target

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -113,6 +113,8 @@ namespace OpenRA.Mods.Common.Traits
 		IEnumerable<int> damageModifiers;
 		IEnumerable<int> inaccuracyModifiers;
 
+		int ticksSinceLastShot;
+
 		List<Pair<int, Action>> delayedActions = new List<Pair<int, Action>>();
 
 		public WDist Recoil;
@@ -169,6 +171,9 @@ namespace OpenRA.Mods.Common.Traits
 			if (IsTraitDisabled)
 				return;
 
+			if (ticksSinceLastShot < Weapon.ReloadDelay)
+				++ticksSinceLastShot;
+
 			if (FireDelay > 0)
 				--FireDelay;
 
@@ -220,6 +225,11 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (!Weapon.IsValidAgainst(target, self.World, self))
 				return null;
+
+			if (ticksSinceLastShot >= Weapon.ReloadDelay)
+				Burst = Weapon.Burst;
+
+			ticksSinceLastShot = 0;
 
 			var barrel = Barrels[Burst % Barrels.Length];
 			Func<WPos> muzzlePosition = () => self.CenterPosition + MuzzleOffset(self, barrel);

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -225,6 +225,23 @@ namespace OpenRA.Mods.Common.Traits
 			Func<WPos> muzzlePosition = () => self.CenterPosition + MuzzleOffset(self, barrel);
 			var legacyFacing = MuzzleOrientation(self, barrel).Yaw.Angle / 4;
 
+			var passiveTarget = Weapon.TargetActorCenter ? target.CenterPosition : target.Positions.PositionClosestTo(muzzlePosition());
+			var initialOffset = Weapon.FirstBurstTargetOffset;
+			if (initialOffset != WVec.Zero)
+			{
+				// We want this to match Armament.LocalOffset, so we need to convert it to forward, right, up
+				initialOffset = new WVec(initialOffset.Y, -initialOffset.X, initialOffset.Z);
+				passiveTarget += initialOffset.Rotate(WRot.FromFacing(legacyFacing));
+			}
+
+			var followingOffset = Weapon.FollowingBurstTargetOffset;
+			if (followingOffset != WVec.Zero)
+			{
+				// We want this to match Armament.LocalOffset, so we need to convert it to forward, right, up
+				followingOffset = new WVec(followingOffset.Y, -followingOffset.X, followingOffset.Z);
+				passiveTarget += ((Weapon.Burst - Burst) * followingOffset).Rotate(WRot.FromFacing(legacyFacing));
+			}
+
 			var args = new ProjectileArgs
 			{
 				Weapon = Weapon,
@@ -239,7 +256,7 @@ namespace OpenRA.Mods.Common.Traits
 				Source = muzzlePosition(),
 				CurrentSource = muzzlePosition,
 				SourceActor = self,
-				PassiveTarget = Weapon.TargetActorCenter ? target.CenterPosition : target.Positions.PositionClosestTo(muzzlePosition()),
+				PassiveTarget = passiveTarget,
 				GuidedTarget = target
 			};
 

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -829,6 +829,22 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						node.Key = "UseTargetableCellsOffsets";
 				}
 
+				// Refactored AttackBomb so it doesn't need it's own special sauce anymore
+				if (engineVersion < 20170713)
+				{
+					if (node.Key == "AttackBomber")
+					{
+						var gunsOrBombs = node.Value.Nodes.FirstOrDefault(n => n.Key == "Guns" || n.Key == "Bombs");
+						if (gunsOrBombs != null)
+						{
+							Console.WriteLine("Hardcoded Guns and Bombs logic has been removed from AttackBomber.");
+							Console.WriteLine("Bombs should work like usual, for gun strafing use the new Weapon TargetOffset modifiers.");
+							Console.WriteLine("Look at the TD mod's A10 for an example.");
+							node.Value.Nodes.RemoveAll(n => n.Key == "Guns" || n.Key == "Bombs");
+						}
+					}
+				}
+
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -205,8 +205,6 @@ A10:
 		Repulsable: False
 	AttackBomber:
 		Armaments: gun, bombs
-		Guns: gun
-		Bombs: bombs
 	Armament@GUNS:
 		Name: gun
 		Weapon: Vulcan

--- a/mods/cnc/weapons/other.yaml
+++ b/mods/cnc/weapons/other.yaml
@@ -78,6 +78,7 @@ Napalm:
 		Damage: 30
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
+			Wood: 65
 			Heavy: 80
 	Warhead@3Eff: CreateEffect
 		Explosions: med_napalm

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -36,7 +36,12 @@ HighV:
 
 Vulcan:
 	Inherits: ^HeavyMG
-	ReloadDelay: 2
+	Range: 8c0
+	Burst: 9
+	BurstDelay: 2
+	FirstBurstTargetOffset: -2984,0,0
+	FollowingBurstTargetOffset: 746,0,0
+	ReloadDelay: 125
 	Report: gun5.aud
 	Warhead@1Dam: SpreadDamage
 		Spread: 426

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -186,9 +186,9 @@ YAK:
 		TargetWhenDamaged: false
 		EnableStances: false
 	AmmoPool:
-		Ammo: 18
-		PipCount: 6
-		ReloadDelay: 11
+		Ammo: 20
+		PipCount: 5
+		ReloadDelay: 10
 	ReturnOnIdle:
 	SelectionDecorations:
 		VisualBounds: 30,28,0,2

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -164,12 +164,12 @@ YAK:
 		Range: 9c0
 		Type: GroundPosition
 	Armament@PRIMARY:
-		Weapon: ChainGun.Yak
+		Weapon: ChainGun.Yak.Left
 		LocalOffset: 256,-213,0
 		MuzzleSequence: muzzle
 	Armament@SECONDARY:
 		Name: secondary
-		Weapon: ChainGun.Yak
+		Weapon: ChainGun.Yak.Right
 		LocalOffset: 256,213,0
 		MuzzleSequence: muzzle
 	AttackPlane:

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -214,6 +214,11 @@ ChainGun.Yak.Right:
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Damage: 40
+		Spread: 171
+		Versus:
+			None: 125
+			Light: 70
+			Heavy: 28
 
 ChainGun.Yak.Left:
 	Inherits: ChainGun.Yak.Right

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -23,8 +23,8 @@
 ZSU-23:
 	Inherits: ^AACannon
 	Burst: 2
-	BurstDelay: 5
-	ReloadDelay: 0
+	BurstDelay: 0
+	ReloadDelay: 5
 	Range: 10c0
 	Projectile: Bullet
 		Speed: 3c340

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -201,15 +201,23 @@ ChainGun:
 		Versus:
 			None: 120
 
-ChainGun.Yak:
+ChainGun.Yak.Right:
 	Inherits: ^HeavyMG
-	ReloadDelay: 3
-	Range: 5c0
-	MinRange: 3c0
+	Burst: 5
+	FirstBurstTargetOffset: -684,213,0
+	FollowingBurstTargetOffset: 342,0,0
+	BurstDelay: 2
+	ReloadDelay: 10
+	Range: 5c6
+	MinRange: 3c420
 	Projectile: Bullet
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Damage: 40
+
+ChainGun.Yak.Left:
+	Inherits: ChainGun.Yak.Right
+	FirstBurstTargetOffset: -684,-213,0
 
 Pistol:
 	Inherits: ^LightMG

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -13,9 +13,9 @@ ParaBomb:
 		Damage: 300
 		Versus:
 			None: 30
-			Wood: 75
+			Wood: 40
 			Light: 75
-			Concrete: 50
+			Concrete: 25
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -7,6 +7,7 @@ ParaBomb:
 		OpenSequence: open
 		Velocity: 0, 0, -86
 		Acceleration: 0, 0, 0
+		Shadow: True
 	Warhead@1Dam: SpreadDamage
 		Spread: 768
 		Damage: 300


### PR DESCRIPTION
This has been overdue in my opinion.

Modifying the targeted offset per burst is by far the easiest approach compared to modifying Attack traits or projectiles.

Closes #2642.
Fixes #2730.