### PR TITLE
TS: Aircrafts land instantly to reload their ammo.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -44,7 +44,8 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 			}
 
-			Fly.FlyToward(self, plane, d.Yaw.Facing, new WDist(target.CenterPosition.Z));
+			var landingAlt = self.World.Map.DistanceAboveTerrain(target.CenterPosition);
+			Fly.FlyToward(self, plane, d.Yaw.Facing, landingAlt);
 
 			return this;
 		}


### PR DESCRIPTION
The Land activity was not taking into account the terrain height when calculating it's landing altitude and was causing non-helicopters to land instantly when above if the landing area was on raised terrain. This should also still allow for landing on units that are in the air (#13701), although I don't think I can test this with the base mods.
 
- Fixes #14312.
- Also tested for obvious issues in TD and RA.
