### PR TITLE
Fix a crash in atreides05

### DIFF
--- a/mods/d2k/bits/scripts/campaign-global.lua
+++ b/mods/d2k/bits/scripts/campaign-global.lua
@@ -122,6 +122,9 @@ end
 
 DefendActor = function(unit, defendingPlayer, defenderCount)
 	Trigger.OnDamaged(unit, function(self, attacker)
+		if unit.Owner ~= defendingPlayer then
+			return
+		end
 
 		-- Don't try to attack spiceblooms
 		if attacker and attacker.Type == "spicebloom" then

--- a/mods/d2k/maps/atreides-05/atreides05.lua
+++ b/mods/d2k/maps/atreides-05/atreides05.lua
@@ -345,7 +345,6 @@ WorldLoaded = function()
 	Trigger.OnCapture(Starport, function()
 		DefendStarport = player.AddSecondaryObjective("Defend the captured Starport.")
 
-		Starport.GrantCondition("captured")
 		Trigger.ClearAll(Starport)
 		Trigger.AfterDelay(0, function()
 			Trigger.OnRemovedFromWorld(Starport, function()

--- a/mods/d2k/maps/atreides-05/rules.yaml
+++ b/mods/d2k/maps/atreides-05/rules.yaml
@@ -6,7 +6,7 @@ World:
 	LuaScript:
 		Scripts: campaign-global.lua, atreides05.lua, atreides05-AI.lua
 	MissionData:
-		Briefing: According to our spies, the Fremen are being held at the far Northwest corner of Sietch Tabr. Push your way through the Harkonnen ranks to rescue the hostages.\n\nScout the terrain before you launch the main assault. Our Engineers must reach the Barracks and capture it intact. The rest of the base can be razed to the ground.\n\nAdditionally, there are rumors of an illegal Smuggling operation in the area. A large shipment of contraband is expected at the Smuggler's Starport. If you can the Starport before the contraband arrives, you will be able to confiscate it for the Atreides war effort.\n\nBe warned, the Smugglers have Mercenary allies who may assist them if you interfere.\n\nGood luck.\n
+		Briefing: According to our spies, the Fremen are being held at the far Northwest corner of Sietch Tabr. Push your way through the Harkonnen ranks to rescue the hostages.\n\nScout the terrain before you launch the main assault. Our Engineers must reach the Barracks and capture it intact. The rest of the base can be razed to the ground.\n\nAdditionally, there are rumors of an illegal Smuggling operation in the area. A large shipment of contraband is expected at the Smuggler's Starport. If you can capture the Starport before the contraband arrives, you will be able to confiscate it for the Atreides war effort.\n\nBe warned, the Smugglers have Mercenary allies who may assist them if you interfere.\n\nGood luck.\n
 		BriefingVideo: A_BR05_E.VQA
 	MapOptions:
 		TechLevel: medium


### PR DESCRIPTION
We removed the external condition from the starport in #14798.

Also fixes a typo in the description of that mission and fixes the campaign AI trying to defend captured buildings.