### PR TITLE
Tweak Cruiser and Destroyer turret offsets

### DIFF
--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -160,7 +160,7 @@ DD:
 		Range: 5c0
 	Turreted:
 		TurnSpeed: 7
-		Offset: 341,0,128
+		Offset: 469,0,128
 	Armament@PRIMARY:
 		Weapon: Stinger
 		LocalOffset: 0,-100,0, 0,100,0
@@ -211,7 +211,7 @@ CA:
 		Range: 5c0
 	Turreted@PRIMARY:
 		Turret: primary
-		Offset: -864,0,128
+		Offset: -896,0,128
 		TurnSpeed: 3
 	Turreted@SECONDARY:
 		Turret: secondary


### PR DESCRIPTION
Moved back turret of cruiser a bit more backwards and destroyer turret a bit forward.
Makes them look a bit more like in the original (and in case of the destroyer, videos).

OLD:
![ra-ship-turrets-old](https://user-images.githubusercontent.com/2857877/37573586-d52d2aa4-2b19-11e8-8995-a758c3dd47e4.png)


NEW:
![ra-ship-turrets](https://user-images.githubusercontent.com/2857877/37572785-8ceb9144-2b10-11e8-8da4-b8d242cb4dfc.png)
