### PR TITLE
Fix not all traits respecting multiple instances of 'Production'

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Buildings/ClonesProducedUnits.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ClonesProducedUnits.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
 		}
 
-		public void UnitProducedByOther(Actor self, Actor producer, Actor produced, string productionType)
+		public void UnitProducedByOther(Actor self, Actor producer, Actor produced, string productionType, TypeDictionary init)
 		{
 			// No recursive cloning!
 			if (producer.Owner != self.Owner || producer.Info.HasTraitInfo<ClonesProducedUnitsInfo>())

--- a/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
@@ -34,18 +34,15 @@ namespace OpenRA.Mods.Cnc.Traits
 
 	class ProductionAirdrop : Production
 	{
-		readonly ProductionAirdropInfo info;
 		public ProductionAirdrop(ActorInitializer init, ProductionAirdropInfo info)
-			: base(init, info)
-		{
-			this.info = info;
-		}
+			: base(init, info) { }
 
 		public override bool Produce(Actor self, ActorInfo producee, string productionType, TypeDictionary inits)
 		{
 			if (IsTraitDisabled || IsTraitPaused)
 				return false;
 
+			var info = (ProductionAirdropInfo)Info;
 			var owner = self.Owner;
 			var aircraftInfo = self.World.Map.Rules.Actors[info.ActorType].TraitInfo<AircraftInfo>();
 

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -595,6 +595,7 @@
     <Compile Include="UpdateRules\Rules\20180923\RemovedNotifyBuildComplete.cs" />
     <Compile Include="UpdateRules\Rules\20180923\ChangeTakeOffSoundAndLandingSound.cs" />
     <Compile Include="UpdateRules\Rules\20180923\AddCarryableHarvester.cs" />
+    <Compile Include="UpdateRules\Rules\20180923\RequireProductionType.cs" />
     <Compile Include="UtilityCommands\CheckYaml.cs" />
     <Compile Include="UtilityCommands\ConvertPngToShpCommand.cs" />
     <Compile Include="UtilityCommands\ConvertSpriteToPngCommand.cs" />

--- a/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
+++ b/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
@@ -405,7 +405,7 @@ namespace OpenRA.Mods.Common.Scripting
 			}
 		}
 
-		public void UnitProducedByOther(Actor self, Actor producee, Actor produced, string productionType)
+		public void UnitProducedByOther(Actor self, Actor producee, Actor produced, string productionType, TypeDictionary init)
 		{
 			if (world.Disposing)
 				return;

--- a/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
@@ -94,7 +94,8 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				// Cancel existing primaries
 				// TODO: THIS IS SHIT
-				var queues = Info.ProductionQueues.Length == 0 ? self.Info.TraitInfos<ProductionInfo>().SelectMany(pi => pi.Produces) : Info.ProductionQueues;
+				var queues = Info.ProductionQueues.Length == 0 ? self.TraitsImplementing<Production>()
+					.Where(t => !t.IsTraitDisabled).SelectMany(pi => pi.Info.Produces) : Info.ProductionQueues;
 				foreach (var q in queues)
 				{
 					foreach (var b in self.World
@@ -103,7 +104,7 @@ namespace OpenRA.Mods.Common.Traits
 								a.Actor != self &&
 								a.Actor.Owner == self.Owner &&
 								a.Trait.IsPrimary &&
-								a.Actor.Info.TraitInfos<ProductionInfo>().Any(pi => pi.Produces.Contains(q))))
+								a.Actor.TraitsImplementing<Production>().Where(p => !p.IsTraitDisabled).Any(pi => pi.Info.Produces.Contains(q))))
 						b.Trait.SetPrimaryProducer(b.Actor, false);
 				}
 

--- a/OpenRA.Mods.Common/Traits/Conditions/ProximityExternalCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ProximityExternalCondition.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -120,7 +121,7 @@ namespace OpenRA.Mods.Common.Traits
 				tokens[a] = external.GrantCondition(a, self);
 		}
 
-		public void UnitProducedByOther(Actor self, Actor producer, Actor produced, string productionType)
+		public void UnitProducedByOther(Actor self, Actor producer, Actor produced, string productionType, TypeDictionary init)
 		{
 			// If the produced Actor doesn't occupy space, it can't be in range
 			if (produced.OccupiesSpace == null)

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				var notifyOthers = self.World.ActorsWithTrait<INotifyOtherProduction>();
 				foreach (var notify in notifyOthers)
-					notify.Trait.UnitProducedByOther(notify.Actor, self, newUnit, productionType);
+					notify.Trait.UnitProducedByOther(notify.Actor, self, newUnit, productionType, td);
 			});
 		}
 

