### PR TITLE
AttackFollow supports multiple attack bases

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
@@ -78,12 +78,12 @@ namespace OpenRA.Mods.Common.Scripting
 	[ScriptPropertyGroup("Combat")]
 	public class GeneralCombatProperties : ScriptActorProperties, Requires<AttackBaseInfo>
 	{
-		readonly AttackBase attackBase;
+		readonly AttackBase[] attackBases;
 
 		public GeneralCombatProperties(ScriptContext context, Actor self)
 			: base(context, self)
 		{
-			attackBase = self.Trait<AttackBase>();
+			attackBases = self.TraitsImplementing<AttackBase>().ToArray();
 		}
 
 		[Desc("Attack the target actor. The target actor needs to be visible.")]
@@ -96,7 +96,8 @@ namespace OpenRA.Mods.Common.Scripting
 			if (!targetActor.Info.HasTraitInfo<FrozenUnderFogInfo>() && !Self.Owner.CanTargetActor(targetActor))
 				Log.Write("lua", "{1} is not revealed for player {0}!", Self.Owner, targetActor);
 
-			attackBase.AttackTarget(target, true, allowMove, forceAttack);
+			foreach (var attackBase in attackBases)
+				attackBase.AttackTarget(target, true, allowMove, forceAttack);
 		}
 
 		[Desc("Checks if the targeted actor is a valid target for this actor.")]

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		class AttackActivity : Activity
 		{
-			readonly AttackFollow attack;
+			readonly AttackFollow[] attackFollows;
 			readonly IMove move;
 			readonly Target target;
 			readonly bool forceAttack;
@@ -67,11 +67,25 @@ namespace OpenRA.Mods.Common.Traits
 
 			public AttackActivity(Actor self, Target target, bool allowMove, bool forceAttack)
 			{
-				attack = self.Trait<AttackFollow>();
+				attackFollows = self.TraitsImplementing<AttackFollow>().ToArray();
 				move = allowMove ? self.TraitOrDefault<IMove>() : null;
 
 				this.target = target;
 				this.forceAttack = forceAttack;
+			}
+
+			Armament GetFirstFeasibleWeapon(Target target, bool forceAttack)
+			{
+				// We scan attackbases in order.
+				// That means, the order of attack base in YAML matters!
+				foreach (var atb in attackFollows)
+				{
+					var weapon = atb.ChooseArmamentsForTarget(target, forceAttack).FirstOrDefault();
+					if (weapon != null)
+						return weapon;
+				}
+
+				return null;
 			}
 
 			public override Activity Tick(Actor self)
@@ -82,7 +96,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (self.IsDisabled())
 					return this;
 
-				var weapon = attack.ChooseArmamentsForTarget(target, forceAttack).FirstOrDefault();
+				var weapon = GetFirstFeasibleWeapon(target, forceAttack);
 				if (weapon != null)
 				{
 					var targetIsMobile = (target.Type == TargetType.Actor && target.Actor.Info.HasTraitInfo<IMoveInfo>())
@@ -95,10 +109,12 @@ namespace OpenRA.Mods.Common.Traits
 
 					// Check that AttackFollow hasn't cancelled the target by modifying attack.Target
 					// Having both this and AttackFollow modify that field is a horrible hack.
-					if (hasTicked && attack.Target.Type == TargetType.Invalid)
+					if (hasTicked && attackFollows.All(a => a.Target.Type == TargetType.Invalid))
 						return NextActivity;
 
-					attack.Target = target;
+					// Assign targets to all so if it can fire, it will fire.
+					foreach (var attack in attackFollows)
+						attack.Target = target;
 					hasTicked = true;
 
 					if (move != null)
@@ -108,7 +124,8 @@ namespace OpenRA.Mods.Common.Traits
 						return this;
 				}
 
-				attack.Target = Target.Invalid;
+				foreach (var attack in attackFollows)
+					attack.Target = Target.Invalid;
 
 				return NextActivity;
 			}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -115,6 +115,7 @@ namespace OpenRA.Mods.Common.Traits
 					// Assign targets to all so if it can fire, it will fire.
 					foreach (var attack in attackFollows)
 						attack.Target = target;
+
 					hasTicked = true;
 
 					if (move != null)

--- a/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
@@ -80,6 +80,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (a.Info.MuzzleSplitFacings > 0)
 				sequence += Util.QuantizeFacing(getFacing(), a.Info.MuzzleSplitFacings).ToString();
 
+			// Weapon might had been fired from some other attack base, such as AttackGarrisoned
+			if (!anims.ContainsKey(barrel))
+				return;
+
 			visible[barrel] = true;
 			anims[barrel].Animation.PlayThen(sequence, () => visible[barrel] = false);
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
@@ -76,13 +76,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (a == null || barrel == null || !armaments.Contains(a))
 				return;
 
-			var sequence = a.Info.MuzzleSequence;
-			if (a.Info.MuzzleSplitFacings > 0)
-				sequence += Util.QuantizeFacing(getFacing(), a.Info.MuzzleSplitFacings).ToString();
-
 			// Weapon might had been fired from some other attack base, such as AttackGarrisoned
 			if (!anims.ContainsKey(barrel))
 				return;
+
+			var sequence = a.Info.MuzzleSequence;
+			if (a.Info.MuzzleSplitFacings > 0)
+				sequence += Util.QuantizeFacing(getFacing(), a.Info.MuzzleSplitFacings).ToString();
 
 			visible[barrel] = true;
 			anims[barrel].Animation.PlayThen(sequence, () => visible[barrel] = false);


### PR DESCRIPTION
In C&C Generals or RA2 (battle fortress), there were vehicles with their own weapons which also let their passengers attack enemies.

This patch allows AttackTurreted and AttackGarrisoned to co-exist in one vehicle. At least, works for Humvee in my mod.