### PR TITLE
Fix NRE when ProvidesPrerequisite is defined on the player actor.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
@@ -63,7 +63,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override void Created(Actor self)
 		{
-			techTree = self.Owner.PlayerActor.Trait<TechTree>();
+			// Special case handling is required for the Player actor.
+			// Created is called before Player.PlayerActor is assigned,
+			// so we must query other player traits from self, knowing that
+			// it refers to the same actor as self.Owner.PlayerActor
+			var playerActor = self.Info.Name == "player" ? self : self.Owner.PlayerActor;
+
+			techTree = playerActor.Trait<TechTree>();
 
 			Update();
 


### PR DESCRIPTION
Fix for #14426.

Testcase: Move the `ProvidesPrerequisite` definitions added in #14426 from `player_prerequisite` to `Player` in the map rules.  Before: crashes on map start.  After: doesn't crash.