### PR TITLE
Made Valued optional for traits who do not require it.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Repair.cs
+++ b/OpenRA.Mods.Common/Activities/Repair.cs
@@ -98,7 +98,8 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (remainingTicks == 0)
 			{
-				var unitCost = self.Info.TraitInfo<ValuedInfo>().Cost;
+				var valued = self.Info.TraitInfoOrDefault<ValuedInfo>();
+				var unitCost = valued != null ? valued.Cost : 0;
 				var hpToRepair = repairable != null && repairable.Info.HpPerStep > 0 ? repairable.Info.HpPerStep : repairsUnits.Info.HpPerStep;
 
 				// Cast to long to avoid overflow when multiplying by the health

--- a/OpenRA.Mods.Common/Traits/SpawnActorsOnSell.cs
+++ b/OpenRA.Mods.Common/Traits/SpawnActorsOnSell.cs
@@ -69,7 +69,15 @@ namespace OpenRA.Mods.Common.Traits
 			var buildingInfo = self.Info.TraitInfoOrDefault<BuildingInfo>();
 
 			var eligibleLocations = buildingInfo != null ? buildingInfo.Tiles(self.Location).ToList() : new List<CPos>();
-			var actorTypes = Info.ActorTypes.Select(a => new { Name = a, Cost = self.World.Map.Rules.Actors[a].TraitInfo<ValuedInfo>().Cost }).ToList();
+			var actorTypes = Info.ActorTypes.Select(a =>
+			{
+				var av = self.World.Map.Rules.Actors[a].TraitInfoOrDefault<ValuedInfo>();
+				return new
+				{
+					Name = a,
+					Cost = av != null ? av.Cost : 0
+				};
+			}).ToList();
 
 			while (eligibleLocations.Count > 0 && actorTypes.Any(a => a.Cost <= dudesValue))
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -70,7 +70,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var tooltip = actor.TraitInfos<TooltipInfo>().FirstOrDefault(info => info.EnabledByDefault);
 				var name = tooltip != null ? tooltip.Name : actor.Name;
 				var buildable = actor.TraitInfo<BuildableInfo>();
-				var cost = actor.TraitInfo<ValuedInfo>().Cost;
+				var valued = actor.TraitInfoOrDefault<ValuedInfo>();
+				var cost = valued != null ? valued.Cost : 0;
 
 				nameLabel.Text = name;
 


### PR DESCRIPTION
Some traits are hardcoded against Valued, but do not rely on them. This PR fixes a crash caused by these traits when an actor does not have a Valued trait. No more need to add Valued with Cost: 0 to actors to avoid the crashes.