### PR TITLE
Hardcoded notification sounds now configurable and optional.

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -910,6 +910,7 @@
     <Compile Include="UpdateRules\Rules\20180307\AddShakeToBridge.cs" />
     <Compile Include="UpdateRules\Rules\20180307\IgnoreAbstractActors.cs" />
     <Compile Include="UpdateRules\Rules\20180307\RemoveCanUndeployFromGrantConditionOnDeploy.cs" />
+    <Compile Include="UpdateRules\Rules\DefineNotificationDefaults.cs" />
     <Compile Include="Traits\Player\PlayerResources.cs" />
     <Compile Include="UtilityCommands\DumpSequenceSheetsCommand.cs" />
     <Compile Include="Traits\Render\WithBuildingRepairDecoration.cs" />

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.Orders
 					orderType = "PlacePlug";
 					if (!AcceptsPlug(topLeft, plugInfo))
 					{
-						Game.Sound.PlayNotification(world.Map.Rules, owner, "Speech", "BuildingCannotPlaceAudio", owner.Faction.InternalName);
+						Game.Sound.PlayNotification(world.Map.Rules, owner, "Speech", placeBuildingInfo.CannotPlaceNotification, owner.Faction.InternalName);
 						yield break;
 					}
 				}
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Common.Orders
 						foreach (var order in ClearBlockersOrders(world, topLeft))
 							yield return order;
 
-						Game.Sound.PlayNotification(world.Map.Rules, owner, "Speech", "BuildingCannotPlaceAudio", owner.Faction.InternalName);
+						Game.Sound.PlayNotification(world.Map.Rules, owner, "Speech", placeBuildingInfo.CannotPlaceNotification, owner.Faction.InternalName);
 						yield break;
 					}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string PrimaryCondition = null;
 
 		[Desc("The speech notification to play when selecting a primary building.")]
-		public readonly string SelectionNotification = "PrimaryBuildingSelected";
+		public readonly string SelectionNotification = null;
 
 		[Desc("List of production queues for which the primary flag should be set.",
 			"If empty, the list given in the `Produces` property of the `Production` trait will be used.")]

--- a/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
@@ -43,6 +43,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The condition to grant to self while being repaired.")]
 		public readonly string RepairCondition = null;
 
+		public readonly string RepairingNotification = null;
+
 		public override object Create(ActorInitializer init) { return new RepairableBuilding(init.Self, this); }
 	}
 
@@ -112,7 +114,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			Repairers.Add(player);
-			Game.Sound.PlayNotification(self.World.Map.Rules, player, "Speech", "Repairing", player.Faction.InternalName);
+			Game.Sound.PlayNotification(self.World.Map.Rules, player, "Speech", Info.RepairingNotification, player.Faction.InternalName);
 			UpdateCondition(self);
 		}
 

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -36,6 +36,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Should the level-up animation be suppressed when actor is created?")]
 		public readonly bool SuppressLevelupAnimation = true;
 
+		public readonly string LevelUpNotification = null;
+
 		public object Create(ActorInitializer init) { return new GainsExperience(init, this); }
 	}
 
@@ -99,7 +101,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (!silent)
 				{
-					Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", "LevelUp", self.Owner.Faction.InternalName);
+					Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Sounds", info.LevelUpNotification, self.Owner.Faction.InternalName);
 					self.World.AddFrameEndTask(w => w.Add(new CrateEffect(self, "levelup", info.LevelUpPalette)));
 				}
 			}

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)
-					Game.Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Lose", player.Faction.InternalName);
+					Game.Sound.PlayNotification(player.World.Map.Rules, player, "Speech", mo.Info.LoseNotification, player.Faction.InternalName);
 			});
 		}
 
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Traits
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)
-					Game.Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Win", player.Faction.InternalName);
+					Game.Sound.PlayNotification(player.World.Map.Rules, player, "Speech", mo.Info.WinNotification, player.Faction.InternalName);
 			});
 		}
 

--- a/OpenRA.Mods.Common/Traits/Player/MissionObjectives.cs
+++ b/OpenRA.Mods.Common/Traits/Player/MissionObjectives.cs
@@ -48,6 +48,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Delay between the game over condition being met, and the game actually ending, in milliseconds.")]
 		public readonly int GameOverDelay = 1500;
 
+		public readonly string WinNotification = null;
+		public readonly string LoseNotification = null;
+		public readonly string LeaveNotification = null;
+
 		public object Create(ActorInitializer init) { return new MissionObjectives(init.World, this); }
 	}
 

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -34,6 +34,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Notification to play after building placement if new construction options are available.")]
 		public readonly string NewOptionsNotification = null;
 
+		public readonly string CannotPlaceNotification = null;
+
 		public object Create(ActorInitializer init) { return new PlaceBuilding(this); }
 	}
 

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int NewOptionsNotificationDelay = 10;
 
 		[Desc("Notification to play after building placement if new construction options are available.")]
