### PR TITLE
Fix CombatProperties not accounting for multiple AttackBase traits

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
@@ -78,12 +78,12 @@ namespace OpenRA.Mods.Common.Scripting
 	[ScriptPropertyGroup("Combat")]
 	public class GeneralCombatProperties : ScriptActorProperties, Requires<AttackBaseInfo>
 	{
-		readonly AttackBase attackBase;
+		readonly AttackBase[] attackBases;
 
 		public GeneralCombatProperties(ScriptContext context, Actor self)
 			: base(context, self)
 		{
-			attackBase = self.Trait<AttackBase>();
+			attackBases = self.TraitsImplementing<AttackBase>().ToArray();
 		}
 
 		[Desc("Attack the target actor. The target actor needs to be visible.")]
@@ -96,7 +96,8 @@ namespace OpenRA.Mods.Common.Scripting
 			if (!targetActor.Info.HasTraitInfo<FrozenUnderFogInfo>() && !targetActor.CanBeViewedByPlayer(Self.Owner))
 				Log.Write("lua", "{1} is not revealed for player {0}!", Self.Owner, targetActor);
 
-			attackBase.AttackTarget(target, true, allowMove, forceAttack);
+			foreach (var attack in attackBases)
+				attack.AttackTarget(target, true, allowMove, forceAttack);
 		}
 
 		[Desc("Checks if the targeted actor is a valid target for this actor.")]


### PR DESCRIPTION
Fixes #15602.

Checks for target validity or conditional traits are done in AttackBase already:
https://github.com/OpenRA/OpenRA/blob/0bff9e911900cbab992423c70385452fbde30a09/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs#L356-L362