### PR TITLE
Add CashTricklerMultiplier

### DIFF
--- a/OpenRA.Mods.Common/Traits/CashTrickler.cs
+++ b/OpenRA.Mods.Common/Traits/CashTrickler.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Linq;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
 
@@ -71,8 +72,10 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (--Ticks < 0)
 			{
+				var cashTrickerModifier = self.TraitsImplementing<ICashTricklerModifier>().Select(x => x.GetCashTricklerModifier());
+
 				Ticks = info.Interval;
-				ModifyCash(self, self.Owner, info.Amount);
+				ModifyCash(self, self.Owner, Util.ApplyPercentageModifiers(info.Amount, cashTrickerModifier));
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Multipliers/CashTricklerMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/CashTricklerMultiplier.cs
@@ -1,0 +1,36 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Modifies the cash given by cash tricker traits of this actor.")]
+	public class CashTricklerMultiplierInfo : ConditionalTraitInfo, Requires<CashTricklerInfo>
+	{
+		[FieldLoader.Require]
+		[Desc("Percentage modifier to apply.")]
+		public readonly int Modifier = 100;
+
+		public override object Create(ActorInitializer init) { return new CashTricklerMultiplier(this); }
+	}
+
+	public class CashTricklerMultiplier : ConditionalTrait<CashTricklerMultiplierInfo>, ICashTricklerModifier
+	{
+		public CashTricklerMultiplier(CashTricklerMultiplierInfo info)
+			: base(info) { }
+
+		int ICashTricklerModifier.GetCashTricklerModifier()
+		{
+			return IsTraitDisabled ? 100 : Info.Modifier;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -309,6 +309,9 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[RequireExplicitImplementation]
+	public interface ICashTricklerModifier { int GetCashTricklerModifier(); }
+
+	[RequireExplicitImplementation]
 	public interface IDamageModifier { int GetDamageModifier(Actor attacker, Damage damage); }
 
 	[RequireExplicitImplementation]


### PR DESCRIPTION
I use that for Supply Lines upgrade's effect on Oil Derricks and Supply Drop Zones in Generals Alpha. Using multipile traits were problematic as it would reset the timer, especially for Supply Drop which gives 1500 every 2 mins.