-		public readonly string NewOptionsNotification = "NewOptions";
+		public readonly string NewOptionsNotification = null;
 
 		public object Create(ActorInitializer init) { return new PlaceBuilding(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
@@ -47,6 +47,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Delay (in ticks) during which warnings will be muted.")]
 		public readonly int InsufficientFundsNotificationDelay = 750;
 
+		public readonly string CashTickUpNotification = null;
+		public readonly string CashTickDownNotification = null;
+
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
 		{
 			var startingCash = SelectableCash.ToDictionary(c => c.ToString(), c => "$" + c.ToString());
@@ -61,12 +64,12 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class PlayerResources : ITick, ISync
 	{
-		readonly PlayerResourcesInfo info;
+		public readonly PlayerResourcesInfo Info;
 		readonly Player owner;
 
 		public PlayerResources(Actor self, PlayerResourcesInfo info)
 		{
-			this.info = info;
+			Info = info;
 			owner = self.Owner;
 
 			var startingCash = self.World.LobbyInfo.GlobalSettings
@@ -164,11 +167,11 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (Cash + Resources < num)
 			{
-				if (notifyLowFunds && !string.IsNullOrEmpty(info.InsufficientFundsNotification) &&
-					owner.World.WorldTick - lastNotificationTick >= info.InsufficientFundsNotificationDelay)
+				if (notifyLowFunds && !string.IsNullOrEmpty(Info.InsufficientFundsNotification) &&
+					owner.World.WorldTick - lastNotificationTick >= Info.InsufficientFundsNotificationDelay)
 				{
 					lastNotificationTick = owner.World.WorldTick;
-					Game.Sound.PlayNotification(owner.World.Map.Rules, owner, "Speech", info.InsufficientFundsNotification, owner.Faction.InternalName);
+					Game.Sound.PlayNotification(owner.World.Map.Rules, owner, "Speech", Info.InsufficientFundsNotification, owner.Faction.InternalName);
 				}
 
 				return false;

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -52,12 +52,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Notification played when production is complete.",
 			"The filename of the audio is defined per faction in notifications.yaml.")]
-		public readonly string ReadyAudio = "UnitReady";
+		public readonly string ReadyAudio = null;
 
 		[Desc("Notification played when you can't train another actor",
 			"when the build limit exceeded or the exit is jammed.",
 			"The filename of the audio is defined per faction in notifications.yaml.")]
-		public readonly string BlockedAudio = "NoBuild";
+		public readonly string BlockedAudio = null;
 
 		[Desc("Notification played when you can't queue another actor",
 			"when the queue length limit is exceeded.",
@@ -66,15 +66,15 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Notification played when user clicks on the build palette icon.",
 			"The filename of the audio is defined per faction in notifications.yaml.")]
-		public readonly string QueuedAudio = "Training";
+		public readonly string QueuedAudio = null;
 
 		[Desc("Notification played when player right-clicks on the build palette icon.",
 			"The filename of the audio is defined per faction in notifications.yaml.")]
-		public readonly string OnHoldAudio = "OnHold";
+		public readonly string OnHoldAudio = null;
 
 		[Desc("Notification played when player right-clicks on a build palette icon that is already on hold.",
 			"The filename of the audio is defined per faction in notifications.yaml.")]
-		public readonly string CancelledAudio = "Cancelled";
+		public readonly string CancelledAudio = null;
 
 		public virtual object Create(ActorInitializer init) { return new ProductionQueue(init, init.Self.Owner.PlayerActor, this); }
 

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Traits
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)
-					Game.Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Lose", player.Faction.InternalName);
+					Game.Sound.PlayNotification(player.World.Map.Rules, player, "Speech", mo.Info.LoseNotification, player.Faction.InternalName);
 			});
 		}
 
@@ -132,7 +132,7 @@ namespace OpenRA.Mods.Common.Traits
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)
-					Game.Sound.PlayNotification(player.World.Map.Rules, player, "Speech", "Win", player.Faction.InternalName);
+					Game.Sound.PlayNotification(player.World.Map.Rules, player, "Speech", mo.Info.WinNotification, player.Faction.InternalName);
 			});
 		}
 

