### PR TITLE
Reorganize RA missions list

### DIFF
--- a/mods/ra/missions.yaml
+++ b/mods/ra/missions.yaml
@@ -20,3 +20,14 @@ Soviet Campaign:
 	./mods/ra/maps/soviet-06a
 	./mods/ra/maps/soviet-06b
 	./mods/ra/maps/soviet-07
+Counterstrike:
+	./mods/ra/maps/soviet-soldier-volkov-n-chitzkoi
+Aftermath:
+	./mods/ra/maps/monster-tank-madness
+OpenRA Originals:
+	./mods/ra/maps/evacuation
+	./mods/ra/maps/exodus
+	./mods/ra/maps/infiltration
+	./mods/ra/maps/intervention
+	./mods/ra/maps/survival01
+	./mods/ra/maps/survival02


### PR DESCRIPTION
This adds categories for Counterstrike and Aftermath, and puts the remaining missions under 'OpenRA Originals'.