### PR TITLE
Refactor handling of hit radii in projectiles.

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -229,6 +229,8 @@ namespace OpenRA.Traits
 		void RemovePosition(Actor a, IOccupySpace ios);
 		void UpdatePosition(Actor a, IOccupySpace ios);
 		IEnumerable<Actor> ActorsInBox(WPos a, WPos b);
+
+		WDist LargestActorRadius { get; }
 	}
 
 	public interface IRenderModifier

--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Projectiles
 {
 	[Desc("Simple, invisible, usually direct-on-target projectile.")]
-	public class InstantHitInfo : IProjectileInfo, IRulesetLoaded<WeaponInfo>
+	public class InstantHitInfo : IProjectileInfo
 	{
 		[Desc("Maximum offset at the maximum range.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
@@ -35,12 +35,6 @@ namespace OpenRA.Mods.Common.Projectiles
 		public WDist BlockerScanRadius = new WDist(-1);
 
 		public IProjectile Create(ProjectileArgs args) { return new InstantHit(this, args); }
-
-		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo wi)
-		{
-			if (BlockerScanRadius < WDist.Zero)
-				BlockerScanRadius = Util.MinimumRequiredBlockerScanRadius(rules);
-		}
 	}
 
 	public class InstantHit : IProjectile
@@ -74,7 +68,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			// Check for blocking actors
 			WPos blockedPos;
 			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, source, target.CenterPosition,
-				info.Width, info.BlockerScanRadius, out blockedPos))
+				info.Width, out blockedPos))
 			{
 				target = Target.FromPos(blockedPos);
 			}

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -22,7 +22,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Projectiles
 {
 	[Desc("Not a sprite, but an engine effect.")]
-	public class LaserZapInfo : IProjectileInfo, IRulesetLoaded<WeaponInfo>
+	public class LaserZapInfo : IProjectileInfo
 	{
 		[Desc("The width of the zap.")]
 		public readonly WDist Width = new WDist(86);
@@ -74,20 +74,10 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		[PaletteReference] public readonly string HitAnimPalette = "effect";
 
-		[Desc("Scan radius for actors with projectile-blocking trait. If set to a negative value (default), it will automatically scale",
-			"to the blocker with the largest health shape. Only set custom values if you know what you're doing.")]
-		public WDist BlockerScanRadius = new WDist(-1);
-
 		public IProjectile Create(ProjectileArgs args)
 		{
 			var c = UsePlayerColor ? args.SourceActor.Owner.Color.RGB : Color;
 			return new LaserZap(this, args, c);
-		}
-
-		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo wi)
-		{
-			if (BlockerScanRadius < WDist.Zero)
-				BlockerScanRadius = Util.MinimumRequiredBlockerScanRadius(rules);
 		}
 	}
 
@@ -133,7 +123,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			// Check for blocking actors
 			WPos blockedPos;
 			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, source, target,
-				info.Width, info.BlockerScanRadius, out blockedPos))
+				info.Width, out blockedPos))
 			{
 				target = blockedPos;
 			}

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -23,7 +23,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Projectiles
 {
-	public class MissileInfo : IProjectileInfo, IRulesetLoaded<WeaponInfo>
+	public class MissileInfo : IProjectileInfo
 	{
 		[Desc("Name of the image containing the projectile sequence.")]
 		public readonly string Image = null;
@@ -148,17 +148,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			"not trigger fast enough, causing the missile to fly past the target.")]
 		public readonly WDist CloseEnough = new WDist(298);
 
-		[Desc("Scan radius for actors with projectile-blocking trait. If set to a negative value (default), it will automatically scale",
-			"to the blocker with the largest health shape. Only set custom values if you know what you're doing.")]
-		public WDist BlockerScanRadius = new WDist(-1);
-
 		public IProjectile Create(ProjectileArgs args) { return new Missile(this, args); }
-
-		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo wi)
-		{
-			if (BlockerScanRadius < WDist.Zero)
-				BlockerScanRadius = Util.MinimumRequiredBlockerScanRadius(rules);
-		}
 	}
 
 	// TODO: double check square roots!!!
