### PR TITLE
D2K - Fix building armors

### DIFF
--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -194,7 +194,7 @@ barracks:
 			TopLeft: -1024, -1024
 			BottomRight: 1024, 1024
 	Armor:
-		Type: wood
+		Type: building
 	RevealsShroud:
 		Range: 3c768
 	RallyPoint:
@@ -279,7 +279,7 @@ refinery:
 			TopLeft: -1536, 0
 			BottomRight: 512, 1024
 	Armor:
-		Type: building
+		Type: heavy
 	RevealsShroud:
 		Range: 4c768
 	Refinery:
@@ -333,7 +333,7 @@ silo:
 	Health:
 		HP: 15000
 	Armor:
-		Type: wall
+		Type: building
 	RevealsShroud:
 		Range: 2c768
 	RenderSprites:
@@ -389,7 +389,7 @@ light_factory:
 			TopLeft: -1536, -1024
 			BottomRight: 1536, 1024
 	Armor:
-		Type: light
+		Type: building
 	RevealsShroud:
 		Range: 4c768
 	RenderSprites:
@@ -480,7 +480,7 @@ heavy_factory:
 			TopLeft: -512, -1536
 			BottomRight: 512, -512
 	Armor:
-		Type: wood
+		Type: building
 	RevealsShroud:
 		Range: 4c768
 	RallyPoint:
@@ -574,7 +574,7 @@ outpost:
 			TopLeft: -1536, -1024
 			BottomRight: 1536, 1024
 	Armor:
-		Type: light
+		Type: building
 	RevealsShroud:
 		Range: 4c768
 	ProvidesRadar:
@@ -626,7 +626,7 @@ starport:
 			TopLeft: -512, 512
 			BottomRight: 512, 1536
 	Armor:
-		Type: building
+		Type: heavy
 	RevealsShroud:
 		Range: 4c768
 	RallyPoint:
@@ -816,7 +816,7 @@ large_gun_turret:
 	Health:
 		HP: 30000
 	Armor:
-		Type: concrete
+		Type: heavy
 	RevealsShroud:
 		Range: 5c768
 	BodyOrientation:
@@ -923,7 +923,7 @@ high_tech_factory:
 			TopLeft: -512, -1536
 			BottomRight: 512, -512
 	Armor:
-		Type: wood
+		Type: building
 	RevealsShroud:
 		Range: 4c768
 	RenderSprites:
@@ -998,7 +998,7 @@ research_centre:
 			TopLeft: -512, -1536
 			BottomRight: 512, -512
 	Armor:
-		Type: wood
+		Type: building
 	RevealsShroud:
 		Range: 4c768
 	RenderSprites:
@@ -1050,7 +1050,7 @@ palace:
 			TopLeft: -512, 512
 			BottomRight: 1536, 1536
 	Armor:
-		Type: wood
+		Type: heavy
 	RevealsShroud:
 		Range: 4c768
 	RenderSprites:


### PR DESCRIPTION
Fixes  #14681
![resim](https://user-images.githubusercontent.com/7933210/34670492-94a369c6-f487-11e7-94fb-29e4590b070f.png)

To test in original game

1-) You can get TibEd and .tib file i used for editing below:
[TibEd and tib file.zip](https://github.com/OpenRA/OpenRA/files/1611562/TibEd.and.tib.file.zip)

2-) Open the .tib file with TibEd and apply the changes.

3-) You can see that i changed all Atreides building armor to Invulnerable. But ingame you'll see they still take damage. I also set their health to 300, and Trikes damage to 100. Also see W_AT for changed percentages.

4-) Open Atreides Test Map on Gruntmods Edition and attack your own buildings with Trike. Ensure that trike is next to the target, as it looks like distance effects damage output in original game.

5-) Buildings with Building armor should die in 3 hits. Heavy armor should die in 4 hits. CY Should die in 15 hits and wall also in 4 hits (but looks like i set wall's health to 200 and lazy to edit the file again, it is actually getting 50% damage from warhead, which is wall armor).
  