### PR TITLE
Implement 999 per-actor production queue limit.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -427,10 +427,11 @@ namespace OpenRA.Mods.Common.Traits
 		protected void CancelProduction(string itemName, uint numberToCancel)
 		{
 			for (var i = 0; i < numberToCancel; i++)
-				CancelProductionInner(itemName);
+				if (!CancelProductionInner(itemName))
+					break;
 		}
 
-		void CancelProductionInner(string itemName)
+		bool CancelProductionInner(string itemName)
 		{
 			var lastIndex = queue.FindLastIndex(a => a.Item == itemName);
 
@@ -444,6 +445,10 @@ namespace OpenRA.Mods.Common.Traits
 				playerResources.GiveCash(item.TotalCost - item.RemainingCost);
 				FinishProduction();
 			}
+			else
+				return false;
+
+			return true;
 		}
 
 		public void FinishProduction()

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -275,13 +275,21 @@ namespace OpenRA.Mods.Common.Widgets
 				return true;
 			}
 
-			if (CurrentQueue.BuildableItems().Any(a => a.Name == icon.Name))
+			var buildable = CurrentQueue.BuildableItems().FirstOrDefault(a => a.Name == icon.Name);
+
+			if (buildable != null)
 			{
 				// Queue a new item
 				Game.Sound.Play(SoundType.UI, TabClick);
-				Game.Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", CurrentQueue.Info.QueuedAudio, World.LocalPlayer.Faction.InternalName);
-				World.IssueOrder(Order.StartProduction(CurrentQueue.Actor, icon.Name, handleCount));
-				return true;
+				string notification;
+				var canQueue = CurrentQueue.CanQueue(buildable, out notification);
+				Game.Sound.PlayNotification(World.Map.Rules, World.LocalPlayer, "Speech", notification, World.LocalPlayer.Faction.InternalName);
+
+				if (canQueue)
+				{
+					World.IssueOrder(Order.StartProduction(CurrentQueue.Actor, icon.Name, handleCount));
+					return true;
+				}
 			}
 
 			return false;

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -33,6 +33,7 @@ FACT:
 		LowPowerSlowdown: 2
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
+		LimitedAudio: BuildingInProgress
 	ProductionQueue@NodBuilding:
 		Type: Building.Nod
 		Factions: nod
@@ -40,6 +41,7 @@ FACT:
 		LowPowerSlowdown: 2
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
+		LimitedAudio: BuildingInProgress
 	ProductionQueue@GDIDefense:
 		Type: Defence.GDI
 		Factions: gdi
@@ -47,6 +49,7 @@ FACT:
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
+		LimitedAudio: BuildingInProgress
 	ProductionQueue@NodDefense:
 		Type: Defence.Nod
 		Factions: nod
@@ -54,6 +57,7 @@ FACT:
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
+		LimitedAudio: BuildingInProgress
 	BaseBuilding:
 	ProductionBar@BuildingGDI:
 		ProductionType: Building.GDI
@@ -290,6 +294,7 @@ PYLE:
 		Group: Infantry
 		RequireOwner: false
 		LowPowerSlowdown: 3
+		LimitedAudio: BuildingInProgress
 	ProductionBar:
 	Power:
 		Amount: -20
@@ -335,6 +340,7 @@ HAND:
 		Group: Infantry
 		RequireOwner: false
 		LowPowerSlowdown: 3
+		LimitedAudio: BuildingInProgress
 	ProductionBar:
 	Power:
 		Amount: -20
@@ -387,6 +393,7 @@ AFLD:
 		RequireOwner: false
 		LowPowerSlowdown: 3
 		ReadyAudio:
+		LimitedAudio: BuildingInProgress
 	ProductionBar:
 	Power:
 		Amount: -50
@@ -439,6 +446,7 @@ WEAP:
 		RequireOwner: false
 		Group: Vehicle
 		LowPowerSlowdown: 3
+		LimitedAudio: BuildingInProgress
 	ProductionBar:
 	Power:
 		Amount: -50
