### PR TITLE
Move several interfaces to Mods.Common.

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -179,11 +179,6 @@ namespace OpenRA.Traits
 	public interface IDisabledTrait { bool IsTraitDisabled { get; } }
 	public interface IDisable { bool Disabled { get; } }
 
-	public interface IRadarSignature
-	{
-		IEnumerable<Pair<CPos, Color>> RadarSignatureCells(Actor self);
-	}
-
 	public interface IDefaultVisibilityInfo : ITraitInfoInterface { }
 	public interface IDefaultVisibility { bool IsVisible(Actor self, Player byPlayer); }
 	public interface IVisibilityModifier { bool IsVisible(Actor self, Player byPlayer); }
@@ -193,8 +188,6 @@ namespace OpenRA.Traits
 		bool IsVisible(Actor actor);
 		bool HasFogVisibility();
 	}
-
-	public interface IRadarColorModifier { Color RadarColorOverride(Actor self, Color color); }
 
 	public interface ITargetableCells
 	{

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -346,21 +346,6 @@ namespace OpenRA.Traits
 		IEnumerable<WPos> TargetablePositions(Actor self);
 	}
 
-	public interface IObjectivesPanel
-	{
-		string PanelName { get; }
-		int ExitDelay { get; }
-	}
-
-	public interface INotifyObjectivesUpdated
-	{
-		void OnPlayerWon(Player winner);
-		void OnPlayerLost(Player loser);
-		void OnObjectiveAdded(Player player, int objectiveID);
-		void OnObjectiveCompleted(Player player, int objectiveID);
-		void OnObjectiveFailed(Player player, int objectiveID);
-	}
-
 	public interface IGameOver { void GameOver(World world); }
 
 	public interface IWarhead

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -135,8 +135,6 @@ namespace OpenRA.Traits
 	public interface INotifyOwnerChanged { void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner); }
 	public interface INotifyEffectiveOwnerChanged { void OnEffectiveOwnerChanged(Actor self, Player oldEffectiveOwner, Player newEffectiveOwner); }
 
-	public interface ISeedableResource { void Seed(Actor self); }
-
 	public interface ISelectionDecorationsInfo : ITraitInfoInterface
 	{
 		int[] SelectionBoxBounds { get; }

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -288,24 +288,6 @@ namespace OpenRA.Traits
 		void SetVisualPosition(Actor self, WPos pos);
 	}
 
-	public interface IMoveInfo : ITraitInfoInterface { }
-	public interface IMove
-	{
-		Activity MoveTo(CPos cell, int nearEnough);
-		Activity MoveTo(CPos cell, Actor ignoreActor);
-		Activity MoveWithinRange(Target target, WDist range);
-		Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange);
-		Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange);
-		Activity MoveIntoWorld(Actor self, CPos cell, SubCell subCell = SubCell.Any);
-		Activity MoveToTarget(Actor self, Target target);
-		Activity MoveIntoTarget(Actor self, Target target);
-		Activity VisualMove(Actor self, WPos fromPos, WPos toPos);
-		CPos NearestMoveableCell(CPos target);
-		bool IsMoving { get; set; }
-		bool IsMovingVertically { get; set; }
-		bool CanEnterTargetNow(Actor self, Target target);
-	}
-
 	[RequireExplicitImplementation]
 	public interface ITemporaryBlocker
 	{

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -353,10 +353,6 @@ namespace OpenRA.Traits
 		IEnumerable<WPos> TargetablePositions(Actor self);
 	}
 
-	public interface ILintPass { void Run(Action<string> emitError, Action<string> emitWarning, ModData modData); }
-	public interface ILintMapPass { void Run(Action<string> emitError, Action<string> emitWarning, Map map); }
-	public interface ILintRulesPass { void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules); }
-
 	public interface IObjectivesPanel
 	{
 		string PanelName { get; }

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -131,10 +131,7 @@ namespace OpenRA.Traits
 	public interface INotifyCreated { void Created(Actor self); }
 	public interface INotifyAddedToWorld { void AddedToWorld(Actor self); }
 	public interface INotifyRemovedFromWorld { void RemovedFromWorld(Actor self); }
-	public interface INotifyDamage { void Damaged(Actor self, AttackInfo e); }
-	public interface INotifyKilled { void Killed(Actor self, AttackInfo e); }
 	public interface INotifyActorDisposing { void Disposing(Actor self); }
-	public interface INotifyAppliedDamage { void AppliedDamage(Actor self, Actor damaged, AttackInfo e); }
 	public interface INotifyOwnerChanged { void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner); }
 	public interface INotifyEffectiveOwnerChanged { void OnEffectiveOwnerChanged(Actor self, Player oldEffectiveOwner, Player newEffectiveOwner); }
 
@@ -181,8 +178,6 @@ namespace OpenRA.Traits
 
 	public interface IDisabledTrait { bool IsTraitDisabled { get; } }
 	public interface IDisable { bool Disabled { get; } }
