### PR TITLE
RA - Fix Fake Naval Yard's Name

### DIFF
--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -37,11 +37,11 @@ SYRF:
 		BuildPaletteOrder: 890
 		Queue: Defense
 		Prerequisites: ~structures.france, ~techlevel.medium
-		Description: Looks like a Shipyard.
+		Description: Looks like a Naval Yard.
 		Icon: fake-icon
 	Tooltip:
-		Name: Fake Shipyard
-		GenericName: Shipyard
+		Name: Fake Naval Yard
+		GenericName: Naval Yard
 		GenericVisibility: Enemy
 		GenericStancePrefix: False
 	Targetable:


### PR DESCRIPTION
It was called Fake Shipyard, while actual one is called Naval Yard.

An overlook from #12469.

Would be good to add this into #14242 i guess.