### PR TITLE
Add support for named Button hotkeys

### DIFF
--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -273,6 +273,10 @@ namespace OpenRA
 
 				return InvalidValueAction(value, fieldType, fieldName);
 			}
+			else if (fieldType == typeof(NamedHotkey))
+			{
+				return new NamedHotkey(value, Game.Settings.Keys);
+			}
 			else if (fieldType == typeof(WDist))
 			{
 				WDist res;

--- a/OpenRA.Game/Input/NamedHotkey.cs
+++ b/OpenRA.Game/Input/NamedHotkey.cs
@@ -1,0 +1,49 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+
+namespace OpenRA
+{
+	/// <summary>
+	/// A reference to either a named hotkey (defined in the game settings) or a statically assigned hotkey
+	/// </summary>
+	public class NamedHotkey
+	{
+		static readonly Func<Hotkey> Invalid = () => Hotkey.Invalid;
+
+		readonly Func<Hotkey> getValue;
+
+		public NamedHotkey()
+		{
+			getValue = Invalid;
+		}
+
+		public NamedHotkey(string name, KeySettings settings)
+		{
+			// Try parsing the value as a reference to a named hotkey
+			getValue = settings.GetHotkeyReference(name);
+
+			if (getValue == null)
+			{
+				// Try parsing the value as a normal (static) hotkey
+				var staticKey = Hotkey.Invalid;
+				Hotkey.TryParse(name, out staticKey);
+				getValue = () => staticKey;
+			}
+		}
+
+		public Hotkey GetValue()
+		{
+			return getValue();
+		}
+	}
+}

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -223,6 +223,7 @@
     <Compile Include="Input\InputHandler.cs" />
     <Compile Include="Input\Keycode.cs" />
     <Compile Include="Input\Hotkey.cs" />
+    <Compile Include="Input\NamedHotkey.cs" />
     <Compile Include="Graphics\PlatformInterfaces.cs" />
     <Compile Include="Sound\Sound.cs" />
     <Compile Include="Sound\SoundDevice.cs" />

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -306,6 +306,15 @@ namespace OpenRA
 				Expression.Field(keySettings, "{0}{1:D2}Key".F(prefix, i + 1)), keySettings).Compile());
 		}
 
