### PR TITLE
Shift temporary owner-change logic from D2k to Common.

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -315,6 +315,7 @@
     <Compile Include="Traits\Conditions\GrantExternalConditionToCrusher.cs" />
     <Compile Include="Traits\Conditions\GrantRandomCondition.cs" />
     <Compile Include="Traits\Contrail.cs" />
+    <Compile Include="Traits\TemporaryOwnerManager.cs" />
     <Compile Include="Traits\TooltipDescription.cs" />
     <Compile Include="Traits\Health.cs" />
     <Compile Include="Traits\HitShape.cs" />
@@ -593,6 +594,7 @@
     <Compile Include="UtilityCommands\ExtractZeroBraneStudioLuaAPI.cs" />
     <Compile Include="UtilityCommands\ExtractTraitDocsCommand.cs" />
     <Compile Include="UtilityCommands\ExtractWeaponDocsCommand.cs" />
+    <Compile Include="Warheads\ChangeOwnerWarhead.cs" />
     <Compile Include="Widgets\Logic\MusicHotkeyLogic.cs" />
     <Compile Include="WorldExtensions.cs" />
     <Compile Include="UtilityCommands\GetMapHashCommand.cs" />

--- a/OpenRA.Mods.Common/Traits/TemporaryOwnerManager.cs
+++ b/OpenRA.Mods.Common/Traits/TemporaryOwnerManager.cs
@@ -12,7 +12,7 @@
 using System.Drawing;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.D2k.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Interacts with the ChangeOwner warhead.",
 		"Displays a bar how long this actor is affected and reverts back to the old owner on temporary changes.")]

--- a/OpenRA.Mods.Common/Warheads/ChangeOwnerWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/ChangeOwnerWarhead.cs
@@ -10,13 +10,12 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.Mods.Common.Warheads;
-using OpenRA.Mods.D2k.Traits;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.D2k.Warheads
+namespace OpenRA.Mods.Common.Warheads
 {
-	[Desc("Interacts with the DynamicOwnerChange trait.")]
+	[Desc("Interacts with the TemporaryOwnerManager trait.")]
 	public class ChangeOwnerWarhead : Warhead
 	{
 		[Desc("Duration of the owner change (in ticks). Set to 0 to make it permanent.")]

--- a/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj
+++ b/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj
@@ -74,14 +74,12 @@
     <Compile Include="Traits\Render\WithDeliveryOverlay.cs" />
     <Compile Include="Traits\Sandworm.cs" />
     <Compile Include="Traits\SpiceBloom.cs" />
-    <Compile Include="Traits\TemporaryOwnerManager.cs" />
     <Compile Include="Traits\World\BuildableTerrainLayer.cs" />
     <Compile Include="Traits\World\D2kResourceLayer.cs" />
     <Compile Include="Traits\World\FogPaletteFromR8.cs" />
     <Compile Include="Traits\World\PaletteFromR8.cs" />
     <Compile Include="Traits\World\PaletteFromScaledPalette.cs" />
     <Compile Include="Traits\AttractsWorms.cs" />
-    <Compile Include="Warheads\ChangeOwnerWarhead.cs" />
     <Compile Include="UtilityCommands\D2kMapImporter.cs" />
     <Compile Include="UtilityCommands\ImportD2kMapCommand.cs" />
     <Compile Include="Traits\World\D2kEditorResourceLayer.cs" />


### PR DESCRIPTION
This seemed like quite the generic trait worthy to be shifted longterm already.