### PR TITLE
Fix spurious unit deaths during bridge transitions

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -285,6 +285,7 @@ namespace OpenRA.Traits
 
 	public interface IPositionable : IOccupySpace
 	{
+		bool CanExistInCell(CPos location);
 		bool IsLeavingCell(CPos location, SubCell subCell = SubCell.Any);
 		bool CanEnterCell(CPos location, Actor ignoreActor = null, bool checkTransientActors = true);
 		SubCell GetValidSubCell(SubCell preferred = SubCell.Any);

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -154,6 +154,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			init.Add(new FacingInit(Facing));
 		}
 
+		public bool CanExistInCell(CPos cell) { return true; }
 		public bool IsLeavingCell(CPos location, SubCell subCell = SubCell.Any) { return false; }
 		public bool CanEnterCell(CPos cell, Actor ignoreActor = null, bool checkTransientActors = false) { return true; }
 		public SubCell GetValidSubCell(SubCell preferred) { return SubCell.Invalid; }

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -503,6 +503,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		#region Implement IPositionable
 
+		public bool CanExistInCell(CPos cell) { return true; }
 		public bool IsLeavingCell(CPos location, SubCell subCell = SubCell.Any) { return false; } // TODO: Handle landing
 		public bool CanEnterCell(CPos cell, Actor ignoreActor = null, bool checkTransientActors = true) { return true; }
 		public SubCell GetValidSubCell(SubCell preferred) { return SubCell.Invalid; }

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -243,7 +243,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			foreach (var c in footprint.Keys)
 				foreach (var a in self.World.ActorMap.GetActorsAt(c))
-					if (a.Info.HasTraitInfo<IPositionableInfo>() && !a.Trait<IPositionable>().CanEnterCell(c))
+					if (a.Info.HasTraitInfo<IPositionableInfo>() && !a.Trait<IPositionable>().CanExistInCell(c))
 						a.Kill(self, info.DamageTypes);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			foreach (var c in cells)
 				foreach (var a in self.World.ActorMap.GetActorsAt(c))
-					if (a.Info.HasTraitInfo<IPositionableInfo>() && !a.Trait<IPositionable>().CanEnterCell(c))
+					if (a.Info.HasTraitInfo<IPositionableInfo>() && !a.Trait<IPositionable>().CanExistInCell(c))
 						a.Kill(self, Info.DamageTypes);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -44,13 +44,21 @@ namespace OpenRA.Mods.Common.Traits
 			return GetAvailableSubCell(world, cell, ignoreActor, checkTransientActors) != SubCell.Invalid;
 		}
 
-		public SubCell GetAvailableSubCell(World world, CPos cell, Actor ignoreActor = null, bool checkTransientActors = true)
+		public bool CanExistInCell(World world, CPos cell)
 		{
 			if (!world.Map.Contains(cell))
-				return SubCell.Invalid;
+				return false;
 
 			var type = world.Map.GetTerrainInfo(cell).Type;
 			if (!TerrainTypes.Contains(type))
+				return false;
+
+			return true;
+		}
+
+		public SubCell GetAvailableSubCell(World world, CPos cell, Actor ignoreActor = null, bool checkTransientActors = true)
+		{
+			if (!CanExistInCell(world, cell))
 				return SubCell.Invalid;
 
 			if (world.WorldActor.Trait<BuildingInfluence>().GetBuildingAt(cell) != null)
@@ -200,6 +208,8 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			return info.GetAvailableSubCell(self.World, cell, ignoreActor, checkTransientActors);
 		}
+
+		public bool CanExistInCell(CPos cell) { return info.CanExistInCell(self.World, cell); }
 
 		public bool CanEnterCell(CPos a, Actor ignoreActor = null, bool checkTransientActors = true)
 		{

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -81,15 +81,23 @@ namespace OpenRA.Mods.Common.Traits
 				self.QueueActivity(new Drag(self, CenterPosition, finalPosition, distance / dragSpeed));
 		}
 
+		public bool CanExistInCell(CPos cell)
+		{
+			if (!self.World.Map.Contains(cell))
+				return false;
+
+			if (!info.AllowedTerrain.Contains(self.World.Map.GetTerrainInfo(cell).Type))
+				return false;
+
+			return true;
+		}
+
 		public Pair<CPos, SubCell>[] OccupiedCells() { return new[] { Pair.New(TopLeft, SubCell.FullCell) }; }
 		public bool IsLeavingCell(CPos location, SubCell subCell = SubCell.Any) { return false; }
 		public SubCell GetValidSubCell(SubCell preferred = SubCell.Any) { return SubCell.FullCell; }
 		public SubCell GetAvailableSubCell(CPos cell, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, bool checkTransientActors = true)
 		{
-			if (!self.World.Map.Contains(cell))
-				return SubCell.Invalid;
-
-			if (!info.AllowedTerrain.Contains(self.World.Map.GetTerrainInfo(cell).Type))
+			if (!CanExistInCell(cell))
 				return SubCell.Invalid;
 
 			if (!checkTransientActors)

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -687,6 +687,11 @@ namespace OpenRA.Mods.Common.Traits
 			return Info.GetAvailableSubCell(self.World, self, a, preferredSubCell, ignoreActor, checkTransientActors ? CellConditions.All : CellConditions.None);
 		}
 
+		public bool CanExistInCell(CPos cell)
+		{
+			return Info.MovementCostForCell(self.World, cell) != int.MaxValue;
+		}
+
 		public bool CanEnterCell(CPos cell, Actor ignoreActor = null, bool checkTransientActors = true)
 		{
 			return Info.CanEnterCell(self.World, self, cell, ignoreActor, checkTransientActors);


### PR DESCRIPTION
To test this, place actors near TD short bridges (which have generous footprints) and destroy or repair the bridge.