### PR TITLE
Refactor targeting of target center and fix pillbox regression

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -69,6 +69,9 @@ namespace OpenRA.GameRules
 		[Desc("The minimum range the weapon can fire.")]
 		public readonly WDist MinRange = WDist.Zero;
 
+		[Desc("Does this weapon aim at the target's center regardless of other targetable offsets?")]
+		public readonly bool TargetActorCenter = false;
+
 		[FieldLoader.LoadUsing("LoadProjectile")]
 		public readonly IProjectileInfo Projectile;
 

--- a/OpenRA.Mods.Cnc/Projectiles/TeslaZap.cs
+++ b/OpenRA.Mods.Cnc/Projectiles/TeslaZap.cs
@@ -36,9 +36,6 @@ namespace OpenRA.Mods.Cnc.Projectiles
 
 		public readonly bool TrackTarget = true;
 
-		[Desc("Ignore any other targetable positions and aim directly at center of target actor.")]
-		public readonly bool TargetCenterPosition = false;
-
 		public IProjectile Create(ProjectileArgs args) { return new TeslaZap(this, args); }
 	}
 
@@ -67,7 +64,7 @@ namespace OpenRA.Mods.Cnc.Projectiles
 
 			// Zap tracks target
 			if (info.TrackTarget && args.GuidedTarget.IsValidFor(args.SourceActor))
-				target = info.TargetCenterPosition ? args.GuidedTarget.CenterPosition : args.GuidedTarget.Positions.PositionClosestTo(args.Source);
+				target = args.Weapon.TargetActorCenter ? args.GuidedTarget.CenterPosition : args.GuidedTarget.Positions.PositionClosestTo(args.Source);
 
 			if (damageDuration-- > 0)
 				args.Weapon.Impact(Target.FromPos(target), args.SourceActor, args.DamageModifiers);

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 			}
 
