### PR TITLE
Tweak effect warhead victim scans

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -69,13 +69,13 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Beam color is the player's color.")]
 		public readonly bool UsePlayerColor = false;
 
-		[Desc("Scan radius for actors with projectile-blocking trait. If set to zero (default), it will automatically scale",
+		[Desc("Scan radius for actors with projectile-blocking trait. If set to a negative value (default), it will automatically scale",
 			"to the blocker with the largest health shape. Only set custom values if you know what you're doing.")]
-		public WDist BlockerScanRadius = WDist.Zero;
+		public WDist BlockerScanRadius = new WDist(-1);
 
-		[Desc("Scan radius for actors damaged by beam. If set to zero (default), it will automatically scale to the largest health shape.",
+		[Desc("Scan radius for actors damaged by beam. If set to a negative value (default), it will automatically scale to the largest health shape.",
 			"Only set custom values if you know what you're doing.")]
-		public WDist AreaVictimScanRadius = WDist.Zero;
+		public WDist AreaVictimScanRadius = new WDist(-1);
 
 		public IProjectile Create(ProjectileArgs args)
 		{
@@ -85,10 +85,10 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo wi)
 		{
-			if (BlockerScanRadius == WDist.Zero)
+			if (BlockerScanRadius < WDist.Zero)
 				BlockerScanRadius = Util.MinimumRequiredBlockerScanRadius(rules);
 
-			if (AreaVictimScanRadius == WDist.Zero)
+			if (AreaVictimScanRadius < WDist.Zero)
 				AreaVictimScanRadius = Util.MinimumRequiredVictimScanRadius(rules);
 		}
 	}

--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			return new AreaBeam(this, args, c);
 		}
 
-		public void RulesetLoaded(Ruleset rules, WeaponInfo wi)
+		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo wi)
 		{
 			if (BlockerScanRadius == WDist.Zero)
 				BlockerScanRadius = Util.MinimumRequiredBlockerScanRadius(rules);

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -103,7 +103,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		public IProjectile Create(ProjectileArgs args) { return new Bullet(this, args); }
 
-		public void RulesetLoaded(Ruleset rules, WeaponInfo wi)
+		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo wi)
 		{
 			if (BlockerScanRadius == WDist.Zero)
 				BlockerScanRadius = Util.MinimumRequiredBlockerScanRadius(rules);

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -93,22 +93,22 @@ namespace OpenRA.Mods.Common.Projectiles
 		public readonly int ContrailDelay = 1;
 		public readonly WDist ContrailWidth = new WDist(64);
 
-		[Desc("Scan radius for actors with projectile-blocking trait. If set to zero (default), it will automatically scale",
+		[Desc("Scan radius for actors with projectile-blocking trait. If set to a negative value (default), it will automatically scale",
 			"to the blocker with the largest health shape. Only set custom values if you know what you're doing.")]
-		public WDist BlockerScanRadius = WDist.Zero;
+		public WDist BlockerScanRadius = new WDist(-1);
 
-		[Desc("Extra search radius beyond path for actors with ValidBounceBlockerStances. If set to zero (default), ",
+		[Desc("Extra search radius beyond path for actors with ValidBounceBlockerStances. If set to a negative value (default), ",
 			"it will automatically scale to the largest health shape. Only set custom values if you know what you're doing.")]
-		public WDist BounceBlockerScanRadius = WDist.Zero;
+		public WDist BounceBlockerScanRadius = new WDist(-1);
 
 		public IProjectile Create(ProjectileArgs args) { return new Bullet(this, args); }
 
 		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo wi)
 		{
-			if (BlockerScanRadius == WDist.Zero)
+			if (BlockerScanRadius < WDist.Zero)
 				BlockerScanRadius = Util.MinimumRequiredBlockerScanRadius(rules);
 
-			if (BounceBlockerScanRadius == WDist.Zero)
+			if (BounceBlockerScanRadius < WDist.Zero)
 				BounceBlockerScanRadius = Util.MinimumRequiredVictimScanRadius(rules);
 		}
 	}

--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -30,15 +30,15 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("The width of the projectile.")]
 		public readonly WDist Width = new WDist(1);
 
-		[Desc("Scan radius for actors with projectile-blocking trait. If set to zero (default), it will automatically scale",
+		[Desc("Scan radius for actors with projectile-blocking trait. If set to a negative value (default), it will automatically scale",
 			"to the blocker with the largest health shape. Only set custom values if you know what you're doing.")]
-		public WDist BlockerScanRadius = WDist.Zero;
+		public WDist BlockerScanRadius = new WDist(-1);
 
 		public IProjectile Create(ProjectileArgs args) { return new InstantHit(this, args); }
 
 		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo wi)
 		{
-			if (BlockerScanRadius == WDist.Zero)
+			if (BlockerScanRadius < WDist.Zero)
 				BlockerScanRadius = Util.MinimumRequiredBlockerScanRadius(rules);
 		}
 	}

--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		public IProjectile Create(ProjectileArgs args) { return new InstantHit(this, args); }
 
-		public void RulesetLoaded(Ruleset rules, WeaponInfo wi)
+		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo wi)
 		{
 			if (BlockerScanRadius == WDist.Zero)
 				BlockerScanRadius = Util.MinimumRequiredBlockerScanRadius(rules);

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -74,9 +74,9 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		[PaletteReference] public readonly string HitAnimPalette = "effect";
 
-		[Desc("Scan radius for actors with projectile-blocking trait. If set to zero (default), it will automatically scale",
+		[Desc("Scan radius for actors with projectile-blocking trait. If set to a negative value (default), it will automatically scale",
 			"to the blocker with the largest health shape. Only set custom values if you know what you're doing.")]
-		public WDist BlockerScanRadius = WDist.Zero;
+		public WDist BlockerScanRadius = new WDist(-1);
 
 		public IProjectile Create(ProjectileArgs args)
 		{
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo wi)
 		{
-			if (BlockerScanRadius == WDist.Zero)
+			if (BlockerScanRadius < WDist.Zero)
 				BlockerScanRadius = Util.MinimumRequiredBlockerScanRadius(rules);
 		}
 	}

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			return new LaserZap(this, args, c);
 		}
 
-		public void RulesetLoaded(Ruleset rules, WeaponInfo wi)
+		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo wi)
 		{
 			if (BlockerScanRadius == WDist.Zero)
 				BlockerScanRadius = Util.MinimumRequiredBlockerScanRadius(rules);

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -148,7 +148,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		public IProjectile Create(ProjectileArgs args) { return new Missile(this, args); }
 
-		public void RulesetLoaded(Ruleset rules, WeaponInfo wi)
+		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo wi)
 		{
 			if (BlockerScanRadius == WDist.Zero)
 				BlockerScanRadius = Util.MinimumRequiredBlockerScanRadius(rules);

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -142,15 +142,15 @@ namespace OpenRA.Mods.Common.Projectiles
 			"not trigger fast enough, causing the missile to fly past the target.")]
 		public readonly WDist CloseEnough = new WDist(298);
 
-		[Desc("Scan radius for actors with projectile-blocking trait. If set to zero (default), it will automatically scale",
+		[Desc("Scan radius for actors with projectile-blocking trait. If set to a negative value (default), it will automatically scale",
 			"to the blocker with the largest health shape. Only set custom values if you know what you're doing.")]
-		public WDist BlockerScanRadius = WDist.Zero;
+		public WDist BlockerScanRadius = new WDist(-1);
 
 		public IProjectile Create(ProjectileArgs args) { return new Missile(this, args); }
 
 		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo wi)
 		{
-			if (BlockerScanRadius == WDist.Zero)
+			if (BlockerScanRadius < WDist.Zero)
 				BlockerScanRadius = Util.MinimumRequiredBlockerScanRadius(rules);
 		}
 	}

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Warheads
 			"Custom overrides should not be necessary under normal circumstances.")]
 		public WDist VictimScanRadius = WDist.Zero;
 
