### PR TITLE
D2K - Allow all upgradable structures to build upgrades

### DIFF
--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -506,21 +506,6 @@ Container@PLAYER_WIDGETS:
 									X: 5
 									Y: 5
 									ImageCollection: production-icons
-						ProductionTypeButton@UPGRADE:
-							Y: 31
-							Width: 25
-							Height: 25
-							VisualHeight: 0
-							Background: sidebar-button
-							TooltipText: Upgrades
-							TooltipContainer: TOOLTIP_CONTAINER
-							ProductionGroup: Upgrade
-							Key: ProductionTypeUpgrade
-							Children:
-								Image@ICON:
-									X: 5
-									Y: 5
-									ImageCollection: production-icons
 						ProductionTypeButton@INFANTRY:
 							Y: 62
 							Width: 25
@@ -591,6 +576,21 @@ Container@PLAYER_WIDGETS:
 							TooltipContainer: TOOLTIP_CONTAINER
 							ProductionGroup: Starport
 							Key: ProductionTypeMerchant
+							Children:
+								Image@ICON:
+									X: 5
+									Y: 5
+									ImageCollection: production-icons
+						ProductionTypeButton@UPGRADE: # Upgrade is defined after others so it won't be automatically selected after sell or at game start.
+							Y: 31
+							Width: 25
+							Height: 25
+							VisualHeight: 0
+							Background: sidebar-button
+							TooltipText: Upgrades
+							TooltipContainer: TOOLTIP_CONTAINER
+							ProductionGroup: Upgrade
+							Key: ProductionTypeUpgrade
 							Children:
 								Image@ICON:
 									X: 5

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -9,14 +9,6 @@ Player:
 		ReadyAudio: BuildingReady
 		BlockedAudio: NoRoom
 		SpeedUp: true
-	ClassicProductionQueue@Upgrade:
-		Type: Upgrade
-		BuildDurationModifier: 250
-		LowPowerSlowdown: 0
-		QueuedAudio: Upgrading
-		ReadyAudio: NewOptions
-		BlockedAudio: NoRoom
-		SpeedUp: true
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
 		BuildDurationModifier: 250
@@ -49,6 +41,14 @@ Player:
 		BuildDurationModifier: 312
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
+		BlockedAudio: NoRoom
+		SpeedUp: true
+	ClassicProductionQueue@Upgrade: # Upgrade is defined after others so it won't be automatically selected by ProductionQueueFromSelection.
+		Type: Upgrade
+		BuildDurationModifier: 250
+		LowPowerSlowdown: 0
+		QueuedAudio: Upgrading
+		ReadyAudio: NewOptions
 		BlockedAudio: NoRoom
 		SpeedUp: true
 	PlaceBuilding:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -204,7 +204,7 @@ barracks:
 		SpawnOffset: 512,480,0
 		ExitCell: 1,2
 	Production:
-		Produces: Infantry
+		Produces: Infantry, Upgrade
 	PrimaryBuilding:
 		PrimaryCondition: primary
 	ProductionBar:
@@ -403,7 +403,7 @@ light_factory:
 		SpawnOffset: 544,-224,0
 		ExitCell: 2,1
 	Production:
-		Produces: Vehicle
+		Produces: Vehicle, Upgrade
 	PrimaryBuilding:
 		PrimaryCondition: primary
 	ProductionBar:
@@ -484,7 +484,7 @@ heavy_factory:
 		SpawnOffset: 256,192,0
 		ExitCell: 0,2
 	Production:
-		Produces: Armor
+		Produces: Armor, Upgrade
 	PrimaryBuilding:
 		PrimaryCondition: primary
 	ProductionBar:
@@ -879,7 +879,7 @@ high_tech_factory:
 	Tooltip:
 		Name: High Tech Factory
 	ProductionFromMapEdge:
-		Produces: Aircraft
+		Produces: Aircraft, Upgrade
 	Exit:
 		SpawnOffset: 0,0,728
 		ExitCell: 0,0


### PR DESCRIPTION
Fixes #12665. This doesn't cause upgrade tab to appear first when you deploy an MCV at the beginning of the game. (unlike moving it to Player: actor) But MCVless missions like Atr5 and Har9b show upgrades first, which i don't think much of a problem