### PR TITLE
Calculate actor preview bounds directly.

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -80,15 +80,13 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Bounds are fixed from the initial render.
 			// If this is a problem, then we may need to fetch the area from somewhere else
-			var r = previews
-				.SelectMany(p => p.Render(worldRenderer, CenterPosition))
-				.Select(rr => rr.PrepareRender(worldRenderer));
+			var r = previews.SelectMany(p => p.ScreenBounds(worldRenderer, CenterPosition));
 
 			if (r.Any())
 			{
-				Bounds = r.First().ScreenBounds(worldRenderer);
+				Bounds = r.First();
 				foreach (var rr in r.Skip(1))
-					Bounds = Rectangle.Union(Bounds, rr.ScreenBounds(worldRenderer));
+					Bounds = Rectangle.Union(Bounds, rr);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
@@ -57,16 +57,13 @@ namespace OpenRA.Mods.Common.Widgets
 			PreviewOffset = int2.Zero;
 			IdealPreviewSize = int2.Zero;
 
-			var r = preview
-				.SelectMany(p => p.Render(worldRenderer, WPos.Zero))
-				.OrderBy(WorldRenderer.RenderableScreenZPositionComparisonKey)
-				.Select(rr => rr.PrepareRender(worldRenderer));
+			var r = preview.SelectMany(p => p.ScreenBounds(worldRenderer, WPos.Zero));
 
 			if (r.Any())
 			{
-				var b = r.First().ScreenBounds(worldRenderer);
+				var b = r.First();
 				foreach (var rr in r.Skip(1))
-					b = Rectangle.Union(b, rr.ScreenBounds(worldRenderer));
+					b = Rectangle.Union(b, rr);
 
 				IdealPreviewSize = new int2(b.Width, b.Height);
 				PreviewOffset = -new int2(b.Left, b.Top) - IdealPreviewSize / 2;


### PR DESCRIPTION
This provides an alternative fix to #14548.

#14557 tackles the issue by making `ModelRenderer` not crash when called at bogus times, but a simpler and cleaner fix is to not call it at all.  It turns out that I actually wrote code to cover this use case, but for some reason (probably lack of testing) didn't use it here.