### PR TITLE
Rework mod launchers to address issues with icons on Windows

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -249,7 +249,14 @@ namespace OpenRA
 			Settings = new Settings(Platform.ResolvePath(Path.Combine("^", "settings.yaml")), args);
 		}
 
-		internal static void Initialize(Arguments args)
+		public static RunStatus InitializeAndRun(string[] args)
+		{
+			Initialize(new Arguments(args));
+			GC.Collect();
+			return Run();
+		}
+
+		static void Initialize(Arguments args)
 		{
 			Console.WriteLine("Platform is {0}", Platform.CurrentPlatform);
 
@@ -790,7 +797,7 @@ namespace OpenRA
 			}
 		}
 
-		internal static RunStatus Run()
+		static RunStatus Run()
 		{
 			if (Settings.Graphics.MaxFramerate < 1)
 			{

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -176,6 +176,7 @@
     <Compile Include="Server\ServerOrder.cs" />
     <Compile Include="Server\TraitInterfaces.cs" />
     <Compile Include="Support\Arguments.cs" />
+    <Compile Include="Support\ExceptionHandler.cs" />
     <Compile Include="Support\LaunchArguments.cs" />
     <Compile Include="Support\PerfHistory.cs" />
     <Compile Include="Support\Program.cs" />

--- a/OpenRA.Game/Support/ExceptionHandler.cs
+++ b/OpenRA.Game/Support/ExceptionHandler.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+
+namespace OpenRA
+{
+	public static class ExceptionHandler
+	{
+		public static void HandleFatalError(Exception ex)
+		{
+			var exceptionName = "exception-" + DateTime.UtcNow.ToString("yyyy-MM-ddTHHmmssZ", CultureInfo.InvariantCulture) + ".log";
+			Log.AddChannel("exception", exceptionName);
+
+			if (Game.EngineVersion != null)
+				Log.Write("exception", "OpenRA engine version {0}", Game.EngineVersion);
+
+			if (Game.ModData != null)
+			{
+				var mod = Game.ModData.Manifest.Metadata;
+				Log.Write("exception", "{0} mod version {1}", mod.Title, mod.Version);
+			}
+
+			if (Game.OrderManager != null && Game.OrderManager.World != null && Game.OrderManager.World.Map != null)
+			{
+				var map = Game.OrderManager.World.Map;
+				Log.Write("exception", "on map {0} ({1} by {2}).", map.Uid, map.Title, map.Author);
+			}
+
+			Log.Write("exception", "Date: {0:u}", DateTime.UtcNow);
+			Log.Write("exception", "Operating System: {0} ({1})", Platform.CurrentPlatform, Environment.OSVersion);
+			Log.Write("exception", "Runtime Version: {0}", Platform.RuntimeVersion);
+			var rpt = BuildExceptionReport(ex).ToString();
+			Log.Write("exception", "{0}", rpt);
+			Console.Error.WriteLine(rpt);
+		}
+
+		static StringBuilder BuildExceptionReport(Exception ex)
+		{
+			return BuildExceptionReport(ex, new StringBuilder(), 0);
+		}
+
+		static StringBuilder AppendIndentedFormatLine(this StringBuilder sb, int indent, string format, params object[] args)
+		{
+			return sb.Append(new string(' ', indent * 2)).AppendFormat(format, args).AppendLine();
+		}
+
+		static StringBuilder BuildExceptionReport(Exception ex, StringBuilder sb, int indent)
+		{
+			if (ex == null)
+				return sb;
+
+			sb.AppendIndentedFormatLine(indent, "Exception of type `{0}`: {1}", ex.GetType().FullName, ex.Message);
+
+			var tle = ex as TypeLoadException;
+			var oom = ex as OutOfMemoryException;
+			if (tle != null)
+			{
+				sb.AppendIndentedFormatLine(indent, "TypeName=`{0}`", tle.TypeName);
+			}
+			else if (oom != null)
+			{
+				var gcMemoryBeforeCollect = GC.GetTotalMemory(false);
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+				GC.Collect();
+				sb.AppendIndentedFormatLine(indent, "GC Memory (post-collect)={0:N0}", GC.GetTotalMemory(false));
+				sb.AppendIndentedFormatLine(indent, "GC Memory (pre-collect)={0:N0}", gcMemoryBeforeCollect);
+
+				using (var p = Process.GetCurrentProcess())
+				{
+					sb.AppendIndentedFormatLine(indent, "Working Set={0:N0}", p.WorkingSet64);
+					sb.AppendIndentedFormatLine(indent, "Private Memory={0:N0}", p.PrivateMemorySize64);
+					sb.AppendIndentedFormatLine(indent, "Virtual Memory={0:N0}", p.VirtualMemorySize64);
+				}
+			}
+			else
+			{
+				// TODO: more exception types
+			}
+
+			if (ex.InnerException != null)
+			{
+				sb.AppendIndentedFormatLine(indent, "Inner");
+				BuildExceptionReport(ex.InnerException, sb, indent + 1);
+			}
+
+			sb.AppendIndentedFormatLine(indent, "{0}", ex.StackTrace);
+
+			return sb;
+		}
+	}
+}

--- a/OpenRA.Game/Support/Program.cs
+++ b/OpenRA.Game/Support/Program.cs
@@ -11,10 +11,7 @@
 
 using System;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 
 namespace OpenRA
 {
@@ -31,109 +28,19 @@ namespace OpenRA
 		static int Main(string[] args)
 		{
 			if (Debugger.IsAttached || args.Contains("--just-die"))
-				return (int)Run(args);
+				return (int)Game.InitializeAndRun(args);
 
-			AppDomain.CurrentDomain.UnhandledException += (_, e) => FatalError((Exception)e.ExceptionObject);
+			AppDomain.CurrentDomain.UnhandledException += (_, e) => ExceptionHandler.HandleFatalError((Exception)e.ExceptionObject);
 
 			try
 			{
-				return (int)Run(args);
+				return (int)Game.InitializeAndRun(args);
 			}
 			catch (Exception e)
 			{
-				FatalError(e);
+				ExceptionHandler.HandleFatalError(e);
 				return (int)RunStatus.Error;
 			}
-		}
-
-		static void FatalError(Exception ex)
-		{
-			var exceptionName = "exception-" + DateTime.UtcNow.ToString("yyyy-MM-ddTHHmmssZ", CultureInfo.InvariantCulture) + ".log";
-			Log.AddChannel("exception", exceptionName);
-
-			if (Game.EngineVersion != null)
-				Log.Write("exception", "OpenRA engine version {0}", Game.EngineVersion);
-
-			if (Game.ModData != null)
-			{
-				var mod = Game.ModData.Manifest.Metadata;
-				Log.Write("exception", "{0} mod version {1}", mod.Title, mod.Version);
-			}
-
-			if (Game.OrderManager != null && Game.OrderManager.World != null && Game.OrderManager.World.Map != null)
-			{
-				var map = Game.OrderManager.World.Map;
-				Log.Write("exception", "on map {0} ({1} by {2}).", map.Uid, map.Title, map.Author);
-			}
-
-			Log.Write("exception", "Date: {0:u}", DateTime.UtcNow);
-			Log.Write("exception", "Operating System: {0} ({1})", Platform.CurrentPlatform, Environment.OSVersion);
-			Log.Write("exception", "Runtime Version: {0}", Platform.RuntimeVersion);
-			var rpt = BuildExceptionReport(ex).ToString();
-			Log.Write("exception", "{0}", rpt);
-			Console.Error.WriteLine(rpt);
-		}
-
-		static StringBuilder BuildExceptionReport(Exception ex)
-		{
-			return BuildExceptionReport(ex, new StringBuilder(), 0);
-		}
-
-		static StringBuilder AppendIndentedFormatLine(this StringBuilder sb, int indent, string format, params object[] args)
-		{
-			return sb.Append(new string(' ', indent * 2)).AppendFormat(format, args).AppendLine();
-		}
-
-		static StringBuilder BuildExceptionReport(Exception ex, StringBuilder sb, int indent)
-		{
-			if (ex == null)
-				return sb;
-
-			sb.AppendIndentedFormatLine(indent, "Exception of type `{0}`: {1}", ex.GetType().FullName, ex.Message);
-
-			var tle = ex as TypeLoadException;
-			var oom = ex as OutOfMemoryException;
-			if (tle != null)
-			{
-				sb.AppendIndentedFormatLine(indent, "TypeName=`{0}`", tle.TypeName);
-			}
-			else if (oom != null)
-			{
-				var gcMemoryBeforeCollect = GC.GetTotalMemory(false);
-				GC.Collect();
-				GC.WaitForPendingFinalizers();
-				GC.Collect();
-				sb.AppendIndentedFormatLine(indent, "GC Memory (post-collect)={0:N0}", GC.GetTotalMemory(false));
-				sb.AppendIndentedFormatLine(indent, "GC Memory (pre-collect)={0:N0}", gcMemoryBeforeCollect);
-
-				using (var p = Process.GetCurrentProcess())
-				{
-					sb.AppendIndentedFormatLine(indent, "Working Set={0:N0}", p.WorkingSet64);
-					sb.AppendIndentedFormatLine(indent, "Private Memory={0:N0}", p.PrivateMemorySize64);
-					sb.AppendIndentedFormatLine(indent, "Virtual Memory={0:N0}", p.VirtualMemorySize64);
-				}
-			}
-			else
-			{
-				// TODO: more exception types
-			}
-
-			if (ex.InnerException != null)
-			{
-				sb.AppendIndentedFormatLine(indent, "Inner");
-				BuildExceptionReport(ex.InnerException, sb, indent + 1);
-			}
-
-			sb.AppendIndentedFormatLine(indent, "{0}", ex.StackTrace);
-
-			return sb;
-		}
-
-		static RunStatus Run(string[] args)
-		{
-			Game.Initialize(new Arguments(args));
-			GC.Collect();
-			return Game.Run();
 		}
 	}
 }

--- a/packaging/windows/WindowsLauncher.cs.in
+++ b/packaging/windows/WindowsLauncher.cs.in
@@ -16,41 +16,12 @@ using System.IO;
 using System.Linq;
 using System.Media;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
 namespace OpenRA
 {
 	class WindowsLauncher
 	{
-		[DllImport("user32.dll")]
-		static extern int SendMessage(IntPtr hwnd, uint message, uint wParam, IntPtr lParam);
-
-		[DllImport("shell32.dll")]
-		static extern IntPtr SHGetFileInfo(string pszPath, uint dwFileAttributes, ref SHFILEINFO psfi, uint cbSizeFileInfo, uint uFlags);
-
-		[DllImport("user32.dll")]
-		public extern static bool DestroyIcon(IntPtr handle);
-
-		struct SHFILEINFO
-		{
-			// Native type: HICON
-			public IntPtr hIcon;
-
-			public int iIcon;
-			public uint dwAttributes;
-
-			// Native type: TCHAR[MAX_PATH]
-			[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
-
-			public string szDisplayName;
-
-			// Native type: TCHAR[80]
-			[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 80)]
-
-			public string szTypeName;
-		}
-
 		static Process gameProcess;
 
 		// Constants to be replaced by the wrapper / compilation script
@@ -58,26 +29,44 @@ namespace OpenRA
 		const string DisplayName = "DISPLAY_NAME";
 		const string FaqUrl = "FAQ_URL";
 
-		// References to the OpenRA.Game.exe icons for later cleanup
-		static IntPtr[] iconHandle = { IntPtr.Zero, IntPtr.Zero };
-
 		[STAThread]
-		static void Main(string[] args)
+		static int Main(string[] args)
+		{
+			if (args.Any(x => x.Contains("Engine.LaunchPath")))
+				return RunGame(args);
+
+			return RunInnerLauncher();
+		}
+
+		static int RunGame(string[] args)
 		{
 			var launcherPath = Assembly.GetExecutingAssembly().Location;
 			var directory = Path.GetDirectoryName(launcherPath);
-			var enginePath = Path.Combine(directory, "OpenRA.Game.exe");
-
 			Directory.SetCurrentDirectory(directory);
+			
+			AppDomain.CurrentDomain.UnhandledException += (_, e) => ExceptionHandler.HandleFatalError((Exception)e.ExceptionObject);
 
+			try
+			{
+				return (int)Game.InitializeAndRun(args);
+			}
+			catch (Exception e)
+			{
+				ExceptionHandler.HandleFatalError(e);
+				return (int)RunStatus.Error;
+			}
+		}
+
+		static int RunInnerLauncher()
+		{
+			var launcherPath = Assembly.GetExecutingAssembly().Location;
+			var args = new[] { "Engine.LaunchPath=" + launcherPath };
 			if (!string.IsNullOrEmpty(ModID))
 				args = args.Append("Game.Mod=" + ModID).ToArray();
 
-			var engineArgs = args
-				.Append("Engine.LaunchPath=" + launcherPath)
-				.Select(arg => "\"" + arg + "\"");
+			args = args.Select(arg => "\"" + arg + "\"").ToArray();
 
-			var psi = new ProcessStartInfo(enginePath, string.Join(" ", engineArgs));
+			var psi = new ProcessStartInfo(launcherPath, string.Join(" ", args));
 
 			try
 			{
@@ -85,31 +74,18 @@ namespace OpenRA
 			}
 			catch
 			{
-				return;
+				return 1;
 			}
 
 			if (gameProcess == null)
-				return;
-
-			if (Platform.CurrentPlatform == PlatformType.Windows)
-			{
-				// Set the OpenRA.Game.exe icon to match the mod
-				// Icon.ExtractAssociatedIcon sets only the 32px icon,
-				// so we use native functions to set both 16 and 32px versions.
-				gameProcess.WaitForInputIdle();
-				SHFILEINFO sfi = new SHFILEINFO();
-				for (var i = 0; i < 2; i++)
-				{
-					SHGetFileInfo(Assembly.GetExecutingAssembly().Location, 0, ref sfi, (uint)Marshal.SizeOf(typeof(SHFILEINFO)), (uint)(0x100 + i));
-					iconHandle[i] = sfi.hIcon;
-					SendMessage(gameProcess.MainWindowHandle, 0x80, (uint)(1 - i), sfi.hIcon);
-				}
-			}
+				return 1;
 
 			gameProcess.EnableRaisingEvents = true;
 			gameProcess.Exited += GameProcessExited;
 
 			Application.Run();
+
+			return 0;
 		}
 
 		static void ShowErrorDialog()
@@ -192,11 +168,6 @@ namespace OpenRA
 		{
 			if (gameProcess.ExitCode != (int)RunStatus.Success)
 				ShowErrorDialog();
-
-			if (Platform.CurrentPlatform == PlatformType.Windows)
-				foreach (var handle in iconHandle)
-					if (handle != IntPtr.Zero)
-						DestroyIcon(handle);
 
 			Exit();
 		}


### PR DESCRIPTION
Until now the mod-specific launchers (with a specific name and icon) launched the mod-agnostic `OpenRA.Game.exe` and told it to pretend like it cares what mod it's running. That resulted in some issues with icons at least on Windows.

This changes the launchers to run the game loop directly, so instead of the launcher launching `OpenRA.Game.exe`, it now launches a child process of the same launcher, but in a different state, which runs the game loop. The point of having a parent and child processes is to maintain error handling if the child blows up.

Unfortunately not straight-forward to test on Windows, and apparently creating the launchers doesn't happen on Windows, so will need someone who can create those to provide reviewers with samples.

Fixes #14174.