### PR TITLE
Don't show Negative Prerequisites on tooltip

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -87,7 +87,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					hotkeyLabel.Bounds.X = nameSize.X + 2 * nameLabel.Bounds.X;
 				}
 
-				var prereqs = buildable.Prerequisites.Select(a => ActorName(mapRules, a)).Where(s => !s.StartsWith("~", StringComparison.Ordinal));
+				var prereqs = buildable.Prerequisites.Select(a => ActorName(mapRules, a))
+					.Where(s => !s.StartsWith("~", StringComparison.Ordinal) && !s.StartsWith("!", StringComparison.Ordinal));
 				requiresLabel.Text = prereqs.Any() ? requiresFormat.F(prereqs.JoinWith(", ")) : "";
 				var requiresSize = requiresFont.Measure(requiresLabel.Text);
 


### PR DESCRIPTION
Prerequisites with ! show the actual string unless there is actually an actor with exact name with !. I guess it is better to hide them. Actual description can be used if negative prerequisite is really should be mentioned. From my experiences, i would say it is usually used for hacky stuff that shouldn't be shown to the player.