### PR TITLE
Use OnBecomingIdle to trigger idle actions on aircraft

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -37,14 +37,15 @@ namespace OpenRA.Mods.Common.Activities
 			this.minRange = minRange;
 		}
 
-		public static void FlyToward(Actor self, Aircraft aircraft, int desiredFacing, WDist desiredAltitude)
+		public static void FlyToward(Actor self, Aircraft aircraft, int desiredFacing, WDist desiredAltitude, int turnSpeedOverride = -1)
 		{
 			desiredAltitude = new WDist(aircraft.CenterPosition.Z) + desiredAltitude - self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition);
 
 			var move = aircraft.FlyStep(aircraft.Facing);
 			var altitude = aircraft.CenterPosition.Z;
 
-			aircraft.Facing = Util.TickFacing(aircraft.Facing, desiredFacing, aircraft.TurnSpeed);
+			var turnSpeed = turnSpeedOverride > -1 ? turnSpeedOverride : aircraft.TurnSpeed;
+			aircraft.Facing = Util.TickFacing(aircraft.Facing, desiredFacing, turnSpeed);
 
 			if (altitude != desiredAltitude.Length)
 			{

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -104,26 +104,4 @@ namespace OpenRA.Mods.Common.Activities
 			yield return target;
 		}
 	}
