### PR TITLE
Remove hardcoded hotkey references from production, support powers, and viewport.

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -297,15 +297,6 @@ namespace OpenRA
 		public Hotkey PrevMusicKey = new Hotkey(Keycode.AUDIOPREV, Modifiers.None);
 		public Hotkey NextMusicKey = new Hotkey(Keycode.AUDIONEXT, Modifiers.None);
 
-		static readonly Func<KeySettings, Hotkey>[] SupportPowerKeys = GetKeys(6, "SupportPower");
-
-		static Func<KeySettings, Hotkey>[] GetKeys(int count, string prefix)
-		{
-			var keySettings = Expression.Parameter(typeof(KeySettings), "keySettings");
-			return Exts.MakeArray(count, i => Expression.Lambda<Func<KeySettings, Hotkey>>(
-				Expression.Field(keySettings, "{0}{1:D2}Key".F(prefix, i + 1)), keySettings).Compile());
-		}
-
 		internal Func<Hotkey> GetHotkeyReference(string name)
 		{
 			var field = typeof(KeySettings).GetField(name + "Key");
@@ -313,19 +304,6 @@ namespace OpenRA
 				return null;
 
 			return () => (Hotkey)field.GetValue(this);
-		}
-
-		public Hotkey GetSupportPowerHotkey(int index)
-		{
-			return GetKey(SupportPowerKeys, index);
-		}
-
-		Hotkey GetKey(Func<KeySettings, Hotkey>[] keys, int index)
-		{
-			if (index < 0 || index >= keys.Length)
-				return Hotkey.Invalid;
-
-			return keys[index](this);
 		}
 	}
 

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -297,7 +297,6 @@ namespace OpenRA
 		public Hotkey PrevMusicKey = new Hotkey(Keycode.AUDIOPREV, Modifiers.None);
 		public Hotkey NextMusicKey = new Hotkey(Keycode.AUDIONEXT, Modifiers.None);
 
-		static readonly Func<KeySettings, Hotkey>[] ProductionKeys = GetKeys(24, "Production");
 		static readonly Func<KeySettings, Hotkey>[] SupportPowerKeys = GetKeys(6, "SupportPower");
 
 		static Func<KeySettings, Hotkey>[] GetKeys(int count, string prefix)
@@ -314,11 +313,6 @@ namespace OpenRA
 				return null;
 
 			return () => (Hotkey)field.GetValue(this);
-		}
-
-		public Hotkey GetProductionHotkey(int index)
-		{
-			return GetKey(ProductionKeys, index);
 		}
 
 		public Hotkey GetSupportPowerHotkey(int index)

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -192,25 +192,25 @@ namespace OpenRA
 		public Hotkey SelectAllUnitsKey = new Hotkey(Keycode.Q, Modifiers.None);
 		public Hotkey SelectUnitsByTypeKey = new Hotkey(Keycode.W, Modifiers.None);
 
-		public Hotkey MapScrollUp = new Hotkey(Keycode.UP, Modifiers.None);
-		public Hotkey MapScrollDown = new Hotkey(Keycode.DOWN, Modifiers.None);
-		public Hotkey MapScrollLeft = new Hotkey(Keycode.LEFT, Modifiers.None);
-		public Hotkey MapScrollRight = new Hotkey(Keycode.RIGHT, Modifiers.None);
+		public Hotkey MapScrollUpKey = new Hotkey(Keycode.UP, Modifiers.None);
+		public Hotkey MapScrollDownKey = new Hotkey(Keycode.DOWN, Modifiers.None);
+		public Hotkey MapScrollLeftKey = new Hotkey(Keycode.LEFT, Modifiers.None);
+		public Hotkey MapScrollRightKey = new Hotkey(Keycode.RIGHT, Modifiers.None);
 
-		public Hotkey MapPushTop = new Hotkey(Keycode.UP, Modifiers.Alt);
-		public Hotkey MapPushBottom = new Hotkey(Keycode.DOWN, Modifiers.Alt);
-		public Hotkey MapPushLeftEdge = new Hotkey(Keycode.LEFT, Modifiers.Alt);
-		public Hotkey MapPushRightEdge = new Hotkey(Keycode.RIGHT, Modifiers.Alt);
+		public Hotkey MapJumpToTopEdgeKey = new Hotkey(Keycode.UP, Modifiers.Alt);
+		public Hotkey MapJumpToBottomEdgeKey = new Hotkey(Keycode.DOWN, Modifiers.Alt);
+		public Hotkey MapJumpToLeftEdgeKey = new Hotkey(Keycode.LEFT, Modifiers.Alt);
+		public Hotkey MapJumpToRightEdgeKey = new Hotkey(Keycode.RIGHT, Modifiers.Alt);
 
