### PR TITLE
Considerably raise Locomotor WaitAverage and WaitSpread

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -50,9 +50,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Locomotor ID.")]
 		public readonly string Name = "default";
 
-		public readonly int WaitAverage = 5;
+		public readonly int WaitAverage = 40;
 
-		public readonly int WaitSpread = 2;
+		public readonly int WaitSpread = 10;
 
 		[Desc("Allow multiple (infantry) units in one cell.")]
 		public readonly bool SharesCell = false;


### PR DESCRIPTION
This considerably reduces frequency of repathing attempts when blocked by other moving actors, without too much of an impact on in-game repathing speed, since most of the time the blocking actor doesn't move out of the way that fast anyway. In other words, this should reduce the percentage and number of *failed* re-attempts to enter a cell on the path quite a bit.

On my system, this cuts the number of Move entries in perf.log by more than half on RA shellmap.
According to additional manual testing, the average path ticks for a larger moving group - *after* the initial spike right after the order was given - are notably lower, which makes sense, since actors in large, moving groups happen to be blocked by actors moving in front of them quite often.

No update rule, because I expect any modder who already uses custom values to either a) already use similarly large values, or b) at least read the changelog of each release/playtest.