### PR TITLE
Expose EffectiveOwner to Lua API

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
@@ -80,6 +80,18 @@ namespace OpenRA.Mods.Common.Scripting
 		{
 			Self.World.Add(new FlashTarget(Self, asPlayer, duration));
 		}
+
+		[Desc("The effective owner of the actor.")]
+		public Player EffectiveOwner
+		{
+			get
+			{
+				if (Self.EffectiveOwner == null || Self.EffectiveOwner.Owner == null)
+					return Self.Owner;
+
+				return Self.EffectiveOwner.Owner;
+			}
+		}
 	}
 
 	[ScriptPropertyGroup("General")]


### PR DESCRIPTION
This enables the LUA scripts to access the Effective owner of a disguised actor in the scripts. Resolves issue #14273.