### PR TITLE
Check for null in Turreted.StopAiming

### DIFF
--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void StopAiming(Actor self)
 		{
-			if (attack.IsAiming)
+			if (attack != null && attack.IsAiming)
 				attack.OnStopOrder(self);
 		}
 


### PR DESCRIPTION
Very simple. Just checks if attack is null in Turreted.StopAiming

Fixes #15804.