### PR TITLE
Remove TargetLocation and TargetActor from order issuing code.

### DIFF
--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -40,8 +40,8 @@ namespace OpenRA
 		public readonly string OrderString;
 		public readonly Actor Subject;
 		public readonly bool Queued;
-		public Actor TargetActor;
-		public CPos TargetLocation;
+		public Actor TargetActor { get; private set; }
+		public CPos TargetLocation { get; private set; }
 		public string TargetString;
 		public CPos ExtraLocation;
 		public uint ExtraData;

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -12,6 +12,7 @@
 using System;
 using System.IO;
 using OpenRA.Network;
+using OpenRA.Traits;
 
 namespace OpenRA
 {
@@ -61,6 +62,21 @@ namespace OpenRA
 			Queued = queued;
 			ExtraLocation = extraLocation;
 			ExtraData = extraData;
+		}
+
+		Order(string orderString, Actor subject, Target target, bool queued, CPos extraLocation, uint extraData)
+		{
+			var targetType = target.SerializableType;
+
+			OrderString = orderString;
+			Subject = subject;
+			TargetActor = targetType == TargetType.Actor ? target.SerializableActor : null;
+			TargetLocation = targetType == TargetType.Terrain ? target.SerializableCell.HasValue ?
+				target.SerializableCell.Value : subject.World.Map.CellContaining(target.CenterPosition) : CPos.Zero;
+			TargetString = null;
+			Queued = queued;
+			ExtraLocation = extraLocation;
+			ExtraData = targetType == TargetType.FrozenActor ? target.FrozenActor.ID : extraData;
 		}
 
 		public static Order Deserialize(World world, BinaryReader r)
@@ -173,6 +189,9 @@ namespace OpenRA
 
 		public Order(string orderString, Actor subject, bool queued)
 			: this(orderString, subject, null, CPos.Zero, null, queued, CPos.Zero, 0) { }
+
+		public Order(string orderString, Actor subject, Target target, bool queued)
+			: this(orderString, subject, target, queued, CPos.Zero, 0) { }
 
 		public Order(string orderstring, Order order)
 			: this(orderstring, order.Subject, order.TargetActor, order.TargetLocation,

--- a/OpenRA.Game/Orders/GenericSelectTarget.cs
+++ b/OpenRA.Game/Orders/GenericSelectTarget.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using OpenRA.Traits;
 
 namespace OpenRA.Orders
 {
@@ -52,7 +53,7 @@ namespace OpenRA.Orders
 
 				var queued = mi.Modifiers.HasModifier(Modifiers.Shift);
 				foreach (var subject in Subjects)
-					yield return new Order(OrderName, subject, queued) { TargetLocation = cell };
+					yield return new Order(OrderName, subject, Target.FromCell(world, cell), queued);
 			}
 		}
 

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -25,12 +25,13 @@ namespace OpenRA.Traits
 		Actor actor;
 		FrozenActor frozen;
 		WPos pos;
+		CPos? cell;
 		int generation;
 
 		public static Target FromPos(WPos p) { return new Target { pos = p, type = TargetType.Terrain }; }
 		public static Target FromCell(World w, CPos c, SubCell subCell = SubCell.FullCell)
 		{
-			return new Target { pos = w.Map.CenterOfSubCell(c, subCell), type = TargetType.Terrain };
+			return new Target { pos = w.Map.CenterOfSubCell(c, subCell), cell = c, type = TargetType.Terrain };
 		}
 
 		public static Target FromOrder(World w, Order o)
@@ -191,5 +192,10 @@ namespace OpenRA.Traits
 					return "Invalid";
 			}
 		}
+
+		// Expose internal state for serialization by the orders code *only*
+		internal TargetType SerializableType { get { return type; } }
+		internal Actor SerializableActor { get { return actor; } }
+		internal CPos? SerializableCell { get { return cell; } }
 	}
 }

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -124,7 +124,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
 			if (order.OrderID == "Disguise")
-				return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
+				return new Order(order.OrderID, self, target, queued);
 
 			return null;
 		}

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
@@ -64,10 +64,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (order.OrderID != "Infiltrate")
 				return null;
 
-			if (target.Type == TargetType.FrozenActor)
-				return new Order(order.OrderID, self, queued) { ExtraData = target.FrozenActor.ID };
-
-			return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
+			return new Order(order.OrderID, self, target, queued);
 		}
 
 		bool IsValidOrder(Actor self, Order order)

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -121,10 +121,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (order.OrderID != "DetonateAttack" && order.OrderID != "Detonate")
 				return null;
 
