### PR TITLE
Fix AI BuildingLimits

### DIFF
--- a/OpenRA.Mods.Common/AI/BaseBuilder.cs
+++ b/OpenRA.Mods.Common/AI/BaseBuilder.cs
@@ -183,7 +183,7 @@ namespace OpenRA.Mods.Common.AI
 				if (!ai.Info.BuildingLimits.ContainsKey(actor.Name))
 					return true;
 
-				return playerBuildings.Count(a => a.Info.Name == actor.Name) <= ai.Info.BuildingLimits[actor.Name];
+				return playerBuildings.Count(a => a.Info.Name == actor.Name) < ai.Info.BuildingLimits[actor.Name];
 			});
 
 			if (orderBy != null)


### PR DESCRIPTION
The AI BaseBuilder would allow building a structure not only when the current number was lower, but also if it was *equal* to the limit, which allowed the AI to build one too many of every building with a build limit.

This is a simple and obvious enough fix to sneak into stable.

Closes #11917.