### PR TITLE
 Add DamageTypes to Kill() and make some traits use it. 

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -321,12 +321,12 @@ namespace OpenRA
 			health.InflictDamage(this, attacker, damage, false);
 		}
 
-		public void Kill(Actor attacker)
+		public void Kill(Actor attacker, HashSet<string> damageTypes = null)
 		{
 			if (Disposed || health == null)
 				return;
 
-			health.Kill(this, attacker);
+			health.Kill(this, attacker, damageTypes);
 		}
 
 		public bool CanBeViewedByPlayer(Player player)

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Traits
 		bool IsDead { get; }
 
 		void InflictDamage(Actor self, Actor attacker, Damage damage, bool ignoreModifiers);
-		void Kill(Actor self, Actor attacker);
+		void Kill(Actor self, Actor attacker, HashSet<string> damageTypes);
 	}
 
 	// depends on the order of pips in WorldRenderer.cs!

--- a/OpenRA.Mods.Cnc/Activities/Leap.cs
+++ b/OpenRA.Mods.Cnc/Activities/Leap.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.GameRules;
@@ -29,8 +30,9 @@ namespace OpenRA.Mods.Cnc.Activities
 		WPos to;
 		int ticks;
 		WAngle angle;
+		HashSet<string> damageTypes;
 
-		public Leap(Actor self, Actor target, Armament a, WDist speed, WAngle angle)
+		public Leap(Actor self, Actor target, Armament a, WDist speed, WAngle angle, HashSet<string> damageTypes)
 		{
 			var targetMobile = target.TraitOrDefault<Mobile>();
 			if (targetMobile == null)
@@ -38,6 +40,7 @@ namespace OpenRA.Mods.Cnc.Activities
 
 			this.weapon = a.Weapon;
 			this.angle = angle;
+			this.damageTypes = damageTypes;
 			mobile = self.Trait<Mobile>();
 			mobile.SetLocation(mobile.FromCell, mobile.FromSubCell, targetMobile.FromCell, targetMobile.FromSubCell);
 			mobile.IsMoving = true;
@@ -67,7 +70,7 @@ namespace OpenRA.Mods.Cnc.Activities
 
 				self.World.ActorMap.GetActorsAt(mobile.ToCell, mobile.ToSubCell)
 					.Except(new[] { self }).Where(t => weapon.IsValidAgainst(t, self))
-					.Do(t => t.Kill(self));
+					.Do(t => t.Kill(self, damageTypes));
 
 				return NextActivity;
 			}

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackLeap.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackLeap.cs
@@ -25,6 +25,9 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public readonly WAngle Angle = WAngle.FromDegrees(20);
 
+		[Desc("Types of damage that this trait causes. Leave empty for no damage types.")]
+		public readonly HashSet<string> DamageTypes = new HashSet<string>();
+
 		public override object Create(ActorInitializer init) { return new AttackLeap(init.Self, this); }
 	}
 
@@ -51,7 +54,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				return;
 
 			self.CancelActivity();
-			self.QueueActivity(new Leap(self, target.Actor, a, info.Speed, info.Angle));
+			self.QueueActivity(new Leap(self, target.Actor, a, info.Speed, info.Angle, info.DamageTypes));
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
+++ b/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using System.Drawing;
 using OpenRA.Mods.Cnc.Activities;
 using OpenRA.Mods.Common.Traits;
@@ -22,6 +23,10 @@ namespace OpenRA.Mods.Cnc.Traits
 	{
 		[Desc("Should the actor die instead of being teleported?")]
 		public readonly bool ExplodeInstead = false;
+
+		[Desc("Types of damage that this trait causes to self when 'ExplodeInstead' is true. Leave empty for no damage types.")]
+		public readonly HashSet<string> DamageTypes = new HashSet<string>();
+
 		public readonly string ChronoshiftSound = "chrono2.aud";
 
 		[Desc("Should the actor return to its previous location after the chronoshift wore out?")]
@@ -95,7 +100,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				{
 					// Damage is inflicted by the chronosphere
 					if (!self.Disposed)
-						self.InflictDamage(chronosphere, new Damage(int.MaxValue));
+						self.Kill(chronosphere, info.DamageTypes);
 				});
 				return true;
 			}

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -53,6 +53,9 @@ namespace OpenRA.Mods.Cnc.Traits
 		public WeaponInfo ThumpDamageWeaponInfo { get; private set; }
 		public WeaponInfo DetonationWeaponInfo { get; private set; }
 