@@ -453,7 +443,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		}
 
 		// NOTE: It might be desirable to make lookahead more intelligent by outputting more information
-		//       than just the highest point in the lookahead distance
+		//		 than just the highest point in the lookahead distance
 		void InclineLookahead(World world, int distCheck, out int predClfHgt, out int predClfDist, out int lastHtChg, out int lastHt)
 		{
 			predClfHgt = 0; // Highest probed terrain height
@@ -849,7 +839,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			var shouldExplode = false;
 			WPos blockedPos;
 			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, lastPos, pos, info.Width,
-				info.BlockerScanRadius, out blockedPos))
+				out blockedPos))
 			{
 				pos = blockedPos;
 				shouldExplode = true;

--- a/OpenRA.Mods.Common/Projectiles/Railgun.cs
+++ b/OpenRA.Mods.Common/Projectiles/Railgun.cs
@@ -90,28 +90,11 @@ namespace OpenRA.Mods.Common.Projectiles
 		[PaletteReference]
 		public readonly string HitAnimPalette = "effect";
 
-		[Desc("Scan radius for actors damaged by beam. If set to zero (default), it will automatically scale to the largest health shape.",
-			"Only set custom values if you know what you're doing.")]
-		public WDist AreaVictimScanRadius = WDist.Zero;
-
-		[Desc("Scan radius for actors with projectile-blocking trait. If set to zero (default), it will automatically scale",
-			"to the blocker with the largest health shape. Only set custom values if you know what you're doing.")]
-		public WDist BlockerScanRadius = WDist.Zero;
-
 		public IProjectile Create(ProjectileArgs args)
 		{
 			var bc = BeamPlayerColor ? Color.FromArgb(BeamColor.A, args.SourceActor.Owner.Color.RGB) : BeamColor;
 			var hc = HelixPlayerColor ? Color.FromArgb(HelixColor.A, args.SourceActor.Owner.Color.RGB) : HelixColor;
 			return new Railgun(args, this, bc, hc);
-		}
-
-		public void RulesetLoaded(Ruleset rules, WeaponInfo wi)
-		{
-			if (BlockerScanRadius == WDist.Zero)
-				BlockerScanRadius = Util.MinimumRequiredBlockerScanRadius(rules);
-
-			if (AreaVictimScanRadius == WDist.Zero)
-				AreaVictimScanRadius = Util.MinimumRequiredVictimScanRadius(rules);
 		}
 	}
 
@@ -156,7 +139,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			// Check for blocking actors
 			WPos blockedPos;
 			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(args.SourceActor.World, target, args.Source,
-					info.BeamWidth, info.BlockerScanRadius, out blockedPos))
+					info.BeamWidth, out blockedPos))
 				target = blockedPos;
 
 			// Note: WAngle.Sin(x) = 1024 * Math.Sin(2pi/1024 * x)
@@ -205,7 +188,7 @@ namespace OpenRA.Mods.Common.Projectiles
 					args.Weapon.Impact(Target.FromPos(target), args.SourceActor, args.DamageModifiers);
 				else
 				{
-					var actors = world.FindActorsOnLine(args.Source, target, info.BeamWidth, info.AreaVictimScanRadius);
+					var actors = world.FindActorsOnLine(args.Source, target, info.BeamWidth);
 					foreach (var a in actors)
 						args.Weapon.Impact(Target.FromActor(a), args.SourceActor, args.DamageModifiers);
 				}

--- a/OpenRA.Mods.Common/Traits/BlocksProjectiles.cs
+++ b/OpenRA.Mods.Common/Traits/BlocksProjectiles.cs
@@ -39,9 +39,9 @@ namespace OpenRA.Mods.Common.Traits
 					.Any(Exts.IsTraitEnabled));
 		}
 
