### PR TITLE
Grant a condition while performing an external capture

### DIFF
--- a/OpenRA.Mods.Common/Activities/ExternalCaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/ExternalCaptureActor.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		void EndCapture(Actor self)
 		{
-			if (capturable.CaptureInProgress)
+			if (target.Type == TargetType.Actor && capturable.CaptureInProgress)
 				capturable.EndCapture();
 			if (capturingToken != ConditionManager.InvalidConditionToken)
 				capturingToken = conditionManager.RevokeCondition(self, capturingToken);

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -173,6 +173,8 @@ namespace OpenRA.Mods.Common.Traits
 			firstTick = false;
 		}
 
+		protected override void TraitDisabled(Actor self) { Uncloak(); }
+
 		public bool IsVisible(Actor self, Player viewer)
 		{
 			if (!Cloaked || self.Owner.IsAlliedWith(viewer))

--- a/OpenRA.Mods.Common/Traits/ExternalCaptures.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCaptures.cs
@@ -34,6 +34,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		[VoiceReference] public readonly string Voice = "Action";
 
+		[GrantedConditionReference]
+		[Desc("Condition granted when capturing.")]
+		public readonly string CapturingCondition = null;
+
 		public readonly string CaptureCursor = "ability";
 		public readonly string CaptureBlockedCursor = "move-blocked";
 


### PR DESCRIPTION
Add a notifier for the beginning of an external capture
Implement uncloaking when a capture begins (#13767)

The attached replay demonstrate engineers modded with the cloaking trait that get uncloaked when they starts capturing an enemy building.
[OpenRA-2017-08-15T165036Z.orarep.zip](https://github.com/OpenRA/OpenRA/files/1225786/OpenRA-2017-08-15T165036Z.orarep.zip)

I'm not sure what will happen if the cloaked unit finish capturing the building.
Should it get cloaked again ? Does that happen automatically ? Could that happen while the unit is still capturing the building ?


