### PR TITLE
Make ProduceActorPower care for PrimaryBuilding 

### DIFF
--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -1071,6 +1071,14 @@ palace:
 	ProvidesPrerequisite@saboteur:
 		Prerequisite: palace.saboteur
 		Factions: ordos
+	PrimaryBuilding:
+		PrimaryCondition: primary
+	WithTextDecoration@primary:
+		RequiresSelection: true
+		Text: PRIMARY
+		ReferencePoint: Top
+		ZOffset: 256
+		RequiresCondition: primary
 	NukePower:
 		Cursor: nuke
 		Icon: deathhand


### PR DESCRIPTION
ProduceActorPower now uses the similar ordering ClassicProductionPalette uses. If there is a primary, use primary. If there is not from last built one.

This also fixes that ProduceActorPower didn't care if Production trait was disabled or not.

This doesn't adress #14660 alone, but is required for actual fix because of point above.