### PR TITLE
Reuse TargetTypes collection in FrozenActor.RefreshState.

### DIFF
--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -101,7 +101,10 @@ namespace OpenRA.Traits
 		public void RefreshState()
 		{
 			Owner = actor.Owner;
-			TargetTypes = actor.GetEnabledTargetTypes().ToHashSet();
+
+			// PERF: Reuse collection to avoid allocations.
+			TargetTypes.Clear();
+			TargetTypes.UnionWith(actor.GetEnabledTargetTypes());
 
 			if (health != null)
 			{


### PR DESCRIPTION
This is called a lot, and saves us reallocating a new hash set each time. Hopefully helps with #14905.