### PR TITLE
Remove INotifyBuildComplete from render traits.

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -587,6 +587,7 @@
     <Compile Include="Traits\World\ActorSpawnManager.cs" />
     <Compile Include="Traits\ActorSpawner.cs" />
     <Compile Include="UpdateRules\Rules\20180923\MergeCaptureTraits.cs" />
+    <Compile Include="UpdateRules\Rules\20180923\RemovedNotifyBuildComplete.cs" />
     <Compile Include="UtilityCommands\CheckYaml.cs" />
     <Compile Include="UtilityCommands\ConvertPngToShpCommand.cs" />
     <Compile Include="UtilityCommands\ConvertSpriteToPngCommand.cs" />

--- a/OpenRA.Mods.Common/Traits/Render/WithAcceptDeliveredCashAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAcceptDeliveredCashAnimation.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Replaces the building animation when it accepts a cash delivery unit.")]
-	public class WithAcceptDeliveredCashAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>
+	public class WithAcceptDeliveredCashAnimationInfo : ConditionalTraitInfo, Requires<WithSpriteBodyInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "active";
@@ -23,41 +23,27 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Which sprite body to play the animation on.")]
 		public readonly string Body = "body";
 
-		public object Create(ActorInitializer init) { return new WithAcceptDeliveredCashAnimation(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithAcceptDeliveredCashAnimation(init.Self, this); }
 	}
 
-	public class WithAcceptDeliveredCashAnimation : INotifyCashTransfer, INotifyBuildComplete, INotifySold
+	public class WithAcceptDeliveredCashAnimation : ConditionalTrait<WithAcceptDeliveredCashAnimationInfo>, INotifyCashTransfer
 	{
-		readonly WithAcceptDeliveredCashAnimationInfo info;
 		readonly WithSpriteBody wsb;
-		bool buildComplete;
 
 		public WithAcceptDeliveredCashAnimation(Actor self, WithAcceptDeliveredCashAnimationInfo info)
+			: base(info)
 		{
-			this.info = info;
 			wsb = self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == info.Body);
 		}
-
-		void INotifyBuildComplete.BuildingComplete(Actor self)
-		{
-			buildComplete = true;
-		}
-
-		void INotifySold.Selling(Actor self)
-		{
-			buildComplete = false;
-		}
-
-		void INotifySold.Sold(Actor self) { }
 
 		bool playing;
 		void INotifyCashTransfer.OnAcceptingCash(Actor self, Actor donor)
 		{
-			if (!buildComplete || playing)
+			if (IsTraitDisabled || playing)
 				return;
 
 			playing = true;
-			wsb.PlayCustomAnimation(self, info.Sequence, () => playing = false);
+			wsb.PlayCustomAnimation(self, Info.Sequence, () => playing = false);
 		}
 
 		void INotifyCashTransfer.OnDeliveringCash(Actor self, Actor acceptor) { }

--- a/OpenRA.Mods.Common/Traits/Render/WithBridgeSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBridgeSpriteBody.cs
@@ -68,8 +68,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 			bridgeLayer = init.World.WorldActor.Trait<BridgeLayer>();
 		}
 
-		protected override void OnBuildComplete(Actor self)
+		protected override void TraitEnabled(Actor self)
 		{
+			base.TraitEnabled(self);
+
 			if (bridgeInfo.AOffset != CVec.Zero)
 				UpdateNeighbour(bridgeInfo.AOffset);
 

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
@@ -26,41 +26,25 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithBuildingPlacedAnimation(init.Self, this); }
 	}
 
-	public class WithBuildingPlacedAnimation : ConditionalTrait<WithBuildingPlacedAnimationInfo>, INotifyBuildingPlaced, INotifyBuildComplete, INotifySold, INotifyTransform
+	public class WithBuildingPlacedAnimation : ConditionalTrait<WithBuildingPlacedAnimationInfo>, INotifyBuildingPlaced
 	{
 		readonly WithSpriteBody wsb;
-		bool buildComplete;
 
 		public WithBuildingPlacedAnimation(Actor self, WithBuildingPlacedAnimationInfo info)
 			: base(info)
 		{
 			wsb = self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == info.Body);
-			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>();
 		}