-		public Hotkey ViewPortBookmarkSaveSlot1 = new Hotkey(Keycode.Q, Modifiers.Ctrl);
-		public Hotkey ViewPortBookmarkSaveSlot2 = new Hotkey(Keycode.W, Modifiers.Ctrl);
-		public Hotkey ViewPortBookmarkSaveSlot3 = new Hotkey(Keycode.E, Modifiers.Ctrl);
-		public Hotkey ViewPortBookmarkSaveSlot4 = new Hotkey(Keycode.R, Modifiers.Ctrl);
+		public Hotkey MapBookmarkSave01Key = new Hotkey(Keycode.Q, Modifiers.Ctrl);
+		public Hotkey MapBookmarkSave02Key = new Hotkey(Keycode.W, Modifiers.Ctrl);
+		public Hotkey MapBookmarkSave03Key = new Hotkey(Keycode.E, Modifiers.Ctrl);
+		public Hotkey MapBookmarkSave04Key = new Hotkey(Keycode.R, Modifiers.Ctrl);
 
-		public Hotkey ViewPortBookmarkUseSlot1 = new Hotkey(Keycode.Q, Modifiers.Alt);
-		public Hotkey ViewPortBookmarkUseSlot2 = new Hotkey(Keycode.W, Modifiers.Alt);
-		public Hotkey ViewPortBookmarkUseSlot3 = new Hotkey(Keycode.E, Modifiers.Alt);
-		public Hotkey ViewPortBookmarkUseSlot4 = new Hotkey(Keycode.R, Modifiers.Alt);
+		public Hotkey MapBookmarkRestore01Key = new Hotkey(Keycode.Q, Modifiers.Alt);
+		public Hotkey MapBookmarkRestore02Key = new Hotkey(Keycode.W, Modifiers.Alt);
+		public Hotkey MapBookmarkRestore03Key = new Hotkey(Keycode.E, Modifiers.Alt);
+		public Hotkey MapBookmarkRestore04Key = new Hotkey(Keycode.R, Modifiers.Alt);
 
 		public Hotkey PauseKey = new Hotkey(Keycode.PAUSE, Modifiers.None);
 		public Hotkey PlaceBeaconKey = new Hotkey(Keycode.B, Modifiers.None);

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -47,6 +47,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var descFont = Game.Renderer.Fonts[descLabel.Font];
 			var requiresFont = Game.Renderer.Fonts[requiresLabel.Font];
 			ActorInfo lastActor = null;
+			Hotkey lastHotkey = Hotkey.Invalid;
 
 			tooltipContainer.BeforeRender = () =>
 			{
@@ -55,7 +56,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return;
 
 				var actor = tooltipIcon.Actor;
-				if (actor == null || actor == lastActor)
+				if (actor == null)
+					return;
+
+				var hotkey = tooltipIcon.Hotkey != null ? tooltipIcon.Hotkey.GetValue() : Hotkey.Invalid;
+				if (actor == lastActor && hotkey == lastHotkey)
 					return;
 
 				var tooltip = actor.TraitInfos<TooltipInfo>().FirstOrDefault(Exts.IsTraitEnabled);
@@ -65,13 +70,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				nameLabel.GetText = () => name;
 
-				var hotkey = tooltipIcon.Hotkey;
 				var nameWidth = font.Measure(name).X;
-				var hotkeyText = "({0})".F(hotkey.DisplayString());
-				var hotkeyWidth = hotkey.IsValid() ? font.Measure(hotkeyText).X + 2 * nameLabel.Bounds.X : 0;
-				hotkeyLabel.GetText = () => hotkeyText;
-				hotkeyLabel.Bounds.X = nameWidth + 2 * nameLabel.Bounds.X;
+				var hotkeyWidth = 0;
 				hotkeyLabel.Visible = hotkey.IsValid();
+
+				if (hotkeyLabel.Visible)
+				{
+					var hotkeyText = "({0})".F(hotkey.DisplayString());
+
+					hotkeyWidth = font.Measure(hotkeyText).X + 2 * nameLabel.Bounds.X;
+					hotkeyLabel.Text = hotkeyText;
+					hotkeyLabel.Bounds.X = nameWidth + 2 * nameLabel.Bounds.X;
+				}
 
 				var prereqs = buildable.Prerequisites.Select(a => ActorName(mapRules, a)).Where(s => !s.StartsWith("~"));
 				var requiresString = prereqs.Any() ? requiresLabel.Text.F(prereqs.JoinWith(", ")) : "";
@@ -112,6 +122,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				widget.Bounds.Height = Math.Max(leftHeight, rightHeight) * 3 / 2 + 3 * nameLabel.Bounds.Y;
 
 				lastActor = actor;
+				lastHotkey = hotkey;
 			};
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -46,8 +46,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var font = Game.Renderer.Fonts[nameLabel.Font];
 			var descFont = Game.Renderer.Fonts[descLabel.Font];
 			var requiresFont = Game.Renderer.Fonts[requiresLabel.Font];
+			var formatBuildTime = new CachedTransform<int, string>(time => WidgetUtils.FormatTime(time, world.Timestep));
+			var requiresFormat = requiresLabel.Text;
+
 			ActorInfo lastActor = null;
 			Hotkey lastHotkey = Hotkey.Invalid;
