### PR TITLE
Revert TicksBeforePathing move from Mobile to Move.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -23,8 +23,6 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class Move : Activity
 	{
-		const int AverageTicksBeforePathing = 5;
-		const int SpreadTicksBeforePathing = 5;
 		static readonly List<CPos> NoPath = new List<CPos>();
 
 		readonly Mobile mobile;
@@ -41,7 +39,6 @@ namespace OpenRA.Mods.Common.Activities
 		int waitTicksRemaining;
 
 		// To work around queued activity issues while minimizing changes to legacy behaviour
-		int ticksBeforePathing;
 		bool evaluateNearestMovableCell;
 
 		// Scriptable move order
@@ -140,9 +137,6 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected override void OnFirstRun(Actor self)
 		{
-			ticksBeforePathing = AverageTicksBeforePathing +
-				self.World.SharedRandom.Next(-SpreadTicksBeforePathing, SpreadTicksBeforePathing);
-
 			if (evaluateNearestMovableCell && destination.HasValue)
 			{
 				var movableDestination = mobile.NearestMoveableCell(destination.Value);
@@ -165,9 +159,9 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (path == null)
 			{
-				if (ticksBeforePathing > 0)
+				if (mobile.TicksBeforePathing > 0)
 				{
-					--ticksBeforePathing;
+					--mobile.TicksBeforePathing;
 					return this;
 				}
 
@@ -264,9 +258,9 @@ namespace OpenRA.Mods.Common.Activities
 				if (--waitTicksRemaining >= 0)
 					return null;
 
-				if (ticksBeforePathing > 0)
+				if (mobile.TicksBeforePathing > 0)
 				{
-					--ticksBeforePathing;
+					--mobile.TicksBeforePathing;
 					return null;
 				}
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -390,6 +390,10 @@ namespace OpenRA.Mods.Common.Traits
 	public class Mobile : ConditionalTrait<MobileInfo>, INotifyCreated, IIssueOrder, IResolveOrder, IOrderVoice, IPositionable, IMove,
 		IFacing, IDeathActorInitModifier, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyBlockingMove, IActorPreviewInitModifier, INotifyBecomingIdle
 	{
+		const int AverageTicksBeforePathing = 5;
+		const int SpreadTicksBeforePathing = 5;
+		internal int TicksBeforePathing = 0;
+
 		readonly Actor self;
 		readonly Lazy<IEnumerable<int>> speedModifiers;
 		public bool IsMoving { get; set; }
@@ -627,6 +631,8 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (!order.Queued)
 					self.CancelActivity();
+
+				TicksBeforePathing = AverageTicksBeforePathing + self.World.SharedRandom.Next(-SpreadTicksBeforePathing, SpreadTicksBeforePathing);
 
 				self.SetTargetLine(Target.FromCell(self.World, order.TargetLocation), Color.Green);
 				self.QueueActivity(order.Queued, new Move(self, order.TargetLocation, WDist.FromCells(8), null, true));


### PR DESCRIPTION
This partially reverts commit 11c8cda0c38ad0ac71c58557d34480925307cebd.

Closes #13710.
Closes #13722.
Closes #13784.