### PR TITLE
Exception handling items

### DIFF
--- a/OpenRA.Game/GameRules/Ruleset.cs
+++ b/OpenRA.Game/GameRules/Ruleset.cs
@@ -227,10 +227,13 @@ namespace OpenRA
 					{
 						var traitName = traitNode.Key.Split('@')[0];
 						var traitType = modData.ObjectCreator.FindType(traitName + "Info");
-						if (traitType.GetInterface("ILobbyCustomRulesIgnore") == null)
+						if (traitType != null && traitType.GetInterface("ILobbyCustomRulesIgnore") == null)
 							return true;
 					}
-					catch { }
+					catch (Exception ex)
+					{
+						Log.Write("debug", "Error in AnyFlaggedTraits\r\n" + ex.ToString());
+					}
 				}
 			}
 

--- a/OpenRA.Game/Server/ServerOrder.cs
+++ b/OpenRA.Game/Server/ServerOrder.cs
@@ -30,6 +30,7 @@ namespace OpenRA.Server
 			byte b;
 			switch (b = r.ReadByte())
 			{
+				case 0xbf:
 				case 0xff:
 					Console.WriteLine("This isn't a server order.");
 					return null;

--- a/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsDevice.cs
@@ -189,7 +189,7 @@ namespace OpenRA.Platforms.Default
 			}
 			catch (Exception ex)
 			{
-				throw new InvalidDataException("Failed to create hardware cursor `{0}` - {1}".F(name, ex.Message), ex);
+				throw new SDL2HardwareCursorException("Failed to create hardware cursor `{0}` - {1}".F(name, ex.Message), ex);
 			}
 		}
 
@@ -226,6 +226,12 @@ namespace OpenRA.Platforms.Default
 			}
 		}
 
+		class SDL2HardwareCursorException : Exception
+		{
+			public SDL2HardwareCursorException(string message) : base(message) { }
+			public SDL2HardwareCursorException(string message, Exception innerException) : base(message, innerException) { }
+		}
+
 		sealed class SDL2HardwareCursor : IHardwareCursor
 		{
 			public IntPtr Cursor { get; private set; }
@@ -245,8 +251,9 @@ namespace OpenRA.Platforms.Default
 					// This call very occasionally fails on Windows, but often works when retried.
 					for (var retries = 0; retries < 3 && Cursor == IntPtr.Zero; retries++)
 						Cursor = SDL.SDL_CreateColorCursor(surface, hotspot.X, hotspot.Y);
+
 					if (Cursor == IntPtr.Zero)
-						throw new InvalidDataException("Failed to create cursor: {0}".F(SDL.SDL_GetError()));
+						throw new SDL2HardwareCursorException("Failed to create cursor: {0}".F(SDL.SDL_GetError()));
 				}
 				catch
 				{


### PR DESCRIPTION
-Perform null check and add exception logging in RuleSet.
-Explicitly recognize connection termination on ServerOrder.Deserialize()
-Use explicit exception type for SDL2HardwareCursor failures.