### PR TITLE
Remove directory creation side effect from Platform.SupportDir.

### DIFF
--- a/OpenRA.Game/ExternalMods.cs
+++ b/OpenRA.Game/ExternalMods.cs
@@ -123,9 +123,6 @@ namespace OpenRA
 
 			foreach (var source in sources.Distinct())
 			{
-				if (!Directory.Exists(source))
-					continue;
-
 				var metadataPath = Path.Combine(source, "ModMetadata");
 
 				try

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -93,9 +93,6 @@ namespace OpenRA
 					break;
 			}
 
-			if (!Directory.Exists(dir))
-				Directory.CreateDirectory(dir);
-
 			return dir + Path.DirectorySeparatorChar;
 		}
 


### PR DESCRIPTION
Fixes #14131.

This was old dead code, and removing it appears to have no regressions aside from the support dir metadata registration which is fixed here.

Things I have tested:
* Running the game with no support dir (support dir is created when needed)
* Installing the deb package (support dir is not created, system metadata installed)
* Installing the Windows package (support dir is not created, system metadata installed)
* Running lint tests (behaves as expected):
  * ~~Support dir *is* created on current branch, but only because it is based before #13938.~~ 
  * When rebased on a fixed version of #14136 the support dir is *not* created.
* Running unit tests (support dir is not created, runs as expected)
* Running mod metadata registration / deregistration (support dir is created when needed)