-			if (target.Type == TargetType.FrozenActor)
-				return new Order(order.OrderID, self, queued) { ExtraData = target.FrozenActor.ID };
-
-			return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
+			return new Order(order.OrderID, self, target, queued);
 		}
 
 		Order IIssueDeployOrder.IssueDeployOrder(Actor self)

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -73,9 +73,9 @@ namespace OpenRA.Mods.Cnc.Traits
 					else
 						self.World.OrderGenerator = new MinefieldOrderGenerator(self, start);
 
-					return new Order("BeginMinefield", self, false) { TargetLocation = start };
+					return new Order("BeginMinefield", self, Target.FromCell(self.World, start), false);
 				case "PlaceMine":
-					return new Order("PlaceMine", self, false) { TargetLocation = self.Location };
+					return new Order("PlaceMine", self, Target.FromCell(self.World, self.Location), false);
 				default:
 					return null;
 			}
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		Order IIssueDeployOrder.IssueDeployOrder(Actor self)
 		{
-			return new Order("PlaceMine", self, false) { TargetLocation = self.Location };
+			return new Order("PlaceMine", self, Target.FromCell(self.World, self.Location), false);
 		}
 
 		void IResolveOrder.ResolveOrder(Actor self, Order order)
@@ -195,7 +195,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				{
 					minelayers.First().World.CancelInputMode();
 					foreach (var minelayer in minelayers)
-						yield return new Order("PlaceMinefield", minelayer, false) { TargetLocation = cell };
+						yield return new Order("PlaceMinefield", minelayer, Target.FromCell(world, cell), false);
 				}
 			}
 

--- a/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
@@ -88,9 +88,9 @@ namespace OpenRA.Mods.Cnc.Traits
 				self.World.OrderGenerator = new PortableChronoOrderGenerator(self, Info);
 
 			if (order.OrderID == "PortableChronoTeleport")
-				return new Order(order.OrderID, self, queued) { TargetLocation = self.World.Map.CellContaining(target.CenterPosition) };
+				return new Order(order.OrderID, self, target, queued);
 
-			return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
+			return null;
 		}
 
 		public void ResolveOrder(Actor self, Order order)
@@ -185,7 +185,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				&& self.Trait<PortableChrono>().CanTeleport && self.Owner.Shroud.IsExplored(cell))
 			{
 				world.CancelInputMode();
-				yield return new Order("PortableChronoTeleport", self, mi.Modifiers.HasModifier(Modifiers.Shift)) { TargetLocation = cell };
+				yield return new Order("PortableChronoTeleport", self, Target.FromCell(world, cell), mi.Modifiers.HasModifier(Modifiers.Shift));
 			}
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
@@ -97,9 +97,8 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			world.CancelInputMode();
 			if (mi.Button == expectedButton && IsValidTarget(world, cell))
-				yield return new Order(order, manager.Self, false)
+				yield return new Order(order, manager.Self, Target.FromCell(world, cell), false)
 				{
-					TargetLocation = cell,
 					SuppressVisualFeedback = true
 				};
 		}

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
@@ -85,14 +85,6 @@ namespace OpenRA.Mods.Cnc.Traits
 			cursorBlocked = cursor + "-blocked";
 		}
 
