### PR TITLE
Multiply damage and HP by 100 for RA

### DIFF
--- a/mods/ra/maps/bomber-john/rules.yaml
+++ b/mods/ra/maps/bomber-john/rules.yaml
@@ -99,7 +99,7 @@ MNLYR:
 	Tooltip:
 		Name: Bomber
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -126,7 +126,7 @@ MNLYR:
 
 FTUR:
 	Health:
-		HP: 1000
+		HP: 100000
 	Transforms:
 		IntoActor: mnlyr
 		Offset: 0,0
@@ -150,14 +150,14 @@ MINVV:
 	Valued:
 		Cost: 30
 	Health:
-		HP: 200
+		HP: 20000
 	RenderSprites:
 		Image: miner
 	WithSpriteBody:
 	Tooltip:
 		Name: Bomb
 	SelfHealing:
-		Step: -1
+		Step: -100
 		Delay: 1
 		HealIfBelow: 101
 	Explodes:

--- a/mods/ra/maps/center-of-attention-redux-2/rules.yaml
+++ b/mods/ra/maps/center-of-attention-redux-2/rules.yaml
@@ -1,13 +1,13 @@
 OILB.Strong:
 	Inherits: OILB
 	Health:
-		HP: 6000
+		HP: 600000
 	RenderSprites:
 		Image: OILB
 
 OILB.Weak:
 	Inherits: OILB
 	Health:
-		HP: 900
+		HP: 90000
 	RenderSprites:
 		Image: OILB

--- a/mods/ra/maps/desert-shellmap/rules.yaml
+++ b/mods/ra/maps/desert-shellmap/rules.yaml
@@ -108,7 +108,7 @@ Ant:
 	Buildable:
 		Prerequisites: barr
 	Health:
-		HP: 200
+		HP: 20000
 
 E7:
 	-AnnounceOnKill:

--- a/mods/ra/maps/drop-zone-battle-of-tikiaki/rules.yaml
+++ b/mods/ra/maps/drop-zone-battle-of-tikiaki/rules.yaml
@@ -50,7 +50,7 @@ UNITCRATE:
 APC:
 	Inherits@AUTOTARGET: ^AutoTargetGround
 	Health:
-		HP: 1000
+		HP: 100000
 	MustBeDestroyed:
 		RequiredForShortGame: true
 	-AttackMove:
@@ -59,7 +59,7 @@ HARV:
 	Tooltip:
 		Name: Bomb Truck
 	Health:
-		HP: 100
+		HP: 10000
 	Explodes:
 		Weapon: CrateNuke
 		EmptyWeapon: CrateNuke
@@ -69,11 +69,11 @@ HARV:
 
 SHOK:
 	Health:
-		HP: 800
+		HP: 80000
 
 DOG:
 	Health:
-		HP: 120
+		HP: 12000
 	Mobile:
 		Speed: 99
 

--- a/mods/ra/maps/drop-zone-battle-of-tikiaki/weapons.yaml
+++ b/mods/ra/maps/drop-zone-battle-of-tikiaki/weapons.yaml
@@ -2,4 +2,4 @@ PortaTesla:
 	ReloadDelay: 20
 	Range: 10c0
 	Warhead@1Dam: SpreadDamage
-		Damage: 80
+		Damage: 8000

--- a/mods/ra/maps/drop-zone-w/rules.yaml
+++ b/mods/ra/maps/drop-zone-w/rules.yaml
@@ -40,7 +40,7 @@ LST:
 	Tooltip:
 		Name: Naval Mobile HQ
 	Health:
-		HP: 1000
+		HP: 100000
 	Mobile:
 		Speed: 170
 	Armament@PRIMARY:

--- a/mods/ra/maps/drop-zone-w/weapons.yaml
+++ b/mods/ra/maps/drop-zone-w/weapons.yaml
@@ -7,7 +7,7 @@
 		Inaccuracy: 3c341
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 250
+		Damage: 25000
 
 SubMissile:
 	ReloadDelay: 250
@@ -17,4 +17,4 @@ SubMissile:
 		Speed: 409
 		LaunchAngle: 62
 	Warhead@1Dam: SpreadDamage
-		Damage: 400
+		Damage: 40000

--- a/mods/ra/maps/drop-zone/rules.yaml
+++ b/mods/ra/maps/drop-zone/rules.yaml
@@ -50,7 +50,7 @@ UNITCRATE:
 APC:
 	Inherits@AUTOTARGET: ^AutoTargetGround
 	Health:
-		HP: 1000
+		HP: 100000
 	MustBeDestroyed:
 		RequiredForShortGame: true
 	-AttackMove:
@@ -59,7 +59,7 @@ HARV:
 	Tooltip:
 		Name: Bomb Truck
 	Health:
-		HP: 100
+		HP: 10000
 	Explodes:
 		Weapon: CrateNuke
 		EmptyWeapon: CrateNuke
@@ -69,11 +69,11 @@ HARV:
 
 SHOK:
 	Health:
-		HP: 800
+		HP: 80000
 
 DOG:
 	Health:
-		HP: 120
+		HP: 12000
 	Mobile:
 		Speed: 99
 

--- a/mods/ra/maps/drop-zone/weapons.yaml
+++ b/mods/ra/maps/drop-zone/weapons.yaml
@@ -2,4 +2,4 @@ PortaTesla:
 	ReloadDelay: 20
 	Range: 10c0
 	Warhead@1Dam: SpreadDamage
-		Damage: 80
+		Damage: 8000

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -113,7 +113,7 @@ Player:
 
 OILB:
 	Health:
-		HP: 3000
+		HP: 300000
 	Armor:
 		Type: Wood
 	WithBuildingBib:
@@ -134,7 +134,7 @@ MOBILETENT:
 		DecorationBounds: 21,21
 	SelectionDecorations:
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Light
 	Mobile:
@@ -156,7 +156,7 @@ MOBILETENT:
 
 TENT:
 	Health:
-		HP: 1000
+		HP: 100000
 	Production:
 		Produces: Infantry, Soldier, Dog, Defense
 	-Sellable:
@@ -185,7 +185,7 @@ PBOX:
 	Valued:
 		Cost: 400
 	Health:
-		HP: 200
+		HP: 20000
 	Armor:
 		Type: Heavy
 	Power:
@@ -262,7 +262,7 @@ SNIPER:
 	Buildable:
 		Prerequisites: barracks
 	Health:
-		HP: 200
+		HP: 20000
 
 SNIPER.soviets:
 	Inherits: SNIPER
@@ -298,19 +298,19 @@ ARTY:
 	Valued:
 		Cost: 600
 	Health:
-		HP: 75
+		HP: 7500
 	RevealsShroud:
 		Range: 7c0
 
 V2RL:
 	Health:
-		HP: 100
+		HP: 10000
 	ReloadAmmoPool:
 		Delay: 280
 
 4TNK:
 	Health:
-		HP: 2500
+		HP: 250000
 	Mobile:
 		Speed: 56
 	RevealsShroud:
@@ -326,13 +326,13 @@ V2RL:
 		Weapon: napalm
 		EmptyWeapon: napalm
 	SelfHealing:
-		Step: 2
+		Step: 200
 		Delay: 1
 		HealIfBelow: 40
 
 BADR.Bomber:
 	Health:
-		HP: 60
+		HP: 6000
 	Aircraft:
 		Speed: 280
 	AmmoPool:

--- a/mods/ra/maps/fort-lonestar/weapons.yaml
+++ b/mods/ra/maps/fort-lonestar/weapons.yaml
@@ -11,9 +11,12 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Versus:
-			None: 75
-			Concrete: 100
-		Damage: 15000
+			None: 56
+			Wood: 56
+			Light: 56
+			Heavy: 86
+			Concrete: 75
+		Damage: 20000
 	Warhead@3Eff: CreateEffect
 		Explosions: self_destruct
 
@@ -60,12 +63,12 @@ TankNapalm:
 		Spread: 341
 		ValidTargets: Ground
 		Versus:
-			None: 90
-			Wood: 170
-			Light: 100
-			Heavy: 100
-			Concrete: 100
-		Damage: 1500
+			None: 65
+			Wood: 125
+			Light: 75
+			Heavy: 75
+			Concrete: 75
+		Damage: 2000
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
@@ -129,11 +132,11 @@ FLAK-23:
 		Spread: 213
 		ValidTargets: Air, Ground
 		Versus:
