### PR TITLE
Make Prerequisite Lint Check use ITechTreePrerequisiteInfo

### DIFF
--- a/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
+++ b/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
@@ -20,16 +20,7 @@ namespace OpenRA.Mods.Common.Lint
 	{
 		public void Run(Action<string> emitError, Action<string> emitWarning, Ruleset rules)
 		{
-			// ProvidesPrerequisite allows arbitrary prereq definitions
-			var customPrereqs = rules.Actors.SelectMany(a => a.Value.TraitInfos<ProvidesPrerequisiteInfo>()
-				.Select(p => p.Prerequisite ?? a.Value.Name));
-
-			// ProvidesTechPrerequisite allows arbitrary prereq definitions
-			// (but only one group at a time during gameplay)
-			var techPrereqs = rules.Actors.SelectMany(a => a.Value.TraitInfos<ProvidesTechPrerequisiteInfo>())
-				.SelectMany(p => p.Prerequisites);
-
-			var providedPrereqs = customPrereqs.Concat(techPrereqs);
+			var providedPrereqs = rules.Actors.SelectMany(a => a.Value.TraitInfos<ITechTreePrerequisiteInfo>().SelectMany(p => p.Prerequisites(a.Value)));
 
 			// TODO: this check is case insensitive while the real check in-game is not
 			foreach (var i in rules.Actors)

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesPrerequisite.cs
@@ -28,6 +28,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Should it recheck everything when it is captured?")]
 		public readonly bool ResetOnOwnerChange = false;
+
+		IEnumerable<string> ITechTreePrerequisiteInfo.Prerequisites(ActorInfo info)
+		{
+			return new string[] { Prerequisite ?? info.Name };
+		}
+
 		public override object Create(ActorInitializer init) { return new ProvidesPrerequisite(init, this); }
 	}
 

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
@@ -25,6 +25,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Prerequisites to grant when this tech level is active.")]
 		public readonly string[] Prerequisites = { };
 
+		IEnumerable<string> ITechTreePrerequisiteInfo.Prerequisites(ActorInfo info) { return Prerequisites; }
+
 		public object Create(ActorInitializer init) { return new ProvidesTechPrerequisite(this, init); }
 	}
 

--- a/OpenRA.Mods.Common/Traits/World/LobbyPrerequisiteCheckbox.cs
+++ b/OpenRA.Mods.Common/Traits/World/LobbyPrerequisiteCheckbox.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Enables defined prerequisites at game start for all players if the checkbox is enabled.")]
-	public class LobbyPrerequisiteCheckboxInfo : ITraitInfo, ILobbyOptions
+	public class LobbyPrerequisiteCheckboxInfo : ITraitInfo, ILobbyOptions, ITechTreePrerequisiteInfo
 	{
 		[FieldLoader.Require]
 		[Desc("Internal id for this checkbox.")]
@@ -44,6 +44,8 @@ namespace OpenRA.Mods.Common.Traits
 		[FieldLoader.Require]
 		[Desc("Prerequisites to grant when this checkbox is enabled.")]
 		public readonly HashSet<string> Prerequisites = new HashSet<string>();
+
+		IEnumerable<string> ITechTreePrerequisiteInfo.Prerequisites(ActorInfo info) { return Prerequisites; }
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
 		{

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -211,7 +211,11 @@ namespace OpenRA.Mods.Common.Traits
 		void Infiltrating(Actor self);
 	}
 
-	public interface ITechTreePrerequisiteInfo : ITraitInfo { }
+	public interface ITechTreePrerequisiteInfo : ITraitInfo
+	{
+		IEnumerable<string> Prerequisites(ActorInfo info);
+	}
+
 	public interface ITechTreePrerequisite
 	{
 		IEnumerable<string> ProvidesPrerequisites { get; }


### PR DESCRIPTION
and make `LobbyPrerequisiteCheckboxInfo` implement `ITechTreePrerequisiteInfo`.

Fixes  #15343.