### PR TITLE
Remove "Mission Aborted" notification from D2k.

### DIFF
--- a/mods/d2k/audio/notifications.yaml
+++ b/mods/d2k/audio/notifications.yaml
@@ -28,7 +28,7 @@ Speech:
 		Guarding: GUARD
 		HarvesterAttack: HATTK
 		InsufficientFunds: MONEY
-		Leave: ABORT
+		Leave:
 		Lose: MFAIL
 		LowPower: POWER
 		MissileLaunchDetected: LAUNC

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -169,6 +169,7 @@ World:
 	DebugPauseState:
 	RadarPings:
 	ObjectivesPanel:
+		ExitDelay: 0
 		PanelName: SKIRMISH_STATS
 	LoadWidgetAtGameStart:
 


### PR DESCRIPTION
Closes #14673.