### PR TITLE
TD Balance Changes. (20170802)

### DIFF
--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -163,7 +163,7 @@ E6:
 		Queue: Infantry.GDI, Infantry.Nod
 		Description: Damages and captures enemy structures.\n  Repairs destroyed vehicles\n  Unarmed
 	Mobile:
-		Speed: 56
+		Speed: 48
 	Health:
 		HP: 30
 	Passenger:

--- a/mods/cnc/weapons/explosions.yaml
+++ b/mods/cnc/weapons/explosions.yaml
@@ -39,6 +39,8 @@ FlametankExplode:
 
 HeliCrash:
 	Inherits: ^DamagingExplosion
+	Warhead@1Dam: SpreadDamage
+		Damage: 100
 
 HeliExplode:
 	Warhead@1Dam: SpreadDamage

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -20,7 +20,7 @@
 		Damage: 35
 		ValidTargets: Ground, Air
 		Versus:
-			None: 30
+			None: 20
 			Wood: 85
 			Light: 100
 			Heavy: 100
@@ -89,7 +89,7 @@ OrcaAGMissiles:
 		Damage: 28
 		ValidTargets: Ground
 		Versus:
-			None: 50
+			None: 30
 			Wood: 100
 			Light: 100
 			Heavy: 75


### PR DESCRIPTION
Engineer movement speed reduced to 48 from 56.

Helicopter crash damage increased to 100 from 40.

Rocket infantry damage vs none reduced to 20 from 30.

Updated: Orca damage vs none reduced to 30 from 50.

------

Engineer movement was the same speed as minigunners and at times would enable them to escape the minigunners. This slight speed reduction helps for this.

Helicopter crash damage was lacking and a slight increase in this enables them to do some damage. With the cost of the helicopter it is still not a good idea to sacrifice aircraft just for exta damage.

Rocket infantry in the playtest being used as infantry killers. Reducing the vs none damage down to fix this. Will see if needs to be lower.

Updated: Updated PR with Orca damage vs none. Same issue with Orcas missile damage doing to much vs infantry.