### PR TITLE
Add Github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,39 @@
+<!--
+  This is a guideline, which shall help to write enhancement requests or bug reports.
+  Fill in the placeholders below. Delete any headings and placeholders that you do not use.
+
+  Before you start check if a similar request/bug report already exists in this Github issue tracker and comment there.
+
+When submitting a feature or enhancement request:
+
+1. Explain briefly what the enhancement is and why you think it would be useful.
+2. Provide any other necessary or useful information regarding your issue, such as (code) examples or related links.
+
+
+When submitting a bug report, please follow the template below:
+-->
+
+### Issue Summary
+<!-- Explanation of the issue. Expectation vs. actual behavior. -->
+... ... ...
+
+#### System Information
+- **Operating System:** [e.g. Windows 10, Mac OS 10.12, Ubuntu 16.04, ...]
+- **.NET / Mono Version:** [e.g. .NET 4.7.1, Mono 4.6.2, ...]
+- **OpenRA Version:** [e.g. release-20180218, playtest-20180208, ...]
+- **Mod:** [e.g. Red Alert, Tiberian Dawn, Dune2000, ...]
+
+#### Additional Information:
+- Steps to reproduce
+	1. Step
+	2. Step
+	3. ...
+
+- Logs
+<!-- If you have a log (e.g. debug.log, exception.log), zip and attach it. -->
+
+- OpenRA Replays
+<!-- You have to zip it before you can attach it. When does the issue appear [e.g. 10:33]? -->
+
+- Screenshots & Videos
+<!-- You should be able to attach screenshots by drag&drop. Videos need to be uploaded to an external platform (e.g. https://www.youtube.com, https://www.dropbox.com) -->


### PR DESCRIPTION
Closes #13774.

This PR adds an issue template to the repo and should be used as a guideline for bug reports and enhancement requests.

If somebody is interested to see the template in action, I created a test-repo [Link](https://github.com/ltem/template_test/issues/new) (Updated on 2018-02-24).
