### PR TITLE
Virtual ProductionQueue.AllQueued

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -216,7 +216,7 @@ namespace OpenRA.Mods.Common.Traits
 			return queue.ElementAtOrDefault(0);
 		}
 
-		public IEnumerable<ProductionItem> AllQueued()
+		public virtual IEnumerable<ProductionItem> AllQueued()
 		{
 			return queue;
 		}


### PR DESCRIPTION
Made ProductionQueue.AllQueued virtual, to allow mods to override it.
Also KKnD mod production behavior relies on this.