### PR TITLE
Fix TD airfield targetable positions

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -343,7 +343,7 @@ HAND:
 AFLD:
 	Inherits: ^BaseBuilding
 	HitShape:
-		TargetableOffsets: 0,0,0, 0,-512,256, 0,-1536,256
+		TargetableOffsets: 0,0,0, 0,-512,256, 0,-1451,384, 0,512,128, 0,1536,85
 		Type: Rectangle
 			TopLeft: -2048, -1024
 			BottomRight: 2048, 1024
@@ -359,7 +359,7 @@ AFLD:
 		Queue: Building.Nod
 		Description: Provides a dropzone\nfor vehicle reinforcements
 	Building:
-		Footprint: xxXX xxxx ====
+		Footprint: XXXX xxxx ====
 		Dimensions: 4,3
 		LocalCenterOffset: 0,-512,0
 	Health:


### PR DESCRIPTION
Looks like there was one of these last-minute changes that nobody - including myself - tested properly.

Old:
![afld-old-pos](https://user-images.githubusercontent.com/2857877/28465758-39582662-6e2a-11e7-9bf8-7c5f27c5a2ff.png)

New:
![afld-new-pos](https://user-images.githubusercontent.com/2857877/28465760-3e4722a4-6e2a-11e7-828b-099bb8f4f24c.png)

