### PR TITLE
Update copyright notice year to 2018

### DIFF
--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Activities/CallFunc.cs
+++ b/OpenRA.Game/Activities/CallFunc.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/CPos.cs
+++ b/OpenRA.Game/CPos.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/CVec.cs
+++ b/OpenRA.Game/CVec.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/CacheStorage.cs
+++ b/OpenRA.Game/CacheStorage.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/CryptoUtil.cs
+++ b/OpenRA.Game/CryptoUtil.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Download.cs
+++ b/OpenRA.Game/Download.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Effects/AsyncAction.cs
+++ b/OpenRA.Game/Effects/AsyncAction.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Effects/DelayedAction.cs
+++ b/OpenRA.Game/Effects/DelayedAction.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Effects/DelayedImpact.cs
+++ b/OpenRA.Game/Effects/DelayedImpact.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Effects/IEffect.cs
+++ b/OpenRA.Game/Effects/IEffect.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/ExternalMods.cs
+++ b/OpenRA.Game/ExternalMods.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/FieldSaver.cs
+++ b/OpenRA.Game/FieldSaver.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/FileFormats/PngLoader.cs
+++ b/OpenRA.Game/FileFormats/PngLoader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/FileFormats/ReplayMetadata.cs
+++ b/OpenRA.Game/FileFormats/ReplayMetadata.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/FileSystem/FileSystem.cs
+++ b/OpenRA.Game/FileSystem/FileSystem.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/FileSystem/Folder.cs
+++ b/OpenRA.Game/FileSystem/Folder.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/FileSystem/IPackage.cs
+++ b/OpenRA.Game/FileSystem/IPackage.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/FileSystem/ZipFile.cs
+++ b/OpenRA.Game/FileSystem/ZipFile.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/GameInformation.cs
+++ b/OpenRA.Game/GameInformation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/GameRules/ActorInfo.cs
+++ b/OpenRA.Game/GameRules/ActorInfo.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/GameRules/MusicInfo.cs
+++ b/OpenRA.Game/GameRules/MusicInfo.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/GameRules/Ruleset.cs
+++ b/OpenRA.Game/GameRules/Ruleset.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/GameRules/SoundInfo.cs
+++ b/OpenRA.Game/GameRules/SoundInfo.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/GameSpeed.cs
+++ b/OpenRA.Game/GameSpeed.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/AnimationWithOffset.cs
+++ b/OpenRA.Game/Graphics/AnimationWithOffset.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/ChromeProvider.cs
+++ b/OpenRA.Game/Graphics/ChromeProvider.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/CursorProvider.cs
+++ b/OpenRA.Game/Graphics/CursorProvider.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/CursorSequence.cs
+++ b/OpenRA.Game/Graphics/CursorSequence.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/HSLColor.cs
+++ b/OpenRA.Game/Graphics/HSLColor.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/HardwareCursor.cs
+++ b/OpenRA.Game/Graphics/HardwareCursor.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/HardwarePalette.cs
+++ b/OpenRA.Game/Graphics/HardwarePalette.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/MappedImage.cs
+++ b/OpenRA.Game/Graphics/MappedImage.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/Model.cs
+++ b/OpenRA.Game/Graphics/Model.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/ModelAnimation.cs
+++ b/OpenRA.Game/Graphics/ModelAnimation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/ModelRenderer.cs
+++ b/OpenRA.Game/Graphics/ModelRenderer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/Palette.cs
+++ b/OpenRA.Game/Graphics/Palette.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/PaletteReference.cs
+++ b/OpenRA.Game/Graphics/PaletteReference.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/PlayerColorRemap.cs
+++ b/OpenRA.Game/Graphics/PlayerColorRemap.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/Renderable.cs
+++ b/OpenRA.Game/Graphics/Renderable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/RgbaColorRenderer.cs
+++ b/OpenRA.Game/Graphics/RgbaColorRenderer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/SequenceProvider.cs
+++ b/OpenRA.Game/Graphics/SequenceProvider.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/SoftwareCursor.cs
+++ b/OpenRA.Game/Graphics/SoftwareCursor.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/Sprite.cs
+++ b/OpenRA.Game/Graphics/Sprite.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/SpriteLoader.cs
+++ b/OpenRA.Game/Graphics/SpriteLoader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/SpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/TargetLineRenderable.cs
+++ b/OpenRA.Game/Graphics/TargetLineRenderable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/TerrainRenderer.cs
+++ b/OpenRA.Game/Graphics/TerrainRenderer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
+++ b/OpenRA.Game/Graphics/TerrainSpriteLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/Theater.cs
+++ b/OpenRA.Game/Graphics/Theater.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/UISpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/UISpriteRenderable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/Vertex.cs
+++ b/OpenRA.Game/Graphics/Vertex.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/HotkeyDefinition.cs
+++ b/OpenRA.Game/HotkeyDefinition.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/HotkeyManager.cs
+++ b/OpenRA.Game/HotkeyManager.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/IUtilityCommand.cs
+++ b/OpenRA.Game/IUtilityCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Input/Hotkey.cs
+++ b/OpenRA.Game/Input/Hotkey.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Input/HotkeyReference.cs
+++ b/OpenRA.Game/Input/HotkeyReference.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Input/IInputHandler.cs
+++ b/OpenRA.Game/Input/IInputHandler.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Input/InputHandler.cs
+++ b/OpenRA.Game/Input/InputHandler.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Input/Keycode.cs
+++ b/OpenRA.Game/Input/Keycode.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/InstalledMods.cs
+++ b/OpenRA.Game/InstalledMods.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/LogProxy.cs
+++ b/OpenRA.Game/LogProxy.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/MPos.cs
+++ b/OpenRA.Game/MPos.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Map/ActorInitializer.cs
+++ b/OpenRA.Game/Map/ActorInitializer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Map/ActorReference.cs
+++ b/OpenRA.Game/Map/ActorReference.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Map/CellLayer.cs
+++ b/OpenRA.Game/Map/CellLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Map/CellRegion.cs
+++ b/OpenRA.Game/Map/CellRegion.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Map/MapCoordsRegion.cs
+++ b/OpenRA.Game/Map/MapCoordsRegion.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Map/MapGrid.cs
+++ b/OpenRA.Game/Map/MapGrid.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Map/MapPlayers.cs
+++ b/OpenRA.Game/Map/MapPlayers.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Map/PlayerReference.cs
+++ b/OpenRA.Game/Map/PlayerReference.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Map/ProjectedCellRegion.cs
+++ b/OpenRA.Game/Map/ProjectedCellRegion.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Map/TileReference.cs
+++ b/OpenRA.Game/Map/TileReference.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/MiniYaml.cs
+++ b/OpenRA.Game/MiniYaml.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Network/Connection.cs
+++ b/OpenRA.Game/Network/Connection.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Network/FrameData.cs
+++ b/OpenRA.Game/Network/FrameData.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Network/GameServer.cs
+++ b/OpenRA.Game/Network/GameServer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Network/GeoIP.cs
+++ b/OpenRA.Game/Network/GeoIP.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Network/Handshake.cs
+++ b/OpenRA.Game/Network/Handshake.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Network/OrderIO.cs
+++ b/OpenRA.Game/Network/OrderIO.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Network/ReplayRecorder.cs
+++ b/OpenRA.Game/Network/ReplayRecorder.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Network/SyncReport.cs
+++ b/OpenRA.Game/Network/SyncReport.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Network/UPnP.cs
+++ b/OpenRA.Game/Network/UPnP.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Orders/GenericSelectTarget.cs
+++ b/OpenRA.Game/Orders/GenericSelectTarget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Orders/IOrderGenerator.cs
+++ b/OpenRA.Game/Orders/IOrderGenerator.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/ActionQueue.cs
+++ b/OpenRA.Game/Primitives/ActionQueue.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/Bits.cs
+++ b/OpenRA.Game/Primitives/Bits.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/Cache.cs
+++ b/OpenRA.Game/Primitives/Cache.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/ConcurrentCache.cs
+++ b/OpenRA.Game/Primitives/ConcurrentCache.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/DisposableAction.cs
+++ b/OpenRA.Game/Primitives/DisposableAction.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/IObservableCollection.cs
+++ b/OpenRA.Game/Primitives/IObservableCollection.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/MergedStream.cs
+++ b/OpenRA.Game/Primitives/MergedStream.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/ObservableCollection.cs
+++ b/OpenRA.Game/Primitives/ObservableCollection.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/ObservableDictionary.cs
+++ b/OpenRA.Game/Primitives/ObservableDictionary.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/ObservableList.cs
+++ b/OpenRA.Game/Primitives/ObservableList.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/Pair.cs
+++ b/OpenRA.Game/Primitives/Pair.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/PriorityQueue.cs
+++ b/OpenRA.Game/Primitives/PriorityQueue.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/ReadOnlyAdapterStream.cs
+++ b/OpenRA.Game/Primitives/ReadOnlyAdapterStream.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/ReadOnlyDictionary.cs
+++ b/OpenRA.Game/Primitives/ReadOnlyDictionary.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/ReadOnlyList.cs
+++ b/OpenRA.Game/Primitives/ReadOnlyList.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/SegmentStream.cs
+++ b/OpenRA.Game/Primitives/SegmentStream.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/SpatiallyPartitioned.cs
+++ b/OpenRA.Game/Primitives/SpatiallyPartitioned.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/TypeDictionary.cs
+++ b/OpenRA.Game/Primitives/TypeDictionary.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/ZipFileHelper.cs
+++ b/OpenRA.Game/Primitives/ZipFileHelper.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/float2.cs
+++ b/OpenRA.Game/Primitives/float2.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/float3.cs
+++ b/OpenRA.Game/Primitives/float3.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Primitives/int2.cs
+++ b/OpenRA.Game/Primitives/int2.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Scripting/ScriptActorInterface.cs
+++ b/OpenRA.Game/Scripting/ScriptActorInterface.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Scripting/ScriptContext.cs
+++ b/OpenRA.Game/Scripting/ScriptContext.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Scripting/ScriptMemberExts.cs
+++ b/OpenRA.Game/Scripting/ScriptMemberExts.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Scripting/ScriptMemberWrapper.cs
+++ b/OpenRA.Game/Scripting/ScriptMemberWrapper.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Scripting/ScriptObjectWrapper.cs
+++ b/OpenRA.Game/Scripting/ScriptObjectWrapper.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Scripting/ScriptPlayerInterface.cs
+++ b/OpenRA.Game/Scripting/ScriptPlayerInterface.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Scripting/ScriptTypes.cs
+++ b/OpenRA.Game/Scripting/ScriptTypes.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/SelectableExts.cs
+++ b/OpenRA.Game/SelectableExts.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Selection.cs
+++ b/OpenRA.Game/Selection.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Server/Connection.cs
+++ b/OpenRA.Game/Server/Connection.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Server/Exts.cs
+++ b/OpenRA.Game/Server/Exts.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Server/ProtocolVersion.cs
+++ b/OpenRA.Game/Server/ProtocolVersion.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Server/ServerOrder.cs
+++ b/OpenRA.Game/Server/ServerOrder.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Server/TraitInterfaces.cs
+++ b/OpenRA.Game/Server/TraitInterfaces.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Sound/SoundDevice.cs
+++ b/OpenRA.Game/Sound/SoundDevice.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/StreamExts.cs
+++ b/OpenRA.Game/StreamExts.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Support/Arguments.cs
+++ b/OpenRA.Game/Support/Arguments.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Support/Evaluator.cs
+++ b/OpenRA.Game/Support/Evaluator.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Support/LaunchArguments.cs
+++ b/OpenRA.Game/Support/LaunchArguments.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Support/Log.cs
+++ b/OpenRA.Game/Support/Log.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Support/MersenneTwister.cs
+++ b/OpenRA.Game/Support/MersenneTwister.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Support/PerfHistory.cs
+++ b/OpenRA.Game/Support/PerfHistory.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Support/PerfItem.cs
+++ b/OpenRA.Game/Support/PerfItem.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Support/PerfSample.cs
+++ b/OpenRA.Game/Support/PerfSample.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Support/PerfTimer.cs
+++ b/OpenRA.Game/Support/PerfTimer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Support/Program.cs
+++ b/OpenRA.Game/Support/Program.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Support/VariableExpression.cs
+++ b/OpenRA.Game/Support/VariableExpression.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Sync.cs
+++ b/OpenRA.Game/Sync.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/TraitDictionary.cs
+++ b/OpenRA.Game/TraitDictionary.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Traits/ActivityUtils.cs
+++ b/OpenRA.Game/Traits/ActivityUtils.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Traits/DebugPauseState.cs
+++ b/OpenRA.Game/Traits/DebugPauseState.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Traits/Interactable.cs
+++ b/OpenRA.Game/Traits/Interactable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Traits/LintAttributes.cs
+++ b/OpenRA.Game/Traits/LintAttributes.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Traits/Player/FixedColorPalette.cs
+++ b/OpenRA.Game/Traits/Player/FixedColorPalette.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Traits/Player/IndexedPlayerPalette.cs
+++ b/OpenRA.Game/Traits/Player/IndexedPlayerPalette.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Traits/Player/PlayerColorPalette.cs
+++ b/OpenRA.Game/Traits/Player/PlayerColorPalette.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Traits/Player/PlayerHighlightPalette.cs
+++ b/OpenRA.Game/Traits/Player/PlayerHighlightPalette.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Game/Traits/Player/PlayerResources.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Traits/Player/Shroud.cs
+++ b/OpenRA.Game/Traits/Player/Shroud.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Traits/Selectable.cs
+++ b/OpenRA.Game/Traits/Selectable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Traits/World/DebugVisualizations.cs
+++ b/OpenRA.Game/Traits/World/DebugVisualizations.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Traits/World/Faction.cs
+++ b/OpenRA.Game/Traits/World/Faction.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Traits/World/ResourceType.cs
+++ b/OpenRA.Game/Traits/World/ResourceType.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Traits/World/ScreenMap.cs
+++ b/OpenRA.Game/Traits/World/ScreenMap.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Traits/World/ScreenShaker.cs
+++ b/OpenRA.Game/Traits/World/ScreenShaker.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/UtilityCommands/ClearInvalidModRegistrationsCommand.cs
+++ b/OpenRA.Game/UtilityCommands/ClearInvalidModRegistrationsCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/UtilityCommands/RegisterModCommand.cs
+++ b/OpenRA.Game/UtilityCommands/RegisterModCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/UtilityCommands/UnregisterModCommand.cs
+++ b/OpenRA.Game/UtilityCommands/UnregisterModCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/VoiceExts.cs
+++ b/OpenRA.Game/VoiceExts.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/WAngle.cs
+++ b/OpenRA.Game/WAngle.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/WDist.cs
+++ b/OpenRA.Game/WDist.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/WPos.cs
+++ b/OpenRA.Game/WPos.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/WRot.cs
+++ b/OpenRA.Game/WRot.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/WVec.cs
+++ b/OpenRA.Game/WVec.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Widgets/ChromeMetrics.cs
+++ b/OpenRA.Game/Widgets/ChromeMetrics.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Widgets/Widget.cs
+++ b/OpenRA.Game/Widgets/Widget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Widgets/WidgetLoader.cs
+++ b/OpenRA.Game/Widgets/WidgetLoader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/Widgets/WidgetUtils.cs
+++ b/OpenRA.Game/Widgets/WidgetUtils.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Game/WorldUtils.cs
+++ b/OpenRA.Game/WorldUtils.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Activities/Infiltrate.cs
+++ b/OpenRA.Mods.Cnc/Activities/Infiltrate.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Activities/LayMines.cs
+++ b/OpenRA.Mods.Cnc/Activities/LayMines.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Activities/Leap.cs
+++ b/OpenRA.Mods.Cnc/Activities/Leap.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Activities/Teleport.cs
+++ b/OpenRA.Mods.Cnc/Activities/Teleport.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Activities/VoxelHarvesterDockSequence.cs
+++ b/OpenRA.Mods.Cnc/Activities/VoxelHarvesterDockSequence.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/CncLoadScreen.cs
+++ b/OpenRA.Mods.Cnc/CncLoadScreen.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Effects/AnimatedBeacon.cs
+++ b/OpenRA.Mods.Cnc/Effects/AnimatedBeacon.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Effects/GpsDotEffect.cs
+++ b/OpenRA.Mods.Cnc/Effects/GpsDotEffect.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Effects/GpsSatellite.cs
+++ b/OpenRA.Mods.Cnc/Effects/GpsSatellite.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Effects/SatelliteLaunch.cs
+++ b/OpenRA.Mods.Cnc/Effects/SatelliteLaunch.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/FileFormats/Blowfish.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/Blowfish.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/FileFormats/CRC32.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/CRC32.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/FileFormats/HvaReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/HvaReader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/FileFormats/IdxEntry.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/IdxEntry.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/FileFormats/IdxReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/IdxReader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/FileFormats/VxlReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/VxlReader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/FileFormats/XccGlobalDatabase.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/XccGlobalDatabase.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/FileFormats/XccLocalDatabase.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/XccLocalDatabase.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/FileSystem/BagFile.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/BagFile.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/FileSystem/BigFile.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/BigFile.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/FileSystem/MixFile.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/MixFile.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/FileSystem/PackageEntry.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/PackageEntry.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/FileSystem/Pak.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/Pak.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Graphics/TeslaZapRenderable.cs
+++ b/OpenRA.Mods.Cnc/Graphics/TeslaZapRenderable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Graphics/Voxel.cs
+++ b/OpenRA.Mods.Cnc/Graphics/Voxel.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Graphics/VoxelLoader.cs
+++ b/OpenRA.Mods.Cnc/Graphics/VoxelLoader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Graphics/VoxelModelSequenceLoader.cs
+++ b/OpenRA.Mods.Cnc/Graphics/VoxelModelSequenceLoader.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Player/PlaceSimpleBeacon.cs
+++ b/OpenRA.Mods.Cnc/Player/PlaceSimpleBeacon.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Projectiles/IonCannon.cs
+++ b/OpenRA.Mods.Cnc/Projectiles/IonCannon.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Projectiles/TeslaZap.cs
+++ b/OpenRA.Mods.Cnc/Projectiles/TeslaZap.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Scripting/Properties/ChronosphereProperties.cs
+++ b/OpenRA.Mods.Cnc/Scripting/Properties/ChronosphereProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Scripting/Properties/DisguiseProperties.cs
+++ b/OpenRA.Mods.Cnc/Scripting/Properties/DisguiseProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Scripting/Properties/InfiltrateProperties.cs
+++ b/OpenRA.Mods.Cnc/Scripting/Properties/InfiltrateProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/SpriteLoaders/TmpTSLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/TmpTSLoader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackLeap.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackLeap.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackPopupTurreted.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTDGunboatTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTDGunboatTurreted.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Buildings/ClonesProducedUnits.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ClonesProducedUnits.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Buildings/TiberianSunRefinery.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/TiberianSunRefinery.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
+++ b/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Cloneable.cs
+++ b/OpenRA.Mods.Cnc/Traits/Cloneable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/EnergyWall.cs
+++ b/OpenRA.Mods.Cnc/Traits/EnergyWall.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,

