### PR TITLE
Split Actor.Bounds into RenderBounds and SelectableBounds

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -138,7 +138,7 @@ namespace OpenRA
 
 		Rectangle DetermineRenderBounds()
 		{
-			var size = TraitsImplementing<IAutoSelectionSize>().Select(x => x.SelectionSize(this)).FirstOrDefault();
+			var size = TraitsImplementing<IAutoRenderSize>().Select(x => x.RenderSize(this)).FirstOrDefault(Exts.IsTraitEnabled);
 			var offset = -size / 2;
 
 			return new Rectangle(offset.X, offset.Y, size.X, size.Y);

--- a/OpenRA.Game/Graphics/SelectionBarsRenderable.cs
+++ b/OpenRA.Game/Graphics/SelectionBarsRenderable.cs
@@ -149,7 +149,7 @@ namespace OpenRA.Graphics
 			var health = actor.TraitOrDefault<IHealth>();
 
 			var screenPos = wr.Screen3DPxPosition(pos);
-			var bounds = actor.VisualBounds;
+			var bounds = actor.SelectionOverlayBounds;
 			bounds.Offset((int)screenPos.X, (int)screenPos.Y);
 
 			var start = new float3(bounds.Left + 1, bounds.Top, screenPos.Z);

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -228,7 +228,6 @@
     <Compile Include="Graphics\PlatformInterfaces.cs" />
     <Compile Include="Sound\Sound.cs" />
     <Compile Include="Sound\SoundDevice.cs" />
-    <Compile Include="Graphics\SelectionBarsRenderable.cs" />
     <Compile Include="Graphics\TargetLineRenderable.cs" />
     <Compile Include="Graphics\UISpriteRenderable.cs" />
     <Compile Include="Graphics\SoftwareCursor.cs" />

--- a/OpenRA.Game/SelectableExts.cs
+++ b/OpenRA.Game/SelectableExts.cs
@@ -47,12 +47,12 @@ namespace OpenRA.Traits
 
 		public static Actor WithHighestSelectionPriority(this IEnumerable<Actor> actors, int2 selectionPixel)
 		{
-			return actors.MaxByOrDefault(a => CalculateActorSelectionPriority(a.Info, a.Bounds, selectionPixel));
+			return actors.MaxByOrDefault(a => CalculateActorSelectionPriority(a.Info, a.SelectableBounds, selectionPixel));
 		}
 
 		public static FrozenActor WithHighestSelectionPriority(this IEnumerable<FrozenActor> actors, int2 selectionPixel)
 		{
-			return actors.MaxByOrDefault(a => CalculateActorSelectionPriority(a.Info, a.Bounds, selectionPixel));
+			return actors.MaxByOrDefault(a => CalculateActorSelectionPriority(a.Info, a.SelectableBounds, selectionPixel));
 		}
 
 		static long CalculateActorSelectionPriority(ActorInfo info, Rectangle bounds, int2 selectionPixel)

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -31,7 +31,8 @@ namespace OpenRA.Traits
 	{
 		public readonly PPos[] Footprint;
 		public readonly WPos CenterPosition;
-		public readonly Rectangle Bounds;
+		public readonly Rectangle RenderBounds;
+		public readonly Rectangle SelectableBounds;
 		public readonly HashSet<string> TargetTypes;
 		readonly Actor actor;
 		readonly Shroud shroud;
@@ -77,7 +78,8 @@ namespace OpenRA.Traits
 					footprint.Select(p => shroud.Contains(p).ToString()).JoinWith("|")));
 
 			CenterPosition = self.CenterPosition;
-			Bounds = self.Bounds;
+			RenderBounds = self.RenderBounds;
+			SelectableBounds = self.SelectableBounds;
 			TargetTypes = self.GetEnabledTargetTypes().ToHashSet();
 
 			tooltips = self.TraitsImplementing<ITooltip>().ToArray();

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -101,6 +101,9 @@ namespace OpenRA.Traits
 	public interface IAutoSelectionSizeInfo : ITraitInfoInterface { }
 	public interface IAutoSelectionSize { int2 SelectionSize(Actor self); }
 
