### PR TITLE
Improve AI excess power management

### DIFF
--- a/OpenRA.Mods.Common/AI/BaseBuilder.cs
+++ b/OpenRA.Mods.Common/AI/BaseBuilder.cs
@@ -35,6 +35,7 @@ namespace OpenRA.Mods.Common.AI
 		int checkForBasesTicks;
 		int cachedBases;
 		int cachedBuildings;
+		int minimumExcessPower;
 
 		enum Water
 		{
@@ -54,6 +55,7 @@ namespace OpenRA.Mods.Common.AI
 			playerResources = pr;
 			this.category = category;
 			failRetryTicks = ai.Info.StructureProductionResumeDelay;
+			minimumExcessPower = ai.Info.MinimumExcessPower;
 		}
 
 		public void Tick()
@@ -100,6 +102,8 @@ namespace OpenRA.Mods.Common.AI
 				return;
 
 			playerBuildings = world.ActorsHavingTrait<Building>().Where(a => a.Owner == player).ToArray();
+			var excessPowerBonus = ai.Info.ExcessPowerIncrement * (playerBuildings.Count() / ai.Info.ExcessPowerIncreaseThreshold.Clamp(1, int.MaxValue));
+			minimumExcessPower = (ai.Info.MinimumExcessPower + excessPowerBonus).Clamp(ai.Info.MinimumExcessPower, ai.Info.MaximumExcessPower);
 
 			var active = false;
 			foreach (var queue in ai.FindQueues(category))
@@ -197,7 +201,7 @@ namespace OpenRA.Mods.Common.AI
 		bool HasSufficientPowerForActor(ActorInfo actorInfo)
 		{
 			return (actorInfo.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault)
-				.Sum(p => p.Amount) + playerPower.ExcessPower) >= ai.Info.MinimumExcessPower;
+				.Sum(p => p.Amount) + playerPower.ExcessPower) >= minimumExcessPower;
 		}
 
 		ActorInfo ChooseBuildingToBuild(ProductionQueue queue)
@@ -209,7 +213,7 @@ namespace OpenRA.Mods.Common.AI
 				a => a.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(p => p.Amount));
 
 			// First priority is to get out of a low power situation
