### PR TITLE
Replace crate collection via crushing with dedicated crate collection logic

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -317,6 +317,7 @@
     <Compile Include="Traits\Rearmable.cs" />
     <Compile Include="Traits\Burns.cs" />
     <Compile Include="Traits\CarryableHarvester.cs" />
+    <Compile Include="Traits\CrateCollector.cs" />
     <Compile Include="Traits\ChangesTerrain.cs" />
     <Compile Include="Traits\CommandBarBlacklist.cs" />
     <Compile Include="Traits\Conditions\GrantExternalConditionToCrusher.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -935,6 +935,7 @@
     <Compile Include="UpdateRules\Rules\20180923\RemoveRepairBuildingsFromAircraft.cs" />
     <Compile Include="UpdateRules\Rules\20180923\AddRearmable.cs" />
     <Compile Include="UpdateRules\Rules\20180923\MergeAttackPlaneAndHeli.cs" />
+    <Compile Include="UpdateRules\Rules\20180923\AddCrateCollector.cs" />
     <Compile Include="Traits\Player\PlayerResources.cs" />
     <Compile Include="UtilityCommands\DumpSequenceSheetsCommand.cs" />
     <Compile Include="Traits\Render\WithBuildingRepairDecoration.cs" />

--- a/OpenRA.Mods.Common/Traits/CrateCollector.cs
+++ b/OpenRA.Mods.Common/Traits/CrateCollector.cs
@@ -1,0 +1,38 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("This actor can collect crates.")]
+	public class CrateCollectorInfo : ITraitInfo
+	{
+		[Desc("Define collector type(s) checked by Crate and CrateAction for validity. Leave empty if actor is supposed to be able to collect any crate.")]
+		public readonly BitSet<CollectorType> CollectorTypes = default(BitSet<CollectorType>);
+
+		public bool All { get { return CollectorTypes == default(BitSet<CollectorType>); } }
+
+		public object Create(ActorInitializer init) { return new CrateCollector(this); }
+	}
+
+	public class CrateCollector
+	{
+		public readonly CrateCollectorInfo Info;
+
+		public CrateCollector(CrateCollectorInfo info)
+		{
+			Info = info;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
@@ -11,6 +11,7 @@
 
 using System.Linq;
 using OpenRA.Mods.Common.Effects;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -38,6 +39,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Only allow this crate action when the collector has these prerequisites")]
 		public readonly string[] Prerequisites = { };
 
+		[Desc("Collector types that this crate action will not occur for.")]
+		public readonly BitSet<CollectorType> ExcludeCollectorTypes = default(BitSet<CollectorType>);
+
 		[Desc("Actor types that this crate action will not occur for.")]
 		[ActorReference] public string[] ExcludedActorTypes = { };
 
@@ -63,6 +67,10 @@ namespace OpenRA.Mods.Common.Traits
 				return 0;
 
 			if (Info.ExcludedActorTypes.Contains(collector.Info.Name))
+				return 0;
+
+			var crateCollectorTraitInfo = collector.Info.TraitInfo<CrateCollectorInfo>();
+			if (!crateCollectorTraitInfo.All && crateCollectorTraitInfo.CollectorTypes.Overlaps(Info.ExcludeCollectorTypes))
 				return 0;
 
 			if (Info.Prerequisites.Any() && !collector.Owner.PlayerActor.Trait<TechTree>().HasPrerequisites(Info.Prerequisites))

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Can the actor be ordered to move in to shroud?")]
 		public readonly bool MoveIntoShroud = true;
 
-		[Desc("e.g. crate, wall, infantry")]
+		[Desc("e.g. wall, infantry")]
 		public readonly BitSet<CrushClass> Crushes = default(BitSet<CrushClass>);
 
 		[Desc("Types of damage that are caused while crushing. Leave empty for no damage types.")]

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/AddCrateCollector.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/AddCrateCollector.cs
@@ -1,0 +1,141 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class AddCrateCollector : UpdateRule
+	{
+		public override string Name { get { return "Add CrateCollector"; } }
+		public override string Description
+		{
+			get
+			{
+				return "Crate collection is now done via CrateCollector trait instead of crushing.";
+			}
+		}
+
+		List<string> collectingLocomotors = new List<string>();
+		List<MiniYamlNode> affectedActors = new List<MiniYamlNode>();
+
+		bool addedCrateCollector;
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (!addedCrateCollector)
+			{
+				addedCrateCollector = true;
+				foreach (var actor in affectedActors)
+					AddCrateCollectorIfNecessary(actor);
+			}
+
+			yield break;
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var crates = actorNode.ChildrenMatching("Crate");
+			foreach (var crate in crates)
+			{
+				var crushClasses = crate.LastChildMatching("CrushClass");
+				if (crushClasses != null)
+					crushClasses.RenameKey("ValidCollectorTypes");
+
+				var huf = actorNode.LastChildMatching("HiddenUnderFog");
+				if (huf != null)
+				{
+					var type = huf.LastChildMatching("Type");
+					if (type != null)
+						type.Value.Value = "GroundPosition";
+					else
+						huf.AddNode("Type", "GroundPosition");
+				}
+
+				var hus = actorNode.LastChildMatching("HiddenUnderShroud");
+				if (hus != null)
+				{
+					var type = hus.LastChildMatching("Type");
+					if (type != null)
+						type.Value.Value = "GroundPosition";
+					else
+						hus.AddNode("Type", "GroundPosition");
+				}
+			}
+
+			var locomotors = actorNode.ChildrenMatching("Locomotor");
+			foreach (var locomotor in locomotors)
+				CheckAndUpdateLocomotor(locomotor);
+
+			var jjLocomotors = actorNode.ChildrenMatching("JumpjetLocomotor");
+			foreach (var locomotor in jjLocomotors)
+				CheckAndUpdateLocomotor(locomotor);
+
+			var stLocomotors = actorNode.ChildrenMatching("SubterraneanLocomotor");
+			foreach (var locomotor in stLocomotors)
+				CheckAndUpdateLocomotor(locomotor);
+
+			// Caching actors with defined locomotor because we have to add CrateCollector in AfterUpdate,
+			// since otherwise it would be impossible to ensure we've checked the locomotors for crate collect ability.
+			var mobile = actorNode.LastChildMatching("Mobile");
+			if (mobile != null)
+			{
+				var locomotor = mobile.LastChildMatching("Locomotor");
+				if (locomotor != null)
+					affectedActors.Add(actorNode);
+			}
+
+			yield break;
+		}
+
+		void CheckAndUpdateLocomotor(MiniYamlNode locomotor)
+		{
+			var name = "default";
+			var nameNode = locomotor.LastChildMatching("Name");
+			if (nameNode != null)
+				name = nameNode.Value.Value;
+
+			var crushes = locomotor.LastChildMatching("Crushes");
+			if (crushes != null)
+			{
+				// If 'crate' is the only entry, remove Crushes node and add to list of crate crushing locos
+				if (crushes.Value.Value == "crate")
+				{
+					collectingLocomotors.Add(name);
+					locomotor.RemoveNode(crushes);
+				}
+				else
+				{
+					var oldCrushesEntries = FieldLoader.GetValue<string[]>("Crushes", crushes.Value.Value);
+					if (oldCrushesEntries.Any(e => e == "crate"))
+						collectingLocomotors.Add(name);
+
+					var newCrushesEntries = oldCrushesEntries.Where(e => e != "crate");
+					crushes.Value.Value = string.Join(", ", newCrushesEntries);
+				}
+			}
+		}
+
+		void AddCrateCollectorIfNecessary(MiniYamlNode actorNode)
+		{
+			// We only cached actors that have Mobile with a Locomotor: entry, so no null checks necessary here
+			var mobile = actorNode.LastChildMatching("Mobile");
+			var locomotorNode = mobile.LastChildMatching("Locomotor");
+
+			// Just to be on the safe side, we check if the actor for some reason already has the CrateCollector trait
+			var hasCrateCollector = actorNode.LastChildMatching("CrateCollector") != null;
+			var crateCollectorNode = new MiniYamlNode("CrateCollector", "");
+			if (!hasCrateCollector && collectingLocomotors.Any(l => l == locomotorNode.Value.Value))
+				actorNode.AddNode(crateCollectorNode);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -104,6 +104,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new MergeAttackPlaneAndHeli(),
 				new RemovedDemolishLocking(),
 				new RequireProductionType(),
+				new AddCrateCollector(),
 			})
 		};
 

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -48,6 +48,7 @@ TRAN:
 	SelectionDecorations:
 	Selectable:
 		DecorationBounds: 41,41
