### PR TITLE
Fix the "Secure the convoy's path" objective being completed without securing a path

### DIFF
--- a/mods/ra/maps/allies-02/allies02.lua
+++ b/mods/ra/maps/allies-02/allies02.lua
@@ -82,7 +82,10 @@ RunInitialActivities = function()
 	Harvester.FindResources()
 	Trigger.OnKilled(Harvester, function() HarvesterKilled = true end)
 
-	Trigger.OnAllKilled(PathGuards, SendTrucks)
+	Trigger.OnAllKilled(PathGuards, function()
+		player.MarkCompletedObjective(SecureObjective)
+		SendTrucks()
+	end)
 
 	if InfantryTypes then
 		Trigger.AfterDelay(InfantryDelay, InfantryProduction)
@@ -202,7 +205,6 @@ SendTrucks = function()
 
 		ticked = 0
 		ConvoyObjective = player.AddPrimaryObjective("Escort the convoy.")
-		player.MarkCompletedObjective(SecureObjective)
 
 		Media.PlaySpeechNotification(player, "ConvoyApproaching")
 		Trigger.AfterDelay(DateTime.Seconds(3), function()


### PR DESCRIPTION
Just start `allies02` with the `Real tough guy` difficulty (timer is set very low) and wait for the convoy to approach. The objective gets completed without even securing the area... Instead this now only happens after you killed all enemy forces on the path.