### PR TITLE
Fix FindResources aborting to early

### DIFF
--- a/OpenRA.Mods.Common/Activities/FindResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindResources.cs
@@ -52,9 +52,6 @@ namespace OpenRA.Mods.Common.Activities
 			if (IsCanceled)
 				return NextActivity;
 
-			if (NextInQueue != null)
-				return NextInQueue;
-
 			if (harv.IsFull)
 				return ActivityUtils.SequenceActivities(new DeliverResources(self), NextActivity);
 


### PR DESCRIPTION
In `Harvester::UnblockRefinery`, there is this bit of code:

```csharp
// FindResources takes care of calling INotifyHarvesterAction
self.QueueActivity(new FindResources(self));

self.QueueActivity(mobile.MoveTo(moveTo, 1));
```

However, the `NextInQueue` check early in `FindResources::Tick` would prevent the `INotfiyHarvesterAction` interface from actually getting called due to the queued move activity, therefore no carryalls get requested.

I have so far not noticed any wrong behaviour from harvesters without this check.

Fixes #15846 