### PR TITLE
Help button to display commands for new players

### DIFF
--- a/HELP
+++ b/HELP
@@ -1,0 +1,101 @@
+HOTKEYS
+
+Note: Many of these commands can be configured in the Input Tab of the Settings menu.
+
+
+MENU COMMANDS
+
+
+GENERAL
+
+Take a screenshot											   		  Ctrl + P
+
+
+
+IN GAME
+
+Menu																              Esc
+
+Mute audio																	  M
+
+
+
+SELECTION COMMANDS
+
+Select a unit																	Click
+
+Add a unit to selection												    Shift + Click
+
+Select a group of units												    Click and drag a box around the desired units
+
+Select highest priority units on screen							Q
+
+Select highest priority units on map								Double-click Q
+
+Show all health bars														,
+
+Toggle pixel 																	.
+
+
+
+
+MOVE AND ATTACK COMMANDS
+
+
+Move units or attack targets														Right Click
+
+Attack move																				 A + Right Click
+
+Assault move																			   Ctrl + A + Right Click
+
+Force fire																					 Ctrl + Right Click
+
+Force move																				 Alt + Right Click
+
+Stop units																				     S
+
+Guard unit																				    D + Right Click
+
+Hold position																			    V
+
+Deploy/return to base																  F
+
+Scartter units																			   Ctrl + X
+
+Hold fire stance																		   Alt + F
+
+Return fire stance																	    Alt + D
+
+Defend stance																			 Alt + S
+
+Attack anything stance															    Alt + A
+
+
+
+
+PRODUCTION AND SIDEBAR COMMANDS
+
+
+Pause the game																		  Pause
+
+Sell mode																					 Z
+
+Power mode																				 X
+
+Repair mode																			    C
+
+Place beacon																			   B
+
+Structure tab																				E
+
+Defense tab																				 R
+
+Infantry tab																				   T
+
+Vehicle tab																				   Y
+
+Aircraft tab																				   U
+
+Naval tab (ra only)																		I
+
+Cancel all units of type																 Ctrl + Scroll Button + Click Icon

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -597,6 +597,7 @@
     <Compile Include="Widgets\Logic\ColorPickerLogic.cs" />
     <Compile Include="Widgets\Logic\ConnectionLogic.cs" />
     <Compile Include="Widgets\Logic\CreditsLogic.cs" />
+    <Compile Include="Widgets\Logic\HelpLogic.cs" />
     <Compile Include="Widgets\Logic\DisconnectWatcherLogic.cs" />
     <Compile Include="Widgets\Logic\Ingame\AddFactionSuffixLogic.cs" />
     <Compile Include="Widgets\Logic\Ingame\ClassicProductionLogic.cs" />

