### PR TITLE
Remove dead WSB from Refinery trait

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -55,7 +55,6 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly Actor self;
 		readonly RefineryInfo info;
-		readonly WithSpriteBody wsb;
 		PlayerResources playerResources;
 
 		int currentDisplayTick = 0;
@@ -78,7 +77,6 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 			playerResources = self.Owner.PlayerActor.Trait<PlayerResources>();
 			currentDisplayTick = info.TickRate;
-			wsb = self.Trait<WithSpriteBody>();
 		}
 
 		public virtual Activity DockSequence(Actor harv, Actor self)
@@ -123,10 +121,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// Harvester was killed while unloading
 			if (dockedHarv != null && dockedHarv.IsDead)
-			{
-				wsb.CancelCustomAnimation(self);
 				dockedHarv = null;
-			}
 
 			if (info.ShowTicks && currentDisplayValue > 0 && --currentDisplayTick <= 0)
 			{


### PR DESCRIPTION
WithSpriteBody code in Refinery trait seems to be dead. It shouldn't be in Refinery trait anyway in today's ORA standards and instead be separated to WithDockAnimation or something, which is non-existent as of now. (There's WithDockingOVERLAY though, used in bundled TS mod).

This piece of code gets in the way of having multiple WithSpriteBody traits on Refineries.