### PR TITLE
Add Support for dropping Cargo with Parachute from an Aircraft

### DIFF
--- a/OpenRA.Mods.Common/Activities/ParadropCargo.cs
+++ b/OpenRA.Mods.Common/Activities/ParadropCargo.cs
@@ -1,0 +1,69 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using OpenRA.Activities;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Activities
+{
+	public class ParadropCargo : Activity
+	{
+		readonly bool unloadAll;
+
+		public ParadropCargo(bool unloadAll)
+		{
+			this.unloadAll = unloadAll;
+		}
+
+		public override Activity Tick(Actor self)
+		{
+			var cargo = self.Trait<Cargo>();
+			var notifiers = self.TraitsImplementing<INotifyUnload>().ToArray();
+
+			cargo.Unloading = false;
+			if (IsCanceled || cargo.IsEmpty(self))
+				return NextActivity;
+
+			foreach (var inu in notifiers)
+				inu.Unloading(self);
+
+			var actor = cargo.Peek(self);
+			var spawn = self.CenterPosition;
+
+			cargo.Unload(self);
+			self.World.AddFrameEndTask(w =>
+			{
+				if (actor.Disposed)
+					return;
+
+				var pos = actor.Trait<IPositionable>();
+
+				pos.SetVisualPosition(actor, spawn);
+
+				actor.CancelActivity();
+				actor.QueueActivity(new Parachute(actor, spawn));
+				w.Add(actor);
+			});
+			Game.Sound.Play(SoundType.World, self.Info.TraitInfo<ParaDropInfo>().ChuteSound, spawn);
+
+			if (!unloadAll || cargo.IsEmpty(self))
+				return NextActivity;
+
+			cargo.Unloading = true;
+			return this;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Activities\Move\MoveAdjacentTo.cs" />
     <Compile Include="Activities\Move\MoveWithinRange.cs" />
     <Compile Include="Activities\Parachute.cs" />
+    <Compile Include="Activities\ParadropCargo.cs" />
     <Compile Include="Activities\Rearm.cs" />
     <Compile Include="Activities\RemoveSelf.cs" />
     <Compile Include="Activities\Repair.cs" />

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -79,6 +79,63 @@ BADR.Bomber:
 	GivesExperience:
 		Experience: 1000
 
+BADR.Transport:
+	Inherits: ^Plane
+	Buildable:
+		Queue: Aircraft
+		BuildAtProductionType: Plane
+		BuildPaletteOrder: 15
+		Prerequisites: ~afld, ~techlevel.medium
+		Description: Fast Infantry Transport plane.\n  Unarmed
+	Valued:
+		Cost: 900
+	ParaDrop:
+		DropRange: 4c0
+	Tooltip:
+		Name: Badger Cargo Plane
+	Health:
+		HP: 300
+	Armor:
+		Type: Light
+	Aircraft:
+		RearmBuildings: afld
+		CruiseAltitude: 2560
+		TurnSpeed: 5
+		Speed: 149
+		Repulsable: False
+		MaximumPitch: 56
+		LandableTerrainTypes: Clear,Rough,Road,Ore,Beach,Gems
+		AltitudeVelocity: 0c58
+		TakeOffOnCreation: false
+	RevealsShroud:
+		Range: 8c0
+		Type: GroundPosition
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 6c0
+		Type: GroundPosition
+	Selectable:
+		Bounds: 44,32,0,-8
+	Cargo:
+		Types: Infantry
+		MaxWeight: 8
+		PipCount: 8
+		UnloadWithParachute: true
+	Contrail@1:
+		Offset: -432,560,0
+	Contrail@2:
+		Offset: -432,-560,0
+	SpawnActorOnDeath:
+		Actor: BADR.Husk
+	SmokeTrailWhenDamaged@0:
+		Offset: -432,560,0
+		Interval: 2
+	SmokeTrailWhenDamaged@1:
+		Offset: -432,-560,0
+		Interval: 2
+	RenderSprites:
+		Image: BADR
+
 MIG:
 	Inherits: ^Plane
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
@@ -211,6 +268,7 @@ YAK:
 
 TRAN:
 	Inherits: ^Helicopter
+	ParaDrop:
 	Buildable:
 		Queue: Aircraft
 		BuildAtProductionType: Helicopter
@@ -258,6 +316,7 @@ TRAN:
 		Types: Infantry
 		MaxWeight: 8
 		PipCount: 8
+		UnloadWithParachute: true
 	SpawnActorOnDeath:
 		Actor: TRAN.Husk
 	SelectionDecorations:
@@ -300,7 +359,7 @@ HELI:
 		FacingTolerance: 20
 	Aircraft:
 		RearmBuildings: hpad
-		LandWhenIdle: false
+		LandWhenIdle: true
 		InitialFacing: 224
 		TurnSpeed: 4
 		Speed: 149
@@ -330,6 +389,7 @@ HELI:
 HIND:
 	Inherits: ^Helicopter
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	ParaDrop:
 	Buildable:
 		Queue: Aircraft
 		BuildAtProductionType: Helicopter
@@ -370,6 +430,7 @@ HIND:
 		InitialFacing: 224
 		TurnSpeed: 4
 		Speed: 112
+		LandableTerrainTypes: Clear,Rough,Road,Ore,Beach,Gems
 	AutoTarget:
 		InitialStance: HoldFire
 		InitialStanceAI: HoldFire
@@ -384,6 +445,10 @@ HIND:
 		PipCount: 6
 		ReloadDelay: 8
 		AmmoCondition: ammo
+	Cargo:
+		Types: Infantry
+		MaxWeight: 8
+		PipCount: 8
 	SelectionDecorations:
 		VisualBounds: 38,32
 	WithMuzzleOverlay:

--- a/mods/ra/sequences/aircraft.yaml
+++ b/mods/ra/sequences/aircraft.yaml
@@ -70,3 +70,4 @@ u2:
 badr:
 	idle:
 		Facings: 16
+	icon: badricon


### PR DESCRIPTION
I'm not sure how well the code is, may need help to make it better. But well it works.

Also maybe for another PR, but i think "unloadAll" should be able to settable on .yaml, i think would be cool. ParadropCargo acts a bit wierd with unloadAll = true tho (plane stays in midair for some ticks and cargo may die because of falling on each other). So it is false with this PR.

For Testcase, to ensure everthing works fine, i added a Badger, also gave ability to use parachute to Chinook, and gave Hind Cargo but without UnloadWithParachute tag.