### PR TITLE
D2K carryall pickup indicator offset fix

### DIFF
--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -207,7 +207,8 @@
 	WithDecoration@CARRYALL:
 		Image: pips
 		Sequence: pickup-indicator
-		ReferencePoint: Center
+		ReferencePoint: Top, Left
+		ZOffset: 256
 		RequiresCondition: carryall-reserved
 	RevealOnFire:
 	RevealOnDeath:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -207,7 +207,7 @@
 	WithDecoration@CARRYALL:
 		Image: pips
 		Sequence: pickup-indicator
-		Offset: -12, -12
+		ReferencePoint: Center
 		RequiresCondition: carryall-reserved
 	RevealOnFire:
 	RevealOnDeath:

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -133,6 +133,7 @@ pips:
 		Offset: 3, 3
 	pickup-indicator: DATA.R8
 		Start: 112
+		Offset: -15, -15
 	pip-empty: DATA.R8
 		Start: 15
 	pip-green: DATA.R8

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -133,7 +133,7 @@ pips:
 		Offset: 3, 3
 	pickup-indicator: DATA.R8
 		Start: 112
-		Offset: -15, -15
+		Offset: -9, -9
 	pip-empty: DATA.R8
 		Start: 15
 	pip-green: DATA.R8


### PR DESCRIPTION
This Fixes #14487 jumping `pickup-indicator` when zooming in/out.

EDIT: `ReferencePoint: Top, Left`, Offset adjusted as seen on [compare_image](https://www.dropbox.com/s/nwzmjl1p0b27axe/openra_pickup.png?dl=0).
<strike>Also the icons should scale on zoom.</strike>

 [d2k Vanilla video source](https://www.youtube.com/watch?v=4P6lANvfXog) 