### PR TITLE
Force buffered sheets to commit data to a texture on buffer release.

### DIFF
--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -153,6 +153,10 @@ namespace OpenRA.Graphics
 				return;
 			dirty = true;
 			releaseBufferOnCommit = true;
+
+			// Commit data from the buffer to the texture, allowing the buffer to be released and reclaimed by GC.
+			if (Game.Renderer != null)
+				GetTexture();
 		}
 
 		public void Dispose()

--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -276,13 +276,8 @@ namespace OpenRA
 				}
 			}
 
-			// The buffer is not fully reclaimed until changes are written out to the texture.
-			// We will access the texture in order to force changes to be written out, allowing the buffer to be freed.
-			Game.RunAfterTick(() =>
-			{
-				sheetBuilder.Current.ReleaseBuffer();
-				sheetBuilder.Current.GetTexture();
-			});
+			// Release the buffer by forcing changes to be written out to the texture, allowing the buffer to be reclaimed by GC.
+			Game.RunAfterTick(sheetBuilder.Current.ReleaseBuffer);
 			Log.Write("debug", "MapCache.LoadAsyncInternal ended");
 		}
 


### PR DESCRIPTION
Previously ReleaseBuffer did not immediately null out the buffer, instead the releaseBufferOnCommit flag allows it to be nulled when the texture is next access and the pending changes from the buffer are committed to it. Now the texture is committed immediately, thus the buffer is null once ReleaseBuffer returns.

Once loaded, we force a GC to reclaim temporary memory used during loading. Previously the buffer would not be null as it was pending commit to the texture and thus could not be reclaimed. As soon as we rendered the first frame, the buffer is nulled but we are now in a low GC state - and the buffer will not be reclaimed until the next gen 2 GC which may be dozens of minutes away.

This change ensures the buffer is null in time for the post-load GC, and thus can be reclaimed before we start rendering.

Reduces memory use post-loading by 34MB on the RA shellmap - similarly when starting games.