### PR TITLE
Aircraft pause rearming when given a stop order

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/ResupplyAircraft.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ResupplyAircraft.cs
@@ -50,6 +50,10 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
+			// Conditional fixes being able to stop aircraft from resupplying.
+			if (IsCanceled && NextInQueue == null)
+				OnFirstRun(self);
+
 			return NextActivity;
 		}
 	}


### PR DESCRIPTION
Fixed being able to stop aircraft rearming by issuing a stop order and occupying landing area (#15055). This fixes the blockages created at landing areas from aircraft sitting indefinitely until ordered off.

Implemented by making the ResupplyAircraft activity check whether or not it has any other queued activities when canceled and if it does not, then re-queues the ResupplyAircraft activity. Let me know if there is a nicer way to do this.

Note that as a side effect this also causes aircraft to start repairing again if they are on a service depo while given a stop order.

Tested in TD, RA and TS (although rearming at helipads isn't a thing in TD but repairing is).