### PR TITLE
Change default Observer shroud option for Explored map

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var keyhandler = shroudSelector.Get<LogicKeyListenerWidget>("SHROUD_KEYHANDLER");
 			keyhandler.OnKeyPress = HandleKeyPress;
 
-			selected = limitViews ? groups.First().Value.First() : disableShroud;
+			selected = limitViews ? groups.First().Value.First() : world.WorldActor.Owner.Shroud.ExploreMapEnabled ? combined : disableShroud;
 			selected.OnClick();
 		}
 


### PR DESCRIPTION
Closes #13923.

Explored map - "All players"
Not Explored map - "Disable Shroud" (no change)