+		[Desc("Types of damage that this trait causes to self while self-destructing. Leave empty for no damage types.")]
+		public readonly HashSet<string> DamageTypes = new HashSet<string>();
+
 		public object Create(ActorInitializer init) { return new MadTank(init.Self, this); }
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
@@ -146,7 +149,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					info.DetonationWeaponInfo.Impact(Target.FromPos(self.CenterPosition), self, Enumerable.Empty<int>());
 				}
 
-				self.Kill(self);
+				self.Kill(self, info.DamageTypes);
 			});
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/Mine.cs
+++ b/OpenRA.Mods.Cnc/Traits/Mine.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (mobile != null && !info.DetonateClasses.Overlaps(mobile.Info.Crushes))
 				return;
 
-			self.Kill(crusher);
+			self.Kill(crusher, mobile != null ? mobile.Info.CrushDamageTypes : new HashSet<string>());
 		}
 
 		bool ICrushable.CrushableBy(Actor self, Actor crusher, HashSet<string> crushClasses)

--- a/OpenRA.Mods.Common/Traits/Attack/AttackSuicides.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackSuicides.cs
@@ -20,6 +20,9 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Does a suicide attack where it moves next to the target when used in combination with `Explodes`.")]
 	class AttackSuicidesInfo : ConditionalTraitInfo, Requires<IMoveInfo>
 	{
+		[Desc("Types of damage that this trait causes to self while suiciding. Leave empty for no damage types.")]
+		public readonly HashSet<string> DamageTypes = new HashSet<string>();
+
 		[VoiceReference] public readonly string Voice = "Action";
 
 		public override object Create(ActorInitializer init) { return new AttackSuicides(init.Self, this); }
@@ -82,10 +85,10 @@ namespace OpenRA.Mods.Common.Traits
 
 				self.QueueActivity(move.MoveToTarget(self, target));
 
-				self.QueueActivity(new CallFunc(() => self.Kill(self)));
+				self.QueueActivity(new CallFunc(() => self.Kill(self, Info.DamageTypes)));
 			}
 			else if (order.OrderString == "Detonate")
-				self.Kill(self);
+				self.Kill(self, Info.DamageTypes);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -46,6 +46,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public WeaponInfo DemolishWeaponInfo { get; private set; }
 
+		[Desc("Types of damage that this bridge causes to units over/in path of it while being destroyed/repaired. Leave empty for no damage types.")]
+		public readonly HashSet<string> DamageTypes = new HashSet<string>();
+
 		public object Create(ActorInitializer init) { return new Bridge(init.Self, this); }
 
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
@@ -241,7 +244,7 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var c in footprint.Keys)
 				foreach (var a in self.World.ActorMap.GetActorsAt(c))
 					if (a.Info.HasTraitInfo<IPositionableInfo>() && !a.Trait<IPositionable>().CanEnterCell(c))
-						a.Kill(self);
+						a.Kill(self, info.DamageTypes);
 		}
 
 		bool NeighbourIsDeadShore(Bridge neighbour)

--- a/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
@@ -30,6 +30,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public WeaponInfo DemolishWeaponInfo { get; private set; }
 
+		[Desc("Types of damage that this bridge causes to units over/in path of it while being destroyed/repaired. Leave empty for no damage types.")]
+		public readonly HashSet<string> DamageTypes = new HashSet<string>();
+
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
 			WeaponInfo weapon;
@@ -95,7 +98,7 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var c in cells)
 				foreach (var a in self.World.ActorMap.GetActorsAt(c))
 					if (a.Info.HasTraitInfo<IPositionableInfo>() && !a.Trait<IPositionable>().CanEnterCell(c))
-						a.Kill(self);
+						a.Kill(self, Info.DamageTypes);
 		}
 
 		void IBridgeSegment.Repair(Actor repairer)

--- a/OpenRA.Mods.Common/Traits/Crushable.cs
+++ b/OpenRA.Mods.Common/Traits/Crushable.cs
@@ -57,7 +57,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			Game.Sound.Play(SoundType.World, Info.CrushSound, crusher.CenterPosition);
 
