### PR TITLE
Made PowerManager optional for traits who do not require it.

### DIFF
--- a/OpenRA.Mods.Common/AI/BaseBuilder.cs
+++ b/OpenRA.Mods.Common/AI/BaseBuilder.cs
@@ -199,7 +199,7 @@ namespace OpenRA.Mods.Common.AI
 
 		bool HasSufficientPowerForActor(ActorInfo actorInfo)
 		{
-			return (actorInfo.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault)
+			return playerPower == null || (actorInfo.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault)
 				.Sum(p => p.Amount) + playerPower.ExcessPower) >= minimumExcessPower;
 		}
 
@@ -212,7 +212,7 @@ namespace OpenRA.Mods.Common.AI
 				a => a.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(p => p.Amount));
 
 			// First priority is to get out of a low power situation
-			if (playerPower.ExcessPower < minimumExcessPower)
+			if (playerPower != null && playerPower.ExcessPower < minimumExcessPower)
 			{
 				if (power != null && power.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(p => p.Amount) > 0)
 				{
@@ -318,7 +318,7 @@ namespace OpenRA.Mods.Common.AI
 
 				// Will this put us into low power?
 				var actor = world.Map.Rules.Actors[name];
-				if (playerPower.ExcessPower < minimumExcessPower || !HasSufficientPowerForActor(actor))
+				if (playerPower != null && (playerPower.ExcessPower < minimumExcessPower || !HasSufficientPowerForActor(actor)))
 				{
 					// Try building a power plant instead
 					if (power != null && power.TraitInfos<PowerInfo>().Where(i => i.EnabledByDefault).Sum(pi => pi.Amount) > 0)

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -330,7 +330,7 @@ namespace OpenRA.Mods.Common.AI
 		{
 			Player = p;
 			IsEnabled = true;
-			playerPower = p.PlayerActor.Trait<PowerManager>();
+			playerPower = p.PlayerActor.TraitOrDefault<PowerManager>();
 			playerResource = p.PlayerActor.Trait<PlayerResources>();
 
 			harvManager = new AIHarvesterManager(this, p);

--- a/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ClassicProductionQueue.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Attach this to the player actor (not a building!) to define a new shared build queue.",
 		"Will only work together with the Production: trait on the actor that actually does the production.",
 		"You will also want to add PrimaryBuildings: to let the user choose where new units should exit.")]
-	public class ClassicProductionQueueInfo : ProductionQueueInfo, Requires<TechTreeInfo>, Requires<PowerManagerInfo>, Requires<PlayerResourcesInfo>
+	public class ClassicProductionQueueInfo : ProductionQueueInfo, Requires<TechTreeInfo>, Requires<PlayerResourcesInfo>
 	{
 		[Desc("If you build more actors of the same type,", "the same queue will get its build time lowered for every actor produced there.")]
 		public readonly bool SpeedUp = false;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -255,10 +255,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			template.Get<LabelWidget>("CASH").GetText = () => "$" + (res.Cash + res.Resources);
 			template.Get<LabelWidget>("EARNED_MIN").GetText = () => AverageEarnedPerMinute(res.Earned);
 
-			var powerRes = player.PlayerActor.Trait<PowerManager>();
-			var power = template.Get<LabelWidget>("POWER");
-			power.GetText = () => powerRes.PowerDrained + "/" + powerRes.PowerProvided;
-			power.GetColor = () => GetPowerColor(powerRes.PowerState);
+			var powerRes = player.PlayerActor.TraitOrDefault<PowerManager>();
+			if (powerRes != null)
+			{
+				var power = template.Get<LabelWidget>("POWER");
+				power.GetText = () => powerRes.PowerDrained + "/" + powerRes.PowerProvided;
+				power.GetColor = () => GetPowerColor(powerRes.PowerState);
+			}
 
 			var stats = player.PlayerActor.TraitOrDefault<PlayerStatistics>();
 			if (stats == null) return template;


### PR DESCRIPTION
PowerManager is required when using power in a mod. If there should be no power at all, removing this trait will cause a crash due to hardcoded usages. This PR fixes the crash by making PowerManager optional for all traits, who do not need PowerManager to work.