### PR TITLE
Add Army Value statistics/graph

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -202,6 +202,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			template.Get<LabelWidget>("UNITS_DEAD").GetText = () => stats.UnitsDead.ToString();
 			template.Get<LabelWidget>("BUILDINGS_KILLED").GetText = () => stats.BuildingsKilled.ToString();
 			template.Get<LabelWidget>("BUILDINGS_DEAD").GetText = () => stats.BuildingsDead.ToString();
+			template.Get<LabelWidget>("ARMY_VALUE").GetText = () => "$" + stats.ArmyValue.ToString();
 
 			return template;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -31,12 +31,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly ContainerWidget productionStatsHeaders;
 		readonly ContainerWidget combatStatsHeaders;
 		readonly ContainerWidget earnedThisMinuteGraphHeaders;
+		readonly ContainerWidget armyThisMinuteGraphHeaders;
 		readonly ScrollPanelWidget playerStatsPanel;
 		readonly ScrollItemWidget basicPlayerTemplate;
 		readonly ScrollItemWidget economyPlayerTemplate;
 		readonly ScrollItemWidget productionPlayerTemplate;
 		readonly ScrollItemWidget combatPlayerTemplate;
 		readonly ContainerWidget earnedThisMinuteGraphTemplate;
+		readonly ContainerWidget armyThisMinuteGraphTemplate;
 		readonly ScrollItemWidget teamTemplate;
 		readonly IEnumerable<Player> players;
 		readonly World world;
@@ -64,6 +66,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			productionStatsHeaders = widget.Get<ContainerWidget>("PRODUCTION_STATS_HEADERS");
 			combatStatsHeaders = widget.Get<ContainerWidget>("COMBAT_STATS_HEADERS");
 			earnedThisMinuteGraphHeaders = widget.Get<ContainerWidget>("EARNED_THIS_MIN_GRAPH_HEADERS");
+			armyThisMinuteGraphHeaders = widget.Get<ContainerWidget>("ARMY_THIS_MIN_GRAPH_HEADERS");
 
 			playerStatsPanel = widget.Get<ScrollPanelWidget>("PLAYER_STATS_PANEL");
 			playerStatsPanel.Layout = new GridLayout(playerStatsPanel);
@@ -73,6 +76,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			productionPlayerTemplate = playerStatsPanel.Get<ScrollItemWidget>("PRODUCTION_PLAYER_TEMPLATE");
 			combatPlayerTemplate = playerStatsPanel.Get<ScrollItemWidget>("COMBAT_PLAYER_TEMPLATE");
 			earnedThisMinuteGraphTemplate = playerStatsPanel.Get<ContainerWidget>("EARNED_THIS_MIN_GRAPH_TEMPLATE");
+			armyThisMinuteGraphTemplate = playerStatsPanel.Get<ContainerWidget>("ARMY_THIS_MIN_GRAPH_TEMPLATE");
 
 			teamTemplate = playerStatsPanel.Get<ScrollItemWidget>("TEAM_TEMPLATE");
 
@@ -98,7 +102,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				createStatsOption("Economy", economyStatsHeaders, () => DisplayStats(EconomyStats)),
 				createStatsOption("Production", productionStatsHeaders, () => DisplayStats(ProductionStats)),
 				createStatsOption("Combat", combatStatsHeaders, () => DisplayStats(CombatStats)),
-				createStatsOption("Earnings (graph)", earnedThisMinuteGraphHeaders, () => EarnedThisMinuteGraph())
+				createStatsOption("Earnings (graph)", earnedThisMinuteGraphHeaders, () => EarnedThisMinuteGraph()),
+				createStatsOption("Army (graph)", armyThisMinuteGraphHeaders, () => ArmyThisMinuteGraph()),
 			};
 
 			Func<StatsDropDownOption, ScrollItemWidget, ScrollItemWidget> setupItem = (option, template) =>
@@ -108,7 +113,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				return item;
 			};
 
-			statsDropDown.OnMouseDown = _ => statsDropDown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 150, statsDropDownOptions, setupItem);
+			statsDropDown.OnMouseDown = _ => statsDropDown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 155, statsDropDownOptions, setupItem);
 			statsDropDownOptions[(int)activePanel].OnClick();
 
 			var close = widget.GetOrNull<ButtonWidget>("CLOSE");
@@ -151,6 +156,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			productionStatsHeaders.Visible = false;
 			combatStatsHeaders.Visible = false;
 			earnedThisMinuteGraphHeaders.Visible = false;
