### PR TITLE
Remove Negative Damage Weapon Full Health Check

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -593,6 +593,7 @@
     <Compile Include="Traits\World\ActorSpawnManager.cs" />
     <Compile Include="Traits\ActorSpawner.cs" />
     <Compile Include="UpdateRules\Rules\20180923\RemovedDemolishLocking.cs" />
+    <Compile Include="UpdateRules\Rules\20180923\RemoveNegativeDamageFullHealthCheck.cs" />
     <Compile Include="UpdateRules\Rules\20180923\RenameCrateActionNotification.cs" />
     <Compile Include="UpdateRules\Rules\20180923\CloakRequiresConditionToPause.cs" />
     <Compile Include="UpdateRules\Rules\20180923\MergeCaptureTraits.cs" />

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/RemoveNegativeDamageFullHealthCheck.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/RemoveNegativeDamageFullHealthCheck.cs
@@ -1,0 +1,70 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RemoveNegativeDamageFullHealthCheck : UpdateRule
+	{
+		public override string Name { get { return "Negative damage weapons are now valid against full-health targets."; } }
+		public override string Description
+		{
+			get
+			{
+				return "Negative-damage weapons are no longer automatically invalid against targets that have full health.\n" +
+				       "Previous behaviour can be restored by enabling a Targetable trait using GrantConditionOnDamageState.\n" +
+				       "Affected weapons are listed so that conditions may be manually defined.";
+			}
+		}
+
+		static readonly string[] DamageWarheads =
+		{
+			"TargetDamage",
+			"SpreadDamage",
+			"HealthPercentageDamage"
+		};
+
+		readonly Dictionary<string, List<string>> locations = new Dictionary<string, List<string>>();
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (locations.Any())
+				yield return "The following weapons may now target actors that have full health. Review their\n" +
+					"target types and, if necessary, use GrantConditionOnDamageState to enable\n" +
+					"a conditional Targetable trait with the appropriate target type when damaged:\n" +
+					UpdateUtils.FormatMessageList(locations.Select(
+						kv => kv.Key + ":\n" + UpdateUtils.FormatMessageList(kv.Value)));
+
+			locations.Clear();
+		}
+
+		public override IEnumerable<string> UpdateWeaponNode(ModData modData, MiniYamlNode weaponNode)
+		{
+			var used = new List<string>();
+			foreach (var node in weaponNode.ChildrenMatching("Warhead"))
+			{
+				foreach (var warhead in DamageWarheads)
+					if (node.NodeValue<string>() == warhead && node.ChildrenMatching("Damage").Any(d => d.NodeValue<int>() < 0))
+						used.Add(node.Key);
+
+				if (used.Any())
+				{
+					var location = "{0} ({1})".F(weaponNode.Key, node.Location.Filename);
+					locations[location] = used;
+				}
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -107,6 +107,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new CloakRequiresConditionToPause(),
 				new AddBotOrderManager(),
 				new AddHarvesterBotModule(),
+				new RemoveNegativeDamageFullHealthCheck(),
 			})
 		};
 

--- a/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
@@ -34,9 +34,6 @@ namespace OpenRA.Mods.Common.Warheads
 			if (!victim.Info.HasTraitInfo<IHealthInfo>())
 				return false;
 
-			if (Damage < 0 && victim.GetDamageState() == DamageState.Undamaged)
-				return false;
-
 			return base.IsValidAgainst(victim, firedBy);
 		}
 

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -249,8 +249,14 @@
 	Selectable:
 		Bounds: 24, 24
 	Targetable:
-		TargetTypes: Ground, Repair, Vehicle
 		RequiresCondition: !parachute
+		TargetTypes: Ground, Vehicle
+	Targetable@REPAIR:
+		RequiresCondition: !parachute && damaged
+		TargetTypes: Repair
+	GrantConditionOnDamageState@DAMAGED:
+		Condition: damaged
+		ValidDamageStates: Light, Medium, Heavy, Critical
 	Repairable:
 	Chronoshiftable:
 	Passenger:
@@ -330,8 +336,14 @@
 		Bounds: 18,20,0,-6
 		DecorationBounds: 12,18,0,-8
 	Targetable:
-		TargetTypes: Ground, Infantry, Disguise
 		RequiresCondition: !parachute
+		TargetTypes: Ground, Infantry, Disguise
+	Targetable@HEAL:
+		RequiresCondition: !parachute && damaged
+		TargetTypes: Heal
+	GrantConditionOnDamageState@DAMAGED:
+		Condition: damaged
+		ValidDamageStates: Light, Medium, Heavy, Critical
 	QuantizeFacingsFromSequence:
 		Sequence: stand
 	WithInfantryBody:
@@ -479,7 +491,13 @@
 	Selectable:
 		Bounds: 24,24
 	Targetable:
-		TargetTypes: Ground, Water, Ship, Repair
+		TargetTypes: Ground, Water, Ship
+	Targetable@REPAIR:
+		RequiresCondition: damaged
+		TargetTypes: Repair
+	GrantConditionOnDamageState@DAMAGED:
+		Condition: damaged
+		ValidDamageStates: Light, Medium, Heavy, Critical
 	HiddenUnderFog:
 	AttackMove:
 	ActorLostNotification:
@@ -528,11 +546,17 @@
 	Aircraft:
 		AirborneCondition: airborne
 	Targetable@GROUND:
-		TargetTypes: Ground, Repair, Vehicle
 		RequiresCondition: !airborne
+		TargetTypes: Ground, Vehicle
 	Targetable@AIRBORNE:
-		TargetTypes: Air
 		RequiresCondition: airborne
+		TargetTypes: Air
+	Targetable@REPAIR:
+		RequiresCondition: !airborne && damaged
+		TargetTypes: Repair
+	GrantConditionOnDamageState@DAMAGED:
+		Condition: damaged
+		ValidDamageStates: Light, Medium, Heavy, Critical
 	HiddenUnderFog:
 		Type: GroundPosition
 	AttackMove:

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -120,14 +120,14 @@ Heal:
 	ReloadDelay: 80
 	Range: 4c0
 	Report: heal2.aud
-	ValidTargets: Infantry
+	ValidTargets: Heal
 	Projectile: Bullet
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: -5000
 		ValidStances: Ally
-		ValidTargets: Infantry
+		ValidTargets: Heal
 		DebugOverlayColor: 00FF00
 
 Repair:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -550,6 +550,12 @@
 	Targetable:
 		RequiresCondition: !inside-tunnel
 		TargetTypes: Ground, Infantry
+	Targetable@HEAL:
+		RequiresCondition: !inside-tunnel && damaged
+		TargetTypes: Heal
+	GrantConditionOnDamageState@DAMAGED:
+		Condition: damaged
+		ValidDamageStates: Light, Medium, Heavy, Critical
 	QuantizeFacingsFromSequence:
 		Sequence: stand
 	WithInfantryBody:
@@ -734,7 +740,13 @@
 		VoiceSet: Vehicle
 	Targetable:
 		RequiresCondition: !inside-tunnel
-		TargetTypes: Ground, Vehicle, Repair
+		TargetTypes: Ground, Vehicle
+	Targetable@REPAIR:
+		RequiresCondition: !inside-tunnel && damaged
+		TargetTypes: Repair
+	GrantConditionOnDamageState@DAMAGED:
+		Condition: damaged
+		ValidDamageStates: Light, Medium, Heavy, Critical
 	Repairable:
 		RepairBuildings: gadept
 		Voice: Move
@@ -764,10 +776,10 @@
 		Weapons: SmallDebris
 		Pieces: 3, 7
 		Range: 2c0, 5c0
-	GrantConditionOnDamageState@DAMAGED:
+	GrantConditionOnDamageState@DAMAGEDSPEED:
 		Condition: damagedspeed
 		ValidDamageStates: Heavy
-	GrantConditionOnDamageState@CRITICAL:
+	GrantConditionOnDamageState@CRITICALSPEED:
 		Condition: criticalspeed
 		ValidDamageStates: Critical
 	SpeedMultiplier@DAMAGED:

--- a/mods/ts/weapons/healweapons.yaml
+++ b/mods/ts/weapons/healweapons.yaml
@@ -2,13 +2,13 @@
 	ReloadDelay: 80
 	Range: 2c849
 	Report: healer1.aud
-	ValidTargets: Infantry
+	ValidTargets: Heal
 	TargetActorCenter: true
 	Projectile: InstantHit
 	Warhead@1Dam: TargetDamage
 		DebugOverlayColor: 00FF00
 		Damage: -5000
-		ValidTargets: Infantry
+		ValidTargets: Heal
 
 Heal:
 	Inherits: ^HealWeapon


### PR DESCRIPTION
The behaviour can be replicated with conditions and currently non-damage warheads on the weapon can prevent this check from properly working.

We talked on irc that some warheads like CreateEffect shouldn't effect the targeting regardless, but i haven't done it yet because couldn't figure how exactly to do it. It can be done in a seperate PR.

I also put an Update rule that notifies about this change, but doesn't actually edit anything.