### PR TITLE
Make BaseProvider PausableConditional

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Common.Traits
 			return (off - new WVec(0, 0, off.Z)) + LocalCenterOffset;
 		}
 
-		public Actor FindBaseProvider(World world, Player p, CPos topLeft)
+		public BaseProvider FindBaseProvider(World world, Player p, CPos topLeft)
 		{
 			var center = world.Map.CenterOfCell(topLeft) + CenterOffset(world);
 			var mapBuildRadius = world.WorldActor.Trait<MapBuildRadius>();
@@ -161,7 +161,7 @@ namespace OpenRA.Mods.Common.Traits
 				// Range is counted from the center of the actor, not from each cell.
 				var target = Target.FromPos(bp.Actor.CenterPosition);
 				if (target.IsInRange(center, bp.Trait.Info.Range))
-					return bp.Actor;
+					return bp.Trait;
 			}
 
 			return null;

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -159,7 +159,7 @@ namespace OpenRA.Mods.Common.Traits
 					// BuildingInfo.IsCloseEnoughToBase has already verified that this is a valid build location
 					var provider = buildingInfo.FindBaseProvider(w, self.Owner, order.TargetLocation);
 					if (provider != null)
-						provider.Trait<BaseProvider>().BeginCooldown();
+						provider.BeginCooldown();
 				}
 
 				if (GetNumBuildables(self.Owner) > prevItems)


### PR DESCRIPTION
I wanted to work on replacing ExternalCapturable building lock with conditions, BaseProvider needs to be conditional for that to work, as currently being captured disables the base providing.

Pausing the trait makes the Range Circle red, disabling it complately removes the circle.