### PR TITLE
Allow turning Missile terrain height checks off

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -61,6 +61,9 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Is the missile blocked by actors with BlocksProjectiles: trait.")]
 		public readonly bool Blockable = true;
 
+		[Desc("Is the missile aware of terrain height levels. Only needed for mods with real, non-visual height levels.")]
+		public readonly bool TerrainHeightAware = false;
+
 		[Desc("Width of projectile (used for finding blocking actors).")]
 		public readonly WDist Width = new WDist(1);
 
@@ -317,14 +320,19 @@ namespace OpenRA.Mods.Common.Projectiles
 			var tarDistVec = targetPosition + offset - pos;
 			var relTarHorDist = tarDistVec.HorizontalLength;
 
-			int predClfHgt, predClfDist, lastHtChg, lastHt;
-			InclineLookahead(world, relTarHorDist, out predClfHgt, out predClfDist, out lastHtChg, out lastHt);
+			int predClfHgt = 0;
+			int predClfDist = 0;
+			int lastHtChg = 0;
+			int lastHt = 0;
+
+			if (info.TerrainHeightAware)
+				InclineLookahead(world, relTarHorDist, out predClfHgt, out predClfDist, out lastHtChg, out lastHt);
 
 			// Height difference between the incline height and missile height
 			var diffClfMslHgt = predClfHgt - pos.Z;
 
 			// Incline coming up
-			if (diffClfMslHgt >= 0 && predClfDist > 0)
+			if (info.TerrainHeightAware && diffClfMslHgt >= 0 && predClfDist > 0)
 				DetermineLaunchSpeedAndAngleForIncline(predClfDist, diffClfMslHgt, relTarHorDist, out speed, out vFacing);
 			else if (lastHt != 0)
 			{
@@ -559,7 +567,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			// the missile hasn't been fired near a cliff) is simply finding the smallest
 			// vertical facing that allows for a smooth climb to the new terrain's height
 			// and coming in at predClfDist at exactly zero vertical facing
-			if (diffClfMslHgt >= 0 && !allowPassBy)
+			if (info.TerrainHeightAware && diffClfMslHgt >= 0 && !allowPassBy)
 				desiredVFacing = IncreaseAltitude(predClfDist, diffClfMslHgt, relTarHorDist, vFacing);
 			else if (relTarHorDist <= 3 * loopRadius || state == States.Hitting)
 			{
@@ -645,7 +653,7 @@ namespace OpenRA.Mods.Common.Projectiles
 						else
 						{
 							// Avoid the cliff edge
-							if (edgeVector.Length > loopRadius && lastHt > targetPosition.Z)
+							if (info.TerrainHeightAware && edgeVector.Length > loopRadius && lastHt > targetPosition.Z)
 							{
 								int vFac;
 								for (vFac = vFacing + 1; vFac <= vFacing + info.VerticalRateOfTurn - 1; vFac++)
@@ -718,8 +726,13 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		WVec HomingTick(World world, WVec tarDistVec, int relTarHorDist)
 		{
-			int predClfHgt, predClfDist, lastHtChg, lastHt;
-			InclineLookahead(world, relTarHorDist, out predClfHgt, out predClfDist, out lastHtChg, out lastHt);
+			int predClfHgt = 0;
+			int predClfDist = 0;
+			int lastHtChg = 0;
+			int lastHt = 0;
+
+			if (info.TerrainHeightAware)
+				InclineLookahead(world, relTarHorDist, out predClfHgt, out predClfDist, out lastHtChg, out lastHt);
 
 			// Height difference between the incline height and missile height
 			var diffClfMslHgt = predClfHgt - pos.Z;

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -972,6 +972,18 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// Made Missile terrain height checks disableable and disabled by default
+				if (engineVersion < 20170713)
+				{
+					var gridMaxHeight = modData.Manifest.Get<MapGrid>().MaximumTerrainHeight;
+					if (gridMaxHeight > 0)
+					{
+						var projectile = node.Value.Nodes.FirstOrDefault(n => n.Key == "Projectile");
+						if (projectile != null && projectile.Value.Value == "Missile")
+							projectile.Value.Nodes.Add(new MiniYamlNode("TerrainHeightAware", "true"));
+					}
+				}
+
 				UpgradeWeaponRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -129,6 +129,7 @@ CyCannon:
 		MinimumLaunchSpeed: 75
 		Speed: 384
 		RangeLimit: 8c0
+		TerrainHeightAware: true
 	Warhead@1Dam: SpreadDamage
 		Spread: 43
 		Damage: 120

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -21,6 +21,7 @@
 		VerticalRateOfTurn: 11
 		CruiseAltitude: 2c124
 		AllowSnapping: true
+		TerrainHeightAware: true
 	Warhead@1Dam: SpreadDamage
 		Spread: 108
 		Falloff: 100, 50, 25, 12, 6, 3, 0

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -15,6 +15,7 @@ MultiCluster:
 		Palette: ra
 		MinimumLaunchSpeed: 75
 		Speed: 384
+		TerrainHeightAware: true
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 65


### PR DESCRIPTION
And do so by default.

At second glance this was easier than expected, by just preventing all height-related helpers from triggering if `!TerrainHeightAware`.
Couldn't spot any regressions so far.

Closes #13616.

Debug builds on my system (Win7x64, i5-2500 @ 3.2GHz) show ~0.015ms savings per Dragon missile in RA.