### PR TITLE
Update .deb packaging to allow parallel installations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ endif
 
 ######################### UTILITIES/SETTINGS ###########################
 #
+VERSION     = $(shell git name-rev --name-only --tags --no-undefined HEAD 2>/dev/null || echo git-`git rev-parse --short HEAD`)
+
 # install locations
 prefix ?= /usr/local
 datarootdir ?= $(prefix)/share
@@ -67,7 +69,7 @@ datadir ?= $(datarootdir)
 mandir ?= $(datarootdir)/man/
 bindir ?= $(prefix)/bin
 libdir ?= $(prefix)/lib
-gameinstalldir ?= $(libdir)/openra
+gameinstalldir ?= $(libdir)/openra-$(VERSION)
 
 BIN_INSTALL_DIR = $(DESTDIR)$(bindir)
 DATA_INSTALL_DIR = $(DESTDIR)$(gameinstalldir)
@@ -86,7 +88,6 @@ INSTALL_DATA = $(INSTALL) -m644
 
 # program targets
 CORE = pdefault game utility server
-VERSION     = $(shell git name-rev --name-only --tags --no-undefined HEAD 2>/dev/null || echo git-`git rev-parse --short HEAD`)
 
 # dependencies
 UNAME_S := $(shell uname -s)
@@ -95,8 +96,6 @@ os-dependencies = osx-dependencies
 else
 os-dependencies = linux-dependencies
 endif
-
-
 
 ######################## PROGRAM TARGET RULES ##########################
 #
@@ -389,36 +388,36 @@ install-linux-icons:
 
 install-linux-desktop:
 	@$(INSTALL_DIR) "$(DESTDIR)$(datadir)/applications"
-	@sed 's/{MOD}/ra/g' packaging/linux/openra.desktop.in | sed 's/{MODNAME}/Red Alert/g' > packaging/linux/openra-ra.desktop
-	@$(INSTALL_DATA) packaging/linux/openra-ra.desktop "$(DESTDIR)$(datadir)/applications"
-	@sed 's/{MOD}/cnc/g' packaging/linux/openra.desktop.in | sed 's/{MODNAME}/Tiberian Dawn/g' > packaging/linux/openra-cnc.desktop
-	@$(INSTALL_DATA) packaging/linux/openra-cnc.desktop "$(DESTDIR)$(datadir)/applications"
-	@sed 's/{MOD}/d2k/g' packaging/linux/openra.desktop.in | sed 's/{MODNAME}/Dune 2000/g' > packaging/linux/openra-d2k.desktop
-	@$(INSTALL_DATA) packaging/linux/openra-d2k.desktop "$(DESTDIR)$(datadir)/applications"
-	@-$(RM) packaging/linux/openra-ra.desktop packaging/linux/openra-cnc.desktop packaging/linux/openra-d2k.desktop
+	@sed 's/{MOD}/ra/g' packaging/linux/openra.desktop.in | sed 's/{MODNAME}/Red Alert/g' | sed 's/{TAG}/$(VERSION)/g' > packaging/linux/openra-ra-$(VERSION).desktop
+	@$(INSTALL_DATA) packaging/linux/openra-ra-$(VERSION).desktop "$(DESTDIR)$(datadir)/applications"
+	@sed 's/{MOD}/cnc/g' packaging/linux/openra.desktop.in | sed 's/{MODNAME}/Tiberian Dawn/g' | sed 's/{TAG}/$(VERSION)/g' > packaging/linux/openra-cnc-$(VERSION).desktop
+	@$(INSTALL_DATA) packaging/linux/openra-cnc-$(VERSION).desktop "$(DESTDIR)$(datadir)/applications"
+	@sed 's/{MOD}/d2k/g' packaging/linux/openra.desktop.in | sed 's/{MODNAME}/Dune 2000/g' | sed 's/{TAG}/$(VERSION)/g' > packaging/linux/openra-d2k-$(VERSION).desktop
+	@$(INSTALL_DATA) packaging/linux/openra-d2k-$(VERSION).desktop "$(DESTDIR)$(datadir)/applications"
+	@-$(RM) packaging/linux/openra-ra-$(VERSION).desktop packaging/linux/openra-cnc-$(VERSION).desktop packaging/linux/openra-d2k-$(VERSION).desktop
 
 install-linux-mime:
 	@$(INSTALL_DIR) "$(DESTDIR)$(datadir)/mime/packages/"
 
 	@sed 's/{MOD}/ra/g' packaging/linux/openra-mimeinfo.xml.in | sed 's/{TAG}/$(VERSION)/g' > packaging/linux/openra-mimeinfo.xml
-	@$(INSTALL_DATA) packaging/linux/openra-mimeinfo.xml "$(DESTDIR)$(datadir)/mime/packages/openra.xml"
+	@$(INSTALL_DATA) packaging/linux/openra-mimeinfo.xml "$(DESTDIR)$(datadir)/mime/packages/openra-$(VERSION).xml"
 
 	@$(INSTALL_DIR) "$(DESTDIR)$(datadir)/applications"
