### PR TITLE
Add more node utility extensions for update rules

### DIFF
--- a/OpenRA.Mods.Common/UpdateRules/Rules/ChangeIntensityToDuration.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/ChangeIntensityToDuration.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				if (intensity == null)
 					continue;
 
-				intensity.RenameKeyPreservingSuffix("Duration");
+				intensity.RenameKey("Duration");
 			}
 
 			yield break;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/ChangeIntensityToDuration.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/ChangeIntensityToDuration.cs
@@ -30,13 +30,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
 		{
 			foreach (var sod in actorNode.ChildrenMatching("ShakeOnDeath"))
-			{
-				var intensity = sod.LastChildMatching("Intensity");
-				if (intensity == null)
-					continue;
-
-				intensity.RenameKey("Duration");
-			}
+				sod.RenameChildrenMatching("Intensity", "Duration");
 
 			yield break;
 		}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/DefineLocomotors.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/DefineLocomotors.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 					mobileNode.RemoveNodes("Subterranean");
 					var conditionNode = mobileNode.LastChildMatching("SubterraneanCondition");
 					if (conditionNode != null)
-						conditionNode.RenameKeyPreservingSuffix("Condition");
+						conditionNode.RenameKey("Condition");
 
 					var transitionImageNode = mobileNode.LastChildMatching("SubterraneanTransitionImage");
 					var transitionSequenceNode = mobileNode.LastChildMatching("SubterraneanTransitionSequence");

--- a/OpenRA.Mods.Common/UpdateRules/Rules/DefineLocomotors.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/DefineLocomotors.cs
@@ -92,9 +92,8 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				if (tunnelConditionNode != null)
 				{
 					var grantNode = new MiniYamlNode("GrantConditionOnTunnelLayer", "");
-					grantNode.AddNode("Condition", tunnelConditionNode.Value.Value);
+					tunnelConditionNode.MoveAndRenameNode(mobileNode, grantNode, "Condition");
 					addNodes.Add(grantNode);
-					mobileNode.RemoveNodes("TunnelCondition");
 				}
 
 				var subterraneanNode = mobileNode.LastChildMatching("Subterranean");
@@ -125,13 +124,8 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 					{
 						var grantNode = new MiniYamlNode("GrantConditionOnSubterraneanLayer", "");
 						foreach (var node in nodes)
-						{
 							if (node != null)
-							{
-								grantNode.AddNode(node);
-								mobileNode.RemoveNode(node);
-							}
-						}
+								node.MoveNode(mobileNode, grantNode);
 
 						addNodes.Add(grantNode);
 					}
