### PR TITLE
Revert "Remove CreateGroup order as the ActorGroupProxy is gone."

### DIFF
--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -51,6 +51,13 @@ namespace OpenRA.Orders
 			if (!actorsInvolved.Any())
 				yield break;
 
+			// HACK: This is required by the hacky player actions-per-minute calculation
+			// TODO: Reimplement APM properly and then remove this
+			yield return new Order("CreateGroup", actorsInvolved.First().Owner.PlayerActor, false)
+			{
+				TargetString = actorsInvolved.Select(a => a.ActorID).JoinWith(",")
+			};
+
 			foreach (var o in orders)
 				yield return CheckSameOrder(o.Order, o.Trait.IssueOrder(o.Actor, o.Order, o.Target, mi.Modifiers.HasModifier(Modifiers.Shift)));
 		}


### PR DESCRIPTION
Reverts #13876 and adds a comment explaining why.
Fixes #14671.