### PR TITLE
Fixed new lines in legacy map import briefing sections

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
@@ -133,7 +133,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 			var briefing = new StringBuilder();
 			foreach (var s in briefingSection)
-				briefing.AppendLine(s.Value);
+			{
+				var line = s.Value.Replace("@", "\n");
+				briefing.AppendLine(line);
+			}
 
 			if (briefing.Length == 0)
 				return;


### PR DESCRIPTION
Excerpt from `sca01ea.ini`:

```ini
[Briefing]
1=We've lost contact with one of our outposts. Before it went off-line, we
2=recieved a brief communique about giant ants. We're unsure what to make
3=of this report, so we want you to investigate.@@Scout the area, bring the
4=outpost back on-line, and report your findings. If there is a threat,
5=reinforcements will be sent in to help you.@@Keep the base functional and
6=radio contact open -- we don't want to lose the outpost again.
```