### PR TITLE
Properly end capturing during an owner change

### DIFF
--- a/OpenRA.Mods.Common/Activities/ExternalCaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/ExternalCaptureActor.cs
@@ -50,7 +50,8 @@ namespace OpenRA.Mods.Common.Activities
 				BeginCapture(self);
 			else
 			{
-				if (capturable.Captor != self) return NextActivity;
+				if (capturable.Captor != self)
+					return NextActivity;
 
 				if (capturable.CaptureProgressTime % 25 == 0)
 				{
@@ -99,8 +100,9 @@ namespace OpenRA.Mods.Common.Activities
 
 		void EndCapture(Actor self)
 		{
-			if (target.Type == TargetType.Actor && capturable.CaptureInProgress)
+			if (capturable.CaptureInProgress)
 				capturable.EndCapture();
+
 			if (capturingToken != ConditionManager.InvalidConditionToken)
 				capturingToken = conditionManager.RevokeCondition(self, capturingToken);
 		}

--- a/OpenRA.Mods.Common/Traits/ExternalCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ExternalCapturable.cs
@@ -52,18 +52,18 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[Sync] public int CaptureProgressTime = 0;
 		[Sync] public Actor Captor;
-		private Actor self;
 		public bool CaptureInProgress { get { return Captor != null; } }
+
+		readonly Building building;
 
 		public ExternalCapturable(Actor self, ExternalCapturableInfo info)
 			: base(info)
 		{
-			this.self = self;
+			building = self.TraitOrDefault<Building>();
 		}
 
 		public void BeginCapture(Actor captor)
 		{
-			var building = self.TraitOrDefault<Building>();
 			if (building != null)
 				building.Lock();
 
@@ -72,7 +72,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void EndCapture()
 		{
-			var building = self.TraitOrDefault<Building>();
 			if (building != null)
 				building.Unlock();
 


### PR DESCRIPTION
Fixes the capturing process not properly ending like seen in this image:
![capturing](https://cdn.discordapp.com/attachments/355423992536104981/493888405365719060/Screen_Shot_2018-09-24_at_23.45.32.png)

Reproduction case: Capture an oil derrick that is owned by another player. That other play surrenders while you attempt to capture their oil derrick. The ownership changes back to "neutral" and the capturing activity is cancelled. However, the bar still progresses.

The fix: As soon as ownership returns to "neutral", the actor's generation is increased which means the target cached in `ExternalCapturesActor` becomes invalid. However, because we check if the type is still an `Actor` we never reach `EndCapture` on `ExternalCapturable`.
I changed `ExternalCapturable` to cache the `Building` trait so we no longer risk a crash by attempting to query the trait of a dead actor, so that the check in `ExternalCapturesActor` can be removed.