### PR TITLE
Remove unused legacy IsWater flag

### DIFF
--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -62,7 +62,6 @@ namespace OpenRA
 		public readonly string Type;
 		public readonly HashSet<string> TargetTypes = new HashSet<string>();
 		public readonly HashSet<string> AcceptsSmudgeType = new HashSet<string>();
-		public readonly bool IsWater = false; // TODO: Remove this
 		public readonly Color Color;
 		public readonly bool RestrictPlayerColor = false;
 		public readonly string CustomCursor;

--- a/OpenRA.Mods.Cnc/UtilityCommands/LegacyTilesetImporter.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/LegacyTilesetImporter.cs
@@ -174,10 +174,7 @@ namespace OpenRA.Mods.Cnc.UtilityCommands
 				metadata.AppendLine("\t\tType: {0}".F(terrainType));
 
 				if (terrainType == "Water")
-				{
 					metadata.AppendLine("\t\tTargetTypes: Water");
-					metadata.AppendLine("\t\tIsWater: True");
-				}
 				else
 					metadata.AppendLine("\t\tTargetTypes: Ground");
 

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -1842,6 +1842,17 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// Removed IsWater.
+				if (engineVersion < 20180222)
+				{
+					if (node.Key == "TerrainType" || node.Key.StartsWith("TerrainType@", StringComparison.Ordinal))
+					{
+						var isWater = node.Value.Nodes.FirstOrDefault(n => n.Key == "IsWater");
+						if (isWater != null)
+							node.Value.Nodes.Remove(isWater);
+					}
+				}
+
 				UpgradeTileset(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 		}

--- a/mods/cnc/tilesets/desert.yaml
+++ b/mods/cnc/tilesets/desert.yaml
@@ -58,7 +58,6 @@ Terrain:
 	TerrainType@Water:
 		Type: Water
 		TargetTypes: Water
-		IsWater: True
 		Color: 5DA5CE
 		RestrictPlayerColor: true
 

--- a/mods/cnc/tilesets/jungle.yaml
+++ b/mods/cnc/tilesets/jungle.yaml
@@ -58,7 +58,6 @@ Terrain:
 	TerrainType@Water:
 		Type: Water
 		TargetTypes: Water
-		IsWater: True
 		Color: 5C74A4
 		RestrictPlayerColor: true
 

--- a/mods/cnc/tilesets/snow.yaml
+++ b/mods/cnc/tilesets/snow.yaml
@@ -58,7 +58,6 @@ Terrain:
 	TerrainType@Water:
 		Type: Water
 		TargetTypes: Water
-		IsWater: True
 		Color: 5C74A4
 		RestrictPlayerColor: true
 

--- a/mods/cnc/tilesets/temperat.yaml
+++ b/mods/cnc/tilesets/temperat.yaml
@@ -58,7 +58,6 @@ Terrain:
 	TerrainType@Water:
 		Type: Water
 		TargetTypes: Water
-		IsWater: True
 		Color: 5C74A4
 		RestrictPlayerColor: true
 

--- a/mods/cnc/tilesets/winter.yaml
+++ b/mods/cnc/tilesets/winter.yaml
@@ -58,7 +58,6 @@ Terrain:
 	TerrainType@Water:
 		Type: Water
 		TargetTypes: Water
-		IsWater: True
 		Color: 5C74A4
 		RestrictPlayerColor: true
 

--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -28,7 +28,6 @@ Terrain:
 	TerrainType@Ice:
 		Type: Ice
 		TargetTypes: Ground
-		IsWater: True
 		Color: FFFFFF
 	TerrainType@Rock:
 		Type: Rock

--- a/mods/ra/tilesets/desert.yaml
+++ b/mods/ra/tilesets/desert.yaml
@@ -67,7 +67,6 @@ Terrain:
 	TerrainType@Water:
 		Type: Water
 		TargetTypes: Water
-		IsWater: True
 		Color: 5DA5CE
 		RestrictPlayerColor: true
 

--- a/mods/ra/tilesets/snow.yaml
+++ b/mods/ra/tilesets/snow.yaml
@@ -63,7 +63,6 @@ Terrain:
 	TerrainType@Water:
 		Type: Water
 		TargetTypes: Water
-		IsWater: True
 		Color: 5C74A4
 		RestrictPlayerColor: true
 

--- a/mods/ra/tilesets/temperat.yaml
+++ b/mods/ra/tilesets/temperat.yaml
@@ -64,7 +64,6 @@ Terrain:
 	TerrainType@Water:
 		Type: Water
 		TargetTypes: Water
-		IsWater: True
 		Color: 5C74A4
 		RestrictPlayerColor: true
 

--- a/mods/ts/tilesets/snow.yaml
+++ b/mods/ts/tilesets/snow.yaml
@@ -34,7 +34,6 @@ Terrain:
 		Type: Water
 		Color: 3D4148
 		TargetTypes: Water
-		IsWater: True
 		RestrictPlayerColor: true
 	TerrainType@DirtRoad:
 		Type: DirtRoad

--- a/mods/ts/tilesets/temperate.yaml
+++ b/mods/ts/tilesets/temperate.yaml
@@ -34,7 +34,6 @@ Terrain:
 		Type: Water
 		Color: 745537
 		TargetTypes: Water
-		IsWater: True
 		RestrictPlayerColor: true
 	TerrainType@DirtRoad:
 		Type: DirtRoad


### PR DESCRIPTION
This is no longer used by any code (last place using it was `CreateEffectWarhead`, until it was refactored to use TargetTypes instead).