+	CrateCollector:
 
 HELI:
 	Inherits: ^Helicopter

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -246,6 +246,7 @@
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
+	CrateCollector:
 	Mobile:
 		Locomotor: wheeled
 		TurnSpeed: 5
@@ -356,6 +357,7 @@
 		Type: None
 	RevealsShroud:
 		Range: 5c0
+	CrateCollector:
 	Mobile:
 		Locomotor: foot
 	SelectionDecorations:
@@ -529,6 +531,7 @@
 		Name: Dinosaur
 	RevealsShroud:
 		Range: 6c0
+	CrateCollector:
 	Mobile:
 		Locomotor: critter
 		Speed: 113
@@ -575,6 +578,7 @@
 		Type: Wood
 	RevealsShroud:
 		Range: 6c0
+	CrateCollector:
 	Mobile:
 		Voice: Move
 		Speed: 71
@@ -721,6 +725,8 @@
 
 ^BaseBuilding:
 	Inherits: ^Building
+	CrateCollector:
+		CollectorTypes: crate-collector, building
 	Building:
 		RequiresBaseProvider: true
 		BuildSounds: constru2.aud, hvydoor1.aud
@@ -1082,6 +1088,7 @@
 	Inherits@1: ^SpriteActor
 	Interactable:
 	HiddenUnderFog:
