### PR TITLE
D2K - Rename vehicle husks

### DIFF
--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -261,23 +261,6 @@
 		Moves: True
 		Explosion: UnitExplodeLarge
 
-^TowerHusk:
-	Health:
-		HP: 125
-	Armor:
-		Type: concrete
-	Husk:
-	AppearsOnRadar:
-	HiddenUnderFog:
-	Burns:
-		Interval: 2
-	Tooltip:
-		Name: Destroyed Tower
-	ScriptTriggers:
-	HitShape:
-	EditorTilesetFilter:
-		Categories: Husk
-
 ^Infantry:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^GainsExperience

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -232,8 +232,6 @@
 		Type: light
 	HiddenUnderFog:
 		Type: CenterPosition
-	Tooltip:
-		Name: Wreck
 	ScriptTriggers:
 	WithFacingSpriteBody:
 	HitShape:

--- a/mods/d2k/rules/husks.yaml
+++ b/mods/d2k/rules/husks.yaml
@@ -3,19 +3,21 @@ mcv.husk:
 	Health:
 		HP: 175
 	Tooltip:
-		Name: Destroyed Mobile Construction Vehicle
+		Name: Mobile Construction Vehicle (Destroyed)
 
 harvester.husk:
 	Inherits: ^VehicleHusk
 	Health:
 		HP: 150
 	Tooltip:
-		Name: Destroyed Spice Harvester
+		Name: Spice Harvester (Destroyed)
 	TransformOnCapture:
 		IntoActor: harvester
 
 siege_tank.husk:
 	Inherits: ^VehicleHusk
+	Tooltip:
+		Name: Siege Tank (Destroyed)
 	ThrowsParticle@turret:
 		Anim: turret
 	TransformOnCapture:
@@ -23,11 +25,15 @@ siege_tank.husk:
 
 missile_tank.husk:
 	Inherits: ^VehicleHusk
+	Tooltip:
+		Name: Missile Tank (Destroyed)
 	TransformOnCapture:
 		IntoActor: missile_tank
 
 sonic_tank.husk:
 	Inherits: ^VehicleHusk
+	Tooltip:
+		Name: Sonic Tank (Destroyed)
 	TransformOnCapture:
 		IntoActor: sonic_tank
 
@@ -35,11 +41,15 @@ devastator.husk:
 	Inherits: ^VehicleHusk
 	Health:
 		HP: 125
+	Tooltip:
+		Name: Devastator (Destroyed)
 	TransformOnCapture:
 		IntoActor: devastator
 
 deviator.husk:
 	Inherits: ^VehicleHusk
+	Tooltip:
+		Name: Deviator (Destroyed)
 	TransformOnCapture:
 		IntoActor: deviator
 
@@ -47,6 +57,8 @@ deviator.husk:
 	Inherits: ^VehicleHusk
 	Health:
 		HP: 100
+	Tooltip:
+		Name: Combat Tank (Destroyed)
 	ThrowsParticle@turret:
 		Anim: turret
 


### PR DESCRIPTION
~~To match the naming in RA mod, also for incosistency with each other.~~

Also removes unused ^TowerHusk default. There were no Tower Husks in D2K mod even when i came, so i guess this is a leftover from even older times.