### PR TITLE
Limit samplers to 8 in combined.frag.

### DIFF
--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Graphics
 		readonly IShader shader;
 
 		readonly Vertex[] vertices;
-		readonly Sheet[] sheets = new Sheet[8];
+		readonly Sheet[] sheets = new Sheet[7];
 
 		BlendMode currentBlend = BlendMode.Alpha;
 		int nv = 0;

--- a/glsl/combined.frag
+++ b/glsl/combined.frag
@@ -5,7 +5,6 @@ uniform sampler2D Texture3;
 uniform sampler2D Texture4;
 uniform sampler2D Texture5;
 uniform sampler2D Texture6;
-uniform sampler2D Texture7;
 uniform sampler2D Palette;
 
 uniform bool EnableDepthPreview;
@@ -50,10 +49,8 @@ vec4 Sample(float samplerIndex, vec2 pos)
 		return texture2D(Texture4, pos);
 	else if (samplerIndex < 5.5)
 		return texture2D(Texture5, pos);
-	else if (samplerIndex < 6.5)
-		return texture2D(Texture6, pos);
 
-	return texture2D(Texture7, pos);
+	return texture2D(Texture6, pos);
 }
 
 void main()


### PR DESCRIPTION
The additional palette sampler wasn't accounted for in the original PR.
This fixes a crash on systems that support a max of 8.

Context: https://logs.openra.net/index.php?year=2018&month=10&day=29#13:09:31