### PR TITLE
Add ability to send a radar ping with lua

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -238,6 +238,7 @@
     <Compile Include="Scripting\Global\MapGlobal.cs" />
     <Compile Include="Scripting\Global\MediaGlobal.cs" />
     <Compile Include="Scripting\Global\PlayerGlobal.cs" />
+    <Compile Include="Scripting\Global\RadarGlobal.cs" />
     <Compile Include="Scripting\Global\ReinforcementsGlobal.cs" />
     <Compile Include="Scripting\Global\TriggerGlobal.cs" />
     <Compile Include="Scripting\Global\UserInterfaceGlobal.cs" />

--- a/OpenRA.Mods.Common/Scripting/Global/RadarGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/RadarGlobal.cs
@@ -1,0 +1,41 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Scripting;
+
+namespace OpenRA.Mods.Common.Scripting
+{
+	[ScriptGlobal("Radar")]
+	public class RadarGlobal : ScriptGlobal
+	{
+		readonly RadarPings radarPings;
+
+		public RadarGlobal(ScriptContext context) : base(context)
+		{
+			radarPings = context.World.WorldActor.TraitOrDefault<RadarPings>();
+		}
+
+		[Desc("Creates a new radar ping that stays for the specified time at the specified WPos.")]
+		public void Ping(Player player, WPos position, HSLColor color, int duration = 30 * 25)
+		{
+			if (radarPings != null)
+			{
+				radarPings.Add(
+					() => player.World.RenderPlayer == player,
+					position,
+					color.RGB,
+					duration);
+			}
+		}
+	}
+}


### PR DESCRIPTION
I noticed we don't have a way to show radar pings with Lua when i wanted to ping for reinforcements in a map i made.

Tescase adds Radar Pings to Harkonnen 5 on ConYard when player reinforcements come.