### PR TITLE
Ignore files included from other mods when running the mod updater.

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -1229,5 +1229,14 @@ namespace OpenRA
 
 			return modData.DefaultFileSystem.Exists(filename);
 		}
+
+		public bool IsExternalModFile(string filename)
+		{
+			// Explicit package paths never refer to a map
+			if (filename.Contains("|"))
+				return modData.DefaultFileSystem.IsExternalModFile(filename);
+
+			return false;
+		}
 	}
 }

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -568,5 +568,14 @@ namespace OpenRA
 
 			return modData.DefaultFileSystem.Exists(filename);
 		}
+
+		bool IReadOnlyFileSystem.IsExternalModFile(string filename)
+		{
+			// Explicit package paths never refer to a map
+			if (filename.Contains("|"))
+				return modData.DefaultFileSystem.IsExternalModFile(filename);
+
+			return false;
+		}
 	}
 }

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -55,7 +55,7 @@ namespace OpenRA
 			ObjectCreator = new ObjectCreator(Manifest, mods);
 			PackageLoaders = ObjectCreator.GetLoaders<IPackageLoader>(Manifest.PackageFormats, "package");
 
-			ModFiles = new FS(mods, PackageLoaders);
+			ModFiles = new FS(mod.Id, mods, PackageLoaders);
 			ModFiles.LoadFromManifest(Manifest);
 			Manifest.LoadCustomData(ObjectCreator);
 

--- a/OpenRA.Mods.Common/UtilityCommands/UpdateMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpdateMapCommand.cs
@@ -74,6 +74,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 		static void ApplyRules(ModData modData, IReadWritePackage mapPackage, IEnumerable<UpdateRule> rules)
 		{
+			var externalFilenames = new HashSet<string>();
 			foreach (var rule in rules)
 			{
 				Console.WriteLine("{0}: {1}", rule.GetType().Name, rule.Name);
@@ -82,7 +83,6 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 				Console.Write("   Updating map... ");
 
-				var externalFilenames = new HashSet<string>();
 				try
 				{
 					manualSteps = UpdateUtils.UpdateMap(modData, mapPackage, rule, out mapFiles, externalFilenames);
@@ -105,13 +105,6 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				mapFiles.Save();
 				Console.WriteLine("COMPLETE");
 
-				if (externalFilenames.Any())
-				{
-					Console.WriteLine("   The following shared yaml files referenced by the map have been ignored:");
-					Console.WriteLine(UpdateUtils.FormatMessageList(externalFilenames, 1));
-					Console.WriteLine("   These files are assumed to have already been updated by the --update-mod command");
-				}
-
 				if (manualSteps.Any())
 				{
 					Console.WriteLine("   Manual changes are required to complete this update:");
@@ -119,6 +112,14 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						Console.WriteLine("    * " + manualStep.Replace("\n", "\n      "));
 				}
 
+				Console.WriteLine();
+			}
+
+			if (externalFilenames.Any())
+			{
+				Console.WriteLine("The following shared yaml files referenced by the map have been ignored:");
+				Console.WriteLine(UpdateUtils.FormatMessageList(externalFilenames));
+				Console.WriteLine("These files are assumed to have already been updated by the --update-mod command");
 				Console.WriteLine();
 			}
 

--- a/OpenRA.Mods.Common/UtilityCommands/UpdateModCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpdateModCommand.cs
@@ -117,6 +117,8 @@ namespace OpenRA.Mods.Common.UtilityCommands
 		static void ApplyRules(ModData modData, IEnumerable<UpdateRule> rules, bool skipMaps)
 		{
 			Console.WriteLine();
+
+			var externalFilenames = new HashSet<string>();
 			foreach (var rule in rules)
 			{
 				var manualSteps = new List<string>();
@@ -127,7 +129,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				try
 				{
 					Console.Write("   Updating mod... ");
-					manualSteps.AddRange(UpdateUtils.UpdateMod(modData, rule, out allFiles));
+					manualSteps.AddRange(UpdateUtils.UpdateMod(modData, rule, out allFiles, externalFilenames));
 					Console.WriteLine("COMPLETE");
 				}
 				catch (Exception ex)
@@ -150,13 +152,13 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				if (!skipMaps)
 				{
 					var mapsFailed = false;
-					var externalFilenames = new HashSet<string>();
+					var mapExternalFilenames = new HashSet<string>();
 					foreach (var package in modData.MapCache.EnumerateMapPackagesWithoutCaching())
 					{
 						try
 						{
 							YamlFileSet mapFiles;
-							var mapSteps = UpdateUtils.UpdateMap(modData, package, rule, out mapFiles, externalFilenames);
+							var mapSteps = UpdateUtils.UpdateMap(modData, package, rule, out mapFiles, mapExternalFilenames);
 							allFiles.AddRange(mapFiles);
 
 							if (mapSteps.Any())
@@ -198,6 +200,14 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					Console.WriteLine(UpdateUtils.FormatMessageList(manualSteps, 1));
 				}
 
+				Console.WriteLine();
+			}
+
+			if (externalFilenames.Any())
+			{
+				Console.WriteLine("The following external mod files have been ignored:");
+				Console.WriteLine(UpdateUtils.FormatMessageList(externalFilenames));
+				Console.WriteLine("These files should be updated by running --update-mod on the referenced mod(s)");
 				Console.WriteLine();
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentLogic.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var modObjectCreator = new ObjectCreator(mod, Game.Mods);
 			var modPackageLoaders = modObjectCreator.GetLoaders<IPackageLoader>(mod.PackageFormats, "package");
-			var modFileSystem = new FS(Game.Mods, modPackageLoaders);
+			var modFileSystem = new FS(mod.Id, Game.Mods, modPackageLoaders);
 			modFileSystem.LoadFromManifest(mod);
 
 			var sourceYaml = MiniYaml.Load(modFileSystem, content.Sources, null);

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentPromptLogic.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				var modObjectCreator = new ObjectCreator(mod, Game.Mods);
 				var modPackageLoaders = modObjectCreator.GetLoaders<IPackageLoader>(mod.PackageFormats, "package");
-				var modFileSystem = new FS(Game.Mods, modPackageLoaders);
+				var modFileSystem = new FS(mod.Id, Game.Mods, modPackageLoaders);
 				modFileSystem.LoadFromManifest(mod);
 
 				var downloadYaml = MiniYaml.Load(modFileSystem, content.Downloads, null);


### PR DESCRIPTION
This PR makes the mod updater ignore any files included from a different mod.  This should make life easier for "overlay-style" SDK mods that inherit from one of the default mods from the engine directory.  This also fixes the duplicated ignored file warnings on the map updater.

Testcase:
* Download / clone https://github.com/pchote/OpenRAModSDK/tree/ra-example-mod
* Change `ENGINE_VERSION` to `d7bb0c7` in `mod.config` and (re)compile.
* Run `utility.(sh|cmd) --update-mod release-20180307 --apply` and notice that it updates the mod's `rules.yaml` and `weapons.yaml` but ignores all of the default RA files.  The mod overrides are actually compatible with current bleed, so it will only change formatting.