### PR TITLE
Add player list to MP server browser.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
@@ -317,7 +317,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						if (addressNode != null)
 							addressNode.Value.Value = bl.Address.ToString().Split(':')[0] + ":" + addressNode.Value.Value.Split(':')[1];
 
-						lanGames.Add(new GameServer(game));
+						try
+						{
+							lanGames.Add(new GameServer(game));
+						}
+						catch { }
 					}
 				}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
@@ -689,7 +689,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (game.State == (int)ServerState.WaitingPlayers && !filters.HasFlag(MPGameFilters.Waiting) && game.Players != 0)
 				return true;
 
-			if (game.Players == 0 && !filters.HasFlag(MPGameFilters.Empty))
+			if ((game.Players + game.Spectators) == 0 && !filters.HasFlag(MPGameFilters.Empty))
 				return true;
 
 			if (!game.IsCompatible && !filters.HasFlag(MPGameFilters.Incompatible))

--- a/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
@@ -563,10 +563,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						var players = item.GetOrNull<LabelWidget>("PLAYERS");
 						if (players != null)
 						{
-							players.GetText = () => "{0} / {1}".F(game.Players, game.MaxPlayers)
+							var label = "{0} / {1}".F(game.Players + game.Bots, game.MaxPlayers + game.Bots)
 								+ (game.Spectators > 0 ? " + {0}".F(game.Spectators) : "");
 
-							players.GetColor = () => canJoin ? players.TextColor : incompatibleGameColor;
+							var color = canJoin ? players.TextColor : incompatibleGameColor;
+							players.GetText = () => label;
+							players.GetColor = () => color;
 						}
 
 						var state = item.GetOrNull<LabelWidget>("STATUS");

--- a/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
@@ -334,7 +334,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Game.RunAfterTick(() => RefreshServerListInner(games));
 			};
 
