### PR TITLE
Fix to dedicated server bug announcement

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -376,7 +376,7 @@ namespace OpenRA.Server
 				Log.Write("server", "{0} ({1}) has joined the game.",
 					client.Name, newConn.Socket.RemoteEndPoint);
 
-				if (LobbyInfo.NonBotClients.Count() > 1)
+				if (LobbyInfo.NonBotClients.Count() >= 1)
 					SendMessage("{0} has joined the game.".F(client.Name));
 
 				// Send initial ping


### PR DESCRIPTION
Closes #14750 
Server was checking if there are at least 2 clients to print out connection message.
This resulted in missing message for the first connected player.