### PR TITLE
Proposal to rename V2 Rocket to V2 Rocket Launcher in tooltip

### DIFF
--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -10,7 +10,7 @@ V2RL:
 	Valued:
 		Cost: 900
 	Tooltip:
-		Name: V2 Rocket
+		Name: V2 Rocket Launcher
 	Health:
 		HP: 200
 	Armor:


### PR DESCRIPTION
In the vehicles.yaml file, the V2 Rocket internal name is V2RL. The tooltip shows V2 Rocket. In my opinion, this name is more about the rocket than the actual vehicle, which is a V2 Rocket Launcher.

I tested the original game, and the tooltip also says V2 Rocket. However, the Red Alert manual says V2 Rocket Launcher. I think this change is a nice polish, but I let you guys decide.