--- a/OpenRA.Mods.Cnc/Traits/FrozenUnderFogUpdatedByGps.cs
+++ b/OpenRA.Mods.Cnc/Traits/FrozenUnderFogUpdatedByGps.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/GpsDot.cs
+++ b/OpenRA.Mods.Cnc/Traits/GpsDot.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/GpsWatcher.cs
+++ b/OpenRA.Mods.Cnc/Traits/GpsWatcher.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/HarvesterHuskModifier.cs
+++ b/OpenRA.Mods.Cnc/Traits/HarvesterHuskModifier.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForCash.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForCash.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForDecoration.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForDecoration.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForExploration.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForExploration.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForPowerOutage.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForPowerOutage.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPower.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Mine.cs
+++ b/OpenRA.Mods.Cnc/Traits/Mine.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/PaletteEffects/ChronoshiftPaletteEffect.cs
+++ b/OpenRA.Mods.Cnc/Traits/PaletteEffects/ChronoshiftPaletteEffect.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/PaletteEffects/LightPaletteRotator.cs
+++ b/OpenRA.Mods.Cnc/Traits/PaletteEffects/LightPaletteRotator.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Render/RenderJammerCircle.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/RenderJammerCircle.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Render/RenderShroudCircle.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/RenderShroudCircle.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Render/WithDeliveryAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithDeliveryAnimation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Render/WithDisguisingInfantryBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithDisguisingInfantryBody.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Render/WithDockingOverlay.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithDockingOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Render/WithEmbeddedTurretSpriteBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithEmbeddedTurretSpriteBody.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Render/WithGunboatBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithGunboatBody.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Render/WithLandingCraftAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithLandingCraftAnimation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Render/WithPermanentInjury.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithPermanentInjury.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Render/WithReloadingSpriteTurret.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithReloadingSpriteTurret.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Render/WithRoof.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithRoof.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeAnimation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeOverlay.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Render/WithVoxelUnloadBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithVoxelUnloadBody.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/GpsPower.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/IonCannonPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/IonCannonPower.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/World/TSShroudPalette.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSShroudPalette.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Traits/World/VoxelNormalsPalette.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/VoxelNormalsPalette.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Cnc/TraitsInterfaces.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertLegacyMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertLegacyMapCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportTSMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportTSMapCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianDawnLegacyMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportTiberianDawnLegacyMapCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/UtilityCommands/LegacyRulesImporter.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/LegacyRulesImporter.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/UtilityCommands/LegacySequenceImporter.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/LegacySequenceImporter.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/UtilityCommands/LegacyTilesetImporter.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/LegacyTilesetImporter.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/UtilityCommands/ListMixContentsCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ListMixContentsCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Cnc/Widgets/Logic/PreReleaseWarningPrompt.cs
+++ b/OpenRA.Mods.Cnc/Widgets/Logic/PreReleaseWarningPrompt.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
+++ b/OpenRA.Mods.Common/AI/AttackOrFleeFuzzy.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/AI/BaseBuilder.cs
+++ b/OpenRA.Mods.Common/AI/BaseBuilder.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/AI/DummyAI.cs
+++ b/OpenRA.Mods.Common/AI/DummyAI.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/AI/Squad.cs
+++ b/OpenRA.Mods.Common/AI/Squad.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/AI/StateMachine.cs
+++ b/OpenRA.Mods.Common/AI/StateMachine.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/AI/States/AirStates.cs
+++ b/OpenRA.Mods.Common/AI/States/AirStates.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/AI/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/AI/States/GroundStates.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/AI/States/NavyStates.cs
+++ b/OpenRA.Mods.Common/AI/States/NavyStates.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/AI/States/ProtectionStates.cs
+++ b/OpenRA.Mods.Common/AI/States/ProtectionStates.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/AI/States/StateBase.cs
+++ b/OpenRA.Mods.Common/AI/States/StateBase.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/AI/SupportPowerDecision.cs
+++ b/OpenRA.Mods.Common/AI/SupportPowerDecision.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Air/AllowYieldingReservation.cs
+++ b/OpenRA.Mods.Common/Activities/Air/AllowYieldingReservation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Air/FlyCircle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyCircle.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Air/FlyOffMap.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyOffMap.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Air/FlyTimed.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyTimed.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Air/HeliFly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliFly.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Air/HeliFlyCircle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliFlyCircle.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Air/HeliLand.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliLand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Air/ResupplyAircraft.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ResupplyAircraft.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
+++ b/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/CaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/CaptureActor.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/DeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverResources.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Demolish.cs
+++ b/OpenRA.Mods.Common/Activities/Demolish.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/DeployForGrantedCondition.cs
+++ b/OpenRA.Mods.Common/Activities/DeployForGrantedCondition.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/DonateCash.cs
+++ b/OpenRA.Mods.Common/Activities/DonateCash.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/DonateExperience.cs
+++ b/OpenRA.Mods.Common/Activities/DonateExperience.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Enter.cs
+++ b/OpenRA.Mods.Common/Activities/Enter.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/EnterTransport.cs
+++ b/OpenRA.Mods.Common/Activities/EnterTransport.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/ExternalCaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/ExternalCaptureActor.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/FindResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindResources.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/HarvestResource.cs
+++ b/OpenRA.Mods.Common/Activities/HarvestResource.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Hunt.cs
+++ b/OpenRA.Mods.Common/Activities/Hunt.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
+++ b/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Move/Drag.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Drag.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Move/Follow.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Follow.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Parachute.cs
+++ b/OpenRA.Mods.Common/Activities/Parachute.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Rearm.cs
+++ b/OpenRA.Mods.Common/Activities/Rearm.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/RemoveSelf.cs
+++ b/OpenRA.Mods.Common/Activities/RemoveSelf.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Repair.cs
+++ b/OpenRA.Mods.Common/Activities/Repair.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/RepairBridge.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBridge.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/RepairBuilding.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBuilding.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Sell.cs
+++ b/OpenRA.Mods.Common/Activities/Sell.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/SimpleTeleport.cs
+++ b/OpenRA.Mods.Common/Activities/SimpleTeleport.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/SpriteHarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/SpriteHarvesterDockSequence.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Turn.cs
+++ b/OpenRA.Mods.Common/Activities/Turn.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/UndeployForGrantedCondition.cs
+++ b/OpenRA.Mods.Common/Activities/UndeployForGrantedCondition.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/Wait.cs
+++ b/OpenRA.Mods.Common/Activities/Wait.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Activities/WaitForTransport.cs
+++ b/OpenRA.Mods.Common/Activities/WaitForTransport.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/AudioLoaders/AudLoader.cs
+++ b/OpenRA.Mods.Common/AudioLoaders/AudLoader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/AudioLoaders/VocLoader.cs
+++ b/OpenRA.Mods.Common/AudioLoaders/VocLoader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/AudioLoaders/WavLoader.cs
+++ b/OpenRA.Mods.Common/AudioLoaders/WavLoader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/ColorValidator.cs
+++ b/OpenRA.Mods.Common/ColorValidator.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Commands/ChatCommands.cs
+++ b/OpenRA.Mods.Common/Commands/ChatCommands.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DebugVisualizationCommands.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Commands/HelpCommand.cs
+++ b/OpenRA.Mods.Common/Commands/HelpCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Commands/PlayerCommands.cs
+++ b/OpenRA.Mods.Common/Commands/PlayerCommands.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorCopyPasteBrush.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Effects/Beacon.cs
+++ b/OpenRA.Mods.Common/Effects/Beacon.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Effects/ContrailFader.cs
+++ b/OpenRA.Mods.Common/Effects/ContrailFader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Effects/CrateEffect.cs
+++ b/OpenRA.Mods.Common/Effects/CrateEffect.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Effects/FlashTarget.cs
+++ b/OpenRA.Mods.Common/Effects/FlashTarget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Effects/FloatingText.cs
+++ b/OpenRA.Mods.Common/Effects/FloatingText.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Effects/MapNotificationEffect.cs
+++ b/OpenRA.Mods.Common/Effects/MapNotificationEffect.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Effects/RepairIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RepairIndicator.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Effects/RevealShroudEffect.cs
+++ b/OpenRA.Mods.Common/Effects/RevealShroudEffect.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Effects/SpriteEffect.cs
+++ b/OpenRA.Mods.Common/Effects/SpriteEffect.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/FileFormats/AudReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/AudReader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/FileFormats/Blast.cs
+++ b/OpenRA.Mods.Common/FileFormats/Blast.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/FileFormats/ImaAdpcmReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/ImaAdpcmReader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/FileFormats/IniFile.cs
+++ b/OpenRA.Mods.Common/FileFormats/IniFile.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/FileFormats/InstallShieldCABCompression.cs
+++ b/OpenRA.Mods.Common/FileFormats/InstallShieldCABCompression.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/FileFormats/LCWCompression.cs
+++ b/OpenRA.Mods.Common/FileFormats/LCWCompression.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/FileFormats/MSCabCompression.cs
+++ b/OpenRA.Mods.Common/FileFormats/MSCabCompression.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/FileFormats/RLEZerosCompression.cs
+++ b/OpenRA.Mods.Common/FileFormats/RLEZerosCompression.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/FileFormats/VqaReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/VqaReader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/FileFormats/WavReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/WavReader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/FileFormats/XORDeltaCompression.cs
+++ b/OpenRA.Mods.Common/FileFormats/XORDeltaCompression.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/FileSystem/InstallShieldPackage.cs
+++ b/OpenRA.Mods.Common/FileSystem/InstallShieldPackage.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Graphics/ActorPreview.cs
+++ b/OpenRA.Mods.Common/Graphics/ActorPreview.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Graphics/BeamRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/BeamRenderable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Graphics/ContrailRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/ContrailRenderable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Graphics/DetectionCircleRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/DetectionCircleRenderable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Graphics/ModelActorPreview.cs
+++ b/OpenRA.Mods.Common/Graphics/ModelActorPreview.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Graphics/ModelRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/ModelRenderable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Graphics/RailgunRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/RailgunRenderable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Graphics/RangeCircleRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/RangeCircleRenderable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Graphics/SelectionBarsRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBarsRenderable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Graphics/SelectionBoxRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBoxRenderable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Graphics/SpriteActorPreview.cs
+++ b/OpenRA.Mods.Common/Graphics/SpriteActorPreview.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Graphics/TextRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/TextRenderable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/TilesetSpecificSpriteSequence.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/HitShapes/Capsule.cs
+++ b/OpenRA.Mods.Common/HitShapes/Capsule.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/HitShapes/Circle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Circle.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/HitShapes/IHitShape.cs
+++ b/OpenRA.Mods.Common/HitShapes/IHitShape.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/HitShapes/Rectangle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Rectangle.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckActors.cs
+++ b/OpenRA.Mods.Common/Lint/CheckActors.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckAngle.cs
+++ b/OpenRA.Mods.Common/Lint/CheckAngle.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckChromeHotkeys.cs
+++ b/OpenRA.Mods.Common/Lint/CheckChromeHotkeys.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckChromeLogic.cs
+++ b/OpenRA.Mods.Common/Lint/CheckChromeLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckConditions.cs
+++ b/OpenRA.Mods.Common/Lint/CheckConditions.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckConflictingMouseBounds.cs
+++ b/OpenRA.Mods.Common/Lint/CheckConflictingMouseBounds.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckDeathTypes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckDeathTypes.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
+++ b/OpenRA.Mods.Common/Lint/CheckDefaultVisibility.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckHitShapes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckHitShapes.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckMapCordon.cs
+++ b/OpenRA.Mods.Common/Lint/CheckMapCordon.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
+++ b/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckPalettes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPalettes.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckRangeLimit.cs
+++ b/OpenRA.Mods.Common/Lint/CheckRangeLimit.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
+++ b/OpenRA.Mods.Common/Lint/CheckRevealFootprint.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckSyncAnnotations.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSyncAnnotations.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckTooltips.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTooltips.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckTraitPrerequisites.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTraitPrerequisites.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
+++ b/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Lint/LintExts.cs
+++ b/OpenRA.Mods.Common/Lint/LintExts.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/LoadScreens/LogoStripeLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/LogoStripeLoadScreen.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/LoadScreens/ModContentLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/ModContentLoadScreen.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/ModContent.cs
+++ b/OpenRA.Mods.Common/ModContent.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Orders/AircraftMoveOrderTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/AircraftMoveOrderTargeter.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Orders/BeaconOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/BeaconOrderGenerator.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Orders/DeployOrderTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/DeployOrderTargeter.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Orders/EnterAlliedActorTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/EnterAlliedActorTargeter.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Orders/EnterTransportTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/EnterTransportTargeter.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Orders/EnterTransportsTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/EnterTransportsTargeter.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Orders/ForceModifiersOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/ForceModifiersOrderGenerator.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Orders/GuardOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/GuardOrderGenerator.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Orders/UnitOrderTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/UnitOrderTargeter.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Pathfinder/BasePathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/BasePathSearch.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Pathfinder/CellInfo.cs
+++ b/OpenRA.Mods.Common/Pathfinder/CellInfo.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Pathfinder/CellInfoLayerPool.cs
+++ b/OpenRA.Mods.Common/Pathfinder/CellInfoLayerPool.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Pathfinder/Constants.cs
+++ b/OpenRA.Mods.Common/Pathfinder/Constants.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Pathfinder/PathCacheStorage.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathCacheStorage.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Pathfinder/PathFinderUnitPathCacheDecorator.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathFinderUnitPathCacheDecorator.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/PlayerExtensions.cs
+++ b/OpenRA.Mods.Common/PlayerExtensions.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Projectiles/NukeLaunch.cs
+++ b/OpenRA.Mods.Common/Projectiles/NukeLaunch.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Projectiles/Railgun.cs
+++ b/OpenRA.Mods.Common/Projectiles/Railgun.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/CallLuaFunc.cs
+++ b/OpenRA.Mods.Common/Scripting/CallLuaFunc.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Global/ActorGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ActorGlobal.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Global/BeaconGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/BeaconGlobal.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Global/CameraGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/CameraGlobal.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Global/CoordinateGlobals.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/CoordinateGlobals.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Global/DateTimeGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/DateTimeGlobal.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Global/FacingGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/FacingGlobal.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Global/HSLColorGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/HSLColorGlobal.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Global/LightingGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/LightingGlobal.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Global/PlayerGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/PlayerGlobal.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Global/TriggerGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/TriggerGlobal.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Global/UserInterfaceGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/UserInterfaceGlobal.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Global/UtilsGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/UtilsGlobal.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/LuaScript.cs
+++ b/OpenRA.Mods.Common/Scripting/LuaScript.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Media.cs
+++ b/OpenRA.Mods.Common/Scripting/Media.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/AircraftProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/AircraftProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/AirstrikeProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/AirstrikeProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/AmmoPoolProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/AmmoPoolProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/CaptureProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CaptureProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/ConditionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ConditionProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/DemolitionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/DemolitionProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/DiplomacyProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/DiplomacyProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/GuardProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GuardProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/HarvesterProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/HarvesterProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/HealthProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/HealthProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/MissionObjectiveProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/MissionObjectiveProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/ParadropProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ParadropProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/ParatroopersProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ParatroopersProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/PlayerExperienceProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/PlayerExperienceProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/PlayerProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/PlayerProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/PlayerStatsProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/PlayerStatsProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/PowerProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/PowerProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/RepairableBuildingProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/RepairableBuildingProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/ResourceProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ResourceProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/SellableProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/SellableProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/TransformProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/TransformProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/Properties/TransportProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/TransportProperties.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
+++ b/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbySettingsNotification.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/ShroudExts.cs
+++ b/OpenRA.Mods.Common/ShroudExts.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/SpriteLoaders/ShpD2Loader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/ShpD2Loader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/SpriteLoaders/ShpTDLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/ShpTDLoader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/SpriteLoaders/ShpTSLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/ShpTSLoader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/SpriteLoaders/TmpRALoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/TmpRALoader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/SpriteLoaders/TmpTDLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/TmpTDLoader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/AcceptsDeliveredCash.cs
+++ b/OpenRA.Mods.Common/Traits/AcceptsDeliveredCash.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/AcceptsDeliveredExperience.cs
+++ b/OpenRA.Mods.Common/Traits/AcceptsDeliveredExperience.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/AffectsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/AffectsShroud.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Air/AttackHeli.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackHeli.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Air/AttackPlane.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackPlane.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Air/FallsToEarth.cs
+++ b/OpenRA.Mods.Common/Traits/Air/FallsToEarth.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Air/FlyAwayOnIdle.cs
+++ b/OpenRA.Mods.Common/Traits/Air/FlyAwayOnIdle.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Air/ReturnOnIdle.cs
+++ b/OpenRA.Mods.Common/Traits/Air/ReturnOnIdle.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/AmmoPool.cs
+++ b/OpenRA.Mods.Common/Traits/AmmoPool.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Armor.cs
+++ b/OpenRA.Mods.Common/Traits/Armor.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Attack/AttackCharges.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackCharges.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Attack/AttackSuicides.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackSuicides.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/AttackWander.cs
+++ b/OpenRA.Mods.Common/Traits/AttackWander.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/AutoCarryable.cs
+++ b/OpenRA.Mods.Common/Traits/AutoCarryable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/AutoCarryall.cs
+++ b/OpenRA.Mods.Common/Traits/AutoCarryall.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/AutoTargetPriority.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTargetPriority.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/BlocksProjectiles.cs
+++ b/OpenRA.Mods.Common/Traits/BlocksProjectiles.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/BodyOrientation.cs
+++ b/OpenRA.Mods.Common/Traits/BodyOrientation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/BaseBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BaseBuilding.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/BridgeHut.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BridgeHut.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/BridgePlaceholder.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BridgePlaceholder.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/FreeActorWithDelivery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FreeActorWithDelivery.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/Gate.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Gate.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/GivesBuildableArea.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/GivesBuildableArea.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/LegacyBridgeHut.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/LegacyBridgeHut.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/LineBuild.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/LineBuild.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/LineBuildNode.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/LineBuildNode.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/RepairsUnits.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairsUnits.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/RequiresBuildableArea.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RequiresBuildableArea.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Burns.cs
+++ b/OpenRA.Mods.Common/Traits/Burns.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Capturable.cs
+++ b/OpenRA.Mods.Common/Traits/Capturable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Captures.cs
+++ b/OpenRA.Mods.Common/Traits/Captures.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Carryable.cs
+++ b/OpenRA.Mods.Common/Traits/Carryable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/CashTrickler.cs
+++ b/OpenRA.Mods.Common/Traits/CashTrickler.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/ChangesTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/ChangesTerrain.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2016 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/CommandBarBlacklist.cs
+++ b/OpenRA.Mods.Common/Traits/CommandBarBlacklist.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Conditions/ConditionManager.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ConditionManager.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Conditions/ConditionalTrait.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ConditionalTrait.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Conditions/ExternalCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ExternalCondition.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantCondition.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnAttack.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnAttack.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDamageState.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDamageState.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLineBuildDirection.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLineBuildDirection.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnMovement.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnMovement.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPowerState.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPowerState.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPrerequisite.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnTerrain.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Conditions/LineBuildSegmentExternalCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/LineBuildSegmentExternalCondition.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Conditions/PausableConditionalTrait.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/PausableConditionalTrait.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Conditions/ProximityExternalCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ProximityExternalCondition.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Conditions/ToggleConditionOnOrder.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ToggleConditionOnOrder.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Contrail.cs
+++ b/OpenRA.Mods.Common/Traits/Contrail.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Crates/DuplicateUnitCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/DuplicateUnitCrateAction.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Crates/ExplodeCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/ExplodeCrateAction.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Crates/GiveCashCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GiveCashCrateAction.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Crates/GiveMcvCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GiveMcvCrateAction.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Crates/GrantExternalConditionCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GrantExternalConditionCrateAction.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Crates/HealUnitsCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/HealUnitsCrateAction.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Crates/HideMapCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/HideMapCrateAction.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Crates/LevelUpCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/LevelUpCrateAction.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Crates/RevealMapCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/RevealMapCrateAction.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Crates/SupportPowerCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/SupportPowerCrateAction.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/CreatesShroud.cs
+++ b/OpenRA.Mods.Common/Traits/CreatesShroud.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Crushable.cs
+++ b/OpenRA.Mods.Common/Traits/Crushable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/CustomSellValue.cs
+++ b/OpenRA.Mods.Common/Traits/CustomSellValue.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/DeliversCash.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversCash.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/DeliversExperience.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversExperience.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Demolishable.cs
+++ b/OpenRA.Mods.Common/Traits/Demolishable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Demolition.cs
+++ b/OpenRA.Mods.Common/Traits/Demolition.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/DetectCloaked.cs
+++ b/OpenRA.Mods.Common/Traits/DetectCloaked.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/EditorTilesetFilter.cs
+++ b/OpenRA.Mods.Common/Traits/EditorTilesetFilter.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/EjectOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/EjectOnDeath.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/EmitInfantryOnSell.cs
+++ b/OpenRA.Mods.Common/Traits/EmitInfantryOnSell.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/EntersTunnels.cs
+++ b/OpenRA.Mods.Common/Traits/EntersTunnels.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/ExitsDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/ExitsDebugOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Explodes.cs
+++ b/OpenRA.Mods.Common/Traits/Explodes.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/ExplosionOnDamageTransition.cs
+++ b/OpenRA.Mods.Common/Traits/ExplosionOnDamageTransition.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/ExternalCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCapturable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/ExternalCapturableBar.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCapturableBar.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/ExternalCaptures.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCaptures.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/GivesBounty.cs
+++ b/OpenRA.Mods.Common/Traits/GivesBounty.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/GivesCashOnCapture.cs
+++ b/OpenRA.Mods.Common/Traits/GivesCashOnCapture.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/GivesExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GivesExperience.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Guard.cs
+++ b/OpenRA.Mods.Common/Traits/Guard.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Guardable.cs
+++ b/OpenRA.Mods.Common/Traits/Guardable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/HitShape.cs
+++ b/OpenRA.Mods.Common/Traits/HitShape.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Huntable.cs
+++ b/OpenRA.Mods.Common/Traits/Huntable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/IgnoresCloak.cs
+++ b/OpenRA.Mods.Common/Traits/IgnoresCloak.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/IgnoresDisguise.cs
+++ b/OpenRA.Mods.Common/Traits/IgnoresDisguise.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Immobile.cs
+++ b/OpenRA.Mods.Common/Traits/Immobile.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
@@ -1,6 +1,6 @@
  #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/JamsMissiles.cs
