### PR TITLE
Update macOS launcher with space-in-filename metadata registration fix.

### DIFF
--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -9,7 +9,7 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
 	command -v genisoimage >/dev/null 2>&1 || { echo >&2 "macOS packaging requires genisoimage."; exit 1; }
 fi
 
-LAUNCHER_TAG="osx-launcher-20170812"
+LAUNCHER_TAG="osx-launcher-20171022"
 
 if [ $# -ne "2" ]; then
 	echo "Usage: `basename $0` tag outputdir"


### PR DESCRIPTION
Fixes ingame mod switching not working on macOS 10.13.