### PR TITLE
Focus the ViewportController on Standard/Inverted scroll modes.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -308,7 +308,12 @@ namespace OpenRA.Mods.Common.Widgets
 			if (scrollType == MouseScrollType.Standard || scrollType == MouseScrollType.Inverted)
 			{
 				if (mi.Event == MouseInputEvent.Down && !isStandardScrolling)
+				{
+					if (!TakeMouseFocus(mi))
+						return false;
+
 					standardScrollStart = mi.Location;
+				}
 				else if (mi.Event == MouseInputEvent.Move && (isStandardScrolling ||
 					(standardScrollStart.HasValue && ((standardScrollStart.Value - mi.Location).Length > Game.Settings.Game.MouseScrollDeadzone))))
 				{
@@ -322,6 +327,7 @@ namespace OpenRA.Mods.Common.Widgets
 					var wasStandardScrolling = isStandardScrolling;
 					isStandardScrolling = false;
 					standardScrollStart = null;
+					YieldMouseFocus(mi);
 
 					if (wasStandardScrolling)
 						return true;
@@ -335,6 +341,7 @@ namespace OpenRA.Mods.Common.Widgets
 				{
 					if (!TakeMouseFocus(mi))
 						return false;
+
 					joystickScrollStart = mi.Location;
 				}
 


### PR DESCRIPTION
Fixes #13727 and makes sure that scrolling remains active when the cursor moves over other interface elements (as it already does for Joystick scrolling).