### PR TITLE
Fix SelectionBox line depths.

### DIFF
--- a/OpenRA.Mods.Common/Graphics/SelectionBoxRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBoxRenderable.cs
@@ -46,8 +46,8 @@ namespace OpenRA.Mods.Common.Graphics
 		{
 			var iz = 1 / wr.Viewport.Zoom;
 			var screenDepth = wr.Screen3DPxPosition(pos).Z;
-			var tl = new float3(decorationBounds.Left, decorationBounds.Top, 0);
-			var br = new float3(decorationBounds.Right, decorationBounds.Bottom, 0);
+			var tl = new float3(decorationBounds.Left, decorationBounds.Top, screenDepth);
+			var br = new float3(decorationBounds.Right, decorationBounds.Bottom, screenDepth);
 			var tr = new float3(br.X, tl.Y, screenDepth);
 			var bl = new float3(tl.X, br.Y, screenDepth);
 			var u = new float2(4 * iz, 0);


### PR DESCRIPTION
Fixes a regression from #14531 that makes the top-left and bottom-right corners of the selection box disappear when selected actors in TS are in the top half of the screen (with pixel doubling disabled).  Notice that `tr` and `bl` already set this.