### PR TITLE
Do not speed D2K upgrades up based on buildings.

### DIFF
--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -50,7 +50,6 @@ Player:
 		QueuedAudio: Upgrading
 		ReadyAudio: NewOptions
 		BlockedAudio: NoRoom
-		SpeedUp: true
 	PlaceBuilding:
 	SupportPowerManager:
 	ScriptTriggers:


### PR DESCRIPTION
Without this patch, building more Barracks, say, will make all upgrades build faster.