### PR TITLE
RA - Remove ^Tank default

### DIFF
--- a/mods/ra/maps/bomber-john/rules.yaml
+++ b/mods/ra/maps/bomber-john/rules.yaml
@@ -95,7 +95,7 @@ Player:
 		Locked: True
 
 MNLYR:
-	Inherits: ^Tank
+	Inherits: ^TrackedVehicle
 	Valued:
 		Cost: 800
 	Tooltip:

--- a/mods/ra/maps/desert-shellmap/rules.yaml
+++ b/mods/ra/maps/desert-shellmap/rules.yaml
@@ -32,15 +32,6 @@ World:
 	ExternalCondition@UNKILLABLE:
 		Condition: unkillable
 
-^Tank:
-	GainsExperience:
-		Conditions:
-	DamageMultiplier@UNKILLABLE:
-		RequiresCondition: unkillable
-		Modifier: 0
-	ExternalCondition@UNKILLABLE:
-		Condition: unkillable
-
 ^Infantry:
 	GainsExperience:
 		Conditions:

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -240,7 +240,6 @@ E7:
 		Cost: 750
 
 3TNK:
-	Inherits: ^Tank
 	Armament:
 		Weapon: TankNapalm
 		Recoil: 200
@@ -296,7 +295,6 @@ FTRK:
 		MuzzleSequence: muzzle
 
 ARTY:
-	Inherits: ^Tank
 	Valued:
 		Cost: 600
 	Health:

--- a/mods/ra/maps/fort-lonestar/weapons.yaml
+++ b/mods/ra/maps/fort-lonestar/weapons.yaml
@@ -168,9 +168,9 @@ SCUD:
 
 SilencedPPK:
 	Range: 25c0
-	ValidTargets: Infantry, Tank, Vehicle, Husk
+	ValidTargets: Infantry, Vehicle, Husk
 	InvalidTargets: Water, Structure, Wall
 	Warhead@1Dam: SpreadDamage
-		ValidTargets: Infantry, Tank, Vehicle, Husk
+		ValidTargets: Infantry, Vehicle, Husk
 		Versus:
 			Heavy: 50

--- a/mods/ra/maps/monster-tank-madness/rules.yaml
+++ b/mods/ra/maps/monster-tank-madness/rules.yaml
@@ -118,7 +118,7 @@ PBOX:
 		Types: Infantry, Demitri
 
 5TNK:
-	Inherits: ^Tank
+	Inherits: ^TrackedVehicle
 	Inherits@AUTOTARGET: ^AutoTargetAll
 	Valued:
 		Cost: 10000

--- a/mods/ra/rules/campaign-tooltips.yaml
+++ b/mods/ra/rules/campaign-tooltips.yaml
@@ -3,11 +3,6 @@
 		GenericVisibility: Enemy
 		ShowOwnerRow: false
 
-^Tank:
-	Tooltip:
-		GenericVisibility: Enemy
-		ShowOwnerRow: false
-
 ^Infantry:
 	Tooltip:
 		GenericVisibility: Enemy

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -161,11 +161,11 @@
 		AttackAnythingCondition: stance-attackanything
 	AutoTargetPriority@DEFAULT:
 		RequiresCondition: !stance-attackanything
-		ValidTargets: Infantry, Vehicle, Tank, Water, Underwater, Defense
+		ValidTargets: Infantry, Vehicle, Water, Underwater, Defense
 		InvalidTargets: NoAutoTarget, WaterStructure
 	AutoTargetPriority@ATTACKANYTHING:
 		RequiresCondition: stance-attackanything
-		ValidTargets: Infantry, Vehicle, Tank, Water, Underwater, Structure, Defense
+		ValidTargets: Infantry, Vehicle, Water, Underwater, Structure, Defense
 		InvalidTargets: NoAutoTarget
 
 ^AutoTargetGroundAssaultMove:
@@ -188,11 +188,11 @@
 		AttackAnythingCondition: stance-attackanything
 	AutoTargetPriority@DEFAULT:
 		RequiresCondition: !stance-attackanything
-		ValidTargets: Infantry, Vehicle, Tank, Water, Underwater, Air, Defense
+		ValidTargets: Infantry, Vehicle, Water, Underwater, Air, Defense
 		InvalidTargets: NoAutoTarget, WaterStructure
 	AutoTargetPriority@ATTACKANYTHING:
 		RequiresCondition: stance-attackanything
