### PR TITLE
Refactor AppearsOnRadar

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -874,6 +874,7 @@
     <Compile Include="UpdateRules\Rules\DefineSquadExcludeHarvester.cs" />
     <Compile Include="UpdateRules\Rules\SplitTurretAimAnimation.cs" />
     <Compile Include="UpdateRules\Rules\RenameWormSpawner.cs" />
+    <Compile Include="UpdateRules\Rules\RenameUseLocation.cs" />
     <Compile Include="UpdateRules\Rules\RemoveWithReloadingSpriteTurret.cs" />
     <Compile Include="UpdateRules\Rules\AddEditorPlayer.cs" />
     <Compile Include="UpdateRules\Rules\RemovePaletteFromCurrentTileset.cs" />

--- a/OpenRA.Mods.Common/UpdateRules/Rules/RenameUseLocation.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/RenameUseLocation.cs
@@ -1,0 +1,50 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RenameUseLocation : UpdateRule
+	{
+		public override string Name { get { return "AppearsOnRadar.UseLocation renamed and refactored to AppearanceType"; } }
+		public override string Description
+		{
+			get
+			{
+				return "The AppearsOnRadar property UseLocation was renamed to AppearanceType,\n" +
+					"and refactored to support four different sources for radar display:\n" +
+					"'CenterPosition' (new), 'Location' (old 'true'), 'OccupiedCells' (old 'false')\n" +
+					"and 'EntireFootprint' (new).";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var appOnRadar in actorNode.ChildrenMatching("AppearsOnRadar"))
+			{
+				var useLocation = appOnRadar.LastChildMatching("UseLocation");
+				if (useLocation != null)
+				{
+					var oldValue = FieldLoader.GetValue<bool>("UseLocation", useLocation.Value.Value);
+					if (oldValue)
+						useLocation.ReplaceValue("Location");
+					else
+						useLocation.ReplaceValue("OccupiedCells");
+
+					useLocation.RenameKeyPreservingSuffix("AppearanceType");
+				}
+			}
+
+			yield break;
+		}
+	}
+}

--- a/mods/cnc/rules/campaign-palettes.yaml
+++ b/mods/cnc/rules/campaign-palettes.yaml
@@ -34,6 +34,11 @@
 	WithDeathAnimation:
 		DeathSequencePalette: player-units
 
+^Building:
+	AppearsOnRadar:
+		ColorModifier: 383838
+		SubtractColorModifier: true
+
 ^CommonHuskDefaults:
 	RenderSprites:
 		PlayerPalette: player-units

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -262,7 +262,7 @@
 	OwnerLostAction:
 		Action: Kill
 	AppearsOnRadar:
-		UseLocation: yes
+		AppearanceType: Location
 	Targetable@GROUND:
 		TargetTypes: Ground, Vehicle
 		RequiresCondition: !airborne
@@ -577,7 +577,7 @@
 	OwnerLostAction:
 		Action: Kill
 	AppearsOnRadar:
-		UseLocation: yes
+		AppearanceType: Location
 	HiddenUnderFog:
 		Type: GroundPosition
 		AlwaysVisibleStances: None

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -35,7 +35,7 @@ spicebloom:
 		QuantizedFacings: 1
 	RenderSprites:
 	AppearsOnRadar:
-		UseLocation: true
+		AppearanceType: Location
 	Tooltip:
 		Name: Spice Bloom
 	SpiceBloom:
@@ -97,7 +97,7 @@ sandworm:
 		Sequence: sand
 	HiddenUnderFog:
 	AppearsOnRadar:
-		UseLocation: true
+		AppearanceType: Location
 	AttackSwallow:
 		AttackRequiresEnteringCell: true
 		IgnoresVisibility: true

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -341,7 +341,7 @@
 	OwnerLostAction:
 		Action: Kill
 	AppearsOnRadar:
-		UseLocation: true
+		AppearanceType: Location
 	HiddenUnderFog:
 		Type: GroundPosition
 		AlwaysVisibleStances: None

--- a/mods/ra/rules/campaign-palettes.yaml
+++ b/mods/ra/rules/campaign-palettes.yaml
@@ -22,3 +22,8 @@
 		BaseName: cloak
 		BasePalette: player
 		Alpha: 0.55
+
+^Building:
+	AppearsOnRadar:
+		ColorModifier: 383838
+		SubtractColorModifier: true

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -483,7 +483,7 @@
 	DrawLineToTarget:
 	UpdatesPlayerStatistics:
 	AppearsOnRadar:
-		UseLocation: true
+		AppearanceType: Location
 	SelectionDecorations:
 	WithSpriteControlGroupDecoration:
 	Selectable:

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -381,7 +381,7 @@ HUNTER:
 	QuantizeFacingsFromSequence:
 	DrawLineToTarget:
 	AppearsOnRadar:
-		UseLocation: true
+		AppearanceType: Location
 	Interactable:
 	SelectionDecorations:
 		Palette: pips

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -785,7 +785,7 @@
 		Action: Kill
 	DrawLineToTarget:
 	AppearsOnRadar:
-		UseLocation: true
+		AppearanceType: Location
 	Targetable@GROUND:
 		TargetTypes: Ground, Vehicle
 		RequiresCondition: !airborne


### PR DESCRIPTION
- Renamed and refactored `UseLocation` to `AppearanceType` for more flexibility
- Added `ColorModifier` (plus `SubtractColorModifier` boolean) to allow different radar color shades for different actor types

Tested everything including the update rule, didn't encounter any issues so far.

Allows to fix #15186 for buildings with larger than 1-cell footprints.