### PR TITLE
Realign turrets before undeploying

### DIFF
--- a/OpenRA.Mods.Common/Activities/UndeployForGrantedCondition.cs
+++ b/OpenRA.Mods.Common/Activities/UndeployForGrantedCondition.cs
@@ -24,8 +24,24 @@ namespace OpenRA.Mods.Common.Activities
 			this.deploy = deploy;
 		}
 
+		protected override void OnFirstRun(Actor self)
+		{
+			var tInfo = self.Info.TraitInfoOrDefault<TurretedInfo>();
+			if (tInfo != null)
+				QueueChild(new WaitForTurretAlignment(self, tInfo.InitialFacing));
+		}
+
 		public override Activity Tick(Actor self)
 		{
+			if (ChildActivity != null)
+			{
+				ActivityUtils.RunActivity(self, ChildActivity);
+				return this;
+			}
+
+			if (IsCanceled)
+				return NextActivity;
+
 			IsInterruptible = false; // must DEPLOY from now.
 			deploy.Undeploy();
 

--- a/OpenRA.Mods.Common/Activities/WaitForTurretAlignment.cs
+++ b/OpenRA.Mods.Common/Activities/WaitForTurretAlignment.cs
@@ -1,0 +1,42 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Activities;
+using OpenRA.Mods.Common.Traits;
+
+namespace OpenRA.Mods.Common.Activities
+{
+    public class WaitForTurretAlignment : Activity
+    {
+        readonly Turreted turreted;
+        readonly int desiredAlignment;
+
+        public WaitForTurretAlignment(Actor self, int desiredAlignment)
+        {
+            this.turreted = self.Trait<Turreted>();
+            this.desiredAlignment = desiredAlignment;
+        }
+
+        protected override void OnFirstRun(Actor self)
+        {
+            turreted.StopAiming(self);
+        }
+
+        public override Activity Tick(Actor self)
+        {
+            turreted.DesiredFacing = desiredAlignment;
+            if (turreted.HasAchievedDesiredFacing)
+                return NextActivity;
+            return this;
+        }
+    }
+}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Activities\UnloadCargo.cs" />
     <Compile Include="Activities\Wait.cs" />
     <Compile Include="Activities\WaitForTransport.cs" />
+    <Compile Include="Activities\WaitForTurretAlignment.cs" />
     <Compile Include="ActorExts.cs" />
     <Compile Include="AI\AIUtils.cs" />
     <Compile Include="AI\AttackOrFleeFuzzy.cs" />

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -156,6 +156,12 @@ namespace OpenRA.Mods.Common.Traits
 			return HasAchievedDesiredFacing;
 		}
 
+		public void StopAiming(Actor self)
+		{
+			if (attack.IsAiming)
+				attack.OnStopOrder(self);
+		}
+
 		public virtual bool HasAchievedDesiredFacing
 		{
 			get { return DesiredFacing == null || TurretFacing == DesiredFacing.Value; }


### PR DESCRIPTION
Units that have one or more turrets when deployed now move their turrets back to their initial positions before undeploying.

I also thought it made sense to support being able to stop the realigning if a cancel order is given. However, I ended up having to use `World.AddFrameEndTask` to set `DesiredFacingOverride` due to Turreted.FaceTarget being called later in the same frame and overwriting the DesiredFacing value that WaitForTurretAlignment sets when it's finished. Here's the line:
```csharp
self.World.AddFrameEndTask(_ => turreted.DesiredFacingOverride = false);
```
 I'm **making the assumption** that the turreted instance can't get destroyed if the actor is destroyed before the end of the frame. Is this right?

Resolves #13285

Edit:
Got rid of the logic to stop the turret orienting when a cancel order occurs since this should probably be handled more generically. 