### PR TITLE
Prevent shellmap Chinook wobble

### DIFF
--- a/mods/ra/maps/desert-shellmap/map.yaml
+++ b/mods/ra/maps/desert-shellmap/map.yaml
@@ -1207,10 +1207,10 @@ Actors:
 		Location: 60,93
 		Owner: Neutral
 	Chinook1Entry: waypoint
-		Location: 44,126
+		Location: 45,126
 		Owner: Neutral
 	Chinook2Entry: waypoint
-		Location: 47,126
+		Location: 48,126
 		Owner: Neutral
 	Paradrop1: waypoint
 		Location: 70,50


### PR DESCRIPTION
Works around an existing issue, but I think it's important to keep the shellmap as polished as possible as it's the first thing a new player will see.

Closes #15245