### PR TITLE
Make positive shape point/corner X values count as 'forward'

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -864,6 +864,7 @@
     <Compile Include="UpdateRules\Rules\AddEditorPlayer.cs" />
     <Compile Include="UpdateRules\Rules\RemovePaletteFromCurrentTileset.cs" />
     <Compile Include="Traits\Player\PlayerResources.cs" />
+    <Compile Include="UpdateRules\Rules\SwitchShapePointsX.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.Common/UpdateRules/Rules/SwitchShapePointsX.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/SwitchShapePointsX.cs
@@ -1,0 +1,71 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class SwitchShapePointsX : UpdateRule
+	{
+		public override string Name { get { return "Switch positive and negative X values on HitShape points"; } }
+		public override string Description
+		{
+			get
+			{
+				return "Positive 'X' values on Rectangle shape 'TopLeft' and 'BottomRight',\n" +
+					"Capsule shape 'PointA' and 'PointB', and Polygon shape 'Points' now mean 'forward'.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var hitShapes = actorNode.ChildrenMatching("HitShape");
+			foreach (var hs in hitShapes)
+			{
+				var type = hs.LastChildMatching("Type");
+				if (type != null)
+				{
+					if (type.Value.Value == "Capsule")
+					{
+						var pointA = type.LastChildMatching("PointA");
+						var pointB = type.LastChildMatching("PointB");
+
+						var pointAField = FieldLoader.GetValue<int2>("PointA", pointA.Value.Value);
+						var pointBField = FieldLoader.GetValue<int2>("PointB", pointB.Value.Value);
+
+						pointAField = new int2(-pointAField.X, pointAField.Y);
+						pointBField = new int2(-pointBField.X, pointBField.Y);
+
+						pointA.Value.Value = pointAField.ToString();
+						pointB.Value.Value = pointBField.ToString();
+					}
+					else if (type.Value.Value == "Rectangle")
+					{
+						var topLeft = type.LastChildMatching("TopLeft");
+						var bottomRight = type.LastChildMatching("BottomRight");
+
+						var topLeftField = FieldLoader.GetValue<int2>("TopLeft", topLeft.Value.Value);
+						var bottomRightField = FieldLoader.GetValue<int2>("BottomRight", bottomRight.Value.Value);
+
+						topLeftField = new int2(-topLeftField.X, topLeftField.Y);
+						bottomRightField = new int2(-bottomRightField.X, bottomRightField.Y);
+
+						topLeft.Value.Value = topLeftField.ToString();
+						bottomRight.Value.Value = bottomRightField.ToString();
+					}
+				}
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -47,7 +47,8 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveWithReloadingSpriteTurret(),
 				new IgnoreAbstractActors(),
 				new AddEditorPlayer(),
-				new RemovePaletteFromCurrentTileset()
+				new RemovePaletteFromCurrentTileset(),
+				new SwitchShapePointsX()
 			})
 		};
 

--- a/OpenRA.Test/OpenRA.Mods.Common/ShapeTest.cs
+++ b/OpenRA.Test/OpenRA.Mods.Common/ShapeTest.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Test
 		[TestCase(TestName = "CapsuleShape report accurate distance")]
 		public void Capsule()
 		{
-			shape = new CapsuleShape(new int2(-50, 0), new int2(500, 235), new WDist(50));
+			shape = new CapsuleShape(new int2(50, 0), new int2(-500, 235), new WDist(50));
 			shape.Initialize();
 
 			Assert.That(shape.DistanceFromEdge(new WVec(300, 100, 0)).Length,
@@ -71,7 +71,7 @@ namespace OpenRA.Test
 		[TestCase(TestName = "RectangleShape report accurate distance")]
 		public void Rectangle()
 		{
-			shape = new RectangleShape(new int2(-123, -456), new int2(100, 100));
+			shape = new RectangleShape(new int2(123, -456), new int2(-100, 100));
 			shape.Initialize();
 
 			Assert.That(shape.DistanceFromEdge(new WVec(10, 10, 0)).Length,
@@ -98,7 +98,7 @@ namespace OpenRA.Test
 		{
 			// Rectangle like above,
 			// Note: The calculations don't match for all, but do have a tolerance of 1.
-			shape = new PolygonShape(new int2[] { new int2(-123, -456), new int2(100, -456), new int2(100, 100), new int2(-123, 100) });
+			shape = new PolygonShape(new int2[] { new int2(123, -456), new int2(-100, -456), new int2(-100, 100), new int2(123, 100) });
 			shape.Initialize();
 
 			Assert.That(shape.DistanceFromEdge(new WVec(10, 10, 0)).Length,
@@ -121,7 +121,7 @@ namespace OpenRA.Test
 
 			// Rectangle like above but reverse order
 			// Note: The calculations don't match for all, but do have a tolerance of 1.
-			shape = new PolygonShape(new int2[] { new int2(-123, 100), new int2(100, 100), new int2(100, -456), new int2(-123, -456) });
+			shape = new PolygonShape(new int2[] { new int2(123, 100), new int2(-100, 100), new int2(-100, -456), new int2(123, -456) });
 			shape.Initialize();
 
 			Assert.That(shape.DistanceFromEdge(new WVec(10, 10, 0)).Length,
@@ -143,7 +143,7 @@ namespace OpenRA.Test
 				Is.EqualTo(877));
 
 			// Right triangle taken from above by removing a point
-			shape = new PolygonShape(new int2[] { new int2(-123, -456), new int2(100, -456), new int2(100, 100) });
+			shape = new PolygonShape(new int2[] { new int2(123, -456), new int2(-100, -456), new int2(-100, 100) });
 			shape.Initialize();
 
 			Assert.That(shape.DistanceFromEdge(new WVec(10, 10, 0)).Length,
@@ -171,7 +171,7 @@ namespace OpenRA.Test
 				Is.EqualTo(878));
 
 			// Right triangle taken from above but reverse order
-			shape = new PolygonShape(new int2[] { new int2(100, 100), new int2(100, -456), new int2(-123, -456) });
+			shape = new PolygonShape(new int2[] { new int2(-100, 100), new int2(-100, -456), new int2(123, -456) });
 			shape.Initialize();
 
 			Assert.That(shape.DistanceFromEdge(new WVec(10, 10, 0)).Length,
@@ -200,9 +200,9 @@ namespace OpenRA.Test
 
 			// Plus shaped dodecagon
 			shape = new PolygonShape(new int2[] {
-				new int2(-511, -1535), new int2(511, -1535), new int2(511, -511), new int2(1535, -511),
-				new int2(1535, 511), new int2(511, 511), new int2(511, 1535), new int2(-511, 1535),
-				new int2(-511, 511), new int2(-1535, 511), new int2(-1535, -511), new int2(-511, -511)
+				new int2(511, -1535), new int2(-511, -1535), new int2(-511, -511), new int2(-1535, -511),
+				new int2(-1535, 511), new int2(-511, 511), new int2(-511, 1535), new int2(511, 1535),
+				new int2(511, 511), new int2(1535, 511), new int2(1535, -511), new int2(511, -511)
 			});
 			shape.Initialize();
 

--- a/mods/cnc/rules/civilian-desert.yaml
+++ b/mods/cnc/rules/civilian-desert.yaml
@@ -4,8 +4,8 @@ V20:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: -840,-512,0, 0,0,0, -840,512,0
 		Type: Rectangle
-			TopLeft: -1024, -512
-			BottomRight: 1024, 896
+			TopLeft: 1024,-512
+			BottomRight: -1024,896
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -32,13 +32,13 @@ V21:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 840,-512,0, 420,0,0, 840,512,0
 		Type: Rectangle
-			TopLeft: -1024, -1024
-			BottomRight: 1024, 0
+			TopLeft: 1024,-1024
+			BottomRight: -1024,0
 	HitShape@WELL:
 		TargetableOffsets: -770,512,0
 		Type: Rectangle
-			TopLeft: 0, 0
-			BottomRight: 1024, 598
+			TopLeft: 0,0
+			BottomRight: -1024,598
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -104,8 +104,8 @@ V24:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: -630,-512,0, 0,0,0, -630,256,0, 420,-512,0
 		Type: Rectangle
-			TopLeft: -1024, -683
-			BottomRight: 640, 853
+			TopLeft: 1024,-683
+			BottomRight: -640,853
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -132,8 +132,8 @@ V25:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,-128,0, 420,512,0
 		Type: Rectangle
-			TopLeft: -683, -683
-			BottomRight: 1024, 512
+			TopLeft: 683,-683
+			BottomRight: -1024,512
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -371,8 +371,8 @@ V37:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 0,1024,0
 		Type: Rectangle
-			TopLeft: -512, -597
-			BottomRight: 1536, 597
+			TopLeft: 512,-597
+			BottomRight: -1536,597
 	SpawnActorOnDeath:
 		Actor: V37.Husk
 	Building:

--- a/mods/cnc/rules/civilian.yaml
+++ b/mods/cnc/rules/civilian.yaml
@@ -4,8 +4,8 @@ V01:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: -490,-384,0, 0,0,0, 0,470,0
 		Type: Rectangle
-			TopLeft: -768, -597
-			BottomRight: 896, 683
+			TopLeft: 768,-597
+			BottomRight: -896,683
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -32,8 +32,8 @@ V02:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: -490,-512,0, 0,0,0, 0,512,0
 		Type: Rectangle
-			TopLeft: -1024, -512
-			BottomRight: 1024, 597
+			TopLeft: 1024,-512
+			BottomRight: -1024,597
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -60,8 +60,8 @@ V03:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: -490,-512,0, 0,0,0, 421,512,0, -210,512,0
 		Type: Rectangle
-			TopLeft: -1024, -597
-			BottomRight: 1024, 597
+			TopLeft: 1024,-597
+			BottomRight: -1024,597
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -88,8 +88,8 @@ V04:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, -421,-256,0, -421,256,0
 		Type: Rectangle
-			TopLeft: -683, -432
-			BottomRight: 683, 683
+			TopLeft: 683,-432
+			BottomRight: -683,683
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -17,29 +17,29 @@
 	HitShape:
 		UseTargetableCellsOffsets: true
 		Type: Rectangle
-			TopLeft: -512, -512
-			BottomRight: 512, 512
+			TopLeft: 512,-512
+			BottomRight: -512,512
 
 ^2x1Shape:
 	HitShape:
 		UseTargetableCellsOffsets: true
 		Type: Rectangle
-			TopLeft: -1024, -512
-			BottomRight: 1024, 512
+			TopLeft: 1024,-512
+			BottomRight: -1024,512
 
 ^2x2Shape:
 	HitShape:
 		UseTargetableCellsOffsets: true
 		Type: Rectangle
-			TopLeft: -1024, -1024
-			BottomRight: 1024, 1024
+			TopLeft: 1024,-1024
+			BottomRight: -1024,1024
 
 ^3x2Shape:
 	HitShape:
 		UseTargetableCellsOffsets: true
 		Type: Rectangle
-			TopLeft: -1536, -1024
-			BottomRight: 1536, 1024
+			TopLeft: 1536,-1024
+			BottomRight: -1536,1024
 
 ^GainsExperience:
 	GainsExperience:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -163,12 +163,12 @@ PROC:
 	Inherits: ^BaseBuilding
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1536, -512
-			BottomRight: 1536, 853
+			TopLeft: 1536,-512
+			BottomRight: -1536,853
 	HitShape@TOP:
 		Type: Rectangle
-			TopLeft: -512, -1450
-			BottomRight: 896, -512
+			TopLeft: 512,-1450
+			BottomRight: -896,-512
 	Valued:
 		Cost: 1500
 	Tooltip:
@@ -258,8 +258,8 @@ PYLE:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 840,-256,0, 840,512,0, 210,-512,0, -71,512,0
 		Type: Rectangle
-			TopLeft: -1024, -1024
-			BottomRight: 1024, 640
+			TopLeft: 1024,-1024
+			BottomRight: -1024,640
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -355,8 +355,8 @@ AFLD:
 	HitShape:
 		TargetableOffsets: 0,0,0, 0,-512,256, 0,-1451,384, 0,512,128, 0,1536,85
 		Type: Rectangle
-			TopLeft: -2048, -1024
-			BottomRight: 2048, 1024
+			TopLeft: 2048,-1024
+			BottomRight: -2048,1024
 	Valued:
 		Cost: 2000
 	Tooltip:
@@ -405,8 +405,8 @@ WEAP:
 	HitShape:
 		TargetableOffsets: 0,0,0, 0,1024,0, 0,-1024,0
 		Type: Rectangle
-			TopLeft: -1536, -1024
-			BottomRight: 1536, 512
+			TopLeft: 1536,-1024
+			BottomRight: -1536,512
 	Valued:
 		Cost: 2000
 	Tooltip:
@@ -510,8 +510,8 @@ HQ:
 	HitShape:
 		TargetableOffsets: 0,0,0, 0,512,0, 420,-598,256
 		Type: Rectangle
-			TopLeft: -1024, -384
-			BottomRight: 1024, 1024
+			TopLeft: 1024,-384
+			BottomRight: -1024,1024
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -575,7 +575,7 @@ FIX:
 	HitShape:
 		TargetableOffsets: 840,0,0, 598,-640,0, 598,640,0, -1060,0,0, -768,-640,0, -768,640,0
 		Type: Polygon
-			Points: -1536,-256, -341,-940, 341,-940, 1536,-256, 1536,341, 341,1110, -341,1110, -1536,341
+			Points: 1536,-256, 341,-940, -341,-940, -1536,-256, -1536,341, -341,1110, 341,1110, 1536,341
 	Valued:
 		Cost: 500
 	Tooltip:
@@ -615,8 +615,8 @@ EYE:
 	HitShape:
 		TargetableOffsets: 0,0,0, 0,512,128, 420,-598,213
 		Type: Rectangle
-			TopLeft: -1024, -384
-			BottomRight: 1024, 1024
+			TopLeft: 1024,-384
+			BottomRight: -1024,1024
 	Valued:
 		Cost: 1800
 	Tooltip:
@@ -785,8 +785,8 @@ SAM:
 	Inherits@shape: ^2x1Shape
 	HitShape:
 		Type: Rectangle
-			TopLeft: -768,-512
-			BottomRight: 768,512
+			TopLeft: 768,-512
+			BottomRight: -768,512
 	Valued:
 		Cost: 650
 	Tooltip:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -385,8 +385,8 @@
 	HitShape:
 		UseTargetableCellsOffsets: true
 		Type: Rectangle
-			TopLeft: -512, -512
-			BottomRight: 512, 512
+			TopLeft: 512,-512
+			BottomRight: -512,512
 	Building:
 		Dimensions: 1,1
 		Footprint: x

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -70,8 +70,8 @@ construction_yard:
 		HP: 30000
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1536, -1024
-			BottomRight: 1536, 1024
+			TopLeft: 1536,-1024
+			BottomRight: -1536,1024
 	Armor:
 		Type: cy
 	RevealsShroud:
@@ -146,8 +146,8 @@ wind_trap:
 		HP: 30000
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1024, -1024
-			BottomRight: 1024, 1024
+			TopLeft: 1024,-1024
+			BottomRight: -1024,1024
 	Armor:
 		Type: building
 	RevealsShroud:
@@ -192,8 +192,8 @@ barracks:
 		HP: 32000
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1024, -1024
-			BottomRight: 1024, 1024
+			TopLeft: 1024,-1024
+			BottomRight: -1024,1024
 	Armor:
 		Type: building
 	RevealsShroud:
@@ -274,12 +274,12 @@ refinery:
 		HP: 30000
 	HitShape:
 		Type: Rectangle
-			TopLeft: -512, -1024
-			BottomRight: 1536, 0
+			TopLeft: 512,-1024
+			BottomRight: -1536,0
 	HitShape@BOTTOM:
 		Type: Rectangle
-			TopLeft: -1536, 0
-			BottomRight: 512, 1024
+			TopLeft: 1536,0
+			BottomRight: -512,1024
 	Armor:
 		Type: heavy
 	RevealsShroud:
@@ -388,8 +388,8 @@ light_factory:
 	HitShape:
 		TargetableOffsets: -210,608,0
 		Type: Rectangle
-			TopLeft: -1536, -1024
-			BottomRight: 1536, 1024
+			TopLeft: 1536,-1024
+			BottomRight: -1536,1024
 	Armor:
 		Type: building
 	RevealsShroud:
@@ -476,12 +476,12 @@ heavy_factory:
 	HitShape:
 		TargetableOffsets: -1155,-704,0, -1365,832,0
 		Type: Rectangle
-			TopLeft: -1536, -512
-			BottomRight: 1536, 1536
+			TopLeft: 1536,-512
+			BottomRight: -1536,1536
 	HitShape@TOP:
 		Type: Rectangle
-			TopLeft: -512, -1536
-			BottomRight: 512, -512
+			TopLeft: 512,-1536
+			BottomRight: -512,-512
 	Armor:
 		Type: building
 	RevealsShroud:
@@ -575,8 +575,8 @@ outpost:
 		HP: 35000
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1536, -1024
-			BottomRight: 1536, 1024
+			TopLeft: 1536,-1024
+			BottomRight: -1536,1024
 	Armor:
 		Type: building
 	RevealsShroud:
@@ -623,12 +623,12 @@ starport:
 		HP: 35000
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1536, -1536
-			BottomRight: 1536, 512
+			TopLeft: 1536,-1536
+			BottomRight: -1536,512
 	HitShape@BOTTOM:
 		Type: Rectangle
-			TopLeft: -512, 512
-			BottomRight: 512, 1536
+			TopLeft: 512,512
+			BottomRight: -512,1536
 	Armor:
 		Type: heavy
 	RevealsShroud:
@@ -743,8 +743,8 @@ wall:
 		Range: 1c512, 2c768
 	HitShape:
 		Type: Rectangle
-			TopLeft: -512, -512
-			BottomRight: 512, 512
+			TopLeft: 512,-512
+			BottomRight: -512,512
 	EditorTilesetFilter:
 		Categories: Defense
 	Replaceable:
@@ -863,12 +863,12 @@ repair_pad:
 		HP: 30000
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1536, -512
-			BottomRight: 1536, 512
+			TopLeft: 1536,-512
+			BottomRight: -1536,512
 	HitShape@TOPANDBOTTOM:
 		Type: Rectangle
-			TopLeft: -512, -1536
-			BottomRight: 512, 1536
+			TopLeft: 512,-1536
+			BottomRight: -512,1536
 	Armor:
 		Type: building
 	RevealsShroud:
@@ -930,13 +930,13 @@ high_tech_factory:
 	HitShape:
 		TargetableOffsets: -1312,0,0, -1312,-1024,0, -1312,1024,0
 		Type: Rectangle
-			TopLeft: -1536, -512
-			BottomRight: 1536, 1536
+			TopLeft: 1536,-512
+			BottomRight: -1536,1536
 	HitShape@TOP:
 		TargetableOffsets: 1280,0,0
 		Type: Rectangle
-			TopLeft: -512, -1536
-			BottomRight: 512, -512
+			TopLeft: 512,-1536
+			BottomRight: -512,-512
 	Armor:
 		Type: building
 	RevealsShroud:
@@ -1011,13 +1011,13 @@ research_centre:
 	HitShape:
 		TargetableOffsets: -1574,-158,0, -1050,-1024,0, -1155,960,0
 		Type: Rectangle
-			TopLeft: -1536, -512
-			BottomRight: 1536, 1536
+			TopLeft: 1536,-512
+			BottomRight: -1536,1536
 	HitShape@TOP:
 		TargetableOffsets: 1312,0,0
 		Type: Rectangle
-			TopLeft: -512, -1536
-			BottomRight: 512, -512
+			TopLeft: 512,-1536
+			BottomRight: -512,-512
 	Armor:
 		Type: building
 	RevealsShroud:
@@ -1060,16 +1060,16 @@ palace:
 		HP: 40000
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1536, -512
-			BottomRight: 1536, 512
+			TopLeft: 1536,-512
+			BottomRight: -1536,512
 	HitShape@TOP:
 		Type: Rectangle
-			TopLeft: -1536, -1536
-			BottomRight: 512, -512
+			TopLeft: 1536,-1536
+			BottomRight: -512,-512
 	HitShape@BOTTOM:
 		Type: Rectangle
-			TopLeft: -512, 512
-			BottomRight: 1536, 1536
+			TopLeft: 512,512
+			BottomRight: -1536,1536
 	Armor:
 		Type: heavy
 	RevealsShroud:

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -136,8 +136,8 @@ V01:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: -490,-384,0, 0,0,0, 0,470,0
 		Type: Rectangle
-			TopLeft: -768, -597
-			BottomRight: 896, 683
+			TopLeft: 768,-597
+			BottomRight: -896,683
 
 V02:
 	Inherits: ^CivBuilding
@@ -150,8 +150,8 @@ V02:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: -490,-512,0, 0,0,0, 0,512,0
 		Type: Rectangle
-			TopLeft: -1024, -512
-			BottomRight: 1024, 597
+			TopLeft: 1024,-512
+			BottomRight: -1024,597
 
 V03:
 	Inherits: ^CivBuilding
@@ -164,8 +164,8 @@ V03:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: -490,-512,0, 0,0,0, 421,512,0, -210,512,0
 		Type: Rectangle
-			TopLeft: -1024, -597
-			BottomRight: 1024, 597
+			TopLeft: 1024,-597
+			BottomRight: -1024,597
 
 V04:
 	Inherits: ^CivBuilding
@@ -178,8 +178,8 @@ V04:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, -421,-256,0, -421,256,0
 		Type: Rectangle
-			TopLeft: -683, -432
-			BottomRight: 683, 683
+			TopLeft: 683,-432
+			BottomRight: -683,683
 
 V05:
 	Inherits: ^CivBuilding
@@ -607,8 +607,8 @@ V20:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: -840,-512,0, 0,0,0, -840,512,0
 		Type: Rectangle
-			TopLeft: -1024, -512
-			BottomRight: 1024, 896
+			TopLeft: 1024,-512
+			BottomRight: -1024,896
 
 V21:
 	Inherits: ^DesertCivBuilding
@@ -619,13 +619,13 @@ V21:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 840,-512,0, 420,0,0, 840,512,0
 		Type: Rectangle
-			TopLeft: -1024, -1024
-			BottomRight: 1024, 0
+			TopLeft: 1024,-1024
+			BottomRight: -1024,0
 	HitShape@WELL:
 		TargetableOffsets: -770,512,0
 		Type: Rectangle
-			TopLeft: 0, 0
-			BottomRight: 1024, 598
+			TopLeft: 0,0
+			BottomRight: -1024,598
 
 V22:
 	Inherits: ^DesertCivBuilding
@@ -646,8 +646,8 @@ V24:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: -630,-512,0, 0,0,0, -630,256,0, 420,-512,0
 		Type: Rectangle
-			TopLeft: -1024, -683
-			BottomRight: 640, 853
+			TopLeft: 1024,-683
+			BottomRight: -640,853
 
 V25:
 	Inherits: ^DesertCivBuilding
@@ -662,8 +662,8 @@ V25:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,-128,0, 420,512,0
 		Type: Rectangle
-			TopLeft: -683, -683
-			BottomRight: 1024, 512
+			TopLeft: 683,-683
+			BottomRight: -1024,512
 
 V26:
 	Inherits: ^DesertCivBuilding
@@ -727,8 +727,8 @@ V37:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 0,1024,0
 		Type: Rectangle
-			TopLeft: -512, -597
-			BottomRight: 1536, 597
+			TopLeft: 512,-597
+			BottomRight: -1536,597
 
 RICE:
 	Inherits: ^CivField

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -16,29 +16,29 @@
 	HitShape:
 		UseTargetableCellsOffsets: true
 		Type: Rectangle
-			TopLeft: -512, -512
-			BottomRight: 512, 512
+			TopLeft: 512,-512
+			BottomRight: -512,512
 
 ^2x1Shape:
 	HitShape:
 		UseTargetableCellsOffsets: true
 		Type: Rectangle
-			TopLeft: -1024, -512
-			BottomRight: 1024, 512
+			TopLeft: 1024,-512
+			BottomRight: -1024,512
 
 ^2x2Shape:
 	HitShape:
 		UseTargetableCellsOffsets: true
 		Type: Rectangle
-			TopLeft: -1024, -1024
-			BottomRight: 1024, 1024
+			TopLeft: 1024,-1024
+			BottomRight: -1024,1024
 
 ^3x2Shape:
 	HitShape:
 		UseTargetableCellsOffsets: true
 		Type: Rectangle
-			TopLeft: -1536, -1024
-			BottomRight: 1536, 1024
+			TopLeft: 1536,-1024
+			BottomRight: -1536,1024
 
 ^GainsExperience:
 	GainsExperience:

--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -65,13 +65,13 @@ SYRF:
 	HitShape:
 		TargetableOffsets: 768,0,0, 768,-1024,0, 768,1024,0
 		Type: Rectangle
-			TopLeft: -1536, -1152
-			BottomRight: 1536, 598
+			TopLeft: 1536,-1152
+			BottomRight: -1536,598
 	HitShape@BOTTOM:
 		TargetableOffsets: -768,0,0
 		Type: Rectangle
-			TopLeft: -512, 598
-			BottomRight: 512, 1110
+			TopLeft: 512,598
+			BottomRight: -512,1110
 
 SPEF:
 	Inherits: ^FakeBuilding
@@ -107,13 +107,13 @@ SPEF:
 		ExcludeTilesets: INTERIOR
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1536, -598
-			BottomRight: 1536, 598
+			TopLeft: 1536,-598
+			BottomRight: -1536,598
 	HitShape@TOPANDBOTTOM:
 		TargetableOffsets: 811,0,0, -811,0,0
 		Type: Rectangle
-			TopLeft: -555, -1110
-			BottomRight: 555, 1110
+			TopLeft: 555,-1110
+			BottomRight: -555,1110
 
 WEAF:
 	Inherits: ^FakeBuilding
@@ -208,7 +208,7 @@ FIXF:
 	HitShape:
 		TargetableOffsets: 840,0,0, 598,-640,0, 598,640,0, -1060,0,0, -768,-640,0, -768,640,0
 		Type: Polygon
-			Points: -1536,-300, -640,-811, 640,-811, 1536,-300, 1536,555, 640,1110, -640,1110, -1536,555
+			Points: 1536,-300, 640,-811, -640,-811, -1536,-300, -1536,555, -640,1110, 640,1110, 1536,555
 
 FAPW:
 	Inherits: ^FakeBuilding
@@ -365,5 +365,5 @@ FACF:
 	HitShape:
 		TargetableOffsets: 1273,939,0, -980,-640,0, -980,640,0
 		Type: Rectangle
-			TopLeft: -1536, -1536
-			BottomRight: 1536, 1536
+			TopLeft: 1536,-1536
+			BottomRight: -1536,1536

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -103,8 +103,8 @@ GAP:
 		EmptyWeapon: SmallBuildingExplode
 	HitShape:
 		Type: Rectangle
-			TopLeft: -512, -512
-			BottomRight: 512, 512
+			TopLeft: 512,-512
+			BottomRight: -512,512
 
 SPEN:
 	Inherits: ^Building
@@ -228,13 +228,13 @@ SPEN:
 		RequiresCondition: primary
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1536, -598
-			BottomRight: 1536, 598
+			TopLeft: 1536,-598
+			BottomRight: -1536,598
 	HitShape@TOPANDBOTTOM:
 		TargetableOffsets: 811,0,0, -811,0,0
 		Type: Rectangle
-			TopLeft: -555, -1110
-			BottomRight: 555, 1110
+			TopLeft: 555,-1110
+			BottomRight: -555,1110
 
 SYRD:
 	Inherits: ^Building
@@ -344,13 +344,13 @@ SYRD:
 	HitShape:
 		TargetableOffsets: 768,0,0, 768,-1024,0, 768,1024,0
 		Type: Rectangle
-			TopLeft: -1536, -1152
-			BottomRight: 1536, 598
+			TopLeft: 1536,-1152
+			BottomRight: -1536,598
 	HitShape@BOTTOM:
 		TargetableOffsets: -768,0,0
 		Type: Rectangle
-			TopLeft: -512, 598
-			BottomRight: 512, 1110
+			TopLeft: 512,598
+			BottomRight: -512,1110
 
 IRON:
 	Inherits: ^ScienceBuilding
@@ -825,8 +825,8 @@ SAM:
 	Inherits@shape: ^2x1Shape
 	HitShape:
 		Type: Rectangle
-			TopLeft: -768,-512
-			BottomRight: 768,512
+			TopLeft: 768,-512
+			BottomRight: -768,512
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 100
@@ -1104,8 +1104,8 @@ FACT:
 	HitShape:
 		TargetableOffsets: 1273,939,0, -980,-640,0, -980,640,0
 		Type: Rectangle
-			TopLeft: -1536, -1536
-			BottomRight: 1536, 1536
+			TopLeft: 1536,-1536
+			BottomRight: -1536,1536
 
 PROC:
 	Inherits: ^Building
@@ -1165,18 +1165,18 @@ PROC:
 	ProvidesPrerequisite@buildingname:
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1536, -512
-			BottomRight: 1536, 598
+			TopLeft: 1536,-512
+			BottomRight: -1536,598
 	HitShape@TOP:
 		TargetableOffsets: 1680,0,0
 		Type: Rectangle
-			TopLeft: -512, -1536
-			BottomRight: 512, -512
+			TopLeft: 512,-1536
+			BottomRight: -512,-512
 	HitShape@BOTTOMLEFT:
 		TargetableOffsets: -1260,-1024,0
 		Type: Rectangle
-			TopLeft: -1536, 598
-			BottomRight: -512, 1280
+			TopLeft: 1536,598
+			BottomRight: 512,1280
 
 SILO:
 	Inherits: ^Building
@@ -1824,7 +1824,7 @@ FIX:
 	HitShape:
 		TargetableOffsets: 840,0,0, 598,-640,0, 598,640,0, -1060,0,0, -768,-640,0, -768,640,0
 		Type: Polygon
-			Points: -1536,-300, -640,-811, 640,-811, 1536,-300, 1536,555, 640,1110, -640,1110, -1536,555
+			Points: 1536,-300, 640,-811, -640,-811, -1536,-300, -1536,555, -640,1110, 640,1110, 1536,555
 
 SBAG:
 	Inherits: ^Wall

--- a/mods/ts/rules/civilian-structures.yaml
+++ b/mods/ts/rules/civilian-structures.yaml
@@ -79,8 +79,8 @@ ABAN05:
 	Inherits@SHAPE: ^3x2Shape
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1536, -1024
-			BottomRight: 768, 1024
+			TopLeft: 1536,-1024
+			BottomRight: -768,1024
 	Tooltip:
 		Name: Hunting Lodge
 	Building:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -172,116 +172,116 @@
 ^2x1Shape:
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1024, -512
-			BottomRight: 1024, 512
+			TopLeft: 1024,-512
+			BottomRight: -1024,512
 
 ^1x2Shape:
 	HitShape:
 		Type: Rectangle
-			TopLeft: -512, -1024
-			BottomRight: 512, 1024
+			TopLeft: 512,-1024
+			BottomRight: -512,1024
 
 ^2x2Shape:
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1024, -1024
-			BottomRight: 1024, 1024
+			TopLeft: 1024,-1024
+			BottomRight: -1024,1024
 
 ^1x3Shape:
 	HitShape:
 		Type: Rectangle
-			TopLeft: -512, -1536
-			BottomRight: 512, 1536
+			TopLeft: 512,-1536
+			BottomRight: -512,1536
 
 ^3x1Shape:
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1536, -512
-			BottomRight: 1536, 512
+			TopLeft: 1536,-512
+			BottomRight: -1536,512
 
 ^3x2Shape:
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1536, -1024
-			BottomRight: 1536, 1024
+			TopLeft: 1536,-1024
+			BottomRight: -1536,1024
 
 ^2x3Shape:
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1024, -1536
-			BottomRight: 1024, 1536
+			TopLeft: 1024,-1536
+			BottomRight: -1024,1536
 
 ^3x3Shape:
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1536, -1536
-			BottomRight: 1536, 1536
+			TopLeft: 1536,-1536
+			BottomRight: -1536,1536
 
 ^2x4Shape:
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1024, -2048
-			BottomRight: 1024, 2048
+			TopLeft: 1024,-2048
+			BottomRight: -1024,2048
 
 ^4x2Shape:
 	HitShape:
 		Type: Rectangle
-			TopLeft: -2048, -1024
-			BottomRight: 2048, 1024
+			TopLeft: 2048,-1024
+			BottomRight: -2048,1024
 
 ^3x4Shape:
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1536, -2048
-			BottomRight: 1536, 2048
+			TopLeft: 1536,-2048
+			BottomRight: -1536,2048
 
 ^4x3FactoryWithBibShape:
 	HitShape:
 		Type: Rectangle
-			TopLeft: -2048, -1536
-			BottomRight: 1024, 1536
+			TopLeft: 2048,-1536
+			BottomRight: -1024,1536
 
 ^4x3Shape:
 	HitShape:
 		Type: Rectangle
-			TopLeft: -2048, -1536
-			BottomRight: 2048, 1536
+			TopLeft: 2048,-1536
+			BottomRight: -2048,1536
 
 ^4x4Shape:
 	HitShape:
 		Type: Rectangle
-			TopLeft: -2048, -2048
-			BottomRight: 2048, 2048
+			TopLeft: 2048,-2048
+			BottomRight: -2048,2048
 
 ^3x5Shape:
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1536, -2560
-			BottomRight: 1536, 2560
+			TopLeft: 1536,-2560
+			BottomRight: -1536,2560
 
 ^5x3Shape:
 	HitShape:
 		Type: Rectangle
-			TopLeft: -2560, -1536
-			BottomRight: 2560, 1536
+			TopLeft: 2560,-1536
+			BottomRight: -2560,1536
 
 ^2x5Shape:
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1024, -2560
-			BottomRight: 1024, 2560
+			TopLeft: 1024,-2560
+			BottomRight: -1024,2560
 
 ^2x6Shape:
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1024, -3072
-			BottomRight: 1024, 3072
+			TopLeft: 1024,-3072
+			BottomRight: -1024,3072
 
 ^6x4Shape:
 	HitShape:
 		Type: Rectangle
-			TopLeft: -3072, -2048
-			BottomRight: 3072, 2048
+			TopLeft: 3072,-2048
+			BottomRight: -3072,2048
 
 ^BasicBuilding:
 	Inherits@1: ^ExistsInWorld
@@ -299,8 +299,8 @@
 		UseTargetableCellsOffsets: true
 		Type: Rectangle
 			LocalYaw: -128
-			TopLeft: -512, -512
-			BottomRight: 512, 512
+			TopLeft: 512,-512
+			BottomRight: -512,512
 	Building:
 		Dimensions: 1,1
 		Footprint: x
@@ -470,8 +470,8 @@
 	HitShape:
 		Type: Rectangle
 			LocalYaw: 128
-			TopLeft: -512, -512
-			BottomRight: 512, 512
+			TopLeft: 512,-512
+			BottomRight: -512,512
 			VerticalTopOffset: 768
 	EditorTilesetFilter:
 		Categories: Wall
@@ -1156,8 +1156,8 @@
 	HitShape:
 		Type: Rectangle
 			LocalYaw: -128
-			TopLeft: -512, -512
-			BottomRight: 512, 512
+			TopLeft: 512,-512
+			BottomRight: -512,512
 			VerticalTopOffset: 768
 	EditorTilesetFilter:
 		Categories: Wall

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -366,8 +366,8 @@ NAWAST:
 	Inherits: ^Building
 	HitShape:
 		Type: Rectangle
-			TopLeft: -1536, -1536
-			BottomRight: 512, 1536
+			TopLeft: 1536,-1536
+			BottomRight: -512,1536
 	Valued:
 		Cost: 1600
 	Tooltip:


### PR DESCRIPTION
Closes #14990.

To keep the regression risk as low as possible, I went for only changing the modder-facing value and internally convert it back to what the math formulas expect.

Note: Update rule has been tested and used to update all shipping mods.
Update rule for Polygon shape has not been included because a) I couldn't get it to work on an int2 array and b) the Polygon shape was merged after last release, so modders updating from release to release won't need an update rule for that shape anyway.