-	@sed 's/{MOD}/ra/g' packaging/linux/openra-join-servers.desktop.in | sed 's/{MODNAME}/Red Alert/g' | sed 's/{TAG}/$(VERSION)/g' > packaging/linux/openra-ra-join-servers.desktop
-	@$(INSTALL_DATA) packaging/linux/openra-ra-join-servers.desktop "$(DESTDIR)$(datadir)/applications"
-	@sed 's/{MOD}/cnc/g' packaging/linux/openra-join-servers.desktop.in | sed 's/{MODNAME}/Tiberian Dawn/g' | sed 's/{TAG}/$(VERSION)/g' > packaging/linux/openra-cnc-join-servers.desktop
-	@$(INSTALL_DATA) packaging/linux/openra-cnc-join-servers.desktop "$(DESTDIR)$(datadir)/applications"
-	@sed 's/{MOD}/d2k/g' packaging/linux/openra-join-servers.desktop.in | sed 's/{MODNAME}/Dune 2000/g' | sed 's/{TAG}/$(VERSION)/g' > packaging/linux/openra-d2k-join-servers.desktop
-	@$(INSTALL_DATA) packaging/linux/openra-d2k-join-servers.desktop "$(DESTDIR)$(datadir)/applications"
-	@-$(RM) packaging/linux/openra-mimeinfo.xml packaging/linux/openra-ra-join-servers.desktop packaging/linux/openra-cnc-join-servers.desktop packaging/linux/openra-d2k-join-servers.desktop
+	@sed 's/{MOD}/ra/g' packaging/linux/openra-join-servers.desktop.in | sed 's/{MODNAME}/Red Alert/g' | sed 's/{TAG}/$(VERSION)/g' > packaging/linux/openra-ra-join-servers-$(VERSION).desktop
+	@$(INSTALL_DATA) packaging/linux/openra-ra-join-servers-$(VERSION).desktop "$(DESTDIR)$(datadir)/applications"
+	@sed 's/{MOD}/cnc/g' packaging/linux/openra-join-servers.desktop.in | sed 's/{MODNAME}/Tiberian Dawn/g' | sed 's/{TAG}/$(VERSION)/g' > packaging/linux/openra-cnc-join-servers-$(VERSION).desktop
+	@$(INSTALL_DATA) packaging/linux/openra-cnc-join-servers-$(VERSION).desktop "$(DESTDIR)$(datadir)/applications"
+	@sed 's/{MOD}/d2k/g' packaging/linux/openra-join-servers.desktop.in | sed 's/{MODNAME}/Dune 2000/g' | sed 's/{TAG}/$(VERSION)/g' > packaging/linux/openra-d2k-join-servers-$(VERSION).desktop
+	@$(INSTALL_DATA) packaging/linux/openra-d2k-join-servers-$(VERSION).desktop "$(DESTDIR)$(datadir)/applications"
+	@-$(RM) packaging/linux/openra-$(VERSION)-mimeinfo.xml packaging/linux/openra-ra-join-servers-$(VERSION).desktop packaging/linux/openra-cnc-join-servers-$(VERSION).desktop packaging/linux/openra-d2k-join-servers-$(VERSION).desktop
 
 install-linux-appdata:
 	@$(INSTALL_DIR) "$(DESTDIR)$(datadir)/appdata/"
-	@$(INSTALL_DATA) packaging/linux/openra.appdata.xml "$(DESTDIR)$(datadir)/appdata/"
+	@$(INSTALL_DATA) packaging/linux/openra.appdata.xml "$(DESTDIR)$(datadir)/appdata/openra-$(VERSION).appdata.xml"
 
 install-man-page: man-page
 	@$(INSTALL_DIR) "$(DESTDIR)$(mandir)/man6/"
-	@$(INSTALL_DATA) openra.6 "$(DESTDIR)$(mandir)/man6/"
+	@$(INSTALL_DATA) openra.6 "$(DESTDIR)$(mandir)/man6/openra-$(VERSION).6"
 
 install-linux-scripts:
 ifeq ($(DEBUG), $(filter $(DEBUG),false no n off 0))
@@ -429,58 +428,58 @@ else
 	@sed 's/{DEBUG}/--debug/' packaging/linux/openra-server.in | sed 's|{GAME_INSTALL_DIR}|$(gameinstalldir)|' | sed 's|{BIN_DIR}|$(bindir)|' > packaging/linux/openra-server.debug.in
 endif
 
