### PR TITLE
Allow multiple units to dock at one building

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Buildings/TiberianSunRefinery.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/TiberianSunRefinery.cs
@@ -24,9 +24,10 @@ namespace OpenRA.Mods.Cnc.Traits
 	{
 		public TiberianSunRefinery(Actor self, RefineryInfo info) : base(self, info) { }
 
-		public override Activity DockSequence(Actor harv, Actor self)
+		public override Activity DockSequence(Actor harv, Actor self, Dock dock)
 		{
-			return new VoxelHarvesterDockSequence(harv, self, DeliveryAngle, IsDragRequired, DragOffset, DragLength);
+			return new VoxelHarvesterDockSequence(harv, self,
+				dock.Info.DockAngle, dock.Info.IsDragRequired, dock.Info.DragOffset, dock.Info.DragLength);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/ActivityInterfaces.cs
+++ b/OpenRA.Mods.Common/Activities/ActivityInterfaces.cs
@@ -1,0 +1,37 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Activities;
+using OpenRA.Mods.Common.Traits;
+
+namespace OpenRA.Mods.Common.Activities
+{
+	public interface IDockActivity
+	{
+		// How to command the actor to move to the dock location.
+		// Assumes that this activity has 100% chance of making client to reach the dock.
+		// That means if you make client to move with nearenough threshold, things will break
+		// and the actor will perform docking actions out of place.
+		Activity ApproachDockActivities(Actor host, Actor client, Dock dock);
+
+		// What to do during the dock.
+		// No need for death check on host, DockManager will automatically use ActivitiesOnDockFail.
+		Activity DockActivities(Actor host, Actor client, Dock dock);
+
+		// Called when docking is complete.
+		// Queue client's post-undocking activities in this function, too.
+		Activity ActivitiesAfterDockDone(Actor host, Actor client, Dock dock);
+
+		// What to do on dock fail.
+		// ... host and dock are gone. Only client is the valid parameter!
+		Activity ActivitiesOnDockFail(Actor client);
+	}
+}

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -41,7 +41,11 @@ namespace OpenRA.Mods.Common.Activities
 
 			// TODO: This should check whether there is ammo left that is actually suitable for the target
 			if (ammoPools.All(x => !x.Info.SelfReloads && !x.HasAmmo()))
-				return ActivityUtils.SequenceActivities(new ReturnToBase(self, aircraft.Info.AbortOnResupply), this);
+			{
+				// return ActivityUtils.SequenceActivities(new ReturnToBase(self, aircraft.Info.AbortOnResupply), this);
+				Queue(new ReturnToBase(self, aircraft.Info.AbortOnResupply));
+				return NextActivity;
+			}
 
 			if (attackPlane != null)
 				attackPlane.DoAttack(self, target);

--- a/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
@@ -67,7 +67,10 @@ namespace OpenRA.Mods.Common.Activities
 
 			// If any AmmoPool is depleted and no weapon is valid against target, return to helipad to reload and then resume the activity
 			if (ammoPools.Any(x => !x.Info.SelfReloads && !x.HasAmmo()) && !attackHeli.HasAnyValidWeapons(target))
-				return ActivityUtils.SequenceActivities(new HeliReturnToBase(self, helicopter.Info.AbortOnResupply), this);
+			{
+				Queue(new HeliReturnToBase(self, helicopter.Info.AbortOnResupply));
+				return NextActivity;
+			}
 
 			var dist = target.CenterPosition - self.CenterPosition;
 

--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -9,6 +9,8 @@
  */
 #endregion
 
+using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
@@ -16,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
-	public class HeliReturnToBase : Activity
+	public class HeliReturnToBase : Activity, IDockActivity
 	{
 		readonly Aircraft heli;
 		readonly bool alwaysLand;
@@ -31,13 +33,31 @@ namespace OpenRA.Mods.Common.Activities
 			this.dest = dest;
 		}
 
-		public Actor ChooseHelipad(Actor self, bool unreservedOnly)
+		IEnumerable<Actor> GetHelipads(Actor self)
 		{
-			var rearmBuildings = heli.Info.RearmBuildings;
-			return self.World.Actors.Where(a => a.Owner == self.Owner
-				&& rearmBuildings.Contains(a.Info.Name)
-				&& (!unreservedOnly || !Reservable.IsReserved(a)))
-				.ClosestTo(self);
+			return self.World.ActorsHavingTrait<DockManager>().Where(a =>
+				a.Owner == self.Owner &&
+				heli.Info.RearmBuildings.Contains(a.Info.Name) &&
+				!a.IsDead &&
+				!a.Disposed);
+		}
+
+		IEnumerable<Actor> GetDockableHelipads(Actor self)
+		{
+			foreach (var pad in GetHelipads(self))
+			{
+				var dockManager = pad.Trait<DockManager>();
+				if (dockManager.HasFreeServiceDock(self))
+					yield return pad;
+			}
+		}
+
+		protected override void OnFirstRun(Actor self)
+		{
+			// Release first, before trying to dock.
+			var dc = self.TraitOrDefault<DockClient>();
+			if (dc != null)
+				dc.Release();
 		}
 
 		public override Activity Tick(Actor self)
@@ -45,54 +65,61 @@ namespace OpenRA.Mods.Common.Activities
 			if (IsCanceled)
 				return NextActivity;
 
-			if (dest == null || dest.IsDead || Reservable.IsReserved(dest))
-				dest = ChooseHelipad(self, true);
-
-			var initialFacing = heli.Info.InitialFacing;
-
-			if (dest == null || dest.IsDead)
+			// Check status and make dest correct.
+			// Priorities:
+			// 1. closest reloadable hpad
+			// 2. closest hpad
+			// 3. null
+			if (dest == null || dest.IsDead || dest.Disposed)
 			{
-				var nearestHpad = ChooseHelipad(self, false);
-
-				if (nearestHpad == null)
-					return ActivityUtils.SequenceActivities(new Turn(self, initialFacing), new HeliLand(self, true), NextActivity);
+				var hpads = GetHelipads(self);
+				var dockableHpads = hpads.Where(p => p.Trait<DockManager>().HasFreeServiceDock(self));
+				if (dockableHpads.Any())
+					dest = dockableHpads.ClosestTo(self);
+				else if (hpads.Any())
+					dest = hpads.ClosestTo(self);
 				else
-				{
-					var distanceFromHelipad = (nearestHpad.CenterPosition - self.CenterPosition).HorizontalLength;
-					var distanceLength = heli.Info.WaitDistanceFromResupplyBase.Length;
-
-					// If no pad is available, move near one and wait
-					if (distanceFromHelipad > distanceLength)
-					{
-						var randomPosition = WVec.FromPDF(self.World.SharedRandom, 2) * distanceLength / 1024;
-
-						var target = Target.FromPos(nearestHpad.CenterPosition + randomPosition);
-
-						return ActivityUtils.SequenceActivities(new HeliFly(self, target, WDist.Zero, heli.Info.WaitDistanceFromResupplyBase), this);
-					}
-
-					return this;
-				}
+					dest = null;
 			}
 
-			var exit = dest.Info.TraitInfos<ExitInfo>().FirstOrDefault();
-			var offset = (exit != null) ? exit.SpawnOffset : WVec.Zero;
-
-			if (ShouldLandAtBuilding(self, dest))
+			// Owner doesn't have any feasible helipad, in this case.
+			if (dest == null)
 			{
-				heli.MakeReservation(dest);
-
+				// Probably the owner is having a crisis lol.
+				// Doesn't matter if the unit just sits there or do what ever NextActivity is.
 				return ActivityUtils.SequenceActivities(
-					new HeliFly(self, Target.FromPos(dest.CenterPosition + offset)),
-					new Turn(self, initialFacing),
-					new HeliLand(self, false),
-					new ResupplyAircraft(self),
-					!abortOnResupply ? NextActivity : null);
+					new Turn(self, heli.Info.InitialFacing),
+					new HeliLand(self, true),
+					NextActivity);
 			}
 
-			return ActivityUtils.SequenceActivities(
-				new HeliFly(self, Target.FromPos(dest.CenterPosition + offset)),
-				NextActivity);
+			// Do we need to land and reload/repair?
+			if (!ShouldLandAtBuilding(self, dest))
+			{
+				// Move near the hpad then do next activity.
+				return ActivityUtils.SequenceActivities(
+					new HeliFly(self, Target.FromActor(dest), new WDist(2048), new WDist(4096)),
+					NextActivity);
+			}
+
+			// Can't dock :(
+			if (!dest.Trait<DockManager>().HasFreeServiceDock(self))
+			{
+				// If no pad is available, move near one and wait
+				var distanceLength = (dest.CenterPosition - self.CenterPosition).HorizontalLength;
+				var randomPosition = WVec.FromPDF(self.World.SharedRandom, 2) * distanceLength / 1024;
+				var target = Target.FromPos(dest.CenterPosition + randomPosition);
+
+				Queue(ActivityUtils.SequenceActivities(
+					new HeliFly(self, target, WDist.Zero, heli.Info.WaitDistanceFromResupplyBase),
+					new Wait(29),
+					new HeliReturnToBase(self, abortOnResupply, null, alwaysLand)));
+				return NextActivity;
+			}
+
+			// Do the docking.
+			dest.Trait<DockManager>().ReserveDock(dest, self, this);
+			return NextActivity;
 		}
 
 		bool ShouldLandAtBuilding(Actor self, Actor dest)
