### PR TITLE
Allow aircraft to scatter

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
@@ -16,6 +16,7 @@ using OpenRA.Graphics;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Orders;
+using OpenRA.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets
@@ -291,7 +292,7 @@ namespace OpenRA.Mods.Common.Widgets
 			guardDisabled = !selectedActors.Any(a => a.Info.HasTraitInfo<GuardInfo>() && a.Info.HasTraitInfo<AutoTargetInfo>());
 			forceMoveDisabled = !selectedActors.Any(a => a.Info.HasTraitInfo<MobileInfo>() || a.Info.HasTraitInfo<AircraftInfo>());
 			forceAttackDisabled = !selectedActors.Any(a => a.Info.HasTraitInfo<AttackBaseInfo>());
-			scatterDisabled = !selectedActors.Any(a => a.Info.HasTraitInfo<MobileInfo>());
+			scatterDisabled = !selectedActors.Any(a => a.Info.HasTraitInfo<IMoveInfo>());
 
 			selectedDeploys = selectedActors
 				.SelectMany(a => a.TraitsImplementing<IIssueDeployOrder>()


### PR DESCRIPTION
Made aircraft able to scatter

From what I can tell there isn't an easy way to determine if a cell is occupied like there is for ground units, so I thought reasonably the best thing to do is to pick a random nearby cell and move to it. However, this is not perfect and aircraft that are at the same altitude will collide and repulse off one another as they try to move past each other. If the group you want to scatter is large enough you will often get aircraft into a sort of deadlock. But this is maybe a separate issue altogether?

Let me know if anyone has any ideas for a better implementation.

Resolves #13137 and #14927.
Tested in TD, RA and TS.