### PR TITLE
Cache trait look-ups in Armament

### DIFF
--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -107,6 +107,7 @@ namespace OpenRA.Mods.Common.Traits
 		Turreted turret;
 		AmmoPool ammoPool;
 		BodyOrientation coords;
+		INotifyBurstComplete[] notifyBurstComplete;
 		IEnumerable<int> rangeModifiers;
 		List<Pair<int, Action>> delayedActions = new List<Pair<int, Action>>();
 
@@ -149,6 +150,7 @@ namespace OpenRA.Mods.Common.Traits
 			turret = self.TraitsImplementing<Turreted>().FirstOrDefault(t => t.Name == Info.Turret);
 			ammoPool = self.TraitsImplementing<AmmoPool>().FirstOrDefault(la => la.Info.Name == Info.AmmoPoolName);
 			coords = self.Trait<BodyOrientation>();
+			notifyBurstComplete = self.TraitsImplementing<INotifyBurstComplete>().ToArray();
 			rangeModifiers = self.TraitsImplementing<IRangeModifier>().ToArray().Select(m => m.GetRangeModifier());
 
 			base.Created(self);
@@ -281,7 +283,7 @@ namespace OpenRA.Mods.Common.Traits
 					});
 				}
 
-				foreach (var nbc in self.TraitsImplementing<INotifyBurstComplete>())
+				foreach (var nbc in notifyBurstComplete)
 					nbc.FiredBurst(self, target, this);
 			}
 

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -108,6 +108,7 @@ namespace OpenRA.Mods.Common.Traits
 		AmmoPool ammoPool;
 		BodyOrientation coords;
 		INotifyBurstComplete[] notifyBurstComplete;
+		INotifyAttack[] notifyAttacks;
 
 		IEnumerable<int> rangeModifiers;
 		IEnumerable<int> reloadModifiers;
@@ -156,6 +157,7 @@ namespace OpenRA.Mods.Common.Traits
 			ammoPool = self.TraitsImplementing<AmmoPool>().FirstOrDefault(la => la.Info.Name == Info.AmmoPoolName);
 			coords = self.Trait<BodyOrientation>();
 			notifyBurstComplete = self.TraitsImplementing<INotifyBurstComplete>().ToArray();
+			notifyAttacks = self.TraitsImplementing<INotifyAttack>().ToArray();
 
 			rangeModifiers = self.TraitsImplementing<IRangeModifier>().ToArray().Select(m => m.GetRangeModifier());
 			reloadModifiers = self.TraitsImplementing<IReloadModifier>().ToArray().Select(m => m.GetReloadModifier());
@@ -248,7 +250,7 @@ namespace OpenRA.Mods.Common.Traits
 				GuidedTarget = target
 			};
 
-			foreach (var na in self.TraitsImplementing<INotifyAttack>())
+			foreach (var na in notifyAttacks)
 				na.PreparingAttack(self, target, this, barrel);
 
 			ScheduleDelayedAction(Info.FireDelay, () =>
@@ -265,7 +267,7 @@ namespace OpenRA.Mods.Common.Traits
 					if (Burst == args.Weapon.Burst && args.Weapon.StartBurstReport != null && args.Weapon.StartBurstReport.Any())
 						Game.Sound.Play(SoundType.World, args.Weapon.StartBurstReport.Random(self.World.SharedRandom), self.CenterPosition);
 
-					foreach (var na in self.TraitsImplementing<INotifyAttack>())
+					foreach (var na in notifyAttacks)
 						na.Attacking(self, target, this, barrel);
 
 					Recoil = Info.Recoil;


### PR DESCRIPTION
On bleed, a total of six `TraitsImplementing` look-ups were performed for every burst.
Now they're cached at actor creation and only relevant IsEnabled/GetModifier look-ups are performed per shot.
This might save a little performance during heated battles.