### PR TITLE
D2K - Make D2K Missions use vanilla Remap Colors

### DIFF
--- a/mods/d2k/maps/atreides-01a/map.yaml
+++ b/mods/d2k/maps/atreides-01a/map.yaml
@@ -111,4 +111,4 @@ Actors:
 		Location: 13,13
 		Owner: Neutral
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/atreides-01b/map.yaml
+++ b/mods/d2k/maps/atreides-01b/map.yaml
@@ -110,4 +110,4 @@ Actors:
 		Location: 22,20
 		Owner: Neutral
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/atreides-02a/map.yaml
+++ b/mods/d2k/maps/atreides-02a/map.yaml
@@ -168,4 +168,4 @@ Actors:
 		Owner: Neutral
 		Location: 30,28
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/atreides-02b/map.yaml
+++ b/mods/d2k/maps/atreides-02b/map.yaml
@@ -138,4 +138,4 @@ Actors:
 		Owner: Neutral
 		Location: 30,28
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/atreides-03a/map.yaml
+++ b/mods/d2k/maps/atreides-03a/map.yaml
@@ -135,4 +135,4 @@ Actors:
 		Owner: Neutral
 		Location: 39,30
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/atreides-03b/map.yaml
+++ b/mods/d2k/maps/atreides-03b/map.yaml
@@ -132,4 +132,4 @@ Actors:
 		Owner: Neutral
 		Location: 15,34
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/atreides-04/map.yaml
+++ b/mods/d2k/maps/atreides-04/map.yaml
@@ -410,6 +410,6 @@ Actors:
 		Owner: Neutral
 		Location: 5,23
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml
 
 Sequences: sequences.yaml

--- a/mods/d2k/maps/atreides-05/map.yaml
+++ b/mods/d2k/maps/atreides-05/map.yaml
@@ -363,4 +363,4 @@ Actors:
 		Owner: Neutral
 		Location: 49,4
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/harkonnen-01a/map.yaml
+++ b/mods/d2k/maps/harkonnen-01a/map.yaml
@@ -106,4 +106,4 @@ Actors:
 		Owner: Neutral
 		Location: 29,7
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/harkonnen-01b/map.yaml
+++ b/mods/d2k/maps/harkonnen-01b/map.yaml
@@ -106,4 +106,4 @@ Actors:
 		Owner: Neutral
 		Location: 28,2
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/harkonnen-02a/map.yaml
+++ b/mods/d2k/maps/harkonnen-02a/map.yaml
@@ -162,4 +162,4 @@ Actors:
 		Owner: Neutral
 		Location: 47,4
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/harkonnen-02b/map.yaml
+++ b/mods/d2k/maps/harkonnen-02b/map.yaml
@@ -144,4 +144,4 @@ Actors:
 		Owner: Neutral
 		Location: 23,16
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/harkonnen-03a/map.yaml
+++ b/mods/d2k/maps/harkonnen-03a/map.yaml
@@ -177,4 +177,4 @@ Actors:
 		Owner: Neutral
 		Location: 29,2
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/harkonnen-03b/map.yaml
+++ b/mods/d2k/maps/harkonnen-03b/map.yaml
@@ -207,4 +207,4 @@ Actors:
 		Owner: Neutral
 		Location: 65,45
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/harkonnen-04/map.yaml
+++ b/mods/d2k/maps/harkonnen-04/map.yaml
@@ -379,4 +379,4 @@ Actors:
 		Owner: Neutral
 		Location: 22,91
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/ordos-01a/map.yaml
+++ b/mods/d2k/maps/ordos-01a/map.yaml
@@ -101,4 +101,4 @@ Actors:
 		Owner: Neutral
 		Location: 29,15
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/ordos-01b/map.yaml
+++ b/mods/d2k/maps/ordos-01b/map.yaml
@@ -101,4 +101,4 @@ Actors:
 		Owner: Neutral
 		Location: 24,2
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/ordos-02a/map.yaml
+++ b/mods/d2k/maps/ordos-02a/map.yaml
@@ -152,4 +152,4 @@ Actors:
 		Owner: Neutral
 		Location: 25,17
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/ordos-02b/map.yaml
+++ b/mods/d2k/maps/ordos-02b/map.yaml
@@ -137,4 +137,4 @@ Actors:
 		Owner: Neutral
 		Location: 9,8
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/ordos-03a/map.yaml
+++ b/mods/d2k/maps/ordos-03a/map.yaml
@@ -143,4 +143,4 @@ Actors:
 		Owner: Harkonnen
 		Location: 4,60
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/ordos-03b/map.yaml
+++ b/mods/d2k/maps/ordos-03b/map.yaml
@@ -254,4 +254,4 @@ Actors:
 		Owner: Neutral
 		Location: 2,20
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/ordos-04/map.yaml
+++ b/mods/d2k/maps/ordos-04/map.yaml
@@ -523,4 +523,4 @@ Actors:
 		Owner: Smugglers
 		Location: 49,19
 
