### PR TITLE
Update macOS launcher template to osx-launcher-20180723.

### DIFF
--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -9,7 +9,7 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
 	command -v genisoimage >/dev/null 2>&1 || { echo >&2 "macOS packaging requires genisoimage."; exit 1; }
 fi
 
-LAUNCHER_TAG="osx-launcher-20171118"
+LAUNCHER_TAG="osx-launcher-20180723"
 
 if [ $# -ne "2" ]; then
 	echo "Usage: `basename $0` tag outputdir"

--- a/thirdparty/fetch-thirdparty-deps-osx.sh
+++ b/thirdparty/fetch-thirdparty-deps-osx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LAUNCHER_TAG="osx-launcher-20171118"
+LAUNCHER_TAG="osx-launcher-20180723"
 
 download_dir="${0%/*}/download/osx"
 mkdir -p "$download_dir"


### PR DESCRIPTION
This pulls in https://github.com/OpenRA/OpenRALauncherOSX/commit/b7c11881d2b52004b387682bd865e9229079d082, which enables dark appearance support as described in the [appkit documentation](https://developer.apple.com/documentation/appkit/nsappearancecustomization/choosing_a_specific_appearance_for_your_app):

> If you build your app against an earlier SDK, you can still enable Dark Mode support by including the `NSRequiresAquaSystemAppearance` key (with a value of `false`) in your app's `Info.plist` file.

Fixes #15369.

