### PR TITLE
Fix or remove bogus yaml definitions from the default mods.

### DIFF
--- a/mods/cnc/maps/nod03b/rules.yaml
+++ b/mods/cnc/maps/nod03b/rules.yaml
@@ -18,7 +18,7 @@ Player:
 HQ:
 	AirstrikePower:
 		Prerequisites: ~disabled
-	Tooltip:
+	Buildable:
 		Description: Provides an overview of the battlefield.\nRequires power to operate.
 
 CYCL:

--- a/mods/cnc/rules/civilian.yaml
+++ b/mods/cnc/rules/civilian.yaml
@@ -549,6 +549,3 @@ MOEBIUS:
 VICE:
 	Inherits: ^Viceroid
 	AttackWander:
-		WanderMoveRadius: 2
-		MinMoveDelayInTicks: 25
-		MaxMoveDelayInTicks: 45

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -897,17 +897,17 @@
 	Targetable:
 		TargetTypes: Trees
 	WithDamageOverlay@SmallBurn:
-		DamageType: Incendiary
+		DamageTypes: Incendiary
 		Image: burn-s
 		MinimumDamageState: Light
 		MaximumDamageState: Medium
 	WithDamageOverlay@MediumBurn:
-		DamageType: Incendiary
+		DamageTypes: Incendiary
 		Image: burn-m
 		MinimumDamageState: Medium
 		MaximumDamageState: Heavy
 	WithDamageOverlay@LargeBurn:
-		DamageType: Incendiary
+		DamageTypes: Incendiary
 		Image: burn-l
 		MinimumDamageState: Heavy
 		MaximumDamageState: Dead

--- a/mods/cnc/rules/palettes.yaml
+++ b/mods/cnc/rules/palettes.yaml
@@ -99,7 +99,6 @@
 		A: 180
 	ShroudPalette@shroud:
 		Name: shroud
-		Type: Shroud
 	ShroudPalette@fog:
 		Name: fog
 		Fog: true

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -293,7 +293,6 @@ PYLE:
 	ProductionQueue:
 		Type: Infantry.GDI
 		Group: Infantry
-		RequireOwner: false
 		LowPowerSlowdown: 3
 		LimitedAudio: BuildingInProgress
 	ProductionBar:
@@ -339,7 +338,6 @@ HAND:
 	ProductionQueue:
 		Type: Infantry.Nod
 		Group: Infantry
-		RequireOwner: false
 		LowPowerSlowdown: 3
 		LimitedAudio: BuildingInProgress
 	ProductionBar:
@@ -391,7 +389,6 @@ AFLD:
 	ProductionQueue:
 		Type: Vehicle.Nod
 		Group: Vehicle
-		RequireOwner: false
 		LowPowerSlowdown: 3
 		ReadyAudio:
 		LimitedAudio: BuildingInProgress
@@ -444,7 +441,6 @@ WEAP:
 		Produces: Vehicle.GDI
 	ProductionQueue:
 		Type: Vehicle.GDI
-		RequireOwner: false
 		Group: Vehicle
 		LowPowerSlowdown: 3
 		LimitedAudio: BuildingInProgress

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -87,7 +87,6 @@ BIO:
 	ProductionQueue:
 		Type: Biolab
 		Group: Infantry
-		RequireOwner: false
 		LowPowerSlowdown: 3
 		LimitedAudio: BuildingInProgress
 	ProductionBar:

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -143,7 +143,13 @@ MammothMissiles:
 	Report: rocket1.aud
 	ValidTargets: Ground
 	TargetActorCenter: true
+	# Remove default Missile properties
+	-Projectile:
 	Projectile: Bullet
+		Blockable: false
+		Image: DRAGON
+		Shadow: true
+		TrailImage: smokey
 		Inaccuracy: 853
 		LaunchAngle: 62
 		ContrailLength: 10

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -367,7 +367,6 @@
 	Selectable:
 		Priority: 2
 	RevealsShroud:
-		VisibilityType: CenterPosition
 	Targetable:
 		TargetTypes: Ground, C4, Structure
 	HitShape:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -596,7 +596,6 @@ outpost:
 		RequiresCondition: !severe-damaged
 	GrantConditionOnDamageState@STOPDISH:
 		Condition: severe-damaged
-		ValidDamageState: Medium, Heavy, Critical
 	Power:
 		Amount: -125
 	ProvidesPrerequisite@buildingname:
@@ -1130,7 +1129,6 @@ palace:
 		RequiresCondition: !launchpad-damaged && harkonnen
 	GrantConditionOnDamageState@LAUNCHPADDAMAGED:
 		Condition: launchpad-damaged
-		ValidDamageState: Medium, Heavy, Critical
 	ProduceActorPower@fremen:
 		Description: Recruit Fremen
 		LongDesc: Elite infantry unit armed with assault rifles and rockets\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery\n  Special Ability: Invisibility

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -1117,7 +1117,7 @@ palace:
 		LongDesc: Launches an atomic missile at a target location
 		BeginChargeSpeechNotification: DeathHandMissilePrepping
 		EndChargeSpeechNotification: DeathHandMissileReady
