### PR TITLE
Remove wrong idle sequences from medic and mechanic

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -391,6 +391,7 @@ MEDI:
 		ForceTargetStances: None
 	AttackFrontal:
 	WithInfantryBody:
+		IdleSequences: idle
 		StandSequences: stand
 		DefaultAttackSequence: heal
 	Voiced:
@@ -432,6 +433,7 @@ MECH:
 		CaptureTypes: husk
 		PlayerExperience: 25
 	WithInfantryBody:
+		IdleSequences: idle
 		DefaultAttackSequence: repair
 		StandSequences: stand
 	Voiced:

--- a/mods/ra/sequences/infantry.yaml
+++ b/mods/ra/sequences/infantry.yaml
@@ -319,11 +319,7 @@ medi:
 		Start: 114
 		Length: 2
 		Facings: 8
-	idle1:
-		Start: 163
-		Length: 14
-		Tick: 120
-	idle2:
+	idle:
 		Start: 178
 		Length: 14
 		Tick: 120
@@ -383,11 +379,7 @@ mech:
 		Start: 114
 		Length: 2
 		Facings: 8
-	idle1:
-		Start: 163
-		Length: 14
-		Tick: 120
-	idle2:
+	idle:
 		Start: 178
 		Length: 14
 		Tick: 120


### PR DESCRIPTION
They look bogus to me:
![medmechidle](https://user-images.githubusercontent.com/7704140/43358171-c24515ba-928d-11e8-868b-d7d0f229b18a.gif)
