### PR TITLE
Targetable positions attack access split

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -376,6 +376,9 @@ namespace OpenRA.Traits
 		IEnumerable<WPos> TargetablePositions(Actor self);
 	}
 
+	public interface IAttackablePositions : ITargetablePositions { }
+	public interface IAccessiblePositions : ITargetablePositions { }
+
 	public interface ILintPass { void Run(Action<string> emitError, Action<string> emitWarning, ModData modData); }
 	public interface ILintMapPass { void Run(Action<string> emitError, Action<string> emitWarning, Map map); }
 	public interface ILintRulesPass { void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules); }

--- a/OpenRA.Mods.Cnc/Projectiles/TeslaZap.cs
+++ b/OpenRA.Mods.Cnc/Projectiles/TeslaZap.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Cnc.Projectiles
 
 			// Zap tracks target
 			if (info.TrackTarget && args.GuidedTarget.IsValidFor(args.SourceActor))
-				target = args.Weapon.TargetActorCenter ? args.GuidedTarget.CenterPosition : args.GuidedTarget.Positions.PositionClosestTo(args.Source);
+				target = args.Weapon.TargetActorCenter ? args.GuidedTarget.CenterPosition : args.GuidedTarget.AttackablePositions.PositionClosestTo(args.Source);
 
 			if (damageDuration-- > 0)
 				args.Weapon.Impact(Target.FromPos(target), args.SourceActor, args.DamageModifiers);

--- a/OpenRA.Mods.Common/Activities/Enter.cs
+++ b/OpenRA.Mods.Common/Activities/Enter.cs
@@ -147,8 +147,8 @@ namespace OpenRA.Mods.Common.Activities
 						if (!TryGetAlternateTarget(self, tries, ref t))
 							return ReserveStatus.TooFar;
 
-						var targetPosition = target.Positions.PositionClosestTo(self.CenterPosition);
-						var alternatePosition = t.Positions.PositionClosestTo(self.CenterPosition);
+						var targetPosition = target.AccessiblePositions.PositionClosestTo(self.CenterPosition);
+						var alternatePosition = t.AccessiblePositions.PositionClosestTo(self.CenterPosition);
 						if ((targetPosition - self.CenterPosition).HorizontalLengthSquared <= (alternatePosition - self.CenterPosition).HorizontalLengthSquared)
 							return ReserveStatus.TooFar;
 						target = t;
@@ -175,7 +175,7 @@ namespace OpenRA.Mods.Common.Activities
 							return EnterState.Done; // No available target -> abort to next activity
 						case ReserveStatus.TooFar:
 						{
-							var moveTarget = repathWhileMoving ? target : Target.FromPos(target.Positions.PositionClosestTo(self.CenterPosition));
+							var moveTarget = repathWhileMoving ? target : Target.FromPos(target.AccessiblePositions.PositionClosestTo(self.CenterPosition));
 							inner = move.MoveToTarget(self, moveTarget); // Approach
 							return EnterState.ApproachingOrEntering;
 						}
@@ -207,7 +207,7 @@ namespace OpenRA.Mods.Common.Activities
 						nextState = EnterState.Inside;
 
 					// Otherwise, try to recover from moving target
