### PR TITLE
[RA] Complete balance patch (1.6) for the next playtest/release.

### DIFF
--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -87,6 +87,7 @@ MIG:
 		BuildAtProductionType: Plane
 		BuildPaletteOrder: 50
 		Prerequisites: ~afld, stek, ~techlevel.high
+		BuildDuration: 1750
 		Description: Fast Ground-Attack Plane.\n  Strong vs Buildings, Tanks\n  Weak vs Infantry, Light armor, Aircraft
 	Valued:
 		Cost: 2000
@@ -216,22 +217,22 @@ TRAN:
 	Tooltip:
 		Name: Chinook
 	Health:
-		HP: 120
+		HP: 140
 	Armor:
 		Type: Light
 	RevealsShroud:
-		Range: 10c0
+		Range: 8c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
-		Range: 8c0
+		Range: 6c0
 		Type: GroundPosition
 	Aircraft:
 		InitialFacing: 224
 		TurnSpeed: 5
-		Speed: 112
+		Speed: 128
 		LandableTerrainTypes: Clear,Rough,Road,Ore,Beach,Gems
-		AltitudeVelocity: 0c100
+		AltitudeVelocity: 0c58
 	WithIdleOverlay@ROTOR1AIR:
 		Offset: 597,0,213
 		Sequence: rotor
@@ -265,6 +266,7 @@ HELI:
 		BuildAtProductionType: Helicopter
 		BuildPaletteOrder: 40
 		Prerequisites: ~hpad, atek, ~techlevel.high
+		BuildDuration: 1750
 		Description: Helicopter gunship armed\nwith multi-purpose missiles.\n  Strong vs Tanks, Aircraft\n  Weak vs Infantry
 	Valued:
 		Cost: 2000

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -69,19 +69,27 @@ FCOM:
 		Footprint: xx xx ==
 		Dimensions: 2,3
 		LocalCenterOffset: 0,-512,0
-	Valued:
-		Cost: 2000
 	Health:
-		HP: 400
+		HP: 800
 	Armor:
 		Type: Wood
 	Tooltip:
 		Name: Forward Command
 	RevealsShroud:
-		Range: 10c0
+		Range: 5c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
 	WithBuildingBib:
+	ExternalCapturable: 
+		CaptureCompleteTime: 30
+	ExternalCapturableBar:
+	GivesBuildableArea:
+	BaseProvider:
+		Range: 8c0
+	EngineerRepairable:
 	Power:
-		Amount: -200
+		Amount: 0
 	ProvidesPrerequisite@buildingname:
 
 HOSP:
@@ -352,17 +360,21 @@ MISS:
 		Footprint: xxx xxx ===
 		Dimensions: 3,3
 		LocalCenterOffset: 0,-512,0
-	Valued:
-		Cost: 2000
 	Health:
-		HP: 400
+		HP: 600
 	RevealsShroud:
-		Range: 3c0
+		Range: 10c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 6c0
 	Armor:
 		Type: Wood
 	Tooltip:
-		Name: Technology Center
+		Name: Communications Center
 	WithBuildingBib:
+	ExternalCapturable: 
+	ExternalCapturableBar:
+	EngineerRepairable:
 	WithDeathAnimation:
 		DeathSequence: dead
 		UseDeathTypeSuffix: false

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -332,6 +332,8 @@ E7:
 		StandSequences: stand
 	AnnounceOnBuild:
 	AnnounceOnKill:
+	DetectCloaked:
+		CloakTypes: Cloak, Hijacker
 	Voiced:
 		VoiceSet: TanyaVoice
 	ProducibleWithLevel:
@@ -350,7 +352,7 @@ MEDI:
 	Tooltip:
 		Name: Medic
 	Health:
-		HP: 80
+		HP: 60
 	RevealsShroud:
 		Range: 3c0
 	Passenger:
@@ -536,11 +538,11 @@ SHOK:
 		Prerequisites: ~barr, stek, tsla, ~infantry.russia, ~techlevel.high
 		Description: Elite infantry with portable tesla coils.\n  Strong vs Infantry, Vehicles\n  Weak vs Aircraft
 	Valued:
-		Cost: 400
+		Cost: 300
 	Tooltip:
 		Name: Shock Trooper
 	Health:
-		HP: 60
+		HP: 50
 	Mobile:
 		Voice: Move
 	RevealsShroud:

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -18,6 +18,7 @@ Player:
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		SpeedUp: True
+		BuildTimeSpeedReduction: 100, 75, 60, 50
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
 		LowPowerSlowdown: 3

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -68,6 +68,7 @@ MSUB:
 		BuildAtProductionType: Submarine
 		BuildPaletteOrder: 60
 		Prerequisites: ~spen, stek, ~techlevel.high
+		BuildDuration: 1750
 		Description: Submerged anti-ground siege unit\nwith anti-air capabilities.\nCan detect other submarines.\n  Strong vs Buildings, Ground units, Aircraft\n  Weak vs Naval units\n  Special Ability: Submerge
 	Valued:
 		Cost: 2000
@@ -182,6 +183,7 @@ CA:
 		BuildAtProductionType: Boat
 		BuildPaletteOrder: 50
 		Prerequisites: ~syrd, atek, ~techlevel.high
+		BuildDuration: 2000
 		Description: Very slow long-range ship.\n  Strong vs Buildings, Ground units\n  Weak vs Naval units, Aircraft
 	Valued:
 		Cost: 2400

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -551,8 +551,6 @@ AGUN:
 		RangeCircleType: aa
 	Power:
 		Amount: -50
-	DetectCloaked:
-		Range: 6c0
 	BodyOrientation:
 		UseClassicFacingFudge: True
 
@@ -602,6 +600,7 @@ DOME:
 	InfiltrateForExploration:
 	DetectCloaked:
 		Range: 10c0
+		RequiresCondition: !disabled
 	RenderDetectionCircle:
 	Power:
 		Amount: -40
@@ -812,7 +811,7 @@ SAM:
 		Prerequisites: dome, ~structures.soviet, ~techlevel.medium
 		Description: Anti-Air base defense.\nRequires power to operate.\nCan detect cloaked units.\n  Strong vs Aircraft\n  Weak vs Ground units
 	Valued:
-		Cost: 750
+		Cost: 700
 	Tooltip:
 		Name: SAM Site
 	Building:
@@ -844,8 +843,6 @@ SAM:
 		RangeCircleType: aa
 	Power:
 		Amount: -40
-	DetectCloaked:
-		Range: 6c0
 	BodyOrientation:
 		UseClassicFacingFudge: True
 
@@ -1106,7 +1103,7 @@ PROC:
 	Armor:
 		Type: Wood
 	RevealsShroud:
-		Range: 6c0
+		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 4c0
@@ -1333,7 +1330,7 @@ AFLD:
 		OrderName: SovietSpyPlane
 		Prerequisites: aircraft.soviet
 		Icon: spyplane
-		ChargeTime: 180
+		ChargeTime: 150
 		Description: Spy Plane
 		LongDesc: Reveals an area of the map\nand cloaked enemy units.
 		SelectTargetSpeechNotification: SelectTarget
@@ -1351,7 +1348,7 @@ AFLD:
 		OrderName: SovietParatroopers
 		Prerequisites: aircraft.soviet
 		Icon: paratroopers
-		ChargeTime: 360
+		ChargeTime: 300
 		Description: Paratroopers
 		LongDesc: A Badger drops a squad of infantry\nanywhere on the map.
 		DropItems: E1R1,E1R1,E1R1,E3R1,E3R1
@@ -1368,7 +1365,7 @@ AFLD:
 		OrderName: UkraineParabombs
 		Prerequisites: aircraft.ukraine
 		Icon: parabombs
-		ChargeTime: 360
+		ChargeTime: 300
 		Description: Parabombs
 		LongDesc: A squad of Badgers drops parachuted\nbombs on your target.
 		SelectTargetSpeechNotification: SelectTarget
