### PR TITLE
Fix ZIP encoding

### DIFF
--- a/OpenRA.Game/FileSystem/ZipFile.cs
+++ b/OpenRA.Game/FileSystem/ZipFile.cs
@@ -13,9 +13,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using ICSharpCode.SharpZipLib.Zip;
-using SZipFile = ICSharpCode.SharpZipLib.Zip.ZipFile;
+using OpenRA.Primitives;
 
 namespace OpenRA.FileSystem
 {
@@ -26,12 +25,7 @@ namespace OpenRA.FileSystem
 		class ReadOnlyZipFile : IReadOnlyPackage
 		{
 			public string Name { get; protected set; }
-			protected SZipFile pkg;
-
-			static ReadOnlyZipFile()
-			{
-				ZipConstants.DefaultCodePage = Encoding.UTF8.CodePage;
-			}
+			protected ZipFile pkg;
 
 			// Dummy constructor for use with ReadWriteZipFile
 			protected ReadOnlyZipFile() { }
@@ -39,7 +33,7 @@ namespace OpenRA.FileSystem
 			public ReadOnlyZipFile(Stream s, string filename)
 			{
 				Name = filename;
-				pkg = new SZipFile(s);
+				pkg = ZipFileHelper.Create(s);
 			}
 
 			public Stream GetStream(string filename)
@@ -117,7 +111,7 @@ namespace OpenRA.FileSystem
 				}
 
 				pkgStream.Position = 0;
-				pkg = new SZipFile(pkgStream);
+				pkg = ZipFileHelper.Create(pkgStream);
 				Name = filename;
 			}
 
@@ -151,11 +145,6 @@ namespace OpenRA.FileSystem
 			public string Name { get { return path; } }
 			public ReadOnlyZipFile Parent { get; private set; }
 			readonly string path;
-
-			static ZipFolder()
-			{
-				ZipConstants.DefaultCodePage = Encoding.UTF8.CodePage;
-			}
 
 			public ZipFolder(ReadOnlyZipFile parent, string path)
 			{

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -164,6 +164,7 @@
     <Compile Include="Primitives\SegmentStream.cs" />
     <Compile Include="Primitives\SpatiallyPartitioned.cs" />
     <Compile Include="Primitives\ConcurrentCache.cs" />
+    <Compile Include="Primitives\ZipFileHelper.cs" />
     <Compile Include="SelectableExts.cs" />
     <Compile Include="Selection.cs" />
     <Compile Include="Server\Connection.cs" />

--- a/OpenRA.Game/Primitives/ZipFileHelper.cs
+++ b/OpenRA.Game/Primitives/ZipFileHelper.cs
@@ -1,0 +1,46 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.IO;
+using System.Text;
+using ICSharpCode.SharpZipLib.Zip;
+
+namespace OpenRA.Primitives
+{
+	public static class ZipFileHelper
+	{
+		/// <summary>
+		/// Creates a <see cref="ZipFile"/> with UTF8 encoding. Avoid using <see cref="ZipFile(Stream)"/> as you
+		/// cannot be sure of the encoding that will be used.
+		/// </summary>
+		public static ZipFile Create(Stream stream)
+		{
+			// SharpZipLib uses this global as the encoding to use for all ZipFiles.
+			// The initial value is the system code page, which causes several problems.
+			// 1) On some systems, the code page for a certain encoding might not even be installed.
+			// 2) The code page is different on every system, resulting in unpredictability.
+			// 3) The code page might not work for decoding some archives.
+			// We set the default to UTF8 instead which fixes all these problems.
+			ZipConstants.DefaultCodePage = Encoding.UTF8.CodePage;
+			return new ZipFile(stream);
+		}
+
+		/// <summary>
+		/// Creates a <see cref="ZipFile"/> with UTF8 encoding. Avoid using <see cref="ZipFile(FileStream)"/> as you
+		/// cannot be sure of the encoding that will be used.
+		/// </summary>
+		public static ZipFile Create(FileStream stream)
+		{
+			ZipConstants.DefaultCodePage = Encoding.UTF8.CodePage;
+			return new ZipFile(stream);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
@@ -15,8 +15,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Net;
 using System.Text;
-using ICSharpCode.SharpZipLib;
-using ICSharpCode.SharpZipLib.Zip;
+using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Widgets;
 
@@ -140,7 +139,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				try
 				{
 					using (var stream = File.OpenRead(file))
-					using (var z = new ZipFile(stream))
+					using (var z = ZipFileHelper.Create(stream))
 					{
 						foreach (var kv in download.Extract)
 						{


### PR DESCRIPTION
Fixes #12985.

We has similar issues before in #10737, #10197 that were fixed by a combination of #5334, #10375 and #10332.

To ensure `DownloadPackageLogic` also gets this fixed encoding, we can't rely on the static constructor in `ZipFile`/`ZipFolder`. Instead, I have created a helper method, and we will just have to hope new code spots it and uses it rather than creating a `new ZipFile(stream)` and still getting the crappy default encoding.