### PR TITLE
Make WithSpriteBody always use Animation.PlayRepeating for looped playback

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			if (info.StartSequence != null)
 				PlayCustomAnimation(init.Self, info.StartSequence,
-					() => PlayCustomAnimationRepeating(init.Self, info.Sequence));
+					() => DefaultAnimation.PlayRepeating(NormalizeSequence(init.Self, info.Sequence)));
 			else
 				DefaultAnimation.PlayRepeating(NormalizeSequence(init.Self, info.Sequence));
 		}
@@ -103,8 +103,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public void PlayCustomAnimationRepeating(Actor self, string name)
 		{
-			var sequence = NormalizeSequence(self, name);
-			DefaultAnimation.PlayThen(sequence, () => PlayCustomAnimationRepeating(self, sequence));
+			DefaultAnimation.PlayRepeating(NormalizeSequence(self, name));
 		}
 
 		public void PlayCustomAnimationBackwards(Actor self, string name, Action after = null)


### PR DESCRIPTION
`PlayCustomAnimationRepeating` looping back into itself via Action instead of simply using `Animation.PlayRepeating` is weird enough by itself.
It also can cause the animation to slowly go out of sync with animations using `Animation.PlayRepeating` under certain circumstances (happens in at least my own downstream mod).