### PR TITLE
Utilize blue and grey passenger pip colors

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -483,6 +483,8 @@
 		HP: 2500
 	RevealsShroud:
 		Range: 2c0
+	Passenger:
+		PipType: Gray
 	ActorLostNotification:
 		Notification: CivilianKilled
 		NotifyAll: true

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -440,6 +440,8 @@
 		GenericVisibility: None
 	RevealsShroud:
 		Range: 3c0
+	Passenger:
+		PipType: Gray
 	ProximityCaptor:
 		Types: CivilianInfantry
 	ScaredyCat:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -268,7 +268,7 @@ SPY:
 	RevealsShroud:
 		Range: 5c0
 	Passenger:
-		PipType: Yellow
+		PipType: Blue
 		Voice: Move
 	Disguise:
 		DisguisedCondition: disguise
@@ -382,7 +382,7 @@ MEDI:
 	RevealsShroud:
 		Range: 3c0
 	Passenger:
-		PipType: Yellow
+		PipType: Blue
 	Armament:
 		Weapon: Heal
 		Cursor: heal
@@ -418,7 +418,7 @@ MECH:
 	RevealsShroud:
 		Range: 3c0
 	Passenger:
-		PipType: Yellow
+		PipType: Blue
 		Voice: Move
 	Armament:
 		Weapon: Repair
@@ -504,7 +504,7 @@ THF:
 	RevealsShroud:
 		Range: 5c0
 	Passenger:
-		PipType: Yellow
+		PipType: Blue
 	Infiltrates:
 		PlayerExperience: 50
 	Voiced:
@@ -532,7 +532,7 @@ HIJACKER:
 	RevealsShroud:
 		Range: 5c0
 	Passenger:
-		PipType: Yellow
+		PipType: Blue
 	Captures:
 		CaptureTypes: vehicle
 		PlayerExperience: 50


### PR DESCRIPTION
This makes the civilian passenger pip color grey, and makes the pips for medics, mechanics, spies and hijackers blue. (And the thief for missions that have him) This will mostly help spectators, who can now tell the difference between a spy/hijacker drop and an engineer drop.

Closes #15346