### PR TITLE
Require explicit implementation on more interfaces

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -193,11 +193,6 @@ namespace OpenRA.Traits
 		bool HasFogVisibility();
 	}
 
-	public interface ITargetableCells
-	{
-		IEnumerable<Pair<CPos, SubCell>> TargetableCells();
-	}
-
 	public interface IOccupySpaceInfo : ITraitInfoInterface
 	{
 		IReadOnlyDictionary<CPos, SubCell> OccupiedCells(ActorInfo info, CPos location, SubCell subCell = SubCell.Any);

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -94,6 +94,7 @@ namespace OpenRA.Traits
 
 	[RequireExplicitImplementation]
 	public interface ITick { void Tick(Actor self); }
+	[RequireExplicitImplementation]
 	public interface ITickRender { void TickRender(WorldRenderer wr, Actor self); }
 	public interface IRender { IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr); }
 

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -354,6 +354,7 @@ namespace OpenRA.Traits
 		bool RequiresForceFire { get; }
 	}
 
+	[RequireExplicitImplementation]
 	public interface ITargetablePositions
 	{
 		IEnumerable<WPos> TargetablePositions(Actor self);

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -134,7 +134,9 @@ namespace OpenRA.Traits
 	[RequireExplicitImplementation]
 	public interface INotifyCreated { void Created(Actor self); }
 
+	[RequireExplicitImplementation]
 	public interface INotifyAddedToWorld { void AddedToWorld(Actor self); }
+	[RequireExplicitImplementation]
 	public interface INotifyRemovedFromWorld { void RemovedFromWorld(Actor self); }
 
 	[RequireExplicitImplementation]

--- a/OpenRA.Mods.Cnc/Traits/EnergyWall.cs
+++ b/OpenRA.Mods.Cnc/Traits/EnergyWall.cs
@@ -103,7 +103,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			return !active;
 		}
 
-		public override void AddedToWorld(Actor self)
+		protected override void AddedToWorld(Actor self)
 		{
 			base.AddedToWorld(self);
 			blockedPositions = info.Tiles(self.Location);

--- a/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			bi = self.Info.TraitInfo<BuildingInfo>();
 		}
 
-		public void AddedToWorld(Actor self)
+		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
 			var rows = info.HasMinibib ? 1 : 2;
 			var width = bi.Dimensions.X;
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		public void RemovedFromWorld(Actor self)
+		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
 		{
 			foreach (var a in anims)
 				rs.Remove(a);

--- a/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
+++ b/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
@@ -322,7 +322,7 @@ namespace OpenRA.Mods.Common.Scripting
 			}
 		}
 
-		public void AddedToWorld(Actor self)
+		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
 			if (world.Disposing)
 				return;
@@ -341,7 +341,7 @@ namespace OpenRA.Mods.Common.Scripting
 			}
 		}
 
-		public void RemovedFromWorld(Actor self)
+		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
 		{
 			if (world.Disposing)
 				return;

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -287,7 +287,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells() { return occupiedCells; }
 
-		public IEnumerable<Pair<CPos, SubCell>> TargetableCells() { return targetableCells; }
+		IEnumerable<Pair<CPos, SubCell>> ITargetableCells.TargetableCells() { return targetableCells; }
 
 		void INotifyCreated.Created(Actor self)
 		{

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -295,7 +295,12 @@ namespace OpenRA.Mods.Common.Traits
 				NotifyBuildingComplete(self);
 		}
 
-		public virtual void AddedToWorld(Actor self)
+		void INotifyAddedToWorld.AddedToWorld(Actor self)
+		{
+			AddedToWorld(self);
+		}
+
+		protected virtual void AddedToWorld(Actor self)
 		{
 			if (Info.RemoveSmudgesOnBuild)
 				RemoveSmudges();

--- a/OpenRA.Mods.Common/Traits/Buildings/Gate.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Gate.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.Traits
 			return !self.IsDisabled() && BuildComplete && blocking.AppearsFriendlyTo(self);
 		}
 
-		public override void AddedToWorld(Actor self)
+		protected override void AddedToWorld(Actor self)
 		{
 			base.AddedToWorld(self);
 			blockedPositions = Info.Tiles(self.Location);

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 				s.Info.Type.DrawCombatOverlay(wr, wcr, self);
 
 			var tc = Color.Lime;
-			var positions = activeShapes.SelectMany(tp => tp.TargetablePositions(self));
+			var positions = Target.FromActor(self).Positions;
 			foreach (var p in positions)
 			{
 				var center = wr.Screen3DPosition(p);

--- a/OpenRA.Mods.Common/Traits/Conditions/ProximityExternalCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ProximityExternalCondition.cs
@@ -62,13 +62,13 @@ namespace OpenRA.Mods.Common.Traits
 			cachedVRange = WDist.Zero;
 		}
 
-		public void AddedToWorld(Actor self)
+		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
 			cachedPosition = self.CenterPosition;
 			proximityTrigger = self.World.ActorMap.AddProximityTrigger(cachedPosition, cachedRange, cachedVRange, ActorEntered, ActorExited);
 		}
 
-		public void RemovedFromWorld(Actor self)
+		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
 		{
 			self.World.ActorMap.RemoveProximityTrigger(proximityTrigger);
 		}

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -212,7 +212,7 @@ namespace OpenRA.Mods.Common.Traits
 			return self.IsAtGroundLevel() && crushClasses.Contains(info.CrushClass);
 		}
 
