### PR TITLE
#14572 Prevent StackOverflowException by not reusing the same Activity

### DIFF
--- a/OpenRA.Mods.Common/Activities/DeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverResources.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Activities
 				foreach (var n in notify)
 					n.MovingToRefinery(self, proc, this);
 
-				return ActivityUtils.SequenceActivities(movement.MoveTo(proc.Location + iao.DeliveryOffset, 0), this);
+				return ActivityUtils.SequenceActivities(movement.MoveTo(proc.Location + iao.DeliveryOffset, 0), new DeliverResources(self));
 			}
 
 			if (!isDocking)


### PR DESCRIPTION
The existing DeliverResources instance was part to a loop in the Activity Queue that led to a endless recursion throughout that loop before.

For more details of the issue see ticket #14572.