### PR TITLE
Replaced obsolete EmptyWeapon with conditional behavior.

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -592,6 +592,7 @@
     <Compile Include="UpdateRules\Rules\20180923\MergeCaptureTraits.cs" />
     <Compile Include="UpdateRules\Rules\20180923\RemovedNotifyBuildComplete.cs" />
     <Compile Include="UpdateRules\Rules\20180923\ChangeTakeOffSoundAndLandingSound.cs" />
+    <Compile Include="UpdateRules\Rules\20180923\RemoveExplodesEmptyWeapon.cs" />
     <Compile Include="UtilityCommands\CheckYaml.cs" />
     <Compile Include="UtilityCommands\ConvertPngToShpCommand.cs" />
     <Compile Include="UtilityCommands\ConvertSpriteToPngCommand.cs" />

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/RemoveExplodesEmptyWeapon.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/RemoveExplodesEmptyWeapon.cs
@@ -1,0 +1,71 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+    public class SplitExplodes : UpdateRule
+    {
+        public override string Name { get { return "Remove Explodes EmptyWeapon parameters"; } }
+        public override string Description
+        {
+            get
+            {
+                return "Explodes.EmptyWeapon has been removed as it became obsolete by introducing conditions.\n" +
+                       "Using conditions allows to specify more precisely when and which Explodes should be used.";
+            }
+        }
+
+        readonly List<Tuple<string, string>> emptyWeaponLocations = new List<Tuple<string, string>>();
+
+        public override IEnumerable<string> AfterUpdate(ModData modData)
+        {
+            var message1 = "EmptyWeapon has been removed from Explodes.\n"
+                           + "Instead, use a second Explodes, and select the correct one using the RequiresCondition property.\n"
+                           + "If you were using the LoadedChance property, grant a condition by using GrantRandomCondition.\n"
+                           + "The following actors have been updated and might need manual adjustments:\n"
+                           + UpdateUtils.FormatMessageList(emptyWeaponLocations.Select(n => n.Item1 + " (" + n.Item2 + ")"));
+
+            if (emptyWeaponLocations.Any())
+                yield return message1;
+
+            emptyWeaponLocations.Clear();
+        }
+
+        public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+        {
+            foreach (var explodes in actorNode.ChildrenMatching("Explodes"))
+            {
+                var weapon = explodes.LastChildMatching("Weapon");
+                var emptyWeapon = explodes.LastChildMatching("EmptyWeapon");
+                var loadedChance = explodes.LastChildMatching("LoadedChance");
+
+                if (weapon == null && emptyWeapon == null)
+                    explodes.AddNode("Weapon", "UnitExplode");
+                else if (weapon == null)
+                    emptyWeapon.Key = "Weapon";
+                else if (emptyWeapon != null)
+                {
+                    emptyWeaponLocations.Add(Tuple.Create(actorNode.Key, actorNode.Location.Filename));
+                    explodes.RemoveNode(emptyWeapon);
+                }
+
+                if (loadedChance != null)
+                    explodes.RemoveNode(loadedChance);
+            }
+
+            yield break;
+        }
+    }
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -96,6 +96,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemovedNotifyBuildComplete(),
 				new LowPowerSlowdownToModifier(),
 				new RenameCrateActionNotification(),
+				new SplitExplodes(),
 			})
 		};
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -266,7 +266,6 @@
 	WithFacingSpriteBody:
 	Explodes:
 		Weapon: UnitExplodeSmall
-		EmptyWeapon: UnitExplodeSmall
 	Guard:
 	Guardable:
 	Tooltip:
@@ -319,7 +318,6 @@
 	ActorLostNotification:
 	Explodes:
 		Weapon: HeliExplode
-		EmptyWeapon: HeliExplode
 	AttackMove:
 	DrawLineToTarget:
 	Guard:
@@ -662,7 +660,6 @@
 	WithDamageOverlay:
 	Explodes:
 		Weapon: UnitExplodeShip
-		EmptyWeapon: UnitExplodeShip
 	Guard:
 	Guardable:
 	Tooltip:
@@ -700,7 +697,6 @@
 	Explodes:
 		Type: Footprint
 		Weapon: BuildingExplode
-		EmptyWeapon: BuildingExplode
 	CaptureNotification:
 		Notification: BuildingCaptured
 		NewOwnerVoice: no
@@ -1024,7 +1020,6 @@
 	ScriptTriggers:
 	Explodes:
 		Weapon: UnitExplodeSmall
-		EmptyWeapon: UnitExplodeSmall
 	BodyOrientation:
 		UseClassicFacingFudge: True
 

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -56,7 +56,6 @@ E2:
 		DefaultAttackSequence: throw
 	Explodes:
 		Weapon: GrenadierExplode
