### PR TITLE
Multiply damage and HP by 10 for D2K

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -1301,16 +1301,19 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
-				// Multiply all health and damage in the TD and RA mod by 100 to avoid issues caused by rounding
+				// Multiply all health and damage in shipping mods by 100 to avoid issues caused by rounding
 				if (engineVersion < 20171212)
 				{
 					var mod = modData.Manifest.Id;
-					if (mod == "cnc" || mod == "ra")
+					if (mod == "cnc" || mod == "ra" || mod == "d2k")
 					{
 						if (node.Key == "HP" && parent.Key == "Health")
 						{
 							var oldValue = FieldLoader.GetValue<int>(node.Key, node.Value.Value);
-							node.Value.Value = MultiplyByFactor(oldValue, 100);
+							if (mod == "d2k")
+								node.Value.Value = MultiplyByFactor(oldValue, 10);
+							else
+								node.Value.Value = MultiplyByFactor(oldValue, 100);
 						}
 
 						if (node.Key.StartsWith("SelfHealing"))
@@ -1321,7 +1324,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 							else if (step != null)
 							{
 								var oldValue = FieldLoader.GetValue<int>(step.Key, step.Value.Value);
-								step.Value.Value = MultiplyByFactor(oldValue, 100);
+								if (mod == "d2k")
+									step.Value.Value = MultiplyByFactor(oldValue, 10);
+								else
+									step.Value.Value = MultiplyByFactor(oldValue, 100);
 							}
 						}
 
@@ -1333,7 +1339,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 							else if (step != null)
 							{
 								var oldValue = FieldLoader.GetValue<int>(step.Key, step.Value.Value);
-								step.Value.Value = MultiplyByFactor(oldValue, 100);
+								if (mod == "d2k")
+									step.Value.Value = MultiplyByFactor(oldValue, 10);
+								else
+									step.Value.Value = MultiplyByFactor(oldValue, 100);
 							}
 						}
 
@@ -1345,7 +1354,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 							else if (step != null)
 							{
 								var oldValue = FieldLoader.GetValue<int>(step.Key, step.Value.Value);
-								step.Value.Value = MultiplyByFactor(oldValue, 100);
+								if (mod == "d2k")
+									step.Value.Value = MultiplyByFactor(oldValue, 10);
+								else
+									step.Value.Value = MultiplyByFactor(oldValue, 100);
 							}
 						}
 
@@ -1357,7 +1369,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 							else if (step != null)
 							{
 								var oldValue = FieldLoader.GetValue<int>(step.Key, step.Value.Value);
-								step.Value.Value = MultiplyByFactor(oldValue, 100);
+								if (mod == "d2k")
+									step.Value.Value = MultiplyByFactor(oldValue, 10);
+								else
+									step.Value.Value = MultiplyByFactor(oldValue, 100);
 							}
 						}
 
@@ -1367,7 +1382,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 							if (step != null)
 							{
 								var oldValue = FieldLoader.GetValue<int>(step.Key, step.Value.Value);
-								step.Value.Value = MultiplyByFactor(oldValue, 100);
+								if (mod == "d2k")
+									step.Value.Value = MultiplyByFactor(oldValue, 10);
+								else
+									step.Value.Value = MultiplyByFactor(oldValue, 100);
 							}
 						}
 					}
@@ -1624,16 +1642,19 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					if (node.Key == "BurstDelay")
 						node.Key = "BurstDelays";
 
-				// Multiply all health and damage in the TD and RA mod by 100 to avoid issues caused by rounding
+				// Multiply all health and damage in shipping mods by 100 to avoid issues caused by rounding
 				if (engineVersion < 20171212)
 				{
 					var mod = modData.Manifest.Id;
-					if (mod == "cnc" || mod == "ra")
+					if (mod == "cnc" || mod == "ra" || mod == "d2k")
 					{
 						if (node.Key == "Damage" && (parent.Value.Value == "SpreadDamage" || parent.Value.Value == "TargetDamage"))
 						{
 							var oldValue = FieldLoader.GetValue<int>(node.Key, node.Value.Value);
-							node.Value.Value = MultiplyByFactor(oldValue, 100);
+							if (mod == "d2k")
+								node.Value.Value = MultiplyByFactor(oldValue, 10);
+							else
+								node.Value.Value = MultiplyByFactor(oldValue, 100);
 						}
 					}
 				}

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -5,7 +5,7 @@ carryall.reinforce:
 	Tooltip:
 		Name: Carryall
 	Health:
