### PR TITLE
Split "Locomotor" from Mobile

### DIFF
--- a/OpenRA.Game/Traits/LintAttributes.cs
+++ b/OpenRA.Game/Traits/LintAttributes.cs
@@ -35,6 +35,9 @@ namespace OpenRA.Traits
 	public sealed class VoiceReferenceAttribute : Attribute { }
 
 	[AttributeUsage(AttributeTargets.Field)]
+	public sealed class LocomotorReferenceAttribute : Attribute { }
+
+	[AttributeUsage(AttributeTargets.Field)]
 	public sealed class SequenceReferenceAttribute : Attribute
 	{
 		public readonly string ImageReference; // The field name in the same trait info that contains the image name.

--- a/OpenRA.Mods.Cnc/Traits/Mine.cs
+++ b/OpenRA.Mods.Cnc/Traits/Mine.cs
@@ -45,10 +45,10 @@ namespace OpenRA.Mods.Cnc.Traits
 				return;
 
 			var mobile = crusher.TraitOrDefault<Mobile>();
-			if (mobile != null && !info.DetonateClasses.Overlaps(mobile.Info.Crushes))
+			if (mobile != null && !info.DetonateClasses.Overlaps(mobile.Info.LocomotorInfo.Crushes))
 				return;
 
-			self.Kill(crusher, mobile != null ? mobile.Info.CrushDamageTypes : new HashSet<string>());
+			self.Kill(crusher, mobile != null ? mobile.Info.LocomotorInfo.CrushDamageTypes : new HashSet<string>());
 		}
 
 		bool ICrushable.CrushableBy(Actor self, Actor crusher, HashSet<string> crushClasses)

