### PR TITLE
D2k - Implement original saboteur cloak logic

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -315,6 +315,7 @@
     <Compile Include="Traits\CaptureProgressBlink.cs" />
     <Compile Include="Traits\Conditions\GrantConditionOnPlayerResources.cs" />
     <Compile Include="Traits\GrantExternalConditionToProduced.cs" />
+    <Compile Include="Traits\Conditions\GrantTimedCondition.cs" />
     <Compile Include="Traits\Multipliers\CreatesShroudMultiplier.cs" />
     <Compile Include="Traits\Multipliers\RevealsShroudMultiplier.cs" />
     <Compile Include="Traits\Conditions\GrantConditionAfterDelay.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -317,6 +317,7 @@
     <Compile Include="Traits\GrantExternalConditionToProduced.cs" />
     <Compile Include="Traits\Multipliers\CreatesShroudMultiplier.cs" />
     <Compile Include="Traits\Multipliers\RevealsShroudMultiplier.cs" />
+    <Compile Include="Traits\Conditions\GrantConditionAfterDelay.cs" />
     <Compile Include="Traits\RepairsUnits.cs" />
     <Compile Include="Traits\Rearmable.cs" />
     <Compile Include="Traits\Burns.cs" />

--- a/OpenRA.Mods.Common/Traits/Conditions/ExternalCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ExternalCondition.cs
@@ -15,13 +15,6 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	[RequireExplicitImplementation]
-	public interface IConditionTimerWatcher
-	{
-		string Condition { get; }
-		void Update(int duration, int remaining);
-	}
-
 	[Desc("Allows a condition to be granted from an external source (Lua, warheads, etc).")]
 	public class ExternalConditionInfo : ITraitInfo, Requires<ConditionManagerInfo>
 	{

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionAfterDelay.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionAfterDelay.cs
@@ -1,0 +1,108 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Drawing;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Gives a condition to the actor after a delay.")]
+	public class GrantConditionAfterDelayInfo : PausableConditionalTraitInfo
+	{
+		[FieldLoader.Require]
+		[GrantedConditionReference]
+		[Desc("The condition to grant.")]
+		public readonly string Condition = null;
+
+		[Desc("Number of ticks to wait before applying the condition.")]
+		public readonly int Delay = 50;
+
+		public readonly bool ShowSelectionBar = true;
+		public readonly Color SelectionBarColor = Color.Magenta;
+
+		public override object Create(ActorInitializer init) { return new GrantConditionAfterDelay(this); }
+	}
+
+	public class GrantConditionAfterDelay : PausableConditionalTrait<GrantConditionAfterDelayInfo>, ITick, ISync, INotifyCreated, ISelectionBar
+	{
+		readonly GrantConditionAfterDelayInfo info;
+		ConditionManager manager;
+		int token = ConditionManager.InvalidConditionToken;
+		[Sync] public int Ticks { get; private set; }
+
+		public GrantConditionAfterDelay(GrantConditionAfterDelayInfo info)
+			: base(info)
+		{
+			this.info = info;
+			Ticks = info.Delay;
+		}
+
+		protected override void Created(Actor self)
+		{
+			manager = self.TraitOrDefault<ConditionManager>();
+
+			base.Created(self);
+		}
+
+		void GrantCondition(Actor self, string cond)
+		{
+			if (manager == null)
+				return;
+
+			if (string.IsNullOrEmpty(cond))
+				return;
+
+			if (token == ConditionManager.InvalidConditionToken)
+				token = manager.GrantCondition(self, cond);
+		}
+
+		void RevokeCondition(Actor self)
+		{
+			if (manager == null)
+				return;
+
+			if (token != ConditionManager.InvalidConditionToken)
+				token = manager.RevokeCondition(self, token);
+		}
+
+		void ITick.Tick(Actor self)
+		{
+			if (IsTraitDisabled)
+				Ticks = info.Delay;
+
+			if (IsTraitPaused || IsTraitDisabled)
+				return;
+
+			if (token != ConditionManager.InvalidConditionToken)
+				return;
+
+			if (--Ticks < 0)
+				GrantCondition(self, info.Condition);
+		}
+
+		float ISelectionBar.GetValue()
+		{
+			if (IsTraitDisabled || !Info.ShowSelectionBar)
+				return 0f;
+
+			return 1f - (float)Ticks / Info.Delay;
+		}
+
+		bool ISelectionBar.DisplayWhenEmpty { get { return !IsTraitDisabled && Info.ShowSelectionBar; } }
+
+		Color ISelectionBar.GetColor() { return Info.SelectionBarColor; }
+
+		protected override void TraitDisabled(Actor self)
+		{
+			RevokeCondition(self);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantTimedCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantTimedCondition.cs
@@ -1,0 +1,103 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Gives a condition to the actor for a limited time.")]
+	public class GrantTimedConditionInfo : PausableConditionalTraitInfo
+	{
+		[FieldLoader.Require]
+		[GrantedConditionReference]
+		[Desc("The condition to grant.")]
+		public readonly string Condition = null;
+
+		[Desc("Number of ticks to wait before revoking the condition.")]
+		public readonly int Duration = 50;
+
+		public override object Create(ActorInitializer init) { return new GrantTimedCondition(this); }
+	}
+
+	public class GrantTimedCondition : PausableConditionalTrait<GrantTimedConditionInfo>, ITick, ISync, INotifyCreated
+	{
+		readonly GrantTimedConditionInfo info;
+		ConditionManager manager;
+		int token = ConditionManager.InvalidConditionToken;
+		IConditionTimerWatcher[] watchers;
+		[Sync] public int Ticks { get; private set; }
+
+		public GrantTimedCondition(GrantTimedConditionInfo info)
+			: base(info)
+		{
+			this.info = info;
+			Ticks = info.Duration;
+		}
+
+		protected override void Created(Actor self)
+		{
+			manager = self.TraitOrDefault<ConditionManager>();
+			watchers = self.TraitsImplementing<IConditionTimerWatcher>().Where(Notifies).ToArray();
+
+			base.Created(self);
+		}
+
+		void GrantCondition(Actor self, string cond)
+		{
+			if (manager == null)
+				return;
+
+			if (string.IsNullOrEmpty(cond))
+				return;
+
+			if (token == ConditionManager.InvalidConditionToken)
+			{
+				Ticks = info.Duration;
+				token = manager.GrantCondition(self, cond);
+			}
+		}
+
+		void RevokeCondition(Actor self)
+		{
+			if (manager == null)
+				return;
+
+			if (token != ConditionManager.InvalidConditionToken)
+				token = manager.RevokeCondition(self, token);
+		}
+
+		void ITick.Tick(Actor self)
+		{
+			if (IsTraitDisabled && token != ConditionManager.InvalidConditionToken)
+				RevokeCondition(self);
+
+			if (IsTraitPaused || IsTraitDisabled)
+				return;
+
+			foreach (var w in watchers)
+				w.Update(info.Duration, Ticks);
+
+			if (token == ConditionManager.InvalidConditionToken)
+				return;
+
+			if (--Ticks < 0)
+				RevokeCondition(self);
+		}
+
+		protected override void TraitEnabled(Actor self)
+		{
+			GrantCondition(self, info.Condition);
+		}
+
+		bool Notifies(IConditionTimerWatcher watcher) { return watcher.Condition == Info.Condition; }
+	}
+}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -518,4 +518,11 @@ namespace OpenRA.Mods.Common.Traits
 			OnChange = onChange;
 		}
 	}