-			None: 35
-			Wood: 30
-			Light: 30
+			None: 32
+			Wood: 28
+			Light: 28
 			Heavy: 40
-			Concrete: 30
+			Concrete: 28
 		Damage: 2500
 		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Smu: LeaveSmudge

--- a/mods/ra/maps/fort-lonestar/weapons.yaml
+++ b/mods/ra/maps/fort-lonestar/weapons.yaml
@@ -13,7 +13,7 @@
 		Versus:
 			None: 75
 			Concrete: 100
-		Damage: 150
+		Damage: 15000
 	Warhead@3Eff: CreateEffect
 		Explosions: self_destruct
 
@@ -38,7 +38,7 @@ MammothTusk:
 			Light: 110
 			Heavy: 100
 			Concrete: 200
-		Damage: 250
+		Damage: 25000
 	Warhead@3Eff: CreateEffect
 		Explosions: nuke
 
@@ -65,7 +65,7 @@ TankNapalm:
 			Light: 100
 			Heavy: 100
 			Concrete: 100
-		Damage: 15
+		Damage: 1500
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
@@ -86,7 +86,7 @@ ParaBomb:
 			Wood: 100
 			Light: 60
 			Concrete: 25
-		Damage: 200
+		Damage: 20000
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@3Eff: CreateEffect
 		Explosions: napalm
@@ -111,7 +111,7 @@ ParaBomb:
 			Wood: 100
 			Heavy: 75
 			Concrete: 35
-		Damage: 20
+		Damage: 2000
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath
 	Warhead@3Eff: CreateEffect
 		Explosions: small_napalm
@@ -134,7 +134,7 @@ FLAK-23:
 			Light: 30
 			Heavy: 40
 			Concrete: 30
-		Damage: 25
+		Damage: 2500
 		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Scorch
@@ -157,7 +157,7 @@ SCUD:
 			Wood: 90
 			Light: 80
 			Heavy: 70
-		Damage: 500
+		Damage: 50000
 		AffectsParent: true
 	Warhead@3Eff: CreateEffect
 		Explosions: nuke

--- a/mods/ra/maps/infiltration/rules.yaml
+++ b/mods/ra/maps/infiltration/rules.yaml
@@ -54,7 +54,7 @@ SPY.Strong:
 	RenderSprites:
 		Image: SPY
 	Health:
-		HP: 100
+		HP: 10000
 	RevealsShroud:
 		Range: 6c0
 	Infiltrates:

--- a/mods/ra/maps/intervention/weapons.yaml
+++ b/mods/ra/maps/intervention/weapons.yaml
@@ -3,4 +3,4 @@ Nike:
 
 Maverick:
 	Warhead@1Dam: SpreadDamage
-		Damage: 175
+		Damage: 17500

--- a/mods/ra/maps/monster-tank-madness/rules.yaml
+++ b/mods/ra/maps/monster-tank-madness/rules.yaml
@@ -126,7 +126,7 @@ PBOX:
 		Name: Super Tank
 		GenericName: Super Tank
 	Health:
-		HP: 20000
+		HP: 2000000
 	Armor:
 		Type: Concrete
 	Mobile:
@@ -165,7 +165,7 @@ PBOX:
 	SpawnActorOnDeath:
 		Actor: 5TNK.Husk
 	SelfHealing:
-		Step: 1
+		Step: 100
 		Delay: 1
 		HealIfBelow: 100
 		DamageCooldown: 150
@@ -181,7 +181,7 @@ PBOX:
 	ThrowsParticle@turret:
 		Anim: turret
 	Health:
-		HP: 2000
+		HP: 200000
 	RenderSprites:
 		Image: 4TNK
 

--- a/mods/ra/maps/monster-tank-madness/weapons.yaml
+++ b/mods/ra/maps/monster-tank-madness/weapons.yaml
@@ -11,5 +11,5 @@ SuperTankPrimary:
 	ReloadDelay: 70
 	Report: turret1.aud
 	Warhead@1Dam: SpreadDamage
-		Damage: 500
+		Damage: 50000
 		InvalidTargets: Air, Infantry

--- a/mods/ra/maps/soviet-03/rules.yaml
+++ b/mods/ra/maps/soviet-03/rules.yaml
@@ -25,11 +25,11 @@ World:
 ^Helicopter:
 	-GivesBounty:
 	Health:
-		HP: 9000
+		HP: 900000
 
 FENC:
 	Health:
-		HP: 9000
+		HP: 900000
 
 V01:
 	Cargo:

--- a/mods/ra/maps/survival02/weapons.yaml
+++ b/mods/ra/maps/survival02/weapons.yaml
@@ -7,7 +7,7 @@ ParaBomb:
 		-OpenSequence:
 	Warhead@1Dam: SpreadDamage
 		Spread: 150
-		Damage: 3500
+		Damage: 350000
 		Versus:
 			None: 125
 			Wood: 100

--- a/mods/ra/maps/training-camp/rules.yaml
+++ b/mods/ra/maps/training-camp/rules.yaml
@@ -27,13 +27,13 @@ Player:
 
 OILB:
 	Health:
-		HP: 6000
+		HP: 600000
 
 BARR:
 	Buildable:
 		Prerequisites: ~disabled
 	Health:
-		HP: 5000
+		HP: 500000
 	Production:
 		Produces: Building, Infantry, Soldier, Dog
 	BaseProvider:
@@ -45,7 +45,7 @@ WEAP:
 	Buildable:
 		Prerequisites: ~disabled
 	Health:
-		HP: 10000
+		HP: 1000000
 	Valued:
 		Cost: 2000
 	Power:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -3,7 +3,7 @@ BADR:
 	ParaDrop:
 		DropRange: 4c0
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Light
 	Aircraft:
@@ -44,7 +44,7 @@ BADR.Bomber:
 	Armament:
 		Weapon: ParaBomb
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Light
 	Aircraft:
@@ -96,7 +96,7 @@ MIG:
 	Tooltip:
 		Name: MiG Attack Plane
 	Health:
-		HP: 75
+		HP: 7000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -158,7 +158,7 @@ YAK:
 	Tooltip:
 		Name: Yak Attack Plane
 	Health:
-		HP: 60
+		HP: 6000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -225,7 +225,7 @@ TRAN:
 	Tooltip:
 		Name: Chinook
 	Health:
-		HP: 140
+		HP: 14000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -282,7 +282,7 @@ HELI:
 	Tooltip:
 		Name: Longbow
 	Health:
-		HP: 120
+		HP: 12000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -346,7 +346,7 @@ HIND:
 	Tooltip:
 		Name: Hind
 	Health:
-		HP: 100
+		HP: 10000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -403,7 +403,7 @@ HIND:
 U2:
 	Inherits: ^NeutralPlane
 	Health:
-		HP: 2000
+		HP: 200000
 	Tooltip:
 		Name: Spy Plane
 	Armor:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -96,7 +96,7 @@ MIG:
 	Tooltip:
 		Name: MiG Attack Plane
 	Health:
-		HP: 7000
+		HP: 7500
 	Armor:
 		Type: Light
 	RevealsShroud:

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -70,7 +70,7 @@ FCOM:
 		Dimensions: 2,3
 		LocalCenterOffset: 0,-512,0
 	Health:
-		HP: 800
+		HP: 80000
 	Armor:
 		Type: Wood
 	Tooltip:
@@ -104,7 +104,7 @@ HOSP:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 800
+		HP: 80000
 	ExternalCapturable:
 	ExternalCapturableBar:
 	EngineerRepairable:
@@ -304,7 +304,7 @@ BARL:
 	SelectionDecorations:
 		RenderSelectionBars: False
 	Health:
-		HP: 10
+		HP: 1000
 	Explodes:
 		Weapon: BarrelExplode
 	Tooltip:
@@ -329,7 +329,7 @@ BRL3:
 	SelectionDecorations:
 		RenderSelectionBars: False
 	Health:
-		HP: 10
+		HP: 1000
 	Explodes:
 		Weapon: BarrelExplode
 	Tooltip:
@@ -370,7 +370,7 @@ MISS:
 		Dimensions: 3,3
 		LocalCenterOffset: 0,-512,0
 	Health:
