### PR TITLE
Alter default tabs' drop-down heights to align with the RA mod.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -70,11 +70,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return item;
 			};
 
-			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 167, options, setupItem);
+			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 180, options, setupItem);
 		}
 
 		public static void ShowPlayerActionDropDown(DropDownButtonWidget dropdown, Session.Slot slot,
-			Session.Client c, OrderManager orderManager, Widget lobby,  Action before, Action after)
+			Session.Client c, OrderManager orderManager, Widget lobby, Action before, Action after)
 		{
 			Action<bool> okPressed = tempBan => { orderManager.IssueOrder(Order.Command("kick {0} {1}".F(c.Index, tempBan))); after(); };
 			var onClick = new Action(() =>
@@ -194,7 +194,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var options = factions.Where(f => f.Value.Selectable).GroupBy(f => f.Value.Side)
 				.ToDictionary(g => g.Key ?? "", g => g.Select(f => f.Key));
 
-			dropdown.ShowDropDown("FACTION_DROPDOWN_TEMPLATE", 150, options, setupItem);
+			dropdown.ShowDropDown("FACTION_DROPDOWN_TEMPLATE", 154, options, setupItem);
 		}
 
 		public static void ShowColorDropDown(DropDownButtonWidget color, Session.Client client,
@@ -418,7 +418,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 
 		public static void SetupPlayerActionWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager,
-			WorldRenderer worldRenderer,  Widget lobby, Action before, Action after)
+			WorldRenderer worldRenderer, Widget lobby, Action before, Action after)
 		{
 			var slot = parent.Get<DropDownButtonWidget>("PLAYER_ACTION");
 			slot.IsVisible = () => Game.IsHost && c.Index != orderManager.LocalClient.Index;


### PR DESCRIPTION
The default values cuts off the ra mod's dropdown options. They don't interfere with other mods cut-off because of their shorter option lists.

![lobby1](https://user-images.githubusercontent.com/2715583/46489612-2b807d00-c806-11e8-8501-2ba109d23292.png)
![lobby2](https://user-images.githubusercontent.com/2715583/46489616-2d4a4080-c806-11e8-80b8-394c42060e07.png)

It would be nice to have these values as user defined so modders can polish the initial visible options, e.g. here RA faction drop-down presents the countries and has the random factions are scrollable.