### PR TITLE
Add ReloadAmmoPool trait

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/LayMines.cs
+++ b/OpenRA.Mods.Cnc/Activities/LayMines.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				var pool = ammoPools.FirstOrDefault(x => x.Info.Name == info.AmmoPoolName);
 				if (pool == null)
 					return;
-				pool.TakeAmmo();
+				pool.TakeAmmo(self, 1);
 			}
 
 			self.World.AddFrameEndTask(

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -500,9 +500,9 @@ namespace OpenRA.Mods.Common.AI
 			if (aircraftInfo == null)
 				return true;
 
-			var ammoPoolsInfo = actorInfo.TraitInfos<AmmoPoolInfo>();
-
-			if (ammoPoolsInfo.Any(x => !x.SelfReloads))
+			// If the aircraft has at least 1 AmmoPool and defines 1 or more RearmBuildings, check if we have enough of those
+			var hasAmmoPool = actorInfo.TraitInfos<AmmoPoolInfo>().Any();
+			if (hasAmmoPool && aircraftInfo.RearmBuildings.Count > 0)
 			{
 				var countOwnAir = CountUnits(actorInfo.Name, Player);
 				var countBuildings = aircraftInfo.RearmBuildings.Sum(b => CountBuilding(b, Player));

--- a/OpenRA.Mods.Common/AI/States/AirStates.cs
+++ b/OpenRA.Mods.Common/AI/States/AirStates.cs
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Common.AI
 		protected static bool ReloadsAutomatically(Actor a)
 		{
 			var ammoPools = a.TraitsImplementing<AmmoPool>();
-			return ammoPools.All(x => x.Info.SelfReloads);
+			return ammoPools.All(x => x.SelfReloads);
 		}
 
 		protected static bool IsRearm(Actor a)

--- a/OpenRA.Mods.Common/AI/States/AirStates.cs
+++ b/OpenRA.Mods.Common/AI/States/AirStates.cs
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Common.AI
 		protected static bool ReloadsAutomatically(Actor a)
 		{
 			var ammoPools = a.TraitsImplementing<AmmoPool>();
-			return ammoPools.All(x => x.SelfReloads);
+			return ammoPools.All(x => x.AutoReloads);
 		}
 
 		protected static bool IsRearm(Actor a)

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly Aircraft aircraft;
 		readonly AttackPlane attackPlane;
 
-		readonly bool selfReloads;
+		readonly bool autoReloads;
 		int ticksUntilTurn;
 
 		public FlyAttack(Actor self, Target target)
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Activities
 			aircraft = self.Trait<Aircraft>();
 			attackPlane = self.TraitOrDefault<AttackPlane>();
 			ticksUntilTurn = attackPlane.AttackPlaneInfo.AttackTurnDelay;
-			selfReloads = self.TraitsImplementing<AmmoPool>().All(p => p.SelfReloads);
+			autoReloads = self.TraitsImplementing<AmmoPool>().All(p => p.AutoReloads);
 		}
 
 		public override Activity Tick(Actor self)
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 
 			// If all valid weapons have depleted their ammo and RearmBuilding is defined, return to RearmBuilding to reload and then resume the activity
-			if (!selfReloads && aircraft.Info.RearmBuildings.Any() && attackPlane.Armaments.All(x => x.IsTraitPaused || !x.Weapon.IsValidAgainst(target, self.World, self)))
+			if (!autoReloads && aircraft.Info.RearmBuildings.Any() && attackPlane.Armaments.All(x => x.IsTraitPaused || !x.Weapon.IsValidAgainst(target, self.World, self)))
 				return ActivityUtils.SequenceActivities(new ReturnToBase(self, aircraft.Info.AbortOnResupply), this);
 
 			if (attackPlane != null)

--- a/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly Aircraft helicopter;
 		readonly AttackHeli attackHeli;
 		readonly bool attackOnlyVisibleTargets;
-		readonly bool selfReloads;
+		readonly bool autoReloads;
 
 		Target target;
 		bool canHideUnderFog;
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Activities
 			helicopter = self.Trait<Aircraft>();
 			attackHeli = self.Trait<AttackHeli>();
 			this.attackOnlyVisibleTargets = attackOnlyVisibleTargets;
-			selfReloads = self.TraitsImplementing<AmmoPool>().All(p => p.SelfReloads);
+			autoReloads = self.TraitsImplementing<AmmoPool>().All(p => p.AutoReloads);
 		}
 
 		public override Activity Tick(Actor self)
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			// If all valid weapons have depleted their ammo and RearmBuilding is defined, return to RearmBuilding to reload and then resume the activity
-			if (!selfReloads && helicopter.Info.RearmBuildings.Any() && attackHeli.Armaments.All(x => x.IsTraitPaused || !x.Weapon.IsValidAgainst(target, self.World, self)))
+			if (!autoReloads && helicopter.Info.RearmBuildings.Any() && attackHeli.Armaments.All(x => x.IsTraitPaused || !x.Weapon.IsValidAgainst(target, self.World, self)))
 				return ActivityUtils.SequenceActivities(new HeliReturnToBase(self, helicopter.Info.AbortOnResupply), this);
 
 			var dist = targetPos - pos;

