### PR TITLE
Fix Cargo>EjectOnDeath crash with multipile INotifyBlockingMove

### DIFF
--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -384,8 +384,8 @@ namespace OpenRA.Mods.Common.Traits
 					if (!inAir && positionable.CanEnterCell(self.Location, self, false))
 					{
 						self.World.AddFrameEndTask(w => w.Add(passenger));
-						var nbm = passenger.TraitOrDefault<INotifyBlockingMove>();
-						if (nbm != null)
+						var nbms = passenger.TraitsImplementing<INotifyBlockingMove>();
+						foreach (var nbm in nbms)
 							nbm.OnNotifyBlockingMove(passenger, passenger);
 					}
 					else


### PR DESCRIPTION
I noticed while working on Combat Cycle passenger logic on Generals Alpha, as Workers were causing a crash. To test you can add EjectOnDeath to LST on RA mod and kill it while it is on a beach tile and a ore truck in it (ore truck has 2 INotifyBlockingMove, one from Mobile, one from Harvester.).