### PR TITLE
D2K Thumper deploy animation fix

### DIFF
--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -97,16 +97,19 @@ thumper:
 		Range: 2c768
 	Mobile:
 		Speed: 43
-		RequiresCondition: !deployed
+		RequiresCondition: undeployed
 	GrantConditionOnDeploy:
 		DeployedCondition: deployed
+		UndeployedCondition: undeployed
 		Facing: 128
 		AllowedTerrainTypes: Sand, Spice, Dune, SpiceSand
 	WithInfantryBody:
-		RequiresCondition: !deployed
+		RequiresCondition: undeployed
 	WithSpriteBody@DEPLOYED:
 		Sequence: thump
-		RequiresCondition: deployed
+		RequiresCondition: !undeployed
+	WithMakeAnimation@DEPLOYING:
+		Sequence: deploy
 	WithIdleOverlay@DEPLOYED:
 		Sequence: thump-sand
 		RequiresCondition: deployed

--- a/mods/d2k/sequences/infantry.yaml
+++ b/mods/d2k/sequences/infantry.yaml
@@ -228,6 +228,9 @@ thumper:
 		Facings: -8
 		Transpose: true
 		Tick: 120
+	deploy: DATA.R8
+		Start: 1458
+		Length: 5
 	thump: DATA.R8
 		Start: 1458
 		Length: 5
@@ -260,22 +263,6 @@ thumper:
 		ZOffset: -511
 	icon: DATA.R8
 		Start: 4275
-		Offset: -30,-24
-
-thumping:
-	idle: DATA.R8
-		Start: 1458
-		Length: 5
-		Tick: 150
-	make: DATA.R8
-		Start: 1458
-		Length: 5
-	damaged-idle: DATA.R8
-		Start: 1458
-		Length: 5
-		Tick: 150
-	icon: DATA.R8
-		Frames: 4275
 		Offset: -30,-24
 
 fremen:


### PR DESCRIPTION
Thumper's deploy animation is broken for very long. However, since Thumper is the ONLY example of deploying infantry in the bundled mods, it must be corrected, once and for all.

5 frames of deploy animation are rather short. I recommend making it 20 for test purpose.