-
-		void INotifyBuildComplete.BuildingComplete(Actor self)
-		{
-			buildComplete = true;
-		}
-
-		void INotifySold.Sold(Actor self) { }
-		void INotifySold.Selling(Actor self)
-		{
-			buildComplete = false;
-		}
-
-		void INotifyTransform.BeforeTransform(Actor self)
-		{
-			buildComplete = false;
-		}
-
-		void INotifyTransform.OnTransform(Actor self) { }
-		void INotifyTransform.AfterTransform(Actor self) { }
 
 		void INotifyBuildingPlaced.BuildingPlaced(Actor self)
 		{
-			if (!IsTraitDisabled && buildComplete)
+			if (!IsTraitDisabled)
 				wsb.PlayCustomAnimation(self, Info.Sequence);
+		}
+
+		protected override void TraitDisabled(Actor self)
+		{
+			wsb.CancelCustomAnimation(self);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Rendered when the actor constructed a building.")]
-	public class WithBuildingPlacedOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
+	public class WithBuildingPlacedOverlayInfo : ConditionalTraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "crane-overlay";
@@ -29,51 +29,29 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;
 
-		public object Create(ActorInitializer init) { return new WithBuildingPlacedOverlay(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithBuildingPlacedOverlay(init.Self, this); }
 	}
 
-	public class WithBuildingPlacedOverlay : INotifyBuildComplete, INotifySold, INotifyDamageStateChanged, INotifyBuildingPlaced, INotifyTransform
+	public class WithBuildingPlacedOverlay : ConditionalTrait<WithBuildingPlacedOverlayInfo>, INotifyDamageStateChanged, INotifyBuildingPlaced
 	{
 		readonly Animation overlay;
-		bool buildComplete;
 		bool visible;
 
 		public WithBuildingPlacedOverlay(Actor self, WithBuildingPlacedOverlayInfo info)
+			: base(info)
 		{
 			var rs = self.Trait<RenderSprites>();
 			var body = self.Trait<BodyOrientation>();
-
-			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>(); // always render instantly for units
 
 			overlay = new Animation(self.World, rs.GetImage(self));
 
 			var anim = new AnimationWithOffset(overlay,
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
-				() => !visible || !buildComplete);
+				() => !visible || IsTraitDisabled);
 
 			overlay.PlayThen(info.Sequence, () => visible = false);
 			rs.Add(anim, info.Palette, info.IsPlayerPalette);
 		}
-
-		void INotifyBuildComplete.BuildingComplete(Actor self)
-		{
-			buildComplete = true;
-			visible = false;
-		}
-
-		void INotifySold.Sold(Actor self) { }
-		void INotifySold.Selling(Actor self)
-		{
-			buildComplete = false;
-		}
-
-		void INotifyTransform.BeforeTransform(Actor self)
-		{
-			buildComplete = false;
-		}
-
-		void INotifyTransform.OnTransform(Actor self) { }
-		void INotifyTransform.AfterTransform(Actor self) { }
 
 		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/WithChargeOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithChargeOverlay.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Render overlay that varies the animation frame based on the AttackCharges trait's charge level.")]
-	class WithChargeOverlayInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<RenderSpritesInfo>
+	class WithChargeOverlayInfo : PausableConditionalTraitInfo, Requires<WithSpriteBodyInfo>, Requires<RenderSpritesInfo>
 	{
 		[SequenceReference]
 		[Desc("Sequence to use for the charge levels.")]
@@ -27,46 +27,33 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;
 
-		public object Create(ActorInitializer init) { return new WithChargeOverlay(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithChargeOverlay(init.Self, this); }
 	}
 
-	class WithChargeOverlay : INotifyBuildComplete, INotifySold, INotifyDamageStateChanged
+	class WithChargeOverlay : PausableConditionalTrait<WithChargeOverlayInfo>, INotifyDamageStateChanged
 	{
-		readonly WithChargeOverlayInfo info;
 		readonly Animation overlay;
-		readonly RenderSprites rs;
-		readonly WithSpriteBody wsb;
-
-		bool buildComplete;
 
 		public WithChargeOverlay(Actor self, WithChargeOverlayInfo info)
+			: base(info)
 		{
-			this.info = info;
-			rs = self.Trait<RenderSprites>();
-			wsb = self.Trait<WithSpriteBody>();
+			var rs = self.Trait<RenderSprites>();
+			var wsb = self.Trait<WithSpriteBody>();
 
 			var attackCharges = self.Trait<AttackCharges>();
 			var attackChargesInfo = (AttackChargesInfo)attackCharges.Info;
 
-			overlay = new Animation(self.World, rs.GetImage(self));
+			overlay = new Animation(self.World, rs.GetImage(self), () => IsTraitPaused);
 			overlay.PlayFetchIndex(wsb.NormalizeSequence(self, info.Sequence),
 				() => int2.Lerp(0, overlay.CurrentSequence.Length, attackCharges.ChargeLevel, attackChargesInfo.ChargeLevel + 1));
 
-			rs.Add(new AnimationWithOffset(overlay, null, () => !buildComplete, 1024),
+			rs.Add(new AnimationWithOffset(overlay, null, () => IsTraitDisabled, 1024),
 				info.Palette, info.IsPlayerPalette);
-		}
-
-		void INotifyBuildComplete.BuildingComplete(Actor self)
-		{
-			buildComplete = true;
 		}
 
 		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
 		{
-			overlay.ReplaceAnim(RenderSprites.NormalizeSequence(overlay, e.DamageState, info.Sequence));
+			overlay.ReplaceAnim(RenderSprites.NormalizeSequence(overlay, e.DamageState, Info.Sequence));
 		}
-
-		void INotifySold.Selling(Actor self) { buildComplete = false; }
-		void INotifySold.Sold(Actor self) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithDeadBridgeSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeadBridgeSpriteBody.cs
@@ -81,8 +81,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return bridgeInfo.RampActors.Contains(neighbour.Info.Name);
 		}
 
-		protected override void OnBuildComplete(Actor self)
+		protected override void TraitEnabled(Actor self)
 		{
+			base.TraitEnabled(self);
+
 			self.World.AddFrameEndTask(w =>
 			{
 				var aRamp = bridgeInfo.AOffset != CVec.Zero && RampExists(self, bridgeInfo.AOffset);

--- a/OpenRA.Mods.Common/Traits/Render/WithGateSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithGateSpriteBody.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		void UpdateState(Actor self)
 		{
-			if (renderOpen)
+			if (renderOpen || IsTraitPaused)
 				DefaultAnimation.PlayRepeating(NormalizeSequence(self, gateBodyInfo.OpenSequence));
 			else
 				DefaultAnimation.PlayFetchIndex(NormalizeSequence(self, Info.Sequence), GetGateFrame);
@@ -91,8 +91,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 			UpdateState(self);
 		}
 
-		protected override void OnBuildComplete(Actor self)
+		protected override void TraitEnabled(Actor self)
 		{
+			base.TraitEnabled(self);
+
 			UpdateState(self);
 			UpdateNeighbours(self);
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleAnimation.cs
@@ -28,23 +28,21 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithIdleAnimation(init.Self, this); }
 	}
 
-	public class WithIdleAnimation : ConditionalTrait<WithIdleAnimationInfo>, ITick, INotifyBuildComplete, INotifySold
+	public class WithIdleAnimation : ConditionalTrait<WithIdleAnimationInfo>, ITick
 	{
 		readonly WithSpriteBody wsb;
-		bool buildComplete;
 		int ticks;
 
 		public WithIdleAnimation(Actor self, WithIdleAnimationInfo info)
 			: base(info)
 		{
 			wsb = self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == Info.Body);
-			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>(); // always render instantly for units
 			ticks = info.Interval;
 		}
 
 		void ITick.Tick(Actor self)
 		{
-			if (!buildComplete || IsTraitDisabled)
+			if (IsTraitDisabled)
 				return;
 
 			if (--ticks <= 0)
@@ -54,16 +52,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 			}
 		}
 
-		void INotifyBuildComplete.BuildingComplete(Actor self)
+		protected override void TraitDisabled(Actor self)
 		{
-			buildComplete = true;
+			wsb.CancelCustomAnimation(self);
 		}
-
-		void INotifySold.Selling(Actor self)
-		{
-			buildComplete = false;
-		}
-
-		void INotifySold.Sold(Actor self) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithNukeLaunchAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithNukeLaunchAnimation.cs
@@ -26,33 +26,25 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithNukeLaunchAnimation(init.Self, this); }
 	}
 
-	public class WithNukeLaunchAnimation : ConditionalTrait<WithNukeLaunchAnimationInfo>, INotifyNuke, INotifyBuildComplete, INotifySold
+	public class WithNukeLaunchAnimation : ConditionalTrait<WithNukeLaunchAnimationInfo>, INotifyNuke
 	{
-		readonly WithSpriteBody spriteBody;
-		bool buildComplete;
+		readonly WithSpriteBody wsb;
 
 		public WithNukeLaunchAnimation(Actor self, WithNukeLaunchAnimationInfo info)
 			: base(info)
 		{
-			spriteBody = self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == Info.Body);
+			wsb = self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == Info.Body);
 		}
 
 		void INotifyNuke.Launching(Actor self)
 		{
-			if (buildComplete && !IsTraitDisabled)
-				spriteBody.PlayCustomAnimation(self, Info.Sequence, () => spriteBody.CancelCustomAnimation(self));
+			if (!IsTraitDisabled)
+				wsb.PlayCustomAnimation(self, Info.Sequence, () => wsb.CancelCustomAnimation(self));
 		}
 
-		void INotifyBuildComplete.BuildingComplete(Actor self)
+		protected override void TraitDisabled(Actor self)
 		{
-			buildComplete = true;
+			wsb.CancelCustomAnimation(self);
 		}
-
-		void INotifySold.Selling(Actor self)
-		{
-			buildComplete = false;
-		}
-
-		void INotifySold.Sold(Actor self) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithNukeLaunchOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithNukeLaunchOverlay.cs
@@ -33,10 +33,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithNukeLaunchOverlay(init.Self, this); }
 	}
 
-	public class WithNukeLaunchOverlay : ConditionalTrait<WithNukeLaunchOverlayInfo>, INotifyBuildComplete, INotifySold, INotifyNuke
+	public class WithNukeLaunchOverlay : ConditionalTrait<WithNukeLaunchOverlayInfo>, INotifyNuke
 	{
 		readonly Animation overlay;
-		bool buildComplete;
 		bool visible;
 
 		public WithNukeLaunchOverlay(Actor self, WithNukeLaunchOverlayInfo info)
@@ -45,27 +44,15 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var rs = self.Trait<RenderSprites>();
 			var body = self.Trait<BodyOrientation>();
 
-			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>(); // always render instantly for units
 			overlay = new Animation(self.World, rs.GetImage(self));
 			overlay.PlayThen(info.Sequence, () => visible = false);
 
 			var anim = new AnimationWithOffset(overlay,
 				() => body.LocalToWorld(info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation))),
-				() => IsTraitDisabled || !visible || !buildComplete,
+				() => IsTraitDisabled || !visible,
 				p => RenderUtils.ZOffsetFromCenter(self, p, 1));
 
 			rs.Add(anim, info.Palette, info.IsPlayerPalette);
