### PR TITLE
Refactor CreateEffectWarhead ImpactTypes

### DIFF
--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -38,7 +38,8 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("List of sounds that can be played on impact.")]
 		public readonly string[] ImpactSounds = new string[0];
 
-		[Desc("Consider explosion above this altitude an air explosion.")]
+		[Desc("Consider explosion above this altitude an air explosion.",
+			"If that's the case, this warhead will consider the explosion position to have the 'Air' TargetType (in addition to any nearby actor's TargetTypes).")]
 		public readonly WDist AirThreshold = new WDist(128);
 
 		[Desc("Scan radius for victims around impact. If set to a negative value (default), it will automatically scale to the largest health shape.",

--- a/OpenRA.Mods.Common/Warheads/Warhead.cs
+++ b/OpenRA.Mods.Common/Warheads/Warhead.cs
@@ -16,18 +16,19 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Warheads
 {
-	[Flags]
 	public enum ImpactType
 	{
-		None = 0,
-		Ground = 1,
-		GroundHit = 2,
-		Water = 4,
-		WaterHit = 8,
-		Air = 16,
-		AirHit = 32,
-		TargetTerrain = 64,
-		TargetHit = 128
+		None,
+		Ground,
+		Air,
+		TargetHit
+	}
+
+	public enum ImpactTargetType
+	{
+		NoActor,
+		ValidActor,
+		InvalidActor
 	}
 
 	[Desc("Base warhead class. This can be used to derive other warheads from.")]

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -32,6 +32,7 @@
 		Explosions: small_frag
 		ImpactSounds: xplos.aud
 		VictimScanRadius: 0
+		ValidTargets: Ground, Water, Air
 
 Dragon:
 	Inherits: ^MissileWeapon
@@ -128,12 +129,12 @@ MammothMissiles:
 	Warhead@3Eff: CreateEffect
 		Explosions: small_poof
 		ImpactSounds: xplos.aud
-		InvalidImpactTypes: Air, AirHit
+		ValidTargets: Ground, Water
 	Warhead@4EffAir: CreateEffect
 		Explosions: small_building
 		ImpactSounds: xplos.aud
 		VictimScanRadius: 0
-		ValidImpactTypes: Air, AirHit
+		ValidTargets: Air
 
 227mm:
 	Inherits: ^MissileWeapon
@@ -207,12 +208,12 @@ BoatMissile:
 	Warhead@3Eff: CreateEffect
 		Explosions: small_poof
 		ImpactSounds: xplos.aud
-		InvalidImpactTypes: Air, AirHit
+		ValidTargets: Ground, Water
 	Warhead@4EffAir: CreateEffect
 		Explosions: small_building
 		ImpactSounds: xplos.aud
-		ValidImpactTypes: Air, AirHit
 		VictimScanRadius: 0
+		ValidTargets: Air
 
 TowerMissle:
 	Inherits: ^MissileWeapon

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -30,6 +30,7 @@ Sniper:
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
 		VictimScanRadius: 0
+		ValidTargets: Ground, Water, Air
 
 HighV:
 	Inherits: ^HeavyMG
@@ -131,6 +132,7 @@ APCGun:
 		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: small_poof
+		ValidTargets: Ground, Water, Air
 
 APCGun.AA:
 	Inherits: APCGun

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -31,6 +31,7 @@
 	Warhead@3Eff: CreateEffect
 		Explosions: tiny_explosion
 		VictimScanRadius: 0
+		ValidTargets: Ground, Air
 
 ^Missile:
 	Inherits: ^Rocket

--- a/mods/ra/maps/drop-zone-w/weapons.yaml
+++ b/mods/ra/maps/drop-zone-w/weapons.yaml
@@ -19,16 +19,6 @@
 			Heavy: 25
 		Damage: 250
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
-	Warhead@1Eff: CreateEffect
-		Explosions: large_explosion
-		ImpactSounds: kaboom12.aud
-		ValidImpactTypes: Ground
-	Warhead@2Eff: CreateEffect
-		Explosions: large_splash
-		ImpactSounds: splash9.aud
-		ValidImpactTypes: Water
-	Warhead@3Smu: LeaveSmudge
-		SmudgeType: Crater
 
 SubMissile:
 	ReloadDelay: 250
@@ -51,13 +41,3 @@ SubMissile:
 			Heavy: 30
 		Damage: 400
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
-	Warhead@1Eff: CreateEffect
-		Explosions: large_explosion
-		ImpactSounds: kaboom12.aud
-		ValidImpactTypes: Ground
-	Warhead@2Eff: CreateEffect
-		Explosions: large_splash
-		ImpactSounds: splash9.aud
-		ValidImpactTypes: Water
-	Warhead@3Smu: LeaveSmudge
-		SmudgeType: Crater

--- a/mods/ra/maps/monster-tank-madness/weapons.yaml
+++ b/mods/ra/maps/monster-tank-madness/weapons.yaml
@@ -7,6 +7,7 @@ TurretGun:
 		Blockable: false
 
 SuperTankPrimary:
+	Inherits: ^Cannon
 	ROF: 70
 	Range: 4c768
 	Report: turret1.aud
@@ -27,9 +28,7 @@ SuperTankPrimary:
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
-	Warhead@3EffGround: CreateEffect
+	Warhead@3Eff: CreateEffect
 		Explosions: small_explosion
-		InvalidImpactTypes: Water
 	Warhead@4EffWater: CreateEffect
 		Explosions: small_splash
-		ValidImpactTypes: Water

--- a/mods/ra/maps/soviet-07/weapons.yaml
+++ b/mods/ra/maps/soviet-07/weapons.yaml
@@ -15,10 +15,6 @@ M1CarbineInterior:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
-		InvalidImpactTypes: Water
-	Warhead@3EffWater: CreateEffect
-		Explosions: water_piffs
-		ValidImpactTypes: Water
 
 FireballLauncherInterior:
 	ReloadDelay: 65

--- a/mods/ra/maps/survival02/weapons.yaml
+++ b/mods/ra/maps/survival02/weapons.yaml
@@ -15,13 +15,9 @@ ParaBomb:
 			Heavy: 50
 			Concrete: 25
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath
-	Warhead@2Smu: LeaveSmudge
-		SmudgeType: Crater
 	Warhead@3Eff: CreateEffect
 		Explosions: napalm
 		ImpactSounds: firebl3.aud
-		InvalidImpactTypes: Water
 	Warhead@4EffWater: CreateEffect
 		Explosions: napalm
-		ImpactSounds: splash9.aud
-		ValidImpactTypes: Water
+		ImpactSounds: firebl3.aud

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -452,7 +452,7 @@
 	Selectable:
 		Bounds: 24,24
 	Targetable:
-		TargetTypes: Ground, Water, Repair
+		TargetTypes: Ground, Water, Ship, Repair
 	HiddenUnderFog:
 	AttackMove:
 	ActorLostNotification:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -23,10 +23,9 @@ SS:
 	RevealsShroud@GAPGEN:
 		Range: 5c0
 	Targetable:
-		TargetTypes: Ground, Water, Repair
 		RequiresCondition: !underwater
 	Targetable@UNDERWATER:
-		TargetTypes: Underwater, Repair
+		TargetTypes: Water, Underwater, Repair
 		RequiresCondition: underwater
 	Cloak:
 		CloakTypes: Underwater
@@ -87,10 +86,9 @@ MSUB:
 	RevealsShroud@GAPGEN:
 		Range: 5c0
 	Targetable:
-		TargetTypes: Ground, Water, Repair
 		RequiresCondition: !underwater
 	Targetable@UNDERWATER:
-		TargetTypes: Underwater, Repair
+		TargetTypes: Water, Underwater, Repair
 		RequiresCondition: underwater
 	Cloak:
 		CloakTypes: Underwater

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -21,11 +21,12 @@
 	Warhead@3Eff: CreateEffect
 		Explosions: small_explosion
 		ImpactSounds: kaboom12.aud
-		InvalidImpactTypes: Water
+		ValidTargets: Ground, Ship
 	Warhead@4EffWater: CreateEffect
 		Explosions: small_splash
 		ImpactSounds: splash9.aud
-		ValidImpactTypes: Water
+		ValidTargets: Water, Underwater
+		InvalidTargets: Ship, Structure
 
 25mm:
 	Inherits: ^Cannon
@@ -139,6 +140,7 @@ TurretGun:
 	ReloadDelay: 60
 	Range: 5c512
 	Report: cannon2.aud
+	InvalidTargets: Underwater
 	Projectile: Bullet
 		Speed: 426
 	Warhead@1Dam: SpreadDamage
@@ -183,7 +185,8 @@ DepthCharge:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 80
-		ValidTargets: Underwater
+		ValidTargets: Underwater, Water
+		InvalidTargets: Ship
 		Versus:
 			None: 30
 			Wood: 75
@@ -194,8 +197,8 @@ DepthCharge:
 	Warhead@4EffWater: CreateEffect
 		Explosions: large_splash
 		ImpactSounds: h2obomb2.aud
-		ValidImpactTypes: Water, WaterHit
+		ValidTargets: Water, Underwater
 	Warhead@3Eff: CreateEffect
 		Explosions: small_explosion
 		ImpactSounds: kaboom15.aud
-		ValidImpactTypes: WaterHit
+		ValidTargets: Underwater

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -1,4 +1,5 @@
 ^Explosion:
+	ValidTargets: Ground, Water, Air
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 50
@@ -15,11 +16,12 @@
 	Warhead@2Eff: CreateEffect
 		Explosions: self_destruct
 		ImpactSounds: kaboom22.aud
-		InvalidImpactTypes: Water
+		ValidTargets: Ground, Air, Ship
 	Warhead@3EffWater: CreateEffect
 		Explosions: large_splash
 		ImpactSounds: splash9.aud
-		ValidImpactTypes: Water
+		ValidTargets: Water, Underwater
+		InvalidTargets: Ship, Structure
 
 CrateNapalm:
 	Inherits: ^Explosion
@@ -37,7 +39,7 @@ CrateNapalm:
 	Warhead@2Eff: CreateEffect
 		Explosions: napalm
 		ImpactSounds: firebl3.aud
-		InvalidImpactTypes: None
+		ValidTargets: Ground, Water, Air
 	-Warhead@3EffWater: CreateEffect
 	Warhead@Smu: LeaveSmudge
 		SmudgeType: Scorch
@@ -48,7 +50,7 @@ CrateExplosion:
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		AffectsParent: true
 	Warhead@2Eff: CreateEffect
-		InvalidImpactTypes: None
+		ValidTargets: Ground, Water, Air
 	-Warhead@3EffWater: CreateEffect
 
 UnitExplode:
@@ -62,7 +64,7 @@ UnitExplodeShip:
 	Warhead@2Eff: CreateEffect
 		Explosions: building
 		ImpactSounds: kaboom25.aud
-		InvalidImpactTypes: None
+		ValidTargets: Ground, Water
 
 UnitExplodeSubmarine:
 	Inherits: ^Explosion
@@ -70,7 +72,7 @@ UnitExplodeSubmarine:
 	Warhead@2Eff: CreateEffect
 		Explosions: large_splash
 		ImpactSounds: splash9.aud
-		InvalidImpactTypes: None
+		ValidTargets: Ground, Water
 
 UnitExplodeSmall:
 	Inherits: ^Explosion
@@ -127,7 +129,6 @@ BarrelExplode:
 		Explosions: napalm
 		ImpactSounds: firebl3.aud
 		Delay: 5
-		InvalidImpactTypes: None
 	-Warhead@3EffWater: CreateEffect
 	Warhead@Smu: LeaveSmudge
 		SmudgeType: Scorch

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -30,11 +30,12 @@
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion
 		ImpactSounds: kaboom25.aud
-		InvalidImpactTypes: Water
+		ValidTargets: Ground, Air, Ship
 	Warhead@4EffWater: CreateEffect
 		Explosions: med_splash
 		ImpactSounds: splash9.aud
-		ValidImpactTypes: Water
+		ValidTargets: Water, Underwater
+		InvalidTargets: Ship, Structure
 
 ^AntiAirMissile:
 	Inherits: ^AntiGroundMissile
@@ -127,11 +128,11 @@ MammothTusk:
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@3Eff: CreateEffect
 		ImpactSounds: kaboom12.aud
-		InvalidImpactTypes: Water, Air, AirHit
+		ValidTargets: Ground
 	Warhead@5EffAir: CreateEffect
 		Explosions: med_explosion_air
 		ImpactSounds: kaboom25.aud
-		ValidImpactTypes: Air, AirHit
+		ValidTargets: Air
 
 Nike:
 	Inherits: ^AntiAirMissile
@@ -177,6 +178,7 @@ Stinger:
 	Range: 7c512
 	Burst: 2
 	BurstDelay: 0
+	InvalidTargets: Underwater
 	Projectile: Missile
 		Arm: 3
 		Inaccuracy: 0
@@ -190,12 +192,6 @@ Stinger:
 			None: 30
 			Light: 75
 			Concrete: 50
-	Warhead@3Eff: CreateEffect
-		InvalidImpactTypes: Water, Air, AirHit
-	Warhead@5EffAir: CreateEffect
-		Explosions: med_explosion_air
-		ImpactSounds: kaboom25.aud
-		ValidImpactTypes: Air, AirHit
 
 StingerAA:
 	Inherits: Stinger
@@ -203,6 +199,9 @@ StingerAA:
 	Projectile: Missile
 		Speed: 255
 		CloseEnough: 298
+	Warhead@3Eff: CreateEffect
+		Explosions: med_explosion_air
+		ImpactSounds: kaboom25.aud
 
 APTusk:
 	Inherits: ^AntiGroundMissile
@@ -250,15 +249,16 @@ TorpTube:
 	Warhead@3Eff: CreateEffect
 		Explosions: large_explosion
 		ImpactSounds: kaboom15.aud
-		InvalidImpactTypes: Water, WaterHit
+		InvalidTargets: Water
 	Warhead@5EffWaterHit: CreateEffect
 		Explosions: artillery_explosion
 		ImpactSounds: kaboom15.aud
-		ValidImpactTypes: WaterHit
+		ValidTargets: Ship, Structure, Underwater
 	Warhead@4EffWater: CreateEffect
 		Explosions: large_splash
 		ImpactSounds: splash9.aud
-		ValidImpactTypes: Water
+		ValidTargets: Water
+		InvalidTargets: Ship, Structure, Underwater
 
 ^SubMissileDefault:
 	Inherits: ^AntiGroundMissile
@@ -288,11 +288,9 @@ TorpTube:
 	Warhead@3Eff: CreateEffect
 		Explosions: artillery_explosion
 		ImpactSounds: kaboom15.aud
-		InvalidImpactTypes: Water
 	Warhead@4EffWater: CreateEffect
 		Explosions: large_splash
 		ImpactSounds: splash9.aud
-		ValidImpactTypes: Water
 
 SubMissile:
 	Inherits: ^SubMissileDefault

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -19,6 +19,7 @@
 		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: small_explosion_air
+		ValidTargets: Air, Ground, Water
 
 ZSU-23:
 	Inherits: ^AACannon
@@ -50,10 +51,11 @@ FLAK-23-AG:
 		ValidTargets: Air, Ground, Water
 	Warhead@2Eff: CreateEffect
 		Explosions: flak_explosion_ground
-		InvalidImpactTypes: Water
+		ValidTargets: Ground, Ship, Air
 	Warhead@3EffWater: CreateEffect
 		Explosions: small_splash
-		ValidImpactTypes: Water
+		ValidTargets: Water, Underwater
+		InvalidTargets: Ship, Structure
 
 ^HeavyMG:
 	ReloadDelay: 30
@@ -73,10 +75,11 @@ FLAK-23-AG:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
-		InvalidImpactTypes: Water
+		ValidTargets: Ground, Ship, Air
 	Warhead@3EffWater: CreateEffect
 		Explosions: water_piffs
-		ValidImpactTypes: Water
+		ValidTargets: Water, Underwater
+		InvalidTargets: Ship, Structure
 
 ^LightMG:
 	Inherits: ^HeavyMG
@@ -107,11 +110,11 @@ Vulcan:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@4Eff_2: CreateEffect
 		Explosions: piffs
-		InvalidImpactTypes: Water
+		ValidTargets: Ground
 		Delay: 2
 	Warhead@4Eff_2Water: CreateEffect
 		Explosions: water_piffs
-		ValidImpactTypes: Water
+		ValidTargets: Water
 		Delay: 2
 	Warhead@5Dam_3: SpreadDamage
 		Spread: 128
@@ -126,11 +129,11 @@ Vulcan:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@6Eff_3: CreateEffect
 		Explosions: piffs
-		InvalidImpactTypes: Water
+		ValidTargets: Ground
 		Delay: 4
 	Warhead@6Eff_3Water: CreateEffect
 		Explosions: water_piffs
-		ValidImpactTypes: Water
+		ValidTargets: Water
 		Delay: 4
 	Warhead@7Dam_4: SpreadDamage
 		Spread: 128
@@ -145,11 +148,11 @@ Vulcan:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@8Eff_4: CreateEffect
 		Explosions: piffs
-		InvalidImpactTypes: Water
+		ValidTargets: Ground
 		Delay: 6
 	Warhead@8Eff_4Water: CreateEffect
 		Explosions: water_piffs
-		ValidImpactTypes: Water
+		ValidTargets: Water
 		Delay: 6
 	Warhead@9Dam_5: SpreadDamage
 		Spread: 128
@@ -164,11 +167,11 @@ Vulcan:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@10Eff_5: CreateEffect
 		Explosions: piffs
-		InvalidImpactTypes: Water
+		ValidTargets: Ground
 		Delay: 8
 	Warhead@10Eff_5Water: CreateEffect
 		Explosions: water_piffs
-		ValidImpactTypes: Water
+		ValidTargets: Water
 		Delay: 8
 	Warhead@11Dam_6: SpreadDamage
 		Spread: 128
@@ -183,11 +186,11 @@ Vulcan:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@12Eff_6: CreateEffect
 		Explosions: piffs
-		InvalidImpactTypes: Water
+		ValidTargets: Ground
 		Delay: 10
 	Warhead@12Eff_6Water: CreateEffect
 		Explosions: water_piffs
-		ValidImpactTypes: Water
+		ValidTargets: Water
 		Delay: 10
 
 ChainGun:
@@ -260,10 +263,11 @@ SilencedPPK:
 		Spread: 128
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
-		InvalidImpactTypes: Water
+		ValidTargets: Ground, Ship, Air
 	Warhead@3EffWater: CreateEffect
 		Explosions: water_piffs
-		ValidImpactTypes: Water
+		ValidTargets: Water, Underwater
+		InvalidTargets: Ship, Structure
 
 Colt45:
 	Inherits: ^SnipeWeapon
@@ -273,10 +277,11 @@ Colt45:
 		Damage: 50
 	Warhead@2Eff: CreateEffect
 		Explosions: piff
-		InvalidImpactTypes: Water
+		ValidTargets: Ground, Ship, Air
 	Warhead@3EffWater: CreateEffect
 		Explosions: water_piff
-		ValidImpactTypes: Water
+		ValidTargets: Water, Underwater
+		InvalidTargets: Ship, Structure
 
 Sniper:
 	Inherits: ^SnipeWeapon

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -22,11 +22,12 @@ ParaBomb:
 	Warhead@3Eff: CreateEffect
 		Explosions: artillery_explosion
 		ImpactSounds: kaboom15.aud
-		InvalidImpactTypes: Water
+		ValidTargets: Ground, Ship
 	Warhead@4EffWater: CreateEffect
 		Explosions: small_splash
 		ImpactSounds: splash9.aud
-		ValidImpactTypes: Water
+		ValidTargets: Water, Underwater
+		InvalidTargets: Ship, Structure
 
 Atomic:
 	ValidTargets: Ground, Trees, Water, Underwater, Air

--- a/mods/ts/weapons/ballisticweapons.yaml
+++ b/mods/ts/weapons/ballisticweapons.yaml
@@ -23,12 +23,13 @@
 		Explosions: medium_clsn
 		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew14.aud
-		InvalidImpactTypes: Water
+		ValidTargets: Ground, Air
 	Warhead@3EffWater: CreateEffect
 		Explosions: small_watersplash
 		ExplosionPalette: player
 		ImpactSounds: ssplash3.aud
-		ValidImpactTypes: Water
+		ValidTargets: Water
+		InvalidTargets: Vehicle
 	Warhead@4Smu: LeaveSmudge
 		SmudgeType: MediumCrater
 		InvalidTargets: Vehicle, Building, Wall

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -107,12 +107,13 @@ SonicZap:
 		Explosions: large_explosion
 		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew12.aud
-		InvalidImpactTypes: Water
+		ValidTargets: Ground, Air
 	Warhead@3EffWater: CreateEffect
 		Explosions: small_watersplash
 		ExplosionPalette: player
 		ImpactSounds: ssplash3.aud
-		ValidImpactTypes: Water
+		ValidTargets: Water
+		InvalidTargets: Vehicle
 	Warhead@4Smu: LeaveSmudge
 		SmudgeType: SmallScorch
 		InvalidTargets: Vehicle, Building, Wall

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -37,12 +37,13 @@
 		Explosions: small_clsn
 		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew12.aud
-		InvalidImpactTypes: Water
+		ValidTargets: Ground, Air
 	Warhead@3EffWater: CreateEffect
 		Explosions: small_watersplash
 		ExplosionPalette: player
 		ImpactSounds: ssplash3.aud
-		ValidImpactTypes: Water
+		ValidTargets: Water
+		InvalidTargets: Vehicle
 	Warhead@Smu: LeaveSmudge
 		SmudgeType: SmallCrater
 		InvalidTargets: Vehicle, Building, Wall

--- a/mods/ts/weapons/otherweapons.yaml
+++ b/mods/ts/weapons/otherweapons.yaml
@@ -50,12 +50,13 @@ Bomb:
 		Explosions: large_explosion
 		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew09.aud
-		InvalidImpactTypes: Water
+		ValidTargets: Ground, Air
 	Warhead@3EffWater: CreateEffect
 		Explosions: small_watersplash
 		ExplosionPalette: player
 		ImpactSounds: ssplash3.aud
-		ValidImpactTypes: Water
+		ValidTargets: Water
+		InvalidTargets: Vehicle
 	Warhead@4Smu: LeaveSmudge
 		SmudgeType: MediumCrater
 		InvalidTargets: Vehicle, Building, Wall
@@ -85,7 +86,8 @@ FiendShard:
 		Explosions: small_watersplash
 		ExplosionPalette: player
 		ImpactSounds: ssplash3.aud
-		ValidImpactTypes: Water
+		ValidTargets: Water
+		InvalidTargets: Vehicle
 
 SlimeAttack:
 	ReloadDelay: 80
@@ -151,12 +153,13 @@ Veins:
 	Warhead@2Eff: CreateEffect
 		Explosions: tiny_twlt
 		ExplosionPalette: effect-ignore-lighting-alpha75
-		InvalidImpactTypes: Water
+		ValidTargets: Ground, Air
 	Warhead@3EffWater: CreateEffect
 		Explosions: small_watersplash
 		ExplosionPalette: player
 		ImpactSounds: ssplash3.aud
-		ValidImpactTypes: Water
+		ValidTargets: Water
+		InvalidTargets: Vehicle
 	Warhead@4Smu: LeaveSmudge
 		SmudgeType: SmallScorch
 		InvalidTargets: Vehicle, Building, Wall

--- a/mods/ts/weapons/smallguns.yaml
+++ b/mods/ts/weapons/smallguns.yaml
@@ -15,11 +15,12 @@
 		DamageTypes: Prone70Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
-		InvalidImpactTypes: Water
+		ValidTargets: Ground, Air
 	Warhead@3EffWater: CreateEffect
 		Explosions: water_piffs
 		ExplosionPalette: ra
-		ValidImpactTypes: Water
+		ValidTargets: Water
+		InvalidTargets: Vehicle
 
 Minigun:
 	Inherits: ^MG

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -29,12 +29,12 @@ MultiCluster:
 	Warhead@2Eff: CreateEffect
 		Explosions: large_explosion
 		ImpactSounds: expnew09.aud
-		InvalidImpactTypes: Water
+		ValidTargets: Ground, Air
 	Warhead@3EffWater: CreateEffect
 		Explosions: small_watersplash
 		ExplosionPalette: player
-		ImpactSounds: ssplash2.aud
-		ValidImpactTypes: Water
+		ValidTargets: Water
+		InvalidTargets: Vehicle
 	Warhead@4Smu: LeaveSmudge
 		SmudgeType: MediumCrater
 		InvalidTargets: Vehicle, Building, Wall


### PR DESCRIPTION
Not only were there quite a few of them, more importantly they also ignored target validity.

This PR solves both.
As side-effect, it fixes the issue in RA where a weapon hitting a cell occupied by a submerged sub would display an explosion instead of a water splash.

TD and D2k didn't use custom impact type settings, so all they need are a few yaml changes to cover the fact that `Warhead.ValidTargets` does not contain `Air` by default.

Closes #11848.