### PR TITLE
Proper ProductionItem costs calculation.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -578,7 +578,8 @@ namespace OpenRA.Mods.Common.Traits
 					return;
 			}
 
-			var costThisFrame = RemainingCost / RemainingTime;
+			var expectedRemainingCost = RemainingTime == 1 ? 0 : TotalCost * RemainingTime / Math.Max(1, TotalTime);
+			var costThisFrame = RemainingCost - expectedRemainingCost;
 			if (costThisFrame != 0 && !pr.TakeCash(costThisFrame, true))
 				return;
 


### PR DESCRIPTION
The current formula fits for games where units cost more than their buildtime. If however a mod uses lower prices, the formula shows a problem. Example: unit costs 50 but has a build time of 100. The unit will be half build when the game starts to consume money. Expected behavior however is that every second tick, 1 money is consumed.