### PR TITLE
Exponentially scale the volume control value

### DIFF
--- a/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
+++ b/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
@@ -273,7 +273,7 @@ namespace OpenRA.Platforms.Default
 		public float Volume
 		{
 			get { return volume; }
-			set { AL10.alListenerf(AL10.AL_GAIN, volume = value); }
+			set { AL10.alListenerf(AL10.AL_GAIN, (volume = value) * value * value * value); } // x^4 for linear->exponential
 		}
 
 		public void PauseSound(ISound sound, bool paused)
@@ -323,7 +323,7 @@ namespace OpenRA.Platforms.Default
 			});
 
 			foreach (var s in sounds)
-				AL10.alSourcef(s, AL10.AL_GAIN, volume);
+				AL10.alSourcef(s, AL10.AL_GAIN, volume * volume * volume * volume); // x^4 for linear->exponential
 		}
 
 		public void StopSound(ISound sound)
@@ -447,8 +447,8 @@ namespace OpenRA.Platforms.Default
 
 		public float Volume
 		{
-			get { float volume; AL10.alGetSourcef(Source, AL10.AL_GAIN, out volume); return volume; }
-			set { AL10.alSourcef(Source, AL10.AL_GAIN, value); }
+			get { float volume; AL10.alGetSourcef(Source, AL10.AL_GAIN, out volume); return (float)Math.Pow(volume, 0.25d); } // x^0.25 for exponential->linear
+			set { AL10.alSourcef(Source, AL10.AL_GAIN, value * value * value * value); } // x^4 for linear->exponential
 		}
 
 		public virtual float SeekPosition


### PR DESCRIPTION
Applies to #14696 

[rationale](https://www.dr-lex.be/info-stuff/volumecontrols.html)
x^4 is a close enough approximation of e^x for the slider setting range of [0.0, 1.0]:

https://www.dr-lex.be/info-stuff/infoimages/volume_curves.gif
![image](https://user-images.githubusercontent.com/1614714/34836754-f1f821c8-f709-11e7-9b71-8900f19da3e6.png)
![image](https://user-images.githubusercontent.com/1614714/34836746-ece8f18a-f709-11e7-8136-745709343a81.png)

Value stored in settings.yaml will now have different meanings between game versions - new version will be [much] more quiet. Due to this fact I would still prefer implementing separate **ExpSliderWidget** for sound control (the beta of it is https://github.com/netnazgul/OpenRA/commit/735927c65dd34f0bdc2c7be89cdc35077aeb6feb).