### PR TITLE
Add DisguisedAsCondition to Disguise

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -105,7 +105,6 @@ namespace OpenRA.Mods.Cnc.Traits
 	{
 		public ActorInfo AsActor { get; private set; }
 		public Player AsPlayer { get; private set; }
-		public string AsSprite { get; private set; }
 		public ITooltipInfo AsTooltipInfo { get; private set; }
 
 		public bool Disguised { get { return AsPlayer != null; } }
@@ -181,14 +180,12 @@ namespace OpenRA.Mods.Cnc.Traits
 				var targetDisguise = target.TraitOrDefault<Disguise>();
 				if (targetDisguise != null && targetDisguise.Disguised)
 				{
-					AsSprite = targetDisguise.AsSprite;
 					AsPlayer = targetDisguise.AsPlayer;
 					AsActor = targetDisguise.AsActor;
 					AsTooltipInfo = targetDisguise.AsTooltipInfo;
 				}
 				else
 				{
-					AsSprite = target.Trait<RenderSprites>().GetImage(target);
 					var tooltip = target.TraitsImplementing<ITooltip>().FirstOrDefault();
 					AsPlayer = tooltip.Owner;
 					AsActor = target.Info;
@@ -200,7 +197,6 @@ namespace OpenRA.Mods.Cnc.Traits
 				AsTooltipInfo = null;
 				AsPlayer = null;
 				AsActor = self.Info;
-				AsSprite = null;
 			}
 
 			HandleDisguise(oldEffectiveActor, oldEffectiveOwner, oldDisguiseSetting);
@@ -212,8 +208,6 @@ namespace OpenRA.Mods.Cnc.Traits
 			var oldEffectiveOwner = AsPlayer;
 			var oldDisguiseSetting = Disguised;
 
-			var renderSprites = actorInfo.TraitInfoOrDefault<RenderSpritesInfo>();
-			AsSprite = renderSprites == null ? null : renderSprites.GetImage(actorInfo, self.World.Map.Rules.Sequences, newOwner.Faction.InternalName);
 			AsPlayer = newOwner;
 			AsActor = actorInfo;
 			AsTooltipInfo = actorInfo.TraitInfos<TooltipInfo>().FirstOrDefault();

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -90,12 +90,20 @@ namespace OpenRA.Mods.Cnc.Traits
 			"Unload, Infiltrate, Demolish, Move.")]
 		public readonly RevealDisguiseType RevealDisguiseOn = RevealDisguiseType.Attack;
 
+		[Desc("Conditions to grant when disguised as specified actor.",
+			"A dictionary of [actor id]: [condition].")]
+		public readonly Dictionary<string, string> DisguisedAsConditions = new Dictionary<string, string>();
+
+		[GrantedConditionReference]
+		public IEnumerable<string> LinterConditions { get { return DisguisedAsConditions.Values; } }
+
 		public object Create(ActorInitializer init) { return new Disguise(init.Self, this); }
 	}
 
 	class Disguise : INotifyCreated, IEffectiveOwner, IIssueOrder, IResolveOrder, IOrderVoice, IRadarColorModifier, INotifyAttack,
 		INotifyDamage, INotifyUnload, INotifyDemolition, INotifyInfiltration, ITick
 	{
+		public ActorInfo AsActor { get; private set; }
 		public Player AsPlayer { get; private set; }
 		public string AsSprite { get; private set; }
 		public ITooltipInfo AsTooltipInfo { get; private set; }
@@ -108,6 +116,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		ConditionManager conditionManager;
 		int disguisedToken = ConditionManager.InvalidConditionToken;
+		int disguisedAsToken = ConditionManager.InvalidConditionToken;
 		CPos? lastPos;
 
 		public Disguise(Actor self, DisguiseInfo info)
@@ -161,8 +170,9 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public void DisguiseAs(Actor target)
 		{
-			var oldDisguiseSetting = Disguised;
+			var oldEffectiveActor = AsActor;
 			var oldEffectiveOwner = AsPlayer;
+			var oldDisguiseSetting = Disguised;
 
 			if (target != null)
 			{
@@ -173,6 +183,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				{
 					AsSprite = targetDisguise.AsSprite;
 					AsPlayer = targetDisguise.AsPlayer;
+					AsActor = targetDisguise.AsActor;
 					AsTooltipInfo = targetDisguise.AsTooltipInfo;
 				}
 				else
@@ -180,6 +191,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					AsSprite = target.Trait<RenderSprites>().GetImage(target);
 					var tooltip = target.TraitsImplementing<ITooltip>().FirstOrDefault();
 					AsPlayer = tooltip.Owner;
+					AsActor = target.Info;
 					AsTooltipInfo = tooltip.TooltipInfo;
 				}
 			}
@@ -187,36 +199,52 @@ namespace OpenRA.Mods.Cnc.Traits
 			{
 				AsTooltipInfo = null;
 				AsPlayer = null;
+				AsActor = self.Info;
 				AsSprite = null;
 			}
 
-			HandleDisguise(oldEffectiveOwner, oldDisguiseSetting);
+			HandleDisguise(oldEffectiveActor, oldEffectiveOwner, oldDisguiseSetting);
 		}
 
 		public void DisguiseAs(ActorInfo actorInfo, Player newOwner)
 		{
-			var oldDisguiseSetting = Disguised;
+			var oldEffectiveActor = AsActor;
 			var oldEffectiveOwner = AsPlayer;
+			var oldDisguiseSetting = Disguised;
 
 			var renderSprites = actorInfo.TraitInfoOrDefault<RenderSpritesInfo>();
 			AsSprite = renderSprites == null ? null : renderSprites.GetImage(actorInfo, self.World.Map.Rules.Sequences, newOwner.Faction.InternalName);
 			AsPlayer = newOwner;
+			AsActor = actorInfo;
 			AsTooltipInfo = actorInfo.TraitInfos<TooltipInfo>().FirstOrDefault();
 
-			HandleDisguise(oldEffectiveOwner, oldDisguiseSetting);
+			HandleDisguise(oldEffectiveActor, oldEffectiveOwner, oldDisguiseSetting);
 		}
 
