### PR TITLE
Rename DefaultCashLocked to DefaultCashDropdownLocked

### DIFF
--- a/mods/cnc/maps/nod02a/rules.yaml
+++ b/mods/cnc/maps/nod02a/rules.yaml
@@ -1,40 +1,8 @@
-^Palettes:
-	-PlayerColorPalette:
-	IndexedPlayerPalette:
-		BasePalette: terrain
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 127, 126, 125, 124, 122, 46, 120, 47, 125, 124, 123, 122, 42, 121, 120, 120
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-	IndexedPlayerPalette@units:
-		BasePalette: terrain
-		BaseName: player-units
-		RemapIndex: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-		PlayerIndex:
-			GDI: 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191
-			Nod: 161, 200, 201, 202, 204, 205, 206, 12, 201, 202, 203, 204, 205, 115, 198, 114
-			Neutral: 192, 164, 132, 155, 133, 197, 112, 12, 163, 132, 155, 133, 134, 197, 154, 198
-
 Player:
-	-ConquestVictoryConditions:
-	MissionObjectives:
-		EarlyGameOver: true
-	Shroud:
-		FogCheckboxLocked: True
-		FogCheckboxEnabled: True
-		ExploredMapCheckboxLocked: True
-		ExploredMapCheckboxEnabled: False
 	PlayerResources:
-		DefaultCashLocked: True
 		DefaultCash: 4000
 
 World:
-	-CrateSpawner:
-	-SpawnMPUnits:
-	-MPStartLocations:
-	ObjectivesPanel:
-		PanelName: MISSION_OBJECTIVES
 	LuaScript:
 		Scripts: nod02a.lua
 	MusicPlaylist:
@@ -46,15 +14,6 @@ World:
 		StartVideo: seige.vqa
 		WinVideo: airstrk.vqa
 		LossVideo: deskill.vqa
-	MapCreeps:
-		CheckboxLocked: True
-		CheckboxEnabled: False
-	MapBuildRadius:
-		AllyBuildRadiusCheckboxLocked: True
-		AllyBuildRadiusCheckboxEnabled: False
-	MapOptions:
-		ShortGameCheckboxLocked: True
-		ShortGameCheckboxEnabled: False
 
 ^Vehicle:
 	Tooltip:

--- a/mods/cnc/maps/the-hot-box/rules.yaml
+++ b/mods/cnc/maps/the-hot-box/rules.yaml
@@ -55,5 +55,5 @@ Player:
 		CrateLocked: True
 		CrateEnabled: True
 	PlayerResources:
-		DefaultCashLocked: True
+		DefaultCashDropdownLocked: True
 		DefaultCash: 5000

--- a/mods/cnc/rules/campaign-maprules.yaml
+++ b/mods/cnc/rules/campaign-maprules.yaml
@@ -26,7 +26,7 @@ Player:
 		ExploredMapCheckboxLocked: True
 		ExploredMapCheckboxEnabled: False
 	PlayerResources:
-		DefaultCashLocked: True
+		DefaultCashDropdownLocked: True
 		DefaultCash: 5000
 
 airstrike.proxy:

--- a/mods/d2k/rules/campaign-rules.yaml
+++ b/mods/d2k/rules/campaign-rules.yaml
@@ -8,7 +8,7 @@ Player:
 		ExploredMapCheckboxLocked: True
 		ExploredMapCheckboxEnabled: False
 	PlayerResources:
-		DefaultCashLocked: True
+		DefaultCashDropdownLocked: True
 
 World:
 	-CrateSpawner:

--- a/mods/ra/maps/bomber-john/rules.yaml
+++ b/mods/ra/maps/bomber-john/rules.yaml
@@ -63,7 +63,7 @@ Player:
 		ExploredMapCheckboxLocked: True
 		ExploredMapCheckboxEnabled: False
 	PlayerResources:
-		DefaultCashLocked: True
+		DefaultCashDropdownLocked: True
 		DefaultCash: 60
 	ChronoshiftPower:
 		Icon: chrono

--- a/mods/ra/maps/drop-zone-battle-of-tikiaki/rules.yaml
+++ b/mods/ra/maps/drop-zone-battle-of-tikiaki/rules.yaml
@@ -72,7 +72,7 @@ Player:
 		ExploredMapCheckboxLocked: True
 		ExploredMapCheckboxEnabled: True
 	PlayerResources:
-		DefaultCashLocked: True
+		DefaultCashDropdownLocked: True
 		DefaultCash: 5000
 	LobbyPrerequisiteCheckbox@GLOBALBOUNTY:
 		Enabled: False

--- a/mods/ra/maps/drop-zone-w/rules.yaml
+++ b/mods/ra/maps/drop-zone-w/rules.yaml
@@ -62,7 +62,7 @@ Player:
 		ExploredMapCheckboxLocked: True
 		ExploredMapCheckboxEnabled: True
 	PlayerResources:
-		DefaultCashLocked: True
+		DefaultCashDropdownLocked: True
 		DefaultCash: 5000
 	LobbyPrerequisiteCheckbox@GLOBALBOUNTY:
 		Enabled: False

--- a/mods/ra/maps/drop-zone/rules.yaml
+++ b/mods/ra/maps/drop-zone/rules.yaml
@@ -72,7 +72,7 @@ Player:
 		ExploredMapCheckboxLocked: True
 		ExploredMapCheckboxEnabled: True
 	PlayerResources:
-		DefaultCashLocked: True
+		DefaultCashDropdownLocked: True
 		DefaultCash: 5000
 	LobbyPrerequisiteCheckbox@GLOBALBOUNTY:
 		Enabled: False

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -96,7 +96,7 @@ Player:
 		ExploredMapCheckboxLocked: True
 		ExploredMapCheckboxEnabled: False
 	PlayerResources:
-		DefaultCashLocked: True
+		DefaultCashDropdownLocked: True
 		DefaultCash: 50
 	-HackyAI@RushAI:
 	-HackyAI@NormalAI:

--- a/mods/ra/maps/training-camp/rules.yaml
+++ b/mods/ra/maps/training-camp/rules.yaml
@@ -22,7 +22,7 @@ Player:
 		ExploredMapCheckboxLocked: True
 		ExploredMapCheckboxEnabled: False
 	PlayerResources:
-		DefaultCashLocked: True
+		DefaultCashDropdownLocked: True
 		DefaultCash: 100
 
 OILB:

--- a/mods/ra/rules/campaign-rules.yaml
+++ b/mods/ra/rules/campaign-rules.yaml
@@ -8,7 +8,7 @@ Player:
 		ExploredMapCheckboxLocked: True
 		ExploredMapCheckboxEnabled: False
 	PlayerResources:
-		DefaultCashLocked: True
+		DefaultCashDropdownLocked: True
 		DefaultCash: 0
 
 World:


### PR DESCRIPTION
Also removes some duplicated rules from `nod02a` as those are already inherited from `campaign-maprules.yaml` and `campaign-palettes.yaml`.

Closes #14944.