### PR TITLE
Improve status line display for unknown-size downloads.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
@@ -82,11 +82,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				if (i.TotalBytesToReceive < 0)
 				{
-					dataTotal = float.NaN;
-					dataReceived = i.BytesReceived;
-					dataSuffix = SizeSuffixes[0];
+					mag = (int)Math.Log(i.BytesReceived, 1024);
+					dataReceived = i.BytesReceived / (float)(1L << (mag * 10));
+					dataSuffix = SizeSuffixes[mag];
 
-					getStatusText = () => "Downloading from {2} {0:0.00} {1} (unknown size)".F(dataReceived,
+					getStatusText = () => "Downloading from {2} {0:0.00} {1}".F(dataReceived,
 						dataSuffix,
 						downloadHost ?? "unknown host");
 					progressBar.Indeterminate = true;


### PR DESCRIPTION
Followup to #15588 / #15611.

Before:
![screen shot 2018-09-14 at 17 27 48](https://user-images.githubusercontent.com/167819/45563356-002cf280-b845-11e8-8772-5fe3710bad2c.png)

After:
![screen shot 2018-09-14 at 17 36 41](https://user-images.githubusercontent.com/167819/45563373-0cb14b00-b845-11e8-860d-65993fcf21c3.png)
