### PR TITLE
Add outdated/unknown version and new playtest notices to the MP server browser.

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
@@ -108,11 +108,11 @@ namespace OpenRA.Mods.Common.Server
 			{
 				try
 				{
-					var serverList = server.ModData.Manifest.Get<WebServices>().ServerList;
+					var endpoint = server.ModData.Manifest.Get<WebServices>().ServerAdvertise;
 					using (var wc = new WebClient())
 					{
 						wc.Proxy = null;
-						var masterResponseText = wc.UploadString(serverList + "ping", postData);
+						var masterResponseText = wc.UploadString(endpoint, postData);
 
 						if (isInitialPing)
 						{

--- a/OpenRA.Mods.Common/WebServices.cs
+++ b/OpenRA.Mods.Common/WebServices.cs
@@ -15,7 +15,8 @@ namespace OpenRA
 {
 	public class WebServices : IGlobalModData
 	{
-		public readonly string ServerList = "http://master.openra.net/";
+		public readonly string ServerList = "http://master.openra.net/games";
+		public readonly string ServerAdvertise = "http://master.openra.net/ping";
 		public readonly string MapRepository = "http://resource.openra.net/map/";
 		public readonly string GameNews = "http://master.openra.net/gamenews";
 	}

--- a/OpenRA.Mods.Common/WebServices.cs
+++ b/OpenRA.Mods.Common/WebServices.cs
@@ -19,5 +19,6 @@ namespace OpenRA
 		public readonly string ServerAdvertise = "http://master.openra.net/ping";
 		public readonly string MapRepository = "http://resource.openra.net/map/";
 		public readonly string GameNews = "http://master.openra.net/gamenews";
+		public readonly string MPNotices = "http://master.openra.net/notices";
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
@@ -348,7 +348,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Game.RunAfterTick(() => RefreshServerListInner(games));
 			};
 
-			var queryURL = services.ServerList + "games?protocol={0}&engine={1}&mod={2}&version={3}".F(
+			var queryURL = services.ServerList + "?protocol={0}&engine={1}&mod={2}&version={3}".F(
 				GameServer.ProtocolVersion,
 				Uri.EscapeUriString(Game.EngineVersion),
 				Uri.EscapeUriString(Game.ModData.Manifest.Id),

--- a/mods/cnc/chrome/multiplayer-browser.yaml
+++ b/mods/cnc/chrome/multiplayer-browser.yaml
@@ -48,6 +48,38 @@ Container@MULTIPLAYER_PANEL:
 							Height: 25
 							Text: Status
 							Font: Bold
+				Container@NOTICE_CONTAINER:
+					X: 15
+					Y: 30
+					Width: 582
+					Height: 19
+					Children:
+						Background@bg:
+							Width: PARENT_RIGHT
+							Height: 20
+							Background: panel-black
+							Children:
+								Label@OUTDATED_VERSION_LABEL:
+									X: 5
+									Width: PARENT_RIGHT-10
+									Height: 18
+									Align: Center
+									Text: You are running an outdated version of OpenRA. Download the latest version from www.openra.net
+									Font: TinyBold
+								Label@UNKNOWN_VERSION_LABEL:
+									X: 5
+									Width: PARENT_RIGHT-10
+									Height: 18
+									Align: Center
+									Text: You are running an unrecognized version of OpenRA. Download the latest version from www.openra.net
+									Font: TinyBold
+								Label@PLAYTEST_AVAILABLE_LABEL:
+									X: 5
+									Width: PARENT_RIGHT-10
+									Height: 18
+									Align: Center
+									Text: A pre-release version of OpenRA is available for testing. Download the playtest from www.openra.net
+									Font: TinyBold
 				ScrollPanel@SERVER_LIST:
 					X: 15
 					Y: 30

--- a/mods/common/chrome/multiplayer-browser.yaml
+++ b/mods/common/chrome/multiplayer-browser.yaml
@@ -43,6 +43,34 @@ Background@MULTIPLAYER_PANEL:
 					Height: 25
 					Text: Status
 					Font: Bold
+		Background@NOTICE_CONTAINER:
+			X: 20
+			Y: 67
+			Width: 583
+			Height: 20
+			Background: dialog2
+			Children:
+				Label@OUTDATED_VERSION_LABEL:
+					X: 5
+					Width: PARENT_RIGHT-10
+					Height: 18
+					Align: Center
+					Text: You are running an outdated version of OpenRA. Download the latest version from www.openra.net
+					Font: TinyBold
+				Label@UNKNOWN_VERSION_LABEL:
+					X: 5
+					Width: PARENT_RIGHT-10
+					Height: 18
+					Align: Center
+					Text: You are running an unrecognized version of OpenRA. Download the latest version from www.openra.net
+					Font: TinyBold
+				Label@PLAYTEST_AVAILABLE_LABEL:
+					X: 5
+					Width: PARENT_RIGHT-10
+					Height: 18
+					Align: Center
+					Text: A pre-release version of OpenRA is available for testing. Download the playtest from www.openra.net
+					Font: TinyBold
 		ScrollPanel@SERVER_LIST:
 			X: 20
 			Y: 67


### PR DESCRIPTION
This replaces yet another failed usecase of the ingame IRC with a better integrated solution.
Banners are displayed at the top of the server list if the player is running an outdated or unknown version of our default mods, or if they are running the latest version and a playtest is available.

![notices](https://user-images.githubusercontent.com/167819/34359512-99f926cc-ea50-11e7-8e29-b282d8f76738.png)

Depends on #14571.

The master server will only give notices for our ra, cnc, and d2k mods.  Other mods must change `MPNotices` in mod.yaml to point at their own backend if they want to use this.

I have set up a placeholder backend service to help with testing:
* A new playtest notice is given for d2k version `release-20171014`.
* No notices are given for other the other mods on `release-20171014`.
* An outdated version notice is given if the version otherwise starts with `release-` or `playtest-`.

I will PR the final backend against the master server after this and the outstanding [protocol rewrite PRs](https://github.com/OpenRA/OpenRAMasterServer/pulls) have been merged.  It will work by fetching a JSON file from https://github.com/OpenRA/OpenRAWeb that contains lists of current and outdated versions.