### PR TITLE
Fix `damaged-idle` sequence of RA refinery

### DIFF
--- a/mods/ra/sequences/structures.yaml
+++ b/mods/ra/sequences/structures.yaml
@@ -83,6 +83,7 @@ proc:
 	idle:
 		ZOffset: -1c511
 	damaged-idle:
+		Start: 1
 		ZOffset: -1c511
 	idle-top: proctop
 		ZOffset: 0


### PR DESCRIPTION
Add back the proper `damaged-idle` sequence of RA refinery.

Supersedes #15819 