-		public void RulesetLoaded(Ruleset rules, WeaponInfo wi)
+		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo info)
 		{
 			if (VictimScanRadius == WDist.Zero)
 				VictimScanRadius = Util.MinimumRequiredVictimScanRadius(rules);

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -41,13 +41,13 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("What impact types should this effect NOT apply to.", "Overrides ValidImpactTypes.")]
 		public readonly ImpactType InvalidImpactTypes = ImpactType.None;
 
-		[Desc("Scan radius for victims around impact. If set to zero (default), it will automatically scale to the largest health shape.",
+		[Desc("Scan radius for victims around impact. If set to a negative value (default), it will automatically scale to the largest health shape.",
 			"Custom overrides should not be necessary under normal circumstances.")]
-		public WDist VictimScanRadius = WDist.Zero;
+		public WDist VictimScanRadius = new WDist(-1);
 
 		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo info)
 		{
-			if (VictimScanRadius == WDist.Zero)
+			if (VictimScanRadius < WDist.Zero)
 				VictimScanRadius = Util.MinimumRequiredVictimScanRadius(rules);
 		}
 

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Warheads
 			"Custom overrides should not be necessary under normal circumstances.")]
 		public WDist VictimScanRadius = WDist.Zero;
 
-		public void RulesetLoaded(Ruleset rules, WeaponInfo info)
+		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo info)
 		{
 			if (VictimScanRadius == WDist.Zero)
 				VictimScanRadius = Util.MinimumRequiredVictimScanRadius(rules);

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -28,13 +28,13 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("Ranges at which each Falloff step is defined. Overrides Spread.")]
 		public WDist[] Range = null;
 
