### PR TITLE
Fix multiplayer player connection notifications

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -402,10 +402,6 @@ namespace OpenRA.Server
 					SendOrderTo(newConn, "Message", TwoHumansRequiredText);
 				else if (Map.Players.Players.Where(p => p.Value.Playable).All(p => !p.Value.AllowBots))
 					SendOrderTo(newConn, "Message", "Bots have been disabled on this map.");
-
-				if (handshake.Mod == "{DEV_VERSION}")
-					SendMessage("{0} is running an unversioned development build, ".F(client.Name) +
-						"and may desynchronize the game state if they have incompatible rules.");
 			}
 			catch (Exception ex)
 			{

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -378,8 +378,8 @@ namespace OpenRA.Server
 				Log.Write("server", "{0} ({1}) has joined the game.",
 					client.Name, newConn.Socket.RemoteEndPoint);
 
-				if (LobbyInfo.NonBotClients.Count() > 1)
-					SendMessage("{0} has joined the game.".F(client.Name));
+				// Report to all other players
+				SendMessage("{0} has joined the game.".F(client.Name), newConn);
 
 				// Send initial ping
 				SendOrderTo(newConn, "Ping", Game.RunTime.ToString(CultureInfo.InvariantCulture));
@@ -470,9 +470,9 @@ namespace OpenRA.Server
 			DispatchOrdersToClient(conn, 0, 0, new ServerOrder(order, data).Serialize());
 		}
 
-		public void SendMessage(string text)
+		public void SendMessage(string text, Connection conn = null)
 		{
-			DispatchOrdersToClients(null, 0, new ServerOrder("Message", text).Serialize());
+			DispatchOrdersToClients(conn, 0, new ServerOrder("Message", text).Serialize());
 
 			if (Dedicated)
 				Console.WriteLine("[{0}] {1}".F(DateTime.Now.ToString(Settings.TimestampFormat), text));


### PR DESCRIPTION
New player notifications are now never reported to the joining player, and always reported in the dedicated server output.

This also removes the long broken DEV_VERSION warning.

Fixes #14750
Supersedes #14794