### PR TITLE
Remove broken Server.ExternalPort setting.

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -135,7 +135,7 @@ namespace OpenRA.Server
 			randomSeed = (int)DateTime.Now.ToBinary();
 
 			if (UPnP.Status == UPnPStatus.Enabled)
-				UPnP.ForwardPort(Settings.ListenPort, Settings.ExternalPort).Wait();
+				UPnP.ForwardPort(Settings.ListenPort, Settings.ListenPort).Wait();
 
 			foreach (var trait in modData.Manifest.ServerTraits)
 				serverTraits.Add(modData.ObjectCreator.CreateObject<ServerTrait>(trait));

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -14,7 +14,6 @@ using System.Collections.Generic;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
 using OpenRA.Graphics;
 using OpenRA.Traits;
 
@@ -41,9 +40,6 @@ namespace OpenRA
 
 		[Desc("Sets the internal port.")]
 		public int ListenPort = 1234;
-
-		[Desc("Sets the port advertised to the master server.")]
-		public int ExternalPort = 1234;
 
 		[Desc("Reports the game to the master server list.")]
 		public bool AdvertiseOnline = true;

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -97,10 +97,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			advertiseOnline = Game.Settings.Server.AdvertiseOnline;
 
-			var externalPort = panel.Get<TextFieldWidget>("EXTERNAL_PORT");
-			externalPort.Text = settings.Server.ExternalPort.ToString();
-			externalPort.IsDisabled = () => !advertiseOnline;
-
 			var advertiseCheckbox = panel.Get<CheckboxWidget>("ADVERTISE_CHECKBOX");
 			advertiseCheckbox.IsChecked = () => advertiseOnline;
 			advertiseCheckbox.OnClick = () =>
@@ -182,12 +178,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		void CreateAndJoin()
 		{
 			var name = Settings.SanitizedServerName(panel.Get<TextFieldWidget>("SERVER_NAME").Text);
-			int listenPort, externalPort;
+			int listenPort;
 			if (!Exts.TryParseIntegerInvariant(panel.Get<TextFieldWidget>("LISTEN_PORT").Text, out listenPort))
 				listenPort = 1234;
-
-			if (!Exts.TryParseIntegerInvariant(panel.Get<TextFieldWidget>("EXTERNAL_PORT").Text, out externalPort))
-				externalPort = 1234;
 
 			var passwordField = panel.GetOrNull<PasswordFieldWidget>("PASSWORD");
 			var password = passwordField != null ? passwordField.Text : "";
@@ -195,7 +188,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			// Save new settings
 			Game.Settings.Server.Name = name;
 			Game.Settings.Server.ListenPort = listenPort;
-			Game.Settings.Server.ExternalPort = externalPort;
 			Game.Settings.Server.AdvertiseOnline = advertiseOnline;
 			Game.Settings.Server.Map = preview.Uid;
 			Game.Settings.Server.Password = password;

--- a/mods/cnc/chrome/multiplayer-createserver.yaml
+++ b/mods/cnc/chrome/multiplayer-createserver.yaml
@@ -3,7 +3,7 @@ Container@MULTIPLAYER_CREATESERVER_PANEL:
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT - 15) / 2
 	Width: 530
-	Height: 314
+	Height: 275
 	Children:
 		Label@TITLE:
 			Width: PARENT_RIGHT
@@ -63,47 +63,33 @@ Container@MULTIPLAYER_CREATESERVER_PANEL:
 					MaxLength: 5
 					Text: 1234
 				Checkbox@ADVERTISE_CHECKBOX:
-					X: 15
-					Y: 121
+					X: 180
+					Y: 87
 					Width: 150
 					Height: 20
 					Font: Regular
 					Text: Advertise Online
-				Label@EXTERNAL_PORT_LABEL:
-					X: 180
-					Y: 119
-					Width: 90
-					Height: 25
-					Align: Right
-					Text: External Port:
-				TextField@EXTERNAL_PORT:
-					X: 275
-					Y: 120
-					Width: 50
-					MaxLength: 5
-					Height: 25
-					Text: 1234
 				Label@NOTICES_HEADER_A:
 					X: 15
-					Y: 165
+					Y: 125
 					Height: 25
 					Align: Left
 					Font: Bold
 				Label@NOTICES_HEADER_B:
 					X: 15
-					Y: 165
+					Y: 125
 					Height: 25
 					Align: Left
 					Font: Bold
 				Label@NOTICES_HEADER_C:
 					X: 15
-					Y: 165
+					Y: 125
 					Height: 25
 					Align: Left
 					Font: Bold
 				Container@NOTICES_LAN:
 					X: 20
-					Y: 185
+					Y: 145
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM
 					Children:
@@ -137,7 +123,7 @@ Container@MULTIPLAYER_CREATESERVER_PANEL:
 							Text: manually configure port forwarding on your router.
 				Container@NOTICES_NO_UPNP:
 					X: 20
-					Y: 185
+					Y: 145
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM
 					Children:
@@ -168,7 +154,7 @@ Container@MULTIPLAYER_CREATESERVER_PANEL:
 							Height: 25
 							Font: Tiny
 							Align: Left
-							Text: connections from the External Port to your local IP and Port.
+							Text: connections to your local IP and Port.
 						Label@SETTINGS_A:
 							Y: 48
 							Width: 305