-		HP: 600
+		HP: 60000
 	RevealsShroud:
 		Range: 10c0
 		RevealGeneratedShroud: False
@@ -423,7 +423,7 @@ OILB:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 800
+		HP: 80000
 	RevealsShroud:
 		Range: 4c0
 	ExternalCapturable:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -111,7 +111,7 @@
 		RequiresCondition: rank-elite
 		Modifier: 50
 	SelfHealing@ELITE:
-		Step: 2
+		Step: 200
 		Delay: 100
 		HealIfBelow: 100
 		DamageCooldown: 125
@@ -307,7 +307,7 @@
 	Huntable:
 	DrawLineToTarget:
 	Health:
-		HP: 25
+		HP: 2500
 	Armor:
 		Type: None
 	RevealsShroud:
@@ -359,7 +359,7 @@
 	Tooltip:
 		GenericName: Soldier
 	SelfHealing@HOSPITAL:
-		Step: 5
+		Step: 500
 		Delay: 100
 		HealIfBelow: 100
 		DamageCooldown: 125
@@ -621,6 +621,7 @@
 		AreaTypes: building
 	RepairableBuilding:
 		PlayerExperience: 25
+		RepairStep: 700
 	EngineerRepairable:
 	AcceptsDeliveredCash:
 	WithMakeAnimation:
@@ -692,7 +693,7 @@
 	FrozenUnderFog:
 	FrozenUnderFogUpdatedByGps:
 	Health:
-		HP: 100
+		HP: 10000
 	EditorTilesetFilter:
 		Categories: Wall
 
@@ -701,7 +702,7 @@
 	Valued:
 		Cost: 250
 	Health:
-		HP: 350
+		HP: 35000
 	Armor:
 		Type: Heavy
 	LineBuildNode:
@@ -727,7 +728,7 @@
 	Inherits: ^BasicBuilding
 	Huntable:
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Wood
 	Tooltip:
@@ -741,7 +742,7 @@
 	Inherits: ^Building
 	-GivesBuildableArea:
 	Health:
-		HP: 100
+		HP: 10000
 	Explodes:
 		Weapon: Demolish
 		DamageThreshold: 70
@@ -774,7 +775,7 @@
 	SelectionDecorations:
 		RenderSelectionBars: False
 	Health:
-		HP: 10
+		HP: 1000
 	Explodes:
 		Weapon: UnitExplode
 	Tooltip:
@@ -840,7 +841,7 @@
 	RadarColorFromTerrain:
 		Terrain: Tree
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Wood
 	Targetable:
@@ -888,7 +889,7 @@
 	Inherits@1: ^SpriteActor
 	Interactable:
 	Health:
-		HP: 280
+		HP: 28000
 	Armor:
 		Type: Heavy
 	HiddenUnderFog:
@@ -973,7 +974,7 @@
 		Footprint: ____ ____
 		Dimensions: 4,2
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Concrete
 	ScriptTriggers:
@@ -1055,7 +1056,7 @@
 		AvoidFriendly: false
 		BlockFriendly: false
 	Health:
-		HP: 100
+		HP: 10000
 		NotifyAppliedDamage: false
 	Armor:
 		Type: Light

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -620,8 +620,8 @@
 	GivesBuildableArea:
 		AreaTypes: building
 	RepairableBuilding:
-		PlayerExperience: 25
 		RepairStep: 700
+		PlayerExperience: 25
 	EngineerRepairable:
 	AcceptsDeliveredCash:
 	WithMakeAnimation:
@@ -905,7 +905,7 @@
 	Husk:
 		AllowedTerrain: Clear, Rough, Road, Ore, Gems, Beach
 	Burns:
-		Damage: 2
+		Damage: 200
 	Capturable:
 		Types: husk
 		CaptureThreshold: 100

--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -21,7 +21,7 @@ FPWR:
 		Dimensions: 2,3
 		LocalCenterOffset: 0,-512,0
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Wood
 	WithBuildingBib:
@@ -57,7 +57,7 @@ SYRF:
 	Valued:
 		Cost: 100
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Light
 	EditorTilesetFilter:
@@ -100,7 +100,7 @@ SPEF:
 	Valued:
 		Cost: 100
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Light
 	EditorTilesetFilter:
@@ -142,7 +142,7 @@ WEAF:
 	Valued:
 		Cost: 200
 	Health:
-		HP: 1500
+		HP: 150000
 	Armor:
 		Type: Wood
 
@@ -175,7 +175,7 @@ DOMF:
 	Valued:
 		Cost: 180
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 
@@ -196,7 +196,7 @@ FIXF:
 		Footprint: _X_ xxx _X_
 		Dimensions: 3,3
 	Health:
-		HP: 800
+		HP: 80000
 	Armor:
 		Type: Wood
 	WithBuildingBib:
@@ -237,7 +237,7 @@ FAPW:
 		Dimensions: 3,3
 		LocalCenterOffset: 0,-512,0
 	Health:
-		HP: 700
+		HP: 70000
 	Armor:
 		Type: Wood
 	WithBuildingBib:
@@ -275,7 +275,7 @@ ATEF:
 	Valued:
 		Cost: 150
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Wood
 
@@ -305,7 +305,7 @@ PDOF:
 	Valued:
 		Cost: 150
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	Explodes:
@@ -335,7 +335,7 @@ MSLF:
 	Valued:
 		Cost: 250
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	Explodes:
@@ -364,7 +364,7 @@ FACF:
 	Valued:
 		Cost: 250
 	Health:
-		HP: 1500
+		HP: 150000
 	Armor:
 		Type: Wood
 	HitShape:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -16,7 +16,7 @@ DOG:
 		DecorationBounds: 12,17,-1,-4
 	SelectionDecorations:
 	Health:
-		HP: 18
+		HP: 1800
 	Mobile:
 		Speed: 99
 		Voice: Move
@@ -64,7 +64,7 @@ E1:
 	Tooltip:
 		Name: Rifle Infantry
 	Health:
-		HP: 50
+		HP: 5000
 	Armament@PRIMARY:
 		Weapon: M1Carbine
 	Armament@GARRISONED:
@@ -100,7 +100,7 @@ E2:
 	Tooltip:
 		Name: Grenadier
 	Health:
-		HP: 50
+		HP: 5000
 	Mobile:
 		Speed: 71
 	Armament@PRIMARY:
@@ -138,7 +138,7 @@ E3:
 	Tooltip:
 		Name: Rocket Soldier
 	Health:
-		HP: 45
+		HP: 4500
 	Armament@PRIMARY:
 		Weapon: RedEye
 		LocalOffset: 0,0,555
@@ -182,7 +182,7 @@ E4:
 	Tooltip:
 		Name: Flamethrower
 	Health:
-		HP: 40
+		HP: 4000
 	Armament@PRIMARY:
 		Weapon: Flamer
 		LocalOffset: 700,0,500
@@ -308,7 +308,7 @@ E7:
 	Tooltip:
 		Name: Tanya
 	Health:
-		HP: 100
+		HP: 10000
 	Mobile:
 		Speed: 71
 		Voice: Move
@@ -356,7 +356,7 @@ MEDI:
 	Tooltip:
 		Name: Medic
 	Health:
-		HP: 60
+		HP: 6000
 	RevealsShroud:
 		Range: 3c0
 	Passenger:
@@ -390,7 +390,7 @@ MECH:
 	Tooltip:
 		Name: Mechanic
 	Health:
-		HP: 80
+		HP: 8000
 	Mobile:
 		Voice: Move
 	RevealsShroud:
@@ -507,7 +507,7 @@ HIJACKER:
 	Tooltip:
 		Name: Hijacker
 	Health:
-		HP: 50
+		HP: 5000
 	RevealsShroud:
 		Range: 5c0
 	Passenger:
@@ -550,7 +550,7 @@ SHOK:
 	Tooltip:
 		Name: Shock Trooper
 	Health:
-		HP: 50
+		HP: 5000
 	Mobile:
 		Voice: Move
 	RevealsShroud:
@@ -591,7 +591,7 @@ SNIPER:
 		Prerequisites: ~disabled
 		Description: Elite sniper infantry unit.\nCan detect cloaked units.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft
 	Health:
-		HP: 80
+		HP: 8000
 	Passenger:
 		PipType: Red
 	RevealsShroud:
@@ -642,7 +642,7 @@ Zombie:
 		Prerequisites: ~barracks, ~bio
 		Description: Slow undead. Attacks in close combat.
 	Health:
-		HP: 250
+		HP: 25000
 	Mobile:
 		Speed: 42
 	AutoTarget:
@@ -676,7 +676,7 @@ Ant:
 		DecorationBounds: 30,30,0,-2
 	SelectionDecorations:
 	Health:
-		HP: 750
+		HP: 75000
 	Mobile:
 		Speed: 99
 		TurnSpeed: 12

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -12,7 +12,7 @@ SS:
 	Tooltip:
 		Name: Submarine
 	Health:
-		HP: 250
+		HP: 25000
 	Armor:
 		Type: Light
 	Mobile:
@@ -80,7 +80,7 @@ MSUB:
 	Tooltip:
 		Name: Missile Submarine
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Light
 	Mobile:
@@ -147,7 +147,7 @@ DD:
 	Tooltip:
 		Name: Destroyer
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -198,7 +198,7 @@ CA:
 	Tooltip:
 		Name: Cruiser
 	Health:
-		HP: 800
+		HP: 80000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -254,7 +254,7 @@ LST:
 	Tooltip:
 		Name: Transport
 	Health:
-		HP: 350
+		HP: 35000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -295,7 +295,7 @@ PT:
 	Tooltip:
 		Name: Gunboat
 	Health:
-		HP: 200
+		HP: 20000
 	Armor:
 		Type: Heavy
 	Mobile:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -162,9 +162,9 @@ SPEN:
 		PrimaryCondition: primary
 	-EmitInfantryOnSell:
 	RepairsUnits:
+		HpPerStep: 1000
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
-		HpPerStep: 1000
 	RallyPoint:
 	ProductionBar:
 	Power:
@@ -266,9 +266,9 @@ SYRD:
 		PrimaryCondition: primary
 	-EmitInfantryOnSell:
 	RepairsUnits:
+		HpPerStep: 1000
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
-		HpPerStep: 1000
 	RallyPoint:
 	ProductionBar:
 	Power:
@@ -1761,10 +1761,10 @@ FIX:
 	Reservable:
 	RallyPoint:
 	RepairsUnits:
+		HpPerStep: 1000
 		Interval: 7
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
-		HpPerStep: 1000
 	WithRepairAnimation:
 	WithRearmAnimation:
 	Power:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -16,7 +16,7 @@ MSLO:
 		Footprint: xx
 		Dimensions: 2,1
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -80,7 +80,7 @@ GAP:
 	WithSpriteBody:
 		PauseOnCondition: disabled
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -132,7 +132,7 @@ SPEN:
 		Adjacent: 8
 	-GivesBuildableArea:
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -164,6 +164,7 @@ SPEN:
 	RepairsUnits:
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
+		HpPerStep: 1000
 	RallyPoint:
 	ProductionBar:
 	Power:
@@ -235,7 +236,7 @@ SYRD:
 		Adjacent: 8
 	-GivesBuildableArea:
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -267,6 +268,7 @@ SYRD:
 	RepairsUnits:
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
+		HpPerStep: 1000
 	RallyPoint:
 	ProductionBar:
 	Power:
@@ -344,7 +346,7 @@ IRON:
 		DecorationBounds: 50,50,0,-12
 	SelectionDecorations:
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -398,7 +400,7 @@ PDOX:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -476,7 +478,7 @@ TSLA:
 		DecorationBounds: 24,40,0,-8
 	SelectionDecorations:
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -521,7 +523,7 @@ AGUN:
 		DecorationBounds: 24,32,0,-4
 	SelectionDecorations:
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -574,7 +576,7 @@ DOME:
 	Targetable:
 		TargetTypes: Ground, Structure, C4, DetonateAttack, SpyInfiltrate
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -618,7 +620,7 @@ PBOX:
 	CustomSellValue:
 		Value: 400
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -667,7 +669,7 @@ HBOX:
 	CustomSellValue:
 		Value: 500
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -721,7 +723,7 @@ GUN:
 		Name: Turret
 	Building:
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -763,7 +765,7 @@ FTUR:
 		Name: Flame Tower
 	Building:
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -814,7 +816,7 @@ SAM:
 		Footprint: xx
 		Dimensions: 2,1
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -864,7 +866,7 @@ ATEK:
 		Dimensions: 2,3
 		LocalCenterOffset: 0,-512,0
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -905,7 +907,7 @@ WEAP:
 		Dimensions: 3,3
 		LocalCenterOffset: 0,-512,0
 	Health:
-		HP: 1500
+		HP: 150000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1033,7 +1035,7 @@ FACT:
 		Factions: ukraine
 		Prerequisite: structures.ukraine
 	Health:
-		HP: 1500
+		HP: 150000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1099,7 +1101,7 @@ PROC:
 	Targetable:
 		TargetTypes: Ground, Structure, C4, DetonateAttack, SpyInfiltrate
 	Health:
-		HP: 900
+		HP: 90000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1160,7 +1162,7 @@ SILO:
 		Name: Silo
 	-GivesBuildableArea:
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1198,7 +1200,7 @@ HPAD:
 		Dimensions: 2,3
 		LocalCenterOffset: 0,-512,0
 	Health:
-		HP: 800
+		HP: 80000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1284,7 +1286,7 @@ AFLD:
 		Footprint: xxx xxx
 		Dimensions: 3,2
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1422,7 +1424,7 @@ POWR:
 		Dimensions: 2,3
 		LocalCenterOffset: 0,-512,0
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1463,7 +1465,7 @@ APWR:
 		DecorationBounds: 72,68,0,-10
 	SelectionDecorations:
 	Health:
-		HP: 700
+		HP: 70000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1499,7 +1501,7 @@ STEK:
 		Dimensions: 3,3
 		LocalCenterOffset: 0,-512,0
 	Health:
-		HP: 800
+		HP: 80000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1532,7 +1534,7 @@ BARR:
 		Dimensions: 2,3
 		LocalCenterOffset: 0,-512,0
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1607,7 +1609,7 @@ KENN:
 		Name: Kennel
 	-GivesBuildableArea:
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1659,7 +1661,7 @@ TENT:
 		Dimensions: 2,3
 		LocalCenterOffset: 0,-512,0
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1746,7 +1748,7 @@ FIX:
 		DecorationBounds: 72,48
 	SelectionDecorations:
 	Health:
-		HP: 800
+		HP: 80000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1762,6 +1764,7 @@ FIX:
 		Interval: 7
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
+		HpPerStep: 1000
 	WithRepairAnimation:
 	WithRearmAnimation:
 	Power:
@@ -1791,7 +1794,7 @@ SBAG:
 	Tooltip:
 		Name: Sandbag Wall
 	Health:
-		HP: 150
+		HP: 15000
 	Armor:
 		Type: Wood
 	LineBuild:
@@ -1816,7 +1819,7 @@ FENC:
 	Tooltip:
 		Name: Wire Fence
 	Health:
-		HP: 150
+		HP: 15000
 	Armor:
 		Type: Wood
 	LineBuild:
@@ -1844,7 +1847,7 @@ BRIK:
 		DamagedSounds: crmble2.aud
 		DestroyedSounds: kaboom30.aud
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Concrete
 	Crushable:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -12,7 +12,7 @@ V2RL:
 	Tooltip:
 		Name: V2 Rocket Launcher
 	Health:
-		HP: 200
+		HP: 20000
 	Armor:
 		Type: Light
 	Mobile:
@@ -60,7 +60,7 @@ V2RL:
 	Tooltip:
 		Name: Light Tank
 	Health:
-		HP: 220
+		HP: 22000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -101,7 +101,7 @@ V2RL:
 	Tooltip:
 		Name: Medium Tank
 	Health:
-		HP: 450
+		HP: 45000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -145,7 +145,7 @@ V2RL:
 	Tooltip:
 		Name: Heavy Tank
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -191,7 +191,7 @@ V2RL:
 	Tooltip:
 		Name: Mammoth Tank
 	Health:
-		HP: 900
+		HP: 90000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -223,7 +223,7 @@ V2RL:
 	SpawnActorOnDeath:
 		Actor: 4TNK.Husk
 	SelfHealing:
-		Step: 1
+		Step: 100
 		Delay: 3
 		HealIfBelow: 50
 		DamageCooldown: 150
@@ -249,7 +249,7 @@ ARTY:
 	Tooltip:
 		Name: Artillery
 	Health:
-		HP: 100
+		HP: 10000
 	Armor:
 		Type: Light
 	Mobile:
@@ -296,7 +296,7 @@ HARV:
 		SearchFromProcRadius: 30
 		SearchFromOrderRadius: 11
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -315,7 +315,7 @@ HARV:
 		FullActor: HARV.FullHusk
 		FullnessThreshold: 50
 	SelfHealing:
-		Step: 1
+		Step: 100
 		Delay: 25
 		HealIfBelow: 50
 		DamageCooldown: 500
@@ -340,7 +340,7 @@ MCV:
 		DecorationBounds: 42,42
 	SelectionDecorations:
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Light
 	Mobile:
@@ -374,7 +374,7 @@ JEEP:
 	Tooltip:
 		Name: Ranger
 	Health:
-		HP: 150
+		HP: 15000
 	Armor:
 		Type: Light
 	Mobile:
@@ -418,7 +418,7 @@ APC:
 	Tooltip:
 		Name: Armored Personnel Carrier
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -456,7 +456,7 @@ MNLY:
 	Tooltip:
 		Name: Minelayer
 	Health:
-		HP: 150
+		HP: 15000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -496,7 +496,7 @@ TRUK:
 	Selectable:
 		Priority: 6
 	Health:
-		HP: 110
+		HP: 11000
 	Armor:
 		Type: Light
 	Mobile:
@@ -523,7 +523,7 @@ MGG:
 	Tooltip:
 		Name: Mobile Gap Generator
 	Health:
-		HP: 220
+		HP: 22000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -556,7 +556,7 @@ MRJ:
 		BuildDurationModifier: 40
 		Description: Jams nearby enemy radar domes\nand deflects incoming missiles.\nCan detect cloaked units.\n  Unarmed
 	Health:
-		HP: 220
+		HP: 22000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -596,7 +596,7 @@ TTNK:
 	Tooltip:
 		Name: Tesla Tank
 	Health:
-		HP: 450
+		HP: 45000
 	Armor:
 		Type: Light
 	Mobile:
@@ -634,7 +634,7 @@ FTRK:
 	Tooltip:
 		Name: Mobile Flak
 	Health:
-		HP: 150
+		HP: 15000
 	Armor:
 		Type: Light
 	Mobile:
@@ -679,7 +679,7 @@ DTRK:
 	Tooltip:
 		Name: Demolition Truck
 	Health:
-		HP: 50
+		HP: 5000
 	Armor:
 		Type: Light
 	Mobile:
@@ -712,7 +712,7 @@ CTNK:
 		Name: Chrono Tank
 	SelectionDecorations:
 	Health:
-		HP: 450
+		HP: 45000
 	Armor:
 		Type: Light
 	Mobile:
@@ -751,7 +751,7 @@ QTNK:
 	Tooltip:
 		Name: MAD Tank
 	Health:
-		HP: 900
+		HP: 90000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -784,7 +784,7 @@ STNK:
 	Tooltip:
 		Name: Phase Transport
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Light
 	Mobile:

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -37,12 +37,13 @@
 		Speed: 853
 		Image: 50CAL
 	Warhead@1Dam: SpreadDamage
-		Damage: 2700
+		Damage: 2500
 		Versus:
-			Wood: 50
-			Light: 110
-			Heavy: 45
-			Concrete: 30
+			None: 32
+			Wood: 40
+			Light: 116
+			Heavy: 48
+			Concrete: 32
 	-Warhead@2Smu: LeaveSmudge
 	Warhead@3Eff: CreateEffect
 		-ImpactSounds:
@@ -83,8 +84,8 @@ TurretGun:
 	Warhead@1Dam: SpreadDamage
 		Damage: 6000
 		Versus:
-			Wood: 50
 			None: 20
+			Wood: 50
 
 ^Artillery:
 	Inherits: ^Cannon
@@ -153,6 +154,11 @@ TurretGun:
 		Speed: 426
 	Warhead@1Dam: SpreadDamage
 		Damage: 2500
+		Versus:
+			None: 28
+			Wood: 72
+			Light: 72
+			Concrete: 48
 
 Grenade:
 	Inherits: ^Artillery

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -8,7 +8,7 @@
 		Shadow: True
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 40
+		Damage: 4000
 		Versus:
 			None: 30
 			Wood: 75
@@ -37,7 +37,7 @@
 		Speed: 853
 		Image: 50CAL
 	Warhead@1Dam: SpreadDamage
-		Damage: 27
+		Damage: 2700
 		Versus:
 			Wood: 50
 			Light: 110
@@ -70,7 +70,7 @@
 	Burst: 2
 	InvalidTargets: Air, Infantry
 	Warhead@1Dam: SpreadDamage
-		Damage: 60
+		Damage: 6000
 		Versus:
 			Heavy: 115
 		InvalidTargets: Air
@@ -81,7 +81,7 @@ TurretGun:
 	Range: 7c0
 	Report: turret1.aud
 	Warhead@1Dam: SpreadDamage
-		Damage: 60
+		Damage: 6000
 		Versus:
 			Wood: 50
 			None: 20
@@ -97,7 +97,7 @@ TurretGun:
 		Inaccuracy: 1c938
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 230
+		Damage: 23000
 		Versus:
 			None: 90
 			Wood: 40
@@ -132,7 +132,7 @@ TurretGun:
 		ContrailLength: 30
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 25
+		Damage: 2500
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
 			None: 60
@@ -152,7 +152,7 @@ TurretGun:
 	Projectile: Bullet
 		Speed: 426
 	Warhead@1Dam: SpreadDamage
-		Damage: 25
+		Damage: 2500
 
 Grenade:
 	Inherits: ^Artillery
@@ -165,7 +165,7 @@ Grenade:
 		Image: BOMB
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
-		Damage: 60
+		Damage: 6000
 		Versus:
 			None: 60
 			Wood: 100
@@ -190,7 +190,7 @@ DepthCharge:
 		Inaccuracy: 128
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 80
+		Damage: 8000
 		ValidTargets: Submarine
 		Versus:
 			None: 30

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -40,7 +40,7 @@
 		Damage: 2500
 		Versus:
 			None: 32
-			Wood: 40
+			Wood: 52
 			Light: 116
 			Heavy: 48
 			Concrete: 32

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -127,7 +127,7 @@ CivBuildingExplosion:
 	Inherits: SmallBuildingExplode
 	Warhead@1Dam: SpreadDamage # Used to panic civilians which are emitted from a killed CivBuilding
 		Spread: 64
-		Damage: 100
+		Damage: 1
 		Delay: 1
 
 BarrelExplode:
@@ -181,9 +181,9 @@ OreExplosion:
 		Damage: 1000
 		Versus:
 			None: 90
-			Wood: 75
+			Wood: 70
 			Light: 60
-			Heavy: 25
+			Heavy: 20
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@3Res: CreateResource
 		AddsResourceType: Ore

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -2,7 +2,7 @@
 	ValidTargets: Ground, Water, Air
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 50
+		Damage: 5000
 		Versus:
 			None: 90
 			Wood: 75
@@ -28,7 +28,7 @@ CrateNapalm:
 	ValidTargets: Ground, Trees
 	Warhead@1Dam: SpreadDamage
 		Spread: 170
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: Ground, Trees
 		Versus:
@@ -94,7 +94,7 @@ UnitExplodeSubmarine:
 UnitExplodeSmall:
 	Inherits: ^Explosion
 	Warhead@1Dam: SpreadDamage
-		Damage: 40
+		Damage: 4000
 	Warhead@2Eff: CreateEffect
 		Explosions: large_explosion
 		ImpactSounds: kaboom15.aud
@@ -102,7 +102,7 @@ UnitExplodeSmall:
 ArtilleryExplode:
 	Inherits: ^Explosion
 	Warhead@1Dam: SpreadDamage
-		Damage: 150
+		Damage: 15000
 	Warhead@2Eff: CreateEffect
 		Explosions: self_destruct
 		ImpactSounds: kaboom22.aud
