### PR TITLE
ActorSelectorLogic: Keep track of available owners.

### DIFF
--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -373,6 +373,8 @@ namespace OpenRA.Widgets
 		public virtual void MouseEntered() { }
 		public virtual void MouseExited() { }
 
+		public virtual void DoUpdate() { }
+
 		/// <summary>Possibly handles mouse input (click, drag, scroll, etc).</summary>
 		/// <returns><c>true</c>, if mouse input was handled, <c>false</c> if the input should bubble to the parent widget</returns>
 		/// <param name="mi">Mouse input data</param>
@@ -460,7 +462,7 @@ namespace OpenRA.Widgets
 			}
 		}
 
-		public virtual void Tick() { }
+		public virtual void Tick() { DoUpdate(); }
 
 		public virtual void TickOuter()
 		{

--- a/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
@@ -61,6 +61,8 @@ namespace OpenRA.Mods.Common.Widgets
 
 		protected readonly Ruleset ModRules;
 
+		public Action OnUpdate = () => { };
+
 		[ObjectCreator.UseCtor]
 		public ButtonWidget(ModData modData)
 		{
@@ -126,6 +128,12 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			Depressed = false;
 			return base.YieldMouseFocus(mi);
+		}
+
+		public override void DoUpdate()
+		{
+			if (!IsDisabled() && IsVisible())
+				OnUpdate();
 		}
 
 		public override bool HandleKeyPress(KeyInput e)

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -88,6 +88,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return item;
 			};
 
+			ownersDropDown.OnUpdate = () =>
+			{
+				if (!editorLayer.Players.Players.ContainsKey(selectedOwner.Name))
+				{
+					var players = editorLayer.Players.Players.Values
+					.Where(p => p.Name.StartsWith("Multi"))
+					.OrderBy(p => p.Name);
+
+					selectedOwner = (players.Count() != 0) ?
+						players.Last() : editorLayer.Players.Players.FirstOrDefault().Value;
+
+					ownersDropDown.Text = selectedOwner.Name;
+					ownersDropDown.TextColor = selectedOwner.Color.RGB;
+				}
+			};
+
 			ownersDropDown.OnClick = () =>
 			{
 				var owners = editorLayer.Players.Players.Values.OrderBy(p => p.Name);


### PR DESCRIPTION
This PR implements ```OnUpdate()``` in ActorSelectorLogic so that the ```OwnersDropdown.Text``` gets updated when owners gets removed (by removing spawn points. It will first try to pick up the last "MultiX" entry otherwise when no "Multi" is found. it will use the first available owner (ex: Neutral).

The next part of this PR is the Question "What should happen with placed) Actors
which was  owned by a removed Owner?
 
fixes #9364
  
  