### PR TITLE
Move Moneycrate to campaign-rules.yaml

### DIFF
--- a/mods/ra/maps/allies-03a/rules.yaml
+++ b/mods/ra/maps/allies-03a/rules.yaml
@@ -56,14 +56,6 @@ CAMERA.VeryLarge:
 	RevealsShroud:
 		Range: 40c0
 
-MONEYCRATE:
-	Tooltip:
-		Name: Crate
-	GiveCashCrateAction:
-		Amount: 2000
-	RenderSprites:
-		Image: scrate
-
 E1.Autotarget:
 	Inherits: E1
 	Buildable:

--- a/mods/ra/maps/allies-03b/rules.yaml
+++ b/mods/ra/maps/allies-03b/rules.yaml
@@ -65,14 +65,6 @@ CAMERA.Jeep:
 		Range: 4c0
 	ScriptTriggers:
 
-MONEYCRATE:
-	Tooltip:
-		Name: Crate
-	GiveCashCrateAction:
-		Amount: 2000
-	RenderSprites:
-		Image: scrate
-
 E1.Autotarget:
 	Inherits: E1
 	Buildable:

--- a/mods/ra/maps/allies-04/rules.yaml
+++ b/mods/ra/maps/allies-04/rules.yaml
@@ -50,6 +50,7 @@ MCV:
 TRUK:
 	Buildable:
 		Prerequisites: ~disabled
+	-SpawnActorOnDeath:
 
 SPEN:
 	Buildable:

--- a/mods/ra/maps/soviet-02b/rules.yaml
+++ b/mods/ra/maps/soviet-02b/rules.yaml
@@ -97,10 +97,6 @@ HARV:
 		SearchFromProcRadius: 50
 		SearchFromOrderRadius: 50
 
-MONEYCRATE:
-	GiveCashCrateAction:
-		Amount: 2000
-
 powerproxy.paratroopers:
 	ParatroopersPower:
 		DropItems: E1,E1,E2,E2,E2

--- a/mods/ra/maps/soviet-06a/rules.yaml
+++ b/mods/ra/maps/soviet-06a/rules.yaml
@@ -151,10 +151,6 @@ AFLD:
 	ParatroopersPower@paratroopers:
 		DropItems: E1,E1,E1,E1,E1
 
-MONEYCRATE:
-	GiveCashCrateAction:
-		Amount: 2000
-
 V01:
 	SpawnActorOnDeath:
 		Actor: moneycrate

--- a/mods/ra/maps/soviet-soldier-volkov-n-chitzkoi/rules.yaml
+++ b/mods/ra/maps/soviet-soldier-volkov-n-chitzkoi/rules.yaml
@@ -76,10 +76,6 @@ HOSP:
 	-TooltipDescription@other:
 	SpawnActorOnDeath:
 		Actor: healcrate
-        
-MONEYCRATE:
-	GiveCashCrateAction:
-		Amount: 2000
 
 ^Vehicle:
 	-Demolishable:

--- a/mods/ra/rules/campaign-rules.yaml
+++ b/mods/ra/rules/campaign-rules.yaml
@@ -44,3 +44,11 @@ E7.noautotarget:
 
 ^Vehicle:
 	Demolishable:
+
+MONEYCRATE:
+	Tooltip:
+		Name: Crate
+	GiveCashCrateAction:
+		Amount: 2000
+	RenderSprites:
+		Image: scrate


### PR DESCRIPTION
Follow up based on discussion of #15666. Went ahead and changed trucks to not spawn crates in Allies04, as the convoys were not a part of the original. I don't see this adversely changing any other missions, especially since we removed bounties.