### PR TITLE
Fix infantry getting stuck in the last attack frame

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -69,12 +69,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 			rs.Add(new AnimationWithOffset(DefaultAnimation, null, () => IsTraitDisabled));
 			PlayStandAnimation(self);
 
-			state = AnimationState.Waiting;
 			move = init.Self.Trait<IMove>();
 		}
 
 		public void PlayStandAnimation(Actor self)
 		{
+			state = AnimationState.Waiting;
+
 			var sequence = DefaultAnimation.GetRandomExistingSequence(Info.StandSequences, Game.CosmeticRandom);
 			if (sequence != null)
 			{
@@ -96,8 +97,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			if (DefaultAnimation.HasSequence(prefix + baseSequence))
 				return prefix + baseSequence;
-			else
-				return baseSequence;
+
+			return baseSequence;
 		}
 
 		protected virtual bool AllowIdleAnimation(Actor self)
@@ -114,7 +115,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (!string.IsNullOrEmpty(sequence) && DefaultAnimation.HasSequence(NormalizeInfantrySequence(self, sequence)))
 			{
 				state = AnimationState.Attacking;
-				DefaultAnimation.PlayThen(NormalizeInfantrySequence(self, sequence), () => state = AnimationState.Idle);
+				DefaultAnimation.PlayThen(NormalizeInfantrySequence(self, sequence), () => PlayStandAnimation(self));
 			}
 		}
 
@@ -147,10 +148,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			}
 			else if (((state == AnimationState.Moving || dirty) && !move.IsMoving)
 				|| ((state == AnimationState.Idle || state == AnimationState.IdleAnimating) && !self.IsIdle))
-			{
-				state = AnimationState.Waiting;
 				PlayStandAnimation(self);
-			}
 
 			dirty = false;
 		}
@@ -175,18 +173,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 					if (idleDelay > 0 && --idleDelay == 0)
 					{
 						state = AnimationState.IdleAnimating;
-						DefaultAnimation.PlayThen(idleSequence, () =>
-						{
-							PlayStandAnimation(self);
-							state = AnimationState.Waiting;
-						});
+						DefaultAnimation.PlayThen(idleSequence, () => PlayStandAnimation(self));
 					}
 				}
 				else
-				{
 					PlayStandAnimation(self);
-					state = AnimationState.Waiting;
-				}
 			}
 		}
 


### PR DESCRIPTION
Fixes #12375 and https://github.com/OpenRA/OpenRA/issues/5884#issuecomment-412519781.

Setting the state to `Idle` was bogus as we were not entering the first else branch in `TickIdle` (which also lets the standard animation play). Only setting the state to `Waiting` instead of `Idle` made the unit pause in between bursts as `TickIdle` is not called. Consequently we are now letting the standard animation play and enter the `Waiting` state to go idle at the next opportunity.