### PR TITLE
Fix a "granted condition is never consumed" warning in D2k

### DIFF
--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -1170,9 +1170,6 @@ palace:
 	GrantConditionOnFaction@Harkonnen:
 		Condition: harkonnen
 		Factions: harkonnen
-	GrantConditionOnFaction@Corrino:
-		Condition: corrino
-		Factions: corrino
 	GrantConditionOnFaction@Ordos:
 		Condition: ordos
 		Factions: ordos, mercenary, smuggler


### PR DESCRIPTION
Fixes the `OpenRA.Utility(1,1): Warning: Actor type 'palace' grants conditions that are not consumed: corrino` warnings.