### PR TITLE
Cache map option ShortGame at game load

### DIFF
--- a/OpenRA.Mods.Common/PlayerExtensions.cs
+++ b/OpenRA.Mods.Common/PlayerExtensions.cs
@@ -16,10 +16,9 @@ namespace OpenRA.Mods.Common
 {
 	public static class PlayerExtensions
 	{
-		public static bool HasNoRequiredUnits(this Player player)
+		public static bool HasNoRequiredUnits(this Player player, bool shortGame)
 		{
-			var mapOptions = player.World.WorldActor.Trait<MapOptions>();
-			if (mapOptions.ShortGame)
+			if (shortGame)
 				return !player.World.ActorsHavingTrait<MustBeDestroyed>(t => t.Info.RequiredForShortGame).Any(a => a.Owner == player);
 			return !player.World.ActorsHavingTrait<MustBeDestroyed>().Any(a => a.Owner == player && a.IsInWorld);
 		}

--- a/OpenRA.Mods.Common/Scripting/Properties/MissionObjectiveProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/MissionObjectiveProperties.cs
@@ -20,11 +20,13 @@ namespace OpenRA.Mods.Common.Scripting
 	public class MissionObjectiveProperties : ScriptPlayerProperties, Requires<MissionObjectivesInfo>
 	{
 		readonly MissionObjectives mo;
+		readonly bool shortGame;
 
 		public MissionObjectiveProperties(ScriptContext context, Player player)
 			: base(context, player)
 		{
 			mo = player.PlayerActor.Trait<MissionObjectives>();
+			shortGame = player.World.WorldActor.Trait<MapOptions>().ShortGame;
 		}
 
 		[ScriptActorPropertyActivity]
@@ -112,7 +114,7 @@ namespace OpenRA.Mods.Common.Scripting
 			"the MustBeDestroyed trait (according to the short game option).")]
 		public bool HasNoRequiredUnits()
 		{
-			return Player.HasNoRequiredUnits();
+			return Player.HasNoRequiredUnits(shortGame);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -33,6 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly ConquestVictoryConditionsInfo info;
 		readonly MissionObjectives mo;
+		readonly bool shortGame;
 		Player[] otherPlayers;
 		int objectiveID = -1;
 
@@ -40,6 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			info = cvcInfo;
 			mo = self.Trait<MissionObjectives>();
+			shortGame = self.Owner.World.WorldActor.Trait<MapOptions>().ShortGame;
 		}
 
 		void ITick.Tick(Actor self)
@@ -49,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (objectiveID < 0)
 				objectiveID = mo.Add(self.Owner, info.Objective, ObjectiveType.Primary, true);
 
-			if (!self.Owner.NonCombatant && self.Owner.HasNoRequiredUnits())
+			if (!self.Owner.NonCombatant && self.Owner.HasNoRequiredUnits(shortGame))
 				mo.MarkFailed(self.Owner, objectiveID);
 
 			// Players, NonCombatants, and IsAlliedWith are all fixed once the game starts, so we can cache the result.

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -51,6 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Sync] public int TicksLeft;
 		readonly Player player;
 		readonly MissionObjectives mo;
+		readonly bool shortGame;
 		int objectiveID = -1;
 
 		public StrategicVictoryConditions(Actor self, StrategicVictoryConditionsInfo svcInfo)
@@ -59,6 +60,7 @@ namespace OpenRA.Mods.Common.Traits
 			TicksLeft = info.HoldDuration;
 			player = self.Owner;
 			mo = self.Trait<MissionObjectives>();
+			shortGame = player.World.WorldActor.Trait<MapOptions>().ShortGame;
 		}
 
 		public IEnumerable<Actor> AllPoints
@@ -78,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (objectiveID < 0)
 				objectiveID = mo.Add(player, info.Objective, ObjectiveType.Primary, true);
 
-			if (!self.Owner.NonCombatant && self.Owner.HasNoRequiredUnits())
+			if (!self.Owner.NonCombatant && self.Owner.HasNoRequiredUnits(shortGame))
 				mo.MarkFailed(self.Owner, objectiveID);
 
 			var others = self.World.Players.Where(p => !p.NonCombatant


### PR DESCRIPTION
To reduce MapOptions calls.

Likely negligible in the grand scheme of things, but this is also a fairly small and risk-free change (as map options don't change mid-game).