### PR TITLE
Add Aircraft Takeoff & Landing Sounds (Planes)

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -22,6 +22,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly Target target;
 		readonly WDist maxRange;
 		readonly WDist minRange;
+		bool soundPlayed;
 
 		public Fly(Actor self, Target t)
 		{
@@ -66,6 +67,12 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (IsCanceled || !target.IsValidFor(self))
 				return NextActivity;
+
+			if (!soundPlayed && aircraft.Info.TakeoffSounds.Length > 0 && self.IsAtGroundLevel())
+			{
+				Game.Sound.Play(SoundType.World, aircraft.Info.TakeoffSounds.Random(self.World.SharedRandom), aircraft.CenterPosition);
+				soundPlayed = true;
+			}
 
 			// Inside the target annulus, so we're done
 			var insideMaxRange = maxRange.Length > 0 && target.IsInRange(aircraft.CenterPosition, maxRange);

--- a/OpenRA.Mods.Common/Activities/Air/HeliFly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliFly.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly Target target;
 		readonly WDist maxRange;
 		readonly WDist minRange;
-		bool playedSound;
+		bool soundPlayed;
 
 		public HeliFly(Actor self, Target t)
 		{
@@ -64,10 +64,10 @@ namespace OpenRA.Mods.Common.Activities
 			if (IsCanceled || !target.IsValidFor(self))
 				return NextActivity;
 
-			if (!playedSound && aircraft.Info.TakeoffSound != null && self.IsAtGroundLevel())
+			if (!soundPlayed && aircraft.Info.TakeoffSounds.Length > 0 && self.IsAtGroundLevel())
 			{
-				Game.Sound.Play(SoundType.World, aircraft.Info.TakeoffSound);
-				playedSound = true;
+				Game.Sound.Play(SoundType.World, aircraft.Info.TakeoffSounds.Random(self.World.SharedRandom), aircraft.CenterPosition);
+				soundPlayed = true;
 			}
 
 			if (AdjustAltitude(self, aircraft, aircraft.Info.CruiseAltitude))

--- a/OpenRA.Mods.Common/Activities/Air/HeliLand.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliLand.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly WDist landAltitude;
 		readonly bool requireSpace;
 
-		bool playedSound;
+		bool soundPlayed;
 
 		public HeliLand(Actor self, bool requireSpace)
 			: this(self, requireSpace, self.Info.TraitInfo<AircraftInfo>().LandAltitude) { }
@@ -40,10 +40,10 @@ namespace OpenRA.Mods.Common.Activities
 			if (requireSpace && !aircraft.CanLand(self.Location))
 				return this;
 
-			if (!playedSound && aircraft.Info.LandingSound != null && !self.IsAtGroundLevel())
+			if (!soundPlayed && aircraft.Info.LandingSounds.Length > 0 && !self.IsAtGroundLevel())
 			{
-				Game.Sound.Play(SoundType.World, aircraft.Info.LandingSound);
-				playedSound = true;
+				Game.Sound.Play(SoundType.World, aircraft.Info.LandingSounds.Random(self.World.SharedRandom), aircraft.CenterPosition);
+				soundPlayed = true;
 			}
 
 			if (HeliFly.AdjustAltitude(self, aircraft, landAltitude))

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -20,6 +20,8 @@ namespace OpenRA.Mods.Common.Activities
 		readonly Target target;
 		readonly Aircraft aircraft;
 
+		bool soundPlayed;
+
 		public Land(Actor self, Target t)
 		{
 			target = t;
@@ -33,6 +35,12 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (IsCanceled)
 				return NextActivity;
+
+			if (!soundPlayed && aircraft.Info.LandingSounds.Length > 0 && !self.IsAtGroundLevel())
+			{
+				Game.Sound.Play(SoundType.World, aircraft.Info.LandingSounds.Random(self.World.SharedRandom), aircraft.CenterPosition);
+				soundPlayed = true;
+			}
 
 			var d = target.CenterPosition - self.CenterPosition;
 

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -588,6 +588,7 @@
     <Compile Include="Traits\ActorSpawner.cs" />
     <Compile Include="UpdateRules\Rules\20180923\MergeCaptureTraits.cs" />
     <Compile Include="UpdateRules\Rules\20180923\RemovedNotifyBuildComplete.cs" />
+    <Compile Include="UpdateRules\Rules\20180923\ChangeTakeOffSoundAndLandingSound.cs" />
     <Compile Include="UtilityCommands\CheckYaml.cs" />
     <Compile Include="UtilityCommands\ConvertPngToShpCommand.cs" />
     <Compile Include="UtilityCommands\ConvertSpriteToPngCommand.cs" />

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -96,11 +96,11 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("How fast this actor ascends or descends when using vertical take off/landing.")]
 		public readonly WDist AltitudeVelocity = new WDist(43);
 
-		[Desc("Sound to play when the actor is taking off.")]
-		public readonly string TakeoffSound = null;
+		[Desc("Sounds to play when the actor is taking off.")]
+		public readonly string[] TakeoffSounds = { };
 
-		[Desc("Sound to play when the actor is landing.")]
-		public readonly string LandingSound = null;
+		[Desc("Sounds to play when the actor is landing.")]
+		public readonly string[] LandingSounds = { };
 
 		[Desc("The distance of the resupply base that the aircraft will wait for its turn.")]
 		public readonly WDist WaitDistanceFromResupplyBase = new WDist(3072);

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/ChangeTakeOffSoundAndLandingSound.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/ChangeTakeOffSoundAndLandingSound.cs
@@ -1,0 +1,41 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class ChangeTakeOffSoundAndLandingSound : UpdateRule
+	{
+		public override string Name { get { return "Change 'TakeOffSound' and 'LandingSound' parameters within 'Aircraft' Trait."; } }
+		public override string Description
+		{
+			get
+			{
+				return "The 'TakeOffSound' and 'LandingSound' parameters within 'Aircraft' have been changed\n" +
+					"to accept an array of playable sounds.\n" +
+					"They were renamed to 'TakeOffSounds' and 'LandingSounds' respectively, to reflect this change.\n" +
+					"Definitions of 'TakeOffSound' and 'LandingSound' will be automatically renamed.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var aircraft in actorNode.ChildrenMatching("Aircraft"))
+			{
+				aircraft.RenameChildrenMatching("TakeOffSound", "TakeOffSounds");
+				aircraft.RenameChildrenMatching("LandingSound", "LandingSounds");
+			}
+
+			yield break;
+		}
+	}
+}

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -44,8 +44,8 @@ DSHP:
 		Speed: 168
 		InitialFacing: 0
 		LandableTerrainTypes: Clear,Road,Rail,DirtRoad,Rough,Tiberium,BlueTiberium,Veins
-		TakeoffSound: dropup1.aud
-		LandingSound: dropdwn1.aud
+		TakeoffSounds: dropup1.aud
+		LandingSounds: dropdwn1.aud
 		IdealSeparation: 1275
 	Health:
 		HP: 20000
@@ -84,8 +84,8 @@ ORCA:
 		TurnSpeed: 5
 		Speed: 186
 		MoveIntoShroud: false
-		TakeoffSound: orcaup1.aud
-		LandingSound: orcadwn1.aud
+		TakeoffSounds: orcaup1.aud
+		LandingSounds: orcadwn1.aud
 	Health:
 		HP: 20000
 	Armor:
@@ -134,8 +134,8 @@ ORCAB:
 		Speed: 96
 		CruisingCondition: cruising
 		MoveIntoShroud: false
-		TakeoffSound: orcaup1.aud
-		LandingSound: orcadwn1.aud
+		TakeoffSounds: orcaup1.aud
+		LandingSounds: orcadwn1.aud
 	ReturnOnIdle:
 	Health:
 		HP: 26000
@@ -182,8 +182,8 @@ ORCATRAN:
 		Speed: 84
 		InitialFacing: 0
 		LandableTerrainTypes: Clear,Road,Rail,DirtRoad,Rough,Tiberium,BlueTiberium,Veins
-		TakeoffSound: orcaup1.aud
-		LandingSound: orcadwn1.aud
+		TakeoffSounds: orcaup1.aud
+		LandingSounds: orcadwn1.aud
 		IdealSeparation: 1275
 	Health:
 		HP: 20000
@@ -218,8 +218,8 @@ TRNSPORT:
 		Speed: 149
 		InitialFacing: 0
 		LandableTerrainTypes: Clear,Road,Rail,DirtRoad,Rough,Tiberium,BlueTiberium,Veins
-		TakeoffSound: dropup1.aud
-		LandingSound: dropdwn1.aud
+		TakeoffSounds: dropup1.aud
+		LandingSounds: dropdwn1.aud
 		AltitudeVelocity: 64
 		MoveIntoShroud: false
 	Carryall:
@@ -264,8 +264,8 @@ SCRIN:
 		Speed: 168
 		AirborneCondition: airborne
 		MoveIntoShroud: false
-		TakeoffSound: dropup1.aud
-		LandingSound: dropdwn1.aud
+		TakeoffSounds: dropup1.aud
+		LandingSounds: dropdwn1.aud
 	ReturnOnIdle:
 	Health:
 		HP: 28000


### PR DESCRIPTION
Added Takeoff & Landing sounds to planes.

Changed Aircraft Trait, TakeoffSound & LandingSound are now arrays & will accept a list of sound files.
It will randomly select one to play.

Changed/Fixed, take off & landing sounds to originate from the aircraft location, rather than play a global sound.

Only affects the offical TS mod, useful for other mods.