### PR TITLE
Remove GivesBounty>LevelMod

### DIFF
--- a/OpenRA.Mods.Common/Traits/GivesBounty.cs
+++ b/OpenRA.Mods.Common/Traits/GivesBounty.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Warheads;
 using OpenRA.Traits;
@@ -78,8 +79,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var a in cargo.Passengers)
 			{
-				var givesBounty = a.TraitOrDefault<GivesBounty>();
-				if (givesBounty != null)
+				var givesBounties = a.TraitsImplementing<GivesBounty>().Where(gb => !gb.IsTraitDisabled);
+				foreach (var givesBounty in givesBounties)
 					bounty += givesBounty.GetDisplayedBountyValue(a);
 			}
 

--- a/OpenRA.Mods.Common/Traits/GivesBounty.cs
+++ b/OpenRA.Mods.Common/Traits/GivesBounty.cs
@@ -23,9 +23,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Percentage of the killed actor's Cost or CustomSellValue to be given.")]
 		public readonly int Percentage = 10;
 
-		[Desc("Scale bounty based on the veterancy of the killed unit. The value is given in percent.")]
-		public readonly int LevelMod = 125;
-
 		[Desc("Stance the attacking player needs to receive the bounty.")]
 		public readonly Stance ValidStances = Stance.Neutral | Stance.Enemy;
 
@@ -41,7 +38,6 @@ namespace OpenRA.Mods.Common.Traits
 
 	class GivesBounty : ConditionalTrait<GivesBountyInfo>, INotifyKilled
 	{
-		GainsExperience gainsExp;
 		Cargo cargo;
 
 		public GivesBounty(GivesBountyInfo info)
@@ -51,24 +47,12 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			base.Created(self);
 
-			gainsExp = self.TraitOrDefault<GainsExperience>();
 			cargo = self.TraitOrDefault<Cargo>();
-		}
-
-		// Returns 100's as 1, so as to keep accuracy for longer.
-		int GetMultiplier()
-		{
-			if (gainsExp == null)
-				return 100;
-
-			var slevel = gainsExp.Level;
-			return (slevel > 0) ? slevel * Info.LevelMod : 100;
 		}
 
 		int GetBountyValue(Actor self)
 		{
-			// Divide by 10000 because of GetMultiplier and info.Percentage.
-			return self.GetSellValue() * GetMultiplier() * Info.Percentage / 10000;
+			return self.GetSellValue() * Info.Percentage / 100;
 		}
 
 		int GetDisplayedBountyValue(Actor self)


### PR DESCRIPTION
Closes #14381. Its effect can be recreated using conditions, as first commit fixes the issue with passengers having multipile GivesBounty traits.

I didn't do that to RA mod tho. I know we wanted to remove this for a while now. This will effect balancing so i would like to hear some words from people looking for these stuff too.

This probably needs a update rule, not sure if i can write a proper one or i should just add a notice but first seems less likely as it is a bit complicated.