### PR TITLE
Added destructible trees to the C&C: TD/RA campaigns

### DIFF
--- a/mods/cnc/rules/campaign-maprules.yaml
+++ b/mods/cnc/rules/campaign-maprules.yaml
@@ -27,6 +27,18 @@ Player:
 		DefaultCashLocked: True
 		DefaultCash: 5000
 
+^TreeHusk:
+	Health:
+		HP: 1000
+	Armor:
+		Type: Heavy
+	Targetable:
+		TargetTypes: Ground
+	HitShape:
+	WithDeathAnimation:
+		DeathSequence: dead
+		UseDeathTypeSuffix: false
+
 airstrike.proxy:
 	AlwaysVisible:
 	AirstrikePower:

--- a/mods/ra/rules/campaign-rules.yaml
+++ b/mods/ra/rules/campaign-rules.yaml
@@ -40,3 +40,15 @@ E7.noautotarget:
 
 ^Vehicle:
 	Demolishable:
+
+^TreeHusk:
+	Health:
+		HP: 1000
+	Armor:
+		Type: Concrete
+	Targetable:
+		TargetTypes: Ground
+	HitShape:
+	WithDeathAnimation:
+		DeathSequence: dead
+		UseDeathTypeSuffix: false


### PR DESCRIPTION
Brings back https://github.com/OpenRA/OpenRA/pull/2612, but for the single-player missions only as I don't want to disturb balancing.