### PR TITLE
Tileset Palette field now references a Palette def by name

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/PaletteFromCurrentTileset.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromCurrentTileset.cs
@@ -43,7 +43,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void LoadPalettes(WorldRenderer wr)
 		{
-			wr.AddPalette(info.Name, new ImmutablePalette(wr.World.Map.Open(world.Map.Rules.TileSet.Palette), info.ShadowIndex), info.AllowModifiers);
+			var palette = new ImmutablePalette(wr.Palette(world.Map.Rules.TileSet.Palette).Palette);
+			wr.AddPalette(info.Name, palette, info.AllowModifiers);
 		}
 
 		public IEnumerable<string> PaletteNames { get { yield return info.Name; } }

--- a/mods/cnc/rules/palettes.yaml
+++ b/mods/cnc/rules/palettes.yaml
@@ -1,4 +1,24 @@
 ^Palettes:
+	PaletteFromFile@desert:
+		Name: desert
+		Filename: desert.pal
+		ShadowIndex: 4
+	PaletteFromFile@jungle:
+		Name: jungle
+		Filename: jungle.pal
+		ShadowIndex: 4
+	PaletteFromFile@snow:
+		Name: snow
+		Filename: snow.pal
+		ShadowIndex: 4
+	PaletteFromFile@temperat:
+		Name: temperat
+		Filename: temperat.pal
+		ShadowIndex: 4
+	PaletteFromFile@winter:
+		Name: winter
+		Filename: winter.pal
+		ShadowIndex: 4
 	PaletteFromCurrentTileset@terrain:
 		Name: terrain
 		ShadowIndex: 4

--- a/mods/cnc/tilesets/desert.yaml
+++ b/mods/cnc/tilesets/desert.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Desert
 	Id: DESERT
-	Palette: desert.pal
+	Palette: desert
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge
 	HeightDebugColors: 880000
 

--- a/mods/cnc/tilesets/jungle.yaml
+++ b/mods/cnc/tilesets/jungle.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Jungle
 	Id: JUNGLE
-	Palette: jungle.pal
+	Palette: jungle
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge
 	HeightDebugColors: AA0000
 

--- a/mods/cnc/tilesets/snow.yaml
+++ b/mods/cnc/tilesets/snow.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Snow
 	Id: SNOW
-	Palette: snow.pal
+	Palette: snow
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge
 	HeightDebugColors: 880000
 

--- a/mods/cnc/tilesets/temperat.yaml
+++ b/mods/cnc/tilesets/temperat.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Temperate
 	Id: TEMPERAT
-	Palette: temperat.pal
+	Palette: temperat
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge
 	HeightDebugColors: AA0000
 

--- a/mods/cnc/tilesets/winter.yaml
+++ b/mods/cnc/tilesets/winter.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Winter
 	Id: WINTER
-	Palette: winter.pal
+	Palette: winter
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Beach, River, Bridge
 	HeightDebugColors: 880000
 

--- a/mods/d2k/rules/palettes.yaml
+++ b/mods/d2k/rules/palettes.yaml
@@ -1,4 +1,8 @@
 ^Palettes:
+	PaletteFromFile@arrakis:
+		Name: arrakis
+		Filename: PALETTE.BIN
+		ShadowIndex: 1
 	PaletteFromCurrentTileset:
 		Name: terrain
 	PaletteFromFile@d2k:

--- a/mods/d2k/tilesets/arrakis.yaml
+++ b/mods/d2k/tilesets/arrakis.yaml
@@ -2,7 +2,7 @@ General:
 	Name: Arrakis
 	Id: ARRAKIS
 	SheetSize: 1024
-	Palette: PALETTE.BIN
+	Palette: arrakis
 	EditorTemplateOrder: Basic, Dune, Sand-Detail, Rock-Detail, Ice-Detail, Rock-Sand-Smooth, Sand-Sand-Cliff, Sand-Rock-Cliff, Sand-Ice-Cliff, Rock-Rock-Cliff, Rock-Sand-Cliff, Cliff-Type-Changer, Cliff-Ends, Sand-Platform, Bridge, Rotten-Base, Dead-Worm, Unidentified
 	IgnoreTileSpriteOffsets: True
 	HeightDebugColors: 880000

--- a/mods/ra/rules/palettes.yaml
+++ b/mods/ra/rules/palettes.yaml
@@ -1,4 +1,20 @@
 ^Palettes:
+	PaletteFromFile@desert:
+		Name: desert
+		Filename: desert.pal
+		ShadowIndex: 4
+	PaletteFromFile@interior:
+		Name: interior
+		Filename: interior.pal
+		ShadowIndex: 4
+	PaletteFromFile@snow:
+		Name: snow
+		Filename: snow.pal
+		ShadowIndex: 4
+	PaletteFromFile@temperat:
+		Name: temperat
+		Filename: temperat.pal
+		ShadowIndex: 4
 	PaletteFromFile@player:
 		Name: player
 		Filename: temperat.pal
@@ -20,10 +36,6 @@
 		Filename: temperat.pal
 		ShadowIndex: 4
 		AllowModifiers: false
-	PaletteFromFile@desert:
-		Name: desert
-		Filename: desert.pal
-		ShadowIndex: 4
 	PaletteFromRGBA@shadow:
 		Name: shadow
 		R: 0

--- a/mods/ra/tilesets/desert.yaml
+++ b/mods/ra/tilesets/desert.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Desert
 	Id: DESERT
-	Palette: desert.pal
+	Palette: desert
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Water Cliffs, Beach, River, Bridge
 	HeightDebugColors: 880000
 

--- a/mods/ra/tilesets/interior.yaml
+++ b/mods/ra/tilesets/interior.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Interior
 	Id: INTERIOR
