### PR TITLE
Fix water splashes on bridge in RA

### DIFF
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -934,7 +934,7 @@
 		Name: Bridge
 		ShowOwnerRow: false
 	Targetable:
-		TargetTypes: Ground, Water
+		TargetTypes: Ground, Water, Bridge
 		RequiresForceFire: true
 	Building:
 		Footprint: ____ ____

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -26,7 +26,7 @@
 		Explosions: small_splash
 		ImpactSounds: splash9.aud
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure
+		InvalidTargets: Ship, Structure, Bridge
 
 25mm:
 	Inherits: ^Cannon

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -21,7 +21,7 @@
 		Explosions: large_splash
 		ImpactSounds: splash9.aud
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure
+		InvalidTargets: Ship, Structure, Bridge
 
 CrateNapalm:
 	Inherits: ^Explosion

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -235,6 +235,8 @@ TorpTube:
 		RangeLimit: 10c819
 		BoundToTerrainType: Water
 		Palette: shadow
+		MaximumLaunchAngle: 0
+		CruiseAltitude: 0
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 180
@@ -247,13 +249,9 @@ TorpTube:
 			Concrete: 500
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@3Eff: CreateEffect
-		Explosions: large_explosion
-		ImpactSounds: kaboom15.aud
-		InvalidTargets: Water
-	Warhead@5EffWaterHit: CreateEffect
 		Explosions: artillery_explosion
 		ImpactSounds: kaboom15.aud
-		ValidTargets: Ship, Structure, Underwater
+		ValidTargets: Ship, Structure, Underwater, Ground, Bridge
 	Warhead@4EffWater: CreateEffect
 		Explosions: large_splash
 		ImpactSounds: splash9.aud

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -35,7 +35,7 @@
 		Explosions: med_splash
 		ImpactSounds: splash9.aud
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure
+		InvalidTargets: Ship, Structure, Bridge
 
 ^AntiAirMissile:
 	Inherits: ^AntiGroundMissile
@@ -258,7 +258,7 @@ TorpTube:
 		Explosions: large_splash
 		ImpactSounds: splash9.aud
 		ValidTargets: Water
-		InvalidTargets: Ship, Structure, Underwater
+		InvalidTargets: Ship, Structure, Underwater, Bridge
 
 ^SubMissileDefault:
 	Inherits: ^AntiGroundMissile

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -55,7 +55,7 @@ FLAK-23-AG:
 	Warhead@3EffWater: CreateEffect
 		Explosions: small_splash
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure
+		InvalidTargets: Ship, Structure, Bridge
 
 ^HeavyMG:
 	ReloadDelay: 30
@@ -79,7 +79,7 @@ FLAK-23-AG:
 	Warhead@3EffWater: CreateEffect
 		Explosions: water_piffs
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure
+		InvalidTargets: Ship, Structure, Bridge
 
 ^LightMG:
 	Inherits: ^HeavyMG
@@ -115,7 +115,7 @@ Vulcan:
 	Warhead@4Eff_2Water: CreateEffect
 		Explosions: water_piffs
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure
+		InvalidTargets: Ship, Structure, Bridge
 		Delay: 2
 	Warhead@5Dam_3: SpreadDamage
 		Spread: 128
@@ -135,7 +135,7 @@ Vulcan:
 	Warhead@6Eff_3Water: CreateEffect
 		Explosions: water_piffs
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure
+		InvalidTargets: Ship, Structure, Bridge
 		Delay: 4
 	Warhead@7Dam_4: SpreadDamage
 		Spread: 128
@@ -155,7 +155,7 @@ Vulcan:
 	Warhead@8Eff_4Water: CreateEffect
 		Explosions: water_piffs
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure
+		InvalidTargets: Ship, Structure, Bridge
 		Delay: 6
 	Warhead@9Dam_5: SpreadDamage
 		Spread: 128
@@ -175,7 +175,7 @@ Vulcan:
 	Warhead@10Eff_5Water: CreateEffect
 		Explosions: water_piffs
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure
+		InvalidTargets: Ship, Structure, Bridge
 		Delay: 8
 	Warhead@11Dam_6: SpreadDamage
 		Spread: 128
@@ -195,7 +195,7 @@ Vulcan:
 	Warhead@12Eff_6Water: CreateEffect
 		Explosions: water_piffs
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure
+		InvalidTargets: Ship, Structure, Bridge
 		Delay: 10
 
 ChainGun:
@@ -272,7 +272,7 @@ SilencedPPK:
 	Warhead@3EffWater: CreateEffect
 		Explosions: water_piffs
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure
+		InvalidTargets: Ship, Structure, Bridge
 
 Colt45:
 	Inherits: ^SnipeWeapon
@@ -286,7 +286,7 @@ Colt45:
 	Warhead@3EffWater: CreateEffect
 		Explosions: water_piff
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure
+		InvalidTargets: Ship, Structure, Bridge
 
 Sniper:
 	Inherits: ^SnipeWeapon


### PR DESCRIPTION
On bleed, both the explosion as well as the water splash warhead of weapons triggered on bridges, since they have both the Ground and Water target types.

Ground cannot be made invalid for water splashes without causing regressions elsewhere, so a new Bridge target type is introduced to explicitly make bridges invalid targets for water splash effect warheads.

Fixes #13989.