### PR TITLE
Add Rearmable trait

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/LayMines.cs
+++ b/OpenRA.Mods.Cnc/Activities/LayMines.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Cnc.Activities
 		readonly MinelayerInfo info;
 		readonly AmmoPool[] ammoPools;
 		readonly IMove movement;
-		readonly HashSet<string> rearmBuildings;
+		readonly RearmableInfo rearmableInfo;
 
 		public LayMines(Actor self)
 		{
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Cnc.Activities
 			info = self.Info.TraitInfo<MinelayerInfo>();
 			ammoPools = self.TraitsImplementing<AmmoPool>().ToArray();
 			movement = self.Trait<IMove>();
-			rearmBuildings = info.RearmBuildings;
+			rearmableInfo = self.Info.TraitInfoOrDefault<RearmableInfo>();
 		}
 
 		public override Activity Tick(Actor self)
@@ -43,11 +43,11 @@ namespace OpenRA.Mods.Cnc.Activities
 			if (IsCanceled)
 				return NextActivity;
 
-			if (ammoPools != null && ammoPools.Any(p => p.Info.Name == info.AmmoPoolName && !p.HasAmmo()))
+			if (rearmableInfo != null && ammoPools.Any(p => p.Info.Name == info.AmmoPoolName && !p.HasAmmo()))
 			{
 				// Rearm (and possibly repair) at rearm building, then back out here to refill the minefield some more
 				var rearmTarget = self.World.Actors.Where(a => self.Owner.Stances[a.Owner] == Stance.Ally
-					&& rearmBuildings.Contains(a.Info.Name))
+					&& rearmableInfo.RearmActors.Contains(a.Info.Name))
 					.ClosestTo(self);
 
 				if (rearmTarget == null)

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -21,10 +21,9 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	public class MinelayerInfo : ITraitInfo
+	public class MinelayerInfo : ITraitInfo, Requires<RearmableInfo>
 	{
 		[ActorReference] public readonly string Mine = "minv";
-		[ActorReference] public readonly HashSet<string> RearmBuildings = new HashSet<string> { "fix" };
 
 		public readonly string AmmoPoolName = "primary";
 

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -443,22 +443,22 @@ namespace OpenRA.Mods.Common.AI
 				CountBuildingByCommonName(Info.BuildingCommonNames.Barracks, Player) == 0;
 		}
 
-		// For mods like RA (number of building must match the number of aircraft)
+		// For mods like RA (number of RearmActors must match the number of aircraft)
 		bool HasAdequateAirUnitReloadBuildings(ActorInfo actorInfo)
 		{
 			var aircraftInfo = actorInfo.TraitInfoOrDefault<AircraftInfo>();
 			if (aircraftInfo == null)
 				return true;
 
-			// If the aircraft has at least 1 AmmoPool and defines 1 or more RearmBuildings, check if we have enough of those
-			var hasAmmoPool = actorInfo.TraitInfos<AmmoPoolInfo>().Any();
-			if (hasAmmoPool && aircraftInfo.RearmBuildings.Count > 0)
-			{
-				var countOwnAir = CountActorsWithTrait<IPositionable>(actorInfo.Name, Player);
-				var countBuildings = aircraftInfo.RearmBuildings.Sum(b => CountActorsWithTrait<Building>(b, Player));
-				if (countOwnAir >= countBuildings)
-					return false;
-			}
+			// If actor isn't Rearmable, it doesn't need a RearmActor to reload
+			var rearmableInfo = actorInfo.TraitInfoOrDefault<RearmableInfo>();
+			if (rearmableInfo == null)
+				return true;
+
+			var countOwnAir = CountActorsWithTrait<IPositionable>(actorInfo.Name, Player);
+			var countBuildings = rearmableInfo.RearmActors.Sum(b => CountActorsWithTrait<Building>(b, Player));
+			if (countOwnAir >= countBuildings)
+				return false;
 
 			return true;
 		}

--- a/OpenRA.Mods.Common/AI/States/AirStates.cs
+++ b/OpenRA.Mods.Common/AI/States/AirStates.cs
@@ -127,7 +127,11 @@ namespace OpenRA.Mods.Common.AI
 		protected static bool ReloadsAutomatically(Actor a)
 		{
 			var ammoPools = a.TraitsImplementing<AmmoPool>();
-			return ammoPools.All(x => x.AutoReloads);
+			var rearmable = a.TraitOrDefault<Rearmable>();
+			if (rearmable == null)
+				return true;
+
+			return ammoPools.All(ap => !rearmable.Info.AmmoPools.Contains(ap.Info.Name));
 		}
 
 		protected static bool IsRearm(Actor a)

