### PR TITLE
Work around AI orders to invalid cells.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -592,6 +592,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		public CPos NearestMoveableCell(CPos target, int minRange, int maxRange)
 		{
+			// HACK: This entire method is a hack, and needs to be replaced with
+			// a proper path search that can account for movement layer transitions.
+			// HACK: Work around code that blindly tries to move to cells in invalid movement layers.
+			// This will need to change (by removing this method completely as above) before we can
+			// properly support user-issued orders on to elevated bridges or other interactable custom layers
+			if (target.Layer != 0)
+				target = new CPos(target.X, target.Y);
+
 			if (CanEnterCell(target))
 				return target;
 


### PR DESCRIPTION
Fixes #14923.
Fixes #14863.
Fixes #14820.

The main (but its possibly not only) cause of these crashes is the AI trying to blindly attack-move units to the location of a target actor in a different movement layer.  `NearestMoveableCell` is not aware of layers, so will happily return a bogus location that then causes a crash.