### PR TITLE
Switch to 64 bit MacOS launcher and dependencies.

### DIFF
--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -9,7 +9,7 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
 	command -v genisoimage >/dev/null 2>&1 || { echo >&2 "macOS packaging requires genisoimage."; exit 1; }
 fi
 
-LAUNCHER_TAG="osx-launcher-20171022"
+LAUNCHER_TAG="osx-launcher-20171118"
 
 if [ $# -ne "2" ]; then
 	echo "Usage: `basename $0` tag outputdir"

--- a/thirdparty/fetch-thirdparty-deps-osx.sh
+++ b/thirdparty/fetch-thirdparty-deps-osx.sh
@@ -1,20 +1,22 @@
 #!/bin/bash
 
+LAUNCHER_TAG="osx-launcher-20171118"
+
 download_dir="${0%/*}/download/osx"
 mkdir -p "$download_dir"
 cd "$download_dir"
 
 if [ ! -f libSDL2.dylib ]; then
 	echo "Fetching OS X SDL2 library from GitHub."
-	curl -LOs https://raw.githubusercontent.com/OpenRA/OpenRALauncherOSX/master/dependencies/libSDL2.dylib
+	curl -LOs https://github.com/OpenRA/OpenRALauncherOSX/releases/download/${LAUNCHER_TAG}/libSDL2.dylib
 fi
 
 if [ ! -f liblua.5.1.dylib ]; then
 	echo "Fetching OS X Lua 5.1 library from GitHub."
-	curl -LOs https://raw.githubusercontent.com/OpenRA/OpenRALauncherOSX/master/dependencies/liblua.5.1.dylib
+	curl -LOs https://github.com/OpenRA/OpenRALauncherOSX/releases/download/${LAUNCHER_TAG}/liblua.5.1.dylib
 fi
 
 if [ ! -f Eluant.dll.config ]; then
 	echo "Fetching OS X Lua configuration file from GitHub."
-	curl -LOs https://raw.githubusercontent.com/OpenRA/OpenRALauncherOSX/master/dependencies/Eluant.dll.config
+	curl -LOs https://raw.githubusercontent.com/OpenRA/OpenRALauncherOSX/${LAUNCHER_TAG}/dependencies/Eluant.dll.config
 fi


### PR DESCRIPTION
This updates us to the [latest OpenRALauncherOSX](https://github.com/OpenRA/OpenRALauncherOSX/releases/tag/osx-launcher-20171118) tag, which now features 64 bit libraries and uses Travis's macOS runtime to automatically compile all binaries.

Closes #13478.