### PR TITLE
Refactor Bib & footprint cells - part 1

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -201,6 +201,11 @@ namespace OpenRA.Traits
 
 	public interface IRadarColorModifier { Color RadarColorOverride(Actor self, Color color); }
 
+	public interface ITargetableCells
+	{
+		IEnumerable<Pair<CPos, SubCell>> TargetableCells();
+	}
+
 	public interface IOccupySpaceInfo : ITraitInfoInterface
 	{
 		IReadOnlyDictionary<CPos, SubCell> OccupiedCells(ActorInfo info, CPos location, SubCell subCell = SubCell.Any);

--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Activities\VoxelHarvesterDockSequence.cs" />
     <Compile Include="SpriteLoaders\TmpTSLoader.cs" />
     <Compile Include="Traits\Buildings\TiberianSunRefinery.cs" />
+    <Compile Include="Traits\Render\WithBuildingBib.cs" />
     <Compile Include="Traits\Render\WithDockingOverlay.cs" />
     <Compile Include="Traits\Render\WithPermanentInjury.cs" />
     <Compile Include="Traits\Render\WithVoxelWalkerBody.cs" />

--- a/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
@@ -12,18 +12,21 @@
 using System.Collections.Generic;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.Common.Traits
+namespace OpenRA.Mods.Cnc.Traits
 {
-	public class BibInfo : ITraitInfo, Requires<BuildingInfo>, IRenderActorPreviewSpritesInfo, IActorPreviewInitInfo, Requires<RenderSpritesInfo>
+	public class WithBuildingBibInfo : ITraitInfo, Requires<BuildingInfo>, IRenderActorPreviewSpritesInfo, IActorPreviewInitInfo, Requires<RenderSpritesInfo>
 	{
 		[SequenceReference] public readonly string Sequence = "bib";
+
 		[PaletteReference] public readonly string Palette = TileSet.TerrainPaletteInternalName;
+
 		public readonly bool HasMinibib = false;
 
-		public object Create(ActorInitializer init) { return new Bib(init.Self, this); }
+		public object Create(ActorInitializer init) { return new WithBuildingBib(init.Self, this); }
 
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{
@@ -35,10 +38,10 @@ namespace OpenRA.Mods.Common.Traits
 
 			var bi = init.Actor.TraitInfo<BuildingInfo>();
 
-			var width = bi.Dimensions.X;
-			var bibOffset = bi.Dimensions.Y - 1;
-			var centerOffset = FootprintUtils.CenterOffset(init.World, bi);
 			var rows = HasMinibib ? 1 : 2;
+			var width = bi.Dimensions.X;
+			var bibOffset = bi.Dimensions.Y - rows;
+			var centerOffset = FootprintUtils.CenterOffset(init.World, bi);
 			var map = init.World.Map;
 			var location = CPos.Zero;
 
@@ -71,14 +74,14 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class Bib : INotifyAddedToWorld, INotifyRemovedFromWorld
+	public class WithBuildingBib : INotifyAddedToWorld, INotifyRemovedFromWorld
 	{
-		readonly BibInfo info;
+		readonly WithBuildingBibInfo info;
 		readonly RenderSprites rs;
 		readonly BuildingInfo bi;
 		readonly List<AnimationWithOffset> anims = new List<AnimationWithOffset>();
 
-		public Bib(Actor self, BibInfo info)
+		public WithBuildingBib(Actor self, WithBuildingBibInfo info)
 		{
 			this.info = info;
 			rs = self.Trait<RenderSprites>();
@@ -87,11 +90,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void AddedToWorld(Actor self)
 		{
+			var rows = info.HasMinibib ? 1 : 2;
 			var width = bi.Dimensions.X;
-			var bibOffset = bi.Dimensions.Y - 1;
+			var bibOffset = bi.Dimensions.Y - rows;
 			var centerOffset = FootprintUtils.CenterOffset(self.World, bi);
 			var location = self.Location;
-			var rows = info.HasMinibib ? 1 : 2;
 			var map = self.World.Map;
 
 			for (var i = 0; i < rows * width; i++)

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -277,7 +277,6 @@
     <Compile Include="Traits\Buildable.cs" />
     <Compile Include="Traits\Buildings\BaseBuilding.cs" />
     <Compile Include="Traits\Buildings\BaseProvider.cs" />
-    <Compile Include="Traits\Buildings\Bib.cs" />
     <Compile Include="Traits\Buildings\Bridge.cs" />
     <Compile Include="Traits\Buildings\LegacyBridgeHut.cs" />
     <Compile Include="Traits\Buildings\Building.cs" />

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -144,7 +144,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class Building : IOccupySpace, INotifySold, INotifyTransform, ISync, INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld
+	public class Building : IOccupySpace, ITargetableCells, INotifySold, INotifyTransform, ISync, INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld
 	{
 		public readonly BuildingInfo Info;
 		public bool BuildComplete { get; private set; }
@@ -153,6 +153,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool SkipMakeAnimation;
 
 		Pair<CPos, SubCell>[] occupiedCells;
+		Pair<CPos, SubCell>[] targetableCells;
 
 		// Shared activity lock: undeploy, sell, capture, etc.
 		[Sync] public bool Locked = true;
@@ -180,11 +181,16 @@ namespace OpenRA.Mods.Common.Traits
 			occupiedCells = FootprintUtils.UnpathableTiles(self.Info.Name, Info, TopLeft)
 				.Select(c => Pair.New(c, SubCell.FullCell)).ToArray();
 
+			targetableCells = FootprintUtils.UnpathableTiles(self.Info.Name, Info, TopLeft)
+				.Select(c => Pair.New(c, SubCell.FullCell)).ToArray();
+
 			CenterPosition = init.World.Map.CenterOfCell(topLeft) + FootprintUtils.CenterOffset(init.World, Info);
 			SkipMakeAnimation = init.Contains<SkipMakeAnimsInit>();
 		}
 
 		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells() { return occupiedCells; }
+
+		public IEnumerable<Pair<CPos, SubCell>> TargetableCells() { return targetableCells; }
 
 		void INotifyCreated.Created(Actor self)
 		{

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -27,21 +27,30 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[Desc("Where you are allowed to place the building (Water, Clear, ...)")]
 		public readonly HashSet<string> TerrainTypes = new HashSet<string>();
+
 		[Desc("The range to the next building it can be constructed. Set it higher for walls.")]
 		public readonly int Adjacent = 2;
+
 		[Desc("x means space it blocks, _ is a part that is passable by actors.")]
 		public readonly string Footprint = "x";
+
 		public readonly CVec Dimensions = new CVec(1, 1);
+
 		public readonly bool RequiresBaseProvider = false;
+
 		public readonly bool AllowInvalidPlacement = false;
+
 		[Desc("Clear smudges from underneath the building footprint.")]
 		public readonly bool RemoveSmudgesOnBuild = true;
+
 		[Desc("Clear smudges from underneath the building footprint on sell.")]
 		public readonly bool RemoveSmudgesOnSell = true;
+
 		[Desc("Clear smudges from underneath the building footprint on transform.")]
 		public readonly bool RemoveSmudgesOnTransform = true;
 
 		public readonly string[] BuildSounds = { "placbldg.aud", "build5.aud" };
+
 		public readonly string[] UndeploySounds = { "cashturn.aud" };
 
 		public virtual object Create(ActorInitializer init) { return new Building(init, this); }

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -36,6 +36,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly CVec Dimensions = new CVec(1, 1);
 
+		[Desc("Shift center of the actor by this offset.")]
+		public readonly WVec LocalCenterOffset = WVec.Zero;
+
 		public readonly bool RequiresBaseProvider = false;
 
 		public readonly bool AllowInvalidPlacement = false;
@@ -84,9 +87,6 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			var buildingMaxBounds = Dimensions;
-			var bibInfo = world.Map.Rules.Actors[buildingName].TraitInfoOrDefault<BibInfo>();
-			if (bibInfo != null && !bibInfo.HasMinibib)
-				buildingMaxBounds += new CVec(0, 1);
 
 			var scanStart = world.Map.Clamp(topLeft - new CVec(Adjacent, Adjacent));
 			var scanEnd = world.Map.Clamp(topLeft + buildingMaxBounds + new CVec(Adjacent, Adjacent));

--- a/OpenRA.Mods.Common/Traits/Buildings/FootprintUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FootprintUtils.cs
@@ -20,15 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 		public static IEnumerable<CPos> Tiles(Ruleset rules, string name, BuildingInfo buildingInfo, CPos topLeft, bool includePassable = false)
 		{
 			var dim = buildingInfo.Dimensions;
-
 			var footprint = buildingInfo.Footprint.Where(x => !char.IsWhiteSpace(x));
-
-			var bibInfo = rules.Actors[name].TraitInfoOrDefault<BibInfo>();
-			if (bibInfo != null && !bibInfo.HasMinibib)
-			{
-				dim += new CVec(0, 1);
-				footprint = footprint.Concat(new char[dim.X]);
-			}
 
 			return TilesWhere(name, dim, footprint.ToArray(), a => includePassable || a != '_').Select(t => t + topLeft);
 		}
@@ -78,8 +70,9 @@ namespace OpenRA.Mods.Common.Traits
 		public static WVec CenterOffset(World w, BuildingInfo buildingInfo)
 		{
 			var dim = buildingInfo.Dimensions;
+			var localOffset = buildingInfo.LocalCenterOffset;
 			var off = (w.Map.CenterOfCell(new CPos(dim.X, dim.Y)) - w.Map.CenterOfCell(new CPos(1, 1))) / 2;
-			return off - new WVec(0, 0, off.Z);
+			return (off - new WVec(0, 0, off.Z)) + localOffset;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/HitShape.cs
+++ b/OpenRA.Mods.Common/Traits/HitShape.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class HitShape : ConditionalTrait<HitShapeInfo>, ITargetablePositions
 	{
 		BodyOrientation orientation;
-		IOccupySpace occupy;
+		ITargetableCells targetableCells;
 
 		public HitShape(Actor self, HitShapeInfo info)
 			: base(info) { }
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 		protected override void Created(Actor self)
 		{
 			orientation = self.Trait<BodyOrientation>();
-			occupy = self.TraitOrDefault<IOccupySpace>();
+			targetableCells = self.TraitOrDefault<ITargetableCells>();
 
 			base.Created(self);
 		}
@@ -78,8 +78,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (IsTraitDisabled)
 				yield break;
 
-			if (Info.UseOccupiedCellsOffsets && occupy != null)
-				foreach (var c in occupy.OccupiedCells())
+			if (Info.UseOccupiedCellsOffsets && targetableCells != null)
+				foreach (var c in targetableCells.TargetableCells())
 					yield return self.World.Map.CenterOfCell(c.First);
 
 			foreach (var o in Info.TargetableOffsets)

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -6,15 +6,16 @@ FACT:
 	Tooltip:
 		Name: Construction Yard
 	Building:
-		Footprint: xxx xxx
-		Dimensions: 3,2
+		Footprint: xxx xxx ===
+		Dimensions: 3,3
+		LocalCenterOffset: 0,-512,0
 	Health:
 		HP: 2100
 	Armor:
 		Type: Wood
 	RevealsShroud:
 		Range: 10c0
-	Bib:
+	WithBuildingBib:
 	Production:
 		Produces: Building.GDI, Building.Nod, Defence.GDI, Defence.Nod
 	Transforms:
@@ -110,13 +111,14 @@ NUKE:
 		Queue: Building.GDI, Building.Nod
 		Description: Generates power
 	Building:
-		Footprint: xx xx
-		Dimensions: 2,2
+		Footprint: xx xx ==
+		Dimensions: 2,3
+		LocalCenterOffset: 0,-512,0
 	Health:
 		HP: 500
 	RevealsShroud:
 		Range: 4c0
-	Bib:
+	WithBuildingBib:
 	Power:
 		Amount: 100
 	ScalePowerWithHealth:
@@ -139,13 +141,14 @@ NUK2:
 		Queue: Building.GDI, Building.Nod
 		Description: Provides more power, cheaper than the\nstandard Power Plant
 	Building:
-		Footprint: xx xx
-		Dimensions: 2,2
+		Footprint: xx xx ==
+		Dimensions: 2,3
+		LocalCenterOffset: 0,-512,0
 	Health:
 		HP: 700
 	RevealsShroud:
 		Range: 4c0
-	Bib:
+	WithBuildingBib:
 	Power:
 		Amount: 200
 	ScalePowerWithHealth:
@@ -172,13 +175,14 @@ PROC:
 		Queue: Building.GDI, Building.Nod
 		Description: Processes raw Tiberium\ninto useable resources
 	Building:
-		Footprint: _x_ xxx ===
-		Dimensions: 3,3
+		Footprint: _x_ xxx === ===
+		Dimensions: 3,4
+		LocalCenterOffset: 0,-512,0
 	Health:
 		HP: 1000
 	RevealsShroud:
 		Range: 6c0
-	Bib:
+	WithBuildingBib:
 	Refinery:
 		DockAngle: 112
 		DockOffset: 0,2
@@ -225,7 +229,7 @@ SILO:
 		HP: 500
 	RevealsShroud:
 		Range: 4c0
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	RenderSprites:
 	WithSpriteBody:
@@ -263,13 +267,14 @@ PYLE:
 		Queue: Building.GDI
 		Description: Trains infantry
 	Building:
-		Footprint: xx xx
-		Dimensions: 2,2
+		Footprint: xx xx ==
+		Dimensions: 2,3
+		LocalCenterOffset: 0,-512,0
 	Health:
 		HP: 600
 	RevealsShroud:
 		Range: 5c0
-	Bib:
+	WithBuildingBib:
 	RallyPoint:
 	Exit@1:
 		SpawnOffset: -426,85,0
@@ -309,13 +314,14 @@ HAND:
 		Queue: Building.Nod
 		Description: Trains infantry
 	Building:
-		Footprint: xx xx
-		Dimensions: 2,2
+		Footprint: xx xx ==
+		Dimensions: 2,3
+		LocalCenterOffset: 0,-512,0
 	Health:
 		HP: 600
 	RevealsShroud:
 		Range: 5c0
-	Bib:
+	WithBuildingBib:
 	RallyPoint:
 		Offset: 1,2
 	Exit@1:
@@ -357,13 +363,14 @@ AFLD:
 		Queue: Building.Nod
 		Description: Provides a dropzone\nfor vehicle reinforcements
 	Building:
-		Footprint: xxxx xxxx
-		Dimensions: 4,2
+		Footprint: xxxx xxxx ====
+		Dimensions: 4,3
+		LocalCenterOffset: 0,-512,0
 	Health:
 		HP: 1100
 	RevealsShroud:
 		Range: 7c0
-	Bib:
+	WithBuildingBib:
 	WithIdleOverlay@DISH:
 		Sequence: idle-dish
 	RallyPoint:
@@ -405,8 +412,9 @@ WEAP:
 		Queue: Building.GDI
 		Description: Produces vehicles
 	Building:
-		Footprint: xxx ===
-		Dimensions: 3,2
+		Footprint: xxx === ===
+		Dimensions: 3,3
+		LocalCenterOffset: 0,-512,0
 	Selectable:
 		Bounds: 72,48
 	SelectionDecorations:
@@ -415,7 +423,7 @@ WEAP:
 		HP: 1100
 	RevealsShroud:
 		Range: 4c0
-	Bib:
+	WithBuildingBib:
 	WithProductionDoorOverlay:
 		Sequence: build-top
 	RallyPoint:
@@ -506,8 +514,9 @@ HQ:
 		Queue: Building.GDI, Building.Nod
 		Description: Provides radar and Air Strike support power.\nUnlocks higher-tech units and buildings.\nRequires power to operate.
 	Building:
-		Footprint: x_ xx
-		Dimensions: 2,2
+		Footprint: x_ xx ==
+		Dimensions: 2,3
+		LocalCenterOffset: 0,-512,0
 	Selectable:
 		Bounds: 48,40,0,9
 	SelectionDecorations:
@@ -522,7 +531,7 @@ HQ:
 		HP: 800
 	RevealsShroud:
 		Range: 10c0
-	Bib:
+	WithBuildingBib:
 	ProvidesRadar:
 		RequiresCondition: !disabled
 	RenderDetectionCircle:
@@ -588,7 +597,7 @@ FIX:
 		HP: 800
 	RevealsShroud:
 		Range: 5c0
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	Reservable:
 	RepairsUnits:
@@ -621,8 +630,9 @@ EYE:
 		Queue: Building.GDI
 		Description: Provides radar and Orbital Ion Cannon support power.\nUnlocks Mammoth Tank and Commando.\nRequires power to operate.
 	Building:
-		Footprint: x_ xx
-		Dimensions: 2,2
+		Footprint: x_ xx ==
+		Dimensions: 2,3
+		LocalCenterOffset: 0,-512,0
 	Selectable:
 		Bounds: 48,40,0,9
 	SelectionDecorations:
@@ -637,7 +647,7 @@ EYE:
 		HP: 1300
 	RevealsShroud:
 		Range: 10c0
-	Bib:
+	WithBuildingBib:
 	ProvidesRadar:
 		RequiresCondition: !disabled
 	RenderDetectionCircle:
@@ -682,8 +692,9 @@ TMPL:
 		Queue: Building.Nod
 		Description: Provides Nuclear Strike support power.\nUnlocks Stealth Tank, Chem. Warrior and Obelisk of Light.\nRequires power to operate.
 	Building:
-		Footprint: xxx xxx
-		Dimensions: 3,2
+		Footprint: xxx xxx ===
+		Dimensions: 3,3
+		LocalCenterOffset: 0,-512,0
 	Selectable:
 		Bounds: 72,48
 	SelectionDecorations:
@@ -696,7 +707,7 @@ TMPL:
 		HP: 2100
 	RevealsShroud:
 		Range: 6c0
-	Bib:
+	WithBuildingBib:
 	RenderDetectionCircle:
 	DetectCloaked:
 		Range: 5c0
@@ -748,7 +759,7 @@ GUN:
 		Type: Heavy
 	RevealsShroud:
 		Range: 6c0
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	Turreted:
 		TurnSpeed: 12
@@ -839,7 +850,7 @@ OBLI:
 		Type: Heavy
 	RevealsShroud:
 		Range: 8c0
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	WithChargeAnimation:
 	Armament:
@@ -877,7 +888,7 @@ GTWR:
 		HP: 400
 	RevealsShroud:
 		Range: 7c0
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	Armament:
 		Weapon: HighV
@@ -920,7 +931,7 @@ ATWR:
 		Type: Heavy
 	RevealsShroud:
 		Range: 8c0
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	Turreted:
 		TurnSpeed: 255

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -37,7 +37,7 @@ HOSP:
 		Name: Hospital
 	SpawnActorOnDeath:
 		Actor: HOSP.Husk
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	ProvidesPrerequisite@buildingname:
 
@@ -48,7 +48,7 @@ HOSP.Husk:
 		Dimensions: 2,2
 	Tooltip:
 		Name: Hospital (Destroyed)
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 
 BIO:
@@ -100,7 +100,7 @@ MISS:
 		Prerequisites: ~disabled
 	Valued:
 		Cost: 2000
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	WithMakeAnimation:
 	ProvidesPrerequisite@buildingname:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -53,13 +53,14 @@ construction_yard:
 		Description: Produces structures.
 	-DamagedByTerrain:
 	Building:
-		Footprint: xxx xxx
-		Dimensions: 3,2
+		Footprint: xxx xxx ===
+		Dimensions: 3,3
 		Adjacent: 4
+		LocalCenterOffset: 0,-512,0
 	LaysTerrain:
 		TerrainTypes: Rock
 		Template: 88
-	Bib:
+	WithBuildingBib:
 	Selectable:
 		Bounds: 96,64
 	Health:
@@ -133,9 +134,10 @@ wind_trap:
 	Tooltip:
 		Name: Wind Trap
 	Building:
-		Footprint: xx xx
-		Dimensions: 2,2
-	Bib:
+		Footprint: xx xx ==
+		Dimensions: 2,3
+		LocalCenterOffset: 0,-512,0
+	WithBuildingBib:
 	Health:
 		HP: 3000
 	HitShape:
@@ -178,9 +180,10 @@ barracks:
 	Tooltip:
 		Name: Barracks
 	Building:
-		Footprint: xx xx
-		Dimensions: 2,2
-	Bib:
+		Footprint: xx xx ==
+		Dimensions: 2,3
+		LocalCenterOffset: 0,-512,0
+	WithBuildingBib:
 	Health:
 		HP: 3200
 	HitShape:
@@ -258,9 +261,10 @@ refinery:
 	Tooltip:
 		Name: Spice Refinery
 	Building:
-		Footprint: =xx xx=
-		Dimensions: 3,2
-	Bib:
+		Footprint: =xx xx= ===
+		Dimensions: 3,3
+		LocalCenterOffset: 0,-512,0
+	WithBuildingBib:
 	Health:
 		HP: 3000
 	HitShape:
@@ -371,9 +375,10 @@ light_factory:
 	Tooltip:
 		Name: Light Factory
 	Building:
-		Footprint: xxx xx=
-		Dimensions: 3,2
-	Bib:
+		Footprint: xxx xx= ===
+		Dimensions: 3,3
+		LocalCenterOffset: 0,-512,0
+	WithBuildingBib:
 	Health:
 		HP: 3300
 	HitShape:
@@ -454,9 +459,10 @@ heavy_factory:
 	Tooltip:
 		Name: Heavy Factory
 	Building:
-		Footprint: _x_ xxx =xx
-		Dimensions: 3,3
-	Bib:
+		Footprint: _x_ xxx =xx ===
+		Dimensions: 3,4
+		LocalCenterOffset: 0,-512,0
+	WithBuildingBib:
 	Health:
 		HP: 3500
 	HitShape:
@@ -551,9 +557,10 @@ outpost:
 	Tooltip:
 		Name: Outpost
 	Building:
-		Footprint: xxx xxx
-		Dimensions: 3,2
-	Bib:
+		Footprint: xxx xxx ===
+		Dimensions: 3,3
+		LocalCenterOffset: 0,-512,0
+	WithBuildingBib:
 	Health:
 		HP: 3500
 	HitShape:
@@ -883,9 +890,10 @@ high_tech_factory:
 		SpawnOffset: 0,0,728
 		ExitCell: 0,0
 	Building:
-		Footprint: _x_ xxx xxx
-		Dimensions: 3,3
-	Bib:
+		Footprint: _x_ xxx xxx ===
+		Dimensions: 3,4
+		LocalCenterOffset: 0,-512,0
+	WithBuildingBib:
 	Health:
 		HP: 3500
 	HitShape:
@@ -961,9 +969,10 @@ research_centre:
 	Tooltip:
 		Name: IX Research Center
 	Building:
-		Footprint: _x_ xxx xxx
-		Dimensions: 3,3
-	Bib:
+		Footprint: _x_ xxx xxx ===
+		Dimensions: 3,4
+		LocalCenterOffset: 0,-512,0
+	WithBuildingBib:
 	Health:
 		HP: 2500
 	HitShape:
@@ -1014,9 +1023,10 @@ palace:
 	Tooltip:
 		Name: Palace
 	Building:
-		Footprint: xx= xxx =xx
-		Dimensions: 3,3
-	Bib:
+		Footprint: xx= xxx =xx ===
+		Dimensions: 3,4
+		LocalCenterOffset: 0,-512,0
+	WithBuildingBib:
 		HasMinibib: True
 	Health:
 		HP: 4000

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -113,7 +113,7 @@ OILB:
 		HP: 3000
 	Armor:
 		Type: Wood
-	Bib:
+	WithBuildingBib:
 	RevealsShroud:
 		Range: 3c0
 	CashTrickler:

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -66,8 +66,9 @@ FCOM:
 	Inherits: ^TechBuilding
 	Inherits@shape: ^2x2Shape
 	Building:
-		Footprint: xx xx
-		Dimensions: 2,2
+		Footprint: xx xx ==
+		Dimensions: 2,3
+		LocalCenterOffset: 0,-512,0
 	Valued:
 		Cost: 2000
 	Health:
@@ -78,7 +79,7 @@ FCOM:
 		Name: Forward Command
 	RevealsShroud:
 		Range: 10c0
-	Bib:
+	WithBuildingBib:
 	Power:
 		Amount: -200
 	ProvidesPrerequisite@buildingname:
@@ -100,7 +101,7 @@ HOSP:
 		Name: Hospital
 	RevealsShroud:
 		Range: 3c0
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	WithDeathAnimation:
 		DeathSequence: dead
@@ -344,8 +345,9 @@ MISS:
 	Selectable:
 		Priority: 0
 	Building:
-		Footprint: xxx xxx
-		Dimensions: 3,2
+		Footprint: xxx xxx ===
+		Dimensions: 3,3
+		LocalCenterOffset: 0,-512,0
 	Valued:
 		Cost: 2000
 	Health:
@@ -356,7 +358,7 @@ MISS:
 		Type: Wood
 	Tooltip:
 		Name: Technology Center
-	Bib:
+	WithBuildingBib:
 	WithDeathAnimation:
 		DeathSequence: dead
 		UseDeathTypeSuffix: false

--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -17,13 +17,14 @@ FPWR:
 		GenericVisibility: Enemy
 		GenericStancePrefix: False
 	Building:
-		Footprint: xx xx
-		Dimensions: 2,2
+		Footprint: xx xx ==
+		Dimensions: 2,3
+		LocalCenterOffset: 0,-512,0
 	Health:
 		HP: 400
 	Armor:
 		Type: Wood
-	Bib:
+	WithBuildingBib:
 	RenderSprites:
 		Image: POWR
 	Valued:
@@ -133,9 +134,10 @@ WEAF:
 		GenericVisibility: Enemy
 		GenericStancePrefix: False
 	Building:
-		Footprint: xxx xxx
-		Dimensions: 3,2
-	Bib:
+		Footprint: xxx xxx ===
+		Dimensions: 3,3
+		LocalCenterOffset: 0,-512,0
+	WithBuildingBib:
 	RenderSprites:
 		Image: WEAP
 	WithProductionDoorOverlay:
@@ -167,9 +169,10 @@ DOMF:
 		Description: Looks like a Radar Dome.
 		Icon: fake-icon
 	Building:
-		Footprint: xx xx
-		Dimensions: 2,2
-	Bib:
+		Footprint: xx xx ==
+		Dimensions: 2,3
+		LocalCenterOffset: 0,-512,0
+	WithBuildingBib:
 	RenderSprites:
 		Image: DOME
 	Valued:
@@ -200,7 +203,7 @@ FIXF:
 		HP: 800
 	Armor:
 		Type: Wood
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	RenderSprites:
 		Image: FIX
@@ -238,13 +241,14 @@ FAPW:
 		GenericVisibility: Enemy
 		GenericStancePrefix: False
 	Building:
-		Footprint: xxx xxx
-		Dimensions: 3,2
+		Footprint: xxx xxx ===
+		Dimensions: 3,3
+		LocalCenterOffset: 0,-512,0
 	Health:
 		HP: 700
 	Armor:
 		Type: Wood
-	Bib:
+	WithBuildingBib:
 	RenderSprites:
 		Image: APWR
 	Selectable:
@@ -270,9 +274,10 @@ ATEF:
 		Description: Looks like an Allied Tech Center.
 		Icon: fake-icon
 	Building:
-		Footprint: xx xx
-		Dimensions: 2,2
-	Bib:
+		Footprint: xx xx ==
+		Dimensions: 2,3
+		LocalCenterOffset: 0,-512,0
+	WithBuildingBib:
 	RenderSprites:
 		Image: ATEK
 	Valued:
@@ -304,7 +309,7 @@ PDOF:
 		Dimensions: 2,2
 	RenderSprites:
 		Image: PDOX
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	Valued:
 		Cost: 150
@@ -361,9 +366,10 @@ FACF:
 		GenericVisibility: Enemy
 		GenericStancePrefix: False
 	Building:
-		Footprint: xxx xxx xxx
-		Dimensions: 3,3
-	Bib:
+		Footprint: xxx xxx xxx ===
+		Dimensions: 3,4
+		LocalCenterOffset: 0,-512,0
+	WithBuildingBib:
 	RenderSprites:
 		Image: FACT
 	Valued:

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -372,7 +372,7 @@ CTFLAG:
 		Dimensions: 1,1
 	Tooltip:
 		Name: Flag
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	DamageMultiplier@INVULNERABLE:
 		Modifier: 0

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -85,7 +85,7 @@ GAP:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 5c0
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	CreatesShroud:
 		Range: 6c0
@@ -346,7 +346,7 @@ IRON:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 6c0
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	GrantExternalConditionPower@IRONCURTAIN:
 		PauseOnCondition: disabled
@@ -398,7 +398,7 @@ PDOX:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 6c0
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	ProvidesPrerequisite@germany:
 		Factions: germany
@@ -475,7 +475,7 @@ TSLA:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 6c0
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	WithTeslaChargeAnimation:
 	Armament:
@@ -521,7 +521,7 @@ AGUN:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 5c0
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	Turreted:
 		TurnSpeed: 15
@@ -560,8 +560,9 @@ DOME:
 	Tooltip:
 		Name: Radar Dome
 	Building:
-		Footprint: xx xx
-		Dimensions: 2,2
+		Footprint: xx xx ==
+		Dimensions: 2,3
+		LocalCenterOffset: 0,-512,0
 	Targetable:
 		TargetTypes: Ground, Structure, C4, DetonateAttack, SpyInfiltrate
 	RequiresPower:
@@ -577,7 +578,7 @@ DOME:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 6c0
-	Bib:
+	WithBuildingBib:
 	ProvidesRadar:
 		RequiresCondition: !jammed && !disabled
 	InfiltrateForExploration:
@@ -616,7 +617,7 @@ PBOX:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 5c0
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	Turreted:
 		TurnSpeed: 255
@@ -719,7 +720,7 @@ GUN:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 5c0
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	Turreted:
 		TurnSpeed: 12
@@ -761,7 +762,7 @@ FTUR:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 5c0
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	Turreted:
 		TurnSpeed: 255
@@ -809,7 +810,7 @@ SAM:
 		Type: Heavy
 	RevealsShroud:
 		Range: 5c0
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	Turreted:
 		TurnSpeed: 30
@@ -846,8 +847,9 @@ ATEK:
 	ProvidesPrerequisite:
 		Prerequisite: techcenter
 	Building:
-		Footprint: xx xx
-		Dimensions: 2,2
+		Footprint: xx xx ==
+		Dimensions: 2,3
+		LocalCenterOffset: 0,-512,0
 	Health:
 		HP: 600
 	Armor:
@@ -857,7 +859,7 @@ ATEK:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 6c0
-	Bib:
+	WithBuildingBib:
 	GpsPower:
 		PauseOnCondition: disabled
 		Icon: gps
@@ -887,15 +889,16 @@ WEAP:
 	Tooltip:
 		Name: War Factory
 	Building:
-		Footprint: xxx xxx
-		Dimensions: 3,2
+		Footprint: xxx xxx ===
+		Dimensions: 3,3
+		LocalCenterOffset: 0,-512,0
 	Health:
 		HP: 1500
 	Armor:
 		Type: Wood
 	RevealsShroud:
 		Range: 4c0
-	Bib:
+	WithBuildingBib:
 	WithProductionDoorOverlay:
 		Sequence: build-top
 	RallyPoint:
@@ -979,8 +982,9 @@ WEAP:
 FACT:
 	Inherits: ^Building
 	Building:
-		Footprint: xxx xxx xxx
-		Dimensions: 3,3
+		Footprint: xxx xxx xxx ===
+		Dimensions: 3,4
+		LocalCenterOffset: 0,-512,0
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 1000
@@ -1022,7 +1026,7 @@ FACT:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 4c0
-	Bib:
+	WithBuildingBib:
 	Production:
 		Produces: Building,Defense
 	Valued:
@@ -1071,8 +1075,9 @@ PROC:
 	Tooltip:
 		Name: Ore Refinery
 	Building:
-		Footprint: _x_ xxx x==
-		Dimensions: 3,3
+		Footprint: _x_ xxx x== ===
+		Dimensions: 3,4
+		LocalCenterOffset: 0,-512,0
 	Selectable:
 		Bounds: 72,50,0,12
 	SelectionDecorations:
@@ -1088,7 +1093,7 @@ PROC:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 4c0
-	Bib:
+	WithBuildingBib:
 	Refinery:
 		DockAngle: 64
 		DockOffset: 1,2
@@ -1151,7 +1156,7 @@ SILO:
 		Type: Wood
 	RevealsShroud:
 		Range: 4c0
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	WithSiloAnimation:
 	StoresResources:
@@ -1180,8 +1185,9 @@ HPAD:
 	Tooltip:
 		Name: Helipad
 	Building:
-		Footprint: xx xx
-		Dimensions: 2,2
+		Footprint: xx xx ==
+		Dimensions: 2,3
+		LocalCenterOffset: 0,-512,0
 	Health:
 		HP: 800
 	Armor:
@@ -1191,7 +1197,7 @@ HPAD:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 4c0
-	Bib:
+	WithBuildingBib:
 	Exit@1:
 		SpawnOffset: 0,-256,0
 		ExitCell: 0,0
@@ -1403,15 +1409,16 @@ POWR:
 	ProvidesPrerequisite:
 		Prerequisite: anypower
 	Building:
-		Footprint: xx xx
-		Dimensions: 2,2
+		Footprint: xx xx ==
+		Dimensions: 2,3
+		LocalCenterOffset: 0,-512,0
 	Health:
 		HP: 400
 	Armor:
 		Type: Wood
 	RevealsShroud:
 		Range: 4c0
-	Bib:
+	WithBuildingBib:
 	Power:
 		Amount: 100
 	Targetable:
@@ -1441,8 +1448,9 @@ APWR:
 	ProvidesPrerequisite:
 		Prerequisite: anypower
 	Building:
-		Footprint: xxx xxx
-		Dimensions: 3,2
+		Footprint: xxx xxx ===
+		Dimensions: 3,3
+		LocalCenterOffset: 0,-512,0
 	Selectable:
 		Bounds: 72,48
 	SelectionDecorations:
@@ -1453,7 +1461,7 @@ APWR:
 		Type: Wood
 	RevealsShroud:
 		Range: 4c0
-	Bib:
+	WithBuildingBib:
 	Power:
 		Amount: 200
 	Targetable:
@@ -1481,15 +1489,16 @@ STEK:
 	ProvidesPrerequisite:
 		Prerequisite: techcenter
 	Building:
-		Footprint: xxx xxx
-		Dimensions: 3,2
+		Footprint: xxx xxx ===
+		Dimensions: 3,3
+		LocalCenterOffset: 0,-512,0
 	Health:
 		HP: 600
 	Armor:
 		Type: Wood
 	RevealsShroud:
 		Range: 4c0
-	Bib:
+	WithBuildingBib:
 	Power:
 		Amount: -100
 	ProvidesPrerequisite@buildingname:
@@ -1510,8 +1519,9 @@ BARR:
 	Tooltip:
 		Name: Soviet Barracks
 	Building:
-		Footprint: xx xx
-		Dimensions: 2,2
+		Footprint: xx xx ==
+		Dimensions: 2,3
+		LocalCenterOffset: 0,-512,0
 	Health:
 		HP: 600
 	Armor:
@@ -1521,7 +1531,7 @@ BARR:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 4c0
-	Bib:
+	WithBuildingBib:
 	RallyPoint:
 	Exit@1:
 		SpawnOffset: -170,810,0
@@ -1594,7 +1604,7 @@ KENN:
 		Type: Wood
 	RevealsShroud:
 		Range: 4c0
-	Bib:
+	WithBuildingBib:
 		HasMinibib: True
 	RallyPoint:
 		Offset: 0,2
@@ -1637,8 +1647,9 @@ TENT:
 	Tooltip:
 		Name: Allied Barracks
 	Building:
-		Footprint: xx xx
-		Dimensions: 2,2
+		Footprint: xx xx ==
+		Dimensions: 2,3
+		LocalCenterOffset: 0,-512,0
 	Health:
 		HP: 600
 	Armor:
@@ -1648,7 +1659,7 @@ TENT:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 4c0
-	Bib:
+	WithBuildingBib:
 	RallyPoint:
 	Exit@1:
 		SpawnOffset: -42,810,0
@@ -1735,7 +1746,7 @@ FIX:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 4c0
-	Bib:
+	WithBuildingBib:
 		HasMinibib: Yes
 	Reservable:
 	RallyPoint:


### PR DESCRIPTION
This PR tries to get stuff out of the way that is easy, but would blow the number of commits and changed lines out of proportion on #13553.

Adds `ITargetableCells` interface for use in #13553, renames `Bib`, and removes the bib-related hacks from `Building` and `FootprintUtils`, while adding a `LocalCenterOffset` to `Building`, to allow shifting the actor center to account for bibs (or other visuals, if modders chose to use it that way).
Finally, moves the renamed `WithBuildingBib` to Mods.Cnc.

Dependency for update of #13553.