-		Actor GetFiringActor(World world, CPos cell)
-		{
-			var pos = world.Map.CenterOfCell(cell);
-			var range = attack.GetMaximumRange().LengthSquared;
-
-			return instance.Instances.Where(i => !i.IsTraitPaused).MinByOrDefault(a => (a.Self.CenterPosition - pos).HorizontalLengthSquared).Self;
-		}
-
 		bool IsValidTarget(World world, CPos cell)
 		{
 			var pos = world.Map.CenterOfCell(cell);
@@ -107,7 +99,6 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (mi.Button == expectedButton && IsValidTarget(world, cell))
 				yield return new Order(order, manager.Self, false)
 				{
-					TargetActor = GetFiringActor(world, cell),
 					TargetLocation = cell,
 					SuppressVisualFeedback = true
 				};

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -221,9 +221,8 @@ namespace OpenRA.Mods.Cnc.Traits
 			{
 				// Cannot chronoshift into unexplored location
 				if (IsValidTarget(xy))
-					yield return new Order(order, manager.Self, false)
+					yield return new Order(order, manager.Self, Target.FromCell(manager.Self.World, xy), false)
 					{
-						TargetLocation = xy,
 						ExtraLocation = sourceLocation,
 						SuppressVisualFeedback = true
 					};

--- a/OpenRA.Mods.Common/AI/BaseBuilder.cs
+++ b/OpenRA.Mods.Common/AI/BaseBuilder.cs
@@ -157,11 +157,13 @@ namespace OpenRA.Mods.Common.AI
 				else
 				{
 					failCount = 0;
-					ai.QueueOrder(new Order("PlaceBuilding", player.PlayerActor, false)
+					ai.QueueOrder(new Order("PlaceBuilding", player.PlayerActor, Target.FromCell(world, location.Value), false)
 					{
-						TargetLocation = location.Value,
+						// Building to place
 						TargetString = currentBuilding.Item,
-						TargetActor = queue.Actor,
+
+						// Actor ID to associate the placement with
+						ExtraData = queue.Actor.ActorID,
 						SuppressVisualFeedback = true
 					});
 

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -757,7 +757,7 @@ namespace OpenRA.Mods.Common.AI
 			if (target.Actor == null)
 				return;
 
-			QueueOrder(new Order(target.OrderString, capturer, true) { TargetActor = target.Actor });
+			QueueOrder(new Order(target.OrderString, capturer, Target.FromActor(target.Actor), true));
 			BotDebug("AI ({0}): Ordered {1} to capture {2}", Player.ClientIndex, capturer, target.Actor);
 			activeUnits.Remove(capturer);
 		}
@@ -813,7 +813,7 @@ namespace OpenRA.Mods.Common.AI
 				// Tell the idle harvester to quit slacking:
 				var newSafeResourcePatch = FindNextResource(harvester, harv);
 				BotDebug("AI: Harvester {0} is idle. Ordering to {1} in search for new resources.".F(harvester, newSafeResourcePatch));
-				QueueOrder(new Order("Harvest", harvester, false) { TargetLocation = newSafeResourcePatch });
+				QueueOrder(new Order("Harvest", harvester, Target.FromCell(World, newSafeResourcePatch), false));
 			}
 		}
 
@@ -927,13 +927,16 @@ namespace OpenRA.Mods.Common.AI
 		void SetRallyPointsForNewProductionBuildings(Actor self)
 		{
 			foreach (var rp in self.World.ActorsWithTrait<RallyPoint>())
+			{
 				if (rp.Actor.Owner == Player &&
 					!IsRallyPointValid(rp.Trait.Location, rp.Actor.Info.TraitInfoOrDefault<BuildingInfo>()))
-					QueueOrder(new Order("SetRallyPoint", rp.Actor, false)
+				{
+					QueueOrder(new Order("SetRallyPoint", rp.Actor, Target.FromCell(World, ChooseRallyLocationNear(rp.Actor)), false)
 					{
-						TargetLocation = ChooseRallyLocationNear(rp.Actor),
 						SuppressVisualFeedback = true
 					});
+				}
+			}
 		}
 
 		// Won't work for shipyards...
@@ -992,7 +995,7 @@ namespace OpenRA.Mods.Common.AI
 				if (desiredLocation == null)
 					continue;
 
-				QueueOrder(new Order("Move", mcv, true) { TargetLocation = desiredLocation.Value });
+				QueueOrder(new Order("Move", mcv, Target.FromCell(World, desiredLocation.Value), true));
 				QueueOrder(new Order("DeployTransform", mcv, true));
 			}
 		}
@@ -1047,7 +1050,7 @@ namespace OpenRA.Mods.Common.AI
 					// Valid target found, delay by a few ticks to avoid rescanning before power fires via order
 					BotDebug("AI: {2} found new target location {0} for support power {1}.", attackLocation, sp.Info.OrderName, Player.PlayerName);
 					waitingPowers[sp] += 10;
-					QueueOrder(new Order(sp.Key, supportPowerMngr.Self, false) { TargetLocation = attackLocation.Value, SuppressVisualFeedback = true });
+					QueueOrder(new Order(sp.Key, supportPowerMngr.Self, Target.FromCell(World, attackLocation.Value), false) { SuppressVisualFeedback = true });
 				}
 			}
 		}
@@ -1199,7 +1202,7 @@ namespace OpenRA.Mods.Common.AI
 				{
 					BotDebug("Bot noticed damage {0} {1}->{2}, repairing.",
 						self, e.PreviousDamageState, e.DamageState);
-					QueueOrder(new Order("RepairBuilding", self.Owner.PlayerActor, false) { TargetActor = self });
+					QueueOrder(new Order("RepairBuilding", self.Owner.PlayerActor, Target.FromActor(self), false));
 				}
 			}
 

--- a/OpenRA.Mods.Common/AI/States/AirStates.cs
+++ b/OpenRA.Mods.Common/AI/States/AirStates.cs
@@ -223,7 +223,7 @@ namespace OpenRA.Mods.Common.AI
 				}
 
 				if (CanAttackTarget(a, owner.TargetActor))