+		Type: GroundPosition
 	Tooltip:
 		Name: Crate
 		GenericName: Crate

--- a/mods/cnc/rules/misc.yaml
+++ b/mods/cnc/rules/misc.yaml
@@ -20,6 +20,7 @@ CRATE:
 		SelectionShares: 5
 		Effect: cloak
 		Condition: cloak-crate-collected
+		ExcludeCollectorTypes: building
 	GiveMcvCrateAction:
 		SelectionShares: 0
 		NoBaseSelectionShares: 50

--- a/mods/cnc/rules/ships.yaml
+++ b/mods/cnc/rules/ships.yaml
@@ -82,3 +82,4 @@ LST:
 		PipCount: 5
 		PassengerFacing: 0
 		LoadingCondition: notmobile
+	CrateCollector:

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -16,7 +16,6 @@
 		OverrideFullFog: full
 	Locomotor@FOOT:
 		Name: foot
-		Crushes: crate
 		SharesCell: true
 		TerrainSpeeds:
 			Clear: 90
@@ -30,7 +29,6 @@
 			Beach: 80
 	Locomotor@CHEM:
 		Name: chem
-		Crushes: crate
 		SharesCell: true
 		TerrainSpeeds:
 			Clear: 90
@@ -42,7 +40,6 @@
 			Beach: 80
 	Locomotor@WHEELED:
 		Name: wheeled
-		Crushes: crate
 		TerrainSpeeds:
 			Clear: 80
 			Rough: 50
@@ -53,7 +50,6 @@
 			Beach: 50
 	Locomotor@BIKE:
 		Name: bike
-		Crushes: crate
 		TerrainSpeeds:
 			Clear: 70
 			Rough: 35
@@ -64,7 +60,7 @@
 			Beach: 35
 	Locomotor@HEAVYWHEELED:
 		Name: heavywheeled
-		Crushes: crate, infantry
+		Crushes: infantry
 		TerrainSpeeds:
 			Clear: 80
 			Rough: 50
@@ -75,7 +71,7 @@
 			Beach: 50
 	Locomotor@TRACKED:
 		Name: tracked
-		Crushes: wall, crate, infantry
+		Crushes: wall, infantry
 		TerrainSpeeds:
 			Clear: 80
 			Rough: 70
@@ -86,7 +82,7 @@
 			Beach: 70
 	Locomotor@HEAVYTRACKED:
 		Name: heavytracked
-		Crushes: wall, heavywall, crate, infantry
+		Crushes: wall, heavywall, infantry
 		TerrainSpeeds:
 			Clear: 80
 			Rough: 70
@@ -97,12 +93,10 @@
 			Beach: 70
 	Locomotor@NAVAL:
 		Name: naval
-		Crushes: crate
 		TerrainSpeeds:
 			Water: 100
 	Locomotor@LANDINGCRAFT:
 		Name: lcraft
-		Crushes: crate
 		TerrainSpeeds:
 			Clear: 100
 			Rough: 100
@@ -114,7 +108,6 @@
 			River: 100
 	Locomotor@CRITTER:
 		Name: critter
-		Crushes: crate
 		TerrainSpeeds:
 			Clear: 90
 			Rough: 80

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -170,6 +170,7 @@
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
+	CrateCollector:
 	Mobile:
 		TurnSpeed: 5
 		Locomotor: vehicle
@@ -277,6 +278,7 @@
 		Type: none
 	RevealsShroud:
 		Range: 3c768
+	CrateCollector:
 	Mobile:
 		Locomotor: foot
 	SelectionDecorations:

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -1,5 +1,6 @@
 crate:
 	HiddenUnderFog:
+		Type: GroundPosition
 	Tooltip:
 		Name: Crate
 	Crate:

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -18,7 +18,7 @@
 		ShroudBlend: Multiply
 	Locomotor@FOOT:
 		Name: foot
-		Crushes: crate, spicebloom
+		Crushes: spicebloom
 		SharesCell: true
 		TerrainSpeeds:
 			Sand: 100
@@ -32,7 +32,7 @@
 			Rough: 80
 	Locomotor@VEHICLE:
 		Name: vehicle
-		Crushes: crate, spicebloom
+		Crushes: spicebloom
 		TerrainSpeeds:
 			Sand: 100
 			Rock: 100
@@ -44,7 +44,7 @@
 			Dune: 50
 	Locomotor@TANK:
 		Name: tank
-		Crushes: crate, infantry, spicebloom
+		Crushes: infantry, spicebloom
 		TerrainSpeeds:
 			Sand: 100
 			Rock: 100
@@ -56,7 +56,7 @@
 			Dune: 50
 	Locomotor@DEVASTATOR:
 		Name: devastator
-		Crushes: crate, infantry, spicebloom, wall
+		Crushes: infantry, spicebloom, wall
 		TerrainSpeeds:
 			Sand: 100
 			Rock: 100

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -259,6 +259,7 @@ TRAN:
 	SelectionDecorations:
 	Selectable:
 		DecorationBounds: 40,36
+	CrateCollector:
 
 HELI:
 	Inherits: ^Helicopter

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -240,6 +240,7 @@
 		Action: Kill
 	DrawLineToTarget:
 	UpdatesPlayerStatistics:
+	CrateCollector:
 	Mobile:
 		RequiresCondition: !being-captured
 		Locomotor: wheeled
@@ -315,6 +316,7 @@
 		Action: Kill
 		DeathTypes: DefaultDeath
 	DrawLineToTarget:
+	CrateCollector:
 	Health:
 		HP: 2500
 	Armor:
@@ -472,6 +474,7 @@
 		Action: Kill
 	DrawLineToTarget:
 	UpdatesPlayerStatistics:
+	CrateCollector:
 	Mobile:
 		Locomotor: naval
 	SelectionDecorations:
@@ -638,6 +641,8 @@
 
 ^Building:
 	Inherits: ^BasicBuilding
+	CrateCollector:
+		CollectorTypes: crate-collector, building
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -1045,6 +1050,7 @@
 	Interactable:
 		Bounds: 24,24
 	HiddenUnderFog:
+		Type: GroundPosition
 	Tooltip:
 		Name: Crate
 		GenericName: Crate

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -108,6 +108,7 @@ CRATE:
 		Sound: ironcur9.aud
 		Condition: invulnerability
 		Duration: 600
+		ExcludeCollectorTypes: building
 
 MONEYCRATE:
 	Inherits: ^Crate

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -10,7 +10,7 @@
 	DebugVisualizations:
 	Locomotor@FOOT:
 		Name: foot
