### PR TITLE
Prevent units from gaining more experience than MaxLevel requires

### DIFF
--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (amount < 0)
 				throw new ArgumentException("Revoking experience is not implemented.", "amount");
 
-			experience += amount;
+			experience = (experience + amount).Clamp(0, nextLevel[MaxLevel - 1].First);
 
 			while (Level < MaxLevel && experience >= nextLevel[Level].First)
 			{


### PR DESCRIPTION
Fixes #15636.

See https://github.com/OpenRA/OpenRA/issues/15636#issuecomment-423841438 for a reproduction case and the details.