### PR TITLE
Artillery Balance Part 1

### DIFF
--- a/vehicles.yaml
+++ b/vehicles.yaml
@@ -1,18 +1,10 @@
 ARTY:
-	-Mobile:
-		-TurnSpeed:
-		-Speed:
 	Mobile:
 		TurnSpeed: 2
 		Speed: 60
-	-RevealsShroud:
 	RevealShroud:
-		-Range: 8c0
 		Range: 8c0
-	-RevealsShroud@GAPGEN:
 	RevealsShroud@GAPGEN:
-		-Range:
 		Range: 4
-	-Passenger:
 	Passenger:
 		Weight: 4

--- a/vehicles.yaml
+++ b/vehicles.yaml
@@ -1,18 +1,18 @@
 ARTY:
-	-Mobile:
-		-TurnSpeed:
-		-Speed:
+	- Mobile:
+		- TurnSpeed:
+		- Speed:
 	Mobile:
 		TurnSpeed: 2
 		Speed: 60
-	-RevealsShroud:
+	- RevealsShroud:
 	RevealShroud:
-		-Range: 8c0
+		- Range: 8c0
 		Range: 8c0
-	-RevealsShroud@GAPGEN:
+	- RevealsShroud@GAPGEN:
 	RevealsShroud@GAPGEN:
-		-Range:
+		- Range:
 		Range: 4
-	-Passenger:
+	- Passenger:
 	Passenger:
 		Weight: 4

--- a/vehicles.yaml
+++ b/vehicles.yaml
@@ -1,0 +1,11 @@
+ARTY:
+	Mobile:
+		TurnSpeed: 2
+		Speed: 60
+	RevealsShroud:
+		Range: 8c0
+		RevealGeneratedShroud: False
+	RevealsShroud@GAPGEN:
+		Range: 4c0
+	Passenger:
+		Weight: 4

--- a/vehicles.yaml
+++ b/vehicles.yaml
@@ -1,11 +1,18 @@
 ARTY:
+	-Mobile:
+		-TurnSpeed:
+		-Speed:
 	Mobile:
 		TurnSpeed: 2
 		Speed: 60
-	RevealsShroud:
+	-RevealsShroud:
+	RevealShroud:
+		-Range: 8c0
 		Range: 8c0
-		RevealGeneratedShroud: False
+	-RevealsShroud@GAPGEN:
 	RevealsShroud@GAPGEN:
-		Range: 4c0
+		-Range:
+		Range: 4
+	-Passenger:
 	Passenger:
 		Weight: 4

--- a/vehicles.yaml
+++ b/vehicles.yaml
@@ -1,18 +1,18 @@
 ARTY:
-	- Mobile:
-		- TurnSpeed:
-		- Speed:
+	-Mobile:
+		-TurnSpeed:
+		-Speed:
 	Mobile:
 		TurnSpeed: 2
 		Speed: 60
-	- RevealsShroud:
+	-RevealsShroud:
 	RevealShroud:
-		- Range: 8c0
+		-Range: 8c0
 		Range: 8c0
-	- RevealsShroud@GAPGEN:
+	-RevealsShroud@GAPGEN:
 	RevealsShroud@GAPGEN:
-		- Range:
+		-Range:
 		Range: 4
-	- Passenger:
+	-Passenger:
 	Passenger:
 		Weight: 4


### PR DESCRIPTION
Balancing artillery
I'd like to get the stuff I've already tested out of the way. The current balance team is essentially doing everything I already did in terms of making balance changes and testing them.

A lot of time is being wasted doing what I've already done. I've tested my changes in hundreds of matches with great feedback. The only negative opinions I get are from trolls or people who need an excuse for why they suck at the game.

So, first up, ARTILLERY.

These values allow the artillery to remain effective, but not overpowered. Instead of 3 arty destroying a huge infantry blob, you'll 4-6 of them.
Damage vs vehicles has been buffed slightly to compensate for lack of infantry killing.
A direct hit will kill the infantry, but if it lands off to the side, it can take anywhere from 1-4 shots. With a small group of artillery firing, the aoe will make it a lot more effective.

Cost also went up, and it's speed has been slowed down. I think I buffed it vs buildings too, maybe not.

Now, the artillery infantry tradeoff is fair, and for what it lacks in anti infantry, it makes up for by doing roughly 10-20% more dmg to everything else.

vehicles.yaml:

ARTY:
Mobile:
TurnSpeed: 2 (used to be 4 I think)
Speed: 60 (I think -10 points?)
RevealsShroud:
Range: 8c0 (remains same, i think, mightve increased by 1-2 cells)
RevealGeneratedShroud: False
RevealsShroud@GAPGEN:
Range: 4c0
Passenger:
Weight: 4

----------


ballistics.yaml:

^Artillery:
Range: 12c0 (it shouldnt outshoot a v2 by 4 cells, or at all, really)
Projectile: Bullet
Speed: 200 (little bit slower to help nerf vs infantry.
Blockable: false
LaunchAngle: 110
Inaccuracy: 1c256
Warhead@1Dam: SpreadDamage
Spread: 420
Versus:
None: 40
Light: 60
Heavy: 35
Concrete: 50

155mm:
MinRange: 4c0 (minimum range back to 4 cells instead of 5)