### PR TITLE
[RA] RevealOnDeath with Aircraft

### DIFF
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -907,6 +907,9 @@
 		Velocity: 86
 	EditorTilesetFilter:
 		Categories: Husk
+	RevealOnDeath:
+		Duration: 60
+		Radius: 4c0
 
 ^HelicopterHusk:
 	Inherits: ^BasicHusk
@@ -921,6 +924,9 @@
 	FallsToEarth:
 	BodyOrientation:
 		UseClassicFacingFudge: True
+	RevealOnDeath:
+		Duration: 60
+		Radius: 4c0
 
 ^Bridge:
 	Inherits@shape: ^1x1Shape

--- a/mods/ra/rules/husks.yaml
+++ b/mods/ra/rules/husks.yaml
@@ -95,11 +95,11 @@ TRAN.Husk:
 		Offset: 597,0,213
 		Sequence: rotor2
 	RevealsShroud:
-		Range: 10c0
+		Range: 8c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
-		Range: 8c0
+		Range: 6c0
 		Type: GroundPosition
 	RenderSprites:
 		Image: tran
@@ -135,6 +135,7 @@ BADR.Husk:
 		MinDamage: Undamaged
 	RenderSprites:
 		Image: badr
+	-RevealOnDeath:
 
 MIG.Husk:
 	Inherits: ^PlaneHusk


### PR DESCRIPTION
Taking advantage of #12999 this PR would add a short duration of vision with aircraft crashes.

Closes #13864 

One issue out of my reach is a small time-gap between the disappearance of the dying unit and its added RevealOnDeath vision. This makes the vision "flicker" when the trait is activated. This happen with any unit the trait is assigned to.

Also if there is a way of deactivating the trait on landed aircrafts that could eliminate the effect when the units are on ground. At least within the content of this PR it would be more consistent.

*edit: set 8c0 vision range to Transport.Husk as with the Transport unit itself. Overlooked by the previous balance PR