### PR TITLE
Fixed FrozenUnderFog for non occupying actors.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -102,7 +102,11 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// If fog is disabled visibility is determined by shroud
 			if (!byPlayer.Shroud.FogEnabled)
-				return byPlayer.Shroud.AnyExplored(self.OccupiesSpace.OccupiedCells());
+			{
+				var cells = self.OccupiesSpace.OccupiedCells();
+				if (cells.Length > 0)
+					return byPlayer.Shroud.AnyExplored(cells);
+			}
 
 			return frozenStates[byPlayer].IsVisible;
 		}


### PR DESCRIPTION
Actory which do not occupy space will not be visible at all if the fog is disabled. In kknd i have oilpatches which are buildings without a blocking footprint. This change fixes this.