### PR TITLE
TerrainSpriteLayer now supports a choice regarding in-memory buffering.

### DIFF
--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -75,6 +75,7 @@ namespace OpenRA
 	public interface IVertexBuffer<T> : IDisposable
 	{
 		void Bind();
+		void GetData(T[] buffer, int start, int length);
 		void SetData(T[] vertices, int length);
 		void SetData(T[] vertices, int start, int length);
 		void SetData(IntPtr data, int start, int length);

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Graphics
 			{
 				var palette = template.Value.Palette ?? TileSet.TerrainPaletteInternalName;
 				spriteLayers.GetOrAdd(palette, pal =>
-					new TerrainSpriteLayer(world, wr, theater.Sheet, BlendMode.Alpha, wr.Palette(palette), world.Type != WorldType.Editor));
+					new TerrainSpriteLayer(world, wr, theater.Sheet, BlendMode.Alpha, wr.Palette(palette), world.Type != WorldType.Editor, false));
 			}
 
 			foreach (var cell in map.AllCells)

--- a/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Traits
 				var layer = spriteLayers.GetOrAdd(r.Value.Palette, pal =>
 				{
 					var first = res.Value.Variants.First().Value.First();
-					return new TerrainSpriteLayer(w, wr, first.Sheet, first.BlendMode, pal, false);
+					return new TerrainSpriteLayer(w, wr, first.Sheet, first.BlendMode, pal, false, false);
 				});
 
 				// Validate that sprites are compatible with this layer

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.Traits
 				var layer = spriteLayers.GetOrAdd(r.Value.Palette, pal =>
 				{
 					var first = r.Value.Variants.First().Value.First();
-					return new TerrainSpriteLayer(w, wr, first.Sheet, first.BlendMode, pal, wr.World.Type != WorldType.Editor);
+					return new TerrainSpriteLayer(w, wr, first.Sheet, first.BlendMode, pal, wr.World.Type != WorldType.Editor, false);
 				});
 
 				// Validate that sprites are compatible with this layer

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -191,8 +191,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (fogSprites.Any(s => s.BlendMode != fogBlend))
 				throw new InvalidDataException("Fog sprites must all use the same blend mode.");
 
-			shroudLayer = new TerrainSpriteLayer(w, wr, shroudSheet, shroudBlend, wr.Palette(info.ShroudPalette), false);
-			fogLayer = new TerrainSpriteLayer(w, wr, fogSheet, fogBlend, wr.Palette(info.FogPalette), false);
+			shroudLayer = new TerrainSpriteLayer(w, wr, shroudSheet, shroudBlend, wr.Palette(info.ShroudPalette), false, true);
+			fogLayer = new TerrainSpriteLayer(w, wr, fogSheet, fogBlend, wr.Palette(info.FogPalette), false, true);
 		}
 
 		Edges GetEdges(PPos puv, Func<PPos, bool> isVisible)

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.Common.Traits
 				throw new InvalidDataException("Smudges specify different blend modes. "
 					+ "Try using different smudge types for smudges that use different blend modes.");
 
-			render = new TerrainSpriteLayer(w, wr, sheet, blendMode, wr.Palette(Info.Palette), wr.World.Type != WorldType.Editor);
+			render = new TerrainSpriteLayer(w, wr, sheet, blendMode, wr.Palette(Info.Palette), wr.World.Type != WorldType.Editor, false);
 
 			// Add map smudges
 			foreach (var kv in Info.InitialSmudges)

--- a/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.D2k.Traits
 		public void WorldLoaded(World w, WorldRenderer wr)
 		{
 			theater = wr.Theater;
-			render = new TerrainSpriteLayer(w, wr, theater.Sheet, BlendMode.Alpha, wr.Palette(info.Palette), wr.World.Type != WorldType.Editor);
+			render = new TerrainSpriteLayer(w, wr, theater.Sheet, BlendMode.Alpha, wr.Palette(info.Palette), wr.World.Type != WorldType.Editor, false);
 		}
 
 		public void AddTile(CPos cell, TerrainTile tile)

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -247,6 +247,9 @@ namespace OpenRA.Platforms.Default
 		public delegate void BufferSubData(int target, IntPtr offset, IntPtr size, IntPtr data);
 		public static BufferSubData glBufferSubData { get; private set; }
 
