### PR TITLE
Check for null pointer in TooltipDescription, in case client is spect…

### DIFF
--- a/OpenRA.Mods.Common/Traits/TooltipDescription.cs
+++ b/OpenRA.Mods.Common/Traits/TooltipDescription.cs
@@ -38,6 +38,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool IsTooltipVisible(Player forPlayer)
 		{
+			if (forPlayer == null)
+				return true;
+
 			if (IsTraitDisabled)
 				return false;
 


### PR DESCRIPTION
Trying OpenRA for the first time, i experienced a crash when joining a Skirmish Game as spectator:

```
[2018-06-17T02:31:44] Game started
Exception of type `System.NullReferenceException`: Object reference not set to an instance of an object
  at OpenRA.Mods.Common.Traits.TooltipDescription.IsTooltipVisible (OpenRA.Player forPlayer) [0x00013] in <2890e92bc17045d0914b365d48f9bd35>:0 
  at OpenRA.Mods.Common.Widgets.Logic.WorldTooltipLogic+<WorldTooltipLogic>c__AnonStorey0.<>m__1 () [0x001f8] in <2890e92bc17045d0914b365d48f9bd35>:0 
  at OpenRA.Mods.Common.Widgets.TooltipContainerWidget.Draw () [0x00001] in <2890e92bc17045d0914b365d48f9bd35>:0 
  at OpenRA.Widgets.Widget.DrawOuter () [0x00012] in <fb6c97eaced840c7a0be4397b4331976>:0 
  at OpenRA.Widgets.Widget.DrawOuter () [0x00032] in <fb6c97eaced840c7a0be4397b4331976>:0 
  at OpenRA.Widgets.Widget.DrawOuter () [0x00032] in <fb6c97eaced840c7a0be4397b4331976>:0 
  at OpenRA.Widgets.Ui.Draw () [0x00001] in <fb6c97eaced840c7a0be4397b4331976>:0 
  at OpenRA.Game.RenderTick () [0x000ba] in <fb6c97eaced840c7a0be4397b4331976>:0 
  at OpenRA.Game.Loop () [0x00142] in <fb6c97eaced840c7a0be4397b4331976>:0 
  at OpenRA.Game.Run () [0x00042] in <fb6c97eaced840c7a0be4397b4331976>:0 
  at OpenRA.Game.InitializeAndRun (System.String[] args) [0x00011] in <fb6c97eaced840c7a0be4397b4331976>:0 
  at OpenRA.Program.Main (System.String[] args) [0x0004f] in <fb6c97eaced840c7a0be4397b4331976>:0 
```

Apparently, the TooltipDescription isn't expecting that there is no world.localPlayer.
I didn't investigate into the root cause of the problem, or if there's other places where  unexpected behaviour in "Spectator mode" could occur, but it fixes this crash.