### PR TITLE
Added support for a real source tarball

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,8 @@ before_deploy:
  - cd packaging
  - mkdir build
  - ./package-all.sh ${TRAVIS_TAG} ${PWD}/build/
+ - cd ..
+ - make dist
 deploy:
   provider: releases
   api_key:
@@ -79,6 +81,7 @@ deploy:
     - build/OpenRA-${TRAVIS_TAG}.exe
     - build/OpenRA-${TRAVIS_TAG}.dmg
     - build/openra_${DOTVERSION}_all.deb
+    - OpenRA-${TRAVIS_TAG}.tar.bz2
   skip_cleanup: true
   on:
     all_branches: true

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ INSTALL = install
 INSTALL_DIR = $(INSTALL) -d
 INSTALL_PROGRAM = $(INSTALL) -m755
 INSTALL_DATA = $(INSTALL) -m644
+TAR = tar
 
 # program targets
 CORE = pdefault game utility server
@@ -293,7 +294,11 @@ clean:
 	@-$(RM_RF) ./*/bin ./*/obj
 	@-$(RM_RF) ./thirdparty/download
 
-distclean: clean
+distclean: clean cleanversion
+	@-$(RM_F) *.tar.bz2
+
+dist: version
+	@-$(TAR) -cjf OpenRA-$(VERSION).tar.bz2 *
 
 cli-dependencies:
 	@./thirdparty/fetch-thirdparty-deps.sh
@@ -326,6 +331,14 @@ version: VERSION mods/ra/mod.yaml mods/cnc/mod.yaml mods/d2k/mod.yaml mods/ts/mo
 	@for i in $? ; do \
 		awk '{sub("Version:.*$$","Version: $(VERSION)"); print $0}' $${i} > $${i}.tmp && \
 		awk '{sub("/[^/]*: User$$", "/$(VERSION): User"); print $0}' $${i}.tmp > $${i} && \
+		rm $${i}.tmp; \
+	done
+
+cleanversion: VERSION mods/ra/mod.yaml mods/cnc/mod.yaml mods/d2k/mod.yaml mods/ts/mod.yaml mods/modcontent/mod.yaml mods/all/mod.yaml
+	@echo "{DEV_VERSION}" > VERSION
+	@for i in $? ; do \
+		awk '{sub("Version:.*$$","Version: {DEV_VERSION}"); print $0}' $${i} > $${i}.tmp && \
+		awk '{sub("/[^/]*: User$$", "/{DEV_VERSION}: User"); print $0}' $${i}.tmp > $${i} && \
 		rm $${i}.tmp; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -289,12 +289,12 @@ mods: mod_common mod_cnc mod_d2k
 
 all: dependencies core stylecheck
 
-clean:
+clean: cleanversion
 	@-$(RM_F) *.exe *.dll *.dylib *.dll.config ./OpenRA*/*.dll ./OpenRA*/*.mdb *.mdb mods/**/*.dll mods/**/*.mdb *.resources
 	@-$(RM_RF) ./*/bin ./*/obj
 	@-$(RM_RF) ./thirdparty/download
 
-distclean: clean cleanversion
+distclean: clean
 	@-$(RM_F) *.tar.bz2
 
 dist: version


### PR DESCRIPTION
Closes https://github.com/OpenRA/OpenRA/issues/12907.

`make dist` and `make distclean` now do something useful.