@@ -186,7 +172,7 @@ Container@MULTIPLAYER_CREATESERVER_PANEL:
 							Text: Advanced tab of the OpenRA settings menu.
 				Container@NOTICES_UPNP:
 					X: 20
-					Y: 185
+					Y: 145
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM
 					Children:
@@ -253,18 +239,18 @@ Container@MULTIPLAYER_CREATESERVER_PANEL:
 					Height: 25
 					Font: Tiny
 					Align: Center
-				Button@MAP_BUTTON:
-					X: PARENT_RIGHT - 189
-					Y: PARENT_BOTTOM - 40
-					Width: 174
-					Height: 25
-					Text: Change Map
 		Button@BACK_BUTTON:
 			Key: return
 			Y: PARENT_BOTTOM - 36
 			Width: 140
 			Height: 35
 			Text: Back
+		Button@MAP_BUTTON:
+			X: PARENT_RIGHT - WIDTH - 150
+			Y: PARENT_BOTTOM - 36
+			Width: 140
+			Height: 35
+			Text: Change Map
 		Button@CREATE_BUTTON:
 			Key: return
 			X: PARENT_RIGHT - WIDTH

--- a/mods/common/chrome/multiplayer-createserver.yaml
+++ b/mods/common/chrome/multiplayer-createserver.yaml
@@ -3,7 +3,7 @@ Background@MULTIPLAYER_CREATESERVER_PANEL:
 	X: (WINDOW_RIGHT - WIDTH)/2
 	Y: (WINDOW_BOTTOM - HEIGHT)/2
 	Width: 530
-	Height: 345
+	Height: 315
 	Children:
 		Label@TITLE:
 			Y: 15
@@ -58,47 +58,33 @@ Background@MULTIPLAYER_CREATESERVER_PANEL:
 			MaxLength: 5
 			Text: 1234
 		Checkbox@ADVERTISE_CHECKBOX:
-			X: 20
-			Y: 151
+			X: 180
+			Y: 117
 			Width: 150
 			Height: 20
 			Font: Regular
 			Text: Advertise Online
-		Label@EXTERNAL_PORT_LABEL:
-			X: 180
-			Y: 149
-			Width: 90
-			Height: 25
-			Align: Right
-			Text: External Port:
-		TextField@EXTERNAL_PORT:
-			X: 275
-			Y: 150
-			Width: 50
-			MaxLength: 5
-			Height: 25
-			Text: 1234
 		Label@NOTICES_HEADER_A:
 			X: 20
-			Y: 185
+			Y: 155
 			Height: 25
 			Align: Left
 			Font: Bold
 		Label@NOTICES_HEADER_B:
 			X: 20
-			Y: 185
+			Y: 155
 			Height: 25
 			Align: Left
 			Font: Bold
 		Label@NOTICES_HEADER_C:
 			X: 20
-			Y: 185
+			Y: 155
 			Height: 25
 			Align: Left
 			Font: Bold
 		Container@NOTICES_LAN:
 			X: 25
-			Y: 205
+			Y: 175
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
 			Children:
@@ -132,7 +118,7 @@ Background@MULTIPLAYER_CREATESERVER_PANEL:
 					Text: manually configure port forwarding on your router.
 		Container@NOTICES_NO_UPNP:
 			X: 25
-			Y: 205
+			Y: 175
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
 			Children:
@@ -163,7 +149,7 @@ Background@MULTIPLAYER_CREATESERVER_PANEL:
 					Height: 25
 					Font: Tiny
 					Align: Left
-					Text: connections from the External Port to your local IP and Port.
+					Text: connections to your local IP and Port.
 				Label@SETTINGS_A:
 					Y: 48
 					Width: 305
@@ -181,7 +167,7 @@ Background@MULTIPLAYER_CREATESERVER_PANEL:
 					Text: Advanced tab of the OpenRA settings menu.
 		Container@NOTICES_UPNP:
 			X: 25
-			Y: 205
+			Y: 175
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
 			Children:
@@ -249,25 +235,25 @@ Background@MULTIPLAYER_CREATESERVER_PANEL:
 			Font: Tiny
 			Align: Center
 		Button@MAP_BUTTON:
-			X: PARENT_RIGHT - 194
-			Y: 268
-			Width: 174
+			X: 20
+			Y: PARENT_BOTTOM - 45
+			Width: 120
 			Height: 25
 			Text: Change Map
 			Font: Bold
 		Button@BACK_BUTTON:
-			X: PARENT_RIGHT - 194
+			X: PARENT_RIGHT - WIDTH - 20
 			Y: PARENT_BOTTOM - 45
-			Width: 174
+			Width: 120
 			Height: 25
 			Text: Back
 			Font: Bold
 			Key: escape
 		Button@CREATE_BUTTON:
 			Key: return
-			X: 20
+			X: PARENT_RIGHT - 2*WIDTH - 30
 			Y: PARENT_BOTTOM - 45
-			Width: 174
+			Width: 120
 			Height: 25
 			Text: Create
 			Font: Bold


### PR DESCRIPTION
The IRC discussion around #14832 highlighted the fact that most people don't understand why we have/want separate port configurations.  The lack of interest in #14869 supports the idea that its not worthwhile to maintain this separation.  Removing the option then also simplifies the server creation UI a bit.

Closes #14832.
Supersedes #14869.