### PR TITLE
Add an outdated version warning to the main menu

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -95,6 +95,9 @@ namespace OpenRA
 
 		public bool StrictActivityChecking = false;
 
+		[Desc("Check whether a newer version is available online.")]
+		public bool CheckVersion = true;
+
 		[Desc("Allow the collection of anonymous data such as Operating System, .NET runtime, OpenGL version and language settings.")]
 		public bool SendSystemInformation = true;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -239,7 +239,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			// Check for updates in the background
 			var webServices = modData.Manifest.Get<WebServices>();
-			webServices.CheckModVersion();
+			if (Game.Settings.Debug.CheckVersion)
+				webServices.CheckModVersion();
 
 			// System information opt-out prompt
 			var sysInfoPrompt = widget.Get("SYSTEM_INFO_PROMPT");

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -37,6 +37,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		// Update news once per game launch
 		static bool fetchedNews;
 
+		bool newsOpen;
+
 		// Increment the version number when adding new stats
 		const int SystemInformationVersion = 3;
 		Dictionary<string, Pair<string, string>> GetSystemInformation()
@@ -242,6 +244,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (Game.Settings.Debug.CheckVersion)
 				webServices.CheckModVersion();
 
+			var updateLabel = rootMenu.GetOrNull("UPDATE_NOTICE");
+			if (updateLabel != null)
+				updateLabel.IsVisible = () => !newsOpen && menuType != MenuType.None &&
+					menuType != MenuType.SystemInfoPrompt &&
+					webServices.ModVersionStatus == ModVersionStatus.Outdated;
+
 			// System information opt-out prompt
 			var sysInfoPrompt = widget.Get("SYSTEM_INFO_PROMPT");
 			sysInfoPrompt.IsVisible = () => menuType == MenuType.SystemInfoPrompt;
@@ -306,12 +314,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 						new Download(newsURL, cacheFile, e => { },
 							e => NewsDownloadComplete(e, cacheFile, currentNews,
-								() => newsButton.AttachPanel(newsPanel)));
+								() => OpenNewsPanel(newsButton)));
 					}
 
-					newsButton.OnClick = () => newsButton.AttachPanel(newsPanel);
+					newsButton.OnClick = () => OpenNewsPanel(newsButton);
 				}
 			}
+		}
+
+		void OpenNewsPanel(DropDownButtonWidget button)
+		{
+			newsOpen = true;
+			button.AttachPanel(newsPanel, () => newsOpen = false);
 		}
 
 		void OnRemoteDirectConnect(string host, int port)

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -237,7 +237,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			Game.OnRemoteDirectConnect += OnRemoteDirectConnect;
 
-			var newsURL = modData.Manifest.Get<WebServices>().GameNews;
+			// Check for updates in the background
+			var webServices = modData.Manifest.Get<WebServices>();
+			webServices.CheckModVersion();
 
 			// System information opt-out prompt
 			var sysInfoPrompt = widget.Get("SYSTEM_INFO_PROMPT");
@@ -267,11 +269,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					Game.Settings.Debug.SystemInformationVersionPrompt = SystemInformationVersion;
 					Game.Settings.Save();
 					SwitchMenu(MenuType.Main);
-					LoadAndDisplayNews(newsURL, newsBG);
+					LoadAndDisplayNews(webServices.GameNews, newsBG);
 				};
 			}
 			else
-				LoadAndDisplayNews(newsURL, newsBG);
+				LoadAndDisplayNews(webServices.GameNews, newsBG);
 		}
 
 		void LoadAndDisplayNews(string newsURL, Widget newsBG)

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -489,6 +489,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			BindCheckboxPref(panel, "FETCH_NEWS_CHECKBOX", gs, "FetchNews");
 			BindCheckboxPref(panel, "LUADEBUG_CHECKBOX", ds, "LuaDebug");
 			BindCheckboxPref(panel, "SENDSYSINFO_CHECKBOX", ds, "SendSystemInformation");
+			BindCheckboxPref(panel, "CHECK_VERSION_CHECKBOX", ds, "CheckVersion");
 			BindCheckboxPref(panel, "REPLAY_COMMANDS_CHECKBOX", ds, "EnableDebugCommandsInReplays");
 
 			return () => { };
@@ -509,6 +510,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ds.SanityCheckUnsyncedCode = dds.SanityCheckUnsyncedCode;
 				ds.BotDebug = dds.BotDebug;
 				ds.LuaDebug = dds.LuaDebug;
+				ds.SendSystemInformation = dds.SendSystemInformation;
+				ds.CheckVersion = dds.CheckVersion;
+				ds.EnableDebugCommandsInReplays = dds.EnableDebugCommandsInReplays;
 			};
 		}
 

--- a/mods/cnc/chrome/mainmenu.yaml
+++ b/mods/cnc/chrome/mainmenu.yaml
@@ -35,7 +35,7 @@ Container@MENU_BACKGROUND:
 			Y: 115
 			Width: 128
 			Align: Center
