### PR TITLE
Initialize map inverse cell projections with capacity 1.

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -429,7 +429,7 @@ namespace OpenRA
 			{
 				var uv = cell.ToMPos(Grid.Type);
 				cellProjection[uv] = new PPos[0];
-				inverseCellProjection[uv] = new List<MPos>();
+				inverseCellProjection[uv] = new List<MPos>(1);
 			}
 
 			// Initialize projections


### PR DESCRIPTION
This prevents the capacity being set to 4 when the first item is added. For flat maps, the inverse projection will only ever be of size 1, thus this is sufficient capacity. For isometric maps, 1 is often sufficient, we only need more near height changes where the discontinuity means multiple cells may project back. We can pay for some reallocations to expand the size in these cases.

On flat maps, this reduces the memory required by the backing array 4x.

Helps with #12494 by reducing overall memory required.