### PR TITLE
Pre-register mod metadata during Windows / .deb installation.

### DIFF
--- a/OpenRA.Game/ExternalMods.cs
+++ b/OpenRA.Game/ExternalMods.cs
@@ -202,6 +202,34 @@ namespace OpenRA
 			}
 		}
 
+		internal void Unregister(Manifest mod, ModRegistration registration)
+		{
+			var sources = new List<string>();
+			if (registration.HasFlag(ModRegistration.System))
+				sources.Add(Platform.SystemSupportDir);
+
+			if (registration.HasFlag(ModRegistration.User))
+				sources.Add(Platform.SupportDir);
+
+			var key = ExternalMod.MakeKey(mod);
+			mods.Remove(key);
+
+			foreach (var source in sources.Distinct())
+			{
+				var path = Path.Combine(source, "ModMetadata", key + ".yaml");
+				try
+				{
+					if (File.Exists(path))
+						File.Delete(path);
+				}
+				catch (Exception e)
+				{
+					Log.Write("debug", "Failed to remove mod metadata file '{0}'", path);
+					Log.Write("debug", e.ToString());
+				}
+			}
+		}
+
 		public ExternalMod this[string key] { get { return mods[key]; } }
 		public int Count { get { return mods.Count; } }
 		public ICollection<string> Keys { get { return mods.Keys; } }

--- a/OpenRA.Game/ExternalMods.cs
+++ b/OpenRA.Game/ExternalMods.cs
@@ -38,15 +38,9 @@ namespace OpenRA
 	{
 		readonly Dictionary<string, ExternalMod> mods = new Dictionary<string, ExternalMod>();
 		readonly SheetBuilder sheetBuilder;
-		readonly string launchPath;
 
-		public ExternalMods(string launchPath)
+		public ExternalMods()
 		{
-			// Process.Start requires paths to not be quoted, even if they contain spaces
-			if (launchPath.First() == '"' && launchPath.Last() == '"')
-				launchPath = launchPath.Substring(1, launchPath.Length - 2);
-
-			this.launchPath = launchPath;
 			sheetBuilder = new SheetBuilder(SheetType.BGRA, 256);
 
 			// Load registered mods
@@ -83,7 +77,7 @@ namespace OpenRA
 			mods[ExternalMod.MakeKey(mod)] = mod;
 		}
 
-		internal void Register(Manifest mod)
+		internal void Register(Manifest mod, string launchPath)
 		{
 			if (mod.Metadata.Hidden)
 				return;

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -351,6 +351,10 @@ namespace OpenRA
 					launchPath = launchPath.Substring(1, launchPath.Length - 2);
 
 				ExternalMods.Register(Mods[modID], launchPath);
+
+				ExternalMod activeMod;
+				if (ExternalMods.TryGetValue(ExternalMod.MakeKey(Mods[modID]), out activeMod))
+					ExternalMods.ClearInvalidRegistrations(activeMod);
 			}
 
 			Console.WriteLine("External mods:");

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -350,11 +350,11 @@ namespace OpenRA
 				if (launchPath.First() == '"' && launchPath.Last() == '"')
 					launchPath = launchPath.Substring(1, launchPath.Length - 2);
 
-				ExternalMods.Register(Mods[modID], launchPath);
+				ExternalMods.Register(Mods[modID], launchPath, ModRegistration.User);
 
 				ExternalMod activeMod;
 				if (ExternalMods.TryGetValue(ExternalMod.MakeKey(Mods[modID]), out activeMod))
-					ExternalMods.ClearInvalidRegistrations(activeMod);
+					ExternalMods.ClearInvalidRegistrations(activeMod, ModRegistration.User);
 			}
 
 			Console.WriteLine("External mods:");

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -255,6 +255,9 @@
     <Compile Include="Support\VariableExpression.cs" />
     <Compile Include="ExternalMods.cs" />
     <Compile Include="Graphics\Model.cs" />
+    <Compile Include="UtilityCommands\RegisterModCommand.cs" />
+    <Compile Include="UtilityCommands\UnregisterModCommand.cs" />
+    <Compile Include="UtilityCommands\ClearInvalidModRegistrationsCommand.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FileSystem\Folder.cs" />

