### PR TITLE
Fix map updater breaking unicode characters.

### DIFF
--- a/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
@@ -216,7 +216,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 		{
 			foreach (var file in files)
 				if (file.Item1 != null)
-					file.Item1.Update(file.Item2, Encoding.ASCII.GetBytes(file.Item3.WriteToString()));
+					file.Item1.Update(file.Item2, Encoding.UTF8.GetBytes(file.Item3.WriteToString()));
 		}
 
 		/// <summary>Renames a yaml key preserving any @suffix</summary>


### PR DESCRIPTION
Fixes #15080.

Testcase: `OpenRA.Utility.exe cnc --update-map mods/cnc/maps/gdi04c/ AddEditorPlayer --apply`