### PR TITLE
Resizable game window support.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -893,5 +893,20 @@ namespace OpenRA
 		{
 			return Renderer.Window.SetClipboardText(text);
 		}
+
+		public static void Resize()
+		{
+			if (worldRenderer != null)
+				worldRenderer.Viewport.Resize();
+
+			if (Ui.Root != null)
+				Ui.Root.ResizeOuter();
+
+			if (Settings != null)
+			{
+				Settings.Graphics.WindowedSize = new int2(Renderer.Resolution);
+				Settings.Save();
+			}
+		}
 	}
 }

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -239,7 +239,7 @@ namespace OpenRA.Graphics
 		}
 
 		// Rectangle (in viewport coords) that contains things to be drawn
-		static readonly Rectangle ScreenClip = Rectangle.FromLTRB(0, 0, Game.Renderer.Resolution.Width, Game.Renderer.Resolution.Height);
+		static readonly Func<Rectangle> ScreenClip = () => Rectangle.FromLTRB(0, 0, Game.Renderer.Resolution.Width, Game.Renderer.Resolution.Height);
 		public Rectangle GetScissorBounds(bool insideBounds)
 		{
 			// Visible rectangle in world coordinates (expanded to the corners of the cells)
@@ -249,8 +249,8 @@ namespace OpenRA.Graphics
 			var cbr = map.CenterOfCell(((MPos)bounds.BottomRight).ToCPos(map)) + new WVec(512, 512, 0);
 
 			// Convert to screen coordinates
-			var tl = WorldToViewPx(worldRenderer.ScreenPxPosition(ctl - new WVec(0, 0, ctl.Z))).Clamp(ScreenClip);
-			var br = WorldToViewPx(worldRenderer.ScreenPxPosition(cbr - new WVec(0, 0, cbr.Z))).Clamp(ScreenClip);
+			var tl = WorldToViewPx(worldRenderer.ScreenPxPosition(ctl - new WVec(0, 0, ctl.Z))).Clamp(ScreenClip());
+			var br = WorldToViewPx(worldRenderer.ScreenPxPosition(cbr - new WVec(0, 0, cbr.Z))).Clamp(ScreenClip());
 
 			// Add an extra one cell fudge in each direction for safety
 			return Rectangle.FromLTRB(tl.X - tileSize.Width, tl.Y - tileSize.Height,
@@ -309,6 +309,13 @@ namespace OpenRA.Graphics
 
 				return allCells;
 			}
+		}
+
+		public void Resize()
+		{
+			viewportSize = (1f / zoom * new float2(Game.Renderer.Resolution)).ToInt2();
+			cellsDirty = true;
+			allCellsDirty = true;
 		}
 	}
 }

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -141,6 +141,9 @@ namespace OpenRA
 				WorldSpriteRenderer.SetViewportParams(lastResolution, depthScale, depthOffset, zoom, scroll);
 				WorldModelRenderer.SetViewportParams(lastResolution, zoom, scroll);
 			}
+
+			if (resolutionChanged)
+				Game.Resize();
 		}
 
 		public void SetPalette(HardwarePalette palette)

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -23,7 +23,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		static readonly string OriginalSoundDevice;
 		static readonly WindowMode OriginalGraphicsMode;
-		static readonly int2 OriginalGraphicsWindowedSize;
 		static readonly int2 OriginalGraphicsFullscreenSize;
 		static readonly bool OriginalServerDiscoverNatDevices;
 
@@ -43,7 +42,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var original = Game.Settings;
 			OriginalSoundDevice = original.Sound.Device;
 			OriginalGraphicsMode = original.Graphics.Mode;
-			OriginalGraphicsWindowedSize = original.Graphics.WindowedSize;
 			OriginalGraphicsFullscreenSize = original.Graphics.FullscreenSize;
 			OriginalServerDiscoverNatDevices = original.Server.DiscoverNatDevices;
 		}
@@ -72,7 +70,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Action closeAndExit = () => { Ui.CloseWindow(); onExit(); };
 				if (OriginalSoundDevice != current.Sound.Device ||
 					OriginalGraphicsMode != current.Graphics.Mode ||
-					OriginalGraphicsWindowedSize != current.Graphics.WindowedSize ||
 					OriginalGraphicsFullscreenSize != current.Graphics.FullscreenSize ||
 					OriginalServerDiscoverNatDevices != current.Server.DiscoverNatDevices)
 				{
@@ -99,6 +96,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				resetPanelActions[settingsPanel]();
 				Game.Settings.Save();
 			};
