### PR TITLE
D2K - Add back palace stuff to prep, but without multipile Production:

### DIFF
--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -1091,16 +1091,18 @@ palace:
 		Factions: corrino
 	PrimaryBuilding:
 		PrimaryCondition: primary
+		RequiresCondition: atreides || ordos
 	WithTextDecoration@primary:
 		RequiresSelection: true
 		Text: PRIMARY
 		ReferencePoint: Top
 		ZOffset: 256
-		RequiresCondition: primary
+		RequiresCondition: primary && (atreides || ordos)
 	NukePower:
 		Cursor: nuke
 		Icon: deathhand
 		PauseOnCondition: disabled
+		RequiresCondition: harkonnen
 		Prerequisites: ~techlevel.superweapons, ~palace.nuke
 		ChargeInterval: 7500
 		Description: Death Hand
@@ -1117,7 +1119,7 @@ palace:
 		ArrowSequence: arrow
 		CircleSequence: circles
 	WithNukeLaunchOverlay:
-		RequiresCondition: !launchpad-damaged
+		RequiresCondition: !launchpad-damaged && harkonnen
 	GrantConditionOnDamageState@LAUNCHPADDAMAGED:
 		Condition: launchpad-damaged
 		ValidDamageState: Medium, Heavy, Critical
@@ -1126,6 +1128,7 @@ palace:
 		LongDesc: Elite infantry unit armed with assault rifles and rockets\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery\n  Special Ability: Invisibility
 		Icon: fremen
 		PauseOnCondition: disabled
+		RequiresCondition: atreides
 		Prerequisites: ~techlevel.superweapons, ~palace.fremen
 		Actors: fremen, fremen
 		Type: Palace
@@ -1138,6 +1141,7 @@ palace:
 		LongDesc: Sneaky infantry, armed with explosives\n  Strong vs Buildings\n  Weak vs Everything\n  Special Ability: destroy buildings
 		Icon: saboteur
 		PauseOnCondition: disabled
+		RequiresCondition: ordos
 		Prerequisites: ~techlevel.superweapons, ~palace.saboteur
 		Actors: saboteur
 		Type: Palace
@@ -1156,7 +1160,18 @@ palace:
 		ExitCell: 0,3
 	Production:
 		Produces: Palace
+		RequiresCondition: atreides || ordos
+	GrantConditionOnFaction@Atreides:
+		Condition: atreides
+		Factions: atreides, fremen
+	GrantConditionOnFaction@Harkonnen:
+		Condition: harkonnen
+		Factions: harkonnen
+	GrantConditionOnFaction@Ordos:
+		Condition: ordos
+		Factions: ordos, mercenary, smuggler
 	SupportPowerChargeBar:
+		RequiresCondition: atreides || harkonnen || ordos
 	ProvidesPrerequisite@buildingname:
 
 conyard.atreides:


### PR DESCRIPTION
I tested Harkonnen 9a, no lua crashes.

Without multipile Production: saboteur can come out of Atreides Palace and fremen can come out of Ordos'. Other than that stuff is working as it should.