### PR TITLE
Get railway tracks to render again

### DIFF
--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -562,6 +562,7 @@ palet04:
 	idle:
 		UseTilesetExtension: true
 		ZOffset: -1c0
+		Offset: 0, 0, 1
 		ZRamp: 1
 
 tracks01:


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/issues/12229 partly.

Good test case is the [Cityscape](https://resource.openra.net/maps/27684/) map.