-		EmptyWeapon: GrenadierExplode
 		Chance: 50
 
 E3:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -181,8 +181,12 @@ ARTY:
 		EffectiveOwnerFromOwner: true
 	Explodes:
 		Weapon: ArtilleryShell
-		EmptyWeapon: UnitExplode
-		LoadedChance: 75
+		RequiresCondition: loaded
+	Explodes@unloaded:
+		Weapon: UnitExplode
+		RequiresCondition: unloaded
+	GrantRandomCondition:
+		Conditions: loaded, loaded, loaded, unloaded
 
 FTNK:
 	Inherits: ^Tank
@@ -217,7 +221,6 @@ FTNK:
 	WithMuzzleOverlay:
 	Explodes:
 		Weapon: FlametankExplode
-		EmptyWeapon: FlametankExplode
 	SpawnActorOnDeath:
 		Actor: FTNK.Husk
 		OwnerType: InternalName

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -42,7 +42,6 @@ spicebloom:
 		Weapon: SpiceExplosion
 	Explodes:
 		Weapon: BloomExplosion
-		EmptyWeapon: BloomExplosion
 	Crushable:
 		CrushClasses: spicebloom
 		CrushedByFriendlies: true

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -250,7 +250,6 @@
 		Palette: disabled
 	Explodes:
 		Weapon: UnitExplodeMed
-		EmptyWeapon: UnitExplodeMed
 
 ^AircraftHusk:
 	Inherits: ^Husk
@@ -395,7 +394,6 @@
 	Explodes:
 		Type: Footprint
 		Weapon: BuildingExplode
-		EmptyWeapon: BuildingExplode
 	RepairableBuilding:
 		RepairStep: 500
 		PlayerExperience: 25

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -194,7 +194,6 @@ grenadier:
 		DefaultAttackSequence: throw
 	Explodes:
 		Weapon: GrenDeath
-		EmptyWeapon: GrenDeath
 
 sardaukar:
 	Inherits: ^Infantry
@@ -227,7 +226,6 @@ sardaukar:
 		VoiceSet: GenericVoice
 	Explodes:
 		Weapon: SardDeath
-		EmptyWeapon: SardDeath
 		Chance: 100
 
 mpsardaukar:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -753,7 +753,6 @@ wall:
 	Guardable:
 	Explodes:
 		Weapon: WallExplode
-		EmptyWeapon: WallExplode
 	ThrowsShrapnel:
 		Weapons: Debris2, Debris3
 		Pieces: 1, 1

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -28,7 +28,6 @@ mcv:
 	BaseBuilding:
 	Explodes:
 		Weapon: UnitExplodeLarge
-		EmptyWeapon: UnitExplodeLarge
 	Transforms:
 		Facing: 16
 		IntoActor: construction_yard
@@ -83,7 +82,6 @@ harvester:
 		Range: 3c768
 	Explodes:
 		Weapon: UnitExplodeLarge
-		EmptyWeapon: UnitExplodeLarge
 	SpawnActorOnDeath:
 		Actor: harvester.Husk
 		OwnerType: InternalName
@@ -137,7 +135,6 @@ trike:
 	AttackFrontal:
 	Explodes:
 		Weapon: UnitExplodeSmall
-		EmptyWeapon: UnitExplodeSmall
 	AttractsWorms:
 		Intensity: 420
 
@@ -171,7 +168,6 @@ quad:
 	AttackFrontal:
 	Explodes:
 		Weapon: UnitExplodeSmall
-		EmptyWeapon: UnitExplodeSmall
 	Selectable:
 		Class: quad
 	AttractsWorms:
@@ -215,7 +211,6 @@ siege_tank:
 	WithSpriteTurret:
 	Explodes:
 		Weapon: UnitExplodeMed
-		EmptyWeapon: UnitExplodeMed
 	AutoTarget:
 		InitialStanceAI: Defend
 	Selectable:
@@ -259,7 +254,6 @@ missile_tank:
 		InitialStanceAI: Defend
 	Explodes:
 		Weapon: UnitExplodeMed
-		EmptyWeapon: UnitExplodeMed
 	Selectable:
 		Class: missiletank
 	SpawnActorOnDeath:
@@ -299,7 +293,6 @@ sonic_tank:
 	AttackFrontal:
 	Explodes:
 		Weapon: UnitExplodeLarge
-		EmptyWeapon: UnitExplodeLarge
 	SpawnActorOnDeath:
 		Actor: sonic_tank.husk
 		OwnerType: InternalName
@@ -344,7 +337,6 @@ devastator:
 		IgnoreOffset: true
 	Explodes:
 		Weapon: UnitExplodeLarge
-		EmptyWeapon: UnitExplodeLarge
 		RequiresCondition: !overload
 	SpawnActorOnDeath:
 		Actor: devastator.husk
