### PR TITLE
Fix WithDisguisingInfantryBody crashing when losing the disguise

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -151,8 +151,12 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			if (order.OrderString == "Disguise")
 			{
-				var target = order.TargetActor != self && order.TargetActor.IsInWorld ? order.TargetActor : null;
-				DisguiseAs(target);
+				var target = order.Target;
+				if (target.Type == TargetType.Actor)
+					DisguiseAs((target.Actor != self && target.Actor.IsInWorld) ? target.Actor : null);
+
+				if (target.Type == TargetType.FrozenActor)
+					DisguiseAs(target.FrozenActor.Info, target.FrozenActor.Owner);
 			}
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -122,6 +122,8 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			this.self = self;
 			this.info = info;
+
+			AsActor = self.Info;
 		}
 
 		void INotifyCreated.Created(Actor self)

--- a/OpenRA.Mods.Cnc/Traits/Render/WithDisguisingInfantryBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithDisguisingInfantryBody.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 				disguisePlayer = disguise.AsPlayer;
 				disguiseImage = null;
 
-				if (disguiseActor != null)
+				if (disguisePlayer != null)
 				{
 					var renderSprites = disguiseActor.TraitInfoOrDefault<RenderSpritesInfo>();
 					if (renderSprites != null)


### PR DESCRIPTION
Since #14059 ([diff](https://github.com/OpenRA/OpenRA/pull/14059/files#diff-162aa0bff4ea50cd0bd1df84115fc893R199)) we don't `null` the `AsSprite`/`AsActor` but `AsPlayer` which leads to the following crash on bleed:
```
OpenRA engine version {DEV_VERSION}
Red Alert mod version {DEV_VERSION}
on map 45b2b2a9b4f4903267b4d0f2d271b25c6975b519 (Fort Lonestar by Nuke'm Bro, abcdefg30).
Date: 2017-11-19 01:07:59Z
Operating System: Windows (Microsoft Windows NT 6.2.9200.0)
Runtime Version: .NET CLR 4.0.30319.42000
Exception of type `System.NullReferenceException`: Object reference not set to an instance of an object. (Der Objektverweis wurde nicht auf eine Objektinstanz festgelegt.)
   at OpenRA.Mods.Cnc.Traits.Render.WithDisguisingInfantryBody.Tick(Actor self) in \OpenRA\OpenRA.Mods.Cnc\Traits\Render\WithDisguisingInfantryBody.cs:Line 52.
   at OpenRA.Mods.Common.Traits.Render.WithInfantryBody.OpenRA.Traits.ITick.Tick(Actor self) in \OpenRA\OpenRA.Mods.Common\Traits\Render\WithInfantryBody.cs:Line 127.
   at OpenRA.World.<Tick>b__b(TraitPair`1 x) in \OpenRA\OpenRA.Game\World.cs:Line 359.
   at OpenRA.WorldUtils.DoTimed[T](IEnumerable`1 e, Action`1 a, String text) in \OpenRA\OpenRA.Game\WorldUtils.cs:Line 75.
   at OpenRA.World.Tick() in \OpenRA\OpenRA.Game\World.cs:Line 0.
   at OpenRA.Game.InnerLogicTick(OrderManager orderManager) in \OpenRA\OpenRA.Game\Game.cs:Line 609.
   at OpenRA.Game.LogicTick() in \OpenRA\OpenRA.Game\Game.cs:Line 633.
   at OpenRA.Game.Loop() in \OpenRA\OpenRA.Game\Game.cs:Line 763.
   at OpenRA.Game.Run() in \OpenRA\OpenRA.Game\Game.cs:Line 803.
   at OpenRA.Program.Run(String[] args) in \OpenRA\OpenRA.Game\Support\Program.cs:Line 136.
   at OpenRA.Program.Main(String[] args) in \OpenRA\OpenRA.Game\Support\Program.cs:Line 40.
```

Edit: Turns out there was another crash I fixed as well now:
```
OpenRA engine version {DEV_VERSION}
Red Alert mod version {DEV_VERSION}
on map 45b2b2a9b4f4903267b4d0f2d271b25c6975b519 (Fort Lonestar by Nuke'm Bro, abcdefg30).
Date: 2017-11-19 00:43:56Z
Operating System: Windows (Microsoft Windows NT 6.2.9200.0)
Runtime Version: .NET CLR 4.0.30319.42000
Exception of type `System.NullReferenceException`: Object reference not set to an instance of an object. (Der Objektverweis wurde nicht auf eine Objektinstanz festgelegt.)
   at OpenRA.Mods.Cnc.Traits.Disguise.OpenRA.Traits.IResolveOrder.ResolveOrder(Actor self, Order order) in \OpenRA\OpenRA.Mods.Cnc\Traits\Disguise.cs:Line 152.
   at OpenRA.Network.UnitOrders.ProcessOrder(OrderManager orderManager, World world, Int32 clientId, Order order) in \OpenRA\OpenRA.Game\Network\UnitOrders.cs:Line 286.
   at OpenRA.Network.OrderManager.Tick() in \OpenRA\OpenRA.Game\Network\OrderManager.cs:Line 179.
   at OpenRA.Game.InnerLogicTick(OrderManager orderManager) in \OpenRA\OpenRA.Game\Game.cs:Line 601.
   at OpenRA.Game.LogicTick() in \OpenRA\OpenRA.Game\Game.cs:Line 633.
   at OpenRA.Game.Loop() in \OpenRA\OpenRA.Game\Game.cs:Line 763.
   at OpenRA.Game.Run() in \OpenRA\OpenRA.Game\Game.cs:Line 803.
   at OpenRA.Program.Run(String[] args) in \OpenRA\OpenRA.Game\Support\Program.cs:Line 136.
   at OpenRA.Program.Main(String[] args) in \OpenRA\OpenRA.Game\Support\Program.cs:Line 40.
```