### PR TITLE
Don't create empty MissionGroups

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -118,8 +118,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						.OrderBy(x => x.Index)
 						.Select(x => x.Preview);
 
-					CreateMissionGroup(kv.Key, previews);
-					allPreviews.AddRange(previews);
+					if (previews.Any())
+					{
+						CreateMissionGroup(kv.Key, previews);
+						allPreviews.AddRange(previews);
+					}
 				}
 			}
 


### PR DESCRIPTION
Only create MissionGroups if there's at least one visible mission.

Split from #15020 to slightly bring down its diff, commit count and things to test during review.

For testing, remove all maps from one campaign category of a mods' mission.yaml of your choice, but leave the campaign category itself in.
On bleed you'd see the campaign title with no missions below, on this branch the mission group should be invisible.