-			var queryURL = services.ServerList + "games?version={0}&mod={1}&modversion={2}".F(
+			var queryURL = services.ServerList + "games?protocol={0}&engine={1}&mod={2}&version={3}".F(
+				GameServer.ProtocolVersion,
 				Uri.EscapeUriString(Game.EngineVersion),
 				Uri.EscapeUriString(Game.ModData.Manifest.Id),
 				Uri.EscapeUriString(Game.ModData.Manifest.Metadata.Version));
@@ -346,11 +347,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			// Games that we can't join are sorted last
 			if (!testEntry.IsCompatible)
-				return testEntry.ModId == modData.Manifest.Id ? 1 : 0;
+				return testEntry.Mod == modData.Manifest.Id ? 1 : 0;
 
 			// Games for the current mod+version are sorted first
-			if (testEntry.ModId == modData.Manifest.Id)
-				return testEntry.ModVersion == modData.Manifest.Metadata.Version ? 4 : 3;
+			if (testEntry.Mod == modData.Manifest.Id)
+				return testEntry.Version == modData.Manifest.Metadata.Version ? 4 : 3;
 
 			// Followed by games for different mods that are joinable
 			return 2;
@@ -405,7 +406,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			nextServerRow = null;
 			var rows = new List<Widget>();
-			var mods = games.GroupBy(g => g.Mods)
+			var mods = games.GroupBy(g => g.ModLabel)
 				.OrderByDescending(g => GroupSortOrder(g.First()))
 				.ThenByDescending(g => g.Count());
 
@@ -553,10 +554,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				var label = "In progress";
 
-				DateTime startTime;
-				if (DateTime.TryParse(game.Started, out startTime))
+				if (game.PlayTime > 0)
 				{
-					var totalMinutes = Math.Ceiling((DateTime.UtcNow - startTime).TotalMinutes);
+					var totalMinutes = Math.Ceiling(game.PlayTime / 60.0);
 					label += " for {0} minute{1}".F(totalMinutes, totalMinutes > 1 ? "s" : "");
 				}
 

--- a/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
@@ -22,7 +22,6 @@ namespace OpenRA.Mods.Common.Widgets
 	public class SpawnOccupant
 	{
 		public readonly HSLColor Color;
-		public readonly int ClientIndex;
 		public readonly string PlayerName;
 		public readonly int Team;
 		public readonly string Faction;
@@ -31,7 +30,6 @@ namespace OpenRA.Mods.Common.Widgets
 		public SpawnOccupant(Session.Client client)
 		{
 			Color = client.Color;
-			ClientIndex = client.Index;
 			PlayerName = client.Name;
 			Team = client.Team;
 			Faction = client.Faction;
@@ -41,10 +39,18 @@ namespace OpenRA.Mods.Common.Widgets
 		public SpawnOccupant(GameInformation.Player player)
 		{
 			Color = player.Color;
-			ClientIndex = player.ClientIndex;
 			PlayerName = player.Name;
 			Team = player.Team;
 			Faction = player.FactionId;
+			SpawnPoint = player.SpawnPoint;
+		}
+
+		public SpawnOccupant(GameClient player, bool suppressFaction)
+		{
+			Color = player.Color;
+			PlayerName = player.Name;
+			Team = player.Team;
+			Faction = !suppressFaction ? player.Faction : null;
 			SpawnPoint = player.SpawnPoint;
 		}
 	}

--- a/mods/cnc/chrome/multiplayer-browser.yaml
+++ b/mods/cnc/chrome/multiplayer-browser.yaml
@@ -118,6 +118,7 @@ Container@MULTIPLAYER_PANEL:
 									Y: 1
 									Width: PARENT_RIGHT - 2
 									Height: PARENT_BOTTOM - 2
+									TooltipContainer: TOOLTIP_CONTAINER
 						Label@SELECTED_MAP:
 							Y: 172
 							Width: PARENT_RIGHT
@@ -148,6 +149,10 @@ Container@MULTIPLAYER_PANEL:
 							Height: 25
 							Font: TinyBold
 							Align: Center
+						Container@CLIENT_LIST_CONTAINER:
+							Y: 240
+							Width: PARENT_RIGHT
+							Height: 230
 						Button@JOIN_BUTTON:
 							Key: return
 							Y: 255
@@ -186,48 +191,3 @@ Container@MULTIPLAYER_PANEL:
 			Height: 35
 			Text: Back
 		TooltipContainer@TOOLTIP_CONTAINER:
-
-ScrollPanel@MULTIPLAYER_FILTER_PANEL:
-	Width: 147
-	Height: 130
-	Background: panel-black
-	Children:
-		Checkbox@WAITING_FOR_PLAYERS:
-			X: 5
-			Y: 5
-			Width: PARENT_RIGHT - 29
-			Height: 20
-			Text: Waiting
-			TextColor: 32CD32
-			Font: Regular
-		Checkbox@EMPTY:
-			X: 5
-			Y: 30
-			Width: PARENT_RIGHT - 29
-			Height: 20
-			Text: Empty
-			Font: Regular
-		Checkbox@PASSWORD_PROTECTED:
-			X: 5
-			Y: 55
-			Width: PARENT_RIGHT - 29
-			Height: 20
-			Text: Protected
-			TextColor: FF0000
-			Font: Regular
-		Checkbox@ALREADY_STARTED:
-			X: 5
-			Y: 80
-			Width: PARENT_RIGHT - 29
-			Height: 20
-			Text: Started
-			TextColor: FFA500
-			Font: Regular
-		Checkbox@INCOMPATIBLE_VERSION:
-			X: 5
-			Y: 105
-			Width: PARENT_RIGHT - 29
-			Height: 20
-			Text: Incompatible
-			TextColor: BEBEBE
-			Font: Regular

--- a/mods/cnc/chrome/multiplayer-browserpanels.yaml
+++ b/mods/cnc/chrome/multiplayer-browserpanels.yaml
@@ -1,0 +1,85 @@
+ScrollPanel@MULTIPLAYER_CLIENT_LIST:
+	Width: PARENT_RIGHT
+	Height: 225
+	IgnoreChildMouseOver: true
+	Children:
+		ScrollItem@HEADER:
+			Width: PARENT_RIGHT - 27
+			Height: 13
+			X: 2
+			Y: 0
+			Visible: false
+			Children:
+				Label@LABEL:
+					Font: TinyBold
+					Width: PARENT_RIGHT
+					Height: 10
+					Align: Center
+		ScrollItem@TEMPLATE:
+			Width: PARENT_RIGHT - 27
+			Height: 25
+			X: 2
+			Y: 0
+			Visible: false
+			Children:
+				Image@FLAG:
+					X: 4
+					Y: 5
+					Width: 32
+					Height: 16
+					Visible: False
+				Label@LABEL:
+					X: 40
+					Width: PARENT_RIGHT - 50
+					Height: 23
+					Shadow: True
+				Label@NOFLAG_LABEL:
+					X: 5
+					Width: PARENT_RIGHT
+					Height: 23
+					Shadow: True
+
+ScrollPanel@MULTIPLAYER_FILTER_PANEL:
+	Width: 147
+	Height: 130
+	Background: panel-black
+	Children:
+		Checkbox@WAITING_FOR_PLAYERS:
+			X: 5
+			Y: 5
+			Width: PARENT_RIGHT - 29
+			Height: 20
+			Text: Waiting
+			TextColor: 32CD32
+			Font: Regular
+		Checkbox@EMPTY:
+			X: 5
+			Y: 30
+			Width: PARENT_RIGHT - 29
+			Height: 20
+			Text: Empty
+			Font: Regular
+		Checkbox@PASSWORD_PROTECTED:
+			X: 5
+			Y: 55
+			Width: PARENT_RIGHT - 29
+			Height: 20
+			Text: Protected
+			TextColor: FF0000
+			Font: Regular
+		Checkbox@ALREADY_STARTED:
+			X: 5
+			Y: 80
+			Width: PARENT_RIGHT - 29
+			Height: 20
+			Text: Started
+			TextColor: FFA500
+			Font: Regular
+		Checkbox@INCOMPATIBLE_VERSION:
+			X: 5
+			Y: 105
+			Width: PARENT_RIGHT - 29
+			Height: 20
+			Text: Incompatible
+			TextColor: BEBEBE
+			Font: Regular

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -90,6 +90,7 @@ Assemblies:
 ChromeLayout:
 	cnc|chrome/mainmenu.yaml
 	cnc|chrome/multiplayer-browser.yaml
+	cnc|chrome/multiplayer-browserpanels.yaml
 	cnc|chrome/multiplayer-createserver.yaml
 	cnc|chrome/multiplayer-directconnect.yaml
 	cnc|chrome/lobby.yaml

--- a/mods/common/chrome/multiplayer-browser.yaml
+++ b/mods/common/chrome/multiplayer-browser.yaml
@@ -3,7 +3,7 @@ Background@MULTIPLAYER_PANEL:
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
 	Width: 808
-	Height: 600
+	Height: 550
 	Children:
 		Label@TITLE:
 			Y: 15
@@ -114,6 +114,7 @@ Background@MULTIPLAYER_PANEL:
 							Y: 1
 							Width: PARENT_RIGHT - 2
 							Height: PARENT_BOTTOM - 2
+							TooltipContainer: TOOLTIP_CONTAINER
 				Label@SELECTED_MAP:
 					Y: 172
 					Width: PARENT_RIGHT
@@ -144,6 +145,10 @@ Background@MULTIPLAYER_PANEL:
 					Height: 25
 					Font: TinyBold
 					Align: Center
+				Container@CLIENT_LIST_CONTAINER:
+					Y: 240
+					Width: PARENT_RIGHT
+					Height: 166
 				Button@JOIN_BUTTON:
 					Key: return
 					Y: 255
@@ -188,47 +193,3 @@ Background@MULTIPLAYER_PANEL:
 			Text: Back
 			Font: Bold
 		TooltipContainer@TOOLTIP_CONTAINER:
-
-ScrollPanel@MULTIPLAYER_FILTER_PANEL:
-	Width: 158
-	Height: 130
-	Children:
-		Checkbox@WAITING_FOR_PLAYERS:
-			X: 5
-			Y: 5
-			Width: PARENT_RIGHT - 29
-			Height: 20
-			Text: Waiting
-			TextColor: 32CD32
-			Font: Regular
-		Checkbox@EMPTY:
-			X: 5
-			Y: 30
-			Width: PARENT_RIGHT - 29
-			Height: 20
-			Text: Empty
-			Font: Regular
-		Checkbox@PASSWORD_PROTECTED:
-			X: 5
-			Y: 55
-			Width: PARENT_RIGHT - 29
-			Height: 20
-			Text: Protected
-			TextColor: FF0000
-			Font: Regular
-		Checkbox@ALREADY_STARTED:
-			X: 5
-			Y: 80
-			Width: PARENT_RIGHT - 29
-			Height: 20
-			Text: Started
-			TextColor: FFA500
-			Font: Regular
-		Checkbox@INCOMPATIBLE_VERSION:
-			X: 5
-			Y: 105
-			Width: PARENT_RIGHT - 29
-			Height: 20
-			Text: Incompatible
-			TextColor: BEBEBE
-			Font: Regular

--- a/mods/common/chrome/multiplayer-browserpanels.yaml
+++ b/mods/common/chrome/multiplayer-browserpanels.yaml
@@ -1,0 +1,85 @@
+ScrollPanel@MULTIPLAYER_CLIENT_LIST:
+	Width: PARENT_RIGHT
+	Height: 159
+	IgnoreChildMouseOver: true
+	Children:
+		ScrollItem@HEADER:
+			BaseName: scrollheader
+			Width: PARENT_RIGHT - 27
+			Height: 13
+			X: 2
+			Y: 0
+			Visible: false
+			Children:
+				Label@LABEL:
+					Font: TinyBold
+					Width: PARENT_RIGHT
+					Height: 10
+					Align: Center
+		ScrollItem@TEMPLATE:
+			Width: PARENT_RIGHT - 27
+			Height: 25
+			X: 2
+			Y: 0
+			Visible: false
+			Children:
+				Image@FLAG:
+					X: 4
+					Y: 6
+					Width: 32
+					Height: 16
+					Visible: False
+				Label@LABEL:
+					X: 40
+					Width: PARENT_RIGHT - 50
+					Height: 23
+					Shadow: True
+				Label@NOFLAG_LABEL:
+					X: 5
+					Width: PARENT_RIGHT
+					Height: 23
+					Shadow: True
+					
+ScrollPanel@MULTIPLAYER_FILTER_PANEL:
+	Width: 158
+	Height: 130
+	Children:
+		Checkbox@WAITING_FOR_PLAYERS:
+			X: 5
+			Y: 5
+			Width: PARENT_RIGHT - 29
+			Height: 20
+			Text: Waiting
+			TextColor: 32CD32
+			Font: Regular
+		Checkbox@EMPTY:
+			X: 5
+			Y: 30
+			Width: PARENT_RIGHT - 29
+			Height: 20
+			Text: Empty
+			Font: Regular
+		Checkbox@PASSWORD_PROTECTED:
+			X: 5
+			Y: 55
+			Width: PARENT_RIGHT - 29
+			Height: 20
+			Text: Protected
+			TextColor: FF0000
+			Font: Regular
+		Checkbox@ALREADY_STARTED:
+			X: 5
+			Y: 80
+			Width: PARENT_RIGHT - 29
+			Height: 20
+			Text: Started
+			TextColor: FFA500
+			Font: Regular
+		Checkbox@INCOMPATIBLE_VERSION:
+			X: 5
+			Y: 105
+			Width: PARENT_RIGHT - 29
+			Height: 20
+			Text: Incompatible
+			TextColor: BEBEBE
+			Font: Regular

--- a/mods/d2k/chrome/multiplayer-browserpanels.yaml
+++ b/mods/d2k/chrome/multiplayer-browserpanels.yaml
@@ -1,0 +1,84 @@
+ScrollPanel@MULTIPLAYER_CLIENT_LIST:
+	Width: PARENT_RIGHT
+	Height: 159
+	IgnoreChildMouseOver: true
+	Children:
+		ScrollItem@HEADER:
+			BaseName: scrollheader
+			Width: PARENT_RIGHT - 27
+			Height: 13
+			X: 2
+			Y: 0
+			Visible: false
+			Children:
+				Label@LABEL:
+					Font: TinyBold
+					Width: PARENT_RIGHT
+					Height: 10
+					Align: Center
+		ScrollItem@TEMPLATE:
+			Width: PARENT_RIGHT - 27
+			Height: 25
+			X: 2
+			Y: 0
+			Visible: false
+			Children:
+				Image@FLAG:
+					X: 4
+					Y: 2
+					Width: 32
+					Height: 16
+					Visible: False
+				Label@LABEL:
+					X: 35
+					Width: PARENT_RIGHT - 45
+					Height: 23
+					Shadow: True
+				Label@NOFLAG_LABEL:
+					X: 5
+					Width: PARENT_RIGHT
+					Height: 23
+					
+ScrollPanel@MULTIPLAYER_FILTER_PANEL:
+	Width: 158
+	Height: 130
+	Children:
+		Checkbox@WAITING_FOR_PLAYERS:
+			X: 5
+			Y: 5
+			Width: PARENT_RIGHT - 29
+			Height: 20
+			Text: Waiting
+			TextColor: 32CD32
+			Font: Regular
+		Checkbox@EMPTY:
+			X: 5
+			Y: 30
+			Width: PARENT_RIGHT - 29
+			Height: 20
+			Text: Empty
+			Font: Regular
+		Checkbox@PASSWORD_PROTECTED:
+			X: 5
+			Y: 55
+			Width: PARENT_RIGHT - 29
+			Height: 20
+			Text: Protected
+			TextColor: FF0000
+			Font: Regular
+		Checkbox@ALREADY_STARTED:
+			X: 5
+			Y: 80
+			Width: PARENT_RIGHT - 29
+			Height: 20
+			Text: Started
+			TextColor: FFA500
+			Font: Regular
+		Checkbox@INCOMPATIBLE_VERSION:
+			X: 5
+			Y: 105
+			Width: PARENT_RIGHT - 29
+			Height: 20
+			Text: Incompatible
+			TextColor: BEBEBE
+			Font: Regular

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -91,6 +91,7 @@ ChromeLayout:
 	common|chrome/color-picker.yaml
 	common|chrome/map-chooser.yaml
 	common|chrome/multiplayer-browser.yaml
+	d2k|chrome/multiplayer-browserpanels.yaml
 	common|chrome/multiplayer-createserver.yaml
 	common|chrome/multiplayer-directconnect.yaml
 	common|chrome/connection.yaml

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -106,6 +106,7 @@ ChromeLayout:
 	common|chrome/color-picker.yaml
 	common|chrome/map-chooser.yaml
 	common|chrome/multiplayer-browser.yaml
+	common|chrome/multiplayer-browserpanels.yaml
 	common|chrome/multiplayer-createserver.yaml
 	common|chrome/multiplayer-directconnect.yaml
 	common|chrome/connection.yaml

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -154,6 +154,7 @@ ChromeLayout:
 	ts|chrome/color-picker.yaml
 	common|chrome/map-chooser.yaml
 	common|chrome/multiplayer-browser.yaml
+	common|chrome/multiplayer-browserpanels.yaml
 	common|chrome/multiplayer-createserver.yaml
 	common|chrome/multiplayer-directconnect.yaml
 	common|chrome/connection.yaml


### PR DESCRIPTION
This switches the game client over to the new master server protocol (https://github.com/OpenRA/OpenRAMasterServer/pull/41, https://github.com/OpenRA/OpenRAMasterServer/pull/42, https://github.com/OpenRA/OpenRAMasterServer/pull/43, https://github.com/OpenRA/OpenRAMasterServer/pull/44) and uses it to drive a new server player list.

![screen shot 2017-12-24 at 15 23 24](https://user-images.githubusercontent.com/167819/34330228-712331ce-e911-11e7-85ab-88bd2867273b.png)

The list is hidden for servers that do not yet use the new protocol.  Factions are hidden for servers on other mods, since we don't have the artwork to display them.

This also unifies the way that game advertisements are handled between LAN and Online games.

Closes #13768
Closes #11646
Closes #14569