### PR TITLE
RA - Add red cross icon for infantry after capturing a hospital

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -376,7 +376,7 @@
 	WithDecoration@HAZMAT:
 		Image: pips
 		Sequence: pip-hazmat
-		ReferencePoint: Bottom, Right
+		ReferencePoint: Bottom, Left
 		RequiresCondition: hazmatsuits
 	ActorLostNotification:
 	SpawnActorOnDeath:
@@ -402,7 +402,7 @@
 	WithDecoration@REDCROSS:
 		Image: pips
 		Sequence: pip-heal
-		ReferencePoint: Bottom, Right
+		ReferencePoint: Bottom, Left
 		RequiresCondition: hospitalheal
 	DetectCloaked:
 		Range: 2c0

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -368,6 +368,11 @@
 	GrantConditionOnPrerequisite:
 		Condition: hospitalheal
 		Prerequisites: hosp
+	WithDecoration@REDCROSS:
+		Image: pips
+		Sequence: medic
+		ReferencePoint: Bottom, Left
+		RequiresCondition: hospitalheal
 	DeathSounds@NORMAL:
 		DeathTypes: DefaultDeath, BulletDeath, SmallExplosionDeath, ExplosionDeath
 	DeathSounds@BURNED:

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -101,6 +101,7 @@ pips:
 		Offset: 9, 5
 	medic:
 		Start: 20
+		Offset: -10, -2
 #	ready:
 #		Start: 3
 #	hold:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -567,7 +567,7 @@
 		Image: pips
 		Sequence: medic
 		Palette: pips
-		ReferencePoint: Bottom, Right
+		ReferencePoint: Bottom, Left
 		RequiresCondition: hospitalheal
 	RevealOnFire:
 	EntersTunnels:

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -97,6 +97,7 @@ darken:
 pips:
 	medic:
 		Start: 6
+		Offset: 1, 0
 	pip-empty: pips2
 	pip-green: pips2
 		Start: 1


### PR DESCRIPTION
The hospital provides healing for all infantry, however there is no visual feedback for that. It is present in the TD- and TS-mod, but it's missing in the RA-mod.

This PR adds the red cross icon for the RA-mod. It also moves the icon to the bottom left of the selection box in all mods to avoid overlapping with the rank icons.

This is how it looks like in the RA-mod with zoomed out/in screenshots + with selection boxes:
![ra](https://user-images.githubusercontent.com/33390659/36073980-80f0b060-0f39-11e8-9340-c689881a4b61.png)
For some reason the red cross icon is drawn above the rank icon when zoomed out. I would like to change it so the rank icons are drawn above (like how it is in the TD-mod, see below). Could anyone help me with that? I played around with the Offset and ZOffset but with no success.

This is how it looks like in the TD-mod with zoomed out/in screenshots + with selection boxes:
![td](https://user-images.githubusercontent.com/33390659/36073899-23ef7be0-0f38-11e8-888e-af1dcd9e8535.png)
While zoomed out there isn't much of a difference, zoomed in the icons don't overlap with the rank icons anymore. There is still a small problem when a player captures both a hospital and a bio lab. As the icons still overlap.

This is how it looks like in the TS-mod with zoomed out/in screenshots + with selection boxes + with group number:
![ts](https://user-images.githubusercontent.com/33390659/36074061-d250c458-0f3a-11e8-9a64-b13e3867ceb0.png)
Here I noticed the group number is at the bottom left. It is also in the bottom left of the original game. Maybe it's an idea to have it on the top left like in TD and RA.

Closes #14736.