### PR TITLE
RenderNametag trait is now conditional and implements INotifyCapture

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/RenderNameTag.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderNameTag.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var spaceBuffer = (int)(10 / wr.Viewport.Zoom);
 			var effectPos = wr.ProjectedPosition(new int2((bounds.Left + bounds.Right) / 2, bounds.Y - spaceBuffer));
 
-			return new IRenderable[] { new TextRenderable(font, effectPos, 0, color, name) };
+			return new IRenderable[] { new TextRenderable(font, effectPos, 4096, color, name) };
 		}
 
 		IEnumerable<Rectangle> IRender.ScreenBounds(Actor self, WorldRenderer wr)

--- a/OpenRA.Mods.Common/Traits/Render/RenderNameTag.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderNameTag.cs
@@ -18,17 +18,19 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
 {
-	[Desc("Displays the player name above the unit")]
-	class RenderNameTagInfo : ITraitInfo, Requires<IDecorationBoundsInfo>
+	[Desc("Displays the player's name above the actor.")]
+	class RenderNameTagInfo : ConditionalTraitInfo, Requires<IDecorationBoundsInfo>
 	{
+		[Desc("Maximum length of name tag shown.")]
 		public readonly int MaxLength = 10;
 
+		[Desc("Font used for name tag.")]
 		public readonly string Font = "TinyBold";
 
-		public object Create(ActorInitializer init) { return new RenderNameTag(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new RenderNameTag(init.Self, this); }
 	}
 
-	class RenderNameTag : IRender
+	class RenderNameTag : ConditionalTrait<RenderNameTagInfo>, IRender
 	{
 		readonly SpriteFont font;
 		readonly Color color;
@@ -36,6 +38,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		readonly IDecorationBounds[] decorationBounds;
 
 		public RenderNameTag(Actor self, RenderNameTagInfo info)
+			: base(info)
 		{
 			font = Game.Renderer.Fonts[info.Font];
 			color = self.Owner.Color.RGB;
@@ -50,6 +53,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)
 		{
+			if (IsTraitDisabled)
+				return SpriteRenderable.None;
+
 			var bounds = decorationBounds.FirstNonEmptyBounds(self, wr);
 			var spaceBuffer = (int)(10 / wr.Viewport.Zoom);
 			var effectPos = wr.ProjectedPosition(new int2((bounds.Left + bounds.Right) / 2, bounds.Y - spaceBuffer));

--- a/OpenRA.Mods.Common/Traits/Render/RenderNameTag.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderNameTag.cs
@@ -30,25 +30,34 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new RenderNameTag(init.Self, this); }
 	}
 
-	class RenderNameTag : ConditionalTrait<RenderNameTagInfo>, IRender
+	class RenderNameTag : ConditionalTrait<RenderNameTagInfo>, INotifyCapture, IRender
 	{
+		readonly RenderNameTagInfo info;
 		readonly SpriteFont font;
-		readonly Color color;
-		readonly string name;
 		readonly IDecorationBounds[] decorationBounds;
+
+		string nameTag;
+		Color color;
 
 		public RenderNameTag(Actor self, RenderNameTagInfo info)
 			: base(info)
 		{
+			this.info = info;
 			font = Game.Renderer.Fonts[info.Font];
-			color = self.Owner.Color.RGB;
-
-			if (self.Owner.PlayerName.Length > info.MaxLength)
-				name = self.Owner.PlayerName.Substring(0, info.MaxLength);
-			else
-				name = self.Owner.PlayerName;
-
 			decorationBounds = self.TraitsImplementing<IDecorationBounds>().ToArray();
+
+			UpdateNameTag(self.Owner);
+		}
+
+		void UpdateNameTag(Player owner)
+		{
+			nameTag = owner.PlayerName.Length > info.MaxLength ? owner.PlayerName.Substring(0, info.MaxLength) : owner.PlayerName;
+			color = owner.Color.RGB;
+		}
+
+		void INotifyCapture.OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner)
+		{
+			UpdateNameTag(newOwner);
 		}
 
 		public IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)
@@ -60,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var spaceBuffer = (int)(10 / wr.Viewport.Zoom);
 			var effectPos = wr.ProjectedPosition(new int2((bounds.Left + bounds.Right) / 2, bounds.Y - spaceBuffer));
 
-			return new IRenderable[] { new TextRenderable(font, effectPos, 4096, color, name) };
+			return new IRenderable[] { new TextRenderable(font, effectPos, 4096, color, nameTag) };
 		}
 
 		IEnumerable<Rectangle> IRender.ScreenBounds(Actor self, WorldRenderer wr)

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -295,6 +295,8 @@
 	HitShape:
 	EditorTilesetFilter:
 		Categories: Vehicle
+	RenderNameTag:
+		RequiresCondition: !invulnerability
 
 ^TrackedVehicle:
 	Inherits: ^Vehicle
@@ -631,6 +633,8 @@
 	EditorTilesetFilter:
 		Categories: Building
 	CommandBarBlacklist:
+	RenderNameTag:
+		RequiresCondition: !invulnerability
 
 ^Building:
 	Inherits: ^BasicBuilding


### PR DESCRIPTION
A few changes for RenderNametag broken by commits:
- Trait is now conditional.
- Fixes the tag's zIndex to appear above nearby units.
- Trait now implements INotifyCaptured, to support updating if an actor's owner changes.

A test case is committed, which makes the name tag appear on all buildings and vehicles unless they are invulnerable.

This is a mod-unused trait that displays the player's name above an actor, originally made for sole survivor type game modes.

![image](https://user-images.githubusercontent.com/566742/43753347-80ea2b6e-99c2-11e8-8fde-9843fc9c7e40.png)

