### PR TITLE
Simplify and fix master server ping logic

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -170,7 +170,6 @@ namespace OpenRA.Server
 				Log.Write("server", "Initial mod: {0}", ModData.Manifest.Id);
 				Log.Write("server", "Initial map: {0}", LobbyInfo.GlobalSettings.Map);
 
-				var timeout = serverTraits.WithInterface<ITick>().Min(t => t.TickTimeout);
 				for (;;)
 				{
 					var checkRead = new List<Socket>();
@@ -180,7 +179,9 @@ namespace OpenRA.Server
 					checkRead.AddRange(Conns.Select(c => c.Socket));
 					checkRead.AddRange(PreConns.Select(c => c.Socket));
 
-					var localTimeout = waitingForAuthenticationCallback > 0 ? 100000 : timeout;
+					// Block for at most 1 second in order to guarantee a minimum tick rate for ServerTraits
+					// Decrease this to 100ms to improve responsiveness if we are waiting for an authentication query
+					var localTimeout = waitingForAuthenticationCallback > 0 ? 100000 : 1000000;
 					if (checkRead.Count > 0)
 						Socket.Select(checkRead, null, null, localTimeout);
 

--- a/OpenRA.Game/Server/TraitInterfaces.cs
+++ b/OpenRA.Game/Server/TraitInterfaces.cs
@@ -23,11 +23,7 @@ namespace OpenRA.Server
 	public interface IStartGame { void GameStarted(Server server); }
 	public interface IClientJoined { void ClientJoined(Server server, Connection conn); }
 	public interface IEndGame { void GameEnded(Server server); }
-	public interface ITick
-	{
-		void Tick(Server server);
-		int TickTimeout { get; }
-	}
+	public interface ITick { void Tick(Server server); }
 
 	public abstract class ServerTrait { }
 

--- a/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/MasterServerPinger.cs
@@ -33,8 +33,6 @@ namespace OpenRA.Mods.Common.Server
 			{ 2, "Server name contains a blacklisted word." }
 		};
 
-		public int TickTimeout { get { return MasterPingInterval * 10000; } }
-
 		long lastPing = 0;
 		bool isInitialPing = true;
 


### PR DESCRIPTION
Fixes #15477 and removes a very old wart from the server code.

There are two key points to understanding this PR:
* `MasterServerPinger` historically tried to update the master server ASAP when something changes.  This is paired with a rate limit to stop the master server from being hammered: if the server data changes again while the first ping is in process, then the subsequent pings are ignored.  This is obviously a very bad idea, and historically only worked out of luck. A recent change (didn't follow up to find which one) changed the order that the `MasterServerPinger` is notified, and it now tries to send a ping immediately before the server state is updated.  The rate limiter then, more often than not, discards the ping containing the server state update (lobby &rarr; started or started &rarr; complete).  The stale state lingers for three minutes until the next heartbeat ping finally syncs the correct state, causing #15477.
* The server's run loop is driven by the `Socket.Select` call, which blocks until data is received from at least one connection or a given timeout (defined in microseconds) expires.  This means that there is no guarantee at all for when a `ServerTrait`'s `ITick` implementation is going to be called.  `TickTimeout` was added so that the `MasterServerPinger` could force the loop to run at least once every 3 minutes.  The authentication PR added a hack to reduce this to 100ms if it is waiting on a response to process.  On closer inspection, `MasterServerPinger`'s `TickTimeout` doesn't actually work, and the tick call runs every ~500ms anyway.

The first commit removes the unnecessary complexity of asking the ServerTraits for a timeout, and instead hardcodes a value of 1s normally or 0.1s when waiting for an auth callback.

The second commit moves the ping logic into `ITick.Tick` and change all the update triggers to set a timestamp.  We then use this timestamp to decide when to update the master server (and LAN clients), with duplicate pings in a single tick now sending the *final* state instead of something inconsistent in the middle.