### PR TITLE
Minor touch ups to Lua's Beacon API

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Global/BeaconGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/BeaconGlobal.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Creates a new beacon that stays for the specified time at the specified WPos. " +
 			"Does not remove player set beacons, nor gets removed by placing them. " +
 			"Requires the 'PlaceBeacon' trait on the player actor.")]
-		public Beacon New(Player owner, WPos position, int duration = 30 * 25, bool showRadarPings = true)
+		public void New(Player owner, WPos position, int duration = 30 * 25, bool showRadarPings = true)
 		{
 			var beacon = owner.PlayerActor.Info.TraitInfoOrDefault<PlaceBeaconInfo>();
 			if (beacon == null)
@@ -49,8 +49,6 @@ namespace OpenRA.Mods.Common.Scripting
 					owner.Color,
 					duration);
 			}
-
-			return playerBeacon;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/Global/BeaconGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/BeaconGlobal.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using Eluant;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Scripting;
@@ -20,16 +21,21 @@ namespace OpenRA.Mods.Common.Scripting
 	{
 		readonly RadarPings radarPings;
 
-		public BeaconGlobal(ScriptContext context) : base(context)
+		public BeaconGlobal(ScriptContext context)
+			: base(context)
 		{
 			radarPings = context.World.WorldActor.TraitOrDefault<RadarPings>();
 		}
 
 		[Desc("Creates a new beacon that stays for the specified time at the specified WPos. " +
-			"Does not remove player set beacons, nor gets removed by placing them.")]
+			"Does not remove player set beacons, nor gets removed by placing them. " +
+			"Requires the 'PlaceBeacon' trait on the player actor.")]
 		public Beacon New(Player owner, WPos position, int duration = 30 * 25, bool showRadarPings = true)
 		{
-			var beacon = owner.PlayerActor.Info.TraitInfo<PlaceBeaconInfo>();
+			var beacon = owner.PlayerActor.Info.TraitInfoOrDefault<PlaceBeaconInfo>();
+			if (beacon == null)
+				throw new LuaException("The player actor has no 'PlaceBeacon' trait.");
+
 			var playerBeacon = new Beacon(owner, position, duration, beacon.Palette, beacon.IsPlayerPalette,
 				beacon.BeaconImage, beacon.BeaconSequence, beacon.ArrowSequence, beacon.CircleSequence);
 


### PR DESCRIPTION
Closes #15778.

Also:
- Throws a proper `LuaException` now if the player actors misses a trait.
- Removed the return type of `Beacon.New`. It was of no use anyway.
- Moved the `PlaceSimpleBeacon` trait and the `Player` subfolder into the `Traits` subfolder.
- Ordered entries in `OpenRA.Mods.Cnc.csproj` in alphabetic order while I was touching it.