### PR TITLE
RA Balance changes April 2018

### DIFF
--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -397,7 +397,7 @@ BIO:
 		Footprint: xx xx
 		Dimensions: 2,2
 	RevealsShroud:
-		Range: 3c0
+		Range: 4c0
 	ExternalCapturable:
 	ExternalCapturableBar:
 	EngineerRepairable:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -597,7 +597,7 @@
 	Huntable:
 	UpdatesPlayerStatistics:
 	GivesBuildableArea:
-		AreaTypes: building
+		AreaTypes: building, fake
 	RepairableBuilding:
 		RepairStep: 700
 		PlayerExperience: 25
@@ -693,14 +693,17 @@
 
 ^FakeBuilding:
 	Inherits: ^Building
-	-GivesBuildableArea:
+	GivesBuildableArea:
+		AreaTypes: fake
+	RequiresBuildableArea:
+		AreaTypes: fake
 	Health:
 		HP: 10000
 	Explodes:
 		Weapon: Demolish
 		DamageThreshold: 70
 	RevealsShroud:
-		Range: 4c0
+		Range: 1c0
 	WithDecoration@fake:
 		RequiresSelection: true
 		Image: pips

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -568,7 +568,7 @@ SHOK:
 		Prerequisites: ~barr, stek, tsla, ~infantry.russia, ~techlevel.high
 		Description: Elite infantry with portable Tesla coils.\n  Strong vs Infantry, Vehicles\n  Weak vs Aircraft
 	Valued:
-		Cost: 300
+		Cost: 350
 	Tooltip:
 		Name: Shock Trooper
 	Health:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -87,7 +87,7 @@ MSUB:
 		TurnSpeed: 3
 		Speed: 42
 	RevealsShroud:
-		Range: 6c0
+		Range: 8c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 5c0

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -192,6 +192,10 @@ SPEN:
 	ProductionBar:
 	Power:
 		Amount: -30
+	DetectCloaked:
+		CloakTypes: Underwater
+		Range: 10c0
+	RenderDetectionCircle:
 	ProvidesPrerequisite@soviet:
 		Factions: soviet, russia, ukraine
 		Prerequisite: ships.soviet
@@ -301,6 +305,10 @@ SYRD:
 	ProductionBar:
 	Power:
 		Amount: -30
+	DetectCloaked:
+		CloakTypes: Underwater
+		Range: 10c0
+	RenderDetectionCircle:
 	ProvidesPrerequisite@allies:
 		Factions: allies, england, france, germany
 		Prerequisite: ships.allies
@@ -844,7 +852,7 @@ SAM:
 	Armor:
 		Type: Heavy
 	RevealsShroud:
-		Range: 6c0
+		Range: 8c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 5c0
@@ -893,7 +901,7 @@ ATEK:
 	Armor:
 		Type: Wood
 	RevealsShroud:
-		Range: 10c0
+		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 6c0
@@ -1323,7 +1331,7 @@ AFLD:
 	Armor:
 		Type: Wood
 	RevealsShroud:
-		Range: 7c0
+		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 4c0
@@ -1512,7 +1520,7 @@ APWR:
 	Armor:
 		Type: Wood
 	RevealsShroud:
-		Range: 4c0
+		Range: 5c0
 	WithBuildingBib:
 	Power:
 		Amount: 200

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -256,7 +256,7 @@ ARTY:
 		Prerequisites: dome, ~vehicles.allies, ~techlevel.medium
 		Description: Long-range artillery.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles, Aircraft
 	Valued:
-		Cost: 800
+		Cost: 850
 	Tooltip:
 		Name: Artillery
 	Health:
@@ -414,8 +414,8 @@ JEEP:
 	WithSpriteTurret:
 	Cargo:
 		Types: Infantry
-		MaxWeight: 1
-		PipCount: 1
+		MaxWeight: 2
+		PipCount: 2
 		LoadingCondition: notmobile
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
@@ -470,6 +470,8 @@ MNLY:
 		Cost: 800
 	Tooltip:
 		Name: Minelayer
+	Selectable:
+		Priority: 5
 	Health:
 		HP: 15000
 	Armor:
@@ -528,7 +530,7 @@ MGG:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 150
-		Prerequisites: atek, ~vehicles.france, ~techlevel.high
+		Prerequisites: atek, ~vehicles.england, ~techlevel.high
 		BuildDuration: 1500
 		BuildDurationModifier: 40
 		Description: Regenerates the shroud nearby, \nobscuring the area.\n  Unarmed
@@ -617,7 +619,7 @@ TTNK:
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 113
+		Speed: 99
 	RevealsShroud:
 		Range: 7c0
 		RevealGeneratedShroud: False
