### PR TITLE
(RA Balance) Revert ranger change and dial back missile sub damage

### DIFF
--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -409,8 +409,8 @@ JEEP:
 	WithSpriteTurret:
 	Cargo:
 		Types: Infantry
-		MaxWeight: 2
-		PipCount: 2
+		MaxWeight: 1
+		PipCount: 1
 		LoadingCondition: notmobile
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -277,7 +277,7 @@ TorpTube:
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Versus:
 			None: 40
-			Wood: 80
+			Wood: 50
 			Light: 30
 			Heavy: 30
 			Concrete: 100


### PR DESCRIPTION
After getting feedback before and during the playtest, I've decided to revert one change and dial back another from #15091

- I'm reducing the missile sub vs wood buff to 10%.
The missile sub sees a lot more use in team games than competitive matches. While I still stand by the fact that missile sub damage vs wood is currently laughable, I feel the need to dial back things considering the effectiveness of siege units in non-competitive play.

- I'm reverting the ranger's extra passenger seat because I've seen the possibilities of the ranger IFV in action now, and I'd like to leave the door open for it.