### PR TITLE
Fix Evacuation not ending

### DIFF
--- a/mods/ra/maps/evacuation/map.yaml
+++ b/mods/ra/maps/evacuation/map.yaml
@@ -1560,7 +1560,7 @@ Actors:
 		Location: 31,111
 		Owner: Neutral
 	ExtractionLZEntryPoint: waypoint
-		Location: 9,9
+		Location: 16,16
 		Owner: Neutral
 	ExtractionLZ: waypoint
 		Location: 30,38
@@ -1581,10 +1581,10 @@ Actors:
 		Location: 86,78
 		Owner: Neutral
 	BadgerEntryPoint1: waypoint
-		Location: 40,12
+		Location: 40,16
 		Owner: Neutral
 	BadgerEntryPoint2: waypoint
-		Location: 119,77
+		Location: 111,77
 		Owner: Neutral
 	BadgerDropPoint1: waypoint
 		Location: 19,96
@@ -1602,7 +1602,7 @@ Actors:
 		Location: 39,108
 		Owner: Neutral
 	YakEntryPoint: waypoint
-		Location: 99,10
+		Location: 99,16
 		Owner: Neutral
 	YakAttackPoint: waypoint
 		Location: 78,62

--- a/mods/ra/maps/evacuation/map.yaml
+++ b/mods/ra/maps/evacuation/map.yaml
@@ -1523,9 +1523,6 @@ Actors:
 	Actor290: pbox
 		Location: 39,92
 		Owner: Allies
-	Actor1000: camera
-		Location: 1,1
-		Owner: Soviets
 	ChinookHusk: tran.husk2
 		Location: 108,87
 		Owner: Neutral

--- a/mods/ra/maps/survival01/map.yaml
+++ b/mods/ra/maps/survival01/map.yaml
@@ -1094,10 +1094,10 @@ Actors:
 		Location: 16,14
 		Owner: Soviets
 	BadgerEntryPoint1: waypoint
-		Location: 1,54
+		Location: 4,54
 		Owner: Neutral
 	BadgerEntryPoint2: waypoint
-		Location: 1,47
+		Location: 4,47
 		Owner: Neutral
 	ParaDrop1: waypoint
 		Location: 54,51
@@ -1178,13 +1178,13 @@ Actors:
 		Location: 42,53
 		Owner: Neutral
 	AirReinforcementsEntry1: waypoint
-		Location: 95,59
+		Location: 91,55
 		Owner: Neutral
 	AirReinforcementsEntry2: waypoint
 		Location: 63,26
 		Owner: Neutral
 	AirReinforcementsRally1: waypoint
-		Location: 88,63
+		Location: 83,59
 		Owner: Neutral
 	AirReinforcementsRally2: waypoint
 		Location: 17,31

--- a/mods/ra/maps/survival01/map.yaml
+++ b/mods/ra/maps/survival01/map.yaml
@@ -1180,10 +1180,10 @@ Actors:
 	AirReinforcementsEntry1: waypoint
 		Location: 91,55
 		Owner: Neutral
-	AirReinforcementsEntry2: waypoint
+	AirReinforcementsRally1: waypoint
 		Location: 63,26
 		Owner: Neutral
-	AirReinforcementsRally1: waypoint
+	AirReinforcementsEntry2: waypoint
 		Location: 83,59
 		Owner: Neutral
 	AirReinforcementsRally2: waypoint

--- a/mods/ra/maps/survival01/survival01.lua
+++ b/mods/ra/maps/survival01/survival01.lua
@@ -38,8 +38,8 @@ end
 
 AlliedAirReinforcementsWaypoints =
 {
-	{ AirReinforcementsEntry1.Location, AirReinforcementsEntry2.Location },
-	{ AirReinforcementsRally1.Location, AirReinforcementsRally2.Location }
+	{ AirReinforcementsEntry1.Location, AirReinforcementsRally1.Location },
+	{ AirReinforcementsEntry2.Location, AirReinforcementsRally2.Location }
 }
 FrenchReinforcements = { "2tnk", "2tnk", "2tnk", "2tnk", "2tnk", "1tnk", "1tnk", "1tnk", "arty", "arty", "arty", "jeep", "jeep" }
 


### PR DESCRIPTION
Fixes #14247.

Since we don't allow aircraft (helis) to fly outside the map bounds, having waypoints there is a bad idea.