### PR TITLE
Fixed indentions of trait documentation table of contents

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				}
 
 				var traitName = t.Name.EndsWith("Info") ? t.Name.Substring(0, t.Name.Length - 4) : t.Name;
-				toc.AppendLine(" * [{0}](#{1})".F(traitName, traitName.ToLowerInvariant()));
+				toc.AppendLine("  * [{0}](#{1})".F(traitName, traitName.ToLowerInvariant()));
 				var traitDescLines = t.GetCustomAttributes<DescAttribute>(false).SelectMany(d => d.Lines);
 				doc.AppendLine();
 				doc.AppendLine("### {0}".F(traitName));


### PR DESCRIPTION
as it seems (GitHub) MarkDown requires two spaces (now).

old: https://github.com/OpenRA/OpenRA/wiki/Traits
new: https://github.com/OpenRA/OpenRA/wiki/Traits-(playtest)
