### PR TITLE
Multiple WithMakeAnimation traits support

### DIFF
--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -66,19 +66,41 @@ namespace OpenRA.Mods.Common.Activities
 			foreach (var nt in self.TraitsImplementing<INotifyTransform>())
 				nt.BeforeTransform(self);
 
-			var makeAnimation = self.TraitOrDefault<WithMakeAnimation>();
-			if (!SkipMakeAnims && makeAnimation != null)
-			{
-				// Once the make animation starts the activity must not be stopped anymore.
-				IsInterruptible = false;
+			if (SkipMakeAnims)
+				return NextActivity;
 
-				// Wait forever
-				QueueChild(new WaitFor(() => false));
-				makeAnimation.Reverse(self, () => DoTransform(self));
-				return this;
+			// Once the make animation starts the activity must not be stopped anymore.
+			IsInterruptible = false;
+
+			PlayTransformAnimations(self);
+
+			// Wait forever
+			QueueChild(new WaitFor(() => false));
+			return this;
+		}
+
+		void PlayTransformAnimations(Actor self)
+		{
+			var makeAnimations = self.TraitsImplementing<WithMakeAnimation>();
+			if (!makeAnimations.Any())
+			{
+				// Let transform happen even without WithMakeAnimation trait.
+				DoTransform(self);
+				return;
 			}
 
-			return NextActivity;
+			bool first = true;
+			foreach (var ma in makeAnimations)
+			{
+				if (first)
+				{
+					// Attach the DoTransform callback to the first animation
+					ma.Reverse(self, () => DoTransform(self));
+					first = false;
+				}
+				else
+					ma.Reverse(self, null);
+			}
 		}
 
 		protected override void OnLastRun(Actor self)

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -176,8 +176,8 @@ namespace OpenRA.Mods.Common.Traits
 
 	public interface INotifyDeployTriggered
 	{
-		void Deploy(Actor self, bool skipMakeAnim);
-		void Undeploy(Actor self, bool skipMakeAnim);
+		void Deploy(Actor self, HashSet<string> deployTypes);
+		void Undeploy(Actor self, HashSet<string> deployTypes);
 	}
 
 	public interface IAcceptResourcesInfo : ITraitInfo { }


### PR DESCRIPTION
#13822 allows skipping of transformations but that wasn't quite enough:

Demo: https://youtu.be/EFjW0aGE_xY
(The demo has a bug targeted by #13745, that horse shoe stops spinning after playing make animation)
That super radar dome has multiple WithSpriteBody to support the gap generator part and the dome part, each with a separate WIthMakeAnimation.

To support multiple bodies and multiple WithMakeAnimation traits we need a filter.