### PR TITLE
Use MoveAndRenameNode in MoveHackyAISupportPowerDecisions.

### DIFF
--- a/OpenRA.Mods.Common/UpdateRules/Rules/MoveHackyAISupportPowerDecisions.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/MoveHackyAISupportPowerDecisions.cs
@@ -44,9 +44,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 				foreach (var child in children.ToList())
 				{
 					var split = child.Key.Split('@');
-					child.Key = split.Length > 1 ? split[1] : "Default";
-					parent.AddNode(child);
-					hackyAINode.RemoveNode(child);
+					child.MoveAndRenameNode(hackyAINode, parent, split.Length > 1 ? split[1] : "Default", false);
 				}
 			}
 


### PR DESCRIPTION
A small fixup to apply the simplifications from #15219 to #15263.