### PR TITLE
Game no longer crashes if no ResourceLayer is used.

### DIFF
--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -230,10 +230,10 @@ namespace OpenRA.Mods.Common.Orders
 				foreach (var r in previewRenderables)
 					yield return r;
 
-				var res = world.WorldActor.Trait<ResourceLayer>();
+				var res = world.WorldActor.TraitOrDefault<ResourceLayer>();
 				var isCloseEnough = buildingInfo.IsCloseEnoughToBase(world, world.LocalPlayer, building, topLeft);
 				foreach (var t in buildingInfo.Tiles(topLeft))
-					cells.Add(t, MakeCellType(isCloseEnough && world.IsCellBuildable(t, buildingInfo) && res.GetResource(t) == null));
+					cells.Add(t, MakeCellType(isCloseEnough && world.IsCellBuildable(t, buildingInfo) && (res == null || res.GetResource(t) == null)));
 			}
 
 			var cellPalette = wr.Palette(placeBuildingInfo.Palette);

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
@@ -43,9 +43,9 @@ namespace OpenRA.Mods.Common.Traits
 			if (building.AllowInvalidPlacement)
 				return true;
 
-			var res = world.WorldActor.Trait<ResourceLayer>();
+			var res = world.WorldActor.TraitOrDefault<ResourceLayer>();
 			return building.Tiles(topLeft).All(
-				t => world.Map.Contains(t) && res.GetResource(t) == null &&
+				t => world.Map.Contains(t) && (res == null || res.GetResource(t) == null) &&
 					world.IsCellBuildable(t, building, toIgnore));
 		}
 


### PR DESCRIPTION
For my mod i have a totally different resource system and do not need the resource layer at all.
However these two Traits do not work if the ResourceLayer trait is not present.
Their behavior should be unaffected whether this trait is enabled or not, as its absence should result in the same behavior as its use-case.
Adding the ResourceLayer would require to also add ResourceType which again requires you to define at last one type, etc...
This huge stack of Traits and configuration could be prevented by simply loosening these two requirements.
The other traits which depend on the ResourceLayer trait were not changed, because they are actual resource based traits (like the harvester code) .