### PR TITLE
Fix frozen actor flicker

### DIFF
--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -254,38 +254,33 @@ namespace OpenRA.Traits
 
 		void ITick.Tick(Actor self)
 		{
-			// Update visibility at the end of the tick to make sure that
-			// the fog/shroud state has been updated for the tick
-			self.World.AddFrameEndTask(w =>
+			UpdateDirtyFrozenActorsFromDirtyBins();
+
+			var frozenActorsToRemove = new List<FrozenActor>();
+			VisibilityHash = 0;
+			FrozenHash = 0;
+
+			foreach (var kvp in frozenActorsById)
 			{
-				UpdateDirtyFrozenActorsFromDirtyBins();
+				var id = kvp.Key;
+				var hash = (int)id;
+				FrozenHash += hash;
 
-				var frozenActorsToRemove = new List<FrozenActor>();
-				VisibilityHash = 0;
-				FrozenHash = 0;
+				var frozenActor = kvp.Value;
+				frozenActor.Tick();
+				if (dirtyFrozenActorIds.Contains(id))
+					frozenActor.UpdateVisibility();
 
-				foreach (var kvp in frozenActorsById)
-				{
-					var id = kvp.Key;
-					var hash = (int)id;
-					FrozenHash += hash;
+				if (frozenActor.Visible)
+					VisibilityHash += hash;
+				else if (frozenActor.Actor == null)
+					frozenActorsToRemove.Add(frozenActor);
+			}
 
-					var frozenActor = kvp.Value;
-					frozenActor.Tick();
-					if (dirtyFrozenActorIds.Contains(id))
-						frozenActor.UpdateVisibility();
+			dirtyFrozenActorIds.Clear();
 
-					if (frozenActor.Visible)
-						VisibilityHash += hash;
-					else if (frozenActor.Actor == null)
-						frozenActorsToRemove.Add(frozenActor);
-				}
-
-				dirtyFrozenActorIds.Clear();
-
-				foreach (var fa in frozenActorsToRemove)
-					Remove(fa);
-			});
+			foreach (var fa in frozenActorsToRemove)
+				Remove(fa);
 		}
 
 		void UpdateDirtyFrozenActorsFromDirtyBins()

--- a/OpenRA.Game/Traits/World/ScreenMap.cs
+++ b/OpenRA.Game/Traits/World/ScreenMap.cs
@@ -245,7 +245,7 @@ namespace OpenRA.Traits
 			return rect;
 		}
 
-		public void Tick()
+		public void TickRender()
 		{
 			foreach (var a in addOrUpdateActors)
 			{

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -353,7 +353,6 @@ namespace OpenRA
 				ActorsWithTrait<ITick>().DoTimed(x => x.Trait.Tick(x.Actor), "Trait");
 
 				effects.DoTimed(e => e.Tick(this), "Effect");
-				ScreenMap.Tick();
 			}
 
 			while (frameEndActions.Count != 0)
@@ -364,6 +363,7 @@ namespace OpenRA
 		public void TickRender(WorldRenderer wr)
 		{
 			ActorsWithTrait<ITickRender>().DoTimed(x => x.Trait.TickRender(wr, x.Actor), "Render");
+			ScreenMap.TickRender();
 		}
 
 		public IEnumerable<Actor> Actors { get { return actors.Values; } }


### PR DESCRIPTION
Fixes #14614.
Fixes #14645.

The first fix (7d4745ce502c2a1ca04f30fd4d6f67b3baa091a2 from #14619) worked for #14614 but then caused #14645. This PR reverts that change and applies a different fix which fixes the original issue without introducing the same regression.