### PR TITLE
Color picker update with team color presets

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -161,6 +161,7 @@ namespace OpenRA
 		public string Name = "Newbie";
 		public HSLColor Color = new HSLColor(75, 255, 180);
 		public string LastServer = "localhost:1234";
+		public HSLColor[] CustomColors = { };
 	}
 
 	public class GameSettings

--- a/OpenRA.Mods.Common/ColorValidator.cs
+++ b/OpenRA.Mods.Common/ColorValidator.cs
@@ -24,6 +24,7 @@ namespace OpenRA.Mods.Common
 		public readonly int Threshold = 0x50;
 		public readonly float[] HsvSaturationRange = new[] { 0.25f, 1f };
 		public readonly float[] HsvValueRange = new[] { 0.2f, 1.0f };
+		public readonly HSLColor[] TeamColorPresets = { };
 
 		double GetColorDelta(Color colorA, Color colorB)
 		{
@@ -86,6 +87,20 @@ namespace OpenRA.Mods.Common
 			return true;
 		}
 
+		public HSLColor RandomPresetColor(MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors)
+		{
+			if (TeamColorPresets.Any())
+			{
+				Color forbidden;
+				Action<string> ignoreError = _ => { };
+				foreach (var c in TeamColorPresets.Shuffle(random))
+					if (IsValid(c.RGB, out forbidden, terrainColors, playerColors, ignoreError))
+						return c;
+			}
+
+			return RandomValidColor(random, terrainColors, playerColors);
+		}
+
 		public HSLColor RandomValidColor(MersenneTwister random, IEnumerable<Color> terrainColors, IEnumerable<Color> playerColors)
 		{
 			HSLColor color;
@@ -142,7 +157,7 @@ namespace OpenRA.Mods.Common
 				// If we reached the limit (The ii >= 255 prevents too much calculations)
 				if (attempt >= 255)
 				{
-					color = RandomValidColor(random, terrainColors, playerColors);
+					color = RandomPresetColor(random, terrainColors, playerColors);
 					break;
 				}
 

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -321,7 +321,7 @@ namespace OpenRA.Mods.Common.Server
 							var terrainColors = tileset.TerrainInfo.Where(ti => ti.RestrictPlayerColor).Select(ti => ti.Color);
 							var playerColors = server.LobbyInfo.Clients.Select(c => c.Color.RGB)
 								.Concat(server.Map.Players.Players.Values.Select(p => p.Color.RGB));
-							bot.Color = bot.PreferredColor = validator.RandomValidColor(server.Random, terrainColors, playerColors);
+							bot.Color = bot.PreferredColor = validator.RandomPresetColor(server.Random, terrainColors, playerColors);
 
 							server.LobbyInfo.Clients.Add(bot);
 						}

--- a/OpenRA.Mods.Common/Widgets/ColorBlockWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ColorBlockWidget.cs
@@ -19,6 +19,9 @@ namespace OpenRA.Mods.Common.Widgets
 	{
 		public Func<Color> GetColor;
 
+		public Action<MouseInput> OnMouseDown = _ => { };
+		public Action<MouseInput> OnMouseUp = _ => { };
+
 		public ColorBlockWidget()
 		{
 			GetColor = () => Color.White;
@@ -38,6 +41,31 @@ namespace OpenRA.Mods.Common.Widgets
 		public override void Draw()
 		{
 			WidgetUtils.FillRectWithColor(RenderBounds, GetColor());
+		}
+
+		public override bool HandleMouseInput(MouseInput mi)
+		{
+			if (mi.Button != MouseButton.Left)
+				return false;
+
+			if (mi.Event == MouseInputEvent.Down && !TakeMouseFocus(mi))
+				return false;
+
+			if (HasMouseFocus && mi.Event == MouseInputEvent.Up)
+			{
+				// Only fire the onMouseUp event if we successfully lost focus, and were pressed
+				OnMouseUp(mi);
+
+				return YieldMouseFocus(mi);
+			}
+
+			if (mi.Event == MouseInputEvent.Down)
+			{
+				// OnMouseDown returns false if the button shouldn't be pressed
+				OnMouseDown(mi);
+			}
+
+			return false;
 		}
 	}
 }

