### PR TITLE
Actor.TraitsImplementing<T>() LINQ specialization & exceptions

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -248,7 +248,7 @@ namespace OpenRA
 			return World.TraitDict.GetOrDefault<T>(this);
 		}
 
-		public IEnumerable<T> TraitsImplementing<T>()
+		public ITraitEnumberable<T> TraitsImplementing<T>()
 		{
 			return World.TraitDict.WithInterface<T>(this);
 		}

--- a/OpenRA.Game/TraitDictionary.cs
+++ b/OpenRA.Game/TraitDictionary.cs
@@ -135,6 +135,11 @@ namespace OpenRA
 			readonly List<Actor> actors = new List<Actor>();
 			readonly List<T> traits = new List<T>();
 
+			static bool ActorHasTrait(List<Actor> actors, uint actor, int index)
+			{
+				return index < actors.Count && actors[index].ActorID == actor;
+			}
+
 			public int Queries { get; private set; }
 
 			public void Add(Actor actor, object trait)
@@ -156,9 +161,9 @@ namespace OpenRA
 			{
 				++Queries;
 				var index = actors.BinarySearchMany(actor);
-				if (index >= actors.Count || actors[index].ActorID != actor)
+				if (ActorHasTrait(actors, actor, index))
 					return default(T);
-				else if (index + 1 < actors.Count && actors[index + 1].ActorID == actor)
+				else if (ActorHasTrait(actors, actor, index + 1))
 					throw new InvalidOperationException("Actor {0} has multiple traits of type `{1}`".F(actors[index].Info.Name, typeof(T)));
 				else return traits[index];
 			}
@@ -194,7 +199,7 @@ namespace OpenRA
 				}
 
 				public void Reset() { index = actors.BinarySearchMany(actor) - 1; }
-				public bool MoveNext() { return ++index < actors.Count && actors[index].ActorID == actor; }
+				public bool MoveNext() { return ActorHasTrait(actors, actor, ++index); }
 				public T Current { get { return traits[index]; } }
 				object System.Collections.IEnumerator.Current { get { return Current; } }
 				public void Dispose() { }
@@ -264,7 +269,7 @@ namespace OpenRA
 			public void RemoveActor(uint actor)
 			{
 				var startIndex = actors.BinarySearchMany(actor);
-				if (startIndex >= actors.Count || actors[startIndex].ActorID != actor)
+				if (!ActorHasTrait(actors, actor, startIndex))
 					return;
 				var endIndex = startIndex + 1;
 				while (endIndex < actors.Count && actors[endIndex].ActorID == actor)

--- a/OpenRA.Game/TraitDictionary.cs
+++ b/OpenRA.Game/TraitDictionary.cs
@@ -44,6 +44,9 @@ namespace OpenRA
 		T FirstOrDefault(Func<T, bool> predicate);
 		List<T> ToList();
 		T[] ToArray();
+		bool Any();
+		bool Any(Func<T, bool> predicate);
+		bool All(Func<T, bool> predicate);
 	}
 
 	/// <summary>
@@ -290,6 +293,31 @@ namespace OpenRA
 
 					return default(T);
 				}
+
+				public virtual bool Any()
+				{
+					int index;
+					return FindFirstTrait(Container.actors, Actor, out index);
+				}
+
+				public virtual bool Check(Func<T, bool> predicate, bool any)
+				{
+					var actors = Container.actors;
+					var traits = Container.traits;
+					int index;
+					if (FindFirstTrait(actors, Actor, out index)) do
+					{
+						var trait = traits[index];
+						if (predicate(trait) == any)
+							return any;
+					}
+					while (ActorHasTrait(actors, Actor, ++index));
+
+					return !any;
+				}
+
+				public bool Any(Func<T, bool> predicate) { return Check(predicate, true); }
+				public bool All(Func<T, bool> predicate) { return Check(predicate, false); }
 			}
 
 			class MultipleEnumerator : IEnumerator<T>
@@ -387,6 +415,23 @@ namespace OpenRA
 						throw MissingAcceptableAt(index - 1);
 
 					return default(T);
+				}
+
+				public override bool Any() { return base.Check(Predicate, true); }
+				public override bool Check(Func<T, bool> predicate, bool any)
+				{
+					var actors = Container.actors;
+					var traits = Container.traits;
+					int index;
+					if (FindFirstTrait(actors, Actor, out index)) do
+					{
+						var trait = traits[index];
+						if (Predicate(trait) && (predicate(trait) == any))
+							return any;
+					}
+					while (ActorHasTrait(actors, Actor, ++index));
+
+					return !any;
 				}
 			}
 

--- a/OpenRA.Game/TraitDictionary.cs
+++ b/OpenRA.Game/TraitDictionary.cs
@@ -146,6 +146,18 @@ namespace OpenRA
 				return ActorHasTrait(actors, actor, index);
 			}
 
