### PR TITLE
D2k: Change concrete radar color to match rock.

### DIFF
--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -20,7 +20,7 @@ Terrain:
 		Type: Concrete
 		TargetTypes: Ground
 		AcceptsSmudgeType: RockCrater
-		Color: E8C498
+		Color: CE8C42
 	TerrainType@Dune:
 		Type: Dune
 		TargetTypes: Ground


### PR DESCRIPTION
This is/was problematic, because right now players can spot expansions through the fog-of-war instantly.
This replicates original game behavior, too. Concrete in original dune2k doesn't show up on the radar.
It changes the concrete radar color to the rock radar color so the two are indistinguishable. 