### PR TITLE
Made MapBuildRadius optional for traits who do not require it.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
@@ -45,9 +45,9 @@ namespace OpenRA.Mods.Common.Traits
 			this.self = self;
 			devMode = self.Owner.PlayerActor.Trait<DeveloperMode>();
 			progress = total = info.InitialDelay;
-			var mapBuildRadius = self.World.WorldActor.Trait<MapBuildRadius>();
-			allyBuildEnabled = mapBuildRadius.AllyBuildRadiusEnabled;
-			buildRadiusEnabled = mapBuildRadius.BuildRadiusEnabled;
+			var mapBuildRadius = self.World.WorldActor.TraitOrDefault<MapBuildRadius>();
+			allyBuildEnabled = mapBuildRadius != null && mapBuildRadius.AllyBuildRadiusEnabled;
+			buildRadiusEnabled = mapBuildRadius != null && mapBuildRadius.BuildRadiusEnabled;
 		}
 
 		void INotifyCreated.Created(Actor self)

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -146,10 +146,10 @@ namespace OpenRA.Mods.Common.Traits
 		public BaseProvider FindBaseProvider(World world, Player p, CPos topLeft)
 		{
 			var center = world.Map.CenterOfCell(topLeft) + CenterOffset(world);
-			var mapBuildRadius = world.WorldActor.Trait<MapBuildRadius>();
-			var allyBuildEnabled = mapBuildRadius.AllyBuildRadiusEnabled;
+			var mapBuildRadius = world.WorldActor.TraitOrDefault<MapBuildRadius>();
+			var allyBuildEnabled = mapBuildRadius != null && mapBuildRadius.AllyBuildRadiusEnabled;
 
-			if (!mapBuildRadius.BuildRadiusEnabled)
+			if (mapBuildRadius == null || !mapBuildRadius.BuildRadiusEnabled)
 				return null;
 
 			foreach (var bp in world.ActorsWithTrait<BaseProvider>())
@@ -176,12 +176,12 @@ namespace OpenRA.Mods.Common.Traits
 		public virtual bool IsCloseEnoughToBase(World world, Player p, ActorInfo ai, CPos topLeft)
 		{
 			var requiresBuildableArea = ai.TraitInfoOrDefault<RequiresBuildableAreaInfo>();
-			var mapBuildRadius = world.WorldActor.Trait<MapBuildRadius>();
+			var mapBuildRadius = world.WorldActor.TraitOrDefault<MapBuildRadius>();
 
 			if (requiresBuildableArea == null || p.PlayerActor.Trait<DeveloperMode>().BuildAnywhere)
 				return true;
 
-			if (mapBuildRadius.BuildRadiusEnabled && RequiresBaseProvider && FindBaseProvider(world, p, topLeft) == null)
+			if (mapBuildRadius != null && mapBuildRadius.BuildRadiusEnabled && RequiresBaseProvider && FindBaseProvider(world, p, topLeft) == null)
 				return false;
 
 			var adjacent = requiresBuildableArea.Adjacent;
@@ -192,7 +192,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var nearnessCandidates = new List<CPos>();
 			var bi = world.WorldActor.Trait<BuildingInfluence>();
-			var allyBuildEnabled = mapBuildRadius.AllyBuildRadiusEnabled;
+			var allyBuildEnabled = mapBuildRadius != null && mapBuildRadius.AllyBuildRadiusEnabled;
 
 			for (var y = scanStart.Y; y < scanEnd.Y; y++)
 			{


### PR DESCRIPTION
MapBuildRadius is used to add checkboxes to lobby to alter standard behavior. However when this trait is removed, the game crashes. With this changes, default values are used if the trait is not enabled.
