### PR TITLE
Remove CNC95Launcher.exe from the IDFiles of the origin cnc install

### DIFF
--- a/mods/cnc/installer/origin.yaml
+++ b/mods/cnc/installer/origin.yaml
@@ -4,7 +4,6 @@ origin: C&C The Ultimate Collection (Origin version, English)
 	RegistryKey: EA Games\CNC and The Covert Operations
 	RegistryValue: Install Dir
 	IDFiles:
-		CNC95Launcher.exe: 1d711adf09ac08738b2599b3092a1b448169b32a
 		CONQUER.MIX: 833e02a09aae694659eb312d3838367f681d1b30
 	Install:
 		copy: .

--- a/mods/ra/installer/origin.yaml
+++ b/mods/ra/installer/origin.yaml
@@ -463,7 +463,6 @@ cnc-origin: Command & Conquer (Origin version, English)
 	RegistryKey: EA Games\CNC and The Covert Operations
 	RegistryValue: Install Dir
 	IDFiles:
-		CNC95Launcher.exe: 1d711adf09ac08738b2599b3092a1b448169b32a
 		CONQUER.MIX: 833e02a09aae694659eb312d3838367f681d1b30
 	Install:
 		copy: .

--- a/mods/ra/installer/origin.yaml
+++ b/mods/ra/installer/origin.yaml
@@ -4,7 +4,6 @@ ra-origin: C&C The Ultimate Collection (Origin version, English)
 	RegistryKey: EA Games\Command and Conquer Red Alert
 	RegistryValue: Install Dir
 	IDFiles:
-		RA95Launcher.exe: 22bf7a1f9f1c2498823e3216541e6012f291c2c0
 		REDALERT.MIX: 0e58f4b54f44f6cd29fecf8cf379d33cf2d4caef
 	Install:
 		copy: .

--- a/mods/ts/installer/origin.yaml
+++ b/mods/ts/installer/origin.yaml
@@ -4,7 +4,6 @@ origin: C&C The Ultimate Collection (Origin version, English)
 	RegistryKey: EA Games\Command and Conquer Tiberian Sun
 	RegistryValue: Install Dir
 	IDFiles:
-		TSLauncher.exe: 0b3e8dfd7cb701868eccef3ba3717a1ced802707
 		GDFBinary_en_US.dll: 4bb56a449bd0003e7ae67625d90a11ae169319d6
 	Install:
 		copy: .


### PR DESCRIPTION
Closes #15445.