### PR TITLE
Added a tooltip that displays the networth of the resource patch under cursor in the map editor

### DIFF
--- a/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
@@ -10,8 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
 
@@ -35,7 +33,10 @@ namespace OpenRA.Mods.Common.Widgets
 		readonly IResourceLayer resourceLayer;
 
 		public EditorActorPreview SelectedActor;
+
 		int2 worldPixel;
+		CPos previousCellUnderCursor = CPos.Zero;
+		int resourcePatchUnderCursorNetworth;
 
 		public EditorDefaultBrush(EditorViewportControllerWidget editorWidget, WorldRenderer wr)
 		{
@@ -75,10 +76,18 @@ namespace OpenRA.Mods.Common.Widgets
 			var underCursor = editorLayer.PreviewsAt(worldPixel).MinByOrDefault(CalculateActorSelectionPriority);
 			var resourceUnderCursor = resourceLayer?.GetResource(cell).Type;
 
+			var mapResources = world.Map.Resources;
+
 			if (underCursor != null)
 				editorWidget.SetTooltip(underCursor.Tooltip);
-			else if (resourceUnderCursor != null)
-				editorWidget.SetTooltip(resourceUnderCursor);
+			else if (mapResources.Contains(cell) && mapResources[cell].Type != 0)
+			{
+				if (cell != previousCellUnderCursor)
+					resourcePatchUnderCursorNetworth = resourceLayer.GetValueFromPatchAround(cell);
+
+				editorWidget.SetTooltip($"${resourcePatchUnderCursorNetworth}");
+				previousCellUnderCursor = cell;
+			}
 			else
 				editorWidget.SetTooltip(null);
 

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -299,5 +299,6 @@ namespace OpenRA.Mods.Common.Traits
 		void IResourceLayer.ClearResources(CPos cell) { ClearResources(cell); }
 		bool IResourceLayer.IsVisible(CPos cell) { return !world.FogObscures(cell); }
 		bool IResourceLayer.IsEmpty => resCells < 1;
+		int IResourceLayer.GetValueFromPatchAround(CPos cell) { return 0; }
 	}
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -685,6 +685,7 @@ namespace OpenRA.Mods.Common.Traits
 		event Action<CPos, string> CellChanged;
 		ResourceLayerContents GetResource(CPos cell);
 		int GetMaxDensity(string resourceType);
+		int GetValueFromPatchAround(CPos startCell);
 		bool CanAddResource(string resourceType, CPos cell, int amount = 1);
 		int AddResource(string resourceType, CPos cell, int amount = 1);
 		int RemoveResource(string resourceType, CPos cell, int amount = 1);


### PR DESCRIPTION
Closes https://github.com/OpenRA/OpenRA/issues/9477.