### PR TITLE
(TD) Add Bridge to TerrainType

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -217,6 +217,7 @@
 			Clear: 80
 			Rough: 50
 			Road: 100
+			Bridge: 100
 			Tiberium: 50
 			BlueTiberium: 50
 			Beach: 50
@@ -260,6 +261,7 @@
 			Clear: 80
 			Rough: 70
 			Road: 100
+			Bridge: 100
 			Tiberium: 70
 			BlueTiberium: 70
 			Beach: 70
@@ -338,6 +340,7 @@
 			Clear: 90
 			Rough: 80
 			Road: 100
+			Bridge: 100
 			Tiberium: 70
 				PathingCost: 300
 			BlueTiberium: 70

--- a/mods/cnc/tilesets/desert.yaml
+++ b/mods/cnc/tilesets/desert.yaml
@@ -16,6 +16,11 @@ Terrain:
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 54FCFC
 		RestrictPlayerColor: true
+	TerrainType@Bridge:
+		Type: Bridge
+		TargetTypes: Ground
+		AcceptsSmudgeType: Crater, Scorch
+		Color: 606060
 	TerrainType@Clear:
 		Type: Clear
 		TargetTypes: Ground
@@ -1601,12 +1606,12 @@ Templates:
 			6: Clear
 			7: Rock
 			8: Wall
-			9: Road
+			9: Bridge
 			10: Wall
 			11: Clear
 			12: River
 			13: River
-			14: Road
+			14: Bridge
 			15: Wall
 			16: Rock
 			17: Rock
@@ -1659,14 +1664,14 @@ Templates:
 			5: Clear
 			6: Clear
 			7: Wall
-			8: Road
+			8: Bridge
 			9: Wall
 			10: River
 			11: River
 			12: Rock
 			13: River
 			14: Wall
-			15: Road
+			15: Bridge
 			16: Wall
 			17: Rock
 			18: River

--- a/mods/cnc/tilesets/jungle.yaml
+++ b/mods/cnc/tilesets/jungle.yaml
@@ -16,6 +16,11 @@ Terrain:
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 54FCFC
 		RestrictPlayerColor: true
+	TerrainType@Bridge:
+		Type: Bridge
+		TargetTypes: Ground, Bridge
+		AcceptsSmudgeType: Crater, Scorch
+		Color: 606060
 	TerrainType@Clear:
 		Type: Clear
 		TargetTypes: Ground
@@ -1624,10 +1629,10 @@ Templates:
 			3: Road
 			4: River
 			5: Wall
-			6: Road
+			6: Bridge
 			7: Wall
 			8: River
-			9: Road
+			9: Bridge
 			10: Wall
 			11: River
 			12: Road
@@ -1665,13 +1670,13 @@ Templates:
 			2: Clear
 			4: Clear
 			5: Wall
-			6: Road
+			6: Bridge
 			7: Wall
 			8: River
 			9: River
 			10: River
 			11: Wall
-			12: Road
+			12: Bridge
 			13: Wall
 			14: Clear
 			15: River

--- a/mods/cnc/tilesets/snow.yaml
+++ b/mods/cnc/tilesets/snow.yaml
@@ -16,6 +16,11 @@ Terrain:
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 54FCFC
 		RestrictPlayerColor: true
+	TerrainType@Bridge:
+		Type: Bridge
+		TargetTypes: Ground
+		AcceptsSmudgeType: Crater, Scorch
+		Color: 606060
 	TerrainType@Clear:
 		Type: Clear
 		TargetTypes: Ground
@@ -1636,10 +1641,10 @@ Templates:
 			3: Road
 			4: River
 			5: Wall
-			6: Road
+			6: Bridge
 			7: Wall
 			8: River
-			9: Road
+			9: Bridge
 			10: Wall
 			11: River
 			12: Road
@@ -1677,13 +1682,13 @@ Templates:
 			2: Clear
 			4: Clear
 			5: Wall
-			6: Road
+			6: Bridge
 			7: Wall
 			8: River
 			9: River
 			10: River
 			11: Wall
-			12: Road
+			12: Bridge
 			13: Wall
 			14: Clear
 			15: River

--- a/mods/cnc/tilesets/temperat.yaml
+++ b/mods/cnc/tilesets/temperat.yaml
@@ -16,6 +16,11 @@ Terrain:
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 54FCFC
 		RestrictPlayerColor: true
+	TerrainType@Bridge:
+		Type: Bridge
+		TargetTypes: Ground, Bridge
+		AcceptsSmudgeType: Crater, Scorch
+		Color: 606060
 	TerrainType@Clear:
 		Type: Clear
 		TargetTypes: Ground
@@ -1624,10 +1629,10 @@ Templates:
 			3: Road
 			4: River
 			5: Wall
-			6: Road
+			6: Bridge
 			7: Wall
 			8: River
-			9: Road
+			9: Bridge
 			10: Wall
 			11: River
 			12: Road
@@ -1665,13 +1670,13 @@ Templates:
 			2: Clear
 			4: Clear
 			5: Wall
-			6: Road
+			6: Bridge
 			7: Wall
 			8: River
 			9: River
 			10: River
 			11: Wall
-			12: Road
+			12: Bridge
 			13: Wall
 			14: Clear
 			15: River

--- a/mods/cnc/tilesets/winter.yaml
+++ b/mods/cnc/tilesets/winter.yaml
@@ -16,6 +16,11 @@ Terrain:
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 54FCFC
 		RestrictPlayerColor: true
+	TerrainType@Bridge:
+		Type: Bridge
+		TargetTypes: Ground, Bridge
+		AcceptsSmudgeType: Crater, Scorch
+		Color: 606060
 	TerrainType@Clear:
 		Type: Clear
 		TargetTypes: Ground
@@ -1608,10 +1613,10 @@ Templates:
 			3: Road
 			4: River
 			5: Wall
-			6: Road
+			6: Bridge
 			7: Wall
 			8: River
-			9: Road
+			9: Bridge
 			10: Wall
 			11: River
 			12: Road
@@ -1649,13 +1654,13 @@ Templates:
 			2: Clear
 			4: Clear
 			5: Wall
-			6: Road
+			6: Bridge
 			7: Wall
 			8: River
 			9: River
 			10: River
 			11: Wall
-			12: Road
+			12: Bridge
 			13: Wall
 			14: Clear
 			15: River


### PR DESCRIPTION
This prevents players from blocking bridges with defense structures or sandbags.

Closes #14258