-		public static bool AnyBlockingActorsBetween(World world, WPos start, WPos end, WDist width, WDist overscan, out WPos hit)
+		public static bool AnyBlockingActorsBetween(World world, WPos start, WPos end, WDist width, out WPos hit)
 		{
-			var actors = world.FindActorsOnLine(start, end, width, overscan);
+			var actors = world.FindActorsOnLine(start, end, width);
 			var length = (end - start).Length;
 
 			foreach (var a in actors)

--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -177,6 +177,8 @@ namespace OpenRA.Mods.Common.Traits
 		readonly HashSet<Actor> removeActorPosition = new HashSet<Actor>();
 		readonly Predicate<Actor> actorShouldBeRemoved;
 
+		public WDist LargestActorRadius { get; private set; }
+
 		public ActorMap(World world, ActorMapInfo info)
 		{
 			this.info = info;
@@ -192,6 +194,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			// PERF: Cache this delegate so it does not have to be allocated repeatedly.
 			actorShouldBeRemoved = removeActorPosition.Contains;
+
+			LargestActorRadius = map.Rules.Actors.SelectMany(a => a.Value.TraitInfos<HitShapeInfo>()).Max(h => h.Type.OuterRadius);
 		}
 
 		void INotifyCreated.Created(Actor self)

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -188,19 +188,6 @@ namespace OpenRA.Mods.Common
 			return world.SharedRandom.Next(range[0], range[1]);
 		}
 
-		// TODO: Investigate caching this or moving it to ActorMapInfo
-		public static WDist MinimumRequiredVictimScanRadius(Ruleset rules)
-		{
-			return rules.Actors.SelectMany(a => a.Value.TraitInfos<HitShapeInfo>()).Max(h => h.Type.OuterRadius);
-		}
-
-		// TODO: Investigate caching this or moving it to ActorMapInfo
-		public static WDist MinimumRequiredBlockerScanRadius(Ruleset rules)
-		{
-			return rules.Actors.Where(a => a.Value.HasTraitInfo<IBlocksProjectilesInfo>())
-				.SelectMany(a => a.Value.TraitInfos<HitShapeInfo>()).Max(h => h.Type.OuterRadius);
-		}
-
 		public static string FriendlyTypeName(Type t)
 		{
 			if (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(HashSet<>))

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -1796,6 +1796,24 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 20180219)
+				{
+					if (node.Key.StartsWith("Warhead", StringComparison.Ordinal) && node.Value.Value == "CreateEffect")
+					{
+						var victimScanRadius = node.Value.Nodes.FirstOrDefault(n => n.Key == "VictimScanRadius");
+						if (victimScanRadius != null)
+						{
+							if (FieldLoader.GetValue<int>(victimScanRadius.Key, victimScanRadius.Value.Value) == 0)
+								node.Value.Nodes.Add(new MiniYamlNode("ImpactActors", "false"));
+
+							node.Value.Nodes.Remove(victimScanRadius);
+						}
+					}
+
+					if (node.Key.StartsWith("Projectile"))
+						node.Value.Nodes.RemoveAll(n => n.Key == "BounceBlockerScanRadius" || n.Key == "BlockerScanRadius" || n.Key == "AreaVictimScanRadius");
+				}
+
 				UpgradeWeaponRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Warheads
 {
-	public class CreateEffectWarhead : Warhead, IRulesetLoaded<WeaponInfo>
+	public class CreateEffectWarhead : Warhead
 	{
 		[Desc("List of explosion sequences that can be used.")]
 		[SequenceReference("Image")] public readonly string[] Explosions = new string[0];
@@ -45,22 +45,15 @@ namespace OpenRA.Mods.Common.Warheads
 			"If that's the case, this warhead will consider the explosion position to have the 'Air' TargetType (in addition to any nearby actor's TargetTypes).")]
 		public readonly WDist AirThreshold = new WDist(128);
 