-Rules: d2k|rules/campaign-rules.yaml, rules.yaml
+Rules: d2k|rules/campaign-rules.yaml, d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/maps/shellmap/d2k-shellmap.lua
+++ b/mods/d2k/maps/shellmap/d2k-shellmap.lua
@@ -14,7 +14,7 @@ IdlingUnits =
 	Atreides = { },
 	Harkonnen = { },
 	Ordos = { },
-	Emperor = { }
+	Corrino = { }
 }
 
 HoldProduction =
@@ -22,7 +22,7 @@ HoldProduction =
 	Atreides = false,
 	Harkonnen = false,
 	Ordos = false,
-	Emperor = false
+	Corrino = false
 }
 
 IsAttacking =
@@ -30,7 +30,7 @@ IsAttacking =
 	Atreides = false,
 	Harkonnen = false,
 	Ordos = false,
-	Emperor = false
+	Corrino = false
 }
 
 AtreidesInfantryTypes = { "light_inf", "light_inf", "light_inf", "trooper", "trooper", "grenadier", "grenadier" }
@@ -48,10 +48,10 @@ OrdosVehicleTypes = { "raider", "raider", "quad", "stealth_raider" }
 OrdosTankTypes = { "combat_tank_o", "combat_tank_o", "combat_tank_o", "siege_tank" }
 OrdosStarportTypes = { "trike.starport", "quad.starport", "siege_tank.starport", "missile_tank.starport", "combat_tank_o.starport" }
 
-EmperorInfantryTypes = { "light_inf", "trooper", "sardaukar", "sardaukar", "sardaukar", "sardaukar" }
-EmperorVehicleTypes = { "trike", "quad", "quad" }
-EmperorTankTypes = { "combat_tank_h", "combat_tank_h", "combat_tank_h", "siege_tank" }
-EmperorStarportTypes = { "trike.starport", "quad.starport", "siege_tank.starport", "missile_tank.starport", "combat_tank_h.starport" }
+CorrinoInfantryTypes = { "light_inf", "trooper", "sardaukar", "sardaukar", "sardaukar", "sardaukar" }
+CorrinoVehicleTypes = { "trike", "quad", "quad" }
+CorrinoTankTypes = { "combat_tank_h", "combat_tank_h", "combat_tank_h", "siege_tank" }
+CorrinoStarportTypes = { "trike.starport", "quad.starport", "siege_tank.starport", "missile_tank.starport", "combat_tank_h.starport" }
 
 Upgrades = { "upgrade.barracks", "upgrade.light", "upgrade.conyard", "upgrade.heavy", "upgrade.hightech" }
 
@@ -60,7 +60,7 @@ Harvester = { "harvester" }
 AtrCarryHarvWaypoints = { atr_harvcarry_2.Location, atr_harvcarry_1.Location }
 HarCarryHarvWaypoints = { har_harvcarry_2.Location, har_harvcarry_1.Location }
 OrdCarryHarvWaypoints = { ord_harvcarry_2.Location, ord_harvcarry_1.Location }
-EmpCarryHarvWaypoints = { emp_harvcarry_2.Location, emp_harvcarry_1.Location }
+CorCarryHarvWaypoints = { cor_harvcarry_2.Location, cor_harvcarry_1.Location }
 SmgCarryHarvWaypoints = { smg_harvcarry_2.Location, smg_harvcarry_1.Location }
 
 IdleHunt = function(unit) if not unit.IsDead then Trigger.OnIdle(unit, unit.Hunt) end end
