### PR TITLE
Update AttackOrderPower.cs

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new AttackOrderPower(init.Self, this); }
 	}
 
-	class AttackOrderPower : SupportPower, INotifyCreated, INotifyBurstComplete
+	class AttackOrderPower : SupportPower, INotifyCreated, INotifyBurstComplete, IResolveOrder
 	{
 		readonly AttackOrderPowerInfo info;
 		AttackBase attack;
@@ -57,6 +57,12 @@ namespace OpenRA.Mods.Cnc.Traits
 		void INotifyBurstComplete.FiredBurst(Actor self, Target target, Armament a)
 		{
 			self.World.IssueOrder(new Order("Stop", self, false));
+		}
+
+		void IResolveOrder.ResolveOrder(Actor self, Order order)
+		{
+			if (order.OrderString == "Stop")
+				self.CancelActivity();
 		}
 	}
 


### PR DESCRIPTION
An IssueOrder should be catched by a ResolveOrder.
Else it does nothing, wich it won't if not a hardcoded trait is withing the actor that catches "Stop"
wich AttackTurreted somehow not does sometimes.