-
-	public class FlyAndContinueWithCirclesWhenIdle : Fly
-	{
-		public FlyAndContinueWithCirclesWhenIdle(Actor self, Target t)
-			: base(self, t) { }
-
-		public FlyAndContinueWithCirclesWhenIdle(Actor self, Target t, WDist minRange, WDist maxRange)
-			: base(self, t, minRange, maxRange) { }
-
-		public override Activity Tick(Actor self)
-		{
-			var activity = base.Tick(self);
-
-			if (activity == null && !IsCanceled)
-			{
-				self.QueueActivity(new FlyCircle(self));
-				activity = NextActivity;
-			}
-
-			return activity;
-		}
-	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/FlyCircle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyCircle.cs
@@ -17,14 +17,14 @@ namespace OpenRA.Mods.Common.Activities
 	public class FlyCircle : Activity
 	{
 		readonly Aircraft aircraft;
-		readonly WDist cruiseAltitude;
+		readonly int turnSpeedOverride;
 		int remainingTicks;
 
-		public FlyCircle(Actor self, int ticks = -1)
+		public FlyCircle(Actor self, int ticks = -1, int turnSpeedOverride = -1)
 		{
 			aircraft = self.Trait<Aircraft>();
-			cruiseAltitude = aircraft.Info.CruiseAltitude;
 			remainingTicks = ticks;
+			this.turnSpeedOverride = turnSpeedOverride;
 		}
 
 		public override Activity Tick(Actor self)
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// We can't possibly turn this fast
 			var desiredFacing = aircraft.Facing + 64;
-			Fly.FlyToward(self, aircraft, desiredFacing, cruiseAltitude);
+			Fly.FlyToward(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, turnSpeedOverride);
 
 			return this;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/HeliFlyCircle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliFlyCircle.cs
@@ -17,10 +17,12 @@ namespace OpenRA.Mods.Common.Activities
 	public class HeliFlyCircle : Activity
 	{
 		readonly Aircraft aircraft;
+		readonly int turnSpeedOverride;
 
-		public HeliFlyCircle(Actor self)
+		public HeliFlyCircle(Actor self, int turnSpeedOverride = -1)
 		{
 			aircraft = self.Trait<Aircraft>();
+			this.turnSpeedOverride = turnSpeedOverride;
 		}
 
 		public override Activity Tick(Actor self)
@@ -42,7 +44,8 @@ namespace OpenRA.Mods.Common.Activities
 			aircraft.SetPosition(self, aircraft.CenterPosition + move);
 
 			var desiredFacing = aircraft.Facing + 64;
-			aircraft.Facing = Util.TickFacing(aircraft.Facing, desiredFacing, aircraft.TurnSpeed / 3);
+			var turnSpeed = turnSpeedOverride > -1 ? turnSpeedOverride : aircraft.TurnSpeed;
+			aircraft.Facing = Util.TickFacing(aircraft.Facing, desiredFacing, turnSpeed);
 
 			return this;
 		}

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -942,6 +942,7 @@
     <Compile Include="UpdateRules\Rules\20180923\MergeAttackPlaneAndHeli.cs" />
     <Compile Include="UpdateRules\Rules\20180923\ExtractHackyAIModules.cs" />
     <Compile Include="UpdateRules\Rules\20180923\DefineLevelUpImageDefault.cs" />
+    <Compile Include="UpdateRules\Rules\20180923\RemovedAutoCarryallCircleTurnSpeed.cs" />
     <Compile Include="Traits\Player\PlayerResources.cs" />
     <Compile Include="UtilityCommands\DumpSequenceSheetsCommand.cs" />
     <Compile Include="Traits\Render\WithBuildingRepairDecoration.cs" />

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -150,7 +150,8 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public class Aircraft : ITick, ISync, IFacing, IPositionable, IMove, IIssueOrder, IResolveOrder, IOrderVoice, IDeathActorInitModifier,
-		INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyActorDisposing, IActorPreviewInitModifier, IIssueDeployOrder, IObservesVariables
+		INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyActorDisposing, INotifyBecomingIdle,
+		IActorPreviewInitModifier, IIssueDeployOrder, IObservesVariables
 	{
 		static readonly Pair<CPos, SubCell>[] NoCells = { };
 
@@ -505,6 +506,29 @@ namespace OpenRA.Mods.Common.Traits
 			init.Add(new FacingInit(Facing));
 		}
 
+		void INotifyBecomingIdle.OnBecomingIdle(Actor self)
+		{
+			OnBecomingIdle(self);
+		}
+
+		protected virtual void OnBecomingIdle(Actor self)
+		{
+			if (Info.VTOL && Info.LandWhenIdle)
+			{
+				if (Info.TurnToLand)
+					self.QueueActivity(new Turn(self, Info.InitialFacing));
+
+				self.QueueActivity(new HeliLand(self, true));
+			}
+			else if (!Info.CanHover)
+				self.QueueActivity(new FlyCircle(self, -1, Info.IdleTurnSpeed > -1 ? Info.IdleTurnSpeed : TurnSpeed));
+
+			// Temporary HACK for the AutoCarryall special case (needs CanHover, but also HeliFlyCircle on idle).
+			// Will go away soon (in a separate PR) with the arrival of ActionsWhenIdle.
+			else if (Info.CanHover && self.Info.HasTraitInfo<AutoCarryallInfo>() && Info.IdleTurnSpeed > -1)
+				self.QueueActivity(new HeliFlyCircle(self, Info.IdleTurnSpeed > -1 ? Info.IdleTurnSpeed : TurnSpeed));
+		}
+
 		#region Implement IPositionable
 
 		public bool CanExistInCell(CPos cell) { return true; }
@@ -554,7 +578,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Activity MoveTo(CPos cell, int nearEnough)
 		{
 			if (!Info.CanHover)
-				return new FlyAndContinueWithCirclesWhenIdle(self, Target.FromCell(self.World, cell));
+				return new Fly(self, Target.FromCell(self.World, cell));
 
 			return new HeliFly(self, Target.FromCell(self.World, cell));
 		}
@@ -562,7 +586,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Activity MoveTo(CPos cell, Actor ignoreActor)
 		{
 			if (!Info.CanHover)
-				return new FlyAndContinueWithCirclesWhenIdle(self, Target.FromCell(self.World, cell));
+				return new Fly(self, Target.FromCell(self.World, cell));
 
 			return new HeliFly(self, Target.FromCell(self.World, cell));
 		}
@@ -570,7 +594,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Activity MoveWithinRange(Target target, WDist range)
 		{
 			if (!Info.CanHover)
-				return new FlyAndContinueWithCirclesWhenIdle(self, target, WDist.Zero, range);
+				return new Fly(self, target, WDist.Zero, range);
 
 			return new HeliFly(self, target, WDist.Zero, range);
 		}
@@ -578,7 +602,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange)
 		{
 			if (!Info.CanHover)
-				return new FlyAndContinueWithCirclesWhenIdle(self, target, minRange, maxRange);
+				return new Fly(self, target, minRange, maxRange);
 
 			return new HeliFly(self, target, minRange, maxRange);
 		}
@@ -716,7 +740,7 @@ namespace OpenRA.Mods.Common.Traits
 				self.SetTargetLine(target, Color.Green);
 
 				if (!Info.CanHover)
-					self.QueueActivity(order.Queued, new FlyAndContinueWithCirclesWhenIdle(self, target));
+					self.QueueActivity(order.Queued, new Fly(self, target));
 				else
 					self.QueueActivity(order.Queued, new HeliFlyAndLandWhenIdle(self, target, Info));
 			}
