### PR TITLE
Default stance logic for production buildings

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -274,6 +274,7 @@
     <Compile Include="Traits\Attack\AttackSuicides.cs" />
     <Compile Include="Traits\Attack\AttackTurreted.cs" />
     <Compile Include="Traits\AttackWander.cs" />
+    <Compile Include="Traits\AutoTargetProducer.cs" />
     <Compile Include="Traits\AutoTarget.cs" />
     <Compile Include="Traits\BlocksProjectiles.cs" />
     <Compile Include="Traits\Buildable.cs" />

--- a/OpenRA.Mods.Common/Traits/AutoTargetProducer.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTargetProducer.cs
@@ -1,0 +1,61 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("The actor can produce units with modified AutoTarget stance.")]
+	public class AutoTargetProducerInfo : ConditionalTraitInfo, Requires<ProductionInfo>
+	{
+		[Desc("Production queue type, for actors with multiple queues.")]
+		public readonly string ProductionType = null;
+		public override object Create(ActorInitializer init) { return new AutoTargetProducer(this); }
+	}
+
+	public class AutoTargetProducer : ConditionalTrait<AutoTargetProducerInfo>, IResolveOrder, IActorStanceSelector
+	{
+		public UnitStance Stance { get; set; }
+
+		bool IActorStanceSelector.Enabled {	get	{ return !IsTraitDisabled; } }
+
+		UnitStance IActorStanceSelector.Stance { get { return PredictedStance; } }
+
+		bool IActorStanceSelector.CanBeDisabled { get {	return true; } }
+
+		public AutoTargetProducer(AutoTargetProducerInfo info) : base(info)
+		{
+			Stance = UnitStance.NoStance;
+			PredictedStance = UnitStance.NoStance;
+		}
+
+		// NOT SYNCED: do not refer to this anywhere other than UI code
+		public UnitStance PredictedStance;
+
+		void IResolveOrder.ResolveOrder(Actor self, Order order)
+		{
+			if (order.OrderString == "SetBuildingProductionStance")
+				Stance = (UnitStance)order.ExtraData;
+		}
+
+		void IActorStanceSelector.SetStance(Actor self, UnitStance stance)
+		{
+			if (IsTraitDisabled)
+				return;
+			PredictedStance = stance;
+			self.World.IssueOrder(new Order("SetBuildingProductionStance", self, false) { ExtraData = (uint)stance });
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -76,15 +76,21 @@ namespace OpenRA.Mods.Common.Traits
 				if (buildableInfo != null && buildableInfo.ForceFaction != null)
 					faction = buildableInfo.ForceFaction;
 
+				var td = new TypeDictionary
+				{
+					new LocationInit(order.TargetLocation),
+					new OwnerInit(order.Player),
+					new FactionInit(faction)
+				};
+
+				var autoTargetProduction = producer.Actor.TraitOrDefault<AutoTargetProducer>();
+				if (autoTargetProduction != null && autoTargetProduction.Stance != UnitStance.NoStance)
+					td.Add(new StanceInit(autoTargetProduction.Stance));
+
 				if (os == "LineBuild")
 				{
 					// Build the parent actor first
-					var placed = w.CreateActor(order.TargetString, new TypeDictionary
-					{
-						new LocationInit(order.TargetLocation),
-						new OwnerInit(order.Player),
-						new FactionInit(faction),
-					});
+					var placed = w.CreateActor(order.TargetString, td);
 
 					foreach (var s in buildingInfo.BuildSounds)
 						Game.Sound.PlayToPlayer(SoundType.World, order.Player, s, placed.CenterPosition);
@@ -136,12 +142,7 @@ namespace OpenRA.Mods.Common.Traits
 						|| !buildingInfo.IsCloseEnoughToBase(self.World, order.Player, order.TargetString, order.TargetLocation))
 						return;
 
-					var building = w.CreateActor(order.TargetString, new TypeDictionary
-					{
-						new LocationInit(order.TargetLocation),
-						new OwnerInit(order.Player),
-						new FactionInit(faction),
-					});
+					var building = w.CreateActor(order.TargetString, td);
 
 					foreach (var s in buildingInfo.BuildSounds)
 						Game.Sound.PlayToPlayer(SoundType.World, order.Player, s, building.CenterPosition);

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -86,11 +86,17 @@ namespace OpenRA.Mods.Common.Traits
 				td.Add(new FacingInit(initialFacing));
 			}
 
+			var autoTargetProduction = self.TraitOrDefault<AutoTargetProducer>();
+
+			if (autoTargetProduction != null && autoTargetProduction.Stance != UnitStance.NoStance)
+				td.Add(new StanceInit(autoTargetProduction.Stance));
+
 			self.World.AddFrameEndTask(w =>
 			{
 				var newUnit = self.World.CreateActor(producee.Name, td);
 
 				var move = newUnit.TraitOrDefault<IMove>();
+
 				if (move != null)
 				{
 					if (exitinfo.MoveIntoWorld)

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -16,6 +16,7 @@ FACT:
 	RevealsShroud:
 		Range: 10c0
 	WithBuildingBib:
+	AutoTargetProducer:
 	Production:
 		Produces: Building.GDI, Building.Nod, Defence.GDI, Defence.Nod
 	Transforms:
@@ -279,6 +280,7 @@ PYLE:
 	Exit@2:
 		SpawnOffset: 298,298,0
 		ExitCell: 1,1
+	AutoTargetProducer:
 	Production:
 		Produces: Infantry.GDI
 	ProductionQueue:
@@ -324,6 +326,7 @@ HAND:
 	Exit@1:
 		SpawnOffset: 512,1024,0
 		ExitCell: 1,2
+	AutoTargetProducer:
 	Production:
 		Produces: Infantry.Nod
 	ProductionQueue:
@@ -374,6 +377,7 @@ AFLD:
 	Exit@1:
 		SpawnOffset: -1024,0,0
 		ExitCell: 3,1
+	AutoTargetProducer:
 	ProductionAirdrop:
 		Produces: Vehicle.Nod
 	WithDeliveryAnimation:
@@ -428,6 +432,7 @@ WEAP:
 		SpawnOffset: -512,-512,0
 		ExitCell: 0,1
 		ExitDelay: 3
+	AutoTargetProducer:
 	Production:
 		Produces: Vehicle.GDI
 	ProductionQueue:
@@ -464,6 +469,7 @@ HPAD:
 		Range: 5c0
 	Exit@1:
 		SpawnOffset: 0,-256,0
+	AutoTargetProducer:
 	Production:
 		Produces: Aircraft.GDI, Aircraft.Nod
 	Reservable:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -75,6 +75,7 @@ construction_yard:
 		Type: cy
 	RevealsShroud:
 		Range: 5c768
+	AutoTargetProducer:
 	Production:
 		Produces: Building, Upgrade
 	Exit:
@@ -204,6 +205,7 @@ barracks:
 	Exit@2:
 		SpawnOffset: 512,480,0
 		ExitCell: 1,2
+	AutoTargetProducer:
 	Production:
 		Produces: Infantry, Upgrade
 	PrimaryBuilding:
@@ -403,6 +405,7 @@ light_factory:
 	Exit@1:
 		SpawnOffset: 544,-224,0
 		ExitCell: 2,1
+	AutoTargetProducer:
 	Production:
 		Produces: Vehicle, Upgrade
 	PrimaryBuilding:
@@ -487,6 +490,7 @@ heavy_factory:
 	Exit@1:
 		SpawnOffset: 256,192,0
 		ExitCell: 0,2
+	AutoTargetProducer:
 	Production:
 		Produces: Armor, Upgrade
 	PrimaryBuilding:
@@ -1125,6 +1129,7 @@ palace:
 	Exit@3:
 		SpawnOffset: -704,768,0
 		ExitCell: 0,3
+	AutoTargetProducer:
 	Production:
 		Produces: Palace
 	SupportPowerChargeBar:

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -159,6 +159,7 @@ MOBILETENT:
 TENT:
 	Health:
 		HP: 100000
+	AutoTargetProducer:
 	Production:
 		Produces: Infantry, Soldier, Dog, Defense
 	-Sellable:

--- a/mods/ra/maps/training-camp/rules.yaml
+++ b/mods/ra/maps/training-camp/rules.yaml
@@ -34,6 +34,7 @@ BARR:
 		Prerequisites: ~disabled
 	Health:
 		HP: 500000
+	AutoTargetProducer:
 	Production:
 		Produces: Building, Infantry, Soldier, Dog
 	BaseProvider:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -182,6 +182,7 @@ SPEN:
 		ProductionTypes: Ship
 	Production:
 		Produces: Ship, Submarine
+	AutoTargetProducer:
 	PrimaryBuilding:
 		PrimaryCondition: primary
 	-EmitInfantryOnSell:
@@ -290,6 +291,7 @@ SYRD:
 		ProductionTypes: Ship
 	Production:
 		Produces: Ship, Boat
+	AutoTargetProducer:
 	PrimaryBuilding:
 		PrimaryCondition: primary
 	-EmitInfantryOnSell:
@@ -952,6 +954,7 @@ WEAP:
 		ExitCell: 1,2
 	Production:
 		Produces: Vehicle
+	AutoTargetProducer:
 	ProvidesPrerequisite@allies:
 		Factions: allies, england, france, germany
 		Prerequisite: vehicles.allies
@@ -1072,6 +1075,7 @@ FACT:
 	RevealsShroud@GAPGEN:
 		Range: 4c0
 	WithBuildingBib:
+	AutoTargetProducer:
 	Production:
 		Produces: Building,Defense
 	Valued:
@@ -1245,6 +1249,7 @@ HPAD:
 	RallyPoint:
 	Production:
 		Produces: Aircraft, Helicopter
+	AutoTargetProducer:
 	Reservable:
 	ProductionBar:
 	PrimaryBuilding:
@@ -1331,6 +1336,7 @@ AFLD:
 	RallyPoint:
 	Production:
 		Produces: Aircraft, Plane
+	AutoTargetProducer:
 	Reservable:
 	ProvidesPrerequisite@soviet:
 		Factions: soviet, russia, ukraine
@@ -1592,6 +1598,7 @@ BARR:
 		ProductionTypes: Soldier, Infantry
 	Production:
 		Produces: Infantry, Soldier
+	AutoTargetProducer:
 	PrimaryBuilding:
 		PrimaryCondition: primary
 	ProductionBar:
@@ -1668,6 +1675,7 @@ KENN:
 		ProductionTypes: Dog, Infantry
 	Production:
 		Produces: Infantry, Dog
+	AutoTargetProducer:
 	PrimaryBuilding:
 		PrimaryCondition: primary
 	ProductionBar:
@@ -1723,6 +1731,7 @@ TENT:
 		ProductionTypes: Soldier, Infantry
 	Production:
 		Produces: Infantry, Soldier
+	AutoTargetProducer:
 	PrimaryBuilding:
 		PrimaryCondition: primary
 	ProductionBar:

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -98,6 +98,7 @@ GAPILE:
 		SpawnOffset: -256,1024,0
 		ExitCell: 2,2
 	ExitsDebugOverlay:
+	AutoTargetProducer:
 	Production:
 		Produces: Infantry
 		PauseOnCondition: empdisable
@@ -158,6 +159,7 @@ GAWEAP:
 		ExitCell: 3,1
 		ExitDelay: 5
 	ExitsDebugOverlay:
+	AutoTargetProducer:
 	Production:
 		Produces: Vehicle
 		PauseOnCondition: empdisable
@@ -213,6 +215,7 @@ GAHPAD:
 	RallyPoint:
 		Palette: mouse
 		IsPlayerPalette: false
+	AutoTargetProducer:
 	Production:
 		Produces: Air
 		PauseOnCondition: empdisable

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -112,6 +112,7 @@ NAHAND:
 		Offset: 3,3
 		Palette: mouse
 		IsPlayerPalette: false
+	AutoTargetProducer:
 	Production:
 		Produces: Infantry
 		PauseOnCondition: empdisable
@@ -170,6 +171,7 @@ NAWEAP:
 		ExitCell: 3,1
 		ExitDelay: 5
 	ExitsDebugOverlay:
+	AutoTargetProducer:
 	Production:
 		Produces: Vehicle
 		PauseOnCondition: empdisable
@@ -221,6 +223,7 @@ NAHPAD:
 	RallyPoint:
 		Palette: mouse
 		IsPlayerPalette: false
+	AutoTargetProducer:
 	Production:
 		Produces: Air
 		PauseOnCondition: empdisable

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -17,6 +17,7 @@ GACNST:
 	RevealsShroud:
 		Range: 5c0
 		MaxHeightDelta: 3
+	AutoTargetProducer:
 	Production:
 		Produces: Building,Defense
 		PauseOnCondition: empdisable


### PR DESCRIPTION
Should resolve #13817 .

No additional buttons added. Logic for it is following:
1) if there is at least one actor that has AutoTarget trait - ignore new logic completely
2) if there are no actors who have AutoTargetProducer trait - ignore
3) if every actor has same stance in AutoTargetProducer and you try to set that stance - clear production stance
4) otherwise - set selected stance to every actor

There is also a property ChangeSpecialStance, which defaults to false. If it is kept that way, it won't change stance for units that have separate from default stance. That required a static property that determined what stance is currently "default" (if it ever changes). Example of such unit is Phase Transporter.

This thing might be clunky if you have production building/unit that can autotarget. Basically if you have AutoTarget, you will never be able to access AutoTargetProducer.