--- a/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly Aircraft aircraft;
 		readonly AttackHeli attackHeli;
 		readonly bool attackOnlyVisibleTargets;
-		readonly bool autoReloads;
+		readonly Rearmable rearmable;
 
 		Target target;
 		bool canHideUnderFog;
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Activities
 			aircraft = self.Trait<Aircraft>();
 			attackHeli = self.Trait<AttackHeli>();
 			this.attackOnlyVisibleTargets = attackOnlyVisibleTargets;
-			autoReloads = self.TraitsImplementing<AmmoPool>().All(p => p.AutoReloads);
+			rearmable = self.TraitOrDefault<Rearmable>();
 		}
 
 		public override Activity Tick(Actor self)
@@ -74,8 +74,8 @@ namespace OpenRA.Mods.Common.Activities
 				return new HeliFly(self, newTarget);
 			}
 
-			// If all valid weapons have depleted their ammo and RearmBuilding is defined, return to RearmBuilding to reload and then resume the activity
-			if (!autoReloads && aircraft.Info.RearmBuildings.Any() && attackHeli.Armaments.All(x => x.IsTraitPaused || !x.Weapon.IsValidAgainst(target, self.World, self)))
+			// If all valid weapons have depleted their ammo and Rearmable trait exists, return to RearmActor to reload and then resume the activity
+			if (rearmable != null && attackHeli.Armaments.All(x => x.IsTraitPaused || !x.Weapon.IsValidAgainst(target, self.World, self)))
 				return ActivityUtils.SequenceActivities(new HeliReturnToBase(self, aircraft.Info.AbortOnResupply), this);
 
 			var dist = targetPos - pos;

