### PR TITLE
Yuri Grinder support using DonateCash

### DIFF
--- a/OpenRA.Mods.Common/Activities/DonateCash.cs
+++ b/OpenRA.Mods.Common/Activities/DonateCash.cs
@@ -42,6 +42,12 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				self.World.AddFrameEndTask(w => w.Add(new FloatingText(target.CenterPosition, target.Owner.Color.RGB, FloatingText.FormatCashTick(payload), 30)));
+
+			foreach (var nct in target.TraitsImplementing<INotifyCashTransfer>())
+				nct.OnAcceptingCash(target, self);
+
+			foreach (var nct in self.TraitsImplementing<INotifyCashTransfer>())
+				nct.OnDeliveringCash(self, target);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -418,6 +418,7 @@
     <Compile Include="Traits\Render\LeavesTrails.cs" />
     <Compile Include="Traits\Render\RenderSpritesEditorOnly.cs" />
     <Compile Include="Traits\Render\WithTurretAttackAnimation.cs" />
+    <Compile Include="Traits\Render\WithAcceptDeliveredCashAnimation.cs" />
     <Compile Include="Traits\Render\RenderUtils.cs" />
     <Compile Include="Traits\Render\RenderDebugState.cs" />
     <Compile Include="Traits\Render\RenderNameTag.cs" />

--- a/OpenRA.Mods.Common/Traits/AcceptsDeliveredCash.cs
+++ b/OpenRA.Mods.Common/Traits/AcceptsDeliveredCash.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using OpenRA.Mods.Common.Traits.Sound;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -23,11 +24,27 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Stance the delivering actor needs to enter.")]
 		public readonly Stance ValidStances = Stance.Ally;
 
+		[Desc("Play a randomly selected sound from this list when accepting cash.")]
+		public readonly string[] Sounds = { };
+
 		public object Create(ActorInitializer init) { return new AcceptsDeliveredCash(init.Self, this); }
 	}
 
-	public class AcceptsDeliveredCash
+	public class AcceptsDeliveredCash : INotifyCashTransfer
 	{
-		public AcceptsDeliveredCash(Actor self, AcceptsDeliveredCashInfo info) { }
+		AcceptsDeliveredCashInfo info;
+
+		public AcceptsDeliveredCash(Actor self, AcceptsDeliveredCashInfo info)
+		{
+			this.info = info;
+		}
+
+		void INotifyCashTransfer.OnAcceptingCash(Actor self, Actor donor)
+		{
+			if (info.Sounds.Length > 0)
+				Game.Sound.Play(SoundType.World, info.Sounds.Random(self.World.SharedRandom), self.CenterPosition);
+		}
+
+		void INotifyCashTransfer.OnDeliveringCash(Actor self, Actor acceptor) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/DeliversCash.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversCash.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using OpenRA.Mods.Common.Activities;
@@ -29,12 +30,15 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Identifier checked against AcceptsDeliveredCash.ValidTypes. Only needed if the latter is not empty.")]
 		public readonly string Type = null;
 
+		[Desc("Sound to play when delivering cash")]
+		public readonly string[] Sounds = { };
+
 		[VoiceReference] public readonly string Voice = "Action";
 
 		public object Create(ActorInitializer init) { return new DeliversCash(this); }
 	}
 
-	class DeliversCash : IIssueOrder, IResolveOrder, IOrderVoice
+	class DeliversCash : IIssueOrder, IResolveOrder, IOrderVoice, INotifyCashTransfer
 	{
 		readonly DeliversCashInfo info;
 
@@ -78,6 +82,14 @@ namespace OpenRA.Mods.Common.Traits
 
 			self.SetTargetLine(target, Color.Yellow);
 			self.QueueActivity(new DonateCash(self, target.Actor, info.Payload, info.PlayerExperience));
+		}
+
+		void INotifyCashTransfer.OnAcceptingCash(Actor self, Actor donor) { }
+
+		void INotifyCashTransfer.OnDeliveringCash(Actor self, Actor acceptor)
+		{
+			if (info.Sounds.Length > 0)
+				Game.Sound.Play(SoundType.World, info.Sounds.Random(self.World.SharedRandom), self.CenterPosition);
 		}
 
 		public class DeliversCashOrderTargeter : UnitOrderTargeter

--- a/OpenRA.Mods.Common/Traits/Render/WithAcceptDeliveredCashAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAcceptDeliveredCashAnimation.cs
@@ -1,0 +1,65 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits.Render
+{
+	[Desc("Replaces the building animation when it accepts a cash delivery unit.")]
+	public class WithAcceptDeliveredCashAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>
+	{
+		[Desc("Sequence name to use")]
+		[SequenceReference] public readonly string Sequence = "active";
+
+		public object Create(ActorInitializer init) { return new WithAcceptDeliveredCashAnimation(init.Self, this); }
+	}
+
+	public class WithAcceptDeliveredCashAnimation : INotifyCashTransfer, INotifyBuildComplete, INotifySold
+	{
+		readonly WithAcceptDeliveredCashAnimationInfo info;
+		readonly WithSpriteBody[] wsbs;
+		bool buildComplete;
+
+		public WithAcceptDeliveredCashAnimation(Actor self, WithAcceptDeliveredCashAnimationInfo info)
+		{
+			this.info = info;
+			wsbs = self.TraitsImplementing<WithSpriteBody>().ToArray();
+		}
+
+		void INotifyBuildComplete.BuildingComplete(Actor self)
+		{
+			buildComplete = true;
+		}
+
+		void INotifySold.Selling(Actor self)
+		{
+			buildComplete = false;
+		}
+
+		void INotifySold.Sold(Actor self) { }
+
+		bool playing;
+		void INotifyCashTransfer.OnAcceptingCash(Actor self, Actor donor)
+		{
+			if (!buildComplete || playing)
+				return;
+
+			foreach (var wsb in wsbs)
+			{
+				playing = true;
+				wsb.PlayCustomAnimation(self, info.Sequence, () => playing = false);
+			}
+		}
+
+		void INotifyCashTransfer.OnDeliveringCash(Actor self, Actor acceptor) { }
+	}
+}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -370,4 +370,10 @@ namespace OpenRA.Mods.Common.Traits
 		void OnObjectiveCompleted(Player player, int objectiveID);
 		void OnObjectiveFailed(Player player, int objectiveID);
 	}
+
+	public interface INotifyCashTransfer
+	{
+		void OnAcceptingCash(Actor self, Actor donor);
+		void OnDeliveringCash(Actor self, Actor acceptor);
+	}
 }


### PR DESCRIPTION
This PR adds support for animation and sound for DonateCash, fulfilling the requirement for Yuri Grinder.
With the implementation of Type filter for DonateCash a while ago, only a little extension was needed, and here it is.