### PR TITLE
Added drag direction mouse interaction for set the approach direction for airstrike and parabombs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -139,6 +139,7 @@ Also thanks to:
     * Teemu Nieminen (Temeez)
     * Tim Mylemans (gecko)
     * Tirili
+    * Tomas Einarsson (Mesacer)
     * Tristan Keating (Kilkakon)
     * Tristan Mühlbacher (MicroBit)
     * UnknownProgrammer

--- a/OpenRA.Game/Graphics/HardwareCursor.cs
+++ b/OpenRA.Game/Graphics/HardwareCursor.cs
@@ -125,6 +125,8 @@ namespace OpenRA.Graphics
 
 		public void Render(Renderer renderer) { }
 
+		public int Frame { get { return frame; } }
+
 		public void Dispose()
 		{
 			foreach (var cursors in hardwareCursors)

--- a/OpenRA.Game/Graphics/SoftwareCursor.cs
+++ b/OpenRA.Game/Graphics/SoftwareCursor.cs
@@ -21,6 +21,7 @@ namespace OpenRA.Graphics
 		void Render(Renderer renderer);
 		void SetCursor(string cursor);
 		void Tick();
+		int Frame { get; }
 	}
 
 	public sealed class SoftwareCursor : ICursor
@@ -77,7 +78,7 @@ namespace OpenRA.Graphics
 				return;
 
 			var cursorSequence = cursorProvider.GetCursorSequence(cursorName);
-			var cursorSprite = sprites[cursorName][((int)cursorFrame % cursorSequence.Length)];
+			var cursorSprite = sprites[cursorName][Frame];
 			var cursorSize = CursorProvider.CursorViewportZoomed ? 2.0f * cursorSprite.Size : cursorSprite.Size;
 
 			var cursorOffset = CursorProvider.CursorViewportZoomed ?
@@ -89,6 +90,15 @@ namespace OpenRA.Graphics
 				Viewport.LastMousePos - cursorOffset,
 				paletteReferences[cursorSequence.Palette],
 				cursorSize);
+		}
+
+		public int Frame
+		{
+			get
+			{
+				var cursorSequence = cursorProvider.GetCursorSequence(cursorName);
+				return (int)cursorFrame % cursorSequence.Length;
+			}
 		}
 
 		public void Dispose()

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -155,7 +155,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return false; } }
 
-		class MinefieldOrderGenerator : IOrderGenerator
+		class MinefieldOrderGenerator : OrderGenerator
 		{
 			readonly List<Actor> minelayers;
 			readonly Sprite tileOk;
@@ -179,7 +179,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				minelayers.Add(a);
 			}
 
-			public IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
+			protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
 			{
 				if (mi.Button == Game.Settings.Game.MouseButtonPreference.Cancel)
 				{
@@ -201,15 +201,15 @@ namespace OpenRA.Mods.Cnc.Traits
 				}
 			}
 
-			public void Tick(World world)
+			protected override void Tick(World world)
 			{
 				minelayers.RemoveAll(minelayer => !minelayer.IsInWorld || minelayer.IsDead);
 				if (!minelayers.Any())
 					world.CancelInputMode();
 			}
 
-			public IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
-			public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
+			protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
+			protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
 			{
 				var minelayer = minelayers.FirstOrDefault(m => m.IsInWorld && !m.IsDead);
 				if (minelayer == null)
@@ -230,7 +230,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				}
 			}
 
-			public string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
+			protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 			{
 				return "ability";
 			}

--- a/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
@@ -180,7 +180,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		}
 	}
 
-	class PortableChronoOrderGenerator : IOrderGenerator
+	class PortableChronoOrderGenerator : OrderGenerator
 	{
 		readonly Actor self;
 		readonly PortableChronoInfo info;
@@ -191,7 +191,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			this.info = info;
 		}
 
-		public IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			if (mi.Button == Game.Settings.Game.MouseButtonPreference.Cancel)
 			{
@@ -207,18 +207,18 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		public void Tick(World world)
+		protected override void Tick(World world)
 		{
 			if (!self.IsInWorld || self.IsDead)
 				world.CancelInputMode();
 		}
 
-		public IEnumerable<IRenderable> Render(WorldRenderer wr, World world)
+		protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world)
 		{
 			yield break;
 		}
 
-		public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
+		protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
 		{
 			if (!self.IsInWorld || self.Owner != self.World.LocalPlayer)
 				yield break;
@@ -234,7 +234,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				Color.FromArgb(96, Color.Black));
 		}
 