-		}
-
-		void INotifyBuildComplete.BuildingComplete(Actor self)
-		{
-			buildComplete = true;
-		}
-
-		void INotifySold.Sold(Actor self) { }
-		void INotifySold.Selling(Actor self)
-		{
-			buildComplete = false;
 		}
 
 		void INotifyNuke.Launching(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	public class WithSpriteBody : PausableConditionalTrait<WithSpriteBodyInfo>, INotifyDamageStateChanged, INotifyBuildComplete, IAutoMouseBounds
+	public class WithSpriteBody : PausableConditionalTrait<WithSpriteBodyInfo>, INotifyDamageStateChanged, IAutoMouseBounds
 	{
 		public readonly Animation DefaultAnimation;
 		readonly RenderSprites rs;
@@ -80,15 +80,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return RenderSprites.NormalizeSequence(DefaultAnimation, self.GetDamageState(), sequence);
 		}
 
-		protected virtual void OnBuildComplete(Actor self)
+		protected override void TraitEnabled(Actor self)
 		{
 			DefaultAnimation.PlayRepeating(NormalizeSequence(self, Info.Sequence));
-		}
-
-		// TODO: Get rid of INotifyBuildComplete in favor of using the condition system
-		void INotifyBuildComplete.BuildingComplete(Actor self)
-		{
-			OnBuildComplete(self);
 		}
 
 		public void PlayCustomAnimation(Actor self, string name, Action after = null)

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -70,16 +70,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	public class WithSpriteTurret : ConditionalTrait<WithSpriteTurretInfo>, INotifyBuildComplete, INotifySold, INotifyTransform, INotifyDamageStateChanged
+	public class WithSpriteTurret : ConditionalTrait<WithSpriteTurretInfo>, INotifyDamageStateChanged
 	{
 		public readonly Animation DefaultAnimation;
 		readonly RenderSprites rs;
 		readonly BodyOrientation body;
 		readonly Turreted t;
 		readonly Armament[] arms;
-
-		// TODO: This should go away once https://github.com/OpenRA/OpenRA/issues/7035 is implemented
-		bool buildComplete;
 
 		public WithSpriteTurret(Actor self, WithSpriteTurretInfo info)
 			: base(info)
@@ -90,13 +87,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 				.First(tt => tt.Name == info.Turret);
 			arms = self.TraitsImplementing<Armament>()
 				.Where(w => w.Info.Turret == info.Turret).ToArray();
-			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>(); // always render instantly for units
 
 			DefaultAnimation = new Animation(self.World, rs.GetImage(self), () => t.TurretFacing);
 			DefaultAnimation.PlayRepeating(NormalizeSequence(self, info.Sequence));
 			rs.Add(new AnimationWithOffset(DefaultAnimation,
 				() => TurretOffset(self),
-				() => IsTraitDisabled || !buildComplete,
+				() => IsTraitDisabled,
 				p => RenderUtils.ZOffsetFromCenter(self, p, 1)), info.Palette, info.IsPlayerPalette);
 
 			// Restrict turret facings to match the sprite
@@ -144,12 +140,5 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			DefaultAnimation.PlayRepeating(NormalizeSequence(self, Info.Sequence));
 		}
-
-		void INotifyBuildComplete.BuildingComplete(Actor self) { buildComplete = true; }
-		void INotifySold.Selling(Actor self) { buildComplete = false; }
-		void INotifySold.Sold(Actor self) { }
-		void INotifyTransform.BeforeTransform(Actor self) { buildComplete = false; }
-		void INotifyTransform.OnTransform(Actor self) { }
-		void INotifyTransform.AfterTransform(Actor toActor) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
@@ -63,15 +63,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	public class WithVoxelBarrel : ConditionalTrait<WithVoxelBarrelInfo>, INotifyBuildComplete, INotifySold, INotifyTransform
+	public class WithVoxelBarrel : ConditionalTrait<WithVoxelBarrelInfo>
 	{
 		readonly Actor self;
 		readonly Armament armament;
 		readonly Turreted turreted;
 		readonly BodyOrientation body;
-
-		// TODO: This should go away once https://github.com/OpenRA/OpenRA/issues/7035 is implemented
-		bool buildComplete;
 
 		public WithVoxelBarrel(Actor self, WithVoxelBarrelInfo info)
 			: base(info)
@@ -83,12 +80,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 			turreted = self.TraitsImplementing<Turreted>()
 				.First(tt => tt.Name == armament.Info.Turret);
 
-			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>(); // always render instantly for units
-
 			var rv = self.Trait<RenderVoxels>();
 			rv.Add(new ModelAnimation(self.World.ModelCache.GetModelSequence(rv.Image, Info.Sequence),
 				BarrelOffset, BarrelRotation,
-				() => IsTraitDisabled || !buildComplete, () => 0, info.ShowShadow));
+				() => IsTraitDisabled, () => 0, info.ShowShadow));
 		}
 
 		WVec BarrelOffset()
@@ -110,12 +105,5 @@ namespace OpenRA.Mods.Common.Traits.Render
 			yield return turreted.WorldOrientation(self) - b + WRot.FromYaw(b.Yaw - qb.Yaw);
 			yield return qb;
 		}
-
-		void INotifyBuildComplete.BuildingComplete(Actor self) { buildComplete = true; }
-		void INotifySold.Selling(Actor self) { buildComplete = false; }
-		void INotifySold.Sold(Actor self) { }
-		void INotifyTransform.BeforeTransform(Actor self) { buildComplete = false; }
-		void INotifyTransform.OnTransform(Actor self) { }
-		void INotifyTransform.AfterTransform(Actor toActor) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
@@ -51,14 +51,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	public class WithVoxelTurret : ConditionalTrait<WithVoxelTurretInfo>, INotifyBuildComplete, INotifySold, INotifyTransform
+	public class WithVoxelTurret : ConditionalTrait<WithVoxelTurretInfo>
 	{
 		readonly Actor self;
 		readonly Turreted turreted;
 		readonly BodyOrientation body;
-
-		// TODO: This should go away once https://github.com/OpenRA/OpenRA/issues/7035 is implemented
-		bool buildComplete;
 
 		public WithVoxelTurret(Actor self, WithVoxelTurretInfo info)
 			: base(info)
@@ -67,12 +64,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 			body = self.Trait<BodyOrientation>();
 			turreted = self.TraitsImplementing<Turreted>()
 				.First(tt => tt.Name == Info.Turret);
-			buildComplete = !self.Info.HasTraitInfo<BuildingInfo>(); // always render instantly for units
 
 			var rv = self.Trait<RenderVoxels>();
 			rv.Add(new ModelAnimation(self.World.ModelCache.GetModelSequence(rv.Image, Info.Sequence),
 				() => turreted.Position(self), TurretRotation,
-				() => IsTraitDisabled || !buildComplete, () => 0, info.ShowShadow));
+				() => IsTraitDisabled, () => 0, info.ShowShadow));
 		}
 
 		IEnumerable<WRot> TurretRotation()
@@ -82,12 +78,5 @@ namespace OpenRA.Mods.Common.Traits.Render
 			yield return turreted.WorldOrientation(self) - b + WRot.FromYaw(b.Yaw - qb.Yaw);
 			yield return qb;
 		}
-
-		void INotifyBuildComplete.BuildingComplete(Actor self) { buildComplete = true; }
-		void INotifySold.Selling(Actor self) { buildComplete = false; }
-		void INotifySold.Sold(Actor self) { }
-		void INotifyTransform.BeforeTransform(Actor self) { buildComplete = false; }
-		void INotifyTransform.OnTransform(Actor self) { }
-		void INotifyTransform.AfterTransform(Actor toActor) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
@@ -139,8 +139,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 			dirty = false;
 		}
 
-		protected override void OnBuildComplete(Actor self)
+		protected override void TraitEnabled(Actor self)
 		{
+			base.TraitEnabled(self);
+			dirty = true;
+
 			DefaultAnimation.PlayFetchIndex(NormalizeSequence(self, Info.Sequence), () => adjacent);
 			UpdateNeighbours(self);
 
@@ -162,8 +165,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			UpdateNeighbours(self);
 		}
