### PR TITLE
Add "Restart" button for multiplayer replays

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var iop = world.WorldActor.TraitsImplementing<IObjectivesPanel>().FirstOrDefault();
 					var exitDelay = iop != null ? iop.ExitDelay : 0;
 
-					if (world.LobbyInfo.NonBotClients.Count() == 1)
+					if (world.IsReplay || world.LobbyInfo.NonBotClients.Count() == 1)
 					{
 						restartAction = () =>
 						{


### PR DESCRIPTION
Check if we're in a replay before checking the number of non-bot clients.

Fixes #14104 and partially #15181.