### PR TITLE
Replace bogus ROF values in missions

### DIFF
--- a/mods/ra/maps/monster-tank-madness/weapons.yaml
+++ b/mods/ra/maps/monster-tank-madness/weapons.yaml
@@ -7,28 +7,9 @@ TurretGun:
 		Blockable: false
 
 SuperTankPrimary:
-	Inherits: ^Cannon
-	ROF: 70
-	Range: 4c768
+	Inherits: 120mm
+	ReloadDelay: 70
 	Report: turret1.aud
-	Burst: 2
-	InvalidTargets: Air, Infantry
-	Projectile: Bullet
-		Speed: 682
-		Image: 120MM
 	Warhead@1Dam: SpreadDamage
-		Spread: 128
-		Damage: 50
+		Damage: 500
 		InvalidTargets: Air, Infantry
-		Versus:
-			None: 20
-			Wood: 75
-			Light: 75
-			Concrete: 50
-		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
-	Warhead@2Smu: LeaveSmudge
-		SmudgeType: Crater
-	Warhead@3Eff: CreateEffect
-		Explosions: small_explosion
-	Warhead@4EffWater: CreateEffect
-		Explosions: small_splash

--- a/mods/ra/maps/survival02/weapons.yaml
+++ b/mods/ra/maps/survival02/weapons.yaml
@@ -1,5 +1,5 @@
 ParaBomb:
-	ROF: 5
+	ReloadDelay: 5
 	Range: 7c0
 	Report: chute1.aud
 	Projectile: GravityBomb


### PR DESCRIPTION
Fixes #14313.

The reason for the change in MTM from 70 to 1 is that the intro sequence was balanced around the fact that `ROF: 70` was bogus and thus falling back to the default value of 1. (This was then "disturbed" by #13543 which let the `SuperTankPrimary` inherit `^Cannon` with another `ReloadDelay` value, hence I need to restate the default value again.)