### PR TITLE
TD Balance 20180520

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -416,6 +416,7 @@
 		SpeedModifier: 60
 		DamageModifiers:
 			Prone50Percent: 50
+			Prone80Percent: 80
 		DamageTriggers: TriggerProne
 		ProneOffset: 400,0,0
 	WithInfantryBody:
@@ -694,6 +695,7 @@
 	Sellable:
 		SellSounds: cashturn.aud
 	Capturable:
+		CaptureThreshold: 55
 	WithMakeAnimation:
 
 ^CivBuilding:
@@ -956,6 +958,11 @@
 		EmptyWeapon: UnitExplodeSmall
 	BodyOrientation:
 		UseClassicFacingFudge: True
+
+^LightHusk:
+	Inherits: ^Husk
+	Health:
+		HP: 2000
 
 ^HelicopterHusk:
 	Inherits: ^CommonHuskDefaults

--- a/mods/cnc/rules/husks.yaml
+++ b/mods/cnc/rules/husks.yaml
@@ -17,7 +17,7 @@ HARV.Husk:
 		Image: harv.destroyed
 
 APC.Husk:
-	Inherits: ^Husk
+	Inherits: ^LightHusk
 	Tooltip:
 		Name: APC (Destroyed)
 	TransformOnCapture:
@@ -44,7 +44,7 @@ ARTY.Husk:
 		Image: arty.destroyed
 
 BGGY.Husk:
-	Inherits: ^Husk
+	Inherits: ^LightHusk
 	Tooltip:
 		Name: Nod Buggy (Destroyed)
 	TransformOnCapture:
@@ -53,7 +53,7 @@ BGGY.Husk:
 		Image: bggy.destroyed
 
 BIKE.Husk:
-	Inherits: ^Husk
+	Inherits: ^LightHusk
 	Tooltip:
 		Name: Recon Bike (Destroyed)
 	TransformOnCapture:
@@ -62,7 +62,7 @@ BIKE.Husk:
 		Image: bike.destroyed
 
 JEEP.Husk:
-	Inherits: ^Husk
+	Inherits: ^LightHusk
 	Tooltip:
 		Name: Hum-Vee (Destroyed)
 	TransformOnCapture:

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -172,6 +172,8 @@ E6:
 	Captures:
 		CaptureTypes: building, husk
 		PlayerExperience: 50
+	Selectable:
+		Priority: 5
 
 RMBO:
 	Inherits: ^Soldier

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -2,7 +2,7 @@ FACT:
 	Inherits: ^BaseBuilding
 	Inherits@shape: ^3x2Shape
 	Valued:
-		Cost: 4000
+		Cost: 3500
 	Tooltip:
 		Name: Construction Yard
 	Building:
@@ -116,13 +116,14 @@ NUKE:
 		BuildPaletteOrder: 10
 		Prerequisites: fact
 		Queue: Building.GDI, Building.Nod
+		BuildDuration: 330
 		Description: Generates power
 	Building:
 		Footprint: xX xx ==
 		Dimensions: 2,3
 		LocalCenterOffset: 0,-512,0
 	Health:
-		HP: 50000
+		HP: 55000
 	RevealsShroud:
 		Range: 4c0
 	WithBuildingBib:
@@ -396,7 +397,7 @@ AFLD:
 		LimitedAudio: BuildingInProgress
 	ProductionBar:
 	Power:
-		Amount: -50
+		Amount: -40
 	ProvidesPrerequisite@buildingname:
 
 WEAP:
@@ -449,7 +450,7 @@ WEAP:
 		LimitedAudio: BuildingInProgress
 	ProductionBar:
 	Power:
-		Amount: -50
+		Amount: -40
 	ProvidesPrerequisite@buildingname:
 
 HPAD:
@@ -606,7 +607,7 @@ FIX:
 	RallyPoint:
 	WithRepairAnimation:
 	Power:
-		Amount: -30
+		Amount: -20
 	ProvidesPrerequisite@buildingname:
 
 EYE:

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -5,7 +5,7 @@ V19:
 		Footprint: x
 		Dimensions: 1,1
 	Health:
-		HP: 100000
+		HP: 80000
 	Tooltip:
 		Name: Oil Derrick
 	TooltipDescription@ally:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -1,7 +1,7 @@
 MCV:
 	Inherits: ^Vehicle
 	Valued:
-		Cost: 4000
+		Cost: 3500
 	Tooltip:
 		Name: Mobile Construction Vehicle
 	Buildable:
@@ -92,28 +92,28 @@ APC:
 	Inherits@CLOAK: ^AcceptsCloakCrate
 	Inherits@AUTOTARGET: ^AutoTargetAllAssaultMove
 	Valued:
-		Cost: 550
+		Cost: 600
 	Tooltip:
 		Name: APC
 	Buildable:
 		BuildPaletteOrder: 30
 		Prerequisites: pyle
 		Queue: Vehicle.GDI
-		BuildDuration: 900
+		BuildDuration: 938
 		BuildDurationModifier: 40
 		Description: Armed infantry transport.\nCan attack Aircraft.\n  Strong vs Vehicles\n  Weak vs Infantry
 	Mobile:
-		TurnSpeed: 8
+		TurnSpeed: 5
 		Speed: 132
 		RequiresCondition: !notmobile
 	Health:
-		HP: 21500
+		HP: 19000
 	Repairable:
 		HpPerStep: 1440
 	Armor:
 		Type: Heavy
 	RevealsShroud:
-		Range: 7c0
+		Range: 6c0
 	Turreted:
 		TurnSpeed: 10
 	Armament@PRIMARY:
@@ -488,7 +488,7 @@ MSAM:
 	Inherits@CLOAK: ^AcceptsCloakCrate
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Valued:
-		Cost: 1000
+		Cost: 900
 	Tooltip:
 		Name: Rocket Launcher
 	Buildable:

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -70,6 +70,7 @@ HeliAGGun:
 			Wood: 50
 			Light: 75
 			Heavy: 25
+		DamageTypes: Prone80Percent, TriggerProne, BulletDeath
 
 HeliAAGun:
 	Inherits: HeliAGGun
@@ -133,7 +134,7 @@ APCGun:
 	Range: 5c0
 	Report: gun20.aud
 	Projectile: Bullet
-		Speed: 1c682
+		Speed: 900
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 2000
@@ -149,7 +150,7 @@ APCGun:
 
 APCGun.AA:
 	Inherits: APCGun
-	Range: 7c0
+	Range: 6c0
 	ValidTargets: Air
 	Projectile: Bullet
 		Speed: 2c0


### PR DESCRIPTION
Apache damage vs infantry at prone increased from 50 percent to 80 percent.

  Apache damage was cut in half making them less effective versus infantry. Giving them an extra boost damage wise versus prone is enough then going with a universal damage boost.

MCV Price from 4000 to 3500.

  Some say they want 3000 but im still paranoid of the epidemics that have happened in the past with 1v1 and team games. Needs more team game tests if they want 3000.

Repair Pad decrease power from -30 to -20.

 Power consumption is a little high. Specifically if they want to build extras.

APC Price from 550 to 600.

APC HP from 21500 to 19000.

APC turn speed from 8 to 5.

APC build duration from 900 to 938.

APC AA range from 7 to 5.

APC reduce vision range from 7c0 to 6c0.

APC projectile speed reduced from 2c0 to 900.

  See notes below.

Power Plant buff HP from 50,000 to 55,000

  Makes power plant sniping a little tougher. But still effective to take out.

Change power structures (Airstrip/Factory and Refinery to 40 power)

  Important change. This allows more diverse builds to happen such as now able to build refinery > barracks > factory. This combo helps easy defends with quick vehicle herasses.

MRLS Price reduction from 1000 to 900.

  Allows an easier method to build on the field. A unit that is often times killed by airstrikes allows more forgiveness when on the field.

Light vehicle husks HP reduce to 2000. (reduce timer on field wreckage.)

  Prevents early on refinery blocks and other pathing unit issues.

Oil Derrick reduce HP from 100,000 to 80,000

  Oil Derricks were a little to strong. Easily can be killed now.

Change power plant build duration from 12 seconds to 8 seconds. (Low power build duration from 24 seconds to 16 seconds.) Note: Does not include Adv. Power plant

  Due to the struggle of low power this enables players to build regular power plants to help get back up quickly. This however, does not apply to Adv. power plants. The outcome is then scattered extra power plants rather then Adv. power due to the player being on low power.

Change engineer capture threshold from 50 to 55.

  Fixes the structures from being fixed and preventing the second engineer from getting canceled out or being wasted on damaging the structure again.

NOTES:

I have mentioned that I disagree on the above APC changes. The reasons I conclude may happen is buffing the bikes with a lack of counter. This may result in games where infantry are now used to help counter against buggy/bike play rather then an APC/infantry play or APC/hummer play. If and when players speak about bikes being OP please look back at the changes that happened in the past.