### PR TITLE
Rewrite a bit of the team chat logic

### DIFF
--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -148,9 +148,11 @@ namespace OpenRA
 					case 0xfe:
 					{
 						var name = r.ReadString();
-						var data = r.ReadString();
+						var flags = (OrderFields)r.ReadByte();
+						var targetString = flags.HasField(OrderFields.TargetString) ? r.ReadString() : null;
+						var extraData = flags.HasField(OrderFields.ExtraData) ? r.ReadUInt32() : 0;
 
-						return new Order(name, null, false) { IsImmediate = true, TargetString = data };
+						return new Order(name, null, false) { IsImmediate = true, TargetString = targetString, ExtraData = extraData };
 					}
 
 					default:
@@ -245,15 +247,29 @@ namespace OpenRA
 
 		public byte[] Serialize()
 		{
-			var minLength = OrderString.Length + 1 + (IsImmediate ? 1 + TargetString.Length + 1 : 6);
+			var minLength = OrderString.Length + 1 + (IsImmediate ? 1 + 1 + TargetString.Length + 1 + 4 : 6);
 			var ret = new MemoryStream(minLength);
 			var w = new BinaryWriter(ret);
+
+			OrderFields fields = 0;
+			if (TargetString != null)
+				fields |= OrderFields.TargetString;
+
+			if (ExtraData != 0)
+				fields |= OrderFields.ExtraData;
 
 			if (IsImmediate)
 			{
 				w.Write((byte)0xFE);
 				w.Write(OrderString);
-				w.Write(TargetString);
+				w.Write((byte)fields);
+
+				if (fields.HasField(OrderFields.TargetString))
+					w.Write(TargetString);
+
+				if (fields.HasField(OrderFields.ExtraData))
+					w.Write(ExtraData);
+
 				return ret.ToArray();
 			}
 
@@ -261,21 +277,14 @@ namespace OpenRA
 			w.Write(OrderString);
 			w.Write(UIntFromActor(Subject));
 
-			OrderFields fields = 0;
 			if (Target.SerializableType != TargetType.Invalid)
 				fields |= OrderFields.Target;
-
-			if (TargetString != null)
-				fields |= OrderFields.TargetString;
 
 			if (Queued)
 				fields |= OrderFields.Queued;
 
 			if (ExtraLocation != CPos.Zero)
 				fields |= OrderFields.ExtraLocation;
-
-			if (ExtraData != 0)
-				fields |= OrderFields.ExtraData;
 
 			if (Target.SerializableCell != null)
 				fields |= OrderFields.TargetIsCell;

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -195,9 +195,12 @@ namespace OpenRA
 
 		// Named constructors for Orders.
 		// Now that Orders are resolved by individual Actors, these are weird; you unpack orders manually, but not pack them.
-		public static Order Chat(bool team, string text)
+		public static Order Chat(bool team, string text, int teamNumber = 0)
 		{
-			return new Order(team ? "TeamChat" : "Chat", null, false) { IsImmediate = true, TargetString = text };
+			if (!team)
+				return new Order("Chat", null, false) { IsImmediate = true, TargetString = text };
+
+			return new Order("TeamChat", null, false) { IsImmediate = true, TargetString = text, ExtraData = (uint)teamNumber };
 		}
 
 		public static Order HandshakeResponse(string text)

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -195,12 +195,9 @@ namespace OpenRA
 
 		// Named constructors for Orders.
 		// Now that Orders are resolved by individual Actors, these are weird; you unpack orders manually, but not pack them.
-		public static Order Chat(bool team, string text, int teamNumber = 0)
+		public static Order Chat(string text, uint teamNumber = 0)
 		{
-			if (!team)
-				return new Order("Chat", null, false) { IsImmediate = true, TargetString = text };
-
-			return new Order("TeamChat", null, false) { IsImmediate = true, TargetString = text, ExtraData = (uint)teamNumber };
+			return new Order("Chat", null, false) { IsImmediate = true, TargetString = text, ExtraData = teamNumber };
 		}
 
 		public static Order HandshakeResponse(string text)

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -80,8 +80,9 @@ namespace OpenRA.Network
 						// We are still in the lobby
 						if (world == null)
 						{
+							var prefix = order.ExtraData == uint.MaxValue ? "[Spectators] " : "[Team] ";
 							if (orderManager.LocalClient != null && client.Team == orderManager.LocalClient.Team)
-								Game.AddChatLine(client.Color, "[Team] " + client.Name, message);
+								Game.AddChatLine(client.Color, prefix + client.Name, message);
 
 							break;
 						}

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -81,22 +81,27 @@ namespace OpenRA.Network
 					{
 						var client = orderManager.LobbyInfo.ClientWithIndex(clientId);
 
+						// Cut chat messages to the hard limit to avoid exploits
+						var message = order.TargetString;
+						if (message.Length > ChatMessageMaxLength)
+							message = order.TargetString.Substring(0, ChatMessageMaxLength);
+
 						if (client != null)
 						{
 							if (world == null)
 							{
 								if (orderManager.LocalClient != null && client.Team == orderManager.LocalClient.Team)
-									Game.AddChatLine(client.Color, "[Team] " + client.Name, order.TargetString);
+									Game.AddChatLine(client.Color, "[Team] " + client.Name, message);
 							}
 							else
 							{
 								var player = world.FindPlayerByClient(client);
 								if (player != null && player.WinState == WinState.Lost)
-									Game.AddChatLine(client.Color, client.Name + " (Dead)", order.TargetString);
+									Game.AddChatLine(client.Color, client.Name + " (Dead)", message);
 								else if ((player != null && world.LocalPlayer != null && player.Stances[world.LocalPlayer] == Stance.Ally) || (world.IsReplay && player != null))
-									Game.AddChatLine(client.Color, "[Team" + (world.IsReplay ? " " + client.Team : "") + "] " + client.Name, order.TargetString);
+									Game.AddChatLine(client.Color, "[Team" + (world.IsReplay ? " " + client.Team : "") + "] " + client.Name, message);
 								else if ((orderManager.LocalClient != null && orderManager.LocalClient.IsObserver && client.IsObserver) || (world.IsReplay  && client.IsObserver))
-									Game.AddChatLine(client.Color, "[Spectators] " + client.Name, order.TargetString);
+									Game.AddChatLine(client.Color, "[Spectators] " + client.Name, message);
 							}
 						}
 

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -24,10 +24,7 @@ namespace OpenRA.Network
 
 		static Player FindPlayerByClient(this World world, Session.Client c)
 		{
-			/* TODO: this is still a hack.
-			 * the cases we're trying to avoid are the extra players on the host's client -- Neutral, other MapPlayers,..*/
-			return world.Players.FirstOrDefault(
-				p => (p.ClientIndex == c.Index && p.PlayerReference.Playable));
+			return world.Players.FirstOrDefault(p => (p.ClientIndex == c.Index && p.PlayerReference.Playable));
 		}
 
 		internal static void ProcessOrder(OrderManager orderManager, World world, int clientId, Order order)
@@ -66,11 +63,13 @@ namespace OpenRA.Network
 						break;
 					}
 
-				case "Message": // Server message
+				// Server message
+				case "Message":
 					Game.AddChatLine(Color.White, ServerChatName, order.TargetString);
 					break;
 
-				case "Disconnected": /* reports that the target player disconnected */
+				// Reports that the target player disconnected
+				case "Disconnected":
 					{
 						var client = orderManager.LobbyInfo.ClientWithIndex(clientId);
 						if (client != null)

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -98,9 +98,7 @@ namespace OpenRA.Network
 						}
 
 						var player = world.FindPlayerByClient(client);
-						if (player != null && player.WinState == WinState.Lost)
-							Game.AddChatLine(client.Color, client.Name + " (Dead)", message);
-						else if ((player != null && world.LocalPlayer != null && player.Stances[world.LocalPlayer] == Stance.Ally) || (world.IsReplay && player != null))
+						if ((player != null && world.LocalPlayer != null && player.Stances[world.LocalPlayer] == Stance.Ally) || (world.IsReplay && player != null))
 							Game.AddChatLine(client.Color, "[Team" + (world.IsReplay ? " " + client.Team : "") + "] " + client.Name, message);
 						else if ((orderManager.LocalClient != null && orderManager.LocalClient.IsObserver && client.IsObserver) || (world.IsReplay  && client.IsObserver))
 							Game.AddChatLine(client.Color, "[Spectators] " + client.Name, message);

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -80,30 +80,30 @@ namespace OpenRA.Network
 				case "TeamChat":
 					{
 						var client = orderManager.LobbyInfo.ClientWithIndex(clientId);
+						if (client == null)
+							break;
 
 						// Cut chat messages to the hard limit to avoid exploits
 						var message = order.TargetString;
 						if (message.Length > ChatMessageMaxLength)
 							message = order.TargetString.Substring(0, ChatMessageMaxLength);
 
-						if (client != null)
+						// We are still in the lobby
+						if (world == null)
 						{
-							if (world == null)
-							{
-								if (orderManager.LocalClient != null && client.Team == orderManager.LocalClient.Team)
-									Game.AddChatLine(client.Color, "[Team] " + client.Name, message);
-							}
-							else
-							{
-								var player = world.FindPlayerByClient(client);
-								if (player != null && player.WinState == WinState.Lost)
-									Game.AddChatLine(client.Color, client.Name + " (Dead)", message);
-								else if ((player != null && world.LocalPlayer != null && player.Stances[world.LocalPlayer] == Stance.Ally) || (world.IsReplay && player != null))
-									Game.AddChatLine(client.Color, "[Team" + (world.IsReplay ? " " + client.Team : "") + "] " + client.Name, message);
-								else if ((orderManager.LocalClient != null && orderManager.LocalClient.IsObserver && client.IsObserver) || (world.IsReplay  && client.IsObserver))
-									Game.AddChatLine(client.Color, "[Spectators] " + client.Name, message);
-							}
+							if (orderManager.LocalClient != null && client.Team == orderManager.LocalClient.Team)
+								Game.AddChatLine(client.Color, "[Team] " + client.Name, message);
+
+							break;
 						}
+
+						var player = world.FindPlayerByClient(client);
+						if (player != null && player.WinState == WinState.Lost)
+							Game.AddChatLine(client.Color, client.Name + " (Dead)", message);
+						else if ((player != null && world.LocalPlayer != null && player.Stances[world.LocalPlayer] == Stance.Ally) || (world.IsReplay && player != null))
+							Game.AddChatLine(client.Color, "[Team" + (world.IsReplay ? " " + client.Team : "") + "] " + client.Name, message);
+						else if ((orderManager.LocalClient != null && orderManager.LocalClient.IsObserver && client.IsObserver) || (world.IsReplay  && client.IsObserver))
+							Game.AddChatLine(client.Color, "[Spectators] " + client.Name, message);
 
 						break;
 					}

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -97,11 +97,17 @@ namespace OpenRA.Network
 							break;
 						}
 
