### PR TITLE
Artillery Balance

### DIFF
--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -12,7 +12,7 @@ V2RL:
 	Tooltip:
 		Name: V2 Rocket Launcher
 	Health:
-		HP: 20000
+		HP: 18000
 	Armor:
 		Type: Light
 	Mobile:
@@ -256,7 +256,7 @@ ARTY:
 		Prerequisites: dome, ~vehicles.allies, ~techlevel.medium
 		Description: Long-range artillery.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles, Aircraft
 	Valued:
-		Cost: 850
+		Cost: 900
 	Tooltip:
 		Name: Artillery
 	Health:
@@ -265,10 +265,10 @@ ARTY:
 		Type: Light
 	Mobile:
 		TurnSpeed: 2
-		Speed: 85
+		Speed: 80
 		Locomotor: lighttracked
 	RevealsShroud:
-		Range: 5c0
+		Range: 8c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 4c0


### PR DESCRIPTION
These values allow the artillery to remain effective, but not overpowered. Instead of 3 arty destroying a huge infantry blob, you'll 4-6 of them.
Damage vs vehicles has been buffed slightly to compensate for lack of infantry killing.
A direct hit will kill the infantry, but if it lands off to the side, it can take anywhere from 1-4 shots. With a small group of artillery firing, the aoe will make it a lot more effective.

Cost also went up, and it's speed has been slowed down. I think I buffed it vs buildings too, maybe not.

Now, the artillery infantry tradeoff is fair, and for what it lacks in anti infantry, it makes up for by doing roughly 10-20% more dmg to everything else.

vehicles.yaml:

ARTY:
Mobile:
TurnSpeed: 2 (used to be 4 I think)
Speed: 60 (I think -10 points?)
RevealsShroud:
Range: 8c0 (remains same, i think, mightve increased by 1-2 cells)
RevealGeneratedShroud: False
RevealsShroud@GAPGEN:
Range: 4c0
Passenger:
Weight: 4

ballistics.yaml:

^Artillery:
Range: 12c0 (it shouldnt outshoot a v2 by 4 cells, or at all, really)
Projectile: Bullet
Speed: 200 (little bit slower to help nerf vs infantry.
Blockable: false
LaunchAngle: 110
Inaccuracy: 1c256
Warhead@1Dam: SpreadDamage
Spread: 420
Versus:
None: 40
Light: 60
Heavy: 35
Concrete: 50

155mm:
MinRange: 4c0 (minimum range back to 4 cells instead of 5)