### PR TITLE
Multiply damage and HP by 100 for TS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -76,6 +76,7 @@ Also thanks to:
     * Jan-Willem Buurlage (jwbuurlage)
     * Jason (atlimit8)
     * Jeff Harris (jeff_1amstudios)
+    * Jefri Sevkin (Arular)
     * Jes
     * Joakim Lindberg (booom3)
     * John Turner (whinis)

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -1305,7 +1305,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				if (engineVersion < 20171212)
 				{
 					var mod = modData.Manifest.Id;
-					if (mod == "cnc" || mod == "ra" || mod == "d2k")
+					if (mod == "cnc" || mod == "ra" || mod == "d2k" || mod == "ts")
 					{
 						if (node.Key == "HP" && parent.Key == "Health")
 						{
@@ -1717,7 +1717,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				if (engineVersion < 20171212)
 				{
 					var mod = modData.Manifest.Id;
-					if (mod == "cnc" || mod == "ra" || mod == "d2k")
+					if (mod == "cnc" || mod == "ra" || mod == "d2k" || mod == "ts")
 					{
 						if (node.Key == "Damage" && (parent.Value.Value == "SpreadDamage" || parent.Value.Value == "TargetDamage"))
 						{

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -12,7 +12,7 @@ DPOD:
 		InitialFacing: 0
 		LandableTerrainTypes: Clear,Road,Rail,DirtRoad,Rough,Tiberium,BlueTiberium,Veins
 	Health:
-		HP: 60
+		HP: 6000
 	Armor:
 		Type: Light
 	Cargo:
@@ -47,7 +47,7 @@ DSHP:
 		LandingSound: dropdwn1.aud
 		IdealSeparation: 1275
 	Health:
-		HP: 200
+		HP: 20000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -86,7 +86,7 @@ ORCA:
 		TakeoffSound: orcaup1.aud
 		LandingSound: orcadwn1.aud
 	Health:
-		HP: 200
+		HP: 20000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -137,7 +137,7 @@ ORCAB:
 		LandingSound: orcadwn1.aud
 	ReturnOnIdle:
 	Health:
-		HP: 260
+		HP: 26000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -185,7 +185,7 @@ ORCATRAN:
 		LandingSound: orcadwn1.aud
 		IdealSeparation: 1275
 	Health:
-		HP: 200
+		HP: 20000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -225,7 +225,7 @@ TRNSPORT:
 		Voice: Move
 		LocalOffset: 0,0,-317
 	Health:
-		HP: 175
+		HP: 17500
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -267,7 +267,7 @@ SCRIN:
 		LandingSound: dropdwn1.aud
 	ReturnOnIdle:
 	Health:
-		HP: 280
+		HP: 28000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -314,7 +314,7 @@ APACHE:
 		Speed: 130
 		MoveIntoShroud: false
 	Health:
-		HP: 225
+		HP: 22500
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -352,7 +352,7 @@ HUNTER:
 	Tooltip:
 		Name: Hunter-Seeker Droid
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Light
 	AttackSuicides:

--- a/mods/ts/rules/bridges.yaml
+++ b/mods/ts/rules/bridges.yaml
@@ -41,7 +41,7 @@ CABHUT:
 		TargetTypes: Ground, Building, Bridge
 		RequiresForceFire: true
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Concrete
 	HitShape:

--- a/mods/ts/rules/civilian-infantry.yaml
+++ b/mods/ts/rules/civilian-infantry.yaml
@@ -9,7 +9,7 @@ WEEDGUY:
 	Mobile:
 		Speed: 42
 	Health:
-		HP: 130
+		HP: 13000
 	Crushable:
 		CrushSound: squishy2.aud
 	Armament:
@@ -39,7 +39,7 @@ UMAGON:
 	Mobile:
 		Speed: 71
 	Health:
-		HP: 150
+		HP: 15000
 	Passenger:
 	RevealsShroud:
 		Range: 7c0
@@ -61,7 +61,7 @@ CHAMSPY:
 	Voiced:
 		VoiceSet: Spy
 	Health:
-		HP: 120
+		HP: 12000
 	Mobile:
 		Speed: 85
 	RevealsShroud:
@@ -94,7 +94,7 @@ MUTANT:
 	Voiced:
 		VoiceSet: Mutant
 	Health:
-		HP: 50
+		HP: 5000
 	Mobile:
 		Speed: 56
 	RevealsShroud:
@@ -120,7 +120,7 @@ MWMN:
 	Voiced:
 		VoiceSet: CivilianFemale
 	Health:
-		HP: 50
+		HP: 5000
 	Mobile:
 		Speed: 56
 	RevealsShroud:
@@ -146,7 +146,7 @@ MUTANT3:
 	Voiced:
 		VoiceSet: Mutant
 	Health:
-		HP: 50
+		HP: 5000
 	Mobile:
 		Speed: 56
 	RevealsShroud:
@@ -170,7 +170,7 @@ TRATOS:
 	Voiced:
 		VoiceSet: Tratos
 	Health:
-		HP: 200
+		HP: 20000
 	Mobile:
 		Speed: 71
 	RevealsShroud:
@@ -187,7 +187,7 @@ OXANNA:
 	Voiced:
 		VoiceSet: Oxanna
 	Health:
-		HP: 50
+		HP: 5000
 	Mobile:
 		Speed: 56
 	RevealsShroud:
@@ -204,7 +204,7 @@ SLAV:
 	Voiced:
 		VoiceSet: Slavick
 	Health:
-		HP: 300
+		HP: 30000
 	Mobile:
 		Speed: 56
 	RevealsShroud:

--- a/mods/ts/rules/civilian-structures.yaml
+++ b/mods/ts/rules/civilian-structures.yaml
@@ -293,7 +293,7 @@ AMMOCRAT:
 	Armor:
 		Type: none
 	Health:
-		HP: 100
+		HP: 1
 	RenderSprites:
 		Palette: player
 

--- a/mods/ts/rules/civilian-structures.yaml
+++ b/mods/ts/rules/civilian-structures.yaml
@@ -9,7 +9,7 @@ ABAN01:
 	Armor:
 		Type: wood
 	Health:
-		HP: 600
+		HP: 60000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
@@ -28,7 +28,7 @@ ABAN02:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 600
+		HP: 60000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
@@ -47,7 +47,7 @@ ABAN03:
 	Armor:
 		Type: wood
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
@@ -66,7 +66,7 @@ ABAN04:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
@@ -89,7 +89,7 @@ ABAN05:
 	Armor:
 		Type: wood
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -104,7 +104,7 @@ ABAN06:
 	Armor:
 		Type: wood
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -119,7 +119,7 @@ ABAN07:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 350
+		HP: 35000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -134,7 +134,7 @@ ABAN08:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -149,7 +149,7 @@ ABAN09:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 350
+		HP: 35000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -164,7 +164,7 @@ ABAN10:
 	Armor:
 		Type: wood
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -179,7 +179,7 @@ ABAN11:
 	Armor:
 		Type: wood
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -194,7 +194,7 @@ ABAN12:
 	Armor:
 		Type: wood
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -208,7 +208,7 @@ ABAN13:
 	Armor:
 		Type: wood
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -222,7 +222,7 @@ ABAN14:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 300
+		HP: 30000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -236,7 +236,7 @@ ABAN15:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -251,7 +251,7 @@ ABAN16:
 	Armor:
 		Type: wood
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -265,7 +265,7 @@ ABAN17:
 	Armor:
 		Type: wood
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -279,7 +279,7 @@ ABAN18:
 	Armor:
 		Type: wood
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: TEMPERATE
 
@@ -293,7 +293,7 @@ AMMOCRAT:
 	Armor:
 		Type: none
 	Health:
-		HP: 1
+		HP: 100
 	RenderSprites:
 		Palette: player
 
@@ -430,7 +430,7 @@ CA0001:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 	ThrowsShrapnel@SMALL:
 		Pieces: 5, 9
 	ThrowsShrapnel@LARGE:
@@ -447,7 +447,7 @@ CA0002:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 	ThrowsShrapnel@SMALL:
 		Pieces: 5, 9
 	ThrowsShrapnel@LARGE:
@@ -464,7 +464,7 @@ CA0003:
 	Armor:
 		Type: light
 	Health:
-		HP: 300
+		HP: 30000
 
 CA0004:
 	Inherits: ^CivBuilding
@@ -477,7 +477,7 @@ CA0004:
 	Armor:
 		Type: light
 	Health:
-		HP: 300
+		HP: 30000
 
 CA0005:
 	Inherits: ^CivBuilding
@@ -490,7 +490,7 @@ CA0005:
 	Armor:
 		Type: light
 	Health:
-		HP: 300
+		HP: 30000
 
 CA0006:
 	Inherits: ^CivBuilding
@@ -503,7 +503,7 @@ CA0006:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 300
+		HP: 30000
 
 CA0007:
 	Inherits: ^CivBuilding
@@ -516,7 +516,7 @@ CA0007:
 	Armor:
 		Type: light
 	Health:
-		HP: 400
+		HP: 40000
 
 CA0008:
 	Inherits: ^CivBuilding
@@ -529,7 +529,7 @@ CA0008:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 
 CA0009:
 	Inherits: ^CivBuilding
@@ -542,7 +542,7 @@ CA0009:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 
 CA0010:
 	Inherits: ^CivBuilding
@@ -555,7 +555,7 @@ CA0010:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 300
+		HP: 30000
 
 CA0011:
 	Inherits: ^CivBuilding
@@ -568,7 +568,7 @@ CA0011:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 200
+		HP: 20000
 
 CA0012:
 	Inherits: ^CivBuilding
@@ -581,7 +581,7 @@ CA0012:
 	Armor:
 		Type: light
 	Health:
-		HP: 100
+		HP: 10000
 
 CA0013:
 	Inherits: ^CivBuilding
@@ -594,7 +594,7 @@ CA0013:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 300
+		HP: 30000
 
 CA0014:
 	Inherits: ^CivBuilding
@@ -606,7 +606,7 @@ CA0014:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 300
+		HP: 30000
 
 CA0015:
 	Inherits: ^CivBuilding
@@ -618,7 +618,7 @@ CA0015:
 	Armor:
 		Type: light
 	Health:
-		HP: 300
+		HP: 30000
 
 CA0016:
 	Inherits: ^CivBuilding
@@ -630,7 +630,7 @@ CA0016:
 	Armor:
 		Type: light
 	Health:
-		HP: 300
+		HP: 30000
 
 CA0017:
 	Inherits: ^CivBuilding
@@ -642,7 +642,7 @@ CA0017:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 300
+		HP: 30000
 
 CA0018:
 	Inherits: ^CivBuilding
@@ -658,7 +658,7 @@ CA0018:
 	Armor:
 		Type: light
 	Health:
-		HP: 200
+		HP: 20000
 
 CA0019:
 	Inherits: ^CivBuilding
@@ -674,7 +674,7 @@ CA0019:
 	Armor:
 		Type: light
 	Health:
-		HP: 200
+		HP: 20000
 
 CA0020:
 	Inherits: ^CivBuilding
@@ -690,7 +690,7 @@ CA0020:
 	Armor:
 		Type: light
 	Health:
-		HP: 200
+		HP: 20000
 
 CA0021:
 	Inherits: ^CivBuilding
@@ -706,7 +706,7 @@ CA0021:
 	Armor:
 		Type: light
 	Health:
-		HP: 200
+		HP: 20000
 
 CAARAY:
 	Inherits: ^CivBuilding
@@ -719,7 +719,7 @@ CAARAY:
 	Armor:
 		Type: concrete
 	Health:
-		HP: 400
+		HP: 40000
 	RenderSprites:
 		Palette: player
 	WithIdleOverlay@SATELLITE:
@@ -746,7 +746,7 @@ CAARMR:
 	Armor:
 		Type: concrete
 	Health:
-		HP: 800
+		HP: 80000
 	RenderSprites:
 		Palette: player
 	ProvidesPrerequisite:
@@ -785,7 +785,7 @@ CAHOSP:
 	Armor:
 		Type: concrete
 	Health:
-		HP: 800
+		HP: 80000
 	RenderSprites:
 		Palette: player
 	Capturable:
@@ -809,7 +809,7 @@ CAPYR01:
 	Armor:
 		Type: concrete
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: SNOW
 
@@ -824,7 +824,7 @@ CAPYR02:
 	Armor:
 		Type: concrete
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: SNOW
 	ThrowsShrapnel@SMALL:
@@ -843,7 +843,7 @@ CAPYR03:
 	Armor:
 		Type: concrete
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		ExcludeTilesets: SNOW
 	ThrowsShrapnel@SMALL:
@@ -862,7 +862,7 @@ CITY01:
 	Armor:
 		Type: wood
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
@@ -881,7 +881,7 @@ CITY02:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 700
+		HP: 70000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
@@ -900,7 +900,7 @@ CITY03:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
@@ -919,7 +919,7 @@ CITY04:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 600
+		HP: 60000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
@@ -938,7 +938,7 @@ CITY05:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 600
+		HP: 60000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
@@ -957,7 +957,7 @@ CITY06:
 	Armor:
 		Type: concrete
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
@@ -976,7 +976,7 @@ CITY07:
 	Armor:
 		Type: wood
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
@@ -995,7 +995,7 @@ CITY08:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 300
+		HP: 30000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -1010,7 +1010,7 @@ CITY09:
 	Armor:
 		Type: wood
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -1025,7 +1025,7 @@ CITY10:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 300
+		HP: 30000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -1040,7 +1040,7 @@ CITY11:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -1055,7 +1055,7 @@ CITY12:
 	Armor:
 		Type: concrete
 	Health:
-		HP: 600
+		HP: 60000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -1070,7 +1070,7 @@ CITY13:
 	Armor:
 		Type: wood
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -1084,7 +1084,7 @@ CITY14:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 600
+		HP: 60000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -1099,7 +1099,7 @@ CITY15:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
@@ -1118,7 +1118,7 @@ CITY16:
 	Armor:
 		Type: wood
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
@@ -1137,7 +1137,7 @@ CITY17:
 	Armor:
 		Type: wood
 	Health:
-		HP: 300
+		HP: 30000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
@@ -1156,7 +1156,7 @@ CITY18:
 	Armor:
 		Type: concrete
 	Health:
-		HP: 600
+		HP: 60000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
@@ -1175,7 +1175,7 @@ CITY19:
 	Armor:
 		Type: wood
 	Health:
-		HP: 500
+		HP: 50000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -1189,7 +1189,7 @@ CITY20:
 	Armor:
 		Type: wood
 	Health:
-		HP: 250
+		HP: 25000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -1203,7 +1203,7 @@ CITY21:
 	Armor:
 		Type: none
 	Health:
-		HP: 100
+		HP: 10000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -1218,7 +1218,7 @@ CITY22:
 	Armor:
 		Type: none
 	Health:
-		HP: 100
+		HP: 10000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 
@@ -1236,7 +1236,7 @@ CTDAM:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 1000
+		HP: 100000
 	ProvidesPrerequisite:
 		Prerequisite: anypower
 	EditorTilesetFilter:
@@ -1261,7 +1261,7 @@ CTVEGA:
 	Armor:
 		Type: none
 	Health:
-		HP: 100
+		HP: 10000
 	EditorTilesetFilter:
 		ExcludeTilesets: SNOW
 	ThrowsShrapnel@SMALL:
@@ -1282,7 +1282,7 @@ GAKODK:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 1500
+		HP: 150000
 	RenderSprites:
 		Palette: player
 	WithIdleOverlay@LARGELIGHTS:
@@ -1341,7 +1341,7 @@ GASAND:
 	Tooltip:
 		Name: Sandbags
 	Health:
-		HP: 250
+		HP: 25000
 	Armor:
 		Type: Light
 	LineBuild:
@@ -1369,7 +1369,7 @@ GASPOT:
 	Armor:
 		Type: wood
 	Health:
-		HP: 400
+		HP: 40000
 	RevealsShroud:
 		Range: 6c0
 		MaxHeightDelta: 3
@@ -1390,7 +1390,7 @@ GALITE:
 	-WithMakeAnimation:
 	-WithDeathAnimation:
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1426,7 +1426,7 @@ GAICBM:
 		Name: Deployed ICBM
 	-GivesBuildableArea:
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -1453,7 +1453,7 @@ NAMNTK:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 1500
+		HP: 150000
 	RenderSprites:
 		Palette: player
 	WithIdleOverlay@LIGHTS:
@@ -1472,7 +1472,7 @@ NTPYRA:
 	Armor:
 		Type: heavy
 	Health:
-		HP: 1500
+		HP: 150000
 	RenderSprites:
 		Palette: player
 	WithIdleOverlay@LIGHTS:
@@ -1496,7 +1496,7 @@ UFO:
 	Tooltip:
 		Name: Scrin Ship
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Heavy
 	EditorTilesetFilter:

--- a/mods/ts/rules/civilian-vehicles.yaml
+++ b/mods/ts/rules/civilian-vehicles.yaml
@@ -33,10 +33,10 @@
 		Voice: Attack
 		PauseOnCondition: empdisable
 	SelfHealing:
+		Step: 500
 		Delay: 10
 		HealIfBelow: 50
 		DamageCooldown: 200
-		Step: 500
 	WithVoxelTurret:
 	WithVoxelBarrel:
 	WithMuzzleOverlay:

--- a/mods/ts/rules/civilian-vehicles.yaml
+++ b/mods/ts/rules/civilian-vehicles.yaml
@@ -12,7 +12,7 @@
 		TurnSpeed: 5
 		Crushes: wall, crate, infantry
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -36,6 +36,7 @@
 		Delay: 10
 		HealIfBelow: 50
 		DamageCooldown: 200
+		Step: 500
 	WithVoxelTurret:
 	WithVoxelBarrel:
 	WithMuzzleOverlay:
@@ -47,7 +48,7 @@
 	Tooltip:
 		Name: Truck
 	Health:
-		HP: 200
+		HP: 20000
 	Armor:
 		Type: Light
 	Mobile:
@@ -70,7 +71,7 @@ ICBM:
 	Tooltip:
 		Name: Ballistic Missile Launcher
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Light
 	Mobile:
@@ -99,7 +100,7 @@ BUS:
 		Speed: 113
 		RequiresCondition: !empdisable && !loading
 	Health:
-		HP: 100
+		HP: 10000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -125,7 +126,7 @@ PICK:
 		Speed: 113
 		RequiresCondition: !empdisable && !loading
 	Health:
-		HP: 100
+		HP: 10000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -151,7 +152,7 @@ CAR:
 		Speed: 113
 		RequiresCondition: !empdisable && !loading
 	Health:
-		HP: 100
+		HP: 10000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -177,7 +178,7 @@ WINI:
 		Speed: 113
 		RequiresCondition: !empdisable && !loading
 	Health:
-		HP: 200
+		HP: 20000
 	Armor:
 		Type: Light
 	RevealsShroud:

--- a/mods/ts/rules/critters.yaml
+++ b/mods/ts/rules/critters.yaml
@@ -6,7 +6,7 @@ DOGGIE:
 	Tooltip:
 		Name: Tiberian Fiend
 	Health:
-		HP: 250
+		HP: 25000
 	Selectable:
 		Bounds: 24,24
 	Valued:
@@ -43,7 +43,7 @@ VISC_SML:
 	Tooltip:
 		Name: Baby Visceroid
 	Health:
-		HP: 200
+		HP: 20000
 	AttackWander:
 		WanderMoveRadius: 2
 		MinMoveDelay: 30
@@ -58,7 +58,7 @@ VISC_LRG:
 	Tooltip:
 		Name: Adult Visceroid
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -88,7 +88,7 @@ JFISH:
 	Tooltip:
 		Name: Tiberium Floater
 	Health:
-		HP: 500
+		HP: 50000
 	RevealsShroud:
 		Range: 5c0
 	Mobile:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -51,7 +51,7 @@
 		RequiresCondition: rank-elite
 		Modifier: 75
 	SelfHealing@ELITE:
-		Step: 2
+		Step: 200
 		Delay: 100
 		HealIfBelow: 100
 		DamageCooldown: 125
@@ -344,6 +344,7 @@
 	RepairableBuilding:
 		IndicatorPalette: mouse
 		PlayerExperience: 25
+		RepairStep: 700
 	WithDeathAnimation:
 		DeathSequence: dead
 		UseDeathTypeSuffix: false
@@ -368,7 +369,7 @@
 	Inherits: ^BasicBuilding
 	-UpdatesPlayerStatistics:
 	Health:
-		HP: 900
+		HP: 90000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -388,7 +389,7 @@
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 	RenderSprites:
 		-Palette:
 	-Cloak@EXTERNALCLOAK:
@@ -403,7 +404,7 @@
 	Armor:
 		Type: heavy
 	Health:
-		HP: 400
+		HP: 40000
 	EditorTilesetFilter:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
@@ -496,7 +497,7 @@
 	Huntable:
 	DrawLineToTarget:
 	Health:
-		HP: 50
+		HP: 5000
 	Armor:
 		Type: None
 	Valued:
@@ -546,7 +547,7 @@
 	ActorLostNotification:
 	DamagedByTerrain:
 		Terrain: Tiberium, BlueTiberium
-		Damage: 2
+		Damage: 200
 		DamageInterval: 16
 		DamageTypes: ExplosionDeath, TriggerVisceroid
 		RequiresCondition: !inside-tunnel
@@ -554,7 +555,7 @@
 		Voice: Move
 	Guardable:
 	SelfHealing@HOSPITAL:
-		Step: 5
+		Step: 500
 		Delay: 100
 		HealIfBelow: 100
 		DamageCooldown: 125
@@ -864,7 +865,7 @@
 		CameraPitch: 90
 	Aircraft:
 	Health:
-		HP: 280
+		HP: 28000
 	Armor:
 		Type: Heavy
 	HiddenUnderFog:
@@ -1050,7 +1051,7 @@
 		Types: Infantry
 		UnloadVoice: Unload
 	Health:
-		HP: 100
+		HP: 10000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -1131,7 +1132,7 @@
 	Valued:
 		Cost: 250
 	Health:
-		HP: 350
+		HP: 35000
 	Armor:
 		Type: Heavy
 	LineBuildNode:
@@ -1185,7 +1186,7 @@
 
 ^HealsOnTiberium:
 	DamagedByTerrain:
-		Damage: -2
+		Damage: -200
 		DamageInterval: 16
 		Terrain: Tiberium, BlueTiberium
 		RequiresCondition: !inside-tunnel

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -342,9 +342,9 @@
 		AreaTypes: building
 	Capturable:
 	RepairableBuilding:
+		RepairStep: 700
 		IndicatorPalette: mouse
 		PlayerExperience: 25
-		RepairStep: 700
 	WithDeathAnimation:
 		DeathSequence: dead
 		UseDeathTypeSuffix: false
@@ -1193,7 +1193,7 @@
 
 ^DamagedByVeins:
 	DamagedByTerrain@VEINS:
-		Damage: 5
+		Damage: 500
 		DamageInterval: 16
 		DamageTypes: BulletDeath
 		Terrain: Veins

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -12,7 +12,7 @@ E2:
 	Tooltip:
 		Name: Disc Thrower
 	Health:
-		HP: 150
+		HP: 15000
 	Mobile:
 		Speed: 56
 	Armament:
@@ -49,7 +49,7 @@ MEDIC:
 	Mobile:
 		Speed: 56
 	Health:
-		HP: 125
+		HP: 12500
 	Crushable:
 		CrushSound: squishy2.aud
 	Armament:
@@ -66,6 +66,7 @@ MEDIC:
 		DefaultAttackSequence: heal
 	SelfHealing:
 		Delay: 60
+		Step: 500
 	Passenger:
 		PipType: Red
 
@@ -92,7 +93,7 @@ JUMPJET:
 		TerrainSpeeds:
 			Jumpjet: 110
 	Health:
-		HP: 120
+		HP: 12000
 	Armor:
 		Type: Light
 	Passenger:
@@ -211,7 +212,7 @@ GHOST:
 	Mobile:
 		Speed: 56
 	Health:
-		HP: 200
+		HP: 20000
 	Passenger:
 	RevealsShroud:
 		Range: 6c0

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -65,8 +65,8 @@ MEDIC:
 	WithInfantryBody:
 		DefaultAttackSequence: heal
 	SelfHealing:
-		Delay: 60
 		Step: 500
+		Delay: 60
 	Passenger:
 		PipType: Red
 

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -220,9 +220,9 @@ GAHPAD:
 		PrimaryCondition: primary
 	Reservable:
 	RepairsUnits:
+		HpPerStep: 1000
 		PauseOnCondition: empdisable
 		PlayerExperience: 15
-		HpPerStep: 1000
 	ProductionBar:
 	WithIdleOverlay@PLATFORM:
 		Sequence: idle-platform
@@ -271,9 +271,9 @@ GADEPT:
 		MaxHeightDelta: 3
 	Reservable:
 	RepairsUnits:
+		HpPerStep: 1000
 		PauseOnCondition: empdisable
 		PlayerExperience: 15
-		HpPerStep: 1000
 	RallyPoint:
 		Palette: mouse
 		IsPlayerPalette: false

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -16,7 +16,7 @@ GAPOWR:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 750
+		HP: 75000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -84,7 +84,7 @@ GAPILE:
 		Bounds: 88, 48, 0, -8
 		DecorationBounds: 88, 56, 0, -8
 	Health:
-		HP: 800
+		HP: 80000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -143,7 +143,7 @@ GAWEAP:
 		Bounds: 154, 96, -2, -12
 		DecorationBounds: 154, 100, -2, -12
 	Health:
-		HP: 1000
+		HP: 100000
 	RevealsShroud:
 		Range: 4c0
 		MaxHeightDelta: 3
@@ -203,7 +203,7 @@ GAHPAD:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 600
+		HP: 60000
 	RevealsShroud:
 		Range: 5c0
 		MaxHeightDelta: 3
@@ -222,6 +222,7 @@ GAHPAD:
 	RepairsUnits:
 		PauseOnCondition: empdisable
 		PlayerExperience: 15
+		HpPerStep: 1000
 	ProductionBar:
 	WithIdleOverlay@PLATFORM:
 		Sequence: idle-platform
@@ -264,7 +265,7 @@ GADEPT:
 		Bounds: 96, 64, -6, -6
 		DecorationBounds: 98, 68, -6, -6
 	Health:
-		HP: 1100
+		HP: 110000
 	RevealsShroud:
 		Range: 5c0
 		MaxHeightDelta: 3
@@ -272,6 +273,7 @@ GADEPT:
 	RepairsUnits:
 		PauseOnCondition: empdisable
 		PlayerExperience: 15
+		HpPerStep: 1000
 	RallyPoint:
 		Palette: mouse
 		IsPlayerPalette: false
@@ -324,7 +326,7 @@ GARADR:
 		Bounds: 96, 48, 0, -6
 		DecorationBounds: 96, 118, 0, -38
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	ProvidesRadar:
@@ -369,7 +371,7 @@ GATECH:
 		Bounds: 110, 60, 3, -4
 		DecorationBounds: 110, 60, 3, -4
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -412,7 +414,7 @@ GAPLUG:
 		RequiresCondition: !disabled && !empdisable
 		Sequence: idle-strip
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RevealsShroud:

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -9,7 +9,7 @@ GAWALL:
 	Tooltip:
 		Name: Concrete Wall
 	Health:
-		HP: 225
+		HP: 22500
 	Armor:
 		Type: Concrete
 	Crushable:
@@ -56,7 +56,7 @@ GACTWR:
 		Bounds: 48, 36, 0, -6
 		DecorationBounds: 48, 48, 0, -12
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Light
 	BlocksProjectiles:

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -17,7 +17,7 @@ APC:
 			Water: 80
 		RequiresCondition: !empdisable && !loading
 	Health:
-		HP: 200
+		HP: 20000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -75,7 +75,7 @@ HVR:
 			BlueTiberium: 100
 			Veins: 100
 	Health:
-		HP: 230
+		HP: 23000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -121,7 +121,7 @@ SMECH:
 		TurnSpeed: 5
 		Speed: 99
 	Health:
-		HP: 175
+		HP: 17500
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -166,7 +166,7 @@ MMCH:
 		Speed: 56
 		Crushes: wall, crate, infantry
 	Health:
-		HP: 400
+		HP: 40000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -227,8 +227,9 @@ HMEC:
 		Speed: 42
 		Crushes: wall, crate, infantry
 	Health:
-		HP: 800
+		HP: 80000
 	SelfHealing:
+		Step: 500
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -273,7 +274,7 @@ SONIC:
 		Speed: 56
 		Crushes: wall, crate, infantry
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -315,7 +316,7 @@ JUGG:
 		Prerequisites: ~gaweap, garadr, ~techlevel.high
 		Description: Mobile Artillery Mech.\nNeeds to deploy in order to shoot.\n  Strong vs Ground units\n  Weak vs Aircraft
 	Health:
-		HP: 350
+		HP: 35000
 	Armor:
 		Type: Light
 	Mobile:

--- a/mods/ts/rules/nod-infantry.yaml
+++ b/mods/ts/rules/nod-infantry.yaml
@@ -14,7 +14,7 @@ E3:
 	Voiced:
 		VoiceSet: Rocket
 	Health:
-		HP: 100
+		HP: 10000
 	Mobile:
 		Speed: 56
 	Armament@PRIMARY:
@@ -54,7 +54,7 @@ CYBORG:
 	Mobile:
 		Speed: 56
 	Health:
-		HP: 300
+		HP: 30000
 	Passenger:
 	RevealsShroud:
 		Range: 5c0
@@ -90,7 +90,7 @@ CYC2:
 	Mobile:
 		Speed: 56
 	Health:
-		HP: 500
+		HP: 50000
 	Passenger:
 	RevealsShroud:
 		Range: 7c0
@@ -119,7 +119,7 @@ MHIJACK:
 	Voiced:
 		VoiceSet: Hijacker
 	Health:
-		HP: 300
+		HP: 30000
 	Mobile:
 		Speed: 99
 	-Crushable:

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -228,9 +228,9 @@ NAHPAD:
 		PrimaryCondition: primary
 	Reservable:
 	RepairsUnits:
+		HpPerStep: 1000
 		PauseOnCondition: empdisable
 		PlayerExperience: 15
-		HpPerStep: 1000
 	ProductionBar:
 	WithIdleOverlay@PLATFORM:
 		Sequence: idle-platform

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -19,7 +19,7 @@ NAPOWR:
 		Bounds: 88, 48, 2, -6
 		DecorationBounds: 88, 80, 2, -12
 	Health:
-		HP: 750
+		HP: 75000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -58,7 +58,7 @@ NAAPWR:
 		Bounds: 100, 54, 0, -4
 		DecorationBounds: 100, 74, 0, -12
 	Health:
-		HP: 750
+		HP: 75000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -98,7 +98,7 @@ NAHAND:
 		Bounds: 116, 60, 3, -6
 		DecorationBounds: 116, 78, 3, -8
 	Health:
-		HP: 800
+		HP: 80000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -155,7 +155,7 @@ NAWEAP:
 		Bounds: 149, 80, -3, -10
 		DecorationBounds: 149, 116, -3, -20
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -211,7 +211,7 @@ NAHPAD:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Health:
-		HP: 600
+		HP: 60000
 	RevealsShroud:
 		Range: 5c0
 		MaxHeightDelta: 3
@@ -230,6 +230,7 @@ NAHPAD:
 	RepairsUnits:
 		PauseOnCondition: empdisable
 		PlayerExperience: 15
+		HpPerStep: 1000
 	ProductionBar:
 	WithIdleOverlay@PLATFORM:
 		Sequence: idle-platform
@@ -275,7 +276,7 @@ NARADR:
 		Bounds: 96, 48, 0, -6
 		DecorationBounds: 96, 72, 0, -12
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	ProvidesRadar:
@@ -320,7 +321,7 @@ NATECH:
 		Bounds: 86, 48, 0, -4
 		DecorationBounds: 86, 58, 0, -4
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -358,7 +359,7 @@ NATMPL:
 	Selectable:
 		Bounds: 134, 120, 12, -12
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RevealsShroud:

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -9,7 +9,7 @@ NAWALL:
 	Tooltip:
 		Name: Concrete Wall
 	Health:
-		HP: 225
+		HP: 22500
 	Armor:
 		Type: Concrete
 	Crushable:
@@ -48,7 +48,7 @@ NAPOST:
 	Tooltip:
 		Name: Laser Fence
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Concrete
 	LineBuild:
@@ -148,7 +148,7 @@ NALASR:
 		Bounds: 40, 30, -8, -6
 		DecorationBounds: 40, 36, -8, -8
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -194,7 +194,7 @@ NAOBEL:
 		Bounds: 88, 42, 0, -6
 		DecorationBounds: 88, 72, 0, -12
 	Health:
-		HP: 725
+		HP: 72500
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -238,7 +238,7 @@ NASAM:
 		Bounds: 40, 30, -3, -8
 		DecorationBounds: 40, 36, -3, -8
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Wood
 	BodyOrientation:
@@ -279,7 +279,7 @@ NASTLH:
 		Footprint: xxx XXX
 		Dimensions: 3,2
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -329,7 +329,7 @@ NAMISL:
 		Bounds: 75,48
 		DecorationBounds: 75,48
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -386,7 +386,7 @@ NAWAST:
 		Bounds: 100, 60, 5, -5
 		DecorationBounds: 100, 60, 5, -5
 	Health:
-		HP: 400
+		HP: 40000
 	RevealsShroud:
 		Range: 6c0
 		MaxHeightDelta: 3

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -335,10 +335,10 @@ WEED:
 	Health:
 		HP: 60000
 	SelfHealing:
+		Step: 500
 		Delay: 10
 		HealIfBelow: 50
 		DamageCooldown: 200
-		Step: 500
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -16,7 +16,7 @@ BGGY:
 		TurnSpeed: 8
 		Speed: 142
 	Health:
-		HP: 220
+		HP: 22000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -54,7 +54,7 @@ BIKE:
 		TurnSpeed: 8
 		Speed: 170
 	Health:
-		HP: 150
+		HP: 15000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -101,7 +101,7 @@ TTNK:
 		Crushes: wall, crate, infantry
 		RequiresCondition: !empdisable && undeployed
 	Health:
-		HP: 350
+		HP: 35000
 	Armor:
 		Type: Light
 		RequiresCondition: undeployed
@@ -210,7 +210,7 @@ ART2:
 		Prerequisites: ~naweap, naradr, ~techlevel.high
 		Description: Mobile Artillery.\nNeeds to deploy in order to shoot.\n  Strong vs Ground units\n  Weak vs Aircraft
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Light
 	Mobile:
@@ -286,7 +286,7 @@ REPAIR:
 	Tooltip:
 		Name: Mobile Repair Vehicle
 	Health:
-		HP: 200
+		HP: 20000
 	Mobile:
 		Speed: 85
 		TurnSpeed: 5
@@ -333,11 +333,12 @@ WEED:
 		Speed: 71
 		TurnSpeed: 5
 	Health:
-		HP: 600
+		HP: 60000
 	SelfHealing:
 		Delay: 10
 		HealIfBelow: 50
 		DamageCooldown: 200
+		Step: 500
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -375,7 +376,7 @@ SAPC:
 		TerrainSpeeds:
 			Subterranean: 120
 	Health:
-		HP: 175
+		HP: 17500
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -422,7 +423,7 @@ SUBTANK:
 		TerrainSpeeds:
 			Subterranean: 120
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Light
 	RevealsShroud:
@@ -458,7 +459,7 @@ STNK:
 		Speed: 85
 		Crushes: wall, crate, infantry
 	Health:
-		HP: 180
+		HP: 18000
 	Armor:
 		Type: Light
 	RevealsShroud:

--- a/mods/ts/rules/shared-infantry.yaml
+++ b/mods/ts/rules/shared-infantry.yaml
@@ -12,7 +12,7 @@ E1:
 	Tooltip:
 		Name: Light Infantry
 	Health:
-		HP: 125
+		HP: 12500
 	Mobile:
 		Speed: 71
 	Armament@PRIMARY:
@@ -51,7 +51,7 @@ ENGINEER:
 	Mobile:
 		Speed: 56
 	Health:
-		HP: 100
+		HP: 10000
 	Passenger:
 		PipType: Yellow
 	EngineerRepair:
@@ -88,9 +88,9 @@ FLAMEGUY:
 	WithInfantryBody:
 		IdleSequences: run
 	Health:
-		HP: 160
+		HP: 16000
 	SelfHealing:
-		Step: -10
+		Step: -1000
 		HealIfBelow: 101
 	ScaredyCat:
 		PanicSequencePrefix:

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -11,7 +11,7 @@ GACNST:
 		Prerequisites: ~disabled
 		Description: Builds base structures.
 	Health:
-		HP: 1500
+		HP: 150000
 	Armor:
 		Type: Wood
 	RevealsShroud:
@@ -75,7 +75,7 @@ PROC:
 		Bounds: 134, 96, 0, -12
 		DecorationBounds: 134, 122, 0, -18
 	Health:
-		HP: 900
+		HP: 90000
 	RevealsShroud:
 		Range: 6c0
 		MaxHeightDelta: 3
@@ -133,7 +133,7 @@ GASILO:
 		DecorationBounds: 80, 48, -5, 0
 	-GivesBuildableArea:
 	Health:
-		HP: 300
+		HP: 30000
 	Armor:
 		Type: Wood
 	RevealsShroud:

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -18,7 +18,7 @@ NAPULS:
 		Bounds: 78, 54, 0, -12
 		DecorationBounds: 78, 54, 0, -12
 	Health:
-		HP: 500
+		HP: 50000
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -82,10 +82,10 @@ HARV:
 	Health:
 		HP: 100000
 	SelfHealing:
+		Step: 500
 		Delay: 10
 		HealIfBelow: 50
 		DamageCooldown: 200
-		Step: 500
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -14,7 +14,7 @@ MCV:
 		Priority: 3
 		DecorationBounds: 42,42
 	Health:
-		HP: 1000
+		HP: 100000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -80,11 +80,12 @@ HARV:
 			BlueTiberium: 80
 			Veins: 80
 	Health:
-		HP: 1000
+		HP: 100000
 	SelfHealing:
 		Delay: 10
 		HealIfBelow: 50
 		DamageCooldown: 200
+		Step: 500
 	Armor:
 		Type: Heavy
 	RevealsShroud:
@@ -125,7 +126,7 @@ LPST:
 		Name: Mobile Sensor Array (deployed)
 		RequiresCondition: deployed
 	Health:
-		HP: 600
+		HP: 60000
 	Armor:
 		Type: Wood
 	Mobile:

--- a/mods/ts/weapons/ballisticweapons.yaml
+++ b/mods/ts/weapons/ballisticweapons.yaml
@@ -11,7 +11,7 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 108
 		Falloff: 100, 50, 25, 12, 6, 3, 0
-		Damage: 36
+		Damage: 3600
 		Versus:
 			None: 25
 			Wood: 65
@@ -50,7 +50,7 @@
 		Blockable: false
 		LaunchAngle: 0
 	Warhead@1Dam: SpreadDamage
-		Damage: 70
+		Damage: 7000
 
 120mmx:
 	Inherits: ^Cannon
@@ -58,7 +58,7 @@
 	Burst: 2
 	BurstDelays: 5
 	Warhead@1Dam: SpreadDamage
-		Damage: 50
+		Damage: 5000
 
 RPGTower:
 	Inherits: ^Cannon
@@ -71,7 +71,7 @@ RPGTower:
 		Image: canister
 		Palette: player
 	Warhead@1Dam: SpreadDamage
-		Damage: 110
+		Damage: 11000
 		Versus:
 			None: 30
 			Wood: 75
@@ -106,7 +106,7 @@ RPGTower:
 		LaunchAngle: 165
 	MinRange: 5c0
 	Warhead@1Dam: SpreadDamage
-		Damage: 150
+		Damage: 15000
 	Warhead@2Eff: CreateEffect
 		Explosions: large_explosion
 		ImpactSounds: expnew06.aud
@@ -125,7 +125,7 @@ Jugg90mm:
 		LaunchAngle: 165
 		Inaccuracy: 2c0
 	Warhead@1Dam: SpreadDamage
-		Damage: 75
+		Damage: 7500
 	Warhead@2Eff: CreateEffect
 		Explosions: small_explosion
 		ImpactSounds: expnew13.aud
@@ -146,7 +146,7 @@ Grenade:
 		BounceCount: 2
 	Warhead@1Dam: SpreadDamage
 		Spread: 154
-		Damage: 40
+		Damage: 4000
 		Versus:
 			Light: 70
 			Concrete: 28

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -205,5 +205,5 @@ LaserFence:
 	Projectile: InstantHit
 	Warhead@1Dam: TargetDamage
 		DebugOverlayColor: FF0000
-		Damage: 9999900
+		Damage: 10000000
 		DamageTypes: FireDeath

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -12,7 +12,7 @@
 	Warhead@1Dam: SpreadDamage
 		Range: 0, 32
 		Falloff: 100, 100
-		Damage: 150
+		Damage: 15000
 		AffectsParent: false
 		Versus:
 			None: 100
@@ -29,7 +29,7 @@ LtRail:
 	Warhead@2Dam: SpreadDamage
 		Range: 0, 32
 		Falloff: 50, 50 # Only does half damage to friendly units
-		Damage: 150
+		Damage: 15000
 		InfDeath: 6
 		AffectsParent: false
 		ValidStances: Ally
@@ -50,7 +50,7 @@ MechRailgun:
 	Projectile: Railgun
 		BeamColor: 00FFFFC8
 	Warhead@1Dam: SpreadDamage
-		Damage: 200
+		Damage: 20000
 		Versus:
 			None: 200
 			Wood: 175
@@ -76,7 +76,7 @@ SonicZap:
 	Warhead@1Dam: SpreadDamage
 		Range: 0, 32
 		Falloff: 100, 100
-		Damage: 8
+		Damage: 800
 		AffectsParent: false
 		ValidStances: Neutral, Enemy
 		Versus:
@@ -86,7 +86,7 @@ SonicZap:
 	Warhead@2Dam: SpreadDamage
 		Range: 0, 32
 		Falloff: 50, 50
-		Damage: 8
+		Damage: 800
 		InvalidTargets: Disruptor # Does not affect friendly disruptors at all
 		AffectsParent: false
 		ValidStances: Ally
@@ -131,7 +131,7 @@ CyCannon:
 		TerrainHeightAware: true
 	Warhead@1Dam: SpreadDamage
 		Spread: 43
-		Damage: 120
+		Damage: 12000
 		Versus:
 			None: 350
 			Wood: 260
@@ -153,7 +153,7 @@ Proton:
 		Image: TORPEDO
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 20
+		Damage: 2000
 		Versus:
 			None: 25
 			Wood: 65
@@ -176,7 +176,7 @@ Proton:
 		SecondaryBeamColor: FF000040
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
-		Damage: 250
+		Damage: 25000
 		DamageTypes: Prone60Percent, TriggerProne, EnergyDeath
 
 ObeliskLaserFire:
@@ -185,7 +185,7 @@ ObeliskLaserFire:
 	Range: 10c512
 	Report: obelray1.aud
 	Warhead@1Dam: SpreadDamage
-		Damage: 250
+		Damage: 25000
 
 TurretLaserFire:
 	Inherits: ^Laser
@@ -198,12 +198,12 @@ TurretLaserFire:
 		SecondaryBeamWidth: 144
 		SecondaryBeamColor: FF000030
 	Warhead@1Dam: SpreadDamage
-		Damage: 30
+		Damage: 3000
 
 LaserFence:
 	TargetActorCenter: true
 	Projectile: InstantHit
 	Warhead@1Dam: TargetDamage
 		DebugOverlayColor: FF0000
-		Damage: 99999
+		Damage: 9999900
 		DamageTypes: FireDeath

--- a/mods/ts/weapons/explosions.yaml
+++ b/mods/ts/weapons/explosions.yaml
@@ -2,7 +2,7 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Falloff: 100, 50, 25, 12, 6, 3, 0
-		Damage: 500
+		Damage: 50000
 		Versus:
 			None: 90
 			Wood: 75
@@ -24,7 +24,7 @@ UnitExplodeSmall:
 	Inherits: ^DamagingExplosion
 	Warhead@1Dam: SpreadDamage
 		Spread: 192
-		Damage: 40
+		Damage: 4000
 	Warhead@2Eff: CreateEffect
 		Explosions: medium_brnl
 		ImpactSounds: expnew13.aud
@@ -49,7 +49,7 @@ TiberiumExplosion:
 	Inherits: ^DamagingExplosion
 	Warhead@1Dam: SpreadDamage
 		Spread: 9
-		Damage: 10
+		Damage: 1000
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@Res: CreateResource
 		AddsResourceType: Tiberium

--- a/mods/ts/weapons/healweapons.yaml
+++ b/mods/ts/weapons/healweapons.yaml
@@ -7,7 +7,7 @@
 	Projectile: InstantHit
 	Warhead@1Dam: TargetDamage
 		DebugOverlayColor: 00FF00
-		Damage: -50
+		Damage: -5000
 		ValidTargets: Infantry
 
 Heal:

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -25,7 +25,7 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 108
 		Falloff: 100, 50, 25, 12, 6, 3, 0
-		Damage: 25
+		Damage: 2500
 		ValidTargets: Ground, Air
 		Versus:
 			None: 25
@@ -62,7 +62,7 @@ HoverMissile:
 	Projectile: Missile
 		RangeLimit: 11c0
 	Warhead@1Dam: SpreadDamage
-		Damage: 30
+		Damage: 3000
 
 MammothTusk:
 	Inherits: ^DefaultMissile
@@ -75,7 +75,7 @@ MammothTusk:
 		RangeLimit: 9c0
 	Warhead@1Dam: SpreadDamage
 		Spread: 144
-		Damage: 40
+		Damage: 4000
 		ValidTargets: Air
 		Versus:
 			None: 100
@@ -101,7 +101,7 @@ BikeMissile:
 	Projectile: Missile
 		RangeLimit: 7c0
 	Warhead@1Dam: SpreadDamage
-		Damage: 40
+		Damage: 4000
 		ValidTargets: Ground, Air
 
 Dragon:
@@ -110,7 +110,7 @@ Dragon:
 	Burst: 2
 	Report: misl1.aud
 	Warhead@1Dam: SpreadDamage
-		Damage: 30
+		Damage: 3000
 
 Hellfire:
 	Inherits: ^DefaultMissile
@@ -120,7 +120,7 @@ Hellfire:
 	ValidTargets: Ground
 	Warhead@1Dam: SpreadDamage
 		Spread: 72
-		Damage: 30
+		Damage: 3000
 		ValidTargets: Ground, Air
 		Versus:
 			None: 30
@@ -143,7 +143,7 @@ RedEye2:
 		Speed: 288
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 33
+		Damage: 3300
 		ValidTargets: Air, Ground
 		DamageTypes: SmallExplosionDeath
 	Warhead@2Eff: CreateEffect

--- a/mods/ts/weapons/otherweapons.yaml
+++ b/mods/ts/weapons/otherweapons.yaml
@@ -11,7 +11,7 @@ FireballLauncher:
 	Warhead@1Dam: SpreadDamage
 		Spread: 288
 		Falloff: 100, 50, 25, 12, 6, 3, 0
-		Damage: 25
+		Damage: 2500
 		Versus:
 			None: 600
 			Wood: 148
@@ -38,7 +38,7 @@ Bomb:
 	Warhead@1Dam: SpreadDamage
 		Spread: 512
 		Falloff: 100, 50, 25, 12, 6, 3, 0
-		Damage: 160
+		Damage: 16000
 		Versus:
 			None: 200
 			Wood: 90
@@ -76,7 +76,7 @@ FiendShard:
 		LaunchAngle: 60
 		Palette: greentiberium
 	Warhead@1Dam: SpreadDamage
-		Damage: 35
+		Damage: 3500
 		Versus:
 			Light: 60
 			Heavy: 40
@@ -96,7 +96,7 @@ SlimeAttack:
 	Projectile: InstantHit
 	InvalidTargets: Wall, Bridge
 	Warhead@1Dam: SpreadDamage
-		Damage: 100
+		Damage: 10000
 		InvalidTargets: Wall, Bridge
 		Versus:
 			Light: 60
@@ -111,7 +111,7 @@ Tentacle:
 	Projectile: InstantHit
 	InvalidTargets: Wall, Bridge
 	Warhead@1Dam: SpreadDamage
-		Damage: 160
+		Damage: 16000
 		InvalidTargets: Wall, Bridge
 		Versus:
 			None: 60
@@ -124,7 +124,7 @@ Tentacle:
 Veins:
 	ReloadDelay: 16
 	Warhead@Damage: TargetDamage
-		Damage: 5
+		Damage: 500
 		DamageTypes: BulletDeath
 	Warhead@Effect: CreateEffect
 		Explosions: veins
@@ -142,7 +142,7 @@ Veins:
 	Warhead@1Dam: SpreadDamage
 		Spread: 200
 		Falloff: 100, 100, 0
-		Damage: 10
+		Damage: 1000
 		Versus:
 			None: 100
 			Wood: 85
@@ -174,7 +174,7 @@ LargeDebris:
 		Sequences: 2, 3, 4, 6, 7, 9, 10
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
-		Damage: 20
+		Damage: 2000
 	Warhead@2Eff: CreateEffect
 		Explosions: small_twlt
 		ImpactSounds: expnew06.aud

--- a/mods/ts/weapons/smallguns.yaml
+++ b/mods/ts/weapons/smallguns.yaml
@@ -28,6 +28,8 @@ Minigun:
 	Report: infgun3.aud, gostgun1.aud, slvkgun1.aud
 	Warhead@1Dam: SpreadDamage
 		Damage: 800
+		Versus:
+			Wood: 50
 
 M1Carbine:
 	Inherits: ^MG

--- a/mods/ts/weapons/smallguns.yaml
+++ b/mods/ts/weapons/smallguns.yaml
@@ -5,7 +5,7 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 108
 		Falloff: 100, 50, 25, 12, 6, 3, 0
-		Damage: 15
+		Damage: 1500
 		Versus:
 			None: 100
 			Wood: 60
@@ -27,7 +27,7 @@ Minigun:
 	ReloadDelay: 21
 	Report: infgun3.aud, gostgun1.aud, slvkgun1.aud
 	Warhead@1Dam: SpreadDamage
-		Damage: 8
+		Damage: 800
 
 M1Carbine:
 	Inherits: ^MG
@@ -37,7 +37,7 @@ Vulcan:
 	Inherits: ^MG
 	Report: chaingn1.aud
 	Warhead@1Dam: SpreadDamage
-		Damage: 20
+		Damage: 2000
 
 Vulcan2:
 	Inherits: ^MG
@@ -46,7 +46,7 @@ Vulcan2:
 	Range: 6c0
 	Report: tsgun4.aud
 	Warhead@1Dam: SpreadDamage
-		Damage: 50
+		Damage: 5000
 
 Vulcan3:
 	Inherits: ^MG
@@ -54,7 +54,7 @@ Vulcan3:
 	Burst: 3
 	Report: cygun1.aud
 	Warhead@1Dam: SpreadDamage
-		Damage: 10
+		Damage: 1000
 
 VulcanTower:
 	Inherits: ^MG
@@ -62,7 +62,7 @@ VulcanTower:
 	Range: 6c0
 	Report: chaingn1.aud
 	Warhead@1Dam: SpreadDamage
-		Damage: 18
+		Damage: 1800
 
 JumpCannon:
 	Inherits: ^MG
@@ -71,7 +71,7 @@ JumpCannon:
 	Range: 5c0
 	Report: jumpjet1.aud
 	Warhead@1Dam: SpreadDamage
-		Damage: 15
+		Damage: 1500
 
 AssaultCannon:
 	Inherits: ^MG
@@ -79,7 +79,7 @@ AssaultCannon:
 	Range: 5c0
 	Report: tsgun4.aud
 	Warhead@1Dam: SpreadDamage
-		Damage: 40
+		Damage: 4000
 
 RaiderCannon:
 	Inherits: ^MG
@@ -89,7 +89,7 @@ RaiderCannon:
 	BurstDelays: 55
 	Report: chaingn1.aud
 	Warhead@1Dam: SpreadDamage
-		Damage: 40
+		Damage: 4000
 
 HarpyClaw:
 	Inherits: ^MG
@@ -97,14 +97,14 @@ HarpyClaw:
 	Range: 5c0
 	Report: cygun1.aud
 	Warhead@1Dam: SpreadDamage
-		Damage: 60
+		Damage: 6000
 
 Pistola:
 	Inherits: ^MG
 	Range: 3c0
 	Report: gun18.aud
 	Warhead@1Dam: SpreadDamage
-		Damage: 2
+		Damage: 200
 	Warhead@2Eff: CreateEffect
 		Explosions: piff
 	Warhead@3EffWater: CreateEffect
@@ -117,7 +117,7 @@ Sniper:
 	Report: silencer.aud
 	Warhead@1Dam: SpreadDamage
 		Spread: 36
-		Damage: 150
+		Damage: 15000
 		Versus:
 			Wood: 5
 			Light: 5

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -18,7 +18,7 @@ MultiCluster:
 		TerrainHeightAware: true
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-		Damage: 65
+		Damage: 6500
 		ValidTargets: Ground
 		Versus:
 			None: 25
@@ -46,7 +46,7 @@ SuicideBomb:
 	Report: hunter2.aud
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
-		Damage: 110
+		Damage: 11000
 		Falloff: 10000, 3680, 1350, 500, 180, 70, 0
 		Versus:
 			None: 90
@@ -60,13 +60,13 @@ IonCannon:
 	ValidTargets: Ground, Water, Air
 	Warhead@1Dam_impact: SpreadDamage
 		Spread: 1c0
-		Damage: 100
+		Damage: 10000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: Ground, Water, Air
 		DamageTypes: Prone100Percent, TriggerProne, EnergyDeath
 	Warhead@2Dam_area: SpreadDamage
 		Spread: 1c0
-		Damage: 250
+		Damage: 25000
 		Falloff: 100, 50, 25, 0
 		Delay: 3
 		ValidTargets: Ground, Water, Air
@@ -125,7 +125,7 @@ ClusterMissile:
 	ValidTargets: Ground, Water, Air
 	Warhead@ImpactDamage0: SpreadDamage
 		Spread: 1c0
-		Damage: 150
+		Damage: 15000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		ValidTargets: Ground, Water, Air
 		Versus:
@@ -144,7 +144,7 @@ ClusterMissile:
 		Size: 1
 	Warhead@ClusterDamage1: SpreadDamage
 		Spread: 2c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 5
 		ValidTargets: Ground, Water, Air
@@ -161,7 +161,7 @@ ClusterMissile:
 		Delay: 5
 	Warhead@ClusterDamage2: SpreadDamage
 		Spread: 3c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 10
 		ValidTargets: Ground, Water, Air
@@ -178,7 +178,7 @@ ClusterMissile:
 		Delay: 10
 	Warhead@ClusterDamage3: SpreadDamage
 		Spread: 4c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 15
 		ValidTargets: Ground, Water, Air
@@ -195,7 +195,7 @@ ClusterMissile:
 		Delay: 15
 	Warhead@ClusterDamage4: SpreadDamage
 		Spread: 5c0
-		Damage: 60
+		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 20
 		ValidTargets: Ground, Water, Air


### PR DESCRIPTION
Before:
![ts1](https://user-images.githubusercontent.com/33390659/34387536-07c496b2-eb2f-11e7-90e3-9b726d727a84.png)

After:
![ts100](https://user-images.githubusercontent.com/33390659/34387542-0fdc9980-eb2f-11e7-886c-ccc670418e9f.png)

Yellow: value that needs to be changed.
Green: increased.
Red: decreased.
Orange: value that needs to be added.
Dark gray: value that should stay because it is an inherits (and not used anywhere else).

Almost all values are the same as before. The exceptions are:
`^Railgun` and `LtRail` vs concrete (0.5 more damage)
`MammothTusk` vs concrete (0.2 more damage) (only air targets)
`SmallDebris` vs wood, heavy, concrete (0.5 more damage)
`JumpCannon` vs concrete (0.05 more damage)
`Sniper` vs wood, light, heavy, concrete (0.5 more damage)
These differences don't have impact for the gameplay.

`DamagedByTerrain@VEINS:` is the only instance the upgrade ruler didn't catch. I didn't add it to the upgrade rules because I think this is not very common.

Related to #14301, #14448, #14461.
Closes #11719.