### PR TITLE
Reduce the size of the sheets created for fonts.

### DIFF
--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -49,8 +49,8 @@ namespace OpenRA.Graphics
 			Func<char, float> characterWidth = character => glyphs[Pair.New(character, Color.White)].Advance;
 			lineWidth = line => line.Sum(characterWidth) / deviceScale;
 
-			PrecacheColor(Color.White, name);
-			PrecacheColor(Color.Red, name);
+			if (size <= 24)
+				PrecacheColor(Color.White, name);
 		}
 
 		public void SetScale(float scale)

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -84,7 +84,7 @@ namespace OpenRA
 			{
 				if (fontSheetBuilder != null)
 					fontSheetBuilder.Dispose();
-				fontSheetBuilder = new SheetBuilder(SheetType.BGRA);
+				fontSheetBuilder = new SheetBuilder(SheetType.BGRA, 512);
 				Fonts = modData.Manifest.Fonts.ToDictionary(x => x.Key,
 					x => new SpriteFont(x.Value.First, modData.DefaultFileSystem.Open(x.Value.First).ReadAllBytes(),
 										x.Value.Second, Device.WindowScale, fontSheetBuilder)).AsReadOnly();


### PR DESCRIPTION
Memory reduction efforts to tackle #12494.

- A 512x512 sheet is about half full after precaching and some usage, but uses 16x less memory than the default 2048x2048 sheet. This saving occurs twice as we maintain a managed buffer for this sheet.
- Only precache smaller fonts, as the larger fonts are less used and take up more space than is worthwhile.
- Only precache in white, as red is largely unused.