### PR TITLE
Fix half-pixel offset in ColorBlock rendering.

### DIFF
--- a/OpenRA.Game/Widgets/WidgetUtils.cs
+++ b/OpenRA.Game/Widgets/WidgetUtils.cs
@@ -65,7 +65,10 @@ namespace OpenRA.Widgets
 
 		public static void FillRectWithColor(Rectangle r, Color c)
 		{
-			Game.Renderer.RgbaColorRenderer.FillRect(new float2(r.Left, r.Top), new float2(r.Right, r.Bottom), c);
+			// Offset to the edges of the pixels
+			var tl = new float2(r.Left - 0.5f, r.Top - 0.5f);
+			var br = new float2(r.Right - 0.5f, r.Bottom - 0.5f);
+			Game.Renderer.RgbaColorRenderer.FillRect(tl, br, c);
 		}
 
 		public static void FillEllipseWithColor(Rectangle r, Color c)


### PR DESCRIPTION
When rendering in HiDPI mode the ColorBlock widget is off by half a pixel.  Standard resolution mode should show no changes.

Before:
<img alt="colorblock_before_hidpi" src="https://user-images.githubusercontent.com/167819/37576087-421677e4-2b09-11e8-806d-8e3ea0b57b2d.png">

After:
<img alt="colorblock_after_hidpi" src="https://user-images.githubusercontent.com/167819/37576088-43015930-2b09-11e8-84ca-7aa2fa7e32b5.png">
