### PR TITLE
Add ArmorTypes to HitShape

### DIFF
--- a/OpenRA.Mods.Common/Traits/HitShape.cs
+++ b/OpenRA.Mods.Common/Traits/HitShape.cs
@@ -25,6 +25,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Create a targetable position at the center of each occupied cell. Stacks with TargetableOffsets.")]
 		public readonly bool UseTargetableCellsOffsets = false;
 
+		[Desc("Defines which Armor types apply when the actor receives damage to this HitShape.",
+			"If none specified, all armor types the actor has are valid.")]
+		public readonly HashSet<string> ArmorTypes = new HashSet<string>();
+
 		[FieldLoader.LoadUsing("LoadShape")]
 		public readonly IHitShape Type;
 

--- a/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
@@ -35,6 +35,9 @@ namespace OpenRA.Mods.Common.Warheads
 			return base.IsValidAgainst(victim, firedBy);
 		}
 
+		/// <summary>
+		/// Apply damage modifiers of all enabled Armor traits the actor has.
+		/// </summary>
 		public int DamageVersus(Actor victim)
 		{
 			var armor = victim.TraitsImplementing<Armor>()
@@ -44,6 +47,10 @@ namespace OpenRA.Mods.Common.Warheads
 			return Util.ApplyPercentageModifiers(100, armor);
 		}
 
+		/// <summary>
+		/// In this DamageVersus overload, we only want to apply Armor modifiers that are listed
+		/// in ArmorTypes of the HitShape the warhead landed in.
+		/// </summary>
 		public int DamageVersus(Actor victim, HitShapeInfo shape)
 		{
 			var armor = victim.TraitsImplementing<Armor>()
@@ -74,6 +81,9 @@ namespace OpenRA.Mods.Common.Warheads
 			victim.InflictDamage(firedBy, new Damage(damage, DamageTypes));
 		}
 
+		/// <summary>
+		/// Only apply modifiers valid for a specific HitShape trait.
+		/// </summary>
 		public virtual void DoImpact(Actor victim, Actor firedBy, HitShapeInfo shape, IEnumerable<int> damageModifiers)
 		{
 			if (!IsValidAgainst(victim, firedBy))

--- a/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
@@ -43,12 +43,20 @@ namespace OpenRA.Mods.Common.Warheads
 			if (!IsValidAgainst(victim, firedBy))
 				return;
 
+			// Cannot be damaged without a Health trait
 			var healthInfo = victim.Info.TraitInfoOrDefault<HealthInfo>();
 			if (healthInfo == null)
 				return;
 
+			var closestActiveShape = victim.TraitsImplementing<HitShape>().Where(Exts.IsTraitEnabled)
+				.MinByOrDefault(t => t.Info.Type.DistanceFromEdge(victim.CenterPosition, victim));
+
+			// Cannot be damaged without an active HitShape
+			if (closestActiveShape == null)
+				return;
+
 			// Damage is measured as a percentage of the target health
-			var damage = Util.ApplyPercentageModifiers(healthInfo.HP, damageModifiers.Append(Damage, DamageVersus(victim)));
+			var damage = Util.ApplyPercentageModifiers(healthInfo.HP, damageModifiers.Append(Damage, DamageVersus(victim, closestActiveShape.Info)));
 			victim.InflictDamage(firedBy, new Damage(damage, DamageTypes));
 		}
 	}

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -65,8 +65,7 @@ namespace OpenRA.Mods.Common.Warheads
 			foreach (var victim in hitActors)
 			{
 				// Cannot be damaged without a Health trait
-				var healthInfo = victim.Info.TraitInfoOrDefault<HealthInfo>();
-				if (healthInfo == null)
+				if (!victim.Info.HasTraitInfo<HealthInfo>())
 					continue;
 
 				// Cannot be damaged without an active HitShape
@@ -74,10 +73,11 @@ namespace OpenRA.Mods.Common.Warheads
 				if (!activeShapes.Any())
 					continue;
 
-				var distance = activeShapes.Min(t => t.Info.Type.DistanceFromEdge(pos, victim));
+				var closestActiveShape = activeShapes.MinBy(t => t.Info.Type.DistanceFromEdge(pos, victim));
+				var distance = closestActiveShape.Info.Type.DistanceFromEdge(pos, victim);
 				var localModifiers = damageModifiers.Append(GetDamageFalloff(distance.Length));
 
-				DoImpact(victim, firedBy, localModifiers);
+				DoImpact(victim, firedBy, closestActiveShape.Info, localModifiers);
 			}
 		}
 


### PR DESCRIPTION
This allows to assign Armor traits to specific HitShapes, allowing to make certain parts of actors more vulnerable or durable than others.
Can also be used to simulate directional armor in a good-enough way that this closes #7718.

Testcase can be found here: https://github.com/reaperrr/OpenRA/tree/hitshape-armor-test

Closes #9268