### PR TITLE
Added TransformsNearResources for Tiberium Tree creation

### DIFF
--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Traits\Render\RenderShroudCircle.cs" />
     <Compile Include="Traits\SupportPowers\ChronoshiftPower.cs" />
     <Compile Include="Traits\SupportPowers\GpsPower.cs" />
+    <Compile Include="Traits\TransformsNearResources.cs" />
     <Compile Include="Traits\GpsWatcher.cs" />
     <Compile Include="Scripting\Properties\ChronosphereProperties.cs" />
     <Compile Include="Traits\Render\WithDisguisingInfantryBody.cs" />

--- a/OpenRA.Mods.Cnc/Traits/TransformsNearResources.cs
+++ b/OpenRA.Mods.Cnc/Traits/TransformsNearResources.cs
@@ -1,0 +1,99 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Cnc.Traits
+{
+	[Desc("Replace with another actor when a resource spawns adjacent.")]
+	public class TransformsNearResourcesInfo : ITraitInfo
+	{
+		[FieldLoader.Require]
+		[ActorReference] public readonly string IntoActor = null;
+
+		public readonly CVec Offset = CVec.Zero;
+
+		[Desc("Don't render the make animation.")]
+		public readonly bool SkipMakeAnims = false;
+
+		[FieldLoader.Require]
+		[Desc("Resource type which triggers the transformation.")]
+		public readonly string Type = null;
+
+		[Desc("Resource density threshold which is required.")]
+		public readonly int Density = 1;
+
+		[Desc("This many adjacent resource tiles are required.")]
+		public readonly int Adjacency = 1;
+
+		[Desc("The range of time (in ticks) until the transformation starts.")]
+		public readonly int[] Delay = { 1000, 3000 };
+
+		public virtual object Create(ActorInitializer init) { return new TransformsNearResources(init.Self, this); }
+	}
+
+	public class TransformsNearResources : ITick
+	{
+		readonly TransformsNearResourcesInfo info;
+		readonly ResourceLayer resourceLayer;
+		int delay;
+
+		public TransformsNearResources(Actor self, TransformsNearResourcesInfo info)
+		{
+			this.info = info;
+			resourceLayer = self.World.WorldActor.Trait<ResourceLayer>();
+			delay = Util.RandomDelay(self.World, info.Delay);
+		}
+
+		void ITick.Tick(Actor self)
+		{
+			if (delay < 0)
+				return;
+
+			var adjacent = 0;
+			foreach (var location in CVec.Directions.Select(d => self.Location + d))
+			{
+				var resource = resourceLayer.GetResource(location);
+				if (resource == null || resource.Info.Type != info.Type)
+					continue;
+
+				var density = resourceLayer.GetResourceDensity(location);
+				if (density < info.Density)
+					continue;
+
+				if (++adjacent < info.Adjacency)
+					continue;
+
+				if (--delay < 0)
+					Transform(self);
+			}
+		}
+
+		void Transform(Actor self)
+		{
+			var transform = new Transform(self, info.IntoActor);
+
+			var facing = self.TraitOrDefault<IFacing>();
+			if (facing != null)
+				transform.Facing = facing.Facing;
+
+			transform.SkipMakeAnims = info.SkipMakeAnims;
+			transform.Offset = info.Offset;
+
+			self.CancelActivity();
+			self.QueueActivity(transform);
+		}
+	}
+}

--- a/mods/cnc/rules/campaign-maprules.yaml
+++ b/mods/cnc/rules/campaign-maprules.yaml
@@ -53,3 +53,15 @@ airstrike.proxy:
 TRUCK:
 	Buildable:
 		Prerequisites: ~disabled
+
+T03:
+	TransformsNearResources:
+		Type: Tiberium
+		IntoActor: split2
+		Offset: 0,1
+
+T13:
+	TransformsNearResources:
+		Type: Tiberium
+		IntoActor: split3
+		Offset: 0,1

--- a/mods/cnc/sequences/decorations.yaml
+++ b/mods/cnc/sequences/decorations.yaml
@@ -6,6 +6,7 @@ split2:
 			DESERT: TEMPERAT
 	make:
 		Length: 30
+		Tick: 120
 	active:
 		Start: 30
 		Length: 24
@@ -18,6 +19,7 @@ split3:
 		UseTilesetExtension: true
 	make:
 		Length: 30
+		Tick: 120
 	active:
 		Start: 30
 		Length: 24


### PR DESCRIPTION
Implements https://github.com/OpenRA/OpenRA/issues/9524#issuecomment-262881258 and closes #14051. I added this to the campaign rules as those maps were designed for it, while all the OpenRA multiplayer maps certainly weren't as we are introducing this just now. I just want to add this detail, not derail all balancing.