@@ -155,7 +155,7 @@ WorldLoaded = function()
 	atreides = Player.GetPlayer("Atreides")
 	harkonnen = Player.GetPlayer("Harkonnen")
 	ordos = Player.GetPlayer("Ordos")
-	emperor = Player.GetPlayer("Emperor")
+	corrino = Player.GetPlayer("Corrino")
 	smugglers = Player.GetPlayer("Smugglers")
 
 	viewportOrigin = Camera.Position
@@ -164,7 +164,7 @@ WorldLoaded = function()
 		atr_cyard.Produce(upgrade)
 		har_cyard.Produce(upgrade)
 		ord_cyard.Produce(upgrade)
-		emp_cyard.Produce(upgrade)
+		cor_cyard.Produce(upgrade)
 	end)
 	atr_cyard.Produce(Upgrades[5])
 
@@ -172,7 +172,7 @@ WorldLoaded = function()
 		SendNewHarv(atreides, AtrCarryHarvWaypoints, 3)
 		SendNewHarv(harkonnen, HarCarryHarvWaypoints, 3)
 		SendNewHarv(ordos, OrdCarryHarvWaypoints, 3)
-		SendNewHarv(emperor, EmpCarryHarvWaypoints, 3)
+		SendNewHarv(corrino, CorCarryHarvWaypoints, 3)
 		SendNewHarv(smugglers, SmgCarryHarvWaypoints, 1)
 	end)
 
@@ -192,9 +192,9 @@ WorldLoaded = function()
 		Produce(ordos, OrdosTankTypes)
 		Produce(ordos, OrdosStarportTypes)
 
-		Produce(emperor, EmperorInfantryTypes)
-		Produce(emperor, EmperorVehicleTypes)
-		Produce(emperor, EmperorTankTypes)
-		Produce(emperor, EmperorStarportTypes)
+		Produce(corrino, CorrinoInfantryTypes)
+		Produce(corrino, CorrinoVehicleTypes)
+		Produce(corrino, CorrinoTankTypes)
+		Produce(corrino, CorrinoStarportTypes)
 	end)
 end

--- a/mods/d2k/maps/shellmap/map.yaml
+++ b/mods/d2k/maps/shellmap/map.yaml
@@ -17,18 +17,13 @@ Visibility: Shellmap
 Categories: Shellmap
 
 Players:
-	PlayerReference@Neutral:
-		Name: Neutral
-		OwnsWorld: True
-		NonCombatant: True
-		Faction: atreides
 	PlayerReference@Atreides:
 		Name: Atreides
 		Faction: atreides
 		Color: 9191FF
-		Enemies: Emperor, Ordos, Harkonnen, Creeps
-	PlayerReference@Emperor:
-		Name: Emperor
+		Enemies: Corrino, Ordos, Harkonnen, Creeps
+	PlayerReference@Corrino:
+		Name: Corrino
 		Faction: corrino
 		Color: EF00FE
 		Enemies: Atreides, Ordos, Harkonnen, Creeps
@@ -36,22 +31,27 @@ Players:
 		Name: Ordos
 		Faction: ordos
 		Color: B3EAA5
-		Enemies: Atreides, Emperor, Harkonnen, Creeps
+		Enemies: Atreides, Corrino, Harkonnen, Creeps
 	PlayerReference@Harkonnen:
 		Name: Harkonnen
 		Faction: harkonnen
 		Color: FE0000
-		Enemies: Atreides, Emperor, Ordos, Creeps
+		Enemies: Atreides, Corrino, Ordos, Creeps
 	PlayerReference@Smugglers:
 		Name: Smugglers
 		Faction: smuggler
 		Color: 542209
 		Enemies: Creeps
+	PlayerReference@Neutral:
+		Name: Neutral
+		OwnsWorld: True
+		NonCombatant: True
+		Faction: atreides
 	PlayerReference@Creeps:
 		Name: Creeps
 		NonCombatant: True
 		Faction: atreides
-		Enemies: Atreides, Emperor, Ordos, Harkonnen, Smugglers
+		Enemies: Atreides, Corrino, Ordos, Harkonnen, Smugglers
 
 Actors:
 	WormSpawner: wormspawner
@@ -418,94 +418,94 @@ Actors:
 	ord_wind7: wind_trap
 		Owner: Ordos
 		Location: 20,25
