### PR TITLE
Sync naming of cached Aircraft trait in air activities

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -18,14 +18,14 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class Fly : Activity
 	{
-		readonly Aircraft plane;
+		readonly Aircraft aircraft;
 		readonly Target target;
 		readonly WDist maxRange;
 		readonly WDist minRange;
 
 		public Fly(Actor self, Target t)
 		{
-			plane = self.Trait<Aircraft>();
+			aircraft = self.Trait<Aircraft>();
 			target = t;
 		}
 
@@ -36,29 +36,29 @@ namespace OpenRA.Mods.Common.Activities
 			this.minRange = minRange;
 		}
 
-		public static void FlyToward(Actor self, Aircraft plane, int desiredFacing, WDist desiredAltitude)
+		public static void FlyToward(Actor self, Aircraft aircraft, int desiredFacing, WDist desiredAltitude)
 		{
-			desiredAltitude = new WDist(plane.CenterPosition.Z) + desiredAltitude - self.World.Map.DistanceAboveTerrain(plane.CenterPosition);
+			desiredAltitude = new WDist(aircraft.CenterPosition.Z) + desiredAltitude - self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition);
 
-			var move = plane.FlyStep(plane.Facing);
-			var altitude = plane.CenterPosition.Z;
+			var move = aircraft.FlyStep(aircraft.Facing);
+			var altitude = aircraft.CenterPosition.Z;
 
-			plane.Facing = Util.TickFacing(plane.Facing, desiredFacing, plane.TurnSpeed);
+			aircraft.Facing = Util.TickFacing(aircraft.Facing, desiredFacing, aircraft.TurnSpeed);
 
 			if (altitude != desiredAltitude.Length)
 			{
-				var delta = move.HorizontalLength * plane.Info.MaximumPitch.Tan() / 1024;
+				var delta = move.HorizontalLength * aircraft.Info.MaximumPitch.Tan() / 1024;
 				var dz = (desiredAltitude.Length - altitude).Clamp(-delta, delta);
 				move += new WVec(0, 0, dz);
 			}
 
