### PR TITLE
Add mod-specific appdata metadata.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -411,7 +411,13 @@ install-linux-mime:
 
 install-linux-appdata:
 	@$(INSTALL_DIR) "$(DESTDIR)$(datadir)/appdata/"
-	@$(INSTALL_DATA) packaging/linux/openra.appdata.xml "$(DESTDIR)$(datadir)/appdata/"
+	@sed 's/{MOD}/ra/g' packaging/linux/openra.appdata.xml.in | sed 's/{MOD_NAME}/Red Alert/g' | sed 's/{SCREENSHOT_RA}/ type="default"/g' | sed 's/{SCREENSHOT_CNC}//g' | sed 's/{SCREENSHOT_D2K}//g'> packaging/linux/openra-ra.appdata.xml
+	@$(INSTALL_DATA) packaging/linux/openra-ra.appdata.xml "$(DESTDIR)$(datadir)/appdata/"
+	@sed 's/{MOD}/cnc/g' packaging/linux/openra.appdata.xml.in | sed 's/{MOD_NAME}/Tiberian Dawn/g' | sed 's/{SCREENSHOT_RA}//g' | sed 's/{SCREENSHOT_CNC}/ type="default"/g' | sed 's/{SCREENSHOT_D2K}//g'> packaging/linux/openra-cnc.appdata.xml
+	@$(INSTALL_DATA) packaging/linux/openra-cnc.appdata.xml "$(DESTDIR)$(datadir)/appdata/"
+	@sed 's/{MOD}/d2k/g' packaging/linux/openra.appdata.xml.in | sed 's/{MOD_NAME}/Dune 2000/g' | sed 's/{SCREENSHOT_RA}//g' | sed 's/{SCREENSHOT_CNC}//g' | sed 's/{SCREENSHOT_D2K}/ type="default"/g'> packaging/linux/openra-d2k.appdata.xml
+	@$(INSTALL_DATA) packaging/linux/openra-d2k.appdata.xml "$(DESTDIR)$(datadir)/appdata/"
+	@-$(RM) packaging/linux/openra-ra.appdata.xml packaging/linux/openra-cnc.appdata.xml packaging/linux/openra-d2k.appdata.xml
 
 install-man-page: man-page
 	@$(INSTALL_DIR) "$(DESTDIR)$(mandir)/man6/"

--- a/packaging/linux/openra.appdata.xml.in
+++ b/packaging/linux/openra.appdata.xml.in
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>openra.desktop</id>
+  <id>openra-{MOD}.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0</project_license>
-  <name>OpenRA</name>
+  <name>OpenRA - {MOD_NAME}</name>
   <summary>Reimagining of early Westwood real-time strategy games</summary>
   <description>
     <p>
@@ -25,15 +25,15 @@
     </p>
   </description>
   <screenshots>
-    <screenshot type="default">
+    <screenshot{SCREENSHOT_RA}>
       <image>http://www.openra.net/images/appdata/ingame-ra.png</image>
       <caption>Red Alert mod</caption>
     </screenshot>
-    <screenshot>
+    <screenshot{SCREENSHOT_CNC}>
       <image>http://www.openra.net/images/appdata/ingame-cnc.png</image>
       <caption>Tiberian Dawn mod</caption>
     </screenshot>
-    <screenshot>
+    <screenshot{SCREENSHOT_D2K}>
       <image>http://www.openra.net/images/appdata/ingame-d2k.png</image>
       <caption>Dune 2000 Mod</caption>
     </screenshot>


### PR DESCRIPTION
Fixes #13907.

This takes the simple and more robust approach of writing a separate appdata file for each *.desktop launcher.  Tested under Ubuntu 17.04 and passes `appstream-util` validation.

![screen shot 2017-08-26 at 21 24 16](https://user-images.githubusercontent.com/167819/29744867-70571c58-8aa5-11e7-9824-e5e60b704d42.png)
![screen shot 2017-08-26 at 21 26 01](https://user-images.githubusercontent.com/167819/29744871-74e97e28-8aa5-11e7-91ee-1ca872a4438c.png)
