### PR TITLE
Resolve conflicts between actor and API names (Radar)

### DIFF
--- a/mods/cnc/maps/nod05/map.yaml
+++ b/mods/cnc/maps/nod05/map.yaml
@@ -342,7 +342,7 @@ Actors:
 	Tower2: gtwr
 		Location: 23,21
 		Owner: GDI
-	Radar: hq
+	CommCenter: hq
 		Location: 21,14
 		Owner: GDI
 	Silo1: silo

--- a/mods/cnc/maps/nod05/nod05.lua
+++ b/mods/cnc/maps/nod05/nod05.lua
@@ -45,16 +45,16 @@ Gdi12Waypoints = { waypoint0, waypoint1, waypoint3, waypoint11, waypoint12 }
 
 AllWaypoints = { Gdi1Waypoints, Gdi2Waypoints, Gdi3Waypoints, Gdi5Waypoints, Gdi11Waypoints, Gdi12Waypoints }
 
-PrimaryTargets = { Tower1, Tower2, Radar, Silo1, Silo2, Silo3, Refinery, Barracks, Plant1, Plant2, Yard, Factory }
+PrimaryTargets = { Tower1, Tower2, CommCenter, Silo1, Silo2, Silo3, Refinery, Barracks, Plant1, Plant2, Yard, Factory }
 
 GDIStartUnits = { }
 
 SendGDIAirstrike = function()
-	if not Radar.IsDead and Radar.Owner == enemy then
+	if not CommCenter.IsDead and CommCenter.Owner == enemy then
 		local target = getAirstrikeTarget()
 
 		if target then
-			Radar.SendAirstrike(target, false, Facing.NorthEast + 4)
+			CommCenter.SendAirstrike(target, false, Facing.NorthEast + 4)
 			Trigger.AfterDelay(AirstrikeDelay, SendGDIAirstrike)
 		else
 			Trigger.AfterDelay(AirstrikeDelay/4, SendGDIAirstrike)

--- a/mods/cnc/maps/nod06a/map.yaml
+++ b/mods/cnc/maps/nod06a/map.yaml
@@ -638,7 +638,7 @@ Actors:
 	Detonator: CRATE.plain
 		Location: 59,43
 		Owner: GDI
-	Radar: hq
+	CommCenter: hq
 		Location: 57,32
 		Owner: GDI
 	Actor187: jeep

--- a/mods/cnc/maps/nod06a/nod06a.lua
+++ b/mods/cnc/maps/nod06a/nod06a.lua
@@ -91,12 +91,12 @@ end
 Atk3TriggerFunction = function()
 	if not Atk3Switch then
 		Atk3Switch = true
