### PR TITLE
Add ArmorTypes to HitShape and adapt damage warheads

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -924,6 +924,7 @@
     <Compile Include="UpdateRules\Rules\20180923\RenameEditorTilesetFilter.cs" />
     <Compile Include="UpdateRules\Rules\20180923\MergeRearmAndRepairAnimation.cs" />
     <Compile Include="UpdateRules\Rules\20180923\LowPowerSlowdownToModifier.cs" />
+    <Compile Include="UpdateRules\Rules\20180923\RemoveHealthPercentageRing.cs" />
     <Compile Include="Traits\Player\PlayerResources.cs" />
     <Compile Include="UtilityCommands\DumpSequenceSheetsCommand.cs" />
     <Compile Include="Traits\Render\WithBuildingRepairDecoration.cs" />

--- a/OpenRA.Mods.Common/Traits/Armor.cs
+++ b/OpenRA.Mods.Common/Traits/Armor.cs
@@ -11,6 +11,9 @@
 
 namespace OpenRA.Mods.Common.Traits
 {
+	// Type tag for armor type bits
+	public class ArmorType { }
+
 	[Desc("Used to define weapon efficiency modifiers with different percentages per Type.")]
 	public class ArmorInfo : ConditionalTraitInfo
 	{

--- a/OpenRA.Mods.Common/Traits/HitShape.cs
+++ b/OpenRA.Mods.Common/Traits/HitShape.cs
@@ -12,6 +12,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.HitShapes;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -24,6 +25,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Create a targetable position at the center of each occupied cell. Stacks with TargetableOffsets.")]
 		public readonly bool UseTargetableCellsOffsets = false;
+
+		[Desc("Defines which Armor types apply when the actor receives damage to this HitShape.",
+			"If none specified, all armor types the actor has are valid.")]
+		public readonly BitSet<ArmorType> ArmorTypes = default(BitSet<ArmorType>);
 
 		[FieldLoader.LoadUsing("LoadShape")]
 		public readonly IHitShape Type;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/RemoveHealthPercentageRing.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/RemoveHealthPercentageRing.cs
@@ -1,0 +1,45 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RemoveHealthPercentageRing : UpdateRule
+	{
+		public override string Name { get { return "Remove ring support from HealthPercentageDamage warheads' Spread"; } }
+		public override string Description
+		{
+			get
+			{
+				return "Setting a second value in this warheads' Spread to define a 'ring' is no longer supported.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateWeaponNode(ModData modData, MiniYamlNode weaponNode)
+		{
+			foreach (var node in weaponNode.ChildrenMatching("Warhead"))
+			{
+				if (node.NodeValue<string>() == "HealthPercentageDamage")
+				{
+					foreach (var spreadNode in node.ChildrenMatching("Spread"))
+					{
+						var oldValue = spreadNode.NodeValue<string[]>();
+						if (oldValue.Length > 1)
+							spreadNode.ReplaceValue(oldValue[0]);
+					}
+				}
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/WorldExtensions.cs
+++ b/OpenRA.Mods.Common/WorldExtensions.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common
 		}
 
 		/// <summary>
-		/// Finds all the actors of which their health radius is intersected by a specified circle.
+		/// Finds all the actors of which their health radius might be intersected by a specified circle.
 		/// </summary>
 		public static IEnumerable<Actor> FindActorsOnCircle(this World world, WPos origin, WDist r)
 		{


### PR DESCRIPTION
Supersedes #13675.

This allows to assign `Armor` traits to specific `HitShape`s, allowing to make certain parts of actors more vulnerable or durable than others.
Can also be used to simulate directional armor in a good-enough way that this closes #9268 and therefore closes #7718.
Also closes #13755.

Testcase can be found here: https://github.com/reaperrr/OpenRA/tree/hitshape-armor-v2-test

The main problems of #13675 that brought it down, 

> The core of the problem is that this introduces a second channel for applying damage (DoImpact with and without a hitshape) right in the middle of a chain of inheritance and overrides. This makes it very difficult to know which will be used, and means that the same weapon/warheads/vs fired by different means will end up doing different amounts of damage to the same actor.
This feature really needs to be integrated from the bottom up, and not just bolted on the side. **Require all damaging warheads to specify the hitshape**, and **fix the higher level code to be able to choose the appropriate one based on whatever rules make sense in each case**.

should be adressed by this updated version.

All damage warheads now absolutely require an enabled hitshape to deal damage to actors, and now that we have the Polygon shape type, there's no real excuse for an actor to have overlapping shapes anymore, so just taking the shape closest to impact for damage calculations should be a sufficient solution.