### PR TITLE
Calculate building placement offsets in screen space

### DIFF
--- a/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
@@ -26,8 +26,7 @@ namespace OpenRA.Mods.Common.Widgets
 		readonly EditorActorLayer editorLayer;
 		readonly EditorViewportControllerWidget editorWidget;
 		readonly ActorPreviewWidget preview;
-		readonly CVec locationOffset;
-		readonly WVec previewOffset;
+		readonly WVec centerOffset;
 		readonly PlayerReference owner;
 		readonly CVec[] footprint;
 
@@ -49,10 +48,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var buildingInfo = actor.TraitInfoOrDefault<BuildingInfo>();
 			if (buildingInfo != null)
-			{
-				locationOffset = -buildingInfo.LocationOffset();
-				previewOffset = buildingInfo.CenterOffset(world);
-			}
+				centerOffset = buildingInfo.CenterOffset(world);
 
 			var td = new TypeDictionary();
 			td.Add(new FacingInit(facing));
@@ -91,17 +87,16 @@ namespace OpenRA.Mods.Common.Widgets
 				return false;
 			}
 
-			var cell = worldRenderer.Viewport.ViewToWorld(mi.Location);
+			var cell = worldRenderer.Viewport.ViewToWorld(mi.Location - worldRenderer.ScreenPxOffset(centerOffset));
 			if (mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Down)
 			{
 				// Check the actor is inside the map
-				if (!footprint.All(c => world.Map.Tiles.Contains(cell + locationOffset + c)))
+				if (!footprint.All(c => world.Map.Tiles.Contains(cell + c)))
 					return true;
 
 				var newActorReference = new ActorReference(Actor.Name);
 				newActorReference.Add(new OwnerInit(owner.Name));
 
-				cell += locationOffset;
 				newActorReference.Add(new LocationInit(cell));
 
 				var ios = Actor.TraitInfoOrDefault<IOccupySpaceInfo>();
@@ -128,8 +123,8 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public void Tick()
 		{
-			var cell = worldRenderer.Viewport.ViewToWorld(Viewport.LastMousePos);
-			var pos = world.Map.CenterOfCell(cell + locationOffset) + previewOffset;
+			var cell = worldRenderer.Viewport.ViewToWorld(Viewport.LastMousePos - worldRenderer.ScreenPxOffset(centerOffset));
+			var pos = world.Map.CenterOfCell(cell) + centerOffset;
 
 			var origin = worldRenderer.Viewport.WorldToViewPx(worldRenderer.ScreenPxPosition(pos));
 

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -144,11 +144,6 @@ namespace OpenRA.Mods.Common.Traits
 				yield return t;
 		}
 
-		public CVec LocationOffset()
-		{
-			return new CVec(Dimensions.X / 2, Dimensions.Y > 1 ? (Dimensions.Y + 1) / 2 : 0);
-		}
-
 		public WVec CenterOffset(World w)
 		{
 			var off = (w.Map.CenterOfCell(new CPos(Dimensions.X, Dimensions.Y)) - w.Map.CenterOfCell(new CPos(1, 1))) / 2;

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -200,7 +200,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (item != null && item.Done && actor.HasTraitInfo<BuildingInfo>())
 			{
-				World.OrderGenerator = new PlaceBuildingOrderGenerator(CurrentQueue, icon.Name);
+				World.OrderGenerator = new PlaceBuildingOrderGenerator(CurrentQueue, icon.Name, worldRenderer);
 				return true;
 			}
 


### PR DESCRIPTION
PBOG and the editor actor brush need to solve the problem of "find the cell that places the center of the actor preview closest to the mouse position".  This is currently done by finding the cell under the mouse and then adding a world space offset, but this doesn't work as well as it could, especially with even-sides buildings, is implemented subtly wrong (#14000), and is completely bogus when terrain height is a factor.

Doing this in screen space is cleaner and gives better results.

Fixes #14000
Fixes #13985