### PR TITLE
Fix memory leak when playing videos

### DIFF
--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -40,7 +40,7 @@ namespace OpenRA
 		ISoundLoader[] loaders;
 		IReadOnlyFileSystem fileSystem;
 		Cache<string, ISoundSource> sounds;
-		ISoundSource rawSource;
+		ISoundSource videoSource;
 		ISound music;
 		ISound video;
 		MusicInfo currentMusic;
@@ -149,8 +149,9 @@ namespace OpenRA
 
 		public void PlayVideo(byte[] raw, int channels, int sampleBits, int sampleRate)
 		{
-			rawSource = soundEngine.AddSoundSourceFromMemory(raw, channels, sampleBits, sampleRate);
-			video = soundEngine.Play2D(rawSource, false, true, WPos.Zero, InternalSoundVolume, false);
+			StopVideo();
+			videoSource = soundEngine.AddSoundSourceFromMemory(raw, channels, sampleBits, sampleRate);
+			video = soundEngine.Play2D(videoSource, false, true, WPos.Zero, InternalSoundVolume, false);
 		}
 
 		public void PlayVideo()
@@ -168,7 +169,12 @@ namespace OpenRA
 		public void StopVideo()
 		{
 			if (video != null)
+			{
 				soundEngine.StopSound(video);
+				videoSource.Dispose();
+				videoSource = null;
+				video = null;
+			}
 		}
 
 		public void Tick()


### PR DESCRIPTION
By inspection, playing a second video does not release the audio for the first video.

Disclaimer: I have not tested this as I lack videos to test with - would be nice if somebody could verify it, but hopefully it's straightforward enough anyway.