### PR TITLE
Fix WithShadow and enable it on airborne TS JumpJet

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithShadow.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithShadow.cs
@@ -43,10 +43,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public IEnumerable<IRenderable> ModifyRender(Actor self, WorldRenderer wr, IEnumerable<IRenderable> r)
 		{
 			if (IsTraitDisabled)
-				return Enumerable.Empty<IRenderable>();
-
-			if (self.IsDead || !self.IsInWorld)
-				return Enumerable.Empty<IRenderable>();
+				return r;
 
 			// Contrails shouldn't cast shadows
 			var height = self.World.Map.DistanceAboveTerrain(self.CenterPosition).Length;

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -149,6 +149,8 @@ JUMPJET:
 		RequiresCondition: !airborne
 	SpawnActorOnDeath@FLAMEGUY:
 		RequiresCondition: !airborne
+	WithShadow@airborne:
+		RequiresCondition: airborne
 
 JUMPJET.Husk:
 	RenderSprites:


### PR DESCRIPTION
`WithShadow`'s behaviour when disabled was bogus, making the whole actor invisible.

Fixed that and enabled it on TS JumpJet infantry when airborne.