### PR TITLE
Add a selection priority of 6 to supply trucks

### DIFF
--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -597,6 +597,8 @@ TDTRUK:
 		Cost: 500
 	Tooltip:
 		Name: Supply Truck
+	Selectable:
+		Priority: 6
 	Health:
 		HP: 110
 	Armor:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -468,6 +468,8 @@ TRUK:
 		Cost: 500
 	Tooltip:
 		Name: Supply Truck
+	Selectable:
+		Priority: 6
 	Health:
 		HP: 110
 	Armor:


### PR DESCRIPTION
Otherwise they get selected by the `Select all combat units` key as reported on discord.