### PR TITLE
Fixed issue with unit ready when capturing

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -276,27 +276,33 @@ namespace OpenRA
 		// TODO: move elsewhere.
 		public void ChangeOwner(Player newOwner)
 		{
-			World.AddFrameEndTask(w =>
-			{
-				if (Disposed)
-					return;
+			World.AddFrameEndTask(_ => ChangeOwnerSync(newOwner));
+		}
 
-				var oldOwner = Owner;
-				var wasInWorld = IsInWorld;
+		/// <summary>
+		/// Change the actors owner without queuing a FrameEndTask.
+		/// This must only be called from inside an existing FrameEndTask.
+		/// </summary>
+		public void ChangeOwnerSync(Player newOwner)
+		{
+			if (Disposed)
+				return;
 
-				// momentarily remove from world so the ownership queries don't get confused
-				if (wasInWorld)
-					w.Remove(this);
+			var oldOwner = Owner;
+			var wasInWorld = IsInWorld;
 
-				Owner = newOwner;
-				Generation++;
+			// momentarily remove from world so the ownership queries don't get confused
+			if (wasInWorld)
+				World.Remove(this);
 
-				foreach (var t in TraitsImplementing<INotifyOwnerChanged>())
-					t.OnOwnerChanged(this, oldOwner, newOwner);
+			Owner = newOwner;
+			Generation++;
 
-				if (wasInWorld)
-					w.Add(this);
-			});
+			foreach (var t in TraitsImplementing<INotifyOwnerChanged>())
+				t.OnOwnerChanged(this, oldOwner, newOwner);
+
+			if (wasInWorld)
+				World.Add(this);
 		}
 
 		public DamageState GetDamageState()

--- a/OpenRA.Mods.Common/Activities/ExternalCaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/ExternalCaptureActor.cs
@@ -67,8 +67,6 @@ namespace OpenRA.Mods.Common.Activities
 
 						var oldOwner = target.Actor.Owner;
 
-						target.Actor.ChangeOwner(self.Owner);
-
 						foreach (var t in target.Actor.TraitsImplementing<INotifyCapture>())
 							t.OnCapture(target.Actor, self, oldOwner, self.Owner);
 
@@ -83,6 +81,8 @@ namespace OpenRA.Mods.Common.Activities
 
 						if (capturesInfo != null && capturesInfo.ConsumeActor)
 							self.Dispose();
+
+						target.Actor.ChangeOwnerSync(self.Owner);
 					});
 				}
 			}


### PR DESCRIPTION
Fixes #14219 and #13983 , hopefully without breaking anything else

Issue was with Actor.ChangeOwner being always scheduled last (since it was using World.AddFrameEndTask inside World.AddFrameEndTask) Modified the code so it now accepts current frame as an optional parameter and moved the actual transition of ownership to the bottom of the code.

Now... I don't know if this is the best solution, but it feels that way. Maybe we can move more actions inside of an Actor to proper "chain" from World.AddFrameEndTask. Maybe all this is a bogus idea, and should be denied

Either way - this fixes the issue, and initial tests shown that everything else works