### PR TITLE
Spatially partition some selection/overlay renderables

### DIFF
--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Graphics
 				palettes[name].Palette = pal;
 		}
 
-		List<IFinalizedRenderable> GenerateRenderables(IEnumerable<Actor> actorsInBox)
+		List<IFinalizedRenderable> GenerateRenderables(HashSet<Actor> actorsInBox)
 		{
 			var actors = actorsInBox.Append(World.WorldActor);
 			if (World.RenderPlayer != null)
@@ -126,7 +126,7 @@ namespace OpenRA.Graphics
 			return renderables;
 		}
 
-		List<IFinalizedRenderable> GenerateOverlayRenderables(IEnumerable<Actor> actorsInBox)
+		List<IFinalizedRenderable> GenerateOverlayRenderables(HashSet<Actor> actorsInBox)
 		{
 			var aboveShroud = World.ActorsWithTrait<IRenderAboveShroud>()
 				.Where(a => a.Actor.IsInWorld && !a.Actor.Disposed && (!a.Trait.SpatiallyPartitionable || actorsInBox.Contains(a.Actor)))
@@ -171,7 +171,7 @@ namespace OpenRA.Graphics
 
 			RefreshPalette();
 
-			var onScreenActors = World.ScreenMap.RenderableActorsInBox(Viewport.TopLeft, Viewport.BottomRight);
+			var onScreenActors = World.ScreenMap.RenderableActorsInBox(Viewport.TopLeft, Viewport.BottomRight).ToHashSet();
 			var renderables = GenerateRenderables(onScreenActors);
 			var bounds = Viewport.GetScissorBounds(World.Type != WorldType.Editor);
 			Game.Renderer.EnableScissor(bounds);

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -343,8 +343,18 @@ namespace OpenRA.Traits
 
 	public interface IRenderAboveWorld { void RenderAboveWorld(Actor self, WorldRenderer wr); }
 	public interface IRenderShroud { void RenderShroud(Shroud shroud, WorldRenderer wr); }
-	public interface IRenderAboveShroud { IEnumerable<IRenderable> RenderAboveShroud(Actor self, WorldRenderer wr); }
-	public interface IRenderAboveShroudWhenSelected { IEnumerable<IRenderable> RenderAboveShroud(Actor self, WorldRenderer wr); }
+
+	public interface IRenderAboveShroud
+	{
+		IEnumerable<IRenderable> RenderAboveShroud(Actor self, WorldRenderer wr);
+		bool SpatiallyPartitionable { get; }
+	}
+
+	public interface IRenderAboveShroudWhenSelected
+	{
+		IEnumerable<IRenderable> RenderAboveShroud(Actor self, WorldRenderer wr);
+		bool SpatiallyPartitionable { get; }
+	}
 
 	public interface ITargetableInfo : ITraitInfoInterface
 	{

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -156,6 +156,8 @@ namespace OpenRA.Mods.Cnc.Traits
 					WVec.Zero, -511, pal, 1f, true);
 		}
 
+		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return false; } }
+
 		class MinefieldOrderGenerator : IOrderGenerator
 		{
 			readonly List<Actor> minelayers;

--- a/OpenRA.Mods.Cnc/Traits/Render/RenderJammerCircle.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/RenderJammerCircle.cs
@@ -60,5 +60,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					Color.FromArgb(96, Color.Black));
 			}
 		}
+
+		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return false; } }
 	}
 }

--- a/OpenRA.Mods.Cnc/Traits/Render/RenderShroudCircle.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/RenderShroudCircle.cs
@@ -56,5 +56,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			return RangeCircleRenderables(self, wr);
 		}
+
+		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return false; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
@@ -99,6 +99,8 @@ namespace OpenRA.Mods.Common.Traits
 			return RangeCircleRenderables(wr);
 		}
 
+		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return false; } }
+
 		float ISelectionBar.GetValue()
 		{
 			// Visible to player and allies

--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -83,6 +83,8 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
+		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return false; } }
+
 		void INotifyBecomingIdle.OnBecomingIdle(Actor a)
 		{
 			if (a.IsIdle)

--- a/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
@@ -97,5 +97,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var aiSquadInfo = "{0}, {1}".F(squad.Type, squad.TargetActor);
 			yield return new TextRenderable(font, self.CenterPosition + offset, 0, color, aiSquadInfo);
 		}
+
+		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return true; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/RenderDetectionCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDetectionCircle.cs
@@ -69,6 +69,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 				info.ContrastColor);
 		}
 
+		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return false; } }
+
 		void ITick.Tick(Actor self)
 		{
 			lineAngle += info.UpdateLineTick;

--- a/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
@@ -112,5 +112,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			return RangeCircleRenderables(wr);
 		}
+
+		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return false; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
@@ -82,6 +82,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return DrawDecorations(self, wr);
 		}
 
+		bool IRenderAboveShroud.SpatiallyPartitionable { get { return true; } }
+
 		IEnumerable<IRenderable> DrawDecorations(Actor self, WorldRenderer wr)
 		{
 			var selected = self.World.Selection.Contains(self);

--- a/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
@@ -92,6 +92,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return Info.RequiresSelection ? RenderInner(self, wr) : SpriteRenderable.None;
 		}
 
+		bool IRenderAboveShroud.SpatiallyPartitionable { get { return true; } }
+		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return true; } }
+
 		IEnumerable<IRenderable> RenderInner(Actor self, WorldRenderer wr)
 		{
 			if (IsTraitDisabled || self.IsDead || !self.IsInWorld || Anim == null)

--- a/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
@@ -97,6 +97,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return RenderRangeCircle(self, wr);
 		}
 
+		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return false; } }
+
 		void IRenderAboveWorld.RenderAboveWorld(Actor self, WorldRenderer wr)
 		{
 			if (Info.Visible == RangeCircleVisibility.Always && Visible)

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
@@ -62,6 +62,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 				yield return r;
 		}
 
+		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return true; } }
+
 		IEnumerable<IRenderable> DrawControlGroup(Actor self, WorldRenderer wr, PaletteReference palette)
 		{
 			var group = self.World.Selection.GetControlGroupForActor(self);

--- a/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
@@ -79,6 +79,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 				yield return r;
 		}
 
+		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return true; } }
+
 		IEnumerable<IRenderable> DrawControlGroup(Actor self, WorldRenderer wr)
 		{
 			var group = self.World.Selection.GetControlGroupForActor(self);

--- a/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
@@ -88,6 +88,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return Info.RequiresSelection ? RenderInner(self, wr) : SpriteRenderable.None;
 		}
 
+		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return true; } }
+
 		IEnumerable<IRenderable> RenderInner(Actor self, WorldRenderer wr)
 		{
 			if (IsTraitDisabled || self.IsDead || !self.IsInWorld)


### PR DESCRIPTION
These were drawn regardless of viewport position before.

On my machine, in bleed RA, the difference between 200 selected actors on-screen and 200 off-screen was only 1.2-1.5 ms per Render tick on bleed, with this PR that increases to around 5ms, dropping render time per render tick from over 10 to around 5.5 ms with 200 off-screen selected actors.

The primary gain possibly comes from the skipped FogObscures checks, rather than the skipped rendering itself, but the gains are potentially significant either way.

Note: I didn't feel like dealing with calculating bounds for target lines or range circles (probably wouldn't be worth the effort anyway), so I concentrated on overlays that are drawn on top of or very close to the selected actor.

Closes #12111.