-		HP: 4800
+		HP: 48000
 	Armor:
 		Type: light
 	Aircraft:
@@ -34,7 +34,7 @@ carryall.reinforce:
 	RenderSprites:
 		Image: carryall
 	SelfHealing:
-		Step: 5
+		Step: 50
 		Delay: 3
 		HealIfBelow: 50
 	Buildable:
@@ -79,7 +79,7 @@ ornithopter:
 	Armament:
 		Weapon: OrniBomb
 	Health:
-		HP: 900
+		HP: 9000
 	Armor:
 		Type: light
 	Aircraft:

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -20,7 +20,7 @@ spicebloom.spawnpoint:
 	SpawnActorOnDeath:
 		Actor: spicebloom
 	Health:
-		HP: 9999
+		HP: 99990
 	Immobile:
 		OccupiesSpace: false
 	HitShape:
@@ -50,7 +50,7 @@ spicebloom:
 		Terrain: Spice
 	Immobile:
 	Health:
-		HP: 1
+		HP: 10
 	Targetable:
 		TargetTypes: Ground
 		RequiresForceFire: true
@@ -71,7 +71,7 @@ sandworm:
 	Tooltip:
 		Name: Sandworm
 	Health:
-		HP: 9990
+		HP: 99900
 	HitShape:
 		Type: Circle
 			Radius: 256
@@ -138,7 +138,7 @@ sietch:
 		Dimensions: 2,2
 		TerrainTypes: Cliff
 	Health:
-		HP: 6000
+		HP: 60000
 	Armor:
 		Type: wood
 	RevealsShroud:

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -20,7 +20,7 @@ spicebloom.spawnpoint:
 	SpawnActorOnDeath:
 		Actor: spicebloom
 	Health:
-		HP: 99990
+		HP: 100000
 	Immobile:
 		OccupiesSpace: false
 	HitShape:
@@ -50,7 +50,7 @@ spicebloom:
 		Terrain: Spice
 	Immobile:
 	Health:
-		HP: 10
+		HP: 1
 	Targetable:
 		TargetTypes: Ground
 		RequiresForceFire: true
@@ -71,7 +71,7 @@ sandworm:
 	Tooltip:
 		Name: Sandworm
 	Health:
-		HP: 99900
+		HP: 100000
 	HitShape:
 		Type: Circle
 			Radius: 256

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -226,7 +226,7 @@
 	Inherits@1: ^SpriteActor
 	Interactable:
 	Health:
-		HP: 75
+		HP: 750
 	Armor:
 		Type: light
 	HiddenUnderFog:
@@ -243,6 +243,7 @@
 		AllowedTerrain: Sand, Rock, Transition, Concrete, Spice, SpiceSand, SpiceBlobs, Dune
 	Burns:
 		Interval: 4
+		Damage: 10
 	Targetable:
 		TargetTypes: Ground, Vehicle
 		RequiresForceFire: true
@@ -394,7 +395,7 @@
 		Weapon: BuildingExplode
 		EmptyWeapon: BuildingExplode
 	RepairableBuilding:
-		RepairStep: 50
+		RepairStep: 500
 		PlayerExperience: 25
 	EmitInfantryOnSell:
 		ActorTypes: light_inf
@@ -412,7 +413,7 @@
 	WithCrumbleOverlay:
 	Demolishable:
 	DamagedByTerrain:
-		Damage: 50
+		Damage: 500
 		DamageInterval: 100
 		Terrain: Rock
 		DamageThreshold: 50

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -242,8 +242,8 @@
 	Husk:
 		AllowedTerrain: Sand, Rock, Transition, Concrete, Spice, SpiceSand, SpiceBlobs, Dune
 	Burns:
-		Interval: 4
 		Damage: 10
+		Interval: 4
 	Targetable:
 		TargetTypes: Ground, Vehicle
 		RequiresForceFire: true

--- a/mods/d2k/rules/husks.yaml
+++ b/mods/d2k/rules/husks.yaml
@@ -1,14 +1,14 @@
 mcv.husk:
 	Inherits: ^VehicleHusk
 	Health:
-		HP: 175
+		HP: 1750
 	Tooltip:
 		Name: Mobile Construction Vehicle (Destroyed)
 
 harvester.husk:
 	Inherits: ^VehicleHusk
 	Health:
-		HP: 150
+		HP: 1500
 	Tooltip:
 		Name: Spice Harvester (Destroyed)
 	TransformOnCapture:
@@ -40,7 +40,7 @@ sonic_tank.husk:
 devastator.husk:
 	Inherits: ^VehicleHusk
 	Health:
-		HP: 125
+		HP: 1250
 	Tooltip:
 		Name: Devastator (Destroyed)
 	TransformOnCapture:
@@ -56,7 +56,7 @@ deviator.husk:
 ^combat_tank.husk:
 	Inherits: ^VehicleHusk
 	Health:
-		HP: 100
+		HP: 1000
 	Tooltip:
 		Name: Combat Tank (Destroyed)
 	ThrowsParticle@turret:

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -12,7 +12,7 @@ light_inf:
 	Tooltip:
 		Name: Light Infantry
 	Health:
-		HP: 600
+		HP: 6000
 	Mobile:
 		Speed: 43
 	Armament:
@@ -35,7 +35,7 @@ engineer:
 	Tooltip:
 		Name: Engineer
 	Health:
-		HP: 500
+		HP: 5000
 	RevealsShroud:
 		Range: 2c768
 	Mobile:
@@ -63,7 +63,7 @@ trooper:
 	Tooltip:
 		Name: Trooper
 	Health:
-		HP: 700
+		HP: 7000
 	RevealsShroud:
 		Range: 4c768
 	Mobile:
@@ -92,7 +92,7 @@ thumper:
 	Tooltip:
 		Name: Thumper Infantry
 	Health:
-		HP: 375
+		HP: 3750
 	RevealsShroud:
 		Range: 2c768
 	Mobile:
@@ -137,7 +137,7 @@ fremen:
 	Valued:
 		Cost: 200	## actually 0, but spawns from support power at Palace
 	Health:
-		HP: 700
+		HP: 7000
 	RevealsShroud:
 		Range: 4c768
 	AutoTarget:
@@ -179,7 +179,7 @@ grenadier:
 	Tooltip:
 		Name: Grenadier
 	Health:
-		HP: 600
+		HP: 6000
 	Mobile:
 		Speed: 43
 	Armament:
@@ -210,7 +210,7 @@ sardaukar:
 	Tooltip:
 		Name: Sardaukar
 	Health:
-		HP: 1000
+		HP: 10000
 	Mobile:
 		Speed: 31
 	RevealsShroud:
@@ -241,7 +241,7 @@ saboteur:
 	Tooltip:
 		Name: Saboteur
 	Health:
-		HP: 400
+		HP: 4000
 	Mobile:
 		Speed: 43
 	Demolition:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -66,7 +66,7 @@ construction_yard:
 	Selectable:
 		Bounds: 96,64
 	Health:
-		HP: 3000
+		HP: 30000
 	HitShape:
 		Type: Rectangle
 			TopLeft: -1536, -1024
@@ -141,7 +141,7 @@ wind_trap:
 		LocalCenterOffset: 0,-512,0
 	WithBuildingBib:
 	Health:
-		HP: 3000
+		HP: 30000
 	HitShape:
 		Type: Rectangle
 			TopLeft: -1024, -1024
@@ -187,7 +187,7 @@ barracks:
 		LocalCenterOffset: 0,-512,0
 	WithBuildingBib:
 	Health:
-		HP: 3200
+		HP: 32000
 	HitShape:
 		Type: Rectangle
 			TopLeft: -1024, -1024
@@ -268,7 +268,7 @@ refinery:
 		LocalCenterOffset: 0,-512,0
 	WithBuildingBib:
 	Health:
-		HP: 3000
+		HP: 30000
 	HitShape:
 		Type: Rectangle
 			TopLeft: -512, -1024
@@ -330,7 +330,7 @@ silo:
 		Adjacent: 4
 	-GivesBuildableArea:
 	Health:
-		HP: 1500
+		HP: 15000
 	Armor:
 		Type: wall
 	RevealsShroud:
@@ -381,7 +381,7 @@ light_factory:
 		LocalCenterOffset: 0,-512,0
 	WithBuildingBib:
 	Health:
-		HP: 3300
+		HP: 33000
 	HitShape:
 		TargetableOffsets: -210,608,0
 		Type: Rectangle
@@ -466,7 +466,7 @@ heavy_factory:
 		LocalCenterOffset: 0,-512,0
 	WithBuildingBib:
 	Health:
-		HP: 3500
+		HP: 35000
 	HitShape:
 		TargetableOffsets: -1155,-704,0, -1365,832,0
 		Type: Rectangle
@@ -556,7 +556,7 @@ outpost:
 		LocalCenterOffset: 0,-512,0
 	WithBuildingBib:
 	Health:
-		HP: 3500
+		HP: 35000
 	HitShape:
 		Type: Rectangle
 			TopLeft: -1536, -1024
@@ -604,7 +604,7 @@ starport:
 	Selectable:
 		Bounds: 96,64
 	Health:
-		HP: 3500
+		HP: 35000
 	HitShape:
 		Type: Rectangle
 			TopLeft: -1536, -1536
@@ -685,7 +685,7 @@ wall:
 		AreaTypes: building
 		Adjacent: 7
 	Health:
-		HP: 2000
+		HP: 20000
 	Armor:
 		Type: wall
 	RevealsShroud:
@@ -744,7 +744,7 @@ medium_gun_turret:
 		Priority: 3
 		DecorationBounds: 32,40,0,-8
 	Health:
-		HP: 2700
+		HP: 27000
 	Armor:
 		Type: heavy
 	RevealsShroud:
@@ -791,7 +791,7 @@ large_gun_turret:
 		Priority: 3
 		DecorationBounds: 32,40,0,-8
 	Health:
-		HP: 3000
+		HP: 30000
 	Armor:
 		Type: concrete
 	RevealsShroud:
@@ -827,7 +827,7 @@ repair_pad:
 		Footprint: =x= xxx =x=
 		Dimensions: 3,3
 	Health:
-		HP: 3000
+		HP: 30000
 	HitShape:
 		Type: Rectangle
 			TopLeft: -1536, -512
@@ -847,7 +847,7 @@ repair_pad:
 	Reservable:
 	RepairsUnits:
 		Interval: 10
-		HpPerStep: 80
+		HpPerStep: 800
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
 	RallyPoint:
@@ -892,7 +892,7 @@ high_tech_factory:
 		LocalCenterOffset: 0,-512,0
 	WithBuildingBib:
 	Health:
-		HP: 3500
+		HP: 35000
 	HitShape:
 		TargetableOffsets: -1312,0,0, -1312,-1024,0, -1312,1024,0
 		Type: Rectangle
@@ -969,7 +969,7 @@ research_centre:
 		LocalCenterOffset: 0,-512,0
 	WithBuildingBib:
 	Health:
-		HP: 2500
+		HP: 25000
 	HitShape:
 		TargetableOffsets: -1574,-158,0, -1050,-1024,0, -1155,960,0
 		Type: Rectangle
@@ -1020,7 +1020,7 @@ palace:
 	WithBuildingBib:
 		HasMinibib: True
 	Health:
-		HP: 4000
+		HP: 40000
 	HitShape:
 		Type: Rectangle
 			TopLeft: -1536, -512

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -16,7 +16,7 @@ mcv:
 		Priority: 3
 		DecorationBounds: 42,42
 	Health:
-		HP: 4500
+		HP: 45000
 	Armor:
 		Type: light
 	Mobile:
@@ -42,7 +42,7 @@ mcv:
 		Intensity: 700
 	SelectionDecorations:
 	SelfHealing:
-		Step: 5
+		Step: 50
 		Delay: 3
 		HealIfBelow: 50
 	-RevealOnFire:
@@ -73,7 +73,7 @@ harvester:
 		SearchFromProcRadius: 30
 		SearchFromOrderRadius: 15
 	Health:
-		HP: 4500
+		HP: 45000
 	Armor:
 		Type: harvester
 	Mobile:
@@ -93,7 +93,7 @@ harvester:
 		Intensity: 700
 	SelectionDecorations:
 	SelfHealing:
-		Step: 5
+		Step: 50
 		Delay: 3
 		HealIfBelow: 50
 	-RevealOnFire:
@@ -116,7 +116,7 @@ trike:
 	Selectable:
 		Class: trike
 	Health:
-		HP: 900
+		HP: 9000
 	Armor:
 		Type: wood
 	Mobile:
@@ -155,7 +155,7 @@ quad:
 	Tooltip:
 		Name: Missile Quad
 	Health:
-		HP: 1100
+		HP: 11000
 	Armor:
 		Type: light
 	Mobile:
@@ -191,7 +191,7 @@ siege_tank:
 	Tooltip:
 		Name: Siege Tank
 	Health:
-		HP: 1200
+		HP: 12000
 	Armor:
 		Type: light
 	Mobile:
@@ -242,7 +242,7 @@ missile_tank:
 		Speed: 64
 		TurnSpeed: 5
 	Health:
-		HP: 1300
+		HP: 13000
 	Armor:
 		Type: wood
 	RevealsShroud:
@@ -279,7 +279,7 @@ sonic_tank:
 	Tooltip:
 		Name: Sonic Tank
 	Health:
-		HP: 3000
+		HP: 30000
 	Armor:
 		Type: light
 	Mobile:
@@ -315,7 +315,7 @@ devastator:
 	Tooltip:
 		Name: Devastator
 	Health:
-		HP: 5000
+		HP: 50000
 	Armor:
 		Type: heavy
 	Mobile:
@@ -361,7 +361,7 @@ devastator:
 		Intensity: 700
 	SelectionDecorations:
 	SelfHealing:
-		Step: 5
+		Step: 50
 		Delay: 3
 		HealIfBelow: 50
 	Selectable:
@@ -383,7 +383,7 @@ raider:
 	Tooltip:
 		Name: Raider Trike
 	Health:
-		HP: 1000
+		HP: 10000
 	Armor:
 		Type: wood
 	Mobile:
@@ -451,7 +451,7 @@ deviator:
 		TurnSpeed: 3
 		Speed: 53
 	Health:
-		HP: 1100
+		HP: 11000
 	Armor:
 		Type: wood
 	RevealsShroud:
@@ -485,7 +485,7 @@ deviator:
 	Tooltip:
 		Name: Combat Tank
 	Health:
-		HP: 2100
+		HP: 21000
 	Armor:
 		Type: heavy
 	Mobile:
@@ -531,7 +531,7 @@ combat_tank_h:
 	Mobile:
 		Speed: 64
 	Health:
-		HP: 2700
+		HP: 27000
 	SpawnActorOnDeath:
 		Actor: combat_tank_h.husk
 
@@ -546,6 +546,6 @@ combat_tank_o:
 	Mobile:
 		Speed: 85
 	Health:
-		HP: 1800
+		HP: 18000
 	SpawnActorOnDeath:
 		Actor: combat_tank_o.husk

--- a/mods/d2k/weapons/debris.yaml
+++ b/mods/d2k/weapons/debris.yaml
@@ -13,7 +13,7 @@ Debris:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 150
+		Damage: 1500
 		Versus:
 			none: 20
 			wall: 50
@@ -41,7 +41,7 @@ Debris2:
 		TrailPalette: effect75alpha
 		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
-		Damage: 250
+		Damage: 2500
 		Versus:
 			none: 90
 			wall: 5
@@ -63,7 +63,7 @@ Debris3:
 		Image: shrapnel3
 		TrailImage: small_trail2
 	Warhead@1Dam: SpreadDamage
-		Damage: 150
+		Damage: 1500
 
 Debris4:
 	Inherits: Debris2

--- a/mods/d2k/weapons/largeguns.yaml
+++ b/mods/d2k/weapons/largeguns.yaml
@@ -9,7 +9,7 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Falloff: 100, 50, 25, 0
-		Damage: 270
+		Damage: 2700
 		Versus:
 			none: 20
 			wall: 50
@@ -36,7 +36,7 @@
 		Speed: 875
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
-		Damage: 290
+		Damage: 2900
 
 80mm_A:
 	Inherits: ^Cannon
@@ -59,7 +59,7 @@ DevBullet:
 		Image: doubleblastbullet
 	Warhead@1Dam: SpreadDamage
 		Spread: 384
-		Damage: 650
+		Damage: 6500
 		Versus:
 			none: 50
 			wall: 100
