### PR TITLE
Avoid allocations when generating RadarSignatureCells.

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -266,9 +266,11 @@ namespace OpenRA.Mods.Common.Traits
 			return nodes;
 		}
 
-		public IEnumerable<Pair<CPos, Color>> RadarSignatureCells(Actor self)
+		public void PopulateRadarSignatureCells(Actor self, List<Pair<CPos, Color>> destinationBuffer)
 		{
-			return cellMap.SelectMany(c => c.Value.Select(p => Pair.New(c.Key, p.Owner.Color.RGB)));
+			foreach (var previewsForCell in cellMap)
+				foreach (var preview in previewsForCell.Value)
+					destinationBuffer.Add(Pair.New(previewsForCell.Key, preview.Owner.Color.RGB));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -354,7 +354,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public interface IRadarSignature
 	{
-		IEnumerable<Pair<CPos, Color>> RadarSignatureCells(Actor self);
+		void PopulateRadarSignatureCells(Actor self, List<Pair<CPos, Color>> destinationBuffer);
 	}
 
 	public interface IRadarColorModifier { Color RadarColorOverride(Actor self, Color color); }

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -15,6 +15,7 @@ using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 using OpenRA.Widgets;
 
@@ -361,6 +362,8 @@ namespace OpenRA.Mods.Common.Widgets
 				var stride = radarSheet.Size.Width;
 				Array.Clear(radarData, 4 * actorSprite.Bounds.Top * stride, 4 * actorSprite.Bounds.Height * stride);
 
+				var cells = new List<Pair<CPos, Color>>();
+
 				unsafe
 				{
 					fixed (byte* colorBytes = &radarData[0])
@@ -372,7 +375,9 @@ namespace OpenRA.Mods.Common.Widgets
 							if (!t.Actor.IsInWorld || world.FogObscures(t.Actor))
 								continue;
 
-							foreach (var cell in t.Trait.RadarSignatureCells(t.Actor))
+							cells.Clear();
+							t.Trait.PopulateRadarSignatureCells(t.Actor, cells);
+							foreach (var cell in cells)
 							{
 								if (!world.Map.Contains(cell.First))
 									continue;


### PR DESCRIPTION
The RadarWidget can supply a reusable buffer to each trait to avoid individual traits having to return new enumerables. Additionally, this allows the two traits to avoid LINQ and further allocations as they can manually enumerate and populate the buffer themselves.