### PR TITLE
TD - Added Burst to APC

### DIFF
--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -129,7 +129,7 @@ MachineGunH:
 			Light: 80
 
 APCGun:
-	ReloadDelay: 18
+	ReloadDelay: 19
 	Range: 5c0
 	Report: gun20.aud
 	Projectile: Bullet
@@ -146,6 +146,8 @@ APCGun:
 	Warhead@2Eff: CreateEffect
 		Explosions: small_poof
 		ValidTargets: Ground, Water, Air
+	Burst: 2
+	BurstDelays: 18
 
 APCGun.AA:
 	Inherits: APCGun


### PR DESCRIPTION
Added `Burst` and `BurstDelay` to `APCGun` (TD) Armament to make use of both barrels. Issue #14464 

Now both barrels shoot at almost the same speed as before. Changing `BurstDelay` to 18 without increasing `ReloadDelay` to 19 ends up in use of only the second barrel instead of only the first one. The solution is not perfect but it seams near it. I am glad for any feedback.