### PR TITLE
Special-case the player actor in GrantConditionOnBotOwner.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs
@@ -44,9 +44,16 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyCreated.Created(Actor self)
 		{
-			conditionManager = self.TraitOrDefault<ConditionManager>();
-			if (conditionManager != null && self.Owner.IsBot && info.Bots.Contains(self.Owner.BotType))
-				conditionToken = conditionManager.GrantCondition(self, info.Condition);
+			// Special case handling is required for the Player actor.
+			// Created is called before Player.IsBot is set, so we
+			// must use a different method to enable this trait if
+			// it's defined on the PlayerActor.
+			self.World.AddFrameEndTask(w =>
+			{
+				conditionManager = self.TraitOrDefault<ConditionManager>();
+				if (conditionManager != null && self.Owner.IsBot && info.Bots.Contains(self.Owner.BotType))
+					conditionToken = conditionManager.GrantCondition(self, info.Condition);
+			});
 		}
 
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)


### PR DESCRIPTION
Player.IsBot is set only after GrantConditionOnBotOwner.Created
have already ran, preventing the trait to work on the Player
actor itself.