### PR TITLE
Fix: Display progress message properly when download size missing (#1)

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
@@ -85,6 +85,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					dataTotal = float.NaN;
 					dataReceived = i.BytesReceived;
 					dataSuffix = SizeSuffixes[0];
+
+					getStatusText = () => "Downloading from {2} {0:0.00} {1} (unknown size)".F(dataReceived,
+						dataSuffix,
+						downloadHost ?? "unknown host");
 				}
 				else
 				{
@@ -92,14 +96,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					dataTotal = i.TotalBytesToReceive / (float)(1L << (mag * 10));
 					dataReceived = i.BytesReceived / (float)(1L << (mag * 10));
 					dataSuffix = SizeSuffixes[mag];
+
+					getStatusText = () => "Downloading from {4} {1:0.00}/{2:0.00} {3} ({0}%)".F(i.ProgressPercentage,
+						dataReceived, dataTotal, dataSuffix,
+						downloadHost ?? "unknown host");
 				}
 
 				progressBar.Indeterminate = false;
 				progressBar.Percentage = i.ProgressPercentage;
-
-				getStatusText = () => "Downloading from {4} {1:0.00}/{2:0.00} {3} ({0}%)".F(i.ProgressPercentage,
-					dataReceived, dataTotal, dataSuffix,
-					downloadHost ?? "unknown host");
 			};
 
 			Action<string> onExtractProgress = s => Game.RunAfterTick(() => getStatusText = () => s);


### PR DESCRIPTION
When I downloaded the assets for Red Alert through the Quick Install I noticed the progress bar proceed and display a recognizable message: `Downloading from … 1.47/12 MB (12%)`. This was fine.

When I downloaded the assets for one of the other games, maybe Dune 2000, there was obviously no total download size available. I saw an unexpected message: `Downloading from … 1.47/NaN (NaN%)`

The code handling network progress events seems to be aware of the possibility that no full download size exists but it doesn't update the message. In this patch I'm proposing that we display a separate message indicating that we don't know how much more we have to download for these cases.

Of the alternative ways to implement this I chose to move the reassignment of `getStatusText` into the conditional structures to preserve the existing choice. The message was qualitatively different and so I felt it worthwhile to create entirely different closures vs. doing something like this…

```cs
getStatusText = () => ( Double.isNaN( dataTotal ) ? "Downloading {1} of unknown amount" : "Downloading {1}/{2}" ).F( … );
```

**Status**

 - I have not tested these changes. I don't have the dev environment setup and for this change I didn't want to attempt all that work. Sorry 🤷‍♂️ - this bug doesn't bother me; I just thought I'd push the change up in case anyone wanted it.
 - Wasn't sure if we should address `progressBar.Percentage = i.ProgressPercentage;` at the same time. I'm guessing that this too will be `NaN` but in the display I think it results in an empty progress bar so maybe it's not a problem.

Closes https://github.com/OpenRA/OpenRA/issues/15489.
Closes https://github.com/OpenRA/OpenRA/pull/15493.