### PR TITLE
Gave RA/TD service depots more accurate hitshapes

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -563,14 +563,9 @@ HQ:
 FIX:
 	Inherits: ^BaseBuilding
 	HitShape:
-		Type: Rectangle
-			TopLeft: -1536, -683
-			BottomRight: 1536, 768
-	HitShape@TOPANDBOTTOM:
-		TargetableOffsets: 840,0,0, -1060,0,0
-		Type: Rectangle
-			TopLeft: -640, -980
-			BottomRight: 640, 1110
+		TargetableOffsets: 840,0,0, 598,-640,0, 598,640,0, -1060,0,0, -768,-640,0, -768,640,0
+		Type: Polygon
+			Points: -1536,-256, -341,-940, 341,-940, 1536,-256, 1536,341, 341,1110, -341,1110, -1536,341
 	Valued:
 		Cost: 500
 	Tooltip:

--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -206,14 +206,9 @@ FIXF:
 	Valued:
 		Cost: 120
 	HitShape:
-		Type: Rectangle
-			TopLeft: -1536, -683
-			BottomRight: 1536, 853
-	HitShape@TOPANDBOTTOM:
-		TargetableOffsets: 840,0,0, -1060,0,0
-		Type: Rectangle
-			TopLeft: -640, -768
-			BottomRight: 640, 1024
+		TargetableOffsets: 840,0,0, 598,-640,0, 598,640,0, -1060,0,0, -768,-640,0, -768,640,0
+		Type: Polygon
+			Points: -1536,-300, -640,-811, 640,-811, 1536,-300, 1536,555, 640,1110, -640,1110, -1536,555
 
 FAPW:
 	Inherits: ^FakeBuilding

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1821,14 +1821,9 @@ FIX:
 		Amount: -30
 	ProvidesPrerequisite@buildingname:
 	HitShape:
-		Type: Rectangle
-			TopLeft: -1536, -683
-			BottomRight: 1536, 853
-	HitShape@TOPANDBOTTOM:
-		TargetableOffsets: 840,0,0, -1060,0,0
-		Type: Rectangle
-			TopLeft: -640, -768
-			BottomRight: 640, 1024
+		TargetableOffsets: 840,0,0, 598,-640,0, 598,640,0, -1060,0,0, -768,-640,0, -768,640,0
+		Type: Polygon
+			Points: -1536,-300, -640,-811, 640,-811, 1536,-300, 1536,555, 640,1110, -640,1110, -1536,555
 
 SBAG:
 	Inherits: ^Wall


### PR DESCRIPTION
Used the new Polygon shape to give TD and RA service depots shapes that match the sprite better than what we have on bleed.

Note: Intentionally didn't touch  any other buildings because a) it would be a lot of work and b) due to possible balance implications.

The service depots were a bit of an exception because their shape on bleed isn't *that* far off from the new shapes.

![fix-shape](https://user-images.githubusercontent.com/2857877/37236433-a7cc4a5e-2407-11e8-80c6-a7153681a2bc.png)
![fix-shape-td](https://user-images.githubusercontent.com/2857877/37236434-aa8f92be-2407-11e8-9e59-d061164d821e.png)