--- a/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new ProductionFromMapEdge(init, this); }
 	}
 
-	class ProductionFromMapEdge : Production, INotifyCreated
+	class ProductionFromMapEdge : Production
 	{
 		readonly CPos? spawnLocation;
 		readonly DomainIndex domainIndex;
@@ -36,8 +36,10 @@ namespace OpenRA.Mods.Common.Traits
 				spawnLocation = init.Get<ProductionSpawnLocationInit, CPos>();
 		}
 
-		void INotifyCreated.Created(Actor self)
+		protected override void Created(Actor self)
 		{
+			base.Created(self);
+
 			rp = self.TraitOrDefault<RallyPoint>();
 		}
 

--- a/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				var notifyOthers = self.World.ActorsWithTrait<INotifyOtherProduction>();
 				foreach (var notify in notifyOthers)
-					notify.Trait.UnitProducedByOther(notify.Actor, self, newUnit, productionType);
+					notify.Trait.UnitProducedByOther(notify.Actor, self, newUnit, productionType, td);
 			});
 
 			return true;

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				var notifyOthers = self.World.ActorsWithTrait<INotifyOtherProduction>();
 				foreach (var notify in notifyOthers)
-					notify.Trait.UnitProducedByOther(notify.Actor, self, newUnit, productionType);
+					notify.Trait.UnitProducedByOther(notify.Actor, self, newUnit, productionType, td);
 			});
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/ProductionQueueFromSelection.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionQueueFromSelection.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (queue == null)
 			{
 				var types = world.Selection.Actors.Where(a => a.IsInWorld && a.World.LocalPlayer == a.Owner)
-					.SelectMany(a => a.TraitsImplementing<Production>())
+					.SelectMany(a => a.TraitsImplementing<Production>().Where(p => !p.IsTraitDisabled))
 					.SelectMany(t => t.Info.Produces);
 
 				queue = world.LocalPlayer.PlayerActor.TraitsImplementing<ProductionQueue>()

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 	public class WithProductionOverlay : PausableConditionalTrait<WithProductionOverlayInfo>, INotifyDamageStateChanged, INotifyCreated, INotifyOwnerChanged
 	{
 		readonly Animation overlay;
-		readonly ProductionInfo production;
+		readonly ProductionInfo[] productionInfos;
 		ProductionQueue[] queues;
 
 		bool IsProducing
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var rs = self.Trait<RenderSprites>();
 			var body = self.Trait<BodyOrientation>();
 
-			production = self.Info.TraitInfo<ProductionInfo>();
+			productionInfos = self.Info.TraitInfos<ProductionInfo>().ToArray();
 
 			overlay = new Animation(self.World, rs.GetImage(self), () => IsTraitPaused);
 			overlay.PlayRepeating(info.Sequence);
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			// Per-actor production
 			queues = self.TraitsImplementing<ProductionQueue>()
-				.Where(q => production.Produces.Contains(q.Info.Type))
+				.Where(q => productionInfos.Any(p => p.Produces.Contains(q.Info.Type)))
 				.Where(q => !Info.Queues.Any() || Info.Queues.Contains(q.Info.Type))
 				.ToArray();
 
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			{
 				// Player-wide production
 				queues = self.Owner.PlayerActor.TraitsImplementing<ProductionQueue>()
-					.Where(q => production.Produces.Contains(q.Info.Type))
+					.Where(q => productionInfos.Any(p => p.Produces.Contains(q.Info.Type)))
 					.Where(q => !Info.Queues.Any() || Info.Queues.Contains(q.Info.Type))
 					.ToArray();
 			}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -131,7 +131,7 @@ namespace OpenRA.Mods.Common.Traits
 	public interface INotifyBurstComplete { void FiredBurst(Actor self, Target target, Armament a); }
 	public interface INotifyChat { bool OnChat(string from, string message); }
 	public interface INotifyProduction { void UnitProduced(Actor self, Actor other, CPos exit); }
-	public interface INotifyOtherProduction { void UnitProducedByOther(Actor self, Actor producer, Actor produced, string productionType); }
+	public interface INotifyOtherProduction { void UnitProducedByOther(Actor self, Actor producer, Actor produced, string productionType, TypeDictionary init); }
 	public interface INotifyDelivery { void IncomingDelivery(Actor self); void Delivered(Actor self); }
 	public interface INotifyDocking { void Docked(Actor self, Actor harvester); void Undocked(Actor self, Actor harvester); }
 	public interface INotifyParachute { void OnParachute(Actor self); void OnLanded(Actor self, Actor ignore); }

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/RequireProductionType.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/RequireProductionType.cs
@@ -1,0 +1,63 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RequireProductionType : UpdateRule
+	{
+		public override string Name { get { return "Require 'ProductionType' on 'ProductionBar'"; } }
+		public override string Description
+		{
+			get
+			{
+				return "The 'ProductionBar' trait now requires the 'ProductionType' to be set.\n" +
+				"The value will be automatically set to the first value in 'Produces' of the first 'Production' trait.";
+			}
+		}
+
+		readonly string[] productionTraits = { "Production", "ProductionAirdrop", "ProductionParadrop", "ProductionFromMapEdge" };
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var pb in actorNode.ChildrenMatching("ProductionBar"))
+			{
+				var type = pb.LastChildMatching("ProductionType");
+				if (type != null)
+					continue;
+
+				MiniYamlNode production = null;
+				foreach (var trait in productionTraits)
+				{
+					if (production != null)
+						break;
+
+					production = actorNode.ChildrenMatching(trait).FirstOrDefault();
+				}
+
+				if (production == null)
+					continue;
+
+				var produces = production.LastChildMatching("Produces");
+				if (produces == null)
+					continue;
+
+				var toAdd = produces.NodeValue<string[]>().FirstOrDefault();
+				if (toAdd != null)
+					pb.AddNode("ProductionType", toAdd);
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -103,6 +103,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new AddRearmable(),
 				new MergeAttackPlaneAndHeli(),
 				new RemovedDemolishLocking(),
+				new RequireProductionType(),
 			})
 		};
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/CycleProductionActorsHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/CycleProductionActorsHotkeyLogic.cs
@@ -45,8 +45,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 			var player = world.RenderPlayer ?? world.LocalPlayer;
 
 			var facilities = world.ActorsHavingTrait<Production>()
