### PR TITLE
Move TickIdle calls from World.Tick to Actor.Tick

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -77,6 +77,7 @@ namespace OpenRA
 		readonly IMouseBounds[] mouseBounds;
 		readonly IVisibilityModifier[] visibilityModifiers;
 		readonly IDefaultVisibility defaultVisibility;
+		readonly INotifyIdle[] tickIdles;
 		readonly ITargetablePositions[] targetablePositions;
 		WPos[] staticTargetablePositions;
 
@@ -119,6 +120,7 @@ namespace OpenRA
 			mouseBounds = TraitsImplementing<IMouseBounds>().ToArray();
 			visibilityModifiers = TraitsImplementing<IVisibilityModifier>().ToArray();
 			defaultVisibility = Trait<IDefaultVisibility>();
+			tickIdles = TraitsImplementing<INotifyIdle>().ToArray();
 			Targetables = TraitsImplementing<ITargetable>().ToArray();
 			targetablePositions = TraitsImplementing<ITargetablePositions>().ToArray();
 			world.AddFrameEndTask(w =>
@@ -141,6 +143,9 @@ namespace OpenRA
 			if (!wasIdle && IsIdle)
 				foreach (var n in TraitsImplementing<INotifyBecomingIdle>())
 					n.OnBecomingIdle(this);
+			else if (wasIdle)
+				foreach (var tickIdle in tickIdles)
+					tickIdle.TickIdle(this);
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -355,12 +355,7 @@ namespace OpenRA
 			{
 				WorldTick++;
 
-				using (new PerfSample("tick_idle"))
-					foreach (var ni in ActorsWithTrait<INotifyIdle>())
-						if (ni.Actor.IsIdle)
-							ni.Trait.TickIdle(ni.Actor);
-
-				using (new PerfSample("tick_activities"))
+				using (new PerfSample("tick_actors"))
 					foreach (var a in actors.Values)
 						a.Tick();
 

--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -87,8 +87,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyBecomingIdle.OnBecomingIdle(Actor a)
 		{
-			if (a.IsIdle)
-				targets = null;
+			targets = null;
 		}
 	}
 


### PR DESCRIPTION
- avoids those extra ActorsHavingTrait look-ups in World.Tick
- allows caching INotifyIdle in Actor

If the numbers from a customized version of our benchmark mode are to be believed, the average cost of activities+TickIdle combined is measurably lower with this PR (on RA shellmap) compared to bleed.