### PR TITLE
Fix target lines still being visible after an owner change

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 		public virtual object Create(ActorInitializer init) { return new DrawLineToTarget(init.Self, this); }
 	}
 
-	public class DrawLineToTarget : IRenderAboveShroudWhenSelected, INotifySelected, INotifyBecomingIdle
+	public class DrawLineToTarget : IRenderAboveShroudWhenSelected, INotifySelected, INotifyBecomingIdle, INotifyOwnerChanged
 	{
 		readonly DrawLineToTargetInfo info;
 		List<Target> targets;
@@ -86,6 +86,11 @@ namespace OpenRA.Mods.Common.Traits
 		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return false; } }
 
 		void INotifyBecomingIdle.OnBecomingIdle(Actor a)
+		{
+			targets = null;
+		}
+
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
 		{
 			targets = null;
 		}


### PR DESCRIPTION
Test case: Send the scientists in allies08a to the evacuation flare and select them. See how you can still see the green target line to the flare even after they move towards to exit on their own.