### PR TITLE
D2K - Add Starport Varied Cost Logic

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -802,6 +802,7 @@
     <Compile Include="Traits\World\JumpjetActorLayer.cs" />
     <Compile Include="Traits\World\ElevatedBridgeLayer.cs" />
     <Compile Include="Traits\World\ElevatedBridgePlaceholder.cs" />
+    <Compile Include="Traits\World\VariedCostManager.cs" />
     <Compile Include="Traits\Attack\AttackCharges.cs" />
     <Compile Include="Traits\Render\WithChargeAnimation.cs" />
     <Compile Include="Traits\Render\WithChargeOverlay.cs" />

--- a/OpenRA.Mods.Common/Traits/Valued.cs
+++ b/OpenRA.Mods.Common/Traits/Valued.cs
@@ -19,6 +19,15 @@ namespace OpenRA.Mods.Common.Traits
 		[FieldLoader.Require]
 		[Desc("Used in production, but also for bounties so remember to set it > 0 even for NPCs.")]
 		public readonly int Cost = 0;
+
+		[Desc("Actor's cost changes with time. Requires `VariedCostManager` on `World` actor.")]
+		public readonly bool Varies = false;
+
+		[Desc("Lower value for varied cost.")]
+		public readonly int MinimumVariationMultiplier = 75;
+
+		[Desc("Upper value for varied cost.")]
+		public readonly int MaximumVariationMultiplier = 100;
 	}
 
 	public class Valued { }

