### PR TITLE
Fixed no explosions showing on some RA civ structures

### DIFF
--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -290,6 +290,9 @@ V19.Husk:
 		RenderSelectionBars: False
 	-Targetable:
 	-Demolishable:
+	-HitShape:
+	-Health:
+	-Explodes:
 
 BARL:
 	Inherits: ^TechBuilding

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -787,6 +787,9 @@
 
 ^CivField:
 	Inherits: ^CivBuilding
+	-HitShape:
+	-Health:
+	-Explodes:
 	-Selectable:
 	-SelectionDecorations:
 	Tooltip:

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -389,8 +389,9 @@ CTFLAG:
 		Name: Flag
 	WithBuildingBib:
 		HasMinibib: Yes
-	DamageMultiplier@INVULNERABLE:
-		Modifier: 0
+	-HitShape:
+	-Health:
+	-Explodes:
 	-Selectable:
 	-SelectionDecorations:
 	-Targetable:


### PR DESCRIPTION
The combination of HitShape, but not Targetable makes the actors be considered invalid for effect warheads.
Lack of Targetable makes them invulnerable anyway, so removing HitShape and Health (and Explodes) is the most logical fix.

Fixes #13960.