### PR TITLE
Added ScreenMap support for common sprite effects

### DIFF
--- a/OpenRA.Game/Effects/IEffect.cs
+++ b/OpenRA.Game/Effects/IEffect.cs
@@ -20,5 +20,8 @@ namespace OpenRA.Effects
 		IEnumerable<IRenderable> Render(WorldRenderer r);
 	}
 
+	// Identifier interface for effects that are added to ScreenMap
+	public interface ISpatiallyPartitionable { }
+
 	public interface IEffectAboveShroud { IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr); }
 }

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -110,7 +110,13 @@ namespace OpenRA.Graphics
 			if (World.OrderGenerator != null)
 				worldRenderables = worldRenderables.Concat(World.OrderGenerator.Render(this, World));
 
-			worldRenderables = worldRenderables.Concat(World.Effects.SelectMany(e => e.Render(this)));
+			// Unpartitioned effects
+			worldRenderables = worldRenderables.Concat(World.UnpartitionedEffects.SelectMany(e => e.Render(this)));
+
+			// Partitioned, currently on-screen effects
+			var effectRenderables = World.ScreenMap.EffectsInBox(Viewport.TopLeft, Viewport.BottomRight);
+			worldRenderables = worldRenderables.Concat(effectRenderables.SelectMany(e => e.Render(this)));
+
 			worldRenderables = worldRenderables.OrderBy(RenderableScreenZPositionComparisonKey);
 
 			Game.Renderer.WorldModelRenderer.BeginFrame();

--- a/OpenRA.Game/Primitives/SpatiallyPartitioned.cs
+++ b/OpenRA.Game/Primitives/SpatiallyPartitioned.cs
@@ -51,10 +51,15 @@ namespace OpenRA.Primitives
 			MutateBins(item, itemBounds[item] = bounds, addItem);
 		}
 
-		public void Remove(T item)
+		public bool Remove(T item)
 		{
-			MutateBins(item, itemBounds[item], removeItem);
+			Rectangle bounds;
+			if (!itemBounds.TryGetValue(item, out bounds))
+				return false;
+
+			MutateBins(item, bounds, removeItem);
 			itemBounds.Remove(item);
+			return true;
 		}
 
 		Dictionary<T, Rectangle> BinAt(int row, int col)

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -30,6 +30,7 @@ namespace OpenRA
 		internal readonly TraitDictionary TraitDict = new TraitDictionary();
 		readonly SortedDictionary<uint, Actor> actors = new SortedDictionary<uint, Actor>();
 		readonly List<IEffect> effects = new List<IEffect>();
+		readonly List<IEffect> unpartitionedEffects = new List<IEffect>();
 		readonly List<ISync> syncedEffects = new List<ISync>();
 
 		readonly Queue<Action<World>> frameEndActions = new Queue<Action<World>>();
