### PR TITLE
Upgraded PixelDouble to selectable PixelScale

### DIFF
--- a/OpenRA.Game/Graphics/CursorProvider.cs
+++ b/OpenRA.Game/Graphics/CursorProvider.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Graphics
 			Cursors = cursors.AsReadOnly();
 		}
 
-		public static bool CursorViewportZoomed { get { return Game.Settings.Graphics.CursorDouble && Game.Settings.Graphics.PixelDouble; } }
+		public static float CursorViewportZoomed { get { return Game.Settings.Graphics.CursorScale ? Game.Settings.Graphics.PixelScale : 1; } }
 
 		public bool HasCursorSequence(string cursor)
 		{

--- a/OpenRA.Game/Graphics/SoftwareCursor.cs
+++ b/OpenRA.Game/Graphics/SoftwareCursor.cs
@@ -78,11 +78,9 @@ namespace OpenRA.Graphics
 
 			var cursorSequence = cursorProvider.GetCursorSequence(cursorName);
 			var cursorSprite = sprites[cursorName][((int)cursorFrame % cursorSequence.Length)];
-			var cursorSize = CursorProvider.CursorViewportZoomed ? 2.0f * cursorSprite.Size : cursorSprite.Size;
+			var cursorSize = CursorProvider.CursorViewportZoomed * cursorSprite.Size;
 
-			var cursorOffset = CursorProvider.CursorViewportZoomed ?
-				(2 * cursorSequence.Hotspot) + cursorSprite.Size.XY.ToInt2() :
-				cursorSequence.Hotspot + (0.5f * cursorSprite.Size.XY).ToInt2();
+			var cursorOffset = (int)CursorProvider.CursorViewportZoomed * (cursorSequence.Hotspot + (0.5f * cursorSprite.Size.XY).ToInt2());
 
 			renderer.SetPalette(palette);
 			renderer.SpriteRenderer.DrawSprite(cursorSprite,

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Graphics
 
 		ProjectedCellRegion allCells;
 		bool allCellsDirty = true;
-		readonly float[] availableZoomSteps = new[] { 2f, 1f, 0.5f, 0.25f };
+		readonly float[] availableZoomSteps = new[] { 4f, 2f, 1f, 0.5f, 0.25f };
 
 		float zoom = 1f;
 
@@ -140,7 +140,7 @@ namespace OpenRA.Graphics
 				CenterLocation = (tl + br) / 2;
 			}
 
-			Zoom = Game.Settings.Graphics.PixelDouble ? 2 : 1;
+			Zoom = Game.Settings.Graphics.PixelScale;
 			tileSize = grid.TileSize;
 		}
 

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -109,8 +109,8 @@ namespace OpenRA
 
 		public bool HardwareCursors = true;
 
-		public bool PixelDouble = false;
-		public bool CursorDouble = false;
+		public float PixelScale = 1;
+		public bool CursorScale = false;
 
 		[Desc("Add a frame rate limiter. It is recommended to not disable this.")]
 		public bool CapFramerate = true;
@@ -233,7 +233,7 @@ namespace OpenRA
 		public Hotkey ObserverWorldView = new Hotkey(Keycode.EQUALS, Modifiers.None);
 
 		public Hotkey CycleStatusBarsKey = new Hotkey(Keycode.COMMA, Modifiers.None);
-		public Hotkey TogglePixelDoubleKey = new Hotkey(Keycode.PERIOD, Modifiers.None);
+		public Hotkey TogglePixelScaleKey = new Hotkey(Keycode.PERIOD, Modifiers.None);
 		public Hotkey TogglePlayerStanceColorsKey = new Hotkey(Keycode.COMMA, Modifiers.Ctrl);
 
 		public Hotkey DevReloadChromeKey = new Hotkey(Keycode.C, Modifiers.Ctrl | Modifiers.Shift);

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var zoomDropdown = widget.GetOrNull<DropDownButtonWidget>("ZOOM_BUTTON");
 			if (zoomDropdown != null)
 			{
-				var selectedZoom = (Game.Settings.Graphics.PixelDouble ? 2f : 1f).ToString();
+				var selectedZoom = Game.Settings.Graphics.PixelScale.ToString();
 
 				zoomDropdown.SelectedItem = selectedZoom;
 				Func<float, ScrollItemWidget, ScrollItemWidget> setupItem = (zoom, itemTemplate) =>
@@ -62,11 +62,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var options = worldRenderer.Viewport.AvailableZoomSteps;
 				zoomDropdown.OnMouseDown = _ => zoomDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 150, options, setupItem);
 				zoomDropdown.GetText = () => zoomDropdown.SelectedItem;
