### PR TITLE
Add search fields to the map editor template and actor lists.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
@@ -91,8 +91,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					var cell = worldRenderer.Viewport.ViewToWorld(Viewport.LastMousePos);
 					var map = worldRenderer.World.Map;
-					var height = map.Height.Contains(cell) ? map.Height[cell] : 0;
-					return "{0},{1}".F(cell, height);
+					return map.Height.Contains(cell) ?
+						"{0},{1} ({2})".F(cell, map.Height[cell], map.Tiles[cell].Type) : "";
 				};
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Widgets;
@@ -18,52 +19,123 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class TileSelectorLogic : ChromeLogic
 	{
+		class TileSelectorTemplate
+		{
+			public readonly TerrainTemplateInfo Template;
+			public readonly string[] Categories;
+			public readonly string[] SearchTerms;
+			public readonly string Tooltip;
+
+			public TileSelectorTemplate(TerrainTemplateInfo template)
+			{
+				Template = template;
+				Categories = template.Categories;
+				Tooltip = template.Id.ToString();
+				SearchTerms = new[] { Tooltip };
+			}
+		}
+
+		readonly TileSet tileset;
+		readonly WorldRenderer worldRenderer;
 		readonly EditorViewportControllerWidget editor;
 		readonly ScrollPanelWidget panel;
 		readonly ScrollItemWidget itemTemplate;
+		readonly TileSelectorTemplate[] allTemplates;
+
+		string selectedCategory;
+		string userSelectedCategory;
+		string searchFilter;
 
 		[ObjectCreator.UseCtor]
 		public TileSelectorLogic(Widget widget, WorldRenderer worldRenderer)
 		{
-			var rules = worldRenderer.World.Map.Rules;
-			var tileset = rules.TileSet;
+			tileset = worldRenderer.World.Map.Rules.TileSet;
+			this.worldRenderer = worldRenderer;
 
 			editor = widget.Parent.Get<EditorViewportControllerWidget>("MAP_EDITOR");
 			panel = widget.Get<ScrollPanelWidget>("TILETEMPLATE_LIST");
 			itemTemplate = panel.Get<ScrollItemWidget>("TILEPREVIEW_TEMPLATE");
 			panel.Layout = new GridLayout(panel);
 
-			var tileCategorySelector = widget.Get<DropDownButtonWidget>("TILE_CATEGORY");
-			var categories = tileset.EditorTemplateOrder;
+			allTemplates = tileset.Templates.Values.Select(t => new TileSelectorTemplate(t)).ToArray();
+
+			var orderedCategories = allTemplates.SelectMany(t => t.Categories)
+				.Distinct()
+				.OrderBy(CategoryOrder)
+				.ToArray();
+
+			var searchTextField = widget.Get<TextFieldWidget>("SEARCH_TEXTFIELD");
+			searchTextField.OnTextEdited = () =>
+			{
+				searchFilter = searchTextField.Text.Trim();
+				selectedCategory = string.IsNullOrEmpty(searchFilter) ? userSelectedCategory : null;
+
+				InitializeTilePreview();
+			};
+
+			Func<string, string> categoryTitle = s => s != null ? s : "Search Results";
 			Func<string, ScrollItemWidget, ScrollItemWidget> setupItem = (option, template) =>
 			{
-				var item = ScrollItemWidget.Setup(template,
-					() => tileCategorySelector.Text == option,
-					() => { tileCategorySelector.Text = option; IntializeTilePreview(widget, worldRenderer, tileset, option); });
+				var item = ScrollItemWidget.Setup(template,	() => selectedCategory == option, () =>
+				{
+					selectedCategory = option;
+					if (option != null)
+						userSelectedCategory = option;
 
-				item.Get<LabelWidget>("LABEL").GetText = () => option;
+					InitializeTilePreview();
+				});
+
+				var title = categoryTitle(option);
+				item.Get<LabelWidget>("LABEL").GetText = () => title;
 				return item;
 			};
 
+			var tileCategorySelector = widget.Get<DropDownButtonWidget>("CATEGORIES_DROPDOWN");
 			tileCategorySelector.OnClick = () =>
-				tileCategorySelector.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 270, categories, setupItem);
+			{
+				if (searchTextField != null)
+					searchTextField.YieldKeyboardFocus();
 
-			tileCategorySelector.Text = categories.First();
-			IntializeTilePreview(widget, worldRenderer, tileset, categories.First());
+				var categories = orderedCategories.AsEnumerable();
+				if (!string.IsNullOrEmpty(searchFilter))
+				{
+					var filteredCategories = allTemplates.Where(t => t.SearchTerms.Any(
+							s => s.IndexOf(searchFilter, StringComparison.OrdinalIgnoreCase) >= 0))
+						.SelectMany(t => t.Categories)
+						.Distinct()
+						.OrderBy(CategoryOrder);
+					categories = new string[] { null }.Concat(filteredCategories);
+				}
+
+				tileCategorySelector.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 270, categories, setupItem);
+			};
+
+			var actorCategorySelector = widget.Get<DropDownButtonWidget>("CATEGORIES_DROPDOWN");
+			actorCategorySelector.GetText = () => categoryTitle(selectedCategory);
+
+			selectedCategory = userSelectedCategory = orderedCategories.First();
+			InitializeTilePreview();
 		}
 
