### PR TITLE
Add a hard requirement on the cert-sync utility.

### DIFF
--- a/packaging/linux/AppRun.in
+++ b/packaging/linux/AppRun.in
@@ -4,7 +4,7 @@
 MINIMUM_MONO_VERSION="4.2"
 
 prompt_apt_install_mono_complete() {
-  command -v mono >/dev/null 2>&1 && return 1
+  command -v mono >/dev/null 2>&1 && command -v cert-sync >/dev/null 2>&1 && return 1
   command -v apt-cache > /dev/null || return 1
   command -v xdg-mime > /dev/null || return 1
   command -v xdg-open > /dev/null || return 1
@@ -19,6 +19,7 @@ make_version() {
 
 mono_missing_or_old() {
   command -v mono >/dev/null 2>&1 || return 0
+  command -v cert-sync >/dev/null 2>&1 || return 0
   MONO_VERSION=$(mono --version | head -n1 | cut -d' ' -f5)
   [ "$(make_version "${MONO_VERSION}")" -lt "$(make_version "${MINIMUM_MONO_VERSION}")" ] && return 0
   return 1
@@ -43,7 +44,7 @@ if prompt_apt_install_mono_complete; then
 fi
 
 if mono_missing_or_old; then
-  ERROR_MESSAGE="{MODNAME} requires Mono ${MINIMUM_MONO_VERSION} or greater.\nPlease install Mono using your system package manager.\n\nSee http://wiki.openra.net/AppImages for more information."
+  ERROR_MESSAGE="{MODNAME} requires Mono ${MINIMUM_MONO_VERSION} or greater and the cert-sync utility.\nPlease install Mono using your system package manager.\n\nSee http://wiki.openra.net/AppImages for more information."
   if command -v zenity > /dev/null; then
     zenity --no-wrap --error --title "{MODNAME}" --text "${ERROR_MESSAGE}" 2> /dev/null
   elif command -v kdialog > /dev/null; then


### PR DESCRIPTION
Closes #15450.

Tested and confirmed that this produces the desired behaviour (prompting `mono-complete` install) on a default Linux Mint installation, and that this doesn't change behaviour on Ubuntu1804/CentOS7/Fedora28.