### PR TITLE
[RA] Revert 4 cell adjacency of Kennel/Silo back to 2.

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1162,7 +1162,7 @@ SILO:
 	Tooltip:
 		Name: Silo
 	Building:
-		Adjacent: 4
+		Adjacent: 2
 	-GivesBuildableArea:
 	Health:
 		HP: 300
@@ -1609,7 +1609,7 @@ KENN:
 	Tooltip:
 		Name: Kennel
 	Building:
-		Adjacent: 4
+		Adjacent: 2
 	-GivesBuildableArea:
 	Health:
 		HP: 300


### PR DESCRIPTION
Fixes #13656

Unforeseen consequence of #13640. The change was supposed to add a level of convenience but risks distorting maps that depend on players not having access to certain part of the maps. E.g. Kennel granting the dog access to restricted areas. Silo having the feature standalone is probably unwanted.