@@ -750,7 +752,7 @@ CTNK:
 		LocalYaw: -60
 	AttackFrontal:
 	PortableChrono:
-		ChargeDelay: 300
+		ChargeDelay: 250
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 	Selectable:
@@ -793,7 +795,7 @@ STNK:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 130
-		Prerequisites: atek, ~vehicles.england, ~techlevel.high
+		Prerequisites: atek, ~vehicles.france, ~techlevel.high
 		BuildDuration: 1166
 		Description: Lightly armored infantry transport which\ncan cloak. Armed with anti-ground missiles.\nCan detect cloaked units.\n  Strong vs Light armor\n  Weak vs Infantry, Tanks, Aircraft
 	Valued:
@@ -830,7 +832,7 @@ STNK:
 		LoadingCondition: notmobile
 	Cloak:
 		InitialDelay: 125
-		CloakDelay: 250
+		CloakDelay: 175
 		CloakSound: appear1.aud
 		UncloakSound: appear1.aud
 		IsPlayerPalette: true

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -102,12 +102,12 @@
 		Name: England
 		InternalName: england
 		Side: Allies
-		Description: England: Espionage\nSpecial Unit: British Spy\nSpecial Unit: Phase Transport
+		Description: England: Counterintelligence\nSpecial Unit: British Spy\nSpecial Unit: Mobile Gap Generator
 	Faction@2:
 		Name: France
 		InternalName: france
 		Side: Allies
-		Description: France: Deception\nSpecial Ability: Can build fake structures\nSpecial Unit: Mobile Gap Generator
+		Description: France: Deception\nSpecial Ability: Can build fake structures\nSpecial Unit: Phase Transport
 	Faction@3:
 		Name: Germany
 		InternalName: germany

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -284,7 +284,7 @@ TorpTube:
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
 			None: 40
-			Wood: 40
+			Wood: 80
 			Light: 30
 			Heavy: 30
 			Concrete: 100

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -25,7 +25,7 @@ ZSU-23:
 	Inherits: ^AACannon
 	Burst: 2
 	BurstDelays: 0
-	ReloadDelay: 5
+	ReloadDelay: 6
 	Range: 10c0
 	Projectile: Bullet
 		Speed: 3c340


### PR DESCRIPTION
**Changes:**

**AA Gun delay increased from 5 to 6**
**Sam Site Vision increased from 6c0 to 8c0**
The relative strength of AA Guns and Sam Sites have been widely decried. This allows Sam Sites to shoot their maximum range, and lowers the DPS of the AA Gun.

**Added 2nd seat to Ranger**
This should allow more harassment play with rocket drops. Also could allow for some inventive Tanya-Medic play.

**Subpens and Naval Yards have 10c0 detection range of Submarines**
Closes #10287

**Shock Trooper price increased from 300 to 350**
**Telsa Tank speed lowered from 113 to 99. (Same speed as MGG and MRJ)**
The strength of Shock Troopers and Tesla Tanks make Russia a very strong faction pick, especially vs Ukraine.

**Missile Sub vision increased from 6c0 to 8c0, damage vs wood increased from 40% to 80%.**
~~**Reload delay decreased to 250 from 300.**~~
The extra vision will be even with subs now, and should provide more ambush opportunities of idling aircraft. Missile Sub damage is pretty bad so we’re looking to boost its worth as a siege weapon. 

**Lowered selection priority of Minelayers**
Closes #14770

**Artillery cost increased to 850 from 800**
Artillery is widely hated, and one of the reasons we're looking into an overhaul of how Allies work in general. This is a change to alleviate the situation in the short term.

**Phase Transport and Mobile Gap Generator swapped between England and France.**
Inter-faction balance has been one of my focus areas for a long time. This should bring up the level of France and reduce England a bit, which will hopefully produce more players choosing Any or Allies as a faction instead of a specific country. Changed the special unit description of England from Espionage to Counterintelligence to fit better with the Mobile Gap Generator.

**Phase Transport Cloaking speed reduced from 9 seconds to 6.**
**Chrono Tank PortableChrono time reduced to ~9 seconds (250 ticks).**
Small buffs to bring these units more utility. 

**Biolab vision increased from 3c0 to 4c0; Vision of Airfield (was 7c0), Allied Tech Center (was 10c0), and Advanced Power Plant (was 4c0) changed to 5c0.**
Mainly polish changes to bring these buildings in line with other structures. (Civ buildings sans the communications center have 4c0 and base buildings sans the radar dome 5c0.)

~~**Sub torpedo speed increased from 85 to 100**~~
~~Small buff to torpedoes, which are pretty easy to dodge atm.~~

**Fake structures can build off of other fake structures. Vision reduced from 4c0 to 1c0**
Closes #10969
I think this addresses #11444 as well.