-		public string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			if (self.IsInWorld && self.Location != cell
 				&& self.Trait<PortableChrono>().CanTeleport && self.Owner.Shroud.IsExplored(cell))

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -61,7 +62,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		}
 	}
 
-	public class SelectAttackPowerTarget : IOrderGenerator
+	public class SelectAttackPowerTarget : OrderGenerator
 	{
 		readonly SupportPowerManager manager;
 		readonly SupportPowerInstance instance;
@@ -94,7 +95,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			return world.Map.Contains(cell) && instance.Instances.Any(a => !a.IsTraitPaused && (a.Self.CenterPosition - pos).HorizontalLengthSquared < range);
 		}
 
-		IEnumerable<Order> IOrderGenerator.Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			world.CancelInputMode();
 			if (mi.Button == expectedButton && IsValidTarget(world, cell))
@@ -104,16 +105,16 @@ namespace OpenRA.Mods.Cnc.Traits
 				};
 		}
 
-		void IOrderGenerator.Tick(World world)
+		protected override void Tick(World world)
 		{
 			// Cancel the OG if we can't use the power
 			if (!manager.Powers.ContainsKey(order))
 				world.CancelInputMode();
 		}
 
-		IEnumerable<IRenderable> IOrderGenerator.Render(WorldRenderer wr, World world) { yield break; }
+		protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
 
-		IEnumerable<IRenderable> IOrderGenerator.RenderAboveShroud(WorldRenderer wr, World world)
+		protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
 		{
 			foreach (var a in instance.Instances.Where(i => !i.IsTraitPaused))
 			{
@@ -133,7 +134,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		string IOrderGenerator.GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			return IsValidTarget(world, cell) ? cursor : cursorBlocked;
 		}

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -120,7 +121,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			return true;
 		}
 
-		class SelectChronoshiftTarget : IOrderGenerator
+		class SelectChronoshiftTarget : OrderGenerator
 		{
 			readonly ChronoshiftPower power;
 			readonly int range;
@@ -143,7 +144,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				tile = world.Map.Rules.Sequences.GetSequence(info.OverlaySpriteGroup, info.SourceTileSequence).GetSprite(0);
 			}
 
-			public IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
+			protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
 			{
 				world.CancelInputMode();
 				if (mi.Button == MouseButton.Left)
@@ -152,14 +153,14 @@ namespace OpenRA.Mods.Cnc.Traits
 				yield break;
 			}
 
-			public void Tick(World world)
+			protected override void Tick(World world)
 			{
 				// Cancel the OG if we can't use the power
 				if (!manager.Powers.ContainsKey(order))
 					world.CancelInputMode();
 			}
 
-			public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
+			protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
 			{
 				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 				var targetUnits = power.UnitsInRange(xy).Where(a => !world.FogObscures(a));
@@ -174,7 +175,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				}
 			}
 
-			public IEnumerable<IRenderable> Render(WorldRenderer wr, World world)
+			protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world)
 			{
 				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 				var tiles = world.Map.FindTilesInCircle(xy, range);
@@ -183,13 +184,13 @@ namespace OpenRA.Mods.Cnc.Traits
 					yield return new SpriteRenderable(tile, wr.World.Map.CenterOfCell(t), WVec.Zero, -511, palette, 1f, true);
 			}
 
-			public string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
+			protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 			{
 				return ((ChronoshiftPowerInfo)power.Info).SelectionCursor;
 			}
 		}
 
-		class SelectDestination : IOrderGenerator
+		class SelectDestination : OrderGenerator
 		{
 			readonly ChronoshiftPower power;
 			readonly CPos sourceLocation;
@@ -214,7 +215,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				sourceTile = world.Map.Rules.Sequences.GetSequence(info.OverlaySpriteGroup, info.SourceTileSequence).GetSprite(0);
 			}
 
-			public IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
+			protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
 			{
 				if (mi.Button == MouseButton.Right)
 				{
@@ -241,14 +242,14 @@ namespace OpenRA.Mods.Cnc.Traits
 					};
 			}
 
-			public void Tick(World world)
+			protected override void Tick(World world)
 			{
 				// Cancel the OG if we can't use the power
 				if (!manager.Powers.ContainsKey(order))
 					world.CancelInputMode();
 			}
 
-			public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
+			protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
 			{
 				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 				var palette = wr.Palette(power.Info.IconPalette);
@@ -289,7 +290,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				}
 			}
 
