### PR TITLE
Fix CrateSpawner sometimes spawning 1 crate too much if Maximum == Minimum

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Traits
 				ticks = info.SpawnInterval;
 
 				var toSpawn = Math.Max(0, info.Minimum - crates)
-					+ (crates < info.Maximum ? 1 : 0);
+					+ (crates < info.Maximum && info.Maximum > info.Minimum ? 1 : 0);
 
 				for (var n = 0; n < toSpawn; n++)
 					SpawnCrate(self);


### PR DESCRIPTION
In CrateSpawner, if Maximum == Minimum but 'crates' < Maximum, the formula would simply return min + 1 regardless of max being identical to min.
Only adding 1 more crate if Maximum is higher than Minimum fixes that.

Fixes #15586.