### PR TITLE
Allow RallyPoint cursor to be defined via Yaml

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -23,6 +23,8 @@ namespace OpenRA.Mods.Common.Traits
 		[SequenceReference("Image")] public readonly string FlagSequence = "flag";
 		[SequenceReference("Image")] public readonly string CirclesSequence = "circles";
 
+		public readonly string Cursor = "ability";
+
 		[Desc("Custom indicator palette name")]
 		[PaletteReference("IsPlayerPalette")] public readonly string Palette = "player";
 
@@ -71,7 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<IOrderTargeter> Orders
 		{
-			get { yield return new RallyPointOrderTargeter(); }
+			get { yield return new RallyPointOrderTargeter(Info.Cursor); }
 		}
 
 		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
@@ -96,6 +98,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		class RallyPointOrderTargeter : IOrderTargeter
 		{
+			readonly string cursor;
+
+			public RallyPointOrderTargeter(string cursor)
+			{
+				this.cursor = cursor;
+			}
+
 			public string OrderID { get { return "SetRallyPoint"; } }
 			public int OrderPriority { get { return 0; } }
 			public bool TargetOverridesSelection(TargetModifiers modifiers) { return true; }
@@ -109,7 +118,7 @@ namespace OpenRA.Mods.Common.Traits
 				var location = self.World.Map.CellContaining(target.CenterPosition);
 				if (self.World.Map.Contains(location))
 				{
-					cursor = "ability";
+					cursor = this.cursor;
 
 					// Notify force-set 'RallyPoint' order watchers with Ctrl and only if this is the only building of its type selected
 					if (modifiers.HasModifier(TargetModifiers.ForceAttack))


### PR DESCRIPTION
Allow RallyPoint cursor to be defined via Yaml - AKA: Unhardcode the cursor "ability".