### PR TITLE
Disable kill bounties by default in campaigns, skirmish, and MP.

### DIFF
--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -64,7 +64,7 @@ Player:
 		ID: bounty
 		Label: Kill Bounties
 		Description: Players receive cash bonuses when killing enemy units
-		Enabled: True
+		Enabled: False
 		DisplayOrder: 6
 		Prerequisites: global-bounty
 	LobbyPrerequisiteCheckbox@GLOBALFACTUNDEPLOY:


### PR DESCRIPTION
As per previous discussions in IRC and the forum.

The results from @Smittytron's tests showed that, despite vocal opinions on both sides, the presence of bounties does not appear to make a significant difference in gameplay.  Disabling it by default (as opposed to completely removing it) keeps this available for players who do want it, and provides an easy route for servers to default it on, while still solving in our default rule set one of our long-running consistency complaints from the casual player community.