@@ -89,7 +89,7 @@ DevBullet:
 	Warhead@1Dam: SpreadDamage
 		Spread: 416
 		Falloff: 100, 65, 35, 20, 0
-		Damage: 450
+		Damage: 4500
 		Versus:
 			none: 125
 			wall: 100

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -130,17 +130,17 @@ DeviatorMissile:
 		TrailPalette: deviatorgas
 		TrailUsePlayerPalette: true
 	Warhead@1Dam: SpreadDamage
-		Damage: 5000
+		Damage: 1000
 		Versus:
-			none: 20
-			wall: 20
-			building: 20
-			wood: 20
-			light: 20
-			heavy: 20
+			none: 100
+			wall: 100
+			building: 100
+			wood: 100
+			light: 100
+			heavy: 100
 			invulnerable: 0
-			cy: 10
-			harvester: 20
+			cy: 50
+			harvester: 100
 	-Warhead@2Smu: LeaveSmudge
 	Warhead@3Eff: CreateEffect
 		Explosions: deviator

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -13,7 +13,7 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 192
 		Falloff: 100, 50, 25, 0
-		Damage: 300
+		Damage: 3000
 		Versus:
 			none: 8
 			wall: 75
@@ -51,7 +51,7 @@
 		Speed: 288
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
-		Damage: 480
+		Damage: 4800
 		Versus:
 			none: 15
 			wall: 75
@@ -77,7 +77,7 @@ Rocket:
 		Speed: 352
 	Warhead@1Dam: SpreadDamage
 		Spread: 160
-		Damage: 250
+		Damage: 2500
 		Versus:
 			none: 25
 			wall: 100
@@ -115,7 +115,7 @@ mtank_pri:
 		Inaccuracy: 96
 		RangeLimit: 7c204
 	Warhead@1Dam: SpreadDamage
-		Damage: 600
+		Damage: 6000
 		ValidTargets: Ground, Air
 
 DeviatorMissile:
@@ -130,7 +130,7 @@ DeviatorMissile:
 		TrailPalette: deviatorgas
 		TrailUsePlayerPalette: true
 	Warhead@1Dam: SpreadDamage
-		Damage: 500
+		Damage: 5000
 		Versus:
 			none: 20
 			wall: 20

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -20,10 +20,10 @@ Sound:
 		ValidStances: Neutral, Enemy
 		Versus:
 			none: 200
-			light: 110
-			wood: 110
 			wall: 50
 			building: 60
+			wood: 110
+			light: 110
 			heavy: 60
 			invulnerable: 0
 			cy: 20
@@ -37,10 +37,10 @@ Sound:
 		ValidStances: Ally
 		Versus:
 			none: 200
-			light: 110
-			wood: 110
 			wall: 50
 			building: 60
+			wood: 110
+			light: 110
 			heavy: 60
 			invulnerable: 0
 			cy: 20

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -15,7 +15,7 @@ Sound:
 	Warhead@1Dam: SpreadDamage
 		Range: 0, 32
 		Falloff: 100, 100
-		Damage: 86
+		Damage: 860
 		AffectsParent: false
 		ValidStances: Neutral, Enemy
 		Versus:
@@ -32,7 +32,7 @@ Sound:
 	Warhead@2Dam: SpreadDamage
 		Range: 0, 32
 		Falloff: 100, 100
-		Damage: 43 # Only does half damage to friendly units
+		Damage: 430 # Only does half damage to friendly units
 		AffectsParent: false
 		ValidStances: Ally
 		Versus:
@@ -67,7 +67,7 @@ OrniBomb:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 750 #400 in original, reduce when bombers can do multiple passes
+		Damage: 7500 #400 in original, reduce when bombers can do multiple passes
 		Versus:
 			none: 90
 			wall: 50
@@ -89,7 +89,7 @@ OrniBomb:
 
 Crush:
 	Warhead@1Dam: SpreadDamage
-		Damage: 100
+		Damage: 1000
 		DamageTypes: ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		ImpactSounds: CRUSH1.WAV
@@ -106,7 +106,7 @@ Atomic:
 	Warhead@1Dam: SpreadDamage
 		Spread: 1c0
 		Falloff: 200, 100, 50, 25, 12, 0
-		Damage: 2700	##225 in vanilla but of course is a cluster bomb instead, so damage spread out
+		Damage: 27000	##225 in vanilla but of course is a cluster bomb instead, so damage spread out
 		Versus:
 			none: 90
 			wall: 50
