### PR TITLE
Support tileset defined palettes.

### DIFF
--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -131,10 +131,9 @@ namespace OpenRA
 
 	public class TileSet
 	{
-		public const string TerrainPaletteInternalName = "terrain";
-
 		public readonly string Name;
 		public readonly string Id;
+		public readonly string Palette = "terrain";
 		public readonly int SheetSize = 512;
 		public readonly Color[] HeightDebugColors = new[] { Color.Red };
 		public readonly string[] EditorTemplateOrder;

--- a/OpenRA.Game/Traits/Player/FixedColorPalette.cs
+++ b/OpenRA.Game/Traits/Player/FixedColorPalette.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Traits
 	public class FixedColorPaletteInfo : ITraitInfo
 	{
 		[Desc("The name of the palette to base off.")]
-		[PaletteReference] public readonly string Base = TileSet.TerrainPaletteInternalName;
+		[PaletteReference] public readonly string Base = null;
 
 		[Desc("The name of the resulting palette")]
 		[PaletteDefinition] public readonly string Name = "resources";
@@ -49,7 +49,8 @@ namespace OpenRA.Traits
 		public void LoadPalettes(WorldRenderer wr)
 		{
 			var remap = new PlayerColorRemap(info.RemapIndex, info.Color, info.Ramp);
-			wr.AddPalette(info.Name, new ImmutablePalette(wr.Palette(info.Base).Palette, remap), info.AllowModifiers);
+			var palette = info.Base ?? wr.World.Map.Rules.TileSet.Palette;
+			wr.AddPalette(info.Name, new ImmutablePalette(wr.Palette(palette).Palette, remap), info.AllowModifiers);
 		}
 	}
 }

--- a/OpenRA.Game/Traits/World/ResourceType.cs
+++ b/OpenRA.Game/Traits/World/ResourceType.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Traits
 
 		[PaletteReference]
 		[Desc("Palette used for rendering the resource sprites.")]
-		public readonly string Palette = TileSet.TerrainPaletteInternalName;
+		public readonly string Palette = null;
 
 		[Desc("Resource index used in the binary map data.")]
 		public readonly int ResourceType = 1;
@@ -87,7 +87,7 @@ namespace OpenRA.Traits
 
 		public void WorldLoaded(World w, WorldRenderer wr)
 		{
-			Palette = wr.Palette(Info.Palette);
+			Palette = wr.Palette(Info.Palette ?? wr.World.Map.Rules.TileSet.Palette);
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -151,7 +151,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (Minefield.Length == 1)
 				yield break;
 
-			var pal = wr.Palette(TileSet.TerrainPaletteInternalName);
+			var pal = wr.Palette(self.World.Map.Rules.TileSet.Palette);
 			foreach (var c in Minefield)
 				yield return new SpriteRenderable(tile, self.World.Map.CenterOfCell(c),
 					WVec.Zero, -511, pal, 1f, true);
@@ -223,7 +223,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					minelayers.Max(m => m.Info.TraitInfo<MinelayerInfo>().MinefieldDepth));
 
 				var movement = minelayer.Trait<IPositionable>();
