### PR TITLE
Rocket Launcher turret twitching fix

### DIFF
--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -452,7 +452,7 @@ MSAM:
 		BuildPaletteOrder: 50
 		Prerequisites: anyhq, ~techlevel.medium
 		Queue: Vehicle.GDI
-		Description: Long range rocket artillery.\n  Strong vs all Ground units.
+		Description: Long-range rocket artillery.\n  Strong vs all Ground units
 	Mobile:
 		Speed: 85
 		TurnSpeed: 4
@@ -468,12 +468,21 @@ MSAM:
 	Armament@PRIMARY:
 		Weapon: 227mm
 		LocalOffset: 213,128,0, 213,-128,0
+		PauseOnCondition: !ammo
 	Armament@SECONDARY:
 		Weapon: 227mm
 		LocalOffset: 213,-128,0, 213,128,0
+		PauseOnCondition: !ammo
+	AmmoPool:
+		Ammo: 8
+		PipCount: 0
+		AmmoCondition: ammo
+	ReloadAmmoPool:
+		Delay: 100
+		Count: 8
 	AttackFrontal:
-	WithSpriteTurret:
-		AimSequence: aim
+	WithReloadingSpriteTurret:
+		AmmoPoolName: primary
 	SpawnActorOnDeath:
 		Actor: MSAM.Husk
 

--- a/mods/cnc/sequences/vehicles.yaml
+++ b/mods/cnc/sequences/vehicles.yaml
@@ -226,12 +226,24 @@ msam:
 		Start: 32
 		Facings: 32
 		UseClassicFacingFudge: True
-	empty-aim:
+	turret8:
+		Start: 32
+		Facings: 32
+		UseClassicFacingFudge: True
+	turret6:
 		Start: 64
 		Facings: 32
 		UseClassicFacingFudge: True
-	aim:
+	turret4:
 		Start: 64
+		Facings: 32
+		UseClassicFacingFudge: True
+	turret2:
+		Start: 64
+		Facings: 32
+		UseClassicFacingFudge: True
+	turret0:
+		Start: 32
 		Facings: 32
 		UseClassicFacingFudge: True
 	icon: msamicnh.tem

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -138,7 +138,7 @@ MammothMissiles:
 
 227mm:
 	Inherits: ^MissileWeapon
-	ReloadDelay: 100
+	ReloadDelay: 0
 	Range: 11c0
 	MinRange: 3c0
 	Burst: 4


### PR DESCRIPTION
Requested in #5204. This is a possible solution for that bug.

The turret twitching is gone by using the same setup like the mobile SAM. There is one change in the behavior, the rocket launcher doesn't keep the turret up when it is aiming. The turret is down when there is no ammo. It is only up when it is launching the rockets.

Closes #5204.