### PR TITLE
Avoid sending HTTP requests to the FetchNews URL when FetchNews is disabled

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -287,7 +287,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		void LoadAndDisplayNews(string newsURL, Widget newsBG)
 		{
-			if (newsBG != null)
+			if (newsBG != null && Game.Settings.Game.FetchNews)
 			{
 				var cacheFile = Platform.ResolvePath(Platform.SupportDirPrefix, "news.yaml");
 				var currentNews = ParseNews(cacheFile);

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -492,6 +492,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			BindCheckboxPref(panel, "CHECK_VERSION_CHECKBOX", ds, "CheckVersion");
 			BindCheckboxPref(panel, "REPLAY_COMMANDS_CHECKBOX", ds, "EnableDebugCommandsInReplays");
 
+			var ssi = panel.Get<CheckboxWidget>("SENDSYSINFO_CHECKBOX");
+			ssi.IsDisabled = () => !gs.FetchNews;
+
 			return () => { };
 		}
 


### PR DESCRIPTION

Also disables the 'Send SysInfo' settings checkbox when 'Fetch News' is disabled as well.

Closes #14787 