-		[Desc("Extra search radius beyond maximum spread. If set to zero (default), it will automatically scale to the largest health shape.",
+		[Desc("Extra search radius beyond maximum spread. If set to a negative value (default), it will automatically scale to the largest health shape.",
 			"Custom overrides should not be necessary under normal circumstances.")]
-		public WDist VictimScanRadius = WDist.Zero;
+		public WDist VictimScanRadius = new WDist(-1);
 
 		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo info)
 		{
-			if (VictimScanRadius == WDist.Zero)
+			if (VictimScanRadius < WDist.Zero)
 				VictimScanRadius = Util.MinimumRequiredVictimScanRadius(rules);
 
 			if (Range != null)

--- a/mods/cnc/weapons/ballistics.yaml
+++ b/mods/cnc/weapons/ballistics.yaml
@@ -21,6 +21,7 @@
 	Warhead@3Eff: CreateEffect
 		Explosions: small_frag
 		ImpactSounds: xplos.aud
+		VictimScanRadius: 0
 
 70mm:
 	Inherits: ^BallisticWeapon

--- a/mods/cnc/weapons/explosions.yaml
+++ b/mods/cnc/weapons/explosions.yaml
@@ -11,6 +11,7 @@
 	Warhead@2Eff: CreateEffect
 		Explosions: poof
 		ImpactSounds: xplos.aud
+		VictimScanRadius: 0
 	Warhead@3Smu: LeaveSmudge
 		SmudgeType: Crater
 		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees, Creep
@@ -80,6 +81,7 @@ BuildingExplode:
 	Warhead@1Eff: CreateEffect
 		Explosions: building, building_napalm, med_frag, poof, small_building
 		Delay: 1
+		VictimScanRadius: 0
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 		Delay: 1

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -31,6 +31,7 @@
 	Warhead@3Eff: CreateEffect
 		Explosions: small_frag
 		ImpactSounds: xplos.aud
+		VictimScanRadius: 0
 
 Dragon:
 	Inherits: ^MissileWeapon
@@ -131,6 +132,7 @@ MammothMissiles:
 	Warhead@4EffAir: CreateEffect
 		Explosions: small_building
 		ImpactSounds: xplos.aud
+		VictimScanRadius: 0
 		ValidImpactTypes: Air, AirHit
 
 227mm:
@@ -210,6 +212,7 @@ BoatMissile:
 		Explosions: small_building
 		ImpactSounds: xplos.aud
 		ValidImpactTypes: Air, AirHit
+		VictimScanRadius: 0
 
 TowerMissle:
 	Inherits: ^MissileWeapon

--- a/mods/cnc/weapons/other.yaml
+++ b/mods/cnc/weapons/other.yaml
@@ -23,6 +23,7 @@
 	Warhead@3Eff: CreateEffect
 		Explosions: small_napalm
 		ImpactSounds: flamer2.aud
+		VictimScanRadius: 0
 
 Flamethrower:
 	Inherits: ^FlameWeapon
@@ -139,3 +140,4 @@ Demolish:
 	Warhead@2Eff: CreateEffect
 		Explosions: building
 		ImpactSounds: xplobig6.aud
+		VictimScanRadius: 0

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -29,6 +29,7 @@ Sniper:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
+		VictimScanRadius: 0
 
 HighV:
 	Inherits: ^HeavyMG

--- a/mods/cnc/weapons/superweapons.yaml
+++ b/mods/cnc/weapons/superweapons.yaml
@@ -15,6 +15,7 @@ Atomic:
 	Warhead@2Eff_impact: CreateEffect
 		Explosions: nuke_explosion
 		ImpactSounds: nukexplo.aud
+		VictimScanRadius: 0
 	Warhead@3Dam_areanukea: SpreadDamage
 		Spread: 2c512
 		Damage: 110
@@ -38,6 +39,7 @@ Atomic:
 	Warhead@6Eff_areanukea: CreateEffect
 		ImpactSounds: xplobig4.aud
 		Delay: 3
+		VictimScanRadius: 0
 	Warhead@7Dam_areanukeb: SpreadDamage
 		Spread: 3c768
 		Damage: 50

--- a/mods/d2k/weapons/debris.yaml
+++ b/mods/d2k/weapons/debris.yaml
@@ -31,6 +31,7 @@ Debris:
 		InvalidTargets: Vehicle, Structure
 	Warhead@3Eff: CreateEffect
 		Explosions: tiny_explosion
+		VictimScanRadius: 0
 
 Debris2:
 	Inherits: Debris

--- a/mods/d2k/weapons/largeguns.yaml
+++ b/mods/d2k/weapons/largeguns.yaml
@@ -25,6 +25,7 @@
 		InvalidTargets: Vehicle, Structure
 	Warhead@3Eff: CreateEffect
 		Explosions: small_napalm
+		VictimScanRadius: 0
 
 110mm_Gun:
 	Inherits: ^Cannon

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -30,6 +30,7 @@
 		InvalidTargets: Vehicle, Structure
 	Warhead@3Eff: CreateEffect
 		Explosions: tiny_explosion
+		VictimScanRadius: 0
 
 ^Missile:
 	Inherits: ^Rocket

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -79,6 +79,7 @@ OrniBomb:
 	Warhead@3Eff: CreateEffect
 		Explosions: large_explosion
 		ImpactSounds: EXPLSML4.WAV
+		VictimScanRadius: 0
 
 Crush:
 	Warhead@1Dam: SpreadDamage
@@ -93,6 +94,7 @@ Demolish:
 	Warhead@2Eff: CreateEffect
 		Explosions: building
 		ImpactSounds: EXPLLG2.WAV
+		VictimScanRadius: 0
 
 Atomic:
 	Warhead@1Dam: SpreadDamage
@@ -113,6 +115,7 @@ Atomic:
 	Warhead@2Eff: CreateEffect
 		Explosions: nuke
 		ImpactSounds: EXPLLG2.WAV
+		VictimScanRadius: 0
 
 CrateNuke:
 	Inherits: Atomic
@@ -142,30 +145,36 @@ CrateExplosion:
 	Warhead@2Eff: CreateEffect
 		Explosions: large_explosion
 		ImpactSounds: EXPLSML4.WAV
+		VictimScanRadius: 0
 
 UnitExplodeSmall:
 	Warhead@1Eff: CreateEffect
 		Explosions: self_destruct
 		ImpactSounds: EXPLSML1.WAV
+		VictimScanRadius: 0
 
 UnitExplodeMed:
 	Warhead@1Eff: CreateEffect
 		Explosions: building
 		ImpactSounds: EXPLSML2.WAV
+		VictimScanRadius: 0
 
 UnitExplodeLarge:
 	Warhead@1Eff: CreateEffect
 		Explosions: large_explosion
 		ImpactSounds: EXPLLG2.WAV
+		VictimScanRadius: 0
 
 BuildingExplode:
 	Warhead@1Eff: CreateEffect
 		Explosions: building, self_destruct, large_explosion
+		VictimScanRadius: 0
 
 WallExplode:
 	Warhead@1Eff: CreateEffect
 		Explosions: wall_explosion
 		ImpactSounds: EXPLHG1.WAV
+		VictimScanRadius: 0
 
 grenade:
 	ReloadDelay: 50
@@ -196,6 +205,7 @@ grenade:
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion
 		ImpactSounds: EXPLMD2.WAV
+		VictimScanRadius: 0
 
 GrenDeath:
 	Warhead@1Dam: SpreadDamage
@@ -216,6 +226,7 @@ GrenDeath:
 	Warhead@3Eff: CreateEffect
 		Explosions: building
 		ImpactSounds: EXPLSML4.WAV
+		VictimScanRadius: 0
 
 SardDeath:
 	Warhead@1Dam: SpreadDamage
@@ -237,6 +248,7 @@ SardDeath:
 	Warhead@3Eff: CreateEffect
 		Explosions: small_napalm
 		ImpactSounds: EXPLSML2.WAV
+		VictimScanRadius: 0
 
 SpiceExplosion:
 	Projectile: Bullet
@@ -266,6 +278,7 @@ SpiceExplosion:
 		Size: 1
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion
+		VictimScanRadius: 0
 
 BloomExplosion:
 	Report: EXPLMD1.WAV

--- a/mods/d2k/weapons/smallguns.yaml
+++ b/mods/d2k/weapons/smallguns.yaml
@@ -19,6 +19,7 @@
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
+		VictimScanRadius: 0
 
 LMG:
 	Inherits: ^MG

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -189,6 +189,7 @@ CrateNuke:
 	Warhead@3Eff_impact: CreateEffect
 		Explosions: nuke
 		ImpactSounds: kaboom1.aud
+		VictimScanRadius: 0
 	Warhead@4Dam_areanuke1: SpreadDamage
 		Spread: 1c0
 		Damage: 60
@@ -205,6 +206,7 @@ CrateNuke:
 	Warhead@6Eff_areanuke1: CreateEffect
 		ImpactSounds: kaboom22.aud
 		Delay: 5
+		VictimScanRadius: 0
 	Warhead@6Smu_areanuke1: LeaveSmudge
 		SmudgeType: Scorch
 		InvalidTargets: Vehicle, Tank, Structure, Wall, Trees
@@ -234,6 +236,7 @@ MiniNuke:
 	Warhead@3Eff_impact: CreateEffect
 		Explosions: nuke
 		ImpactSounds: kaboom1.aud
+		VictimScanRadius: 0
 	Warhead@4Dam_areanuke1: SpreadDamage
 		Spread: 2c0
 		Damage: 60
@@ -250,6 +253,7 @@ MiniNuke:
 	Warhead@6Eff_areanuke1: CreateEffect
 		ImpactSounds: kaboom22.aud
 		Delay: 5
+		VictimScanRadius: 0
 	Warhead@7Dam_areanuke2: SpreadDamage
 		Spread: 3c0
 		Damage: 60

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -39,6 +39,8 @@
 ^AntiAirMissile:
 	Inherits: ^AntiGroundMissile
 	ValidTargets: Air
+	Warhead@3Eff: CreateEffect
+		VictimScanRadius: 0
 
 Maverick:
 	Inherits: ^AntiGroundMissile

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -19,6 +19,7 @@
 	Warhead@3Eff: CreateEffect
 		Explosions: napalm
 		ImpactSounds: firebl3.aud
+		VictimScanRadius: 0
 
 FireballLauncher:
 	Inherits: ^FireWeapon
@@ -182,3 +183,4 @@ MADTankDetonate:
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion
 		ImpactSounds: mineblo1.aud
+		VictimScanRadius: 0

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -47,6 +47,7 @@ Atomic:
 	Warhead@4Eff_impact: CreateEffect
 		Explosions: nuke
 		ImpactSounds: kaboom1.aud
+		VictimScanRadius: 0
 	Warhead@5Dam_areanuke1: SpreadDamage
 		Spread: 2c0
 		Damage: 60
@@ -67,6 +68,7 @@ Atomic:
 	Warhead@8Eff_areanuke1: CreateEffect
 		ImpactSounds: kaboom22.aud
 		Delay: 5
+		VictimScanRadius: 0
 	Warhead@9Dam_areanuke2: SpreadDamage
 		Spread: 3c0
 		Damage: 60

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -83,14 +83,11 @@ MammothTusk:
 			Concrete: 28
 		DamageTypes: Explosion
 	Warhead@2Eff: CreateEffect
+		VictimScanRadius: 0
 		Explosions: medium_twlt
 		ImpactSounds: expnew07.aud
 		InvalidImpactTypes: Water
-	Warhead@3EffWater: CreateEffect
-		Explosions: small_watersplash
-		ExplosionPalette: player
-		ImpactSounds: ssplash3.aud
-		ValidImpactTypes: Water
+	-Warhead@3EffWater: CreateEffect
 
 BikeMissile:
 	Inherits: ^DefaultMissile
@@ -150,3 +147,4 @@ RedEye2:
 	Warhead@2Eff: CreateEffect
 		Explosions: large_grey_explosion
 		ImpactSounds: expnew13.aud
+		VictimScanRadius: 0

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -79,21 +79,27 @@ IonCannon:
 		Explosions: ionbeam
 		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: ion1.aud
+		VictimScanRadius: 0
 	Warhead@5Effect: CreateEffect
 		Explosions: ionbeam2
 		ExplosionPalette: effect-ignore-lighting-alpha75
+		VictimScanRadius: 0
 	Warhead@6Effect: CreateEffect
 		Explosions: ionbeam3
 		ExplosionPalette: effect-ignore-lighting-alpha75
+		VictimScanRadius: 0
 	Warhead@7Effect: CreateEffect
 		Explosions: ionbeam4
 		ExplosionPalette: effect-ignore-lighting-alpha75
+		VictimScanRadius: 0
 	Warhead@8Effect: CreateEffect
 		Explosions: ionbeam5
 		ExplosionPalette: effect-ignore-lighting-alpha75
+		VictimScanRadius: 0
 	Warhead@9Effect: CreateEffect
 		Explosions: ionbeam6
 		ExplosionPalette: effect-ignore-lighting-alpha75
+		VictimScanRadius: 0
 
 EMPulseCannon:
 	ReloadDelay: 100
@@ -108,6 +114,7 @@ EMPulseCannon:
 	Warhead@1Eff: CreateEffect
 		Explosions: pulse_explosion
 		ExplosionPalette: effect-ignore-lighting-alpha75
+		VictimScanRadius: 0
 	Warhead@emp: GrantExternalCondition
 		Range: 4c0
 		Duration: 250
@@ -127,6 +134,7 @@ ClusterMissile:
 		Explosions: large_explosion
 		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew19.aud
+		VictimScanRadius: 0
 	Warhead@ResourceDestruction0: DestroyResource
 		Size: 1
 	Warhead@ClusterSmudges0: LeaveSmudge


### PR DESCRIPTION
In cases where explosions are supposed to display unconditionally regardless of whether an actor was hit or not, the victim scan is basically just wasting performance.

By triggering the auto-calculation of the victim scan at `-1`* and making `0` do what is more intuitive anyway and disabling the scan, we can disable it in those cases.

Closes #12574.

*or some other negative value