### PR TITLE
TS - Don't show new build walls in fow

### DIFF
--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -434,7 +434,7 @@
 	Inherits@1: ^SpriteActor
 	Inherits@2: ^Cloakable
 	CombatDebugOverlay:
-	HiddenUnderShroud:
+	FrozenUnderFog:
 	AppearsOnRadar:
 	Interactable:
 	Building:


### PR DESCRIPTION
New build walls of the enemy where visible when in fog of war.

To test the changes:
- Open two TS games and create a game with explored map enabled.
- Build a wall with one of the clients.
- Look with the other client to where the walls are placed.

Without the fix, the walls can be seen trough the fog of war.

Related to #14683.