### PR TITLE
Support multiple buildings per cell.

### DIFF
--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -161,12 +161,11 @@ namespace OpenRA.Mods.Common.Orders
 
 		bool AcceptsPlug(CPos cell, PlugInfo plug)
 		{
-			var host = buildingInfluence.GetBuildingAt(cell);
-			if (host == null)
+			var hosts = buildingInfluence.GetBuildingsAt(cell);
+			if (hosts == null || !hosts.Any())
 				return false;
 
-			var location = host.Location;
-			return host.TraitsImplementing<Pluggable>().Any(p => location + p.Info.Offset == cell && p.AcceptsPlug(host, plug.Type));
+			return hosts.Any(host => host.TraitsImplementing<Pluggable>().Any(p => host.Location + p.Info.Offset == cell && p.AcceptsPlug(host, plug.Type)));
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -139,7 +139,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!LandableTerrainTypes.Contains(type))
 				return false;
 
-			if (world.WorldActor.Trait<BuildingInfluence>().GetBuildingAt(cell) != null)
+			var buildings = world.WorldActor.Trait<BuildingInfluence>().GetBuildingsAt(cell);
+			if (buildings != null && buildings.Any())
 				return false;
 
 			if (!checkTransientActors)

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -200,9 +200,9 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					var pos = new CPos(x, y);
 
-					var buildingAtPos = bi.GetBuildingAt(pos);
+					var buildingsAtPos = bi.GetBuildingsAt(pos);
 
-					if (buildingAtPos == null)
+					if (buildingsAtPos == null || !buildingsAtPos.Any())
 					{
 						var unitsAtPos = world.ActorMap.GetActorsAt(pos).Where(a => a.IsInWorld
 							&& (a.Owner == p || (allyBuildEnabled && a.Owner.Stances[p] == Stance.Ally))
@@ -211,9 +211,11 @@ namespace OpenRA.Mods.Common.Traits
 						if (unitsAtPos.Any())
 							nearnessCandidates.Add(pos);
 					}
-					else if (buildingAtPos.IsInWorld && ActorGrantsValidArea(buildingAtPos, requiresBuildableArea)
-						&& (buildingAtPos.Owner == p || (allyBuildEnabled && buildingAtPos.Owner.Stances[p] == Stance.Ally)))
-						nearnessCandidates.Add(pos);
+					else
+						foreach (var buildingAtPos in buildingsAtPos)
+							if (buildingAtPos.IsInWorld && ActorGrantsValidArea(buildingAtPos, requiresBuildableArea)
+								&& (buildingAtPos.Owner == p || (allyBuildEnabled && buildingAtPos.Owner.Stances[p] == Stance.Ally)))
+								nearnessCandidates.Add(pos);
 				}
 			}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -23,30 +24,37 @@ namespace OpenRA.Mods.Common.Traits
 	public class BuildingInfluence
 	{
 		readonly Map map;
-		readonly CellLayer<Actor> influence;
+		readonly CellLayer<List<Actor>> influence;
 
 		public BuildingInfluence(World world)
 		{
 			map = world.Map;
 
-			influence = new CellLayer<Actor>(map);
+			influence = new CellLayer<List<Actor>>(map);
 		}
 
 		internal void AddInfluence(Actor a, IEnumerable<CPos> tiles)
 		{
 			foreach (var u in tiles)
-				if (influence.Contains(u) && influence[u] == null)
-					influence[u] = a;
+			{
+				if (influence.Contains(u))
+				{
+					if (influence[u] == null)
+						influence[u] = new List<Actor>();
+
+					influence[u].Add(a);
+				}
+			}
 		}
 
 		internal void RemoveInfluence(Actor a, IEnumerable<CPos> tiles)
 		{
 			foreach (var u in tiles)
-				if (influence.Contains(u) && influence[u] == a)
-					influence[u] = null;
+				if (influence.Contains(u) && influence[u].Contains(a))
+					influence[u].Remove(a);
 		}
 
-		public Actor GetBuildingAt(CPos cell)
+		public List<Actor> GetBuildingsAt(CPos cell)
 		{
 			return influence.Contains(cell) ? influence[cell] : null;
 		}

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
@@ -22,9 +22,12 @@ namespace OpenRA.Mods.Common.Traits
 			if (!world.Map.Contains(cell))
 				return false;
 
-			var building = world.WorldActor.Trait<BuildingInfluence>().GetBuildingAt(cell);
-			if (building != null)
+			var buildings = world.WorldActor.Trait<BuildingInfluence>().GetBuildingsAt(cell);
+
+			if (buildings != null)
 			{
+				foreach (var building in buildings)
+				{
 				if (ai == null)
 					return false;
 
@@ -33,8 +36,9 @@ namespace OpenRA.Mods.Common.Traits
 					return false;
 
 				if (!building.TraitsImplementing<Replaceable>().Any(p => !p.IsTraitDisabled &&
-					p.Info.Types.Overlaps(replacementInfo.ReplaceableTypes)))
+																		 p.Info.Types.Overlaps(replacementInfo.ReplaceableTypes)))
 					return false;
+				}
 			}
 			else if (!bi.AllowInvalidPlacement && world.ActorMap.GetActorsAt(cell).Any(a => a != toIgnore))
 				return false;

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -61,7 +61,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!CanExistInCell(world, cell))
 				return SubCell.Invalid;
 
