### PR TITLE
Fix the "Unit Ready" notification playing erroneously

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!producers.Any())
 			{
 				CancelProduction(unit.Name, 1);
-				return true;
+				return false;
 			}
 
 			foreach (var p in producers.Where(p => !p.Actor.IsDisabled()))

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -378,7 +378,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!self.IsInWorld || self.IsDead)
 			{
 				CancelProduction(unit.Name, 1);
-				return true;
+				return false;
 			}
 
 			var sp = self.TraitsImplementing<Production>().FirstOrDefault(p => p.Info.Produces.Contains(Info.Type));


### PR DESCRIPTION
Testcase: Build a barracks and block the entries. Produce a unit (will be blocked on "Ready") and then sell the structure. Without this fix the "Unit Ready" sound is played.

Note that `BuildUnit` is only ever used [here](https://github.com/OpenRA/OpenRA/blob/32df83d3c43294df4a469aee9db70ea96526e4e8/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs#L297), so this change should change any other behavior.