### PR TITLE
Skip ITemporaryBlocker check entirely if rules contain no temporary blockers

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -299,6 +299,8 @@ namespace OpenRA.Traits
 		void SetVisualPosition(Actor self, WPos pos);
 	}
 
+	public interface ITemporaryBlockerInfo : ITraitInfoInterface { }
+
 	[RequireExplicitImplementation]
 	public interface ITemporaryBlocker
 	{

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -149,6 +149,8 @@ namespace OpenRA
 			}
 		}
 
+		public bool RulesContainTemporaryBlocker { get; private set; }
+
 		internal World(ModData modData, Map map, OrderManager orderManager, WorldType type)
 		{
 			Type = type;
@@ -185,6 +187,8 @@ namespace OpenRA
 				MapUid = Map.Uid,
 				MapTitle = Map.Title
 			};
+
+			RulesContainTemporaryBlocker = map.Rules.Actors.Any(a => a.Value.HasTraitInfo<ITemporaryBlockerInfo>());
 		}
 
 		public void AddToMaps(Actor self, IOccupySpace ios)

--- a/OpenRA.Game/WorldUtils.cs
+++ b/OpenRA.Game/WorldUtils.cs
@@ -45,6 +45,9 @@ namespace OpenRA
 
 		public static bool ContainsTemporaryBlocker(this World world, CPos cell, Actor ignoreActor = null)
 		{
+			if (!world.RulesContainTemporaryBlocker)
+				return false;
+
 			var temporaryBlockers = world.ActorMap.GetActorsAt(cell);
 			foreach (var temporaryBlocker in temporaryBlockers)
 			{

--- a/OpenRA.Mods.Cnc/Traits/EnergyWall.cs
+++ b/OpenRA.Mods.Cnc/Traits/EnergyWall.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Will open and be passable for actors that appear friendly when there are no enemies in range.")]
-	public class EnergyWallInfo : BuildingInfo, IObservesVariablesInfo, IRulesetLoaded
+	public class EnergyWallInfo : BuildingInfo, ITemporaryBlockerInfo, IObservesVariablesInfo, IRulesetLoaded
 	{
 		[FieldLoader.Require]
 		[WeaponReference]

--- a/OpenRA.Mods.Common/Traits/Buildings/Gate.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Gate.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Will open and be passable for actors that appear friendly when there are no enemies in range.")]
-	public class GateInfo : PausableConditionalTraitInfo, IBlocksProjectilesInfo, Requires<BuildingInfo>
+	public class GateInfo : PausableConditionalTraitInfo, ITemporaryBlockerInfo, IBlocksProjectilesInfo, Requires<BuildingInfo>
 	{
 		public readonly string OpeningSound = null;
 		public readonly string ClosingSound = null;

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -268,10 +268,14 @@ namespace OpenRA.Mods.Common.Traits
 				IsMovingInMyDirection(self, otherActor))
 				return false;
 
-			// If there is a temporary blocker in our path, but we can remove it, we are not blocked.
-			var temporaryBlocker = otherActor.TraitOrDefault<ITemporaryBlocker>();
-			if (temporaryBlocker != null && temporaryBlocker.CanRemoveBlockage(otherActor, self))
-				return false;
+			// PERF: Only perform ITemporaryBlocker trait look-up if mod/map rules contain any actors that are temporary blockers
+			if (self.World.RulesContainTemporaryBlocker)
+			{
+				// If there is a temporary blocker in our path, but we can remove it, we are not blocked.
+				var temporaryBlocker = otherActor.TraitOrDefault<ITemporaryBlocker>();
+				if (temporaryBlocker != null && temporaryBlocker.CanRemoveBlockage(otherActor, self))
+					return false;
+			}
 
 			// If we cannot crush the other actor in our way, we are blocked.
 			if (Crushes == null || Crushes.Count == 0)


### PR DESCRIPTION
This benefits all mods without temporary blockers like gates or energy walls in their mod rules.

According to the tables towards the end of the #13547 discussion, the TraitOrDefault look-ups for ITemporaryBlocker are cheap individually, but since the game does so many of them, they do have a (low) performance impact.

Avoiding them altogether if the mod rules contain no temporary blocker actors should save that little bit of performance.