+++ b/OpenRA.Mods.Common/Traits/JamsMissiles.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/KillsSelf.cs
+++ b/OpenRA.Mods.Common/Traits/KillsSelf.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Modifiers/AlwaysVisible.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/AlwaysVisible.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderFog.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderShroud.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderShroud.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Modifiers/WithColoredOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/WithColoredOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Multipliers/DamageMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/DamageMultiplier.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Multipliers/FirepowerMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/FirepowerMultiplier.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Multipliers/GainsExperienceMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/GainsExperienceMultiplier.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Multipliers/GivesExperienceMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/GivesExperienceMultiplier.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Multipliers/InaccuracyMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/InaccuracyMultiplier.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Multipliers/PowerMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/PowerMultiplier.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Multipliers/RangeMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/RangeMultiplier.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Multipliers/ReloadDelayMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/ReloadDelayMultiplier.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Multipliers/SpeedMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/SpeedMultiplier.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/MustBeDestroyed.cs
+++ b/OpenRA.Mods.Common/Traits/MustBeDestroyed.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/CloakPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/CloakPaletteEffect.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/FlashPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/FlashPaletteEffect.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/GlobalLightingPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/GlobalLightingPaletteEffect.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/MenuPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/MenuPaletteEffect.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/RotationPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/RotationPaletteEffect.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/ParaDrop.cs
+++ b/OpenRA.Mods.Common/Traits/ParaDrop.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Player/AllyRepair.cs
+++ b/OpenRA.Mods.Common/Traits/Player/AllyRepair.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Player/BaseAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/BaseAttackNotifier.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
+++ b/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Player/GrantConditionOnPrerequisiteManager.cs
+++ b/OpenRA.Mods.Common/Traits/Player/GrantConditionOnPrerequisiteManager.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Player/MissionObjectives.cs
+++ b/OpenRA.Mods.Common/Traits/Player/MissionObjectives.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Player/PlayerExperience.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerExperience.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Player/ResourceStorageWarning.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ResourceStorageWarning.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Player/TechTree.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TechTree.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Plug.cs
+++ b/OpenRA.Mods.Common/Traits/Plug.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Pluggable.cs
+++ b/OpenRA.Mods.Common/Traits/Pluggable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Power/AffectedByPowerOutage.cs
+++ b/OpenRA.Mods.Common/Traits/Power/AffectedByPowerOutage.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Power/Power.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Power.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Power/ScalePowerWithHealth.cs
+++ b/OpenRA.Mods.Common/Traits/Power/ScalePowerWithHealth.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/PowerTooltip.cs
+++ b/OpenRA.Mods.Common/Traits/PowerTooltip.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/ProducibleWithLevel.cs
+++ b/OpenRA.Mods.Common/Traits/ProducibleWithLevel.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/ProductionQueueFromSelection.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionQueueFromSelection.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/ProximityCaptor.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCaptor.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/QuantizeFacingsFromSequence.cs
+++ b/OpenRA.Mods.Common/Traits/QuantizeFacingsFromSequence.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Radar/AppearsOnRadar.cs
+++ b/OpenRA.Mods.Common/Traits/Radar/AppearsOnRadar.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Radar/ProvidesRadar.cs
+++ b/OpenRA.Mods.Common/Traits/Radar/ProvidesRadar.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Radar/RadarColorFromTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/Radar/RadarColorFromTerrain.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/RejectsOrders.cs
+++ b/OpenRA.Mods.Common/Traits/RejectsOrders.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/ReloadAmmoPool.cs
+++ b/OpenRA.Mods.Common/Traits/ReloadAmmoPool.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,

