### PR TITLE
RA - Fix palette of Oil Pump, Ice, Boxes, Hedgehogs and Utility Poles on Desert Tileset

### DIFF
--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -265,8 +265,8 @@ V18:
 
 V19:
 	Inherits: ^CivBuilding
-	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+	RenderSprites:
+		Palette: player
 	Tooltip:
 		Name: Oil Pump
 	-SpawnActorOnDeath@1:
@@ -279,8 +279,8 @@ V19:
 
 V19.Husk:
 	Inherits: ^CivBuilding
-	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
+	RenderSprites:
+		Palette: player
 	Tooltip:
 		Name: Husk (Oil Pump)
 	RenderSprites:

--- a/mods/ra/rules/decoration.yaml
+++ b/mods/ra/rules/decoration.yaml
@@ -215,123 +215,141 @@ TC05:
 
 BOXES01:
 	Inherits: ^Tree
+	RenderSprites:
+		Palette: player
 	Tooltip:
 		Name: Boxes
-	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
 		Categories: Decoration
 
 BOXES02:
 	Inherits: ^Tree
+	RenderSprites:
+		Palette: player
 	Tooltip:
 		Name: Boxes
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
 		Categories: Decoration
 
 BOXES03:
 	Inherits: ^Tree
+	RenderSprites:
+		Palette: player
 	Tooltip:
 		Name: Boxes
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
 		Categories: Decoration
 
 BOXES04:
 	Inherits: ^Tree
+	RenderSprites:
+		Palette: player
 	Tooltip:
 		Name: Boxes
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
 		Categories: Decoration
 
 BOXES05:
 	Inherits: ^Tree
+	RenderSprites:
+		Palette: player
 	Tooltip:
 		Name: Boxes
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
 		Categories: Decoration
 
 BOXES06:
 	Inherits: ^Tree
+	RenderSprites:
+		Palette: player
 	Tooltip:
 		Name: Boxes
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
 		Categories: Decoration
 
 BOXES07:
 	Inherits: ^Tree
+	RenderSprites:
+		Palette: player
 	Tooltip:
 		Name: Boxes
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
 		Categories: Decoration
 
 BOXES08:
 	Inherits: ^Tree
+	RenderSprites:
+		Palette: player
 	Tooltip:
 		Name: Boxes
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
 		Categories: Decoration
 
 BOXES09:
 	Inherits: ^Tree
+	RenderSprites:
+		Palette: player
 	Tooltip:
 		Name: Boxes
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
 		Categories: Decoration
 
 ICE01:
 	Inherits: ^Tree
+	RenderSprites:
+		Palette: player
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
 	Tooltip:
 		Name: Ice Floe
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT, INTERIOR
+		RequireTilesets: SNOW
 		Categories: Decoration
 
 ICE02:
 	Inherits: ^Tree
+	RenderSprites:
+		Palette: player
 	Building:
 		Footprint: x x
 		Dimensions: 1,2
 	Tooltip:
 		Name: Ice Floe
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT, INTERIOR
+		RequireTilesets: SNOW
 		Categories: Decoration
 
 ICE03:
 	Inherits: ^Tree
+	RenderSprites:
+		Palette: player
 	Building:
 		Footprint: xx
 		Dimensions: 2,1
 	Tooltip:
 		Name: Ice Floe
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT, INTERIOR
+		RequireTilesets: SNOW
 		Categories: Decoration
 
 ICE04:
 	Inherits: ^Tree
+	RenderSprites:
+		Palette: player
 	Tooltip:
 		Name: Ice Floe
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT, INTERIOR
+		RequireTilesets: SNOW
 		Categories: Decoration
 
 ICE05:
 	Inherits: ^Tree
+	RenderSprites:
+		Palette: player
 	Tooltip:
 		Name: Ice Floe
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT, INTERIOR
+		RequireTilesets: SNOW
 		Categories: Decoration
 
 ROCK1:
@@ -378,38 +396,42 @@ ROCK7:
 
 UTILPOL1:
 	Inherits: ^Tree
+	RenderSprites:
+		Palette: player
 	Tooltip:
 		Name: Utility Pole
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
 		Categories: Decoration
 
 UTILPOL2:
 	Inherits: ^Tree
+	RenderSprites:
+		Palette: player
 	Tooltip:
 		Name: Utility Pole
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
 		Categories: Decoration
 
 TANKTRAP1:
 	Inherits: ^Rock
+	RenderSprites:
+		Palette: player
 	Building:
 		Footprint: x
 		Dimensions: 1,1
 	Tooltip:
 		Name: Tank Trap
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
-		RequireTilesets: TEMPERAT, SNOW, INTERIOR
+		RequireTilesets: TEMPERAT, SNOW, DESERT, INTERIOR
 
 TANKTRAP2:
 	Inherits: ^Rock
+	RenderSprites:
+		Palette: player
 	Building:
 		Footprint: x
 		Dimensions: 1,1
 	Tooltip:
 		Name: Tank Trap
 	EditorTilesetFilter:
-		ExcludeTilesets: DESERT
-		RequireTilesets: TEMPERAT, SNOW, INTERIOR
+		RequireTilesets: TEMPERAT, SNOW, DESERT, INTERIOR

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -794,7 +794,7 @@
 ^CivBuilding:
 	Inherits: ^TechBuilding
 	RenderSprites:
-		Palette: terrain
+		Palette: player
 	EditorTilesetFilter:
 		ExcludeTilesets: INTERIOR
 		Categories: Civilian building
@@ -995,7 +995,7 @@
 		Name: Rock
 		ShowOwnerRow: false
 	RenderSprites:
-		Palette: terrain
+		Palette: desert
 	WithSpriteBody:
 	Building:
 		Footprint: __ x_
@@ -1012,7 +1012,7 @@
 ^DesertCivBuilding:
 	Inherits: ^CivBuilding
 	RenderSprites:
-		Palette: terrain
+		Palette: desert
 	EditorTilesetFilter:
 		RequireTilesets: DESERT
 

--- a/mods/ra/rules/palettes.yaml
+++ b/mods/ra/rules/palettes.yaml
@@ -20,6 +20,10 @@
 		Filename: temperat.pal
 		ShadowIndex: 4
 		AllowModifiers: false
+	PaletteFromFile@desert:
+		Name: desert
+		Filename: desert.pal
+		ShadowIndex: 4
 	PaletteFromRGBA@shadow:
 		Name: shadow
 		R: 0


### PR DESCRIPTION
And remove Editor Exclution of them from Desert Tileset. Interior and Snow palettes are literally the same file as temprate.pal, so making them always use temperate.pal won't break anything on those and allow using them on Desert theater too. Not sure what can be done with Ice on desert, but still included them too.