### PR TITLE
Add `critical-idle` sequence to RA refinery

### DIFF
--- a/mods/ra/sequences/structures.yaml
+++ b/mods/ra/sequences/structures.yaml
@@ -82,7 +82,8 @@ fact:
 proc:
 	idle:
 		ZOffset: -1c511
-	damaged-idle:
+	critical-idle:
+		Start: 1
 		ZOffset: -1c511
 	idle-top: proctop
 		ZOffset: 0


### PR DESCRIPTION
There is an unused sequence for the refinery in RA. It was used for `damaged-idle` but was removed in #7741. I don't know if that was intenional but in my opinion it's a nice sequence for the `critical-idle` state. 

I've added it and also removed `damaged-idle` as it is the same as `idle`. Here is how it looks in-game (the damaged state comes from `proctop`):

![ra-proc-idle-damaged-critical-sequences](https://user-images.githubusercontent.com/1355810/48543693-bc994800-e8ca-11e8-90f3-1466895756ba.png)
