### PR TITLE
Fix all animation traits that would crash when more than one SpriteBody is present

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackPopupTurreted.cs
@@ -21,21 +21,24 @@ namespace OpenRA.Mods.Cnc.Traits
 	class AttackPopupTurretedInfo : AttackTurretedInfo, Requires<BuildingInfo>, Requires<WithEmbeddedTurretSpriteBodyInfo>
 	{
 		[Desc("How many game ticks should pass before closing the actor's turret.")]
-		public int CloseDelay = 125;
+		public readonly int CloseDelay = 125;
 
-		public int DefaultFacing = 0;
+		public readonly int DefaultFacing = 0;
 
 		[Desc("The percentage of damage that is received while this actor is closed.")]
-		public int ClosedDamageMultiplier = 50;
+		public readonly int ClosedDamageMultiplier = 50;
 
 		[Desc("Sequence to play when opening.")]
-		[SequenceReference] public string OpeningSequence = "opening";
+		[SequenceReference] public readonly string OpeningSequence = "opening";
 
 		[Desc("Sequence to play when closing.")]
-		[SequenceReference] public string ClosingSequence = "closing";
+		[SequenceReference] public readonly string ClosingSequence = "closing";
 
 		[Desc("Idle sequence to play when closed.")]
-		[SequenceReference] public string ClosedIdleSequence = "closed-idle";
+		[SequenceReference] public readonly string ClosedIdleSequence = "closed-idle";
+
+		[Desc("Which sprite body to play the animation on.")]
+		public readonly string Body = "body";
 
 		public override object Create(ActorInitializer init) { return new AttackPopupTurreted(init, this); }
 	}
@@ -57,7 +60,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			this.info = info;
 			turret = turrets.FirstOrDefault();
-			wsb = init.Self.Trait<WithSpriteBody>();
+			wsb = init.Self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == info.Body);
 			skippedMakeAnimation = init.Contains<SkipMakeAnimsInit>();
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/Render/WithDeliveryAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithDeliveryAnimation.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
@@ -22,6 +23,9 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 
 		[SequenceReference] public readonly string IdleSequence = "idle";
 
+		[Desc("Which sprite body to play the animation on.")]
+		public readonly string Body = "body";
+
 		public object Create(ActorInitializer init) { return new WithDeliveryAnimation(init.Self, this); }
 	}
 
@@ -32,7 +36,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 
 		public WithDeliveryAnimation(Actor self, WithDeliveryAnimationInfo info)
 		{
-			wsb = self.Trait<WithSpriteBody>();
+			wsb = self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == info.Body);
 
 			this.info = info;
 		}

--- a/OpenRA.Mods.Cnc/Traits/Render/WithLandingCraftAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithLandingCraftAnimation.cs
@@ -24,6 +24,9 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		[SequenceReference] public readonly string CloseSequence = "close";
 		[SequenceReference] public readonly string UnloadSequence = "unload";
 
+		[Desc("Which sprite body to play the animation on.")]
+		public readonly string Body = "body";
+
 		public object Create(ActorInitializer init) { return new WithLandingCraftAnimation(init, this); }
 	}
 
@@ -42,7 +45,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 			self = init.Self;
 			cargo = self.Trait<Cargo>();
 			move = self.Trait<IMove>();
-			wsb = init.Self.Trait<WithSpriteBody>();
+			wsb = init.Self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == info.Body);
 		}
 
 		public bool ShouldBeOpen()

--- a/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeAnimation.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Linq;
 using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
@@ -19,6 +20,9 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 	{
 		[Desc("Sequence to use for charge animation.")]
 		[SequenceReference] public readonly string ChargeSequence = "active";
+
+		[Desc("Which sprite body to play the animation on.")]
+		public readonly string Body = "body";
 
 		public object Create(ActorInitializer init) { return new WithTeslaChargeAnimation(init, this); }
 	}
