### PR TITLE
Implemented a percentual chance to play the ImpactSound

### DIFF
--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -38,6 +38,9 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("List of sounds that can be played on impact.")]
 		public readonly string[] ImpactSounds = new string[0];
 
+		[Desc("Chance of impact sound to play.")]
+		public readonly int ImpactSoundChance = 100;
+
 		[Desc("Consider explosion above this altitude an air explosion.",
 			"If that's the case, this warhead will consider the explosion position to have the 'Air' TargetType (in addition to any nearby actor's TargetTypes).")]
 		public readonly WDist AirThreshold = new WDist(128);
@@ -135,7 +138,7 @@ namespace OpenRA.Mods.Common.Warheads
 			}
 
 			var impactSound = ImpactSounds.RandomOrDefault(Game.CosmeticRandom);
-			if (impactSound != null)
+			if (impactSound != null && Game.CosmeticRandom.Next(0, 100) < ImpactSoundChance)
 				Game.Sound.Play(SoundType.World, impactSound, pos);
 		}
 


### PR DESCRIPTION
This allows to play the impact sound with a specific chance, usefull for guns like extremely fast shooting machineguns which have a ricochet sound.