### PR TITLE
Added PlaceBuildingInit.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -16,6 +16,9 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	// Allows third party mods to detect whether an actor was created by PlaceBuilding.
+	public class PlaceBuildingInit : IActorInit { }
+
 	[Desc("Allows the player to execute build orders.", " Attach this to the player actor.")]
 	public class PlaceBuildingInfo : ITraitInfo
 	{
@@ -84,6 +87,7 @@ namespace OpenRA.Mods.Common.Traits
 						new LocationInit(order.TargetLocation),
 						new OwnerInit(order.Player),
 						new FactionInit(faction),
+						new PlaceBuildingInit()
 					});
 
 					foreach (var s in buildingInfo.BuildSounds)
@@ -105,7 +109,8 @@ namespace OpenRA.Mods.Common.Traits
 							new OwnerInit(order.Player),
 							new FactionInit(faction),
 							new LineBuildDirectionInit(t.First.X == order.TargetLocation.X ? LineBuildDirection.Y : LineBuildDirection.X),
-							new LineBuildParentInit(new[] { t.Second, placed })
+							new LineBuildParentInit(new[] { t.Second, placed }),
+							new PlaceBuildingInit()
 						});
 					}
 				}
@@ -153,6 +158,7 @@ namespace OpenRA.Mods.Common.Traits
 						new LocationInit(order.TargetLocation),
 						new OwnerInit(order.Player),
 						new FactionInit(faction),
+						new PlaceBuildingInit()
 					});
 
 					foreach (var s in buildingInfo.BuildSounds)


### PR DESCRIPTION
The basical idea is to know how an actor is build / created. Not just by building it from the ui. I only added this one case, as its the only one i need currently. A crate may spawn an actor. A factory may produce an actor. A building may be placed by the player. It might spawn cause its some kind of reinforcement. The basical idea is to have an actor which may behave differently under certain circumstances, without this feature, the traits will keep triggering equaly.

Example A: Imagine we have an oil tanker vehicle. When it gets produced by a factory, it should wait for its assignment. However, in case B we have an oil derrick, and the vehicle is granted by FreeActor. It should search for the next derrick on spawn and start driving towards it. (kknd logic)

Example B: I have buildings which will build-up themself after placement. However, this would be the general case, all buildings which are spawned by script, unit deployment, or whatever other reason will start to build at this point, consuming money.