--- a/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
@@ -21,7 +21,6 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly Aircraft helicopter;
 		readonly AttackHeli attackHeli;
-		readonly AmmoPool[] ammoPools;
 		readonly bool attackOnlyVisibleTargets;
 
 		Target target;
@@ -46,7 +45,6 @@ namespace OpenRA.Mods.Common.Activities
 			Target = target;
 			helicopter = self.Trait<Aircraft>();
 			attackHeli = self.Trait<AttackHeli>();
-			ammoPools = self.TraitsImplementing<AmmoPool>().ToArray();
 			this.attackOnlyVisibleTargets = attackOnlyVisibleTargets;
 		}
 
@@ -74,8 +72,8 @@ namespace OpenRA.Mods.Common.Activities
 				return new HeliFly(self, newTarget);
 			}
 
-			// If any AmmoPool is depleted and no weapon is valid against target, return to helipad to reload and then resume the activity
-			if (ammoPools.Any(x => !x.Info.SelfReloads && !x.HasAmmo()) && !attackHeli.HasAnyValidWeapons(target))
+			// If all valid weapons have depleted their ammo, return to RearmBuilding to reload and then resume the activity
+			if (attackHeli.Armaments.All(x => x.OutOfAmmo || !x.Weapon.IsValidAgainst(target, self.World, self)))
 				return ActivityUtils.SequenceActivities(new HeliReturnToBase(self, helicopter.Info.AbortOnResupply), this);
 
 			var dist = targetPos - pos;

--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 
 			return heli.Info.RearmBuildings.Contains(dest.Info.Name) && self.TraitsImplementing<AmmoPool>()
-					.Any(p => !p.SelfReloads && !p.FullAmmo());
+					.Any(p => !p.AutoReloads && !p.FullAmmo());
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 
 			return heli.Info.RearmBuildings.Contains(dest.Info.Name) && self.TraitsImplementing<AmmoPool>()
-					.Any(p => !p.Info.SelfReloads && !p.FullAmmo());
+					.Any(p => !p.SelfReloads && !p.FullAmmo());
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 
 			return planeInfo.RearmBuildings.Contains(dest.Info.Name) && self.TraitsImplementing<AmmoPool>()
-					.Any(p => !p.SelfReloads && !p.FullAmmo());
+					.Any(p => !p.AutoReloads && !p.FullAmmo());
 		}
 
 		public override Activity Tick(Actor self)

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 
 			return planeInfo.RearmBuildings.Contains(dest.Info.Name) && self.TraitsImplementing<AmmoPool>()
-					.Any(p => !p.Info.SelfReloads && !p.FullAmmo());
+					.Any(p => !p.SelfReloads && !p.FullAmmo());
 		}
 
 		public override Activity Tick(Actor self)

