### PR TITLE
Fix frozen actor regressions

### DIFF
--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -107,15 +107,18 @@ namespace OpenRA
 
 								case TargetType.FrozenActor:
 									{
+										var playerActorID = r.ReadUInt32();
+										var frozenActorID = r.ReadUInt32();
+
 										Actor playerActor;
-										if (world == null || !TryGetActorFromUInt(world, r.ReadUInt32(), out playerActor))
+										if (world == null || !TryGetActorFromUInt(world, playerActorID, out playerActor))
 											break;
 
 										var frozenLayer = playerActor.TraitOrDefault<FrozenActorLayer>();
 										if (frozenLayer == null)
 											break;
 
-										var frozen = frozenLayer.FromID(r.ReadUInt32());
+										var frozen = frozenLayer.FromID(frozenActorID);
 										if (frozen != null)
 											target = Target.FromFrozenActor(frozen);
 

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -284,7 +284,7 @@ namespace OpenRA
 						w.Write(UIntFromActor(Target.SerializableActor));
 						break;
 					case TargetType.FrozenActor:
-						w.Write(Target.FrozenActor.Owner.PlayerActor.ActorID);
+						w.Write(Target.FrozenActor.Viewer.PlayerActor.ActorID);
 						w.Write(Target.FrozenActor.ID);
 						break;
 					case TargetType.Terrain:

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -32,6 +32,7 @@ namespace OpenRA.Traits
 		public readonly PPos[] Footprint;
 		public readonly WPos CenterPosition;
 		readonly Actor actor;
+		readonly Player viewer;
 		readonly Shroud shroud;
 
 		public Player Owner { get; private set; }
@@ -59,10 +60,11 @@ namespace OpenRA.Traits
 
 		int flashTicks;
 
-		public FrozenActor(Actor self, PPos[] footprint, Shroud shroud, bool startsRevealed)
+		public FrozenActor(Actor actor, PPos[] footprint, Player viewer, bool startsRevealed)
 		{
-			actor = self;
-			this.shroud = shroud;
+			this.actor = actor;
+			this.viewer = viewer;
+			shroud = viewer.Shroud;
 			NeedRenderables = startsRevealed;
 
 			// Consider all cells inside the map area (ignoring the current map bounds)
@@ -81,11 +83,11 @@ namespace OpenRA.Traits
 					footprint.Select(p => p.ToString()).JoinWith("|"),
 					footprint.Select(p => shroud.Contains(p).ToString()).JoinWith("|")));
 
-			CenterPosition = self.CenterPosition;
+			CenterPosition = actor.CenterPosition;
 			TargetTypes = new HashSet<string>();
 
-			tooltips = self.TraitsImplementing<ITooltip>().ToArray();
-			health = self.TraitOrDefault<IHealth>();
+			tooltips = actor.TraitsImplementing<ITooltip>().ToArray();
+			health = actor.TraitOrDefault<IHealth>();
 
 			UpdateVisibility();
 		}
@@ -94,6 +96,7 @@ namespace OpenRA.Traits
 		public bool IsValid { get { return Owner != null; } }
 		public ActorInfo Info { get { return actor.Info; } }
 		public Actor Actor { get { return !actor.IsDead ? actor : null; } }
+		public Player Viewer { get { return viewer; } }
 
 		public void RefreshState()
 		{

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			frozenStates = new PlayerDictionary<FrozenState>(self.World, (player, playerIndex) =>
 			{
-				var frozenActor = new FrozenActor(self, footprint, player.Shroud, startsRevealed);
+				var frozenActor = new FrozenActor(self, footprint, player, startsRevealed);
 				if (startsRevealed)
 					UpdateFrozenActor(self, frozenActor, playerIndex);
 				player.PlayerActor.Trait<FrozenActorLayer>().Add(frozenActor);

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -252,11 +252,17 @@ namespace OpenRA.Mods.Common.Widgets
 			if (frozen != null)
 			{
 				var actor = frozen.Actor;
-				if (actor != null && actor.TraitsImplementing<IVisibilityModifier>().All(t => t.IsVisible(actor, world.RenderPlayer)))
+
+				// HACK: This leaks the cloak state through the fog (cloaked buildings will not show tooltips)
+				if (actor == null || actor.TraitsImplementing<IVisibilityModifier>().All(t => t.IsVisible(actor, world.RenderPlayer)))
 				{
 					FrozenActorTooltip = frozen;
+
+					// HACK: This leaks the tooltip state through the fog
+					// This will cause issues for any downstream mods that use IProvideTooltipInfo on enemy actors
 					if (frozen.Actor != null)
 						ActorTooltipExtra = frozen.Actor.TraitsImplementing<IProvideTooltipInfo>().ToArray();
+
 					TooltipType = WorldTooltipType.FrozenActor;
 					return;
 				}


### PR DESCRIPTION
Fixes #14613
Fixes #14614
Fixes #14615

Simple repro case:
1. Start a multiplayer game with two clients and cheats enabled
2. Client A enables cheats and places a structure just outside the vision range of player B
3. Client B moves a starting unit in range to view the structure, then out of range again
4. Client B observes the transition from actor -> frozen actor
5. Client B tests tooltip and attack order feedback
6. Client A sells the structure while it is still frozen for Client B
7. Client B tests tooltip and attack order feedback