-	@sed 's/{MOD}/ra/g' packaging/linux/openra.debug.in | sed 's/{MODNAME}/Red Alert/g' > packaging/linux/openra-ra
-	@sed 's/{MOD}/cnc/g' packaging/linux/openra.debug.in | sed 's/{MODNAME}/Tiberian Dawn/g' > packaging/linux/openra-cnc
-	@sed 's/{MOD}/d2k/g' packaging/linux/openra.debug.in | sed 's/{MODNAME}/Dune 2000/g' > packaging/linux/openra-d2k
+	@sed 's/{MOD}/ra/g' packaging/linux/openra.debug.in | sed 's/{MODNAME}/Red Alert/g' | sed 's/{TAG}/$(VERSION)/g' > packaging/linux/openra-ra-$(VERSION)
+	@sed 's/{MOD}/cnc/g' packaging/linux/openra.debug.in | sed 's/{MODNAME}/Tiberian Dawn/g' | sed 's/{TAG}/$(VERSION)/g' > packaging/linux/openra-cnc-$(VERSION)
+	@sed 's/{MOD}/d2k/g' packaging/linux/openra.debug.in | sed 's/{MODNAME}/Dune 2000/g' | sed 's/{TAG}/$(VERSION)/g' > packaging/linux/openra-d2k-$(VERSION)
 
 	@$(INSTALL_DIR) "$(BIN_INSTALL_DIR)"
-	@$(INSTALL_PROGRAM) -m +rx packaging/linux/openra-ra "$(BIN_INSTALL_DIR)"
-	@$(INSTALL_PROGRAM) -m +rx packaging/linux/openra-cnc "$(BIN_INSTALL_DIR)"
-	@$(INSTALL_PROGRAM) -m +rx packaging/linux/openra-d2k "$(BIN_INSTALL_DIR)"
-	@-$(RM) packaging/linux/openra-ra packaging/linux/openra-cnc packaging/linux/openra-d2k packaging/linux/openra.debug.in
+	@$(INSTALL_PROGRAM) -m +rx packaging/linux/openra-ra-$(VERSION) "$(BIN_INSTALL_DIR)"
+	@$(INSTALL_PROGRAM) -m +rx packaging/linux/openra-cnc-$(VERSION) "$(BIN_INSTALL_DIR)"
+	@$(INSTALL_PROGRAM) -m +rx packaging/linux/openra-d2k-$(VERSION) "$(BIN_INSTALL_DIR)"
+	@-$(RM) packaging/linux/openra-ra-$(VERSION) packaging/linux/openra-cnc-$(VERSION) packaging/linux/openra-d2k-$(VERSION) packaging/linux/openra.debug.in
 
-	@sed 's/{MOD}/ra/g' packaging/linux/openra-server.debug.in | sed 's/{MODNAME}/Red Alert/g' > packaging/linux/openra-ra-server
-	@sed 's/{MOD}/cnc/g' packaging/linux/openra-server.debug.in | sed 's/{MODNAME}/Tiberian Dawn/g' > packaging/linux/openra-cnc-server
-	@sed 's/{MOD}/d2k/g' packaging/linux/openra-server.debug.in | sed 's/{MODNAME}/Dune 2000/g' > packaging/linux/openra-d2k-server
+	@sed 's/{MOD}/ra/g' packaging/linux/openra-server.debug.in | sed 's/{MODNAME}/Red Alert/g' | sed 's/{TAG}/$(VERSION)/g' > packaging/linux/openra-ra-server-$(VERSION)
+	@sed 's/{MOD}/cnc/g' packaging/linux/openra-server.debug.in | sed 's/{MODNAME}/Tiberian Dawn/g' | sed 's/{TAG}/$(VERSION)/g' > packaging/linux/openra-cnc-server-$(VERSION)
+	@sed 's/{MOD}/d2k/g' packaging/linux/openra-server.debug.in | sed 's/{MODNAME}/Dune 2000/g' | sed 's/{TAG}/$(VERSION)/g' > packaging/linux/openra-d2k-server-$(VERSION)
 
 	@$(INSTALL_DIR) "$(BIN_INSTALL_DIR)"
-	@$(INSTALL_PROGRAM) -m +rx packaging/linux/openra-ra-server "$(BIN_INSTALL_DIR)"
-	@$(INSTALL_PROGRAM) -m +rx packaging/linux/openra-cnc-server "$(BIN_INSTALL_DIR)"
-	@$(INSTALL_PROGRAM) -m +rx packaging/linux/openra-d2k-server "$(BIN_INSTALL_DIR)"
-	@-$(RM) packaging/linux/openra-ra-server packaging/linux/openra-cnc-server packaging/linux/openra-d2k-server packaging/linux/openra-server.debug.in
+	@$(INSTALL_PROGRAM) -m +rx packaging/linux/openra-ra-server-$(VERSION) "$(BIN_INSTALL_DIR)"
+	@$(INSTALL_PROGRAM) -m +rx packaging/linux/openra-cnc-server-$(VERSION) "$(BIN_INSTALL_DIR)"
+	@$(INSTALL_PROGRAM) -m +rx packaging/linux/openra-d2k-server-$(VERSION) "$(BIN_INSTALL_DIR)"
+	@-$(RM) packaging/linux/openra-ra-server-$(VERSION) packaging/linux/openra-cnc-server-$(VERSION) packaging/linux/openra-d2k-server-$(VERSION) packaging/linux/openra-server.debug.in
 
 uninstall:
 	@-$(RM_R) "$(DATA_INSTALL_DIR)"