--- a/OpenRA.Mods.Common/Traits/Render/CashTricklerBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/CashTricklerBar.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/Hovers.cs
+++ b/OpenRA.Mods.Common/Traits/Render/Hovers.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
+++ b/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/ProductionBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/ProductionBar.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/ReloadArmamentsBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/ReloadArmamentsBar.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/RenderDetectionCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDetectionCircle.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/RenderNameTag.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderNameTag.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/RenderSpritesEditorOnly.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSpritesEditorOnly.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/RenderUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderUtils.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/SupportPowerChargeBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SupportPowerChargeBar.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/TimedConditionBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/TimedConditionBar.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/VeteranProductionIconOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/VeteranProductionIconOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithAcceptDeliveredCashAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAcceptDeliveredCashAnimation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithAttackAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAttackAnimation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithAttackOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAttackOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithBridgeSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBridgeSpriteBody.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithChargeAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithChargeAnimation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithChargeOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithChargeOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithDeadBridgeSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeadBridgeSpriteBody.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithDockingAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDockingAnimation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithFacingSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithFacingSpriteBody.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithGateSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithGateSpriteBody.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleAnimation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithMoveAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMoveAnimation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithNukeLaunchAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithNukeLaunchAnimation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithNukeLaunchOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithNukeLaunchOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithRearmAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRearmAnimation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairAnimation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithResources.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResources.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithShadow.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithShadow.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithSiloAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSiloAnimation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithTurretAttackAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurretAttackAnimation.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/RepairsBridges.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsBridges.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/RevealOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/RevealOnDeath.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/RevealOnFire.cs
+++ b/OpenRA.Mods.Common/Traits/RevealOnFire.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/RevealsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/RevealsShroud.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/ScriptTags.cs
+++ b/OpenRA.Mods.Common/Traits/ScriptTags.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/SeedsResource.cs
+++ b/OpenRA.Mods.Common/Traits/SeedsResource.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/SelfHealing.cs
+++ b/OpenRA.Mods.Common/Traits/SelfHealing.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Sellable.cs
+++ b/OpenRA.Mods.Common/Traits/Sellable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/ShakeOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/ShakeOnDeath.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
+++ b/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Sound/ActorLostNotification.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/ActorLostNotification.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AmbientSound.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Sound/AnnounceOnBuild.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AnnounceOnBuild.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Sound/AnnounceOnKill.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AnnounceOnKill.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Sound/AnnounceOnSeen.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AnnounceOnSeen.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Sound/AttackSounds.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AttackSounds.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Sound/CaptureNotification.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/CaptureNotification.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Sound/DeathSounds.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/DeathSounds.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Sound/SoundOnDamageTransition.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/SoundOnDamageTransition.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/StoresResources.cs
+++ b/OpenRA.Mods.Common/Traits/StoresResources.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/SupportPowers/ParatroopersPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/ParatroopersPower.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SpawnActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SpawnActorPower.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Targetable.cs
+++ b/OpenRA.Mods.Common/Traits/Targetable.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/ThrowsShrapnel.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsShrapnel.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Tooltip.cs
+++ b/OpenRA.Mods.Common/Traits/Tooltip.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/TransformOnCapture.cs
+++ b/OpenRA.Mods.Common/Traits/TransformOnCapture.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/TunnelEntrance.cs
+++ b/OpenRA.Mods.Common/Traits/TunnelEntrance.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Valued.cs
+++ b/OpenRA.Mods.Common/Traits/Valued.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Voiced.cs
+++ b/OpenRA.Mods.Common/Traits/Voiced.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/Wanders.cs
+++ b/OpenRA.Mods.Common/Traits/Wanders.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/CliffBackImpassabilityLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/CliffBackImpassabilityLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/CreateMPPlayers.cs
+++ b/OpenRA.Mods.Common/Traits/World/CreateMPPlayers.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
+++ b/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/ElevatedBridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ElevatedBridgeLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/ElevatedBridgePlaceholder.cs
+++ b/OpenRA.Mods.Common/Traits/World/ElevatedBridgePlaceholder.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/ExitsDebugOverlayManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/ExitsDebugOverlayManager.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/JumpjetActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/JumpjetActorLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/LegacyBridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/LegacyBridgeLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/LoadWidgetAtGameStart.cs
+++ b/OpenRA.Mods.Common/Traits/World/LoadWidgetAtGameStart.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/LobbyPrerequisiteCheckbox.cs
+++ b/OpenRA.Mods.Common/Traits/World/LobbyPrerequisiteCheckbox.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/MPStartLocations.cs
+++ b/OpenRA.Mods.Common/Traits/World/MPStartLocations.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/MPStartUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/MPStartUnits.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/MapBuildRadius.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapBuildRadius.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/MapOptions.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapOptions.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/MissionData.cs
+++ b/OpenRA.Mods.Common/Traits/World/MissionData.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
+++ b/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromCurrentTileset.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromCurrentTileset.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromFile.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromFile.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromPaletteWithAlpha.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromPaletteWithAlpha.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromPlayerPaletteWithAlpha.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromPlayerPaletteWithAlpha.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromRGBA.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromRGBA.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/RadarPings.cs
+++ b/OpenRA.Mods.Common/Traits/World/RadarPings.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/ResourceClaimLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceClaimLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/ScriptLobbyDropdown.cs
+++ b/OpenRA.Mods.Common/Traits/World/ScriptLobbyDropdown.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/ShroudPalette.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudPalette.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
+++ b/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/SubterraneanActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SubterraneanActorLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/TerrainTunnel.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainTunnel.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/TerrainTunnelLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainTunnelLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs
+++ b/OpenRA.Mods.Common/Traits/World/ValidateOrder.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Traits/World/WeatherOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/WeatherOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/CheckExplicitInterfacesCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckExplicitInterfacesCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/CheckSequenceSprites.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckSequenceSprites.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/ConvertPngToShpCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ConvertPngToShpCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/CreateManPage.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CreateManPage.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			Console.WriteLine(".SH BUGS");
 			Console.WriteLine("Known issues are tracked at http://bugs.openra.net");
 			Console.WriteLine(".SH COPYRIGHT");
