### PR TITLE
Remove remaining internal .aud sound defaults from Mods.Common

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -55,9 +55,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Clear smudges from underneath the building footprint on transform.")]
 		public readonly bool RemoveSmudgesOnTransform = true;
 
-		public readonly string[] BuildSounds = { "placbldg.aud", "build5.aud" };
+		public readonly string[] BuildSounds = { };
 
-		public readonly string[] UndeploySounds = { "cashturn.aud" };
+		public readonly string[] UndeploySounds = { };
 
 		public virtual object Create(ActorInitializer init) { return new Building(init, this); }
 

--- a/OpenRA.Mods.Common/Traits/EjectOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/EjectOnDeath.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int SuccessRate = 50;
 
 		[Desc("Sound to play when ejecting the pilot from the aircraft.")]
-		public readonly string ChuteSound = "chute1.aud";
+		public readonly string ChuteSound = null;
 
 		[Desc("Can a destroyed aircraft eject its pilot while it has not yet fallen to ground level?")]
 		public readonly bool EjectInAir = false;

--- a/OpenRA.Mods.Common/Traits/ParaDrop.cs
+++ b/OpenRA.Mods.Common/Traits/ParaDrop.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly WDist DropRange = WDist.FromCells(4);
 
 		[Desc("Sound to play when dropping.")]
-		public readonly string ChuteSound = "chute1.aud";
+		public readonly string ChuteSound = null;
 
 		public object Create(ActorInitializer init) { return new ParaDrop(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		[ActorReference(typeof(AircraftInfo))] public readonly string ActorType = "badr";
 
 		[Desc("Sound to play when dropping the unit.")]
-		public readonly string ChuteSound = "chute1.aud";
+		public readonly string ChuteSound = null;
 
 		[Desc("Notification to play when dropping the unit.")]
 		public readonly string ReadyAudio = null;

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeRules.cs
@@ -1674,6 +1674,41 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					}
 				}
 
+				if (engineVersion < 20180309)
+				{
+					if (node.Key == "ParaDrop")
+					{
+						var soundNodePD = node.Value.Nodes.FirstOrDefault(n => n.Key == "ChuteSound");
+						if (soundNodePD == null)
+							node.Value.Nodes.Add(new MiniYamlNode("ChuteSound", "chute1.aud"));
+					}
+
+					if (depth == 1 && node.Key == "EjectOnDeath")
+					{
+						var soundNodeEOD = node.Value.Nodes.FirstOrDefault(n => n.Key == "ChuteSound");
+						if (soundNodeEOD == null)
+							node.Value.Nodes.Add(new MiniYamlNode("ChuteSound", "chute1.aud"));
+					}
+
+					if (node.Key.StartsWith("ProductionParadrop", StringComparison.Ordinal))
+					{
+						var soundNodePP = node.Value.Nodes.FirstOrDefault(n => n.Key == "ChuteSound");
+						if (soundNodePP == null)
+							node.Value.Nodes.Add(new MiniYamlNode("ChuteSound", "chute1.aud"));
+					}
+
+					if (node.Key == "Building")
+					{
+						var soundNodeB1 = node.Value.Nodes.FirstOrDefault(n => n.Key == "BuildSounds");
+						if (soundNodeB1 == null)
+							node.Value.Nodes.Add(new MiniYamlNode("BuildSounds", "placbldg.aud, build5.aud"));
+
+						var soundNodeB2 = node.Value.Nodes.FirstOrDefault(n => n.Key == "UndeploySounds");
+						if (soundNodeB2 == null)
+							node.Value.Nodes.Add(new MiniYamlNode("UndeploySounds", "cashturn.aud"));
+					}
+				}
+
 				UpgradeActorRules(modData, engineVersion, ref node.Value.Nodes, node, depth + 1);
 			}
 

--- a/mods/cnc/maps/nod07c/rules.yaml
+++ b/mods/cnc/maps/nod07c/rules.yaml
@@ -141,6 +141,8 @@ HPAD.IN:
 		CaptureThreshold: 100
 	Building:
 		Footprint: x_ xx
