### PR TITLE
Remove helicopter RTB from command bar deploy description.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -663,6 +663,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		Order IIssueDeployOrder.IssueDeployOrder(Actor self)
 		{
+			if (!Info.RearmBuildings.Any())
+				return null;
+
 			return new Order("ReturnToBase", self, false);
 		}
 
@@ -675,9 +678,10 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				case "Move":
 				case "Enter":
-				case "ReturnToBase":
 				case "Stop":
 					return Info.Voice;
+				case "ReturnToBase":
+					return Info.RearmBuildings.Any() ? Info.Voice : null;
 				default: return null;
 			}
 		}
@@ -764,7 +768,7 @@ namespace OpenRA.Mods.Common.Traits
 					self.QueueActivity(new HeliLand(self, true));
 				}
 			}
-			else if (order.OrderString == "ReturnToBase")
+			else if (order.OrderString == "ReturnToBase" && Info.RearmBuildings.Any())
 			{
 				UnReserve();
 				self.CancelActivity();

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
@@ -309,6 +309,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var orders = selectedDeploys
 				.Where(pair => pair.Trait.IsTraitEnabled())
 				.Select(d => d.Trait.IssueDeployOrder(d.Actor))
+				.Where(d => d != null)
 				.ToArray();
 
 			foreach (var o in orders)

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -388,7 +388,7 @@ Container@PLAYER_WIDGETS:
 					DisableKeyRepeat: true
 					DisableKeySound: true
 					TooltipText: Deploy
-					TooltipDesc: Selected units will perform their default deploy activity\n - MCVs will unpack into a Construction Yard\n - Construction Yards will re-pack into a MCV\n - Transports will unload their passengers\n - Helicopters will return to base\n\nActs immediately on selected units.
+					TooltipDesc: Selected units will perform their default deploy activity\n - MCVs will unpack into a Construction Yard\n - Construction Yards will re-pack into a MCV\n - Transports will unload their passengers\n\nActs immediately on selected units.
 					TooltipContainer: TOOLTIP_CONTAINER
 					Children:
 						Image@ICON:


### PR DESCRIPTION
This no longer functions, and does not make sense as a feature.  We do not have a dedicated "return and repair" hotkey for any units in any other mods, and it only worked in TD before now because of a hack that we have removed and do not want to restore.

If we really do want a "retreat to base" command then that would be best implemented as its own button/hotkey that works with all unit types.

Closes #14641.
  
  
  