### PR TITLE
Add more RevealDisguiseOn types and unhardcode some events

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/Infiltrate.cs
+++ b/OpenRA.Mods.Cnc/Activities/Infiltrate.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Cnc.Traits;
 using OpenRA.Mods.Common.Activities;
@@ -21,14 +22,14 @@ namespace OpenRA.Mods.Cnc.Activities
 	{
 		readonly Actor target;
 		readonly Infiltrates infiltrates;
-		readonly Cloak cloak;
+		readonly INotifyInfiltration[] notifiers;
 
 		public Infiltrate(Actor self, Actor target, Infiltrates infiltrate)
 			: base(self, target, infiltrate.Info.EnterBehaviour)
 		{
 			this.target = target;
 			infiltrates  = infiltrate;
-			cloak = self.TraitOrDefault<Cloak>();
+			notifiers = self.TraitsImplementing<INotifyInfiltration>().ToArray();
 		}
 
 		protected override void OnInside(Actor self)
@@ -40,8 +41,8 @@ namespace OpenRA.Mods.Cnc.Activities
 			if (!infiltrates.Info.ValidStances.HasStance(stance))
 				return;
 
-			if (cloak != null && cloak.Info.UncloakOn.HasFlag(UncloakType.Infiltrate))
-				cloak.Uncloak();
+			foreach (var ini in notifiers)
+				ini.Infiltrating(self);
 
 			foreach (var t in target.TraitsImplementing<INotifyInfiltrated>())
 				t.Infiltrated(target, self);

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -64,7 +64,10 @@ namespace OpenRA.Mods.Cnc.Traits
 	{
 		None = 0,
 		Attack = 1,
-		Damaged = 2
+		Damaged = 2,
+		Unload = 4,
+		Infiltrate = 8,
+		Demolish = 16
 	}
 
 	[Desc("Provides access to the disguise command, which makes the actor appear to be another player's actor.")]
@@ -76,13 +79,15 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("The condition to grant to self while disguised.")]
 		public readonly string DisguisedCondition = null;
 
-		[Desc("Triggers which cause the actor to drop it's disguise. Possible values: None, Attack, Damaged.")]
+		[Desc("Triggers which cause the actor to drop it's disguise. Possible values: None, Attack, Damaged,",
+			"Unload, Infiltrate, Demolish.")]
 		public readonly RevealDisguiseType RevealDisguiseOn = RevealDisguiseType.Attack;
 
 		public object Create(ActorInitializer init) { return new Disguise(init.Self, this); }
 	}
 
-	class Disguise : INotifyCreated, IEffectiveOwner, IIssueOrder, IResolveOrder, IOrderVoice, IRadarColorModifier, INotifyAttack, INotifyDamage
+	class Disguise : INotifyCreated, IEffectiveOwner, IIssueOrder, IResolveOrder, IOrderVoice, IRadarColorModifier, INotifyAttack,
+		INotifyDamage, INotifyUnload, INotifyDemolition, INotifyInfiltration
 	{
 		public Player AsPlayer { get; private set; }
 		public string AsSprite { get; private set; }
@@ -218,6 +223,24 @@ namespace OpenRA.Mods.Cnc.Traits
 		void INotifyDamage.Damaged(Actor self, AttackInfo e)
 		{
 			if (info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Damaged) && e.Damage.Value > 0)
+				DisguiseAs(null);
+		}
+
+		void INotifyUnload.Unloading(Actor self)
+		{
+			if (info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Unload))
+				DisguiseAs(null);
+		}
+
+		void INotifyDemolition.Demolishing(Actor self)
+		{
+			if (info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Demolish))
+				DisguiseAs(null);
+		}
+
+		void INotifyInfiltration.Infiltrating(Actor self)
+		{
+			if (info.RevealDisguiseOn.HasFlag(RevealDisguiseType.Infiltrate))
 				DisguiseAs(null);
 		}
 	}

--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -23,14 +23,14 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly Actor self;
 		readonly Cargo cargo;
