### PR TITLE
Fixed appdata.xml after mod launcher split

### DIFF
--- a/packaging/linux/openra.appdata.xml
+++ b/packaging/linux/openra.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>openra.desktop</id>
+  <id>net.openra</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0</project_license>
   <name>OpenRA</name>
@@ -43,6 +43,9 @@
     </screenshot>
   </screenshots>
   <url type="homepage">http://www.openra.net</url>
+  ​<launchable type="desktop-id">openra-ra.desktop</launchable>
+  ​<launchable type="desktop-id">openra-cnc.desktop</launchable>
+  ​<launchable type="desktop-id">openra-d2k.desktop</launchable>
   <update_contact>paul_at_chote.net</update_contact>
   <content_rating type="oars-1.0">
     <content_attribute id="violence-cartoon">none</content_attribute>

--- a/packaging/linux/openra.appdata.xml
+++ b/packaging/linux/openra.appdata.xml
@@ -43,6 +43,10 @@
     </screenshot>
   </screenshots>
   <url type="homepage">http://www.openra.net</url>
+  <url type="bugtracker">http://bugs.openra.net</url>
+  <url type="faq">http://wiki.openra.net/FAQ</url>
+  <url type="help">http://wiki.openra.net</url>
+  <url type="donation">https://salt.bountysource.com/teams/openra</url>
   ​<launchable type="desktop-id">openra-ra.desktop</launchable>
   ​<launchable type="desktop-id">openra-cnc.desktop</launchable>
   ​<launchable type="desktop-id">openra-d2k.desktop</launchable>


### PR DESCRIPTION
This should fix the currently broken GNOME Software integration. Followup of https://github.com/OpenRA/OpenRA/pull/13138. For reference:

* https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-launchable
* https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url