### PR TITLE
[TS] Stop order does not stop deployed turreted unit's turret from orienting

### DIFF
--- a/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackTurreted.cs
@@ -46,5 +46,13 @@ namespace OpenRA.Mods.Common.Traits
 
 			return turretReady && base.CanAttack(self, target);
 		}
+
+		public override void OnStopOrder(Actor self)
+		{
+			foreach (var turret in turrets)
+				turret.DesiredFacing = turret.TurretFacing;
+
+			base.OnStopOrder(self);
+		}
 	}
 }


### PR DESCRIPTION
If a turreted unit was given a cancel order while it was orienting towards a target, it would not stop orienting even though all other units have this behavior. I think this only affects the tick tank, nod artillery, and the juggernaut.

Resolves #15508