### PR TITLE
Add ProductionCostMultiplier and ProductionTimeMultiplier Traits

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -331,6 +331,8 @@
     <Compile Include="Traits\Conditions\GrantRandomCondition.cs" />
     <Compile Include="Traits\Contrail.cs" />
     <Compile Include="Traits\SupportPowers\SelectDirectionalTarget.cs" />
+    <Compile Include="Traits\Multipliers\ProductionCostMultiplier.cs" />
+    <Compile Include="Traits\Multipliers\ProductionTimeMultiplier.cs" />
     <Compile Include="Traits\TemporaryOwnerManager.cs" />
     <Compile Include="Traits\TooltipDescription.cs" />
     <Compile Include="Traits\Health.cs" />

--- a/OpenRA.Mods.Common/Traits/Multipliers/ProductionCostMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/ProductionCostMultiplier.cs
@@ -1,0 +1,41 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Modifies the production cost of this actor for a specific queue or when a prerequisite is granted.")]
+	public class ProductionCostMultiplierInfo : TraitInfo<ProductionCostMultiplier>, IProductionCostModifierInfo
+	{
+		[Desc("Percentage modifier to apply.")]
+		public readonly int Multiplier = 100;
+
+		[Desc("Only apply this cost change if owner has these prerequisites.")]
+		public readonly string[] Prerequisites = { };
+
+		[Desc("Queues that this cost will apply.")]
+		public readonly HashSet<string> Queue = new HashSet<string>();
+
+		int IProductionCostModifierInfo.GetProductionCostModifier(TechTree techTree, string queue)
+		{
+			if ((!Queue.Any() || Queue.Contains(queue)) && (!Prerequisites.Any() || techTree.HasPrerequisites(Prerequisites)))
+				return Multiplier;
+
+			return 100;
+		}
+	}
+
+	public class ProductionCostMultiplier { }
+}

--- a/OpenRA.Mods.Common/Traits/Multipliers/ProductionTimeMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/ProductionTimeMultiplier.cs
@@ -1,0 +1,41 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Modifies the production time of this actor for a specific queue or when a prerequisite is granted.")]
+	public class ProductionTimeMultiplierInfo : TraitInfo<ProductionTimeMultiplier>, IProductionTimeModifierInfo
+	{
+		[Desc("Percentage modifier to apply.")]
+		public readonly int Multiplier = 100;
+
+		[Desc("Only apply this time change if owner has these prerequisites.")]
+		public readonly string[] Prerequisites = { };
+
+		[Desc("Queues that this time will apply.")]
+		public readonly HashSet<string> Queue = new HashSet<string>();
+
+		int IProductionTimeModifierInfo.GetProductionTimeModifier(TechTree techTree, string queue)
+		{
+			if ((!Queue.Any() || Queue.Contains(queue)) && (!Prerequisites.Any() || techTree.HasPrerequisites(Prerequisites)))
+				return Multiplier;
+
+			return 100;
+		}
+	}
+
+	public class ProductionTimeMultiplier { }
+}

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -111,6 +111,7 @@ namespace OpenRA.Mods.Common.Traits
 		PowerManager playerPower;
 		protected PlayerResources playerResources;
 		protected DeveloperMode developerMode;
+		protected TechTree techTree;
 
 		public Actor Actor { get { return self; } }
 
@@ -123,14 +124,11 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			self = init.Self;
 			Info = info;
-			playerResources = playerActor.Trait<PlayerResources>();
-			developerMode = playerActor.Trait<DeveloperMode>();
 
 			Faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : self.Owner.Faction.InternalName;
 			IsValidFaction = !info.Factions.Any() || info.Factions.Contains(Faction);
 			Enabled = IsValidFaction;
 
-			CacheProducibles(playerActor);
 			allProducibles = Producible.Where(a => a.Value.Buildable || a.Value.Visible).Select(a => a.Key);
 			buildableProducibles = Producible.Where(a => a.Value.Buildable).Select(a => a.Key);
 		}
@@ -141,8 +139,15 @@ namespace OpenRA.Mods.Common.Traits
 			// Created is called before Player.PlayerActor is assigned,
 			// so we must query other player traits from self, knowing that
 			// it refers to the same actor as self.Owner.PlayerActor
-			playerPower = (self.Info.Name == "player" ? self : self.Owner.PlayerActor).TraitOrDefault<PowerManager>();
+			var playerActor = self.Info.Name == "player" ? self : self.Owner.PlayerActor;
+
+			playerPower = playerActor.TraitOrDefault<PowerManager>();
+			playerResources = playerActor.Trait<PlayerResources>();
+			developerMode = playerActor.Trait<DeveloperMode>();
+			techTree = playerActor.Trait<TechTree>();
+
 			productionTraits = self.TraitsImplementing<Production>().Where(p => p.Info.Produces.Contains(Info.Type)).ToArray();
+			CacheProducibles(playerActor);
 		}
 
 		protected void ClearQueue()
