### PR TITLE
Allow mods to determine associated SuperPower from SelectGenericPowerTarget

### DIFF
--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -265,6 +265,8 @@ namespace OpenRA.Mods.Common.Traits
 		readonly string cursor;
 		readonly MouseButton expectedButton;
 
+		public string OrderKey { get { return order; } }
+
 		public SelectGenericPowerTarget(string order, SupportPowerManager manager, string cursor, MouseButton button)
 		{
 			// Clear selection if using Left-Click Orders


### PR DESCRIPTION
In my case, my UI does this on the specific button:
```csharp
IsActive = () =>
{
	var og = sidebar.IngameUi.World.OrderGenerator as SelectGenericPowerTarget;
	return og != null && og.OrderKey == power.Key;
},
```