### PR TITLE
Add DamageSource to Explodes

### DIFF
--- a/OpenRA.Mods.Common/Traits/Explodes.cs
+++ b/OpenRA.Mods.Common/Traits/Explodes.cs
@@ -19,6 +19,8 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public enum ExplosionType { Footprint, CenterPosition }
 
+	public enum DamageSource { Self, Killer }
+
 	[Desc("This actor explodes when killed.")]
 	public class ExplodesInfo : ConditionalTraitInfo, Requires<HealthInfo>
 	{
@@ -39,6 +41,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("DeathType(s) that trigger the explosion. Leave empty to always trigger an explosion.")]
 		public readonly HashSet<string> DeathTypes = new HashSet<string>();
+
+		[Desc("Who is counted as source of damage for explosion.",
+			"Possible values are Self and Killer.")]
+		public readonly DamageSource DamageSource = DamageSource.Self;
 
 		[Desc("Possible values are CenterPosition (explosion at the actors' center) and ",
 			"Footprint (explosion on each occupied cell).")]
@@ -103,20 +109,21 @@ namespace OpenRA.Mods.Common.Traits
 			if (weapon == null)
 				return;
 
+			var source = Info.DamageSource == DamageSource.Self ? self : e.Attacker;
 			if (weapon.Report != null && weapon.Report.Any())
-				Game.Sound.Play(SoundType.World, weapon.Report.Random(e.Attacker.World.SharedRandom), self.CenterPosition);
+				Game.Sound.Play(SoundType.World, weapon.Report.Random(source.World.SharedRandom), self.CenterPosition);
 
 			if (Info.Type == ExplosionType.Footprint && buildingInfo != null)
 			{
 				var cells = buildingInfo.UnpathableTiles(self.Location);
 				foreach (var c in cells)
-					weapon.Impact(Target.FromPos(self.World.Map.CenterOfCell(c)), e.Attacker, Enumerable.Empty<int>());
+					weapon.Impact(Target.FromPos(self.World.Map.CenterOfCell(c)), source, Enumerable.Empty<int>());
 
 				return;
 			}
 
 			// Use .FromPos since this actor is killed. Cannot use Target.FromActor
-			weapon.Impact(Target.FromPos(self.CenterPosition), e.Attacker, Enumerable.Empty<int>());
+			weapon.Impact(Target.FromPos(self.CenterPosition), source, Enumerable.Empty<int>());
 		}
 
 		WeaponInfo ChooseWeaponForExplosion(Actor self)
@@ -135,8 +142,9 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			// Cast to long to avoid overflow when multiplying by the health
+			var source = Info.DamageSource == DamageSource.Self ? self : e.Attacker;
 			if (health.HP * 100L < Info.DamageThreshold * (long)health.MaxHP)
-				self.World.AddFrameEndTask(w => self.Kill(e.Attacker));
+				self.World.AddFrameEndTask(w => self.Kill(source));
 		}
 	}
 }

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -696,6 +696,7 @@ DTRK:
 	Explodes:
 		Weapon: MiniNuke
 		EmptyWeapon: MiniNuke
+		DamageSource: Killer
 	AttackSuicides:
 	-DamageMultiplier@IRONCURTAIN:
 	KillsSelf:


### PR DESCRIPTION
    [10:27:27] | <MustaphaTR>  pchote, abcdefg30 , I think i already asked that but didn't get any  answer iirc: I have this change on my engine that should fix #9044, i  think seems like a obivious fix and i have that for a while now, didn't  see any regression or crash. Should i PR that to upstream, any reason  why this was e.Attacker? https://github.com/MustaphaTR/OpenRA/commit/1284f8945ad6eec3b8543d96cd07f3638b2edbed
    [10:27:28] | <orabot> Title: Make actor itself the source of damage for Explodes weapon · MustaphaTR/OpenRA@1284f89 · GitHub
    [10:27:30] | <orabot> Issue #9044 (open) by MustaphaTR: RA - Unit that destroyed the Demo Truck is counted as source of damage. \| http://bugs.openra.net/9044
    [10:27:52] | <pchote> MustaphaTR: to attribute kills from demo trucks
    [10:28:15] | <MustaphaTR> For statistics?
    [10:28:18] | <pchote>  the idea being that if somebody shoots a demo truck and that then  destroys a bunch of stuff that the original attacker should get all the  credits
    [10:28:29] | <pchote> IIRC the main argument was for bounties
    [10:28:48] | <MustaphaTR> Well demo truck bounties are already broken.
    [10:29:02] | <MustaphaTR> #14502
    [10:29:02] | <orabot> Issue #14502 (open) by MustaphaTR: Dead actors can't get bounties. \| http://bugs.openra.net/14502
    [10:29:16] | <pchote> tldr: bounties in general are broken ;)
    [10:30:03] | <FRenzy>  (that reminds me that mines also seem to mess up with statistics, I'm  not entirely sure though and I'll have to test more in-depth)
    [10:30:03] | <pchote> MustaphaTR: you can expose an enum in the trait info to set which actor should be treated as the source
    [10:30:13] | <pchote> then default it to self, and override demo trucks to the killer
    [10:33:12] | <MustaphaTR>  I was thiking why i fixed it in the first place, but i remember now, it  was Demo Gen's Demolitions ability which should only damage enemy  units, current setup messes up Stance checks in the weapon.
    [10:33:28] | <pchote> right