### PR TITLE
Get rid of unit pathing delay completely

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -198,12 +198,6 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (path == null)
 			{
-				if (mobile.TicksBeforePathing > 0)
-				{
-					--mobile.TicksBeforePathing;
-					return this;
-				}
-
 				path = EvalPath();
 				SanityCheckPath(mobile);
 			}
@@ -314,12 +308,6 @@ namespace OpenRA.Mods.Common.Activities
 
 				if (--waitTicksRemaining >= 0)
 					return null;
-
-				if (mobile.TicksBeforePathing > 0)
-				{
-					--mobile.TicksBeforePathing;
-					return null;
-				}
 
 				// Calculate a new path
 				mobile.RemoveInfluence();

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -91,10 +91,6 @@ namespace OpenRA.Mods.Common.Traits
 	public class Mobile : ConditionalTrait<MobileInfo>, INotifyCreated, IIssueOrder, IResolveOrder, IOrderVoice, IPositionable, IMove,
 		IFacing, IDeathActorInitModifier, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyBlockingMove, IActorPreviewInitModifier, INotifyBecomingIdle
 	{
-		const int AverageTicksBeforePathing = 5;
-		const int SpreadTicksBeforePathing = 5;
-		internal int TicksBeforePathing = 0;
-
 		readonly Actor self;
 		readonly Lazy<IEnumerable<int>> speedModifiers;
 
@@ -642,8 +638,6 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (!order.Queued)
 					self.CancelActivity();
-
-				TicksBeforePathing = AverageTicksBeforePathing + self.World.SharedRandom.Next(-SpreadTicksBeforePathing, SpreadTicksBeforePathing);
 
 				self.SetTargetLine(Target.FromCell(self.World, loc), Color.Green);
 				self.QueueActivity(order.Queued, new Move(self, loc, WDist.FromCells(8), null, true));


### PR DESCRIPTION
This was a fairly halfbaked idea. Let's get rid of it and then reintroduce a path request throttling system if we need to.