-		public void AddedToWorld(Actor self)
+		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
 			self.World.AddToMaps(self, this);
 
@@ -221,7 +221,7 @@ namespace OpenRA.Mods.Common.Traits
 				cs.IncrementCrates();
 		}
 
-		public void RemovedFromWorld(Actor self)
+		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
 		{
 			self.World.RemoveFromMaps(self, this);
 

--- a/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 			health = self.Trait<Health>();
 		}
 
-		public void AddedToWorld(Actor self)
+		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
 			if (!Info.StartOnThreshold)
 				return;

--- a/OpenRA.Mods.Common/Traits/HitShape.cs
+++ b/OpenRA.Mods.Common/Traits/HitShape.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 			base.Created(self);
 		}
 
-		public IEnumerable<WPos> TargetablePositions(Actor self)
+		IEnumerable<WPos> ITargetablePositions.TargetablePositions(Actor self)
 		{
 			if (IsTraitDisabled)
 				yield break;

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -118,12 +118,12 @@ namespace OpenRA.Mods.Common.Traits
 			self.World.UpdateMaps(self, this);
 		}
 
-		public void AddedToWorld(Actor self)
+		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
 			self.World.AddToMaps(self, this);
 		}
 
-		public void RemovedFromWorld(Actor self)
+		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
 		{
 			self.World.RemoveFromMaps(self, this);
 		}

--- a/OpenRA.Mods.Common/Traits/Immobile.cs
+++ b/OpenRA.Mods.Common/Traits/Immobile.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 		public WPos CenterPosition { get { return position; } }
 		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells() { return occupied; }
 
-		public void AddedToWorld(Actor self)
+		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
 			self.World.ActorMap.AddInfluence(self, this);
 			self.World.ActorMap.AddPosition(self, this);
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 				self.World.ScreenMap.Add(self);
 		}
 
-		public void RemovedFromWorld(Actor self)
+		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
 		{
 			self.World.ActorMap.RemoveInfluence(self, this);
 			self.World.ActorMap.RemovePosition(self, this);

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -569,12 +569,12 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public void AddedToWorld(Actor self)
+		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
 			self.World.AddToMaps(self, this);
 		}
 
-		public void RemovedFromWorld(Actor self)
+		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
 		{
 			self.World.RemoveFromMaps(self, this);
 		}

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public void TickRender(WorldRenderer wr, Actor self)
+		void ITickRender.TickRender(WorldRenderer wr, Actor self)
 		{
 			IRenderable[] renderables = null;
 			for (var playerIndex = 0; playerIndex < frozenStates.Count; playerIndex++)

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/MenuPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/MenuPaletteEffect.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 			to = type;
 		}
 
-		public void TickRender(WorldRenderer wr, Actor self)
+		void ITickRender.TickRender(WorldRenderer wr, Actor self)
 		{
 			if (remainingFrames > 0)
 				remainingFrames--;

--- a/OpenRA.Mods.Common/Traits/ParaDrop.cs
+++ b/OpenRA.Mods.Common/Traits/ParaDrop.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.Traits
 			return actorToDrop.Trait<IPositionable>().CanEnterCell(p);
 		}
 
