### PR TITLE
Improve Armament overridability

### DIFF
--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -238,25 +238,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			FireBarrel(self, facing, target, barrel);
 
-			if (--Burst > 0)
-				FireDelay = Weapon.BurstDelay;
-			else
-			{
-				var modifiers = reloadModifiers.ToArray();
-				FireDelay = Util.ApplyPercentageModifiers(Weapon.ReloadDelay, modifiers);
-				Burst = Weapon.Burst;
-
-				if (Weapon.AfterFireSound != null && Weapon.AfterFireSound.Any())
-				{
-					ScheduleDelayedAction(Weapon.AfterFireSoundDelay, () =>
-					{
-						Game.Sound.Play(SoundType.World, Weapon.AfterFireSound.Random(self.World.SharedRandom), self.CenterPosition);
-					});
-				}
-
-				foreach (var nbc in notifyBurstComplete)
-					nbc.FiredBurst(self, target, this);
-			}
+			UpdateBurst(self, target);
 
 			return barrel;
 		}
@@ -324,6 +306,29 @@ namespace OpenRA.Mods.Common.Traits
 					Recoil = Info.Recoil;
 				}
 			});
+		}
+
+		protected virtual void UpdateBurst(Actor self, Target target)
+		{
+			if (--Burst > 0)
+				FireDelay = Weapon.BurstDelay;
+			else
+			{
+				var modifiers = reloadModifiers.ToArray();
+				FireDelay = Util.ApplyPercentageModifiers(Weapon.ReloadDelay, modifiers);
+				Burst = Weapon.Burst;
+
+				if (Weapon.AfterFireSound != null && Weapon.AfterFireSound.Any())
+				{
+					ScheduleDelayedAction(Weapon.AfterFireSoundDelay, () =>
+					{
+						Game.Sound.Play(SoundType.World, Weapon.AfterFireSound.Random(self.World.SharedRandom), self.CenterPosition);
+					});
+				}
+
+				foreach (var nbc in notifyBurstComplete)
+					nbc.FiredBurst(self, target, this);
+			}
 		}
 
 		public virtual bool OutOfAmmo { get { return ammoPool != null && !ammoPool.Info.SelfReloads && !ammoPool.HasAmmo(); } }

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -206,19 +206,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected virtual bool CanFire(Actor self, Target target)
 		{
-			if (IsReloading)
-				return false;
-
-			if (ammoPool != null && !ammoPool.HasAmmo())
+			if (IsReloading || (ammoPool != null && !ammoPool.HasAmmo()))
 				return false;
 
 			if (turret != null && !turret.HasAchievedDesiredFacing)
 				return false;
 
-			if (!target.IsInRange(self.CenterPosition, MaxRange()))
-				return false;
-
-			if (Weapon.MinRange != WDist.Zero && target.IsInRange(self.CenterPosition, Weapon.MinRange))
+			if ((!target.IsInRange(self.CenterPosition, MaxRange()))
+				|| (Weapon.MinRange != WDist.Zero && target.IsInRange(self.CenterPosition, Weapon.MinRange)))
 				return false;
 
 			if (!Weapon.IsValidAgainst(target, self.World, self))

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -204,26 +204,34 @@ namespace OpenRA.Mods.Common.Traits
 				a();
 		}
 
+		protected virtual bool CanFire(Actor self, Target target)
+		{
+			if (IsReloading)
+				return false;
+
+			if (ammoPool != null && !ammoPool.HasAmmo())
+				return false;
+
+			if (turret != null && !turret.HasAchievedDesiredFacing)
+				return false;
+
+			if (!target.IsInRange(self.CenterPosition, MaxRange()))
+				return false;
+
+			if (Weapon.MinRange != WDist.Zero && target.IsInRange(self.CenterPosition, Weapon.MinRange))
+				return false;
+
+			if (!Weapon.IsValidAgainst(target, self.World, self))
+				return false;
+
+			return true;
+		}
+
 		// Note: facing is only used by the legacy positioning code
 		// The world coordinate model uses Actor.Orientation
 		public virtual Barrel CheckFire(Actor self, IFacing facing, Target target)
 		{
-			if (IsReloading)
-				return null;
-
-			if (ammoPool != null && !ammoPool.HasAmmo())
-				return null;
-
-			if (turret != null && !turret.HasAchievedDesiredFacing)
-				return null;
-
-			if (!target.IsInRange(self.CenterPosition, MaxRange()))
-				return null;
-
-			if (Weapon.MinRange != WDist.Zero && target.IsInRange(self.CenterPosition, Weapon.MinRange))
-				return null;
-
-			if (!Weapon.IsValidAgainst(target, self.World, self))
+			if (!CanFire(self, target))
 				return null;
 
 			if (ticksSinceLastShot >= Weapon.ReloadDelay)

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -336,7 +336,12 @@ namespace OpenRA.Mods.Common.Traits
 		public virtual bool AllowExplode { get { return !IsReloading; } }
 		bool IExplodeModifier.ShouldExplode(Actor self) { return AllowExplode; }
 
-		public virtual WVec MuzzleOffset(Actor self, Barrel b)
+		public WVec MuzzleOffset(Actor self, Barrel b)
+		{
+			return CalculateMuzzleOffset(self, b);
+		}
+
+		protected virtual WVec CalculateMuzzleOffset(Actor self, Barrel b)
 		{
 			var bodyOrientation = coords.QuantizeOrientation(self, self.Orientation);
 			var localOffset = b.Offset + new WVec(-Recoil, WDist.Zero, WDist.Zero);
@@ -353,7 +358,12 @@ namespace OpenRA.Mods.Common.Traits
 			return coords.LocalToWorld(localOffset.Rotate(bodyOrientation));
 		}
 
-		public virtual WRot MuzzleOrientation(Actor self, Barrel b)
+		public WRot MuzzleOrientation(Actor self, Barrel b)
+		{
+			return CalculateMuzzleOrientation(self, b);
+		}
+
+		protected virtual WRot CalculateMuzzleOrientation(Actor self, Barrel b)
 		{
 			var orientation = turret != null ? turret.WorldOrientation(self) :
 				coords.QuantizeOrientation(self, self.Orientation);


### PR DESCRIPTION
The `CheckFire` barrel part is quite monolithic, anyone wanting to modify it in a trait that inherits `Armament` risks overlooking/breaking something unless the whole thing is copy-pasted and then modified, which has the downside of potentially missing upstream changes.

This PR tries to ease the situation by splitting the "can fire" check at the beginning, the actual "fire barrel" logic in the middle and the "update Burst" part at the end into separate, overridable methods, so each part  of the code can be overridden or replaced more easily and independently from the rest.

Reviewing commit by commit is recommended.