### PR TITLE
Fix actors with PauseOnCondition ammo not scanning for targets when reloading

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -87,6 +87,8 @@ HELI:
 		LocalOffset: 128,-213,-85, 128,213,-85
 		MuzzleSequence: muzzle
 		PauseOnCondition: !ammo
+	AutoTarget:
+		ScanRadius: 4
 	AttackHeli:
 		FacingTolerance: 20
 	AmmoPool:
@@ -146,6 +148,8 @@ ORCA:
 		Weapon: OrcaAAMissiles
 		LocalOffset: 427,-171,-213, 427,171,-213
 		PauseOnCondition: !ammo
+	AutoTarget:
+		ScanRadius: 5
 	AttackHeli:
 		FacingTolerance: 20
 	AmmoPool:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -25,6 +25,8 @@ V2RL:
 	Armament:
 		Weapon: SCUD
 		PauseOnCondition: !ammo
+	AutoTarget:
+		ScanRadius: 10
 	AmmoPool:
 		Ammo: 1
 		PipCount: 0


### PR DESCRIPTION
Fixes #14921.

Introducing PauseOnCondition for V2RLs made them moving towards a-move point instead of acquiring targets and waiting for reload because when reloading they are now don't have any weapon to scan with. Explicit ScanRadius on AutoTarget trait amends this behaviour and forces actors to always scan not depending on the weapon they use.