### PR TITLE
Polish RA Jeep and APC muzzle offsets

### DIFF
--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -367,10 +367,11 @@ JEEP:
 		Range: 4c0
 	Turreted:
 		TurnSpeed: 10
-		Offset: 0,0,85
+		Offset: 0,0,128
 	Armament:
 		Weapon: M60mg
 		MuzzleSequence: muzzle
+		LocalOffset: 128,0,43
 	AttackTurreted:
 	WithMuzzleOverlay:
 	WithSpriteTurret:
@@ -409,7 +410,7 @@ APC:
 		Range: 4c0
 	Armament:
 		Weapon: M60mg
-		LocalOffset: 0,0,171
+		LocalOffset: 85,0,171
 		MuzzleSequence: muzzle
 	AttackFrontal:
 	WithMuzzleOverlay:


### PR DESCRIPTION
And Jeep turret offset.

The muzzle offsets had zero forward offset, which made the muzzle draw over - instead of in front of - the MG barrel.

Not a blocker for the playtest, but should go into release if possible, since this can't regress anything and adds some polish.