-		MissileLaunchDetected: MissileLaunchDetected
+		LaunchSpeechNotification: MissileLaunchDetected
 		MissileWeapon: atomic
 		MissileDelay: 19
 		SpawnOffset: -512,1c171,0

--- a/mods/ra/maps/bomber-john/rules.yaml
+++ b/mods/ra/maps/bomber-john/rules.yaml
@@ -17,6 +17,9 @@ World:
 		TechLevel: unrestricted
 	MPStartLocations:
 		SeparateTeamSpawnsCheckboxVisible: false
+	Locomotor@LIGHTTRACKED:
+		WaitAverage: 1
+		WaitSpread: 1
 
 APWR:
 	Buildable:
@@ -118,8 +121,6 @@ MNLYR:
 		Type: Heavy
 	Mobile:
 		Speed: 128
-		WaitAverage: 1
-		WaitSpread: 1
 		TurnSpeed: 900
 	RevealsShroud:
 		Range: 40c0

--- a/mods/ra/maps/drop-zone-w/rules.yaml
+++ b/mods/ra/maps/drop-zone-w/rules.yaml
@@ -48,9 +48,7 @@ LST:
 		Name: secondary
 		Weapon: M60mg
 	AttackFrontal:
-	WithMuzzleOverlay@PRIMARY:
-	WithMuzzleOverlay@SECONDARY:
-		Armament: secondary
+	WithMuzzleOverlay:
 	MustBeDestroyed:
 		RequiredForShortGame: true
 

--- a/mods/ra/maps/exodus/rules.yaml
+++ b/mods/ra/maps/exodus/rules.yaml
@@ -30,9 +30,8 @@ powerproxy.paratroopers:
 
 HBOX:
 	Buildable:
+		# Invalid targets for YakAttack
 		Prerequisites: ~disabled
-	EditorOnlyTooltip:
-		Description: invalid targets for YakAttack
 
 E7:
 	Buildable:
@@ -182,7 +181,6 @@ GAP:
 
 CAMERA.Large:
 	Inherits: CAMERA
+	# Required for YakAttack to work
 	RevealsShroud:
 		Range: 49c0
-	EditorOnlyTooltip:
-		Description: required for YakAttack to work

--- a/mods/ra/maps/fort-lonestar/weapons.yaml
+++ b/mods/ra/maps/fort-lonestar/weapons.yaml
@@ -148,7 +148,6 @@ SCUD:
 	Range: 7c0
 	ReloadDelay: 280
 	Projectile: Bullet
-		Arm: 10
 		TrailImage: smokey
 		Blockable: false
 		Inaccuracy: 0c426

--- a/mods/ra/rules/decoration.yaml
+++ b/mods/ra/rules/decoration.yaml
@@ -219,6 +219,7 @@ BOXES01:
 		Palette: player
 	Tooltip:
 		Name: Boxes
+	EditorTilesetFilter:
 		Categories: Decoration
 
 BOXES02:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -854,17 +854,17 @@
 	Targetable:
 		TargetTypes: Trees
 	WithDamageOverlay@SmallBurn:
-		DamageType: Incendiary
+		DamageTypes: Incendiary
 		Image: burn-s
 		MinimumDamageState: Light
 		MaximumDamageState: Medium
 	WithDamageOverlay@MediumBurn:
-		DamageType: Incendiary
+		DamageTypes: Incendiary
 		Image: burn-m
 		MinimumDamageState: Medium
 		MaximumDamageState: Heavy
 	WithDamageOverlay@LargeBurn:
-		DamageType: Incendiary
+		DamageTypes: Incendiary
 		Image: burn-l
 		MinimumDamageState: Heavy
 		MaximumDamageState: Dead

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -506,7 +506,6 @@ THF:
 	Passenger:
 		PipType: Yellow
 	Infiltrates:
-		InfiltrateTypes: Cash
 		PlayerExperience: 50
 	Voiced:
 		VoiceSet: ThiefVoice
@@ -706,7 +705,6 @@ Ant:
 	Mobile:
 		Speed: 99
 		TurnSpeed: 12
-		SharesCell: no
 	-Crushable:
 	AutoTarget:
 		ScanRadius: 5

--- a/mods/ra/rules/palettes.yaml
+++ b/mods/ra/rules/palettes.yaml
@@ -85,7 +85,6 @@
 		A: 180
 	ShroudPalette@shroud:
 		Name: shroud
-		Type: Shroud
 	ShroudPalette@fog:
 		Name: fog
 		Fog: true

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -319,7 +319,7 @@ HARV:
 		OwnerType: InternalName
 		EffectiveOwnerFromOwner: true
 	HarvesterHuskModifier:
-		FullActor: HARV.FullHusk
+		FullHuskActor: HARV.FullHusk
 		FullnessThreshold: 50
 	SelfHealing:
 		Step: 100

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -274,7 +274,6 @@ TorpTube:
 		Inaccuracy: 0c614
 		HorizontalRateOfTurn: 15
 		RangeLimit: 9c0
-		LaunchAngle: 120
 		Image: MISSILE
 		TrailImage: smokey
 		ContrailLength: 30

--- a/mods/ts/rules/bridges.yaml
+++ b/mods/ts/rules/bridges.yaml
@@ -3,7 +3,6 @@ CABHUT:
 	Tooltip:
 		Name: Bridge repair hut
 	Building:
-		Adjacent: 0
 		Footprint: x
 		Dimensions: 1, 1
 	BridgeHut:

--- a/mods/ts/rules/critters.yaml
+++ b/mods/ts/rules/critters.yaml
@@ -102,7 +102,7 @@ VISC_LRG:
 		MinMoveDelay: 25
 		MaxMoveDelay: 50
 	WithAttackAnimation:
-		AttackSequence: attack
+		Sequence: attack
 	RenderSprites:
 		Image: vislrg
 
@@ -130,7 +130,7 @@ JFISH:
 		MinMoveDelay: 250
 		MaxMoveDelay: 600
 	WithAttackAnimation:
-		AttackSequence: attack
+		Sequence: attack
 	RenderSprites:
 		Image: floater
 	Selectable:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -109,8 +109,6 @@
 		Sequence: emp-overlay
 		Palette: effect
 		RequiresCondition: empdisable
-		ShowToEnemies: true
-		ZOffset: 512
 	PowerMultiplier@EMPDISABLE:
 		RequiresCondition: empdisable
 		Modifier: 0
@@ -439,7 +437,6 @@
 	RenderSprites:
 		Palette: terraindecoration
 	WithCrateBody:
-		Images: crate
 	EditorTilesetFilter:
 		Categories: System
 	Interactable:
@@ -1112,7 +1109,6 @@
 	Targetable:
 	AlwaysVisible:
 	TunnelEntrance:
-		Dimensions: 3, 3
 	EditorTilesetFilter:
 		Categories: Tunnel
 	Interactable:

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -130,7 +130,7 @@ SMECH:
 	WithFacingSpriteBody:
 		Sequence: stand
 	WithAttackAnimation:
-		AttackSequence: shoot
+		Sequence: shoot
 	WithMoveAnimation:
 		MoveSequence: walk
 	Selectable:

--- a/mods/ts/rules/palettes.yaml
+++ b/mods/ts/rules/palettes.yaml
@@ -132,7 +132,6 @@
 		Alpha: 0.4
 	TSShroudPalette@shroud:
 		Name: shroud
-		Type: Shroud
 	VoxelNormalsPalette@normals:
 		Name: normals
 		Type: TiberianSun

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -147,7 +147,6 @@ LPST:
 		DeploySound: place2.aud
 		UndeploySound: clicky1.aud
 	WithVoxelBody:
-		Image: lpst
 		RequiresCondition: undeployed
 	WithSpriteBody@deployed:
 		RequiresCondition: !undeployed && real-actor

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -374,5 +374,4 @@ EditorWorld:
 	EditorResourceLayer:
 	EditorSelectionLayer:
 		Palette: placebuilding
-		LineBuildSegmentPalette: placelinesegment
 	LoadWidgetAtGameStart:

--- a/mods/ts/weapons/energyweapons.yaml
+++ b/mods/ts/weapons/energyweapons.yaml
@@ -3,9 +3,7 @@
 	Range: 6c0
 	Report: bigggun1.aud
 	Projectile: Railgun
-		Speed: 20c0
 		Duration: 15
-		Width: 80
 		Blockable: true
 		DamageActorsInLine: true
 		BeamColor: 0080FFC8
@@ -30,7 +28,6 @@ LtRail:
 		Range: 0, 32
 		Falloff: 50, 50 # Only does half damage to friendly units
 		Damage: 15000
-		InfDeath: 6
 		AffectsParent: false
 		ValidStances: Ally
 		Versus:

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -88,7 +88,6 @@ MammothTusk:
 		ImpactActors: false
 		Explosions: medium_twlt
 		ImpactSounds: expnew07.aud
-		InvalidImpactTypes: Water
 	-Warhead@3EffWater: CreateEffect
 
 BikeMissile:


### PR DESCRIPTION
This PR removes all of the unused/bogus trait and weapon property definitions in the default mods. See commit descriptions for more info where required, and feel free to use my [throw-on-junk-properties](https://github.com/pchote/OpenRA/tree/throw-on-junk-properties) branch to verify that there are no more hidden cases (except for the AI support power decisions, which will have a PR of their own).

Fixes #15232.
Fixes #15233.
Fixes #15234.
Fixes #15236.
Fixes #15250.
