### PR TITLE
Fixes for WavReader to explictly handle "LIST" and "cue " chunks (RA2)

### DIFF
--- a/OpenRA.Mods.Common/FileFormats/WavReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/WavReader.cs
@@ -46,6 +46,9 @@ namespace OpenRA.Mods.Common.FileFormats
 				if ((s.Position & 1) == 1)
 					s.ReadByte(); // Alignment
 
+				if (s.Position == s.Length)
+					break; // Break if we aligned with end of stream
+
 				var blockType = s.ReadASCII(4);
 				switch (blockType)
 				{
@@ -75,9 +78,13 @@ namespace OpenRA.Mods.Common.FileFormats
 						dataOffset = s.Position;
 						s.Position += dataSize;
 						break;
+					case "LIST":
+					case "cue ":
+						var listCueChunkSize = s.ReadInt32();
+						s.ReadBytes(listCueChunkSize);
+						break;
 					default:
-						var unknownChunkSize = s.ReadInt32();
-						s.ReadBytes(unknownChunkSize);
+						s.Position = s.Length; // Skip to end of stream
 						break;
 				}
 			}


### PR DESCRIPTION
Apologies for the noise in your queue - I closed this issue prematurely and would like to reopen it: https://github.com/OpenRA/OpenRA/pull/14986
I've found a better way to handle the junk data in the DR wavs.

When an unknown .wav data chunk type is encountered, it's handled in the current WavReader class by just reading the next int then reading that many bytes.

```
switch (blockType)
{
...
default:
    var unknownChunkSize = s.ReadInt32();
    s.ReadBytes(unknownChunkSize);
    break;
}
```

This causes a problem in my Dark Reign mod where there is junk data at the end of the wav file data (Usually with the chunk type "????" or sometimes combined with unicode chars). The chunk size value read here is huge and crashes OpenRA.

D2k uses wav files, and so does RA2, so I tested these out by playing a few matches. D2k wav files never hit the default block above. RA2 wav files hit this block for "LIST" and "cue " chunk types.

In order to handle the junk data in the DR wavs, I've altered the default statement to skip to the end of the stream, and handled the RA2 chunks explictly:

```
switch (blockType)
{
...
case "LIST":
case "cue ":
	var listCueChunkSize = s.ReadInt32();
	s.ReadBytes(listCueChunkSize);
	break;
default:
	s.Position = s.Length;  // Skip to end of stream
	break;
}
```

In addition, for one .wav file, the s.ReadByte() alignment reaches the end of the file, so we have to drop out early here:

```
if ((s.Position & 1) == 1)
	s.ReadByte(); // Alignment

if (s.Position == s.Length)
	break;	// Break if we aligned with end of stream
```

This will let me use the DR wavs without having to make a copy of WavLoader and WavReader in my mod with this fix applied.