### PR TITLE
Fixes mines not auto-targeted even if revealed.

### DIFF
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -1050,7 +1050,7 @@
 	Tooltip:
 		Name: Mine
 	Targetable:
-		TargetTypes: Ground
+		TargetTypes: Ground, Defense
 	Immobile:
 		OccupiesSpace: true
 	HitShape:


### PR DESCRIPTION
Fixes #14278. Mines are now always auto-targeted if revealed.
Classifying mines as Defense structure makes sense, too, in my oppinion.