### PR TITLE
IPv6 - Basic support.

### DIFF
--- a/OpenRA.Game/GlobalChat.cs
+++ b/OpenRA.Game/GlobalChat.cs
@@ -141,7 +141,7 @@ namespace OpenRA.Chat
 			{
 				try
 				{
-					client.Connect(Game.Settings.Chat.Hostname, Game.Settings.Chat.Port);
+					client.Connect(Game.Settings.Chat.Address.Host, Game.Settings.Chat.Address.Port);
 				}
 				catch (Exception e)
 				{
@@ -178,7 +178,7 @@ namespace OpenRA.Chat
 
 		void OnConnecting(object sender, EventArgs e)
 		{
-			AddNotification("Connecting to {0}:{1}...".F(Game.Settings.Chat.Hostname, Game.Settings.Chat.Port));
+			AddNotification("Connecting to {0}...".F(Game.Settings.Chat.Address.ToString()));
 			connectionStatus = ChatConnectionStatus.Connecting;
 		}
 

--- a/OpenRA.Game/Network/GameServer.cs
+++ b/OpenRA.Game/Network/GameServer.cs
@@ -63,6 +63,9 @@ namespace OpenRA.Network
 				}
 			}
 
+			if (!new ConnectionAddress(Address).IsValid)
+				IsCompatible = false;
+
 			var mapAvailable = Game.Settings.Game.AllowDownloading || Game.ModData.MapCache[Map].Status == MapStatus.Available;
 			IsJoinable = IsCompatible && State == 1 && mapAvailable;
 		}

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -28,8 +28,7 @@ namespace OpenRA.Network
 		public Session.Client LocalClient { get { return LobbyInfo.ClientWithIndex(Connection.LocalClientId); } }
 		public World World;
 
-		public readonly string Host;
-		public readonly int Port;
+		public readonly ConnectionAddress Address;
 		public readonly string Password = "";
 
 		public string ServerError = "Server is not responding";
@@ -68,10 +67,9 @@ namespace OpenRA.Network
 				Connection.Send(i, new List<byte[]>());
 		}
 
-		public OrderManager(string host, int port, string password, IConnection conn)
+		public OrderManager(ConnectionAddress address, string password, IConnection conn)
 		{
-			Host = host;
-			Port = port;
+			Address = address;
 			Password = password;
 			Connection = conn;
 			syncReport = new SyncReport(this);

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -35,8 +35,7 @@ namespace OpenRA.Server
 	{
 		public readonly string TwoHumansRequiredText = "This server requires at least two human players to start a match.";
 
-		public readonly IPAddress Ip;
-		public readonly int Port;
+		public readonly ConnectionAddress Address;
 		public readonly MersenneTwister Random = new MersenneTwister();
 		public readonly bool Dedicated;
 
@@ -121,10 +120,10 @@ namespace OpenRA.Server
 			Log.AddChannel("server", "server.log");
 
 			listener = new TcpListener(endpoint);
+			listener.Server.SetSocketOption(SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, false);
 			listener.Start();
 			var localEndpoint = (IPEndPoint)listener.LocalEndpoint;
-			Ip = localEndpoint.Address;
-			Port = localEndpoint.Port;
+			Address = new ConnectionAddress(localEndpoint.Address.ToString(), localEndpoint.Port);
 			Dedicated = dedicated;
 			Settings = settings;
 

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -16,6 +16,7 @@ using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using OpenRA.Graphics;
+using OpenRA.Network;
 using OpenRA.Traits;
 
 namespace OpenRA
@@ -322,8 +323,7 @@ namespace OpenRA
 
 	public class ChatSettings
 	{
-		public string Hostname = "irc.openra.net";
-		public int Port = 6667;
+		public ConnectionAddress Address = new ConnectionAddress("irc.openra.net", 6667);
 		public string Channel = "lobby";
 		public string QuitMessage = "Battle control terminated!";
 		public string TimestampFormat = "HH:mm";

--- a/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
@@ -15,6 +15,7 @@ using System.IO;
 using System.Linq;
 using OpenRA.FileFormats;
 using OpenRA.Mods.Common.Widgets.Logic;
+using OpenRA.Network;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.LoadScreens
@@ -69,7 +70,7 @@ namespace OpenRA.Mods.Common.LoadScreens
 					var host = parts[0];
 					var port = Exts.ParseIntegerInvariant(parts[1]);
 					Game.LoadShellMap();
-					Game.RemoteDirectConnect(host, port);
+					Game.RemoteDirectConnect(new ConnectionAddress(host, port));
 					return;
 				}
 			}

--- a/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
@@ -16,6 +16,7 @@ using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
 using BeaconLib;
+using OpenRA.Network;
 using OpenRA.Server;
 using S = OpenRA.Server.Server;
 
@@ -64,7 +65,7 @@ namespace OpenRA.Mods.Common.Server
 
 		public void ServerStarted(S server)
 		{
-			if (!server.Ip.Equals(IPAddress.Loopback) && LanGameBeacon != null)
+			if (!server.Address.Host.Equals("localhost") && LanGameBeacon != null)
 				LanGameBeacon.Start();
 		}
 
@@ -192,16 +193,16 @@ namespace OpenRA.Mods.Common.Server
 @"Game:
 	Id: {0}
 	Name: {1}
-	Address: {2}:{3}
-	State: {4}
-	Players: {5}
-	MaxPlayers: {6}
-	Bots: {7}
-	Spectators: {8}
-	Map: {9}
-	Mods: {10}@{11}
-	Protected: {12}".F(Platform.SessionGUID, settings.Name, server.Ip, settings.ListenPort, (int)server.State, numPlayers, numSlots, numBots, numSpectators,
-				server.Map.Uid, mod.Id, mod.Metadata.Version, passwordProtected);
+	Address: {2}
+	State: {3}
+	Players: {4}
+	MaxPlayers: {5}
+	Bots: {6}
+	Spectators: {7}
+	Map: {8}
+	Mods: {9}@{10}
+	Protected: {11}".F(Platform.SessionGUID, settings.Name, new ConnectionAddress(server.Address.Host, settings.ListenPort).ToString(), (int)server.State, numPlayers, numSlots,
+				numBots, numSpectators, server.Map.Uid, mod.Id, mod.Metadata.Version, passwordProtected);
 
 			LanGameBeacon.BeaconData = lanGameYaml;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 
 		[ObjectCreator.UseCtor]
