### PR TITLE
Add RequiresSpecificOwner trait and lint check

### DIFF
--- a/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
@@ -41,6 +41,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			Actor = actor;
 			this.owner = owner;
+			var ownerName = owner.Name;
 
 			preview = editorWidget.Get<ActorPreviewWidget>("DRAG_ACTOR_PREVIEW");
 			preview.GetScale = () => worldRenderer.Viewport.Zoom;
@@ -50,10 +51,15 @@ namespace OpenRA.Mods.Common.Widgets
 			if (buildingInfo != null)
 				centerOffset = buildingInfo.CenterOffset(world);
 
+			// Enforce first entry of ValidOwnerNames as owner if the actor has RequiresSpecificOwners
+			var specificOwnerInfo = actor.TraitInfoOrDefault<RequiresSpecificOwnersInfo>();
+			if (specificOwnerInfo != null && !specificOwnerInfo.ValidOwnerNames.Contains(ownerName))
+				ownerName = specificOwnerInfo.ValidOwnerNames.First();
+
 			var td = new TypeDictionary();
 			td.Add(new FacingInit(facing));
 			td.Add(new TurretFacingInit(facing));
-			td.Add(new OwnerInit(owner.Name));
+			td.Add(new OwnerInit(ownerName));
 			td.Add(new FactionInit(owner.Faction));
 			preview.SetPreview(actor, td);
 
@@ -94,8 +100,14 @@ namespace OpenRA.Mods.Common.Widgets
 				if (!footprint.All(c => world.Map.Tiles.Contains(cell + c)))
 					return true;
 
+				// Enforce first entry of ValidOwnerNames as owner if the actor has RequiresSpecificOwners
+				var ownerName = owner.Name;
+				var specificOwnerInfo = Actor.TraitInfoOrDefault<RequiresSpecificOwnersInfo>();
+				if (specificOwnerInfo != null && !specificOwnerInfo.ValidOwnerNames.Contains(ownerName))
+					ownerName = specificOwnerInfo.ValidOwnerNames.First();
+
 				var newActorReference = new ActorReference(Actor.Name);
-				newActorReference.Add(new OwnerInit(owner.Name));
+				newActorReference.Add(new OwnerInit(ownerName));
 
 				newActorReference.Add(new LocationInit(cell));
 

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -13,6 +13,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
+using OpenRA.Scripting;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
@@ -73,6 +75,11 @@ namespace OpenRA.Mods.Common.Lint
 					emitError("Duplicate spawn point locations detected.");
 			}
 
+			// Check for actors that require specific owners
+			var actorsWithRequiredOwner = map.Rules.Actors
+				.Where(a => a.Value.HasTraitInfo<RequiresSpecificOwnersInfo>())
+				.ToDictionary(a => a.Key, a => a.Value.TraitInfo<RequiresSpecificOwnersInfo>());
+
 			foreach (var kv in map.ActorDefinitions)
 			{
 				var actorReference = new ActorReference(kv.Value.Value, kv.Value.ToDictionary());
@@ -89,6 +96,11 @@ namespace OpenRA.Mods.Common.Lint
 						emitError("Actor {0} needs to be owned by the player that owns the world. ".F(kv.Key) +
 							"Use the `Spawn` and `LockSpawn` player properties to force players onto a particular spawn instead.");
 					}
+
+					RequiresSpecificOwnersInfo info;
+					if (actorsWithRequiredOwner.TryGetValue(kv.Value.Value, out info))
+						if (!info.ValidOwnerNames.Contains(ownerName))
+							emitError("Actor {0} owner {1} is not one of ValidOwnerNames: {2}".F(kv.Key, ownerName, info.ValidOwnerNames.JoinWith(", ")));
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/Lint/CheckPlayers.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPlayers.cs
@@ -91,11 +91,6 @@ namespace OpenRA.Mods.Common.Lint
 					var ownerName = ownerInit.PlayerName;
 					if (!playerNames.Contains(ownerName))
 						emitError("Actor {0} is owned by unknown player {1}.".F(kv.Key, ownerName));
-					else if (kv.Value.Value == "mpspawn" && !players[ownerName].OwnsWorld)
-					{
-						emitError("Actor {0} needs to be owned by the player that owns the world. ".F(kv.Key) +
-							"Use the `Spawn` and `LockSpawn` player properties to force players onto a particular spawn instead.");
-					}
 
 					RequiresSpecificOwnersInfo info;
 					if (actorsWithRequiredOwner.TryGetValue(kv.Value.Value, out info))

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -501,6 +501,7 @@
     <Compile Include="Traits\RepairsBridges.cs" />
     <Compile Include="Traits\Replaceable.cs" />
     <Compile Include="Traits\Replacement.cs" />
+    <Compile Include="Traits\RequiresSpecificOwners.cs" />
     <Compile Include="Traits\SeedsResource.cs" />
     <Compile Include="Traits\StoresResources.cs" />
     <Compile Include="Traits\Render\SelectionDecorations.cs" />

--- a/OpenRA.Mods.Common/Traits/RequiresSpecificOwners.cs
+++ b/OpenRA.Mods.Common/Traits/RequiresSpecificOwners.cs
@@ -1,0 +1,26 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Can be used to enforce specific owners (like 'Neutral' or 'Creeps') for this actor.")]
+	public class RequiresSpecificOwnersInfo : TraitInfo<RequiresSpecificOwners>
+	{
+		[Desc("Only allow players listed here as owners.")]
+		[FieldLoader.Require]
+		public readonly HashSet<string> ValidOwnerNames = new HashSet<string>();
+	}
+
+	public class RequiresSpecificOwners { }
+}

--- a/mods/cnc/rules/misc.yaml
+++ b/mods/cnc/rules/misc.yaml
@@ -58,6 +58,8 @@ mpspawn:
 		QuantizedFacings: 1
 	MapEditorData:
 		Categories: System
+	RequiresSpecificOwners:
+		ValidOwnerNames: Neutral
 
 waypoint:
 	Interactable:

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -152,6 +152,8 @@ mpspawn:
 		QuantizedFacings: 1
 	MapEditorData:
 		Categories: System
+	RequiresSpecificOwners:
+		ValidOwnerNames: Neutral
 
 waypoint:
 	Interactable:

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -373,6 +373,8 @@ mpspawn:
 		QuantizedFacings: 1
 	MapEditorData:
 		Categories: System
+	RequiresSpecificOwners:
+		ValidOwnerNames: Neutral
 
 waypoint:
 	Interactable:

--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -11,6 +11,8 @@ mpspawn:
 		QuantizedFacings: 1
 	MapEditorData:
 		Categories: System
+	RequiresSpecificOwners:
+		ValidOwnerNames: Neutral
 
 waypoint:
 	Interactable:


### PR DESCRIPTION
The purpose of this trait is to allow Lint and the map editor to check for and enforce specific owner(s) for actors where any other owner could cause issues (case in point: #15457).

In practice, this is only used to enforce Neutral on RA/TD trees for now, because their Targetable trait makes AI squads consider them as valid targets when owned by the 'enemy' Creeps.
The fact that the AI only looks for the Targetable trait and not whether the target type is actually valid for the squad leader is certainly another issue, but this PR has its own merits regardless of that.