### PR TITLE
Added Waterfall terrain overlay animations

### DIFF
--- a/mods/ts/maps/arivruns/map.yaml
+++ b/mods/ts/maps/arivruns/map.yaml
@@ -1589,6 +1589,24 @@ Actors:
 	Actor505: bridge1
 		Owner: Neutral
 		Location: 180,4
+	Actor558: wa01x
+		Owner: Neutral
+		Location: 162,70
+	Actor565: wa03x
+		Owner: Neutral
+		Location: 99,-64
+	Actor566: wa02x
+		Owner: Neutral
+		Location: 164,70
+	Actor567: wa03x
+		Owner: Neutral
+		Location: 102,-64
+	Actor568: wa03x
+		Owner: Neutral
+		Location: 165,70
+	Actor574: wa04x
+		Owner: Neutral
+		Location: 104,-64
 
 Rules:
 	World:

--- a/mods/ts/maps/karasjok/map.yaml
+++ b/mods/ts/maps/karasjok/map.yaml
@@ -1553,6 +1553,12 @@ Actors:
 	Actor472: srock03
 		Location: 134,73
 		Owner: Neutral
+	Actor473: wa03x
+		Owner: Neutral
+		Location: 68,22
+	Actor474: wa03x
+		Owner: Neutral
+		Location: 139,-88
 
 Rules:
 	World:

--- a/mods/ts/maps/sunstroke/map.yaml
+++ b/mods/ts/maps/sunstroke/map.yaml
@@ -2573,6 +2573,18 @@ Actors:
 	Actor743: lobrdg_b_d
 		Owner: Neutral
 		Location: 170,-17
+	Actor744: wa01x
+		Owner: Neutral
+		Location: 109,-95
+	Actor745: wa01x
+		Owner: Neutral
+		Location: 159,-25
+	Actor746: wa04x
+		Owner: Neutral
+		Location: 161,-25
+	Actor747: wa04x
+		Owner: Neutral
+		Location: 111,-95
 
 Rules: rules.yaml
 

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -1098,10 +1098,10 @@
 		UseClassicPerspectiveFudge: False
 		QuantizedFacings: 1
 	Building:
-		Dimensions: 1, 1
-		Footprint: _
+		Dimensions: 1, 3
+		Footprint: x x x
 	AutoSelectionSize:
-	AlwaysVisible:
+	HiddenUnderFog:
 	EditorTilesetFilter:
 		Categories: Waterfall
 

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -1088,6 +1088,23 @@
 	EditorTilesetFilter:
 		Categories: Tunnel
 
+^Waterfall:
+	EditorOnlyTooltip:
+		Name: Waterfall Animation
+	RenderSprites:
+		Palette: terrain
+	WithSpriteBody:
+	BodyOrientation:
+		UseClassicPerspectiveFudge: False
+		QuantizedFacings: 1
+	Building:
+		Dimensions: 1, 1
+		Footprint: _
+	AutoSelectionSize:
+	AlwaysVisible:
+	EditorTilesetFilter:
+		Categories: Waterfall
+
 ^Gate:
 	Inherits: ^Building
 	Huntable:

--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -252,6 +252,9 @@ WA02X:
 
 WA03X:
 	Inherits: ^Waterfall
+	Building:
+		Dimensions: 2, 3
+		Footprint: xx xx xx
 
 WA04X:
 	Inherits: ^Waterfall

--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -243,3 +243,15 @@ TUNTOP04:
 	TunnelEntrance:
 		RallyPoint: 1, 3
 		Sensor: 1, 0
+
+WA01X:
+	Inherits: ^Waterfall
+
+WA02X:
+	Inherits: ^Waterfall
+
+WA03X:
+	Inherits: ^Waterfall
+
+WA04X:
+	Inherits: ^Waterfall

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -644,7 +644,7 @@ wa01x:
 		Length: 7
 		Start: 1
 		Tick: 200
-		Offset: -9, 30
+		Offset: 15, 18
 
 wa02x:
 	idle:
@@ -653,7 +653,7 @@ wa02x:
 		Length: 7
 		Start: 1
 		Tick: 200
-		Offset: -39, 15
+		Offset: -15, 3
 
 wa03x:
 	idle:
@@ -662,7 +662,7 @@ wa03x:
 		Length: 7
 		Start: 1
 		Tick: 200
-		Offset: -26, 23
+		Offset: -13, 5
 
 wa04x:
 	idle:
@@ -671,7 +671,7 @@ wa04x:
 		Length: 7
 		Start: 1
 		Tick: 200
-		Offset: -38, 13
+		Offset: -14, 1
 
 dig:
 	idle:

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -637,6 +637,42 @@ tuntop04:
 	idle:
 		Offset: -24, -49, 24
 
+wa01x:
+	idle:
+		ZRamp: 1
+		UseTilesetExtension: true
+		Length: 7
+		Start: 1
+		Tick: 200
+		Offset: -9, 30
+
+wa02x:
+	idle:
+		ZRamp: 1
+		UseTilesetExtension: true
+		Length: 7
+		Start: 1
+		Tick: 200
+		Offset: -39, 15
+
+wa03x:
+	idle:
+		ZRamp: 1
+		UseTilesetExtension: true
+		Length: 7
+		Start: 1
+		Tick: 200
+		Offset: -26, 23
+
+wa04x:
+	idle:
+		ZRamp: 1
+		UseTilesetExtension: true
+		Length: 7
+		Start: 1
+		Tick: 200
+		Offset: -38, 13
+
 dig:
 	idle:
 		Length: *

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -637,40 +637,32 @@ tuntop04:
 	idle:
 		Offset: -24, -49, 24
 
-wa01x:
+^waterfall:
 	idle:
 		ZRamp: 1
 		UseTilesetExtension: true
 		Length: 7
 		Start: 1
 		Tick: 200
+
+wa01x:
+	Inherits: ^waterfall
+	idle:
 		Offset: 15, 18
 
 wa02x:
+	Inherits: ^waterfall
 	idle:
-		ZRamp: 1
-		UseTilesetExtension: true
-		Length: 7
-		Start: 1
-		Tick: 200
 		Offset: -15, 3
 
 wa03x:
+	Inherits: ^waterfall
 	idle:
-		ZRamp: 1
-		UseTilesetExtension: true
-		Length: 7
-		Start: 1
-		Tick: 200
 		Offset: -13, 5
 
 wa04x:
+	Inherits: ^waterfall
 	idle:
-		ZRamp: 1
-		UseTilesetExtension: true
-		Length: 7
-		Start: 1
-		Tick: 200
 		Offset: -14, 1
 
 dig:


### PR DESCRIPTION
Like tunnel tops it works best if terrain overlays https://github.com/OpenRA/OpenRA/issues/13929 are added as actors. The downside is that they have to get placed manually. However map editor/import tooling can probably automatize this in the future.

The tricky part was to get the offset right. Luckily the first frame includes a reference piece from terrain artwork. I took a screenshot, moved it and counted the pixels. It then turned out that the OpenRA `sequence.yaml` offset currently matches `art.ini` in that
* `TileXOffset=` is the same as our `X`
* `TileYOffset=` minus 24 is our `Y`

I don't know if that applies generally.

I added them to maps where I could spot waterfalls with both snow and temperate test cases included. Waterfalls-B, -C and -D are still missing.