### PR TITLE
Made PowerManager and MapBuildRadius optional for traits who do not require it.

### DIFF
--- a/OpenRA.Mods.Common/AI/BaseBuilder.cs
+++ b/OpenRA.Mods.Common/AI/BaseBuilder.cs
@@ -199,7 +199,7 @@ namespace OpenRA.Mods.Common.AI
 
 		bool HasSufficientPowerForActor(ActorInfo actorInfo)
 		{
-			return (actorInfo.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault)
+			return playerPower == null || (actorInfo.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault)
 				.Sum(p => p.Amount) + playerPower.ExcessPower) >= minimumExcessPower;
 		}
 
@@ -212,7 +212,7 @@ namespace OpenRA.Mods.Common.AI
 				a => a.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(p => p.Amount));
 
 			// First priority is to get out of a low power situation
-			if (playerPower.ExcessPower < minimumExcessPower)
+			if (playerPower != null && playerPower.ExcessPower < minimumExcessPower)
 			{
 				if (power != null && power.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(p => p.Amount) > 0)
 				{
@@ -318,7 +318,7 @@ namespace OpenRA.Mods.Common.AI
 
 				// Will this put us into low power?
 				var actor = world.Map.Rules.Actors[name];
-				if (playerPower.ExcessPower < minimumExcessPower || !HasSufficientPowerForActor(actor))
+				if (playerPower != null && (playerPower.ExcessPower < minimumExcessPower || !HasSufficientPowerForActor(actor)))
 				{
 					// Try building a power plant instead
 					if (power != null && power.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(pi => pi.Amount) > 0)

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -330,7 +330,7 @@ namespace OpenRA.Mods.Common.AI
 		{
 			Player = p;
 			IsEnabled = true;
-			playerPower = p.PlayerActor.Trait<PowerManager>();
+			playerPower = p.PlayerActor.TraitOrDefault<PowerManager>();
 			playerResource = p.PlayerActor.Trait<PlayerResources>();
 
 			harvManager = new AIHarvesterManager(this, p);

--- a/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
@@ -45,9 +45,9 @@ namespace OpenRA.Mods.Common.Traits
 			this.self = self;
 			devMode = self.Owner.PlayerActor.Trait<DeveloperMode>();
 			progress = total = info.InitialDelay;
-			var mapBuildRadius = self.World.WorldActor.Trait<MapBuildRadius>();
-			allyBuildEnabled = mapBuildRadius.AllyBuildRadiusEnabled;
-			buildRadiusEnabled = mapBuildRadius.BuildRadiusEnabled;
+			var mapBuildRadius = self.World.WorldActor.TraitOrDefault<MapBuildRadius>();
+			allyBuildEnabled = mapBuildRadius == null || mapBuildRadius.AllyBuildRadiusEnabled;
+			buildRadiusEnabled = mapBuildRadius == null || mapBuildRadius.BuildRadiusEnabled;
 		}
 
 		void INotifyCreated.Created(Actor self)

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -146,10 +146,10 @@ namespace OpenRA.Mods.Common.Traits
 		public BaseProvider FindBaseProvider(World world, Player p, CPos topLeft)
 		{
 			var center = world.Map.CenterOfCell(topLeft) + CenterOffset(world);
-			var mapBuildRadius = world.WorldActor.Trait<MapBuildRadius>();
-			var allyBuildEnabled = mapBuildRadius.AllyBuildRadiusEnabled;
+			var mapBuildRadius = world.WorldActor.TraitOrDefault<MapBuildRadius>();
+			var allyBuildEnabled = mapBuildRadius == null || mapBuildRadius.AllyBuildRadiusEnabled;
 
-			if (!mapBuildRadius.BuildRadiusEnabled)
+			if (mapBuildRadius != null && !mapBuildRadius.BuildRadiusEnabled)
 				return null;
 
 			foreach (var bp in world.ActorsWithTrait<BaseProvider>())
@@ -176,12 +176,12 @@ namespace OpenRA.Mods.Common.Traits
 		public virtual bool IsCloseEnoughToBase(World world, Player p, ActorInfo ai, CPos topLeft)
 		{
 			var requiresBuildableArea = ai.TraitInfoOrDefault<RequiresBuildableAreaInfo>();
-			var mapBuildRadius = world.WorldActor.Trait<MapBuildRadius>();
+			var mapBuildRadius = world.WorldActor.TraitOrDefault<MapBuildRadius>();
 
 			if (requiresBuildableArea == null || p.PlayerActor.Trait<DeveloperMode>().BuildAnywhere)
 				return true;
 
-			if (mapBuildRadius.BuildRadiusEnabled && RequiresBaseProvider && FindBaseProvider(world, p, topLeft) == null)
+			if ((mapBuildRadius == null || mapBuildRadius.BuildRadiusEnabled) && RequiresBaseProvider && FindBaseProvider(world, p, topLeft) == null)
 				return false;
 
 			var adjacent = requiresBuildableArea.Adjacent;
@@ -192,7 +192,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var nearnessCandidates = new List<CPos>();
 			var bi = world.WorldActor.Trait<BuildingInfluence>();
-			var allyBuildEnabled = mapBuildRadius.AllyBuildRadiusEnabled;
+			var allyBuildEnabled = mapBuildRadius == null || mapBuildRadius.AllyBuildRadiusEnabled;
 
 			for (var y = scanStart.Y; y < scanEnd.Y; y++)
 			{

--- a/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Attach this to the player actor (not a building!) to define a new shared build queue.",
 		"Will only work together with the Production: trait on the actor that actually does the production.",
 		"You will also want to add PrimaryBuildings: to let the user choose where new units should exit.")]
-	public class ClassicProductionQueueInfo : ProductionQueueInfo, Requires<TechTreeInfo>, Requires<PowerManagerInfo>, Requires<PlayerResourcesInfo>
+	public class ClassicProductionQueueInfo : ProductionQueueInfo, Requires<TechTreeInfo>, Requires<PlayerResourcesInfo>
 	{
 		[Desc("If you build more actors of the same type,", "the same queue will get its build time lowered for every actor produced there.")]
 		public readonly bool SpeedUp = false;

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.Common.Traits
 			self = init.Self;
 			Info = info;
 			playerResources = playerActor.Trait<PlayerResources>();
-			playerPower = playerActor.Trait<PowerManager>();
+			playerPower = playerActor.TraitOrDefault<PowerManager>();
 			developerMode = playerActor.Trait<DeveloperMode>();
 
 			Faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : self.Owner.Faction.InternalName;
@@ -152,7 +152,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			ClearQueue();
 
-			playerPower = newOwner.PlayerActor.Trait<PowerManager>();
+			playerPower = newOwner.PlayerActor.TraitOrDefault<PowerManager>();
 			playerResources = newOwner.PlayerActor.Trait<PlayerResources>();
 			developerMode = newOwner.PlayerActor.Trait<DeveloperMode>();
 
@@ -522,7 +522,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				return (pm.PowerState == PowerState.Normal) ? RemainingTime :
+				return (pm == null || pm.PowerState == PowerState.Normal) ? RemainingTime :
 					RemainingTime * Queue.Info.LowPowerSlowdown;
 			}
 		}
@@ -570,7 +570,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (Paused)
 				return;
 
-			if (pm.PowerState != PowerState.Normal)
+			if (pm != null && pm.PowerState != PowerState.Normal)
 			{
 				if (--Slowdown <= 0)
 					Slowdown = Queue.Info.LowPowerSlowdown;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -255,10 +255,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			template.Get<LabelWidget>("CASH").GetText = () => "$" + (res.Cash + res.Resources);
 			template.Get<LabelWidget>("EARNED_MIN").GetText = () => AverageEarnedPerMinute(res.Earned);
 
-			var powerRes = player.PlayerActor.Trait<PowerManager>();
-			var power = template.Get<LabelWidget>("POWER");
-			power.GetText = () => powerRes.PowerDrained + "/" + powerRes.PowerProvided;
-			power.GetColor = () => GetPowerColor(powerRes.PowerState);
+			var powerRes = player.PlayerActor.TraitOrDefault<PowerManager>();
+			if (powerRes != null)
+			{
+				var power = template.Get<LabelWidget>("POWER");
+				power.GetText = () => powerRes.PowerDrained + "/" + powerRes.PowerProvided;
+				power.GetColor = () => GetPowerColor(powerRes.PowerState);
+			}
 
 			var stats = player.PlayerActor.TraitOrDefault<PlayerStatistics>();
 			if (stats == null) return template;


### PR DESCRIPTION
PowerManager is required when using power in a mod. If there should be no power at all, removing this trait will cause a crash due to hardcoded usages. This PR fixes the crash by making PowerManager optional for all traits, who do not need PowerManager to work.
Also i did the same with MapBuildRadius. If the checkboxes are not present in lobby, the default behavior should apply, without making the whole game crash.