### PR TITLE
Fix the carryall freeze and untangle the afterLandActivity mess

### DIFF
--- a/OpenRA.Mods.Common/Activities/DeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverResources.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (self.Location != proc.Location + iao.DeliveryOffset)
 			{
 				foreach (var n in self.TraitsImplementing<INotifyHarvesterAction>())
-					n.MovingToRefinery(self, proc, this);
+					n.MovingToRefinery(self, proc, null);
 
 				return ActivityUtils.SequenceActivities(movement.MoveTo(proc.Location + iao.DeliveryOffset, 0), this);
 			}

--- a/OpenRA.Mods.Common/Activities/DeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverResources.cs
@@ -65,8 +65,7 @@ namespace OpenRA.Mods.Common.Activities
 			self.SetTargetLine(Target.FromActor(proc), Color.Green, false);
 			if (self.Location != proc.Location + iao.DeliveryOffset)
 			{
-				var notify = self.TraitsImplementing<INotifyHarvesterAction>();
-				foreach (var n in notify)
+				foreach (var n in self.TraitsImplementing<INotifyHarvesterAction>())
 					n.MovingToRefinery(self, proc, this);
 
 				return ActivityUtils.SequenceActivities(movement.MoveTo(proc.Location + iao.DeliveryOffset, 0), this);

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -593,6 +593,7 @@
     <Compile Include="UpdateRules\Rules\20180923\MergeCaptureTraits.cs" />
     <Compile Include="UpdateRules\Rules\20180923\RemovedNotifyBuildComplete.cs" />
     <Compile Include="UpdateRules\Rules\20180923\ChangeTakeOffSoundAndLandingSound.cs" />
+    <Compile Include="UpdateRules\Rules\20180923\AddCarryableHarvester.cs" />
     <Compile Include="UtilityCommands\CheckYaml.cs" />
     <Compile Include="UtilityCommands\ConvertPngToShpCommand.cs" />
     <Compile Include="UtilityCommands\ConvertSpriteToPngCommand.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -316,6 +316,7 @@
     <Compile Include="Traits\CaptureProgressBlink.cs" />
     <Compile Include="Traits\RepairsUnits.cs" />
     <Compile Include="Traits\Burns.cs" />
+    <Compile Include="Traits\CarryableHarvester.cs" />
     <Compile Include="Traits\ChangesTerrain.cs" />
     <Compile Include="Traits\CommandBarBlacklist.cs" />
     <Compile Include="Traits\Conditions\GrantExternalConditionToCrusher.cs" />

--- a/OpenRA.Mods.Common/Traits/AutoCarryable.cs
+++ b/OpenRA.Mods.Common/Traits/AutoCarryable.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new AutoCarryable(init.Self, this); }
 	}
 
-	public class AutoCarryable : Carryable, INotifyHarvesterAction, ICallForTransport
+	public class AutoCarryable : Carryable, ICallForTransport
 	{
 		readonly AutoCarryableInfo info;
 		Activity afterLandActivity;
@@ -37,21 +37,6 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		public WDist MinimumDistance { get { return info.MinDistance; } }
-
-		void INotifyHarvesterAction.MovingToResources(Actor self, CPos targetCell, Activity next) { RequestTransport(self, targetCell, next); }
-
-		void INotifyHarvesterAction.MovingToRefinery(Actor self, Actor refineryActor, Activity next)
-		{
-			var iao = refineryActor.Trait<IAcceptResources>();
-			RequestTransport(self, refineryActor.Location + iao.DeliveryOffset, next);
-		}
-
-		void INotifyHarvesterAction.MovementCancelled(Actor self) { MovementCancelled(self); }
-
-		// We do not handle Harvested notification
-		void INotifyHarvesterAction.Harvested(Actor self, ResourceType resource) { }
-		void INotifyHarvesterAction.Docked() { }
-		void INotifyHarvesterAction.Undocked() { }
 
 		// No longer want to be carried
 		void ICallForTransport.MovementCancelled(Actor self) { MovementCancelled(self); }

--- a/OpenRA.Mods.Common/Traits/AutoCarryable.cs
+++ b/OpenRA.Mods.Common/Traits/AutoCarryable.cs
@@ -11,7 +11,6 @@
 
 using System.Linq;
 using OpenRA.Activities;
-using OpenRA.Mods.Common.Activities;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -88,15 +87,7 @@ namespace OpenRA.Mods.Common.Traits
 			Destination = null;
 
 			if (afterLandActivity != null)
-			{
-				// HACK: Harvesters need special treatment to avoid getting stuck on resource fields,
-				// so if a Harvester's afterLandActivity is not DeliverResources, queue a new FindResources activity
-				var findResources = self.Info.HasTraitInfo<HarvesterInfo>() && !(afterLandActivity is DeliverResources);
-				if (findResources)
-					self.QueueActivity(new FindResources(self));
-				else
-					self.QueueActivity(false, afterLandActivity);
-			}
+				self.QueueActivity(false, afterLandActivity);
 
 			base.Detached(self);
 		}