-				.Where(a => a.Owner == player && !a.Info.HasTraitInfo<BaseBuildingInfo>())
-				.OrderBy(f => f.Info.TraitInfo<ProductionInfo>().Produces.First())
+				.Where(a => a.Owner == player && !a.Info.HasTraitInfo<BaseBuildingInfo>()
+					&& a.TraitsImplementing<Production>().Any(t => !t.IsTraitDisabled))
+				.OrderBy(f => f.TraitsImplementing<Production>().First(t => !t.IsTraitDisabled).Info.Produces.First())
 				.ToList();
 
 			if (!facilities.Any())

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -322,6 +322,7 @@ PYLE:
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 	ProductionBar:
+		ProductionType: Infantry.GDI
 	Power:
 		Amount: -20
 	ProvidesPrerequisite@buildingname:
@@ -372,6 +373,7 @@ HAND:
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 	ProductionBar:
+		ProductionType: Infantry.Nod
 	Power:
 		Amount: -20
 	ProvidesPrerequisite@buildingname:
@@ -431,6 +433,7 @@ AFLD:
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 	ProductionBar:
+		ProductionType: Vehicle.Nod
 	Power:
 		Amount: -40
 	ProvidesPrerequisite@buildingname:
@@ -489,6 +492,7 @@ WEAP:
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 	ProductionBar:
+		ProductionType: Vehicle.GDI
 	Power:
 		Amount: -40
 	ProvidesPrerequisite@buildingname:

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -104,6 +104,7 @@ BIO:
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 	ProductionBar:
+		ProductionType: Biolab
 	RallyPoint:
 		Offset: -1,-1
 	SpawnActorOnDeath:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -89,6 +89,7 @@ construction_yard:
 		ActorTypes: light_inf, light_inf, engineer
 	BaseBuilding:
 	ProductionBar:
+		ProductionType: Building
 	Power:
 		Amount: 20
 	RenderSprites:
@@ -215,6 +216,7 @@ barracks:
 		ProductionQueues: Infantry
 		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
+		ProductionType: Infantry
 	ProvidesPrerequisite@atreides:
 		Prerequisite: barracks.atreides
 		Factions: atreides
@@ -426,6 +428,7 @@ light_factory:
 		ProductionQueues: Vehicle
 		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
+		ProductionType: Vehicle
 	ProvidesPrerequisite@atreides:
 		Prerequisite: light.atreides
 		Factions: atreides
@@ -507,6 +510,7 @@ heavy_factory:
 		ProductionQueues: Armor
 		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
+		ProductionType: Armor
 	ProvidesPrerequisite@atreides:
 		Prerequisite: heavy.atreides
 		Factions: atreides
@@ -669,6 +673,7 @@ starport:
 		RequiresCondition: !build-incomplete
 		Palette: starportlights
 	ProductionBar:
