### PR TITLE
Reuse buffers when loading Xcc databases.

### DIFF
--- a/OpenRA.Mods.Cnc/FileFormats/XccGlobalDatabase.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/XccGlobalDatabase.cs
@@ -28,15 +28,16 @@ namespace OpenRA.Mods.Cnc.FileFormats
 			while (s.Peek() > -1)
 			{
 				var count = s.ReadInt32();
+				var chars = new List<char>();
 				for (var i = 0; i < count; i++)
 				{
-					var chars = new List<char>();
 					byte c;
 
 					// Read filename
 					while ((c = s.ReadUInt8()) != 0)
 						chars.Add((char)c);
 					entries.Add(new string(chars.ToArray()));
+					chars.Clear();
 
 					// Skip comment
 					while ((c = s.ReadUInt8()) != 0) { }

--- a/OpenRA.Mods.Cnc/FileFormats/XccLocalDatabase.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/XccLocalDatabase.cs
@@ -26,14 +26,15 @@ namespace OpenRA.Mods.Cnc.FileFormats
 			var reader = new BinaryReader(s);
 			var count = reader.ReadInt32();
 			Entries = new string[count];
+			var chars = new List<char>();
 			for (var i = 0; i < count; i++)
 			{
-				var chars = new List<char>();
 				char c;
 				while ((c = reader.ReadChar()) != 0)
 					chars.Add(c);
 
 				Entries[i] = new string(chars.ToArray());
+				chars.Clear();
 			}
 		}
 


### PR DESCRIPTION
We can reuse the list as a buffer when reading strings to avoid throwaway allocations, which will reduce GC pressure during loading.