### PR TITLE
Check for player trait prereqs in ProximityCapturable

### DIFF
--- a/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
@@ -21,13 +21,13 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Actor can be captured by units in a specified proximity.")]
-	public class ProximityCapturableInfo : ITraitInfo
+	public class ProximityCapturableInfo : ITraitInfo, IRulesetLoaded
 	{
 		[Desc("Maximum range at which a ProximityCaptor actor can initiate the capture.")]
 		public readonly WDist Range = WDist.FromCells(5);
 
 		[Desc("Allowed ProximityCaptor actors to capture this actor.")]
-		public readonly BitSet<CaptureType> CaptorTypes = new BitSet<CaptureType>("Vehicle", "Tank", "Infantry");
+		public readonly BitSet<CaptureType> CaptorTypes = new BitSet<CaptureType>("Player", "Vehicle", "Tank", "Infantry");
 
 		[Desc("If set, the capturing process stops immediately after another player comes into Range.")]
 		public readonly bool MustBeClear = false;
@@ -38,6 +38,13 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("If set, the actor can only be captured via this logic once.",
 			"This option implies the `Sticky` behaviour as well.")]
 		public readonly bool Permanent = false;
+
+		public void RulesetLoaded(Ruleset rules, ActorInfo info)
+		{
+			var pci = rules.Actors["player"].TraitInfoOrDefault<ProximityCaptorInfo>();
+			if (pci == null)
+				throw new YamlException("ProximityCapturable requires the `Player` actor to have the ProximityCaptor trait.");
+		}
 
 		public object Create(ActorInitializer init) { return new ProximityCapturable(init.Self, this); }
 	}


### PR DESCRIPTION
`ProximityCapturable.ChangeOwner()` is called a few times with a PlayerActor as argument, which causes `pc` to be null [here](https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Traits/ProximityCapturable.cs#L188) when `Player` does not have the `ProximityCaptor` trait. This adds a lint check which will recognize this condition.