### PR TITLE
Fix for V2 Rocket Launcher facings

### DIFF
--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -301,6 +301,8 @@ ARTY:
 V2RL:
 	Health:
 		HP: 100
+	ReloadAmmoPool:
+		Delay: 280
 
 4TNK:
 	Health:

--- a/mods/ra/maps/fort-lonestar/weapons.yaml
+++ b/mods/ra/maps/fort-lonestar/weapons.yaml
@@ -142,7 +142,6 @@ FLAK-23:
 		Explosions: med_explosion
 
 SCUD:
-	ReloadDelay: 280
 	Range: 7c0
 	Projectile: Bullet
 		Arm: 10

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -24,14 +24,24 @@ V2RL:
 		Range: 4c0
 	Armament:
 		Weapon: SCUD
+		PauseOnCondition: !ammo
+	AmmoPool:
+		Ammo: 1
+		PipCount: 0
+		AmmoCondition: ammo
+	ReloadAmmoPool:
+		Delay: 240
+		Count: 1
 	AttackFrontal:
+	WithFacingSpriteBody:
+		RequiresCondition: ammo
+	WithFacingSpriteBody@EMPTY:
+		RequiresCondition: !ammo
+		Sequence: empty-idle
 	SelectionDecorations:
 		VisualBounds: 28,28
 	Explodes:
 		Weapon: V2Explode
-	WithAttackAnimation:
-		AimSequence: aim
-		ReloadPrefix: empty-
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 

--- a/mods/ra/sequences/vehicles.yaml
+++ b/mods/ra/sequences/vehicles.yaml
@@ -166,12 +166,6 @@ v2rl:
 		Start: 32
 		Facings: 32
 		UseClassicFacingFudge: True
-	aim:
-		Start: 64
-		Facings: 8
-	empty-aim:
-		Start: 72
-		Facings: 8
 	icon: v2rlicon
 
 arty:

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -313,7 +313,7 @@ SubMissileAA:
 
 SCUD:
 	Inherits: ^AntiGroundMissile
-	ReloadDelay: 240
+	ReloadDelay: 0
 	Range: 10c0
 	MinRange: 3c0
 	Report: missile1.aud


### PR DESCRIPTION
I’ve found a solution for the V2 rocket launcher shaking. The V2 rocket launcher has 32 facings for when it is loaded with a rocket and 32 facings without a rocket. Additional, there are only 8 facings for when the rocket is raised and only 8 facings when the rocket is launched with that thing that holds the rocket still raised. Now, I’ve inspected the original game and that thing that raises the rocket is not used there. (I always thought that I missed that detail somehow in the originals.)

So, in order to fix this problem, I removed the aim and empty-aim in sequences/vehicles.yaml. Now the V2 rocket launcher doesn’t shake anymore. There is only a small problem with that.

If the V2 faces one direction (let’s say to the east) with still a rocket on it. And it shoot its rocket to the east, the image of the V2 doesn’t change to an image of a V2 without a rocket.
However, if the V2 moves after that, the image of the V2 gets updated and is now displayed without a rocket.

The solution for that was to reuse the empty-aim trait, but this time pointing at the 32 facings of a V2 without a rocket. Now the V2 rocket launcher works perfectly!

Closes  #12117