### PR TITLE
Make Exit Conditional and change RA capture Production Lock back to Exit Lock.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -89,8 +89,8 @@ namespace OpenRA.Mods.Common.Activities
 				}
 			}
 
-			var exit = dest.Info.FirstExitOrDefault(null);
-			var offset = (exit != null) ? exit.SpawnOffset : WVec.Zero;
+			var exit = dest.FirstExitOrDefault(null);
+			var offset = exit != null ? exit.Info.SpawnOffset : WVec.Zero;
 
 			if (ShouldLandAtBuilding(self, dest))
 			{

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -750,8 +750,8 @@ namespace OpenRA.Mods.Common.Traits
 
 						Action enter = () =>
 						{
-							var exit = targetActor.Info.FirstExitOrDefault(null);
-							var offset = (exit != null) ? exit.SpawnOffset : WVec.Zero;
+							var exit = targetActor.FirstExitOrDefault(null);
+							var offset = exit != null ? exit.Info.SpawnOffset : WVec.Zero;
 
 							self.QueueActivity(new HeliFly(self, Target.FromPos(targetActor.CenterPosition + offset)));
 							self.QueueActivity(new Turn(self, Info.InitialFacing));

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -119,14 +119,14 @@ namespace OpenRA.Mods.Common.Traits
 			});
 		}
 
-		protected virtual ExitInfo SelectExit(Actor self, ActorInfo producee, string productionType, Func<ExitInfo, bool> p)
+		protected virtual Exit SelectExit(Actor self, ActorInfo producee, string productionType, Func<Exit, bool> p)
 		{
-			return self.RandomExitOrDefault(productionType, p);
+			return self.RandomExitOrDefault(self.World, productionType, p);
 		}
 
-		protected ExitInfo SelectExit(Actor self, ActorInfo producee, string productionType)
+		protected Exit SelectExit(Actor self, ActorInfo producee, string productionType)
 		{
-			return SelectExit(self, producee, productionType, e => CanUseExit(self, producee, e));
+			return SelectExit(self, producee, productionType, e => CanUseExit(self, producee, e.Info));
 		}
 
 		public virtual bool Produce(Actor self, ActorInfo producee, string productionType, TypeDictionary inits)
@@ -139,7 +139,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (exit != null || self.OccupiesSpace == null)
 			{
-				DoProduction(self, producee, exit, productionType, inits);
+				DoProduction(self, producee, exit.Info, productionType, inits);
 
 				return true;
 			}

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Start a fixed distance away: the width of the map.
 			// This makes the production timing independent of spawnpoint
-			var dropPos = exit != null ? self.Location + exit.ExitCell : self.Location;
+			var dropPos = exit != null ? self.Location + exit.Info.ExitCell : self.Location;
 			var startPos = dropPos + new CVec(owner.World.Map.Bounds.Width, 0);
 			var endPos = new CPos(owner.World.Map.Bounds.Left - 5, dropPos.Y);
 
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Traits
 					foreach (var cargo in self.TraitsImplementing<INotifyDelivery>())
 						cargo.Delivered(self);
 
-					self.World.AddFrameEndTask(ww => DoProduction(self, producee, exit, productionType, inits));
+					self.World.AddFrameEndTask(ww => DoProduction(self, producee, exit.Info, productionType, inits));
 					Game.Sound.Play(SoundType.World, info.ChuteSound, self.CenterPosition);
 					Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.ReadyAudio, self.Owner.Faction.InternalName);
 				}));

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -147,47 +147,54 @@ SPEN:
 	RevealsShroud@GAPGEN:
 		Range: 4c0
 	Exit@1:
+		RequiresCondition: !being-captured
 		SpawnOffset: 0,-213,0
 		Facing: 96
 		ExitCell: -1,2
 		ProductionTypes: Submarine
 	Exit@2:
+		RequiresCondition: !being-captured
 		SpawnOffset: 0,-213,0
 		Facing: 160
 		ExitCell: 3,2
 		ProductionTypes: Submarine
 	Exit@3:
+		RequiresCondition: !being-captured
 		SpawnOffset: 0,0,0
 		Facing: 32
 		ExitCell: 0,0
 		ProductionTypes: Submarine
 	Exit@4:
+		RequiresCondition: !being-captured
 		SpawnOffset: 0,0,0
 		Facing: 224
 		ExitCell: 2,0
 		ProductionTypes: Submarine
 	Exit@b1:
+		RequiresCondition: !being-captured
 		SpawnOffset: -1024,1024,0
 		Facing: 160
 		ExitCell: 0,2
 		ProductionTypes: Ship
 	Exit@b2:
+		RequiresCondition: !being-captured
 		SpawnOffset: 1024,1024,0
 		Facing: 224
 		ExitCell: 2,2
 		ProductionTypes: Ship
 	Exit@b3:
+		RequiresCondition: !being-captured
 		SpawnOffset: -1024,-1024,0
 		Facing: 96
 		ExitCell: 0,0
 		ProductionTypes: Ship
 	Exit@b4:
+		RequiresCondition: !being-captured
 		SpawnOffset: 1024,-1024,0
 		Facing: 32
 		ExitCell: 2,0
 		ProductionTypes: Ship
 	Production:
-		PauseOnCondition: being-captured
 		Produces: Ship, Submarine
 	PrimaryBuilding:
 		PrimaryCondition: primary
@@ -285,27 +292,30 @@ SYRD:
 	RevealsShroud@GAPGEN:
 		Range: 4c0
 	Exit@1:
+		RequiresCondition: !being-captured
 		SpawnOffset: -1024,1024,0
 		Facing: 160
 		ExitCell: 0,2
 		ProductionTypes: Ship, Boat
 	Exit@2:
+		RequiresCondition: !being-captured
 		SpawnOffset: 1024,1024,0
 		Facing: 224
 		ExitCell: 2,2
 		ProductionTypes: Ship, Boat
 	Exit@3:
+		RequiresCondition: !being-captured
 		SpawnOffset: -1024,-1024,0
 		Facing: 96
 		ExitCell: 0,0
 		ProductionTypes: Ship, Boat
 	Exit@4:
+		RequiresCondition: !being-captured
 		SpawnOffset: 1024,-1024,0
 		Facing: 32
 		ExitCell: 2,0
 		ProductionTypes: Ship, Boat
 	Production:
-		PauseOnCondition: being-captured
 		Produces: Ship, Boat
 	PrimaryBuilding:
 		PrimaryCondition: primary
@@ -979,10 +989,10 @@ WEAP:
 		Sequence: build-top
 	RallyPoint:
 	Exit@1:
+		RequiresCondition: !being-captured
 		SpawnOffset: 213,-128,0
 		ExitCell: 1,2
 	Production:
-		PauseOnCondition: being-captured
 		Produces: Vehicle
 	ProvidesPrerequisite@allies:
 		Factions: allies, england, france, germany
@@ -1108,7 +1118,6 @@ FACT:
 	RevealsShroud@GAPGEN:
 		Range: 4c0
 	Production:
-		PauseOnCondition: being-captured
 		Produces: Building, Defense
 	Valued:
 		Cost: 2500
@@ -1305,13 +1314,13 @@ HPAD:
 	WithResupplyAnimation:
 		RequiresCondition: !build-incomplete
 	Exit@1:
+		RequiresCondition: !being-captured
 		SpawnOffset: 0,-256,0
 		ExitCell: 0,0
 		MoveIntoWorld: false
 		Facing: 224
 	RallyPoint:
 	Production:
-		PauseOnCondition: being-captured
 		Produces: Aircraft, Helicopter
 	Reservable:
 	ProductionBar:
@@ -1395,12 +1404,12 @@ AFLD:
 	RevealsShroud@GAPGEN:
 		Range: 4c0
 	Exit@1:
+		RequiresCondition: !being-captured
 		ExitCell: 1,1
 		Facing: 192
 		MoveIntoWorld: false
 	RallyPoint:
 	Production:
-		PauseOnCondition: being-captured
 		Produces: Aircraft, Plane
 	Reservable:
 	ProvidesPrerequisite@soviet:
@@ -1666,15 +1675,16 @@ BARR:
 	WithBuildingBib:
 	RallyPoint:
 	Exit@1:
+		RequiresCondition: !being-captured
 		SpawnOffset: -170,810,0
 		ExitCell: 1,2
 		ProductionTypes: Soldier, Infantry
 	Exit@2:
+		RequiresCondition: !being-captured
 		SpawnOffset: -725,640,0
 		ExitCell: 0,2
 		ProductionTypes: Soldier, Infantry
 	Production:
-		PauseOnCondition: being-captured
 		Produces: Infantry, Soldier
 	PrimaryBuilding:
 		PrimaryCondition: primary
@@ -1747,15 +1757,16 @@ KENN:
 	RallyPoint:
 		Offset: 0,2
 	Exit@1:
+		RequiresCondition: !being-captured
 		SpawnOffset: -280,400,0
 		ExitCell: 0,1
 		ProductionTypes: Dog, Infantry
 	Exit@2:
+		RequiresCondition: !being-captured
 		SpawnOffset: -280,400,0
 		ExitCell: -1,0
 		ProductionTypes: Dog, Infantry
 	Production:
-		PauseOnCondition: being-captured
 		Produces: Infantry, Dog
 	PrimaryBuilding:
 		PrimaryCondition: primary
@@ -1806,15 +1817,16 @@ TENT:
 	WithBuildingBib:
 	RallyPoint:
 	Exit@1:
+		RequiresCondition: !being-captured
 		SpawnOffset: -42,810,0
 		ExitCell: 1,2
 		ProductionTypes: Soldier, Infantry
 	Exit@2:
+		RequiresCondition: !being-captured
 		SpawnOffset: -725,640,0
 		ExitCell: 0,2
 		ProductionTypes: Soldier, Infantry
 	Production:
-		PauseOnCondition: being-captured
 		Produces: Infantry, Soldier
 	PrimaryBuilding:
 		PrimaryCondition: primary


### PR DESCRIPTION
I added DisableExitOnCondition to Production as i couldn't get making Exit conditional work, but i guess that would be the correct way to do it. I don't wanna mess with it again rn, but someone else can do it, this hack can be removed. Current changes should do the job for now.

