### PR TITLE
Tweak RA and D2K's HackyAI

### DIFF
--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -28,6 +28,7 @@ Player:
 			starport: 1
 			repair_pad: 1
 			research_centre: 1
+			palace: 1
 			upgrade.conyard: 1
 			upgrade.barracks: 1
 			upgrade.light: 1
@@ -45,6 +46,7 @@ Player:
 			starport: 0.1%
 			repair_pad: 0.1%
 			research_centre: 0.1%
+			palace: 0.1%
 			upgrade.conyard: 0.1%
 			upgrade.barracks: 0.1%
 			upgrade.light: 0.1%

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -17,7 +17,7 @@ Player:
 			Silo: silo
 		UnitsCommonNames:
 			Mcv: mcv
-			ExcludeFromSquads: harv
+			ExcludeFromSquads: harvester
 		BuildingLimits:
 			barracks: 1
 			refinery: 4
@@ -142,7 +142,7 @@ Player:
 			Silo: silo
 		UnitsCommonNames:
 			Mcv: mcv
-			ExcludeFromSquads: harv
+			ExcludeFromSquads: harvester
 		BuildingLimits:
 			barracks: 1
 			refinery: 4
@@ -267,7 +267,7 @@ Player:
 			Silo: silo
 		UnitsCommonNames:
 			Mcv: mcv
-			ExcludeFromSquads: harv
+			ExcludeFromSquads: harvester
 		BuildingLimits:
 			barracks: 1
 			refinery: 4

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -2,10 +2,10 @@ Player:
 	HackyAI@RushAI:
 		Name: Rush AI
 		Type: rush
-		MinimumExcessPower: 20
+		MinimumExcessPower: 60
+		MaximumExcessPower: 160
 		ExcessPowerIncrement: 40
 		ExcessPowerIncreaseThreshold: 4
-		MaximumExcessPower: 160
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -45,28 +45,31 @@ Player:
 			stek: 1%
 			fix: 0.1%
 			dome: 10%
+			mslo: 1%
 		UnitsToBuild:
 			e1: 65%
-			e2: 25%
-			e3: 40%
+			e2: 15%
+			e3: 30%
 			e4: 15%
 			dog: 15%
 			shok: 15%
 			harv: 10%
 			apc: 30%
-			jeep: 40%
+			jeep: 20%
 			arty: 15%
 			v2rl: 40%
-			ftrk: 50%
-			1tnk: 70%
-			2tnk: 25%
+			ftrk: 30%
+			1tnk: 50%
+			2tnk: 50%
 			3tnk: 50%
-			4tnk: 10%
-			ttnk: 10%
+			4tnk: 25%
+			ttnk: 25%
 			stnk: 5%
 		UnitLimits:
 			dog: 4
 			harv: 8
+			jeep: 4
+			ftrk: 4
 		SquadSize: 20
 		SupportPowerDecisions:
 			spyplane:
@@ -120,10 +123,10 @@ Player:
 	HackyAI@NormalAI:
 		Name: Normal AI
 		Type: normal
-		MinimumExcessPower: 40
+		MinimumExcessPower: 60
+		MaximumExcessPower: 200
 		ExcessPowerIncrement: 40
 		ExcessPowerIncreaseThreshold: 4
-		MaximumExcessPower: 200
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -152,7 +155,7 @@ Player:
 			stek: 1
 			fix: 1
 		BuildingFractions:
-			proc: 10%
+			proc: 15%
 			tent: 1%
 			barr: 1%
 			kenn: 0.5%
@@ -176,23 +179,23 @@ Player:
 			mslo: 1%
 		UnitsToBuild:
 			e1: 65%
-			e2: 25%
-			e3: 40%
+			e2: 15%
+			e3: 30%
 			e4: 15%
 			dog: 15%
 			shok: 15%
-			harv: 10%
+			harv: 15%
 			apc: 30%
-			jeep: 40%
+			jeep: 20%
 			arty: 15%
 			v2rl: 40%
-			ftrk: 50%
-			1tnk: 70%
-			2tnk: 25%
+			ftrk: 30%
+			1tnk: 40%
+			2tnk: 50%
 			3tnk: 50%
