### PR TITLE
Fixed AutoSelectionSize not taking Sprite offsets into account

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -132,10 +132,11 @@ namespace OpenRA
 		Rectangle DetermineBounds()
 		{
 			var si = Info.TraitInfoOrDefault<SelectableInfo>();
+			var autoSelectionSize = TraitsImplementing<IAutoSelectionSize>();
 			var size = (si != null && si.Bounds != null) ? new int2(si.Bounds[0], si.Bounds[1]) :
-				TraitsImplementing<IAutoSelectionSize>().Select(x => x.SelectionSize(this)).FirstOrDefault();
+				autoSelectionSize.Select(x => x.SelectionSize(this)).FirstOrDefault();
 
-			var offset = -size / 2;
+			var offset = autoSelectionSize.Select(x => x.SelectionOffset(this)).FirstOrDefault() - size / 2;
 			if (si != null && si.Bounds != null && si.Bounds.Length > 2)
 				offset += new int2(si.Bounds[2], si.Bounds[3]);
 

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -98,7 +98,13 @@ namespace OpenRA.Traits
 	public interface IRender { IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr); }
 
 	public interface IAutoSelectionSizeInfo : ITraitInfoInterface { }
-	public interface IAutoSelectionSize { int2 SelectionSize(Actor self); }
+
+	[RequireExplicitImplementation]
+	public interface IAutoSelectionSize
+	{
+		int2 SelectionSize(Actor self);
+		int2 SelectionOffset(Actor self);
+	}
 
 	public interface IIssueOrder
 	{

--- a/OpenRA.Mods.Cnc/Traits/Render/WithVoxelUnloadBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithVoxelUnloadBody.cs
@@ -73,6 +73,8 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 				() => 0, info.ShowShadow));
 		}
 
-		public int2 SelectionSize(Actor self) { return size; }
+		int2 IAutoSelectionSize.SelectionSize(Actor self) { return size; }
+
+		int2 IAutoSelectionSize.SelectionOffset(Actor self) { return int2.Zero; }
 	}
 }

--- a/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
@@ -79,6 +79,8 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 
 		int2 IAutoSelectionSize.SelectionSize(Actor self) { return size; }
 
+		int2 IAutoSelectionSize.SelectionOffset(Actor self) { return int2.Zero; }
+
 		void ITick.Tick(Actor self)
 		{
 			if (movement.IsMoving || facing.Facing != oldFacing)

--- a/OpenRA.Mods.Common/Traits/CustomSelectionSize.cs
+++ b/OpenRA.Mods.Common/Traits/CustomSelectionSize.cs
@@ -17,6 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class CustomSelectionSizeInfo : ITraitInfo, IAutoSelectionSizeInfo
 	{
 		[FieldLoader.Require]
+		[Desc("First two comma separated values is the size. Optional second pair defines offsets.")]
 		public readonly int[] CustomBounds = null;
 
 		public object Create(ActorInitializer init) { return new CustomSelectionSize(this); }
@@ -27,9 +28,14 @@ namespace OpenRA.Mods.Common.Traits
 		readonly CustomSelectionSizeInfo info;
 		public CustomSelectionSize(CustomSelectionSizeInfo info) { this.info = info; }
 
-		public int2 SelectionSize(Actor self)
+		int2 IAutoSelectionSize.SelectionSize(Actor self)
 		{
 			return new int2(info.CustomBounds[0], info.CustomBounds[1]);
+		}
+
+		int2 IAutoSelectionSize.SelectionOffset(Actor self)
+		{
+			return info.CustomBounds.Length > 3 ? new int2(info.CustomBounds[2], info.CustomBounds[3]) : int2.Zero;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/AutoSelectionSize.cs
+++ b/OpenRA.Mods.Common/Traits/Render/AutoSelectionSize.cs
@@ -23,10 +23,16 @@ namespace OpenRA.Mods.Common.Traits.Render
 	{
 		public AutoSelectionSize(AutoSelectionSizeInfo info) { }
 
-		public int2 SelectionSize(Actor self)
+		int2 IAutoSelectionSize.SelectionSize(Actor self)
 		{
 			var rs = self.Trait<RenderSprites>();
 			return rs.AutoSelectionSize(self);
+		}
+
+		int2 IAutoSelectionSize.SelectionOffset(Actor self)
+		{
+			var rs = self.Trait<RenderSprites>();
+			return rs.AutoSelectionOffset(self);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -245,6 +245,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 					.FirstOrDefault();
 		}
 
+		public int2 AutoSelectionOffset(Actor self)
+		{
+			return anims.Where(b => b.IsVisible
+				&& b.Animation.Animation.CurrentSequence != null)
+					.Select(a => (a.Animation.Animation.Image.Offset.XY * info.Scale).ToInt2())
+					.FirstOrDefault();
+		}
+
 		void IActorPreviewInitModifier.ModifyActorPreviewInit(Actor self, TypeDictionary inits)
 		{
 			if (!inits.Contains<FactionInit>())

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
@@ -60,6 +60,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 			size = new int2(s, s);
 		}
 
-		public int2 SelectionSize(Actor self) { return size; }
+		int2 IAutoSelectionSize.SelectionSize(Actor self) { return size; }
+
+		int2 IAutoSelectionSize.SelectionOffset(Actor self) { return int2.Zero; }
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/issues/12119 and the trees popping in and out.