### PR TITLE
Add an AppImage workaround to import SSL certs.

### DIFF
--- a/packaging/linux/AppRun.in
+++ b/packaging/linux/AppRun.in
@@ -26,6 +26,17 @@ if mono_missing_or_old; then
   exit 1
 fi
 
+# Some distros and self-compiled mono installations don't set up
+# the SSL required for http web queries. If we detect that these
+# are missing we can try and create a local sync as a fallback.
+if [ ! -d "/usr/share/.mono/certs" ] && [ ! -d "~/.config/.mono/certs" ]; then
+  if [ -f "/etc/pki/tls/certs/ca-bundle.crt" ]; then
+    cert-sync --quiet --user /etc/pki/tls/certs/ca-bundle.crt
+  elif [ -f "/etc/ssl/certs/ca-certificates.crt" ]; then
+    cert-sync --quiet --user /etc/ssl/certs/ca-certificates.crt
+  fi
+fi
+
 # Run the game or server
 HERE="$(dirname "$(readlink -f "${0}")")"
 export PATH="${HERE}"/usr/bin/:"${PATH}"


### PR DESCRIPTION
Fedora, self-compiled mono installations, and probably a few other distros fail to set up the SSL certificates needed for https web queries.

This PR adds a workaround [adapted from the Flatpak packaging](https://github.com/flathub/net.openra.OpenRA/blob/master/net.openra.OpenRA.json) to locally import the system certificates to `~/.config/.mono/certs` where OpenRA can use them.