-				var pal = wr.Palette(TileSet.TerrainPaletteInternalName);
+				var pal = wr.Palette(world.Map.Rules.TileSet.Palette);
 				foreach (var c in minefield)
 				{
 					var tile = movement.CanEnterCell(c, null, false) && !world.ShroudObscures(c) ? tileOk : tileBlocked;

--- a/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	{
 		[SequenceReference] public readonly string Sequence = "bib";
 
-		[PaletteReference] public readonly string Palette = TileSet.TerrainPaletteInternalName;
+		[PaletteReference] public readonly string Palette = null;
 
 		public readonly bool HasMinibib = false;
 
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				yield break;
 
 			if (Palette != null)
-				p = init.WorldRenderer.Palette(Palette);
+				p = init.WorldRenderer.Palette(Palette ?? init.World.Map.Rules.TileSet.Palette);
 
 			var bi = init.Actor.TraitInfo<BuildingInfo>();
 
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				var offset = self.World.Map.CenterOfCell(cell) - self.World.Map.CenterOfCell(location) - centerOffset;
 				var awo = new AnimationWithOffset(anim, () => offset, null, -(offset.Y + centerOffset.Y + 512));
 				anims.Add(awo);
-				rs.Add(awo, info.Palette);
+				rs.Add(awo, info.Palette ?? self.World.Map.Rules.TileSet.Palette);
 			}
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Ticks until returning after teleportation.")]
 		public readonly int Duration = 750;
 
-		[PaletteReference] public readonly string TargetOverlayPalette = TileSet.TerrainPaletteInternalName;
+		[PaletteReference] public readonly string TargetOverlayPalette = null;
 
 		public readonly string OverlaySpriteGroup = "overlay";
 		[SequenceReference("OverlaySpriteGroup", true)] public readonly string ValidTileSequencePrefix = "target-valid-";
@@ -176,7 +176,8 @@ namespace OpenRA.Mods.Cnc.Traits
 			{
 				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 				var tiles = world.Map.FindTilesInCircle(xy, range);
-				var palette = wr.Palette(((ChronoshiftPowerInfo)power.Info).TargetOverlayPalette);
+				var cpi = (ChronoshiftPowerInfo)power.Info;
+				var palette = wr.Palette(cpi.TargetOverlayPalette ?? world.Map.Rules.TileSet.Palette);
 				foreach (var t in tiles)
 					yield return new SpriteRenderable(tile, wr.World.Map.CenterOfCell(t), WVec.Zero, -511, palette, 1f, true);
 			}

--- a/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorResourceBrush.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Widgets
 			world = wr.World;
 
 			preview = editorWidget.Get<SpriteWidget>("DRAG_LAYER_PREVIEW");
-			preview.Palette = resource.Palette;
+			preview.Palette = resource.Palette ?? wr.World.Map.Rules.TileSet.Palette;
 			preview.GetScale = () => worldRenderer.Viewport.Zoom;
 			preview.IsVisible = () => editorWidget.CurrentBrush == this;
 

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -237,8 +237,10 @@ namespace OpenRA.Mods.Common.Orders
 					cells.Add(t, MakeCellType(isCloseEnough && world.IsCellBuildable(t, actorInfo, buildingInfo) && (res == null || res.GetResource(t) == null)));
 			}
 