@@ -352,7 +344,6 @@ devastator:
 		EffectiveOwnerFromOwner: true
 	Explodes@OVERLOAD:
 		Weapon: PlasmaExplosion
-		EmptyWeapon: PlasmaExplosion
 		RequiresCondition: meltdown
 	GrantConditionOnDeploy@REACTOR:
 		DeployedCondition: overload
@@ -412,7 +403,6 @@ raider:
 	AttackFrontal:
 	Explodes:
 		Weapon: UnitExplodeSmall
-		EmptyWeapon: UnitExplodeSmall
 	AttractsWorms:
 		Intensity: 420
 
@@ -474,7 +464,6 @@ deviator:
 		InitialStanceAI: Defend
 	Explodes:
 		Weapon: UnitExplodeLarge
-		EmptyWeapon: UnitExplodeLarge
 	SpawnActorOnDeath:
 		Actor: deviator.husk
 		OwnerType: InternalName
@@ -519,7 +508,6 @@ deviator:
 	WithSpriteTurret:
 	Explodes:
 		Weapon: UnitExplodeMed
-		EmptyWeapon: UnitExplodeMed
 	Selectable:
 		Class: combat
 	AttractsWorms:

--- a/mods/ra/maps/bomber-john/rules.yaml
+++ b/mods/ra/maps/bomber-john/rules.yaml
@@ -179,7 +179,6 @@ MINVV:
 		HealIfBelow: 101
 	Explodes:
 		Weapon: CrateNuke
-		EmptyWeapon: CrateNuke
 	HitShape:
 	Interactable:
 

--- a/mods/ra/maps/drop-zone-battle-of-tikiaki/rules.yaml
+++ b/mods/ra/maps/drop-zone-battle-of-tikiaki/rules.yaml
@@ -49,7 +49,6 @@ HARV:
 		HP: 10000
 	Explodes:
 		Weapon: CrateNuke
-		EmptyWeapon: CrateNuke
 	AttackSuicides:
 	Buildable:
 		Description: Explodes like a damn nuke!

--- a/mods/ra/maps/drop-zone/rules.yaml
+++ b/mods/ra/maps/drop-zone/rules.yaml
@@ -49,7 +49,6 @@ HARV:
 		HP: 10000
 	Explodes:
 		Weapon: CrateNuke
-		EmptyWeapon: CrateNuke
 	AttackSuicides:
 	Buildable:
 		Description: Explodes like a damn nuke!

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -330,7 +330,6 @@ V2RL:
 		Recoil: 2
 	Explodes:
 		Weapon: napalm
-		EmptyWeapon: napalm
 	SelfHealing:
 		Step: 200
 		Delay: 1

--- a/mods/ra/maps/monster-tank-madness/rules.yaml
+++ b/mods/ra/maps/monster-tank-madness/rules.yaml
@@ -25,7 +25,6 @@ World:
 	Inherits: ^CivBuilding
 	Explodes:
 		Weapon: BarrelExplode
-		EmptyWeapon: BarrelExplode
 	-SpawnActorOnDeath@1:
 	-SpawnActorOnDeath@2:
 	-SpawnActorOnDeath@3:
@@ -83,7 +82,6 @@ V11.exploding:
 V19:
 	Explodes:
 		Weapon: BarrelExplode
-		EmptyWeapon: BarrelExplode
 
 DEMITRI:
 	Inherits: DELPHI
@@ -160,7 +158,6 @@ PBOX:
 	WithSpriteTurret:
 	Explodes:
 		Weapon: MiniNuke
-		EmptyWeapon: MiniNuke
 	SpawnActorOnDeath:
 		Actor: 5TNK.Husk
 	SelfHealing:

--- a/mods/ra/maps/soviet-01/rules.yaml
+++ b/mods/ra/maps/soviet-01/rules.yaml
@@ -18,6 +18,7 @@ V01:
 
 JEEP:
 	Explodes:
+		Weapon: UnitExplode
 	ProximityExternalCondition@JAMMER:
 		Range: 10c0
 		ValidStances: Enemy, Neutral

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -283,7 +283,6 @@
 		ParachutingCondition: parachute
 	Explodes:
 		Weapon: UnitExplodeSmall
-		EmptyWeapon: UnitExplodeSmall
 	WithFacingSpriteBody:
 	WithParachute:
 		ShadowImage: parach-shadow
@@ -493,7 +492,6 @@
 	WithDamageOverlay:
 	Explodes:
 		Weapon: UnitExplodeShip
-		EmptyWeapon: UnitExplodeShip
 	Guard:
 	Guardable:
 	Tooltip:
@@ -619,7 +617,6 @@
 	Explodes:
 		Type: Footprint
 		Weapon: BuildingExplode
-		EmptyWeapon: BuildingExplode
 	CaptureNotification:
 	ShakeOnDeath:
 	ProximityCaptor:
@@ -691,7 +688,6 @@
 	RenderRangeCircle:
 	Explodes:
 		Weapon: SmallBuildingExplode
-		EmptyWeapon: SmallBuildingExplode
 	MapEditorData:
 		Categories: Defense
 	-CommandBarBlacklist:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -126,7 +126,6 @@ E2:
 		RequiresCondition: parachute
 	Explodes:
 		Weapon: UnitExplodeSmall
-		EmptyWeapon: UnitExplodeSmall
 		DamageSource: Killer
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded
@@ -208,7 +207,6 @@ E4:
 	AttackFrontal:
 	Explodes:
 		Weapon: VisualExplode
-		EmptyWeapon: VisualExplode
 		Chance: 50
 	WithInfantryBody:
 		DefaultAttackSequence: shoot

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -60,7 +60,6 @@ SS:
 	RenderDetectionCircle:
 	Explodes:
 		Weapon: UnitExplodeSubmarine
-		EmptyWeapon: UnitExplodeSubmarine
 	-MustBeDestroyed:
 	Selectable:
 		DecorationBounds: 38,38
@@ -128,7 +127,6 @@ MSUB:
 	RenderDetectionCircle:
 	Explodes:
 		Weapon: UnitExplodeSubmarine
-		EmptyWeapon: UnitExplodeSubmarine
 	-MustBeDestroyed:
 	Selectable:
 		DecorationBounds: 44,44

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -105,7 +105,6 @@ GAP:
 	-AcceptsDeliveredCash:
 	Explodes:
 		Weapon: SmallBuildingExplode
-		EmptyWeapon: SmallBuildingExplode
 	HitShape:
 		Type: Rectangle
 			TopLeft: -512, -512
@@ -853,7 +852,6 @@ FTUR:
 	ProvidesPrerequisite@buildingname:
 	Explodes:
 		Weapon: BuildingExplode
-		EmptyWeapon: BuildingExplode
 
 SAM:
 	Inherits: ^Defense
@@ -1276,7 +1274,6 @@ SILO:
 		Amount: -10
 	Explodes:
 		Weapon: SmallBuildingExplode
-		EmptyWeapon: SmallBuildingExplode
 
 HPAD:
 	Inherits: ^Building

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -274,8 +274,12 @@ ARTY:
 	WithMuzzleOverlay:
 	Explodes:
 		Weapon: ArtilleryExplode
-		EmptyWeapon: UnitExplodeSmall
-		LoadedChance: 75
+		RequiresCondition: loaded
+	Explodes@unloaded:
+		Weapon: UnitExplodeSmall
+		RequiresCondition: unloaded
+	GrantRandomCondition:
+		Conditions: loaded, loaded, loaded, unloaded
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 
@@ -699,7 +703,6 @@ DTRK:
 		Range: 4c0
 	Explodes:
 		Weapon: MiniNuke
-		EmptyWeapon: MiniNuke
 		DamageSource: Killer
 	AttackSuicides:
 	-DamageMultiplier@IRONCURTAIN:

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -359,7 +359,6 @@ HUNTER:
 	AttackSuicides:
 	Explodes:
 		Weapon: SuicideBomb
-		EmptyWeapon: SuicideBomb
 	Aircraft:
 		TurnSpeed: 16
 		Speed: 355

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -326,7 +326,6 @@
 	WithSpriteBody:
 	Explodes:
 		Weapon: BuildingExplosions
-		EmptyWeapon: BuildingExplosions
 		Type: Footprint
 	EngineerRepairable:
 	ShakeOnDeath:
@@ -671,7 +670,6 @@
 		TriggerOnlyOnce: true
 	Explodes:
 		Weapon: CyborgExplode
-		EmptyWeapon: CyborgExplode
 	DeathSounds:
 	RevealsShroud:
 		Range: 4c0
@@ -751,7 +749,6 @@
 		CameraPitch: 90
 	Explodes:
 		Weapon: UnitExplodeSmall
-		EmptyWeapon: UnitExplodeSmall
 	MustBeDestroyed:
 	RenderSprites:
 	ThrowsShrapnel:
@@ -1071,7 +1068,6 @@
 		QuantizedFacings: 0
 	Explodes:
 		Weapon: UnitExplodeSmall
-		EmptyWeapon: UnitExplodeSmall
 	ThrowsShrapnel:
 		Weapons: SmallDebris
 		Pieces: 3, 7

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -131,7 +131,6 @@ NAFNCE:
 		Modifier: 0
 	Explodes:
 		Weapon: BuildingExplosions
-		EmptyWeapon: BuildingExplosions
 		Type: Footprint
 	ThrowsShrapnel@SMALL:
 		Weapons: SmallDebris


### PR DESCRIPTION
Instead of writing Weapon and EmptyWeapon over and over again, EmptyWeapon is now removed, as its behavior can be archived by using conditions.