### PR TITLE
Fix Repairable crash

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -717,9 +717,9 @@ namespace OpenRA.Mods.Common.Traits
 				else
 					self.QueueActivity(order.Queued, new HeliFlyAndLandWhenIdle(self, target, Info));
 			}
-			else if (order.OrderString == "Enter")
+			else if (order.OrderString == "Enter" || order.OrderString == "Repair")
 			{
-				// Enter orders are only valid for own/allied actors,
+				// Enter and Repair orders are only valid for own/allied actors,
 				// which are guaranteed to never be frozen.
 				if (order.Target.Type != TargetType.Actor)
 					return;

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -101,6 +101,10 @@ namespace OpenRA.Mods.Common.Traits
 				if (order.Target.Type != TargetType.Actor)
 					return;
 
+				// Aircraft handle Repair orders directly in the Aircraft trait
+				if (self.Info.HasTraitInfo<AircraftInfo>())
+					return;
+
 				if (!CanRepairAt(order.Target.Actor) || (!CanRepair() && !CanRearm()))
 					return;
 

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -108,7 +108,7 @@ namespace OpenRA.Mods.Common.Traits
 					self.CancelActivity();
 
 				self.SetTargetLine(order.Target, Color.Green);
-				self.QueueActivity(new WaitForTransport(self, ActivityUtils.SequenceActivities(new MoveAdjacentTo(self, order.Target),
+				self.QueueActivity(new WaitForTransport(self, ActivityUtils.SequenceActivities(movement.MoveToTarget(self, order.Target),
 					new CallFunc(() => AfterReachActivities(self, order, movement)))));
 
 				TryCallTransport(self, order.Target, new CallFunc(() => AfterReachActivities(self, order, movement)));


### PR DESCRIPTION
`MoveAdjacentTo` is a `Mobile`-only activity, and `Repairable.AfterReachActivities` was generally written with ground actors in mind.
Reusing the "Enter" logic in `Aircraft` is both simpler and safer (regarding regression risk) than trying to adapt `Repairable`.

Fixes #15820.
Closes #13975.