### PR TITLE
Account for visibility when selecting AI superweapon targets.

### DIFF
--- a/OpenRA.Game/Map/CellRegion.cs
+++ b/OpenRA.Game/Map/CellRegion.cs
@@ -40,6 +40,16 @@ namespace OpenRA
 			mapBottomRight = BottomRight.ToMPos(gridType);
 		}
 
+		public CellRegion(MapGridType gridType, MPos topLeft, MPos bottomRight)
+		{
+			this.gridType = gridType;
+			mapTopLeft = topLeft;
+			mapBottomRight = bottomRight;
+
+			TopLeft = topLeft.ToCPos(gridType);
+			BottomRight = bottomRight.ToCPos(gridType);
+		}
+
 		/// <summary>Expand the specified region with an additional cordon. This may expand the region outside the map borders.</summary>
 		public static CellRegion Expand(CellRegion region, int cordon)
 		{

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -31,11 +31,11 @@ namespace OpenRA.Traits
 	{
 		public readonly PPos[] Footprint;
 		public readonly WPos CenterPosition;
-		public readonly HashSet<string> TargetTypes;
 		readonly Actor actor;
 		readonly Shroud shroud;
 
 		public Player Owner { get; private set; }
+		public HashSet<string> TargetTypes { get; private set; }
 
 		public ITooltipInfo TooltipInfo { get; private set; }
 		public Player TooltipOwner { get; private set; }
@@ -82,7 +82,7 @@ namespace OpenRA.Traits
 					footprint.Select(p => shroud.Contains(p).ToString()).JoinWith("|")));
 
 			CenterPosition = self.CenterPosition;
-			TargetTypes = self.GetEnabledTargetTypes().ToHashSet();
+			TargetTypes = new HashSet<string>();
 
 			tooltips = self.TraitsImplementing<ITooltip>().ToArray();
 			health = self.TraitOrDefault<IHealth>();
@@ -98,6 +98,7 @@ namespace OpenRA.Traits
 		public void RefreshState()
 		{
 			Owner = actor.Owner;
+			TargetTypes = actor.GetEnabledTargetTypes().ToHashSet();
 
 			if (health != null)
 			{

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -182,6 +182,7 @@ namespace OpenRA.Traits
 		readonly SpatiallyPartitioned<uint> partitionedFrozenActorIds;
 		readonly bool[] dirtyBins;
 		readonly HashSet<uint> dirtyFrozenActorIds = new HashSet<uint>();
+		readonly int rows, cols;
 
 		public FrozenActorLayer(Actor self, FrozenActorLayerInfo info)
 		{
@@ -195,16 +196,17 @@ namespace OpenRA.Traits
 			// expensive visibility update for frozen actors in these regions.
 			partitionedFrozenActorIds = new SpatiallyPartitioned<uint>(
 				world.Map.MapSize.X, world.Map.MapSize.Y, binSize);
-			var maxX = world.Map.MapSize.X / binSize + 1;
-			var maxY = world.Map.MapSize.Y / binSize + 1;
-			dirtyBins = new bool[maxX * maxY];
+
+			cols = world.Map.MapSize.X / binSize + 1;
+			rows = world.Map.MapSize.Y / binSize + 1;
+			dirtyBins = new bool[cols * rows];
 			self.Trait<Shroud>().CellsChanged += cells =>
 			{
 				foreach (var cell in cells)
 				{
 					var x = cell.U / binSize;
 					var y = cell.V / binSize;
-					dirtyBins[y * maxX + x] = true;
+					dirtyBins[y * cols + x] = true;
 				}
 			};
 		}
@@ -281,14 +283,13 @@ namespace OpenRA.Traits
 		{
 			// Check which bins on the map were dirtied due to changes in the shroud and gather the frozen actors whose
 			// footprint overlap with these bins.
-			var maxX = world.Map.MapSize.X / binSize + 1;
-			var maxY = world.Map.MapSize.Y / binSize + 1;
-			for (var y = 0; y < maxY; y++)
+			for (var y = 0; y < rows; y++)
 			{
-				for (var x = 0; x < maxX; x++)
+				for (var x = 0; x < cols; x++)
 				{
-					if (!dirtyBins[y * maxX + x])
+					if (!dirtyBins[y * cols + x])
 						continue;
+
 					var box = new Rectangle(x * binSize, y * binSize, binSize, binSize);
 					dirtyFrozenActorIds.UnionWith(partitionedFrozenActorIds.InBox(box));
 				}
@@ -317,6 +318,13 @@ namespace OpenRA.Traits
 				return null;
 
 			return fa;
+		}
+
+		public IEnumerable<FrozenActor> FrozenActorsInRegion(CellRegion region)
+		{
+			var tl = region.TopLeft;
+			var br = region.BottomRight;
+			return partitionedFrozenActorIds.InBox(Rectangle.FromLTRB(tl.X, tl.Y, br.X, br.Y)).Select(FromID);
 		}
 	}
 }

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -75,13 +75,19 @@ Player:
 			Consideration@1:
 				Against: Enemy
 				Types: Vehicle, Infantry
-				Attractiveness: 1
+				Attractiveness: 3
 				TargetMetric: Value
 				CheckRadius: 2c0
 			Consideration@2:
 				Against: Ally
 				Types: Ground, Water
-				Attractiveness: -10
+				Attractiveness: -20
+				TargetMetric: Value
+				CheckRadius: 2c0
+			Consideration@3:
+				Against: Enemy
+				Types: Structure
+				Attractiveness: 1
 				TargetMetric: Value
 				CheckRadius: 2c0
 		SupportPowerDecision@IonCannonPower:
@@ -197,13 +203,19 @@ Player:
 			Consideration@1:
 				Against: Enemy
 				Types: Vehicle, Infantry
-				Attractiveness: 1
+				Attractiveness: 3
 				TargetMetric: Value
 				CheckRadius: 2c0
 			Consideration@2:
 				Against: Ally
 				Types: Ground, Water
-				Attractiveness: -10
+				Attractiveness: -20
+				TargetMetric: Value
+				CheckRadius: 2c0
+			Consideration@3:
+				Against: Enemy
+				Types: Structure
+				Attractiveness: 1
 				TargetMetric: Value
 				CheckRadius: 2c0
 		SupportPowerDecision@IonCannonPower:
@@ -321,13 +333,19 @@ Player:
 			Consideration@1:
 				Against: Enemy
 				Types: Vehicle, Infantry
-				Attractiveness: 1
+				Attractiveness: 3
 				TargetMetric: Value
 				CheckRadius: 2c0
 			Consideration@2:
 				Against: Ally
 				Types: Ground, Water
-				Attractiveness: -10
+				Attractiveness: -20
+				TargetMetric: Value
+				CheckRadius: 2c0
+			Consideration@3:
+				Against: Enemy
+				Types: Structure
+				Attractiveness: 1
 				TargetMetric: Value
 				CheckRadius: 2c0
 		SupportPowerDecision@IonCannonPower:


### PR DESCRIPTION
This fixes the single biggest complaint from casual players – that the TD airstrike always knows exactly the best target to hit.  This also helps make the AI feel more like a real player, as it will fire the weapons where it *think* the enemy base is, which may no longer be accurate.

I have tested and tweaked TD's AI, but RA and D2K will need to be tested during review.

Adding to the milestone because this gives us a very nice user-facing feature to talk about in the news post.

Closes #7659.