### PR TITLE
Add plumbing for performing custom activity code on actor disposal

### DIFF
--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -200,6 +200,24 @@ namespace OpenRA.Activities
 		/// </summary>
 		protected virtual void OnLastRun(Actor self) { }
 
+		/// <summary>
+		/// Runs once on Actor.Dispose() (through OnActorDisposeOuter) and can be used to perform activity clean-up on actor death/disposal,
+		/// for example by force-triggering OnLastRun (which would otherwise be skipped).
+		/// </summary>
+		protected virtual void OnActorDispose(Actor self) { }
+
+		/// <summary>
+		/// Runs once on Actor.Dispose().
+		/// Main purpose is to ensure ChildActivity.OnActorDispose runs as well (which isn't otherwise accessible due to protection level).
+		/// </summary>
+		internal void OnActorDisposeOuter(Actor self)
+		{
+			if (ChildActivity != null)
+				ChildActivity.OnActorDisposeOuter(self);
+
+			OnActorDispose(self);
+		}
+
 		public virtual bool Cancel(Actor self, bool keepQueue = false)
 		{
 			if (!IsInterruptible)

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -265,6 +265,11 @@ namespace OpenRA
 
 		public void Dispose()
 		{
+			// If CurrentActivity isn't null, run OnActorDisposeOuter in case some cleanups are needed.
+			// This should be done before the FrameEndTask to avoid dependency issues.
+			if (CurrentActivity != null)
+				CurrentActivity.RootActivity.OnActorDisposeOuter(this);
+
 			World.AddFrameEndTask(w =>
 			{
 				if (Disposed)


### PR DESCRIPTION
It appears that if an actor dies (or is disposed directly) while an activity is active, the actor will be disposed before the activities' `TickOuter` can tick one last time, so `OnLastRun` is never triggered.
As #15543 shows, this can lead to some nasty bugs.

This PR enforces a proper activity end on actor death/disposal.