### PR TITLE
Fix RA/TD selection/decoration/interaction bounds

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -840,6 +840,7 @@
 	Inherits@1: ^SpriteActor
 	Inherits@shape: ^1x1Shape
 	Interactable:
+		Bounds: 24,24
 	CombatDebugOverlay:
 	AppearsOnRadar:
 	OwnerLostAction:

--- a/mods/cnc/rules/ships.yaml
+++ b/mods/cnc/rules/ships.yaml
@@ -70,6 +70,8 @@ LST:
 	RevealsShroud:
 		Range: 7c0
 	WithFacingSpriteBody:
+	Selectable:
+		Bounds: 48,48
 	WithRoof:
 	WithCargo:
 		DisplayTypes: Infantry, Vehicle

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -206,7 +206,7 @@ PROC:
 		PipCount: 10
 		Capacity: 700
 	Selectable:
-		Bounds: 72,56,0,12
+		Bounds: 72,56
 		DecorationBounds: 73,72
 	CustomSellValue:
 		Value: 500

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -1,6 +1,8 @@
 FACT:
 	Inherits: ^BaseBuilding
 	Inherits@shape: ^3x2Shape
+	Selectable:
+		Bounds: 72,48
 	Valued:
 		Cost: 3500
 	Tooltip:
@@ -104,6 +106,8 @@ FACT.NOD:
 NUKE:
 	Inherits: ^BaseBuilding
 	Inherits@shape: ^2x2Shape
+	Selectable:
+		Bounds: 48,48
 	HitShape:
 		TargetableOffsets: 630,299,0
 	Valued:
@@ -134,6 +138,8 @@ NUKE:
 NUK2:
 	Inherits: ^BaseBuilding
 	Inherits@shape: ^2x2Shape
+	Selectable:
+		Bounds: 48,48
 	HitShape:
 		TargetableOffsets: 630,299,0
 	Valued:
@@ -251,6 +257,7 @@ SILO:
 	SelectionDecorations:
 	-AcceptsDeliveredCash:
 	Selectable:
+		Bounds: 48,24
 		DecorationBounds: 49,30
 
 PYLE:
@@ -351,6 +358,8 @@ HAND:
 
 AFLD:
 	Inherits: ^BaseBuilding
+	Selectable:
+		Bounds: 96,48
 	HitShape:
 		TargetableOffsets: 0,0,0, 0,-512,256, 0,-1451,384, 0,512,128, 0,1536,85
 		Type: Rectangle
@@ -452,6 +461,8 @@ WEAP:
 HPAD:
 	Inherits: ^BaseBuilding
 	Inherits@shape: ^2x2Shape
+	Selectable:
+		Bounds: 48,48
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 768,-512,0, 768,512,0, -281,-512,0, -630,512,0
@@ -736,6 +747,8 @@ TMPL:
 GUN:
 	Inherits: ^Defense
 	Inherits@AUTOTARGET: ^AutoTargetGround
+	Selectable:
+		Bounds: 24,24
 	Valued:
 		Cost: 600
 	Tooltip:
@@ -780,6 +793,8 @@ SAM:
 	Inherits@IDISABLE: ^DisabledOverlay
 	Inherits@AUTOTARGET: ^AutoTargetAir
 	Inherits@shape: ^2x1Shape
+	Selectable:
+		Bounds: 48,24
 	HitShape:
 		Type: Rectangle
 			TopLeft: -768,-512
@@ -871,6 +886,8 @@ OBLI:
 GTWR:
 	Inherits: ^Defense
 	Inherits@AUTOTARGET: ^AutoTargetGround
+	Selectable:
+		Bounds: 24,24
 	Valued:
 		Cost: 600
 	Tooltip:

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -1,5 +1,7 @@
 V19:
 	Inherits: ^TechBuilding
+	Selectable:
+		Bounds: 24,24
 	CashTrickler:
 	Building:
 		Footprint: x
@@ -19,6 +21,8 @@ V19:
 
 V19.Husk:
 	Inherits: ^CivBuildingHusk
+	Interactable:
+		Bounds: 24,24
 	WithSpriteBody:
 	WithIdleOverlay:
 		StartSequence: fire-start
@@ -33,6 +37,7 @@ HOSP:
 	Inherits: ^TechBuilding
 	Inherits@shape: ^2x2Shape
 	Selectable:
+		Bounds: 48,48
 		Priority: 0
 	Building:
 		Footprint: xx xx
@@ -55,6 +60,8 @@ HOSP:
 
 HOSP.Husk:
 	Inherits: ^CivBuildingHusk
+	Interactable:
+		Bounds: 48,48
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -66,6 +73,8 @@ HOSP.Husk:
 BIO:
 	Inherits: ^TechBuilding
 	Inherits@shape: ^2x2Shape
+	Selectable:
+		Bounds: 48,48
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -98,6 +107,8 @@ BIO:
 
 BIO.Husk:
 	Inherits: ^CivBuildingHusk
+	Interactable:
+		Bounds: 48,48
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -107,6 +118,8 @@ BIO.Husk:
 MISS:
 	Inherits: ^CivBuilding
 	Inherits@shape: ^3x2Shape
+	Selectable:
+		Bounds: 72,48
 	Building:
 		Footprint: xxx xxx
 		Dimensions: 3,2

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -65,6 +65,8 @@ TECN:
 FCOM:
 	Inherits: ^TechBuilding
 	Inherits@shape: ^2x2Shape
+	Selectable:
+		Bounds: 48,48
 	OwnerLostAction:
 		Action: ChangeOwner
 	Building:
@@ -110,6 +112,7 @@ HOSP:
 		Action: ChangeOwner
 	Selectable:
 		Priority: 0
+		Bounds: 48,48
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -380,6 +383,7 @@ MISS:
 		TargetableOffsets: 0,0,0, 840,0,0, 840,-1024,0, 420,768,0, -840,0,0, -840,-1024,0, -840,1024,0
 	Selectable:
 		Priority: 0
+		Bounds: 72,48
 	OwnerLostAction:
 		Action: ChangeOwner
 	Building:
@@ -417,6 +421,8 @@ MISS:
 BIO:
 	Inherits: ^TechBuilding
 	Inherits@shape: ^2x2Shape
+	Selectable:
+		Bounds: 48,48
 	OwnerLostAction:
 		Action: ChangeOwner
 	Building:
@@ -450,6 +456,7 @@ OILB:
 		TargetableOffsets: 0,0,0, 630,-300,0, 420,512,0, -420,-512,0, -630,300,0
 	Selectable:
 		Priority: 0
+		Bounds: 48,48
 	OwnerLostAction:
 		Action: ChangeOwner
 	Building:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -671,6 +671,8 @@
 
 ^Defense:
 	Inherits: ^Building
+	Selectable:
+		Bounds: 24,24
 	Targetable:
 		TargetTypes: Ground, C4, DetonateAttack, Structure, Defense
 	MustBeDestroyed:
@@ -691,6 +693,7 @@
 	Inherits@2: ^SpriteActor
 	Inherits@shape: ^1x1Shape
 	Interactable:
+		Bounds: 24,24
 	OwnerLostAction:
 		Action: ChangeOwner
 	Building:
@@ -1028,6 +1031,7 @@
 ^Crate:
 	Inherits@1: ^SpriteActor
 	Interactable:
+		Bounds: 24,24
 	HiddenUnderFog:
 	Tooltip:
 		Name: Crate
@@ -1062,6 +1066,7 @@
 ^Mine:
 	Inherits: ^SpriteActor
 	Interactable:
+		Bounds: 24,24
 	WithSpriteBody:
 	HiddenUnderFog:
 	Mine:

--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -181,6 +181,9 @@ DOMF:
 
 FIXF:
 	Inherits: ^FakeBuilding
+	Selectable:
+		Bounds: 68,34,0,3
+		DecorationBounds: 72,48
 	Buildable:
 		BuildPaletteOrder: 940
 		Queue: Defense
@@ -193,7 +196,7 @@ FIXF:
 		GenericVisibility: Enemy
 		GenericStancePrefix: False
 	Building:
-		Footprint: _X_ xxx _X_
+		Footprint: _=_ xxx _=_
 		Dimensions: 3,3
 	Health:
 		HP: 80000

--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -2,6 +2,8 @@ FPWR:
 	Inherits: ^FakeBuilding
 	Inherits@infiltrate: ^InfiltratableFake
 	Inherits@shape: ^2x2Shape
