### PR TITLE
HackyAI AvoidCapturingActorTypes

### DIFF
--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -213,6 +213,12 @@ namespace OpenRA.Mods.Common.AI
 			"Leave this empty to include all actors.")]
 		public HashSet<string> CapturableActorTypes = new HashSet<string>();
 
+		// Makes it so the AI can tell what not to capture
+		[Desc("Actor types to avoid capturing.",
+			"Leave this empty to include no actors to avoid.",
+			"If empty CapturableActorTypes takes over and this is ignored!")]
+		public HashSet<string> AvoidCapturingActorTypes = new HashSet<string>();
+
 		[Desc("Minimum delay (in ticks) between trying to capture with CapturingActorTypes.")]
 		public readonly int MinimumCaptureDelay = 375;
 
@@ -764,10 +770,28 @@ namespace OpenRA.Mods.Common.AI
 				.OrderByDescending(target => target.Actor.GetSellValue())
 				.Take(maximumCaptureTargetOptions);
 
-			if (Info.CapturableActorTypes.Any())
+			if (Info.CapturableActorTypes.Any() && !Info.AvoidCapturingActorTypes.Any())
 			{
-				capturableTargetOptions = capturableTargetOptions.Where(target => Info.CapturableActorTypes.Contains(target.Actor.Info.Name.ToLowerInvariant()));
-				externalCapturableTargetOptions = externalCapturableTargetOptions.Where(target => Info.CapturableActorTypes.Contains(target.Actor.Info.Name.ToLowerInvariant()));
+				capturableTargetOptions = capturableTargetOptions.Where(target =>
+					Info.CapturableActorTypes.Contains(target.Actor.Info.Name.ToLowerInvariant()));
+				externalCapturableTargetOptions = externalCapturableTargetOptions.Where(target =>
+					Info.CapturableActorTypes.Contains(target.Actor.Info.Name.ToLowerInvariant()));
+			}
+			else if (Info.CapturableActorTypes.Any() && Info.AvoidCapturingActorTypes.Any())
+			{
+				capturableTargetOptions = capturableTargetOptions.Where(target =>
+					(Info.CapturableActorTypes.Contains(target.Actor.Info.Name.ToLowerInvariant()) &&
+					!Info.AvoidCapturingActorTypes.Contains(target.Actor.Info.Name.ToLowerInvariant())));
+				externalCapturableTargetOptions = externalCapturableTargetOptions.Where(target =>
+					(Info.CapturableActorTypes.Contains(target.Actor.Info.Name.ToLowerInvariant()) &&
+					!Info.AvoidCapturingActorTypes.Contains(target.Actor.Info.Name.ToLowerInvariant())));
+			}
+			else if (!Info.CapturableActorTypes.Any() && Info.AvoidCapturingActorTypes.Any())
+			{
+				capturableTargetOptions = capturableTargetOptions.Where(target =>
+					!Info.AvoidCapturingActorTypes.Contains(target.Actor.Info.Name.ToLowerInvariant()));
+				externalCapturableTargetOptions = externalCapturableTargetOptions.Where(target =>
+					!Info.AvoidCapturingActorTypes.Contains(target.Actor.Info.Name.ToLowerInvariant()));
 			}
 
 			if (!capturableTargetOptions.Any() && !externalCapturableTargetOptions.Any())

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -50,6 +50,9 @@ Player:
 			e4: 15%
 			dog: 15%
 			shok: 15%
+			e6: 1%
+			mech: 1%
+			hijacker: 1%
 			harv: 10%
 			apc: 30%
 			jeep: 40%
@@ -65,7 +68,17 @@ Player:
 		UnitLimits:
 			dog: 4
 			harv: 8
+			e6: 4
+			mech: 4
+			hijacker: 4
 		SquadSize: 20
+		CapturingActorTypes: e6, mech, hijacker
+		CapturableActorTypes:
+		AvoidCapturingActorTypes: tsla,agun,pbox,hbox,gun,ftur,sam
+		MinimumCaptureDelay: 300
+		MaximumCaptureTargetOptions: 25
+		CheckCaptureTargetsForVisibility: false
+		CapturableStances: Enemy, Neutral
 		SupportPowerDecision@spyplane:
 			OrderName: SovietSpyPlane
 			MinimumAttractiveness: 1


### PR DESCRIPTION
Was told to retry my massive string of AI updates in a more sensible manner and order.  The first of which is added the ability for the AI to ignore capturing certain things if told to do so.  There's an example of how the code can be used on the RA Rush AI, I would have put examples on the other mods' AIs but could deside on who'd get it in those mods.  If you guys don't want the example useage code in the yaml you can ignore that part.

The general idea in this step was to both make it so the AI could tell what it should ignore when capturing and hopefully at some point avoid having capture units near those targets as well.  Other ideas for how this can go could be maybe adding in repair building and bridge functionality but unsure on how to add either of those just yet.


Feel free to close #14727 for now since this is basically it going in a less crazy order


For those that weren't looking at the other PR here's what I'm up to.

1. AI Avoid Capturing Actors code (Done besides the side ideas I mentioned)
2. AI Able to use multi-targeting Support Powers (Done)
3. AI Limiting Production of Actors by number of other actors (Done)
4. AI Able to Limit the max of an actor's production based on a ratio with another actor (Idea)
5. AI able to use any Actor Ability Trait when told to do so and if needed how to do so (Idea and unsure how this is going to go)
6. AI using Transports (Too Tempting to grab the auto carryall code for this someone talk me out of it)
7. AI using Deployables (Both the ones that use Transforms and the TS/RA2 ones, I think the Crystallized Doom guys have this one, poke them)

Keep in mind they might not all come in this order or at all, just making a list so I don't go wild and do something stupid. :)