### PR TITLE
Add MPSpawnUnits>BaseActorOffset

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/MPStartUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/MPStartUnits.cs
@@ -26,8 +26,11 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Only available when selecting one of these factions.", "Leave empty for no restrictions.")]
 		public readonly HashSet<string> Factions = new HashSet<string>();
 
-		[Desc("The mobile construction vehicle.")]
+		[Desc("The actor at the center, usually the mobile construction vehicle.")]
 		public readonly string BaseActor = null;
+
+		[Desc("Offset from the spawn point, BaseActor will spawn at.")]
+		public readonly CVec BaseActorOffset = CVec.Zero;
 
 		[Desc("A group of units ready to defend or scout.")]
 		public readonly string[] SupportActors = { };

--- a/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				w.CreateActor(unitGroup.BaseActor.ToLowerInvariant(), new TypeDictionary
 				{
-					new LocationInit(sp),
+					new LocationInit(sp + unitGroup.BaseActorOffset),
 					new OwnerInit(p),
 					new SkipMakeAnimsInit(),
 					new FacingInit(unitGroup.BaseActorFacing < 0 ? w.SharedRandom.Next(256) : unitGroup.BaseActorFacing),


### PR DESCRIPTION
Something i had on Generals Alpha engine, that i got reminded of at Discord so wanted to PR to upstream.

MPSpawnUnits, BaseActor allows buildings, but the building won't be centered. Its top-left will be on the spawn point. Now you can fine tune that if you wanna use a building for BaseActor.