+	Selectable:
+		Bounds: 48,48
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 640,-384,0, 640,512,0, -710,-512,0, -710,512,0
@@ -33,6 +35,8 @@ FPWR:
 SYRF:
 	Inherits: ^FakeBuilding
 	Inherits@infiltrate: ^InfiltratableFake
+	Selectable:
+		Bounds: 72,48
 	Buildable:
 		BuildPaletteOrder: 890
 		Queue: Defense
@@ -76,6 +80,8 @@ SYRF:
 SPEF:
 	Inherits: ^FakeBuilding
 	Inherits@infiltrate: ^InfiltratableFake
+	Selectable:
+		Bounds: 72,48
 	Targetable:
 		TargetTypes: Ground, Water, Structure, SpyInfiltrate
 	Buildable:
@@ -119,6 +125,8 @@ WEAF:
 	Inherits: ^FakeBuilding
 	Inherits@infiltrate: ^InfiltratableFake
 	Inherits@shape: ^3x2Shape
+	Selectable:
+		Bounds: 72,48
 	Buildable:
 		BuildPaletteOrder: 920
 		Prerequisites: ~structures.france, ~techlevel.medium
@@ -151,6 +159,8 @@ DOMF:
 	Inherits@IDISABLE: ^DisableOnLowPower
 	Inherits@infiltrate: ^InfiltratableFake
 	Inherits@shape: ^2x2Shape
+	Selectable:
+		Bounds: 48,48
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 630,-384,0, 630,384,0, -700,-512,0, -700,512,0
@@ -252,6 +262,8 @@ ATEF:
 	Inherits: ^FakeBuilding
 	Inherits@IDISABLE: ^DisableOnLowPower
 	Inherits@shape: ^2x2Shape
+	Selectable:
+		Bounds: 48,48
 	Tooltip:
 		Name: Fake Allied Tech Center
 		GenericName: Allied Tech Center
@@ -281,6 +293,8 @@ PDOF:
 	Inherits: ^FakeBuilding
 	Inherits@IDISABLE: ^DisableOnLowPower
 	Inherits@shape: ^2x2Shape
+	Selectable:
+		Bounds: 48,48
 	Tooltip:
 		Name: Fake Chronosphere
 		GenericName: Chronosphere
@@ -313,6 +327,8 @@ MSLF:
 	Inherits: ^FakeBuilding
 	Inherits@IDISABLE: ^DisableOnLowPower
 	Inherits@shape: ^2x1Shape
+	Selectable:
+		Bounds: 48,24
 	Tooltip:
 		Name: Fake Missile Silo
 		GenericName: Missile Silo
@@ -341,6 +357,8 @@ MSLF:
 
 FACF:
 	Inherits: ^FakeBuilding
+	Selectable:
+		Bounds: 72,72
 	Buildable:
 		BuildPaletteOrder: 1000
 		Queue: Defense

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -2,6 +2,8 @@ MSLO:
 	Inherits: ^ScienceBuilding
 	Inherits@IDISABLE: ^DisableOnLowPowerOrPowerDown
 	Inherits@shape: ^2x1Shape
+	Selectable:
+		Bounds: 48,24
 	Valued:
 		Cost: 2500
 	Tooltip:
@@ -108,6 +110,8 @@ GAP:
 
 SPEN:
 	Inherits: ^Building
+	Selectable:
+		Bounds: 72,48
 	InfiltrateForSupportPower:
 		Proxy: powerproxy.sonarpulse
 		Types: SpyInfiltrate
@@ -242,6 +246,8 @@ SPEN:
 
 SYRD:
 	Inherits: ^Building
+	Selectable:
+		Bounds: 72,48
 	InfiltrateForSupportPower:
 		Proxy: powerproxy.sonarpulse
 		Types: SpyInfiltrate
@@ -421,6 +427,8 @@ PDOX:
 	Inherits: ^ScienceBuilding
 	Inherits@IDISABLE: ^DisableOnLowPowerOrPowerDown
 	Inherits@shape: ^2x2Shape
+	Selectable:
+		Bounds: 48,48
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 120
@@ -589,6 +597,8 @@ DOME:
 	Inherits: ^Building
 	Inherits@IDISABLE: ^DisableOnLowPowerOrPowerDown
 	Inherits@shape: ^2x2Shape