+	public interface IAutoRenderSizeInfo : ITraitInfoInterface { }
+	public interface IAutoRenderSize { int2 RenderSize(Actor self); }
+
 	public interface IIssueOrder
 	{
 		IEnumerable<IOrderTargeter> Orders { get; }

--- a/OpenRA.Game/Traits/World/ScreenMap.cs
+++ b/OpenRA.Game/Traits/World/ScreenMap.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Traits
 		Rectangle FrozenActorBounds(FrozenActor fa)
 		{
 			var pos = worldRenderer.ScreenPxPosition(fa.CenterPosition);
-			var bounds = fa.Bounds;
+			var bounds = fa.RenderBounds;
 			bounds.Offset(pos.X, pos.Y);
 			return bounds;
 		}
@@ -61,7 +61,7 @@ namespace OpenRA.Traits
 		Rectangle ActorBounds(Actor a)
 		{
 			var pos = worldRenderer.ScreenPxPosition(a.CenterPosition);
-			var bounds = a.Bounds;
+			var bounds = a.RenderBounds;
 			bounds.Offset(pos.X, pos.Y);
 			return bounds;
 		}

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -192,7 +192,7 @@ namespace OpenRA
 			ActorMap.AddInfluence(self, ios);
 			ActorMap.AddPosition(self, ios);
 
-			if (!self.Bounds.Size.IsEmpty)
+			if (!self.RenderBounds.Size.IsEmpty)
 				ScreenMap.Add(self);
 		}
 
@@ -201,7 +201,7 @@ namespace OpenRA
 			if (!self.IsInWorld)
 				return;
 
-			if (!self.Bounds.Size.IsEmpty)
+			if (!self.RenderBounds.Size.IsEmpty)
 				ScreenMap.Update(self);
 
 			ActorMap.UpdatePosition(self, ios);
@@ -212,7 +212,7 @@ namespace OpenRA
 			ActorMap.RemoveInfluence(self, ios);
 			ActorMap.RemovePosition(self, ios);
 
-			if (!self.Bounds.Size.IsEmpty)
+			if (!self.RenderBounds.Size.IsEmpty)
 				ScreenMap.Remove(self);
 		}
 

--- a/OpenRA.Mods.Common/Graphics/SelectionBarsRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBarsRenderable.cs
@@ -10,9 +10,10 @@
 #endregion
 
 using System.Drawing;
+using OpenRA.Graphics;
 using OpenRA.Traits;
 