-		Crushes: mine, crate
+		Crushes: mine
 		SharesCell: true
 		TerrainSpeeds:
 			Clear: 90
@@ -22,7 +22,7 @@
 			Beach: 80
 	Locomotor@WHEELED:
 		Name: wheeled
-		Crushes: mine, crate
+		Crushes: mine
 		TerrainSpeeds:
 			Clear: 80
 			Rough: 40
@@ -33,7 +33,7 @@
 			Beach: 40
 	Locomotor@HEAVYWHEELED:
 		Name: heavywheeled
-		Crushes: wall, mine, crate, infantry
+		Crushes: wall, mine, infantry
 		TerrainSpeeds:
 			Clear: 80
 			Rough: 40
@@ -44,7 +44,7 @@
 			Beach: 40
 	Locomotor@LIGHTTRACKED:
 		Name: lighttracked
-		Crushes: wall, mine, crate
+		Crushes: wall, mine
 		TerrainSpeeds:
 			Clear: 80
 			Rough: 70
@@ -55,7 +55,7 @@
 			Beach: 70
 	Locomotor@TRACKED:
 		Name: tracked
-		Crushes: wall, infantry, mine, crate
+		Crushes: wall, infantry, mine
 		TerrainSpeeds:
 			Clear: 80
 			Rough: 70
@@ -66,7 +66,7 @@
 			Beach: 70
 	Locomotor@HEAVYTRACKED:
 		Name: heavytracked
-		Crushes: wall, infantry, mine, crate, heavywall
+		Crushes: wall, infantry, mine, heavywall
 		TerrainSpeeds:
 			Clear: 80
 			Rough: 70
@@ -77,12 +77,10 @@
 			Beach: 70
 	Locomotor@NAVAL:
 		Name: naval
-		Crushes: crate
 		TerrainSpeeds:
 			Water: 100
 	Locomotor@LANDINGCRAFT:
 		Name: lcraft
-		Crushes: crate
 		TerrainSpeeds:
 			Water: 100
 			Beach: 70

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -62,6 +62,7 @@ DSHP:
 		EjectOnDeath: true
 	SpawnActorOnDeath:
 		Actor: DSHP.Husk
+	CrateCollector:
 
 ORCA:
 	Inherits: ^Helicopter
@@ -202,6 +203,7 @@ ORCATRAN:
 		EjectOnDeath: true
 	SpawnActorOnDeath:
 		Actor: ORCATRAN.Husk
+	CrateCollector:
 
 TRNSPORT:
 	Inherits: ^Helicopter
@@ -239,6 +241,7 @@ TRNSPORT:
 		Bounds: 44,32,0,-8
 	SpawnActorOnDeath:
 		Actor: TRNSPORT.Husk
+	CrateCollector:
 
 SCRIN:
 	Inherits: ^Aircraft

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -437,6 +437,7 @@
 
 ^Crate:
 	HiddenUnderFog:
+		Type: GroundPosition
 	Tooltip:
 		Name: Crate
 	Crate:
@@ -535,6 +536,7 @@
 		RequiresCondition: !inside-tunnel
 		Range: 2c0
 		MaxHeightDelta: 3
+	CrateCollector:
 	Mobile:
 		Voice: Move
 		Speed: 71
@@ -720,6 +722,7 @@
 	OwnerLostAction:
 		Action: Kill
 	DrawLineToTarget:
+	CrateCollector:
 	Mobile:
 		RequiresCondition: !empdisable && !being-captured
 		Locomotor: wheeled
@@ -931,6 +934,7 @@
 		Categories: Critter
 	GrantConditionOnTunnelLayer:
 		Condition: inside-tunnel
+	CrateCollector:
 
 ^BlossomTree:
 	Inherits@1: ^SpriteActor
@@ -1089,6 +1093,7 @@
 		Categories: Railway
 	GrantConditionOnTunnelLayer:
 		Condition: inside-tunnel
+	CrateCollector:
 
 ^TerrainOverlay:
 	AlwaysVisible:

--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -90,20 +90,24 @@ CRATE:
 		Effect: stealth
 		Condition: crate-cloak
 		Sound: cloak5.aud
