### PR TITLE
Process shared map includes as part of the mod rules.

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/UpdateMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpdateMapCommand.cs
@@ -82,9 +82,10 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 				Console.Write("   Updating map... ");
 
+				var externalFilenames = new HashSet<string>();
 				try
 				{
-					manualSteps = UpdateUtils.UpdateMap(modData, mapPackage, rule, out mapFiles);
+					manualSteps = UpdateUtils.UpdateMap(modData, mapPackage, rule, out mapFiles, externalFilenames);
 				}
 				catch (Exception ex)
 				{
@@ -103,6 +104,13 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				// Files are saved after each successful automated rule update
 				mapFiles.Save();
 				Console.WriteLine("COMPLETE");
+
+				if (externalFilenames.Any())
+				{
+					Console.WriteLine("   The following shared yaml files referenced by the map have been ignored:");
+					Console.WriteLine(UpdateUtils.FormatMessageList(externalFilenames, 1));
+					Console.WriteLine("   These files are assumed to have already been updated by the --update-mod command");
+				}
 
 				if (manualSteps.Any())
 				{

--- a/OpenRA.Mods.Common/UtilityCommands/UpdateMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpdateMapCommand.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				throw new FileNotFoundException(args[1]);
 
 			IEnumerable<UpdateRule> rules = null;
-			if (args.Length > 1)
+			if (args.Length > 2)
 				rules = UpdatePath.FromSource(modData.ObjectCreator, args[2]);
 
 			if (rules == null)

--- a/OpenRA.Mods.Common/UtilityCommands/UpdateModCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpdateModCommand.cs
@@ -146,15 +146,17 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				}
 
 				Console.Write("   Updating system maps... ");
+
 				if (!skipMaps)
 				{
 					var mapsFailed = false;
+					var externalFilenames = new HashSet<string>();
 					foreach (var package in modData.MapCache.EnumerateMapPackagesWithoutCaching())
 					{
 						try
 						{
 							YamlFileSet mapFiles;
-							var mapSteps = UpdateUtils.UpdateMap(modData, package, rule, out mapFiles);
+							var mapSteps = UpdateUtils.UpdateMap(modData, package, rule, out mapFiles, externalFilenames);
 							allFiles.AddRange(mapFiles);
 
 							if (mapSteps.Any())


### PR DESCRIPTION
This ensures that they are only updated once instead of repeating the updates for every map that includes them.

Testcase: `OpenRA.Utility.exe cnc --update-mod IgnoreAbstractActors --apply` (manual steps for the campaign-* files are now included the mod steps instead of repeated in every custom map).

Testcase: `OpenRA.Utility.exe cnc --update-map mods/cnc/maps/gdi01/ IgnoreAbstractActors --apply` (manual steps are no longer listed, and a list of ignored files are reported).