### PR TITLE
Revert Yak gun strafing

### DIFF
--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -164,12 +164,12 @@ YAK:
 		Range: 9c0
 		Type: GroundPosition
 	Armament@PRIMARY:
-		Weapon: ChainGun.Yak.Left
+		Weapon: ChainGun.Yak
 		LocalOffset: 256,-213,0
 		MuzzleSequence: muzzle
 	Armament@SECONDARY:
 		Name: secondary
-		Weapon: ChainGun.Yak.Right
+		Weapon: ChainGun.Yak
 		LocalOffset: 256,213,0
 		MuzzleSequence: muzzle
 	AttackPlane:
@@ -186,9 +186,9 @@ YAK:
 		TargetWhenDamaged: false
 		EnableStances: false
 	AmmoPool:
-		Ammo: 20
-		PipCount: 5
-		ReloadDelay: 10
+		Ammo: 18
+		PipCount: 6
+		ReloadDelay: 11
 	ReturnOnIdle:
 	SelectionDecorations:
 		VisualBounds: 30,28,0,2

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -204,28 +204,15 @@ ChainGun:
 		Versus:
 			None: 120
 
-ChainGun.Yak.Right:
+ChainGun.Yak:
 	Inherits: ^HeavyMG
-	Burst: 5
-	FirstBurstTargetOffset: -684,213,0
-	FollowingBurstTargetOffset: 342,0,0
-	BurstDelay: 2
-	ReloadDelay: 10
-	Range: 5c6
-	MinRange: 3c420
+	ReloadDelay: 3
+	Range: 5c0
+	MinRange: 3c0
 	Projectile: Bullet
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Damage: 40
-		Spread: 171
-		Versus:
-			None: 125
-			Light: 70
-			Heavy: 28
-
-ChainGun.Yak.Left:
-	Inherits: ChainGun.Yak.Right
-	FirstBurstTargetOffset: -684,-213,0
 
 Pistol:
 	Inherits: ^LightMG


### PR DESCRIPTION
When I filed #13522, I wasn't sure whether the Yak changes would see some acceptance, but since there wasn't much feedback initially, I kept them.

However, with some concerns voiced shortly before it was merged and some shortly after, we're now at @abcdefg30 , @FrameLimiter and @SoScared for voices of (rather strong) concern, so the probability of more complaints and a push to revert it once the playtest is out is extremely high.

In a pre-emptive strike for that, it's probably better to just let it go and drop it before that happens, to save some nerves and time.

The functionality remains, so we can still consider using it for single-player missions at some point, and modders have the option to use it for maps and mods as well, that's good enough.