-					owner.Bot.QueueOrder(new Order("Attack", a, false) { TargetActor = owner.TargetActor });
+					owner.Bot.QueueOrder(new Order("Attack", a, Target.FromActor(owner.TargetActor), false));
 			}
 		}
 
@@ -250,7 +250,7 @@ namespace OpenRA.Mods.Common.AI
 					continue;
 				}
 
-				owner.Bot.QueueOrder(new Order("Move", a, false) { TargetLocation = RandomBuildingLocation(owner) });
+				owner.Bot.QueueOrder(new Order("Move", a, Target.FromCell(owner.World, RandomBuildingLocation(owner)), false));
 			}
 
 			owner.FuzzyStateMachine.ChangeState(owner, new AirIdleState(), true);

--- a/OpenRA.Mods.Common/AI/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/AI/States/GroundStates.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.AI
 			if (AttackOrFleeFuzzy.Default.CanAttack(owner.Units, enemyUnits))
 			{
 				foreach (var u in owner.Units)
-					owner.Bot.QueueOrder(new Order("AttackMove", u, false) { TargetLocation = owner.TargetActor.Location });
+					owner.Bot.QueueOrder(new Order("AttackMove", u, Target.FromCell(owner.World, owner.TargetActor.Location), false));
 
 				// We have gathered sufficient units. Attack the nearest enemy unit.
 				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsAttackMoveState(), true);
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.AI
 				// Let them regroup into tighter formation.
 				owner.Bot.QueueOrder(new Order("Stop", leader, false));
 				foreach (var unit in owner.Units.Where(a => !ownUnits.Contains(a)))
-					owner.Bot.QueueOrder(new Order("AttackMove", unit, false) { TargetLocation = leader.Location });
+					owner.Bot.QueueOrder(new Order("AttackMove", unit, Target.FromCell(owner.World, leader.Location), false));
 			}
 			else
 			{
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.AI
 				}
 				else
 					foreach (var a in owner.Units)
-						owner.Bot.QueueOrder(new Order("AttackMove", a, false) { TargetLocation = owner.TargetActor.Location });
+						owner.Bot.QueueOrder(new Order("AttackMove", a, Target.FromCell(owner.World, owner.TargetActor.Location), false));
 			}
 
 			if (ShouldFlee(owner))
@@ -147,7 +147,7 @@ namespace OpenRA.Mods.Common.AI
 
 			foreach (var a in owner.Units)
 				if (!BusyAttack(a))
-					owner.Bot.QueueOrder(new Order("Attack", a, false) { TargetActor = owner.TargetActor });
+					owner.Bot.QueueOrder(new Order("Attack", a, Target.FromActor(owner.TargetActor), false));
 
 			if (ShouldFlee(owner))
 				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsFleeState(), true);

--- a/OpenRA.Mods.Common/AI/States/NavyStates.cs
+++ b/OpenRA.Mods.Common/AI/States/NavyStates.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.AI
 			if (AttackOrFleeFuzzy.Default.CanAttack(owner.Units, enemyUnits))
 			{
 				foreach (var u in owner.Units)
-					owner.Bot.QueueOrder(new Order("AttackMove", u, false) { TargetLocation = owner.TargetActor.Location });
+					owner.Bot.QueueOrder(new Order("AttackMove", u, Target.FromCell(owner.World, owner.TargetActor.Location), false));
 
 				// We have gathered sufficient units. Attack the nearest enemy unit.
 				owner.FuzzyStateMachine.ChangeState(owner, new NavyUnitsAttackMoveState(), true);
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Common.AI
 				// Let them regroup into tighter formation.
 				owner.Bot.QueueOrder(new Order("Stop", leader, false));
 				foreach (var unit in owner.Units.Where(a => !ownUnits.Contains(a)))
-					owner.Bot.QueueOrder(new Order("AttackMove", unit, false) { TargetLocation = leader.Location });
+					owner.Bot.QueueOrder(new Order("AttackMove", unit, Target.FromCell(owner.World, leader.Location), false));
 			}
 			else
 			{
@@ -141,7 +141,7 @@ namespace OpenRA.Mods.Common.AI
 				}
 				else
 					foreach (var a in owner.Units)
-						owner.Bot.QueueOrder(new Order("AttackMove", a, false) { TargetLocation = owner.TargetActor.Location });
+						owner.Bot.QueueOrder(new Order("AttackMove", a, Target.FromCell(owner.World, owner.TargetActor.Location), false));
 			}
 
 			if (ShouldFlee(owner))
@@ -174,7 +174,7 @@ namespace OpenRA.Mods.Common.AI
 
 			foreach (var a in owner.Units)
 				if (!BusyAttack(a))