@@ -285,6 +286,11 @@ namespace OpenRA
 		public void Add(IEffect e)
 		{
 			effects.Add(e);
+
+			var sp = e as ISpatiallyPartitionable;
+			if (sp == null)
+				unpartitionedEffects.Add(e);
+
 			var se = e as ISync;
 			if (se != null)
 				syncedEffects.Add(se);
@@ -293,6 +299,11 @@ namespace OpenRA
 		public void Remove(IEffect e)
 		{
 			effects.Remove(e);
+
+			var sp = e as ISpatiallyPartitionable;
+			if (sp == null)
+				unpartitionedEffects.Remove(e);
+
 			var se = e as ISync;
 			if (se != null)
 				syncedEffects.Remove(se);
@@ -301,6 +312,7 @@ namespace OpenRA
 		public void RemoveAll(Predicate<IEffect> predicate)
 		{
 			effects.RemoveAll(predicate);
+			unpartitionedEffects.RemoveAll(e => predicate((IEffect)e));
 			syncedEffects.RemoveAll(e => predicate((IEffect)e));
 		}
 
@@ -361,6 +373,7 @@ namespace OpenRA
 
 		public IEnumerable<Actor> Actors { get { return actors.Values; } }
 		public IEnumerable<IEffect> Effects { get { return effects; } }
+		public IEnumerable<IEffect> UnpartitionedEffects { get { return unpartitionedEffects; } }
 		public IEnumerable<ISync> SyncedEffects { get { return syncedEffects; } }
 
 		public Actor GetActorById(uint actorId)

--- a/OpenRA.Mods.Cnc/Effects/GpsSatellite.cs
+++ b/OpenRA.Mods.Cnc/Effects/GpsSatellite.cs
@@ -16,7 +16,7 @@ using OpenRA.Mods.Cnc.Traits;
 
 namespace OpenRA.Mods.Cnc.Effects
 {
-	class GpsSatellite : IEffect
+	class GpsSatellite : IEffect, ISpatiallyPartitionable
 	{
 		readonly Player launcher;
 		readonly Animation anim;
@@ -34,6 +34,7 @@ namespace OpenRA.Mods.Cnc.Effects
 
 			anim = new Animation(world, image);
 			anim.PlayRepeating(sequence);
+			world.ScreenMap.Add(this, pos, anim.Image);
 		}
 
 		public void Tick(World world)
@@ -45,8 +46,10 @@ namespace OpenRA.Mods.Cnc.Effects
 			{
 				var watcher = launcher.PlayerActor.Trait<GpsWatcher>();
 				watcher.ReachedOrbit(launcher);
-				world.AddFrameEndTask(w => w.Remove(this));
+				world.AddFrameEndTask(w => { w.Remove(this); w.ScreenMap.Remove(this); });
 			}
+
+			world.ScreenMap.Update(this, pos, anim.Image);
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)

--- a/OpenRA.Mods.Cnc/Effects/SatelliteLaunch.cs
+++ b/OpenRA.Mods.Cnc/Effects/SatelliteLaunch.cs
@@ -16,7 +16,7 @@ using OpenRA.Mods.Cnc.Traits;
 
 namespace OpenRA.Mods.Cnc.Effects
 {
-	class SatelliteLaunch : IEffect
+	class SatelliteLaunch : IEffect, ISpatiallyPartitionable
 	{
 		readonly GpsPowerInfo info;
 		readonly Actor launcher;
@@ -31,14 +31,16 @@ namespace OpenRA.Mods.Cnc.Effects
 
 			doors = new Animation(launcher.World, info.DoorImage);
 			doors.PlayThen(info.DoorSequence,
-				() => launcher.World.AddFrameEndTask(w => w.Remove(this)));
+				() => launcher.World.AddFrameEndTask(w => { w.Remove(this); w.ScreenMap.Remove(this); }));
 
 			pos = launcher.CenterPosition;
+			launcher.World.ScreenMap.Add(this, pos, doors.Image);
 		}
 
 		public void Tick(World world)
 		{
 			doors.Tick();
+			world.ScreenMap.Update(this, pos, doors.Image);
 
 			if (++frame == 19)
 			{

--- a/OpenRA.Mods.Common/Effects/CrateEffect.cs
+++ b/OpenRA.Mods.Common/Effects/CrateEffect.cs
@@ -15,7 +15,7 @@ using OpenRA.Graphics;
 
 namespace OpenRA.Mods.Common.Effects
 {
-	public class CrateEffect : IEffect
+	public class CrateEffect : IEffect, ISpatiallyPartitionable
 	{
 		readonly string palette;
 		readonly Actor a;
@@ -27,12 +27,14 @@ namespace OpenRA.Mods.Common.Effects
 			this.palette = palette;
 
 			anim = new Animation(a.World, "crate-effects");
-			anim.PlayThen(seq, () => a.World.AddFrameEndTask(w => w.Remove(this)));
+			anim.PlayThen(seq, () => a.World.AddFrameEndTask(w => { w.Remove(this); w.ScreenMap.Remove(this); }));
+			a.World.ScreenMap.Add(this, a.CenterPosition, anim.Image);
 		}
 
 		public void Tick(World world)
 		{
 			anim.Tick();
+			world.ScreenMap.Update(this, a.CenterPosition, anim.Image);
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)

--- a/OpenRA.Mods.Common/Effects/SpriteEffect.cs
+++ b/OpenRA.Mods.Common/Effects/SpriteEffect.cs
@@ -15,7 +15,7 @@ using OpenRA.Graphics;
 
 namespace OpenRA.Mods.Common.Effects
 {
-	public class SpriteEffect : IEffect
+	public class SpriteEffect : IEffect, ISpatiallyPartitionable
 	{
 		readonly World world;
 		readonly string palette;
@@ -32,7 +32,8 @@ namespace OpenRA.Mods.Common.Effects
 			this.scaleSizeWithZoom = scaleSizeWithZoom;
 			this.visibleThroughFog = visibleThroughFog;
 			anim = new Animation(world, image, () => facing);
-			anim.PlayThen(sequence, () => world.AddFrameEndTask(w => w.Remove(this)));
+			anim.PlayThen(sequence, () => world.AddFrameEndTask(w => { w.Remove(this); w.ScreenMap.Remove(this); }));
+			world.ScreenMap.Add(this, pos, anim.Image);
 		}
 
 		public void Tick(World world)

--- a/OpenRA.Mods.Common/Projectiles/NukeLaunch.cs
+++ b/OpenRA.Mods.Common/Projectiles/NukeLaunch.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Effects
 {
-	public class NukeLaunch : IProjectile
+	public class NukeLaunch : IProjectile, ISpatiallyPartitionable
 	{
 		readonly Player firedBy;
 		readonly Animation anim;
@@ -64,6 +64,8 @@ namespace OpenRA.Mods.Common.Effects
 
 			if (skipAscent)
 				ticks = turn;
+
+			firedBy.World.ScreenMap.Add(this, pos, anim.Image);
 		}
 
 		public void Tick(World world)
@@ -81,12 +83,14 @@ namespace OpenRA.Mods.Common.Effects
 			if (ticks == delay)
 				Explode(world);
 
+			world.ScreenMap.Update(this, pos, anim.Image);
+
 			ticks++;
 		}
 
 		void Explode(World world)
 		{
-			world.AddFrameEndTask(w => w.Remove(this));
+			world.AddFrameEndTask(w => { w.Remove(this); w.ScreenMap.Remove(this); });
 			weapon.Impact(Target.FromPos(pos), firedBy.PlayerActor, Enumerable.Empty<int>());
 			world.WorldActor.Trait<ScreenShaker>().AddEffect(20, pos, 5);
 


### PR DESCRIPTION
This adds the `ScreenMap` plumbing for sprite `IEffect`s (which can later be used for other `IEffect`s as well) and adapts all the easy sprite effects.

The only one of real importance here will be `SpriteEffect`, as it's used in `LeavesTrails`, projectile sprite trails and explosions, as well as a few other places.

The other migrated effects will likely give no noticable performance gains, but I migrated them as well since they were similarly easy to adapt and just might save a tiny additional bit of render time here and there.

Note about effects not touched by this PR:
- Support for `IEffectAboveShroud` effects would seemingly require some more changes to `WorldRenderer` (if at all possible) for presumably low gains (compared to `SpriteEffect`), so a decision and possible implementation is deferred to the future.
- System-drawn effects like contrails and beams, as well as special cases like TeslaZaps, and therefore most projectiles will possibly require some more low-level preparations and for that reason are left to a later follow-up, although they are definitely desired due to expected gains comparable to (or larger than) `SpriteEffect` in mods with considerable use of these.

Supersedes #11676.
Partially adresses #9443.