### PR TITLE
Implemented trait defined Rollovers.

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -286,6 +286,8 @@ namespace OpenRA.Traits
 	[RequireExplicitImplementation]
 	public interface ISelectionBar { float GetValue(); Color GetColor(); bool DisplayWhenEmpty { get; } }
 
+	public interface ISelectionDecorations { void DrawRollover(Actor self, WorldRenderer worldRenderer); }
+
 	public interface IOccupySpaceInfo : ITraitInfoInterface
 	{
 		IReadOnlyDictionary<CPos, SubCell> OccupiedCells(ActorInfo info, CPos location, SubCell subCell = SubCell.Any);

--- a/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public object Create(ActorInitializer init) { return new SelectionDecorations(init.Self, this); }
 	}
 
-	public class SelectionDecorations : IRenderAboveShroud, INotifyCreated, ITick
+	public class SelectionDecorations : ISelectionDecorations, IRenderAboveShroud, INotifyCreated, ITick
 	{
 		// depends on the order of pips in TraitsInterfaces.cs!
 		static readonly string[] PipStrings = { "pip-empty", "pip-green", "pip-yellow", "pip-red", "pip-gray", "pip-blue", "pip-ammo", "pip-ammoempty" };
@@ -119,6 +119,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			foreach (var r in DrawPips(self, bounds, wr))
 				yield return r;
+		}
+
+		public void DrawRollover(Actor self, WorldRenderer worldRenderer)
+		{
+			var bounds = decorationBounds.FirstNonEmptyBounds(self, worldRenderer);
+			new SelectionBarsRenderable(self, bounds, true, true).Render(worldRenderer);
 		}
 
 		IEnumerable<IRenderable> DrawPips(Actor self, Rectangle bounds, WorldRenderer wr)

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -14,7 +14,6 @@ using System.Drawing;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Effects;
-using OpenRA.Mods.Common.Graphics;
 using OpenRA.Orders;
 using OpenRA.Traits;
 using OpenRA.Widgets;
@@ -48,12 +47,11 @@ namespace OpenRA.Mods.Common.Widgets
 
 		void DrawRollover(Actor unit)
 		{
-			// TODO: Integrate this with SelectionDecorations to unhardcode the *Renderable
-			if (unit.Info.HasTraitInfo<SelectableInfo>())
-			{
-				var bounds = unit.TraitsImplementing<IDecorationBounds>().FirstNonEmptyBounds(unit, worldRenderer);
-				new SelectionBarsRenderable(unit, bounds, true, true).Render(worldRenderer);
-			}
+			var selectionDecorations = unit.TraitOrDefault<ISelectionDecorations>();
+			if (selectionDecorations == null)
+				return;
+
+			selectionDecorations.DrawRollover(unit, worldRenderer);
 		}
 
 		public override void Draw()


### PR DESCRIPTION
This implements a long open TODO in the openra code, which allows mods to define their own statusbar to use when hovering actors.