### PR TITLE
Audio device names is now shown correctly in the Audio Device combolist.

### DIFF
--- a/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
+++ b/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Platforms.Default
 				}
 
 				// A null indicates termination of that string, so add that to our list.
-				devices.Add(Encoding.Default.GetString(buffer.ToArray()));
+				devices.Add(Encoding.UTF8.GetString(buffer.ToArray()));
 				buffer.Clear();
 
 				// Two successive nulls indicates the end of the list.


### PR DESCRIPTION
Ignored DA version of resource dll.