### PR TITLE
Rename another Stream.Write(byte[]) extension method.

### DIFF
--- a/OpenRA.Game/Network/OrderIO.cs
+++ b/OpenRA.Game/Network/OrderIO.cs
@@ -16,13 +16,6 @@ namespace OpenRA.Network
 {
 	public static class OrderIO
 	{
-		// Note: renamed from Write() to avoid being aliased by
-		// System.IO.Stream.Write(System.ReadOnlySpan) (which is not implemented in Mono)
-		public static void WriteArray(this Stream s, byte[] buf)
-		{
-			s.Write(buf, 0, buf.Length);
-		}
-
 		public static List<Order> ToOrderList(this byte[] bytes, World world)
 		{
 			var ms = new MemoryStream(bytes, 4, bytes.Length - 4);

--- a/OpenRA.Game/StreamExts.cs
+++ b/OpenRA.Game/StreamExts.cs
@@ -81,7 +81,7 @@ namespace OpenRA
 
 		public static void Write(this Stream s, int value)
 		{
-			s.Write(BitConverter.GetBytes(value));
+			s.WriteArray(BitConverter.GetBytes(value));
 		}
 
 		public static float ReadFloat(this Stream s)
@@ -131,7 +131,9 @@ namespace OpenRA
 			}
 		}
 
-		public static void Write(this Stream s, byte[] data)
+		// Note: renamed from Write() to avoid being aliased by
+		// System.IO.Stream.Write(System.ReadOnlySpan) (which is not implemented in Mono)
+		public static void WriteArray(this Stream s, byte[] data)
 		{
 			s.Write(data, 0, data.Length);
 		}
@@ -166,7 +168,7 @@ namespace OpenRA
 				bytes = new byte[0];
 
 			s.Write(bytes.Length);
-			s.Write(bytes);
+			s.WriteArray(bytes);
 
 			return 4 + bytes.Length;
 		}

--- a/OpenRA.Mods.Cnc/FileSystem/BagFile.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/BagFile.cs
@@ -55,19 +55,19 @@ namespace OpenRA.Mods.Cnc.FileSystem
 				if ((entry.Flags & 2) > 0)
 				{
 					// PCM
-					waveHeaderMemoryStream.Write(Encoding.ASCII.GetBytes("RIFF"));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes(entry.Length + 36));
-					waveHeaderMemoryStream.Write(Encoding.ASCII.GetBytes("WAVE"));
-					waveHeaderMemoryStream.Write(Encoding.ASCII.GetBytes("fmt "));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes(16));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes((short)1));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes((short)channels));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes(entry.SampleRate));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes(2 * channels * entry.SampleRate));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes((short)(2 * channels)));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes((short)16));
-					waveHeaderMemoryStream.Write(Encoding.ASCII.GetBytes("data"));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes(entry.Length));
+					waveHeaderMemoryStream.WriteArray(Encoding.ASCII.GetBytes("RIFF"));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes(entry.Length + 36));
+					waveHeaderMemoryStream.WriteArray(Encoding.ASCII.GetBytes("WAVE"));
+					waveHeaderMemoryStream.WriteArray(Encoding.ASCII.GetBytes("fmt "));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes(16));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes((short)1));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes((short)channels));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes(entry.SampleRate));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes(2 * channels * entry.SampleRate));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes((short)(2 * channels)));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes((short)16));
+					waveHeaderMemoryStream.WriteArray(Encoding.ASCII.GetBytes("data"));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes(entry.Length));
 				}
 
 				if ((entry.Flags & 8) > 0)
@@ -77,24 +77,24 @@ namespace OpenRA.Mods.Cnc.FileSystem
 					var bytesPerSec = (int)Math.Floor(((double)(2 * entry.ChunkSize) / samplesPerChunk) * ((double)entry.SampleRate / 2));
 					var chunkSize = entry.ChunkSize > entry.Length ? entry.Length : entry.ChunkSize;
 
-					waveHeaderMemoryStream.Write(Encoding.ASCII.GetBytes("RIFF"));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes(entry.Length + 52));
-					waveHeaderMemoryStream.Write(Encoding.ASCII.GetBytes("WAVE"));
-					waveHeaderMemoryStream.Write(Encoding.ASCII.GetBytes("fmt "));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes(20));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes((short)17));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes((short)channels));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes(entry.SampleRate));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes(bytesPerSec));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes((short)chunkSize));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes((short)4));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes((short)2));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes((short)samplesPerChunk));
-					waveHeaderMemoryStream.Write(Encoding.ASCII.GetBytes("fact"));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes(4));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes(4 * entry.Length));
-					waveHeaderMemoryStream.Write(Encoding.ASCII.GetBytes("data"));
-					waveHeaderMemoryStream.Write(BitConverter.GetBytes(entry.Length));
+					waveHeaderMemoryStream.WriteArray(Encoding.ASCII.GetBytes("RIFF"));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes(entry.Length + 52));
+					waveHeaderMemoryStream.WriteArray(Encoding.ASCII.GetBytes("WAVE"));
+					waveHeaderMemoryStream.WriteArray(Encoding.ASCII.GetBytes("fmt "));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes(20));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes((short)17));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes((short)channels));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes(entry.SampleRate));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes(bytesPerSec));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes((short)chunkSize));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes((short)4));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes((short)2));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes((short)samplesPerChunk));
+					waveHeaderMemoryStream.WriteArray(Encoding.ASCII.GetBytes("fact"));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes(4));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes(4 * entry.Length));
+					waveHeaderMemoryStream.WriteArray(Encoding.ASCII.GetBytes("data"));
+					waveHeaderMemoryStream.WriteArray(BitConverter.GetBytes(entry.Length));
 				}
 
 				waveHeaderMemoryStream.Seek(0, SeekOrigin.Begin);

--- a/OpenRA.Mods.Common/FileFormats/VqaReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/VqaReader.cs
@@ -194,14 +194,14 @@ namespace OpenRA.Mods.Common.FileFormats
 							else if (audioChannels == 1)
 							{
 								var rawAudio = stream.ReadBytes((int)length);
-								audio1.Write(rawAudio);
+								audio1.WriteArray(rawAudio);
 							}
 							else
 							{
 								var rawAudio = stream.ReadBytes((int)length / 2);
-								audio1.Write(rawAudio);
+								audio1.WriteArray(rawAudio);
 								rawAudio = stream.ReadBytes((int)length / 2);
-								audio2.Write(rawAudio);
+								audio2.WriteArray(rawAudio);
 								if (length % 2 != 0)
 									stream.ReadBytes(2);
 							}


### PR DESCRIPTION
Fixes #14504 (again).

It turns out that the extra cases reported by @shiningdracon are using a completely separate extension method.  I have updated these in the same way as #14870, and removed the duplicated extension method in `OrderIO`.  I confirmed the issue and fix on mono 5.10 by playing one of the mission FMVs, which crashes before but works with this fix.