### PR TITLE
Fix game crash when adding a player with a removed owner selected

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -172,7 +172,10 @@ namespace OpenRA.Mods.Common.Traits
 				var index = int.Parse(name.Substring(5));
 
 				if (index >= newCount)
+				{
 					Players.Players.Remove(name);
+					OnPlayerRemoved();
+				}
 			}
 
 			for (var index = 0; index < newCount; index++)
@@ -248,6 +251,8 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			return screenMap.At(worldPx);
 		}
+
+		public Action OnPlayerRemoved = () => { };
 
 		string NextActorName()
 		{

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -72,20 +72,19 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			selectedOwner = editorLayer.Players.Players.Values.First();
 			Func<PlayerReference, ScrollItemWidget, ScrollItemWidget> setupItem = (option, template) =>
 			{
-				var item = ScrollItemWidget.Setup(template, () => selectedOwner == option, () =>
-				{
-					selectedOwner = option;
-
-					ownersDropDown.Text = selectedOwner.Name;
-					ownersDropDown.TextColor = selectedOwner.Color.RGB;
-
-					InitializeActorPreviews();
-				});
+				var item = ScrollItemWidget.Setup(template, () => selectedOwner == option, () => SelectOwner(option));
 
 				item.Get<LabelWidget>("LABEL").GetText = () => option.Name;
 				item.GetColor = () => option.Color.RGB;
 
 				return item;
+			};
+
+			editorLayer.OnPlayerRemoved = () =>
+			{
+				if (editorLayer.Players.Players.Values.Any(p => p.Name == selectedOwner.Name))
+					return;
+				SelectOwner(editorLayer.Players.Players.Values.First());
 			};
 
 			ownersDropDown.OnClick = () =>
@@ -199,6 +198,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				actorCategorySelector.AttachPanel(CreateCategoriesPanel());
 			};
 
+			InitializeActorPreviews();
+		}
+
+		void SelectOwner(PlayerReference option)
+		{
+			selectedOwner = option;
+			ownersDropDown.Text = option.Name;
+			ownersDropDown.TextColor = option.Color.RGB;
 			InitializeActorPreviews();
 		}
 


### PR DESCRIPTION
fix #9364
fix #15623 
fix #14924

added an event/event handler to EditorLayer/PlayerSelectorLogic to notify when selected owner should be updated.
Detailed information in commit message.