@@ -128,14 +128,14 @@ CrateNuke:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 500
+		Damage: 5000
 		AffectsParent: true
 
 CrateExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 500
+		Damage: 5000
 		Versus:
 			none: 90
 			wall: 5
@@ -195,7 +195,7 @@ grenade:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 65, 35, 20, 0
-		Damage: 150
+		Damage: 1500
 		Versus:
 			none: 125
 			wood: 70
@@ -217,7 +217,7 @@ GrenDeath:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 150
+		Damage: 1500
 		Versus:
 			none: 125
 			wood: 70
@@ -238,7 +238,7 @@ SardDeath:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Falloff: 100, 50, 25, 0
-		Damage: 300
+		Damage: 3000
 		Versus:
 			none: 15
 			wall: 75
@@ -266,7 +266,7 @@ SpiceExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 75
+		Damage: 750
 		Versus:
 			none: 90
 			wall: 5
@@ -293,7 +293,7 @@ BloomExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
 		Falloff: 100, 60, 30, 15, 0
-		Damage: 750
+		Damage: 7500
 		Versus:
 			none: 90
 			wall: 5
@@ -311,7 +311,7 @@ PlasmaExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 2c0
 		Falloff: 100, 37, 0
-		Damage: 2000
+		Damage: 20000
 		Versus:
 			None: 100
 			Wood: 100

--- a/mods/d2k/weapons/smallguns.yaml
+++ b/mods/d2k/weapons/smallguns.yaml
@@ -6,7 +6,7 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Falloff: 100, 50, 25, 0
-		Damage: 125
+		Damage: 1250
 		Versus:
 			wall: 10
 			building: 25
@@ -42,7 +42,7 @@ M_HMG:
 	Report: 20MMGUN1.WAV
 	Warhead@1Dam: SpreadDamage
 		Spread: 192
-		Damage: 250
+		Damage: 2500
 		Versus:
 			none: 25
 			wall: 100
@@ -70,7 +70,7 @@ HMG:
 	Warhead@1Dam: SpreadDamage
 		Spread: 160
 		Falloff: 100, 60, 30, 0
-		Damage: 180
+		Damage: 1800
 
 HMGo:
 	Inherits: HMG


### PR DESCRIPTION
Same changes as #14301 (#14448 related).
Link to issue #11719.

I only adjusted one value. I decided to not adjust any other value because this is not needed. The values in D2K are ten times higher compared to RA and TD. This results in less than 1% difference after the conversion (with some exceptions), whereby in RA and TD the differences could go up to 50%. Luckily, there are not that much different weapons in D2K compared to the other mods, so I can post the values in one screenshot. However, they do have more different armor types.
![d2k](https://user-images.githubusercontent.com/33390659/33440459-51c6cf90-d5f0-11e7-8656-a5cdcf6e7530.png)

The exceptions with more than 1% difference are:
`Debris2` vs wall
`Debris3` vs wall and vs harv
`Sound@1Dam` and `Sound@2Dam`
`Grenade` and `GrenDeath` vs harv
`SpiceExplosion`
`BloomExplosion` vs wall
`^MG` vs wall

I'm not familiar with D2K, but I think the Debris damages, Spice and Bloom explosions are not that common to do a little more damage vs for example a wall. We are talking about less than 1 damage difference after all.

The Grenade and GrenDeath vs harvesters, and the MGs vs the wall the same reasons.

The `Sound@1Dam` and `Sound@2Dam` are adjusted. The differences could go up to more than 1 damage because the weapon has multiple impacts.

Keep in mind, because I decide to not change the values does not mean that I won't change it if desired.

There are some errors in D2K. The concrete armor type is only defined in a couple of weapons. There is only one building with concrete armor, the ~Large Gun Turret~ Rocket Turret. All weapons without the vs concrete trait does 100% damage to concrete. The should probably be changed in a separate PR.

The `PlasmaExplosion` does damage vs invulnerable armor type. This should also be changed in a separate PR.

In the second commit I also changed the DeviatorMissile. It does 100 damage vs everything and 50 damage vs the construction yard, but now written differently.

The upgrade rules will be added in this PR in a separate commit after the upgrade rules for the RA and TD mod are merged.