### PR TITLE
Change menu cancel buttons to back

### DIFF
--- a/mods/cnc/chrome/mapchooser.yaml
+++ b/mods/cnc/chrome/mapchooser.yaml
@@ -116,7 +116,7 @@ Container@MAPCHOOSER_PANEL:
 					Y: 539
 					Width: 140
 					Height: 35
-					Text: Cancel
+					Text: Back
 				Button@RANDOMMAP_BUTTON:
 					Key: space
 					X: PARENT_RIGHT - 150 - WIDTH

--- a/mods/common/chrome/map-chooser.yaml
+++ b/mods/common/chrome/map-chooser.yaml
@@ -142,6 +142,6 @@ Background@MAPCHOOSER_PANEL:
 			Y: PARENT_BOTTOM - 45
 			Width: 120
 			Height: 25
-			Text: Cancel
+			Text: Back
 			Font: Bold
 			Key: escape

--- a/mods/common/chrome/replaybrowser.yaml
+++ b/mods/common/chrome/replaybrowser.yaml
@@ -251,7 +251,7 @@ Background@REPLAYBROWSER_PANEL:
 			Y: PARENT_BOTTOM - 45
 			Width: 120
 			Height: 25
-			Text: Cancel
+			Text: Back
 			Font: Bold
 			Key: escape
 		TooltipContainer@TOOLTIP_CONTAINER:


### PR DESCRIPTION
Closes #15398 

The only change I'm unsure of is the save map button. It can be argued that save map is a prompt instead of part of the menu navigation, and thus makes more sense as 'cancel'. We're splitting hairs either way so I went ahead and pushed it as requested by @FrameLimiter 

If anyone has the same hang-up I can take the save map change out.