-			public IEnumerable<IRenderable> Render(WorldRenderer wr, World world)
+			protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world)
 			{
 				var palette = wr.Palette(power.Info.IconPalette);
 
@@ -322,7 +323,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				return canTeleport;
 			}
 
-			public string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
+			protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 			{
 				var powerInfo = (ChronoshiftPowerInfo)power.Info;
 				return IsValidTarget(cell) ? powerInfo.TargetCursor : powerInfo.TargetBlockedCursor;

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Activities\WaitForTransport.cs" />
     <Compile Include="ActorExts.cs" />
     <Compile Include="AIUtils.cs" />
+    <Compile Include="Orders\OrderGenerator.cs" />
     <Compile Include="TargetExtensions.cs" />
     <Compile Include="Traits\BotModules\Squads\AttackOrFleeFuzzy.cs" />
     <Compile Include="Traits\BotModules\BotModuleLogic\BaseBuilderQueueManager.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -330,6 +330,7 @@
     <Compile Include="Traits\Conditions\GrantExternalConditionToCrusher.cs" />
     <Compile Include="Traits\Conditions\GrantRandomCondition.cs" />
     <Compile Include="Traits\Contrail.cs" />
+    <Compile Include="Traits\SupportPowers\SelectDirectionalTarget.cs" />
     <Compile Include="Traits\TemporaryOwnerManager.cs" />
     <Compile Include="Traits\TooltipDescription.cs" />
     <Compile Include="Traits\Health.cs" />

--- a/OpenRA.Mods.Common/Orders/BeaconOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/BeaconOrderGenerator.cs
@@ -15,9 +15,9 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Orders
 {
-	public class BeaconOrderGenerator : IOrderGenerator
+	public class BeaconOrderGenerator : OrderGenerator
 	{
-		public IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			world.CancelInputMode();
 
@@ -25,10 +25,10 @@ namespace OpenRA.Mods.Common.Orders
 				yield return new Order("PlaceBeacon", world.LocalPlayer.PlayerActor, Target.FromCell(world, cell), false) { SuppressVisualFeedback = true };
 		}
 
-		public virtual void Tick(World world) { }
-		public IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
-		public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
-		public string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		protected override void Tick(World world) { }
+		protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
+		protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
+		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			return "ability";
 		}

--- a/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
@@ -16,7 +16,7 @@ using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.Common.Orders
 {
-	public abstract class GlobalButtonOrderGenerator<T> : IOrderGenerator
+	public abstract class GlobalButtonOrderGenerator<T> : OrderGenerator
 	{
 		string order;
 
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Orders
 			this.order = order;
 		}
 
-		public IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			if (mi.Button == MouseButton.Right)
 				world.CancelInputMode();
@@ -54,17 +54,17 @@ namespace OpenRA.Mods.Common.Orders
 			}
 		}
 
-		public void Tick(World world)
+		protected override void Tick(World world)
 		{
 			if (world.LocalPlayer != null &&
 				world.LocalPlayer.WinState != WinState.Undefined)
 				world.CancelInputMode();
 		}
 
-		public IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
-		public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
+		protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
+		protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
 
-		public abstract string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi);
+		protected abstract override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi);
 	}
 
 	public class PowerDownOrderGenerator : GlobalButtonOrderGenerator<ToggleConditionOnOrder>
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.Orders
 			return !t.IsTraitDisabled && !t.IsTraitPaused;
 		}
 
-		public override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			mi.Button = MouseButton.Left;
 			return OrderInner(world, mi).Any() ? "powerdown" : "powerdown-blocked";
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Orders
 	{
 		public SellOrderGenerator() : base("Sell") { }
 
-		public override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			mi.Button = MouseButton.Left;
 

--- a/OpenRA.Mods.Common/Orders/OrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/OrderGenerator.cs
@@ -1,0 +1,39 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+
+namespace OpenRA.Mods.Common.Orders
+{
+	public abstract class OrderGenerator : IOrderGenerator
+	{
+		public IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		{
+			if ((mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Down) || (mi.Button == MouseButton.Right && mi.Event == MouseInputEvent.Up))
+				return OrderInner(world, cell, worldPixel, mi);
+
+			return Enumerable.Empty<Order>();
+		}
+
+		void IOrderGenerator.Tick(World world) { Tick(world); }
+		IEnumerable<IRenderable> IOrderGenerator.Render(WorldRenderer wr, World world) { return Render(wr, world); }
+		IEnumerable<IRenderable> IOrderGenerator.RenderAboveShroud(WorldRenderer wr, World world) { return RenderAboveShroud(wr, world); }
+		string IOrderGenerator.GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi) { return GetCursor(world, cell, worldPixel, mi); }
+
+		protected abstract void Tick(World world);
+		protected abstract IEnumerable<IRenderable> Render(WorldRenderer wr, World world);
+		protected abstract IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world);
+		protected abstract string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi);
+		protected abstract IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi);
+	}
+}

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Orders
 {
-	public class PlaceBuildingOrderGenerator : IOrderGenerator
+	public class PlaceBuildingOrderGenerator : OrderGenerator
 	{
 		[Flags]
 		enum CellType { Valid = 0, Invalid = 1, LineBuild = 2 }
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Orders
 			return cell;
 		}
 
-		public IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			if (mi.Button == MouseButton.Right)
 				world.CancelInputMode();
@@ -147,7 +147,7 @@ namespace OpenRA.Mods.Common.Orders
 			}
 		}
 