--- a/OpenRA.Game/UtilityCommands/ClearInvalidModRegistrationsCommand.cs
+++ b/OpenRA.Game/UtilityCommands/ClearInvalidModRegistrationsCommand.cs
@@ -1,0 +1,41 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+
+namespace OpenRA.UtilityCommands
+{
+	class ClearInvalidModRegistrationsCommand : IUtilityCommand
+	{
+		string IUtilityCommand.Name { get { return "--clear-invalid-mod-registrations"; } }
+		bool IUtilityCommand.ValidateArguments(string[] args)
+		{
+			return args.Length >= 2 && new string[] { "system", "user", "both" }.Contains(args[1]);
+		}
+
+		[Desc("(system|user|both)", "Removes invalid metadata entries for the in-game mod switcher.")]
+		void IUtilityCommand.Run(Utility utility, string[] args)
+		{
+			ModRegistration type = 0;
+			if (args[1] == "system" || args[1] == "both")
+				type |= ModRegistration.System;
+
+			if (args[1] == "user" || args[1] == "both")
+				type |= ModRegistration.User;
+
+			var mods = new ExternalMods();
+
+			ExternalMod activeMod = null;
+			mods.TryGetValue(ExternalMod.MakeKey(utility.ModData.Manifest), out activeMod);
+			mods.ClearInvalidRegistrations(activeMod, type);
+		}
+	}
+}

--- a/OpenRA.Game/UtilityCommands/RegisterModCommand.cs
+++ b/OpenRA.Game/UtilityCommands/RegisterModCommand.cs
@@ -1,0 +1,37 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+
+namespace OpenRA.UtilityCommands
+{
+	class RegisterModCommand : IUtilityCommand
+	{
+		string IUtilityCommand.Name { get { return "--register-mod"; } }
+		bool IUtilityCommand.ValidateArguments(string[] args)
+		{
+			return args.Length >= 3 && new string[] { "system", "user", "both" }.Contains(args[2]);
+		}
+
+		[Desc("LAUNCHPATH (system|user|both)", "Generates a mod metadata entry for the in-game mod switcher.")]
+		void IUtilityCommand.Run(Utility utility, string[] args)
+		{
+			ModRegistration type = 0;
+			if (args[2] == "system" || args[2] == "both")
+				type |= ModRegistration.System;
+
+			if (args[2] == "user" || args[2] == "both")
+				type |= ModRegistration.User;
+
+			new ExternalMods().Register(utility.ModData.Manifest, args[1], type);
+		}
+	}
+}

--- a/OpenRA.Game/UtilityCommands/UnregisterModCommand.cs
+++ b/OpenRA.Game/UtilityCommands/UnregisterModCommand.cs
@@ -1,0 +1,37 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+
+namespace OpenRA.UtilityCommands
+{
+	class UnregisterModCommand : IUtilityCommand
+	{
+		string IUtilityCommand.Name { get { return "--unregister-mod"; } }
+		bool IUtilityCommand.ValidateArguments(string[] args)
+		{
+			return args.Length >= 2 && new string[] { "system", "user", "both" }.Contains(args[1]);
+		}
+
+		[Desc("(system|user|both)", "Removes the mod metadata entry for the in-game mod switcher.")]
+		void IUtilityCommand.Run(Utility utility, string[] args)
+		{
+			ModRegistration type = 0;
+			if (args[1] == "system" || args[1] == "both")
+				type |= ModRegistration.System;
+
+			if (args[1] == "user" || args[1] == "both")
+				type |= ModRegistration.User;
+
+			new ExternalMods().Unregister(utility.ModData.Manifest, type);
+		}
+	}
+}

--- a/packaging/linux/deb/DEBIAN/postinst
+++ b/packaging/linux/deb/DEBIAN/postinst
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Register default mods for in-game switching
+mkdir -p "{SYSTEMSUPPORTDIR}/ModMetadata"
+mono {LIBDIR}/OpenRA.Utility.exe ra --register-mod /usr/games/openra-ra system
+mono {LIBDIR}/OpenRA.Utility.exe cnc --register-mod /usr/games/openra-cnc system
+mono {LIBDIR}/OpenRA.Utility.exe d2k --register-mod /usr/games/openra-d2k system

--- a/packaging/linux/deb/DEBIAN/prerm
+++ b/packaging/linux/deb/DEBIAN/prerm
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+mono {LIBDIR}/OpenRA.Utility.exe ra --unregister-mod system
+mono {LIBDIR}/OpenRA.Utility.exe cnc --unregister-mod system
+mono {LIBDIR}/OpenRA.Utility.exe d2k --unregister-mod system