-namespace OpenRA.Graphics
+namespace OpenRA.Mods.Common.Graphics
 {
 	public struct SelectionBarsRenderable : IRenderable, IFinalizedRenderable
 	{

--- a/OpenRA.Mods.Common/Graphics/SelectionBoxRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBoxRenderable.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Graphics
 		readonly Color color;
 
 		public SelectionBoxRenderable(Actor actor, Color color)
-			: this(actor.CenterPosition, actor.VisualBounds, color) { }
+			: this(actor.CenterPosition, actor.SelectionOverlayBounds, color) { }
 
 		public SelectionBoxRenderable(WPos pos, Rectangle visualBounds, Color color)
 		{

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -328,6 +328,7 @@
     <Compile Include="Traits\Crushable.cs" />
     <Compile Include="Traits\CustomSellValue.cs" />
     <Compile Include="Traits\CustomSelectionSize.cs" />
+    <Compile Include="Traits\Render\CustomRenderSize.cs" />
     <Compile Include="Traits\DamagedByTerrain.cs" />
     <Compile Include="Traits\DeliversCash.cs" />
     <Compile Include="Traits\DeliversExperience.cs" />
@@ -417,6 +418,7 @@
     <Compile Include="Traits\BodyOrientation.cs" />
     <Compile Include="Traits\QuantizeFacingsFromSequence.cs" />
     <Compile Include="Traits\Render\AutoSelectionSize.cs" />
+    <Compile Include="Traits\Render\AutoRenderSize.cs" />
     <Compile Include="Traits\Render\CashTricklerBar.cs" />
     <Compile Include="Traits\Render\CustomTerrainDebugOverlay.cs" />
     <Compile Include="Traits\Render\Hovers.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -163,6 +163,7 @@
     <Compile Include="Graphics\BeamRenderable.cs" />
     <Compile Include="Graphics\ContrailRenderable.cs" />
     <Compile Include="Graphics\RangeCircleRenderable.cs" />
+    <Compile Include="Graphics\SelectionBarsRenderable.cs" />
     <Compile Include="Graphics\SelectionBoxRenderable.cs" />
     <Compile Include="Graphics\SpriteActorPreview.cs" />
     <Compile Include="Graphics\TextRenderable.cs" />

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -314,7 +314,7 @@ namespace OpenRA.Mods.Common.Traits
 			self.World.ActorMap.AddInfluence(self, this);
 			self.World.ActorMap.AddPosition(self, this);
 
-			if (!self.Bounds.Size.IsEmpty)
+			if (!self.RenderBounds.Size.IsEmpty)
 				self.World.ScreenMap.Add(self);
 
 			influence.AddInfluence(self, Info.Tiles(self.Location));
@@ -325,7 +325,7 @@ namespace OpenRA.Mods.Common.Traits
 			self.World.ActorMap.RemoveInfluence(self, this);
 			self.World.ActorMap.RemovePosition(self, this);
 
-			if (!self.Bounds.Size.IsEmpty)
+			if (!self.RenderBounds.Size.IsEmpty)
 				self.World.ScreenMap.Remove(self);
 
 			influence.RemoveInfluence(self, Info.Tiles(self.Location));

--- a/OpenRA.Mods.Common/Traits/Immobile.cs
+++ b/OpenRA.Mods.Common/Traits/Immobile.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 			self.World.ActorMap.AddInfluence(self, this);
 			self.World.ActorMap.AddPosition(self, this);
 
-			if (!self.Bounds.Size.IsEmpty)
+			if (!self.RenderBounds.Size.IsEmpty)
 				self.World.ScreenMap.Add(self);
 		}
 
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 			self.World.ActorMap.RemoveInfluence(self, this);
 			self.World.ActorMap.RemovePosition(self, this);
 
-			if (!self.Bounds.Size.IsEmpty)
+			if (!self.RenderBounds.Size.IsEmpty)
 				self.World.ScreenMap.Remove(self);
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Render/AutoRenderSize.cs
+++ b/OpenRA.Mods.Common/Traits/Render/AutoRenderSize.cs
@@ -1,0 +1,32 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits.Render
+{
+	[Desc("Automatically calculates the screen map boundaries from the sprite size.")]
+	public class AutoRenderSizeInfo : ITraitInfo, Requires<RenderSpritesInfo>, IAutoRenderSizeInfo
+	{
+		public object Create(ActorInitializer init) { return new AutoRenderSize(this); }
+	}
+
+	public class AutoRenderSize : IAutoRenderSize
+	{
+		public AutoRenderSize(AutoRenderSizeInfo info) { }
+
+		public int2 RenderSize(Actor self)
+		{
+			var rs = self.Trait<RenderSprites>();
+			return rs.AutoRenderSize(self);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Render/CustomRenderSize.cs
+++ b/OpenRA.Mods.Common/Traits/Render/CustomRenderSize.cs
@@ -1,0 +1,35 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Special case trait for actors that need to define targetable area and screen map bounds manually.")]
+	public class CustomRenderSizeInfo : ITraitInfo, IAutoRenderSizeInfo
+	{
+		[FieldLoader.Require]
+		public readonly int[] CustomBounds = null;
+
+		public object Create(ActorInitializer init) { return new CustomRenderSize(this); }
+	}
+
+	public class CustomRenderSize : IAutoRenderSize
+	{
+		readonly CustomRenderSizeInfo info;
+		public CustomRenderSize(CustomRenderSizeInfo info) { this.info = info; }
+
+		public int2 RenderSize(Actor self)
+		{
+			return new int2(info.CustomBounds[0], info.CustomBounds[1]);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Render/RenderNameTag.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderNameTag.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)
 		{
 			var pos = wr.ScreenPxPosition(self.CenterPosition);
-			var bounds = self.Bounds;
+			var bounds = self.SelectableBounds;
 			bounds.Offset(pos.X, pos.Y);
 			var spaceBuffer = (int)(10 / wr.Viewport.Zoom);
 			var effectPos = wr.ProjectedPosition(new int2(pos.X, bounds.Y - spaceBuffer));

--- a/OpenRA.Mods.Common/Traits/Render/RenderNameTag.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderNameTag.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)
 		{
 			var pos = wr.ScreenPxPosition(self.CenterPosition);
-			var bounds = self.SelectableBounds;
+			var bounds = self.SelectionOverlayBounds;
 			bounds.Offset(pos.X, pos.Y);
 			var spaceBuffer = (int)(10 / wr.Viewport.Zoom);
 			var effectPos = wr.ProjectedPosition(new int2(pos.X, bounds.Y - spaceBuffer));

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -239,6 +239,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 		// Required by WithSpriteBody and WithInfantryBody
 		public int2 AutoSelectionSize(Actor self)
 		{
+			return AutoRenderSize(self);
+		}
+
+		// Required by WithSpriteBody and WithInfantryBody
+		public int2 AutoRenderSize(Actor self)
+		{
 			return anims.Where(b => b.IsVisible
 				&& b.Animation.Animation.CurrentSequence != null)
 					.Select(a => (a.Animation.Animation.Image.Size.XY * info.Scale).ToInt2())

--- a/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 	{
 		[PaletteReference] public readonly string Palette = "chrome";
 
-		[Desc("Visual bounds for selection box. If null, it uses AutoSelectionSize.",
+		[Desc("Bounds for visual selection box. If null, it uses AutoSelectionSize.",
 		"The first two values define the bounds' size, the optional third and fourth",
 		"values specify the position relative to the actors' center. Defaults to selectable bounds.")]
 		public readonly int[] VisualBounds = null;
@@ -128,7 +128,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (pipSources.Length == 0)
 				return Enumerable.Empty<IRenderable>();
 
-			var b = self.VisualBounds;
+			var b = self.SelectionOverlayBounds;
 			var pos = wr.ScreenPxPosition(self.CenterPosition);
 			var bl = wr.Viewport.WorldToViewPx(pos + new int2(b.Left, b.Bottom));
 			var pal = wr.Palette(Info.Palette);
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var pipSize = pipImages.Image.Size.XY.ToInt2();
 			var pipxyBase = basePosition + new int2(1 - pipSize.X / 2, -(3 + pipSize.Y / 2));
 			var pipxyOffset = new int2(0, 0);
-			var width = self.VisualBounds.Width;
+			var width = self.SelectionOverlayBounds.Width;
 
 			foreach (var pips in pipSources)
 			{

--- a/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (!ShouldRender(self) || self.World.FogObscures(self))
 				return Enumerable.Empty<IRenderable>();
 
-			var bounds = self.VisualBounds;
+			var bounds = self.SelectionOverlayBounds;
 			var halfSize = (0.5f * Anim.Image.Size.XY).ToInt2();
 
 			var boundsOffset = new int2(bounds.Left + bounds.Right, bounds.Top + bounds.Bottom) / 2;

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			pipImages.PlayFetchIndex(Info.GroupSequence, () => (int)group);
 
-			var bounds = self.VisualBounds;
+			var bounds = self.SelectionOverlayBounds;
 			var boundsOffset = 0.5f * new float2(bounds.Left + bounds.Right, bounds.Top + bounds.Bottom);
 			if (Info.ReferencePoint.HasFlag(ReferencePoints.Top))
 				boundsOffset -= new float2(0, 0.5f * bounds.Height);

--- a/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (group == null)
 				yield break;
 
-			var bounds = self.VisualBounds;
+			var bounds = self.SelectionOverlayBounds;
 			var number = group.Value.ToString();
 			var halfSize = font.Measure(number) / 2;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (!ShouldRender(self) || self.World.FogObscures(self))
 				return Enumerable.Empty<IRenderable>();
 
-			var bounds = self.VisualBounds;
+			var bounds = self.SelectionOverlayBounds;
 			var halfSize = font.Measure(Info.Text) / 2;
 
 			var boundsOffset = new int2(bounds.Left + bounds.Right, bounds.Top + bounds.Bottom) / 2;

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Also returns a default selection size that is calculated automatically from the voxel dimensions.")]
-	public class WithVoxelBodyInfo : ConditionalTraitInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>, IAutoSelectionSizeInfo
+	public class WithVoxelBodyInfo : ConditionalTraitInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>, IAutoSelectionSizeInfo, IAutoRenderSizeInfo
 	{
 		public readonly string Sequence = "idle";
 
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	public class WithVoxelBody : ConditionalTrait<WithVoxelBodyInfo>, IAutoSelectionSize
+	public class WithVoxelBody : ConditionalTrait<WithVoxelBodyInfo>, IAutoSelectionSize, IAutoRenderSize
 	{
 		readonly int2 size;
 
@@ -61,5 +61,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 
 		public int2 SelectionSize(Actor self) { return size; }
+		public int2 RenderSize(Actor self) { return size; }
 	}
 }

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -1234,6 +1234,25 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// Split Selection- and RenderSize
+				if (engineVersion < 20171115)
+				{
+					var autoSelSize = node.Value.Nodes.FirstOrDefault(n => n.Key.StartsWith("AutoSelectionSize", StringComparison.Ordinal));
+					if (autoSelSize != null)
+						node.Value.Nodes.Add(new MiniYamlNode("AutoRenderSize", ""));
+
+					var customSelSize = node.Value.Nodes.FirstOrDefault(n => n.Key.StartsWith("CustomSelectionSize", StringComparison.Ordinal));
+					if (customSelSize != null)
+					{
+						var bounds = customSelSize.Value.Nodes.FirstOrDefault(n => n.Key == "CustomBounds");
+						var customRenderSize = new MiniYamlNode("CustomRenderSize", "");
+						if (bounds != null)
+							customRenderSize.Value.Nodes.Add(bounds);
+
+						node.Value.Nodes.Add(customRenderSize);
+					}
+				}
+
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -14,6 +14,7 @@ using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Effects;
+using OpenRA.Mods.Common.Graphics;
 using OpenRA.Orders;
 using OpenRA.Traits;
 using OpenRA.Widgets;

--- a/mods/cnc/rules/civilian.yaml
+++ b/mods/cnc/rules/civilian.yaml
@@ -417,6 +417,8 @@ BRIDGE1:
 	FreeActor@south:
 		Actor: bridgehut
 		SpawnOffset: 0,2
+	CustomRenderSize:
+		CustomBounds: 96,96
 
 BRIDGE2:
 	Inherits: ^Bridge
@@ -434,6 +436,8 @@ BRIDGE2:
 	FreeActor@south:
 		Actor: bridgehut
 		SpawnOffset: 2,2
+	CustomRenderSize:
+		CustomBounds: 120,120
 
 BRIDGE3:
 	Inherits: ^Bridge
@@ -451,6 +455,8 @@ BRIDGE3:
 	FreeActor@south:
 		Actor: bridgehut
 		SpawnOffset: 1,2
+	CustomRenderSize:
+		CustomBounds: 144,120
 
 BRIDGE4:
 	Inherits: ^Bridge
@@ -468,6 +474,8 @@ BRIDGE4:
 	FreeActor@south:
 		Actor: bridgehut
 		SpawnOffset: 3,2
+	CustomRenderSize:
+		CustomBounds: 144,96
 
 BRIDGEHUT:
 	AlwaysVisible:
@@ -479,6 +487,8 @@ BRIDGEHUT:
 	LegacyBridgeHut:
 	Targetable:
 		TargetTypes: BridgeHut, C4
+	CustomRenderSize:
+		CustomBounds: 48,48
 
 C1:
 	Inherits: ^CivInfantry

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -13,6 +13,7 @@
 	QuantizeFacingsFromSequence:
 	AutoSelectionSize:
 	RenderSprites:
+	AutoRenderSize:
 
 ^1x1Shape:
 	HitShape:

--- a/mods/cnc/rules/misc.yaml
+++ b/mods/cnc/rules/misc.yaml
@@ -134,3 +134,4 @@ FLARE:
 	AutoSelectionSize:
 	EditorTilesetFilter:
 		Categories: System
+	AutoRenderSize:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -243,6 +243,7 @@ SILO:
 	SelectionDecorations:
 		VisualBounds: 49,30
 	-AcceptsDeliveredCash:
+	AutoRenderSize:
 
 PYLE:
 	Inherits: ^BaseBuilding
@@ -814,6 +815,7 @@ SAM:
 		Amount: -20
 	BodyOrientation:
 		UseClassicFacingFudge: True
+	AutoRenderSize:
 
 OBLI:
 	Inherits: ^Defense

--- a/mods/d2k/maps/atreides-04/rules.yaml
+++ b/mods/d2k/maps/atreides-04/rules.yaml
@@ -88,6 +88,7 @@ tile475:
 	BodyOrientation:
 		QuantizedFacings: 1
 	AutoSelectionSize:
+	AutoRenderSize:
 
 # Placed after the sietch is destroyed so that the cliff is still unpassable
 invisibleBlocker:

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -63,6 +63,7 @@ spicebloom:
 			Radius: 512
 	EditorTilesetFilter:
 		Categories: System
+	AutoRenderSize:
 
 sandworm:
 	Inherits@1: ^SpriteActor

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -13,6 +13,7 @@
 	QuantizeFacingsFromSequence:
 	AutoSelectionSize:
 	RenderSprites:
+	AutoRenderSize:
 
 ^GainsExperience:
 	GainsExperience:

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -138,6 +138,8 @@ crate:
 		CustomBounds: 20,20
 	EditorTilesetFilter:
 		Categories: System
+	CustomRenderSize:
+		CustomBounds: 20,20
 
 mpspawn:
 	EditorOnlyTooltip:

--- a/mods/ra/maps/allies-01/rules.yaml
+++ b/mods/ra/maps/allies-01/rules.yaml
@@ -22,6 +22,7 @@ TRAN.Extraction:
 	AutoSelectionSize:
 	RenderSprites:
 		Image: tran
+	AutoRenderSize:
 
 TRAN.Insertion:
 	Inherits: TRAN.Extraction
@@ -31,6 +32,7 @@ TRAN.Insertion:
 	AutoSelectionSize:
 	RenderSprites:
 		Image: tran
+	AutoRenderSize:
 
 EINSTEIN:
 	Passenger:

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -320,6 +320,8 @@ BARL:
 	-Demolishable:
 	EditorTilesetFilter:
 		Categories: Decoration
+	CustomRenderSize:
+		CustomBounds: 24,24
 
 BRL3:
 	Inherits: ^TechBuilding
@@ -344,6 +346,8 @@ BRL3:
 	-Demolishable:
 	EditorTilesetFilter:
 		Categories: Decoration
+	CustomRenderSize:
+		CustomBounds: 24,24
 
 AMMOBOX1:
 	Inherits: ^AmmoBox
@@ -491,6 +495,8 @@ BRIDGE1:
 	FreeActor@south:
 		Actor: bridgehut
 		SpawnOffset: 0,1
+	CustomRenderSize:
+		CustomBounds: 120,72
 
 BRIDGE2:
 	Inherits: ^Bridge
@@ -509,6 +515,8 @@ BRIDGE2:
 	FreeActor@south:
 		Actor: bridgehut
 		SpawnOffset: 2,1
+	CustomRenderSize:
+		CustomBounds: 120,48
 
 SBRIDGE1:
 	Inherits: ^Bridge
@@ -527,6 +535,8 @@ SBRIDGE1:
 	FreeActor@south:
 		Actor: bridgehut.small
 		SpawnOffset: 1,1
+	CustomRenderSize:
+		CustomBounds: 72,48
 
 SBRIDGE2:
 	Inherits: ^Bridge
@@ -545,6 +555,8 @@ SBRIDGE2:
 	FreeActor@east:
 		Actor: bridgehut.small
 		SpawnOffset: 1,1
+	CustomRenderSize:
+		CustomBounds: 48,72
 
 SBRIDGE3:
 	Inherits: ^Bridge

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -12,6 +12,7 @@
 	QuantizeFacingsFromSequence:
 	AutoSelectionSize:
 	RenderSprites:
+	AutoRenderSize:
 
 ^1x1Shape:
 	HitShape:
@@ -786,6 +787,8 @@
 		Type: Light
 	EditorTilesetFilter:
 		Categories: Decoration
+	CustomRenderSize:
+		CustomBounds: 24,24
 
 ^CivBuilding:
 	Inherits: ^TechBuilding
@@ -974,6 +977,8 @@
 	ScriptTriggers:
 	BodyOrientation:
 		QuantizedFacings: 1
+	CustomRenderSize:
+		CustomBounds: 96,48
 
 ^Rock:
 	Inherits@1: ^SpriteActor

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -201,6 +201,7 @@ FLARE:
 	AutoSelectionSize:
 	EditorTilesetFilter:
 		Categories: Decoration
+	AutoRenderSize:
 
 MINE:
 	Inherits@1: ^SpriteActor

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -381,3 +381,4 @@ HUNTER:
 	HitShape:
 	EditorTilesetFilter:
 		Categories: System
+	AutoRenderSize:

--- a/mods/ts/rules/bridges.yaml
+++ b/mods/ts/rules/bridges.yaml
@@ -34,6 +34,7 @@ CABHUT:
 		Name: Bridge
 	EditorTilesetFilter:
 		Categories: Bridge
+	AutoRenderSize:
 
 ^LowBridge:
 	Inherits: ^LowBridgeRamp
@@ -81,6 +82,8 @@ LOBRDG_A_D:
 		BOffset: 1,1
 	CustomSelectionSize:
 		CustomBounds: 96, 48
+	CustomRenderSize:
+		CustomBounds: 96, 48
 
 LOBRDG_B:
 	Inherits: ^LowBridge
@@ -116,6 +119,8 @@ LOBRDG_B_D:
 		AOffset: 1,1
 		BOffset: -1,1
 	CustomSelectionSize:
+		CustomBounds: 96, 48
+	CustomRenderSize:
 		CustomBounds: 96, 48
 
 LOBRDG_R_SE:
@@ -177,6 +182,8 @@ LOBRDG_R_SW:
 		CustomBounds: 96, 144
 	EditorTilesetFilter:
 		Categories: Bridge
+	CustomRenderSize:
+		CustomBounds: 96, 144
 
 BRIDGE1:
 	Inherits: ^ElevatedBridgePlaceholder

--- a/mods/ts/rules/bridges.yaml
+++ b/mods/ts/rules/bridges.yaml
@@ -163,7 +163,6 @@ LOBRDG_R_SW:
 	RenderSprites:
 		Palette: terraindecoration
 	WithSpriteBody:
-	AutoSelectionSize:
 	AppearsOnRadar:
 	RadarColorFromTerrain:
 		Terrain: Bridge

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -15,6 +15,7 @@
 	QuantizeFacingsFromSequence:
 	AutoSelectionSize:
 	RenderSprites:
+	AutoRenderSize:
 
 ^GainsExperience:
 	GainsExperience:
@@ -431,6 +432,8 @@
 		CustomBounds: 24,24
 	EditorTilesetFilter:
 		Categories: System
+	CustomRenderSize:
+		CustomBounds: 24,24
 
 ^Wall:
 	Inherits@1: ^SpriteActor
@@ -1099,6 +1102,7 @@
 		TerrainType: Rail
 	EditorTilesetFilter:
 		Categories: Railway
+	AutoRenderSize:
 
 ^Tunnel:
 	RenderSprites:
@@ -1118,6 +1122,8 @@
 		Dimensions: 3, 3
 	EditorTilesetFilter:
 		Categories: Tunnel
+	CustomRenderSize:
+		CustomBounds: 144, 144
 
 ^Gate:
 	Inherits: ^Building

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -188,6 +188,7 @@ JUMPJET.Husk:
 		FallbackSequence: die-splash
 	EditorTilesetFilter:
 		Categories: Husk
+	AutoRenderSize:
 
 GHOST:
 	Inherits: ^Soldier

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -129,6 +129,8 @@ NAFNCE:
 		Weapons: SmallDebris
 		Pieces: 0, 1
 		Range: 2c0, 5c0
+	CustomRenderSize:
+		CustomBounds: 48, 24
 
 NALASR:
 	Inherits: ^Defense

--- a/mods/ts/rules/trees.yaml
+++ b/mods/ts/rules/trees.yaml
@@ -118,6 +118,7 @@ VEINHOLE:
 	AutoSelectionSize:
 	EditorTilesetFilter:
 		Categories: Resource spawn
+	AutoRenderSize:
 
 ^TibFlora:
 	Inherits: ^Tree


### PR DESCRIPTION
Additionally, internally renamed `VisualBounds` to `SelectionOverlayBounds` to avoid confusion with `RenderBounds`.

This step was necessary to prevent actors with selectable area smaller than their graphics to be removed too early from ScreenMap even though part of the graphics should still be visible.
RA cruisers were a prime example, but to a lesser extent several other actors were affected as well.

This also serves as preparation to determine the final `RenderBounds` from multiple source bounds without worrying about the selectable area, to fix the remaining ScreenMap issues (building 'bibs', aircraft shadows, parachuted infantry shadows and possibly a few more edge cases).