--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -19,6 +19,7 @@ namespace OpenRA.Mods.Common.Activities
 	public class HeliReturnToBase : Activity
 	{
 		readonly Aircraft aircraft;
+		readonly RepairableInfo repairableInfo;
 		readonly bool alwaysLand;
 		readonly bool abortOnResupply;
 		Actor dest;
@@ -26,6 +27,7 @@ namespace OpenRA.Mods.Common.Activities
 		public HeliReturnToBase(Actor self, bool abortOnResupply, Actor dest = null, bool alwaysLand = true)
 		{
 			aircraft = self.Trait<Aircraft>();
+			repairableInfo = self.Info.TraitInfoOrDefault<RepairableInfo>();
 			this.alwaysLand = alwaysLand;
 			this.abortOnResupply = abortOnResupply;
 			this.dest = dest;
@@ -114,7 +116,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (alwaysLand)
 				return true;
 
-			if (aircraft.Info.RepairBuildings.Contains(dest.Info.Name) && self.GetDamageState() != DamageState.Undamaged)
+			if (repairableInfo != null && repairableInfo.RepairBuildings.Contains(dest.Info.Name) && self.GetDamageState() != DamageState.Undamaged)
 				return true;
 
 			return aircraft.Info.RearmBuildings.Contains(dest.Info.Name) && self.TraitsImplementing<AmmoPool>()

--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -20,6 +20,7 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly Aircraft aircraft;
 		readonly RepairableInfo repairableInfo;
+		readonly Rearmable rearmable;
 		readonly bool alwaysLand;
 		readonly bool abortOnResupply;
 		Actor dest;
@@ -28,6 +29,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			aircraft = self.Trait<Aircraft>();
 			repairableInfo = self.Info.TraitInfoOrDefault<RepairableInfo>();
+			rearmable = self.TraitOrDefault<Rearmable>();
 			this.alwaysLand = alwaysLand;
 			this.abortOnResupply = abortOnResupply;
 			this.dest = dest;
@@ -35,9 +37,11 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Actor ChooseResupplier(Actor self, bool unreservedOnly)
 		{
-			var rearmBuildings = aircraft.Info.RearmBuildings;
+			if (rearmable == null)
+				return null;
+
 			return self.World.Actors.Where(a => a.Owner == self.Owner
-				&& rearmBuildings.Contains(a.Info.Name)
+				&& rearmable.Info.RearmActors.Contains(a.Info.Name)
 				&& (!unreservedOnly || !Reservable.IsReserved(a)))
 				.ClosestTo(self);
 		}
@@ -119,8 +123,8 @@ namespace OpenRA.Mods.Common.Activities
 			if (repairableInfo != null && repairableInfo.RepairBuildings.Contains(dest.Info.Name) && self.GetDamageState() != DamageState.Undamaged)
 				return true;
 
-			return aircraft.Info.RearmBuildings.Contains(dest.Info.Name) && self.TraitsImplementing<AmmoPool>()
-					.Any(p => !p.AutoReloads && !p.FullAmmo());
+			return rearmable != null && rearmable.Info.RearmActors.Contains(dest.Info.Name)
+					&& rearmable.RearmableAmmoPools.Any(p => !p.FullAmmo());
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -22,6 +22,7 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly Aircraft aircraft;
 		readonly AircraftInfo aircraftInfo;
+		readonly RepairableInfo repairableInfo;
 		readonly bool alwaysLand;
 		readonly bool abortOnResupply;
 		bool isCalculated;
@@ -35,6 +36,7 @@ namespace OpenRA.Mods.Common.Activities
 			this.abortOnResupply = abortOnResupply;
 			aircraft = self.Trait<Aircraft>();
 			aircraftInfo = self.Info.TraitInfo<AircraftInfo>();
+			repairableInfo = self.Info.TraitInfoOrDefault<RepairableInfo>();
 		}
 
 		public static Actor ChooseResupplier(Actor self, bool unreservedOnly)
@@ -101,7 +103,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (alwaysLand)
 				return true;
 
-			if (aircraftInfo.RepairBuildings.Contains(dest.Info.Name) && self.GetDamageState() != DamageState.Undamaged)
+			if (repairableInfo != null && repairableInfo.RepairBuildings.Contains(dest.Info.Name) && self.GetDamageState() != DamageState.Undamaged)
 				return true;
 
 			return aircraftInfo.RearmBuildings.Contains(dest.Info.Name) && self.TraitsImplementing<AmmoPool>()

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly Aircraft aircraft;
 		readonly AircraftInfo aircraftInfo;
 		readonly RepairableInfo repairableInfo;
+		readonly Rearmable rearmable;
 		readonly bool alwaysLand;
 		readonly bool abortOnResupply;
 		bool isCalculated;
@@ -37,14 +38,18 @@ namespace OpenRA.Mods.Common.Activities
 			aircraft = self.Trait<Aircraft>();
 			aircraftInfo = self.Info.TraitInfo<AircraftInfo>();
 			repairableInfo = self.Info.TraitInfoOrDefault<RepairableInfo>();
+			rearmable = self.TraitOrDefault<Rearmable>();
 		}
 
 		public static Actor ChooseResupplier(Actor self, bool unreservedOnly)
 		{
-			var rearmBuildings = self.Info.TraitInfo<AircraftInfo>().RearmBuildings;
+			var rearmInfo = self.Info.TraitInfoOrDefault<RearmableInfo>();
+			if (rearmInfo == null)
+				return null;
+
 			return self.World.ActorsHavingTrait<Reservable>()
 				.Where(a => a.Owner == self.Owner
-					&& rearmBuildings.Contains(a.Info.Name)
+					&& rearmInfo.RearmActors.Contains(a.Info.Name)
 					&& (!unreservedOnly || !Reservable.IsReserved(a)))
 				.ClosestTo(self);
 		}
@@ -106,8 +111,8 @@ namespace OpenRA.Mods.Common.Activities
 			if (repairableInfo != null && repairableInfo.RepairBuildings.Contains(dest.Info.Name) && self.GetDamageState() != DamageState.Undamaged)
 				return true;
 
-			return aircraftInfo.RearmBuildings.Contains(dest.Info.Name) && self.TraitsImplementing<AmmoPool>()
-					.Any(p => !p.AutoReloads && !p.FullAmmo());
+			return rearmable != null && rearmable.Info.RearmActors.Contains(dest.Info.Name)
+					&& rearmable.RearmableAmmoPools.Any(p => !p.FullAmmo());
 		}
 
 		public override Activity Tick(Actor self)

--- a/OpenRA.Mods.Common/Activities/Rearm.cs
+++ b/OpenRA.Mods.Common/Activities/Rearm.cs
@@ -21,13 +21,13 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly Target host;
 		readonly WDist closeEnough;
-		readonly AmmoPool[] ammoPools;
+		readonly Rearmable rearmable;
 
 		public Rearm(Actor self, Actor host, WDist closeEnough)
 		{
 			this.host = Target.FromActor(host);
 			this.closeEnough = closeEnough;
-			ammoPools = self.TraitsImplementing<AmmoPool>().Where(p => !p.AutoReloads).ToArray();
+			rearmable = self.Trait<Rearmable>();
 		}
 
 		protected override void OnFirstRun(Actor self)
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Activities
 			// Reset the ReloadDelay to avoid any issues with early cancellation
 			// from previous reload attempts (explicit order, host building died, etc).
 			// HACK: this really shouldn't be managed from here
