### PR TITLE
Improved SplitTurretAimAnimation update rule

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithTurretAimAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurretAimAnimation.cs
@@ -29,15 +29,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[SequenceReference(null, true)] public readonly string ReloadPrefix = null;
 
 		public override object Create(ActorInitializer init) { return new WithTurretAimAnimation(init, this); }
-
-		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
-		{
-			var turretAttackAnim = ai.TraitInfos<WithTurretAttackAnimationInfo>().Any(t => t.Turret == Turret);
-			if (turretAttackAnim)
-				throw new YamlException("WithTurretAimAnimation is currently not compatible with WithTurretAttackAnimation. Don't use them on the same turret.");
-
-			base.RulesetLoaded(rules, ai);
-		}
 	}
 
 	public class WithTurretAimAnimation : ConditionalTrait<WithTurretAimAnimationInfo>, ITick


### PR DESCRIPTION
- Now lists each updated location after update
- Now properly handles the unlikely-but-possible case of "only ReloadPrefix, no Sequences"
- Dropped load-time exception when an actor has both `WithTurretAimAnimation` and `WithTurretAttackAnimation`. While they don't mesh very well, forcing modders to not use them together when it's rather a design issue/bug than something really intentional is a bit harsh. Also, I'm working on a fix already.

Split from #15140.