### PR TITLE
Add several features to LaserZap

### DIFF
--- a/OpenRA.Mods.Common/Effects/LaunchEffect.cs
+++ b/OpenRA.Mods.Common/Effects/LaunchEffect.cs
@@ -1,0 +1,57 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using OpenRA.Effects;
+using OpenRA.Graphics;
+
+namespace OpenRA.Mods.Common.Effects
+{
+	public class LaunchEffect : IEffect, ISpatiallyPartitionable
+	{
+		readonly World world;
+		readonly Animation anim;
+		readonly string palette;
+		WPos pos;
+		Func<WPos> posFunc;
+
+		public LaunchEffect(World world, string image, string sequence, string palette)
+			: this(world, () => WPos.Zero, () => 0, image, sequence, palette) { }
+
+		public LaunchEffect(World world, Func<WPos> posFunc, Func<int> facingFunc, string image, string sequence, string palette)
+		{
+			this.world = world;
+			this.posFunc = posFunc;
+			this.palette = palette;
+
+			anim = new Animation(world, image, facingFunc);
+			anim.PlayThen(sequence, () => world.AddFrameEndTask(w => { w.Remove(this); w.ScreenMap.Remove(this); }));
+			pos = posFunc();
+			world.ScreenMap.Add(this, pos, anim.Image);
+		}
+
+		public void Tick(World world)
+		{
+			anim.Tick();
+			pos = posFunc();
+			world.ScreenMap.Update(this, pos, anim.Image);
+		}
+
+		public IEnumerable<IRenderable> Render(WorldRenderer wr)
+		{
+			if (world.FogObscures(pos))
+				return SpriteRenderable.None;
+
+			return anim.Render(pos, wr.Palette(palette));
+		}
+	}
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -149,6 +149,7 @@
     <Compile Include="Effects\RepairIndicator.cs" />
     <Compile Include="Effects\SpriteEffect.cs" />
     <Compile Include="Graphics\RailgunRenderable.cs" />
+    <Compile Include="Effects\LaunchEffect.cs" />
     <Compile Include="Projectiles\AreaBeam.cs" />
     <Compile Include="Projectiles\Bullet.cs" />
     <Compile Include="Projectiles\InstantHit.cs" />

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -81,6 +81,15 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		[PaletteReference] public readonly string HitAnimPalette = "effect";
 
+		[Desc("Image containing launch effect sequence.")]
+		public readonly string LaunchEffectImage = null;
+
+		[Desc("Launch effect sequence to play.")]
+		[SequenceReference("LaunchEffectImage")] public readonly string LaunchEffectSequence = null;
+
+		[Desc("Palette to use for launch effect.")]
+		[PaletteReference] public readonly string LaunchEffectPalette = "effect";
+
 		public IProjectile Create(ProjectileArgs args)
 		{
 			var c = UsePlayerColor ? args.SourceActor.Owner.Color.RGB : Color;
@@ -98,6 +107,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		int ticks = 0;
 		int interval;
 		bool showHitAnim;
+		bool hasLaunchEffect;
 		[Sync] WPos target;
 		[Sync] WPos source;
 
@@ -122,11 +132,17 @@ namespace OpenRA.Mods.Common.Projectiles
 				hitanim = new Animation(args.SourceActor.World, info.HitAnim);
 				showHitAnim = true;
 			}
+
+			hasLaunchEffect = !string.IsNullOrEmpty(info.LaunchEffectImage) && !string.IsNullOrEmpty(info.LaunchEffectSequence);
 		}
 
 		public void Tick(World world)
 		{
 			source = args.CurrentSource();
+
+			if (hasLaunchEffect && ticks == 0)
+				world.AddFrameEndTask(w => w.Add(new LaunchEffect(world, args.CurrentSource, () => 0,
+					info.LaunchEffectImage, info.LaunchEffectSequence, info.LaunchEffectPalette)));
 
 			// Beam tracks target
 			if (info.TrackTarget && args.GuidedTarget.IsValidFor(args.SourceActor))

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -126,6 +126,8 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		public void Tick(World world)
 		{
+			source = args.CurrentSource();
+
 			// Beam tracks target
 			if (info.TrackTarget && args.GuidedTarget.IsValidFor(args.SourceActor))
 				target = args.Weapon.TargetActorCenter ? args.GuidedTarget.CenterPosition : args.GuidedTarget.Positions.PositionClosestTo(source);
@@ -159,18 +161,18 @@ namespace OpenRA.Mods.Common.Projectiles
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
 			if (wr.World.FogObscures(target) &&
-				wr.World.FogObscures(args.Source))
+				wr.World.FogObscures(source))
 				yield break;
 
 			if (ticks < info.Duration)
 			{
 				var rc = Color.FromArgb((info.Duration - ticks) * color.A / info.Duration, color);
-				yield return new BeamRenderable(args.Source, info.ZOffset, target - args.Source, info.Shape, info.Width, rc);
+				yield return new BeamRenderable(source, info.ZOffset, target - source, info.Shape, info.Width, rc);
 
 				if (info.SecondaryBeam)
 				{
 					var src = Color.FromArgb((info.Duration - ticks) * secondaryColor.A / info.Duration, secondaryColor);
-					yield return new BeamRenderable(args.Source, info.SecondaryBeamZOffset, target - args.Source,
+					yield return new BeamRenderable(source, info.SecondaryBeamZOffset, target - source,
 						info.SecondaryBeamShape, info.SecondaryBeamWidth, src);
 				}
 			}


### PR DESCRIPTION
Filing downstream changes from my MechWars mod.

- beam source point now follows the source offset instead of being static
- Added `DamageInterval` and `DamageDuration` for continous-damage support
- Added `LaunchEffect*`, which in my opinion is more flexible and less issue-prone than `WithMuzzleFlash` and can be applied to other projectiles later