### PR TITLE
Small override fix in mission Intervention

### DIFF
--- a/mods/ra/maps/intervention/weapons.yaml
+++ b/mods/ra/maps/intervention/weapons.yaml
@@ -4,4 +4,3 @@ Nike:
 Maverick:
 	Warhead@1Dam: SpreadDamage
 		Damage: 175
-		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath


### PR DESCRIPTION
Inline with #14353 and #14377.

DamageTypes is inherited from [AntiGroundMissile](https://github.com/OpenRA/OpenRA/blob/bleed/mods/ra/weapons/missiles.yaml#L26).