### PR TITLE
Support non-int Enum types in the Lua API.

### DIFF
--- a/OpenRA.Game/Scripting/ScriptTypes.cs
+++ b/OpenRA.Game/Scripting/ScriptTypes.cs
@@ -79,6 +79,18 @@ namespace OpenRA.Scripting
 				return true;
 			}
 
+			if (value is LuaNumber && t.IsAssignableFrom(typeof(short)))
+			{
+				clrObject = (short)value.ToNumber().Value;
+				return true;
+			}
+
+			if (value is LuaNumber && t.IsAssignableFrom(typeof(byte)))
+			{
+				clrObject = (byte)value.ToNumber().Value;
+				return true;
+			}
+
 			if (value is LuaString && t.IsAssignableFrom(typeof(string)))
 			{
 				clrObject = value.ToString();

--- a/OpenRA.Mods.Common/Scripting/Global/ActorGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ActorGlobal.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Linq;
 using Eluant;
 using OpenRA.Mods.Common.Traits;
@@ -43,7 +44,7 @@ namespace OpenRA.Mods.Common.Scripting
 					var genericType = initType.GetInterfaces()
 						.First(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IActorInit<>));
 					var innerType = genericType.GetGenericArguments().First();
-					var valueType = innerType.IsEnum ? typeof(int) : innerType;
+					var valueType = innerType.IsEnum ? Enum.GetUnderlyingType(innerType) : innerType;
 
 					// Try and coerce the table value to the required type
 					object value;


### PR DESCRIPTION
Fixes #15775.

This can probably be added to the changelog entry for #15479.