### PR TITLE
[RA] Balance - Allied Barracks (Tent) cost increase

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1673,7 +1673,7 @@ TENT:
 		Prerequisites: anypower, ~structures.allies, ~techlevel.infonly
 		Description: Trains infantry.
 	Valued:
-		Cost: 400
+		Cost: 500
 	Tooltip:
 		Name: Allied Barracks
 	Building:


### PR DESCRIPTION
Quick fix. Slipped through the code review of balance patch #13790

Allied Barracks, cost $500 up from $400