### PR TITLE
Fix the map editor crashing on invisible actors

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -106,7 +106,9 @@ namespace OpenRA.Mods.Common.Traits
 
 			var preview = new EditorActorPreview(worldRenderer, id, reference, owner);
 			previews.Add(preview);
-			screenMap.Add(preview, preview.Bounds);
+
+			if (!preview.Bounds.IsEmpty)
+				screenMap.Add(preview, preview.Bounds);
 
 			foreach (var kv in preview.Footprint)
 			{


### PR DESCRIPTION
Testcase: Open `allies03b` in the map editor or place a powerproxy in any map before opening the map editor.

We also don't use the returned value of `Add`, so I removed that.