+			var lastPowerState = pm.PowerState;
 
 			tooltipContainer.BeforeRender = () =>
 			{
@@ -60,7 +64,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return;
 
 				var hotkey = tooltipIcon.Hotkey != null ? tooltipIcon.Hotkey.GetValue() : Hotkey.Invalid;
-				if (actor == lastActor && hotkey == lastHotkey)
+				if (actor == lastActor && hotkey == lastHotkey && pm.PowerState == lastPowerState)
 					return;
 
 				var tooltip = actor.TraitInfos<TooltipInfo>().FirstOrDefault(Exts.IsTraitEnabled);
@@ -68,9 +72,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var buildable = actor.TraitInfo<BuildableInfo>();
 				var cost = actor.TraitInfo<ValuedInfo>().Cost;
 
-				nameLabel.GetText = () => name;
+				nameLabel.Text = name;
 
-				var nameWidth = font.Measure(name).X;
+				var nameSize = font.Measure(name);
 				var hotkeyWidth = 0;
 				hotkeyLabel.Visible = hotkey.IsValid();
 
@@ -80,49 +84,49 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					hotkeyWidth = font.Measure(hotkeyText).X + 2 * nameLabel.Bounds.X;
 					hotkeyLabel.Text = hotkeyText;
-					hotkeyLabel.Bounds.X = nameWidth + 2 * nameLabel.Bounds.X;
+					hotkeyLabel.Bounds.X = nameSize.X + 2 * nameLabel.Bounds.X;
 				}
 
-				var prereqs = buildable.Prerequisites.Select(a => ActorName(mapRules, a)).Where(s => !s.StartsWith("~"));
-				var requiresString = prereqs.Any() ? requiresLabel.Text.F(prereqs.JoinWith(", ")) : "";
-				requiresLabel.GetText = () => requiresString;
+				var prereqs = buildable.Prerequisites.Select(a => ActorName(mapRules, a)).Where(s => !s.StartsWith("~", StringComparison.Ordinal));
+				requiresLabel.Text = prereqs.Any() ? requiresFormat.F(prereqs.JoinWith(", ")) : "";
+				var requiresSize = requiresFont.Measure(requiresLabel.Text);
 
 				var power = actor.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(i => i.Amount);
-				var powerString = power.ToString();
-				powerLabel.GetText = () => powerString;
+				powerLabel.Text = power.ToString();
 				powerLabel.GetColor = () => ((pm.PowerProvided - pm.PowerDrained) >= -power || power > 0)
 					? Color.White : Color.Red;
-				powerLabel.IsVisible = () => power != 0;
-				powerIcon.IsVisible = () => power != 0;
+				powerLabel.Visible = power != 0;
+				powerIcon.Visible = power != 0;
+				var powerSize = font.Measure(powerLabel.Text);
 
-				var lowpower = pm.PowerState != PowerState.Normal;
-				var time = tooltipIcon.ProductionQueue == null ? 0 : tooltipIcon.ProductionQueue.GetBuildTime(actor, buildable)
-					* (lowpower ? tooltipIcon.ProductionQueue.Info.LowPowerSlowdown : 1);
-				var timeString = WidgetUtils.FormatTime(time, world.Timestep);
-				timeLabel.GetText = () => timeString;
-				timeLabel.GetColor = () => lowpower ? Color.Red : Color.White;
+				var buildTime = tooltipIcon.ProductionQueue == null ? 0 : tooltipIcon.ProductionQueue.GetBuildTime(actor, buildable);
+				var timeMultiplier = pm.PowerState != PowerState.Normal ? tooltipIcon.ProductionQueue.Info.LowPowerSlowdown : 1;
 
-				var costString = cost.ToString();
-				costLabel.GetText = () => costString;
-				costLabel.GetColor = () => pr.Cash + pr.Resources >= cost
-					? Color.White : Color.Red;
+				timeLabel.Text = formatBuildTime.Update(buildTime * timeMultiplier);
+				timeLabel.TextColor = pm.PowerState != PowerState.Normal ? Color.Red : Color.White;
+				var timeSize = font.Measure(timeLabel.Text);
 
-				var descString = buildable.Description.Replace("\\n", "\n");
-				descLabel.GetText = () => descString;
+				costLabel.Text = cost.ToString();
+				costLabel.GetColor = () => pr.Cash + pr.Resources >= cost ? Color.White : Color.Red;
+				var costSize = font.Measure(costLabel.Text);
 
-				var leftWidth = new[] { nameWidth + hotkeyWidth, requiresFont.Measure(requiresString).X, descFont.Measure(descString).X }.Aggregate(Math.Max);
-				var rightWidth = new[] { font.Measure(powerString).X, font.Measure(timeString).X, font.Measure(costString).X }.Aggregate(Math.Max);
+				descLabel.Text = buildable.Description.Replace("\\n", "\n");
+				var descSize = descFont.Measure(descLabel.Text);
+
+				var leftWidth = new[] { nameSize.X + hotkeyWidth, requiresSize.X, descSize.X }.Aggregate(Math.Max);
+				var rightWidth = new[] { powerSize.X, timeSize.X, costSize.X }.Aggregate(Math.Max);
 
 				timeIcon.Bounds.X = powerIcon.Bounds.X = costIcon.Bounds.X = leftWidth + 2 * nameLabel.Bounds.X;
 				timeLabel.Bounds.X = powerLabel.Bounds.X = costLabel.Bounds.X = timeIcon.Bounds.Right + iconMargin;
 				widget.Bounds.Width = leftWidth + rightWidth + 3 * nameLabel.Bounds.X + timeIcon.Bounds.Width + iconMargin;
 
