### PR TITLE
Remove chat bindings when closing the ingame menu

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -196,14 +196,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		public void AddChatLineWrapper(Color c, string from, string text)
 		{
-			AddChatLine(c, from, text, false);
-		}
-
-		void AddChatLine(Color c, string from, string text, bool replayCache)
-		{
-			if (!replayCache && chatOverlayDisplay != null)
+			if (chatOverlayDisplay != null)
 				chatOverlayDisplay.AddLine(c, from, text);
 
+			// HACK: Force disable the chat notification sound for the in-menu chat dialog
+			// This works around our inability to disable the sounds for the in-game dialog when it is hidden
+			AddChatLine(c, from, text, chatOverlay == null);
+		}
+
+		void AddChatLine(Color c, string from, string text, bool suppressSound)
+		{
 			var template = chatTemplate.Clone();
 			var nameLabel = template.Get<LabelWidget>("NAME");
 			var textLabel = template.Get<LabelWidget>("TEXT");
@@ -236,7 +238,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (scrolledToBottom)
 				chatScrollPanel.ScrollToBottom(smooth: true);
 
-			if (!replayCache)
+			if (!suppressSound)
 				Game.Sound.PlayNotification(modRules, null, "Sounds", "ChatLine", null);
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -145,7 +145,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				AddChatLine(chatLine.Color, chatLine.Name, chatLine.Text, true);
 
 			orderManager.AddChatLine += AddChatLineWrapper;
-			Game.BeforeGameStart += UnregisterEvents;
 
 			chatText.IsDisabled = () => world.IsReplay && !Game.Settings.Debug.EnableDebugCommandsInReplays;
 
@@ -175,12 +174,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (!disableTeamChat)
 				teamChat ^= true;
 			return true;
-		}
-
-		void UnregisterEvents()
-		{
-			orderManager.AddChatLine -= AddChatLineWrapper;
-			Game.BeforeGameStart -= UnregisterEvents;
 		}
 
 		public void OpenChat()
@@ -245,6 +238,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			if (!replayCache)
 				Game.Sound.PlayNotification(modRules, null, "Sounds", "ChatLine", null);
+		}
+
+		bool disposed = false;
+		protected override void Dispose(bool disposing)
+		{
+			if (!disposed)
+			{
+				orderManager.AddChatLine -= AddChatLineWrapper;
+				disposed = true;
+			}
+
+			base.Dispose(disposing);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #14695.

Simple test case:
1. Replace https://github.com/OpenRA/OpenRA/blob/5f54e46eae98632e3f38d5fc13287789a32e3735/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs#L102 with `if (true)`
2. Start a skirmish
3. Open and close the in-game menu a bunch of times
4. Send a chat message.