### PR TITLE
Remove draw line 2D helper method.

### DIFF
--- a/OpenRA.Game/Graphics/RgbaColorRenderer.cs
+++ b/OpenRA.Game/Graphics/RgbaColorRenderer.cs
@@ -204,11 +204,6 @@ namespace OpenRA.Graphics
 			}
 		}
 
-		public void DrawLine(IEnumerable<float2> points, float width, Color color, bool connectSegments = false)
-		{
-			DrawLine(points.Select(p => new float3(p, 0)), width, color, connectSegments);
-		}
-
 		public void DrawLine(IEnumerable<float3> points, float width, Color color, bool connectSegments = false)
 		{
 			if (!connectSegments)

--- a/OpenRA.Mods.Common/Graphics/SelectionBoxRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBoxRenderable.cs
@@ -46,8 +46,8 @@ namespace OpenRA.Mods.Common.Graphics
 		{
 			var iz = 1 / wr.Viewport.Zoom;
 			var screenDepth = wr.Screen3DPxPosition(pos).Z;
-			var tl = new float2(decorationBounds.Left, decorationBounds.Top);
-			var br = new float2(decorationBounds.Right, decorationBounds.Bottom);
+			var tl = new float3(decorationBounds.Left, decorationBounds.Top, 0);
+			var br = new float3(decorationBounds.Right, decorationBounds.Bottom, 0);
 			var tr = new float3(br.X, tl.Y, screenDepth);
 			var bl = new float3(tl.X, br.Y, screenDepth);
 			var u = new float2(4 * iz, 0);

--- a/OpenRA.Mods.Common/Widgets/LineGraphWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LineGraphWidget.cs
@@ -131,7 +131,7 @@ namespace OpenRA.Mods.Common.Widgets
 						{
 							lastX = x;
 							lastPoint = point;
-							return origin + new float2(x * xStep, -point * scale);
+							return origin + new float3(x * xStep, -point * scale, 0);
 						}), 1, color);
 
 					if (lastPoint != 0f)

--- a/OpenRA.Mods.Common/Widgets/PerfGraphWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/PerfGraphWidget.cs
@@ -27,9 +27,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 			cr.DrawLine(new[]
 			{
-				new float2(rect.Left, rect.Top),
-				new float2(rect.Left, rect.Bottom),
-				new float2(rect.Right, rect.Bottom)
+				new float3(rect.Left, rect.Top, 0),
+				new float3(rect.Left, rect.Bottom, 0),
+				new float3(rect.Right, rect.Bottom, 0)
 			}, 1, Color.White);
 
 			cr.DrawLine(origin + new float2(100, 0) * basis, origin + new float2(100, 100) * basis, 1, Color.White);
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Widgets
 			foreach (var item in PerfHistory.Items.Values)
 			{
 				cr.DrawLine(item.Samples()
-					.Select((sample, i) => origin + new float2(i, (float)sample) * basis),
+					.Select((sample, i) => origin + new float3(i, (float)sample, 0) * basis),
 					1, item.C);
 
 				var u = new float2(rect.Left, rect.Top);


### PR DESCRIPTION
Callers can provide 3D points easily, and this avoids the need to allocate and slow down enumeration via the points.Select(p => new float3(p, 0)) wrapper.