### PR TITLE
Added FieldDescriptionTooltip

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -303,6 +303,7 @@
     <Compile Include="Traits\CommandBarBlacklist.cs" />
     <Compile Include="Traits\Conditions\GrantRandomCondition.cs" />
     <Compile Include="Traits\Contrail.cs" />
+    <Compile Include="Traits\TooltipDescription.cs" />
     <Compile Include="Traits\Health.cs" />
     <Compile Include="Traits\HitShape.cs" />
     <Compile Include="Traits\Player\DeveloperMode.cs" />

--- a/OpenRA.Mods.Common/Traits/TooltipDescription.cs
+++ b/OpenRA.Mods.Common/Traits/TooltipDescription.cs
@@ -1,0 +1,41 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Additional info shown in the battlefield tooltip.")]
+	public class TooltipDescriptionInfo : ConditionalTraitInfo
+	{
+		[Desc("Text shown in tooltip.")]
+		[Translate]
+		public readonly string Description = "";
+
+		public override object Create(ActorInitializer init) { return new TooltipDescription(this); }
+	}
+
+	public class TooltipDescription : ConditionalTrait<TooltipDescriptionInfo>, IProvideTooltipInfo
+	{
+		public TooltipDescription(TooltipDescriptionInfo info)
+			: base(info) { }
+
+		public bool IsTooltipVisible(Player forPlayer) { return !IsTraitDisabled; }
+
+		public string TooltipText
+		{
+			get
+			{
+				return Info.Description;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added the possibility to expand the tooltip shown on units in the field. Everyone can see these tooltips.

The structure used to add this description inside the YAML is
`FieldDescriptionTooltip:`
`-Description: Description of the unit`

This will add the "Description" to the unit's tooltip:
![openra_fieldtooltip](https://user-images.githubusercontent.com/388694/37172126-39fdb0b4-2310-11e8-8470-fb4f57458015.png)

Pull request related to issue #14453 