-
-		protected override void TraitEnabled(Actor self) { dirty = true; }
 	}
 
 	public class RuntimeNeighbourInit : IActorInit<Dictionary<CPos, string[]>>, ISuppressInitExport

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/RemovedNotifyBuildComplete.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/RemovedNotifyBuildComplete.cs
@@ -1,0 +1,86 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RemovedNotifyBuildComplete : UpdateRule
+	{
+		public override string Name { get { return "Render traits are no longer automatically disabled during Building make-animations"; } }
+		public override string Description
+		{
+			get
+			{
+				return "Traits are no longer force-disabled while the WithMakeAnimation trait is active.\n" +
+					"This affects the With*Animation, With*Overlay, and Gate traits.\n" +
+					"Affected actors are listed so that conditions may be manually defined.";
+			}
+		}
+
+		static readonly string[] Traits =
+		{
+			"WithAcceptDeliveredCashAnimation",
+			"WithBuildingPlacedAnimation",
+			"WithBuildingPlacedOverlay",
+			"WithChargeAnimation",
+			"WithChargeOverlay",
+			"WithDockedOverlay",
+			"WithIdleAnimation",
+			"WithIdleOverlay",
+			"WithNukeLaunchAnimation",
+			"WithNukeLaunchOverlay",
+			"WithProductionDoorOverlay",
+			"WithProductionOverlay",
+			"WithRepairOverlay",
+			"WithResources",
+			"WithResupplyAnimation",
+			"WithSiloAnimation",
+			"WithSpriteTurret",
+			"WithVoxelBarrel",
+			"WithVoxelTurret",
+			"WithDeliveryAnimation",
+			"WithCrumbleOverlay",
+			"WithDeliveryOverlay",
+			"Gate"
+		};
+
+		readonly Dictionary<string, List<string>> locations = new Dictionary<string, List<string>>();
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (locations.Any())
+				yield return "Review the following definitions and, for those that are buildings,\n" +
+					"define conditions to disable them while WithMakeAnimation is active:\n" +
+					UpdateUtils.FormatMessageList(locations.Select(
+						kv => kv.Key + ":\n" + UpdateUtils.FormatMessageList(kv.Value)));
+
+			locations.Clear();
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var used = new List<string>();
+			foreach (var t in Traits)
+				if (actorNode.LastChildMatching(t) != null)
+					used.Add(t);
+
+			if (used.Any())
+			{
+				var location = "{0} ({1})".F(actorNode.Key, actorNode.Location.Filename);
+				locations[location] = used;
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -93,6 +93,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new DefineNotificationDefaults(),
 				new MergeRearmAndRepairAnimation(),
 				new MergeCaptureTraits(),
+				new RemovedNotifyBuildComplete(),
 			})
 		};
 

--- a/OpenRA.Mods.D2k/Traits/Render/WithCrumbleOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithCrumbleOverlay.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.D2k.Traits.Render
 {
 	[Desc("Rendered together with the \"make\" animation.")]
-	public class WithCrumbleOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>
+	public class WithCrumbleOverlayInfo : ConditionalTraitInfo, Requires<RenderSpritesInfo>
 	{
 		[Desc("Sequence name to use")]
 		[SequenceReference] public readonly string Sequence = "crumble-overlay";
@@ -28,14 +28,13 @@ namespace OpenRA.Mods.D2k.Traits.Render
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;
 
-		public object Create(ActorInitializer init) { return new WithCrumbleOverlay(init, this); }
+		public override object Create(ActorInitializer init) { return new WithCrumbleOverlay(init, this); }
 	}
 
-	public class WithCrumbleOverlay : INotifyBuildComplete
+	public class WithCrumbleOverlay : ConditionalTrait<WithCrumbleOverlayInfo>
 	{
-		bool buildComplete = false;
-
 		public WithCrumbleOverlay(ActorInitializer init, WithCrumbleOverlayInfo info)
+			: base(info)
 		{
 			if (init.Contains<SkipMakeAnimsInit>())
 				return;
@@ -43,17 +42,12 @@ namespace OpenRA.Mods.D2k.Traits.Render
 			var rs = init.Self.Trait<RenderSprites>();
 
 			var overlay = new Animation(init.World, rs.GetImage(init.Self));
-			var anim = new AnimationWithOffset(overlay, null, () => !buildComplete);
+			var anim = new AnimationWithOffset(overlay, null, () => IsTraitDisabled);
 
 			// Remove the animation once it is complete
 			overlay.PlayThen(info.Sequence, () => init.World.AddFrameEndTask(w => rs.Remove(anim)));
 
 			rs.Add(anim, info.Palette, info.IsPlayerPalette);
-		}
-
-		void INotifyBuildComplete.BuildingComplete(Actor self)
-		{
-			buildComplete = true;
 		}
 	}
 }

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -17,7 +17,6 @@ FACT:
 		Type: Wood
 	RevealsShroud:
 		Range: 10c0
-	WithBuildingBib:
 	Production:
 		Produces: Building.GDI, Building.Nod, Defence.GDI, Defence.Nod
 	Transforms:
@@ -84,7 +83,11 @@ FACT:
 	BaseProvider:
 		Cooldown: 75
 		Range: 14c0
+	WithBuildingBib:
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithBuildingPlacedAnimation:
+		RequiresCondition: !build-incomplete
 	Power:
 		Amount: 0
 	ProvidesPrerequisite@buildingname:
@@ -205,7 +208,6 @@ PROC:
 		HP: 100000
 	RevealsShroud:
 		Range: 6c0
-	WithBuildingBib:
 	Refinery:
 		DockAngle: 112
 		DockOffset: 0,2
@@ -226,7 +228,11 @@ PROC:
 		Actor: HARV
 		SpawnOffset: 1,2
 		Facing: 64
+	WithBuildingBib:
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithResources:
+		RequiresCondition: !build-incomplete
 	Power:
 		Amount: -40
 	ProvidesPrerequisite@buildingname:
@@ -254,9 +260,10 @@ SILO:
 		Range: 4c0
 	WithBuildingBib:
 		HasMinibib: Yes
-	RenderSprites:
-	WithSpriteBody:
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithSiloAnimation:
+		RequiresCondition: !build-incomplete
 	StoresResources:
 		PipCount: 10
 		PipColor: Green
@@ -406,9 +413,6 @@ AFLD:
 		HP: 110000
 	RevealsShroud:
 		Range: 7c0
-	WithBuildingBib:
-	WithIdleOverlay@DISH:
-		Sequence: idle-dish
 	RallyPoint:
 		Offset: 4,2
 	Exit@1:
@@ -416,7 +420,14 @@ AFLD:
 		ExitCell: 3,1
 	ProductionAirdrop:
 		Produces: Vehicle.Nod
+	WithBuildingBib:
+	WithMakeAnimation:
+		Condition: build-incomplete
+	WithIdleOverlay@DISH:
+		RequiresCondition: !build-incomplete
+		Sequence: idle-dish
 	WithDeliveryAnimation:
+		RequiresCondition: !build-incomplete
 	ProductionQueue:
 		Type: Vehicle.Nod
 		Group: Vehicle
@@ -463,7 +474,10 @@ WEAP:
 	RevealsShroud:
 		Range: 4c0
 	WithBuildingBib:
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithProductionDoorOverlay:
+		RequiresCondition: !build-incomplete
 		Sequence: build-top
 	RallyPoint:
 		Offset: 0,2
@@ -521,7 +535,10 @@ HPAD:
 		HpPerStep: 1000
 		PlayerExperience: 25
 		StartRepairingNotification: Repairing
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithResupplyAnimation:
+		RequiresCondition: !build-incomplete
 	RallyPoint:
 	ProductionQueue@GDI:
 		Type: Aircraft.GDI
@@ -647,6 +664,10 @@ FIX:
 		Range: 5c0
 	WithBuildingBib:
 		HasMinibib: Yes
+	WithMakeAnimation:
+		Condition: build-incomplete
+	WithResupplyAnimation:
+		RequiresCondition: !build-incomplete
 	Reservable:
 	RepairsUnits:
 		HpPerStep: 1000
@@ -654,7 +675,6 @@ FIX:
 		PlayerExperience: 25
 		StartRepairingNotification: Repairing
 	RallyPoint:
-	WithResupplyAnimation:
 	Power:
 		Amount: -20
 	ProvidesPrerequisite@buildingname:
@@ -749,7 +769,6 @@ TMPL:
 		HP: 210000
 	RevealsShroud:
 		Range: 6c0
-	WithBuildingBib:
 	RenderDetectionCircle:
 	DetectCloaked:
 		Range: 5c0
@@ -778,8 +797,13 @@ TMPL:
 		ArrowSequence: arrow
 		ClockSequence: clock
 		CircleSequence: circles
+	WithBuildingBib:
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithNukeLaunchAnimation:
+		RequiresCondition: !build-incomplete
 	WithNukeLaunchOverlay:
