### PR TITLE
Fix ExternalCapture footprint/targetable position mismatch.

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -208,26 +208,6 @@ namespace OpenRA.Traits
 		Pair<CPos, SubCell>[] OccupiedCells();
 	}
 
-	public static class IOccupySpaceExts
-	{
-		public static CPos NearestCellTo(this IOccupySpace ios, CPos other)
-		{
-			var nearest = ios.TopLeft;
-			var nearestDistance = int.MaxValue;
-			foreach (var cell in ios.OccupiedCells())
-			{
-				var dist = (other - cell.First).LengthSquared;
-				if (dist < nearestDistance)
-				{
-					nearest = cell.First;
-					nearestDistance = dist;
-				}
-			}
-
-			return nearest;
-		}
-	}
-
 	public enum SubCell { Invalid = int.MinValue, Any = int.MinValue / 2, FullCell = 0, First = 1 }
 	public interface IActorMap
 	{

--- a/OpenRA.Mods.Common/Activities/ExternalCaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/ExternalCaptureActor.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits;
@@ -42,9 +43,7 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 			}
 
-			var nearest = target.Actor.OccupiesSpace.NearestCellTo(mobile.ToCell);
-
-			if ((nearest - mobile.ToCell).LengthSquared > 2)
+			if (!Util.AdjacentCells(self.World, target).Contains(mobile.ToCell))
 				return ActivityUtils.SequenceActivities(new MoveAdjacentTo(self, target), this);
 
 			if (!capturable.CaptureInProgress)


### PR DESCRIPTION
Fixes #14275.

The problem was that `ExternalCaptureActor` used `NearestCellTo` which was based on the actor's cell footprint, while `MoveAdjacentTo` used `Util.AdjacentCells` which is based on the actor's targetable positions.  `Util.AdjacentCells` is the more correct option in all cases.