### PR TITLE
Allies06a reveal enemy base after capturing radar dome

### DIFF
--- a/mods/ra/maps/allies-06a/allies06a.lua
+++ b/mods/ra/maps/allies-06a/allies06a.lua
@@ -115,6 +115,19 @@ CaptureRadarDome = function()
 
 	Trigger.OnCapture(Radar, function()
 		player.MarkCompletedObjective(CaptureRadarDomeObj)
+		Beacon.New(player, TechLab1.CenterPosition)
+		Beacon.New(player, TechLab2.CenterPosition)
+		Beacon.New(player, TechLab3.CenterPosition)
+		Media.DisplayMessage("Coordinates of the Soviet tech centers discovered.")
+		if Map.LobbyOption("difficulty") ~= "hard" then
+			Utils.Do(TechLabCams, function(a)
+				Actor.Create("TECH.CAM", true, { Owner = player, Location = a.Location })
+			end)
+
+			if Map.LobbyOption("difficulty") == "easy" then
+				Actor.Create("Camera", true, { Owner = player, Location = Weapcam.Location })
+			end
+		end
 	end)
 end
 
@@ -201,16 +214,6 @@ WorldLoaded = function()
 	InfiltrateRefObj = player.AddSecondaryObjective("Infiltrate the Refinery for money.")
 
 	Camera.Position = DefaultCameraPosition.CenterPosition
-
-	if Map.LobbyOption("difficulty") ~= "hard" then
-		Utils.Do(TechLabCams, function(a)
-			Actor.Create("TECH.CAM", true, { Owner = player, Location = a.Location })
-		end)
-
-		if Map.LobbyOption("difficulty") == "easy" then
-			Actor.Create("Camera", true, { Owner = player, Location = Weapcam.Location })
-		end
-	end
 
 	Utils.Do(BadGuys, function(a)
 		a.AttackMove(MCVStopLocation.Location)


### PR DESCRIPTION
A proposal to polish the Allies-06a mission.

The enemy base could be seen from the start of this mission. I think a nice feature would be to reveal the enemy base after the radar dome is captured.

In the original game the enemy base is not revealed at the start of the game. It gets only revealed by infiltrating the radar dome with a spy (at [7:32](https://youtu.be/oOtVfflViRg?t=7m32s) the spy infiltrates the radar dome, at [9:11](https://youtu.be/oOtVfflViRg?t=9m11s) you can see the enemy base revealed), or [getting close to the enemy base](https://youtu.be/roaLeV1Xpi4?t=16m29s).

I kept the mechanic that the engineer captures the radar dome rather than an infiltration by the spy. The reason for that is, in Allied03a/b and Soviet05 the player also needs to capture a radar dome with an engineer.