@@ -1505,7 +1502,7 @@ STEK:
 		Dimensions: 3,3
 		LocalCenterOffset: 0,-512,0
 	Health:
-		HP: 600
+		HP: 800
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1527,7 +1524,7 @@ BARR:
 		Prerequisites: anypower, ~structures.soviet, ~techlevel.infonly
 		Description: Trains infantry.
 	Valued:
-		Cost: 400
+		Cost: 500
 	Tooltip:
 		Name: Soviet Barracks
 	Building:
@@ -1796,7 +1793,7 @@ SBAG:
 	Tooltip:
 		Name: Sandbag Wall
 	Health:
-		HP: 300
+		HP: 150
 	Armor:
 		Type: Wood
 	LineBuild:
@@ -1821,7 +1818,7 @@ FENC:
 	Tooltip:
 		Name: Wire Fence
 	Health:
-		HP: 300
+		HP: 150
 	Armor:
 		Type: Wood
 	LineBuild:
@@ -1849,7 +1846,7 @@ BRIK:
 		DamagedSounds: crmble2.aud
 		DestroyedSounds: kaboom30.aud
 	Health:
-		HP: 500
+		HP: 400
 	Armor:
 		Type: Concrete
 	Crushable:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -129,7 +129,7 @@ V2RL:
 	Tooltip:
 		Name: Heavy Tank
 	Health:
-		HP: 550
+		HP: 600
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -213,6 +213,8 @@ V2RL:
 		VisualBounds: 44,38,0,-4
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
+	DetectCloaked:
+		Range: 6c0
 
 ARTY:
 	Inherits: ^Tank
@@ -322,7 +324,7 @@ MCV:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 85
+		Speed: 71
 		Crushes: wall, mine, crate, infantry
 	RevealsShroud:
 		Range: 4c0
@@ -502,7 +504,7 @@ MGG:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 85
+		Speed: 99
 	WithIdleOverlay@SPINNER:
 		Offset: -299,0,171
 		Sequence: spinner
@@ -535,7 +537,7 @@ MRJ:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 85
+		Speed: 99
 	RevealsShroud:
 		Range: 7c0
 	WithIdleOverlay@SPINNER:
@@ -554,7 +556,7 @@ MRJ:
 		DeflectionStances: Neutral, Enemy
 	RenderJammerCircle:
 	DetectCloaked:
-		Range: 7c0
+		Range: 6c0
 
 TTNK:
 	Inherits: ^Tank
@@ -563,13 +565,14 @@ TTNK:
 		Queue: Vehicle
 		BuildPaletteOrder: 170
 		Prerequisites: tsla, stek, ~vehicles.russia, ~techlevel.high
+		BuildDuration: 1166
 		Description: Tank with mounted tesla coil.\n  Strong vs Infantry, Vehicles, Buildings\n  Weak vs Aircraft
 	Valued:
 		Cost: 1350
 	Tooltip:
 		Name: Tesla Tank
 	Health:
-		HP: 400
+		HP: 450
 	Armor:
 		Type: Light
 	Mobile:
@@ -673,6 +676,7 @@ CTNK:
 		Queue: Vehicle
 		BuildPaletteOrder: 200
 		Prerequisites: atek, ~vehicles.germany, ~techlevel.high
+		BuildDuration: 1166
 		Description: Chrono Tank, teleports to areas within range.\n  Strong vs Vehicles, Buildings\n  Weak vs Infantry, Aircraft\n  Special ability: Can teleport
 	Valued:
 		Cost: 1350
@@ -681,7 +685,7 @@ CTNK:
 	SelectionDecorations:
 		VisualBounds: 30,30
 	Health:
-		HP: 400
+		HP: 450
 	Armor:
 		Type: Light
 	Mobile:
@@ -743,6 +747,7 @@ STNK:
 		Queue: Vehicle
 		BuildPaletteOrder: 130
 		Prerequisites: atek, ~vehicles.england, ~techlevel.high