+		ProductionType: Starport
 	PrimaryBuilding:
 		PrimaryCondition: primary
 		ProductionQueues: Starport
@@ -933,6 +938,7 @@ high_tech_factory:
 	ProductionFromMapEdge:
 		Produces: Aircraft, Upgrade
 	ProductionBar:
+		ProductionType: Aircraft
 	PrimaryBuilding:
 		PrimaryCondition: primary
 		ProductionQueues: Aircraft

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -1228,17 +1228,6 @@ conyard.harkonnen:
 		Image: conyard.harkonnen
 		-FactionImages:
 
-conyard.corrino:
-	Inherits: construction_yard
-	Buildable:
-		Queue: Building
-		BuildPaletteOrder: 1000
-		Prerequisites: ~disabled
-		ForceFaction: corrino
-	RenderSprites:
-		Image: conyard.harkonnen
-		-FactionImages:
-
 conyard.ordos:
 	Inherits: construction_yard
 	Buildable:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -205,6 +205,7 @@ SPEN:
 		PlayerExperience: 15
 	RallyPoint:
 	ProductionBar:
+		ProductionType: Ship
 	Power:
 		Amount: -30
 	DetectCloaked:
@@ -326,6 +327,7 @@ SYRD:
 		PlayerExperience: 15
 	RallyPoint:
 	ProductionBar:
+		ProductionType: Ship
 	Power:
 		Amount: -30
 	DetectCloaked:
@@ -1055,6 +1057,7 @@ WEAP:
 		PrimaryCondition: primary
 		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
+		ProductionType: Vehicle
 	Power:
 		Amount: -30
 	ProvidesPrerequisite@buildingname:
@@ -1320,6 +1323,7 @@ HPAD:
 		Produces: Aircraft, Helicopter
 	Reservable:
 	ProductionBar:
+		ProductionType: Aircraft
 	PrimaryBuilding:
 		PrimaryCondition: primary
 		SelectionNotification: PrimaryBuildingSelected
@@ -1488,6 +1492,7 @@ AFLD:
 		ClockSequence: clock
 		CircleSequence: circles
 	ProductionBar:
+		ProductionType: Aircraft
 	SupportPowerChargeBar:
 	PrimaryBuilding:
 		PrimaryCondition: primary
@@ -1684,6 +1689,7 @@ BARR:
 		PrimaryCondition: primary
 		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
+		ProductionType: Infantry
 	ProvidesPrerequisite:
 		Prerequisite: barracks
 	ProvidesPrerequisite@soviet:
@@ -1766,6 +1772,7 @@ KENN:
 		PrimaryCondition: primary
 		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
+		ProductionType: Infantry
 	-SpawnActorsOnSell:
 	Power:
 		Amount: -10
@@ -1826,6 +1833,7 @@ TENT:
 		PrimaryCondition: primary
 		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
+		ProductionType: Infantry
 	ProvidesPrerequisite@barracks:
 		Prerequisite: barracks
 	ProvidesPrerequisite@allies:

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -110,6 +110,7 @@ GAPILE:
 		PrimaryCondition: primary
 		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
+		ProductionType: Infantry
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-lights
@@ -174,6 +175,7 @@ GAWEAP:
 		PrimaryCondition: primary
 		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
+		ProductionType: Vehicle
 	WithIdleOverlay@ROOF:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-roof
@@ -242,6 +244,7 @@ GAHPAD:
 		PlayerExperience: 15
 		StartRepairingNotification: Repairing
 	ProductionBar:
+		ProductionType: Air
 	WithIdleOverlay@PLATFORM:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-platform

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -119,6 +119,7 @@ NAHAND:
 		PrimaryCondition: primary
 		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
+		ProductionType: Infantry
 	WithIdleOverlay@LIGHTS:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-lights
@@ -180,6 +181,7 @@ NAWEAP:
 		PrimaryCondition: primary
 		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
+		ProductionType: Vehicle
 	WithIdleOverlay@ROOF:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-roof
@@ -242,6 +244,7 @@ NAHPAD:
 		PlayerExperience: 15
 		StartRepairingNotification: Repairing
 	ProductionBar:
+		ProductionType: Air
 	WithIdleOverlay@PLATFORM:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-platform


### PR DESCRIPTION
~~I'll update `ClonesProducedUnits` in a follow-up PR.~~

> Note for clarity: Currently the last Harkonnen missions crash (and that's probably just one case; #14796 "fixed" this for the upcoming playtest.) We want to sort all those issues with multiple instances of `Produces` out for `Next+1`. (I.e. replace all occurrences of `Trait<Produces>` and `TraitInfo<ProducesInfo>`)