### PR TITLE
Fixes the positioning of the performance graph

### DIFF
--- a/mods/common/chrome/ingame-perf.yaml
+++ b/mods/common/chrome/ingame-perf.yaml
@@ -10,8 +10,8 @@ Container@PERF_WIDGETS:
 		Background@GRAPH_BG:
 			ClickThrough: true
 			Background: dialog4
-			X: 30
-			Y: WINDOW_BOTTOM - 240
+			X: 10
+			Y: WINDOW_BOTTOM - 265
 			Width: 210
 			Height: 210
 			Children:


### PR DESCRIPTION
Fixes #13549

The reason why the graph is not "in line" with the ra commandbar is that the other commandbars maybe differ in size and position, so I tried to choose a neutral position.

|Without PR|With PR|
|:-----:|:-----:|
|![image](https://user-images.githubusercontent.com/20945684/27519525-29fa57e6-59f6-11e7-86e1-15568ac6ada3.png)|![image](https://user-images.githubusercontent.com/20945684/27519524-24886ee2-59f6-11e7-96b8-12157deb4c18.png)|
