### PR TITLE
Eliminated LengthSquared > 0 for slight performance

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -841,7 +841,7 @@ namespace OpenRA
 		public int FacingBetween(CPos cell, CPos towards, int fallbackfacing)
 		{
 			var delta = CenterOfCell(towards) - CenterOfCell(cell);
-			if (delta.HorizontalLengthSquared == 0)
+			if (!delta.HasNonZeroHorizontalLength)
 				return fallbackfacing;
 
 			return delta.Yaw.Facing;

--- a/OpenRA.Game/WVec.cs
+++ b/OpenRA.Game/WVec.cs
@@ -39,6 +39,7 @@ namespace OpenRA
 		public static int Dot(WVec a, WVec b) { return a.X * b.X + a.Y * b.Y + a.Z * b.Z; }
 		public long LengthSquared { get { return (long)X * X + (long)Y * Y + (long)Z * Z; } }
 		public int Length { get { return (int)Exts.ISqrt(LengthSquared); } }
+		public bool HasNonZeroHorizontalLength { get { return X != 0 || Y != 0; } }
 		public long HorizontalLengthSquared { get { return (long)X * X + (long)Y * Y; } }
 		public int HorizontalLength { get { return (int)Exts.ISqrt(HorizontalLengthSquared); } }
 		public long VerticalLengthSquared { get { return (long)Z * Z; } }
@@ -65,7 +66,7 @@ namespace OpenRA
 		{
 			get
 			{
-				if (LengthSquared == 0)
+				if (this == WVec.Zero)
 					return WAngle.Zero;
 
 				// OpenRA defines north as -y

--- a/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Activities
 			var dist = target.CenterPosition - self.CenterPosition;
 
 			// Can rotate facing while ascending
-			var desiredFacing = dist.HorizontalLengthSquared != 0 ? dist.Yaw.Facing : helicopter.Facing;
+			var desiredFacing = dist.HasNonZeroHorizontalLength ? dist.Yaw.Facing : helicopter.Facing;
 			helicopter.Facing = Util.TickFacing(helicopter.Facing, desiredFacing, helicopter.TurnSpeed);
 
 			if (HeliFly.AdjustAltitude(self, helicopter, helicopter.Info.CruiseAltitude))

--- a/OpenRA.Mods.Common/Activities/Air/HeliFly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliFly.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Rotate towards the target
 			var dist = pos - self.CenterPosition;
-			var desiredFacing = dist.HorizontalLengthSquared != 0 ? dist.Yaw.Facing : helicopter.Facing;
+			var desiredFacing = dist.HasNonZeroHorizontalLength ? dist.Yaw.Facing : helicopter.Facing;
 			helicopter.Facing = Util.TickFacing(helicopter.Facing, desiredFacing, helicopter.TurnSpeed);
 			var move = helicopter.FlyStep(desiredFacing);
 

--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -110,11 +110,11 @@ namespace OpenRA.Mods.Common.Activities
 
 					var localOffset = carryall.CarryableOffset.Rotate(body.QuantizeOrientation(self, self.Orientation));
 					var carryablePosition = self.CenterPosition + body.LocalToWorld(localOffset);
-					if ((carryablePosition - targetPosition).HorizontalLengthSquared != 0)
+					if ((carryablePosition - targetPosition).HasNonZeroHorizontalLength)
 					{
 						// For non-zero offsets the drop position depends on the carryall facing
 						// We therefore need to predict/correct for the facing *at the drop point*
-						if (carryall.CarryableOffset.HorizontalLengthSquared != 0)
+						if (carryall.CarryableOffset.HasNonZeroHorizontalLength)
 						{
 							var facing = (targetPosition - self.CenterPosition).Yaw.Facing;
 							localOffset = carryall.CarryableOffset.Rotate(body.QuantizeOrientation(self, WRot.FromFacing(facing)));

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Activities
 					// Line up with the attachment point
 					var localOffset = carryall.OffsetForCarryable(self, cargo).Rotate(carryableBody.QuantizeOrientation(self, cargo.Orientation));
 					var targetPosition = cargo.CenterPosition - carryableBody.LocalToWorld(localOffset);
-					if ((self.CenterPosition - targetPosition).HorizontalLengthSquared != 0)
+					if ((self.CenterPosition - targetPosition).HasNonZeroHorizontalLength)
 					{
 						// Run the first tick of the move activity immediately to avoid a one-frame pause
 						innerActivity = ActivityUtils.RunActivity(self, new HeliFly(self, Target.FromPos(targetPosition)));
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Common.Activities
 				{
 					var localOffset = carryall.OffsetForCarryable(self, cargo).Rotate(carryableBody.QuantizeOrientation(self, cargo.Orientation));
 					var targetPosition = cargo.CenterPosition - carryableBody.LocalToWorld(localOffset);
-					if ((self.CenterPosition - targetPosition).HorizontalLengthSquared != 0 || carryallFacing.Facing != carryableFacing.Facing)
+					if ((self.CenterPosition - targetPosition).HasNonZeroHorizontalLength || carryallFacing.Facing != carryableFacing.Facing)
 					{
 						state = PickupState.MoveToCarryable;
 						return this;

--- a/OpenRA.Mods.Common/Activities/Repair.cs
+++ b/OpenRA.Mods.Common/Activities/Repair.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (host.Type == TargetType.Invalid || health == null)
 				return NextActivity;
 
-			if (closeEnough.Length != 0 && !host.IsInRange(self.CenterPosition, closeEnough))
+			if (closeEnough != WDist.Zero && !host.IsInRange(self.CenterPosition, closeEnough))
 				return NextActivity;
 
 			if (health.DamageState == DamageState.Undamaged)

--- a/OpenRA.Mods.Common/Activities/Repair.cs
+++ b/OpenRA.Mods.Common/Activities/Repair.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (host.Type == TargetType.Invalid || health == null)
 				return NextActivity;
 
-			if (closeEnough.LengthSquared > 0 && !host.IsInRange(self.CenterPosition, closeEnough))
+			if (closeEnough.Length != 0 && !host.IsInRange(self.CenterPosition, closeEnough))
 				return NextActivity;
 
 			if (health.DamageState == DamageState.Undamaged)

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -573,7 +573,7 @@ namespace OpenRA.Mods.Common.Projectiles
 				{
 					// Aim for the target
 					var vDist = new WVec(-relTarHgt, -relTarHorDist, 0);
-					desiredVFacing = (sbyte)vDist.HorizontalLengthSquared != 0 ? vDist.Yaw.Facing : vFacing;
+					desiredVFacing = (sbyte)(vDist.HasNonZeroHorizontalLength ? vDist.Yaw.Facing : vFacing);
 
 					// Do not accept -1  as valid vertical facing since it is usually a numerical error
 					// and will lead to premature descent and crashing into the ground
@@ -666,7 +666,7 @@ namespace OpenRA.Mods.Common.Projectiles
 							{
 								// Aim for the target
 								var vDist = new WVec(-relTarHgt, -relTarHorDist, 0);
-								desiredVFacing = (sbyte)vDist.HorizontalLengthSquared != 0 ? vDist.Yaw.Facing : vFacing;
+								desiredVFacing = (sbyte)(vDist.HasNonZeroHorizontalLength ? vDist.Yaw.Facing : vFacing);
 								if (desiredVFacing < 0 && info.VerticalRateOfTurn < (sbyte)vFacing)
 									desiredVFacing = 0;
 							}
@@ -676,7 +676,7 @@ namespace OpenRA.Mods.Common.Projectiles
 					{
 						// Aim for the target
 						var vDist = new WVec(-relTarHgt, relTarHorDist, 0);
-						desiredVFacing = (sbyte)vDist.HorizontalLengthSquared != 0 ? vDist.Yaw.Facing : vFacing;
+						desiredVFacing = (sbyte)(vDist.HasNonZeroHorizontalLength ? vDist.Yaw.Facing : vFacing);
 						if (desiredVFacing < 0 && info.VerticalRateOfTurn < (sbyte)vFacing)
 							desiredVFacing = 0;
 					}
@@ -686,7 +686,7 @@ namespace OpenRA.Mods.Common.Projectiles
 					// Aim to attain cruise altitude as soon as possible while having the absolute value
 					// of vertical facing bound by the maximum vertical rate of turn
 					var vDist = new WVec(-diffClfMslHgt - info.CruiseAltitude.Length, -speed, 0);
-					desiredVFacing = (sbyte)vDist.HorizontalLengthSquared != 0 ? vDist.Yaw.Facing : vFacing;
+					desiredVFacing = (sbyte)(vDist.HasNonZeroHorizontalLength ? vDist.Yaw.Facing : vFacing);
 
 					// If the missile is launched above CruiseAltitude, it has to descend instead of climbing
 					if (-diffClfMslHgt > info.CruiseAltitude.Length)
@@ -702,7 +702,7 @@ namespace OpenRA.Mods.Common.Projectiles
 				// Aim to attain cruise altitude as soon as possible while having the absolute value
 				// of vertical facing bound by the maximum vertical rate of turn
 				var vDist = new WVec(-diffClfMslHgt - info.CruiseAltitude.Length, -speed, 0);
-				desiredVFacing = (sbyte)vDist.HorizontalLengthSquared != 0 ? vDist.Yaw.Facing : vFacing;
+				desiredVFacing = (sbyte)(vDist.HasNonZeroHorizontalLength ? vDist.Yaw.Facing : vFacing);
 
 				// If the missile is launched above CruiseAltitude, it has to descend instead of climbing
 				if (-diffClfMslHgt > info.CruiseAltitude.Length)
@@ -732,7 +732,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			// Compute which direction the projectile should be facing
 			var velVec = tarDistVec + predVel;
-			var desiredHFacing = velVec.HorizontalLengthSquared != 0 ? velVec.Yaw.Facing : hFacing;
+			var desiredHFacing = velVec.HasNonZeroHorizontalLength ? velVec.Yaw.Facing : hFacing;
 
 			var delta = Util.NormalizeFacing(hFacing - desiredHFacing);
 			if (allowPassBy && delta > 64 && delta < 192)
@@ -803,9 +803,9 @@ namespace OpenRA.Mods.Common.Projectiles
 					+ new WVec(WDist.Zero, WDist.Zero, info.AirburstAltitude);
 
 			// Compute target's predicted velocity vector (assuming uniform circular motion)
-			var yaw1 = tarVel.HorizontalLengthSquared != 0 ? tarVel.Yaw : WAngle.FromFacing(hFacing);
+			var yaw1 = tarVel.HasNonZeroHorizontalLength ? tarVel.Yaw : WAngle.FromFacing(hFacing);
 			tarVel = newTarPos - targetPosition;
-			var yaw2 = tarVel.HorizontalLengthSquared != 0 ? tarVel.Yaw : WAngle.FromFacing(hFacing);
+			var yaw2 = tarVel.HasNonZeroHorizontalLength ? tarVel.Yaw : WAngle.FromFacing(hFacing);
 			predVel = tarVel.Rotate(WRot.FromYaw(yaw2 - yaw1));
 			targetPosition = newTarPos;
 

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -210,8 +210,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			var oldCachedPosition = cachedPosition;
 			cachedPosition = self.CenterPosition;
-			isMoving = (oldCachedPosition - cachedPosition).HorizontalLengthSquared != 0;
-			isMovingVertically = (oldCachedPosition - cachedPosition).VerticalLengthSquared != 0;
+			isMoving = (oldCachedPosition - cachedPosition).HasNonZeroHorizontalLength;
+			isMovingVertically = (oldCachedPosition - cachedPosition).Z != 0;
 
 			Repulse();
 		}
@@ -219,7 +219,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void Repulse()
 		{
 			var repulsionForce = GetRepulsionForce();
-			if (repulsionForce.HorizontalLengthSquared == 0)
+			if (!repulsionForce.HasNonZeroHorizontalLength)
 				return;
 
 			var speed = Info.RepulsionSpeed != -1 ? Info.RepulsionSpeed : MovementSpeed;

--- a/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var f = facing.Facing;
 			var delta = target.CenterPosition - self.CenterPosition;
-			var facingToTarget = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : f;
+			var facingToTarget = delta.HasNonZeroHorizontalLength ? delta.Yaw.Facing : f;
 			facingTarget = Math.Abs(facingToTarget - f) % 256 <= info.FacingTolerance;
 
 			// Bombs drop anywhere in range

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 			var pos = self.CenterPosition;
 			var targetedPosition = GetTargetPosition(pos, target);
 			var delta = targetedPosition - pos;
-			var facingToTarget = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : f;
+			var facingToTarget = delta.HasNonZeroHorizontalLength ? delta.Yaw.Facing : f;
 
 			if (Math.Abs(facingToTarget - f) % 256 > info.FacingTolerance)
 				return false;

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -958,7 +958,7 @@ namespace OpenRA.Mods.Common.Traits
 			var length = speed > 0 ? (toPos - fromPos).Length / speed : 0;
 
 			var delta = toPos - fromPos;
-			var facing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : Facing;
+			var facing = delta.HasNonZeroHorizontalLength ? delta.Yaw.Facing : Facing;
 			return ActivityUtils.SequenceActivities(new Turn(self, facing), new Drag(self, fromPos, toPos, length));
 		}
 

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (exitinfo.Facing < 0)
 				{
 					var delta = to - spawn;
-					if (delta.HorizontalLengthSquared == 0)
+					if (!delta.HasNonZeroHorizontalLength)
 					{
 						var fi = producee.TraitInfoOrDefault<IFacingInfo>();
 						initialFacing = fi != null ? fi.GetInitialFacing() : 0;

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -141,7 +141,7 @@ namespace OpenRA.Mods.Common.Traits
 			var pos = self.CenterPosition;
 			var targetPos = attack != null ? attack.GetTargetPosition(pos, target) : target.CenterPosition;
 			var delta = targetPos - pos;
-			DesiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : TurretFacing;
+			DesiredFacing = delta.HasNonZeroHorizontalLength ? delta.Yaw.Facing : TurretFacing;
 			MoveTurret();
 			return HasAchievedDesiredFacing;
 		}


### PR DESCRIPTION
It is common in current bleed that LengthSquared is compared with 0. In this case, it is faster to check if all elements are 0 than to perform sum of squared then compare with zero.