### PR TITLE
Add WithTurretAimAnimation and remove WithSpriteTurret.AimSequence

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -423,6 +423,7 @@
     <Compile Include="Traits\Render\RenderSpritesEditorOnly.cs" />
     <Compile Include="Traits\Render\WithTurretAttackAnimation.cs" />
     <Compile Include="Traits\Render\WithAcceptDeliveredCashAnimation.cs" />
+    <Compile Include="Traits\Render\WithTurretAimAnimation.cs" />
     <Compile Include="Traits\Render\RenderUtils.cs" />
     <Compile Include="Traits\Render\RenderDebugState.cs" />
     <Compile Include="Traits\Render\RenderNameTag.cs" />

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -25,9 +25,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "turret";
 
-		[Desc("Sequence name to use when prepared to fire")]
-		[SequenceReference] public readonly string AimSequence = null;
-
 		[Desc("Turreted 'Turret' key to display")]
 		public readonly string Turret = "primary";
 
@@ -62,10 +59,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	public class WithSpriteTurret : ConditionalTrait<WithSpriteTurretInfo>, INotifyBuildComplete, INotifySold, INotifyTransform, ITick, INotifyDamageStateChanged
+	public class WithSpriteTurret : ConditionalTrait<WithSpriteTurretInfo>, INotifyBuildComplete, INotifySold, INotifyTransform, INotifyDamageStateChanged
 	{
 		public readonly Animation DefaultAnimation;
-		protected readonly AttackBase Attack;
 		readonly RenderSprites rs;
 		readonly BodyOrientation body;
 		readonly Turreted t;
@@ -79,7 +75,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			rs = self.Trait<RenderSprites>();
 			body = self.Trait<BodyOrientation>();
-			Attack = self.TraitOrDefault<AttackBase>();
 			t = self.TraitsImplementing<Turreted>()
 				.First(tt => tt.Name == info.Turret);
 			arms = self.TraitsImplementing<Armament>()
@@ -119,24 +114,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 				DefaultAnimation.ReplaceAnim(NormalizeSequence(self, DefaultAnimation.CurrentSequence.Name));
 		}
 
-		protected virtual void Tick(Actor self)
-		{
-			if (Info.AimSequence == null)
-				return;
-
-			var sequence = Attack.IsAiming ? Info.AimSequence : Info.Sequence;
-			DefaultAnimation.ReplaceAnim(sequence);
-		}
-
 		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
 		{
 			DamageStateChanged(self);
-		}
-
-		void ITick.Tick(Actor self)
-		{
-			// Split into a protected method to allow subclassing
-			Tick(self);
 		}
 
 		public void PlayCustomAnimation(Actor self, string name, Action after = null)

--- a/OpenRA.Mods.Common/Traits/Render/WithTurretAimAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurretAimAnimation.cs
@@ -1,0 +1,68 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits.Render
+{
+	public class WithTurretAimAnimationInfo : ITraitInfo, Requires<WithSpriteTurretInfo>, Requires<ArmamentInfo>, Requires<AttackBaseInfo>
+	{
+		[Desc("Armament name")]
+		public readonly string Armament = "primary";
+
+		[Desc("Turret name")]
+		public readonly string Turret = "primary";
+
+		[Desc("Displayed while targeting.")]
+		[SequenceReference] public readonly string Sequence = null;
+
+		[Desc("Shown while reloading.")]
+		[SequenceReference(null, true)] public readonly string ReloadPrefix = null;
+
+		public object Create(ActorInitializer init) { return new WithTurretAimAnimation(init, this); }
+	}
+
+	public class WithTurretAimAnimation : ITick
+	{
+		readonly WithTurretAimAnimationInfo info;
+		readonly AttackBase attack;
+		readonly Armament armament;
+		readonly WithSpriteTurret wst;
+
+		public WithTurretAimAnimation(ActorInitializer init, WithTurretAimAnimationInfo info)
+		{
+			this.info = info;
+			attack = init.Self.Trait<AttackBase>();
+			armament = init.Self.TraitsImplementing<Armament>()
+				.Single(a => a.Info.Name == info.Armament);
+			wst = init.Self.TraitsImplementing<WithSpriteTurret>()
+				.Single(st => st.Info.Turret == info.Turret);
+		}
+
+		void ITick.Tick(Actor self)
+		{
+			if (string.IsNullOrEmpty(info.Sequence) && string.IsNullOrEmpty(info.ReloadPrefix))
+				return;
+
+			var sequence = wst.Info.Sequence;
+			if (!string.IsNullOrEmpty(info.Sequence) && attack.IsAiming)
+				sequence = info.Sequence;
+
+			var prefix = (armament.IsReloading && !string.IsNullOrEmpty(info.ReloadPrefix)) ? info.ReloadPrefix : "";
+
+			if (!string.IsNullOrEmpty(prefix) && sequence != (prefix + sequence))
+				sequence = prefix + sequence;
+
+			wst.DefaultAnimation.ReplaceAnim(sequence);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Render/WithTurretAttackAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurretAttackAnimation.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
 {
-	public class WithTurretAttackAnimationInfo : ITraitInfo, Requires<WithSpriteTurretInfo>, Requires<ArmamentInfo>, Requires<AttackBaseInfo>
+	public class WithTurretAttackAnimationInfo : ITraitInfo, Requires<WithSpriteTurretInfo>, Requires<ArmamentInfo>
 	{
 		[Desc("Armament name")]
 		public readonly string Armament = "primary";
@@ -23,13 +23,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly string Turret = "primary";
 
 		[Desc("Displayed while attacking.")]
-		[SequenceReference] public readonly string AttackSequence = null;
-
-		[Desc("Displayed while targeting.")]
-		[SequenceReference] public readonly string AimSequence = null;
-
-		[Desc("Shown while reloading.")]
-		[SequenceReference(null, true)] public readonly string ReloadPrefix = null;
+		[SequenceReference] public readonly string Sequence = null;
 
 		[Desc("Delay in ticks before animation starts, either relative to attack preparation or attack.")]
 		public readonly int Delay = 0;
@@ -43,8 +37,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 	public class WithTurretAttackAnimation : ITick, INotifyAttack
 	{
 		readonly WithTurretAttackAnimationInfo info;
-		readonly AttackBase attack;
-		readonly Armament armament;
 		readonly WithSpriteTurret wst;
 
 		int tick;
@@ -52,21 +44,21 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public WithTurretAttackAnimation(ActorInitializer init, WithTurretAttackAnimationInfo info)
 		{
 			this.info = info;
-			attack = init.Self.Trait<AttackBase>();
-			armament = init.Self.TraitsImplementing<Armament>()
-				.Single(a => a.Info.Name == info.Armament);
 			wst = init.Self.TraitsImplementing<WithSpriteTurret>()
 				.Single(st => st.Info.Turret == info.Turret);
 		}
 
 		void PlayAttackAnimation(Actor self)
 		{
-			if (!string.IsNullOrEmpty(info.AttackSequence))
-				wst.PlayCustomAnimation(self, info.AttackSequence);
+			if (!string.IsNullOrEmpty(info.Sequence))
+				wst.PlayCustomAnimation(self, info.Sequence);
 		}
 
 		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel)
 		{
+			if (a.Info.Name != info.Armament)
+				return;
+
 			if (info.DelayRelativeTo == AttackDelayType.Attack)
 			{
 				if (info.Delay > 0)
@@ -78,6 +70,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel)
 		{
+			if (a.Info.Name != info.Armament)
+				return;
+
 			if (info.DelayRelativeTo == AttackDelayType.Preparation)
 			{
 				if (info.Delay > 0)
@@ -91,20 +86,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			if (info.Delay > 0 && --tick == 0)
 				PlayAttackAnimation(self);
-
-			if (string.IsNullOrEmpty(info.AimSequence) && string.IsNullOrEmpty(info.ReloadPrefix))
-				return;
-
-			var sequence = wst.Info.Sequence;
-			if (!string.IsNullOrEmpty(info.AimSequence) && attack.IsAiming)
-				sequence = info.AimSequence;
-
-			var prefix = (armament.IsReloading && !string.IsNullOrEmpty(info.ReloadPrefix)) ? info.ReloadPrefix : "";
-
-			if (!string.IsNullOrEmpty(prefix) && sequence != (prefix + sequence))
-				sequence = prefix + sequence;
-
-			wst.DefaultAnimation.ReplaceAnim(sequence);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -1756,6 +1756,24 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				// Removed AimSequence from WithSpriteTurret, use WithTurretAimAnimation instead
+				if (engineVersion < 20180224)
+				{
+					var spriteTurret = node.Value.Nodes.FirstOrDefault(n => n.Key.StartsWith("WithSpriteTurret", StringComparison.Ordinal));
+					if (spriteTurret != null)
+					{
+						var aimSequence = spriteTurret.Value.Nodes.FirstOrDefault(n => n.Key == "AimSequence");
+						if (aimSequence != null)
+						{
+							var aimAnim = new MiniYamlNode("WithTurretAimAnimation", "");
+							RenameNodeKey(aimSequence, "Sequence");
+							aimAnim.Value.Nodes.Add(aimSequence);
+							spriteTurret.Value.Nodes.Remove(aimSequence);
+							node.Value.Nodes.Add(aimAnim);
+						}
+					}
+				}
+
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -1710,7 +1710,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				}
 
 				// Split aim animation logic from WithTurretAttackAnimation to separate WithTurretAimAnimation
-				if (engineVersion < 20180223)
+				if (engineVersion < 20180309)
 				{
 					var turAttackAnim = node.Value.Nodes.FirstOrDefault(n => n.Key.StartsWith("WithTurretAttackAnimation", StringComparison.Ordinal));
 					if (turAttackAnim != null)
@@ -1757,7 +1757,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				}
 
 				// Removed AimSequence from WithSpriteTurret, use WithTurretAimAnimation instead
-				if (engineVersion < 20180224)
+				if (engineVersion < 20180309)
 				{
 					var spriteTurret = node.Value.Nodes.FirstOrDefault(n => n.Key.StartsWith("WithSpriteTurret", StringComparison.Ordinal));
 					if (spriteTurret != null)

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -496,15 +496,17 @@ MSAM:
 		Weapon: 227mm
 		LocalOffset: 213,128,0, 213,-128,0
 	Armament@SECONDARY:
+		Name: secondary
 		Weapon: 227mm
 		LocalOffset: 213,-128,0, 213,128,0
 	AttackFrontal:
 	WithSpriteTurret:
-		AimSequence: aim
 	SpawnActorOnDeath:
 		Actor: MSAM.Husk
 		OwnerType: InternalName
 		EffectiveOwnerFromOwner: true
+	WithTurretAimAnimation:
+		Sequence: aim
 
 MLRS:
 	Inherits: ^Tank


### PR DESCRIPTION
`AimSequence` and `AttackSequence` on `WithTurretAttackAnimation` actually conflicted with each other when used at the same time, so splitting them is the sensible thing to do.

Additionally, with this the `AimSequence` on `WithSpriteTurret` becomes redundant, allowing us to remove it and simplify `WithSpriteTurret`'s code.

Testcase: Check that TD MLRS/Rocket Launcher still correctly raises turret before firing.

Split from #14036.