@@ -31,7 +35,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		public WithTeslaChargeAnimation(ActorInitializer init, WithTeslaChargeAnimationInfo info)
 		{
 			this.info = info;
-			wsb = init.Self.Trait<WithSpriteBody>();
+			wsb = init.Self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == info.Body);
 		}
 
 		void INotifyTeslaCharging.Charging(Actor self, Target target)

--- a/OpenRA.Mods.Common/Lint/CheckSpriteBodies.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSpriteBodies.cs
@@ -1,0 +1,32 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using OpenRA.Mods.Common.Traits.Render;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Lint
+{
+	class CheckSpriteBodies : ILintRulesPass
+	{
+		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
+		{
+			foreach (var actorInfo in rules.Actors)
+			{
+				var wsbs = actorInfo.Value.TraitInfos<WithSpriteBodyInfo>();
+				foreach (var wsb in wsbs)
+					if (wsbs.Any(w => w != wsb && w.Name == wsb.Name))
+						emitError("Actor type `{0}` has more than one *SpriteBody with Name: {1}!".F(actorInfo.Key, wsb.Name));
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Lint\CheckChromeHotkeys.cs" />
     <Compile Include="Lint\CheckConflictingMouseBounds.cs" />
     <Compile Include="Lint\CheckLocomotorReferences.cs" />
+    <Compile Include="Lint\CheckSpriteBodies.cs" />
     <Compile Include="Lint\LintBuildablePrerequisites.cs" />
     <Compile Include="Lint\LintExts.cs" />
     <Compile Include="LoadScreens\ModContentLoadScreen.cs" />

--- a/OpenRA.Mods.Common/Traits/Render/WithAcceptDeliveredCashAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAcceptDeliveredCashAnimation.cs
@@ -20,19 +20,22 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "active";
 
+		[Desc("Which sprite body to play the animation on.")]
+		public readonly string Body = "body";
+
 		public object Create(ActorInitializer init) { return new WithAcceptDeliveredCashAnimation(init.Self, this); }
 	}
 
 	public class WithAcceptDeliveredCashAnimation : INotifyCashTransfer, INotifyBuildComplete, INotifySold
 	{
 		readonly WithAcceptDeliveredCashAnimationInfo info;
-		readonly WithSpriteBody[] wsbs;
+		readonly WithSpriteBody wsb;
 		bool buildComplete;
 
 		public WithAcceptDeliveredCashAnimation(Actor self, WithAcceptDeliveredCashAnimationInfo info)
 		{
 			this.info = info;
-			wsbs = self.TraitsImplementing<WithSpriteBody>().ToArray();
+			wsb = self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == info.Body);
 		}
 
 		void INotifyBuildComplete.BuildingComplete(Actor self)
@@ -53,11 +56,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (!buildComplete || playing)
 				return;
 
-			foreach (var wsb in wsbs)
-			{
-				playing = true;
-				wsb.PlayCustomAnimation(self, info.Sequence, () => playing = false);
-			}
+			playing = true;
+			wsb.PlayCustomAnimation(self, info.Sequence, () => playing = false);
 		}
 
 		void INotifyCashTransfer.OnDeliveringCash(Actor self, Actor acceptor) { }

--- a/OpenRA.Mods.Common/Traits/Render/WithAttackAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAttackAnimation.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			armament = init.Self.TraitsImplementing<Armament>()
 				.Single(a => a.Info.Name == Info.Armament);
-			wsb = init.Self.TraitsImplementing<WithSpriteBody>().First(w => w.Info.Name == Info.Body);
+			wsb = init.Self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == Info.Body);
 		}
 
 		void PlayAttackAnimation(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
@@ -18,6 +19,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 	{
 		[Desc("Sequence name to use"), SequenceReference]
 		public readonly string Sequence = "build";
+
+		[Desc("Which sprite body to play the animation on.")]
+		public readonly string Body = "body";
 
 		public object Create(ActorInitializer init) { return new WithBuildingPlacedAnimation(init.Self, this); }
 	}
@@ -31,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public WithBuildingPlacedAnimation(Actor self, WithBuildingPlacedAnimationInfo info)
 		{
 			this.info = info;
-			wsb = self.Trait<WithSpriteBody>();
+			wsb = self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == info.Body);
 			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>();
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithChargeAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithChargeAnimation.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
@@ -19,6 +20,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[SequenceReference]
 		[Desc("Sequence to use for the charge levels.")]
 		public readonly string Sequence = "active";
+
+		[Desc("Which sprite body to play the animation on.")]
+		public readonly string Body = "body";
 
 		public object Create(ActorInitializer init) { return new WithChargeAnimation(init.Self, this); }
 	}
