### PR TITLE
 Add Creates/RevealsShroudMultiplier

### DIFF
--- a/OpenRA.Game/Sync.cs
+++ b/OpenRA.Game/Sync.cs
@@ -96,7 +96,7 @@ namespace OpenRA
 			foreach (var prop in t.GetProperties(Binding).Where(x => x.HasAttribute<SyncAttribute>()))
 			{
 				il.Emit(OpCodes.Ldloc, this_);
-				il.EmitCall(OpCodes.Call, prop.GetGetMethod(), null);
+				il.EmitCall(OpCodes.Call, prop.GetGetMethod(true), null);
 
 				EmitSyncOpcodes(prop.PropertyType, il);
 			}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -314,6 +314,8 @@
     <Compile Include="Traits\CapturableProgressBar.cs" />
     <Compile Include="Traits\CaptureProgressBar.cs" />
     <Compile Include="Traits\CaptureProgressBlink.cs" />
+    <Compile Include="Traits\Multipliers\CreatesShroudMultiplier.cs" />
+    <Compile Include="Traits\Multipliers\RevealsShroudMultiplier.cs" />
     <Compile Include="Traits\RepairsUnits.cs" />
     <Compile Include="Traits\Burns.cs" />
     <Compile Include="Traits\ChangesTerrain.cs" />

--- a/OpenRA.Mods.Common/Traits/AffectsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/AffectsShroud.cs
@@ -34,7 +34,8 @@ namespace OpenRA.Mods.Common.Traits
 		readonly HashSet<PPos> footprint;
 
 		[Sync] CPos cachedLocation;
-		[Sync] bool cachedTraitDisabled;
+		[Sync] WDist cachedRange;
+		[Sync] protected bool CachedTraitDisabled { get; private set; }
 
 		protected abstract void AddCellsToPlayerShroud(Actor self, Player player, PPos[] uv);
 		protected abstract void RemoveCellsFromPlayerShroud(Actor self, Player player);
@@ -80,12 +81,14 @@ namespace OpenRA.Mods.Common.Traits
 			var projectedPos = centerPosition - new WVec(0, centerPosition.Z, centerPosition.Z);
 			var projectedLocation = self.World.Map.CellContaining(projectedPos);
 			var traitDisabled = IsTraitDisabled;
+			var range = Range;
 
-			if (cachedLocation == projectedLocation && traitDisabled == cachedTraitDisabled)
+			if (cachedLocation == projectedLocation && cachedRange == range && traitDisabled == CachedTraitDisabled)
 				return;
 
+			cachedRange = range;
 			cachedLocation = projectedLocation;
-			cachedTraitDisabled = traitDisabled;
+			CachedTraitDisabled = traitDisabled;
 
 			var cells = ProjectedCells(self);
 			foreach (var p in self.World.Players)
@@ -100,7 +103,7 @@ namespace OpenRA.Mods.Common.Traits
 			var centerPosition = self.CenterPosition;
 			var projectedPos = centerPosition - new WVec(0, centerPosition.Z, centerPosition.Z);
 			cachedLocation = self.World.Map.CellContaining(projectedPos);
-			cachedTraitDisabled = IsTraitDisabled;
+			CachedTraitDisabled = IsTraitDisabled;
 			var cells = ProjectedCells(self);
 
 			foreach (var p in self.World.Players)
@@ -113,6 +116,6 @@ namespace OpenRA.Mods.Common.Traits
 				RemoveCellsFromPlayerShroud(self, p);
 		}
 
-		public WDist Range { get { return cachedTraitDisabled ? WDist.Zero : Info.Range; } }
+		public virtual WDist Range { get { return CachedTraitDisabled ? WDist.Zero : Info.Range; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Multipliers/CreatesShroudMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/CreatesShroudMultiplier.cs
@@ -1,0 +1,34 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Modifies the shroud range created by this actor.")]
+	public class CreatesShroudMultiplierInfo : ConditionalTraitInfo
+	{
+		[FieldLoader.Require]
+		[Desc("Percentage modifier to apply.")]
+		public readonly int Modifier = 100;
+
+		public override object Create(ActorInitializer init) { return new CreatesShroudMultiplier(this); }
+	}
+
+	public class CreatesShroudMultiplier : ConditionalTrait<CreatesShroudMultiplierInfo>, ICreatesShroudModifier
+	{
+		public CreatesShroudMultiplier(CreatesShroudMultiplierInfo info)
+			: base(info) { }
+
+		int ICreatesShroudModifier.GetCreatesShroudModifier()
+		{
+			return IsTraitDisabled ? 100 : Info.Modifier;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Multipliers/RevealsShroudMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/RevealsShroudMultiplier.cs
@@ -1,0 +1,34 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Modifies the shroud range revealed by this actor.")]
+	public class RevealsShroudMultiplierInfo : ConditionalTraitInfo
+	{
+		[FieldLoader.Require]
+		[Desc("Percentage modifier to apply.")]
+		public readonly int Modifier = 100;
+
+		public override object Create(ActorInitializer init) { return new RevealsShroudMultiplier(this); }
+	}
+
+	public class RevealsShroudMultiplier : ConditionalTrait<RevealsShroudMultiplierInfo>, IRevealsShroudModifier
+	{
+		public RevealsShroudMultiplier(RevealsShroudMultiplierInfo info)
+			: base(info) { }
+
+		int IRevealsShroudModifier.GetRevealsShroudModifier()
+		{
+			return IsTraitDisabled ? 100 : Info.Modifier;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -359,6 +359,12 @@ namespace OpenRA.Mods.Common.Traits
 	public interface IGainsExperienceModifier { int GetGainsExperienceModifier(); }
 
 	[RequireExplicitImplementation]
+	public interface ICreatesShroudModifier { int GetCreatesShroudModifier(); }
+
+	[RequireExplicitImplementation]
+	public interface IRevealsShroudModifier { int GetRevealsShroudModifier(); }
+
+	[RequireExplicitImplementation]
 	public interface ICustomMovementLayer
 	{
 		byte Index { get; }


### PR DESCRIPTION
Sole Survivor's Range Crates increased units' vision ranges too, considering all the units with 10 different range for 10 level, it is really unnecessarily long thing to code if i were to use conditions on RevealShroud traits. Multipliers can do the job way easier.

TESTCASE makes RA Infantry get Sight bonus when you have radar and adds deploying Gap Generator to effect a larger area.