--- a/mods/cnc/chrome/color-picker.yaml
+++ b/mods/cnc/chrome/color-picker.yaml
@@ -1,44 +1,138 @@
 Background@COLOR_CHOOSER:
 	Logic: ColorPickerLogic
+		PaletteColumns: 8
+		PalettePresetRows: 2
+		PaletteCustomRows: 1
 	Background: panel-black
 	Width: 311
-	Height: 140
+	Height: 148
 	Children:
 		Button@RANDOM_BUTTON:
 			Key: tab
-			X: 235
-			Y: 109
-			Width: 70
+			X: 229
+			Y: 89
+			Width: 77
 			Height: 25
 			Text: Random
-		Background@HUEBG:
+		Button@STORE_BUTTON:
+			X: 229
+			Y: 118
+			Width: 77
+			Height: 25
+			Text: Store
+			Font: Bold
+		ActorPreview@PREVIEW:
+			X: 232
+			Y: 7
+			Width: 77
+			Height: 73
+			Animate: true
+		Button@MIXER_TAB_BUTTON:
+			X: 5
+			Y: PARENT_BOTTOM - 30
+			Height: 25
+			Width: 80
+			Text: Mixer
+			Font: Bold
+		Button@PALETTE_TAB_BUTTON:
+			X: 90
+			Y: PARENT_BOTTOM - 30
+			Height: 25
+			Width: 80
+			Text: Palette
+			Font: Bold
+		Container@MIXER_TAB:
+			X: 5
+			Y: 5
+			Width: PARENT_RIGHT - 91
+			Height: PARENT_BOTTOM - 34
+			Children:
+				Background@HUEBG:
+					Background: panel-black
+					X: 0
+					Y: 0
+					Width: PARENT_RIGHT
+					Height: 17
+					Children:
+						HueSlider@HUE:
+							X: 2
+							Y: 2
+							Width: PARENT_RIGHT - 4
+							Height: PARENT_BOTTOM - 4
+							Ticks: 5
+				Background@MIXERBG:
+					Background: panel-black
+					X: 0
+					Y: 22
+					Width: PARENT_RIGHT
+					Height: 92
+					Children:
+						ColorMixer@MIXER:
+							X: 2
+							Y: 2
+							Width: PARENT_RIGHT - 4
+							Height: PARENT_BOTTOM - 4
+		Background@PALETTE_TAB:
 			Background: panel-black
 			X: 5
 			Y: 5
-			Width: 225
-			Height: 17
+			Width: PARENT_RIGHT - 91
+			Height: PARENT_BOTTOM - 34
+			Visible: false
 			Children:
-				HueSlider@HUE:
-					X: 2
-					Y: 2
-					Width: PARENT_RIGHT - 4
-					Height: PARENT_BOTTOM - 4
-					Ticks: 5
-		Background@MIXERBG:
-			Background: panel-black
-			X: 5
-			Y: 27
-			Width: 225
-			Height: 107
-			Children:
-				ColorMixer@MIXER:
-					X: 2
-					Y: 2
-					Width: PARENT_RIGHT - 4
-					Height: PARENT_BOTTOM - 4
-		ActorPreview@PREVIEW:
-			X: 230
-			Y: 21
-			Width: 80
-			Height: 73
-			Animate: true
+				Container@PALETTE_TAB_PANEL:
+					X: 0
+					Y: 0
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
+					Children:
+						Background@PRESET_HEADER:
+							Background: panel-black
+							Width: PARENT_RIGHT - 4
+							Height: 13
+							X: 2
+							Y: 2
+							Children:
+								Label@LABEL:
+									Font: TinyBold
+									Width: PARENT_RIGHT
+									Height: 10
+									Align: Center
+									Text: Preset Colors
+						Container@PRESET_AREA:
+							Width: PARENT_RIGHT - 4
+							Height: 58
+							X: 2
+							Y: 16
+							Children:
+								ColorBlock@COLORPRESET:
+									X: 0
+									Y: 0
+									Width: 27
+									Height: 27
+									Visible: false
+						Background@CUSTOM_HEADER:
+							Background: panel-black
+							Width: PARENT_RIGHT - 4
+							Height: 13
+							X: 2
+							Y: 71
+							Children:
+								Label@LABEL:
+									Font: TinyBold
+									Width: PARENT_RIGHT
+									Height: 10
+									Align: Center
+									Text: Custom Colors
+						Container@CUSTOM_AREA:
+							Width: PARENT_RIGHT - 4
+							Height: 31
+							X: 2
+							Y: 85
+							Children:
+								ColorBlock@COLORCUSTOM:
+									X: 0
+									Y: 0
+									Width: 27
+									Height: 27
+									Visible: false

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -235,6 +235,7 @@ GameSpeeds:
 		OrderLatency: 6
 
 ColorValidator:
+	TeamColorPresets: f70606, ff7a22, f8d3b3, f8e947, b6f706, f335a0, a64d6c, ce08f9, f5b2db, 12b572, 380135, 1d06f7, 328dff, 78dbf8, cef6b1, 000000
 
 ModContent:
 	InstallPromptMessage: Tiberian Dawn requires artwork and audio from the original game.\n\nQuick Install will automatically download this content (without music\nor videos) from a mirror of the 2007 C&C Gold freeware release.\n\nAdvanced Install includes options for downloading the music and for\ncopying the videos and other content from an original game disc.

--- a/mods/common/chrome/color-picker.yaml
+++ b/mods/common/chrome/color-picker.yaml
@@ -1,44 +1,138 @@
 Background@COLOR_CHOOSER:
 	Logic: ColorPickerLogic
+		PaletteColumns: 8
+		PalettePresetRows: 2
+		PaletteCustomRows: 1
 	Background: dialog2
 	Width: 326
-	Height: 140
+	Height: 154
 	Children:
 		Button@RANDOM_BUTTON:
 			Key: tab
-			X: 250
-			Y: 109
-			Width: 70
+			X: 245
+			Y: 95
+			Width: 76
 			Height: 25
 			Text: Random
 			Font: Bold
-		Background@HUEBG:
+		Button@STORE_BUTTON:
+			X: 245
+			Y: 124
+			Width: 76
+			Height: 25
+			Text: Store
+			Font: Bold
+		ActorPreview@PREVIEW:
+			X: 245
+			Y: 13
+			Width: 76
+			Height: 73
+		Button@MIXER_TAB_BUTTON:
+			X: 5
+			Y: PARENT_BOTTOM - 30
+			Height: 25
+			Width: 80
+			Text: Mixer
+			Font: Bold
+		Button@PALETTE_TAB_BUTTON:
+			X: 85
+			Y: PARENT_BOTTOM - 30
+			Height: 25
+			Width: 80
+			Text: Palette
+			Font: Bold
+		Container@MIXER_TAB:
+			X: 5
+			Y: 5
+			Width: PARENT_RIGHT - 90
+			Height: PARENT_BOTTOM - 34
+			Children:
+				Background@HUEBG:
+					Background: dialog3
+					X: 0
+					Y: 0
+					Width: PARENT_RIGHT
+					Height: 17
+					Children:
+						HueSlider@HUE:
+							X: 2
+							Y: 2
+							Width: PARENT_RIGHT - 4
+							Height: PARENT_BOTTOM - 4
+							Ticks: 5
+				Background@MIXERBG:
+					Background: dialog3
+					X: 0
+					Y: 22
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM - 22
+					Children:
+						ColorMixer@MIXER:
+							X: 2
+							Y: 2
+							Width: PARENT_RIGHT - 4
+							Height: PARENT_BOTTOM - 4
+		Background@PALETTE_TAB:
 			Background: dialog3
 			X: 5
 			Y: 5
-			Width: 240
-			Height: 17
+			Width: PARENT_RIGHT - 90
+			Height: PARENT_BOTTOM - 34
+			Visible: false
 			Children:
-				HueSlider@HUE:
-					X: 2
-					Y: 2
-					Width: PARENT_RIGHT - 4
-					Height: PARENT_BOTTOM - 4
-					Ticks: 5
-		Background@MIXERBG:
-			Background: dialog3
-			X: 5
-			Y: 27
-			Width: 240
-			Height: 107
-			Children:
-				ColorMixer@MIXER:
-					X: 2
-					Y: 2
-					Width: PARENT_RIGHT - 4
-					Height: PARENT_BOTTOM - 4
-		ActorPreview@PREVIEW:
-			X: 245
-			Y: 21
-			Width: 80
-			Height: 73
+				Container@PALETTE_TAB_PANEL:
+					X: 0
+					Y: 0
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
+					Children:
+						Background@PRESET_HEADER:
+							Background: dialog2
+							Width: PARENT_RIGHT - 4
+							Height: 13
+							X: 2
+							Y: 2
+							Children:
+								Label@LABEL:
+									Font: TinyBold
+									Width: PARENT_RIGHT
+									Height: 10
+									Align: Center
+									Text: Preset Colors
+						Container@PRESET_AREA:
+							Width: PARENT_RIGHT - 4
+							Height: 58
+							X: 2
+							Y: 16
+							Children:
+								ColorBlock@COLORPRESET:
+									X: 0
+									Y: 0
+									Width: 29
+									Height: 29
+									Visible: false
+						Background@CUSTOM_HEADER:
+							Background: dialog2
+							Width: PARENT_RIGHT - 4
+							Height: 13
+							X: 2
+							Y: 75
+							Children:
+								Label@LABEL:
+									Font: TinyBold
+									Width: PARENT_RIGHT
+									Height: 10
+									Align: Center
+									Text: Custom Colors
+						Container@CUSTOM_AREA:
+							Width: PARENT_RIGHT - 4
+							Height: 31
+							X: 2
+							Y: 89
+							Children:
+								ColorBlock@COLORCUSTOM:
+									X: 0
+									Y: 0
+									Width: 29
+									Height: 29
+									Visible: false

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -212,6 +212,7 @@ GameSpeeds:
 		OrderLatency: 6
 
 ColorValidator:
+	TeamColorPresets: ffc9ca, f53333, ffae00, fff830, 87f506, f872ad, da06f3, ddb8ff, def7b2, 39c46f, 200738, 280df6, 2f86f2, 76d2f8, 498221, 000000
 
 ModContent:
 	InstallPromptMessage: Dune 2000 requires artwork and audio from the original game.\n\nQuick Install will automatically download this content (without\nmusic or videos) from an online mirror of the game files.\n\nAdvanced Install includes options for copying the music, videos,\nand other content from an original game disc.

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -237,6 +237,7 @@ GameSpeeds:
 		OrderLatency: 6
 
 ColorValidator:
+	TeamColorPresets: ffc9ca, f50606, 98331f, f57606, f7bb06, f861a4, da06f3, ddb8ff, 06f739, cef7b2, 200738, 280df6, 2f86f2, 76d2f8, 34ba93, 000000
 
 ModContent:
 	InstallPromptMessage: Red Alert requires artwork and audio from the original game.\n\nQuick Install will automatically download this content (without music\nor videos) from a mirror of the 2008 Red Alert freeware release.\n\nAdvanced Install includes options for downloading the music and for\ncopying the videos and other content from an original game disc.

--- a/mods/ts/chrome/color-picker.yaml
+++ b/mods/ts/chrome/color-picker.yaml
@@ -1,45 +1,139 @@
 Background@COLOR_CHOOSER:
 	Logic: ColorPickerLogic
+		PaletteColumns: 8
+		PalettePresetRows: 2
+		PaletteCustomRows: 1
 	Background: dialog2
 	Width: 326
-	Height: 140
+	Height: 154
 	Children:
 		Button@RANDOM_BUTTON:
 			Key: tab
-			X: 250
-			Y: 109
-			Width: 70
+			X: 245
+			Y: 95
+			Width: 76
 			Height: 25
 			Text: Random
 			Font: Bold
-		Background@HUEBG:
+		Button@STORE_BUTTON:
+			X: 245
+			Y: 124
+			Width: 76
+			Height: 25
+			Text: Store
+			Font: Bold
+		ActorPreview@PREVIEW:
+			X: 245
+			Y: 16
+			Width: 76
+			Height: 74
+			Animate: true
+		Button@MIXER_TAB_BUTTON:
+			X: 5
+			Y: PARENT_BOTTOM - 30
+			Height: 25
+			Width: 80
+			Text: Mixer
+			Font: Bold
+		Button@PALETTE_TAB_BUTTON:
+			X: 85
+			Y: PARENT_BOTTOM - 30
+			Height: 25
+			Width: 80
+			Text: Palette
+			Font: Bold
+		Container@MIXER_TAB:
+			X: 5
+			Y: 5
+			Width: PARENT_RIGHT - 90
+			Height: PARENT_BOTTOM - 34
+			Children:
+				Background@HUEBG:
+					Background: dialog3
+					X: 0
+					Y: 0
+					Width: PARENT_RIGHT
+					Height: 17
+					Children:
+						HueSlider@HUE:
+							X: 2
+							Y: 2
+							Width: PARENT_RIGHT - 4
+							Height: PARENT_BOTTOM - 4
+							Ticks: 5
+				Background@MIXERBG:
+					Background: dialog3
+					X: 0
+					Y: 22
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM - 22
+					Children:
+						ColorMixer@MIXER:
+							X: 2
+							Y: 2
+							Width: PARENT_RIGHT - 4
+							Height: PARENT_BOTTOM - 4
+		Background@PALETTE_TAB:
 			Background: dialog3
 			X: 5
 			Y: 5