-	Palette: interior.pal
+	Palette: interior
 	EditorTemplateOrder: Floor, Wall
 	HeightDebugColors: 880000
 

--- a/mods/ra/tilesets/snow.yaml
+++ b/mods/ra/tilesets/snow.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Snow
 	Id: SNOW
-	Palette: snow.pal
+	Palette: snow
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Water Cliffs, Beach, River, Bridge
 	HeightDebugColors: 880000
 

--- a/mods/ra/tilesets/temperat.yaml
+++ b/mods/ra/tilesets/temperat.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Temperate
 	Id: TEMPERAT
-	Palette: temperat.pal
+	Palette: temperat
 	SheetSize: 1024
 	EditorTemplateOrder: Terrain, Debris, Road, Cliffs, Water Cliffs, Beach, River, Bridge
 	HeightDebugColors: AA0000

--- a/mods/ts/rules/palettes.yaml
+++ b/mods/ts/rules/palettes.yaml
@@ -1,4 +1,12 @@
 ^Palettes:
+	PaletteFromFile@snow:
+		Name: snow
+		Filename: isosno.pal
+		ShadowIndex: 1
+	PaletteFromFile@temperate:
+		Name: temperate
+		Filename: isotem.pal
+		ShadowIndex: 1
 	PaletteFromFile@mouse:
 		Name: mouse
 		Filename: mousepal.pal

--- a/mods/ts/tilesets/snow.yaml
+++ b/mods/ts/tilesets/snow.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Snow
 	Id: SNOW
-	Palette: isosno.pal
+	Palette: snow
 	HeightDebugColors: 00000080, 00004480, 00008880, 0000CC80, 0000FF80, 4400CC80, 88008880, CC004480, FF110080, FF550080, FF990080, FFDD0080, DDFF0080, 99FF0080, 55FF0080, 11FF0080
 	EditorTemplateOrder: Bendy Dirt Roads, Blank, Bridges, Civilian Buildings, Clear, Clear/Rough LAT, Cliff Pieces, Cliff Set, Cliff/Water pieces, Dead Oil Tanker, Destroyable Cliffs, Dirt Road Junctions, Dirt Road Slopes, DirtTrackTunnel Floor, DirtTunnel Floor, Grey/Clear LAT, House, Ice 01, Ice 02, Ice 03, Ice Flow, Ice Ramps, Ice shore, Misc Buildings, Monorail Slopes, Paved Road Ends, Paved Road Slopes, Paved Roads, Pavement, Pavement (Use for LAT), Pavement/Clear LAT, Ramp edge fixup, Rough ground, Rough lat, Ruins, Shore Pieces, Slope Set Pieces, Straight Dirt Roads, TrackTunnel Floor, TrainBridges, Tunnel Side, Tunnels, Water, Water slopes, Waterfalls, Waterfalls-B, Waterfalls-C, Waterfalls-D
 	SheetSize: 2048

--- a/mods/ts/tilesets/temperate.yaml
+++ b/mods/ts/tilesets/temperate.yaml
@@ -1,7 +1,7 @@
 General:
 	Name: Temperate
 	Id: TEMPERATE
-	Palette: isotem.pal
+	Palette: temperate
 	HeightDebugColors: 00000080, 00004480, 00008880, 0000CC80, 0000FF80, 4400CC80, 88008880, CC004480, FF110080, FF550080, FF990080, FFDD0080, DDFF0080, 99FF0080, 55FF0080, 11FF0080
 	EditorTemplateOrder: Misc Buildings, Clear, Cliff Pieces, Ice Flow, House, Blank, Ice Ramps, Cliff Set, Civilian Buildings, Shore Pieces, Rough LAT tile, Clear/Rough LAT, Cliff/Water pieces, Bendy Dirt Roads, Dirt Road Junctions, Straight Dirt Roads, Bridges, Paved Roads, Water, Dirt Road Slopes, Slope Set Pieces, Dead Oil Tanker, Ruins, Waterfalls, Ground 01, Ground 02, Sand, Sand/Clear LAT, Rough ground, Paved Road Ends, TrainBridges, Pavement, Pavement/Clear LAT, Paved road bits, Green, Green/Clear LAT, Ramp edge fixup, Water slopes, Pavement (Use for LAT), Paved Road Slopes, Monorail Slopes, Waterfalls-B, Waterfalls-C, Waterfalls-D, Tunnel Floor, Tunnel Side, TrackTunnel Floor, Destroyable Cliffs, Water Caves, Scrin Wreckage, DirtTrackTunnel Floor, DirtTunnel Floor, Crystal LAT tile, Clear Crystal LAT, Swampy, Swampy LAT, Blue Mold, Blue Mold LAT, Crystal Cliff, Kodiak Crash
 	SheetSize: 2048


### PR DESCRIPTION
Tileset Palette field can now reference a Palette by name, instead of only a filename. Seeks a matching palette filename first, then looks for a Palette definition in the World palettes by name if the file isn't found.

For example, if I wanted to make the Temperat tileset in RA use a JASC palette file:

**tilesets/temperat.yaml:**

```
General:
	Name: Temperate
	Id: TEMPERAT
	Palette: temperat   #previously "temperat.pal"
...
```

**rules/palettes.yaml:**

```
^Palettes:
	PaletteFromGimpOrJascFile@temperat:
		Name: temperat
		Filename: temperat.jasc
		ShadowIndex: 4
	...
	PaletteFromCurrentTileset:
		Name: terrain
		ShadowIndex: 3,4
```

Please note that these tileset-specific palettes must be defined in palettes.yaml before "terrain".

I need this for Dark Reign, so I can load tileset palettes in JASC format.