+	Selectable:
+		Bounds: 48,48
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 630,-384,0, 630,384,0, -700,-512,0, -700,512,0
@@ -831,6 +841,8 @@ SAM:
 	Inherits@IDISABLE: ^DisableOnLowPowerOrPowerDown
 	Inherits@AUTOTARGET: ^AutoTargetAir
 	Inherits@shape: ^2x1Shape
+	Selectable:
+		Bounds: 48,24
 	HitShape:
 		Type: Rectangle
 			TopLeft: -768,-512
@@ -881,6 +893,8 @@ ATEK:
 	Inherits: ^ScienceBuilding
 	Inherits@IDISABLE: ^DisableOnLowPower
 	Inherits@shape: ^2x2Shape
+	Selectable:
+		Bounds: 48,48
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 140
@@ -924,6 +938,8 @@ ATEK:
 WEAP:
 	Inherits: ^Building
 	Inherits@shape: ^3x2Shape
+	Selectable:
+		Bounds: 72,48
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 80
@@ -1030,6 +1046,8 @@ WEAP:
 
 FACT:
 	Inherits: ^Building
+	Selectable:
+		Bounds: 72,72
 	Building:
 		Footprint: xxX xxx XxX ===
 		Dimensions: 3,4
@@ -1186,6 +1204,8 @@ PROC:
 
 SILO:
 	Inherits: ^Building
+	Selectable:
+		Bounds: 24,24
 	Buildable:
 		Queue: Defense
 		BuildPaletteOrder: 35
@@ -1219,6 +1239,8 @@ SILO:
 HPAD:
 	Inherits: ^Building
 	Inherits@shape: ^2x2Shape
+	Selectable:
+		Bounds: 48,48
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 768,-512,0, 768,512,0, -281,-512,0, -630,512,0
@@ -1321,6 +1343,7 @@ AFLD:
 		Name: Airfield
 	Selectable:
 		Class: afld
+		Bounds: 72,48
 	Building:
 		Footprint: xxx xxx
 		Dimensions: 3,2
@@ -1454,6 +1477,8 @@ POWR:
 	Inherits: ^Building
 	Inherits@POWER_OUTAGE: ^DisabledByPowerOutage
 	Inherits@shape: ^2x2Shape
+	Selectable:
+		Bounds: 48,48
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 640,-384,0, 640,512,0, -710,-512,0, -710,512,0
@@ -1532,6 +1557,8 @@ APWR:
 STEK:
 	Inherits: ^ScienceBuilding
 	Inherits@shape: ^3x2Shape
+	Selectable:
+		Bounds: 72,48
 	HitShape:
 		TargetableOffsets: 420,-768,0, 420,768,0, -770,-768,0, -770,768,0
 	Buildable:
@@ -1566,6 +1593,8 @@ STEK:
 BARR:
 	Inherits: ^Building
 	Inherits@shape: ^2x2Shape
+	Selectable:
+		Bounds: 48,48
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 490,-470,0, 355,512,0, -355,-512,0, -630,512,0
@@ -1650,6 +1679,8 @@ BARR:
 
 KENN:
 	Inherits: ^Building
+	Selectable:
+		Bounds: 24,24
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 175
@@ -1698,6 +1729,8 @@ KENN:
 TENT:
 	Inherits: ^Building
 	Inherits@shape: ^2x2Shape
+	Selectable:
+		Bounds: 48,48
 	HitShape:
 		UseTargetableCellsOffsets: false
 		TargetableOffsets: 0,0,0, 630,-512,0, 355,512,0, -281,-512,0, -630,512,0

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1147,7 +1147,7 @@ PROC:
 		Dimensions: 3,4
 		LocalCenterOffset: 0,-512,0
 	Selectable:
-		Bounds: 72,50,0,12
+		Bounds: 72,50,0,4
 		DecorationBounds: 72,70,0,-2
 	SelectionDecorations:
 	Targetable:


### PR DESCRIPTION
The dynamic/per-frame 'canvas' for SHP(TD) introduced by #15148 messed up the old auto-calculation assumptions.

We already use fixed bounds in most other places (D2k, TS, all moving actors in RA and TD, several structures in RA/TD), so finishing the job for RA/TD buildings is the easiest way to fix #15184, avoiding both reversion of #15148 as well as code-level work-arounds.