### PR TITLE
Generate a versioned tarball during package creation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ deploy:
   file:
     - build/OpenRA-${TRAVIS_TAG}.exe
     - build/OpenRA-${TRAVIS_TAG}.dmg
+    - build/OpenRA-${TRAVIS_TAG}-source.tar.bz2
     - build/openra_${DOTVERSION}_all.deb
   skip_cleanup: true
   on:

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -30,5 +30,6 @@ set -e
 build_package windows
 build_package osx
 build_package linux
+build_package source
 
 echo "Package build done."

--- a/packaging/source/buildpackage.sh
+++ b/packaging/source/buildpackage.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# OpenRA packaging script for versioned source tarball
+
+if [ $# -ne "2" ]; then
+    echo "Usage: `basename $0` tag outputdir"
+    exit 1
+fi
+
+# Set the working dir to the location of this script
+cd $(dirname $0)
+
+TAG="$1"
+OUTPUTDIR="$2"
+SRCDIR="$(pwd)/../.."
+
+pushd ${SRCDIR} > /dev/null
+make version VERSION="${TAG}"
+git ls-tree HEAD --name-only -r -z | xargs -0 tar cvjf "${OUTPUTDIR}/OpenRA-${TAG}-source.tar.bz2"
+popd > /dev/null


### PR DESCRIPTION
Closes #12907.

This has a couple of advantages over #13908, such as supporting custom versions (like the other packaging scripts), and not packaging stray build products in the tarball.