### PR TITLE
Some CrateSpawner related changes

### DIFF
--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -77,6 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly Actor self;
 		readonly CrateInfo info;
+		readonly CrateSpawner spawner;
 		bool collected;
 
 		[Sync] int ticks;
@@ -86,6 +87,9 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			self = init.Self;
 			this.info = info;
+
+			if (init.Contains<CrateSpawnerTraitInit>())
+				spawner = init.Get<CrateSpawnerTraitInit, CrateSpawner>();
 
 			if (init.Contains<LocationInit>())
 				SetPosition(self, init.Get<LocationInit, CPos>());
@@ -226,18 +230,16 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			self.World.AddToMaps(self, this);
 
-			var cs = self.World.WorldActor.TraitOrDefault<CrateSpawner>();
-			if (cs != null)
-				cs.IncrementCrates();
+			if (spawner != null)
+				spawner.IncrementCrates();
 		}
 
 		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)
 		{
 			self.World.RemoveFromMaps(self, this);
 
-			var cs = self.World.WorldActor.TraitOrDefault<CrateSpawner>();
-			if (cs != null)
-				cs.DecrementCrates();
+			if (spawner != null)
+				spawner.DecrementCrates();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
@@ -141,7 +141,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				if (info.DeliveryAircraft != null)
 				{
-					var crate = w.CreateActor(false, crateActor, new TypeDictionary { new OwnerInit(w.WorldActor.Owner) });
+					var crate = w.CreateActor(false, crateActor, new TypeDictionary { new OwnerInit(w.WorldActor.Owner), new CrateSpawnerTraitInit(this) });
 					var dropFacing = 256 * self.World.SharedRandom.Next(info.QuantizedFacings) / info.QuantizedFacings;
 					var delta = new WVec(0, -1024, 0).Rotate(WRot.FromFacing(dropFacing));
 
@@ -166,7 +166,7 @@ namespace OpenRA.Mods.Common.Traits
 					plane.QueueActivity(new RemoveSelf());
 				}
 				else
-					w.CreateActor(crateActor, new TypeDictionary { new OwnerInit(w.WorldActor.Owner), new LocationInit(p) });
+					w.CreateActor(crateActor, new TypeDictionary { new OwnerInit(w.WorldActor.Owner), new LocationInit(p), new CrateSpawnerTraitInit(this) });
 			});
 		}
 
@@ -217,5 +217,11 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			crates--;
 		}
+
+	public class CrateSpawnerTraitInit : IActorInit<CrateSpawner>
+	{
+		readonly CrateSpawner value;
+		public CrateSpawnerTraitInit(CrateSpawner init) { value = init; }
+		public CrateSpawner Value(World world) { return value; }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
@@ -153,7 +153,7 @@ namespace OpenRA.Mods.Common.Traits
 					var plane = w.CreateActor(info.DeliveryAircraft, new TypeDictionary
 					{
 						new CenterPositionInit(startEdge),
-						new OwnerInit(self.Owner),
+						new OwnerInit(w.WorldActor.Owner),
 						new FacingInit(dropFacing),
 					});
 


### PR DESCRIPTION
First commit fixes the small issue with owners i noted at #15586.

Second commit adds an actor init to pass which CrateSpawner trait spawned the crate, so multipile CrateSpawner traits can have their max-min values separetly calculated. I never noticed if it was ever a problem, nor tested it. But if that was actually the case, this should fix preplaced and Supply Truck (and Scrap Crates for Generals Alpha) crates intervene with CrateSpawner trait.

Third commit makes the trait conditional. While not much useful under World actor. I use CrateSpawner under Player actor and i used conditions so i can add additional crates per player in No Bases mode i added to my mod. GrantConditionOnPrerequisite unfortunately doesn't work on World actor. If it did, we could remove the dedicated lobby option logic under CrateSpawner and use LobbyPrerequisiteCheckbox instead. On my engine i moved the crate lobby option stuff to MapOptions: trait but i still think best way of doing it is LobbyPrerequisiteCheckbox, so haven't touched it here. I can update this PR if someone can help me with that.