### PR TITLE
Adding support for fetching files using wget instead, if curl is unavailable

### DIFF
--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -5,7 +5,7 @@ set -e
 command -v make >/dev/null 2>&1 || { echo >&2 "Linux packaging requires make."; exit 1; }
 command -v python >/dev/null 2>&1 || { echo >&2 "Linux packaging requires python."; exit 1; }
 command -v tar >/dev/null 2>&1 || { echo >&2 "Linux packaging requires tar."; exit 1; }
-command -v curl >/dev/null 2>&1 || { echo >&2 "Linux packaging requires curl."; exit 1; }
+command -v curl >/dev/null 2>&1 || command -v wget > /dev/null 2>&1 || { echo >&2 "Linux packaging requires curl or wget."; exit 1; }
 
 DEPENDENCIES_TAG="20180723"
 
@@ -55,8 +55,14 @@ popd > /dev/null
 
 # Add native libraries
 echo "Downloading dependencies"
-curl -s -L -O https://github.com/OpenRA/AppImageSupport/releases/download/${DEPENDENCIES_TAG}/libs.tar.bz2 || exit 3
-curl -s -L -O https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage || exit 3
+if command -v curl >/dev/null 2>&1; then
+	curl -s -L -O https://github.com/OpenRA/AppImageSupport/releases/download/${DEPENDENCIES_TAG}/libs.tar.bz2 || exit 3
+	curl -s -L -O https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage || exit 3
+else
+	wget -cq https://github.com/OpenRA/AppImageSupport/releases/download/${DEPENDENCIES_TAG}/libs.tar.bz2 || exit 3
+	wget -cq https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage || exit 3
+fi
+
 chmod a+x appimagetool-x86_64.AppImage
 
 echo "Building AppImage"

--- a/thirdparty/fetch-geoip-db.sh
+++ b/thirdparty/fetch-geoip-db.sh
@@ -13,6 +13,10 @@ filename="GeoLite2-Country.mmdb.gz"
 if [ ! -e $filename ] || [ -n "$(find . -name $filename -mtime +30 -print)" ]; then
 	rm -f $filename
 	echo "Updating GeoIP country database from MaxMind."
-	curl -s -L -O http://geolite.maxmind.com/download/geoip/database/$filename
+	if command -v curl >/dev/null 2>&1; then
+		curl -s -L -O http://geolite.maxmind.com/download/geoip/database/$filename
+	else
+		wget -cq http://geolite.maxmind.com/download/geoip/database/$filename
+	fi
 fi
 

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -81,19 +81,33 @@ fi
 
 if [ ! -f SDL2-CS.dll -o ! -f SDL2-CS.dll.config ]; then
 	echo "Fetching SDL2-CS from GitHub."
-	curl -s -L -O https://github.com/OpenRA/SDL2-CS/releases/download/20161223/SDL2-CS.dll
-	curl -s -L -O https://github.com/OpenRA/SDL2-CS/releases/download/20161223/SDL2-CS.dll.config
+	if command -v curl >/dev/null 2>&1; then
+		curl -s -L -O https://github.com/OpenRA/SDL2-CS/releases/download/20161223/SDL2-CS.dll
+		curl -s -L -O https://github.com/OpenRA/SDL2-CS/releases/download/20161223/SDL2-CS.dll.config
+	else
+		wget -cq https://github.com/OpenRA/SDL2-CS/releases/download/20161223/SDL2-CS.dll
+		wget -cq https://github.com/OpenRA/SDL2-CS/releases/download/20161223/SDL2-CS.dll.config
+	fi
 fi
 
 if [ ! -f OpenAL-CS.dll -o ! -f OpenAL-CS.dll.config ]; then
 	echo "Fetching OpenAL-CS from GitHub."
-	curl -s -L -O https://github.com/OpenRA/OpenAL-CS/releases/download/20151227/OpenAL-CS.dll
-	curl -s -L -O https://github.com/OpenRA/OpenAL-CS/releases/download/20151227/OpenAL-CS.dll.config
+	if command -v curl >/dev/null 2>&1; then
+		curl -s -L -O https://github.com/OpenRA/OpenAL-CS/releases/download/20151227/OpenAL-CS.dll
+		curl -s -L -O https://github.com/OpenRA/OpenAL-CS/releases/download/20151227/OpenAL-CS.dll.config
+	else
+		wget -cq https://github.com/OpenRA/OpenAL-CS/releases/download/20151227/OpenAL-CS.dll
+		wget -cq https://github.com/OpenRA/OpenAL-CS/releases/download/20151227/OpenAL-CS.dll.config
+	fi
 fi
 
 if [ ! -f Eluant.dll ]; then
 	echo "Fetching Eluant from GitHub."
-	curl -s -L -O https://github.com/OpenRA/Eluant/releases/download/20160124/Eluant.dll
+	if command -v curl >/dev/null 2>&1; then
+		curl -s -L -O https://github.com/OpenRA/Eluant/releases/download/20160124/Eluant.dll
+	else
+		wget -cq https://github.com/OpenRA/Eluant/releases/download/20160124/Eluant.dll
+	fi
 fi
 
 if [ ! -f rix0rrr.BeaconLib.dll ]; then

--- a/thirdparty/noget.sh
+++ b/thirdparty/noget.sh
@@ -6,8 +6,14 @@
 # Copy-paste the entire script into http://shellcheck.net to check.
 ####
 
+command -v curl >/dev/null 2>&1 || command -v wget > /dev/null 2>&1 || { echo >&2 "Obtaining thirdparty dependencies requires curl or wget."; exit 1; }
+
 archive="$1"
 version="$2"
-curl -o "$archive.zip" -Ls https://nuget.org/api/v2/package/"$archive"/"$version"
+if command -v curl >/dev/null 2>&1; then
+	curl -o "$archive.zip" -Ls https://nuget.org/api/v2/package/"$archive"/"$version"
+else
+	wget -cq https://nuget.org/api/v2/package/"$archive"/"$version" -O "$archive.zip"
+fi
 mkdir -p "$archive"
 unzip -o -qq "$archive.zip" -d "$archive" && rm "$archive.zip"


### PR DESCRIPTION
Hi,

This pull is me just making the job of building OpenRA on Linux a little easier, by adding support for using wget instead of curl, should curl not be installed. wget comes pre-installed on a few distros that curl doesn't come pre-installed on (e.g. Ubuntu). 

Check list:
-  [x] Make sure that you have read and understand the OpenRA Coding Standard (see https://github.com/OpenRA/OpenRA/wiki/Coding-Standard). 
(N/A, as not editing C# files. Only part that might be applicable is using tabs instead of spaces. I noticed the scripts already used spaces for indentation, so I just copy-pasted the indentation already in use.)
-  [x] Write quality commit messages (see https://chris.beams.io/posts/git-commit/).
(I even edited my commit message to try to make it more concise and helpful).
-  [x] Only commit changes that directly relate to your Pull Request. Use your Git interface to unstage any unrelated changes to project files, line endings, whitespace, or other files.
-  [x] Review the code diff view below to double check that your changes satisfy the above three points.
-  [x] Use the `make test` and `make check` commands to check for (and fix!) any issues that are reported by our automated tests.
(Tested on openSUSE Tumbleweed 20180712)

I have tried my best here to make sure what I have done complies to the standards of this repository, but if there's something I've done wrong do say and I'll try my best to fix it. 

Thanks for your time and hope this helps,
Brenton
