### PR TITLE
Add overlooked entries to bleed update path

### DIFF
--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -95,6 +95,8 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new MergeCaptureTraits(),
 				new RemovedNotifyBuildComplete(),
 				new LowPowerSlowdownToModifier(),
+				new ChangeTakeOffSoundAndLandingSound(),
+				new RemoveHealthPercentageRing(),
 				new RenameCrateActionNotification(),
 			})
 		};


### PR DESCRIPTION
Those were forgotten to be added in their respective PR.
Not adding them at the bottom because
- `RenameCrateActionNotification` was merged later than them
- this might allow some open PRs to rebase without merge conflicts (or at least the 3-way auto-merge might succeed), if they've been rebased onto a bleed-state which already included the `RenameCrateActionNotification` entry