### PR TITLE
Fixes footprints when affected by multiple buildings.

### DIFF
--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -161,12 +161,8 @@ namespace OpenRA.Mods.Common.Orders
 
 		bool AcceptsPlug(CPos cell, PlugInfo plug)
 		{
-			var host = buildingInfluence.GetBuildingAt(cell);
-			if (host == null)
-				return false;
-
-			var location = host.Location;
-			return host.TraitsImplementing<Pluggable>().Any(p => location + p.Info.Offset == cell && p.AcceptsPlug(host, plug.Type));
+			var hosts = buildingInfluence.GetBuildingsAt(cell);
+			return hosts.Any(host => host.TraitsImplementing<Pluggable>().Any(p => host.Location + p.Info.Offset == cell && p.AcceptsPlug(host, plug.Type)));
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -142,7 +142,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!LandableTerrainTypes.Contains(type))
 				return false;
 
-			if (world.WorldActor.Trait<BuildingInfluence>().GetBuildingAt(cell) != null)
+			if (world.WorldActor.Trait<BuildingInfluence>().GetBuildingsAt(cell).Any())
 				return false;
 
 			if (!checkTransientActors)

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -199,9 +199,9 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					var pos = new CPos(x, y);
 
-					var buildingAtPos = bi.GetBuildingAt(pos);
+					var buildingsAtPos = bi.GetBuildingsAt(pos);
 
-					if (buildingAtPos == null)
+					if (!buildingsAtPos.Any())
 					{
 						var unitsAtPos = world.ActorMap.GetActorsAt(pos).Where(a => a.IsInWorld
 							&& (a.Owner == p || (allyBuildEnabled && a.Owner.Stances[p] == Stance.Ally))
@@ -210,9 +210,11 @@ namespace OpenRA.Mods.Common.Traits
 						if (unitsAtPos.Any())
 							nearnessCandidates.Add(pos);
 					}
-					else if (buildingAtPos.IsInWorld && ActorGrantsValidArea(buildingAtPos, requiresBuildableArea)
-						&& (buildingAtPos.Owner == p || (allyBuildEnabled && buildingAtPos.Owner.Stances[p] == Stance.Ally)))
-						nearnessCandidates.Add(pos);
+					else
+						foreach (var buildingAtPos in buildingsAtPos)
+							if (buildingAtPos.IsInWorld && ActorGrantsValidArea(buildingAtPos, requiresBuildableArea)
+								&& (buildingAtPos.Owner == p || (allyBuildEnabled && buildingAtPos.Owner.Stances[p] == Stance.Ally)))
+								nearnessCandidates.Add(pos);
 				}
 			}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
@@ -23,32 +23,42 @@ namespace OpenRA.Mods.Common.Traits
 	public class BuildingInfluence
 	{
 		readonly Map map;
-		readonly CellLayer<Actor> influence;
+		readonly CellLayer<List<Actor>> influence;
 
 		public BuildingInfluence(World world)
 		{
 			map = world.Map;
 
-			influence = new CellLayer<Actor>(map);
+			influence = new CellLayer<List<Actor>>(map);
 		}
 
-		internal void AddInfluence(Actor a, IEnumerable<CPos> tiles)
+		public void AddInfluence(Actor a, IEnumerable<CPos> tiles)
 		{
 			foreach (var u in tiles)
-				if (influence.Contains(u) && influence[u] == null)
-					influence[u] = a;
+			{
+				if (influence.Contains(u))
+				{
+					if (influence[u] == null)
+						influence[u] = new List<Actor>();
+					influence[u].Add(a);
+				}
+			}
 		}
 
-		internal void RemoveInfluence(Actor a, IEnumerable<CPos> tiles)
+		public void RemoveInfluence(Actor a, IEnumerable<CPos> tiles)
 		{
 			foreach (var u in tiles)
-				if (influence.Contains(u) && influence[u] == a)
-					influence[u] = null;
+				if (influence.Contains(u) && influence[u].Contains(a))
+					influence[u].Remove(a);
 		}
 
-		public Actor GetBuildingAt(CPos cell)
+		public IEnumerable<Actor> GetBuildingsAt(CPos cell)
 		{
-			return influence.Contains(cell) ? influence[cell] : null;
+			if (!influence.Contains(cell) || influence[cell] == null)
+				yield break;
+
+			foreach (var building in influence[cell])
+				yield return building;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
@@ -22,19 +22,22 @@ namespace OpenRA.Mods.Common.Traits
 			if (!world.Map.Contains(cell))
 				return false;
 
-			var building = world.WorldActor.Trait<BuildingInfluence>().GetBuildingAt(cell);
-			if (building != null)
+			var buildings = world.WorldActor.Trait<BuildingInfluence>().GetBuildingsAt(cell);
+			if (buildings.Any())
 			{
-				if (ai == null)
-					return false;
+				foreach (var building in buildings)
+				{
+					if (ai == null)
+						return false;
 
-				var replacementInfo = ai.TraitInfoOrDefault<ReplacementInfo>();
-				if (replacementInfo == null)
-					return false;
+					var replacementInfo = ai.TraitInfoOrDefault<ReplacementInfo>();
+					if (replacementInfo == null)
+						return false;
 
-				if (!building.TraitsImplementing<Replaceable>().Any(p => !p.IsTraitDisabled &&
-					p.Info.Types.Overlaps(replacementInfo.ReplaceableTypes)))
-					return false;
+					if (!building.TraitsImplementing<Replaceable>().Any(p => !p.IsTraitDisabled &&
+						p.Info.Types.Overlaps(replacementInfo.ReplaceableTypes)))
+						return false;
+				}
 			}
 			else if (!bi.AllowInvalidPlacement && world.ActorMap.GetActorsAt(cell).Any(a => a != toIgnore))
 				return false;

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!CanExistInCell(world, cell))
 				return SubCell.Invalid;
 
-			if (world.WorldActor.Trait<BuildingInfluence>().GetBuildingAt(cell) != null)
+			if (world.WorldActor.Trait<BuildingInfluence>().GetBuildingsAt(cell).Any())
 				return SubCell.Invalid;
 
 			if (!checkTransientActors)

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -125,24 +125,27 @@ namespace OpenRA.Mods.Common.Traits
 				}
 				else if (os == "PlacePlug")
 				{
-					var host = self.World.WorldActor.Trait<BuildingInfluence>().GetBuildingAt(order.TargetLocation);
-					if (host == null)
+					var hosts = self.World.WorldActor.Trait<BuildingInfluence>().GetBuildingsAt(order.TargetLocation);
+					if (!hosts.Any())
 						return;
 
-					var plugInfo = actorInfo.TraitInfoOrDefault<PlugInfo>();
-					if (plugInfo == null)
-						return;
+					foreach (var host in hosts)
+					{
+						var plugInfo = actorInfo.TraitInfoOrDefault<PlugInfo>();
+						if (plugInfo == null)
+							return;
 
-					var location = host.Location;
-					var pluggable = host.TraitsImplementing<Pluggable>()
-						.FirstOrDefault(p => location + p.Info.Offset == order.TargetLocation && p.AcceptsPlug(host, plugInfo.Type));
+						var location = host.Location;
+						var pluggable = host.TraitsImplementing<Pluggable>()
+							.FirstOrDefault(p => location + p.Info.Offset == order.TargetLocation && p.AcceptsPlug(host, plugInfo.Type));
 
-					if (pluggable == null)
-						return;
+						if (pluggable == null)
+							return;
 
-					pluggable.EnablePlug(host, plugInfo.Type);
-					foreach (var s in buildingInfo.BuildSounds)
-						Game.Sound.PlayToPlayer(SoundType.World, order.Player, s, host.CenterPosition);
+						pluggable.EnablePlug(host, plugInfo.Type);
+						foreach (var s in buildingInfo.BuildSounds)
+							Game.Sound.PlayToPlayer(SoundType.World, order.Player, s, host.CenterPosition);
+					}
 				}
 				else
 				{
@@ -156,8 +159,8 @@ namespace OpenRA.Mods.Common.Traits
 						var buildingInfluence = self.World.WorldActor.Trait<BuildingInfluence>();
 						foreach (var t in buildingInfo.Tiles(order.TargetLocation))
 						{
-							var host = buildingInfluence.GetBuildingAt(t);
-							if (host != null)
+							var hosts = buildingInfluence.GetBuildingsAt(t);
+							foreach (var host in hosts)
 								host.World.Remove(host);
 						}
 					}