-			self.Kill(crusher);
+			var crusherMobile = crusher.TraitOrDefault<Mobile>();
+			self.Kill(crusher, crusherMobile != null ? crusherMobile.Info.CrushDamageTypes : new HashSet<string>());
 		}
 
 		bool ICrushable.CrushableBy(Actor self, Actor crusher, HashSet<string> crushClasses)

--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -163,9 +164,12 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public void Kill(Actor self, Actor attacker)
+		public void Kill(Actor self, Actor attacker, HashSet<string> damageTypes = null)
 		{
-			InflictDamage(self, attacker, new Damage(MaxHP), true);
+			if (damageTypes == null)
+				damageTypes = new HashSet<string>();
+
+			InflictDamage(self, attacker, new Damage(MaxHP, damageTypes), true);
 		}
 
 		void ITick.Tick(Actor self)

--- a/OpenRA.Mods.Common/Traits/KillsSelf.cs
+++ b/OpenRA.Mods.Common/Traits/KillsSelf.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -20,6 +21,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("The amount of time (in ticks) before the actor dies. Two values indicate a range between which a random value is chosen.")]
 		public readonly int[] Delay = { 0 };
+
+		[Desc("Types of damage that this trait causes. Leave empty for no damage types.")]
+		public readonly HashSet<string> DamageTypes = new HashSet<string>();
 
 		[GrantedConditionReference]
 		[Desc("The condition to grant moments before suiciding.")]
@@ -81,7 +85,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (Info.RemoveInstead || !self.Info.HasTraitInfo<HealthInfo>())
 				self.Dispose();
 			else
-				self.Kill(self);
+				self.Kill(self, Info.DamageTypes);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -59,6 +59,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("e.g. crate, wall, infantry")]
 		public readonly HashSet<string> Crushes = new HashSet<string>();
 
+		[Desc("Types of damage that are caused while crushing. Leave empty for no damage types.")]
+		public readonly HashSet<string> CrushDamageTypes = new HashSet<string>();
+
 		public readonly int WaitAverage = 5;
 
 		public readonly int WaitSpread = 2;

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -22,6 +22,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("If we land on invalid terrain for my actor type should we be killed?")]
 		public readonly bool KilledOnImpassableTerrain = true;
 
+		[Desc("Types of damage that this trait causes to self when 'KilledOnImpassableTerrain' is true. Leave empty for no damage types.")]
+		public readonly HashSet<string> DamageTypes = new HashSet<string>();
+
 		[Desc("Image where Ground/WaterCorpseSequence is looked up.")]
 		public readonly string Image = "explosion";
 
@@ -101,7 +104,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (sequence != null && palette != null)
 				self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(self.OccupiesSpace.CenterPosition, w, info.Image, sequence, palette)));
 
-			self.Kill(self);
+			self.Kill(self, info.DamageTypes);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
@@ -219,15 +219,13 @@ namespace OpenRA.Mods.Common.Traits
 						break;
 
 					var actor = order.Target.Actor;
-					var health = actor.TraitOrDefault<Health>();
 					var args = order.TargetString.Split(' ');
 					var damageTypes = new HashSet<string>();
 
 					foreach (var damageType in args)
 						damageTypes.Add(damageType);
 
-					if (health != null)
-						health.InflictDamage(actor, actor, new Damage(health.HP, damageTypes), true);
+					actor.Kill(actor, damageTypes);
 
 					break;
 				}

--- a/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("How much (raw) damage to deal.")]
 		public readonly int Damage = 0;
 
-		[Desc("Types of damage that this warhead causes. Leave empty for no damage.")]
+		[Desc("Types of damage that this warhead causes. Leave empty for no damage types.")]
 		public readonly HashSet<string> DamageTypes = new HashSet<string>();
 
 		[Desc("Damage percentage versus each armortype.")]


### PR DESCRIPTION
I gave it a default value of null, so it doesn't have to be defined and act like it is now without that.

This changes /kill command and Chronoshiftable to use Kill, instead of InflictDamage.

There are 2 testcases, one on Demo Truck which makes it only explode by AttackSuicides, KillsSelf(IC) or Chronoshiftable, but not direct damage. Kinda like Generals GLA Terrorist. Other one makes D2K Sardaukar only explode when crushed.

If you think another usage of Kill() may benefit from having DamageTypes, i can add that too.