### PR TITLE
Replace Order TargetActor/TargetCell for serialized orders

### DIFF
--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -74,9 +74,7 @@ namespace OpenRA
 			TargetString = targetString;
 			Queued = queued;
 			ExtraLocation = extraLocation;
-
-			// TODO: remove FrozenActor ID after the various ResolveOrders that rely on it are updated 
-			ExtraData = target.Type == TargetType.FrozenActor ? target.FrozenActor.ID : extraData;
+			ExtraData = extraData;
 		}
 
 		public static Order Deserialize(World world, BinaryReader r)

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -15,7 +15,7 @@ using System.Linq;
 
 namespace OpenRA.Traits
 {
-	public enum TargetType { Invalid, Actor, Terrain, FrozenActor }
+	public enum TargetType : byte { Invalid, Actor, Terrain, FrozenActor }
 	public struct Target
 	{
 		public static readonly Target[] None = { };
@@ -34,6 +34,10 @@ namespace OpenRA.Traits
 			return new Target { pos = w.Map.CenterOfSubCell(c, subCell), cell = c, type = TargetType.Terrain };
 		}
 
+		/// <summary>
+		/// DEPRECATED: Use Order.Target instead.
+		/// This method is kept to maintain compatibility with legacy code that may not understand TargetType.FrozenActor.
+		/// </summary>
 		public static Target FromOrder(World w, Order o)
 		{
 			return o.TargetActor != null

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
@@ -72,29 +72,14 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (IsTraitDisabled)
 				return false;
 
-			// Not targeting an actor
-			if (order.ExtraData == 0 && order.TargetActor == null)
-				return false;
+			IEnumerable<string> targetTypes = null;
+			if (order.Target.Type == TargetType.FrozenActor)
+				targetTypes = order.Target.FrozenActor.TargetTypes;
 
-			IEnumerable<string> targetTypes;
-
-			if (order.ExtraData != 0)
-			{
-				// Targeted an actor under the fog
-				var frozenLayer = self.Owner.PlayerActor.TraitOrDefault<FrozenActorLayer>();
-				if (frozenLayer == null)
-					return false;
-
-				var frozen = frozenLayer.FromID(order.ExtraData);
-				if (frozen == null)
-					return false;
-
-				targetTypes = frozen.TargetTypes;
-			}
-			else
+			if (order.Target.Type == TargetType.Actor)
 				targetTypes = order.TargetActor.GetEnabledTargetTypes();
 
-			return Info.Types.Overlaps(targetTypes);
+			return targetTypes != null && Info.Types.Overlaps(targetTypes);
 		}
 
 		public string VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -59,20 +59,16 @@ namespace OpenRA.Mods.Common
 			return stance == Stance.Enemy;
 		}
 
+		/// <summary>
+		/// DEPRECATED: Write code that can handle FrozenActors correctly instead.
+		/// </summary>
 		public static Target ResolveFrozenActorOrder(this Actor self, Order order, Color targetLine)
 		{
 			// Not targeting a frozen actor
-			if (order.ExtraData == 0)
-				return Target.FromOrder(self.World, order);
+			if (order.Target.Type != TargetType.FrozenActor)
+				return order.Target;
 
-			// Targeted an actor under the fog
-			var frozenLayer = self.Owner.PlayerActor.TraitOrDefault<FrozenActorLayer>();
-			if (frozenLayer == null)
-				return Target.Invalid;
-
-			var frozen = frozenLayer.FromID(order.ExtraData);
-			if (frozen == null)
-				return Target.Invalid;
+			var frozen = order.Target.FrozenActor;
 
 			// Flashes the frozen proxy
 			self.SetTargetLine(frozen, targetLine, true);

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -159,28 +159,6 @@ namespace OpenRA.Mods.Common.Traits
 			self.CancelActivity();
 		}
 
