### PR TITLE
Corrected gnrl sequences & added TakeCover: to him

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -460,6 +460,10 @@ GNRL:
 	Voiced:
 		VoiceSet: StavrosVoice
 	-ScaredyCat:
+	TakeCover:
+		DamageModifiers:
+			Prone50Percent: 50
+		DamageTriggers: TriggerProne
 	WithInfantryBody:
 		IdleSequences: idle1
 

--- a/mods/ra/sequences/infantry.yaml
+++ b/mods/ra/sequences/infantry.yaml
@@ -853,21 +853,22 @@ gnrl:
 		Facings: 8
 	run:
 		Start: 8
-		Length: 5
+		Length: 6
 		Facings: 8
-		Tick: 80
+		Tick: 100
 	shoot:
 		Start: 56
 		Length: 4
 		Facings: 8
 	prone-stand:
-		Start: 88
-		Stride: 2
+		Start: 104
+		Stride: 4
 		Facings: 8
 	prone-run:
 		Start: 104
 		Length: 4
 		Facings: 8
+		Tick: 100
 	standup:
 		Start: 136
 		Length: 2


### PR DESCRIPTION
Closes #13724.

I added `TakeCover:` to him because the sequences were already defined and don't see a reason not to use them.