### PR TITLE
TD Balance Changes. 20172606

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -91,8 +91,8 @@ HELI:
 		Ammo: 10
 		PipCount: 5
 		SelfReloads: true
-		ReloadCount: 10
-		SelfReloadDelay: 200
+		ReloadCount: 1
+		SelfReloadDelay: 40
 	WithIdleOverlay@ROTORAIR:
 		Offset: 0,0,85
 		Sequence: rotor

--- a/mods/cnc/rules/misc.yaml
+++ b/mods/cnc/rules/misc.yaml
@@ -22,8 +22,18 @@ CRATE:
 		Condition: cloak-crate-collected
 	GiveMcvCrateAction:
 		SelectionShares: 0
-		NoBaseSelectionShares: 120
+		NoBaseSelectionShares: 50
 		Units: mcv
+	ExplodeCrateAction:
+		Weapon: Atomic
+		SelectionShares: 1
+	GiveUnitCrateAction:
+		Units: vice
+		Owner: Creeps
+		SelectionShares: 10
+	LevelUpCrateAction:
+		Levels: 4
+		SelectionShares: 12
 
 WCRATE:
 	Inherits: ^Crate

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -803,7 +803,7 @@ SAM:
 	WithTurretedSpriteBody:
 	AutoSelectionSize:
 	Armament:
-		Weapon: SAMMissile
+		Weapon: Dragon
 		MuzzleSequence: muzzle
 	AttackPopupTurreted:
 	WithMuzzleOverlay:
@@ -930,7 +930,7 @@ ATWR:
 		LocalOffset: 256,128,0, 256,-128,0
 		LocalYaw: -100,100
 	Armament@SECONDARY:
-		Weapon: SAMMissile
+		Weapon: TowerAAMissile
 		LocalOffset: 256,128,0, 256,-128,0
 		LocalYaw: -100,100
 	AttackTurreted:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -302,7 +302,7 @@ JEEP:
 		TurnSpeed: 10
 		Offset: -85,0,128
 	Armament:
-		Weapon: MachineGun
+		Weapon: MachineGunH
 		LocalOffset: 171,0,85
 		MuzzleSequence: muzzle
 	AttackTurreted:

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -36,7 +36,7 @@
 Dragon:
 	Inherits: ^MissileWeapon
 	ReloadDelay: 20
-	Range: 12c0
+	Range: 10c0
 	Report: rocket2.aud
 	ValidTargets: Air
 	Burst: 2
@@ -44,7 +44,7 @@ Dragon:
 	Projectile: Missile
 		Speed: 426
 		HorizontalRateOfTurn: 20
-		RangeLimit: 15c0
+		RangeLimit: 12c0
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: Air
 		Versus:
@@ -85,7 +85,7 @@ OrcaAGMissiles:
 		Speed: 256
 		RangeLimit: 6c0
 	Warhead@1Dam: SpreadDamage
-		Damage: 25
+		Damage: 28
 		ValidTargets: Ground
 		Versus:
 			None: 50
@@ -236,7 +236,7 @@ TowerMissle:
 		Explosions: med_frag
 		ImpactSounds: xplos.aud
 
-SAMMissile:
+TowerAAMissile:
 	Inherits: ^MissileWeapon
 	ReloadDelay: 15
 	Range: 8c0

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -114,6 +114,12 @@ MachineGun:
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
 
+MachineGunH:
+	Inherits: MachineGun
+	Warhead@1Dam: SpreadDamage
+		Versus:
+			Light: 55
+
 APCGun:
 	ReloadDelay: 18
 	Range: 5c0

--- a/mods/cnc/weapons/superweapons.yaml
+++ b/mods/cnc/weapons/superweapons.yaml
@@ -6,6 +6,7 @@ Atomic:
 		Damage: 150
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: Ground, Air, Trees
+		AffectsParent: True
 		Versus:
 			None: 100
 			Wood: 100
@@ -22,6 +23,7 @@ Atomic:
 		Falloff: 1000, 700, 500, 300, 150, 50, 0
 		Delay: 3
 		ValidTargets: Ground, Air
+		AffectsParent: True
 		Versus:
 			None: 100
 			Wood: 100
@@ -46,6 +48,7 @@ Atomic:
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 6
 		ValidTargets: Ground, Air, Trees
+		AffectsParent: True
 		Versus:
 			None: 100
 			Wood: 100
@@ -66,6 +69,7 @@ Atomic:
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 9
 		ValidTargets: Ground, Air, Trees
+		AffectsParent: True
 		Versus:
 			None: 100
 			Wood: 100
@@ -88,6 +92,7 @@ IonCannon:
 		Damage: 100
 		Falloff: 1000, 1000, 250, 100
 		ValidTargets: Ground, Air, Trees
+		AffectsParent: True
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@2Smu_impact: LeaveSmudge
 		SmudgeType: Scorch


### PR DESCRIPTION
The list of changes do not affect the new hitboxes of the structures. The engineer external capture was dropped currently due to the new change. Same applies to the MCV price change due to some of these changes. These changes will be looked at in the playtest and if need be after the next release.

+ Orca damage increased from 25 to 28.
Damage is increased because of their lack of damage vs armored units and structures.

+ Apache ammo reload reduced from 200 to 40.
Apaches gaining a full clip of ammo is a bit to strong. Firing the first shot starts the timer tick and will reload even if the clip is not fully reloaded. This also fixes so they don't sit on top of infantry and blow them all away to quickly.

+ Apache ammo reload amount reduced from 10 to 1.
Fixed in unison with ammo reload timer.

+ Sam now fires two missiles. (CNC95)
Does extra damage.

+ Sam range increase from 8c0 to 10c0.
Compensate for the aircraft changes. Also had a problem of MSAMs were always the better choice rather then the structure SAMs itself. This change will make them more viable.

+ Sam range limit from 9c614 to 12c0.
Makes it so aircraft can still escape while the missile won't detonate at the edge of the circle range.

+ Humvee damag vs light increased from 50 to 55.
Compensates for the price of the hummer. Having just the HP wasn't enough to counter certian builds of Nod. Enabling them a slightly higher damage allows them to kill buggies and bikes a bit more effectively. Makes them also decent arty and MRLS killers.

+ Crates got some love.

+ Viceroids now spawn.

+ An atomic bomb can now detonate. (CNC95)

+ Crate veterancy level now gives general rank instead of stripe 1.
This makes grabbing crates all the more rewarding and riskier. Such as willing to bring a mammoth tank or commando to the crate rather then a minigunner. Instead of a crate granting level 1 for units it will now give rank level 4 promoting to general status.