### PR TITLE
Fix Windows desktop icons being installed for all users.

### DIFF
--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -159,6 +159,7 @@ Section "Game" GAME
 	nsExec::ExecToLog '"$INSTDIR\OpenRA.Utility.exe" cnc --clear-invalid-mod-registrations system'
 	nsExec::ExecToLog '"$INSTDIR\OpenRA.Utility.exe" d2k --register-mod "$INSTDIR\Dune2000.exe" system'
 	nsExec::ExecToLog '"$INSTDIR\OpenRA.Utility.exe" d2k --clear-invalid-mod-registrations system'
+	SetShellVarContext current
 
 SectionEnd
 


### PR DESCRIPTION
Fixes a regression from #12764:

> upon uninstall, it didn't remove the launcher icons from desktop (on Windows).

The `SetShellVarContext` remained set to `all` when writing the desktop icons, which generated them in the "all users" directory.  We then tried to remove them from the local profile on uninstall, which fails because they aren't there.