### PR TITLE
TD APC Change. 20180217

### DIFF
--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -95,6 +95,8 @@ APC:
 		BuildPaletteOrder: 30
 		Prerequisites: pyle
 		Queue: Vehicle.GDI
+		BuildDuration: 900
+		BuildDurationModifier: 40
 		Description: Armed infantry transport.\nCan attack Aircraft.\n  Strong vs Vehicles\n  Weak vs Infantry
 	Mobile:
 		TurnSpeed: 8


### PR DESCRIPTION
Changed the build timer for APCs from 14 seconds to 15 seconds.

An oddity here is that it wasn't exactly on 14 seconds. It was closer to 13.6 seconds.
Changing this to be about 14.8 seconds will help a little from the mass production problem
rather then changing damages or HP further.