### PR TITLE
Add some changes required downstream

### DIFF
--- a/OpenRA.Game/Graphics/RgbaColorRenderer.cs
+++ b/OpenRA.Game/Graphics/RgbaColorRenderer.cs
@@ -200,6 +200,20 @@ namespace OpenRA.Graphics
 			DrawPolygon(new[] { tl, tr, br, bl }, width, color);
 		}
 
+		public void FillTriangle(float3 a, float3 b, float3 c, Color color)
+		{
+			color = Util.PremultiplyAlpha(color);
+			var cr = color.R / 255.0f;
+			var cg = color.G / 255.0f;
+			var cb = color.B / 255.0f;
+			var ca = color.A / 255.0f;
+
+			vertices[0] = new Vertex(a + Offset, cr, cg, cb, ca, 0, 0);
+			vertices[1] = new Vertex(b + Offset, cr, cg, cb, ca, 0, 0);
+			vertices[2] = new Vertex(c + Offset, cr, cg, cb, ca, 0, 0);
+			parent.DrawRGBAVertices(vertices);
+		}
+
 		public void FillRect(float3 tl, float3 br, Color color)
 		{
 			var tr = new float3(br.X, tl.Y, tl.Z);

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -175,7 +175,8 @@ namespace OpenRA.Mods.Common.Traits
 				OnStopOrder(self);
 		}
 
-		protected virtual void OnStopOrder(Actor self)
+		// Some 3rd-party mods rely on this being public
+		public virtual void OnStopOrder(Actor self)
 		{
 			self.CancelActivity();
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 			return new AttackActivity(self, newTarget, allowMove, forceAttack);
 		}
 
-		protected override void OnStopOrder(Actor self)
+		public override void OnStopOrder(Actor self)
 		{
 			Target = Target.Invalid;
 			base.OnStopOrder(self);

--- a/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
@@ -29,7 +29,8 @@ namespace OpenRA.Mods.Common.Traits
 			return new SetTarget(this, newTarget, allowMove);
 		}
 
-		protected class SetTarget : Activity
+		// Some 3rd-party mods rely on this being public
+		public class SetTarget : Activity
 		{
 			readonly Target target;
 			readonly AttackOmni attack;


### PR DESCRIPTION
This should remove the need of at least the downstream engine of Shattered Paradise / Nomad Galaxy to ship customized OpenRA.Game and OpenRA.Mods.Common, which also makes it easier for them to rebase onto upstream bleed or releases.