-				var leftHeight = font.Measure(name).Y + requiresFont.Measure(requiresString).Y + descFont.Measure(descString).Y;
-				var rightHeight = font.Measure(powerString).Y + font.Measure(timeString).Y + font.Measure(costString).Y;
+				var leftHeight = nameSize.Y + requiresSize.Y + descSize.Y;
+				var rightHeight = powerSize.Y + timeSize.Y + costSize.Y;
 				widget.Bounds.Height = Math.Max(leftHeight, rightHeight) * 3 / 2 + 3 * nameLabel.Bounds.Y;
 
 				lastActor = actor;
 				lastHotkey = hotkey;
+				lastPowerState = pm.PowerState;
 			};
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
@@ -57,12 +57,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				name = sp.Info.Description;
 				desc = sp.Info.LongDesc.Replace("\\n", "\n");
 
-				var hotkey = icon.Hotkey;
-				var hotkeyText = "({0})".F(hotkey.DisplayString());
-				var hotkeyWidth = hotkey.IsValid() ? nameFont.Measure(hotkeyText).X + 2 * nameLabel.Bounds.X : 0;
-				hotkeyLabel.GetText = () => hotkeyText;
-				hotkeyLabel.Bounds.X = nameFont.Measure(name).X + 2 * nameLabel.Bounds.X;
+				var hotkeyWidth = 0;
+				var hotkey = icon.Hotkey != null ? icon.Hotkey.GetValue() : Hotkey.Invalid;
 				hotkeyLabel.Visible = hotkey.IsValid();
+
+				if (hotkeyLabel.Visible)
+				{
+					var hotkeyText = "({0})".F(hotkey.DisplayString());
+
+					hotkeyWidth = nameFont.Measure(hotkeyText).X + 2 * nameLabel.Bounds.X;
+					hotkeyLabel.Text = hotkeyText;
+					hotkeyLabel.Bounds.X = nameFont.Measure(name).X + 2 * nameLabel.Bounds.X;
+				}
 
 				var timeWidth = timeFont.Measure(time).X;
 				var topWidth = nameFont.Measure(name).X + hotkeyWidth + timeWidth + timeOffset;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Drawing;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Widgets;
 
