### PR TITLE
Remove redundant overrides

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -45,9 +45,6 @@ TRAN:
 		PipCount: 10
 	SpawnActorOnDeath:
 		Actor: TRAN.Husk
-	Explodes:
-		Weapon: HeliExplode
-		EmptyWeapon: HeliExplode
 	SelectionDecorations:
 	Selectable:
 		DecorationBounds: 41,41
@@ -106,9 +103,6 @@ HELI:
 	WithMuzzleOverlay:
 	SpawnActorOnDeath:
 		Actor: HELI.Husk
-	Explodes:
-		Weapon: HeliExplode
-		EmptyWeapon: HeliExplode
 	SelectionDecorations:
 	ReloadAmmoPool:
 		Delay: 40
@@ -158,9 +152,6 @@ ORCA:
 		AmmoCondition: ammo
 	SpawnActorOnDeath:
 		Actor: ORCA.Husk
-	Explodes:
-		Weapon: HeliExplode
-		EmptyWeapon: HeliExplode
 	WithMoveAnimation:
 		MoveSequence: move
 	SelectionDecorations:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -968,7 +968,6 @@ SBAG:
 	Armor:
 		Type: Light
 	LineBuild:
-		Range: 8
 		NodeTypes: sandbag
 	LineBuildNode:
 		Types: sandbag
@@ -991,7 +990,6 @@ CYCL:
 	Armor:
 		Type: Light
 	LineBuild:
-		Range: 8
 		NodeTypes: chain
 	LineBuildNode:
 		Types: chain
@@ -1024,7 +1022,6 @@ BRIK:
 	SoundOnDamageTransition:
 		DestroyedSounds: crumble.aud
 	LineBuild:
-		Range: 8
 		NodeTypes: concrete
 	LineBuildNode:
 		Types: concrete

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -623,7 +623,6 @@ STNK:
 	AutoTarget:
 		InitialStance: HoldFire
 		InitialStanceAI: ReturnFire
-	Targetable:
 	SpawnActorOnDeath:
 		Actor: STNK.Husk
 		OwnerType: InternalName

--- a/mods/cnc/weapons/explosions.yaml
+++ b/mods/cnc/weapons/explosions.yaml
@@ -43,9 +43,7 @@ HeliCrash:
 		Damage: 10000
 
 HeliExplode:
-	Warhead@1Dam: SpreadDamage
-		DamageTypes: ExplosionDeath
-	Warhead@2Eff: CreateEffect
+	Warhead@1Eff: CreateEffect
 		Explosions: small_building
 		ImpactSounds: xplos.aud
 

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -125,11 +125,9 @@ MammothMissiles:
 			Heavy: 44
 	Warhead@3Eff: CreateEffect
 		Explosions: small_poof
-		ImpactSounds: xplos.aud
 		ValidTargets: Ground, Water
 	Warhead@4EffAir: CreateEffect
 		Explosions: small_building
-		ImpactSounds: xplos.aud
 		ImpactActors: false
 		ValidTargets: Air
 
@@ -164,7 +162,6 @@ MammothMissiles:
 			Heavy: 48
 	Warhead@3Eff: CreateEffect
 		Explosions: med_frag
-		ImpactSounds: xplos.aud
 
 227mm.stnk:
 	Inherits: ^MissileWeapon
@@ -209,11 +206,9 @@ BoatMissile:
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@3Eff: CreateEffect
 		Explosions: small_poof
-		ImpactSounds: xplos.aud
 		ValidTargets: Ground, Water
 	Warhead@4EffAir: CreateEffect
 		Explosions: small_building
-		ImpactSounds: xplos.aud
 		ImpactActors: false
 		ValidTargets: Air
 
@@ -238,7 +233,6 @@ TowerMissile:
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@3Eff: CreateEffect
 		Explosions: med_frag
-		ImpactSounds: xplos.aud
 
 TowerAAMissile:
 	Inherits: ^MissileWeapon
@@ -263,7 +257,6 @@ TowerAAMissile:
 	-Warhead@2Smu: LeaveSmudge
 	Warhead@3Eff: CreateEffect
 		Explosions: small_building
-		ImpactSounds: xplos.aud
 
 Patriot:
 	Inherits: ^MissileWeapon
@@ -290,4 +283,3 @@ Patriot:
 	-Warhead@2Smu: LeaveSmudge
 	Warhead@3Eff: CreateEffect
 		Explosions: poof
-		ImpactSounds: xplos.aud

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -5,8 +5,6 @@ BADR:
 		ChuteSound: chute1.aud
 	Health:
 		HP: 30000
-	Armor:
-		Type: Light
 	Aircraft:
 		CruiseAltitude: 2560
 		TurnSpeed: 5
