### PR TITLE
Tweak the project README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,8 @@ Check our [Playing the Game](https://github.com/OpenRA/OpenRA/wiki/Playing-the-g
 
 ## Contribute
 
-[![Bountysource](https://api.bountysource.com/badge/team?team_id=528&style=bounties_received)](https://www.bountysource.com/teams/openra/issues?utm_source=OpenRA&utm_medium=shield&utm_campaign=bounties_received)
-
 * Please read [INSTALL.md](https://github.com/OpenRA/OpenRA/blob/bleed/INSTALL.md) and [Compiling](http://wiki.openra.net/Compiling) on how to set up an OpenRA development environment.
-* See [Hacking](http://wiki.openra.net/Hacking) for an overview of the engine.
+* See [Hacking](http://wiki.openra.net/Hacking) for a (now very outdated) overview of the engine.
 * To get your patches merged, please adhere to the [Contributing](https://github.com/OpenRA/OpenRA/blob/bleed/CONTRIBUTING.md) guidelines.
 
 ## Mapping
@@ -36,8 +34,9 @@ Check our [Playing the Game](https://github.com/OpenRA/OpenRA/wiki/Playing-the-g
 
 ## Modding
 
-* There exists an auto-generated [Trait documentation](http://wiki.openra.net/Traits) to get started with yaml files.
+* Download a copy of the [OpenRA Mod SDK](https://github.com/OpenRA/OpenRAModSDK/) to start your own mod.
 * Check the [Modding Guide](http://wiki.openra.net/Modding-Guide) to create your own classic RTS.
+* There exists an auto-generated [Trait documentation](http://wiki.openra.net/Traits) to get started with yaml files.
 * Some hints on how to create new OpenRA compatible [Pixelart](http://wiki.openra.net/Pixelart).
 * Upload total conversions at [our ModDB profile](http://www.moddb.com/games/openra/mods).
 
@@ -45,7 +44,6 @@ Check our [Playing the Game](https://github.com/OpenRA/OpenRA/wiki/Playing-the-g
 
 * Sponsor a [mirror server](https://github.com/OpenRA/OpenRAWeb/tree/master/content/packages) if you have some bandwidth to spare.
 * You can immediately set up a [Dedicated](http://wiki.openra.net/Dedicated) Game Server.
-* Fund development by creating [Bounties](https://www.bountysource.com/trackers/36085-openra) on specific tasks.
 
 ## License
 Copyright 2007-2018 The OpenRA Developers (see [AUTHORS](https://github.com/OpenRA/OpenRA/blob/bleed/AUTHORS))


### PR DESCRIPTION
- Remove BountySource references (deprecated for a long time).
- Add a comment about the Hacking page being very outdated.
- Add a link to the Mod SDK.