@@ -18,70 +19,75 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class SupportPowerTooltipLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
-		public SupportPowerTooltipLogic(Widget widget, TooltipContainerWidget tooltipContainer, SupportPowersWidget palette, World world)
+		public SupportPowerTooltipLogic(Widget widget, TooltipContainerWidget tooltipContainer, Player player, SupportPowersWidget palette, World world)
 		{
-			widget.IsVisible = () => palette.TooltipIcon != null;
+			widget.IsVisible = () => palette.TooltipIcon != null && palette.TooltipIcon.Power.Info != null;
 			var nameLabel = widget.Get<LabelWidget>("NAME");
 			var hotkeyLabel = widget.Get<LabelWidget>("HOTKEY");
 			var timeLabel = widget.Get<LabelWidget>("TIME");
 			var descLabel = widget.Get<LabelWidget>("DESC");
 			var nameFont = Game.Renderer.Fonts[nameLabel.Font];
+			var hotkeyFont = Game.Renderer.Fonts[hotkeyLabel.Font];
 			var timeFont = Game.Renderer.Fonts[timeLabel.Font];
 			var descFont = Game.Renderer.Fonts[descLabel.Font];
-			var name = "";
-			var time = "";
-			var desc = "";
 			var baseHeight = widget.Bounds.Height;
 			var timeOffset = timeLabel.Bounds.X;
+			var pm = player.PlayerActor.Trait<PowerManager>();
 
 			SupportPowerInstance lastPower = null;
+			Hotkey lastHotkey = Hotkey.Invalid;
+			var lastRemainingSeconds = 0;
+
 			tooltipContainer.BeforeRender = () =>
 			{
 				var icon = palette.TooltipIcon;
-
 				if (icon == null)
 					return;
 
 				var sp = icon.Power;
 
-				if (sp.Info == null)
-					return;		// no instances actually exist (race with destroy)
+				// HACK: This abuses knowledge of the internals of WidgetUtils.FormatTime
+				// to efficiently work when the label is going to change, requiring a panel relayout
+				var remainingSeconds = (int)Math.Ceiling(sp.RemainingTime * world.Timestep / 1000f);
+
+				var hotkey = icon.Hotkey != null ? icon.Hotkey.GetValue() : Hotkey.Invalid;
+				if (sp == lastPower && hotkey == lastHotkey && lastRemainingSeconds == remainingSeconds)
+					return;
+
+				nameLabel.Text = sp.Info.Description;
+				var nameSize = nameFont.Measure(nameLabel.Text);
+
+				descLabel.Text = sp.Info.LongDesc.Replace("\\n", "\n");
+				var descSize = descFont.Measure(descLabel.Text);
 
 				var remaining = WidgetUtils.FormatTime(sp.RemainingTime, world.Timestep);
 				var total = WidgetUtils.FormatTime(sp.Info.ChargeTime * 25, world.Timestep);
-				time = "{0} / {1}".F(remaining, total);
-
-				if (sp == lastPower)
-					return;
-
-				name = sp.Info.Description;
-				desc = sp.Info.LongDesc.Replace("\\n", "\n");
+				timeLabel.Text = "{0} / {1}".F(remaining, total);
+				var timeSize = timeFont.Measure(timeLabel.Text);
 
 				var hotkeyWidth = 0;
-				var hotkey = icon.Hotkey != null ? icon.Hotkey.GetValue() : Hotkey.Invalid;
 				hotkeyLabel.Visible = hotkey.IsValid();
-
 				if (hotkeyLabel.Visible)
 				{
 					var hotkeyText = "({0})".F(hotkey.DisplayString());
 
-					hotkeyWidth = nameFont.Measure(hotkeyText).X + 2 * nameLabel.Bounds.X;
+					hotkeyWidth = hotkeyFont.Measure(hotkeyText).X + 2 * nameLabel.Bounds.X;
 					hotkeyLabel.Text = hotkeyText;
-					hotkeyLabel.Bounds.X = nameFont.Measure(name).X + 2 * nameLabel.Bounds.X;
+					hotkeyLabel.Bounds.X = nameSize.X + 2 * nameLabel.Bounds.X;
 				}
 
-				var timeWidth = timeFont.Measure(time).X;
-				var topWidth = nameFont.Measure(name).X + hotkeyWidth + timeWidth + timeOffset;
-				var descSize = descFont.Measure(desc);
+				var timeWidth = timeSize.X;
+				var topWidth = nameSize.X + hotkeyWidth + timeWidth + timeOffset;
 				widget.Bounds.Width = 2 * nameLabel.Bounds.X + Math.Max(topWidth, descSize.X);
 				widget.Bounds.Height = baseHeight + descSize.Y;
 				timeLabel.Bounds.X = widget.Bounds.Width - nameLabel.Bounds.X - timeWidth;
+
 				lastPower = sp;
+				lastHotkey = hotkey;
+				lastRemainingSeconds = remainingSeconds;
 			};
 
-			nameLabel.GetText = () => name;
-			timeLabel.GetText = () => time;
-			descLabel.GetText = () => desc;
+			timeLabel.GetColor = () => pm.PowerState != PowerState.Normal ? Color.Red : Color.White;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -463,24 +463,24 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				var hotkeys = new Dictionary<string, string>()
 				{
-					{ "MapScrollUp", "Scroll up" },
-					{ "MapScrollDown", "Scroll down" },
-					{ "MapScrollLeft", "Scroll left" },
-					{ "MapScrollRight", "Scroll right" },
+					{ "MapScrollUpKey", "Scroll up" },
+					{ "MapScrollDownKey", "Scroll down" },
+					{ "MapScrollLeftKey", "Scroll left" },
+					{ "MapScrollRightKey", "Scroll right" },
 
-					{ "MapPushTop", "Jump to top edge" },
-					{ "MapPushBottom", "Jump to bottom edge" },
-					{ "MapPushLeftEdge", "Jump to left edge" },
-					{ "MapPushRightEdge", "Jump to right edge" },
+					{ "MapJumpToTopEdgeKey", "Jump to top edge" },
+					{ "MapJumpToBottomEdgeKey", "Jump to bottom edge" },
+					{ "MapJumpToLeftEdgeKey", "Jump to left edge" },
+					{ "MapJumpToRightEdgeKey", "Jump to right edge" },
 
-					{ "ViewPortBookmarkSaveSlot1", "Record bookmark #1" },
-					{ "ViewPortBookmarkUseSlot1", "Jump to bookmark #1" },
-					{ "ViewPortBookmarkSaveSlot2", "Record bookmark #2" },
-					{ "ViewPortBookmarkUseSlot2", "Jump to bookmark #2" },
-					{ "ViewPortBookmarkSaveSlot3", "Record bookmark #3" },
-					{ "ViewPortBookmarkUseSlot3", "Jump to bookmark #3" },
-					{ "ViewPortBookmarkSaveSlot4", "Record bookmark #4" },
-					{ "ViewPortBookmarkUseSlot4", "Jump to bookmark #4" }
+					{ "MapBookmarkSave01Key", "Record bookmark #1" },
+					{ "MapBookmarkRestore01Key", "Jump to bookmark #1" },
+					{ "MapBookmarkSave02Key", "Record bookmark #2" },
+					{ "MapBookmarkRestore02Key", "Jump to bookmark #2" },
+					{ "MapBookmarkSave03Key", "Record bookmark #3" },
+					{ "MapBookmarkRestore03Key", "Jump to bookmark #3" },
+					{ "MapBookmarkSave04Key", "Record bookmark #4" },
+					{ "MapBookmarkRestore04Key", "Jump to bookmark #4" }
 				};
 
 				var header = ScrollItemWidget.Setup(hotkeyHeader, returnTrue, doNothing);

--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -68,7 +68,11 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public readonly int TabWidth = 30;
 		public readonly int ArrowWidth = 20;
-		public Dictionary<string, ProductionTabGroup> Groups;
+
+		public readonly NamedHotkey PreviousProductionTabKey = new NamedHotkey();
+		public readonly NamedHotkey NextProductionTabKey = new NamedHotkey();
+
+		public readonly Dictionary<string, ProductionTabGroup> Groups;
 
 		int contentWidth = 0;
 		float listOffset = 0;
@@ -284,16 +288,16 @@ namespace OpenRA.Mods.Common.Widgets
 				return false;
 
 			var hotkey = Hotkey.FromKeyInput(e);
-
-			if (hotkey == Game.Settings.Keys.NextProductionTabKey)
-			{
-				Game.Sound.PlayNotification(world.Map.Rules, null, "Sounds", "ClickSound", null);
-				return SelectNextTab(false);
-			}
-			else if (hotkey == Game.Settings.Keys.PreviousProductionTabKey)
+			if (hotkey == PreviousProductionTabKey.GetValue())
 			{
 				Game.Sound.PlayNotification(world.Map.Rules, null, "Sounds", "ClickSound", null);
 				return SelectNextTab(true);
+			}
+
+			if (hotkey == NextProductionTabKey.GetValue())
+			{
+				Game.Sound.PlayNotification(world.Map.Rules, null, "Sounds", "ClickSound", null);
+				return SelectNextTab(false);
 			}
 
 			return false;

--- a/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
@@ -228,7 +228,7 @@ namespace OpenRA.Mods.Common.Widgets
 				return;
 
 			tooltipContainer.Value.SetTooltip(TooltipTemplate,
-				new WidgetArgs() { { "world", worldRenderer.World }, { "palette", this } });
+				new WidgetArgs() { { "world", worldRenderer.World }, { "player", spm.Self.Owner }, { "palette", this } });
 		}
 
 		public override void MouseExited()

