### PR TITLE
Keep Attack M./Guard while holding hotkey (revert Playtest change)

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
@@ -10,13 +10,10 @@
 #endregion
 
 using System;
-using System.Drawing;
 using System.Linq;
-using OpenRA.Graphics;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Orders;
-using OpenRA.Primitives;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets
@@ -58,14 +55,20 @@ namespace OpenRA.Mods.Common.Widgets
 				attackMoveButton.IsHighlighted = () => world.OrderGenerator is GenericSelectTarget
 					&& ((GenericSelectTarget)world.OrderGenerator).OrderName == "AttackMove";
 
-				attackMoveButton.OnClick = () =>
+				Action<bool> toggle = allowCancel =>
 				{
 					if (attackMoveButton.IsHighlighted())
-						world.CancelInputMode();
+					{
+						if (allowCancel)
+							world.CancelInputMode();
+					}
 					else
 						world.OrderGenerator = new GenericSelectTarget(selectedActors,
 							"AttackMove", "attackmove", Game.Settings.Game.MouseButtonPreference.Action);
 				};
+
+				attackMoveButton.OnClick = () => toggle(true);
+				attackMoveButton.OnKeyPress = _ => toggle(false);
 			}
 
 			var forceMoveButton = widget.GetOrNull<ButtonWidget>("FORCE_MOVE");
@@ -110,14 +113,20 @@ namespace OpenRA.Mods.Common.Widgets
 				guardButton.IsHighlighted = () => world.OrderGenerator is GenericSelectTarget
 					&& ((GenericSelectTarget)world.OrderGenerator).OrderName == "Guard";
 
-				guardButton.OnClick = () =>
+				Action<bool> toggle = allowCancel =>
 				{
 					if (guardButton.IsHighlighted())
-						world.CancelInputMode();
+					{
+						if (allowCancel)
+							world.CancelInputMode();
+					}
 					else
 						world.OrderGenerator = new GuardOrderGenerator(selectedActors,
 							"Guard", "guard", Game.Settings.Game.MouseButtonPreference.Action);
 				};
+
+				guardButton.OnClick = () => toggle(true);
+				guardButton.OnKeyPress = _ => toggle(false);
 			}
 
 			var scatterButton = widget.GetOrNull<ButtonWidget>("SCATTER");

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -270,7 +270,6 @@ Container@PLAYER_WIDGETS:
 					Width: 34
 					Height: 34
 					Background: command-button
-					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Attack Move
 					TooltipDesc: Selected units will move to the desired location\nand attack any enemies they encounter en route.\n\nLeft-click icon then right-click on target location.
@@ -321,7 +320,6 @@ Container@PLAYER_WIDGETS:
 					Width: 34
 					Height: 34
 					Background: command-button
-					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Guard
 					TooltipDesc: Selected units will follow the targeted unit.\n\nLeft-click icon then right-click on target unit.

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -43,7 +43,6 @@ Container@PLAYER_WIDGETS:
 					Height: 41
 					VisualHeight: 0
 					Background: command-button
-					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Attack Move
 					TooltipDesc: Selected units will move to the desired location\nand attack any enemies they encounter en route.\n\nLeft-click icon then right-click on target location.
@@ -94,7 +93,6 @@ Container@PLAYER_WIDGETS:
 					Height: 41
 					VisualHeight: 0
 					Background: command-button
-					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Guard
 					TooltipDesc: Selected units will follow the targeted unit.\n\nLeft-click icon then right-click on target unit.

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -49,7 +49,6 @@ Container@PLAYER_WIDGETS:
 					Height: 26
 					VisualHeight: 0
 					Background: command-button
-					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Attack Move
 					TooltipDesc: Selected units will move to the desired location\nand attack any enemies they encounter en route.\n\nLeft-click icon then right-click on target location.
@@ -103,7 +102,6 @@ Container@PLAYER_WIDGETS:
 					Height: 26
 					VisualHeight: 0
 					Background: command-button
-					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Guard
 					TooltipDesc: Selected units will follow the targeted unit.\n\nLeft-click icon then right-click on target unit.


### PR DESCRIPTION
Fixes #13804

It is basically like before but using command bar so there could be better solution, because like before, new GenericSelectTarget is being created constantly while holding A key.