@@ -32,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public WithChargeAnimation(Actor self, WithChargeAnimationInfo info)
 		{
 			this.info = info;
-			wsb = self.Trait<WithSpriteBody>();
+			wsb = self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == info.Body);
 			attackCharges = self.Trait<AttackCharges>();
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Traits;
 
@@ -21,6 +22,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		[Desc("Displayed while harvesting.")]
 		[SequenceReference] public readonly string HarvestSequence = "harvest";
+
+		[Desc("Which sprite body to play the animation on.")]
+		public readonly string Body = "body";
 
 		public object Create(ActorInitializer init) { return new WithHarvestAnimation(init, this); }
 	}
@@ -38,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			Info = info;
 			harv = init.Self.Trait<Harvester>();
-			wsb = init.Self.Trait<WithSpriteBody>();
+			wsb = init.Self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == Info.Body);
 		}
 
 		protected virtual string NormalizeHarvesterSequence(Actor self, string baseSequence)

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleAnimation.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
@@ -20,6 +21,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly string[] Sequences = { "active" };
 
 		public readonly int Interval = 750;
+
+		[Desc("Which sprite body to play the animation on.")]
+		public readonly string Body = "body";
 
 		public override object Create(ActorInitializer init) { return new WithIdleAnimation(init.Self, this); }
 	}
@@ -33,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public WithIdleAnimation(Actor self, WithIdleAnimationInfo info)
 			: base(info)
 		{
-			wsb = self.Trait<WithSpriteBody>();
+			wsb = self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == Info.Body);
 			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>(); // always render instantly for units
 			ticks = info.Interval;
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithMoveAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMoveAnimation.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			: base(info)
 		{
 			movement = init.Self.Trait<IMove>();
-			wsb = init.Self.TraitsImplementing<WithSpriteBody>().First(w => w.Info.Name == Info.Body);
+			wsb = init.Self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == Info.Body);
 		}
 
 		void ITick.Tick(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/WithNukeLaunchAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithNukeLaunchAnimation.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
@@ -18,6 +19,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "active";
+
+		[Desc("Which sprite body to play the animation on.")]
+		public readonly string Body = "body";
 
 		public override object Create(ActorInitializer init) { return new WithNukeLaunchAnimation(init.Self, this); }
 	}
@@ -30,12 +34,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public WithNukeLaunchAnimation(Actor self, WithNukeLaunchAnimationInfo info)
 			: base(info)
 		{
-			spriteBody = self.TraitOrDefault<WithSpriteBody>();
+			spriteBody = self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == Info.Body);
 		}
 
 		void INotifyNuke.Launching(Actor self)
 		{
-			if (buildComplete && spriteBody != null && !IsTraitDisabled)
+			if (buildComplete && !IsTraitDisabled)
 				spriteBody.PlayCustomAnimation(self, Info.Sequence, () => spriteBody.CancelCustomAnimation(self));
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithRearmAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRearmAnimation.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
@@ -18,6 +19,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "active";
+
+		[Desc("Which sprite body to play the animation on.")]
+		public readonly string Body = "body";
 
 		public override object Create(ActorInitializer init) { return new WithRearmAnimation(init.Self, this); }
 	}