-			Console.WriteLine("Copyright 2007-2017 The OpenRA Developers (see AUTHORS)");
+			Console.WriteLine("Copyright 2007-2018 The OpenRA Developers (see AUTHORS)");
 			Console.WriteLine("This manual is part of OpenRA, which is free software. It is GNU GPL v3 licensed. See COPYING for details.");
 		}
 	}

--- a/OpenRA.Mods.Common/UtilityCommands/Extensions.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/Extensions.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractFilesCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractFilesCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractLanguageStringsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractLanguageStringsCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractMapRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractMapRules.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractSettingsDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractSettingsDocsCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractWeaponDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractWeaponDocsCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractZeroBraneStudioLuaAPI.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractZeroBraneStudioLuaAPI.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/FixClassicTilesets.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/FixClassicTilesets.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/GetMapHashCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/GetMapHashCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/Glob.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/Glob.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ImportLegacyMapCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/LintInterfaces.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/LintInterfaces.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/ListInstallShieldCabContentsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ListInstallShieldCabContentsCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/ListInstallShieldContentsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ListInstallShieldContentsCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/ListMSCabContentsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ListMSCabContentsCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/OutputResolvedRulesCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/OutputResolvedRulesCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/OutputResolvedSequencesCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/OutputResolvedSequencesCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/OutputResolvedWeaponsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/OutputResolvedWeaponsCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/RemapShpCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/RemapShpCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/ReplayMetadataCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ReplayMetadataCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/ResizeMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ResizeMapCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/Rgba2Hex.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/Rgba2Hex.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeMapCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UtilityCommands/Utilities.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/Utilities.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Warheads/CreateResourceWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateResourceWarhead.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Warheads/DestroyResourceWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DestroyResourceWarhead.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Warheads/GrantExternalConditionWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/GrantExternalConditionWarhead.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Warheads/LeaveSmudgeWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/LeaveSmudgeWarhead.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Warheads/TargetDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/TargetDamageWarhead.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Warheads/Warhead.cs
+++ b/OpenRA.Mods.Common/Warheads/Warhead.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/WebServices.cs
+++ b/OpenRA.Mods.Common/WebServices.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/BackgroundWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/BackgroundWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/ChatDisplayWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ChatDisplayWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/CheckboxWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/CheckboxWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/ClientTooltipRegionWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ClientTooltipRegionWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/ColorBlockWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ColorBlockWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ColorMixerWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/ColorPreviewManagerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ColorPreviewManagerWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/ConfirmationDialogs.cs
+++ b/OpenRA.Mods.Common/Widgets/ConfirmationDialogs.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/EditorViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/EditorViewportControllerWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/GridLayout.cs
+++ b/OpenRA.Mods.Common/Widgets/GridLayout.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/HotkeyEntryWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/HotkeyEntryWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/HueSliderWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/HueSliderWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/ImageWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ImageWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/LabelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LabelWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/LabelWithTooltipWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LabelWithTooltipWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/LineGraphWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LineGraphWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/ListLayout.cs
+++ b/OpenRA.Mods.Common/Widgets/ListLayout.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipWithDescHighlightLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipWithDescHighlightLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ColorPickerLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/CreditsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/CreditsLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/DirectConnectLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/DirectConnectLogic.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation. For more information,