-	@-$(RM_F) "$(BIN_INSTALL_DIR)/openra-ra"
-	@-$(RM_F) "$(BIN_INSTALL_DIR)/openra-ra-server"
-	@-$(RM_F) "$(BIN_INSTALL_DIR)/openra-cnc"
-	@-$(RM_F) "$(BIN_INSTALL_DIR)/openra-cnc-server"
-	@-$(RM_F) "$(BIN_INSTALL_DIR)/openra-d2k"
-	@-$(RM_F) "$(BIN_INSTALL_DIR)/openra-d2k-server"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/applications/openra-ra.desktop"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/applications/openra-cnc.desktop"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/applications/openra-d2k.desktop"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/applications/openra-ra-join-servers.desktop"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/applications/openra-cnc-join-servers.desktop"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/applications/openra-d2k-join-servers.desktop"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/16x16/apps/openra-ra.png"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/32x32/apps/openra-ra.png"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/48x48/apps/openra-ra.png"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/64x64/apps/openra-ra.png"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/128x128/apps/openra-ra.png"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/16x16/apps/openra-cnc.png"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/32x32/apps/openra-cnc.png"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/48x48/apps/openra-cnc.png"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/64x64/apps/openra-cnc.png"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/128x128/apps/openra-cnc.png"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/16x16/apps/openra-d2k.png"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/32x32/apps/openra-d2k.png"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/48x48/apps/openra-d2k.png"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/64x64/apps/openra-d2k.png"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/128x128/apps/openra-d2k.png"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/mime/packages/openra.xml"
-	@-$(RM_F) "$(DESTDIR)$(datadir)/appdata/openra.appdata.xml"
-	@-$(RM_F) "$(DESTDIR)$(mandir)/man6/openra.6"
+	@-$(RM_F) "$(BIN_INSTALL_DIR)/openra-ra-$(VERSION)"
+	@-$(RM_F) "$(BIN_INSTALL_DIR)/openra-ra-server-$(VERSION)"
+	@-$(RM_F) "$(BIN_INSTALL_DIR)/openra-cnc-$(VERSION)"
+	@-$(RM_F) "$(BIN_INSTALL_DIR)/openra-cnc-server-$(VERSION)"
+	@-$(RM_F) "$(BIN_INSTALL_DIR)/openra-d2k-$(VERSION)"
+	@-$(RM_F) "$(BIN_INSTALL_DIR)/openra-d2k-server-$(VERSION)"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/applications/openra-ra-$(VERSION).desktop"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/applications/openra-cnc-$(VERSION).desktop"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/applications/openra-d2k-$(VERSION).desktop"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/applications/openra-ra-join-servers-$(VERSION).desktop"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/applications/openra-cnc-join-servers-$(VERSION).desktop"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/applications/openra-d2k-join-servers-$(VERSION).desktop"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/16x16/apps/openra-ra-$(VERSION).png"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/32x32/apps/openra-ra-$(VERSION).png"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/48x48/apps/openra-ra-$(VERSION).png"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/64x64/apps/openra-ra-$(VERSION).png"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/128x128/apps/openra-ra-$(VERSION).png"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/16x16/apps/openra-cnc-$(VERSION).png"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/32x32/apps/openra-cnc-$(VERSION).png"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/48x48/apps/openra-cnc-$(VERSION).png"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/64x64/apps/openra-cnc-$(VERSION).png"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/128x128/apps/openra-cnc-$(VERSION).png"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/16x16/apps/openra-d2k-$(VERSION).png"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/32x32/apps/openra-d2k-$(VERSION).png"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/48x48/apps/openra-d2k-$(VERSION).png"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/64x64/apps/openra-d2k-$(VERSION).png"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/icons/hicolor/128x128/apps/openra-d2k-$(VERSION).png"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/mime/packages/openra-$(VERSION).xml"
+	@-$(RM_F) "$(DESTDIR)$(datadir)/appdata/openra-$(VERSION).appdata.xml"
+	@-$(RM_F) "$(DESTDIR)$(mandir)/man6/openra-$(VERSION).6"
 
 help:
 	@echo 'to compile, run:'

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ endif
 
 ######################### UTILITIES/SETTINGS ###########################
 #
-VERSION     = $(shell git name-rev --name-only --tags --no-undefined HEAD 2>/dev/null || echo git-`git rev-parse --short HEAD`)
+VERSION = $(shell git name-rev --name-only --tags --no-undefined HEAD 2>/dev/null || echo git-`git rev-parse --short HEAD`)
 
 # install locations
 prefix ?= /usr/local
@@ -385,6 +385,7 @@ install-core: install-engine install-common-mod-files install-default-mods
 install-linux-icons:
 	@$(INSTALL_DIR) "$(DESTDIR)$(datadir)/icons/"
 	@$(CP_R) packaging/linux/hicolor "$(DESTDIR)$(datadir)/icons/"