@@ -147,8 +141,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 					if (conditionNode != null)
 					{
 						var grantNode = new MiniYamlNode("GrantConditionOnJumpjetLayer", "");
-						grantNode.AddNode("Condition", conditionNode.Value.Value);
-						mobileNode.RemoveNodes("JumpjetCondition");
+						conditionNode.MoveAndRenameNode(mobileNode, grantNode, "Condition");
 						addNodes.Add(grantNode);
 					}
 				}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/RemoveWithReloadingSpriteTurret.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/RemoveWithReloadingSpriteTurret.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 		{
 			foreach (var turret in actorNode.ChildrenMatching("WithReloadingSpriteTurret"))
 			{
-				turret.RenameKeyPreservingSuffix("WithSpriteTurret");
+				turret.RenameKey("WithSpriteTurret");
 				locations.Add("{0} ({1})".F(actorNode.Key, turret.Location.Filename));
 			}
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/RenameEmitInfantryOnSell.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/RenameEmitInfantryOnSell.cs
@@ -28,12 +28,9 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
 		{
-			foreach (var uneios in actorNode.ChildrenMatching("-EmitInfantryOnSell"))
-				uneios.RenameKeyPreservingSuffix("-SpawnActorsOnSell");
-
 			foreach (var eios in actorNode.ChildrenMatching("EmitInfantryOnSell"))
 			{
-				eios.RenameKeyPreservingSuffix("SpawnActorsOnSell");
+				eios.RenameKey("SpawnActorsOnSell");
 				var actortypes = eios.LastChildMatching("ActorTypes");
 				if (actortypes == null)
 					eios.AddNode("ActorTypes", "e1");

--- a/OpenRA.Mods.Common/UpdateRules/Rules/RenameEmitInfantryOnSell.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/RenameEmitInfantryOnSell.cs
@@ -13,33 +13,33 @@ using System.Collections.Generic;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {
-    public class RenameEmitInfantryOnSell : UpdateRule
-    {
-        public override string Name { get { return "EmitInfantryOnSell renamed to SpawnActorsOnSell"; } }
-        public override string Description
-        {
-            get
-            {
-                return "The EmitInfantryOnSell trait was renamed to SpawnActorsOnSell and the default\n" +
-                    "actor type to spawn was removed. Uses of the old traits and defaults are updated\n" +
-                    "to account for this.";
-            }
-        }
+	public class RenameEmitInfantryOnSell : UpdateRule
+	{
+		public override string Name { get { return "EmitInfantryOnSell renamed to SpawnActorsOnSell"; } }
+		public override string Description
+		{
+			get
+			{
+				return "The EmitInfantryOnSell trait was renamed to SpawnActorsOnSell and the default\n" +
+					"actor type to spawn was removed. Uses of the old traits and defaults are updated\n" +
+					"to account for this.";
+			}
+		}
 
-        public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
-        {
-            foreach (var uneios in actorNode.ChildrenMatching("-EmitInfantryOnSell"))
-                uneios.RenameKeyPreservingSuffix("-SpawnActorsOnSell");
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var uneios in actorNode.ChildrenMatching("-EmitInfantryOnSell"))
+				uneios.RenameKeyPreservingSuffix("-SpawnActorsOnSell");
 
-            foreach (var eios in actorNode.ChildrenMatching("EmitInfantryOnSell"))
-            {
-                eios.RenameKeyPreservingSuffix("SpawnActorsOnSell");
-                var actortypes = eios.LastChildMatching("ActorTypes");
-                if (actortypes == null)
-                    eios.AddNode("ActorTypes", "e1");
-            }
+			foreach (var eios in actorNode.ChildrenMatching("EmitInfantryOnSell"))
+			{
+				eios.RenameKeyPreservingSuffix("SpawnActorsOnSell");
+				var actortypes = eios.LastChildMatching("ActorTypes");
+				if (actortypes == null)
+					eios.AddNode("ActorTypes", "e1");
+			}
 
-            yield break;
-        }
-    }
+			yield break;
+		}
+	}
 }

--- a/OpenRA.Mods.Common/UpdateRules/Rules/RenameWormSpawner.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/RenameWormSpawner.cs
@@ -28,14 +28,14 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
 		{
 			foreach (var spawner in actorNode.ChildrenMatching("WormSpawner"))
-				spawner.RenameKeyPreservingSuffix("ActorSpawner");
+				spawner.RenameKey("ActorSpawner");
 
 			foreach (var manager in actorNode.ChildrenMatching("WormManager"))
 			{
-				manager.RenameKeyPreservingSuffix("ActorSpawnManager");
+				manager.RenameKey("ActorSpawnManager");
 				var signature = manager.LastChildMatching("WormSignature");
 				if (signature != null)
-					signature.RenameKeyPreservingSuffix("Actors");
+					signature.RenameKey("Actors");
 			}
 
 			yield break;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/SplitAimAnimations.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/SplitAimAnimations.cs
@@ -74,23 +74,23 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				// If both aren't null, split/copy everything relevant to the new WithTurretAimAnimation.
 				// If both are null (extremely unlikely), do nothing.
 				if (attackSequence != null && aimSequence == null)
-					attackSequence.RenameKeyPreservingSuffix("Sequence");
+					attackSequence.RenameKey("Sequence");
 				else if (attackSequence == null && aimSequence == null && reloadPrefix != null)
 				{
 					turretAttack.RemoveNode(reloadPrefix);
-					turretAttack.RenameKeyPreservingSuffix("WithTurretAimAnimation");
+					turretAttack.RenameKey("WithTurretAimAnimation");
 				}
 				else if (attackSequence == null && aimSequence != null)
 				{
-					turretAttack.RenameKeyPreservingSuffix("WithTurretAimAnimation");
-					aimSequence.RenameKeyPreservingSuffix("Sequence");
+					turretAttack.RenameKey("WithTurretAimAnimation");
+					aimSequence.RenameKey("Sequence");
 					if (reloadPrefix != null)
 						turretAttack.RemoveNode(reloadPrefix);
 				}
 				else if (attackSequence != null && aimSequence != null)
 				{
 					var turretAim = new MiniYamlNode("WithTurretAimAnimation", "");
-					aimSequence.RenameKeyPreservingSuffix("Sequence");
+					aimSequence.RenameKey("Sequence");
 					turretAim.AddNode(aimSequence);
 					turretAttack.RemoveNode(aimSequence);
 
@@ -104,7 +104,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 					if (armament != null)
 						turretAim.AddNode(armament);
 
-					attackSequence.RenameKeyPreservingSuffix("Sequence");
+					attackSequence.RenameKey("Sequence");
 					actorNode.AddNode(turretAim);
 				}
 			}
@@ -118,7 +118,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 					aimAnimLocations.Add(Tuple.Create(actorNode.Key, actorNode.Location.Filename));
 
 					var aimAnim = new MiniYamlNode("WithTurretAimAnimation", "");
-					aimSequence.RenameKeyPreservingSuffix("Sequence");
+					aimSequence.RenameKey("Sequence");
 					aimAnim.AddNode(aimSequence);
 					spriteTurret.RemoveNode(aimSequence);
 					actorNode.AddNode(aimAnim);
@@ -144,23 +144,23 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				// If both sequences aren't null, split/copy everything relevant to the new WithAimAnimation.
 				// If both sequences and the prefix are null (extremely unlikely), do nothing.
 				if (attackSequence != null && aimSequence == null && reloadPrefix == null)
-					attackSequence.RenameKeyPreservingSuffix("Sequence");
+					attackSequence.RenameKey("Sequence");
 				else if (attackSequence == null && aimSequence == null && reloadPrefix != null)
 				{
 					attackAnim.RemoveNode(reloadPrefix);
-					attackAnim.RenameKeyPreservingSuffix("WithAimAnimation");
+					attackAnim.RenameKey("WithAimAnimation");
 				}
 				else if (attackSequence == null && aimSequence != null)
 				{
-					attackAnim.RenameKeyPreservingSuffix("WithAimAnimation");
-					aimSequence.RenameKeyPreservingSuffix("Sequence");
+					attackAnim.RenameKey("WithAimAnimation");
+					aimSequence.RenameKey("Sequence");
 					if (reloadPrefix != null)
 						attackAnim.RemoveNode(reloadPrefix);
 				}
 				else if (attackSequence != null && aimSequence != null)
 				{
 					var aimAnim = new MiniYamlNode("WithAimAnimation", "");
-					aimSequence.RenameKeyPreservingSuffix("Sequence");
+					aimSequence.RenameKey("Sequence");
 					aimAnim.AddNode(aimSequence);
 					attackAnim.RemoveNode(aimSequence);
 
@@ -174,7 +174,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 					if (armament != null)
 						aimAnim.AddNode(armament);
 
-					attackSequence.RenameKeyPreservingSuffix("Sequence");
+					attackSequence.RenameKey("Sequence");
 					actorNode.AddNode(aimAnim);
 				}
 			}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/SplitAimAnimations.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/SplitAimAnimations.cs
