### PR TITLE
Add TransferAmmoWarhead

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -821,7 +821,7 @@
     <Compile Include="Traits\Render\ReloadArmamentsBar.cs" />
     <Compile Include="Lint\CheckChromeHotkeys.cs" />
     <Compile Include="UtilityCommands\LintInterfaces.cs" />
-    <Compile Include="Warheads\ProvideAmmoWarhead.cs" />
+    <Compile Include="Warheads\TransferAmmoWarhead.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -821,6 +821,7 @@
     <Compile Include="Traits\Render\ReloadArmamentsBar.cs" />
     <Compile Include="Lint\CheckChromeHotkeys.cs" />
     <Compile Include="UtilityCommands\LintInterfaces.cs" />
+    <Compile Include="Warheads\ProvideAmmoWarhead.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.Common/Traits/AmmoPool.cs
+++ b/OpenRA.Mods.Common/Traits/AmmoPool.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
@@ -82,19 +83,20 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool GiveAmmo()
 		{
-			if (CurrentAmmo >= Info.Ammo)
-				return false;
-
-			++CurrentAmmo;
-			return true;
+			return AddAmmo(1);
 		}
 
 		public bool TakeAmmo()
 		{
-			if (CurrentAmmo <= 0)
+			return AddAmmo(-1);
+		}
+
+		public bool AddAmmo(int amount)
+		{
+			if (CurrentAmmo + amount > Info.Ammo || CurrentAmmo + amount < 0)
 				return false;
 
-			--CurrentAmmo;
+			CurrentAmmo += amount;
 			return true;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -120,12 +120,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (IsTraitDisabled)
 					yield break;
 
-				var armament = Armaments.FirstOrDefault(a => a.Weapon.Warheads.Any(w => (w is DamageWarhead)));
-				if (armament == null)
-					yield break;
-
-				var negativeDamage = (armament.Weapon.Warheads.FirstOrDefault(w => (w is DamageWarhead)) as DamageWarhead).Damage < 0;
-				yield return new AttackOrderTargeter(this, 6, negativeDamage);
+				yield return new AttackOrderTargeter(this, 6);
 			}
 		}
 
@@ -390,7 +385,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			readonly AttackBase ab;
 
-			public AttackOrderTargeter(AttackBase ab, int priority, bool negativeDamage)
+			public AttackOrderTargeter(AttackBase ab, int priority)
 			{
 				this.ab = ab;
 				OrderID = ab.attackOrderName;

--- a/OpenRA.Mods.Common/Warheads/ProvideAmmoWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/ProvideAmmoWarhead.cs
@@ -1,0 +1,83 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.GameRules;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Warheads
+{
+	public class ProvideAmmoWarhead : Warhead
+	{
+		[Desc("Name of the AmmoPool.")]
+		public readonly string AmmoPoolName = "primary";
+
+		[Desc("Give ammo to source actor if the target actor doesn't have enough space.")]
+		public readonly bool ReturnAmmo = true;
+
+		public override bool IsValidAgainst(Actor victim, Actor firedBy)
+		{
+			if (!base.IsValidAgainst(victim, firedBy))
+				return false;
+
+			return GetAmmoPools(victim).Any(x => !x.FullAmmo());
+		}
+
+		public override void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers)
+		{
+			// Damages a single actor, rather than a position. Only support by InstantHit for now.
+			// TODO: Add support for 'area of damage'
+			if (target.Type == TargetType.Actor)
+				DoImpact(target.Actor, firedBy, damageModifiers);
+		}
+
+		public void DoImpact(Actor victim, Actor firedBy, IEnumerable<int> damageModifiers)
+		{
+			bool wasSuccessful = false;
+
+			if (IsValidAgainst(victim, firedBy))
+			{
+				foreach (var pool in GetAmmoPools(victim).Where(x => !x.FullAmmo()))
+				{
+					if (pool.GiveAmmo())
+					{
+						wasSuccessful = true;
+						break;
+					}
+				}
+
+				var world = firedBy.World;
+				if (world.LocalPlayer != null)
+				{
+					var debugOverlayRange = new[] { WDist.Zero, new WDist(128) };
+					var debugVis = world.LocalPlayer.PlayerActor.TraitOrDefault<DebugVisualizations>();
+					if (debugVis != null && debugVis.CombatGeometry)
+						world.WorldActor.Trait<WarheadDebugOverlay>().AddImpact(victim.CenterPosition, debugOverlayRange, DebugOverlayColor);
+				}
+			}
+
+			if (ReturnAmmo && !wasSuccessful)
+			{
+				foreach (var pool in GetAmmoPools(firedBy).Where(x => !x.FullAmmo()))
+				{
+					pool.GiveAmmo();
+				}
+			}
+		}
+
+		IEnumerable<AmmoPool> GetAmmoPools(Actor actor)
+		{
+			return actor.TraitsImplementing<AmmoPool>().Where(x => x.Info.Name == AmmoPoolName);
+		}
+	}
+}

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -53,3 +53,5 @@ NAPULS:
 		LongDesc: Fires a pulse blast which disables\nall mechanical units in the area.
 		EndChargeSpeechNotification: EmPulseCannonReady
 		SelectTargetSpeechNotification: SelectTarget
+	RejectsOrders:
+		Reject: Attack, ForceAttack


### PR DESCRIPTION
This Warhead allows transferring ammo from one actor to another one and similar things. The change of AttackBase is needed to allow attacking without adding a DamageWarhead to the weapon. It shouldn't affect anything except the EMPulseCannon in TS and explosions in all bundled mods. The EMPulseCannon uses AttackOrderPower which uses AttackBase internally but shouldn't call into the modified part of it.

Skript:
```
#!/bin/bash

for mod in "ra" "cnc" "d2k" "ts"; do
        for line in $(egrep -r '^[a-zA-Z0-9]+:$' "mods/$mod/weapons/" | cut -d':' -f2); do
                mono OpenRA.Utility.exe "$mod" --resolved-weapons "$line" | grep "Warhead" | egrep "(HealthPercentageDamage|SpreadDamage|TargetDamage)" > /dev/null
                if [ "$?" == "1" ]; then
                        echo "No DamageWarhead found for weapon $line in mod $mod"
                fi
        done
done
```

Result:
```
No DamageWarhead found for weapon BuildingExplode in mod ra
No DamageWarhead found for weapon SmallBuildingExplode in mod ra
No DamageWarhead found for weapon BuildingExplode in mod cnc
No DamageWarhead found for weapon UnitExplodeSmall in mod d2k
No DamageWarhead found for weapon UnitExplodeMed in mod d2k
No DamageWarhead found for weapon UnitExplodeLarge in mod d2k
No DamageWarhead found for weapon BuildingExplode in mod d2k
No DamageWarhead found for weapon WallExplode in mod d2k
No DamageWarhead found for weapon EMPulseCannon in mod ts
No DamageWarhead found for weapon BuildingExplosions in mod ts
No DamageWarhead found for weapon CyborgExplode in mod ts
```