### PR TITLE
[RA] War Factory quicker production cap and Barracks price increase.

### DIFF
--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -18,6 +18,7 @@ Player:
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		SpeedUp: True
+		BuildTimeSpeedReduction: 100, 75, 60, 50
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
 		LowPowerSlowdown: 3

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1527,7 +1527,7 @@ BARR:
 		Prerequisites: anypower, ~structures.soviet, ~techlevel.infonly
 		Description: Trains infantry.
 	Valued:
-		Cost: 400
+		Cost: 500
 	Tooltip:
 		Name: Soviet Barracks
 	Building:
@@ -1656,7 +1656,7 @@ TENT:
 		Prerequisites: anypower, ~structures.allies, ~techlevel.infonly
 		Description: Trains infantry.
 	Valued:
-		Cost: 400
+		Cost: 500
 	Tooltip:
 		Name: Allied Barracks
 	Building:


### PR DESCRIPTION
Following #13640 

- Barracks: Price $500, up from $400
- War Factory: Production caps at 4 structures (100, 75, 60, 50) instead of 7 (100, 85, 75, 65, 60, 55, 50).

I initially on #13640 to keep away from balance changes that could jeopardize the playtesting of the Hitshape/UnitStance changes but after some deliberations I believe it's worth adding to the playtest a couple more changes from the playtest series.

The barracks price increase isn't really new, was added onto the experimental series and has more or less been anticipated by the playing community and hailed as a step in the right direction. With the UnitStance the Barracks loses an additional role as a damage soaker so I thought of hold of the change but the reward of putting a dent on to the infantry production makes the change worth doing still.

The War Factory cap being the most intriguing change of the two was introduced to the v1.6 playtest series right off the bat as a 'work or die' feature that after hundreds of games ended up as a background feature - meaning it doesn't really add to the game until mid-late game or in big team games. Initially players attempted to take advantage of the 2nd War Factory reducing production time early by 25% in order to execute new aggressive strategies, however quickly faded as the expansion and tech route inevitable dominated it. The super fast tank/vehicle rushes (e.g. 9 second Light Tanks with 4 WF's!) just don't happen. Thus it ended up as a feature I initially hoped for, although less prevalent, as an option later in the game that expands the range of strategies.

In addition to that the $2000 War Factory never really gets to have its production time for its units decreased as its pricing makes additional structures very low priority throughout all matches. This is not the case for all other production queues including building production where the MCV production despite being expensive, is well integrated in the meta and part of just about every strategy. As for the reduction values themselves they're really just the 1st,3rd,5th,7th value of the original 7-steps reduction values for the rest of the production decrease.