### PR TITLE
Fix compiler warnings on linux

### DIFF
--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -31,6 +31,7 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
`<CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>` is used for static code analysis in Visual Studio. I'm not aware of anyone using this feature, so it should be safe to remove.

See https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/how-to-enable-and-disable-automatic-binding-redirection for details on the commit about `AutoGenerateBindingRedirects`.