-		if not Radar.IsDead then
+		if not CommCenter.IsDead then
 			local targets = player.GetGroundAttackers()
 			local target = targets[DateTime.GameTime % #targets + 1].CenterPosition
 
 			if target then
-				Radar.SendAirstrike(target, false, Facing.NorthEast + 4)
+				CommCenter.SendAirstrike(target, false, Facing.NorthEast + 4)
 			end
 		end
 	end
@@ -135,7 +135,7 @@ InsertNodUnits = function()
 	local difficulty = Map.LobbyOption("difficulty")
 	NodStartUnitsRight = NodStartUnitsRight[difficulty]
 	NodStartUnitsLeft = NodStartUnitsLeft[difficulty]
-	
+
 	Camera.Position = UnitsRallyRight.CenterPosition
 
 	Media.PlaySpeechNotification(player, "Reinforce")
@@ -183,7 +183,7 @@ WorldLoaded = function()
 	OnAnyDamaged(Atk1ActorTriggerActivator, Atk1TriggerFunction)
 
 	OnAnyDamaged(Atk2ActorTriggerActivator, Atk2TriggerFunction)
-	
+
 	if Map.LobbyOption("difficulty") == "tough" then
 		Trigger.OnDamaged(Atk3Activator, Atk3TriggerFunction)
 	end

--- a/mods/ra/maps/allies-06a/allies06a.lua
+++ b/mods/ra/maps/allies-06a/allies06a.lua
@@ -109,11 +109,11 @@ InitialAlliedReinforcements = function()
 end
 
 CaptureRadarDome = function()
-	Trigger.OnKilled(Radar, function()
+	Trigger.OnKilled(RadarDome, function()
 		player.MarkFailedObjective(CaptureRadarDomeObj)
 	end)
 
-	Trigger.OnCapture(Radar, function()
+	Trigger.OnCapture(RadarDome, function()
 		player.MarkCompletedObjective(CaptureRadarDomeObj)
 		Beacon.New(player, TechLab1.CenterPosition)
 		Beacon.New(player, TechLab2.CenterPosition)

--- a/mods/ra/maps/allies-06a/map.yaml
+++ b/mods/ra/maps/allies-06a/map.yaml
@@ -630,7 +630,7 @@ Actors:
 	Refinery: proc
 		Location: 81,90
 		Owner: USSR
-	Radar: dome
+	RadarDome: dome
 		Location: 20,83
 		Owner: USSR
 	WeaponMeetPoint: waypoint

--- a/mods/ra/maps/allies-06b/allies06b.lua
+++ b/mods/ra/maps/allies-06b/allies06b.lua
@@ -120,11 +120,11 @@ InitialAlliedReinforcements = function()
 end
 
 CaptureRadarDome = function()
-	Trigger.OnKilled(Radar, function()
+	Trigger.OnKilled(RadarDome, function()
 		player.MarkFailedObjective(CaptureRadarDomeObj)
 	end)
 
-	Trigger.OnCapture(Radar, function()
+	Trigger.OnCapture(RadarDome, function()
 		player.MarkCompletedObjective(CaptureRadarDomeObj)
 		Beacon.New(player, TechLab1.CenterPosition)
 		Beacon.New(player, TechLab2.CenterPosition)

--- a/mods/ra/maps/allies-06b/map.yaml
+++ b/mods/ra/maps/allies-06b/map.yaml
@@ -618,7 +618,7 @@ Actors:
 	Refinery: proc
 		Location: 68,35
 		Owner: USSR
-	Radar: dome
+	RadarDome: dome
 		Location: 75,86
 		Owner: USSR
 	Radar2: dome

--- a/mods/ra/maps/soviet-04a/map.yaml
+++ b/mods/ra/maps/soviet-04a/map.yaml
@@ -415,7 +415,7 @@ Actors:
 	Actor159: mine
 		Location: 77,46
 		Owner: Neutral
-	Radar: dome
+	RadarDome: dome
 		Location: 49,46
 		Owner: Greece
 	CYard: fact

--- a/mods/ra/maps/soviet-04a/soviet04a-reinforcements_teams.lua
+++ b/mods/ra/maps/soviet-04a/soviet04a-reinforcements_teams.lua
@@ -39,7 +39,7 @@ AttackPaths =
 }
 
 ReinfInf = function()
-	if Radar.IsDead or Radar.Owner ~= Greece then
+	if RadarDome.IsDead or RadarDome.Owner ~= Greece then
 		return
 	end
 
@@ -49,7 +49,7 @@ ReinfInf = function()
 end
 
 ReinfArmor = function()
-	if not Radar.IsDead and Radar.Owner == Greece then
+	if not RadarDome.IsDead and RadarDome.Owner == Greece then
 		RCheck = true
 		Reinforcements.Reinforce(Greece, ArmorReinfGreece, ArmorReinfPath, 0, function(soldier)
 			soldier.Hunt()
@@ -58,7 +58,7 @@ ReinfArmor = function()
 end
 
 BringPatrol1 = function()
-	if Radar.IsDead or Radar.Owner ~= Greece then
+	if RadarDome.IsDead or RadarDome.Owner ~= Greece then
 		return
 	end
 
@@ -77,7 +77,7 @@ BringPatrol1 = function()
 end
 
 BringPatrol2 = function()
-	if Radar.IsDead or Radar.Owner ~= Greece then
+	if RadarDome.IsDead or RadarDome.Owner ~= Greece then
 		return
 	end
 

--- a/mods/ra/maps/soviet-04a/soviet04a.lua
+++ b/mods/ra/maps/soviet-04a/soviet04a.lua
@@ -154,7 +154,7 @@ WorldLoaded = function()
 		Media.PlaySpeechNotification(player, "Win")
 	end)
 
-	Trigger.OnKilled(Radar, function()
+	Trigger.OnKilled(RadarDome, function()
 		player.MarkCompletedObjective(KillRadar)
 		Media.PlaySpeechNotification(player, "ObjectiveMet")
 	end)

--- a/mods/ra/maps/soviet-04b/map.yaml
+++ b/mods/ra/maps/soviet-04b/map.yaml
@@ -482,7 +482,7 @@ Actors:
 	Actor169: mine
 		Location: 91,87
 		Owner: Neutral
-	Radar: dome
+	RadarDome: dome
 		Location: 111,50
 		Owner: Greece
 	Pbox1: pbox

--- a/mods/ra/maps/soviet-04b/soviet04b-reinforcements_teams.lua
+++ b/mods/ra/maps/soviet-04b/soviet04b-reinforcements_teams.lua
@@ -39,7 +39,7 @@ AttackPaths =
 }
 
 ReinfInf = function()
-	if Radar.IsDead or Radar.Owner ~= Greece then
+	if RadarDome.IsDead or RadarDome.Owner ~= Greece then
 		return
 	end
 
@@ -49,7 +49,7 @@ ReinfInf = function()
 end
 
 ReinfArmor = function()
-	if not Radar.IsDead and Radar.Owner == Greece then
+	if not RadarDome.IsDead and RadarDome.Owner == Greece then
 		RCheck = true
 		Reinforcements.Reinforce(Greece, ArmorReinfGreece, InfReinfPath, 0, function(soldier)
 			soldier.Hunt()
@@ -58,7 +58,7 @@ ReinfArmor = function()
 end
 
 BringPatrol1 = function()
-	if Radar.IsDead or Radar.Owner ~= Greece then
+	if RadarDome.IsDead or RadarDome.Owner ~= Greece then
 		return
 	end
 
@@ -77,7 +77,7 @@ BringPatrol1 = function()
 end
 
 BringPatrol2 = function()
-	if Radar.IsDead or Radar.Owner ~= Greece then
+	if RadarDome.IsDead or RadarDome.Owner ~= Greece then
 		return
 	end
 

--- a/mods/ra/maps/soviet-04b/soviet04b.lua
+++ b/mods/ra/maps/soviet-04b/soviet04b.lua
@@ -139,7 +139,7 @@ WorldLoaded = function()
 		Media.PlaySpeechNotification(player, "Win")
 	end)
 
-	Trigger.OnKilled(Radar, function()
+	Trigger.OnKilled(RadarDome, function()
 		player.MarkCompletedObjective(KillRadar)
 		Media.PlaySpeechNotification(player, "ObjectiveMet")
 	end)

--- a/mods/ra/maps/soviet-05/map.yaml
+++ b/mods/ra/maps/soviet-05/map.yaml
@@ -225,7 +225,7 @@ Actors:
 		Location: 69,49
 		Owner: Greece
 		Facing: 32
-	Radar: dome
+	RadarDome: dome
 		Location: 70,45
 		Owner: France
 	Actor57: fact

--- a/mods/ra/maps/soviet-05/soviet05.lua
+++ b/mods/ra/maps/soviet-05/soviet05.lua
@@ -214,7 +214,7 @@ WorldLoaded = function()
 	Trigger.OnDamaged(mcvGG, Expand)
 	Trigger.OnDamaged(mcvtransport, Expand)
 
-	Trigger.OnKilled(Radar, function()
+	Trigger.OnKilled(RadarDome, function()
 		if not player.IsObjectiveCompleted(CaptureObjective) then
 			player.MarkFailedObjective(CaptureObjective)
 		end
@@ -224,8 +224,8 @@ WorldLoaded = function()
 		end
 	end)
 
-	Radar.GrantCondition("french")
-	Trigger.OnCapture(Radar, function()
+	RadarDome.GrantCondition("french")
+	Trigger.OnCapture(RadarDome, function()
 		HoldObjective = player.AddPrimaryObjective("Defend the Radar Dome.")
 		player.MarkCompletedObjective(CaptureObjective)
 		Beacon.New(player, MCVDeploy.CenterPosition)
@@ -244,17 +244,17 @@ WorldLoaded = function()
 
 		Reinforcements.Reinforce(Greece, ArmorReinfGreece, AlliedCrossroadsToRadarPath , 0, IdleHunt)
 
-		Radar.RevokeCondition(1)
-		Trigger.ClearAll(Radar)
+		RadarDome.RevokeCondition(1)
+		Trigger.ClearAll(RadarDome)
 		Trigger.AfterDelay(0, function()
-			Trigger.OnRemovedFromWorld(Radar, function()
+			Trigger.OnRemovedFromWorld(RadarDome, function()
 				player.MarkFailedObjective(HoldObjective)
 			end)
 		end)
 	end)
 
 	Trigger.OnEnteredProximityTrigger(USSRExpansionPoint.CenterPosition, WDist.New(4 * 1024), function(unit, id)
-		if unit.Owner == player and Radar.Owner == player then
+		if unit.Owner == player and RadarDome.Owner == player then
 			Trigger.RemoveProximityTrigger(id)
 
 			Para2()


### PR DESCRIPTION
Fixes #15449.

#15359 added `Radar` as part of the API, which conflicted with actor names in the broken missions.