### PR TITLE
AI will now defend MCV as if it was a harvester or a building.

### DIFF
--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -1257,8 +1257,8 @@ namespace OpenRA.Mods.Common.AI
 			if (!e.Attacker.Info.HasTraitInfo<ITargetableInfo>())
 				return;
 
-			// Protected harvesters or building
-			if ((self.Info.HasTraitInfo<HarvesterInfo>() || self.Info.HasTraitInfo<BuildingInfo>()) &&
+			// Protected priority assets, MCVs, harvesters and buildings
+			if ((self.Info.HasTraitInfo<HarvesterInfo>() || self.Info.HasTraitInfo<BuildingInfo>() || self.Info.HasTraitInfo<BaseBuildingInfo>()) &&
 				Player.Stances[e.Attacker.Owner] == Stance.Enemy)
 			{
 				defenseCenter = e.Attacker.Location;


### PR DESCRIPTION
The AI will now defend MCV, just like it does buildings and harvesters.

This PR should solve #14250 and prevent AI from losing too many MCVs. 