-	emp_cyard: construction_yard
-		Owner: Emperor
+	cor_cyard: construction_yard
+		Owner: Corrino
 		Location: 27,92
-	emp_wind5: wind_trap
-		Owner: Emperor
+	cor_wind5: wind_trap
+		Owner: Corrino
 		Location: 31,92
-	emp_wind4: wind_trap
-		Owner: Emperor
+	cor_wind4: wind_trap
+		Owner: Corrino
 		Location: 24,92
-	emp_barracks: barracks
-		Owner: Emperor
+	cor_barracks: barracks
+		Owner: Corrino
 		Location: 33,92
-	emp_ref1: refinery
-		Owner: Emperor
+	cor_ref1: refinery
+		Owner: Corrino
 		Location: 38,87
-	emp_ref2: refinery
-		Owner: Emperor
+	cor_ref2: refinery
+		Owner: Corrino
 		Location: 21,86
-	emp_hfac: heavy_factory
-		Owner: Emperor
+	cor_hfac: heavy_factory
+		Owner: Corrino
 		Location: 31,85
-	emp_outp: outpost
-		Owner: Emperor
+	cor_outp: outpost
+		Owner: Corrino
 		Location: 17,92
-	emp_wind1: wind_trap
-		Owner: Emperor
+	cor_wind1: wind_trap
+		Owner: Corrino
 		Location: 22,92
-	emp_wind2: wind_trap
-		Owner: Emperor
+	cor_wind2: wind_trap
+		Owner: Corrino
 		Location: 20,92
 	Actor151: wall
-		Owner: Emperor
+		Owner: Corrino
 		Location: 19,87
 	Actor152: wall
-		Owner: Emperor
+		Owner: Corrino
 		Location: 20,86
 	Actor153: wall
-		Owner: Emperor
+		Owner: Corrino
 		Location: 21,85
-	emp_gunt1: medium_gun_turret
-		Owner: Emperor
+	cor_gunt1: medium_gun_turret
+		Owner: Corrino
 		Location: 20,87
 		TurretFacing: 0
-	emp_rckt1: large_gun_turret
-		Owner: Emperor
+	cor_rckt1: large_gun_turret
+		Owner: Corrino
 		Location: 20,85
 		TurretFacing: 0
 	Actor154: wall
-		Owner: Emperor
+		Owner: Corrino
 		Location: 23,83
 	Actor155: wall
-		Owner: Emperor
+		Owner: Corrino
 		Location: 24,84
-	emp_gunt2: medium_gun_turret
-		Owner: Emperor
+	cor_gunt2: medium_gun_turret
+		Owner: Corrino
 		Location: 23,84
 		TurretFacing: 32
 	Actor158: wall
-		Owner: Emperor
+		Owner: Corrino
 		Location: 35,84
 	Actor160: wall
-		Owner: Emperor
+		Owner: Corrino
 		Location: 36,85
-	emp_gunt3: medium_gun_turret
-		Owner: Emperor
+	cor_gunt3: medium_gun_turret
+		Owner: Corrino
 		Location: 36,84
 		TurretFacing: 192
 	Actor162: wall
-		Owner: Emperor
+		Owner: Corrino
 		Location: 36,80
 	Actor163: wall
-		Owner: Emperor
+		Owner: Corrino
 		Location: 37,79
-	emp_rckt2: large_gun_turret
-		Owner: Emperor
+	cor_rckt2: large_gun_turret
+		Owner: Corrino
 		Location: 36,79
 		TurretFacing: 160
-	emp_htech: high_tech_factory
-		Owner: Emperor
+	cor_htech: high_tech_factory
+		Owner: Corrino
 		Location: 37,91
-	emp_wind3: wind_trap
-		Owner: Emperor
+	cor_wind3: wind_trap
+		Owner: Corrino
 		Location: 35,92
-	emp_lfac: light_factory
-		Owner: Emperor
+	cor_lfac: light_factory
+		Owner: Corrino
 		Location: 17,89
-	emp_pad: repair_pad
-		Owner: Emperor
+	cor_pad: repair_pad
+		Owner: Corrino
 		Location: 26,84
 	Actor170: spicebloom.spawnpoint
 		Owner: Neutral
@@ -760,62 +760,62 @@ Actors:
 		SubCell: 3
 		Facing: 0
 		TurretFacing: 0
