### PR TITLE
Fix a crash in PlaceBuilding.cs

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 				var prevItems = GetNumBuildables(self.Owner);
 				var targetActor = w.GetActorById(order.ExtraData);
 
-				if (targetActor.IsDead)
+				if (targetActor == null || targetActor.IsDead)
 					return;
 
 				var unit = self.World.Map.Rules.Actors[order.TargetString];


### PR DESCRIPTION
Fixes a possible regression from the order rework:
```
Exception of type `System.NullReferenceException`: Object reference not set to an instance of an object. (Der Objektverweis wurde nicht auf eine Objektinstanz festgelegt.)
   at OpenRA.Mods.Common.Traits.PlaceBuilding.<>c__DisplayClass6.<OpenRA.Traits.IResolveOrder.ResolveOrder>b__3(World w) in \OpenRA\OpenRA.Mods.Common\Traits\Player\PlaceBuilding.cs:Line 61.
   at OpenRA.World.Tick() in \OpenRA\OpenRA.Game\World.cs:Line 360.
   at OpenRA.Game.InnerLogicTick(OrderManager orderManager) in \OpenRA\OpenRA.Game\Game.cs:Line 611.
   at OpenRA.Game.LogicTick() in \OpenRA\OpenRA.Game\Game.cs:Line 635.
   at OpenRA.Game.Loop() in \OpenRA\OpenRA.Game\Game.cs:Line 765.
   at OpenRA.Game.Run() in \OpenRA\OpenRA.Game\Game.cs:Line 805.
   at OpenRA.Game.InitializeAndRun(String[] args) in \OpenRA\OpenRA.Game\Game.cs:Line 253.
   at OpenRA.Program.Main(String[] args) in \OpenRA\OpenRA.Game\Support\Program.cs:Line 37.
```