### PR TITLE
Disable the new build radius lobby option for minigames

### DIFF
--- a/mods/cnc/maps/the-hot-box/rules.yaml
+++ b/mods/cnc/maps/the-hot-box/rules.yaml
@@ -11,6 +11,8 @@ World:
 	MapBuildRadius:
 		AllyBuildRadiusLocked: True
 		AllyBuildRadiusEnabled: False
+		BuildRadiusLocked: True
+		BuildRadiusEnabled: True
 	MapOptions:
 		TechLevelLocked: True
 		TechLevel: unrestricted

--- a/mods/cnc/rules/campaign-maprules.yaml
+++ b/mods/cnc/rules/campaign-maprules.yaml
@@ -10,6 +10,8 @@ World:
 	MapBuildRadius:
 		AllyBuildRadiusLocked: True
 		AllyBuildRadiusEnabled: False
+		BuildRadiusLocked: True
+		BuildRadiusEnabled: True
 	MapOptions:
 		ShortGameLocked: True
 		ShortGameEnabled: False

--- a/mods/ra/maps/bomber-john/rules.yaml
+++ b/mods/ra/maps/bomber-john/rules.yaml
@@ -6,6 +6,8 @@ World:
 	MapBuildRadius:
 		AllyBuildRadiusLocked: True
 		AllyBuildRadiusEnabled: False
+		BuildRadiusLocked: True
+		BuildRadiusEnabled: True
 	MapOptions:
 		TechLevelLocked: True
 		TechLevel: unrestricted

--- a/mods/ra/maps/drop-zone-battle-of-tikiaki/rules.yaml
+++ b/mods/ra/maps/drop-zone-battle-of-tikiaki/rules.yaml
@@ -9,6 +9,8 @@ World:
 	MapBuildRadius:
 		AllyBuildRadiusLocked: True
 		AllyBuildRadiusEnabled: False
+		BuildRadiusLocked: True
+		BuildRadiusEnabled: True
 	MapOptions:
 		TechLevelLocked: True
 		TechLevel: unrestricted

--- a/mods/ra/maps/drop-zone-w/rules.yaml
+++ b/mods/ra/maps/drop-zone-w/rules.yaml
@@ -10,6 +10,8 @@ World:
 	MapBuildRadius:
 		AllyBuildRadiusLocked: True
 		AllyBuildRadiusEnabled: False
+		BuildRadiusLocked: True
+		BuildRadiusEnabled: True
 	MapOptions:
 		TechLevelLocked: True
 		TechLevel: unrestricted

--- a/mods/ra/maps/drop-zone/rules.yaml
+++ b/mods/ra/maps/drop-zone/rules.yaml
@@ -9,6 +9,8 @@ World:
 	MapBuildRadius:
 		AllyBuildRadiusLocked: True
 		AllyBuildRadiusEnabled: False
+		BuildRadiusLocked: True
+		BuildRadiusEnabled: True
 	MapOptions:
 		TechLevelLocked: True
 		TechLevel: unrestricted

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -31,6 +31,8 @@ World:
 	MapBuildRadius:
 		AllyBuildRadiusLocked: True
 		AllyBuildRadiusEnabled: True
+		BuildRadiusLocked: True
+		BuildRadiusEnabled: True
 	SpawnMPUnits:
 		Locked: True
 	MapOptions:

--- a/mods/ra/maps/training-camp/rules.yaml
+++ b/mods/ra/maps/training-camp/rules.yaml
@@ -5,6 +5,8 @@ World:
 	MapBuildRadius:
 		AllyBuildRadiusLocked: True
 		AllyBuildRadiusEnabled: False
+		BuildRadiusLocked: True
+		BuildRadiusEnabled: True
 	MapOptions:
 		TechLevelLocked: True
 		TechLevel: unrestricted

--- a/mods/ra/rules/campaign-rules.yaml
+++ b/mods/ra/rules/campaign-rules.yaml
@@ -22,6 +22,8 @@ World:
 	MapBuildRadius:
 		AllyBuildRadiusLocked: True
 		AllyBuildRadiusEnabled: False
+		BuildRadiusLocked: True
+		BuildRadiusEnabled: True
 	MapOptions:
 		TechLevelLocked: True
 		ShortGameLocked: True


### PR DESCRIPTION
Closes #14358.

One thing that was not clear for me is if we want to enforce this also in the campaign-rules. Currently the missions: Evacuation, Exodus and Infiltration can be played without a build radius.