--- a/OpenRA.Mods.Common/Widgets/Logic/DisconnectWatcherLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/DisconnectWatcherLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorTabsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorTabsLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/NewMapLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/AddFactionSuffixLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/AddFactionSuffixLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ClassicProductionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ClassicProductionLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ControlGroupLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ControlGroupLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/DebugMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/DebugMenuLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoBriefingLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoBriefingLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoObjectivesLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoObjectivesLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoStatsLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameTimerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameTimerLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/CycleBasesHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/CycleBasesHotkeyLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/CycleProductionActorsHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/CycleProductionActorsHotkeyLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/CycleStatusBarsHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/CycleStatusBarsHotkeyLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/JumpToLastEventHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/JumpToLastEventHotkeyLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/JumpToSelectedActorsHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/JumpToSelectedActorsHotkeyLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/PauseHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/PauseHotkeyLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/TogglePixelDoubleHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/TogglePixelDoubleHotkeyLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/TogglePlayerStanceColorHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/TogglePlayerStanceColorHotkeyLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerBarLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerCounterLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngamePowerCounterLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameRadarDisplayLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameRadarDisplayLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameSiloBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameSiloBarLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePerfLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePerfLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePlayerOrObserverUILogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadMapEditorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadMapEditorLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/MenuButtonsChromeLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/OrderButtonsChromeLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/OrderButtonsChromeLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTabsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTabsLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ReplayControlBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ReplayControlBarLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/StanceSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/StanceSelectorLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerBinLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerBinLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/WorldTooltipLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentDiscTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentDiscTooltipLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentPromptLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/ClientTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/ClientTooltipLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickClientLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickClientLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickSpectatorsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/KickSpectatorsLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyOptionsLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/MapPreviewLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/SpawnSelectorTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/SpawnSelectorTooltipLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/MusicHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MusicHotkeyLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/MuteHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MuteHotkeyLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/PerfDebugLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PerfDebugLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayUtils.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/ScreenshotHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ScreenshotHotkeyLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/SimpleTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SimpleTooltipLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/SingleHotkeyBaseLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SingleHotkeyBaseLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/Logic/TabCompletionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/TabCompletionLogic.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/LogicKeyListenerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LogicKeyListenerWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/LogicTickerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LogicTickerWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MapPreviewWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/MenuButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MenuButtonWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/PasswordFieldWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/PasswordFieldWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/PerfGraphWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/PerfGraphWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/ProductionTypeButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTypeButtonWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/ProgressBarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProgressBarWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/RGBASpriteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RGBASpriteWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/ResourceBarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ResourceBarWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/ScrollItemWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollItemWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/SliderWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SliderWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/SpriteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SpriteWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/StrategicProgressWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/StrategicProgressWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/TerrainTemplatePreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TerrainTemplatePreviewWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/TooltipContainerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TooltipContainerWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/VqaPlayerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/VqaPlayerWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/WorldExtensions.cs
+++ b/OpenRA.Mods.Common/WorldExtensions.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/Lint/CheckImportActors.cs
+++ b/OpenRA.Mods.D2k/Lint/CheckImportActors.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/PackageLoaders/D2kSoundResources.cs
+++ b/OpenRA.Mods.D2k/PackageLoaders/D2kSoundResources.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/SpriteLoaders/R8Loader.cs
+++ b/OpenRA.Mods.D2k/SpriteLoaders/R8Loader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
+++ b/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/Traits/AttractsWorms.cs
+++ b/OpenRA.Mods.D2k/Traits/AttractsWorms.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/Traits/Buildings/LaysTerrain.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/LaysTerrain.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/Traits/Player/HarvesterInsurance.cs
+++ b/OpenRA.Mods.D2k/Traits/Player/HarvesterInsurance.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/Traits/Render/WithCrumbleOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithCrumbleOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/Traits/Sandworm.cs
+++ b/OpenRA.Mods.D2k/Traits/Sandworm.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
+++ b/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/Traits/TemporaryOwnerManager.cs
+++ b/OpenRA.Mods.D2k/Traits/TemporaryOwnerManager.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/Traits/World/D2kEditorResourceLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/D2kEditorResourceLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/Traits/World/D2kResourceLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/D2kResourceLayer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/Traits/World/FogPaletteFromR8.cs
+++ b/OpenRA.Mods.D2k/Traits/World/FogPaletteFromR8.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/Traits/World/PaletteFromR8.cs
+++ b/OpenRA.Mods.D2k/Traits/World/PaletteFromR8.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/Traits/World/PaletteFromScaledPalette.cs
+++ b/OpenRA.Mods.D2k/Traits/World/PaletteFromScaledPalette.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/Traits/World/WormManager.cs
+++ b/OpenRA.Mods.D2k/Traits/World/WormManager.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/Traits/WormSpawner.cs
+++ b/OpenRA.Mods.D2k/Traits/WormSpawner.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/D2kMapImporter.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/UtilityCommands/ImportD2kMapCommand.cs
+++ b/OpenRA.Mods.D2k/UtilityCommands/ImportD2kMapCommand.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.D2k/Warheads/ChangeOwnerWarhead.cs
+++ b/OpenRA.Mods.D2k/Warheads/ChangeOwnerWarhead.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Platforms.Default/DefaultPlatform.cs
+++ b/OpenRA.Platforms.Default/DefaultPlatform.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Platforms.Default/FrameBuffer.cs
+++ b/OpenRA.Platforms.Default/FrameBuffer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Platforms.Default/MultiTapDetection.cs
+++ b/OpenRA.Platforms.Default/MultiTapDetection.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
+++ b/OpenRA.Platforms.Default/OpenAlSoundEngine.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Platforms.Default/Sdl2Input.cs
+++ b/OpenRA.Platforms.Default/Sdl2Input.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Platforms.Default/Shader.cs
+++ b/OpenRA.Platforms.Default/Shader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Platforms.Default/Texture.cs
+++ b/OpenRA.Platforms.Default/Texture.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Platforms.Default/ThreadAffine.cs
+++ b/OpenRA.Platforms.Default/ThreadAffine.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Platforms.Default/VertexBuffer.cs
+++ b/OpenRA.Platforms.Default/VertexBuffer.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Server/Program.cs
+++ b/OpenRA.Server/Program.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.StyleCheck/Program.cs
+++ b/OpenRA.StyleCheck/Program.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, and is made available under the terms of the MS-PL license.
  * For more information, see https://opensource.org/licenses/MS-PL
  */

