### PR TITLE
Replace the wrong CURRENTENGINE description by OLDENGINE

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeMapCommand.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			map.Save(package);
 		}
 
-		[Desc("MAP", "CURRENTENGINE", "Upgrade map rules to the latest engine version.")]
+		[Desc("MAP", "OLDENGINE", "Upgrade map rules to the latest engine version.")]
 		void IUtilityCommand.Run(Utility utility, string[] args)
 		{
 			// HACK: The engine code assumes that Game.modData is set.

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			}
 		}
 
-		[Desc("CURRENTENGINE", "Upgrade mod rules to the latest engine version.")]
+		[Desc("OLDENGINE", "Upgrade mod rules to the latest engine version.")]
 		void IUtilityCommand.Run(Utility utility, string[] args)
 		{
 			// HACK: The engine code assumes that Game.modData is set.


### PR DESCRIPTION
`CURRENTENGINE` was misleading, as you actually have to enter the version of the old engine your updating the map or mod from.

Note to self: We might want to update documentation once/if this is merged.