--- a/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Lint;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Widgets;
 
@@ -31,6 +32,10 @@ namespace OpenRA.Mods.Common.Widgets
 		public readonly string TooltipContainer;
 		public readonly string TooltipTemplate = "SUPPORT_POWER_TOOLTIP";
 
+		// Note: LinterHotkeyNames assumes that these are disabled by default
+		public readonly string HotkeyPrefix = null;
+		public readonly int HotkeyCount = 0;
+
 		public readonly string ClockAnimation = "clock";
 		public readonly string ClockSequence = "idle";
 		public readonly string ClockPalette = "chrome";
@@ -47,11 +52,34 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public SupportPowerIcon TooltipIcon { get; private set; }
 		Lazy<TooltipContainerWidget> tooltipContainer;
+		NamedHotkey[] hotkeys;
 
 		Rectangle eventBounds;
 		public override Rectangle EventBounds { get { return eventBounds; } }
 		SpriteFont overlayFont;
 		float2 holdOffset, readyOffset, timeOffset;
+
+		[CustomLintableHotkeyNames]
+		public static IEnumerable<string> LinterHotkeyNames(MiniYamlNode widgetNode, Action<string> emitError, Action<string> emitWarning)
+		{
+			var prefix = "";
+			var prefixNode = widgetNode.Value.Nodes.FirstOrDefault(n => n.Key == "HotkeyPrefix");
+			if (prefixNode != null)
+				prefix = prefixNode.Value.Value;
+
+			var count = 0;
+			var countNode = widgetNode.Value.Nodes.FirstOrDefault(n => n.Key == "HotkeyCount");
+			if (countNode != null)
+				count = FieldLoader.GetValue<int>("HotkeyCount", countNode.Value.Value);
+
+			if (count == 0)
+				return new string[0];
+
+			if (string.IsNullOrEmpty(prefix))
+				emitError("{0} must define HotkeyPrefix if HotkeyCount > 0.".F(widgetNode.Location));
+
+			return Exts.MakeArray(count, i => prefix + (i + 1).ToString("D2"));
+		}
 
 		[ObjectCreator.UseCtor]
 		public SupportPowersWidget(World world, WorldRenderer worldRenderer)
@@ -65,6 +93,14 @@ namespace OpenRA.Mods.Common.Widgets
 			clock = new Animation(world, ClockAnimation);
 		}
 