-			4tnk: 15%
-			ttnk: 15%
-			stnk: 10%
+			4tnk: 25%
+			ttnk: 25%
+			stnk: 5%
 			heli: 30%
 			hind: 30%
 			mig: 30%
@@ -205,6 +208,8 @@ Player:
 		UnitLimits:
 			dog: 4
 			harv: 8
+			jeep: 4
+			ftrk: 4
 		SquadSize: 40
 		SupportPowerDecisions:
 			spyplane:
@@ -258,10 +263,10 @@ Player:
 	HackyAI@TurtleAI:
 		Name: Turtle AI
 		Type: turtle
-		MinimumExcessPower: 50
+		MinimumExcessPower: 60
+		MaximumExcessPower: 250
 		ExcessPowerIncrement: 50
 		ExcessPowerIncreaseThreshold: 4
-		MaximumExcessPower: 250
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -315,23 +320,23 @@ Player:
 			mslo: 1%
 		UnitsToBuild:
 			e1: 65%
-			e2: 25%
-			e3: 40%
+			e2: 15%
+			e3: 30%
 			e4: 15%
 			dog: 15%
 			shok: 15%
-			harv: 10%
+			harv: 15%
 			apc: 30%
-			jeep: 40%
+			jeep: 20%
 			arty: 15%
 			v2rl: 40%
 			ftrk: 50%
-			1tnk: 70%
-			2tnk: 25%
+			1tnk: 50%
+			2tnk: 50%
 			3tnk: 50%
-			4tnk: 20%
-			ttnk: 20%
-			stnk: 15%
+			4tnk: 25%
+			ttnk: 25%
+			stnk: 10%
 			heli: 30%
 			hind: 30%
 			mig: 30%
@@ -344,6 +349,8 @@ Player:
 		UnitLimits:
 			dog: 4
 			harv: 8
+			jeep: 4
+			ftrk: 4
 		SquadSize: 10
 		SupportPowerDecisions:
 			spyplane:
@@ -397,10 +404,10 @@ Player:
 	HackyAI@NavalAI:
 		Name: Naval AI
 		Type: naval
-		MinimumExcessPower: 20
+		MinimumExcessPower: 60
+		MaximumExcessPower: 200
 		ExcessPowerIncrement: 40
 		ExcessPowerIncreaseThreshold: 4
-		MaximumExcessPower: 200
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -429,7 +436,7 @@ Player:
 			stek: 1
 			fix: 1
 		BuildingFractions:
-			proc: 29%
+			proc: 30%
 			dome: 1%
 			weap: 1%
 			hpad: 20%


### PR DESCRIPTION
From my recent experience with fiddling with the HackyAI on RA I'd recommend a few tweaks with its setup:

MinimumExcessPower: 60 on all bots.

The AI sometimes executes some "exotic" builds that sometimes puts it on low power. Sometimes whenever during a game. Probably because it doesn't calculate the combined power cost of its two structure queues against the minimum excess power. I'm guessing the custom yaml per bot were set to save time, e.g. not having the rush ai waste time on additional power but the price of a PP is negligible ($300).

As a small, positive side-effect the extra powerplant in the build queue gives the bot a slight better chance at fair refinery placements early on.

The infantry production change scales down counterproductive grens and expensive rockets vs riflemen. With a higher share of riflemen the attacks comes in a bit earlier due to the squad size limit, at least until  other queues kicks in.

The vehicle production change boosts mid- late-tech units usually drowned out by excessive low tech vehicles that just suicides into the player once the player has set up his defenses. The AI has a low priority on the service depot so this transition happens quite late but when it happens the player shouldn't have to deal with fleets of rangers, flak trucks and light tanks that acts more like a nuisance rather than a threat. For some bots, refinery/harvesters got a nudge to scale the attacks more reliably in time.

Overall these changes makes the bots slightly more potent and stable.

*Almost forgot, I added the missile silo to the rush ai since in my view it doesn't really define the rush ai's behavior whether or not it goes for the nuke, and 'superpowers' is already an option in the lobby.