### PR TITLE
Change Parachutable.GroundCorpseSequence default to null

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -881,6 +881,7 @@
     <Compile Include="Traits\Player\PlayerResources.cs" />
     <Compile Include="UtilityCommands\DumpSequenceSheetsCommand.cs" />
     <Compile Include="UpdateRules\Rules\DefineLocomotors.cs" />
+    <Compile Include="UpdateRules\Rules\DefineGroundCorpseDefault.cs" />
     <Compile Include="UpdateRules\Rules\DefineOwnerLostAction.cs" />
     <Compile Include="UpdateRules\Rules\RenameEmitInfantryOnSell.cs" />
     <Compile Include="Traits\Render\WithBuildingRepairDecoration.cs" />

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var sequence = onWater ? info.WaterCorpseSequence : info.GroundCorpseSequence;
 			var palette = onWater ? info.WaterCorpsePalette : info.GroundCorpsePalette;
-			if (sequence != null && palette != null)
+			if (!string.IsNullOrEmpty(info.Image) && !string.IsNullOrEmpty(sequence) && palette != null)
 				self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(self.OccupiesSpace.CenterPosition, w, info.Image, sequence, palette)));
 
 			self.Kill(self, info.DamageTypes);

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -28,16 +28,20 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Image where Ground/WaterCorpseSequence is looked up.")]
 		public readonly string Image = "explosion";
 
-		public readonly string GroundImpactSound = null;
 		[SequenceReference("Image")] public readonly string GroundCorpseSequence = "corpse";
+
 		[PaletteReference] public readonly string GroundCorpsePalette = "effect";
 
-		public readonly string WaterImpactSound = null;
+		public readonly string GroundImpactSound = null;
+
 		[SequenceReference("Image")] public readonly string WaterCorpseSequence = null;
+
 		[PaletteReference] public readonly string WaterCorpsePalette = "effect";
 
 		[Desc("Terrain types on which to display WaterCorpseSequence.")]
 		public readonly HashSet<string> WaterTerrainTypes = new HashSet<string> { "Water" };
+
+		public readonly string WaterImpactSound = null;
 
 		public readonly int FallRate = 13;
 

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Image where Ground/WaterCorpseSequence is looked up.")]
 		public readonly string Image = "explosion";
 
-		[SequenceReference("Image")] public readonly string GroundCorpseSequence = "corpse";
+		[SequenceReference("Image")] public readonly string GroundCorpseSequence = null;
 
 		[PaletteReference] public readonly string GroundCorpsePalette = "effect";
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/DefineGroundCorpseDefault.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/DefineGroundCorpseDefault.cs
@@ -1,0 +1,68 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class DefineGroundCorpseDefault : UpdateRule
+	{
+		public override string Name { get { return "Move Parachutable GroundCorspeSequence default to yaml"; } }
+		public override string Description
+		{
+			get
+			{
+				return "Parachutable's GroundCorspeSequence 'corpse' default has been moved to yaml.";
+			}
+		}
+
+		Tuple<string, string, string, List<string>>[] fields =
+		{
+			Tuple.Create("Parachutable", "GroundCorpseSequence", "corpse", new List<string>()),
+		};
+
+		string BuildMessage(Tuple<string, string, string, List<string>> field)
+		{
+			return "The default value for {0}.{1} has been removed.\n".F(field.Item1, field.Item2) +
+				"You may wish to explicitly define `{0}: {1}` on the `{2}` trait \n".F(field.Item2, field.Item3, field.Item1) +
+				"definitions on the following actors (if they have not already been inherited from a parent).\n" +
+				UpdateUtils.FormatMessageList(field.Item4);
+		}
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			foreach (var field in fields)
+			{
+				if (field.Item4.Any())
+					yield return BuildMessage(field);
+
+				field.Item4.Clear();
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var field in fields)
+			{
+				foreach (var traitNode in actorNode.ChildrenMatching(field.Item1))
+				{
+					var node = traitNode.LastChildMatching(field.Item2);
+					if (node == null)
+						field.Item4.Add("{0} ({1})".F(actorNode.Key, traitNode.Location.Filename));
+				}
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -55,6 +55,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RenameEmitInfantryOnSell(),
 				new SplitRepairDecoration(),
 				new MoveHackyAISupportPowerDecisions(),
+				new DefineGroundCorpseDefault(),
 			})
 		};
 

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -277,10 +277,6 @@
 	Parachutable:
 		FallRate: 26
 		KilledOnImpassableTerrain: true
-		GroundCorpseSequence:
-		GroundCorpsePalette:
-		WaterCorpseSequence:
-		WaterCorpsePalette:
 		ParachutingCondition: parachute
 	Explodes:
 		Weapon: UnitExplodeSmall
@@ -391,6 +387,7 @@
 	Parachutable:
 		FallRate: 26
 		KilledOnImpassableTerrain: true
+		GroundCorpseSequence: corpse
 		GroundImpactSound: squishy2.aud
 		WaterImpactSound: splash9.aud
 		WaterCorpseSequence: small_splash


### PR DESCRIPTION
Missions and 3rd-party mods may paradrop vehicles which normally don't need a corpse sequence (because they already have `Explodes`), so the old infantry-centric internal default can cause more harm than good.

Additionally, made it easier to disable inherited corpse sequences (checking Image + using NullOrEmpty instead of just null checks) and improved internal order and readability of the properties a bit.