### PR TITLE
Run GC more during loading.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -170,8 +170,12 @@ namespace OpenRA
 
 			worldRenderer = new WorldRenderer(ModData, OrderManager.World);
 
+			GC.Collect();
+
 			using (new PerfTimer("LoadComplete"))
 				OrderManager.World.LoadComplete(worldRenderer);
+
+			GC.Collect();
 
 			if (OrderManager.GameStarted)
 				return;


### PR DESCRIPTION
This helps reduce the peak GC size by trimming temporary loading garbage a bit more often, rather than just doing it at the end of loading.

Helps reduce our peak virtual memory usage be reducing the spike the occurs during loading. Should help with #12494 for when loading pushes you over the edge but after loading you would free enough memory to have it be otherwise playable.