### PR TITLE
Fixes rocket soldiers not attacking right away vs air units by increa…

### DIFF
--- a/infantry.yaml
+++ b/infantry.yaml
@@ -1,0 +1,3 @@
+E3:
+	AutoTarget:
+		ScanRadius: 6


### PR DESCRIPTION
…sing scan range +1 cell.

This is a fix I implemented in my CG420 map mods ages ago, and would like to see it used in the base game.

The problem with rocket men vs air is that, upon locking on, they delay before shooting at the air units, allowing the air units to travel 2-4 cells in a rocket soldiers range before actually being shot at.

The simple fix was increasing the ScanRange trait by 1-2 cells. Now, they attack the air units immediately upon being spotted/are within firing range.

Here is the latest CG420 map for the current release with the fix, including some other changes (ignore those, being tweaked):

https://resource.openra.net/maps/26325/

