### PR TITLE
Add Constant and Common logic for Support Directory Handling

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -243,7 +243,7 @@ namespace OpenRA
 
 		public static void InitializeSettings(Arguments args)
 		{
-			Settings = new Settings(Platform.ResolvePath(Path.Combine("^", "settings.yaml")), args);
+			Settings = new Settings(Platform.ResolvePath(Path.Combine(Platform.SupportDirPrefix, "settings.yaml")), args);
 		}
 
 		public static RunStatus InitializeAndRun(string[] args)
@@ -528,7 +528,7 @@ namespace OpenRA
 			ThreadPool.QueueUserWorkItem(_ =>
 			{
 				var mod = ModData.Manifest.Metadata;
-				var directory = Platform.ResolvePath("^", "Screenshots", ModData.Manifest.Id, mod.Version);
+				var directory = Platform.ResolvePath(Platform.SupportDirPrefix, "Screenshots", ModData.Manifest.Id, mod.Version);
 				Directory.CreateDirectory(directory);
 
 				var filename = TimestampedFilename(true);

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -70,7 +70,7 @@ namespace OpenRA
 				try
 				{
 					// HACK: If the path is inside the the support directory then we may need to create it
-					if (name.StartsWith("^", StringComparison.Ordinal))
+					if (Platform.IsPathRelativeToSupportDirectory(name))
 					{
 						// Assume that the path is a directory if there is not an existing file with the same name
 						var resolved = Platform.ResolvePath(name);
@@ -144,7 +144,7 @@ namespace OpenRA
 					name = name.Substring(1);
 
 				// Don't try to open the map directory in the support directory if it doesn't exist
-				if (name.StartsWith("^", StringComparison.Ordinal))
+				if (Platform.IsPathRelativeToSupportDirectory(name))
 				{
 					var resolved = Platform.ResolvePath(name);
 					if (!Directory.Exists(resolved) || !File.Exists(resolved))

--- a/OpenRA.Game/Network/ReplayRecorder.cs
+++ b/OpenRA.Game/Network/ReplayRecorder.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Network
 		{
 			var filename = chooseFilename();
 			var mod = Game.ModData.Manifest;
-			var dir = Platform.ResolvePath("^", "Replays", mod.Id, mod.Metadata.Version);
+			var dir = Platform.ResolvePath(Platform.SupportDirPrefix, "Replays", mod.Id, mod.Metadata.Version);
 
 			if (!Directory.Exists(dir))
 				Directory.CreateDirectory(dir);

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -21,6 +21,7 @@ namespace OpenRA
 
 	public static class Platform
 	{
+		public const string SupportDirPrefix = "^";
 		public static PlatformType CurrentPlatform { get { return currentPlatform.Value; } }
 		public static readonly Guid SessionGUID = Guid.NewGuid();
 
@@ -143,7 +144,7 @@ namespace OpenRA
 			path = path.TrimEnd(' ', '\t');
 
 			// Paths starting with ^ are relative to the support dir
-			if (path.StartsWith("^", StringComparison.Ordinal))
+			if (Platform.IsPathRelativeToSupportDirectory(path))
 				path = SupportDir + path.Substring(1);
 
 			// Paths starting with . are relative to the game dir
@@ -166,12 +167,17 @@ namespace OpenRA
 		public static string UnresolvePath(string path)
 		{
 			if (path.StartsWith(SupportDir, StringComparison.Ordinal))
-				path = "^" + path.Substring(SupportDir.Length);
+				path = Platform.SupportDirPrefix + path.Substring(SupportDir.Length);
 
 			if (path.StartsWith(GameDir, StringComparison.Ordinal))
 				path = "./" + path.Substring(GameDir.Length);
 
 			return path;
+		}
+
+		public static bool IsPathRelativeToSupportDirectory(string path)
+		{
+			return path.StartsWith(Platform.SupportDirPrefix, StringComparison.Ordinal);
 		}
 	}
 }

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -384,7 +384,7 @@ namespace OpenRA.Server
 
 				if (Dedicated)
 				{
-					var motdFile = Platform.ResolvePath("^", "motd.txt");
+					var motdFile = Platform.ResolvePath(Platform.SupportDirPrefix, "motd.txt");
 					if (!File.Exists(motdFile))
 						File.WriteAllText(motdFile, "Welcome, have fun and good luck!");
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -289,7 +289,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			if (newsBG != null)
 			{
-				var cacheFile = Platform.ResolvePath("^", "news.yaml");
+				var cacheFile = Platform.ResolvePath(Platform.SupportDirPrefix, "news.yaml");
 				var currentNews = ParseNews(cacheFile);
 				if (currentNews != null)
 					DisplayNews(currentNews);

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var template = panel.Get<ScrollItemWidget>("REPLAY_TEMPLATE");
 
 			var mod = modData.Manifest;
-			var dir = Platform.ResolvePath("^", "Replays", mod.Id, mod.Metadata.Version);
+			var dir = Platform.ResolvePath(Platform.SupportDirPrefix, "Replays", mod.Id, mod.Metadata.Version);
 
 			if (Directory.Exists(dir))
 				ThreadPool.QueueUserWorkItem(_ => LoadReplays(dir, template));


### PR DESCRIPTION
Move literal usage of "^" for directory references to Platform, and provide a method to determine if the support dir prefix is used for a given path.