### PR TITLE
Refactored cursors.yaml to use palettes from rules.

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using OpenRA.Activities;
+using OpenRA.FileSystem;
 using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Primitives;
@@ -269,6 +270,13 @@ namespace OpenRA.Traits
 		// HACK: This is here to support the WithShadow trait.
 		// That trait should be rewritten using standard techniques, and then this interface method removed
 		IEnumerable<Rectangle> ModifyScreenBounds(Actor self, WorldRenderer wr, IEnumerable<Rectangle> r);
+	}
+
+	[RequireExplicitImplementation]
+	public interface IProvidesCursorPaletteInfo : ITraitInfoInterface
+	{
+		string Palette { get; }
+		ImmutablePalette ReadPalette(IReadOnlyFileSystem fileSystem);
 	}
 
 	public interface ILoadsPalettes { void LoadPalettes(WorldRenderer wr); }

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromFile.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromFile.cs
@@ -10,13 +10,14 @@
 #endregion
 
 using System.Collections.Generic;
+using OpenRA.FileSystem;
 using OpenRA.Graphics;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Load VGA palette (.pal) registers.")]
-	class PaletteFromFileInfo : ITraitInfo
+	class PaletteFromFileInfo : ITraitInfo, IProvidesCursorPaletteInfo
 	{
 		[FieldLoader.Require, PaletteDefinition]
 		[Desc("internal palette name")]
@@ -34,7 +35,17 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly bool AllowModifiers = true;
 
+		[Desc("Whether this palette is available for cursors.")]
+		public readonly bool CursorPalette = false;
+
 		public object Create(ActorInitializer init) { return new PaletteFromFile(init.World, this); }
+
+		string IProvidesCursorPaletteInfo.Palette { get { return CursorPalette ? Name : null; } }
+
+		ImmutablePalette IProvidesCursorPaletteInfo.ReadPalette(IReadOnlyFileSystem fileSystem)
+		{
+			return new ImmutablePalette(fileSystem.Open(Filename), ShadowIndex);
+		}
 	}
 
 	class PaletteFromFile : ILoadsPalettes, IProvidesAssetBrowserPalettes
@@ -50,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void LoadPalettes(WorldRenderer wr)
 		{
 			if (info.Tileset == null || info.Tileset.ToLowerInvariant() == world.Map.Tileset.ToLowerInvariant())
-				wr.AddPalette(info.Name, new ImmutablePalette(world.Map.Open(info.Filename), info.ShadowIndex), info.AllowModifiers);
+				wr.AddPalette(info.Name, ((IProvidesCursorPaletteInfo)info).ReadPalette(world.Map), info.AllowModifiers);
 		}
 
 		public IEnumerable<string> PaletteNames

--- a/mods/cnc/cursors.yaml
+++ b/mods/cnc/cursors.yaml
@@ -1,8 +1,5 @@
-Palettes:
-	cursor: temperat.pal
-
 Cursors:
-	mouse2.shp: cursor
+	mouse2.shp: chrome
 		scroll-t:
 			Start: 1
 			Y: -12
@@ -139,7 +136,7 @@ Cursors:
 		sell-vehicle:
 			Start: 154
 			Length: 24
-	mouse3.shp: cursor
+	mouse3.shp: chrome
 		default:
 			Start: 0
 			X: -16
@@ -151,7 +148,7 @@ Cursors:
 		deploy-blocked:
 			Start: 1
 			Length: 1
-	mouse4.shp: cursor
+	mouse4.shp: chrome
 		move:
 			Start: 0
 			Length: 8
@@ -191,14 +188,14 @@ Cursors:
 		assaultmove-blocked-minimap:
 			Start: 40
 			Length: 1
-	mouse5.shp: cursor
+	mouse5.shp: chrome
 		guard:
 			Start: 0
 			Length: 8
 		guard-minimap:
 			Start: 8
 			Length: 8
-	mouse6.shp: cursor
+	mouse6.shp: chrome
 		goldwrench:
 			Start: 0
 			Length: 3
@@ -229,7 +226,7 @@ Cursors:
 		enter-blocked-minimap:
 			Start: 17
 			Length: 1
-	mouse7.shp: cursor
+	mouse7.shp: chrome
 		attackoutsiderange:
 			Start: 0
 			Length: 8

--- a/mods/cnc/rules/palettes.yaml
+++ b/mods/cnc/rules/palettes.yaml
@@ -54,6 +54,7 @@
 		Filename: temperat.pal
 		ShadowIndex: 3
 		AllowModifiers: false
+		CursorPalette: true
 	PaletteFromFile@beaconposter:
 		Name: beaconposter
 		Filename: temperat.pal

--- a/mods/d2k/cursors.yaml
+++ b/mods/d2k/cursors.yaml
@@ -1,10 +1,5 @@
-ShadowIndex: 1
-
-Palettes:
-	mouse: PALETTE.BIN
-
 Cursors:
-	MOUSE.R8: mouse
+	MOUSE.R8: d2k
 		scroll-t:
 			Start: 112
 			X: 24
@@ -284,7 +279,7 @@ Cursors:
 			Length: 8
 			X: 24
 			Y: 24
-	nopower.shp: mouse
+	nopower.shp: d2k
 		powerdown-blocked:
 			Start: 0
 			Length: 1
@@ -295,7 +290,7 @@ Cursors:
 			Length: 3
 			X: 12
 			Y: 12
-	attackmove.shp: mouse
+	attackmove.shp: d2k
 		attackmove:
 			Start: 0
 			Length: 8
@@ -314,7 +309,7 @@ Cursors:
 			Start: 8
 			X: -2
 			Y: -2
-	assaultmove.shp: mouse
+	assaultmove.shp: d2k
 		assaultmove:
 			Start: 0
 			Length: 8

--- a/mods/d2k/rules/palettes.yaml
+++ b/mods/d2k/rules/palettes.yaml
@@ -6,6 +6,7 @@
 		Name: d2k
 		Filename: PALETTE.BIN
 		ShadowIndex: 1
+		CursorPalette: true
 	PaletteFromFile@chrome:
 		Name: chrome
 		Filename: PALETTE.BIN

--- a/mods/modcontent/cursors.yaml
+++ b/mods/modcontent/cursors.yaml
@@ -1,6 +1,3 @@
-Palettes:
-	cursor: cursor.pal
-
 Cursors:
 	cursor.shp: cursor
 		default:

--- a/mods/modcontent/mod.yaml
+++ b/mods/modcontent/mod.yaml
@@ -8,6 +8,9 @@ Packages:
 	./mods/modcontent: modcontent
 	./mods/common: common
 
+Rules:
+	modcontent|rules.yaml
+
 Cursors:
 	modcontent|cursors.yaml
 

--- a/mods/modcontent/rules.yaml
+++ b/mods/modcontent/rules.yaml
@@ -1,0 +1,5 @@
+World:
+	PaletteFromFile:
+		Name: cursor
+		Filename: cursor.pal
+		CursorPalette: true

--- a/mods/ra/cursors.yaml
+++ b/mods/ra/cursors.yaml
@@ -1,8 +1,5 @@
-Palettes:
-	cursor: temperat.pal
-
 Cursors:
-	mouse.shp: cursor
+	mouse.shp: chrome
 		scroll-t:
 			Start: 1
 			Y: -7
@@ -203,14 +200,14 @@ Cursors:
 		sell2:
 			Start: 148
 			Length: 12
-	nopower.shp: cursor
+	nopower.shp: chrome
 		powerdown-blocked:
 			Start: 0
 			Length: 1
 		powerdown:
 			Start: 1
 			Length: 3
-	attackmove.shp: cursor
+	attackmove.shp: chrome
 		attackmove:
 			Start: 0
 			Length: 4

--- a/mods/ra/rules/palettes.yaml
+++ b/mods/ra/rules/palettes.yaml
@@ -28,6 +28,7 @@
 		Filename: temperat.pal
 		ShadowIndex: 3
 		AllowModifiers: false
+		CursorPalette: true
 	PaletteFromFile@effect:
 		Name: effect
 		Filename: temperat.pal

--- a/mods/ts/cursors.yaml
+++ b/mods/ts/cursors.yaml
@@ -1,8 +1,5 @@
-Palettes:
-	cursor: mousepal.pal
-
 Cursors:
-	mouse.shp: cursor
+	mouse.shp: mouse
 		scroll-t:
 			Start: 2
 			Y: -19
@@ -218,7 +215,7 @@ Cursors:
 			Start: 385
 		joystick-tl-blocked:
 			Start: 386
-	attackmove.shp: cursor
+	attackmove.shp: mouse
 		attackmove:
 			Start: 0
 			Length: 10
@@ -231,7 +228,7 @@ Cursors:
 		attackmove-minimap-blocked:
 			Start: 21
 			Length: 1
-	assaultmove.shp: cursor
+	assaultmove.shp: mouse
 		assaultmove:
 			Start: 0
 			Length: 10

--- a/mods/ts/rules/palettes.yaml
+++ b/mods/ts/rules/palettes.yaml
@@ -2,6 +2,7 @@
 	PaletteFromFile@mouse:
 		Name: mouse
 		Filename: mousepal.pal
+		CursorPalette: true
 	PaletteFromFile@terraintem:
 		Name: terrain
 		Tileset: TEMPERATE


### PR DESCRIPTION
This completely replaces the hacky palettes in cursors.yaml with proper rules based palettes.
This supports any palette loader class, instead of enforcing the default VGA palette for cursors.