@@ -779,15 +803,6 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				UnReserve();
-
-				// TODO: Implement INotifyBecomingIdle instead
-				if (Info.VTOL && Info.LandWhenIdle)
-				{
-					if (Info.TurnToLand)
-						self.QueueActivity(new Turn(self, Info.InitialFacing));
-
-					self.QueueActivity(new HeliLand(self, true));
-				}
 			}
 			else if (order.OrderString == "ReturnToBase" && rearmableInfo != null && rearmableInfo.RearmActors.Any())
 			{

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -40,6 +40,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly int TurnSpeed = 255;
 
+		[Desc("Turn speed to apply when aircraft flies in circles while idle. Defaults to TurnSpeed if negative.")]
+		public readonly int IdleTurnSpeed = -1;
+
 		public readonly int Speed = 1;
 
 		[Desc("Minimum altitude where this aircraft is considered airborne.")]

--- a/OpenRA.Mods.Common/Traits/AutoCarryall.cs
+++ b/OpenRA.Mods.Common/Traits/AutoCarryall.cs
@@ -33,9 +33,13 @@ namespace OpenRA.Mods.Common.Traits
 			busy = false;
 			FindCarryableForTransport(self);
 
-			// TODO: This should be handled by the aircraft trait
+			// TODO: This should be handled by the Aircraft trait
 			if (!busy)
-				self.QueueActivity(new HeliFlyCircle(self));
+			{
+				var aircraft = self.Trait<Aircraft>();
+				var turnSpeedOverride = aircraft.Info.IdleTurnSpeed > -1 ? aircraft.Info.IdleTurnSpeed : aircraft.TurnSpeed;
+				self.QueueActivity(new HeliFlyCircle(self, turnSpeedOverride));
+			}
 		}
 
 		// A carryable notifying us that he'd like to be carried

--- a/OpenRA.Mods.Common/Traits/AutoCarryall.cs
+++ b/OpenRA.Mods.Common/Traits/AutoCarryall.cs
@@ -32,14 +32,6 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			busy = false;
 			FindCarryableForTransport(self);
-
-			// TODO: This should be handled by the Aircraft trait
-			if (!busy)
-			{
-				var aircraft = self.Trait<Aircraft>();
-				var turnSpeedOverride = aircraft.Info.IdleTurnSpeed > -1 ? aircraft.Info.IdleTurnSpeed : aircraft.TurnSpeed;
-				self.QueueActivity(new HeliFlyCircle(self, turnSpeedOverride));
-			}
 		}
 
 		// A carryable notifying us that he'd like to be carried

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/RemovedAutoCarryallCircleTurnSpeed.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/RemovedAutoCarryallCircleTurnSpeed.cs
@@ -1,0 +1,55 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RemovedAutoCarryallCircleTurnSpeed : UpdateRule
+	{
+		public override string Name { get { return "Removed AutoCarryall idle circling turnspeed hardcoding"; } }
+		public override string Description
+		{
+			get
+			{
+				return "Aircraft that circle while idle despite having CanHover (AutoCarryall) have their\n" +
+					"turn speed during idle circling no longer hardcoded to 1/3 of regular TurnSpeed." +
+					"Note that the new IdleTurnSpeed override works on all aircraft that circle when idle.";
+			}
+		}
+
+		bool showMessage;
+		bool messageShown;
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			var message = "While circling idle, your AutoCarryall(s) will now turn at full TurnSpeed,\n" +
+				"unless you manually define a custom IdleTurnSpeed.";
+
+			if (showMessage && !messageShown)
+				yield return message;
+
+			showMessage = false;
+			messageShown = true;
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var autoCarryall = actorNode.LastChildMatching("AutoCarryall");
+			if (autoCarryall == null)
+				yield break;
+
+			showMessage = true;
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -109,6 +109,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveNegativeDamageFullHealthCheck(),
 				new RemoveResourceExplodeModifier(),
 				new DefineLevelUpImageDefault(),
+				new RemovedAutoCarryallCircleTurnSpeed(),
 			})
 		};
 

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -20,6 +20,7 @@ carryall.reinforce:
 		AirborneCondition: airborne
 		CanHover: True
 		VTOL: true
+		IdleTurnSpeed: 1
 	Targetable@GROUND:
 		TargetTypes: Ground, Vehicle
 		RequiresCondition: !airborne


### PR DESCRIPTION
Like circling or landing.
Also added `IdleTurnSpeed` to allow to set a different turn speed for idle circling and in turn removed hardcoded 1/3 turnspeed from `HeliFlyCircle`.

Split from #15803.

Will get a follow-up later, replacing `LandWhenIdle` with a more flexible `ActionsWhenIdle`.