### PR TITLE
Allow disabling Burst reset & tweak TS missile trails

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -63,6 +63,9 @@ namespace OpenRA.GameRules
 		[Desc("Number of shots in a single ammo magazine.")]
 		public readonly int Burst = 1;
 
+		[Desc("Should number of remaining bursts be reset to Burst if ReloadDelay has passed since last shot?")]
+		public readonly bool ResetBurstAfterReloadDelay = true;
+
 		[Desc("What types of targets are affected.")]
 		public readonly HashSet<string> ValidTargets = new HashSet<string> { "Ground", "Water" };
 

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -229,7 +229,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!CanFire(self, target))
 				return null;
 
-			if (ticksSinceLastShot >= Weapon.ReloadDelay)
+			if (Weapon.ResetBurstAfterReloadDelay && ticksSinceLastShot >= Weapon.ReloadDelay)
 				Burst = Weapon.Burst;
 
 			ticksSinceLastShot = 0;

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -46,6 +46,7 @@ MechRailgun:
 	Range: 8c0
 	Burst: 2 # for alternating muzzle offsets, dmg/s identical to original
 	BurstDelay: 60
+	ResetBurstAfterReloadDelay: false
 	Report: railuse5.aud
 	Projectile: Railgun
 		BeamColor: 00FFFFC8

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -10,6 +10,8 @@
 		Inaccuracy: 128
 		Image: DRAGON
 		TrailImage: small_smoke_trail
+		TrailPalette: effect-ignore-lighting-alpha75
+		TrailInterval: 1
 		HorizontalRateOfTurn: 8
 		RangeLimit: 8c0
 		Palette: ra

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -95,6 +95,7 @@ BikeMissile:
 	Inherits: ^DefaultMissile
 	Burst: 2 # to make bike alternate between left and right launcher, no change in dmg/s compared to original TS
 	BurstDelay: 60
+	ResetBurstAfterReloadDelay: false
 	Range: 5c0
 	Report: misl1.aud
 	ValidTargets: Ground

--- a/mods/ts/weapons/smallguns.yaml
+++ b/mods/ts/weapons/smallguns.yaml
@@ -87,6 +87,7 @@ RaiderCannon:
 	Range: 4c0
 	Burst: 2 # this + BurstDelay just makes the buggy alternate between barrels (for muzzle flash), no actual difference to original TS
 	BurstDelay: 55
+	ResetBurstAfterReloadDelay: false
 	Report: chaingn1.aud
 	Warhead@1Dam: SpreadDamage
 		Damage: 40


### PR DESCRIPTION
Already resetting Bursts if ticksSinceLastShot reached ReloadDelay broke the alternating between muzzle offsets on some TS weapons, and might do the same for some 3rd-party mods.

Additionally, this PR tweaks TS missile trails a little, reducing the delay between trail spawn and making the trail anim use a palette with alpha transparency, bringing both aspects closer to the original.