### PR TITLE
Add units to Control Group with Shift

### DIFF
--- a/OpenRA.Game/Selection.cs
+++ b/OpenRA.Game/Selection.cs
@@ -123,8 +123,8 @@ namespace OpenRA
 
 		public void DoControlGroup(World world, WorldRenderer worldRenderer, int group, Modifiers mods, int multiTapCount)
 		{
-			var addModifier = Platform.CurrentPlatform == PlatformType.OSX ? Modifiers.Meta : Modifiers.Ctrl;
-			if (mods.HasModifier(addModifier))
+			var addModifier = (Platform.CurrentPlatform == PlatformType.OSX ? Modifiers.Meta : Modifiers.Ctrl) | Modifiers.Shift;
+			if ((mods & addModifier) != 0)
 			{
 				if (actors.Count == 0)
 					return;


### PR DESCRIPTION
_Shift + 0-9_ - Add units to group 0-9 (or create the group), currently it is _Ctrl + Shift + 0-9_.
See http://www.sleipnirstuff.com/forum/viewtopic.php?f=82&t=20253 for comparison of release vs this PR.