### PR TITLE
Remove Airstrike from nod06a Normal Difficulty

### DIFF
--- a/mods/cnc/maps/nod06a/map.yaml
+++ b/mods/cnc/maps/nod06a/map.yaml
@@ -26,14 +26,13 @@ Players:
 		Faction: gdi
 	PlayerReference@GDI:
 		Name: GDI
-		Playable: False
 		Faction: gdi
 		Color: F5D378
 		Enemies: Nod
 	PlayerReference@Nod:
 		Name: Nod
-		Playable: True
 		AllowBots: False
+		Playable: True
 		Required: True
 		LockFaction: True
 		Faction: nod
@@ -637,10 +636,39 @@ Actors:
 		Location: 36,23
 		Owner: GDI
 	Detonator: CRATE.plain
-		Location: 59, 43
+		Location: 59,43
 		Owner: GDI
 	Radar: hq
 		Location: 57,32
 		Owner: GDI
+	Actor187: jeep
+		Owner: GDI
+		Location: 40,21
+		Facing: 92
+		TurretFacing: 92
+	Actor188: e1
+		Owner: GDI
+		Location: 41,22
+		SubCell: 3
+		Facing: 92
+		TurretFacing: 92
+	Actor189: e1
+		Owner: GDI
+		Location: 39,20
+		SubCell: 3
+		Facing: 92
+		TurretFacing: 92
+	Actor190: e3
+		Owner: GDI
+		Location: 40,20
+		SubCell: 3
+		Facing: 92
+		TurretFacing: 92
+	Actor191: e3
+		Owner: GDI
+		Location: 40,20
+		SubCell: 1
+		Facing: 92
+		TurretFacing: 92
 
 Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml

--- a/mods/cnc/maps/nod06a/nod06a.lua
+++ b/mods/cnc/maps/nod06a/nod06a.lua
@@ -166,8 +166,10 @@ WorldLoaded = function()
 	OnAnyDamaged(Atk1ActorTriggerActivator, Atk1TriggerFunction)
 
 	OnAnyDamaged(Atk2ActorTriggerActivator, Atk2TriggerFunction)
-
-	Trigger.OnDamaged(Atk3Activator, Atk3TriggerFunction)
+	
+	if Map.LobbyOption("difficulty") == "hard" then
+		Trigger.OnDamaged(Atk3Activator, Atk3TriggerFunction)
+	end
 
 	Trigger.OnAllKilled(Chn1ActorTriggerActivator, Chn1TriggerFunction)
 

--- a/mods/cnc/maps/nod06a/rules.yaml
+++ b/mods/cnc/maps/nod06a/rules.yaml
@@ -9,6 +9,13 @@ World:
 		BriefingVideo: nod6.vqa
 		StartVideo: sundial.vqa
 		LossVideo: banner.vqa
+	ScriptLobbyDropdown@difficulty:
+		ID: difficulty
+		Label: Difficulty
+		Values:
+			normal: Normal
+			hard: Hard
+		Default: normal
 
 Player:
 	EnemyWatcher:


### PR DESCRIPTION
This removes the triggered airstrike from nod06a per #12961. To make sure there was still some threat to the player for attacking the village, I added a Humvee, two rifles, and two rockets by the church.

Closes #12961