### PR TITLE
Added a workaround for open build service machine deployment

### DIFF
--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -40,10 +40,22 @@ namespace OpenRA
 	{
 		static void Main(string[] args)
 		{
-			Log.AddChannel("perf", null);
-			Log.AddChannel("debug", null);
+			// Avoid crashes when building and testing OpenRA in secured build VMs under Mono 5
+			// where the system isn't allowed to write into / root.
+			try
+			{
+				Log.AddChannel("perf", null);
+				Log.AddChannel("debug", null);
 
-			Game.InitializeSettings(Arguments.Empty);
+				// TODO: Don't rely on the MapCache, which requires the SheetBuilder and so forth
+				// as this will crash when the utility is run as root to install the mod metadata.
+				Game.InitializeSettings(Arguments.Empty);
+			}
+			catch (Exception e)
+			{
+				Console.WriteLine("Failed to initialize the commandline utility.");
+				Console.WriteLine(e);
+			}
 
 			var envModSearchPaths = Environment.GetEnvironmentVariable("MOD_SEARCH_PATHS");
 			var modSearchPaths = !string.IsNullOrWhiteSpace(envModSearchPaths) ?


### PR DESCRIPTION
Hopefully resolves https://github.com/OpenRA/OpenRA/issues/13922. I can't test it due to https://news.opensuse.org/2017/10/04/planned-downtime-to-affect-opensuse-services/ right now.

I tried other hacks with `bool utility` switches, but the whole architecture is so complex and interconnected that I had to give up.