### PR TITLE
#14542 fix carry all path

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -109,6 +109,7 @@ Also thanks to:
     * Paul Dovydaitis (pdovy)
     * Pavlos Touboulidis (pav)
     * Pedro Ferreira Ramos (bateramos)
+    * Peter Amrehn (jongleur1983)
     * Pizzaoverhead
     * Pi Delport (pjdelport)
     * Psydev

--- a/OpenRA.Mods.Common/Activities/DeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverResources.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				var notify = self.TraitsImplementing<INotifyHarvesterAction>();
 				foreach (var n in notify)
-					n.MovingToRefinery(self, proc.Location + iao.DeliveryOffset, this);
+					n.MovingToRefinery(self, proc, this);
 
 				return ActivityUtils.SequenceActivities(movement.MoveTo(proc.Location + iao.DeliveryOffset, 0), this);
 			}

--- a/OpenRA.Mods.Common/Traits/AutoCarryable.cs
+++ b/OpenRA.Mods.Common/Traits/AutoCarryable.cs
@@ -39,7 +39,13 @@ namespace OpenRA.Mods.Common.Traits
 		public WDist MinimumDistance { get { return info.MinDistance; } }
 
 		void INotifyHarvesterAction.MovingToResources(Actor self, CPos targetCell, Activity next) { RequestTransport(self, targetCell, next); }
-		void INotifyHarvesterAction.MovingToRefinery(Actor self, CPos targetCell, Activity next) { RequestTransport(self, targetCell, next); }
+
+		void INotifyHarvesterAction.MovingToRefinery(Actor self, Actor refineryActor, Activity next)
+		{
+			var iao = refineryActor.Trait<IAcceptResources>();
+			RequestTransport(self, refineryActor.Location + iao.DeliveryOffset, next);
+		}
+
 		void INotifyHarvesterAction.MovementCancelled(Actor self) { MovementCancelled(self); }
 
 		// We do not handle Harvested notification

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -201,7 +201,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyHarvesterAction.MovingToResources(Actor self, CPos targetCell, Activity next) { }
 
-		void INotifyHarvesterAction.MovingToRefinery(Actor self, CPos targetCell, Activity next) { }
+		void INotifyHarvesterAction.MovingToRefinery(Actor self, Actor refineryActor, Activity next) { }
 
 		void INotifyHarvesterAction.MovementCancelled(Actor self) { }
 

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -413,8 +413,9 @@ namespace OpenRA.Mods.Common.Traits
 				var deliver = new DeliverResources(self);
 				self.QueueActivity(deliver);
 
-				foreach (var n in notify)
-					n.MovingToRefinery(self, order.Target.Actor.Location, deliver);
+				if (order.Target.Type == TargetType.Actor)
+					foreach (var n in notify)
+						n.MovingToRefinery(self, order.Target.Actor, deliver);
 			}
 			else if (order.OrderString == "Stop" || order.OrderString == "Move")
 			{

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -414,7 +414,7 @@ namespace OpenRA.Mods.Common.Traits
 				self.QueueActivity(deliver);
 
 				foreach (var n in notify)
-					n.MovingToRefinery(self, order.TargetLocation, deliver);
+					n.MovingToRefinery(self, order.Target.Actor.Location, deliver);
 			}
 			else if (order.OrderString == "Stop" || order.OrderString == "Move")
 			{

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 
 		void INotifyHarvesterAction.MovingToResources(Actor self, CPos targetCell, Activity next) { }
-		void INotifyHarvesterAction.MovingToRefinery(Actor self, CPos targetCell, Activity next) { }
+		void INotifyHarvesterAction.MovingToRefinery(Actor self, Actor refineryActor, Activity next) { }
 		void INotifyHarvesterAction.MovementCancelled(Actor self) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 
 		public void MovingToResources(Actor self, CPos targetCell, Activity next) { }
-		public void MovingToRefinery(Actor self, CPos targetCell, Activity next) { }
+		public void MovingToRefinery(Actor self, Actor targetRefinery, Activity next) { }
 		public void MovementCancelled(Actor self) { }
 		public void Docked() { }
 		public void Undocked() { }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -152,7 +152,7 @@ namespace OpenRA.Mods.Common.Traits
 	public interface INotifyHarvesterAction
 	{
 		void MovingToResources(Actor self, CPos targetCell, Activity next);
-		void MovingToRefinery(Actor self, CPos targetCell, Activity next);
+		void MovingToRefinery(Actor self, Actor refineryActor, Activity next);
 		void MovementCancelled(Actor self);
 		void Harvested(Actor self, ResourceType resource);
 		void Docked();


### PR DESCRIPTION
This PR is an easy fix to issue #14542: When the harvester was explicitly ordered to the refinery before being taken by the CarryAll, the CarryAll loaded the harvester (as intended), but did a detour to (0,0), unloaded, reloaded and then moved to the refinery it should have moved directly.
This was due to the harvester issuing the wrong coordinate from order.TargetLocation.

As @penev92 and @pchote engage in a longer discussion about what should or should not happen here - in short, mid or long term goals - I'll leave this PR here, happy to take suggestions for what to do different or what to do next.