### PR TITLE
Presize MemoryStream when possible.

### DIFF
--- a/OpenRA.Game/Network/Connection.cs
+++ b/OpenRA.Game/Network/Connection.cs
@@ -77,10 +77,10 @@ namespace OpenRA.Network
 
 		public virtual void SendSync(int frame, byte[] syncData)
 		{
-			var ms = new MemoryStream();
+			var ms = new MemoryStream(4 + syncData.Length);
 			ms.Write(BitConverter.GetBytes(frame));
 			ms.Write(syncData);
-			Send(ms.ToArray());
+			Send(ms.GetBuffer());
 		}
 
 		protected virtual void Send(byte[] packet)
@@ -197,10 +197,10 @@ namespace OpenRA.Network
 
 		public override void SendSync(int frame, byte[] syncData)
 		{
-			var ms = new MemoryStream();
+			var ms = new MemoryStream(4 + syncData.Length);
 			ms.Write(BitConverter.GetBytes(frame));
 			ms.Write(syncData);
-			queuedSyncPackets.Add(ms.ToArray());
+			queuedSyncPackets.Add(ms.GetBuffer());
 		}
 
 		protected override void Send(byte[] packet)

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -240,7 +240,7 @@ namespace OpenRA
 		{
 			if (IsImmediate)
 			{
-				var ret = new MemoryStream();
+				var ret = new MemoryStream(1 + OrderString.Length + 1 + TargetString.Length + 1);
 				var w = new BinaryWriter(ret);
 				w.Write((byte)0xfe);
 				w.Write(OrderString);

--- a/OpenRA.Game/Network/OrderIO.cs
+++ b/OpenRA.Game/Network/OrderIO.cs
@@ -38,14 +38,14 @@ namespace OpenRA.Network
 
 		public static byte[] SerializeSync(int sync)
 		{
-			var ms = new MemoryStream();
+			var ms = new MemoryStream(1 + 4);
 			using (var writer = new BinaryWriter(ms))
 			{
 				writer.Write((byte)0x65);
 				writer.Write(sync);
 			}
 
-			return ms.ToArray();
+			return ms.GetBuffer();
 		}
 
 		public static int2 ReadInt2(this BinaryReader r)

--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -127,10 +127,10 @@ namespace OpenRA.Network
 
 		public void SendSync(int frame, byte[] syncData)
 		{
-			var ms = new MemoryStream();
+			var ms = new MemoryStream(4 + syncData.Length);
 			ms.Write(BitConverter.GetBytes(frame));
 			ms.Write(syncData);
-			sync.Add(ms.ToArray());
+			sync.Add(ms.GetBuffer());
 
 			// Store the current frame so Receive() can return the next chunk of orders.
 			ordersFrame = frame + LobbyInfo.GlobalSettings.OrderLatency;

--- a/OpenRA.Game/Server/ServerOrder.cs
+++ b/OpenRA.Game/Server/ServerOrder.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Server
 
 		public byte[] Serialize()
 		{
-			var ms = new MemoryStream();
+			var ms = new MemoryStream(1 + Name.Length + 1 + Data.Length + 1);
 			var bw = new BinaryWriter(ms);
 
 			bw.Write((byte)0xfe);

--- a/OpenRA.Mods.Cnc/FileSystem/MixFile.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/MixFile.cs
@@ -150,7 +150,7 @@ namespace OpenRA.Mods.Cnc.FileSystem
 			{
 				var decrypted = fish.Decrypt(h);
 
-				var ms = new MemoryStream();
+				var ms = new MemoryStream(decrypted.Length * 4);
 				var writer = new BinaryWriter(ms);
 				foreach (var t in decrypted)
 					writer.Write(t);


### PR DESCRIPTION
Also use GetBuffer when we know we have presized the stream to the exact required size to prevent a needless copy.

Helps with #14178 by reducing allocations during loading (the main culprits are ZipFile and MixFile), decreasing the peak memory reached when loading. The other stuff is mostly just along for the ride. :)