### PR TITLE
Correct UI for unslowed queues in low power.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -63,6 +63,11 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string CancelledAudio = "Cancelled";
 
 		public virtual object Create(ActorInitializer init) { return new ProductionQueue(init, init.Self.Owner.PlayerActor, this); }
+
+		public void RulesetLoaded(Ruleset rules, ActorInfo ai) {
+			if (LowPowerSlowdown <= 0)
+				throw new YamlException("Production queue must have LowPowerSlowdown of at least 1.");
+		}
 	}
 
 	public class ProductionQueue : IResolveOrder, ITick, ITechTreeElement, INotifyOwnerChanged, INotifyKilled, INotifySold, ISync, INotifyTransform, INotifyCreated

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -103,7 +103,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var timeMultiplier = pm.PowerState != PowerState.Normal ? tooltipIcon.ProductionQueue.Info.LowPowerSlowdown : 1;
 
 				timeLabel.Text = formatBuildTime.Update(buildTime * timeMultiplier);
-				timeLabel.TextColor = pm.PowerState != PowerState.Normal ? Color.Red : Color.White;
+				timeLabel.TextColor = (pm.PowerState != PowerState.Normal && tooltipIcon.ProductionQueue.Info.LowPowerSlowdown > 1) ? Color.Red : Color.White;
 				var timeSize = font.Measure(timeLabel.Text);
 
 				costLabel.Text = cost.ToString();

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -32,7 +32,7 @@ Player:
 	ClassicProductionQueue@Starport:
 		Type: Starport
 		BuildDurationModifier: 212
-		LowPowerSlowdown: 0
+		LowPowerSlowdown: 1
 		BlockedAudio: NoRoom
 		QueuedAudio: OrderPlaced
 		ReadyAudio:
@@ -46,7 +46,7 @@ Player:
 	ClassicProductionQueue@Upgrade: # Upgrade is defined after others so it won't be automatically selected by ProductionQueueFromSelection.
 		Type: Upgrade
 		BuildDurationModifier: 250
-		LowPowerSlowdown: 0
+		LowPowerSlowdown: 1
 		QueuedAudio: Upgrading
 		ReadyAudio: NewOptions
 		BlockedAudio: NoRoom


### PR DESCRIPTION
Because of the way the tick logic works, 0 (or any negative number) for
LowPowerSlowdown is functionally equivalent to 1. But LowPowerSlowdown
is multipled by a time in several cases, so while 1 will produce the
correct result (no slowdown), 0 will say that the time remaining is
00:00. Forbid nonpositive values, and correct the d2k mod which was
using 0.

Additionally, in the production tooltip, the colour should display as
white even in low power if there is no slowdown.