### PR TITLE
Fix "Aim" sequences glitching when an AttackFrontal unit is turning

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Render/WithReloadingSpriteTurret.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithReloadingSpriteTurret.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		protected override void Tick(Actor self)
 		{
 			if (Info.AimSequence != null)
-				sequence = Attack.IsAttacking ? Info.AimSequence : Info.Sequence;
+				sequence = Attack.IsAiming ? Info.AimSequence : Info.Sequence;
 
 			var currentAmmo = ammoPool.GetAmmoCount();
 			if (reloadStages < 0)

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Activities
 			foreach (var attack in attackTraits.Where(x => !x.IsTraitDisabled))
 			{
 				var status = TickAttack(self, attack);
-				attack.IsAttacking = status == AttackStatus.Attacking || status == AttackStatus.NeedsToTurn;
+				attack.IsAiming = status == AttackStatus.Attacking || status == AttackStatus.NeedsToTurn;
 			}
 
 			if (attackStatus.HasFlag(AttackStatus.Attacking))

--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -208,7 +208,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			// While the head is travelling, the tail must start to follow Duration ticks later.
 			// Alternatively, also stop emitting the beam if source actor dies or is ordered to stop.
 			if ((headTicks >= info.Duration && !isTailTravelling) || args.SourceActor.IsDead ||
-				!actorAttackBase.IsAttacking || outOfWeaponRange)
+				!actorAttackBase.IsAiming || outOfWeaponRange)
 				StopTargeting();
 
 			if (isTailTravelling)

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly string attackOrderName = "Attack";
 		readonly string forceAttackOrderName = "ForceAttack";
 
-		[Sync] public bool IsAttacking { get; internal set; }
+		[Sync] public bool IsAiming { get; internal set; }
 		public IEnumerable<Armament> Armaments { get { return getArmaments(); } }
 
 		protected IFacing facing;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			DoAttack(self, Target);
-			IsAttacking = Target.IsValidFor(self);
+			IsAiming = Target.IsValidFor(self);
 		}
 
 		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack)

--- a/OpenRA.Mods.Common/Traits/Render/WithAttackAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAttackAnimation.cs
@@ -110,7 +110,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				return;
 
 			var sequence = wsb.Info.Sequence;
-			if (!string.IsNullOrEmpty(Info.AimSequence) && attack.IsAttacking)
+			if (!string.IsNullOrEmpty(Info.AimSequence) && attack.IsAiming)
 				sequence = Info.AimSequence;
 
 			var prefix = (armament.IsReloading && !string.IsNullOrEmpty(Info.ReloadPrefix)) ? Info.ReloadPrefix : "";

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -124,7 +124,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (Info.AimSequence == null)
 				return;
 
-			var sequence = Attack.IsAttacking ? Info.AimSequence : Info.Sequence;
+			var sequence = Attack.IsAiming ? Info.AimSequence : Info.Sequence;
 			DefaultAnimation.ReplaceAnim(sequence);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithTurretAttackAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurretAttackAnimation.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				return;
 
 			var sequence = wst.Info.Sequence;
-			if (!string.IsNullOrEmpty(info.AimSequence) && attack.IsAttacking)
+			if (!string.IsNullOrEmpty(info.AimSequence) && attack.IsAiming)
 				sequence = info.AimSequence;
 
 			var prefix = (armament.IsReloading && !string.IsNullOrEmpty(info.ReloadPrefix)) ? info.ReloadPrefix : "";

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (attack != null)
 			{
 				// Only realign while not attacking anything
-				if (attack.IsAttacking)
+				if (attack.IsAiming)
 					return;
 
 				if (realignTick < Info.RealignDelay)


### PR DESCRIPTION
This PR renames `IsAttacking` to `IsAiming` and then defines "turning to face target" as part of the aiming process.  Fixes #5204.

Testcase: Build a Rocket Launcher and force-target it at a humvee or other fast unit that is ordered to drive in circles around it (hint: pause the game to queue the attack and move orders).