### PR TITLE
Fix ProductionQueue audio notifications in TS

### DIFF
--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -15,6 +15,7 @@ Player:
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
+		BlockedAudio:
 		LimitedAudio: BuildingInProgress
 		SpeedUp: True
 	ClassicProductionQueue@Defense:
@@ -23,24 +24,28 @@ Player:
 		LowPowerSlowdown: 3
 		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
+		BlockedAudio:
 		LimitedAudio: BuildingInProgress
 		SpeedUp: True
 	ClassicProductionQueue@Vehicle:
 		Type: Vehicle
 		BuildDurationModifier: 120
 		LowPowerSlowdown: 3
+		BlockedAudio:
 		LimitedAudio: BuildingInProgress
 		SpeedUp: True
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
 		BuildDurationModifier: 120
 		LowPowerSlowdown: 3
+		BlockedAudio:
 		LimitedAudio: BuildingInProgress
 		SpeedUp: True
 	ClassicProductionQueue@Air:
 		Type: Air
 		BuildDurationModifier: 120
 		LowPowerSlowdown: 3
+		BlockedAudio:
 		LimitedAudio: BuildingInProgress
 		SpeedUp: True
 	PlaceBuilding:


### PR DESCRIPTION
Added "BlockedAudio: BuildingInProgress" as the default "NoBuild" notification was removed.
Fixes #15071.

Testcase: Build a MK II and transport it using a carryall. While the MK II is transported (not in the world), the build icon isn't greyed out and you can try building another one.