-					owner.Bot.QueueOrder(new Order("Attack", a, false) { TargetActor = owner.TargetActor });
+					owner.Bot.QueueOrder(new Order("Attack", a, Target.FromActor(owner.TargetActor), false));
 
 			if (ShouldFlee(owner))
 				owner.FuzzyStateMachine.ChangeState(owner, new NavyUnitsFleeState(), true);

--- a/OpenRA.Mods.Common/AI/States/ProtectionStates.cs
+++ b/OpenRA.Mods.Common/AI/States/ProtectionStates.cs
@@ -9,6 +9,8 @@
  */
 #endregion
 
+using OpenRA.Traits;
+
 namespace OpenRA.Mods.Common.AI
 {
 	class UnitsForProtectionIdleState : GroundStateBase, IState
@@ -55,7 +57,7 @@ namespace OpenRA.Mods.Common.AI
 			else
 			{
 				foreach (var a in owner.Units)
-					owner.Bot.QueueOrder(new Order("AttackMove", a, false) { TargetLocation = owner.TargetActor.Location });
+					owner.Bot.QueueOrder(new Order("AttackMove", a, Target.FromCell(owner.World, owner.TargetActor.Location), false));
 			}
 		}
 

--- a/OpenRA.Mods.Common/AI/States/StateBase.cs
+++ b/OpenRA.Mods.Common/AI/States/StateBase.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.AI
 		{
 			var loc = RandomBuildingLocation(squad);
 			foreach (var a in squad.Units)
-				squad.Bot.QueueOrder(new Order("Move", a, false) { TargetLocation = loc });
+				squad.Bot.QueueOrder(new Order("Move", a, Target.FromCell(squad.World, loc), false));
 		}
 
 		protected static CPos RandomBuildingLocation(Squad squad)

--- a/OpenRA.Mods.Common/Orders/BeaconOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/BeaconOrderGenerator.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using OpenRA.Graphics;
+using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Orders
 {
@@ -21,7 +22,7 @@ namespace OpenRA.Mods.Common.Orders
 			world.CancelInputMode();
 
 			if (mi.Button == MouseButton.Left)
-				yield return new Order("PlaceBeacon", world.LocalPlayer.PlayerActor, false) { TargetLocation = cell, SuppressVisualFeedback = true };
+				yield return new Order("PlaceBeacon", world.LocalPlayer.PlayerActor, Target.FromCell(world, cell), false) { SuppressVisualFeedback = true };
 		}
 
 		public virtual void Tick(World world) { }

--- a/OpenRA.Mods.Common/Orders/GuardOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/GuardOrderGenerator.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Orders;
+using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Orders
 {
@@ -35,7 +36,7 @@ namespace OpenRA.Mods.Common.Orders
 			var queued = mi.Modifiers.HasModifier(Modifiers.Shift);
 			foreach (var subject in Subjects)
 				if (subject != target)
-					yield return new Order(OrderName, subject, queued) { TargetActor = target };
+					yield return new Order(OrderName, subject, Target.FromActor(target), queued);
 		}
 
 		public override void Tick(World world)

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -133,11 +133,13 @@ namespace OpenRA.Mods.Common.Orders
 						orderType = "LineBuild";
 				}
 
-				yield return new Order(orderType, owner.PlayerActor, false)
+				yield return new Order(orderType, owner.PlayerActor, Target.FromCell(world, topLeft), false)
 				{
-					TargetLocation = topLeft,
-					TargetActor = queue.Actor,
+					// Building to place
 					TargetString = building,
+
+					// Actor to associate the placement with
+					ExtraData = queue.Actor.ActorID,
 					SuppressVisualFeedback = true
 				};
 			}
@@ -267,9 +269,8 @@ namespace OpenRA.Mods.Common.Orders
 				if (availableCells.Count == 0)
 					continue;
 
-				yield return new Order("Move", blocker.Actor, false)
+				yield return new Order("Move", blocker.Actor, Target.FromCell(world, blocker.Actor.ClosestCell(availableCells)), false)
 				{
-					TargetLocation = blocker.Actor.ClosestCell(availableCells),
 					SuppressVisualFeedback = true
 				};
 			}

--- a/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Orders
 
 			// Repair a building.
 			if (underCursor.Info.HasTraitInfo<RepairableBuildingInfo>())
-				yield return new Order("RepairBuilding", world.LocalPlayer.PlayerActor, false) { TargetActor = underCursor };
+				yield return new Order("RepairBuilding", world.LocalPlayer.PlayerActor, Target.FromActor(underCursor), false);
 
 			// Don't command allied units
 			if (underCursor.Owner != world.LocalPlayer)
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Orders
 			if (repairBuilding == null)
 				yield break;
 