+		RequiresCondition: !build-incomplete
 		Sequence: smoke
 	SupportPowerChargeBar:
 	Power:
@@ -906,7 +930,10 @@ OBLI:
 		Range: 8c0
 	WithBuildingBib:
 		HasMinibib: Yes
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithChargeAnimation:
+		RequiresCondition: !build-incomplete
 	Armament:
 		Weapon: Laser
 		LocalOffset: 0,-85,1280

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -392,7 +392,6 @@
 	SoundOnDamageTransition:
 		DamagedSounds: EXPLSML1.WAV
 		DestroyedSounds: EXPLHG1.WAV
-	WithSpriteBody:
 	Explodes:
 		Type: Footprint
 		Weapon: BuildingExplode
@@ -414,7 +413,6 @@
 		SellSounds: BUILD1.WAV
 	Guardable:
 		Range: 3c0
-	WithCrumbleOverlay:
 	Demolishable:
 	DamagedByTerrain:
 		Damage: 500
@@ -426,7 +424,11 @@
 		Weapons: Debris, Debris2, Debris3, Debris4
 		Pieces: 2, 5
 		Range: 1c512, 4c0
+	WithSpriteBody:
 	WithMakeAnimation:
+		Condition: build-incomplete
+	WithCrumbleOverlay:
+		RequiresCondition: !build-incomplete
 	RevealOnDeath:
 		Duration: 100
 		Radius: 4c768
@@ -449,6 +451,7 @@
 		Range: 1c768
 	-GivesBuildableArea:
 	-WithMakeAnimation:
+	-WithCrumbleOverlay:
 	-Capturable:
 	-WithSpriteBody:
 	WithWallSpriteBody:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -99,6 +99,7 @@ construction_yard:
 			harkonnen: conyard.harkonnen
 			corrino: conyard.harkonnen
 	WithBuildingPlacedOverlay:
+		RequiresCondition: !build-incomplete
 		Palette: d2k
 	PrimaryBuilding:
 		PrimaryCondition: primary
@@ -142,7 +143,6 @@ wind_trap:
 		Footprint: xx xx ==
 		Dimensions: 2,3
 		LocalCenterOffset: 0,-512,0
-	WithBuildingBib:
 	Health:
 		HP: 30000
 	HitShape:
@@ -160,7 +160,9 @@ wind_trap:
 			fremen: power.atreides
 			harkonnen: power.harkonnen
 			corrino: power.harkonnen
+	WithBuildingBib:
 	WithIdleOverlay@ZAPS:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-zaps
 	Power:
 		Amount: 200
@@ -188,7 +190,6 @@ barracks:
 		Footprint: xx xx ==
 		Dimensions: 2,3
 		LocalCenterOffset: 0,-512,0
-	WithBuildingBib:
 	Health:
 		HP: 32000
 	HitShape:
@@ -232,6 +233,7 @@ barracks:
 			fremen: barracks.atreides
 			harkonnen: barracks.harkonnen
 			corrino: barracks.harkonnen
+	WithBuildingBib:
 	ProvidesPrerequisite@buildingname:
 	GrantConditionOnPrerequisite:
 		Prerequisites: upgrade.barracks
@@ -271,7 +273,6 @@ refinery:
 		Footprint: =xx xx= ===
 		Dimensions: 3,3
 		LocalCenterOffset: 0,-512,0
-	WithBuildingBib:
 	Health:
 		HP: 30000
 	HitShape:
@@ -308,12 +309,15 @@ refinery:
 			fremen: refinery.atreides
 			harkonnen: refinery.harkonnen
 			corrino: refinery.harkonnen
+	WithBuildingBib:
+	WithIdleOverlay@TOP:
+		RequiresCondition: !build-incomplete
+		Sequence: idle-top
 	WithDockedOverlay@SMOKE:
+		RequiresCondition: !build-incomplete
 		Sequence: smoke
 	Power:
 		Amount: -75
-	WithIdleOverlay@TOP:
-		Sequence: idle-top
 	ProvidesPrerequisite@buildingname:
 
 silo:
@@ -347,8 +351,8 @@ silo:
 			fremen: silo.atreides
 			harkonnen: silo.harkonnen
 			corrino: silo.harkonnen
-	WithSpriteBody:
 	WithSiloAnimation:
+		RequiresCondition: !build-incomplete
 	StoresResources:
 		PipColor: green
 		PipCount: 5
@@ -384,7 +388,6 @@ light_factory:
 		Footprint: xxx xx= ===
 		Dimensions: 3,3
 		LocalCenterOffset: 0,-512,0
-	WithBuildingBib:
 	Health:
 		HP: 33000
 	HitShape:
@@ -403,6 +406,14 @@ light_factory:
 			fremen: light.atreides
 			harkonnen: light.harkonnen
 			corrino: light.harkonnen
+	WithBuildingBib:
+	WithIdleOverlay@TOP:
+		RequiresCondition: !build-incomplete
+		Sequence: idle-top
+	WithProductionOverlay@WELDING:
+		RequiresCondition: !build-incomplete
+		Queues: Vehicle
+		Sequence: production-welding
 	RallyPoint:
 		Offset: 2,2
 	Exit@1:
@@ -431,11 +442,6 @@ light_factory:
 		Prerequisite: light.raider
 		Factions: ordos, smuggler, mercenary
 	ProvidesPrerequisite@buildingname:
-	WithProductionOverlay@WELDING:
-		Queues: Vehicle
-		Sequence: production-welding
-	WithIdleOverlay@TOP:
-		Sequence: idle-top
 	Power:
 		Amount: -125
 	GrantConditionOnPrerequisite:
@@ -474,7 +480,6 @@ heavy_factory:
 		Footprint: _x_ xxx =xX ===
 		Dimensions: 3,4
 		LocalCenterOffset: 0,-512,0
-	WithBuildingBib:
 	Health:
 		HP: 35000
 	HitShape:
@@ -531,11 +536,14 @@ heavy_factory:
 			harkonnen: heavy.harkonnen
 			corrino: heavy.harkonnen
 			mercenary: heavy.mercenary
+	WithBuildingBib:
+	WithIdleOverlay@TOP:
+		RequiresCondition: !build-incomplete
+		Sequence: idle-top
 	WithProductionOverlay@WELDING:
+		RequiresCondition: !build-incomplete
 		Queues: Armor
 		Sequence: production-welding
-	WithIdleOverlay@TOP:
-		Sequence: idle-top
 	Power:
 		Amount: -150
 	ProvidesPrerequisite@buildingname:
@@ -576,7 +584,6 @@ outpost:
 		Footprint: xxx xxx ===
 		Dimensions: 3,3
 		LocalCenterOffset: 0,-512,0
-	WithBuildingBib:
 	Health:
 		HP: 35000
 	HitShape:
@@ -596,10 +603,11 @@ outpost:
 			fremen: outpost.atreides
 			harkonnen: outpost.harkonnen
 			corrino: outpost.harkonnen
+	WithBuildingBib:
 	WithIdleOverlay@DISH:
+		RequiresCondition: !build-incomplete && !severe-damaged
 		Sequence: idle-dish
 		PauseOnCondition: disabled
-		RequiresCondition: !severe-damaged
 	GrantConditionOnDamageState@STOPDISH:
 		Condition: severe-damaged
 	Power:
@@ -658,6 +666,7 @@ starport:
 			corrino: starport.harkonnen
 			smuggler: starport.smuggler
 	WithDeliveryOverlay:
+		RequiresCondition: !build-incomplete
 		Palette: starportlights
 	ProductionBar:
 	PrimaryBuilding:
@@ -900,6 +909,7 @@ repair_pad:
 			harkonnen: repair_pad.harkonnen
 			corrino: repair_pad.harkonnen
 	WithRepairOverlay:
+		RequiresCondition: !build-incomplete
 		Palette: effect75alpha
 	Power:
 		Amount: -50
@@ -934,7 +944,6 @@ high_tech_factory:
 		Footprint: _X_ xxx XXX ===
 		Dimensions: 3,4
 		LocalCenterOffset: 0,-512,0