+			armyThisMinuteGraphHeaders.Visible = false;
 		}
 
 		void EarnedThisMinuteGraph()
@@ -164,6 +170,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					p.PlayerName,
 					p.Color.RGB,
 					(p.PlayerActor.TraitOrDefault<PlayerStatistics>() ?? new PlayerStatistics(p.PlayerActor)).EarnedSamples.Select(s => (float)s)));
+
+			playerStatsPanel.AddChild(template);
+			playerStatsPanel.ScrollToTop();
+		}
+
+		void ArmyThisMinuteGraph()
+		{
+			armyThisMinuteGraphHeaders.Visible = true;
+			var template = armyThisMinuteGraphTemplate.Clone();
+
+			var graph = template.Get<LineGraphWidget>("ARMY_THIS_MIN_GRAPH");
+			graph.GetSeries = () =>
+				players.Select(p => new LineGraphSeries(
+					p.PlayerName,
+					p.Color.RGB,
+					(p.PlayerActor.TraitOrDefault<PlayerStatistics>() ?? new PlayerStatistics(p.PlayerActor)).ArmySamples.Select(s => (float)s)));
 
 			playerStatsPanel.AddChild(template);
 			playerStatsPanel.ScrollToTop();

--- a/mods/cnc/chrome/ingame-observerstats.yaml
+++ b/mods/cnc/chrome/ingame-observerstats.yaml
@@ -284,6 +284,20 @@ Background@INGAME_OBSERVERSTATS_BG:
 							Font: Bold
 							Text: Earnings received each minute
 							Align: Center
+				Container@ARMY_THIS_MIN_GRAPH_HEADERS:
+					X: 0
+					Y: 0
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
+					Children:
+						Label@EARNED_THIS_MIN_HEADER:
+							X: 0
+							Y: 40
+							Width: PARENT_RIGHT
+							Height: 25
+							Font: Bold
+							Text: Army value over time
+							Align: Center
 				ScrollPanel@PLAYER_STATS_PANEL:
 					X: 15
 					Y: 70
@@ -552,6 +566,26 @@ Background@INGAME_OBSERVERSTATS_BG:
 							Height: PARENT_BOTTOM - 60
 							Children:
 								LineGraph@EARNED_THIS_MIN_GRAPH:
+									X: 0
+									Y: 0
+									Width: PARENT_RIGHT
+									Height: PARENT_BOTTOM
+									ValueFormat: ${0}
+									XAxisValueFormat: {0}
+									YAxisValueFormat: ${0:F0}
+									XAxisSize: 20
+									YAxisSize: 10
+									XAxisLabel: m
+									YAxisLabel: $
+									LabelFont: TinyBold
+									AxisFont: Bold
+						Container@ARMY_THIS_MIN_GRAPH_TEMPLATE:
+							X: 10
+							Y: 10
+							Width: PARENT_RIGHT - 100
+							Height: PARENT_BOTTOM - 60
+							Children:
+								LineGraph@ARMY_THIS_MIN_GRAPH:
 									X: 0
 									Y: 0
 									Width: PARENT_RIGHT

--- a/mods/cnc/chrome/ingame-observerstats.yaml
+++ b/mods/cnc/chrome/ingame-observerstats.yaml
@@ -262,6 +262,14 @@ Background@INGAME_OBSERVERSTATS_BG:
 							Font: Bold
 							Text: Bldg Lost
 							Align: Right
+						Label@ARMY_VALUE_HEADER:
+							X: 835
+							Y: 40
+							Width: 40
+							Height: 25
+							Font: Bold
+							Text: Army Value
+							Align: Right
 				Container@EARNED_THIS_MIN_GRAPH_HEADERS:
 					X: 0
 					Y: 0
@@ -525,6 +533,13 @@ Background@INGAME_OBSERVERSTATS_BG:
 									Shadow: True
 								Label@BUILDINGS_DEAD:
 									X: 715
+									Y: 0
+									Width: 40
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@ARMY_VALUE:
+									X: 815
 									Y: 0
 									Width: 40
 									Height: PARENT_BOTTOM

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -4,6 +4,8 @@ TRAN:
 		Cost: 750
 	Tooltip:
 		Name: Chinook Transport
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 10
 		Prerequisites: hpad
@@ -56,6 +58,8 @@ HELI:
 		Cost: 1200
 	Tooltip:
 		Name: Apache Longbow
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 20
 		Prerequisites: hpad, anyhq, ~techlevel.medium
@@ -116,6 +120,8 @@ ORCA:
 		Cost: 1200
 	Tooltip:
 		Name: Orca
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 20
 		Prerequisites: hpad, anyhq, ~techlevel.medium

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -7,6 +7,8 @@ E1:
 		Cost: 100
 	Tooltip:
 		Name: Minigunner
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 10
 		Prerequisites: barracks
@@ -34,6 +36,8 @@ E2:
 		Cost: 160
 	Tooltip:
 		Name: Grenadier
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 40
 		Prerequisites: anyhq, ~techlevel.medium
@@ -68,6 +72,8 @@ E3:
 		Cost: 300
 	Tooltip:
 		Name: Rocket Soldier
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 20
 		Prerequisites: barracks
@@ -98,6 +104,8 @@ E4:
 		Cost: 200
 	Tooltip:
 		Name: Flamethrower
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 40
 		Prerequisites: anyhq, ~techlevel.medium
@@ -130,6 +138,8 @@ E5:
 		Cost: 300
 	Tooltip:
 		Name: Chemical Warrior
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 50
 		Prerequisites: tmpl, ~techlevel.high
@@ -161,6 +171,8 @@ E6:
 		Cost: 500
 	Tooltip:
 		Name: Engineer
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 30
 		Prerequisites: barracks
@@ -194,6 +206,8 @@ RMBO:
 		Cost: 2000
 	Tooltip:
 		Name: Commando
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 50
 		Prerequisites: eye, ~techlevel.high
@@ -243,6 +257,8 @@ PVICE:
 		BuildPaletteOrder: 40
 		Description: Mutated abomination that spits liquid Tiberium.\n  Strong vs Infantry, Buildings\n  Weak vs Aircraft
 	Tooltip:
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	ActorLostNotification:
 
 STEG:

--- a/mods/cnc/rules/ships.yaml
+++ b/mods/cnc/rules/ships.yaml
@@ -6,6 +6,8 @@ BOAT:
 		Cost: 300
 	Tooltip:
 		Name: Gunboat
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 70000
 	Armor:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -97,6 +97,8 @@ APC:
 		Cost: 600
 	Tooltip:
 		Name: APC
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 30
 		Prerequisites: pyle
@@ -153,6 +155,8 @@ ARTY:
 		Cost: 600
 	Tooltip:
 		Name: Artillery
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 60
 		Prerequisites: anyhq, ~techlevel.medium
@@ -196,6 +200,8 @@ FTNK:
 		Cost: 600
 	Tooltip:
 		Name: Flame Tank
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 50
 		Prerequisites: anyhq, ~techlevel.medium
@@ -235,6 +241,8 @@ BGGY:
 		Cost: 300
 	Tooltip:
 		Name: Nod Buggy
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 20
 		Prerequisites: afld
@@ -275,6 +283,8 @@ BIKE:
 		Cost: 500
 	Tooltip:
 		Name: Recon Bike
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 30
 		Prerequisites: afld
@@ -311,6 +321,8 @@ JEEP:
 		Cost: 400
 	Tooltip:
 		Name: Hum-Vee
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 20
 		Prerequisites: weap
@@ -351,6 +363,8 @@ LTNK:
 		Cost: 650
 	Tooltip:
 		Name: Light Tank
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 40
 		Prerequisites: anyhq, ~techlevel.medium
@@ -394,6 +408,8 @@ MTNK:
 		Cost: 800
 	Tooltip:
 		Name: Medium Tank
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 40
 		Prerequisites: anyhq, ~techlevel.medium
@@ -437,6 +453,8 @@ HTNK:
 		Cost: 1500
 	Tooltip:
 		Name: Mammoth Tank
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 60
 		Prerequisites: eye, ~techlevel.high
@@ -494,6 +512,8 @@ MSAM:
 		Cost: 900
 	Tooltip:
 		Name: Rocket Launcher
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 50
 		Prerequisites: anyhq, ~techlevel.medium
@@ -539,6 +559,8 @@ MLRS:
 		Cost: 600
 	Tooltip:
 		Name: Mobile S.A.M.
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 70
 		Prerequisites: anyhq, ~techlevel.medium
@@ -594,6 +616,8 @@ STNK:
 		Cost: 900
 	Tooltip:
 		Name: Stealth Tank
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 90
 		Prerequisites: tmpl, ~techlevel.high

--- a/mods/common/chrome/ingame-observerstats.yaml
+++ b/mods/common/chrome/ingame-observerstats.yaml
@@ -284,6 +284,20 @@ Background@INGAME_OBSERVERSTATS_BG:
 							Font: Bold
 							Text: Earnings received each minute
 							Align: Center
+				Container@ARMY_THIS_MIN_GRAPH_HEADERS:
+					X: 0
+					Y: 0
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
+					Children:
+						Label@EARNED_THIS_MIN_HEADER:
+							X: 0
+							Y: 40
+							Width: PARENT_RIGHT
+							Height: 25
+							Font: Bold
+							Text: Army value over time
+							Align: Center
 				ScrollPanel@PLAYER_STATS_PANEL:
 					X: 25
 					Y: 70
@@ -552,6 +566,26 @@ Background@INGAME_OBSERVERSTATS_BG:
 							Height: PARENT_BOTTOM - 50
 							Children:
 								LineGraph@EARNED_THIS_MIN_GRAPH:
+									X: 0
+									Y: 0
+									Width: PARENT_RIGHT
+									Height: PARENT_BOTTOM
+									ValueFormat: ${0}
+									XAxisValueFormat: {0}
+									YAxisValueFormat: ${0:F0}
+									XAxisSize: 20
+									YAxisSize: 10
+									XAxisLabel: m
+									YAxisLabel: $
+									LabelFont: TinyBold
+									AxisFont: Bold
+						Container@ARMY_THIS_MIN_GRAPH_TEMPLATE:
+							X: 0
+							Y: 0
+							Width: PARENT_RIGHT - 100
+							Height: PARENT_BOTTOM - 50
+							Children:
+								LineGraph@ARMY_THIS_MIN_GRAPH:
 									X: 0
 									Y: 0
 									Width: PARENT_RIGHT

--- a/mods/common/chrome/ingame-observerstats.yaml
+++ b/mods/common/chrome/ingame-observerstats.yaml
@@ -262,6 +262,14 @@ Background@INGAME_OBSERVERSTATS_BG:
 							Font: Bold
 							Text: Bldg Lost
 							Align: Right
+						Label@ARMY_VALUE_HEADER:
+							X: 845
+							Y: 40
+							Width: 40
+							Height: 25
+							Font: Bold
+							Text: Army Value
+							Align: Right
 				Container@EARNED_THIS_MIN_GRAPH_HEADERS:
 					X: 0
 					Y: 0
@@ -525,6 +533,13 @@ Background@INGAME_OBSERVERSTATS_BG:
 									Shadow: True
 								Label@BUILDINGS_DEAD:
 									X: 715
+									Y: 0
+									Width: 40
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@ARMY_VALUE:
+									X: 815
 									Y: 0
 									Width: 40
 									Height: PARENT_BOTTOM

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -11,6 +11,8 @@ light_inf:
 		Cost: 50
 	Tooltip:
 		Name: Light Infantry
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 6000
 	Mobile:
@@ -34,6 +36,8 @@ engineer:
 		Cost: 400
 	Tooltip:
 		Name: Engineer
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 5000
 	RevealsShroud:
@@ -63,6 +67,8 @@ trooper:
 		Cost: 90
 	Tooltip:
 		Name: Trooper
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 7000
 	RevealsShroud:
@@ -92,6 +98,8 @@ thumper:
 		Cost: 200
 	Tooltip:
 		Name: Thumper Infantry
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 3750
 	RevealsShroud:
@@ -128,6 +136,8 @@ fremen:
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Tooltip:
 		Name: Fremen
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 80
@@ -179,6 +189,8 @@ grenadier:
 		Cost: 80
 	Tooltip:
 		Name: Grenadier
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 6000
 	Mobile:
@@ -210,6 +222,8 @@ sardaukar:
 		Cost: 120
 	Tooltip:
 		Name: Sardaukar
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 10000
 	Mobile:
@@ -258,6 +272,8 @@ saboteur:
 		Cost: 300 ## actually 0, but spawns from support power at Palace
 	Tooltip:
 		Name: Saboteur
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 4000
 	Mobile:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -116,6 +116,8 @@ trike:
 		Cost: 300
 	Tooltip:
 		Name: Trike
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Selectable:
 		Class: trike
 	Health:
@@ -157,6 +159,8 @@ quad:
 		Cost: 400
 	Tooltip:
 		Name: Missile Quad
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 11000
 	Armor:
@@ -193,6 +197,8 @@ siege_tank:
 		Cost: 700
 	Tooltip:
 		Name: Siege Tank
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 12000
 	Armor:
@@ -234,6 +240,8 @@ missile_tank:
 	Inherits@AUTOTARGET: ^AutoTargetAllAssaultMove
 	Tooltip:
 		Name: Missile Tank
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Armor
 		Prerequisites: ~heavy.missile_tank, upgrade.heavy, research_centre, ~techlevel.high
@@ -285,6 +293,8 @@ sonic_tank:
 		Cost: 1000
 	Tooltip:
 		Name: Sonic Tank
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 30000
 	Armor:
@@ -323,6 +333,8 @@ devastator:
 		Cost: 1050
 	Tooltip:
 		Name: Devastator
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 50000
 	Armor:
@@ -393,6 +405,8 @@ raider:
 		Cost: 350
 	Tooltip:
 		Name: Raider Trike
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 10000
 	Armor:
@@ -429,6 +443,8 @@ stealth_raider:
 		Cost: 400
 	Tooltip:
 		Name: Stealth Raider Trike
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Cloak:
 		InitialDelay: 45
 		CloakDelay: 90
@@ -451,6 +467,8 @@ deviator:
 		Cost: 1000
 	Tooltip:
 		Name: Deviator
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Armor
 		BuildPaletteOrder: 50
@@ -497,6 +515,8 @@ deviator:
 		Cost: 700
 	Tooltip:
 		Name: Combat Tank
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 21000
 	Armor:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -92,6 +92,8 @@ MIG:
 		Cost: 2000
 	Tooltip:
 		Name: MiG Attack Plane
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 7500
 	RevealsShroud:
@@ -153,6 +155,8 @@ YAK:
 		Cost: 1350
 	Tooltip:
 		Name: Yak Attack Plane
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 6000
 	RevealsShroud:
@@ -219,6 +223,8 @@ TRAN:
 		Cost: 900
 	Tooltip:
 		Name: Chinook
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 14000
 	RevealsShroud:
@@ -273,6 +279,8 @@ HELI:
 		Cost: 2000
 	Tooltip:
 		Name: Longbow
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 12000
 	RevealsShroud:
@@ -335,6 +343,8 @@ HIND:
 		Cost: 1350
 	Tooltip:
 		Name: Hind
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 10000
 	RevealsShroud:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -11,6 +11,8 @@ DOG:
 	Tooltip:
 		Name: Attack Dog
 		GenericName: Dog
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Selectable:
 		Bounds: 12,17,-1,-4
 		DecorationBounds: 12,17,-1,-4
@@ -79,6 +81,8 @@ E1:
 		Cost: 100
 	Tooltip:
 		Name: Rifle Infantry
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 5000
 	Armament@PRIMARY:
@@ -119,6 +123,8 @@ E2:
 		Cost: 160
 	Tooltip:
 		Name: Grenadier
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 5000
 	Mobile:
@@ -162,6 +168,8 @@ E3:
 		Cost: 300
 	Tooltip:
 		Name: Rocket Soldier
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 4500
 	Armament@PRIMARY:
@@ -210,6 +218,8 @@ E4:
 		Cost: 300
 	Tooltip:
 		Name: Flamethrower
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 4000
 	Armament@PRIMARY:
@@ -247,6 +257,8 @@ E6:
 		Cost: 500
 	Tooltip:
 		Name: Engineer
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	WithInfantryBody:
 		RequiresCondition: !parachute
 	WithInfantryBody@PARACHUTE:
@@ -293,6 +305,8 @@ SPY:
 	DisguiseTooltip:
 		Name: Spy
 		GenericName: Soldier
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	-Guard:
 	Mobile:
 		Voice: Move
@@ -361,6 +375,8 @@ E7:
 		Cost: 1200
 	Tooltip:
 		Name: Tanya
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 10000
 	Mobile:
@@ -413,6 +429,8 @@ MEDI:
 		Cost: 200
 	Tooltip:
 		Name: Medic
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 6000
 	RevealsShroud:
@@ -448,6 +466,8 @@ MECH:
 		Cost: 500
 	Tooltip:
 		Name: Mechanic
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 8000
 	Mobile:
@@ -551,6 +571,8 @@ THF:
 		Cost: 500
 	Tooltip:
 		Name: Thief
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 5000
 	RevealsShroud:
@@ -599,6 +621,8 @@ SHOK:
 		Cost: 350
 	Tooltip:
 		Name: Shock Trooper
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 5000
 	Mobile:
@@ -638,6 +662,8 @@ SNIPER:
 		Cost: 700
 	Tooltip:
 		Name: Sniper
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
@@ -689,6 +715,8 @@ Zombie:
 		Cost: 100
 	Tooltip:
 		Name: Zombie
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
@@ -719,6 +747,8 @@ Ant:
 	Tooltip:
 		Name: Giant Ant
 		GenericName: Ant
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -11,6 +11,8 @@ SS:
 		Cost: 950
 	Tooltip:
 		Name: Submarine
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 25000
 	Armor:
@@ -79,6 +81,8 @@ MSUB:
 		Cost: 2000
 	Tooltip:
 		Name: Missile Submarine
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 40000
 	Armor:
@@ -147,6 +151,8 @@ DD:
 		Cost: 1000
 	Tooltip:
 		Name: Destroyer
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 40000
 	Armor:
@@ -198,6 +204,8 @@ CA:
 		Cost: 2400
 	Tooltip:
 		Name: Cruiser
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 80000
 	Armor:
@@ -256,6 +264,8 @@ LST:
 		Cost: 700
 	Tooltip:
 		Name: Transport
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 35000
 	Armor:
@@ -296,6 +306,8 @@ PT:
 		Cost: 500
 	Tooltip:
 		Name: Gunboat
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 20000
 	Armor:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -11,6 +11,8 @@ V2RL:
 		Cost: 900
 	Tooltip:
 		Name: V2 Rocket Launcher
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 20000
 	Armor:
@@ -58,6 +60,8 @@ V2RL:
 	Tooltip:
 		Name: Light Tank
 		GenericName: Tank
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 22000
 	Armor:
@@ -99,6 +103,8 @@ V2RL:
 	Tooltip:
 		Name: Medium Tank
 		GenericName: Tank
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 45000
 	Armor:
@@ -143,6 +149,8 @@ V2RL:
 	Tooltip:
 		Name: Heavy Tank
 		GenericName: Tank
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 60000
 	Armor:
@@ -188,6 +196,8 @@ V2RL:
 	Tooltip:
 		Name: Mammoth Tank
 		GenericName: Tank
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 90000
 	Armor:
@@ -246,6 +256,8 @@ ARTY:
 		Cost: 850
 	Tooltip:
 		Name: Artillery
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 10000
 	Armor:
@@ -376,6 +388,8 @@ JEEP:
 		Cost: 500
 	Tooltip:
 		Name: Ranger
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 15000
 	Armor:
@@ -420,6 +434,8 @@ APC:
 		Cost: 850
 	Tooltip:
 		Name: Armored Personnel Carrier
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 30000
 	Armor:
@@ -457,6 +473,8 @@ MNLY:
 		Cost: 800
 	Tooltip:
 		Name: Minelayer
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Selectable:
 		Priority: 5
 	Health:
@@ -526,6 +544,8 @@ MGG:
 		Cost: 1200
 	Tooltip:
 		Name: Mobile Gap Generator
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 22000
 	Armor:
@@ -552,6 +572,8 @@ MRJ:
 		Cost: 1100
 	Tooltip:
 		Name: Mobile Radar Jammer
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 140
@@ -599,6 +621,8 @@ TTNK:
 	Tooltip:
 		Name: Tesla Tank
 		GenericName: Tank
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 45000
 	Armor:
@@ -636,6 +660,8 @@ FTRK:
 		Cost: 600
 	Tooltip:
 		Name: Mobile Flak
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 15000
 	Armor:
@@ -681,6 +707,8 @@ DTRK:
 		Cost: 2500
 	Tooltip:
 		Name: Demolition Truck
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 5000
 	Armor:
@@ -715,6 +743,8 @@ CTNK:
 	Tooltip:
 		Name: Chrono Tank
 		GenericName: Tank
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	SelectionDecorations:
 	Health:
 		HP: 45000
@@ -756,6 +786,8 @@ QTNK:
 	Tooltip:
 		Name: MAD Tank
 		GenericName: Tank
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 90000
 	Armor:
@@ -792,6 +824,8 @@ STNK:
 		Cost: 1350
 	Tooltip:
 		Name: Phase Transport
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 30000
 	Armor:

--- a/mods/ts/chrome/ingame-observerstats.yaml
+++ b/mods/ts/chrome/ingame-observerstats.yaml
@@ -284,6 +284,20 @@ Background@INGAME_OBSERVERSTATS_BG:
 							Font: Bold
 							Text: Earnings received each minute
 							Align: Center
+				Container@ARMY_THIS_MIN_GRAPH_HEADERS:
+					X: 0
+					Y: 0
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
+					Children:
+						Label@EARNED_THIS_MIN_HEADER:
+							X: 0
+							Y: 40
+							Width: PARENT_RIGHT
+							Height: 25
+							Font: Bold
+							Text: Army value over time
+							Align: Center
 				ScrollPanel@PLAYER_STATS_PANEL:
 					X: 25
 					Y: 70
@@ -554,6 +568,26 @@ Background@INGAME_OBSERVERSTATS_BG:
 							Height: PARENT_BOTTOM - 50
 							Children:
 								LineGraph@EARNED_THIS_MIN_GRAPH:
+									X: 0
+									Y: 0
+									Width: PARENT_RIGHT
+									Height: PARENT_BOTTOM
+									ValueFormat: ${0}
+									XAxisValueFormat: {0}
+									YAxisValueFormat: ${0:F0}
+									XAxisSize: 20
+									YAxisSize: 10
+									XAxisLabel: m
+									YAxisLabel: $
+									LabelFont: TinyBold
+									AxisFont: Bold
+						Container@ARMY_THIS_MIN_GRAPH_TEMPLATE:
+							X: 0
+							Y: 0
+							Width: PARENT_RIGHT - 100
+							Height: PARENT_BOTTOM - 50
+							Children:
+								LineGraph@ARMY_THIS_MIN_GRAPH:
 									X: 0
 									Y: 0
 									Width: PARENT_RIGHT

--- a/mods/ts/chrome/ingame-observerstats.yaml
+++ b/mods/ts/chrome/ingame-observerstats.yaml
@@ -262,6 +262,14 @@ Background@INGAME_OBSERVERSTATS_BG:
 							Font: Bold
 							Text: Bldg Lost
 							Align: Right
+						Label@ARMY_VALUE_HEADER:
+							X: 845
+							Y: 40
+							Width: 40
+							Height: 25
+							Font: Bold
+							Text: Army Value
+							Align: Right
 				Container@EARNED_THIS_MIN_GRAPH_HEADERS:
 					X: 0
 					Y: 0
@@ -527,6 +535,13 @@ Background@INGAME_OBSERVERSTATS_BG:
 									Shadow: True
 								Label@BUILDINGS_DEAD:
 									X: 715
+									Y: 0
+									Width: 40
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@ARMY_VALUE:
+									X: 815
 									Y: 0
 									Width: 40
 									Height: PARENT_BOTTOM

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -38,6 +38,8 @@ DSHP:
 		Cost: 1000
 	Tooltip:
 		Name: Dropship
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Aircraft:
 		LandWhenIdle: true
 		TurnSpeed: 5
@@ -72,6 +74,8 @@ ORCA:
 		Cost: 1000
 	Tooltip:
 		Name: Orca Fighter
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Air
 		BuildPaletteOrder: 10
@@ -120,6 +124,8 @@ ORCAB:
 		Cost: 1600
 	Tooltip:
 		Name: Orca Bomber
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Air
 		BuildPaletteOrder: 30
@@ -173,6 +179,8 @@ ORCATRAN:
 		Cost: 1200
 	Tooltip:
 		Name: Orca Transport
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Air
 		BuildPaletteOrder: 50
@@ -209,6 +217,8 @@ TRNSPORT:
 		Cost: 750
 	Tooltip:
 		Name: Carryall
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Air
 		BuildPaletteOrder: 60
@@ -249,6 +259,8 @@ SCRIN:
 		Cost: 1500
 	Tooltip:
 		Name: Banshee Fighter
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Air
 		BuildPaletteOrder: 40
@@ -305,6 +317,8 @@ APACHE:
 		Cost: 1000
 	Tooltip:
 		Name: Harpy
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Air
 		BuildPaletteOrder: 20

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -12,6 +12,8 @@ E2:
 		Cost: 200
 	Tooltip:
 		Name: Disc Thrower
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 15000
 	Mobile:
@@ -39,6 +41,8 @@ MEDIC:
 		Cost: 600
 	Tooltip:
 		Name: Medic
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 50
@@ -81,6 +85,8 @@ JUMPJET:
 		Cost: 600
 	Tooltip:
 		Name: Jumpjet Infantry
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 70
@@ -201,6 +207,8 @@ GHOST:
 		Cost: 1750
 	Tooltip:
 		Name: Ghost Stalker
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 90

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -5,6 +5,8 @@ APC:
 		Cost: 800
 	Tooltip:
 		Name: Amphibious APC
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 80
@@ -55,6 +57,8 @@ HVR:
 		Cost: 900
 	Tooltip:
 		Name: Hover MLRS
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 80
@@ -101,6 +105,8 @@ SMECH:
 		Cost: 500
 	Tooltip:
 		Name: Wolverine
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 20
@@ -146,6 +152,8 @@ MMCH:
 		Cost: 800
 	Tooltip:
 		Name: Titan
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 50
@@ -206,6 +214,8 @@ HMEC:
 		Cost: 3000
 	Tooltip:
 		Name: Mammoth Mk. II
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 140
@@ -252,6 +262,8 @@ SONIC:
 		Cost: 1300
 	Tooltip:
 		Name: Disruptor
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 120
@@ -299,6 +311,8 @@ JUGG:
 	Tooltip@DEPLOYED:
 		Name: Juggernaut (deployed)
 		RequiresCondition: deployed
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 100

--- a/mods/ts/rules/nod-infantry.yaml
+++ b/mods/ts/rules/nod-infantry.yaml
@@ -12,6 +12,8 @@ E3:
 		Cost: 250
 	Tooltip:
 		Name: Rocket Infantry
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Voiced:
 		VoiceSet: Rocket
 	Health:
@@ -43,6 +45,8 @@ CYBORG:
 		Cost: 650
 	Tooltip:
 		Name: Cyborg Infantry
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 60
@@ -79,6 +83,8 @@ CYC2:
 		Cost: 2000
 	Tooltip:
 		Name: Cyborg Commando
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 100
@@ -119,6 +125,8 @@ MHIJACK:
 		Cost: 1850
 	Tooltip:
 		Name: Mutant Hijacker
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Voiced:
 		VoiceSet: Hijacker
 	Health:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -7,6 +7,8 @@ BGGY:
 		Cost: 500
 	Tooltip:
 		Name: Attack Buggy
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 30
@@ -45,6 +47,8 @@ BIKE:
 		Cost: 600
 	Tooltip:
 		Name: Attack Cycle
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 40
@@ -90,6 +94,8 @@ TTNK:
 	Tooltip@DEPLOYED:
 		Name: Tick Tank (deployed)
 		RequiresCondition: deployed
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 60
@@ -203,6 +209,8 @@ ART2:
 	Tooltip@DEPLOYED:
 		Name: Artillery (deployed)
 		RequiresCondition: deployed
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 100
@@ -285,6 +293,8 @@ REPAIR:
 		Cost: 1000
 	Tooltip:
 		Name: Mobile Repair Vehicle
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 20000
 	Mobile:
@@ -357,6 +367,8 @@ SAPC:
 		Cost: 800
 	Tooltip:
 		Name: Subterranean APC
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 110
@@ -401,6 +413,8 @@ SUBTANK:
 		Cost: 750
 	Tooltip:
 		Name: Devil's Tongue
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 130
@@ -442,6 +456,8 @@ STNK:
 		Cost: 1100
 	Tooltip:
 		Name: Stealth Tank
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		BuildPaletteOrder: 150
 		Prerequisites: ~naweap, natech, ~techlevel.high

--- a/mods/ts/rules/shared-infantry.yaml
+++ b/mods/ts/rules/shared-infantry.yaml
@@ -12,6 +12,8 @@ E1:
 		Cost: 120
 	Tooltip:
 		Name: Light Infantry
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Health:
 		HP: 12500
 	Mobile:
@@ -42,6 +44,8 @@ ENGINEER:
 		Cost: 500
 	Tooltip:
 		Name: Engineer
+	UpdatesPlayerStatistics:
+		AddToArmyValue: true
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 40


### PR DESCRIPTION
This feature makes possible to follow the army value over time in a game, useful for analysis in the competitive scene (typically to spot when good/bad trades happen).

There are a bunch of units for which I'm unsure whether I should count them as part of the army or not. Following is the list of my doubts, open to discussion. Note: some of the unit in RA are redundant in other mods (such as medic).

RA:
    engie? -> no
    medic? -> no
    mechanic? -> no
    spy? -> yes
    minelayer? -> yes
    mobile gap gen? -> yes
    mobile radar jammer? -> yes
    general? -> yes
    thief? -> yes
    hijacker? -> yes
    transport? (ship) -> no
    chinook? -> no

CNC:
    dino? -> no
    landing craft? -> no

D2K:
    orni? -> no
    thumper? -> no
    saboteur? -> yes

TS:
    mutant hijacker? -> yes

Here is a screenshot on how it looks in observer mode. There is also a new column in the Combat tab.

![2018-10-31-223605_1920x1080_scrot](https://user-images.githubusercontent.com/34467/47823395-68d61d00-dd68-11e8-8072-21eb567528a7.png)