@@ -127,7 +127,7 @@ CivBuildingExplosion:
 	Inherits: SmallBuildingExplode
 	Warhead@1Dam: SpreadDamage # Used to panic civilians which are emitted from a killed CivBuilding
 		Spread: 64
-		Damage: 1
+		Damage: 100
 		Delay: 1
 
 BarrelExplode:
@@ -155,7 +155,7 @@ BarrelExplode:
 ATMine:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
-		Damage: 400
+		Damage: 40000
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Eff: CreateEffect
@@ -178,7 +178,7 @@ APMine:
 OreExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 9
-		Damage: 10
+		Damage: 1000
 		Versus:
 			None: 90
 			Wood: 75
@@ -196,7 +196,7 @@ CrateNuke:
 	ValidTargets: Ground, Trees, Water, Air
 	Warhead@1Dam_impact: SpreadDamage
 		Spread: 1c0
-		Damage: 100
+		Damage: 10000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: Ground, Trees, Water, Air
 		Versus:
@@ -210,7 +210,7 @@ CrateNuke:
 		VictimScanRadius: 0
 	Warhead@4Dam_areanuke1: SpreadDamage
 		Spread: 1c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 600, 400, 250, 150, 100, 0
 		Delay: 5
 		ValidTargets: Ground, Water, Air
@@ -232,7 +232,7 @@ CrateNuke:
 		Delay: 5
 	Warhead@TREEKILL: SpreadDamage
 		Spread: 1c0
-		Damage: 120
+		Damage: 12000
 		Falloff: 1000, 600, 400, 250, 150, 100, 0
 		Delay: 5
 		ValidTargets: Trees
@@ -242,7 +242,7 @@ MiniNuke:
 	ValidTargets: Ground, Trees, Water, Underwater, Air
 	Warhead@1Dam_impact: SpreadDamage
 		Spread: 1c0
-		Damage: 150
+		Damage: 15000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: Ground, Trees, Water, Air
 		Versus:
@@ -258,7 +258,7 @@ MiniNuke:
 		VictimScanRadius: 0
 	Warhead@4Dam_areanuke1: SpreadDamage
 		Spread: 2c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 5
 		ValidTargets: Ground, Trees, Water, Underwater, Air
@@ -276,7 +276,7 @@ MiniNuke:
 		VictimScanRadius: 0
 	Warhead@7Dam_areanuke2: SpreadDamage
 		Spread: 3c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 10
 		ValidTargets: Ground, Water, Underwater, Air
@@ -287,7 +287,7 @@ MiniNuke:
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@8Dam_areanuke2: SpreadDamage
 		Spread: 3c0
-		Damage: 120
+		Damage: 12000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 10
 		ValidTargets: Trees
@@ -297,7 +297,7 @@ MiniNuke:
 		Delay: 10
 	Warhead@10Dam_areanuke3: SpreadDamage
 		Spread: 4c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 15
 		ValidTargets: Ground, Water, Underwater
@@ -307,7 +307,7 @@ MiniNuke:
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@11Dam_areanuke3: SpreadDamage
 		Spread: 4c0
-		Damage: 180
+		Damage: 18000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 15
 		ValidTargets: Trees

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -15,7 +15,7 @@
 		RangeLimit: 6c0
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 50
+		Damage: 5000
 		ValidTargets: Ground, Water, Air
 		Versus:
 			None: 10
@@ -57,7 +57,7 @@ Maverick:
 		CruiseAltitude: 2c0
 		RangeLimit: 14c410
 	Warhead@1Dam: SpreadDamage
-		Damage: 70
+		Damage: 7000
 		Versus:
 			None: 30
 			Wood: 90
@@ -81,7 +81,7 @@ HellfireAG:
 		HorizontalRateOfTurn: 10
 		RangeLimit: 8c512
 	Warhead@1Dam: SpreadDamage
-		Damage: 60
+		Damage: 6000
 		Versus:
 			None: 30
 			Wood: 90
@@ -100,7 +100,7 @@ HellfireAA:
 		HorizontalRateOfTurn: 10
 		RangeLimit: 7c0
 	Warhead@1Dam: SpreadDamage
-		Damage: 40
+		Damage: 4000
 		ValidTargets: Air
 		Versus:
 			Light: 75
@@ -119,7 +119,7 @@ MammothTusk:
 		RangeLimit: 9c614
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
-		Damage: 50
+		Damage: 5000
 		ValidTargets: Air, Infantry
 		Versus:
 			None: 100
@@ -148,7 +148,7 @@ Nike:
 		RangeLimit: 9c0
 		Speed: 341
 	Warhead@1Dam: SpreadDamage
-		Damage: 50
+		Damage: 5000
 		ValidTargets: Air
 		Versus:
 			None: 90
@@ -166,7 +166,7 @@ RedEye:
 		HorizontalRateOfTurn: 20
 		Speed: 298
 	Warhead@1Dam: SpreadDamage
-		Damage: 40
+		Damage: 4000
 		ValidTargets: Air
 		Versus:
 			Wood: 75
@@ -188,7 +188,7 @@ Stinger:
 		Speed: 170
 		CloseEnough: 149
 	Warhead@1Dam: SpreadDamage
-		Damage: 30
+		Damage: 3000
 		Versus:
 			None: 30
 			Light: 75
@@ -214,7 +214,7 @@ APTusk:
 		HorizontalRateOfTurn: 10
 		RangeLimit: 7c204
 	Warhead@1Dam: SpreadDamage
-		Damage: 30
+		Damage: 3000
 		Versus:
 			None: 25
 			Light: 75
@@ -240,7 +240,7 @@ TorpTube:
 		CruiseAltitude: 0
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 180
+		Damage: 18000
 		ValidTargets: Water, Underwater, Bridge
 		Versus:
 			None: 30
@@ -275,7 +275,7 @@ TorpTube:
 		ContrailLength: 30
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
-		Damage: 25
+		Damage: 2500
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
 			None: 40
@@ -310,7 +310,7 @@ SubMissileAA:
 	Inherits: ^SubMissileDefault
 	ValidTargets: Air
 	Warhead@1Dam: SpreadDamage
-		Damage: 15
+		Damage: 1500
 
 SCUD:
 	Inherits: ^AntiGroundMissile
@@ -330,7 +330,7 @@ SCUD:
 		LaunchAngle: 62
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
-		Damage: 45
+		Damage: 4500
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: Ground, Water, Trees
 		Versus:

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -19,8 +19,8 @@
 		ValidTargets: Ground, Water, Air
 		Versus:
 			None: 10
-			Wood: 75
-			Light: 35
+			Wood: 74
+			Light: 34
 			Heavy: 100
 			Concrete: 50
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
@@ -103,6 +103,7 @@ HellfireAA:
 		Damage: 4000
 		ValidTargets: Air
 		Versus:
+			Wood: 75
 			Light: 75
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion_air
@@ -124,7 +125,7 @@ MammothTusk:
 		Versus:
 			None: 100
 			Light: 60
-			Heavy: 25
+			Heavy: 24
 			Concrete: 50
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@3Eff: CreateEffect
@@ -188,11 +189,13 @@ Stinger:
 		Speed: 170
 		CloseEnough: 149
 	Warhead@1Dam: SpreadDamage
-		Damage: 3000
+		Damage: 2500
 		Versus:
-			None: 30
-			Light: 75
-			Concrete: 50
+			None: 36
+			Wood: 88
+			Light: 88
+			Heavy: 120
+			Concrete: 60
 
 StingerAA:
 	Inherits: Stinger
@@ -214,11 +217,13 @@ APTusk:
 		HorizontalRateOfTurn: 10
 		RangeLimit: 7c204
 	Warhead@1Dam: SpreadDamage
-		Damage: 3000
+		Damage: 2500
 		Versus:
-			None: 25
-			Light: 75
-			Concrete: 50
+			None: 28
+			Wood: 88
+			Light: 88
+			Heavy: 120
+			Concrete: 60
 
 TorpTube:
 	ReloadDelay: 100
@@ -335,6 +340,7 @@ SCUD:
 		ValidTargets: Ground, Water, Trees
 		Versus:
 			None: 90
+			Wood: 75
 			Light: 70
 			Heavy: 40
 			Concrete: 100

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -46,9 +46,13 @@ Flamer:
 		Inaccuracy: 853
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
-		Damage: 800
+		Damage: 1000
 		Versus:
-			Wood: 100
+			None: 70
+			Wood: 80
+			Light: 40
+			Heavy: 20
+			Concrete: 10
 	Warhead@3Eff: CreateEffect
 		Explosions: small_napalm
 
@@ -92,7 +96,7 @@ PortaTesla:
 	Warhead@1Dam: SpreadDamage
 		Damage: 4500
 		Versus:
-			Wood: 75
+			Wood: 73
 			Heavy: 60
 
 TTankZap:
@@ -155,9 +159,9 @@ Claw:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 3300
+		Damage: 3000
 		Versus:
-			None: 90
+			None: 97
 			Wood: 10
 			Light: 30
 			Heavy: 10
@@ -169,6 +173,8 @@ Mandible:
 	ReloadDelay: 10
 	Warhead@1Dam: SpreadDamage
 		Damage: 6000
+		Versus:
+			None: 90
 
 MADTankThump:
 	InvalidTargets: MADTank, Infantry

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -4,7 +4,7 @@
 	Range: 5c0
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 150
+		Damage: 15000
 		ValidTargets: Ground, Water, Trees
 		Versus:
 			None: 90
@@ -46,7 +46,7 @@ Flamer:
 		Inaccuracy: 853
 	Warhead@1Dam: SpreadDamage
 		Spread: 341
-		Damage: 8
+		Damage: 800
 		Versus:
 			Wood: 100
 	Warhead@3Eff: CreateEffect
@@ -62,7 +62,7 @@ Napalm:
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Spread: 170
-		Damage: 100
+		Damage: 10000
 		Versus:
 			Wood: 100
 			Concrete: 50
@@ -74,7 +74,7 @@ Napalm:
 	Projectile: TeslaZap
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
-		Damage: 100
+		Damage: 10000
 		Versus:
 			None: 1000
 		DamageTypes: Prone50Percent, TriggerProne, ElectricityDeath
@@ -90,7 +90,7 @@ PortaTesla:
 	ReloadDelay: 70
 	Range: 6c0
 	Warhead@1Dam: SpreadDamage
-		Damage: 45
+		Damage: 4500
 		Versus:
 			Wood: 75
 			Heavy: 60
@@ -107,7 +107,7 @@ DogJaw:
 	Report: dogg5p.aud
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 100
+		Damage: 10000
 		ValidTargets: Infantry
 		InvalidTargets: Ant
 		DamageTypes: DefaultDeath
@@ -121,7 +121,7 @@ Heal:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: -50
+		Damage: -5000
 		ValidStances: Ally
 		ValidTargets: Infantry
 		DebugOverlayColor: 00FF00
@@ -131,12 +131,12 @@ Repair:
 	Report: fixit1.aud
 	ValidTargets: Repair
 	Warhead@1Dam: SpreadDamage
-		Damage: -20
+		Damage: -2000
 		ValidTargets: Repair
 
 Crush:
 	Warhead@1Dam: SpreadDamage
-		Damage: 100
+		Damage: 10000
 		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Eff: CreateEffect
 		ImpactSounds: squishy2.aud
@@ -155,7 +155,7 @@ Claw:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 33
+		Damage: 3300
 		Versus:
 			None: 90
 			Wood: 10
@@ -168,7 +168,7 @@ Mandible:
 	Inherits: Claw
 	ReloadDelay: 10
 	Warhead@1Dam: SpreadDamage
-		Damage: 60
+		Damage: 6000
 
 MADTankThump:
 	InvalidTargets: MADTank, Infantry

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -32,7 +32,7 @@ ZSU-23:
 	Warhead@1Dam: SpreadDamage
 		Damage: 1200
 		Versus:
-			None: 30
+			None: 25
 			Wood: 75
 			Light: 75
 			Heavy: 100
@@ -65,13 +65,13 @@ FLAK-23-AG:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 3000
+		Damage: 2500
 		Versus:
-			None: 100
-			Wood: 50
-			Light: 60
-			Heavy: 25
-			Concrete: 25
+			None: 120
+			Wood: 60
+			Light: 72
+			Heavy: 28
+			Concrete: 28
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
@@ -84,10 +84,11 @@ FLAK-23-AG:
 ^LightMG:
 	Inherits: ^HeavyMG
 	Warhead@1Dam: SpreadDamage
-		Damage: 1500
+		Damage: 1000
 		Versus:
+			None: 150
 			Wood: 10
-			Light: 30
+			Light: 40
 			Heavy: 10
 			Concrete: 10
 
@@ -97,7 +98,10 @@ Vulcan:
 		Damage: 1000
 		Versus:
 			None: 200
+			Wood: 50
 			Light: 50
+			Heavy: 20
+			Concrete: 20
 	Warhead@4Dam_2: SpreadDamage
 		Spread: 128
 		Damage: 1000
@@ -106,8 +110,8 @@ Vulcan:
 			None: 200
 			Wood: 50
 			Light: 50
-			Heavy: 25
-			Concrete: 25
+			Heavy: 20
+			Concrete: 20
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@4Eff_2: CreateEffect
 		Explosions: piffs
@@ -126,8 +130,8 @@ Vulcan:
 			None: 200
 			Wood: 50
 			Light: 50
-			Heavy: 25
-			Concrete: 25
+			Heavy: 20
+			Concrete: 20
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@6Eff_3: CreateEffect
 		Explosions: piffs
@@ -146,8 +150,8 @@ Vulcan:
 			None: 200
 			Wood: 50
 			Light: 50
-			Heavy: 25
-			Concrete: 25
+			Heavy: 20
+			Concrete: 20
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@8Eff_4: CreateEffect
 		Explosions: piffs
@@ -166,8 +170,8 @@ Vulcan:
 			None: 200
 			Wood: 50
 			Light: 50
-			Heavy: 25
-			Concrete: 25
+			Heavy: 20
+			Concrete: 20
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@10Eff_5: CreateEffect
 		Explosions: piffs
@@ -186,8 +190,8 @@ Vulcan:
 			None: 200
 			Wood: 50
 			Light: 50
-			Heavy: 25
-			Concrete: 25
+			Heavy: 20
+			Concrete: 20
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@12Eff_6: CreateEffect
 		Explosions: piffs
@@ -208,7 +212,7 @@ ChainGun:
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Versus:
-			None: 120
+			None: 144
 
 ChainGun.Yak:
 	Inherits: ^HeavyMG
@@ -219,6 +223,12 @@ ChainGun.Yak:
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Damage: 4000
+		Versus:
+			None: 100
+			Wood: 50
+			Light: 60
+			Heavy: 25
+			Concrete: 25
 
 Pistol:
 	Inherits: ^LightMG
@@ -227,6 +237,8 @@ Pistol:
 	Report: gun27.aud
 	Warhead@1Dam: SpreadDamage
 		Damage: 100
+		Versus:
+			None: 100
 	Warhead@2Eff: CreateEffect
 		Explosions: piff
 	Warhead@3EffWater: CreateEffect
@@ -239,7 +251,7 @@ M1Carbine:
 	Report: gun11.aud
 	Warhead@1Dam: SpreadDamage
 		Versus:
-			Wood: 25
+			Wood: 30
 
 M60mg:
 	Inherits: ^LightMG

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -8,7 +8,7 @@
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
-		Damage: 20
+		Damage: 2000
 		ValidTargets: Air
 		Versus:
 			None: 40
@@ -30,7 +30,7 @@ ZSU-23:
 	Projectile: Bullet
 		Speed: 3c340
 	Warhead@1Dam: SpreadDamage
-		Damage: 12
+		Damage: 1200
 		Versus:
 			None: 30
 			Wood: 75
@@ -65,7 +65,7 @@ FLAK-23-AG:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 30
+		Damage: 3000
 		Versus:
 			None: 100
 			Wood: 50
@@ -84,7 +84,7 @@ FLAK-23-AG:
 ^LightMG:
 	Inherits: ^HeavyMG
 	Warhead@1Dam: SpreadDamage
-		Damage: 15
+		Damage: 1500
 		Versus:
 			Wood: 10
 			Light: 30
@@ -94,13 +94,13 @@ FLAK-23-AG:
 Vulcan:
 	Inherits: ^HeavyMG
 	Warhead@1Dam: SpreadDamage
