### PR TITLE
Use strafing for RA Yak - 2nd attempt

### DIFF
--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -164,12 +164,12 @@ YAK:
 		Range: 9c0
 		Type: GroundPosition
 	Armament@PRIMARY:
-		Weapon: ChainGun.Yak
+		Weapon: ChainGun.Yak.Left
 		LocalOffset: 256,-213,0
 		MuzzleSequence: muzzle
 	Armament@SECONDARY:
 		Name: secondary
-		Weapon: ChainGun.Yak
+		Weapon: ChainGun.Yak.Right
 		LocalOffset: 256,213,0
 		MuzzleSequence: muzzle
 	AttackPlane:
@@ -186,9 +186,9 @@ YAK:
 		TargetWhenDamaged: false
 		EnableStances: false
 	AmmoPool:
-		Ammo: 18
-		PipCount: 6
-		ReloadDelay: 11
+		Ammo: 20
+		PipCount: 5
+		ReloadDelay: 10
 	ReturnOnIdle:
 	SelectionDecorations:
 		VisualBounds: 30,28,0,2

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -204,15 +204,28 @@ ChainGun:
 		Versus:
 			None: 120
 
-ChainGun.Yak:
+ChainGun.Yak.Right:
 	Inherits: ^HeavyMG
-	ReloadDelay: 3
+	Burst: 5
+	FirstBurstTargetOffset: -512,213,0
+	FollowingBurstTargetOffset: 256,0,0
+	BurstDelay: 2
+	ReloadDelay: 10
 	Range: 5c0
 	MinRange: 3c0
 	Projectile: Bullet
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Damage: 40
+		Spread: 171
+		Versus:
+			None: 125
+			Light: 70
+			Heavy: 28
+
+ChainGun.Yak.Left:
+	Inherits: ChainGun.Yak.Right
+	FirstBurstTargetOffset: -512,-213,0
 
 Pistol:
 	Inherits: ^LightMG


### PR DESCRIPTION
The primary (balancing) issue of the first attempt was that syncing the impact offsets with the Yak's speed - to replicate the original game's behavior - resulted in too large gaps between shots, reducing pin-point damage too much.

The original behavior was not necessarily realistic either, since Yaks would have to tip their nose to shoot at ground targets, which would result in more 'compressed' impact range as well.

For now, I've made the damage more focused by reducing the distance between impacts from 342 to 256 WDist (about 2 pixels vertically or horizontally on the map), which - combined with the other damage tweaks I previously made - just might be enough already.

I was able to kill two artilleries in a row with some quick clicking on the 2nd.

This might need further fine-tuning of course, but by no longer sticking to 100%-RA1 style strafing, balancing this properly should be doable.