### PR TITLE
Correct the amount of money found in crates in allies03

### DIFF
--- a/mods/ra/maps/allies-03a/rules.yaml
+++ b/mods/ra/maps/allies-03a/rules.yaml
@@ -70,7 +70,8 @@ CAMERA.VeryLarge:
 MONEYCRATE:
 	Tooltip:
 		Name: Crate
-	WithCrateBody:
+	GiveCashCrateAction:
+		Amount: 2000
 	RenderSprites:
 		Image: scrate
 

--- a/mods/ra/maps/allies-03b/rules.yaml
+++ b/mods/ra/maps/allies-03b/rules.yaml
@@ -79,7 +79,8 @@ CAMERA.Jeep:
 MONEYCRATE:
 	Tooltip:
 		Name: Crate
-	WithCrateBody:
+	GiveCashCrateAction:
+		Amount: 2000
 	RenderSprites:
 		Image: scrate
 


### PR DESCRIPTION
You got 2000 in the original missions, too. Since bounties are disabled, 500 is not enough any more.
`WithCrateBody` can be removed as it is inherited from `^Crate` already.