### PR TITLE
Added ability to customise what happens to an actor when its owner loses.

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -181,6 +181,7 @@ namespace OpenRA.Traits
 	public interface INotifyActorDisposing { void Disposing(Actor self); }
 	public interface INotifyOwnerChanged { void OnOwnerChanged(Actor self, Player oldOwner, Player newOwner); }
 	public interface INotifyEffectiveOwnerChanged { void OnEffectiveOwnerChanged(Actor self, Player oldEffectiveOwner, Player newEffectiveOwner); }
+	public interface INotifyOwnerLost { void OnOwnerLost(Actor self); }
 
 	[RequireExplicitImplementation]
 	public interface IVoiced

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -341,6 +341,7 @@
     <Compile Include="Traits\Crates\RevealMapCrateAction.cs" />
     <Compile Include="Traits\Crates\SupportPowerCrateAction.cs" />
     <Compile Include="Traits\Crushable.cs" />
+    <Compile Include="Traits\OwnerLostAction.cs" />
     <Compile Include="Traits\CustomSellValue.cs" />
     <Compile Include="Traits\DamagedByTerrain.cs" />
     <Compile Include="Traits\DeliversCash.cs" />
@@ -876,6 +877,7 @@
     <Compile Include="Traits\Player\PlayerResources.cs" />
     <Compile Include="UtilityCommands\DumpSequenceSheetsCommand.cs" />
     <Compile Include="UpdateRules\Rules\DefineLocomotors.cs" />
