### PR TITLE
Fix Helis facing target center instead of attacked position

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
@@ -62,10 +62,12 @@ namespace OpenRA.Mods.Common.Activities
 			if (IsCanceled || !target.IsValidFor(self))
 				return NextActivity;
 
+			var pos = self.CenterPosition;
+			var targetPos = attackHeli.GetTargetPosition(pos, target);
 			if (attackOnlyVisibleTargets && target.Type == TargetType.Actor && canHideUnderFog
 				&& !self.Owner.CanTargetActor(target.Actor))
 			{
-				var newTarget = Target.FromCell(self.World, self.World.Map.CellContaining(target.CenterPosition));
+				var newTarget = Target.FromCell(self.World, self.World.Map.CellContaining(targetPos));
 
 				Cancel(self);
 				self.SetTargetLine(newTarget, Color.Green);
@@ -76,7 +78,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (ammoPools.Any(x => !x.Info.SelfReloads && !x.HasAmmo()) && !attackHeli.HasAnyValidWeapons(target))
 				return ActivityUtils.SequenceActivities(new HeliReturnToBase(self, helicopter.Info.AbortOnResupply), this);
 
-			var dist = target.CenterPosition - self.CenterPosition;
+			var dist = targetPos - pos;
 
 			// Can rotate facing while ascending
 			var desiredFacing = dist.HorizontalLengthSquared != 0 ? dist.Yaw.Facing : helicopter.Facing;
@@ -86,11 +88,11 @@ namespace OpenRA.Mods.Common.Activities
 				return this;
 
 			// Fly towards the target
-			if (!target.IsInRange(self.CenterPosition, attackHeli.GetMaximumRangeVersusTarget(target)))
+			if (!target.IsInRange(pos, attackHeli.GetMaximumRangeVersusTarget(target)))
 				helicopter.SetPosition(self, helicopter.CenterPosition + helicopter.FlyStep(desiredFacing));
 
 			// Fly backwards from the target
-			if (target.IsInRange(self.CenterPosition, attackHeli.GetMinimumRangeVersusTarget(target)))
+			if (target.IsInRange(pos, attackHeli.GetMinimumRangeVersusTarget(target)))
 			{
 				// Facing 0 doesn't work with the following position change
 				var facing = 1;


### PR DESCRIPTION
Fixes a minor issue that was unfortunately overlooked during the playtest phase.

On bleed/release, armed helis face the target center even when shooting at the closest targetable position. Only noticable when attacking larger buildings, so not a big deal, but should be fixed for next release.