### PR TITLE
"Map tools" for the Map Editor, cross-mods

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,6 +59,7 @@ Also thanks to:
     * Fahrradkette
     * Florian Wiesbauer (FiveAces)
     * Frank Razenberg (zzattack)
+    * FRenzy
     * Gareth Needham (Ripley`)
     * Glen Anderson (GlenLife)
     * Glenn Martin Jensen (Baxxster)

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -596,6 +596,7 @@
     <Compile Include="UtilityCommands\ExtractTraitDocsCommand.cs" />
     <Compile Include="UtilityCommands\ExtractWeaponDocsCommand.cs" />
     <Compile Include="Warheads\ChangeOwnerWarhead.cs" />
+    <Compile Include="Widgets\Logic\Editor\MapToolsLogic.cs" />
     <Compile Include="Widgets\Logic\MusicHotkeyLogic.cs" />
     <Compile Include="WorldExtensions.cs" />
     <Compile Include="UtilityCommands\GetMapHashCommand.cs" />
@@ -887,22 +888,14 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
-    <MakeDir Directories="$(SolutionDir)mods/common/"/>
-    <Copy
-      SourceFiles="$(TargetPath)"
-      DestinationFolder="$(SolutionDir)mods/common/"/>
+    <MakeDir Directories="$(SolutionDir)mods/common/" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(SolutionDir)mods/common/" />
     <!--
       csc generates .pdb symbol files (not `.dll.pdb`).
       mcs generates .dll.mdb symbol files.
     -->
-    <Copy
-      SourceFiles="$(TargetDir)$(TargetName).pdb"
-      DestinationFolder="$(SolutionDir)mods/common/"
-      Condition="Exists('$(TargetDir)$(TargetName).pdb')"/>
-    <Copy
-      SourceFiles="$(TargetPath).mdb"
-      DestinationFolder="$(SolutionDir)mods/common/"
-      Condition="Exists('$(TargetPath).mdb')"/>
+    <Copy SourceFiles="$(TargetDir)$(TargetName).pdb" DestinationFolder="$(SolutionDir)mods/common/" Condition="Exists('$(TargetDir)$(TargetName).pdb')" />
+    <Copy SourceFiles="$(TargetPath).mdb" DestinationFolder="$(SolutionDir)mods/common/" Condition="Exists('$(TargetPath).mdb')" />
     <!-- Uncomment these lines when debugging or adding to this target
     <Message Text="DEBUG OS:                     $(OS)"/>
     <Message Text="DEBUG SolutionDir:            $(SolutionDir)"/>

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -576,6 +576,7 @@
     <Compile Include="UtilityCommands\ExtractZeroBraneStudioLuaAPI.cs" />
     <Compile Include="UtilityCommands\ExtractTraitDocsCommand.cs" />
     <Compile Include="UtilityCommands\ExtractWeaponDocsCommand.cs" />
+    <Compile Include="Widgets\Logic\Editor\MapToolsLogic.cs" />
     <Compile Include="Widgets\Logic\MusicHotkeyLogic.cs" />
     <Compile Include="WorldExtensions.cs" />
     <Compile Include="UtilityCommands\GetMapHashCommand.cs" />
@@ -867,22 +868,14 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
-    <MakeDir Directories="$(SolutionDir)mods/common/"/>
-    <Copy
-      SourceFiles="$(TargetPath)"
-      DestinationFolder="$(SolutionDir)mods/common/"/>
+    <MakeDir Directories="$(SolutionDir)mods/common/" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(SolutionDir)mods/common/" />
     <!--
       csc generates .pdb symbol files (not `.dll.pdb`).
       mcs generates .dll.mdb symbol files.
     -->
-    <Copy
-      SourceFiles="$(TargetDir)$(TargetName).pdb"
-      DestinationFolder="$(SolutionDir)mods/common/"
-      Condition="Exists('$(TargetDir)$(TargetName).pdb')"/>
-    <Copy
-      SourceFiles="$(TargetPath).mdb"
-      DestinationFolder="$(SolutionDir)mods/common/"
-      Condition="Exists('$(TargetPath).mdb')"/>
+    <Copy SourceFiles="$(TargetDir)$(TargetName).pdb" DestinationFolder="$(SolutionDir)mods/common/" Condition="Exists('$(TargetDir)$(TargetName).pdb')" />
+    <Copy SourceFiles="$(TargetPath).mdb" DestinationFolder="$(SolutionDir)mods/common/" Condition="Exists('$(TargetPath).mdb')" />
     <!-- Uncomment these lines when debugging or adding to this target
     <Message Text="DEBUG OS:                     $(OS)"/>
     <Message Text="DEBUG SolutionDir:            $(SolutionDir)"/>

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapToolsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapToolsLogic.cs
@@ -1,0 +1,871 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using OpenRA.Widgets;
+using OpenRA.FileSystem;
+
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+	public class MapToolsLogic : ChromeLogic
+	{
+		Widget panel;
+		DropDownButtonWidget[] resizeDropdowns = new DropDownButtonWidget[10];
+
+		class DropDownOption
+		{
+			public string Title;
+			public Func<bool> IsSelected;
+			public Action OnClick;
+		}
+		// Constants
+		static Dictionary<string, Tuple<int, int>> resizeFactors = new Dictionary<string, Tuple<int, int>>
+			{ // Default Resize Factors
+				{ "0.25" , Tuple.Create( 1  , 4  ) },
+				{ "0.50" , Tuple.Create( 1  , 2  ) },
+				{ "0.75" , Tuple.Create( 3  , 4  ) },
+				{ "0.90" , Tuple.Create( 9  , 10 ) },
+				{ "1.00" , Tuple.Create( 1  , 1  ) },
+				{ "1.10" , Tuple.Create( 11 , 10 ) },
+				{ "1.25" , Tuple.Create( 5  , 4  ) },
+				{ "1.33" , Tuple.Create( 4  , 3  ) },
+				{ "1.50" , Tuple.Create( 3  , 2  ) },
+				{ "2.00" , Tuple.Create( 2  , 1  ) }
+			};
+		static Dictionary<string, Tuple<int, int, int>> mapElements = new Dictionary<string, Tuple<int, int, int>>
+			{ // Default Resize Factors
+				{ "T, R, A" , Tuple.Create( 1, 1, 1 ) },
+				{ "T, R, _" , Tuple.Create( 1, 1, 0 ) },
+				{ "T, _, A" , Tuple.Create( 1, 0, 1 ) },
+				{ "_, R, A" , Tuple.Create( 0, 1, 1 ) },
+				{ "T, _, _" , Tuple.Create( 1, 0, 0 ) },
+				{ "_, R, _" , Tuple.Create( 0, 1, 0 ) },
+				{ "_, _, A" , Tuple.Create( 0, 0, 1 ) }
+			};
+
+		// Variables
+		Map Map_A = null;
+		Map Map_B = null;
+		Map Map_C = null;
+
+		TextFieldWidget filepathTextField_A = null;
+		TextFieldWidget filepathTextField_B = null;
+
+		string filepathText_A = "";
+		string filepathText_B = "";
+		string filepathText_C = "";
+
+		string tileset_A_txt = "";
+		string tileset_B_txt = "";
+
+		int A_left    =	0; int B_left    =	0;
+		int A_right   =	0; int B_right   =	0;
+		int A_top     =	0; int B_top     =	0;
+		int A_bottom  =	0; int B_bottom  =	0;
+				  		   	  
+		int A_X       =	0; int B_X       =	0;
+		int A_Y       =	0; int B_Y       =	0;
+				  		   		
+		int A_W       =	0; int B_W       =	0;
+		int A_H       =	0; int B_H       =	0;
+
+		int Wmin = 0;
+		int Hmin = 0;
+		int Wmax = 0;
+		int Hmax = 0;
+
+		int Xmin = 0;
+		int Ymin = 0;
+		int Xmax = 0;
+		int Ymax = 0;
+
+		int usingTiles = 0; int usingResources = 0; int usingActors = 0;
+
+		Tuple<int, int> activeResizeW = Tuple.Create(1, 1);
+		Tuple<int, int> activeResizeH = Tuple.Create(1, 1);
+		Tuple<int, int, int> activeMapElements = Tuple.Create(1, 1, 1);
+
+		// Common functions
+		bool getVariablesAndMaps_A(ModData modData, Action showPanel)
+		{		
+			// Function : gets variables, and map A.
+			usingTiles = activeMapElements.Item1; usingResources = activeMapElements.Item2; usingActors = activeMapElements.Item3;
+
+			filepathTextField_A = panel.Get<TextFieldWidget>("FILE_PATH_A");
+			filepathText_A = filepathTextField_A.Text;
+
+			
+			// checks: file exists? 
+			if (!File.Exists(filepathTextField_A.Text))
+			{
+				panel.Visible = false;
+				ConfirmationDialogs.ButtonPrompt(
+					title: "Map A not found",
+					text: "Map A does not exist or could not be accessed.",
+					onConfirm: showPanel);
+				return false;
+			}
+
+			// checks: file of .oramap type?
+			try
+			{
+				var package_A = new Folder(".").OpenPackage(filepathTextField_A.Text, modData.ModFiles) as IReadWritePackage; 
+				Map_A = new Map(modData, package_A);
+			}
+			catch (ArgumentException)
+			{
+				panel.Visible = false;
+				ConfirmationDialogs.ButtonPrompt(
+					title: "Incompatible file format",
+					text: "File A must be of .oramap type!",
+					onConfirm: showPanel);
+				return false;
+			}
+
+			// checks: mod ?
+			if (modData.Manifest.Id != Map_A.RequiresMod)
+			{
+				panel.Visible = false;
+				ConfirmationDialogs.ButtonPrompt(
+					title: "Incompatible mod",
+					text: "Map A incompatible with mod.",
+					onConfirm: showPanel);
+				return false;
+			}
+
+			// variables
+			A_left   = Map_A.Bounds.Left; 
+			A_right  = Map_A.Bounds.Right;
+			A_X		 = Map_A.MapSize.X;
+			A_W		 = Map_A.Bounds.Width;
+			A_top	 = Map_A.Bounds.Top; 
+			A_bottom = Map_A.Bounds.Bottom;
+			A_Y      = Map_A.MapSize.Y; 
+			A_H      = Map_A.Bounds.Height;
+			
+			return true;
+		}
+
+		bool getVariablesAndMaps_B(ModData modData, Action showPanel)
+		{
+			// Function : gets variables, and map B.
+			filepathTextField_B = panel.Get<TextFieldWidget>("FILE_PATH_B");
+			filepathText_B = filepathTextField_B.Text;
+
+			// checks: file exists? 
+			if (!File.Exists(filepathTextField_B.Text))
+			{
+				panel.Visible = false;
+				ConfirmationDialogs.ButtonPrompt(
+					title: "Map B not found",
+					text: "Map B does not exist or could not be accessed.",
+					onConfirm: showPanel);
+				return false;
+			}
+
+			// checks: file of .oramap type?
+			try
+			{
+				var package_B = new Folder(".").OpenPackage(filepathTextField_B.Text, modData.ModFiles) as IReadWritePackage;
+				Map_B = new Map(modData, package_B);
+			}
+			catch (ArgumentException)
+			{
+				panel.Visible = false;
+				ConfirmationDialogs.ButtonPrompt(
+					title: "Incompatible file format",
+					text: "File B must be of .oramap type!",
+					onConfirm: showPanel);
+				return false;
+			}
+
+			// checks: mod ?
+			if (modData.Manifest.Id != Map_B.RequiresMod)
+			{
+				panel.Visible = false;
+				ConfirmationDialogs.ButtonPrompt(
+					title: "Incompatible mod",
+					text: "Map B incompatible with mod.",
+					onConfirm: showPanel);
+				return false;
+			}
+
+			// variables
+			B_left   = Map_B.Bounds.Left; 
+			B_right  = Map_B.Bounds.Right; 
+			B_top    = Map_B.Bounds.Top; 
+			B_bottom = Map_B.Bounds.Bottom;
+			
+			B_X      = Map_B.MapSize.X; 
+			B_Y      = Map_B.MapSize.Y; 
+				     
+			B_W      = Map_B.Bounds.Width;
+			B_H      = Map_B.Bounds.Height;
+			return true;
+		}
+
+		bool getVariablesAndMaps_AB(ModData modData, Action showPanel)
+		{
+			// Function : gets variables, and maps A and B.
+
+			if (!getVariablesAndMaps_A(modData, showPanel)) { return false; };
+			if (!getVariablesAndMaps_B(modData, showPanel)) { return false; };
+
+			// checks: same tileset?
+			tileset_A_txt = Map_A.Tileset;
+			tileset_B_txt = Map_B.Tileset;
+
+			if (tileset_A_txt != tileset_B_txt)
+			{
+				panel.Visible = false;
+				ConfirmationDialogs.ButtonPrompt(
+					title: "Different tilesets",
+					text: "The maps have different tilesets.",
+					onConfirm: showPanel);
+				return false;
+			}
+			Wmin = Math.Max(2, Math.Min(A_W, B_W)); // unused
+			Hmin = Math.Max(2, Math.Min(A_H, B_H)); // unused
+
+			Wmax = Math.Max(A_W, B_W); // unused
+			Hmax = Math.Max(A_H, B_H); // unused
+
+			Xmin = Math.Max(2, Math.Min(A_X, B_X));
+			Ymin = Math.Max(2, Math.Min(A_Y, B_Y));
+
+			Xmax = Math.Max(A_X, B_X);
+			Ymax = Math.Max(A_Y, B_Y);
+			return true;
+		}
+
+		void saveNewMap(Action<string> onSelect, Action onExit)
+		{
+			// saving the map
+			Action<string> afterSave = uid =>
+			{
+				// HACK: Work around a synced-code change check.
+				// It's not clear why this is needed here, but not in the other places that load maps.
+				Game.RunAfterTick(() =>
+				{
+					ConnectionLogic.Connect(System.Net.IPAddress.Loopback.ToString(),
+						Game.CreateLocalServer(uid), "",
+						() => Game.LoadEditor(uid),
+						() => { Game.CloseServer(); onExit(); });
+				});
+
+				Ui.CloseWindow();
+				onSelect(uid);
+			};
+
+			Ui.OpenWindow("SAVE_MAP_PANEL", new WidgetArgs()
+				{
+					{ "onSave", afterSave },
+					{ "onExit", () => { Ui.CloseWindow(); onExit(); } },
+					{ "map", Map_C },
+					{ "playerDefinitions", Map_C.PlayerDefinitions },
+					{ "actorDefinitions", Map_C.ActorDefinitions }
+				});
+		}
+		
+		// Object creator
+		[ObjectCreator.UseCtor]
+		public MapToolsLogic(Widget widget, World world, ModData modData, Action<string> onSelect, Action onExit)
+		{
+			panel = widget;
+			Action showPanel = () => panel.Visible = true;
+
+			var resizeDropdownW = panel.Get<DropDownButtonWidget>("RESIZE_W");
+			var resizeDropdownH = panel.Get<DropDownButtonWidget>("RESIZE_H");
+			var mapElementsDropdown = panel.Get<DropDownButtonWidget>("USING_ELEMENTS");
+
+			resizeDropdownW.Text = "0.25"; 
+			resizeDropdownH.Text = "0.25";
+			mapElementsDropdown.Text = "T, R, A"; 	 
+
+			activeResizeW = resizeFactors[resizeDropdownW.Text];
+			activeResizeH = resizeFactors[resizeDropdownH.Text];
+			activeMapElements = mapElements[mapElementsDropdown.Text];
+
+			resizeDropdownW.OnMouseDown = _ =>
+			{
+				var resizeFactorsB = resizeFactors.Select(kv => new DropDownOption
+				{
+					Title = kv.Key,
+					IsSelected = () => resizeDropdownW.Text == kv.Key,
+					OnClick = () =>
+					{
+						resizeDropdownW.Text = kv.Key;
+						activeResizeW = resizeFactors[kv.Key];
+					}
+				});
+
+				Func<DropDownOption, ScrollItemWidget, ScrollItemWidget> setupItem = (option, template) =>
+				{
+					var item = ScrollItemWidget.Setup(template, option.IsSelected, option.OnClick);
+					item.Get<LabelWidget>("LABEL").GetText = () => option.Title;
+					return item;
+				};
+
+				resizeDropdownW.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", resizeFactorsB.Count() * 30, resizeFactorsB, setupItem);
+			};
+
+			resizeDropdownH.OnMouseDown = _ =>
+			{
+				var resizeFactorsB = resizeFactors.Select(kv => new DropDownOption
+				{
+					Title = kv.Key,
+					IsSelected = () => resizeDropdownH.Text == kv.Key,
+					OnClick = () =>
+					{
+						resizeDropdownH.Text = kv.Key;
+						activeResizeH = resizeFactors[kv.Key];
+					}
+				});
+
+				Func<DropDownOption, ScrollItemWidget, ScrollItemWidget> setupItem = (option, template) =>
+				{
+					var item = ScrollItemWidget.Setup(template, option.IsSelected, option.OnClick);
+					item.Get<LabelWidget>("LABEL").GetText = () => option.Title;
+					return item;
+				};
+
+				resizeDropdownH.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", resizeFactorsB.Count() * 30, resizeFactorsB, setupItem);
+			};
+
+			mapElementsDropdown.OnMouseDown = _ =>
+			{
+				var mapElementsB = mapElements.Select(kv => new DropDownOption
+				{
+					Title = kv.Key,
+					IsSelected = () => mapElementsDropdown.Text == kv.Key,
+					OnClick = () =>
+					{
+						mapElementsDropdown.Text = kv.Key;
+						activeMapElements = mapElements[kv.Key];
+					}
+				});
+
+				Func<DropDownOption, ScrollItemWidget, ScrollItemWidget> setupItem = (option, template) =>
+				{
+					var item = ScrollItemWidget.Setup(template, option.IsSelected, option.OnClick);
+					item.Get<LabelWidget>("LABEL").GetText = () => option.Title;
+					return item;
+				};
+
+				mapElementsDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", mapElementsB.Count() * 30, mapElementsB, setupItem);
+			};
+
+			panel.Get<ButtonWidget>("CANCEL_BUTTON").OnClick = () => { Ui.CloseWindow(); onExit(); };
+
+			//// Map Tools
+			//// APPEND TOOL
+			panel.Get<ButtonWidget>("APPEND_BUTTON").OnClick = () =>
+			{
+				// initialization. if fails, break.
+				if (!getVariablesAndMaps_AB(modData, showPanel)) { return; };
+
+				// copy map A to create map C
+				filepathText_C = filepathTextField_A.Text.Replace(".oramap", "") + "-Append";
+				filepathText_C += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
+
+				System.IO.File.Copy(filepathText_A, filepathText_C, true);
+				var package_C = new Folder(".").OpenPackage(filepathText_C, modData.ModFiles) as IReadWritePackage;
+				Map_C = new Map(modData, package_C);
+
+				Map_C.Title += "-Append";
+				Map_C.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
+
+				Map_C.Resize((A_X + B_X), Math.Max(A_Y, B_Y));
+
+				var LT_new = new PPos(A_left, Math.Min(A_top, B_top));
+				var RB_new = new PPos(A_X + B_right - 1, Math.Max(A_bottom, B_bottom) - 1);
+				Map_C.SetBounds(LT_new, RB_new);
+
+
+				// APPEND TOOL
+				// appending B map to A : 
+				for (int j = 0; j < B_Y; j++)
+				{
+					for (int i = 0; i < B_X; i++)
+					{
+						var posB = new MPos(i, j);
+						var posC = new MPos(i + A_X, j);
+
+						if (usingTiles == 1) { Map_C.Tiles[posC] = Map_B.Tiles[posB]; Map_C.Height[posC] = Map_B.Height[posB]; };
+						if (usingResources == 1) { Map_C.Resources[posC] = Map_B.Resources[posB]; };
+
+					}
+				}
+
+				if (usingActors == 1)
+				{
+					foreach (var kv in Map_B.ActorDefinitions)
+					{
+
+						var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+						var location = actor.InitDict.Get<LocationInit>().Value(null);
+
+						var loc_MPos_old = new CPos(location.X, location.Y).ToMPos(Map_C);
+						var loc_CPos_new = new MPos(loc_MPos_old.U + A_X, loc_MPos_old.V).ToCPos(Map_C);
+						var location_new = new LocationInit(loc_CPos_new);
+
+						var actType = actor.Type;
+						var actor_new = new ActorReference(actType) { location_new, new OwnerInit("Neutral") };
+						Map_C.ActorDefinitions.Add(new MiniYamlNode("Actor" + Map_C.ActorDefinitions.Count, actor_new.Save()));
+
+					}
+				}
+
+				saveNewMap(onSelect, onExit);
+			};
+
+			//// COPY TOOL
+			panel.Get<ButtonWidget>("COPY_BUTTON").OnClick = () =>
+			{
+				// initialization. if fails, break.
+				if (!getVariablesAndMaps_AB(modData, showPanel)) { return; };
+
+				// copy map A to create map C
+
+				filepathText_C = filepathTextField_A.Text.Replace(".oramap", "") + "-Copy";
+				filepathText_C += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
+
+				System.IO.File.Copy(filepathText_A, filepathText_C, true);
+				var package_C = new Folder(".").OpenPackage(filepathText_C, modData.ModFiles) as IReadWritePackage;
+				Map_C = new Map(modData, package_C);
+
+
+				Map_C.Title += "-Copy";
+				Map_C.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
+
+				// COPY TOOL
+				// --------------------------------------------------------------
+				// copying map B over A
+				for (int j = 0; j < Ymin; j++)
+				{
+					for (int i = 0; i < Xmin; i++)
+					{
+						var pos = new MPos(i, j);
+
+						if (usingTiles == 1) { Map_C.Tiles[pos] = Map_B.Tiles[pos]; Map_C.Height[pos] = Map_B.Height[pos]; };
+						if (usingResources == 1) { Map_C.Resources[pos] = Map_B.Resources[pos]; };
+					}
+				}
+
+				var forRemoval = new List<MiniYamlNode>();
+
+				foreach (var kv in Map_C.ActorDefinitions)
+				{
+					forRemoval.Add(kv);
+				}
+
+				foreach (var kv in forRemoval)
+				{
+					Map_C.ActorDefinitions.Remove(kv);
+				}
+
+				if (usingActors == 1)
+				{
+					foreach (var kv in Map_B.ActorDefinitions)
+					{
+						var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+						var location = actor.InitDict.Get<LocationInit>().Value(null);
+						var loc_MPos = new CPos(location.X, location.Y).ToMPos(Map_C);
+
+						bool inMapC_Bounds = (loc_MPos.U < Map_C.MapSize.X) && (loc_MPos.V < Map_C.MapSize.Y);
+
+						if (inMapC_Bounds)
+						{
+							Map_C.ActorDefinitions.Add(new MiniYamlNode("Actor" + Map_C.ActorDefinitions.Count, actor.Save()));
+
+						}
+					}
+				};
+
+				foreach (var kv in Map_A.ActorDefinitions)
+				{
+					var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+					var location = actor.InitDict.Get<LocationInit>().Value(null);
+					var loc_MPos = new CPos(location.X, location.Y).ToMPos(Map_C);
+
+					bool inMapC_Bounds = (loc_MPos.U < Map_C.MapSize.X) && (loc_MPos.V < Map_C.MapSize.Y);
+					bool inMapB_Bounds = (loc_MPos.U < B_X) && (loc_MPos.V < B_Y);
+					bool inMapB_reserved = ((usingActors == 1) && inMapB_Bounds);
+
+					if (inMapC_Bounds && !inMapB_reserved)
+					{
+						Map_C.ActorDefinitions.Add(new MiniYamlNode("Actor" + Map_C.ActorDefinitions.Count, actor.Save()));
+					}
+				}
+
+				saveNewMap(onSelect, onExit);
+			};
+
+			//// MIRROR_LEFT TOOL
+			panel.Get<ButtonWidget>("MIRROR_LEFT").OnClick = () =>
+			{
+				// initialization. if fails, break.
+				if (!getVariablesAndMaps_A(modData, showPanel)) { return; };
+
+				// copy map A to create map C
+				filepathText_C = filepathTextField_A.Text.Replace(".oramap", "") + "-MirrorLeft";
+				filepathText_C += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
+
+				System.IO.File.Copy(filepathText_A, filepathText_C, true);
+				var package_C = new Folder(".").OpenPackage(filepathText_C, modData.ModFiles) as IReadWritePackage;
+				Map_C = new Map(modData, package_C);
+
+				Map_C.Title += "-MirrorLeft";
+				Map_C.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
+
+
+				// MIRROR_LEFT TOOL
+				int A_W_half = A_W / 2;
+				int A_W_rest = A_W % 2;
+
+				A_W_half = A_W_half + A_W_rest;
+
+				for (int j = 0; j < A_Y; j++)
+				{
+					for (int i = 0 ; i < A_W_half; i++)
+					{
+						var i_old = i + A_left;
+						var j_old = j;
+						var posA = new MPos(i_old, j_old);
+
+						var i_iso = (Map_A.Grid.Type == MapGridType.RectangularIsometric) ? j % 2 : 0;  // adding offset if Isometric map. See MPos diagram.
+						var i_new = A_right - (i + i_iso) - 1;
+						var j_new = j_old;
+
+						var posC = new MPos(i_new, j_new);
+
+						if (usingTiles == 1) { Map_C.Tiles[posC] = Map_A.Tiles[posA]; Map_C.Height[posC] = Map_A.Height[posA]; };
+						if (usingResources == 1) { Map_C.Resources[posC] = Map_A.Resources[posA]; };
+					}
+				}
+
+				if (usingActors == 1)
+				{
+					var forRemoval = new List<MiniYamlNode>();
+					var forKeeping = new List<MiniYamlNode>();
+
+					foreach (var kv in Map_C.ActorDefinitions)
+					{
+						var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+						var location = actor.InitDict.Get<LocationInit>().Value(null);
+						var location_MPos = new CPos(location.X, location.Y).ToMPos(Map_C);
+
+						if ((A_left < location_MPos.U) && (location_MPos.U <= A_left + A_W_half - A_W_rest))
+						{
+							forKeeping.Add(kv);
+						}
+						else
+						{
+							forRemoval.Add(kv);
+						}
+					}
+					foreach (var kv in forRemoval)
+					{
+						Map_C.ActorDefinitions.Remove(kv);
+					}
+
+					foreach (var kv in forKeeping)
+					{
+						var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+						var location = actor.InitDict.Get<LocationInit>().Value(null);
+
+						var loc_MPos_old = location.ToMPos(Map_C);
+
+						var i = loc_MPos_old.U - A_left;
+						var j = loc_MPos_old.V;
+						var i_iso = (Map_A.Grid.Type == MapGridType.RectangularIsometric) ? j % 2 : 0;
+						i += i_iso; // adding offset if Isometric map. See MPos diagram.
+
+						var loc_CPos_new = new MPos(A_right - 1 - i, j).ToCPos(Map_C);
+						var location_new = new LocationInit(loc_CPos_new);
+
+						var actType = actor.Type;
+						var actor_new = new ActorReference(actType) { location_new, new OwnerInit("Neutral") };
+						Map_C.ActorDefinitions.Add(new MiniYamlNode("Actor" + Map_C.ActorDefinitions.Count, actor_new.Save()));
+					}
+				}
+
+				saveNewMap(onSelect, onExit);
+			};
+
+			//// MIRROR_TOP TOOL
+			panel.Get<ButtonWidget>("MIRROR_TOP").OnClick = () =>
+			{
+				// initialization. if fails, break.
+				if (!getVariablesAndMaps_A(modData, showPanel)) { return; };
+
+				// copy map A to create map C
+				filepathText_C = filepathTextField_A.Text.Replace(".oramap", "") + "-MirrorTop";
+				filepathText_C += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
+
+				System.IO.File.Copy(filepathText_A, filepathText_C, true);
+				var package_C = new Folder(".").OpenPackage(filepathText_C, modData.ModFiles) as IReadWritePackage;
+				Map_C = new Map(modData, package_C);
+
+				Map_C.Title += "-MirrorTop";
+				Map_C.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
+
+				// MIRROR_TOP TOOL
+
+				int A_H_half = A_H / 2;
+				int A_H_rest = A_H % 2;
+				A_H_half = A_H_half + A_H_rest;
+
+				for (int j = 0; j < A_H_half; j++)
+				{
+					for (int i = 0; i < A_X; i++)
+					{
+						var i_old = i;
+						var j_old = j + A_top;
+						var posA = new MPos(i_old, j_old);
+
+						var i_new = i_old;
+						var j_new = A_bottom - (j) - 1;
+						if ((Map_A.Grid.Type == MapGridType.RectangularIsometric) && ((A_H % 2) == 0)) // if height is odd, MPos issue. (-1) offset to correct it.
+						{
+							j_new -= 1;
+						}
+						
+						var posC = new MPos(i_new, j_new);
+
+						if (usingTiles == 1) { Map_C.Tiles[posC] = Map_A.Tiles[posA]; Map_C.Height[posC] = Map_A.Height[posA]; };
+						if (usingResources == 1) { Map_C.Resources[posC] = Map_A.Resources[posA]; };
+					}
+				}
+
+				if (usingActors == 1)
+				{
+					var forRemoval = new List<MiniYamlNode>();
+					var forKeeping = new List<MiniYamlNode>();
+
+					foreach (var kv in Map_C.ActorDefinitions)
+					{
+						var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+						var location = actor.InitDict.Get<LocationInit>().Value(null);
+						var location_MPos = new CPos(location.X, location.Y).ToMPos(Map_C);
+
+						if ((A_top < location_MPos.V) && (location_MPos.V <= A_top + A_H_half - A_H_rest))
+						{
+							forKeeping.Add(kv);
+						}
+						else
+						{
+							forRemoval.Add(kv);
+						}
+						
+					}
+
+					foreach (var kv in forRemoval)
+					{
+						Map_C.ActorDefinitions.Remove(kv);
+					}
+
+					foreach (var kv in forKeeping)
+					{
+						var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+						var location = actor.InitDict.Get<LocationInit>().Value(null);
+
+						var loc_MPos_old = location.ToMPos(Map_C);
+
+
+						var i = loc_MPos_old.U;
+						var j_local = loc_MPos_old.V - A_top;
+						
+						var j_new = A_bottom - 1 - j_local;
+						if ((Map_A.Grid.Type == MapGridType.RectangularIsometric) && ((A_H % 2) == 0)) // if height is odd, MPos issue. (-1) offset to correct it.
+						{
+							j_new -= 1;
+						}
+						var loc_CPos_new = new MPos(i, j_new).ToCPos(Map_C);
+						var location_new = new LocationInit(loc_CPos_new);
+
+						var actType = actor.Type;
+						var actor_new = new ActorReference(actType) { location_new, new OwnerInit("Neutral") };
+						Map_C.ActorDefinitions.Add(new MiniYamlNode("Actor" + Map_C.ActorDefinitions.Count, actor_new.Save()));
+					}
+				};
+
+				saveNewMap(onSelect, onExit);
+			};
+
+			// RESIZE TOOL
+			panel.Get<ButtonWidget>("RESIZE_BUTTON").OnClick = () =>
+			{
+
+				// initialization. if fails, break.
+				if (!getVariablesAndMaps_A(modData, showPanel)) { return; };
+
+				// copy map A to create map C
+				filepathText_C = filepathTextField_A.Text.Replace(".oramap", "") + "-Resize";
+				filepathText_C += "_" + resizeDropdownW.Text.Replace(".", "");
+				filepathText_C += "_" + resizeDropdownH.Text.Replace(".", "");
+				filepathText_C += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
+				
+
+				System.IO.File.Copy(filepathText_A, filepathText_C, true);
+				var package_C = new Folder(".").OpenPackage(filepathText_C, modData.ModFiles) as IReadWritePackage;
+				Map_C = new Map(modData, package_C);
+				Map_C.Title += "-Resize";
+				Map_C.Title += "_" + resizeDropdownW.Text.Replace(".", "");
+				Map_C.Title += "_" + resizeDropdownH.Text.Replace(".", "");
+				Map_C.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
+
+				///////////
+
+
+				// RESIZE TOOL
+				int Aw = activeResizeW.Item1; int Bw = activeResizeW.Item2;
+				int Ah = activeResizeH.Item1; int Bh = activeResizeH.Item2;
+
+				int W = A_W;
+				int H = A_H;
+
+				int W_new = Math.Max(1, (A_W * Aw) / Bw);
+				int H_new = Math.Max(1, (A_H * Ah) / Bh);
+
+				var A_X_new = A_X + W_new - W;
+				var A_Y_new = A_Y + H_new - H;
+
+				var LT_new = new PPos(A_left            , A_top            );
+				var RB_new = new PPos(A_left + W_new - 1, A_top + H_new - 1);
+
+				// fixing potential southern bound problem : resizeOffset
+				int[] A_Tiles_lastRow_height = new int[A_X];
+				for (int i = 0; i < A_X; i++)
+				{
+					var posA = new MPos(i, A_Y - 1);
+					A_Tiles_lastRow_height[i] = Map_A.Height[posA];
+				}
+
+				var A_Tiles_lastRow_MaxHeight = A_Tiles_lastRow_height.Max();
+				var A_bottomBound = A_Y - A_bottom;
+				var resizeOffset = 0;
+
+				if (A_bottomBound == A_Tiles_lastRow_MaxHeight) { resizeOffset = 1; }
+
+				// resize and set bounds
+				Map_C.Resize(A_X_new, A_Y_new + resizeOffset);
+				Map_C.SetBounds(LT_new, RB_new); // radar widget bug ???
+
+				// grid B resizing bigger
+				for (int local_j_new = 1; local_j_new <= H_new; local_j_new++)
+				{
+					for (int local_i_new = 1; local_i_new <= W_new; local_i_new++)
+					{
+						var local_i_old = Math.Max(1, Math.Min(W, (local_i_new * Bw) / Aw));
+						var local_j_old = Math.Max(1, Math.Min(H, (local_j_new * Bh) / Ah));
+
+						var i_new = (local_i_new - 1) + A_left; var j_new = (local_j_new - 1) + A_top;
+						var i_old = (local_i_old - 1) + A_left; var j_old = (local_j_old - 1) + A_top;
+
+						var posC = new MPos(i_new, j_new);
+						var posA = new MPos(i_old, j_old);
+
+						if (usingTiles == 1) { Map_C.Tiles[posC] = Map_A.Tiles[posA]; Map_C.Height[posC] = Map_A.Height[posA]; };
+						if (usingResources == 1) { Map_C.Resources[posC] = Map_A.Resources[posA]; };
+					}
+				}
+
+				// cleaning bottom border, if resize Y < 1;
+				if (Ah < Bh)
+				{
+					for (int j_old = A_bottom; j_old < A_Y; j_old++)
+					{
+						for (int i_old = 0; i_old < Math.Min(A_X, A_X_new); i_old++)
+						{
+
+							var i_new = i_old;
+							var j_new = j_old + H_new - H;
+
+							var posC = new MPos(i_new, j_new);
+							var posA = new MPos(i_old, j_old);
+
+							Map_C.Tiles[posC] = Map_A.Tiles[posA]; Map_C.Height[posC] = Map_A.Height[posA];
+							Map_C.Resources[posC] = Map_A.Resources[posA];
+						}
+					}
+				}
+
+
+
+				// cleaning right border, if resize X < 1;
+				if (Aw < Bw)
+				{
+					for (int j_old = 0; j_old < Math.Min(A_Y, A_Y_new); j_old++)
+					{
+						for (int i_old = A_right; i_old < A_X; i_old++)
+						{
+							var i_new = i_old + W_new - W;
+							var j_new = j_old;
+
+							var posC = new MPos(i_new, j_new);
+							var posA = new MPos(i_old, j_old);
+
+							Map_C.Tiles[posC] = Map_A.Tiles[posA]; Map_C.Height[posC] = Map_A.Height[posA];
+							Map_C.Resources[posC] = Map_A.Resources[posA];
+						}
+					}
+				}
+
+				var forRemoval = new List<MiniYamlNode>();
+
+				foreach (var kv in Map_C.ActorDefinitions)
+				{
+					forRemoval.Add(kv);
+				}
+				foreach (var kv in forRemoval)
+				{
+					Map_C.ActorDefinitions.Remove(kv);
+				}
+
+				foreach (var kv in Map_A.ActorDefinitions)
+				{
+
+					var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+					var location = actor.InitDict.Get<LocationInit>().Value(null);
+					var actType = actor.Type;
+
+					var loc_MPos_old = new CPos(location.X, location.Y).ToMPos(Map_C);
+					var X_old = loc_MPos_old.U; var Y_old = loc_MPos_old.V;
+					var local_X_old = X_old - A_left; var local_Y_old = Y_old - A_top;
+
+					var inBounds = ((A_left <= X_old) && (X_old < A_right)) && ((A_top <= Y_old) && (Y_old < A_bottom));
+					if (inBounds)
+					{
+						if (usingActors == 1)
+						{
+							var local_X_new = Math.Min((local_X_old * Aw) / Bw, W_new - 1);
+							var local_Y_new = Math.Min((local_Y_old * Ah) / Bh, H_new - 1);
+
+							var X_new = local_X_new + A_left;
+							var Y_new = local_Y_new + A_top;
+							var loc_CPos_new = new MPos(X_new, Y_new).ToCPos(Map_C);
+							var location_new = new LocationInit(loc_CPos_new);
+
+							var actor_new = new ActorReference(actType) { location_new, new OwnerInit("Neutral") };
+							Map_C.ActorDefinitions.Add(new MiniYamlNode("Actor" + Map_C.ActorDefinitions.Count, actor_new.Save()));
+
+						};
+
+						if (usingActors == 0)
+						{
+							Map_C.ActorDefinitions.Add(new MiniYamlNode("Actor" + Map_C.ActorDefinitions.Count, actor.Save()));
+						};
+
+					}
+
+				}
+				saveNewMap(onSelect, onExit);
+
+			};
+
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapToolsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapToolsLogic.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		// Common functions.
 		bool GetInputBaseMap(ModData modData, Action showPanel)
 		{
-			// Function : gets variables, and map A.
+			// Function : gets variables, and Base map.
 			usingTiles = activeMapElements.Item1; usingResources = activeMapElements.Item2; usingActors = activeMapElements.Item3;
 
 			inputBaseMapFilepathTextField = panel.Get<TextFieldWidget>("FILE_PATH_A");
@@ -80,8 +80,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				panel.Visible = false;
 				ConfirmationDialogs.ButtonPrompt(
-					title: "Map A not found",
-					text: "Map A does not exist or could not be accessed.",
+					title: "Base map not found",
+					text: "Base map does not exist or could not be accessed.",
 					onConfirm: showPanel);
 				return false;
 			}
@@ -89,15 +89,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			// checks: file of .oramap type?
 			try
 			{
-				var package_A = new Folder(".").OpenPackage(inputBaseMapFilepathTextField.Text, modData.ModFiles) as IReadWritePackage;
-				inputBaseMap = new Map(modData, package_A);
+				var inputBaseMapPackage = new Folder(".").OpenPackage(inputBaseMapFilepathTextField.Text, modData.ModFiles) as IReadWritePackage;
+				inputBaseMap = new Map(modData, inputBaseMapPackage);
 			}
 			catch (ArgumentException)
 			{
 				panel.Visible = false;
 				ConfirmationDialogs.ButtonPrompt(
 					title: "Incompatible file format",
-					text: "File A must be of .oramap type!",
+					text: "Base file must be of .oramap type!",
 					onConfirm: showPanel);
 				return false;
 			}
@@ -108,7 +108,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				panel.Visible = false;
 				ConfirmationDialogs.ButtonPrompt(
 					title: "Incompatible mod",
-					text: "Map A incompatible with mod.",
+					text: "Base map incompatible with mod.",
 					onConfirm: showPanel);
 				return false;
 			}
@@ -118,7 +118,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		bool GetInputSecondaryMap(ModData modData, Action showPanel)
 		{
-			// Function : gets variables, and map B.
+			// Function : gets variables, and Secondary map.
 			inputSecondaryMapFilepathTextField = panel.Get<TextFieldWidget>("FILE_PATH_B");
 
 			// checks: file exists?
@@ -126,8 +126,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				panel.Visible = false;
 				ConfirmationDialogs.ButtonPrompt(
-					title: "Map B not found",
-					text: "Map B does not exist or could not be accessed.",
+					title: "Secondary map not found",
+					text: "Sec. map does not exist or could not be accessed.",
 					onConfirm: showPanel);
 				return false;
 			}
@@ -135,15 +135,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			// checks: file of .oramap type?
 			try
 			{
-				var package_B = new Folder(".").OpenPackage(inputSecondaryMapFilepathTextField.Text, modData.ModFiles) as IReadWritePackage;
-				inputSecondaryMap = new Map(modData, package_B);
+				var inputSecondaryMapPackage = new Folder(".").OpenPackage(inputSecondaryMapFilepathTextField.Text, modData.ModFiles) as IReadWritePackage;
+				inputSecondaryMap = new Map(modData, inputSecondaryMapPackage);
 			}
 			catch (ArgumentException)
 			{
 				panel.Visible = false;
 				ConfirmationDialogs.ButtonPrompt(
 					title: "Incompatible file format",
-					text: "File B must be of .oramap type!",
+					text: "Secondary file must be of .oramap type!",
 					onConfirm: showPanel);
 				return false;
 			}
@@ -154,7 +154,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				panel.Visible = false;
 				ConfirmationDialogs.ButtonPrompt(
 					title: "Incompatible mod",
-					text: "Map B incompatible with mod.",
+					text: "Secondary map incompatible with mod.",
 					onConfirm: showPanel);
 				return false;
 			}
@@ -309,16 +309,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			//// APPEND TOOL.
 			panel.Get<ButtonWidget>("APPEND_BUTTON").OnClick = () =>
 			{
-				// Initialization. if fails, break.
+				// Initialization. If fails, break.
 				if (!GetInputMaps(modData, showPanel)) { return; };
 
-				// Copy map A to create map C
+				// Copy Base map to create Output map
 				outputMapFilepathText = inputBaseMapFilepathTextField.Text.Replace(".oramap", "") + "-Append";
 				outputMapFilepathText += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
 
 				System.IO.File.Copy(inputBaseMapFilepathTextField.Text, outputMapFilepathText, true);
-				var package_C = new Folder(".").OpenPackage(outputMapFilepathText, modData.ModFiles) as IReadWritePackage;
-				outputMap = new Map(modData, package_C);
+				var outputPackage = new Folder(".").OpenPackage(outputMapFilepathText, modData.ModFiles) as IReadWritePackage;
+				outputMap = new Map(modData, outputPackage);
 
 				outputMap.Title += "-Append";
 				outputMap.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
@@ -331,16 +331,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				outputMap.SetBounds(outputLeftTopCell, outputRightBottomCell);
 
-				// Appending B map to A.
+				// Appending Secondary map to Base map.
 				for (int j = 0; j < inputSecondaryMap.MapSize.Y; j++)
 				{
 					for (int i = 0; i < inputSecondaryMap.MapSize.X; i++)
 					{
 						var posB = new MPos(i, j);
-						var posC = new MPos(i + inputBaseMap.MapSize.X, j);
+						var outPos = new MPos(i + inputBaseMap.MapSize.X, j);
 
-						if (usingTiles == 1) { outputMap.Tiles[posC] = inputSecondaryMap.Tiles[posB]; outputMap.Height[posC] = inputSecondaryMap.Height[posB]; };
-						if (usingResources == 1) { outputMap.Resources[posC] = inputSecondaryMap.Resources[posB]; };
+						if (usingTiles == 1) { outputMap.Tiles[outPos] = inputSecondaryMap.Tiles[posB]; outputMap.Height[outPos] = inputSecondaryMap.Height[posB]; };
+						if (usingResources == 1) { outputMap.Resources[outPos] = inputSecondaryMap.Resources[posB]; };
 					}
 				}
 
@@ -367,21 +367,21 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			//// COPY TOOL.
 			panel.Get<ButtonWidget>("COPY_BUTTON").OnClick = () =>
 			{
-				// Initialization. if fails, break.
+				// Initialization. If fails, break.
 				if (!GetInputMaps(modData, showPanel)) { return; };
 
-				// Copy map A to create map C.
+				// Copy Base map to create Output map.
 				outputMapFilepathText = inputBaseMapFilepathTextField.Text.Replace(".oramap", "") + "-Copy";
 				outputMapFilepathText += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
 
 				System.IO.File.Copy(inputBaseMapFilepathTextField.Text, outputMapFilepathText, true);
-				var package_C = new Folder(".").OpenPackage(outputMapFilepathText, modData.ModFiles) as IReadWritePackage;
-				outputMap = new Map(modData, package_C);
+				var outputPackage = new Folder(".").OpenPackage(outputMapFilepathText, modData.ModFiles) as IReadWritePackage;
+				outputMap = new Map(modData, outputPackage);
 
 				outputMap.Title += "-Copy";
 				outputMap.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
 
-				// Copying map B over A.
+				// Copying Secondary map over Base map.
 				for (int j = 0; j < minMapSizeY; j++)
 				{
 					for (int i = 0; i < minMapSizeX; i++)
@@ -409,9 +409,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						var location = actor.InitDict.Get<LocationInit>().Value(null);
 						var loc_MPos = new CPos(location.X, location.Y).ToMPos(outputMap);
 
-						bool inoutputMap_Bounds = (loc_MPos.U < outputMap.MapSize.X) && (loc_MPos.V < outputMap.MapSize.Y);
+						bool outputMap_Bounds = (loc_MPos.U < outputMap.MapSize.X) && (loc_MPos.V < outputMap.MapSize.Y);
 
-						if (inoutputMap_Bounds)
+						if (outputMap_Bounds)
 							outputMap.ActorDefinitions.Add(new MiniYamlNode("Actor" + outputMap.ActorDefinitions.Count, actor.Save()));
 					}
 				};
@@ -422,11 +422,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var location = actor.InitDict.Get<LocationInit>().Value(null);
 					var loc_MPos = new CPos(location.X, location.Y).ToMPos(outputMap);
 
-					bool inoutputMap_Bounds = (loc_MPos.U < outputMap.MapSize.X) && (loc_MPos.V < outputMap.MapSize.Y);
-					bool ininputSecondaryMap_Bounds = (loc_MPos.U < inputSecondaryMap.MapSize.X) && (loc_MPos.V < inputSecondaryMap.MapSize.Y);
-					bool ininputSecondaryMap_reserved = (usingActors == 1) && ininputSecondaryMap_Bounds;
+					bool outputMap_Bounds = (loc_MPos.U < outputMap.MapSize.X) && (loc_MPos.V < outputMap.MapSize.Y);
+					bool inputSecondaryMap_Bounds = (loc_MPos.U < inputSecondaryMap.MapSize.X) && (loc_MPos.V < inputSecondaryMap.MapSize.Y);
+					bool inputSecondaryMap_reserved = (usingActors == 1) && inputSecondaryMap_Bounds;
 
-					if (inoutputMap_Bounds && !ininputSecondaryMap_reserved)
+					if (outputMap_Bounds && !inputSecondaryMap_reserved)
 						outputMap.ActorDefinitions.Add(new MiniYamlNode("Actor" + outputMap.ActorDefinitions.Count, actor.Save()));
 				}
 
@@ -436,16 +436,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			//// MIRROR_LEFT TOOL.
 			panel.Get<ButtonWidget>("MIRROR_LEFT").OnClick = () =>
 			{
-				// Initialization. if fails, break.
+				// Initialization. If fails, break.
 				if (!GetInputBaseMap(modData, showPanel)) { return; };
 
-				// Copy map A to create map C.
+				// Copy Base map to create Output map.
 				outputMapFilepathText = inputBaseMapFilepathTextField.Text.Replace(".oramap", "") + "-MirrorLeft";
 				outputMapFilepathText += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
 
 				System.IO.File.Copy(inputBaseMapFilepathTextField.Text, outputMapFilepathText, true);
-				var package_C = new Folder(".").OpenPackage(outputMapFilepathText, modData.ModFiles) as IReadWritePackage;
-				outputMap = new Map(modData, package_C);
+				var outputPackage = new Folder(".").OpenPackage(outputMapFilepathText, modData.ModFiles) as IReadWritePackage;
+				outputMap = new Map(modData, outputPackage);
 
 				outputMap.Title += "-MirrorLeft";
 				outputMap.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
@@ -462,17 +462,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						var i_old = i + inputBaseMap.Bounds.Left;
 						var j_old = j;
-						var posA = new MPos(i_old, j_old);
+						var inPos = new MPos(i_old, j_old);
 
 						// Adding offset if Isometric map. See MPos diagram.
 						var i_iso = (inputBaseMap.Grid.Type == MapGridType.RectangularIsometric) ? j % 2 : 0;
 						var i_new = inputBaseMap.Bounds.Right - (i + i_iso) - 1;
 						var j_new = j_old;
 
-						var posC = new MPos(i_new, j_new);
+						var outPos = new MPos(i_new, j_new);
 
-						if (usingTiles == 1) { outputMap.Tiles[posC] = inputBaseMap.Tiles[posA]; outputMap.Height[posC] = inputBaseMap.Height[posA]; };
-						if (usingResources == 1) { outputMap.Resources[posC] = inputBaseMap.Resources[posA]; };
+						if (usingTiles == 1) { outputMap.Tiles[outPos] = inputBaseMap.Tiles[inPos]; outputMap.Height[outPos] = inputBaseMap.Height[inPos]; };
+						if (usingResources == 1) { outputMap.Resources[outPos] = inputBaseMap.Resources[inPos]; };
 					}
 				}
 
@@ -525,16 +525,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			//// MIRROR_TOP TOOL.
 			panel.Get<ButtonWidget>("MIRROR_TOP").OnClick = () =>
 			{
-				// Initialization. if fails, break.
+				// Initialization. If fails, break.
 				if (!GetInputBaseMap(modData, showPanel)) { return; };
 
-				// Copy map A to create map C.
+				// Copy Base map to create Output map.
 				outputMapFilepathText = inputBaseMapFilepathTextField.Text.Replace(".oramap", "") + "-MirrorTop";
 				outputMapFilepathText += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
 
 				System.IO.File.Copy(inputBaseMapFilepathTextField.Text, outputMapFilepathText, true);
-				var package_C = new Folder(".").OpenPackage(outputMapFilepathText, modData.ModFiles) as IReadWritePackage;
-				outputMap = new Map(modData, package_C);
+				var outputPackage = new Folder(".").OpenPackage(outputMapFilepathText, modData.ModFiles) as IReadWritePackage;
+				outputMap = new Map(modData, outputPackage);
 
 				outputMap.Title += "-MirrorTop";
 				outputMap.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
@@ -550,7 +550,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{
 						var i_old = i;
 						var j_old = j + inputBaseMap.Bounds.Top;
-						var posA = new MPos(i_old, j_old);
+						var inPos = new MPos(i_old, j_old);
 
 						var i_new = i_old;
 						var j_new = inputBaseMap.Bounds.Bottom - j - 1;
@@ -559,16 +559,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						if ((inputBaseMap.Grid.Type == MapGridType.RectangularIsometric) && ((inputBaseMap.Bounds.Height % 2) == 0))
 							j_new -= 1;
 
-						var posC = new MPos(i_new, j_new);
+						var outPos = new MPos(i_new, j_new);
 
 						if (usingTiles == 1)
 						{
-							outputMap.Tiles[posC] = inputBaseMap.Tiles[posA];
-							outputMap.Height[posC] = inputBaseMap.Height[posA];
+							outputMap.Tiles[outPos] = inputBaseMap.Tiles[inPos];
+							outputMap.Height[outPos] = inputBaseMap.Height[inPos];
 						}
 
 						if (usingResources == 1)
-							outputMap.Resources[posC] = inputBaseMap.Resources[posA];
+							outputMap.Resources[outPos] = inputBaseMap.Resources[inPos];
 					}
 				}
 
@@ -624,15 +624,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				// Initialization. If fails, break.
 				if (!GetInputBaseMap(modData, showPanel)) { return; };
 
-				// Copy map A to create map C.
+				// Copy Base map to create Output map.
 				outputMapFilepathText = inputBaseMapFilepathTextField.Text.Replace(".oramap", "") + "-Resize";
 				outputMapFilepathText += "_" + resizeDropdownW.Text.Replace(".", "");
 				outputMapFilepathText += "_" + resizeDropdownH.Text.Replace(".", "");
 				outputMapFilepathText += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
 
 				System.IO.File.Copy(inputBaseMapFilepathTextField.Text, outputMapFilepathText, true);
-				var package_C = new Folder(".").OpenPackage(outputMapFilepathText, modData.ModFiles) as IReadWritePackage;
-				outputMap = new Map(modData, package_C);
+				var outputPackage = new Folder(".").OpenPackage(outputMapFilepathText, modData.ModFiles) as IReadWritePackage;
+				outputMap = new Map(modData, outputPackage);
 				outputMap.Title += "-Resize";
 				outputMap.Title += "_" + resizeDropdownW.Text.Replace(".", "");
 				outputMap.Title += "_" + resizeDropdownH.Text.Replace(".", "");
@@ -655,8 +655,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				int[] A_Tiles_lastRow_height = new int[inputBaseMap.MapSize.X];
 				for (int i = 0; i < inputBaseMap.MapSize.X; i++)
 				{
-					var posA = new MPos(i, inputBaseMap.MapSize.Y - 1);
-					A_Tiles_lastRow_height[i] = inputBaseMap.Height[posA];
+					var inPos = new MPos(i, inputBaseMap.MapSize.Y - 1);
+					A_Tiles_lastRow_height[i] = inputBaseMap.Height[inPos];
 				}
 
 				var A_Tiles_lastRow_MaxHeight = A_Tiles_lastRow_height.Max();
@@ -681,11 +681,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						var i_new = (local_i_new - 1) + inputBaseMap.Bounds.Left; var j_new = (local_j_new - 1) + inputBaseMap.Bounds.Top;
 						var i_old = (local_i_old - 1) + inputBaseMap.Bounds.Left; var j_old = (local_j_old - 1) + inputBaseMap.Bounds.Top;
 
-						var posC = new MPos(i_new, j_new);
-						var posA = new MPos(i_old, j_old);
+						var outPos = new MPos(i_new, j_new);
+						var inPos = new MPos(i_old, j_old);
 
-						if (usingTiles == 1) { outputMap.Tiles[posC] = inputBaseMap.Tiles[posA]; outputMap.Height[posC] = inputBaseMap.Height[posA]; };
-						if (usingResources == 1) { outputMap.Resources[posC] = inputBaseMap.Resources[posA]; };
+						if (usingTiles == 1) { outputMap.Tiles[outPos] = inputBaseMap.Tiles[inPos]; outputMap.Height[outPos] = inputBaseMap.Height[inPos]; };
+						if (usingResources == 1) { outputMap.Resources[outPos] = inputBaseMap.Resources[inPos]; };
 					}
 				}
 
@@ -699,11 +699,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							var i_new = i_old;
 							var j_new = j_old + outputMapHeight - inputBaseMap.Bounds.Height;
 
-							var posC = new MPos(i_new, j_new);
-							var posA = new MPos(i_old, j_old);
+							var outPos = new MPos(i_new, j_new);
+							var inPos = new MPos(i_old, j_old);
 
-							outputMap.Tiles[posC] = inputBaseMap.Tiles[posA]; outputMap.Height[posC] = inputBaseMap.Height[posA];
-							outputMap.Resources[posC] = inputBaseMap.Resources[posA];
+							outputMap.Tiles[outPos] = inputBaseMap.Tiles[inPos]; outputMap.Height[outPos] = inputBaseMap.Height[inPos];
+							outputMap.Resources[outPos] = inputBaseMap.Resources[inPos];
 						}
 					}
 				}
@@ -718,11 +718,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							var i_new = i_old + outputMapWidth - inputBaseMap.Bounds.Width;
 							var j_new = j_old;
 
-							var posC = new MPos(i_new, j_new);
-							var posA = new MPos(i_old, j_old);
+							var outPos = new MPos(i_new, j_new);
+							var inPos = new MPos(i_old, j_old);
 
-							outputMap.Tiles[posC] = inputBaseMap.Tiles[posA]; outputMap.Height[posC] = inputBaseMap.Height[posA];
-							outputMap.Resources[posC] = inputBaseMap.Resources[posA];
+							outputMap.Tiles[outPos] = inputBaseMap.Tiles[inPos]; outputMap.Height[outPos] = inputBaseMap.Height[inPos];
+							outputMap.Resources[outPos] = inputBaseMap.Resources[inPos];
 						}
 					}
 				}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapToolsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapToolsLogic.cs
@@ -3,9 +3,8 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using OpenRA.Widgets;
 using OpenRA.FileSystem;
-
+using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
@@ -20,66 +19,47 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			public Func<bool> IsSelected;
 			public Action OnClick;
 		}
-		// Constants
+
+		// Constants.
 		static Dictionary<string, Tuple<int, int>> resizeFactors = new Dictionary<string, Tuple<int, int>>
-			{ // Default Resize Factors
-				{ "0.25" , Tuple.Create( 1  , 4  ) },
-				{ "0.50" , Tuple.Create( 1  , 2  ) },
-				{ "0.75" , Tuple.Create( 3  , 4  ) },
-				{ "0.90" , Tuple.Create( 9  , 10 ) },
-				{ "1.00" , Tuple.Create( 1  , 1  ) },
-				{ "1.10" , Tuple.Create( 11 , 10 ) },
-				{ "1.25" , Tuple.Create( 5  , 4  ) },
-				{ "1.33" , Tuple.Create( 4  , 3  ) },
-				{ "1.50" , Tuple.Create( 3  , 2  ) },
-				{ "2.00" , Tuple.Create( 2  , 1  ) }
+			{ // Default Resize Factors.
+				{ "0.25", Tuple.Create(1, 4) },
+				{ "0.50", Tuple.Create(1, 2) },
+				{ "0.75", Tuple.Create(3, 4) },
+				{ "0.90", Tuple.Create(9, 10) },
+				{ "1.00", Tuple.Create(1, 1) },
+				{ "1.10", Tuple.Create(11, 10) },
+				{ "1.25", Tuple.Create(5, 4) },
+				{ "1.33", Tuple.Create(4, 3) },
+				{ "1.50", Tuple.Create(3, 2) },
+				{ "2.00", Tuple.Create(2, 1) }
 			};
 		static Dictionary<string, Tuple<int, int, int>> mapElements = new Dictionary<string, Tuple<int, int, int>>
-			{ // Default Resize Factors
-				{ "T, R, A" , Tuple.Create( 1, 1, 1 ) },
-				{ "T, R, _" , Tuple.Create( 1, 1, 0 ) },
-				{ "T, _, A" , Tuple.Create( 1, 0, 1 ) },
-				{ "_, R, A" , Tuple.Create( 0, 1, 1 ) },
-				{ "T, _, _" , Tuple.Create( 1, 0, 0 ) },
-				{ "_, R, _" , Tuple.Create( 0, 1, 0 ) },
-				{ "_, _, A" , Tuple.Create( 0, 0, 1 ) }
+			{ // Default Resize Factors.
+				{ "T, R, A", Tuple.Create(1, 1, 1) },
+				{ "T, R, _", Tuple.Create(1, 1, 0) },
+				{ "T, _, A", Tuple.Create(1, 0, 1) },
+				{ "_, R, A", Tuple.Create(0, 1, 1) },
+				{ "T, _, _", Tuple.Create(1, 0, 0) },
+				{ "_, R, _", Tuple.Create(0, 1, 0) },
+				{ "_, _, A", Tuple.Create(0, 0, 1) }
 			};
 
-		// Variables
-		Map Map_A = null;
-		Map Map_B = null;
-		Map Map_C = null;
+		// Shared variables.
+		Map inputBaseMap = null;
+		Map inputSecondaryMap = null;
+		Map outputMap = null;
 
-		TextFieldWidget filepathTextField_A = null;
-		TextFieldWidget filepathTextField_B = null;
+		TextFieldWidget inputBaseMapFilepathTextField = null;
+		TextFieldWidget inputSecondaryMapFilepathTextField = null;
 
-		string filepathText_A = "";
-		string filepathText_B = "";
-		string filepathText_C = "";
+		string outputMapFilepathText = "";
 
-		string tileset_A_txt = "";
-		string tileset_B_txt = "";
+		string inputBaseMapTilesetText = "";
+		string inputSecondaryMapTilesetText = "";
 
-		int A_left    =	0; int B_left    =	0;
-		int A_right   =	0; int B_right   =	0;
-		int A_top     =	0; int B_top     =	0;
-		int A_bottom  =	0; int B_bottom  =	0;
-
-		int A_X       =	0; int B_X       =	0;
-		int A_Y       =	0; int B_Y       =	0;
-
-		int A_W       =	0; int B_W       =	0;
-		int A_H       =	0; int B_H       =	0;
-
-		int Wmin = 0;
-		int Hmin = 0;
-		int Wmax = 0;
-		int Hmax = 0;
-
-		int Xmin = 0;
-		int Ymin = 0;
-		int Xmax = 0;
-		int Ymax = 0;
+		int minMapSizeX = 0;
+		int minMapSizeY = 0;
 
 		int usingTiles = 0; int usingResources = 0; int usingActors = 0;
 
@@ -87,18 +67,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		Tuple<int, int> activeResizeH = Tuple.Create(1, 1);
 		Tuple<int, int, int> activeMapElements = Tuple.Create(1, 1, 1);
 
-		// Common functions
-		bool getVariablesAndMaps_A(ModData modData, Action showPanel)
-		{		
+		// Common functions.
+		bool GetInputBaseMap(ModData modData, Action showPanel)
+		{
 			// Function : gets variables, and map A.
 			usingTiles = activeMapElements.Item1; usingResources = activeMapElements.Item2; usingActors = activeMapElements.Item3;
 
-			filepathTextField_A = panel.Get<TextFieldWidget>("FILE_PATH_A");
-			filepathText_A = filepathTextField_A.Text;
+			inputBaseMapFilepathTextField = panel.Get<TextFieldWidget>("FILE_PATH_A");
 
-			
-			// checks: file exists? 
-			if (!File.Exists(filepathTextField_A.Text))
+			// checks: file exists?
+			if (!File.Exists(inputBaseMapFilepathTextField.Text))
 			{
 				panel.Visible = false;
 				ConfirmationDialogs.ButtonPrompt(
@@ -111,8 +89,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			// checks: file of .oramap type?
 			try
 			{
-				var package_A = new Folder(".").OpenPackage(filepathTextField_A.Text, modData.ModFiles) as IReadWritePackage; 
-				Map_A = new Map(modData, package_A);
+				var package_A = new Folder(".").OpenPackage(inputBaseMapFilepathTextField.Text, modData.ModFiles) as IReadWritePackage;
+				inputBaseMap = new Map(modData, package_A);
 			}
 			catch (ArgumentException)
 			{
@@ -125,7 +103,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			// checks: mod ?
-			if (modData.Manifest.Id != Map_A.RequiresMod)
+			if (modData.Manifest.Id != inputBaseMap.RequiresMod)
 			{
 				panel.Visible = false;
 				ConfirmationDialogs.ButtonPrompt(
@@ -135,27 +113,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return false;
 			}
 
-			// variables
-			A_left   = Map_A.Bounds.Left; 
-			A_right  = Map_A.Bounds.Right;
-			A_X      = Map_A.MapSize.X;
-			A_W      = Map_A.Bounds.Width;
-			A_top    = Map_A.Bounds.Top; 
-			A_bottom = Map_A.Bounds.Bottom;
-			A_Y      = Map_A.MapSize.Y; 
-			A_H      = Map_A.Bounds.Height;
-
 			return true;
 		}
 
-		bool getVariablesAndMaps_B(ModData modData, Action showPanel)
+		bool GetInputSecondaryMap(ModData modData, Action showPanel)
 		{
 			// Function : gets variables, and map B.
-			filepathTextField_B = panel.Get<TextFieldWidget>("FILE_PATH_B");
-			filepathText_B = filepathTextField_B.Text;
+			inputSecondaryMapFilepathTextField = panel.Get<TextFieldWidget>("FILE_PATH_B");
 
-			// checks: file exists? 
-			if (!File.Exists(filepathTextField_B.Text))
+			// checks: file exists?
+			if (!File.Exists(inputSecondaryMapFilepathTextField.Text))
 			{
 				panel.Visible = false;
 				ConfirmationDialogs.ButtonPrompt(
@@ -168,8 +135,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			// checks: file of .oramap type?
 			try
 			{
-				var package_B = new Folder(".").OpenPackage(filepathTextField_B.Text, modData.ModFiles) as IReadWritePackage;
-				Map_B = new Map(modData, package_B);
+				var package_B = new Folder(".").OpenPackage(inputSecondaryMapFilepathTextField.Text, modData.ModFiles) as IReadWritePackage;
+				inputSecondaryMap = new Map(modData, package_B);
 			}
 			catch (ArgumentException)
 			{
@@ -182,7 +149,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			// checks: mod ?
-			if (modData.Manifest.Id != Map_B.RequiresMod)
+			if (modData.Manifest.Id != inputSecondaryMap.RequiresMod)
 			{
 				panel.Visible = false;
 				ConfirmationDialogs.ButtonPrompt(
@@ -192,32 +159,20 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return false;
 			}
 
-			// variables
-			B_left   = Map_B.Bounds.Left; 
-			B_right  = Map_B.Bounds.Right; 
-			B_top    = Map_B.Bounds.Top; 
-			B_bottom = Map_B.Bounds.Bottom;
-			
-			B_X      = Map_B.MapSize.X; 
-			B_Y      = Map_B.MapSize.Y; 
-				     
-			B_W      = Map_B.Bounds.Width;
-			B_H      = Map_B.Bounds.Height;
 			return true;
 		}
 
-		bool getVariablesAndMaps_AB(ModData modData, Action showPanel)
+		bool GetInputMaps(ModData modData, Action showPanel)
 		{
 			// Function : gets variables, and maps A and B.
-
-			if (!getVariablesAndMaps_A(modData, showPanel)) { return false; };
-			if (!getVariablesAndMaps_B(modData, showPanel)) { return false; };
+			if (!GetInputBaseMap(modData, showPanel)) { return false; }
+			if (!GetInputSecondaryMap(modData, showPanel)) { return false; }
 
 			// checks: same tileset?
-			tileset_A_txt = Map_A.Tileset;
-			tileset_B_txt = Map_B.Tileset;
+			inputBaseMapTilesetText = inputBaseMap.Tileset;
+			inputSecondaryMapTilesetText = inputSecondaryMap.Tileset;
 
-			if (tileset_A_txt != tileset_B_txt)
+			if (inputBaseMapTilesetText != inputSecondaryMapTilesetText)
 			{
 				panel.Visible = false;
 				ConfirmationDialogs.ButtonPrompt(
@@ -226,21 +181,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					onConfirm: showPanel);
 				return false;
 			}
-			Wmin = Math.Max(2, Math.Min(A_W, B_W)); // unused
-			Hmin = Math.Max(2, Math.Min(A_H, B_H)); // unused
 
-			Wmax = Math.Max(A_W, B_W); // unused
-			Hmax = Math.Max(A_H, B_H); // unused
-
-			Xmin = Math.Max(2, Math.Min(A_X, B_X));
-			Ymin = Math.Max(2, Math.Min(A_Y, B_Y));
-
-			Xmax = Math.Max(A_X, B_X);
-			Ymax = Math.Max(A_Y, B_Y);
+			minMapSizeX = Math.Max(2, Math.Min(inputBaseMap.MapSize.X, inputSecondaryMap.MapSize.X));
+			minMapSizeY = Math.Max(2, Math.Min(inputBaseMap.MapSize.Y, inputSecondaryMap.MapSize.Y));
 			return true;
 		}
 
-		void saveNewMap(Action<string> onSelect, Action onExit)
+		void SaveNewMap(Action<string> onSelect, Action onExit)
 		{
 			// saving the map
 			Action<string> afterSave = uid =>
@@ -263,13 +210,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					{ "onSave", afterSave },
 					{ "onExit", () => { Ui.CloseWindow(); onExit(); } },
-					{ "map", Map_C },
-					{ "playerDefinitions", Map_C.PlayerDefinitions },
-					{ "actorDefinitions", Map_C.ActorDefinitions }
+					{ "map", outputMap },
+					{ "playerDefinitions", outputMap.PlayerDefinitions },
+					{ "actorDefinitions", outputMap.ActorDefinitions }
 				});
 		}
-		
-		// Object creator
+
+		// Object creator.
 		[ObjectCreator.UseCtor]
 		public MapToolsLogic(Widget widget, World world, ModData modData, Action<string> onSelect, Action onExit)
 		{
@@ -280,7 +227,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var resizeDropdownH = panel.Get<DropDownButtonWidget>("RESIZE_H");
 			var mapElementsDropdown = panel.Get<DropDownButtonWidget>("USING_ELEMENTS");
 
-			resizeDropdownW.Text = "0.25"; 
+			resizeDropdownW.Text = "0.25";
 			resizeDropdownH.Text = "0.25";
 			mapElementsDropdown.Text = "T, R, A";
 
@@ -359,190 +306,173 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			panel.Get<ButtonWidget>("CANCEL_BUTTON").OnClick = () => { Ui.CloseWindow(); onExit(); };
 
-			//// Map Tools
-			//// APPEND TOOL
+			//// APPEND TOOL.
 			panel.Get<ButtonWidget>("APPEND_BUTTON").OnClick = () =>
 			{
-				// initialization. if fails, break.
-				if (!getVariablesAndMaps_AB(modData, showPanel)) { return; };
+				// Initialization. if fails, break.
+				if (!GetInputMaps(modData, showPanel)) { return; };
 
-				// copy map A to create map C
-				filepathText_C = filepathTextField_A.Text.Replace(".oramap", "") + "-Append";
-				filepathText_C += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
+				// Copy map A to create map C
+				outputMapFilepathText = inputBaseMapFilepathTextField.Text.Replace(".oramap", "") + "-Append";
+				outputMapFilepathText += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
 
-				System.IO.File.Copy(filepathText_A, filepathText_C, true);
-				var package_C = new Folder(".").OpenPackage(filepathText_C, modData.ModFiles) as IReadWritePackage;
-				Map_C = new Map(modData, package_C);
+				System.IO.File.Copy(inputBaseMapFilepathTextField.Text, outputMapFilepathText, true);
+				var package_C = new Folder(".").OpenPackage(outputMapFilepathText, modData.ModFiles) as IReadWritePackage;
+				outputMap = new Map(modData, package_C);
 
-				Map_C.Title += "-Append";
-				Map_C.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
+				outputMap.Title += "-Append";
+				outputMap.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
 
-				Map_C.Resize((A_X + B_X), Math.Max(A_Y, B_Y));
+				outputMap.Resize(inputBaseMap.MapSize.X + inputSecondaryMap.MapSize.X, Math.Max(inputBaseMap.MapSize.Y, inputSecondaryMap.MapSize.Y));
 
-				var LT_new = new PPos(A_left, Math.Min(A_top, B_top));
-				var RB_new = new PPos(A_X + B_right - 1, Math.Max(A_bottom, B_bottom) - 1);
-				Map_C.SetBounds(LT_new, RB_new);
+				var outputLeftTopCell = new PPos(inputBaseMap.Bounds.Left, Math.Min(inputBaseMap.Bounds.Top, inputSecondaryMap.Bounds.Top));
+				var outputRightBottomCell = new PPos(inputBaseMap.MapSize.X + inputSecondaryMap.Bounds.Right - 1,
+					Math.Max(inputBaseMap.Bounds.Bottom, inputSecondaryMap.Bounds.Bottom) - 1);
 
+				outputMap.SetBounds(outputLeftTopCell, outputRightBottomCell);
 
-				// APPEND TOOL
-				// appending B map to A : 
-				for (int j = 0; j < B_Y; j++)
+				// Appending B map to A.
+				for (int j = 0; j < inputSecondaryMap.MapSize.Y; j++)
 				{
-					for (int i = 0; i < B_X; i++)
+					for (int i = 0; i < inputSecondaryMap.MapSize.X; i++)
 					{
 						var posB = new MPos(i, j);
-						var posC = new MPos(i + A_X, j);
+						var posC = new MPos(i + inputBaseMap.MapSize.X, j);
 
-						if (usingTiles == 1) { Map_C.Tiles[posC] = Map_B.Tiles[posB]; Map_C.Height[posC] = Map_B.Height[posB]; };
-						if (usingResources == 1) { Map_C.Resources[posC] = Map_B.Resources[posB]; };
-
+						if (usingTiles == 1) { outputMap.Tiles[posC] = inputSecondaryMap.Tiles[posB]; outputMap.Height[posC] = inputSecondaryMap.Height[posB]; };
+						if (usingResources == 1) { outputMap.Resources[posC] = inputSecondaryMap.Resources[posB]; };
 					}
 				}
 
 				if (usingActors == 1)
 				{
-					foreach (var kv in Map_B.ActorDefinitions)
+					foreach (var kv in inputSecondaryMap.ActorDefinitions)
 					{
-
 						var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
 						var location = actor.InitDict.Get<LocationInit>().Value(null);
 
-						var loc_MPos_old = new CPos(location.X, location.Y).ToMPos(Map_C);
-						var loc_CPos_new = new MPos(loc_MPos_old.U + A_X, loc_MPos_old.V).ToCPos(Map_C);
-						var location_new = new LocationInit(loc_CPos_new);
+						var oldMPos = new CPos(location.X, location.Y).ToMPos(outputMap);
+						var newCPos = new MPos(oldMPos.U + inputBaseMap.MapSize.X, oldMPos.V).ToCPos(outputMap);
+						var newLocation = new LocationInit(newCPos);
 
 						var actType = actor.Type;
-						var actor_new = new ActorReference(actType) { location_new, new OwnerInit("Neutral") };
-						Map_C.ActorDefinitions.Add(new MiniYamlNode("Actor" + Map_C.ActorDefinitions.Count, actor_new.Save()));
-
+						var newActor = new ActorReference(actType) { newLocation, new OwnerInit("Neutral") };
+						outputMap.ActorDefinitions.Add(new MiniYamlNode("Actor" + outputMap.ActorDefinitions.Count, newActor.Save()));
 					}
 				}
 
-				saveNewMap(onSelect, onExit);
+				SaveNewMap(onSelect, onExit);
 			};
 
-			//// COPY TOOL
+			//// COPY TOOL.
 			panel.Get<ButtonWidget>("COPY_BUTTON").OnClick = () =>
 			{
-				// initialization. if fails, break.
-				if (!getVariablesAndMaps_AB(modData, showPanel)) { return; };
+				// Initialization. if fails, break.
+				if (!GetInputMaps(modData, showPanel)) { return; };
 
-				// copy map A to create map C
+				// Copy map A to create map C.
+				outputMapFilepathText = inputBaseMapFilepathTextField.Text.Replace(".oramap", "") + "-Copy";
+				outputMapFilepathText += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
 
-				filepathText_C = filepathTextField_A.Text.Replace(".oramap", "") + "-Copy";
-				filepathText_C += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
+				System.IO.File.Copy(inputBaseMapFilepathTextField.Text, outputMapFilepathText, true);
+				var package_C = new Folder(".").OpenPackage(outputMapFilepathText, modData.ModFiles) as IReadWritePackage;
+				outputMap = new Map(modData, package_C);
 
-				System.IO.File.Copy(filepathText_A, filepathText_C, true);
-				var package_C = new Folder(".").OpenPackage(filepathText_C, modData.ModFiles) as IReadWritePackage;
-				Map_C = new Map(modData, package_C);
+				outputMap.Title += "-Copy";
+				outputMap.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
 
-
-				Map_C.Title += "-Copy";
-				Map_C.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
-
-				// COPY TOOL
-				// --------------------------------------------------------------
-				// copying map B over A
-				for (int j = 0; j < Ymin; j++)
+				// Copying map B over A.
+				for (int j = 0; j < minMapSizeY; j++)
 				{
-					for (int i = 0; i < Xmin; i++)
+					for (int i = 0; i < minMapSizeX; i++)
 					{
 						var pos = new MPos(i, j);
 
-						if (usingTiles == 1) { Map_C.Tiles[pos] = Map_B.Tiles[pos]; Map_C.Height[pos] = Map_B.Height[pos]; };
-						if (usingResources == 1) { Map_C.Resources[pos] = Map_B.Resources[pos]; };
+						if (usingTiles == 1) { outputMap.Tiles[pos] = inputSecondaryMap.Tiles[pos]; outputMap.Height[pos] = inputSecondaryMap.Height[pos]; };
+						if (usingResources == 1) { outputMap.Resources[pos] = inputSecondaryMap.Resources[pos]; };
 					}
 				}
 
 				var forRemoval = new List<MiniYamlNode>();
 
-				foreach (var kv in Map_C.ActorDefinitions)
-				{
+				foreach (var kv in outputMap.ActorDefinitions)
 					forRemoval.Add(kv);
-				}
 
 				foreach (var kv in forRemoval)
-				{
-					Map_C.ActorDefinitions.Remove(kv);
-				}
+					outputMap.ActorDefinitions.Remove(kv);
 
 				if (usingActors == 1)
 				{
-					foreach (var kv in Map_B.ActorDefinitions)
+					foreach (var kv in inputSecondaryMap.ActorDefinitions)
 					{
 						var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
 						var location = actor.InitDict.Get<LocationInit>().Value(null);
-						var loc_MPos = new CPos(location.X, location.Y).ToMPos(Map_C);
+						var loc_MPos = new CPos(location.X, location.Y).ToMPos(outputMap);
 
-						bool inMapC_Bounds = (loc_MPos.U < Map_C.MapSize.X) && (loc_MPos.V < Map_C.MapSize.Y);
+						bool inoutputMap_Bounds = (loc_MPos.U < outputMap.MapSize.X) && (loc_MPos.V < outputMap.MapSize.Y);
 
-						if (inMapC_Bounds)
-						{
-							Map_C.ActorDefinitions.Add(new MiniYamlNode("Actor" + Map_C.ActorDefinitions.Count, actor.Save()));
-
-						}
+						if (inoutputMap_Bounds)
+							outputMap.ActorDefinitions.Add(new MiniYamlNode("Actor" + outputMap.ActorDefinitions.Count, actor.Save()));
 					}
 				};
 
-				foreach (var kv in Map_A.ActorDefinitions)
+				foreach (var kv in inputBaseMap.ActorDefinitions)
 				{
 					var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
 					var location = actor.InitDict.Get<LocationInit>().Value(null);
-					var loc_MPos = new CPos(location.X, location.Y).ToMPos(Map_C);
+					var loc_MPos = new CPos(location.X, location.Y).ToMPos(outputMap);
 
-					bool inMapC_Bounds = (loc_MPos.U < Map_C.MapSize.X) && (loc_MPos.V < Map_C.MapSize.Y);
-					bool inMapB_Bounds = (loc_MPos.U < B_X) && (loc_MPos.V < B_Y);
-					bool inMapB_reserved = ((usingActors == 1) && inMapB_Bounds);
+					bool inoutputMap_Bounds = (loc_MPos.U < outputMap.MapSize.X) && (loc_MPos.V < outputMap.MapSize.Y);
+					bool ininputSecondaryMap_Bounds = (loc_MPos.U < inputSecondaryMap.MapSize.X) && (loc_MPos.V < inputSecondaryMap.MapSize.Y);
+					bool ininputSecondaryMap_reserved = (usingActors == 1) && ininputSecondaryMap_Bounds;
 
-					if (inMapC_Bounds && !inMapB_reserved)
-					{
-						Map_C.ActorDefinitions.Add(new MiniYamlNode("Actor" + Map_C.ActorDefinitions.Count, actor.Save()));
-					}
+					if (inoutputMap_Bounds && !ininputSecondaryMap_reserved)
+						outputMap.ActorDefinitions.Add(new MiniYamlNode("Actor" + outputMap.ActorDefinitions.Count, actor.Save()));
 				}
 
-				saveNewMap(onSelect, onExit);
+				SaveNewMap(onSelect, onExit);
 			};
 
-			//// MIRROR_LEFT TOOL
+			//// MIRROR_LEFT TOOL.
 			panel.Get<ButtonWidget>("MIRROR_LEFT").OnClick = () =>
 			{
-				// initialization. if fails, break.
-				if (!getVariablesAndMaps_A(modData, showPanel)) { return; };
+				// Initialization. if fails, break.
+				if (!GetInputBaseMap(modData, showPanel)) { return; };
 
-				// copy map A to create map C
-				filepathText_C = filepathTextField_A.Text.Replace(".oramap", "") + "-MirrorLeft";
-				filepathText_C += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
+				// Copy map A to create map C.
+				outputMapFilepathText = inputBaseMapFilepathTextField.Text.Replace(".oramap", "") + "-MirrorLeft";
+				outputMapFilepathText += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
 
-				System.IO.File.Copy(filepathText_A, filepathText_C, true);
-				var package_C = new Folder(".").OpenPackage(filepathText_C, modData.ModFiles) as IReadWritePackage;
-				Map_C = new Map(modData, package_C);
+				System.IO.File.Copy(inputBaseMapFilepathTextField.Text, outputMapFilepathText, true);
+				var package_C = new Folder(".").OpenPackage(outputMapFilepathText, modData.ModFiles) as IReadWritePackage;
+				outputMap = new Map(modData, package_C);
 
-				Map_C.Title += "-MirrorLeft";
-				Map_C.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
+				outputMap.Title += "-MirrorLeft";
+				outputMap.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
 
+				// Calculations.
+				int halfWidth = inputBaseMap.Bounds.Width / 2;
+				int halfWidthRest = inputBaseMap.Bounds.Width % 2;
 
-				// MIRROR_LEFT TOOL
-				int A_W_half = A_W / 2;
-				int A_W_rest = A_W % 2;
+				halfWidth = halfWidth + halfWidthRest;
 
-				A_W_half = A_W_half + A_W_rest;
-
-				for (int j = 0; j < A_Y; j++)
+				for (int j = 0; j < inputBaseMap.MapSize.Y; j++)
 				{
-					for (int i = 0 ; i < A_W_half; i++)
+					for (int i = 0; i < halfWidth; i++)
 					{
-						var i_old = i + A_left;
+						var i_old = i + inputBaseMap.Bounds.Left;
 						var j_old = j;
 						var posA = new MPos(i_old, j_old);
 
-						var i_iso = (Map_A.Grid.Type == MapGridType.RectangularIsometric) ? j % 2 : 0;  // adding offset if Isometric map. See MPos diagram.
-						var i_new = A_right - (i + i_iso) - 1;
+						// Adding offset if Isometric map. See MPos diagram.
+						var i_iso = (inputBaseMap.Grid.Type == MapGridType.RectangularIsometric) ? j % 2 : 0;
+						var i_new = inputBaseMap.Bounds.Right - (i + i_iso) - 1;
 						var j_new = j_old;
 
 						var posC = new MPos(i_new, j_new);
 
-						if (usingTiles == 1) { Map_C.Tiles[posC] = Map_A.Tiles[posA]; Map_C.Height[posC] = Map_A.Height[posA]; };
-						if (usingResources == 1) { Map_C.Resources[posC] = Map_A.Resources[posA]; };
+						if (usingTiles == 1) { outputMap.Tiles[posC] = inputBaseMap.Tiles[posA]; outputMap.Height[posC] = inputBaseMap.Height[posA]; };
+						if (usingResources == 1) { outputMap.Resources[posC] = inputBaseMap.Resources[posA]; };
 					}
 				}
 
@@ -551,92 +481,94 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var forRemoval = new List<MiniYamlNode>();
 					var forKeeping = new List<MiniYamlNode>();
 
-					foreach (var kv in Map_C.ActorDefinitions)
+					foreach (var kv in outputMap.ActorDefinitions)
 					{
 						var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
 						var location = actor.InitDict.Get<LocationInit>().Value(null);
-						var location_MPos = new CPos(location.X, location.Y).ToMPos(Map_C);
+						var location_MPos = new CPos(location.X, location.Y).ToMPos(outputMap);
 
-						if ((A_left < location_MPos.U) && (location_MPos.U <= A_left + A_W_half - A_W_rest))
-						{
+						if ((inputBaseMap.Bounds.Left < location_MPos.U) && (location_MPos.U <= inputBaseMap.Bounds.Left + halfWidth - halfWidthRest))
 							forKeeping.Add(kv);
-						}
 						else
-						{
 							forRemoval.Add(kv);
-						}
 					}
+
 					foreach (var kv in forRemoval)
-					{
-						Map_C.ActorDefinitions.Remove(kv);
-					}
+						outputMap.ActorDefinitions.Remove(kv);
 
 					foreach (var kv in forKeeping)
 					{
 						var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
 						var location = actor.InitDict.Get<LocationInit>().Value(null);
 
-						var loc_MPos_old = location.ToMPos(Map_C);
+						var oldMPos = location.ToMPos(outputMap);
 
-						var i = loc_MPos_old.U - A_left;
-						var j = loc_MPos_old.V;
-						var i_iso = (Map_A.Grid.Type == MapGridType.RectangularIsometric) ? j % 2 : 0;
-						i += i_iso; // adding offset if Isometric map. See MPos diagram.
+						var i = oldMPos.U - inputBaseMap.Bounds.Left;
+						var j = oldMPos.V;
 
-						var loc_CPos_new = new MPos(A_right - 1 - i, j).ToCPos(Map_C);
-						var location_new = new LocationInit(loc_CPos_new);
+						// Adding offset if Isometric map. See MPos diagram.
+						var i_iso = (inputBaseMap.Grid.Type == MapGridType.RectangularIsometric) ? j % 2 : 0;
+						i += i_iso;
+
+						var newCPos = new MPos(inputBaseMap.Bounds.Right - 1 - i, j).ToCPos(outputMap);
+						var newLocation = new LocationInit(newCPos);
 
 						var actType = actor.Type;
-						var actor_new = new ActorReference(actType) { location_new, new OwnerInit("Neutral") };
-						Map_C.ActorDefinitions.Add(new MiniYamlNode("Actor" + Map_C.ActorDefinitions.Count, actor_new.Save()));
+						var newActor = new ActorReference(actType) { newLocation, new OwnerInit("Neutral") };
+						outputMap.ActorDefinitions.Add(new MiniYamlNode("Actor" + outputMap.ActorDefinitions.Count, newActor.Save()));
 					}
 				}
 
-				saveNewMap(onSelect, onExit);
+				SaveNewMap(onSelect, onExit);
 			};
 
-			//// MIRROR_TOP TOOL
+			//// MIRROR_TOP TOOL.
 			panel.Get<ButtonWidget>("MIRROR_TOP").OnClick = () =>
 			{
-				// initialization. if fails, break.
-				if (!getVariablesAndMaps_A(modData, showPanel)) { return; };
+				// Initialization. if fails, break.
+				if (!GetInputBaseMap(modData, showPanel)) { return; };
 
-				// copy map A to create map C
-				filepathText_C = filepathTextField_A.Text.Replace(".oramap", "") + "-MirrorTop";
-				filepathText_C += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
+				// Copy map A to create map C.
+				outputMapFilepathText = inputBaseMapFilepathTextField.Text.Replace(".oramap", "") + "-MirrorTop";
+				outputMapFilepathText += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
 
-				System.IO.File.Copy(filepathText_A, filepathText_C, true);
-				var package_C = new Folder(".").OpenPackage(filepathText_C, modData.ModFiles) as IReadWritePackage;
-				Map_C = new Map(modData, package_C);
+				System.IO.File.Copy(inputBaseMapFilepathTextField.Text, outputMapFilepathText, true);
+				var package_C = new Folder(".").OpenPackage(outputMapFilepathText, modData.ModFiles) as IReadWritePackage;
+				outputMap = new Map(modData, package_C);
 
-				Map_C.Title += "-MirrorTop";
-				Map_C.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
+				outputMap.Title += "-MirrorTop";
+				outputMap.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
 
-				// MIRROR_TOP TOOL
+				// Calculations.
+				int halfHeight = inputBaseMap.Bounds.Height / 2;
+				int halfHeightRest = inputBaseMap.Bounds.Height % 2;
+				halfHeight = halfHeight + halfHeightRest;
 
-				int A_H_half = A_H / 2;
-				int A_H_rest = A_H % 2;
-				A_H_half = A_H_half + A_H_rest;
-
-				for (int j = 0; j < A_H_half; j++)
+				for (int j = 0; j < halfHeight; j++)
 				{
-					for (int i = 0; i < A_X; i++)
+					for (int i = 0; i < inputBaseMap.MapSize.X; i++)
 					{
 						var i_old = i;
-						var j_old = j + A_top;
+						var j_old = j + inputBaseMap.Bounds.Top;
 						var posA = new MPos(i_old, j_old);
 
 						var i_new = i_old;
-						var j_new = A_bottom - (j) - 1;
-						if ((Map_A.Grid.Type == MapGridType.RectangularIsometric) && ((A_H % 2) == 0)) // if height is odd, MPos issue. (-1) offset to correct it.
-						{
+						var j_new = inputBaseMap.Bounds.Bottom - j - 1;
+
+						// If height is odd, MPos issue. (-1) offset to correct it.
+						if ((inputBaseMap.Grid.Type == MapGridType.RectangularIsometric) && ((inputBaseMap.Bounds.Height % 2) == 0))
 							j_new -= 1;
-						}
-						
+
 						var posC = new MPos(i_new, j_new);
 
-						if (usingTiles == 1) { Map_C.Tiles[posC] = Map_A.Tiles[posA]; Map_C.Height[posC] = Map_A.Height[posA]; };
-						if (usingResources == 1) { Map_C.Resources[posC] = Map_A.Resources[posA]; };
+						if (usingTiles == 1)
+						{
+							outputMap.Tiles[posC] = inputBaseMap.Tiles[posA];
+							outputMap.Height[posC] = inputBaseMap.Height[posA];
+						}
+
+						if (usingResources == 1)
+							outputMap.Resources[posC] = inputBaseMap.Resources[posA];
 					}
 				}
 
@@ -645,227 +577,200 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var forRemoval = new List<MiniYamlNode>();
 					var forKeeping = new List<MiniYamlNode>();
 
-					foreach (var kv in Map_C.ActorDefinitions)
+					foreach (var kv in outputMap.ActorDefinitions)
 					{
 						var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
 						var location = actor.InitDict.Get<LocationInit>().Value(null);
-						var location_MPos = new CPos(location.X, location.Y).ToMPos(Map_C);
+						var location_MPos = new CPos(location.X, location.Y).ToMPos(outputMap);
 
-						if ((A_top < location_MPos.V) && (location_MPos.V <= A_top + A_H_half - A_H_rest))
-						{
+						if ((inputBaseMap.Bounds.Top < location_MPos.V) && (location_MPos.V <= inputBaseMap.Bounds.Top + halfHeight - halfHeightRest))
 							forKeeping.Add(kv);
-						}
 						else
-						{
 							forRemoval.Add(kv);
-						}
-						
 					}
 
 					foreach (var kv in forRemoval)
-					{
-						Map_C.ActorDefinitions.Remove(kv);
-					}
+						outputMap.ActorDefinitions.Remove(kv);
 
 					foreach (var kv in forKeeping)
 					{
 						var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
 						var location = actor.InitDict.Get<LocationInit>().Value(null);
 
-						var loc_MPos_old = location.ToMPos(Map_C);
+						var oldMPos = location.ToMPos(outputMap);
 
+						var i = oldMPos.U;
+						var j_local = oldMPos.V - inputBaseMap.Bounds.Top;
 
-						var i = loc_MPos_old.U;
-						var j_local = loc_MPos_old.V - A_top;
-						
-						var j_new = A_bottom - 1 - j_local;
-						if ((Map_A.Grid.Type == MapGridType.RectangularIsometric) && ((A_H % 2) == 0)) // if height is odd, MPos issue. (-1) offset to correct it.
-						{
+						// If height is odd, MPos issue. (-1) offset to correct it.
+						var j_new = inputBaseMap.Bounds.Bottom - 1 - j_local;
+						if ((inputBaseMap.Grid.Type == MapGridType.RectangularIsometric) && ((inputBaseMap.Bounds.Height % 2) == 0))
 							j_new -= 1;
-						}
-						var loc_CPos_new = new MPos(i, j_new).ToCPos(Map_C);
-						var location_new = new LocationInit(loc_CPos_new);
+
+						var newCPos = new MPos(i, j_new).ToCPos(outputMap);
+						var newLocation = new LocationInit(newCPos);
 
 						var actType = actor.Type;
-						var actor_new = new ActorReference(actType) { location_new, new OwnerInit("Neutral") };
-						Map_C.ActorDefinitions.Add(new MiniYamlNode("Actor" + Map_C.ActorDefinitions.Count, actor_new.Save()));
+						var newActor = new ActorReference(actType) { newLocation, new OwnerInit("Neutral") };
+						outputMap.ActorDefinitions.Add(new MiniYamlNode("Actor" + outputMap.ActorDefinitions.Count, newActor.Save()));
 					}
 				};
-
-				saveNewMap(onSelect, onExit);
+				SaveNewMap(onSelect, onExit);
 			};
 
-			// RESIZE TOOL
+			// RESIZE TOOL.
 			panel.Get<ButtonWidget>("RESIZE_BUTTON").OnClick = () =>
 			{
+				// Initialization. If fails, break.
+				if (!GetInputBaseMap(modData, showPanel)) { return; };
 
-				// initialization. if fails, break.
-				if (!getVariablesAndMaps_A(modData, showPanel)) { return; };
+				// Copy map A to create map C.
+				outputMapFilepathText = inputBaseMapFilepathTextField.Text.Replace(".oramap", "") + "-Resize";
+				outputMapFilepathText += "_" + resizeDropdownW.Text.Replace(".", "");
+				outputMapFilepathText += "_" + resizeDropdownH.Text.Replace(".", "");
+				outputMapFilepathText += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
 
-				// copy map A to create map C
-				filepathText_C = filepathTextField_A.Text.Replace(".oramap", "") + "-Resize";
-				filepathText_C += "_" + resizeDropdownW.Text.Replace(".", "");
-				filepathText_C += "_" + resizeDropdownH.Text.Replace(".", "");
-				filepathText_C += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
-				
+				System.IO.File.Copy(inputBaseMapFilepathTextField.Text, outputMapFilepathText, true);
+				var package_C = new Folder(".").OpenPackage(outputMapFilepathText, modData.ModFiles) as IReadWritePackage;
+				outputMap = new Map(modData, package_C);
+				outputMap.Title += "-Resize";
+				outputMap.Title += "_" + resizeDropdownW.Text.Replace(".", "");
+				outputMap.Title += "_" + resizeDropdownH.Text.Replace(".", "");
+				outputMap.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
 
-				System.IO.File.Copy(filepathText_A, filepathText_C, true);
-				var package_C = new Folder(".").OpenPackage(filepathText_C, modData.ModFiles) as IReadWritePackage;
-				Map_C = new Map(modData, package_C);
-				Map_C.Title += "-Resize";
-				Map_C.Title += "_" + resizeDropdownW.Text.Replace(".", "");
-				Map_C.Title += "_" + resizeDropdownH.Text.Replace(".", "");
-				Map_C.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
-
-				///////////
-
-
-				// RESIZE TOOL
+				// Calculations.
 				int Aw = activeResizeW.Item1; int Bw = activeResizeW.Item2;
 				int Ah = activeResizeH.Item1; int Bh = activeResizeH.Item2;
 
-				int W = A_W;
-				int H = A_H;
+				int outputMapWidth = Math.Max(1, (inputBaseMap.Bounds.Width * Aw) / Bw);
+				int outputMapHeight = Math.Max(1, (inputBaseMap.Bounds.Height * Ah) / Bh);
 
-				int W_new = Math.Max(1, (A_W * Aw) / Bw);
-				int H_new = Math.Max(1, (A_H * Ah) / Bh);
+				var outputMapSizeX = inputBaseMap.MapSize.X + outputMapWidth - inputBaseMap.Bounds.Width;
+				var outputMapSizeY = inputBaseMap.MapSize.Y + outputMapHeight - inputBaseMap.Bounds.Height;
 
-				var A_X_new = A_X + W_new - W;
-				var A_Y_new = A_Y + H_new - H;
+				var outputLeftTopCell = new PPos(inputBaseMap.Bounds.Left, inputBaseMap.Bounds.Top);
+				var outputRightBottomCell = new PPos(inputBaseMap.Bounds.Left + outputMapWidth - 1, inputBaseMap.Bounds.Top + outputMapHeight - 1);
 
-				var LT_new = new PPos(A_left            , A_top            );
-				var RB_new = new PPos(A_left + W_new - 1, A_top + H_new - 1);
-
-				// fixing potential southern bound problem : resizeOffset
-				int[] A_Tiles_lastRow_height = new int[A_X];
-				for (int i = 0; i < A_X; i++)
+				// Fixing potential southern bound problem : resizeOffset.
+				int[] A_Tiles_lastRow_height = new int[inputBaseMap.MapSize.X];
+				for (int i = 0; i < inputBaseMap.MapSize.X; i++)
 				{
-					var posA = new MPos(i, A_Y - 1);
-					A_Tiles_lastRow_height[i] = Map_A.Height[posA];
+					var posA = new MPos(i, inputBaseMap.MapSize.Y - 1);
+					A_Tiles_lastRow_height[i] = inputBaseMap.Height[posA];
 				}
 
 				var A_Tiles_lastRow_MaxHeight = A_Tiles_lastRow_height.Max();
-				var A_bottomBound = A_Y - A_bottom;
+				var BottomBound = inputBaseMap.MapSize.Y - inputBaseMap.Bounds.Bottom;
 				var resizeOffset = 0;
 
-				if (A_bottomBound == A_Tiles_lastRow_MaxHeight) { resizeOffset = 1; }
+				if (BottomBound == A_Tiles_lastRow_MaxHeight)
+					resizeOffset = 1;
 
-				// resize and set bounds
-				Map_C.Resize(A_X_new, A_Y_new + resizeOffset);
-				Map_C.SetBounds(LT_new, RB_new); // radar widget bug ???
+				// Resize and set bounds.
+				outputMap.Resize(outputMapSizeX, outputMapSizeY + resizeOffset);
+				outputMap.SetBounds(outputLeftTopCell, outputRightBottomCell);
 
-				// grid B resizing bigger
-				for (int local_j_new = 1; local_j_new <= H_new; local_j_new++)
+				// Grid B resizing bigger.
+				for (int local_j_new = 1; local_j_new <= outputMapHeight; local_j_new++)
 				{
-					for (int local_i_new = 1; local_i_new <= W_new; local_i_new++)
+					for (int local_i_new = 1; local_i_new <= outputMapWidth; local_i_new++)
 					{
-						var local_i_old = Math.Max(1, Math.Min(W, (local_i_new * Bw) / Aw));
-						var local_j_old = Math.Max(1, Math.Min(H, (local_j_new * Bh) / Ah));
+						var local_i_old = Math.Max(1, Math.Min(inputBaseMap.Bounds.Width, (local_i_new * Bw) / Aw));
+						var local_j_old = Math.Max(1, Math.Min(inputBaseMap.Bounds.Height, (local_j_new * Bh) / Ah));
 
-						var i_new = (local_i_new - 1) + A_left; var j_new = (local_j_new - 1) + A_top;
-						var i_old = (local_i_old - 1) + A_left; var j_old = (local_j_old - 1) + A_top;
+						var i_new = (local_i_new - 1) + inputBaseMap.Bounds.Left; var j_new = (local_j_new - 1) + inputBaseMap.Bounds.Top;
+						var i_old = (local_i_old - 1) + inputBaseMap.Bounds.Left; var j_old = (local_j_old - 1) + inputBaseMap.Bounds.Top;
 
 						var posC = new MPos(i_new, j_new);
 						var posA = new MPos(i_old, j_old);
 
-						if (usingTiles == 1) { Map_C.Tiles[posC] = Map_A.Tiles[posA]; Map_C.Height[posC] = Map_A.Height[posA]; };
-						if (usingResources == 1) { Map_C.Resources[posC] = Map_A.Resources[posA]; };
+						if (usingTiles == 1) { outputMap.Tiles[posC] = inputBaseMap.Tiles[posA]; outputMap.Height[posC] = inputBaseMap.Height[posA]; };
+						if (usingResources == 1) { outputMap.Resources[posC] = inputBaseMap.Resources[posA]; };
 					}
 				}
 
-				// cleaning bottom border, if resize Y < 1;
+				// Cleaning bottom border, if resize Y < 1.
 				if (Ah < Bh)
 				{
-					for (int j_old = A_bottom; j_old < A_Y; j_old++)
+					for (int j_old = inputBaseMap.Bounds.Bottom; j_old < inputBaseMap.MapSize.Y; j_old++)
 					{
-						for (int i_old = 0; i_old < Math.Min(A_X, A_X_new); i_old++)
+						for (int i_old = 0; i_old < Math.Min(inputBaseMap.MapSize.X, outputMapSizeX); i_old++)
 						{
-
 							var i_new = i_old;
-							var j_new = j_old + H_new - H;
+							var j_new = j_old + outputMapHeight - inputBaseMap.Bounds.Height;
 
 							var posC = new MPos(i_new, j_new);
 							var posA = new MPos(i_old, j_old);
 
-							Map_C.Tiles[posC] = Map_A.Tiles[posA]; Map_C.Height[posC] = Map_A.Height[posA];
-							Map_C.Resources[posC] = Map_A.Resources[posA];
+							outputMap.Tiles[posC] = inputBaseMap.Tiles[posA]; outputMap.Height[posC] = inputBaseMap.Height[posA];
+							outputMap.Resources[posC] = inputBaseMap.Resources[posA];
 						}
 					}
 				}
 
-
-
-				// cleaning right border, if resize X < 1;
+				// Cleaning right border, if resize X < 1.
 				if (Aw < Bw)
 				{
-					for (int j_old = 0; j_old < Math.Min(A_Y, A_Y_new); j_old++)
+					for (int j_old = 0; j_old < Math.Min(inputBaseMap.MapSize.Y, outputMapSizeY); j_old++)
 					{
-						for (int i_old = A_right; i_old < A_X; i_old++)
+						for (int i_old = inputBaseMap.Bounds.Right; i_old < inputBaseMap.MapSize.X; i_old++)
 						{
-							var i_new = i_old + W_new - W;
+							var i_new = i_old + outputMapWidth - inputBaseMap.Bounds.Width;
 							var j_new = j_old;
 
 							var posC = new MPos(i_new, j_new);
 							var posA = new MPos(i_old, j_old);
 
-							Map_C.Tiles[posC] = Map_A.Tiles[posA]; Map_C.Height[posC] = Map_A.Height[posA];
-							Map_C.Resources[posC] = Map_A.Resources[posA];
+							outputMap.Tiles[posC] = inputBaseMap.Tiles[posA]; outputMap.Height[posC] = inputBaseMap.Height[posA];
+							outputMap.Resources[posC] = inputBaseMap.Resources[posA];
 						}
 					}
 				}
 
 				var forRemoval = new List<MiniYamlNode>();
 
-				foreach (var kv in Map_C.ActorDefinitions)
-				{
+				foreach (var kv in outputMap.ActorDefinitions)
 					forRemoval.Add(kv);
-				}
+
 				foreach (var kv in forRemoval)
-				{
-					Map_C.ActorDefinitions.Remove(kv);
-				}
+					outputMap.ActorDefinitions.Remove(kv);
 
-				foreach (var kv in Map_A.ActorDefinitions)
+				foreach (var kv in inputBaseMap.ActorDefinitions)
 				{
-
 					var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
 					var location = actor.InitDict.Get<LocationInit>().Value(null);
 					var actType = actor.Type;
 
-					var loc_MPos_old = new CPos(location.X, location.Y).ToMPos(Map_C);
-					var X_old = loc_MPos_old.U; var Y_old = loc_MPos_old.V;
-					var local_X_old = X_old - A_left; var local_Y_old = Y_old - A_top;
+					var oldMPos = new CPos(location.X, location.Y).ToMPos(outputMap);
+					var oldX = oldMPos.U; var oldY = oldMPos.V;
+					var local_oldX = oldX - inputBaseMap.Bounds.Left; var local_oldY = oldY - inputBaseMap.Bounds.Top;
 
-					var inBounds = ((A_left <= X_old) && (X_old < A_right)) && ((A_top <= Y_old) && (Y_old < A_bottom));
+					var inBounds = ((inputBaseMap.Bounds.Left <= oldX) && (oldX < inputBaseMap.Bounds.Right)) &&
+						((inputBaseMap.Bounds.Top <= oldY) && (oldY < inputBaseMap.Bounds.Bottom));
+
 					if (inBounds)
 					{
 						if (usingActors == 1)
 						{
-							var local_X_new = Math.Min((local_X_old * Aw) / Bw, W_new - 1);
-							var local_Y_new = Math.Min((local_Y_old * Ah) / Bh, H_new - 1);
+							var local_newX = Math.Min((local_oldX * Aw) / Bw, outputMapWidth - 1);
+							var local_newY = Math.Min((local_oldY * Ah) / Bh, outputMapHeight - 1);
 
-							var X_new = local_X_new + A_left;
-							var Y_new = local_Y_new + A_top;
-							var loc_CPos_new = new MPos(X_new, Y_new).ToCPos(Map_C);
-							var location_new = new LocationInit(loc_CPos_new);
+							var newX = local_newX + inputBaseMap.Bounds.Left;
+							var newY = local_newY + inputBaseMap.Bounds.Top;
+							var newCPos = new MPos(newX, newY).ToCPos(outputMap);
+							var newLocation = new LocationInit(newCPos);
 
-							var actor_new = new ActorReference(actType) { location_new, new OwnerInit("Neutral") };
-							Map_C.ActorDefinitions.Add(new MiniYamlNode("Actor" + Map_C.ActorDefinitions.Count, actor_new.Save()));
-
-						};
+							var newActor = new ActorReference(actType) { newLocation, new OwnerInit("Neutral") };
+							outputMap.ActorDefinitions.Add(new MiniYamlNode("Actor" + outputMap.ActorDefinitions.Count, newActor.Save()));
+						}
 
 						if (usingActors == 0)
-						{
-							Map_C.ActorDefinitions.Add(new MiniYamlNode("Actor" + Map_C.ActorDefinitions.Count, actor.Save()));
-						};
-
+							outputMap.ActorDefinitions.Add(new MiniYamlNode("Actor" + outputMap.ActorDefinitions.Count, actor.Save()));
 					}
-
 				}
-				saveNewMap(onSelect, onExit);
 
+				SaveNewMap(onSelect, onExit);
 			};
-
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapToolsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapToolsLogic.cs
@@ -1,0 +1,775 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using OpenRA.FileSystem;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+	public class MapToolsLogic : ChromeLogic
+	{
+		Widget panel;
+
+		class DropDownOption
+		{
+			public string Title;
+			public Func<bool> IsSelected;
+			public Action OnClick;
+		}
+
+		// Constants.
+		static Dictionary<string, Tuple<int, int>> resizeFactors = new Dictionary<string, Tuple<int, int>>
+			{ // Default Resize Factors.
+				{ "0.25", Tuple.Create(1, 4) },
+				{ "0.50", Tuple.Create(1, 2) },
+				{ "0.75", Tuple.Create(3, 4) },
+				{ "0.90", Tuple.Create(9, 10) },
+				{ "1.00", Tuple.Create(1, 1) },
+				{ "1.10", Tuple.Create(11, 10) },
+				{ "1.25", Tuple.Create(5, 4) },
+				{ "1.33", Tuple.Create(4, 3) },
+				{ "1.50", Tuple.Create(3, 2) },
+				{ "2.00", Tuple.Create(2, 1) }
+			};
+		static Dictionary<string, Tuple<int, int, int>> mapElements = new Dictionary<string, Tuple<int, int, int>>
+			{ // Default Resize Factors.
+				{ "T, R, A", Tuple.Create(1, 1, 1) },
+				{ "T, R, _", Tuple.Create(1, 1, 0) },
+				{ "T, _, A", Tuple.Create(1, 0, 1) },
+				{ "_, R, A", Tuple.Create(0, 1, 1) },
+				{ "T, _, _", Tuple.Create(1, 0, 0) },
+				{ "_, R, _", Tuple.Create(0, 1, 0) },
+				{ "_, _, A", Tuple.Create(0, 0, 1) }
+			};
+
+		// Shared variables.
+		Map inputBaseMap = null;
+		Map inputSecondaryMap = null;
+		Map outputMap = null;
+
+		TextFieldWidget inputBaseMapFilepathTextField = null;
+		TextFieldWidget inputSecondaryMapFilepathTextField = null;
+
+		string outputMapFilepathText = "";
+
+		string inputBaseMapTilesetText = "";
+		string inputSecondaryMapTilesetText = "";
+
+		int minMapSizeX = 0;
+		int minMapSizeY = 0;
+
+		int usingTiles = 0; int usingResources = 0; int usingActors = 0;
+
+		Tuple<int, int> activeResizeW = Tuple.Create(1, 1);
+		Tuple<int, int> activeResizeH = Tuple.Create(1, 1);
+		Tuple<int, int, int> activeMapElements = Tuple.Create(1, 1, 1);
+
+		// Common functions.
+		bool GetInputBaseMap(ModData modData, Action showPanel)
+		{
+			// Function : gets variables, and Base map.
+			usingTiles = activeMapElements.Item1; usingResources = activeMapElements.Item2; usingActors = activeMapElements.Item3;
+
+			inputBaseMapFilepathTextField = panel.Get<TextFieldWidget>("FILE_PATH_A");
+
+			// checks: file exists?
+			if (!File.Exists(inputBaseMapFilepathTextField.Text))
+			{
+				panel.Visible = false;
+				ConfirmationDialogs.ButtonPrompt(
+					title: "Base map not found",
+					text: "Base map does not exist or could not be accessed.",
+					onConfirm: showPanel);
+				return false;
+			}
+
+			// checks: file of .oramap type?
+			try
+			{
+				var inputBaseMapPackage = new Folder(".").OpenPackage(inputBaseMapFilepathTextField.Text, modData.ModFiles) as IReadWritePackage;
+				inputBaseMap = new Map(modData, inputBaseMapPackage);
+			}
+			catch (ArgumentException)
+			{
+				panel.Visible = false;
+				ConfirmationDialogs.ButtonPrompt(
+					title: "Incompatible file format",
+					text: "Base file must be of .oramap type!",
+					onConfirm: showPanel);
+				return false;
+			}
+
+			// checks: mod ?
+			if (modData.Manifest.Id != inputBaseMap.RequiresMod)
+			{
+				panel.Visible = false;
+				ConfirmationDialogs.ButtonPrompt(
+					title: "Incompatible mod",
+					text: "Base map incompatible with mod.",
+					onConfirm: showPanel);
+				return false;
+			}
+
+			return true;
+		}
+
+		bool GetInputSecondaryMap(ModData modData, Action showPanel)
+		{
+			// Function : gets variables, and Secondary map.
+			inputSecondaryMapFilepathTextField = panel.Get<TextFieldWidget>("FILE_PATH_B");
+
+			// checks: file exists?
+			if (!File.Exists(inputSecondaryMapFilepathTextField.Text))
+			{
+				panel.Visible = false;
+				ConfirmationDialogs.ButtonPrompt(
+					title: "Secondary map not found",
+					text: "Sec. map does not exist or could not be accessed.",
+					onConfirm: showPanel);
+				return false;
+			}
+
+			// checks: file of .oramap type?
+			try
+			{
+				var inputSecondaryMapPackage = new Folder(".").OpenPackage(inputSecondaryMapFilepathTextField.Text, modData.ModFiles) as IReadWritePackage;
+				inputSecondaryMap = new Map(modData, inputSecondaryMapPackage);
+			}
+			catch (ArgumentException)
+			{
+				panel.Visible = false;
+				ConfirmationDialogs.ButtonPrompt(
+					title: "Incompatible file format",
+					text: "Secondary file must be of .oramap type!",
+					onConfirm: showPanel);
+				return false;
+			}
+
+			// checks: mod ?
+			if (modData.Manifest.Id != inputSecondaryMap.RequiresMod)
+			{
+				panel.Visible = false;
+				ConfirmationDialogs.ButtonPrompt(
+					title: "Incompatible mod",
+					text: "Secondary map incompatible with mod.",
+					onConfirm: showPanel);
+				return false;
+			}
+
+			return true;
+		}
+
+		bool GetInputMaps(ModData modData, Action showPanel)
+		{
+			// Function : gets variables, and maps A and B.
+			if (!GetInputBaseMap(modData, showPanel)) { return false; }
+			if (!GetInputSecondaryMap(modData, showPanel)) { return false; }
+
+			// checks: same tileset?
+			inputBaseMapTilesetText = inputBaseMap.Tileset;
+			inputSecondaryMapTilesetText = inputSecondaryMap.Tileset;
+
+			if (inputBaseMapTilesetText != inputSecondaryMapTilesetText)
+			{
+				panel.Visible = false;
+				ConfirmationDialogs.ButtonPrompt(
+					title: "Different tilesets",
+					text: "The maps have different tilesets.",
+					onConfirm: showPanel);
+				return false;
+			}
+
+			minMapSizeX = Math.Max(2, Math.Min(inputBaseMap.MapSize.X, inputSecondaryMap.MapSize.X));
+			minMapSizeY = Math.Max(2, Math.Min(inputBaseMap.MapSize.Y, inputSecondaryMap.MapSize.Y));
+			return true;
+		}
+
+		void SaveNewMap(Action<string> onSelect, Action onExit)
+		{
+			// saving the map
+			Action<string> afterSave = uid =>
+			{
+				// HACK: Work around a synced-code change check.
+				// It's not clear why this is needed here, but not in the other places that load maps.
+				Game.RunAfterTick(() =>
+				{
+					ConnectionLogic.Connect(System.Net.IPAddress.Loopback.ToString(),
+						Game.CreateLocalServer(uid), "",
+						() => Game.LoadEditor(uid),
+						() => { Game.CloseServer(); onExit(); });
+				});
+
+				Ui.CloseWindow();
+				onSelect(uid);
+			};
+
+			Ui.OpenWindow("SAVE_MAP_PANEL", new WidgetArgs()
+				{
+					{ "onSave", afterSave },
+					{ "onExit", () => { Ui.CloseWindow(); onExit(); } },
+					{ "map", outputMap },
+					{ "playerDefinitions", outputMap.PlayerDefinitions },
+					{ "actorDefinitions", outputMap.ActorDefinitions }
+				});
+		}
+
+		// Object creator.
+		[ObjectCreator.UseCtor]
+		public MapToolsLogic(Widget widget, World world, ModData modData, Action<string> onSelect, Action onExit)
+		{
+			panel = widget;
+			Action showPanel = () => panel.Visible = true;
+
+			var resizeDropdownW = panel.Get<DropDownButtonWidget>("RESIZE_W");
+			var resizeDropdownH = panel.Get<DropDownButtonWidget>("RESIZE_H");
+			var mapElementsDropdown = panel.Get<DropDownButtonWidget>("USING_ELEMENTS");
+
+			resizeDropdownW.Text = "0.25";
+			resizeDropdownH.Text = "0.25";
+			mapElementsDropdown.Text = "T, R, A";
+
+			activeResizeW = resizeFactors[resizeDropdownW.Text];
+			activeResizeH = resizeFactors[resizeDropdownH.Text];
+			activeMapElements = mapElements[mapElementsDropdown.Text];
+
+			resizeDropdownW.OnMouseDown = _ =>
+			{
+				var resizeFactorsB = resizeFactors.Select(kv => new DropDownOption
+				{
+					Title = kv.Key,
+					IsSelected = () => resizeDropdownW.Text == kv.Key,
+					OnClick = () =>
+					{
+						resizeDropdownW.Text = kv.Key;
+						activeResizeW = resizeFactors[kv.Key];
+					}
+				});
+
+				Func<DropDownOption, ScrollItemWidget, ScrollItemWidget> setupItem = (option, template) =>
+				{
+					var item = ScrollItemWidget.Setup(template, option.IsSelected, option.OnClick);
+					item.Get<LabelWidget>("LABEL").GetText = () => option.Title;
+					return item;
+				};
+
+				resizeDropdownW.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", resizeFactorsB.Count() * 30, resizeFactorsB, setupItem);
+			};
+
+			resizeDropdownH.OnMouseDown = _ =>
+			{
+				var resizeFactorsB = resizeFactors.Select(kv => new DropDownOption
+				{
+					Title = kv.Key,
+					IsSelected = () => resizeDropdownH.Text == kv.Key,
+					OnClick = () =>
+					{
+						resizeDropdownH.Text = kv.Key;
+						activeResizeH = resizeFactors[kv.Key];
+					}
+				});
+
+				Func<DropDownOption, ScrollItemWidget, ScrollItemWidget> setupItem = (option, template) =>
+				{
+					var item = ScrollItemWidget.Setup(template, option.IsSelected, option.OnClick);
+					item.Get<LabelWidget>("LABEL").GetText = () => option.Title;
+					return item;
+				};
+
+				resizeDropdownH.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", resizeFactorsB.Count() * 30, resizeFactorsB, setupItem);
+			};
+
+			mapElementsDropdown.OnMouseDown = _ =>
+			{
+				var mapElementsB = mapElements.Select(kv => new DropDownOption
+				{
+					Title = kv.Key,
+					IsSelected = () => mapElementsDropdown.Text == kv.Key,
+					OnClick = () =>
+					{
+						mapElementsDropdown.Text = kv.Key;
+						activeMapElements = mapElements[kv.Key];
+					}
+				});
+
+				Func<DropDownOption, ScrollItemWidget, ScrollItemWidget> setupItem = (option, template) =>
+				{
+					var item = ScrollItemWidget.Setup(template, option.IsSelected, option.OnClick);
+					item.Get<LabelWidget>("LABEL").GetText = () => option.Title;
+					return item;
+				};
+
+				mapElementsDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", mapElementsB.Count() * 30, mapElementsB, setupItem);
+			};
+
+			panel.Get<ButtonWidget>("CANCEL_BUTTON").OnClick = () => { Ui.CloseWindow(); onExit(); };
+
+			//// APPEND TOOL.
+			panel.Get<ButtonWidget>("APPEND_BUTTON").OnClick = () =>
+			{
+				// Initialization. If fails, break.
+				if (!GetInputMaps(modData, showPanel)) { return; };
+
+				// Copy Base map to create Output map
+				outputMapFilepathText = inputBaseMapFilepathTextField.Text.Replace(".oramap", "") + "-Append";
+				outputMapFilepathText += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
+
+				System.IO.File.Copy(inputBaseMapFilepathTextField.Text, outputMapFilepathText, true);
+				var outputPackage = new Folder(".").OpenPackage(outputMapFilepathText, modData.ModFiles) as IReadWritePackage;
+				outputMap = new Map(modData, outputPackage);
+
+				outputMap.Title += "-Append";
+				outputMap.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
+
+				outputMap.Resize(inputBaseMap.MapSize.X + inputSecondaryMap.MapSize.X, Math.Max(inputBaseMap.MapSize.Y, inputSecondaryMap.MapSize.Y));
+
+				var outputLeftTopCell = new PPos(inputBaseMap.Bounds.Left, Math.Min(inputBaseMap.Bounds.Top, inputSecondaryMap.Bounds.Top));
+				var outputRightBottomCell = new PPos(inputBaseMap.MapSize.X + inputSecondaryMap.Bounds.Right - 1,
+					Math.Max(inputBaseMap.Bounds.Bottom, inputSecondaryMap.Bounds.Bottom) - 1);
+
+				outputMap.SetBounds(outputLeftTopCell, outputRightBottomCell);
+
+				// Appending Secondary map to Base map.
+				for (int j = 0; j < inputSecondaryMap.MapSize.Y; j++)
+				{
+					for (int i = 0; i < inputSecondaryMap.MapSize.X; i++)
+					{
+						var posB = new MPos(i, j);
+						var outPos = new MPos(i + inputBaseMap.MapSize.X, j);
+
+						if (usingTiles == 1) { outputMap.Tiles[outPos] = inputSecondaryMap.Tiles[posB]; outputMap.Height[outPos] = inputSecondaryMap.Height[posB]; };
+						if (usingResources == 1) { outputMap.Resources[outPos] = inputSecondaryMap.Resources[posB]; };
+					}
+				}
+
+				if (usingActors == 1)
+				{
+					foreach (var kv in inputSecondaryMap.ActorDefinitions)
+					{
+						var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+						var location = actor.InitDict.Get<LocationInit>().Value(null);
+
+						var oldMPos = new CPos(location.X, location.Y).ToMPos(outputMap);
+						var newCPos = new MPos(oldMPos.U + inputBaseMap.MapSize.X, oldMPos.V).ToCPos(outputMap);
+						var newLocation = new LocationInit(newCPos);
+
+						var actType = actor.Type;
+						var newActor = new ActorReference(actType) { newLocation, new OwnerInit("Neutral") };
+						outputMap.ActorDefinitions.Add(new MiniYamlNode("Actor" + outputMap.ActorDefinitions.Count, newActor.Save()));
+					}
+				}
+
+				SaveNewMap(onSelect, onExit);
+			};
+
+			//// COPY TOOL.
+			panel.Get<ButtonWidget>("COPY_BUTTON").OnClick = () =>
+			{
+				// Initialization. If fails, break.
+				if (!GetInputMaps(modData, showPanel)) { return; };
+
+				// Copy Base map to create Output map.
+				outputMapFilepathText = inputBaseMapFilepathTextField.Text.Replace(".oramap", "") + "-Copy";
+				outputMapFilepathText += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
+
+				System.IO.File.Copy(inputBaseMapFilepathTextField.Text, outputMapFilepathText, true);
+				var outputPackage = new Folder(".").OpenPackage(outputMapFilepathText, modData.ModFiles) as IReadWritePackage;
+				outputMap = new Map(modData, outputPackage);
+
+				outputMap.Title += "-Copy";
+				outputMap.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
+
+				// Copying Secondary map over Base map.
+				for (int j = 0; j < minMapSizeY; j++)
+				{
+					for (int i = 0; i < minMapSizeX; i++)
+					{
+						var pos = new MPos(i, j);
+
+						if (usingTiles == 1) { outputMap.Tiles[pos] = inputSecondaryMap.Tiles[pos]; outputMap.Height[pos] = inputSecondaryMap.Height[pos]; };
+						if (usingResources == 1) { outputMap.Resources[pos] = inputSecondaryMap.Resources[pos]; };
+					}
+				}
+
+				var forRemoval = new List<MiniYamlNode>();
+
+				foreach (var kv in outputMap.ActorDefinitions)
+					forRemoval.Add(kv);
+
+				foreach (var kv in forRemoval)
+					outputMap.ActorDefinitions.Remove(kv);
+
+				if (usingActors == 1)
+				{
+					foreach (var kv in inputSecondaryMap.ActorDefinitions)
+					{
+						var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+						var location = actor.InitDict.Get<LocationInit>().Value(null);
+						var loc_MPos = new CPos(location.X, location.Y).ToMPos(outputMap);
+
+						bool outputMap_Bounds = (loc_MPos.U < outputMap.MapSize.X) && (loc_MPos.V < outputMap.MapSize.Y);
+
+						if (outputMap_Bounds)
+							outputMap.ActorDefinitions.Add(new MiniYamlNode("Actor" + outputMap.ActorDefinitions.Count, actor.Save()));
+					}
+				};
+
+				foreach (var kv in inputBaseMap.ActorDefinitions)
+				{
+					var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+					var location = actor.InitDict.Get<LocationInit>().Value(null);
+					var loc_MPos = new CPos(location.X, location.Y).ToMPos(outputMap);
+
+					bool outputMap_Bounds = (loc_MPos.U < outputMap.MapSize.X) && (loc_MPos.V < outputMap.MapSize.Y);
+					bool inputSecondaryMap_Bounds = (loc_MPos.U < inputSecondaryMap.MapSize.X) && (loc_MPos.V < inputSecondaryMap.MapSize.Y);
+					bool inputSecondaryMap_reserved = (usingActors == 1) && inputSecondaryMap_Bounds;
+
+					if (outputMap_Bounds && !inputSecondaryMap_reserved)
+						outputMap.ActorDefinitions.Add(new MiniYamlNode("Actor" + outputMap.ActorDefinitions.Count, actor.Save()));
+				}
+
+				SaveNewMap(onSelect, onExit);
+			};
+
+			//// MIRROR_LEFT TOOL.
+			panel.Get<ButtonWidget>("MIRROR_LEFT").OnClick = () =>
+			{
+				// Initialization. If fails, break.
+				if (!GetInputBaseMap(modData, showPanel)) { return; };
+
+				// Copy Base map to create Output map.
+				outputMapFilepathText = inputBaseMapFilepathTextField.Text.Replace(".oramap", "") + "-MirrorLeft";
+				outputMapFilepathText += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
+
+				System.IO.File.Copy(inputBaseMapFilepathTextField.Text, outputMapFilepathText, true);
+				var outputPackage = new Folder(".").OpenPackage(outputMapFilepathText, modData.ModFiles) as IReadWritePackage;
+				outputMap = new Map(modData, outputPackage);
+
+				outputMap.Title += "-MirrorLeft";
+				outputMap.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
+
+				// Calculations.
+				int halfWidth = inputBaseMap.Bounds.Width / 2;
+				int halfWidthRest = inputBaseMap.Bounds.Width % 2;
+
+				halfWidth = halfWidth + halfWidthRest;
+
+				for (int j = 0; j < inputBaseMap.MapSize.Y; j++)
+				{
+					for (int i = 0; i < halfWidth; i++)
+					{
+						var i_old = i + inputBaseMap.Bounds.Left;
+						var j_old = j;
+						var inPos = new MPos(i_old, j_old);
+
+						// Adding offset if Isometric map. See MPos diagram.
+						var i_iso = (inputBaseMap.Grid.Type == MapGridType.RectangularIsometric) ? j % 2 : 0;
+						var i_new = inputBaseMap.Bounds.Right - (i + i_iso) - 1;
+						var j_new = j_old;
+
+						var outPos = new MPos(i_new, j_new);
+
+						if (usingTiles == 1) { outputMap.Tiles[outPos] = inputBaseMap.Tiles[inPos]; outputMap.Height[outPos] = inputBaseMap.Height[inPos]; };
+						if (usingResources == 1) { outputMap.Resources[outPos] = inputBaseMap.Resources[inPos]; };
+					}
+				}
+
+				if (usingActors == 1)
+				{
+					var forRemoval = new List<MiniYamlNode>();
+					var forKeeping = new List<MiniYamlNode>();
+
+					foreach (var kv in outputMap.ActorDefinitions)
+					{
+						var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+						var location = actor.InitDict.Get<LocationInit>().Value(null);
+						var location_MPos = new CPos(location.X, location.Y).ToMPos(outputMap);
+
+						if ((inputBaseMap.Bounds.Left < location_MPos.U) && (location_MPos.U <= inputBaseMap.Bounds.Left + halfWidth - halfWidthRest))
+							forKeeping.Add(kv);
+						else
+							forRemoval.Add(kv);
+					}
+
+					foreach (var kv in forRemoval)
+						outputMap.ActorDefinitions.Remove(kv);
+
+					foreach (var kv in forKeeping)
+					{
+						var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+						var location = actor.InitDict.Get<LocationInit>().Value(null);
+
+						var oldMPos = location.ToMPos(outputMap);
+
+						var i = oldMPos.U - inputBaseMap.Bounds.Left;
+						var j = oldMPos.V;
+
+						// Adding offset if Isometric map. See MPos diagram.
+						var i_iso = (inputBaseMap.Grid.Type == MapGridType.RectangularIsometric) ? j % 2 : 0;
+						i += i_iso;
+
+						var newCPos = new MPos(inputBaseMap.Bounds.Right - 1 - i, j).ToCPos(outputMap);
+						var newLocation = new LocationInit(newCPos);
+
+						var actType = actor.Type;
+						var newActor = new ActorReference(actType) { newLocation, new OwnerInit("Neutral") };
+						outputMap.ActorDefinitions.Add(new MiniYamlNode("Actor" + outputMap.ActorDefinitions.Count, newActor.Save()));
+					}
+				}
+
+				SaveNewMap(onSelect, onExit);
+			};
+
+			//// MIRROR_TOP TOOL.
+			panel.Get<ButtonWidget>("MIRROR_TOP").OnClick = () =>
+			{
+				// Initialization. If fails, break.
+				if (!GetInputBaseMap(modData, showPanel)) { return; };
+
+				// Copy Base map to create Output map.
+				outputMapFilepathText = inputBaseMapFilepathTextField.Text.Replace(".oramap", "") + "-MirrorTop";
+				outputMapFilepathText += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
+
+				System.IO.File.Copy(inputBaseMapFilepathTextField.Text, outputMapFilepathText, true);
+				var outputPackage = new Folder(".").OpenPackage(outputMapFilepathText, modData.ModFiles) as IReadWritePackage;
+				outputMap = new Map(modData, outputPackage);
+
+				outputMap.Title += "-MirrorTop";
+				outputMap.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
+
+				// Calculations.
+				int halfHeight = inputBaseMap.Bounds.Height / 2;
+				int halfHeightRest = inputBaseMap.Bounds.Height % 2;
+				halfHeight = halfHeight + halfHeightRest;
+
+				for (int j = 0; j < halfHeight; j++)
+				{
+					for (int i = 0; i < inputBaseMap.MapSize.X; i++)
+					{
+						var i_old = i;
+						var j_old = j + inputBaseMap.Bounds.Top;
+						var inPos = new MPos(i_old, j_old);
+
+						var i_new = i_old;
+						var j_new = inputBaseMap.Bounds.Bottom - j - 1;
+
+						// If height is odd, MPos issue. (-1) offset to correct it.
+						if ((inputBaseMap.Grid.Type == MapGridType.RectangularIsometric) && ((inputBaseMap.Bounds.Height % 2) == 0))
+							j_new -= 1;
+
+						var outPos = new MPos(i_new, j_new);
+
+						if (usingTiles == 1)
+						{
+							outputMap.Tiles[outPos] = inputBaseMap.Tiles[inPos];
+							outputMap.Height[outPos] = inputBaseMap.Height[inPos];
+						}
+
+						if (usingResources == 1)
+							outputMap.Resources[outPos] = inputBaseMap.Resources[inPos];
+					}
+				}
+
+				if (usingActors == 1)
+				{
+					var forRemoval = new List<MiniYamlNode>();
+					var forKeeping = new List<MiniYamlNode>();
+
+					foreach (var kv in outputMap.ActorDefinitions)
+					{
+						var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+						var location = actor.InitDict.Get<LocationInit>().Value(null);
+						var location_MPos = new CPos(location.X, location.Y).ToMPos(outputMap);
+
+						if ((inputBaseMap.Bounds.Top < location_MPos.V) && (location_MPos.V <= inputBaseMap.Bounds.Top + halfHeight - halfHeightRest))
+							forKeeping.Add(kv);
+						else
+							forRemoval.Add(kv);
+					}
+
+					foreach (var kv in forRemoval)
+						outputMap.ActorDefinitions.Remove(kv);
+
+					foreach (var kv in forKeeping)
+					{
+						var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+						var location = actor.InitDict.Get<LocationInit>().Value(null);
+
+						var oldMPos = location.ToMPos(outputMap);
+
+						var i = oldMPos.U;
+						var j_local = oldMPos.V - inputBaseMap.Bounds.Top;
+
+						// If height is odd, MPos issue. (-1) offset to correct it.
+						var j_new = inputBaseMap.Bounds.Bottom - 1 - j_local;
+						if ((inputBaseMap.Grid.Type == MapGridType.RectangularIsometric) && ((inputBaseMap.Bounds.Height % 2) == 0))
+							j_new -= 1;
+
+						var newCPos = new MPos(i, j_new).ToCPos(outputMap);
+						var newLocation = new LocationInit(newCPos);
+
+						var actType = actor.Type;
+						var newActor = new ActorReference(actType) { newLocation, new OwnerInit("Neutral") };
+						outputMap.ActorDefinitions.Add(new MiniYamlNode("Actor" + outputMap.ActorDefinitions.Count, newActor.Save()));
+					}
+				};
+				SaveNewMap(onSelect, onExit);
+			};
+
+			// RESIZE TOOL.
+			panel.Get<ButtonWidget>("RESIZE_BUTTON").OnClick = () =>
+			{
+				// Initialization. If fails, break.
+				if (!GetInputBaseMap(modData, showPanel)) { return; };
+
+				// Copy Base map to create Output map.
+				outputMapFilepathText = inputBaseMapFilepathTextField.Text.Replace(".oramap", "") + "-Resize";
+				outputMapFilepathText += "_" + resizeDropdownW.Text.Replace(".", "");
+				outputMapFilepathText += "_" + resizeDropdownH.Text.Replace(".", "");
+				outputMapFilepathText += "-" + mapElementsDropdown.Text.Replace(", ", "") + ".oramap";
+
+				System.IO.File.Copy(inputBaseMapFilepathTextField.Text, outputMapFilepathText, true);
+				var outputPackage = new Folder(".").OpenPackage(outputMapFilepathText, modData.ModFiles) as IReadWritePackage;
+				outputMap = new Map(modData, outputPackage);
+				outputMap.Title += "-Resize";
+				outputMap.Title += "_" + resizeDropdownW.Text.Replace(".", "");
+				outputMap.Title += "_" + resizeDropdownH.Text.Replace(".", "");
+				outputMap.Title += "-" + mapElementsDropdown.Text.Replace(", ", "");
+
+				// Calculations.
+				int Aw = activeResizeW.Item1; int Bw = activeResizeW.Item2;
+				int Ah = activeResizeH.Item1; int Bh = activeResizeH.Item2;
+
+				int outputMapWidth = Math.Max(1, (inputBaseMap.Bounds.Width * Aw) / Bw);
+				int outputMapHeight = Math.Max(1, (inputBaseMap.Bounds.Height * Ah) / Bh);
+
+				var outputMapSizeX = inputBaseMap.MapSize.X + outputMapWidth - inputBaseMap.Bounds.Width;
+				var outputMapSizeY = inputBaseMap.MapSize.Y + outputMapHeight - inputBaseMap.Bounds.Height;
+
+				var outputLeftTopCell = new PPos(inputBaseMap.Bounds.Left, inputBaseMap.Bounds.Top);
+				var outputRightBottomCell = new PPos(inputBaseMap.Bounds.Left + outputMapWidth - 1, inputBaseMap.Bounds.Top + outputMapHeight - 1);
+
+				// Fixing potential southern bound problem : resizeOffset.
+				int[] A_Tiles_lastRow_height = new int[inputBaseMap.MapSize.X];
+				for (int i = 0; i < inputBaseMap.MapSize.X; i++)
+				{
+					var inPos = new MPos(i, inputBaseMap.MapSize.Y - 1);
+					A_Tiles_lastRow_height[i] = inputBaseMap.Height[inPos];
+				}
+
+				var A_Tiles_lastRow_MaxHeight = A_Tiles_lastRow_height.Max();
+				var BottomBound = inputBaseMap.MapSize.Y - inputBaseMap.Bounds.Bottom;
+				var resizeOffset = 0;
+
+				if (BottomBound == A_Tiles_lastRow_MaxHeight)
+					resizeOffset = 1;
+
+				// Resize and set bounds.
+				outputMap.Resize(outputMapSizeX, outputMapSizeY + resizeOffset);
+				outputMap.SetBounds(outputLeftTopCell, outputRightBottomCell);
+
+				// Grid B resizing bigger.
+				for (int local_j_new = 1; local_j_new <= outputMapHeight; local_j_new++)
+				{
+					for (int local_i_new = 1; local_i_new <= outputMapWidth; local_i_new++)
+					{
+						var local_i_old = Math.Max(1, Math.Min(inputBaseMap.Bounds.Width, (local_i_new * Bw) / Aw));
+						var local_j_old = Math.Max(1, Math.Min(inputBaseMap.Bounds.Height, (local_j_new * Bh) / Ah));
+
+						var i_new = (local_i_new - 1) + inputBaseMap.Bounds.Left; var j_new = (local_j_new - 1) + inputBaseMap.Bounds.Top;
+						var i_old = (local_i_old - 1) + inputBaseMap.Bounds.Left; var j_old = (local_j_old - 1) + inputBaseMap.Bounds.Top;
+
+						var outPos = new MPos(i_new, j_new);
+						var inPos = new MPos(i_old, j_old);
+
+						if (usingTiles == 1) { outputMap.Tiles[outPos] = inputBaseMap.Tiles[inPos]; outputMap.Height[outPos] = inputBaseMap.Height[inPos]; };
+						if (usingResources == 1) { outputMap.Resources[outPos] = inputBaseMap.Resources[inPos]; };
+					}
+				}
+
+				// Cleaning bottom border, if resize Y < 1.
+				if (Ah < Bh)
+				{
+					for (int j_old = inputBaseMap.Bounds.Bottom; j_old < inputBaseMap.MapSize.Y; j_old++)
+					{
+						for (int i_old = 0; i_old < Math.Min(inputBaseMap.MapSize.X, outputMapSizeX); i_old++)
+						{
+							var i_new = i_old;
+							var j_new = j_old + outputMapHeight - inputBaseMap.Bounds.Height;
+
+							var outPos = new MPos(i_new, j_new);
+							var inPos = new MPos(i_old, j_old);
+
+							outputMap.Tiles[outPos] = inputBaseMap.Tiles[inPos]; outputMap.Height[outPos] = inputBaseMap.Height[inPos];
+							outputMap.Resources[outPos] = inputBaseMap.Resources[inPos];
+						}
+					}
+				}
+
+				// Cleaning right border, if resize X < 1.
+				if (Aw < Bw)
+				{
+					for (int j_old = 0; j_old < Math.Min(inputBaseMap.MapSize.Y, outputMapSizeY); j_old++)
+					{
+						for (int i_old = inputBaseMap.Bounds.Right; i_old < inputBaseMap.MapSize.X; i_old++)
+						{
+							var i_new = i_old + outputMapWidth - inputBaseMap.Bounds.Width;
+							var j_new = j_old;
+
+							var outPos = new MPos(i_new, j_new);
+							var inPos = new MPos(i_old, j_old);
+
+							outputMap.Tiles[outPos] = inputBaseMap.Tiles[inPos]; outputMap.Height[outPos] = inputBaseMap.Height[inPos];
+							outputMap.Resources[outPos] = inputBaseMap.Resources[inPos];
+						}
+					}
+				}
+
+				var forRemoval = new List<MiniYamlNode>();
+
+				foreach (var kv in outputMap.ActorDefinitions)
+					forRemoval.Add(kv);
+
+				foreach (var kv in forRemoval)
+					outputMap.ActorDefinitions.Remove(kv);
+
+				foreach (var kv in inputBaseMap.ActorDefinitions)
+				{
+					var actor = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
+					var location = actor.InitDict.Get<LocationInit>().Value(null);
+					var actType = actor.Type;
+
+					var oldMPos = new CPos(location.X, location.Y).ToMPos(outputMap);
+					var oldX = oldMPos.U; var oldY = oldMPos.V;
+					var local_oldX = oldX - inputBaseMap.Bounds.Left; var local_oldY = oldY - inputBaseMap.Bounds.Top;
+
+					var inBounds = ((inputBaseMap.Bounds.Left <= oldX) && (oldX < inputBaseMap.Bounds.Right)) &&
+						((inputBaseMap.Bounds.Top <= oldY) && (oldY < inputBaseMap.Bounds.Bottom));
+
+					if (inBounds)
+					{
+						if (usingActors == 1)
+						{
+							var local_newX = Math.Min((local_oldX * Aw) / Bw, outputMapWidth - 1);
+							var local_newY = Math.Min((local_oldY * Ah) / Bh, outputMapHeight - 1);
+
+							var newX = local_newX + inputBaseMap.Bounds.Left;
+							var newY = local_newY + inputBaseMap.Bounds.Top;
+							var newCPos = new MPos(newX, newY).ToCPos(outputMap);
+							var newLocation = new LocationInit(newCPos);
+
+							var newActor = new ActorReference(actType) { newLocation, new OwnerInit("Neutral") };
+							outputMap.ActorDefinitions.Add(new MiniYamlNode("Actor" + outputMap.ActorDefinitions.Count, newActor.Save()));
+						}
+
+						if (usingActors == 0)
+							outputMap.ActorDefinitions.Add(new MiniYamlNode("Actor" + outputMap.ActorDefinitions.Count, actor.Save()));
+					}
+				}
+
+				SaveNewMap(onSelect, onExit);
+			};
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapToolsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapToolsLogic.cs
@@ -64,10 +64,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		int A_right   =	0; int B_right   =	0;
 		int A_top     =	0; int B_top     =	0;
 		int A_bottom  =	0; int B_bottom  =	0;
-				  		   	  
+
 		int A_X       =	0; int B_X       =	0;
 		int A_Y       =	0; int B_Y       =	0;
-				  		   		
+
 		int A_W       =	0; int B_W       =	0;
 		int A_H       =	0; int B_H       =	0;
 
@@ -138,13 +138,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			// variables
 			A_left   = Map_A.Bounds.Left; 
 			A_right  = Map_A.Bounds.Right;
-			A_X		 = Map_A.MapSize.X;
-			A_W		 = Map_A.Bounds.Width;
-			A_top	 = Map_A.Bounds.Top; 
+			A_X      = Map_A.MapSize.X;
+			A_W      = Map_A.Bounds.Width;
+			A_top    = Map_A.Bounds.Top; 
 			A_bottom = Map_A.Bounds.Bottom;
 			A_Y      = Map_A.MapSize.Y; 
 			A_H      = Map_A.Bounds.Height;
-			
+
 			return true;
 		}
 
@@ -282,7 +282,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			resizeDropdownW.Text = "0.25"; 
 			resizeDropdownH.Text = "0.25";
-			mapElementsDropdown.Text = "T, R, A"; 	 
+			mapElementsDropdown.Text = "T, R, A";
 
 			activeResizeW = resizeFactors[resizeDropdownW.Text];
 			activeResizeH = resizeFactors[resizeDropdownH.Text];

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapToolsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapToolsLogic.cs
@@ -11,7 +11,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class MapToolsLogic : ChromeLogic
 	{
 		Widget panel;
-		DropDownButtonWidget[] resizeDropdowns = new DropDownButtonWidget[10];
 
 		class DropDownOption
 		{

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -208,6 +208,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				});
 			};
 
+			var mapToolsButton = widget.Get<ButtonWidget>("MAP_TOOLS_BUTTON");
+			mapToolsButton.OnClick = () =>
+			{
+				SwitchMenu(MenuType.None);
+				Game.OpenWindow("MAP_TOOLS_BG", new WidgetArgs()
+				{
+					{ "onSelect", onSelect },
+					{ "onExit", () => SwitchMenu(MenuType.MapEditor) }
+				});
+			};
+
 			var loadMapButton = widget.Get<ButtonWidget>("LOAD_MAP_BUTTON");
 			loadMapButton.OnClick = () =>
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -208,6 +208,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				});
 			};
 
+			var importSketchButton = widget.Get<ButtonWidget>("MAP_TOOLS_BUTTON");
+			importSketchButton.OnClick = () =>
+			{
+				SwitchMenu(MenuType.None);
+				Game.OpenWindow("MAP_TOOLS_BG", new WidgetArgs()
+				{
+					{ "onSelect", onSelect },
+					{ "onExit", () => SwitchMenu(MenuType.MapEditor) }
+				});
+			};
+
 			var loadMapButton = widget.Get<ButtonWidget>("LOAD_MAP_BUTTON");
 			loadMapButton.OnClick = () =>
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -208,8 +208,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				});
 			};
 
-			var importSketchButton = widget.Get<ButtonWidget>("MAP_TOOLS_BUTTON");
-			importSketchButton.OnClick = () =>
+			var mapToolsButton = widget.Get<ButtonWidget>("MAP_TOOLS_BUTTON");
+			mapToolsButton.OnClick = () =>
 			{
 				SwitchMenu(MenuType.None);
 				Game.OpenWindow("MAP_TOOLS_BG", new WidgetArgs()

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -75,6 +75,154 @@ Container@NEW_MAP_BG:
 			Font: Bold
 			Key: return
 
+Background@MAP_TOOLS_BG:
+	Logic: MapToolsLogic
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 330
+	Height: 600
+	Children:
+		Label@LABEL_TITLE:
+			X: 0
+			Y: 0 - 30
+			Width: 330
+			Height: 25
+			Text: Map Tools
+			Font: BigBold
+			Contrast: true
+			Align: Center
+		Background@bg:
+			Width: PARENT_RIGHT
+			Height: 500
+			Background: panel-black
+			Children:
+            
+				Label@FILE_PATH_A_LABEL:
+                    X: 35
+                    Y: 40 + 30 * 0
+                    Width: 95
+                    Height: 25
+                    Align: Left
+                    Text: File path - Map A :
+                    
+                TextField@FILE_PATH_A:
+                    X: 35
+                    Y: 40 + 30 * 1
+                    Width: 260
+                    Height: 25
+                    Text: path_to_A.oramap
+                    
+                Label@FILE_PATH_B_LABEL:
+                    X: 35
+                    Y: 40 + 30 * 2
+                    Width: 95
+                    Height: 25
+                    Align: Left
+                    Text: File path - Map B ("Append", "Copy") :
+                TextField@FILE_PATH_B:
+                    X: 35
+                    Y: 40 + 30 * 3
+                    Width: 260
+                    Height: 25
+                    Text: path_to_B.oramap
+                
+                Label@FOR_RESIZE:
+                    X: 35
+                    Y: 40 + 30 * 4
+                    Width: 95
+                    Height: 25
+                    Align: Left
+                    Text: "Resize" factors :
+                    
+                                
+                Label@RESIZE_LABEL_W:
+                    X: 35
+                    Y: 40 + 30 * 5
+                    Width: 80
+                    Height: 25
+                    Align: Left
+                    Text: Hor. / Ver.
+                DropDownButton@RESIZE_W:
+                    X: 125
+                    Y: 40 + 30 * 5
+                    Width: 80
+                    Height: 25
+ 
+                DropDownButton@RESIZE_H:
+                    X: 215
+                    Y: 40 + 30 * 5
+                    Width: 80
+                    Height: 25
+
+				Label@USING_ELEMENTS_LABEL:
+					X: 35
+					Y: 40 + 30 * 6
+					Width: 200
+					Height: 25
+					Align: Left
+					Text: Using elem. (Tiles, Resources, Actors):  
+            
+				DropDownButton@USING_ELEMENTS:
+					X: (PARENT_RIGHT -WIDTH)/2
+					Y: 40 + 30 * 7
+					Width: 160
+					Height: 25
+
+
+                Button@APPEND_BUTTON:
+					X: (330-10)/2-WIDTH
+					Y: PARENT_BOTTOM-HEIGHT-10 -30*2
+					Width: 125
+					Height: 25
+					Text: Append B to A
+					Font: Bold
+					Key: return
+				Button@COPY_BUTTON:
+					X: (330+10)/2
+					Y: PARENT_BOTTOM-HEIGHT-10 -30*2
+					Width: 125
+					Height: 25
+					Text: Copy B on A
+					Font: Bold
+					Key: escape			
+				Button@MIRROR_LEFT:
+					X: (330-10)/2-WIDTH
+					Y: PARENT_BOTTOM-HEIGHT-10 -30*1
+					Width: 125
+					Height: 25
+					Text: Mirror Left
+					Font: Bold
+					Key: return
+				Button@MIRROR_TOP:
+					X: (330+10)/2
+					Y: PARENT_BOTTOM-HEIGHT-10 -30*1
+					Width: 125
+					Height: 25
+					Text: Mirror Top
+					Font: Bold
+					Key: escape			
+				Button@RESIZE_BUTTON:
+					X: (330-10)/2-WIDTH
+					Y: PARENT_BOTTOM-HEIGHT-10 -30*0
+					Width: 125
+					Height: 25
+					Text: Resize
+					Font: Bold
+					Key: return
+				Button@CANCEL_BUTTON:
+					X: (330+10)/2
+					Y: PARENT_BOTTOM-HEIGHT-10 -30*0
+					Width: 125
+					Height: 25
+					Text: Cancel
+					Font: Bold
+					Key: escape		    
+                    
+                    
+                    
+                    
+			
+		
 Container@SAVE_MAP_PANEL:
 	Logic: SaveMapLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -75,6 +75,7 @@ Container@NEW_MAP_BG:
 			Font: Bold
 			Key: return
 
+
 Background@MAP_TOOLS_BG:
 	Logic: MapToolsLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
@@ -96,64 +97,56 @@ Background@MAP_TOOLS_BG:
 			Height: 500
 			Background: panel-black
 			Children:
-            
 				Label@FILE_PATH_A_LABEL:
-                    X: 35
-                    Y: 40 + 30 * 0
-                    Width: 95
-                    Height: 25
-                    Align: Left
-                    Text: File path - Map A :
-                    
-                TextField@FILE_PATH_A:
-                    X: 35
-                    Y: 40 + 30 * 1
-                    Width: 260
-                    Height: 25
-                    Text: path_to_A.oramap
-                    
-                Label@FILE_PATH_B_LABEL:
-                    X: 35
-                    Y: 40 + 30 * 2
-                    Width: 95
-                    Height: 25
-                    Align: Left
-                    Text: File path - Map B ("Append", "Copy") :
-                TextField@FILE_PATH_B:
-                    X: 35
-                    Y: 40 + 30 * 3
-                    Width: 260
-                    Height: 25
-                    Text: path_to_B.oramap
-                
-                Label@FOR_RESIZE:
-                    X: 35
-                    Y: 40 + 30 * 4
-                    Width: 95
-                    Height: 25
-                    Align: Left
-                    Text: "Resize" factors :
-                    
-                                
-                Label@RESIZE_LABEL_W:
-                    X: 35
-                    Y: 40 + 30 * 5
-                    Width: 80
-                    Height: 25
-                    Align: Left
-                    Text: Hor. / Ver.
-                DropDownButton@RESIZE_W:
-                    X: 125
-                    Y: 40 + 30 * 5
-                    Width: 80
-                    Height: 25
- 
-                DropDownButton@RESIZE_H:
-                    X: 215
-                    Y: 40 + 30 * 5
-                    Width: 80
-                    Height: 25
-
+					X: 35
+					Y: 40 + 30 * 0
+					Width: 95
+					Height: 25
+					Align: Left
+					Text: File path - Map A :
+				TextField@FILE_PATH_A:
+					X: 35
+					Y: 40 + 30 * 1
+					Width: 260
+					Height: 25
+					Text: path_to_A.oramap
+				Label@FILE_PATH_B_LABEL:
+					X: 35
+					Y: 40 + 30 * 2
+					Width: 95
+					Height: 25
+					Align: Left
+					Text: File path - Map B ("Append", "Copy") :
+				TextField@FILE_PATH_B:
+					X: 35
+					Y: 40 + 30 * 3
+					Width: 260
+					Height: 25
+					Text: path_to_B.oramap
+				Label@FOR_RESIZE:
+					X: 35
+					Y: 40 + 30 * 4
+					Width: 95
+					Height: 25
+					Align: Left
+					Text: "Resize" factors :
+				Label@RESIZE_LABEL_W:
+					X: 35
+					Y: 40 + 30 * 5
+					Width: 80
+					Height: 25
+					Align: Left
+					Text: Hor. / Ver.
+				DropDownButton@RESIZE_W:
+					X: 125
+					Y: 40 + 30 * 5
+					Width: 80
+					Height: 25
+				DropDownButton@RESIZE_H:
+					X: 215
+					Y: 40 + 30 * 5
+					Width: 80
+					Height: 25
 				Label@USING_ELEMENTS_LABEL:
 					X: 35
 					Y: 40 + 30 * 6
@@ -161,15 +154,12 @@ Background@MAP_TOOLS_BG:
 					Height: 25
 					Align: Left
 					Text: Using elem. (Tiles, Resources, Actors):  
-            
 				DropDownButton@USING_ELEMENTS:
 					X: (PARENT_RIGHT -WIDTH)/2
 					Y: 40 + 30 * 7
 					Width: 160
 					Height: 25
-
-
-                Button@APPEND_BUTTON:
+				Button@APPEND_BUTTON:
 					X: (330-10)/2-WIDTH
 					Y: PARENT_BOTTOM-HEIGHT-10 -30*2
 					Width: 125
@@ -184,7 +174,7 @@ Background@MAP_TOOLS_BG:
 					Height: 25
 					Text: Copy B on A
 					Font: Bold
-					Key: escape			
+					Key: escape
 				Button@MIRROR_LEFT:
 					X: (330-10)/2-WIDTH
 					Y: PARENT_BOTTOM-HEIGHT-10 -30*1
@@ -200,7 +190,7 @@ Background@MAP_TOOLS_BG:
 					Height: 25
 					Text: Mirror Top
 					Font: Bold
-					Key: escape			
+					Key: escape
 				Button@RESIZE_BUTTON:
 					X: (330-10)/2-WIDTH
 					Y: PARENT_BOTTOM-HEIGHT-10 -30*0
@@ -216,13 +206,8 @@ Background@MAP_TOOLS_BG:
 					Height: 25
 					Text: Cancel
 					Font: Bold
-					Key: escape		    
-                    
-                    
-                    
-                    
-			
-		
+					Key: escape
+
 Container@SAVE_MAP_PANEL:
 	Logic: SaveMapLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -103,26 +103,26 @@ Background@MAP_TOOLS_BG:
 					Width: 95
 					Height: 25
 					Align: Left
-					Text: File path - Map A :
+					Text: Base map path :
 				TextField@FILE_PATH_A:
 					X: 35
 					Y: 40 + 30 * 1
 					Width: 260
 					Height: 25
-					Text: path_to_A.oramap
+					Text: path/to/base.oramap
 				Label@FILE_PATH_B_LABEL:
 					X: 35
 					Y: 40 + 30 * 2
 					Width: 95
 					Height: 25
 					Align: Left
-					Text: File path - Map B ("Append", "Copy") :
+					Text: Secondary map path ("Append", "Copy") :
 				TextField@FILE_PATH_B:
 					X: 35
 					Y: 40 + 30 * 3
 					Width: 260
 					Height: 25
-					Text: path_to_B.oramap
+					Text: path/to/secondary.oramap
 				Label@FOR_RESIZE:
 					X: 35
 					Y: 40 + 30 * 4
@@ -164,7 +164,7 @@ Background@MAP_TOOLS_BG:
 					Y: PARENT_BOTTOM-HEIGHT-10 -30*2
 					Width: 125
 					Height: 25
-					Text: Append B to A
+					Text: Append
 					Font: Bold
 					Key: return
 				Button@COPY_BUTTON:
@@ -172,7 +172,7 @@ Background@MAP_TOOLS_BG:
 					Y: PARENT_BOTTOM-HEIGHT-10 -30*2
 					Width: 125
 					Height: 25
-					Text: Copy B on A
+					Text: Copy
 					Font: Bold
 					Key: escape
 				Button@MIRROR_LEFT:

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -75,6 +75,139 @@ Container@NEW_MAP_BG:
 			Font: Bold
 			Key: return
 
+
+Background@MAP_TOOLS_BG:
+	Logic: MapToolsLogic
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 330
+	Height: 600
+	Children:
+		Label@LABEL_TITLE:
+			X: 0
+			Y: 0 - 30
+			Width: 330
+			Height: 25
+			Text: Map Tools
+			Font: BigBold
+			Contrast: true
+			Align: Center
+		Background@bg:
+			Width: PARENT_RIGHT
+			Height: 500
+			Background: panel-black
+			Children:
+				Label@FILE_PATH_A_LABEL:
+					X: 35
+					Y: 40 + 30 * 0
+					Width: 95
+					Height: 25
+					Align: Left
+					Text: Base map path :
+				TextField@FILE_PATH_A:
+					X: 35
+					Y: 40 + 30 * 1
+					Width: 260
+					Height: 25
+					Text: path/to/base.oramap
+				Label@FILE_PATH_B_LABEL:
+					X: 35
+					Y: 40 + 30 * 2
+					Width: 95
+					Height: 25
+					Align: Left
+					Text: Secondary map path ("Append", "Copy") :
+				TextField@FILE_PATH_B:
+					X: 35
+					Y: 40 + 30 * 3
+					Width: 260
+					Height: 25
+					Text: path/to/secondary.oramap
+				Label@FOR_RESIZE:
+					X: 35
+					Y: 40 + 30 * 4
+					Width: 95
+					Height: 25
+					Align: Left
+					Text: "Resize" factors :
+				Label@RESIZE_LABEL_W:
+					X: 35
+					Y: 40 + 30 * 5
+					Width: 80
+					Height: 25
+					Align: Left
+					Text: Hor. / Ver.
+				DropDownButton@RESIZE_W:
+					X: 125
+					Y: 40 + 30 * 5
+					Width: 80
+					Height: 25
+				DropDownButton@RESIZE_H:
+					X: 215
+					Y: 40 + 30 * 5
+					Width: 80
+					Height: 25
+				Label@USING_ELEMENTS_LABEL:
+					X: 35
+					Y: 40 + 30 * 6
+					Width: 200
+					Height: 25
+					Align: Left
+					Text: Using elem. (Tiles, Resources, Actors):  
+				DropDownButton@USING_ELEMENTS:
+					X: (PARENT_RIGHT -WIDTH)/2
+					Y: 40 + 30 * 7
+					Width: 160
+					Height: 25
+				Button@APPEND_BUTTON:
+					X: (330-10)/2-WIDTH
+					Y: PARENT_BOTTOM-HEIGHT-10 -30*2
+					Width: 125
+					Height: 25
+					Text: Append
+					Font: Bold
+					Key: return
+				Button@COPY_BUTTON:
+					X: (330+10)/2
+					Y: PARENT_BOTTOM-HEIGHT-10 -30*2
+					Width: 125
+					Height: 25
+					Text: Copy
+					Font: Bold
+					Key: escape
+				Button@MIRROR_LEFT:
+					X: (330-10)/2-WIDTH
+					Y: PARENT_BOTTOM-HEIGHT-10 -30*1
+					Width: 125
+					Height: 25
+					Text: Mirror Left
+					Font: Bold
+					Key: return
+				Button@MIRROR_TOP:
+					X: (330+10)/2
+					Y: PARENT_BOTTOM-HEIGHT-10 -30*1
+					Width: 125
+					Height: 25
+					Text: Mirror Top
+					Font: Bold
+					Key: escape
+				Button@RESIZE_BUTTON:
+					X: (330-10)/2-WIDTH
+					Y: PARENT_BOTTOM-HEIGHT-10 -30*0
+					Width: 125
+					Height: 25
+					Text: Resize
+					Font: Bold
+					Key: return
+				Button@CANCEL_BUTTON:
+					X: (330+10)/2
+					Y: PARENT_BOTTOM-HEIGHT-10 -30*0
+					Width: 125
+					Height: 25
+					Text: Cancel
+					Font: Bold
+					Key: escape
+
 Container@SAVE_MAP_PANEL:
 	Logic: SaveMapLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -73,6 +73,154 @@ Container@NEW_MAP_BG:
 			Font: Bold
 			Key: return
 
+Background@MAP_TOOLS_BG:
+	Logic: MapToolsLogic
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 330
+	Height: 600
+	Children:
+		Label@LABEL_TITLE:
+			X: 0
+			Y: 0 - 30
+			Width: 330
+			Height: 25
+			Text: Map Tools
+			Font: BigBold
+			Contrast: true
+			Align: Center
+		Background@bg:
+			Width: PARENT_RIGHT
+			Height: 500
+			Background: panel-black
+			Children:
+            
+				Label@FILE_PATH_A_LABEL:
+                    X: 35
+                    Y: 40 + 30 * 0
+                    Width: 95
+                    Height: 25
+                    Align: Left
+                    Text: File path - Map A :
+                    
+                TextField@FILE_PATH_A:
+                    X: 35
+                    Y: 40 + 30 * 1
+                    Width: 260
+                    Height: 25
+                    Text: path_to_A.oramap
+                    
+                Label@FILE_PATH_B_LABEL:
+                    X: 35
+                    Y: 40 + 30 * 2
+                    Width: 95
+                    Height: 25
+                    Align: Left
+                    Text: File path - Map B ("Append", "Copy") :
+                TextField@FILE_PATH_B:
+                    X: 35
+                    Y: 40 + 30 * 3
+                    Width: 260
+                    Height: 25
+                    Text: path_to_B.oramap
+                
+                Label@FOR_RESIZE:
+                    X: 35
+                    Y: 40 + 30 * 4
+                    Width: 95
+                    Height: 25
+                    Align: Left
+                    Text: "Resize" factors :
+                    
+                                
+                Label@RESIZE_LABEL_W:
+                    X: 35
+                    Y: 40 + 30 * 5
+                    Width: 80
+                    Height: 25
+                    Align: Left
+                    Text: Hor. / Ver.
+                DropDownButton@RESIZE_W:
+                    X: 125
+                    Y: 40 + 30 * 5
+                    Width: 80
+                    Height: 25
+ 
+                DropDownButton@RESIZE_H:
+                    X: 215
+                    Y: 40 + 30 * 5
+                    Width: 80
+                    Height: 25
+
+				Label@USING_ELEMENTS_LABEL:
+					X: 35
+					Y: 40 + 30 * 6
+					Width: 200
+					Height: 25
+					Align: Left
+					Text: Using elem. (Tiles, Resources, Actors):  
+            
+				DropDownButton@USING_ELEMENTS:
+					X: (PARENT_RIGHT -WIDTH)/2
+					Y: 40 + 30 * 7
+					Width: 160
+					Height: 25
+
+
+                Button@APPEND_BUTTON:
+					X: (330-10)/2-WIDTH
+					Y: PARENT_BOTTOM-HEIGHT-10 -30*2
+					Width: 125
+					Height: 25
+					Text: Append B to A
+					Font: Bold
+					Key: return
+				Button@COPY_BUTTON:
+					X: (330+10)/2
+					Y: PARENT_BOTTOM-HEIGHT-10 -30*2
+					Width: 125
+					Height: 25
+					Text: Copy B on A
+					Font: Bold
+					Key: escape			
+				Button@MIRROR_LEFT:
+					X: (330-10)/2-WIDTH
+					Y: PARENT_BOTTOM-HEIGHT-10 -30*1
+					Width: 125
+					Height: 25
+					Text: Mirror Left
+					Font: Bold
+					Key: return
+				Button@MIRROR_TOP:
+					X: (330+10)/2
+					Y: PARENT_BOTTOM-HEIGHT-10 -30*1
+					Width: 125
+					Height: 25
+					Text: Mirror Top
+					Font: Bold
+					Key: escape			
+				Button@RESIZE_BUTTON:
+					X: (330-10)/2-WIDTH
+					Y: PARENT_BOTTOM-HEIGHT-10 -30*0
+					Width: 125
+					Height: 25
+					Text: Resize
+					Font: Bold
+					Key: return
+				Button@CANCEL_BUTTON:
+					X: (330+10)/2
+					Y: PARENT_BOTTOM-HEIGHT-10 -30*0
+					Width: 125
+					Height: 25
+					Text: Cancel
+					Font: Bold
+					Key: escape		    
+                    
+                    
+                    
+                    
+			
+		
 Container@SAVE_MAP_PANEL:
 	Logic: SaveMapLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2

--- a/mods/cnc/chrome/mainmenu.yaml
+++ b/mods/cnc/chrome/mainmenu.yaml
@@ -197,15 +197,22 @@ Container@MENU_BACKGROUND:
 							Height: 35
 							Text: New Map
 							Font: Bold
-						Button@LOAD_MAP_BUTTON:
+						Button@MAP_TOOLS_BUTTON:
 							X: 150
+							Y: 0
+							Width: 140
+							Height: 35
+							Text: Map Tools
+							Font: Bold
+						Button@LOAD_MAP_BUTTON:
+							X: 300
 							Y: 0
 							Width: 140
 							Height: 35
 							Text: Load Map
 							Font: Bold
 						Button@BACK_BUTTON:
-							X: 300
+							X: 450
 							Y: 0
 							Width: 140
 							Height: 35

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -72,6 +72,142 @@ Background@NEW_MAP_BG:
 			Font: Bold
 			Key: escape
 
+Background@MAP_TOOLS_BG:
+	Logic: MapToolsLogic
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 330
+	Height: 600
+	Children:
+		Label@LABEL_TITLE:
+			X: 0
+			Y: 10
+			Width: 330
+			Height: 25
+			Text: Map Tools
+			Align: Center
+			Font: Bold
+
+		Label@FILE_PATH_A_LABEL:
+            X: 35
+            Y: 40 + 30 * 0
+            Width: 95
+            Height: 25
+            Align: Left
+            Text: File path - Map A :
+                    
+        TextField@FILE_PATH_A:
+            X: 35
+            Y: 40 + 30 * 1
+            Width: 260
+            Height: 25
+            Text: path_to_A.oramap
+
+        Label@FILE_PATH_B_LABEL:
+            X: 35
+            Y: 40 + 30 * 2
+            Width: 95
+            Height: 25
+            Align: Left
+            Text: File path - Map B ("Append", "Copy") :
+        TextField@FILE_PATH_B:
+            X: 35
+            Y: 40 + 30 * 3
+            Width: 260
+            Height: 25
+            Text: path_to_B.oramap
+
+        Label@FOR_RESIZE:
+            X: 35
+            Y: 40 + 30 * 4
+            Width: 95
+            Height: 25
+            Align: Left
+            Text: "Resize" factors :      
+                                
+        Label@RESIZE_LABEL_W:
+            X: 35
+            Y: 40 + 30 * 5
+            Width: 80
+            Height: 25
+            Align: Left
+            Text: Hor. / Ver.
+        DropDownButton@RESIZE_W:
+            X: 125
+            Y: 40 + 30 * 5
+            Width: 80
+            Height: 25
+ 
+        DropDownButton@RESIZE_H:
+            X: 215
+            Y: 40 + 30 * 5
+            Width: 80
+            Height: 25
+
+		Label@USING_ELEMENTS_LABEL:
+			X: 35
+			Y: 40 + 30 * 6
+			Width: 200
+			Height: 25
+			Align: Left
+			Text: Using elem. (Tiles, Resources, Actors):  
+            
+		DropDownButton@USING_ELEMENTS:
+			X: (PARENT_RIGHT -WIDTH)/2
+			Y: 40 + 30 * 7
+			Width: 160
+			Height: 25
+
+
+        Button@APPEND_BUTTON:
+			X: (330-10)/2-WIDTH
+			Y: PARENT_BOTTOM-HEIGHT-10 -30*2 -10
+			Width: 125
+			Height: 25
+			Text: Append B to A
+			Font: Bold
+			Key: return
+		Button@COPY_BUTTON:
+			X: (330+10)/2
+			Y: PARENT_BOTTOM-HEIGHT-10 -30*2 -10
+			Width: 125
+			Height: 25
+			Text: Copy B on A
+			Font: Bold
+			Key: escape			
+		Button@MIRROR_LEFT:
+			X: (330-10)/2-WIDTH
+			Y: PARENT_BOTTOM-HEIGHT-10 -30*1 -10
+			Width: 125
+			Height: 25
+			Text: Mirror Left
+			Font: Bold
+			Key: return
+		Button@MIRROR_TOP:
+			X: (330+10)/2
+			Y: PARENT_BOTTOM-HEIGHT-10 -30*1 -10
+			Width: 125
+			Height: 25
+			Text: Mirror Top
+			Font: Bold
+			Key: escape			
+		Button@RESIZE_BUTTON:
+			X: (330-10)/2-WIDTH
+			Y: PARENT_BOTTOM-HEIGHT-10 -30*0 -10
+			Width: 125
+			Height: 25
+			Text: Resize
+			Font: Bold
+			Key: return
+		Button@CANCEL_BUTTON:
+			X: (330+10)/2
+			Y: PARENT_BOTTOM-HEIGHT-10 -30*0 -10
+			Width: 125
+			Height: 25
+			Text: Cancel
+			Font: Bold
+			Key: escape		  
+
 Background@SAVE_MAP_PANEL:
 	Logic: SaveMapLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -72,6 +72,132 @@ Background@NEW_MAP_BG:
 			Font: Bold
 			Key: escape
 
+Background@MAP_TOOLS_BG:
+	Logic: MapToolsLogic
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 330
+	Height: 600
+	Children:
+		Label@LABEL_TITLE:
+			X: 0
+			Y: 10
+			Width: 330
+			Height: 25
+			Text: Map Tools
+			Align: Center
+			Font: Bold
+		Label@FILE_PATH_A_LABEL:
+			X: 35
+			Y: 40 + 30 * 0
+			Width: 95
+			Height: 25
+			Align: Left
+			Text: Base map path :
+		TextField@FILE_PATH_A:
+			X: 35
+			Y: 40 + 30 * 1
+			Width: 260
+			Height: 25
+			Text: path/to/base.oramap
+		Label@FILE_PATH_B_LABEL:
+			X: 35
+			Y: 40 + 30 * 2
+			Width: 95
+			Height: 25
+			Align: Left
+			Text: Secondary map path ("Append", "Copy") :
+		TextField@FILE_PATH_B:
+			X: 35
+			Y: 40 + 30 * 3
+			Width: 260
+			Height: 25
+			Text: path/to/secondary.oramap
+		Label@FOR_RESIZE:
+			X: 35
+			Y: 40 + 30 * 4
+			Width: 95
+			Height: 25
+			Align: Left
+			Text: "Resize" factors :
+		Label@RESIZE_LABEL_W:
+			X: 35
+			Y: 40 + 30 * 5
+			Width: 80
+			Height: 25
+			Align: Left
+			Text: Hor. / Ver.
+		DropDownButton@RESIZE_W:
+			X: 125
+			Y: 40 + 30 * 5
+			Width: 80
+			Height: 25
+		DropDownButton@RESIZE_H:
+			X: 215
+			Y: 40 + 30 * 5
+			Width: 80
+			Height: 25
+		Label@USING_ELEMENTS_LABEL:
+			X: 35
+			Y: 40 + 30 * 6
+			Width: 200
+			Height: 25
+			Align: Left
+			Text: Using elem. (Tiles, Resources, Actors):
+		DropDownButton@USING_ELEMENTS:
+			X: (PARENT_RIGHT -WIDTH)/2
+			Y: 40 + 30 * 7
+			Width: 160
+			Height: 25
+		Button@APPEND_BUTTON:
+			X: (330-10)/2-WIDTH
+			Y: PARENT_BOTTOM-HEIGHT-10 -30*2 -10
+			Width: 125
+			Height: 25
+			Text: Append
+			Font: Bold
+			Key: return
+		Button@COPY_BUTTON:
+			X: (330+10)/2
+			Y: PARENT_BOTTOM-HEIGHT-10 -30*2 -10
+			Width: 125
+			Height: 25
+			Text: Copy
+			Font: Bold
+			Key: escape
+		Button@MIRROR_LEFT:
+			X: (330-10)/2-WIDTH
+			Y: PARENT_BOTTOM-HEIGHT-10 -30*1 -10
+			Width: 125
+			Height: 25
+			Text: Mirror Left
+			Font: Bold
+			Key: return
+		Button@MIRROR_TOP:
+			X: (330+10)/2
+			Y: PARENT_BOTTOM-HEIGHT-10 -30*1 -10
+			Width: 125
+			Height: 25
+			Text: Mirror Top
+			Font: Bold
+			Key: escape
+		Button@RESIZE_BUTTON:
+			X: (330-10)/2-WIDTH
+			Y: PARENT_BOTTOM-HEIGHT-10 -30*0 -10
+			Width: 125
+			Height: 25
+			Text: Resize
+			Font: Bold
+			Key: return
+		Button@CANCEL_BUTTON:
+			X: (330+10)/2
+			Y: PARENT_BOTTOM-HEIGHT-10 -30*0 -10
+			Width: 125
+			Height: 25
+			Text: Cancel
+			Font: Bold
+			Key: escape
+
 Background@SAVE_MAP_PANEL:
 	Logic: SaveMapLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -93,26 +93,26 @@ Background@MAP_TOOLS_BG:
 			Width: 95
 			Height: 25
 			Align: Left
-			Text: File path - Map A :
+			Text: Base map path :
 		TextField@FILE_PATH_A:
 			X: 35
 			Y: 40 + 30 * 1
 			Width: 260
 			Height: 25
-			Text: path_to_A.oramap
+			Text: path/to/base.oramap
 		Label@FILE_PATH_B_LABEL:
 			X: 35
 			Y: 40 + 30 * 2
 			Width: 95
 			Height: 25
 			Align: Left
-			Text: File path - Map B ("Append", "Copy") :
+			Text: Secondary map path ("Append", "Copy") :
 		TextField@FILE_PATH_B:
 			X: 35
 			Y: 40 + 30 * 3
 			Width: 260
 			Height: 25
-			Text: path_to_B.oramap
+			Text: path/to/secondary.oramap
 		Label@FOR_RESIZE:
 			X: 35
 			Y: 40 + 30 * 4
@@ -154,7 +154,7 @@ Background@MAP_TOOLS_BG:
 			Y: PARENT_BOTTOM-HEIGHT-10 -30*2 -10
 			Width: 125
 			Height: 25
-			Text: Append B to A
+			Text: Append
 			Font: Bold
 			Key: return
 		Button@COPY_BUTTON:
@@ -162,7 +162,7 @@ Background@MAP_TOOLS_BG:
 			Y: PARENT_BOTTOM-HEIGHT-10 -30*2 -10
 			Width: 125
 			Height: 25
-			Text: Copy B on A
+			Text: Copy
 			Font: Bold
 			Key: escape
 		Button@MIRROR_LEFT:

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -70,6 +70,142 @@ Background@NEW_MAP_BG:
 			Font: Bold
 			Key: escape
 
+Background@MAP_TOOLS_BG:
+	Logic: MapToolsLogic
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 330
+	Height: 600
+	Children:
+		Label@LABEL_TITLE:
+			X: 0
+			Y: 10
+			Width: 330
+			Height: 25
+			Text: Map Tools
+			Align: Center
+			Font: Bold
+
+		Label@FILE_PATH_A_LABEL:
+            X: 35
+            Y: 40 + 30 * 0
+            Width: 95
+            Height: 25
+            Align: Left
+            Text: File path - Map A :
+                    
+        TextField@FILE_PATH_A:
+            X: 35
+            Y: 40 + 30 * 1
+            Width: 260
+            Height: 25
+            Text: path_to_A.oramap
+
+        Label@FILE_PATH_B_LABEL:
+            X: 35
+            Y: 40 + 30 * 2
+            Width: 95
+            Height: 25
+            Align: Left
+            Text: File path - Map B ("Append", "Copy") :
+        TextField@FILE_PATH_B:
+            X: 35
+            Y: 40 + 30 * 3
+            Width: 260
+            Height: 25
+            Text: path_to_B.oramap
+
+        Label@FOR_RESIZE:
+            X: 35
+            Y: 40 + 30 * 4
+            Width: 95
+            Height: 25
+            Align: Left
+            Text: "Resize" factors :      
+                                
+        Label@RESIZE_LABEL_W:
+            X: 35
+            Y: 40 + 30 * 5
+            Width: 80
+            Height: 25
+            Align: Left
+            Text: Hor. / Ver.
+        DropDownButton@RESIZE_W:
+            X: 125
+            Y: 40 + 30 * 5
+            Width: 80
+            Height: 25
+ 
+        DropDownButton@RESIZE_H:
+            X: 215
+            Y: 40 + 30 * 5
+            Width: 80
+            Height: 25
+
+		Label@USING_ELEMENTS_LABEL:
+			X: 35
+			Y: 40 + 30 * 6
+			Width: 200
+			Height: 25
+			Align: Left
+			Text: Using elem. (Tiles, Resources, Actors):  
+            
+		DropDownButton@USING_ELEMENTS:
+			X: (PARENT_RIGHT -WIDTH)/2
+			Y: 40 + 30 * 7
+			Width: 160
+			Height: 25
+
+
+        Button@APPEND_BUTTON:
+			X: (330-10)/2-WIDTH
+			Y: PARENT_BOTTOM-HEIGHT-10 -30*2 -10
+			Width: 125
+			Height: 25
+			Text: Append B to A
+			Font: Bold
+			Key: return
+		Button@COPY_BUTTON:
+			X: (330+10)/2
+			Y: PARENT_BOTTOM-HEIGHT-10 -30*2 -10
+			Width: 125
+			Height: 25
+			Text: Copy B on A
+			Font: Bold
+			Key: escape			
+		Button@MIRROR_LEFT:
+			X: (330-10)/2-WIDTH
+			Y: PARENT_BOTTOM-HEIGHT-10 -30*1 -10
+			Width: 125
+			Height: 25
+			Text: Mirror Left
+			Font: Bold
+			Key: return
+		Button@MIRROR_TOP:
+			X: (330+10)/2
+			Y: PARENT_BOTTOM-HEIGHT-10 -30*1 -10
+			Width: 125
+			Height: 25
+			Text: Mirror Top
+			Font: Bold
+			Key: escape			
+		Button@RESIZE_BUTTON:
+			X: (330-10)/2-WIDTH
+			Y: PARENT_BOTTOM-HEIGHT-10 -30*0 -10
+			Width: 125
+			Height: 25
+			Text: Resize
+			Font: Bold
+			Key: return
+		Button@CANCEL_BUTTON:
+			X: (330+10)/2
+			Y: PARENT_BOTTOM-HEIGHT-10 -30*0 -10
+			Width: 125
+			Height: 25
+			Text: Cancel
+			Font: Bold
+			Key: escape		  
+
 Background@SAVE_MAP_PANEL:
 	Logic: SaveMapLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -87,79 +87,71 @@ Background@MAP_TOOLS_BG:
 			Text: Map Tools
 			Align: Center
 			Font: Bold
-
 		Label@FILE_PATH_A_LABEL:
-            X: 35
-            Y: 40 + 30 * 0
-            Width: 95
-            Height: 25
-            Align: Left
-            Text: File path - Map A :
-                    
-        TextField@FILE_PATH_A:
-            X: 35
-            Y: 40 + 30 * 1
-            Width: 260
-            Height: 25
-            Text: path_to_A.oramap
-
-        Label@FILE_PATH_B_LABEL:
-            X: 35
-            Y: 40 + 30 * 2
-            Width: 95
-            Height: 25
-            Align: Left
-            Text: File path - Map B ("Append", "Copy") :
-        TextField@FILE_PATH_B:
-            X: 35
-            Y: 40 + 30 * 3
-            Width: 260
-            Height: 25
-            Text: path_to_B.oramap
-
-        Label@FOR_RESIZE:
-            X: 35
-            Y: 40 + 30 * 4
-            Width: 95
-            Height: 25
-            Align: Left
-            Text: "Resize" factors :      
-                                
-        Label@RESIZE_LABEL_W:
-            X: 35
-            Y: 40 + 30 * 5
-            Width: 80
-            Height: 25
-            Align: Left
-            Text: Hor. / Ver.
-        DropDownButton@RESIZE_W:
-            X: 125
-            Y: 40 + 30 * 5
-            Width: 80
-            Height: 25
- 
-        DropDownButton@RESIZE_H:
-            X: 215
-            Y: 40 + 30 * 5
-            Width: 80
-            Height: 25
-
+			X: 35
+			Y: 40 + 30 * 0
+			Width: 95
+			Height: 25
+			Align: Left
+			Text: File path - Map A :
+					
+		TextField@FILE_PATH_A:
+			X: 35
+			Y: 40 + 30 * 1
+			Width: 260
+			Height: 25
+			Text: path_to_A.oramap
+		Label@FILE_PATH_B_LABEL:
+			X: 35
+			Y: 40 + 30 * 2
+			Width: 95
+			Height: 25
+			Align: Left
+			Text: File path - Map B ("Append", "Copy") :
+		TextField@FILE_PATH_B:
+			X: 35
+			Y: 40 + 30 * 3
+			Width: 260
+			Height: 25
+			Text: path_to_B.oramap
+		Label@FOR_RESIZE:
+			X: 35
+			Y: 40 + 30 * 4
+			Width: 95
+			Height: 25
+			Align: Left
+			Text: "Resize" factors :
+		Label@RESIZE_LABEL_W:
+			X: 35
+			Y: 40 + 30 * 5
+			Width: 80
+			Height: 25
+			Align: Left
+			Text: Hor. / Ver.
+		DropDownButton@RESIZE_W:
+			X: 125
+			Y: 40 + 30 * 5
+			Width: 80
+			Height: 25
+		DropDownButton@RESIZE_H:
+			X: 215
+			Y: 40 + 30 * 5
+			Width: 80
+			Height: 25
 		Label@USING_ELEMENTS_LABEL:
 			X: 35
 			Y: 40 + 30 * 6
 			Width: 200
 			Height: 25
 			Align: Left
-			Text: Using elem. (Tiles, Resources, Actors):  
-            
+			Text: Using elem. (Tiles, Resources, Actors):
+			
 		DropDownButton@USING_ELEMENTS:
 			X: (PARENT_RIGHT -WIDTH)/2
 			Y: 40 + 30 * 7
 			Width: 160
 			Height: 25
-
-
-        Button@APPEND_BUTTON:
+		Button@APPEND_BUTTON:
 			X: (330-10)/2-WIDTH
 			Y: PARENT_BOTTOM-HEIGHT-10 -30*2 -10
 			Width: 125
@@ -174,7 +166,7 @@ Background@MAP_TOOLS_BG:
 			Height: 25
 			Text: Copy B on A
 			Font: Bold
-			Key: escape			
+			Key: escape
 		Button@MIRROR_LEFT:
 			X: (330-10)/2-WIDTH
 			Y: PARENT_BOTTOM-HEIGHT-10 -30*1 -10
@@ -190,7 +182,7 @@ Background@MAP_TOOLS_BG:
 			Height: 25
 			Text: Mirror Top
 			Font: Bold
-			Key: escape			
+			Key: escape
 		Button@RESIZE_BUTTON:
 			X: (330-10)/2-WIDTH
 			Y: PARENT_BOTTOM-HEIGHT-10 -30*0 -10
@@ -206,7 +198,7 @@ Background@MAP_TOOLS_BG:
 			Height: 25
 			Text: Cancel
 			Font: Bold
-			Key: escape		  
+			Key: escape
 
 Background@SAVE_MAP_PANEL:
 	Logic: SaveMapLogic

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -94,7 +94,6 @@ Background@MAP_TOOLS_BG:
 			Height: 25
 			Align: Left
 			Text: File path - Map A :
-					
 		TextField@FILE_PATH_A:
 			X: 35
 			Y: 40 + 30 * 1
@@ -145,7 +144,6 @@ Background@MAP_TOOLS_BG:
 			Height: 25
 			Align: Left
 			Text: Using elem. (Tiles, Resources, Actors):
-			
 		DropDownButton@USING_ELEMENTS:
 			X: (PARENT_RIGHT -WIDTH)/2
 			Y: 40 + 30 * 7

--- a/mods/common/chrome/mainmenu.yaml
+++ b/mods/common/chrome/mainmenu.yaml
@@ -198,7 +198,7 @@ Container@MAINMENU:
 							Font: Bold
 						Button@MAP_TOOLS_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
-							Y: 100	
+							Y: 100
 							Width: 140
 							Height: 30
 							Text: Map Tools

--- a/mods/common/chrome/mainmenu.yaml
+++ b/mods/common/chrome/mainmenu.yaml
@@ -196,9 +196,16 @@ Container@MAINMENU:
 							Height: 30
 							Text: New Map
 							Font: Bold
+						Button@MAP_TOOLS_BUTTON:
+							X: PARENT_RIGHT / 2 - WIDTH / 2
+							Y: 100	
+							Width: 140
+							Height: 30
+							Text: Map Tools
+							Font: Bold
 						Button@LOAD_MAP_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
-							Y: 100
+							Y: 140
 							Width: 140
 							Height: 30
 							Text: Load Map

--- a/mods/common/chrome/mainmenu.yaml
+++ b/mods/common/chrome/mainmenu.yaml
@@ -196,9 +196,16 @@ Container@MAINMENU:
 							Height: 30
 							Text: New Map
 							Font: Bold
-						Button@LOAD_MAP_BUTTON:
+						Button@MAP_TOOLS_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 100
+							Width: 140
+							Height: 30
+							Text: Map Tools
+							Font: Bold
+						Button@LOAD_MAP_BUTTON:
+							X: PARENT_RIGHT / 2 - WIDTH / 2
+							Y: 140
 							Width: 140
 							Height: 30
 							Text: Load Map

--- a/mods/d2k/chrome/mainmenu.yaml
+++ b/mods/d2k/chrome/mainmenu.yaml
@@ -183,9 +183,16 @@ Container@MAINMENU:
 							Height: 30
 							Text: New Map
 							Font: Bold
-						Button@LOAD_MAP_BUTTON:
+						Button@MAP_TOOLS_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 100
+							Width: 140
+							Height: 30
+							Text: Map Tools
+							Font: Bold
+						Button@LOAD_MAP_BUTTON:
+							X: PARENT_RIGHT / 2 - WIDTH / 2
+							Y: 140
 							Width: 140
 							Height: 30
 							Text: Load Map

--- a/mods/d2k/chrome/mainmenu.yaml
+++ b/mods/d2k/chrome/mainmenu.yaml
@@ -183,9 +183,16 @@ Container@MAINMENU:
 							Height: 30
 							Text: New Map
 							Font: Bold
+						Button@MAP_TOOLS_BUTTON:
+							X: PARENT_RIGHT / 2 - WIDTH / 2
+							Y: 100	
+							Width: 140
+							Height: 30
+							Text: Map Tools
+							Font: Bold
 						Button@LOAD_MAP_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
-							Y: 100
+							Y: 140
 							Width: 140
 							Height: 30
 							Text: Load Map

--- a/mods/d2k/chrome/mainmenu.yaml
+++ b/mods/d2k/chrome/mainmenu.yaml
@@ -185,7 +185,7 @@ Container@MAINMENU:
 							Font: Bold
 						Button@MAP_TOOLS_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
-							Y: 100	
+							Y: 100
 							Width: 140
 							Height: 30
 							Text: Map Tools


### PR DESCRIPTION
(First PR / piece of OpenRA code for me :) )

Adds a new set of tools for the Map Editor. 
Interface : a new button "Map tools" into the map editor menu. 

The tools currently include : Append, Copy, Mirror (Left or Top), Resize.
There is an option to choose what is affected by the operation :Tiles, Resources, Actors

Support added for all mods (rectangular and isometric maps). Only the Resize for isometric maps gives scrambled results, due to the nature of iso grid.

Some screenshots in the forum post : https://forum.openra.net/viewtopic.php?f=83&t=20568&p=307886#p307886

----------------------
Ideas for future improvements (out of scope for now) : 
- more tools (e.g. : "Rotate" for antisymmetry)
- improving "Resize" for iso maps
- polished interface
- map selector
- in-editor local tools ? e.g. : mirroring a selection, ...