### PR TITLE
DefaultSpriteSequence now allows derived classes to enhance sprites.

### DIFF
--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Graphics
 	public class DefaultSpriteSequence : ISpriteSequence
 	{
 		static readonly WDist DefaultShadowSpriteZOffset = new WDist(-5);
-		readonly Sprite[] sprites;
+		protected Sprite[] sprites;
 		readonly bool reverseFacings, transpose, useClassicFacingFudge;
 
 		protected readonly ISpriteSequenceLoader Loader;


### PR DESCRIPTION
This allows mods to extend the sprite sequence and access the sprites, without the need to duplicate all of the default class code.