### PR TITLE
Add a screen map visualization overlay

### DIFF
--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -212,6 +212,13 @@ namespace OpenRA.Graphics
 						r.RenderDebugGeometry(this);
 			}
 
+			if (debugVis.Value != null && debugVis.Value.ScreenMap)
+				foreach (var r in World.ScreenMap.ItemBounds(World.RenderPlayer))
+					Game.Renderer.WorldRgbaColorRenderer.DrawRect(
+						new float3(r.Left, r.Top, r.Bottom),
+						new float3(r.Right, r.Bottom, r.Bottom),
+						1 / Viewport.Zoom, Color.MediumSpringGreen);
+
 			Game.Renderer.Flush();
 		}
 

--- a/OpenRA.Game/Primitives/SpatiallyPartitioned.cs
+++ b/OpenRA.Game/Primitives/SpatiallyPartitioned.cs
@@ -133,5 +133,7 @@ namespace OpenRA.Primitives
 					}
 				}
 		}
+
+		public IEnumerable<Rectangle> ItemBounds { get { return itemBounds.Values; } }
 	}
 }

--- a/OpenRA.Game/Traits/World/DebugVisualizations.cs
+++ b/OpenRA.Game/Traits/World/DebugVisualizations.cs
@@ -18,6 +18,7 @@ namespace OpenRA.Traits
 	{
 		public bool CombatGeometry;
 		public bool RenderGeometry;
+		public bool ScreenMap;
 		public bool DepthBuffer;
 		public bool ActorTags;
 	}

--- a/OpenRA.Game/Traits/World/ScreenMap.cs
+++ b/OpenRA.Game/Traits/World/ScreenMap.cs
@@ -188,5 +188,13 @@ namespace OpenRA.Traits
 				return NoFrozenActors;
 			return partitionedFrozenActors[p].InBox(r).Where(frozenActorIsValid);
 		}
+
+		public IEnumerable<Rectangle> ItemBounds(Player viewer)
+		{
+			var bounds = partitionedActors.ItemBounds
+				.Concat(partitionedEffects.ItemBounds);
+
+			return viewer != null ? bounds.Concat(partitionedFrozenActors[viewer].ItemBounds) : bounds;
+		}
 	}
 }

--- a/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
@@ -11,6 +11,7 @@
 
 using System;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Commands
@@ -21,11 +22,15 @@ namespace OpenRA.Mods.Common.Commands
 	public class DebugVisualizationCommands : IChatCommand, IWorldLoaded
 	{
 		DebugVisualizations debugVis;
+		DeveloperMode devMode;
 
 		public void WorldLoaded(World w, WorldRenderer wr)
 		{
 			var world = w;
 			debugVis = world.WorldActor.TraitOrDefault<DebugVisualizations>();
+
+			if (world.LocalPlayer != null)
+				devMode = world.LocalPlayer.PlayerActor.Trait<DeveloperMode>();
 
 			if (debugVis == null)
 				return;
@@ -41,6 +46,7 @@ namespace OpenRA.Mods.Common.Commands
 
 			register("showcombatgeometry", "toggles combat geometry overlay.");
 			register("showrendergeometry", "toggles render geometry overlay.");
+			register("showscreenmap", "toggles screen map overlay.");
 			register("showdepthbuffer", "toggles depth buffer overlay.");
 			register("showactortags", "toggles actor tags overlay.");
 		}
@@ -55,6 +61,11 @@ namespace OpenRA.Mods.Common.Commands
 
 				case "showrendergeometry":
 					debugVis.RenderGeometry ^= true;
+					break;
+
+				case "showscreenmap":
+					if (devMode == null || devMode.Enabled)
+						debugVis.ScreenMap ^= true;
 					break;
 
 				case "showdepthbuffer":

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/DebugMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/DebugMenuLogic.cs
@@ -77,6 +77,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				showGeometryCheckbox.OnClick = () => debugVis.RenderGeometry ^= true;
 			}
 
+			var showScreenMapCheckbox = widget.GetOrNull<CheckboxWidget>("SHOW_SCREENMAP");
+			if (showScreenMapCheckbox != null)
+			{
+				showScreenMapCheckbox.Disabled = debugVis == null;
+				showScreenMapCheckbox.IsChecked = () => debugVis != null && debugVis.ScreenMap;
+				showScreenMapCheckbox.OnClick = () => debugVis.ScreenMap ^= true;
+			}
+
 			var terrainGeometryTrait = world.WorldActor.Trait<TerrainGeometryOverlay>();
 			var showTerrainGeometryCheckbox = widget.GetOrNull<CheckboxWidget>("SHOW_TERRAIN_OVERLAY");
 			if (showTerrainGeometryCheckbox != null && terrainGeometryTrait != null)

--- a/mods/cnc/chrome/ingame-debug.yaml
+++ b/mods/cnc/chrome/ingame-debug.yaml
@@ -3,10 +3,10 @@ Container@DEBUG_PANEL:
 	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM
 	Children:
-		Label@CHEATS_TITLE:
+		Label@TITLE:
 			Y: 25
 			Font: Bold
-			Text: Cheats
+			Text: Debug Options
 			Align: Center
 			Width: PARENT_RIGHT
 		Checkbox@INSTANT_BUILD:
