### PR TITLE
Add liblua 5.3 library name so it can build on Fedora Linux

### DIFF
--- a/thirdparty/configure-native-deps.sh
+++ b/thirdparty/configure-native-deps.sh
@@ -7,7 +7,7 @@
 ####
 
 locations="/lib /lib64 /usr/lib /usr/lib64 /usr/lib/i386-linux-gnu /usr/lib/x86_64-linux-gnu /usr/lib/mipsel-linux-gnu /usr/local/lib /opt/lib /opt/local/lib"
-sonames="liblua.so.5.1.5 liblua5.1.so.5.1 liblua5.1.so.0 liblua.so.5.1 liblua-5.1.so liblua5.1.so"
+sonames="liblua.so.5.1.5 liblua5.1.so.5.1 liblua5.1.so.0 liblua.so.5.1 liblua-5.1.so liblua5.1.so liblua-5.3.so"
 
 if [ -f Eluant.dll.config ]; then
 	exit 0


### PR DESCRIPTION
Lua 5.1 is not available on the current Fedora 25 distribution so I added the Lua 5.3 library file so the compile would work. Only issue I have found with the change is the Red Alert mod will crash with Lua 5.3 but all the other mods are working fine.