### PR TITLE
RA - Fix Flamers sometimes explode with UnitExplode

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -195,6 +195,7 @@ E4:
 	AttackFrontal:
 	Explodes:
 		Weapon: VisualExplode
+		EmptyWeapon: VisualExplode
 		Chance: 50
 	WithInfantryBody:
 		DefaultAttackSequence: shoot


### PR DESCRIPTION
Visual flamer explosion PR caused flamers to sometimes chain explode like Grens did.