### PR TITLE
Remove more IsDisabled checks

### DIFF
--- a/OpenRA.Mods.Common/Traits/AffectsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/AffectsShroud.cs
@@ -31,12 +31,10 @@ namespace OpenRA.Mods.Common.Traits
 		static readonly PPos[] NoCells = { };
 
 		[Sync] CPos cachedLocation;
-		[Sync] bool cachedDisabled;
 		[Sync] bool cachedTraitDisabled;
 
 		protected abstract void AddCellsToPlayerShroud(Actor self, Player player, PPos[] uv);
 		protected abstract void RemoveCellsFromPlayerShroud(Actor self, Player player);
-		protected virtual bool IsDisabled(Actor self) { return false; }
 
 		public AffectsShroud(Actor self, AffectsShroudInfo info)
 			: base(info) { }
@@ -69,14 +67,12 @@ namespace OpenRA.Mods.Common.Traits
 			var centerPosition = self.CenterPosition;
 			var projectedPos = centerPosition - new WVec(0, centerPosition.Z, centerPosition.Z);
 			var projectedLocation = self.World.Map.CellContaining(projectedPos);
-			var disabled = IsDisabled(self);
 			var traitDisabled = IsTraitDisabled;
 
-			if (cachedLocation == projectedLocation && traitDisabled == cachedTraitDisabled && cachedDisabled == disabled)
+			if (cachedLocation == projectedLocation && traitDisabled == cachedTraitDisabled)
 				return;
 
 			cachedLocation = projectedLocation;
-			cachedDisabled = disabled;
 			cachedTraitDisabled = traitDisabled;
 
 			var cells = ProjectedCells(self);
@@ -92,7 +88,6 @@ namespace OpenRA.Mods.Common.Traits
 			var centerPosition = self.CenterPosition;
 			var projectedPos = centerPosition - new WVec(0, centerPosition.Z, centerPosition.Z);
 			cachedLocation = self.World.Map.CellContaining(projectedPos);
-			cachedDisabled = IsDisabled(self);
 			cachedTraitDisabled = IsTraitDisabled;
 			var cells = ProjectedCells(self);
 
@@ -106,6 +101,6 @@ namespace OpenRA.Mods.Common.Traits
 				RemoveCellsFromPlayerShroud(self, p);
 		}
 
