### PR TITLE
Added Visceroid fusing

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -502,6 +502,7 @@
     <Compile Include="Traits\ThrowsParticle.cs" />
     <Compile Include="Traits\Tooltip.cs" />
     <Compile Include="Traits\TransformOnCapture.cs" />
+    <Compile Include="Traits\TransformCrusherOnCrush.cs" />
     <Compile Include="Traits\Transforms.cs" />
     <Compile Include="Traits\Turreted.cs" />
     <Compile Include="Traits\ProducibleWithLevel.cs" />

--- a/OpenRA.Mods.Common/Traits/TransformCrusherOnCrush.cs
+++ b/OpenRA.Mods.Common/Traits/TransformCrusherOnCrush.cs
@@ -1,0 +1,58 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Put this on the actor that gets crushed to replace the crusher with a new actor.")]
+	public class TransformCrusherOnCrushInfo : ITraitInfo
+	{
+		[ActorReference, FieldLoader.Require] public readonly string IntoActor = null;
+
+		public readonly bool SkipMakeAnims = true;
+
+		public readonly HashSet<string> CrushClasses = new HashSet<string>();
+
+		public virtual object Create(ActorInitializer init) { return new TransformCrusherOnCrush(init, this); }
+	}
+
+	public class TransformCrusherOnCrush : INotifyCrushed
+	{
+		readonly TransformCrusherOnCrushInfo info;
+		readonly string faction;
+
+		public TransformCrusherOnCrush(ActorInitializer init, TransformCrusherOnCrushInfo info)
+		{
+			this.info = info;
+			faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
+		}
+
+		void INotifyCrushed.WarnCrush(Actor self, Actor crusher, HashSet<string> crushClasses) { }
+
+		void INotifyCrushed.OnCrush(Actor self, Actor crusher, HashSet<string> crushClasses)
+		{
+			if (!info.CrushClasses.Overlaps(crushClasses))
+				return;
+
+			var facing = crusher.TraitOrDefault<IFacing>();
+			var transform = new Transform(crusher, info.IntoActor) { Faction = faction };
+			if (facing != null)
+				transform.Facing = facing.Facing;
+
+			transform.SkipMakeAnims = info.SkipMakeAnims;
+			if (crusher.CancelActivity())
+				crusher.QueueActivity(transform);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/TransformOnCapture.cs
+++ b/OpenRA.Mods.Common/Traits/TransformOnCapture.cs
@@ -16,9 +16,10 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[Desc("Replaces the captured actor with a new one.")]
 	public class TransformOnCaptureInfo : ITraitInfo
 	{
-		[ActorReference] public readonly string IntoActor = null;
+		[ActorReference, FieldLoader.Require] public readonly string IntoActor = null;
 		public readonly int ForceHealthPercentage = 0;
 		public readonly bool SkipMakeAnims = true;
 

--- a/mods/ra/maps/monster-tank-madness/rules.yaml
+++ b/mods/ra/maps/monster-tank-madness/rules.yaml
@@ -184,6 +184,8 @@ PBOX:
 		HP: 200000
 	RenderSprites:
 		Image: 4TNK
+	-Capturable:
+	-TransformOnCapture:
 
 DOME.NoInfiltrate:
 	Inherits: DOME

--- a/mods/ra/rules/husks.yaml
+++ b/mods/ra/rules/husks.yaml
@@ -110,6 +110,8 @@ TRAN.Husk1:
 		Name: Husk (Chinook)
 	RenderSprites:
 		Image: tran1husk
+	-Capturable:
+	-TransformOnCapture:
 
 TRAN.Husk2:
 	Inherits: ^Husk
@@ -117,6 +119,8 @@ TRAN.Husk2:
 		Name: Husk (Chinook)
 	RenderSprites:
 		Image: tran2husk
+	-Capturable:
+	-TransformOnCapture:
 
 BADR.Husk:
 	Inherits: ^PlaneHusk

--- a/mods/ts/rules/critters.yaml
+++ b/mods/ts/rules/critters.yaml
@@ -50,6 +50,15 @@ VISC_SML:
 		MaxMoveDelay: 60
 	RenderSprites:
 		Image: vissml
+	Mobile:
+		Crushes: visceroid-fusing
+	Crushable:
+		CrushClasses: visceroid-fusing
+		WarnProbability: 0
+		CrushedByFriendlies: True
+	TransformCrusherOnCrush:
+		IntoActor: visc_lrg
+		CrushClasses: visceroid-fusing
 
 VISC_LRG:
 	Inherits: ^Visceroid


### PR DESCRIPTION
Closes https://github.com/OpenRA/OpenRA/issues/10791.

For generating a lot of small test visceroids I suggest the following change to defaults.yaml:
```diff
@@ -584,7 +584,7 @@
 		CrushSound: squish6.aud
 	SpawnActorOnDeath:
 		Actor: visc_sml
-		Probability: 10
+		Probability: 100
 		OwnerType: InternalName
 		InternalOwner: Creeps
 		DeathType: TriggerVisceroid
```