### PR TITLE
No longer check Carryable IsInWorld when Carryall is killed.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -111,8 +111,13 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (State == CarryallState.Carrying)
 			{
-				if (Carryable.IsInWorld && !Carryable.IsDead)
-					Carryable.Kill(e.Attacker);
+				if (!Carryable.IsDead)
+                {
+                    var positionable = Carryable.Trait<IPositionable>();
+                    positionable.SetPosition(Carryable, self.Location);
+                    Carryable.Kill(e.Attacker);
+                }
+
 				Carryable = null;
 			}
 


### PR DESCRIPTION
This PR concerns issue #14336, it seems the Carryable in a Carryall is always going to have IsInWorld == false since it's removed from the world when it's loaded, so Kill isn't called on the Carryable when the Carryall dies.

I have removed checking IsInWorld when the Carryall dies (I'm fairly confident this is the correct thing to do, as a Cargo doesn't perform this check when it dies and will call Kill on its passengers) and you can now build a Mammoth Mk II again if it's destroyed in a CarryAll.

I assume this would have also been affecting other things that are notified on kill such as exp gain and scores at the end of the game.

P.S. I'm new here (OpenRA, Github, and C#) so any advice/criticism is welcome! :smile: