### PR TITLE
RA - Subfaction FactionSuffix

### DIFF
--- a/mods/ra/metrics.yaml
+++ b/mods/ra/metrics.yaml
@@ -7,6 +7,9 @@ Metrics:
 	FactionSuffix-england: allies
 	FactionSuffix-france: allies
 	FactionSuffix-germany: allies
+	FactionSuffix-spain: allies
+	FactionSuffix-greece: allies
+	FactionSuffix-turkey: allies
 	FactionSuffix-russia: soviet
 	FactionSuffix-soviet: soviet
 	FactionSuffix-ukraine: soviet


### PR DESCRIPTION
Our RA mod has flag artwork and definition on chrome.yaml for Allied subfactions from original game that we don't use. But without `FactionSuffixes` it would crash if a player becomes them on a mapmod that adds factions for them.