--- a/OpenRA.Mods.Common/Activities/Rearm.cs
+++ b/OpenRA.Mods.Common/Activities/Rearm.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Rearm(Actor self)
 		{
-			ammoPools = self.TraitsImplementing<AmmoPool>().Where(p => !p.SelfReloads).ToArray();
+			ammoPools = self.TraitsImplementing<AmmoPool>().Where(p => !p.AutoReloads).ToArray();
 		}
 
 		public override Activity Tick(Actor self)

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -359,6 +359,7 @@
     <Compile Include="Traits\JamsMissiles.cs" />
     <Compile Include="Traits\KillsSelf.cs" />
     <Compile Include="Traits\AmmoPool.cs" />
+    <Compile Include="Traits\ReloadAmmoPool.cs" />
     <Compile Include="Traits\Mobile.cs" />
     <Compile Include="Traits\Modifiers\FrozenUnderFog.cs" />
     <Compile Include="Traits\Modifiers\HiddenUnderFog.cs" />

--- a/OpenRA.Mods.Common/Scripting/Properties/AmmoPoolProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/AmmoPoolProperties.cs
@@ -59,17 +59,9 @@ namespace OpenRA.Mods.Common.Scripting
 				throw new LuaException("Invalid ammopool name {0} queried on actor {1}.".F(poolName, self));
 
 			if (amount > 0)
-			{
-				while (amount-- > 0)
-					if (!pool.GiveAmmo())
-						return;
-			}
+				pool.GiveAmmo(self, amount);
 			else
-			{
-				while (amount++ < 0)
-					if (!pool.TakeAmmo())
-						return;
-			}
+				pool.TakeAmmo(self, -amount);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/AmmoPool.cs
+++ b/OpenRA.Mods.Common/Traits/AmmoPool.cs
@@ -62,10 +62,9 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Stack<int> tokens = new Stack<int>();
 		ConditionManager conditionManager;
 
-		bool selfReloads;
-
 		// HACK: Temporarily needed until Rearm activity is gone for good
 		[Sync] public int RemainingTicks;
+
 		[Sync] int currentAmmo;
 
 		public AmmoPool(Actor self, AmmoPoolInfo info)
@@ -100,12 +99,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		// This mostly serves to avoid complicated ReloadAmmoPool look-ups in various other places.
 		// TODO: Investigate removing this when the Rearm activity is replaced with a condition-based solution.
