### PR TITLE
Partially refactor WithInfantryBody

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/Leap.cs
+++ b/OpenRA.Mods.Cnc/Activities/Leap.cs
@@ -25,6 +25,7 @@ namespace OpenRA.Mods.Cnc.Activities
 	{
 		readonly Mobile mobile;
 		readonly INotifyMoving[] notifyMoving;
+		readonly INotifyAttack[] notifyAttack;
 		readonly WeaponInfo weapon;
 		readonly int length;
 		readonly bool wasMoving;
@@ -46,6 +47,7 @@ namespace OpenRA.Mods.Cnc.Activities
 			this.damageTypes = damageTypes;
 			mobile = self.Trait<Mobile>();
 			notifyMoving = self.TraitsImplementing<INotifyMoving>().ToArray();
+			notifyAttack = self.TraitsImplementing<INotifyAttack>().ToArray();
 			mobile.SetLocation(mobile.FromCell, mobile.FromSubCell, targetMobile.FromCell, targetMobile.FromSubCell);
 			wasMoving = mobile.IsMoving;
 			mobile.IsMoving = true;
@@ -54,8 +56,9 @@ namespace OpenRA.Mods.Cnc.Activities
 			to = self.World.Map.CenterOfSubCell(targetMobile.FromCell, targetMobile.FromSubCell);
 			length = Math.Max((to - from).Length / speed.Length, 1);
 
-			// HACK: why isn't this using the interface?
-			self.Trait<WithInfantryBody>().Attacking(self, Target.FromActor(target), a);
+			// HACK that should work well enough until this is rewritten in #15008
+			foreach (var n in notifyAttack)
+				n.PreparingAttack(self, Target.FromActor(target), a, null);
 
 			if (weapon.Report != null && weapon.Report.Any())
 				Game.Sound.Play(SoundType.World, weapon.Report.Random(self.World.SharedRandom), self.CenterPosition);

--- a/OpenRA.Mods.Cnc/Traits/Render/WithDisguisingInfantryBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithDisguisingInfantryBody.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithDisguisingInfantryBody(init, this); }
 	}
 
-	class WithDisguisingInfantryBody : WithInfantryBody
+	class WithDisguisingInfantryBody : WithInfantryBody, ITick
 	{
 		readonly WithDisguisingInfantryBodyInfo info;
 		readonly Disguise disguise;
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 			disguise = init.Self.Trait<Disguise>();
 		}
 
-		protected override void Tick(Actor self)
+		void ITick.Tick(Actor self)
 		{
 			if (disguise.AsActor != disguiseActor || disguise.AsPlayer != disguisePlayer)
 			{
@@ -57,8 +57,6 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 					DefaultAnimation.ChangeImage(disguiseImage ?? rs.GetImage(self), sequence);
 				rs.UpdatePalette();
 			}
-
-			base.Tick(self);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Move/Drag.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Drag.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
@@ -21,6 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly IPositionable positionable;
 		readonly IMove movement;
 		readonly IDisabledTrait disableable;
+		readonly INotifyMoving[] notifyMoving;
 		WPos start, end;
 		int length;
 		int ticks = 0;
@@ -30,6 +33,7 @@ namespace OpenRA.Mods.Common.Activities
 			positionable = self.Trait<IPositionable>();
 			movement = self.TraitOrDefault<IMove>();
 			disableable = movement as IDisabledTrait;
+			notifyMoving = self.TraitsImplementing<INotifyMoving>().ToArray();
 			this.start = start;
 			this.end = end;
 			this.length = length;
@@ -49,13 +53,21 @@ namespace OpenRA.Mods.Common.Activities
 			if (++ticks >= length)
 			{
 				if (movement != null)
+				{
 					movement.IsMoving = false;
+					foreach (var n in notifyMoving)
+						n.StoppedMoving(self);
+				}
 
 				return NextActivity;
 			}
 
 			if (movement != null)
+			{
 				movement.IsMoving = true;
+				foreach (var n in notifyMoving)
+					n.StartedMoving(self);
+			}
 
 			return this;
 		}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -442,4 +442,13 @@ namespace OpenRA.Mods.Common.Traits
 
 	[RequireExplicitImplementation]
 	public interface IPreventsShroudReset { bool PreventShroudReset(Actor self); }
+
+	[RequireExplicitImplementation]
+	public interface INotifyMoving
+	{
+		void StartedMoving(Actor self);
+		void StoppedMoving(Actor self);
+		void StartedMovingVertically(Actor self);
+		void StoppedMovingVertically(Actor self);
+	}
 }


### PR DESCRIPTION
Makes use of #15675 to get rid of ITick and make the code simpler and easier to read.

Either depends on or supersedes (whatever you prefer to review first) #15675.