-			foreach (var pool in ammoPools)
+			foreach (var pool in rearmable.RearmableAmmoPools)
 				pool.RemainingTicks = pool.Info.ReloadDelay;
 
 			if (host.Type == TargetType.Invalid)
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 
 			var complete = true;
-			foreach (var pool in ammoPools)
+			foreach (var pool in rearmable.RearmableAmmoPools)
 			{
 				if (!pool.FullAmmo())
 				{

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -928,6 +928,7 @@
     <Compile Include="UpdateRules\Rules\20180923\LowPowerSlowdownToModifier.cs" />
     <Compile Include="UpdateRules\Rules\20180923\RemoveHealthPercentageRing.cs" />
     <Compile Include="UpdateRules\Rules\20180923\RemoveRepairBuildingsFromAircraft.cs" />
+    <Compile Include="UpdateRules\Rules\20180923\AddRearmable.cs" />
     <Compile Include="Traits\Player\PlayerResources.cs" />
     <Compile Include="UtilityCommands\DumpSequenceSheetsCommand.cs" />
     <Compile Include="Traits\Render\WithBuildingRepairDecoration.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -315,6 +315,7 @@
     <Compile Include="Traits\CaptureProgressBar.cs" />
     <Compile Include="Traits\CaptureProgressBlink.cs" />
     <Compile Include="Traits\RepairsUnits.cs" />
+    <Compile Include="Traits\Rearmable.cs" />
     <Compile Include="Traits\Burns.cs" />
     <Compile Include="Traits\ChangesTerrain.cs" />
     <Compile Include="Traits\CommandBarBlacklist.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -926,6 +926,7 @@
     <Compile Include="UpdateRules\Rules\20180923\MergeRearmAndRepairAnimation.cs" />
     <Compile Include="UpdateRules\Rules\20180923\LowPowerSlowdownToModifier.cs" />
     <Compile Include="UpdateRules\Rules\20180923\RemoveHealthPercentageRing.cs" />
+    <Compile Include="UpdateRules\Rules\20180923\RemoveRepairBuildingsFromAircraft.cs" />
     <Compile Include="Traits\Player\PlayerResources.cs" />
     <Compile Include="UtilityCommands\DumpSequenceSheetsCommand.cs" />
     <Compile Include="Traits\Render\WithBuildingRepairDecoration.cs" />

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -37,9 +37,6 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int RepulsionSpeed = -1;
 
 		[ActorReference]
-		public readonly HashSet<string> RepairBuildings = new HashSet<string> { };
-
-		[ActorReference]
 		public readonly HashSet<string> RearmBuildings = new HashSet<string> { };
 
 		public readonly int InitialFacing = 0;
@@ -157,6 +154,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly AircraftInfo Info;
 		readonly Actor self;
 
+		RepairableInfo repairableInfo;
 		ConditionManager conditionManager;
 		IDisposable reservation;
 		IEnumerable<int> speedModifiers;
@@ -212,6 +210,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected virtual void Created(Actor self)
 		{
+			repairableInfo = self.Info.TraitInfoOrDefault<RepairableInfo>();
 			conditionManager = self.TraitOrDefault<ConditionManager>();
 			speedModifiers = self.TraitsImplementing<ISpeedModifier>().ToArray().Select(sm => sm.GetSpeedModifier());
 			cachedPosition = self.CenterPosition;
@@ -452,7 +451,7 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			return Info.RearmBuildings.Contains(a.Info.Name)
-				|| Info.RepairBuildings.Contains(a.Info.Name);
+				|| (repairableInfo != null && repairableInfo.RepairBuildings.Contains(a.Info.Name));
 		}
 
 		public int MovementSpeed
@@ -492,7 +491,7 @@ namespace OpenRA.Mods.Common.Traits
 				yield return new Rearm(self, a, WDist.Zero);
 
 			// The ResupplyAircraft activity guarantees that we're on the helipad
-			if (Info.RepairBuildings.Contains(name))
+			if (repairableInfo != null && repairableInfo.RepairBuildings.Contains(name))
 				yield return new Repair(self, a, WDist.Zero);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -36,9 +36,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The speed at which the aircraft is repulsed from other aircraft. Specify -1 for normal movement speed.")]
 		public readonly int RepulsionSpeed = -1;
 
-		[ActorReference]
-		public readonly HashSet<string> RearmBuildings = new HashSet<string> { };
-
 		public readonly int InitialFacing = 0;
 
 		public readonly int TurnSpeed = 255;
@@ -155,6 +152,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Actor self;
 
 		RepairableInfo repairableInfo;
+		RearmableInfo rearmableInfo;
 		ConditionManager conditionManager;
 		IDisposable reservation;
 		IEnumerable<int> speedModifiers;
@@ -211,6 +209,7 @@ namespace OpenRA.Mods.Common.Traits
 		protected virtual void Created(Actor self)
 		{
 			repairableInfo = self.Info.TraitInfoOrDefault<RepairableInfo>();
+			rearmableInfo = self.Info.TraitInfoOrDefault<RearmableInfo>();
 			conditionManager = self.TraitOrDefault<ConditionManager>();
 			speedModifiers = self.TraitsImplementing<ISpeedModifier>().ToArray().Select(sm => sm.GetSpeedModifier());
 			cachedPosition = self.CenterPosition;
@@ -450,7 +449,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (self.AppearsHostileTo(a))
 				return false;
 
-			return Info.RearmBuildings.Contains(a.Info.Name)
+			return (rearmableInfo != null && rearmableInfo.RearmActors.Contains(a.Info.Name))
 				|| (repairableInfo != null && repairableInfo.RepairBuildings.Contains(a.Info.Name));
 		}
 
@@ -487,7 +486,7 @@ namespace OpenRA.Mods.Common.Traits
 		public virtual IEnumerable<Activity> GetResupplyActivities(Actor a)
 		{
 			var name = a.Info.Name;
-			if (Info.RearmBuildings.Contains(name))
+			if (rearmableInfo != null && rearmableInfo.RearmActors.Contains(name))
 				yield return new Rearm(self, a, WDist.Zero);
 
 			// The ResupplyAircraft activity guarantees that we're on the helipad
@@ -669,13 +668,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		Order IIssueDeployOrder.IssueDeployOrder(Actor self, bool queued)
 		{
-			if (!Info.RearmBuildings.Any())
+			if (rearmableInfo == null || !rearmableInfo.RearmActors.Any())
 				return null;
 
 			return new Order("ReturnToBase", self, queued);
 		}
 
-		bool IIssueDeployOrder.CanIssueDeployOrder(Actor self) { return Info.RearmBuildings.Any(); }
+		bool IIssueDeployOrder.CanIssueDeployOrder(Actor self) { return rearmableInfo != null && rearmableInfo.RearmActors.Any(); }
 
 		public string VoicePhraseForOrder(Actor self, Order order)
 		{
@@ -689,7 +688,7 @@ namespace OpenRA.Mods.Common.Traits
 				case "Stop":
 					return Info.Voice;
 				case "ReturnToBase":
-					return Info.RearmBuildings.Any() ? Info.Voice : null;
+					return rearmableInfo != null && rearmableInfo.RearmActors.Any() ? Info.Voice : null;
 				default: return null;
 			}
 		}
@@ -782,7 +781,7 @@ namespace OpenRA.Mods.Common.Traits
 					self.QueueActivity(new HeliLand(self, true));
 				}
 			}