--- a/OpenRA.Mods.Common/AI/AIHarvesterManager.cs
+++ b/OpenRA.Mods.Common/AI/AIHarvesterManager.cs
@@ -41,16 +41,16 @@ namespace OpenRA.Mods.Common.AI
 
 		CPos FindNextResource(Actor actor, Harvester harv)
 		{
-			var mobileInfo = actor.Info.TraitInfo<MobileInfo>();
-			var passable = (uint)mobileInfo.GetMovementClass(world.Map.Rules.TileSet);
+			var locomotorInfo = actor.Info.TraitInfo<MobileInfo>().LocomotorInfo;
+			var passable = (uint)locomotorInfo.GetMovementClass(World.Map.Rules.TileSet);
 
 			Func<CPos, bool> isValidResource = cell =>
-				domainIndex.IsPassable(actor.Location, cell, mobileInfo, passable) &&
+				domainIndex.IsPassable(actor.Location, cell, locomotorInfo, passable) &&
 				harv.CanHarvestCell(actor, cell) &&
 				claimLayer.CanClaimCell(actor, cell);
 
 			var path = pathfinder.FindPath(
-				PathSearch.Search(world, mobileInfo, actor, true, isValidResource)
+				PathSearch.Search(world, locomotorInfo, actor, true, isValidResource)
 					.WithCustomCost(loc => world.FindActorsInCircle(world.Map.CenterOfCell(loc), ai.Info.HarvesterEnemyAvoidanceRadius)
 						.Where(u => !u.IsDead && actor.Owner.Stances[u.Owner] == Stance.Enemy)
 						.Sum(u => Math.Max(WDist.Zero.Length, ai.Info.HarvesterEnemyAvoidanceRadius.Length - (world.Map.CenterOfCell(loc) - u.CenterPosition).Length)))

--- a/OpenRA.Mods.Common/AI/AIHarvesterManager.cs
+++ b/OpenRA.Mods.Common/AI/AIHarvesterManager.cs
@@ -42,10 +42,9 @@ namespace OpenRA.Mods.Common.AI
 		CPos FindNextResource(Actor actor, Harvester harv)
 		{
 			var locomotorInfo = actor.Info.TraitInfo<MobileInfo>().LocomotorInfo;
-			var passable = (uint)locomotorInfo.GetMovementClass(World.Map.Rules.TileSet);
 
 			Func<CPos, bool> isValidResource = cell =>
-				domainIndex.IsPassable(actor.Location, cell, locomotorInfo, passable) &&
+				domainIndex.IsPassable(actor.Location, cell, locomotorInfo) &&
 				harv.CanHarvestCell(actor, cell) &&
 				claimLayer.CanClaimCell(actor, cell);
 

--- a/OpenRA.Mods.Common/AI/States/NavyStates.cs
+++ b/OpenRA.Mods.Common/AI/States/NavyStates.cs
@@ -31,11 +31,10 @@ namespace OpenRA.Mods.Common.AI
 			// You might be tempted to move these lookups into Activate() but that causes null reference exception.
 			var domainIndex = first.World.WorldActor.Trait<DomainIndex>();
 			var locomotorInfo = first.Info.TraitInfo<MobileInfo>().LocomotorInfo;
-			var passable = (uint)locomotorInfo.GetMovementClass(first.World.Map.Rules.TileSet);
 
 			var navalProductions = owner.World.ActorsHavingTrait<Building>().Where(a
 				=> owner.Bot.Info.BuildingCommonNames.NavalProduction.Contains(a.Info.Name)
-				&& domainIndex.IsPassable(first.Location, a.Location, locomotorInfo, passable)
+				&& domainIndex.IsPassable(first.Location, a.Location, locomotorInfo)
 				&& a.AppearsHostileTo(first));
 
 			if (navalProductions.Any())

--- a/OpenRA.Mods.Common/AI/States/NavyStates.cs
+++ b/OpenRA.Mods.Common/AI/States/NavyStates.cs
@@ -30,12 +30,12 @@ namespace OpenRA.Mods.Common.AI
 			// (Way better than finding a nearest target which is likely to be on Ground)
 			// You might be tempted to move these lookups into Activate() but that causes null reference exception.
 			var domainIndex = first.World.WorldActor.Trait<DomainIndex>();
-			var mobileInfo = first.Info.TraitInfo<MobileInfo>();
-			var passable = (uint)mobileInfo.GetMovementClass(first.World.Map.Rules.TileSet);
+			var locomotorInfo = first.Info.TraitInfo<MobileInfo>().LocomotorInfo;
+			var passable = (uint)locomotorInfo.GetMovementClass(first.World.Map.Rules.TileSet);
 
 			var navalProductions = owner.World.ActorsHavingTrait<Building>().Where(a
 				=> owner.Bot.Info.BuildingCommonNames.NavalProduction.Contains(a.Info.Name)
-				&& domainIndex.IsPassable(first.Location, a.Location, mobileInfo, passable)
+				&& domainIndex.IsPassable(first.Location, a.Location, locomotorInfo, passable)
 				&& a.AppearsHostileTo(first));
 
 			if (navalProductions.Any())

--- a/OpenRA.Mods.Common/Activities/FindResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindResources.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly Harvester harv;
 		readonly HarvesterInfo harvInfo;
 		readonly Mobile mobile;
-		readonly MobileInfo mobileInfo;
+		readonly LocomotorInfo locomotorInfo;
 		readonly ResourceClaimLayer claimLayer;
 		readonly IPathFinder pathFinder;
 		readonly DomainIndex domainIndex;
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Activities
 			harv = self.Trait<Harvester>();
 			harvInfo = self.Info.TraitInfo<HarvesterInfo>();
 			mobile = self.Trait<Mobile>();
-			mobileInfo = self.Info.TraitInfo<MobileInfo>();
+			locomotorInfo = mobile.Info.LocomotorInfo;
 			claimLayer = self.World.WorldActor.Trait<ResourceClaimLayer>();
 			pathFinder = self.World.WorldActor.Trait<IPathFinder>();
 			domainIndex = self.World.WorldActor.Trait<DomainIndex>();
@@ -126,10 +126,10 @@ namespace OpenRA.Mods.Common.Activities
 			var searchRadiusSquared = searchRadius * searchRadius;
 
 			// Find any harvestable resources:
-			var passable = (uint)mobileInfo.GetMovementClass(self.World.Map.Rules.TileSet);
+			var passable = (uint)locomotorInfo.GetMovementClass(self.World.Map.Rules.TileSet);
 			List<CPos> path;
-			using (var search = PathSearch.Search(self.World, mobileInfo, self, true, loc =>
-					domainIndex.IsPassable(self.Location, loc, mobileInfo, passable) && harv.CanHarvestCell(self, loc) && claimLayer.CanClaimCell(self, loc))
+			using (var search = PathSearch.Search(self.World, locomotorInfo, self, true, loc =>
+					domainIndex.IsPassable(self.Location, loc, locomotorInfo, passable) && harv.CanHarvestCell(self, loc) && claimLayer.CanClaimCell(self, loc))
 				.WithCustomCost(loc =>
 				{
 					if ((avoidCell.HasValue && loc == avoidCell.Value) ||

--- a/OpenRA.Mods.Common/Activities/FindResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindResources.cs
@@ -126,10 +126,9 @@ namespace OpenRA.Mods.Common.Activities
 			var searchRadiusSquared = searchRadius * searchRadius;
 
 			// Find any harvestable resources:
-			var passable = (uint)locomotorInfo.GetMovementClass(self.World.Map.Rules.TileSet);
 			List<CPos> path;
 			using (var search = PathSearch.Search(self.World, locomotorInfo, self, true, loc =>
-					domainIndex.IsPassable(self.Location, loc, locomotorInfo, passable) && harv.CanHarvestCell(self, loc) && claimLayer.CanClaimCell(self, loc))
+					domainIndex.IsPassable(self.Location, loc, locomotorInfo) && harv.CanHarvestCell(self, loc) && claimLayer.CanClaimCell(self, loc))
 				.WithCustomCost(loc =>
 				{
 					if ((avoidCell.HasValue && loc == avoidCell.Value) ||

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				List<CPos> path;
 				using (var search =
-					PathSearch.FromPoint(self.World, mobile.Info, self, mobile.ToCell, destination, false)
+					PathSearch.FromPoint(self.World, mobile.Info.LocomotorInfo, self, mobile.ToCell, destination, false)
 					.WithoutLaneBias())
 					path = self.World.WorldActor.Trait<IPathFinder>().FindPath(search);
 				return path;
@@ -293,7 +293,9 @@ namespace OpenRA.Mods.Common.Activities
 				// Wait a bit to see if they leave
 				if (!hasWaited)
 				{
-					waitTicksRemaining = mobile.Info.WaitAverage + self.World.SharedRandom.Next(-mobile.Info.WaitSpread, mobile.Info.WaitSpread);
+					waitTicksRemaining = mobile.Info.LocomotorInfo.WaitAverage
+						+ self.World.SharedRandom.Next(-mobile.Info.LocomotorInfo.WaitSpread, mobile.Info.LocomotorInfo.WaitSpread);
+
 					hasWaited = true;
 				}
 

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -26,7 +26,6 @@ namespace OpenRA.Mods.Common.Activities
 		protected readonly Mobile Mobile;
 		readonly IPathFinder pathFinder;
 		readonly DomainIndex domainIndex;
-		readonly uint movementClass;
 
 		Target target;
 		bool canHideUnderFog;
@@ -56,7 +55,6 @@ namespace OpenRA.Mods.Common.Activities
 			Mobile = self.Trait<Mobile>();
 			pathFinder = self.World.WorldActor.Trait<IPathFinder>();
 			domainIndex = self.World.WorldActor.Trait<DomainIndex>();
-			movementClass = (uint)Mobile.Info.LocomotorInfo.GetMovementClass(self.World.Map.Rules.TileSet);
 
 			if (target.IsValidFor(self))
 				targetPosition = self.World.Map.CellContaining(target.CenterPosition);
@@ -142,7 +140,7 @@ namespace OpenRA.Mods.Common.Activities
 			var loc = self.Location;
 
 			foreach (var cell in targetCells)
-				if (domainIndex.IsPassable(loc, cell, Mobile.Info.LocomotorInfo, movementClass) && Mobile.CanEnterCell(cell))
+				if (domainIndex.IsPassable(loc, cell, Mobile.Info.LocomotorInfo) && Mobile.CanEnterCell(cell))
 					searchCells.Add(cell);
 
 			if (!searchCells.Any())

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Activities
 			Mobile = self.Trait<Mobile>();
 			pathFinder = self.World.WorldActor.Trait<IPathFinder>();
 			domainIndex = self.World.WorldActor.Trait<DomainIndex>();
-			movementClass = (uint)Mobile.Info.GetMovementClass(self.World.Map.Rules.TileSet);
+			movementClass = (uint)Mobile.Info.LocomotorInfo.GetMovementClass(self.World.Map.Rules.TileSet);
 
 			if (target.IsValidFor(self))
 				targetPosition = self.World.Map.CellContaining(target.CenterPosition);
@@ -142,14 +142,14 @@ namespace OpenRA.Mods.Common.Activities
 			var loc = self.Location;
 
 			foreach (var cell in targetCells)
-				if (domainIndex.IsPassable(loc, cell, Mobile.Info, movementClass) && Mobile.CanEnterCell(cell))
+				if (domainIndex.IsPassable(loc, cell, Mobile.Info.LocomotorInfo, movementClass) && Mobile.CanEnterCell(cell))
 					searchCells.Add(cell);
 
 			if (!searchCells.Any())
 				return NoPath;
 
-			using (var fromSrc = PathSearch.FromPoints(self.World, Mobile.Info, self, searchCells, loc, true))
-			using (var fromDest = PathSearch.FromPoint(self.World, Mobile.Info, self, loc, targetPosition, true).Reverse())
+			using (var fromSrc = PathSearch.FromPoints(self.World, Mobile.Info.LocomotorInfo, self, searchCells, loc, true))
+			using (var fromDest = PathSearch.FromPoint(self.World, Mobile.Info.LocomotorInfo, self, loc, targetPosition, true).Reverse())
 				return pathFinder.FindBidiPath(fromSrc, fromDest);
 		}
 

--- a/OpenRA.Mods.Common/Lint/CheckLocomotorReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckLocomotorReferences.cs
@@ -1,0 +1,51 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Lint
+{
+	public class CheckLocomotorReferences : ILintRulesPass
+	{
+		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		{
+			var worldActor = rules.Actors["world"];
+			var locomotorInfos = worldActor.TraitInfos<LocomotorInfo>().ToArray();
+			foreach (var actorInfo in rules.Actors)
+			{
+				foreach (var traitInfo in actorInfo.Value.TraitInfos<ITraitInfo>())
+				{
+					var fields = traitInfo.GetType().GetFields().Where(f => f.HasAttribute<LocomotorReferenceAttribute>());
+					foreach (var field in fields)
+					{
+						var locomotors = LintExts.GetFieldValues(traitInfo, field, emitError);
+						foreach (var locomotor in locomotors)
+						{
+							if (string.IsNullOrEmpty(locomotor))
+								continue;
+
+							CheckLocomotors(actorInfo.Value, emitError, rules, locomotorInfos, locomotor);
+						}
+					}
+				}
+			}
+		}
+
+		void CheckLocomotors(ActorInfo actorInfo, Action<string> emitError, Ruleset rules, LocomotorInfo[] locomotorInfos, string locomotor)
+		{
+			if (!locomotorInfos.Any(l => l.Name == locomotor))
+				emitError("Actor {0} defines Locomotor {1} not found on World actor.".F(actorInfo.Name, locomotor));
+		}
+	}
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -524,6 +524,10 @@
     <Compile Include="Traits\Conditions\GrantConditionOnDamageState.cs" />
     <Compile Include="Traits\Conditions\GrantConditionOnFaction.cs" />
     <Compile Include="Traits\Conditions\GrantConditionOnTerrain.cs" />
+    <Compile Include="Traits\Conditions\GrantConditionOnLayer.cs" />
+    <Compile Include="Traits\Conditions\GrantConditionOnTunnelLayer.cs" />
+    <Compile Include="Traits\Conditions\GrantConditionOnJumpjetLayer.cs" />
+    <Compile Include="Traits\Conditions\GrantConditionOnSubterraneanLayer.cs" />
     <Compile Include="Traits\Conditions\GrantConditionOnMovement.cs" />
     <Compile Include="Traits\Conditions\GrantConditionOnPrerequisite.cs" />
     <Compile Include="Traits\Conditions\ConditionManager.cs" />
@@ -534,6 +538,9 @@
     <Compile Include="Traits\World\CrateSpawner.cs" />
     <Compile Include="Traits\World\CreateMPPlayers.cs" />
     <Compile Include="Traits\World\DomainIndex.cs" />
+    <Compile Include="Traits\World\Locomotor.cs" />
+    <Compile Include="Traits\World\JumpjetLocomotor.cs" />
+    <Compile Include="Traits\World\SubterraneanLocomotor.cs" />
     <Compile Include="Traits\World\LoadWidgetAtGameStart.cs" />
     <Compile Include="Traits\World\MPStartLocations.cs" />
     <Compile Include="Traits\World\MPStartUnits.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -872,6 +872,7 @@
     <Compile Include="UpdateRules\Rules\RemovePaletteFromCurrentTileset.cs" />
     <Compile Include="Traits\Player\PlayerResources.cs" />
     <Compile Include="UtilityCommands\DumpSequenceSheetsCommand.cs" />
+    <Compile Include="UpdateRules\Rules\DefineLocomotors.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -45,18 +45,18 @@ namespace OpenRA.Mods.Common.Pathfinder
 			considered = new LinkedList<Pair<CPos, int>>();
 		}
 
-		public static IPathSearch Search(World world, MobileInfo mi, Actor self, bool checkForBlocked, Func<CPos, bool> goalCondition)
+		public static IPathSearch Search(World world, LocomotorInfo li, Actor self, bool checkForBlocked, Func<CPos, bool> goalCondition)
 		{
-			var graph = new PathGraph(LayerPoolForWorld(world), mi, self, world, checkForBlocked);
+			var graph = new PathGraph(LayerPoolForWorld(world), li, self, world, checkForBlocked);
 			var search = new PathSearch(graph);
 			search.isGoal = goalCondition;
 			search.heuristic = loc => 0;
 			return search;
 		}
 
-		public static IPathSearch FromPoint(World world, MobileInfo mi, Actor self, CPos from, CPos target, bool checkForBlocked)
+		public static IPathSearch FromPoint(World world, LocomotorInfo li, Actor self, CPos from, CPos target, bool checkForBlocked)
 		{
-			var graph = new PathGraph(LayerPoolForWorld(world), mi, self, world, checkForBlocked);
+			var graph = new PathGraph(LayerPoolForWorld(world), li, self, world, checkForBlocked);
 			var search = new PathSearch(graph)
 			{
 				heuristic = DefaultEstimator(target)
@@ -74,9 +74,9 @@ namespace OpenRA.Mods.Common.Pathfinder
 			return search;
 		}
 
-		public static IPathSearch FromPoints(World world, MobileInfo mi, Actor self, IEnumerable<CPos> froms, CPos target, bool checkForBlocked)
+		public static IPathSearch FromPoints(World world, LocomotorInfo li, Actor self, IEnumerable<CPos> froms, CPos target, bool checkForBlocked)
 		{
-			var graph = new PathGraph(LayerPoolForWorld(world), mi, self, world, checkForBlocked);
+			var graph = new PathGraph(LayerPoolForWorld(world), li, self, world, checkForBlocked);
 			var search = new PathSearch(graph)
 			{
 				heuristic = DefaultEstimator(target)

--- a/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
@@ -159,22 +159,19 @@ namespace OpenRA.Mods.Common.Scripting
 					// Try to find an alternative landing spot if we can't land at the current destination
 					if (!aircraft.CanLand(destination) && dropRange > 0)
 					{
-						var mobiles = cargo != null ? cargo.Passengers.Select(a =>
-						{
-							var mobile = a.TraitOrDefault<Mobile>();
-							if (mobile == null)
-								return new Pair<LocomotorInfo, uint>(null, 0);
-
-							var locomotorInfo = mobile.Info.LocomotorInfo;
-							return new Pair<LocomotorInfo, uint>(locomotorInfo, (uint)locomotorInfo.GetMovementClass(a.World.Map.Rules.TileSet));
-						}) : new Pair<LocomotorInfo, uint>[0];
+						var locomotors = cargo.Passengers
+							.Select(a => a.Info.TraitInfoOrDefault<MobileInfo>())
+							.Where(m => m != null)
+							.Distinct()
+							.Select(m => m.LocomotorInfo)
+							.ToList();
 
 						foreach (var c in transport.World.Map.FindTilesInCircle(destination, dropRange))
 						{
 							if (!aircraft.CanLand(c))
 								continue;
 
-							if (!mobiles.All(m => m.First == null || domainIndex.IsPassable(destination, c, m.First, m.Second)))
+							if (!locomotors.All(m => domainIndex.IsPassable(destination, c, m)))
 								continue;
 
 							destination = c;

--- a/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
@@ -161,12 +161,13 @@ namespace OpenRA.Mods.Common.Scripting
 					{
 						var mobiles = cargo != null ? cargo.Passengers.Select(a =>
 						{
-							var mobileInfo = a.Info.TraitInfoOrDefault<MobileInfo>();
-							if (mobileInfo == null)
-								return new Pair<MobileInfo, uint>(null, 0);
+							var mobile = a.TraitOrDefault<Mobile>();
+							if (mobile == null)
+								return new Pair<LocomotorInfo, uint>(null, 0);
 
-							return new Pair<MobileInfo, uint>(mobileInfo, (uint)mobileInfo.GetMovementClass(a.World.Map.Rules.TileSet));
-						}) : new Pair<MobileInfo, uint>[0];
+							var locomotorInfo = mobile.Info.LocomotorInfo;
+							return new Pair<LocomotorInfo, uint>(locomotorInfo, (uint)locomotorInfo.GetMovementClass(a.World.Map.Rules.TileSet));
+						}) : new Pair<LocomotorInfo, uint>[0];
 
 						foreach (var c in transport.World.Map.FindTilesInCircle(destination, dropRange))
 						{

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnJumpjetLayer.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnJumpjetLayer.cs
@@ -1,0 +1,59 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public class GrantConditionOnJumpjetLayerInfo : GrantConditionOnLayerInfo
+	{
+		public override object Create(ActorInitializer init) { return new GrantConditionOnJumpjetLayer(init.Self, this); }
+
+		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
+		{
+			var mobileInfo = ai.TraitInfoOrDefault<MobileInfo>();
+			if (mobileInfo == null || !(mobileInfo.LocomotorInfo is JumpjetLocomotorInfo))
+				throw new YamlException("GrantConditionOnJumpjetLayer requires Mobile to be linked to a JumpjetLocomotor!");
+
+			base.RulesetLoaded(rules, ai);
+		}
+	}
+
+	public class GrantConditionOnJumpjetLayer : GrantConditionOnLayer<GrantConditionOnJumpjetLayerInfo>, INotifyFinishedMoving
+	{
+		bool jumpjetInAir;
+
+		public GrantConditionOnJumpjetLayer(Actor self, GrantConditionOnJumpjetLayerInfo info)
+			: base(self, info, CustomMovementLayerType.Jumpjet) { }
+
+		void INotifyFinishedMoving.FinishedMoving(Actor self, byte oldLayer, byte newLayer)
+		{
+			if (jumpjetInAir && oldLayer != ValidLayerType && newLayer != ValidLayerType)
+				UpdateConditions(self, oldLayer, newLayer);
+		}
+
+		protected override void UpdateConditions(Actor self, byte oldLayer, byte newLayer)
+		{
+			if (!jumpjetInAir && newLayer == ValidLayerType && oldLayer != ValidLayerType && conditionToken == ConditionManager.InvalidConditionToken)
+			{
+				conditionToken = conditionManager.GrantCondition(self, Info.Condition);
+				jumpjetInAir = true;
+			}
+
+			// By the time the condition is meant to be revoked, the 'oldLayer' is already no longer the Jumpjet layer, either
+			if (jumpjetInAir && newLayer != ValidLayerType && oldLayer != ValidLayerType && conditionToken != ConditionManager.InvalidConditionToken)
+			{
+				conditionToken = conditionManager.RevokeCondition(self, conditionToken);
+				jumpjetInAir = false;
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLayer.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLayer.cs
@@ -1,0 +1,73 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public abstract class GrantConditionOnLayerInfo : ConditionalTraitInfo
+	{
+		[FieldLoader.Require]
+		[GrantedConditionReference]
+		[Desc("The condition to grant to self when changing to specific custom layer.")]
+		public readonly string Condition = null;
+	}
+
+	public abstract class GrantConditionOnLayer<InfoType> : ConditionalTrait<InfoType>, INotifyCustomLayerChanged where InfoType : GrantConditionOnLayerInfo
+	{
+		protected readonly byte ValidLayerType;
+		protected ConditionManager conditionManager;
+		protected int conditionToken = ConditionManager.InvalidConditionToken;
+
+		public GrantConditionOnLayer(Actor self, InfoType info, byte validLayer)
+			: base(info)
+		{
+			ValidLayerType = validLayer;
+		}
+
+		protected override void Created(Actor self)
+		{
+			conditionManager = self.TraitOrDefault<ConditionManager>();
+			base.Created(self);
+		}
+
+		void INotifyCustomLayerChanged.CustomLayerChanged(Actor self, byte oldLayer, byte newLayer)
+		{
+			if (conditionManager == null)
+				return;
+
+			UpdateConditions(self, oldLayer, newLayer);
+		}
+
+		protected virtual void UpdateConditions(Actor self, byte oldLayer, byte newLayer)
+		{
+			if (newLayer == ValidLayerType && oldLayer != ValidLayerType && conditionToken == ConditionManager.InvalidConditionToken)
+				conditionToken = conditionManager.GrantCondition(self, Info.Condition);
+			else if (newLayer != ValidLayerType && oldLayer == ValidLayerType && conditionToken != ConditionManager.InvalidConditionToken)
+				conditionToken = conditionManager.RevokeCondition(self, conditionToken);
+		}
+
+		protected override void TraitEnabled(Actor self)
+		{
+			if (self.Location.Layer == ValidLayerType && conditionToken == ConditionManager.InvalidConditionToken)
+				conditionToken = conditionManager.GrantCondition(self, Info.Condition);
+		}
+
+		protected override void TraitDisabled(Actor self)
+		{
+			if (conditionToken == ConditionManager.InvalidConditionToken)
+				return;
+
+			conditionToken = conditionManager.RevokeCondition(self, conditionToken);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnSubterraneanLayer.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnSubterraneanLayer.cs
@@ -1,0 +1,94 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Mods.Common.Effects;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Grants Condition on subterranean layer. Also plays transition audio-visuals.")]
+	public class GrantConditionOnSubterraneanLayerInfo : GrantConditionOnLayerInfo
+	{
+		[Desc("Dig animation image to play when transitioning.")]
+		public readonly string SubterraneanTransitionImage = null;
+
+		[SequenceReference("SubterraneanTransitionImage")]
+		[Desc("Dig animation sequence to play when transitioning.")]
+		public readonly string SubterraneanTransitionSequence = null;
+
+		[PaletteReference]
+		public readonly string SubterraneanTransitionPalette = "effect";
+
+		[Desc("Dig sound to play when transitioning.")]
+		public readonly string SubterraneanTransitionSound = null;
+
+		public override object Create(ActorInitializer init) { return new GrantConditionOnSubterraneanLayer(init.Self, this); }
+
+		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
+		{
+			var mobileInfo = ai.TraitInfoOrDefault<MobileInfo>();
+			if (mobileInfo == null || !(mobileInfo.LocomotorInfo is SubterraneanLocomotorInfo))
+				throw new YamlException("GrantConditionOnSubterraneanLayer requires Mobile to be linked to a SubterraneanLocomotor!");
+
+			base.RulesetLoaded(rules, ai);
+		}
+	}
+
+	public class GrantConditionOnSubterraneanLayer : GrantConditionOnLayer<GrantConditionOnSubterraneanLayerInfo>, INotifyVisualPositionChanged
+	{
+		WDist transitionDepth;
+
+		public GrantConditionOnSubterraneanLayer(Actor self, GrantConditionOnSubterraneanLayerInfo info)
+			: base(self, info, CustomMovementLayerType.Subterranean) { }
+
+		protected override void Created(Actor self)
+		{
+			var mobileInfo = self.Info.TraitInfo<MobileInfo>();
+			var li = (SubterraneanLocomotorInfo)mobileInfo.LocomotorInfo;
+			transitionDepth = li.SubterraneanTransitionDepth;
+			base.Created(self);
+		}
+
+		void PlayTransitionAudioVisuals(Actor self, CPos fromCell)
+		{
+			if (!string.IsNullOrEmpty(Info.SubterraneanTransitionSequence))
+				self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(self.World.Map.CenterOfCell(fromCell), self.World,
+					Info.SubterraneanTransitionImage,
+					Info.SubterraneanTransitionSequence, Info.SubterraneanTransitionPalette)));
+
+			if (!string.IsNullOrEmpty(Info.SubterraneanTransitionSound))
+				Game.Sound.Play(SoundType.World, Info.SubterraneanTransitionSound);
+		}
+
+		void INotifyVisualPositionChanged.VisualPositionChanged(Actor self, byte oldLayer, byte newLayer)
+		{
+			var depth = self.World.Map.DistanceAboveTerrain(self.CenterPosition);
+
+			// Grant condition when new layer is Subterranean and depth is lower than transition depth,
+			// revoke condition when new layer is not Subterranean and depth is at or higher than transition depth.
+			if (newLayer == ValidLayerType && depth < transitionDepth && conditionToken == ConditionManager.InvalidConditionToken)
+				conditionToken = conditionManager.GrantCondition(self, Info.Condition);
+			else if (newLayer != ValidLayerType && depth > transitionDepth && conditionToken != ConditionManager.InvalidConditionToken)
+			{
+				conditionToken = conditionManager.RevokeCondition(self, conditionToken);
+				PlayTransitionAudioVisuals(self, self.Location);
+			}
+		}
+
+		protected override void UpdateConditions(Actor self, byte oldLayer, byte newLayer)
+		{
+			// Special case, only audio-visuals are played at the time the Layer changes from normal to Subterranean
+			if (newLayer == ValidLayerType && oldLayer != ValidLayerType)
+				PlayTransitionAudioVisuals(self, self.Location);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnTunnelLayer.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnTunnelLayer.cs
@@ -1,0 +1,26 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public class GrantConditionOnTunnelLayerInfo : GrantConditionOnLayerInfo
+	{
+		public override object Create(ActorInitializer init) { return new GrantConditionOnTunnelLayer(init.Self, this); }
+	}
+
+	public class GrantConditionOnTunnelLayer : GrantConditionOnLayer<GrantConditionOnTunnelLayerInfo>
+	{
+		public GrantConditionOnTunnelLayer(Actor self, GrantConditionOnTunnelLayerInfo info)
+			: base(self, info, CustomMovementLayerType.Tunnel) { }
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				// Make sure that the actor can collect this crate type
 				// Crate can only be crushed if it is not in the air.
-				return self.IsAtGroundLevel() && mi.Crushes.Contains(info.CrushClass);
+				return self.IsAtGroundLevel() && mi.LocomotorInfo.Crushes.Contains(info.CrushClass);
 			});
 
 			// Destroy the crate if none of the units in the cell are valid collectors

--- a/OpenRA.Mods.Common/Traits/Crushable.cs
+++ b/OpenRA.Mods.Common/Traits/Crushable.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 			Game.Sound.Play(SoundType.World, Info.CrushSound, crusher.CenterPosition);
 
 			var crusherMobile = crusher.TraitOrDefault<Mobile>();
-			self.Kill(crusher, crusherMobile != null ? crusherMobile.Info.CrushDamageTypes : new HashSet<string>());
+			self.Kill(crusher, crusherMobile != null ? crusherMobile.Info.LocomotorInfo.CrushDamageTypes : new HashSet<string>());
 		}
 
 		bool ICrushable.CrushableBy(Actor self, Actor crusher, HashSet<string> crushClasses)

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -185,8 +185,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Start a search from each refinery's delivery location:
 			List<CPos> path;
-			var mi = self.Info.TraitInfo<MobileInfo>();
-			using (var search = PathSearch.FromPoints(self.World, mi, self, refs.Values.Select(r => r.Location), self.Location, false)
+			var li = self.Info.TraitInfo<MobileInfo>().LocomotorInfo;
+			using (var search = PathSearch.FromPoints(self.World, li, self, refs.Values.Select(r => r.Location), self.Location, false)
 				.WithCustomCost(loc =>
 				{
 					if (!refs.ContainsKey(loc))

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		UsesInit<FacingInit>, UsesInit<LocationInit>, UsesInit<SubCellInit>, IActorPreviewInitInfo
 	{
 		[Desc("Which Locomotor does this trait use. Must be defined on the World actor.")]
-		[FieldLoader.Require]
+		[LocomotorReference, FieldLoader.Require]
 		public readonly string Locomotor = null;
 
 		public readonly int InitialFacing = 0;

--- a/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Drawing;
+using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -47,8 +48,9 @@ namespace OpenRA.Mods.Common.Traits
 
 			var aircraftInfo = producee.TraitInfoOrDefault<AircraftInfo>();
 			var mobileInfo = producee.TraitInfoOrDefault<MobileInfo>();
+			var locomotorInfo = mobileInfo.LocomotorInfo;
 
-			var passable = mobileInfo != null ? (uint)mobileInfo.GetMovementClass(self.World.Map.Rules.TileSet) : 0;
+			var passable = mobileInfo != null ? (uint)locomotorInfo.GetMovementClass(self.World.Map.Rules.TileSet) : 0;
 			var destination = rp != null ? rp.Location : self.Location;
 
 			var location = spawnLocation;
@@ -59,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (mobileInfo != null)
 					location = self.World.Map.ChooseClosestMatchingEdgeCell(self.Location,
-						c => mobileInfo.CanEnterCell(self.World, null, c) && domainIndex.IsPassable(c, destination, mobileInfo, passable));
+						c => mobileInfo.CanEnterCell(self.World, null, c) && domainIndex.IsPassable(c, destination, locomotorInfo, passable));
 			}
 
 			// No suitable spawn location could be found, so production has failed.

--- a/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
@@ -48,9 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var aircraftInfo = producee.TraitInfoOrDefault<AircraftInfo>();
 			var mobileInfo = producee.TraitInfoOrDefault<MobileInfo>();
-			var locomotorInfo = mobileInfo.LocomotorInfo;
 
-			var passable = mobileInfo != null ? (uint)locomotorInfo.GetMovementClass(self.World.Map.Rules.TileSet) : 0;
 			var destination = rp != null ? rp.Location : self.Location;
 
 			var location = spawnLocation;
@@ -60,8 +58,11 @@ namespace OpenRA.Mods.Common.Traits
 					location = self.World.Map.ChooseClosestEdgeCell(self.Location);
 
 				if (mobileInfo != null)
+				{
+					var locomotorInfo = mobileInfo.LocomotorInfo;
 					location = self.World.Map.ChooseClosestMatchingEdgeCell(self.Location,
-						c => mobileInfo.CanEnterCell(self.World, null, c) && domainIndex.IsPassable(c, destination, locomotorInfo, passable));
+						c => mobileInfo.CanEnterCell(self.World, null, c) && domainIndex.IsPassable(c, destination, locomotorInfo));
+				}
 			}
 
 			// No suitable spawn location could be found, so production has failed.

--- a/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
+++ b/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
@@ -29,15 +29,14 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			domainIndexes = new Dictionary<uint, MovementClassDomainIndex>();
 			var tileSet = world.Map.Rules.TileSet;
-			var movementClasses =
-				world.Map.Rules.Actors.Where(ai => ai.Value.HasTraitInfo<MobileInfo>())
-					.Select(ai => (uint)ai.Value.TraitInfo<MobileInfo>().GetMovementClass(tileSet)).Distinct();
+			var locomotors = world.WorldActor.TraitsImplementing<Locomotor>().Where(l => !string.IsNullOrEmpty(l.Info.Name));
+			var movementClasses = locomotors.Select(t => (uint)t.Info.GetMovementClass(tileSet)).Distinct();
 
 			foreach (var mc in movementClasses)
 				domainIndexes[mc] = new MovementClassDomainIndex(world, mc);
 		}
 
-		public bool IsPassable(CPos p1, CPos p2, MobileInfo mi, uint movementClass)
+		public bool IsPassable(CPos p1, CPos p2, LocomotorInfo loco, uint movementClass)
 		{
 			// HACK: Work around units in other movement layers from being blocked
 			// when the point in the main layer is not pathable
@@ -45,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 				return true;
 
 			// HACK: Workaround until we can generalize movement classes
-			if (mi.Subterranean || mi.Jumpjet)
+			if (loco is SubterraneanLocomotorInfo || loco is JumpjetLocomotorInfo)
 				return true;
 
 			return domainIndexes[movementClass].IsPassable(p1, p2);

--- a/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
+++ b/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
@@ -44,8 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (p1.Layer != 0 || p2.Layer != 0)
 				return true;
 
-			// HACK: Workaround until we can generalize movement classes
-			if (li is SubterraneanLocomotorInfo || li is JumpjetLocomotorInfo)
+			if (li.DisableDomainPassabilityCheck)
 				return true;
 
 			var movementClass = li.GetMovementClass(tileSet);

--- a/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
+++ b/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
@@ -23,12 +23,13 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class DomainIndex : IWorldLoaded
 	{
+		TileSet tileSet;
 		Dictionary<uint, MovementClassDomainIndex> domainIndexes;
 
 		public void WorldLoaded(World world, WorldRenderer wr)
 		{
 			domainIndexes = new Dictionary<uint, MovementClassDomainIndex>();
-			var tileSet = world.Map.Rules.TileSet;
+			tileSet = world.Map.Rules.TileSet;
 			var locomotors = world.WorldActor.TraitsImplementing<Locomotor>().Where(l => !string.IsNullOrEmpty(l.Info.Name));
 			var movementClasses = locomotors.Select(t => (uint)t.Info.GetMovementClass(tileSet)).Distinct();
 
@@ -36,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 				domainIndexes[mc] = new MovementClassDomainIndex(world, mc);
 		}
 
-		public bool IsPassable(CPos p1, CPos p2, LocomotorInfo loco, uint movementClass)
+		public bool IsPassable(CPos p1, CPos p2, LocomotorInfo li)
 		{
 			// HACK: Work around units in other movement layers from being blocked
 			// when the point in the main layer is not pathable
@@ -44,9 +45,10 @@ namespace OpenRA.Mods.Common.Traits
 				return true;
 
 			// HACK: Workaround until we can generalize movement classes
-			if (loco is SubterraneanLocomotorInfo || loco is JumpjetLocomotorInfo)
+			if (li is SubterraneanLocomotorInfo || li is JumpjetLocomotorInfo)
 				return true;
 
+			var movementClass = li.GetMovementClass(tileSet);
 			return domainIndexes[movementClass].IsPassable(p1, p2);
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/ElevatedBridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ElevatedBridgeLayer.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		bool ICustomMovementLayer.EnabledForActor(ActorInfo a, MobileInfo mi) { return enabled; }
+		bool ICustomMovementLayer.EnabledForActor(ActorInfo a, LocomotorInfo li) { return enabled; }
 		byte ICustomMovementLayer.Index { get { return CustomMovementLayerType.ElevatedBridge; } }
 		bool ICustomMovementLayer.InteractsWithDefaultLayer { get { return true; } }
 
@@ -78,12 +78,12 @@ namespace OpenRA.Mods.Common.Traits
 			return cellCenters[cell];
 		}
 
-		int ICustomMovementLayer.EntryMovementCost(ActorInfo a, MobileInfo mi, CPos cell)
+		int ICustomMovementLayer.EntryMovementCost(ActorInfo a, LocomotorInfo li, CPos cell)
 		{
 			return ends.Contains(cell) ? 0 : int.MaxValue;
 		}
 
-		int ICustomMovementLayer.ExitMovementCost(ActorInfo a, MobileInfo mi, CPos cell)
+		int ICustomMovementLayer.ExitMovementCost(ActorInfo a, LocomotorInfo li, CPos cell)
 		{
 			return ends.Contains(cell) ? 0 : int.MaxValue;
 		}

--- a/OpenRA.Mods.Common/Traits/World/JumpjetActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/JumpjetActorLayer.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		bool ICustomMovementLayer.EnabledForActor(ActorInfo a, MobileInfo mi) { return mi.Jumpjet; }
+		bool ICustomMovementLayer.EnabledForActor(ActorInfo a, LocomotorInfo li) { return li is JumpjetLocomotorInfo; }
 		byte ICustomMovementLayer.Index { get { return CustomMovementLayerType.Jumpjet; } }
 		bool ICustomMovementLayer.InteractsWithDefaultLayer { get { return true; } }
 
@@ -72,13 +72,14 @@ namespace OpenRA.Mods.Common.Traits
 			return pos + new WVec(0, 0, height[cell] - pos.Z);
 		}
 
-		bool ValidTransitionCell(CPos cell, MobileInfo mi)
+		bool ValidTransitionCell(CPos cell, LocomotorInfo li)
 		{
 			var terrainType = map.GetTerrainInfo(cell).Type;
-			if (!mi.JumpjetTransitionTerrainTypes.Contains(terrainType) && mi.JumpjetTransitionTerrainTypes.Any())
+			var jli = (JumpjetLocomotorInfo)li;
+			if (!jli.JumpjetTransitionTerrainTypes.Contains(terrainType) && jli.JumpjetTransitionTerrainTypes.Any())
 				return false;
 
-			if (mi.JumpjetTransitionOnRamps)
+			if (jli.JumpjetTransitionOnRamps)
 				return true;
 
 			var tile = map.Tiles[cell];
@@ -86,14 +87,16 @@ namespace OpenRA.Mods.Common.Traits
 			return ti == null || ti.RampType == 0;
 		}
 
-		int ICustomMovementLayer.EntryMovementCost(ActorInfo a, MobileInfo mi, CPos cell)
+		int ICustomMovementLayer.EntryMovementCost(ActorInfo a, LocomotorInfo li, CPos cell)
 		{
-			return ValidTransitionCell(cell, mi) ? mi.JumpjetTransitionCost : int.MaxValue;
+			var jli = (JumpjetLocomotorInfo)li;
+			return ValidTransitionCell(cell, jli) ? jli.JumpjetTransitionCost : int.MaxValue;
 		}
 
-		int ICustomMovementLayer.ExitMovementCost(ActorInfo a, MobileInfo mi, CPos cell)
+		int ICustomMovementLayer.ExitMovementCost(ActorInfo a, LocomotorInfo li, CPos cell)
 		{
-			return ValidTransitionCell(cell, mi) ? mi.JumpjetTransitionCost : int.MaxValue;
+			var jli = (JumpjetLocomotorInfo)li;
+			return ValidTransitionCell(cell, jli) ? jli.JumpjetTransitionCost : int.MaxValue;
 		}
 
 		byte ICustomMovementLayer.GetTerrainIndex(CPos cell)

--- a/OpenRA.Mods.Common/Traits/World/JumpjetLocomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/JumpjetLocomotor.cs
@@ -1,0 +1,36 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Used by Mobile. Required for jumpjet actors. Attach these to the world actor. You can have multiple variants by adding @suffixes.")]
+	public class JumpjetLocomotorInfo : LocomotorInfo
+	{
+		[Desc("Pathfinding cost for taking off or landing.")]
+		public readonly int JumpjetTransitionCost = 0;
+
+		[Desc("The terrain types that this actor can transition on. Leave empty to allow any.")]
+		public readonly HashSet<string> JumpjetTransitionTerrainTypes = new HashSet<string>();
+
+		[Desc("Can this actor transition on slopes?")]
+		public readonly bool JumpjetTransitionOnRamps = true;
+
+		public override object Create(ActorInitializer init) { return new JumpjetLocomotor(init.Self, this); }
+	}
+
+	public class JumpjetLocomotor : Locomotor
+	{
+		public JumpjetLocomotor(Actor self, JumpjetLocomotorInfo info)
+			: base(self, info) { }
+	}
+}

--- a/OpenRA.Mods.Common/Traits/World/JumpjetLocomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/JumpjetLocomotor.cs
@@ -25,6 +25,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Can this actor transition on slopes?")]
 		public readonly bool JumpjetTransitionOnRamps = true;
 
+		public override bool DisableDomainPassabilityCheck { get { return true; } }
+
 		public override object Create(ActorInitializer init) { return new JumpjetLocomotor(init.Self, this); }
 	}
 

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -169,9 +169,9 @@ namespace OpenRA.Mods.Common.Traits
 			return TilesetTerrainInfo[tileset].Select(ti => ti.Cost < int.MaxValue).ToBits();
 		}
 
-		public int GetMovementClass(TileSet tileset)
+		public uint GetMovementClass(TileSet tileset)
 		{
-			return TilesetMovementClass[tileset];
+			return (uint)TilesetMovementClass[tileset];
 		}
 
 		public int TileSetMovementHash(TileSet tileSet)

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -287,6 +287,8 @@ namespace OpenRA.Mods.Common.Traits
 			return true;
 		}
 
+		public virtual bool DisableDomainPassabilityCheck { get { return false; } }
+
 		public virtual object Create(ActorInitializer init) { return new Locomotor(init.Self, this); }
 	}
 

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -1,0 +1,302 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Pathfinder;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Flags]
+	public enum CellConditions
+	{
+		None = 0,
+		TransientActors,
+		BlockedByMovers,
+		All = TransientActors | BlockedByMovers
+	}
+
+	public static class CellConditionsExts
+	{
+		public static bool HasCellCondition(this CellConditions c, CellConditions cellCondition)
+		{
+			// PERF: Enum.HasFlag is slower and requires allocations.
+			return (c & cellCondition) == cellCondition;
+		}
+	}
+
+	public static class CustomMovementLayerType
+	{
+		public const byte Tunnel = 1;
+		public const byte Subterranean = 2;
+		public const byte Jumpjet = 3;
+		public const byte ElevatedBridge = 4;
+	}
+
+	[Desc("Used by Mobile. Attach these to the world actor. You can have multiple variants by adding @suffixes.")]
+	public class LocomotorInfo : ITraitInfo
+	{
+		[Desc("Locomotor ID.")]
+		public readonly string Name = "default";
+
+		public readonly int WaitAverage = 5;
+
+		public readonly int WaitSpread = 2;
+
+		[Desc("Allow multiple (infantry) units in one cell.")]
+		public readonly bool SharesCell = false;
+
+		[Desc("Can the actor be ordered to move in to shroud?")]
+		public readonly bool MoveIntoShroud = true;
+
+		[Desc("e.g. crate, wall, infantry")]
+		public readonly HashSet<string> Crushes = new HashSet<string>();
+
+		[Desc("Types of damage that are caused while crushing. Leave empty for no damage types.")]
+		public readonly HashSet<string> CrushDamageTypes = new HashSet<string>();
+
+		[FieldLoader.LoadUsing("LoadSpeeds", true)]
+		[Desc("Set Water: 0 for ground units and lower the value on rough terrain.")]
+		public readonly Dictionary<string, TerrainInfo> TerrainSpeeds;
+
+		protected static object LoadSpeeds(MiniYaml y)
+		{
+			var ret = new Dictionary<string, TerrainInfo>();
+			foreach (var t in y.ToDictionary()["TerrainSpeeds"].Nodes)
+			{
+				var speed = FieldLoader.GetValue<int>("speed", t.Value.Value);
+				var nodesDict = t.Value.ToDictionary();
+				var cost = nodesDict.ContainsKey("PathingCost")
+					? FieldLoader.GetValue<int>("cost", nodesDict["PathingCost"].Value)
+					: 10000 / speed;
+				ret.Add(t.Key, new TerrainInfo(speed, cost));
+			}
+
+			return ret;
+		}
+
+		TerrainInfo[] LoadTilesetSpeeds(TileSet tileSet)
+		{
+			var info = new TerrainInfo[tileSet.TerrainInfo.Length];
+			for (var i = 0; i < info.Length; i++)
+				info[i] = TerrainInfo.Impassable;
+
+			foreach (var kvp in TerrainSpeeds)
+			{
+				byte index;
+				if (tileSet.TryGetTerrainIndex(kvp.Key, out index))
+					info[index] = kvp.Value;
+			}
+
+			return info;
+		}
+
+		public class TerrainInfo
+		{
+			public static readonly TerrainInfo Impassable = new TerrainInfo();
+
+			public readonly int Cost;
+			public readonly int Speed;
+
+			public TerrainInfo()
+			{
+				Cost = int.MaxValue;
+				Speed = 0;
+			}
+
+			public TerrainInfo(int speed, int cost)
+			{
+				Speed = speed;
+				Cost = cost;
+			}
+		}
+
+		public struct WorldMovementInfo
+		{
+			internal readonly World World;
+			internal readonly TerrainInfo[] TerrainInfos;
+			internal WorldMovementInfo(World world, LocomotorInfo info)
+			{
+				// PERF: This struct allows us to cache the terrain info for the tileset used by the world.
+				// This allows us to speed up some performance-sensitive pathfinding calculations.
+				World = world;
+				TerrainInfos = info.TilesetTerrainInfo[world.Map.Rules.TileSet];
+			}
+		}
+
+		public readonly Cache<TileSet, TerrainInfo[]> TilesetTerrainInfo;
+		public readonly Cache<TileSet, int> TilesetMovementClass;
+
+		public LocomotorInfo()
+		{
+			TilesetTerrainInfo = new Cache<TileSet, TerrainInfo[]>(LoadTilesetSpeeds);
+			TilesetMovementClass = new Cache<TileSet, int>(CalculateTilesetMovementClass);
+		}
+
+		public int MovementCostForCell(World world, CPos cell)
+		{
+			return MovementCostForCell(world, TilesetTerrainInfo[world.Map.Rules.TileSet], cell);
+		}
+
+		int MovementCostForCell(World world, TerrainInfo[] terrainInfos, CPos cell)
+		{
+			if (!world.Map.Contains(cell))
+				return int.MaxValue;
+
+			var index = cell.Layer == 0 ? world.Map.GetTerrainIndex(cell) :
+				world.GetCustomMovementLayers()[cell.Layer].GetTerrainIndex(cell);
+
+			if (index == byte.MaxValue)
+				return int.MaxValue;
+
+			return terrainInfos[index].Cost;
+		}
+
+		public int CalculateTilesetMovementClass(TileSet tileset)
+		{
+			// collect our ability to cross *all* terraintypes, in a bitvector
+			return TilesetTerrainInfo[tileset].Select(ti => ti.Cost < int.MaxValue).ToBits();
+		}
+
+		public int GetMovementClass(TileSet tileset)
+		{
+			return TilesetMovementClass[tileset];
+		}
+
+		public int TileSetMovementHash(TileSet tileSet)
+		{
+			var terrainInfos = TilesetTerrainInfo[tileSet];
+
+			// Compute and return the hash using aggregate
+			return terrainInfos.Aggregate(terrainInfos.Length,
+				(current, terrainInfo) => unchecked(current * 31 + terrainInfo.Cost));
+		}
+
+		public WorldMovementInfo GetWorldMovementInfo(World world)
+		{
+			return new WorldMovementInfo(world, this);
+		}
+
+		public int MovementCostToEnterCell(WorldMovementInfo worldMovementInfo, Actor self, CPos cell, Actor ignoreActor = null, CellConditions check = CellConditions.All)
+		{
+			var cost = MovementCostForCell(worldMovementInfo.World, worldMovementInfo.TerrainInfos, cell);
+			if (cost == int.MaxValue || !CanMoveFreelyInto(worldMovementInfo.World, self, cell, ignoreActor, check))
+				return int.MaxValue;
+			return cost;
+		}
+
+		public SubCell GetAvailableSubCell(
+			World world, Actor self, CPos cell, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, CellConditions check = CellConditions.All)
+		{
+			if (MovementCostForCell(world, cell) == int.MaxValue)
+				return SubCell.Invalid;
+
+			if (check.HasCellCondition(CellConditions.TransientActors))
+			{
+				Func<Actor, bool> checkTransient = otherActor => IsBlockedBy(self, otherActor, ignoreActor, check);
+
+				if (!SharesCell)
+					return world.ActorMap.AnyActorsAt(cell, SubCell.FullCell, checkTransient) ? SubCell.Invalid : SubCell.FullCell;
+
+				return world.ActorMap.FreeSubCell(cell, preferredSubCell, checkTransient);
+			}
+
+			if (!SharesCell)
+				return world.ActorMap.AnyActorsAt(cell, SubCell.FullCell) ? SubCell.Invalid : SubCell.FullCell;
+
+			return world.ActorMap.FreeSubCell(cell, preferredSubCell);
+		}
+
+		static bool IsMovingInMyDirection(Actor self, Actor other)
+		{
+			var otherMobile = other.TraitOrDefault<Mobile>();
+			if (otherMobile == null || !otherMobile.IsMoving)
+				return false;
+
+			var selfMobile = self.TraitOrDefault<Mobile>();
+			if (selfMobile == null)
+				return false;
+
+			// Moving in the same direction if the facing delta is between +/- 90 degrees
+			var delta = Util.NormalizeFacing(otherMobile.Facing - selfMobile.Facing);
+			return delta < 64 || delta > 192;
+		}
+
+		// Determines whether the actor is blocked by other Actors
+		public bool CanMoveFreelyInto(World world, Actor self, CPos cell, Actor ignoreActor, CellConditions check)
+		{
+			if (!check.HasCellCondition(CellConditions.TransientActors))
+				return true;
+
+			if (SharesCell && world.ActorMap.HasFreeSubCell(cell))
+				return true;
+
+			// PERF: Avoid LINQ.
+			foreach (var otherActor in world.ActorMap.GetActorsAt(cell))
+				if (IsBlockedBy(self, otherActor, ignoreActor, check))
+					return false;
+
+			return true;
+		}
+
+		bool IsBlockedBy(Actor self, Actor otherActor, Actor ignoreActor, CellConditions check)
+		{
+			// We are not blocked by the actor we are ignoring.
+			if (otherActor == ignoreActor)
+				return false;
+
+			// If self is null, we don't have a real actor - we're just checking what would happen theoretically.
+			// In such a scenario - we'll just assume any other actor in the cell will block us by default.
+			// If we have a real actor, we can then perform the extra checks that allow us to avoid being blocked.
+			if (self == null)
+				return true;
+
+			// If the check allows: we are not blocked by allied units moving in our direction.
+			if (!check.HasCellCondition(CellConditions.BlockedByMovers) &&
+				self.Owner.Stances[otherActor.Owner] == Stance.Ally &&
+				IsMovingInMyDirection(self, otherActor))
+				return false;
+
+			// If there is a temporary blocker in our path, but we can remove it, we are not blocked.
+			var temporaryBlocker = otherActor.TraitOrDefault<ITemporaryBlocker>();
+			if (temporaryBlocker != null && temporaryBlocker.CanRemoveBlockage(otherActor, self))
+				return false;
+
+			// If we cannot crush the other actor in our way, we are blocked.
+			if (Crushes == null || Crushes.Count == 0)
+				return true;
+
+			// If the other actor in our way cannot be crushed, we are blocked.
+			// PERF: Avoid LINQ.
+			var crushables = otherActor.TraitsImplementing<ICrushable>();
+			foreach (var crushable in crushables)
+				if (crushable.CrushableBy(otherActor, self, Crushes))
+					return false;
+
+			return true;
+		}
+
+		public virtual object Create(ActorInitializer init) { return new Locomotor(init.Self, this); }
+	}
+
+	public class Locomotor
+	{
+		public readonly LocomotorInfo Info;
+
+		public Locomotor(Actor self, LocomotorInfo info)
+		{
+			Info = info;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -67,12 +67,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			// If a water-land transition is required, bail early
 			var domainIndex = world.WorldActor.TraitOrDefault<DomainIndex>();
-			if (domainIndex != null)
-			{
-				var passable = li.GetMovementClass(world.Map.Rules.TileSet);
-				if (!domainIndex.IsPassable(source, target, li, (uint)passable))
-					return EmptyPath;
-			}
+			if (domainIndex != null && !domainIndex.IsPassable(source, target, li))
+				return EmptyPath;
 
 			List<CPos> pb;
 			using (var fromSrc = PathSearch.FromPoint(world, li, self, target, source, true).WithIgnoredActor(ignoreActor))
@@ -104,8 +100,7 @@ namespace OpenRA.Mods.Common.Traits
 			var domainIndex = world.WorldActor.TraitOrDefault<DomainIndex>();
 			if (domainIndex != null)
 			{
-				var passable = li.GetMovementClass(world.Map.Rules.TileSet);
-				tilesInRange = new List<CPos>(tilesInRange.Where(t => domainIndex.IsPassable(source, t, li, (uint)passable)));
+				tilesInRange = new List<CPos>(tilesInRange.Where(t => domainIndex.IsPassable(source, t, li)));
 				if (!tilesInRange.Any())
 					return EmptyPath;
 			}

--- a/OpenRA.Mods.Common/Traits/World/SubterraneanActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SubterraneanActorLayer.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		bool ICustomMovementLayer.EnabledForActor(ActorInfo a, MobileInfo mi) { return mi.Subterranean; }
+		bool ICustomMovementLayer.EnabledForActor(ActorInfo a, LocomotorInfo li) { return li is SubterraneanLocomotorInfo; }
 		byte ICustomMovementLayer.Index { get { return CustomMovementLayerType.Subterranean; } }
 		bool ICustomMovementLayer.InteractsWithDefaultLayer { get { return false; } }
 
@@ -71,13 +71,14 @@ namespace OpenRA.Mods.Common.Traits
 			return pos + new WVec(0, 0, height[cell] - pos.Z);
 		}
 
-		bool ValidTransitionCell(CPos cell, MobileInfo mi)
+		bool ValidTransitionCell(CPos cell, LocomotorInfo li)
 		{
 			var terrainType = map.GetTerrainInfo(cell).Type;
-			if (!mi.SubterraneanTransitionTerrainTypes.Contains(terrainType) && mi.SubterraneanTransitionTerrainTypes.Any())
+			var sli = (SubterraneanLocomotorInfo)li;
+			if (!sli.SubterraneanTransitionTerrainTypes.Contains(terrainType) && sli.SubterraneanTransitionTerrainTypes.Any())
 				return false;
 
-			if (mi.SubterraneanTransitionOnRamps)
+			if (sli.SubterraneanTransitionOnRamps)
 				return true;
 
 			var tile = map.Tiles[cell];
@@ -85,14 +86,16 @@ namespace OpenRA.Mods.Common.Traits
 			return ti == null || ti.RampType == 0;
 		}
 
-		int ICustomMovementLayer.EntryMovementCost(ActorInfo a, MobileInfo mi, CPos cell)
+		int ICustomMovementLayer.EntryMovementCost(ActorInfo a, LocomotorInfo li, CPos cell)
 		{
-			return ValidTransitionCell(cell, mi) ? mi.SubterraneanTransitionCost : int.MaxValue;
+			var sli = (SubterraneanLocomotorInfo)li;
+			return ValidTransitionCell(cell, sli) ? sli.SubterraneanTransitionCost : int.MaxValue;
 		}
 
-		int ICustomMovementLayer.ExitMovementCost(ActorInfo a, MobileInfo mi, CPos cell)
+		int ICustomMovementLayer.ExitMovementCost(ActorInfo a, LocomotorInfo li, CPos cell)
 		{
-			return ValidTransitionCell(cell, mi) ? mi.SubterraneanTransitionCost : int.MaxValue;
+			var sli = (SubterraneanLocomotorInfo)li;
+			return ValidTransitionCell(cell, sli) ? sli.SubterraneanTransitionCost : int.MaxValue;
 		}
 
 		byte ICustomMovementLayer.GetTerrainIndex(CPos cell)

--- a/OpenRA.Mods.Common/Traits/World/SubterraneanLocomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/SubterraneanLocomotor.cs
@@ -29,6 +29,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Depth at which the subterranian condition is applied.")]
 		public readonly WDist SubterraneanTransitionDepth = new WDist(-1024);
 
+		public override bool DisableDomainPassabilityCheck { get { return true; } }
+
 		public override object Create(ActorInitializer init) { return new SubterraneanLocomotor(init.Self, this); }
 	}
 

--- a/OpenRA.Mods.Common/Traits/World/SubterraneanLocomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/SubterraneanLocomotor.cs
@@ -1,0 +1,40 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Used by Mobile. Required for subterranean actors. Attach these to the world actor. You can have multiple variants by adding @suffixes.")]
+	public class SubterraneanLocomotorInfo : LocomotorInfo
+	{
+		[Desc("Pathfinding cost for submerging or reemerging.")]
+		public readonly int SubterraneanTransitionCost = 0;
+
+		[Desc("The terrain types that this actor can transition on. Leave empty to allow any.")]
+		public readonly HashSet<string> SubterraneanTransitionTerrainTypes = new HashSet<string>();
+
+		[Desc("Can this actor transition on slopes?")]
+		public readonly bool SubterraneanTransitionOnRamps = false;
+
+		[Desc("Depth at which the subterranian condition is applied.")]
+		public readonly WDist SubterraneanTransitionDepth = new WDist(-1024);
+
+		public override object Create(ActorInitializer init) { return new SubterraneanLocomotor(init.Self, this); }
+	}
+
+	public class SubterraneanLocomotor : Locomotor
+	{
+		public SubterraneanLocomotor(Actor self, SubterraneanLocomotorInfo info)
+			: base(self, info) { }
+	}
+}

--- a/OpenRA.Mods.Common/Traits/World/TerrainTunnelLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainTunnelLayer.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		bool ICustomMovementLayer.EnabledForActor(ActorInfo a, MobileInfo mi) { return enabled; }
+		bool ICustomMovementLayer.EnabledForActor(ActorInfo a, LocomotorInfo li) { return enabled; }
 		byte ICustomMovementLayer.Index { get { return CustomMovementLayerType.Tunnel; } }
 		bool ICustomMovementLayer.InteractsWithDefaultLayer { get { return false; } }
 
@@ -77,12 +77,12 @@ namespace OpenRA.Mods.Common.Traits
 			return cellCenters[cell];
 		}
 
-		int ICustomMovementLayer.EntryMovementCost(ActorInfo a, MobileInfo mi, CPos cell)
+		int ICustomMovementLayer.EntryMovementCost(ActorInfo a, LocomotorInfo li, CPos cell)
 		{
 			return portals.Contains(cell) ? 0 : int.MaxValue;
 		}
 
-		int ICustomMovementLayer.ExitMovementCost(ActorInfo a, MobileInfo mi, CPos cell)
+		int ICustomMovementLayer.ExitMovementCost(ActorInfo a, LocomotorInfo li, CPos cell)
 		{
 			return portals.Contains(cell) ? 0 : int.MaxValue;
 		}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -50,6 +50,24 @@ namespace OpenRA.Mods.Common.Traits
 		void Sold(Actor self);
 	}
 
+	[RequireExplicitImplementation]
+	public interface INotifyCustomLayerChanged
+	{
+		void CustomLayerChanged(Actor self, byte oldLayer, byte newLayer);
+	}
+
+	[RequireExplicitImplementation]
+	public interface INotifyVisualPositionChanged
+	{
+		void VisualPositionChanged(Actor self, byte oldLayer, byte newLayer);
+	}
+
+	[RequireExplicitImplementation]
+	public interface INotifyFinishedMoving
+	{
+		void FinishedMoving(Actor self, byte oldLayer, byte newLayer);
+	}
+
 	public interface IDemolishableInfo : ITraitInfoInterface { bool IsValidTarget(ActorInfo actorInfo, Actor saboteur); }
 	public interface IDemolishable
 	{
@@ -313,9 +331,9 @@ namespace OpenRA.Mods.Common.Traits
 		byte Index { get; }
 		bool InteractsWithDefaultLayer { get; }
 
-		bool EnabledForActor(ActorInfo a, MobileInfo mi);
-		int EntryMovementCost(ActorInfo a, MobileInfo mi, CPos cell);
-		int ExitMovementCost(ActorInfo a, MobileInfo mi, CPos cell);
+		bool EnabledForActor(ActorInfo a, LocomotorInfo li);
+		int EntryMovementCost(ActorInfo a, LocomotorInfo li, CPos cell);
+		int ExitMovementCost(ActorInfo a, LocomotorInfo li, CPos cell);
 
 		byte GetTerrainIndex(CPos cell);
 		WPos CenterOfCell(CPos cell);

--- a/OpenRA.Mods.Common/UpdateRules/Rules/DefineLocomotors.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/DefineLocomotors.cs
@@ -1,0 +1,163 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class DefineLocomotors : UpdateRule
+	{
+		public override string Name { get { return "Introduce global Locomotor definitions"; } }
+		public override string Description
+		{
+			get
+			{
+				return "A large number of properties have been moved from the actor-level Mobile trait\n" +
+					"to either world-level Locomotor traits or new actor-level GrantCondition* traits.\n" +
+					"Conditions for subterranean and jumpjet behaviours are migrated,\n" +
+					"and affected Mobile traits are listed for inspection.";
+			}
+		}
+
+		readonly List<Tuple<string, string>> locations = new List<Tuple<string, string>>();
+		bool subterraneanUsed;
+		bool jumpjetUsed;
+
+		readonly string[] locomotorFields =
+		{
+			"TerrainSpeeds", "Crushes", "CrushDamageTypes", "SharesCell", "MoveIntoShroud"
+		};
+
+		readonly string[] subterraneanFields =
+		{
+			"SubterraneanTransitionCost", "SubterraneanTransitionTerrainTypes",
+			"SubterraneanTransitionOnRamps", "SubterraneanTransitionDepth",
+			"SubterraneanTransitionPalette", "SubterraneanTransitionSound",
+		};
+
+		readonly string[] jumpjetFields =
+		{
+			"JumpjetTransitionCost", "JumpjetTransitionTerrainTypes", "JumpjetTransitionOnRamps"
+		};
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			var message = "You must define a set of Locomotor traits to the World actor for the different\n"
+				+ "movement classes used in your mod (e.g. Infantry, Vehicles, Tanks, Ships, etc)\n"
+				+ "and replace any definitions/overrides of the following properties on each\n"
+				+ "actor with a Locomotor field referencing the appropriate locomotor type.\n\n"
+				+ "The standard Locomotor definition contains the following fields:\n"
+				+ UpdateUtils.FormatMessageList(locomotorFields) + "\n\n";
+
+			if (subterraneanUsed)
+				message += "Actors using the subterranean logic should reference a SubterraneanLocomotor\n"
+				+ "instance that extends Locomotor with additional fields:\n"
+				+ UpdateUtils.FormatMessageList(subterraneanFields) + "\n\n";
+
+			if (jumpjetUsed)
+				message += "Actors using the jump-jet logic should reference a JumpjetLocomotor\n"
+				+ "instance that extends Locomotor with additional fields:\n"
+				+ UpdateUtils.FormatMessageList(jumpjetFields) + "\n\n";
+
+			message += "Condition definitions have been automatically migrated.\n"
+				+ "The following definitions reference fields that must be manually moved to Locomotors:\n"
+				+ UpdateUtils.FormatMessageList(locations.Select(n => n.Item1 + " (" + n.Item2 + ")"));
+
+			if (locations.Any())
+				yield return message;
+
+			locations.Clear();
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var addNodes = new List<MiniYamlNode>();
+			foreach (var mobileNode in actorNode.ChildrenMatching("Mobile"))
+			{
+				var checkFields = locomotorFields.Append(subterraneanFields).Append(jumpjetFields);
+				if (checkFields.Any(f => mobileNode.ChildrenMatching(f).Any()))
+					locations.Add(Tuple.Create(actorNode.Key, actorNode.Location.Filename));
+
+				var tunnelConditionNode = mobileNode.LastChildMatching("TunnelCondition");
+				if (tunnelConditionNode != null)
+				{
+					var grantNode = new MiniYamlNode("GrantConditionOnTunnelLayer", "");
+					grantNode.AddNode("Condition", tunnelConditionNode.Value.Value);
+					addNodes.Add(grantNode);
+					mobileNode.RemoveNodes("TunnelCondition");
+				}
+
+				var subterraneanNode = mobileNode.LastChildMatching("Subterranean");
+				if (subterraneanNode != null)
+				{
+					subterraneanUsed = true;
+
+					mobileNode.RemoveNodes("Subterranean");
+					var conditionNode = mobileNode.LastChildMatching("SubterraneanCondition");
+					if (conditionNode != null)
+						conditionNode.RenameKeyPreservingSuffix("Condition");
+
+					var transitionImageNode = mobileNode.LastChildMatching("SubterraneanTransitionImage");
+					var transitionSequenceNode = mobileNode.LastChildMatching("SubterraneanTransitionSequence");
+					var transitionPaletteNode = mobileNode.LastChildMatching("SubterraneanTransitionPalette");
+					var transitionSoundNode = mobileNode.LastChildMatching("SubterraneanTransitionSound");
+
+					var nodes = new[]
+					{
+						conditionNode,
+						transitionImageNode,
+						transitionSequenceNode,
+						transitionPaletteNode,
+						transitionSoundNode
+					};
+
+					if (nodes.Any(n => n != null))
+					{
+						var grantNode = new MiniYamlNode("GrantConditionOnSubterraneanLayer", "");
+						foreach (var node in nodes)
+						{
+							if (node != null)
+							{
+								grantNode.Value.Nodes.Add(node);
+								mobileNode.Value.Nodes.Remove(node);
+							}
+						}
+
+						addNodes.Add(grantNode);
+					}
+				}
+
+				var jumpjetNode = mobileNode.LastChildMatching("Jumpjet");
+				if (jumpjetNode != null)
+				{
+					jumpjetUsed = true;
+
+					mobileNode.RemoveNodes("Jumpjet");
+					var conditionNode = mobileNode.LastChildMatching("JumpjetCondition");
+					if (conditionNode != null)
+					{
+						var grantNode = new MiniYamlNode("GrantConditionOnJumpjetLayer", "");
+						grantNode.AddNode("Condition", conditionNode.Value.Value);
+						mobileNode.RemoveNodes("JumpjetCondition");
+						addNodes.Add(grantNode);
+					}
+				}
+			}
+
+			foreach (var node in addNodes)
+				actorNode.Value.Nodes.Add(node);
+
+			yield break;
+		}
+	}
+}

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -212,15 +212,7 @@
 	Inherits@3: ^SpriteActor
 	Huntable:
 	Mobile:
-		Crushes: crate
-		TerrainSpeeds:
-			Clear: 80
-			Rough: 50
-			Road: 100
-			Bridge: 100
-			Tiberium: 50
-			BlueTiberium: 50
-			Beach: 50
+		Locomotor: wheeled
 		TurnSpeed: 5
 	SelectionDecorations:
 	WithSpriteControlGroupDecoration:
@@ -256,15 +248,7 @@
 ^Tank:
 	Inherits: ^Vehicle
 	Mobile:
-		Crushes: wall, crate, infantry
-		TerrainSpeeds:
-			Clear: 80
-			Rough: 70
-			Road: 100
-			Bridge: 100
-			Tiberium: 70
-			BlueTiberium: 70
-			Beach: 70
+		Locomotor: tracked
 		TurnSpeed: 5
 	Tooltip:
 		GenericName: Tank
@@ -334,18 +318,7 @@
 	RevealsShroud:
 		Range: 5c0
 	Mobile:
-		Crushes: crate
-		SharesCell: true
-		TerrainSpeeds:
-			Clear: 90
-			Rough: 80
-			Road: 100
-			Bridge: 100
-			Tiberium: 70
-				PathingCost: 300
-			BlueTiberium: 70
-				PathingCost: 300
-			Beach: 80
+		Locomotor: foot
 	SelectionDecorations:
 	WithSpriteControlGroupDecoration:
 	Selectable:
@@ -499,15 +472,8 @@
 	RevealsShroud:
 		Range: 6c0
 	Mobile:
-		Crushes: crate
+		Locomotor: critter
 		Speed: 113
-		TerrainSpeeds:
-			Clear: 90
-			Rough: 80
-			Road: 100
-			Tiberium: 70
-			BlueTiberium: 70
-			Beach: 80
 		Voice: Move
 	SelectionDecorations:
 	WithSpriteControlGroupDecoration:
@@ -554,13 +520,7 @@
 	Mobile:
 		Voice: Move
 		Speed: 71
-		TerrainSpeeds:
-			Clear: 70
-			Rough: 60
-			Road: 70
-			Tiberium: 100
-			BlueTiberium: 100
-			Beach: 60
+		Locomotor: critter
 	SelectionDecorations:
 	WithSpriteControlGroupDecoration:
 	Selectable:

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -132,11 +132,7 @@ E5:
 		Description: Advanced general-purpose infantry.\n  Strong vs all Ground units
 	Mobile:
 		Speed: 56
-		TerrainSpeeds:
-			Tiberium: 90
-				PathingCost: 90
-			BlueTiberium: 90
-				PathingCost: 90
+		Locomotor: chem
 	Health:
 		HP: 9000
 	AutoTarget:
@@ -225,8 +221,6 @@ RMBO:
 
 PVICE:
 	Inherits: ^Viceroid
-	Mobile:
-		Crushes: crate
 	Buildable:
 		Queue: Biolab
 		BuildPaletteOrder: 40

--- a/mods/cnc/rules/ships.yaml
+++ b/mods/cnc/rules/ships.yaml
@@ -58,16 +58,7 @@ LST:
 		BuildPaletteOrder: 1000
 		Prerequisites: ~disabled
 	Mobile:
-		Crushes: crate
-		TerrainSpeeds:
-			Clear: 100
-			Rough: 100
-			Road: 100
-			Water: 100
-			Tiberium: 100
-			BlueTiberium: 100
-			Beach: 100
-			River: 100
+		Locomotor: lcraft
 		InitialFacing: 0
 		TurnSpeed: 4
 		Speed: 142

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -16,7 +16,7 @@ MCV:
 		DecorationBounds: 36,36
 	Mobile:
 		Speed: 71
-		Crushes: crate, infantry
+		Locomotor: heavywheeled
 	Health:
 		HP: 120000
 	Armor:
@@ -268,13 +268,7 @@ BIKE:
 	Mobile:
 		TurnSpeed: 10
 		Speed: 213
-		TerrainSpeeds:
-			Clear: 70
-			Rough: 35
-			Road: 100
-			Tiberium: 35
-			BlueTiberium: 35
-			Beach: 35
+		Locomotor: bike
 	Health:
 		HP: 11000
 	Armor:
@@ -426,7 +420,7 @@ HTNK:
 		Queue: Vehicle.GDI
 		Description: Heavily armored GDI Tank.\nCan attack Aircraft.\n  Strong vs Everything
 	Mobile:
-		Crushes: wall, heavywall, crate, infantry
+		Locomotor: heavytracked
 		Speed: 56
 		TurnSpeed: 3
 	Health:
@@ -576,9 +570,9 @@ STNK:
 		Queue: Vehicle.Nod
 		Description: Long-range missile tank that can cloak.\nCan attack Aircraft.\nHas weak armor. Can be spotted by infantry and defense structures.\n  Strong vs Vehicles, Tanks\n  Weak vs Infantry.
 	Mobile:
+		Locomotor: heavywheeled
 		TurnSpeed: 10
 		Speed: 142
-		Crushes: crate, infantry
 	Health:
 		HP: 15000
 	Armor:

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -13,6 +13,115 @@
 		FogVariants: typea, typeb, typec, typed
 		OverrideFullShroud: full
 		OverrideFullFog: full
+	Locomotor@FOOT:
+		Name: foot
+		Crushes: crate
+		SharesCell: true
+		TerrainSpeeds:
+			Clear: 90
+			Rough: 80
+			Road: 100
+			Bridge: 100
+			Tiberium: 70
+				PathingCost: 300
+			BlueTiberium: 70
+				PathingCost: 300
+			Beach: 80
+	Locomotor@CHEM:
+		Name: chem
+		Crushes: crate
+		SharesCell: true
+		TerrainSpeeds:
+			Clear: 90
+			Rough: 80
+			Road: 100
+			Bridge: 100
+			Tiberium: 90
+			BlueTiberium: 90
+			Beach: 80
+	Locomotor@WHEELED:
+		Name: wheeled
+		Crushes: crate
+		TerrainSpeeds:
+			Clear: 80
+			Rough: 50
+			Road: 100
+			Bridge: 100
+			Tiberium: 50
+			BlueTiberium: 50
+			Beach: 50
+	Locomotor@BIKE:
+		Name: bike
+		Crushes: crate
+		TerrainSpeeds:
+			Clear: 70
+			Rough: 35
+			Road: 100
+			Bridge: 100
+			Tiberium: 35
+			BlueTiberium: 35
+			Beach: 35
+	Locomotor@HEAVYWHEELED:
+		Name: heavywheeled
+		Crushes: crate, infantry
+		TerrainSpeeds:
+			Clear: 80
+			Rough: 50
+			Road: 100
+			Bridge: 100
+			Tiberium: 50
+			BlueTiberium: 50
+			Beach: 50
+	Locomotor@TRACKED:
+		Name: tracked
+		Crushes: wall, crate, infantry
+		TerrainSpeeds:
+			Clear: 80
+			Rough: 70
+			Road: 100
+			Bridge: 100
+			Tiberium: 70
+			BlueTiberium: 70
+			Beach: 70
+	Locomotor@HEAVYTRACKED:
+		Name: heavytracked
+		Crushes: wall, heavywall, crate, infantry
+		TerrainSpeeds:
+			Clear: 80
+			Rough: 70
+			Road: 100
+			Bridge: 100
+			Tiberium: 70
+			BlueTiberium: 70
+			Beach: 70
+	Locomotor@NAVAL:
+		Name: naval
+		Crushes: crate
+		TerrainSpeeds:
+			Water: 100
+	Locomotor@LANDINGCRAFT:
+		Name: lcraft
+		Crushes: crate
+		TerrainSpeeds:
+			Clear: 100
+			Rough: 100
+			Road: 100
+			Water: 100
+			Tiberium: 100
+			BlueTiberium: 100
+			Beach: 100
+			River: 100
+	Locomotor@CRITTER:
+		Name: critter
+		Crushes: crate
+		TerrainSpeeds:
+			Clear: 90
+			Rough: 80
+			Road: 100
+			Bridge: 100
+			Tiberium: 70
+			BlueTiberium: 70
+			Beach: 80
 	Faction@Random:
 		Name: Any
 		InternalName: Random

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -79,11 +79,7 @@ sandworm:
 		Type: heavy
 	Mobile:
 		Speed: 42
-		TerrainSpeeds:
-			Sand: 100
-			Dune: 100
-			SpiceSand: 100
-			Spice: 100
+		Locomotor: worm
 	Targetable:
 		TargetTypes: Ground, Creep
 	WithSpriteBody:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -168,17 +168,8 @@
 		GenericName: Unit
 	Huntable:
 	Mobile:
-		Crushes: crate, spicebloom
-		TerrainSpeeds:
-			Sand: 100
-			Rock: 100
-			Transition: 100
-			Concrete: 100
-			SpiceSand: 100
-			Spice: 100
-			SpiceBlobs: 100
-			Dune: 50
 		TurnSpeed: 5
+		Locomotor: vehicle
 		RequiresCondition: !notmobile
 	SelectionDecorations:
 	WithSpriteControlGroupDecoration:
@@ -223,7 +214,7 @@
 ^Tank:
 	Inherits: ^Vehicle
 	Mobile:
-		Crushes: crate, infantry, spicebloom
+		Locomotor: tank
 
 ^Husk:
 	Inherits@1: ^SpriteActor
@@ -281,18 +272,7 @@
 	RevealsShroud:
 		Range: 3c768
 	Mobile:
-		Crushes: crate, spicebloom
-		SharesCell: true
-		TerrainSpeeds:
-			Sand: 100
-			Rock: 100
-			Transition: 100
-			Concrete: 100
-			SpiceSand: 100
-			Spice: 100
-			SpiceBlobs: 100
-			Dune: 80
-			Rough: 80
+		Locomotor: foot
 	SelectionDecorations:
 	WithSpriteControlGroupDecoration:
 	Selectable:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -1,5 +1,5 @@
 mcv:
-	Inherits: ^Vehicle
+	Inherits: ^Tank
 	Buildable:
 		Prerequisites: repair_pad, upgrade.heavy, ~techlevel.medium
 		Queue: Armor
@@ -21,7 +21,6 @@ mcv:
 		Type: light
 	Mobile:
 		Speed: 31
-		Crushes: crate, infantry, spicebloom
 	RevealsShroud:
 		Range: 2c768
 	MustBeDestroyed:
@@ -50,7 +49,7 @@ mcv:
 	-RevealOnFire:
 
 harvester:
-	Inherits: ^Vehicle
+	Inherits: ^Tank
 	Buildable:
 		Queue: Armor
 		Prerequisites: refinery
@@ -80,7 +79,6 @@ harvester:
 		Type: harvester
 	Mobile:
 		Speed: 43
-		Crushes: crate, infantry, spicebloom
 	RevealsShroud:
 		Range: 3c768
 	Explodes:
@@ -331,7 +329,7 @@ devastator:
 	Mobile:
 		TurnSpeed: 3
 		Speed: 31
-		Crushes: crate, infantry, spicebloom, wall
+		Locomotor: devastator
 		RequiresCondition: !overload && !notmobile
 	AutoCarryable:
 		RequiresCondition: !overload

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -15,6 +15,63 @@
 		OverrideFullShroud: shroudfull
 		OverrideFullFog: fogfull
 		ShroudBlend: Multiply
+	Locomotor@FOOT:
+		Name: foot
+		Crushes: crate, spicebloom
+		SharesCell: true
+		TerrainSpeeds:
+			Sand: 100
+			Rock: 100
+			Transition: 100
+			Concrete: 100
+			SpiceSand: 100
+			Spice: 100
+			SpiceBlobs: 100
+			Dune: 80
+			Rough: 80
+	Locomotor@VEHICLE:
+		Name: vehicle
+		Crushes: crate, spicebloom
+		TerrainSpeeds:
+			Sand: 100
+			Rock: 100
+			Transition: 100
+			Concrete: 100
+			SpiceSand: 100
+			Spice: 100
+			SpiceBlobs: 100
+			Dune: 50
+	Locomotor@TANK:
+		Name: tank
+		Crushes: crate, infantry, spicebloom
+		TerrainSpeeds:
+			Sand: 100
+			Rock: 100
+			Transition: 100
+			Concrete: 100
+			SpiceSand: 100
+			Spice: 100
+			SpiceBlobs: 100
+			Dune: 50
+	Locomotor@DEVASTATOR:
+		Name: devastator
+		Crushes: crate, infantry, spicebloom, wall
+		TerrainSpeeds:
+			Sand: 100
+			Rock: 100
+			Transition: 100
+			Concrete: 100
+			SpiceSand: 100
+			Spice: 100
+			SpiceBlobs: 100
+			Dune: 50
+	Locomotor@WORM:
+		Name: worm
+		TerrainSpeeds:
+			Sand: 100
+			Dune: 100
+			SpiceSand: 100
+			Spice: 100
 	Faction@Random:
 		Name: Any
 		InternalName: Random

--- a/mods/ra/maps/allies-03b/rules.yaml
+++ b/mods/ra/maps/allies-03b/rules.yaml
@@ -71,7 +71,7 @@ CAMERA.VeryLarge:
 CAMERA.Jeep:
 	AlwaysVisible:
 	Mobile:
-		TerrainSpeeds:
+		Locomotor: immobile
 	RevealsShroud:
 		Range: 4c0
 	ScriptTriggers:

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -141,7 +141,7 @@ MOBILETENT:
 		Type: Light
 	Mobile:
 		Speed: 85
-		Crushes: wall, mine, crate, infantry
+		Locomotor: heavywheeled
 	RevealsShroud:
 		Range: 4c0
 	MustBeDestroyed:

--- a/mods/ra/maps/monster-tank-madness/rules.yaml
+++ b/mods/ra/maps/monster-tank-madness/rules.yaml
@@ -131,7 +131,6 @@ PBOX:
 		Type: Concrete
 	Mobile:
 		Speed: 42
-		Crushes: wall, mine, crate, infantry
 	RevealsShroud:
 		Range: 6c0
 		RequiresCondition: !friendly

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -220,15 +220,7 @@
 	DrawLineToTarget:
 	UpdatesPlayerStatistics:
 	Mobile:
-		Crushes: mine, crate
-		TerrainSpeeds:
-			Clear: 80
-			Rough: 40
-			Road: 100
-			Bridge: 100
-			Ore: 70
-			Gems: 70
-			Beach: 40
+		Locomotor: wheeled
 		TurnSpeed: 5
 	SelectionDecorations:
 	WithSpriteControlGroupDecoration:
@@ -291,15 +283,7 @@
 ^TrackedVehicle:
 	Inherits: ^Vehicle
 	Mobile:
-		Crushes: wall, mine, crate
-		TerrainSpeeds:
-			Clear: 80
-			Rough: 70
-			Road: 100
-			Bridge: 100
-			Ore: 70
-			Gems: 70
-			Beach: 70
+		Locomotor: tracked
 
 ^Infantry:
 	Inherits@1: ^ExistsInWorld
@@ -316,16 +300,7 @@
 		Range: 4c0
 	Mobile:
 		Speed: 56
-		Crushes: mine, crate
-		SharesCell: true
-		TerrainSpeeds:
-			Clear: 90
-			Rough: 80
-			Road: 100
-			Bridge: 100
-			Ore: 80
-			Gems: 80
-			Beach: 80
+		Locomotor: foot
 	SelectionDecorations:
 	WithSpriteControlGroupDecoration:
 	Selectable:
@@ -457,9 +432,7 @@
 	DrawLineToTarget:
 	UpdatesPlayerStatistics:
 	Mobile:
-		Crushes: crate
-		TerrainSpeeds:
-			Water: 100
+		Locomotor: naval
 	SelectionDecorations:
 	WithSpriteControlGroupDecoration:
 	Selectable:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -259,10 +259,9 @@ LST:
 	Armor:
 		Type: Heavy
 	Mobile:
+		Locomotor: lcraft
 		TurnSpeed: 10
 		Speed: 113
-		TerrainSpeeds:
-			Beach: 70
 		RequiresCondition: !notmobile
 	RevealsShroud:
 		Range: 6c0

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -68,7 +68,6 @@ V2RL:
 		Type: Heavy
 	Mobile:
 		Speed: 128
-		Crushes: wall, mine, crate, infantry
 	RevealsShroud:
 		Range: 5c0
 		RevealGeneratedShroud: False
@@ -112,7 +111,6 @@ V2RL:
 		Type: Heavy
 	Mobile:
 		Speed: 85
-		Crushes: wall, mine, crate, infantry
 	RevealsShroud:
 		Range: 6c0
 		RevealGeneratedShroud: False
@@ -159,7 +157,6 @@ V2RL:
 		Type: Heavy
 	Mobile:
 		Speed: 71
-		Crushes: wall, mine, crate, infantry
 	RevealsShroud:
 		Range: 6c0
 		RevealGeneratedShroud: False
@@ -208,7 +205,7 @@ V2RL:
 		Type: Heavy
 	Mobile:
 		Speed: 50
-		Crushes: wall, mine, crate, infantry, heavywall
+		Locomotor: heavytracked
 	RevealsShroud:
 		Range: 7c0
 		RevealGeneratedShroud: False
@@ -269,6 +266,7 @@ ARTY:
 	Mobile:
 		TurnSpeed: 2
 		Speed: 85
+		Locomotor: lighttracked
 	RevealsShroud:
 		Range: 5c0
 		RevealGeneratedShroud: False
@@ -315,7 +313,7 @@ HARV:
 		Type: Heavy
 	Mobile:
 		Speed: 85
-		Crushes: wall, mine, crate, infantry
+		Locomotor: heavywheeled
 	RevealsShroud:
 		Range: 4c0
 	WithHarvestAnimation:
@@ -361,7 +359,7 @@ MCV:
 		Type: Light
 	Mobile:
 		Speed: 71
-		Crushes: wall, mine, crate, infantry
+		Locomotor: heavywheeled
 	RevealsShroud:
 		Range: 4c0
 	Transforms:
@@ -441,7 +439,6 @@ APC:
 		Type: Heavy
 	Mobile:
 		Speed: 142
-		Crushes: wall, mine, crate, infantry
 		RequiresCondition: !notmobile
 	RevealsShroud:
 		Range: 5c0
@@ -479,7 +476,6 @@ MNLY:
 		Type: Heavy
 	Mobile:
 		Speed: 128
-		Crushes: wall, mine, crate, infantry
 	RevealsShroud:
 		Range: 5c0
 		RevealGeneratedShroud: False
@@ -622,7 +618,6 @@ TTNK:
 		Type: Light
 	Mobile:
 		Speed: 113
-		Crushes: wall, mine, crate, infantry
 	RevealsShroud:
 		Range: 7c0
 		RevealGeneratedShroud: False
@@ -739,7 +734,7 @@ CTNK:
 		Type: Light
 	Mobile:
 		Speed: 113
-		Crushes: wall, mine, crate, infantry
+		Locomotor: heavywheeled
 	RevealsShroud:
 		Range: 6c0
 		RevealGeneratedShroud: False
@@ -779,7 +774,6 @@ QTNK:
 		Type: Heavy
 	Mobile:
 		Speed: 56
-		Crushes: wall, mine, crate, infantry
 	RevealsShroud:
 		Range: 6c0
 		RevealGeneratedShroud: False
@@ -812,7 +806,7 @@ STNK:
 		Type: Light
 	Mobile:
 		Speed: 142
-		Crushes: wall, mine, crate, infantry
+		Locomotor: heavywheeled
 		RequiresCondition: !notmobile
 	RevealsShroud:
 		Range: 7c0

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -8,6 +8,87 @@
 		DefeatMusic: map
 	TerrainGeometryOverlay:
 	DebugVisualizations:
+	Locomotor@FOOT:
+		Name: foot
+		Crushes: mine, crate
+		SharesCell: true
+		TerrainSpeeds:
+			Clear: 90
+			Rough: 80
+			Road: 100
+			Bridge: 100
+			Ore: 80
+			Gems: 80
+			Beach: 80
+	Locomotor@WHEELED:
+		Name: wheeled
+		Crushes: mine, crate
+		TerrainSpeeds:
+			Clear: 80
+			Rough: 40
+			Road: 100
+			Bridge: 100
+			Ore: 70
+			Gems: 70
+			Beach: 40
+	Locomotor@HEAVYWHEELED:
+		Name: heavywheeled
+		Crushes: wall, mine, crate, infantry
+		TerrainSpeeds:
+			Clear: 80
+			Rough: 40
+			Road: 100
+			Bridge: 100
+			Ore: 70
+			Gems: 70
+			Beach: 40
+	Locomotor@LIGHTTRACKED:
+		Name: lighttracked
+		Crushes: wall, mine, crate
+		TerrainSpeeds:
+			Clear: 80
+			Rough: 70
+			Road: 100
+			Bridge: 100
+			Ore: 70
+			Gems: 70
+			Beach: 70
+	Locomotor@TRACKED:
+		Name: tracked
+		Crushes: wall, infantry, mine, crate
+		TerrainSpeeds:
+			Clear: 80
+			Rough: 70
+			Road: 100
+			Bridge: 100
+			Ore: 70
+			Gems: 70
+			Beach: 70
+	Locomotor@HEAVYTRACKED:
+		Name: heavytracked
+		Crushes: wall, infantry, mine, crate, heavywall
+		TerrainSpeeds:
+			Clear: 80
+			Rough: 70
+			Road: 100
+			Bridge: 100
+			Ore: 70
+			Gems: 70
+			Beach: 70
+	Locomotor@NAVAL:
+		Name: naval
+		Crushes: crate
+		TerrainSpeeds:
+			Water: 100
+	Locomotor@LANDINGCRAFT:
+		Name: lcraft
+		Crushes: crate
+		TerrainSpeeds:
+			Water: 100
+			Beach: 70
+	Locomotor@IMMOBILE:
+		Name: immobile
+		TerrainSpeeds:
 	ShroudRenderer:
 		FogVariants: shroud
 		Index: 255, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 20, 40, 56, 65, 97, 130, 148, 194, 24, 33, 66, 132, 28, 41, 67, 134, 1, 2, 4, 8, 3, 6, 12, 9, 7, 14, 13, 11, 5, 10, 15, 255

--- a/mods/ts/rules/civilian-vehicles.yaml
+++ b/mods/ts/rules/civilian-vehicles.yaml
@@ -10,7 +10,6 @@
 	Mobile:
 		Speed: 56
 		TurnSpeed: 5
-		Crushes: wall, crate, infantry
 	Health:
 		HP: 60000
 	Armor:

--- a/mods/ts/rules/critters.yaml
+++ b/mods/ts/rules/critters.yaml
@@ -69,7 +69,7 @@ VISC_SML:
 	RenderSprites:
 		Image: vissml
 	Mobile:
-		Crushes: visceroid-fusing
+		Locomotor: smallvisc
 	Crushable:
 		CrushClasses: visceroid-fusing
 		WarnProbability: 0
@@ -103,8 +103,6 @@ VISC_LRG:
 		MaxMoveDelay: 50
 	WithAttackAnimation:
 		AttackSequence: attack
-	Mobile:
-		Crushes: crate, infantry
 	RenderSprites:
 		Image: vislrg
 
@@ -120,13 +118,7 @@ JFISH:
 		Range: 5c0
 	Mobile:
 		Speed: 72
-		Crushes: crate
-		TerrainSpeeds:
-			Clear: 100
-			Rail: 100
-			DirtRoad: 100
-			Rough: 100
-			Water: 100
+		Locomotor: hover
 	Armament:
 		Weapon: Tentacle
 		FireDelay: 10

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -512,21 +512,7 @@
 	Mobile:
 		Voice: Move
 		Speed: 71
-		Crushes: crate
-		SharesCell: true
-		TerrainSpeeds:
-			Clear: 90
-			Road: 100
-			Bridge: 100
-			Rail: 90
-			DirtRoad: 100
-			Rough: 80
-			Tiberium: 90
-				PathingCost: 90
-			BlueTiberium: 90
-				PathingCost: 90
-			Veins: 50
-		TunnelCondition: inside-tunnel
+		Locomotor: foot
 	WithTextControlGroupDecoration:
 	SelectionDecorations:
 		Palette: pips
@@ -580,6 +566,8 @@
 			Radius: 128
 	EditorTilesetFilter:
 		Categories: Infantry
+	GrantConditionOnTunnelLayer:
+		Condition: inside-tunnel
 
 ^RegularInfantryDeath:
 	WithDeathAnimation@normal:
@@ -697,22 +685,10 @@
 	Huntable:
 	DrawLineToTarget:
 	Mobile:
-		Crushes: crate
-		TerrainSpeeds:
-			Clear: 70
-			Road: 100
-			Bridge: 100
-			Rail: 50
-			DirtRoad: 90
-			Rough: 40
-			Tiberium: 50
-			BlueTiberium: 50
-			Veins: 50
-				PathingCost: 90
 		TurnSpeed: 5
 		Voice: Move
 		RequiresCondition: !empdisable
-		TunnelCondition: inside-tunnel
+		Locomotor: wheeled
 	Selectable:
 		Bounds: 40,24
 	WithTextControlGroupDecoration:
@@ -771,21 +747,13 @@
 	HitShape:
 	EditorTilesetFilter:
 		Categories: Vehicle
+	GrantConditionOnTunnelLayer:
+		Condition: inside-tunnel
 
 ^Tank:
 	Inherits: ^Vehicle
 	Mobile:
-		Crushes: wall, crate, infantry
-		TerrainSpeeds:
-			Clear: 70
-			Road: 100
-			Bridge: 100
-			Rail: 100
-			DirtRoad: 90
-			Rough: 60
-			Tiberium: 70
-			BlueTiberium: 70
-			Veins: 70
+		Locomotor: tracked
 
 ^VoxelActor:
 	BodyOrientation:
@@ -801,7 +769,7 @@
 ^CivilianVoxelCrusher:
 	Inherits: ^CivilianVoxelVehicle
 	Mobile:
-		Crushes: wall, crate, infantry
+		Locomotor: heavywheeled
 
 ^Aircraft:
 	Inherits@2: ^ExistsInWorld
@@ -901,18 +869,7 @@
 	Mobile:
 		Speed: 113
 		TurnSpeed: 16
-		SharesCell: no
-		TerrainSpeeds:
-			Clear: 90
-			Road: 100
-			Bridge: 100
-			Rail: 80
-			DirtRoad: 90
-			Rough: 70
-			Tiberium: 100
-			BlueTiberium: 100
-			Veins: 100
-		TunnelCondition: inside-tunnel
+		Locomotor: visceroid
 	WithTextControlGroupDecoration:
 	SelectionDecorations:
 		Palette: pips
@@ -933,6 +890,8 @@
 			VerticalTopOffset: 512
 	EditorTilesetFilter:
 		Categories: Critter
+	GrantConditionOnTunnelLayer:
+		Condition: inside-tunnel
 
 ^BlossomTree:
 	Inherits@1: ^SpriteActor
@@ -1046,14 +1005,11 @@
 	WithVoxelBody:
 	DrawLineToTarget:
 	Mobile:
-		TerrainSpeeds:
-			Rail: 100
-		Crushes: wall, crate, infantry
 		TurnSpeed: 5
 		Voice: Move
 		Speed: 113
 		RequiresCondition: !empdisable
-		TunnelCondition: inside-tunnel
+		Locomotor: train
 	Cargo:
 		Types: Infantry
 		UnloadVoice: Unload
@@ -1091,6 +1047,8 @@
 	HitShape:
 	EditorTilesetFilter:
 		Categories: Railway
+	GrantConditionOnTunnelLayer:
+		Condition: inside-tunnel
 
 ^TerrainOverlay:
 	AlwaysVisible:

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -87,11 +87,7 @@ JUMPJET:
 		VoiceSet: JumpJet
 	Mobile:
 		Speed: 71
-		Jumpjet: True
-		JumpjetTransitionCost: 100
-		JumpjetCondition: airborne
-		TerrainSpeeds:
-			Jumpjet: 110
+		Locomotor: jumpjet
 	Health:
 		HP: 12000
 	Armor:
@@ -152,6 +148,8 @@ JUMPJET:
 		RequiresCondition: !airborne
 	WithShadow@airborne:
 		RequiresCondition: airborne
+	GrantConditionOnJumpjetLayer:
+		Condition: airborne
 
 JUMPJET.Husk:
 	RenderSprites:

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -13,9 +13,8 @@ APC:
 	Mobile:
 		TurnSpeed: 5
 		Speed: 113
-		TerrainSpeeds:
-			Water: 80
 		RequiresCondition: !empdisable && !loading
+		Locomotor: amphibious
 	Health:
 		HP: 20000
 	Armor:
@@ -63,17 +62,8 @@ HVR:
 		Description: Hovering vehicle armed with\nlong range missiles.\n  Strong vs Vehicles, Aircraft\n  Weak vs Infantry
 	Mobile:
 		Speed: 99
-		TerrainSpeeds:
-			Clear: 100
-			Road: 100
-			Bridge: 100
-			Rail: 100
-			DirtRoad: 100
-			Rough: 100
-			Water: 100
-			Tiberium: 100
-			BlueTiberium: 100
-			Veins: 100
+		Locomotor: hover
+		RequiresCondition: !empdisable
 	Health:
 		HP: 23000
 	Armor:
@@ -164,7 +154,6 @@ MMCH:
 	Mobile:
 		TurnSpeed: 5
 		Speed: 56
-		Crushes: wall, crate, infantry
 	Health:
 		HP: 40000
 	Armor:
@@ -225,7 +214,6 @@ HMEC:
 	Mobile:
 		TurnSpeed: 3
 		Speed: 42
-		Crushes: wall, crate, infantry
 	Health:
 		HP: 80000
 	SelfHealing:
@@ -272,7 +260,6 @@ SONIC:
 	Mobile:
 		TurnSpeed: 4
 		Speed: 56
-		Crushes: wall, crate, infantry
 	Health:
 		HP: 50000
 	Armor:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -98,7 +98,6 @@ TTNK:
 	Mobile:
 		TurnSpeed: 5
 		Speed: 85
-		Crushes: wall, crate, infantry
 		RequiresCondition: !empdisable && undeployed
 	Health:
 		HP: 35000
@@ -366,15 +365,7 @@ SAPC:
 		TurnSpeed: 5
 		Speed: 71
 		RequiresCondition: !empdisable && !loading
-		Subterranean: true
-		SubterraneanCondition: submerged
-		SubterraneanTransitionTerrainTypes: Clear, Rough
-		SubterraneanTransitionCost: 120
-		SubterraneanTransitionSound: subdril1.aud
-		SubterraneanTransitionImage: dig
-		SubterraneanTransitionSequence: idle
-		TerrainSpeeds:
-			Subterranean: 120
+		Locomotor: subterranean
 	Health:
 		HP: 17500
 	Armor:
@@ -394,6 +385,11 @@ SAPC:
 		RequiresCondition: !submerged
 	Targetable:
 		RequiresCondition: !inside-tunnel && !submerged
+	GrantConditionOnSubterraneanLayer:
+		Condition: submerged
+		SubterraneanTransitionImage: dig
+		SubterraneanTransitionSequence: idle
+		SubterraneanTransitionSound: subdril1.aud
 
 SUBTANK:
 	Inherits: ^Tank
@@ -412,16 +408,7 @@ SUBTANK:
 	Mobile:
 		TurnSpeed: 6
 		Speed: 71
-		Crushes: wall, crate, infantry
-		Subterranean: true
-		SubterraneanCondition: submerged
-		SubterraneanTransitionTerrainTypes: Clear, Rough
-		SubterraneanTransitionCost: 120
-		SubterraneanTransitionSound: subdril1.aud
-		SubterraneanTransitionImage: dig
-		SubterraneanTransitionSequence: idle
-		TerrainSpeeds:
-			Subterranean: 120
+		Locomotor: subterranean
 	Health:
 		HP: 30000
 	Armor:
@@ -439,6 +426,11 @@ SUBTANK:
 		RequiresCondition: !submerged
 	Targetable:
 		RequiresCondition: !inside-tunnel && !submerged
+	GrantConditionOnSubterraneanLayer:
+		Condition: submerged
+		SubterraneanTransitionImage: dig
+		SubterraneanTransitionSequence: idle
+		SubterraneanTransitionSound: subdril1.aud
 
 STNK:
 	Inherits: ^Tank
@@ -457,7 +449,6 @@ STNK:
 	Mobile:
 		TurnSpeed: 5
 		Speed: 85
-		Crushes: wall, crate, infantry
 	Health:
 		HP: 18000
 	Armor:

--- a/mods/ts/rules/shared-infantry.yaml
+++ b/mods/ts/rules/shared-infantry.yaml
@@ -72,18 +72,8 @@ FLAMEGUY:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
 	Mobile:
-		Speed: 71
-		SharesCell: true
-		TerrainSpeeds:
-			Clear: 45
-			Road: 50
-			Bridge: 50
-			Rail: 45
-			DirtRoad: 50
-			Rough: 40
-			Tiberium: 45
-			BlueTiberium: 45
-			Veins: 25
+		Speed: 36
+		Locomotor: flameguy
 	HiddenUnderFog:
 	WithInfantryBody:
 		IdleSequences: run

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -69,16 +69,6 @@ HARV:
 		DeliverVoice: Move
 	Mobile:
 		Speed: 71
-		Crushes: wall, crate
-		TerrainSpeeds:
-			Clear: 90
-			Rough: 70
-			Road: 100
-			Bridge: 100
-			Beach: 70
-			Tiberium: 80
-			BlueTiberium: 80
-			Veins: 80
 	Health:
 		HP: 100000
 	SelfHealing:

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -11,6 +11,177 @@
 		UseExtendedIndex: true
 		ShroudPalette: shroud
 		FogPalette: shroud
+	Locomotor@FOOT:
+		Name: foot
+		Crushes: crate
+		SharesCell: true
+		TerrainSpeeds:
+			Clear: 90
+			Road: 100
+			Bridge: 100
+			Rail: 90
+			DirtRoad: 100
+			Rough: 80
+			Tiberium: 90
+			BlueTiberium: 90
+			Veins: 50
+	Locomotor@FLAMEGUY:
+		Name: flameguy
+		SharesCell: true
+		TerrainSpeeds:
+			Clear: 90
+			Road: 100
+			Bridge: 100
+			Rail: 90
+			DirtRoad: 100
+			Rough: 80
+			Tiberium: 90
+			BlueTiberium: 90
+			Veins: 50
+	JumpjetLocomotor@JUMPJET:
+		Name: jumpjet
+		Crushes: crate
+		SharesCell: true
+		JumpjetTransitionCost: 100
+		TerrainSpeeds:
+			Clear: 90
+			Road: 100
+			Bridge: 100
+			Rail: 90
+			DirtRoad: 100
+			Rough: 80
+			Tiberium: 90
+			BlueTiberium: 90
+			Veins: 50
+			Jumpjet: 110
+	Locomotor@WHEELED:
+		Name: wheeled
+		Crushes: crate
+		TerrainSpeeds:
+			Clear: 70
+			Road: 100
+			Bridge: 100
+			Rail: 50
+			DirtRoad: 90
+			Rough: 40
+			Tiberium: 50
+			BlueTiberium: 50
+			Veins: 50
+				PathingCost: 90
+	Locomotor@HEAVYWHEELED:
+		Name: heavywheeled
+		Crushes: wall, crate, infantry
+		TerrainSpeeds:
+			Clear: 70
+			Road: 100
+			Bridge: 100
+			Rail: 50
+			DirtRoad: 90
+			Rough: 40
+			Tiberium: 50
+			BlueTiberium: 50
+			Veins: 50
+				PathingCost: 90
+	Locomotor@TRACKED:
+		Name: tracked
+		Crushes: wall, crate, infantry
+		TerrainSpeeds:
+			Clear: 70
+			Road: 100
+			Bridge: 100
+			Rail: 100
+			DirtRoad: 90
+			Rough: 60
+			Tiberium: 70
+			BlueTiberium: 70
+			Veins: 70
+	Locomotor@AMPHIBIOUS:
+		Name: amphibious
+		Crushes: wall, crate, infantry
+		TerrainSpeeds:
+			Clear: 70
+			Road: 100
+			Bridge: 100
+			Rail: 100
+			DirtRoad: 90
+			Rough: 60
+			Tiberium: 70
+			BlueTiberium: 70
+			Veins: 70
+			Water: 80
+	SubterraneanLocomotor@SUBTERRANEAN:
+		Name: subterranean
+		Crushes: wall, crate, infantry
+		TerrainSpeeds:
+			Clear: 70
+			Road: 100
+			Bridge: 100
+			Rail: 100
+			DirtRoad: 90
+			Rough: 60
+			Tiberium: 70
+			BlueTiberium: 70
+			Veins: 70
+			Subterranean: 120
+		SubterraneanTransitionTerrainTypes: Clear, Rough
+		SubterraneanTransitionCost: 120
+	Locomotor@HOVER:
+		Name: hover
+		Crushes: wall, crate, infantry
+		TerrainSpeeds:
+			Clear: 100
+			Road: 100
+			Bridge: 100
+			Rail: 100
+			DirtRoad: 100
+			Rough: 100
+			Water: 100
+			Tiberium: 100
+			BlueTiberium: 100
+			Veins: 100
+	Locomotor@SMALLVISC:
+		Name: smallvisc
+		Crushes: visceroid-fusing
+		TerrainSpeeds:
+			Clear: 90
+			Road: 100
+			Bridge: 100
+			Rail: 80
+			DirtRoad: 90
+			Rough: 70
+			Tiberium: 100
+			BlueTiberium: 100
+			Veins: 100
+	Locomotor@VISCEROID:
+		Name: visceroid
+		Crushes: crate, infantry
+		TerrainSpeeds:
+			Clear: 90
+			Road: 100
+			Bridge: 100
+			Rail: 80
+			DirtRoad: 90
+			Rough: 70
+			Tiberium: 100
+			BlueTiberium: 100
+			Veins: 100
+	Locomotor@CRITTER:
+		Name: critter
+		TerrainSpeeds:
+			Clear: 90
+			Road: 100
+			Bridge: 100
+			Rail: 80
+			DirtRoad: 90
+			Rough: 70
+			Tiberium: 100
+			BlueTiberium: 100
+			Veins: 100
+	Locomotor@TRAIN:
+		Name: train
+		TerrainSpeeds:
+			Rail: 100
+		Crushes: wall, crate, infantry
 	Faction@Random:
 		Name: Any
 		InternalName: Random


### PR DESCRIPTION
This moves a lot of stuff from `Mobile` to `Locomotor` world trait(s).

The idea is to keep the number of locomotors limited and - in the future - cache/pre-calculate as many things as possible on them, to save performance and make further movement code refactors easier.