-			yield return new Order(orderId, underCursor, false) { TargetActor = repairBuilding, VisualFeedbackTarget = underCursor };
+			yield return new Order(orderId, underCursor, Target.FromActor(repairBuilding), false) { VisualFeedbackTarget = underCursor };
 		}
 
 		public void Tick(World world)

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -655,11 +655,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
-			if (order.OrderID == "Enter")
-				return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
-
-			if (order.OrderID == "Move")
-				return new Order(order.OrderID, self, queued) { TargetLocation = self.World.Map.CellContaining(target.CenterPosition) };
+			if (order.OrderID == "Enter" || order.OrderID == "Move")
+				return new Order(order.OrderID, self, target, queued);
 
 			return null;
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -132,17 +132,7 @@ namespace OpenRA.Mods.Common.Traits
 		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
 			if (order is AttackOrderTargeter)
-			{
-				switch (target.Type)
-				{
-					case TargetType.Actor:
-						return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
-					case TargetType.FrozenActor:
-						return new Order(order.OrderID, self, queued) { ExtraData = target.FrozenActor.ID };
-					case TargetType.Terrain:
-						return new Order(order.OrderID, self, queued) { TargetLocation = self.World.Map.CellContaining(target.CenterPosition) };
-				}
-			}
+				return new Order(order.OrderID, self, target, queued);
 
 			return null;
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackSuicides.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackSuicides.cs
@@ -50,10 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (order.OrderID != "DetonateAttack" && order.OrderID != "Detonate")
 				return null;
 
-			if (target.Type == TargetType.FrozenActor)
-				return new Order(order.OrderID, self, queued) { ExtraData = target.FrozenActor.ID };
-
-			return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
+			return new Order(order.OrderID, self, target, queued);
 		}
 
 		Order IIssueDeployOrder.IssueDeployOrder(Actor self)

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -150,7 +150,7 @@ namespace OpenRA.Mods.Common.Traits
 				// Cells outside the playable area should be clamped to the edge for consistency with move orders
 				cell = world.Map.Clamp(cell);
 				foreach (var s in subjects)
-					yield return new Order(orderName, s.Actor, queued) { TargetLocation = cell };
+					yield return new Order(orderName, s.Actor, Target.FromCell(world, cell), queued);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/AttackWander.cs
+++ b/OpenRA.Mods.Common/Traits/AttackWander.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override void DoAction(Actor self, CPos targetCell)
 		{
-			attackMove.ResolveOrder(self, new Order("AttackMove", self, false) { TargetLocation = targetCell });
+			attackMove.ResolveOrder(self, new Order("AttackMove", self, Target.FromCell(self.World, targetCell), false));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
 			if (order.OrderID == OrderID)
-				return new Order(order.OrderID, self, false) { TargetLocation = self.World.Map.CellContaining(target.CenterPosition), SuppressVisualFeedback = true,
+				return new Order(order.OrderID, self, target, false) { SuppressVisualFeedback = true,
 					ExtraData = ((RallyPointOrderTargeter)order).ForceSet ? ForceSet : 0 };
 
 			return null;

--- a/OpenRA.Mods.Common/Traits/Captures.cs
+++ b/OpenRA.Mods.Common/Traits/Captures.cs
@@ -65,10 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (order.OrderID != "CaptureActor")
 				return null;
 
-			if (target.Type == TargetType.FrozenActor)
-				return new Order(order.OrderID, self, queued) { ExtraData = target.FrozenActor.ID };
-
-			return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
+			return new Order(order.OrderID, self, target, queued);
 		}
 
 		public string VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -205,21 +205,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
-			if (order.OrderID == "PickupUnit")
-			{
-				if (target.Type == TargetType.FrozenActor)
-					return new Order(order.OrderID, self, queued) { ExtraData = target.FrozenActor.ID };
-
-				return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
-			}
-			else if (order.OrderID == "DeliverUnit")
-			{
-				return new Order(order.OrderID, self, queued) { TargetLocation = self.World.Map.CellContaining(target.CenterPosition) };
-			}
-			else if (order.OrderID == "Unload")
-			{
-				return new Order(order.OrderID, self, queued) { TargetLocation = self.World.Map.CellContaining(target.CenterPosition) };
-			}
+			if (order.OrderID == "PickupUnit" || order.OrderID == "DeliverUnit" || order.OrderID == "Unload")
+				return new Order(order.OrderID, self, target, queued);
 
 			return null;
 		}

--- a/OpenRA.Mods.Common/Traits/DeliversCash.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversCash.cs
@@ -57,10 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (order.OrderID != "DeliverCash")
 				return null;
 
