### PR TITLE
OccupiedCells and TargetableCells must return arrays, not just enumerables.

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -203,7 +203,7 @@ namespace OpenRA.Traits
 	{
 		WPos CenterPosition { get; }
 		CPos TopLeft { get; }
-		IEnumerable<Pair<CPos, SubCell>> OccupiedCells();
+		Pair<CPos, SubCell>[] OccupiedCells();
 	}
 
 	public static class IOccupySpaceExts

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -136,7 +136,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			get { return Util.ApplyPercentageModifiers(Info.Speed, speedModifiers); }
 		}
 
-		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells() { return new[] { Pair.New(TopLeft, SubCell.FullCell) }; }
+		public Pair<CPos, SubCell>[] OccupiedCells() { return new[] { Pair.New(TopLeft, SubCell.FullCell) }; }
 
 		WVec MoveStep(int facing)
 		{

--- a/OpenRA.Mods.Common/ShroudExts.cs
+++ b/OpenRA.Mods.Common/ShroudExts.cs
@@ -15,11 +15,9 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common
 {
-	using OccupiedCells = IEnumerable<Pair<CPos, SubCell>>;
-
 	public static class ShroudExts
 	{
-		public static bool AnyExplored(this Shroud shroud, OccupiedCells cells)
+		public static bool AnyExplored(this Shroud shroud, Pair<CPos, SubCell>[] cells)
 		{
 			// PERF: Avoid LINQ.
 			foreach (var cell in cells)
@@ -29,7 +27,7 @@ namespace OpenRA.Mods.Common
 			return false;
 		}
 
-		public static bool AnyVisible(this Shroud shroud, OccupiedCells cells)
+		public static bool AnyVisible(this Shroud shroud, Pair<CPos, SubCell>[] cells)
 		{
 			// PERF: Avoid LINQ.
 			foreach (var cell in cells)

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -460,7 +460,7 @@ namespace OpenRA.Mods.Common.Traits
 			get { return Util.ApplyPercentageModifiers(Info.Speed, speedModifiers); }
 		}
 
-		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells() { return NoCells; }
+		public Pair<CPos, SubCell>[] OccupiedCells() { return NoCells; }
 
 		public WVec FlyStep(int facing)
 		{

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -291,9 +291,9 @@ namespace OpenRA.Mods.Common.Traits
 			SkipMakeAnimation = init.Contains<SkipMakeAnimsInit>();
 		}
 
-		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells() { return occupiedCells; }
+		public Pair<CPos, SubCell>[] OccupiedCells() { return occupiedCells; }
 
-		IEnumerable<Pair<CPos, SubCell>> ITargetableCells.TargetableCells() { return targetableCells; }
+		Pair<CPos, SubCell>[] ITargetableCells.TargetableCells() { return targetableCells; }
 
 		void INotifyCreated.Created(Actor self)
 		{

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -160,7 +160,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		public CPos TopLeft { get { return Location; } }
-		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells() { return new[] { Pair.New(Location, SubCell.FullCell) }; }
+		public Pair<CPos, SubCell>[] OccupiedCells() { return new[] { Pair.New(Location, SubCell.FullCell) }; }
 
 		public WPos CenterPosition { get; private set; }
 

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 				self.QueueActivity(new Drag(self, CenterPosition, finalPosition, distance / dragSpeed));
 		}
 
-		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells() { return new[] { Pair.New(TopLeft, SubCell.FullCell) }; }
+		public Pair<CPos, SubCell>[] OccupiedCells() { return new[] { Pair.New(TopLeft, SubCell.FullCell) }; }
 		public bool IsLeavingCell(CPos location, SubCell subCell = SubCell.Any) { return false; }
 		public SubCell GetValidSubCell(SubCell preferred = SubCell.Any) { return SubCell.FullCell; }
 		public SubCell GetAvailableSubCell(CPos cell, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, bool checkTransientActors = true)

--- a/OpenRA.Mods.Common/Traits/Immobile.cs
+++ b/OpenRA.Mods.Common/Traits/Immobile.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[Sync] readonly CPos location;
 		[Sync] readonly WPos position;
-		readonly IEnumerable<Pair<CPos, SubCell>> occupied;
+		readonly Pair<CPos, SubCell>[] occupied;
 
 		public Immobile(ActorInitializer init, ImmobileInfo info)
 		{
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public CPos TopLeft { get { return location; } }
 		public WPos CenterPosition { get { return position; } }
-		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells() { return occupied; }
+		public Pair<CPos, SubCell>[] OccupiedCells() { return occupied; }
 
 		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -665,7 +665,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public CPos TopLeft { get { return ToCell; } }
 
-		public IEnumerable<Pair<CPos, SubCell>> OccupiedCells()
+		public Pair<CPos, SubCell>[] OccupiedCells()
 		{
 			if (FromCell == ToCell)
 				return new[] { Pair.New(FromCell, FromSubCell) };

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -383,7 +383,7 @@ namespace OpenRA.Mods.Common.Traits
 	[RequireExplicitImplementation]
 	public interface ITargetableCells
 	{
-		IEnumerable<Pair<CPos, SubCell>> TargetableCells();
+		Pair<CPos, SubCell>[] TargetableCells();
 	}
 
 	[RequireExplicitImplementation]


### PR DESCRIPTION
This allows callers to efficiently enumerate these returned collections without the allocation and overhead imposed by the IEnumerable interface. All implementations were already returning arrays, so this only required a signature change.