-		void IntializeTilePreview(Widget widget, WorldRenderer worldRenderer, TileSet tileset, string category)
+		int CategoryOrder(string category)
+		{
+			var i = tileset.EditorTemplateOrder.IndexOf(category);
+			return i >= 0 ? i : int.MaxValue;
+		}
+
+		void InitializeTilePreview()
 		{
 			panel.RemoveChildren();
 
-			var categoryTiles = tileset.Templates.Where(t => t.Value.Categories.Contains(category)).Select(t => t.Value).ToList();
-			var tileIds = categoryTiles.Where(t => t.Categories[0] == category)
-				.Concat(categoryTiles.Where(t => t.Categories[0] != category))
-				.Select(t => t.Id);
-
-			foreach (var t in tileIds)
+			foreach (var t in allTemplates)
 			{
-				var tileId = t;
+				if (selectedCategory != null && !t.Categories.Contains(selectedCategory))
+					continue;
+
+				if (!string.IsNullOrEmpty(searchFilter) && !t.SearchTerms.Any(s => s.IndexOf(searchFilter, StringComparison.OrdinalIgnoreCase) >= 0))
+					continue;
+
+				var tileId = t.Template.Id;
 				var item = ScrollItemWidget.Setup(itemTemplate,
 					() => { var brush = editor.CurrentBrush as EditorTileBrush; return brush != null && brush.Template == tileId; },
 					() => editor.SetBrush(new EditorTileBrush(editor, tileId, worldRenderer)));
@@ -86,7 +158,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				item.Bounds.Width = preview.Bounds.Width + 2 * preview.Bounds.X;
 				item.Bounds.Height = preview.Bounds.Height + 2 * preview.Bounds.Y;
 				item.IsVisible = () => true;
-				item.GetTooltipText = () => tileId.ToString();
+				item.GetTooltipText = () => t.Tooltip;
 
 				panel.AddChild(item);
 			}

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -316,18 +316,49 @@ Container@EDITOR_WORLD_ROOT:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM
 					Children:
-						DropDownButton@OWNERS_DROPDOWN:
-							Width: PARENT_RIGHT
+						Background:
+							Width: 61
+							Height: 75
+							Background: panel-black
+							Children:
+								Label@SEARCH_LABEL:
+									Width: PARENT_RIGHT - 5
+									Height: 25
+									Text: Search:
+									Align: Right
+									Font: TinyBold
+								Label@CATEGORIES_LABEL:
+									Y: 24
+									Width: PARENT_RIGHT - 5
+									Height: 25
+									Text: Filter:
+									Align: Right
+									Font: TinyBold
+								Label@OWNERS_LABEL:
+									Y: 48
+									Width: PARENT_RIGHT - 5
+									Height: 25
+									Text: Owner:
+									Align: Right
+									Font: TinyBold
+						TextField@SEARCH_TEXTFIELD:
+							X: 60
+							Width: PARENT_RIGHT - 60
+							Height: 25
+						DropDownButton@CATEGORIES_DROPDOWN:
+							X: 60
+							Y: 24
+							Width: PARENT_RIGHT - 60
 							Height: 25
 							Font: Bold
-						DropDownButton@ACTOR_CATEGORY:
-							Y: 25
-							Width: PARENT_RIGHT
+						DropDownButton@OWNERS_DROPDOWN:
+							X: 60
+							Y: 48
+							Width: PARENT_RIGHT - 60
 							Height: 25
-							Text: Categories
 							Font: Bold
 						ScrollPanel@ACTORTEMPLATE_LIST:
-							Y: 50
+							Y: 72
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM - 50
 							TopBottomSpacing: 4
@@ -417,7 +448,7 @@ Container@EDITOR_WORLD_ROOT:
 			Contrast: true
 
 ScrollPanel@ACTOR_CATEGORY_FILTER_PANEL:
-	Width: 250
+	Width: 190
 	Children:
 		Container@SELECT_CATEGORIES_BUTTONS:
 			Width: PARENT_RIGHT
@@ -426,15 +457,15 @@ ScrollPanel@ACTOR_CATEGORY_FILTER_PANEL:
 				Button@SELECT_ALL:
 					X: 10
 					Y: 2
-					Width: 100
+					Width: 60
 					Height: 25
-					Text: Select all
+					Text: All
 				Button@SELECT_NONE:
-					X: 120
+					X: PARENT_RIGHT - WIDTH - 34
 					Y: 2
-					Width: 100
+					Width: 60
 					Height: 25
-					Text: Select none
+					Text: None
 		Checkbox@CATEGORY_TEMPLATE:
 			X: 5
 			Y: 5

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -464,7 +464,7 @@ Container@EDITOR_WORLD_ROOT:
 			Font: Bold
 			Contrast: true
 		Label@CASH_LABEL:
-			X: 95
+			X: 125
 			Width: 50
 			Height: 25
 			Align: Left

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -258,14 +258,38 @@ Container@EDITOR_WORLD_ROOT:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM
 					Children:
-						DropDownButton@TILE_CATEGORY:
-							Width: PARENT_RIGHT
+						Background:
+							Width: 61
+							Height: 50
+							Background: panel-black
+							Children:
+								Label@SEARCH_LABEL:
+									Width: PARENT_RIGHT - 5
+									Height: 25
+									Text: Search:
+									Align: Right
+									Font: TinyBold
+								Label@CATEGORIES_LABEL:
+									Y: 24
+									Width: PARENT_RIGHT - 5
+									Height: 25
+									Text: Filter:
+									Align: Right
+									Font: TinyBold
+						TextField@SEARCH_TEXTFIELD:
+							X: 60
+							Width: PARENT_RIGHT - 60
+							Height: 25
+						DropDownButton@CATEGORIES_DROPDOWN:
+							X: 60
+							Y: 24
+							Width: PARENT_RIGHT - 60
 							Height: 25
 							Font: Bold
 						ScrollPanel@TILETEMPLATE_LIST:
-							Y: 24
+							Y: 48
 							Width: PARENT_RIGHT
-							Height: PARENT_BOTTOM - 24
+							Height: PARENT_BOTTOM - 48
 							TopBottomSpacing: 4
 							ItemSpacing: 4
 							Children:

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -289,24 +289,49 @@ Container@EDITOR_WORLD_ROOT:
 					Width: 240
 					Height: WINDOW_BOTTOM - 382
 					Children:
-						DropDownButton@OWNERS_DROPDOWN:
-							X: 10
+						Label@SEARCH_LABEL:
 							Y: 10
-							Width: 220
+							Width: 55
+							Height: 25
+							Text: Search:
+							Align: Right
+							Font: TinyBold
+						TextField@SEARCH_TEXTFIELD:
+							X: 60
+							Y: 10
+							Width: PARENT_RIGHT - 70
+							Height: 25
+						Label@CATEGORIES_LABEL:
+							Y: 34
+							Width: 55
+							Height: 25
+							Text: Filter:
+							Align: Right
+							Font: TinyBold
+						DropDownButton@CATEGORIES_DROPDOWN:
+							X: 60
+							Y: 34
+							Width: PARENT_RIGHT - 70
 							Height: 25
 							Font: Bold
-						DropDownButton@ACTOR_CATEGORY:
-							X: 10
-							Y: 35
-							Width: 220
+						Label@OWNERS_LABEL:
+							Y: 58
+							Width: 55
 							Height: 25
-							Text: Categories
+							Text: Owner:
+							Align: Right
+							Font: TinyBold
+						DropDownButton@OWNERS_DROPDOWN:
+							X: 60
+							Y: 58
+							Width: PARENT_RIGHT - 70
+							Height: 25
 							Font: Bold
 						ScrollPanel@ACTORTEMPLATE_LIST:
 							X: 10
-							Y: 60
-							Width: 220
-							Height: PARENT_BOTTOM - 70
+							Y: 82
+							Width: PARENT_RIGHT - 20
+							Height: PARENT_BOTTOM - 92
 							TopBottomSpacing: 4
 							ItemSpacing: 4
 							Children:
@@ -403,25 +428,25 @@ Container@EDITOR_WORLD_ROOT:
 			Contrast: true
 
 ScrollPanel@ACTOR_CATEGORY_FILTER_PANEL:
-	Width: 220
+	Width: 170
 	Children:
 		Container@SELECT_CATEGORIES_BUTTONS:
-			Width: 220
+			Width: PARENT_RIGHT
 			Height: 29
 			Children:
 				Button@SELECT_ALL:
-					X: 5
+					X: 10
 					Y: 2
-					Width: 90
+					Width: 60
 					Height: 25
-					Text: Select all
+					Text: All
 					Font: Bold
 				Button@SELECT_NONE:
-					X: 100
+					X: PARENT_RIGHT - WIDTH - 34
 					Y: 2
-					Width: 90
+					Width: 60
 					Height: 25
-					Text: Select none
+					Text: None
 					Font: Bold
 		Checkbox@CATEGORY_TEMPLATE:
 			X: 5

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -439,7 +439,7 @@ Container@EDITOR_WORLD_ROOT:
 			Font: Bold
 			Contrast: true
 		Label@CASH_LABEL:
-			X: 570
+			X: 600
 			Width: 50
 			Height: 25
 			Align: Left

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -230,17 +230,36 @@ Container@EDITOR_WORLD_ROOT:
 					Width: 240
 					Height: WINDOW_BOTTOM - 382
 					Children:
-						DropDownButton@TILE_CATEGORY:
-							X: 10
+						Label@SEARCH_LABEL:
 							Y: 10
-							Width: 220
+							Width: 55
+							Height: 25
+							Text: Search:
+							Align: Right
+							Font: TinyBold
+						TextField@SEARCH_TEXTFIELD:
+							X: 60
+							Y: 10
+							Width: PARENT_RIGHT - 70
+							Height: 25
+						Label@CATEGORIES_LABEL:
+							Y: 34
+							Width: 55
+							Height: 25
+							Text: Filter:
+							Align: Right
+							Font: TinyBold
+						DropDownButton@CATEGORIES_DROPDOWN:
+							X: 60
+							Y: 34
+							Width: PARENT_RIGHT - 70
 							Height: 25
 							Font: Bold
 						ScrollPanel@TILETEMPLATE_LIST:
 							X: 10
-							Y: 35
+							Y: 58
 							Width: PARENT_RIGHT - 20
-							Height: PARENT_BOTTOM - 45
+							Height: PARENT_BOTTOM - 68
 							TopBottomSpacing: 4
 							ItemSpacing: 4
 							Children:


### PR DESCRIPTION
This PR wraps up @rob-v's editor improvements by adding a search field to filter actors/tiles by name/id/category/tooltip.  It also adds the template ID to the current cell display so that mappers can quickly identify and filter/select any tile on the map.

<img width="263" alt="screen shot 2017-07-05 at 18 56 30" src="https://user-images.githubusercontent.com/167819/27877737-be860256-61b3-11e7-8dc3-fc740dd620ad.png">

<img width="289" alt="screen shot 2017-07-05 at 13 49 02" src="https://user-images.githubusercontent.com/167819/27877672-79d042fc-61b3-11e7-8e78-2d7956579740.png">

Supersedes #13337.

~~Depends on #13339, #13353.~~