@@ -105,6 +132,41 @@ namespace OpenRA.Mods.Common.Activities
 
 			return heli.Info.RearmBuildings.Contains(dest.Info.Name) && self.TraitsImplementing<AmmoPool>()
 					.Any(p => !p.Info.SelfReloads && !p.FullAmmo());
+		}
+
+		Activity IDockActivity.ApproachDockActivities(Actor host, Actor client, Dock dock)
+		{
+			return ActivityUtils.SequenceActivities(
+				new HeliFly(client, Target.FromPos(dock.CenterPosition)),
+				new Turn(client, dock.Info.DockAngle),
+				new HeliLand(client, false));
+		}
+
+		Activity IDockActivity.DockActivities(Actor host, Actor client, Dock dock)
+		{
+			client.SetTargetLine(Target.FromCell(client.World, dock.Location), Color.Green, false);
+
+			// Let's reload. The assumption here is that for aircrafts, there are no waiting docks.
+			return new ResupplyAircraft(client);
+		}
+
+		Activity IDockActivity.ActivitiesAfterDockDone(Actor host, Actor client, Dock dock)
+		{
+			var rp = host.Trait<RallyPoint>();
+
+			// Take off and move to RP.
+			// I know this depreciates AbortOnResupply activity but it is a bug to reuse NextActivity!
+			client.SetTargetLine(Target.FromCell(client.World, rp.Location), Color.Green, false);
+			return client.Trait<IMove>().MoveTo(rp.Location, 2);
+
+			// Old code:
+			// client.Info.TraitInfo<AircraftInfo>().AbortOnResupply ? null : client.CurrentActivity.NextActivity));
+		}
+
+		Activity IDockActivity.ActivitiesOnDockFail(Actor client)
+		{
+			// Stay idle
+			return null;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
@@ -18,15 +19,13 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
-	public class ReturnToBase : Activity
+	public class ReturnToBase : Activity, IDockActivity
 	{
 		readonly Aircraft plane;
 		readonly AircraftInfo planeInfo;
 		readonly bool alwaysLand;
 		readonly bool abortOnResupply;
-		bool isCalculated;
 		Actor dest;
-		WPos w1, w2, w3;
 
 		public ReturnToBase(Actor self, bool abortOnResupply, Actor dest = null, bool alwaysLand = true)
 		{
@@ -37,25 +36,18 @@ namespace OpenRA.Mods.Common.Activities
 			planeInfo = self.Info.TraitInfo<AircraftInfo>();
 		}
 
-		public static Actor ChooseAirfield(Actor self, bool unreservedOnly)
+		public static IEnumerable<Actor> GetAirfields(Actor self)
 		{
 			var rearmBuildings = self.Info.TraitInfo<AircraftInfo>().RearmBuildings;
-			return self.World.ActorsHavingTrait<Reservable>()
-				.Where(a => a.Owner == self.Owner
-					&& rearmBuildings.Contains(a.Info.Name)
-					&& (!unreservedOnly || !Reservable.IsReserved(a)))
-				.ClosestTo(self);
+			return self.World.ActorsHavingTrait<DockManager>()
+				.Where(a => a.Owner == self.Owner && rearmBuildings.Contains(a.Info.Name));
 		}
 
-		void Calculate(Actor self)
+		void CalculateLandingPath(Actor self, Dock dock, out WPos w1, out WPos w2, out WPos w3)
 		{
-			if (dest == null || dest.IsDead || Reservable.IsReserved(dest))
-				dest = ChooseAirfield(self, true);
-
-			if (dest == null)
-				return;
-
-			var landPos = dest.CenterPosition;
+			var plane = self.Trait<Aircraft>();
+			var planeInfo = self.Info.TraitInfo<AircraftInfo>();
+			var landPos = dock.CenterPosition;
 			var altitude = planeInfo.CruiseAltitude.Length;
 
 			// Distance required for descent.
@@ -66,7 +58,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Add 10% to the turning radius to ensure we have enough room
 			var speed = plane.MovementSpeed * 32 / 35;
-			var turnRadius = CalculateTurnRadius(speed);
+			var turnRadius = CalculateTurnRadius(planeInfo, speed);
 
 			// Find the center of the turning circles for clockwise and counterclockwise turns
 			var angle = WAngle.FromFacing(plane.Facing);
@@ -92,8 +84,6 @@ namespace OpenRA.Mods.Common.Activities
 			w1 = posCenter + tangentOffset;
 			w2 = approachCenter + tangentOffset;
 			w3 = approachStart;
-
-			isCalculated = true;
 		}
 
 		bool ShouldLandAtBuilding(Actor self, Actor dest)
@@ -108,34 +98,70 @@ namespace OpenRA.Mods.Common.Activities
 					.Any(p => !p.Info.SelfReloads && !p.FullAmmo());
 		}
 
+		protected override void OnFirstRun(Actor self)
+		{
+			// Release first, before trying to dock.
+			var dc = self.TraitOrDefault<DockClient>();
+			if (dc != null)
+				dc.Release();
+		}
+
 		public override Activity Tick(Actor self)
 		{
 			if (IsCanceled || self.IsDead)
 				return NextActivity;
 
-			if (!isCalculated)
-				Calculate(self);
-
-			if (dest == null || dest.IsDead)
+			// Check status and make dest correct.
+			// Priorities:
+			// 1. closest reloadable afld
+			// 2. closest afld
+			// 3. null
+			if (dest == null || dest.IsDead || dest.Disposed)
 			{
-				var nearestAfld = ChooseAirfield(self, false);
-
-				if (nearestAfld != null)
-					return ActivityUtils.SequenceActivities(
-						new Fly(self, Target.FromActor(nearestAfld), WDist.Zero, plane.Info.WaitDistanceFromResupplyBase),
-						new FlyCircleTimed(self, plane.Info.NumberOfTicksToVerifyAvailableAirport),
-						this);
+				var aflds = GetAirfields(self);
+				var dockableAflds = aflds.Where(p => p.Trait<DockManager>().HasFreeServiceDock(self));
+				if (dockableAflds.Any())
+					dest = dockableAflds.ClosestTo(self);
+				else if (aflds.Any())
+					dest = aflds.ClosestTo(self);
 				else
-				{
-					// Prevent an infinite loop in case we'd return to the activity that called ReturnToBase in the first place. Go idle instead.
-					Cancel(self);
-					return NextActivity;
-				}
+					dest = null;
 			}
+
+			// Owner doesn't have any feasible afld. In this case,
+			if (dest == null)
+			{
+				// Prevent an infinite loop in case we'd return to the activity that called ReturnToBase in the first place.
+				// Go idle instead.
+				Cancel(self);
+				return NextActivity;
+			}
+
+			// Player has an airfield but it is busy. Circle around.
+			if (!dest.Trait<DockManager>().HasFreeServiceDock(self))
+			{
+				Queue(ActivityUtils.SequenceActivities(
+					new Fly(self, Target.FromActor(dest), WDist.Zero, plane.Info.WaitDistanceFromResupplyBase),
+					new FlyCircleTimed(self, plane.Info.NumberOfTicksToVerifyAvailableAirport),
+					new ReturnToBase(self, abortOnResupply, null, alwaysLand)));
+				return NextActivity;
+			}
+
+			// Now we land. Unlike helis, regardless of ShouldLandAtBuilding, we should land.
+			// The difference is, do we just land or do we land and resupply.
+			dest.Trait<DockManager>().ReserveDock(dest, self, this);
+			return NextActivity;
+		}
+
+		public Activity LandingProcedure(Actor self, Dock dock)
+		{
+			var planeInfo = self.Info.TraitInfo<AircraftInfo>();
+			WPos w1, w2, w3;
+			CalculateLandingPath(self, dock, out w1, out w2, out w3);
 
 			List<Activity> landingProcedures = new List<Activity>();
 
-			var turnRadius = CalculateTurnRadius(planeInfo.Speed);
+			var turnRadius = CalculateTurnRadius(planeInfo, planeInfo.Speed);
 
 			landingProcedures.Add(new Fly(self, Target.FromPos(w1), WDist.Zero, new WDist(turnRadius * 3)));
 			landingProcedures.Add(new Fly(self, Target.FromPos(w2)));
@@ -144,22 +170,51 @@ namespace OpenRA.Mods.Common.Activities
 			landingProcedures.Add(new Fly(self, Target.FromPos(w3), WDist.Zero, new WDist(turnRadius / 2)));
 
 			if (ShouldLandAtBuilding(self, dest))
-			{
-				plane.MakeReservation(dest);
+				landingProcedures.Add(new Land(self, Target.FromPos(dock.CenterPosition)));
 
-				landingProcedures.Add(new Land(self, Target.FromActor(dest)));
-				landingProcedures.Add(new ResupplyAircraft(self));
-			}
-
-			if (!abortOnResupply)
-				landingProcedures.Add(NextActivity);
+			/*
+			// Causes bugs. Aircrafts should forget what they were doing.
+			// if (!abortOnResupply)
+			//	landingProcedures.Add(NextActivity);
+			*/
 
 			return ActivityUtils.SequenceActivities(landingProcedures.ToArray());
 		}
 
-		int CalculateTurnRadius(int speed)
+		int CalculateTurnRadius(AircraftInfo planeInfo, int speed)
 		{
 			return 45 * speed / planeInfo.TurnSpeed;
+		}
+
+		Activity IDockActivity.ApproachDockActivities(Actor host, Actor client, Dock dock)
+		{
+			// Let's reload. The assumption here is that for aircrafts, there are no waiting docks.
+			return LandingProcedure(client, dock);
+		}
+
+		Activity IDockActivity.DockActivities(Actor host, Actor client, Dock dock)
+		{
+			client.SetTargetLine(Target.FromPos(dock.CenterPosition), Color.Green, false);
+			return new ResupplyAircraft(client);
+		}
+
+		Activity IDockActivity.ActivitiesAfterDockDone(Actor host, Actor client, Dock dock)
+		{
+			// I'm ASSUMING rallypoint here.
+			var rp = host.Trait<RallyPoint>();
+
+			client.SetTargetLine(Target.FromCell(client.World, rp.Location), Color.Green, false);
+
+			// ResupplyAircraft handles this.
+			// Take off and move to RP.
+			return ActivityUtils.SequenceActivities(
+				new Fly(client, Target.FromCell(client.World, rp.Location)),
+				new FlyCircle(client));
+		}
+
+		Activity IDockActivity.ActivitiesOnDockFail(Actor client)
+		{
+			return new ReturnToBase(client, abortOnResupply);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
+++ b/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			aircraft.UnReserve();
 
-			var host = aircraft.GetActorBelow();
+			var host = aircraft.GetSupplierActorBelow();
 			var hasHost = host != null;
 			var rp = hasHost ? host.TraitOrDefault<RallyPoint>() : null;
 

--- a/OpenRA.Mods.Common/Activities/DeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverResources.cs
@@ -9,76 +9,84 @@
  */
 #endregion
 
+using System;
 using System.Drawing;
+using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
-	public class DeliverResources : Activity
+	public class DeliverResources : Activity, IDockActivity
 	{
 		const int NextChooseTime = 100;
 
-		readonly IMove movement;
 		readonly Harvester harv;
 
-		bool isDocking;
 		int chosenTicks;
 
 		public DeliverResources(Actor self)
 		{
-			movement = self.Trait<IMove>();
 			harv = self.Trait<Harvester>();
 			IsInterruptible = false;
 		}
 
 		public override Activity Tick(Actor self)
 		{
-			if (NextInQueue != null)
-				return NextInQueue;
+			// If a refinery is explicitly specified, link it.
+			if (harv.OwnerLinkedProc != null && harv.OwnerLinkedProc.IsInWorld)
+			{
+				harv.LinkProc(self, harv.OwnerLinkedProc);
+				harv.OwnerLinkedProc = null;
+			}
+			//// at this point, harv.OwnerLinkedProc == null.
 
-			// Find the nearest best refinery if not explicitly ordered to a specific refinery:
-			if (harv.OwnerLinkedProc == null || !harv.OwnerLinkedProc.IsInWorld)
+			// Is the refinery still alive? If not, link one.
+			if (harv.LinkedProc == null || !harv.LinkedProc.IsInWorld)
 			{
 				// Maybe we lost the owner-linked refinery:
-				harv.OwnerLinkedProc = null;
+				harv.LinkedProc = null;
 				if (self.World.WorldTick - chosenTicks > NextChooseTime)
 				{
 					harv.ChooseNewProc(self, null);
 					chosenTicks = self.World.WorldTick;
 				}
 			}
-			else
-				harv.LinkProc(self, harv.OwnerLinkedProc);
 
-			if (harv.LinkedProc == null || !harv.LinkedProc.IsInWorld)
-				harv.ChooseNewProc(self, null);
-
-			// No refineries exist; check again after delay defined in Harvester.
+			// No refineries exist. Check again after delay defined in Harvester.
 			if (harv.LinkedProc == null)
-				return ActivityUtils.SequenceActivities(new Wait(harv.Info.SearchForDeliveryBuildingDelay), this);
+			{
+				Queue(ActivityUtils.SequenceActivities(new Wait(harv.Info.SearchForDeliveryBuildingDelay), new DeliverResources(self)));
+				return NextActivity;
+			}
 
 			var proc = harv.LinkedProc;
-			var iao = proc.Trait<IAcceptResources>();
-
 			self.SetTargetLine(Target.FromActor(proc), Color.Green, false);
-			if (self.Location != proc.Location + iao.DeliveryOffset)
-			{
-				var notify = self.TraitsImplementing<INotifyHarvesterAction>();
-				foreach (var n in notify)
-					n.MovingToRefinery(self, proc.Location + iao.DeliveryOffset, this);
+			proc.Trait<DockManager>().ReserveDock(proc, self, this);
+			return NextActivity;
+		}
 
-				return ActivityUtils.SequenceActivities(movement.MoveTo(proc.Location + iao.DeliveryOffset, 0), this);
-			}
+		Activity IDockActivity.ApproachDockActivities(Actor host, Actor client, Dock dock)
+		{
+			return DockUtils.GenericApproachDockActivities(host, client, dock, this);
+		}
 
-			if (!isDocking)
-			{
-				isDocking = true;
-				iao.OnDock(self, this);
-			}
+		public Activity DockActivities(Actor host, Actor client, Dock dock)
+		{
+			return host.Trait<Refinery>().DockSequence(client, host, dock);
+		}
 
-			return ActivityUtils.SequenceActivities(new Wait(10), this);
+		Activity IDockActivity.ActivitiesAfterDockDone(Actor host, Actor client, Dock dock)
+		{
+			// Move to south of the ref to avoid cluttering up with other dock locations
+			return new CallFunc(() => harv.ContinueHarvesting(client));
+		}
+
+		Activity IDockActivity.ActivitiesOnDockFail(Actor client)
+		{
+			// go to somewhere else
+			return new CallFunc(() => harv.ContinueHarvesting(client));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/DockUtils.cs
+++ b/OpenRA.Mods.Common/Activities/DockUtils.cs
@@ -1,0 +1,75 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Drawing;
+using OpenRA.Activities;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Activities
+{
+	public static class DockUtils
+	{
+		public static Activity GenericApproachDockActivities(Actor host, Actor client, Dock dock,
+			Activity requester, bool goThroughHost = false)
+		{
+			var air = client.TraitOrDefault<Aircraft>();
+			if (air != null)
+			{
+				if (air.IsPlane)
+				{
+					// Let's reload. The assumption here is that for aircrafts, there are no waiting docks.
+					System.Diagnostics.Debug.Assert(requester is ReturnToBase, "Wrong parameter for landing");
+					var rtb = requester as ReturnToBase;
+					return rtb.LandingProcedure(client, dock);
+				}
+
+				var angle = dock.Info.DockAngle;
+				if (angle < 0)
+					angle = client.Info.TraitInfo<AircraftInfo>().InitialFacing;
+
+				return ActivityUtils.SequenceActivities(
+					new HeliFly(client, Target.FromPos(dock.CenterPosition)),
+					new Turn(client, angle),
+					new HeliLand(client, false));
+			}
+
+			if (goThroughHost)
+				return client.Trait<IMove>().MoveTo(dock.Location, host);
+			else
+				return client.Trait<IMove>().MoveTo(dock.Location, 0);
+		}
+
+		public static Activity GenericFollowRallyPointActivities(Actor host, Actor client, Dock dock, Activity requester)
+		{
+			var rp = host.Trait<RallyPoint>();
+
+			var air = client.TraitOrDefault<Aircraft>();
+			if (air != null)
+			{
+				if (air.IsPlane)
+				{
+					// ResupplyAircraft handles this.
+					// Take off and move to RP.
+					return ActivityUtils.SequenceActivities(
+						new Fly(client, Target.FromCell(client.World, rp.Location)),
+						new FlyCircle(client));
+				}
+
+				// Don't make helis do attack move, it will waste ammo.
+				return client.Trait<IMove>().MoveTo(rp.Location, 2);
+			}
+
+			client.SetTargetLine(Target.FromCell(host.World, rp.Location), Color.Green);
+			return new AttackMoveActivity(client, client.Trait<IMove>().MoveTo(rp.Location, 2));
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Activities/FindResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindResources.cs
@@ -58,7 +58,10 @@ namespace OpenRA.Mods.Common.Activities
 			var deliver = new DeliverResources(self);
 
 			if (harv.IsFull)
-				return ActivityUtils.SequenceActivities(deliver, NextActivity);
+			{
+				Queue(deliver);
+				return NextActivity;
+			}
 
 			var closestHarvestablePosition = ClosestHarvestablePos(self);
 
@@ -67,7 +70,10 @@ namespace OpenRA.Mods.Common.Activities
 			if (!closestHarvestablePosition.HasValue)
 			{
 				if (!harv.IsEmpty)
-					return deliver;
+				{
+					Queue(deliver);
+					return NextActivity;
+				}
 
 				var unblockCell = harv.LastHarvestedCell ?? (self.Location + harvInfo.UnblockCell);
 				var moveTo = mobile.NearestMoveableCell(unblockCell, 2, 5);
@@ -103,7 +109,10 @@ namespace OpenRA.Mods.Common.Activities
 				foreach (var n in notify)
 					n.MovingToResources(self, closestHarvestablePosition.Value, this);
 
-				return ActivityUtils.SequenceActivities(mobile.MoveTo(closestHarvestablePosition.Value, 1), new HarvestResource(self), this);
+				Queue(mobile.MoveTo(closestHarvestablePosition.Value, 2));
+				Queue(new HarvestResource(self));
+				Queue(new FindResources(self)); // don't reuse "this" activity.
+				return NextActivity;
 			}
 		}
 

--- a/OpenRA.Mods.Common/Activities/RepairDocking.cs
+++ b/OpenRA.Mods.Common/Activities/RepairDocking.cs
@@ -1,0 +1,61 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using OpenRA.Activities;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Activities
+{
+	public class RepairDocking : Activity, IDockActivity
+	{
+		readonly Repairable repairable;
+
+		public RepairDocking(Actor self, Actor host)
+		{
+			repairable = self.Trait<Repairable>();
+
+			var dc = self.Trait<DockClient>();
+			dc.Release();
+		}
+
+		public override Activity Tick(Actor self)
+		{
+			// No need for tick. This is a virtual activity just to fit IDockActivity.
+			throw new NotImplementedException();
+		}
+
+		Activity IDockActivity.ActivitiesAfterDockDone(Actor host, Actor client, Dock dock)
+		{
+			return DockUtils.GenericFollowRallyPointActivities(host, client, dock, this);
+		}
+
+		Activity IDockActivity.ActivitiesOnDockFail(Actor client)
+		{
+			// stay idle
+			return null;
+		}
+
+		Activity IDockActivity.ApproachDockActivities(Actor host, Actor client, Dock dock)
+		{
+			return DockUtils.GenericApproachDockActivities(host, client, dock, this, true);
+		}
+
+		Activity IDockActivity.DockActivities(Actor host, Actor client, Dock dock)
+		{
+			return repairable.AfterReachActivities(client, host, dock);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Activities/SpriteHarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/SpriteHarvesterDockSequence.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly WithSpriteBody wsb;
 		readonly WithDockingAnimationInfo wda;
 
-		public SpriteHarvesterDockSequence(Actor self, Actor refinery, int dockAngle, bool isDragRequired, WVec dragOffset, int dragLength)
+		public SpriteHarvesterDockSequence(Actor self, Actor refinery, CPos dockLocation, int dockAngle, bool isDragRequired, WVec dragOffset, int dragLength)
 			: base(self, refinery, dockAngle, isDragRequired, dragOffset, dragLength)
 		{
 			wsb = self.Trait<WithSpriteBody>();

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -68,6 +68,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Activities\ActivityInterfaces.cs" />
     <Compile Include="Activities\Air\AllowYieldingReservation.cs" />
     <Compile Include="Activities\Air\FallToEarth.cs" />
     <Compile Include="Activities\Air\Fly.cs" />
@@ -90,6 +91,7 @@
     <Compile Include="Activities\DeliverResources.cs" />
     <Compile Include="Activities\Demolish.cs" />
     <Compile Include="Activities\DeployForGrantedCondition.cs" />
+    <Compile Include="Activities\DockUtils.cs" />
     <Compile Include="Activities\DonateCash.cs" />
     <Compile Include="Activities\Enter.cs" />
     <Compile Include="Activities\EnterTransport.cs" />
@@ -110,6 +112,7 @@
     <Compile Include="Activities\Repair.cs" />
     <Compile Include="Activities\RepairBridge.cs" />
     <Compile Include="Activities\RepairBuilding.cs" />
+    <Compile Include="Activities\RepairDocking.cs" />
     <Compile Include="Activities\Sell.cs" />
     <Compile Include="Activities\SimpleTeleport.cs" />
     <Compile Include="Activities\SpriteHarvesterDockSequence.cs" />
@@ -295,6 +298,9 @@
     <Compile Include="Traits\Burns.cs" />
     <Compile Include="Traits\ChangesTerrain.cs" />
     <Compile Include="Traits\CommandBarBlacklist.cs" />
+    <Compile Include="Traits\Dock.cs" />
+    <Compile Include="Traits\DockClient.cs" />
+    <Compile Include="Traits\DockManager.cs" />
     <Compile Include="Traits\Health.cs" />
     <Compile Include="Traits\HitShape.cs" />
     <Compile Include="Traits\Player\DeveloperMode.cs" />

--- a/OpenRA.Mods.Common/Traits/Air/ReturnOnIdle.cs
+++ b/OpenRA.Mods.Common/Traits/Air/ReturnOnIdle.cs
@@ -36,11 +36,11 @@ namespace OpenRA.Mods.Common.Traits
 			if (self.World.Map.DistanceAboveTerrain(self.CenterPosition).Length < aircraftInfo.MinAirborneAltitude)
 				return;
 
-			var airfield = ReturnToBase.ChooseAirfield(self, true);
-			if (airfield != null)
+			var airfield = ReturnToBase.GetAirfields(self);
+			if (airfield.Any())
 			{
-				self.QueueActivity(new ReturnToBase(self, aircraftInfo.AbortOnResupply, airfield));
-				self.QueueActivity(new ResupplyAircraft(self));
+				self.CancelActivity(); // quit circling
+				self.QueueActivity(new ReturnToBase(self, aircraftInfo.AbortOnResupply, null));
 			}
 			else
 			{

--- a/OpenRA.Mods.Common/Traits/Dock.cs
+++ b/OpenRA.Mods.Common/Traits/Dock.cs
@@ -1,0 +1,87 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Activities;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public class DockInfo : ITraitInfo
+	{
+		[Desc("Docking offset relative to top-left cell.")]
+		public readonly CVec DockOffset = CVec.Zero;
+
+		[Desc("When CenterPosition is requested, we add this offset in addition to DockOffset.")]
+		public readonly WVec WOffset = WVec.Zero;
+
+		[Desc("Override Offset value and use center of the host actor as the dock offset?")]
+		public readonly bool Center = false;
+
+		[Desc("Just a waiting slot, not a dock that allows reloading / unloading / fixing")]
+		public readonly bool WaitingPlace = false;
+
+		[Desc("Dock angle. If < 0, the docker doesn't need to turn.")]
+		public readonly int DockAngle = -1;
+
+		[Desc("Does the refinery require the harvester to be dragged in?")]
+		public readonly bool IsDragRequired = false;
+
+		[Desc("Dock client gets dragged to the the location, where location = center of the host actor + this offset.")]
+		public readonly WVec DragOffset = WVec.Zero;
+
+		[Desc("In how many steps to perform the dragging?")]
+		public readonly int DragLength = 0;
+
+		[Desc("Priority of the docks, when managed by DockManager.")]
+		public readonly int Order = 0;
+
+		public object Create(ActorInitializer init) { return new Dock(init, this); }
+	}
+
+	public class Dock
+	{
+		public readonly DockInfo Info;
+		readonly Actor self;
+
+		public Actor Reserver;
+
+		public CPos Location { get { return self.Location + Info.DockOffset; } }
+		public WPos CenterPosition { get { return self.World.Map.CenterOfCell(Location) + Info.WOffset; } }
+
+		// blocked by some immoble obstacle?
+		public bool IsBlocked;
+
+		public Dock(ActorInitializer init, DockInfo info)
+		{
+			Info = info;
+			self = init.Self;
+		}
+
+		// Update IsBlocked on request...
+		// Could have made IsBlocked a property but that will make the game slow.
+		// Only checks for immobile objects so if there is a permanently EMP'ed mobile actor there,
+		// then this will not work...
+		public void CheckObstacle()
+		{
+			foreach (var a in self.World.ActorMap.GetActorsAt(Location))
+				if (a != self && a.TraitOrDefault<Mobile>() == null)
+				{
+					IsBlocked = true;
+					return;
+				}
+
+			IsBlocked = false;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Dock.cs
+++ b/OpenRA.Mods.Common/Traits/Dock.cs
@@ -25,9 +25,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("When CenterPosition is requested, we add this offset in addition to DockOffset.")]
 		public readonly WVec WOffset = WVec.Zero;
 
-		[Desc("Override Offset value and use center of the host actor as the dock offset?")]
-		public readonly bool Center = false;
-
 		[Desc("Just a waiting slot, not a dock that allows reloading / unloading / fixing")]
 		public readonly bool WaitingPlace = false;
 

--- a/OpenRA.Mods.Common/Traits/DockClient.cs
+++ b/OpenRA.Mods.Common/Traits/DockClient.cs
@@ -1,0 +1,136 @@
+﻿#region Copyright & License Information
+/*
+ * Dock client module by Boolbada of OP Mod.
+ *
+ * OpenRA Copyright info:
+ *
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Activities;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public class DockClientInfo : ITraitInfo
+	{
+		public object Create(ActorInitializer init) { return new DockClient(init, this); }
+	}
+
+	public enum DockState
+	{
+		NotAssigned,
+		WaitAssigned,
+		ServiceAssigned
+	}
+
+	// When dockmanager manages docked units, these units require dock client trait.
+	public class DockClient : INotifyKilled, INotifyBecomingIdle, INotifyActorDisposing, INotifyOwnerChanged, IResolveOrder
+	{
+		// readonly DockClientInfo info;
+		readonly Actor self;
+		Actor host;
+		Dock currentDock;
+
+		public DockState DockState = DockState.NotAssigned;
+		public IDockActivity Requester; // The activity that requested dock.
+
+		int acquireTimeStamp = -1;
+
+		public Actor Host { get { return host; } }
+
+		public Dock CurrentDock { get { return currentDock; } }
+
+		public DockClient(ActorInitializer init, DockClientInfo info)
+		{
+			// this.info = info;
+			self = init.Self;
+		}
+
+		public void Acquire(Actor host, Dock dock, DockState dockState)
+		{
+			// You are to acquire only when you don't have one.
+			// i.e., release first.
+			Release();
+
+			System.Diagnostics.Debug.Assert(currentDock == null, "To acquire dock, release first.");
+			dock.Reserver = self;
+			currentDock = dock;
+			DockState = dockState;
+			this.host = host;
+
+			acquireTimeStamp = self.World.WorldTick;
+		}
+
+		// Release what we are currently holding
+		public void Release()
+		{
+			if (currentDock != null)
+				currentDock.Reserver = null;
+
+			currentDock = null;
+			DockState = DockState.NotAssigned;
+			acquireTimeStamp = -1;
+			host = null;
+			//// Do NOT reset Requester! Deadlock resoluiton needs it.
+		}
+
+		public bool WaitedLong(int threshold)
+		{
+			if (acquireTimeStamp < 0)
+				return false;
+			return (self.World.WorldTick - acquireTimeStamp) >= threshold;
+		}
+
+		void INotifyKilled.Killed(Actor self, AttackInfo e)
+		{
+			Release();
+		}
+
+		void INotifyBecomingIdle.OnBecomingIdle(Actor self)
+		{
+			Release();
+		}
+
+		void INotifyActorDisposing.Disposing(Actor self)
+		{
+			Release();
+		}
+
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		{
+			Release();
+		}
+
+		void IResolveOrder.ResolveOrder(Actor self, Order order)
+		{
+			if (order.Queued)
+				return;
+
+			switch (order.OrderString)
+			{
+				case "Enter":
+				case "Deliver":
+				case "ReturnToBase":
+				case "Repair":
+					// Prevent race condition.
+					// i.e., other order acquires the dock then
+					// this gets evaled and releases it! Not good.
+					break;
+				default:
+					Release();
+					break;
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/DockManager.cs
+++ b/OpenRA.Mods.Common/Traits/DockManager.cs
@@ -1,0 +1,439 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Activities;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public class DockManagerInfo : ITraitInfo, Requires<DockInfo>
+	{
+		[Desc("Are any of the docks lie outside the building footprint? (and needs obstacle checking)")]
+		public readonly bool ExternalDocks = false;
+
+		[Desc("Dock next to the actor like RA1 naval yard?",
+			"Although dock position is ignored, one dummy dock is still required to determine DockAngle and stuff when docking.")]
+		public readonly bool DockNextToActor = false;
+
+		[Desc("Enable deadlock detection")]
+		public readonly bool DeadlockDetectionEnabled = true;
+
+		[Desc("Dead lock detection sampling is done this often.")]
+		public readonly int DeadlockDetectionPeriod = 457; // prime number yay =~ 30 seconds
+
+		public object Create(ActorInitializer init) { return new DockManager(init, this); }
+	}
+
+	/*
+	 * The class to do all the crazy queue management.
+	 * Not all multi-dock guys need queue management so making a separate manager class.
+	 */
+	public class DockManager : ITick, INotifyKilled, INotifyActorDisposing
+	{
+		readonly DockManagerInfo info;
+		readonly Actor host; // Don't use "self" as the name. Eventually, it gets confusing with client and causes bug!
+
+		readonly Dock[] allDocks;
+		readonly Dock[] serviceDocks;
+		readonly Dock[] waitDocks;
+		readonly List<Actor> queue = new List<Actor>();
+
+		CPos lastLocation; // in case this is a mobile dock.
+		int ticks;
+
+		public DockManager(ActorInitializer init, DockManagerInfo info)
+		{
+			host = init.Self;
+			this.info = info;
+			ticks = info.DeadlockDetectionPeriod;
+
+			// sort the dock traits by their Order trait.
+			var t0 = host.TraitsImplementing<Dock>().ToList();
+			t0.Sort(delegate(Dock a, Dock b) { return a.Info.Order - b.Info.Order; });
+			var t1 = t0.Where(d => !d.Info.WaitingPlace).ToList();
+			var t2 = t0.Where(d => d.Info.WaitingPlace).ToList();
+			allDocks = t0.ToArray();
+			serviceDocks = t1.ToArray();
+			waitDocks = t2.ToArray();
+		}
+
+		public bool HasFreeServiceDock(Actor client)
+		{
+			// This one is usually used by actors who will NOT use
+			// waiting docks (aircrafts).
+			// It makes sense to update dock status here.
+			CheckObstacle(host);
+			RemoveDead(queue);
+
+			foreach (var d in serviceDocks)
+			{
+				if (d.Reserver == null)
+					return true;
+				if (d.Reserver == client)
+					return true;
+			}
+
+			return false;
+		}
+
+		// for blocking check.
+		public IEnumerable<CPos> DockLocations
+		{
+			get
+			{
+				foreach (var d in allDocks)
+				{
+					yield return d.Location;
+				}
+			}
+		}
+
+		// For determining whether PROC to play animation or not. (+ some others)
+		public IEnumerable<Actor> DockedUnits
+		{
+			get
+			{
+				return serviceDocks.Where(d => d.Reserver != null && d.Reserver.Location == d.Location).Select(d => d.Reserver);
+			}
+		}
+
+		void CheckObstacle(Actor host)
+		{
+			if (info.DockNextToActor)
+				return;
+
+			if (!info.ExternalDocks)
+				return;
+
+			if (host.Location == lastLocation)
+				return;
+			lastLocation = host.Location;
+
+			foreach (var d in allDocks)
+				d.CheckObstacle();
+		}
+
+		// Parameters: sometimes the activity that requests ReserveDock knows well on how to do the docking.
+		// To help docking, pass this as param.
+		public void ReserveDock(Actor host, Actor client, IDockActivity requester)
+		{
+			if (info.DockNextToActor)
+			{
+				ServeAdjacentDocker(host, client, requester);
+				return;
+			}
+
+			// First, put the new client in the queue then process it.
+			if (!queue.Contains(client))
+			{
+				queue.Add(client);
+
+				// Initialize this noob.
+				// It might had been transferred from proc A to this proc.
+				var dc = client.Trait<DockClient>();
+				dc.DockState = DockState.NotAssigned;
+				dc.Requester = requester;
+			}
+
+			// notify the queue
+			ProcessQueue(host, client);
+		}
+
+		// This client cancels the dock.
+		void CancelDock(Actor a)
+		{
+			if (a == null || a.IsDead || a.Disposed)
+				return;
+
+			var dc = a.Trait<DockClient>();
+			dc.Release();
+
+			a.CancelActivity();
+			var act = dc.Requester.ActivitiesOnDockFail(a);
+			if (act != null)
+				a.QueueActivity(act);
+		}
+
+		// Cancel on request or death (host's mass cancel notification to all clients)
+		public void CancelDockAllClients()
+		{
+			foreach (var a in serviceDocks.Select(d => d.Reserver))
+				CancelDock(a);
+
+			foreach (var a in queue)
+				CancelDock(a);
+		}
+
+		// OnDock is called, even when client arrives at a waiting dock.
+		public void OnDock(Actor client, Dock dock)
+		{
+			// We have "arrived". But did we get to where we intended?
+			var dc = client.Trait<DockClient>();
+
+			if (client == null || client.IsDead || client.Disposed)
+				return;
+
+			if (host == null || host.IsDead || host.Disposed)
+			{
+				dc.Release();
+				CancelDock(client);
+				return;
+			}
+
+			// I tried to arrive at a waiting spot but actually it was a working dock and I'm sitting on it!
+			// (happens often when only one dock which is shared)
+			if (dock.Info.WaitingPlace == false && dc.DockState == DockState.WaitAssigned && client.Location == dock.Location)
+			{
+				dc.Release();
+				client.CancelActivity();
+				ProcessQueue(host, client);
+				return;
+			}
+
+			// Properly docked.
+			if (dock.Info.WaitingPlace == false && dc.DockState == DockState.ServiceAssigned && client.Location == dock.Location)
+			{
+				// resource transfer activities are queued by OnDock.
+				client.QueueActivity(dc.Requester.DockActivities(host, client, dock));
+				client.QueueActivity(new CallFunc(() => ReleaseAndSignalNext(client)));
+				client.QueueActivity(dc.Requester.ActivitiesAfterDockDone(host, client, dock));
+			}
+		}
+
+		void RemoveDeadLock(List<Actor> queue)
+		{
+			bool locked = false;
+
+			foreach (var d in allDocks)
+			{
+				foreach (var a in host.World.ActorMap.GetActorsAt(d.Location))
+				{
+					var dc = a.TraitOrDefault<DockClient>();
+					var mobile = a.TraitOrDefault<Mobile>();
+
+					if (host.Owner.Stances[a.Owner] != Stance.Ally)
+						continue;
+
+					// Not even my client. Get off my dock.
+					if (dc == null && mobile != null)
+					{
+						mobile.Nudge(a, host, true);
+						continue;
+					}
+					else if (dc == null) // do nothing, probably non-reloading aircraft or something.
+						continue;
+
+					if (dc.CurrentDock != null && dc.WaitedLong(info.DeadlockDetectionPeriod))
+						locked = true;
+				}
+			}
+
+			if (locked)
+				ResetDocks();
+		}
+
+		void ResetDocks()
+		{
+			// Expensive, but a sure solution where all locked guys get rescued.
+			// We don't get deadlocks very often so, let's be sure to remove then when they occur.
+			var clients = host.World.ActorsWithTrait<DockClient>().Where(a => a.Trait.Host == host);
+			queue.Clear();
+
+			foreach (var a in clients)
+			{
+				if (a.Actor.IsDead || a.Actor.Disposed)
+					continue;
+
+				var dc = a.Trait;
+				a.Actor.CancelActivity();
+				dc.Release();
+				queue.Add(a.Actor);
+			}
+
+			ProcessQueue(host, null);
+		}
+
+		public void ReleaseAndSignalNext(Actor client)
+		{
+			client.Trait<DockClient>().Release();
+
+			if (host.IsDead || host.Disposed)
+				return;
+			ProcessQueue(host, null); // notify queue
+		}
+
+		void ServeAdjacentDocker(Actor host, Actor client, IDockActivity requester)
+		{
+			// Since there is 0 tolerance about distance, we WILL arrive at the dock (or we get stuck haha)
+			client.QueueActivity(new MoveAdjacentTo(client, Target.FromActor(host)));
+
+			var dock = host.Trait<Dock>();
+
+			// resource transfer activities are queued by OnDock.
+			client.QueueActivity(requester.DockActivities(host, client, dock));
+			client.QueueActivity(requester.ActivitiesAfterDockDone(host, client, dock));
+		}
+
+		void ServeHead(Actor host, Actor head, Dock serviceDock)
+		{
+			var dockClient = head.Trait<DockClient>();
+
+			/*
+			cd == null means the queue is not so busy that the head is a new comer.
+            (for example, head == client case)
+			With thi in mind, 4 cases of null/not nullness of dock and cd:
+
+			cd == null and dock == null    ERROR: What? Docks can't be busy when cd == null. Can't happen.
+			cd == null and dock != null    Safe to serve.
+			cd != null and dock == null    ERROR: First in line, has nowhere to go? Can't happen.
+			cd != null and dock != null    Was in the waiting queue and now ready to serve.
+
+			So, except for the errorneous state that can't happen, head is safe to serve.
+			We rule out dock == null case in outer loop, before calling this function though.
+            */
+
+			dockClient.Release();
+			dockClient.Acquire(host, serviceDock, DockState.ServiceAssigned);
+
+			head.QueueActivity(dockClient.Requester.ApproachDockActivities(host, head, serviceDock));
+			head.QueueActivity(new CallFunc(() => OnDock(head, serviceDock)));
+		}
+
+		// As the actors are coming from all directions, first request, first served is not good.
+		// Let it be first come first served.
+		// We approximate distance computation by Rect-linear distance here, not Euclidean dist.
+		Actor NearestClient(Actor host, Dock dock, IEnumerable<Actor> queue)
+		{
+			Actor r = null;
+			int bestDist = -1;
+			foreach (var a in queue)
+			{
+				var vec = a.Location - dock.Location;
+				var dist = Math.Abs(vec.X) + Math.Abs(vec.Y);
+				if (r == null || dist < bestDist)
+				{
+					r = a;
+					bestDist = dist;
+				}
+			}
+
+			return r;
+		}
+
+		void ServeNewClient(Actor client)
+		{
+			var dockClient = client.Trait<DockClient>();
+
+			Dock dock = null;
+			if (waitDocks.Count() == 0)
+			{
+				dock = serviceDocks.Last();
+			}
+			else
+			{
+				// Find any available waiting slot.
+				dock = waitDocks.FirstOrDefault(d => d.Reserver == null && !d.IsBlocked);
+
+				// on nothing, share the last slot.
+				if (dock == null)
+					dock = waitDocks.Last();
+			}
+
+			// For last dock, current dock and occupier will be messed up but doesn't matter.
+			// The last one is shared anyway. The vacancy info is not very meaningful there.
+			if (dockClient.CurrentDock != null)
+				dockClient.Release();
+			dockClient.Acquire(host, dock, DockState.WaitAssigned);
+
+			// Move to the waiting dock and wait for service dock to be released.
+			client.QueueActivity(client.Trait<IMove>().MoveTo(dock.Location, 2));
+			client.QueueActivity(new CallFunc(() => OnDock(client, dock)));
+			client.QueueActivity(new WaitFor(() => dockClient.DockState == DockState.ServiceAssigned));
+		}
+
+		void RemoveDead(List<Actor> queue)
+		{
+			// dock release, acquire is done by DockClient trait. But, queue must be updated by DockManager.
+			// It won't be too hard though.
+
+			// hack: For refinaries idle ones should be excluded.
+			List<Actor> rms;
+			if (host.TraitOrDefault<Refinery>() != null)
+				rms = queue.Where(a => a.IsDead || a.IsIdle || a.Disposed).ToList();
+			else
+				rms = queue.Where(a => a.IsDead || a.Disposed).ToList();
+
+			foreach (var rm in rms)
+				queue.Remove(rm);
+		}
+
+		// Get the queue going by popping queue.
+		// Then, find a suitable dock place for the client and return it.
+		void ProcessQueue(Actor host, Actor client)
+		{
+			CheckObstacle(host);
+			RemoveDead(queue);
+
+			// Now serve the 1st in line, until all service docks are occupied.
+			while (queue.Count > 0)
+			{
+				// find the first available slot in the service docks.
+				var serviceDock = serviceDocks.FirstOrDefault(d => d.Reserver == null && !d.IsBlocked);
+				if (serviceDock == null)
+					break;
+				var head = NearestClient(host, serviceDock, queue);
+				ServeHead(host, head, serviceDock);
+				queue.Remove(head); // remove head
+			}
+
+			// was just a queue notification when the someone released the dock.
+			if (client == null)
+				return;
+
+			// Is served already?
+			if (!queue.Contains(client))
+				return;
+
+			ServeNewClient(client);
+		}
+
+		public static bool IsInQueue(Actor host, Actor client)
+		{
+			return host.Trait<DockManager>().queue.Contains(client);
+		}
+
+		void ITick.Tick(Actor host)
+		{
+			if (!info.DeadlockDetectionEnabled)
+				return;
+
+			if (ticks-- <= 0)
+			{
+				RemoveDeadLock(queue);
+				ticks = info.DeadlockDetectionPeriod;
+			}
+		}
+
+		public void Killed(Actor self, AttackInfo e)
+		{
+			CancelDockAllClients();
+		}
+
+		public void Disposing(Actor self)
+		{
+			CancelDockAllClients();
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -176,10 +176,10 @@ namespace OpenRA.Mods.Common.Traits
 		public Actor ClosestProc(Actor self, Actor ignore)
 		{
 			// Find all refineries and their occupancy count:
-			var refs = self.World.ActorsWithTrait<IAcceptResources>()
+			var refs = self.World.ActorsWithTrait<Refinery>()
 				.Where(r => r.Actor != ignore && r.Actor.Owner == self.Owner && IsAcceptableProcType(r.Actor))
 				.Select(r => new {
-					Location = r.Actor.Location + r.Trait.DeliveryOffset,
+					Location = r.Actor.Location, // ignore dock offsets
 					Actor = r.Actor,
 					Occupancy = self.World.ActorsHavingTrait<Harvester>(h => h.LinkedProc == r.Actor).Count() })
 				.ToDictionary(r => r.Location);
@@ -228,11 +228,13 @@ namespace OpenRA.Mods.Common.Traits
 			var lastproc = LastLinkedProc ?? LinkedProc;
 			if (lastproc != null && !lastproc.Disposed)
 			{
-				var deliveryLoc = lastproc.Location + lastproc.Trait<IAcceptResources>().DeliveryOffset;
-				if (self.Location == deliveryLoc)
+				// Am I blocking one of the dock positions?
+				var deliveryLocs = lastproc.Trait<DockManager>().DockLocations;
+				var deliveryLoc = deliveryLocs.Where(loc => loc == self.Location);
+				if (deliveryLoc.Any())
 				{
 					// Get out of the way:
-					var unblockCell = LastHarvestedCell ?? (deliveryLoc + Info.UnblockCell);
+					var unblockCell = LastHarvestedCell ?? (deliveryLoc.First() + Info.UnblockCell);
 					var moveTo = mobile.NearestMoveableCell(unblockCell, 1, 5);
 
 					// TODO: The harvest-deliver-return sequence is a horrible mess of duplicated code and edge-cases
@@ -302,11 +304,11 @@ namespace OpenRA.Mods.Common.Traits
 			if (contents.Keys.Count > 0)
 			{
 				var type = contents.First().Key;
-				var iao = proc.Trait<IAcceptResources>();
-				if (!iao.CanGiveResource(type.ValuePerUnit))
+				var ire = proc.Trait<IResourceExchange>();
+				if (!ire.CanGiveResource(type.ValuePerUnit))
 					return false;
 
-				iao.GiveResource(type.ValuePerUnit);
+				ire.GiveResource(type.ValuePerUnit);
 				if (--contents[type] == 0)
 					contents.Remove(type);
 
@@ -334,9 +336,9 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				yield return new EnterAlliedActorTargeter<IAcceptResourcesInfo>("Deliver", 5,
+				yield return new EnterAlliedActorTargeter<RefineryInfo>("Deliver", 5,
 					proc => IsAcceptableProcType(proc),
-					proc => proc.Trait<IAcceptResources>().AllowDocking);
+					proc => proc.Trait<Refinery>().AllowDocking);
 				yield return new HarvestOrderTargeter();
 			}
 		}
@@ -401,8 +403,8 @@ namespace OpenRA.Mods.Common.Traits
 			else if (order.OrderString == "Deliver")
 			{
 				// NOTE: An explicit deliver order forces the harvester to always deliver to this refinery.
-				var iao = order.TargetActor.TraitOrDefault<IAcceptResources>();
-				if (iao == null || !iao.AllowDocking || !IsAcceptableProcType(order.TargetActor))
+				var refi = order.TargetActor.TraitOrDefault<Refinery>();
+				if (refi == null || !refi.AllowDocking || !IsAcceptableProcType(order.TargetActor))
 					return;
 
 				if (order.TargetActor != OwnerLinkedProc)

--- a/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			buildComplete = false;
 		}
 
-		void INotifyDocking.Docked(Actor self, Actor harvester) { docked = true; PlayDockingOverlay(); }
-		void INotifyDocking.Undocked(Actor self, Actor harvester) { docked = false; }
+		void INotifyDocking.Docked(Actor self, Actor client) { docked = true; PlayDockingOverlay(); }
+		void INotifyDocking.Undocked(Actor self, Actor client) { docked = false; }
 	}
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -89,7 +89,7 @@ namespace OpenRA.Mods.Common.Traits
 	public interface INotifyProduction { void UnitProduced(Actor self, Actor other, CPos exit); }
 	public interface INotifyOtherProduction { void UnitProducedByOther(Actor self, Actor producer, Actor produced); }
 	public interface INotifyDelivery { void IncomingDelivery(Actor self); void Delivered(Actor self); }
-	public interface INotifyDocking { void Docked(Actor self, Actor harvester); void Undocked(Actor self, Actor harvester); }
+	public interface INotifyDocking { void Docked(Actor self, Actor client); void Undocked(Actor self, Actor client); }
 	public interface INotifyParachute { void OnParachute(Actor self); void OnLanded(Actor self, Actor ignore); }
 	public interface INotifyCapture { void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner); }
 	public interface INotifyDiscovered { void OnDiscovered(Actor self, Player discoverer, bool playNotification); }
@@ -179,14 +179,10 @@ namespace OpenRA.Mods.Common.Traits
 		void Undeploy(Actor self);
 	}
 
-	public interface IAcceptResourcesInfo : ITraitInfo { }
-	public interface IAcceptResources
+	public interface IResourceExchange
 	{
-		void OnDock(Actor harv, DeliverResources dockOrder);
 		void GiveResource(int amount);
 		bool CanGiveResource(int amount);
-		CVec DeliveryOffset { get; }
-		bool AllowDocking { get; }
 	}
 
 	public interface IProvidesAssetBrowserPalettes

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -210,6 +210,7 @@
 		Bounds: 24,24
 	Targetable:
 		TargetTypes: Ground, Vehicle
+	DockClient:
 	Repairable:
 	Passenger:
 		CargoType: Vehicle
@@ -266,6 +267,7 @@
 	WithSpriteControlGroupDecoration:
 	Selectable:
 		Bounds: 24,24
+	DockClient: # repairable so, dock client.
 	Aircraft:
 		RepairBuildings: hpad
 		LandWhenIdle: false

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -180,12 +180,16 @@ PROC:
 		Range: 6c0
 	WithBuildingBib:
 	Refinery:
+		TickRate: 15
+	DockManager:
+		ExternalDocks: false
+	Dock@0:
 		DockAngle: 112
 		DockOffset: 0,2
 		IsDragRequired: True
 		DragOffset: -554,512,0
 		DragLength: 12
-		TickRate: 15
+		Order: 0
 	StoresResources:
 		PipColor: Green
 		PipCount: 10
@@ -466,7 +470,15 @@ HPAD:
 		SpawnOffset: 0,-256,0
 	Production:
 		Produces: Aircraft.GDI, Aircraft.Nod
-	Reservable:
+	DockManager:
+		DockOnActor: true
+		DeadlockDetectionEnabled: false
+	Dock@0:
+		DockOffset: 0,0
+		# Don't put 512 there. If you put 512 then it will get out of designated offset
+		# from (0, 0) to (1, 1) and docking will not work as expected.
+		WOffset: 511,256,0
+		DockAngle: 224
 	RepairsUnits:
 		PlayerExperience: 25
 	WithRepairAnimation:
@@ -591,7 +603,12 @@ FIX:
 		Range: 5c0
 	WithBuildingBib:
 		HasMinibib: Yes
-	Reservable:
+	DockManager:
+		DeadlockDetectionEnabled: false
+		DockOnActor: true
+	Dock@0:
+		DockOffset: 1,1
+		Order: 0
 	RepairsUnits:
 		Interval: 15
 		PlayerExperience: 25

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -53,6 +53,7 @@ HARV:
 		Description: Collects Tiberium for processing.\n  Unarmed
 	Selectable:
 		Priority: 7
+	DockClient:
 	Harvester:
 		Resources: Tiberium, BlueTiberium
 		PipCount: 7

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -174,6 +174,7 @@
 	DrawLineToTarget:
 	HiddenUnderFog:
 	ActorLostNotification:
+	DockClient: # Repairable needs dock client
 	Repairable:
 		RepairBuildings: repair_pad
 	Guard:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -280,9 +280,13 @@ refinery:
 	RevealsShroud:
 		Range: 4c768
 	Refinery:
+		TickRate: 20
+	DockManager:
+		ExternalDocks: false
+	Dock@0:
 		DockAngle: 160
 		DockOffset: 2,1
-		TickRate: 20
+		Order: 0
 	StoresResources:
 		PipColor: green
 		PipCount: 10
@@ -844,7 +848,12 @@ repair_pad:
 		Bounds: 96,64
 	SelectionDecorations:
 		VisualBounds: 96,80
-	Reservable:
+	DockManager:
+		DeadlockDetectionEnabled: false
+		DockOnActor: true
+	Dock@0:
+		DockOffset: 1,1
+		Order: 0
 	RepairsUnits:
 		Interval: 10
 		HpPerStep: 80

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -63,6 +63,7 @@ harvester:
 	Selectable:
 		Class: harvester
 		Priority: 7
+	DockClient:
 	Harvester:
 		PipCount: 7
 		Capacity: 28

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -213,6 +213,7 @@
 	Targetable:
 		TargetTypes: Ground, Repair, Vehicle
 		RequiresCondition: !parachute
+	DockClient: # repairable implies dock client.
 	Repairable:
 	Chronoshiftable:
 	Passenger:
@@ -494,6 +495,7 @@
 	WithSpriteControlGroupDecoration:
 	Selectable:
 		Bounds: 24,24
+	DockClient: # Repair and Rearm implies dock client
 	Aircraft:
 		RepairBuildings: fix
 		RearmBuildings: afld

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1112,8 +1112,32 @@ PROC:
 		Range: 4c0
 	WithBuildingBib:
 	Refinery:
+	DockManager:
+		ExternalDocks: true
+	Dock@0:
 		DockAngle: 64
 		DockOffset: 1,2
+		Order: 0
+	Dock@1:
+		DockAngle: 64
+		DockOffset: 2,2
+		Order: 1
+		WaitingPlace: true
+	Dock@2:
+		DockAngle: 64
+		DockOffset: 3,2
+		Order: 2
+		WaitingPlace: true
+	Dock@3:
+		DockAngle: 64
+		DockOffset: 3,1
+		Order: 3
+		WaitingPlace: true
+	Dock@4:
+		DockAngle: 64
+		DockOffset: 3,0
+		Order: 4
+		WaitingPlace: true
 	StoresResources:
 		PipCount: 17
 		Capacity: 2000
@@ -1220,7 +1244,15 @@ HPAD:
 	RallyPoint:
 	Production:
 		Produces: Aircraft, Helicopter
-	Reservable:
+	DockManager:
+		DockOnActor: true
+		DeadlockDetectionEnabled: false
+	Dock@0:
+		DockOffset: 0,0
+		# Don't put 512 there. If you put 512 then it will get out of designated offset
+		# from (0, 0) to (1, 1) and docking will not work as expected.
+		WOffset: 511,256,0
+		DockAngle: 224
 	ProductionBar:
 	PrimaryBuilding:
 		PrimaryCondition: primary
@@ -1304,7 +1336,14 @@ AFLD:
 	RallyPoint:
 	Production:
 		Produces: Aircraft, Plane
-	Reservable:
+	DockManager:
+		DockOnActor: true
+		DeadlockDetectionEnabled: false
+	Dock@0:
+		DockOffset: 1,0
+		# Don't put 512 there. If you put 512 then it will get out of designated offset
+		# from (1, 0) to (1, 1) and docking will not work as expected.
+		WOffset: 0,511,0
 	ProvidesPrerequisite@soviet:
 		Factions: soviet, russia, ukraine
 		Prerequisite: aircraft.soviet
@@ -1761,7 +1800,12 @@ FIX:
 		Range: 4c0
 	WithBuildingBib:
 		HasMinibib: Yes
-	Reservable:
+	DockManager:
+		DeadlockDetectionEnabled: false
+		DockOnActor: true
+	Dock@0:
+		DockOffset: 1,1
+		Order: 0
 	RallyPoint:
 	RepairsUnits:
 		Interval: 7

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -267,6 +267,7 @@ HARV:
 		Priority: 7
 	SelectionDecorations:
 		VisualBounds: 42,42
+	DockClient:
 	Harvester:
 		Capacity: 20
 		Resources: Ore,Gems

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -569,6 +569,7 @@
 	Targetable:
 		RequiresCondition: !inside-tunnel
 		TargetTypes: Ground, Vehicle, Repair
+	DockClient:
 	Repairable:
 		RepairBuildings: gadept
 		Voice: Move
@@ -666,6 +667,7 @@
 	WithTextControlGroupDecoration:
 	SelectionDecorations:
 		Palette: pips
+	DockClient:
 	Aircraft:
 		AirborneCondition: airborne
 		RepairBuildings: gadept

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -212,7 +212,15 @@ GAHPAD:
 		Produces: Air
 	PrimaryBuilding:
 		PrimaryCondition: primary
-	Reservable:
+	DockManager:
+		DockOnActor: true
+		DeadlockDetectionEnabled: false
+	Dock@0:
+		DockOffset: 0,0
+		# Don't put 512 there. If you put 512 then it will get out of designated offset
+		# from (0, 0) to (1, 1) and docking will not work as expected.
+		WOffset: 0,511,0
+		DockAngle: 224
 	RepairsUnits:
 		PauseOnCondition: empdisable
 		PlayerExperience: 15
@@ -260,7 +268,12 @@ GADEPT:
 	RevealsShroud:
 		Range: 5c0
 		MaxHeightDelta: 3
-	Reservable:
+	DockManager:
+		DeadlockDetectionEnabled: false
+		DockOnActor: true
+	Dock@0:
+		DockOffset: 1,1
+		Order: 0
 	RepairsUnits:
 		PauseOnCondition: empdisable
 		PlayerExperience: 15

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -220,7 +220,15 @@ NAHPAD:
 		Produces: Air
 	PrimaryBuilding:
 		PrimaryCondition: primary
-	Reservable:
+	DockManager:
+		DockOnActor: true
+		DeadlockDetectionEnabled: false
+	Dock@0:
+		DockOffset: 0,0
+		# Don't put 512 there. If you put 512 then it will get out of designated offset
+		# from (0, 0) to (1, 1) and docking will not work as expected.
+		WOffset: 0,511,0
+		DockAngle: 224
 	RepairsUnits:
 		PauseOnCondition: empdisable
 		PlayerExperience: 15

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -399,8 +399,12 @@ NAWAST:
 		Range: 6c0
 		MaxHeightDelta: 3
 	TiberianSunRefinery:
+	DockManager:
+		ExternalDocks: false
+	Dock@0:
 		DockAngle: 160
 		DockOffset: 2,1
+		Order: 0
 	StoresResources:
 		PipColor: Red
 		PipCount: 15

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -311,6 +311,7 @@ WEED:
 		BuildPaletteOrder: 170
 		Prerequisites: ~naweap, nawast, ~techlevel.superweapons
 		Description: Collects veins for processing.\n  Unarmed
+	DockClient:
 	Harvester:
 		DeliveryBuildings: nawast
 		Capacity: 7

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -76,9 +76,13 @@ PROC:
 		Range: 6c0
 		MaxHeightDelta: 3
 	TiberianSunRefinery:
+		DiscardExcessResources: true
+	DockManager:
+		ExternalDocks: false
+	Dock@0:
 		DockAngle: 160
 		DockOffset: 2,1
-		DiscardExcessResources: true
+		Order: 0
 	StoresResources:
 		PipColor: Green
 		PipCount: 10

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -55,6 +55,7 @@ HARV:
 	Selectable:
 		Priority: 7
 		Bounds: 36,36
+	DockClient:
 	Harvester:
 		DeliveryBuildings: proc
 		Capacity: 28


### PR DESCRIPTION
Lua scriptable AI is nothing compared to this!
I have tamed this for several releases of my mod and the recent AI reinforcement learning, which involved about 1000 AI vs AI games. (Aircraft and Harvesters are expected to be stable. Not too sure about repairs and mine laying as AIs don't do that but they share code with aircraft and harvesters.)

Unifies ALL the docking: Including harvesting, repairing, rearming, aircraft repairing and rearming.

  * Solves RA2 style multiple aircraft landing in one building. #13654
  * Still susceptible to #9503 but if wait docks are carefully assigned, that can be mitigated.
  * #3089 can be mitigated as well.
  * Supersedes #13714 but I expect that one to be accepted into PR first :(
  * Makes Reservable obsolete.
  * Fixes harvester getting dead locked at the refinery by detecting the dead lock. (My other PR attempted fix in-field one). Might not work if, like 10 harvesters are there at the refinery and no waiting docks are added.
  * Also nudge away some silly units hanging around at the service docks.

I didn't want to touch those many activities but since the dock uses NextActivity extensively I HAD to get rid of most SequenceActivities.

And I came to a conclusion that it is the activity that knows what to do when docking, not the client/host actors. For example, if I ordered an MNLY to dock at a FIX it should move to the rally point after reloading and repairing. On the other hand, if it was laying mines and it came back to the dock to reload, it should reload and continue to lay the mines.