@@ -160,6 +165,7 @@ namespace OpenRA.Mods.Common.Traits
 			playerPower = newOwner.PlayerActor.TraitOrDefault<PowerManager>();
 			playerResources = newOwner.PlayerActor.Trait<PlayerResources>();
 			developerMode = newOwner.PlayerActor.Trait<DeveloperMode>();
+			techTree = newOwner.PlayerActor.Trait<TechTree>();
 
 			if (!Info.Sticky)
 			{
@@ -170,7 +176,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Regenerate the producibles and tech tree state
 			oldOwner.PlayerActor.Trait<TechTree>().Remove(this);
 			CacheProducibles(newOwner.PlayerActor);
-			newOwner.PlayerActor.Trait<TechTree>().Update();
+			techTree.Update();
 		}
 
 		void INotifyKilled.Killed(Actor killed, AttackInfo e) { if (killed == self) { ClearQueue(); Enabled = false; } }
@@ -187,14 +193,12 @@ namespace OpenRA.Mods.Common.Traits
 			if (!Enabled)
 				return;
 
-			var ttc = playerActor.Trait<TechTree>();
-
 			foreach (var a in AllBuildables(Info.Type))
 			{
 				var bi = a.TraitInfo<BuildableInfo>();
 
 				Producible.Add(a, new ProductionState());
-				ttc.Add(a.Name, bi.Prerequisites, bi.BuildLimit, this);
+				techTree.Add(a.Name, bi.Prerequisites, bi.BuildLimit, this);
 			}
 		}
 
@@ -393,8 +397,7 @@ namespace OpenRA.Mods.Common.Traits
 							return;
 					}
 
-					var valued = unit.TraitInfoOrDefault<ValuedInfo>();
-					var cost = valued != null ? valued.Cost : 0;
+					var cost = GetProductionCost(unit);
 					var time = GetBuildTime(unit, bi);
 					var amountToBuild = Math.Min(fromLimit, order.ExtraData);
 					for (var n = 0; n < amountToBuild; n++)
@@ -434,13 +437,26 @@ namespace OpenRA.Mods.Common.Traits
 
 			var time = bi.BuildDuration;
 			if (time == -1)
-			{
-				var valued = unit.TraitInfoOrDefault<ValuedInfo>();
-				time = valued != null ? valued.Cost : 0;
-			}
+				time = GetProductionCost(unit);
 
-			time = time * bi.BuildDurationModifier * Info.BuildDurationModifier / 10000;
-			return time;
+			var modifiers = unit.TraitInfos<IProductionTimeModifierInfo>()
+				.Select(t => t.GetProductionTimeModifier(techTree, Info.Type))
+				.Append(bi.BuildDurationModifier)
+				.Append(Info.BuildDurationModifier);
+
+			return Util.ApplyPercentageModifiers(time, modifiers);
+		}
+
+		public virtual int GetProductionCost(ActorInfo unit)
+		{
+			var valued = unit.TraitInfoOrDefault<ValuedInfo>();
+			if (valued == null)
+				return 0;
+
+			var modifiers = unit.TraitInfos<IProductionCostModifierInfo>()
+				.Select(t => t.GetProductionCostModifier(techTree, Info.Type));
+
+			return Util.ApplyPercentageModifiers(valued.Cost, modifiers);
 		}
 
 		protected void PauseProduction(string itemName, bool paused)

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -324,6 +324,12 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[RequireExplicitImplementation]
+	public interface IProductionCostModifierInfo : ITraitInfo { int GetProductionCostModifier(TechTree techTree, string queue); }
+
+	[RequireExplicitImplementation]
+	public interface IProductionTimeModifierInfo : ITraitInfo { int GetProductionTimeModifier(TechTree techTree, string queue); }
+
+	[RequireExplicitImplementation]
 	public interface ICashTricklerModifier { int GetCashTricklerModifier(); }
 
 	[RequireExplicitImplementation]

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -70,8 +70,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var tooltip = actor.TraitInfos<TooltipInfo>().FirstOrDefault(info => info.EnabledByDefault);
 				var name = tooltip != null ? tooltip.Name : actor.Name;
 				var buildable = actor.TraitInfo<BuildableInfo>();
-				var valued = actor.TraitInfoOrDefault<ValuedInfo>();
-				var cost = valued != null ? valued.Cost : 0;
+
+				var cost = 0;
+				if (tooltipIcon.ProductionQueue != null)
+					cost = tooltipIcon.ProductionQueue.GetProductionCost(actor);
+				else
+				{
+					var valued = actor.TraitInfoOrDefault<ValuedInfo>();
+					if (valued != null)
+						cost = valued.Cost;
+				}
 
 				nameLabel.Text = name;
 


### PR DESCRIPTION
I was wrong with that this solves duplicate D2k actors, as prerequisites are still a concern there (still could remove dupe Carryall and Harvester but i don't think it is a good idea to handle some units differently than others.).

Still this solves the duplicate actors on our RAClassic mod for Russia and Turkey and also should solve @SoScared's problem at #15301. Also allows stuff like Generals Tech Oil Refinery and YR Soviet Industrial Plant.

Selling, bounties etc. still use the valued trait for their calculations.