### PR TITLE
Reject invalid orders from unvalidated clients.

### DIFF
--- a/OpenRA.Game/Server/Connection.cs
+++ b/OpenRA.Game/Server/Connection.cs
@@ -25,6 +25,7 @@ namespace OpenRA.Server
 		public int ExpectLength = 8;
 		public int Frame = 0;
 		public int MostRecentFrame = 0;
+		public bool Validated;
 
 		public long TimeSinceLastResponse { get { return Game.RunTime - lastReceivedTime; } }
 		public bool TimeoutMessageShown = false;


### PR DESCRIPTION
This fixes an exploit that allows unsolicited and anonymous chat messages to be sent to a server. See https://www.twitch.tv/videos/211729111 from 1:45:30.

Thanks to @netnazgul for reporting this!