-		ValidTargets: Infantry, Vehicle, Tank, Water, Underwater, Air, Structure, Defense
+		ValidTargets: Infantry, Vehicle, Water, Underwater, Air, Structure, Defense
 		InvalidTargets: NoAutoTarget
 
 ^AutoTargetAllAssaultMove:
@@ -288,7 +288,7 @@
 	EditorTilesetFilter:
 		Categories: Vehicle
 
-^Tank:
+^TrackedVehicle:
 	Inherits: ^Vehicle
 	Mobile:
 		Crushes: wall, mine, crate
@@ -300,12 +300,6 @@
 			Ore: 70
 			Gems: 70
 			Beach: 70
-	Targetable:
-		TargetTypes: Ground, C4, Repair, Tank
-	ProximityCaptor:
-		Types: Tank
-	Tooltip:
-		GenericName: Tank
 
 ^Infantry:
 	Inherits@1: ^ExistsInWorld

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -47,7 +47,7 @@ V2RL:
 		DecorationBounds: 28,28
 
 1TNK:
-	Inherits: ^Tank
+	Inherits: ^TrackedVehicle
 	Inherits@GAINSEXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Buildable:
@@ -59,6 +59,7 @@ V2RL:
 		Cost: 700
 	Tooltip:
 		Name: Light Tank
+		GenericName: Tank
 	Health:
 		HP: 22000
 	Armor:
@@ -90,7 +91,7 @@ V2RL:
 		Prerequisites: vehicles.upgraded
 
 2TNK:
-	Inherits: ^Tank
+	Inherits: ^TrackedVehicle
 	Inherits@GAINSEXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Buildable:
@@ -102,6 +103,7 @@ V2RL:
 		Cost: 850
 	Tooltip:
 		Name: Medium Tank
+		GenericName: Tank
 	Health:
 		HP: 45000
 	Armor:
@@ -136,7 +138,7 @@ V2RL:
 		DecorationBounds: 28,28
 
 3TNK:
-	Inherits: ^Tank
+	Inherits: ^TrackedVehicle
 	Inherits@GAINSEXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Buildable:
@@ -148,6 +150,7 @@ V2RL:
 		Cost: 1150
 	Tooltip:
 		Name: Heavy Tank
+		GenericName: Tank
 	Health:
 		HP: 60000
 	Armor:
@@ -182,7 +185,7 @@ V2RL:
 		DecorationBounds: 28,28
 
 4TNK:
-	Inherits: ^Tank
+	Inherits: ^TrackedVehicle
 	Inherits@GAINSEXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetAllAssaultMove
 	Buildable:
@@ -196,6 +199,7 @@ V2RL:
 		Cost: 2000
 	Tooltip:
 		Name: Mammoth Tank
+		GenericName: Tank
 	Health:
 		HP: 90000
 	Armor:
@@ -244,7 +248,7 @@ V2RL:
 		DecorationBounds: 44,38,0,-4
 
 ARTY:
-	Inherits: ^Tank
+	Inherits: ^TrackedVehicle
 	Inherits@GAINSEXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Buildable:
@@ -417,7 +421,7 @@ JEEP:
 		Prerequisites: vehicles.upgraded
 
 APC:
-	Inherits: ^Tank
+	Inherits: ^TrackedVehicle
 	Inherits@GAINSEXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Buildable:
@@ -457,7 +461,7 @@ APC:
 		Prerequisites: vehicles.upgraded
 
 MNLY:
-	Inherits: ^Tank
+	Inherits: ^TrackedVehicle
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 100
@@ -596,7 +600,7 @@ MRJ:
 		Range: 6c0
 
 TTNK:
-	Inherits: ^Tank
+	Inherits: ^TrackedVehicle
 	Inherits@GAINSEXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Buildable:
@@ -609,6 +613,7 @@ TTNK:
 		Cost: 1350
 	Tooltip:
 		Name: Tesla Tank
+		GenericName: Tank
 	Health:
 		HP: 45000
 	Armor:
@@ -724,6 +729,7 @@ CTNK:
 		Cost: 1350
 	Tooltip:
 		Name: Chrono Tank
+		GenericName: Tank
 	SelectionDecorations:
 	Health:
 		HP: 45000
@@ -754,7 +760,7 @@ CTNK:
 		DecorationBounds: 30,30
 
 QTNK:
-	Inherits: ^Tank
+	Inherits: ^TrackedVehicle
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 190
@@ -764,6 +770,7 @@ QTNK:
 		Cost: 2000
 	Tooltip:
 		Name: MAD Tank
