### PR TITLE
Implement new, explicit player stances for owners, allies and spectators.

### DIFF
--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -167,7 +167,7 @@ namespace OpenRA
 		public bool IsAlliedWith(Player p)
 		{
 			// Observers are considered allies to active combatants
-			return p == null || Stances[p] == Stance.Ally || (p.Spectating && !NonCombatant);
+			return p == null || (Stances[p] & Stance.Ally) != 0;
 		}
 
 		public Color PlayerStanceColor(Actor a)

--- a/OpenRA.Game/SelectableExts.cs
+++ b/OpenRA.Game/SelectableExts.cs
@@ -38,9 +38,10 @@ namespace OpenRA.Traits
 
 			switch (lp.Stances[a.Owner])
 			{
-				case Stance.Ally: return basePriority - PriorityRange;
-				case Stance.Neutral: return basePriority - 2 * PriorityRange;
-				case Stance.Enemy: return basePriority - 3 * PriorityRange;
+				case Stance.Owner: return basePriority - PriorityRange;
+				case Stance.StrictAlly: return basePriority - 2 * PriorityRange;
+				case Stance.Neutral: return basePriority - 3 * PriorityRange;
+				case Stance.Enemy: return basePriority - 4 * PriorityRange;
 
 				default:
 					throw new InvalidOperationException();

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -54,7 +54,10 @@ namespace OpenRA.Traits
 		None = 0,
 		Enemy = 1,
 		Neutral = 2,
-		Ally = 4,
+		Owner = 4,
+		StrictAlly = 8,
+		Spectator = 16,
+		Ally = Owner | StrictAlly | Spectator
 	}
 
 	public static class StanceExts

--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -38,11 +38,11 @@ namespace OpenRA.Mods.Common
 		public static bool AppearsFriendlyTo(this Actor self, Actor toActor)
 		{
 			var stance = toActor.Owner.Stances[self.Owner];
-			if (stance == Stance.Ally)
+			if ((stance & Stance.Ally) != 0)
 				return true;
 
 			if (self.EffectiveOwner != null && self.EffectiveOwner.Disguised && !toActor.Info.HasTraitInfo<IgnoresDisguiseInfo>())
-				return toActor.Owner.Stances[self.EffectiveOwner.Owner] == Stance.Ally;
+				return (toActor.Owner.Stances[self.EffectiveOwner.Owner] & Stance.Ally) != 0;
 
 			return false;
 		}
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common
 		public static bool AppearsHostileTo(this Actor self, Actor toActor)
 		{
 			var stance = toActor.Owner.Stances[self.Owner];
-			if (stance == Stance.Ally)
+			if ((stance & Stance.Ally) != 0)
 				return false;		/* otherwise, we'll hate friendly disguised spies */
 
 			if (self.EffectiveOwner != null && self.EffectiveOwner.Disguised && !toActor.Info.HasTraitInfo<IgnoresDisguiseInfo>())

--- a/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 			: base(info)
 		{
 			health = self.Trait<Health>();
-			isNotActiveAlly = player => player.WinState != WinState.Undefined || player.Stances[self.Owner] != Stance.Ally;
+			isNotActiveAlly = player => player.WinState != WinState.Undefined || (player.Stances[self.Owner] & Stance.Ally) == 0;
 		}
 
 		public void RepairBuilding(Actor self, Player player)

--- a/OpenRA.Mods.Common/Traits/World/CreateMPPlayers.cs
+++ b/OpenRA.Mods.Common/Traits/World/CreateMPPlayers.cs
@@ -81,14 +81,14 @@ namespace OpenRA.Mods.Common.Traits
 		static Stance ChooseInitialStance(Player p, Player q)
 		{
 			if (p == q)
-				return Stance.Ally;
+				return Stance.Owner;
 
 			if (q.Spectating && !p.NonCombatant && p.Playable)
-				return Stance.Ally;
+				return Stance.Spectator;
 
 			// Stances set via PlayerReference
 			if (p.PlayerReference.Allies.Contains(q.InternalName))
-				return Stance.Ally;
+				return Stance.StrictAlly;
 			if (p.PlayerReference.Enemies.Contains(q.InternalName))
 				return Stance.Enemy;
 
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.Common.Traits
 				var qc = GetClientForPlayer(q);
 				if (pc != null && qc != null)
 					return pc.Team != 0 && pc.Team == qc.Team
-						? Stance.Ally : Stance.Enemy;
+						? Stance.StrictAlly : Stance.Enemy;
 			}
 
 			// Otherwise, default to neutral


### PR DESCRIPTION
This PR is aimed towards Next+1, it's heavily WIP, it's opened this early to ensure necessary discussion. and to made sure that it gets merged early in a release cycle.

This PR aims to resolve a long-standing issue with stances can't distinguishing between owners and allies.

At this point i only tested the first 5 minutes in the RA mod but I'm fixing issues on the get-go.

Related to #10892, #11093, #11102 and probably a lot more.