### PR TITLE
Allows GDI-Turrets, GDI- and Nod-Gates to be placed on walls.

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -474,6 +474,8 @@
     <Compile Include="Traits\Repairable.cs" />
     <Compile Include="Traits\RepairableNear.cs" />
     <Compile Include="Traits\RepairsBridges.cs" />
+    <Compile Include="Traits\Replaceable.cs" />
+    <Compile Include="Traits\Replacement.cs" />
     <Compile Include="Traits\SeedsResource.cs" />
     <Compile Include="Traits\StoresResources.cs" />
     <Compile Include="Traits\Render\SelectionDecorations.cs" />

--- a/OpenRA.Mods.Common/Traits/Replaceable.cs
+++ b/OpenRA.Mods.Common/Traits/Replaceable.cs
@@ -1,0 +1,44 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Primitives;
+using OpenRA.Support;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public class ReplaceableInfo : ITraitInfo
+	{
+		// TODO: Currently a Replacement can only replace one Type of Replaceable. Implement possibility for a as in Pluggable
+		[FieldLoader.Require]
+		[Desc("Identifyer for this replaceable Actor (matched against Types in Replacement)")]
+		public readonly string Type = null;
+
+		public object Create(ActorInitializer init) { return new Replaceable(init, this); }
+	}
+
+	public class Replaceable
+	{
+		public readonly ReplaceableInfo Info;
+
+		public Replaceable(ActorInitializer init, ReplaceableInfo info)
+		{
+			this.Info = info;
+		}
+
+		public bool AcceptsReplacement(Actor self, string replaces)
+		{
+			return Info.Type.Equals(replaces);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Replacement.cs
+++ b/OpenRA.Mods.Common/Traits/Replacement.cs
@@ -1,0 +1,24 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public class ReplacementInfo : TraitInfo<Replacement>
+	{
+		[FieldLoader.Require]
+		[Desc("Replaceable 'Type'(s) this Actor can replace")]
+		public readonly string Replaces = null;
+	}
+
+	public class Replacement {	}
+}

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -16,6 +16,8 @@ GAWALL:
 		CrushClasses: heavywall
 	LineBuild:
 		NodeTypes: wall, turret
+	Replaceable:
+		Type: wall
 
 GAGATE_A:
 	Inherits: ^Gate_A
@@ -25,6 +27,8 @@ GAGATE_A:
 		Prerequisites: gapile, ~structures.gdi, ~techlevel.low
 	Tooltip:
 		Name: GDI Gate
+	Replacement:
+		Replaces: wall
 
 GAGATE_B:
 	Inherits: ^Gate_B
@@ -34,6 +38,8 @@ GAGATE_B:
 		Prerequisites: gapile, ~structures.gdi, ~techlevel.low
 	Tooltip:
 		Name: GDI Gate
+	Replacement:
+		Replaces: wall
 
 GACTWR:
 	Inherits: ^Defense
@@ -128,6 +134,8 @@ GACTWR:
 			tower.sam: tower.sam
 	ProvidesPrerequisite@buildingname:
 	SelectionDecorations:
+	Replacement:
+		Replaces: wall
 
 GAVULC:
 	Inherits: ^BuildingPlug

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -16,6 +16,8 @@ NAWALL:
 		CrushClasses: heavywall
 	LineBuild:
 		NodeTypes: wall, turret
+	Replaceable:
+		Type: wall
 
 NAGATE_A:
 	Inherits: ^Gate_A
@@ -25,6 +27,8 @@ NAGATE_A:
 		Prerequisites: nahand, ~structures.nod, ~techlevel.low
 	Tooltip:
 		Name: Nod Gate
+	Replacement:
+		Replaces: wall
 
 NAGATE_B:
 	Inherits: ^Gate_B
@@ -34,6 +38,8 @@ NAGATE_B:
 		Prerequisites: nahand, ~structures.nod, ~techlevel.low
 	Tooltip:
 		Name: Nod Gate
+	Replacement:
+		Replaces: wall
 
 NAPOST:
 	Inherits: ^Building


### PR DESCRIPTION
Allows GDI-Turrets, GDI- and Nod-Gates to replace walls by implementing traits `Replaceable` and `Replacement`.


ToDo:
- After placing a turret on a wall it's not possible to attach a plug. I do not know where that bug cames from.
- Allow `Replacement` to replace more than one `Replaceable` type (by changing accepting more items)

![unbenannt](https://user-images.githubusercontent.com/25386322/36609461-2c6af6a2-18cd-11e8-9c4e-d24cd1b921ab.JPG)
_Gates and Turrets built on walls._

Thankful for any feedback : )

Closes #12088 