-			Width: 240
-			Height: 17
+			Width: PARENT_RIGHT - 90
+			Height: PARENT_BOTTOM - 34
+			Visible: false
 			Children:
-				HueSlider@HUE:
-					X: 2
-					Y: 2
-					Width: PARENT_RIGHT - 4
-					Height: PARENT_BOTTOM - 4
-					Ticks: 5
-		Background@MIXERBG:
-			Background: dialog3
-			X: 5
-			Y: 27
-			Width: 240
-			Height: 107
-			Children:
-				ColorMixer@MIXER:
-					X: 2
-					Y: 2
-					Width: PARENT_RIGHT - 4
-					Height: PARENT_BOTTOM - 4
-		ActorPreview@PREVIEW:
-			X: 245
-			Y: 11
-			Width: 80
-			Height: 74
-			Animate: true
+				Container@PALETTE_TAB_PANEL:
+					X: 0
+					Y: 0
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
+					Children:
+						Background@PRESET_HEADER:
+							Background: dialog2
+							Width: PARENT_RIGHT - 4
+							Height: 13
+							X: 2
+							Y: 2
+							Children:
+								Label@LABEL:
+									Font: TinyBold
+									Width: PARENT_RIGHT
+									Height: 10
+									Align: Center
+									Text: Preset Colors
+						Container@PRESET_AREA:
+							Width: PARENT_RIGHT - 4
+							Height: 58
+							X: 2
+							Y: 16
+							Children:
+								ColorBlock@COLORPRESET:
+									X: 0
+									Y: 0
+									Width: 29
+									Height: 29
+									Visible: false
+						Background@CUSTOM_HEADER:
+							Background: dialog2
+							Width: PARENT_RIGHT - 4
+							Height: 13
+							X: 2
+							Y: 75
+							Children:
+								Label@LABEL:
+									Font: TinyBold
+									Width: PARENT_RIGHT
+									Height: 10
+									Align: Center
+									Text: Custom Colors
+						Container@CUSTOM_AREA:
+							Width: PARENT_RIGHT - 4
+							Height: 31
+							X: 2
+							Y: 89
+							Children:
+								ColorBlock@COLORCUSTOM:
+									X: 0
+									Y: 0
+									Width: 29
+									Height: 29
+									Visible: false

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -273,6 +273,7 @@ GameSpeeds:
 		OrderLatency: 6
 
 ColorValidator:
+	TeamColorPresets: f70606, ff7a22, f8d3b3, f8e947, b6f706, f335a0, a64d6c, ce08f9, f5b2db, 12b572, 380135, 1d06f7, 328dff, 78dbf8, cef6b1, 000000
 
 ModContent:
 	InstallPromptMessage: Tiberian Sun requires artwork and audio from the original game.\n\nQuick Install will automatically download this content (without music\nor videos) from a mirror of the 2012 Tiberian Sun freeware release.\n\nAdvanced Install includes options for downloading the music and for\ncopying the videos and other content from an original game disc.


### PR DESCRIPTION
Changes to the color picker and ColorValidator to support built-in team colors.

![colorpresets](https://user-images.githubusercontent.com/1639681/36637331-d24ae60a-1a25-11e8-8d24-799349362be3.png)

Preset colors are defined in mod.yaml as TeamColorPresets. These are based off the colors in the original games, with a couple of extras I selected myself.

Users can also save a selected color in the Custom Colors by holding LCtrl and clicking a swatch.

Bots added to skirmish or multiplayer games will use a preset color if there are any available. If all preset colors are used, a random color will be used instead.

The previous attempt at this was: https://github.com/OpenRA/OpenRA/pull/13072
