### PR TITLE
Add TrimExcess to TypeDictionary.

### DIFF
--- a/OpenRA.Game/GameRules/ActorInfo.cs
+++ b/OpenRA.Game/GameRules/ActorInfo.cs
@@ -51,6 +51,8 @@ namespace OpenRA
 							throw new YamlException(e.Message);
 					}
 				}
+
+				traits.TrimExcess();
 			}
 			catch (YamlException e)
 			{
@@ -63,6 +65,7 @@ namespace OpenRA
 			Name = name;
 			foreach (var t in traitInfos)
 				traits.Add(t);
+			traits.TrimExcess();
 		}
 
 		static ITraitInfo LoadTraitInfo(ObjectCreator creator, string traitName, MiniYaml my)

--- a/OpenRA.Game/Primitives/TypeDictionary.cs
+++ b/OpenRA.Game/Primitives/TypeDictionary.cs
@@ -97,6 +97,12 @@ namespace OpenRA.Primitives
 				data.Remove(t);
 		}
 
+		public void TrimExcess()
+		{
+			foreach (var objs in data.Values)
+				objs.TrimExcess();
+		}
+
 		public IEnumerator GetEnumerator()
 		{
 			return WithInterface<object>().GetEnumerator();

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -140,6 +140,8 @@ namespace OpenRA.Server
 			foreach (var trait in modData.Manifest.ServerTraits)
 				serverTraits.Add(modData.ObjectCreator.CreateObject<ServerTrait>(trait));
 
+			serverTraits.TrimExcess();
+
 			LobbyInfo = new Session
 			{
 				GlobalSettings =


### PR DESCRIPTION
Small improvement to memory usage. Reduces memory used on the RA shellmap for object arrays from 2.3 MB to 1.7 MB.