### PR TITLE
Fix game crashes when no maps are available to load

### DIFF
--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -332,8 +332,8 @@ namespace OpenRA
 			if (string.IsNullOrEmpty(initialUid) || previews[initialUid].Status != MapStatus.Available)
 			{
 				var selected = previews.Values.Where(IsSuitableInitialMap).RandomOrDefault(random) ??
-					previews.Values.First(m => m.Status == MapStatus.Available && m.Visibility.HasFlag(MapVisibility.Lobby));
-				return selected.Uid;
+					previews.Values.FirstOrDefault(m => m.Status == MapStatus.Available && m.Visibility.HasFlag(MapVisibility.Lobby));
+				return selected == null ? string.Empty : selected.Uid;
 			}
 
 			return initialUid;

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -122,7 +122,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			missionsButton.Disabled = !hasCampaign && !hasMissions;
 
-			singleplayerMenu.Get<ButtonWidget>("SKIRMISH_BUTTON").OnClick = StartSkirmishGame;
+			var hasMaps = modData.MapCache.Any(p => p.Visibility.HasFlag(MapVisibility.Lobby));
+			var skirmishButton = singleplayerMenu.Get<ButtonWidget>("SKIRMISH_BUTTON");
+			skirmishButton.OnClick = StartSkirmishGame;
+			skirmishButton.Disabled = !hasMaps;
 
 			singleplayerMenu.Get<ButtonWidget>("BACK_BUTTON").OnClick = () => SwitchMenu(MenuType.Main);
 
@@ -199,6 +202,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{ "filter", MapVisibility.Lobby | MapVisibility.Shellmap | MapVisibility.MissionSelector },
 				});
 			};
+
+			loadMapButton.Disabled = !hasMaps;
 
 			mapEditorMenu.Get<ButtonWidget>("BACK_BUTTON").OnClick = () => SwitchMenu(MenuType.Extras);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MultiplayerLogic.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Linq;
 using OpenRA.Network;
 using OpenRA.Widgets;
 
@@ -54,6 +55,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{ "onExit", DoNothing }
 				});
 			};
+
+			var hasMaps = modData.MapCache.Any(p => !p.Visibility.HasFlag(MapVisibility.Shellmap));
+			createServerButton.Disabled = !hasMaps;
 
 			widget.Get<ButtonWidget>("BACK_BUTTON").OnClick = () => { Ui.CloseWindow(); onExit(); };
 


### PR DESCRIPTION
Fixes #15492 

Bug was reproduced on 2 scenarios:
1. No maps available - Skirmish game started.
2. No maps available - Map editor (load maps) opened.

The fix solves these 2 issues in a general way (by safely trying to iterate the maps (map previews) collection, and
1. Skirmish - blocks server initializaion and prompts user on error.
2. Map Editor - Opens the editor with no maps (only shell maps if available)

* Detailed information in the commit message.

Thank you for your contribution to OpenRA!

Please be aware that we do not have enough project maintainers to match the rate of contributions, so it may take several days before somebody is able to respond to your Pull Request.

You can help speed up the review process by following a few steps:

* Make sure that you have read and understand the OpenRA Coding Standard (see https://github.com/OpenRA/OpenRA/wiki/Coding-Standard).
* Write quality commit messages (see https://chris.beams.io/posts/git-commit/).
* Only commit changes that directly relate to your Pull Request.  Use your Git interface to unstage any unrelated changes to project files, line endings, whitespace, or other files.
* Review the code diff view below to double check that your changes satisfy the above three points.
* Use the `make test` and `make check` commands to check for (and fix!) any issues that are reported by our automated tests.
* If you are changing shared mod or engine code, make sure that you have tested your changes in all four default mods.
* Respond to review comments as soon as you reasonably can.  Reviewers will usually prioritize Pull Requests that are still fresh in their minds.  Make sure to leave a comment when you push new changes, otherwise GitHub does not automatically notify reviewers!
* Leave a polite comment asking for reviews if a week or more has passed without feedback.

If you need any help you can ask in the #openra IRC channel on freenode (most active during European evenings).