### PR TITLE
Remove redundant Disposed checks

### DIFF
--- a/OpenRA.Mods.Common/AI/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/AI/States/GroundStates.cs
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Common.AI
 			else
 			{
 				var enemies = owner.World.FindActorsInCircle(leader.CenterPosition, WDist.FromCells(12))
-					.Where(a1 => !a1.Disposed && !a1.IsDead);
+					.Where(a1 => !a1.IsDead);
 				var enemynearby = enemies.Where(a1 => a1.Info.HasTraitInfo<ITargetableInfo>() && leader.Owner.Stances[a1.Owner] == Stance.Enemy);
 				var target = enemynearby.ClosestTo(leader.CenterPosition);
 				if (target != null)

--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.Commands
 
 					foreach (var actor in world.Selection.Actors)
 					{
-						if (actor.IsDead || actor.Disposed)
+						if (actor.IsDead)
 							continue;
 
 						var leveluporder = new Order("DevLevelUp", actor, false);


### PR DESCRIPTION
`IsDead` always returns `true` if `Disposed` is `true`, so in both cases the `Disposed` check was redundant as it would return the same result as `IsDead`.