### PR TITLE
Add Types: support for InfiltrateFor* traits

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/Infiltrate.cs
+++ b/OpenRA.Mods.Cnc/Activities/Infiltrate.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				ini.Infiltrating(self);
 
 			foreach (var t in target.TraitsImplementing<INotifyInfiltrated>())
-				t.Infiltrated(target, self);
+				t.Infiltrated(target, self, infiltrates.Info.Types);
 
 			var exp = self.Owner.PlayerActor.TraitOrDefault<PlayerExperience>();
 			if (exp != null)

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForCash.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForCash.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
@@ -19,6 +20,8 @@ namespace OpenRA.Mods.Cnc.Traits
 	[Desc("This structure can be infiltrated causing funds to be stolen.")]
 	class InfiltrateForCashInfo : ITraitInfo
 	{
+		public readonly HashSet<string> Types = new HashSet<string>();
+
 		[Desc("Percentage of the victim's resources that will be stolen.")]
 		public readonly int Percentage = 100;
 
@@ -44,8 +47,11 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public InfiltrateForCash(InfiltrateForCashInfo info) { this.info = info; }
 
-		void INotifyInfiltrated.Infiltrated(Actor self, Actor infiltrator)
+		void INotifyInfiltrated.Infiltrated(Actor self, Actor infiltrator, HashSet<string> types)
 		{
+			if (!info.Types.Overlaps(types))
+				return;
+
 			var targetResources = self.Owner.PlayerActor.Trait<PlayerResources>();
 			var spyResources = infiltrator.Owner.PlayerActor.Trait<PlayerResources>();
 			var spyValue = infiltrator.Info.TraitInfoOrDefault<ValuedInfo>();

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForDecoration.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForDecoration.cs
@@ -20,18 +20,27 @@ namespace OpenRA.Mods.Cnc.Traits
 	[Desc("Reveals a decoration sprite to the indicated players when infiltrated.")]
 	class InfiltrateForDecorationInfo : WithDecorationInfo
 	{
+		public readonly HashSet<string> Types = new HashSet<string>();
+
 		public override object Create(ActorInitializer init) { return new InfiltrateForDecoration(init.Self, this); }
 	}
 
 	class InfiltrateForDecoration : WithDecoration, INotifyInfiltrated
 	{
 		readonly HashSet<Player> infiltrators = new HashSet<Player>();
+		readonly InfiltrateForDecorationInfo info;
 
 		public InfiltrateForDecoration(Actor self, InfiltrateForDecorationInfo info)
-			: base(self, info) { }
-
-		void INotifyInfiltrated.Infiltrated(Actor self, Actor infiltrator)
+			: base(self, info)
 		{
+			this.info = info;
+		}
+
+		void INotifyInfiltrated.Infiltrated(Actor self, Actor infiltrator, HashSet<string> types)
+		{
+			if (!info.Types.Overlaps(types))
+				return;
+
 			infiltrators.Add(infiltrator.Owner);
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForPowerOutage.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForPowerOutage.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -16,6 +17,8 @@ namespace OpenRA.Mods.Cnc.Traits
 {
 	class InfiltrateForPowerOutageInfo : ITraitInfo
 	{
+		public readonly HashSet<string> Types = new HashSet<string>();
+
 		public readonly int Duration = 25 * 20;
 
 		public object Create(ActorInitializer init) { return new InfiltrateForPowerOutage(init.Self, this); }
@@ -32,8 +35,11 @@ namespace OpenRA.Mods.Cnc.Traits
 			playerPower = self.Owner.PlayerActor.Trait<PowerManager>();
 		}
 
-		void INotifyInfiltrated.Infiltrated(Actor self, Actor infiltrator)
+		void INotifyInfiltrated.Infiltrated(Actor self, Actor infiltrator, HashSet<string> types)
 		{
+			if (!info.Types.Overlaps(types))
+				return;
+
 			playerPower.TriggerPowerOutage(info.Duration);
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPower.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -18,6 +19,8 @@ namespace OpenRA.Mods.Cnc.Traits
 	class InfiltrateForSupportPowerInfo : ITraitInfo
 	{
 		[ActorReference, FieldLoader.Require] public readonly string Proxy = null;
+
+		public readonly HashSet<string> Types = new HashSet<string>();
 
 		public object Create(ActorInitializer init) { return new InfiltrateForSupportPower(this); }
 	}
@@ -31,8 +34,11 @@ namespace OpenRA.Mods.Cnc.Traits
 			this.info = info;
 		}
 
-		void INotifyInfiltrated.Infiltrated(Actor self, Actor infiltrator)
+		void INotifyInfiltrated.Infiltrated(Actor self, Actor infiltrator, HashSet<string> types)
 		{
+			if (!info.Types.Overlaps(types))
+				return;
+
 			infiltrator.World.AddFrameEndTask(w => w.CreateActor(info.Proxy, new TypeDictionary
 			{
 				new OwnerInit(infiltrator.Owner)

--- a/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
+++ b/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
@@ -302,7 +302,7 @@ namespace OpenRA.Mods.Common.Scripting
 			OnCapturedInternal(self);
 		}
 
-		void INotifyInfiltrated.Infiltrated(Actor self, Actor infiltrator)
+		void INotifyInfiltrated.Infiltrated(Actor self, Actor infiltrator, HashSet<string> types)
 		{
 			if (world.Disposing)
 				return;

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -118,7 +118,7 @@ namespace OpenRA.Mods.Common.Traits
 	public interface ISeedableResource { void Seed(Actor self); }
 
 	[RequireExplicitImplementation]
-	public interface INotifyInfiltrated { void Infiltrated(Actor self, Actor infiltrator); }
+	public interface INotifyInfiltrated { void Infiltrated(Actor self, Actor infiltrator, HashSet<string> types); }
 
 	[RequireExplicitImplementation]
 	public interface INotifyBlockingMove { void OnNotifyBlockingMove(Actor self, Actor blocking); }

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -770,6 +770,7 @@
 	Targetable:
 		TargetTypes: Ground, Structure, C4, DetonateAttack, SpyInfiltrate
 	InfiltrateForDecoration:
+		Types: SpyInfiltrate
 		RequiresSelection: true
 		Image: pips
 		Sequence: tag-fake
@@ -1120,5 +1121,6 @@
 	AffectedByPowerOutage:
 		Condition: power-outage
 	InfiltrateForPowerOutage:
+		Types: SpyInfiltrate
 	Power:
 		RequiresCondition: !disabled

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -112,6 +112,7 @@ SPEN:
 	Inherits: ^Building
 	InfiltrateForSupportPower:
 		Proxy: powerproxy.sonarpulse
+		Types: SpyInfiltrate
 	Valued:
 		Cost: 800
 	Tooltip:
@@ -241,6 +242,7 @@ SYRD:
 	Inherits: ^Building
 	InfiltrateForSupportPower:
 		Proxy: powerproxy.sonarpulse
+		Types: SpyInfiltrate
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 40
@@ -621,6 +623,7 @@ DOME:
 	ProvidesRadar:
 		RequiresCondition: !jammed && !disabled
 	InfiltrateForExploration:
+		Types: SpyInfiltrate
 	DetectCloaked:
 		Range: 10c0
 		RequiresCondition: !disabled
@@ -1016,6 +1019,7 @@ WEAP:
 		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
 	InfiltrateForSupportPower:
 		Proxy: vehicles.upgraded
+		Types: SpyInfiltrate
 	WithDecoration@primary:
 		RequiresSelection: true
 		Image: pips
@@ -1153,6 +1157,7 @@ PROC:
 		Facing: 64
 	InfiltrateForCash:
 		Percentage: 50
+		Types: SpyInfiltrate
 		Notification: CreditsStolen
 	WithIdleOverlay@TOP:
 		Sequence: idle-top
@@ -1286,6 +1291,7 @@ HPAD:
 		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
 	InfiltrateForSupportPower:
 		Proxy: aircraft.upgraded
+		Types: SpyInfiltrate
 	WithDecoration@primary:
 		RequiresSelection: true
 		Image: pips
@@ -1422,6 +1428,7 @@ AFLD:
 		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
 	InfiltrateForSupportPower:
 		Proxy: aircraft.upgraded
+		Types: SpyInfiltrate
 	WithDecoration@primary:
 		RequiresSelection: true
 		Image: pips
@@ -1626,6 +1633,7 @@ BARR:
 	ProvidesPrerequisite@buildingname:
 	InfiltrateForSupportPower:
 		Proxy: barracks.upgraded
+		Types: SpyInfiltrate
 	Targetable:
 		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
 	WithDecoration@primary:
@@ -1763,6 +1771,7 @@ TENT:
 	ProvidesPrerequisite@buildingname:
 	InfiltrateForSupportPower:
 		Proxy: barracks.upgraded
+		Types: SpyInfiltrate
 	Targetable:
 		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
 	WithDecoration@primary:


### PR DESCRIPTION
This is required for RA Classic mod as there are 2 infiltrators (Spy and Thief) that do different things in same building.

~~For TESTCASE i buffed British Spy to give a better sonar pulse, create power outage for double the time and steal 75% of the cash instead of 50%.~~