-			var cellPalette = wr.Palette(placeBuildingInfo.Palette);
-			var linePalette = wr.Palette(placeBuildingInfo.LineBuildSegmentPalette);
+			var cp = placeBuildingInfo.Palette ?? world.Map.Rules.TileSet.Palette;
+			var cellPalette = wr.Palette(cp);
+			var lp = placeBuildingInfo.LineBuildSegmentPalette ?? world.Map.Rules.TileSet.Palette;
+			var linePalette = wr.Palette(lp);
 			var topLeftPos = world.Map.CenterOfCell(topLeft);
 			foreach (var c in cells)
 			{

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -209,7 +209,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (!initialized)
 			{
-				var palette = wr.Palette(TileSet.TerrainPaletteInternalName);
+				var palette = wr.Palette(self.World.Map.Rules.TileSet.Palette);
 				renderables = new Dictionary<ushort, IRenderable[]>();
 				foreach (var t in info.Templates)
 					renderables.Add(t.First, TemplateRenderables(wr, palette, t.First));

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -22,10 +22,10 @@ namespace OpenRA.Mods.Common.Traits
 	public class PlaceBuildingInfo : ITraitInfo
 	{
 		[Desc("Palette to use for rendering the placement sprite.")]
-		[PaletteReference] public readonly string Palette = TileSet.TerrainPaletteInternalName;
+		[PaletteReference] public readonly string Palette = null;
 
 		[Desc("Palette to use for rendering the placement sprite for line build segments.")]
-		[PaletteReference] public readonly string LineBuildSegmentPalette = TileSet.TerrainPaletteInternalName;
+		[PaletteReference] public readonly string LineBuildSegmentPalette = null;
 
 		[Desc("Play NewOptionsNotification this many ticks after building placement.")]
 		public readonly int NewOptionsNotificationDelay = 10;

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
@@ -149,7 +149,7 @@ namespace OpenRA.Mods.Common.Traits
 			public IEnumerable<IRenderable> Render(WorldRenderer wr, World world)
 			{
 				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
-				var pal = wr.Palette(TileSet.TerrainPaletteInternalName);
+				var pal = wr.Palette(world.Map.Rules.TileSet.Palette);
 
 				foreach (var t in world.Map.FindTilesInCircle(xy, range))
 					yield return new SpriteRenderable(tile, wr.World.Map.CenterOfCell(t), WVec.Zero, -511, pal, 1f, true);

--- a/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[PaletteReference]
 		[Desc("Palette to use for rendering the placement sprite.")]
-		public readonly string Palette = TileSet.TerrainPaletteInternalName;
+		public readonly string Palette = null;
 
 		[Desc("Sequence image where the selection overlay types are defined.")]
 		public readonly string Image = "editor-overlay";
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (w.Type != WorldType.Editor)
 				return;
 
-			palette = wr.Palette(info.Palette);
+			palette = wr.Palette(info.Palette ?? w.Map.Rules.TileSet.Palette);
 		}
 
 		public void SetCopyRegion(CPos start, CPos end)

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[PaletteReference] public readonly string SmokePalette = "effect";
 
-		[PaletteReference] public readonly string Palette = TileSet.TerrainPaletteInternalName;
+		[PaletteReference] public readonly string Palette = null;
 
 		[FieldLoader.LoadUsing("LoadInitialSmudges")]
 		public readonly Dictionary<CPos, MapSmudge> InitialSmudges;
@@ -117,7 +117,8 @@ namespace OpenRA.Mods.Common.Traits
 				throw new InvalidDataException("Smudges specify different blend modes. "
 					+ "Try using different smudge types for smudges that use different blend modes.");
 
-			render = new TerrainSpriteLayer(w, wr, sheet, blendMode, wr.Palette(Info.Palette), wr.World.Type != WorldType.Editor);
+			var palette = Info.Palette ?? w.Map.Rules.TileSet.Palette;
+			render = new TerrainSpriteLayer(w, wr, sheet, blendMode, wr.Palette(palette), wr.World.Type != WorldType.Editor);
 
 			// Add map smudges
 			foreach (var kv in Info.InitialSmudges)

--- a/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var template in map.Rules.TileSet.Templates)
 			{
-				var palette = template.Value.Palette ?? TileSet.TerrainPaletteInternalName;
+				var palette = template.Value.Palette ?? map.Rules.TileSet.Palette;
 				spriteLayers.GetOrAdd(palette, pal =>
 					new TerrainSpriteLayer(world, wr, theater.Sheet, BlendMode.Alpha, wr.Palette(palette), world.Type != WorldType.Editor));
 			}
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void UpdateCell(CPos cell)
 		{
 			var tile = map.Tiles[cell];
-			var palette = TileSet.TerrainPaletteInternalName;
+			var palette = map.Rules.TileSet.Palette;
 			if (map.Rules.TileSet.Templates.ContainsKey(tile.Type))
 				palette = map.Rules.TileSet.Templates[tile.Type].Palette ?? palette;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				var layerPreview = newResourcePreviewTemplate.Get<SpriteWidget>("LAYER_PREVIEW");
 				layerPreview.IsVisible = () => true;
-				layerPreview.GetPalette = () => resource.Palette;
+				layerPreview.GetPalette = () => resource.Palette ?? worldRenderer.World.Map.Rules.TileSet.Palette;
 
 				var variant = resource.Sequences.FirstOrDefault();
 				var sequence = rules.Sequences.GetSequence("resources", variant);

--- a/OpenRA.Mods.Common/Widgets/TerrainTemplatePreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TerrainTemplatePreviewWidget.cs
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Widgets
 					var u = gridType == MapGridType.Rectangular ? x : (x - y) / 2f;
 					var v = gridType == MapGridType.Rectangular ? y : (x + y) / 2f;
 					var pos = origin + scale * (new float2(u * ts.Width, (v - 0.5f * tileInfo.Height) * ts.Height) - 0.5f * sprite.Size);
-					var palette = Template.Palette ?? TileSet.TerrainPaletteInternalName;
+					var palette = Template.Palette ?? tileset.Palette;
 					Game.Renderer.SpriteRenderer.DrawSprite(sprite, pos, worldRenderer.Palette(palette), size);
 				}
 			}

--- a/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.D2k.Traits
 	public class BuildableTerrainLayerInfo : ITraitInfo
 	{
 		[Desc("Palette to render the layer sprites in.")]
-		public readonly string Palette = TileSet.TerrainPaletteInternalName;
+		public readonly string Palette = null;
 
 		[Desc("The hitpoints, which can be reduced by the DamagesConcreteWarhead.")]
 		public readonly int MaxStrength = 9000;
@@ -51,7 +51,8 @@ namespace OpenRA.Mods.D2k.Traits
 		{
 			theater = wr.Theater;
 			bi = w.WorldActor.Trait<BuildingInfluence>();
-			render = new TerrainSpriteLayer(w, wr, theater.Sheet, BlendMode.Alpha, wr.Palette(info.Palette), wr.World.Type != WorldType.Editor);
+			var palette = info.Palette ?? w.Map.Rules.TileSet.Palette;
+			render = new TerrainSpriteLayer(w, wr, theater.Sheet, BlendMode.Alpha, wr.Palette(palette), wr.World.Type != WorldType.Editor);
 		}
 
 		public void AddTile(CPos cell, TerrainTile tile)


### PR DESCRIPTION
We already support per template palette definitions but no tileset specific palette. This PR fills this gap, avoiding the need to add the same palette again and again to all the templates.