-		public void Tick(World world)
+		protected override void Tick(World world)
 		{
 			if (queue.AllQueued().All(i => !i.Done || i.Item != actorInfo.Name))
 				world.CancelInputMode();
@@ -169,8 +169,8 @@ namespace OpenRA.Mods.Common.Orders
 			return host.TraitsImplementing<Pluggable>().Any(p => location + p.Info.Offset == cell && p.AcceptsPlug(host, plug.Type));
 		}
 
-		public IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
-		public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
+		protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
+		protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
 		{
 			var topLeft = viewport.ViewToWorld(Viewport.LastMousePos + topLeftScreenOffset);
 			var centerPosition = world.Map.CenterOfCell(topLeft) + centerOffset;
@@ -250,7 +250,7 @@ namespace OpenRA.Mods.Common.Orders
 			}
 		}
 
-		public string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi) { return "default"; }
+		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi) { return "default"; }
 
 		IEnumerable<Order> ClearBlockersOrders(World world, CPos topLeft)
 		{

--- a/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
@@ -17,9 +17,9 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Orders
 {
-	public class RepairOrderGenerator : IOrderGenerator
+	public class RepairOrderGenerator : OrderGenerator
 	{
-		public IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			if (mi.Button == MouseButton.Right)
 				world.CancelInputMode();
@@ -73,17 +73,17 @@ namespace OpenRA.Mods.Common.Orders
 			yield return new Order(orderId, underCursor, Target.FromActor(repairBuilding), false) { VisualFeedbackTarget = Target.FromActor(underCursor) };
 		}
 
-		public void Tick(World world)
+		protected override void Tick(World world)
 		{
 			if (world.LocalPlayer != null &&
 				world.LocalPlayer.WinState != WinState.Undefined)
 				world.CancelInputMode();
 		}
 
-		public IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
-		public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
+		protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
+		protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
 
-		public string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			mi.Button = MouseButton.Left;
 			return OrderInner(world, mi).Any()

--- a/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
@@ -36,6 +36,12 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Amount of time to keep the camera alive after the aircraft have finished attacking")]
 		public readonly int CameraRemoveDelay = 25;
 
+		[Desc("Placeholder cursor animation for the target cursor when the real cursor is invisible.")]
+		public readonly string TargetPlaceholderCursorAnimation = null;
+
+		[Desc("Animation used to render the direction arrows.")]
+		public readonly string DirectionArrowAnimation = null;
+
 		[Desc("Weapon range offset to apply during the beacon clock calculation")]
 		public readonly WDist BeaconDistanceOffset = WDist.FromCells(6);
 
@@ -52,11 +58,19 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 		}
 
+		public override void SelectTarget(Actor self, string order, SupportPowerManager manager)
+		{
+			Game.Sound.PlayToPlayer(SoundType.UI, manager.Self.Owner, Info.SelectTargetSound);
+			Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech",
+				Info.SelectTargetSpeechNotification, self.Owner.Faction.InternalName);
+
+			self.World.OrderGenerator = new SelectDirectionalTarget(self.World, order, manager, Info.Cursor, info.TargetPlaceholderCursorAnimation, info.DirectionArrowAnimation);
+		}
+
 		public override void Activate(Actor self, Order order, SupportPowerManager manager)
 		{
 			base.Activate(self, order, manager);
-
-			SendAirstrike(self, order.Target.CenterPosition);
+			SendAirstrike(self, order.Target.CenterPosition, order.ExtraData == uint.MaxValue, (int)order.ExtraData);
 		}
 
 		public void SendAirstrike(Actor self, WPos target, bool randomize = true, int attackFacing = 0)

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -101,7 +102,7 @@ namespace OpenRA.Mods.Common.Traits
 			});
 		}
 
