### PR TITLE
Add a 2500 character limit to chat messages.

### DIFF
--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -16,8 +16,9 @@ using OpenRA.Traits;
 
 namespace OpenRA.Network
 {
-	static class UnitOrders
+	public static class UnitOrders
 	{
+		public const int ChatMessageMaxLength = 2500;
 		const string ServerChatName = "Battlefield Control";
 
 		static Player FindPlayerByClient(this World world, Session.Client c)
@@ -28,7 +29,7 @@ namespace OpenRA.Network
 				p => (p.ClientIndex == c.Index && p.PlayerReference.Playable));
 		}
 
-		public static void ProcessOrder(OrderManager orderManager, World world, int clientId, Order order)
+		internal static void ProcessOrder(OrderManager orderManager, World world, int clientId, Order order)
 		{
 			if (world != null)
 			{
@@ -42,6 +43,12 @@ namespace OpenRA.Network
 				case "Chat":
 					{
 						var client = orderManager.LobbyInfo.ClientWithIndex(clientId);
+
+						// Cut chat messages to the hard limit to avoid exploits
+						var message = order.TargetString;
+						if (message.Length > ChatMessageMaxLength)
+							message = order.TargetString.Substring(0, ChatMessageMaxLength);
+
 						if (client != null)
 						{
 							var player = world != null ? world.FindPlayerByClient(client) : null;
@@ -51,10 +58,10 @@ namespace OpenRA.Network
 							if (orderManager.LocalClient != null && client != orderManager.LocalClient && client.Team > 0 && client.Team == orderManager.LocalClient.Team)
 								suffix += " (Ally)";
 
-							Game.AddChatLine(client.Color.RGB, client.Name + suffix, order.TargetString);
+							Game.AddChatLine(client.Color.RGB, client.Name + suffix, message);
 						}
 						else
-							Game.AddChatLine(Color.White, "(player {0})".F(clientId), order.TargetString);
+							Game.AddChatLine(Color.White, "(player {0})".F(clientId), message);
 						break;
 					}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/GlobalChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GlobalChatLogic.cs
@@ -42,6 +42,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			inputBox.IsDisabled = () => Game.GlobalChat.ConnectionStatus != ChatConnectionStatus.Joined;
 			inputBox.OnEnterKey = EnterPressed;
 
+			// IRC protocol limits messages to 510 characters + CRLF
+			inputBox.MaxLength = 510;
+
 			var nickName = Game.GlobalChat.SanitizedName(Game.Settings.Player.Name);
 			var nicknameBox = widget.Get<TextFieldWidget>("NICKNAME_TEXTFIELD");
 			nicknameBox.Text = nickName;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -71,6 +71,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			chatMode.IsDisabled = () => disableTeamChat;
 
 			chatText = chatChrome.Get<TextFieldWidget>("CHAT_TEXTFIELD");
+			chatText.MaxLength = UnitOrders.ChatMessageMaxLength;
 			chatText.OnEnterKey = () =>
 			{
 				var team = teamChat && !disableTeamChat;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var team = teamChat && !disableTeamChat;
 				if (chatText.Text != "")
 				{
-					if (!chatText.Text.StartsWith("/"))
+					if (!chatText.Text.StartsWith("/", StringComparison.Ordinal))
 						orderManager.IssueOrder(Order.Chat(team, chatText.Text.Trim()));
 					else if (chatTraits != null)
 					{

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -469,6 +469,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			chatLabel = lobby.Get<LabelWidget>("LABEL_CHATTYPE");
 			var chatTextField = lobby.Get<TextFieldWidget>("CHAT_TEXTFIELD");
+			chatTextField.MaxLength = UnitOrders.ChatMessageMaxLength;
+
 			chatTextField.TakeKeyboardFocus();
 			chatTextField.OnEnterKey = () =>
 			{


### PR DESCRIPTION
Closes #14141, and is safe enough to take for prep.  We have a repro case for the freeze reported in that ticket thanks to @anjew175, which I will fix in a separate PR for Next + 1.  Even with that fix the rendering performance of the text is bad enough to warrant the limit here.

A simple way to test this is to generate an arbitrary message (using e.g. https://www.lipsum.com/) that is 10000 – 20000 characters long.