### PR TITLE
Revoke WithMakeAnimation condition at the end of the tick.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
@@ -67,11 +67,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			wsb.PlayCustomAnimation(self, info.Sequence, () =>
 			{
-				if (token != ConditionManager.InvalidConditionToken)
-					token = conditionManager.RevokeCondition(self, token);
+				self.World.AddFrameEndTask(w =>
+				{
+					if (token != ConditionManager.InvalidConditionToken)
+						token = conditionManager.RevokeCondition(self, token);
 
-				// TODO: Rewrite this to use a trait notification for save game support
-				onComplete();
+					// TODO: Rewrite this to use a trait notification for save game support
+					onComplete();
+				});
 			});
 		}
 
@@ -87,11 +90,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			wsb.PlayCustomAnimationBackwards(self, info.Sequence, () =>
 			{
-				if (token != ConditionManager.InvalidConditionToken)
-					token = conditionManager.RevokeCondition(self, token);
+				self.World.AddFrameEndTask(w =>
+				{
+					if (token != ConditionManager.InvalidConditionToken)
+						token = conditionManager.RevokeCondition(self, token);
 
-				// TODO: Rewrite this to use a trait notification for save game support
-				onComplete();
+					// TODO: Rewrite this to use a trait notification for save game support
+					onComplete();
+				});
 			});
 		}
 


### PR DESCRIPTION
This fixes traits becoming enabled for a tick between the animation completing and the actor being removed from the world.

Testcase: Apply #15045 and #15743 to a test branch, then add `RequiresCondition: !build-incomplete` to the production traits in either TD or RA. The production is reenabled for a tick between the sell/undeploy animation completing and the actor being removed from the world.