### PR TITLE
D2K - Update some prerequisites to include subfactions too

### DIFF
--- a/mods/d2k/maps/atreides-05/rules.yaml
+++ b/mods/d2k/maps/atreides-05/rules.yaml
@@ -76,7 +76,3 @@ siege_tank:
 missile_tank:
 	Buildable:
 		Prerequisites: upgrade.heavy, research_centre
-
-combat_tank_o.starport:
-	Buildable:
-		Prerequisites: starport

--- a/mods/d2k/maps/harkonnen-05/rules.yaml
+++ b/mods/d2k/maps/harkonnen-05/rules.yaml
@@ -48,7 +48,7 @@ research_centre:
 
 missile_tank:
 	Buildable:
-		Prerequisites: ~heavy.missiletank, upgrade.heavy, research_centre
+		Prerequisites: ~heavy.missile_tank, upgrade.heavy, research_centre
 
 siege_tank:
 	Buildable:

--- a/mods/d2k/maps/harkonnen-06a/rules.yaml
+++ b/mods/d2k/maps/harkonnen-06a/rules.yaml
@@ -56,7 +56,7 @@ starport:
 
 missile_tank:
 	Buildable:
-		Prerequisites: ~heavy.missiletank, upgrade.heavy, research_centre
+		Prerequisites: ~heavy.missile_tank, upgrade.heavy, research_centre
 
 sardaukar:
 	Buildable:

--- a/mods/d2k/maps/harkonnen-06b/rules.yaml
+++ b/mods/d2k/maps/harkonnen-06b/rules.yaml
@@ -56,7 +56,7 @@ starport:
 
 missile_tank:
 	Buildable:
-		Prerequisites: ~heavy.missiletank, upgrade.heavy, research_centre
+		Prerequisites: ~heavy.missile_tank, upgrade.heavy, research_centre
 
 sardaukar:
 	Buildable:

--- a/mods/d2k/maps/ordos-04/rules.yaml
+++ b/mods/d2k/maps/ordos-04/rules.yaml
@@ -54,14 +54,6 @@ engineer:
 	Buildable:
 		Prerequisites: upgrade.barracks
 
-light_factory:
-	ProvidesPrerequisite@ordos:
-		Factions: ordos, smuggler
-
-heavy_factory:
-	ProvidesPrerequisite@ordos:
-		Factions: ordos, smuggler
-
 repair_pad:
 	Buildable:
 		Prerequisites: heavy_factory, upgrade.heavy

--- a/mods/d2k/rules/starport.yaml
+++ b/mods/d2k/rules/starport.yaml
@@ -61,7 +61,7 @@ missile_tank.starport:
 combat_tank_a.starport:
 	Inherits: combat_tank_a
 	Buildable:
-		Prerequisites: ~starport.atreides
+		Prerequisites: ~starport.atreides_combat
 		Queue: Starport
 	Valued:
 		Cost: 875
@@ -71,7 +71,7 @@ combat_tank_a.starport:
 combat_tank_h.starport:
 	Inherits: combat_tank_h
 	Buildable:
-		Prerequisites: ~starport.harkonnen
+		Prerequisites: ~starport.harkonnen_combat
 		Queue: Starport
 	Valued:
 		Cost: 875
@@ -81,7 +81,7 @@ combat_tank_h.starport:
 combat_tank_o.starport:
 	Inherits: combat_tank_o
 	Buildable:
-		Prerequisites: ~starport.ordos
+		Prerequisites: ~starport.ordos_combat
 		Queue: Starport
 	Valued:
 		Cost: 875

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -416,9 +416,12 @@ light_factory:
 	ProvidesPrerequisite@harkonnen:
 		Prerequisite: light.harkonnen
 		Factions: harkonnen
-	ProvidesPrerequisite@trikes:
-		Prerequisite: light.regulartrikes
-		Factions: atreides, harkonnen
+	ProvidesPrerequisite@trike:
+		Prerequisite: light.trike
+		Factions: atreides, fremen, harkonnen, corrino
+	ProvidesPrerequisite@raider:
+		Prerequisite: light.raider
+		Factions: ordos, smuggler, mercenary
 	ProvidesPrerequisite@buildingname:
 	WithProductionOverlay@WELDING:
 		Sequence: production-welding
@@ -497,9 +500,18 @@ heavy_factory:
 	ProvidesPrerequisite@harkonnen:
 		Prerequisite: heavy.harkonnen
 		Factions: harkonnen
