### PR TITLE
RA Balance changes (December 2017)

### DIFF
--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -94,7 +94,7 @@ MIG:
 	Tooltip:
 		Name: MiG Attack Plane
 	Health:
-		HP: 70
+		HP: 75
 	Armor:
 		Type: Light
 	RevealsShroud:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -744,7 +744,7 @@
 		HP: 100
 	Explodes:
 		Weapon: Demolish
-		DamageThreshold: 90
+		DamageThreshold: 70
 	RevealsShroud:
 		Range: 4c0
 	WithDecoration@fake:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -118,7 +118,7 @@ E2:
 		DefaultAttackSequence: throw
 	Explodes:
 		Weapon: UnitExplodeSmall
-		Chance: 50
+		EmptyWeapon: UnitExplodeSmall
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded
 

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -19,7 +19,7 @@ SS:
 		TurnSpeed: 4
 		Speed: 71
 	RevealsShroud:
-		Range: 6c0
+		Range: 8c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 5c0

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -647,7 +647,7 @@ PBOX:
 	RenderRangeCircle:
 		FallbackRange: 6c0
 	Power:
-		Amount: -15
+		Amount: -20
 	DetectCloaked:
 		Range: 6c0
 
@@ -704,7 +704,7 @@ HBOX:
 		PortYaws: 0, 176, 341, 512, 682, 853
 		PortCones: 88, 88, 88, 88, 88, 88
 	Power:
-		Amount: -15
+		Amount: -20
 	-MustBeDestroyed:
 
 GUN:

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -30,7 +30,7 @@
 
 25mm:
 	Inherits: ^Cannon
-	ReloadDelay: 22
+	ReloadDelay: 21
 	Range: 4c0
 	Report: cannon2.aud
 	Projectile: Bullet
@@ -39,7 +39,7 @@
 	Warhead@1Dam: SpreadDamage
 		Damage: 27
 		Versus:
-			Wood: 40
+			Wood: 50
 			Light: 110
 			Heavy: 45
 			Concrete: 30
@@ -113,7 +113,7 @@ TurretGun:
 
 155mm:
 	Inherits: ^Artillery
-	MinRange: 3c0
+	MinRange: 5c0
 	Report: tank5.aud
 	TargetActorCenter: true
 	Projectile: Bullet
@@ -123,12 +123,12 @@ TurretGun:
 	Inherits: ^Artillery
 	MinRange: 3c0
 	ReloadDelay: 250
-	Range: 16c0
+	Range: 20c0
 	Burst: 2
 	Report: turret1.aud
 	TargetActorCenter: true
 	Projectile: Bullet
-		Inaccuracy: 2c938
+		Inaccuracy: 1c938
 		ContrailLength: 30
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
@@ -185,7 +185,7 @@ DepthCharge:
 	Range: 5c0
 	ValidTargets: Underwater
 	Projectile: Bullet
-		Speed: 85
+		Speed: 125
 		Image: BOMB
 		Inaccuracy: 128
 	Warhead@1Dam: SpreadDamage

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -62,6 +62,7 @@ Maverick:
 			None: 30
 			Wood: 90
 			Light: 90
+			Heavy: 115
 			Concrete: 100
 
 Dragon:
@@ -292,14 +293,14 @@ TorpTube:
 
 SubMissile:
 	Inherits: ^SubMissileDefault
-	Range: 16c0
+	Range: 20c0
 	TargetActorCenter: true
 	-Projectile:
 	Projectile: Bullet
 		Speed: 162
 		Blockable: false
 		LaunchAngle: 120
-		Inaccuracy: 2c938
+		Inaccuracy: 0c614
 		Image: MISSILE
 		Shadow: True
 		TrailImage: smokey
@@ -315,7 +316,7 @@ SCUD:
 	Inherits: ^AntiGroundMissile
 	ReloadDelay: 0
 	Range: 10c0
-	MinRange: 3c0
+	MinRange: 5c0
 	Report: missile1.aud
 	-Projectile:
 	Projectile: Bullet


### PR DESCRIPTION
**Light Tank damage vs wood increased by 10%. Reload delay reduced from 22 to 21.**
The goal here is to allow the light tank to fill a raider role, meaning with the extra damage, teams of light tanks will be more effective at picking off buildings and harvesters away from the enemy army. 

**Minimum range of Artillery and V2 Rocket Launcher increased by 2 cells (5c0).** 
The general counter to siege weapons in RTS games is to quickly close the distance and destroy them from point blank range. The low minimum distance in this game hurts that conventional wisdom, and the fast moving units like flak trucks and light tanks are often one-shotted by the units they are supposed to counter. Extra minimum range will make closing on siege weapons more viable and rewarding.

**Grenadier explosion changed to small explosion. Explode chance now 100%.**
The grenadier explosion is comically large, and leads several players to not use gren play because of the shutdown potential. A concern was that removing the chain explosion might make grens too hard to stop early, but testing has revealed that to not be the case.

**Pillbox and Camo Pillbox use 20 power, up from 15.**
Static defense spam remains a concern for general gameplay. This is a small change aimed at bringing late game pillboxes in line with flame towers in terms of how many a player is able to build.

**Fake Building DamageThreshold changed to 70% from 90%.**
Fake buildings can currently be destroyed by getting breathed on. This improves their ability to distract an opponent.

**MIG damage vs Heavy increased by 15%.  HP Increased to 75 from 70.**
MIGs are rare in competitive play. The damage increase is targeted at their primary role of tank-buster. The extra bit of health should allow for one more hit from rockets and flak. 

**Cruiser and Missile Sub range increased from 16c0 to 20c0. Cruiser inaccuracy decreased from 2c938 to 1c938. Missile Sub inaccuracy decreased from 2c938 to 0c614**
The naval siege units aren't performing up to their price tag. Improving their ability to actually hit targets is a first step in making them desirable to build. 

**Depth Charge speed increased from 85 to 125**
This is as much of a polish fix as it is a balance change. Gun boats currently look like they are hitting themselves with depth charges while chasing subs. 

**Submarine vision increased by 2 (8c0)**
Submarines don't have that much more vision than Gunboats or Destroyers have detection range. This allows for some stalk-and-ambush play with Subs.