+			static int FindTraitRange(List<Actor> actors, uint actor, out int firstIndex, out int endIndex)
+			{
+				var actorCount = actors.Count;
+				firstIndex = actors.BinarySearchMany(actor);
+				var end = firstIndex;
+				while (end < actorCount && actors[end].ActorID == actor)
+					end++;
+
+				endIndex = end;
+				return end - firstIndex;
+			}
+
 			public int Queries { get; private set; }
 
 			public void Add(Actor actor, object trait)
@@ -274,13 +286,11 @@ namespace OpenRA
 
 			public void RemoveActor(uint actor)
 			{
-				int startIndex;
-				if (!FindFirstTrait(actors, actor, out startIndex))
+				int startIndex, endIndex;
+				var count = FindTraitRange(actors, actor, out startIndex, out endIndex);
+				if (count == 0)
 					return;
-				var endIndex = startIndex + 1;
-				while (ActorHasTrait(actors, actor, endIndex))
-					endIndex++;
-				var count = endIndex - startIndex;
+
 				actors.RemoveRange(startIndex, count);
 				traits.RemoveRange(startIndex, count);
 			}

--- a/OpenRA.Game/TraitDictionary.cs
+++ b/OpenRA.Game/TraitDictionary.cs
@@ -35,6 +35,10 @@ namespace OpenRA
 		}
 	}
 
+	public interface ITraitEnumberable<T> : IEnumerable<T>
+	{
+	}
+
 	/// <summary>
 	/// Provides efficient ways to query a set of actors by their traits.
 	/// </summary>
@@ -95,7 +99,7 @@ namespace OpenRA
 			return InnerGet<T>().GetOrDefault(actor.ActorID);
 		}
 
-		public IEnumerable<T> WithInterface<T>(Actor actor)
+		public ITraitEnumberable<T> WithInterface<T>(Actor actor)
 		{
 			CheckDestroyed(actor);
 			return InnerGet<T>().GetMultiple(actor.ActorID);
@@ -186,14 +190,14 @@ namespace OpenRA
 				else return traits[index];
 			}
 
-			public IEnumerable<T> GetMultiple(uint actor)
+			public ITraitEnumberable<T> GetMultiple(uint actor)
 			{
 				// PERF: Custom enumerator for efficiency - using `yield` is slower.
 				++Queries;
 				return new MultipleEnumerable(this, actor);
 			}
 
-			class MultipleEnumerable : IEnumerable<T>
+			class MultipleEnumerable : ITraitEnumberable<T>
 			{
 				readonly TraitContainer<T> container;
 				readonly uint actor;

--- a/OpenRA.Game/TraitDictionary.cs
+++ b/OpenRA.Game/TraitDictionary.cs
@@ -38,6 +38,7 @@ namespace OpenRA
 	public interface ITraitEnumberable<T> : IEnumerable<T>
 	{
 		ITraitEnumberable<T> Where(Func<T, bool> predicate);
+		List<T> ToList();
 	}
 
 	/// <summary>
@@ -206,6 +207,16 @@ namespace OpenRA
 				public virtual IEnumerator<T> GetEnumerator() { return new MultipleEnumerator(Container, Actor); }
 				System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() { return GetEnumerator(); }
 				public virtual ITraitEnumberable<T> Where(Func<T, bool> predicate) { return new MultipleEnumerableWhere(Container, Actor, predicate); }
+				public virtual List<T> ToList()
+				{
+					int startIndex, endIndex;
+					var result = new List<T>(FindTraitRange(Container.actors, Actor, out startIndex, out endIndex));
+					var traits = Container.traits;
+					while (startIndex < endIndex)
+						result.Add(traits[startIndex++]);
+
+					return result;
+				}
 			}
 
 			class MultipleEnumerator : IEnumerator<T>
@@ -238,6 +249,21 @@ namespace OpenRA
 				public override ITraitEnumberable<T> Where(Func<T, bool> predicate)
 				{
 					return new MultipleEnumerableWhere(Container, Actor, t => Predicate(t) && predicate(t));
+				}
+
+				public override List<T> ToList()
+				{
+					int startIndex, endIndex;
+					var result = new List<T>(FindTraitRange(Container.actors, Actor, out startIndex, out endIndex));
+					var traits = Container.traits;
+					while (startIndex < endIndex)
+					{
+						var trait = traits[startIndex++];
+						if (Predicate(trait))
+							result.Add(trait);
+					}
+
+					return result;
 				}
 			}
 


### PR DESCRIPTION
This leaves the LINQ queries as is, but provides `ITraitEnumberable<T>` which allows for specialization of `Where`, `ToList`, `ToArray`, `First[OrDefault]`, `Any`, `All`, and `Single[OrDefault]`. These specializations usually use one less `IEnumerator` and at most one array allocation for `ToList` & `ToArray` except for `.Where(...).ToArray()` which usually uses two array allocations. The `First` & `Single` specializations provide clearer exception messages as well. 