### PR TITLE
Improve MiniYaml support for comments and whitespace.

### DIFF
--- a/OpenRA.Game/ExternalMods.cs
+++ b/OpenRA.Game/ExternalMods.cs
@@ -128,7 +128,7 @@ namespace OpenRA
 				try
 				{
 					Directory.CreateDirectory(metadataPath);
-					File.WriteAllLines(Path.Combine(metadataPath, key + ".yaml"), yaml.ToLines(false).ToArray());
+					File.WriteAllLines(Path.Combine(metadataPath, key + ".yaml"), yaml.ToLines().ToArray());
 				}
 				catch (Exception e)
 				{

--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -375,6 +375,10 @@ namespace OpenRA
 				var key = keySelector(item);
 				var element = elementSelector(item);
 
+				// Discard elements with null keys
+				if (!typeof(TKey).IsValueType && key == null)
+					continue;
+
 				// Check for a key conflict:
 				if (d.ContainsKey(key))
 				{

--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -202,7 +202,8 @@ namespace OpenRA
 
 		public TileSet(IReadOnlyFileSystem fileSystem, string filepath)
 		{
-			var yaml = MiniYaml.DictFromStream(fileSystem.Open(filepath), filepath);
+			var yaml = MiniYaml.FromStream(fileSystem.Open(filepath), filepath)
+				.ToDictionary(x => x.Key, x => x.Value);
 
 			// General info
 			FieldLoader.Load(this, yaml["General"]);

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -232,18 +232,19 @@ namespace OpenRA
 
 				if (File.Exists(settingsFile))
 				{
-					yamlCache = MiniYaml.FromFile(settingsFile);
+					yamlCache = MiniYaml.FromFile(settingsFile, false);
 					foreach (var yamlSection in yamlCache)
 					{
 						object settingsSection;
-						if (Sections.TryGetValue(yamlSection.Key, out settingsSection))
+						if (yamlSection.Key != null && Sections.TryGetValue(yamlSection.Key, out settingsSection))
 							LoadSectionYaml(yamlSection.Value, settingsSection);
 					}
 
 					var keysNode = yamlCache.FirstOrDefault(n => n.Key == "Keys");
 					if (keysNode != null)
 						foreach (var node in keysNode.Value.Nodes)
-							Keys[node.Key] = FieldLoader.GetValue<Hotkey>(node.Key, node.Value.Value);
+							if (node.Key != null)
+								Keys[node.Key] = FieldLoader.GetValue<Hotkey>(node.Key, node.Value.Value);
 				}
 
 				// Override with commandline args

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractLanguageStringsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractLanguageStringsCommand.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			foreach (var filename in modData.Manifest.ChromeLayout)
 			{
 				Console.WriteLine("# {0}:", filename);
-				var yaml = MiniYaml.FromFile(filename);
+				var yaml = MiniYaml.FromFile(filename, false);
 				FromChromeLayout(ref yaml, null,
 					translatableFields.Select(t => t.Name).Distinct(), null);
 				using (var file = new StreamWriter(filename))

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractMapRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractMapRules.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				{
 					include |= map.Package.Contains(f);
 					if (include)
-						nodes.AddRange(MiniYaml.FromStream(map.Open(f), f));
+						nodes.AddRange(MiniYaml.FromStream(map.Open(f), f, false));
 					else
 						includes.Add(f);
 				}

--- a/OpenRA.Mods.Common/UtilityCommands/UpdateModCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpdateModCommand.cs
@@ -62,8 +62,6 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				if (!args.Contains("--yes"))
 				{
 					Console.WriteLine("WARNING: This command will automatically rewrite your mod rules.");
-					Console.WriteLine("Side effects of this command may include changing the whitespace to ");
-					Console.WriteLine("match the default conventions, and any yaml comments will be removed.");
 					Console.WriteLine();
 					Console.WriteLine("We strongly recommend that you have a backup of your mod rules, and ");
 					Console.WriteLine("for best results, to use a Git client to review the line-by-line ");

--- a/mods/cnc/cursors.yaml
+++ b/mods/cnc/cursors.yaml
@@ -111,7 +111,7 @@ Cursors:
 			Start: 136
 		joystick-tl-blocked:
 			Start: 137
-# Cursors that need minimap variants
+		# Cursors that need minimap variants
 		deploy:
 			Start: 53
 			Length: 9

--- a/mods/d2k/cursors.yaml
+++ b/mods/d2k/cursors.yaml
@@ -233,7 +233,7 @@ Cursors:
 			Start: 236
 			X: 24
 			Y: 24
-# Cursors that need minimap variants
+		# Cursors that need minimap variants
 		deploy:
 			Start: 96
 			Length: 8

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -135,7 +135,7 @@ fremen:
 	Mobile:
 		Speed: 43
 	Valued:
-		Cost: 200	## actually 0, but spawns from support power at Palace
+		Cost: 200 ## actually 0, but spawns from support power at Palace
 	Health:
 		HP: 7000
 	RevealsShroud:
@@ -171,7 +171,7 @@ grenadier:
 		Queue: Infantry
 		BuildPaletteOrder: 60
 		Prerequisites: ~barracks.atreides, upgrade.barracks, high_tech_factory, ~techlevel.medium
-		BuildDuration: 81	## Wasn't converted, copied from Sardauker who has same value in TibEd.
+		BuildDuration: 81 ## Wasn't converted, copied from Sardauker who has same value in TibEd.
 		BuildDurationModifier: 40
 		Description: Infantry armed with grenades. \n  Strong vs Buildings, Infantry\n  Weak vs Vehicles
 	Valued:
@@ -254,7 +254,7 @@ saboteur:
 		Prerequisites: ~disabled
 		Description: Sneaky infantry, armed with explosives\n  Strong vs Buildings\n  Weak vs Everything\n  Special Ability: destroy buildings
 	Valued:
-		Cost: 300	## actually 0, but spawns from support power at Palace
+		Cost: 300 ## actually 0, but spawns from support power at Palace
 	Tooltip:
 		Name: Saboteur
 	Health:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -421,7 +421,7 @@ stealth_raider:
 	Buildable:
 		Prerequisites: ~light.ordos, upgrade.light, high_tech_factory, ~techlevel.medium
 		BuildPaletteOrder: 30
-		BuildDuration: 194	## Copied from Raider, not included in conversion. Both have same "BuildSpeed" in TibEd
+		BuildDuration: 194 ## Copied from Raider, not included in conversion. Both have same "BuildSpeed" in TibEd
 		BuildDurationModifier: 40
 		Description: Invisible Raider Trike\n  Strong vs Infantry, Light Vehicles\n  Weak vs Tanks
 	Valued:

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -106,7 +106,7 @@ Atomic:
 	Warhead@1Dam: SpreadDamage
 		Spread: 1c0
 		Falloff: 200, 100, 50, 25, 12, 0
-		Damage: 27000	##225 in vanilla but of course is a cluster bomb instead, so damage spread out
+		Damage: 27000 ##225 in vanilla but of course is a cluster bomb instead, so damage spread out
 		Versus:
 			none: 90
 			wall: 50

--- a/mods/ra/cursors.yaml
+++ b/mods/ra/cursors.yaml
@@ -166,7 +166,7 @@ Cursors:
 			Start: 130
 		joystick-tl-blocked:
 			Start: 131
-# Cursors that need minimap variants
+		# Cursors that need minimap variants
 		deploy:
 			Start: 59
 			Length: 9

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -75,7 +75,7 @@ E1:
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
 		RequiresCondition: !parachute
-	WithInfantryBody@PARACHUTE
+	WithInfantryBody@PARACHUTE:
 		StandSequences: parachute
 		RequiresCondition: parachute
 	ProducibleWithLevel:
@@ -121,7 +121,7 @@ E2:
 	WithInfantryBody:
 		DefaultAttackSequence: throw
 		RequiresCondition: !parachute
-	WithInfantryBody@PARACHUTE
+	WithInfantryBody@PARACHUTE:
 		StandSequences: parachute
 		RequiresCondition: parachute
 	Explodes:
@@ -163,7 +163,7 @@ E3:
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
 		RequiresCondition: !parachute
-	WithInfantryBody@PARACHUTE
+	WithInfantryBody@PARACHUTE:
 		StandSequences: parachute
 		RequiresCondition: parachute
 	ProducibleWithLevel:
@@ -212,7 +212,7 @@ E4:
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
 		RequiresCondition: !parachute
-	WithInfantryBody@PARACHUTE
+	WithInfantryBody@PARACHUTE:
 		StandSequences: parachute
 		RequiresCondition: parachute
 	ProducibleWithLevel:
@@ -232,7 +232,7 @@ E6:
 		Name: Engineer
 	WithInfantryBody:
 		RequiresCondition: !parachute
-	WithInfantryBody@PARACHUTE
+	WithInfantryBody@PARACHUTE:
 		StandSequences: parachute
 		RequiresCondition: parachute
 	Passenger:
@@ -596,7 +596,7 @@ SHOK:
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
 		RequiresCondition: !parachute
-	WithInfantryBody@PARACHUTE
+	WithInfantryBody@PARACHUTE:
 		StandSequences: parachute
 		RequiresCondition: parachute
 	Voiced:

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -101,10 +101,10 @@ pips:
 		Offset: 9, 5
 	medic:
 		Start: 20
-#	ready:
-#		Start: 3
-#	hold:
-#		Start: 4
+	#ready:
+	#	Start: 3
+	#hold:
+	#	Start: 4
 	tag-fake:
 		Start: 18
 		Offset: 0, 2

--- a/mods/ts/audio/voices.yaml
+++ b/mods/ts/audio/voices.yaml
@@ -3,7 +3,7 @@ Infantry:
 		Select: 15-i000, 15-i004, 15-i012, 15-i048
 		Move: 15-i018, 15-i024, 15-i044
 		Attack: 15-i044, 15-i050, 15-i044, 15-i046
-#		Feedback: 15-i058, 15-i064 # TODO
+		#Feedback: 15-i058, 15-i064 # TODO
 		Die: dedman1, dedman3, dedman4, dedman5, dedman6
 		Burned: dedman2
 		Zapped: electro1
@@ -14,7 +14,7 @@ Rocket:
 		Select: 15-i000, 15-i032, 15-i048
 		Move: 15-i008, 15-i014, 15-i026
 		Attack: 15-i008, 15-i014, 15-i026, 15-i050, 15-i060
-#		Feedback: 15-i058, 15-i064 #TODO
+		#Feedback: 15-i058, 15-i064 #TODO
 		Die: dedman1, dedman3, dedman4, dedman5, dedman6
 		Burned: dedman2
 		Zapped: electro1
@@ -65,7 +65,7 @@ JumpJet:
 		Select: 15-i000, 15-i004, 15-i012, 15-i048
 		Move: 15-i018, 15-i024, 15-i044
 		Attack: 15-i044, 15-i050, 15-i044, 15-i046
-#		Feedback: 15-i058, 15-i064
+		#Feedback: 15-i058, 15-i064
 		Die: dedman1, dedman3, dedman4, dedman5, dedman6
 		Burned: dedman2
 		Zapped: electro1
@@ -76,7 +76,7 @@ Weed:
 		Select: 15-i000, 15-i006, 15-i040, 15-i042
 		Move: 15-i024, 15-i044
 		Attack: 15-i006, 15-i046
-#		Feedback: 15-i058, 15-i064 # TODO
+		#Feedback: 15-i058, 15-i064 # TODO
 		Die: dedman1, dedman3, dedman4, dedman5, dedman6
 		Burned: dedman2
 		Zapped: electro1
@@ -87,7 +87,7 @@ Spy:
 		Select: 21-i000, 21-i002, 21-i004
 		Move: 21-i010, 21-i012, 21-i016
 		Action: 21-i010, 21-i012, 21-i022
-#		Feedback: 21-i000, 21-i002 # TODO
+		#Feedback: 21-i000, 21-i002 # TODO
 		Die: dedman1, dedman3, dedman4, dedman5, dedman6
 		Burned: dedman2
 		Zapped: electro1

--- a/mods/ts/maps/sunstroke/map.yaml
+++ b/mods/ts/maps/sunstroke/map.yaml
@@ -114,16 +114,16 @@ Actors:
 		Owner: Neutral
 		Health: 38
 		Facing: 160
-#	Actor13: cabhut
-#		Location: 138,-12
-#		Owner: Neutral
-#		Health: 100
-#		Facing: 160
-#	Actor14: cabhut
-#		Location: 63,-16
-#		Owner: Neutral
-#		Health: 100
-#		Facing: 160
+	#Actor13: cabhut
+	#	Location: 138,-12
+	#	Owner: Neutral
+	#	Health: 100
+	#	Facing: 160
+	#Actor14: cabhut
+	#	Location: 63,-16
+	#	Owner: Neutral
+	#	Health: 100
+	#	Facing: 160
 	Actor15: ca0011
 		Location: 110,26
 		Owner: Neutral

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -11,7 +11,7 @@ Packages:
 	$ts: ts
 	./mods/common: common
 
-# Tiberian Sun
+	# Tiberian Sun
 	~scores.mix
 	~sidenc01.mix
 	~sidenc02.mix
@@ -35,7 +35,7 @@ Packages:
 	~speech02.mix: speech-nod
 	~tem.mix
 	~temperat.mix
-# Firestorm
+	# Firestorm
 	~scores01.mix
 	~expand01.mix
 	~sounds01.mix

--- a/mods/ts/rules/civilian-structures.yaml
+++ b/mods/ts/rules/civilian-structures.yaml
@@ -1398,7 +1398,7 @@ GALITE:
 		MaxHeightDelta: 3
 	Power:
 		Amount: 0
-# TODO: should use terrain lighting instead, depends on https://github.com/OpenRA/OpenRA/issues/3605
+	# TODO: should use terrain lighting instead, depends on https://github.com/OpenRA/OpenRA/issues/3605
 	WithIdleOverlay@LIGHTING:
 		Sequence: lighting
 		Palette: alpha

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -116,7 +116,7 @@ pips:
 		Tick: 300
 		Offset: 0, -6
 
-# TODO:
+	# TODO:
 	pip-empty-building:
 	pip-green-building:
 		Start: 1


### PR DESCRIPTION
The bulk of this PR is described by the second commit message:

> Extend MiniYaml parser with new features:
> - Add support for escaping '#' inside values
> - Add support for escaping leading and trailing whitespace
> 
> And when discardCommentsAndWhitespace is set to false:
> - Add proper support for comments
> - Persist empty lines
> 
> Whitespace and comment support requires an explicit opt-in because
> they produce MiniYamlNodes with null keys.  Supporting these through
> the entire game engine would require changing all yaml enumerations
> to explicitly check and account for these keys with no benefit.
> 
> Comments and whitespace are now treated as real nodes during parsing,
> which means that the yaml parser will throw errors if they have
> incorrect indentation, even if these nodes will be discarded.

Fixes #2407.  Fixes the mod updater removing comments and inserting/removing arbitrary newlines.

The comment indentation change requires special attention: modders will need to manually check and fix this *before* running the mod updater.  This will need to be documented in the mod SDK upgrade instructions alongside other mod.yaml syntax changes.