-		public void RemovedFromWorld(Actor self)
+		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
 		{
 			OnRemovedFromWorld(self);
 		}

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -120,7 +120,8 @@ namespace OpenRA.Mods.Common.Traits
 			return true;
 		}
 
-		public void RemovedFromWorld(Actor self) { Unreserve(self); }
+		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self) { Unreserve(self); }
+
 		public void Unreserve(Actor self)
 		{
 			if (ReservedCargo == null)

--- a/OpenRA.Mods.Common/Traits/Power/Power.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Power.cs
@@ -43,9 +43,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override void TraitEnabled(Actor self) { PlayerPower.UpdateActor(self); }
 		protected override void TraitDisabled(Actor self) { PlayerPower.UpdateActor(self); }
-		public void AddedToWorld(Actor self) { PlayerPower.UpdateActor(self); }
-		public void RemovedFromWorld(Actor self) { PlayerPower.RemoveActor(self); }
-		public void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+
+		void INotifyAddedToWorld.AddedToWorld(Actor self) { PlayerPower.UpdateActor(self); }
+		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self) { PlayerPower.RemoveActor(self); }
+
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			PlayerPower.RemoveActor(self);
 			PlayerPower = newOwner.PlayerActor.Trait<PowerManager>();

--- a/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
@@ -155,7 +155,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				aat.SetDirty();
 		}
 
-		public void RemovedFromWorld(Actor self)
+		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
 		{
 			UpdateNeighbours(self);
 		}

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 				UpdateNeighbours(p.Footprint);
 		}
 
-		public void TickRender(WorldRenderer wr, Actor self)
+		void ITickRender.TickRender(WorldRenderer wr, Actor self)
 		{
 			if (wr.World.Type != WorldType.Editor)
 				return;

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -162,7 +162,7 @@ namespace OpenRA.Mods.Common.Traits
 			return t.Variants.Keys.Random(Game.CosmeticRandom);
 		}
 
-		public void TickRender(WorldRenderer wr, Actor self)
+		void ITickRender.TickRender(WorldRenderer wr, Actor self)
 		{
 			var remove = new List<CPos>();
 			foreach (var c in dirty)

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -181,7 +181,7 @@ namespace OpenRA.Mods.Common.Traits
 			dirty[loc] = tile;
 		}
 
-		public void TickRender(WorldRenderer wr, Actor self)
+		void ITickRender.TickRender(WorldRenderer wr, Actor self)
 		{
 			var remove = new List<CPos>();
 			foreach (var kv in dirty)

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -376,4 +376,10 @@ namespace OpenRA.Mods.Common.Traits
 		void OnAcceptingCash(Actor self, Actor donor);
 		void OnDeliveringCash(Actor self, Actor acceptor);
 	}
+
+	[RequireExplicitImplementation]
+	public interface ITargetableCells
+	{
+		IEnumerable<Pair<CPos, SubCell>> TargetableCells();
+	}
 }

--- a/OpenRA.Mods.D2k/Traits/Buildings/LaysTerrain.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/LaysTerrain.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.D2k.Traits
 			buildingInfo = self.Info.TraitInfo<BuildingInfo>();
 		}
 
-		public void AddedToWorld(Actor self)
+		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
 			var map = self.World.Map;
 

--- a/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.D2k.Traits
 			dirty[cell] = new Sprite(s.Sheet, s.Bounds, s.ZRamp, float2.Zero, s.Channel, s.BlendMode);
 		}
 
-		public void TickRender(WorldRenderer wr, Actor self)
+		void ITickRender.TickRender(WorldRenderer wr, Actor self)
 		{
 			var remove = new List<CPos>();
 			foreach (var kv in dirty)


### PR DESCRIPTION
While there are still a lot of interfaces to migrate even after this PR, with `INotifyAddedToWorld` and `INotifyRemovedFromWorld` we should now be covering most (possibly all) of the common ones (not counting those that will go away eventually like `INotifyBuildComplete` and `IDisable`).