+	@find "$(DESTDIR)$(datadir)/icons/" -type f -exec rename 's|openra-(.*)\.(.*)|openra-$$1-'"$(VERSION)"'.$$2|' {} +
 
 install-linux-desktop:
 	@$(INSTALL_DIR) "$(DESTDIR)$(datadir)/applications"
@@ -409,7 +410,7 @@ install-linux-mime:
 	@$(INSTALL_DATA) packaging/linux/openra-cnc-join-servers-$(VERSION).desktop "$(DESTDIR)$(datadir)/applications"
 	@sed 's/{MOD}/d2k/g' packaging/linux/openra-join-servers.desktop.in | sed 's/{MODNAME}/Dune 2000/g' | sed 's/{TAG}/$(VERSION)/g' > packaging/linux/openra-d2k-join-servers-$(VERSION).desktop
 	@$(INSTALL_DATA) packaging/linux/openra-d2k-join-servers-$(VERSION).desktop "$(DESTDIR)$(datadir)/applications"
-	@-$(RM) packaging/linux/openra-$(VERSION)-mimeinfo.xml packaging/linux/openra-ra-join-servers-$(VERSION).desktop packaging/linux/openra-cnc-join-servers-$(VERSION).desktop packaging/linux/openra-d2k-join-servers-$(VERSION).desktop
+	@-$(RM) packaging/linux/openra-mimeinfo.xml packaging/linux/openra-ra-join-servers-$(VERSION).desktop packaging/linux/openra-cnc-join-servers-$(VERSION).desktop packaging/linux/openra-d2k-join-servers-$(VERSION).desktop
 
 install-linux-appdata:
 	@$(INSTALL_DIR) "$(DESTDIR)$(datadir)/appdata/"

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -38,7 +38,7 @@ make install-man-page prefix="/usr" DESTDIR="${BUILTDIR}"
 popd > /dev/null
 
 # Documentation
-DOCSDIR="${BUILTDIR}/usr/share/doc/openra/"
+DOCSDIR="${BUILTDIR}/usr/share/doc/openra-${TAG}/"
 
 mkdir -p "${DOCSDIR}"
 
@@ -56,5 +56,4 @@ if [ $? -ne 0 ]; then
     echo "Debian package build failed."
 fi
 popd >/dev/null
-
 rm -rf "${BUILTDIR}"

--- a/packaging/linux/deb/DEBIAN/control
+++ b/packaging/linux/deb/DEBIAN/control
@@ -1,4 +1,4 @@
-Package: openra
+Package: openra-{TAG}
 Version: {VERSION}
 Architecture: all
 Maintainer: Paul Chote <paul@chote.net>