+    <Compile Include="UpdateRules\Rules\DefineOwnerLostAction.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.Common/Traits/OwnerLostAction.cs
+++ b/OpenRA.Mods.Common/Traits/OwnerLostAction.cs
@@ -1,0 +1,51 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public enum OwnerLostActionType { ChangeOwner, Dispose, Kill }
+
+	[Desc("Perform an action when the actor's owner is defeated.")]
+	public class OwnerLostActionInfo : ConditionalTraitInfo
+	{
+		[FieldLoader.Require]
+		[Desc("What does this unit do when its owner loses.",
+		"Allowed values are 'ChangeOwner', 'Dispose', 'Kill'")]
+		public readonly OwnerLostActionType Action = OwnerLostActionType.Kill;
+
+		[Desc("Map player to use when 'Action' is 'ChangeOwner'.")]
+		public readonly string Owner = "Neutral";
+
+		public override object Create(ActorInitializer init) { return new OwnerLostAction(init, this); }
+	}
+
+	public class OwnerLostAction : ConditionalTrait<OwnerLostActionInfo>, INotifyOwnerLost
+	{
+		public OwnerLostAction(ActorInitializer init, OwnerLostActionInfo info)
+			: base(info) { }
+
+		void INotifyOwnerLost.OnOwnerLost(Actor self)
+		{
+			if (IsTraitDisabled)
+				return;
+
+			if (Info.Action == OwnerLostActionType.Kill)
+				self.Kill(self);
+			else if (Info.Action == OwnerLostActionType.Dispose)
+				self.Dispose();
+			else if (Info.Action == OwnerLostActionType.ChangeOwner)
+				self.ChangeOwner(self.World.Players.First(p => p.InternalName == Info.Owner));
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -70,8 +70,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void OnPlayerLost(Player player)
 		{
-			foreach (var a in player.World.Actors.Where(a => a.Owner == player))
-				a.Kill(a);
+			foreach (var a in player.World.ActorsWithTrait<INotifyOwnerLost>().Where(a => a.Actor.Owner == player))
+				a.Trait.OnOwnerLost(a.Actor);
 
 			if (info.SuppressNotifications)
 				return;

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -109,8 +109,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void OnPlayerLost(Player player)
 		{
-			foreach (var a in player.World.Actors.Where(a => a.Owner == player))
-				a.Kill(a);
+			foreach (var a in player.World.ActorsWithTrait<INotifyOwnerLost>().Where(a => a.Actor.Owner == player))
+				a.Trait.OnOwnerLost(a.Actor);
 
 			if (info.SuppressNotifications)
 				return;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/DefineOwnerLostAction.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/DefineOwnerLostAction.cs
@@ -1,0 +1,46 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class DefineOwnerLostAction : UpdateRule
+	{
+		public override string Name { get { return "Add OwnerLostAction to player-controlled actors"; } }
+		public override string Description
+		{
+			get
+			{
+				return "A new OwnerLostAction trait has been introduced to control what happens to a\n" +
+				"player's actors when they are defeated. A warning is displayed notifying that\nthis trait must be added to actors.";
+			}
+		}
+
+		bool reported;
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (!reported)
+				yield return "All player-controlled (or player-capturable) actors should define an OwnerLostAction trait\n" +
+					"specifying an action (Kill, Dispose, ChangeOwner) to apply when the actor's owner is defeated.\n" +
+					"You must manually define this trait on the appropriate default actor templates.\n" +
+					"Actors missing this trait will remain controllable by their owner after they have been defeated.";
+
+			reported = true;
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -51,7 +51,8 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new AddShakeToBridge(),
 				new AddEditorPlayer(),
 				new RemovePaletteFromCurrentTileset(),
-				new DefineLocomotors()
+				new DefineLocomotors(),
+				new DefineOwnerLostAction()
 			})
 		};
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -309,8 +309,6 @@
 		Categories: Aircraft
 	SpawnActorOnDeath:
 		RequiresCondition: airborne
-		OwnerType: InternalName
-		EffectiveOwnerFromOwner: true
 
 ^Infantry:
 	Inherits@1: ^ExistsInWorld

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -727,7 +727,7 @@
 ^TechBuilding:
 	Inherits: ^CivBuilding
 	OwnerLostAction:
-		Action: Kill
+		Action: ChangeOwner
 	Capturable:
 	CaptureNotification:
 		Notification: CivilianBuildingCaptured

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -782,7 +782,7 @@
 	CombatDebugOverlay:
 	AppearsOnRadar:
 	OwnerLostAction:
-		Action: Kill
+		Action: ChangeOwner
 	Building:
 		Dimensions: 1,1
 		Footprint: x

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -211,6 +211,8 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@3: ^SpriteActor
 	Huntable:
+	OwnerLostAction:
+		Action: Kill
 	Mobile:
 		Locomotor: wheeled
 		TurnSpeed: 5
@@ -257,6 +259,8 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@3: ^SpriteActor
 	Huntable:
+	OwnerLostAction:
+		Action: Kill
 	AppearsOnRadar:
 		UseLocation: yes
 	Targetable@GROUND:
@@ -312,6 +316,8 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@3: ^SpriteActor
 	Huntable:
+	OwnerLostAction:
+		Action: Kill
 	Health:
 	Armor:
 		Type: None
@@ -457,6 +463,8 @@
 	Inherits@2: ^SpriteActor
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Huntable:
+	OwnerLostAction:
+		Action: Kill
 	Health:
 		HP: 100000
 	Armor:
@@ -567,6 +575,8 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
 	Huntable:
+	OwnerLostAction:
+		Action: Kill
 	AppearsOnRadar:
 		UseLocation: yes
 	HiddenUnderFog:
@@ -589,6 +599,8 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@3: ^SpriteActor
 	Huntable:
+	OwnerLostAction:
+		Action: Kill
 	SelectionDecorations:
 	WithSpriteControlGroupDecoration:
 	Selectable:
@@ -617,6 +629,8 @@
 	Inherits@2: ^SpriteActor
 	Inherits@shape: ^1x1Shape
 	Huntable:
+	OwnerLostAction:
+		Action: Kill
 	SelectionDecorations:
 	WithSpriteControlGroupDecoration:
 	Selectable:
@@ -714,6 +728,8 @@
 
 ^TechBuilding:
 	Inherits: ^CivBuilding
+	OwnerLostAction:
+		Action: Kill
 	Capturable:
 	CaptureNotification:
 		Notification: CivilianBuildingCaptured
@@ -767,6 +783,8 @@
 	Interactable:
 	CombatDebugOverlay:
 	AppearsOnRadar:
+	OwnerLostAction:
+		Action: Kill
 	Building:
 		Dimensions: 1,1
 		Footprint: x

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -29,13 +29,9 @@ carryall.reinforce:
 	SpawnActorOnDeath@CRUISING:
 		Actor: carryall.husk
 		RequiresCondition: cruising
-		OwnerType: InternalName
-		EffectiveOwnerFromOwner: true
 	SpawnActorOnDeath@LANDING:
 		Actor: carryall.huskVTOL
 		RequiresCondition: !cruising
-		OwnerType: InternalName
-		EffectiveOwnerFromOwner: true
 	Carryall:
 		LoadingDelay: 10
 		UnloadingDelay: 15
@@ -114,8 +110,6 @@ ornithopter:
 		Name: Ornithopter
 	SpawnActorOnDeath:
 		Actor: ornithopter.husk
-		OwnerType: InternalName
-		EffectiveOwnerFromOwner: true
 	RejectsOrders:
 	RevealOnFire:
 

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -167,6 +167,8 @@
 	Tooltip:
 		GenericName: Unit
 	Huntable:
+	OwnerLostAction:
+		Action: Kill
 	Mobile:
 		TurnSpeed: 5
 		Locomotor: vehicle
@@ -266,6 +268,8 @@
 	Tooltip:
 		GenericName: Unit
 	Huntable:
+	OwnerLostAction:
+		Action: Kill
 	Health:
 	Armor:
 		Type: none
@@ -334,6 +338,8 @@
 	Tooltip:
 		GenericName: Unit
 	Huntable:
+	OwnerLostAction:
+		Action: Kill
 	AppearsOnRadar:
 		UseLocation: true
 	HiddenUnderFog:
@@ -354,6 +360,8 @@
 	Tooltip:
 		GenericName: Structure
 	Huntable:
+	OwnerLostAction:
+		Action: Kill
 	SelectionDecorations:
 	WithSpriteControlGroupDecoration:
 	Selectable:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -693,7 +693,7 @@ wall:
 	FrozenUnderFog:
 	ScriptTriggers:
 	OwnerLostAction:
-		Action: Kill
+		Action: ChangeOwner
 	Buildable:
 		Queue: Building
 		Prerequisites: barracks

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -692,6 +692,8 @@ wall:
 	CombatDebugOverlay:
 	FrozenUnderFog:
 	ScriptTriggers:
+	OwnerLostAction:
+		Action: Kill
 	Buildable:
 		Queue: Building
 		Prerequisites: barracks

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -65,6 +65,8 @@ TECN:
 FCOM:
 	Inherits: ^TechBuilding
 	Inherits@shape: ^2x2Shape
+	OwnerLostAction:
+		Action: Kill
 	Building:
 		Footprint: xx xx ==
 		Dimensions: 2,3
@@ -98,6 +100,8 @@ FCOM:
 HOSP:
 	Inherits: ^TechBuilding
 	Inherits@shape: ^2x2Shape
+	OwnerLostAction:
+		Action: Kill
 	Selectable:
 		Priority: 0
 	Building:
@@ -364,6 +368,8 @@ MISS:
 		TargetableOffsets: 0,0,0, 840,0,0, 840,-1024,0, 420,768,0, -840,0,0, -840,-1024,0, -840,1024,0
 	Selectable:
 		Priority: 0
+	OwnerLostAction:
+		Action: Kill
 	Building:
 		Footprint: xxx xxx ===
 		Dimensions: 3,3
@@ -393,6 +399,8 @@ MISS:
 BIO:
 	Inherits: ^TechBuilding
 	Inherits@shape: ^2x2Shape
+	OwnerLostAction:
+		Action: Kill
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -418,6 +426,8 @@ OILB:
 		TargetableOffsets: 0,0,0, 630,-300,0, 420,512,0, -420,-512,0, -630,300,0
 	Selectable:
 		Priority: 0
+	OwnerLostAction:
+		Action: Kill
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -66,7 +66,7 @@ FCOM:
 	Inherits: ^TechBuilding
 	Inherits@shape: ^2x2Shape
 	OwnerLostAction:
-		Action: Kill
+		Action: ChangeOwner
 	Building:
 		Footprint: xx xx ==
 		Dimensions: 2,3
@@ -101,7 +101,7 @@ HOSP:
 	Inherits: ^TechBuilding
 	Inherits@shape: ^2x2Shape
 	OwnerLostAction:
-		Action: Kill
+		Action: ChangeOwner
 	Selectable:
 		Priority: 0
 	Building:
@@ -369,7 +369,7 @@ MISS:
 	Selectable:
 		Priority: 0
 	OwnerLostAction:
-		Action: Kill
+		Action: ChangeOwner
 	Building:
 		Footprint: xxx xxx ===
 		Dimensions: 3,3
@@ -400,7 +400,7 @@ BIO:
 	Inherits: ^TechBuilding
 	Inherits@shape: ^2x2Shape
 	OwnerLostAction:
-		Action: Kill
+		Action: ChangeOwner
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -427,7 +427,7 @@ OILB:
 	Selectable:
 		Priority: 0
 	OwnerLostAction:
-		Action: Kill
+		Action: ChangeOwner
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -529,8 +529,6 @@
 		Categories: Aircraft
 	SpawnActorOnDeath:
 		RequiresCondition: airborne
-		OwnerType: InternalName
-		EffectiveOwnerFromOwner: true
 	Explodes:
 		Weapon: UnitExplode
 		RequiresCondition: !airborne

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -651,7 +651,7 @@
 	Inherits@shape: ^1x1Shape
 	Interactable:
 	OwnerLostAction:
-		Action: Kill
+		Action: ChangeOwner
 	Building:
 		Dimensions: 1,1
 		Footprint: x

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -217,6 +217,8 @@
 	Inherits@3: ^SpriteActor
 	Inherits@bounty: ^GlobalBounty
 	Huntable:
+	OwnerLostAction:
+		Action: Kill
 	DrawLineToTarget:
 	UpdatesPlayerStatistics:
 	Mobile:
@@ -291,6 +293,8 @@
 	Inherits@3: ^SpriteActor
 	Inherits@bounty: ^GlobalBounty
 	Huntable:
+	OwnerLostAction:
+		Action: Kill
 	DrawLineToTarget:
 	Health:
 		HP: 2500
@@ -429,6 +433,8 @@
 	Inherits@4: ^SpriteActor
 	Inherits@bounty: ^GlobalBounty
 	Huntable:
+	OwnerLostAction:
+		Action: Kill
 	DrawLineToTarget:
 	UpdatesPlayerStatistics:
 	Mobile:
@@ -472,6 +478,8 @@
 	Inherits@4: ^SpriteActor
 	Inherits@bounty: ^GlobalBounty
 	Huntable:
+	OwnerLostAction:
+		Action: Kill
 	DrawLineToTarget:
 	UpdatesPlayerStatistics:
 	AppearsOnRadar:
@@ -595,6 +603,8 @@
 ^Building:
 	Inherits: ^BasicBuilding
 	Huntable:
+	OwnerLostAction:
+		Action: Kill
 	UpdatesPlayerStatistics:
 	GivesBuildableArea:
 		AreaTypes: building, fake
@@ -642,6 +652,8 @@
 	Inherits@2: ^SpriteActor
 	Inherits@shape: ^1x1Shape
 	Interactable:
+	OwnerLostAction:
+		Action: Kill
 	Building:
 		Dimensions: 1,1
 		Footprint: x

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -825,8 +825,6 @@
 		Categories: Aircraft
 	SpawnActorOnDeath:
 		RequiresCondition: airborne
-		OwnerType: InternalName
-		EffectiveOwnerFromOwner: true
 
 ^Helicopter:
 	Inherits: ^Aircraft

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -439,7 +439,7 @@
 	AppearsOnRadar:
 	Interactable:
 	OwnerLostAction:
-		Action: Kill
+		Action: ChangeOwner
 	Building:
 		Dimensions: 1,1
 		Footprint: x

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -438,6 +438,8 @@
 	FrozenUnderFog:
 	AppearsOnRadar:
 	Interactable:
+	OwnerLostAction:
+		Action: Kill
 	Building:
 		Dimensions: 1,1
 		Footprint: x
@@ -498,6 +500,8 @@
 	Inherits@4: ^Cloakable
 	Inherits@CRATESTATS: ^CrateStatModifiers
 	Huntable:
+	OwnerLostAction:
+		Action: Kill
 	DrawLineToTarget:
 	Health:
 		HP: 5000
@@ -683,6 +687,8 @@
 	Inherits@5: ^DamagedByVeins
 	Inherits@CRATESTATS: ^CrateStatModifiers
 	Huntable:
+	OwnerLostAction:
+		Action: Kill
 	DrawLineToTarget:
 	Mobile:
 		TurnSpeed: 5
@@ -775,6 +781,8 @@
 	Inherits@2: ^ExistsInWorld
 	Inherits@3: ^Cloakable
 	Huntable:
+	OwnerLostAction:
+		Action: Kill
 	DrawLineToTarget:
 	AppearsOnRadar:
 		UseLocation: true


### PR DESCRIPTION
Wanted to hit two bird with one stone, this fixes the issues with the Aircraft Husks (#14858, #14849, #14902), also adds support for #4706, but not implements in this PR for now. I guess it may need furter discussion and to not block this PR as i think husk issues are a bit more important.

The fix for Aircraft Husks are in second commit. I wasn't sure what to do with vehicle husks, current implementation doesn't break anything from them, afaik.

Testcase commit is for testing other 2 things you can make actors to do, change their owner, or get disposed. Testcase makes Tech Structures turn back to neutral and Demo Truck get disposed/not explode.

Fixes #14858.
Fixes #14849.
Fixes #14902.