### PR TITLE
Fix rendering of IProductionIconOverlay on Spectator UI

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -136,7 +136,7 @@ namespace OpenRA.Mods.Common.Widgets
 				var pio = queue.Trait.Actor.Owner.PlayerActor.TraitsImplementing<IProductionIconOverlay>()
 					.FirstOrDefault(p => p.IsOverlayActive(actor));
 				if (pio != null)
-					WidgetUtils.DrawSHPCentered(pio.Sprite, location + 0.5f * iconSize + pio.Offset(0.5f * iconSize),
+					WidgetUtils.DrawSHPCentered(pio.Sprite, location + 0.5f * iconSize + pio.Offset(iconSize),
 						worldRenderer.Palette(pio.Palette), 0.5f);
 
 				var clock = clocks[queue.Trait];


### PR DESCRIPTION
They weren't placed at where they should be. To test you can open 3 instance of the RA mod, one player as spectator, Infiltrate enemy's production building and build something that is effected by it. As spectator player check the production menu, with and without this change.