### PR TITLE
Group update rule display by update path.

### DIFF
--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 			})
 		};
 
-		public static IEnumerable<UpdateRule> FromSource(ObjectCreator objectCreator, string source)
+		public static IEnumerable<UpdateRule> FromSource(ObjectCreator objectCreator, string source, bool chain = true)
 		{
 			// Use reflection to identify types
 			var namedType = objectCreator.FindType(source);
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				return new[] { (UpdateRule)objectCreator.CreateBasic(namedType) };
 
 			var namedPath = Paths.FirstOrDefault(p => p.source == source);
-			return namedPath != null ? namedPath.Rules : null;
+			return namedPath != null ? namedPath.Rules(chain) : null;
 		}
 
 		public static IEnumerable<string> KnownPaths { get { return Paths.Select(p => p.source); } }
@@ -88,18 +88,15 @@ namespace OpenRA.Mods.Common.UpdateRules
 			this.chainToSource = chainToSource;
 		}
 
-		IEnumerable<UpdateRule> Rules
+		IEnumerable<UpdateRule> Rules(bool chain = true)
 		{
-			get
+			if (chainToSource != null && chain)
 			{
-				if (chainToSource != null)
-				{
-					var chain = Paths.First(p => p.source == chainToSource);
-					return rules.Concat(chain.Rules);
-				}
-
-				return rules;
+				var child = Paths.First(p => p.source == chainToSource);
+				return rules.Concat(child.Rules(chain));
 			}
+
+			return rules;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/UtilityCommands/UpdateMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpdateMapCommand.cs
@@ -53,15 +53,40 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 				Console.WriteLine("Valid sources are:");
 
+				var ruleGroups = new Dictionary<string, List<string>>();
+
 				// Print known tags
 				Console.WriteLine("   Update Paths:");
 				foreach (var p in UpdatePath.KnownPaths)
+				{
 					Console.WriteLine("      " + p);
+					ruleGroups[p] = UpdatePath.FromSource(modData.ObjectCreator, p, false)
+						.Select(r => r.GetType().Name)
+						.Where(r => !ruleGroups.Values.Any(g => g.Contains(r)))
+						.ToList();
+				}
 
 				// Print known rules
 				Console.WriteLine("   Individual Rules:");
-				foreach (var r in UpdatePath.KnownRules(modData.ObjectCreator))
-					Console.WriteLine("      " + r);
+				foreach (var kv in ruleGroups)
+				{
+					if (!kv.Value.Any())
+						continue;
+
+					Console.WriteLine("      " + kv.Key + ":");
+					foreach (var r in kv.Value)
+						Console.WriteLine("         " + r);
+				}
+
+				var other = UpdatePath.KnownRules(modData.ObjectCreator)
+					.Where(r => !ruleGroups.Values.Any(g => g.Contains(r)));
+
+				if (other.Any())
+				{
+					Console.WriteLine("      Other:");
+					foreach (var r in other)
+						Console.WriteLine("         " + r);
+				}
 
 				return;
 			}

--- a/OpenRA.Mods.Common/UtilityCommands/UpdateModCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/UpdateModCommand.cs
@@ -45,15 +45,40 @@ namespace OpenRA.Mods.Common.UtilityCommands
 
 				Console.WriteLine("Valid sources are:");
 
+				var ruleGroups = new Dictionary<string, List<string>>();
+
 				// Print known tags
 				Console.WriteLine("   Update Paths:");
 				foreach (var p in UpdatePath.KnownPaths)
+				{
 					Console.WriteLine("      " + p);
+					ruleGroups[p] = UpdatePath.FromSource(modData.ObjectCreator, p, false)
+						.Select(r => r.GetType().Name)
+						.Where(r => !ruleGroups.Values.Any(g => g.Contains(r)))
+						.ToList();
+				}
 
 				// Print known rules
 				Console.WriteLine("   Individual Rules:");
-				foreach (var r in UpdatePath.KnownRules(modData.ObjectCreator))
-					Console.WriteLine("      " + r);
+				foreach (var kv in ruleGroups)
+				{
+					if (!kv.Value.Any())
+						continue;
+
+					Console.WriteLine("      " + kv.Key + ":");
+					foreach (var r in kv.Value)
+						Console.WriteLine("         " + r);
+				}
+
+				var other = UpdatePath.KnownRules(modData.ObjectCreator)
+					.Where(r => !ruleGroups.Values.Any(g => g.Contains(r)));
+
+				if (other.Any())
+				{
+					Console.WriteLine("      Other:");
+					foreach (var r in other)
+						Console.WriteLine("         " + r);
+				}
 
 				return;
 			}


### PR DESCRIPTION
Fixes #15323.

```
Valid sources are:
   Update Paths:
      release-20171014
      release-20180218
      release-20180307
   Individual Rules:
      release-20171014:
         LegacyBetaWarning
         RemoveMobileOnRails
         AircraftCanHoverGeneralization
         AddNukeLaunchAnimation
         RenameWithTurreted
         RemovePlayerPaletteTileset
         CapturableChanges
         DecoupleSelfReloading
         RemoveOutOfAmmo
         ChangeCanPowerDown
         ReplaceRequiresPower
         DropPauseAnimationWhenDisabled
         ChangeBuildableArea
         MoveVisualBounds
         ScaleDefaultModHealth
         ReworkCheckboxes
         SplitGateFromBuilding
         RemoveIDisable
         ReplaceCanPowerDown
         ScaleSupportPowerSecondsToTicks
         WarnAboutInfiltrateForTypes
         RenameBurstDelay
      release-20180307:
         RemoveTerrainTypeIsWaterFlag
         DefineSquadExcludeHarvester
         RemoveWeaponScanRadius
         SplitAimAnimations
         DefineSoundDefaults
         RenameWormSpawner
         RemoveWithReloadingSpriteTurret
         ChangeIntensityToDuration
         IgnoreAbstractActors
         AddShakeToBridge
         RemovePaletteFromCurrentTileset
         DefineLocomotors
         DefineOwnerLostAction
         RenameEmitInfantryOnSell
         SplitRepairDecoration
         MoveHackyAISupportPowerDecisions
      Other:
         ScaleModHealthBy10
         ScaleModHealthBy100
         ScaleModHealth
```