### PR TITLE
Avoid modData.MapCache during lint checks

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -77,10 +77,29 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						}
 					}
 
-					modData.MapCache.LoadMaps();
-					maps.AddRange(modData.MapCache
-						.Where(m => m.Status == MapStatus.Available)
-						.Select(m => new Map(modData, m.Package)));
+					foreach (var kv in modData.Manifest.MapFolders)
+					{
+						var name = kv.Key;
+						var classification = string.IsNullOrEmpty(kv.Value)
+							? MapClassification.Unknown : Enum<MapClassification>.Parse(kv.Value);
+
+						if (classification == MapClassification.Unknown)
+							continue;
+
+						var optional = name.StartsWith("~", StringComparison.Ordinal);
+						if (optional)
+							name = name.Substring(1);
+
+						using (var package = (IReadWritePackage)modData.ModFiles.OpenPackage(name))
+						{
+							foreach (var map in package.Contents)
+							{
+								var mapPackage = package.OpenPackage(map, modData.ModFiles);
+								if (mapPackage != null)
+									maps.Add(new Map(modData, mapPackage));
+							}
+						}
+					}
 				}
 				else
 					maps.Add(new Map(modData, new Folder(".").OpenPackage(args[1], modData.ModFiles)));


### PR DESCRIPTION
The `MapCache` requires `SheetBuilder` to set the minimap preview. This isn't necessary nor wanted.