### PR TITLE
Allow mods to override WithSpriteTurret.TurretOffset.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			t.QuantizedFacings = DefaultAnimation.CurrentSequence.Facings;
 		}
 
-		WVec TurretOffset(Actor self)
+		protected virtual WVec TurretOffset(Actor self)
 		{
 			if (!Info.Recoils)
 				return t.Position(self);


### PR DESCRIPTION
This allows mods to rely on stock turret logic while providing their own implementation how to correctly position the turret on the actor.

Example usage: For KKnD i cannot rely on a formula to position turrets right, i need the position set per-frame. Position however is for rendering only and has no impact on logic. I could copy the whole WithSpriteTurret class instead of overriding the method, but that would break other traits depending on this trait, requiring them to be copied as well etc. So this is far the most easy method to not change any core behavior, but allow my custom trait to use another placement calculation.
