### PR TITLE
Add TurnToDock to Aircraft

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -106,7 +106,9 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				aircraft.MakeReservation(dest);
 
-				landingProcedures.Add(new Turn(self, initialFacing));
+				if (aircraft.Info.TurnToDock)
+					landingProcedures.Add(new Turn(self, initialFacing));
+
 				landingProcedures.Add(new HeliLand(self, false));
 				landingProcedures.Add(new ResupplyAircraft(self));
 				if (!abortOnResupply)

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -21,7 +21,6 @@ namespace OpenRA.Mods.Common.Activities
 	public class ReturnToBase : Activity
 	{
 		readonly Aircraft aircraft;
-		readonly AircraftInfo aircraftInfo;
 		readonly RepairableInfo repairableInfo;
 		readonly Rearmable rearmable;
 		readonly bool alwaysLand;
@@ -36,7 +35,6 @@ namespace OpenRA.Mods.Common.Activities
 			this.alwaysLand = alwaysLand;
 			this.abortOnResupply = abortOnResupply;
 			aircraft = self.Trait<Aircraft>();
-			aircraftInfo = self.Info.TraitInfo<AircraftInfo>();
 			repairableInfo = self.Info.TraitInfoOrDefault<RepairableInfo>();
 			rearmable = self.TraitOrDefault<Rearmable>();
 		}
@@ -56,7 +54,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		int CalculateTurnRadius(int speed)
 		{
-			return 45 * speed / aircraftInfo.TurnSpeed;
+			return 45 * speed / aircraft.Info.TurnSpeed;
 		}
 
 		void Calculate(Actor self)
@@ -68,10 +66,10 @@ namespace OpenRA.Mods.Common.Activities
 				return;
 
 			var landPos = dest.CenterPosition;
-			var altitude = aircraftInfo.CruiseAltitude.Length;
+			var altitude = aircraft.Info.CruiseAltitude.Length;
 
 			// Distance required for descent.
-			var landDistance = altitude * 1024 / aircraftInfo.MaximumPitch.Tan();
+			var landDistance = altitude * 1024 / aircraft.Info.MaximumPitch.Tan();
 
 			// Land towards the east
 			var approachStart = landPos + new WVec(-landDistance, 0, altitude);
@@ -155,7 +153,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			List<Activity> landingProcedures = new List<Activity>();
 
-			var turnRadius = CalculateTurnRadius(aircraftInfo.Speed);
+			var turnRadius = CalculateTurnRadius(aircraft.Info.Speed);
 
 			landingProcedures.Add(new Fly(self, Target.FromPos(w1), WDist.Zero, new WDist(turnRadius * 3)));
 			landingProcedures.Add(new Fly(self, Target.FromPos(w2)));

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -54,6 +54,11 @@ namespace OpenRA.Mods.Common.Activities
 				.ClosestTo(self);
 		}
 
+		int CalculateTurnRadius(int speed)
+		{
+			return 45 * speed / aircraftInfo.TurnSpeed;
+		}
+
 		void Calculate(Actor self)
 		{
 			if (dest == null || dest.IsDead || Reservable.IsReserved(dest))
@@ -170,11 +175,6 @@ namespace OpenRA.Mods.Common.Activities
 				landingProcedures.Add(NextActivity);
 
 			return ActivityUtils.SequenceActivities(landingProcedures.ToArray());
-		}
-
-		int CalculateTurnRadius(int speed)
-		{
-			return 45 * speed / aircraftInfo.TurnSpeed;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -69,8 +69,11 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Will this actor try to land after it has no more commands?")]
 		public readonly bool LandWhenIdle = true;
 
-		[Desc("Does this actor need to turn before landing?")]
+		[Desc("Does this VTOL actor need to turn before landing (on terrain)?")]
 		public readonly bool TurnToLand = false;
+
+		[Desc("Does this VTOL actor need to turn before landing on a resupplier?")]
+		public readonly bool TurnToDock = true;
 
 		[Desc("Does this actor cancel its previous activity after resupplying?")]
 		public readonly bool AbortOnResupply = true;
@@ -752,7 +755,9 @@ namespace OpenRA.Mods.Common.Traits
 							var offset = exit != null ? exit.Info.SpawnOffset : WVec.Zero;
 
 							self.QueueActivity(new HeliFly(self, Target.FromPos(targetActor.CenterPosition + offset)));
-							self.QueueActivity(new Turn(self, Info.InitialFacing));
+							if (Info.TurnToDock)
+								self.QueueActivity(new Turn(self, Info.InitialFacing));
+
 							self.QueueActivity(new HeliLand(self, false));
 							self.QueueActivity(new ResupplyAircraft(self));
 						};

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -13,7 +13,6 @@ TRAN:
 		LandWhenIdle: true
 		TurnSpeed: 5
 		Speed: 150
-		InitialFacing: 224
 		LandableTerrainTypes: Clear,Rough,Road,Ore,Beach,Tiberium,BlueTiberium
 		AltitudeVelocity: 0c100
 	Health:
@@ -63,7 +62,6 @@ HELI:
 		Queue: Aircraft.Nod
 		Description: Helicopter Gunship with Chainguns.\n  Strong vs Infantry, Light Vehicles and\n  Aircraft\n  Weak vs Tanks
 	Aircraft:
-		InitialFacing: 224
 		TurnSpeed: 7
 		Speed: 180
 	Health:
@@ -124,7 +122,6 @@ ORCA:
 		Queue: Aircraft.GDI
 		Description: Helicopter Gunship with AG Missiles.\n  Strong vs Buildings, Tanks\n  Weak vs Infantry
 	Aircraft:
-		InitialFacing: 224
 		TurnSpeed: 7
 		Speed: 186
 	Health:

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -315,6 +315,7 @@
 		CanHover: True
 		TakeOffOnResupply: true
 		VTOL: true
+		InitialFacing: 224
 	HiddenUnderFog:
 		Type: GroundPosition
 	ActorLostNotification:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -229,7 +229,6 @@ TRAN:
 		Range: 6c0
 		Type: GroundPosition
 	Aircraft:
-		InitialFacing: 224
 		TurnSpeed: 5
 		Speed: 128
 		LandableTerrainTypes: Clear,Rough,Road,Ore,Beach,Gems
@@ -295,7 +294,6 @@ HELI:
 		FacingTolerance: 20
 	Aircraft:
 		LandWhenIdle: false
-		InitialFacing: 224
 		TurnSpeed: 4
 		Speed: 149
 	AutoTarget:
@@ -361,7 +359,6 @@ HIND:
 		FacingTolerance: 20
 	Aircraft:
 		LandWhenIdle: false
-		InitialFacing: 224
 		TurnSpeed: 4
 		Speed: 112
 	AutoTarget:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -585,6 +585,7 @@
 		WaitDistanceFromResupplyBase: 4c0
 		TakeOffOnResupply: true
 		VTOL: true
+		InitialFacing: 224
 	GpsDot:
 		String: Helicopter
 	Hovers@CRUISING:


### PR DESCRIPTION
There is no way to disable the "turn before landing on helipad/service depot" behavior of VTOLs on bleed and - as discussed on IRC - a separate boolean is better than using `TurnToLand` for this.

Additionally, pulled in some style changes from a later, larger aircraft activity refactor (see https://github.com/reaperrr/OpenRA/tree/merge-air-activities-WIP if you're interested, and don't get scared, it's not as bad as it looks. Probably.).

~While I was at it, I also reduced the RA helipad reload animation speed to match the helipad in TD~ Split to #15725.