### PR TITLE
Don't trigger LobbyInfoSynced on ping update.

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -668,10 +668,8 @@ namespace OpenRA.Server
 			// TODO: Split this further into per client ping orders
 			var clientPings = LobbyInfo.ClientPings.Select(ping => ping.Serialize()).ToList();
 
+			// Note that syncing pings doesn't trigger INotifySyncLobbyInfo
 			DispatchOrders(null, 0, new ServerOrder("SyncClientPings", clientPings.WriteToString()).Serialize());
-
-			foreach (var t in serverTraits.WithInterface<INotifySyncLobbyInfo>())
-				t.LobbyInfoSynced(this);
 		}
 
 		public void StartGame()


### PR DESCRIPTION
This interface is only used for updating the master server advertisement, which doesn't use the player pings at all.  Removing this should reduce the master server traffic by a factor of several tens.