### PR TITLE
Add dynamic LaunchEffect facing support to LaserZap

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -25,6 +25,7 @@ namespace OpenRA.GameRules
 		public int[] InaccuracyModifiers;
 		public int[] RangeModifiers;
 		public int Facing;
+		public Func<int> CurrentMuzzleFacing;
 		public WPos Source;
 		public Func<WPos> CurrentSource;
 		public Actor SourceActor;

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -141,7 +141,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			source = args.CurrentSource();
 
 			if (hasLaunchEffect && ticks == 0)
-				world.AddFrameEndTask(w => w.Add(new LaunchEffect(world, args.CurrentSource, () => 0,
+				world.AddFrameEndTask(w => w.Add(new LaunchEffect(world, args.CurrentSource, args.CurrentMuzzleFacing,
 					info.LaunchEffectImage, info.LaunchEffectSequence, info.LaunchEffectPalette)));
 
 			// Beam tracks target

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -277,6 +277,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			Func<WPos> muzzlePosition = () => self.CenterPosition + MuzzleOffset(self, barrel);
 			var legacyFacing = MuzzleOrientation(self, barrel).Yaw.Angle / 4;
+			Func<int> legacyMuzzleFacing = () => MuzzleOrientation(self, barrel).Yaw.Angle / 4;
 
 			var passiveTarget = Weapon.TargetActorCenter ? target.CenterPosition : target.Positions.PositionClosestTo(muzzlePosition());
 			var initialOffset = Weapon.FirstBurstTargetOffset;
@@ -299,6 +300,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				Weapon = Weapon,
 				Facing = legacyFacing,
+				CurrentMuzzleFacing = legacyMuzzleFacing,
 
 				DamageModifiers = damageModifiers.ToArray(),
 

--- a/OpenRA.Mods.Common/Traits/ThrowsShrapnel.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsShrapnel.cs
@@ -68,6 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 					{
 						Weapon = wep,
 						Facing = self.World.SharedRandom.Next(-1, 255),
+						CurrentMuzzleFacing = () => 0,
 
 						DamageModifiers = self.TraitsImplementing<IFirepowerModifier>()
 							.Select(a => a.GetFirepowerModifier()).ToArray(),

--- a/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
+++ b/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
@@ -137,6 +137,7 @@ namespace OpenRA.Mods.D2k.Traits
 				{
 					Weapon = self.World.Map.Rules.Weapons[info.Weapon.ToLowerInvariant()],
 					Facing = 0,
+					CurrentMuzzleFacing = () => 0,
 
 					DamageModifiers = self.TraitsImplementing<IFirepowerModifier>()
 						.Select(a => a.GetFirepowerModifier()).ToArray(),


### PR DESCRIPTION
Allows the launch effect facing to sync with the barrel facing (if the launch anim has facings) and
enables it on LaserZap.

Split from #14988.