--- a/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
@@ -181,7 +181,7 @@ namespace OpenRA.Mods.Common.Traits
 					continue;
 
 				// Don't drop on any actors
-				if (self.World.WorldActor.Trait<BuildingInfluence>().GetBuildingAt(p) != null
+				if (self.World.WorldActor.Trait<BuildingInfluence>().GetBuildingsAt(p).Any()
 					|| self.World.ActorMap.GetActorsAt(p).Any())
 					continue;
 

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -193,7 +193,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!rt.Info.AllowUnderActors && world.ActorMap.AnyActorsAt(cell))
 				return false;
 
-			if (!rt.Info.AllowUnderBuildings && buildingInfluence.GetBuildingAt(cell) != null)
+			if (!rt.Info.AllowUnderBuildings && buildingInfluence.GetBuildingsAt(cell).Any())
 				return false;
 
 			if (!rt.Info.AllowOnRamps)

--- a/OpenRA.Mods.D2k/Traits/Buildings/LaysTerrain.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/LaysTerrain.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -63,7 +64,7 @@ namespace OpenRA.Mods.D2k.Traits
 						continue;
 
 					// Don't place under other buildings or custom terrain
-					if (bi.GetBuildingAt(c) != self || map.CustomTerrain[c] != byte.MaxValue)
+					if (bi.GetBuildingsAt(c).Any(building => building != self) || map.CustomTerrain[c] != byte.MaxValue)
 						continue;
 
 					var index = Game.CosmeticRandom.Next(template.TilesCount);
@@ -83,7 +84,7 @@ namespace OpenRA.Mods.D2k.Traits
 					continue;
 
 				// Don't place under other buildings or custom terrain
-				if (bi.GetBuildingAt(c) != self || map.CustomTerrain[c] != byte.MaxValue)
+				if (bi.GetBuildingsAt(c).Any(building => building != self) || map.CustomTerrain[c] != byte.MaxValue)
 					continue;
 
 				layer.AddTile(c, new TerrainTile(template.Id, (byte)i));

--- a/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
@@ -69,7 +70,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 		public void HitTile(CPos cell, int damage)
 		{
-			if (!strength.Contains(cell) || strength[cell] == 0 || bi.GetBuildingAt(cell) != null)
+			if (!strength.Contains(cell) || strength[cell] == 0 || bi.GetBuildingsAt(cell).Any())
 				return;
 
 			strength[cell] = strength[cell] - damage;


### PR DESCRIPTION
Imagine the following case:
A building occupies 3x3 cells.
Now another building will be created, which footprint overlaps with this building -> no problem so far.
Now one of the two buildings gets removed -> the overlapped cells will be freed and the footprint of the other building is now broken. This PR fixes this by saving all actors which occupy particular cells, making the cells free if no single actor is occupying it anymore.