### PR TITLE
Fix ProduceActorPower not checking if Production trait is Disabled or Paused.

### DIFF
--- a/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var info = Info as ProduceActorPowerInfo;
 			var sp = self.TraitsImplementing<Production>()
-				.FirstOrDefault(p => p.Info.Produces.Contains(info.Type));
+				.FirstOrDefault(p => !p.IsTraitDisabled && !p.IsTraitPaused && p.Info.Produces.Contains(info.Type));
 
 			// TODO: The power should not reset if the production fails.
 			// Fixing this will require a larger rework of the support power code


### PR DESCRIPTION
May say this is something missed from #14387, but there wasn't a IDisabled check to begin with so i dunno.

Check here makes sense because if Production: is disabled, than no actor is produced, even tho if there are other Producers with trait enabled (at least when disabled, not checked paused.).
  