### PR TITLE
TD Balance Changes 20180114

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -840,7 +840,7 @@ OBLI:
 		DecorationBounds: 22,44,0,-10
 	SelectionDecorations:
 	Health:
-		HP: 60000
+		HP: 75000
 	Armor:
 		Type: Heavy
 	RevealsShroud:

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -138,10 +138,10 @@ APCGun:
 		Spread: 128
 		Damage: 2000
 		Versus:
-			None: 35
-			Wood: 35
+			None: 30
+			Wood: 25
 			Light: 75
-			Heavy: 35
+			Heavy: 25
 		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: small_poof


### PR DESCRIPTION
Changes in TD:

APC vs none decreased from 35 to 30

APC vs wood decreased from 35 to 25

APC vs heavy decreased from 35 to 25

Obelisk HP Increased from 600 (60000) to 750 (75000)

APCs are doing to much damage vs structures and heavy armor. They are managing to kill Guard Towers, light tanks, and power plants to effectively in numbers between 5 and 10. This will help to prevent this from happening. A small decrease vs infantry allows rocket infantry to last just a little bit longer as well.

Obelisk is getting a HP increase. Going from the old notes and responses happening now leaves me to believe its HP is to small. In one testing example an obelisk getting airstriked leaves it with no HP left. 4 minigunner shots and then it dies. Increasing the HP allows an expensive structure to stand longer.