-		readonly Cloak[] cloaks;
+		readonly INotifyUnload[] notifiers;
 		readonly bool unloadAll;
 
 		public UnloadCargo(Actor self, bool unloadAll)
 		{
 			this.self = self;
 			cargo = self.Trait<Cargo>();
-			cloaks = self.TraitsImplementing<Cloak>().ToArray();
+			notifiers = self.TraitsImplementing<INotifyUnload>().ToArray();
 			this.unloadAll = unloadAll;
 		}
 
@@ -60,9 +60,8 @@ namespace OpenRA.Mods.Common.Activities
 			if (IsCanceled || cargo.IsEmpty(self))
 				return NextActivity;
 
-			foreach (var cloak in cloaks)
-				if (cloak.Info.UncloakOn.HasFlag(UncloakType.Unload))
-					cloak.Uncloak();
+			foreach (var inu in notifiers)
+				inu.Unloading(self);
 
 			var actor = cargo.Peek(self);
 			var spawn = self.CenterPosition;

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -237,7 +237,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public class Building : IOccupySpace, ITargetableCells, INotifySold, INotifyTransform, ISync, INotifyCreated,
-		INotifyAddedToWorld, INotifyRemovedFromWorld
+		INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyDemolition
 	{
 		public readonly bool SkipMakeAnimation;
 		public readonly BuildingInfo Info;
@@ -329,6 +329,11 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var notify in self.TraitsImplementing<INotifyBuildComplete>())
 				notify.BuildingComplete(self);
+		}
+
+		void INotifyDemolition.Demolishing(Actor self)
+		{
+			Lock();
 		}
 
 		void INotifySold.Selling(Actor self)

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -62,8 +62,8 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new Cloak(this); }
 	}
 
-	public class Cloak : ConditionalTrait<CloakInfo>, IRenderModifier, INotifyDamage,
-	INotifyAttack, ITick, IVisibilityModifier, IRadarColorModifier, INotifyCreated, INotifyHarvesterAction
+	public class Cloak : ConditionalTrait<CloakInfo>, IRenderModifier, INotifyDamage, INotifyUnload, INotifyDemolition, INotifyInfiltration,
+		INotifyAttack, ITick, IVisibilityModifier, IRadarColorModifier, INotifyCreated, INotifyHarvesterAction
 	{
 		[Sync] int remainingTime;
 		bool isDocking;
@@ -211,6 +211,24 @@ namespace OpenRA.Mods.Common.Traits
 		void INotifyHarvesterAction.Undocked()
 		{
 			isDocking = false;
+		}
+
+		void INotifyUnload.Unloading(Actor self)
+		{
+			if (Info.UncloakOn.HasFlag(UncloakType.Unload))
+				Uncloak();
+		}
+
+		void INotifyDemolition.Demolishing(Actor self)
+		{
+			if (Info.UncloakOn.HasFlag(UncloakType.Demolish))
+				Uncloak();
+		}
+
+		void INotifyInfiltration.Infiltrating(Actor self)
+		{
+			if (Info.UncloakOn.HasFlag(UncloakType.Infiltrate))
+				Uncloak();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -148,6 +148,24 @@ namespace OpenRA.Mods.Common.Traits
 		void Undocked();
 	}
 
+	[RequireExplicitImplementation]
+	public interface INotifyUnload
+	{
+		void Unloading(Actor self);
+	}
+
+	[RequireExplicitImplementation]
+	public interface INotifyDemolition
+	{
+		void Demolishing(Actor self);
+	}
+
+	[RequireExplicitImplementation]
+	public interface INotifyInfiltration
+	{
+		void Infiltrating(Actor self);
+	}
+
 	public interface ITechTreePrerequisiteInfo : ITraitInfo { }
 	public interface ITechTreePrerequisite
 	{


### PR DESCRIPTION
Events means things like `Infiltration`, `Demolition` and `Unloading`. That was hardcoded to only uncloak units before, but now calls an interface which can be easily implemented by custom traits.