### PR TITLE
Make WithMoveAnimation conditional and modify only a single WSB

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithAttackAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAttackAnimation.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
-			var matches = ai.TraitInfos<WithSpriteBodyInfo>().Count(w => Body == w.Name);
+			var matches = ai.TraitInfos<WithSpriteBodyInfo>().Count(w => w.Name == Body);
 			if (matches != 1)
 				throw new YamlException("WithAttackAnimation needs exactly one sprite body with matching name.");
 


### PR DESCRIPTION
To match what we do on WithAttackAnimation already.

If this makes it into the playtest, it won't need an upgrade rule for BodyNames -> Body since we haven't shipped a release/playtest with BodyNames yet.

Closes #11884.