### PR TITLE
Add a tab to the credits panel for mod-specific text.

### DIFF
--- a/OpenRA.Mods.Common/ModCredits.cs
+++ b/OpenRA.Mods.Common/ModCredits.cs
@@ -1,0 +1,21 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+namespace OpenRA
+{
+	public class ModCredits : IGlobalModData
+	{
+		public readonly string ModTabTitle = "Game";
+
+		[FieldLoader.Require]
+		public readonly string ModCreditsFile = null;
+	}
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -883,6 +883,7 @@
     <Compile Include="UpdateRules\Rules\RenameEmitInfantryOnSell.cs" />
     <Compile Include="Traits\Render\WithBuildingRepairDecoration.cs" />
     <Compile Include="UpdateRules\Rules\SplitRepairDecoration.cs" />
+    <Compile Include="ModCredits.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.Common/Widgets/Logic/CreditsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/CreditsLogic.cs
@@ -11,15 +11,27 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
 	public class CreditsLogic : ChromeLogic
 	{
+		readonly ModData modData;
+		readonly ScrollPanelWidget scrollPanel;
+		readonly LabelWidget template;
+
+		readonly IEnumerable<string> modLines;
+		readonly IEnumerable<string> engineLines;
+		bool showMod = false;
+
 		[ObjectCreator.UseCtor]
 		public CreditsLogic(Widget widget, ModData modData, Action onExit)
 		{
+			this.modData = modData;
+
 			var panel = widget.Get("CREDITS_PANEL");
 
 			panel.Get<ButtonWidget>("BACK_BUTTON").OnClick = () =>
@@ -28,19 +40,55 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				onExit();
 			};
 
-			var scrollPanel = panel.Get<ScrollPanelWidget>("CREDITS_DISPLAY");
-			var template = scrollPanel.Get<LabelWidget>("CREDITS_TEMPLATE");
-			scrollPanel.RemoveChildren();
+			engineLines = ParseLines("AUTHORS");
 
-			var lines = modData.DefaultFileSystem.Open("AUTHORS").ReadAllLines();
-			foreach (var l in lines)
+			var tabContainer = panel.Get("TAB_CONTAINER");
+			var modTab = tabContainer.Get<ButtonWidget>("MOD_TAB");
+			modTab.IsHighlighted = () => showMod;
+			modTab.OnClick = () => ShowCredits(true);
+
+			var engineTab = tabContainer.Get<ButtonWidget>("ENGINE_TAB");
+			engineTab.IsHighlighted = () => !showMod;
+			engineTab.OnClick = () => ShowCredits(false);
+
+			scrollPanel = panel.Get<ScrollPanelWidget>("CREDITS_DISPLAY");
+			template = scrollPanel.Get<LabelWidget>("CREDITS_TEMPLATE");
+
+			var hasModCredits = modData.Manifest.Contains<ModCredits>();
+			if (hasModCredits)
 			{
-				// Improve the formatting
-				var line = l.Replace("\t", "    ").Replace("*", "\u2022");
+				var modCredits = modData.Manifest.Get<ModCredits>();
+				modLines = ParseLines(modCredits.ModCreditsFile);
+				modTab.GetText = () => modCredits.ModTabTitle;
+
+				// Make space to show the tabs
+				tabContainer.IsVisible = () => true;
+				scrollPanel.Bounds.Y += tabContainer.Bounds.Height;
+				scrollPanel.Bounds.Height -= tabContainer.Bounds.Height;
+			}
+
+			ShowCredits(hasModCredits);
+		}
+
+		void ShowCredits(bool modCredits)
+		{
+			showMod = modCredits;
+
+			scrollPanel.RemoveChildren();
+			foreach (var line in showMod ? modLines : engineLines)
+			{
 				var label = template.Clone() as LabelWidget;
 				label.GetText = () => line;
 				scrollPanel.AddChild(label);
 			}
+		}
+
+		IEnumerable<string> ParseLines(string file)
+		{
+			return modData.DefaultFileSystem.Open(file)
+				.ReadAllLines()
+				.Select(l => l.Replace("\t", "    ").Replace("*", "\u2022"))
+				.ToList();
 		}
 	}
 }

--- a/mods/cnc/chrome/credits.yaml
+++ b/mods/cnc/chrome/credits.yaml
@@ -17,15 +17,31 @@ Container@CREDITS_PANEL:
 			Height: 400
 			Background: panel-black
 			Children:
+				Container@TAB_CONTAINER:
+					Visible: False
+					X: 15
+					Y: 15
+					Width: PARENT_RIGHT - 30
+					Height: 34
+					Children:
+						Button@MOD_TAB:
+							Width: 140
+							Height: 35
+						Button@ENGINE_TAB:
+							X: 150
+							Width: 140
+							Height: 35
+							Text: OpenRA
 				ScrollPanel@CREDITS_DISPLAY:
 					X: 15
 					Y: 15
 					Width: PARENT_RIGHT - 30
 					Height: PARENT_BOTTOM - 30
-					TopBottomSpacing: 18
+					TopBottomSpacing: 6
 					Children:
 						Label@CREDITS_TEMPLATE:
 							X: 8
+							Width: PARENT_RIGHT - 25
 							Height: 16
 							VAlign: Top
 		Button@BACK_BUTTON:

--- a/mods/common/chrome/credits.yaml
+++ b/mods/common/chrome/credits.yaml
@@ -12,15 +12,33 @@ Background@CREDITS_PANEL:
 			Font: Bold
 			Align: Center
 			Text: Credits
+		Container@TAB_CONTAINER:
+			Visible: False
+			X: 15
+			Y: 50
+			Width: PARENT_RIGHT - 30
+			Height: 30
+			Children:
+				Button@MOD_TAB:
+					Width: 140
+					Height: 31
+					Font: Bold
+				Button@ENGINE_TAB:
+					X: 140
+					Width: 140
+					Height: 31
+					Text: OpenRA
+					Font: Bold
 		ScrollPanel@CREDITS_DISPLAY:
 			X: 15
 			Y: 50
 			Width: PARENT_RIGHT - 30
 			Height: 345
-			TopBottomSpacing: 18
+			TopBottomSpacing: 6
 			Children:
 				Label@CREDITS_TEMPLATE:
 					X: 8
+					Width: PARENT_RIGHT - 25
 					Height: 16
 					VAlign: Top
 		Button@BACK_BUTTON:


### PR DESCRIPTION
Closes #6225.

The tab is only enabled if a `ModCredits` block in mod.yaml.

e.g. for TD:
```
ModCredits:
	ModTabTitle: Tiberian Dawn
	ModCreditsFile: cnc|rules/vehicles.yaml
```

This also fixes the unnecessarily large top and bottom margins in the scroll panel.