### PR TITLE
Revert RA Grenadier explosion DamageSource.

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -127,6 +127,7 @@ E2:
 	Explodes:
 		Weapon: UnitExplodeSmall
 		EmptyWeapon: UnitExplodeSmall
+		DamageSource: Killer
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded
 


### PR DESCRIPTION
This is the safest way to fix #15537.  Adding a damage type filter to the explosion would require careful auditing and testing of all the potential ways that they could be killed in order to avoid introducing other regressions.  This is best left until after the proposed `Explodes` rework (removing `EmptyWeapon` and adding `InvalidDeathTypes`).