### PR TITLE
D2K - Subfaction Images and Voices

### DIFF
--- a/mods/d2k/audio/notifications.yaml
+++ b/mods/d2k/audio/notifications.yaml
@@ -4,8 +4,12 @@ Speech:
 	DefaultVariant: .AUD
 	Prefixes:
 		atreides: AI_
+		fremen: AI_
 		ordos: OI_
+		smuggler: OI_
+		mercenary: OI_
 		harkonnen: HI_
+		corrino: HI_
 	Notifications:
 		BaseAttack: ATACK
 		Building: BUILD

--- a/mods/d2k/audio/voices.yaml
+++ b/mods/d2k/audio/voices.yaml
@@ -8,8 +8,12 @@ GenericVoice:
 		harkonnen: .WAV
 	Prefixes:
 		atreides: A
+		fremen: A
 		ordos: O
+		smuggler: O
+		mercenary: O
 		harkonnen: H
+		corrino: H
 	Voices:
 		Select: G_SSEL1,G_SSEL2,G_SSEL3
 		Action: G_SCONF1,G_SCONF2,G_SCONF3
@@ -22,8 +26,12 @@ VehicleVoice:
 	DefaultVariant: .AUD
 	Prefixes:
 		atreides: A
+		fremen: A
 		ordos: O
+		smuggler: O
+		mercenary: O
 		harkonnen: H
+		corrino: H
 	Voices:
 		Select: _VSEL1,_VSEL2,_VSEL3
 		Action: _VCONF1,_VCONF2,_VCONF3
@@ -37,8 +45,12 @@ InfantryVoice:
 		harkonnen: .WAV
 	Prefixes:
 		atreides: A
+		fremen: A
 		ordos: O
+		smuggler: O
+		mercenary: O
 		harkonnen: H
+		corrino: H
 	Voices:
 		Select: _ISEL1,_ISEL2,_ISEL3
 		Action: _ICONF1,_ICONF2,_ICONF3
@@ -55,8 +67,12 @@ EngineerVoice:
 		harkonnen: .WAV
 	Prefixes:
 		atreides: A
+		fremen: A
 		ordos: O
+		smuggler: O
+		mercenary: O
 		harkonnen: H
+		corrino: H
 	Voices:
 		Select: _ESEL1,_ESEL2,_ESEL3
 		Action: _ECONF1,_ECONF2,_ECONF3
@@ -73,8 +89,12 @@ FremenVoice:
 		harkonnen: .WAV
 	Prefixes:
 		atreides: A
+		fremen: A
 		ordos: O
+		smuggler: O
+		mercenary: O
 		harkonnen: H
+		corrino: H
 	Voices:
 		Select: A_FSEL1,A_FSEL2,A_FSEL3,A_FSEL4
 		Action: A_FCONF1,A_FCONF2,A_FCONF3,A_FCONF4
@@ -91,8 +111,12 @@ SaboteurVoice:
 		harkonnen: .WAV
 	Prefixes:
 		atreides: A
+		fremen: A
 		ordos: O
+		smuggler: O
+		mercenary: O
 		harkonnen: H
+		corrino: H
 	Voices:
 		Select: O_SSEL1,O_SSEL2,O_SSEL3
 		Action: O_SCONF1,O_SCONF2,O_SCONF3

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -224,11 +224,12 @@ upgrade.conyard:
 	Valued:
 		Cost: 1000
 	RenderSprites:
-		Image: conyard.harkonnen
+		Image: conyard.ordos
 		FactionImages:
 			atreides: conyard.atreides
-			ordos: conyard.ordos
-			corrino: conyard.corrino
+			fremen: conyard.atreides
+			harkonnen: conyard.harkonnen
+			corrino: conyard.harkonnen
 	ProvidesPrerequisite@upgradename:
 
 upgrade.barracks:
@@ -247,12 +248,12 @@ upgrade.barracks:
 	Valued:
 		Cost: 500
 	RenderSprites:
-		Image: barracks.harkonnen
+		Image: barracks.ordos
 		FactionImages:
 			atreides: barracks.atreides
-			ordos: barracks.ordos
-			mercenary: barracks.ordos
-			smuggler: barracks.ordos
+			fremen: barracks.atreides
+			harkonnen: barracks.harkonnen
+			corrino: barracks.harkonnen
 	ProvidesPrerequisite@upgradename:
 
 upgrade.light:
@@ -271,12 +272,12 @@ upgrade.light:
 	Valued:
 		Cost: 400
 	RenderSprites:
-		Image: light.harkonnen
+		Image: light.ordos
 		FactionImages:
 			atreides: light.atreides
-			ordos: light.ordos
-			mercenary: light.ordos
-			smuggler: light.ordos
+			fremen: light.atreides
+			harkonnen: light.harkonnen
+			corrino: light.harkonnen
 	ProvidesPrerequisite@upgradename:
 
 upgrade.heavy:
@@ -295,12 +296,13 @@ upgrade.heavy:
 	Valued:
 		Cost: 800
 	RenderSprites:
-		Image: heavy.harkonnen
+		Image: heavy.ordos
 		FactionImages:
 			atreides: heavy.atreides
-			ordos: heavy.ordos
+			fremen: heavy.atreides
+			harkonnen: heavy.harkonnen
+			corrino: heavy.harkonnen
 			mercenary: heavy.mercenary
-			smuggler: heavy.ordos
 	ProvidesPrerequisite@upgradename:
 
 upgrade.hightech:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -91,12 +91,12 @@ construction_yard:
 	Power:
 		Amount: 20
 	RenderSprites:
-		Image: conyard.harkonnen
+		Image: conyard.ordos
 		FactionImages:
 			atreides: conyard.atreides
-			ordos: conyard.ordos
-			smuggler: conyard.ordos
-			mercenary: conyard.ordos
+			fremen: conyard.atreides
+			harkonnen: conyard.harkonnen
+			corrino: conyard.harkonnen
 	WithBuildingPlacedOverlay:
 		Palette: d2k
 	PrimaryBuilding:
@@ -151,12 +151,12 @@ wind_trap:
 	RevealsShroud:
 		Range: 3c768
 	RenderSprites:
-		Image: power.harkonnen
+		Image: power.ordos
 		FactionImages:
 			atreides: power.atreides
-			ordos: power.ordos
-			smuggler: power.ordos
-			mercenary: power.ordos
+			fremen: power.atreides
+			harkonnen: power.harkonnen
+			corrino: power.harkonnen
 	WithIdleOverlay@ZAPS:
 		Sequence: idle-zaps
 	Power:
@@ -221,12 +221,12 @@ barracks:
 	Power:
 		Amount: -30
 	RenderSprites:
-		Image: barracks.harkonnen
+		Image: barracks.ordos
 		FactionImages:
 			atreides: barracks.atreides
-			ordos: barracks.ordos
-			smuggler: barracks.ordos
-			mercenary: barracks.ordos
+			fremen: barracks.atreides
+			harkonnen: barracks.harkonnen
+			corrino: barracks.harkonnen
 	ProvidesPrerequisite@buildingname:
 	GrantConditionOnPrerequisite:
 		Prerequisites: upgrade.barracks
@@ -297,12 +297,12 @@ refinery:
 		DeliveringActor: carryall.reinforce
 		Facing: 160
 	RenderSprites:
-		Image: refinery.harkonnen
+		Image: refinery.ordos
 		FactionImages:
 			atreides: refinery.atreides
-			ordos: refinery.ordos
-			smuggler: refinery.ordos
-			mercenary: refinery.ordos
+			fremen: refinery.atreides
+			harkonnen: refinery.harkonnen
+			corrino: refinery.harkonnen
 	WithDockedOverlay@SMOKE:
 		Sequence: smoke
 	Power:
@@ -336,12 +336,12 @@ silo:
 	RevealsShroud:
 		Range: 2c768
 	RenderSprites:
-		Image: silo.harkonnen
+		Image: silo.ordos
 		FactionImages:
 			atreides: silo.atreides
-			ordos: silo.ordos
-			smuggler: silo.ordos
-			mercenary: silo.ordos
+			fremen: silo.atreides
+			harkonnen: silo.harkonnen
+			corrino: silo.harkonnen
 	WithSpriteBody:
 	WithSiloAnimation:
 	StoresResources:
@@ -392,12 +392,12 @@ light_factory:
 	RevealsShroud:
 		Range: 4c768
 	RenderSprites:
-		Image: light.harkonnen
+		Image: light.ordos
 		FactionImages:
 			atreides: light.atreides
-			ordos: light.ordos
-			smuggler: light.ordos
-			mercenary: light.ordos
+			fremen: light.atreides
+			harkonnen: light.harkonnen
+			corrino: light.harkonnen
 	RallyPoint:
 		Offset: 2,2
 	Exit@1:
@@ -503,12 +503,13 @@ heavy_factory:
 		Prerequisite: heavy.missiletank
 		Factions: atreides, harkonnen
 	RenderSprites:
-		Image: heavy.harkonnen
+		Image: heavy.ordos
 		FactionImages:
 			atreides: heavy.atreides
-			ordos: heavy.ordos
+			fremen: heavy.atreides
+			harkonnen: heavy.harkonnen
+			corrino: heavy.harkonnen
 			mercenary: heavy.mercenary
-			smuggler: heavy.ordos
 	WithProductionOverlay@WELDING:
 		Sequence: production-welding
 	WithIdleOverlay@TOP:
@@ -568,12 +569,12 @@ outpost:
 	ProvidesRadar:
 		RequiresCondition: !disabled
 	RenderSprites:
-		Image: outpost.harkonnen
+		Image: outpost.ordos
 		FactionImages:
 			atreides: outpost.atreides
-			ordos: outpost.ordos
-			smuggler: outpost.ordos
-			mercenary: outpost.ordos
+			fremen: outpost.atreides
+			harkonnen: outpost.harkonnen
+			corrino: outpost.harkonnen
 	WithIdleOverlay@DISH:
 		Sequence: idle-dish
 		PauseOnCondition: disabled
@@ -629,12 +630,13 @@ starport:
 		Produces: Starport
 		ActorType: frigate
 	RenderSprites:
-		Image: starport.harkonnen
+		Image: starport.ordos
 		FactionImages:
 			atreides: starport.atreides
-			ordos: starport.ordos
+			fremen: starport.atreides
+			harkonnen: starport.harkonnen
+			corrino: starport.harkonnen
 			smuggler: starport.smuggler
-			mercenary: starport.ordos
 	WithDeliveryOverlay:
 		Palette: starportlights
 	ProductionBar:
@@ -853,12 +855,12 @@ repair_pad:
 	RallyPoint:
 		Offset: 1,3
 	RenderSprites:
-		Image: repair_pad.harkonnen
+		Image: repair_pad.ordos
 		FactionImages:
 			atreides: repair_pad.atreides
-			ordos: repair_pad.ordos
-			smuggler: repair_pad.ordos
-			mercenary: repair_pad.ordos
+			fremen: repair_pad.atreides
+			harkonnen: repair_pad.harkonnen
+			corrino: repair_pad.harkonnen
 	WithRepairOverlay:
 		Palette: effect75alpha
 	Power:
@@ -908,12 +910,12 @@ high_tech_factory:
 	RevealsShroud:
 		Range: 4c768
 	RenderSprites:
-		Image: hightech.harkonnen
+		Image: hightech.ordos
 		FactionImages:
 			atreides: hightech.atreides
-			ordos: hightech.ordos
-			smuggler: hightech.ordos
-			mercenary: hightech.ordos
+			fremen: hightech.atreides
+			harkonnen: hightech.harkonnen
+			corrino: hightech.harkonnen
 	ProvidesPrerequisite@upgrade:
 		Prerequisite: hightech.atreides
 		Factions: atreides
@@ -985,12 +987,12 @@ research_centre:
 	RevealsShroud:
 		Range: 4c768
 	RenderSprites:
-		Image: research.harkonnen
+		Image: research.ordos
 		FactionImages:
 			atreides: research.atreides
-			ordos: research.ordos
-			smuggler: research.ordos
-			mercenary: research.ordos
+			fremen: research.atreides
+			harkonnen: research.harkonnen
+			corrino: research.harkonnen
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
 	Power:
@@ -1038,13 +1040,12 @@ palace:
 	RevealsShroud:
 		Range: 4c768
 	RenderSprites:
-		Image: palace.harkonnen
+		Image: palace.ordos
 		FactionImages:
 			atreides: palace.atreides
-			ordos: palace.ordos
+			fremen: palace.atreides
+			harkonnen: palace.harkonnen
 			corrino: palace.corrino
-			smuggler: palace.ordos
-			mercenary: palace.ordos
 	Power:
 		Amount: -200
 	ProvidesPrerequisite@nuke:

--- a/mods/d2k/sequences/structures.yaml
+++ b/mods/d2k/sequences/structures.yaml
@@ -1556,8 +1556,8 @@ starport.smuggler:
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8 # TODO: blank
-		Start: 4281
+	icon: DATA.R8
+		Start: 4358
 		Offset: -30,-24
 
 heavy.mercenary:
@@ -1606,8 +1606,8 @@ heavy.mercenary:
 		Frames: 643, 644, 645, 663, 664, 665
 		Length: 6
 		Offset: -16,-16
-	icon: DATA.R8 # TODO: blank
-		Start: 4281
+	icon: DATA.R8
+		Start: 4353
 		Offset: -30,-24
 
 plates: # TODO: unused


### PR DESCRIPTION
Before this PR human player that uses subfactions get no unit or mentat voice. Now they use the voices from the same faction they share structure artwork with.

This fixes that Fremen uses Harkonnen structure artwork instead of Atreides.

This changes `Image:` tag for structures from Harkonnen ones to Ordos, as there are 3 Ordos and 2 other subfactions. Harkonnen and Corrino are now defined on `FactionImages:`, while Ordos, Mercenary and Smuggler are removed from there.

At last this replaces missing cameos with Ordos counterparts for Mercenary War Factory and Smuggler Starport (Those use Ornithopter Cameo in original game and was Atreides Combat Tank on ORA).

~~Depends on #14457, as you can't test the second commit without what that PR fixes.~~