-						var player = world.FindPlayerByClient(client);
-						if ((player != null && world.LocalPlayer != null && player.Stances[world.LocalPlayer] == Stance.Ally) || (world.IsReplay && player != null))
-							Game.AddChatLine(client.Color, "[Team" + (world.IsReplay ? " " + client.Team : "") + "] " + client.Name, message);
-						else if ((orderManager.LocalClient != null && orderManager.LocalClient.IsObserver && client.IsObserver) || (world.IsReplay  && client.IsObserver))
+						if (orderManager.LocalClient == null)
+							break;
+
+						if (client.IsObserver && (orderManager.LocalClient.IsObserver || world.IsReplay))
+						{
 							Game.AddChatLine(client.Color, "[Spectators] " + client.Name, message);
+							break;
+						}
+
+						if (client.Team == orderManager.LocalClient.Team || world.IsReplay)
+							Game.AddChatLine(client.Color, "[Team" + (world.IsReplay ? " " + client.Team : "") + "] " + client.Name, message);
 
 						break;
 					}

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -631,7 +631,6 @@ namespace OpenRA.Server
 					}
 
 				case "Chat":
-				case "TeamChat":
 				case "PauseGame":
 					DispatchOrdersToClients(conn, 0, so.Serialize());
 					break;

--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -96,7 +96,6 @@ namespace OpenRA.Mods.Common.Traits
 			switch (order.OrderString)
 			{
 				case "Chat":
-				case "TeamChat":
 				case "HandshakeResponse":
 				case "PauseGame":
 				case "StartGame":

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -136,8 +136,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						if (!isObserver && orderManager.LocalClient == null && world.LocalPlayer == null)
 							return true;
 
-						var teamNumber = (isObserver || world.LocalPlayer.WinState != WinState.Undefined) ? 0 : orderManager.LocalClient.Team;
-						orderManager.IssueOrder(Order.Chat(team, chatText.Text.Trim(), teamNumber));
+						var teamNumber = (uint)0;
+						if (team)
+							teamNumber = (isObserver || world.LocalPlayer.WinState != WinState.Undefined) ? uint.MaxValue : (uint)orderManager.LocalClient.Team;
+
+						orderManager.IssueOrder(Order.Chat(chatText.Text.Trim(), teamNumber));
 					}
 					else if (chatTraits != null)
 					{

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -124,7 +124,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (chatText.Text != "")
 				{
 					if (!chatText.Text.StartsWith("/", StringComparison.Ordinal))
-						orderManager.IssueOrder(Order.Chat(team, chatText.Text.Trim()));
+					{
+						// This should never happen, but avoid a crash if it does somehow (chat will just stay open)
+						if (!isObserver && orderManager.LocalClient == null && world.LocalPlayer == null)
+							return true;
+
+						var teamNumber = (isObserver || world.LocalPlayer.WinState != WinState.Undefined) ? 0 : orderManager.LocalClient.Team;
+						orderManager.IssueOrder(Order.Chat(team, chatText.Text.Trim(), teamNumber));
+					}
 					else if (chatTraits != null)
 					{
 						var text = chatText.Text.Trim();

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			chatChrome.Visible = true;
 
 			var chatMode = chatChrome.Get<ButtonWidget>("CHAT_MODE");
-			chatMode.GetText = () => teamChat ? "Team" : "All";
+			chatMode.GetText = () => teamChat && !disableTeamChat ? "Team" : "All";
 			chatMode.OnClick = () => teamChat ^= true;
 
 			// Team chat is disabled if we are the only spectator
@@ -113,6 +113,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			else
 				chatMode.IsDisabled = () => disableTeamChat;
 
+			// Disable team chat after the game ended
+			world.GameOver += () => disableTeamChat = true;
+
 			chatText = chatChrome.Get<TextFieldWidget>("CHAT_TEXTFIELD");
 			chatText.MaxLength = UnitOrders.ChatMessageMaxLength;
 			chatText.OnEnterKey = () =>
@@ -144,10 +147,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				chatText.Text = tabCompletion.Complete(chatText.Text);
 				chatText.CursorPosition = chatText.Text.Length;
 
-				if (chatText.Text == previousText)
-					return SwitchTeamChat();
-				else
-					return true;
+				if (chatText.Text == previousText && !disableTeamChat)
+					teamChat ^= true;
+
+				return true;
 			};
 
 			chatText.OnEscKey = () =>
@@ -215,13 +218,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			MiniYaml yaml;
 			if (logicArgs.TryGetValue("ChatLineSound", out yaml))
 				chatLineSound = yaml.Value;
-		}
-
-		bool SwitchTeamChat()
-		{
-			if (!disableTeamChat)
-				teamChat ^= true;
-			return true;
 		}
 
 		public void OpenChat()

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -93,7 +93,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					if (world.IsGameOver)
 						return true;
 
-					// Nothing changed since the start
+					// Check if we are the only living team member
+					if (players.All(p => p.WinState != WinState.Undefined || !p.IsAlliedWith(world.LocalPlayer)))
+					{
+						disableTeamChat = true;
+						return disableTeamChat;
+					}
+
+					// Still alive and nothing changed since the start
 					if (world.LocalPlayer.WinState == WinState.Undefined)
 						return disableTeamChat;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -402,11 +402,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				// Always scroll to bottom when we've typed something
 				lobbyChatPanel.ScrollToBottom();
 
-				var teamNumber = 0;
-				if (teamChat && orderManager.LocalClient != null && !orderManager.LocalClient.IsObserver)
-					teamNumber = orderManager.LocalClient.Team;
+				var teamNumber = (uint)0;
+				if (teamChat && orderManager.LocalClient != null)
+					teamNumber = orderManager.LocalClient.IsObserver ? uint.MaxValue : (uint)orderManager.LocalClient.Team;
 
-				orderManager.IssueOrder(Order.Chat(teamChat, chatTextField.Text, teamNumber));
+				orderManager.IssueOrder(Order.Chat(chatTextField.Text, teamNumber));
 				chatTextField.Text = "";
 				return true;
 			};

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -402,7 +402,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				// Always scroll to bottom when we've typed something
 				lobbyChatPanel.ScrollToBottom();
 
