### PR TITLE
Remove TargetWhenIdle and TargetWhenDamaged from AutoTarget

### DIFF
--- a/mods/cnc/maps/gdi06/rules.yaml
+++ b/mods/cnc/maps/gdi06/rules.yaml
@@ -74,8 +74,8 @@ RMBO:
 	MustBeDestroyed:
 		RequiredForShortGame: true
 	AutoTarget:
-		TargetWhenIdle: false
-		TargetWhenDamaged: true
+		EnableStances: false
+		InitialStance: ReturnFire
 	Health:
 		HP: 150
 

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -117,9 +117,8 @@ MIG:
 		RepulsionSpeed: 40
 		MaximumPitch: 56
 	AutoTarget:
-		TargetWhenIdle: false
-		TargetWhenDamaged: false
-		EnableStances: false
+		InitialStance: HoldFire
+		InitialStanceAI: HoldFire
 	AmmoPool:
 		Ammo: 8
 	ReturnOnIdle:
@@ -182,9 +181,8 @@ YAK:
 		RepulsionSpeed: 40
 		MaximumPitch: 56
 	AutoTarget:
-		TargetWhenIdle: false
-		TargetWhenDamaged: false
-		EnableStances: false
+		InitialStance: HoldFire
+		InitialStanceAI: HoldFire
 	AmmoPool:
 		Ammo: 18
 		PipCount: 6


### PR DESCRIPTION
Those were just bogus/unnecessary and are now replaced by using `InitialStance` (and `EnableStances: false`).