### PR TITLE
Fix lint warnings about not using the being-captured condition

### DIFF
--- a/mods/ra/maps/allies-08a/rules.yaml
+++ b/mods/ra/maps/allies-08a/rules.yaml
@@ -72,6 +72,8 @@ ATEK:
 		Prerequisites: ~disabled
 	GpsPower:
 		ChargeInterval: 15000
+	CaptureManager:
+		-BeingCapturedCondition:
 	-Sellable:
 
 PDOX:
@@ -80,6 +82,8 @@ PDOX:
 		Prerequisites: ~disabled
 	ChronoshiftPower@chronoshift:
 		Prerequisites: ~disabled
+	CaptureManager:
+		-BeingCapturedCondition:
 	-Sellable:
 
 IRON:

--- a/mods/ra/maps/infiltration/rules.yaml
+++ b/mods/ra/maps/infiltration/rules.yaml
@@ -81,7 +81,7 @@ TRUK.Hijackable:
 	Buildable:
 		Prerequisites: ~disabled
 	Mobile:
-		RequiresCondition: mobile
+		RequiresCondition: mobile && !being-captured
 	Cargo:
 		Types: Infantry
 		MaxWeight: 5

--- a/mods/ra/maps/soviet-07/rules.yaml
+++ b/mods/ra/maps/soviet-07/rules.yaml
@@ -30,6 +30,8 @@ FTUR:
 		Cost: 0
 	Power:
 		Amount: 0
+	CaptureManager:
+		-BeingCapturedCondition:
 	-Sellable:
 
 PBOX:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -391,7 +391,7 @@ JEEP:
 	Mobile:
 		TurnSpeed: 10
 		Speed: 170
-		RequiresCondition: !notmobile
+		RequiresCondition: !notmobile && !being-captured
 	RevealsShroud:
 		Range: 8c0
 		RevealGeneratedShroud: False
@@ -434,7 +434,7 @@ APC:
 		Type: Heavy
 	Mobile:
 		Speed: 142
-		RequiresCondition: !notmobile
+		RequiresCondition: !notmobile && !being-captured
 	RevealsShroud:
 		Range: 5c0
 		RevealGeneratedShroud: False
@@ -769,10 +769,10 @@ QTNK:
 	Armor:
 		Type: Heavy
 	Mobile:
-		RequiresCondition: !deployed
+		RequiresCondition: !deployed && !being-captured
 		Speed: 56
 	Chronoshiftable:
-		RequiresCondition: !deployed
+		RequiresCondition: !deployed && !being-captured
 	RevealsShroud:
 		Range: 6c0
 		RevealGeneratedShroud: False
@@ -807,7 +807,7 @@ STNK:
 	Mobile:
 		Speed: 142
 		Locomotor: heavywheeled
-		RequiresCondition: !notmobile
+		RequiresCondition: !notmobile && !being-captured
 	RevealsShroud:
 		Range: 7c0
 		RevealGeneratedShroud: False

--- a/mods/ts/rules/civilian-vehicles.yaml
+++ b/mods/ts/rules/civilian-vehicles.yaml
@@ -97,7 +97,7 @@ BUS:
 	Mobile:
 		TurnSpeed: 5
 		Speed: 113
-		RequiresCondition: !empdisable && !loading
+		RequiresCondition: !empdisable && !loading && !being-captured
 	Health:
 		HP: 10000
 	Armor:
@@ -123,7 +123,7 @@ PICK:
 	Mobile:
 		TurnSpeed: 5
 		Speed: 113
-		RequiresCondition: !empdisable && !loading
+		RequiresCondition: !empdisable && !loading && !being-captured
 	Health:
 		HP: 10000
 	Armor:
@@ -149,7 +149,7 @@ CAR:
 	Mobile:
 		TurnSpeed: 5
 		Speed: 113
-		RequiresCondition: !empdisable && !loading
+		RequiresCondition: !empdisable && !loading && !being-captured
 	Health:
 		HP: 10000
 	Armor:
@@ -175,7 +175,7 @@ WINI:
 	Mobile:
 		TurnSpeed: 5
 		Speed: 113
-		RequiresCondition: !empdisable && !loading
+		RequiresCondition: !empdisable && !loading && !being-captured
 	Health:
 		HP: 20000
 	Armor:

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -13,7 +13,7 @@ APC:
 	Mobile:
 		TurnSpeed: 5
 		Speed: 113
-		RequiresCondition: !empdisable && !loading
+		RequiresCondition: !empdisable && !loading && !being-captured
 		Locomotor: amphibious
 	Health:
 		HP: 20000
@@ -63,7 +63,6 @@ HVR:
 	Mobile:
 		Speed: 99
 		Locomotor: hover
-		RequiresCondition: !empdisable
 	Health:
 		HP: 23000
 	Armor:
@@ -312,7 +311,7 @@ JUGG:
 	Mobile:
 		Speed: 71
 		TurnSpeed: 5
-		RequiresCondition: !empdisable && undeployed
+		RequiresCondition: !empdisable && undeployed && !being-captured
 		AlwaysConsiderTurnAsMove: true
 	RevealsShroud:
 		RequiresCondition: !inside-tunnel

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -98,7 +98,7 @@ TTNK:
 	Mobile:
 		TurnSpeed: 5
 		Speed: 85
-		RequiresCondition: !empdisable && undeployed
+		RequiresCondition: !empdisable && undeployed && !being-captured
 	Health:
 		HP: 35000
 	Armor:
@@ -215,7 +215,7 @@ ART2:
 	Mobile:
 		Speed: 71
 		TurnSpeed: 2
-		RequiresCondition: !empdisable && undeployed
+		RequiresCondition: !empdisable && undeployed && !being-captured
 	RevealsShroud:
 		RequiresCondition: !inside-tunnel
 		Range: 9c0
@@ -364,7 +364,7 @@ SAPC:
 	Mobile:
 		TurnSpeed: 5
 		Speed: 71
-		RequiresCondition: !empdisable && !loading
+		RequiresCondition: !empdisable && !loading && !being-captured
 		Locomotor: subterranean
 	Health:
 		HP: 17500

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -122,7 +122,7 @@ LPST:
 	Mobile:
 		Speed: 85
 		TurnSpeed: 5
-		RequiresCondition: !empdisable && undeployed
+		RequiresCondition: !empdisable && undeployed && !being-captured
 	RevealsShroud:
 		RequiresCondition: !inside-tunnel && undeployed
 		Range: 10c0


### PR DESCRIPTION
Fixes an oversight from #15661. The warnings are reported by travis (take https://travis-ci.org/OpenRA/OpenRA/jobs/438730771#L1790 for example).