### PR TITLE
Fix exception in DefaultSpriteSequence.GetSprite.

### DIFF
--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -366,7 +366,7 @@ namespace OpenRA.Mods.Common.Graphics
 			var j = Frames != null ? Frames[i] : start + i;
 			if (sprites[j] == null)
 				throw new InvalidOperationException("Attempted to query unloaded sprite from {0}.{1}".F(Name, sequence) +
-					" start={2} frame={3} facing={4}".F(start, frame, facing));
+					" start={0} frame={1} facing={2}".F(start, frame, facing));
 
 			return sprites[j];
 		}


### PR DESCRIPTION
The real exception is hidden by the exception thrown due to wrong format parameters.