### PR TITLE
Add "Slowest" gamespeed with Timestep of 80.

### DIFF
--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -209,6 +209,10 @@ SpriteSequenceFormat: TilesetSpecificSpriteSequence
 ModelSequenceFormat: PlaceholderModelSequence
 
 GameSpeeds:
+	slowest:
+		Name: Slowest
+		Timestep: 80
+		OrderLatency: 2
 	slower:
 		Name: Slower
 		Timestep: 50

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -186,6 +186,10 @@ SpriteSequenceFormat: DefaultSpriteSequence
 ModelSequenceFormat: PlaceholderModelSequence
 
 GameSpeeds:
+	slowest:
+		Name: Slowest
+		Timestep: 80
+		OrderLatency: 2
 	slower:
 		Name: Slower
 		Timestep: 50

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -211,6 +211,10 @@ SpriteSequenceFormat: TilesetSpecificSpriteSequence
 ModelSequenceFormat: PlaceholderModelSequence
 
 GameSpeeds:
+	slowest:
+		Name: Slowest
+		Timestep: 80
+		OrderLatency: 2
 	slower:
 		Name: Slower
 		Timestep: 50

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -247,6 +247,10 @@ SpriteSequenceFormat: TilesetSpecificSpriteSequence
 ModelSequenceFormat: VoxelModelSequence
 
 GameSpeeds:
+	slowest:
+		Name: Slowest
+		Timestep: 80
+		OrderLatency: 2
 	slower:
 		Name: Slower
 		Timestep: 50


### PR DESCRIPTION
Some people just want to see the world burn. Really slowly.

Applies "slowest" game speed in the 4 stock mods.

As requested in #14784 