### PR TITLE
Ignore malformed orders instead of crashing.

### DIFF
--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -76,10 +76,12 @@ namespace OpenRA
 
 		public static Order Deserialize(World world, BinaryReader r)
 		{
-			var magic = r.ReadByte();
-			switch (magic)
+			try
 			{
-				case 0xFF:
+				var magic = r.ReadByte();
+				switch (magic)
+				{
+					case 0xFF:
 					{
 						var order = r.ReadString();
 						var subjectId = r.ReadUInt32();
@@ -156,7 +158,7 @@ namespace OpenRA
 						return new Order(order, subject, target, targetString, queued, extraLocation, extraData);
 					}
 
-				case 0xfe:
+					case 0xfe:
 					{
 						var name = r.ReadString();
 						var data = r.ReadString();
@@ -164,11 +166,23 @@ namespace OpenRA
 						return new Order(name, null, false) { IsImmediate = true, TargetString = data };
 					}
 
-				default:
+					default:
 					{
 						Log.Write("debug", "Received unknown order with magic {0}", magic);
 						return null;
 					}
+				}
+			}
+			catch (Exception e)
+			{
+				Log.Write("debug", "Caught exception while processing order");
+				Log.Write("debug", e.ToString());
+
+				// HACK: this can hopefully go away in the future
+				Game.Debug("Ignoring malformed order that would have crashed the game");
+				Game.Debug("Please file a bug report and include the replay from this match");
+
+				return null;
 			}
 		}
 


### PR DESCRIPTION
Implements a workaround for #15526 so that we can collect information that may eventually lead to a proper fix.

Testcase: Add the following to `Order.Serialize` to trigger a crash with the same stacktrace as #15526
```diff
diff --git a/OpenRA.Game/Network/Order.cs b/OpenRA.Game/Network/Order.cs
index 25b9aca186..70b4272c99 100644
--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -267,6 +267,13 @@ public byte[] Serialize()
                                w.Write((byte)0xFE);
                                w.Write(OrderString);
                                w.Write(TargetString);
+
+                               if (TargetString.StartsWith("map", StringComparison.Ordinal))
+                               {
+                                       var r = ret.ToArray();
+                                       return r.Take(r.Length - 3).ToArray();
+                               }
+
                                return ret.ToArray();
                        }
```