### PR TITLE
Balance artillery vs all

### DIFF
--- a/ballistics.yaml
+++ b/ballistics.yaml
@@ -1,0 +1,17 @@
+^Artillery:
+	Range: 12c0
+	Projectile: Bullet
+		Speed: 200
+		Blockable: false
+		LaunchAngle: 110
+		Inaccuracy: 1c256
+	Warhead@1Dam: SpreadDamage
+        Spread: 420
+		Versus:
+			None: 42
+			Light: 60
+			Heavy: 35
+			Concrete: 50
+
+155mm:
+	MinRange: 4c0


### PR DESCRIPTION
Through testing, this allows artillery to still be effective vs infantry, while not being over powered, having 3 artillery kill off 50 soldiers. You'll need about 5-6 now for 50 soldiers, roughly, lol. Slight increase in effectiveness vs all vehicles too.