-		void HandleDisguise(Player oldEffectiveOwner, bool oldDisguiseSetting)
+		void HandleDisguise(ActorInfo oldEffectiveActor, Player oldEffectiveOwner, bool oldDisguiseSetting)
 		{
 			foreach (var t in self.TraitsImplementing<INotifyEffectiveOwnerChanged>())
 				t.OnEffectiveOwnerChanged(self, oldEffectiveOwner, AsPlayer);
 
-			if (Disguised != oldDisguiseSetting && conditionManager != null)
+			if (conditionManager != null)
 			{
-				if (Disguised && disguisedToken == ConditionManager.InvalidConditionToken && !string.IsNullOrEmpty(info.DisguisedCondition))
-					disguisedToken = conditionManager.GrantCondition(self, info.DisguisedCondition);
-				else if (!Disguised && disguisedToken != ConditionManager.InvalidConditionToken)
-					disguisedToken = conditionManager.RevokeCondition(self, disguisedToken);
+				if (Disguised != oldDisguiseSetting)
+				{
+					if (Disguised && disguisedToken == ConditionManager.InvalidConditionToken && !string.IsNullOrEmpty(info.DisguisedCondition))
+						disguisedToken = conditionManager.GrantCondition(self, info.DisguisedCondition);
+					else if (!Disguised && disguisedToken != ConditionManager.InvalidConditionToken)
+						disguisedToken = conditionManager.RevokeCondition(self, disguisedToken);
+				}
+
+				if (AsActor != oldEffectiveActor)
+				{
+					if (disguisedAsToken != ConditionManager.InvalidConditionToken)
+						disguisedAsToken = conditionManager.RevokeCondition(self, disguisedAsToken);
+
+					string disguisedAsCondition;
+					if (info.DisguisedAsConditions.TryGetValue(AsActor.Name, out disguisedAsCondition))
+						disguisedAsToken = conditionManager.GrantCondition(self, disguisedAsCondition);
+				}
 			}
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/Render/WithDisguisingInfantryBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithDisguisingInfantryBody.cs
@@ -25,7 +25,9 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		readonly WithDisguisingInfantryBodyInfo info;
 		readonly Disguise disguise;
 		readonly RenderSprites rs;
-		string intendedSprite;
+		ActorInfo disguiseActor;
+		Player disguisePlayer;
+		string disguiseImage;
 
 		public WithDisguisingInfantryBody(ActorInitializer init, WithDisguisingInfantryBodyInfo info)
 			: base(init, info)
@@ -33,17 +35,26 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 			this.info = info;
 			rs = init.Self.Trait<RenderSprites>();
 			disguise = init.Self.Trait<Disguise>();
-			intendedSprite = disguise.AsSprite;
 		}
 
 		protected override void Tick(Actor self)
 		{
-			if (disguise.AsSprite != intendedSprite)
+			if (disguise.AsActor != disguiseActor || disguise.AsPlayer != disguisePlayer)
 			{
-				intendedSprite = disguise.AsSprite;
+				disguiseActor = disguise.AsActor;
+				disguisePlayer = disguise.AsPlayer;
+				disguiseImage = null;
+
+				if (disguiseActor != null)
+				{
+					var renderSprites = disguiseActor.TraitInfoOrDefault<RenderSpritesInfo>();
+					if (renderSprites != null)
+						disguiseImage = renderSprites.GetImage(disguiseActor, self.World.Map.Rules.Sequences, disguisePlayer.InternalName);
+				}
+
 				var sequence = DefaultAnimation.GetRandomExistingSequence(info.StandSequences, Game.CosmeticRandom);
 				if (sequence != null)
-					DefaultAnimation.ChangeImage(intendedSprite ?? rs.GetImage(self), sequence);
+					DefaultAnimation.ChangeImage(disguiseImage ?? rs.GetImage(self), sequence);
 				rs.UpdatePalette();
 			}
 


### PR DESCRIPTION
~~First commit fixes a part of #13765.~~

~~Second commit~~ adds DisguisedAsCondition to Disguise. Similiar to what Cargo has, you can make Disguised actor get a condition depending on what it disguised as. In the future WithDisguisingInfantryBody can be scrapped and replaced by these conditions, i keep it for now tho and only add support.

I added a TESTCASE for second commit, it makes it so Spy's eye icon will only be shown for Rifle, Gren, Rocket or Tanya and not other infantries.