### PR TITLE
Ensure that orders are longer than 4 bytes

### DIFF
--- a/OpenRA.Game/Network/FrameData.cs
+++ b/OpenRA.Game/Network/FrameData.cs
@@ -73,6 +73,7 @@ namespace OpenRA.Network
 				.ToDictionary(k => k, v => frameData[v]);
 
 			return clientData
+				.Where(x => x.Value.Length > 4)
 				.SelectMany(x => x.Value
 					.ToOrderList(world)
 					.Select(o => new ClientOrder { Client = x.Key, Order = o }));

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -121,6 +121,9 @@ namespace OpenRA.Network
 
 			foreach (var p in immediatePackets)
 			{
+				if (p.Second.Length < 5)
+					continue;
+
 				foreach (var o in p.Second.ToOrderList(World))
 				{
 					UnitOrders.ProcessOrder(this, World, p.First, o);

--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -69,6 +69,9 @@ namespace OpenRA.Network
 						continue; // sync
 					else if (frame == 0)
 					{
+						if (packet.Length < 5)
+							continue;
+
 						// Parse replay metadata from orders stream
 						var orders = packet.ToOrderList(null);
 						foreach (var o in orders)

--- a/OpenRA.Game/Network/ReplayRecorder.cs
+++ b/OpenRA.Game/Network/ReplayRecorder.cs
@@ -25,6 +25,9 @@ namespace OpenRA.Network
 
 		static bool IsGameStart(byte[] data)
 		{
+			if (data.Length < 5)
+				return false;
+
 			if (data.Length == 5 && data[4] == 0xbf)
 				return false;
 			if (data.Length >= 5 && data[4] == 0x65)


### PR DESCRIPTION
In normal cases Order are longer than 4 bytes in length (Header (4 bytes) + (Order itself X bytes long) in some magical cases (network) the ```ToOrderList``` get malformed Orders from clients (smaller than 4 bytes, maybe null or entire empty data). So we should filter out these invalid "useless" Orders to ensure that we pass only valid Orders.

fixes #13070
  