### PR TITLE
Fix expectator kick dropdown crash.

### DIFF
--- a/mods/ts/chrome/dropdowns.yaml
+++ b/mods/ts/chrome/dropdowns.yaml
@@ -58,6 +58,22 @@ ScrollPanel@SPAWN_DROPDOWN_TEMPLATE:
 					Height: 25
 					Align: Center
 
+ScrollPanel@PLAYERACTION_DROPDOWN_TEMPLATE:
+	Width: DROPDOWN_WIDTH
+	Children:
+		ScrollItem@TEMPLATE:
+			Width: PARENT_RIGHT - 27
+			Height: 25
+			X: 2
+			Y: 0
+			Visible: false
+			Children:
+				Label@LABEL:
+					X: 10
+					Width: PARENT_RIGHT - 20
+					Height: 25
+					Align: Left
+
 ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 	Width: DROPDOWN_WIDTH
 	Children:


### PR DESCRIPTION
Fixes #15352 , as far as I could understand, the reason for this crash is that some of the chrome configuration of ORA TS was duplicated from Commons, and this fixed was missed by #15307