### PR TITLE
Change RA mechanic to repair ally-owned husks

### DIFF
--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -65,6 +65,7 @@
     <Compile Include="CncLoadScreen.cs" />
     <Compile Include="Traits\Attack\AttackPopupTurreted.cs" />
     <Compile Include="Traits\Buildings\ProductionAirdrop.cs" />
+    <Compile Include="Traits\Infiltration\InfiltrateForTransform.cs" />
     <Compile Include="Traits\Render\WithGunboatBody.cs" />
     <Compile Include="Traits\Render\WithEmbeddedTurretSpriteBody.cs" />
     <Compile Include="Traits\Render\WithCargo.cs" />

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForCash.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForCash.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	[Desc("This structure can be infiltrated causing funds to be stolen.")]
+	[Desc("Funds are transferred from the owner to the infiltrator.")]
 	class InfiltrateForCashInfo : ITraitInfo
 	{
 		public readonly BitSet<TargetableType> Types;

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForTransform.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForTransform.cs
@@ -18,11 +18,14 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	[Desc("This structure can be infiltrated causing funds to be stolen.")]
+	[Desc("Transform into a different actor type.")]
 	class InfiltrateForTransformInfo : ITraitInfo
 	{
-		[ActorReference, FieldLoader.Require] public readonly string IntoActor = null;
+		[ActorReference, FieldLoader.Require]
+		public readonly string IntoActor = null;
+
 		public readonly int ForceHealthPercentage = 0;
+
 		public readonly bool SkipMakeAnims = true;
 
 		public readonly BitSet<TargetableType> Types = default(BitSet<TargetableType>);
@@ -46,10 +49,17 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (!info.Types.Overlaps(types))
 				return;
 
+			var transform = new Transform(self, info.IntoActor)
+			{
+				ForceHealthPercentage = info.ForceHealthPercentage,
+				Faction = faction,
+				SkipMakeAnims = info.SkipMakeAnims
+			};
+
 			var facing = self.TraitOrDefault<IFacing>();
-			var transform = new Transform(self, info.IntoActor) { ForceHealthPercentage = info.ForceHealthPercentage, Faction = faction };
-			if (facing != null) transform.Facing = facing.Facing;
-			transform.SkipMakeAnims = info.SkipMakeAnims;
+			if (facing != null)
+				transform.Facing = facing.Facing;
+
 			self.CancelActivity();
 			self.QueueActivity(transform);
 		}

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForTransform.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForTransform.cs
@@ -1,0 +1,57 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Cnc.Traits
+{
+	[Desc("This structure can be infiltrated causing funds to be stolen.")]
+	class InfiltrateForTransformInfo : ITraitInfo
+	{
+		[ActorReference, FieldLoader.Require] public readonly string IntoActor = null;
+		public readonly int ForceHealthPercentage = 0;
+		public readonly bool SkipMakeAnims = true;
+
+		public readonly BitSet<TargetableType> Types = default(BitSet<TargetableType>);
+
+		public object Create(ActorInitializer init) { return new InfiltrateForTransform(init, this); }
+	}
+
+	class InfiltrateForTransform : INotifyInfiltrated
+	{
+		readonly InfiltrateForTransformInfo info;
+		readonly string faction;
+
+		public InfiltrateForTransform(ActorInitializer init, InfiltrateForTransformInfo info)
+		{
+			this.info = info;
+			faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : init.Self.Owner.Faction.InternalName;
+		}
+
+		void INotifyInfiltrated.Infiltrated(Actor self, Actor infiltrator, BitSet<TargetableType> types)
+		{
+			if (!info.Types.Overlaps(types))
+				return;
+
+			var facing = self.TraitOrDefault<IFacing>();
+			var transform = new Transform(self, info.IntoActor) { ForceHealthPercentage = info.ForceHealthPercentage, Faction = faction };
+			if (facing != null) transform.Facing = facing.Facing;
+			transform.SkipMakeAnims = info.SkipMakeAnims;
+			self.CancelActivity();
+			self.QueueActivity(transform);
+		}
+	}
+}

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
@@ -23,9 +23,10 @@ namespace OpenRA.Mods.Cnc.Traits
 {
 	public class InfiltratesInfo : ConditionalTraitInfo
 	{
-		public readonly BitSet<TargetableType> Types;
+		public readonly BitSet<TargetableType> Types = default(BitSet<TargetableType>);
 
-		[VoiceReference] public readonly string Voice = "Action";
+		[VoiceReference]
+		public readonly string Voice = "Action";
 
 		[Desc("What diplomatic stances can be infiltrated by this actor.")]
 		public readonly Stance ValidStances = Stance.Neutral | Stance.Enemy;
@@ -36,7 +37,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		[NotificationReference("Speech")]
 		[Desc("Notification to play when a building is infiltrated.")]
-		public readonly string Notification = "BuildingInfiltrated";
+		public readonly string Notification = null;
 
 		[Desc("Experience to grant to the infiltrating player.")]
 		public readonly int PlayerExperience = 0;

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
@@ -31,12 +31,12 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("What diplomatic stances can be infiltrated by this actor.")]
 		public readonly Stance ValidStances = Stance.Neutral | Stance.Enemy;
 
-		[Desc("Behaviour when entering the structure.",
+		[Desc("Behaviour when entering the target.",
 			"Possible values are Exit, Suicide, Dispose.")]
 		public readonly EnterBehaviour EnterBehaviour = EnterBehaviour.Dispose;
 
 		[NotificationReference("Speech")]
-		[Desc("Notification to play when a building is infiltrated.")]
+		[Desc("Notification to play when a target is infiltrated.")]
 		public readonly string Notification = null;
 
 		[Desc("Experience to grant to the infiltrating player.")]

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
@@ -42,6 +42,8 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Experience to grant to the infiltrating player.")]
 		public readonly int PlayerExperience = 0;
 
+		public readonly string EnterCursor = "enter";
+
 		public override object Create(ActorInitializer init) { return new Infiltrates(this); }
 	}
 
@@ -113,7 +115,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		readonly InfiltratesInfo info;
 
 		public InfiltrationOrderTargeter(InfiltratesInfo info)
-			: base("Infiltrate", 7, "enter", true, false)
+			: base("Infiltrate", 7, info.EnterCursor, true, true)
 		{
 			this.info = info;
 		}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/DefineNotificationDefaults.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/DefineNotificationDefaults.cs
@@ -76,6 +76,9 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 			}),
 			new TraitWrapper("PowerManager", new Dictionary<string, string> {
 				{ "SpeechNotification", "LowPower" }
+			}),
+			new TraitWrapper("Infiltrates", new Dictionary<string, string> {
+				{ "Notification", "BuildingInfiltrated" }
 			})
 		};
 

