### PR TITLE
Cycle through all Armament.LocalOffsets if weapon has Burst: 1

### DIFF
--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -39,7 +39,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Time (in frames) until the weapon can fire again.")]
 		public readonly int FireDelay = 0;
 
-		[Desc("Muzzle position relative to turret or body. (forward, right, up) triples")]
+		[Desc("Muzzle position relative to turret or body, (forward, right, up) triples.",
+			"If weapon Burst = 1, it cycles through all listed offsets, otherwise the offset corresponding to current burst is used.")]
 		public readonly WVec[] LocalOffset = { };
 
 		[Desc("Muzzle yaw relative to turret or body.")]
@@ -113,6 +114,8 @@ namespace OpenRA.Mods.Common.Traits
 		IEnumerable<int> inaccuracyModifiers;
 
 		int ticksSinceLastShot;
+		int currentBarrel;
+		int barrelCount;
 
 		List<Pair<int, Action>> delayedActions = new List<Pair<int, Action>>();
 
@@ -140,6 +143,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (barrels.Count == 0)
 				barrels.Add(new Barrel { Offset = WVec.Zero, Yaw = WAngle.Zero });
+
+			barrelCount = barrels.Count;
 
 			Barrels = barrels.ToArray();
 		}
@@ -232,7 +237,10 @@ namespace OpenRA.Mods.Common.Traits
 
 			ticksSinceLastShot = 0;
 
-			var barrel = Barrels[Burst % Barrels.Length];
+			// If Weapon.Burst == 1, cycle through all LocalOffsets, otherwise use the offset corresponding to current Burst
+			currentBarrel %= barrelCount;
+			var barrel = Weapon.Burst == 1 ? Barrels[currentBarrel] : Barrels[Burst % Barrels.Length];
+			currentBarrel++;
 
 			FireBarrel(self, facing, target, barrel);
 

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -75,8 +75,6 @@ BikeRockets:
 OrcaAGMissiles:
 	Inherits: ^MissileWeapon
 	ReloadDelay: 12
-	Burst: 2
-	BurstDelays: 12
 	Range: 5c0
 	MinRange: 1c256
 	ValidTargets: Ground

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -294,11 +294,11 @@ HELI:
 		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: HellfireAA
-		LocalOffset: 0,-213,-85
+		LocalOffset: 0,-213,-85, 0,213,-85
 		PauseOnCondition: !ammo
 	Armament@SECONDARY:
 		Weapon: HellfireAG
-		LocalOffset: 0,213,-85
+		LocalOffset: 0,213,-85, 0,-213,-85
 		PauseOnCondition: !ammo
 	AttackHeli:
 		FacingTolerance: 20
@@ -358,13 +358,13 @@ HIND:
 		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: ChainGun
-		LocalOffset: 85,-213,-85
+		LocalOffset: 85,-213,-85, 85,213,-85
 		MuzzleSequence: muzzle
 		PauseOnCondition: !ammo
 	Armament@SECONDARY:
 		Name: secondary
 		Weapon: ChainGun
-		LocalOffset: 85,213,-85
+		LocalOffset: 85,213,-85, 85,-213,-85
 		MuzzleSequence: muzzle
 		PauseOnCondition: !ammo
 	AttackHeli:

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -44,8 +44,6 @@ LtRail:
 MechRailgun:
 	Inherits: ^Railgun
 	Range: 8c0
-	Burst: 2 # for alternating muzzle offsets, dmg/s identical to original
-	BurstDelays: 60
 	Report: railuse5.aud
 	Projectile: Railgun
 		BeamColor: 00FFFFC8

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -93,8 +93,6 @@ MammothTusk:
 
 BikeMissile:
 	Inherits: ^DefaultMissile
-	Burst: 2 # to make bike alternate between left and right launcher, no change in dmg/s compared to original TS
-	BurstDelays: 60
 	Range: 5c0
 	Report: misl1.aud
 	ValidTargets: Ground

--- a/mods/ts/weapons/smallguns.yaml
+++ b/mods/ts/weapons/smallguns.yaml
@@ -85,8 +85,6 @@ RaiderCannon:
 	Inherits: ^MG
 	ReloadDelay: 55
 	Range: 4c0
-	Burst: 2 # this + BurstDelay just makes the buggy alternate between barrels (for muzzle flash), no actual difference to original TS
-	BurstDelays: 55
 	Report: chaingn1.aud
 	Warhead@1Dam: SpreadDamage
 		Damage: 40


### PR DESCRIPTION
While the approach in #14578 might be good enough in some cases, the fact that modders are forced to use BurstDelay < ReloadDelay and therefore couldn't balance this 100% perfectly just highlights that this needs a code-level solution.

Also, TS was still using values from a time when BurstDelay == ReloadDelay was supposed to be supported (but dropped due to other technical issues that would have caused).

Fixes #14464.
Fixes #14577.