### PR TITLE
Fix NRE in Guard when the target actor is dead.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Guard.cs
+++ b/OpenRA.Mods.Common/Traits/Guard.cs
@@ -41,13 +41,16 @@ namespace OpenRA.Mods.Common.Traits
 		public void ResolveOrder(Actor self, Order order)
 		{
 			if (order.OrderString == "Guard")
-				GuardTarget(self, Target.FromActor(order.TargetActor), order.Queued);
+				GuardTarget(self, order.Target, order.Queued);
 		}
 
 		public void GuardTarget(Actor self, Target target, bool queued = false)
 		{
 			if (!queued)
 				self.CancelActivity();
+
+			if (target.Type != TargetType.Actor)
+				return;
 
 			self.SetTargetLine(target, Color.Yellow);
 


### PR DESCRIPTION
Fixes #15081.  As of release-20171014 `order.TargetActor` (which is deprecated in favour of `order.Target`) will return null instead of a reference to a dead actor.