### PR TITLE
Add DeathTypes to OwnerLostAction.

### DIFF
--- a/OpenRA.Mods.Common/Traits/OwnerLostAction.cs
+++ b/OpenRA.Mods.Common/Traits/OwnerLostAction.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -27,6 +28,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Map player to use when 'Action' is 'ChangeOwner'.")]
 		public readonly string Owner = "Neutral";
 
+		[Desc("The deathtypes used when 'Action' is 'Kill'.")]
+		public readonly HashSet<string> DeathTypes = new HashSet<string>();
+
 		public override object Create(ActorInitializer init) { return new OwnerLostAction(init, this); }
 	}
 
@@ -41,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			if (Info.Action == OwnerLostActionType.Kill)
-				self.Kill(self);
+				self.Kill(self, Info.DeathTypes);
 			else if (Info.Action == OwnerLostActionType.Dispose)
 				self.Dispose();
 			else if (Info.Action == OwnerLostActionType.ChangeOwner)

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -348,6 +348,7 @@
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
+		DeathTypes: DefaultDeath
 	Health:
 	Armor:
 		Type: None

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -270,6 +270,7 @@
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
+		DeathTypes: ExplosionDeath
 	Health:
 	Armor:
 		Type: none

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -314,6 +314,7 @@
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
+		DeathTypes: DefaultDeath
 	DrawLineToTarget:
 	Health:
 		HP: 2500

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -513,6 +513,7 @@
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
+		DeathTypes: BulletDeath
 	DrawLineToTarget:
 	Health:
 		HP: 5000


### PR DESCRIPTION
Something I overlooked back at reviewing #14982. Would be cool if it would hit the playtest, because it is a good polish. I've enabled the first deathtype in all mods because that was the case in RA and TS (notsure what D2K used originally.)

Fixes #12802.