-			if (target.Type == TargetType.FrozenActor)
-				return new Order(order.OrderID, self, queued) { ExtraData = target.FrozenActor.ID };
-
-			return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
+			return new Order(order.OrderID, self, target, queued);
 		}
 
 		public string VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/DeliversExperience.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversExperience.cs
@@ -58,10 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (order.OrderID != "DeliverExperience")
 				return null;
 
-			if (target.Type == TargetType.FrozenActor)
-				return new Order(order.OrderID, self, queued) { ExtraData = target.FrozenActor.ID };
-
-			return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
+			return new Order(order.OrderID, self, target, queued);
 		}
 
 		public string VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/Demolition.cs
+++ b/OpenRA.Mods.Common/Traits/Demolition.cs
@@ -67,10 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (order.OrderID != "C4")
 				return null;
 
-			if (target.Type == TargetType.FrozenActor)
-				return new Order(order.OrderID, self, queued) { ExtraData = target.FrozenActor.ID };
-
-			return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
+			return new Order(order.OrderID, self, target, queued);
 		}
 
 		public void ResolveOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -51,10 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (order.OrderID != "EngineerRepair")
 				return null;
 
-			if (target.Type == TargetType.FrozenActor)
-				return new Order(order.OrderID, self, queued) { ExtraData = target.FrozenActor.ID };
-
-			return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
+			return new Order(order.OrderID, self, target, queued);
 		}
 
 		static bool IsValidOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/EntersTunnels.cs
+++ b/OpenRA.Mods.Common/Traits/EntersTunnels.cs
@@ -52,10 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (order.OrderID != "EnterTunnel")
 				return null;
 
-			if (target.Type == TargetType.FrozenActor)
-				return new Order(order.OrderID, self, queued) { ExtraData = target.FrozenActor.ID, SuppressVisualFeedback = true };
-
-			return new Order(order.OrderID, self, queued) { TargetActor = target.Actor, SuppressVisualFeedback = true };
+			return new Order(order.OrderID, self, target, queued) { SuppressVisualFeedback = true };
 		}
 
 		public string VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/ExternalCaptures.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCaptures.cs
@@ -66,10 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (order.OrderID != "ExternalCaptureActor")
 				return null;
 
-			if (target.Type == TargetType.FrozenActor)
-				return new Order(order.OrderID, self, queued) { ExtraData = target.FrozenActor.ID };
-
-			return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
+			return new Order(order.OrderID, self, target, queued);
 		}
 
 		static bool IsValidOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -342,11 +342,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
-			if (order.OrderID == "Deliver")
-				return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
-
-			if (order.OrderID == "Harvest")
-				return new Order(order.OrderID, self, queued) { TargetLocation = self.World.Map.CellContaining(target.CenterPosition) };
+			if (order.OrderID == "Deliver" || order.OrderID == "Harvest")
+				return new Order(order.OrderID, self, target, queued);
 
 			return null;
 		}

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -585,7 +585,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
 			if (order is MoveOrderTargeter)
-				return new Order("Move", self, queued) { TargetLocation = self.World.Map.CellContaining(target.CenterPosition) };
+				return new Order("Move", self, target, queued);
 
 			return null;
 		}

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
 			if (order.OrderID == "EnterTransport" || order.OrderID == "EnterTransports")
-				return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
+				return new Order(order.OrderID, self, target, queued);
 
 			return null;
 		}

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -56,12 +56,13 @@ namespace OpenRA.Mods.Common.Traits
 			self.World.AddFrameEndTask(w =>
 			{
 				var prevItems = GetNumBuildables(self.Owner);
+				var targetActor = w.GetActorById(order.ExtraData);
 
-				if (order.TargetActor.IsDead)
+				if (targetActor.IsDead)
 					return;
 
 				var unit = self.World.Map.Rules.Actors[order.TargetString];
-				var queue = order.TargetActor.TraitsImplementing<ProductionQueue>()
+				var queue = targetActor.TraitsImplementing<ProductionQueue>()
 					.FirstOrDefault(q => q.CanBuild(unit) && q.CurrentItem() != null && q.CurrentItem().Item == order.TargetString && q.CurrentItem().RemainingTime == 0);
 
 				if (queue == null)

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
 			if (order.OrderID == "Repair")
-				return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
+				return new Order(order.OrderID, self, target, queued);
 
 			return null;
 		}

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
 			if (order.OrderID == "RepairNear")
-				return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
+				return new Order(order.OrderID, self, target, queued);
 
 			return null;
 		}

--- a/OpenRA.Mods.Common/Traits/RepairsBridges.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsBridges.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
 			if (order.OrderID == "RepairBridge")