-					else if (target.Positions.PositionClosestTo(self.CenterPosition) != self.CenterPosition)
+					else if (target.AccessiblePositions.PositionClosestTo(self.CenterPosition) != self.CenterPosition)
 					{
 						nextState = EnterState.ApproachingOrEntering;
 						Unreserve(self, false);

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -810,6 +810,7 @@
     <Compile Include="Widgets\Logic\ButtonTooltipWithDescHighlightLogic.cs" />
     <Compile Include="Traits\AutoTargetPriority.cs" />
     <Compile Include="Traits\Conditions\GrantConditionOnBotOwner.cs" />
+    <Compile Include="Traits\Entrances.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			if (args.GuidedTarget.IsValidFor(args.SourceActor))
 			{
-				var guidedTargetPos = args.Weapon.TargetActorCenter ? args.GuidedTarget.CenterPosition : args.GuidedTarget.Positions.PositionClosestTo(args.Source);
+				var guidedTargetPos = args.Weapon.TargetActorCenter ? args.GuidedTarget.CenterPosition : args.GuidedTarget.AttackablePositions.PositionClosestTo(args.Source);
 				var targetDistance = new WDist((guidedTargetPos - args.Source).Length);
 
 				// Only continue tracking target if it's within weapon range +

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -128,7 +128,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		{
 			// Beam tracks target
 			if (info.TrackTarget && args.GuidedTarget.IsValidFor(args.SourceActor))
-				target = args.Weapon.TargetActorCenter ? args.GuidedTarget.CenterPosition : args.GuidedTarget.Positions.PositionClosestTo(source);
+				target = args.Weapon.TargetActorCenter ? args.GuidedTarget.CenterPosition : args.GuidedTarget.AttackablePositions.PositionClosestTo(source);
 
 			// Check for blocking actors
 			WPos blockedPos;

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -799,7 +799,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			// Check if target position should be updated (actor visible & locked on)
 			var newTarPos = targetPosition;
 			if (args.GuidedTarget.IsValidFor(args.SourceActor) && lockOn)
-				newTarPos = (args.Weapon.TargetActorCenter ? args.GuidedTarget.CenterPosition : args.GuidedTarget.Positions.PositionClosestTo(args.Source))
+				newTarPos = (args.Weapon.TargetActorCenter ? args.GuidedTarget.CenterPosition : args.GuidedTarget.AttackablePositions.PositionClosestTo(args.Source))
 					+ new WVec(WDist.Zero, WDist.Zero, info.AirburstAltitude);
 
 			// Compute target's predicted velocity vector (assuming uniform circular motion)

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -539,7 +539,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool CanEnterTargetNow(Actor self, Target target)
 		{
-			if (target.Positions.Any(p => self.World.ActorMap.GetActorsAt(self.World.Map.CellContaining(p)).Any(a => a != self && a != target.Actor)))
+			if (target.AttackablePositions.Any(p => self.World.ActorMap.GetActorsAt(self.World.Map.CellContaining(p)).Any(a => a != self && a != target.Actor)))
 				return false;
 
 			MakeReservation(target.Actor);

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -235,7 +235,7 @@ namespace OpenRA.Mods.Common.Traits
 			Func<WPos> muzzlePosition = () => self.CenterPosition + MuzzleOffset(self, barrel);
 			var legacyFacing = MuzzleOrientation(self, barrel).Yaw.Angle / 4;
 
-			var passiveTarget = Weapon.TargetActorCenter ? target.CenterPosition : target.Positions.PositionClosestTo(muzzlePosition());
+			var passiveTarget = Weapon.TargetActorCenter ? target.CenterPosition : target.AttackablePositions.PositionClosestTo(muzzlePosition());
 			var initialOffset = Weapon.FirstBurstTargetOffset;
 			if (initialOffset != WVec.Zero)
 			{

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -219,7 +219,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual WPos GetTargetPosition(WPos pos, Target target)
 		{
-			return HasAnyValidWeapons(target, true) ? target.CenterPosition : target.Positions.PositionClosestTo(pos);
+			return HasAnyValidWeapons(target, true) ? target.CenterPosition : target.AttackablePositions.PositionClosestTo(pos);
 		}
 
 		public WDist GetMinimumRange()

--- a/OpenRA.Mods.Common/Traits/Entrances.cs
+++ b/OpenRA.Mods.Common/Traits/Entrances.cs
@@ -1,0 +1,61 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Entrances passangers, infiltrators, etc..")]
+	public class EntrancesInfo : ConditionalTraitInfo, Requires<BodyOrientationInfo>
+	{
+		[Desc("Create a enterable position for each offset listed here (relative to CenterPosition).")]
+		public readonly WVec[] EntranceOffsets = { WVec.Zero };
+
+		[Desc("Create a enterable position at the center of each occupied cell. Stacks with EntranceOffsets.")]
+		public readonly bool UseOccupiedCellsOffsets = false;
+
+		public override object Create(ActorInitializer init) { return new Entrances(init.Self, this); }
+	}
+
+	public class Entrances : ConditionalTrait<EntrancesInfo>, IAccessiblePositions
+	{
+		BodyOrientation orientation;
+		ITargetableCells targetableCells;
+
+		public Entrances(Actor self, EntrancesInfo info)
+			: base(info) { }
+
+		protected override void Created(Actor self)
+		{
+			orientation = self.Trait<BodyOrientation>();
+			targetableCells = self.TraitOrDefault<ITargetableCells>();
+
+			base.Created(self);
+		}
+
+		public IEnumerable<WPos> TargetablePositions(Actor self)
+		{
+			if (IsTraitDisabled)
+				yield break;
+
+			if (Info.UseOccupiedCellsOffsets && targetableCells != null)
+				foreach (var c in targetableCells.TargetableCells())
+					yield return self.World.Map.CenterOfCell(c.First);
+
+			foreach (var o in Info.EntranceOffsets)
+			{
+				var offset = orientation.LocalToWorld(o.Rotate(orientation.QuantizeOrientation(self, self.Orientation)));
+				yield return self.CenterPosition + offset;
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/HitShape.cs
+++ b/OpenRA.Mods.Common/Traits/HitShape.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new HitShape(init.Self, this); }
 	}
 
-	public class HitShape : ConditionalTrait<HitShapeInfo>, IAttackablePositions, IAccessiblePositions
+	public class HitShape : ConditionalTrait<HitShapeInfo>, IAttackablePositions
 	{
 		BodyOrientation orientation;
 		ITargetableCells targetableCells;

--- a/OpenRA.Mods.Common/Traits/HitShape.cs
+++ b/OpenRA.Mods.Common/Traits/HitShape.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new HitShape(init.Self, this); }
 	}
 
-	public class HitShape : ConditionalTrait<HitShapeInfo>, ITargetablePositions
+	public class HitShape : ConditionalTrait<HitShapeInfo>, IAttackablePositions, IAccessiblePositions
 	{
 		BodyOrientation orientation;
 		ITargetableCells targetableCells;

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -939,7 +939,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (target.Type == TargetType.Invalid)
 				return null;
 
-			return VisualMove(self, self.CenterPosition, target.Positions.PositionClosestTo(self.CenterPosition));
+			return VisualMove(self, self.CenterPosition, target.AccessiblePositions.PositionClosestTo(self.CenterPosition));
 		}
 
 		public bool CanEnterTargetNow(Actor self, Target target)

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -137,7 +137,7 @@ namespace OpenRA.Mods.Common
 
 		public static IEnumerable<CPos> AdjacentCells(World w, Target target)
 		{
-			var cells = target.Positions.Select(p => w.Map.CellContaining(p)).Distinct();
+			var cells = target.AccessiblePositions.Select(p => w.Map.CellContaining(p)).Distinct();
 			return ExpandFootprint(cells, true);
 		}
 

--- a/mods/cnc/rules/civilian-desert.yaml
+++ b/mods/cnc/rules/civilian-desert.yaml
@@ -1,5 +1,8 @@
 V20:
 	Inherits: ^CivBuilding
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: -840,-512,0, 0,0,0, -840,512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: -840,-512,0, 0,0,0, -840,512,0
@@ -28,6 +31,9 @@ V20.Husk:
 
 V21:
 	Inherits: ^CivBuilding
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 840,-512,0, 420,0,0, 840,512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 840,-512,0, 420,0,0, 840,512,0
@@ -100,6 +106,9 @@ V23.Husk:
 
 V24:
 	Inherits: ^CivBuilding
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: -630,-512,0, 0,0,0, -630,256,0, 420,-512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: -630,-512,0, 0,0,0, -630,256,0, 420,-512,0
@@ -128,6 +137,9 @@ V24.Husk:
 
 V25:
 	Inherits: ^CivBuilding
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 0,-128,0, 420,512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,-128,0, 420,512,0
@@ -367,6 +379,9 @@ V36.Husk:
 
 V37:
 	Inherits: ^CivBuilding
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 0,0,0, 0,1024,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 0,1024,0

--- a/mods/cnc/rules/civilian.yaml
+++ b/mods/cnc/rules/civilian.yaml
@@ -1,5 +1,8 @@
 V01:
 	Inherits: ^CivBuilding
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: -490,-384,0, 0,0,0, 0,470,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: -490,-384,0, 0,0,0, 0,470,0
@@ -28,6 +31,9 @@ V01.Husk:
 
 V02:
 	Inherits: ^CivBuilding
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: -490,-512,0, 0,0,0, 0,512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: -490,-512,0, 0,0,0, 0,512,0
@@ -56,6 +62,9 @@ V02.Husk:
 
 V03:
 	Inherits: ^CivBuilding
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: -490,-512,0, 0,0,0, 421,512,0, -210,512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: -490,-512,0, 0,0,0, 421,512,0, -210,512,0
@@ -84,6 +93,9 @@ V03.Husk:
 
 V04:
 	Inherits: ^CivBuilding
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 0,0,0, -421,-256,0, -421,256,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, -421,-256,0, -421,256,0

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -15,6 +15,8 @@
 	RenderSprites:
 
 ^1x1Shape:
+	Entrances:
+		UseOccupiedCellsOffsets: true
 	HitShape:
 		UseTargetableCellsOffsets: true
 		Type: Rectangle
@@ -22,6 +24,8 @@
 			BottomRight: 512, 512
 
 ^2x1Shape:
+	Entrances:
+		UseOccupiedCellsOffsets: true
 	HitShape:
 		UseTargetableCellsOffsets: true
 		Type: Rectangle
@@ -29,6 +33,8 @@
 			BottomRight: 1024, 512
 
 ^2x2Shape:
+	Entrances:
+		UseOccupiedCellsOffsets: true
 	HitShape:
 		UseTargetableCellsOffsets: true
 		Type: Rectangle
@@ -36,6 +42,8 @@
 			BottomRight: 1024, 1024
 
 ^3x2Shape:
+	Entrances:
+		UseOccupiedCellsOffsets: true
 	HitShape:
 		UseTargetableCellsOffsets: true
 		Type: Rectangle

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -96,6 +96,8 @@ FACT.NOD:
 NUKE:
 	Inherits: ^BaseBuilding
 	Inherits@shape: ^2x2Shape
+	Entrances:
+		EntranceOffsets: 630,299,0
 	HitShape:
 		TargetableOffsets: 630,299,0
 	Valued:
@@ -125,6 +127,8 @@ NUKE:
 NUK2:
 	Inherits: ^BaseBuilding
 	Inherits@shape: ^2x2Shape
+	Entrances:
+		EntranceOffsets: 630,299,0
 	HitShape:
 		TargetableOffsets: 630,299,0
 	Valued:
@@ -245,6 +249,9 @@ SILO:
 
 PYLE:
 	Inherits: ^BaseBuilding
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 840,-256,0, 840,512,0, 210,-512,0, -71,512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 840,-256,0, 840,512,0, 210,-512,0, -71,512,0
@@ -295,6 +302,9 @@ PYLE:
 HAND:
 	Inherits: ^BaseBuilding
 	Inherits@shape: ^2x2Shape
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 630,-512,0, 355,512,0, -281,-512,0, -630,512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 630,-512,0, 355,512,0, -281,-512,0, -630,512,0
@@ -341,6 +351,8 @@ HAND:
 
 AFLD:
 	Inherits: ^BaseBuilding
+	Entrances:
+		EntranceOffsets: 0,0,0, 0,-512,256, 0,-1536,256
 	HitShape:
 		TargetableOffsets: 0,0,0, 0,-512,256, 0,-1536,256
 		Type: Rectangle
@@ -390,6 +402,8 @@ AFLD:
 WEAP:
 	Inherits: ^BaseBuilding
 	Inherits@shape: ^3x2Shape
+	Entrances:
+		EntranceOffsets: 0,0,0, 0,1024,0, 0,-1024,0
 	HitShape:
 		TargetableOffsets: 0,0,0, 0,1024,0, 0,-1024,0
 		Type: Rectangle
@@ -442,6 +456,9 @@ WEAP:
 HPAD:
 	Inherits: ^BaseBuilding
 	Inherits@shape: ^2x2Shape
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 768,-512,0, 768,512,0, -281,-512,0, -630,512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 768,-512,0, 768,512,0, -281,-512,0, -630,512,0
@@ -491,6 +508,8 @@ HPAD:
 HQ:
 	Inherits: ^BaseBuilding
 	Inherits@IDISABLE: ^DisabledOverlay
+	Entrances:
+		EntranceOffsets: 0,0,0, 0,512,0, 420,-598,256
 	HitShape:
 		TargetableOffsets: 0,0,0, 0,512,0, 420,-598,256
 		Type: Rectangle
@@ -559,6 +578,8 @@ HQ:
 
 FIX:
 	Inherits: ^BaseBuilding
+	Entrances:
+		EntranceOffsets: 0,0,0, 840,0,0, -1060,0,0
 	HitShape:
 		Type: Rectangle
 			TopLeft: -1536, -683
@@ -603,6 +624,8 @@ FIX:
 EYE:
 	Inherits: ^BaseBuilding
 	Inherits@IDISABLE: ^DisabledOverlay
+	Entrances:
+		EntranceOffsets: 0,0,0, 0,512,128, 420,-598,213
 	HitShape:
 		TargetableOffsets: 0,0,0, 0,512,128, 420,-598,213
 		Type: Rectangle
@@ -667,6 +690,9 @@ TMPL:
 	Inherits: ^BaseBuilding
 	Inherits@IDISABLE: ^DisabledOverlay
 	Inherits@shape: ^3x2Shape
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 0,-896,0, 0,896,0, 840,0,0, -706,0,0, -706,-768,0, -706,640,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 0,-896,0, 0,896,0, 840,0,0, -706,0,0, -706,-768,0, -706,640,0

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -368,6 +368,8 @@
 		VisibilityType: CenterPosition
 	Targetable:
 		TargetTypes: Ground, C4, Structure
+	Entrances:
+		UseOccupiedCellsOffsets: true
 	HitShape:
 		UseTargetableCellsOffsets: true
 		Type: Rectangle

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -380,6 +380,8 @@ light_factory:
 	WithBuildingBib:
 	Health:
 		HP: 3300
+	Entrances:
+		EntranceOffsets: -210,608,0
 	HitShape:
 		TargetableOffsets: -210,608,0
 		Type: Rectangle
@@ -464,6 +466,8 @@ heavy_factory:
 	WithBuildingBib:
 	Health:
 		HP: 3500
+	Entrances:
+		EntranceOffsets: -1155,-704,0, -1365,832,0
 	HitShape:
 		TargetableOffsets: -1155,-704,0, -1365,832,0
 		Type: Rectangle
@@ -892,6 +896,8 @@ high_tech_factory:
 	WithBuildingBib:
 	Health:
 		HP: 3500
+	Entrances:
+		EntranceOffsets: -1312,0,0, -1312,-1024,0, -1312,1024,0
 	HitShape:
 		TargetableOffsets: -1312,0,0, -1312,-1024,0, -1312,1024,0
 		Type: Rectangle
@@ -969,6 +975,8 @@ research_centre:
 	WithBuildingBib:
 	Health:
 		HP: 2500
+	Entrances:
+		EntranceOffsets: -1574,-158,0, -1050,-1024,0, -1155,960,0
 	HitShape:
 		TargetableOffsets: -1574,-158,0, -1050,-1024,0, -1155,960,0
 		Type: Rectangle

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -121,6 +121,9 @@ V01:
 		Range: 10c0
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT, INTERIOR
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: -490,-384,0, 0,0,0, 0,470,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: -490,-384,0, 0,0,0, 0,470,0
@@ -135,6 +138,9 @@ V02:
 		Dimensions: 2,2
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT, INTERIOR
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: -490,-512,0, 0,0,0, 0,512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: -490,-512,0, 0,0,0, 0,512,0
@@ -149,6 +155,9 @@ V03:
 		Dimensions: 2,2
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT, INTERIOR
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: -490,-512,0, 0,0,0, 421,512,0, -210,512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: -490,-512,0, 0,0,0, 421,512,0, -210,512,0
@@ -163,6 +172,9 @@ V04:
 		Dimensions: 2,2
 	EditorTilesetFilter:
 		ExcludeTilesets: DESERT, INTERIOR
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 0,0,0, -421,-256,0, -421,256,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, -421,-256,0, -421,256,0
@@ -343,6 +355,9 @@ AMMOBOX3:
 MISS:
 	Inherits: ^TechBuilding
 	Inherits@shape: ^3x2Shape
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 840,0,0, 840,-1024,0, 420,768,0, -840,0,0, -840,-1024,0, -840,1024,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 840,0,0, 840,-1024,0, 420,768,0, -840,0,0, -840,-1024,0, -840,1024,0
@@ -391,6 +406,9 @@ BIO:
 OILB:
 	Inherits: ^TechBuilding
 	Inherits@shape: ^2x2Shape
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 630,-300,0, 420,512,0, -420,-512,0, -630,300,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 630,-300,0, 420,512,0, -420,-512,0, -630,300,0
@@ -581,6 +599,9 @@ V20:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: -840,-512,0, 0,0,0, -840,512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: -840,-512,0, 0,0,0, -840,512,0
@@ -593,6 +614,9 @@ V21:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 840,-512,0, 420,0,0, 840,512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 840,-512,0, 420,0,0, 840,512,0
@@ -620,6 +644,9 @@ V24:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: -630,-512,0, 0,0,0, -630,256,0, 420,-512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: -630,-512,0, 0,0,0, -630,256,0, 420,-512,0
@@ -636,6 +663,9 @@ V25:
 		Name: Church
 	RevealsShroud:
 		Range: 10c0
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 0,-128,0, 420,512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,-128,0, 420,512,0
@@ -701,6 +731,9 @@ V37:
 	Building:
 		Footprint: __xx_ ___xx
 		Dimensions: 5,2
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 0,0,0, 0,1024,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 0,1024,0
@@ -720,6 +753,8 @@ RUSHOUSE:
 	Building:
 		Footprint: x x
 		Dimensions: 1,2
+	Entrances:
+		UseTargetableCellsOffsets: false
 	HitShape:
 		UseTargetableCellsOffsets: false
 
@@ -737,6 +772,8 @@ SNOWHUT:
 		Dimensions: 1,2
 	RenderSprites:
 		Scale: 0.7
+	Entrances:
+		UseTargetableCellsOffsets: false
 	HitShape:
 		UseTargetableCellsOffsets: false
 

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -14,6 +14,8 @@
 	RenderSprites:
 
 ^1x1Shape:
+	Entrances:
+		UseOccupiedCellsOffsets: true
 	HitShape:
 		UseTargetableCellsOffsets: true
 		Type: Rectangle
@@ -21,6 +23,8 @@
 			BottomRight: 512, 512
 
 ^2x1Shape:
+	Entrances:
+		UseOccupiedCellsOffsets: true
 	HitShape:
 		UseTargetableCellsOffsets: true
 		Type: Rectangle
@@ -28,6 +32,8 @@
 			BottomRight: 1024, 512
 
 ^2x2Shape:
+	Entrances:
+		UseOccupiedCellsOffsets: true
 	HitShape:
 		UseTargetableCellsOffsets: true
 		Type: Rectangle
@@ -35,6 +41,8 @@
 			BottomRight: 1024, 1024
 
 ^3x2Shape:
+	Entrances:
+		UseOccupiedCellsOffsets: true
 	HitShape:
 		UseTargetableCellsOffsets: true
 		Type: Rectangle

--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -2,6 +2,9 @@ FPWR:
 	Inherits: ^FakeBuilding
 	Inherits@infiltrate: ^InfiltratableFake
 	Inherits@shape: ^2x2Shape
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 640,-384,0, 640,512,0, -710,-512,0, -710,512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 640,-384,0, 640,512,0, -710,-512,0, -710,512,0
@@ -61,6 +64,8 @@ SYRF:
 		Type: Light
 	EditorTilesetFilter:
 		ExcludeTilesets: INTERIOR
+	Entrances:
+		EntranceOffsets: 768,0,0, 768,-1024,0, 768,1024,0
 	HitShape:
 		TargetableOffsets: 768,0,0, 768,-1024,0, 768,1024,0
 		Type: Rectangle
@@ -103,6 +108,8 @@ SPEF:
 		Type: Light
 	EditorTilesetFilter:
 		ExcludeTilesets: INTERIOR
+	Entrances:
+		EntranceOffsets: 811,0,0, -811,0,0
 	HitShape:
 		Type: Rectangle
 			TopLeft: -1536, -598
@@ -149,6 +156,9 @@ DOMF:
 	Inherits@IDISABLE: ^DisabledOverlay
 	Inherits@infiltrate: ^InfiltratableFake
 	Inherits@shape: ^2x2Shape
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 630,-384,0, 630,384,0, -700,-512,0, -700,512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 630,-384,0, 630,384,0, -700,-512,0, -700,512,0
@@ -204,6 +214,8 @@ FIXF:
 		Image: FIX
 	Valued:
 		Cost: 120
+	Entrances:
+		EntranceOffsets: 840,0,0, -1060,0,0
 	HitShape:
 		Type: Rectangle
 			TopLeft: -1536, -683
@@ -218,6 +230,8 @@ FAPW:
 	Inherits: ^FakeBuilding
 	Inherits@infiltrate: ^InfiltratableFake
 	Inherits@shape: ^3x2Shape
+	Entrances:
+		EntranceOffsets: -355,-1024,0
 	HitShape:
 		TargetableOffsets: -355,-1024,0
 	Buildable:
@@ -369,6 +383,8 @@ FACF:
 		HP: 1500
 	Armor:
 		Type: Wood
+	Entrances:
+		EntranceOffsets: 1273,939,0, -980,-640,0, -980,640,0
 	HitShape:
 		TargetableOffsets: 1273,939,0, -980,-640,0, -980,640,0
 		Type: Rectangle

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -191,6 +191,8 @@ SPEN:
 		ReferencePoint: Top
 		ZOffset: 256
 		RequiresCondition: primary
+	Entrances:
+		EntranceOffsets: 811,0,0, -811,0,0
 	HitShape:
 		Type: Rectangle
 			TopLeft: -1536, -598
@@ -296,6 +298,8 @@ SYRD:
 		ReferencePoint: Top
 		ZOffset: 256
 		RequiresCondition: primary
+	Entrances:
+		EntranceOffsets: 768,0,0, 768,-1024,0, 768,1024,0
 	HitShape:
 		TargetableOffsets: 768,0,0, 768,-1024,0, 768,1024,0
 		Type: Rectangle
@@ -542,6 +546,9 @@ DOME:
 	Inherits: ^Building
 	Inherits@IDISABLE: ^DisabledOverlay
 	Inherits@shape: ^2x2Shape
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 630,-384,0, 630,384,0, -700,-512,0, -700,512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 630,-384,0, 630,384,0, -700,-512,0, -700,512,0
@@ -1051,6 +1058,8 @@ FACT:
 		DeathSequence: dead
 		UseDeathTypeSuffix: false
 	ProvidesPrerequisite@buildingname:
+	Entrances:
+		EntranceOffsets: 1273,939,0, -980,-640,0, -980,640,0
 	HitShape:
 		TargetableOffsets: 1273,939,0, -980,-640,0, -980,640,0
 		Type: Rectangle
@@ -1112,6 +1121,8 @@ PROC:
 		DeathSequence: dead
 		UseDeathTypeSuffix: false
 	ProvidesPrerequisite@buildingname:
+	Entrances:
+		EntranceOffsets: 1680,0,0, -1260,-1024,0
 	HitShape:
 		Type: Rectangle
 			TopLeft: -1536, -512
@@ -1162,6 +1173,9 @@ SILO:
 HPAD:
 	Inherits: ^Building
 	Inherits@shape: ^2x2Shape
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 768,-512,0, 768,512,0, -281,-512,0, -630,512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 768,-512,0, 768,512,0, -281,-512,0, -630,512,0
@@ -1249,6 +1263,9 @@ HPAD:
 AFLD:
 	Inherits: ^Building
 	Inherits@shape: ^3x2Shape
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 420,0,0, 420,-1024,0, 420,1024,0, -777,0,0, -777,-1024,0, -777,1024,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 420,0,0, 420,-1024,0, 420,1024,0, -777,0,0, -777,-1024,0, -777,1024,0
@@ -1384,6 +1401,9 @@ POWR:
 	Inherits@IDISABLE: ^DisabledOverlay
 	Inherits@POWER_OUTAGE: ^DisabledByPowerOutage
 	Inherits@shape: ^2x2Shape
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 640,-384,0, 640,512,0, -710,-512,0, -710,512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 640,-384,0, 640,512,0, -710,-512,0, -710,512,0
@@ -1423,6 +1443,8 @@ APWR:
 	Inherits@IDISABLE: ^DisabledOverlay
 	Inherits@POWER_OUTAGE: ^DisabledByPowerOutage
 	Inherits@shape: ^3x2Shape
+	Entrances:
+		EntranceOffsets: -355,-1024,0
 	HitShape:
 		TargetableOffsets: -355,-1024,0
 	Buildable:
@@ -1463,6 +1485,8 @@ APWR:
 STEK:
 	Inherits: ^ScienceBuilding
 	Inherits@shape: ^3x2Shape
+	Entrances:
+		EntranceOffsets: 420,-768,0, 420,768,0, -770,-768,0, -770,768,0
 	HitShape:
 		TargetableOffsets: 420,-768,0, 420,768,0, -770,-768,0, -770,768,0
 	Buildable:
@@ -1494,6 +1518,9 @@ STEK:
 BARR:
 	Inherits: ^Building
 	Inherits@shape: ^2x2Shape
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 490,-470,0, 355,512,0, -355,-512,0, -630,512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 490,-470,0, 355,512,0, -355,-512,0, -630,512,0
@@ -1622,6 +1649,9 @@ KENN:
 TENT:
 	Inherits: ^Building
 	Inherits@shape: ^2x2Shape
+	Entrances:
+		UseTargetableCellsOffsets: false
+		EntranceOffsets: 630,-512,0, 355,512,0, -281,-512,0, -630,512,0
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 630,-512,0, 355,512,0, -281,-512,0, -630,512,0
@@ -1747,6 +1777,8 @@ FIX:
 	Power:
 		Amount: -30
 	ProvidesPrerequisite@buildingname:
+	Entrances:
+		EntranceOffsets: 840,0,0, -1060,0,0
 	HitShape:
 		Type: Rectangle
 			TopLeft: -1536, -683
@@ -1840,6 +1872,8 @@ BRIK:
 
 VGATE:
 	Inherits: ^Gate
+	Entrances:
+		UseTargetableCellsOffsets: true
 	HitShape:
 		UseTargetableCellsOffsets: true
 		Type: Rectangle
@@ -1857,6 +1891,8 @@ VGATE:
 
 HGATE:
 	Inherits: ^Gate
+	Entrances:
+		UseTargetableCellsOffsets: true
 	HitShape:
 		UseTargetableCellsOffsets: true
 		Type: Rectangle

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -165,6 +165,8 @@
 		Priority: 3
 	Targetable:
 		TargetTypes: Ground, Building, C4
+	Entrances:
+		UseOccupiedCellsOffsets: true
 	HitShape:
 		UseOccupiedCellsOffsets: true
 	Building:


### PR DESCRIPTION
This is a piece of some refactoring for enter & exit logic. In the future, `Exit` and `Entrances` probably should be merged, but this PR focuses on giving enter activities separate target positions. It does not have much in the way of repositioning access points, but suggestions are welcome and the playtest could be used to tweak it.

In the future I would like to have different kinds of access points (docks for harvesters & aircraft, production exits, and infiltration entrances) and different access/target types for the different kinds of access points.