### PR TITLE
Fix infinite loop in HeliAttack/HeliReturnToBase

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -59,8 +59,17 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				var nearestHpad = ChooseHelipad(self, false);
 
-				if (nearestHpad == null)
-					return ActivityUtils.SequenceActivities(new Turn(self, initialFacing), new HeliLand(self, true), NextActivity);
+				// If a heli was told to return and there's no (available) RearmBuilding, going to the probable next queued activity (HeliAttack)
+				// would be pointless (due to lack of ammo), and possibly even lead to an infinite loop due to HeliAttack.cs:L79.
+				if (nearestHpad == null && heli.Info.LandWhenIdle)
+				{
+					if (heli.Info.TurnToLand)
+						return ActivityUtils.SequenceActivities(new Turn(self, initialFacing), new HeliLand(self, true));
+
+					return new HeliLand(self, true);
+				}
+				else if (nearestHpad == null && !heli.Info.LandWhenIdle)
+					return null;
 				else
 				{
 					var distanceFromHelipad = (nearestHpad.CenterPosition - self.CenterPosition).HorizontalLength;


### PR DESCRIPTION
This can happen if `HeliAttack` tells the heli to return to base when the player doesn't have any of the `RearmBuildings` available, because the activity queues itself after the `HeliReturnToBase`, and the latter will, after a forced land, then queue back `HeliAttack`, which then immediately queues back HRTB and so on.

Instead, we now assume that if there is no base to return to, going to `NextActivity` is pointless and don't queue it.
RTB was most likely ordered by `HeliAttack` due to lack of ammo, so resuming the attack would be pointless anyway without means to reload first.

Fixes #14479.