### PR TITLE
Map editor crashes - if items assigned to players without spawns

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -172,7 +172,10 @@ namespace OpenRA.Mods.Common.Traits
 				var index = int.Parse(name.Substring(5));
 
 				if (index >= newCount)
+				{
 					Players.Players.Remove(name);
+					OnSpawnRemoved();
+				}
 			}
 
 			for (var index = 0; index < newCount; index++)
@@ -196,6 +199,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!string.IsNullOrEmpty(creeps))
 				Players.Players[creeps].Enemies = Players.Players.Keys.Where(p => !Players.Players[p].NonCombatant).ToArray();
 		}
+
+		public Action OnSpawnRemoved = () => { };
 
 		void UpdateNeighbours(IReadOnlyDictionary<CPos, SubCell> footprint)
 		{


### PR DESCRIPTION
 - After a player removes a spawn point which is selected, the owner
   remains selected in the DropdownList after trying to spawn something
   the EditorActorBrush gets created with an invalid owner.

 - This fixes this by checking if the removed spawnpoint is the selected
   one, then falls back to the previous entry.
