### PR TITLE
Keep a 1px border around trimmed ShpTD data.

### DIFF
--- a/OpenRA.Mods.Common/SpriteLoaders/ShpTDLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/ShpTDLoader.cs
@@ -108,6 +108,19 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 					}
 				}
 
+				// Keep a 1px empty border to work avoid rounding issues in the gpu shader
+				if (left > 0)
+					left -= 1;
+
+				if (top > 0)
+					top -= 1;
+
+				if (right < origSize.Width - 1)
+					right += 1;
+
+				if (bottom < origSize.Height - 1)
+					bottom += 1;
+
 				var trimmedWidth = right - left + 1;
 				var trimmedHeight = bottom - top + 1;
 


### PR DESCRIPTION
This should provide a workaround for #15350, but as that issue is system specific I cannot reproduce the bug or the verify the fix myself.  Ping @Smittytron.