### PR TITLE
Update AppImage dependencies to 20180723 tag.

### DIFF
--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -7,7 +7,7 @@ command -v python >/dev/null 2>&1 || { echo >&2 "Linux packaging requires python
 command -v tar >/dev/null 2>&1 || { echo >&2 "Linux packaging requires tar."; exit 1; }
 command -v curl >/dev/null 2>&1 || { echo >&2 "Linux packaging requires curl."; exit 1; }
 
-DEPENDENCIES_TAG="20180410"
+DEPENDENCIES_TAG="20180723"
 
 if [ $# -eq "0" ]; then
 	echo "Usage: `basename $0` version [outputdir]"


### PR DESCRIPTION
Fixes #15337 by changing the dependency build platform to Debian 7 (https://github.com/OpenRA/AppImageSupport/commit/88446423676a4ace41482bc88e067ebc14088008).

I have tested the updated libraries on the following systems to confirm that cursors/video/sound work:
* Ubuntu 18.04 (real machine)
* openSUSE 42.2 (real machine)
* Kubuntu 18.04 (virtual machine)
* Fedora 28 (virtual machine)
* CentOS 7 (virtual machine)

AppImages for release-20180307 (which will be used for #15293 after this PR is merged) can be downloaded from https://github.com/pchote/OpenRA/releases/tag/release-20180307-appimages