### PR TITLE
Fixed CustomTerrainDebugOverlay not being rendered in isometric mods

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new CustomTerrainDebugOverlay(init.Self, this); }
 	}
 
-	class CustomTerrainDebugOverlay : IWorldLoaded, IChatCommand, IRender
+	class CustomTerrainDebugOverlay : IWorldLoaded, IChatCommand, IRenderAboveWorld
 	{
 		const string CommandName = "debugcustomterrain";
 		const string CommandDesc = "toggles the custom terrain debug overlay.";
@@ -58,10 +58,10 @@ namespace OpenRA.Mods.Common.Traits
 				Enabled ^= true;
 		}
 
-		IEnumerable<IRenderable> IRender.Render(Actor self, WorldRenderer wr)
+		void IRenderAboveWorld.RenderAboveWorld(Actor self, WorldRenderer wr)
 		{
 			if (!Enabled)
-				yield break;
+				return;
 
 			foreach (var uv in wr.Viewport.VisibleCellsInsideBounds.CandidateMapCoords)
 			{
@@ -72,14 +72,9 @@ namespace OpenRA.Mods.Common.Traits
 					continue;
 
 				var info = wr.World.Map.GetTerrainInfo(cell);
-				yield return new TextRenderable(font, center, 0, info.Color, info.Type);
+				var render = new TextRenderable(font, center, 0, info.Color, info.Type);
+				render.Render(wr);
 			}
-		}
-
-		IEnumerable<Rectangle> IRender.ScreenBounds(Actor self, WorldRenderer wr)
-		{
-			// World-actor render traits don't require screen bounds
-			yield break;
 		}
 	}
 }


### PR DESCRIPTION
Closes https://github.com/OpenRA/OpenRA/issues/13945.