### PR TITLE
Fix ActorMap.RemoveInfluenceInner see #14939 

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -389,11 +389,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (influenceNode == null)
 				return;
 
+			RemoveInfluenceInner(ref influenceNode.Next, toRemove);
+
 			if (influenceNode.Actor == toRemove)
 				influenceNode = influenceNode.Next;
-
-			if (influenceNode != null)
-				RemoveInfluenceInner(ref influenceNode.Next, toRemove);
 		}
 
 		void ITick.Tick(Actor self)


### PR DESCRIPTION
RemoveInfluenceInner(influenceNode.Next.Next) is called if influenceNode.Actor == toRemove

Closes #14939.