--- a/OpenRA.Mods.Common/Traits/World/VariedCostManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/VariedCostManager.cs
@@ -1,0 +1,74 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Makes the Varied Cost logic work. Attach this to `World` actor.")]
+	public class VariedCostManagerInfo : ITraitInfo
+	{
+		[Desc("How often the varied cost is recalculated.",
+			"Two values indicate a random interval range.")]
+		public readonly int[] VariationRecalculationInterval = { 0 };
+
+		public object Create(ActorInitializer init) { return new VariedCostManager(init.Self, this); }
+	}
+
+	public class VariedCostManager : ITick, ISync
+	{
+		readonly World world;
+		readonly VariedCostManagerInfo info;
+		readonly ICollection<ActorInfo> units;
+		public Dictionary<string, int> VariedCost = new Dictionary<string, int>();
+		[Sync] int ticks;
+
+		public VariedCostManager(Actor self, VariedCostManagerInfo info)
+		{
+			this.info = info;
+			world = self.World;
+			units = world.Map.Rules.Actors.Values;
+			ticks = Util.RandomDelay(world, info.VariationRecalculationInterval);
+
+			foreach (var unit in units)
+			{
+				var valued = unit.TraitInfoOrDefault<ValuedInfo>();
+
+				if (valued != null && valued.Varies)
+				{
+					VariedCost.Add(unit.Name,
+						world.SharedRandom.Next((valued.Cost * valued.MinimumVariationMultiplier) / 100, (valued.Cost * valued.MaximumVariationMultiplier) / 100));
+				}
+			}
+		}
+
+		void ITick.Tick(Actor self)
+		{
+			if (--ticks < 0)
+			{
+				ticks = Util.RandomDelay(world, info.VariationRecalculationInterval);
+
+				foreach (var unit in units)
+				{
+					var valued = unit.TraitInfoOrDefault<ValuedInfo>();
+					if (valued != null && valued.Varies)
+					{
+						VariedCost.Remove(unit.Name);
+						VariedCost.Add(unit.Name,
+							world.SharedRandom.Next((valued.Cost * valued.MinimumVariationMultiplier) / 100, (valued.Cost * valued.MaximumVariationMultiplier) / 100));
+					}
+				}
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -28,6 +28,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var mapRules = world.Map.Rules;
 			var pm = player.PlayerActor.Trait<PowerManager>();
 			var pr = player.PlayerActor.Trait<PlayerResources>();
+			var vcm = world.WorldActor.TraitOrDefault<VariedCostManager>();
 
 			widget.IsVisible = () => getTooltipIcon() != null && getTooltipIcon().Actor != null;
 			var nameLabel = widget.Get<LabelWidget>("NAME");
@@ -70,7 +71,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var tooltip = actor.TraitInfos<TooltipInfo>().FirstOrDefault(info => info.EnabledByDefault);
 				var name = tooltip != null ? tooltip.Name : actor.Name;
 				var buildable = actor.TraitInfo<BuildableInfo>();
-				var cost = actor.TraitInfo<ValuedInfo>().Cost;
+				var valued = actor.TraitInfo<ValuedInfo>();
+				var cost = 0;
+				if (vcm != null && valued != null && valued.Varies)
+					cost = vcm.VariedCost.First(vc => vc.Key == actor.Name).Value;
+				else if (valued != null && (vcm == null || (vcm != null && !valued.Varies)))
+					cost = valued.Cost;
 
 				nameLabel.Text = name;
 

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -31,7 +31,7 @@ Player:
 		SpeedUp: true
 	ClassicProductionQueue@Starport:
 		Type: Starport
-		BuildDurationModifier: 212
+		BuildDurationModifier: 250
 		LowPowerSlowdown: 0
 		BlockedAudio: NoRoom
 		QueuedAudio: OrderPlaced

--- a/mods/d2k/rules/starport.yaml
+++ b/mods/d2k/rules/starport.yaml
@@ -4,7 +4,7 @@ mcv.starport:
 		Prerequisites: starport
 		Queue: Starport
 	Valued:
-		Cost: 2500
+		Varies: true
 	RenderSprites:
 		Image: mcv
 
@@ -14,7 +14,7 @@ harvester.starport:
 		Prerequisites: starport
 		Queue: Starport
 	Valued:
-		Cost: 1500
+		Varies: true
 	RenderSprites:
 		Image: harvester
 
@@ -24,7 +24,7 @@ trike.starport:
 		Prerequisites: starport
 		Queue: Starport
 	Valued:
-		Cost: 315
+		Varies: true
 	RenderSprites:
 		Image: trike
 
@@ -34,7 +34,7 @@ quad.starport:
 		Prerequisites: starport
 		Queue: Starport
 	Valued:
-		Cost: 500
+		Varies: true
 	RenderSprites:
 		Image: quad
 
@@ -44,7 +44,7 @@ siege_tank.starport:
 		Prerequisites: starport
 		Queue: Starport
 	Valued:
-		Cost: 1075
+		Varies: true
 	RenderSprites:
 		Image: siege_tank
 
@@ -54,7 +54,7 @@ missile_tank.starport:
 		Prerequisites: starport
 		Queue: Starport
 	Valued:
-		Cost: 1250
+		Varies: true
 	RenderSprites:
 		Image: missile_tank
 
@@ -64,7 +64,7 @@ combat_tank_a.starport:
 		Prerequisites: ~starport.atreides_combat
 		Queue: Starport
 	Valued:
-		Cost: 875
+		Varies: true
 	RenderSprites:
 		Image: combat_tank_a
 
@@ -74,7 +74,7 @@ combat_tank_h.starport:
 		Prerequisites: ~starport.harkonnen_combat
 		Queue: Starport
 	Valued:
-		Cost: 875
+		Varies: true
 	RenderSprites:
 		Image: combat_tank_h
 
@@ -84,7 +84,7 @@ combat_tank_o.starport:
 		Prerequisites: ~starport.ordos_combat
 		Queue: Starport
 	Valued:
-		Cost: 875
+		Varies: true
 	RenderSprites:
 		Image: combat_tank_o
 
@@ -94,4 +94,4 @@ carryall.starport:
 		Prerequisites: starport
 		Queue: Starport
 	Valued:
-		Cost: 1500
+		Varies: true

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -606,7 +606,7 @@ starport:
 		BuildPaletteOrder: 70
 		BuildDuration: 540
 		BuildDurationModifier: 40
-		Description: Dropzone for quick reinforcements, at a price.
+		Description: Dropzone for reinforcements with changing prices.
 	Valued:
 		Cost: 1500
 	Building:

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -164,6 +164,8 @@ World:
 		OuterSupportRadius: 5
 	SpawnMPUnits:
 		DropdownDisplayOrder: 1
+	VariedCostManager:
+		VariationRecalculationInterval: 1500
 	PathFinder:
 	ValidateOrder:
 	DebugPauseState:


### PR DESCRIPTION
Fixes #2252.

~~Values for `MinimumVariationMultiplier`, `MaximumVariationMultiplier` and `VariationRecalculationInterval` may not be matching original. I asked on FED2K Forum if they are correct. If anyone here knows the original values, would be happy if someone can tell the correct values.~~ Edit: Updated with correct values.

I removed quicker building for starport, but more starports still don't speed up building.

I put the trait on World actor instead of Player to ensure all players get same cost at the same time.~~I'm not sure if that was the behviour in original, but~~ i think it is better for balance. Edit: It wasn't, but as i said, i wanna keep that as this.