### PR TITLE
Rename EditorTilesetFilter to MapEditorData

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -93,6 +93,7 @@ Also thanks to:
     * Lawrence Wang
     * Lesueur Benjamin (Valkirie)
     * Maarten Meuris (Nyerguds)
+    * Manuel Geiger (Ectras)
     * Mark Olson (markolson)
     * Markus Hartung (hartmark)
     * Matija Hustic (matija-hustic)

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -351,7 +351,7 @@
     <Compile Include="Traits\Demolishable.cs" />
     <Compile Include="Traits\Demolition.cs" />
     <Compile Include="Traits\DetectCloaked.cs" />
-    <Compile Include="Traits\EditorTilesetFilter.cs" />
+    <Compile Include="Traits\MapEditorData.cs" />
     <Compile Include="Traits\EjectOnDeath.cs" />
     <Compile Include="Traits\SpawnActorsOnSell.cs" />
     <Compile Include="Traits\EngineerRepair.cs" />
@@ -866,6 +866,7 @@
     <Compile Include="UpdateRules\UpdateRule.cs" />
     <Compile Include="UpdateRules\UpdatePath.cs" />
     <Compile Include="UpdateRules\UpdateUtils.cs" />
+    <Compile Include="UpdateRules\Rules\RenameEditorTilesetFilter.cs" />
     <Compile Include="UpdateRules\Rules\20171014\LegacyBetaWarning.cs" />
     <Compile Include="UpdateRules\Rules\20171014\RemoveMobileOnRails.cs" />
     <Compile Include="UpdateRules\Rules\20171014\AircraftCanHoverGeneralization.cs" />

--- a/OpenRA.Mods.Common/Traits/MapEditorData.cs
+++ b/OpenRA.Mods.Common/Traits/MapEditorData.cs
@@ -14,12 +14,12 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class EditorTilesetFilterInfo : TraitInfo<EditorTilesetFilter>
+	public class MapEditorDataInfo : TraitInfo<MapEditorData>
 	{
 		public readonly HashSet<string> RequireTilesets = null;
 		public readonly HashSet<string> ExcludeTilesets = null;
 		public readonly string[] Categories;
 	}
 
-	public class EditorTilesetFilter { }
+	public class MapEditorData { }
 }