-			plane.SetPosition(self, plane.CenterPosition + move);
+			aircraft.SetPosition(self, aircraft.CenterPosition + move);
 		}
 
 		public override Activity Tick(Actor self)
 		{
 			// Refuse to take off if it would land immediately again.
-			if (plane.ForceLanding)
+			if (aircraft.ForceLanding)
 			{
 				Cancel(self);
 				return NextActivity;
@@ -68,25 +68,25 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 
 			// Inside the target annulus, so we're done
-			var insideMaxRange = maxRange.Length > 0 && target.IsInRange(plane.CenterPosition, maxRange);
-			var insideMinRange = minRange.Length > 0 && target.IsInRange(plane.CenterPosition, minRange);
+			var insideMaxRange = maxRange.Length > 0 && target.IsInRange(aircraft.CenterPosition, maxRange);
+			var insideMinRange = minRange.Length > 0 && target.IsInRange(aircraft.CenterPosition, minRange);
 			if (insideMaxRange && !insideMinRange)
 				return NextActivity;
 
 			var d = target.CenterPosition - self.CenterPosition;
 
 			// The next move would overshoot, so consider it close enough
-			var move = plane.FlyStep(plane.Facing);
+			var move = aircraft.FlyStep(aircraft.Facing);
 			if (d.HorizontalLengthSquared < move.HorizontalLengthSquared)
 				return NextActivity;
 
 			// Don't turn until we've reached the cruise altitude
 			var desiredFacing = d.Yaw.Facing;
-			var targetAltitude = plane.CenterPosition.Z + plane.Info.CruiseAltitude.Length - self.World.Map.DistanceAboveTerrain(plane.CenterPosition).Length;
-			if (plane.CenterPosition.Z < targetAltitude)
-				desiredFacing = plane.Facing;
+			var targetAltitude = aircraft.CenterPosition.Z + aircraft.Info.CruiseAltitude.Length - self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition).Length;
+			if (aircraft.CenterPosition.Z < targetAltitude)
+				desiredFacing = aircraft.Facing;
 
-			FlyToward(self, plane, desiredFacing, plane.Info.CruiseAltitude);
+			FlyToward(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude);
 
 			return this;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/FlyCircle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyCircle.cs
@@ -16,21 +16,21 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class FlyCircle : Activity
 	{
-		readonly Aircraft plane;
+		readonly Aircraft aircraft;
 		readonly WDist cruiseAltitude;
 		int remainingTicks;
 
 		public FlyCircle(Actor self, int ticks = -1)
 		{
-			plane = self.Trait<Aircraft>();
-			cruiseAltitude = plane.Info.CruiseAltitude;
+			aircraft = self.Trait<Aircraft>();
+			cruiseAltitude = aircraft.Info.CruiseAltitude;
 			remainingTicks = ticks;
 		}
 
 		public override Activity Tick(Actor self)
 		{
 			// Refuse to take off if it would land immediately again.
-			if (plane.ForceLanding)
+			if (aircraft.ForceLanding)
 			{
 				Cancel(self);
 				return NextActivity;
@@ -45,8 +45,8 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 
 			// We can't possibly turn this fast
-			var desiredFacing = plane.Facing + 64;
-			Fly.FlyToward(self, plane, desiredFacing, cruiseAltitude);
+			var desiredFacing = aircraft.Facing + 64;
+			Fly.FlyToward(self, aircraft, desiredFacing, cruiseAltitude);
 
 			return this;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
@@ -18,14 +18,14 @@ namespace OpenRA.Mods.Common.Activities
 	public class FlyFollow : Activity
 	{
 		Target target;
-		Aircraft plane;
+		Aircraft aircraft;
 		WDist minRange;
 		WDist maxRange;
 
 		public FlyFollow(Actor self, Target target, WDist minRange, WDist maxRange)
 		{
 			this.target = target;
-			plane = self.Trait<Aircraft>();
+			aircraft = self.Trait<Aircraft>();
 			this.minRange = minRange;
 			this.maxRange = maxRange;
 		}
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Activities
 		public override Activity Tick(Actor self)
 		{
 			// Refuse to take off if it would land immediately again.
-			if (plane.ForceLanding)
+			if (aircraft.ForceLanding)
 			{
 				Cancel(self);
 				return NextActivity;
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (target.IsInRange(self.CenterPosition, maxRange) && !target.IsInRange(self.CenterPosition, minRange))
 			{
-				Fly.FlyToward(self, plane, plane.Facing, plane.Info.CruiseAltitude);
+				Fly.FlyToward(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);
 				return this;
 			}
 

--- a/OpenRA.Mods.Common/Activities/Air/FlyOffMap.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyOffMap.cs
@@ -16,17 +16,17 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class FlyOffMap : Activity
 	{
-		readonly Aircraft plane;
+		readonly Aircraft aircraft;
 
 		public FlyOffMap(Actor self)
 		{
-			plane = self.Trait<Aircraft>();
+			aircraft = self.Trait<Aircraft>();
 		}
 
 		public override Activity Tick(Actor self)
 		{
 			// Refuse to take off if it would land immediately again.
-			if (plane.ForceLanding)
+			if (aircraft.ForceLanding)
 			{
 				Cancel(self);
 				return NextActivity;
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (IsCanceled || !self.World.Map.Contains(self.Location))
 				return NextActivity;
 
-			Fly.FlyToward(self, plane, plane.Facing, plane.Info.CruiseAltitude);
+			Fly.FlyToward(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);
 			return this;
 		}
 	}

--- a/OpenRA.Mods.Common/Activities/Air/FlyTimed.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyTimed.cs
@@ -16,21 +16,21 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class FlyTimed : Activity
 	{
-		readonly Aircraft plane;
+		readonly Aircraft aircraft;
 		readonly WDist cruiseAltitude;
 		int remainingTicks;
 
 		public FlyTimed(int ticks, Actor self)
 		{
 			remainingTicks = ticks;
-			plane = self.Trait<Aircraft>();
-			cruiseAltitude = plane.Info.CruiseAltitude;
+			aircraft = self.Trait<Aircraft>();
+			cruiseAltitude = aircraft.Info.CruiseAltitude;
 		}
 
 		public override Activity Tick(Actor self)
 		{
 			// Refuse to take off if it would land immediately again.
-			if (plane.ForceLanding)
+			if (aircraft.ForceLanding)
 			{
 				Cancel(self);
 				return NextActivity;
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (IsCanceled || remainingTicks-- == 0)
 				return NextActivity;
 
-			Fly.FlyToward(self, plane, plane.Facing, cruiseAltitude);
+			Fly.FlyToward(self, aircraft, aircraft.Facing, cruiseAltitude);
 
 			return this;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/HeliFlyCircle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliFlyCircle.cs
@@ -17,17 +17,17 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class HeliFlyCircle : Activity
 	{
-		readonly Aircraft helicopter;
+		readonly Aircraft aircraft;
 
 		public HeliFlyCircle(Actor self)
 		{
-			helicopter = self.Trait<Aircraft>();
+			aircraft = self.Trait<Aircraft>();
 		}
 
 		public override Activity Tick(Actor self)
 		{
 			// Refuse to take off if it would land immediately again.
-			if (helicopter.ForceLanding)
+			if (aircraft.ForceLanding)
 			{
 				Cancel(self);
 				return NextActivity;
@@ -36,14 +36,14 @@ namespace OpenRA.Mods.Common.Activities
 			if (IsCanceled)
 				return NextActivity;
 
-			if (HeliFly.AdjustAltitude(self, helicopter, helicopter.Info.CruiseAltitude))
+			if (HeliFly.AdjustAltitude(self, aircraft, aircraft.Info.CruiseAltitude))
 				return this;
 
-			var move = helicopter.FlyStep(helicopter.Facing);
-			helicopter.SetPosition(self, helicopter.CenterPosition + move);
+			var move = aircraft.FlyStep(aircraft.Facing);
+			aircraft.SetPosition(self, aircraft.CenterPosition + move);
 
-			var desiredFacing = helicopter.Facing + 64;
-			helicopter.Facing = Util.TickFacing(helicopter.Facing, desiredFacing, helicopter.TurnSpeed / 3);
+			var desiredFacing = aircraft.Facing + 64;
+			aircraft.Facing = Util.TickFacing(aircraft.Facing, desiredFacing, aircraft.TurnSpeed / 3);
 
 			return this;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/HeliLand.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliLand.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class HeliLand : Activity
 	{
-		readonly Aircraft helicopter;
+		readonly Aircraft aircraft;
 		readonly WDist landAltitude;
 		readonly bool requireSpace;
 
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			this.requireSpace = requireSpace;
 			this.landAltitude = landAltitude;
-			helicopter = self.Trait<Aircraft>();
+			aircraft = self.Trait<Aircraft>();
 		}
 
 		public override Activity Tick(Actor self)
@@ -37,16 +37,16 @@ namespace OpenRA.Mods.Common.Activities
 			if (IsCanceled)
 				return NextActivity;
 
-			if (requireSpace && !helicopter.CanLand(self.Location))
+			if (requireSpace && !aircraft.CanLand(self.Location))
 				return this;
 
-			if (!playedSound && helicopter.Info.LandingSound != null && !self.IsAtGroundLevel())
+			if (!playedSound && aircraft.Info.LandingSound != null && !self.IsAtGroundLevel())
 			{
-				Game.Sound.Play(SoundType.World, helicopter.Info.LandingSound);
+				Game.Sound.Play(SoundType.World, aircraft.Info.LandingSound);
 				playedSound = true;
 			}
 
-			if (HeliFly.AdjustAltitude(self, helicopter, landAltitude))
+			if (HeliFly.AdjustAltitude(self, aircraft, landAltitude))
 				return this;
 
 			return NextActivity;

--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Activities
 			this.dest = dest;
 		}
 
-		public Actor ChooseHelipad(Actor self, bool unreservedOnly)
+		public Actor ChooseResupplier(Actor self, bool unreservedOnly)
 		{
 			var rearmBuildings = aircraft.Info.RearmBuildings;
 			return self.World.Actors.Where(a => a.Owner == self.Owner
@@ -51,36 +51,36 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 
 			if (dest == null || dest.IsDead || Reservable.IsReserved(dest))
-				dest = ChooseHelipad(self, true);
+				dest = ChooseResupplier(self, true);
 
 			var initialFacing = aircraft.Info.InitialFacing;
 
 			if (dest == null || dest.IsDead)
 			{
-				var nearestHpad = ChooseHelipad(self, false);
+				var nearestResupplier = ChooseResupplier(self, false);
 
 				// If a heli was told to return and there's no (available) RearmBuilding, going to the probable next queued activity (HeliAttack)
 				// would be pointless (due to lack of ammo), and possibly even lead to an infinite loop due to HeliAttack.cs:L79.
-				if (nearestHpad == null && aircraft.Info.LandWhenIdle)
+				if (nearestResupplier == null && aircraft.Info.LandWhenIdle)
 				{
 					if (aircraft.Info.TurnToLand)
 						return ActivityUtils.SequenceActivities(new Turn(self, initialFacing), new HeliLand(self, true));
 
 					return new HeliLand(self, true);
 				}
-				else if (nearestHpad == null && !aircraft.Info.LandWhenIdle)
+				else if (nearestResupplier == null && !aircraft.Info.LandWhenIdle)
 					return null;
 				else
 				{
-					var distanceFromHelipad = (nearestHpad.CenterPosition - self.CenterPosition).HorizontalLength;
+					var distanceFromResupplier = (nearestResupplier.CenterPosition - self.CenterPosition).HorizontalLength;
 					var distanceLength = aircraft.Info.WaitDistanceFromResupplyBase.Length;
 
 					// If no pad is available, move near one and wait
-					if (distanceFromHelipad > distanceLength)
+					if (distanceFromResupplier > distanceLength)
 					{
 						var randomPosition = WVec.FromPDF(self.World.SharedRandom, 2) * distanceLength / 1024;
 
-						var target = Target.FromPos(nearestHpad.CenterPosition + randomPosition);
+						var target = Target.FromPos(nearestResupplier.CenterPosition + randomPosition);
 
 						return ActivityUtils.SequenceActivities(new HeliFly(self, target, WDist.Zero, aircraft.Info.WaitDistanceFromResupplyBase), this);
 					}

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -18,12 +18,12 @@ namespace OpenRA.Mods.Common.Activities
 	public class Land : Activity
 	{
 		readonly Target target;
-		readonly Aircraft plane;
+		readonly Aircraft aircraft;
 
 		public Land(Actor self, Target t)
 		{
 			target = t;
-			plane = self.Trait<Aircraft>();
+			aircraft = self.Trait<Aircraft>();
 		}
 
 		public override Activity Tick(Actor self)
@@ -37,15 +37,15 @@ namespace OpenRA.Mods.Common.Activities
 			var d = target.CenterPosition - self.CenterPosition;
 
 			// The next move would overshoot, so just set the final position
-			var move = plane.FlyStep(plane.Facing);
+			var move = aircraft.FlyStep(aircraft.Facing);
 			if (d.HorizontalLengthSquared < move.HorizontalLengthSquared)
 			{
-				plane.SetPosition(self, target.CenterPosition);
+				aircraft.SetPosition(self, target.CenterPosition);
 				return NextActivity;
 			}
 
 			var landingAlt = self.World.Map.DistanceAboveTerrain(target.CenterPosition);
-			Fly.FlyToward(self, plane, d.Yaw.Facing, landingAlt);
+			Fly.FlyToward(self, aircraft, d.Yaw.Facing, landingAlt);
 
 			return this;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Activities
 			aircraftInfo = self.Info.TraitInfo<AircraftInfo>();
 		}
 
-		public static Actor ChooseAirfield(Actor self, bool unreservedOnly)
+		public static Actor ChooseResupplier(Actor self, bool unreservedOnly)
 		{
 			var rearmBuildings = self.Info.TraitInfo<AircraftInfo>().RearmBuildings;
 			return self.World.ActorsHavingTrait<Reservable>()
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Activities
 		void Calculate(Actor self)
 		{
 			if (dest == null || dest.IsDead || Reservable.IsReserved(dest))
-				dest = ChooseAirfield(self, true);
+				dest = ChooseResupplier(self, true);
 
 			if (dest == null)
 				return;
@@ -123,11 +123,11 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (dest == null || dest.IsDead)
 			{
-				var nearestAfld = ChooseAirfield(self, false);
+				var nearestResupplier = ChooseResupplier(self, false);
 
-				if (nearestAfld != null)
+				if (nearestResupplier != null)
 					return ActivityUtils.SequenceActivities(
-						new Fly(self, Target.FromActor(nearestAfld), WDist.Zero, aircraft.Info.WaitDistanceFromResupplyBase),
+						new Fly(self, Target.FromActor(nearestResupplier), WDist.Zero, aircraft.Info.WaitDistanceFromResupplyBase),
 						new FlyCircle(self, aircraft.Info.NumberOfTicksToVerifyAvailableAirport),
 						this);
 				else

--- a/OpenRA.Mods.Common/Traits/Air/ReturnOnIdle.cs
+++ b/OpenRA.Mods.Common/Traits/Air/ReturnOnIdle.cs
@@ -36,10 +36,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (self.World.Map.DistanceAboveTerrain(self.CenterPosition).Length < aircraftInfo.MinAirborneAltitude)
 				return;
 
-			var airfield = ReturnToBase.ChooseAirfield(self, true);
-			if (airfield != null)
+			var resupplier = ReturnToBase.ChooseResupplier(self, true);
+			if (resupplier != null)
 			{
-				self.QueueActivity(new ReturnToBase(self, aircraftInfo.AbortOnResupply, airfield));
+				self.QueueActivity(new ReturnToBase(self, aircraftInfo.AbortOnResupply, resupplier));
 				self.QueueActivity(new ResupplyAircraft(self));
 			}
 			else


### PR DESCRIPTION
Generalizing and - where sensible - merging heli and plane activities has long been considered a must to fix long-standing issues and limitations.

All air activities cache `Aircraft`, but usually named as either `plane` or `helicopter` respectively, since that were the original separate trait names. Generalizing this is a first step that is easy to review and allows any future PRs to concentrate on actual logic changes.

Additionally, generalized airfield/helipad references in RTB activities and ReturnOnIdle to generic `resupplier`.