### PR TITLE
Allow skipping sell/undeploy anim

### DIFF
--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Activities
 				nt.BeforeTransform(self);
 
 			var makeAnimation = self.TraitOrDefault<WithMakeAnimation>();
-			if (makeAnimation != null)
+			if (!SkipMakeAnims && makeAnimation != null)
 			{
 				// Once the make animation starts the activity must not be stopped anymore.
 				IsInterruptible = false;

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -55,6 +55,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Can this actor undeploy?")]
 		public readonly bool CanUndeploy = true;
 
+		[Desc("Skip make/deploy animation?")]
+		public readonly bool SkipMakeAnimation = false;
+
 		public object Create(ActorInitializer init) { return new GrantConditionOnDeploy(init, this); }
 	}
 
@@ -223,7 +226,7 @@ namespace OpenRA.Mods.Common.Traits
 				OnDeployCompleted();
 			else
 				foreach (var n in notify)
-					n.Deploy(self);
+					n.Deploy(self, Info.SkipMakeAnimation);
 		}
 
 		/// <summary>Play undeploy sound and animation and after that revoke the condition.</summary>
@@ -246,7 +249,7 @@ namespace OpenRA.Mods.Common.Traits
 				OnUndeployCompleted();
 			else
 				foreach (var n in notify)
-					n.Undeploy(self);
+					n.Undeploy(self, Info.SkipMakeAnimation);
 		}
 
 		void OnDeployStarted()

--- a/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
@@ -116,16 +116,24 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 
 		// TODO: Make this use Forward instead
-		void INotifyDeployTriggered.Deploy(Actor self)
+		void INotifyDeployTriggered.Deploy(Actor self, bool skipMakeAnim)
 		{
 			var notified = false;
+			var notify = self.TraitsImplementing<INotifyDeployComplete>();
+
+			if (skipMakeAnim)
+			{
+				foreach (var n in notify)
+					n.FinishedDeploy(self);
+
+				return;
+			}
 
 			foreach (var wsb in wsbs)
 			{
 				if (wsb.IsTraitDisabled)
 					continue;
 
-				var notify = self.TraitsImplementing<INotifyDeployComplete>();
 				wsb.PlayCustomAnimation(self, info.Sequence, () =>
 				{
 					if (notified)
@@ -141,16 +149,24 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 
 		// TODO: Make this use Reverse instead
-		void INotifyDeployTriggered.Undeploy(Actor self)
+		void INotifyDeployTriggered.Undeploy(Actor self, bool skipMakeAnim)
 		{
 			var notified = false;
+			var notify = self.TraitsImplementing<INotifyDeployComplete>();
+
+			if (skipMakeAnim)
+			{
+				foreach (var n in notify)
+					n.FinishedUndeploy(self);
+
+				return;
+			}
 
 			foreach (var wsb in wsbs)
 			{
 				if (wsb.IsTraitDisabled)
 					continue;
 
-				var notify = self.TraitsImplementing<INotifyDeployComplete>();
 				wsb.PlayCustomAnimationBackwards(self, info.Sequence, () =>
 				{
 					if (notified)

--- a/OpenRA.Mods.Common/Traits/Sellable.cs
+++ b/OpenRA.Mods.Common/Traits/Sellable.cs
@@ -23,6 +23,9 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int RefundPercent = 50;
 		public readonly string[] SellSounds = { };
 
+		[Desc("Skip playing (reversed) make animation.")]
+		public readonly bool SkipMakeAnimation = false;
+
 		public override object Create(ActorInitializer init) { return new Sellable(init.Self, this); }
 	}
 
@@ -63,11 +66,17 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var ns in self.TraitsImplementing<INotifySold>())
 				ns.Selling(self);
 
-			var makeAnimation = self.TraitOrDefault<WithMakeAnimation>();
-			if (makeAnimation != null)
-				makeAnimation.Reverse(self, new Sell(self), false);
-			else
-				self.QueueActivity(false, new Sell(self));
+			if (!info.SkipMakeAnimation)
+			{
+				var makeAnimation = self.TraitOrDefault<WithMakeAnimation>();
+				if (makeAnimation != null)
+				{
+					makeAnimation.Reverse(self, new Sell(self), false);
+					return;
+				}
+			}
+
+			self.QueueActivity(false, new Sell(self));
 		}
 
 		public bool IsTooltipVisible(Player forPlayer)

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -175,8 +175,8 @@ namespace OpenRA.Mods.Common.Traits
 
 	public interface INotifyDeployTriggered
 	{
-		void Deploy(Actor self);
-		void Undeploy(Actor self);
+		void Deploy(Actor self, bool skipMakeAnim);
+		void Undeploy(Actor self, bool skipMakeAnim);
 	}
 
 	public interface IAcceptResourcesInfo : ITraitInfo { }


### PR DESCRIPTION
At least in `TransformOnCapture` and `Sellable`.

Closes #13688.
Closes #13704.