+		public delegate void GetBufferSubData(int target, IntPtr offset, IntPtr size, IntPtr data);
+		public static GetBufferSubData glGetBufferSubData { get; private set; }
+
 		public delegate void DeleteBuffers(int n, ref uint buffers);
 		public static DeleteBuffers glDeleteBuffers { get; private set; }
 
@@ -413,6 +416,7 @@ namespace OpenRA.Platforms.Default
 				glBindBuffer = Bind<BindBuffer>("glBindBuffer");
 				glBufferData = Bind<BufferData>("glBufferData");
 				glBufferSubData = Bind<BufferSubData>("glBufferSubData");
+				glGetBufferSubData = Bind<GetBufferSubData>("glGetBufferSubData");
 				glDeleteBuffers = Bind<DeleteBuffers>("glDeleteBuffers");
 				glBindAttribLocation = Bind<BindAttribLocation>("glBindAttribLocation");
 				glVertexAttribPointer = Bind<VertexAttribPointer>("glVertexAttribPointer");

--- a/OpenRA.Platforms.Default/VertexBuffer.cs
+++ b/OpenRA.Platforms.Default/VertexBuffer.cs
@@ -55,6 +55,26 @@ namespace OpenRA.Platforms.Default
 			}
 		}
 
+		public void GetData(T[] buffer, int start, int length)
+		{
+			Bind();
+
+			var ptr = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+			try
+			{
+				OpenGL.glGetBufferSubData(OpenGL.GL_ARRAY_BUFFER,
+					new IntPtr(VertexSize * start),
+					new IntPtr(VertexSize * length),
+					ptr.AddrOfPinnedObject());
+			}
+			finally
+			{
+				ptr.Free();
+			}
+
+			OpenGL.CheckGLError();
+		}
+
 		public void SetData(T[] data, int length)
 		{
 			SetData(data, 0, length);


### PR DESCRIPTION
Currently, TerrainSpriteLayer buffers all changes in memory, only writing out changes to the GPU for visible areas that need to be drawn. This reduces the CPU overhead of keeping the GPU updated with data it doesn't need. It comes at the cost of having to maintain two copies of the vertices, one in memory and one on the GPU.

For larger maps, the allocation requirements for this grows into megabytes. A new parameter allows the in-memory buffering to be turned off. This reduces memory required by half, but requires all updates to immediately be sent to the GPU, even if not visible. For layers that do not get updated too often this providers a useful trade-off to reduce memory load.

Currently, only the shroud & fog layers in ShroudRenderer are updated frequently enough to justify a buffer, the other layers save memory by removing their buffers.

Finally, in order to handle UpdatePaletteIndices when we are not buffering vertices, we must be able to read the vertex buffer back from the GPU, so add methods to support that to the graphics layer.

----

How much memory? For a 130x130 map, it's 130x130x6x36x5 (6 vertices per cell, 36 bytes per vertex, typically we create 5 layers). That's 17Mb. For the oversize 'Spinning World' map at 812x330, that's 276Mb! This PR is intended to help with the memory issues noted in #12494 by removing some of these buffers.

To test `UpdatePaletteIndices` works, try adding this to the top of `WorldRenderer.Draw`. On tick 300 it will generate a bunch of extra palettes, forcing a resize and thus `UpdatePaletteIndices` will be called. Since it works, things will look normal afterwards, if you comment out the body of `UpdatePaletteIndices` the terrain will look funky instead.

```c#
if (Game.LocalTick == 300)
{
	for (int i = 'a'; i < 'z'; i++)
		AddPalette(new string((char)i, 1), new ImmutablePalette(new uint[0]));
}
```

----

Sorry for the long preamble - the change itself isn't so bad. :)