### PR TITLE
TD Bridges.

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -962,7 +962,9 @@
 		RequiresForceFire: yes
 		TargetTypes: Ground, Water
 	Health:
-		HP: 500
+		HP: 600
+	Armor:
+		Type: Heavy
 	SoundOnDamageTransition:
 		DamagedSounds: xplos.aud
 		DestroyedSounds: xplobig4.aud


### PR DESCRIPTION
Currently in both playtest and release the bridges for TD is 500hp with no armor. Meaning that minigunners and other unit types were able to kill them off fairly quickly. Giving them extra HP and an armor type means units such as minigunners, humvees, flamethrowers, and APCs can't kill bridges off quickly.

Bridge HP to 600 instead of 500.

Armor is now Heavy instead of no armor.