+		public override void Initialize(WidgetArgs args)
+		{
+			base.Initialize(args);
+
+			hotkeys = Exts.MakeArray(HotkeyCount,
+				i => new NamedHotkey(HotkeyPrefix + (i + 1).ToString("D2"), Game.Settings.Keys));
+		}
+
 		public class SupportPowerIcon
 		{
 			public SupportPowerInstance Power;
@@ -72,7 +108,7 @@ namespace OpenRA.Mods.Common.Widgets
 			public Sprite Sprite;
 			public PaletteReference Palette;
 			public PaletteReference IconClockPalette;
-			public Hotkey Hotkey;
+			public NamedHotkey Hotkey;
 		}
 
 		public void RefreshIcons()
@@ -84,8 +120,6 @@ namespace OpenRA.Mods.Common.Widgets
 			IconCount = 0;
 
 			var rb = RenderBounds;
-			var ks = Game.Settings.Keys;
-
 			foreach (var p in powers)
 			{
 				var rect = new Rectangle(rb.X, rb.Y + IconCount * (IconSize.Y + IconMargin), IconSize.X, IconSize.Y);
@@ -98,7 +132,7 @@ namespace OpenRA.Mods.Common.Widgets
 					Sprite = icon.Image,
 					Palette = worldRenderer.Palette(p.Info.IconPalette),
 					IconClockPalette = worldRenderer.Palette(ClockPalette),
-					Hotkey = ks.GetSupportPowerHotkey(IconCount)
+					Hotkey = IconCount < HotkeyCount ? hotkeys[IconCount] : null,
 				};
 
 				icons.Add(rect, power);