-	ProvidesPrerequisite@missiletank:
-		Prerequisite: heavy.missiletank
-		Factions: atreides, harkonnen
+	ProvidesPrerequisite@atreides_combat:
+		Prerequisite: heavy.atreides_combat
+		Factions: atreides, fremen
+	ProvidesPrerequisite@ordos_combat:
+		Prerequisite: heavy.ordos_combat
+		Factions: ordos, smuggler, mercenary
+	ProvidesPrerequisite@harkonnen_combat:
+		Prerequisite: heavy.harkonnen_combat
+		Factions: harkonnen, corrino
+	ProvidesPrerequisite@missile_tank:
+		Prerequisite: heavy.missile_tank
+		Factions: atreides, fremen, harkonnen, corrino
 	RenderSprites:
 		Image: heavy.harkonnen
 		FactionImages:
@@ -648,6 +660,15 @@ starport:
 	ProvidesPrerequisite@harkonnen:
 		Prerequisite: starport.harkonnen
 		Factions: harkonnen
+	ProvidesPrerequisite@atreides_combat:
+		Prerequisite: starport.atreides_combat
+		Factions: atreides, fremen
+	ProvidesPrerequisite@ordos_combat:
+		Prerequisite: starport.ordos_combat
+		Factions: ordos, smuggler, mercenary
+	ProvidesPrerequisite@harkonnen_combat:
+		Prerequisite: starport.harkonnen_combat
+		Factions: harkonnen, corrino
 	Power:
 		Amount: -150
 	ProvidesPrerequisite@buildingname:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -105,7 +105,7 @@ trike:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 10
-		Prerequisites: ~light.regulartrikes
+		Prerequisites: ~light.trike
 		BuildDuration: 194
 		BuildDurationModifier: 40
 		Description: Fast scout\n  Strong vs Infantry\n  Weak vs Tanks
@@ -231,7 +231,7 @@ missile_tank:
 		Name: Missile Tank
 	Buildable:
 		Queue: Armor
-		Prerequisites: ~heavy.missiletank, upgrade.heavy, research_centre, ~techlevel.high
+		Prerequisites: ~heavy.missile_tank, upgrade.heavy, research_centre, ~techlevel.high
 		BuildPaletteOrder: 60
 		BuildDuration: 441
 		BuildDurationModifier: 40
@@ -373,7 +373,7 @@ raider:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 10
-		Prerequisites: ~light.ordos
+		Prerequisites: ~light.raider
 		BuildDuration: 194
 		BuildDurationModifier: 40
 		Description: Improved Scout\n  Strong vs Infantry, Light Vehicles\n  Weak vs Tanks
@@ -515,7 +515,7 @@ deviator:
 combat_tank_a:
 	Inherits: ^combat_tank
 	Buildable:
-		Prerequisites: ~heavy.atreides
+		Prerequisites: ~heavy.atreides_combat
 	Armament:
 		Weapon: 80mm_A
 	SpawnActorOnDeath:
@@ -524,7 +524,7 @@ combat_tank_a:
 combat_tank_h:
 	Inherits: ^combat_tank
 	Buildable:
-		Prerequisites: ~heavy.harkonnen
+		Prerequisites: ~heavy.harkonnen_combat
 	Armament:
 		Weapon: 80mm_H
 	Mobile:
@@ -537,7 +537,7 @@ combat_tank_h:
 combat_tank_o:
 	Inherits: ^combat_tank
 	Buildable:
-		Prerequisites: ~heavy.ordos
+		Prerequisites: ~heavy.ordos_combat
 	Turreted:
 		TurnSpeed: 5
 	Armament:


### PR DESCRIPTION
Now this is a bit problematic, because stuff in original game are a bit incosistent. So i only added some of them.

This PR only makes Combat Tanks, Raiders, Trikes and Missile Tanks available to subfactions they should be.

In original, factions with specific war factories (Corrino (just code level, no specific artwork) and Mercenaries) can't build their IX specific units. But others (Fremen and Smugglers) can. I didn't touch them, none are available to subfactions currently.

Similar can be said for Palace units. I didn't touch to them and ornithopter either.

On TibEd, none of Palace, Hi-Tech Factory or IX Tier special units lists subfactions for their owners.

~~This PR probably makes some mission map specific code unnecessary. I'll add a commit that removes them later when i find time too.~~