### PR TITLE
Add campaign progression system

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -40,6 +40,7 @@ namespace OpenRA
 
 		public static ModData ModData;
 		public static Settings Settings;
+		public static GlobalMissionData GlobalMissionData;
 		public static ICursor Cursor;
 		static WorldRenderer worldRenderer;
 
@@ -246,6 +247,15 @@ namespace OpenRA
 			Settings = new Settings(Platform.ResolvePath(Path.Combine(Platform.SupportDirPrefix, "settings.yaml")), args);
 		}
 
+		public static void InitializeGlobalMissionData(string modID, Arguments args)
+		{
+			var directory = Platform.ResolvePath(Platform.SupportDirPrefix, "MissionData");
+			Directory.CreateDirectory(directory);
+
+			var destination = Path.Combine(directory, modID + ".yaml");
+			GlobalMissionData = new GlobalMissionData(Platform.ResolvePath(destination), args);
+		}
+
 		public static RunStatus InitializeAndRun(string[] args)
 		{
 			Initialize(new Arguments(args));
@@ -280,6 +290,7 @@ namespace OpenRA
 			}
 
 			InitializeSettings(args);
+			InitializeGlobalMissionData(modID, args);
 
 			Log.AddChannel("perf", "perf.log");
 			Log.AddChannel("debug", "debug.log");

--- a/OpenRA.Game/GlobalMissionData.cs
+++ b/OpenRA.Game/GlobalMissionData.cs
@@ -1,0 +1,121 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace OpenRA
+{
+	public class GlobalMissionData
+	{
+		readonly string missionDataFile;
+
+		public readonly Dictionary<string, string> SavedMissionData = new Dictionary<string, string>();
+
+		public readonly Dictionary<string, object> Sections;
+
+		// A direct clone of the file loaded from disk.
+		// Any changes will be merged over this on save,
+		// allowing us to persist any unknown configuration keys
+		readonly List<MiniYamlNode> yamlCache = new List<MiniYamlNode>();
+
+		public GlobalMissionData(string file, Arguments args)
+		{
+			missionDataFile = file;
+			Sections = new Dictionary<string, object>()
+			{
+				{ "SavedMissionData", SavedMissionData },
+			};
+
+			// Override fieldloader to ignore invalid entries
+			var err1 = FieldLoader.UnknownFieldAction;
+			var err2 = FieldLoader.InvalidValueAction;
+			try
+			{
+				FieldLoader.UnknownFieldAction = (s, f) => Console.WriteLine("Ignoring unknown field `{0}` on `{1}`".F(s, f.Name));
+
+				if (File.Exists(missionDataFile))
+				{
+					yamlCache = MiniYaml.FromFile(missionDataFile);
+					foreach (var yamlSection in yamlCache)
+					{
+						object settingsSection;
+						if (Sections.TryGetValue(yamlSection.Key, out settingsSection))
+							LoadSectionYaml(yamlSection.Value, settingsSection);
+					}
+				}
+
+				// Override with commandline args
+				foreach (var kv in Sections)
+					foreach (var f in kv.Value.GetType().GetFields())
+						if (args.Contains(kv.Key + "." + f.Name))
+							FieldLoader.LoadField(kv.Value, f.Name, args.GetValue(kv.Key + "." + f.Name, ""));
+			}
+			finally
+			{
+				FieldLoader.UnknownFieldAction = err1;
+				FieldLoader.InvalidValueAction = err2;
+			}
+		}
+
+		public void Save()
+		{
+			foreach (var kv in Sections)
+			{
+				var sectionYaml = yamlCache.FirstOrDefault(x => x.Key == kv.Key);
+				if (sectionYaml == null)
+				{
+					sectionYaml = new MiniYamlNode(kv.Key, new MiniYaml(""));
+					yamlCache.Add(sectionYaml);
+				}
+
+				var defaultValues = Activator.CreateInstance(kv.Value.GetType());
+				var fields = FieldLoader.GetTypeLoadInfo(kv.Value.GetType());
+				foreach (var fli in fields)
+				{
+					var serialized = FieldSaver.FormatValue(kv.Value, fli.Field);
+					var defaultSerialized = FieldSaver.FormatValue(defaultValues, fli.Field);
+
+					// Fields with their default value are not saved in the settings yaml
+					// Make sure that we erase any previously defined custom values
+					if (serialized == defaultSerialized)
+						sectionYaml.Value.Nodes.RemoveAll(n => n.Key == fli.YamlName);
+					else
+					{
+						// Update or add the custom value
+						var fieldYaml = sectionYaml.Value.Nodes.FirstOrDefault(n => n.Key == fli.YamlName);
+						if (fieldYaml != null)
+							fieldYaml.Value.Value = serialized;
+						else
+							sectionYaml.Value.Nodes.Add(new MiniYamlNode(fli.YamlName, new MiniYaml(serialized)));
+					}
+				}
+			}
+
+			yamlCache.WriteToFile(missionDataFile);
+		}
+
+		static void LoadSectionYaml(MiniYaml yaml, object section)
+		{
+			var defaults = Activator.CreateInstance(section.GetType());
+			FieldLoader.InvalidValueAction = (s, t, f) =>
+			{
+				var ret = defaults.GetType().GetField(f).GetValue(defaults);
+				Console.WriteLine("FieldLoader: Cannot parse `{0}` into `{2}:{1}`; substituting default `{3}`".F(s, t.Name, f, ret));
+				return ret;
+			};
+
+			FieldLoader.Load(section, yaml);
+		}
+	}
+}

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -305,6 +305,7 @@
     <Compile Include="Map\ActorReference.cs" />
     <Compile Include="Support\Evaluator.cs" />
     <Compile Include="Settings.cs" />
