### PR TITLE
Fix the devastator lint warnings

### DIFF
--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -322,7 +322,7 @@ devastator:
 		TurnSpeed: 3
 		Speed: 31
 		Crushes: crate, infantry, spicebloom, wall
-		RequiresCondition: !overload
+		RequiresCondition: !overload && !notmobile
 	RevealsShroud:
 		Range: 4c768
 	Armament:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -323,6 +323,8 @@ devastator:
 		Speed: 31
 		Crushes: crate, infantry, spicebloom, wall
 		RequiresCondition: !overload && !notmobile
+	AutoCarryable:
+		RequiresCondition: !overload
 	RevealsShroud:
 		Range: 4c768
 	Armament:


### PR DESCRIPTION
`OpenRA.Utility(1,1): Warning: Actor type `devastator` grants conditions that are not consumed: notmobile`