### PR TITLE
Remove legacy building.Locked and building.BuildComplete from Gate.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/Gate.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Gate.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public class Gate : PausableConditionalTrait<GateInfo>, ITick, ITemporaryBlocker, IBlocksProjectiles,
-		INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyBlockingMove, ISync
+		INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyBlockingMove
 	{
 		readonly Actor self;
 		readonly Building building;
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ITick.Tick(Actor self)
 		{
-			if (IsTraitDisabled || IsTraitPaused || building.Locked || !building.BuildComplete)
+			if (IsTraitDisabled || IsTraitPaused)
 				return;
 
 			if (desiredPosition < Position)
@@ -125,7 +125,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool CanRemoveBlockage(Actor self, Actor blocking)
 		{
-			return !IsTraitDisabled && !IsTraitPaused && building.BuildComplete && !building.Locked && blocking.AppearsFriendlyTo(self);
+			return !IsTraitDisabled && !IsTraitPaused && blocking.AppearsFriendlyTo(self);
 		}
 
 		bool IsBlocked()

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -1133,6 +1133,8 @@
 	-Capturable:
 	-GivesBuildableArea:
 	-MustBeDestroyed:
+	WithMakeAnimation:
+		Condition: build-incomplete
 	-WithSpriteBody:
 	WithGateSpriteBody:
 		OpenSequence: open
@@ -1148,10 +1150,10 @@
 	MapEditorData:
 		Categories: Wall
 	Gate:
+		PauseOnCondition: empdisable || build-incomplete
 		OpeningSound: gateup1.aud
 		ClosingSound: gatedwn1.aud
 		BlocksProjectilesHeight: 768
-		PauseOnCondition: empdisable
 
 ^Gate_A:
 	Inherits: ^Gate


### PR DESCRIPTION
Another step towards eliminating these legacy code warts.