-	emp_missile: missile_tank
-		Owner: Emperor
+	cor_missile: missile_tank
+		Owner: Corrino
 		Location: 41,91
 		Facing: 160
-	emp_combat1: combat_tank_h
-		Owner: Emperor
+	cor_combat1: combat_tank_h
+		Owner: Corrino
 		Location: 38,85
 		Facing: 0
 		TurretFacing: 0
-	emp_combat2: combat_tank_h
-		Owner: Emperor
+	cor_combat2: combat_tank_h
+		Owner: Corrino
 		Location: 21,84
 		Facing: 0
 		TurretFacing: 0
-	emp_siege1: siege_tank
-		Owner: Emperor
+	cor_siege1: siege_tank
+		Owner: Corrino
 		Location: 35,85
 		Facing: 224
 		TurretFacing: 224
-	emp_siege2: siege_tank
-		Owner: Emperor
+	cor_siege2: siege_tank
+		Owner: Corrino
 		Location: 20,88
 		Facing: 0
 		TurretFacing: 0
-	emp_sardaukar1: sardaukar
-		Owner: Emperor
+	cor_sardaukar1: sardaukar
+		Owner: Corrino
 		Location: 40,85
 		SubCell: 3
 		Facing: 0
 		TurretFacing: 0
-	emp_sardaukar2: sardaukar
-		Owner: Emperor
+	cor_sardaukar2: sardaukar
+		Owner: Corrino
 		Location: 30,85
 		SubCell: 3
 		Facing: 0
 		TurretFacing: 0
-	emp_sardaukar3: sardaukar
-		Owner: Emperor
+	cor_sardaukar3: sardaukar
+		Owner: Corrino
 		Location: 23,89
 		SubCell: 3
 		Facing: 128
 		TurretFacing: 128
-	emp_sardaukar4: sardaukar
-		Owner: Emperor
+	cor_sardaukar4: sardaukar
+		Owner: Corrino
 		Location: 30,91
 		SubCell: 3
 		Facing: 0
 		TurretFacing: 0
-	emp_sardaukar5: sardaukar
-		Owner: Emperor
+	cor_sardaukar5: sardaukar
+		Owner: Corrino
 		Location: 17,88
 		SubCell: 3
 		Facing: 0
 		TurretFacing: 0
-	emp_sardaukar6: sardaukar
-		Owner: Emperor
+	cor_sardaukar6: sardaukar
+		Owner: Corrino
 		Location: 33,81
 		SubCell: 3
 		Facing: 192
@@ -853,8 +853,8 @@ Actors:
 	har_wind7: wind_trap
 		Owner: Harkonnen
 		Location: 88,24
-	emp_wind7: wind_trap
-		Owner: Emperor
+	cor_wind7: wind_trap
+		Owner: Corrino
 		Location: 36,87
 	har_carry1: carryall
 		Owner: Harkonnen
@@ -879,8 +879,8 @@ Actors:
 		SubCell: 3
 		Facing: 0
 		TurretFacing: 0
-	emp_engi: engineer
-		Owner: Emperor
+	cor_engi: engineer
+		Owner: Corrino
 		Location: 35,89
 		SubCell: 3
 		Facing: 0
@@ -906,17 +906,17 @@ Actors:
 	atr_silo4: silo
 		Owner: Atreides
 		Location: 73,84
-	emp_silo1: silo
-		Owner: Emperor
+	cor_silo1: silo
+		Owner: Corrino
 		Location: 33,90
-	emp_silo2: silo
-		Owner: Emperor
+	cor_silo2: silo
+		Owner: Corrino
 		Location: 32,90
-	emp_silo3: silo
-		Owner: Emperor
+	cor_silo3: silo
+		Owner: Corrino
 		Location: 31,90
-	emp_quad: quad
-		Owner: Emperor
+	cor_quad: quad
+		Owner: Corrino
 		Location: 33,89
 		Facing: 0
 	har_silo1: silo
@@ -943,8 +943,8 @@ Actors:
 	ord_silo4: silo
 		Owner: Ordos
 		Location: 28,25
-	emp_silo4: silo
-		Owner: Emperor
+	cor_silo4: silo
+		Owner: Corrino
 		Location: 34,90
 	Actor281: wall
 		Owner: Atreides
