### PR TITLE
Removed 'Crush' per issue #15246

### DIFF
--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -138,13 +138,6 @@ Repair:
 		Damage: -2000
 		ValidTargets: Repair
 
-Crush:
-	Warhead@1Dam: SpreadDamage
-		Damage: 10000
-		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
-	Warhead@2Eff: CreateEffect
-		ImpactSounds: squishy2.aud
-
 Demolish:
 	Warhead@1Dam: SpreadDamage
 		DamageTypes: DefaultDeath


### PR DESCRIPTION
Ticket 15246 https://github.com/OpenRA/OpenRA/issues/15246 states weapon 'Crush' is not used and should be removed. Removed.