### PR TITLE
Changed Civilian cost from 70 to 5.

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -441,7 +441,7 @@
 ^CivInfantry:
 	Inherits: ^Infantry
 	Valued:
-		Cost: 70
+		Cost: 5
 	Tooltip:
 		Name: Civilian
 		GenericVisibility: None


### PR DESCRIPTION
This fixes the issue of units in TD gaining veterancy rather quickly for killing civilians.

Fixes #14629