@@ -971,20 +971,20 @@ Actors:
 		Location: 33,33
 		TurretFacing: 128
 	Actor287: wall
-		Owner: Emperor
+		Owner: Corrino
 		Location: 38,86
 	Actor288: wall
-		Owner: Emperor
+		Owner: Corrino
 		Location: 40,86
-	emp_rckt3: large_gun_turret
-		Owner: Emperor
+	cor_rckt3: large_gun_turret
+		Owner: Corrino
 		Location: 39,86
 		TurretFacing: 0
-	emp_wind6: wind_trap
-		Owner: Emperor
+	cor_wind6: wind_trap
+		Owner: Corrino
 		Location: 25,88
-	emp_sport: starport
-		Owner: Emperor
+	cor_sport: starport
+		Owner: Corrino
 		Location: 27,88
 	smg_carry: carryall
 		Owner: Smugglers
@@ -999,8 +999,8 @@ Actors:
 	smg_harvcarry_1: waypoint
 		Owner: Smugglers
 		Location: 56,60
-	emp_harvcarry_1: waypoint
-		Owner: Emperor
+	cor_harvcarry_1: waypoint
+		Owner: Corrino
 		Location: 34,82
 	ord_harvcarry_1: waypoint
 		Owner: Ordos
@@ -1011,8 +1011,8 @@ Actors:
 	smg_harvcarry_2: waypoint
 		Owner: Smugglers
 		Location: 56,96
-	emp_harvcarry_2: waypoint
-		Owner: Emperor
+	cor_harvcarry_2: waypoint
+		Owner: Corrino
 		Location: 15,96
 	ord_harvcarry_2: waypoint
 		Owner: Ordos

--- a/mods/d2k/maps/shellmap/map.yaml
+++ b/mods/d2k/maps/shellmap/map.yaml
@@ -1030,4 +1030,4 @@ Actors:
 		Owner: Neutral
 		Location: 50,65
 
-Rules: rules.yaml
+Rules: d2k|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/d2k/rules/campaign-palettes.yaml
+++ b/mods/d2k/rules/campaign-palettes.yaml
@@ -1,0 +1,27 @@
+^Palettes:
+	-PlayerColorPalette:
+	-PaletteFromPlayerPaletteWithAlpha@deviatorgas:
+	-PaletteFromPlayerPaletteWithAlpha@cloak:
+	IndexedPlayerPalette:
+		BasePalette: d2k
+		BaseName: player
+		RemapIndex: 255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240
+		PlayerIndex:
+			Atreides: 143, 142, 141, 140, 139, 138, 137, 136, 135, 134, 133, 132, 131, 130, 129, 128
+			Harkonnen: 159, 158, 157, 156, 155, 154, 153, 152, 151, 150, 149, 148, 147, 146, 145, 144
+			Ordos: 175, 174, 173, 172, 171, 170, 169, 168, 167, 166, 165, 164, 163, 162, 161, 160
+			Corrino: 191, 190, 189, 188, 187, 186, 185, 184, 183, 182, 181, 180, 179, 178, 177, 176
+			Fremen: 207, 206, 205, 204, 203, 202, 201, 200, 199, 198, 197, 196, 195, 194, 193, 192
+			Smugglers: 223, 222, 221, 220, 219, 218, 217, 216, 215, 214, 213, 212, 211, 210, 209, 208
+			Mercenaries: 239, 238, 237, 236, 235, 234, 233, 232, 231, 230, 229, 228, 227, 226, 225, 224
+			Neutral: 255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240
+			Creeps: 255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240
+	PaletteFromPlayerPaletteWithAlpha@DeviatorGas:
+		BaseName: deviatorgas
+		BasePalette: player
+		Alpha: 0.68
+		Premultiply: false
+	PaletteFromPlayerPaletteWithAlpha@Cloak:
+		BaseName: cloak
+		BasePalette: player
+		Alpha: 0.55


### PR DESCRIPTION
Not sure if this is correct approach, i couldn't manage to get exactly what TD does (`-`ing `PlayerColorPalette:` and adding `IndexedPlayerPalette:` with `BaseName:` of `player`) work. Instead i added  `IndexedPlayerPalette:` with `BaseName:` of  `player2` and kept `PlayerColorPalette:` available but unused.

https://youtu.be/qNSze_g4p9A