### PR TITLE
Add logic to disallowing On Hold on a queue.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -35,6 +35,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Should the prerequisite remain enabled if the owner changes?")]
 		public readonly bool Sticky = true;
 
+		[Desc("Should right clicking on the icon instantly cancel the production instead of putting it on hold?")]
+		public readonly bool DisallowPaused = false;
+
 		[Desc("This percentage value is multiplied with actor cost to translate into build time (lower means faster).")]
 		public readonly int BuildDurationModifier = 100;
 

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -294,9 +294,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 			Game.Sound.Play(SoundType.UI, TabClick);
 
-			if (item.Paused || item.Done || item.TotalCost == item.RemainingCost)
+			if (CurrentQueue.Info.DisallowPaused || item.Paused || item.Done || item.TotalCost == item.RemainingCost)
 			{
-				// Instant cancel of things we have not started yet and things that are finished
+				// Instantly cancel items that haven't started, have finished, or if the queue doesn't support pausing
 				Game.Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.CancelledAudio, World.LocalPlayer.Faction.InternalName);
 				World.IssueOrder(Order.CancelProduction(CurrentQueue.Actor, icon.Name, handleCount));
 			}


### PR DESCRIPTION
Right clicking to an icon for such queue would instanly cancel, regardless of progress.

Generals did not have holding the production. I have broken On Hold while adding instant cash draining on queueing for my Generals Alpha mod. Wanted to properly implement a way of it on upsteam if someone wants to use.