### PR TITLE
Dispose Streams and readers and ensure that orders are always longer than 4 bytes

### DIFF
--- a/OpenRA.Game/Network/OrderIO.cs
+++ b/OpenRA.Game/Network/OrderIO.cs
@@ -23,14 +23,22 @@ namespace OpenRA.Network
 
 		public static List<Order> ToOrderList(this byte[] bytes, World world)
 		{
-			var ms = new MemoryStream(bytes, 4, bytes.Length - 4);
-			var reader = new BinaryReader(ms);
 			var ret = new List<Order>();
-			while (ms.Position < ms.Length)
+
+			if (bytes.Length <= 4)
+				return ret;
+
+			using (var ms = new MemoryStream(bytes, 4, bytes.Length - 4))
 			{
-				var o = Order.Deserialize(world, reader);
-				if (o != null)
-					ret.Add(o);
+				using (var reader = new BinaryReader(ms))
+				{
+					while (ms.Position < ms.Length)
+					{
+						var o = Order.Deserialize(world, reader);
+						if (o != null)
+							ret.Add(o);
+					}
+				}
 			}
 
 			return ret;
@@ -38,14 +46,20 @@ namespace OpenRA.Network
 
 		public static byte[] SerializeSync(int sync)
 		{
-			var ms = new MemoryStream(1 + 4);
-			using (var writer = new BinaryWriter(ms))
+			byte[] buffer;
+
+			using (var ms = new MemoryStream(1 + 4))
 			{
-				writer.Write((byte)0x65);
-				writer.Write(sync);
+				using (var writer = new BinaryWriter(ms))
+				{
+					writer.Write((byte)0x65);
+					writer.Write(sync);
+				}
+
+				buffer = ms.GetBuffer();
 			}
 
-			return ms.GetBuffer();
+			return buffer;
 		}
 
 		public static int2 ReadInt2(this BinaryReader r)

--- a/OpenRA.Test/OpenRA.Game/OrderTest.cs
+++ b/OpenRA.Test/OpenRA.Game/OrderTest.cs
@@ -43,8 +43,13 @@ namespace OpenRA.Test
 
 		Order RoundTripOrder(Order o)
 		{
-			var serializedData = new MemoryStream(o.Serialize());
-			return Order.Deserialize(null, new BinaryReader(serializedData));
+			Order desOrder;
+
+			using (var serializedData = new MemoryStream(o.Serialize()))
+				using (var reader = new BinaryReader(serializedData))
+					desOrder = Order.Deserialize(null, reader);
+
+			return desOrder;
 		}
 
 		[TestCase(TestName = "Data persists over serialization")]


### PR DESCRIPTION
This PR adds adds Disposing in Methods where we create Memory streams but does not disposing them.

(2) While i created this PR i found a condition (https://github.com/LipkeGu/OpenRA/blob/8d8f4195cd146dd13ea2757872514477575f0346/OpenRA.Game/Network/OrderIO.cs#L31) which can crash the game, when a array is smaller than the requested position (4). I Decided to return an empty 
Result in this case.

This fix (2) can be tested by quickly repeatly creating a local or online multiplayer server lobby. It should showing you the lobby as expected. So i decided to return an empty OrderList, 

(2) fixes  #13070

  
  
  
  
  
  
  
  