### PR TITLE
RA - Fix Inconsistency with AcceptsDeliveredCash

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -104,6 +104,7 @@ GAP:
 		Amount: -60
 	MustBeDestroyed:
 		RequiredForShortGame: false
+	-AcceptsDeliveredCash:
 	Explodes:
 		Weapon: SmallBuildingExplode
 		EmptyWeapon: SmallBuildingExplode
@@ -459,7 +460,6 @@ PDOX:
 		DisplayRadarPing: True
 		Range: 2
 	SupportPowerChargeBar:
-	-AcceptsDeliveredCash:
 	Power:
 		Amount: -200
 	MustBeDestroyed:


### PR DESCRIPTION
Chronosphere weren't accepting cash while Iron Curtain and Missile Silo does.

Also Gap Generator were accepting it, while other defences don't.