-			Contrast: true
+			Shadow: true
 		Background@BORDER:
 			Width: WINDOW_RIGHT
 			Height: WINDOW_BOTTOM

--- a/mods/cnc/chrome/mainmenu.yaml
+++ b/mods/cnc/chrome/mainmenu.yaml
@@ -281,6 +281,24 @@ Container@MENU_BACKGROUND:
 					Height: 25
 					Text: Battlefield News
 					Font: Bold
+		Container@UPDATE_NOTICE:
+			X: (WINDOW_RIGHT - WIDTH) / 2
+			Y: 75
+			Width: 128
+			Children:
+				Label@A:
+					Width: PARENT_RIGHT
+					Height: 25
+					Align: Center
+					Shadow: true
+					Text: You are running an outdated version of OpenRA.
+				Label@B:
+					Y: 20
+					Width: PARENT_RIGHT
+					Height: 25
+					Align: Center
+					Shadow: true
+					Text: Download the latest version from www.openra.net
 		Container@PERFORMANCE_INFO:
 			Logic: PerfDebugLogic
 			Children:

--- a/mods/cnc/chrome/multiplayer-browser.yaml
+++ b/mods/cnc/chrome/multiplayer-browser.yaml
@@ -79,7 +79,7 @@ Container@MULTIPLAYER_PANEL:
 									Width: PARENT_RIGHT-10
 									Height: 18
 									Align: Center
-									Text: A pre-release version of OpenRA is available for testing. Download the playtest from www.openra.net
+									Text: A preview of the next OpenRA release is available for testing. Download the playtest from www.openra.net
 									Font: TinyBold
 				ScrollPanel@SERVER_LIST:
 					X: 15

--- a/mods/cnc/chrome/multiplayer-browser.yaml
+++ b/mods/cnc/chrome/multiplayer-browser.yaml
@@ -48,6 +48,7 @@ Container@MULTIPLAYER_PANEL:
 							Height: 25
 							Text: Status
 							Font: Bold
+				LogicTicker@NOTICE_WATCHER:
 				Container@NOTICE_CONTAINER:
 					X: 15
 					Y: 30

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -542,51 +542,58 @@ Container@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Fetch Community News
-						Checkbox@SENDSYSINFO_CHECKBOX:
+						Checkbox@CHECK_VERSION_CHECKBOX:
 							X: 310
 							Y: 70
+							Width: 300
+							Height: 20
+							Font: Regular
+							Text: Check for Updates
+						Checkbox@SENDSYSINFO_CHECKBOX:
+							X: 310
+							Y: 100
 							Width: 300
 							Height: 20
 							Font: Regular
 							Text: Send System Information
 						Label@SENDSYSINFO_DESC:
 							X: 310
-							Y: 85
+							Y: 115
 							Width: 250
 							Height: 30
 							Font: Tiny
 							WordWrap: True
 							Text: Your Operating System, OpenGL and .NET runtime versions, and language settings will be sent along with an anonymous ID to help prioritize future development.
 						Label@DEBUG_TITLE:
-							Y: 170
+							Y: 200
 							Width: PARENT_RIGHT
 							Font: Bold
 							Text: Debug
 							Align: Center
 						Checkbox@BOTDEBUG_CHECKBOX:
 							X: 15
-							Y: 190
+							Y: 220
 							Width: 300
 							Height: 20
 							Font: Regular
 							Text: Show Bot Debug Messages
 						Checkbox@CHECKUNSYNCED_CHECKBOX:
 							X: 15
-							Y: 220
+							Y: 250
 							Width: 300
 							Height: 20
 							Font: Regular
 							Text: Check Sync around Unsynced Code
 						Checkbox@LUADEBUG_CHECKBOX:
 							X: 310
-							Y: 190
+							Y: 220
 							Width: 300
 							Height: 20
 							Font: Regular
 							Text: Show Map Debug Messages
 						Checkbox@REPLAY_COMMANDS_CHECKBOX:
 							X: 310
-							Y: 220
+							Y: 250
 							Width: 300
 							Height: 20
 							Font: Regular

--- a/mods/common/chrome/mainmenu.yaml
+++ b/mods/common/chrome/mainmenu.yaml
@@ -27,7 +27,7 @@ Container@MAINMENU:
 			Height: 25
 			Align: Center
 			Font: Regular
-			Contrast: True
+			Shadow: true
 		Container@MENUS:
 			X: 13 + (WINDOW_RIGHT - 522) / 4 - WIDTH / 2
 			Y: WINDOW_BOTTOM / 2 - HEIGHT / 2
@@ -302,3 +302,21 @@ Container@MAINMENU:
 					Height: 25
 					Text: Battlefield News
 					Font: Bold
+		Container@UPDATE_NOTICE:
+			X: (WINDOW_RIGHT - WIDTH) / 2
+			Y: 95
+			Width: 128
+			Children:
+				Label@A:
+					Width: PARENT_RIGHT
+					Height: 25
+					Align: Center
+					Shadow: true
+					Text: You are running an outdated version of OpenRA.
+				Label@B:
+					Y: 20
+					Width: PARENT_RIGHT
+					Height: 25
+					Align: Center
+					Shadow: true
+					Text: Download the latest version from www.openra.net

