### PR TITLE
fix threadedRenderer context creation logic

### DIFF
--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -189,7 +189,7 @@ namespace OpenRA.Platforms.Default
 			// If the calling thread is the main game thread, this means it can run more logic and render ticks.
 			// This is disabled on Windows because it breaks the ability to minimize/restore the window from the taskbar for reasons that we dont understand.
 			var threadedRenderer = Platform.CurrentPlatform != PlatformType.Windows || !Game.Settings.Graphics.DisableWindowsRenderThread;
-			if (threadedRenderer)
+			if (!threadedRenderer)
 			{
 				var ctx = new Sdl2GraphicsContext(this);
 				ctx.InitializeOpenGL();


### PR DESCRIPTION
A single-character PR that should hopefully be self-explanatory.