### PR TITLE
Remove dummy d2k support bin overlay.

### DIFF
--- a/mods/d2k/chrome.yaml
+++ b/mods/d2k/chrome.yaml
@@ -2,7 +2,6 @@ sidebar: chrome.png
 	background-top: 0,0,226,295
 	background-iconrow: 0,295,226,48
 	background-bottom: 0,343,226,13
-	background-supportoverlay: 236,212,60,48
 
 sidebar-button: chrome.png
 	background: 377,0,25,25

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -14,16 +14,6 @@ Container@PLAYER_WIDGETS:
 					TooltipContainer: TOOLTIP_CONTAINER
 					ReadyText: READY
 					HoldText: ON HOLD
-				Container@PALETTE_FOREGROUND:
-					Children:
-						Image@ICON_TEMPLATE:
-							X: 0 - 2
-							Y: 0 - 2
-							Width: 60
-							Height: 48
-							IgnoreMouseOver: true
-							ImageCollection: sidebar
-							ImageName: background-supportoverlay
 		Image@COMMAND_BAR_BACKGROUND:
 			X: 0
 			Y: WINDOW_BOTTOM - HEIGHT


### PR DESCRIPTION
Fixes #13999.

D2K doesn't draw an overlay over the support power icons, but was set up to draw a transparent image instead of simply removing the overlay yaml.  As of #13552, that space was no longer transparent.