--- a/packaging/linux/deb/DEBIAN/control.virtual
+++ b/packaging/linux/deb/DEBIAN/control.virtual
@@ -1,0 +1,18 @@
+Package: openra{SUFFIX}
+Version: {VERSION}
+Architecture: all
+Maintainer: Paul Chote <paul@chote.net>
+Installed-Size: 0
+Depends: openra-{TAG}
+Section: games
+Priority: extra
+Homepage: http://www.openra.net/
+Description: Multiplayer re-envisioning of early RTS games by Westwood Studios
+ OpenRA is a Libre/Free Real Time Strategy game engine supporting early
+ Westwood games like Command & Conquer and Command & Conquer: Red Alert.
+ The engine is designed from the ground up to be extremely moddable and
+ natively supports user-created maps and mods.
+ .
+ Support can be obtained from our IRC channel (#openra on irc.freenode.net),
+ our forum (http://www.sleipnirstuff.com/forum/viewforum.php?f=80), and our
+ bug tracker (http://bugs.openra.net).

--- a/packaging/linux/deb/DEBIAN/postinst
+++ b/packaging/linux/deb/DEBIAN/postinst
@@ -3,9 +3,9 @@ set -e
 
 # Register default mods for in-game switching
 mkdir -p "{SYSTEMSUPPORTDIR}/ModMetadata"
-mono {LIBDIR}/OpenRA.Utility.exe ra --register-mod /usr/games/openra-ra system
-mono {LIBDIR}/OpenRA.Utility.exe cnc --register-mod /usr/games/openra-cnc system
-mono {LIBDIR}/OpenRA.Utility.exe d2k --register-mod /usr/games/openra-d2k system
+mono {LIBDIR}/OpenRA.Utility.exe ra --register-mod /usr/games/openra-ra-{TAG} system
+mono {LIBDIR}/OpenRA.Utility.exe cnc --register-mod /usr/games/openra-cnc-{TAG} system
+mono {LIBDIR}/OpenRA.Utility.exe d2k --register-mod /usr/games/openra-d2k-{TAG} system
 
 # Register using update-alternatives
 update-alternatives --install /usr/games/openra-ra{SUFFIX} openra-ra{SUFFIX} /usr/games/openra-ra-{TAG} {PRIORITY} \

--- a/packaging/linux/deb/DEBIAN/postinst
+++ b/packaging/linux/deb/DEBIAN/postinst
@@ -6,3 +6,11 @@ mkdir -p "{SYSTEMSUPPORTDIR}/ModMetadata"
 mono {LIBDIR}/OpenRA.Utility.exe ra --register-mod /usr/games/openra-ra system
 mono {LIBDIR}/OpenRA.Utility.exe cnc --register-mod /usr/games/openra-cnc system
 mono {LIBDIR}/OpenRA.Utility.exe d2k --register-mod /usr/games/openra-d2k system
+
+# Register using update-alternatives
+update-alternatives --install /usr/games/openra-ra{SUFFIX} openra-ra{SUFFIX} /usr/games/openra-ra-{TAG} {PRIORITY} \
+                      --slave /usr/games/openra-cnc{SUFFIX} openra-cnc{SUFFIX} /usr/games/openra-cnc-{TAG} \
+		      --slave /usr/games/openra-d2k{SUFFIX} openra-d2k{SUFFIX} /usr/games/openra-d2k-{TAG} \
+                      --slave /usr/games/openra-ra-server{SUFFIX} openra-ra-server{SUFFIX} /usr/games/openra-ra-server-{TAG} \
+                      --slave /usr/games/openra-cnc-server{SUFFIX} openra-cnc-server{SUFFIX} /usr/games/openra-cnc-server-{TAG} \
+		      --slave /usr/games/openra-d2k-server{SUFFIX} openra-d2k-server{SUFFIX} /usr/games/openra-d2k-server-{TAG}

--- a/packaging/linux/deb/DEBIAN/prerm
+++ b/packaging/linux/deb/DEBIAN/prerm
@@ -4,3 +4,6 @@ set -e
 mono {LIBDIR}/OpenRA.Utility.exe ra --unregister-mod system
 mono {LIBDIR}/OpenRA.Utility.exe cnc --unregister-mod system
 mono {LIBDIR}/OpenRA.Utility.exe d2k --unregister-mod system
+
+# Unregister the whole group from update-alternatives
+update-alternatives --remove openra-ra{SUFFIX} /usr/games/openra-ra-{TAG}

--- a/packaging/linux/deb/buildpackage.sh
+++ b/packaging/linux/deb/buildpackage.sh
@@ -19,8 +19,8 @@ OUTPUTDIR="${3}"
 
 DEB_BUILD_ROOT="$(pwd)/build"
 
-LIBDIR=/usr/lib/openra
-DOCDIR=/usr/share/doc/openra
+LIBDIR=/usr/lib/openra-${TAG}
+DOCDIR=/usr/share/doc/openra-${TAG}
 SYSTEMSUPPORTDIR=/var/games/openra
 LINTIANORDIR=/usr/share/lintian/overrides
 E_BADARGS=85
@@ -39,17 +39,17 @@ chmod 0644 "${DEB_BUILD_ROOT}/${LIBDIR}/"*/**/*.dll
 
 # Binaries go in /usr/games
 mv "${DEB_BUILD_ROOT}/usr/bin/" "${DEB_BUILD_ROOT}/usr/games/"
-sed "s|/usr/bin|/usr/games|g" "${DEB_BUILD_ROOT}/usr/games/openra-ra" > temp
-mv -f temp "${DEB_BUILD_ROOT}/usr/games/openra-ra"
-sed "s|/usr/bin|/usr/games|g" "${DEB_BUILD_ROOT}/usr/games/openra-cnc" > temp
-mv -f temp "${DEB_BUILD_ROOT}/usr/games/openra-cnc"
-sed "s|/usr/bin|/usr/games|g" "${DEB_BUILD_ROOT}/usr/games/openra-d2k" > temp
-mv -f temp "${DEB_BUILD_ROOT}/usr/games/openra-d2k"
+sed "s|/usr/bin|/usr/games|g" "${DEB_BUILD_ROOT}/usr/games/openra-ra-${TAG}" > temp
+mv -f temp "${DEB_BUILD_ROOT}/usr/games/openra-ra-${TAG}"
+sed "s|/usr/bin|/usr/games|g" "${DEB_BUILD_ROOT}/usr/games/openra-cnc-${TAG}" > temp
+mv -f temp "${DEB_BUILD_ROOT}/usr/games/openra-cnc-${TAG}"
+sed "s|/usr/bin|/usr/games|g" "${DEB_BUILD_ROOT}/usr/games/openra-d2k-${TAG}" > temp
+mv -f temp "${DEB_BUILD_ROOT}/usr/games/openra-d2k-${TAG}"
 
 chmod 0755 "${DEB_BUILD_ROOT}/usr/games/openra"*
 
 # Compress the man page
-gzip -9n "${DEB_BUILD_ROOT}/usr/share/man/man6/openra.6"
+gzip -9n "${DEB_BUILD_ROOT}/usr/share/man/man6/openra-${TAG}.6"
 
 # Put the copyright and changelog in /usr/share/doc/openra/
 mkdir -p "${DEB_BUILD_ROOT}/${DOCDIR}"
@@ -60,9 +60,9 @@ DATE=`date -R`
 
 # Put the lintian overrides in /usr/share/lintian/overrides/
 mkdir -p "${DEB_BUILD_ROOT}/${LINTIANORDIR}"
-cp openra.lintian-overrides "${DEB_BUILD_ROOT}/${LINTIANORDIR}/openra"
+cp openra.lintian-overrides "${DEB_BUILD_ROOT}/${LINTIANORDIR}/openra-${TAG}"
 
-echo -e "openra (${VERSION}) unstable; urgency=low\n" > "${DEB_BUILD_ROOT}/${DOCDIR}/changelog"
+echo -e "openra-${TAG} (${VERSION}) unstable; urgency=low\n" > "${DEB_BUILD_ROOT}/${DOCDIR}/changelog"
 echo -e "  * New upstream release: $TAG" >> "${DEB_BUILD_ROOT}/${DOCDIR}/changelog"
 echo -e "\n -- Paul Chote <paul@chote.net>  ${DATE}" >> "${DEB_BUILD_ROOT}/${DOCDIR}/changelog"
 gzip -9 "${DEB_BUILD_ROOT}/${DOCDIR}/changelog"
@@ -75,12 +75,12 @@ chmod -R g-w "${DEB_BUILD_ROOT}"
 # Create the control file
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	# BSD du doesn't have an --apparent-size flag, so we must accept a different result
-	PACKAGE_SIZE=`du -c "${DEB_BUILD_ROOT}/usr" | grep "total" | awk '{print $1}'`
+	PACKAGE_SIZE=`LC_ALL=C du -c "${DEB_BUILD_ROOT}/usr" | grep "total" | awk '{print $1}'`
 else
-	PACKAGE_SIZE=`du --apparent-size -c "${DEB_BUILD_ROOT}/usr" | grep "total" | awk '{print $1}'`
+	PACKAGE_SIZE=`LC_ALL=C du --apparent-size -c "${DEB_BUILD_ROOT}/usr" | grep "total" | awk '{print $1}'`
 fi
 
-sed "s/{VERSION}/${VERSION}/" DEBIAN/control | sed "s/{SIZE}/${PACKAGE_SIZE}/" > "${DEB_BUILD_ROOT}/DEBIAN/control"
+sed "s/{VERSION}/${VERSION}/" DEBIAN/control | sed "s/{SIZE}/${PACKAGE_SIZE}/" | sed "s/{TAG}/${TAG}/" > "${DEB_BUILD_ROOT}/DEBIAN/control"
 sed "s|{LIBDIR}|${LIBDIR}|g" DEBIAN/postinst | sed "s|{SYSTEMSUPPORTDIR}|${SYSTEMSUPPORTDIR}|g" > "${DEB_BUILD_ROOT}/DEBIAN/postinst"
 sed "s|{LIBDIR}|${LIBDIR}|g" DEBIAN/prerm | sed "s|{SYSTEMSUPPORTDIR}|${SYSTEMSUPPORTDIR}|g" > "${DEB_BUILD_ROOT}/DEBIAN/prerm"
 chmod 0755 "${DEB_BUILD_ROOT}/DEBIAN/postinst" "${DEB_BUILD_ROOT}/DEBIAN/prerm"
@@ -92,16 +92,16 @@ pushd "${DEB_BUILD_ROOT}" >/dev/null
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	find . -type f -not -path "./DEBIAN/*" -print0 | xargs -0 -n1 openssl md5 | awk '{ print $2, substr($1, 7, length($1)-8) }' > DEBIAN/md5sums
 else
-	find . -type f -not -path "./DEBIAN/*" -print0 | xargs -0 -n1 md5sum | sed 's|\./usr/|usr/|' > DEBIAN/md5sums	
+	find . -type f -not -path "./DEBIAN/*" -print0 | xargs -0 -n1 md5sum | sed 's|\./usr/|usr/|' > DEBIAN/md5sums
 fi
- 
+
 chmod 0644 DEBIAN/md5sums
 
 # Replace any dashes in the version string with periods
 PKGVERSION=`echo ${TAG} | sed "s/-/\\./g"`
 
 # Start building, the file should appear in the output directory
-fakeroot dpkg-deb -b . "${OUTPUTDIR}/openra_${PKGVERSION}_all.deb"
+fakeroot dpkg-deb -b . "${OUTPUTDIR}/openra-${TAG}_${PKGVERSION}_all.deb"
 
 # Clean up
 popd >/dev/null

--- a/packaging/linux/deb/buildpackage.sh
+++ b/packaging/linux/deb/buildpackage.sh
@@ -28,10 +28,11 @@ E_BADARGS=85
 DATE=`echo ${TAG} | grep -o "[0-9]\\+-\\?[0-9]\\?"`
 TYPE=`echo $1 | grep -o "^[a-z]*"`
 VERSION="${DATE}.${TYPE}"
-CHANNEL_SUFFIX="-$(echo $TAG | cut -d- -f1)"
-if [[ "$CHANNEL_SUFFIX" == "-release" ]]; then
+CHANNEL_SUFFIX="-$(echo ${TAG} | cut -d- -f1)"
+if [[ "${CHANNEL_SUFFIX}" == "-release" ]]; then
 	CHANNEL_SUFFIX=""
 fi
+PRIORITY=${DATE}
 
 # Copy template files into a clean build directory (required)
 mkdir "${DEB_BUILD_ROOT}"
@@ -85,8 +86,8 @@ else
 fi
 
 sed "s/{VERSION}/${VERSION}/" DEBIAN/control | sed "s/{SIZE}/${PACKAGE_SIZE}/" | sed "s/{TAG}/${TAG}/" > "${DEB_BUILD_ROOT}/DEBIAN/control"
-sed "s|{LIBDIR}|${LIBDIR}|g" DEBIAN/postinst | sed "s|{SYSTEMSUPPORTDIR}|${SYSTEMSUPPORTDIR}|g" > "${DEB_BUILD_ROOT}/DEBIAN/postinst"
-sed "s|{LIBDIR}|${LIBDIR}|g" DEBIAN/prerm | sed "s|{SYSTEMSUPPORTDIR}|${SYSTEMSUPPORTDIR}|g" > "${DEB_BUILD_ROOT}/DEBIAN/prerm"
+sed "s|{LIBDIR}|${LIBDIR}|g" DEBIAN/postinst | sed "s|{SYSTEMSUPPORTDIR}|${SYSTEMSUPPORTDIR}|g" | sed "s/{TAG}/${TAG}/" | sed "s/{SUFFIX}/${CHANNEL_SUFFIX}/g" | sed "s/{PRIORITY}/${PRIORITY}/g" > "${DEB_BUILD_ROOT}/DEBIAN/postinst"
+sed "s|{LIBDIR}|${LIBDIR}|g" DEBIAN/prerm | sed "s|{SYSTEMSUPPORTDIR}|${SYSTEMSUPPORTDIR}|g" | sed "s/{TAG}/${TAG}/" | sed "s/{SUFFIX}/${CHANNEL_SUFFIX}/g" | sed "s/{PRIORITY}/${PRIORITY}/g" > "${DEB_BUILD_ROOT}/DEBIAN/prerm"
 chmod 0755 "${DEB_BUILD_ROOT}/DEBIAN/postinst" "${DEB_BUILD_ROOT}/DEBIAN/prerm"
 
 # Build it in the temp directory, but place the finished deb in our starting directory

--- a/packaging/linux/openra-join-servers.desktop.in
+++ b/packaging/linux/openra-join-servers.desktop.in
@@ -1,12 +1,12 @@
 [Desktop Entry]
 Type=Application
 Version=1.0
-Name=OpenRA - {MODNAME}
+Name=OpenRA - {MODNAME} ({TAG})
 GenericName=Real Time Strategy Game
 GenericName[de]=Echtzeit-Strategiespiel
 Comment=Reimagining of early Westwood Games
-Icon=openra-{MOD}
-Exec=openra-{MOD} Launch.URI=%U
+Icon=openra-{MOD}-{TAG}
+Exec=openra-{MOD}-{TAG} Launch.URI=%U
 Terminal=false
 NoDisplay=true
 Categories=Game;StrategyGame;

--- a/packaging/linux/openra.appdata.xml
+++ b/packaging/linux/openra.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>openra.desktop</id>
+  <id>openra-{TAG}.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0</project_license>
   <name>OpenRA</name>

--- a/packaging/linux/openra.desktop.in
+++ b/packaging/linux/openra.desktop.in
@@ -1,11 +1,11 @@
 [Desktop Entry]
 Type=Application
 Version=1.0
-Name=OpenRA - {MODNAME}
+Name=OpenRA - {MODNAME} ({TAG})
 GenericName=Real Time Strategy Game
 GenericName[de]=Echtzeit-Strategiespiel
 Comment=Reimagining of early Westwood Games
-Icon=openra-{MOD}
-Exec=openra-{MOD}
+Icon=openra-{MOD}-{TAG}
+Exec=openra-{MOD}-{TAG}
 Terminal=false
 Categories=Game;StrategyGame;

--- a/packaging/linux/openra.in
+++ b/packaging/linux/openra.in
@@ -1,7 +1,7 @@
 #!/bin/sh
 cd "{GAME_INSTALL_DIR}"
 
-mono {DEBUG} OpenRA.Game.exe Game.Mod={MOD} Engine.LaunchPath="{BIN_DIR}/openra-{MOD}" "$@"
+mono {DEBUG} OpenRA.Game.exe Game.Mod={MOD} Engine.LaunchPath="{BIN_DIR}/openra-{MOD}-{TAG}" "$@"
 
 # Show a crash dialog if required
 if [ $? != 0 ] && [ $? != 1 ]


### PR DESCRIPTION
This should allow the usage of multiple releases and playtests on dpkg based systems simultaneously.