### PR TITLE
Throttles for notification sounds so rapid user actions do not produce annoying sounds

### DIFF
--- a/mods/cnc/audio/notifications.yaml
+++ b/mods/cnc/audio/notifications.yaml
@@ -6,11 +6,13 @@ Speech:
 		AirstrikeReady: airredy1
 		BaseAttack: baseatk1
 		Building: bldging1
+			RateLimit: 600
 		BuildingCannotPlaceAudio: deploy1
 		BuildingCaptured: capt1
 		BuildingInProgress: bldg1
 		BuildingLost: strclost
 		Cancelled: cancel1
+			RateLimit: 500
 		CivilianBuildingCaptured: civcapt1
 		CivilianKilled: civdead1
 		ConstructionComplete: constru1
@@ -41,9 +43,11 @@ Speech:
 		SilosNeeded: silos1
 		StartGame:
 		Training: bldging1
+			RateLimit: 800
 		UnitDestroyed: dead1
 		UnitLost: unitlost
 		UnitReady: unitredy
+			RateLimit: 900
 		Win: accom1
 	DisablePrefixes: AbilityInsufficientPower, BaseAttack, Building, BuildingCannotPlaceAudio, BuildingInProgress, BuildingLost, Cancelled, CivilianBuildingCaptured, CivilianKilled, ConstructionComplete, EnemyUnitsApproaching, EnemyStructureDestroyed, EnemyPlanesApproaching, HarvesterAttack, InsufficientPower, IonCannonCharging, IonCannonReady, Leave, Lose, LowPower, MissionAccomplished, MissionFailed, NewOptions, NoBuild, NodStructureDestroyed, NotReady, NuclearWarheadApproaching, NuclearWeaponAvailable, NuclearWeaponLaunched, OnHold, PrimaryBuildingSelected, Reinforce, Repairing, SelectTarget, SilosNeeded, Training, UnitLost, UnitReady, Win
 

--- a/mods/d2k/audio/notifications.yaml
+++ b/mods/d2k/audio/notifications.yaml
@@ -13,11 +13,13 @@ Speech:
 	Notifications:
 		BaseAttack: ATACK
 		Building: BUILD
+			RateLimit: 600
 		BuildingCannotPlaceAudio: PLACE
 		BuildingCaptured: CAPT
 		BuildingLost: BLOST
 		BuildingReady: BDRDY
 		Cancelled: CANCL
+			RateLimit: 500
 		CannotDeploy: DPLOY
 		DeathHandMissilePrepping: PREP
 		DeathHandMissileReady: DHRDY
@@ -50,8 +52,10 @@ Speech:
 		TMinusThree: 3MIN
 		TMinusTwo: 2MIN
 		Training: TRAIN
+			RateLimit: 800
 		UnitLost: ULOST
 		UnitReady: UNRDY
+			RateLimit: 900
 		UnitRepaired: GANEW
 		UpgradeOptions: UPGOP
 		Upgrading: UPGRD

--- a/mods/ra/audio/notifications.yaml
+++ b/mods/ra/audio/notifications.yaml
@@ -17,12 +17,14 @@ Speech:
 		AtomBombPrepping: atprep1
 		BaseAttack: baseatk1
 		Building: abldgin1
+			RateLimit: 600
 		BuildingCannotPlaceAudio: nodeply1
 		BuildingCaptured: strucap1
 		BuildingInfiltrated: bldginf1
 		BuildingInProgress: progres1
 		BuildingProgress: bldgprg1
 		Cancelled: cancld1
+			RateLimit: 500
 		ChronosphereCharging: chrochr1
 		ChronosphereReady: chrordy1
 		ChronosphereTestSuccessful: chroyes1
@@ -97,12 +99,14 @@ Speech:
 		TimerStarted: timergo1
 		TimerStopped: timerno1
 		Training: train1