-			if (world.WorldActor.Trait<BuildingInfluence>().GetBuildingAt(cell) != null)
+			var buildings = world.WorldActor.Trait<BuildingInfluence>().GetBuildingsAt(cell);
+			if (buildings != null && buildings.Any())
 				return SubCell.Invalid;
 
 			if (!checkTransientActors)

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -126,24 +126,27 @@ namespace OpenRA.Mods.Common.Traits
 				}
 				else if (os == "PlacePlug")
 				{
-					var host = self.World.WorldActor.Trait<BuildingInfluence>().GetBuildingAt(order.TargetLocation);
-					if (host == null)
+					var hosts = self.World.WorldActor.Trait<BuildingInfluence>().GetBuildingsAt(order.TargetLocation);
+					if (hosts == null || !hosts.Any())
 						return;
 
-					var plugInfo = actorInfo.TraitInfoOrDefault<PlugInfo>();
-					if (plugInfo == null)
-						return;
+					foreach (var host in hosts)
+					{
+						var plugInfo = actorInfo.TraitInfoOrDefault<PlugInfo>();
+						if (plugInfo == null)
+							return;
 
-					var location = host.Location;
-					var pluggable = host.TraitsImplementing<Pluggable>()
-						.FirstOrDefault(p => location + p.Info.Offset == order.TargetLocation && p.AcceptsPlug(host, plugInfo.Type));
+						var location = host.Location;
+						var pluggable = host.TraitsImplementing<Pluggable>()
+							.FirstOrDefault(p => location + p.Info.Offset == order.TargetLocation && p.AcceptsPlug(host, plugInfo.Type));
 
-					if (pluggable == null)
-						return;
+						if (pluggable == null)
+							return;
 
-					pluggable.EnablePlug(host, plugInfo.Type);
-					foreach (var s in buildingInfo.BuildSounds)
-						Game.Sound.PlayToPlayer(SoundType.World, order.Player, s, host.CenterPosition);
+						pluggable.EnablePlug(host, plugInfo.Type);
+						foreach (var s in buildingInfo.BuildSounds)
+							Game.Sound.PlayToPlayer(SoundType.World, order.Player, s, host.CenterPosition);
+					}
 				}
 				else
 				{
@@ -157,9 +160,10 @@ namespace OpenRA.Mods.Common.Traits
 						var buildingInfluence = self.World.WorldActor.Trait<BuildingInfluence>();
 						foreach (var t in buildingInfo.Tiles(order.TargetLocation))
 						{
-							var host = buildingInfluence.GetBuildingAt(t);
-							if (host != null)
-								host.World.Remove(host);
+							var hosts = buildingInfluence.GetBuildingsAt(t);
+							if (hosts != null)
+								foreach (var host in hosts)
+									host.World.Remove(host);
 						}
 					}
 

--- a/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
@@ -182,7 +182,8 @@ namespace OpenRA.Mods.Common.Traits
 					continue;
 
 				// Don't drop on any actors
-				if (self.World.WorldActor.Trait<BuildingInfluence>().GetBuildingAt(p) != null
+				var buildings = self.World.WorldActor.Trait<BuildingInfluence>().GetBuildingsAt(p);
+				if ((buildings != null && buildings.Any())
 					|| self.World.ActorMap.GetActorsAt(p).Any())
 					continue;
 

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -193,8 +193,12 @@ namespace OpenRA.Mods.Common.Traits
 			if (!rt.Info.AllowUnderActors && world.ActorMap.AnyActorsAt(cell))
 				return false;
 
-			if (!rt.Info.AllowUnderBuildings && buildingInfluence.GetBuildingAt(cell) != null)
-				return false;
+			if (!rt.Info.AllowUnderBuildings)
+			{
+				var buildings = buildingInfluence.GetBuildingsAt(cell);
+				if (buildings != null && buildings.Any())
+					return false;
+			}
 
 			if (!rt.Info.AllowOnRamps)
 			{

--- a/OpenRA.Mods.D2k/Traits/Buildings/LaysTerrain.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/LaysTerrain.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -63,7 +64,8 @@ namespace OpenRA.Mods.D2k.Traits
 						continue;
 
 					// Don't place under other buildings or custom terrain
-					if (bi.GetBuildingAt(c) != self || map.CustomTerrain[c] != byte.MaxValue)
+					var buildings = bi.GetBuildingsAt(c);
+					if (buildings == null || buildings.Any(building => building != self) || map.CustomTerrain[c] != byte.MaxValue)
 						continue;
 
 					var index = Game.CosmeticRandom.Next(template.TilesCount);
@@ -83,7 +85,8 @@ namespace OpenRA.Mods.D2k.Traits
 					continue;
 
 				// Don't place under other buildings or custom terrain
-				if (bi.GetBuildingAt(c) != self || map.CustomTerrain[c] != byte.MaxValue)
+				var buildings = bi.GetBuildingsAt(c);
+				if (buildings == null || buildings.Any(building => building != self) || map.CustomTerrain[c] != byte.MaxValue)
 					continue;
 
 				layer.AddTile(c, new TerrainTile(template.Id, (byte)i));


### PR DESCRIPTION
Makes multiple buildings on the same cell work correctly. This is a requirement if the later added one grants buildable area for example.