### PR TITLE
RA: Fix silo preventing player elimination

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -44,6 +44,7 @@ Also thanks to:
     * Chris Grant (Unit158)
     * clem
     * Cody Brittain (Generalcamo)
+    * Constantin Helmig (CH4Code)
     * D2k Sardaukar
     * D'Arcy Rush (r34ch)
     * Daniel Derejvanik (Harisson)

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1190,6 +1190,7 @@ SILO:
 	Tooltip:
 		Name: Silo
 	-GivesBuildableArea:
+	-MustBeDestroyed:
 	Health:
 		HP: 30000
 	Armor:


### PR DESCRIPTION
Fixes inconsistency in RA mod. Silos were considered important structures with MustBeDestroyed. In d2k and TD players lose if they have only silos on the map.

Also added me to the Authors considering all my previous commits, too.  