### PR TITLE
Cache ITargetablePositions in Actor to speed up Target.Positions

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -77,6 +77,8 @@ namespace OpenRA
 		readonly IMouseBounds[] mouseBounds;
 		readonly IVisibilityModifier[] visibilityModifiers;
 		readonly IDefaultVisibility defaultVisibility;
+		readonly ITargetablePositions[] targetablePositions;
+		WPos[] staticTargetablePositions;
 
 		internal Actor(World world, string name, TypeDictionary initDict)
 		{
@@ -118,6 +120,15 @@ namespace OpenRA
 			visibilityModifiers = TraitsImplementing<IVisibilityModifier>().ToArray();
 			defaultVisibility = Trait<IDefaultVisibility>();
 			Targetables = TraitsImplementing<ITargetable>().ToArray();
+			targetablePositions = TraitsImplementing<ITargetablePositions>().ToArray();
+			world.AddFrameEndTask(w =>
+			{
+				// Caching this in a AddFrameEndTask, because trait construction order might cause problems if done directly at creation time.
+				// All actors that can move should have IMove, if not it's pretty safe to assume the actor is immobile and
+				// all targetable positions can be cached if all ITargetablePositions have no conditional requirements.
+				if (!Info.HasTraitInfo<IMoveInfo>() && targetablePositions.All(tp => tp.AlwaysEnabled))
+					staticTargetablePositions = targetablePositions.SelectMany(tp => tp.TargetablePositions(this)).ToArray();
+			});
 
 			SyncHashes = TraitsImplementing<ISync>().Select(sync => new SyncHash(sync)).ToArray();
 		}
@@ -364,6 +375,18 @@ namespace OpenRA
 					return true;
 
 			return false;
+		}
+
+		public IEnumerable<WPos> GetTargetablePositions()
+		{
+			if (staticTargetablePositions != null)
+				return staticTargetablePositions;
+
+			var enabledTargetablePositionTraits = targetablePositions.Where(Exts.IsTraitEnabled);
+			if (enabledTargetablePositionTraits.Any())
+				return enabledTargetablePositionTraits.SelectMany(tp => tp.TargetablePositions(this));
+
+			return new[] { this.CenterPosition };
 		}
 
 		#region Scripting interface

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -157,14 +157,7 @@ namespace OpenRA.Traits
 						if (!actor.Targetables.Any(Exts.IsTraitEnabled))
 							return new[] { actor.CenterPosition };
 
-						var targetablePositions = actor.TraitsImplementing<ITargetablePositions>().Where(Exts.IsTraitEnabled);
-						if (targetablePositions.Any())
-						{
-							var target = this;
-							return targetablePositions.SelectMany(tp => tp.TargetablePositions(target.actor));
-						}
-
-						return new[] { actor.CenterPosition };
+						return actor.GetTargetablePositions();
 					case TargetType.FrozenActor:
 						return new[] { frozen.CenterPosition };
 					case TargetType.Terrain:

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -354,7 +354,10 @@ namespace OpenRA.Traits
 	public interface ITargetablePositions
 	{
 		IEnumerable<WPos> TargetablePositions(Actor self);
+		bool AlwaysEnabled { get; }
 	}
+
+	public interface IMoveInfo : ITraitInfoInterface { }
 
 	[RequireExplicitImplementation]
 	public interface IGameOver { void GameOver(World world); }

--- a/OpenRA.Mods.Common/Traits/HitShape.cs
+++ b/OpenRA.Mods.Common/Traits/HitShape.cs
@@ -73,6 +73,8 @@ namespace OpenRA.Mods.Common.Traits
 			base.Created(self);
 		}
 
+		bool ITargetablePositions.AlwaysEnabled { get { return Info.RequiresCondition == null; } }
+
 		IEnumerable<WPos> ITargetablePositions.TargetablePositions(Actor self)
 		{
 			if (IsTraitDisabled)

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -334,8 +334,6 @@ namespace OpenRA.Mods.Common.Traits
 		IEnumerable<object> ActorPreviewInits(ActorInfo ai, ActorPreviewType type);
 	}
 
-	public interface IMoveInfo : ITraitInfoInterface { }
-
 	public interface IMove
 	{
 		Activity MoveTo(CPos cell, int nearEnough);


### PR DESCRIPTION
According to https://github.com/OpenRA/OpenRA/pull/13547#issuecomment-311810610, together with  `Production` and 3 movement-related traits `ITargetablePositions` is one of the 5 most-looked-up traits (via `Target.Positions`, which on bleed performs a `TraitsImplementing<ITargetablePositions>().(Exts.IsTraitEnabled)` every time it is called).

Caching it on `Actor` should reduce those trait look-ups.
