### PR TITLE
Calling PreparingAttack before calculating Muzzle.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -275,6 +275,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected virtual void FireBarrel(Actor self, IFacing facing, Target target, Barrel barrel)
 		{
+			foreach (var na in notifyAttacks)
+				na.PreparingAttack(self, target, this, barrel);
+
 			Func<WPos> muzzlePosition = () => self.CenterPosition + MuzzleOffset(self, barrel);
 			var legacyFacing = MuzzleOrientation(self, barrel).Yaw.Angle / 4;
 			Func<int> legacyMuzzleFacing = () => MuzzleOrientation(self, barrel).Yaw.Angle / 4;
@@ -314,9 +317,6 @@ namespace OpenRA.Mods.Common.Traits
 				PassiveTarget = passiveTarget,
 				GuidedTarget = target
 			};
-
-			foreach (var na in notifyAttacks)
-				na.PreparingAttack(self, target, this, barrel);
 
 			ScheduleDelayedAction(Info.FireDelay, () =>
 			{


### PR DESCRIPTION
In KKnD i depend on the metadata from the frames to visualy calculate muzzle offsets. This however requires switching over to the fire/shoot animation before calculating the correct muzzle offset, otherwise, it will be still "idle" when the muzzle gets calculates. This reordering fixes this.