@@ -46,8 +44,6 @@ BADR.Bomber:
 		Weapon: ParaBomb
 	Health:
 		HP: 30000
-	Armor:
-		Type: Light
 	Aircraft:
 		CruiseAltitude: 2560
 		TurnSpeed: 5
@@ -98,8 +94,6 @@ MIG:
 		Name: MiG Attack Plane
 	Health:
 		HP: 7500
-	Armor:
-		Type: Light
 	RevealsShroud:
 		Range: 13c0
 		Type: GroundPosition
@@ -160,8 +154,6 @@ YAK:
 		Name: Yak Attack Plane
 	Health:
 		HP: 6000
-	Armor:
-		Type: Light
 	RevealsShroud:
 		Range: 11c0
 		Type: GroundPosition
@@ -227,8 +219,6 @@ TRAN:
 		Name: Chinook
 	Health:
 		HP: 14000
-	Armor:
-		Type: Light
 	RevealsShroud:
 		Range: 8c0
 		Type: GroundPosition
@@ -284,8 +274,6 @@ HELI:
 		Name: Longbow
 	Health:
 		HP: 12000
-	Armor:
-		Type: Light
 	RevealsShroud:
 		Range: 12c0
 		Type: GroundPosition
@@ -348,8 +336,6 @@ HIND:
 		Name: Hind
 	Health:
 		HP: 10000
-	Armor:
-		Type: Light
 	RevealsShroud:
 		Range: 10c0
 		Type: GroundPosition
@@ -407,8 +393,6 @@ U2:
 		HP: 200000
 	Tooltip:
 		Name: Spy Plane
-	Armor:
-		Type: Heavy
 	Aircraft:
 		CruiseAltitude: 2560
 		TurnSpeed: 7

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -513,6 +513,8 @@
 	OwnerLostAction:
 		Action: Kill
 	DrawLineToTarget:
+	Armor:
+		Type: Light
 	UpdatesPlayerStatistics:
 	AppearsOnRadar:
 		UseLocation: true

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1082,8 +1082,6 @@ FACT:
 		Cost: 2500
 	Tooltip:
 		Name: Construction Yard
-	CustomSellValue:
-		Value: 2500
 	SpawnActorsOnSell:
 		ActorTypes: e1,e1,e1,tecn,tecn,e6
 	BaseBuilding:
@@ -1852,7 +1850,6 @@ SBAG:
 	Armor:
 		Type: Wood
 	LineBuild:
-		Range: 8
 		NodeTypes: sandbag
 	LineBuildNode:
 		Types: sandbag
@@ -1877,7 +1874,6 @@ FENC:
 	Armor:
 		Type: Wood
 	LineBuild:
-		Range: 8
 		NodeTypes: fence
 	LineBuildNode:
 		Types: fence
@@ -1908,7 +1904,6 @@ BRIK:
 		CrushClasses: heavywall
 	BlocksProjectiles:
 	LineBuild:
-		Range: 8
 		NodeTypes: concrete
 	LineBuildNode:
 		Types: concrete

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -104,7 +104,6 @@ TurretGun:
 			Wood: 40
 			Light: 60
 			Heavy: 25
-			Concrete: 50
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@3Eff: CreateEffect
 		Explosions: artillery_explosion
@@ -199,11 +198,7 @@ DepthCharge:
 		Damage: 8000
 		ValidTargets: Submarine
 		Versus:
-			None: 30
-			Wood: 75
 			Light: 75
-			Heavy: 100
-			Concrete: 50
 		DamageTypes: ExplosionDeath
 	Warhead@4EffWater: CreateEffect
 		Explosions: large_splash

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -121,7 +121,6 @@ MammothTusk:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 5000
-		ValidTargets: Air, Infantry
 		Versus:
 			None: 100
 			Light: 60
@@ -152,9 +151,7 @@ Nike:
 		Damage: 5000
 		ValidTargets: Air
 		Versus:
-			None: 90
 			Light: 90
-			Heavy: 50
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion_air
 		ImpactSounds: kaboom25.aud
@@ -170,9 +167,7 @@ RedEye:
 		Damage: 4000
 		ValidTargets: Air
 		Versus:
-			Wood: 75
 			Light: 60
-			Heavy: 25
 
 Stinger:
 	Inherits: ^AntiGroundMissile
@@ -248,7 +243,6 @@ TorpTube:
 		Damage: 18000
 		ValidTargets: Water, Underwater, Bridge
 		Versus:
-			None: 30
 			Wood: 75
 			Light: 75
 			Heavy: 100


### PR DESCRIPTION
Closes #15247

In addition to @FrameLimiter's list, I moved the aircraft Light armor to ^NeutralPlane as all aircraft are light armor sans the Spy Plane, which is untargetable. 