### PR TITLE
Fix GetSupportDir not returning an absolute path

### DIFF
--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -70,8 +70,9 @@ namespace OpenRA
 		static string GetSupportDir()
 		{
 			// Use a local directory in the game root if it exists
-			if (Directory.Exists("Support"))
-				return "Support" + Path.DirectorySeparatorChar;
+			var supportDir = Path.Combine(GameDir, "Support");
+			if (Directory.Exists(supportDir))
+				return supportDir + Path.DirectorySeparatorChar;
 
 			var dir = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
 


### PR DESCRIPTION
Current bleed crashes with a misleading exception when using a Support dir. This fixes it.

```
Exception of type `System.ArgumentException`: Second path fragment must not be a drive or UNC name.
Parameter name: path2
  at System.IO.Path.InternalCombine (System.String path1, System.String path2) [0x00058] in <a07d6bf484a54da2861691df910339b1>:0 
  at System.IO.FileSystemEnumerableIterator`1[TSource].CommonInit () [0x00000] in <a07d6bf484a54da2861691df910339b1>:0 
  at System.IO.FileSystemEnumerableIterator`1[TSource]..ctor (System.String path, System.String originalUserPath, System.String searchPattern, System.IO.SearchOption searchOption, System.IO.SearchResultHandler`1[TSource] resultHandler, System.Boolean checkHost) [0x000d6] in <a07d6bf484a54da2861691df910339b1>:0 
  at System.IO.FileSystemEnumerableFactory.CreateFileNameIterator (System.String path, System.String originalUserPath, System.String searchPattern, System.Boolean includeFiles, System.Boolean includeDirs, System.IO.SearchOption searchOption, System.Boolean checkHost) [0x00009] in <a07d6bf484a54da2861691df910339b1>:0 
  at System.IO.Directory.InternalGetFileDirectoryNames (System.String path, System.String userPathOriginal, System.String searchPattern, System.Boolean includeFiles, System.Boolean includeDirs, System.IO.SearchOption searchOption, System.Boolean checkHost) [0x00000] in <a07d6bf484a54da2861691df910339b1>:0 
  at System.IO.Directory.InternalGetFiles (System.String path, System.String searchPattern, System.IO.SearchOption searchOption) [0x00000] in <a07d6bf484a54da2861691df910339b1>:0 
  at System.IO.Directory.GetFiles (System.String path, System.String searchPattern) [0x0001c] in <a07d6bf484a54da2861691df910339b1>:0 
  at OpenRA.ExternalMods..ctor (System.String launchPath) [0x00099] in /home/oliver/devel/openra/git/OpenRA.Game/ExternalMods.cs:58 
  at OpenRA.Game.Initialize (OpenRA.Arguments args) [0x003e6] in /home/oliver/devel/openra/git/OpenRA.Game/Game.cs:342 
  at OpenRA.Program.Run (System.String[] args) [0x00007] in /home/oliver/devel/openra/git/OpenRA.Game/Support/Program.cs:134 
  at OpenRA.Program.Main (System.String[] args) [0x00050] in /home/oliver/devel/openra/git/OpenRA.Game/Support/Program.cs:40 
```