### PR TITLE
Send additional mod metadata in master server game advertisements

### DIFF
--- a/OpenRA.Game/Manifest.cs
+++ b/OpenRA.Game/Manifest.cs
@@ -46,6 +46,8 @@ namespace OpenRA
 	{
 		public string Title;
 		public string Version;
+		public string Website;
+		public string WebIcon32;
 		public bool Hidden;
 	}
 

--- a/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
@@ -122,7 +122,7 @@ namespace OpenRA.Mods.Common.Server
 
 							if (masterResponseText.Length > 0)
 							{
-								var regex = new Regex(@"^\[(?<code>\d+)\](?<message>.*)");
+								var regex = new Regex(@"^\[(?<code>-?\d+)\](?<message>.*)");
 								var match = regex.Match(masterResponseText);
 								errorMessage = match.Success && int.TryParse(match.Groups["code"].Value, out errorCode) ?
 									match.Groups["message"].Value.Trim() : "Failed to parse error message";
@@ -140,7 +140,11 @@ namespace OpenRA.Mods.Common.Server
 										message = errorMessage;
 
 									masterServerMessages.Enqueue("Warning: " + message);
-									masterServerMessages.Enqueue("Game has not been advertised online.");
+
+									// Positive error codes indicate errors that prevent advertisement
+									// Negative error codes are non-fatal warnings
+									if (errorCode > 0)
+										masterServerMessages.Enqueue("Game has not been advertised online.");
 								}
 							}
 						}

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -262,7 +262,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				modVersion.GetColor = () => currentServer.IsCompatible ? modVersion.TextColor : incompatibleVersionColor;
 
 				var font = Game.Renderer.Fonts[modVersion.Font];
-				var version = new CachedTransform<GameServer, string>(s => WidgetUtils.TruncateText(s.ModLabel, mapTitle.Bounds.Width, font));
+				var version = new CachedTransform<GameServer, string>(s => WidgetUtils.TruncateText(s.ModLabel, modVersion.Bounds.Width, font));
 				modVersion.GetText = () => version.Update(currentServer);
 			}
 

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -1,6 +1,8 @@
 Metadata:
 	Title: Tiberian Dawn
 	Version: {DEV_VERSION}
+	Website: https://www.openra.net
+	WebIcon32: https://www.openra.net/images/icons/cnc_32x32.png
 
 PackageFormats: Mix
 

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -1,6 +1,8 @@
 Metadata:
 	Title: Dune 2000
 	Version: {DEV_VERSION}
+	Website: https://www.openra.net
+	WebIcon32: https://www.openra.net/images/icons/d2k_32x32.png
 
 PackageFormats: D2kSoundResources
 

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -1,6 +1,8 @@
 Metadata:
 	Title: Red Alert
 	Version: {DEV_VERSION}
+	Website: https://www.openra.net
+	WebIcon32: https://www.openra.net/images/icons/ra_32x32.png
 
 PackageFormats: Mix
 

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -1,6 +1,8 @@
 Metadata:
 	Title: Tiberian Sun
 	Version: {DEV_VERSION}
+	Website: https://www.openra.net
+	WebIcon32: https://www.openra.net/images/icons/ts_32x32.png
 
 PackageFormats: Mix
 


### PR DESCRIPTION
This PR sends three new fields to the master server:
* `ModTitle` includes the mod's human readable title.
* `ModWebsite` includes the mod's website URL (new mod.yaml field).
* `ModIcon32` includes a URL to a web-hosted version of the mod's icon  (new mod.yaml field, `WebIcon32`, should match icon.png).

The `ModTitle` is used as the primary source of the mod name in the server list, and so fixes the "Unknown mod (id)"'s in the server list (for mods that have been updated to include this PR).

The other fields will be used in the web server listings, and I plan a future PR (probably not this cycle) to use them in a dialog similar to the mod-switch dialog when double clicking on a server for a mod that isn't installed and/or mod header tooltip.

Depends on https://github.com/OpenRA/OpenRAMasterServer/pull/56 (already merged).
Depends on https://github.com/OpenRA/OpenRAWeb/pull/383 - the master server will complain about missing icons, but still accept the rest of the data.