+		BuildSounds: placbldg.aud, build5.aud
+		UndeploySounds: cashturn.aud
 	-Sellable:
 	-Power:
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -700,6 +700,7 @@
 	Building:
 		RequiresBaseProvider: true
 		BuildSounds: constru2.aud, hvydoor1.aud
+		UndeploySounds: cashturn.aud
 		TerrainTypes: Clear,Road
 	RequiresBuildableArea:
 		AreaTypes: building

--- a/mods/ra/maps/bomber-john/rules.yaml
+++ b/mods/ra/maps/bomber-john/rules.yaml
@@ -145,6 +145,8 @@ MINVV:
 	HiddenUnderFog:
 	Building:
 		TerrainTypes: Clear,Road
+		BuildSounds: placbldg.aud, build5.aud
+		UndeploySounds: cashturn.aud
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 10

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -2,6 +2,7 @@ BADR:
 	Inherits: ^NeutralPlane
 	ParaDrop:
 		DropRange: 4c0
+		ChuteSound: chute1.aud
 	Health:
 		HP: 30000
 	Armor:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -531,6 +531,7 @@
 		EjectOnGround: false
 		EjectInAir: true
 		AllowUnsuitableCell: true
+		ChuteSound: chute1.aud
 	GpsDot:
 		String: Plane
 	Tooltip:
@@ -591,6 +592,8 @@
 		Footprint: x
 		TerrainTypes: Clear,Road
 		RequiresBaseProvider: True
+		BuildSounds: placbldg.aud, build5.aud
+		UndeploySounds: cashturn.aud
 	RequiresBuildableArea:
 		AreaTypes: building
 	SoundOnDamageTransition:
@@ -671,6 +674,7 @@
 		Footprint: x
 		BuildSounds: placbldg.aud
 		TerrainTypes: Clear,Road
+		UndeploySounds: cashturn.aud
 	RequiresBuildableArea:
 		AreaTypes: building
 		Adjacent: 7
@@ -717,6 +721,7 @@
 	Building:
 		BuildSounds: place2.aud
 		TerrainTypes: Clear, Road
+		UndeploySounds: cashturn.aud
 	RequiresBuildableArea:
 		AreaTypes: building
 		Adjacent: 4

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -306,6 +306,7 @@
 		Footprint: x
 		BuildSounds: place2.aud
 		TerrainTypes: Clear, Rough, Road, DirtRoad, Green, Sand, Pavement
+		UndeploySounds: cashturn.aud
 	RequiresBuildableArea:
 		AreaTypes: building
 		Adjacent: 4
@@ -442,6 +443,7 @@
 		Footprint: x
 		BuildSounds: place2.aud
 		TerrainTypes: Clear, Rough, Road, DirtRoad, Green, Sand, Pavement
+		UndeploySounds: cashturn.aud
 	RequiresBuildableArea:
 		AreaTypes: building
 		Adjacent: 7
@@ -485,6 +487,7 @@
 	AlwaysVisible:
 	Building:
 		BuildSounds: place2.aud
+		UndeploySounds: cashturn.aud
 	KillsSelf:
 		RemoveInstead: true
 	RenderSprites:

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -51,7 +51,6 @@ GACTWR:
 		BuildPaletteOrder: 70
 		Prerequisites: gapile, ~structures.gdi, ~techlevel.low
 		Description: Modular tower for base defenses.
-	Building:
 	Selectable:
 		Bounds: 48, 36, 0, -6
 		DecorationBounds: 48, 48, 0, -12

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -142,7 +142,6 @@ NALASR:
 		Prerequisites: nahand, ~structures.nod, ~techlevel.low
 		BuildPaletteOrder: 90
 		Description: Basic base defense.\nRequires power to operate.\n  Strong vs Ground units\n  Weak vs Aircraft
-	Building:
 	Selectable:
 		Bounds: 40, 30, -8, -6
 		DecorationBounds: 40, 36, -8, -8


### PR DESCRIPTION
They were fine when RA and TD were the only mods, but now that there are several non-C&C 3rd-party mods in development and possibly more in the future, it would be more modder-friendly as well as more consistent with the majority of sound properties in Mods.Common to get rid of the remaining internal .aud defaults.

I left Mods.Cnc untouched for now, since MadTank and the two chrono traits are pretty RA-specific.