### PR TITLE
Label next item in production queue

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ParallelProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ParallelProductionQueue.cs
@@ -50,6 +50,11 @@ namespace OpenRA.Mods.Common.Traits
 			return Queue.Contains(item);
 		}
 
+		public override bool IsNextInQueue(ProductionItem item)
+		{
+			return false;
+		}
+
 		protected override void BeginProduction(ProductionItem item, bool hasPriority)
 		{
 			// Ignore `hasPriority` as it's not relevant in parallel production context.

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -232,6 +232,11 @@ namespace OpenRA.Mods.Common.Traits
 			return Queue.Count > 0 && Queue[0] == item;
 		}
 
+		public virtual bool IsNextInQueue(ProductionItem item)
+		{
+			return Queue.Count > 1 && Queue[1] == item;
+		}
+
 		public virtual IEnumerable<ProductionItem> AllQueued()
 		{
 			return Queue;

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -68,6 +68,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		[Translate] public readonly string ReadyText = "";
 		[Translate] public readonly string HoldText = "";
+		[Translate] public readonly string NextText = "";
 		[Translate] public readonly string InfiniteSymbol = "\u221E";
 
 		public int DisplayedIconCount { get; private set; }
@@ -104,7 +105,7 @@ namespace OpenRA.Mods.Common.Widgets
 		readonly WorldRenderer worldRenderer;
 
 		SpriteFont overlayFont, symbolFont;
-		float2 holdOffset, readyOffset, timeOffset, queuedOffset, infiniteOffset;
+		float2 nextOffset, holdOffset, readyOffset, timeOffset, queuedOffset, infiniteOffset;
 
 		[CustomLintableHotkeyNames]
 		public static IEnumerable<string> LinterHotkeyNames(MiniYamlNode widgetNode, Action<string> emitError, Action<string> emitWarning)
@@ -432,6 +433,7 @@ namespace OpenRA.Mods.Common.Widgets
 			timeOffset = iconOffset - overlayFont.Measure(WidgetUtils.FormatTime(0, World.Timestep)) / 2;
 			queuedOffset = new float2(4, 2);
 			holdOffset = iconOffset - overlayFont.Measure(HoldText) / 2;
+			nextOffset = iconOffset - overlayFont.Measure(NextText) / 2;
 			readyOffset = iconOffset - overlayFont.Measure(ReadyText) / 2;
 
 			if (ChromeMetrics.TryGet("InfiniteOffset", out infiniteOffset))
@@ -478,6 +480,7 @@ namespace OpenRA.Mods.Common.Widgets
 				if (total > 0)
 				{
 					var first = icon.Queued[0];
+					var isNext = CurrentQueue.IsNextInQueue(first);
 					var waiting = !CurrentQueue.IsProducing(first) && !first.Done;
 					if (first.Done)
 					{
@@ -502,6 +505,11 @@ namespace OpenRA.Mods.Common.Widgets
 					else if (total > 1 || waiting)
 						overlayFont.DrawTextWithContrast(total.ToString(),
 							icon.Pos + queuedOffset,
+							Color.White, Color.Black, 1);
+
+					if (isNext)
+						overlayFont.DrawTextWithContrast(NextText,
+							icon.Pos + nextOffset,
 							Color.White, Color.Black, 1);
 				}
 			}

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -752,6 +752,7 @@ Container@PLAYER_WIDGETS:
 			TooltipContainer: TOOLTIP_CONTAINER
 			ReadyText: Ready
 			HoldText: On Hold
+			NextText: Next
 			HotkeyPrefix: Production
 			HotkeyCount: 24
 		ProductionTabs@PRODUCTION_TABS:

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -481,6 +481,7 @@ Container@PLAYER_WIDGETS:
 					TooltipContainer: TOOLTIP_CONTAINER
 					ReadyText: READY
 					HoldText: ON HOLD
+					NextText: NEXT
 					IconSize: 58, 48
 					IconMargin: 2, 0
 					IconSpriteOffset: 0, 0

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -472,6 +472,7 @@ Container@PLAYER_WIDGETS:
 					TooltipContainer: TOOLTIP_CONTAINER
 					ReadyText: READY
 					HoldText: ON HOLD
+					NextText: NEXT
 					IconSize: 62, 46
 					IconMargin: 1, 1
 					IconSpriteOffset: -1, -1

--- a/mods/ts/chrome/ingame-player.yaml
+++ b/mods/ts/chrome/ingame-player.yaml
@@ -481,6 +481,7 @@ Container@PLAYER_WIDGETS:
 					TooltipContainer: TOOLTIP_CONTAINER
 					ReadyText: READY
 					HoldText: ON HOLD
+					NextText: NEXT
 					ClockPalette: iconclock
 					NotBuildableAnimation: darken
 					NotBuildablePalette: chromewithshadow


### PR DESCRIPTION
The CNC production tabs are a good piece of UI but they have one major flaw -- the queue is not presented as a sequence. This is an attempt at alleviating this problem a bit by adding a "Next" label to the next item in the queue. The label is visible only if the next item if of a different type.

Here are screenshots from all default mods:
![openra-label-next-production-queue-item](https://user-images.githubusercontent.com/1355810/48796171-9549dd00-ed07-11e8-9f35-1ea9291229e4.png)

Remarks:
* An alternative implementation that I considered was adding the label next to the quantity, possibly as an icon glyph. That way items of the same type can also be labeled.

Your comments are very much welcome!
