### PR TITLE
Fix ShakeOnDeath and remove hardcoded screen shaking from bridges

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -578,6 +578,7 @@
     <Compile Include="Traits\World\WeatherOverlay.cs" />
     <Compile Include="Traits\World\ActorSpawnManager.cs" />
     <Compile Include="Traits\ActorSpawner.cs" />
+    <Compile Include="UpdateRules\Rules\ChangeIntensityToDuration.cs" />
     <Compile Include="UpdateRules\Rules\IgnoreAbstractActors.cs" />
     <Compile Include="UtilityCommands\CheckYaml.cs" />
     <Compile Include="UtilityCommands\ConvertPngToShpCommand.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -579,6 +579,7 @@
     <Compile Include="Traits\World\ActorSpawnManager.cs" />
     <Compile Include="Traits\ActorSpawner.cs" />
     <Compile Include="UpdateRules\Rules\ChangeIntensityToDuration.cs" />
+    <Compile Include="UpdateRules\Rules\AddShakeToBridge.cs" />
     <Compile Include="UpdateRules\Rules\IgnoreAbstractActors.cs" />
     <Compile Include="UtilityCommands\CheckYaml.cs" />
     <Compile Include="UtilityCommands\ConvertPngToShpCommand.cs" />

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -378,7 +378,6 @@ namespace OpenRA.Mods.Common.Traits
 				// Use .FromPos since this actor is killed. Cannot use Target.FromActor
 				info.DemolishWeaponInfo.Impact(Target.FromPos(self.CenterPosition), saboteur, Enumerable.Empty<int>());
 
-				self.World.WorldActor.Trait<ScreenShaker>().AddEffect(15, self.CenterPosition, 6);
 				self.Kill(saboteur);
 			});
 

--- a/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
@@ -116,7 +116,6 @@ namespace OpenRA.Mods.Common.Traits
 				// Use .FromPos since this actor is dead. Cannot use Target.FromActor
 				Info.DemolishWeaponInfo.Impact(Target.FromPos(self.CenterPosition), saboteur, Enumerable.Empty<int>());
 
-				self.World.WorldActor.Trait<ScreenShaker>().AddEffect(15, self.CenterPosition, 6);
 				self.Kill(saboteur);
 			});
 		}

--- a/OpenRA.Mods.Common/Traits/ShakeOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/ShakeOnDeath.cs
@@ -15,7 +15,8 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public class ShakeOnDeathInfo : ITraitInfo
 	{
-		public readonly int Intensity = 10;
+		public readonly int Duration = 10;
+		public readonly int Intensity = 1;
 		public object Create(ActorInitializer init) { return new ShakeOnDeath(this); }
 	}
 
@@ -30,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyKilled.Killed(Actor self, AttackInfo e)
 		{
-			self.World.WorldActor.Trait<ScreenShaker>().AddEffect(info.Intensity, self.CenterPosition, 1);
+			self.World.WorldActor.Trait<ScreenShaker>().AddEffect(info.Duration, self.CenterPosition, info.Intensity);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/UpdateRules/Rules/AddShakeToBridge.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/AddShakeToBridge.cs
@@ -1,0 +1,47 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class AddShakeToBridge : UpdateRule
+	{
+		public override string Name { get { return "Screen shaking was removed from dying bridges."; } }
+		public override string Description
+		{
+			get
+			{
+				return "'Bridges' (and 'GroundLevelBridges') no longer shake the screen on their own.\n" +
+					"The 'ShakeOnDeath' trait is to be used instead.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			if (actorNode.ChildrenMatching("Bridge").Any())
+				AddShakeNode(actorNode);
+			else if (actorNode.ChildrenMatching("GroundLevelBridge").Any())
+				AddShakeNode(actorNode);
+
+			yield break;
+		}
+
+		void AddShakeNode(MiniYamlNode actorNode)
+		{
+			var shake = new MiniYamlNode("ShakeOnDeath", "");
+			shake.AddNode("Duration", "15");
+			shake.AddNode("Intensity", "6");
+			actorNode.AddNode(shake);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/ChangeIntensityToDuration.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/ChangeIntensityToDuration.cs
@@ -1,0 +1,44 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class ChangeIntensityToDuration : UpdateRule
+	{
+		public override string Name { get { return "Add a 'Duration' parameter to 'ShakeOnDeath'."; } }
+		public override string Description
+		{
+			get
+			{
+				return "The 'Intensity' parameter on 'ShakeOnDeath' has been used as duration\n" +
+					"by accident. A new 'Duration' parameter was added to fix that.\n" +
+					"Definitions of 'Intensity' will be automatically renamed to 'Duration'.\n" +
+					"The old 'Intensity' parameter will now change the intensity as intended.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var sod in actorNode.ChildrenMatching("ShakeOnDeath"))
+			{
+				var intensity = sod.LastChildMatching("Intensity");
+				if (intensity == null)
+					continue;
+
+				intensity.RenameKeyPreservingSuffix("Duration");
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -48,6 +48,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveWithReloadingSpriteTurret(),
 				new ChangeIntensityToDuration(),
 				new IgnoreAbstractActors(),
+				new AddShakeToBridge(),
 				new AddEditorPlayer(),
 				new RemovePaletteFromCurrentTileset(),
 				new DefineLocomotors()

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -46,6 +46,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new DefineSoundDefaults(),
 				new RenameWormSpawner(),
 				new RemoveWithReloadingSpriteTurret(),
+				new ChangeIntensityToDuration(),
 				new IgnoreAbstractActors(),
 				new AddEditorPlayer(),
 				new RemovePaletteFromCurrentTileset(),

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -977,6 +977,9 @@
 	ScriptTriggers:
 	BodyOrientation:
 		QuantizedFacings: 1
+	ShakeOnDeath:
+		Duration: 15
+		Intensity: 6
 
 ^Crate:
 	Inherits@1: ^SpriteActor

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -939,6 +939,9 @@
 		QuantizedFacings: 1
 	Interactable:
 		Bounds: 96,48
+	ShakeOnDeath:
+		Duration: 15
+		Intensity: 6
 
 ^Rock:
 	Inherits@1: ^SpriteActor

--- a/mods/ts/rules/bridges.yaml
+++ b/mods/ts/rules/bridges.yaml
@@ -63,6 +63,9 @@ LOBRDG_A:
 		ADestroyedSequences: adead
 		BDestroyedSequences: bdead
 		ABDestroyedSequences: abdead
+	ShakeOnDeath:
+		Duration: 15
+		Intensity: 6
 
 LOBRDG_A_D:
 	Inherits: LOBRDG_A
@@ -99,6 +102,9 @@ LOBRDG_B:
 		ADestroyedSequences: adead
 		BDestroyedSequences: bdead
 		ABDestroyedSequences: abdead
+	ShakeOnDeath:
+		Duration: 15
+		Intensity: 6
 
 LOBRDG_B_D:
 	Inherits: LOBRDG_B


### PR DESCRIPTION
`ShakeOnDeath` was using the `Intensity` parameter for the duration all along. Fixed that and introduced a new `Duration` parameter together with an update rule for this change.

To make use of the new fix, I also removed the screen shaking from `Bridge` and `GroundLevelBridge` and made bridge actors use `ShakeOnDeath` instead. Note that the update rule for this change has a dependency on #15107 or - if this gets merged first - #15107 will need to adjust the rule.