--- a/mods/common/chrome/multiplayer-browser.yaml
+++ b/mods/common/chrome/multiplayer-browser.yaml
@@ -70,7 +70,7 @@ Background@MULTIPLAYER_PANEL:
 					Width: PARENT_RIGHT-10
 					Height: 18
 					Align: Center
-					Text: A pre-release version of OpenRA is available for testing. Download the playtest from www.openra.net
+					Text: A preview of the next OpenRA release is available for testing. Download the playtest from www.openra.net
 					Font: TinyBold
 		ScrollPanel@SERVER_LIST:
 			X: 20

--- a/mods/common/chrome/multiplayer-browser.yaml
+++ b/mods/common/chrome/multiplayer-browser.yaml
@@ -43,6 +43,7 @@ Background@MULTIPLAYER_PANEL:
 					Height: 25
 					Text: Status
 					Font: Bold
+		LogicTicker@NOTICE_WATCHER:
 		Background@NOTICE_CONTAINER:
 			X: 20
 			Y: 67

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -553,51 +553,58 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Fetch Community News
-				Checkbox@SENDSYSINFO_CHECKBOX:
+				Checkbox@CHECK_VERSION_CHECKBOX:
 					X: 310
 					Y: 70
+					Width: 300
+					Height: 20
+					Font: Regular
+					Text: Check for Updates
+				Checkbox@SENDSYSINFO_CHECKBOX:
+					X: 310
+					Y: 100
 					Width: 300
 					Height: 20
 					Font: Regular
 					Text: Send System Information
 				Label@SENDSYSINFO_DESC:
 					X: 310
-					Y: 85
+					Y: 115
 					Width: 250
 					Height: 30
 					Font: Tiny
 					WordWrap: True
 					Text: Your Operating System, OpenGL and .NET runtime versions, and language settings will be sent along with an anonymous ID to help prioritize future development.
 				Label@DEBUG_TITLE:
-					Y: 170
+					Y: 200
 					Width: PARENT_RIGHT
 					Font: Bold
 					Text: Debug
 					Align: Center
 				Checkbox@BOTDEBUG_CHECKBOX:
 					X: 15
-					Y: 190
+					Y: 220
 					Width: 300
 					Height: 20
 					Font: Regular
 					Text: Show Bot Debug Messages
 				Checkbox@CHECKUNSYNCED_CHECKBOX:
 					X: 15
-					Y: 220
+					Y: 250
 					Width: 300
 					Height: 20
 					Font: Regular
 					Text: Check Sync around Unsynced Code
 				Checkbox@LUADEBUG_CHECKBOX:
 					X: 310
-					Y: 190
+					Y: 220
 					Width: 300
 					Height: 20
 					Font: Regular
 					Text: Show Map Debug Messages
 				Checkbox@REPLAY_COMMANDS_CHECKBOX:
 					X: 310
-					Y: 220
+					Y: 250
 					Width: 300
 					Height: 20
 					Font: Regular

--- a/mods/d2k/chrome/mainmenu.yaml
+++ b/mods/d2k/chrome/mainmenu.yaml
@@ -14,7 +14,7 @@ Container@MAINMENU:
 			Y: WINDOW_BOTTOM - 20
 			Align: Right
 			Font: Regular
-			Contrast: True
+			Shadow: True
 		Container@MENUS:
 			X: 13 + (WINDOW_RIGHT - 522) / 4 - WIDTH / 2
 			Y: WINDOW_BOTTOM / 2 - HEIGHT / 2

--- a/mods/d2k/chrome/mainmenu.yaml
+++ b/mods/d2k/chrome/mainmenu.yaml
@@ -266,6 +266,24 @@ Container@MAINMENU:
 					Height: 25
 					Text: Battlefield News
 					Font: Bold
+		Container@UPDATE_NOTICE:
+			X: (WINDOW_RIGHT - WIDTH) / 2
+			Y: 95
+			Width: 128
+			Children:
+				Label@A:
+					Width: PARENT_RIGHT
+					Height: 25
+					Align: Center
+					Shadow: true
+					Text: You are running an outdated version of OpenRA.
+				Label@B:
+					Y: 20
+					Width: PARENT_RIGHT
+					Height: 25
+					Align: Center
+					Shadow: true
+					Text: Download the latest version from www.openra.net
 		Container@PERFORMANCE_INFO:
 			Logic: PerfDebugLogic
 			Children:


### PR DESCRIPTION
This refines #14581 by moving the logic into a more general location and exposing (only) the new version notice to the main menu.

This also adds a setting to disable the check, and switches the version labels from the ugly contrast rendering to shadow.

For testing keep the version at `{DEV_VERSION}` to see the unknown version prompt in the MP browser, `release-20170527` to see the version update prompt, `release-20171014` to see the playtest update prompt in the MP browser, and `playtest-20180101` to see nothing.