### PR TITLE
Pull request for allowing /givecash commands to accept floats

### DIFF
--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -72,10 +72,10 @@ namespace OpenRA.Mods.Common.Commands
 				case "givecash":
 					var givecashorder = new Order("DevGiveCash", world.LocalPlayer.PlayerActor, false);
 					int cash;
-                    float fcash;
+					float fcash;
 
-                    float.TryParse(arg, out fcash);
-                    cash = (int)fcash;
+					float.TryParse(arg, out fcash);
+					cash = (int) fcash;
 
 					givecashorder.ExtraData = (uint)cash;
 					Game.Debug("Giving {0} credits to player {1}.", cash == 0 ? "cheat default" : cash.ToString(CultureInfo.InvariantCulture), world.LocalPlayer.PlayerName);
@@ -84,10 +84,10 @@ namespace OpenRA.Mods.Common.Commands
 					break;
 
 				case "givecashall":
-                    float.TryParse(arg, out fcash);
-                    cash = (int)fcash;
+					float.TryParse(arg, out fcash);
+					cash = (int) fcash;
 
-                    foreach (var player in world.Players.Where(p => !p.NonCombatant))
+					foreach (var player in world.Players.Where(p => !p.NonCombatant))
 					{
 						var givecashall = new Order("DevGiveCash", player.PlayerActor, false);
 						givecashall.ExtraData = (uint)cash;

--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -72,7 +72,10 @@ namespace OpenRA.Mods.Common.Commands
 				case "givecash":
 					var givecashorder = new Order("DevGiveCash", world.LocalPlayer.PlayerActor, false);
 					int cash;
-					int.TryParse(arg, out cash);
+                    float fcash;
+
+                    float.TryParse(arg, out fcash);
+                    cash = (int)fcash;
 
 					givecashorder.ExtraData = (uint)cash;
 					Game.Debug("Giving {0} credits to player {1}.", cash == 0 ? "cheat default" : cash.ToString(CultureInfo.InvariantCulture), world.LocalPlayer.PlayerName);
@@ -81,9 +84,10 @@ namespace OpenRA.Mods.Common.Commands
 					break;
 
 				case "givecashall":
-					int.TryParse(arg, out cash);
+                    float.TryParse(arg, out fcash);
+                    cash = (int)fcash;
 
-					foreach (var player in world.Players.Where(p => !p.NonCombatant))
+                    foreach (var player in world.Players.Where(p => !p.NonCombatant))
 					{
 						var givecashall = new Order("DevGiveCash", player.PlayerActor, false);
 						givecashall.ExtraData = (uint)cash;

--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -71,11 +71,9 @@ namespace OpenRA.Mods.Common.Commands
 			{
 				case "givecash":
 					var givecashorder = new Order("DevGiveCash", world.LocalPlayer.PlayerActor, false);
-					int cash;
-					float fcash;
-
-					float.TryParse(arg, out fcash);
-					cash = (int) fcash;
+					float cash;
+					
+					float.TryParse(arg, out cash);
 
 					givecashorder.ExtraData = (uint)cash;
 					Game.Debug("Giving {0} credits to player {1}.", cash == 0 ? "cheat default" : cash.ToString(CultureInfo.InvariantCulture), world.LocalPlayer.PlayerName);
@@ -84,9 +82,8 @@ namespace OpenRA.Mods.Common.Commands
 					break;
 
 				case "givecashall":
-					float.TryParse(arg, out fcash);
-					cash = (int) fcash;
-
+					float.TryParse(arg, out cash);
+					
 					foreach (var player in world.Players.Where(p => !p.NonCombatant))
 					{
 						var givecashall = new Order("DevGiveCash", player.PlayerActor, false);


### PR DESCRIPTION
Changed int.TryParse to float.TryParse to allow floating point numbers to be given to /givecash commands, and casts the float to an integer (not truncation).