+			RateLimit: 800
 		TwentyMinutesRemaining: 20minr
 		UnitArmorUpgraded: armorup1
 		UnitFirepowerUpgraded: firepo1
 		UnitFull: unitful1
 		UnitLost: unitlst1
 		UnitReady: unitrdy1
+			RateLimit: 900
 		UnitRepaired: unitrep1
 		UnitSold: unitsld1
 		UnitSpeedUpgraded: unitspd1

--- a/mods/ts/audio/speech-generic.yaml
+++ b/mods/ts/audio/speech-generic.yaml
@@ -14,10 +14,12 @@ Speech:
 		BridgeRepaired2: 00-n128
 		BridgeRepaired: 00-i118
 		Building: 00-i216
+			RateLimit: 600
 		BuildingCannotPlaceAudio: 00-i016 #CannotDeployHere
 		BuildingCaptured: 00-i056
 		BuildingInfiltrated: 00-i014
 		Cancelled: 00-i220
+			RateLimit: 500
 		ChemicalMissileReady: 00-i152
 		CivilianKilled: 00-n018
 		CloakedUnitDetected: 00-i172
@@ -71,10 +73,12 @@ Speech:
 		TiberiumMissileReady2: 01-n194
 		TiberiumMissileReady: 01-n176
 		Training: 00-i062
+			RateLimit: 800
 		UnitArmourUpgraded: 00-i068
 		UnitFirepowerUpgraded: 00-i070
 		UnitLost: 00-i074
 		UnitReady: 00-i076
+			RateLimit: 900
 		UnitRepaired: 00-i078
 		UnitSold: 00-i226
 		UnitSpeedUpgraded: 00-i080


### PR DESCRIPTION
One of the first things I noticed in OpenRA that deviated from the originals was no throttling or selective omitting of EVA notification sounds when the user rapidly queues/cancels items in the build palette. It's probably also worth a mention that when I recently played a LAN game of OpenRA, my friends would consistently giggle at all the "Build-build-build-building" and "Can-can-can-cancel" sounds going on. This is totally killing me in Dark Reign because the sounds are "Unit generation in progress" and "Construction under way" which are really long sounds!

So I have a proposed way of throttling these sounds which uses `NotificationSoundThrottle` traits attached to the World object like so:

```
NotificationSoundThrottle@building:
	Delay: 800
	Sounds: Building
NotificationSoundThrottle@cancelled:
	Delay: 500
	Sounds: Cancelled
NotificationSoundThrottle@training:
	Delay: 800
	Sounds: Training
NotificationSoundThrottle@unitready:
	Delay: 500
	Sounds: UnitReady
```

The delay is in milliseconds and the Sounds are a list of Notifications key names (see notifications.yaml if unfamiliar)

I am accomplishing the throttle in Sound.PlayPredefined(...) like so:

```csharp
// Check whether this sound is in throttle rules and suppress if so
if (p != null)
{
	var soundThrottles = p.World.WorldActor.TraitsImplementing<NotificationSoundThrottle>().Where(x => x.IsSoundPartOfPool(p, definition));
	foreach (var t in soundThrottles)
	{
		if (t.IsSoundThrottled(p, definition))
			return true; // Count as success
		t.UpdateLastSoundPlayed();
		break;
	}
}
```

I have a couple of questions about this approach:

1. Is this trait named OK? I thought about mentioning that it omits sounds so maybe something like "NotificationSoundOmitThrottle" instead?
2. Should the traits be attached to the World object?
3. Looking up the throttles using `p.World.WorldActor.TraitsImplementing<NotificationSoundThrottle>()`  . Should this be done in another way?
4. Performance. Is this going to be too much of a performance penalty?

Anyway, it feels a lot nicer, but I might suggest the Building throttle delay be reduced a little because users can queue several different buildings quickly without it being "spammy" and it would be good to get a"Building" sound for every click.

Related to https://github.com/OpenRA/OpenRA/pull/6908 .

Cheers for your time