### PR TITLE
Prevent attack move crashing if selected actors die.

### DIFF
--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -165,6 +165,12 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
+		public override void Tick(World world)
+		{
+			if (subjects.All(s => s.Actor.IsDead))
+				world.CancelInputMode();
+		}
+
 		public override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			var prefix = mi.Modifiers.HasModifier(Modifiers.Ctrl) ? "assaultmove" : "attackmove";

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
@@ -267,7 +267,7 @@ namespace OpenRA.Mods.Common.Widgets
 				return;
 
 			selectedActors = world.Selection.Actors
-				.Where(a => a.Owner == world.LocalPlayer && a.IsInWorld)
+				.Where(a => a.Owner == world.LocalPlayer && a.IsInWorld && !a.IsDead)
 				.ToArray();
 
 			attackMoveDisabled = !selectedActors.Any(a => a.Info.HasTraitInfo<AttackMoveInfo>() && a.Info.HasTraitInfo<AutoTargetInfo>());


### PR DESCRIPTION
- Cancel attack move if all actors die.
- Command bar no longer shows available actions from any dead units.

Fixes #14942.