### PR TITLE
D2K - Subfaction FactionSuffix

### DIFF
--- a/mods/d2k/metrics.yaml
+++ b/mods/d2k/metrics.yaml
@@ -2,3 +2,7 @@
 Metrics:
 	ColorPickerActorType: ^carryall.colorpicker
 	ColorPickerRemapIndices: 255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240
+	FactionSuffix-fremen: atreides
+	FactionSuffix-corrino: harkonnen
+	FactionSuffix-smuggler: ordos
+	FactionSuffix-mercenary: ordos


### PR DESCRIPTION
Before this PR making a human player one of the subfactions crashes the game on start.

I made it so using `FactionSuffix-` those sides use the same UI with the side they share building artwork.

Note that currently on OpenRA, Fremen are using Harkonnen structure artwork, this is wrong and i'll fix it with another PR.

Testcase enables the subfactions so you can test.