### PR TITLE
Cache VariableExpressions on load.

### DIFF
--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -71,6 +71,11 @@ namespace OpenRA
 		static readonly ConcurrentCache<MemberInfo, bool> MemberHasTranslateAttribute =
 			new ConcurrentCache<MemberInfo, bool>(member => member.HasAttribute<TranslateAttribute>());
 
+		static readonly ConcurrentCache<string, BooleanExpression> BooleanExpressionCache =
+			new ConcurrentCache<string, BooleanExpression>(expression => new BooleanExpression(expression));
+		static readonly ConcurrentCache<string, IntegerExpression> IntegerExpressionCache =
+			new ConcurrentCache<string, IntegerExpression>(expression => new IntegerExpression(expression));
+
 		static readonly object TranslationsLock = new object();
 		static Dictionary<string, string> translations;
 
@@ -408,7 +413,7 @@ namespace OpenRA
 				{
 					try
 					{
-						return new BooleanExpression(value);
+						return BooleanExpressionCache[value];
 					}
 					catch (InvalidDataException e)
 					{
@@ -424,7 +429,7 @@ namespace OpenRA
 				{
 					try
 					{
-						return new IntegerExpression(value);
+						return IntegerExpressionCache[value];
 					}
 					catch (InvalidDataException e)
 					{


### PR DESCRIPTION
Compiling these expressions is sadly expensive, and we needed new ones for every trait on every actor each time one was generated. The expressions thankfully can be shared as they are pure functions, which removes this overhead.

Saves 15% of CPU during initial game load (caused by loading actors for the RA shellmap). This would also save a bit of CPU when creating new actors during regular games too.