### PR TITLE
Add --dump-sequence-sheets Utility command.

### DIFF
--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -137,6 +137,8 @@ namespace OpenRA.Graphics
 		}
 
 		public Sheet Current { get { return current; } }
+		public TextureChannel CurrentChannel { get { return channel; } }
+		public IEnumerable<Sheet> AllSheets { get { return sheets; } }
 
 		public void Dispose()
 		{

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -864,6 +864,7 @@
     <Compile Include="UpdateRules\Rules\AddEditorPlayer.cs" />
     <Compile Include="UpdateRules\Rules\RemovePaletteFromCurrentTileset.cs" />
     <Compile Include="Traits\Player\PlayerResources.cs" />
+    <Compile Include="UtilityCommands\DumpSequenceSheetsCommand.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
@@ -1,0 +1,62 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using OpenRA.FileSystem;
+using OpenRA.Graphics;
+
+namespace OpenRA.Mods.Common.UtilityCommands
+{
+	class DumpSequenceSheetsCommand : IUtilityCommand
+	{
+		static readonly int[] ChannelMasks = { 2, 1, 0, 3 };
+
+		string IUtilityCommand.Name { get { return "--dump-sequence-sheets"; } }
+
+		bool IUtilityCommand.ValidateArguments(string[] args)
+		{
+			return args.Length >= 3;
+		}
+
+		[Desc("PALETTE", "TILESET-OR-MAP", "Exports sequence texture atlas as a set of png images.")]
+		void IUtilityCommand.Run(Utility utility, string[] args)
+		{
+			// HACK: The engine code assumes that Game.modData is set.
+			var modData = Game.ModData = utility.ModData;
+
+			var palette = new ImmutablePalette(args[1], new int[0]);
+
+			SequenceProvider sequences = null;
+			var mapPackage = new Folder(".").OpenPackage(args[2], modData.ModFiles);
+			if (mapPackage != null)
+				sequences = new Map(modData, mapPackage).Rules.Sequences;
+			else if (!modData.DefaultSequences.TryGetValue(args[2], out sequences))
+				throw new InvalidOperationException("{0} is not a valid tileset or map path".F(args[2]));
+
+			sequences.Preload();
+
+			var count = 0;
+			var sb = sequences.SpriteCache.SheetBuilder;
+			foreach (var s in sb.AllSheets)
+			{
+				var max = s == sb.Current ? (int)sb.CurrentChannel + 1 : 4;
+				for (var i = 0; i < max; i++)
+					s.AsBitmap((TextureChannel)ChannelMasks[i], palette).Save("{0}.png".F(count++));
+			}
+
+			Console.WriteLine("Saved [0..{0}].png", count - 1);
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a utility command to export the sequence texture atlas that is uploaded to the GPU.
There are two main use cases for this:
* Allowing mods to be aware of and optimize their sprite layout to improve their rendering performance.
* Providing a testcase for my next set of PRs that will improve the texture packing to get RA and TD down to a single sheet (4 exported layers).

Testcase:
* Run `OpenRA.Utility.exe ra --extract temperat.pal` to extract the temperat.pal
* Run `OpenRA.Utility.exe ra --dump-sequence-sheets temperat.pal TEMPERAT` to dump the sheets for the default mod rules on the TEMPERAT tileset (or substitute a different tileset or a path to a map).
* Inspect 0-6.png in your favourite image viewer.