### PR TITLE
Add a proper exception when creating an actor with an invalid owner in Lua

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Global/ActorGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ActorGlobal.cs
@@ -56,6 +56,10 @@ namespace OpenRA.Mods.Common.Scripting
 				}
 			}
 
+			var owner = initDict.GetOrDefault<OwnerInit>();
+			if (owner == null)
+				throw new LuaException("Tried to create actor '{0}' with an invalid or no owner init!".F(type));
+
 			// The actor must be added to the world at the end of the tick
 			var a = Context.World.CreateActor(false, type, initDict);
 			if (addToWorld)


### PR DESCRIPTION
Closes #10966.