### PR TITLE
Report custom map rule errors in the lint output.

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -215,6 +215,7 @@ namespace OpenRA
 
 		public Ruleset Rules { get; private set; }
 		public bool InvalidCustomRules { get; private set; }
+		public Exception InvalidCustomRulesException { get; private set; }
 
 		/// <summary>
 		/// The top-left of the playable area in projected world coordinates
@@ -405,6 +406,7 @@ namespace OpenRA
 			{
 				Log.Write("debug", "Failed to load rules for {0} with error {1}", Title, e);
 				InvalidCustomRules = true;
+				InvalidCustomRulesException = e;
 				Rules = Ruleset.LoadDefaultsForTileSet(modData, Tileset);
 			}
 

--- a/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
+++ b/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
@@ -31,9 +31,6 @@ namespace OpenRA.Mods.Common.Lint
 
 			if (!map.Categories.Any())
 				emitError("Map does not define any categories.");
-
-			if (map.InvalidCustomRules)
-				emitError("Map contains invalid custom rules.");
 		}
 	}
 }

--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -87,6 +87,14 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				{
 					Console.WriteLine("Testing map: {0}".F(testMap.Title));
 
+					// Lint tests can't be trusted if the map rules are bogus
+					// so report that problem then skip the tests
+					if (testMap.InvalidCustomRules)
+					{
+						EmitError(testMap.InvalidCustomRulesException.ToString());
+						continue;
+					}
+
 					// Run all rule checks on the map if it defines custom rules.
 					if (testMap.RuleDefinitions != null || testMap.VoiceDefinitions != null || testMap.WeaponDefinitions != null)
 						CheckRules(modData, testMap.Rules, testMap);


### PR DESCRIPTION
This PR exposes parse errors in custom map rules directly to the lint output instead of quietly falling back to the default mod rules and then failing other unrelated tests.

Fixes #14030.

Before:
```
Testing map: Fort Lonestar
OpenRA.Utility(1,1): Error: Map contains invalid custom rules.
OpenRA.Utility(1,1): Error: Actor sniper.soviets is not defined by any rule.
OpenRA.Utility(1,1): Error: Actor sniper.soviets is not defined by any rule.
OpenRA.Utility(1,1): Error: Actor sniper.soviets is not defined by any rule.
OpenRA.Utility(1,1): Error: Actor sniper.soviets is not defined by any rule.
OpenRA.Utility(1,1): Error: Actor sniper.soviets is not defined by any rule.
OpenRA.Utility(1,1): Error: Actor sniper.soviets is not defined by any rule.
OpenRA.Utility(1,1): Error: Actor sniper.soviets is not defined by any rule.
OpenRA.Utility(1,1): Error: Actor sniper.soviets is not defined by any rule.
OpenRA.Utility(1,1): Error: Actor sniper.soviets is not defined by any rule.
OpenRA.Utility(1,1): Error: Actor sniper.soviets is not defined by any rule.
OpenRA.Utility(1,1): Error: Actor sniper.soviets is not defined by any rule.
OpenRA.Utility(1,1): Error: Actor sniper.soviets is not defined by any rule.
Errors: 13
```

After:
```
Testing map: Fort Lonestar
OpenRA.Utility(1,1): Error: System.AggregateException: One or more errors occurred. ---> OpenRA.YamlException: Actor type world: Junk value `JunkValue` on trait node BrokenTrait
  at OpenRA.ActorInfo..ctor (OpenRA.ObjectCreator creator, System.String name, OpenRA.MiniYaml node) [0x000d5] in <c69711e2b30a429c9315af125e46b55c>:0 
  at OpenRA.Ruleset+<Load>c__AnonStorey2.<>m__1 (OpenRA.MiniYamlNode k) [0x00016] in <c69711e2b30a429c9315af125e46b55c>:0 
  at OpenRA.Exts.ToDictionaryWithConflictLog[TSource,TKey,TElement] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] keySelector, System.Func`2[T,TResult] elementSelector, System.String debugName, System.Func`2[T,TResult] logKey, System.Func`2[T,TResult] logValue) [0x00071] in <c69711e2b30a429c9315af125e46b55c>:0 
  at OpenRA.Ruleset.MergeOrDefault[T] (System.String name, OpenRA.FileSystem.IReadOnlyFileSystem fileSystem, System.Collections.Generic.IEnumerable`1[T] files, OpenRA.MiniYaml additional, OpenRA.IReadOnlyDictionary`2[TKey,TValue] defaults, System.Func`2[T,TResult] makeObject, System.Func`2[T,TResult] filterNode) [0x0006a] in <c69711e2b30a429c9315af125e46b55c>:0 
  at OpenRA.Ruleset+<Load>c__AnonStorey2.<>m__0 () [0x00001] in <c69711e2b30a429c9315af125e46b55c>:0 
  at System.Threading.Tasks.Task.InnerInvoke () [0x0000f] in <bb7b695b8c6246b3ac1646577aea7650>:0 
  at System.Threading.Tasks.Task.Execute () [0x00010] in <bb7b695b8c6246b3ac1646577aea7650>:0 
   --- End of inner exception stack trace ---
  at System.Threading.Tasks.Task.ThrowIfExceptional (System.Boolean includeTaskCanceledExceptions) [0x00011] in <bb7b695b8c6246b3ac1646577aea7650>:0 
  at System.Threading.Tasks.Task.Wait (System.Int32 millisecondsTimeout, System.Threading.CancellationToken cancellationToken) [0x00043] in <bb7b695b8c6246b3ac1646577aea7650>:0 
  at System.Threading.Tasks.Task.Wait (System.Int32 millisecondsTimeout) [0x00000] in <bb7b695b8c6246b3ac1646577aea7650>:0 
  at OpenRA.Ruleset.Load (OpenRA.ModData modData, OpenRA.FileSystem.IReadOnlyFileSystem fileSystem, System.String tileSet, OpenRA.MiniYaml mapRules, OpenRA.MiniYaml mapWeapons, OpenRA.MiniYaml mapVoices, OpenRA.MiniYaml mapNotifications, OpenRA.MiniYaml mapMusic, OpenRA.MiniYaml mapSequences, OpenRA.MiniYaml mapModelSequences) [0x000c2] in <c69711e2b30a429c9315af125e46b55c>:0 
  at OpenRA.Map.PostInit () [0x00002] in <c69711e2b30a429c9315af125e46b55c>:0 