+		internal Func<Hotkey> GetHotkeyReference(string name)
+		{
+			var field = typeof(KeySettings).GetField(name + "Key");
+			if (field == null)
+				return null;
+
+			return () => (Hotkey)field.GetValue(this);
+		}
+
 		public Hotkey GetProductionHotkey(int index)
 		{
 			return GetKey(ProductionKeys, index);

--- a/OpenRA.Mods.Common/Lint/CheckChromeHotkeys.cs
+++ b/OpenRA.Mods.Common/Lint/CheckChromeHotkeys.cs
@@ -1,0 +1,69 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using OpenRA.Mods.Common.Widgets;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Lint
+{
+	class CheckChromeHotkeys : ILintPass
+	{
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData)
+		{
+			// Build the list of valid key names
+			// For now they are hardcoded, but this will change.
+			var namedKeys = typeof(KeySettings).GetFields()
+				.Where(x => x.Name.EndsWith("Key", StringComparison.Ordinal))
+				.Select(x => x.Name.Substring(0, x.Name.Length - 3))
+				.ToArray();
+
+			// Build the list of widget keys to validate
+			var checkWidgetFields = modData.ObjectCreator.GetTypesImplementing<Widget>()
+				.SelectMany(w => w.GetFields()
+					.Where(f => f.FieldType == typeof(NamedHotkey))
+					.Select(f => Pair.New(w.Name.Substring(0, w.Name.Length - 6), f.Name)))
+				.ToArray();
+
+			foreach (var filename in modData.Manifest.ChromeLayout)
+				CheckInner(modData, namedKeys, checkWidgetFields, MiniYaml.FromStream(modData.DefaultFileSystem.Open(filename), filename), filename, null, emitError);
+		}
+
+		void CheckInner(ModData modData, string[] namedKeys, Pair<string, string>[] checkWidgetFields,
+			List<MiniYamlNode> nodes, string filename, MiniYamlNode parent, Action<string> emitError)
+		{
+			foreach (var node in nodes)
+			{
+				if (node.Value == null)
+					continue;
+
+				foreach (var x in checkWidgetFields)
+				{
+					if (node.Key == x.Second && parent != null && parent.Key.StartsWith(x.First, StringComparison.Ordinal))
+					{
+						// Keys are valid if they refer to a named key or can be parsed as a regular Hotkey.
+						Hotkey unused;
+						if (!namedKeys.Contains(node.Value.Value) && !Hotkey.TryParse(node.Value.Value, out unused))
+							emitError("{0} refers to a Key named `{1}` that does not exist".F(node.Location, node.Value.Value));
+					}
+				}
+
+				if (node.Value.Nodes != null)
+					CheckInner(modData, namedKeys, checkWidgetFields, node.Value.Nodes, filename, node, emitError);
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -816,6 +816,7 @@
     <Compile Include="Traits\AutoTargetPriority.cs" />
     <Compile Include="Traits\Conditions\GrantConditionOnBotOwner.cs" />
     <Compile Include="Traits\Render\ReloadArmamentsBar.cs" />
+    <Compile Include="Lint\CheckChromeHotkeys.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
@@ -19,14 +19,8 @@ namespace OpenRA.Mods.Common.Widgets
 	{
 		public readonly string TooltipContainer;
 		public readonly string TooltipTemplate = "BUTTON_TOOLTIP";
-		public Func<ButtonWidget, Hotkey> GetKey = _ => Hotkey.Invalid;
 
-		public Hotkey Key
-		{
-			get { return GetKey(this); }
-			set { GetKey = _ => value; }
-		}
-
+		public NamedHotkey Key = new NamedHotkey();
 		public bool DisableKeyRepeat = false;
 		public bool DisableKeySound = false;
 
@@ -136,7 +130,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override bool HandleKeyPress(KeyInput e)
 		{
-			if (Hotkey.FromKeyInput(e) != Key || e.Event != KeyInputEvent.Down || (DisableKeyRepeat && e.IsRepeat))
+			if (Hotkey.FromKeyInput(e) != Key.GetValue() || e.Event != KeyInputEvent.Down || (DisableKeyRepeat && e.IsRepeat))
 				return false;
 
 			if (!IsDisabled())

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -149,7 +149,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var playButton = panel.GetOrNull<ButtonWidget>("BUTTON_PLAY");
 			if (playButton != null)
 			{
-				playButton.Key = new Hotkey(Keycode.SPACE, Modifiers.None);
 				playButton.OnClick = () =>
 				{
 					if (isVideoLoaded)
@@ -164,7 +163,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var pauseButton = panel.GetOrNull<ButtonWidget>("BUTTON_PAUSE");
 			if (pauseButton != null)
 			{
-				pauseButton.Key = new Hotkey(Keycode.SPACE, Modifiers.None);
 				pauseButton.OnClick = () =>
 				{
 					if (isVideoLoaded)
@@ -179,7 +177,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var stopButton = panel.GetOrNull<ButtonWidget>("BUTTON_STOP");
 			if (stopButton != null)
 			{
-				stopButton.Key = new Hotkey(Keycode.RETURN, Modifiers.None);
 				stopButton.OnClick = () =>
 				{
 					if (isVideoLoaded)
@@ -196,7 +193,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var nextButton = panel.GetOrNull<ButtonWidget>("BUTTON_NEXT");
 			if (nextButton != null)
 			{
-				nextButton.Key = new Hotkey(Keycode.RIGHT, Modifiers.None);
 				nextButton.OnClick = () =>
 				{
 					if (!isVideoLoaded)
@@ -209,7 +205,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var prevButton = panel.GetOrNull<ButtonWidget>("BUTTON_PREV");
 			if (prevButton != null)
 			{
-				prevButton.Key = new Hotkey(Keycode.LEFT, Modifiers.None);
 				prevButton.OnClick = () =>
 				{
 					if (!isVideoLoaded)

--- a/OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipLogic.cs
@@ -23,17 +23,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var font = Game.Renderer.Fonts[label.Font];
 			var text = button.GetTooltipText();
 			var labelWidth = font.Measure(text).X;
+			var key = button.Key.GetValue();
 
 			label.GetText = () => text;
 			label.Bounds.Width = labelWidth;
 			widget.Bounds.Width = 2 * label.Bounds.X + labelWidth;
 
-			if (button.Key.IsValid())
+			if (key.IsValid())
 			{
 				var hotkey = widget.Get<LabelWidget>("HOTKEY");
 				hotkey.Visible = true;
 
-				var hotkeyLabel = "({0})".F(button.Key.DisplayString());
+				var hotkeyLabel = "({0})".F(key.DisplayString());
 				hotkey.GetText = () => hotkeyLabel;
 				hotkey.Bounds.X = labelWidth + 2 * label.Bounds.X;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipWithDescHighlightLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipWithDescHighlightLogic.cs
@@ -25,17 +25,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var font = Game.Renderer.Fonts[label.Font];
 			var text = button.GetTooltipText();
 			var labelWidth = font.Measure(text).X;
+			var key = button.Key.GetValue();
 
 			label.GetText = () => text;
 			label.Bounds.Width = labelWidth;
 			widget.Bounds.Width = 2 * label.Bounds.X + labelWidth;
 
-			if (button.Key.IsValid())
+			if (key.IsValid())
 			{
 				var hotkey = widget.Get<LabelWidget>("HOTKEY");
 				hotkey.Visible = true;
 
-				var hotkeyLabel = "({0})".F(button.Key.DisplayString());
+				var hotkeyLabel = "({0})".F(key.DisplayString());
 				hotkey.GetText = () => hotkeyLabel;
 				hotkey.Bounds.X = labelWidth + 2 * label.Bounds.X;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
@@ -62,7 +62,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var options = worldRenderer.Viewport.AvailableZoomSteps;
 				zoomDropdown.OnMouseDown = _ => zoomDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 150, options, setupItem);
 				zoomDropdown.GetText = () => zoomDropdown.SelectedItem;
-				zoomDropdown.GetKey = _ => Game.Settings.Keys.TogglePixelDoubleKey;
 				zoomDropdown.OnKeyPress = e =>
 				{
 					var key = Hotkey.FromKeyInput(e);

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ClassicProductionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ClassicProductionLogic.cs
@@ -43,21 +43,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				palette.PickUpCompletedBuilding();
 			};
 
-			Func<ButtonWidget, Hotkey> getKey = _ => Hotkey.Invalid;
-			if (!string.IsNullOrEmpty(button.HotkeyName))
-			{
-				var ks = Game.Settings.Keys;
-				var field = ks.GetType().GetField(button.HotkeyName);
-				if (field != null)
-					getKey = _ => (Hotkey)field.GetValue(ks);
-			}
-
 			button.IsDisabled = () => !queues.Any(q => q.BuildableItems().Any());
 			button.OnMouseUp = mi => selectTab(mi.Modifiers.HasModifier(Modifiers.Shift));
 			button.OnKeyPress = e => selectTab(e.Modifiers.HasModifier(Modifiers.Shift));
 			button.OnClick = () => selectTab(false);
 			button.IsHighlighted = () => queues.Contains(palette.CurrentQueue);
-			button.GetKey = getKey;
 
 			var chromeName = button.ProductionGroup.ToLowerInvariant();
 			var icon = button.Get<ImageWidget>("ICON");

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
@@ -43,14 +43,12 @@ namespace OpenRA.Mods.Common.Widgets
 		public CommandBarLogic(Widget widget, World world)
 		{
 			this.world = world;
-			var ks = Game.Settings.Keys;
 
 			var attackMoveButton = widget.GetOrNull<ButtonWidget>("ATTACK_MOVE");
 			if (attackMoveButton != null)
 			{
 				BindButtonIcon(attackMoveButton);
 
-				attackMoveButton.GetKey = _ => ks.AttackMoveKey;
 				attackMoveButton.IsDisabled = () => { UpdateStateIfNecessary(); return attackMoveDisabled; };
 				attackMoveButton.IsHighlighted = () => world.OrderGenerator is GenericSelectTarget
 					&& ((GenericSelectTarget)world.OrderGenerator).OrderName == "AttackMove";
@@ -108,7 +106,6 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				BindButtonIcon(guardButton);
 
-				guardButton.GetKey = _ => ks.GuardKey;
 				guardButton.IsDisabled = () => { UpdateStateIfNecessary(); return guardDisabled; };
 				guardButton.IsHighlighted = () => world.OrderGenerator is GenericSelectTarget
 					&& ((GenericSelectTarget)world.OrderGenerator).OrderName == "Guard";
@@ -134,7 +131,6 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				BindButtonIcon(scatterButton);
 
-				scatterButton.GetKey = _ => ks.ScatterKey;
 				scatterButton.IsDisabled = () => { UpdateStateIfNecessary(); return scatterDisabled; };
 				scatterButton.IsHighlighted = () => scatterHighlighted > 0;
 				scatterButton.OnClick = () => PerformKeyboardOrderOnSelection(a => new Order("Scatter", a, false));
@@ -146,7 +142,6 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				BindButtonIcon(deployButton);
 
-				deployButton.GetKey = _ => ks.DeployKey;
 				deployButton.IsDisabled = () => { UpdateStateIfNecessary(); return !selectedDeploys.Any(Exts.IsTraitEnabled); };
 				deployButton.IsHighlighted = () => deployHighlighted > 0;
 				deployButton.OnClick = PerformDeployOrderOnSelection;
@@ -158,7 +153,6 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				BindButtonIcon(stopButton);
 
-				stopButton.GetKey = _ => ks.StopKey;
 				stopButton.IsDisabled = () => { UpdateStateIfNecessary(); return stopDisabled; };
 				stopButton.IsHighlighted = () => stopHighlighted > 0;
 				stopButton.OnClick = () => PerformKeyboardOrderOnSelection(a => new Order("Stop", a, false));

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/OrderButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/OrderButtonsChromeLogic.cs
@@ -21,10 +21,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var sell = widget as ButtonWidget;
 			if (sell != null)
-			{
-				sell.GetKey = _ => Game.Settings.Keys.SellKey;
 				OrderButtonsChromeUtils.BindOrderButton<SellOrderGenerator>(world, sell, "sell");
-			}
 		}
 	}
 
@@ -35,10 +32,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var repair = widget as ButtonWidget;
 			if (repair != null)
-			{
-				repair.GetKey = _ => Game.Settings.Keys.RepairKey;
 				OrderButtonsChromeUtils.BindOrderButton<RepairOrderGenerator>(world, repair, "repair");
-			}
 		}
 	}
 
@@ -49,10 +43,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var power = widget as ButtonWidget;
 			if (power != null)
-			{
-				power.GetKey = _ => Game.Settings.Keys.PowerDownKey;
 				OrderButtonsChromeUtils.BindOrderButton<PowerDownOrderGenerator>(world, power, "power");
-			}
 		}
 	}
 
@@ -63,10 +54,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var beacon = widget as ButtonWidget;
 			if (beacon != null)
-			{
-				beacon.GetKey = _ => Game.Settings.Keys.PlaceBeaconKey;
 				OrderButtonsChromeUtils.BindOrderButton<BeaconOrderGenerator>(world, beacon, "beacon");
-			}
 		}
 	}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTabsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTabsLogic.cs
@@ -34,20 +34,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				tabs.PickUpCompletedBuilding();
 			};
 
-			Func<ButtonWidget, Hotkey> getKey = _ => Hotkey.Invalid;
-			if (!string.IsNullOrEmpty(button.HotkeyName))
-			{
-				var ks = Game.Settings.Keys;
-				var field = ks.GetType().GetField(button.HotkeyName);
-				if (field != null)
-					getKey = _ => (Hotkey)field.GetValue(ks);
-			}
-
 			button.IsDisabled = () => tabs.Groups[button.ProductionGroup].Tabs.Count == 0;
 			button.OnMouseUp = mi => selectTab(mi.Modifiers.HasModifier(Modifiers.Shift));
 			button.OnKeyPress = e => selectTab(e.Modifiers.HasModifier(Modifiers.Shift));
 			button.IsHighlighted = () => tabs.QueueGroup == button.ProductionGroup;
-			button.GetKey = getKey;
 
 			var chromeName = button.ProductionGroup.ToLowerInvariant();
 			var icon = button.Get<ImageWidget>("ICON");

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ReplayControlBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ReplayControlBarLogic.cs
@@ -46,18 +46,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var originalTimestep = world.Timestep;
 
 				var pauseButton = widget.Get<ButtonWidget>("BUTTON_PAUSE");
-				pauseButton.GetKey = _ => Game.Settings.Keys.PauseKey;
 				pauseButton.IsVisible = () => world.Timestep != 0 && orderManager.NetFrameNumber < replayNetTicks;
 				pauseButton.OnClick = () => world.Timestep = 0;
 
 				var playButton = widget.Get<ButtonWidget>("BUTTON_PLAY");
-				playButton.GetKey = _ => Game.Settings.Keys.PauseKey;
 				playButton.IsVisible = () => world.Timestep == 0 || orderManager.NetFrameNumber >= replayNetTicks;
 				playButton.OnClick = () => world.Timestep = (int)Math.Ceiling(originalTimestep * multipliers[speed]);
 				playButton.IsDisabled = () => orderManager.NetFrameNumber >= replayNetTicks;
 
 				var slowButton = widget.Get<ButtonWidget>("BUTTON_SLOW");
-				slowButton.GetKey = _ => Game.Settings.Keys.ReplaySpeedSlowKey;
 				slowButton.IsHighlighted = () => speed == PlaybackSpeed.Slow;
 				slowButton.IsDisabled = () => orderManager.NetFrameNumber >= replayNetTicks;
 				slowButton.OnClick = () =>
@@ -68,7 +65,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				};
 
 				var normalSpeedButton = widget.Get<ButtonWidget>("BUTTON_REGULAR");
-				normalSpeedButton.GetKey = _ => Game.Settings.Keys.ReplaySpeedRegularKey;
 				normalSpeedButton.IsHighlighted = () => speed == PlaybackSpeed.Regular;
 				normalSpeedButton.IsDisabled = () => orderManager.NetFrameNumber >= replayNetTicks;
 				normalSpeedButton.OnClick = () =>
@@ -79,7 +75,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				};
 
 				var fastButton = widget.Get<ButtonWidget>("BUTTON_FAST");
-				fastButton.GetKey = _ => Game.Settings.Keys.ReplaySpeedFastKey;
 				fastButton.IsHighlighted = () => speed == PlaybackSpeed.Fast;
 				fastButton.IsDisabled = () => orderManager.NetFrameNumber >= replayNetTicks;
 				fastButton.OnClick = () =>
@@ -90,7 +85,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				};
 
 				var maximumButton = widget.Get<ButtonWidget>("BUTTON_MAXIMUM");
-				maximumButton.GetKey = _ => Game.Settings.Keys.ReplaySpeedMaxKey;
 				maximumButton.IsHighlighted = () => speed == PlaybackSpeed.Maximum;
 				maximumButton.IsDisabled = () => orderManager.NetFrameNumber >= replayNetTicks;
 				maximumButton.OnClick = () =>

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/StanceSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/StanceSelectorLogic.cs
@@ -27,32 +27,30 @@ namespace OpenRA.Mods.Common.Widgets
 		public StanceSelectorLogic(Widget widget, World world)
 		{
 			this.world = world;
-			var ks = Game.Settings.Keys;
 
 			var holdFireButton = widget.GetOrNull<ButtonWidget>("STANCE_HOLDFIRE");
 			if (holdFireButton != null)
-				BindStanceButton(holdFireButton, UnitStance.HoldFire, _ => ks.StanceHoldFireKey);
+				BindStanceButton(holdFireButton, UnitStance.HoldFire);
 
 			var returnFireButton = widget.GetOrNull<ButtonWidget>("STANCE_RETURNFIRE");
 			if (returnFireButton != null)
-				BindStanceButton(returnFireButton, UnitStance.ReturnFire, _ => ks.StanceReturnFireKey);
+				BindStanceButton(returnFireButton, UnitStance.ReturnFire);
 
 			var defendButton = widget.GetOrNull<ButtonWidget>("STANCE_DEFEND");
 			if (defendButton != null)
-				BindStanceButton(defendButton, UnitStance.Defend, _ => ks.StanceDefendKey);
+				BindStanceButton(defendButton, UnitStance.Defend);
 
 			var attackAnythingButton = widget.GetOrNull<ButtonWidget>("STANCE_ATTACKANYTHING");
 			if (attackAnythingButton != null)
-				BindStanceButton(attackAnythingButton, UnitStance.AttackAnything, _ => ks.StanceAttackAnythingKey);
+				BindStanceButton(attackAnythingButton, UnitStance.AttackAnything);
 		}
 
-		void BindStanceButton(ButtonWidget button, UnitStance stance, Func<ButtonWidget, Hotkey> getHotkey)
+		void BindStanceButton(ButtonWidget button, UnitStance stance)
 		{
 			var icon = button.Get<ImageWidget>("ICON");
 			icon.GetImageName = () => button.IsDisabled() ? icon.ImageName + "-disabled" :
 				button.IsHighlighted() ? icon.ImageName + "-active" : icon.ImageName;
 
-			button.GetKey = getHotkey;
 			button.IsDisabled = () => { UpdateStateIfNecessary(); return !actorStances.Any(); };
 			button.IsHighlighted = () => actorStances.Any(
 				at => !at.Trait.IsTraitDisabled && at.Trait.PredictedStance == stance);

--- a/OpenRA.Mods.Common/Widgets/ProductionTypeButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTypeButtonWidget.cs
@@ -14,7 +14,6 @@ namespace OpenRA.Mods.Common.Widgets
 	public class ProductionTypeButtonWidget : ButtonWidget
 	{
 		public readonly string ProductionGroup;
-		public readonly string HotkeyName;
 
 		[ObjectCreator.UseCtor]
 		public ProductionTypeButtonWidget(ModData modData)

--- a/mods/cnc/chrome/assetbrowser.yaml
+++ b/mods/cnc/chrome/assetbrowser.yaml
@@ -119,6 +119,7 @@ Container@ASSETBROWSER_PANEL:
 						Button@BUTTON_PREV:
 							Width: 26
 							Height: 26
+							Key: LEFT
 							Children:
 								Image@IMAGE_PREV:
 									X: 5
@@ -131,6 +132,7 @@ Container@ASSETBROWSER_PANEL:
 							X: 35
 							Width: 26
 							Height: 26
+							Key: SPACE
 							Children:
 								Image@IMAGE_PLAY:
 									X: 5
@@ -144,6 +146,7 @@ Container@ASSETBROWSER_PANEL:
 							X: 35
 							Width: 26
 							Height: 26
+							Key: SPACE
 							Children:
 								Image@IMAGE_PAUSE:
 									X: 5
@@ -156,6 +159,7 @@ Container@ASSETBROWSER_PANEL:
 							X: 70
 							Width: 26
 							Height: 26
+							Key: RETURN
 							Children:
 								Image@IMAGE_STOP:
 									X: 5
@@ -168,6 +172,7 @@ Container@ASSETBROWSER_PANEL:
 							X: 105
 							Width: 26
 							Height: 26
+							Key: RIGHT
 							Children:
 								Image@IMAGE_NEXT:
 									X: 5

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -450,6 +450,7 @@ Container@EDITOR_WORLD_ROOT:
 			Width: 70
 			Height: 25
 			Font: Bold
+			Key: TogglePixelDouble
 		Button@COPYPASTE_BUTTON:
 			X: WINDOW_RIGHT - 390
 			Y: 5

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -141,6 +141,9 @@ Container@OBSERVER_WIDGETS:
 					Y: 10
 					Width: 26
 					Height: 26
+					Key: Pause
+					TooltipText: Pause
+					TooltipContainer: TOOLTIP_CONTAINER
 					IgnoreChildMouseOver: true
 					Children:
 						Image@IMAGE_PAUSE:
@@ -155,6 +158,9 @@ Container@OBSERVER_WIDGETS:
 					Y: 10
 					Width: 26
 					Height: 26
+					Key: Pause
+					TooltipText: Play
+					TooltipContainer: TOOLTIP_CONTAINER
 					IgnoreChildMouseOver: true
 					Children:
 						Image@IMAGE_PLAY:
@@ -170,6 +176,7 @@ Container@OBSERVER_WIDGETS:
 					Width: 36
 					Height: 20
 					BaseLine: 1
+					Key: ReplaySpeedSlow
 					TooltipText: Slow speed
 					TooltipContainer: TOOLTIP_CONTAINER
 					VisualHeight: 0
@@ -181,6 +188,7 @@ Container@OBSERVER_WIDGETS:
 					Width: 38
 					Height: 20
 					BaseLine: 1
+					Key: ReplaySpeedRegular
 					TooltipText: Regular speed
 					TooltipContainer: TOOLTIP_CONTAINER
 					VisualHeight: 0
@@ -192,6 +200,7 @@ Container@OBSERVER_WIDGETS:
 					Width: 38
 					Height: 20
 					BaseLine: 1
+					Key: ReplaySpeedFast
 					TooltipText: Fast speed
 					TooltipContainer: TOOLTIP_CONTAINER
 					VisualHeight: 0
@@ -203,6 +212,7 @@ Container@OBSERVER_WIDGETS:
 					Width: 38
 					Height: 20
 					BaseLine: 1
+					Key: ReplaySpeedMax
 					TooltipText: Maximum speed
 					TooltipContainer: TOOLTIP_CONTAINER
 					VisualHeight: 0
@@ -270,6 +280,7 @@ Container@PLAYER_WIDGETS:
 					Width: 34
 					Height: 34
 					Background: command-button
+					Key: AttackMove
 					DisableKeySound: true
 					TooltipText: Attack Move
 					TooltipDesc: Selected units will move to the desired location\nand attack any enemies they encounter en route.\n\nLeft-click icon then right-click on target location.
@@ -320,6 +331,7 @@ Container@PLAYER_WIDGETS:
 					Width: 34
 					Height: 34
 					Background: command-button
+					Key: Guard
 					DisableKeySound: true
 					TooltipText: Guard
 					TooltipDesc: Selected units will follow the targeted unit.\n\nLeft-click icon then right-click on target unit.
@@ -336,6 +348,7 @@ Container@PLAYER_WIDGETS:
 					Width: 34
 					Height: 34
 					Background: command-button
+					Key: Deploy
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Deploy
@@ -353,6 +366,7 @@ Container@PLAYER_WIDGETS:
 					Width: 34
 					Height: 34
 					Background: command-button
+					Key: Scatter
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Scatter
@@ -370,6 +384,7 @@ Container@PLAYER_WIDGETS:
 					Width: 34
 					Height: 34
 					Background: command-button
+					Key: Stop
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Stop
@@ -412,6 +427,7 @@ Container@PLAYER_WIDGETS:
 					Width: 34
 					Height: 26
 					Background: stance-button
+					Key: StanceAttackAnything
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Attack Anything Stance
@@ -429,6 +445,7 @@ Container@PLAYER_WIDGETS:
 					Width: 34
 					Height: 26
 					Background: stance-button
+					Key: StanceDefend
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Defend Stance
@@ -446,6 +463,7 @@ Container@PLAYER_WIDGETS:
 					Width: 34
 					Height: 26
 					Background: stance-button
+					Key: StanceReturnFire
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Return Fire Stance
@@ -463,6 +481,7 @@ Container@PLAYER_WIDGETS:
 					Width: 34
 					Height: 26
 					Background: stance-button
+					Key: StanceHoldFire
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Hold Fire Stance
@@ -483,12 +502,12 @@ Container@PLAYER_WIDGETS:
 			Background: panel-black
 			Children:
 				MenuButton@OPTIONS_BUTTON:
-					Key: escape
 					X: 22
 					Y: 0 - 24
 					Width: 30
 					Height: 25
 					Font: Bold
+					Key: escape
 					TooltipText: Menu
 					TooltipContainer: TOOLTIP_CONTAINER
 					DisableWorldSounds: true
@@ -505,6 +524,7 @@ Container@PLAYER_WIDGETS:
 					Width: 30
 					Height: 25
 					Font: Bold
+					Key: PlaceBeacon
 					TooltipText: Place Beacon
 					TooltipContainer: TOOLTIP_CONTAINER
 					Children:
@@ -519,6 +539,7 @@ Container@PLAYER_WIDGETS:
 					Width: 30
 					Height: 25
 					Font: Bold
+					Key: Sell
 					TooltipText: Sell
 					TooltipContainer: TOOLTIP_CONTAINER
 					Children:
@@ -533,6 +554,7 @@ Container@PLAYER_WIDGETS:
 					Width: 30
 					Height: 25
 					Font: Bold
+					Key: Repair
 					TooltipText: Repair
 					TooltipContainer: TOOLTIP_CONTAINER
 					Children:
@@ -614,7 +636,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Buildings
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Building
-							HotkeyName: ProductionTypeBuildingKey
+							Key: ProductionTypeBuilding
 							Children:
 								Image@ICON:
 									X: 7
@@ -627,7 +649,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Support
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Defence
-							HotkeyName: ProductionTypeDefenseKey
+							Key: ProductionTypeDefense
 							Children:
 								Image@ICON:
 									X: 7
@@ -640,7 +662,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Infantry
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Infantry
-							HotkeyName: ProductionTypeInfantryKey
+							Key: ProductionTypeInfantry
 							Children:
 								Image@ICON:
 									X: 7
@@ -653,7 +675,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Vehicles
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Vehicle
-							HotkeyName: ProductionTypeVehicleKey
+							Key: ProductionTypeVehicle
 							Children:
 								Image@ICON:
 									X: 7
@@ -666,7 +688,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Aircraft
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Aircraft
-							HotkeyName: ProductionTypeAircraftKey
+							Key: ProductionTypeAircraft
 							Children:
 								Image@ICON:
 									X: 7

--- a/mods/common/chrome/assetbrowser.yaml
+++ b/mods/common/chrome/assetbrowser.yaml
@@ -116,6 +116,7 @@ Background@ASSETBROWSER_PANEL:
 					Y: 0
 					Width: 25
 					Height: 25
+					Key: LEFT
 					Children:
 						Image@IMAGE_PREV:
 							X: 0
@@ -129,6 +130,7 @@ Background@ASSETBROWSER_PANEL:
 					Y: 0
 					Width: 25
 					Height: 25
+					Key: SPACE
 					Children:
 						Image@IMAGE_PLAY:
 							X: 0
@@ -143,6 +145,7 @@ Background@ASSETBROWSER_PANEL:
 					Y: 0
 					Width: 25
 					Height: 25
+					Key: SPACE
 					Children:
 						Image@IMAGE_PAUSE:
 							X: 0
@@ -156,6 +159,7 @@ Background@ASSETBROWSER_PANEL:
 					Y: 0
 					Width: 25
 					Height: 25
+					Key: RETURN
 					Children:
 						Image@IMAGE_STOP:
 							X: 0
@@ -169,6 +173,7 @@ Background@ASSETBROWSER_PANEL:
 					Y: 0
 					Width: 25
 					Height: 25
+					Key: RIGHT
 					Children:
 						Image@IMAGE_NEXT:
 							X: 0

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -431,6 +431,7 @@ Container@EDITOR_WORLD_ROOT:
 			Width: 70
 			Height: 25
 			Font: Bold
+			Key: TogglePixelDouble
 		Label@COORDINATE_LABEL:
 			X: 485
 			Width: 50

--- a/mods/common/chrome/ingame-observer.yaml
+++ b/mods/common/chrome/ingame-observer.yaml
@@ -94,6 +94,9 @@ Container@OBSERVER_WIDGETS:
 							Y: 10
 							Width: 26
 							Height: 26
+							Key: Pause
+							TooltipText: Pause
+							TooltipContainer: TOOLTIP_CONTAINER
 							IgnoreChildMouseOver: true
 							Children:
 								Image@IMAGE_PAUSE:
@@ -107,7 +110,10 @@ Container@OBSERVER_WIDGETS:
 							Y: 10
 							Width: 26
 							Height: 26
+							Key: Pause
 							IgnoreChildMouseOver: true
+							TooltipText: Play
+							TooltipContainer: TOOLTIP_CONTAINER
 							Children:
 								Image@IMAGE_PLAY:
 									Width: 25
@@ -120,9 +126,9 @@ Container@OBSERVER_WIDGETS:
 							Width: 36
 							Height: 20
 							BaseLine: 1
+							Key: ReplaySpeedSlow
 							TooltipText: Slow speed
 							TooltipContainer: TOOLTIP_CONTAINER
-							VisualHeight: 0
 							Text: 50%
 							Font: TinyBold
 						Button@BUTTON_REGULAR:
@@ -131,9 +137,9 @@ Container@OBSERVER_WIDGETS:
 							Width: 38
 							Height: 20
 							BaseLine: 1
+							Key: ReplaySpeedRegular
 							TooltipText: Regular speed
 							TooltipContainer: TOOLTIP_CONTAINER
-							VisualHeight: 0
 							Text: 100%
 							Font: TinyBold
 						Button@BUTTON_FAST:
@@ -142,9 +148,9 @@ Container@OBSERVER_WIDGETS:
 							Width: 38
 							Height: 20
 							BaseLine: 1
+							Key: ReplaySpeedFast
 							TooltipText: Fast speed
 							TooltipContainer: TOOLTIP_CONTAINER
-							VisualHeight: 0
 							Text: 200%
 							Font: TinyBold
 						Button@BUTTON_MAXIMUM:
@@ -153,8 +159,8 @@ Container@OBSERVER_WIDGETS:
 							Width: 38
 							Height: 20
 							BaseLine: 1
+							Key: ReplaySpeedMax
 							TooltipText: Maximum speed
 							TooltipContainer: TOOLTIP_CONTAINER
-							VisualHeight: 0
 							Text: MAX
 							Font: TinyBold

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -43,6 +43,7 @@ Container@PLAYER_WIDGETS:
 					Height: 41
 					VisualHeight: 0
 					Background: command-button
+					Key: AttackMove
 					DisableKeySound: true
 					TooltipText: Attack Move
 					TooltipDesc: Selected units will move to the desired location\nand attack any enemies they encounter en route.\n\nLeft-click icon then right-click on target location.
@@ -93,6 +94,7 @@ Container@PLAYER_WIDGETS:
 					Height: 41
 					VisualHeight: 0
 					Background: command-button
+					Key: Guard
 					DisableKeySound: true
 					TooltipText: Guard
 					TooltipDesc: Selected units will follow the targeted unit.\n\nLeft-click icon then right-click on target unit.
@@ -109,6 +111,7 @@ Container@PLAYER_WIDGETS:
 					Height: 41
 					VisualHeight: 0
 					Background: command-button
+					Key: Deploy
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Deploy
@@ -126,6 +129,7 @@ Container@PLAYER_WIDGETS:
 					Height: 41
 					VisualHeight: 0
 					Background: command-button
+					Key: Scatter
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Scatter
@@ -143,6 +147,7 @@ Container@PLAYER_WIDGETS:
 					Height: 41
 					VisualHeight: 0
 					Background: command-button
+					Key: Stop
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Stop
@@ -183,6 +188,7 @@ Container@PLAYER_WIDGETS:
 					Height: 26
 					VisualHeight: 0
 					Background:
+					Key: StanceAttackAnything
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Attack Anything Stance
@@ -200,6 +206,7 @@ Container@PLAYER_WIDGETS:
 					Height: 26
 					VisualHeight: 0
 					Background:
+					Key: StanceDefend
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Defend Stance
@@ -217,6 +224,7 @@ Container@PLAYER_WIDGETS:
 					Height: 26
 					VisualHeight: 0
 					Background:
+					Key: StanceReturnFire
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Return Fire Stance
@@ -234,6 +242,7 @@ Container@PLAYER_WIDGETS:
 					Height: 26
 					VisualHeight: 0
 					Background:
+					Key: StanceHoldFire
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Hold Fire Stance
@@ -260,11 +269,11 @@ Container@PLAYER_WIDGETS:
 					Y: 236
 					Children:
 						MenuButton@DEBUG_BUTTON:
-							Key: escape Shift
 							X: 4
 							Width: 34
 							Height: 35
 							Background:
+							Key: escape Shift
 							TooltipText: Debug Menu
 							TooltipContainer: TOOLTIP_CONTAINER
 							DisableWorldSounds: true
@@ -281,6 +290,7 @@ Container@PLAYER_WIDGETS:
 							Width: 34
 							Height: 35
 							Background:
+							Key: Repair
 							TooltipText: Repair
 							TooltipContainer: TOOLTIP_CONTAINER
 							VisualHeight: 0
@@ -295,6 +305,7 @@ Container@PLAYER_WIDGETS:
 							Width: 34
 							Height: 35
 							Background:
+							Key: Sell
 							TooltipText: Sell
 							TooltipContainer: TOOLTIP_CONTAINER
 							VisualHeight: 0
@@ -309,6 +320,7 @@ Container@PLAYER_WIDGETS:
 							Width: 36
 							Height: 35
 							Background:
+							Key: PlaceBeacon
 							TooltipText: Place Beacon
 							TooltipContainer: TOOLTIP_CONTAINER
 							VisualHeight: 0
@@ -323,6 +335,7 @@ Container@PLAYER_WIDGETS:
 							Width: 36
 							Height: 35
 							Background:
+							Key: PowerDown
 							TooltipText: Power Down
 							TooltipContainer: TOOLTIP_CONTAINER
 							VisualHeight: 0
@@ -491,7 +504,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Buildings
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Building
-							HotkeyName: ProductionTypeBuildingKey
+							Key: ProductionTypeBuilding
 							Children:
 								Image@ICON:
 									X: 5
@@ -506,7 +519,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Upgrades
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Upgrade
-							HotkeyName: ProductionTypeUpgradeKey
+							Key: ProductionTypeUpgrade
 							Children:
 								Image@ICON:
 									X: 5
@@ -521,7 +534,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Infantry
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Infantry
-							HotkeyName: ProductionTypeInfantryKey
+							Key: ProductionTypeInfantry
 							Children:
 								Image@ICON:
 									X: 5
@@ -536,7 +549,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Light Vehicles
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Vehicle
-							HotkeyName: ProductionTypeVehicleKey
+							Key: ProductionTypeVehicle
 							Children:
 								Image@ICON:
 									X: 5
@@ -551,7 +564,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Heavy Vehicles
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Armor
-							HotkeyName: ProductionTypeTankKey
+							Key: ProductionTypeTank
 							Children:
 								Image@ICON:
 									X: 5
@@ -566,7 +579,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Aircraft
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Aircraft
-							HotkeyName: ProductionTypeAircraftKey
+							Key: ProductionTypeAircraft
 							Children:
 								Image@ICON:
 									X: 5
@@ -581,7 +594,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Starport
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Starport
-							HotkeyName: ProductionTypeMerchantKey
+							Key: ProductionTypeMerchant
 							Children:
 								Image@ICON:
 									X: 5

--- a/mods/ra/chrome/ingame-observer.yaml
+++ b/mods/ra/chrome/ingame-observer.yaml
@@ -128,6 +128,7 @@ Container@OBSERVER_WIDGETS:
 					Width: 28
 					Height: 28
 					Background: sidebar-button-observer
+					Key: Pause
 					TooltipText: Pause
 					TooltipContainer: TOOLTIP_CONTAINER
 					VisualHeight: 0
@@ -143,6 +144,7 @@ Container@OBSERVER_WIDGETS:
 					Width: 28
 					Height: 28
 					Background: sidebar-button-observer
+					Key: Pause
 					TooltipText: Play
 					TooltipContainer: TOOLTIP_CONTAINER
 					VisualHeight: 0
@@ -159,6 +161,7 @@ Container@OBSERVER_WIDGETS:
 					Height: 22
 					BaseLine: 1
 					Background: sidebar-button-observer
+					Key: ReplaySpeedSlow
 					TooltipText: Slow speed
 					TooltipContainer: TOOLTIP_CONTAINER
 					VisualHeight: 0
@@ -171,6 +174,7 @@ Container@OBSERVER_WIDGETS:
 					Height: 22
 					BaseLine: 1
 					Background: sidebar-button-observer
+					Key: ReplaySpeedRegular
 					TooltipText: Regular speed
 					TooltipContainer: TOOLTIP_CONTAINER
 					VisualHeight: 0
@@ -183,6 +187,7 @@ Container@OBSERVER_WIDGETS:
 					Height: 22
 					BaseLine: 1
 					Background: sidebar-button-observer
+					Key: ReplaySpeedFast
 					TooltipText: Fast speed
 					TooltipContainer: TOOLTIP_CONTAINER
 					VisualHeight: 0
@@ -195,6 +200,7 @@ Container@OBSERVER_WIDGETS:
 					Height: 22
 					BaseLine: 1
 					Background: sidebar-button-observer
+					Key: ReplaySpeedMax
 					TooltipText: Maximum speed
 					TooltipContainer: TOOLTIP_CONTAINER
 					VisualHeight: 0

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -49,6 +49,7 @@ Container@PLAYER_WIDGETS:
 					Height: 26
 					VisualHeight: 0
 					Background: command-button
+					Key: AttackMove
 					DisableKeySound: true
 					TooltipText: Attack Move
 					TooltipDesc: Selected units will move to the desired location\nand attack any enemies they encounter en route.\n\nLeft-click icon then right-click on target location.
@@ -102,6 +103,7 @@ Container@PLAYER_WIDGETS:
 					Height: 26
 					VisualHeight: 0
 					Background: command-button
+					Key: Guard
 					DisableKeySound: true
 					TooltipText: Guard
 					TooltipDesc: Selected units will follow the targeted unit.\n\nLeft-click icon then right-click on target unit.
@@ -119,6 +121,7 @@ Container@PLAYER_WIDGETS:
 					Height: 26
 					VisualHeight: 0
 					Background: command-button
+					Key: Deploy
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Deploy
@@ -137,6 +140,7 @@ Container@PLAYER_WIDGETS:
 					Height: 26
 					VisualHeight: 0
 					Background: command-button
+					Key: Scatter
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Scatter
@@ -155,6 +159,7 @@ Container@PLAYER_WIDGETS:
 					Height: 26
 					VisualHeight: 0
 					Background: command-button
+					Key: Stop
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Stop
@@ -197,6 +202,7 @@ Container@PLAYER_WIDGETS:
 					Height: 26
 					VisualHeight: 0
 					Background: command-button
+					Key: StanceAttackAnything
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Attack Anything Stance
@@ -215,6 +221,7 @@ Container@PLAYER_WIDGETS:
 					Height: 26
 					VisualHeight: 0
 					Background: command-button
+					Key: StanceDefend
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Defend Stance
@@ -233,6 +240,7 @@ Container@PLAYER_WIDGETS:
 					Height: 26
 					VisualHeight: 0
 					Background: command-button
+					Key: StanceReturnFire
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Return Fire Stance
@@ -251,6 +259,7 @@ Container@PLAYER_WIDGETS:
 					Height: 26
 					VisualHeight: 0
 					Background: command-button
+					Key: StanceHoldFire
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Hold Fire Stance
@@ -282,6 +291,7 @@ Container@PLAYER_WIDGETS:
 							Width: 28
 							Height: 28
 							Background: sidebar-button
+							Key: PlaceBeacon
 							TooltipText: Place Beacon
 							TooltipContainer: TOOLTIP_CONTAINER
 							VisualHeight: 0
@@ -296,6 +306,7 @@ Container@PLAYER_WIDGETS:
 							Width: 28
 							Height: 28
 							Background: sidebar-button
+							Key: Sell
 							TooltipText: Sell
 							TooltipContainer: TOOLTIP_CONTAINER
 							VisualHeight: 0
@@ -310,6 +321,7 @@ Container@PLAYER_WIDGETS:
 							Width: 28
 							Height: 28
 							Background: sidebar-button
+							Key: PowerDown
 							TooltipText: Power Down
 							TooltipContainer: TOOLTIP_CONTAINER
 							VisualHeight: 0
@@ -324,6 +336,7 @@ Container@PLAYER_WIDGETS:
 							Width: 28
 							Height: 28
 							Background: sidebar-button
+							Key: Repair
 							TooltipText: Repair
 							TooltipContainer: TOOLTIP_CONTAINER
 							VisualHeight: 0
@@ -334,11 +347,11 @@ Container@PLAYER_WIDGETS:
 									ImageCollection: order-icons
 						MenuButton@DEBUG_BUTTON:
 							Logic: AddFactionSuffixLogic
-							Key: escape Shift
 							X: 128
 							Width: 28
 							Height: 28
 							Background: sidebar-button
+							Key: escape Shift
 							TooltipText: Debug Menu
 							TooltipContainer: TOOLTIP_CONTAINER
 							DisableWorldSounds: true
@@ -351,11 +364,11 @@ Container@PLAYER_WIDGETS:
 									ImageName: debug
 						MenuButton@OPTIONS_BUTTON:
 							Logic: AddFactionSuffixLogic
-							Key: escape
 							X: 192
 							Width: 28
 							Height: 28
 							Background: sidebar-button
+							Key: escape
 							TooltipText: Options
 							TooltipContainer: TOOLTIP_CONTAINER
 							DisableWorldSounds: true
@@ -481,7 +494,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Buildings
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Building
-							HotkeyName: ProductionTypeBuildingKey
+							Key: ProductionTypeBuilding
 							Children:
 								Image@ICON:
 									X: 6
@@ -497,7 +510,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Defense
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Defense
-							HotkeyName: ProductionTypeDefenseKey
+							Key: ProductionTypeDefense
 							Children:
 								Image@ICON:
 									X: 6
@@ -513,7 +526,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Infantry
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Infantry
-							HotkeyName: ProductionTypeInfantryKey
+							Key: ProductionTypeInfantry
 							Children:
 								Image@ICON:
 									X: 6
@@ -529,7 +542,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Vehicles
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Vehicle
-							HotkeyName: ProductionTypeVehicleKey
+							Key: ProductionTypeVehicle
 							Children:
 								Image@ICON:
 									X: 6
@@ -545,7 +558,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Aircraft
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Aircraft
-							HotkeyName: ProductionTypeAircraftKey
+							Key: ProductionTypeAircraft
 							Children:
 								Image@ICON:
 									X: 6
@@ -561,7 +574,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Naval
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Ship
-							HotkeyName: ProductionTypeNavalKey
+							Key: ProductionTypeNaval
 							Children:
 								Image@ICON:
 									X: 6

--- a/mods/ts/chrome/ingame-observer.yaml
+++ b/mods/ts/chrome/ingame-observer.yaml
@@ -94,6 +94,9 @@ Container@OBSERVER_WIDGETS:
 							Y: 10
 							Width: 26
 							Height: 26
+							Key: Pause
+							TooltipText: Pause
+							TooltipContainer: TOOLTIP_CONTAINER
 							IgnoreChildMouseOver: true
 							Children:
 								Image@IMAGE_PAUSE:
@@ -107,6 +110,9 @@ Container@OBSERVER_WIDGETS:
 							Y: 10
 							Width: 26
 							Height: 26
+							Key: Pause
+							TooltipText: Play
+							TooltipContainer: TOOLTIP_CONTAINER
 							IgnoreChildMouseOver: true
 							Children:
 								Image@IMAGE_PLAY:
@@ -120,9 +126,9 @@ Container@OBSERVER_WIDGETS:
 							Width: 36
 							Height: 20
 							BaseLine: 1
+							Key: ReplaySpeedSlow
 							TooltipText: Slow speed
 							TooltipContainer: TOOLTIP_CONTAINER
-							VisualHeight: 0
 							Text: 50%
 							Font: TinyBold
 						Button@BUTTON_REGULAR:
@@ -131,9 +137,9 @@ Container@OBSERVER_WIDGETS:
 							Width: 38
 							Height: 20
 							BaseLine: 1
+							Key: ReplaySpeedRegular
 							TooltipText: Regular speed
 							TooltipContainer: TOOLTIP_CONTAINER
-							VisualHeight: 0
 							Text: 100%
 							Font: TinyBold
 						Button@BUTTON_FAST:
@@ -142,9 +148,9 @@ Container@OBSERVER_WIDGETS:
 							Width: 38
 							Height: 20
 							BaseLine: 1
+							Key: ReplaySpeedFast
 							TooltipText: Fast speed
 							TooltipContainer: TOOLTIP_CONTAINER
-							VisualHeight: 0
 							Text: 200%
 							Font: TinyBold
 						Button@BUTTON_MAXIMUM:
@@ -153,8 +159,8 @@ Container@OBSERVER_WIDGETS:
 							Width: 38
 							Height: 20
 							BaseLine: 1
+							Key: ReplaySpeedMax
 							TooltipText: Maximum speed
 							TooltipContainer: TOOLTIP_CONTAINER
-							VisualHeight: 0
 							Text: MAX
 							Font: TinyBold

--- a/mods/ts/chrome/ingame-player.yaml
+++ b/mods/ts/chrome/ingame-player.yaml
@@ -68,6 +68,7 @@ Container@PLAYER_WIDGETS:
 							Width: 30
 							Height: 31
 							Background: sidebar-button
+							Key: Repair
 							TooltipText: Repair
 							TooltipContainer: TOOLTIP_CONTAINER
 							VisualHeight: 0
@@ -83,6 +84,7 @@ Container@PLAYER_WIDGETS:
 							Width: 30
 							Height: 31
 							Background: sidebar-button
+							Key: Sell
 							TooltipText: Sell
 							TooltipContainer: TOOLTIP_CONTAINER
 							VisualHeight: 0
@@ -98,6 +100,7 @@ Container@PLAYER_WIDGETS:
 							Width: 30
 							Height: 31
 							Background: sidebar-button
+							Key: PlaceBeacon
 							TooltipText: Place Beacon
 							TooltipContainer: TOOLTIP_CONTAINER
 							VisualHeight: 0
@@ -113,6 +116,7 @@ Container@PLAYER_WIDGETS:
 							Width: 30
 							Height: 31
 							Background: sidebar-button
+							Key: PowerDown
 							TooltipText: Power Down
 							TooltipContainer: TOOLTIP_CONTAINER
 							VisualHeight: 0
@@ -276,7 +280,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Buildings
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Building
-							HotkeyName: ProductionTypeBuildingKey
+							Key: ProductionTypeBuilding
 							Children:
 								Image@ICON:
 									Logic: AddFactionSuffixLogic
@@ -294,7 +298,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Defense
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Defense
-							HotkeyName: ProductionTypeDefenseKey
+							Key: ProductionTypeDefense
 							Children:
 								Image@ICON:
 									Logic: AddFactionSuffixLogic
@@ -312,7 +316,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Infantry
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Infantry
-							HotkeyName: ProductionTypeInfantryKey
+							Key: ProductionTypeInfantry
 							Children:
 								Image@ICON:
 									Logic: AddFactionSuffixLogic
@@ -330,7 +334,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Vehicles
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Vehicle
-							HotkeyName: ProductionTypeVehicleKey
+							Key: ProductionTypeVehicle
 							Children:
 								Image@ICON:
 									Logic: AddFactionSuffixLogic
@@ -348,7 +352,7 @@ Container@PLAYER_WIDGETS:
 							TooltipText: Aircraft
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Air
-							HotkeyName: ProductionTypeAircraftKey
+							Key: ProductionTypeAircraft
 							Children:
 								Image@ICON:
 									Logic: AddFactionSuffixLogic


### PR DESCRIPTION
This restarts progress towards moving our hotkey definitions into mod code.  A `NamedHotkey` class is introduced to enable `ButtonWidget` `Key`'s to refer to a named hotkey.  All hardcoded button hotkeys are switched over to this new setup.

Followup PRs will remove the remaining hardcoded hotkeys and then finally replace the hardcoded list in `KeySettings` with a dynamic dictionary using mod-defined defaults/descriptions.