### PR TITLE
Add a fallback error dialog for AppImages using Python.

### DIFF
--- a/packaging/linux/AppRun.in
+++ b/packaging/linux/AppRun.in
@@ -24,6 +24,10 @@ mono_missing_or_old() {
   return 1
 }
 
+HERE="$(dirname "$(readlink -f "${0}")")"
+export PATH="${HERE}"/usr/bin/:"${PATH}"
+export XDG_DATA_DIRS="${HERE}"/usr/share/:"${XDG_DATA_DIRS}"
+
 # If mono is not installed, and the user has apt-cache, apt-url,
 # xdg-open, and either zenity or kdialog, then we can prompt to
 # automatically install the mono-complete package
@@ -33,6 +37,8 @@ if prompt_apt_install_mono_complete; then
     zenity --no-wrap --question --title "{MODNAME}" --text "${PROMPT_MESSAGE}" 2> /dev/null && xdg-open apt://mono-complete && exit 0
   elif command -v kdialog > /dev/null; then
     kdialog --title "{MODNAME}" --yesno "${PROMPT_MESSAGE}" && xdg-open apt://mono-complete && exit 0
+  elif "${HERE}/usr/bin/gtk-dialog.py" test > /dev/null; then
+    "${HERE}/usr/bin/gtk-dialog.py" question --title "{MODNAME}" --text "${PROMPT_MESSAGE}" 2> /dev/null && xdg-open apt://mono-complete && exit 0
   fi
 fi
 
@@ -42,6 +48,8 @@ if mono_missing_or_old; then
     zenity --no-wrap --error --title "{MODNAME}" --text "${ERROR_MESSAGE}" 2> /dev/null
   elif command -v kdialog > /dev/null; then
     kdialog --title "{MODNAME}" --error "${ERROR_MESSAGE}"
+  elif "${HERE}/usr/bin/gtk-dialog.py" test > /dev/null; then
+    "${HERE}/usr/bin/gtk-dialog.py" error --title "{MODNAME}" --text "${ERROR_MESSAGE}" 2> /dev/null
   else
     printf "${ERROR_MESSAGE}"
   fi
@@ -60,10 +68,6 @@ if [ ! -d "/usr/share/.mono/certs" ] && [ ! -d "${HOME}/.config/.mono/certs" ]; 
 fi
 
 # Run the game or server
-HERE="$(dirname "$(readlink -f "${0}")")"
-export PATH="${HERE}"/usr/bin/:"${PATH}"
-export XDG_DATA_DIRS="${HERE}"/usr/share/:"${XDG_DATA_DIRS}"
-
 if [ -n "$1" ] && [ "$1" = "--server" ]; then
   exec "openra-{MODID}-server" "$@"
 else

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -114,6 +114,8 @@ build_appimage() {
 	sed "s/{MODID}/${MOD_ID}/g" openra-server.appimage.in > openra-mod-server.temp
 	install -m 0755 openra-mod-server.temp "${APPDIR}/usr/bin/openra-${MOD_ID}-server"
 
+	install -m 0755 gtk-dialog.py "${APPDIR}/usr/bin/gtk-dialog.py"
+
 	# travis-ci doesn't support mounting FUSE filesystems so extract and run the contents manually
 	./appimagetool-x86_64.AppImage --appimage-extract
 	

--- a/packaging/linux/gtk-dialog.py
+++ b/packaging/linux/gtk-dialog.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+"""A simple GTK3 graphical dialog helper that can be used as a fallback if zenity is not available
+   Compatible with python 2 or 3 with the gi bindings.
+
+   Three modes are available:
+       test: accepts no arguments, returns 0 if the python dependencies are available, or 1 if not
+       error: show a gtk-3 error dialog
+              accepts arguments --title and --text
+       error: show a gtk-3 question dialog
+              accepts arguments --title and --text
+              returns 0 on Yes, or 1 on No
+"""
+
+import sys
+
+try:
+    import argparse
+    import gi
+    gi.require_version('Gtk', '3.0')
+    from gi.repository import Gtk
+except ImportError:
+    sys.exit(1)
+
+class Error():
+    def __init__(self, title, text):
+        dialog = Gtk.MessageDialog(None, 0, Gtk.MessageType.ERROR, Gtk.ButtonsType.OK, title)
+        dialog.format_secondary_text(text)
+        dialog.run()
+        dialog.destroy()
+
+class Question():
+    def __init__(self, title, text):
+        dialog = Gtk.MessageDialog(None, 0, Gtk.MessageType.QUESTION, Gtk.ButtonsType.YES_NO, title)
+        dialog.format_secondary_text(text)
+        response = dialog.run()
+        dialog.destroy()
+        sys.exit(0 if response == Gtk.ResponseType.YES else 1)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('type', choices=['error', 'question', 'test'])
+    parser.add_argument('--title', type=str, required=False, default='')
+    parser.add_argument('--text', type=str, required=False, default='')
+    args = parser.parse_args()
+    if args.type == 'question':
+        Question(args.title, args.text.replace('\\n', '\n'))
+    elif args.type == 'error':
+        Error(args.title, args.text.replace('\\n', '\n'))

--- a/packaging/linux/openra.appimage.in
+++ b/packaging/linux/openra.appimage.in
@@ -44,6 +44,8 @@ if [ $? != 0 ] && [ $? != 1 ]; then
     zenity --no-wrap --error --title "{MODNAME}" --text "${ERROR_MESSAGE}" 2> /dev/null
   elif command -v kdialog > /dev/null; then
     kdialog --title "{MODNAME}" --error "${ERROR_MESSAGE}"
+  elif "${HERE}/gtk-dialog.py" test > /dev/null; then
+    "${HERE}/gtk-dialog.py" error --title "{MODNAME}" --text "${ERROR_MESSAGE}" 2> /dev/null
   else
     printf "${ERROR_MESSAGE}\n"
   fi


### PR DESCRIPTION
Fixes #15311.
Depends on #15299.

I have tested and confirmed this to work on both MX Linux as originally reported and Ubuntu (after manually breaking the `zenity` package).  Note that the transient dialog error is a feature of gnome, and both zenity and the apt-url dialog report the same message.

![screen shot 2018-07-01 at 18 08 01](https://user-images.githubusercontent.com/167819/42136796-cece0dc6-7d59-11e8-9e5f-97b8e8996e7f.png)
![screen shot 2018-07-01 at 17 42 52](https://user-images.githubusercontent.com/167819/42136676-f0b1cd94-7d57-11e8-9f62-ac7428b7c60f.png)
![screen shot 2018-07-01 at 17 47 42](https://user-images.githubusercontent.com/167819/42136680-f82fa014-7d57-11e8-998f-f566ef54acfd.png)
![screen shot 2018-07-01 at 17 49 25](https://user-images.githubusercontent.com/167819/42136681-01d1129c-7d58-11e8-9402-c27c3fc6440a.png)

Test AppImage: https://www.dropbox.com/s/of46hufiiiapfwe/OpenRA-Red-Alert-pygtk-x86_64.AppImage?dl=1