### PR TITLE
Avoid array resizing in OpenAlAsyncLoadSound.

### DIFF
--- a/OpenRA.Game/Primitives/ReadOnlyAdapterStream.cs
+++ b/OpenRA.Game/Primitives/ReadOnlyAdapterStream.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Primitives
 		public sealed override bool CanRead { get { return true; } }
 		public sealed override bool CanWrite { get { return false; } }
 
-		public sealed override long Length { get { throw new NotSupportedException(); } }
+		public override long Length { get { throw new NotSupportedException(); } }
 		public sealed override long Position
 		{
 			get { throw new NotSupportedException(); }

--- a/OpenRA.Mods.Common/FileFormats/AudReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/AudReader.cs
@@ -170,6 +170,11 @@ namespace OpenRA.Mods.Common.FileFormats
 				this.dataSize = dataSize;
 			}
 
+			public override long Length
+			{
+				get { return outputSize; }
+			}
+
 			protected override bool BufferData(Stream baseStream, Queue<byte> data)
 			{
 				if (dataSize <= 0)


### PR DESCRIPTION
- Where it is accessible, use the length of the stream to presize the MemoryStream to the correct size.
- Instead of copying out the result via ToArray, grab the underlying buffer via GetBuffer and use that to create the sound source.

This avoids extraneous copying of the array containing the audio.

Helps with #12494 by allocating less when music tracks switch, reducing peak memory.