### PR TITLE
Perform FogObscures check as late as possible

### DIFF
--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Orders
 		static Target TargetForInput(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			var actor = world.ScreenMap.ActorsAt(mi)
-				.Where(a => !world.FogObscures(a) && a.Info.HasTraitInfo<ITargetableInfo>())
+				.Where(a => a.Info.HasTraitInfo<ITargetableInfo>() && !world.FogObscures(a))
 				.WithHighestSelectionPriority(worldPixel);
 
 			if (actor != null)

--- a/OpenRA.Mods.Common/Effects/SpriteEffect.cs
+++ b/OpenRA.Mods.Common/Effects/SpriteEffect.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Effects
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (world.FogObscures(pos) && !visibleThroughFog)
+			if (!visibleThroughFog && world.FogObscures(pos))
 				return SpriteRenderable.None;
 
 			var zoom = scaleSizeWithZoom ? 1f / wr.Viewport.Zoom : 1f;

--- a/OpenRA.Mods.Common/Orders/GuardOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/GuardOrderGenerator.cs
@@ -57,9 +57,10 @@ namespace OpenRA.Mods.Common.Orders
 		static IEnumerable<Actor> FriendlyGuardableUnits(World world, MouseInput mi)
 		{
 			return world.ScreenMap.ActorsAt(mi)
-				.Where(a => !world.FogObscures(a) && !a.IsDead &&
+				.Where(a => !a.IsDead &&
 					a.AppearsFriendlyTo(world.LocalPlayer.PlayerActor) &&
-					a.Info.HasTraitInfo<GuardableInfo>());
+					a.Info.HasTraitInfo<GuardableInfo>() &&
+					!world.FogObscures(a));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
@@ -159,10 +159,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (info.ShadowImage == null)
 				return Enumerable.Empty<IRenderable>();
 
-			if (IsTraitDisabled)
-				return Enumerable.Empty<IRenderable>();
-
-			if (self.IsDead || !self.IsInWorld)
+			if (IsTraitDisabled || self.IsDead || !self.IsInWorld)
 				return Enumerable.Empty<IRenderable>();
 
 			if (self.World.FogObscures(self))

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
@@ -49,10 +49,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
-			if (self.World.FogObscures(self))
+			if (self.Owner != wr.World.LocalPlayer)
 				yield break;
 
-			if (self.Owner != wr.World.LocalPlayer)
+			if (self.World.FogObscures(self))
 				yield break;
 
 			var pal = wr.Palette(Info.Palette);

--- a/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
@@ -66,10 +66,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
-			if (self.World.FogObscures(self))
+			if (self.Owner != wr.World.LocalPlayer)
 				yield break;
 
-			if (self.Owner != wr.World.LocalPlayer)
+			if (self.World.FogObscures(self))
 				yield break;
 
 			foreach (var r in DrawControlGroup(self, wr))

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -185,7 +185,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var worldPixel = worldRenderer.Viewport.ViewToWorldPx(Viewport.LastMousePos);
 			var underCursor = world.ScreenMap.ActorsAt(worldPixel)
-				.Where(a => !world.FogObscures(a) && a.Info.HasTraitInfo<ITooltipInfo>())
+				.Where(a => a.Info.HasTraitInfo<ITooltipInfo>() && !world.FogObscures(a))
 				.WithHighestSelectionPriority(worldPixel);
 
 			if (underCursor != null)


### PR DESCRIPTION
`FogObscures` is usually much more expensive than simpler boolean, viewing player or `HasTraitInfo` checks, so in these places it makes sense to perform the other checks first to avoid `FogObscures` altogether, if possible.

