### PR TITLE
[RA Balance] Dial back Artillery/V2 minimum range change

### DIFF
--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -114,7 +114,7 @@ TurretGun:
 
 155mm:
 	Inherits: ^Artillery
-	MinRange: 5c0
+	MinRange: 4c0
 	Report: tank5.aud
 	TargetActorCenter: true
 	Projectile: Bullet

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -321,7 +321,7 @@ SCUD:
 	Inherits: ^AntiGroundMissile
 	ReloadDelay: 0
 	Range: 10c0
-	MinRange: 5c0
+	MinRange: 4c0
 	Report: missile1.aud
 	-Projectile:
 	Projectile: Bullet


### PR DESCRIPTION
In #14471 I changed the minimum range of Artillery and V2s to 5c0 from 3c0. I've heard plenty of feedback from the playtest, and after considering the feedback and my own play experience, I have decided to dial back that change from 5c0 to 4c0.

I am happy with the 5c0 range as far as balance goes, but we've noticed these units, especially V2s, can look rather hapless during large battles. Not having your units do what you tell them is more frustrating to players than imbalance, so we're going to dial this back to a one-cell minimum range increase.