### PR TITLE
Unhardcode GrantExternalConditionPower cursors

### DIFF
--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
@@ -38,6 +38,9 @@ namespace OpenRA.Mods.Common.Traits
 			"This requires the actor to have the WithSpriteBody trait or one of its derivatives.")]
 		public readonly string Sequence = "active";
 
+		[Desc("Cursor to display when there are no units to apply the condition in range.")]
+		public readonly string BlockedCursor = "move-blocked";
+
 		public override object Create(ActorInitializer init) { return new GrantExternalConditionPower(init.Self, this); }
 	}
 
@@ -153,7 +156,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 			{
-				return power.UnitsInRange(cell).Any() ? "ability" : "move-blocked";
+				return power.UnitsInRange(cell).Any() ? power.info.Cursor : power.info.BlockedCursor;
 			}
 		}
 	}


### PR DESCRIPTION
Noticed while messing with RA2 mod. As IC was lacking its own cursor there.