### PR TITLE
Update macOS launcher to 20170812 tag.

### DIFF
--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -9,7 +9,7 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
 	command -v genisoimage >/dev/null 2>&1 || { echo >&2 "macOS packaging requires genisoimage."; exit 1; }
 fi
 
-LAUNCHER_TAG="osx-launcher-20170708"
+LAUNCHER_TAG="osx-launcher-20170812"
 
 if [ $# -ne "2" ]; then
 	echo "Usage: `basename $0` tag outputdir"


### PR DESCRIPTION
See [osx-launcher-20170812](https://github.com/OpenRA/OpenRALauncherOSX/releases/tag/osx-launcher-20170812).

Closes #13679.

About half of our macOS players are currently using Mono 4.2 or 4.4.  This change bumps the minimum version on macOS to 4.6 to make sure that all players have a working 64 bit runtime in preparation for #13478 (Mono on macOS was 32-bit only before 4.4).

This also brings the benefit of being able to drop workarounds for older runtimes, and since most players will update to 5.0 it will also give them a noticable performance boost.