--- a/OpenRA.Test/OpenRA.Game/ActionQueueTest.cs
+++ b/OpenRA.Test/OpenRA.Game/ActionQueueTest.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
+++ b/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Test/OpenRA.Game/CoordinateTest.cs
+++ b/OpenRA.Test/OpenRA.Game/CoordinateTest.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
+++ b/OpenRA.Test/OpenRA.Game/MiniYamlTest.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Test/OpenRA.Game/OrderTest.cs
+++ b/OpenRA.Test/OpenRA.Game/OrderTest.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Test/OpenRA.Game/PlatformTest.cs
+++ b/OpenRA.Test/OpenRA.Game/PlatformTest.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Test/OpenRA.Game/PriorityQueueTest.cs
+++ b/OpenRA.Test/OpenRA.Game/PriorityQueueTest.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Test/OpenRA.Game/SpatiallyPartitionedTest.cs
+++ b/OpenRA.Test/OpenRA.Game/SpatiallyPartitionedTest.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Test/OpenRA.Game/VariableExpressionTest.cs
+++ b/OpenRA.Test/OpenRA.Game/VariableExpressionTest.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Test/OpenRA.Mods.Common/ShapeTest.cs
+++ b/OpenRA.Test/OpenRA.Mods.Common/ShapeTest.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Utility/Program.cs
+++ b/OpenRA.Utility/Program.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Check our [Playing the Game](https://github.com/OpenRA/OpenRA/wiki/Playing-the-g
 * Fund development by creating [Bounties](https://www.bountysource.com/trackers/36085-openra) on specific tasks.
 
 ## License
-Copyright 2007-2017 The OpenRA Developers (see [AUTHORS](https://github.com/OpenRA/OpenRA/blob/bleed/AUTHORS))
+Copyright 2007-2018 The OpenRA Developers (see [AUTHORS](https://github.com/OpenRA/OpenRA/blob/bleed/AUTHORS))
 This file is part of OpenRA, which is free software. It is made 
 available to you under the terms of the GNU General Public License
 as published by the Free Software Foundation, either version 3 of

--- a/lua/scriptwrapper.lua
+++ b/lua/scriptwrapper.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/cnc64gdi01/cnc64gdi01.lua
+++ b/mods/cnc/maps/cnc64gdi01/cnc64gdi01.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/funpark01/scj01ea.lua
+++ b/mods/cnc/maps/funpark01/scj01ea.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/gdi01/gdi01.lua
+++ b/mods/cnc/maps/gdi01/gdi01.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/gdi02/gdi02.lua
+++ b/mods/cnc/maps/gdi02/gdi02.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/gdi03/gdi03.lua
+++ b/mods/cnc/maps/gdi03/gdi03.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/gdi04a/gdi04a.lua
+++ b/mods/cnc/maps/gdi04a/gdi04a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/gdi04b/gdi04b.lua
+++ b/mods/cnc/maps/gdi04b/gdi04b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/gdi04c/gdi04c.lua
+++ b/mods/cnc/maps/gdi04c/gdi04c.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/gdi05a/gdi05a.lua
+++ b/mods/cnc/maps/gdi05a/gdi05a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/gdi05b/gdi05b.lua
+++ b/mods/cnc/maps/gdi05b/gdi05b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/gdi06/gdi06.lua
+++ b/mods/cnc/maps/gdi06/gdi06.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/gdi07/gdi07.lua
+++ b/mods/cnc/maps/gdi07/gdi07.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod01/nod01.lua
+++ b/mods/cnc/maps/nod01/nod01.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod02a/nod02a.lua
+++ b/mods/cnc/maps/nod02a/nod02a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod02b/nod02b.lua
+++ b/mods/cnc/maps/nod02b/nod02b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod03a/nod03a.lua
+++ b/mods/cnc/maps/nod03a/nod03a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod03b/nod03b.lua
+++ b/mods/cnc/maps/nod03b/nod03b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod04a/nod04a.lua
+++ b/mods/cnc/maps/nod04a/nod04a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod04b/nod04b.lua
+++ b/mods/cnc/maps/nod04b/nod04b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod05/nod05.lua
+++ b/mods/cnc/maps/nod05/nod05.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod06a/nod06a.lua
+++ b/mods/cnc/maps/nod06a/nod06a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod06b/nod06b.lua
+++ b/mods/cnc/maps/nod06b/nod06b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod06c/nod06c.lua
+++ b/mods/cnc/maps/nod06c/nod06c.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod07a/nod07a-AI.lua
+++ b/mods/cnc/maps/nod07a/nod07a-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod07a/nod07a.lua
+++ b/mods/cnc/maps/nod07a/nod07a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod07b/nod07b-AI.lua
+++ b/mods/cnc/maps/nod07b/nod07b-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod07b/nod07b.lua
+++ b/mods/cnc/maps/nod07b/nod07b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod07c/nod07c.lua
+++ b/mods/cnc/maps/nod07c/nod07c.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod08a/nod08a-AI.lua
+++ b/mods/cnc/maps/nod08a/nod08a-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod08a/nod08a.lua
+++ b/mods/cnc/maps/nod08a/nod08a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod08b/nod08b-AI.lua
+++ b/mods/cnc/maps/nod08b/nod08b-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod08b/nod08b.lua
+++ b/mods/cnc/maps/nod08b/nod08b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod09/nod09-AI.lua
+++ b/mods/cnc/maps/nod09/nod09-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/cnc/maps/nod09/nod09.lua
+++ b/mods/cnc/maps/nod09/nod09.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/bits/scripts/campaign-global.lua
+++ b/mods/d2k/bits/scripts/campaign-global.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/atreides-01a/atreides01a.lua
+++ b/mods/d2k/maps/atreides-01a/atreides01a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/atreides-01b/atreides01b.lua
+++ b/mods/d2k/maps/atreides-01b/atreides01b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/atreides-02a/atreides02a-AI.lua
+++ b/mods/d2k/maps/atreides-02a/atreides02a-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/atreides-02a/atreides02a.lua
+++ b/mods/d2k/maps/atreides-02a/atreides02a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/atreides-02b/atreides02b-AI.lua
+++ b/mods/d2k/maps/atreides-02b/atreides02b-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/atreides-02b/atreides02b.lua
+++ b/mods/d2k/maps/atreides-02b/atreides02b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/atreides-03a/atreides03a-AI.lua
+++ b/mods/d2k/maps/atreides-03a/atreides03a-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/atreides-03a/atreides03a.lua
+++ b/mods/d2k/maps/atreides-03a/atreides03a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/atreides-03b/atreides03b-AI.lua
+++ b/mods/d2k/maps/atreides-03b/atreides03b-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/atreides-03b/atreides03b.lua
+++ b/mods/d2k/maps/atreides-03b/atreides03b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/atreides-04/atreides04-AI.lua
+++ b/mods/d2k/maps/atreides-04/atreides04-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/atreides-04/atreides04.lua
+++ b/mods/d2k/maps/atreides-04/atreides04.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/atreides-05/atreides05-AI.lua
+++ b/mods/d2k/maps/atreides-05/atreides05-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/atreides-05/atreides05.lua
+++ b/mods/d2k/maps/atreides-05/atreides05.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-01a/harkonnen01a.lua
+++ b/mods/d2k/maps/harkonnen-01a/harkonnen01a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-01b/harkonnen01b.lua
+++ b/mods/d2k/maps/harkonnen-01b/harkonnen01b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-02a/harkonnen02a-AI.lua
+++ b/mods/d2k/maps/harkonnen-02a/harkonnen02a-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-02a/harkonnen02a.lua
+++ b/mods/d2k/maps/harkonnen-02a/harkonnen02a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-02b/harkonnen02b-AI.lua
+++ b/mods/d2k/maps/harkonnen-02b/harkonnen02b-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-02b/harkonnen02b.lua
+++ b/mods/d2k/maps/harkonnen-02b/harkonnen02b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-03a/harkonnen03a-AI.lua
+++ b/mods/d2k/maps/harkonnen-03a/harkonnen03a-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-03a/harkonnen03a.lua
+++ b/mods/d2k/maps/harkonnen-03a/harkonnen03a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-03b/harkonnen03b-AI.lua
+++ b/mods/d2k/maps/harkonnen-03b/harkonnen03b-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-03b/harkonnen03b.lua
+++ b/mods/d2k/maps/harkonnen-03b/harkonnen03b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-04/harkonnen04-AI.lua
+++ b/mods/d2k/maps/harkonnen-04/harkonnen04-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-04/harkonnen04.lua
+++ b/mods/d2k/maps/harkonnen-04/harkonnen04.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-05/harkonnen05-AI.lua
+++ b/mods/d2k/maps/harkonnen-05/harkonnen05-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-05/harkonnen05.lua
+++ b/mods/d2k/maps/harkonnen-05/harkonnen05.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-06a/harkonnen06a-AI.lua
+++ b/mods/d2k/maps/harkonnen-06a/harkonnen06a-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-06a/harkonnen06a.lua
+++ b/mods/d2k/maps/harkonnen-06a/harkonnen06a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-06b/harkonnen06b-AI.lua
+++ b/mods/d2k/maps/harkonnen-06b/harkonnen06b-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-06b/harkonnen06b.lua
+++ b/mods/d2k/maps/harkonnen-06b/harkonnen06b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-07/harkonnen07-AI.lua
+++ b/mods/d2k/maps/harkonnen-07/harkonnen07-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-07/harkonnen07.lua
+++ b/mods/d2k/maps/harkonnen-07/harkonnen07.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-08/harkonnen08-AI.lua
+++ b/mods/d2k/maps/harkonnen-08/harkonnen08-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-08/harkonnen08.lua
+++ b/mods/d2k/maps/harkonnen-08/harkonnen08.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-09a/harkonnen09a-AI.lua
+++ b/mods/d2k/maps/harkonnen-09a/harkonnen09a-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-09a/harkonnen09a.lua
+++ b/mods/d2k/maps/harkonnen-09a/harkonnen09a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-09b/harkonnen09b-AI.lua
+++ b/mods/d2k/maps/harkonnen-09b/harkonnen09b-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/harkonnen-09b/harkonnen09b.lua
+++ b/mods/d2k/maps/harkonnen-09b/harkonnen09b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/ordos-01a/ordos01a.lua
+++ b/mods/d2k/maps/ordos-01a/ordos01a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/ordos-01b/ordos01b.lua
+++ b/mods/d2k/maps/ordos-01b/ordos01b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/ordos-02a/ordos02a-AI.lua
+++ b/mods/d2k/maps/ordos-02a/ordos02a-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/ordos-02a/ordos02a.lua
+++ b/mods/d2k/maps/ordos-02a/ordos02a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/ordos-02b/ordos02b-AI.lua
+++ b/mods/d2k/maps/ordos-02b/ordos02b-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/ordos-02b/ordos02b.lua
+++ b/mods/d2k/maps/ordos-02b/ordos02b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/ordos-03a/ordos03a-AI.lua
+++ b/mods/d2k/maps/ordos-03a/ordos03a-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/ordos-03a/ordos03a.lua
+++ b/mods/d2k/maps/ordos-03a/ordos03a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/ordos-03b/ordos03b-AI.lua
+++ b/mods/d2k/maps/ordos-03b/ordos03b-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/ordos-03b/ordos03b.lua
+++ b/mods/d2k/maps/ordos-03b/ordos03b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/ordos-04/ordos04-AI.lua
+++ b/mods/d2k/maps/ordos-04/ordos04-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/ordos-04/ordos04.lua
+++ b/mods/d2k/maps/ordos-04/ordos04.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/d2k/maps/shellmap/d2k-shellmap.lua
+++ b/mods/d2k/maps/shellmap/d2k-shellmap.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/allies-01/allies01.lua
+++ b/mods/ra/maps/allies-01/allies01.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/allies-02/allies02.lua
+++ b/mods/ra/maps/allies-02/allies02.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/allies-03a/allies03a.lua
+++ b/mods/ra/maps/allies-03a/allies03a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/allies-03b/allies03b.lua
+++ b/mods/ra/maps/allies-03b/allies03b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/allies-04/allies04-AI.lua
+++ b/mods/ra/maps/allies-04/allies04-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/allies-04/allies04.lua
+++ b/mods/ra/maps/allies-04/allies04.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/allies-05a/allies05a-AI.lua
+++ b/mods/ra/maps/allies-05a/allies05a-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/allies-05a/allies05a.lua
+++ b/mods/ra/maps/allies-05a/allies05a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/allies-06a/allies06a-AI.lua
+++ b/mods/ra/maps/allies-06a/allies06a-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/allies-06a/allies06a.lua
+++ b/mods/ra/maps/allies-06a/allies06a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/allies-06b/allies06b-AI.lua
+++ b/mods/ra/maps/allies-06b/allies06b-AI.lua
@@ -1,10 +1,10 @@
 --[[
-  Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
-  This file is part of OpenRA, which is free software. It is made
-  available to you under the terms of the GNU General Public License
-  as published by the Free Software Foundation, either version 3 of
-  the License, or (at your option) any later version. For more
-  information, see COPYING.
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+   This file is part of OpenRA, which is free software. It is made
+   available to you under the terms of the GNU General Public License
+   as published by the Free Software Foundation, either version 3 of
+   the License, or (at your option) any later version. For more
+   information, see COPYING.
 ]]
 
 WTransWays =

--- a/mods/ra/maps/allies-06b/allies06b.lua
+++ b/mods/ra/maps/allies-06b/allies06b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/desert-shellmap/desert-shellmap.lua
+++ b/mods/ra/maps/desert-shellmap/desert-shellmap.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/evacuation/evacuation.lua
+++ b/mods/ra/maps/evacuation/evacuation.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/exodus/exodus.lua
+++ b/mods/ra/maps/exodus/exodus.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/fort-lonestar/fort-lonestar-AI.lua
+++ b/mods/ra/maps/fort-lonestar/fort-lonestar-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/fort-lonestar/fort-lonestar.lua
+++ b/mods/ra/maps/fort-lonestar/fort-lonestar.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/infiltration/infiltration.lua
+++ b/mods/ra/maps/infiltration/infiltration.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/intervention/intervention.lua
+++ b/mods/ra/maps/intervention/intervention.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/monster-tank-madness/monster-tank-madness.lua
+++ b/mods/ra/maps/monster-tank-madness/monster-tank-madness.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/soviet-01/soviet01.lua
+++ b/mods/ra/maps/soviet-01/soviet01.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/soviet-02a/soviet02a.lua
+++ b/mods/ra/maps/soviet-02a/soviet02a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/soviet-02b/soviet02b.lua
+++ b/mods/ra/maps/soviet-02b/soviet02b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/soviet-03/soviet03.lua
+++ b/mods/ra/maps/soviet-03/soviet03.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/soviet-04a/soviet04a-AI.lua
+++ b/mods/ra/maps/soviet-04a/soviet04a-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/soviet-04a/soviet04a-reinforcements_teams.lua
+++ b/mods/ra/maps/soviet-04a/soviet04a-reinforcements_teams.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/soviet-04a/soviet04a.lua
+++ b/mods/ra/maps/soviet-04a/soviet04a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/soviet-04b/soviet04b-AI.lua
+++ b/mods/ra/maps/soviet-04b/soviet04b-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/soviet-04b/soviet04b-reinforcements_teams.lua
+++ b/mods/ra/maps/soviet-04b/soviet04b-reinforcements_teams.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/soviet-04b/soviet04b.lua
+++ b/mods/ra/maps/soviet-04b/soviet04b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/soviet-05/soviet05-AI.lua
+++ b/mods/ra/maps/soviet-05/soviet05-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/soviet-05/soviet05-reinforcements_teams.lua
+++ b/mods/ra/maps/soviet-05/soviet05-reinforcements_teams.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/soviet-05/soviet05.lua
+++ b/mods/ra/maps/soviet-05/soviet05.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/soviet-06a/soviet06a-AI.lua
+++ b/mods/ra/maps/soviet-06a/soviet06a-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/soviet-06a/soviet06a-reinforcements_teams.lua
+++ b/mods/ra/maps/soviet-06a/soviet06a-reinforcements_teams.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/soviet-06a/soviet06a.lua
+++ b/mods/ra/maps/soviet-06a/soviet06a.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/soviet-06b/soviet06b-AI.lua
+++ b/mods/ra/maps/soviet-06b/soviet06b-AI.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/soviet-06b/soviet06b-reinforcements_teams.lua
+++ b/mods/ra/maps/soviet-06b/soviet06b-reinforcements_teams.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/soviet-06b/soviet06b.lua
+++ b/mods/ra/maps/soviet-06b/soviet06b.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/soviet-07/soviet07.lua
+++ b/mods/ra/maps/soviet-07/soviet07.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/survival01/survival01.lua
+++ b/mods/ra/maps/survival01/survival01.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ra/maps/survival02/survival02.lua
+++ b/mods/ra/maps/survival02/survival02.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ts/maps/fields-of-green/fields-of-green.lua
+++ b/mods/ts/maps/fields-of-green/fields-of-green.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/mods/ts/maps/sunstroke/sunstroke.lua
+++ b/mods/ts/maps/sunstroke/sunstroke.lua
@@ -1,5 +1,5 @@
 --[[
-   Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
    This file is part of OpenRA, which is free software. It is made
    available to you under the terms of the GNU General Public License
    as published by the Free Software Foundation, either version 3 of

--- a/packaging/fixheader.cs
+++ b/packaging/fixheader.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2011 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/packaging/linux/deb/copyright
+++ b/packaging/linux/deb/copyright
@@ -3,11 +3,11 @@ Upstream-Name: openra
 Source: https://github.com/OpenRA/OpenRA
 
 Files: *
-Copyright: 2007-2014 The OpenRA Developers
+Copyright: 2007-2018 The OpenRA Developers
 License: GPL-3.0
 
 Files: DEBIAN/*
-Copyright: 2007-2014 The OpenRA Developers
+Copyright: 2007-2018 The OpenRA Developers
 License: GPL-3.0
 
 License: GPL-3.0

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -1,4 +1,4 @@
-; Copyright 2007-2015 OpenRA developers (see AUTHORS)
+; Copyright 2007-2018 OpenRA developers (see AUTHORS)
 ; This file is part of OpenRA.
 ;
 ;  OpenRA is free software: you can redistribute it and/or modify

--- a/packaging/windows/WindowsLauncher.cs.in
+++ b/packaging/windows/WindowsLauncher.cs.in
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2017 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of


### PR DESCRIPTION
The reason why there are 13 more changes than files is:

The following 6 files had a LF - CRLF issue:
OpenRA.Mods.Common/Traits/AttackMove.cs.
OpenRA.Mods.Common/Traits/Capturable.cs.
OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs.
OpenRA.Mods.Common/Traits/ExternalCapturable.cs.
OpenRA.Mods.Common/Widgets/Logic/ButtonTooltipLogic.cs.
OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs.

The following 2 files had two hits:
OpenRA.Mods.Common/UtilityCommands/CreateManPage.cs
packaging/linux/deb/copyright (Second commit)

This file (the only one) had only two spaces instead of three in the header (+5 lines):
mods/ra/maps/allies-06b/allies06b-AI.lua (Third commit)

Closes #14704.