### PR TITLE
AI AttackOrFleeFuzzy improvements

### DIFF
--- a/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
+++ b/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
@@ -66,8 +66,8 @@ namespace OpenRA.Mods.Common.AI
 		static readonly string[] DefaultRulesNearDeadOwnHealth = new[]
 		{
 			"if ((OwnHealth is NearDead) " +
-			"and (EnemyHealth is Injured) " +
-			"and (RelativeAttackPower is Equal) " +
+			"and ((EnemyHealth is NearDead) or (EnemyHealth is Injured)) " +
+			"and ((RelativeAttackPower is Equal) or (RelativeAttackPower is Strong)) " +
 			"and ((RelativeSpeed is Slow) or (RelativeSpeed is Equal))) " +
 			"then AttackOrFlee is Attack",
 

--- a/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
+++ b/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
@@ -221,8 +221,8 @@ namespace OpenRA.Mods.Common.AI
 				var arms = a.TraitsImplementing<Armament>();
 				foreach (var arm in arms)
 				{
-					var warhead = arm.Weapon.Warheads.OfType<DamageWarhead>().FirstOrDefault();
-					if (warhead != null)
+					var damageWarheads = arm.Weapon.Warheads.OfType<DamageWarhead>();
+					foreach (var warhead in damageWarheads)
 						sumOfDamage += warhead.Damage;
 				}
 

--- a/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
+++ b/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
@@ -221,9 +221,16 @@ namespace OpenRA.Mods.Common.AI
 				var arms = a.TraitsImplementing<Armament>();
 				foreach (var arm in arms)
 				{
+					var burst = arm.Weapon.Burst;
+
+					// For simplicity's sake, we're only factoring in the first burst delay, as more than one burst delay is extremely rare.
+					// Additionally, clamping total delay to minimum of 1 (ReloadDelay: 0 is technically possible) and maximum of 200.
+					// High dmg/low ROF weapons shouldn't be rated too low as high dmg/shot can outweigh mere dps due to likelier 1-hit-kills.
+					// TODO: Revisit this at some point to replace the arbitrary cap with something smarter.
+					var totalReloadDelay = arm.Weapon.ReloadDelay + (arm.Weapon.BurstDelays[0] * (burst - 1)).Clamp(1, 200);
 					var damageWarheads = arm.Weapon.Warheads.OfType<DamageWarhead>();
 					foreach (var warhead in damageWarheads)
-						sumOfDamage += warhead.Damage;
+						sumOfDamage += (warhead.Damage * burst / totalReloadDelay) * 100;
 				}
 
 				return sumOfDamage;

--- a/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
+++ b/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
@@ -72,13 +72,7 @@ namespace OpenRA.Mods.Common.AI
 			"then AttackOrFlee is Attack",
 
 			"if ((OwnHealth is NearDead) " +
-			"and (EnemyHealth is NearDead) " +
-			"and (RelativeAttackPower is Weak) " +
-			"and ((RelativeSpeed is Equal) or (RelativeSpeed is Fast))) " +
-			"then AttackOrFlee is Flee",
-
-			"if ((OwnHealth is NearDead) " +
-			"and (EnemyHealth is Injured) " +
+			"and ((EnemyHealth is NearDead) or (EnemyHealth is Injured)) " +
 			"and (RelativeAttackPower is Weak) " +
 			"and ((RelativeSpeed is Equal) or (RelativeSpeed is Fast))) " +
 			"then AttackOrFlee is Flee",
@@ -91,13 +85,7 @@ namespace OpenRA.Mods.Common.AI
 
 			"if (OwnHealth is NearDead) " +
 			"and (EnemyHealth is Normal) " +
-			"and (RelativeAttackPower is Equal) " +
-			"and (RelativeSpeed is Fast) " +
-			"then AttackOrFlee is Flee",
-
-			"if (OwnHealth is NearDead) " +
-			"and (EnemyHealth is Normal) " +
-			"and (RelativeAttackPower is Strong) " +
+			"and ((RelativeAttackPower is Equal) or (RelativeAttackPower is Strong)) " +
 			"and (RelativeSpeed is Fast) " +
 			"then AttackOrFlee is Flee",
 


### PR DESCRIPTION
I needed a break from the other stuff I'm working on, so I gave this a look.

The idea behind the string shortenings is the assumption that the FuzzyLibrary must be doing *some* kind of string comparison, so shorter strings should speed things up a little (likely insignificant, but who knows...).

The other commits should, at least in theory, make the AI behave a little smarter when making attack-or-flee decisions.