### PR TITLE
Leaving game should bring you back to respective lobby

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -38,6 +38,7 @@ Also thanks to:
     * Bellator
     * Biofreak
     * Braxton Williams (Buddytex)
+    * Brendan Gluth (Mechanical_Man)
     * Bryan Wilbur
     * Bugra Cuhadaroglu (BugraC)
     * Christer Ulfsparre (Holloweye)

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -59,6 +59,8 @@ namespace OpenRA
 		static Task discoverNat;
 		static bool takeScreenshot = false;
 
+		public static event Action OnShellmapLoaded;
+
 		public static OrderManager JoinServer(string host, int port, string password, bool recordReplay = true)
 		{
 			var connection = new NetworkConnection(host, port);
@@ -471,7 +473,10 @@ namespace OpenRA
 			var shellmap = ChooseShellmap();
 
 			using (new PerfTimer("StartGame"))
+			{
 				StartGame(shellmap, WorldType.Shellmap);
+				OnShellmapLoaded();
+			}
 		}
 
 		static string ChooseShellmap()


### PR DESCRIPTION
Leaving a game now brings you back to the respective lobby (#15325)

I'm very new to the code base so please let me know if I could have done this in a better way!

Roughly what I did was whenever the player leaves the main menu and goes into a "game" (missions, skirmish, multiplayer, map editor, and replays), it stores what type of thing they started and when the main menu is loaded later it reopens back up the appropriate menu again.

I'm not sure if this last game state is already available somewhere else but if it is I can just update my PR to use that instead.

Also tested on Dune TD RA and TS.