### PR TITLE
Reduce barrel explosion damage vs wood armor

### DIFF
--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -138,7 +138,7 @@ BarrelExplode:
 		ValidTargets: Ground, Trees
 		Versus:
 			None: 120
-			Wood: 200
+			Wood: 100
 			Light: 50
 			Concrete: 10
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath, Incendiary


### PR DESCRIPTION
Barrels do more damage to buildings because of the hit shape changes. This is because of the fallout damage of the barrel explosion. The new hit shape is closer to the barrel, resulting in more fallout damage. This can be fixed by reducing the damage vs wood armor. I've tested this in all 2-player maps with barrels close to oil derricks. 

Also, keep in mind that the HP of the oil derricks are reduced in the 20171014 release. The oil derricks have 800 HP in the current release. It was 1000 HP in the previous releases.

| 20170527 | 20171014 | PR |
| --- | --- | --- |
| | Agenda ![agenda 20171014](https://user-images.githubusercontent.com/33390659/32542335-89a10924-c472-11e7-9cc8-f566688dc624.png) |![agenda pr](https://user-images.githubusercontent.com/33390659/32542348-93a2f946-c472-11e7-8857-c78376ed751f.png) |
| Behind the Veil ![behind the veil 20170527](https://user-images.githubusercontent.com/33390659/32541670-b0002a02-c470-11e7-9f13-95e314bcaadc.png) |![behind the veil 20171014](https://user-images.githubusercontent.com/33390659/32541896-517aff38-c471-11e7-8f24-1df30cce1b6c.png) |![behind the veil pr](https://user-images.githubusercontent.com/33390659/32541912-5ca2d3ae-c471-11e7-9c37-42887f345779.png) |
| Desert Rats ![desert rats 20170527](https://user-images.githubusercontent.com/33390659/32542395-be2c3920-c472-11e7-8928-9d7d4f4aba81.png) | ![desert rats 20171014](https://user-images.githubusercontent.com/33390659/32542406-cc489daa-c472-11e7-8586-eb69a0cf711d.png) |![desert rats pr](https://user-images.githubusercontent.com/33390659/32542417-d9646726-c472-11e7-9436-0ad8be445cba.png) |
| Polar Disorder ![polar disorder 20170527](https://user-images.githubusercontent.com/33390659/32542446-f3738f98-c472-11e7-8a11-1f32c5b3d2ad.png) |![polar disorder 20171014](https://user-images.githubusercontent.com/33390659/32542460-ff864cda-c472-11e7-967b-0ce002a6926f.png) |![polar disorder pr](https://user-images.githubusercontent.com/33390659/32542476-090e49ce-c473-11e7-9cc0-73bb8f0fef17.png) |
| Siberian Pass ![siberian pass 20170527](https://user-images.githubusercontent.com/33390659/32542557-4599c350-c473-11e7-899b-8dcd3656cbfd.png) |![siberian pass 20171014](https://user-images.githubusercontent.com/33390659/32542568-4f8cd6ae-c473-11e7-9949-4a6ed96dffa5.png) |![siberian pass pr](https://user-images.githubusercontent.com/33390659/32542576-588188a4-c473-11e7-8a96-04eb986bd05d.png) |
| Snow Off ![snow off 20170527](https://user-images.githubusercontent.com/33390659/32542619-7acc563c-c473-11e7-8977-fabda1503676.png) | ![snow off 20171014](https://user-images.githubusercontent.com/33390659/32542632-8587adec-c473-11e7-864c-3242cee941de.png) |![snow off pr](https://user-images.githubusercontent.com/33390659/32542646-8e9ccb10-c473-11e7-8f3f-b813eb08c6de.png) |

Agenda: is a new map, only the house takes less damage.
Behind the Veil: 1 barrel directly next to the oil derrick, damage was more than 50%.
Desert Rats: no big differences.
Polar Disorder: 2 barrels next to oil derrick, damage was more than 75%.
Siberian Pass: 4 barrels directly next to the oil derrick, it destroyed the oil derrick.
Snow Off: only top right oil derrick took more than 50% damage.

This PR is a nice compromise between the last two releases. If someone places 1 barrel next to an oil derrick (excluding the corners), it will take approximately 20% damage, 2 barrels approximately 40% damage and 4 barrels approximately 80% damage.

Closes #14302 