### PR TITLE
TD Airstrike Balance.

### DIFF
--- a/mods/cnc/weapons/other.yaml
+++ b/mods/cnc/weapons/other.yaml
@@ -78,7 +78,7 @@ Napalm:
 		Damage: 30
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
-			Wood: 65
+			Wood: 35
 			Heavy: 80
 	Warhead@3Eff: CreateEffect
 		Explosions: med_napalm

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -48,7 +48,7 @@ Vulcan:
 		Spread: 426
 		Damage: 100
 		Versus:
-			Wood: 25
+			Wood: 15
 			Light: 100
 			Heavy: 35
 


### PR DESCRIPTION
This has been a tough decision. I have nerfed the napalm damage from 65 to 35 commited by reaperrr since at 65 they were still one shotting weapon factories and airstrips. The problem however was that it still did way to much damage to the airstrip. Sometimes even killing it in one strike. This also affected refineries coming in at certain angles. Bringing the Vulcan down from 25 to 15 wood damage helps to keep it alive a majority of the time. (Still brings it to red at times.) Problem now is the airstrike is now a unit killing role rather then killing power plants and various other structures. (Doesn't exactly kill barracks/helipads everytime anymore.)

Im not exactly sure what to do. The hitboxes has been doing very well with the exception of this one. For the time being the airstrike will play its role as a unit killer rather then its role to kill structures of certain types. I would strongly prefer this then having them one shotting weapon factories/airstrips.

Shortened:

Airstrike Napalm vs wood from 65 to 35.
Airstrike Vulcan vs wood from 25 to 15.