### PR TITLE
Disable the threaded renderer on Windows.

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -130,6 +130,9 @@ namespace OpenRA
 		[Desc("Disable high resolution DPI scaling on Windows operating systems.")]
 		public bool DisableWindowsDPIScaling = true;
 
+		[Desc("Disable separate OpenGL render thread on Windows operating systems.")]
+		public bool DisableWindowsRenderThread = true;
+
 		public int BatchSize = 8192;
 		public int SheetSize = 2048;
 

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -187,7 +187,16 @@ namespace OpenRA.Platforms.Default
 			// Run graphics rendering on a dedicated thread.
 			// The calling thread will then have more time to process other tasks, since rendering happens in parallel.
 			// If the calling thread is the main game thread, this means it can run more logic and render ticks.
-			context = new ThreadedGraphicsContext(new Sdl2GraphicsContext(this), batchSize);
+			// This is disabled on Windows because it breaks the ability to minimize/restore the window from the taskbar for reasons that we dont understand.
+			var threadedRenderer = Platform.CurrentPlatform != PlatformType.Windows || !Game.Settings.Graphics.DisableWindowsRenderThread;
+			if (threadedRenderer)
+			{
+				var ctx = new Sdl2GraphicsContext(this);
+				ctx.InitializeOpenGL();
+				context = ctx;
+			}
+			else
+				context = new ThreadedGraphicsContext(new Sdl2GraphicsContext(this), batchSize);
 
 			SDL.SDL_SetModState(SDL.SDL_Keymod.KMOD_NONE);
 			input = new Sdl2Input();


### PR DESCRIPTION
This PR disables the threaded renderer on Windows (sorry @RoosterDragon) as we have run out of ideas on how to fix the window manager regression.

Closes #15422