### PR TITLE
Don't try to remove tooltips that haven't been added.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/LabelWithTooltipWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LabelWithTooltipWidget.cs
@@ -55,10 +55,10 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override void MouseExited()
 		{
-			if (TooltipContainer == null)
-				return;
-
-			tooltipContainer.Value.RemoveTooltip();
+			// Only try to remove the tooltip if we know it has been created
+			// This avoids a crash if the widget (and the container it refers to) are being removed
+			if (TooltipContainer != null && tooltipContainer.IsValueCreated)
+				tooltipContainer.Value.RemoveTooltip();
 		}
 	}
 }


### PR DESCRIPTION
Fixes @abcdefg30's playtest crash.

Repro case: move the mouse over the players column in the server browser (for a different mod/version) and then quickly double click to join before the player tooltip appears (or would, if it could).  Then move the mouse after the switch mod dialog appears.

The crash happens because the MouseExit tries to instantiate a tooltip container that no longer exists.  The fix is to make sure it doesn't do that.