### PR TITLE
Adjust IsAtGroundLevel fixing EjectOnDeath

### DIFF
--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -21,9 +21,6 @@ namespace OpenRA.Mods.Common
 	{
 		public static bool IsAtGroundLevel(this Actor self)
 		{
-			if (self.IsDead)
-				return false;
-
 			if (self.OccupiesSpace == null)
 				return false;
 


### PR DESCRIPTION
Fixes `EjectOnDeath` ejecting pilots even when at ground level. The aircraft actor is already dead the time `EjectOnDeath` runs and thus `self.IsAtGroundLevel` was always `false`.

I didn't notice any side-effects from removing the (unnecessary) `IsDead` check from `IsAtGroundLevel`. 