### PR TITLE
Use array to lookup trait types in the trait dictionary, not a dictionary.

### DIFF
--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -178,6 +178,7 @@
     <Compile Include="Support\Program.cs" />
     <Compile Include="Sync.cs" />
     <Compile Include="TraitDictionary.cs" />
+    <Compile Include="TraitTypeIndex.cs" />
     <Compile Include="Traits\LintAttributes.cs" />
     <Compile Include="Traits\Player\DeveloperMode.cs" />
     <Compile Include="Traits\Player\PlayerResources.cs" />

--- a/OpenRA.Game/TraitDictionary.cs
+++ b/OpenRA.Game/TraitDictionary.cs
@@ -67,17 +67,20 @@ namespace OpenRA
 			if (index <= 0) {
 				throw new InvalidOperationException("Traits type index out of bounds (<=0)");
 			}
+
 			if (index >= traits.Length) {
 				Resize();
 				if (index > traits.Length) {
 					throw new InvalidOperationException("Traits type index out of bounds, index greater than max registered type index");
 				}
 			}
+
 			ITraitContainer trait = traits[index];
 			if (trait == null) {
 				trait = CreateTraitContainer(t);
 				traits[index] = trait;
 			}
+
 			return trait;
 		}
 
@@ -89,7 +92,7 @@ namespace OpenRA
 
 		TraitContainer<T> InnerGet<T>()
 		{
-			return (TraitContainer<T>) InnerGet(TraitTypeIndex<T>.GetTypeIndex(), typeof(T));
+			return (TraitContainer<T>)InnerGet(TraitTypeIndex<T>.GetTypeIndex(), typeof(T));
 		}
 
 		public void PrintReport()
@@ -97,9 +100,10 @@ namespace OpenRA
 			if (traits == null) {
 				return;
 			}
+
 			Log.AddChannel("traitreport", "traitreport.log");
 			Log.Write("traitreport", "Number of registered trait types {0}", TraitTypeIndexMap.GetCount());
