### PR TITLE
Added HpPerStep to Repairable trait and using this value in Repair activity 

### DIFF
--- a/OpenRA.Mods.Common/Activities/Repair.cs
+++ b/OpenRA.Mods.Common/Activities/Repair.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly RepairsUnits[] allRepairsUnits;
 		readonly Target host;
 		readonly WDist closeEnough;
+		readonly Repairable repairable;
 
 		int remainingTicks;
 		bool played = false;
@@ -33,6 +34,7 @@ namespace OpenRA.Mods.Common.Activities
 			this.closeEnough = closeEnough;
 			allRepairsUnits = host.TraitsImplementing<RepairsUnits>().ToArray();
 			health = self.TraitOrDefault<Health>();
+			repairable = self.TraitOrDefault<Repairable>();
 		}
 
 		protected override void OnFirstRun(Actor self)
@@ -97,7 +99,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (remainingTicks == 0)
 			{
 				var unitCost = self.Info.TraitInfo<ValuedInfo>().Cost;
-				var hpToRepair = repairsUnits.Info.HpPerStep;
+				var hpToRepair = repairable != null && repairable.Info.HpPerStep > 0 ? repairable.Info.HpPerStep : repairsUnits.Info.HpPerStep;
 
 				// Cast to long to avoid overflow when multiplying by the health
 				var cost = Math.Max(1, (int)(((long)hpToRepair * unitCost * repairsUnits.Info.ValuePercentage) / (health.MaxHP * 100L)));

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -26,19 +26,22 @@ namespace OpenRA.Mods.Common.Traits
 
 		[VoiceReference] public readonly string Voice = "Action";
 
+		[Desc("The amount the unit will be repaired at each step. Use -1 for fallback behavior where HpPerStep from RepairUnit trait will be used.")]
+		public readonly int HpPerStep = -1;
+
 		public virtual object Create(ActorInitializer init) { return new Repairable(init.Self, this); }
 	}
 
 	class Repairable : IIssueOrder, IResolveOrder, IOrderVoice
 	{
-		readonly RepairableInfo info;
+		public readonly RepairableInfo Info;
 		readonly Health health;
 		readonly IMove movement;
 		readonly AmmoPool[] ammoPools;
 
 		public Repairable(Actor self, RepairableInfo info)
 		{
-			this.info = info;
+			Info = info;
 			health = self.Trait<Health>();
 			movement = self.Trait<IMove>();
 			ammoPools = self.TraitsImplementing<AmmoPool>().ToArray();
@@ -62,12 +65,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool CanRepairAt(Actor target)
 		{
-			return info.RepairBuildings.Contains(target.Info.Name);
+			return Info.RepairBuildings.Contains(target.Info.Name);
 		}
 
 		bool CanRearmAt(Actor target)
 		{
-			return info.RepairBuildings.Contains(target.Info.Name);
+			return Info.RepairBuildings.Contains(target.Info.Name);
 		}
 
 		bool CanRepair()
@@ -82,7 +85,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public string VoicePhraseForOrder(Actor self, Order order)
 		{
-			return (order.OrderString == "Repair" && CanRepair()) ? info.Voice : null;
+			return (order.OrderString == "Repair" && CanRepair()) ? Info.Voice : null;
 		}
 
 		public void ResolveOrder(Actor self, Order order)
@@ -133,7 +136,7 @@ namespace OpenRA.Mods.Common.Traits
 			var repairBuilding = self.World.ActorsWithTrait<RepairsUnits>()
 				.Where(a => !a.Actor.IsDead && a.Actor.IsInWorld
 					&& a.Actor.Owner.IsAlliedWith(self.Owner) &&
-					info.RepairBuildings.Contains(a.Actor.Info.Name))
+					Info.RepairBuildings.Contains(a.Actor.Info.Name))
 				.OrderBy(p => (self.Location - p.Actor.Location).LengthSquared);
 
 			// Worst case FirstOrDefault() will return a TraitPair<null, null>, which is OK.


### PR DESCRIPTION
In the current form the repair activity is lacking the ability to set the HpPerStep for each unit with the Repairable trait. By only having this property on the RepairsUnits trait it will be hard to find a good value that works across all the repairable units in games. 

For example in TD with the current HpPerStep in the live, repair time comparing to the build time on the units:

| Unit| Repair time (s)| Build time (s)|
| ------------- | ------------- | ------------- |
| Buggy | 6 | 8 |
| Bike | 6 | 12|
| Medium tank | 28 | 20|
| Mammoth tank | 43| 36 |

By have this be set on the trait Repairable it will enable mods to balance the repair activity in a better way. 

Ping @AoAGeneral 