+		BuildDuration: 1166
 		Description: Lightly armored infantry transport\nwhich can cloak. Can detect cloaked units.\n  Strong vs Light armor\n  Weak vs Infantry, Tanks, Aircraft
 	Valued:
 		Cost: 1350

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -52,12 +52,20 @@
 
 90mm:
 	Inherits: ^Cannon
+	Warhead@1Dam: SpreadDamage
+		Versus:
+			None: 30
+			Heavy: 115
 
 105mm:
 	Inherits: ^Cannon
 	ReloadDelay: 70
 	Burst: 2
 	BurstDelay: 4
+	Warhead@1Dam: SpreadDamage
+		Versus:
+			None: 30
+			Heavy: 115
 
 120mm:
 	Inherits: ^Cannon
@@ -66,6 +74,9 @@
 	InvalidTargets: Air, Infantry
 	Warhead@1Dam: SpreadDamage
 		Damage: 60
+		Versus:
+			None: 30
+			Heavy: 115
 		InvalidTargets: Air
 
 TurretGun:
@@ -86,13 +97,13 @@ TurretGun:
 		Speed: 204
 		Blockable: false
 		LaunchAngle: 62
-		Inaccuracy: 2c256
+		Inaccuracy: 1c938
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 240
+		Damage: 230
 		Versus:
-			None: 90
-			Wood: 40
+			None: 80
+			Wood: 35
 			Light: 60
 			Heavy: 25
 			Concrete: 50
@@ -161,7 +172,7 @@ Grenade:
 		Spread: 256
 		Damage: 60
 		Versus:
-			None: 50
+			None: 60
 			Wood: 100
 			Light: 25
 			Heavy: 25

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -29,6 +29,9 @@ FireballLauncher:
 		Speed: 250
 		TrailImage: fb2
 		Image: FB1
+	Warhead@1Dam: SpreadDamage
+		Versus:
+			Light: 50
 
 Flamer:
 	Inherits: ^FireWeapon
@@ -88,6 +91,9 @@ PortaTesla:
 	Range: 6c0
 	Warhead@1Dam: SpreadDamage
 		Damage: 45
+		Versus:
+			Wood: 75
+			Heavy: 60
 
 TTankZap:
 	Inherits: ^TeslaWeapon

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -104,7 +104,7 @@ Vulcan:
 		Versus:
 			None: 200
 			Wood: 50
-			Light: 60
+			Light: 50
 			Heavy: 25
 			Concrete: 25
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath


### PR DESCRIPTION
**To skip the abstract you can safely jump down straight to the changes themselves (see bold text below).**

I initially held off these changes from #13640 in anticipation of the HitShape/UnitStance features in order to better evaluate its balance implications. A few changes listed below are adjustments from the current playtest but the majority represents the full experience coming out of the playtest maps concluded with the so-called v1.6 map playtest series: http://www.sleipnirstuff.com/forum/viewtopic.php?f=83&t=20017