@@ -30,12 +34,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public WithRearmAnimation(Actor self, WithRearmAnimationInfo info)
 			: base(info)
 		{
-			spriteBody = self.TraitOrDefault<WithSpriteBody>();
+			spriteBody = self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == Info.Body);
 		}
 
 		void INotifyRearm.Rearming(Actor self, Actor target)
 		{
-			if (buildComplete && spriteBody != null && !IsTraitDisabled)
+			if (buildComplete && !IsTraitDisabled)
 				spriteBody.PlayCustomAnimation(self, Info.Sequence);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairAnimation.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
@@ -18,6 +19,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "active";
+
+		[Desc("Which sprite body to play the animation on.")]
+		public readonly string Body = "body";
 
 		public override object Create(ActorInitializer init) { return new WithRepairAnimation(init.Self, this); }
 	}
@@ -30,14 +34,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public WithRepairAnimation(Actor self, WithRepairAnimationInfo info)
 			: base(info)
 		{
-			spriteBody = self.TraitOrDefault<WithSpriteBody>();
+			spriteBody = self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == Info.Body);
 		}
 
 		void INotifyRepair.BeforeRepair(Actor self, Actor target) { }
 
 		void INotifyRepair.RepairTick(Actor self, Actor target)
 		{
-			if (buildComplete && spriteBody != null && !IsTraitDisabled)
+			if (buildComplete && !IsTraitDisabled)
 				spriteBody.PlayCustomAnimation(self, Info.Sequence);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithSiloAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSiloAnimation.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
@@ -22,6 +23,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Internal resource stages. Does not have to match number of sequence frames.")]
 		public readonly int Stages = 10;
 
+		[Desc("Which sprite body to play the animation on.")]
+		public readonly string Body = "body";
+
 		public object Create(ActorInitializer init) { return new WithSiloAnimation(init, this); }
 	}
 
@@ -34,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public WithSiloAnimation(ActorInitializer init, WithSiloAnimationInfo info)
 		{
 			this.info = info;
-			wsb = init.Self.Trait<WithSpriteBody>();
+			wsb = init.Self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == info.Body);
 			playerResources = init.Self.Owner.PlayerActor.Trait<PlayerResources>();
 		}
 

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -30,9 +30,11 @@ V2RL:
 	AttackFrontal:
 	WithFacingSpriteBody:
 		RequiresCondition: !reloading
+		Name: loaded
 	WithFacingSpriteBody@EMPTY:
 		RequiresCondition: reloading
 		Sequence: empty-idle
+		Name: reloading
 	SelectionDecorations:
 	Explodes:
 		Weapon: V2Explode

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -110,16 +110,20 @@ NAFNCE:
 		RequiresCondition: laserfence-direction-x && active-posts == 2
 		Type: laserfence
 		Sequence: enabled-x
+		Name: x-enabled
 	WithWallSpriteBody@YENABLED:
 		RequiresCondition: laserfence-direction-y && active-posts == 2
 		Type: laserfence
 		Sequence: enabled-y
+		Name: y-enabled
 	WithSpriteBody@XDISABLED:
 		RequiresCondition: laserfence-direction-x && active-posts < 2
 		Sequence: disabled-x
+		Name: x-disabled
 	WithSpriteBody@YDISABLED:
 		RequiresCondition: laserfence-direction-y && active-posts < 2
 		Sequence: disabled-y
+		Name: y-disabled
 	BlocksProjectiles:
 		RequiresCondition: active-posts == 2
 	DamageMultiplier: # Prevent all normal damage, but still allows direct kills from the post


### PR DESCRIPTION
The majority of `With*Animation` traits was not written with sprite body traits being conditional in mind and would crash if the actor has more than one `With*SpriteBody` trait.

This PR fixes that, by making these traits run on an assigned sprite body and simply ignore all other sprite bodies.
This indirectly now also allows having multiple of these animation traits on one actor (but still only one per sprite body).

Dependency for animation priority system.