+		GenericName: Tank
 	Health:
 		HP: 90000
 	Armor:

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -17,7 +17,7 @@
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
-		InvalidTargets: Vehicle, Tank, Structure, Wall, Husk, Trees
+		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees
 	Warhead@3Eff: CreateEffect
 		Explosions: small_explosion
 		ImpactSounds: kaboom12.aud

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -227,7 +227,7 @@ CrateNuke:
 		VictimScanRadius: 0
 	Warhead@6Smu_areanuke1: LeaveSmudge
 		SmudgeType: Scorch
-		InvalidTargets: Vehicle, Tank, Structure, Wall, Trees
+		InvalidTargets: Vehicle, Structure, Wall, Trees
 		Size: 4
 		Delay: 5
 	Warhead@TREEKILL: SpreadDamage
@@ -317,6 +317,6 @@ MiniNuke:
 		Delay: 15
 	Warhead@13Smu_areanuke3: LeaveSmudge
 		SmudgeType: Scorch
-		InvalidTargets: Vehicle, Tank, Structure, Wall, Trees
+		InvalidTargets: Vehicle, Structure, Wall, Trees
 		Size: 4
 		Delay: 15

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -26,7 +26,7 @@
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
-		InvalidTargets: Vehicle, Tank, Structure, Wall, Husk, Trees
+		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion
 		ImpactSounds: kaboom25.aud

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -265,7 +265,7 @@ M60mg:
 	Range: 2c512
 	Report: gun5.aud
 	ValidTargets: Ground, Infantry
-	InvalidTargets: Vehicle, Tank, Water, Structure, Wall, Husk
+	InvalidTargets: Vehicle, Water, Structure, Wall, Husk
 	Projectile: Bullet
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -19,7 +19,7 @@ ParaBomb:
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
-		InvalidTargets: Vehicle, Tank, Structure, Wall, Husk, Trees
+		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees
 	Warhead@3Eff: CreateEffect
 		Explosions: artillery_explosion
 		ImpactSounds: kaboom15.aud
@@ -45,7 +45,7 @@ Atomic:
 		Size: 1
 	Warhead@3Smu_impact: LeaveSmudge
 		SmudgeType: Scorch
-		InvalidTargets: Vehicle, Tank, Structure, Wall
+		InvalidTargets: Vehicle, Structure, Wall
 		Size: 1
 	Warhead@4Eff_impact: CreateEffect
 		Explosions: nuke
@@ -67,7 +67,7 @@ Atomic:
 		Delay: 5
 	Warhead@7Smu_areanuke1: LeaveSmudge
 		SmudgeType: Scorch
-		InvalidTargets: Vehicle, Tank, Structure, Wall, Husk, Trees
+		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees
 		Size: 2
 		Delay: 5
 	Warhead@8Eff_areanuke1: CreateEffect
@@ -96,7 +96,7 @@ Atomic:
 		Delay: 10
 	Warhead@12Smu_areanuke2: LeaveSmudge
 		SmudgeType: Scorch
-		InvalidTargets: Vehicle, Tank, Structure, Wall, Husk, Trees
+		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees
 		Size: 3
 		Delay: 10
 	Warhead@13Dam_areanuke3: SpreadDamage
@@ -120,7 +120,7 @@ Atomic:
 		Delay: 15
 	Warhead@16Smu_areanuke3: LeaveSmudge
 		SmudgeType: Scorch
-		InvalidTargets: Vehicle, Tank, Structure, Wall, Husk, Trees
+		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees
 		Size: 4
 		Delay: 15
 	Warhead@17Dam_areanuke4: SpreadDamage
@@ -144,6 +144,6 @@ Atomic:
 		Delay: 20
 	Warhead@20Smu_areanuke4: LeaveSmudge
 		SmudgeType: Scorch
-		InvalidTargets: Vehicle, Tank, Structure, Wall, Husk, Trees
+		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees
 		Size: 5
 		Delay: 20


### PR DESCRIPTION
Fixes #14662 in a longer way. Tank target type was never used alone. So it was pretty much unnecessary. Speed modifiers are now under a different default `^TrackedVehicle`. Name comes from the fact that this speed diference was due to Tracked trait in original game.

I changed the `GenericName:`s so only actors with Tank in their actual name uses `GenericName: Tank`. So for example Artillery will no longer show Tank as generic name, but Chrono Tank will.