@@ -128,7 +162,7 @@ namespace OpenRA.Mods.Common.Widgets
 			if (e.Event == KeyInputEvent.Down)
 			{
 				var hotkey = Hotkey.FromKeyInput(e);
-				var a = icons.Values.FirstOrDefault(i => i.Hotkey == hotkey);
+				var a = icons.Values.FirstOrDefault(i => i.Hotkey != null && i.Hotkey.GetValue() == hotkey);
 
 				if (a != null)
 				{

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -224,6 +224,17 @@ Container@EDITOR_WORLD_ROOT:
 			Width: WINDOW_RIGHT
 			Height: WINDOW_BOTTOM
 			IgnoreMouseOver: True
+			ScrollUpKey: MapScrollUp
+			ScrollDownKey: MapScrollDown
+			ScrollLeftKey: MapScrollLeft
+			ScrollRightKey: MapScrollRight
+			JumpToTopEdgeKey: MapJumpToTopEdge
+			JumpToBottomEdgeKey: MapJumpToBottomEdge
+			JumpToLeftEdgeKey: MapJumpToLeftEdge
+			JumpToRightEdgeKey: MapJumpToRightEdge
+			BookmarkSaveKeyPrefix: MapBookmarkSave
+			BookmarkRestoreKeyPrefix: MapBookmarkRestore
+			BookmarkKeyCount: 4
 		Background@RADAR_BG:
 			X: WINDOW_RIGHT - 255
 			Y: 5

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -719,6 +719,8 @@ Container@PLAYER_WIDGETS:
 			PaletteWidget: PRODUCTION_PALETTE
 			TypesContainer: PRODUCTION_TYPES
 			BackgroundContainer: PRODUCTION_BACKGROUND
+			PreviousProductionTabKey: PreviousProductionTab
+			NextProductionTabKey: NextProductionTab
 			X: WINDOW_RIGHT - 204
 			Y: 268
 			Width: 194

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -272,6 +272,8 @@ Container@PLAYER_WIDGETS:
 					TooltipContainer: TOOLTIP_CONTAINER
 					ReadyText: Ready
 					HoldText: On Hold
+					HotkeyPrefix: SupportPower
+					HotkeyCount: 6
 		Background@COMMAND_BAR:
 			Logic: CommandBarLogic
 			X: 5

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -714,6 +714,8 @@ Container@PLAYER_WIDGETS:
 			TooltipContainer: TOOLTIP_CONTAINER
 			ReadyText: Ready
 			HoldText: On Hold
+			HotkeyPrefix: Production
+			HotkeyCount: 24
 		ProductionTabs@PRODUCTION_TABS:
 			Logic: ProductionTabsLogic
 			PaletteWidget: PRODUCTION_PALETTE

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -33,6 +33,17 @@ Container@INGAME_ROOT:
 					Width: WINDOW_RIGHT
 					Height: WINDOW_BOTTOM
 					TooltipContainer: TOOLTIP_CONTAINER
+					ScrollUpKey: MapScrollUp
+					ScrollDownKey: MapScrollDown
+					ScrollLeftKey: MapScrollLeft
+					ScrollRightKey: MapScrollRight
+					JumpToTopEdgeKey: MapJumpToTopEdge
+					JumpToBottomEdgeKey: MapJumpToBottomEdge
+					JumpToLeftEdgeKey: MapJumpToLeftEdge
+					JumpToRightEdgeKey: MapJumpToRightEdge
+					BookmarkSaveKeyPrefix: MapBookmarkSave
+					BookmarkRestoreKeyPrefix: MapBookmarkRestore
+					BookmarkKeyCount: 4
 				WorldCommand:
 					Width: WINDOW_RIGHT
 					Height: WINDOW_BOTTOM

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -215,6 +215,17 @@ Container@EDITOR_WORLD_ROOT:
 			Width: WINDOW_RIGHT
 			Height: WINDOW_BOTTOM
 			IgnoreMouseOver: True
+			ScrollUpKey: MapScrollUp
+			ScrollDownKey: MapScrollDown
+			ScrollLeftKey: MapScrollLeft
+			ScrollRightKey: MapScrollRight
+			JumpToTopEdgeKey: MapJumpToTopEdge
+			JumpToBottomEdgeKey: MapJumpToBottomEdge
+			JumpToLeftEdgeKey: MapJumpToLeftEdge
+			JumpToRightEdgeKey: MapJumpToRightEdge
+			BookmarkSaveKeyPrefix: MapBookmarkSave
+			BookmarkRestoreKeyPrefix: MapBookmarkRestore
+			BookmarkKeyCount: 4
 		Background@RADAR_BG:
 			X: WINDOW_RIGHT - 255
 			Y: 5

--- a/mods/common/chrome/ingame.yaml
+++ b/mods/common/chrome/ingame.yaml
@@ -29,6 +29,17 @@ Container@INGAME_ROOT:
 					Width: WINDOW_RIGHT
 					Height: WINDOW_BOTTOM
 					TooltipContainer: TOOLTIP_CONTAINER
+					ScrollUpKey: MapScrollUp
+					ScrollDownKey: MapScrollDown
+					ScrollLeftKey: MapScrollLeft
+					ScrollRightKey: MapScrollRight
+					JumpToTopEdgeKey: MapJumpToTopEdge
+					JumpToBottomEdgeKey: MapJumpToBottomEdge
+					JumpToLeftEdgeKey: MapJumpToLeftEdge
+					JumpToRightEdgeKey: MapJumpToRightEdge
+					BookmarkSaveKeyPrefix: MapBookmarkSave
+					BookmarkRestoreKeyPrefix: MapBookmarkRestore
+					BookmarkKeyCount: 4
 				WorldCommand:
 					Width: WINDOW_RIGHT
 					Height: WINDOW_BOTTOM

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -14,6 +14,8 @@ Container@PLAYER_WIDGETS:
 					TooltipContainer: TOOLTIP_CONTAINER
 					ReadyText: READY
 					HoldText: ON HOLD
+					HotkeyPrefix: SupportPower
+					HotkeyCount: 6
 		Image@COMMAND_BAR_BACKGROUND:
 			X: 0
 			Y: WINDOW_BOTTOM - HEIGHT

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -480,6 +480,8 @@ Container@PLAYER_WIDGETS:
 					IconSpriteOffset: 0, 0
 					MinimumRows: 5
 					MaximumRows: 6
+					HotkeyPrefix: Production
+					HotkeyCount: 24
 				Container@PRODUCTION_TYPES:
 					X: 6
 					Y: 2

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -469,6 +469,8 @@ Container@PLAYER_WIDGETS:
 					IconSize: 62, 46
 					IconMargin: 1, 1
 					IconSpriteOffset: -1, -1
+					HotkeyPrefix: Production
+					HotkeyCount: 24
 				Container@PALETTE_FOREGROUND:
 					X: 40
 					Y: 0 - 1

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -14,6 +14,8 @@ Container@PLAYER_WIDGETS:
 					TooltipContainer: TOOLTIP_CONTAINER
 					ReadyText: READY
 					HoldText: ON HOLD
+					HotkeyPrefix: SupportPower
+					HotkeyCount: 6
 				Container@PALETTE_FOREGROUND:
 					Children:
 						Image@ICON_TEMPLATE:

--- a/mods/ts/chrome/ingame-player.yaml
+++ b/mods/ts/chrome/ingame-player.yaml
@@ -483,6 +483,8 @@ Container@PLAYER_WIDGETS:
 					IconSpriteOffset: 0, 0
 					MinimumRows: 4
 					MaximumRows: 6
+					HotkeyPrefix: Production
+					HotkeyCount: 24
 				Container@PRODUCTION_TYPES:
 					X: 0
 					Y: 0 - 32

--- a/mods/ts/chrome/ingame-player.yaml
+++ b/mods/ts/chrome/ingame-player.yaml
@@ -15,6 +15,8 @@ Container@PLAYER_WIDGETS:
 					ReadyText: READY
 					HoldText: ON HOLD
 					ClockPalette: iconclock
+					HotkeyPrefix: SupportPower
+					HotkeyCount: 6
 		Image@COMMAND_BAR_BACKGROUND:
 			Logic: AddFactionSuffixLogic
 			X: 5


### PR DESCRIPTION
Part 3 of my campaign to unhardcode and move gameplay-specific hotkeys to mod code.
This follows on from #13706 and #13711.

This converts all the remaining hotkey consumers except for `WorldCommandWidget` and the hardcoded "dev" hotkeys.  Those two require more drastic changes that will come in their own PRs.