### PR TITLE
Fixing several ShellCheck warnings

### DIFF
--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -14,8 +14,8 @@ EnableSingleplayer="${EnableSingleplayer:-"False"}"
 Password="${Password:-""}"
 
 while true; do
-     mono --debug OpenRA.Server.exe Game.Mod=$Mod \
-     Server.Name="$Name" Server.ListenPort=$ListenPort \
-     Server.AdvertiseOnline=$AdvertiseOnline \
-     Server.EnableSingleplayer=$EnableSingleplayer Server.Password=$Password
+     mono --debug OpenRA.Server.exe Game.Mod="$Mod" \
+     Server.Name="$Name" Server.ListenPort="$ListenPort" \
+     Server.AdvertiseOnline="$AdvertiseOnline" \
+     Server.EnableSingleplayer="$EnableSingleplayer" Server.Password="$Password"
 done

--- a/launch-game.sh
+++ b/launch-game.sh
@@ -5,7 +5,7 @@ MODLAUNCHER=$(python -c "import os; print(os.path.realpath('$0'))")
 MODARG=''
 if [ z"${*#*Game.Mod}" = z"$*" ]
 then
-	if which zenity > /dev/null
+	if command -v zenity > /dev/null
 	then
 		TITLE=$(zenity --forms --add-combo="" --combo-values="Red Alert|Tiberian Dawn|Dune 2000|Tiberian Sun" --text "Select mod" --title="" || echo "cancel")
 		if [ "$TITLE" = "cancel" ]; then exit 0
@@ -31,7 +31,7 @@ if [ $? != 0 ] && [ $? != 1 ]; then
 	elif command -v kdialog > /dev/null; then
 		kdialog --title "{MODNAME}" --error "${ERROR_MESSAGE}"
 	else
-		printf "${ERROR_MESSAGE}\n"
+		printf "%s\n" "${ERROR_MESSAGE}"
 	fi
 	exit 1
 fi

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -10,12 +10,12 @@ command -v curl >/dev/null 2>&1 || command -v wget > /dev/null 2>&1 || { echo >&
 DEPENDENCIES_TAG="20180723"
 
 if [ $# -eq "0" ]; then
-	echo "Usage: `basename $0` version [outputdir]"
+	echo "Usage: $(basename "$0") version [outputdir]"
 	exit 1
 fi
 
 # Set the working dir to the location of this script
-cd $(dirname $0)
+cd "$(dirname "$0")" || exit 1
 
 TAG="$1"
 OUTPUTDIR="$2"
@@ -35,7 +35,7 @@ elif [[ ${TAG} == pkgtest* ]]; then
 	SUFFIX="-pkgtest"
 fi
 
-pushd "${TEMPLATE_ROOT}" > /dev/null
+pushd "${TEMPLATE_ROOT}" > /dev/null || exit 1
 
 if [ ! -d "${OUTPUTDIR}" ]; then
 	echo "Output directory '${OUTPUTDIR}' does not exist.";
@@ -44,14 +44,14 @@ fi
 
 echo "Building core files"
 
-pushd ${SRCDIR} > /dev/null
+pushd "${SRCDIR}" > /dev/null || exit 1
 make linux-dependencies
 make core SDK="-sdk:4.5"
 make version VERSION="${TAG}"
 make install-engine prefix="usr" DESTDIR="${BUILTDIR}/"
 make install-common-mod-files prefix="usr" DESTDIR="${BUILTDIR}/"
 
-popd > /dev/null
+popd > /dev/null || exit 1
 
 # Add native libraries
 echo "Downloading dependencies"
@@ -79,14 +79,14 @@ build_appimage() {
 	MOD_ID=${1}
 	DISPLAY_NAME=${2}
 	APPDIR="$(pwd)/${MOD_ID}.appdir"
-	APPIMAGE="OpenRA-$(echo ${DISPLAY_NAME} | sed 's/ /-/g')${SUFFIX}-x86_64.AppImage"
+	APPIMAGE="OpenRA-$(echo "${DISPLAY_NAME}" | sed 's/ /-/g')${SUFFIX}-x86_64.AppImage"
 
 	cp -r "${BUILTDIR}" "${APPDIR}"
 
 	# Add mod files
-	pushd "${SRCDIR}" > /dev/null
+	pushd "${SRCDIR}" > /dev/null || exit 1
 	cp -r "mods/${MOD_ID}" mods/modcontent "${APPDIR}/usr/lib/openra/mods"
-	popd > /dev/null
+	popd > /dev/null || exit 1
 
 	# Add launcher and icons
 	sed "s/{MODID}/${MOD_ID}/g" AppRun.in | sed "s/{MODNAME}/${DISPLAY_NAME}/g" > AppRun.temp

--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -12,12 +12,12 @@ fi
 LAUNCHER_TAG="osx-launcher-20171118"
 
 if [ $# -ne "2" ]; then
-	echo "Usage: `basename $0` tag outputdir"
+	echo "Usage: $(basename "$0") tag outputdir"
     exit 1
 fi
 
 # Set the working dir to the location of this script
-cd $(dirname $0)
+cd "$(dirname "$0")" || exit 1
 
 TAG="$1"
 OUTPUTDIR="$2"
@@ -44,10 +44,10 @@ populate_template() {
 
 # Deletes from the first argument's mod dirs all the later arguments
 delete_mods() {
-	pushd "${BUILTDIR}/${1}/Contents/Resources/mods" > /dev/null
+	pushd "${BUILTDIR}/${1}/Contents/Resources/mods" > /dev/null || exit 1
 	shift
-	rm -rf $@
-	pushd > /dev/null
+	rm -rf "$@"
+	pushd > /dev/null || exit 1
 }
 
 echo "Building launchers"
@@ -70,12 +70,12 @@ modify_plist "{DEV_VERSION}" "${TAG}" "${BUILTDIR}/OpenRA.app/Contents/Info.plis
 modify_plist "{FAQ_URL}" "http://wiki.openra.net/FAQ" "${BUILTDIR}/OpenRA.app/Contents/Info.plist"
 echo "Building core files"
 
-pushd ${SRCDIR} > /dev/null
+pushd "${SRCDIR}" > /dev/null || exit 1
 make osx-dependencies
 make core SDK="-sdk:4.5"
 make version VERSION="${TAG}"
 make install-core gameinstalldir="/Contents/Resources/" DESTDIR="${BUILTDIR}/OpenRA.app"
-popd > /dev/null
+popd > /dev/null || exit 1
 
 curl -s -L -O https://raw.githubusercontent.com/wiki/OpenRA/OpenRA/Changelog.md
 markdown Changelog.md > "${BUILTDIR}/OpenRA.app/Contents/Resources/CHANGELOG.html"
@@ -106,10 +106,10 @@ else
 	curl -s -L -O https://github.com/OpenRA/libdmg-hfsplus/archive/master.zip || exit 3
 	unzip -qq master.zip
 	rm master.zip
-	pushd libdmg-hfsplus-master > /dev/null
+	pushd libdmg-hfsplus-master > /dev/null || exit 1
 	cmake . > /dev/null
 	make > /dev/null
-	popd > /dev/null
+	popd > /dev/null || exit 1
 
 	if [[ ! -f libdmg-hfsplus-master/dmg/dmg ]] ; then
 		echo "libdmg-hfsplus compilation failed"

--- a/packaging/package-all.sh
+++ b/packaging/package-all.sh
@@ -10,7 +10,7 @@ export GIT_TAG="$1"
 export BUILD_OUTPUT_DIR="$2"
 
 # Set the working dir to the location of this script using bash parameter expansion
-cd "${0%/*}"
+cd "${0%/*}" || exit 1
 
 #build packages using a subshell so directory changes do not persist beyond the function
 function build_package() (

--- a/packaging/source/buildpackage.sh
+++ b/packaging/source/buildpackage.sh
@@ -2,18 +2,18 @@
 # OpenRA packaging script for versioned source tarball
 
 if [ $# -ne "2" ]; then
-    echo "Usage: `basename $0` tag outputdir"
+    echo "Usage: $(basename "$0") tag outputdir"
     exit 1
 fi
 
 # Set the working dir to the location of this script
-cd $(dirname $0)
+cd "$(dirname "$0")" || exit 1
 
 TAG="$1"
 OUTPUTDIR="$2"
 SRCDIR="$(pwd)/../.."
 
-pushd ${SRCDIR} > /dev/null
+pushd "${SRCDIR}" > /dev/null || exit 1
 make version VERSION="${TAG}"
 git ls-tree HEAD --name-only -r -z | xargs -0 tar cvjf "${OUTPUTDIR}/OpenRA-${TAG}-source.tar.bz2"
-popd > /dev/null
+popd > /dev/null || exit 1

--- a/packaging/update-wiki.sh
+++ b/packaging/update-wiki.sh
@@ -24,15 +24,15 @@ mkdir -p "$(dirname "$SSH_KEY")"
 openssl aes-256-cbc -k "$KEY" -in ssh.enc -d -out "$SSH_KEY"
 chmod 0600 "$SSH_KEY"
 
-rm -rf $HOME/openra-wiki
-git clone git@github.com:OpenRA/OpenRA.wiki.git $HOME/openra-wiki
+rm -rf "$HOME/openra-wiki"
+git clone git@github.com:OpenRA/OpenRA.wiki.git "$HOME/openra-wiki"
 
 mono --debug ../OpenRA.Utility.exe all --docs > "${HOME}/openra-wiki/Traits${TAG}.md"
 mono --debug ../OpenRA.Utility.exe all --weapon-docs > "${HOME}/openra-wiki/Weapons${TAG}.md"
 mono --debug ../OpenRA.Utility.exe all --lua-docs > "${HOME}/openra-wiki/Lua API${TAG}.md"
 mono --debug ../OpenRA.Utility.exe all --settings-docs > "${HOME}/openra-wiki/Settings${TAG}.md"
 
-pushd $HOME/openra-wiki
+pushd "$HOME/openra-wiki" || exit 1
 git config --local user.email "orabot@users.noreply.github.com"
 git config --local user.name "orabot"
 git add "Traits${TAG}.md"
@@ -40,6 +40,6 @@ git add "Lua API${TAG}.md"
 git add "Settings${TAG}.md"
 git commit -m "Update trait and scripting documentation for branch $1" &&
 git push origin master
-popd
+popd || exit
 
 shred -u "$SSH_KEY"

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -5,12 +5,12 @@ command -v markdown >/dev/null 2>&1 || { echo >&2 "Windows packaging requires ma
 command -v makensis >/dev/null 2>&1 || { echo >&2 "Windows packaging requires makensis."; exit 1; }
 
 if [ $# -ne "2" ]; then
-	echo "Usage: `basename $0` tag outputdir"
+	echo "Usage: $(basename "$0") tag outputdir"
     exit 1
 fi
 
 # Set the working dir to the location of this script
-cd $(dirname $0)
+cd "$(dirname "$0")" || exit 1
 
 TAG="$1"
 OUTPUTDIR="$2"
@@ -32,17 +32,17 @@ function makelauncher()
 	sed "s|DISPLAY_NAME|$2|" WindowsLauncher.cs.in | sed "s|MOD_ID|$3|" | sed "s|FAQ_URL|${FAQ_URL}|" > WindowsLauncher.cs
 	mcs -sdk:4.5 WindowsLauncher.cs -warn:4 -codepage:utf8 -warnaserror -out:"$1" -t:winexe ${LAUNCHER_LIBS} -win32icon:"$4"
 	rm WindowsLauncher.cs
-	mono "${SRCDIR}/fixheader.exe" $1 > /dev/null
+	mono "${SRCDIR}/fixheader.exe" "$1" > /dev/null
 }
 
 echo "Building core files"
 
-pushd ${SRCDIR} > /dev/null
+pushd "${SRCDIR}" > /dev/null || exit 1
 make windows-dependencies
 make core SDK="-sdk:4.5"
 make version VERSION="${TAG}"
 make install-core gameinstalldir="" DESTDIR="${BUILTDIR}"
-popd > /dev/null
+popd > /dev/null || exit 1
 
 echo "Compiling Windows launchers"
 makelauncher "${BUILTDIR}/RedAlert.exe" "Red Alert" "ra" RedAlert.ico

--- a/thirdparty/fetch-geoip-db.sh
+++ b/thirdparty/fetch-geoip-db.sh
@@ -5,7 +5,7 @@ set -e
 
 download_dir="${0%/*}/download"
 mkdir -p "${download_dir}"
-cd "${download_dir}"
+cd "${download_dir}" || exit 1
 
 filename="GeoLite2-Country.mmdb.gz"
 

--- a/thirdparty/fetch-thirdparty-deps-osx.sh
+++ b/thirdparty/fetch-thirdparty-deps-osx.sh
@@ -4,7 +4,7 @@ LAUNCHER_TAG="osx-launcher-20171118"
 
 download_dir="${0%/*}/download/osx"
 mkdir -p "$download_dir"
-cd "$download_dir"
+cd "$download_dir" || exit 1
 
 if [ ! -f libSDL2.dylib ]; then
 	echo "Fetching OS X SDL2 library from GitHub."

--- a/thirdparty/fetch-thirdparty-deps-windows.sh
+++ b/thirdparty/fetch-thirdparty-deps-windows.sh
@@ -6,7 +6,7 @@ set -e
 download_dir="${0%/*}/download/windows"
 
 mkdir -p "${download_dir}"
-cd "${download_dir}"
+cd "${download_dir}" || exit 1
 
 if [ ! -f SDL2.dll ]; then
 	echo "Fetching SDL2 from libsdl.org"

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -11,7 +11,7 @@ set -e
 download_dir="${0%/*}/download"
 
 mkdir -p "${download_dir}"
-cd "${download_dir}"
+cd "${download_dir}" || exit 1
 
 if [ ! -f StyleCopPlus.dll ]; then
 	echo "Fetching StyleCopPlus from NuGet"
@@ -79,7 +79,7 @@ if [ ! -f FuzzyLogicLibrary.dll ]; then
 	rm -rf FuzzyLogicLibrary
 fi
 
-if [ ! -f SDL2-CS.dll -o ! -f SDL2-CS.dll.config ]; then
+if [ ! -f SDL2-CS.dll ] || [ ! -f SDL2-CS.dll.config ]; then
 	echo "Fetching SDL2-CS from GitHub."
 	if command -v curl >/dev/null 2>&1; then
 		curl -s -L -O https://github.com/OpenRA/SDL2-CS/releases/download/20161223/SDL2-CS.dll
@@ -90,7 +90,7 @@ if [ ! -f SDL2-CS.dll -o ! -f SDL2-CS.dll.config ]; then
 	fi
 fi
 
-if [ ! -f OpenAL-CS.dll -o ! -f OpenAL-CS.dll.config ]; then
+if [ ! -f OpenAL-CS.dll ] || [ ! -f OpenAL-CS.dll.config ]; then
 	echo "Fetching OpenAL-CS from GitHub."
 	if command -v curl >/dev/null 2>&1; then
 		curl -s -L -O https://github.com/OpenRA/OpenAL-CS/releases/download/20151227/OpenAL-CS.dll


### PR DESCRIPTION
Hi,

This pull request is essentially me running ShellCheck on the shell scripts included in this project, and fixing the warnings that arose where needed. 

### Checklist

- [x] Make sure that you have read and understand the OpenRA Coding Standard (see https://github.com/OpenRA/OpenRA/wiki/Coding-Standard).
- [x] Write quality commit messages (see https://chris.beams.io/posts/git-commit/). I think "Fixing several ShellCheck warnings" is as quality as I can get as there are quite a few changes, so many I can only adequately explain them in a few sentences, at least. 
- [x] Only commit changes that directly relate to your Pull Request.  Use your Git interface to unstage any unrelated changes to project files, line endings, whitespace, or other files.
- [x] Review the code diff view below to double check that your changes satisfy the above three points.
- [x] Use the `make test` and `make check` commands to check for (and fix!) any issues that are reported by our automated tests.

### Summary of what I did and why

* I added double quotes around references (not sure the exact lingo here) to variables (`$0` is an example, which would be changed to `"$0"`). ShellCheck gave the warning:

 > Double quote to prevent globbing and word splitting. [SC2086]

and this is how I reacted. 

* I changed `which` to `command -v` as, in the words of ShellCheck:

> which is non-standard. Use builtin 'command -v' instead. [SC2230]

* I changed `printf "${ERROR_MESSAGE}\n"` to `printf "%s\n" "${ERROR_MESSAGE}"` as, in the words of ShellCheck:

> Don't use variables in the printf format string. Use printf "..%s.." "$foo". [SC2059]

* I changed:

```bash
`basename $0`
```

to:

```bash
$(basename "$0")
```

because of the globbing/word splitting issue mentioned earlier (for the double quotes) and because, in the words of ShellCheck:

> Use $(..) instead of legacy \`..\`. [SC2006]

* I added ` || exit` to the end of cd, pushd and popd lines, because in the words of ShellCheck:

> Use 'cd ... || exit' or 'cd ... || return' in case cd fails. [SC2164]

* Replaced `[ p -o q ]` with `[ p ] || [ q ]` (where p and q are conditions), because, in the words of ShellCheck:

> Prefer [ p ] || [ q ] as [ p -o q ] is not well defined. [SC2166]

. If you seek an example, see [thirdparty/fetch-thirdparty-deps.sh#L82](https://github.com/OpenRA/OpenRA/compare/bleed...fusion809:patch-2?expand=1#diff-bd8ae1e6c88f2944de688b25e8c7b799R82).

### When I ignored ShellCheck

* [Line 27 of launch-game.sh](https://github.com/OpenRA/OpenRA/blob/65776bdeb5c04d39673f69a14a161f40fd367027/launch-game.sh#L27) where it warned:

> Check exit code directly with e.g. 'if mycmd;', not indirectly with $?. [SC2181]

as I thought things might get a little cramped shoving it as a condition into if, especially since this warning also applies to [packaging/windows/buildpackage.sh#L65](https://github.com/OpenRA/OpenRA/blob/65776bdeb5c04d39673f69a14a161f40fd367027/packaging/windows/buildpackage.sh#L65), where the condition is especially large.

* [Line 28 of launch-game.sh](https://github.com/OpenRA/OpenRA/blob/65776bdeb5c04d39673f69a14a161f40fd367027/launch-game.sh#L28) there is another warning I ignored, namely:

> Backslash is literal in "\n". Prefer explicit escaping: "\\n". [SC1117]

as a new line is what is desired, escaping it again will make `\n` shown literally. This warning also occurred on a few other lines. 

* [Line 82 of packaging/linux/buildpackage.sh](https://github.com/OpenRA/OpenRA/blob/65776bdeb5c04d39673f69a14a161f40fd367027/packaging/linux/buildpackage.sh#L82) I get the warning:

> See if you can use ${variable//search/replace} instead. [SC2001]

. I tried to implement this by replacing `$(echo ${DISPLAY_NAME} | sed 's/ /-/g')` with `${DISPLAY_NAME/ /-}` but while running `$(echo ${DISPLAY_NAME} | sed 's/ /-/g')` returned the same output as `${DISPLAY_NAME/ /-}` in a shell where `DISPLAY_NAME` had been defined as "Red Alert", running `./buildpackage.sh 25093 .` after making this change failed, with the error:

```bash
squashfs-root/usr/share
squashfs-root/usr/share/metainfo
squashfs-root/usr/share/metainfo/appimagetool.appdata.xml
appimagetool, continuous build (commit ceb684f), build 1803 built on 2018-07-26 12:02:14 UTC
Using architecture x86_64
/data/GitHub/mine/packaging/OpenRA-build/packaging/linux/ra.appdir should be packaged as ./OpenRA-Red-/Alert-25097-x86_64.AppImage
Deleting pre-existing .DirIcon
Creating .DirIcon symlink based on information from desktop file
Generating squashfs...
Could not create destination file: No such file or directory
Embedding ELF...
Not able to open the AppImage for writing, aborting
```

so clearly that didn't work. 

* [Line 21 of packaging/package-all.sh](https://github.com/OpenRA/OpenRA/blob/65776bdeb5c04d39673f69a14a161f40fd367027/packaging/package-all.sh#L21) gave me the warning:

> Use single quotes, otherwise this expands now rather than when signalled. [SC2064]

as it seemed inappropriate as then `$1` wouldn't be evaluated and left as is. 

Thanks for your time,
Brenton