+
+	[RequireExplicitImplementation]
+	public interface IConditionTimerWatcher
+	{
+		string Condition { get; }
+		void Update(int duration, int remaining);
+	}
 }

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -180,7 +180,7 @@
 	Selectable:
 		Bounds: 32,32
 	Targetable:
-		TargetTypes: Ground, Vehicle, C4
+		TargetTypes: Ground, Vehicle
 	Passenger:
 		CargoType: Vehicle
 	AttackMove:
@@ -193,7 +193,6 @@
 		Voice: Guard
 	Guardable:
 	WithFacingSpriteBody:
-	Demolishable:
 	TemporaryOwnerManager:
 	MustBeDestroyed:
 	Voiced:

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -253,7 +253,7 @@ saboteur:
 		Queue: Infantry
 		BuildPaletteOrder: 100
 		Prerequisites: ~disabled
-		Description: Sneaky infantry, armed with explosives\n  Strong vs Buildings\n  Weak vs Everything\n  Special Ability: destroy buildings
+		Description: Sneaky infantry, armed with explosives.\nCan be deployed to become invisible for a limited time.\n  Strong vs Buildings\n  Weak vs Everything\n  Special Ability: destroy buildings
 	Valued:
 		Cost: 300 ## actually 0, but spawns from support power at Palace
 	Tooltip:
@@ -267,13 +267,29 @@ saboteur:
 		Flashes: 0
 		EnterBehaviour: Suicide
 	-RevealOnFire:
+	GrantConditionOnDeploy:
+		PauseOnCondition: !charged
+		UndeployOnCondition: !discharging
+		DeployedCondition: deployed
+		DeploySound: STEALTH1.WAV
+	GrantConditionAfterDelay@CHARGE:
+		RequiresCondition: !deployed
+		Condition: charged
+		Delay: 1250
+	GrantTimedCondition@DISCHARGE:
+		RequiresCondition: deployed
+		Condition: discharging
+		Duration: 375
+	TimedConditionBar@DISCHARGE:
+		Condition: discharging
+		Color: FF00FFFF
 	Cloak:
-		InitialDelay: 85
-		CloakDelay: 85
-		CloakSound: STEALTH1.WAV
-		UncloakOn: Attack, Unload, Infiltrate, Demolish, Move, Damage, Heal
-		IsPlayerPalette: true
+		RequiresCondition: deployed
 		PauseOnCondition: cloak-force-disabled
+		InitialDelay: 0
+		CloakDelay: 85
+		UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage, Heal
+		IsPlayerPalette: true
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -1160,7 +1160,7 @@ palace:
 		CircleSequence: circles
 	ProduceActorPower@fremen:
 		Description: Recruit Fremen
-		LongDesc: Elite infantry unit armed with assault rifles and rockets\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery\n  Special Ability: Invisibility
+		LongDesc: Elite infantry unit armed with assault rifles and rockets.\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery\n  Special Ability: Invisibility
 		Icon: fremen
 		PauseOnCondition: disabled
 		RequiresCondition: atreides
@@ -1173,7 +1173,7 @@ palace:
 		OrderName: ProduceActorPower.Fremen
 	ProduceActorPower@saboteur:
 		Description: Recruit Saboteur
-		LongDesc: Sneaky infantry, armed with explosives\n  Strong vs Buildings\n  Weak vs Everything\n  Special Ability: destroy buildings
+		LongDesc: Sneaky infantry, armed with explosives.\nCan be deployed to become invisible for a limited time.\n  Strong vs Buildings\n  Weak vs Everything\n  Special Ability: destroy buildings
 		Icon: saboteur
 		PauseOnCondition: disabled
 		RequiresCondition: ordos


### PR DESCRIPTION
Also removes ability to blow vehicles up from saboteur because that wasn't the case in original.

I did some tests in original game to find the values. On Ordos Test Mission you start with a preplaced Saboteur and a Palace. We know saboteur charges in 1 min 30 sec.
This image is when saboteur bar is full:
![resim](https://user-images.githubusercontent.com/7933210/46581787-e39c6880-ca46-11e8-9dd1-321a02f61620.png)
This is when bar is empty again, after i clicked deploy as soon as it charged: 
![resim](https://user-images.githubusercontent.com/7933210/46581793-fa42bf80-ca46-11e8-916e-46b5f8ebf27b.png)

So i concluded it charges in 50 sec and decharges in 15.

Closes #12542.
Closes #10083.
