### PR TITLE
Fix spy voices

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -241,13 +241,14 @@ SPY:
 		Name: Spy
 		GenericName: Soldier
 	-Guard:
+	Mobile:
+		Voice: Move
 	RevealsShroud:
 		Range: 5c0
 	Passenger:
 		PipType: Yellow
 		Voice: Move
 	Disguise:
-		Voice: Move
 		DisguisedCondition: disguise
 	Infiltrates:
 		Types: SpyInfiltrate


### PR DESCRIPTION
The spy has several different lines in [voices.yaml](https://github.com/OpenRA/OpenRA/blob/634faa31deb9e03ed7b49b06c9b6ade0225bcb01/mods/ra/audio/voices.yaml#L77). However, in the infantry.yaml the move and action voices are mixed up. If the spy disguises, it uses the move voices. If the spy moves, it uses the action voices.

Action: sking1: "For King and Country!"

Move: sonway1: "On my way!"
sindeed1: "Indeed!"