### PR TITLE
Add EnableDebugCommandsInReplays option

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -94,6 +94,7 @@ namespace OpenRA
 		public bool SendSystemInformation = true;
 		public int SystemInformationVersionPrompt = 0;
 		public string UUID = System.Guid.NewGuid().ToString();
+		public bool EnableDebugCommandsInReplays = false;
 	}
 
 	public class GraphicSettings

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -130,7 +130,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Game.BeforeGameStart += UnregisterEvents;
 
 			CloseChat();
-			chatText.IsDisabled = () => world.IsReplay;
+			chatText.IsDisabled = () => world.IsReplay && !Game.Settings.Debug.EnableDebugCommandsInReplays;
 
 			var keyListener = chatChrome.Get<LogicKeyListenerWidget>("KEY_LISTENER");
 			keyListener.OnKeyPress = e =>

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -674,6 +674,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			BindCheckboxPref(panel, "FETCH_NEWS_CHECKBOX", gs, "FetchNews");
 			BindCheckboxPref(panel, "LUADEBUG_CHECKBOX", ds, "LuaDebug");
 			BindCheckboxPref(panel, "SENDSYSINFO_CHECKBOX", ds, "SendSystemInformation");
+			BindCheckboxPref(panel, "REPLAY_COMMANDS_CHECKBOX", ds, "EnableDebugCommandsInReplays");
 
 			return () => { };
 		}

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -585,6 +585,13 @@ Container@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Show Map Debug Messages
+						Checkbox@REPLAY_COMMANDS_CHECKBOX:
+							X: 310
+							Y: 220
+							Width: 300
+							Height: 20
+							Font: Regular
+							Text: Enable Debug Commands in Replays
 		Button@BACK_BUTTON:
 			Key: escape
 			Y: 393

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -586,3 +586,10 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Show Map Debug Messages
+				Checkbox@REPLAY_COMMANDS_CHECKBOX:
+					X: 310
+					Y: 220
+					Width: 300
+					Height: 20
+					Font: Regular
+					Text: Enable Debug Commands in Replays


### PR DESCRIPTION
Closes #13761

New option to enable chat also in Replays to use visual debug commands - Settings-Advanced:
![image](https://user-images.githubusercontent.com/16348750/29137843-f4a22dd4-7d41-11e7-9a79-ac65f11bedf0.png)




