### PR TITLE
Upgrade maps without parsing ruleset

### DIFF
--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -122,7 +122,7 @@ namespace OpenRA
 			}
 		}
 
-		public IEnumerable<Map> EnumerateMapsWithoutCaching(MapClassification classification = MapClassification.System)
+		public IEnumerable<IReadWritePackage> EnumerateMapPackagesWithoutCaching(MapClassification classification = MapClassification.System)
 		{
 			// Utility mod that does not support maps
 			if (!modData.Manifest.Contains<MapGrid>())
@@ -155,12 +155,18 @@ namespace OpenRA
 				{
 					foreach (var map in package.Contents)
 					{
-						var mapPackage = package.OpenPackage(map, modData.ModFiles);
+						var mapPackage = package.OpenPackage(map, modData.ModFiles) as IReadWritePackage;
 						if (mapPackage != null)
-							yield return new Map(modData, mapPackage);
+							yield return mapPackage;
 					}
 				}
 			}
+		}
+
+		public IEnumerable<Map> EnumerateMapsWithoutCaching(MapClassification classification = MapClassification.System)
+		{
+			foreach (var mapPackage in EnumerateMapPackagesWithoutCaching(classification))
+				yield return new Map(modData, mapPackage);
 		}
 
 		public void QueryRemoteMapDetails(string repositoryUrl, IEnumerable<string> uids, Action<MapPreview> mapDetailsReceived = null, Action queryFailed = null)

--- a/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpgradeModCommand.cs
@@ -77,16 +77,16 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			// The map cache won't be valid if there was a map format upgrade, so walk the map packages manually
 			// Only upgrade system maps - user maps must be updated manually using --upgrade-map
 			Console.WriteLine("Processing System Maps:");
-			foreach (var map in modData.MapCache.EnumerateMapsWithoutCaching())
+			foreach (var package in modData.MapCache.EnumerateMapPackagesWithoutCaching())
 			{
 				try
 				{
-					Console.WriteLine(map.Package.Name);
-					UpgradeMapCommand.UpgradeMap(modData, (IReadWritePackage)map.Package, engineDate);
+					Console.WriteLine(package.Name);
+					UpgradeMapCommand.UpgradeMap(modData, package, engineDate);
 				}
 				catch (Exception e)
 				{
-					Console.WriteLine("Failed to upgrade map {0}", map);
+					Console.WriteLine("Failed to upgrade map {0}", package.Name);
 					Console.WriteLine("Error was: {0}", e.ToString());
 				}
 			}


### PR DESCRIPTION
Creating a `Map` object throws an exception if the mod's default Ruleset is not valid.  This is a good thing in most cases, but is a major blocker for #14600 - even an innocuous error (from a yaml syntax perspective) like a missing required key is enough to completely break the upgrade process.

I expect that @reaperrr, @abcdefg30, and others will be familiar with this frustration, but for completeness I have included a testcase that demonstrates the issue when cherry-picked to bleed.

This sidesteps the crash by applying the upgrade rules directly to the map yaml without first parsing a `Map`.  This has an extra side-effect of significantly improving the upgrade rule run time.