### PR TITLE
Avoid format strings in some places.

### DIFF
--- a/OpenRA.Game/Support/PerfTimer.cs
+++ b/OpenRA.Game/Support/PerfTimer.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Support
 			var label = type == typeof(string) || type.IsGenericType ? item.ToString() : type.Name;
 			Log.Write("perf", FormatString,
 				1000f * (endStopwatchTicks - startStopwatchTicks) / Stopwatch.Frequency,
-				"[{0}] {1}: {2}".F(Game.LocalTick, name, label));
+				"[" + Game.LocalTick + "] " + name + ": " + label);
 		}
 
 		public static long LongTickThresholdInStopwatchTicks

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -475,6 +475,6 @@ namespace OpenRA
 		public bool Equals(TraitPair<T> other) { return this == other; }
 		public override bool Equals(object obj) { return obj is TraitPair<T> && Equals((TraitPair<T>)obj); }
 
-		public override string ToString() { return "{0}->{1}".F(Actor.Info.Name, Trait.GetType().Name); }
+		public override string ToString() { return Actor.Info.Name + "->" + Trait.GetType().Name; }
 	}
 }


### PR DESCRIPTION
Where it is possible to directly concat strings, prefer this in some often-called methods.