### PR TITLE
Load replays also in sub directories

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			using (new Support.PerfTimer("Load replays"))
 			{
 				var loadedReplays = new ConcurrentBag<ReplayMetadata>();
-				Parallel.ForEach(Directory.GetFiles(dir, "*.orarep"), (fileName, pls) =>
+				Parallel.ForEach(Directory.GetFiles(dir, "*.orarep", SearchOption.AllDirectories), (fileName, pls) =>
 				{
 					if (cancelLoadingReplays)
 					{


### PR DESCRIPTION
Requested here #13809

It is simpler to copy/delete a folder with replays, extract a zip,.. into e.g. \Documents\OpenRA\Replays\ra\release-20170527 than having to copy all replays into 1 folder.
If wanted/supported we might add a new filter option - folder selection to restrict the filter for select folder (e.g. a tournament, ...).