### PR TITLE
Fix Client tooltip crash in Lobby

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/ClientTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/ClientTooltipLogic.cs
@@ -51,6 +51,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			widget.IsVisible = () => (orderManager.LobbyInfo.ClientWithIndex(clientIndex) != null);
 			tooltipContainer.BeforeRender = () =>
 			{
+				if (!widget.IsVisible())
+					return;
+
 				var latencyPrefixSize = latencyPrefix == null ? 0 : latencyPrefix.Bounds.X + latencyPrefixFont.Measure(latencyPrefix.GetText() + " ").X;
 				var locationWidth = locationFont.Measure(location.GetText()).X;
 				var adminWidth = adminFont.Measure(admin.GetText()).X;


### PR DESCRIPTION
Fixes #13731 

As I checked the combination I changed it to `widget.IsVisible() + tooltipContainer.BeforeRender` in #13365 is standard. It failed on line `if (admin.IsVisible())`. I tried to add the check to admin.IsVisible which avoided the crash but the tooltip of disconnected player stayed visible until mouse move so I added the early return as suggested by @pchote in #13731 .