--- a/packaging/linux/deb/buildpackage.sh
+++ b/packaging/linux/deb/buildpackage.sh
@@ -21,6 +21,7 @@ DEB_BUILD_ROOT="$(pwd)/build"
 
 LIBDIR=/usr/lib/openra
 DOCDIR=/usr/share/doc/openra
+SYSTEMSUPPORTDIR=/var/games/openra
 LINTIANORDIR=/usr/share/lintian/overrides
 E_BADARGS=85
 
@@ -80,6 +81,9 @@ else
 fi
 
 sed "s/{VERSION}/${VERSION}/" DEBIAN/control | sed "s/{SIZE}/${PACKAGE_SIZE}/" > "${DEB_BUILD_ROOT}/DEBIAN/control"
+sed "s|{LIBDIR}|${LIBDIR}|g" DEBIAN/postinst | sed "s|{SYSTEMSUPPORTDIR}|${SYSTEMSUPPORTDIR}|g" > "${DEB_BUILD_ROOT}/DEBIAN/postinst"
+sed "s|{LIBDIR}|${LIBDIR}|g" DEBIAN/prerm | sed "s|{SYSTEMSUPPORTDIR}|${SYSTEMSUPPORTDIR}|g" > "${DEB_BUILD_ROOT}/DEBIAN/prerm"
+chmod 0755 "${DEB_BUILD_ROOT}/DEBIAN/postinst" "${DEB_BUILD_ROOT}/DEBIAN/prerm"
 
 # Build it in the temp directory, but place the finished deb in our starting directory
 pushd "${DEB_BUILD_ROOT}" >/dev/null

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -150,6 +150,16 @@ Section "Game" GAME
 	${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
 	IntFmt $0 "0x%08X" $0
 	WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\OpenRA${SUFFIX}" "EstimatedSize" "$0"
+
+	SetShellVarContext all
+	CreateDirectory "$APPDATA\OpenRA\ModMetadata"
+	nsExec::ExecToLog '"$INSTDIR\OpenRA.Utility.exe" ra --register-mod "$INSTDIR\RedAlert.exe" system'
+	nsExec::ExecToLog '"$INSTDIR\OpenRA.Utility.exe" ra --clear-invalid-mod-registrations system'
+	nsExec::ExecToLog '"$INSTDIR\OpenRA.Utility.exe" cnc --register-mod "$INSTDIR\TiberianDawn.exe" system'
+	nsExec::ExecToLog '"$INSTDIR\OpenRA.Utility.exe" cnc --clear-invalid-mod-registrations system'
+	nsExec::ExecToLog '"$INSTDIR\OpenRA.Utility.exe" d2k --register-mod "$INSTDIR\Dune2000.exe" system'
+	nsExec::ExecToLog '"$INSTDIR\OpenRA.Utility.exe" d2k --clear-invalid-mod-registrations system'
+
 SectionEnd
 
 Section "Desktop Shortcut" DESKTOPSHORTCUT
@@ -200,6 +210,10 @@ SectionEnd
 
 !macro Clean UN
 Function ${UN}Clean
+	nsExec::ExecToLog '"$INSTDIR\OpenRA.Utility.exe" ra --unregister-mod system'
+	nsExec::ExecToLog '"$INSTDIR\OpenRA.Utility.exe" cnc --unregister-mod system'
+	nsExec::ExecToLog '"$INSTDIR\OpenRA.Utility.exe" d2k --unregister-mod system'
+
 	RMDir /r $INSTDIR\mods
 	RMDir /r $INSTDIR\maps
 	RMDir /r $INSTDIR\glsl


### PR DESCRIPTION
Requiring users to switch to a mod manually before it is available for switching caused a lot of confusion when `release-20170421` and `release-20170527` were first released.  This PR fixes the issue for Windows and Linux (just deb here, but downstream packaging is also expected to adopt this) by pre-registering mods during installation.

A new "system support" directory is defined at:
* Windows: `C:\ProgramData\OpenRA\` ([spec](https://msdn.microsoft.com/en-us/library/s2esdf4x(v=vs.100).aspx))
* Linux: `/var/games/openra/` ([spec](http://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s07.html))
* macOS: `/Library/Application Support/OpenRA/`

and a `ModMetadata` subdirectory is created and populated for ra/td/d2k.  These are left read-only for normal users to avoid a malicious user from changing the `LaunchPath` to something nasty.

Closes #12764 and implements the first steps towards #10374.

