### PR TITLE
Make turret Attack/Aim anim traits conditional

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithTurretAttackAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurretAttackAnimation.cs
@@ -55,32 +55,24 @@ namespace OpenRA.Mods.Common.Traits.Render
 				wst.PlayCustomAnimation(self, Info.Sequence);
 		}
 
+		void NotifyAttack(Actor self)
+		{
+			if (Info.Delay > 0)
+				tick = Info.Delay;
+			else
+				PlayAttackAnimation(self);
+		}
+
 		void INotifyAttack.Attacking(Actor self, Target target, Armament a, Barrel barrel)
 		{
-			if (IsTraitDisabled || a != armament)
-				return;
-
-			if (Info.DelayRelativeTo == AttackDelayType.Attack)
-			{
-				if (Info.Delay > 0)
-					tick = Info.Delay;
-				else
-					PlayAttackAnimation(self);
-			}
+			if (!IsTraitDisabled && a == armament && Info.DelayRelativeTo == AttackDelayType.Attack)
+				NotifyAttack(self);
 		}
 
 		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel)
 		{
-			if (IsTraitDisabled || a != armament)
-				return;
-
-			if (Info.DelayRelativeTo == AttackDelayType.Preparation)
-			{
-				if (Info.Delay > 0)
-					tick = Info.Delay;
-				else
-					PlayAttackAnimation(self);
-			}
+			if (!IsTraitDisabled && a == armament && Info.DelayRelativeTo == AttackDelayType.Preparation)
+				NotifyAttack(self);
 		}
 
 		void ITick.Tick(Actor self)


### PR DESCRIPTION
This is the third and last part split from #14036 and follow-up to #14846.

- Makes `WithTurretAttackAnimation` and `WithTurretAimAnimation` conditional
- adds Ruleset.Loaded check on `WithTurretAimAnimation` to prevent modders from using both on the same turret, as they currently conflict with each other too much
- de-duplicates `INotifyAttack.PreparingAttack` and `INotifyAttack.Attacking` in `WithTurretAttackAnimation`, by extracting a shared `NotifyAttack` method