+		}
+
+		public override void Resize()
+		{
+			var panel = panelContainer.Get("DISPLAY_PANEL");
+			var windowWidth = panel.Get<TextFieldWidget>("WINDOW_WIDTH");
+			windowWidth.Text = Game.Renderer.Resolution.Width.ToString();
+
+			var windowHeight = panel.Get<TextFieldWidget>("WINDOW_HEIGHT");
+			windowHeight.Text = Game.Renderer.Resolution.Height.ToString();
 		}
 
 		static void BindCheckboxPref(Widget parent, string id, object group, string pref)

--- a/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
@@ -170,6 +170,7 @@ namespace OpenRA.Platforms.Default
 		public void Clear()
 		{
 			VerifyThreadAffinity();
+			OpenGL.glViewport(0, 0, window.WindowSize.Width, window.WindowSize.Height);
 			OpenGL.glClearColor(0, 0, 0, 1);
 			OpenGL.CheckGLError();
 			OpenGL.glClear(OpenGL.GL_COLOR_BUFFER_BIT | OpenGL.GL_DEPTH_BUFFER_BIT);

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -104,7 +104,7 @@ namespace OpenRA.Platforms.Default
 
 				Console.WriteLine("Using resolution: {0}x{1}", windowSize.Width, windowSize.Height);
 
-				var windowFlags = SDL.SDL_WindowFlags.SDL_WINDOW_OPENGL | SDL.SDL_WindowFlags.SDL_WINDOW_ALLOW_HIGHDPI;
+				var windowFlags = SDL.SDL_WindowFlags.SDL_WINDOW_OPENGL | SDL.SDL_WindowFlags.SDL_WINDOW_ALLOW_HIGHDPI | SDL.SDL_WindowFlags.SDL_WINDOW_RESIZABLE;
 
 				// HiDPI doesn't work properly on OSX with (legacy) fullscreen mode
 				if (Platform.CurrentPlatform == PlatformType.OSX && windowMode == WindowMode.Fullscreen)
@@ -253,13 +253,13 @@ namespace OpenRA.Platforms.Default
 
 		internal void WindowSizeChanged()
 		{
+			int width, height;
+			SDL.SDL_GL_GetDrawableSize(Window, out width, out height);
+
 			// The ratio between pixels and points can change when moving between displays in OSX
 			// We need to recalculate our scale to account for the potential change in the actual rendered area
 			if (Platform.CurrentPlatform == PlatformType.OSX)
 			{
-				int width, height;
-				SDL.SDL_GL_GetDrawableSize(Window, out width, out height);
-
 				if (width != SurfaceSize.Width || height != SurfaceSize.Height)
 				{
 					float oldScale;
@@ -271,6 +271,14 @@ namespace OpenRA.Platforms.Default
 					}
 
 					OnWindowScaleChanged(oldScale, windowScale);
+				}
+			}
+			else
+			{
+				lock (syncObject)
+				{
+					surfaceSize = new Size(width, height);
+					windowSize = new Size(width, height);
 				}
 			}
 		}

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -105,6 +105,7 @@ Container@SETTINGS_PANEL:
 									Height: 25
 									MaxLength: 5
 									Type: Integer
+									Disabled: true
 								Label@X:
 									Text: x
 									Font: Bold
@@ -119,6 +120,7 @@ Container@SETTINGS_PANEL:
 									Height: 25
 									MaxLength: 5
 									Type: Integer
+									Disabled: true
 						Checkbox@HARDWARECURSORS_CHECKBOX:
 							X: 310
 							Y: 75

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -118,6 +118,7 @@ Background@SETTINGS_PANEL:
 							Height: 25
 							MaxLength: 5
 							Type: Integer
+							Disabled: true
 						Label@X:
 							Text: x
 							Font: Bold
@@ -132,6 +133,7 @@ Background@SETTINGS_PANEL:
 							Height: 25
 							MaxLength: 5
 							Type: Integer
+							Disabled: true
 				Checkbox@HARDWARECURSORS_CHECKBOX:
 					X: 310
 					Y: 75


### PR DESCRIPTION
### WIP!

This PR implements resizable window support. The basic functionality is tested on windows and linux (someone with a mac might verify if this works there too!).

It currently lacks the default widgets to adopt the resize method and reposition its children if necessary, so some widgets might break their bounds while resizing.
Fell free to contribute with widget implementations!