### PR TITLE
Make WithSpriteBody and -Turret always use CancelCustomAnimation() after custom anim

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithAttackAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAttackAnimation.cs
@@ -75,8 +75,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (!IsTraitDisabled && !wsb.IsTraitDisabled && !string.IsNullOrEmpty(Info.AttackSequence))
 			{
 				attackAnimPlaying = true;
-				wsb.PlayCustomAnimation(self, Info.AttackSequence,
-					() => { wsb.CancelCustomAnimation(self); attackAnimPlaying = false; });
+				wsb.PlayCustomAnimation(self, Info.AttackSequence, () => attackAnimPlaying = false);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		void INotifyBuildingPlaced.BuildingPlaced(Actor self)
 		{
 			if (buildComplete)
-				wsb.PlayCustomAnimation(self, info.Sequence, () => wsb.CancelCustomAnimation(self));
+				wsb.PlayCustomAnimation(self, info.Sequence);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
@@ -31,6 +31,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		readonly WithSpriteBody wsb;
 		readonly Harvester harv;
 
+		// TODO: Remove this once WithSpriteBody has its own replacement
 		public bool IsModifying;
 
 		public WithHarvestAnimation(ActorInitializer init, WithHarvestAnimationInfo info)
@@ -51,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				return baseSequence;
 		}
 
-		public void Tick(Actor self)
+		void ITick.Tick(Actor self)
 		{
 			var baseSequence = wsb.NormalizeSequence(self, wsb.Info.Sequence);
 			var sequence = NormalizeHarvesterSequence(self, baseSequence);
@@ -59,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				wsb.DefaultAnimation.ReplaceAnim(sequence);
 		}
 
-		public void Harvested(Actor self, ResourceType resource)
+		void INotifyHarvesterAction.Harvested(Actor self, ResourceType resource)
 		{
 			var baseSequence = wsb.NormalizeSequence(self, Info.HarvestSequence);
 			var sequence = NormalizeHarvesterSequence(self, baseSequence);
@@ -72,18 +73,18 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		// If IsModifying isn't set to true, the docking animation
 		// will be overridden by the WithHarvestAnimation fullness modifier.
-		public void Docked()
+		void INotifyHarvesterAction.Docked()
 		{
 			IsModifying = true;
 		}
 
-		public void Undocked()
+		void INotifyHarvesterAction.Undocked()
 		{
 			IsModifying = false;
 		}
 
-		public void MovingToResources(Actor self, CPos targetCell, Activity next) { }
-		public void MovingToRefinery(Actor self, CPos targetCell, Activity next) { }
-		public void MovementCancelled(Actor self) { }
+		void INotifyHarvesterAction.MovingToResources(Actor self, CPos targetCell, Activity next) { }
+		void INotifyHarvesterAction.MovingToRefinery(Actor self, CPos targetCell, Activity next) { }
+		void INotifyHarvesterAction.MovementCancelled(Actor self) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleAnimation.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			if (--ticks <= 0)
 			{
-				wsb.PlayCustomAnimation(self, Info.Sequences.Random(Game.CosmeticRandom), () => wsb.CancelCustomAnimation(self));
+				wsb.PlayCustomAnimation(self, Info.Sequences.Random(Game.CosmeticRandom));
 				ticks = Info.Interval;
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithRearmAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRearmAnimation.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		void INotifyRearm.Rearming(Actor self, Actor target)
 		{
 			if (buildComplete && spriteBody != null && !IsTraitDisabled)
-				spriteBody.PlayCustomAnimation(self, Info.Sequence, () => spriteBody.CancelCustomAnimation(self));
+				spriteBody.PlayCustomAnimation(self, Info.Sequence);
 		}
 
 		void INotifyBuildComplete.BuildingComplete(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairAnimation.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		void INotifyRepair.Repairing(Actor self, Actor target)
 		{
 			if (buildComplete && spriteBody != null && !IsTraitDisabled)
-				spriteBody.PlayCustomAnimation(self, Info.Sequence, () => spriteBody.CancelCustomAnimation(self));
+				spriteBody.PlayCustomAnimation(self, Info.Sequence);
 		}
 
 		void INotifyBuildComplete.BuildingComplete(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			DefaultAnimation.PlayThen(NormalizeSequence(self, name), () =>
 			{
-				DefaultAnimation.Play(NormalizeSequence(self, Info.Sequence));
+				CancelCustomAnimation(self);
 				if (after != null)
 					after();
 			});
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			DefaultAnimation.PlayBackwardsThen(NormalizeSequence(self, name), () =>
 			{
-				DefaultAnimation.PlayRepeating(NormalizeSequence(self, Info.Sequence));
+				CancelCustomAnimation(self);
 				if (after != null)
 					after();
 			});

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			DefaultAnimation.PlayThen(NormalizeSequence(self, name), () =>
 			{
-				DefaultAnimation.Play(NormalizeSequence(self, Info.Sequence));
+				CancelCustomAnimation(self);
 				if (after != null)
 					after();
 			});

--- a/OpenRA.Mods.Common/Traits/Render/WithTurretedAttackAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurretedAttackAnimation.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		void PlayAttackAnimation(Actor self)
 		{
 			if (!string.IsNullOrEmpty(info.AttackSequence))
-				wst.PlayCustomAnimation(self, info.AttackSequence, () => wst.CancelCustomAnimation(self));
+				wst.PlayCustomAnimation(self, info.AttackSequence);
 		}
 
 		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel)

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var wsb = self.TraitOrDefault<WithSpriteBody>();
 			if (wsb != null && wsb.DefaultAnimation.HasSequence(info.Sequence))
-				wsb.PlayCustomAnimation(self, info.Sequence, () => wsb.CancelCustomAnimation(self));
+				wsb.PlayCustomAnimation(self, info.Sequence);
 
 			Game.Sound.Play(SoundType.World, info.OnFireSound, self.World.Map.CenterOfCell(order.TargetLocation));
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!string.IsNullOrEmpty(info.ActivationSequence))
 			{
 				var wsb = self.Trait<WithSpriteBody>();
-				wsb.PlayCustomAnimation(self, info.ActivationSequence, () => wsb.CancelCustomAnimation(self));
+				wsb.PlayCustomAnimation(self, info.ActivationSequence);
 			}
 
 			var targetPosition = self.World.Map.CenterOfCell(order.TargetLocation);


### PR DESCRIPTION
On bleed, custom animations that don't queue `CancelCustomAnimation()` will break the default sequence loop.

Closes #13742.