### PR TITLE
Add uninterruptability support to sprite turret anims and fix trait namings

### DIFF
--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Traits\Attack\AttackPopupTurreted.cs" />
     <Compile Include="Traits\Buildings\ProductionAirdrop.cs" />
     <Compile Include="Traits\Render\WithGunboatBody.cs" />
+    <Compile Include="Traits\Render\WithEmbeddedTurretSpriteBody.cs" />
     <Compile Include="Traits\Render\WithCargo.cs" />
     <Compile Include="Traits\Render\WithDeliveryAnimation.cs" />
     <Compile Include="Traits\Render\WithReloadingSpriteTurret.cs" />

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackPopupTurreted.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Linq;
+using OpenRA.Mods.Cnc.Traits.Render;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
@@ -17,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Actor's turret rises from the ground before attacking.")]
-	class AttackPopupTurretedInfo : AttackTurretedInfo, Requires<BuildingInfo>, Requires<WithTurretedSpriteBodyInfo>
+	class AttackPopupTurretedInfo : AttackTurretedInfo, Requires<BuildingInfo>, Requires<WithEmbeddedTurretSpriteBodyInfo>
 	{
 		[Desc("How many game ticks should pass before closing the actor's turret.")]
 		public int CloseDelay = 125;

--- a/OpenRA.Mods.Cnc/Traits/Render/WithEmbeddedTurretSpriteBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithEmbeddedTurretSpriteBody.cs
@@ -14,14 +14,16 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.Common.Traits.Render
+namespace OpenRA.Mods.Cnc.Traits.Render
 {
 	[Desc("This actor has turret art with facings baked into the sprite.")]
-	public class WithTurretedSpriteBodyInfo : WithSpriteBodyInfo, Requires<TurretedInfo>, Requires<BodyOrientationInfo>
+	public class WithEmbeddedTurretSpriteBodyInfo : WithSpriteBodyInfo, Requires<TurretedInfo>, Requires<BodyOrientationInfo>
 	{
-		public override object Create(ActorInitializer init) { return new WithTurretedSpriteBody(init, this); }
+		public override object Create(ActorInitializer init) { return new WithEmbeddedTurretSpriteBody(init, this); }
 
 		public override IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{
@@ -36,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	public class WithTurretedSpriteBody : WithSpriteBody
+	public class WithEmbeddedTurretSpriteBody : WithSpriteBody
 	{
 		readonly Turreted turreted;
 
@@ -47,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return () => turreted.TurretFacing;
 		}
 
-		public WithTurretedSpriteBody(ActorInitializer init, WithSpriteBodyInfo info)
+		public WithEmbeddedTurretSpriteBody(ActorInitializer init, WithSpriteBodyInfo info)
 			: base(init, info, MakeTurretFacingFunc(init.Self))
 		{
 			turreted = init.Self.TraitsImplementing<Turreted>().FirstOrDefault();

--- a/OpenRA.Mods.Cnc/Traits/Render/WithReloadingSpriteTurret.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithReloadingSpriteTurret.cs
@@ -59,6 +59,9 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 
 		protected override void Tick(Actor self)
 		{
+			if (UninterruptibleAnimationPlaying)
+				return;
+
 			if (Info.AimSequence != null)
 				sequence = Attack.IsAttacking ? Info.AimSequence : Info.Sequence;
 

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -413,7 +413,6 @@
     <Compile Include="Traits\Render\LeavesTrails.cs" />
     <Compile Include="Traits\Render\RenderSpritesEditorOnly.cs" />
     <Compile Include="Traits\Render\WithTurretAttackAnimation.cs" />
-    <Compile Include="Traits\Render\WithTurretedSpriteBody.cs" />
     <Compile Include="Traits\Render\RenderUtils.cs" />
     <Compile Include="Traits\Render\RenderDebugState.cs" />
     <Compile Include="Traits\Render\RenderNameTag.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -412,7 +412,7 @@
     <Compile Include="Traits\Render\Hovers.cs" />
     <Compile Include="Traits\Render\LeavesTrails.cs" />
     <Compile Include="Traits\Render\RenderSpritesEditorOnly.cs" />
-    <Compile Include="Traits\Render\WithTurretedAttackAnimation.cs" />
+    <Compile Include="Traits\Render\WithTurretAttackAnimation.cs" />
     <Compile Include="Traits\Render\WithTurretedSpriteBody.cs" />
     <Compile Include="Traits\Render\RenderUtils.cs" />
     <Compile Include="Traits\Render\RenderDebugState.cs" />

--- a/OpenRA.Mods.Common/Traits/Render/WithTurretAttackAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurretAttackAnimation.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
 {
-	public class WithTurretedAttackAnimationInfo : ITraitInfo, Requires<WithSpriteTurretInfo>, Requires<ArmamentInfo>, Requires<AttackBaseInfo>
+	public class WithTurretAttackAnimationInfo : ITraitInfo, Requires<WithSpriteTurretInfo>, Requires<ArmamentInfo>, Requires<AttackBaseInfo>
 	{
 		[Desc("Armament name")]
 		public readonly string Armament = "primary";
@@ -40,19 +40,19 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Whether the animation can be interrupted/overridden by other animations.")]
 		public readonly bool IsInterruptible = false;
 
-		public object Create(ActorInitializer init) { return new WithTurretedAttackAnimation(init, this); }
+		public object Create(ActorInitializer init) { return new WithTurretAttackAnimation(init, this); }
 	}
 
-	public class WithTurretedAttackAnimation : ITick, INotifyAttack
+	public class WithTurretAttackAnimation : ITick, INotifyAttack
 	{
-		readonly WithTurretedAttackAnimationInfo info;
+		readonly WithTurretAttackAnimationInfo info;
 		readonly AttackBase attack;
 		readonly Armament armament;
 		readonly WithSpriteTurret wst;
 
 		int tick;
 
-		public WithTurretedAttackAnimation(ActorInitializer init, WithTurretedAttackAnimationInfo info)
+		public WithTurretAttackAnimation(ActorInitializer init, WithTurretAttackAnimationInfo info)
 		{
 			this.info = info;
 			attack = init.Self.Trait<AttackBase>();

--- a/OpenRA.Mods.Common/Traits/Render/WithTurretedAttackAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurretedAttackAnimation.cs
@@ -37,6 +37,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Should the animation be delayed relative to preparation or actual attack?")]
 		public readonly AttackDelayType DelayRelativeTo = AttackDelayType.Preparation;
 
+		[Desc("Whether the animation can be interrupted/overridden by other animations.")]
+		public readonly bool IsInterruptible = false;
+
 		public object Create(ActorInitializer init) { return new WithTurretedAttackAnimation(init, this); }
 	}
 
@@ -62,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		void PlayAttackAnimation(Actor self)
 		{
 			if (!string.IsNullOrEmpty(info.AttackSequence))
-				wst.PlayCustomAnimation(self, info.AttackSequence, () => wst.CancelCustomAnimation(self));
+				wst.PlayCustomAnimation(self, info.AttackSequence, () => wst.CancelCustomAnimation(self), !info.IsInterruptible);
 		}
 
 		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel)

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -953,6 +953,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 20170711)
+					if (node.Key.StartsWith("WithTurretedAttackAnimation", StringComparison.Ordinal))
+						RenameNodeKey(node, "WithTurretAttackAnimation");
+
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -954,8 +954,12 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				}
 
 				if (engineVersion < 20170711)
+				{
 					if (node.Key.StartsWith("WithTurretedAttackAnimation", StringComparison.Ordinal))
 						RenameNodeKey(node, "WithTurretAttackAnimation");
+					if (node.Key.StartsWith("WithTurretedSpriteBody", StringComparison.Ordinal))
+						RenameNodeKey(node, "WithEmbeddedTurretSpriteBody");
+				}
 
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -756,7 +756,7 @@ GUN:
 		TurnSpeed: 12
 		InitialFacing: 56
 	-WithSpriteBody:
-	WithTurretedSpriteBody:
+	WithEmbeddedTurretSpriteBody:
 	Armament:
 		Weapon: TurretGun
 		LocalOffset: 512,0,112
@@ -806,7 +806,7 @@ SAM:
 		InitialFacing: 0
 		RealignDelay: -1
 	-WithSpriteBody:
-	WithTurretedSpriteBody:
+	WithEmbeddedTurretSpriteBody:
 	AutoSelectionSize:
 	Armament:
 		Weapon: Dragon

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -546,7 +546,7 @@ AGUN:
 		TurnSpeed: 15
 		InitialFacing: 224
 	-WithSpriteBody:
-	WithTurretedSpriteBody:
+	WithEmbeddedTurretSpriteBody:
 	Armament:
 		Weapon: ZSU-23
 		LocalOffset: 520,100,450, 520,-150,450
@@ -749,7 +749,7 @@ GUN:
 		TurnSpeed: 12
 		InitialFacing: 56
 	-WithSpriteBody:
-	WithTurretedSpriteBody:
+	WithEmbeddedTurretSpriteBody:
 	Armament:
 		Weapon: TurretGun
 		LocalOffset: 512,0,112
@@ -846,7 +846,7 @@ SAM:
 		TurnSpeed: 30
 		InitialFacing: 0
 	-WithSpriteBody:
-	WithTurretedSpriteBody:
+	WithEmbeddedTurretSpriteBody:
 	Armament:
 		Weapon: Nike
 		LocalOffset: 0,0,320


### PR DESCRIPTION
The goal of this PR is to make the addition of more turret animation traits less of a hassle.

- All animations being overridable by other anims would easily cause issues once more animation types are added (turret move anim, turret charge etc.), so I added support for making them uninterruptible.
- With*Turreted*AttackAnimation could easily be misinterpreted by modders to modify 'With*Turreted*SpriteBody', which is wrong, so I gave the latter a less ambigous name. 
- 'Turret*ed*' was also not in line with our implicit render trait naming convention (affects both traits mentioned), so I adressed that as well.
- Moved the renamed `WithEmbeddedTurretSpriteBody` to Mods.Cnc, since only gun turrets, sam sites and flak cannon in TD/RA use it in our official mods.