### PR TITLE
Add "Random AI" bot option

### DIFF
--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -113,6 +113,18 @@ namespace OpenRA
 			return factions.FirstOrDefault(f => f.InternalName == factionName) ?? factions.First();
 		}
 
+		static string ChooseBot(World world, string botType)
+		{
+			if (botType == null || botType != "random")
+				return botType;
+
+			var realBots = world.Map.Rules.Actors["player"].TraitInfos<IBotInfo>()
+				.Where(b => !b.Type.Equals("random"))
+				.ToList();
+
+			return realBots.Random(world.SharedRandom).Type;
+		}
+
 		public Player(World world, Session.Client client, PlayerReference pr)
 		{
 			World = world;
@@ -135,7 +147,7 @@ namespace OpenRA
 				else
 					PlayerName = client.Name;
 
-				BotType = client.Bot;
+				BotType = ChooseBot(world, client.Bot);
 				Faction = ChooseFaction(world, client.Faction, !pr.LockFaction);
 				DisplayFaction = ChooseDisplayFaction(world, client.Faction);
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -216,9 +216,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 								{
 									foreach (var slot in orderManager.LobbyInfo.Slots)
 									{
-										var bot = botTypes.Random(Game.CosmeticRandom);
+										var bot = botTypes.Contains("random") ? "random" : botTypes.Random(Game.CosmeticRandom);
 										var c = orderManager.LobbyInfo.ClientInSlot(slot.Key);
-										if (slot.Value.AllowBots == true && (c == null || c.Bot != null))
+										if (slot.Value.AllowBots && (c == null || c.Bot != null))
 											orderManager.IssueOrder(Order.Command("slot_bot {0} {1} {2}".F(slot.Key, botController.Index, bot)));
 									}
 								}

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -1,9 +1,7 @@
 Player:
-	HackyAI@Random:
+	DummyAI@Random:
 		Name: Random
 		Type: random
-		BuildingCommonNames:
-		UnitsCommonNames:
 	HackyAI@Cabal:
 		Name: Cabal
 		Type: cabal

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -1,4 +1,9 @@
 Player:
+	HackyAI@Random:
+		Name: Random
+		Type: random
+		BuildingCommonNames:
+		UnitsCommonNames:
 	HackyAI@Cabal:
 		Name: Cabal
 		Type: cabal

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -1,4 +1,9 @@
 Player:
+	HackyAI@Random:
+		Name: Random
+		Type: random
+		BuildingCommonNames:
+		UnitsCommonNames:
 	HackyAI@Omnius:
 		Name: Omnius
 		Type: omnius

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -1,9 +1,7 @@
 Player:
-	HackyAI@Random:
+	DummyAI@Random:
 		Name: Random
 		Type: random
-		BuildingCommonNames:
-		UnitsCommonNames:
 	HackyAI@Omnius:
 		Name: Omnius
 		Type: omnius

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -1,4 +1,9 @@
 Player:
+	HackyAI@RandomAI:
+		Name: Random AI
+		Type: random
+		BuildingCommonNames:
+		UnitsCommonNames:
 	HackyAI@RushAI:
 		Name: Rush AI
 		Type: rush

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -1,9 +1,7 @@
 Player:
-	HackyAI@RandomAI:
+	DummyAI@RandomAI:
 		Name: Random AI
 		Type: random
-		BuildingCommonNames:
-		UnitsCommonNames:
 	HackyAI@RushAI:
 		Name: Rush AI
 		Type: rush

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -1,4 +1,9 @@
 Player:
+	HackyAI@RandomAI:
+		Name: Random AI
+		Type: random
+		BuildingCommonNames:
+		UnitsCommonNames:
 	HackyAI@TestAI:
 		Name: Test AI
 		Type: test

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -1,9 +1,7 @@
 Player:
-	HackyAI@RandomAI:
+	DummyAI@RandomAI:
 		Name: Random AI
 		Type: random
-		BuildingCommonNames:
-		UnitsCommonNames:
 	HackyAI@TestAI:
 		Name: Test AI
 		Type: test


### PR DESCRIPTION
Implements and closes #15608.

Now it is possible to pick a Random AI in the lobby, so you don't have to worry about the concrete bot type. A random bot type will be chosen when the game starts. Also fill empty lobby slots with "Random AI" instead of concrete bot types.