### PR TITLE
Fix order deserialization when there is no indended order subject

### DIFF
--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -140,7 +140,7 @@ namespace OpenRA
 						if (world == null)
 							return new Order(order, null, target, targetString, queued, extraLocation, extraData);
 
-						if (subject == null)
+						if (subject == null && subjectId != uint.MaxValue)
 							return null;
 
 						return new Order(order, subject, target, targetString, queued, extraLocation, extraData);


### PR DESCRIPTION
Fixes an issue introduced in #14189. The old code relied on some ... _questionable_ behaviour.
Basically the fix is "if there is an intended subject for the order but we can't find it, `return null`; if we didn't find a subject actor because the subject ID is a placeholder, carry on".

Fixes #14284.