-		public bool SelfReloads { get { return selfReloads; } }
+		public bool AutoReloads { get; private set; }
 
 		void INotifyCreated.Created(Actor self)
 		{
 			conditionManager = self.TraitOrDefault<ConditionManager>();
-			selfReloads = self.TraitsImplementing<ReloadAmmoPool>().Any(r => r.Info.AmmoPool == Info.Name && r.Info.RequiresCondition == null);
+			AutoReloads = self.TraitsImplementing<ReloadAmmoPool>().Any(r => r.Info.AmmoPool == Info.Name && r.Info.RequiresCondition == null);
 
 			UpdateCondition(self);
 

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -107,6 +107,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Actor self;
 		Turreted turret;
 		AmmoPool ammoPool;
+		ReloadAmmoPool reloadAmmoPool;
 		BodyOrientation coords;
 		INotifyBurstComplete[] notifyBurstComplete;
 		INotifyAttack[] notifyAttacks;
@@ -157,6 +158,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			turret = self.TraitsImplementing<Turreted>().FirstOrDefault(t => t.Name == Info.Turret);
 			ammoPool = self.TraitsImplementing<AmmoPool>().FirstOrDefault(la => la.Info.Name == Info.AmmoPoolName);
+			reloadAmmoPool = self.TraitsImplementing<ReloadAmmoPool>().FirstOrDefault(ra => ra.Info.AmmoPool == Info.AmmoPoolName);
 			coords = self.Trait<BodyOrientation>();
 			notifyBurstComplete = self.TraitsImplementing<INotifyBurstComplete>().ToArray();
 			notifyAttacks = self.TraitsImplementing<INotifyAttack>().ToArray();
@@ -339,7 +341,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public virtual bool OutOfAmmo { get { return ammoPool != null && !ammoPool.Info.SelfReloads && !ammoPool.HasAmmo(); } }
+		public virtual bool OutOfAmmo { get { return ammoPool != null && !ammoPool.HasAmmo() && (reloadAmmoPool == null || reloadAmmoPool.IsTraitDisabled); } }
 		public virtual bool IsReloading { get { return FireDelay > 0 || IsTraitDisabled; } }
 		public virtual bool AllowExplode { get { return !IsReloading; } }
 		bool IExplodeModifier.ShouldExplode(Actor self) { return AllowExplode; }

--- a/OpenRA.Mods.Common/Traits/ReloadAmmoPool.cs
+++ b/OpenRA.Mods.Common/Traits/ReloadAmmoPool.cs
@@ -1,0 +1,88 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation. For more information,
+ * see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Reloads an ammo pool.")]
+	public class ReloadAmmoPoolInfo : PausableConditionalTraitInfo
+	{
+		[Desc("Reload ammo pool with this name.")]
+		public readonly string AmmoPool = "primary";
+
+		[Desc("Reload time in ticks per Count.")]
+		public readonly int Delay = 50;
+
+		[Desc("How much ammo is reloaded after Delay.")]
+		public readonly int Count = 1;
+
+		[Desc("Whether or not reload timer should be reset when ammo has been fired.")]
+		public readonly bool ResetOnFire = false;
+
+		[Desc("Play this sound each time ammo is reloaded.")]
+		public readonly string Sound = null;
+
+		public override object Create(ActorInitializer init) { return new ReloadAmmoPool(this); }
+
+		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
+		{
+			if (ai.TraitInfos<AmmoPoolInfo>().Count(ap => ap.Name == AmmoPool) != 1)
+				throw new YamlException("ReloadsAmmoPool.AmmoPool requires exactly one AmmoPool with matching Name!");
+
+			base.RulesetLoaded(rules, ai);
+		}
+	}
+
+	public class ReloadAmmoPool : PausableConditionalTrait<ReloadAmmoPoolInfo>, ITick, INotifyCreated, INotifyAttack, ISync
+	{
+		AmmoPool ammoPool;
+
+		[Sync] int remainingTicks;
+
+		public ReloadAmmoPool(ReloadAmmoPoolInfo info)
+			: base(info) { }
+
+		void INotifyCreated.Created(Actor self)
+		{
+			ammoPool = self.TraitsImplementing<AmmoPool>().Single(ap => ap.Info.Name == Info.AmmoPool);
+			remainingTicks = Info.Delay;
+		}
+
+		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel)
+		{
+			if (Info.ResetOnFire)
+				remainingTicks = Info.Delay;
+		}
+
+		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel) { }
+
+		void ITick.Tick(Actor self)
+		{
+			if (IsTraitPaused || IsTraitDisabled)
+				return;
+
+			Reload(self, Info.Delay, Info.Count, Info.Sound);
+		}
+
+		protected virtual void Reload(Actor self, int reloadDelay, int reloadCount, string sound)
+		{
+			if (!ammoPool.FullAmmo() && --remainingTicks == 0)
+			{
+				remainingTicks = reloadDelay;
+				if (!string.IsNullOrEmpty(sound))
+					Game.Sound.PlayToPlayer(SoundType.World, self.Owner, sound, self.CenterPosition);
+
+				ammoPool.GiveAmmo(self, reloadCount);
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool CanRearm()
 		{
-			return ammoPools.Any(x => !x.Info.SelfReloads && !x.FullAmmo());
+			return ammoPools.Any(x => !x.SelfReloads && !x.FullAmmo());
 		}
 
 		public string VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool CanRearm()
 		{
-			return ammoPools.Any(x => !x.SelfReloads && !x.FullAmmo());
+			return ammoPools.Any(x => !x.AutoReloads && !x.FullAmmo());
 		}
 
 		public string VoicePhraseForOrder(Actor self, Order order)

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -65,7 +65,6 @@ HELI:
 		Queue: Aircraft.Nod
 		Description: Helicopter Gunship with Chainguns.\n  Strong vs Infantry, Light Vehicles and\n  Aircraft\n  Weak vs Tanks
 	Aircraft:
-		RearmBuildings: hpad
 		InitialFacing: 224
 		TurnSpeed: 7
 		Speed: 180
@@ -124,7 +123,6 @@ ORCA:
 		Queue: Aircraft.GDI
 		Description: Helicopter Gunship with AG Missiles.\n  Strong vs Buildings, Tanks\n  Weak vs Infantry
 	Aircraft:
-		RearmBuildings: hpad
 		InitialFacing: 224
 		TurnSpeed: 7
 		Speed: 186

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -89,9 +89,6 @@ HELI:
 	AmmoPool:
 		Ammo: 10
 		PipCount: 5
-		SelfReloads: true
-		ReloadCount: 1
-		SelfReloadDelay: 40
 	WithIdleOverlay@ROTORAIR:
 		Offset: 0,0,85
 		Sequence: rotor
@@ -108,6 +105,9 @@ HELI:
 		EmptyWeapon: HeliExplode
 	SelectionDecorations:
 		VisualBounds: 30,24
+	ReloadAmmoPool:
+		Delay: 40
+		Count: 1
 
 ORCA:
 	Inherits: ^Helicopter
@@ -144,9 +144,6 @@ ORCA:
 	AmmoPool:
 		Ammo: 6
 		PipCount: 6
-		SelfReloads: true
-		ReloadCount: 2
-		SelfReloadDelay: 100
 	SpawnActorOnDeath:
 		Actor: ORCA.Husk
 	Explodes:
@@ -156,6 +153,9 @@ ORCA:
 		MoveSequence: move
 	SelectionDecorations:
 		VisualBounds: 30,24
+	ReloadAmmoPool:
+		Delay: 100
+		Count: 2
 
 C17:
 	Inherits: ^Plane

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -79,16 +79,19 @@ HELI:
 		Weapon: HeliAGGun
 		LocalOffset: 128,-213,-85, 128,213,-85
 		MuzzleSequence: muzzle
+		PauseOnCondition: !ammo
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: HeliAAGun
 		LocalOffset: 128,-213,-85, 128,213,-85
 		MuzzleSequence: muzzle
+		PauseOnCondition: !ammo
 	AttackHeli:
 		FacingTolerance: 20
 	AmmoPool:
 		Ammo: 10
 		PipCount: 5
+		AmmoCondition: ammo
 	WithIdleOverlay@ROTORAIR:
 		Offset: 0,0,85
 		Sequence: rotor
@@ -136,14 +139,17 @@ ORCA:
 	Armament@PRIMARY:
 		Weapon: OrcaAGMissiles
 		LocalOffset: 427,-171,-213, 427,171,-213
+		PauseOnCondition: !ammo
 	Armament@SECONDARY:
 		Weapon: OrcaAAMissiles
 		LocalOffset: 427,-171,-213, 427,171,-213
+		PauseOnCondition: !ammo
 	AttackHeli:
 		FacingTolerance: 20
 	AmmoPool:
 		Ammo: 6
 		PipCount: 6
+		AmmoCondition: ammo
 	SpawnActorOnDeath:
 		Actor: ORCA.Husk
 	Explodes:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -510,9 +510,6 @@ MLRS:
 	AmmoPool:
 		Ammo: 2
 		PipCount: 0
-		SelfReloads: true
-		ReloadCount: 1
-		SelfReloadDelay: 45
 	AttackTurreted:
 	WithReloadingSpriteTurret:
 		AmmoPoolName: primary
@@ -521,6 +518,9 @@ MLRS:
 	RenderRangeCircle:
 	SpawnActorOnDeath:
 		Actor: MLRS.Husk
+	ReloadAmmoPool:
+		Delay: 45
+		Count: 1
 
 STNK:
 	Inherits: ^Vehicle

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -111,6 +111,7 @@ MIG:
 	AttackPlane:
 		FacingTolerance: 20
 	Aircraft:
+		RearmBuildings: afld
 		CruiseAltitude: 2560
 		InitialFacing: 192
 		TurnSpeed: 4
@@ -175,6 +176,7 @@ YAK:
 	AttackPlane:
 		FacingTolerance: 20
 	Aircraft:
+		RearmBuildings: afld
 		CruiseAltitude: 2560
 		InitialFacing: 192
 		TurnSpeed: 4
@@ -290,6 +292,7 @@ HELI:
 	AttackHeli:
 		FacingTolerance: 20
 	Aircraft:
+		RearmBuildings: hpad
 		LandWhenIdle: false
 		InitialFacing: 224
 		TurnSpeed: 4
@@ -352,6 +355,7 @@ HIND:
 	AttackHeli:
 		FacingTolerance: 20
 	Aircraft:
+		RearmBuildings: hpad
 		LandWhenIdle: false
 		InitialFacing: 224
 		TurnSpeed: 4

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -108,6 +108,7 @@ MIG:
 		Weapon: Maverick
 		LocalOffset: 0,-640,0, 0,640,0
 		LocalYaw: -40, 24
+		PauseOnCondition: !ammo
 	AttackPlane:
 		FacingTolerance: 20
 	Aircraft:
@@ -123,6 +124,7 @@ MIG:
 		InitialStanceAI: HoldFire
 	AmmoPool:
 		Ammo: 8
+		AmmoCondition: ammo
 	ReturnOnIdle:
 	Selectable:
 		Bounds: 36,28,0,2
@@ -168,11 +170,13 @@ YAK:
 		Weapon: ChainGun.Yak
 		LocalOffset: 256,-213,0
 		MuzzleSequence: muzzle
+		PauseOnCondition: !ammo
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: ChainGun.Yak
 		LocalOffset: 256,213,0
 		MuzzleSequence: muzzle
+		PauseOnCondition: !ammo
 	AttackPlane:
 		FacingTolerance: 20
 	Aircraft:
@@ -190,6 +194,7 @@ YAK:
 		Ammo: 18
 		PipCount: 6
 		ReloadDelay: 11
+		AmmoCondition: ammo
 	ReturnOnIdle:
 	SelectionDecorations:
 		VisualBounds: 30,28,0,2
@@ -286,9 +291,11 @@ HELI:
 	Armament@PRIMARY:
 		Weapon: HellfireAA
 		LocalOffset: 0,-213,-85
+		PauseOnCondition: !ammo
 	Armament@SECONDARY:
 		Weapon: HellfireAG
 		LocalOffset: 0,213,-85
+		PauseOnCondition: !ammo
 	AttackHeli:
 		FacingTolerance: 20
 	Aircraft:
@@ -310,6 +317,7 @@ HELI:
 		RequiresCondition: !airborne
 	AmmoPool:
 		Ammo: 8
+		AmmoCondition: ammo
 	SelectionDecorations:
 		VisualBounds: 36,28
 	SpawnActorOnDeath:
@@ -347,11 +355,13 @@ HIND:
 		Weapon: ChainGun
 		LocalOffset: 85,-213,-85
 		MuzzleSequence: muzzle
+		PauseOnCondition: !ammo
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: ChainGun
 		LocalOffset: 85,213,-85
 		MuzzleSequence: muzzle
+		PauseOnCondition: !ammo
 	AttackHeli:
 		FacingTolerance: 20
 	Aircraft:
@@ -373,6 +383,7 @@ HIND:
 		Ammo: 24
 		PipCount: 6
 		ReloadDelay: 8
+		AmmoCondition: ammo
 	SelectionDecorations:
 		VisualBounds: 38,32
 	WithMuzzleOverlay:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -507,7 +507,6 @@
 		Bounds: 24,24
 	Aircraft:
 		RepairBuildings: fix
-		RearmBuildings: afld
 		AirborneCondition: airborne
 	Targetable@GROUND:
 		TargetTypes: Ground, Repair, Vehicle
@@ -560,7 +559,6 @@
 	Tooltip:
 		GenericName: Helicopter
 	Aircraft:
-		RearmBuildings: hpad
 		CanHover: True
 		CruisingCondition: cruising
 		WaitDistanceFromResupplyBase: 4c0

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -78,6 +78,7 @@ ORCA:
 	Selectable:
 		Bounds: 30,24
 	Aircraft:
+		RearmBuildings: gahpad, nahpad
 		TurnSpeed: 5
 		Speed: 186
 		MoveIntoShroud: false
@@ -120,6 +121,7 @@ ORCAB:
 	Selectable:
 		Bounds: 30,24
 	Aircraft:
+		RearmBuildings: gahpad, nahpad
 		CruiseAltitude: 3072
 		MaximumPitch: 120
 		TurnSpeed: 3
@@ -245,6 +247,7 @@ SCRIN:
 	Voiced:
 		VoiceSet: Scrin
 	Aircraft:
+		RearmBuildings: gahpad, nahpad
 		CruiseAltitude: 2560
 		MaximumPitch: 90
 		TurnSpeed: 3
@@ -293,6 +296,7 @@ APACHE:
 	Selectable:
 		Bounds: 30,24
 	Aircraft:
+		RearmBuildings: gahpad, nahpad
 		TurnSpeed: 5
 		Speed: 130
 		MoveIntoShroud: false

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -93,6 +93,7 @@ ORCA:
 		Type: CenterPosition
 	Armament:
 		Weapon: Hellfire
+		PauseOnCondition: !ammo
 	AttackHeli:
 		FacingTolerance: 20
 		Voice: Attack
@@ -101,6 +102,7 @@ ORCA:
 		PipCount: 5
 		PipType: Ammo
 		PipTypeEmpty: AmmoEmpty
+		AmmoCondition: ammo
 	RenderSprites:
 	SpawnActorOnDeath:
 		Actor: ORCA.Husk
@@ -140,6 +142,7 @@ ORCAB:
 		Type: CenterPosition
 	Armament:
 		Weapon: Bomb
+		PauseOnCondition: !ammo
 	AttackPlane:
 		Voice: Attack
 		FacingTolerance: 20
@@ -150,6 +153,7 @@ ORCAB:
 		ReloadDelay: 200
 		PipType: Ammo
 		PipTypeEmpty: AmmoEmpty
+		AmmoCondition: ammo
 	RenderSprites:
 	Hovers@CRUISING:
 		RequiresCondition: cruising
@@ -266,6 +270,7 @@ SCRIN:
 		Type: CenterPosition
 	Armament:
 		Weapon: Proton
+		PauseOnCondition: !ammo
 	AttackPlane:
 		Voice: Attack
 		FacingTolerance: 20
@@ -275,6 +280,7 @@ SCRIN:
 		ReloadCount: 5
 		PipType: Ammo
 		PipTypeEmpty: AmmoEmpty
+		AmmoCondition: ammo
 	RenderSprites:
 	DeathSounds:
 	SpawnActorOnDeath:
@@ -309,6 +315,7 @@ APACHE:
 		Type: CenterPosition
 	Armament:
 		Weapon: HarpyClaw
+		PauseOnCondition: !ammo
 	AttackHeli:
 		FacingTolerance: 20
 		Voice: Attack
@@ -317,6 +324,7 @@ APACHE:
 		PipCount: 4
 		PipType: Ammo
 		PipTypeEmpty: AmmoEmpty
+		AmmoCondition: ammo
 	WithIdleOverlay@ROTORAIR:
 		Offset: 85,0,384
 		Sequence: rotor

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -814,7 +814,6 @@
 	Aircraft:
 		AirborneCondition: airborne
 		RepairBuildings: gadept
-		RearmBuildings: gahpad, nahpad
 		LandWhenIdle: false
 		Voice: Move
 		IdealSeparation: 853


### PR DESCRIPTION
First step towards #9613.

This adds a `ReloadAmmoPool` trait, splits the `AmmoPool` reload logic into a method that can be called externally, and gets rid of the `AmmoPool.SelfReloads`-related properties.

The 3rd commit looks more intimidating than it really is, but if push comes to shove, I can split it off to a follow-up PR along the upgrade rule.

Note: I've tested the upgrade rule myself - even on a testcase with multiple AmmoPools - and verified that it works as intended.