### PR TITLE
Fix replay timer not showing correct percentage complete

### DIFF
--- a/OpenRA.Game/GameInformation.cs
+++ b/OpenRA.Game/GameInformation.cs
@@ -24,6 +24,7 @@ namespace OpenRA
 
 		public string MapUid;
 		public string MapTitle;
+		public int FinalGameTick;
 
 		/// <summary>Game start timestamp (when the recoding started).</summary>
 		public DateTime StartTimeUtc;

--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -33,6 +33,7 @@ namespace OpenRA.Network
 		public int LocalClientId { get { return 0; } }
 		public ConnectionState ConnectionState { get { return ConnectionState.Connected; } }
 		public readonly int TickCount;
+		public readonly int FinalGameTick;
 		public readonly bool IsValid;
 		public readonly Session LobbyInfo;
 		public readonly string Filename;
@@ -40,6 +41,7 @@ namespace OpenRA.Network
 		public ReplayConnection(string replayFilename)
 		{
 			Filename = replayFilename;
+			FinalGameTick = ReplayMetadata.Read(replayFilename).GameInfo.FinalGameTick;
 
 			// Parse replay data into a struct that can be fed to the game in chunks
 			// to avoid issues with all immediate orders being resolved on the first tick.

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -65,7 +65,7 @@ namespace OpenRA
 
 				foreach (var t in WorldActor.TraitsImplementing<IGameOver>())
 					t.GameOver(this);
-
+				gameInfo.FinalGameTick = WorldTick;
 				GameOver();
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameTimerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameTimerLogic.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				var connection = orderManager.Connection as ReplayConnection;
 				if (connection != null && connection.TickCount != 0)
-					timerTooltip.GetTooltipText = () => "{0}% complete".F(orderManager.NetFrameNumber * 100 / connection.TickCount);
+					timerTooltip.GetTooltipText = () => "{0}% complete".F(world.WorldTick * 100 / connection.FinalGameTick);
 				else
 					timerTooltip.GetTooltipText = null;
 			}


### PR DESCRIPTION
Fixes #12265

### Description
Fixes the completion percentage by saving the final game tick on *World.EndGame* to the replay meta data.
This information is read in on *ReplayConnection* and utilized as the *TickCount* for percentage calculation on *GameTimerLogic*. The local tick will be used in conjunction with the new *TickCount* for accurate calculations.

* Old calculations were left in due to the new *TickCount* disabling all speed and pause options for previously recorded replays (ReplayControlBarLogic).

* Previously recorded games should show the same behavior while new replays will show the correct percentage complete. 