### PR TITLE
Add LocalRandom to World

### DIFF
--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -41,6 +41,7 @@ namespace OpenRA
 		public Session LobbyInfo { get { return OrderManager.LobbyInfo; } }
 
 		public readonly MersenneTwister SharedRandom;
+		public readonly MersenneTwister LocalRandom;
 		public readonly IModelCache ModelCache;
 
 		public Player[] Players = new Player[0];
@@ -169,6 +170,7 @@ namespace OpenRA
 			Map = map;
 			Timestep = orderManager.LobbyInfo.GlobalSettings.Timestep;
 			SharedRandom = new MersenneTwister(orderManager.LobbyInfo.GlobalSettings.RandomSeed);
+			LocalRandom = new MersenneTwister();
 
 			ModelCache = modData.ModelSequenceLoader.CacheModels(map, modData, map.Rules.ModelSequences);
 

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -119,7 +119,7 @@ namespace OpenRA.Mods.Common.Warheads
 			if (UsePlayerPalette)
 				palette += firedBy.Owner.InternalName;
 
-			var explosion = Explosions.RandomOrDefault(Game.CosmeticRandom);
+			var explosion = Explosions.RandomOrDefault(world.LocalRandom);
 			if (Image != null && explosion != null)
 			{
 				if (ForceDisplayAtGroundLevel)
@@ -131,8 +131,8 @@ namespace OpenRA.Mods.Common.Warheads
 				world.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, w, Image, explosion, palette)));
 			}
 
-			var impactSound = ImpactSounds.RandomOrDefault(Game.CosmeticRandom);
-			if (impactSound != null && Game.CosmeticRandom.Next(0, 100) < ImpactSoundChance)
+			var impactSound = ImpactSounds.RandomOrDefault(world.LocalRandom);
+			if (impactSound != null && world.LocalRandom.Next(0, 100) < ImpactSoundChance)
 				Game.Sound.Play(SoundType.World, impactSound, pos);
 		}
 


### PR DESCRIPTION
To replace Game.CosmeticRandom later down the road.

Only ported `CreateEffectWarhead` for now to have something to test, but will be used by AI bot modules as well.

Suggested testcase: Add
```
	Warhead@3Eff: CreateEffect
		Explosions: flak_explosion_ground, small_explosion, med_explosion, artillery_explosion
```
to RA's `90mm` weapon (ballistics.yaml) and watch allied medium tanks on shellmap shoot.