-				zoomDropdown.GetKey = _ => Game.Settings.Keys.TogglePixelDoubleKey;
+				zoomDropdown.GetKey = _ => Game.Settings.Keys.TogglePixelScaleKey;
 				zoomDropdown.OnKeyPress = e =>
 				{
 					var key = Hotkey.FromKeyInput(e);
-					if (key != Game.Settings.Keys.TogglePixelDoubleKey)
+					if (key != Game.Settings.Keys.TogglePixelScaleKey)
 						return;
 
 					var selected = (options.IndexOf(float.Parse(selectedZoom)) + 1) % options.Length;

--- a/OpenRA.Mods.Common/Widgets/TooltipContainerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TooltipContainerWidget.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			get
 			{
-				var pos = Viewport.LastMousePos + (CursorProvider.CursorViewportZoomed ? CursorOffset * 2 : CursorOffset);
+				var pos = Viewport.LastMousePos + ((int)CursorProvider.CursorViewportZoomed * CursorOffset);
 				if (tooltip != null)
 				{
 					// If the tooltip overlaps the right edge of the screen, move it left until it fits
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 					// If the tooltip overlaps the bottom edge of the screen, switch tooltip above cursor
 					if (pos.Y + tooltip.Bounds.Bottom > Game.Renderer.Resolution.Height)
-						pos = pos.WithY(Viewport.LastMousePos.Y + (CursorProvider.CursorViewportZoomed ? 2 : 1) * BottomEdgeYOffset - tooltip.Bounds.Height);
+						pos = pos.WithY(Viewport.LastMousePos.Y + (int)CursorProvider.CursorViewportZoomed * BottomEdgeYOffset - tooltip.Bounds.Height);
 				}
 
 				return pos;

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -14,6 +14,7 @@ using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Effects;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Orders;
 using OpenRA.Traits;
 using OpenRA.Widgets;
@@ -290,8 +291,8 @@ namespace OpenRA.Mods.Common.Widgets
 				}
 				else if (key == Game.Settings.Keys.CycleStatusBarsKey)
 					return CycleStatusBars();
-				else if (key == Game.Settings.Keys.TogglePixelDoubleKey)
-					return TogglePixelDouble();
+				else if (key == Game.Settings.Keys.TogglePixelScaleKey)
+					return TogglePixelScale();
 				else if (key == Game.Settings.Keys.ToggleMuteKey)
 					return ToggleMute();
 				else if (key == Game.Settings.Keys.TogglePlayerStanceColorsKey)
@@ -348,18 +349,18 @@ namespace OpenRA.Mods.Common.Widgets
 			return true;
 		}
 
-		bool TogglePixelDouble()
+		bool TogglePixelScale()
 		{
-			if (worldRenderer.Viewport.Zoom == 1f)
-				worldRenderer.Viewport.Zoom = 2f;
+			var current = worldRenderer.Viewport.AvailableZoomSteps.IndexOf(worldRenderer.Viewport.Zoom);
+
+			if (current + 1 == worldRenderer.Viewport.AvailableZoomSteps.Length)
+				worldRenderer.Viewport.Zoom = worldRenderer.Viewport.AvailableZoomSteps[0];
 			else
 			{
-				// Reset zoom to regular view if it was anything else before
-				// (like a zoom level only reachable by using the scroll wheel).
-				worldRenderer.Viewport.Zoom = 1f;
+				worldRenderer.Viewport.Zoom = worldRenderer.Viewport.AvailableZoomSteps[current + 1];
 			}
 
-			Game.Settings.Graphics.PixelDouble = worldRenderer.Viewport.Zoom == 2f;
+			Game.Settings.Graphics.PixelScale = worldRenderer.Viewport.Zoom;
 
 			return true;
 		}

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -113,20 +113,20 @@ Container@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Enable Frame Limiter
-						Checkbox@PIXELDOUBLE_CHECKBOX:
+						DropDownButton@PIXELSCALE_DROPDOWNBUTTON:
 							X: 310
 							Y: 125
 							Width: 200
 							Height: 20
 							Font: Regular
-							Text: Enable Pixel Doubling
-						Checkbox@CURSORDOUBLE_CHECKBOX:
+							Text: Pixel Scale
+						Checkbox@CURSORSCALE_CHECKBOX:
 							X: 340
 							Y: 155
 							Width: 200
 							Height: 20
 							Font: Regular
-							Text: Also Double Cursor
+							Text: Also Scale Cursor
 						Label@FRAME_LIMIT_DESC_A:
 							X: 45
 							Y: 152

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -126,20 +126,20 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Enable Frame Limiter
-				Checkbox@PIXELDOUBLE_CHECKBOX:
+				DropDownButton@PIXELSCALE_DROPDOWNBUTTON:
 					X: 310
 					Y: 125
 					Width: 200
 					Height: 20
 					Font: Regular
-					Text: Enable Pixel Doubling
-				Checkbox@CURSORDOUBLE_CHECKBOX:
+					Text: Pixel Scale
+				Checkbox@CURSORSCALE_CHECKBOX:
 					X: 340
 					Y: 160
 					Width: 200
 					Height: 20
 					Font: Regular
-					Text: Also Double Cursor
+					Text: Also Scale Cursor
 				Label@FRAME_LIMIT_DESC_A:
 					X: 45
 					Y: 157


### PR DESCRIPTION
This replaces the pixel doubling with a selectable scale. I also added x4 as an option, to make the game look good on 4K screens, or for mods which have tiles in <= 16 pixel size, or a combination of both.
