### PR TITLE
Add a CommandBarBlacklist trait to blacklist Stop and Waypoint Mode

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -293,6 +293,7 @@
     <Compile Include="Traits\Buildings\Reservable.cs" />
     <Compile Include="Traits\Burns.cs" />
     <Compile Include="Traits\ChangesTerrain.cs" />
+    <Compile Include="Traits\CommandBarBlacklist.cs" />
     <Compile Include="Traits\Health.cs" />
     <Compile Include="Traits\HitShape.cs" />
     <Compile Include="Traits\PowerTooltip.cs" />

--- a/OpenRA.Mods.Common/Traits/CommandBarBlacklist.cs
+++ b/OpenRA.Mods.Common/Traits/CommandBarBlacklist.cs
@@ -1,0 +1,27 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Blacklist certain order types to disable on the command bar when this unit is selected.")]
+	public class CommandBarBlacklistInfo : TraitInfo<CommandBarBlacklist>
+	{
+		[Desc("Disable the 'Stop' button for this actor.")]
+		public readonly bool DisableStop = true;
+
+		[Desc("Disable the 'Waypoint Mode' button for this actor.")]
+		public readonly bool DisableWaypointMode = true;
+	}
+
+	public class CommandBarBlacklist { }
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
@@ -33,6 +33,8 @@ namespace OpenRA.Mods.Common.Widgets
 		bool forceAttackDisabled = true;
 		bool guardDisabled = true;
 		bool scatterDisabled = true;
+		bool stopDisabled = true;
+		bool waypointModeDisabled = true;
 
 		int deployHighlighted;
 		int scatterHighlighted;
@@ -148,7 +150,7 @@ namespace OpenRA.Mods.Common.Widgets
 				BindButtonIcon(stopButton);
 
 				stopButton.GetKey = _ => ks.StopKey;
-				stopButton.IsDisabled = () => { UpdateStateIfNecessary(); return !selectedActors.Any(); };
+				stopButton.IsDisabled = () => { UpdateStateIfNecessary(); return stopDisabled; };
 				stopButton.IsHighlighted = () => stopHighlighted > 0;
 				stopButton.OnClick = () => PerformKeyboardOrderOnSelection(a => new Order("Stop", a, false));
 				stopButton.OnKeyPress = ki => { stopHighlighted = 2; stopButton.OnClick(); };
@@ -159,7 +161,7 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				BindButtonIcon(queueOrdersButton);
 
-				queueOrdersButton.IsDisabled = () => { UpdateStateIfNecessary(); return !selectedActors.Any(); };
+				queueOrdersButton.IsDisabled = () => { UpdateStateIfNecessary(); return waypointModeDisabled; };
 				queueOrdersButton.IsHighlighted = () => !queueOrdersButton.IsDisabled() && IsForceModifiersActive(Modifiers.Shift);
 				queueOrdersButton.OnClick = () =>
 				{
@@ -223,6 +225,10 @@ namespace OpenRA.Mods.Common.Widgets
 				.SelectMany(a => a.TraitsImplementing<IIssueDeployOrder>()
 					.Select(d => new TraitPair<IIssueDeployOrder>(a, d)))
 				.ToArray();
+
+			var cbbInfos = selectedActors.Select(a => a.Info.TraitInfoOrDefault<CommandBarBlacklistInfo>()).ToArray();
+			stopDisabled = !cbbInfos.Any(i => i == null || !i.DisableStop);
+			waypointModeDisabled = !cbbInfos.Any(i => i == null || !i.DisableWaypointMode);
 
 			selectionHash = world.Selection.Hash;
 		}

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -669,6 +669,7 @@
 	Demolishable:
 	EditorTilesetFilter:
 		Categories: Building
+	CommandBarBlacklist:
 
 ^BaseBuilding:
 	Inherits: ^Building
@@ -1000,6 +1001,7 @@
 		TargetTypes: Ground, C4, Structure, Defense
 	EditorTilesetFilter:
 		Categories: Defense
+	-CommandBarBlacklist:
 
 ^DisabledOverlay:
 	WithColoredOverlay@IDISABLE:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -424,6 +424,7 @@
 		Radius: 4c768
 	EditorTilesetFilter:
 		Categories: Building
+	CommandBarBlacklist:
 
 ^Defense:
 	Inherits: ^Building
@@ -450,6 +451,7 @@
 		TargetTypes: Ground, C4, Structure, Defense
 	EditorTilesetFilter:
 		Categories: Defense
+	-CommandBarBlacklist:
 
 ^DisabledOverlay:
 	WithColoredOverlay@IDISABLE:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -592,6 +592,7 @@
 	Demolishable:
 	EditorTilesetFilter:
 		Categories: Building
+	CommandBarBlacklist:
 
 ^Building:
 	Inherits: ^BasicBuilding
@@ -634,6 +635,7 @@
 		EmptyWeapon: SmallBuildingExplode
 	EditorTilesetFilter:
 		Categories: Defense
+	-CommandBarBlacklist:
 
 ^Wall:
 	Inherits@1: ^ExistsInWorld


### PR DESCRIPTION
Otherwise they are visible for buildings. I kept "Stop" enabled for defenses.