-			for (int i=1;i<traits.Length;i++) {
+			for (int i = 1; i < traits.Length; i++) {
 				var trait = traits[i];
 				if (trait != null) {
 					Log.Write("traitreport", "{0}: {1}", TraitTypeIndexMap.GetType(i), trait.Queries);

--- a/OpenRA.Game/TraitDictionary.cs
+++ b/OpenRA.Game/TraitDictionary.cs
@@ -43,23 +43,68 @@ namespace OpenRA
 		static readonly Func<Type, ITraitContainer> CreateTraitContainer = t =>
 			(ITraitContainer)typeof(TraitContainer<>).MakeGenericType(t).GetConstructor(Type.EmptyTypes).Invoke(null);
 
-		readonly Dictionary<Type, ITraitContainer> traits = new Dictionary<Type, ITraitContainer>();
+		private ITraitContainer[] traits = null;
+
+		public TraitDictionary() {
+			Resize();
+		}
+
+		private void Resize() {
+			// New trait types have been registered. Ensure our array is same size as trait type index map.
+			int newSize = TraitTypeIndexMap.GetCount() + 64;
+			if (traits == null) {
+				traits = new ITraitContainer[newSize];
+			}
+			else {
+				if (traits.Length < newSize) {
+					Array.Resize(ref traits, newSize);
+				}
+			}
+		}
+
+		private ITraitContainer InnerGet(int index, Type t) {
+			// Lookup trait by index in array, rather than hash key in dictionary.
+			if (index <= 0) {
+				throw new InvalidOperationException("Traits type index out of bounds (<=0)");
+			}
+			if (index >= traits.Length) {
+				Resize();
+				if (index > traits.Length) {
+					throw new InvalidOperationException("Traits type index out of bounds, index greater than max registered type index");
+				}
+			}
+			ITraitContainer trait = traits[index];
+			if (trait == null) {
+				trait = CreateTraitContainer(t);
+				traits[index] = trait;
+			}
+			return trait;
+		}
 
 		ITraitContainer InnerGet(Type t)
 		{
-			return traits.GetOrAdd(t, CreateTraitContainer);
+			// Slower, dictionary lookup of index
+			return InnerGet(TraitTypeIndexMap.RegisterType(t), t);
 		}
 
 		TraitContainer<T> InnerGet<T>()
 		{
-			return (TraitContainer<T>)InnerGet(typeof(T));
+			return (TraitContainer<T>) InnerGet(TraitTypeIndex<T>.GetTypeIndex(), typeof(T));
 		}
 
 		public void PrintReport()
 		{
+			if (traits == null) {
+				return;
+			}
 			Log.AddChannel("traitreport", "traitreport.log");
-			foreach (var t in traits.OrderByDescending(t => t.Value.Queries).TakeWhile(t => t.Value.Queries > 0))
-				Log.Write("traitreport", "{0}: {1}", t.Key.Name, t.Value.Queries);
+			Log.Write("traitreport", "Number of registered trait types {0}", TraitTypeIndexMap.GetCount());
+			for (int i=1;i<traits.Length;i++) {
+				var trait = traits[i];
+				if (trait != null) {
+					Log.Write("traitreport", "{0}: {1}", TraitTypeIndexMap.GetType(i), trait.Queries);
+				}
+			}
 		}
 
 		public void AddTrait(Actor actor, object val)
@@ -118,8 +163,11 @@ namespace OpenRA
 
 		public void RemoveActor(Actor a)
 		{
-			foreach (var t in traits)
-				t.Value.RemoveActor(a.ActorID);
+			foreach (var t in traits) {
+				if (t != null) {
+					t.RemoveActor(a.ActorID);
+				}
+			}
 		}
 
 		interface ITraitContainer

--- a/OpenRA.Game/TraitTypeIndex.cs
+++ b/OpenRA.Game/TraitTypeIndex.cs
@@ -1,0 +1,72 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+
+namespace OpenRA
+{
+	
+	public class TraitTypeIndexMap
+	{
+		private static Dictionary<Type, int> map = new Dictionary<Type, int>();
+
+		public static int RegisterType(Type t) {
+			int index;
+			if (map.TryGetValue(t, out index)) {
+				return index;
+			}
+			index = map.Count+1;
+			map.Add(t, index);
+			return index;
+		}
+
+		public static int FindType(Type t) {
+			int index;
+			if (map.TryGetValue(t, out index)) {
+				return index;
+			}
+			return 0;
+		}
+
+		public static int GetCount() {
+			return map.Count;
+		}
+
+		public static Type GetType(int index) {
+			if (index > 0 && index < map.Count) {
+				foreach (var t in map) {
+					if (t.Value == index) {
+						return t.Key;
+					}
+				}
+			}
+			return null;
+		}
+	};
+
+	// Index of type in array
+	public class TraitTypeIndex<T>
+	{
+		private static int TypeIndex = 0;
+		public static int GetTypeIndex() {
+			if (TypeIndex == 0) {
+				TypeIndex = TraitTypeIndexMap.RegisterType(typeof(T));
+			}
+			return TypeIndex;
+		}
+
+		public static bool IsRegistered() {
+			return TypeIndex != 0;
+		}
+	};
+}
+

--- a/OpenRA.Game/TraitTypeIndex.cs
+++ b/OpenRA.Game/TraitTypeIndex.cs
@@ -14,7 +14,6 @@ using System.Collections.Generic;
 
 namespace OpenRA
 {
-	
 	public class TraitTypeIndexMap
 	{
 		private static Dictionary<Type, int> map = new Dictionary<Type, int>();
@@ -24,7 +23,8 @@ namespace OpenRA
 			if (map.TryGetValue(t, out index)) {
 				return index;
 			}
-			index = map.Count+1;
+
+			index = map.Count + 1;
 			map.Add(t, index);
 			return index;
 		}
@@ -34,6 +34,7 @@ namespace OpenRA
 			if (map.TryGetValue(t, out index)) {
 				return index;
 			}
+
 			return 0;
 		}
 
@@ -44,29 +45,29 @@ namespace OpenRA
 		public static Type GetType(int index) {
 			if (index > 0 && index < map.Count) {
 				foreach (var t in map) {
-					if (t.Value == index) {
+					if (t.Value == index)
 						return t.Key;
-					}
 				}
 			}
+
 			return null;
 		}
-	};
+	}
 
 	// Index of type in array
 	public class TraitTypeIndex<T>
 	{
-		private static int TypeIndex = 0;
+		private static int typeIndex = 0;
 		public static int GetTypeIndex() {
-			if (TypeIndex == 0) {
-				TypeIndex = TraitTypeIndexMap.RegisterType(typeof(T));
+			if (typeIndex == 0) {
+				typeIndex = TraitTypeIndexMap.RegisterType(typeof(T));
 			}
-			return TypeIndex;
+
+			return typeIndex;
 		}
 
 		public static bool IsRegistered() {
-			return TypeIndex != 0;
+			return typeIndex != 0;
 		}
-	};
+	}
 }
-


### PR DESCRIPTION
To avoid more expensive dictionary lookups. 

In a small test program 100 million hash table look ups with integer keys (representing hash code) with a table size of 512 take ~1.558 seconds where array index lookup takes ~0.125s. 

When playing RA about 500 trait types seem to be registered.

Performance of generic get i.e InnerGet<T>() should be faster (used in in game logic). While InnerGet(Type t) still uses a dictionary lookup (used during initialization, when loading yaml files).

Relying on generic/template arguments to be resolved at compile time.

Passes make test.
