### PR TITLE
TS - Fix Laser Turret disabled in low power and power-down speech notification

### DIFF
--- a/mods/ts/audio/speech-generic.yaml
+++ b/mods/ts/audio/speech-generic.yaml
@@ -25,8 +25,8 @@ Speech:
 		ConstructionComplete: 00-i018
 		CriticalStructureLost: 00-i196
 		CriticalUnitLost: 00-i194
-		DisablePower: 00-i232
-		EnablePower: 00-i230
+		DisablePower: 00-i230
+		EnablePower: 00-i232
 		EmPulseCannonReady: 00-i158
 		EstablishingBattleControlStandBy: 01-n006
 		FireStormDefenseOffline: 00-i170

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -164,7 +164,7 @@ NALASR:
 		InitialFacing: 224
 		Offset: 298,-171,288
 	AttackTurreted:
-		PauseOnCondition: empdisable
+		PauseOnCondition: empdisable || disabled
 	Armament:
 		Weapon: TurretLaserFire
 		LocalOffset: 498,0,317


### PR DESCRIPTION
Fixes #15134

Also, the speech notifications for powering-down structures were mixed up.