### PR TITLE
Fix NRE in mods that don't immediately show the main menu.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -59,7 +59,7 @@ namespace OpenRA
 		static Task discoverNat;
 		static bool takeScreenshot = false;
 
-		public static event Action OnShellmapLoaded;
+		public static event Action OnShellmapLoaded = () => { };
 
 		public static OrderManager JoinServer(string host, int port, string password, bool recordReplay = true)
 		{


### PR DESCRIPTION
Fixes #15383.

Testcase: `make version` and run the TS mod.