-	WithBuildingBib:
 	Health:
 		HP: 35000
 	HitShape:
@@ -958,6 +967,11 @@ high_tech_factory:
 			fremen: hightech.atreides
 			harkonnen: hightech.harkonnen
 			corrino: hightech.harkonnen
+	WithBuildingBib:
+	WithProductionOverlay@WELDING:
+		RequiresCondition: !build-incomplete
+		Queues: Aircraft
+		Sequence: production-welding
 	ProvidesPrerequisite@upgrade:
 		Prerequisite: hightech.atreides
 		Factions: atreides
@@ -975,9 +989,6 @@ high_tech_factory:
 		CameraActor: camera
 		ArrowSequence: arrow
 		CircleSequence: circles
-	WithProductionOverlay@WELDING:
-		Queues: Aircraft
-		Sequence: production-welding
 	Power:
 		Amount: -75
 	GrantConditionOnPrerequisite:
@@ -1016,7 +1027,6 @@ research_centre:
 		Footprint: _X_ xxx XXX ===
 		Dimensions: 3,4
 		LocalCenterOffset: 0,-512,0
-	WithBuildingBib:
 	Health:
 		HP: 25000
 	HitShape:
@@ -1040,7 +1050,9 @@ research_centre:
 			fremen: research.atreides
 			harkonnen: research.harkonnen
 			corrino: research.harkonnen
+	WithBuildingBib:
 	WithIdleOverlay@LIGHTS:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-lights
 	Power:
 		Amount: -175
@@ -1065,8 +1077,6 @@ palace:
 	Building:
 		Footprint: xx= xxx =xx
 		Dimensions: 3,3
-	WithBuildingBib:
-		HasMinibib: True
 	Health:
 		HP: 40000
 	HitShape:
@@ -1092,6 +1102,12 @@ palace:
 			fremen: palace.atreides
 			harkonnen: palace.harkonnen
 			corrino: palace.corrino
+	WithBuildingBib:
+		HasMinibib: True
+	WithNukeLaunchOverlay:
+		RequiresCondition: !build-incomplete && !launchpad-damaged && harkonnen
+	GrantConditionOnDamageState@LAUNCHPADDAMAGED:
+		Condition: launchpad-damaged
 	Power:
 		Amount: -200
 	ProvidesPrerequisite@nuke:
@@ -1136,10 +1152,6 @@ palace:
 		CameraRange: 10c0
 		ArrowSequence: arrow
 		CircleSequence: circles
-	WithNukeLaunchOverlay:
-		RequiresCondition: !launchpad-damaged && harkonnen
-	GrantConditionOnDamageState@LAUNCHPADDAMAGED:
-		Condition: launchpad-damaged
 	ProduceActorPower@fremen:
 		Description: Recruit Fremen
 		LongDesc: Elite infantry unit armed with assault rifles and rockets\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery\n  Special Ability: Invisibility

--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -142,10 +142,13 @@ WEAF:
 		Footprint: xxx xxx ===
 		Dimensions: 3,3
 		LocalCenterOffset: 0,-512,0
-	WithBuildingBib:
 	RenderSprites:
 		Image: WEAP
+	WithBuildingBib:
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithProductionDoorOverlay:
+		RequiresCondition: !build-incomplete
 		Sequence: build-top
 	Valued:
 		Cost: 200

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -60,7 +60,10 @@ MSLO:
 		Amount: -150
 	MustBeDestroyed:
 		RequiredForShortGame: false
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithNukeLaunchAnimation:
+		RequiresCondition: !build-incomplete
 
 GAP:
 	Inherits: ^ScienceBuilding
@@ -969,7 +972,10 @@ WEAP:
 	RevealsShroud@GAPGEN:
 		Range: 4c0
 	WithBuildingBib:
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithProductionDoorOverlay:
+		RequiresCondition: !build-incomplete
 		Sequence: build-top
 	RallyPoint:
 	Exit@1:
@@ -1101,7 +1107,6 @@ FACT:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 4c0
-	WithBuildingBib:
 	Production:
 		PauseOnCondition: being-captured
 		Produces: Building, Defense
@@ -1131,8 +1136,11 @@ FACT:
 	BaseProvider:
 		PauseOnCondition: being-captured
 		Range: 16c0
+	WithBuildingBib:
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithBuildingPlacedAnimation:
-		RequiresCondition: !chrono-vortex
+		RequiresCondition: !build-incomplete && !chrono-vortex
 	Power:
 		Amount: 0
 	WithDeathAnimation:
@@ -1180,7 +1188,6 @@ PROC:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 4c0
-	WithBuildingBib:
 	Refinery:
 		DockAngle: 64
 		DockOffset: 1,2
@@ -1198,7 +1205,11 @@ PROC:
 		Percentage: 50
 		Types: SpyInfiltrate
 		Notification: CreditsStolen
+	WithBuildingBib:
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@TOP:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-top
 	Power:
 		Amount: -30
@@ -1244,7 +1255,10 @@ SILO:
 		Range: 4c0
 	WithBuildingBib:
 		HasMinibib: Yes
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithSiloAnimation:
+		RequiresCondition: !build-incomplete
 	StoresResources:
 		PipCount: 5
 		Capacity: 3000
@@ -1286,6 +1300,10 @@ HPAD:
 	RevealsShroud@GAPGEN:
 		Range: 4c0
 	WithBuildingBib:
+	WithMakeAnimation:
+		Condition: build-incomplete
+	WithResupplyAnimation:
+		RequiresCondition: !build-incomplete
 	Exit@1:
 		SpawnOffset: 0,-256,0
 		ExitCell: 0,0
@@ -1345,7 +1363,6 @@ HPAD:
 		ReferencePoint: Top
 		ZOffset: 256
 		RequiresCondition: primary
-	WithResupplyAnimation:
 
 AFLD:
 	Inherits: ^Building
@@ -1486,7 +1503,10 @@ AFLD:
 		ReferencePoint: Top
 		ZOffset: 256
 		RequiresCondition: primary
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithResupplyAnimation:
+		RequiresCondition: !build-incomplete
 
 AFLD.Ukraine:
 	Inherits: AFLD
@@ -1875,8 +1895,6 @@ FIX:
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 4c0
-	WithBuildingBib:
-		HasMinibib: Yes
 	Reservable:
 	RallyPoint:
 	RepairsUnits:
@@ -1885,7 +1903,12 @@ FIX:
 		StartRepairingNotification: Repairing
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
+	WithBuildingBib:
+		HasMinibib: Yes
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithResupplyAnimation:
+		RequiresCondition: !build-incomplete
 	Power:
 		Amount: -30
 	ProvidesPrerequisite@buildingname:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -1140,6 +1140,7 @@
 		Condition: build-incomplete
 	-WithSpriteBody:
 	WithGateSpriteBody:
+		PauseOnCondition: !build-incomplete
 		OpenSequence: open
 	Tooltip:
 	Buildable:

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -22,10 +22,13 @@ GAPOWR:
 	RevealsShroud:
 		Range: 4c0
 		MaxHeightDelta: 3
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@LIGHTS:
-		RequiresCondition: !empdisable
+		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: idle-lights
 	WithIdleOverlay@PLUG:
+		RequiresCondition: !build-incomplete
 		PauseOnCondition: empdisable
 		Sequence: idle-plug
 	Selectable:
@@ -42,19 +45,23 @@ GAPOWR:
 		Offset: 0,1
 		Conditions:
 			powrup: powrup.a
+		Requirements:
+			powrup: !build-incomplete
 	Power@pluga:
 		RequiresCondition: !empdisable && powrup.a
 		Amount: 50
 	WithIdleOverlay@pluga:
-		RequiresCondition: powrup.a
+		RequiresCondition: !build-incomplete && powrup.a
 		PauseOnCondition: empdisable
 		Sequence: idle-powrupa
 	Pluggable@plugb:
 		Offset: 1,1
 		Conditions:
 			powrup: powrup.b
+		Requirements:
+			powrup: !build-incomplete
 	WithIdleOverlay@plugb:
-		RequiresCondition: powrup.b
+		RequiresCondition: !build-incomplete && powrup.b
 		PauseOnCondition: empdisable
 		Sequence: idle-powrupb
 	Power@plugb:
@@ -105,11 +112,16 @@ GAPILE:
 		PrimaryCondition: primary
 		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@LIGHTS:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-lights
 	WithIdleOverlay@LIGHT:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-light
 	WithIdleOverlay@FLAG:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-flag
 	Power:
 		Amount: -20
@@ -166,16 +178,24 @@ GAWEAP:
 		PrimaryCondition: primary
 		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@ROOF:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-roof
 	WithProductionDoorOverlay@DOOR:
+		RequiresCondition: !build-incomplete
 	WithIdleOverlay@WHITELIGHTS:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-lights-white
 	WithIdleOverlay@REDLIGHTS:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-lights-red
 	WithIdleOverlay@TURBINES:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-turbines
 	WithIdleOverlay@BIB:
+		RequiresCondition: !build-incomplete
 		Sequence: bib
 	Power:
 		Amount: -30
@@ -228,9 +248,13 @@ GAHPAD:
 		PlayerExperience: 15
 		StartRepairingNotification: Repairing
 	ProductionBar:
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@PLATFORM:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-platform
 	WithIdleOverlay@LIGHTS:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-lights
 	WithDeathAnimation@BIB:
 		DeathSequence: dead-platform
@@ -282,19 +306,25 @@ GADEPT:
 	RallyPoint:
 		Palette: mouse
 		IsPlayerPalette: false
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@LIGHT:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-light
 	WithIdleOverlay@GROUND:
+		RequiresCondition: !build-incomplete
 		Sequence: ground
 	WithIdleOverlay@CIRCUITS:
+		RequiresCondition: !build-incomplete
 		Sequence: circuits
 	WithRepairOverlay@CRANE:
+		RequiresCondition: !build-incomplete
 		PauseOnCondition: empdisable
 		StartSequence: crane-start
 		Sequence: crane-loop
 		EndSequence: crane-end
 	WithRepairOverlay@PLATFORM:
-		RequiresCondition: !empdisable
+		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: platform
 	WithDeathAnimation@BIB:
 		DeathSequence: dead-ground
@@ -343,9 +373,12 @@ GARADR:
 	RevealsShroud:
 		Range: 10c0
 		MaxHeightDelta: 3
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@DISH:
-		Sequence: idle-dish
+		RequiresCondition: !build-incomplete
 		PauseOnCondition: disabled || empdisable
+		Sequence: idle-dish
 	Targetable:
 		TargetTypes: Ground, Building, C4, SpyInfiltrate
 	Power:
@@ -381,8 +414,10 @@ GATECH:
 	RevealsShroud:
 		Range: 4c0
 		MaxHeightDelta: 3
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@LIGHTS:
-		RequiresCondition: !disabled
+		RequiresCondition: !build-incomplete && !disabled
 		Sequence: idle-lights
 	Power:
 		Amount: -150
@@ -408,14 +443,17 @@ GAPLUG:
 	Building:
 		Footprint: xxx xxx
 		Dimensions: 2,3
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@DISH:
+		RequiresCondition: !build-incomplete
 		PauseOnCondition: disabled || empdisable
 		Sequence: idle-dish
 	WithIdleOverlay@LIGHTS:
-		RequiresCondition: !disabled && !empdisable
+		RequiresCondition: !build-incomplete && !disabled && !empdisable
 		Sequence: idle-lights
 	WithIdleOverlay@STRIP:
-		RequiresCondition: !disabled && !empdisable
+		RequiresCondition: !build-incomplete && !disabled && !empdisable
 		Sequence: idle-strip
 	Health:
 		HP: 100000
@@ -469,14 +507,14 @@ GAPLUG:
 			plug.ioncannon: plug.ioncannona
 			plug.hunterseeker: plug.hunterseekera
 		Requirements:
-			plug.ioncannon: !plug.ioncannonb && !plug.ioncannona && !plug.hunterseekera
-			plug.hunterseeker: !plug.hunterseekerb && !plug.ioncannona && !plug.hunterseekera
+			plug.ioncannon: !build-incomplete && !plug.ioncannonb && !plug.ioncannona && !plug.hunterseekera
+			plug.hunterseeker: !build-incomplete && !plug.hunterseekerb && !plug.ioncannona && !plug.hunterseekera
 	WithIdleOverlay@ioncannona:
-		RequiresCondition: plug.ioncannona
+		RequiresCondition: !build-incomplete && plug.ioncannona
 		PauseOnCondition: disabled
 		Sequence: idle-ioncannona
 	WithIdleOverlay@hunterseekera:
-		RequiresCondition: plug.hunterseekera
+		RequiresCondition: !build-incomplete && plug.hunterseekera
 		PauseOnCondition: disabled
 		Sequence: idle-hunterseekera
 	Pluggable@plugb:
@@ -485,14 +523,14 @@ GAPLUG:
 			plug.ioncannon: plug.ioncannonb
 			plug.hunterseeker: plug.hunterseekerb
 		Requirements:
-			plug.ioncannon: !plug.ioncannona && !plug.ioncannonb && !plug.hunterseekerb
-			plug.hunterseeker: !plug.hunterseekera && !plug.ioncannonb && !plug.hunterseekerb
+			plug.ioncannon: !build-incomplete && !plug.ioncannona && !plug.ioncannonb && !plug.hunterseekerb
+			plug.hunterseeker: !build-incomplete && !plug.hunterseekera && !plug.ioncannonb && !plug.hunterseekerb
 	WithIdleOverlay@ioncannonb:
-		RequiresCondition: plug.ioncannonb
+		RequiresCondition: !build-incomplete && plug.ioncannonb
 		PauseOnCondition: disabled
 		Sequence: idle-ioncannonb
 	WithIdleOverlay@hunterseekerb:
-		RequiresCondition: plug.hunterseekerb
+		RequiresCondition: !build-incomplete && plug.hunterseekerb
 		PauseOnCondition: disabled
 		Sequence: idle-hunterseekerb
 	ProvidesPrerequisite@buildingname:

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -76,16 +76,18 @@ GACTWR:
 	AttackTurreted:
 		RequiresCondition: tower.vulcan || tower.rocket || tower.sam
 		PauseOnCondition: empdisable || disabled
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithSpriteTurret@VULC:
-		RequiresCondition: tower.vulcan
+		RequiresCondition: !build-incomplete && tower.vulcan
 		Recoils: false
 		Sequence: turret-vulcan
 	WithSpriteTurret@ROCKET:
-		RequiresCondition: tower.rocket
+		RequiresCondition: !build-incomplete && tower.rocket
 		Recoils: false
 		Sequence: turret-rocket
 	WithSpriteTurret@SAM:
-		RequiresCondition: tower.sam
+		RequiresCondition: !build-incomplete && tower.sam
 		Recoils: false
 		Sequence: turret-sam
 	Armament@VULCPRIMARY:
@@ -112,9 +114,9 @@ GACTWR:
 		Weapon: RedEye2
 		LocalOffset: 543,0,1697
 	WithMuzzleOverlay:
-		RequiresCondition: tower.vulcan
+		RequiresCondition: !build-incomplete && tower.vulcan
 	WithIdleOverlay@LIGHTS:
-		RequiresCondition: !disabled
+		RequiresCondition: !build-incomplete && !disabled
 		Sequence: idle-lights
 	LineBuildNode:
 		Types: turret
@@ -132,6 +134,10 @@ GACTWR:
 			tower.vulcan: tower.vulcan
 			tower.rocket: tower.rocket
 			tower.sam: tower.sam
+		Requirements:
+			tower.vulcan: !build-incomplete
+			tower.rocket: !build-incomplete
+			tower.sam: !build-incomplete
 	ProvidesPrerequisite@buildingname:
 	SelectionDecorations:
 	Replacement:

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -25,8 +25,10 @@ NAPOWR:
 	RevealsShroud:
 		Range: 4c0
 		MaxHeightDelta: 3
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@LIGHTS:
-		RequiresCondition: !empdisable
+		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: idle-lights
 	Power:
 		Amount: 100