-		public WDist Range { get { return (cachedDisabled || cachedTraitDisabled) ? WDist.Zero : Info.Range; } }
+		public WDist Range { get { return cachedTraitDisabled ? WDist.Zero : Info.Range; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public abstract class AttackBaseInfo : ConditionalTraitInfo
+	public abstract class AttackBaseInfo : PausableConditionalTraitInfo
 	{
 		[Desc("Armament names")]
 		public readonly string[] Armaments = { "primary", "secondary" };
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override abstract object Create(ActorInitializer init);
 	}
 
-	public abstract class AttackBase : ConditionalTrait<AttackBaseInfo>, INotifyCreated, IIssueOrder, IResolveOrder, IOrderVoice, ISync
+	public abstract class AttackBase : PausableConditionalTrait<AttackBaseInfo>, INotifyCreated, IIssueOrder, IResolveOrder, IOrderVoice, ISync
 	{
 		readonly string attackOrderName = "Attack";
 		readonly string forceAttackOrderName = "ForceAttack";
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected virtual bool CanAttack(Actor self, Target target)
 		{
-			if (!self.IsInWorld || IsTraitDisabled || self.IsDisabled())
+			if (!self.IsInWorld || IsTraitDisabled || IsTraitPaused)
 				return false;
 
 			if (!target.IsValidFor(self))
@@ -333,7 +333,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void AttackTarget(Target target, bool queued, bool allowMove, bool forceAttack = false)
 		{
-			if (self.IsDisabled() || IsTraitDisabled)
+			if (IsTraitDisabled || IsTraitPaused)
 				return;
 
 			if (!target.IsValidFor(self))

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (IsCanceled || !target.IsValidFor(self))
 					return NextActivity;
 
-				if (self.IsDisabled())
+				if (attack.IsTraitPaused)
 					return this;
 
 				var weapon = attack.ChooseArmamentsForTarget(target, forceAttack).FirstOrDefault();

--- a/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs
@@ -17,6 +17,9 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Actor has a visual turret used to attack.")]
 	public class AttackTurretedInfo : AttackFollowInfo, Requires<TurretedInfo>
 	{
+		[Desc("Turret names")]
+		public readonly string[] Turrets = { "primary" };
+
 		public override object Create(ActorInitializer init) { return new AttackTurreted(init.Self, this); }
 	}
 
@@ -27,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 		public AttackTurreted(Actor self, AttackTurretedInfo info)
 			: base(self, info)
 		{
-			turrets = self.TraitsImplementing<Turreted>().ToArray();
+			turrets = self.TraitsImplementing<Turreted>().Where(t => info.Turrets.Contains(t.Info.Turret)).ToArray();
 		}
 
 		protected override bool CanAttack(Actor self, Target target)

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -144,9 +144,6 @@ namespace OpenRA.Mods.Common.Traits
 				if (remainingTime > 0 && !isDocking)
 					remainingTime--;
 
-				if (self.IsDisabled())
-					Uncloak();
-
 				if (Info.UncloakOn.HasFlag(UncloakType.Move) && (lastPos == null || lastPos.Value != self.Location))
 				{
 					Uncloak();

--- a/OpenRA.Mods.Common/Traits/CreatesShroud.cs
+++ b/OpenRA.Mods.Common/Traits/CreatesShroud.cs
@@ -37,7 +37,5 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		protected override void RemoveCellsFromPlayerShroud(Actor self, Player p) { p.Shroud.RemoveSource(this); }
-
-		protected override bool IsDisabled(Actor self) { return self.IsDisabled(); }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -142,7 +142,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool FaceTarget(Actor self, Target target)
 		{
-			if (attack == null || attack.IsTraitDisabled)
+			if (attack == null || attack.IsTraitDisabled || attack.IsTraitPaused)
 				return false;
 
 			var pos = self.CenterPosition;

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -804,7 +804,7 @@ SAM:
 		Weapon: Dragon
 		MuzzleSequence: muzzle
 	AttackPopupTurreted:
-		RequiresCondition: !lowpower
+		PauseOnCondition: lowpower
 	WithMuzzleOverlay:
 	-RenderDetectionCircle:
 	Power:
@@ -844,7 +844,7 @@ OBLI:
 		Weapon: Laser
 		LocalOffset: 0,-85,1280
 	AttackCharges:
-		RequiresCondition: !lowpower
+		PauseOnCondition: lowpower
 		ChargeLevel: 50
 		ChargingCondition: charging
 	AmbientSound:
@@ -932,7 +932,7 @@ ATWR:
 		LocalOffset: 256,128,0, 256,-128,0
 		LocalYaw: -100,100
 	AttackTurreted:
-		RequiresCondition: !lowpower
+		PauseOnCondition: lowpower
 	BodyOrientation:
 		QuantizedFacings: 8
 	DetectCloaked:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -762,7 +762,7 @@ large_gun_turret:
 	Inherits@IDISABLE: ^DisableOnLowPowerOrPowerDown
 	Inherits@AUTOTARGET: ^AutoTargetGround
 	AttackTurreted:
-		RequiresCondition: !disabled
+		PauseOnCondition: disabled
 	Buildable:
 		Queue: Building
 		Prerequisites: outpost, upgrade.conyard, ~techlevel.medium

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -92,6 +92,7 @@ GAP:
 		HasMinibib: Yes
 	CreatesShroud:
 		Range: 6c0
+		RequiresCondition: !disabled
 	RenderShroudCircle:
 	Power:
 		RequiresCondition: !powerdown
@@ -487,7 +488,7 @@ TSLA:
 		Weapon: TeslaZap
 		LocalOffset: 0,0,896
 	AttackTesla:
-		RequiresCondition: !disabled
+		PauseOnCondition: disabled
 		ChargeAudio: tslachg2.aud
 		MaxCharges: 3
 		ReloadDelay: 120
@@ -536,7 +537,7 @@ AGUN:
 		LocalOffset: 520,100,450, 520,-150,450
 		MuzzleSequence: muzzle
 	AttackTurreted:
-		RequiresCondition: !disabled
+		PauseOnCondition: disabled
 	WithMuzzleOverlay:
 	RenderRangeCircle:
 		RangeCircleType: aa
@@ -829,7 +830,7 @@ SAM:
 		LocalOffset: 0,0,320
 		MuzzleSequence: muzzle
 	AttackTurreted:
-		RequiresCondition: !disabled
+		PauseOnCondition: disabled
 	WithMuzzleOverlay:
 	RenderRangeCircle:
 		RangeCircleType: aa

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -66,6 +66,7 @@ ORCA:
 	Inherits: ^Helicopter
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	Inherits@EMPDISABLE: ^EmpDisable
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -97,6 +98,7 @@ ORCA:
 	AttackHeli:
 		FacingTolerance: 20
 		Voice: Attack
+		PauseOnCondition: empdisable
 	AmmoPool:
 		Ammo: 5
 		PipCount: 5
@@ -111,6 +113,7 @@ ORCAB:
 	Inherits: ^Aircraft
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	Inherits@EMPDISABLE: ^EmpDisable
 	Valued:
 		Cost: 1600
 	Tooltip:
@@ -146,6 +149,7 @@ ORCAB:
 	AttackPlane:
 		Voice: Attack
 		FacingTolerance: 20
+		PauseOnCondition: empdisable
 	AmmoPool:
 		Ammo: 10
 		PipCount: 2
@@ -237,6 +241,7 @@ SCRIN:
 	Inherits: ^Aircraft
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	Inherits@EMPDISABLE: ^EmpDisable
 	Valued:
 		Cost: 1500
 	Tooltip:
@@ -274,6 +279,7 @@ SCRIN:
 	AttackPlane:
 		Voice: Attack
 		FacingTolerance: 20
+		PauseOnCondition: empdisable
 	AmmoPool:
 		Ammo: 15
 		PipCount: 3
@@ -290,6 +296,7 @@ APACHE:
 	Inherits: ^Helicopter
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	Inherits@EMPDISABLE: ^EmpDisable
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -319,6 +326,7 @@ APACHE:
 	AttackHeli:
 		FacingTolerance: 20
 		Voice: Attack
+		PauseOnCondition: empdisable
 	AmmoPool:
 		Ammo: 12
 		PipCount: 4

--- a/mods/ts/rules/civilian-vehicles.yaml
+++ b/mods/ts/rules/civilian-vehicles.yaml
@@ -31,6 +31,7 @@
 		LocalOffset: 0,283,580, 0,-283,580
 	AttackTurreted:
 		Voice: Attack
+		PauseOnCondition: empdisable
 	SelfHealing:
 		Delay: 10
 		HealIfBelow: 50

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -63,12 +63,13 @@ GACTWR:
 	BodyOrientation:
 		QuantizedFacings: 32
 	DetectCloaked:
-		RequiresCondition: tower.vulcan || tower.rocket || tower.sam
+		RequiresCondition: !empdisable && (tower.vulcan || tower.rocket || tower.sam)
 	Turreted:
 		TurnSpeed: 10
 		InitialFacing: 224
 	AttackTurreted:
 		RequiresCondition: tower.vulcan || tower.rocket || tower.sam
+		PauseOnCondition: empdisable
 	WithSpriteTurret@VULC:
 		RequiresCondition: tower.vulcan
 		Recoils: false

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -90,6 +90,7 @@ HVR:
 		Offset: -128,0,85
 	AttackTurreted:
 		Voice: Attack
+		PauseOnCondition: empdisable
 	WithVoxelTurret:
 	Hovers:
 	LeavesTrails:
@@ -129,6 +130,7 @@ SMECH:
 		MaxHeightDelta: 3
 	AttackFrontal:
 		Voice: Attack
+		PauseOnCondition: empdisable
 	Armament:
 		Weapon: AssaultCannon
 	Voiced:
@@ -182,6 +184,7 @@ MMCH:
 		TurnSpeed: 5
 	AttackTurreted:
 		Voice: Attack
+		PauseOnCondition: empdisable
 	WithSpriteTurret:
 		Recoils: false
 	Armament:
@@ -234,6 +237,7 @@ HMEC:
 		MaxHeightDelta: 3
 	AttackFrontal:
 		Voice: Attack
+		PauseOnCondition: empdisable
 	Armament@MISSILES:
 		Weapon: MammothTusk
 		LocalOffset: -243,-368,1208, -243,368,1208
@@ -281,6 +285,7 @@ SONIC:
 		LocalOffset: -71,0,580
 	AttackTurreted:
 		Voice: Attack
+		PauseOnCondition: empdisable
 	Turreted:
 		TurnSpeed: 5
 		Offset: -170,0,0
@@ -364,7 +369,9 @@ JUGG:
 	AttackTurreted@deployed:
 		Voice: Attack
 		Armaments: deployed
+		Turrets: deployed
 		RequiresCondition: deployed
+		PauseOnCondition: empdisable
 	Armament@deployed:
 		Name: deployed
 		Turret: deployed

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -159,6 +159,7 @@ NALASR:
 		InitialFacing: 224
 		Offset: 298,-171,288
 	AttackTurreted:
+		PauseOnCondition: empdisable
 	Armament:
 		Weapon: TurretLaserFire
 		LocalOffset: 498,0,317
@@ -201,7 +202,7 @@ NAOBEL:
 		Weapon: ObeliskLaserFire
 		LocalOffset: 1980,297,1131
 	AttackCharges:
-		RequiresCondition: !disabled
+		PauseOnCondition: empdisable || disabled
 		ChargeLevel: 65
 		ChargingCondition: charging
 	AmbientSound:
@@ -247,7 +248,7 @@ NASAM:
 		TurnSpeed: 10
 		InitialFacing: 224
 	AttackTurreted:
-		RequiresCondition: !disabled
+		PauseOnCondition: empdisable || disabled
 	WithSpriteTurret:
 		Recoils: false
 	Armament:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -463,7 +463,7 @@ STNK:
 		UncloakSound: cloak5.aud
 		IsPlayerPalette: true
 		UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage, Heal
-		RequiresCondition: !cloak-force-disabled
+		RequiresCondition: !cloak-force-disabled && !empdisable
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -31,6 +31,7 @@ BGGY:
 		MuzzleSplitFacings: 8
 	AttackFrontal:
 		Voice: Attack
+		PauseOnCondition: empdisable
 	WithMuzzleOverlay:
 	-DamagedByTerrain@VEINS:
 	-LeavesTrails@VEINS:
@@ -70,6 +71,7 @@ BIKE:
 		LocalOffset: -153,-204,509, -153,204,509
 	AttackFrontal:
 		Voice: Attack
+		PauseOnCondition: empdisable
 	DamagedByTerrain@VEINS:
 		RequiresCondition: !inside-tunnel && !rank-elite
 	LeavesTrails@VEINS:
@@ -139,6 +141,7 @@ TTNK:
 	AttackFrontal:
 		Voice: Attack
 		RequiresCondition: undeployed
+		PauseOnCondition: empdisable
 	Turreted:
 		TurnSpeed: 6
 		Turret: deployed
@@ -155,7 +158,9 @@ TTNK:
 	AttackTurreted@deployed:
 		Voice: Attack
 		Armaments: deployed
+		Turrets: deployed
 		RequiresCondition: deployed
+		PauseOnCondition: empdisable
 	Armament@deployed:
 		Name: deployed
 		Turret: deployed
@@ -251,7 +256,9 @@ ART2:
 	AttackTurreted@deployed:
 		Voice: Attack
 		Armaments: deployed
+		Turrets: deployed
 		RequiresCondition: deployed
+		PauseOnCondition: empdisable
 	Armament@deployed:
 		Name: deployed
 		Turret: deployed
@@ -295,6 +302,7 @@ REPAIR:
 		ForceTargetStances: None
 	AttackFrontal:
 		Voice: Attack
+		PauseOnCondition: empdisable
 	AutoTarget:
 	AutoTargetPriority@DEFAULT:
 		ValidTargets: Vehicles
@@ -425,6 +433,7 @@ SUBTANK:
 		Weapon: FireballLauncher
 	AttackFrontal:
 		Voice: Attack
+		PauseOnCondition: empdisable
 	WithVoxelBody:
 		RequiresCondition: !submerged
 	Targetable:
@@ -472,6 +481,7 @@ STNK:
 		LocalOffset: 301,61,421, 301,-61,421
 	AttackFrontal:
 		Voice: Attack
+		PauseOnCondition: empdisable
 	AutoTarget:
 		InitialStance: HoldFire
 		InitialStanceAI: ReturnFire

--- a/mods/ts/sequences/aircraft.yaml
+++ b/mods/ts/sequences/aircraft.yaml
@@ -1,16 +1,20 @@
 orca:
+	Inherits: ^VehicleOverlays
 	icon: orcaicon
 
 orcab:
+	Inherits: ^VehicleOverlays
 	icon: obmbicon
 
 trnsport:
 	icon: otrnicon
 
 scrin:
+	Inherits: ^VehicleOverlays
 	icon: proicon
 
 apache:
+	Inherits: ^VehicleOverlays
 	icon: apchicon
 	rotor: lrotor
 		Length: 4


### PR DESCRIPTION
Depends on #13998.

This removes most of the remaining `Actor.IsDisabled` look-ups.
After this, only `Gate`,  `ProductionQueue` and AI `AirStates` remain (might be worth investigating whether those are easy enough to migrate to add them to this PR, too).