### PR TITLE
Fix Chronoshifted units not returning to their origin

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/Teleport.cs
+++ b/OpenRA.Mods.Cnc/Activities/Teleport.cs
@@ -15,6 +15,7 @@ using OpenRA.Activities;
 using OpenRA.Mods.Cnc.Traits;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Render;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Activities
@@ -23,12 +24,16 @@ namespace OpenRA.Mods.Cnc.Activities
 	{
 		readonly Actor teleporter;
 		readonly int? maximumDistance;
+		readonly bool killOnFailure;
+		readonly BitSet<DamageType> killDamageTypes;
 		CPos destination;
 		bool killCargo;
 		bool screenFlash;
 		string sound;
 
-		public Teleport(Actor teleporter, CPos destination, int? maximumDistance, bool killCargo, bool screenFlash, string sound)
+		public Teleport(Actor teleporter, CPos destination, int? maximumDistance,
+			bool killCargo, bool screenFlash, string sound, bool interruptable = true,
+			bool killOnFailure = false, BitSet<DamageType> killDamageTypes = default(BitSet<DamageType>))
 		{
 			var max = teleporter.World.Map.Grid.MaximumTileSearchRange;
 			if (maximumDistance > max)
@@ -40,17 +45,32 @@ namespace OpenRA.Mods.Cnc.Activities
 			this.killCargo = killCargo;
 			this.screenFlash = screenFlash;
 			this.sound = sound;
+			this.killOnFailure = killOnFailure;
+			this.killDamageTypes = killDamageTypes;
+
+			if (!interruptable)
+				IsInterruptible = false;
 		}
 
 		public override Activity Tick(Actor self)
 		{
 			var pc = self.TraitOrDefault<PortableChrono>();
 			if (teleporter == self && pc != null && !pc.CanTeleport)
+			{
+				if (killOnFailure)
+					self.Kill(teleporter, killDamageTypes);
+
 				return NextActivity;
+			}
 
 			var bestCell = ChooseBestDestinationCell(self, destination);
 			if (bestCell == null)
+			{
+				if (killOnFailure)
+					self.Kill(teleporter, killDamageTypes);
+
 				return NextActivity;
+			}
 
 			destination = bestCell.Value;
 

--- a/OpenRA.Mods.Cnc/Activities/Teleport.cs
+++ b/OpenRA.Mods.Cnc/Activities/Teleport.cs
@@ -19,8 +19,6 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Activities
 {
-	public interface IPreventsTeleport { bool PreventsTeleport(Actor self); }
-
 	public class Teleport : Activity
 	{
 		readonly Actor teleporter;
@@ -49,10 +47,6 @@ namespace OpenRA.Mods.Cnc.Activities
 			var pc = self.TraitOrDefault<PortableChrono>();
 			if (teleporter == self && pc != null && !pc.CanTeleport)
 				return NextActivity;
-
-			foreach (var condition in self.TraitsImplementing<IPreventsTeleport>())
-				if (condition.PreventsTeleport(self))
-					return NextActivity;
 
 			var bestCell = ChooseBestDestinationCell(self, destination);
 			if (bestCell == null)

--- a/OpenRA.Mods.Cnc/Scripting/Properties/ChronosphereProperties.cs
+++ b/OpenRA.Mods.Cnc/Scripting/Properties/ChronosphereProperties.cs
@@ -17,9 +17,9 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Scripting
 {
 	[ScriptPropertyGroup("Support Powers")]
-	public class ChronsphereProperties : ScriptActorProperties, Requires<ChronoshiftPowerInfo>
+	public class ChronosphereProperties : ScriptActorProperties, Requires<ChronoshiftPowerInfo>
 	{
-		public ChronsphereProperties(ScriptContext context, Actor self)
+		public ChronosphereProperties(ScriptContext context, Actor self)
 			: base(context, self) { }
 
 		[Desc("Chronoshift a group of actors. A duration of 0 will teleport the actors permanently.")]

--- a/OpenRA.Mods.Cnc/Scripting/Properties/ChronosphereProperties.cs
+++ b/OpenRA.Mods.Cnc/Scripting/Properties/ChronosphereProperties.cs
@@ -37,7 +37,9 @@ namespace OpenRA.Mods.Cnc.Scripting
 							kv.Key.WrappedClrType().Name, kv.Value.WrappedClrType().Name));
 				}
 
-				var cs = actor.TraitOrDefault<Chronoshiftable>();
+				var cs = actor.TraitsImplementing<Chronoshiftable>()
+					.FirstEnabledTraitOrDefault();
+
 				if (cs != null && cs.CanChronoshiftTo(actor, cell))
 					cs.Teleport(actor, cell, duration, killCargo, Self);
 			}

--- a/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
+++ b/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Drawing;
+using OpenRA.Activities;
 using OpenRA.Mods.Cnc.Activities;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
@@ -24,7 +25,8 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Should the actor die instead of being teleported?")]
 		public readonly bool ExplodeInstead = false;
 
-		[Desc("Types of damage that this trait causes to self when 'ExplodeInstead' is true. Leave empty for no damage types.")]
+		[Desc("Types of damage that this trait causes to self when 'ExplodeInstead' is true",
+			"or the return-to-origin is blocked. Leave empty for no damage types.")]
 		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
 
 		public readonly string ChronoshiftSound = "chrono2.aud";
@@ -78,7 +80,10 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (--ReturnTicks == 0)
 			{
 				self.CancelActivity();
-				self.QueueActivity(new Teleport(chronosphere, Origin, null, killCargo, true, Info.ChronoshiftSound));
+
+				// The actor is killed using Info.DamageTypes if the teleport fails
+				self.QueueActivity(new Teleport(chronosphere, Origin, null, true, killCargo, Info.ChronoshiftSound,
+					false, true, Info.DamageTypes));
 			}
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
+++ b/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
@@ -11,6 +11,7 @@
 
 using System.Drawing;
 using OpenRA.Mods.Cnc.Activities;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -18,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Can be teleported via Chronoshift power.")]
-	public class ChronoshiftableInfo : ITraitInfo
+	public class ChronoshiftableInfo : ConditionalTraitInfo
 	{
 		[Desc("Should the actor die instead of being teleported?")]
 		public readonly bool ExplodeInstead = false;
@@ -37,9 +38,9 @@ namespace OpenRA.Mods.Cnc.Traits
 		public object Create(ActorInitializer init) { return new Chronoshiftable(init, this); }
 	}
 
-	public class Chronoshiftable : ITick, ISync, ISelectionBar, IDeathActorInitModifier, ITransformActorInitModifier, INotifyCreated
+	public class Chronoshiftable : ConditionalTrait<ChronoshiftableInfo>, ITick, ISync, ISelectionBar,
+		IDeathActorInitModifier, ITransformActorInitModifier, INotifyCreated
 	{
-		readonly ChronoshiftableInfo info;
 		readonly Actor self;
 		Actor chronosphere;
 		bool killCargo;
@@ -51,8 +52,8 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Sync] public int ReturnTicks = 0;
 
 		public Chronoshiftable(ActorInitializer init, ChronoshiftableInfo info)
+			: base(info)
 		{
-			this.info = info;
 			self = init.Self;
 
 			if (init.Contains<ChronoshiftReturnInit>())
@@ -70,7 +71,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		void ITick.Tick(Actor self)
 		{
-			if (!info.ReturnToOrigin || ReturnTicks <= 0)
+			if (IsTraitDisabled || !Info.ReturnToOrigin || ReturnTicks <= 0)
 				return;
 
 			// Return to original location

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -50,6 +50,10 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		[VoiceReference] public readonly string Voice = "Action";
 
+		[GrantedConditionReference]
+		[Desc("The condition to grant to self while deployed.")]
+		public readonly string DeployedCondition = null;
+
 		public WeaponInfo ThumpDamageWeaponInfo { get; private set; }
 		public WeaponInfo DetonationWeaponInfo { get; private set; }
 
@@ -75,12 +79,13 @@ namespace OpenRA.Mods.Cnc.Traits
 		}
 	}
 
-	class MadTank : IIssueOrder, IResolveOrder, IOrderVoice, ITick, IPreventsTeleport, IIssueDeployOrder
+	class MadTank : INotifyCreated, IIssueOrder, IResolveOrder, IOrderVoice, ITick, IIssueDeployOrder
 	{
 		readonly Actor self;
 		readonly MadTankInfo info;
 		readonly WithFacingSpriteBody wfsb;
 		readonly ScreenShaker screenShaker;
+		ConditionManager conditionManager;
 		bool deployed;
 		int tick;
 
@@ -90,6 +95,11 @@ namespace OpenRA.Mods.Cnc.Traits
 			this.info = info;
 			wfsb = self.Trait<WithFacingSpriteBody>();
 			screenShaker = self.World.WorldActor.Trait<ScreenShaker>();
+		}
+
+		void INotifyCreated.Created(Actor self)
+		{
+			conditionManager = self.TraitOrDefault<ConditionManager>();
 		}
 
 		void ITick.Tick(Actor self)
@@ -171,6 +181,9 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			if (deployed)
 				return;
+
+			if (conditionManager != null && !string.IsNullOrEmpty(info.DeployedCondition))
+				conditionManager.GrantCondition(self, info.DeployedCondition);
 
 			self.World.AddFrameEndTask(w => EjectDriver());
 			if (info.ThumpSequence != null)

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -65,7 +65,12 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			foreach (var target in UnitsInRange(order.ExtraLocation))
 			{
-				var cs = target.Trait<Chronoshiftable>();
+				var cs = target.TraitsImplementing<Chronoshiftable>()
+					.FirstEnabledTraitOrDefault();
+
+				if (cs == null)
+					continue;
+
 				var targetCell = target.Location + (order.TargetLocation - order.ExtraLocation);
 				var cpi = Info as ChronoshiftPowerInfo;
 
@@ -82,7 +87,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			foreach (var t in tiles)
 				units.UnionWith(Self.World.ActorMap.GetActorsAt(t));
 
-			return units.Where(a => a.Info.HasTraitInfo<ChronoshiftableInfo>() &&
+			return units.Where(a => a.TraitsImplementing<Chronoshiftable>().Any(cs => !cs.IsTraitDisabled) &&
 				!a.TraitsImplementing<IPreventsTeleport>().Any(condition => condition.PreventsTeleport(a)));
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -87,8 +87,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			foreach (var t in tiles)
 				units.UnionWith(Self.World.ActorMap.GetActorsAt(t));
 
-			return units.Where(a => a.TraitsImplementing<Chronoshiftable>().Any(cs => !cs.IsTraitDisabled) &&
-				!a.TraitsImplementing<IPreventsTeleport>().Any(condition => condition.PreventsTeleport(a)));
+			return units.Where(a => a.TraitsImplementing<Chronoshiftable>().Any(cs => !cs.IsTraitDisabled));
 		}
 
 		public bool SimilarTerrain(CPos xy, CPos sourceLocation)

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -769,7 +769,10 @@ QTNK:
 	Armor:
 		Type: Heavy
 	Mobile:
+		RequiresCondition: !deployed
 		Speed: 56
+	Chronoshiftable:
+		RequiresCondition: !deployed
 	RevealsShroud:
 		Range: 6c0
 		RevealGeneratedShroud: False
@@ -777,6 +780,7 @@ QTNK:
 		Range: 4c0
 	SelectionDecorations:
 	MadTank:
+		DeployedCondition: deployed
 	Targetable:
 		TargetTypes: Ground, MADTank, Repair, Vehicle
 	Selectable:


### PR DESCRIPTION
Fixes #8670
Fixes #13059
Fixes #15497

There are 3 cases where the Teleport activity can fail:
1. The unit is a deployed MAD Tank (via the `IPreventsTeleport` interface)
2. There are no free cells within a caller-defined radius of the target.  Note that for the chrono-return case the range is 50 cells, so this should never occur in practice.
3. Described by the source code comment, and also described with screenshots to help in #8670:
   ```
   // The Move activity is not immediately cancelled, which, combined
   // with Activity.Cancel discarding NextActivity without checking the
   // IsInterruptable flag, means that a well timed order can cancel the
   // Teleport activity queued below - an exploit / cheat of the return mechanic.
   ```
   This is the one that causes all our problems.

This PR removes the first case by replacing the `IPreventsTeleport` interface with conditions on `Chronoshiftable`.  The second case is handled by killing the actor in the rare event that it may happen (so there should be no meaningful impact on gameplay behaviour).  The third case is worked around using a dirty but IMO well explained and justified hack in the last commit.

Note that the Chronoshift code lives in Mods.Cnc, and is generally poor quality - the whole thing needs a rewrite.  Implementing this hack gives us a pragmatic medium-term fix until the activity and chronoshift code can be rewritten properly.