### PR TITLE
Updated CPos struct to use bit field for all properties.

### DIFF
--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -56,7 +56,7 @@ namespace OpenRA
 		public readonly string[] categories;
 		public readonly int players;
 		public readonly Rectangle bounds;
-		public readonly int[] spawnpoints = { };
+		public readonly short[] spawnpoints = { };
 		public readonly MapGridType map_grid_type;
 		public readonly string minimap;
 		public readonly bool downloading;

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -128,7 +128,7 @@ namespace OpenRA
 									{
 										if (flags.HasField(OrderFields.TargetIsCell))
 										{
-											var cell = new CPos(r.ReadInt32(), r.ReadInt32(), r.ReadByte());
+											var cell = new CPos(r.ReadInt32());
 											var subCell = (SubCell)r.ReadByte();
 											if (world != null)
 												target = Target.FromCell(world, cell, subCell);
@@ -146,7 +146,7 @@ namespace OpenRA
 
 						var targetString = flags.HasField(OrderFields.TargetString) ? r.ReadString() : null;
 						var queued = flags.HasField(OrderFields.Queued);
-						var extraLocation = flags.HasField(OrderFields.ExtraLocation) ? new CPos(r.ReadInt32(), r.ReadInt32(), r.ReadByte()) : CPos.Zero;
+						var extraLocation = flags.HasField(OrderFields.ExtraLocation) ? new CPos(r.ReadInt32()) : CPos.Zero;
 						var extraData = flags.HasField(OrderFields.ExtraData) ? r.ReadUInt32() : 0;
 
 						if (world == null)

--- a/OpenRA.Game/Network/OrderIO.cs
+++ b/OpenRA.Game/Network/OrderIO.cs
@@ -58,9 +58,7 @@ namespace OpenRA.Network
 
 		public static void Write(this BinaryWriter w, CPos cell)
 		{
-			w.Write(cell.X);
-			w.Write(cell.Y);
-			w.Write(cell.Layer);
+			w.Write(cell.Bits);
 		}
 
 		public static void Write(this BinaryWriter w, WPos pos)

--- a/OpenRA.Test/OpenRA.Game/CPosTest.cs
+++ b/OpenRA.Test/OpenRA.Game/CPosTest.cs
@@ -1,0 +1,31 @@
+﻿using System.Runtime.Remoting.Metadata;
+using NUnit.Framework;
+
+namespace OpenRA.Test
+{
+	[TestFixture]
+	public class CPosTest
+	{
+		[TestCase(TestName = "Packing x,y and layer into int")]
+		public void PackUnpackBits()
+		{
+			var values = new int[] { -2048, -1024, 0, 1024, 2047 };
+			var layerValues = new byte[] { 0, 128, 255 };
+
+			foreach (var x in values)
+			{
+				foreach (var y in values)
+				{
+					foreach (var layer in layerValues)
+					{
+						var cell = new CPos(x, y, layer);
+
+						Assert.AreEqual(x, cell.X);
+						Assert.AreEqual(y, cell.Y);
+						Assert.AreEqual(layer, cell.Layer);
+					}
+				}
+			}
+		}
+	}
+}

--- a/OpenRA.Test/OpenRA.Game/OrderTest.cs
+++ b/OpenRA.Test/OpenRA.Game/OrderTest.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Test
 			var o = new Order("Test", null, Target.Invalid, true)
 			{
 				TargetString = "TargetString",
-				ExtraLocation = new CPos(int.MinValue, int.MaxValue, 128),
+				ExtraLocation = new CPos(2047, 2047, 128),
 				ExtraData = uint.MaxValue,
 				IsImmediate = true,
 			}.Serialize();

--- a/OpenRA.Test/OpenRA.Test.csproj
+++ b/OpenRA.Test/OpenRA.Test.csproj
@@ -46,6 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="OpenRA.Game\ActionQueueTest.cs" />
+    <Compile Include="OpenRA.Game\CPosTest.cs" />
     <Compile Include="OpenRA.Game\MiniYamlTest.cs" />
     <Compile Include="OpenRA.Game\ActorInfoTest.cs" />
     <Compile Include="OpenRA.Game\CoordinateTest.cs" />


### PR DESCRIPTION
Trying to minimize the memory footprint for structs used in the pathfinding, so changing the coordinates to use short instead of int saves us 32 bits for this struct.