### PR TITLE
Add Engine.SupportDir argument.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -258,6 +258,10 @@ namespace OpenRA
 
 		static void Initialize(Arguments args)
 		{
+			var supportDirArg = args.GetValue("Engine.SupportDir", null);
+			if (supportDirArg != null)
+				Platform.OverrideSupportDir(supportDirArg);
+
 			Console.WriteLine("Platform is {0}", Platform.CurrentPlatform);
 
 			// Load the engine version as early as possible so it can be written to exception logs

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -71,9 +71,30 @@ namespace OpenRA
 		/// </summary>
 		public static string SupportDir { get { return supportDir.Value; } }
 		static Lazy<string> supportDir = Exts.Lazy(GetSupportDir);
+		static string supportDirOverride;
+
+		/// <summary>
+		/// Specify a custom support directory that already exists on the filesystem.
+		/// MUST be called before Platform.SupportDir is first accessed.
+		/// </summary>
+		public static void OverrideSupportDir(string path)
+		{
+			if (!Directory.Exists(path))
+				throw new DirectoryNotFoundException(path);
+
+			if (!path.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal) &&
+					!path.EndsWith(Path.AltDirectorySeparatorChar.ToString(), StringComparison.Ordinal))
+				path += Path.DirectorySeparatorChar;
+
+			supportDirOverride = path;
+		}
 
 		static string GetSupportDir()
 		{
+			// Use the custom override if it has been defined
+			if (supportDirOverride != null)
+				return supportDirOverride;
+
 			// Use a local directory in the game root if it exists (shared with the system support dir)
 			var localSupportDir = Path.Combine(GameDir, "Support");
 			if (Directory.Exists(localSupportDir))

--- a/OpenRA.Server/Program.cs
+++ b/OpenRA.Server/Program.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Threading;
 using OpenRA.Support;
@@ -23,6 +22,10 @@ namespace OpenRA.Server
 		static void Main(string[] args)
 		{
 			var arguments = new Arguments(args);
+			var supportDirArg = arguments.GetValue("Engine.SupportDir", null);
+			if (supportDirArg != null)
+				Platform.OverrideSupportDir(supportDirArg);
+
 			Log.AddChannel("debug", "dedicated-debug.log");
 			Log.AddChannel("perf", "dedicated-perf.log");
 			Log.AddChannel("server", "dedicated-server.log");


### PR DESCRIPTION
@jaZzKCS raised the point in IRC that our AppImage packages can't currently be used for servers where the operator wants to record different logs per instance.

Making life simple for server operators is one of my goals for the AppImages, so this PR aims to solve the problem by introducing a new commandline argument that can be given to set a custom support dir for each instance.  It will also be generally useful for other purposes.

Closes #4043.