-		Damage: 10
+		Damage: 1000
 		Versus:
 			None: 200
 			Light: 50
 	Warhead@4Dam_2: SpreadDamage
 		Spread: 128
-		Damage: 10
+		Damage: 1000
 		Delay: 2
 		Versus:
 			None: 200
@@ -120,7 +120,7 @@ Vulcan:
 		Delay: 2
 	Warhead@5Dam_3: SpreadDamage
 		Spread: 128
-		Damage: 10
+		Damage: 1000
 		Delay: 4
 		Versus:
 			None: 200
@@ -140,7 +140,7 @@ Vulcan:
 		Delay: 4
 	Warhead@7Dam_4: SpreadDamage
 		Spread: 128
-		Damage: 10
+		Damage: 1000
 		Delay: 6
 		Versus:
 			None: 200
@@ -160,7 +160,7 @@ Vulcan:
 		Delay: 6
 	Warhead@9Dam_5: SpreadDamage
 		Spread: 128
-		Damage: 10
+		Damage: 1000
 		Delay: 8
 		Versus:
 			None: 200
@@ -180,7 +180,7 @@ Vulcan:
 		Delay: 8
 	Warhead@11Dam_6: SpreadDamage
 		Spread: 128
-		Damage: 10
+		Damage: 1000
 		Delay: 10
 		Versus:
 			None: 200
@@ -218,7 +218,7 @@ ChainGun.Yak:
 	Projectile: Bullet
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
-		Damage: 40
+		Damage: 4000
 
 Pistol:
 	Inherits: ^LightMG
@@ -226,7 +226,7 @@ Pistol:
 	Range: 3c0
 	Report: gun27.aud
 	Warhead@1Dam: SpreadDamage
-		Damage: 1
+		Damage: 100
 	Warhead@2Eff: CreateEffect
 		Explosions: piff
 	Warhead@3EffWater: CreateEffect
@@ -258,7 +258,7 @@ M60mg:
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
-		Damage: 150
+		Damage: 15000
 		ValidTargets: Barrel, Infantry
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 
@@ -280,7 +280,7 @@ Colt45:
 	ReloadDelay: 5
 	Range: 7c0
 	Warhead@1Dam: SpreadDamage
-		Damage: 50
+		Damage: 5000
 	Warhead@2Eff: CreateEffect
 		Explosions: piff
 		ValidTargets: Ground, Ship, Air, Trees
@@ -294,4 +294,4 @@ Sniper:
 	ReloadDelay: 70
 	Range: 10c0
 	Warhead@1Dam: SpreadDamage
-		Damage: 140
+		Damage: 14000

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -10,7 +10,7 @@ ParaBomb:
 		Shadow: False
 	Warhead@1Dam: SpreadDamage
 		Spread: 768
-		Damage: 300
+		Damage: 30000
 		Versus:
 			None: 30
 			Wood: 30
@@ -34,7 +34,7 @@ Atomic:
 	ValidTargets: Ground, Trees, Water, Underwater, Air
 	Warhead@1Dam_impact: SpreadDamage
 		Spread: 1c0
-		Damage: 150
+		Damage: 15000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: Ground, Trees, Water, Underwater, Air
 		Versus:
@@ -54,7 +54,7 @@ Atomic:
 		ValidTargets: Ground, Water, Air
 	Warhead@5Dam_areanuke1: SpreadDamage
 		Spread: 2c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 5
 		ValidTargets: Ground, Trees, Water, Underwater, Air
@@ -76,7 +76,7 @@ Atomic:
 		VictimScanRadius: 0
 	Warhead@9Dam_areanuke2: SpreadDamage
 		Spread: 3c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 10
 		ValidTargets: Ground, Water, Underwater, Air
@@ -86,7 +86,7 @@ Atomic:
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@10Dam_areanuke2: SpreadDamage
 		Spread: 3c0
-		Damage: 120
+		Damage: 12000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 15
 		ValidTargets: Trees
@@ -101,7 +101,7 @@ Atomic:
 		Delay: 10
 	Warhead@13Dam_areanuke3: SpreadDamage
 		Spread: 4c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 15
 		ValidTargets: Ground, Water, Underwater, Air
@@ -110,7 +110,7 @@ Atomic:
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@14Dam_areanuke3: SpreadDamage
 		Spread: 4c0
-		Damage: 120
+		Damage: 12000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 15
 		ValidTargets: Trees
@@ -125,7 +125,7 @@ Atomic:
 		Delay: 15
 	Warhead@17Dam_areanuke4: SpreadDamage
 		Spread: 5c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 20
 		ValidTargets: Ground, Water, Underwater, Air
@@ -134,7 +134,7 @@ Atomic:
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
 	Warhead@18Dam_areanuke4: SpreadDamage
 		Spread: 5c0
-		Damage: 120
+		Damage: 12000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 20
 		ValidTargets: Trees


### PR DESCRIPTION
I multiplied all damage and HP by 100. See this issue #11719. I calculated everything in a spreadsheet to find out all the rounding errors it had, and adjusted it so there are little to no differences. I also changed the repair and selfheal values. Infantry with veterancy are now actually dealing more damage.

Here is an example of an easy change:
In ballistics.yaml the `cannon` has a damage of 40. Armor types affect the damage by a certain percentage. In this case, 30% for none, 75% for wood and light, and 50% for concrete armor. Calculating this has all rounded values. (40 x 0.3 = 12 | 40 x 0.75 = 30 | 40 x 0.5 = 20)

Some cases do not have rounded values. Therefore, the values are changed to reach the original values. Example:

Ballistics.yaml: `25mm`:
Damage 27
Vs none 30%, is 8.1, in-game value is 8
Vs wood 40%, is 10.8, in-game value is 10
Vs light 110%, is 29.7, in-game value is 29
Vs heavy 45%, is 12.15, in-game value is 12
Vs concrete 30%, is 8.1, in-game value is 8

To reach the in-game values, I made these changes:
New damage 25
Vs none 32%, is 8
Vs wood 40%, is 10
Vs light 116%, is 29
Vs heavy 48%, is 12
Vs concrete 32%, is 8

And, of course, multiplied by 100.

The same procedure is used for these weapons:
Ballistics.yaml: `2Inch`
Explosions.yaml: `OreExplosion`
Missiles.yaml: `AntiGroundMissile`, `HellfireAA`, `MammothTusk`, `Nike`, `Stinger`, `APTusk`
Smallcaliber.yaml: `ZSU-23`, `HeavyMG`, `LightMG`, `Vulcan`, `ChainGun`, `ChainGun.Yak`, `Pistol`, `M1Carbine`
Other.yaml: `Flamer`

Some values could not be rounded easily. I tried to reach as close as possible. These are the numbers:
In other.yaml:
`PortaTesla`: damage vs wood (45 x 0.75 = 33.75, in-game value is 33)
New value is 45 x 0.73 = 32.85 (so it deals 0.15 less damage than it used to do)
`Claw`: damage vs none (33 x 0.9 = 29.7, in-game value is 29)
New value is 30 x 0.97 = 29.1 (so it deals 0.1 more damage than it used to do)

So far, only these two values are not the same. However, there are other cases that are not the same anymore. These cases involve _fallout_. But luckily, the differences are also less than 1. These are nuke explosions, barrel explosions, cruisers and other weapons with area of effect damage. I tested these out and didn’t notice any differences.

~Barrels do a lot of damage to buildings now compared to the previous release without the Hitshape changes. I will file a bug report for this to possibly find out a proper way to fix it.~ Edit: fixed in #14314.

~Vulcan weapon is an interesting case. I see there is a PR #14244 from Smitty that will fix the inconsistency. I kept the old values for now.~ Edit: updated with the Vulcan changes.

Because there are a lot of changes, this PR is hard to review. I suggest to just play the game with these changes. It is maybe the easiest way to find out something is wrong. That’s how I found out that I forgot the repair and selfheal changes, also husk damage. Maybe one good way to do so is in a playtest with a streamer testing these changes. I did however double-check everything. Everything should be the same as before.

~This, by the way, breaks all the custom rules in missions and maps. If this PR is accepted, I will make a new PR to change the rules there too. Edit: this breaks only the external custom maps and missions.~ Edit: upgrade rules added.

_Fun fact: The pistol, which the technicians use, now actually do damage against armored units and buildings. Although it’s still not a lot :P_