### PR TITLE
Ignore empty children when aggregating EventBounds.

### DIFF
--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -284,8 +284,15 @@ namespace OpenRA.Widgets
 			// PERF: Avoid LINQ.
 			var bounds = EventBounds;
 			foreach (var child in Children)
+			{
 				if (child.IsVisible())
-					bounds = Rectangle.Union(bounds, child.GetEventBounds());
+				{
+					var childBounds = child.GetEventBounds();
+					if (childBounds != Rectangle.Empty)
+						bounds = Rectangle.Union(bounds, childBounds);
+				}
+			}
+
 			return bounds;
 		}
 


### PR DESCRIPTION
This PR fixes cases where the parent widget's EventBounds are expanded to include the origin, which breaks tooltips and other mouseover events unless all parent widgets are ClickThrough or ignore events.  This hasn't been an issue for our default mods, but breaks at least one third party mod that uses custom UI (Medieval Warfare).

Testcase:
1. Clone and compile https://github.com/CombinE88/Medieval-Warfare
2. Start a skirmish and notice that the world tooltips (unit mouseover, "Unrevealed Terrain", etc) do not work at the start of the game.
3. Update mod.config to set `ENGINE_VERSION="fix-eventbound-aggregation-testcase"` and `AUTOMATIC_ENGINE_SOURCE="https://github.com/pchote/OpenRA/archive/${ENGINE_VERSION}.zip"` and then recompile.
4. Start a skirmish and notice that world tooltips now work correctly.