### PR TITLE
Support for BurstDelays 0

### DIFF
--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -251,26 +251,29 @@ namespace OpenRA.Mods.Common.Traits
 
 		// Note: facing is only used by the legacy positioning code
 		// The world coordinate model uses Actor.Orientation
-		public virtual Barrel CheckFire(Actor self, IFacing facing, Target target)
+		public virtual Barrel[] CheckFire(Actor self, IFacing facing, Target target)
 		{
-			if (!CanFire(self, target))
-				return null;
+			var barrels = new List<Barrel>();
 
-			if (ticksSinceLastShot >= Weapon.ReloadDelay)
-				Burst = Weapon.Burst;
+			while (CanFire(self, target))
+			{
+				if (ticksSinceLastShot >= Weapon.ReloadDelay)
+					Burst = Weapon.Burst;
 
-			ticksSinceLastShot = 0;
+				ticksSinceLastShot = 0;
 
-			// If Weapon.Burst == 1, cycle through all LocalOffsets, otherwise use the offset corresponding to current Burst
-			currentBarrel %= barrelCount;
-			var barrel = Weapon.Burst == 1 ? Barrels[currentBarrel] : Barrels[Burst % Barrels.Length];
-			currentBarrel++;
+				// If Weapon.Burst == 1, cycle through all LocalOffsets, otherwise use the offset corresponding to current Burst
+				currentBarrel %= barrelCount;
+				var barrel = Weapon.Burst == 1 ? Barrels[currentBarrel] : Barrels[Burst % Barrels.Length];
+				currentBarrel++;
 
-			FireBarrel(self, facing, target, barrel);
+				FireBarrel(self, facing, target, barrel);
 
-			UpdateBurst(self, target);
+				UpdateBurst(self, target);
+				barrels.Add(barrel);
+			}
 
-			return barrel;
+			return barrels.ToArray();
 		}
 
 		protected virtual void FireBarrel(Actor self, IFacing facing, Target target, Barrel barrel)

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -163,8 +163,8 @@ namespace OpenRA.Mods.Common.Traits
 				paxFacing[a.Actor].Facing = muzzleFacing;
 				paxPos[a.Actor].SetVisualPosition(a.Actor, pos + PortOffset(self, port));
 
-				var barrel = a.CheckFire(a.Actor, facing, target);
-				if (barrel == null)
+				var barrels = a.CheckFire(a.Actor, facing, target);
+				if (barrels.Length == 0)
 					continue;
 
 				if (a.Info.MuzzleSequence != null)
@@ -186,7 +186,8 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				foreach (var npa in self.TraitsImplementing<INotifyAttack>())
-					npa.Attacking(self, target, a, barrel);
+					foreach (var barrel in barrels)
+						npa.Attacking(self, target, a, barrel);
 			}
 		}
 

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -84,13 +84,14 @@ namespace OpenRA.Mods.D2k.Activities
 			foreach (var player in affectedPlayers)
 				self.World.AddFrameEndTask(w => w.Add(new MapNotificationEffect(player, "Speech", swallow.Info.WormAttackNotification, 25, true, attackPosition, Color.Red)));
 
-			var barrel = armament.CheckFire(self, facing, target);
-			if (barrel == null)
+			var barrels = armament.CheckFire(self, facing, target);
+			if (barrels.Length == 0)
 				return false;
 
 			// armament.CheckFire already calls INotifyAttack.PreparingAttack
 			foreach (var notify in self.TraitsImplementing<INotifyAttack>())
-				notify.Attacking(self, target, armament, barrel);
+				foreach (var barrel in barrels)
+					notify.Attacking(self, target, armament, barrel);
 
 			return true;
 		}


### PR DESCRIPTION
Support for weapons which fire a whole clip / burst at once, without a delay between the shots. This avoids the need for ugly hacks, giving actors for example 10 armaments if they have to shoot 10 shots at once.