### PR TITLE
Fix production queue numbers increasing needlessly.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -36,6 +36,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			var queues = allQueues.Where(q => q.Info.Group == Group).ToList();
 			var tabs = new List<ProductionTab>();
+			var largestUsedName = 0;
 
 			// Remove stale queues
 			foreach (var t in Tabs)
@@ -45,7 +46,10 @@ namespace OpenRA.Mods.Common.Widgets
 
 				tabs.Add(t);
 				queues.Remove(t.Queue);
+				largestUsedName = Math.Max(int.Parse(t.Name), largestUsedName);
 			}
+
+			NextQueueName = largestUsedName + 1;
 
 			// Add new queues
 			foreach (var queue in queues)


### PR DESCRIPTION
Fixes production queue numbers increasing while previous buildings already disappeared. The number assigned to a new queue is decreased to the least highest number available. This approach may still leave lower numbers unused, but avoids confusing players by reusing or renaming queues that are in use.

Closes #15050.