-			var targetedPosition = attack.Info.AttackTargetCenter ? Target.CenterPosition : Target.Positions.PositionClosestTo(pos);
+			var targetedPosition = attack.GetTargetPosition(pos, Target);
 			var desiredFacing = (targetedPosition - pos).Yaw.Facing;
 			if (facing.Facing != desiredFacing)
 			{

--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -57,9 +57,6 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Does the beam follow the target.")]
 		public readonly bool TrackTarget = false;
 
-		[Desc("Ignore any other targetable positions and aim directly at center of target actor.")]
-		public readonly bool TargetCenterPosition = false;
-
 		[Desc("Should the beam be visually rendered? False = Beam is invisible.")]
 		public readonly bool RenderBeam = true;
 
@@ -160,7 +157,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			if (args.GuidedTarget.IsValidFor(args.SourceActor))
 			{
-				var guidedTargetPos = info.TargetCenterPosition ? args.GuidedTarget.CenterPosition : args.GuidedTarget.Positions.PositionClosestTo(args.Source);
+				var guidedTargetPos = args.Weapon.TargetActorCenter ? args.GuidedTarget.CenterPosition : args.GuidedTarget.Positions.PositionClosestTo(args.Source);
 				var targetDistance = new WDist((guidedTargetPos - args.Source).Length);
 
 				// Only continue tracking target if it's within weapon range +

--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -21,9 +21,6 @@ namespace OpenRA.Mods.Common.Projectiles
 	[Desc("Simple, invisible, usually direct-on-target projectile.")]
 	public class InstantHitInfo : IProjectileInfo, IRulesetLoaded<WeaponInfo>
 	{
-		[Desc("Apply warheads directly to center of target actor.")]
-		public readonly bool TargetCenterPosition = false;
-
 		[Desc("Maximum offset at the maximum range.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
 
@@ -60,9 +57,9 @@ namespace OpenRA.Mods.Common.Projectiles
 			this.info = info;
 			source = args.Source;
 
-			if (info.TargetCenterPosition)
+			if (args.Weapon.TargetActorCenter)
 				target = args.GuidedTarget;
-			else if (!info.TargetCenterPosition && info.Inaccuracy.Length > 0)
+			else if (info.Inaccuracy.Length > 0)
 			{
 				var inaccuracy = Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
 				var maxOffset = inaccuracy * (args.PassiveTarget - source).Length / args.Weapon.Range.Length;

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -49,9 +49,6 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Beam can be blocked.")]
 		public readonly bool Blockable = false;
 
-		[Desc("Ignore any other targetable positions and aim directly at center of target actor.")]
-		public readonly bool TargetCenterPosition = false;
-
 		[Desc("Draw a second beam (for 'glow' effect).")]
 		public readonly bool SecondaryBeam = false;
 
@@ -131,7 +128,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		{
 			// Beam tracks target
 			if (info.TrackTarget && args.GuidedTarget.IsValidFor(args.SourceActor))
-				target = info.TargetCenterPosition ? args.GuidedTarget.CenterPosition : args.GuidedTarget.Positions.PositionClosestTo(source);
+				target = args.Weapon.TargetActorCenter ? args.GuidedTarget.CenterPosition : args.GuidedTarget.Positions.PositionClosestTo(source);
 
 			// Check for blocking actors
 			WPos blockedPos;

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -137,9 +137,6 @@ namespace OpenRA.Mods.Common.Projectiles
 			"the missile enters the radius of the current speed around the target.")]
 		public readonly bool AllowSnapping = false;
 
-		[Desc("Ignore any other targetable positions and aim directly at center of target actor.")]
-		public readonly bool TargetCenterPosition = false;
-
 		[Desc("Explodes when inside this proximity radius to target.",
 			"Note: If this value is lower than the missile speed, this check might",
 			"not trigger fast enough, causing the missile to fly past the target.")]
@@ -802,7 +799,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			// Check if target position should be updated (actor visible & locked on)
 			var newTarPos = targetPosition;
 			if (args.GuidedTarget.IsValidFor(args.SourceActor) && lockOn)
-				newTarPos = (info.TargetCenterPosition ? args.GuidedTarget.CenterPosition : args.GuidedTarget.Positions.PositionClosestTo(args.Source))
+				newTarPos = (args.Weapon.TargetActorCenter ? args.GuidedTarget.CenterPosition : args.GuidedTarget.Positions.PositionClosestTo(args.Source))
 					+ new WVec(WDist.Zero, WDist.Zero, info.AirburstAltitude);
 
 			// Compute target's predicted velocity vector (assuming uniform circular motion)

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -102,8 +102,6 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly Barrel[] Barrels;
 
 		readonly Actor self;
-		readonly AttackBase[] attackTraits;
-		AttackBase attack;
 		Turreted turret;
 		AmmoPool ammoPool;
 		BodyOrientation coords;
@@ -143,7 +141,6 @@ namespace OpenRA.Mods.Common.Traits
 				barrels.Add(new Barrel { Offset = WVec.Zero, Yaw = WAngle.Zero });
 
 			Barrels = barrels.ToArray();
-			attackTraits = self.TraitsImplementing<AttackBase>().Where(a => a.Info.Armaments.Contains(Info.Name)).ToArray();
 		}
 
 		public virtual WDist MaxRange()
@@ -206,10 +203,6 @@ namespace OpenRA.Mods.Common.Traits
 		// The world coordinate model uses Actor.Orientation
 		public virtual Barrel CheckFire(Actor self, IFacing facing, Target target)
 		{
-			attack = attackTraits.FirstOrDefault(Exts.IsTraitEnabled);
-			if (attack == null)
-				return null;
-
 			if (IsReloading)
 				return null;
 
@@ -246,7 +239,7 @@ namespace OpenRA.Mods.Common.Traits
 				Source = muzzlePosition(),
 				CurrentSource = muzzlePosition,
 				SourceActor = self,
-				PassiveTarget = attack.Info.AttackTargetCenter ? target.CenterPosition : target.Positions.PositionClosestTo(muzzlePosition()),
+				PassiveTarget = Weapon.TargetActorCenter ? target.CenterPosition : target.Positions.PositionClosestTo(muzzlePosition()),
 				GuidedTarget = target
 			};
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -198,7 +198,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public abstract Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack);
 
-		public bool HasAnyValidWeapons(Target t)
+		public bool HasAnyValidWeapons(Target t, bool checkForCenterTargetingWeapons = false)
 		{
 			if (IsTraitDisabled)
 				return false;
@@ -209,25 +209,8 @@ namespace OpenRA.Mods.Common.Traits
 			// PERF: Avoid LINQ.
 			foreach (var armament in Armaments)
 			{
-				if (!armament.OutOfAmmo && armament.Weapon.IsValidAgainst(t, self.World, self))
-					return true;
-			}
-
-			return false;
-		}
-
-		public bool HasAnyValidCenterTargetingWeapons(Target t)
-		{
-			if (IsTraitDisabled)
-				return false;
-
-			if (Info.AttackRequiresEnteringCell && (positionable == null || !positionable.CanEnterCell(t.Actor.Location, null, false)))
-				return false;
-
-			// PERF: Avoid LINQ.
-			foreach (var armament in Armaments)
-			{
-				if (armament.Weapon.TargetActorCenter && armament.Weapon.IsValidAgainst(t, self.World, self))
+				var checkIsValid = checkForCenterTargetingWeapons ? armament.Weapon.TargetActorCenter : !armament.OutOfAmmo;
+				if (checkIsValid && armament.Weapon.IsValidAgainst(t, self.World, self))
 					return true;
 			}
 
@@ -236,7 +219,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual WPos GetTargetPosition(WPos pos, Target target)
 		{
-			return HasAnyValidCenterTargetingWeapons(target) ? target.CenterPosition : target.Positions.PositionClosestTo(pos);
+			return HasAnyValidWeapons(target, true) ? target.CenterPosition : target.Positions.PositionClosestTo(pos);
 		}
 
 		public WDist GetMinimumRange()

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var f = facing.Facing;
 			var pos = self.CenterPosition;
-			var targetedPosition = Info.AttackTargetCenter ? target.CenterPosition : target.Positions.PositionClosestTo(pos);
+			var targetedPosition = GetTargetPosition(pos, target);
 			var delta = targetedPosition - pos;
 			var facingToTarget = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : f;
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -146,7 +146,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			var pos = self.CenterPosition;
-			var targetedPosition = Info.AttackTargetCenter ? target.CenterPosition : target.Positions.PositionClosestTo(pos);
+			var targetedPosition = GetTargetPosition(pos, target);
 			var targetYaw = (targetedPosition - pos).Yaw;
 
 			foreach (var a in Armaments)

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -131,7 +131,7 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			var pos = self.CenterPosition;
-			var targetPos = attack != null && attack.Info.AttackTargetCenter ? target.CenterPosition : target.Positions.PositionClosestTo(pos);
+			var targetPos = attack != null ? attack.GetTargetPosition(pos, target) : target.CenterPosition;
 			var delta = targetPos - pos;
 			DesiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : TurretFacing;
 			MoveTurret();

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -156,7 +156,6 @@ ARTY:
 		LocalOffset: 624,0,208
 		MuzzleSequence: muzzle
 	AttackFrontal:
-		AttackTargetCenter: true
 	WithMuzzleOverlay:
 	AutoTarget:
 		InitialStanceAI: Defend
@@ -473,7 +472,6 @@ MSAM:
 		Weapon: 227mm
 		LocalOffset: 213,-128,0, 213,128,0
 	AttackFrontal:
-		AttackTargetCenter: true
 	WithSpriteTurret:
 		AimSequence: aim
 	SpawnActorOnDeath:

--- a/mods/cnc/weapons/ballistics.yaml
+++ b/mods/cnc/weapons/ballistics.yaml
@@ -64,6 +64,7 @@ ArtilleryShell:
 	Range: 11c0
 	MinRange: 3c0
 	Report: tnkfire2.aud
+	TargetActorCenter: true
 	Projectile: Bullet
 		Speed: 204
 		Blockable: false

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -142,6 +142,7 @@ MammothMissiles:
 	BurstDelay: 4
 	Report: rocket1.aud
 	ValidTargets: Ground
+	TargetActorCenter: true
 	Projectile: Bullet
 		Inaccuracy: 853
 		LaunchAngle: 62

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -113,7 +113,6 @@ MSUB:
 		LocalOffset: 0,-171,0, 0,171,0
 		FireDelay: 2
 	AttackFrontal:
-		AttackTargetCenter: true
 	SelectionDecorations:
 		VisualBounds: 44,44
 	AutoTarget:
@@ -226,7 +225,6 @@ CA:
 		RecoilRecovery: 34
 		MuzzleSequence: muzzle
 	AttackTurreted:
-		AttackTargetCenter: true
 	WithMuzzleOverlay:
 	SelectionDecorations:
 		VisualBounds: 44,44

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -243,7 +243,6 @@ ARTY:
 		LocalOffset: 624,0,208
 		MuzzleSequence: muzzle
 	AttackFrontal:
-		AttackTargetCenter: true
 	WithMuzzleOverlay:
 	Explodes:
 		Weapon: ArtilleryExplode

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -106,6 +106,7 @@ TurretGun:
 	Inherits: ^Artillery
 	MinRange: 3c0
 	Report: tank5.aud
+	TargetActorCenter: true
 	Projectile: Bullet
 		ContrailLength: 30
 
@@ -116,6 +117,7 @@ TurretGun:
 	Range: 16c0
 	Burst: 2
 	Report: turret1.aud
+	TargetActorCenter: true
 	Projectile: Bullet
 		Inaccuracy: 2c938
 		ContrailLength: 30

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -295,6 +295,7 @@ TorpTube:
 SubMissile:
 	Inherits: ^SubMissileDefault
 	Range: 16c0
+	TargetActorCenter: true
 	-Projectile:
 	Projectile: Bullet
 		Speed: 162

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -357,7 +357,6 @@ JUGG:
 		Voice: Attack
 		Armaments: deployed
 		RequiresCondition: deployed
-		AttackTargetCenter: true
 	Armament@deployed:
 		Name: deployed
 		Turret: deployed

--- a/mods/ts/weapons/ballisticweapons.yaml
+++ b/mods/ts/weapons/ballisticweapons.yaml
@@ -98,6 +98,7 @@ RPGTower:
 	Inherits: ^ArtilleryWeapon
 	ReloadDelay: 110
 	Range: 18c0
+	TargetActorCenter: true
 	Projectile: Bullet
 		Speed: 384
 		LaunchAngle: 165
@@ -117,6 +118,7 @@ Jugg90mm:
 	BurstDelay: 3
 	-Report:
 	StartBurstReport: jugger1.aud
+	TargetActorCenter: true
 	Projectile: Bullet
 		Speed: 384
 		LaunchAngle: 165

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -200,8 +200,8 @@ TurretLaserFire:
 		Damage: 30
 
 LaserFence:
+	TargetActorCenter: true
 	Projectile: InstantHit
-		TargetCenterPosition: true
 	Warhead@1Dam: TargetDamage
 		DebugOverlayColor: FF0000
 		Damage: 99999

--- a/mods/ts/weapons/healweapons.yaml
+++ b/mods/ts/weapons/healweapons.yaml
@@ -3,8 +3,8 @@
 	Range: 2c849
 	Report: healer1.aud
 	ValidTargets: Infantry
+	TargetActorCenter: true
 	Projectile: InstantHit
-		TargetCenterPosition: true
 	Warhead@1Dam: TargetDamage
 		DebugOverlayColor: 00FF00
 		Damage: -50

--- a/mods/ts/weapons/otherweapons.yaml
+++ b/mods/ts/weapons/otherweapons.yaml
@@ -28,6 +28,7 @@ Bomb:
 	Burst: 5
 	BurstDelay: 6
 	Range: 2c512
+	TargetActorCenter: true
 	Projectile: GravityBomb
 		Velocity: 72, 0, -90
 		Acceleration: 0, 0, -8


### PR DESCRIPTION
Pillboxes (and possibly other actors in external mods) themselves don't have an Attack* trait, so the previous approach would prevent them from working.

Update: Refactored #13497 due to 

> Would this be a good enough reason add AttackTargetCenter to WeaponInfo instead, and replace the other uses with that? Having separate flags on AttackBase vs the projectiles still doesn't sit well with me.

(which I agree with anyway, the old approach was only taken to avoid an additional projectile arg).