### PR TITLE
Rework the addition and removal of building influence

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -29,28 +30,20 @@ namespace OpenRA.Mods.Common.Traits
 			map = world.Map;
 
 			influence = new CellLayer<Actor>(map);
+		}
 
-			world.ActorAdded += a =>
-			{
-				var b = a.Info.TraitInfoOrDefault<BuildingInfo>();
-				if (b == null)
-					return;
+		internal void AddInfluence(Actor a, IEnumerable<CPos> tiles)
+		{
+			foreach (var u in tiles)
+				if (influence.Contains(u) && influence[u] == null)
+					influence[u] = a;
+		}
 
-				foreach (var u in b.Tiles(a.Location))
-					if (influence.Contains(u) && influence[u] == null)
-						influence[u] = a;
-			};
-
-			world.ActorRemoved += a =>
-			{
-				var b = a.Info.TraitInfoOrDefault<BuildingInfo>();
-				if (b == null)
-					return;
-
-				foreach (var u in b.Tiles(a.Location))
-					if (influence.Contains(u) && influence[u] == a)
-						influence[u] = null;
-			};
+		internal void RemoveInfluence(Actor a, IEnumerable<CPos> tiles)
+		{
+			foreach (var u in tiles)
+				if (influence.Contains(u) && influence[u] == a)
+					influence[u] = null;
 		}
 
 		public Actor GetBuildingAt(CPos cell)


### PR DESCRIPTION
Pulled from #13796. This should improve performance a tiny bit as we don't do the extra trait query for `BuildingInfo` whenever an actor is added to or removed from the world.