### PR TITLE
D2K: Fix refinery smoke anim, hi-tec factory offset and tile 401 terrain type

### DIFF
--- a/mods/d2k/sequences/structures.yaml
+++ b/mods/d2k/sequences/structures.yaml
@@ -394,8 +394,8 @@ refinery.atreides:
 	smoke: DATA.R8
 		Start: 4138
 		Length: 14
-		Offset: 10,-16
-		Tick: 200
+		Offset: 13,-16
+		Tick: 100
 		BlendMode: Additive
 
 silo.atreides:
@@ -904,8 +904,8 @@ refinery.harkonnen:
 	smoke: DATA.R8
 		Start: 4138
 		Length: 14
-		Offset: 10,-16
-		Tick: 200
+		Offset: 13,-16
+		Tick: 100
 		BlendMode: Additive
 
 silo.harkonnen:
@@ -1307,8 +1307,8 @@ refinery.ordos:
 	smoke: DATA.R8
 		Start: 4138
 		Length: 14
-		Offset: 10,-16
-		Tick: 200
+		Offset: 13,-16
+		Tick: 100
 		BlendMode: Additive
 
 silo.ordos:

--- a/mods/d2k/sequences/structures.yaml
+++ b/mods/d2k/sequences/structures.yaml
@@ -427,7 +427,7 @@ silo.atreides:
 
 hightech.atreides:
 	Defaults:
-		Offset: -48,84
+		Offset: -48,80
 	idle: DATA.R8
 		Start: 2812
 	make: DATA.R8
@@ -937,7 +937,7 @@ silo.harkonnen:
 
 hightech.harkonnen:
 	Defaults:
-		Offset: -48,84
+		Offset: -48,80
 	idle: DATA.R8
 		Start: 2972
 	make: DATA.R8
@@ -1340,7 +1340,7 @@ silo.ordos:
 
 hightech.ordos:
 	Defaults:
-		Offset: -48,84
+		Offset: -48,80
 	idle: DATA.R8
 		Start: 3132
 	make: DATA.R8

--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -3439,12 +3439,12 @@ Templates:
 		Size: 2,3
 		Categories: Rock-Detail
 		Tiles:
-			0: Sand
-			1: Sand
-			2: Sand
-			3: Sand
-			4: Sand
-			5: Sand
+			0: Rough
+			1: Rough
+			2: Rough
+			3: Rough
+			4: Rough
+			5: Rough
 	Template@402:
 		Id: 402
 		Images: BLOXICE.R8


### PR DESCRIPTION
The refinery overlay played too slowly and was positioned a few pixels too far to the left compared to the original.

Tile 401 is "infantry-only rocks" on rock terrain and should therefore be "Rough" terrain, yet had "Sand"(!) on bleed. This affected Harkonnen mission 5 for example (north-east of starting position).

Fixes are simple and obvious enough to make this a playtest blocker.