### PR TITLE
[RA] Add Gap effect values to new vision range changes.

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -137,6 +137,9 @@ SPEN:
 		Type: Wood
 	RevealsShroud:
 		Range: 5c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	Exit@1:
 		SpawnOffset: 0,-213,0
 		Facing: 96
@@ -236,6 +239,9 @@ SYRD:
 		Type: Wood
 	RevealsShroud:
 		Range: 5c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	Exit@1:
 		SpawnOffset: -1024,1024,0
 		Facing: 160
@@ -827,6 +833,9 @@ SAM:
 	Armor:
 		Type: Heavy
 	RevealsShroud:
+		Range: 6c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
 		Range: 5c0
 	WithBuildingBib:
 		HasMinibib: Yes
@@ -916,6 +925,9 @@ WEAP:
 		Type: Wood
 	RevealsShroud:
 		Range: 5c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	WithBuildingBib:
 	WithProductionDoorOverlay:
 		Sequence: build-top
@@ -1510,6 +1522,9 @@ STEK:
 		Type: Wood
 	RevealsShroud:
 		Range: 5c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	WithBuildingBib:
 	Power:
 		Amount: -100


### PR DESCRIPTION
Was overlooked as part of #13640

Also equalizes SAM Site vision range/gap effect with other defensive structures. 

> The SAM occupying two cells adds to the horizontal vision range but ought to have that as its standalone differential in relation to other defensive structures as opposed to adding onto it a -1c0 vision range to compensate. 
> 
> Playtested as part of http://www.sleipnirstuff.com/forum/viewtopic.php?f=83&t=20017