-			else if (order.OrderString == "ReturnToBase" && Info.RearmBuildings.Any())
+			else if (order.OrderString == "ReturnToBase" && rearmableInfo != null && rearmableInfo.RearmActors.Any())
 			{
 				UnReserve();
 				self.CancelActivity();

--- a/OpenRA.Mods.Common/Traits/Air/ReturnOnIdle.cs
+++ b/OpenRA.Mods.Common/Traits/Air/ReturnOnIdle.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	[Desc("Return to a player owned RearmBuildings. If none available, head back to base and circle over it.")]
+	[Desc("Return to a player owned RearmActor. If none available, head back to base and circle over it.")]
 	public class ReturnOnIdleInfo : ITraitInfo, Requires<AircraftInfo>
 	{
 		public object Create(ActorInitializer init) { return new ReturnOnIdle(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/AmmoPool.cs
+++ b/OpenRA.Mods.Common/Traits/AmmoPool.cs
@@ -97,15 +97,9 @@ namespace OpenRA.Mods.Common.Traits
 			return true;
 		}
 
-		// This mostly serves to avoid complicated ReloadAmmoPool look-ups in various other places.
-		// TODO: Investigate removing this when the Rearm activity is replaced with a condition-based solution.
-		public bool AutoReloads { get; private set; }
-
 		void INotifyCreated.Created(Actor self)
 		{
 			conditionManager = self.TraitOrDefault<ConditionManager>();
-			AutoReloads = self.TraitsImplementing<ReloadAmmoPool>().Any(r => r.Info.AmmoPool == Info.Name && r.Info.RequiresCondition == null);
-
 			UpdateCondition(self);
 
 			// HACK: Temporarily needed until Rearm activity is gone for good

--- a/OpenRA.Mods.Common/Traits/Rearmable.cs
+++ b/OpenRA.Mods.Common/Traits/Rearmable.cs
@@ -1,0 +1,46 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public class RearmableInfo : ITraitInfo
+	{
+		[Desc("Actors that this actor can dock to and get rearmed by.")]
+		[FieldLoader.Require]
+		[ActorReference] public readonly HashSet<string> RearmActors = new HashSet<string> { };
+
+		[Desc("Name(s) of AmmoPool(s) that use this trait to rearm.")]
+		public readonly HashSet<string> AmmoPools = new HashSet<string> { "primary" };
+
+		public object Create(ActorInitializer init) { return new Rearmable(this); }
+	}
+
+	public class Rearmable : INotifyCreated
+	{
+		public readonly RearmableInfo Info;
+
+		public Rearmable(RearmableInfo info)
+		{
+			Info = info;
+		}
+
+		public AmmoPool[] RearmableAmmoPools { get; private set; }
+
+		void INotifyCreated.Created(Actor self)
+		{
+			RearmableAmmoPools = self.TraitsImplementing<AmmoPool>().Where(p => Info.AmmoPools.Contains(p.Info.Name)).ToArray();
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/AddRearmable.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/AddRearmable.cs
@@ -1,0 +1,102 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class AddRearmable : UpdateRule
+	{
+		public override string Name { get { return "Added Rearmable trait and move RearmBuildings properties there"; } }
+		public override string Description
+		{
+			get
+			{
+				return "Added Rearmable trait and replaced Aircraft.RearmBuildings and\n" +
+					"Minelayer.RearmBuildings with Rearmable.RearmActors.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var aircraftNodes = actorNode.ChildrenMatching("Aircraft");
+			var minelayerNodes = actorNode.ChildrenMatching("Minelayer");
+			var ammoPoolNodes = actorNode.ChildrenMatching("AmmoPool");
+			var addNodes = new List<MiniYamlNode>();
+
+			var ammoPoolNames = new List<string>() { "primary" };
+			foreach (var ap in ammoPoolNodes)
+			{
+				var poolName = ap.LastChildMatching("Name");
+				if (poolName != null && poolName.NodeValue<string>() != "primary")
+					ammoPoolNames.Add(poolName.NodeValue<string>());
+			}
+
+			var rearmableAdded = false;
+			foreach (var aircraftNode in aircraftNodes)
+			{
+				var rearmBuildings = aircraftNode.LastChildMatching("RearmBuildings");
+				if (rearmBuildings != null)
+				{
+					if (!rearmableAdded)
+					{
+						var rearmableNode = new MiniYamlNode("Rearmable", "");
+						rearmBuildings.MoveAndRenameNode(aircraftNode, rearmableNode, "RearmActors");
+
+						// If the list has more than one entry, at least one of them won't be "primary"
+						if (ammoPoolNames.Count > 1)
+						{
+							var ammoPools = new MiniYamlNode("AmmoPools", string.Join(", ", ammoPoolNames));
+							rearmableNode.AddNode(ammoPools);
+						}
+
+						addNodes.Add(rearmableNode);
+						rearmableAdded = true;
+					}
+					else
+						aircraftNode.RemoveNodes("RearmBuildings");
+				}
+			}
+
+			// If it's a minelayer, it won't be an aircraft and rearmableAdded should still be false, so we can use it here
+			foreach (var minelayerNode in minelayerNodes)
+			{
+				var rearmableNode = new MiniYamlNode("Rearmable", "");
+
+				var rearmBuildings = minelayerNode.LastChildMatching("RearmBuildings");
+				if (!rearmableAdded)
+				{
+					if (rearmBuildings != null)
+						rearmBuildings.MoveAndRenameNode(minelayerNode, rearmableNode, "RearmActors");
+					else
+						rearmableNode.AddNode(new MiniYamlNode("RearmActors", "fix"));
+
+					// If the list has more than one entry, at least one of them won't be "primary"
+					if (ammoPoolNames.Count > 1)
+					{
+						var ammoPools = new MiniYamlNode("AmmoPools", string.Join(", ", ammoPoolNames));
+						rearmableNode.AddNode(ammoPools);
+					}
+
+					addNodes.Add(rearmableNode);
+					rearmableAdded = true;
+				}
+				else if (rearmableAdded && rearmBuildings != null)
+					minelayerNode.RemoveNodes("RearmBuildings");
+			}
+
+			foreach (var node in addNodes)
+				actorNode.AddNode(node);
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/RemoveRepairBuildingsFromAircraft.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/RemoveRepairBuildingsFromAircraft.cs
@@ -1,0 +1,50 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RemoveRepairBuildingsFromAircraft : UpdateRule
+	{
+		public override string Name { get { return "Removed RepairBuildings from Aircraft"; } }
+		public override string Description
+		{
+			get
+			{
+				return "Removed RepairBuildings from Aircraft in favor of using Repairable instead.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			// Aircraft isn't conditional or otherwise supports multiple traits, so LastChildMatching is fine.
+			var aircraftNode = actorNode.LastChildMatching("Aircraft");
+			if (aircraftNode != null)
+			{
+				var repairBuildings = aircraftNode.LastChildMatching("RepairBuildings");
+				if (repairBuildings != null)
+				{
+					var repariableNode = new MiniYamlNode("Repairable", "");
+					repairBuildings.MoveAndRenameNode(aircraftNode, repariableNode, "RepairBuildings");
+
+					var voice = aircraftNode.LastChildMatching("Voice");
+					if (voice != null)
+						repariableNode.AddNode(voice);
+
+					actorNode.AddNode(repariableNode);
+				}
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -96,6 +96,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemovedNotifyBuildComplete(),
 				new LowPowerSlowdownToModifier(),
 				new RenameCrateActionNotification(),
+				new RemoveRepairBuildingsFromAircraft(),
 			})
 		};
 

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -97,6 +97,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new LowPowerSlowdownToModifier(),
 				new RenameCrateActionNotification(),
 				new RemoveRepairBuildingsFromAircraft(),
+				new AddRearmable(),
 			})
 		};
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -306,8 +306,9 @@
 	WithSpriteControlGroupDecoration:
 	Selectable:
 		Bounds: 24,24
-	Aircraft:
+	Repairable:
 		RepairBuildings: hpad
+	Aircraft:
 		LandWhenIdle: false
 		AirborneCondition: airborne
 		CruisingCondition: cruising

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -109,7 +109,6 @@ MIG:
 	AttackPlane:
 		FacingTolerance: 20
 	Aircraft:
-		RearmBuildings: afld, afld.ukraine
 		CruiseAltitude: 2560
 		InitialFacing: 192
 		TurnSpeed: 4
@@ -138,6 +137,8 @@ MIG:
 		Interval: 2
 	ProducibleWithLevel:
 		Prerequisites: aircraft.upgraded
+	Rearmable:
+		RearmActors: afld, afld.ukraine
 
 YAK:
 	Inherits: ^Plane
@@ -175,7 +176,6 @@ YAK:
 	AttackPlane:
 		FacingTolerance: 20
 	Aircraft:
-		RearmBuildings: afld, afld.ukraine
 		CruiseAltitude: 2560
 		InitialFacing: 192
 		TurnSpeed: 4
@@ -204,6 +204,8 @@ YAK:
 		Prerequisites: aircraft.upgraded
 	Selectable:
 		DecorationBounds: 30,28,0,2
+	Rearmable:
+		RearmActors: afld, afld.ukraine
 
 TRAN:
 	Inherits: ^Helicopter
@@ -292,7 +294,6 @@ HELI:
 	AttackHeli:
 		FacingTolerance: 20
 	Aircraft:
-		RearmBuildings: hpad
 		LandWhenIdle: false
 		InitialFacing: 224
 		TurnSpeed: 4
@@ -320,6 +321,8 @@ HELI:
 		Prerequisites: aircraft.upgraded
 	Selectable:
 		DecorationBounds: 36,28
+	Rearmable:
+		RearmActors: hpad
 
 HIND:
 	Inherits: ^Helicopter
@@ -357,7 +360,6 @@ HIND:
 	AttackHeli:
 		FacingTolerance: 20
 	Aircraft:
-		RearmBuildings: hpad
 		LandWhenIdle: false
 		InitialFacing: 224
 		TurnSpeed: 4
@@ -386,6 +388,8 @@ HIND:
 		Prerequisites: aircraft.upgraded
 	Selectable:
 		DecorationBounds: 38,32
+	Rearmable:
+		RearmActors: hpad
 
 U2:
 	Inherits: ^NeutralPlane

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -526,7 +526,6 @@
 	Selectable:
 		Bounds: 24,24
 	Aircraft:
-		RepairBuildings: fix
 		AirborneCondition: airborne
 	Targetable@GROUND:
 		TargetTypes: Ground, Repair, Vehicle
@@ -573,6 +572,8 @@
 ^Plane:
 	Inherits: ^NeutralPlane
 	Inherits@2: ^GainsExperience
+	Repairable:
+		RepairBuildings: fix
 
 ^Helicopter:
 	Inherits: ^Plane

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -492,6 +492,8 @@ MNLY:
 		Weapon: ATMine
 	RenderSprites:
 		Image: MNLY
+	Rearmable:
+		RearmActors: fix
 
 TRUK:
 	Inherits: ^Vehicle

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -80,7 +80,6 @@ ORCA:
 	Selectable:
 		Bounds: 30,24
 	Aircraft:
-		RearmBuildings: gahpad, nahpad
 		TurnSpeed: 5
 		Speed: 186
 		MoveIntoShroud: false
@@ -109,6 +108,8 @@ ORCA:
 	RenderSprites:
 	SpawnActorOnDeath:
 		Actor: ORCA.Husk
+	Rearmable:
+		RearmActors: gahpad, nahpad
 
 ORCAB:
 	Inherits: ^Aircraft
@@ -127,7 +128,6 @@ ORCAB:
 	Selectable:
 		Bounds: 30,24
 	Aircraft:
-		RearmBuildings: gahpad, nahpad
 		CruiseAltitude: 3072
 		MaximumPitch: 120
 		TurnSpeed: 3
@@ -164,6 +164,8 @@ ORCAB:
 		RequiresCondition: cruising
 	SpawnActorOnDeath:
 		Actor: ORCAB.Husk
+	Rearmable:
+		RearmActors: gahpad, nahpad
 
 ORCATRAN:
 	Inherits: ^Helicopter
@@ -257,7 +259,6 @@ SCRIN:
 	Voiced:
 		VoiceSet: Scrin
 	Aircraft:
-		RearmBuildings: gahpad, nahpad
 		CruiseAltitude: 2560
 		MaximumPitch: 90
 		TurnSpeed: 3
@@ -292,6 +293,8 @@ SCRIN:
 	DeathSounds:
 	SpawnActorOnDeath:
 		Actor: SCRIN.Husk
+	Rearmable:
+		RearmActors: gahpad, nahpad
 
 APACHE:
 	Inherits: ^Helicopter
@@ -310,7 +313,6 @@ APACHE:
 	Selectable:
 		Bounds: 30,24
 	Aircraft:
-		RearmBuildings: gahpad, nahpad
 		TurnSpeed: 5
 		Speed: 130
 		MoveIntoShroud: false
@@ -345,6 +347,8 @@ APACHE:
 	RenderSprites:
 	SpawnActorOnDeath:
 		Actor: APACHE.Husk
+	Rearmable:
+		RearmActors: gahpad, nahpad
 
 HUNTER:
 	Inherits@2: ^ExistsInWorld

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -821,9 +821,11 @@
 	WithTextControlGroupDecoration:
 	SelectionDecorations:
 		Palette: pips
+	Repairable:
+		RepairBuildings: gadept
+		Voice: Move
 	Aircraft:
 		AirborneCondition: airborne
-		RepairBuildings: gadept
 		LandWhenIdle: false
 		Voice: Move
 		IdealSeparation: 853


### PR DESCRIPTION
Some work towards #9613.

This removes `RepairBuildings` and `RearmBuildings` from `Aircraft` and `Minelayer` in favor of using `Repairable` and the new `Rearmable`, respectively.

Notes about `Rearmable`: 
1) The idea is to keep it this simple for the forseeable future (I'd like to keep the `Trait(Info)OrDefault` approach until the follow-up).
2) My plan is to later split `Repairable` into a similarly simple trait (probably keeping the trait name) as well as a generalistic `SupplyManager` that handles all the orders etc. for both resupply types, and just uses the existence of those traits and - if present - Rearm/RepairActors to decide on the details of the order handling and activity queueing. This would also allow to later introduce other resupply types (`Refuel` comes to mind).

The yaml changes were done via the provided upgrade rules, so they've been tested and work.