### PR TITLE
GrantConditionOnTerrain checks Location.Layer==0 to fix apcs swimming

### DIFF
--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -39,7 +39,7 @@ APC:
 		Sequence: water
 		RequiresCondition: inwater
 	LeavesTrails:
-		RequiresCondition: !inside-tunnel
+		RequiresCondition: !inside-tunnel && inwater
 		Image: wake
 		Palette: effect
 		TerrainTypes: Water


### PR DESCRIPTION
Fix APCs 'swimming' over bridges

Fixes part of #14592

![34468893-00783bba-ef13-11e7-8fb4-b2a683786bea](https://user-images.githubusercontent.com/25386322/34653609-b46075b8-f3ee-11e7-93c2-ae8731f2091f.JPG)

I messed PR #14621 (with rebase) up so i cloesd it and made the exact same change here.
