### PR TITLE
Remove ApplyToAllTargetablePositions hack from RectangleShape

### DIFF
--- a/OpenRA.Mods.Common/HitShapes/Rectangle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Rectangle.cs
@@ -38,10 +38,6 @@ namespace OpenRA.Mods.Common.HitShapes
 			"Mobile actors do NOT need this!")]
 		public readonly WAngle LocalYaw = WAngle.Zero;
 
-		// This is just a temporary work-around until we have a customizable PolygonShape
-		[Desc("Applies shape to every TargetablePosition instead of just CenterPosition.")]
-		public readonly bool ApplyToAllTargetablePositions = false;
-
 		int2 quadrantSize;
 		int2 center;
 
@@ -103,13 +99,6 @@ namespace OpenRA.Mods.Common.HitShapes
 			var actorPos = actor.CenterPosition;
 			var orientation = actor.Orientation + WRot.FromYaw(LocalYaw);
 
-			var targetablePositions = actor.TraitsImplementing<ITargetablePositions>();
-			if (ApplyToAllTargetablePositions && targetablePositions.Any())
-			{
-				var positions = targetablePositions.SelectMany(tp => tp.TargetablePositions(actor));
-				actorPos = positions.PositionClosestTo(pos);
-			}
-
 			if (pos.Z > actorPos.Z + VerticalTopOffset)
 				return DistanceFromEdge((pos - (actorPos + new WVec(0, 0, VerticalTopOffset))).Rotate(-orientation));
 
@@ -124,25 +113,10 @@ namespace OpenRA.Mods.Common.HitShapes
 			var actorPos = actor.CenterPosition;
 			var orientation = actor.Orientation + WRot.FromYaw(LocalYaw);
 
-			var targetablePositions = actor.TraitsImplementing<ITargetablePositions>();
-			if (ApplyToAllTargetablePositions && targetablePositions.Any())
-			{
-				var positions = targetablePositions.SelectMany(tp => tp.TargetablePositions(actor));
-				foreach (var pos in positions)
-				{
-					var vertsTop = combatOverlayVertsTop.Select(v => wr.Screen3DPosition(pos + v.Rotate(orientation)));
-					var vertsBottom = combatOverlayVertsBottom.Select(v => wr.Screen3DPosition(pos + v.Rotate(orientation)));
-					wcr.DrawPolygon(vertsTop.ToArray(), 1, Color.Yellow);
-					wcr.DrawPolygon(vertsBottom.ToArray(), 1, Color.Yellow);
-				}
-			}
-			else
-			{
-				var vertsTop = combatOverlayVertsTop.Select(v => wr.Screen3DPosition(actorPos + v.Rotate(orientation)));
-				var vertsBottom = combatOverlayVertsBottom.Select(v => wr.Screen3DPosition(actorPos + v.Rotate(orientation)));
-				wcr.DrawPolygon(vertsTop.ToArray(), 1, Color.Yellow);
-				wcr.DrawPolygon(vertsBottom.ToArray(), 1, Color.Yellow);
-			}
+			var vertsTop = combatOverlayVertsTop.Select(v => wr.Screen3DPosition(actorPos + v.Rotate(orientation)));
+			var vertsBottom = combatOverlayVertsBottom.Select(v => wr.Screen3DPosition(actorPos + v.Rotate(orientation)));
+			wcr.DrawPolygon(vertsTop.ToArray(), 1, Color.Yellow);
+			wcr.DrawPolygon(vertsBottom.ToArray(), 1, Color.Yellow);
 
 			RangeCircleRenderable.DrawRangeCircle(wr, actorPos, OuterRadius, 1, Color.LimeGreen, 0, Color.LimeGreen);
 		}

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -749,6 +749,28 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// Removed ApplyToAllTargetablePositions hack from Rectangle shape
+				if (engineVersion < 20170629)
+				{
+					if (node.Key.StartsWith("HitShape", StringComparison.Ordinal))
+					{
+						var shape = node.Value.Nodes.FirstOrDefault(n => n.Key == "Type" && n.Value.Value == "Rectangle");
+						if (shape != null)
+						{
+							var hack = shape.Value.Nodes.FirstOrDefault(n => n.Key == "ApplyToAllTargetablePositions");
+							if (hack != null)
+							{
+								Console.WriteLine("Rectangle.ApplyToAllTargetablePositions has been removed due to incompatibilities");
+								Console.WriteLine("with the HitShape refactor and projectile/warhead victim scans, as well as performance concerns.");
+								Console.WriteLine("If you absolutely want to use it, please ship a duplicate of the old Rectangle code with your mod code.");
+								Console.WriteLine("Otherwise, we recommend using inheritable shape templates for rectangular buildings");
+								Console.WriteLine("and custom setups for the rest (see our official mods for examples).");
+								shape.Value.Nodes.Remove(hack);
+							}
+						}
+					}
+				}
+
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 


### PR DESCRIPTION
In its current form, it's bad for performance due to the `var targetablePositions` look-up happening before the `if (ApplyToAllTargetablePositions...)`, and while that would be easy to fix, fixing it only to remove the hack entirely a few weeks later would be kind of pointless, so let's get this over with.

Should go into the playtest as all mods have a lot of Rectangle shapes now, so it might improve performance.

3rd-party mods currently using this still have multiple options, so the transition shouldn't be that painful:
- Ship a duplicate of the bleed version + performance fix and use that (could even simplify code by removing the boolean and making it a dedicated shape type).
- Stay on a bleed revision before this is merged until the `PolygonShape` and/or our TS mod shape templates are finished and merged and then use them.
- Write their own HitShape trait templates. It's quite easy for rectangular buildings, not that hard for asymmetric shapes (with some practice) and normally just a one-time job.