### PR TITLE
Add support for custom sell cursors

### DIFF
--- a/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
@@ -16,14 +16,12 @@ using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.Common.Orders
 {
-	public class GlobalButtonOrderGenerator<T> : IOrderGenerator
+	public abstract class GlobalButtonOrderGenerator<T> : IOrderGenerator
 	{
-		string cursor;
 		string order;
 
-		public GlobalButtonOrderGenerator(string cursor, string order)
+		public GlobalButtonOrderGenerator(string order)
 		{
-			this.cursor = cursor;
 			this.order = order;
 		}
 
@@ -35,7 +33,7 @@ namespace OpenRA.Mods.Common.Orders
 			return OrderInner(world, mi);
 		}
 
-		IEnumerable<Order> OrderInner(World world, MouseInput mi)
+		protected IEnumerable<Order> OrderInner(World world, MouseInput mi)
 		{
 			if (mi.Button == MouseButton.Left)
 			{
@@ -64,20 +62,28 @@ namespace OpenRA.Mods.Common.Orders
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
 		public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
 
-		public string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
-		{
-			mi.Button = MouseButton.Left;
-			return cursor + (OrderInner(world, mi).Any() ? "" : "-blocked");
-		}
+		public abstract string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi);
 	}
 
 	public class PowerDownOrderGenerator : GlobalButtonOrderGenerator<CanPowerDown>
 	{
-		public PowerDownOrderGenerator() : base("powerdown", "PowerDown") { }
+		public PowerDownOrderGenerator() : base("PowerDown") { }
+
+		public override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		{
+			mi.Button = MouseButton.Left;
+			return OrderInner(world, mi).Any() ? "powerdown" : "powerdown-blocked";
+		}
 	}
 
 	public class SellOrderGenerator : GlobalButtonOrderGenerator<Sellable>
 	{
-		public SellOrderGenerator() : base("sell", "Sell") { }
+		public SellOrderGenerator() : base("Sell") { }
+
+		public override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		{
+			mi.Button = MouseButton.Left;
+			return OrderInner(world, mi).Any() ? "sell" : "sell-blocked";
+		}
 	}
 }

--- a/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
@@ -83,7 +83,14 @@ namespace OpenRA.Mods.Common.Orders
 		public override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			mi.Button = MouseButton.Left;
-			return OrderInner(world, mi).Any() ? "sell" : "sell-blocked";
+
+			var cursor = OrderInner(world, mi)
+				.SelectMany(o => o.Subject.TraitsImplementing<Sellable>())
+				.Where(Exts.IsTraitEnabled)
+				.Select(si => si.Info.Cursor)
+				.FirstOrDefault();
+
+			return cursor ?? "sell-blocked";
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Sellable.cs
+++ b/OpenRA.Mods.Common/Traits/Sellable.cs
@@ -27,6 +27,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Skip playing (reversed) make animation.")]
 		public readonly bool SkipMakeAnimation = false;
 
+		[Desc("Cursor type to use when the sell order generator hovers over this actor.")]
+		public readonly string Cursor = "sell";
+
 		public override object Create(ActorInitializer init) { return new Sellable(init.Self, this); }
 	}
 


### PR DESCRIPTION
Reimplements #14292 in a simpler/cleaner way.
Closes #14283.

Simple test case:
```diff
diff --git a/mods/ra/rules/defaults.yaml b/mods/ra/rules/defaults.yaml
index 5434d0b8a6..fc1e8437df 100644
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -281,6 +281,9 @@
        HitShape:
        EditorTilesetFilter:
                Categories: Vehicle
+       Sellable:
+               Cursor: sell2
+               SellSounds: cashturn.aud
 
 ^Tank:
        Inherits: ^Vehicle
```