+    <Compile Include="GlobalMissionData.cs" />
     <Compile Include="Graphics\PlayerColorRemap.cs" />
     <Compile Include="Graphics\Palette.cs" />
     <Compile Include="FileSystem\FileSystem.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -241,6 +241,7 @@
     <Compile Include="Scripting\Properties\GeneralProperties.cs" />
     <Compile Include="Scripting\Properties\GuardProperties.cs" />
     <Compile Include="Scripting\Properties\MissionObjectiveProperties.cs" />
+    <Compile Include="Scripting\Properties\MissionDataProperties.cs" />
     <Compile Include="Scripting\Properties\MobileProperties.cs" />
     <Compile Include="Scripting\Properties\DeliveryProperties.cs" />
     <Compile Include="Scripting\Properties\DemolitionProperties.cs" />

--- a/OpenRA.Mods.Common/Scripting/Properties/MissionDataProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/MissionDataProperties.cs
@@ -1,0 +1,36 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using Eluant;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Scripting;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Scripting
+{
+	[ScriptPropertyGroup("MissionData")]
+	public class MissionDataProperties : ScriptPlayerProperties
+	{
+		public MissionDataProperties(ScriptContext context, Player player)
+			: base(context, player) { }
+
+		[ScriptActorPropertyActivity]
+		[Desc("Write data to SavedMissionData.")]
+		public void SaveMissionData(string category, string flag)
+		{
+			var data = Game.GlobalMissionData.SavedMissionData;
+			if (!data.ContainsKey(category) || (data.ContainsKey(category) && data[category] != flag))
+				Game.GlobalMissionData.SavedMissionData.Add(category, flag);
+
+			Game.GlobalMissionData.Save();
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/World/MissionData.cs
+++ b/OpenRA.Mods.Common/Traits/World/MissionData.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	[Desc("Defines the FMVs that can be played by missions.")]
+	[Desc("Defines the prerequisites, briefing and FMVs that can be played by missions.")]
 	public class MissionDataInfo : TraitInfo<MissionData>
 	{
 		[Desc("Briefing text displayed in the mission browser.")]
@@ -34,6 +34,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Automatically played when the player loses the mission.")]
 		public readonly string LossVideo;
+
+		[Desc("Flags that need to be found in saved mission data before this mission becomes available.")]
+		public readonly Dictionary<string, string> RequiredMissionData;
 	}
 
 	public class MissionData { }

--- a/mods/cnc/maps/gdi01/gdi01.lua
+++ b/mods/cnc/maps/gdi01/gdi01.lua
@@ -79,6 +79,7 @@ WorldLoaded = function()
 	end)
 
 	Trigger.OnPlayerWon(player, function()
+		player.SaveMissionData("gdi01", "finished")
 		Media.PlaySpeechNotification(player, "Win")
 	end)
 
@@ -94,8 +95,9 @@ WorldLoaded = function()
 
 	SendNodPatrol()
 
-	Trigger.AfterDelay(DateTime.Seconds(10), function() Reinforce(InfantryReinforcements) end)
-	Trigger.AfterDelay(DateTime.Seconds(60), function() Reinforce(VehicleReinforcements) end)
+	Trigger.AfterDelay(DateTime.Seconds(20), function() Reinforce(InfantryReinforcements) end)
+	Trigger.AfterDelay(DateTime.Seconds(5), function() Reinforce(VehicleReinforcements) end)
+	Trigger.AfterDelay(DateTime.Seconds(10), function() Reinforce(VehicleReinforcements) end)
 end
 
 Tick = function()
@@ -109,6 +111,7 @@ Tick = function()
 	end
 
 	if DateTime.GameTime % DateTime.Seconds(1) == 0 and not player.IsObjectiveCompleted(beachheadObjective) and CheckForBase(player) then
+		player.SaveMissionData("gdi01-beachhead", "built")
 		player.MarkCompletedObjective(beachheadObjective)
 	end
 end

--- a/mods/cnc/maps/gdi02/map.yaml
+++ b/mods/cnc/maps/gdi02/map.yaml
@@ -2,6 +2,10 @@ MapFormat: 11
 
 RequiresMod: cnc
 
+RequiresMissionFinished: gdi01
+
+RequiresFlag: gdi1bhestablished
+
 Title: 02:   Knock out the Refinery
 
 Author: Westwood Studios

--- a/mods/cnc/maps/gdi02/rules.yaml
+++ b/mods/cnc/maps/gdi02/rules.yaml
@@ -8,6 +8,9 @@ World:
 		BriefingVideo: gdi2.vqa
 		WinVideo: flag.vqa
 		LossVideo: gameover.vqa
+		RequiredMissionData:
+			gdi01: finished
+			gdi01-beachhead: built
 
 SBAG:
 	-Crushable:


### PR DESCRIPTION
This allows to hide missions and even entire campaigns until a certain mission has been finished and/or a certain flag has been triggered.

Closes #7213.
Closes #14238.