### PR TITLE
ADD TurnWhileDisabled condition to IMove

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -202,6 +202,11 @@ namespace OpenRA.Mods.Cnc.Traits
 			return false;
 		}
 
+		bool IMove.TurnWhileDisabled(Actor self)
+		{
+			return false;
+		}
+
 		void IActorPreviewInitModifier.ModifyActorPreviewInit(Actor self, TypeDictionary inits)
 		{
 			if (!inits.Contains<DynamicFacingInit>() && !inits.Contains<FacingInit>())

--- a/OpenRA.Mods.Common/Activities/Turn.cs
+++ b/OpenRA.Mods.Common/Activities/Turn.cs
@@ -17,12 +17,17 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class Turn : Activity
 	{
+		readonly IMove move;
 		readonly IDisabledTrait disablable;
 		readonly int desiredFacing;
 
 		public Turn(Actor self, int desiredFacing)
 		{
-			disablable = self.TraitOrDefault<IMove>() as IDisabledTrait;
+			move = self.TraitOrDefault<IMove>();
+
+			if (move != null)
+				disablable = move as IDisabledTrait;
+
 			this.desiredFacing = desiredFacing;
 		}
 
@@ -30,7 +35,8 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			if (IsCanceled)
 				return NextActivity;
-			if (disablable != null && disablable.IsTraitDisabled)
+
+			if (disablable != null && disablable.IsTraitDisabled && !move.TurnWhileDisabled(self))
 				return this;
 
 			var facing = self.Trait<IFacing>();

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -18,6 +18,7 @@ using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Pathfinder;
 using OpenRA.Primitives;
+using OpenRA.Support;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -75,6 +76,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Can the actor be ordered to move in to shroud?")]
 		public readonly bool MoveIntoShroud = true;
+
+		[ConsumedConditionReference]
+		[Desc("Under this condition, this actor may turn even while this trait is disabled.",
+			"Useful for turretless units that deploy to become immobile, but still fires its weapon.")]
+		public readonly BooleanExpression TurnWhileDisabledCondition = null;
 
 		public readonly string Cursor = "move";
 		public readonly string BlockedCursor = "move-blocked";
@@ -406,6 +412,7 @@ namespace OpenRA.Mods.Common.Traits
 		int subterraneanToken = ConditionManager.InvalidConditionToken;
 		int jumpjetToken = ConditionManager.InvalidConditionToken;
 		ConditionManager conditionManager;
+		bool turnWhileDisabled = false;
 
 		[Sync] public int Facing
 		{
@@ -948,6 +955,11 @@ namespace OpenRA.Mods.Common.Traits
 			return self.Location == self.World.Map.CellContaining(target.CenterPosition) || Util.AdjacentCells(self.World, target).Any(c => c == self.Location);
 		}
 
+		bool IMove.TurnWhileDisabled(Actor self)
+		{
+			return turnWhileDisabled;
+		}
+
 		public Activity VisualMove(Actor self, WPos fromPos, WPos toPos)
 		{
 			return VisualMove(self, fromPos, toPos, self.Location);
@@ -999,6 +1011,21 @@ namespace OpenRA.Mods.Common.Traits
 			var moveTo = ClosestGroundCell();
 			if (moveTo != null)
 				self.QueueActivity(MoveTo(moveTo.Value, 0));
+		}
+
+		public override IEnumerable<VariableObserver> GetVariableObservers()
+		{
+			if (Info.TurnWhileDisabledCondition != null)
+				yield return new VariableObserver(TurnWhileDisabledConditionChanged, Info.TurnWhileDisabledCondition.Variables);
+
+			foreach (var v in base.GetVariableObservers())
+				yield return v;
+		}
+
+		void TurnWhileDisabledConditionChanged(Actor self, IReadOnlyDictionary<string, int> conditions)
+		{
+			if (Info.TurnWhileDisabledCondition != null)
+				turnWhileDisabled = Info.TurnWhileDisabledCondition.Evaluate(conditions);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -339,6 +339,7 @@ namespace OpenRA.Mods.Common.Traits
 		bool IsMoving { get; set; }
 		bool IsMovingVertically { get; set; }
 		bool CanEnterTargetNow(Actor self, Target target);
+		bool TurnWhileDisabled(Actor self);
 	}
 
 	public interface IRadarSignature


### PR DESCRIPTION
Fixes #12738

I found TurnsWhileImmobile is necessary while implementing GI. While this PR may look ad-hoc, I think this could be the proper fix.

* GI deploys and the Mobile trait becomes disabled.
* Because mobile is disabled, Turn activity won't work (intended for EMP'ed units) and the unit can't change its facing to attack the enemy.
* One option is to use turreted attack AND attack frontal so that while in deploy mode, it will use its "turret" to attack.
* However, even if we get this multiple AttackBase approach to work, it still doesn't look good since:
  * The infantry returns its facing to its "neutral" facing on idle (because, turret.)
  * If we disable that by RealignDelay = -1 in TurretedInfo, it still looks bad. When we undeploy the GI and deploy it somewhere else, the turret will not face where the unit was facing just before it deploys and instead, the turret alignment just before relocating the GI will be in effect.
* So I think the option of allowing the unit to turn even when it is immobile is a good solution.

YAML for GI looks like this:
https://github.com/forcecore/yupgi_alert0/blob/3fea2282a536b72f90bd30c8bb0b779e6af86270/rules/infantry.yaml#L1496