-		class SelectConditionTarget : IOrderGenerator
+		class SelectConditionTarget : OrderGenerator
 		{
 			readonly GrantExternalConditionPower power;
 			readonly int range;
@@ -122,21 +123,21 @@ namespace OpenRA.Mods.Common.Traits
 				tile = world.Map.Rules.Sequences.GetSequence("overlay", "target-select").GetSprite(0);
 			}
 
-			public IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
+			protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
 			{
 				world.CancelInputMode();
 				if (mi.Button == MouseButton.Left && power.UnitsInRange(cell).Any())
 					yield return new Order(order, manager.Self, Target.FromCell(world, cell), false) { SuppressVisualFeedback = true };
 			}
 
-			public void Tick(World world)
+			protected override void Tick(World world)
 			{
 				// Cancel the OG if we can't use the power
 				if (!manager.Powers.ContainsKey(order))
 					world.CancelInputMode();
 			}
 
-			public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
+			protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
 			{
 				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 				foreach (var unit in power.UnitsInRange(xy))
@@ -146,7 +147,7 @@ namespace OpenRA.Mods.Common.Traits
 				}
 			}
 
-			public IEnumerable<IRenderable> Render(WorldRenderer wr, World world)
+			protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world)
 			{
 				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 				var pal = wr.Palette(TileSet.TerrainPaletteInternalName);
@@ -155,7 +156,7 @@ namespace OpenRA.Mods.Common.Traits
 					yield return new SpriteRenderable(tile, wr.World.Map.CenterOfCell(t), WVec.Zero, -511, pal, 1f, true);
 			}
 
-			public string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
+			protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 			{
 				return power.UnitsInRange(cell).Any() ? power.info.Cursor : power.info.BlockedCursor;
 			}

--- a/OpenRA.Mods.Common/Traits/SupportPowers/ParatroopersPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/ParatroopersPower.cs
@@ -50,6 +50,12 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Amount of time (in ticks) to keep the camera alive while the passengers drop.")]
 		public readonly int CameraRemoveDelay = 85;
 
+		[Desc("Placeholder cursor animation for the target cursor when the real cursor is invisible.")]
+		public readonly string TargetPlaceholderCursorAnimation = null;
+
+		[Desc("Animation used to render the direction arrows.")]
+		public readonly string DirectionArrowAnimation = null;
+
 		[Desc("Weapon range offset to apply during the beacon clock calculation.")]
 		public readonly WDist BeaconDistanceOffset = WDist.FromCells(4);
 
@@ -66,11 +72,20 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 		}
 
