### PR TITLE
Prevent the map editor from saving files with question marks in their name

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -161,6 +161,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (string.IsNullOrEmpty(filename.Text))
 					return;
 
+				if (filename.Text.IndexOfAny(Path.GetInvalidPathChars()) != -1)
+					return;
+
 				map.Title = title.Text;
 				map.Author = author.Text;
 


### PR DESCRIPTION
type: fix
subject: Prevent the map editor from saving files with question marks in their name

Closes #14255.