---> (Inner Exception #0) OpenRA.YamlException: Actor type world: Junk value `JunkValue` on trait node BrokenTrait
  at OpenRA.ActorInfo..ctor (OpenRA.ObjectCreator creator, System.String name, OpenRA.MiniYaml node) [0x000d5] in <c69711e2b30a429c9315af125e46b55c>:0 
  at OpenRA.Ruleset+<Load>c__AnonStorey2.<>m__1 (OpenRA.MiniYamlNode k) [0x00016] in <c69711e2b30a429c9315af125e46b55c>:0 
  at OpenRA.Exts.ToDictionaryWithConflictLog[TSource,TKey,TElement] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] keySelector, System.Func`2[T,TResult] elementSelector, System.String debugName, System.Func`2[T,TResult] logKey, System.Func`2[T,TResult] logValue) [0x00071] in <c69711e2b30a429c9315af125e46b55c>:0 
  at OpenRA.Ruleset.MergeOrDefault[T] (System.String name, OpenRA.FileSystem.IReadOnlyFileSystem fileSystem, System.Collections.Generic.IEnumerable`1[T] files, OpenRA.MiniYaml additional, OpenRA.IReadOnlyDictionary`2[TKey,TValue] defaults, System.Func`2[T,TResult] makeObject, System.Func`2[T,TResult] filterNode) [0x0006a] in <c69711e2b30a429c9315af125e46b55c>:0 
  at OpenRA.Ruleset+<Load>c__AnonStorey2.<>m__0 () [0x00001] in <c69711e2b30a429c9315af125e46b55c>:0 
  at System.Threading.Tasks.Task.InnerInvoke () [0x0000f] in <bb7b695b8c6246b3ac1646577aea7650>:0 
  at System.Threading.Tasks.Task.Execute () [0x00010] in <bb7b695b8c6246b3ac1646577aea7650>:0 <---

Errors: 1
```

Testcase: Break the rules in a custom map in an arbitrary way, then run the linter with and without this PR.