+		public override void SelectTarget(Actor self, string order, SupportPowerManager manager)
+		{
+			Game.Sound.PlayToPlayer(SoundType.UI, manager.Self.Owner, Info.SelectTargetSound);
+			Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech",
+				Info.SelectTargetSpeechNotification, self.Owner.Faction.InternalName);
+
+			self.World.OrderGenerator = new SelectDirectionalTarget(self.World, order, manager, Info.Cursor, info.TargetPlaceholderCursorAnimation, info.DirectionArrowAnimation);
+		}
+
 		public override void Activate(Actor self, Order order, SupportPowerManager manager)
 		{
 			base.Activate(self, order, manager);
 
-			SendParatroopers(self, order.Target.CenterPosition);
+			SendParatroopers(self, order.Target.CenterPosition, order.ExtraData == uint.MaxValue, (int)order.ExtraData);
 		}
 
 		public Actor[] SendParatroopers(Actor self, WPos target, bool randomize = true, int dropFacing = 0)

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SelectDirectionalTarget.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SelectDirectionalTarget.cs
@@ -1,0 +1,186 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public class SelectDirectionalTarget : IOrderGenerator
+	{
+		readonly string order;
+		readonly SupportPowerManager manager;
+		readonly string cursor;
+		readonly Animation targetCursor;
+
+		readonly string[] arrows = { "arrow-t", "arrow-tl", "arrow-l", "arrow-bl", "arrow-b", "arrow-br", "arrow-r", "arrow-tr" };
+		readonly Arrow[] directionArrows;
+
+		CPos targetCell;
+		int2 location;
+		int2 dragLocation;
+		bool beginDrag;
+		bool dragStarted;
+		Arrow currentArrow;
+
+		public SelectDirectionalTarget(World world, string order, SupportPowerManager manager, string cursor, string targetPlaceholderCursorAnimation,
+			string directionArrowAnimation)
+		{
+			this.order = order;
+			this.manager = manager;
+			this.cursor = cursor;
+
+			targetCursor = new Animation(world, targetPlaceholderCursorAnimation);
+			targetCursor.PlayRepeating("cursor");
+
+			for (var i = 0; i < Game.Cursor.Frame; i++)
+				targetCursor.Tick();
+
+			directionArrows = LoadArrows(directionArrowAnimation, world, arrows.Length);
+		}
+
+		IEnumerable<Order> IOrderGenerator.Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		{
+			if (mi.Button == MouseButton.Right)
+			{
+				world.CancelInputMode();
+				yield break;
+			}
+
+			if (mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Down)
+			{
+				if (!beginDrag)
+				{
+					targetCell = cell;
+					location = mi.Location;
+					beginDrag = true;
+				}
+
+				yield break;
+			}
+
+			if (mi.Event == MouseInputEvent.Move)
+			{
+				if (beginDrag)
+				{
+					dragLocation = mi.Location;
+					var angle = AngleBetween(location, dragLocation);
+					currentArrow = GetArrow(angle);
+					dragStarted = true;
+
+					yield break;
+				}
+			}
+
+			if (mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Up)
+			{
+				yield return new Order(order, manager.Self, Target.FromCell(manager.Self.World, targetCell), false)
+				{
+					SuppressVisualFeedback = true,
+					ExtraData = IsOutsideDragZone ? (uint)currentArrow.Direction.Facing : uint.MaxValue
+				};
+
+				world.CancelInputMode();
+			}
+		}
+
+		void IOrderGenerator.Tick(World world)
+		{
+			targetCursor.Tick();
+
+			// Cancel the OG if we can't use the power
+			if (!manager.Powers.ContainsKey(order))
+				world.CancelInputMode();
+		}
+
+		bool IsOutsideDragZone
+		{
+			get { return dragStarted && (dragLocation - location).Length > 20; }
+		}
+
+		IEnumerable<IRenderable> IOrderGenerator.Render(WorldRenderer wr, World world) { yield break; }
+
+		IEnumerable<IRenderable> IOrderGenerator.RenderAboveShroud(WorldRenderer wr, World world)
+		{
+			if (!beginDrag)
+				return Enumerable.Empty<IRenderable>();
+
+			var palette = wr.Palette("chrome");
+			var worldPx = wr.Viewport.ViewToWorldPx(location);
+			var worldPos = wr.ProjectedPosition(worldPx);
+			var renderables = new List<IRenderable>(targetCursor.Render(worldPos, WVec.Zero, -511, palette, 1 / wr.Viewport.Zoom));
+
+			if (IsOutsideDragZone)
+				renderables.Add(new SpriteRenderable(currentArrow.Sprite, worldPos, WVec.Zero, -511, palette, 1 / wr.Viewport.Zoom, true));
+
+			return renderables;
+		}
+
+		string IOrderGenerator.GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi) { return beginDrag ? "invisible" : cursor; }
+
+		// Starting at (0, -1) and rotating in CCW
+		static double AngleBetween(int2 p1, int2 p2)
+		{
+			var radian = Math.Atan2(p2.Y - p1.Y, p2.X - p1.X);
+			var d = radian * (180 / Math.PI);
+			if (d < 0.0)
+				d += 360.0;
+			var angle = 270.0 - d;
+			if (angle < 0)
+				angle += 360.0;
+
+			return angle;
+		}
+
+		Arrow GetArrow(double degree)
+		{
+			var arrow = directionArrows.FirstOrDefault(d => d.EndAngle >= degree);
+			return arrow ?? directionArrows[0];
+		}
+
+		Arrow[] LoadArrows(string cursorAnimation, World world, int noOfDividingPoints)
+		{
+			var points = new Arrow[noOfDividingPoints];
+			var partAngle = 360 / noOfDividingPoints;
+			var i1 = partAngle / 2d;
+
+			for (var i = 0; i < noOfDividingPoints; i++)
+			{
+				var sprite = world.Map.Rules.Sequences.GetSequence(cursorAnimation, arrows[i]).GetSprite(0);
+
+				var angle = i * partAngle;
+				var direction = WAngle.FromDegrees(angle);
+				var endAngle = angle + i1;
+
+				points[i] = new Arrow(sprite, endAngle, direction);
+			}
+
+			return points;
+		}
+
+		class Arrow
+		{
+			public Sprite Sprite { get; private set; }
+			public double EndAngle { get; private set; }
+			public WAngle Direction { get; private set; }
+
+			public Arrow(Sprite sprite, double endAngle, WAngle direction)
+			{
+				Sprite = sprite;
+				EndAngle = endAngle;
+				Direction = direction;
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -258,7 +259,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class SelectGenericPowerTarget : IOrderGenerator
+	public class SelectGenericPowerTarget : OrderGenerator
 	{
 		readonly SupportPowerManager manager;
 		readonly string order;
@@ -279,23 +280,23 @@ namespace OpenRA.Mods.Common.Traits
 			expectedButton = button;
 		}
 
-		public IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			world.CancelInputMode();
 			if (mi.Button == expectedButton && world.Map.Contains(cell))
 				yield return new Order(order, manager.Self, Target.FromCell(world, cell), false) { SuppressVisualFeedback = true };
 		}
 
-		public virtual void Tick(World world)
+		protected override void Tick(World world)
 		{
 			// Cancel the OG if we can't use the power
 			if (!manager.Powers.ContainsKey(order))
 				world.CancelInputMode();
 		}
 
-		public IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
-		public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
-		public string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
+		protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
+		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			return world.Map.Contains(cell) ? cursor : "generic-blocked";
 		}

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -82,6 +82,14 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var multiClick = mi.MultiTapCount >= 2;
 