--- a/OpenRA.Mods.Common/Widgets/Logic/HelpLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/HelpLogic.cs
@@ -1,0 +1,34 @@
+using System;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+	public class HelpLogic : ChromeLogic
+	{
+		[ObjectCreator.UseCtor]
+		public HelpLogic(Widget widget, ModData modData, Action onExit)
+		{
+			var panel = widget.Get("HELP_PANEL");
+
+			panel.Get<ButtonWidget>("BACK_BUTTON").OnClick = () =>
+			{
+				Ui.CloseWindow();
+				onExit();
+			};
+
+			var scrollPanel = panel.Get<ScrollPanelWidget>("HELP_DISPLAY");
+			var template = scrollPanel.Get<LabelWidget>("HELP_TEMPLATE");
+			scrollPanel.RemoveChildren();
+
+			var lines = modData.DefaultFileSystem.Open("HELP").ReadAllLines();
+			foreach (var l in lines)
+			{
+				// Improve the formatting
+				var line = l.Replace("\t", "    ").Replace("*", "\u2022");
+				var label = template.Clone() as LabelWidget;
+				label.GetText = () => line;
+				scrollPanel.AddChild(label);
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -136,7 +136,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			singleplayerMenu.Get<ButtonWidget>("SKIRMISH_BUTTON").OnClick = StartSkirmishGame;
 
-			singleplayerMenu.Get<ButtonWidget>("BACK_BUTTON").OnClick = () => SwitchMenu(MenuType.Main);
+            singleplayerMenu.Get<ButtonWidget>("HELP_BUTTON").OnClick = () =>
+            {
+                SwitchMenu(MenuType.None);
+                Ui.OpenWindow("HELP_PANEL", new WidgetArgs
+                {
+                    { "onExit", () => SwitchMenu(MenuType.Singleplayer) },
+                });
+            };
+
+            singleplayerMenu.Get<ButtonWidget>("BACK_BUTTON").OnClick = () => SwitchMenu(MenuType.Main);
 
 			// Extras menu
 			var extrasMenu = widget.Get("EXTRAS_MENU");

--- a/mods/cnc/chrome/help.yaml
+++ b/mods/cnc/chrome/help.yaml
@@ -1,0 +1,33 @@
+Background@HELP_PANEL:
+	Logic: HelpLogic
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - 600) / 2
+	Width: 800
+	Height: 600
+	Children:
+		Label@HELP_TITLE:
+			Width: PARENT_RIGHT
+			Y: 15
+			Height: 30
+			Font: Bold
+			Align: Center
+			Text: COMMANDS
+		ScrollPanel@HELP_DISPLAY:
+			X: 15
+			Y: 50
+			Width: PARENT_RIGHT - 30
+			Height: 490
+			TopBottomSpacing: 15
+			Children:
+				Label@HELP_TEMPLATE:
+					X: 50
+					Height: 16
+					VAlign: Top
+		Button@BACK_BUTTON:
+			X: PARENT_RIGHT - 180
+			Y: PARENT_BOTTOM - 45
+			Width: 160
+			Height: 25
+			Text: Back
+			Font: Bold
+			Key: escape

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -119,6 +119,7 @@ ChromeLayout:
 	cnc|chrome/music.yaml
 	cnc|chrome/settings.yaml
 	cnc|chrome/credits.yaml
+	cnc|chrome/help.yaml
 	cnc|chrome/dialogs.yaml
 	cnc|chrome/tooltips.yaml
 	cnc|chrome/assetbrowser.yaml

--- a/mods/common/chrome/help.yaml
+++ b/mods/common/chrome/help.yaml
@@ -1,0 +1,33 @@
+Background@HELP_PANEL:
+	Logic: HelpLogic
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - 600) / 2
+	Width: 800
+	Height: 600
+	Children:
+		Label@HELP_TITLE:
+			Width: PARENT_RIGHT
+			Y: 15
+			Height: 30
+			Font: Bold
+			Align: Center
+			Text: COMMANDS
+		ScrollPanel@HELP_DISPLAY:
+			X: 15
+			Y: 50
+			Width: PARENT_RIGHT - 30
+			Height: 490
+			TopBottomSpacing: 15
+			Children:
+				Label@HELP_TEMPLATE:
+					X: 50
+					Height: 16
+					VAlign: Top
+		Button@BACK_BUTTON:
+			X: PARENT_RIGHT - 180
+			Y: PARENT_BOTTOM - 45
+			Width: 160
+			Height: 25
+			Text: Back
+			Font: Bold
+			Key: escape

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -82,6 +82,7 @@ ChromeLayout:
 	d2k|chrome/mainmenu.yaml
 	common|chrome/settings.yaml
 	common|chrome/credits.yaml
+	common|chrome/help.yaml
 	common|chrome/lobby.yaml
 	common|chrome/lobby-mappreview.yaml
 	d2k|chrome/lobby-players.yaml

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -97,6 +97,7 @@ ChromeLayout:
 	common|chrome/mainmenu.yaml
 	common|chrome/settings.yaml
 	common|chrome/credits.yaml
+	common|chrome/help.yaml
 	common|chrome/lobby.yaml
 	common|chrome/lobby-mappreview.yaml
 	common|chrome/lobby-players.yaml

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -145,6 +145,7 @@ ChromeLayout:
 	ts|chrome/mainmenu-prerelease-notification.yaml
 	common|chrome/settings.yaml
 	common|chrome/credits.yaml
+	common|chrome/help.yaml
 	common|chrome/lobby.yaml
 	common|chrome/lobby-mappreview.yaml
 	common|chrome/lobby-players.yaml


### PR DESCRIPTION
The idea is to have a help button available for beginners in single player mode. I originally intended to implement the tutorial maps for new players (#13671: Make tutorial maps for new players). But I realized having a help option that displays hotkeys and commands could be useful for new players.

The Screenshot shows the before and after of the Single Player Menu:

<img width="191" alt="screen shot 2017-12-12 at 1 58 04 am" src="https://user-images.githubusercontent.com/29164205/33875961-08c8a8a8-def2-11e7-8306-5f8322615987.png">     <img width="191" alt="screen shot 2017-12-12 at 1 58 15 am" src="https://user-images.githubusercontent.com/29164205/33875966-0a2abee8-def2-11e7-9a98-502c1322d548.png">

The Help button displays the commands:

<img width="301" alt="screen shot 2017-12-12 at 2 04 42 am" src="https://user-images.githubusercontent.com/29164205/33875977-125a8a62-def2-11e7-8389-0a10f3c3012e.png">
<img width="303" alt="screen shot 2017-12-12 at 2 04 48 am" src="https://user-images.githubusercontent.com/29164205/33875979-13a131f0-def2-11e7-9d72-2d82a19b6c15.png">


**Further Improvements:**
The Help button can be further improved to be a menu which will include Tutorials, Tips or a concise How to Play features.