--- a/mods/ra/maps/monster-tank-madness/rules.yaml
+++ b/mods/ra/maps/monster-tank-madness/rules.yaml
@@ -185,6 +185,7 @@ PBOX:
 		Image: 4TNK
 	-Capturable:
 	-TransformOnCapture:
+	-InfiltrateForTransform:
 
 DOME.NoInfiltrate:
 	Inherits: DOME

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -961,8 +961,11 @@
 	CaptureManager:
 	Capturable:
 		Types: husk
-		ValidStances: Enemy, Neutral, Ally
+		ValidStances: Enemy, Neutral
 	TransformOnCapture:
+		ForceHealthPercentage: 25
+	InfiltrateForTransform:
+		Types: Husk
 		ForceHealthPercentage: 25
 	WithColoredOverlay@IDISABLE:
 		Palette: disabled

--- a/mods/ra/rules/husks.yaml
+++ b/mods/ra/rules/husks.yaml
@@ -6,6 +6,8 @@
 		Anim: turret
 	TransformOnCapture:
 		IntoActor: 1tnk
+	InfiltrateForTransform:
+		IntoActor: 1tnk
 	RenderSprites:
 		Image: 1tnk.destroyed
 
@@ -16,6 +18,8 @@
 	ThrowsParticle@turret:
 		Anim: turret
 	TransformOnCapture:
+		IntoActor: 2tnk
+	InfiltrateForTransform:
 		IntoActor: 2tnk
 	RenderSprites:
 		Image: 2tnk.destroyed
@@ -28,6 +32,8 @@
 		Anim: turret
 	TransformOnCapture:
 		IntoActor: 3tnk
+	InfiltrateForTransform:
+		IntoActor: 3tnk
 	RenderSprites:
 		Image: 3tnk.destroyed
 
@@ -39,6 +45,8 @@
 		Anim: turret
 	TransformOnCapture:
 		IntoActor: 4tnk
+	InfiltrateForTransform:
+		IntoActor: 4tnk
 	RenderSprites:
 		Image: 4tnk.destroyed
 
@@ -47,6 +55,8 @@ HARV.FullHusk:
 	Tooltip:
 		Name: Husk (Ore Truck)
 	TransformOnCapture:
+		IntoActor: harv
+	InfiltrateForTransform:
 		IntoActor: harv
 	RenderSprites:
 		Image: hhusk
@@ -57,6 +67,8 @@ HARV.EmptyHusk:
 		Name: Husk (Ore Truck)
 	TransformOnCapture:
 		IntoActor: harv
+	InfiltrateForTransform:
+		IntoActor: harv
 	RenderSprites:
 		Image: hhusk2
 
@@ -65,6 +77,8 @@ MCV.Husk:
 	Tooltip:
 		Name: Husk (Mobile Construction Vehicle)
 	TransformOnCapture:
+		IntoActor: mcv
+	InfiltrateForTransform:
 		IntoActor: mcv
 	RenderSprites:
 		Image: mcvhusk
@@ -77,6 +91,8 @@ MGG.Husk:
 		Anim: spinner-idle
 		Offset: -299,0,171
 	TransformOnCapture:
+		IntoActor: mgg
+	InfiltrateForTransform:
 		IntoActor: mgg
 	RenderSprites:
 		Image: mgg.destroyed
@@ -112,6 +128,7 @@ TRAN.Husk1:
 		Image: tran1husk
 	-Capturable:
 	-TransformOnCapture:
+	-InfiltrateForTransform:
 
 TRAN.Husk2:
 	Inherits: ^Husk
@@ -121,6 +138,7 @@ TRAN.Husk2:
 		Image: tran2husk
 	-Capturable:
 	-TransformOnCapture:
+	-InfiltrateForTransform:
 
 BADR.Husk:
 	Inherits: ^PlaneHusk

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -450,6 +450,11 @@ MECH:
 	Captures:
 		CaptureTypes: husk
 		PlayerExperience: 25
+	Infiltrates:
+		Types: Husk
+		ValidStances: Ally
+		EnterCursor: goldwrench
+		PlayerExperience: 25
 	WithInfantryBody:
 		IdleSequences: idle
 		DefaultAttackSequence: repair

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -289,6 +289,7 @@ SPY:
 		DisguisedCondition: disguise
 	Infiltrates:
 		Types: SpyInfiltrate
+		Notification: BuildingInfiltrated
 		PlayerExperience: 50
 	AutoTarget:
 		InitialStance: HoldFire
@@ -525,6 +526,7 @@ THF:
 	Passenger:
 		PipType: Blue
 	Infiltrates:
+		Notification: BuildingInfiltrated
 		PlayerExperience: 50
 	Voiced:
 		VoiceSet: ThiefVoice

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -81,8 +81,6 @@ V2RL:
 	WithSpriteTurret:
 	SpawnActorOnDeath:
 		Actor: 1TNK.Husk
-		OwnerType: InternalName
-		EffectiveOwnerFromOwner: true
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 
@@ -124,8 +122,6 @@ V2RL:
 	WithSpriteTurret:
 	SpawnActorOnDeath:
 		Actor: 2TNK.Husk
-		OwnerType: InternalName
-		EffectiveOwnerFromOwner: true
 	SelectionDecorations:
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
@@ -170,8 +166,6 @@ V2RL:
 	WithSpriteTurret:
 	SpawnActorOnDeath:
 		Actor: 3TNK.Husk
-		OwnerType: InternalName
-		EffectiveOwnerFromOwner: true
 	SelectionDecorations:
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
@@ -225,8 +219,6 @@ V2RL:
 	WithSpriteTurret:
 	SpawnActorOnDeath:
 		Actor: 4TNK.Husk
-		OwnerType: InternalName
-		EffectiveOwnerFromOwner: true
 	SelfHealing:
 		Step: 100
 		Delay: 3
@@ -318,8 +310,6 @@ HARV:
 		String: Harvester
 	SpawnActorOnDeath:
 		Actor: HARV.EmptyHusk
-		OwnerType: InternalName
-		EffectiveOwnerFromOwner: true
 	HarvesterHuskModifier:
 		FullHuskActor: HARV.FullHusk
 		FullnessThreshold: 50
@@ -368,8 +358,6 @@ MCV:
 	BaseBuilding:
 	SpawnActorOnDeath:
 		Actor: MCV.Husk
-		OwnerType: InternalName
-		EffectiveOwnerFromOwner: true
 	TransferTimedExternalConditionOnTransform:
 		Condition: invulnerability
 
@@ -555,8 +543,6 @@ MGG:
 	RenderShroudCircle:
 	SpawnActorOnDeath:
 		Actor: MGG.Husk
-		OwnerType: InternalName
-		EffectiveOwnerFromOwner: true
 
 MRJ:
 	Inherits: ^Vehicle

--- a/mods/ts/rules/civilian-infantry.yaml
+++ b/mods/ts/rules/civilian-infantry.yaml
@@ -79,6 +79,7 @@ CHAMSPY:
 		RequiresCondition: disguise
 	Infiltrates:
 		Types: SpyInfiltrate
+		Notification: BuildingInfiltrated
 	-WithInfantryBody:
 	WithDisguisingInfantryBody:
 		IdleSequences: idle1,idle2


### PR DESCRIPTION
Fixes #14019.
Fixes #9960.

Mechanics now show the goldwrench cursor for own- and ally-husks, and restore vehicles to their original owner.  Capturing vs enemy-husks has not changed, and continues to use the "enter" cursor.  This is close enough to the way engineers handle repair vs capturing that it should hopefully not cause confusion.