@@ -481,11 +489,13 @@ HPAD:
 		Factions: gdi
 		Group: Aircraft
 		LowPowerSlowdown: 3
+		LimitedAudio: BuildingInProgress
 	ProductionQueue@Nod:
 		Type: Aircraft.Nod
 		Factions: nod
 		Group: Aircraft
 		LowPowerSlowdown: 3
+		LimitedAudio: BuildingInProgress
 	ProductionBar@GDI:
 		ProductionType: Aircraft.GDI
 	ProductionBar@Nod:

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -71,6 +71,7 @@ BIO:
 		Group: Infantry
 		RequireOwner: false
 		LowPowerSlowdown: 3
+		LimitedAudio: BuildingInProgress
 	ProductionBar:
 	RallyPoint:
 		Offset: -1,-1

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -6,32 +6,38 @@ Player:
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
+		LimitedAudio: BuildingInProgress
 		SpeedUp: True
 	ClassicProductionQueue@Defense:
 		Type: Defense
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
+		LimitedAudio: BuildingInProgress
 		SpeedUp: True
 	ClassicProductionQueue@Vehicle:
 		Type: Vehicle
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
+		LimitedAudio: BuildingInProgress
 		SpeedUp: True
 		BuildTimeSpeedReduction: 100, 75, 60, 50
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
 		LowPowerSlowdown: 3
+		LimitedAudio: BuildingInProgress
 		SpeedUp: True
 	ClassicProductionQueue@Ship:
 		Type: Ship
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
+		LimitedAudio: BuildingInProgress
 		SpeedUp: True
 	ClassicProductionQueue@Aircraft:
 		Type: Aircraft
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
+		LimitedAudio: BuildingInProgress
 		SpeedUp: True
 	PlaceBuilding:
 	SupportPowerManager:

--- a/mods/ts/audio/speech-generic.yaml
+++ b/mods/ts/audio/speech-generic.yaml
@@ -47,7 +47,7 @@ Speech:
 		NavalUnitLost: 00-i074
 		NewOptions: 00-i032
 		NewTerrainDiscovered: 00-i198
-		NoBuild: 00-i064
+		BuildingInProgress: 00-i064
 		OnHold: 00-i218
 		OurAllyIsUnderAttack: 00-i308
 		PlayerHasResigned: 00-i252

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -8,6 +8,7 @@ Player:
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
+		LimitedAudio: BuildingInProgress
 		SpeedUp: True
 	ClassicProductionQueue@Defense:
 		Type: Defense
@@ -15,21 +16,25 @@ Player:
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
+		LimitedAudio: BuildingInProgress
 		SpeedUp: True
 	ClassicProductionQueue@Vehicle:
 		Type: Vehicle
 		BuildDurationModifier: 120
 		LowPowerSlowdown: 3
+		LimitedAudio: BuildingInProgress
 		SpeedUp: True
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
 		BuildDurationModifier: 120
 		LowPowerSlowdown: 3
+		LimitedAudio: BuildingInProgress
 		SpeedUp: True
 	ClassicProductionQueue@Air:
 		Type: Air
 		BuildDurationModifier: 120
 		LowPowerSlowdown: 3
+		LimitedAudio: BuildingInProgress
 		SpeedUp: True
 	PlaceBuilding:
 		Palette: placebuilding


### PR DESCRIPTION
This PR implements `ProductionQueue.QueueLimit` and `ProductionQueue.ItemLimit` to limit the number of items that can be queued in total and for each actor type respectively.

A per-item limit of 999 is defined to fix a game-breaking MP exploit while remaining large enough that nobody can reasonably complain.  This also fixes the "Training" production notification when trying to queue units that have already reached their build limit.

Testcase: Try to queue more than 999 of some actor type (or reduce the number, and try to build more than that).
Testcase: Set `QueueLimit: 1` and relive the frustration from the original game.
Testcase: Try to queue a second tanya while the first is already training (with instant build and all tech cheats disabled).  Notice that it now plays the correct audio.