### PR TITLE
Burnt Trees using RadarColor from trees

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -877,6 +877,8 @@
 	Inherits@1: ^SpriteActor
 	Interactable:
 	AppearsOnRadar:
+	RadarColorFromTerrain:
+		Terrain: Tree
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -879,6 +879,8 @@
 	RenderSprites:
 		Palette: terrain
 	AppearsOnRadar:
+	RadarColorFromTerrain:
+		Terrain: Tree
 	Building:
 		Footprint: x
 		Dimensions: 1,1


### PR DESCRIPTION
Burnt Trees now use RadarColor from Trees on the Radar instead of none (white).

The Radarmap showed white pixels at burned trees location before.
This yaml-edit Fixes #14582 and concerns only mods with flammable trees (TD and RA so far)