--- a/OpenRA.Mods.Common/UpdateRules/Rules/RenameEditorTilesetFilter.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/RenameEditorTilesetFilter.cs
@@ -1,0 +1,35 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RenameEditorTilesetFilter : UpdateRule
+	{
+		public override string Name { get { return "EditorTilesetFilter renamed to MapEditorData"; } }
+		public override string Description
+		{
+			get
+			{
+				return "The name EditorTilesetFilter was misleading and was renamed to MapEditorData.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var data in actorNode.ChildrenMatching("EditorTilesetFilter"))
+				data.RenameKey("MapEditorData");
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -87,6 +87,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 			new UpdatePath("playtest-20180729", new UpdateRule[]
 			{
 				// Bleed only changes here
+				new RenameEditorTilesetFilter()
 			})
 		};
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (!a.HasTraitInfo<IRenderActorPreviewInfo>())
 					continue;
 
-				var editorData = a.TraitInfoOrDefault<EditorTilesetFilterInfo>();
+				var editorData = a.TraitInfoOrDefault<MapEditorDataInfo>();
 
 				// Actor must be included in at least one category
 				if (editorData == null || editorData.Categories == null)

--- a/mods/cnc/rules/civilian-desert.yaml
+++ b/mods/cnc/rules/civilian-desert.yaml
@@ -11,7 +11,7 @@ V20:
 		Dimensions: 2,2
 	SpawnActorOnDeath:
 		Actor: V20.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Sala's House
@@ -21,7 +21,7 @@ V20.Husk:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Sala's House (Destroyed)
@@ -44,7 +44,7 @@ V21:
 		Dimensions: 2,2
 	SpawnActorOnDeath:
 		Actor: V21.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Abdul's House
@@ -54,7 +54,7 @@ V21.Husk:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Abdul's House (Destroyed)
@@ -67,7 +67,7 @@ V22:
 		Dimensions: 2,1
 	SpawnActorOnDeath:
 		Actor: V22.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Pablo's Wicked Pub
@@ -77,7 +77,7 @@ V22.Husk:
 	Building:
 		Footprint: xx
 		Dimensions: 2,1
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Pablo's Wicked Pub (Destroyed)
@@ -86,14 +86,14 @@ V23:
 	Inherits: ^CivBuilding
 	SpawnActorOnDeath:
 		Actor: V23.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Village Well
 
 V23.Husk:
 	Inherits: ^CivBuildingHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Village Well (Destroyed)
@@ -111,7 +111,7 @@ V24:
 		Dimensions: 2,2
 	SpawnActorOnDeath:
 		Actor: V24.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Camel Trader
@@ -121,7 +121,7 @@ V24.Husk:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Camel Trader (Destroyed)
@@ -141,7 +141,7 @@ V25:
 		Name: Church
 	SpawnActorOnDeath:
 		Actor: V25.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 
 V25.Husk:
@@ -151,7 +151,7 @@ V25.Husk:
 		Dimensions: 2,2
 	Tooltip:
 		Name: Church (Destroyed)
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 
 V26:
@@ -162,7 +162,7 @@ V26:
 		Dimensions: 2,1
 	SpawnActorOnDeath:
 		Actor: V26.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Ali's House
@@ -172,7 +172,7 @@ V26.Husk:
 	Building:
 		Footprint: xx
 		Dimensions: 2,1
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Ali's House (Destroyed)
@@ -181,14 +181,14 @@ V27:
 	Inherits: ^CivBuilding
 	SpawnActorOnDeath:
 		Actor: V27.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Trader Ted's
 
 V27.Husk:
 	Inherits: ^CivBuildingHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Trader Ted's (Destroyed)
@@ -197,14 +197,14 @@ V28:
 	Inherits: ^CivBuilding
 	SpawnActorOnDeath:
 		Actor: V28.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Menelik's House
 
 V28.Husk:
 	Inherits: ^CivBuildingHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Menelik's House (Destroyed)
@@ -213,14 +213,14 @@ V29:
 	Inherits: ^CivBuilding
 	SpawnActorOnDeath:
 		Actor: V29.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Prestor John's House
 
 V29.Husk:
 	Inherits: ^CivBuildingHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Prestor John's House (Destroyed)
@@ -233,7 +233,7 @@ V30:
 		Dimensions: 2,1
 	SpawnActorOnDeath:
 		Actor: V30.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Village Well
@@ -243,7 +243,7 @@ V30.Husk:
 	Building:
 		Footprint: xx
 		Dimensions: 2,1
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Village Well (Destroyed)
@@ -256,7 +256,7 @@ V31:
 		Dimensions: 2,1
 	SpawnActorOnDeath:
 		Actor: V31.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Witch Doctor's Hut
@@ -266,7 +266,7 @@ V31.Husk:
 	Building:
 		Footprint: xx
 		Dimensions: 2,1
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Witch Doctor's Hut (Destroyed)
@@ -279,7 +279,7 @@ V32:
 		Dimensions: 2,1
 	SpawnActorOnDeath:
 		Actor: V32.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Rikitikitembo's Hut
@@ -289,7 +289,7 @@ V32.Husk:
 	Building:
 		Footprint: xx
 		Dimensions: 2,1
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Rikitikitembo's Hut (Destroyed)
@@ -302,7 +302,7 @@ V33:
 		Dimensions: 2,1
 	SpawnActorOnDeath:
 		Actor: V33.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Roarke's Hut
@@ -312,7 +312,7 @@ V33.Husk:
 	Building:
 		Footprint: xx
 		Dimensions: 2,1
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Roarke's Hut (Destroyed)
@@ -321,14 +321,14 @@ V34:
 	Inherits: ^CivBuilding
 	SpawnActorOnDeath:
 		Actor: V34.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Mubasa's Hut
 
 V34.Husk:
 	Inherits: ^CivBuildingHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Mubasa's Hut (Destroyed)
@@ -337,14 +337,14 @@ V35:
 	Inherits: ^CivBuilding
 	SpawnActorOnDeath:
 		Actor: V35.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Aksum's Hut
 
 V35.Husk:
 	Inherits: ^CivBuildingHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Aksum's Hut (Destroyed)
@@ -353,14 +353,14 @@ V36:
 	Inherits: ^CivBuilding
 	SpawnActorOnDeath:
 		Actor: V36.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Mambo's Hut
 
 V36.Husk:
 	Inherits: ^CivBuildingHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: Mambo's Hut (Destroyed)
@@ -378,7 +378,7 @@ V37:
 	Building:
 		Footprint: __xx_ ___xx
 		Dimensions: 5,2
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: The Studio
@@ -388,7 +388,7 @@ V37.Husk:
 	Building:
 		Footprint: __xx_ ___xx
 		Dimensions: 5,2
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	Tooltip:
 		Name: The Studio (Destroyed)

--- a/mods/cnc/rules/civilian.yaml
+++ b/mods/cnc/rules/civilian.yaml
@@ -13,7 +13,7 @@ V01:
 		Name: Church
 	SpawnActorOnDeath:
 		Actor: V01.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 
 V01.Husk:
@@ -23,7 +23,7 @@ V01.Husk:
 		Dimensions: 2,2
 	Tooltip:
 		Name: Church (Destroyed)
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 
 V02:
@@ -39,7 +39,7 @@ V02:
 		Dimensions: 2,2
 	SpawnActorOnDeath:
 		Actor: V02.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Han's and Gretel's
@@ -49,7 +49,7 @@ V02.Husk:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Han's and Gretel's (Destroyed)
@@ -67,7 +67,7 @@ V03:
 		Dimensions: 2,2
 	SpawnActorOnDeath:
 		Actor: V03.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Hewitt's House
@@ -77,7 +77,7 @@ V03.Husk:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Hewitt's House (Destroyed)
@@ -95,7 +95,7 @@ V04:
 		Dimensions: 2,2
 	SpawnActorOnDeath:
 		Actor: V04.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Ricktor's House
@@ -105,7 +105,7 @@ V04.Husk:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Ricktor's House (Destroyed)
@@ -118,7 +118,7 @@ V05:
 		Dimensions: 2,1
 	SpawnActorOnDeath:
 		Actor: V05.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Gretchkin's house
@@ -128,7 +128,7 @@ V05.Husk:
 	Building:
 		Footprint: xx
 		Dimensions: 2,1
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Gretchkin's house (Destroyed)
@@ -141,7 +141,7 @@ V06:
 		Dimensions: 2,1
 	SpawnActorOnDeath:
 		Actor: V06.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: The Barn
@@ -151,7 +151,7 @@ V06.Husk:
 	Building:
 		Footprint: xx
 		Dimensions: 2,1
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: The Barn (Destroyed)
@@ -164,7 +164,7 @@ V07:
 		Dimensions: 2,1
 	SpawnActorOnDeath:
 		Actor: V07.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Damon's Pub
@@ -174,7 +174,7 @@ V07.Husk:
 	Building:
 		Footprint: xx
 		Dimensions: 2,1
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Damon's Pub (Destroyed)
@@ -183,14 +183,14 @@ V08:
 	Inherits: ^CivBuilding
 	SpawnActorOnDeath:
 		Actor: V08.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Fran's House
 
 V08.Husk:
 	Inherits: ^CivBuildingHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Fran's House (Destroyed)
@@ -199,14 +199,14 @@ V09:
 	Inherits: ^CivBuilding
 	SpawnActorOnDeath:
 		Actor: V09.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Music Factory
 
 V09.Husk:
 	Inherits: ^CivBuildingHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Music Factory (Destroyed)
@@ -215,14 +215,14 @@ V10:
 	Inherits: ^CivBuilding
 	SpawnActorOnDeath:
 		Actor: V10.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Toymaker's
 
 V10.Husk:
 	Inherits: ^CivBuildingHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Toymaker's (Destroyed)
@@ -231,14 +231,14 @@ V11:
 	Inherits: ^CivBuilding
 	SpawnActorOnDeath:
 		Actor: V11.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Ludwig's House
 
 V11.Husk:
 	Inherits: ^CivBuildingHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Ludwig's House (Destroyed)
@@ -247,14 +247,14 @@ V12:
 	Inherits: ^CivField
 	SpawnActorOnDeath:
 		Actor: V12.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Haystacks
 
 V12.Husk:
 	Inherits: ^CivBuildingHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Haystacks (Destroyed)
@@ -263,14 +263,14 @@ V13:
 	Inherits: ^CivField
 	SpawnActorOnDeath:
 		Actor: V13.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Haystacks
 
 V13.Husk:
 	Inherits: ^CivBuildingHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Haystacks (Destroyed)
@@ -279,14 +279,14 @@ V14:
 	Inherits: ^CivField
 	SpawnActorOnDeath:
 		Actor: V14.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Wheat Field
 
 V14.Husk:
 	Inherits: ^CivFieldHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Wheat Field (Destroyed)
@@ -295,14 +295,14 @@ V15:
 	Inherits: ^CivField
 	SpawnActorOnDeath:
 		Actor: V15.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Fallow Field
 
 V15.Husk:
 	Inherits: ^CivFieldHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Fallow Field (Destroyed)
@@ -311,14 +311,14 @@ V16:
 	Inherits: ^CivField
 	SpawnActorOnDeath:
 		Actor: V16.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Corn Field
 
 V16.Husk:
 	Inherits: ^CivFieldHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Corn Field (Destroyed)
@@ -327,14 +327,14 @@ V17:
 	Inherits: ^CivField
 	SpawnActorOnDeath:
 		Actor: V17.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Celery Field
 
 V17.Husk:
 	Inherits: ^CivFieldHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Celery Field (Destroyed)
@@ -343,14 +343,14 @@ V18:
 	Inherits: ^CivField
 	SpawnActorOnDeath:
 		Actor: V18.Husk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Potato Field
 
 V18.Husk:
 	Inherits: ^CivFieldHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	Tooltip:
 		Name: Potato Field (Destroyed)

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -276,7 +276,7 @@
 	BodyOrientation:
 		UseClassicFacingFudge: True
 	HitShape:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Vehicle
 
 ^Tank:
@@ -337,7 +337,7 @@
 	BodyOrientation:
 		UseClassicFacingFudge: True
 	HitShape:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Aircraft
 	SpawnActorOnDeath:
 		RequiresCondition: airborne
@@ -450,7 +450,7 @@
 	HitShape:
 		Type: Circle
 			Radius: 128
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Infantry
 
 ^Soldier:
@@ -496,7 +496,7 @@
 	Wanders:
 		MinMoveDelay: 150
 		MaxMoveDelay: 750
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Civilian infantry
 
 ^ArmedCivilian:
@@ -559,7 +559,7 @@
 	HitShape:
 		Type: Circle
 			Radius: 128
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Critter
 
 ^Viceroid:
@@ -616,7 +616,7 @@
 	HitShape:
 		Type: Circle
 			Radius: 427
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Critter
 
 ^Plane:
@@ -640,7 +640,7 @@
 	RejectsOrders:
 	Aircraft:
 		CruiseAltitude: 2560
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Aircraft
 
 ^Ship:
@@ -669,7 +669,7 @@
 	Voiced:
 		VoiceSet: VehicleVoice
 	HitShape:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Naval
 
 ^Building:
@@ -712,7 +712,7 @@
 		GenericName: Structure
 	FrozenUnderFog:
 	Demolishable:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Building
 	CommandBarBlacklist:
 	AcceptsDeliveredCash:
@@ -761,7 +761,7 @@
 		GenericStancePrefix: false
 		ShowOwnerRow: false
 	FrozenUnderFog:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Civilian building
 
 ^CivBuildingHusk:
@@ -778,7 +778,7 @@
 		ShowOwnerRow: false
 	FrozenUnderFog:
 	ScriptTriggers:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Husk
 
 ^TechBuilding:
@@ -797,7 +797,7 @@
 		Range: 3c0
 	Tooltip:
 		ShowOwnerRow: True
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Tech building
 	WithBuildingRepairDecoration:
 		Image: allyrepair
@@ -836,7 +836,7 @@
 	WithSpriteBody:
 	FrozenUnderFog:
 	ScriptTriggers:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Husk
 
 ^Wall:
@@ -877,7 +877,7 @@
 	ScriptTriggers:
 	Health:
 		HP: 10000
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Wall
 
 ^Tree:
@@ -919,7 +919,7 @@
 	HiddenUnderShroud:
 	ScriptTriggers:
 	HitShape:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Tree
 
 ^TreeHusk:
@@ -937,7 +937,7 @@
 		ShowOwnerRow: false
 	FrozenUnderFog:
 	ScriptTriggers:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Tree
 
 ^TibTree:
@@ -957,7 +957,7 @@
 		Terrain: Tiberium
 	HiddenUnderShroud:
 	WithMakeAnimation:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Resource spawn
 
 ^Rock:
@@ -977,7 +977,7 @@
 		Terrain: Tree
 	HiddenUnderShroud:
 	ScriptTriggers:
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 		Categories: Decoration
 
@@ -992,7 +992,7 @@
 		Type: CenterPosition
 	WithFacingSpriteBody:
 	HitShape:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Husk
 
 ^Husk:
@@ -1082,7 +1082,7 @@
 		Image: crate
 	WithCrateBody:
 		XmasImages: xcratea, xcrateb, xcratec, xcrated
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 
 ^Defense:
@@ -1094,7 +1094,7 @@
 		RequiredForShortGame: false
 	Targetable:
 		TargetTypes: Ground, C4, Structure, Defense
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Defense
 	-CommandBarBlacklist:
 	-AcceptsDeliveredCash:

--- a/mods/cnc/rules/misc.yaml
+++ b/mods/cnc/rules/misc.yaml
@@ -56,7 +56,7 @@ mpspawn:
 	RenderSpritesEditorOnly:
 	BodyOrientation:
 		QuantizedFacings: 1
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 
 waypoint:
@@ -70,13 +70,13 @@ waypoint:
 	RenderSpritesEditorOnly:
 	BodyOrientation:
 		QuantizedFacings: 1
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 
 fact.colorpicker:
 	Inherits: FACT
 	-Buildable:
-	-EditorTilesetFilter:
+	-MapEditorData:
 	RenderSprites:
 		Image: fact
 		Palette: colorpicker
@@ -95,7 +95,7 @@ CAMERA:
 	RevealsShroud:
 		Range: 10c0
 		Type: CenterPosition
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 
 CAMERA.small:
@@ -116,7 +116,7 @@ CAMERA.small:
 	RevealsShroud:
 		Range: 6c0
 		Type: CenterPosition
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 
 FLARE:
@@ -137,6 +137,6 @@ FLARE:
 		ShowOwnerRow: false
 	BodyOrientation:
 		QuantizedFacings: 1
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 	Interactable:

--- a/mods/cnc/rules/trees.yaml
+++ b/mods/cnc/rules/trees.yaml
@@ -67,86 +67,86 @@ ROCK7:
 
 T01:
 	Inherits: ^Tree
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: T01.Husk
 
 T01.Husk:
 	Inherits: ^TreeHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 
 T02:
 	Inherits: ^Tree
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: T02.Husk
 
 T02.Husk:
 	Inherits: ^TreeHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 
 T03:
 	Inherits: ^Tree
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: T03.Husk
 
 T03.Husk:
 	Inherits: ^TreeHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 
 T04:
 	Inherits: ^Tree
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: T04.Husk
 
 T04.Husk:
 	Inherits: ^TreeHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 
 T05:
 	Inherits: ^Tree
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: T05.Husk
 
 T05.Husk:
 	Inherits: ^TreeHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 
 T06:
 	Inherits: ^Tree
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: T06.Husk
 
 T06.Husk:
 	Inherits: ^TreeHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 
 T07:
 	Inherits: ^Tree
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: T07.Husk
 
 T07.Husk:
 	Inherits: ^TreeHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 
 T08:
@@ -168,7 +168,7 @@ T09:
 	Building:
 		Footprint: x_
 		Dimensions: 2,1
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: T09.Husk
@@ -178,14 +178,14 @@ T09.Husk:
 	Building:
 		Footprint: x_
 		Dimensions: 2,1
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 
 T10:
 	Inherits: ^Tree
 	Building:
 		Footprint: __ xx
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: T10.Husk
@@ -194,14 +194,14 @@ T10.Husk:
 	Inherits: ^TreeHusk
 	Building:
 		Footprint: __ xx
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 
 T11:
 	Inherits: ^Tree
 	Building:
 		Footprint: __ xx
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: T11.Husk
@@ -210,12 +210,12 @@ T11.Husk:
 	Inherits: ^TreeHusk
 	Building:
 		Footprint: __ xx
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 
 T12:
 	Inherits: ^Tree
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: T12.Husk
@@ -223,12 +223,12 @@ T12:
 T12.Husk:
 	Inherits: ^TreeHusk
 	Building:
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 
 T13:
 	Inherits: ^Tree
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: T13.Husk
@@ -236,19 +236,19 @@ T13:
 T13.Husk:
 	Inherits: ^TreeHusk
 	Building:
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 
 T14:
 	Inherits: ^Tree
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: T14.Husk
 
 T14.Husk:
 	Inherits: ^TreeHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 
 T15:
@@ -256,7 +256,7 @@ T15:
 	Building:
 		Footprint: ___ xx_
 		Dimensions: 3,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: T15.Husk
@@ -266,43 +266,43 @@ T15.Husk:
 	Building:
 		Footprint: ___ xx_
 		Dimensions: 3,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 
 T16:
 	Inherits: ^Tree
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: T16.Husk
 
 T16.Husk:
 	Inherits: ^TreeHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 
 T17:
 	Inherits: ^Tree
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: T17.Husk
 
 T17.Husk:
 	Inherits: ^TreeHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 
 T18:
 	Inherits: ^Tree
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: T18.Husk
 
 T18.Husk:
 	Inherits: ^TreeHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 
 TC01:
@@ -310,7 +310,7 @@ TC01:
 	Building:
 		Footprint: ___ xx_
 		Dimensions: 3,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: TC01.Husk
@@ -320,7 +320,7 @@ TC01.Husk:
 	Building:
 		Footprint: ___ xx_
 		Dimensions: 3,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 
 TC02:
@@ -328,7 +328,7 @@ TC02:
 	Building:
 		Footprint: _x_ xx_
 		Dimensions: 3,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: TC02.Husk
@@ -338,7 +338,7 @@ TC02.Husk:
 	Building:
 		Footprint: _x_ xx_
 		Dimensions: 3,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 
 TC03:
@@ -346,7 +346,7 @@ TC03:
 	Building:
 		Footprint: _x_ xx_
 		Dimensions: 3,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: TC03.Husk
@@ -356,7 +356,7 @@ TC03.Husk:
 	Building:
 		Footprint: _x_ xx_
 		Dimensions: 3,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 
 TC04:
@@ -364,7 +364,7 @@ TC04:
 	Building:
 		Footprint: ____ xxx_ x___
 		Dimensions: 4,3
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: TC04.Husk
@@ -374,7 +374,7 @@ TC04.Husk:
 	Building:
 		Footprint: ____ xxx_ x___
 		Dimensions: 4,3
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 
 TC05:
@@ -382,7 +382,7 @@ TC05:
 	Building:
 		Footprint: __x_ xxx_ _xx_
 		Dimensions: 4,3
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT
 	SpawnActorOnDeath:
 		Actor: TC05.Husk
@@ -392,5 +392,5 @@ TC05.Husk:
 	Building:
 		Footprint: __x_ xxx_ _xx_
 		Dimensions: 4,3
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -26,7 +26,7 @@ spicebloom.spawnpoint:
 	HitShape:
 		Type: Circle
 			Radius: 1
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 
 spicebloom:
@@ -61,7 +61,7 @@ spicebloom:
 	HitShape:
 		Type: Circle
 			Radius: 512
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 	Interactable:
 

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -210,7 +210,7 @@
 		Duration: 100
 		Radius: 2c512
 	HitShape:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Vehicle
 
 ^Tank:
@@ -232,7 +232,7 @@
 	ScriptTriggers:
 	WithFacingSpriteBody:
 	HitShape:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Husk
 
 ^VehicleHusk:
@@ -329,7 +329,7 @@
 	HitShape:
 		Type: Circle
 			Radius: 96
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Infantry
 
 ^Plane:
@@ -352,7 +352,7 @@
 	WithFacingSpriteBody:
 	WithShadow:
 	HitShape:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Aircraft
 
 ^Building:
@@ -427,7 +427,7 @@
 	RevealOnDeath:
 		Duration: 100
 		Radius: 4c768
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Building
 	CommandBarBlacklist:
 	WithBuildingRepairDecoration:
@@ -460,7 +460,7 @@
 	RevealOnFire:
 	Targetable:
 		TargetTypes: Ground, C4, Structure, Defense
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Defense
 	-CommandBarBlacklist:
 

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -134,7 +134,7 @@ crate:
 		Palette: effect
 	WithCrateBody:
 	Passenger:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 	Interactable:
 		Bounds: 20,20
@@ -150,7 +150,7 @@ mpspawn:
 	WithSpriteBody:
 	BodyOrientation:
 		QuantizedFacings: 1
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 
 waypoint:
@@ -164,7 +164,7 @@ waypoint:
 	WithSpriteBody:
 	BodyOrientation:
 		QuantizedFacings: 1
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 
 carryall.colorpicker:
@@ -172,7 +172,7 @@ carryall.colorpicker:
 	Aircraft:
 		InitialFacing: 104
 	-Buildable:
-	-EditorTilesetFilter:
+	-MapEditorData:
 	RenderSprites:
 		Image: carryall
 		Palette: colorpicker
@@ -191,7 +191,7 @@ camera:
 	RevealsShroud:
 		Range: 6c768
 		Type: CenterPosition
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 
 wormspawner:
@@ -206,7 +206,7 @@ wormspawner:
 	BodyOrientation:
 		QuantizedFacings: 1
 	ActorSpawner:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 
 upgrade.conyard:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -748,7 +748,7 @@ wall:
 		Type: Rectangle
 			TopLeft: -512, -512
 			BottomRight: 512, 512
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Defense
 	Replaceable:
 		Types: Tower

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -149,7 +149,7 @@ V01:
 		Name: Church
 	RevealsShroud:
 		Range: 10c0
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	HitShape:
 		UseTargetableCellsOffsets: false
@@ -163,7 +163,7 @@ V02:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	HitShape:
 		UseTargetableCellsOffsets: false
@@ -177,7 +177,7 @@ V03:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	HitShape:
 		UseTargetableCellsOffsets: false
@@ -191,7 +191,7 @@ V04:
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	HitShape:
 		UseTargetableCellsOffsets: false
@@ -206,7 +206,7 @@ V05:
 	Building:
 		Footprint: xx
 		Dimensions: 2,1
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 V06:
@@ -215,7 +215,7 @@ V06:
 	Building:
 		Footprint: xx
 		Dimensions: 2,1
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 V07:
@@ -224,62 +224,62 @@ V07:
 	Building:
 		Footprint: xx
 		Dimensions: 2,1
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 V08:
 	Inherits: ^CivBuilding
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 V09:
 	Inherits: ^CivBuilding
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 V10:
 	Inherits: ^CivBuilding
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 V11:
 	Inherits: ^CivBuilding
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 V12:
 	Inherits: ^CivBuilding
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 V13:
 	Inherits: ^CivBuilding
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 V14:
 	Inherits: ^CivField
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 V15:
 	Inherits: ^CivField
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 V16:
 	Inherits: ^CivField
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 V17:
 	Inherits: ^CivField
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 V18:
 	Inherits: ^CivField
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 V19:
@@ -336,7 +336,7 @@ BARL:
 	-ShakeOnDeath:
 	-SoundOnDamageTransition:
 	-Demolishable:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Decoration
 	Interactable:
 		Bounds: 24,24
@@ -360,7 +360,7 @@ BRL3:
 	-ShakeOnDeath:
 	-SoundOnDamageTransition:
 	-Demolishable:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Decoration
 	Interactable:
 		Bounds: 24,24
@@ -814,12 +814,12 @@ V37:
 
 RICE:
 	Inherits: ^CivField
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERAT
 
 RUSHOUSE:
 	Inherits: ^CivBuilding
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERAT
 	Building:
 		Footprint: x x
@@ -829,12 +829,12 @@ RUSHOUSE:
 
 ASIANHUT:
 	Inherits: ^CivBuilding
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERAT
 
 SNOWHUT:
 	Inherits: ^CivBuilding
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: SNOW
 	Building:
 		Footprint: x x
@@ -846,7 +846,7 @@ SNOWHUT:
 
 LHUS:
 	Inherits: ^CivBuilding
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERAT
 	Selectable:
 		Bounds: 24,48,0,-16
@@ -858,7 +858,7 @@ LHUS:
 
 WINDMILL:
 	Inherits: ^CivBuilding
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERAT
 	Selectable:
 		Bounds: 24,24,0,-14

--- a/mods/ra/rules/decoration.yaml
+++ b/mods/ra/rules/decoration.yaml
@@ -3,7 +3,7 @@ T01:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	SpawnActorOnDeath:
 		Actor: T01.Husk
@@ -13,7 +13,7 @@ T02:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	SpawnActorOnDeath:
 		Actor: T02.Husk
@@ -23,7 +23,7 @@ T03:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	SpawnActorOnDeath:
 		Actor: T03.Husk
@@ -33,7 +33,7 @@ T04:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERAT, SNOW, INTERIOR
 	SpawnActorOnDeath:
 		Actor: T04.Husk
@@ -43,7 +43,7 @@ T05:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	SpawnActorOnDeath:
 		Actor: T05.Husk
@@ -53,7 +53,7 @@ T06:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	SpawnActorOnDeath:
 		Actor: T06.Husk
@@ -63,7 +63,7 @@ T07:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	SpawnActorOnDeath:
 		Actor: T07.Husk
@@ -78,7 +78,7 @@ T08:
 
 T09:
 	Inherits: ^Tree
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERAT, SNOW, INTERIOR
 	SpawnActorOnDeath:
 		Actor: T09.Husk
@@ -88,7 +88,7 @@ T10:
 	Building:
 		Footprint: __ xx
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	SpawnActorOnDeath:
 		Actor: T10.Husk
@@ -98,7 +98,7 @@ T11:
 	Building:
 		Footprint: __ xx
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	SpawnActorOnDeath:
 		Actor: T11.Husk
@@ -108,7 +108,7 @@ T12:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	SpawnActorOnDeath:
 		Actor: T12.Husk
@@ -118,7 +118,7 @@ T13:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	SpawnActorOnDeath:
 		Actor: T13.Husk
@@ -128,7 +128,7 @@ T14:
 	Building:
 		Footprint: ___ xx_
 		Dimensions: 3,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	SpawnActorOnDeath:
 		Actor: T14.Husk
@@ -138,7 +138,7 @@ T15:
 	Building:
 		Footprint: ___ xx_
 		Dimensions: 3,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	SpawnActorOnDeath:
 		Actor: T15.Husk
@@ -148,7 +148,7 @@ T16:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	SpawnActorOnDeath:
 		Actor: T16.Husk
@@ -158,7 +158,7 @@ T17:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	SpawnActorOnDeath:
 		Actor: T17.Husk
@@ -168,7 +168,7 @@ TC01:
 	Building:
 		Footprint: ___ xx_
 		Dimensions: 3,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: INTERIOR
 	SpawnActorOnDeath:
 		Actor: TC01.Husk
@@ -178,7 +178,7 @@ TC02:
 	Building:
 		Footprint: _x_ xx_
 		Dimensions: 3,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	SpawnActorOnDeath:
 		Actor: TC02.Husk
@@ -188,7 +188,7 @@ TC03:
 	Building:
 		Footprint: xx_ xx_
 		Dimensions: 3,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	SpawnActorOnDeath:
 		Actor: TC03.Husk
@@ -198,7 +198,7 @@ TC04:
 	Building:
 		Footprint: ____ xxx_ x___
 		Dimensions: 4,3
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	SpawnActorOnDeath:
 		Actor: TC04.Husk
@@ -208,7 +208,7 @@ TC05:
 	Building:
 		Footprint: __x_ xxx_ _xx_
 		Dimensions: 4,3
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 	SpawnActorOnDeath:
 		Actor: TC05.Husk
@@ -219,7 +219,7 @@ BOXES01:
 		Palette: player
 	Tooltip:
 		Name: Boxes
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Decoration
 
 BOXES02:
@@ -228,7 +228,7 @@ BOXES02:
 		Palette: player
 	Tooltip:
 		Name: Boxes
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Decoration
 
 BOXES03:
@@ -237,7 +237,7 @@ BOXES03:
 		Palette: player
 	Tooltip:
 		Name: Boxes
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Decoration
 
 BOXES04:
@@ -246,7 +246,7 @@ BOXES04:
 		Palette: player
 	Tooltip:
 		Name: Boxes
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Decoration
 
 BOXES05:
@@ -255,7 +255,7 @@ BOXES05:
 		Palette: player
 	Tooltip:
 		Name: Boxes
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Decoration
 
 BOXES06:
@@ -264,7 +264,7 @@ BOXES06:
 		Palette: player
 	Tooltip:
 		Name: Boxes
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Decoration
 
 BOXES07:
@@ -273,7 +273,7 @@ BOXES07:
 		Palette: player
 	Tooltip:
 		Name: Boxes
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Decoration
 
 BOXES08:
@@ -282,7 +282,7 @@ BOXES08:
 		Palette: player
 	Tooltip:
 		Name: Boxes
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Decoration
 
 BOXES09:
@@ -291,7 +291,7 @@ BOXES09:
 		Palette: player
 	Tooltip:
 		Name: Boxes
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Decoration
 
 ICE01:
@@ -303,7 +303,7 @@ ICE01:
 		Dimensions: 2,2
 	Tooltip:
 		Name: Ice Floe
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: SNOW
 		Categories: Decoration
 
@@ -316,7 +316,7 @@ ICE02:
 		Dimensions: 1,2
 	Tooltip:
 		Name: Ice Floe
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: SNOW
 		Categories: Decoration
 
@@ -329,7 +329,7 @@ ICE03:
 		Dimensions: 2,1
 	Tooltip:
 		Name: Ice Floe
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: SNOW
 		Categories: Decoration
 
@@ -339,7 +339,7 @@ ICE04:
 		Palette: player
 	Tooltip:
 		Name: Ice Floe
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: SNOW
 		Categories: Decoration
 
@@ -349,7 +349,7 @@ ICE05:
 		Palette: player
 	Tooltip:
 		Name: Ice Floe
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: SNOW
 		Categories: Decoration
 
@@ -401,7 +401,7 @@ UTILPOL1:
 		Palette: player
 	Tooltip:
 		Name: Utility Pole
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Decoration
 
 UTILPOL2:
@@ -410,7 +410,7 @@ UTILPOL2:
 		Palette: player
 	Tooltip:
 		Name: Utility Pole
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Decoration
 
 TANKTRAP1:
@@ -422,7 +422,7 @@ TANKTRAP1:
 		Dimensions: 1,1
 	Tooltip:
 		Name: Tank Trap
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERAT, SNOW, DESERT, INTERIOR
 
 TANKTRAP2:
@@ -434,5 +434,5 @@ TANKTRAP2:
 		Dimensions: 1,1
 	Tooltip:
 		Name: Tank Trap
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERAT, SNOW, DESERT, INTERIOR

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -293,7 +293,7 @@
 	BodyOrientation:
 		UseClassicFacingFudge: True
 	HitShape:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Vehicle
 
 ^TrackedVehicle:
@@ -407,7 +407,7 @@
 	HitShape:
 		Type: Circle
 			Radius: 128
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Infantry
 
 ^Soldier:
@@ -447,7 +447,7 @@
 	Wanders:
 		MinMoveDelay: 150
 		MaxMoveDelay: 750
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Civilian infantry
 
 ^ArmedCivilian:
@@ -496,7 +496,7 @@
 	Tooltip:
 		GenericName: Ship
 	MustBeDestroyed:
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: INTERIOR
 		Categories: Naval
 	Voiced:
@@ -559,7 +559,7 @@
 	Voiced:
 		VoiceSet: GenericVoice
 	HitShape:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Aircraft
 	SpawnActorOnDeath:
 		RequiresCondition: airborne
@@ -628,7 +628,7 @@
 	Tooltip:
 		GenericName: Structure
 	Demolishable:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Building
 	CommandBarBlacklist:
 
@@ -683,7 +683,7 @@
 	Explodes:
 		Weapon: SmallBuildingExplode
 		EmptyWeapon: SmallBuildingExplode
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Defense
 	-CommandBarBlacklist:
 
@@ -727,7 +727,7 @@
 	FrozenUnderFogUpdatedByGps:
 	Health:
 		HP: 10000
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Wall
 
 ^TechBuilding:
@@ -741,7 +741,7 @@
 		Name: Civilian Building
 		GenericVisibility: None
 	FrozenUnderFog:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Tech building
 
 ^FakeBuilding:
@@ -765,7 +765,7 @@
 		ZOffset: 256
 	-SpawnActorsOnSell:
 	-MustBeDestroyed:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Fake
 
 ^InfiltratableFake:
@@ -794,7 +794,7 @@
 		TargetTypes: Ground, C4, DetonateAttack, Structure, NoAutoTarget
 	Armor:
 		Type: Light
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Decoration
 	Interactable:
 		Bounds: 24,24
@@ -803,7 +803,7 @@
 	Inherits: ^TechBuilding
 	RenderSprites:
 		Palette: player
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: INTERIOR
 		Categories: Civilian building
 	SpawnActorOnDeath@1:
@@ -832,7 +832,7 @@
 		Name: Field
 	-Targetable:
 	-Demolishable:
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: INTERIOR
 	Interactable:
 
@@ -875,7 +875,7 @@
 		MaximumDamageState: Dead
 	HiddenUnderShroud:
 	ScriptTriggers:
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: INTERIOR
 		Categories: Tree
 
@@ -896,7 +896,7 @@
 		ShowOwnerRow: false
 	FrozenUnderFog:
 	ScriptTriggers:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Tree
 
 ^BasicHusk:
@@ -911,7 +911,7 @@
 	ScriptTriggers:
 	WithFacingSpriteBody:
 	HitShape:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Husk
 
 ^Husk:
@@ -950,7 +950,7 @@
 		Moves: True
 		Velocity: 86
 		Explosion: UnitExplodePlane
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Husk
 	RevealOnDeath:
 		Duration: 60
@@ -1016,7 +1016,7 @@
 		Terrain: Tree
 	HiddenUnderShroud:
 	ScriptTriggers:
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 		Categories: Decoration
 
@@ -1024,7 +1024,7 @@
 	Inherits: ^CivBuilding
 	RenderSprites:
 		Palette: desert
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: DESERT
 
 ^Crate:
@@ -1059,7 +1059,7 @@
 		ShadowSequence: idle
 		RequiresCondition: parachute
 	ConditionManager:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 
 ^Mine:
@@ -1091,7 +1091,7 @@
 	Immobile:
 		OccupiesSpace: true
 	HitShape:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 
 ^DisableOnLowPower:

--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -64,7 +64,7 @@ SYRF:
 		HP: 100000
 	Armor:
 		Type: Light
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: INTERIOR
 	HitShape:
 		TargetableOffsets: 768,0,0, 768,-1024,0, 768,1024,0
@@ -109,7 +109,7 @@ SPEF:
 		HP: 100000
 	Armor:
 		Type: Light
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: INTERIOR
 	HitShape:
 		Type: Rectangle

--- a/mods/ra/rules/husks.yaml
+++ b/mods/ra/rules/husks.yaml
@@ -257,7 +257,7 @@ T01.Husk:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 T02.Husk:
@@ -265,7 +265,7 @@ T02.Husk:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 T03.Husk:
@@ -273,7 +273,7 @@ T03.Husk:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 T04.Husk:
@@ -281,7 +281,7 @@ T04.Husk:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERAT, SNOW, INTERIOR
 
 T05.Husk:
@@ -289,7 +289,7 @@ T05.Husk:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 T06.Husk:
@@ -297,7 +297,7 @@ T06.Husk:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 T07.Husk:
@@ -305,7 +305,7 @@ T07.Husk:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 T08.Husk:
@@ -316,7 +316,7 @@ T08.Husk:
 
 T09.Husk:
 	Inherits: ^TreeHusk
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERAT, SNOW, INTERIOR
 
 T10.Husk:
@@ -324,7 +324,7 @@ T10.Husk:
 	Building:
 		Footprint: __ xx
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 T11.Husk:
@@ -332,7 +332,7 @@ T11.Husk:
 	Building:
 		Footprint: __ xx
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 T12.Husk:
@@ -340,7 +340,7 @@ T12.Husk:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 T13.Husk:
@@ -348,7 +348,7 @@ T13.Husk:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 T14.Husk:
@@ -356,7 +356,7 @@ T14.Husk:
 	Building:
 		Footprint: ___ xx_
 		Dimensions: 3,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 T15.Husk:
@@ -364,7 +364,7 @@ T15.Husk:
 	Building:
 		Footprint: ___ xx_
 		Dimensions: 3,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 T16.Husk:
@@ -372,7 +372,7 @@ T16.Husk:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 T17.Husk:
@@ -380,7 +380,7 @@ T17.Husk:
 	Building:
 		Footprint: __ x_
 		Dimensions: 2,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 TC01.Husk:
@@ -388,7 +388,7 @@ TC01.Husk:
 	Building:
 		Footprint: ___ xx_
 		Dimensions: 3,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: INTERIOR
 
 TC02.Husk:
@@ -396,7 +396,7 @@ TC02.Husk:
 	Building:
 		Footprint: _x_ xx_
 		Dimensions: 3,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 TC03.Husk:
@@ -404,7 +404,7 @@ TC03.Husk:
 	Building:
 		Footprint: xx_ xx_
 		Dimensions: 3,2
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 TC04.Husk:
@@ -412,7 +412,7 @@ TC04.Husk:
 	Building:
 		Footprint: ____ xxx_ x___
 		Dimensions: 4,3
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR
 
 TC05.Husk:
@@ -420,5 +420,5 @@ TC05.Husk:
 	Building:
 		Footprint: __x_ xxx_ _xx_
 		Dimensions: 4,3
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: DESERT, INTERIOR

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -156,7 +156,7 @@ CAMERA:
 	WithSpriteBody:
 	RenderSpritesEditorOnly:
 		Image: camera
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 
 camera.paradrop:
@@ -200,7 +200,7 @@ FLARE:
 	Tooltip:
 		Name: Flare
 		ShowOwnerRow: false
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Decoration
 
 MINE:
@@ -219,7 +219,7 @@ MINE:
 	RadarColorFromTerrain:
 		Terrain: Ore
 	SeedsResource:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Resource spawn
 
 GMINE:
@@ -239,7 +239,7 @@ GMINE:
 		Terrain: Gems
 	SeedsResource:
 		ResourceType: Gems
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Resource spawn
 
 RAILMINE:
@@ -254,7 +254,7 @@ RAILMINE:
 	Building:
 		Footprint: xx
 		Dimensions: 2,1
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: INTERIOR
 		Categories: Civilian building
 
@@ -270,7 +270,7 @@ QUEE:
 		Dimensions: 2,1
 	WithSpriteBody:
 	AppearsOnRadar:
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: INTERIOR
 		Categories: Critter
 
@@ -288,7 +288,7 @@ LAR1:
 		Palette: terrain
 	WithSpriteBody:
 	AppearsOnRadar:
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: INTERIOR
 		Categories: Critter
 
@@ -371,7 +371,7 @@ mpspawn:
 	RenderSpritesEditorOnly:
 	BodyOrientation:
 		QuantizedFacings: 1
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 
 waypoint:
@@ -385,13 +385,13 @@ waypoint:
 	RenderSpritesEditorOnly:
 	BodyOrientation:
 		QuantizedFacings: 1
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 
 fact.colorpicker:
 	Inherits: FACT
 	-Buildable:
-	-EditorTilesetFilter:
+	-MapEditorData:
 	RenderSprites:
 		Image: fact
 		Palette: colorpicker
@@ -411,6 +411,6 @@ CTFLAG:
 	-Selectable:
 	-SelectionDecorations:
 	-Targetable:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Decoration
 	Interactable:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -225,7 +225,7 @@ SPEN:
 		RequiresPrerequisites: structures.ukraine
 		Prerequisite: ships.ukraine
 	ProvidesPrerequisite@buildingname:
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: INTERIOR
 	WithDecoration@primary:
 		RequiresSelection: true
@@ -346,7 +346,7 @@ SYRD:
 		RequiresPrerequisites: structures.germany
 		Prerequisite: ships.germany
 	ProvidesPrerequisite@buildingname:
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: INTERIOR
 	WithDecoration@primary:
 		RequiresSelection: true

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -387,5 +387,5 @@ HUNTER:
 		Palette: pips
 	ActorLostNotification:
 	HitShape:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System

--- a/mods/ts/rules/bridges.yaml
+++ b/mods/ts/rules/bridges.yaml
@@ -14,7 +14,7 @@ CABHUT:
 	-SelectionDecorations:
 	-Demolishable:
 	-Explodes:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Bridge
 
 ^LowBridgeRamp:
@@ -30,7 +30,7 @@ CABHUT:
 		QuantizedFacings: 1
 	Tooltip:
 		Name: Bridge
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Bridge
 	Interactable:
 
@@ -178,7 +178,7 @@ LOBRDG_R_SW:
 		Name: Bridge
 	Immobile:
 		OccupiesSpace: false
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Bridge
 	Interactable:
 		Bounds: 96, 144

--- a/mods/ts/rules/civilian-structures.yaml
+++ b/mods/ts/rules/civilian-structures.yaml
@@ -10,7 +10,7 @@ ABAN01:
 		Type: wood
 	Health:
 		HP: 60000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
 		Pieces: 5, 9
@@ -29,7 +29,7 @@ ABAN02:
 		Type: heavy
 	Health:
 		HP: 60000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
 		Pieces: 5, 9
@@ -48,7 +48,7 @@ ABAN03:
 		Type: wood
 	Health:
 		HP: 50000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
 		Pieces: 5, 9
@@ -67,7 +67,7 @@ ABAN04:
 		Type: heavy
 	Health:
 		HP: 40000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
 		Pieces: 4, 7
@@ -90,7 +90,7 @@ ABAN05:
 		Type: wood
 	Health:
 		HP: 50000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERATE
 
 ABAN06:
@@ -105,7 +105,7 @@ ABAN06:
 		Type: wood
 	Health:
 		HP: 50000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERATE
 
 ABAN07:
@@ -120,7 +120,7 @@ ABAN07:
 		Type: heavy
 	Health:
 		HP: 35000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERATE
 
 ABAN08:
@@ -135,7 +135,7 @@ ABAN08:
 		Type: heavy
 	Health:
 		HP: 50000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERATE
 
 ABAN09:
@@ -150,7 +150,7 @@ ABAN09:
 		Type: heavy
 	Health:
 		HP: 35000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERATE
 
 ABAN10:
@@ -165,7 +165,7 @@ ABAN10:
 		Type: wood
 	Health:
 		HP: 50000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERATE
 
 ABAN11:
@@ -180,7 +180,7 @@ ABAN11:
 		Type: wood
 	Health:
 		HP: 40000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERATE
 
 ABAN12:
@@ -195,7 +195,7 @@ ABAN12:
 		Type: wood
 	Health:
 		HP: 40000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERATE
 
 ABAN13:
@@ -209,7 +209,7 @@ ABAN13:
 		Type: wood
 	Health:
 		HP: 40000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERATE
 
 ABAN14:
@@ -223,7 +223,7 @@ ABAN14:
 		Type: heavy
 	Health:
 		HP: 30000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERATE
 
 ABAN15:
@@ -237,7 +237,7 @@ ABAN15:
 		Type: heavy
 	Health:
 		HP: 40000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERATE
 
 ABAN16:
@@ -252,7 +252,7 @@ ABAN16:
 		Type: wood
 	Health:
 		HP: 40000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERATE
 
 ABAN17:
@@ -266,7 +266,7 @@ ABAN17:
 		Type: wood
 	Health:
 		HP: 40000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERATE
 
 ABAN18:
@@ -280,7 +280,7 @@ ABAN18:
 		Type: wood
 	Health:
 		HP: 40000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: TEMPERATE
 
 AMMOCRAT:
@@ -801,7 +801,7 @@ CAHOSP:
 		Pieces: 5, 9
 	ThrowsShrapnel@LARGE:
 		Pieces: 2, 4
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Civilian building
 
 CAPYR01:
@@ -816,7 +816,7 @@ CAPYR01:
 		Type: concrete
 	Health:
 		HP: 40000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: SNOW
 
 CAPYR02:
@@ -831,7 +831,7 @@ CAPYR02:
 		Type: concrete
 	Health:
 		HP: 40000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: SNOW
 	ThrowsShrapnel@SMALL:
 		Pieces: 6, 9
@@ -850,7 +850,7 @@ CAPYR03:
 		Type: concrete
 	Health:
 		HP: 40000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: SNOW
 	ThrowsShrapnel@SMALL:
 		Pieces: 6, 9
@@ -869,7 +869,7 @@ CITY01:
 		Type: wood
 	Health:
 		HP: 40000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
 		Pieces: 5, 9
@@ -888,7 +888,7 @@ CITY02:
 		Type: heavy
 	Health:
 		HP: 70000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
 		Pieces: 5, 9
@@ -907,7 +907,7 @@ CITY03:
 		Type: heavy
 	Health:
 		HP: 50000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
 		Pieces: 5, 9
@@ -926,7 +926,7 @@ CITY04:
 		Type: heavy
 	Health:
 		HP: 60000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
 		Pieces: 5, 9
@@ -945,7 +945,7 @@ CITY05:
 		Type: heavy
 	Health:
 		HP: 60000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
 		Pieces: 5, 9
@@ -964,7 +964,7 @@ CITY06:
 		Type: concrete
 	Health:
 		HP: 50000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
 		Pieces: 7, 9
@@ -983,7 +983,7 @@ CITY07:
 		Type: wood
 	Health:
 		HP: 40000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
 		Pieces: 7, 9
@@ -1002,7 +1002,7 @@ CITY08:
 		Type: heavy
 	Health:
 		HP: 30000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 
 CITY09:
@@ -1017,7 +1017,7 @@ CITY09:
 		Type: wood
 	Health:
 		HP: 40000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 
 CITY10:
@@ -1032,7 +1032,7 @@ CITY10:
 		Type: heavy
 	Health:
 		HP: 30000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 
 CITY11:
@@ -1047,7 +1047,7 @@ CITY11:
 		Type: heavy
 	Health:
 		HP: 50000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 
 CITY12:
@@ -1062,7 +1062,7 @@ CITY12:
 		Type: concrete
 	Health:
 		HP: 60000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 
 CITY13:
@@ -1077,7 +1077,7 @@ CITY13:
 		Type: wood
 	Health:
 		HP: 50000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 
 CITY14:
@@ -1091,7 +1091,7 @@ CITY14:
 		Type: heavy
 	Health:
 		HP: 60000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 
 CITY15:
@@ -1106,7 +1106,7 @@ CITY15:
 		Type: heavy
 	Health:
 		HP: 50000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
 		Pieces: 7, 9
@@ -1125,7 +1125,7 @@ CITY16:
 		Type: wood
 	Health:
 		HP: 50000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
 		Pieces: 7, 9
@@ -1144,7 +1144,7 @@ CITY17:
 		Type: wood
 	Health:
 		HP: 30000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
 		Pieces: 7, 9
@@ -1163,7 +1163,7 @@ CITY18:
 		Type: concrete
 	Health:
 		HP: 60000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
 		Pieces: 8, 12
@@ -1182,7 +1182,7 @@ CITY19:
 		Type: wood
 	Health:
 		HP: 50000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 
 CITY20:
@@ -1196,7 +1196,7 @@ CITY20:
 		Type: wood
 	Health:
 		HP: 25000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 
 CITY21:
@@ -1210,7 +1210,7 @@ CITY21:
 		Type: none
 	Health:
 		HP: 10000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 
 CITY22:
@@ -1225,7 +1225,7 @@ CITY22:
 		Type: none
 	Health:
 		HP: 10000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 
 CTDAM:
@@ -1245,7 +1245,7 @@ CTDAM:
 		HP: 100000
 	ProvidesPrerequisite:
 		Prerequisite: anypower
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: SNOW
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
@@ -1268,7 +1268,7 @@ CTVEGA:
 		Type: none
 	Health:
 		HP: 10000
-	EditorTilesetFilter:
+	MapEditorData:
 		ExcludeTilesets: SNOW
 	ThrowsShrapnel@SMALL:
 		Pieces: 7, 9
@@ -1382,7 +1382,7 @@ GASPOT:
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
 	SelectionDecorations:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Civilian building
 
 GALITE:
@@ -1415,7 +1415,7 @@ GALITE:
 	-Cloak@EXTERNALCLOAK:
 	-ExternalCondition@CLOAKGENERATOR:
 	-ExternalCondition@CRATE-CLOAK:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Civilian building
 
 TSTLAMP:
@@ -1445,7 +1445,7 @@ GAICBM:
 		TransformSounds: place2.aud
 		NoTransformSounds:
 	-WithDeathAnimation:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Vehicle
 
 NAMNTK:
@@ -1505,7 +1505,7 @@ UFO:
 		HP: 100000
 	Armor:
 		Type: Heavy
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 	SelectionDecorations:
 	ThrowsShrapnel@SMALL:

--- a/mods/ts/rules/critters.yaml
+++ b/mods/ts/rules/critters.yaml
@@ -3,7 +3,7 @@ DOGGIE:
 	Inherits@2: ^RegularInfantryDeath
 	Inherits@3: ^HealsOnTiberium
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Critter
 	Tooltip:
 		Name: Tiberian Fiend

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -340,7 +340,7 @@
 		Weapons: LargeDebris, LargeDebrisWithTrail
 		Pieces: 1, 2
 		Range: 2c0, 5c0
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Building
 	CommandBarBlacklist:
 
@@ -390,7 +390,7 @@
 		MaxHeightDelta: 3
 	RenderSprites:
 		Palette: terraindecoration
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Civilian building
 
 ^OldBase:
@@ -418,13 +418,13 @@
 		Type: heavy
 	Health:
 		HP: 40000
-	EditorTilesetFilter:
+	MapEditorData:
 		RequireTilesets: TEMPERATE
 	ThrowsShrapnel@SMALL:
 		Pieces: 1, 3
 	ThrowsShrapnel@LARGE:
 		Pieces: 1, 1
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Billboard
 
 ^Crate:
@@ -437,7 +437,7 @@
 	RenderSprites:
 		Palette: terraindecoration
 	WithCrateBody:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 	Interactable:
 		Bounds: 24,24
@@ -486,7 +486,7 @@
 			TopLeft: -512, -512
 			BottomRight: 512, 512
 			VerticalTopOffset: 768
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Wall
 	Valued:
 		Cost: 50
@@ -588,7 +588,7 @@
 	HitShape:
 		Type: Circle
 			Radius: 128
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Infantry
 	GrantConditionOnTunnelLayer:
 		Condition: inside-tunnel
@@ -697,7 +697,7 @@
 	Wanders:
 		MinMoveDelay: 150
 		MaxMoveDelay: 750
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Civilian infantry
 
 ^Vehicle:
@@ -771,7 +771,7 @@
 	EntersTunnels:
 		Voice: Move
 	HitShape:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Vehicle
 	GrantConditionOnTunnelLayer:
 		Condition: inside-tunnel
@@ -841,7 +841,7 @@
 	WithVoxelBody:
 	RevealOnFire:
 	HitShape:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Aircraft
 	SpawnActorOnDeath:
 		RequiresCondition: airborne
@@ -880,7 +880,7 @@
 		Moves: true
 		Velocity: 86
 	HitShape:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Husk
 
 ^Visceroid:
@@ -914,7 +914,7 @@
 		Type: Circle
 			Radius: 256
 			VerticalTopOffset: 512
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Critter
 	GrantConditionOnTunnelLayer:
 		Condition: inside-tunnel
@@ -938,7 +938,7 @@
 		ResourceType: Tiberium
 		Interval: 55
 	WithIdleAnimation:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Resource spawn
 
 ^Tree:
@@ -956,7 +956,7 @@
 		Terrain: Tree
 	Tooltip:
 		Name: Tree
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Tree
 
 ^Rock:
@@ -974,7 +974,7 @@
 		Terrain: Rock
 	Tooltip:
 		Name: Rock
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Decoration
 
 ^Decoration:
@@ -987,7 +987,7 @@
 	Building:
 		Footprint: x
 		Dimensions: 1, 1
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Decoration
 
 ^Box:
@@ -1018,7 +1018,7 @@
 		TargetTypes: Ground, Building, C4, Defense
 	-Capturable:
 	RevealOnFire:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Defense
 	-CommandBarBlacklist:
 
@@ -1072,7 +1072,7 @@
 		Pieces: 3, 7
 		Range: 2c0, 5c0
 	HitShape:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Railway
 	GrantConditionOnTunnelLayer:
 		Condition: inside-tunnel
@@ -1094,7 +1094,7 @@
 		Name: Railway
 	ChangesTerrain:
 		TerrainType: Rail
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Railway
 	Interactable:
 
@@ -1111,7 +1111,7 @@
 	Targetable:
 	AlwaysVisible:
 	TunnelEntrance:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Tunnel
 	Interactable:
 		Bounds: 144, 144
@@ -1143,7 +1143,7 @@
 			TopLeft: -512, -512
 			BottomRight: 512, 512
 			VerticalTopOffset: 768
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Wall
 	Gate:
 		OpeningSound: gateup1.aud

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -187,7 +187,7 @@ JUMPJET.Husk:
 	WithDeathAnimation@SPLASH:
 		RequiresCondition: water-death
 		FallbackSequence: die-splash
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Husk
 	Interactable:
 

--- a/mods/ts/rules/misc.yaml
+++ b/mods/ts/rules/misc.yaml
@@ -9,7 +9,7 @@ mpspawn:
 	WithSpriteBody:
 	BodyOrientation:
 		QuantizedFacings: 1
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 
 waypoint:
@@ -23,7 +23,7 @@ waypoint:
 	WithSpriteBody:
 	BodyOrientation:
 		QuantizedFacings: 1
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 
 mmch.colorpicker:
@@ -35,7 +35,7 @@ mmch.colorpicker:
 	WithFacingSpriteBody:
 		Sequence: walk
 	-Buildable:
-	-EditorTilesetFilter:
+	-MapEditorData:
 	RenderVoxels:
 		Image: mmch
 		Palette: colorpicker
@@ -59,7 +59,7 @@ CAMERA:
 		Type: CenterPosition
 	DetectCloaked:
 		Range: 10c0
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 
 CRATE:
@@ -104,7 +104,7 @@ CRATE:
 		SelectionShares: 5
 		Condition: crate-speed
 		Notification: 00-i080.aud
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System
 
 SROCK01:

--- a/mods/ts/rules/shared-infantry.yaml
+++ b/mods/ts/rules/shared-infantry.yaml
@@ -89,5 +89,5 @@ FLAMEGUY:
 		FallbackSequence: die
 		UseDeathTypeSuffix: false
 	HitShape:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: System

--- a/mods/ts/rules/trees.yaml
+++ b/mods/ts/rules/trees.yaml
@@ -115,7 +115,7 @@ VEINHOLE:
 	RenderSprites:
 		Palette: player
 	WithSpriteBody:
-	EditorTilesetFilter:
+	MapEditorData:
 		Categories: Resource spawn
 	Interactable:
 


### PR DESCRIPTION
Closes #13857.
Renamed the EditorTilesetFilter class to MapEditorData (and EditorTilesetFilterInfo to MapEditorDataInfo).
Created an UpdateRule (RenameEditorTilesetFilter.cs). Updated all four mods with it.