### PR TITLE
Hide the Ready checkbox when a spectator transfers away Admin.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -646,6 +646,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					if (client.IsAdmin)
 						LobbyUtils.SetupEditableReadyWidget(template, null, client, orderManager, map);
+					else
+						LobbyUtils.HideReadyWidgets(template);
 				}
 				else
 				{
@@ -661,6 +663,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					if (client.IsAdmin)
 						LobbyUtils.SetupReadyWidget(template, null, client);
+					else
+						LobbyUtils.HideReadyWidgets(template);
 				}
 
 				LobbyUtils.SetupLatencyWidget(template, c, orderManager, true);

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -564,6 +564,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			parent.Get<ImageWidget>("STATUS_IMAGE").IsVisible = () => c.IsReady || c.Bot != null;
 		}
 
+		public static void HideReadyWidgets(Widget parent)
+		{
+			HideChildWidget(parent, "STATUS_CHECKBOX");
+			HideChildWidget(parent, "STATUS_IMAGE");
+		}
+
 		public static void AddPlayerFlagAndName(ScrollItemWidget template, Player player)
 		{
 			var flag = template.Get<ImageWidget>("FLAG");


### PR DESCRIPTION
Fixes #15436.