### PR TITLE
Add selection modes - "Select All" and "Select Low Priority"

### DIFF
--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -22,14 +22,14 @@ namespace OpenRA.Orders
 		{
 			var actor = world.ScreenMap.ActorsAtMouse(mi)
 				.Where(a => !a.Actor.IsDead && a.Actor.Info.HasTraitInfo<ITargetableInfo>() && !world.FogObscures(a.Actor))
-				.WithHighestSelectionPriority(worldPixel);
+				.WithHighestSelectionPriority(worldPixel, mi.Modifiers);
 
 			if (actor != null)
 				return Target.FromActor(actor);
 
 			var frozen = world.ScreenMap.FrozenActorsAtMouse(world.RenderPlayer, mi)
 				.Where(a => a.Info.HasTraitInfo<ITargetableInfo>() && a.Visible && a.HasRenderables)
-				.WithHighestSelectionPriority(worldPixel);
+				.WithHighestSelectionPriority(worldPixel, mi.Modifiers);
 
 			if (frozen != null)
 				return Target.FromFrozenActor(frozen);
@@ -93,7 +93,7 @@ namespace OpenRA.Orders
 		{
 			var actor = world.ScreenMap.ActorsAtMouse(xy)
 				.Where(a => !a.Actor.IsDead)
-				.WithHighestSelectionPriority(xy);
+				.WithHighestSelectionPriority(xy, mi.Modifiers);
 
 			if (actor == null)
 				return true;
@@ -103,7 +103,7 @@ namespace OpenRA.Orders
 			var actorsAt = world.ActorMap.GetActorsAt(cell).ToList();
 			var underCursor = world.Selection.Actors
 				.Select(a => new ActorBoundsPair(a, a.MouseBounds(wr)))
-				.WithHighestSelectionPriority(xy);
+				.WithHighestSelectionPriority(xy, mi.Modifiers);
 
 			var o = OrderForUnit(underCursor, target, actorsAt, cell, mi);
 			if (o != null)

--- a/OpenRA.Game/Traits/Selectable.cs
+++ b/OpenRA.Game/Traits/Selectable.cs
@@ -9,12 +9,28 @@
  */
 #endregion
 
+using System;
+
 namespace OpenRA.Traits
 {
-	[Desc("This actor is selectable. Defines bounds of selectable area, selection class and selection priority.")]
+	[Flags]
+	public enum SelectionPriorityModifiers
+	{
+		None = 0,
+		Ctrl = 1,
+		Alt = 2
+	}
+
+	[Desc("This actor is selectable. Defines bounds of selectable area, selection class, selection priority and selection priority modifiers.")]
 	public class SelectableInfo : InteractableInfo
 	{
 		public readonly int Priority = 10;
+
+		[Desc("Allow selection priority to be modified using a hotkey.",
+			"Valid values are None (priority is not affected by modifiers)",
+			"Ctrl (priority is raised when Ctrl pressed) and",
+			"Alt (priority is raised when Alt pressed).")]
+		public readonly SelectionPriorityModifiers PriorityModifiers = SelectionPriorityModifiers.None;
 
 		[Desc("All units having the same selection class specified will be selected with select-by-type commands (e.g. double-click). "
 		+ "Defaults to the actor name when not defined or inherited.")]

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -218,6 +218,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			TooltipType = WorldTooltipType.None;
 			ActorTooltipExtra = null;
+			var modifiers = Game.GetModifierKeys();
 			var cell = worldRenderer.Viewport.ViewToWorld(Viewport.LastMousePos);
 			if (!world.Map.Contains(cell))
 				return;
@@ -231,7 +232,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var worldPixel = worldRenderer.Viewport.ViewToWorldPx(Viewport.LastMousePos);
 			var underCursor = world.ScreenMap.ActorsAtMouse(worldPixel)
 				.Where(a => a.Actor.Info.HasTraitInfo<ITooltipInfo>() && !world.FogObscures(a.Actor))
-				.WithHighestSelectionPriority(worldPixel);
+				.WithHighestSelectionPriority(worldPixel, modifiers);
 
 			if (underCursor != null)
 			{
@@ -247,7 +248,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var frozen = world.ScreenMap.FrozenActorsAtMouse(world.RenderPlayer, worldPixel)
 				.Where(a => a.TooltipInfo != null && a.IsValid && a.Visible && !a.Hidden)
-				.WithHighestSelectionPriority(worldPixel);
+				.WithHighestSelectionPriority(worldPixel, modifiers);
 
 			if (frozen != null)
 			{

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -242,9 +242,18 @@
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical
 
+^FlatSelectionMode:
+	Selectable:
+		PriorityModifiers: Ctrl
+
+^LowPrioritySelectionMode:
+	Selectable:
+		PriorityModifiers: Ctrl, Alt
+
 ^Vehicle:
 	Inherits@1: ^ExistsInWorld
 	Inherits@3: ^SpriteActor
+	Inherits@SELECTION_MODE: ^FlatSelectionMode
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -294,6 +303,7 @@
 ^Helicopter:
 	Inherits@1: ^ExistsInWorld
 	Inherits@3: ^SpriteActor
+	Inherits@SELECTION_MODE: ^FlatSelectionMode
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -351,6 +361,7 @@
 ^Infantry:
 	Inherits@1: ^ExistsInWorld
 	Inherits@3: ^SpriteActor
+	Inherits@SELECTION_MODE: ^FlatSelectionMode
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -517,6 +528,7 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	Inherits@SELECTION_MODE: ^FlatSelectionMode
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -573,6 +585,7 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
+	Inherits@SELECTION_MODE: ^FlatSelectionMode
 	Huntable:
 	Health:
 		HP: 30000
@@ -629,6 +642,7 @@
 ^Plane:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
+	Inherits@SELECTION_MODE: ^FlatSelectionMode
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -653,6 +667,7 @@
 ^Ship:
 	Inherits@1: ^ExistsInWorld
 	Inherits@3: ^SpriteActor
+	Inherits@SELECTION_MODE: ^FlatSelectionMode
 	Huntable:
 	OwnerLostAction:
 		Action: Kill

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -162,6 +162,7 @@ E5:
 
 E6:
 	Inherits: ^Soldier
+	Inherits@SELECTION_MODE: ^LowPrioritySelectionMode
 	Valued:
 		Cost: 500
 	Tooltip:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -1,5 +1,6 @@
 MCV:
 	Inherits: ^Vehicle
+	Inherits@SELECTION_MODE: ^LowPrioritySelectionMode
 	Valued:
 		Cost: 3500
 	Tooltip:
@@ -43,6 +44,7 @@ MCV:
 HARV:
 	Inherits: ^Tank
 	Inherits@CLOAK: ^AcceptsCloakCrate
+	Inherits@SELECTION_MODE: ^LowPrioritySelectionMode
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -681,6 +683,7 @@ MHQ:
 
 TRUCK:
 	Inherits: ^Vehicle
+	Inherits@SELECTION_MODE: ^LowPrioritySelectionMode
 	Buildable:
 		Queue: Vehicle.GDI, Vehicle.Nod
 		BuildPaletteOrder: 35

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -163,9 +163,18 @@
 	AttackMove:
 		AssaultMoveCondition: assault-move
 
+^FlatSelectionMode:
+	Selectable:
+		PriorityModifiers: Ctrl
+
+^LowPrioritySelectionMode:
+	Selectable:
+		PriorityModifiers: Ctrl, Alt
+
 ^Vehicle:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
+	Inherits@SELECTION_MODE: ^FlatSelectionMode
 	Tooltip:
 		GenericName: Unit
 	Huntable:
@@ -269,6 +278,7 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^GainsExperience
 	Inherits@3: ^SpriteActor
+	Inherits@SELECTION_MODE: ^FlatSelectionMode
 	Tooltip:
 		GenericName: Unit
 	Huntable:

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -1,5 +1,6 @@
 mcv:
 	Inherits: ^Tank
+	Inherits@SELECTION_MODE: ^LowPrioritySelectionMode
 	Buildable:
 		Prerequisites: repair_pad, upgrade.heavy, ~techlevel.medium
 		Queue: Armor
@@ -50,6 +51,7 @@ mcv:
 
 harvester:
 	Inherits: ^Tank
+	Inherits@SELECTION_MODE: ^LowPrioritySelectionMode
 	Buildable:
 		Queue: Armor
 		Prerequisites: refinery

--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -138,6 +138,7 @@ OILB:
 
 MOBILETENT:
 	Inherits: ^Vehicle
+	Inherits@SELECTION_MODE: ^LowPrioritySelectionMode
 	Valued:
 		Cost: 2000
 	Tooltip:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -231,11 +231,20 @@
 	GivesBounty:
 		RequiresCondition: global-bounty
 
+^FlatSelectionMode:
+	Selectable:
+		PriorityModifiers: Ctrl
+
+^LowPrioritySelectionMode:
+	Selectable:
+		PriorityModifiers: Ctrl, Alt
+
 ^Vehicle:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^IronCurtainable
 	Inherits@3: ^SpriteActor
 	Inherits@bounty: ^GlobalBounty
+	Inherits@SELECTION_MODE: ^FlatSelectionMode
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -319,6 +328,7 @@
 	Inherits@3: ^InfantryExperienceHospitalOverrides
 	Inherits@4: ^SpriteActor
 	Inherits@bounty: ^GlobalBounty
+	Inherits@SELECTION_MODE: ^FlatSelectionMode
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -488,6 +498,7 @@
 	Inherits@3: ^IronCurtainable
 	Inherits@4: ^SpriteActor
 	Inherits@bounty: ^GlobalBounty
+	Inherits@SELECTION_MODE: ^FlatSelectionMode
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -540,6 +551,7 @@
 	Inherits@3: ^IronCurtainable
 	Inherits@4: ^SpriteActor
 	Inherits@bounty: ^GlobalBounty
+	Inherits@SELECTION_MODE: ^FlatSelectionMode
 	Huntable:
 	OwnerLostAction:
 		Action: Kill

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -244,6 +244,7 @@ E4:
 
 E6:
 	Inherits: ^Soldier
+	Inherits@SELECTION_MODE: ^LowPrioritySelectionMode
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -289,6 +289,7 @@ ARTY:
 
 HARV:
 	Inherits: ^Vehicle
+	Inherits@SELECTION_MODE: ^LowPrioritySelectionMode
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 10
@@ -342,6 +343,7 @@ HARV:
 
 MCV:
 	Inherits: ^Vehicle
+	Inherits@SELECTION_MODE: ^LowPrioritySelectionMode
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 90
@@ -468,6 +470,7 @@ APC:
 
 MNLY:
 	Inherits: ^TrackedVehicle
+	Inherits@SELECTION_MODE: ^LowPrioritySelectionMode
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 100
@@ -511,6 +514,7 @@ MNLY:
 
 TRUK:
 	Inherits: ^Vehicle
+	Inherits@SELECTION_MODE: ^LowPrioritySelectionMode
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 20

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -179,6 +179,14 @@
 	AttackMove:
 		AssaultMoveCondition: assault-move
 
+^FlatSelectionMode:
+	Selectable:
+		PriorityModifiers: Ctrl
+
+^LowPrioritySelectionMode:
+	Selectable:
+		PriorityModifiers: Ctrl, Alt
+
 ^2x1Shape:
 	HitShape:
 		Type: Rectangle
@@ -536,6 +544,7 @@
 	Inherits@3: ^SpriteActor
 	Inherits@4: ^Cloakable
 	Inherits@CRATESTATS: ^CrateStatModifiers
+	Inherits@SELECTION_MODE: ^FlatSelectionMode
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -738,6 +747,7 @@
 	Inherits@4: ^Cloakable
 	Inherits@5: ^DamagedByVeins
 	Inherits@CRATESTATS: ^CrateStatModifiers
+	Inherits@SELECTION_MODE: ^FlatSelectionMode
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -839,6 +849,7 @@
 ^Aircraft:
 	Inherits@2: ^ExistsInWorld
 	Inherits@3: ^Cloakable
+	Inherits@SELECTION_MODE: ^FlatSelectionMode
 	Huntable:
 	OwnerLostAction:
 		Action: Kill
@@ -931,6 +942,7 @@
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
 	Inherits@3: ^HealsOnTiberium
+	Inherits@SELECTION_MODE: ^FlatSelectionMode
 	Huntable:
 	DrawLineToTarget:
 	Health:
@@ -1082,6 +1094,7 @@
 	Inherits@1: ^EmpDisable
 	Inherits@2: ^ExistsInWorld
 	Inherits@3: ^Cloakable
+	Inherits@SELECTION_MODE: ^FlatSelectionMode
 	Huntable:
 	RenderVoxels:
 	RenderSprites:

--- a/mods/ts/rules/shared-infantry.yaml
+++ b/mods/ts/rules/shared-infantry.yaml
@@ -40,6 +40,7 @@ E1:
 
 ENGINEER:
 	Inherits: ^Soldier
+	Inherits@SELECTION_MODE: ^LowPrioritySelectionMode
 	Valued:
 		Cost: 500
 	Tooltip:

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -1,6 +1,7 @@
 MCV:
 	Inherits: ^Tank
 	Inherits@VOXELS: ^VoxelActor
+	Inherits@SELECTION_MODE: ^LowPrioritySelectionMode
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 160
@@ -45,6 +46,7 @@ MCV:
 HARV:
 	Inherits: ^Tank
 	Inherits@VOXELS: ^VoxelActor
+	Inherits@SELECTION_MODE: ^LowPrioritySelectionMode
 	Valued:
 		Cost: 1400
 	Tooltip:


### PR DESCRIPTION
This is a proposed implementation of the modifiers discussed in #14694. It adds two modes that alter the priority calculation. The modes are activated by holding down modifiers keys when selecting by mouse dragging.

~~Two new fields are added to the `Selectable` trait:~~
~~- `IncludeInSelectAllMode = true`~~
~~- `IncludeInSelectLowPriorityMode = false`~~

One new field is added to `Selectable`:
- `PriorityModifiers` with valid values `None` (default), `Ctrl` and `Alt`

Using the new field I have impleted two selection modes as YAML templates. This is how they work:
- **Flat Mode:** holding down <kbd>Ctrl</kbd> selects all actors that inherit `^FlatSelectionMode`. Buildings are not included but would still be selected if there are no higher priority actors. 
_Example use case_: Retreating all of your units (combat and non-combat).
_Example use case_: Moving together a mixed group of units (combat and non-combat).
- **Low Priority Mode:** holding down <kbd>Alt</kbd> selects all actors that inherit `^LowPrioritySelectionMode`. This is added to all non-combat units.
_Example use case_: Retreating non-combat units (harvesters or engies for example).
_Example use case_: Selecting low priority units among blobs (engies, harvesters, MCV).

![изображение](https://user-images.githubusercontent.com/1355810/57387167-7f997880-71be-11e9-93df-c9262cd12fc9.png)

Remarks:
- I was thinking about adding a third modifier - <kbd>Ctrl</kbd> + <kbd>Alt</kbd> but decided that this is good enough for now
- This can be used by modders to set up their own selection modes ("Aircraft Mode" for example)
- It doesn't work with hotkey selection (hotkeys with modifiers are considered a different hotkey).
- Possible hotkey implementation will conflict with the default bindings for bookmarks (<kbd>Ctrl</kbd>+<kbd>q</kbd> and <kbd>Alt</kbd>+<kbd>q</kbd>).
- The selection modes are not exposed in any way in the UI. This should be addressed in another PR.