### PR TITLE
Properly unload passengers in nod05

### DIFF
--- a/mods/cnc/maps/nod05/map.yaml
+++ b/mods/cnc/maps/nod05/map.yaml
@@ -360,7 +360,7 @@ Actors:
 	Barracks: pyle
 		Location: 25,18
 		Owner: GDI
-	Plant1: nuke
+	Plant1: nuk2
 		Location: 21,17
 		Owner: GDI
 	Plant2: nuke

--- a/mods/cnc/maps/nod05/nod05.lua
+++ b/mods/cnc/maps/nod05/nod05.lua
@@ -122,13 +122,8 @@ Atk6TriggerFunction = function()
 end
 
 Atk1TriggerFunction = function()
-	Reinforcements.ReinforceWithTransport(enemy, 'tran', GDIReinforceUnits, { waypoint9.Location, waypoint26.Location }, nil,
-	function(transport, cargo)
-		transport.UnloadPassengers()
-		Utils.Do(cargo, function(actor)
-			IdleHunt(actor)
-		end)
-	end)
+	local cargo = Reinforcements.ReinforceWithTransport(enemy, 'tran', GDIReinforceUnits, { waypoint9.Location, waypoint26.Location }, { waypoint9.Location })[2]
+	Utils.Do(cargo, IdleHunt)
 end
 
 AutoTriggerFunction = function()


### PR DESCRIPTION
Also lets the transport fly out of the map after unloading all soldiers.

Fixes #14612.