### PR TITLE
Fix args in linux server scripts

### DIFF
--- a/packaging/linux/openra-server.in
+++ b/packaging/linux/openra-server.in
@@ -1,4 +1,4 @@
 #!/bin/sh
 cd "{GAME_INSTALL_DIR}"
 
-mono {DEBUG} OpenRA.Server.exe Game.Mod={MOD} "$$@"
+mono {DEBUG} OpenRA.Server.exe Game.Mod={MOD} "$@"


### PR DESCRIPTION
Looks like a typo. 
Any args passed to the openra-{MOD}-server scripts were not correctly passed to OpenRA.Server.exe.
The client/game scripts are fine.
(I guess "$$@" resolves to a PID with an '@' hanging off it)
