### PR TITLE
Code cleanups.

### DIFF
--- a/OpenRA.Game/Effects/DelayedImpact.cs
+++ b/OpenRA.Game/Effects/DelayedImpact.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using OpenRA.Graphics;
 using OpenRA.Traits;

--- a/OpenRA.Game/GameRules/MusicInfo.cs
+++ b/OpenRA.Game/GameRules/MusicInfo.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.IO;
-using OpenRA.FileFormats;
 using OpenRA.FileSystem;
 
 namespace OpenRA.GameRules

--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Support;

--- a/OpenRA.Game/Graphics/AnimationWithOffset.cs
+++ b/OpenRA.Game/Graphics/AnimationWithOffset.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Drawing;
 
 namespace OpenRA.Graphics

--- a/OpenRA.Game/Graphics/RgbaSpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/RgbaSpriteRenderer.cs
@@ -10,9 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
 
 namespace OpenRA.Graphics
 {

--- a/OpenRA.Game/Graphics/SpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderable.cs
@@ -11,7 +11,6 @@
 
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 
 namespace OpenRA.Graphics
 {

--- a/OpenRA.Game/LocalPlayerProfile.cs
+++ b/OpenRA.Game/LocalPlayerProfile.cs
@@ -16,7 +16,6 @@ using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
-using OpenRA.Network;
 
 namespace OpenRA
 {

--- a/OpenRA.Game/LocalPlayerProfile.cs
+++ b/OpenRA.Game/LocalPlayerProfile.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -18,7 +18,6 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using OpenRA.FileSystem;
-using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Traits;

--- a/OpenRA.Game/Map/MapPreview.cs
+++ b/OpenRA.Game/Map/MapPreview.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.IO;

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using OpenRA.Network;
 using OpenRA.Traits;
 

--- a/OpenRA.Game/Network/UPnP.cs
+++ b/OpenRA.Game/Network/UPnP.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;
 using System.Threading;

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -9,12 +9,9 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
 using OpenRA.Traits;
 
 namespace OpenRA.Network

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -12,7 +12,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Orders

--- a/OpenRA.Game/Platform.cs
+++ b/OpenRA.Game/Platform.cs
@@ -12,7 +12,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 
 namespace OpenRA

--- a/OpenRA.Game/Primitives/float3.cs
+++ b/OpenRA.Game/Primitives/float3.cs
@@ -9,9 +9,7 @@
  */
 #endregion
 
-using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Drawing;
 using System.Runtime.InteropServices;
 
 namespace OpenRA

--- a/OpenRA.Game/SelectableExts.cs
+++ b/OpenRA.Game/SelectableExts.cs
@@ -13,8 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using OpenRA.Graphics;
-using OpenRA.Primitives;
 
 namespace OpenRA.Traits
 {

--- a/OpenRA.Game/Traits/Interactable.cs
+++ b/OpenRA.Game/Traits/Interactable.cs
@@ -12,7 +12,6 @@
 using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Traits;
 
 namespace OpenRA.Traits
 {

--- a/OpenRA.Game/Traits/Selectable.cs
+++ b/OpenRA.Game/Traits/Selectable.cs
@@ -9,10 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.Drawing;
-using OpenRA.Graphics;
-
 namespace OpenRA.Traits
 {
 	[Desc("This actor is selectable. Defines bounds of selectable area, selection class and selection priority.")]

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -13,7 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
-using OpenRA.Activities;
 using OpenRA.FileSystem;
 using OpenRA.Graphics;
 using OpenRA.Network;

--- a/OpenRA.Mods.Cnc/Activities/LayMines.cs
+++ b/OpenRA.Mods.Cnc/Activities/LayMines.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Cnc.Traits;

--- a/OpenRA.Mods.Cnc/Activities/Leap.cs
+++ b/OpenRA.Mods.Cnc/Activities/Leap.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.GameRules;

--- a/OpenRA.Mods.Cnc/CncLoadScreen.cs
+++ b/OpenRA.Mods.Cnc/CncLoadScreen.cs
@@ -12,7 +12,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
-using System.IO;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.LoadScreens;
 using OpenRA.Widgets;

--- a/OpenRA.Mods.Cnc/Effects/AnimatedBeacon.cs
+++ b/OpenRA.Mods.Cnc/Effects/AnimatedBeacon.cs
@@ -9,12 +9,9 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Effects;
 using OpenRA.Graphics;
-using OpenRA.Scripting;
 
 namespace OpenRA.Mods.Cnc.Effects
 {

--- a/OpenRA.Mods.Cnc/FileFormats/HvaReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/HvaReader.cs
@@ -7,7 +7,6 @@
  * the License, or (at your option) any later version. For more
  * information, see COPYING.
  */
-
 #endregion
 
 using System;

--- a/OpenRA.Mods.Cnc/FileFormats/VxlReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/VxlReader.cs
@@ -7,7 +7,6 @@
  * the License, or (at your option) any later version. For more
  * information, see COPYING.
  */
-
 #endregion
 
 using System.Collections.Generic;

--- a/OpenRA.Mods.Cnc/FileSystem/MixFile.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/MixFile.cs
@@ -13,7 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using OpenRA.FileFormats;
 using OpenRA.FileSystem;
 using OpenRA.Mods.Cnc.FileFormats;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.Cnc/Projectiles/IonCannon.cs
+++ b/OpenRA.Mods.Cnc/Projectiles/IonCannon.cs
@@ -11,7 +11,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Effects;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Cnc/Projectiles/TeslaZap.cs
+++ b/OpenRA.Mods.Cnc/Projectiles/TeslaZap.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.Effects;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Mods.Cnc.Graphics;

--- a/OpenRA.Mods.Cnc/Scripting/Properties/InfiltrateProperties.cs
+++ b/OpenRA.Mods.Cnc/Scripting/Properties/InfiltrateProperties.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using Eluant;
 using OpenRA.Mods.Cnc.Activities;

--- a/OpenRA.Mods.Cnc/Scripting/Properties/IonCannonProperties.cs
+++ b/OpenRA.Mods.Cnc/Scripting/Properties/IonCannonProperties.cs
@@ -5,7 +5,7 @@
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of
  * the License, or (at your option) any later version. For more
- * Information, see COPYING.
+ * information, see COPYING.
  */
 #endregion
 

--- a/OpenRA.Mods.Cnc/Scripting/Properties/IonCannonProperties.cs
+++ b/OpenRA.Mods.Cnc/Scripting/Properties/IonCannonProperties.cs
@@ -10,10 +10,7 @@
 #endregion
 
 using System.Linq;
-using OpenRA.Mods.Cnc.Effects;
 using OpenRA.Mods.Cnc.Traits;
-using OpenRA.Mods.Common.Activities;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Scripting;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common;

--- a/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
+++ b/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Drawing;
-using OpenRA.Activities;
 using OpenRA.Mods.Cnc.Activities;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;

--- a/OpenRA.Mods.Cnc/Traits/Cloneable.cs
+++ b/OpenRA.Mods.Cnc/Traits/Cloneable.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -15,7 +15,6 @@ using System.Drawing;
 using System.Linq;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Cnc/Traits/EnergyWall.cs
+++ b/OpenRA.Mods.Cnc/Traits/EnergyWall.cs
@@ -3,8 +3,9 @@
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
- * as published by the Free Software Foundation. For more information,
- * see COPYING.
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
  */
 #endregion
 

--- a/OpenRA.Mods.Cnc/Traits/GpsDot.cs
+++ b/OpenRA.Mods.Cnc/Traits/GpsDot.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using OpenRA.Graphics;
 using OpenRA.Mods.Cnc.Effects;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForCash.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForCash.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForExploration.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForExploration.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForPowerOutage.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForPowerOutage.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPower.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
@@ -11,7 +11,6 @@
 
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 using OpenRA.Mods.Cnc.Activities;
 using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Activities;

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -14,7 +14,6 @@ using System.Drawing;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.GameRules;
-using OpenRA.Mods.Cnc.Activities;
 using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;

--- a/OpenRA.Mods.Cnc/Traits/Render/RenderJammerCircle.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/RenderJammerCircle.cs
@@ -14,7 +14,6 @@ using System.Drawing;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.Common.Traits.Radar;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits

--- a/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
@@ -16,7 +16,6 @@ using OpenRA.Graphics;
 using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Cnc/Traits/Render/WithDisguisingInfantryBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithDisguisingInfantryBody.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Cnc/Traits/Render/WithRoof.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithRoof.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Cnc/Traits/Render/WithVoxelUnloadBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithVoxelUnloadBody.cs
@@ -12,7 +12,6 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Common.Traits;

--- a/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
@@ -12,9 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Render;

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -13,7 +13,6 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Mods.Cnc.Activities;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/GpsPower.cs
@@ -9,9 +9,7 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Effects;
 using OpenRA.Mods.Cnc.Effects;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Radar;

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -13,7 +13,6 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common;
-using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Cnc/UtilityCommands/LegacyRulesImporter.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/LegacyRulesImporter.cs
@@ -14,7 +14,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using OpenRA.Mods.Common.FileFormats;
-using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.Cnc.UtilityCommands
 {

--- a/OpenRA.Mods.Cnc/UtilityCommands/LegacySequenceImporter.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/LegacySequenceImporter.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using OpenRA.Mods.Common.FileFormats;

--- a/OpenRA.Mods.Common/AI/AISupportPowerManager.cs
+++ b/OpenRA.Mods.Common/AI/AISupportPowerManager.cs
@@ -9,13 +9,8 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using OpenRA.Mods.Common.Activities;
-using OpenRA.Mods.Common.Pathfinder;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Support;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.AI

--- a/OpenRA.Mods.Common/AI/HackyAI.cs
+++ b/OpenRA.Mods.Common/AI/HackyAI.cs
@@ -13,8 +13,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Mods.Common.Activities;
-using OpenRA.Mods.Common.Pathfinder;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Support;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Activities/Air/HeliFlyCircle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliFlyCircle.cs
@@ -11,7 +11,6 @@
 
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {

--- a/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
+++ b/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
@@ -11,7 +11,6 @@
 
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {

--- a/OpenRA.Mods.Common/Activities/CaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/CaptureActor.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using System;
-using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Activities/Demolish.cs
+++ b/OpenRA.Mods.Common/Activities/Demolish.cs
@@ -10,10 +10,8 @@
 #endregion
 
 using System.Linq;
-using OpenRA.Effects;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {

--- a/OpenRA.Mods.Common/Activities/DonateCash.cs
+++ b/OpenRA.Mods.Common/Activities/DonateCash.cs
@@ -11,7 +11,6 @@
 
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {

--- a/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs
@@ -11,7 +11,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities

--- a/OpenRA.Mods.Common/Activities/Rearm.cs
+++ b/OpenRA.Mods.Common/Activities/Rearm.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Activities/RepairBuilding.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBuilding.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Render;

--- a/OpenRA.Mods.Common/Activities/WaitForTurretAlignment.cs
+++ b/OpenRA.Mods.Common/Activities/WaitForTurretAlignment.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 

--- a/OpenRA.Mods.Common/Commands/DevCommands.cs
+++ b/OpenRA.Mods.Common/Commands/DevCommands.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using OpenRA.Graphics;

--- a/OpenRA.Mods.Common/Effects/MapNotificationEffect.cs
+++ b/OpenRA.Mods.Common/Effects/MapNotificationEffect.cs
@@ -14,7 +14,6 @@ using System.Drawing;
 using OpenRA.Effects;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Effects
 {

--- a/OpenRA.Mods.Common/FileFormats/Blast.cs
+++ b/OpenRA.Mods.Common/FileFormats/Blast.cs
@@ -6,7 +6,10 @@
  * as published by the Free Software Foundation, either version 3 of
  * the License, or (at your option) any later version. For more
  * information, see COPYING.
- *
+ */
+#endregion
+#region Additional Copyright & License Information
+/*
  * This file is based on the blast routines (version 1.1 by Mark Adler)
  * included in zlib/contrib
  */

--- a/OpenRA.Mods.Common/FileFormats/InstallShieldCABCompression.cs
+++ b/OpenRA.Mods.Common/FileFormats/InstallShieldCABCompression.cs
@@ -13,7 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using ICSharpCode.SharpZipLib.Zip.Compression;
 
 namespace OpenRA.Mods.Common.FileFormats

--- a/OpenRA.Mods.Common/FileFormats/LZOCompression.cs
+++ b/OpenRA.Mods.Common/FileFormats/LZOCompression.cs
@@ -1,62 +1,68 @@
-#region Copyright notice
-/* C# port of the crude minilzo source version 2.06 by Frank Razenberg
-
-  Beware, you should never want to see C# code like this. You were warned.
-  I simply ran the MSVC preprocessor on the original source, changed the datatypes
-  to their C# counterpart and fixed changed some control flow stuff to amend for
-  the different goto semantics between C and C#.
-
-  Original copyright notice is included below.
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+#region Additional Copyright & License Information
+/*
+ * C# port of the crude minilzo source version 2.06 by Frank Razenberg
+ * The full LZO package can be found at http://www.oberhumer.com/opensource/lzo/
+ *
+ * Beware, you should never want to see C# code like this. You were warned.
+ * I simply ran the MSVC preprocessor on the original source, changed the datatypes
+ * to their C# counterpart and fixed changed some control flow stuff to amend for
+ * the different goto semantics between C and C#.
+ *
+ * Original copyright notice is included below.
 */
 
-/* minilzo.c -- mini subset of the LZO real-time data compression library
-
-   This file is part of the LZO real-time data compression library.
-
-   Copyright (C) 2011 Markus Franz Xaver Johannes Oberhumer
-   Copyright (C) 2010 Markus Franz Xaver Johannes Oberhumer
-   Copyright (C) 2009 Markus Franz Xaver Johannes Oberhumer
-   Copyright (C) 2008 Markus Franz Xaver Johannes Oberhumer
-   Copyright (C) 2007 Markus Franz Xaver Johannes Oberhumer
-   Copyright (C) 2006 Markus Franz Xaver Johannes Oberhumer
-   Copyright (C) 2005 Markus Franz Xaver Johannes Oberhumer
-   Copyright (C) 2004 Markus Franz Xaver Johannes Oberhumer
-   Copyright (C) 2003 Markus Franz Xaver Johannes Oberhumer
-   Copyright (C) 2002 Markus Franz Xaver Johannes Oberhumer
-   Copyright (C) 2001 Markus Franz Xaver Johannes Oberhumer
-   Copyright (C) 2000 Markus Franz Xaver Johannes Oberhumer
-   Copyright (C) 1999 Markus Franz Xaver Johannes Oberhumer
-   Copyright (C) 1998 Markus Franz Xaver Johannes Oberhumer
-   Copyright (C) 1997 Markus Franz Xaver Johannes Oberhumer
-   Copyright (C) 1996 Markus Franz Xaver Johannes Oberhumer
-   All Rights Reserved.
-
-   The LZO library is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License as
-   published by the Free Software Foundation; either version 2 of
-   the License, or (at your option) any later version.
-
-   The LZO library is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with the LZO library; see the file COPYING.
-   If not, write to the Free Software Foundation, Inc.,
-   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
-
-   Markus F.X.J. Oberhumer
-   <markus@oberhumer.com>
-   http://www.oberhumer.com/opensource/lzo/
- */
-
 /*
- * NOTE:
- *   the full LZO package can be found at
- *   http://www.oberhumer.com/opensource/lzo/
+ * minilzo.c -- mini subset of the LZO real-time data compression library
+ *
+ * This file is part of the LZO real-time data compression library.
+ *
+ * Copyright (C) 2011 Markus Franz Xaver Johannes Oberhumer
+ * Copyright (C) 2010 Markus Franz Xaver Johannes Oberhumer
+ * Copyright (C) 2009 Markus Franz Xaver Johannes Oberhumer
+ * Copyright (C) 2008 Markus Franz Xaver Johannes Oberhumer
+ * Copyright (C) 2007 Markus Franz Xaver Johannes Oberhumer
+ * Copyright (C) 2006 Markus Franz Xaver Johannes Oberhumer
+ * Copyright (C) 2005 Markus Franz Xaver Johannes Oberhumer
+ * Copyright (C) 2004 Markus Franz Xaver Johannes Oberhumer
+ * Copyright (C) 2003 Markus Franz Xaver Johannes Oberhumer
+ * Copyright (C) 2002 Markus Franz Xaver Johannes Oberhumer
+ * Copyright (C) 2001 Markus Franz Xaver Johannes Oberhumer
+ * Copyright (C) 2000 Markus Franz Xaver Johannes Oberhumer
+ * Copyright (C) 1999 Markus Franz Xaver Johannes Oberhumer
+ * Copyright (C) 1998 Markus Franz Xaver Johannes Oberhumer
+ * Copyright (C) 1997 Markus Franz Xaver Johannes Oberhumer
+ * Copyright (C) 1996 Markus Franz Xaver Johannes Oberhumer
+ * All Rights Reserved.
+ *
+ * The LZO library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * The LZO library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with the LZO library; see the file COPYING.
+ * If not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Markus F.X.J. Oberhumer
+ * <markus@oberhumer.com>
+ * http://www.oberhumer.com/opensource/lzo/
  */
-
 #endregion
 
 using System;

--- a/OpenRA.Mods.Common/FileFormats/VqaReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/VqaReader.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.IO;
-using OpenRA.FileFormats;
 
 namespace OpenRA.Mods.Common.FileFormats
 {

--- a/OpenRA.Mods.Common/Graphics/RailgunRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/RailgunRenderable.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Drawing;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Projectiles;

--- a/OpenRA.Mods.Common/HitShapes/Capsule.cs
+++ b/OpenRA.Mods.Common/HitShapes/Capsule.cs
@@ -11,10 +11,8 @@
 
 using System;
 using System.Drawing;
-using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.HitShapes
 {

--- a/OpenRA.Mods.Common/HitShapes/Circle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Circle.cs
@@ -11,10 +11,8 @@
 
 using System;
 using System.Drawing;
-using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.HitShapes
 {

--- a/OpenRA.Mods.Common/HitShapes/Rectangle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Rectangle.cs
@@ -14,7 +14,6 @@ using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.HitShapes
 {

--- a/OpenRA.Mods.Common/Lint/CheckActors.cs
+++ b/OpenRA.Mods.Common/Lint/CheckActors.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Linq;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {

--- a/OpenRA.Mods.Common/Lint/CheckAngle.cs
+++ b/OpenRA.Mods.Common/Lint/CheckAngle.cs
@@ -10,10 +10,7 @@
 #endregion
 
 using System;
-using System.Linq;
 using OpenRA.Mods.Common.Projectiles;
-using OpenRA.Mods.Common.Traits;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {

--- a/OpenRA.Mods.Common/Lint/CheckChromeHotkeys.cs
+++ b/OpenRA.Mods.Common/Lint/CheckChromeHotkeys.cs
@@ -13,7 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Primitives;
-using OpenRA.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Lint

--- a/OpenRA.Mods.Common/Lint/CheckChromeLogic.cs
+++ b/OpenRA.Mods.Common/Lint/CheckChromeLogic.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using OpenRA.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Lint

--- a/OpenRA.Mods.Common/Lint/CheckMapCordon.cs
+++ b/OpenRA.Mods.Common/Lint/CheckMapCordon.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {

--- a/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
+++ b/OpenRA.Mods.Common/Lint/CheckMapMetadata.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Linq;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {

--- a/OpenRA.Mods.Common/Lint/CheckNotifications.cs
+++ b/OpenRA.Mods.Common/Lint/CheckNotifications.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/Lint/CheckRangeLimit.cs
+++ b/OpenRA.Mods.Common/Lint/CheckRangeLimit.cs
@@ -10,10 +10,7 @@
 #endregion
 
 using System;
-using System.Linq;
 using OpenRA.Mods.Common.Projectiles;
-using OpenRA.Mods.Common.Traits;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -13,7 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Lint/CheckSpriteBodies.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSpriteBodies.cs
@@ -12,7 +12,6 @@
 using System;
 using System.Linq;
 using OpenRA.Mods.Common.Traits.Render;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {

--- a/OpenRA.Mods.Common/Lint/CheckSyncAnnotations.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSyncAnnotations.cs
@@ -13,7 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {

--- a/OpenRA.Mods.Common/Lint/CheckTooltips.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTooltips.cs
@@ -12,7 +12,6 @@
 using System;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {

--- a/OpenRA.Mods.Common/Lint/CheckTraitPrerequisites.cs
+++ b/OpenRA.Mods.Common/Lint/CheckTraitPrerequisites.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Linq;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {

--- a/OpenRA.Mods.Common/Lint/CheckUnknownTraitFields.cs
+++ b/OpenRA.Mods.Common/Lint/CheckUnknownTraitFields.cs
@@ -12,8 +12,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Mods.Common.Traits;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {

--- a/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
+++ b/OpenRA.Mods.Common/Lint/LintBuildablePrerequisites.cs
@@ -12,7 +12,6 @@
 using System;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Lint
 {

--- a/OpenRA.Mods.Common/LoadScreens/LogoStripeLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/LogoStripeLoadScreen.cs
@@ -12,7 +12,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
-using System.IO;
 using OpenRA.Graphics;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Orders/EnterTransportTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/EnterTransportTargeter.cs
@@ -10,9 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Drawing;
-using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Orders/EnterTransportsTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/EnterTransportsTargeter.cs
@@ -10,9 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Drawing;
-using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Orders/ForceModifiersOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/ForceModifiersOrderGenerator.cs
@@ -10,8 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Orders;
 
 namespace OpenRA.Mods.Common.Orders

--- a/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
@@ -14,7 +14,6 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Pathfinder
 {

--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -12,10 +12,8 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using OpenRA.Effects;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -13,7 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using OpenRA.Effects;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Effects;

--- a/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
@@ -10,10 +10,8 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.Effects;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Projectiles

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -11,7 +11,6 @@
 
 using System.Collections.Generic;
 using System.Drawing;
-using OpenRA.Effects;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Effects;

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -9,11 +9,9 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using OpenRA.Effects;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Effects;

--- a/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MapGlobal.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using Eluant;
 using OpenRA.Mods.Common.Traits;

--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -14,7 +14,6 @@ using System.Drawing;
 using System.IO;
 using Eluant;
 using OpenRA.Effects;
-using OpenRA.FileSystem;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Effects;

--- a/OpenRA.Mods.Common/Scripting/Global/UtilsGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/UtilsGlobal.cs
@@ -9,11 +9,9 @@
  */
 #endregion
 
-using System.Collections;
 using System.Linq;
 using Eluant;
 using OpenRA.Scripting;
-using OpenRA.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Scripting

--- a/OpenRA.Mods.Common/Scripting/Properties/CaptureProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CaptureProperties.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.Linq;
 using Eluant;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;

--- a/OpenRA.Mods.Common/Scripting/Properties/ConditionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ConditionProperties.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/OpenRA.Mods.Common/Scripting/Properties/DiplomacyProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/DiplomacyProperties.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using OpenRA.Scripting;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Scripting
 {

--- a/OpenRA.Mods.Common/Scripting/Properties/HealthProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/HealthProperties.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Scripting;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Scripting/Properties/NukeProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/NukeProperties.cs
@@ -10,9 +10,6 @@
 #endregion
 
 using System.Linq;
-using OpenRA.Effects;
-using OpenRA.Mods.Common.Activities;
-using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Scripting;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Scripting/Properties/NukeProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/NukeProperties.cs
@@ -5,7 +5,7 @@
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of
  * the License, or (at your option) any later version. For more
- * Information, see COPYING.
+ * information, see COPYING.
  */
 #endregion
 

--- a/OpenRA.Mods.Common/Scripting/Properties/PlayerExperienceProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/PlayerExperienceProperties.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using Eluant;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Scripting;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Scripting/Properties/PlayerStatsProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/PlayerStatsProperties.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using Eluant;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Scripting;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/ShroudExts.cs
+++ b/OpenRA.Mods.Common/ShroudExts.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/SpriteLoaders/PngSheetLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/PngSheetLoader.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/Traits/AcceptsDeliveredCash.cs
+++ b/OpenRA.Mods.Common/Traits/AcceptsDeliveredCash.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.Mods.Common.Traits.Sound;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/ActorSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/ActorSpawner.cs
@@ -9,9 +9,7 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {

--- a/OpenRA.Mods.Common/Traits/Attack/AttackCharges.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackCharges.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using OpenRA.Activities;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/AutoCarryable.cs
+++ b/OpenRA.Mods.Common/Traits/AutoCarryable.cs
@@ -11,7 +11,6 @@
 
 using System.Linq;
 using OpenRA.Activities;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {

--- a/OpenRA.Mods.Common/Traits/BlocksProjectiles.cs
+++ b/OpenRA.Mods.Common/Traits/BlocksProjectiles.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Linq;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {

--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -15,7 +15,6 @@ using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.AI;
 using OpenRA.Mods.Common.Pathfinder;
-using OpenRA.Support;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Buildings/BridgePlaceholder.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BridgePlaceholder.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -13,7 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Buildings/GivesBuildableArea.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/GivesBuildableArea.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {

--- a/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
@@ -12,7 +12,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/CaptureManager.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureManager.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.Common/Traits/CaptureProgressBar.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureProgressBar.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;

--- a/OpenRA.Mods.Common/Traits/CaptureProgressBlink.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureProgressBlink.cs
@@ -9,12 +9,9 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using OpenRA.Mods.Common.Effects;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Captures.cs
+++ b/OpenRA.Mods.Common/Traits/Captures.cs
@@ -11,7 +11,6 @@
 
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.Common/Traits/CarryableHarvester.cs
+++ b/OpenRA.Mods.Common/Traits/CarryableHarvester.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/CarryableHarvester.cs
+++ b/OpenRA.Mods.Common/Traits/CarryableHarvester.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/Traits/CashTrickler.cs
+++ b/OpenRA.Mods.Common/Traits/CashTrickler.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Linq;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/Conditions/ConditionManager.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ConditionManager.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Conditions/ExternalCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ExternalCondition.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -9,13 +9,10 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
-using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnFaction.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnFaction.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnJumpjetLayer.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnJumpjetLayer.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using OpenRA.Traits;
-
 namespace OpenRA.Mods.Common.Traits
 {
 	public class GrantConditionOnJumpjetLayerInfo : GrantConditionOnLayerInfo

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLayer.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLayer.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnMovement.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnMovement.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnProduction.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnProduction.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnSubterraneanLayer.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnSubterraneanLayer.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using OpenRA.Mods.Common.Effects;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnTunnelLayer.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnTunnelLayer.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using OpenRA.Traits;
-
 namespace OpenRA.Mods.Common.Traits
 {
 	public class GrantConditionOnTunnelLayerInfo : GrantConditionOnLayerInfo

--- a/OpenRA.Mods.Common/Traits/Conditions/PausableConditionalTrait.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/PausableConditionalTrait.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Conditions/ToggleConditionOnOrder.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ToggleConditionOnOrder.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Crates/GiveCashCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GiveCashCrateAction.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using OpenRA.Mods.Common.Effects;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {

--- a/OpenRA.Mods.Common/Traits/Crates/GrantExternalConditionCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GrantExternalConditionCrateAction.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Linq;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {

--- a/OpenRA.Mods.Common/Traits/CreatesShroud.cs
+++ b/OpenRA.Mods.Common/Traits/CreatesShroud.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Crushable.cs
+++ b/OpenRA.Mods.Common/Traits/Crushable.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/DeliversCash.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversCash.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Drawing;
 using OpenRA.Mods.Common.Activities;

--- a/OpenRA.Mods.Common/Traits/Demolishable.cs
+++ b/OpenRA.Mods.Common/Traits/Demolishable.cs
@@ -9,11 +9,8 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Effects;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Explodes.cs
+++ b/OpenRA.Mods.Common/Traits/Explodes.cs
@@ -9,10 +9,8 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.GameRules;
-using OpenRA.Mods.Common.Warheads;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/ExplosionOnDamageTransition.cs
+++ b/OpenRA.Mods.Common/Traits/ExplosionOnDamageTransition.cs
@@ -9,10 +9,8 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.GameRules;
-using OpenRA.Mods.Common.Warheads;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Primitives;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/GivesCashOnCapture.cs
+++ b/OpenRA.Mods.Common/Traits/GivesCashOnCapture.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Primitives;
 

--- a/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
@@ -11,7 +11,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Mods.Common.Warheads;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
@@ -1,4 +1,4 @@
- #region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
@@ -7,7 +7,7 @@
  * the License, or (at your option) any later version. For more
  * information, see COPYING.
  */
- #endregion
+#endregion
 
 using System.Collections.Generic;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
@@ -10,7 +10,6 @@
  #endregion
 
 using System.Collections.Generic;
-using OpenRA.Mods.Common.Warheads;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -15,7 +15,6 @@ using System.Drawing;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
-using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Pathfinder;
 using OpenRA.Primitives;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/Multipliers/GainsExperienceMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/GainsExperienceMultiplier.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using OpenRA.Traits;
-
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Modifies the experience gathered by this actor.")]

--- a/OpenRA.Mods.Common/Traits/Multipliers/GivesExperienceMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/GivesExperienceMultiplier.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using OpenRA.Traits;
-
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Modifies the experience given by this actor.")]

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/RotationPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/RotationPaletteEffect.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Linq;
-using OpenRA.Effects;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Player/PlayerExperience.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerExperience.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using System;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Pluggable.cs
+++ b/OpenRA.Mods.Common/Traits/Pluggable.cs
@@ -11,7 +11,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Drawing;
-using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Primitives;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Drawing;
-using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/ProximityCaptor.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCaptor.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
@@ -10,11 +10,8 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
-using OpenRA.Graphics;
 using OpenRA.Mods.Common.Effects;
-using OpenRA.Mods.Common.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Radar/AppearsOnRadar.cs
+++ b/OpenRA.Mods.Common/Traits/Radar/AppearsOnRadar.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;

--- a/OpenRA.Mods.Common/Traits/Radar/ProvidesRadar.cs
+++ b/OpenRA.Mods.Common/Traits/Radar/ProvidesRadar.cs
@@ -9,9 +9,6 @@
  */
 #endregion
 
-using System.Linq;
-using OpenRA.Traits;
-
 namespace OpenRA.Mods.Common.Traits.Radar
 {
 	[Desc("This actor enables the radar minimap.")]

--- a/OpenRA.Mods.Common/Traits/RejectsOrders.cs
+++ b/OpenRA.Mods.Common/Traits/RejectsOrders.cs
@@ -11,7 +11,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {

--- a/OpenRA.Mods.Common/Traits/ReloadAmmoPool.cs
+++ b/OpenRA.Mods.Common/Traits/ReloadAmmoPool.cs
@@ -3,8 +3,9 @@
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
- * as published by the Free Software Foundation. For more information,
- * see COPYING.
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
  */
 #endregion
 

--- a/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.Drawing;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Commands;
 using OpenRA.Mods.Common.Graphics;

--- a/OpenRA.Mods.Common/Traits/Render/ProductionBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/ProductionBar.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/Render/ReloadArmamentsBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/ReloadArmamentsBar.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingRepairDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingRepairDecoration.cs
@@ -9,11 +9,8 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Support;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render

--- a/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using OpenRA.Effects;
 using OpenRA.Graphics;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithFacingSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithFacingSpriteBody.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;

--- a/OpenRA.Mods.Common/Traits/Render/WithGateSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithGateSpriteBody.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;

--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;

--- a/OpenRA.Mods.Common/Traits/Render/WithNukeLaunchOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithNukeLaunchOverlay.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using OpenRA.Effects;
 using OpenRA.Graphics;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using OpenRA.Effects;
 using OpenRA.Graphics;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
@@ -10,10 +10,8 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.Graphics;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render

--- a/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBody.cs
@@ -12,7 +12,6 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/RevealOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/RevealOnDeath.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Primitives;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/RevealsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/RevealsShroud.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
+++ b/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -9,13 +9,9 @@
  */
 #endregion
 
-using System;
 using OpenRA.Effects;
 using OpenRA.GameRules;
-using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Effects;
-using OpenRA.Mods.Common.Traits.Render;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/Targetable.cs
+++ b/OpenRA.Mods.Common/Traits/Targetable.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/TransformOnCapture.cs
+++ b/OpenRA.Mods.Common/Traits/TransformOnCapture.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Primitives;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/TunnelEntrance.cs
+++ b/OpenRA.Mods.Common/Traits/TunnelEntrance.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Linq;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Wanders.cs
+++ b/OpenRA.Mods.Common/Traits/Wanders.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/World/ActorSpawnManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorSpawnManager.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.Common/Traits/World/CliffBackImpassabilityLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/CliffBackImpassabilityLayer.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
@@ -13,7 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
-using OpenRA.Network;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/World/ElevatedBridgePlaceholder.cs
+++ b/OpenRA.Mods.Common/Traits/World/ElevatedBridgePlaceholder.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/World/LobbyPrerequisiteCheckbox.cs
+++ b/OpenRA.Mods.Common/Traits/World/LobbyPrerequisiteCheckbox.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/World/MissionData.cs
+++ b/OpenRA.Mods.Common/Traits/World/MissionData.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -13,7 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using OpenRA.Graphics;
 using OpenRA.Mods.Common.Pathfinder;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/World/ResourceClaimLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceClaimLayer.cs
@@ -11,7 +11,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Graphics;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/World/ScriptLobbyDropdown.cs
+++ b/OpenRA.Mods.Common/Traits/World/ScriptLobbyDropdown.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/World/SubterraneanLocomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/SubterraneanLocomotor.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {

--- a/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
@@ -9,10 +9,7 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/AddNukeLaunchAnimation.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/AddNukeLaunchAnimation.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/CapturableChanges.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/CapturableChanges.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ChangeBuildableArea.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ChangeBuildableArea.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ChangeCanPowerDown.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ChangeCanPowerDown.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/DecoupleSelfReloading.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/DecoupleSelfReloading.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/DropPauseAnimationWhenDisabled.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/DropPauseAnimationWhenDisabled.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/LegacyBetaWarning.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/LegacyBetaWarning.cs
@@ -9,9 +9,7 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/MoveVisualBounds.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/MoveVisualBounds.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/RemoveIDisable.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/RemoveIDisable.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/RemoveMobileOnRails.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/RemoveMobileOnRails.cs
@@ -9,10 +9,8 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Mods.Common.UpdateRules;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/RemoveOutOfAmmo.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/RemoveOutOfAmmo.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/RemovePlayerPaletteTileset.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/RemovePlayerPaletteTileset.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/RenameWithTurreted.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/RenameWithTurreted.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ReplaceCanPowerDown.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ReplaceCanPowerDown.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ReplaceRequiresPower.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ReplaceRequiresPower.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ReworkCheckboxes.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ReworkCheckboxes.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ScaleDefaultModHealth.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ScaleDefaultModHealth.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ScaleModHealth.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ScaleModHealth.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ScaleModHealthBy10.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ScaleModHealthBy10.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ScaleModHealthBy100.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ScaleModHealthBy100.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ScaleSupportPowerSecondsToTicks.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ScaleSupportPowerSecondsToTicks.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ScaleSupportPowerSecondsToTicks.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/ScaleSupportPowerSecondsToTicks.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20171014/SplitGateFromBuilding.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20171014/SplitGateFromBuilding.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180307/DefineOwnerLostAction.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180307/DefineOwnerLostAction.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Linq;
 
 namespace OpenRA.Mods.Common.UpdateRules.Rules
 {

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180307/RemoveCanUndeployFromGrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180307/RemoveCanUndeployFromGrantConditionOnDeploy.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/AddBotOrderManager.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/AddBotOrderManager.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/AddCarryableHarvester.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/AddCarryableHarvester.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/AddCarryableHarvester.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/AddCarryableHarvester.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/AddHarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/AddHarvesterBotModule.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/CloakRequiresConditionToPause.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/CloakRequiresConditionToPause.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/DefineNotificationDefaults.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/DefineNotificationDefaults.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/MergeCaptureTraits.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/MergeCaptureTraits.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/RenameCrateActionNotification.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/RenameCrateActionNotification.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/RequireProductionType.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/RequireProductionType.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Mods.Common/UpdateRules/UpdateRule.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateRule.cs
@@ -9,9 +9,7 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace OpenRA.Mods.Common.UpdateRules
 {

--- a/OpenRA.Mods.Common/UtilityCommands/ConvertPngToShpCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ConvertPngToShpCommand.cs
@@ -12,10 +12,8 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using OpenRA.FileFormats;
 using OpenRA.Mods.Common.SpriteLoaders;
 

--- a/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
@@ -10,10 +10,6 @@
 #endregion
 
 using System;
-using System.Drawing;
-using System.IO;
-using System.Linq;
-using System.Reflection;
 using OpenRA.FileSystem;
 using OpenRA.Graphics;
 

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractMapRules.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractMapRules.cs
@@ -11,8 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using OpenRA.FileSystem;
 
 namespace OpenRA.Mods.Common.UtilityCommands

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractWeaponDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractWeaponDocsCommand.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using OpenRA.GameRules;

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractZeroBraneStudioLuaAPI.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractZeroBraneStudioLuaAPI.cs
@@ -13,7 +13,6 @@ using System;
 using System.Linq;
 using System.Reflection;
 using OpenRA.Scripting;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {

--- a/OpenRA.Mods.Common/UtilityCommands/ListInstallShieldCabContentsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ListInstallShieldCabContentsCommand.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using OpenRA.Mods.Common.FileFormats;

--- a/OpenRA.Mods.Common/UtilityCommands/ResizeMapCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ResizeMapCommand.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using OpenRA.FileSystem;
 
 namespace OpenRA.Mods.Common.UtilityCommands

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -11,7 +11,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.GameRules;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.Common/Warheads/Warhead.cs
+++ b/OpenRA.Mods.Common/Warheads/Warhead.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Drawing;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.Common/Widgets/ColorPreviewManagerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ColorPreviewManagerWidget.cs
@@ -7,7 +7,6 @@
  * the License, or (at your option) any later version. For more
  * information, see COPYING.
  */
-
 #endregion
 
 using OpenRA.Graphics;

--- a/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ConnectionLogic.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/CreditsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/CreditsLogic.cs
@@ -7,7 +7,6 @@
  * the License, or (at your option) any later version. For more
  * information, see COPYING.
  */
-
 #endregion
 
 using System;

--- a/OpenRA.Mods.Common/Widgets/Logic/DirectConnectLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/DirectConnectLogic.cs
@@ -3,8 +3,9 @@
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
- * as published by the Free Software Foundation. For more information,
- * see COPYING.
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
  */
 #endregion
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorTabsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorTabsLogic.cs
@@ -7,7 +7,6 @@
  * the License, or (at your option) any later version. For more
  * information, see COPYING.
  */
-
 #endregion
 
 using OpenRA.Graphics;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Widgets;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -12,7 +12,6 @@
 using System.Linq;
 using OpenRA.Mods.Common.Scripting;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/CycleStatusBarsHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/CycleStatusBarsHotkeyLogic.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.Graphics;
 using OpenRA.Mods.Common.Lint;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/PauseHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/PauseHotkeyLogic.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.Graphics;
 using OpenRA.Mods.Common.Lint;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/TogglePlayerStanceColorHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/TogglePlayerStanceColorHotkeyLogic.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.Graphics;
 using OpenRA.Mods.Common.Lint;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameCashCounterLogic.cs
@@ -10,9 +10,7 @@
 #endregion
 
 using System;
-using System.Linq;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -14,7 +14,6 @@ using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Scripting;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -17,7 +17,6 @@ using OpenRA.Graphics;
 using OpenRA.Mods.Common.Lint;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Network;
-using OpenRA.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ProductionTooltipLogic.cs
@@ -13,8 +13,6 @@ using System;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Support;
-using OpenRA.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/StanceSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/StanceSelectorLogic.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/InstallFromDiscLogic.cs
@@ -14,8 +14,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using OpenRA;
-using OpenRA.FileFormats;
 using OpenRA.Mods.Common.FileFormats;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentDiscTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/ModContentDiscTooltipLogic.cs
@@ -10,8 +10,6 @@
 #endregion
 
 using System;
-using System.IO;
-using System.Linq;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LatencyTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LatencyTooltipLogic.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using System;
-using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MapChooserLogic.cs
@@ -11,9 +11,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using OpenRA;
 using OpenRA.Primitives;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -11,13 +11,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Network;
-using OpenRA.Primitives;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System;
-using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Widgets;

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -7,7 +7,6 @@
  * the License, or (at your option) any later version. For more
  * information, see COPYING.
  */
-
 #endregion
 
 using System;

--- a/OpenRA.Mods.Common/Widgets/Logic/SingleHotkeyBaseLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SingleHotkeyBaseLogic.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.Mods.Common.Lint;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic

--- a/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
@@ -9,11 +9,9 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/WorldExtensions.cs
+++ b/OpenRA.Mods.Common/WorldExtensions.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;

--- a/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using OpenRA.Effects;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Render;

--- a/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
+++ b/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
@@ -11,14 +11,11 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Effects;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Render;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits

--- a/OpenRA.Mods.D2k/Warheads/DamagesConcreteWarhead.cs
+++ b/OpenRA.Mods.D2k/Warheads/DamagesConcreteWarhead.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Platforms.Default/DefaultPlatform.cs
+++ b/OpenRA.Platforms.Default/DefaultPlatform.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Drawing;
-using OpenRA;
 
 namespace OpenRA.Platforms.Default
 {

--- a/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
+++ b/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
@@ -9,9 +9,7 @@
  */
 #endregion
 
-using System;
 using System.Linq;
-using System.Text.RegularExpressions;
 using NUnit.Framework;
 using OpenRA.Traits;
 

--- a/OpenRA.Test/OpenRA.Game/CPosTest.cs
+++ b/OpenRA.Test/OpenRA.Game/CPosTest.cs
@@ -1,4 +1,15 @@
-﻿using NUnit.Framework;
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using NUnit.Framework;
 
 namespace OpenRA.Test
 {

--- a/OpenRA.Test/OpenRA.Game/CPosTest.cs
+++ b/OpenRA.Test/OpenRA.Game/CPosTest.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright & License Information
+#region Copyright & License Information
 /*
  * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made

--- a/OpenRA.Test/OpenRA.Game/CPosTest.cs
+++ b/OpenRA.Test/OpenRA.Game/CPosTest.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.Remoting.Metadata;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 namespace OpenRA.Test
 {

--- a/OpenRA.Test/OpenRA.Game/VariableExpressionTest.cs
+++ b/OpenRA.Test/OpenRA.Game/VariableExpressionTest.cs
@@ -9,10 +9,8 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using NUnit.Framework;
 using OpenRA.Support;
 


### PR DESCRIPTION
Just good old cleanup work... :smile: 

Step1: removing unused "using" imports. Not sure about performance impact here, its highly possible this makes no difference at all. But hey, its a cleanup :)

Step2: Unifying the copyright regions. Firstly some files where missions the copyright at all, which i added. Secondly i unified all the copyright blocks to be 1:1 the same across all files. Makes a replace way easier in the future if a change is needed (example: year change)

Step3: Bom removal. I found out that several files still contain an utf8 bom. I removed them for cleanup purposes :)