-			if (playerPower.ExcessPower < ai.Info.MinimumExcessPower)
+			if (playerPower.ExcessPower < minimumExcessPower)
 			{
 				if (power != null && power.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(p => p.Amount) > 0)
 				{
@@ -314,7 +318,7 @@ namespace OpenRA.Mods.Common.AI
 
 				// Will this put us into low power?
 				var actor = world.Map.Rules.Actors[name];
-				if (playerPower.ExcessPower < ai.Info.MinimumExcessPower || !HasSufficientPowerForActor(actor))
+				if (playerPower.ExcessPower < minimumExcessPower || !HasSufficientPowerForActor(actor))
 				{
 					// Try building a power plant instead
 					if (power != null && power.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(pi => pi.Amount) > 0)

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -96,6 +96,15 @@ namespace OpenRA.Mods.Common.AI
 		[Desc("Minimum excess power the AI should try to maintain.")]
 		public readonly int MinimumExcessPower = 0;
 
+		[Desc("Increase maintained excess power by this amount for every ExcessPowerIncreaseThreshold of base buildings.")]
+		public readonly int ExcessPowerIncrement = 0;
+
+		[Desc("Increase maintained excess power by ExcessPowerIncrement for every N base buildings.")]
+		public readonly int ExcessPowerIncreaseThreshold = 1;
+
+		[Desc("The targeted excess power the AI tries to maintain cannot rise above this.")]
+		public readonly int MaximumExcessPower = 0;
+
 		[Desc("Additional delay (in ticks) between structure production checks when there is no active production.",
 			"StructureProductionRandomBonusDelay is added to this.")]
 		public readonly int StructureProductionInactiveDelay = 125;
@@ -193,7 +202,7 @@ namespace OpenRA.Mods.Common.AI
 		public readonly UnitCategories UnitsCommonNames;
 
 		[Desc("Tells the AI what building types fall under the same common name.",
-			"Possible keys are ConstructionYard, Power, Refinery, Silo , Barracks, Production, VehiclesFactory, NavalProduction.")]
+			"Possible keys are ConstructionYard, Power, Refinery, Silo, Barracks, Production, VehiclesFactory, NavalProduction.")]
 		[FieldLoader.LoadUsing("LoadBuildingCategories", true)]
 		public readonly BuildingCategories BuildingCommonNames;
 

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -2,7 +2,10 @@ Player:
 	HackyAI@Cabal:
 		Name: Cabal
 		Type: cabal
-		MinimumExcessPower: 60
+		MinimumExcessPower: 30
+		ExcessPowerIncrement: 30
+		ExcessPowerIncreaseThreshold: 5
+		MaximumExcessPower: 150
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -30,11 +33,9 @@ Player:
 			silo: 1
 		BuildingFractions:
 			proc: 20%
-			nuke: 9%
 			pyle: 5%
 			hand: 5%
 			hq: 4%
-			nuk2: 9%
 			weap: 9%
 			afld: 9%
 			gtwr: 5%
@@ -130,7 +131,10 @@ Player:
 	HackyAI@Watson:
 		Name: Watson
 		Type: watson
-		MinimumExcessPower: 60
+		MinimumExcessPower: 30
+		ExcessPowerIncrement: 30
+		ExcessPowerIncreaseThreshold: 4
+		MaximumExcessPower: 150
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -158,11 +162,9 @@ Player:
 			silo: 1
 		BuildingFractions:
 			proc: 17%
-			nuke: 1%
 			pyle: 2%
 			hand: 2%
 			hq: 1%
-			nuk2: 18%
 			weap: 5%
 			afld: 5%
 			hpad: 4%
@@ -258,7 +260,10 @@ Player:
 	HackyAI@HAL9001:
 		Name: HAL 9001
 		Type: hal9001
-		MinimumExcessPower: 60
+		MinimumExcessPower: 30
+		ExcessPowerIncrement: 30
+		ExcessPowerIncreaseThreshold: 4
+		MaximumExcessPower: 210
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -286,11 +291,9 @@ Player:
 			silo: 1
 		BuildingFractions:
 			proc: 17%
-			nuke: 10%
 			pyle: 7%
 			hand: 9%
 			hq: 1%
-			nuk2: 18%
 			weap: 8%
 			afld: 6%
 			hpad: 4%

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -2,7 +2,10 @@ Player:
 	HackyAI@Omnius:
 		Name: Omnius
 		Type: omnius
-		MinimumExcessPower: 60
+		MinimumExcessPower: 50
+		ExcessPowerIncrement: 50
+		ExcessPowerIncreaseThreshold: 4
+		MaximumExcessPower: 200
 		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport, Aircraft
 		BuildingCommonNames:
@@ -30,7 +33,6 @@ Player:
 			upgrade.heavy: 1
 			upgrade.hightech: 1
 		BuildingFractions:
-			wind_trap: 10%
 			barracks: 0.1%
 			refinery: 20.1%
 			medium_gun_turret: 8%
@@ -121,7 +123,10 @@ Player:
 	HackyAI@Vidius:
 		Name: Vidious
 		Type: vidious
-		MinimumExcessPower: 60
+		MinimumExcessPower: 50
+		ExcessPowerIncrement: 50
+		ExcessPowerIncreaseThreshold: 4
+		MaximumExcessPower: 200
 		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport, Aircraft
 		BuildingCommonNames:
@@ -150,7 +155,6 @@ Player:
 			upgrade.heavy: 1
 			upgrade.hightech: 1
 		BuildingFractions:
-			wind_trap: 12%
 			barracks: 0.1%
 			refinery: 20.1%
 			medium_gun_turret: 5%
@@ -242,7 +246,10 @@ Player:
 	HackyAI@Gladius:
 		Name: Gladius
 		Type: gladius
-		MinimumExcessPower: 60
+		MinimumExcessPower: 50
+		ExcessPowerIncrement: 50
+		ExcessPowerIncreaseThreshold: 4
+		MaximumExcessPower: 200
 		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport, Aircraft
 		BuildingCommonNames:
@@ -271,7 +278,6 @@ Player:
 			upgrade.heavy: 1
 			upgrade.hightech: 1
 		BuildingFractions:
-			wind_trap: 10%
 			barracks: 0.1%
 			refinery: 20.1%
 			medium_gun_turret: 4%

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -2,7 +2,10 @@ Player:
 	HackyAI@RushAI:
 		Name: Rush AI
 		Type: rush
-		MinimumExcessPower: 40
+		MinimumExcessPower: 20
+		ExcessPowerIncrement: 40
+		ExcessPowerIncreaseThreshold: 4
+		MaximumExcessPower: 160
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -26,8 +29,6 @@ Player:
 			fix: 1
 		BuildingFractions:
 			proc: 30%
-			powr: 15%
-			apwr: 20%
 			barr: 1%
 			kenn: 0.5%
 			tent: 1%
@@ -117,7 +118,10 @@ Player:
 	HackyAI@NormalAI:
 		Name: Normal AI
 		Type: normal
-		MinimumExcessPower: 60
+		MinimumExcessPower: 40
+		ExcessPowerIncrement: 40
+		ExcessPowerIncreaseThreshold: 4
+		MaximumExcessPower: 200
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -145,8 +149,6 @@ Player:
 			fix: 1
 		BuildingFractions:
 			proc: 10%
-			powr: 1%
-			apwr: 30%
 			tent: 1%
 			barr: 1%
 			kenn: 0.5%
@@ -250,7 +252,10 @@ Player:
 	HackyAI@TurtleAI:
 		Name: Turtle AI
 		Type: turtle
-		MinimumExcessPower: 100
+		MinimumExcessPower: 50
+		ExcessPowerIncrement: 50
+		ExcessPowerIncreaseThreshold: 4
+		MaximumExcessPower: 250
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -279,8 +284,6 @@ Player:
 			fix: 1
 		BuildingFractions:
 			proc: 30%
-			powr: 1%
-			apwr: 20%
 			tent: 1%
 			barr: 1%
 			kenn: 0.5%
@@ -383,6 +386,10 @@ Player:
 	HackyAI@NavalAI:
 		Name: Naval AI
 		Type: naval
+		MinimumExcessPower: 20
+		ExcessPowerIncrement: 40
+		ExcessPowerIncreaseThreshold: 4
+		MaximumExcessPower: 200
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -410,8 +417,6 @@ Player:
 			fix: 1
 		BuildingFractions:
 			proc: 29%
-			powr: 1%
-			apwr: 24%
 			dome: 1%
 			weap: 1%
 			hpad: 20%

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -2,7 +2,10 @@ Player:
 	HackyAI@TestAI:
 		Name: Test AI
 		Type: test
-		MinimumExcessPower: 60
+		MinimumExcessPower: 30
+		ExcessPowerIncrement: 30
+		ExcessPowerIncreaseThreshold: 4
+		MaximumExcessPower: 200
 		BuildingCommonNames:
 			ConstructionYard: gacnst
 			Refinery: proc
@@ -35,8 +38,6 @@ Player:
 			nasam: 4
 		BuildingFractions:
 			proc: 30%
-			gapowr: 35%
-			napowr: 35%
 			gapile: 1%
 			nahand: 1%
 			gaweap: 1%


### PR DESCRIPTION
This allows to scale the minimum excess power that the AI is targeting, while also allowing to set a cap. Combined with removing power plants from BuildingFractions, this should prevent the mod AIs from building too many excess power plants, while building enough to maintain a sufficient power reserve.

Fixes #14586.