+			if (!(World.OrderGenerator is UnitOrderGenerator))
+			{
+				ApplyOrders(World, mi);
+				isDragging = false;
+				YieldMouseFocus(mi);
+				return true;
+			}
+
 			if (mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Down)
 			{
 				if (!TakeMouseFocus(mi))
@@ -89,15 +97,6 @@ namespace OpenRA.Mods.Common.Widgets
 
 				dragStart = mousePos;
 				isDragging = true;
-
-				// Place buildings, use support powers, and other non-unit things
-				if (!(World.OrderGenerator is UnitOrderGenerator))
-				{
-					ApplyOrders(World, mi);
-					isDragging = false;
-					YieldMouseFocus(mi);
-					return true;
-				}
 			}
 
 			if (mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Up)

--- a/mods/cnc/cursors.yaml
+++ b/mods/cnc/cursors.yaml
@@ -136,6 +136,8 @@ Cursors:
 		sell-vehicle:
 			Start: 154
 			Length: 24
+		invisible:
+			Start: 28
 	mouse3.shp: cursor
 		default:
 			Start: 0

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -628,6 +628,8 @@ HQ:
 		ArrowSequence: arrow
 		ClockSequence: clock
 		CircleSequence: circles
+		TargetPlaceholderCursorAnimation: airstriketarget
+		DirectionArrowAnimation: airstrikedirection
 	SupportPowerChargeBar:
 	Power:
 		Amount: -50

--- a/mods/cnc/sequences/misc.yaml
+++ b/mods/cnc/sequences/misc.yaml
@@ -436,3 +436,47 @@ smokland:
 		Length: 32
 		Tick: 120
 		ZOffset: 1023
+
+airstriketarget:
+	cursor: mouse2
+		Start: 88
+		Length: 8
+		Tick: 80
+
+airstrikedirection:
+	arrow-t: mouse2
+		Start: 1
+		Y: -12
+		Offset: 0, -15, 0
+	arrow-tr: mouse2
+		Start: 2
+		X: 14
+		Y: -12
+		Offset: 7, -7, 0
+	arrow-r: mouse2
+		Start: 3
+		X: 14
+		Offset: 12, 0, 0
+	arrow-br: mouse2
+		Start: 4
+		X: 14
+		Y: 11
+		Offset: 7, 7, 0
+	arrow-b: mouse2
+		Start: 5
+		Y: 11
+		Offset: 0, 15, 0
+	arrow-bl: mouse2
+		Start: 6
+		X: -15
+		Y: 11
+		Offset: -7, 7, 0
+	arrow-l: mouse2
+		Start: 7
+		X: -15
+		Offset: -12, 0, 0
+	arrow-tl: mouse2
+		Start: 8
+		X: -15
+		Y: -12
+		Offset: -7, -7, 0

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -8,14 +8,6 @@ Container@PLAYER_WIDGETS:
 			X: 10
 			Y: 10
 			Children:
-				SupportPowers@SUPPORT_PALETTE:
-					IconSize: 62, 46
-					IconSpriteOffset: -1, -1
-					TooltipContainer: TOOLTIP_CONTAINER
-					ReadyText: READY
-					HoldText: ON HOLD
-					HotkeyPrefix: SupportPower
-					HotkeyCount: 6
 				Container@PALETTE_FOREGROUND:
 					Children:
 						Image@ICON_TEMPLATE:
@@ -24,9 +16,18 @@ Container@PLAYER_WIDGETS:
 							Y: 0 - 2
 							Width: 62
 							Height: 46
+							ClickThrough: false
 							IgnoreMouseOver: true
 							ImageCollection: sidebar
 							ImageName: background-supportoverlay
+				SupportPowers@SUPPORT_PALETTE:
+					IconSize: 62, 46
+					IconSpriteOffset: -1, -1
+					TooltipContainer: TOOLTIP_CONTAINER
+					ReadyText: READY
+					HoldText: ON HOLD
+					HotkeyPrefix: SupportPower
+					HotkeyCount: 6
 		SupportPowerTimer@SUPPORT_POWER_TIMER:
 			X: 80
 			Y: 10

--- a/mods/ra/cursors.yaml
+++ b/mods/ra/cursors.yaml
@@ -200,6 +200,8 @@ Cursors:
 		sell2:
 			Start: 148
 			Length: 12
+		invisible:
+			Start: 34
 	nopower.shp: cursor
 		powerdown-blocked:
 			Start: 0

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1461,6 +1461,8 @@ AFLD:
 		ArrowSequence: arrow
 		ClockSequence: clock
 		CircleSequence: circles
+		TargetPlaceholderCursorAnimation: paratarget
+		DirectionArrowAnimation: paradirection
 	ParatroopersPower@paratroopers:
 		OrderName: SovietParatroopers
 		Prerequisites: aircraft.soviet
@@ -1479,6 +1481,8 @@ AFLD:
 		ArrowSequence: arrow
 		ClockSequence: clock
 		CircleSequence: circles
+		TargetPlaceholderCursorAnimation: paratarget
+		DirectionArrowAnimation: paradirection
 	AirstrikePower@parabombs:
 		OrderName: UkraineParabombs
 		Prerequisites: aircraft.ukraine
@@ -1498,6 +1502,8 @@ AFLD:
 		ArrowSequence: arrow
 		ClockSequence: clock
 		CircleSequence: circles
+		TargetPlaceholderCursorAnimation: paratarget
+		DirectionArrowAnimation: paradirection
 	ProductionBar:
 		ProductionType: Aircraft
 	SupportPowerChargeBar:

--- a/mods/ra/sequences/misc.yaml
+++ b/mods/ra/sequences/misc.yaml
@@ -627,3 +627,47 @@ ctflag:
 	bib: mbGAP
 		Length: *
 		UseTilesetExtension: true
+
+paratarget:
+	cursor: mouse
+		Start: 82
+		Length: 8
+		Tick: 80
+
+paradirection:
+	arrow-t: mouse
+		Start: 1
+		Y: -7
+		Offset: 0, -19, 0
+	arrow-tr: mouse
+		Start: 2
+		X: 6
+		Y: -5
+		Offset: 15, -15, 0
+	arrow-r: mouse
+		Start: 3
+		X: 7
+		Offset: 19, 0, 0
+	arrow-br: mouse
+		Start: 4
+		X: 6
+		Y: 5
+		Offset: 15, 15, 0
+	arrow-b: mouse
+		Start: 5
+		Y: 7
+		Offset: 0, 19, 0
+	arrow-bl: mouse
+		Start: 6
+		X: -6
+		Y: 5
+		Offset: -15, 15, 0
+	arrow-l: mouse
+		Start: 7
+		X: -8
+		Offset: -19, 0, 0
+	arrow-tl: mouse
+		Start: 8
+		X: -6
+		y: 5
+		Offset: -15, -15, 0


### PR DESCRIPTION
This PR will update the WorldInteractionControllerWidget with support for drag a direction that could be used for setting the direction for AirStrike, Parabombs and similar stuff. It also updated the AirStrike Power to use this direction.

Fixes #4873

**Open discussion around** #14181
One idea I have is to make the plane spawn equal distance from the target location regardless of the location of the map. Problem is to make it look good with when it spawns inside the map boundaries. I tested a bit with making the plane approaching from higher heights, but I'm not sure if its the best way to do it.