-	public interface IExplodeModifier { bool ShouldExplode(Actor self); }
-	public interface IHuskModifier { string HuskActor(Actor self); }
 
 	public interface IRadarSignature
 	{

--- a/OpenRA.Mods.Common/Activities/Enter.cs
+++ b/OpenRA.Mods.Common/Activities/Enter.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Linq;
 using OpenRA.Activities;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities

--- a/OpenRA.Mods.Common/Activities/Move/Drag.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Drag.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using OpenRA.Activities;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities

--- a/OpenRA.Mods.Common/Activities/Move/Follow.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Follow.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using OpenRA.Activities;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities

--- a/OpenRA.Mods.Common/Activities/Turn.cs
+++ b/OpenRA.Mods.Common/Activities/Turn.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using OpenRA.Activities;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -817,6 +817,7 @@
     <Compile Include="Traits\Conditions\GrantConditionOnBotOwner.cs" />
     <Compile Include="Traits\Render\ReloadArmamentsBar.cs" />
     <Compile Include="Lint\CheckChromeHotkeys.cs" />
+    <Compile Include="UtilityCommands\LintInterfaces.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -104,6 +104,8 @@ namespace OpenRA.Mods.Common.Traits
 	public interface IExplodeModifier { bool ShouldExplode(Actor self); }
 	public interface IHuskModifier { string HuskActor(Actor self); }
 
+	public interface ISeedableResource { void Seed(Actor self); }
+
 	[RequireExplicitImplementation]
 	public interface INotifyInfiltrated { void Infiltrated(Actor self, Actor infiltrator); }
 

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -327,4 +327,19 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public interface IRadarColorModifier { Color RadarColorOverride(Actor self, Color color); }
+
+	public interface IObjectivesPanel
+	{
+		string PanelName { get; }
+		int ExitDelay { get; }
+	}
+
+	public interface INotifyObjectivesUpdated
+	{
+		void OnPlayerWon(Player winner);
+		void OnPlayerLost(Player loser);
+		void OnObjectiveAdded(Player player, int objectiveID);
+		void OnObjectiveCompleted(Player player, int objectiveID);
+		void OnObjectiveFailed(Player player, int objectiveID);
+	}
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Drawing;
 using OpenRA.Activities;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Activities;
@@ -319,4 +320,11 @@ namespace OpenRA.Mods.Common.Traits
 		bool IsMovingVertically { get; set; }
 		bool CanEnterTargetNow(Actor self, Target target);
 	}
+
+	public interface IRadarSignature
+	{
+		IEnumerable<Pair<CPos, Color>> RadarSignatureCells(Actor self);
+	}
+
+	public interface IRadarColorModifier { Color RadarColorOverride(Actor self, Color color); }
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -294,4 +294,23 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		IEnumerable<object> ActorPreviewInits(ActorInfo ai, ActorPreviewType type);
 	}
+
+	public interface IMoveInfo : ITraitInfoInterface { }
+
+	public interface IMove
+	{
+		Activity MoveTo(CPos cell, int nearEnough);
+		Activity MoveTo(CPos cell, Actor ignoreActor);
+		Activity MoveWithinRange(Target target, WDist range);
+		Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange);
+		Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange);
+		Activity MoveIntoWorld(Actor self, CPos cell, SubCell subCell = SubCell.Any);
+		Activity MoveToTarget(Actor self, Target target);
+		Activity MoveIntoTarget(Actor self, Target target);
+		Activity VisualMove(Actor self, WPos fromPos, WPos toPos);
+		CPos NearestMoveableCell(CPos target);
+		bool IsMoving { get; set; }
+		bool IsMovingVertically { get; set; }
+		bool CanEnterTargetNow(Actor self, Target target);
+	}
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -82,6 +82,9 @@ namespace OpenRA.Mods.Common.Traits
 	[RequireExplicitImplementation]
 	public interface INotifyDamageStateChanged { void DamageStateChanged(Actor self, AttackInfo e); }
 
+	public interface INotifyDamage { void Damaged(Actor self, AttackInfo e); }
+	public interface INotifyKilled { void Killed(Actor self, AttackInfo e); }
+	public interface INotifyAppliedDamage { void AppliedDamage(Actor self, Actor damaged, AttackInfo e); }
 	public interface INotifyBuildingPlaced { void BuildingPlaced(Actor self); }
 	public interface INotifyRepair { void Repairing(Actor self, Actor target); }
 	public interface INotifyNuke { void Launching(Actor self); }
@@ -96,6 +99,9 @@ namespace OpenRA.Mods.Common.Traits
 	public interface INotifyDiscovered { void OnDiscovered(Actor self, Player discoverer, bool playNotification); }
 	public interface IRenderActorPreviewInfo : ITraitInfo { IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init); }
 	public interface ICruiseAltitudeInfo : ITraitInfo { WDist GetCruiseAltitude(); }
+
+	public interface IExplodeModifier { bool ShouldExplode(Actor self); }
+	public interface IHuskModifier { string HuskActor(Actor self); }
 
 	[RequireExplicitImplementation]
 	public interface INotifyInfiltrated { void Infiltrated(Actor self, Actor infiltrator); }

--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -13,7 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.FileSystem;
-using OpenRA.Traits;
+using OpenRA.Mods.Common.Lint;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {

--- a/OpenRA.Mods.Common/UtilityCommands/LintInterfaces.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/LintInterfaces.cs
@@ -1,0 +1,19 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+
+namespace OpenRA.Mods.Common.Lint
+{
+	public interface ILintPass { void Run(Action<string> emitError, Action<string> emitWarning, ModData modData); }
+	public interface ILintMapPass { void Run(Action<string> emitError, Action<string> emitWarning, Map map); }
+	public interface ILintRulesPass { void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules); }
+}

--- a/OpenRA.Mods.D2k/Lint/CheckImportActors.cs
+++ b/OpenRA.Mods.D2k/Lint/CheckImportActors.cs
@@ -10,8 +10,8 @@
 #endregion
 
 using System;
+using OpenRA.Mods.Common.Lint;
 using OpenRA.Mods.D2k.UtilityCommands;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Lint
 {


### PR DESCRIPTION
#13916 and #13732 want to extend the `IMove` interface in ways which are reasonable in themselves, but expose concepts that we don't want the engine to have to know about.  On closer inspection, all the code that cares about `IMove` has already been migrated to mod code, so this offers a cleaner solution for those and other future PRs.