### PR TITLE
Re-activate Edge-Scrolling for inverted Mouse-Scrolling

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -362,7 +362,7 @@ namespace OpenRA.Mods.Common.Widgets
 				else if (mi.Event == MouseInputEvent.Move && (isStandardScrolling ||
 					(standardScrollStart.HasValue && ((standardScrollStart.Value - mi.Location).Length > Game.Settings.Game.MouseScrollDeadzone))))
 				{
-					isStandardScrolling = true;
+					isStandardScrolling = scrollType == MouseScrollType.Standard;
 					var d = scrollType == MouseScrollType.Inverted ? -1 : 1;
 					worldRenderer.Viewport.Scroll((Viewport.LastMousePos - mi.Location) * d, false);
 					return true;


### PR DESCRIPTION
Hi!
hehe

When playing the new release, i was a bit annoyed to see edge-scrolling no longer works while holding the right mouse button / scroll wheel button to scroll around.

Course I understand why:
To prevent accidentally scrolling in the opposite direction when using the "standard" scrolling option.

But as I use the "inverted" scrolling (which saves a lot of mouse movements), I miss it:
When you play a huge map or zoom in, you may not be able to go from one edge of the map to the other without releasing the button, reposition the cursor and holding the button again.
This is where edge scrolling comes in:
You can just continue to move the cursor in the direction where you want to go, and edge scrolling takes you the rest of the way.
Try it, it makes sense and again, it saves a LOT of mouse movements and thus makes you a better player.
ehehe...

So i re-activated it, but ONLY while inverted mouse-scrolling is active.
While scrolling with standard scrolling, it is not active.

Yet, if you dont want edge scrolling at all, you can still simply disable it, of course.

So i thought I would share.
Makes sense, eh?