### PR TITLE
Avoid LINQ in some key methods.

### DIFF
--- a/OpenRA.Game/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Game/Traits/Player/PlayerResources.cs
@@ -172,9 +172,11 @@ namespace OpenRA.Traits
 
 		void ITick.Tick(Actor self)
 		{
-			ResourceCapacity = self.World.ActorsWithTrait<IStoreResources>()
-				.Where(a => a.Actor.Owner == owner)
-				.Sum(a => a.Trait.Capacity);
+			// PERF: Avoid LINQ.
+			ResourceCapacity = 0;
+			foreach (var tp in self.World.ActorsWithTrait<IStoreResources>())
+				if (tp.Actor.Owner == owner)
+					ResourceCapacity += tp.Trait.Capacity;
 
 			if (Resources > ResourceCapacity)
 				Resources = ResourceCapacity;

--- a/OpenRA.Mods.Common/Traits/Player/TechTree.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TechTree.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Primitives;
@@ -66,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 		public bool HasPrerequisites(IEnumerable<string> prerequisites)
 		{
 			var ownedPrereqs = GatherOwnedPrerequisites(player);
-			return prerequisites.All(p => !(p.Replace("~", "").StartsWith("!")
+			return prerequisites.All(p => !(p.Replace("~", "").StartsWith("!", StringComparison.Ordinal)
 					^ !ownedPrereqs.ContainsKey(p.Replace("!", "").Replace("~", ""))));
 		}
 
@@ -134,7 +135,7 @@ namespace OpenRA.Mods.Common.Traits
 				foreach (var prereq in prerequisites)
 				{
 					var withoutTilde = prereq.Replace("~", "");
-					if (withoutTilde.StartsWith("!") ^ !ownedPrerequisites.ContainsKey(withoutTilde.Replace("!", "")))
+					if (withoutTilde.StartsWith("!", StringComparison.Ordinal) ^ !ownedPrerequisites.ContainsKey(withoutTilde.Replace("!", "")))
 						return false;
 				}
 
@@ -146,10 +147,10 @@ namespace OpenRA.Mods.Common.Traits
 				// PERF: Avoid LINQ.
 				foreach (var prereq in prerequisites)
 				{
-					if (!prereq.StartsWith("~"))
+					if (!prereq.StartsWith("~", StringComparison.Ordinal))
 						continue;
 					var withoutTilde = prereq.Replace("~", "");
-					if (withoutTilde.StartsWith("!") ^ !ownedPrerequisites.ContainsKey(withoutTilde.Replace("!", "")))
+					if (withoutTilde.StartsWith("!", StringComparison.Ordinal) ^ !ownedPrerequisites.ContainsKey(withoutTilde.Replace("!", "")))
 						return true;
 				}
 

--- a/OpenRA.Mods.Common/Traits/Player/TechTree.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TechTree.cs
@@ -130,13 +130,30 @@ namespace OpenRA.Mods.Common.Traits
 
 			bool HasPrerequisites(Cache<string, List<Actor>> ownedPrerequisites)
 			{
-				return prerequisites.All(p => !(p.Replace("~", "").StartsWith("!") ^ !ownedPrerequisites.ContainsKey(p.Replace("!", "").Replace("~", ""))));
+				// PERF: Avoid LINQ.
+				foreach (var prereq in prerequisites)
+				{
+					var withoutTilde = prereq.Replace("~", "");
+					if (withoutTilde.StartsWith("!") ^ !ownedPrerequisites.ContainsKey(withoutTilde.Replace("!", "")))
+						return false;
+				}
+
+				return true;
 			}
 
 			bool IsHidden(Cache<string, List<Actor>> ownedPrerequisites)
 			{
-				return prerequisites.Any(prereq => prereq.StartsWith("~") &&
-					(prereq.Replace("~", "").StartsWith("!") ^ !ownedPrerequisites.ContainsKey(prereq.Replace("~", "").Replace("!", ""))));
+				// PERF: Avoid LINQ.
+				foreach (var prereq in prerequisites)
+				{
+					if (!prereq.StartsWith("~"))
+						continue;
+					var withoutTilde = prereq.Replace("~", "");
+					if (withoutTilde.StartsWith("!") ^ !ownedPrerequisites.ContainsKey(withoutTilde.Replace("!", "")))
+						return true;
+				}
+
+				return false;
 			}
 
 			public void Update(Cache<string, List<Actor>> ownedPrerequisites)

--- a/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
+++ b/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
@@ -204,7 +204,7 @@ namespace OpenRA.Mods.Common.Traits
 			var toProcess = new Queue<CPos>();
 			toProcess.Enqueue(MPos.Zero.ToCPos(map));
 
-			// Flood-fill over each domain
+			// Flood-fill over each domain.
 			while (toProcess.Count != 0)
 			{
 				var start = toProcess.Dequeue();
@@ -220,7 +220,7 @@ namespace OpenRA.Mods.Common.Traits
 				var currentPassable = CanTraverseTile(world, start);
 
 				// Add all contiguous cells to our domain, and make a note of
-				// any non-contiguous cells for future domains
+				// any non-contiguous cells for future domains.
 				while (domainQueue.Count != 0)
 				{
 					var n = domainQueue.Dequeue();
@@ -237,12 +237,14 @@ namespace OpenRA.Mods.Common.Traits
 					visited[n] = true;
 					domains[n] = domain;
 
-					// Don't crawl off the map, or add already-visited cells
-					var neighbors = CVec.Directions.Select(d => n + d)
-						.Where(p => visited.Contains(p) && !visited[p]);
-
-					foreach (var neighbor in neighbors)
-						domainQueue.Enqueue(neighbor);
+					// PERF: Avoid LINQ.
+					foreach (var direction in CVec.Directions)
+					{
+						// Don't crawl off the map, or add already-visited cells.
+						var neighbor = direction + n;
+						if (visited.Contains(neighbor) && !visited[neighbor])
+							domainQueue.Enqueue(neighbor);
+					}
 				}
 
 				domain += 1;


### PR DESCRIPTION
Avoid LINQ in some commonly called Tick methods, and also avoid it when building map domains as this generates a lot of needless work for the GC when loading.