-				orderManager.IssueOrder(Order.Chat(teamChat, chatTextField.Text));
+				var teamNumber = 0;
+				if (teamChat && orderManager.LocalClient != null && !orderManager.LocalClient.IsObserver)
+					teamNumber = orderManager.LocalClient.Team;
+
+				orderManager.IssueOrder(Order.Chat(teamChat, chatTextField.Text, teamNumber));
 				chatTextField.Text = "";
 				return true;
 			};

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -550,8 +550,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (orderManager.LocalClient == null)
 				return;
 
-			disableTeamChat = orderManager.LocalClient.Team == 0 ||
-				!orderManager.LobbyInfo.Clients.Any(c =>
+			// Check if we are not assigned to any team, and are no spectator
+			// If we are a spectator, check if there are more and enable spectator chat
+			// Otherwise check if our assigned team has more players
+			if (orderManager.LocalClient.Team == 0 && !orderManager.LocalClient.IsObserver)
+				disableTeamChat = true;
+			else if (orderManager.LocalClient.IsObserver)
+				disableTeamChat = !orderManager.LobbyInfo.Clients.Any(c => c != orderManager.LocalClient && c.IsObserver);
+			else
+				disableTeamChat = !orderManager.LobbyInfo.Clients.Any(c =>
 					c != orderManager.LocalClient &&
 					c.Bot == null &&
 					c.Team == orderManager.LocalClient.Team);


### PR DESCRIPTION
Fixes #12226.

Team chat is...
- now disabled if you are the only spectator.
- re-enabled if the count of spectators is greater than one due to dead players.
- permanently disabled when the game ended.

Note that team chat currently does not get disabled if you are the only player left on your team. However, that shouldn't be too hard to do if we want that fixed, too.