--- a/OpenRA.Mods.Common/Traits/CarryableHarvester.cs
+++ b/OpenRA.Mods.Common/Traits/CarryableHarvester.cs
@@ -1,0 +1,57 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using OpenRA.Activities;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public class CarryableHarvesterInfo : ITraitInfo
+	{
+		public object Create(ActorInitializer init) { return new CarryableHarvester(); }
+	}
+
+	public class CarryableHarvester : INotifyCreated, INotifyHarvesterAction
+	{
+		ICallForTransport[] transports;
+
+		void INotifyCreated.Created(Actor self)
+		{
+			transports = self.TraitsImplementing<ICallForTransport>().ToArray();
+		}
+
+		void INotifyHarvesterAction.MovingToResources(Actor self, CPos targetCell, Activity next)
+		{
+			foreach (var t in transports)
+				t.RequestTransport(self, targetCell, next);
+		}
+
+		void INotifyHarvesterAction.MovingToRefinery(Actor self, Actor refineryActor, Activity next)
+		{
+			var iao = refineryActor.Trait<IAcceptResources>();
+			var location = refineryActor.Location + iao.DeliveryOffset;
+			foreach (var t in transports)
+				t.RequestTransport(self, location, next);
+		}
+
+		void INotifyHarvesterAction.MovementCancelled(Actor self)
+		{
+			foreach (var t in transports)
+				t.MovementCancelled(self);
+		}
+
+		void INotifyHarvesterAction.Harvested(Actor self, ResourceType resource) { }
+		void INotifyHarvesterAction.Docked() { }
+		void INotifyHarvesterAction.Undocked() { }
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -412,7 +412,7 @@ namespace OpenRA.Mods.Common.Traits
 				self.QueueActivity(new DeliverResources(self));
 
 				foreach (var n in notifyHarvesterAction)
-					n.MovingToRefinery(self, targetActor, new DeliverResources(self));
+					n.MovingToRefinery(self, targetActor, null);
 			}
 			else if (order.OrderString == "Stop" || order.OrderString == "Move")
 			{

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				p => ZOffsetFromCenter(self, p, 0)), info.Palette);
 		}
 
-		public void Harvested(Actor self, ResourceType resource)
+		void INotifyHarvesterAction.Harvested(Actor self, ResourceType resource)
 		{
 			if (visible)
 				return;
@@ -59,11 +59,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 			anim.PlayThen(info.Sequence, () => visible = false);
 		}
 
-		public void MovingToResources(Actor self, CPos targetCell, Activity next) { }
-		public void MovingToRefinery(Actor self, Actor targetRefinery, Activity next) { }
-		public void MovementCancelled(Actor self) { }
-		public void Docked() { }
-		public void Undocked() { }
+		void INotifyHarvesterAction.MovingToResources(Actor self, CPos targetCell, Activity next) { }
+		void INotifyHarvesterAction.MovingToRefinery(Actor self, Actor targetRefinery, Activity next) { }
+		void INotifyHarvesterAction.MovementCancelled(Actor self) { }
+		void INotifyHarvesterAction.Docked() { }
+		void INotifyHarvesterAction.Undocked() { }
 
 		public static int ZOffsetFromCenter(Actor self, WPos pos, int offset)
 		{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/AddCarryableHarvester.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/AddCarryableHarvester.cs
@@ -1,0 +1,61 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class AddCarryableHarvester : UpdateRule
+	{
+		public override string Name { get { return "Inform about the 'CarryableHarvester' trait."; } }
+		public override string Description
+		{
+			get
+			{
+				return "A 'CarryableHarvester' trait was added for harvesters that use 'AutoCarryable'.";
+			}
+		}
+
+		bool hasAutoCarryable;
+		readonly List<string> harvesters = new List<string>();
+
+		public override IEnumerable<string> BeforeUpdate(ModData modData)
+		{
+			harvesters.Clear();
+			yield break;
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			if (!hasAutoCarryable)
+				hasAutoCarryable = actorNode.ChildrenMatching("AutoCarryable").Any();
+
+			var harvester = actorNode.LastChildMatching("Harvester");
+			if (harvester != null)
+				harvesters.Add("{0} ({1})".F(actorNode.Key, harvester.Location.Filename));
+
+			yield break;
+		}
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (!hasAutoCarryable || !harvesters.Any())
+				yield break;
+
+			yield return "Detected an 'AutoCarryable' trait.\n" +
+				"Review the following definitions and, if required,\n" +
+				"add the new 'CarryableHarvester' trait.\n" +
+					UpdateUtils.FormatMessageList(harvesters, 1);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -89,6 +89,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 			new UpdatePath("release-20180923", new UpdateRule[]
 			{
 				// Bleed only changes here
+				new AddCarryableHarvester(),
 				new RenameEditorTilesetFilter(),
 				new DefineNotificationDefaults(),
 				new MergeRearmAndRepairAnimation(),

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -73,6 +73,7 @@ harvester:
 		BaleUnloadDelay: 5
 		SearchFromProcRadius: 30
 		SearchFromOrderRadius: 15
+	CarryableHarvester:
 	Health:
 		HP: 45000
 	Armor:


### PR DESCRIPTION
Fixes #14572.
Supersedes #14595.

This PR removes `MovingToResources`, `MovingToRefinery` and `MovementCancelled` from the `INotifyHarvesterAction` interface, as those methods are redundant to what `ICallForTransport` offers.
We also avoid getting stuck in a loop by not creating a new activity and queuing another new one as `landAfterActivity` right afterwards.