+		ExcludeCollectorTypes: building
 	GrantExternalConditionCrateAction@firepower:
 		SelectionShares: 5
 		Effect: firepower
 		Condition: crate-firepower
 		Notification: UnitFirepowerUpgraded
+		ExcludeCollectorTypes: building
 	GrantExternalConditionCrateAction@armor:
 		SelectionShares: 5
 		Effect: armor
 		Condition: crate-damage
 		Notification: UnitArmourUpgraded
+		ExcludeCollectorTypes: building
 	GrantExternalConditionCrateAction@speed:
 		SelectionShares: 5
 		Condition: crate-speed
 		Notification: UnitSpeedUpgraded
+		ExcludeCollectorTypes: building
 	MapEditorData:
 		Categories: System
 

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -14,7 +14,6 @@
 		FogPalette: shroud
 	Locomotor@FOOT:
 		Name: foot
-		Crushes: crate
 		SharesCell: true
 		TerrainSpeeds:
 			Clear: 90
@@ -41,7 +40,6 @@
 			Veins: 50
 	JumpjetLocomotor@JUMPJET:
 		Name: jumpjet
-		Crushes: crate
 		SharesCell: true
 		JumpjetTransitionCost: 100
 		TerrainSpeeds:
@@ -57,7 +55,6 @@
 			Jumpjet: 110
 	Locomotor@WHEELED:
 		Name: wheeled
-		Crushes: crate
 		TerrainSpeeds:
 			Clear: 70
 			Road: 100
@@ -71,7 +68,7 @@
 				PathingCost: 90
 	Locomotor@HEAVYWHEELED:
 		Name: heavywheeled
-		Crushes: wall, crate, infantry
+		Crushes: wall, infantry
 		TerrainSpeeds:
 			Clear: 70
 			Road: 100
@@ -85,7 +82,7 @@
 				PathingCost: 90
 	Locomotor@TRACKED:
 		Name: tracked
-		Crushes: wall, crate, infantry
+		Crushes: wall, infantry
 		TerrainSpeeds:
 			Clear: 70
 			Road: 100
@@ -98,7 +95,7 @@
 			Veins: 70
 	Locomotor@AMPHIBIOUS:
 		Name: amphibious
-		Crushes: wall, crate, infantry
+		Crushes: wall, infantry
 		TerrainSpeeds:
 			Clear: 70
 			Road: 100
@@ -112,7 +109,7 @@
 			Water: 80
 	SubterraneanLocomotor@SUBTERRANEAN:
 		Name: subterranean
-		Crushes: wall, crate, infantry
+		Crushes: wall, infantry
 		TerrainSpeeds:
 			Clear: 70
 			Road: 100
@@ -128,7 +125,7 @@
 		SubterraneanTransitionCost: 120
 	Locomotor@HOVER:
 		Name: hover
-		Crushes: wall, crate, infantry
+		Crushes: wall, infantry
 		TerrainSpeeds:
 			Clear: 100
 			Road: 100
@@ -155,7 +152,7 @@
 			Veins: 100
 	Locomotor@VISCEROID:
 		Name: visceroid
-		Crushes: crate, infantry
+		Crushes: infantry
 		TerrainSpeeds:
 			Clear: 90
 			Road: 100
@@ -182,7 +179,7 @@
 		Name: train
 		TerrainSpeeds:
 			Rail: 100
-		Crushes: wall, crate, infantry
+		Crushes: wall, infantry
 	Faction@Random:
 		Name: Any
 		InternalName: Random


### PR DESCRIPTION
- Allows crates to be collected by non-mobile actors (aircraft, buildings etc.)
- Allows crates to be hidden behind buildings, like in the original games (by not giving or removing `CrateCollector` to/from building in question)
- Allows paratroops being dropped on cells occupied by crates
- Allows mobile actors to enter cells that a crate is currently being paradropped on

For testing, I suggest adding `CrateCollector` to helicopter default in RA, then ingame enable insta-build cheat and test a) placing a building under a dropping crate, b) place a building on a dropped crate, and c) let a transport heli land on a crate. All of these should work.

Fixes #9555.
Closes #14920.