### PR TITLE
Remove leftover sniper disabled from missions

### DIFF
--- a/mods/ra/maps/allies-03a/rules.yaml
+++ b/mods/ra/maps/allies-03a/rules.yaml
@@ -206,10 +206,6 @@ E6:
 	Buildable:
 		Prerequisites: ~disabled
 
-SNIPER:
-	Buildable:
-		Prerequisites: ~disabled
-
 HIJACKER:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/allies-03b/rules.yaml
+++ b/mods/ra/maps/allies-03b/rules.yaml
@@ -158,10 +158,6 @@ E6:
 	Buildable:
 		Prerequisites: ~disabled
 
-SNIPER:
-	Buildable:
-		Prerequisites: ~disabled
-
 HIJACKER:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/intervention/rules.yaml
+++ b/mods/ra/maps/intervention/rules.yaml
@@ -147,10 +147,6 @@ SHOK:
 	Buildable:
 		Prerequisites: ~disabled
 
-SNIPER:
-	Buildable:
-		Prerequisites: ~disabled
-
 2TNK:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/soviet-02a/rules.yaml
+++ b/mods/ra/maps/soviet-02a/rules.yaml
@@ -72,10 +72,6 @@ SHOK:
 	Buildable:
 		Prerequisites: ~disabled
 
-SNIPER:
-	Buildable:
-		Prerequisites: ~disabled
-
 HIJACKER:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/soviet-02b/rules.yaml
+++ b/mods/ra/maps/soviet-02b/rules.yaml
@@ -72,10 +72,6 @@ SHOK:
 	Buildable:
 		Prerequisites: ~disabled
 
-SNIPER:
-	Buildable:
-		Prerequisites: ~disabled
-
 HIJACKER:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/soviet-06a/rules.yaml
+++ b/mods/ra/maps/soviet-06a/rules.yaml
@@ -72,10 +72,6 @@ SPY:
 	Buildable:
 		Prerequisites: ~disabled
 
-SNIPER:
-	Buildable:
-		Prerequisites: ~disabled
-
 HIJACKER:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/soviet-06b/rules.yaml
+++ b/mods/ra/maps/soviet-06b/rules.yaml
@@ -72,10 +72,6 @@ SPY:
 	Buildable:
 		Prerequisites: ~disabled
 
-SNIPER:
-	Buildable:
-		Prerequisites: ~disabled
-
 HIJACKER:
 	Buildable:
 		Prerequisites: ~disabled


### PR DESCRIPTION
A few missions individually have snipers disabled, which is done by the default mod rules.