-				return new Order(order.OrderID, self, queued) { TargetActor = target.Actor };
+				return new Order(order.OrderID, self, target, queued);
 
 			return null;
 		}

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				world.CancelInputMode();
 				if (mi.Button == MouseButton.Left && power.UnitsInRange(cell).Any())
-					yield return new Order(order, manager.Self, false) { TargetLocation = cell, SuppressVisualFeedback = true };
+					yield return new Order(order, manager.Self, Target.FromCell(world, cell), false) { SuppressVisualFeedback = true };
 			}
 
 			public void Tick(World world)

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -280,7 +280,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			world.CancelInputMode();
 			if (mi.Button == expectedButton && world.Map.Contains(cell))
-				yield return new Order(order, manager.Self, false) { TargetLocation = cell, SuppressVisualFeedback = true };
+				yield return new Order(order, manager.Self, Target.FromCell(world, cell), false) { SuppressVisualFeedback = true };
 		}
 
 		public virtual void Tick(World world)

--- a/OpenRA.Mods.Common/Traits/Wanders.cs
+++ b/OpenRA.Mods.Common/Traits/Wanders.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual void DoAction(Actor self, CPos targetCell)
 		{
-			move.ResolveOrder(self, new Order("Move", self, false) { TargetLocation = targetCell });
+			move.ResolveOrder(self, new Order("Move", self, Target.FromCell(self.World, targetCell), false));
 		}
 	}
 }

--- a/OpenRA.Test/OpenRA.Game/OrderTest.cs
+++ b/OpenRA.Test/OpenRA.Game/OrderTest.cs
@@ -11,6 +11,7 @@
 
 using System.IO;
 using NUnit.Framework;
+using OpenRA.Traits;
 
 namespace OpenRA.Test
 {
@@ -18,6 +19,7 @@ namespace OpenRA.Test
 	public class OrderTest
 	{
 		Order order;
+		Order targetInvalid;
 		Order immediateOrder;
 
 		[SetUp]
@@ -26,10 +28,11 @@ namespace OpenRA.Test
 			order = new Order("TestOrder", null, false)
 			{
 				TargetString = "TestTarget",
-				TargetLocation = new CPos(1234, 5678),
 				ExtraData = 1234,
 				ExtraLocation = new CPos(555, 555)
 			};
+
+			targetInvalid = new Order("TestOrder", null, Target.Invalid, false);
 
 			immediateOrder = new Order("TestOrderImmediate", null, false)
 			{
@@ -38,22 +41,28 @@ namespace OpenRA.Test
 			};
 		}
 
+		Order RoundTripOrder(Order o)
+		{
+			var serializedData = new MemoryStream(o.Serialize());
+			return Order.Deserialize(null, new BinaryReader(serializedData));
+		}
+
 		[TestCase(TestName = "Data persists over serialization")]
 		public void SerializeA()
 		{
-			var serializedData = new MemoryStream(order.Serialize());
-			var result = Order.Deserialize(null, new BinaryReader(serializedData));
-
-			Assert.That(result.ToString(), Is.EqualTo(order.ToString()));
+			Assert.That(RoundTripOrder(order).ToString(), Is.EqualTo(order.ToString()));
 		}
 
-		[TestCase(TestName = "Data persists over serialization immediate")]
+		[TestCase(TestName = "Data persists over serialization (Immediate order)")]
 		public void SerializeB()
 		{
-			var serializedData = new MemoryStream(immediateOrder.Serialize());
-			var result = Order.Deserialize(null, new BinaryReader(serializedData));
+			Assert.That(RoundTripOrder(immediateOrder).ToString(), Is.EqualTo(immediateOrder.ToString()));
+		}
 
-			Assert.That(result.ToString(), Is.EqualTo(immediateOrder.ToString()));
+		[TestCase(TestName = "Data persists over serialization (Invalid target)")]
+		public void SerializeC()
+		{
+			Assert.That(RoundTripOrder(targetInvalid).ToString(), Is.EqualTo(targetInvalid.ToString()));
 		}
 	}
 }


### PR DESCRIPTION
Teaching actors how to properly behave when ordered to interact with frozen actors is a prerequisite for TS (#11265 is a major issue for cloak generators), and something we'd like to fix in general for the next release.  This is tricky right now because the Order class was never taught about Target, and frozen actor targeting is a bolted on kludge.

This PR starts the fixing this by introducing a new `Order` constructor that accepts a `Target`, and migrating all order issuing to use it.  Future PRs will push this through serialization/deserialization and then order resolving.

Once this is complete we will be able to implement the changes from #13363 across several smaller (and more reviewable) PRs by porting traits/activities from `ResolveFrozenActorOrder` to the native `Order.Target` on an activity-by-activity basis.