--- a/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class PowerManagerInfo : ITraitInfo, Requires<DeveloperModeInfo>
 	{
 		public readonly int AdviceInterval = 250;
-		public readonly string SpeechNotification = "LowPower";
+		public readonly string SpeechNotification = null;
 
 		public object Create(ActorInitializer init) { return new PowerManager(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/RepairsUnits.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsUnits.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int Interval = 24;
 
 		[Desc("The sound played when starting to repair a unit.")]
-		public readonly string StartRepairingNotification = "Repairing";
+		public readonly string StartRepairingNotification = null;
 
 		[Desc("The sound played when repairing a unit is done.")]
 		public readonly string FinishRepairingNotification = null;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/DefineNotificationDefaults.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/DefineNotificationDefaults.cs
@@ -1,0 +1,139 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class DefineNotificationDefaults : UpdateRule
+	{
+		public override string Name { get { return "Move mod-specific notifications to yaml"; } }
+		public override string Description
+		{
+			get
+			{
+				return "Mod-specific default notifications values have been removed from several traits and the Radar widget\n" +
+					"(" + traits.Select(f => f.Trait).JoinWith(", ") + ")\n" +
+					"The mod chrome is updated automatically and uses of these traits are listed for inspection so the values can be overriden in yaml.";
+			}
+		}
+
+		class TraitWrapper
+		{
+			public readonly string Trait;
+			public readonly Dictionary<string, string> Fields;
+			public List<string> Uses = new List<string>();
+
+			public TraitWrapper(string trait, Dictionary<string, string> fields)
+			{
+				Trait = trait;
+				Fields = fields;
+			}
+		}
+
+		TraitWrapper[] traits =
+		{
+			new TraitWrapper("PrimaryBuilding", new Dictionary<string, string> {
+				{ "SelectionNotification", "PrimaryBuildingSelected" }
+			}),
+			new TraitWrapper("RepairableBuilding", new Dictionary<string, string> {
+				{ "RepairingNotification", "Repairing" }
+			}),
+			new TraitWrapper("RepairsUnits", new Dictionary<string, string> {
+				{ "StartRepairingNotification", "Repairing" }
+			}),
+			new TraitWrapper("GainsExperience", new Dictionary<string, string> {
+				{ "LevelUpNotification", "LevelUp" }
+			}),
+			new TraitWrapper("MissionObjectives", new Dictionary<string, string> {
+				{ "WinNotification", "Win" },
+				{ "LoseNotification", "Lose" },
+				{ "LeaveNotification", "Leave" }
+			}),
+			new TraitWrapper("PlaceBuilding", new Dictionary<string, string> {
+				{ "NewOptionsNotification", "NewOptions" },
+				{ "CannotPlaceNotification", "BuildingCannotPlaceAudio" }
+			}),
+			new TraitWrapper("PlayerResources", new Dictionary<string, string> {
+				{ "CashTickUpNotification", "CashTickUp" },
+				{ "CashTickDownNotification", "CashTickDown" }
+			}),
+			new TraitWrapper("ProductionQueue", new Dictionary<string, string> {
+				{ "ReadyAudio", "UnitReady" },
+				{ "BlockedAudio", "NoBuild" },
+				{ "QueuedAudio", "Training" },
+				{ "OnHoldAudio", "OnHold" },
+				{ "CancelledAudio", "Cancelled" }
+			}),
+			new TraitWrapper("PowerManager", new Dictionary<string, string> {
+				{ "SpeechNotification", "LowPower" }
+			})
+		};
+
+		string BuildMessage(TraitWrapper t)
+		{
+			return "Default notification values have been removed from {0}.\n".F(t.Trait) +
+				"You may wish to explicitly define the following overrides:\n   " + t.Trait + ":\n" +
+				UpdateUtils.FormatMessageList(t.Fields.Select(kv => "   " + kv.Key + ": " + kv.Value), separator: "  ") +
+				"\non the following actors (if they have not already been inherited from a parent).\n" +
+				UpdateUtils.FormatMessageList(t.Uses);
+		}
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			foreach (var t in traits)
+			{
+				if (t.Uses.Any())
+					yield return BuildMessage(t);
+
+				t.Uses.Clear();
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var t in traits)
+			{
+				foreach (var traitNode in actorNode.ChildrenMatching(t.Trait))
+				{
+					foreach (var f in t.Fields)
+					{
+						var node = traitNode.LastChildMatching(f.Key);
+						if (node == null)
+						{
+							var location = "{0} ({1})".F(actorNode.Key, traitNode.Location.Filename);
+							if (!t.Uses.Contains(location))
+								t.Uses.Add(location);
+						}
+					}
+				}
+			}
+
+			yield break;
+		}
+
+		public override IEnumerable<string> UpdateChromeNode(ModData modData, MiniYamlNode chromeNode)
+		{
+			foreach (var node in chromeNode.ChildrenMatching("Radar"))
+			{
+				if (!node.ChildrenMatching("SoundUp").Any())
+					node.AddNode("SoundUp", "RadarUp");
+
+				if (!node.ChildrenMatching("SoundDown").Any())
+					node.AddNode("SoundDown", "RadarDown");
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -87,7 +87,8 @@ namespace OpenRA.Mods.Common.UpdateRules
 			new UpdatePath("playtest-20180729", new UpdateRule[]
 			{
 				// Bleed only changes here
-				new RenameEditorTilesetFilter()
+				new RenameEditorTilesetFilter(),
+				new DefineNotificationDefaults(),
 			})
 		};
 

--- a/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
@@ -221,10 +221,10 @@ namespace OpenRA.Mods.Common.UpdateRules
 							yield return manualStep;
 		}
 
-		public static string FormatMessageList(IEnumerable<string> messages, int indent = 0)
+		public static string FormatMessageList(IEnumerable<string> messages, int indent = 0, string separator = "*")
 		{
 			var prefix = string.Concat(Enumerable.Repeat("   ", indent));
-			return string.Join("\n", messages.Select(m => prefix + " * {0}".F(m.Replace("\n", "\n   " + prefix))));
+			return string.Join("\n", messages.Select(m => prefix + " {0} {1}".F(separator, m.Replace("\n", "\n   " + prefix))));
 		}
 	}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				displayResources += move;
 
 				if (Game.Settings.Sound.CashTicks)
-					Game.Sound.PlayNotification(world.Map.Rules, player, "Sounds", "CashTickUp", player.Faction.InternalName);
+					Game.Sound.PlayNotification(world.Map.Rules, player, "Sounds", playerResources.Info.CashTickUpNotification, player.Faction.InternalName);
 			}
 			else if (displayResources > actual)
 			{
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				if (Game.Settings.Sound.CashTicks && nextCashTickTime == 0)
 				{
-					Game.Sound.PlayNotification(world.Map.Rules, player, "Sounds", "CashTickDown", player.Faction.InternalName);
+					Game.Sound.PlayNotification(world.Map.Rules, player, "Sounds", playerResources.Info.CashTickDownNotification, player.Faction.InternalName);
 					nextCashTickTime = 2;
 				}
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -44,7 +44,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			Action onQuit = () =>
 			{
 				if (world.Type == WorldType.Regular)
-					Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", "Leave", world.LocalPlayer == null ? null : world.LocalPlayer.Faction.InternalName);
+				{
+					var moi = world.Map.Rules.Actors["player"].TraitInfoOrDefault<MissionObjectivesInfo>();
+					if (moi != null)
+					{
+						var faction = world.LocalPlayer == null ? null : world.LocalPlayer.Faction.InternalName;
+						Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", moi.LeaveNotification, faction);
+					}
+				}
 
 				leaving = true;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameRadarDisplayLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameRadarDisplayLogic.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					.Any(a => a.Owner == world.LocalPlayer);
 
 				if (radarEnabled != cachedRadarEnabled)
-					Game.Sound.PlayNotification(world.Map.Rules, null, "Sounds", radarEnabled ? "RadarUp" : "RadarDown", null);
+					Game.Sound.PlayNotification(world.Map.Rules, null, "Sounds", radarEnabled ? radar.SoundUp : radar.SoundDown, null);
 				cachedRadarEnabled = radarEnabled;
 			};
 

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -59,6 +59,9 @@ namespace OpenRA.Mods.Common.Widgets
 		Sprite shroudSprite;
 		Shroud renderShroud;
 
+		public string SoundUp { get; private set; }
+		public string SoundDown { get; private set; }
+
 		[ObjectCreator.UseCtor]
 		public RadarWidget(World world, WorldRenderer worldRenderer)
 		{

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -618,6 +618,8 @@ Container@PLAYER_WIDGETS:
 							Width: PARENT_RIGHT - 2
 							Height: PARENT_BOTTOM - 2
 							WorldInteractionController: INTERACTION_CONTROLLER
+							SoundUp: RadarUp
+							SoundDown: RadarDown
 							Children:
 								LogicTicker@RADAR_TICKER:
 						VqaPlayer@PLAYER:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -734,6 +734,7 @@
 		RepairPercent: 40
 		RepairStep: 1400
 		PlayerExperience: 15
+		RepairingNotification: Repairing
 	WithDeathAnimation:
 		DeathSequence: dead
 		UseDeathTypeSuffix: false
@@ -793,6 +794,7 @@
 		RepairPercent: 40
 		RepairStep: 1400
 		PlayerExperience: 15
+		RepairingNotification: Repairing
 	EngineerRepairable:
 	RevealsShroud:
 		Range: 3c0

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -43,6 +43,7 @@
 
 ^GainsExperience:
 	GainsExperience:
+		LevelUpNotification: LevelUp
 		Conditions:
 			200: rank-veteran
 			400: rank-veteran

--- a/mods/cnc/rules/player.yaml
+++ b/mods/cnc/rules/player.yaml
@@ -14,6 +14,9 @@ Player:
 	SupportPowerManager:
 	ScriptTriggers:
 	MissionObjectives:
+		WinNotification: Win
+		LoseNotification: Lose
+		LeaveNotification: Leave
 	ConquestVictoryConditions:
 	PowerManager:
 		SpeechNotification: LowPower

--- a/mods/cnc/rules/player.yaml
+++ b/mods/cnc/rules/player.yaml
@@ -16,6 +16,8 @@ Player:
 	PowerManager:
 	AllyRepair:
 	PlayerResources:
+		CashTickUpNotification: CashTickUp
+		CashTickDownNotification: CashTickDown
 	DeveloperMode:
 		CheckboxDisplayOrder: 8
 	BaseAttackNotifier:

--- a/mods/cnc/rules/player.yaml
+++ b/mods/cnc/rules/player.yaml
@@ -9,6 +9,7 @@ Player:
 	Inherits: ^BasePlayer
 	PlaceBuilding:
 		NewOptionsNotification: NewOptions
+		CannotPlaceNotification: BuildingCannotPlaceAudio
 	TechTree:
 	SupportPowerManager:
 	ScriptTriggers:

--- a/mods/cnc/rules/player.yaml
+++ b/mods/cnc/rules/player.yaml
@@ -8,6 +8,7 @@ EditorPlayer:
 Player:
 	Inherits: ^BasePlayer
 	PlaceBuilding:
+		NewOptionsNotification: NewOptions
 	TechTree:
 	SupportPowerManager:
 	ScriptTriggers:

--- a/mods/cnc/rules/player.yaml
+++ b/mods/cnc/rules/player.yaml
@@ -14,6 +14,7 @@ Player:
 	MissionObjectives:
 	ConquestVictoryConditions:
 	PowerManager:
+		SpeechNotification: LowPower
 	AllyRepair:
 	PlayerResources:
 		CashTickUpNotification: CashTickUp

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -520,6 +520,7 @@ HPAD:
 	RepairsUnits:
 		HpPerStep: 1000
 		PlayerExperience: 25
+		StartRepairingNotification: Repairing
 	WithRepairAnimation:
 	RallyPoint:
 	ProductionQueue@GDI:
@@ -651,6 +652,7 @@ FIX:
 		HpPerStep: 1000
 		Interval: 15
 		PlayerExperience: 25
+		StartRepairingNotification: Repairing
 	RallyPoint:
 	WithRepairAnimation:
 	Power:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -33,33 +33,45 @@ FACT:
 		Factions: gdi
 		Group: Building
 		LowPowerSlowdown: 2
-		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
+		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Building
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 	ProductionQueue@NodBuilding:
 		Type: Building.Nod
 		Factions: nod
 		Group: Building
 		LowPowerSlowdown: 2
-		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
+		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Building
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 	ProductionQueue@GDIDefense:
 		Type: Defence.GDI
 		Factions: gdi
 		Group: Defence
 		LowPowerSlowdown: 3
-		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
+		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Building
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 	ProductionQueue@NodDefense:
 		Type: Defence.Nod
 		Factions: nod
 		Group: Defence
 		LowPowerSlowdown: 3
-		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
+		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Building
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 	BaseBuilding:
 	ProductionBar@BuildingGDI:
 		ProductionType: Building.GDI
@@ -301,7 +313,12 @@ PYLE:
 		Type: Infantry.GDI
 		Group: Infantry
 		LowPowerSlowdown: 3
+		ReadyAudio: UnitReady
+		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Training
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 	ProductionBar:
 	Power:
 		Amount: -20
@@ -346,7 +363,12 @@ HAND:
 		Type: Infantry.Nod
 		Group: Infantry
 		LowPowerSlowdown: 3
+		ReadyAudio: UnitReady
+		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Training
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 	ProductionBar:
 	Power:
 		Amount: -20
@@ -399,8 +421,11 @@ AFLD:
 		Type: Vehicle.Nod
 		Group: Vehicle
 		LowPowerSlowdown: 3
-		ReadyAudio:
+		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Training
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 	ProductionBar:
 	Power:
 		Amount: -40
@@ -452,7 +477,12 @@ WEAP:
 		Type: Vehicle.GDI
 		Group: Vehicle
 		LowPowerSlowdown: 3
+		ReadyAudio: UnitReady
+		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Training
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 	ProductionBar:
 	Power:
 		Amount: -40
@@ -497,13 +527,23 @@ HPAD:
 		Factions: gdi
 		Group: Aircraft
 		LowPowerSlowdown: 3
+		ReadyAudio: UnitReady
+		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Training
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 	ProductionQueue@Nod:
 		Type: Aircraft.Nod
 		Factions: nod
 		Group: Aircraft
 		LowPowerSlowdown: 3
+		ReadyAudio: UnitReady
+		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Training
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 	ProductionBar@GDI:
 		ProductionType: Aircraft.GDI
 	ProductionBar@Nod:

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -97,7 +97,12 @@ BIO:
 		Type: Biolab
 		Group: Infantry
 		LowPowerSlowdown: 3
+		ReadyAudio: UnitReady
+		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Training
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 	ProductionBar:
 	RallyPoint:
 		Offset: -1,-1

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -376,6 +376,8 @@ Container@PLAYER_WIDGETS:
 							Y: 34
 							Width: 202
 							Height: 202
+							SoundUp: RadarUp
+							SoundDown: RadarDown
 							Children:
 						VqaPlayer@PLAYER:
 							X: 12

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -399,6 +399,7 @@
 	RepairableBuilding:
 		RepairStep: 500
 		PlayerExperience: 25
+		RepairingNotification: Repairing
 	SpawnActorsOnSell:
 		ActorTypes: light_inf
 	MustBeDestroyed:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -15,6 +15,7 @@
 
 ^GainsExperience:
 	GainsExperience:
+		LevelUpNotification: LevelUp
 		Conditions:
 			200: rank-veteran
 			400: rank-veteran

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -68,6 +68,8 @@ Player:
 	PlayerResources:
 		SelectableCash: 2500, 5000, 7000, 10000, 20000
 		InsufficientFundsNotification: InsufficientFunds
+		CashTickUpNotification: CashTickUp
+		CashTickDownNotification: CashTickDown
 	DeveloperMode:
 		CheckboxDisplayOrder: 7
 	BaseAttackNotifier:

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -12,29 +12,41 @@ Player:
 		Type: Building
 		BuildDurationModifier: 250
 		LowPowerSlowdown: 3
-		QueuedAudio: Building
 		ReadyAudio: BuildingReady
 		BlockedAudio: NoRoom
+		QueuedAudio: Building
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 		SpeedUp: true
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
 		BuildDurationModifier: 250
 		LowPowerSlowdown: 3
+		ReadyAudio: UnitReady
 		BlockedAudio: NoRoom
+		QueuedAudio: Training
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 		SpeedUp: true
 	ClassicProductionQueue@Vehicle:
 		Type: Vehicle
 		BuildDurationModifier: 250
 		LowPowerSlowdown: 3
-		QueuedAudio: Building
+		ReadyAudio: UnitReady
 		BlockedAudio: NoRoom
+		QueuedAudio: Building
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 		SpeedUp: true
 	ClassicProductionQueue@Armor:
 		Type: Armor
 		BuildDurationModifier: 250
 		LowPowerSlowdown: 3
-		QueuedAudio: Building
+		ReadyAudio: UnitReady
 		BlockedAudio: NoRoom
+		QueuedAudio: Building
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 		SpeedUp: true
 	ClassicProductionQueue@Starport:
 		Type: Starport
@@ -42,21 +54,27 @@ Player:
 		LowPowerSlowdown: 1
 		BlockedAudio: NoRoom
 		QueuedAudio: OrderPlaced
-		ReadyAudio:
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 	ClassicProductionQueue@Aircraft:
 		Type: Aircraft
 		BuildDurationModifier: 312
 		LowPowerSlowdown: 3
-		QueuedAudio: Building
+		ReadyAudio: UnitReady
 		BlockedAudio: NoRoom
+		QueuedAudio: Building
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 		SpeedUp: true
 	ClassicProductionQueue@Upgrade: # Upgrade is defined after others so it won't be automatically selected by ProductionQueueFromSelection.
 		Type: Upgrade
 		BuildDurationModifier: 250
 		LowPowerSlowdown: 1
-		QueuedAudio: Upgrading
 		ReadyAudio: NewOptions
 		BlockedAudio: NoRoom
+		QueuedAudio: Upgrading
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 	PlaceBuilding:
 		NewOptionsNotification: NewOptions
 		CannotPlaceNotification: BuildingCannotPlaceAudio

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -64,6 +64,7 @@ Player:
 	ConquestVictoryConditions:
 	PowerManager:
 		AdviceInterval: 650
+		SpeechNotification: LowPower
 	AllyRepair:
 	PlayerResources:
 		SelectableCash: 2500, 5000, 7000, 10000, 20000

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -81,6 +81,9 @@ Player:
 	SupportPowerManager:
 	ScriptTriggers:
 	MissionObjectives:
+		WinNotification: Win
+		LoseNotification: Lose
+		LeaveNotification: Leave
 	ConquestVictoryConditions:
 	PowerManager:
 		AdviceInterval: 650

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -58,6 +58,7 @@ Player:
 		ReadyAudio: NewOptions
 		BlockedAudio: NoRoom
 	PlaceBuilding:
+		NewOptionsNotification: NewOptions
 	SupportPowerManager:
 	ScriptTriggers:
 	MissionObjectives:

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -59,6 +59,7 @@ Player:
 		BlockedAudio: NoRoom
 	PlaceBuilding:
 		NewOptionsNotification: NewOptions
+		CannotPlaceNotification: BuildingCannotPlaceAudio
 	SupportPowerManager:
 	ScriptTriggers:
 	MissionObjectives:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -887,6 +887,7 @@ repair_pad:
 	RepairsUnits:
 		Interval: 10
 		HpPerStep: 800
+		StartRepairingNotification: Repairing
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
 	RallyPoint:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -103,6 +103,7 @@ construction_yard:
 	PrimaryBuilding:
 		PrimaryCondition: primary
 		ProductionQueues: Building
+		SelectionNotification: PrimaryBuildingSelected
 	ProvidesPrerequisite@buildingname:
 	GrantConditionOnPrerequisite:
 		Prerequisites: upgrade.conyard
@@ -211,6 +212,7 @@ barracks:
 	PrimaryBuilding:
 		PrimaryCondition: primary
 		ProductionQueues: Infantry
+		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
 	ProvidesPrerequisite@atreides:
 		Prerequisite: barracks.atreides
@@ -411,6 +413,7 @@ light_factory:
 	PrimaryBuilding:
 		PrimaryCondition: primary
 		ProductionQueues: Vehicle
+		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
 	ProvidesPrerequisite@atreides:
 		Prerequisite: light.atreides
@@ -497,6 +500,7 @@ heavy_factory:
 	PrimaryBuilding:
 		PrimaryCondition: primary
 		ProductionQueues: Armor
+		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
 	ProvidesPrerequisite@atreides:
 		Prerequisite: heavy.atreides
@@ -659,6 +663,7 @@ starport:
 	PrimaryBuilding:
 		PrimaryCondition: primary
 		ProductionQueues: Starport
+		SelectionNotification: PrimaryBuildingSelected
 	ProvidesPrerequisite@atreides:
 		Prerequisite: starport.atreides
 		Factions: atreides
@@ -920,6 +925,7 @@ high_tech_factory:
 	PrimaryBuilding:
 		PrimaryCondition: primary
 		ProductionQueues: Aircraft
+		SelectionNotification: PrimaryBuildingSelected
 	Exit:
 		SpawnOffset: 0,0,728
 		ExitCell: 0,0
@@ -1102,6 +1108,7 @@ palace:
 	PrimaryBuilding:
 		PrimaryCondition: primary
 		RequiresCondition: atreides || ordos
+		SelectionNotification: PrimaryBuildingSelected
 	WithTextDecoration@primary:
 		RequiresSelection: true
 		Text: PRIMARY

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -398,6 +398,8 @@ Container@PLAYER_WIDGETS:
 							Y: 41
 							Width: 220
 							Height: 220
+							SoundUp: RadarUp
+							SoundDown: RadarDown
 							Children:
 						VqaPlayer@PLAYER:
 							X: 8

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -644,6 +644,7 @@
 	RepairableBuilding:
 		RepairStep: 700
 		PlayerExperience: 25
+		RepairingNotification: Repairing
 	EngineerRepairable:
 	AcceptsDeliveredCash:
 	WithMakeAnimation:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -42,6 +42,7 @@
 
 ^GainsExperience:
 	GainsExperience:
+		LevelUpNotification: LevelUp
 		Conditions:
 			200: rank-veteran
 			400: rank-veteran

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -75,6 +75,9 @@ Player:
 	SupportPowerManager:
 	ScriptTriggers:
 	MissionObjectives:
+		WinNotification: Win
+		LoseNotification: Lose
+		LeaveNotification: Leave
 	ConquestVictoryConditions:
 	PowerManager:
 		SpeechNotification: LowPower

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -11,40 +11,63 @@ Player:
 	ClassicProductionQueue@Building:
 		Type: Building
 		LowPowerSlowdown: 3
-		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
+		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Building
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 		SpeedUp: True
 	ClassicProductionQueue@Defense:
 		Type: Defense
 		LowPowerSlowdown: 3
-		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
+		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Building
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 		SpeedUp: True
 	ClassicProductionQueue@Vehicle:
 		Type: Vehicle
 		LowPowerSlowdown: 3
-		QueuedAudio: Building
+		ReadyAudio: UnitReady
+		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Building
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 		SpeedUp: True
 		BuildTimeSpeedReduction: 100, 75, 60, 50
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
 		LowPowerSlowdown: 3
+		ReadyAudio: UnitReady
+		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Training
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 		SpeedUp: True
 	ClassicProductionQueue@Ship:
 		Type: Ship
 		LowPowerSlowdown: 3
-		QueuedAudio: Building
+		ReadyAudio: UnitReady
+		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Building
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 		SpeedUp: True
 	ClassicProductionQueue@Aircraft:
 		Type: Aircraft
 		LowPowerSlowdown: 3
-		QueuedAudio: Building
+		ReadyAudio: UnitReady
+		BlockedAudio: NoBuild
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Building
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 		SpeedUp: True
 	PlaceBuilding:
 		NewOptionsNotification: NewOptions

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -47,6 +47,7 @@ Player:
 		LimitedAudio: BuildingInProgress
 		SpeedUp: True
 	PlaceBuilding:
+		NewOptionsNotification: NewOptions
 	SupportPowerManager:
 	ScriptTriggers:
 	MissionObjectives:

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -55,6 +55,8 @@ Player:
 	AllyRepair:
 	PlayerResources:
 		InsufficientFundsNotification: InsufficientFunds
+		CashTickUpNotification: CashTickUp
+		CashTickDownNotification: CashTickDown
 	DeveloperMode:
 		CheckboxDisplayOrder: 9
 	GpsWatcher:

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -48,6 +48,7 @@ Player:
 		SpeedUp: True
 	PlaceBuilding:
 		NewOptionsNotification: NewOptions
+		CannotPlaceNotification: BuildingCannotPlaceAudio
 	SupportPowerManager:
 	ScriptTriggers:
 	MissionObjectives:

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -52,6 +52,7 @@ Player:
 	MissionObjectives:
 	ConquestVictoryConditions:
 	PowerManager:
+		SpeechNotification: LowPower
 	AllyRepair:
 	PlayerResources:
 		InsufficientFundsNotification: InsufficientFunds

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -187,6 +187,7 @@ SPEN:
 		Produces: Ship, Submarine
 	PrimaryBuilding:
 		PrimaryCondition: primary
+		SelectionNotification: PrimaryBuildingSelected
 	-SpawnActorsOnSell:
 	RepairsUnits:
 		HpPerStep: 1000
@@ -302,6 +303,7 @@ SYRD:
 		Produces: Ship, Boat
 	PrimaryBuilding:
 		PrimaryCondition: primary
+		SelectionNotification: PrimaryBuildingSelected
 	-SpawnActorsOnSell:
 	RepairsUnits:
 		HpPerStep: 1000
@@ -1027,6 +1029,7 @@ WEAP:
 		Prerequisite: vehicles.ukraine
 	PrimaryBuilding:
 		PrimaryCondition: primary
+		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
 	Power:
 		Amount: -30
@@ -1287,6 +1290,7 @@ HPAD:
 	ProductionBar:
 	PrimaryBuilding:
 		PrimaryCondition: primary
+		SelectionNotification: PrimaryBuildingSelected
 	Power:
 		Amount: -10
 	ProvidesPrerequisite@allies:
@@ -1455,6 +1459,7 @@ AFLD:
 	SupportPowerChargeBar:
 	PrimaryBuilding:
 		PrimaryCondition: primary
+		SelectionNotification: PrimaryBuildingSelected
 	Power:
 		Amount: -20
 	ProvidesPrerequisite@buildingname:
@@ -1642,6 +1647,7 @@ BARR:
 		Produces: Infantry, Soldier
 	PrimaryBuilding:
 		PrimaryCondition: primary
+		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
 	ProvidesPrerequisite:
 		Prerequisite: barracks
@@ -1721,6 +1727,7 @@ KENN:
 		Produces: Infantry, Dog
 	PrimaryBuilding:
 		PrimaryCondition: primary
+		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
 	-SpawnActorsOnSell:
 	Power:
@@ -1778,6 +1785,7 @@ TENT:
 		Produces: Infantry, Soldier
 	PrimaryBuilding:
 		PrimaryCondition: primary
+		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
 	ProvidesPrerequisite@barracks:
 		Prerequisite: barracks

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -191,6 +191,7 @@ SPEN:
 	-SpawnActorsOnSell:
 	RepairsUnits:
 		HpPerStep: 1000
+		StartRepairingNotification: Repairing
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
 	RallyPoint:
@@ -307,6 +308,7 @@ SYRD:
 	-SpawnActorsOnSell:
 	RepairsUnits:
 		HpPerStep: 1000
+		StartRepairingNotification: Repairing
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
 	RallyPoint:
@@ -1869,6 +1871,7 @@ FIX:
 	RepairsUnits:
 		HpPerStep: 1000
 		Interval: 7
+		StartRepairingNotification: Repairing
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
 	WithRepairAnimation:

--- a/mods/ts/chrome/ingame-player.yaml
+++ b/mods/ts/chrome/ingame-player.yaml
@@ -400,6 +400,8 @@ Container@PLAYER_WIDGETS:
 							Y: 64
 							Width: 206
 							Height: 161
+							SoundUp: RadarUp
+							SoundDown: RadarDown
 						VqaPlayer@PLAYER:
 							X: 16
 							Y: 64

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -354,6 +354,7 @@
 	RepairableBuilding:
 		RepairStep: 700
 		PlayerExperience: 25
+		RepairingNotification: Repairing
 	WithDeathAnimation:
 		DeathSequence: dead
 		UseDeathTypeSuffix: false

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -17,6 +17,7 @@
 
 ^GainsExperience:
 	GainsExperience:
+		LevelUpNotification: LevelUp
 		Conditions:
 			500: rank
 			1000: rank

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -103,6 +103,7 @@ GAPILE:
 		PauseOnCondition: empdisable
 	PrimaryBuilding:
 		PrimaryCondition: primary
+		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
@@ -163,6 +164,7 @@ GAWEAP:
 		PauseOnCondition: empdisable
 	PrimaryBuilding:
 		PrimaryCondition: primary
+		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
 	WithIdleOverlay@ROOF:
 		Sequence: idle-roof
@@ -218,6 +220,7 @@ GAHPAD:
 		PauseOnCondition: empdisable
 	PrimaryBuilding:
 		PrimaryCondition: primary
+		SelectionNotification: PrimaryBuildingSelected
 	Reservable:
 	RepairsUnits:
 		HpPerStep: 1000

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -226,6 +226,7 @@ GAHPAD:
 		HpPerStep: 1000
 		PauseOnCondition: empdisable
 		PlayerExperience: 15
+		StartRepairingNotification: Repairing
 	ProductionBar:
 	WithIdleOverlay@PLATFORM:
 		Sequence: idle-platform
@@ -277,6 +278,7 @@ GADEPT:
 		HpPerStep: 1000
 		PauseOnCondition: empdisable
 		PlayerExperience: 15
+		StartRepairingNotification: Repairing
 	RallyPoint:
 		Palette: mouse
 		IsPlayerPalette: false

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -234,6 +234,7 @@ NAHPAD:
 		HpPerStep: 1000
 		PauseOnCondition: empdisable
 		PlayerExperience: 15
+		StartRepairingNotification: Repairing
 	ProductionBar:
 	WithIdleOverlay@PLATFORM:
 		Sequence: idle-platform

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -117,6 +117,7 @@ NAHAND:
 		PauseOnCondition: empdisable
 	PrimaryBuilding:
 		PrimaryCondition: primary
+		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
@@ -175,6 +176,7 @@ NAWEAP:
 		PauseOnCondition: empdisable
 	PrimaryBuilding:
 		PrimaryCondition: primary
+		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
 	WithIdleOverlay@ROOF:
 		Sequence: idle-roof
@@ -226,6 +228,7 @@ NAHPAD:
 		PauseOnCondition: empdisable
 	PrimaryBuilding:
 		PrimaryCondition: primary
+		SelectionNotification: PrimaryBuildingSelected
 	Reservable:
 	RepairsUnits:
 		HpPerStep: 1000

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -50,6 +50,7 @@ Player:
 		SpeedUp: True
 	PlaceBuilding:
 		NewOptionsNotification: NewOptions
+		CannotPlaceNotification: BuildingCannotPlaceAudio
 		Palette: placebuilding
 		LineBuildSegmentPalette: placelinesegment
 	SupportPowerManager:

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -56,6 +56,7 @@ Player:
 	MissionObjectives:
 	ConquestVictoryConditions:
 	PowerManager:
+		SpeechNotification: LowPower
 	AllyRepair:
 	PlayerResources:
 		InsufficientFundsNotification: InsufficientFunds

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -49,6 +49,7 @@ Player:
 		LimitedAudio: BuildingInProgress
 		SpeedUp: True
 	PlaceBuilding:
+		NewOptionsNotification: NewOptions
 		Palette: placebuilding
 		LineBuildSegmentPalette: placelinesegment
 	SupportPowerManager:

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -13,40 +13,51 @@ Player:
 		Type: Building
 		BuildDurationModifier: 120
 		LowPowerSlowdown: 3
-		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
-		BlockedAudio:
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Building
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 		SpeedUp: True
 	ClassicProductionQueue@Defense:
 		Type: Defense
 		BuildDurationModifier: 120
 		LowPowerSlowdown: 3
-		QueuedAudio: Building
 		ReadyAudio: ConstructionComplete
-		BlockedAudio:
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Building
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 		SpeedUp: True
 	ClassicProductionQueue@Vehicle:
 		Type: Vehicle
 		BuildDurationModifier: 120
 		LowPowerSlowdown: 3
-		BlockedAudio:
+		ReadyAudio: UnitReady
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Training
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 		SpeedUp: True
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
 		BuildDurationModifier: 120
 		LowPowerSlowdown: 3
-		BlockedAudio:
+		ReadyAudio: UnitReady
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Training
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 		SpeedUp: True
 	ClassicProductionQueue@Air:
 		Type: Air
 		BuildDurationModifier: 120
 		LowPowerSlowdown: 3
-		BlockedAudio:
+		ReadyAudio: UnitReady
 		LimitedAudio: BuildingInProgress
+		QueuedAudio: Training
+		OnHoldAudio: OnHold
+		CancelledAudio: Cancelled
 		SpeedUp: True
 	PlaceBuilding:
 		NewOptionsNotification: NewOptions

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -59,6 +59,8 @@ Player:
 	AllyRepair:
 	PlayerResources:
 		InsufficientFundsNotification: InsufficientFunds
+		CashTickUpNotification: CashTickUp
+		CashTickDownNotification: CashTickDown
 	DeveloperMode:
 		CheckboxEnabled: true
 		CheckboxDisplayOrder: 8

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -67,6 +67,9 @@ Player:
 	SupportPowerManager:
 	ScriptTriggers:
 	MissionObjectives:
+		WinNotification: Win
+		LoseNotification: Lose
+		LeaveNotification: Leave
 	ConquestVictoryConditions:
 	PowerManager:
 		SpeechNotification: LowPower


### PR DESCRIPTION
Made all hardcoded notification sounds configurable, except the ui clicks and chatline, which are optional and do not cause a crash if not found. Also nulled all defaults so mods do never explicit need to override them with "" for proper consistency and mod friendlyness. Added these defaults to the core mods yaml files. I left out some traits which are explicit meant to just add a notification, as it makes no sense to make them optional here.
