### PR TITLE
ExternalCaptures Type filter YAML fix up

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -215,7 +215,7 @@ E6:
 	EngineerRepair:
 	RepairsBridges:
 	ExternalCaptures:
-		Type: building
+		CaptureTypes: building
 		PlayerExperience: 25
 	Voiced:
 		VoiceSet: EngineerVoice


### PR DESCRIPTION
In ExternalCaptures.cs, the Type became CaptureTypes but in YAML it wasn't up to date in RA mod. Examined all uses of ExternalCaptures traits and E6 was the only place that needed the fix.