### PR TITLE
Fix TS visceroid and tib floater weapons

### DIFF
--- a/mods/ts/weapons/otherweapons.yaml
+++ b/mods/ts/weapons/otherweapons.yaml
@@ -91,8 +91,10 @@ SlimeAttack:
 	Range: 1c384
 	Report: vicer1.aud
 	Projectile: InstantHit
-	Warhead@1Dam: TargetDamage
+	InvalidTargets: Wall, Bridge
+	Warhead@1Dam: SpreadDamage
 		Damage: 100
+		InvalidTargets: Wall, Bridge
 		Versus:
 			Light: 60
 			Heavy: 40
@@ -105,7 +107,7 @@ Tentacle:
 	Report: floatk1.aud
 	Projectile: InstantHit
 	InvalidTargets: Wall, Bridge
-	Warhead@1Dam: TargetDamage
+	Warhead@1Dam: SpreadDamage
 		Damage: 160
 		InvalidTargets: Wall, Bridge
 		Versus:


### PR DESCRIPTION
They need to target closest targetable position to be able to attack larger buildings, which conflicts with the TargetDamage warhead.

Fixes #13505.