@@ -90,9 +90,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				else if (attackSequence != null && aimSequence != null)
 				{
 					var turretAim = new MiniYamlNode("WithTurretAimAnimation", "");
-					aimSequence.RenameKey("Sequence");
-					turretAim.AddNode(aimSequence);
-					turretAttack.RemoveNode(aimSequence);
+					aimSequence.MoveAndRenameNode(turretAttack, turretAim, "Sequence");
 
 					var turret = turretAttack.LastChildMatching("Turret");
 					var armament = turretAttack.LastChildMatching("Armament");
@@ -118,9 +116,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 					aimAnimLocations.Add(Tuple.Create(actorNode.Key, actorNode.Location.Filename));
 
 					var aimAnim = new MiniYamlNode("WithTurretAimAnimation", "");
-					aimSequence.RenameKey("Sequence");
-					aimAnim.AddNode(aimSequence);
-					spriteTurret.RemoveNode(aimSequence);
+					aimSequence.MoveAndRenameNode(spriteTurret, aimAnim, "Sequence");
 					actorNode.AddNode(aimAnim);
 				}
 			}
@@ -160,9 +156,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				else if (attackSequence != null && aimSequence != null)
 				{
 					var aimAnim = new MiniYamlNode("WithAimAnimation", "");
-					aimSequence.RenameKey("Sequence");
-					aimAnim.AddNode(aimSequence);
-					attackAnim.RemoveNode(aimSequence);
+					aimSequence.MoveAndRenameNode(attackAnim, aimAnim, "Sequence");
 
 					var body = attackAnim.LastChildMatching("Body");
 					var armament = attackAnim.LastChildMatching("Armament");

--- a/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
@@ -273,6 +273,19 @@ namespace OpenRA.Mods.Common.UpdateRules
 			node.Value.Nodes.Remove(toRemove);
 		}
 
+		public static void MoveNode(this MiniYamlNode node, MiniYamlNode fromNode, MiniYamlNode toNode)
+		{
+			toNode.Value.Nodes.Add(node);
+			fromNode.Value.Nodes.Remove(node);
+		}
+
+		public static void MoveAndRenameNode(this MiniYamlNode node,
+			MiniYamlNode fromNode, MiniYamlNode toNode, string newKey, bool preserveSuffix = true, bool includeRemovals = true)
+		{
+			node.RenameKey(newKey, preserveSuffix, includeRemovals);
+			node.MoveNode(fromNode, toNode);
+		}
+
 		/// <summary>Removes children with keys equal to [match] or [match]@[arbitrary suffix]</summary>
 		public static int RemoveNodes(this MiniYamlNode node, string match, bool ignoreSuffix = true, bool includeRemovals = true)
 		{
@@ -306,6 +319,13 @@ namespace OpenRA.Mods.Common.UpdateRules
 		public static MiniYamlNode LastChildMatching(this MiniYamlNode node, string match, bool includeRemovals = true)
 		{
 			return node.ChildrenMatching(match, includeRemovals).LastOrDefault();
+		}
+
+		public static void RenameChildrenMatching(this MiniYamlNode node, string match, string newKey, bool preserveSuffix = true, bool includeRemovals = true)
+		{
+			var matching = node.ChildrenMatching(match);
+			foreach (var m in matching)
+				m.RenameKey(newKey, preserveSuffix, includeRemovals);
 		}
 	}
 }


### PR DESCRIPTION
Adds `MoveNode`, `MoveAndRenameNode` and `RenameChildrenMatching` extensions.

Only updated 4 rules to serve as examples, but #15010 has some prime candidates that could benefit a lot from this (in particular, `ReworkCheckboxes` and `SplitGateFromBuilding`).

For the record, I tested all new extensions and updated rules.