### PR TITLE
Remove Order.TargetActor and related fixes

### DIFF
--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -53,11 +53,6 @@ namespace OpenRA
 		/// <summary>
 		/// DEPRECATED: Use Target instead.
 		/// </summary>
-		public Actor TargetActor { get { return Target.SerializableActor; } }
-
-		/// <summary>
-		/// DEPRECATED: Use Target instead.
-		/// </summary>
 		public CPos TargetLocation
 		{
 			get
@@ -326,7 +321,7 @@ namespace OpenRA
 		{
 			return ("OrderString: \"{0}\" \n\t Subject: \"{1}\". \n\t TargetActor: \"{2}\" \n\t TargetLocation: {3}." +
 				"\n\t TargetString: \"{4}\".\n\t IsImmediate: {5}.\n\t Player(PlayerName): {6}\n").F(
-				OrderString, Subject, TargetActor != null ? TargetActor.Info.Name : null, TargetLocation,
+				OrderString, Subject, Target.Type == TargetType.Actor ? Target.Actor.Info.Name : null, TargetLocation,
 				TargetString, IsImmediate, Player != null ? Player.PlayerName : null);
 		}
 	}

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -48,7 +48,7 @@ namespace OpenRA
 		public bool IsImmediate;
 
 		public bool SuppressVisualFeedback;
-		public Actor VisualFeedbackTarget;
+		public Target VisualFeedbackTarget;
 
 		/// <summary>
 		/// DEPRECATED: Use Target instead.

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -41,17 +41,6 @@ namespace OpenRA.Traits
 			};
 		}
 
-		/// <summary>
-		/// DEPRECATED: Use Order.Target instead.
-		/// This method is kept to maintain compatibility with legacy code that may not understand TargetType.FrozenActor.
-		/// </summary>
-		public static Target FromOrder(World w, Order o)
-		{
-			return o.TargetActor != null
-				? FromActor(o.TargetActor)
-				: FromCell(w, o.TargetLocation);
-		}
-
 		public static Target FromActor(Actor a)
 		{
 			if (a == null)

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				targetTypes = order.Target.FrozenActor.TargetTypes;
 
 			if (order.Target.Type == TargetType.Actor)
-				targetTypes = order.TargetActor.GetEnabledTargetTypes();
+				targetTypes = order.Target.Actor.GetEnabledTargetTypes();
 
 			return Info.Types.Overlaps(targetTypes);
 		}

--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -70,8 +70,7 @@ namespace OpenRA.Mods.Common
 
 			var frozen = order.Target.FrozenActor;
 
-			// Flashes the frozen proxy
-			self.SetTargetLine(frozen, targetLine, true);
+			self.SetTargetLine(order.Target, targetLine, true);
 
 			// Target is still alive - resolve the real order
 			if (frozen.Actor != null && frozen.Actor.IsInWorld)

--- a/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Orders
 			if (repairBuilding == null)
 				yield break;
 
-			yield return new Order(orderId, underCursor, Target.FromActor(repairBuilding), false) { VisualFeedbackTarget = underCursor };
+			yield return new Order(orderId, underCursor, Target.FromActor(repairBuilding), false) { VisualFeedbackTarget = Target.FromActor(underCursor) };
 		}
 
 		public void Tick(World world)

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits
 				return order.Target.FrozenActor.DamageState > DamageState.Undamaged;
 
 			if (order.Target.Type == TargetType.Actor)
-				return order.TargetActor.GetDamageState() > DamageState.Undamaged;
+				return order.Target.Actor.GetDamageState() > DamageState.Undamaged;
 
 			return false;
 		}

--- a/OpenRA.Mods.Common/Traits/ExternalCaptures.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCaptures.cs
@@ -80,8 +80,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (order.Target.Type == TargetType.Actor)
 			{
-				var c = order.TargetActor.TraitOrDefault<ExternalCapturable>();
-				return c != null && !c.CaptureInProgress && c.CanBeTargetedBy(self, order.TargetActor.Owner);
+				var c = order.Target.Actor.TraitOrDefault<ExternalCapturable>();
+				return c != null && !c.CaptureInProgress && c.CanBeTargetedBy(self, order.Target.Actor.Owner);
 			}
 
 			return false;

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -158,11 +158,11 @@ namespace OpenRA.Mods.Common.Traits
 			if (!IsCorrectCargoType(targetActor))
 				return;
 
-			self.SetTargetLine(order.Target, Color.Green);
-
-			self.CancelActivity();
+			if (!order.Queued)
+				self.CancelActivity();
 
 			var transports = order.OrderString == "EnterTransports";
+			self.SetTargetLine(order.Target, Color.Green);
 			self.QueueActivity(new EnterTransport(self, targetActor, transports ? Info.MaxAlternateTransportAttempts : 0, !transports));
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -121,23 +121,5 @@ namespace OpenRA.Mods.Common.Traits
 					line.SetTarget(self, target, color, display);
 			});
 		}
