### PR TITLE
Add Cursor: support for Sellable

### DIFF
--- a/OpenRA.Mods.Common/Traits/Sellable.cs
+++ b/OpenRA.Mods.Common/Traits/Sellable.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int RefundPercent = 50;
 		public readonly string[] SellSounds = { };
 		public readonly bool ShowTicks = true;
+		public readonly string Cursor = "sell";
 
 		[Desc("Skip playing (reversed) make animation.")]
 		public readonly bool SkipMakeAnimation = false;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/OrderButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/OrderButtonsChromeLogic.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Widgets;
 
@@ -17,11 +18,31 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class SellOrderButtonLogic : ChromeLogic
 	{
 		[ObjectCreator.UseCtor]
-		public SellOrderButtonLogic(Widget widget, World world)
+		public SellOrderButtonLogic(Widget widget, World world, Dictionary<string, MiniYaml> logicArgs)
 		{
+			var blockedCursor = "sell-blocked";
+			if (logicArgs.ContainsKey("BlockedCursor"))
+				blockedCursor = FieldLoader.GetValue<string>("BlockedCursor", logicArgs["BlockedCursor"].Value);
+
 			var sell = widget as ButtonWidget;
 			if (sell != null)
-				OrderButtonsChromeUtils.BindOrderButton<SellOrderGenerator>(world, sell, "sell");
+			{
+				sell.OnClick = () => {
+					if (world.OrderGenerator is SellOrderGenerator)
+					{
+						world.CancelInputMode();
+					}
+					else
+					{
+						world.OrderGenerator = new SellOrderGenerator(blockedCursor);
+					}
+				};
+
+				sell.IsHighlighted = () => world.OrderGenerator is SellOrderGenerator;
+
+				sell.Get<ImageWidget>("ICON").GetImageName =
+					() => world.OrderGenerator is SellOrderGenerator ? "sell-active" : "sell";
+			}
 		}
 	}
 

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -306,6 +306,7 @@ Container@PLAYER_WIDGETS:
 									ImageCollection: order-icons
 						Button@SELL_BUTTON:
 							Logic: SellOrderButtonLogic, AddFactionSuffixLogic
+								BlockedCursor: ability
 							X: 32
 							Width: 28
 							Height: 28

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -281,6 +281,9 @@
 	HitShape:
 	EditorTilesetFilter:
 		Categories: Vehicle
+	Sellable:
+		Cursor: sell2
+		SellSounds: cashturn.aud
 
 ^Tank:
 	Inherits: ^Vehicle


### PR DESCRIPTION
Fixes #14283.

When hovering the cursor over a sellable unit, it now shows cursor set on its Sellable: trait. Otherwise it fallsblack to blocked cursor defined on sell button's chrome definition, which is `sell-blocked` by default.

For testcase i made RA vehicles sellable and use green sell cursor from original game, and changed blocked sell cursor to `ability`. You can look to other mods to ensure everything works fine without defining anything new on yaml.