### PR TITLE
Fix OnAllRemovedFromWorld only triggering once

### DIFF
--- a/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
+++ b/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
@@ -43,6 +43,7 @@ namespace OpenRA.Mods.Common.Scripting
 		public event Action<Actor> OnKilledInternal = _ => { };
 		public event Action<Actor> OnCapturedInternal = _ => { };
 		public event Action<Actor> OnRemovedInternal = _ => { };
+		public event Action<Actor> OnAddedInternal = _ => { };
 		public event Action<Actor, Actor> OnProducedInternal = (a, b) => { };
 		public event Action<Actor, Actor> OnOtherProducedInternal = (a, b) => { };
 
@@ -340,6 +341,9 @@ namespace OpenRA.Mods.Common.Scripting
 					return;
 				}
 			}
+
+			// Run any internally bound callbacks
+			OnAddedInternal(self);
 		}
 
 		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)


### PR DESCRIPTION
We trigger all the other triggers like `OnRemovedFromWorld` multiple times, except the "on killed" ones (obviously) and the "on captured" triggers (I could fix those as well, we usually don't need this however).