-
-		public static void SetTargetLine(this Actor self, FrozenActor target, Color color, bool display)
-		{
-			if (self.Owner != self.World.LocalPlayer)
-				return;
-
-			self.World.AddFrameEndTask(w =>
-			{
-				if (self.Disposed)
-					return;
-
-				target.Flash();
-
-				var line = self.TraitOrDefault<DrawLineToTarget>();
-				if (line != null)
-					line.SetTarget(self, Target.FromPos(target.CenterPosition), color, display);
-			});
-		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public string VoicePhraseForOrder(Actor self, Order order)
 		{
-			return (order.OrderString == "Repair" && CanRepair()) ? Info.Voice : null;
+			return order.OrderString == "Repair" && (CanRepair() || CanRearm()) ? Info.Voice : null;
 		}
 
 		public void ResolveOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -100,9 +100,10 @@ namespace OpenRA.Mods.Common.Traits
 				if (!CanRepairAt(order.Target.Actor) || (!CanRepair() && !CanRearm()))
 					return;
 
-				self.SetTargetLine(order.Target, Color.Green);
+				if (!order.Queued)
+					self.CancelActivity();
 
-				self.CancelActivity();
+				self.SetTargetLine(order.Target, Color.Green);
 				self.QueueActivity(new WaitForTransport(self, ActivityUtils.SequenceActivities(new MoveAdjacentTo(self, order.Target),
 					new CallFunc(() => AfterReachActivities(self, order, movement)))));
 

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -92,41 +92,49 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (order.OrderString == "Repair")
 			{
-				if (!CanRepairAt(order.TargetActor) || (!CanRepair() && !CanRearm()))
+				// Repair orders are only valid for own/allied actors,
+				// which are guaranteed to never be frozen.
+				if (order.Target.Type != TargetType.Actor)
 					return;
 
-				var target = Target.FromOrder(self.World, order);
-				self.SetTargetLine(target, Color.Green);
+				if (!CanRepairAt(order.Target.Actor) || (!CanRepair() && !CanRearm()))
+					return;
+
+				self.SetTargetLine(order.Target, Color.Green);
 
 				self.CancelActivity();
-				self.QueueActivity(new WaitForTransport(self, ActivityUtils.SequenceActivities(new MoveAdjacentTo(self, target),
+				self.QueueActivity(new WaitForTransport(self, ActivityUtils.SequenceActivities(new MoveAdjacentTo(self, order.Target),
 					new CallFunc(() => AfterReachActivities(self, order, movement)))));
 
-				TryCallTransport(self, target, new CallFunc(() => AfterReachActivities(self, order, movement)));
+				TryCallTransport(self, order.Target, new CallFunc(() => AfterReachActivities(self, order, movement)));
 			}
 		}
 
 		void AfterReachActivities(Actor self, Order order, IMove movement)
 		{
-			if (!order.TargetActor.IsInWorld || order.TargetActor.IsDead || order.TargetActor.TraitsImplementing<RepairsUnits>().All(r => r.IsTraitDisabled))
+			if (order.Target.Type != TargetType.Actor)
+				return;
+
+			var targetActor = order.Target.Actor;
+			if (!targetActor.IsInWorld || targetActor.IsDead || targetActor.TraitsImplementing<RepairsUnits>().All(r => r.IsTraitDisabled))
 				return;
 
 			// TODO: This is hacky, but almost every single component affected
 			// will need to be rewritten anyway, so this is OK for now.
-			self.QueueActivity(movement.MoveTo(self.World.Map.CellContaining(order.TargetActor.CenterPosition), order.TargetActor));
-			if (CanRearmAt(order.TargetActor) && CanRearm())
+			self.QueueActivity(movement.MoveTo(self.World.Map.CellContaining(targetActor.CenterPosition), targetActor));
+			if (CanRearmAt(targetActor) && CanRearm())
 				self.QueueActivity(new Rearm(self));
 
 			// Add a CloseEnough range of 512 to ensure we're at the host actor
-			self.QueueActivity(new Repair(self, order.TargetActor, new WDist(512)));
+			self.QueueActivity(new Repair(self, targetActor, new WDist(512)));
 
-			var rp = order.TargetActor.TraitOrDefault<RallyPoint>();
+			var rp = targetActor.TraitOrDefault<RallyPoint>();
 			if (rp != null)
 			{
 				self.QueueActivity(new CallFunc(() =>
 				{
 					self.SetTargetLine(Target.FromCell(self.World, rp.Location), Color.Green);
-					self.QueueActivity(movement.MoveTo(rp.Location, order.TargetActor));
+					self.QueueActivity(movement.MoveTo(rp.Location, targetActor));
 				}));
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -82,7 +82,9 @@ namespace OpenRA.Mods.Common.Traits
 			if (!CanRepairAt(order.Target.Actor) || !ShouldRepair())
 				return;
 
-			self.CancelActivity();
+			if (!order.Queued)
+				self.CancelActivity();
+
 			self.QueueActivity(movement.MoveWithinRange(order.Target, info.CloseEnough));
 			self.QueueActivity(new Repair(self, order.Target.Actor, info.CloseEnough));
 

--- a/OpenRA.Mods.Common/Traits/RepairsBridges.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsBridges.cs
@@ -62,14 +62,16 @@ namespace OpenRA.Mods.Common.Traits
 
 		public string VoicePhraseForOrder(Actor self, Order order)
 		{
-			if (order.OrderString != "RepairBridge")
+			// TODO: Add support for FrozenActors
+			if (order.OrderString != "RepairBridge" || order.Target.Type != TargetType.Actor)
 				return null;
 
-			var legacyHut = order.TargetActor.TraitOrDefault<LegacyBridgeHut>();
+			var targetActor = order.Target.Actor;
+			var legacyHut = targetActor.TraitOrDefault<LegacyBridgeHut>();
 			if (legacyHut != null)
 				return legacyHut.BridgeDamageState == DamageState.Undamaged || legacyHut.Repairing || legacyHut.Bridge.IsDangling ? null : info.Voice;
 
-			var hut = order.TargetActor.TraitOrDefault<BridgeHut>();
+			var hut = targetActor.TraitOrDefault<BridgeHut>();
 			if (hut != null)
 				return hut.BridgeDamageState == DamageState.Undamaged || hut.Repairing ? null : info.Voice;
 
@@ -78,10 +80,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void ResolveOrder(Actor self, Order order)
 		{
-			if (order.OrderString == "RepairBridge")
+			// TODO: Add support for FrozenActors
+			if (order.OrderString == "RepairBridge" && order.Target.Type == TargetType.Actor)
 			{
-				var legacyHut = order.TargetActor.TraitOrDefault<LegacyBridgeHut>();
-				var hut = order.TargetActor.TraitOrDefault<BridgeHut>();
+				var targetActor = order.Target.Actor;
+				var legacyHut = targetActor.TraitOrDefault<LegacyBridgeHut>();
+				var hut = targetActor.TraitOrDefault<BridgeHut>();
 				if (legacyHut != null)
 				{
 					if (legacyHut.BridgeDamageState == DamageState.Undamaged || legacyHut.Repairing || legacyHut.Bridge.IsDangling)
@@ -98,8 +102,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (!order.Queued)
 					self.CancelActivity();
 
-				self.SetTargetLine(Target.FromOrder(self.World, order), Color.Yellow);
-				self.QueueActivity(new RepairBridge(self, order.TargetActor, info.EnterBehaviour, info.RepairNotification));
+				self.SetTargetLine(order.Target, Color.Yellow);
+				self.QueueActivity(new RepairBridge(self, targetActor, info.EnterBehaviour, info.RepairNotification));
 			}
 		}
 

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -201,16 +201,20 @@ namespace OpenRA.Mods.Common.Widgets
 
 				if (!flashed && !o.SuppressVisualFeedback)
 				{
-					var visualTargetActor = o.VisualFeedbackTarget ?? o.TargetActor;
-					if (visualTargetActor != null)
+					var visualTarget = o.VisualFeedbackTarget.Type != TargetType.Invalid ? o.VisualFeedbackTarget : o.Target;
+					if (visualTarget.Type == TargetType.Actor)
 					{
-						world.AddFrameEndTask(w => w.Add(new FlashTarget(visualTargetActor)));
+						world.AddFrameEndTask(w => w.Add(new FlashTarget(visualTarget.Actor)));
 						flashed = true;
 					}
-					else if (o.TargetLocation != CPos.Zero)
+					else if (visualTarget.Type == TargetType.FrozenActor)
 					{
-						var pos = world.Map.CenterOfCell(cell);
-						world.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, world, "moveflsh", "idle", "moveflash", true, true)));
+						visualTarget.FrozenActor.Flash();
+						flashed = true;
+					}
+					else if (visualTarget.Type == TargetType.Terrain)
+					{
+						world.AddFrameEndTask(w => w.Add(new SpriteEffect(visualTarget.CenterPosition, world, "moveflsh", "idle", "moveflash", true, true)));
 						flashed = true;
 					}
 				}


### PR DESCRIPTION
This PR rewrites the remaining uses of `Order.TargetActor` to properly use `Target`s.
It also fixes order queuing for repair and passenger orders.

Fixes #15166.
Fixes #15146.
Fixes #15085.
Related to #11265, #14872.