### PR TITLE
Remove old engineer behavior in campaign

### DIFF
--- a/mods/ra/maps/allies-03a/allies03a.lua
+++ b/mods/ra/maps/allies-03a/allies03a.lua
@@ -214,17 +214,6 @@ InitTriggers = function()
 		end)
 	end)
 
-	Trigger.OnCapture(USSRRadarDome, function(self)
-		largeCamera = Actor.Create("camera.verylarge", true, { Owner = player, Location = LargeCameraWaypoint.Location })
-		Trigger.ClearAll(self)
-		Trigger.AfterDelay(DateTime.Seconds(1), function()
-			Trigger.OnRemovedFromWorld(self, function()
-				Trigger.ClearAll(self)
-				if largeCamera.IsInWorld then largeCamera.Destroy() end
-			end)
-		end)
-	end)
-
 	Trigger.OnEnteredFootprint(WaterTransportTriggerArea, function(a, id)
 		if a.Owner == player and not waterTransportTriggered then
 			waterTransportTriggered = true

--- a/mods/ra/maps/allies-03a/map.yaml
+++ b/mods/ra/maps/allies-03a/map.yaml
@@ -1250,7 +1250,7 @@ Actors:
 		Owner: Greece
 		Facing: 128
 		SubCell: 0
-	PrisonedEngi: hacke6
+	PrisonedEngi: mech
 		Location: 57,67
 		Owner: Greece
 		Facing: 96
@@ -1284,9 +1284,6 @@ Actors:
 		Owner: Neutral
 	BaseCameraWaypoint: waypoint
 		Location: 55,70
-		Owner: Neutral
-	LargeCameraWaypoint: waypoint
-		Location: 71,65
 		Owner: Neutral
 	ParadropLZ: waypoint
 		Location: 73,57

--- a/mods/ra/maps/allies-03a/rules.yaml
+++ b/mods/ra/maps/allies-03a/rules.yaml
@@ -14,30 +14,15 @@ World:
 			normal: Normal
 		Default: easy
 
-^Building:
-	Capturable:
-		CaptureThreshold: 25
-
-^TechBuilding:
-	Capturable:
-		Types: ~disabled
-
 powerproxy.paratroopers:
 	ParatroopersPower:
 		DropItems: E1,E1,E1,E2,E2
 
-HACKE6:
-	Inherits: E6
-	-RepairsBridges:
-	-ExternalCaptures:
-	Captures:
-		CaptureTypes: building
+MECH:
 	Targetable:
 		RequiresCondition: !jail
 	Targetable@PRISONER:
 		TargetTypes: Prisoner
-	RenderSprites:
-		Image: E6
 	ExternalCondition@JAIL:
 		Condition: jail
 
@@ -61,11 +46,6 @@ PRISON:
 CAMERA:
 	RevealsShroud:
 		Range: 8c7
-
-CAMERA.VeryLarge:
-	Inherits: CAMERA
-	RevealsShroud:
-		Range: 40c0
 
 MONEYCRATE:
 	Tooltip:
@@ -101,119 +81,3 @@ DOG:
 		Range: 9c0
 	AutoTarget:
 		ScanRadius: 8
-
-DOME:
-	Buildable:
-		Prerequisites: ~disabled
-
-WEAP:
-	Buildable:
-		Prerequisites: ~disabled
-
-FIX:
-	Buildable:
-		Prerequisites: ~disabled
-
-APC:
-	Buildable:
-		Prerequisites: ~disabled
-
-V2RL:
-	Buildable:
-		Prerequisites: ~disabled
-
-2TNK:
-	Buildable:
-		Prerequisites: ~disabled
-
-3TNK:
-	Buildable:
-		Prerequisites: ~disabled
-
-4TNK:
-	Buildable:
-		Prerequisites: ~disabled
-
-MCV:
-	Buildable:
-		Prerequisites: ~disabled
-
-MNLY:
-	Buildable:
-		Prerequisites: ~disabled
-
-TTNK:
-	Buildable:
-		Prerequisites: ~disabled
-
-FTRK:
-	Buildable:
-		Prerequisites: ~disabled
-
-DTRK:
-	Buildable:
-		Prerequisites: ~disabled
-
-QTNK:
-	Buildable:
-		Prerequisites: ~disabled
-
-MSLO:
-	Buildable:
-		Prerequisites: ~disabled
-
-SPEN:
-	Buildable:
-		Prerequisites: ~disabled
-
-IRON:
-	Buildable:
-		Prerequisites: ~disabled
-
-TSLA:
-	Buildable:
-		Prerequisites: ~disabled
-
-SAM:
-	Buildable:
-		Prerequisites: ~disabled
-
-AFLD:
-	Buildable:
-		Prerequisites: ~disabled
-
-APWR:
-	Buildable:
-		Prerequisites: ~disabled
-
-STEK:
-	Buildable:
-		Prerequisites: ~disabled
-
-KENN:
-	Buildable:
-		Prerequisites: ~disabled
-
-E3:
-	Buildable:
-		Prerequisites: ~disabled
-
-E4:
-	Buildable:
-		Prerequisites: ~disabled
-
-E6:
-	Buildable:
-		Prerequisites: ~disabled
-
-SNIPER:
-	Buildable:
-		Prerequisites: ~disabled
-
-HIJACKER:
-	Buildable:
-		Prerequisites: ~disabled
-
-SHOK:
-	Buildable:
-		Prerequisites: ~disabled

--- a/mods/ra/maps/allies-03b/map.yaml
+++ b/mods/ra/maps/allies-03b/map.yaml
@@ -998,7 +998,6 @@ Actors:
 	USSRSubPen: spen
 		Location: 109,53
 		Owner: USSR
-		Health: 52
 	USSRFlameTower1: ftur
 		Location: 82,82
 		Owner: USSR
@@ -1020,11 +1019,9 @@ Actors:
 	USSRRadarDome: dome
 		Location: 105,56
 		Owner: USSR
-		Health: 56
 	USSRPowerPlant: powr
 		Location: 103,55
 		Owner: USSR
-		Health: 52
 	USSRBarracks1: barr
 		Location: 84,81
 		Owner: USSR
@@ -1124,22 +1121,22 @@ Actors:
 		Health: 15
 		Facing: 192
 		SubCell: 0
-	PrisonedEngi1: hacke6
+	PrisonedEngi1: e6
 		Location: 91,86
 		Owner: Greece
 		Facing: 192
 		SubCell: 0
-	PrisonedEngi2: hacke6
+	PrisonedEngi2: e6
 		Location: 91,86
 		Owner: Greece
 		Facing: 192
 		SubCell: 1
-	PrisonedEngi3: hacke6
+	PrisonedEngi3: e6
 		Location: 91,86
 		Owner: Greece
 		Facing: 192
 		SubCell: 2
-	PrisonedEngi4: hacke6
+	PrisonedEngi4: e6
 		Location: 91,86
 		Owner: Greece
 		Facing: 192

--- a/mods/ra/maps/allies-03b/rules.yaml
+++ b/mods/ra/maps/allies-03b/rules.yaml
@@ -14,31 +14,15 @@ World:
 			normal: Normal
 		Default: easy
 
-^Building:
-	Capturable:
-		CaptureThreshold: 25
-
-^TechBuilding:
-	Capturable:
-		Types: ~disabled
-
 powerproxy.paratroopers:
 	ParatroopersPower:
 		DropItems: E1,E1,E1,E2,E2
 
-HACKE6:
-	Inherits: E6
-	-RepairsBridges:
-	-ExternalCaptures:
-	Captures:
-		CaptureTypes: building
-	WithInfantryBody:
+E6:
 	Targetable:
 		RequiresCondition: !jail
 	Targetable@PRISONER:
 		TargetTypes: Prisoner
-	RenderSprites:
-		Image: E6
 	ExternalCondition@JAIL:
 		Condition: jail
 


### PR DESCRIPTION
This is a proposal to remove the old engineer behavior in campaign missions.

There are only two campaign missions (Allies 03a and b) with the old engineer behavior. The rest of the campaign missions (including Monster Tank Madness) has the external capturing. By changing it to the external capturing, the campaign experience will be unified with the skirmish/multiplayer experience.

Starting with Allies 03b.
There are four engineers on this map. The mission can be completed without ever using these engineers. In case [the middle bridge](https://www.flickr.com/photos/97634864@N04/9070757722/in/album-72157634178861495/) is destroyed, but Tanya is still on the south of that bridge, the player needs to capture the sub pen to build the transport unit. (The flame tower defending the south of the base will get destroyed thanks to a script. Opening a way to capture the sub pen.)

The radar dome has a special function. If the radar dome gets captured, the whole map will be revealed.

The buildings are all damaged so the player only needs two engineers to capture a building, resulting that only two buildings can be captured.

Now the new situation. I restored the HP of the buildings back to 100%. The engineers can now capture all the buildings.

The cons about this change:
There is no decision needed anymore to consider which buildings to capture, and by potentially choosing the wrong building, having to start the game over again.

The pros about this change:
The player doesn’t need to start over again if the wrong buildings are captured. (Which is convenient because the mission can’t be saved.)
Unifies the engineer with the rest of the missions, skirmish and multiplayer.

Now Allies 03a.
There is one engineer on this map. The mission can be completed without ever using the engineer. The radar dome is the only building with a special function. If the radar dome gets captured, the whole map will be revealed. The rest of the buildings are useless to capture because there is no money to build something.

I replaced the engineer with a mechanic.

The cons about this change:
Cannot capture the radar dome to reveal the map. On a side note, I never knew this, and there is no indication that it will reveal the whole map. However, the mission could be easily scouted completely, making this function a little bit redundant.

The pros about this change:
Now the artillery can be repaired by the mechanic.
Unifies the engineer with the rest of the missions, skirmish and multiplayer.