### PR TITLE
Add AppImage prompt to install mono-complete package using apt-url

### DIFF
--- a/packaging/linux/AppRun.in
+++ b/packaging/linux/AppRun.in
@@ -37,7 +37,7 @@ if prompt_apt_install_mono_complete; then
 fi
 
 if mono_missing_or_old; then
-  ERROR_MESSAGE="{MODNAME} requires Mono ${MINIMUM_MONO_VERSION} or greater.\nPlease install Mono using your system package manager."
+  ERROR_MESSAGE="{MODNAME} requires Mono ${MINIMUM_MONO_VERSION} or greater.\nPlease install Mono using your system package manager.\n\nSee http://wiki.openra.net/AppImages for more information."
   if command -v zenity > /dev/null; then
     zenity --no-wrap --error --title "{MODNAME}" --text "${ERROR_MESSAGE}" 2> /dev/null
   elif command -v kdialog > /dev/null; then

--- a/packaging/linux/AppRun.in
+++ b/packaging/linux/AppRun.in
@@ -51,7 +51,7 @@ fi
 # Some distros and self-compiled mono installations don't set up
 # the SSL required for http web queries. If we detect that these
 # are missing we can try and create a local sync as a fallback.
-if [ ! -d "/usr/share/.mono/certs" ] && [ ! -d "~/.config/.mono/certs" ]; then
+if [ ! -d "/usr/share/.mono/certs" ] && [ ! -d "${HOME}/.config/.mono/certs" ]; then
   if [ -f "/etc/pki/tls/certs/ca-bundle.crt" ]; then
     cert-sync --quiet --user /etc/pki/tls/certs/ca-bundle.crt
   elif [ -f "/etc/ssl/certs/ca-certificates.crt" ]; then

--- a/packaging/linux/AppRun.in
+++ b/packaging/linux/AppRun.in
@@ -3,6 +3,16 @@
 # Make sure the user has a sufficiently recent version of mono on the PATH
 MINIMUM_MONO_VERSION="4.2"
 
+prompt_apt_install_mono_complete() {
+  command -v mono >/dev/null 2>&1 && return 1
+  command -v apt-cache > /dev/null || return 1
+  command -v xdg-mime > /dev/null || return 1
+  command -v xdg-open > /dev/null || return 1
+  [ ! "$(xdg-mime query default x-scheme-handler/apt)" ] && return 1
+  apt-cache search --names-only mono-complete | cut -d' ' -f1 | grep "^mono-complete$" > /dev/null || return 1
+  return 0
+}
+
 make_version() {
   echo "$1" | tr '.' '\n' | head -n 4 | xargs printf "%03d%03d%03d%03d";
 }
@@ -13,6 +23,18 @@ mono_missing_or_old() {
   [ "$(make_version "${MONO_VERSION}")" -lt "$(make_version "${MINIMUM_MONO_VERSION}")" ] && return 0
   return 1
 }
+
+# If mono is not installed, and the user has apt-cache, apt-url,
+# xdg-open, and either zenity or kdialog, then we can prompt to
+# automatically install the mono-complete package
+if prompt_apt_install_mono_complete; then
+  PROMPT_MESSAGE="{MODNAME} requires the Mono runtime.\nWould you like to install it now?"
+  if command -v zenity > /dev/null; then
+    zenity --no-wrap --question --title "{MODNAME}" --text "${PROMPT_MESSAGE}" 2> /dev/null && xdg-open apt://mono-complete && exit 0
+  elif command -v kdialog > /dev/null; then
+    kdialog --title "{MODNAME}" --yesno "${PROMPT_MESSAGE}" && xdg-open apt://mono-complete && exit 0
+  fi
+fi
 
 if mono_missing_or_old; then
   ERROR_MESSAGE="{MODNAME} requires Mono ${MINIMUM_MONO_VERSION} or greater.\nPlease install Mono using your system package manager."


### PR DESCRIPTION
This PR aims to improve the first-run flow on apt-based distributions, leveraging the `apt://` URL integration in the respective software centers.

From the AppRun.in comment:
```
# If mono is not installed, and the user has apt-cache, apt-url,
# xdg-open, and either zenity or kdialog, then we can prompt to
# automatically install the mono-complete package
```

The standard dialog (now extended with a link to the wiki) continues to show on other distros (tested Fedora 28 and CentOS 7), or if the prompt is declined.


Gnome:
![screen shot 2018-06-26 at 21 41 49](https://user-images.githubusercontent.com/167819/41941595-6663b24a-7994-11e8-8918-ded203c10721.png)
![screen shot 2018-06-26 at 22 03 31](https://user-images.githubusercontent.com/167819/41941621-7616ad8c-7994-11e8-8f10-0f037bbb4952.png)
![screen shot 2018-06-26 at 22 03 19](https://user-images.githubusercontent.com/167819/41941603-6b07190e-7994-11e8-8909-18da09550309.png)

KDE:
![screen shot 2018-06-26 at 22 39 31](https://user-images.githubusercontent.com/167819/41941508-2163d058-7994-11e8-9740-ece3f6209cfe.png)
![screen shot 2018-06-26 at 22 40 01](https://user-images.githubusercontent.com/167819/41941512-245af64c-7994-11e8-88bd-147026fac174.png)
