### PR TITLE
Switch to .NET 4.5 compatible Marshal.SizeOf overload.

### DIFF
--- a/packaging/windows/WindowsLauncher.cs.in
+++ b/packaging/windows/WindowsLauncher.cs.in
@@ -100,7 +100,7 @@ namespace OpenRA
 				SHFILEINFO sfi = new SHFILEINFO();
 				for (var i = 0; i < 2; i++)
 				{
-					SHGetFileInfo(Assembly.GetExecutingAssembly().Location, 0, ref sfi, (uint)Marshal.SizeOf(sfi), (uint)(0x100 + i));
+					SHGetFileInfo(Assembly.GetExecutingAssembly().Location, 0, ref sfi, (uint)Marshal.SizeOf(typeof(SHFILEINFO)), (uint)(0x100 + i));
 					iconHandle[i] = sfi.hIcon;
 					SendMessage(gameProcess.MainWindowHandle, 0x80, (uint)(1 - i), sfi.hIcon);
 				}


### PR DESCRIPTION
Fixes #13747.

Fix confirmed by @AoAGeneral:
>What I did instead was replaced the existing client in the actual folder itself with the one pchote has. Once I did that it worked with both versions 4.5 and 4.6.2. 

Credit to @rob-v for identifying the cause of the crash.