### PR TITLE
Fix attack behaviour of disabled units

### DIFF
--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
@@ -200,8 +201,16 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			attackStatus |= AttackStatus.Attacking;
-			attack.DoAttack(self, target, armaments);
+			DoAttack(self, attack, armaments);
+
 			return AttackStatus.Attacking;
+		}
+
+		protected virtual void DoAttack(Actor self, AttackFrontal attack, IEnumerable<Armament> armaments)
+		{
+			if (!attack.IsTraitPaused)
+				foreach (var a in armaments)
+					a.CheckFire(self, facing, target);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -122,12 +122,12 @@ namespace OpenRA.Mods.Common.Traits
 			return true;
 		}
 
-		public virtual void DoAttack(Actor self, Target target, IEnumerable<Armament> armaments = null)
+		public virtual void DoAttack(Actor self, Target target)
 		{
-			if (armaments == null && !CanAttack(self, target))
+			if (!CanAttack(self, target))
 				return;
 
-			foreach (var a in armaments ?? Armaments)
+			foreach (var a in Armaments)
 				a.CheckFire(self, facing, target);
 		}
 
@@ -350,7 +350,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void AttackTarget(Target target, bool queued, bool allowMove, bool forceAttack = false)
 		{
-			if (IsTraitDisabled || IsTraitPaused)
+			if (IsTraitDisabled)
 				return;
 
 			if (!target.IsValidFor(self))

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -142,7 +142,7 @@ namespace OpenRA.Mods.Common.Traits
 			return coords.Value.LocalToWorld(p.Offset.Rotate(bodyOrientation));
 		}
 
-		public override void DoAttack(Actor self, Target target, IEnumerable<Armament> armaments = null)
+		public override void DoAttack(Actor self, Target target)
 		{
 			if (!CanAttack(self, target))
 				return;

--- a/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
+++ b/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.D2k.Traits
 			Info = info;
 		}
 
-		public override void DoAttack(Actor self, Target target, IEnumerable<Armament> armaments = null)
+		public override void DoAttack(Actor self, Target target)
 		{
 			// This is so that the worm does not launch an attack against a target that has reached solid rock
 			if (target.Type != TargetType.Actor || !CanAttack(self, target))
@@ -85,6 +85,11 @@ namespace OpenRA.Mods.D2k.Traits
 				// Worms ignore visibility, so don't need to recalculate targets
 				targetIsHiddenActor = false;
 				return target;
+			}
+
+			protected override void DoAttack(Actor self, AttackFrontal attack, IEnumerable<Armament> armaments)
+			{
+				attack.DoAttack(self, target);
 			}
 		}
 	}


### PR DESCRIPTION
This moves the disabled/paused check in `AttackBase` from `AttackTarget` to `DoAttack`. Adding it to `DoAttack` pauses (and unpauses) an already attacking unit. Removing it from `AttackTarget` allows for retargeting while the unit is disabled.

Fixes #13355.