### PR TITLE
Correctly handle Production traits disabled by condition.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -139,7 +139,7 @@ namespace OpenRA.Mods.Common.Traits
 			// so we must query other player traits from self, knowing that
 			// it refers to the same actor as self.Owner.PlayerActor
 			playerPower = (self.Info.Name == "player" ? self : self.Owner.PlayerActor).TraitOrDefault<PowerManager>();
-			productionTraits = self.TraitsImplementing<Production>().ToArray();
+			productionTraits = self.TraitsImplementing<Production>().Where(p => p.Info.Produces.Contains(Info.Type)).ToArray();
 		}
 
 		protected void ClearQueue()
@@ -236,6 +236,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual IEnumerable<ActorInfo> AllItems()
 		{
+			if (productionTraits.Any() && productionTraits.All(p => p.IsTraitDisabled))
+				return Enumerable.Empty<ActorInfo>();
 			if (developerMode.AllTech)
 				return Producible.Keys;
 
@@ -244,6 +246,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual IEnumerable<ActorInfo> BuildableItems()
 		{
+			if (productionTraits.Any() && productionTraits.All(p => p.IsTraitDisabled))
+				return Enumerable.Empty<ActorInfo>();
 			if (!Enabled)
 				return Enumerable.Empty<ActorInfo>();
 			if (developerMode.AllTech)

--- a/OpenRA.Mods.Common/Traits/ProductionQueueFromSelection.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionQueueFromSelection.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits
 					.FirstOrDefault(q => q.Enabled && types.Contains(q.Info.Type));
 			}
 
-			if (queue == null)
+			if (queue == null || !queue.BuildableItems().Any())
 				return;
 
 			if (tabsWidget.Value != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTabsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTabsLogic.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Linq;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
@@ -34,7 +35,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				tabs.PickUpCompletedBuilding();
 			};
 
-			button.IsDisabled = () => tabs.Groups[button.ProductionGroup].Tabs.Count == 0;
+			button.IsDisabled = () => !tabs.Groups[button.ProductionGroup].Tabs.Any(t => t.Queue.BuildableItems().Any());
 			button.OnMouseUp = mi => selectTab(mi.Modifiers.HasModifier(Modifiers.Shift));
 			button.OnKeyPress = e => selectTab(e.Modifiers.HasModifier(Modifiers.Shift));
 			button.IsHighlighted = () => tabs.QueueGroup == button.ProductionGroup;

--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -161,6 +161,11 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override void Draw()
 		{
+			var tabs = Groups[queueGroup].Tabs.Where(t => t.Queue.BuildableItems().Any());
+
+			if (!tabs.Any())
+				return;
+
 			var rb = RenderBounds;
 			leftButtonRect = new Rectangle(rb.X, rb.Y, ArrowWidth, rb.Height);
 			rightButtonRect = new Rectangle(rb.Right - ArrowWidth, rb.Y, ArrowWidth, rb.Height);
@@ -185,7 +190,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var font = Game.Renderer.Fonts["TinyBold"];
 			contentWidth = 0;
 
-			foreach (var tab in Groups[queueGroup].Tabs)
+			foreach (var tab in tabs)
 			{
 				var rect = new Rectangle(origin.X + contentWidth, origin.Y, TabWidth, rb.Height);
 				var hover = !leftHover && !rightHover && Ui.MouseOverWidget == this && rect.Contains(Viewport.LastMousePos);


### PR DESCRIPTION
While Production trait is disabled via condition, ProductionQueue traits wont build. Additionally, the UI now ignores these actors.
While this is barely noticable in the core mods, it has a major impact on mods where construction takes longer.
