### PR TITLE
Add lint tests for unknown trait and weapon fields

### DIFF
--- a/OpenRA.Mods.Common/Lint/CheckActors.cs
+++ b/OpenRA.Mods.Common/Lint/CheckActors.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Lint
 {
 	public class CheckActors : ILintMapPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
 		{
 			var actorTypes = map.ActorDefinitions.Select(a => a.Value.Value);
 			foreach (var actor in actorTypes)

--- a/OpenRA.Mods.Common/Lint/CheckMapCordon.cs
+++ b/OpenRA.Mods.Common/Lint/CheckMapCordon.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.Lint
 {
 	public class CheckMapCordon : ILintMapPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
 		{
 			if (map.Bounds.Left == 0 || map.Bounds.Top == 0
 				|| map.Bounds.Right == map.MapSize.X || map.Bounds.Bottom == map.MapSize.Y)

--- a/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
+++ b/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Lint
 {
 	public class CheckMapMetadata : ILintMapPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
 		{
 			if (map.MapFormat != Map.SupportedMapFormat)
 				emitError("Map format {0} does not match the supported version {1}."

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Lint
 {
 	public class CheckPlayers : ILintMapPass
 	{
-		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
 		{
 			var players = new MapPlayers(map.PlayerDefinitions).Players;
 			var worldOwnerFound = false;

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -25,12 +25,11 @@ namespace OpenRA.Mods.Common.Lint
 
 		List<MiniYamlNode> sequenceDefinitions;
 
-		public void Run(Action<string> emitError, Action<string> emitWarning, Map map)
+		public void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
 		{
 			if (map.SequenceDefinitions == null)
 				return;
 
-			var modData = Game.ModData;
 			this.emitError = emitError;
 
 			sequenceDefinitions = MiniYaml.Load(map, modData.Manifest.Sequences, map.SequenceDefinitions);

--- a/OpenRA.Mods.Common/Lint/CheckUnknownTraitFields.cs
+++ b/OpenRA.Mods.Common/Lint/CheckUnknownTraitFields.cs
@@ -1,0 +1,75 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Lint
+{
+	class CheckUnknownTraitFields : ILintPass, ILintMapPass
+	{
+		string NormalizeName(string key)
+		{
+			var name = key.Split('@')[0];
+			if (name.StartsWith("-", StringComparison.Ordinal))
+				return name.Substring(1);
+
+			return name;
+		}
+
+		void CheckActors(IEnumerable<MiniYamlNode> actors, Action<string> emitError, ModData modData)
+		{
+			foreach (var actor in actors)
+			{
+				foreach (var t in actor.Value.Nodes)
+				{
+					// Removals can never define children
+					if (t.Key.StartsWith("-", StringComparison.Ordinal) && t.Value.Nodes.Any())
+					{
+						emitError("{0} has child nodes, which is not valid for removals.".F(t.Key));
+						continue;
+					}
+
+					var traitName = NormalizeName(t.Key);
+					var traitInfo = modData.ObjectCreator.FindType(traitName + "Info");
+					foreach (var field in t.Value.Nodes)
+					{
+						var fieldName = NormalizeName(field.Key);
+						if (traitInfo.GetField(fieldName) == null)
+							emitError("{0} refers to a trait field `{1}` that does not exist on `{2}`.".F(field.Location, fieldName, traitName));
+					}
+				}
+			}
+		}
+
+		void ILintPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData)
+		{
+			foreach (var f in modData.Manifest.Rules)
+				CheckActors(MiniYaml.FromStream(modData.DefaultFileSystem.Open(f), f), emitError, modData);
+		}
+
+		void ILintMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
+		{
+			if (map.RuleDefinitions != null && map.RuleDefinitions.Value != null)
+			{
+				var mapFiles = FieldLoader.GetValue<string[]>("value", map.RuleDefinitions.Value);
+				foreach (var f in mapFiles)
+					CheckActors(MiniYaml.FromStream(map.Open(f), f), emitError, modData);
+
+				if (map.RuleDefinitions.Nodes.Any())
+					CheckActors(map.RuleDefinitions.Nodes, emitError, modData);
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Lint/CheckUnknownWeaponFields.cs
+++ b/OpenRA.Mods.Common/Lint/CheckUnknownWeaponFields.cs
@@ -1,0 +1,98 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.GameRules;
+
+namespace OpenRA.Mods.Common.Lint
+{
+	class CheckUnknownWeaponFields : ILintPass, ILintMapPass
+	{
+		string NormalizeName(string key)
+		{
+			var name = key.Split('@')[0];
+			if (name.StartsWith("-", StringComparison.Ordinal))
+				return name.Substring(1);
+
+			return name;
+		}
+
+		void CheckWeapons(IEnumerable<MiniYamlNode> weapons, Action<string> emitError, Action<string> emitWarning, ModData modData)
+		{
+			var weaponInfo = typeof(WeaponInfo);
+			foreach (var weapon in weapons)
+			{
+				foreach (var field in weapon.Value.Nodes)
+				{
+					// Removals can never define children
+					if (field.Key.StartsWith("-", StringComparison.Ordinal) && field.Value.Nodes.Any())
+					{
+						emitError("{0} has child nodes, which is not valid for removals.".F(field.Key));
+						continue;
+					}
+
+					var fieldName = NormalizeName(field.Key);
+					if (fieldName == "Projectile" && !string.IsNullOrEmpty(field.Value.Value))
+					{
+						var projectileName = NormalizeName(field.Value.Value);
+						var projectileInfo = modData.ObjectCreator.FindType(projectileName + "Info");
+						foreach (var projectileField in field.Value.Nodes)
+						{
+							var projectileFieldName = NormalizeName(projectileField.Key);
+							if (projectileInfo.GetField(projectileFieldName) == null)
+								emitError("{0} refers to a projectile field `{1}` that does not exist on `{2}`.".F(projectileField.Location, projectileFieldName, projectileName));
+						}
+					}
+					else if (fieldName == "Warhead")
+					{
+						if (string.IsNullOrEmpty(field.Value.Value))
+						{
+							emitWarning("{0} does not define a warhead type. Skipping unknown field check.".F(field.Location));
+							continue;
+						}
+
+						var warheadName = NormalizeName(field.Value.Value);
+						var warheadInfo = modData.ObjectCreator.FindType(warheadName + "Warhead");
+						foreach (var warheadField in field.Value.Nodes)
+						{
+							var warheadFieldName = NormalizeName(warheadField.Key);
+							if (warheadInfo.GetField(warheadFieldName) == null)
+								emitError("{0} refers to a warhead field `{1}` that does not exist on `{2}`.".F(warheadField.Location, warheadFieldName, warheadName));
+						}
+					}
+					else if (fieldName != "Inherits" && weaponInfo.GetField(fieldName) == null)
+						emitError("{0} refers to a weapon field `{1}` that does not exist.".F(field.Location, fieldName));
+				}
+			}
+		}
+
+		void ILintPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData)
+		{
+			foreach (var f in modData.Manifest.Weapons)
+				CheckWeapons(MiniYaml.FromStream(modData.DefaultFileSystem.Open(f), f), emitError, emitWarning, modData);
+		}
+
+		void ILintMapPass.Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map)
+		{
+			if (map.WeaponDefinitions != null && map.WeaponDefinitions.Value != null)
+			{
+				var mapFiles = FieldLoader.GetValue<string[]>("value", map.WeaponDefinitions.Value);
+				foreach (var f in mapFiles)
+					CheckWeapons(MiniYaml.FromStream(map.Open(f), f), emitError, emitWarning, modData);
+
+				if (map.WeaponDefinitions.Nodes.Any())
+					CheckWeapons(map.WeaponDefinitions.Nodes, emitError, emitWarning, modData);
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -885,6 +885,7 @@
     <Compile Include="ModCredits.cs" />
     <Compile Include="UpdateRules\Rules\MoveHackyAISupportPowerDecisions.cs" />
     <Compile Include="Lint\CheckUnknownTraitFields.cs" />
+    <Compile Include="Lint\CheckUnknownWeaponFields.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -884,6 +884,7 @@
     <Compile Include="UpdateRules\Rules\SplitRepairDecoration.cs" />
     <Compile Include="ModCredits.cs" />
     <Compile Include="UpdateRules\Rules\MoveHackyAISupportPowerDecisions.cs" />
+    <Compile Include="Lint\CheckUnknownTraitFields.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckYaml.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						try
 						{
 							var customMapPass = (ILintMapPass)modData.ObjectCreator.CreateBasic(customMapPassType);
-							customMapPass.Run(EmitError, EmitWarning, testMap);
+							customMapPass.Run(EmitError, EmitWarning, modData, testMap);
 						}
 						catch (Exception e)
 						{

--- a/OpenRA.Mods.Common/UtilityCommands/LintInterfaces.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/LintInterfaces.cs
@@ -14,6 +14,6 @@ using System;
 namespace OpenRA.Mods.Common.Lint
 {
 	public interface ILintPass { void Run(Action<string> emitError, Action<string> emitWarning, ModData modData); }
-	public interface ILintMapPass { void Run(Action<string> emitError, Action<string> emitWarning, Map map); }
+	public interface ILintMapPass { void Run(Action<string> emitError, Action<string> emitWarning, ModData modData, Map map); }
 	public interface ILintRulesPass { void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules); }
 }

--- a/mods/ra/maps/allies-03a/weapons.yaml
+++ b/mods/ra/maps/allies-03a/weapons.yaml
@@ -1,3 +1,3 @@
 BarrelExplode:
-	Warhead@1Dam:
+	Warhead@1Dam: SpreadDamage
 		ValidTargets: Ground, Prisoner

--- a/mods/ra/maps/allies-03b/weapons.yaml
+++ b/mods/ra/maps/allies-03b/weapons.yaml
@@ -6,5 +6,5 @@ Colt45:
 			Truk: 50
 
 BarrelExplode:
-	Warhead@1Dam:
+	Warhead@1Dam: SpreadDamage
 		ValidTargets: Ground, Prisoner


### PR DESCRIPTION
Fixes #15201, with several key improvements over #15264:
* Doesn't hook into the internal game logic.
* Lists all errors in a single pass.
* Displays filenames and line numbers instead of just actor/trait name.