### PR TITLE
Return IRenderable[] rather than IEnumerable<IRenderable> for animations.

### DIFF
--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Graphics
 		public int CurrentFrame { get { return backwards ? CurrentSequence.Start + CurrentSequence.Length - frame - 1 : frame; } }
 		public Sprite Image { get { return CurrentSequence.GetSprite(CurrentFrame, facingFunc()); } }
 
-		public IEnumerable<IRenderable> Render(WPos pos, WVec offset, int zOffset, PaletteReference palette, float scale)
+		public IRenderable[] Render(WPos pos, WVec offset, int zOffset, PaletteReference palette, float scale)
 		{
 			var imageRenderable = new SpriteRenderable(Image, pos, offset, CurrentSequence.ZOffset + zOffset, palette, scale, IsDecoration);
 
@@ -78,7 +78,7 @@ namespace OpenRA.Graphics
 				xy.Y + (int)(cb.Bottom * scale));
 		}
 
-		public IEnumerable<IRenderable> Render(WPos pos, PaletteReference palette)
+		public IRenderable[] Render(WPos pos, PaletteReference palette)
 		{
 			return Render(pos, WVec.Zero, 0, palette, 1f);
 		}

--- a/OpenRA.Game/Graphics/AnimationWithOffset.cs
+++ b/OpenRA.Game/Graphics/AnimationWithOffset.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Graphics
 			ZOffset = zOffset;
 		}
 
-		public IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr, PaletteReference pal, float scale)
+		public IRenderable[] Render(Actor self, WorldRenderer wr, PaletteReference pal, float scale)
 		{
 			var center = self.CenterPosition;
 			var offset = OffsetFunc != null ? OffsetFunc() : WVec.Zero;

--- a/OpenRA.Game/Graphics/SpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderable.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Graphics
 {
 	public struct SpriteRenderable : IRenderable, IFinalizedRenderable
 	{
-		public static readonly IEnumerable<IRenderable> None = new IRenderable[0].AsEnumerable();
+		public static readonly IEnumerable<IRenderable> None = new IRenderable[0];
 
 		readonly Sprite sprite;
 		readonly WPos pos;


### PR DESCRIPTION
Since some callers now know they have an array, then can enumerate it more efficiently and without allocating an enumerator.