### PR TITLE
Improve WidgetUtils.WrapText performance on long lines.

### DIFF
--- a/OpenRA.Game/Widgets/WidgetUtils.cs
+++ b/OpenRA.Game/Widgets/WidgetUtils.cs
@@ -203,29 +203,29 @@ namespace OpenRA.Widgets
 				for (var i = 0; i < lines.Count; i++)
 				{
 					var line = lines[i];
-					var m = font.Measure(line);
-
-					if (m.X <= width)
+					if (font.Measure(line).X <= width)
 						continue;
 
-					var bestSpaceIndex = -1;
-					var start = line.Length - 1;
-
-					while (m.X > width)
+					// Scan forwards until we find the last word that fits
+					// This guarantees a small bound on the amount of string we need to search before a linebreak
+					var start = 0;
+					while (true)
 					{
-						var spaceIndex = line.LastIndexOf(' ', start);
+						var spaceIndex = line.IndexOf(' ', start);
 						if (spaceIndex == -1)
 							break;
-						bestSpaceIndex = spaceIndex;
 
-						start = spaceIndex - 1;
-						m = font.Measure(line.Substring(0, spaceIndex));
+						var fragmentWidth = font.Measure(line.Substring(0, spaceIndex)).X;
+						if (fragmentWidth > width)
+							break;
+
+						start = spaceIndex + 1;
 					}
 
-					if (bestSpaceIndex != -1)
+					if (start > 0)
 					{
-						lines[i] = line.Substring(0, bestSpaceIndex);
-						lines.Insert(i + 1, line.Substring(bestSpaceIndex + 1));
+						lines[i] = line.Substring(0, start - 1);
+						lines.Insert(i + 1, line.Substring(start));
 					}
 				}
 


### PR DESCRIPTION
Fixes the performance cliff that caused the freeze in #14141.

The word wrap algorithm was scanning backwards from the end of the string which is horrific for performance when the line of text is hundreds of times longer than the wrap width.  Scanning forwards instead places an upper bound on the number of iterations it needs to do before it terminates, fixing the issue and improving perf in the less extreme cases.

Testcase: paste a block of arbitrary text into the chat with and without the change: the results should be the same.