### PR TITLE
Rename Stream.Write(byte[]) extension method to fix mono compatibility

### DIFF
--- a/OpenRA.Game/Network/Connection.cs
+++ b/OpenRA.Game/Network/Connection.cs
@@ -60,26 +60,26 @@ namespace OpenRA.Network
 		public virtual void Send(int frame, List<byte[]> orders)
 		{
 			var ms = new MemoryStream();
-			ms.Write(BitConverter.GetBytes(frame));
+			ms.WriteArray(BitConverter.GetBytes(frame));
 			foreach (var o in orders)
-				ms.Write(o);
+				ms.WriteArray(o);
 			Send(ms.ToArray());
 		}
 
 		public virtual void SendImmediate(List<byte[]> orders)
 		{
 			var ms = new MemoryStream();
-			ms.Write(BitConverter.GetBytes(0));
+			ms.WriteArray(BitConverter.GetBytes(0));
 			foreach (var o in orders)
-				ms.Write(o);
+				ms.WriteArray(o);
 			Send(ms.ToArray());
 		}
 
 		public virtual void SendSync(int frame, byte[] syncData)
 		{
 			var ms = new MemoryStream(4 + syncData.Length);
-			ms.Write(BitConverter.GetBytes(frame));
-			ms.Write(syncData);
+			ms.WriteArray(BitConverter.GetBytes(frame));
+			ms.WriteArray(syncData);
 			Send(ms.GetBuffer());
 		}
 
@@ -198,8 +198,8 @@ namespace OpenRA.Network
 		public override void SendSync(int frame, byte[] syncData)
 		{
 			var ms = new MemoryStream(4 + syncData.Length);
-			ms.Write(BitConverter.GetBytes(frame));
-			ms.Write(syncData);
+			ms.WriteArray(BitConverter.GetBytes(frame));
+			ms.WriteArray(syncData);
 			queuedSyncPackets.Add(ms.GetBuffer());
 		}
 
@@ -210,13 +210,13 @@ namespace OpenRA.Network
 			try
 			{
 				var ms = new MemoryStream();
-				ms.Write(BitConverter.GetBytes(packet.Length));
-				ms.Write(packet);
+				ms.WriteArray(BitConverter.GetBytes(packet.Length));
+				ms.WriteArray(packet);
 
 				foreach (var q in queuedSyncPackets)
 				{
-					ms.Write(BitConverter.GetBytes(q.Length));
-					ms.Write(q);
+					ms.WriteArray(BitConverter.GetBytes(q.Length));
+					ms.WriteArray(q);
 					base.Send(q);
 				}
 

--- a/OpenRA.Game/Network/OrderIO.cs
+++ b/OpenRA.Game/Network/OrderIO.cs
@@ -16,7 +16,9 @@ namespace OpenRA.Network
 {
 	public static class OrderIO
 	{
-		public static void Write(this Stream s, byte[] buf)
+		// Note: renamed from Write() to avoid being aliased by
+		// System.IO.Stream.Write(System.ReadOnlySpan) (which is not implemented in Mono)
+		public static void WriteArray(this Stream s, byte[] buf)
 		{
 			s.Write(buf, 0, buf.Length);
 		}

--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -128,8 +128,8 @@ namespace OpenRA.Network
 		public void SendSync(int frame, byte[] syncData)
 		{
 			var ms = new MemoryStream(4 + syncData.Length);
-			ms.Write(BitConverter.GetBytes(frame));
-			ms.Write(syncData);
+			ms.WriteArray(BitConverter.GetBytes(frame));
+			ms.WriteArray(syncData);
 			sync.Add(ms.GetBuffer());
 
 			// Store the current frame so Receive() can return the next chunk of orders.

--- a/OpenRA.Game/Network/ReplayRecorder.cs
+++ b/OpenRA.Game/Network/ReplayRecorder.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Network
 				catch (IOException) { }
 			}
 
-			file.Write(initialContent);
+			file.WriteArray(initialContent);
 			writer = new BinaryWriter(file);
 		}
 


### PR DESCRIPTION
Fixes #14504.