The map playtest v1.6 was distributed with ca 17.000 (!) map downloads with [1.6a](https://pastebin.com/7HPdCryT) and [1.6b](https://pastebin.com/SvX4rBAm) (latter version [still up on the resource site](http://resource.openra.net/maps/uploader/78/)) after an aggressive distribution campaign, resulting in maps being redistributed within the community itself mostly within a period of ca 2-3 months. The download count doesn't tell us really the quality of the changes itself but shows the balance changes has been accessible, redistributed and familiarized with the larger community for a long period of time. This made it possible to observe hundreds upon hundreds of games periodically which made it possible to track the progression of both 1v1s and team games and on how players dealt with the changes over time.

As with my previous balance PR's I will refer to the experience drawn from the playtesting itself, not delving too much into discussion about other changes or experiences drawn from sources outside this particular playtest series. This outlines my attitude towards playtesting in the past where I would often dismiss concerns on past balance PRs from other community members that contrasted the experiences drawn from the playtesting itself. These often originated from other sources or just concerns in general drawn from general insight of the game. This might have come across as unfair to some, especially now that the community has recently split up into multiple playtest series, often overlapping certain tests of changes but at the end of the day that's the only way I can personally guarantee the experience gathered from the map playtests will accurately reflect that of the upcoming playtest/release.

- - - - 

This balance patch is a culmination of pretty much everything I've worked for up to this point and was part of a long-term 2-punch-combo plan starting with #12739 for the current release. The aim was to make way for a broad yet safe path for the RA mod to provide more fun, colorful and exciting games for everybody while at the same time slowly expanding some options for our most dedicated of players in the community. No doubt this playtest series managed to achieved that and is my proudest work in my time with OpenRA, especially in a time with growth in both the general player base and the competitive arena, challenged with more viewpoints and opinions than ever putting on an ever growing pressure to offer more of what the RA mod already provides.

- - - - - - - - - - - -

**For anyone not having followed up on the playtest series previously, don't let the long list of changes intimidate. In a nutshell the changes are more akin to tuning an equalizer, and with few exceptions has been quality checked over a very long period of time.**

**The proposal includes the following changes**:

- - - - - - - - - - - -

**VEHICLES**

**Medium/Heavy/Mammoth Tank**
Damage vs None: 30%, up from 20%
Damage vs Heavy: 115%, up from 100%

**Heavy Tank**
HP: 600, up from 550

**Mammoth Tank***
Added Cloak Detection range: 6

**Artillery***
Innaccuracy: 1c938, down fromk 2c256 (playtest)
Damage: 230, down from 240 (playtest)
Damage vs None: 80, down from 90 (playtest)
Damage vs Wood: 35, down from 40 (playtest)

**Phase/Chrono/Tesla Tank**
Production time: 28 sec, down from 33 sec

**Chrono/Tesla Tank**
HP: 450, up from 400

**MCV**
Speed: 71, down from 85

**Mobile Radar Jammer, Mobile Gap Generator***
Speed: 99, up from 85

**Comments**:
* **The cloak detection for the Mammoth Tank** is part of a group of changes aimed to make the use of the Phase Transport more deliberate. All changes involving cloak detection in this list is part of that package and the standardization of cloak detection range for all defensive structures in the playtest preceded this move. 
* **The Artillery weapons change** is a further tweak from that of the playtest. The increase of innaccuracy felt slightly overboard and so I pulled it back a bit and compensated by pulling back some of its damage output. 
* **The speed upgrade for the MRJ and MGG** is the only feature from now a previously planned round of playtest maps that despite never having seen the light of day I feel is worth bringing along, at the very least towards the official playtest. As with the obscure Mammoth Tank pre-release-20161019 a speed upgrade will likely make the units more applicable. It's not a change I'm committed to in this PR but I highly recommend giving it a go.

- - - - - - - - - - - -

**INFANTRY**

**Medic**
HP: 60, down from 80

**Shock Trooper**
Cost: $300, down from $400
HP: 50, down from 60
Damage vs Wood 75%, vs Heavy 60%

**Tanya**
Added Cloak Detection range: 5

**Grenadier**
Damage vs None: 60% (up from 50%)

- - - - - - - - - - - -

**AIRCRAFT**

**MiG/Longbow**
Production time: 42 sec, down from 48 sec

**Chinook**
Speed: 128, up from 112
Vision: 8, down from 10
HP: 140, up from 120
Land/Liftoff speed: 0c58, down from 0c100

- - - - - - - - - - - -

**NAVAL**

**Cruiser**
Production time: 48 sec, down from 58 sec

**Missile Sub**
Production time: 42 sec, down from 48 sec

- - - - - - - - - - - -

**STRUCTURES**

**Barracks**
Cost: $500, up from $400

**War Factory***
Build-time reduction caps at 50% with 4 structures (100, 75, 60, 50), down from of 7 (100, 85, 75, 65, 60, 55, 50)

**Radar Dome**
Power-down disables cloak detection

**Soviet Tech Center***
HP: 800, up from 600

**Refinery**
Vision range: 5, down from 6

**Comments**: 
* **The War Factory production cap** is dealt with at _the bottom of this post_ as it deals with overall game design issues and requires a broader comment. 
* **The Soviet Tech Center HP increase** is in response to the new hitshape changes as the structure is one of the big losers in the AoE department. The parabombs flattens the structure. The HP increase will be quite noticeable in-game balance wise but as-is I don't see any other way to approach the issue practically.

- - - - - - - - - - - -

**DEFENSIVE STRUCTURES**

**AAGun/SAM**
Removed cloak detection

**SAM**
Cost: $700, down from $750

**Pillbox/C.Pillbox/Flame Tower**
Damage vs Light: 50%, down from 60%

**Walls**
HP: 400, down from 500

**Sandbag/Fence**
HP: 150, down from 300

- - - - - - - - - - - -

**SUPPORT POWERS**

**Paradrops**
Chargetime: 5 min, down from 6 min. 

**Parabombs**
Chargetime: 5 min, down from 6 min. 

**Spy Plane**
Chargetime: 2 min 30sec, down from 3 min.

- - - - - - - - - - - -

**CIVILIAN STRUCTURES**

**Forward Command**
Capturable, grants Base Provider Trait (8c0)
HP: 800
Powercost: 0
Vision Range: 5
Takes Engineer 2x normal cap time

**Technology Center***
Renamed to Communications Center
Capturable, grants 10c0 vision range
HP: 600

**Comments**:
The remaining civilian structures coming alive is one of my personal favorite changes, I had a lot of fun experimenting with these on few maps. The Technology Center is renamed to Communications Center in order to distinguish it from the buildable Tech Center. Originally the Technology Center building went by so many different names and uses in CnC and RA, almost as a running joke, so renaming it shouldn't be an issue.

- - - - - - - - - - - -

**War Factory, new production cap**

One of the above changes needs to have the developer team on-board as it does essentially deal with questions regarding game design. The War Factory production capped at 4 instead of 7 breaks with all other build queues and essentially creates a two-tiered queue system. Practically the WF queue in relation to the others looks like this:
![red alert blackground 1920x1200-2](https://user-images.githubusercontent.com/2715583/29044833-76eca7e2-7bc1-11e7-86b2-49e25e918244.png)
With the 3 middle values scooped out the War Factory is allowed to reduce its production time with 25% on the second War Factory.

I don't remember who came up with the idea but I decided to bring it aboard early on and throw it out at the first sign of trouble. The War Factory being a $2000 structure I figured there was a chance it would add to the game without disrupting too much. To my surprise it basically under-performed, being phased out quickly as an early-to-mid-game option after just a few days of players attempting to abuse the vehicle production gain as a build-order opener. The geniality of the feature became apparent at the later stages in the games, ca. 15-20 minutes into the game after the tech-tree had fully developed both in 1v1s and team games. Practically there were more options presented on the table late-game with quicker transitions between types of vehicles and in combination with the new T3 custom build times and HP upgrades (phase/chrono/tesla tank) represented in this PR we saw players playing around with more of these units and often helping players close out games in a more colorful fashion instead of grinding the beaten player down in long drawn-out stalemate situations. It never felt over-board except perhaps in games with people playing around having their fun but at the expense of winning the game against an equal opponent.

The standard 7-point production queues themselves being a bit obscure to most players makes the deviation of a 4-point War Factory seemingly even more so but I would ask you to consider this - it never came up as an issue in any games I observed in the entire time. In fact players were discussing among themselves about the values given that the WF now had a distinct different production cap value. Those values themselves being simply a derivative of the original 7-point value (as visualized above) made the WF 4-point value easy and quick to learn and in return ironically fostered awareness on what the standard queue values really are.

It's my intention to sell this point across to the developers to add this deviation to the game for the great fun, the rewards and vast potential this feature adds to the experience. This playtest/release has with it a great many changes to standardize certain elements for sake of ease of understanding including building vision range and and cloak detection for the defensive structures. Those deviations served no purpose. This one does and I'd anticipate it to be one of the most well received balance features with the next release.

- - - - - - - - - - - -

As mentioned initially all of these changes has been playtested at an unprecedented rate and, as with the previous balance PRs, can be expected to take aboard changes that are predictable and expected to function in the release as promised.