### PR TITLE
[RA] Adjust AoE damage vs Wood in relation to HitShape Playtest.

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -77,9 +77,9 @@ GAP:
 	WithSpriteBody:
 		PauseAnimationWhenDisabled: true
 	Health:
-		HP: 1000
+		HP: 500
 	Armor:
-		Type: Wood
+		Type: Heavy
 	RevealsShroud:
 		Range: 6c0
 		RevealGeneratedShroud: False
@@ -126,7 +126,7 @@ SPEN:
 	Health:
 		HP: 1000
 	Armor:
-		Type: Light
+		Type: Wood
 	RevealsShroud:
 		Range: 4c0
 	Exit@1:
@@ -225,7 +225,7 @@ SYRD:
 	Health:
 		HP: 1000
 	Armor:
-		Type: Light
+		Type: Wood
 	RevealsShroud:
 		Range: 4c0
 	Exit@1:

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -86,13 +86,13 @@ TurretGun:
 		Speed: 204
 		Blockable: false
 		LaunchAngle: 62
-		Inaccuracy: 1c682
+		Inaccuracy: 2c256
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 220
+		Damage: 240
 		Versus:
 			None: 90
-			Wood: 75
+			Wood: 40
 			Light: 60
 			Heavy: 25
 			Concrete: 50
@@ -128,7 +128,7 @@ TurretGun:
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
 			None: 60
-			Wood: 75
+			Wood: 35
 			Light: 60
 			Heavy: 25
 			Concrete: 100

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -229,6 +229,7 @@ MiniNuke:
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: Ground, Trees, Water, Air
 		Versus:
+			Wood: 25
 			Concrete: 25
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
@@ -245,6 +246,7 @@ MiniNuke:
 		Delay: 5
 		ValidTargets: Ground, Trees, Water, Underwater, Air
 		Versus:
+			Wood: 50
 			Concrete: 25
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
@@ -262,6 +264,7 @@ MiniNuke:
 		Delay: 10
 		ValidTargets: Ground, Water, Underwater, Air
 		Versus:
+			Wood: 50
 			Concrete: 25
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -280,7 +280,7 @@ TorpTube:
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
 			None: 40
-			Wood: 100
+			Wood: 40
 			Light: 30
 			Heavy: 30
 			Concrete: 100

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -13,7 +13,7 @@ ParaBomb:
 		Damage: 300
 		Versus:
 			None: 30
-			Wood: 40
+			Wood: 30
 			Light: 75
 			Concrete: 25
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
@@ -38,6 +38,7 @@ Atomic:
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: Ground, Trees, Water, Underwater, Air
 		Versus:
+			Wood: 25
 			Concrete: 25
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@2Res_impact: DestroyResource
@@ -57,6 +58,7 @@ Atomic:
 		Delay: 5
 		ValidTargets: Ground, Trees, Water, Underwater, Air
 		Versus:
+			Wood: 25
 			Concrete: 25
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@6Res_areanuke1: DestroyResource
@@ -78,6 +80,7 @@ Atomic:
 		Delay: 10
 		ValidTargets: Ground, Water, Underwater, Air
 		Versus:
+			Wood: 50
 			Concrete: 25
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@10Dam_areanuke2: SpreadDamage


### PR DESCRIPTION
Adjusts **Artillery**, **Parabomb**, **Cruiser**, **Missile Sub**, **ABomb** and **Nuke Truck** damage vs wood to mimic the current release.

I've spent some time running release and bleed clients side-by-side.

Their damage output is now fairly similar with a few exceptions. It should be much easier to playtest and adjust following these values compared to vanilla.

*Swapped Sub Pen and Naval Yard armor type from Light to Wood.

*Swapped Gap Generator 1000hp Wood armor with 500hp Heavy armor.