@@ -64,8 +66,10 @@ NAAPWR:
 	RevealsShroud:
 		Range: 4c0
 		MaxHeightDelta: 3
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@LIGHTS:
-		RequiresCondition: !empdisable
+		RequiresCondition: !build-incomplete && !empdisable
 		Sequence: idle-lights
 	Power:
 		Amount: 200
@@ -119,9 +123,13 @@ NAHAND:
 		PrimaryCondition: primary
 		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@LIGHTS:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-lights
 	WithIdleOverlay@LIGHT:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-light
 	Power:
 		Amount: -20
@@ -178,12 +186,18 @@ NAWEAP:
 		PrimaryCondition: primary
 		SelectionNotification: PrimaryBuildingSelected
 	ProductionBar:
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@ROOF:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-roof
 	WithProductionDoorOverlay@DOOR:
+		RequiresCondition: !build-incomplete
 	WithIdleOverlay@LIGHTS:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-lights
 	WithIdleOverlay@BIB:
+		RequiresCondition: !build-incomplete
 		Sequence: bib
 	Power:
 		Amount: -30
@@ -236,9 +250,13 @@ NAHPAD:
 		PlayerExperience: 15
 		StartRepairingNotification: Repairing
 	ProductionBar:
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@PLATFORM:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-platform
 	WithIdleOverlay@LIGHTS:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-lights
 	WithDeathAnimation@BIB:
 		DeathSequence: dead-platform
@@ -292,9 +310,12 @@ NARADR:
 	RevealsShroud:
 		Range: 10c0
 		MaxHeightDelta: 3
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@DISH:
-		Sequence: idle-dish
+		RequiresCondition: !build-incomplete
 		PauseOnCondition: disabled || empdisable
+		Sequence: idle-dish
 	Targetable:
 		TargetTypes: Ground, Building, C4, SpyInfiltrate
 	Power:
@@ -330,8 +351,10 @@ NATECH:
 	RevealsShroud:
 		Range: 4c0
 		MaxHeightDelta: 3
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@LIGHTS:
-		RequiresCondition: !disabled
+		RequiresCondition: !build-incomplete && !disabled
 		Sequence: idle-lights
 	Power:
 		Amount: -150
@@ -370,8 +393,10 @@ NATMPL:
 		MaxHeightDelta: 3
 	Power:
 		Amount: -200
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@LIGHTS:
-		RequiresCondition: !disabled
+		RequiresCondition: !build-incomplete && !disabled
 		Sequence: idle-lights
 	ProduceActorPower:
 		PauseOnCondition: empdisable || disabled

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -63,8 +63,6 @@ NAPOST:
 		NodeTypes: laserfencenode
 		SegmentType: nafnce
 		SegmentsRequireNode: true
-	WithMakeAnimation:
-		Condition: make-animation-playing
 	Selectable:
 		Bounds: 42, 44, 0, -12
 	LineBuildNode:
@@ -73,14 +71,16 @@ NAPOST:
 		Amount: -25
 	RevealsShroud:
 		Range: 4c0
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@LIGHTS:
-		RequiresCondition: !disabled
+		RequiresCondition: !build-incomplete && !disabled
 		Sequence: lights
 	WithIdleOverlay@CHAINOFLIGHTS:
-		RequiresCondition: !disabled
+		RequiresCondition: !build-incomplete && !disabled
 		Sequence: chainoflights
 	LineBuildSegmentExternalCondition:
-		RequiresCondition: !disabled && !make-animation-playing
+		RequiresCondition: !build-incomplete && !disabled
 		Condition: active-posts
 
 NAFNCE:
@@ -173,8 +173,11 @@ NALASR:
 	Armament:
 		Weapon: TurretLaserFire
 		LocalOffset: 498,0,317
+	WithMakeAnimation:
+		Condition: build-incomplete
 	RenderVoxels:
 	WithVoxelTurret:
+		RequiresCondition: !build-incomplete
 	Power:
 		Amount: -40
 	SelectionDecorations:
@@ -218,11 +221,14 @@ NAOBEL:
 		RequiresCondition: charging && !disabled
 		SoundFiles: obelpowr.aud
 		Interval: 30, 40
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithChargeOverlay:
+		RequiresCondition: !build-incomplete
 		Palette: player
 		IsPlayerPalette: true
 	WithIdleOverlay@LIGHTS:
-		RequiresCondition: !disabled
+		RequiresCondition: !build-incomplete && !disabled
 		Sequence: idle-lights
 	Power:
 		Amount: -150
@@ -257,7 +263,10 @@ NASAM:
 		InitialFacing: 224
 	AttackTurreted:
 		PauseOnCondition: empdisable || disabled
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithSpriteTurret:
+		RequiresCondition: !build-incomplete
 		Recoils: false
 	Armament:
 		Weapon: RedEye2
@@ -291,9 +300,11 @@ NASTLH:
 	RevealsShroud:
 		Range: 6c0
 		MaxHeightDelta: 3
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@pulse:
+		RequiresCondition: !build-incomplete && !disabled
 		Sequence: pulse
-		RequiresCondition: !disabled
 	WithRangeCircle:
 		Range: 12c0
 		Type: cloakgenerator
@@ -339,8 +350,10 @@ NAMISL:
 		Type: Wood
 	RevealsShroud:
 		Range: 4c0
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@LIGHTS:
-		RequiresCondition: !disabled
+		RequiresCondition: !build-incomplete && !disabled
 		Sequence: idle-lights
 	Power:
 		Amount: -50
@@ -407,12 +420,16 @@ NAWAST:
 		Actor: WEED
 		SpawnOffset: 3,1
 		Facing: 160
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@GLOW:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-glow
 	WithIdleOverlay@LIGHTS:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-lights
 	WithIdleOverlay@BIB:
+		RequiresCondition: !build-incomplete
 		Sequence: bib
 	ProvidesPrerequisite@buildingname:
 	SelectionDecorations:
-	RenderSprites:

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -40,13 +40,19 @@ GACNST:
 		ProductionType: Building
 	ProductionBar@Defense:
 		ProductionType: Defense
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@TOP:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-top
 	WithIdleOverlay@SIDE:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-side
 	WithIdleOverlay@FRONT:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-front
 	WithBuildingPlacedOverlay:
+		RequiresCondition: !build-incomplete
 	Power:
 		Amount: 0
 	Selectable:
@@ -97,14 +103,20 @@ PROC:
 		Actor: HARV
 		SpawnOffset: 2,1
 		Facing: 160
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithIdleOverlay@REDLIGHTS:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-redlights
 	WithIdleOverlay@BIB:
+		RequiresCondition: !build-incomplete
 		Sequence: bib
 	WithDockedOverlay@FLAME:
+		RequiresCondition: !build-incomplete
 		Sequence: flame
 		Palette: effect
 	WithDockingOverlay@UNLOAD:
+		RequiresCondition: !build-incomplete
 	Power:
 		Amount: -30
 	ProvidesPrerequisite@buildingname:
@@ -148,11 +160,15 @@ GASILO:
 		FactionImages:
 			gdi: gasilo.gdi
 			nod: gasilo.nod
-	WithSpriteBody:
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithSiloAnimation:
+		RequiresCondition: !build-incomplete
 	WithIdleOverlay@UNDERLAY:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-underlay
 	WithIdleOverlay@LIGHTS:
+		RequiresCondition: !build-incomplete
 		Sequence: idle-lights
 	StoresResources:
 		PipColor: Green

--- a/mods/ts/rules/shared-support.yaml
+++ b/mods/ts/rules/shared-support.yaml
@@ -32,7 +32,10 @@ NAPULS:
 		Weapon: EMPulseCannon
 		LocalOffset: 212,0,1768
 		LocalYaw: 0,100
+	WithMakeAnimation:
+		Condition: build-incomplete
 	WithSpriteTurret:
+		RequiresCondition: !build-incomplete
 		Sequence: turret
 	Power:
 		Amount: -150


### PR DESCRIPTION
This PR removes the hardcoded logic that disables most render traits while `WithMakeAnimation` is active. The default mod rules are migrated to use conditions, and an update rule is provided to help other mods apply the same fixes.

This gets us most of the way towards completing #7035.