### PR TITLE
Tooltip fixes for the Parabombs

### DIFF
--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -330,6 +330,11 @@ V2RL:
 		Delay: 1
 		HealIfBelow: 40
 
+powerproxy.parabombs:
+	AirstrikePower:
+		LongDesc: A MiG bomber drops a load of parachuted bombs on your target.
+		CameraRemoveDelay: 50
+
 BADR.Bomber:
 	Health:
 		HP: 60

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -302,7 +302,7 @@ powerproxy.parabombs:
 	AirstrikePower:
 		Icon: parabombs
 		Description: Parabombs (Single Use)
-		LongDesc: Three Badgers drops a load of parachuted\nbombs on your target.
+		LongDesc: A Badger drops a load of parachuted bombs on your target.
 		OneShot: true
 		AllowMultiple: true
 		UnitType: badr.bomber
@@ -311,6 +311,7 @@ powerproxy.parabombs:
 		DisplayBeacon: True
 		BeaconPoster: pbmbicon
 		CameraActor: camera
+		CameraRemoveDelay: 150
 		ArrowSequence: arrow
 		ClockSequence: clock
 		CircleSequence: circles

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1274,12 +1274,14 @@ AFLD:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 130
-		Prerequisites: dome, ~structures.soviet, ~techlevel.medium
+		Prerequisites: dome, ~structures.soviet, ~techlevel.medium, ~!structures.ukraine
 		Description: Produces and reloads aircraft.\n  Special Ability: Spy Plane\n  Special Ability: Paratroopers
 	Valued:
 		Cost: 500
 	Tooltip:
 		Name: Airfield
+	Selectable:
+		Class: afld
 	Building:
 		Footprint: xxx xxx
 		Dimensions: 3,2
@@ -1366,7 +1368,7 @@ AFLD:
 		Icon: parabombs
 		ChargeTime: 300
 		Description: Parabombs
-		LongDesc: A squad of Badgers drops parachuted\nbombs on your target.
+		LongDesc: A squad of Badgers drop parachuted\nbombs on your target.
 		SelectTargetSpeechNotification: SelectTarget
 		CameraActor: camera
 		CameraRemoveDelay: 150
@@ -1398,6 +1400,14 @@ AFLD:
 		ZOffset: 256
 		RequiresCondition: primary
 	WithRearmAnimation:
+
+AFLD.Ukraine:
+	Inherits: AFLD
+	Buildable:
+		Prerequisites: dome, ~techlevel.medium, ~structures.ukraine
+		Description: Produces and reloads aircraft.\n  Special Ability: Spy Plane\n  Special Ability: Paratroopers\n  Special Ability: Parabombs
+	RenderSprites:
+		Image: afld
 
 POWR:
 	Inherits: ^Building


### PR DESCRIPTION
I noticed for the parabombs in Fort Lonestar, the Badger bomber was in the description instead of the MiG bomber. Also, a `CameraRemoveDelay` is added for that.

![1](https://user-images.githubusercontent.com/33390659/33221831-f772cbf8-d152-11e7-84b2-ec1fb2eaf276.png)
I removed the `\n` because there was no spacing between the title and the time behind it.

I reverted my previous change (Three Badgers instead of A Badger) because this turned out incorrect.

In the second commit I added in the description of the airfield the Parabomb special ability. I wanted to do that with a `Buildable@UKRAINE:` to have that description only for Ukraine. Sadly after various attempts, this didn't work and I get an exception log: `Exception of type System.InvalidOperationException: TypeDictionary contains multiple instances of type OpenRA.Mods.Common.Traits.BuildableInfo`
I changed it for now like this:
![2](https://user-images.githubusercontent.com/33390659/33222043-784f5dc6-d154-11e7-8d84-d790ee3fc6d6.png)
But this can be seen on any airfield. I would like to know the opinion of you guys if this is really wanted. If not, I could drop this commit.

A possible solution is to make a new AFLD.Ukraine, like how the British spy was made. But this is maybe a too big of a change for only the tooltip.