### PR TITLE
Fix Mobile not sanitizing target location of Move orders

### DIFF
--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -626,7 +626,9 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (order.OrderString == "Move")
 			{
-				if (!Info.MoveIntoShroud && !self.Owner.Shroud.IsExplored(order.TargetLocation))
+				var loc = self.World.Map.Clamp(order.TargetLocation);
+
+				if (!Info.MoveIntoShroud && !self.Owner.Shroud.IsExplored(loc))
 					return;
 
 				if (!order.Queued)
@@ -634,8 +636,8 @@ namespace OpenRA.Mods.Common.Traits
 
 				TicksBeforePathing = AverageTicksBeforePathing + self.World.SharedRandom.Next(-SpreadTicksBeforePathing, SpreadTicksBeforePathing);
 
-				self.SetTargetLine(Target.FromCell(self.World, order.TargetLocation), Color.Green);
-				self.QueueActivity(order.Queued, new Move(self, order.TargetLocation, WDist.FromCells(8), null, true));
+				self.SetTargetLine(Target.FromCell(self.World, loc), Color.Green);
+				self.QueueActivity(order.Queued, new Move(self, loc, WDist.FromCells(8), null, true));
 			}
 
 			if (order.OrderString == "Stop")


### PR DESCRIPTION
Fixes #13707.

In #13528, the call to `Map.Clamp` got lost along the way.