### PR TITLE
Fix height calculations in custom terrain layers.

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -784,6 +784,19 @@ namespace OpenRA
 			return new WDist(delta.Z);
 		}
 
+		/// <summary>
+		/// The size of the map Height step in world units
+		/// </summary>
+		public WDist CellHeightStep
+		{
+			get
+			{
+				// RectangularIsometric defines 1024 units along the diagonal axis,
+				// giving a half-tile height step of sqrt(2) * 512
+				return new WDist(Grid.Type == MapGridType.RectangularIsometric ? 724 : 512);
+			}
+		}
+
 		public CPos CellContaining(WPos pos)
 		{
 			if (Grid.Type == MapGridType.Rectangular)

--- a/OpenRA.Mods.Common/Traits/World/ElevatedBridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ElevatedBridgeLayer.cs
@@ -43,6 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void WorldLoaded(World world, WorldRenderer wr)
 		{
 			var domainIndex = world.WorldActor.Trait<DomainIndex>();
+			var cellHeight = world.Map.CellHeightStep.Length;
 			foreach (var tti in world.WorldActor.Info.TraitInfos<ElevatedBridgePlaceholderInfo>())
 			{
 				enabled = true;
@@ -54,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 					terrainIndices[uv] = terrain;
 
 					var pos = map.CenterOfCell(c);
-					cellCenters[uv] = pos - new WVec(0, 0, pos.Z - 512 * tti.Height);
+					cellCenters[uv] = pos - new WVec(0, 0, pos.Z - cellHeight * tti.Height);
 				}
 
 				var end = tti.EndCells();

--- a/OpenRA.Mods.Common/Traits/World/JumpjetActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/JumpjetActorLayer.cs
@@ -40,6 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 			map = self.World.Map;
 			terrainIndex = self.World.Map.Rules.TileSet.GetTerrainIndex(info.TerrainType);
 			height = new CellLayer<int>(map);
+			var cellHeight = self.World.Map.CellHeightStep.Length;
 			foreach (var c in map.AllCells)
 			{
 				var neighbourCount = 0;
@@ -57,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 					}
 				}
 
-				height[c] = info.HeightOffset.Length + neighbourHeight * 512 / neighbourCount;
+				height[c] = info.HeightOffset.Length + neighbourHeight * cellHeight / neighbourCount;
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/TerrainTunnelLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainTunnelLayer.cs
@@ -42,6 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void WorldLoaded(World world, WorldRenderer wr)
 		{
 			var domainIndex = world.WorldActor.Trait<DomainIndex>();
+			var cellHeight = world.Map.CellHeightStep.Length;
 			foreach (var tti in world.WorldActor.Info.TraitInfos<TerrainTunnelInfo>())
 			{
 				enabled = true;
@@ -53,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 					terrainIndices[uv] = terrain;
 
 					var pos = map.CenterOfCell(c);
-					cellCenters[uv] = pos - new WVec(0, 0, pos.Z - 512 * tti.Height);
+					cellCenters[uv] = pos - new WVec(0, 0, pos.Z - cellHeight * tti.Height);
 				}
 
 				var portal = tti.PortalCells();


### PR DESCRIPTION
These were not updated in #13253.  This fixes the altitude drop when units cross a bridge / enter a tunnel / start flying.