-		public ConnectionLogic(Widget widget, string host, int port, Action onConnect, Action onAbort, Action<string> onRetry)
+		public ConnectionLogic(Widget widget, ConnectionAddress address, Action onConnect, Action onAbort, Action<string> onRetry)
 		{
 			this.onConnect = onConnect;
 			this.onAbort = onAbort;
@@ -61,18 +61,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			panel.Get<ButtonWidget>("ABORT_BUTTON").OnClick = () => { CloseWindow(); onAbort(); };
 
 			widget.Get<LabelWidget>("CONNECTING_DESC").GetText = () =>
-				"Connecting to {0}:{1}...".F(host, port);
+				"Connecting to {0}...".F(address.ToString());
 		}
 
-		public static void Connect(string host, int port, string password, Action onConnect, Action onAbort)
+		public static void Connect(ConnectionAddress address, string password, Action onConnect, Action onAbort)
 		{
-			Game.JoinServer(host, port, password);
-			Action<string> onRetry = newPassword => Connect(host, port, newPassword, onConnect, onAbort);
+			Game.JoinServer(address, password);
+			Action<string> onRetry = newPassword => Connect(address, newPassword, onConnect, onAbort);
 
 			Ui.OpenWindow("CONNECTING_PANEL", new WidgetArgs()
 			{
-				{ "host", host },
-				{ "port", port },
+				{ "address", address },
 				{ "onConnect", onConnect },
 				{ "onAbort", onAbort },
 				{ "onRetry", onRetry }
@@ -105,7 +104,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			widget.Get<LabelWidget>("CONNECTING_DESC").GetText = () =>
-				"Could not connect to {0}:{1}".F(orderManager.Host, orderManager.Port);
+				"Could not connect to {0}".F(orderManager.Address);
 
 			var connectionError = widget.Get<LabelWidget>("CONNECTION_ERROR");
 			connectionError.GetText = () => orderManager.ServerError;
@@ -165,7 +164,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			switchButton.OnClick = () =>
 			{
-				var launchCommand = "Launch.Connect=" + orderManager.Host + ":" + orderManager.Port;
+				var launchCommand = "Launch.Connect=" + orderManager.Address;
 				Game.SwitchToExternalMod(orderManager.ServerExternalMod, new[] { launchCommand }, () =>
 				{
 					orderManager.ServerError = "Failed to switch mod.";

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Linq;
+using OpenRA.Network;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
@@ -71,8 +72,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					// It's not clear why this is needed here, but not in the other places that load maps.
 					Game.RunAfterTick(() =>
 					{
-						ConnectionLogic.Connect(System.Net.IPAddress.Loopback.ToString(),
-							Game.CreateLocalServer(uid), "",
+						ConnectionLogic.Connect(Game.CreateLocalServer(uid),
+							"",
 							() => Game.LoadEditor(uid),
 							() => { Game.CloseServer(); onExit(); });
 					});

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					});
 				};
 
-				Action<string> onRetry = password => ConnectionLogic.Connect(om.Host, om.Port, password, onConnect, onExit);
+				Action<string> onRetry = password => ConnectionLogic.Connect(om.Address, password, onConnect, onExit);
 
 				var switchPanel = om.ServerExternalMod != null ? "CONNECTION_SWITCHMOD_PANEL" : "CONNECTIONFAILED_PANEL";
 				Ui.OpenWindow(switchPanel, new WidgetArgs()

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -246,7 +246,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			if (ip == null)
 				return "Unknown Host";
-			if (ip == IPAddress.Loopback.ToString())
+			if (ip == "localhost")
 				return "Local Host";
 			return ip;
 		}
@@ -532,7 +532,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var client = orderManager.LobbyInfo.ClientWithIndex(clientIndex);
 			var address = client != null ? client.IpAddress : "";
 			var lc = orderManager.LocalClient;
-			if (lc != null && lc.Index == clientIndex && address == IPAddress.Loopback.ToString())
+			if (lc != null && lc.Index == clientIndex && address == "localhost")
 			{
 				var externalIP = UPnP.ExternalIP;
 				if (externalIP != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -17,6 +17,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
+using OpenRA.Network;
 using OpenRA.Primitives;
 using OpenRA.Widgets;
 
@@ -84,8 +85,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					{ "onStart", RemoveShellmapUI },
 					{ "onExit", () => SwitchMenu(MenuType.Main) },
-					{ "directConnectHost", null },
-					{ "directConnectPort", 0 },
+					{ "directConnectAddress", null },
 				});
 			};
 
@@ -311,22 +311,20 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 		}
 
-		void OnRemoteDirectConnect(string host, int port)
+		void OnRemoteDirectConnect(ConnectionAddress address)
 		{
 			SwitchMenu(MenuType.None);
 			Ui.OpenWindow("MULTIPLAYER_PANEL", new WidgetArgs
 			{
 				{ "onStart", RemoveShellmapUI },
 				{ "onExit", () => SwitchMenu(MenuType.Main) },
-				{ "directConnectHost", host },
-				{ "directConnectPort", port },
+				{ "directConnectAddress", address },
 			});
 		}
 
 		void LoadMapIntoEditor(string uid)
 		{
-			ConnectionLogic.Connect(IPAddress.Loopback.ToString(),
-				Game.CreateLocalServer(uid),
+			ConnectionLogic.Connect(Game.CreateLocalServer(uid),
 				"",
 				() => { Game.LoadEditor(uid); },
 				() => { Game.CloseServer(); SwitchMenu(MenuType.MapEditor); });
@@ -447,8 +445,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Game.Settings.Server.Map = map;
 			Game.Settings.Save();
 
-			ConnectionLogic.Connect(IPAddress.Loopback.ToString(),
-				Game.CreateLocalServer(map),
+			ConnectionLogic.Connect(Game.CreateLocalServer(map),
 				"",
 				OpenSkirmishLobbyPanel,
 				() => { Game.CloseServer(); SwitchMenu(MenuType.Main); });

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Net;
+using OpenRA.Network;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
@@ -147,7 +148,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return;
 			}
 
-			ConnectionLogic.Connect(IPAddress.Loopback.ToString(), Game.Settings.Server.ListenPort, password, onCreate, onExit);
+			ConnectionLogic.Connect(new ConnectionAddress("localhost", Game.Settings.Server.ListenPort), password, onCreate, onExit);
 		}
 	}
 }


### PR DESCRIPTION
This changes **do not affect / invalidate** the discussion https://github.com/OpenRA/OpenRA/issues/13125 which is about implementing server - masterserver - client communication and session management.
This changes make the engine listen on incomming ipv6 connections too, which can be joined by using the direct-connect feature. This is extremely useful for testing in-development mods currently while the discussion mentioned above is not over and implemented yet.

Note: I am unable to test wether this will break anything on environments where IPv6 is not available at all and only IPv4 is available, as i do not have this environment. So it would be nice if someone could verify wether the default behavior still works.