### PR TITLE
Fix incorrectly named lobby option properties.

### DIFF
--- a/mods/cnc/rules/player.yaml
+++ b/mods/cnc/rules/player.yaml
@@ -10,10 +10,10 @@ Player:
 	AllyRepair:
 	PlayerResources:
 	DeveloperMode:
-		DisplayOrder: 6
+		CheckboxDisplayOrder: 6
 	BaseAttackNotifier:
 	Shroud:
-		FogDisplayOrder: 3
+		FogCheckboxDisplayOrder: 3
 	PlayerStatistics:
 	FrozenActorLayer:
 	PlaceBeacon:

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -80,12 +80,12 @@ World:
 		CheckboxVisible: False
 	SpawnMapActors:
 	MapBuildRadius:
-		AllyBuildRadiusDisplayOrder: 4
-		BuildRadiusDisplayOrder: 5
+		AllyBuildRadiusCheckboxDisplayOrder: 4
+		BuildRadiusCheckboxDisplayOrder: 5
 	MapOptions:
-		ShortGameDisplayOrder: 2
-		TechLevelDisplayOrder: 2
-		GameSpeedDisplayOrder: 3
+		ShortGameCheckboxDisplayOrder: 2
+		TechLevelDropdownDisplayOrder: 2
+		GameSpeedDropdownDisplayOrder: 3
 	MPStartLocations:
 	CreateMPPlayers:
 	MPStartUnits@mcvonly:
@@ -131,14 +131,14 @@ World:
 		SupportActors: e1,e1,e1,e1,e1,e2,e2,e2,e3,e3,apc,mtnk
 	SpawnMPUnits:
 		StartingUnitsClass: light
-		DisplayOrder: 0
+		DropdownDisplayOrder: 0
 	CrateSpawner:
 		Minimum: 1
 		Maximum: 6
 		SpawnInterval: 3000
 		WaterChance: 0
 		InitialSpawnDelay: 1500
-		DisplayOrder: 1
+		CheckboxDisplayOrder: 1
 	PathFinder:
 	ValidateOrder:
 	DebugPauseState:

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -63,10 +63,10 @@ Player:
 		SelectableCash: 2500, 5000, 7000, 10000, 20000
 		InsufficientFundsNotification: InsufficientFunds
 	DeveloperMode:
-		DisplayOrder: 6
+		CheckboxDisplayOrder: 6
 	BaseAttackNotifier:
 	Shroud:
-		FogDisplayOrder: 3
+		FogCheckboxDisplayOrder: 3
 	FrozenActorLayer:
 	HarvesterAttackNotifier:
 	PlayerStatistics:

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -80,7 +80,7 @@ World:
 		WaterChance: 0
 		ValidGround: Sand, Rock, Transition, Spice, SpiceSand, Dune, Concrete
 		InitialSpawnDelay: 1500
-		DisplayOrder: 1
+		CheckboxDisplayOrder: 1
 	DomainIndex:
 	WarheadDebugOverlay:
 	BuildableTerrainLayer:
@@ -101,12 +101,12 @@ World:
 		CheckboxDisplayOrder: 5
 	SpawnMapActors:
 	MapBuildRadius:
-		AllyBuildRadiusDisplayOrder: 4
-		BuildRadiusVisible: False
+		AllyBuildRadiusCheckboxDisplayOrder: 4
+		BuildRadiusCheckboxVisible: False
 	MapOptions:
-		ShortGameDisplayOrder: 2
-		TechLevelDisplayOrder: 2
-		GameSpeedDisplayOrder: 3
+		ShortGameCheckboxDisplayOrder: 2
+		TechLevelDropdownDisplayOrder: 2
+		GameSpeedDropdownDisplayOrder: 3
 	CreateMPPlayers:
 	MPStartLocations:
 	MPStartUnits@mcv:
@@ -163,7 +163,7 @@ World:
 		InnerSupportRadius: 3
 		OuterSupportRadius: 5
 	SpawnMPUnits:
-		DisplayOrder: 1
+		DropdownDisplayOrder: 1
 	PathFinder:
 	ValidateOrder:
 	DebugPauseState:

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -43,10 +43,10 @@ Player:
 	PlayerResources:
 		InsufficientFundsNotification: InsufficientFunds
 	DeveloperMode:
-		DisplayOrder: 6
+		CheckboxDisplayOrder: 6
 	GpsWatcher:
 	Shroud:
-		FogDisplayOrder: 3
+		FogCheckboxDisplayOrder: 3
 	FrozenActorLayer:
 	BaseAttackNotifier:
 	PlayerStatistics:

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -112,7 +112,7 @@ World:
 		SpawnInterval: 3000
 		WaterChance: 20
 		InitialSpawnDelay: 1500
-		DisplayOrder: 1
+		CheckboxDisplayOrder: 1
 	DomainIndex:
 	SmudgeLayer@SCORCH:
 		Type: Scorch
@@ -126,12 +126,12 @@ World:
 	WarheadDebugOverlay:
 	SpawnMapActors:
 	MapBuildRadius:
-		AllyBuildRadiusDisplayOrder: 4
-		BuildRadiusDisplayOrder: 5
+		AllyBuildRadiusCheckboxDisplayOrder: 4
+		BuildRadiusCheckboxDisplayOrder: 5
 	MapOptions:
-		ShortGameDisplayOrder: 2
-		TechLevelDisplayOrder: 2
-		GameSpeedDisplayOrder: 3
+		ShortGameCheckboxDisplayOrder: 2
+		TechLevelDropdownDisplayOrder: 2
+		GameSpeedDropdownDisplayOrder: 3
 	CreateMPPlayers:
 	MPStartUnits@mcvonly:
 		Class: none
@@ -172,7 +172,7 @@ World:
 		OuterSupportRadius: 5
 	MPStartLocations:
 	SpawnMPUnits:
-		DisplayOrder: 1
+		DropdownDisplayOrder: 1
 	PathFinder:
 	ValidateOrder:
 	DebugPauseState:

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -43,10 +43,10 @@ Player:
 	PlayerResources:
 		InsufficientFundsNotification: InsufficientFunds
 	DeveloperMode:
-		Enabled: true
-		DisplayOrder: 6
+		CheckboxEnabled: true
+		CheckboxDisplayOrder: 6
 	Shroud:
-		FogDisplayOrder: 3
+		FogCheckboxDisplayOrder: 3
 	FrozenActorLayer:
 	BaseAttackNotifier:
 		AllyNotification: OurAllyIsUnderAttack

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -111,15 +111,15 @@ World:
 	ResourceClaimLayer:
 	WarheadDebugOverlay:
 	MapCreeps:
-		Visible: False
+		CheckboxVisible: False
 	SpawnMapActors:
 	MapBuildRadius:
-		AllyBuildRadiusDisplayOrder: 4
-		BuildRadiusDisplayOrder: 5
+		AllyBuildRadiusCheckboxDisplayOrder: 4
+		BuildRadiusCheckboxDisplayOrder: 5
 	MapOptions:
-		ShortGameDisplayOrder: 2
-		TechLevelDisplayOrder: 2
-		GameSpeedDisplayOrder: 3
+		ShortGameCheckboxDisplayOrder: 2
+		TechLevelDropdownDisplayOrder: 2
+		GameSpeedDropdownDisplayOrder: 3
 	CreateMPPlayers:
 	MPStartUnits@MCV:
 		Class: none
@@ -176,7 +176,7 @@ World:
 		OuterSupportRadius: 5
 	MPStartLocations:
 	SpawnMPUnits:
-		DisplayOrder: 1
+		DropdownDisplayOrder: 1
 	CrateSpawner:
 		Minimum: 1
 		Maximum: 6
@@ -184,7 +184,7 @@ World:
 		WaterChance: 0
 		ValidGround: Clear, Rough, Road, DirtRoad, Tiberium, BlueTiberium
 		InitialSpawnDelay: 1500
-		DisplayOrder: 1
+		CheckboxDisplayOrder: 1
 	PathFinder:
 	ValidateOrder:
 	DebugPauseState:


### PR DESCRIPTION
Fixes an oversight from #14359 - I somehow managed to accidentally discard the rule changes associated with the requested renames.  This PR fixes the order of the lobby options and reenables cheats by default in TS.