### PR TITLE
Revert macOS dark mode support

### DIFF
--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -9,7 +9,7 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
 	command -v genisoimage >/dev/null 2>&1 || { echo >&2 "macOS packaging requires genisoimage."; exit 1; }
 fi
 
-LAUNCHER_TAG="osx-launcher-20180723"
+LAUNCHER_TAG="osx-launcher-20171118"
 
 if [ $# -ne "2" ]; then
 	echo "Usage: `basename $0` tag outputdir"

--- a/thirdparty/fetch-thirdparty-deps-osx.sh
+++ b/thirdparty/fetch-thirdparty-deps-osx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LAUNCHER_TAG="osx-launcher-20180723"
+LAUNCHER_TAG="osx-launcher-20171118"
 
 download_dir="${0%/*}/download/osx"
 mkdir -p "$download_dir"


### PR DESCRIPTION
Reverts #15379.

It seems that Apple have changed the way that dark mode interacts with OpenGL in later betas of 10.14.  Testing playtest-20180825 with the (assumed) GM release of 10.14 produces a black screen - sound and input works, but nothing is rendered.  Removing the `NSRequiresAquaSystemAppearance` key from info.plist fixes the rendering.

Reopens #15369.

The changelog "entry" for this should be to remove the entry for #15379.
