### PR TITLE
Fixes to make WavReader handle junk data at EOF better

### DIFF
--- a/OpenRA.Mods.Common/FileFormats/WavReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/WavReader.cs
@@ -46,6 +46,9 @@ namespace OpenRA.Mods.Common.FileFormats
 				if ((s.Position & 1) == 1)
 					s.ReadByte(); // Alignment
 
+				if (s.Position == s.Length)
+					break;	// Break if we aligned with end of stream
+
 				var blockType = s.ReadASCII(4);
 				switch (blockType)
 				{
@@ -76,8 +79,7 @@ namespace OpenRA.Mods.Common.FileFormats
 						s.Position += dataSize;
 						break;
 					default:
-						var unknownChunkSize = s.ReadInt32();
-						s.ReadBytes(unknownChunkSize);
+						s.Position = s.Length; // Skip to end
 						break;
 				}
 			}


### PR DESCRIPTION
When unknown .wav file data is encountered, it's handled in the current WavReader class by just reading the next int then reading that many bytes.

```
default:
    var unknownChunkSize = s.ReadInt32();
    s.ReadBytes(unknownChunkSize);
    break;
```

Currently I'm working on a Dark Reign mod, and the .wav files included with that have a problem with this handling logic. The next int read will be a negative number, and the s.ReadBytes(unknownChunkSize) causes an exception for a few of my .wav files.

In addition, for one .wav file, the s.ReadByte() alignment reaches the end of the file, so we have to drop out early here:

```
if ((s.Position & 1) == 1)
	s.ReadByte(); // Alignment

if (s.Position == s.Length)
	break;	// Break if we aligned with end of stream
```

.wav files are only used by d2k, so I played a few matches with these changes. It didn't cause any issues and all the sounds played OK.