-		static Target TargetFromOrder(Actor self, Order order)
-		{
-			// Not targeting a frozen actor
-			if (order.ExtraData == 0)
-				return Target.FromOrder(self.World, order);
-
-			// Targeted an actor under the fog
-			var frozenLayer = self.Owner.PlayerActor.TraitOrDefault<FrozenActorLayer>();
-			if (frozenLayer == null)
-				return Target.Invalid;
-
-			var frozen = frozenLayer.FromID(order.ExtraData);
-			if (frozen == null)
-				return Target.Invalid;
-
-			// Target is still alive - resolve the real order
-			if (frozen.Actor != null && frozen.Actor.IsInWorld)
-				return Target.FromActor(frozen.Actor);
-
-			return Target.Invalid;
-		}
-
 		string IOrderVoice.VoicePhraseForOrder(Actor self, Order order)
 		{
 			return order.OrderString == attackOrderName || order.OrderString == forceAttackOrderName ? Info.Voice : null;

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -56,25 +56,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		static bool IsValidOrder(Actor self, Order order)
 		{
-			// Not targeting a frozen actor
-			if (order.ExtraData == 0 && order.TargetActor == null)
-				return false;
+			if (order.Target.Type == TargetType.FrozenActor)
+				return order.Target.FrozenActor.DamageState > DamageState.Undamaged;
 
-			if (order.ExtraData != 0)
-			{
-				// Targeted an actor under the fog
-				var frozenLayer = self.Owner.PlayerActor.TraitOrDefault<FrozenActorLayer>();
-				if (frozenLayer == null)
-					return false;
+			if (order.Target.Type == TargetType.Actor)
+				return order.TargetActor.GetDamageState() > DamageState.Undamaged;
 
-				var frozen = frozenLayer.FromID(order.ExtraData);
-				if (frozen == null)
-					return false;
-
-				return frozen.DamageState > DamageState.Undamaged;
-			}
-
-			return order.TargetActor.GetDamageState() > DamageState.Undamaged;
+			return false;
 		}
 
 		public string VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/ExternalCaptures.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCaptures.cs
@@ -71,27 +71,20 @@ namespace OpenRA.Mods.Common.Traits
 
 		static bool IsValidOrder(Actor self, Order order)
 		{
-			// Not targeting an actor
-			if (order.ExtraData == 0 && order.TargetActor == null)
-				return false;
-
-			if (order.ExtraData != 0)
+			if (order.Target.Type == TargetType.FrozenActor)
 			{
-				// Targeted an actor under the fog
-				var frozenLayer = self.Owner.PlayerActor.TraitOrDefault<FrozenActorLayer>();
-				if (frozenLayer == null)
-					return false;
-
-				var frozen = frozenLayer.FromID(order.ExtraData);
-				if (frozen == null)
-					return false;
-
+				var frozen = order.Target.FrozenActor;
 				var ci = frozen.Info.TraitInfoOrDefault<ExternalCapturableInfo>();
 				return ci != null && ci.CanBeTargetedBy(self, frozen.Owner);
 			}
 
-			var c = order.TargetActor.TraitOrDefault<ExternalCapturable>();
-			return c != null && !c.CaptureInProgress && c.Info.CanBeTargetedBy(self, order.TargetActor.Owner);
+			if (order.Target.Type == TargetType.Actor)
+			{
+				var c = order.TargetActor.TraitOrDefault<ExternalCapturable>();
+				return c != null && !c.CaptureInProgress && c.Info.CanBeTargetedBy(self, order.TargetActor.Owner);
+			}
+
+			return false;
 		}
 
 		public string VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/Player/AllyRepair.cs
+++ b/OpenRA.Mods.Common/Traits/Player/AllyRepair.cs
@@ -20,10 +20,9 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public void ResolveOrder(Actor self, Order order)
 		{
-			if (order.OrderString == "RepairBuilding")
+			if (order.OrderString == "RepairBuilding" && order.Target.Type == TargetType.Actor)
 			{
-				var building = order.TargetActor;
-
+				var building = order.Target.Actor;
 				if (building.Info.HasTraitInfo<RepairableBuildingInfo>())
 					if (building.AppearsFriendlyTo(self))
 						building.Trait<RepairableBuilding>().RepairBuilding(building, self.Owner);


### PR DESCRIPTION
Followup to #13995: this carries the new Target field through the networking code to where it can be used by `ResolveOrder`.

As traits are updated to use `order.Target` they will get free error checking (`TargetType.Actor` is guaranteed to be a valid living actor, `TargetType.Location` is guaranteed to not be the placeholder `CPos.Zero`, etc) and proper support for frozen actors.  This will make it possible to split #13363 into smaller more testable PRs starting after this is merged.