@@ -95,6 +95,13 @@ Container@DEBUG_PANEL:
 			Width: 200
 			Font: Regular
 			Text: Show Custom Terrain
+		Checkbox@SHOW_ACTOR_TAGS:
+			X: 45
+			Y: 335
+			Height: 20
+			Width: 200
+			Font: Regular
+			Text: Show Actor Tags
 		Checkbox@SHOW_COMBATOVERLAY:
 			X: 290
 			Y: 275
@@ -116,10 +123,3 @@ Container@DEBUG_PANEL:
 			Width: 200
 			Font: Regular
 			Text: Show Terrain Geometry
-		Checkbox@SHOW_ACTOR_TAGS:
-			X: 45
-			Y: 335
-			Height: 20
-			Width: 200
-			Font: Regular
-			Text: Show Actor Tags

--- a/mods/cnc/chrome/ingame-debug.yaml
+++ b/mods/cnc/chrome/ingame-debug.yaml
@@ -123,3 +123,10 @@ Container@DEBUG_PANEL:
 			Width: 200
 			Font: Regular
 			Text: Show Terrain Geometry
+		Checkbox@SHOW_SCREENMAP:
+			X: 290
+			Y: 365
+			Height: 20
+			Width: 200
+			Font: Regular
+			Text: Show Screen Map

--- a/mods/common/chrome/ingame-debug.yaml
+++ b/mods/common/chrome/ingame-debug.yaml
@@ -4,7 +4,7 @@ Container@DEBUG_PANEL:
 	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM
 	Children:
-		Label@LABLE_TITLE:
+		Label@TITLE:
 			Y: 25
 			Font: Bold
 			Text: Debug Options
@@ -100,6 +100,13 @@ Container@DEBUG_PANEL:
 			Width: 200
 			Font: Regular
 			Text: Show Custom Terrain
+		Checkbox@SHOW_ACTOR_TAGS:
+			X: 45
+			Y: 335
+			Height: 20
+			Width: 200
+			Font: Regular
+			Text: Show Actor Tags
 		Checkbox@SHOW_COMBATOVERLAY:
 			X: 290
 			Y: 275
@@ -121,10 +128,3 @@ Container@DEBUG_PANEL:
 			Width: 200
 			Font: Regular
 			Text: Show Terrain Geometry
-		Checkbox@SHOW_ACTOR_TAGS:
-			X: 45
-			Y: 335
-			Height: 20
-			Width: 200
-			Font: Regular
-			Text: Show Actor Tags

--- a/mods/common/chrome/ingame-debug.yaml
+++ b/mods/common/chrome/ingame-debug.yaml
@@ -128,3 +128,10 @@ Container@DEBUG_PANEL:
 			Width: 200
 			Font: Regular
 			Text: Show Terrain Geometry
+		Checkbox@SHOW_SCREENMAP:
+			X: 290
+			Y: 365
+			Height: 20
+			Width: 200
+			Font: Regular
+			Text: Show Screen Map

--- a/mods/ts/chrome/ingame-debug.yaml
+++ b/mods/ts/chrome/ingame-debug.yaml
@@ -135,3 +135,10 @@ Container@DEBUG_PANEL:
 			Width: 200
 			Font: Regular
 			Text: Show Terrain Geometry
+		Checkbox@SHOW_SCREENMAP:
+			X: 290
+			Y: 365
+			Height: 20
+			Width: 200
+			Font: Regular
+			Text: Show Screen Map

--- a/mods/ts/chrome/ingame-debug.yaml
+++ b/mods/ts/chrome/ingame-debug.yaml
@@ -4,7 +4,7 @@ Container@DEBUG_PANEL:
 	Width: PARENT_RIGHT
 	Height: PARENT_BOTTOM
 	Children:
-		Label@LABLE_TITLE:
+		Label@TITLE:
 			Y: 25
 			Font: Bold
 			Text: Debug Options
@@ -51,7 +51,7 @@ Container@DEBUG_PANEL:
 			Height: 20
 			Width: 200
 			Font: Regular
-			Text: Disable visibility checks
+			Text: Disable Visibility Checks
 		Button@GIVE_CASH:
 			X: 90
 			Y: 150
@@ -100,9 +100,16 @@ Container@DEBUG_PANEL:
 			Width: 200
 			Font: Regular
 			Text: Show Custom Terrain
-		Checkbox@SHOW_DEPTH_PREVIEW:
+		Checkbox@SHOW_ACTOR_TAGS:
 			X: 45
 			Y: 335
+			Height: 20
+			Width: 200
+			Font: Regular
+			Text: Show Actor Tags
+		Checkbox@SHOW_DEPTH_PREVIEW:
+			X: 45
+			Y: 365
 			Height: 20
 			Width: 200
 			Font: Regular
@@ -128,10 +135,3 @@ Container@DEBUG_PANEL:
 			Width: 200
 			Font: Regular
 			Text: Show Terrain Geometry
-		Checkbox@SHOW_ACTOR_TAGS:
-			X: 45
-			Y: 365
-			Height: 20
-			Width: 200
-			Font: Regular
-			Text: Show Actor Tags


### PR DESCRIPTION
This makes it easy to see and test the various issues with screen map rectangles (especially in TS), and will significantly simplify testing of the ScreenMap rewrite PR.