-		[Desc("Scan radius for victims around impact. If set to a negative value (default), it will automatically scale to the largest health shape.",
-			"Custom overrides should not be necessary under normal circumstances.")]
-		public WDist VictimScanRadius = new WDist(-1);
-
-		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo info)
-		{
-			if (VictimScanRadius < WDist.Zero)
-				VictimScanRadius = Util.MinimumRequiredVictimScanRadius(rules);
-		}
+		[Desc("Whether to consider actors in determining whether the explosion should happen. If false, only terrain will be considered.")]
+		public readonly bool ImpactActors = true;
 
 		static readonly string[] TargetTypeAir = new string[] { "Air" };
 
 		public ImpactType GetImpactType(World world, CPos cell, WPos pos, Actor firedBy)
 		{
 			// Matching target actor
-			if (VictimScanRadius > WDist.Zero)
+			if (ImpactActors)
 			{
 				var targetType = GetDirectHitTargetType(world, cell, pos, firedBy, true);
 				if (targetType == ImpactTargetType.ValidActor)
@@ -78,7 +71,7 @@ namespace OpenRA.Mods.Common.Warheads
 
 		public ImpactTargetType GetDirectHitTargetType(World world, CPos cell, WPos pos, Actor firedBy, bool checkTargetValidity = false)
 		{
-			var victims = world.FindActorsInCircle(pos, VictimScanRadius);
+			var victims = world.FindActorsOnCircle(pos, WDist.Zero);
 			var invalidHit = false;
 
 			foreach (var victim in victims)

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -28,15 +28,8 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("Ranges at which each Falloff step is defined. Overrides Spread.")]
 		public WDist[] Range = null;
 
-		[Desc("Extra search radius beyond maximum spread. If set to a negative value (default), it will automatically scale to the largest health shape.",
-			"Custom overrides should not be necessary under normal circumstances.")]
-		public WDist VictimScanRadius = new WDist(-1);
-
 		void IRulesetLoaded<WeaponInfo>.RulesetLoaded(Ruleset rules, WeaponInfo info)
 		{
-			if (VictimScanRadius < WDist.Zero)
-				VictimScanRadius = Util.MinimumRequiredVictimScanRadius(rules);
-
 			if (Range != null)
 			{
 				if (Range.Length != 1 && Range.Length != Falloff.Length)
@@ -58,9 +51,7 @@ namespace OpenRA.Mods.Common.Warheads
 			if (debugVis != null && debugVis.CombatGeometry)
 				world.WorldActor.Trait<WarheadDebugOverlay>().AddImpact(pos, Range, DebugOverlayColor);
 
-			// This only finds actors where the center is within the search radius,
-			// so we need to search beyond the maximum spread to account for actors with large health radius
-			var hitActors = world.FindActorsInCircle(pos, Range[Range.Length - 1] + VictimScanRadius);
+			var hitActors = world.FindActorsOnCircle(pos, Range[Range.Length - 1]);
 
 			foreach (var victim in hitActors)
 			{

--- a/OpenRA.Mods.Common/WorldExtensions.cs
+++ b/OpenRA.Mods.Common/WorldExtensions.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common
 		/// <param name="lineEnd">The position the line should end at</param>
 		/// <param name="lineWidth">How close an actor's health radius needs to be to the line to be considered 'intersected' by the line</param>
 		/// <returns>A list of all the actors intersected by the line</returns>
-		public static IEnumerable<Actor> FindActorsOnLine(this World world, WPos lineStart, WPos lineEnd, WDist lineWidth, WDist targetExtraSearchRadius)
+		public static IEnumerable<Actor> FindActorsOnLine(this World world, WPos lineStart, WPos lineEnd, WDist lineWidth)
 		{
 			// This line intersection check is done by first just finding all actors within a square that starts at the source, and ends at the target.
 			// Then we iterate over this list, and find all actors for which their health radius is at least within lineWidth of the line.
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common
 			var yDir = yDiff < 0 ? -1 : 1;
 
 			var dir = new WVec(xDir, yDir, 0);
-			var overselect = dir * (1024 + lineWidth.Length + targetExtraSearchRadius.Length);
+			var overselect = dir * (1024 + lineWidth.Length + world.ActorMap.LargestActorRadius.Length);
 			var finalTarget = lineEnd + overselect;
 			var finalSource = lineStart - overselect;
 
@@ -62,6 +62,14 @@ namespace OpenRA.Mods.Common
 			}
 
 			return intersectedActors;
+		}
+
+		/// <summary>
+		/// Finds all the actors of which their health radius is intersected by a specified circle.
+		/// </summary>
+		public static IEnumerable<Actor> FindActorsOnCircle(this World world, WPos origin, WDist r)
+		{
+			return world.FindActorsInCircle(origin, r + world.ActorMap.LargestActorRadius);
 		}
 
 		/// <summary>

--- a/mods/cnc/weapons/ballistics.yaml
+++ b/mods/cnc/weapons/ballistics.yaml
@@ -21,7 +21,7 @@
 	Warhead@3Eff: CreateEffect
 		Explosions: small_frag
 		ImpactSounds: xplos.aud
-		VictimScanRadius: 0
+		ImpactActors: false
 
 70mm:
 	Inherits: ^BallisticWeapon

--- a/mods/cnc/weapons/explosions.yaml
+++ b/mods/cnc/weapons/explosions.yaml
@@ -11,7 +11,7 @@
 	Warhead@2Eff: CreateEffect
 		Explosions: poof
 		ImpactSounds: xplos.aud
-		VictimScanRadius: 0
+		ImpactActors: false
 	Warhead@3Smu: LeaveSmudge
 		SmudgeType: Crater
 		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees, Creep
@@ -92,7 +92,7 @@ BuildingExplode:
 	Warhead@1Eff: CreateEffect
 		Explosions: building, building_napalm, med_frag, poof, small_building
 		Delay: 1
-		VictimScanRadius: 0
+		ImpactActors: false
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 		Delay: 1

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -31,7 +31,7 @@
 	Warhead@3Eff: CreateEffect
 		Explosions: small_frag
 		ImpactSounds: xplos.aud
-		VictimScanRadius: 0
+		ImpactActors: false
 		ValidTargets: Ground, Water, Air
 
 Dragon:
@@ -130,7 +130,7 @@ MammothMissiles:
 	Warhead@4EffAir: CreateEffect
 		Explosions: small_building
 		ImpactSounds: xplos.aud
-		VictimScanRadius: 0
+		ImpactActors: false
 		ValidTargets: Air
 
 227mm:
@@ -208,7 +208,7 @@ BoatMissile:
 	Warhead@4EffAir: CreateEffect
 		Explosions: small_building
 		ImpactSounds: xplos.aud
-		VictimScanRadius: 0
+		ImpactActors: false
 		ValidTargets: Air
 
 TowerMissile:

--- a/mods/cnc/weapons/other.yaml
+++ b/mods/cnc/weapons/other.yaml
@@ -23,7 +23,7 @@
 	Warhead@3Eff: CreateEffect
 		Explosions: small_napalm
 		ImpactSounds: flamer2.aud
-		VictimScanRadius: 0
+		ImpactActors: false
 
 Flamethrower:
 	Inherits: ^FlameWeapon
@@ -144,4 +144,4 @@ Demolish:
 	Warhead@2Eff: CreateEffect
 		Explosions: building
 		ImpactSounds: xplobig6.aud
-		VictimScanRadius: 0
+		ImpactActors: false

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -29,7 +29,7 @@ Sniper:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
-		VictimScanRadius: 0
+		ImpactActors: false
 		ValidTargets: Ground, Water, Air
 
 HighV:

--- a/mods/cnc/weapons/superweapons.yaml
+++ b/mods/cnc/weapons/superweapons.yaml
@@ -16,7 +16,7 @@ Atomic:
 	Warhead@2Eff_impact: CreateEffect
 		Explosions: nuke_explosion
 		ImpactSounds: nukexplo.aud
-		VictimScanRadius: 0
+		ImpactActors: false
 	Warhead@3Dam_areanukea: SpreadDamage
 		Spread: 2c512
 		Damage: 11000
@@ -41,7 +41,7 @@ Atomic:
 	Warhead@6Eff_areanukea: CreateEffect
 		ImpactSounds: xplobig4.aud
 		Delay: 3
-		VictimScanRadius: 0
+		ImpactActors: false
 	Warhead@7Dam_areanukeb: SpreadDamage
 		Spread: 3c768
 		Damage: 5000

--- a/mods/d2k/weapons/debris.yaml
+++ b/mods/d2k/weapons/debris.yaml
@@ -31,7 +31,7 @@ Debris:
 		InvalidTargets: Vehicle, Structure
 	Warhead@3Eff: CreateEffect
 		Explosions: tiny_explosion
-		VictimScanRadius: 0
+		ImpactActors: false
 
 Debris2:
 	Inherits: Debris

--- a/mods/d2k/weapons/largeguns.yaml
+++ b/mods/d2k/weapons/largeguns.yaml
@@ -25,7 +25,7 @@
 		InvalidTargets: Vehicle, Structure
 	Warhead@3Eff: CreateEffect
 		Explosions: small_napalm
-		VictimScanRadius: 0
+		ImpactActors: false
 
 110mm_Gun:
 	Inherits: ^Cannon

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -30,7 +30,7 @@
 		InvalidTargets: Vehicle, Structure
 	Warhead@3Eff: CreateEffect
 		Explosions: tiny_explosion
-		VictimScanRadius: 0
+		ImpactActors: false
 		ValidTargets: Ground, Air
 
 ^Missile:

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -85,7 +85,7 @@ OrniBomb:
 	Warhead@3Eff: CreateEffect
 		Explosions: large_explosion
 		ImpactSounds: EXPLSML4.WAV
-		VictimScanRadius: 0
+		ImpactActors: false
 
 Crush:
 	Warhead@1Dam: SpreadDamage
@@ -100,7 +100,7 @@ Demolish:
 	Warhead@2Eff: CreateEffect
 		Explosions: building
 		ImpactSounds: EXPLLG2.WAV
-		VictimScanRadius: 0
+		ImpactActors: false
 
 Atomic:
 	Warhead@1Dam: SpreadDamage
@@ -121,7 +121,7 @@ Atomic:
 	Warhead@2Eff: CreateEffect
 		Explosions: nuke
 		ImpactSounds: EXPLLG2.WAV
-		VictimScanRadius: 0
+		ImpactActors: false
 
 CrateNuke:
 	Inherits: Atomic
@@ -151,36 +151,36 @@ CrateExplosion:
 	Warhead@2Eff: CreateEffect
 		Explosions: large_explosion
 		ImpactSounds: EXPLSML4.WAV
-		VictimScanRadius: 0
+		ImpactActors: false
 
 UnitExplodeSmall:
 	Warhead@1Eff: CreateEffect
 		Explosions: self_destruct
 		ImpactSounds: EXPLSML1.WAV
-		VictimScanRadius: 0
+		ImpactActors: false
 
 UnitExplodeMed:
 	Warhead@1Eff: CreateEffect
 		Explosions: building
 		ImpactSounds: EXPLSML2.WAV
-		VictimScanRadius: 0
+		ImpactActors: false
 
 UnitExplodeLarge:
 	Warhead@1Eff: CreateEffect
 		Explosions: large_explosion
 		ImpactSounds: EXPLLG2.WAV
-		VictimScanRadius: 0
+		ImpactActors: false
 
 BuildingExplode:
 	Warhead@1Eff: CreateEffect
 		Explosions: building, self_destruct, large_explosion
-		VictimScanRadius: 0
+		ImpactActors: false
 
 WallExplode:
 	Warhead@1Eff: CreateEffect
 		Explosions: wall_explosion
 		ImpactSounds: EXPLHG1.WAV
-		VictimScanRadius: 0
+		ImpactActors: false
 
 grenade:
 	ReloadDelay: 50
@@ -211,7 +211,7 @@ grenade:
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion
 		ImpactSounds: EXPLMD2.WAV
-		VictimScanRadius: 0
+		ImpactActors: false
 
 GrenDeath:
 	Warhead@1Dam: SpreadDamage
@@ -232,7 +232,7 @@ GrenDeath:
 	Warhead@3Eff: CreateEffect
 		Explosions: building
 		ImpactSounds: EXPLSML4.WAV
-		VictimScanRadius: 0
+		ImpactActors: false
 
 SardDeath:
 	Warhead@1Dam: SpreadDamage
@@ -254,7 +254,7 @@ SardDeath:
 	Warhead@3Eff: CreateEffect
 		Explosions: small_napalm
 		ImpactSounds: EXPLSML2.WAV
-		VictimScanRadius: 0
+		ImpactActors: false
 
 SpiceExplosion:
 	Projectile: Bullet
@@ -284,7 +284,7 @@ SpiceExplosion:
 		Size: 1
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion
-		VictimScanRadius: 0
+		ImpactActors: false
 
 BloomExplosion:
 	Report: EXPLMD1.WAV

--- a/mods/d2k/weapons/smallguns.yaml
+++ b/mods/d2k/weapons/smallguns.yaml
@@ -19,7 +19,7 @@
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
-		VictimScanRadius: 0
+		ImpactActors: false
 
 LMG:
 	Inherits: ^MG

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -207,7 +207,7 @@ CrateNuke:
 	Warhead@3Eff_impact: CreateEffect
 		Explosions: nuke
 		ImpactSounds: kaboom1.aud
-		VictimScanRadius: 0
+		ImpactActors: false
 	Warhead@4Dam_areanuke1: SpreadDamage
 		Spread: 1c0
 		Damage: 6000
@@ -224,7 +224,7 @@ CrateNuke:
 	Warhead@6Eff_areanuke1: CreateEffect
 		ImpactSounds: kaboom22.aud
 		Delay: 5
-		VictimScanRadius: 0
+		ImpactActors: false
 	Warhead@6Smu_areanuke1: LeaveSmudge
 		SmudgeType: Scorch
 		InvalidTargets: Vehicle, Structure, Wall, Trees
@@ -255,7 +255,7 @@ MiniNuke:
 	Warhead@3Eff_impact: CreateEffect
 		Explosions: nuke
 		ImpactSounds: kaboom1.aud
-		VictimScanRadius: 0
+		ImpactActors: false
 	Warhead@4Dam_areanuke1: SpreadDamage
 		Spread: 2c0
 		Damage: 6000
@@ -273,7 +273,7 @@ MiniNuke:
 	Warhead@6Eff_areanuke1: CreateEffect
 		ImpactSounds: kaboom22.aud
 		Delay: 5
-		VictimScanRadius: 0
+		ImpactActors: false
 	Warhead@7Dam_areanuke2: SpreadDamage
 		Spread: 3c0
 		Damage: 6000

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -41,7 +41,7 @@
 	Inherits: ^AntiGroundMissile
 	ValidTargets: Air
 	Warhead@3Eff: CreateEffect
-		VictimScanRadius: 0
+		ImpactActors: false
 
 Maverick:
 	Inherits: ^AntiGroundMissile

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -19,7 +19,7 @@
 	Warhead@3Eff: CreateEffect
 		Explosions: napalm
 		ImpactSounds: firebl3.aud
-		VictimScanRadius: 0
+		ImpactActors: false
 
 FireballLauncher:
 	Inherits: ^FireWeapon
@@ -195,4 +195,4 @@ MADTankDetonate:
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion
 		ImpactSounds: mineblo1.aud
-		VictimScanRadius: 0
+		ImpactActors: false

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -50,7 +50,7 @@ Atomic:
 	Warhead@4Eff_impact: CreateEffect
 		Explosions: nuke
 		ImpactSounds: kaboom1.aud
-		VictimScanRadius: 0
+		ImpactActors: false
 		ValidTargets: Ground, Water, Air
 	Warhead@5Dam_areanuke1: SpreadDamage
 		Spread: 2c0
@@ -73,7 +73,7 @@ Atomic:
 	Warhead@8Eff_areanuke1: CreateEffect
 		ImpactSounds: kaboom22.aud
 		Delay: 5
-		VictimScanRadius: 0
+		ImpactActors: false
 	Warhead@9Dam_areanuke2: SpreadDamage
 		Spread: 3c0
 		Damage: 6000

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -85,7 +85,7 @@ MammothTusk:
 			Concrete: 28
 		DamageTypes: Explosion
 	Warhead@2Eff: CreateEffect
-		VictimScanRadius: 0
+		ImpactActors: false
 		Explosions: medium_twlt
 		ImpactSounds: expnew07.aud
 		InvalidImpactTypes: Water
@@ -147,4 +147,4 @@ RedEye2:
 	Warhead@2Eff: CreateEffect
 		Explosions: large_grey_explosion
 		ImpactSounds: expnew13.aud
-		VictimScanRadius: 0
+		ImpactActors: false

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -80,27 +80,27 @@ IonCannon:
 		Explosions: ionbeam
 		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: ion1.aud
-		VictimScanRadius: 0
+		ImpactActors: false
 	Warhead@5Effect: CreateEffect
 		Explosions: ionbeam2
 		ExplosionPalette: effect-ignore-lighting-alpha75
-		VictimScanRadius: 0
+		ImpactActors: false
 	Warhead@6Effect: CreateEffect
 		Explosions: ionbeam3
 		ExplosionPalette: effect-ignore-lighting-alpha75
-		VictimScanRadius: 0
+		ImpactActors: false
 	Warhead@7Effect: CreateEffect
 		Explosions: ionbeam4
 		ExplosionPalette: effect-ignore-lighting-alpha75
-		VictimScanRadius: 0
+		ImpactActors: false
 	Warhead@8Effect: CreateEffect
 		Explosions: ionbeam5
 		ExplosionPalette: effect-ignore-lighting-alpha75
-		VictimScanRadius: 0
+		ImpactActors: false
 	Warhead@9Effect: CreateEffect
 		Explosions: ionbeam6
 		ExplosionPalette: effect-ignore-lighting-alpha75
-		VictimScanRadius: 0
+		ImpactActors: false
 
 EMPulseCannon:
 	ReloadDelay: 100
@@ -115,7 +115,7 @@ EMPulseCannon:
 	Warhead@1Eff: CreateEffect
 		Explosions: pulse_explosion
 		ExplosionPalette: effect-ignore-lighting-alpha75
-		VictimScanRadius: 0
+		ImpactActors: false
 	Warhead@emp: GrantExternalCondition
 		Range: 4c0
 		Duration: 250
@@ -135,7 +135,7 @@ ClusterMissile:
 		Explosions: large_explosion
 		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew19.aud
-		VictimScanRadius: 0
+		ImpactActors: false
 	Warhead@ResourceDestruction0: DestroyResource
 		Size: 1
 	Warhead@ClusterSmudges0: LeaveSmudge


### PR DESCRIPTION
This pull request is intended as a premilinary review of the code changes I'm proposing. I haven't yet done extensive testing or written the necessary upgrade rules. If it does what I expect, it's possible that, as a result of this, shots that weren't previously blocked will now be blocked, but if that's true, it was a bug.

The performance cost from not having a separate radius for blocking actors is easily fixed by storing that on the ActorMap as well, and then having a flag to pass into FindActorsOnLine, if that's a concern.

--------------------------------

penev discovered that the RulesetLoaded functions of projectiles were
never being called, meaning that their blocking calculations were not
properly accounting for actors with large hitboxes.

The best fix for this is to change FindActorsOnLine to always account
for the largest actor's hit radius, rather than forcing callers to pass
the largest radius. Per the comment in Util.cs, as a result, move this
computation to ActorMap. I decided to simplify by not making a separate
calculation for actors that block projectiles only; this may cause a
small performance degradation as the search space is a bit larger.

Similarly to this, I've removed the ability to specify a search radius
manually. Because this is only a search radius, setting a value smaller
than the largest eligible actor makes no sense; that would lead to
completely inconsistent blocking. Setting a larger value, on the other
hand, would make no difference.

CreateEffectWarhead was the only place in core code any of these search
radii were set, and that's because 0 was a mysterious magic value that
made the warhead incapable of hitting actors. I replaced it with a
boolean flag that more clearly indicates the actual behaviour.

Fixes #14151.