### PR TITLE
AttackFrontal's FacingTolerance is now in effect

### DIFF
--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -29,6 +29,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly IFacing facing;
 		readonly IPositionable positionable;
 		readonly bool forceAttack;
+		readonly int facingTolerance;
 
 		WDist minRange;
 		WDist maxRange;
@@ -36,11 +37,12 @@ namespace OpenRA.Mods.Common.Activities
 		Activity moveActivity;
 		AttackStatus attackStatus = AttackStatus.UnableToAttack;
 
-		public Attack(Actor self, Target target, bool allowMovement, bool forceAttack)
+		public Attack(Actor self, Target target, bool allowMovement, bool forceAttack, int facingTolerance)
 		{
 			Target = target;
 
 			this.forceAttack = forceAttack;
+			this.facingTolerance = facingTolerance;
 
 			attackTraits = self.TraitsImplementing<AttackBase>().ToArray();
 			facing = self.Trait<IFacing>();
@@ -117,7 +119,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			var targetedPosition = attack.GetTargetPosition(pos, Target);
 			var desiredFacing = (targetedPosition - pos).Yaw.Facing;
-			if (facing.Facing != desiredFacing)
+			if (!Util.FacingWithinTolerance(facing.Facing, desiredFacing, facingTolerance))
 			{
 				attackStatus |= AttackStatus.NeedsToTurn;
 				turnActivity = ActivityUtils.SequenceActivities(new Turn(self, desiredFacing), this);

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
@@ -18,7 +18,13 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Unit got to face the target")]
 	public class AttackFrontalInfo : AttackBaseInfo, Requires<IFacingInfo>
 	{
-		public readonly int FacingTolerance = 1;
+		public readonly int FacingTolerance = 0;
+
+		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
+		{
+			if (FacingTolerance < 0 || FacingTolerance > 128)
+				throw new YamlException("Facing tolerance must be in range of [0, 128], 128 covers 360 degrees.");
+		}
 
 		public override object Create(ActorInitializer init) { return new AttackFrontal(init.Self, this); }
 	}
@@ -38,21 +44,19 @@ namespace OpenRA.Mods.Common.Traits
 			if (!base.CanAttack(self, target))
 				return false;
 
-			var f = facing.Facing;
 			var pos = self.CenterPosition;
 			var targetedPosition = GetTargetPosition(pos, target);
 			var delta = targetedPosition - pos;
-			var facingToTarget = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : f;
 
-			if (Math.Abs(facingToTarget - f) % 256 > info.FacingTolerance)
-				return false;
+			if (delta.HorizontalLengthSquared == 0)
+				return true;
 
-			return true;
+			return Util.FacingWithinTolerance(facing.Facing, delta.Yaw.Facing, info.FacingTolerance);
 		}
 
 		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack)
 		{
-			return new Activities.Attack(self, newTarget, allowMove, forceAttack);
+			return new Activities.Attack(self, newTarget, allowMove, forceAttack, info.FacingTolerance);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -85,6 +85,15 @@ namespace OpenRA.Mods.Common
 			return negative == 0 ? 0 : 256 - negative;
 		}
 
+		public static bool FacingWithinTolerance(int facing, int desiredFacing, int facingTolerance)
+		{
+			if (facingTolerance == 0 && facing == desiredFacing)
+				return true;
+
+			var delta = Util.NormalizeFacing(desiredFacing - facing);
+			return delta <= facingTolerance || delta >= 256 - facingTolerance;
+		}
+
 		public static WPos BetweenCells(World w, CPos from, CPos to)
 		{
 			var fromPos = from.Layer == 0 ? w.Map.CenterOfCell(from) :


### PR DESCRIPTION
FacingTolerance didn't work as expected. Add new facing check code to make it work.

* Allows modders to make cool units that don't need to turn when attacking: https://www.youtube.com/watch?v=kgPlmc85i6Y

* There's a catch though. If the unit is facing North (facing 0)  and ordered to attack NorthEast (Facing =~ 230) it will turn due to "wrong" condition, as their absolute difference is big. I copy pasted this condition from AttackFrontal.cs:CanAttack() facing check code so if this seems wrong that should be fixed as well.

* I'm wondering why the default value for FacingTolerance is 1, when it is effectively 0. Unless there's a good reason I wish to make it 0 and make the facing check condition simpler. (rather than <= 1, I want to make it != 0.)