### PR TITLE
Focused Stylecop corrections on existing code.

### DIFF
--- a/OpenRA.Game/Map/MapGrid.cs
+++ b/OpenRA.Game/Map/MapGrid.cs
@@ -89,8 +89,12 @@ namespace OpenRA
 			var defaultSubCellIndex = (byte)DefaultSubCell;
 			if (defaultSubCellIndex == byte.MaxValue)
 				DefaultSubCell = (SubCell)(SubCellOffsets.Length / 2);
-			else if (defaultSubCellIndex < (SubCellOffsets.Length > 1 ? 1 : 0) || defaultSubCellIndex >= SubCellOffsets.Length)
-				throw new InvalidDataException("Subcell default index must be a valid index into the offset triples and must be greater than 0 for mods with subcells");
+			else
+			{
+				var minSubCellOffset = SubCellOffsets.Length > 1 ? 1 : 0;
+				if (defaultSubCellIndex < minSubCellOffset || defaultSubCellIndex >= SubCellOffsets.Length)
+					throw new InvalidDataException("Subcell default index must be a valid index into the offset triples and must be greater than 0 for mods with subcells");
+			}
 
 			var makeCorners = Type == MapGridType.RectangularIsometric ?
 				(Func<int[], WVec[]>)IsometricCellCorners : RectangularCellCorners;

--- a/OpenRA.Game/Server/Connection.cs
+++ b/OpenRA.Game/Server/Connection.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Server
 					// from `socket.Receive(rx)`.
 					if (!Socket.Poll(0, SelectMode.SelectRead)) break;
 
-					if (0 < (len = Socket.Receive(rx)))
+					if ((len = Socket.Receive(rx)) > 0)
 						Data.AddRange(rx.Take(len));
 					else
 					{

--- a/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/BlowfishKeyProvider.cs
@@ -385,7 +385,7 @@ namespace OpenRA.Mods.Cnc.FileFormats
 								MulBignumWord(esi, globOne, tmp, 2 * len);
 								if ((*edi & 0x8000) == 0)
 								{
-									if (0 != SubBigNum((uint*)esi, (uint*)esi, g1, 0, (int)len))
+									if (SubBigNum((uint*)esi, (uint*)esi, g1, 0, (int)len) != 0)
 										(*edi)--;
 								}
 							}

--- a/OpenRA.Mods.Common/FileFormats/AudReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/AudReader.cs
@@ -116,8 +116,8 @@ namespace OpenRA.Mods.Common.FileFormats
 			var flags = (SoundFlags)s.ReadByte();
 
 			var samples = outputSize;
-			if (0 != (flags & SoundFlags.Stereo)) samples /= 2;
-			if (0 != (flags & SoundFlags._16Bit)) samples /= 2;
+			if ((flags & SoundFlags.Stereo) != 0) samples /= 2;
+			if ((flags & SoundFlags._16Bit) != 0) samples /= 2;
 			return (float)samples / sampleRate;
 		}
 


### PR DESCRIPTION
Clear up Stylecop Parser failure and warnings.
-Warning		SA1131 : CSharp.Readability : Do not use comparison where value goes first, reverse order of operands in '0 < (len = Socket.Receive(rx))'.	OpenRA.Game	
-Warning		SA0102 : CSharp.CsParser : A syntax error has been discovered in file D:\Dev\OpenRa\OpenRA.Game\Map\MapGrid.cs on line 92.	OpenRA.Game