### PR TITLE
Clear team in lobby for spectators

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -184,6 +184,7 @@ namespace OpenRA.Mods.Common.Server
 						{
 							client.Slot = null;
 							client.SpawnPoint = 0;
+							client.Team = 0;
 							client.Color = HSLColor.FromRGB(255, 255, 255);
 							server.SyncLobbyClients();
 							CheckAutoStart(server);


### PR DESCRIPTION
Fixes #14140 
When switching to Spectator in lobby Team number is now also cleared like Spawn point, Faction is still kept.