### PR TITLE
Add BaseBuilderBotModule and BuildingRepairBotModule

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -122,10 +122,12 @@
     <Compile Include="ActorExts.cs" />
     <Compile Include="AI\AIUtils.cs" />
     <Compile Include="AI\AttackOrFleeFuzzy.cs" />
-    <Compile Include="AI\BaseBuilder.cs" />
+    <Compile Include="Traits\BotModules\BotModuleLogic\BaseBuilderQueueManager.cs" />
     <Compile Include="AI\HackyAI.cs" />
     <Compile Include="Traits\BotModules\HarvesterBotModule.cs" />
     <Compile Include="Traits\BotModules\SupportPowerBotModule.cs" />
+    <Compile Include="Traits\BotModules\BaseBuilderBotModule.cs" />
+    <Compile Include="Traits\BotModules\BuildingRepairBotModule.cs" />
     <Compile Include="AI\Squad.cs" />
     <Compile Include="AI\StateMachine.cs" />
     <Compile Include="AI\States\AirStates.cs" />

--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -1,0 +1,244 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.AI;
+using OpenRA.Support;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Manages AI base construction.")]
+	public class BaseBuilderBotModuleInfo : ConditionalTraitInfo
+	{
+		[Desc("Tells the AI what building types are considered construction yards.")]
+		public readonly HashSet<string> ConstructionYardTypes = new HashSet<string>();
+
+		[Desc("Tells the AI what building types are considered vehicle production facilities.")]
+		public readonly HashSet<string> VehiclesFactoryTypes = new HashSet<string>();
+
+		[Desc("Tells the AI what building types are considered refineries.")]
+		public readonly HashSet<string> RefineryTypes = new HashSet<string>();
+
+		[Desc("Tells the AI what building types are considered power plants.")]
+		public readonly HashSet<string> PowerTypes = new HashSet<string>();
+
+		[Desc("Tells the AI what building types are considered infantry production facilities.")]
+		public readonly HashSet<string> BarracksTypes = new HashSet<string>();
+
+		[Desc("Tells the AI what building types are considered production facilities.")]
+		public readonly HashSet<string> ProductionTypes = new HashSet<string>();
+
+		[Desc("Tells the AI what building types are considered naval production facilities.")]
+		public readonly HashSet<string> NavalProductionTypes = new HashSet<string>();
+
+		[Desc("Tells the AI what building types are considered silos (resource storage).")]
+		public readonly HashSet<string> SiloTypes = new HashSet<string>();
+
+		[Desc("Production queues AI uses for buildings.")]
+		public readonly HashSet<string> BuildingQueues = new HashSet<string> { "Building" };
+
+		[Desc("Production queues AI uses for defenses.")]
+		public readonly HashSet<string> DefenseQueues = new HashSet<string> { "Defense" };
+
+		[Desc("Minimum distance in cells from center of the base when checking for building placement.")]
+		public readonly int MinBaseRadius = 2;
+
+		[Desc("Radius in cells around the center of the base to expand.")]
+		public readonly int MaxBaseRadius = 20;
+
+		[Desc("Minimum excess power the AI should try to maintain.")]
+		public readonly int MinimumExcessPower = 0;
+
+		[Desc("The targeted excess power the AI tries to maintain cannot rise above this.")]
+		public readonly int MaximumExcessPower = 0;
+
+		[Desc("Increase maintained excess power by this amount for every ExcessPowerIncreaseThreshold of base buildings.")]
+		public readonly int ExcessPowerIncrement = 0;
+
+		[Desc("Increase maintained excess power by ExcessPowerIncrement for every N base buildings.")]
+		public readonly int ExcessPowerIncreaseThreshold = 1;
+
+		[Desc("Additional delay (in ticks) between structure production checks when there is no active production.",
+			"StructureProductionRandomBonusDelay is added to this.")]
+		public readonly int StructureProductionInactiveDelay = 125;
+
+		[Desc("Additional delay (in ticks) added between structure production checks when actively building things.",
+			"Note: The total delay is gamespeed OrderLatency x 4 + this + StructureProductionRandomBonusDelay.")]
+		public readonly int StructureProductionActiveDelay = 0;
+
+		[Desc("A random delay (in ticks) of up to this is added to active/inactive production delays.")]
+		public readonly int StructureProductionRandomBonusDelay = 10;
+
+		[Desc("Delay (in ticks) until retrying to build structure after the last 3 consecutive attempts failed.")]
+		public readonly int StructureProductionResumeDelay = 1500;
+
+		[Desc("After how many failed attempts to place a structure should AI give up and wait",
+			"for StructureProductionResumeDelay before retrying.")]
+		public readonly int MaximumFailedPlacementAttempts = 3;
+
+		[Desc("How many randomly chosen cells with resources to check when deciding refinery placement.")]
+		public readonly int MaxResourceCellsToCheck = 3;
+
+		[Desc("Delay (in ticks) until rechecking for new BaseProviders.")]
+		public readonly int CheckForNewBasesDelay = 1500;
+
+		[Desc("Minimum range at which to build defensive structures near a combat hotspot.")]
+		public readonly int MinimumDefenseRadius = 5;
+
+		[Desc("Maximum range at which to build defensive structures near a combat hotspot.")]
+		public readonly int MaximumDefenseRadius = 20;
+
+		[Desc("Try to build another production building if there is too much cash.")]
+		public readonly int NewProductionCashThreshold = 5000;
+
+		[Desc("Radius in cells around a factory scanned for rally points by the AI.")]
+		public readonly int RallyPointScanRadius = 8;
+
+		[Desc("Radius in cells around each building with ProvideBuildableArea",
+			"to check for a 3x3 area of water where naval structures can be built.",
+			"Should match maximum adjacency of naval structures.")]
+		public readonly int CheckForWaterRadius = 8;
+
+		[Desc("Terrain types which are considered water for base building purposes.")]
+		public readonly HashSet<string> WaterTerrainTypes = new HashSet<string> { "Water" };
+
+		[Desc("What buildings to the AI should build.", "What integer percentage of the total base must be this type of building.")]
+		public readonly Dictionary<string, int> BuildingFractions = null;
+
+		[Desc("What buildings should the AI have a maximum limit to build.")]
+		public readonly Dictionary<string, int> BuildingLimits = null;
+
+		public override object Create(ActorInitializer init) { return new BaseBuilderBotModule(init.Self, this); }
+	}
+
+	public class BaseBuilderBotModule : ConditionalTrait<BaseBuilderBotModuleInfo>, IBotTick, IBotPositionsUpdated, IBotRespondToAttack
+	{
+		public CPos GetRandomBaseCenter()
+		{
+			var randomConstructionYard = world.Actors.Where(a => a.Owner == player &&
+				Info.ConstructionYardTypes.Contains(a.Info.Name))
+				.RandomOrDefault(world.LocalRandom);
+
+			return randomConstructionYard != null ? randomConstructionYard.Location : initialBaseCenter;
+		}
+
+		public CPos DefenseCenter { get { return defenseCenter; } }
+
+		readonly World world;
+		readonly Player player;
+		PowerManager playerPower;
+		PlayerResources playerResources;
+		IBotPositionsUpdated[] positionsUpdatedModules;
+		BitArray resourceTypeIndices;
+		CPos initialBaseCenter;
+		CPos defenseCenter;
+
+		List<BaseBuilderQueueManager> builders = new List<BaseBuilderQueueManager>();
+
+		public BaseBuilderBotModule(Actor self, BaseBuilderBotModuleInfo info)
+			: base(info)
+		{
+			world = self.World;
+			player = self.Owner;
+		}
+
+		protected override void TraitEnabled(Actor self)
+		{
+			playerPower = player.PlayerActor.TraitOrDefault<PowerManager>();
+			playerResources = player.PlayerActor.Trait<PlayerResources>();
+			positionsUpdatedModules = player.PlayerActor.TraitsImplementing<IBotPositionsUpdated>().ToArray();
+
+			var tileset = world.Map.Rules.TileSet;
+			resourceTypeIndices = new BitArray(tileset.TerrainInfo.Length); // Big enough
+			foreach (var t in world.Map.Rules.Actors["world"].TraitInfos<ResourceTypeInfo>())
+				resourceTypeIndices.Set(tileset.GetTerrainIndex(t.TerrainType), true);
+
+			foreach (var building in Info.BuildingQueues)
+				builders.Add(new BaseBuilderQueueManager(this, building, player, playerPower, playerResources, resourceTypeIndices));
+			foreach (var defense in Info.DefenseQueues)
+				builders.Add(new BaseBuilderQueueManager(this, defense, player, playerPower, playerResources, resourceTypeIndices));
+		}
+
+		void IBotPositionsUpdated.UpdatedBaseCenter(CPos newLocation)
+		{
+			initialBaseCenter = newLocation;
+		}
+
+		void IBotPositionsUpdated.UpdatedDefenseCenter(CPos newLocation)
+		{
+			defenseCenter = newLocation;
+		}
+
+		void IBotTick.BotTick(IBot bot)
+		{
+			SetRallyPointsForNewProductionBuildings(bot);
+
+			foreach (var b in builders)
+				b.Tick(bot);
+		}
+
+		void IBotRespondToAttack.RespondToAttack(IBot bot, Actor self, AttackInfo e)
+		{
+			if (e.Attacker == null || e.Attacker.Disposed)
+				return;
+
+			if (e.Attacker.Owner.Stances[self.Owner] != Stance.Enemy)
+				return;
+
+			if (!e.Attacker.Info.HasTraitInfo<ITargetableInfo>())
+				return;
+
+			// Protected priority assets, MCVs, harvesters and buildings
+			if (self.Info.HasTraitInfo<BuildingInfo>() || self.Info.HasTraitInfo<BaseBuildingInfo>())
+				foreach (var n in positionsUpdatedModules)
+					n.UpdatedDefenseCenter(e.Attacker.Location);
+		}
+
+		void SetRallyPointsForNewProductionBuildings(IBot bot)
+		{
+			foreach (var rp in world.ActorsWithTrait<RallyPoint>())
+			{
+				if (rp.Actor.Owner == player &&
+					!IsRallyPointValid(rp.Trait.Location, rp.Actor.Info.TraitInfoOrDefault<BuildingInfo>()))
+				{
+					bot.QueueOrder(new Order("SetRallyPoint", rp.Actor, Target.FromCell(world, ChooseRallyLocationNear(rp.Actor)), false)
+					{
+						SuppressVisualFeedback = true
+					});
+				}
+			}
+		}
+
+		// Won't work for shipyards...
+		CPos ChooseRallyLocationNear(Actor producer)
+		{
+			var possibleRallyPoints = world.Map.FindTilesInCircle(producer.Location, Info.RallyPointScanRadius)
+				.Where(c => IsRallyPointValid(c, producer.Info.TraitInfoOrDefault<BuildingInfo>()));
+
+			if (!possibleRallyPoints.Any())
+			{
+				AIUtils.BotDebug("Bot Bug: No possible rallypoint near {0}", producer.Location);
+				return producer.Location;
+			}
+
+			return possibleRallyPoints.Random(world.LocalRandom);
+		}
+
+		bool IsRallyPointValid(CPos x, BuildingInfo info)
+		{
+			return info != null && world.IsCellBuildable(x, null, info);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/BotModules/BuildingRepairBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BuildingRepairBotModule.cs
@@ -1,0 +1,42 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Mods.Common.AI;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Manages AI repairing base buildings.")]
+	public class BuildingRepairBotModuleInfo : ConditionalTraitInfo
+	{
+		public override object Create(ActorInitializer init) { return new BuildingRepairBotModule(init.Self, this); }
+	}
+
+	public class BuildingRepairBotModule : ConditionalTrait<BuildingRepairBotModuleInfo>, IBotRespondToAttack
+	{
+		public BuildingRepairBotModule(Actor self, BuildingRepairBotModuleInfo info)
+			: base(info) { }
+
+		void IBotRespondToAttack.RespondToAttack(IBot bot, Actor self, AttackInfo e)
+		{
+			var rb = self.TraitOrDefault<RepairableBuilding>();
+			if (rb != null)
+			{
+				if (e.DamageState > DamageState.Light && e.PreviousDamageState <= DamageState.Light && !rb.RepairActive)
+				{
+					AIUtils.BotDebug("Bot noticed damage {0} {1}->{2}, repairing.",
+						self, e.PreviousDamageState, e.DamageState);
+					bot.QueueOrder(new Order("RepairBuilding", self.Owner.PlayerActor, Target.FromActor(self), false));
+				}
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -452,6 +452,15 @@ namespace OpenRA.Mods.Common.Traits
 	[RequireExplicitImplementation]
 	public interface IBotTick { void BotTick(IBot bot); }
 
+	public interface IBotRespondToAttack { void RespondToAttack(IBot bot, Actor self, AttackInfo e); }
+
+	[RequireExplicitImplementation]
+	public interface IBotPositionsUpdated
+	{
+		void UpdatedBaseCenter(CPos newLocation);
+		void UpdatedDefenseCenter(CPos newLocation);
+	}
+
 	[RequireExplicitImplementation]
 	public interface IEditorActorOptions : ITraitInfoInterface
 	{

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -2,10 +2,6 @@ Player:
 	HackyAI@Cabal:
 		Name: Cabal
 		Type: cabal
-		MinimumExcessPower: 30
-		ExcessPowerIncrement: 30
-		ExcessPowerIncreaseThreshold: 5
-		MaximumExcessPower: 150
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -17,38 +13,7 @@ Player:
 		UnitsCommonNames:
 			Mcv: mcv
 			ExcludeFromSquads: harv
-		BuildingQueues: Building.Nod, Building.GDI
-		DefenseQueues: Defence.Nod, Defence.GDI
 		UnitQueues: Vehicle.Nod, Vehicle.GDI, Infantry.Nod, Infantry.GDI, Aircraft.Nod, Aircraft.GDI
-		BuildingLimits:
-			proc: 4
-			pyle: 3
-			hand: 3
-			hq: 1
-			weap: 3
-			afld: 3
-			hpad: 0
-			eye: 1
-			tmpl: 1
-			fix: 1
-			silo: 1
-		BuildingFractions:
-			proc: 20%
-			pyle: 5%
-			hand: 5%
-			hq: 4%
-			weap: 9%
-			afld: 9%
-			gtwr: 5%
-			gun: 5%
-			atwr: 9%
-			obli: 7%
-			sam: 7%
-			eye: 1%
-			tmpl: 1%
-			silo: 0%
-			fix: 1%
-			hpad: 2%
 		UnitsToBuild:
 			e1: 65%
 			e2: 25%
@@ -74,10 +39,6 @@ Player:
 	HackyAI@Watson:
 		Name: Watson
 		Type: watson
-		MinimumExcessPower: 30
-		ExcessPowerIncrement: 30
-		ExcessPowerIncreaseThreshold: 4
-		MaximumExcessPower: 150
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -89,38 +50,7 @@ Player:
 		UnitsCommonNames:
 			Mcv: mcv
 			ExcludeFromSquads: harv
-		BuildingQueues: Building.Nod, Building.GDI
-		DefenseQueues: Defence.Nod, Defence.GDI
 		UnitQueues: Vehicle.Nod, Vehicle.GDI, Infantry.Nod, Infantry.GDI, Aircraft.Nod, Aircraft.GDI
-		BuildingLimits:
-			proc: 4
-			pyle: 3
-			hand: 3
-			hq: 1
-			weap: 3
-			afld: 3
-			hpad: 2
-			eye: 1
-			tmpl: 1
-			fix: 1
-			silo: 1
-		BuildingFractions:
-			proc: 17%
-			pyle: 2%
-			hand: 2%
-			hq: 1%
-			weap: 5%
-			afld: 5%
-			hpad: 4%
-			gtwr: 5%
-			gun: 5%
-			atwr: 9%
-			obli: 7%
-			eye: 1%
-			tmpl: 1%
-			sam: 7%
-			silo: 0%
-			fix: 1%
 		UnitsToBuild:
 			e1: 65%
 			e2: 30%
@@ -146,10 +76,6 @@ Player:
 	HackyAI@HAL9001:
 		Name: HAL 9001
 		Type: hal9001
-		MinimumExcessPower: 30
-		ExcessPowerIncrement: 30
-		ExcessPowerIncreaseThreshold: 4
-		MaximumExcessPower: 210
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -161,38 +87,7 @@ Player:
 		UnitsCommonNames:
 			Mcv: mcv
 			ExcludeFromSquads: harv
-		BuildingQueues: Building.Nod, Building.GDI
-		DefenseQueues: Defence.Nod, Defence.GDI
 		UnitQueues: Vehicle.Nod, Vehicle.GDI, Infantry.Nod, Infantry.GDI, Aircraft.Nod, Aircraft.GDI
-		BuildingLimits:
-			proc: 4
-			pyle: 4
-			hand: 4
-			hq: 1
-			weap: 4
-			afld: 4
-			hpad: 2
-			eye: 1
-			tmpl: 1
-			fix: 1
-			silo: 1
-		BuildingFractions:
-			proc: 17%
-			pyle: 7%
-			hand: 9%
-			hq: 1%
-			weap: 8%
-			afld: 6%
-			hpad: 4%
-			gtwr: 5%
-			gun: 5%
-			atwr: 9%
-			obli: 7%
-			eye: 1%
-			tmpl: 1%
-			sam: 7%
-			silo: 0%
-			fix: 1%
 		UnitsToBuild:
 			e1: 65%
 			e2: 30%
@@ -288,4 +183,135 @@ Player:
 		Condition: enable-hal9001-ai
 		Bots: hal9001
 	HarvesterBotModule:
+		RequiresCondition: enable-cabal-ai || enable-watson-ai || enable-hal9001-ai
+	BaseBuilderBotModule@cabal:
+		RequiresCondition: enable-cabal-ai
+		BuildingQueues: Building.Nod, Building.GDI
+		DefenseQueues: Defence.Nod, Defence.GDI
+		MinimumExcessPower: 30
+		MaximumExcessPower: 150
+		ExcessPowerIncrement: 30
+		ExcessPowerIncreaseThreshold: 5
+		ConstructionYardTypes: fact
+		RefineryTypes: proc
+		PowerTypes: nuke,nuk2
+		BarracksTypes: pyle,hand
+		VehiclesFactoryTypes: weap,afld
+		ProductionTypes: pyle,hand,weap,afld,hpad
+		SiloTypes: silo
+		BuildingLimits:
+			proc: 4
+			pyle: 3
+			hand: 3
+			hq: 1
+			weap: 3
+			afld: 3
+			hpad: 0
+			eye: 1
+			tmpl: 1
+			fix: 1
+			silo: 1
+		BuildingFractions:
+			proc: 20
+			pyle: 5
+			hand: 5
+			hq: 4
+			weap: 9
+			afld: 9
+			gtwr: 5
+			gun: 5
+			atwr: 9
+			obli: 7
+			sam: 7
+			eye: 1
+			tmpl: 1
+			fix: 1
+			hpad: 2
+	BaseBuilderBotModule@watson:
+		RequiresCondition: enable-watson-ai
+		BuildingQueues: Building.Nod, Building.GDI
+		DefenseQueues: Defence.Nod, Defence.GDI
+		MinimumExcessPower: 30
+		MaximumExcessPower: 150
+		ExcessPowerIncrement: 30
+		ExcessPowerIncreaseThreshold: 4
+		ConstructionYardTypes: fact
+		RefineryTypes: proc
+		PowerTypes: nuke,nuk2
+		BarracksTypes: pyle,hand
+		VehiclesFactoryTypes: weap,afld
+		ProductionTypes: pyle,hand,weap,afld,hpad
+		SiloTypes: silo
+		BuildingLimits:
+			proc: 4
+			pyle: 3
+			hand: 3
+			hq: 1
+			weap: 3
+			afld: 3
+			hpad: 2
+			eye: 1
+			tmpl: 1
+			fix: 1
+			silo: 1
+		BuildingFractions:
+			proc: 17
+			pyle: 2
+			hand: 2
+			hq: 1
+			weap: 5
+			afld: 5
+			hpad: 4
+			gtwr: 5
+			gun: 5
+			atwr: 9
+			obli: 7
+			eye: 1
+			tmpl: 1
+			sam: 7
+			fix: 1
+	BaseBuilderBotModule@hal9001:
+		RequiresCondition: enable-hal9001-ai
+		BuildingQueues: Building.Nod, Building.GDI
+		DefenseQueues: Defence.Nod, Defence.GDI
+		MinimumExcessPower: 30
+		MaximumExcessPower: 210
+		ExcessPowerIncrement: 30
+		ExcessPowerIncreaseThreshold: 4
+		ConstructionYardTypes: fact
+		RefineryTypes: proc
+		PowerTypes: nuke,nuk2
+		BarracksTypes: pyle,hand
+		VehiclesFactoryTypes: weap,afld
+		ProductionTypes: pyle,hand,weap,afld,hpad
+		SiloTypes: silo
+		BuildingLimits:
+			proc: 4
+			pyle: 4
+			hand: 4
+			hq: 1
+			weap: 4
+			afld: 4
+			hpad: 2
+			eye: 1
+			tmpl: 1
+			fix: 1
+			silo: 1
+		BuildingFractions:
+			proc: 17
+			pyle: 7
+			hand: 9
+			hq: 1
+			weap: 8
+			afld: 6
+			hpad: 4
+			gtwr: 5
+			gun: 5
+			atwr: 9
+			obli: 7
+			eye: 1
+			tmpl: 1
+			sam: 7
+			fix: 1
+	BuildingRepairBotModule:
 		RequiresCondition: enable-cabal-ai || enable-watson-ai || enable-hal9001-ai

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -2,11 +2,6 @@ Player:
 	HackyAI@Omnius:
 		Name: Omnius
 		Type: omnius
-		MinimumExcessPower: 50
-		ExcessPowerIncrement: 50
-		ExcessPowerIncreaseThreshold: 4
-		MaximumExcessPower: 200
-		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport, Aircraft
 		BuildingCommonNames:
 			ConstructionYard: construction_yard
@@ -18,40 +13,6 @@ Player:
 		UnitsCommonNames:
 			Mcv: mcv
 			ExcludeFromSquads: harvester
-		BuildingLimits:
-			barracks: 1
-			refinery: 4
-			outpost: 1
-			high_tech_factory: 1
-			light_factory: 1
-			heavy_factory: 1
-			starport: 1
-			repair_pad: 1
-			research_centre: 1
-			palace: 1
-			upgrade.conyard: 1
-			upgrade.barracks: 1
-			upgrade.light: 1
-			upgrade.heavy: 1
-			upgrade.hightech: 1
-		BuildingFractions:
-			barracks: 0.1%
-			refinery: 20.1%
-			medium_gun_turret: 8%
-			outpost: 0.1%
-			high_tech_factory: 0.1%
-			large_gun_turret: 6%
-			light_factory: 0.1%
-			heavy_factory: 0.1%
-			starport: 0.1%
-			repair_pad: 0.1%
-			research_centre: 0.1%
-			palace: 0.1%
-			upgrade.conyard: 0.1%
-			upgrade.barracks: 0.1%
-			upgrade.light: 0.1%
-			upgrade.heavy: 0.1%
-			upgrade.hightech: 0.1%
 		UnitsToBuild:
 			carryall: 1%
 			light_inf: 65%
@@ -86,11 +47,6 @@ Player:
 	HackyAI@Vidius:
 		Name: Vidious
 		Type: vidious
-		MinimumExcessPower: 50
-		ExcessPowerIncrement: 50
-		ExcessPowerIncreaseThreshold: 4
-		MaximumExcessPower: 200
-		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport, Aircraft
 		BuildingCommonNames:
 			ConstructionYard: construction_yard
@@ -102,40 +58,6 @@ Player:
 		UnitsCommonNames:
 			Mcv: mcv
 			ExcludeFromSquads: harvester
-		BuildingLimits:
-			barracks: 1
-			refinery: 4
-			outpost: 1
-			high_tech_factory: 1
-			light_factory: 1
-			heavy_factory: 1
-			starport: 1
-			repair_pad: 1
-			research_centre: 1
-			palace: 1
-			upgrade.conyard: 1
-			upgrade.barracks: 1
-			upgrade.light: 1
-			upgrade.heavy: 1
-			upgrade.hightech: 1
-		BuildingFractions:
-			barracks: 0.1%
-			refinery: 20.1%
-			medium_gun_turret: 5%
-			outpost: 0.1%
-			high_tech_factory: 0.1%
-			large_gun_turret: 10%
-			light_factory: 0.1%
-			heavy_factory: 0.1%
-			starport: 0.1%
-			repair_pad: 0.1%
-			research_centre: 0.1%
-			palace: 0.1%
-			upgrade.conyard: 0.1%
-			upgrade.barracks: 0.1%
-			upgrade.light: 0.1%
-			upgrade.heavy: 0.1%
-			upgrade.hightech: 0.1%
 		UnitsToBuild:
 			carryall: 1%
 			light_inf: 65%
@@ -170,11 +92,6 @@ Player:
 	HackyAI@Gladius:
 		Name: Gladius
 		Type: gladius
-		MinimumExcessPower: 50
-		ExcessPowerIncrement: 50
-		ExcessPowerIncreaseThreshold: 4
-		MaximumExcessPower: 200
-		BuildingQueues: Building, Upgrade
 		UnitQueues: Infantry, Vehicle, Armor, Starport, Aircraft
 		BuildingCommonNames:
 			ConstructionYard: construction_yard
@@ -186,39 +103,6 @@ Player:
 		UnitsCommonNames:
 			Mcv: mcv
 			ExcludeFromSquads: harvester
-		BuildingLimits:
-			barracks: 1
-			refinery: 4
-			outpost: 1
-			high_tech_factory: 1
-			light_factory: 1
-			heavy_factory: 1
-			starport: 1
-			repair_pad: 1
-			research_centre: 1
-			palace: 1
-			upgrade.conyard: 1
-			upgrade.barracks: 1
-			upgrade.light: 1
-			upgrade.heavy: 1
-			upgrade.hightech: 1
-		BuildingFractions:
-			barracks: 0.1%
-			refinery: 20.1%
-			medium_gun_turret: 4%
-			outpost: 0.1%
-			high_tech_factory: 0.1%
-			large_gun_turret: 12%
-			light_factory: 0.1%
-			heavy_factory: 0.1%
-			repair_pad: 0.1%
-			research_centre: 0.1%
-			palace: 0.1%
-			upgrade.conyard: 0.1%
-			upgrade.barracks: 0.1%
-			upgrade.light: 0.1%
-			upgrade.heavy: 0.1%
-			upgrade.hightech: 0.1%
 		UnitsToBuild:
 			carryall: 1%
 			light_inf: 65%
@@ -303,4 +187,149 @@ Player:
 		Condition: enable-gladius-ai
 		Bots: gladius
 	HarvesterBotModule:
+		RequiresCondition: enable-omnius-ai || enable-vidious-ai || enable-gladius-ai
+	BaseBuilderBotModule@omnius:
+		RequiresCondition: enable-omnius-ai
+		BuildingQueues: Building, Upgrade
+		MinimumExcessPower: 50
+		MaximumExcessPower: 200
+		ExcessPowerIncrement: 50
+		ExcessPowerIncreaseThreshold: 4
+		MaxBaseRadius: 40
+		ConstructionYardTypes: construction_yard
+		RefineryTypes: refinery
+		PowerTypes: wind_trap
+		VehiclesFactoryTypes: light_factory, heavy_factory, starport
+		ProductionTypes: light_factory, heavy_factory, barracks, starport
+		SiloTypes: silo
+		BuildingLimits:
+			barracks: 1
+			refinery: 4
+			outpost: 1
+			high_tech_factory: 1
+			light_factory: 1
+			heavy_factory: 1
+			starport: 1
+			repair_pad: 1
+			research_centre: 1
+			palace: 1
+			upgrade.conyard: 1
+			upgrade.barracks: 1
+			upgrade.light: 1
+			upgrade.heavy: 1
+			upgrade.hightech: 1
+		BuildingFractions:
+			barracks: 1
+			refinery: 20
+			medium_gun_turret: 8
+			outpost: 1
+			high_tech_factory: 1
+			large_gun_turret: 6
+			light_factory: 1
+			heavy_factory: 1
+			starport: 1
+			repair_pad: 1
+			research_centre: 1
+			palace: 1
+			upgrade.conyard: 1
+			upgrade.barracks: 1
+			upgrade.light: 1
+			upgrade.heavy: 1
+			upgrade.hightech: 1
+	BaseBuilderBotModule@vidious:
+		RequiresCondition: enable-vidious-ai
+		BuildingQueues: Building, Upgrade
+		MinimumExcessPower: 50
+		MaximumExcessPower: 200
+		ExcessPowerIncrement: 50
+		ExcessPowerIncreaseThreshold: 4
+		MaxBaseRadius: 40
+		ConstructionYardTypes: construction_yard
+		RefineryTypes: refinery
+		PowerTypes: wind_trap
+		VehiclesFactoryTypes: light_factory, heavy_factory, starport
+		ProductionTypes: light_factory, heavy_factory, barracks, starport
+		SiloTypes: silo
+		BuildingLimits:
+			barracks: 1
+			refinery: 4
+			outpost: 1
+			high_tech_factory: 1
+			light_factory: 1
+			heavy_factory: 1
+			starport: 1
+			repair_pad: 1
+			research_centre: 1
+			palace: 1
+			upgrade.conyard: 1
+			upgrade.barracks: 1
+			upgrade.light: 1
+			upgrade.heavy: 1
+			upgrade.hightech: 1
+		BuildingFractions:
+			barracks: 1
+			refinery: 20
+			medium_gun_turret: 5
+			outpost: 1
+			high_tech_factory: 1
+			large_gun_turret: 10
+			light_factory: 1
+			heavy_factory: 1
+			starport: 1
+			repair_pad: 1
+			research_centre: 1
+			palace: 1
+			upgrade.conyard: 1
+			upgrade.barracks: 1
+			upgrade.light: 1
+			upgrade.heavy: 1
+			upgrade.hightech: 1
+	BaseBuilderBotModule@gladius:
+		RequiresCondition: enable-gladius-ai
+		BuildingQueues: Building, Upgrade
+		MinimumExcessPower: 50
+		MaximumExcessPower: 200
+		ExcessPowerIncrement: 50
+		ExcessPowerIncreaseThreshold: 4
+		MaxBaseRadius: 40
+		ConstructionYardTypes: construction_yard
+		RefineryTypes: refinery
+		PowerTypes: wind_trap
+		VehiclesFactoryTypes: light_factory, heavy_factory, starport
+		ProductionTypes: light_factory, heavy_factory, barracks, starport
+		SiloTypes: silo
+		BuildingLimits:
+			barracks: 1
+			refinery: 4
+			outpost: 1
+			high_tech_factory: 1
+			light_factory: 1
+			heavy_factory: 1
+			starport: 1
+			repair_pad: 1
+			research_centre: 1
+			palace: 1
+			upgrade.conyard: 1
+			upgrade.barracks: 1
+			upgrade.light: 1
+			upgrade.heavy: 1
+			upgrade.hightech: 1
+		BuildingFractions:
+			barracks: 1
+			refinery: 20
+			medium_gun_turret: 4
+			outpost: 1
+			high_tech_factory: 1
+			large_gun_turret: 12
+			light_factory: 1
+			heavy_factory: 1
+			repair_pad: 1
+			research_centre: 1
+			palace: 1
+			upgrade.conyard: 1
+			upgrade.barracks: 1
+			upgrade.light: 1
+			upgrade.heavy: 1
+			upgrade.hightech: 1
+	BuildingRepairBotModule:
 		RequiresCondition: enable-omnius-ai || enable-vidious-ai || enable-gladius-ai

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -2,10 +2,6 @@ Player:
 	HackyAI@RushAI:
 		Name: Rush AI
 		Type: rush
-		MinimumExcessPower: 60
-		MaximumExcessPower: 160
-		ExcessPowerIncrement: 40
-		ExcessPowerIncreaseThreshold: 4
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -18,34 +14,6 @@ Player:
 			Mcv: mcv
 			ExcludeFromSquads: harv
 			NavalUnits: ss,msub,dd,ca,lst,pt
-		BuildingLimits:
-			proc: 4
-			barr: 1
-			tent: 1
-			kenn: 1
-			dome: 1
-			weap: 1
-			atek: 1
-			stek: 1
-			fix: 1
-		BuildingFractions:
-			proc: 30%
-			barr: 1%
-			kenn: 0.5%
-			tent: 1%
-			weap: 1%
-			pbox: 7%
-			gun: 7%
-			tsla: 5%
-			gap: 2%
-			ftur: 10%
-			agun: 5%
-			sam: 5%
-			atek: 1%
-			stek: 1%
-			fix: 0.1%
-			dome: 10%
-			mslo: 1%
 		UnitsToBuild:
 			e1: 65%
 			e2: 15%
@@ -74,10 +42,6 @@ Player:
 	HackyAI@NormalAI:
 		Name: Normal AI
 		Type: normal
-		MinimumExcessPower: 60
-		MaximumExcessPower: 200
-		ExcessPowerIncrement: 40
-		ExcessPowerIncreaseThreshold: 4
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -91,43 +55,6 @@ Player:
 			Mcv: mcv
 			ExcludeFromSquads: harv
 			NavalUnits: ss,msub,dd,ca,lst,pt
-		BuildingLimits:
-			proc: 4
-			barr: 1
-			tent: 1
-			dome: 1
-			weap: 1
-			spen: 1
-			syrd: 1
-			hpad: 4
-			afld: 4
-			afld.ukraine: 4
-			atek: 1
-			stek: 1
-			fix: 1
-		BuildingFractions:
-			proc: 15%
-			tent: 1%
-			barr: 1%
-			kenn: 0.5%
-			dome: 1%
-			weap: 6%
-			hpad: 4%
-			spen: 1%
-			syrd: 1%
-			afld: 4%
-			afld.ukraine: 4%
-			pbox: 7%
-			gun: 7%
-			ftur: 10%
-			tsla: 5%
-			gap: 2%
-			fix: 1%
-			agun: 5%
-			sam: 1%
-			atek: 1%
-			stek: 1%
-			mslo: 1%
 		UnitsToBuild:
 			e1: 65%
 			e2: 15%
@@ -165,10 +92,6 @@ Player:
 	HackyAI@TurtleAI:
 		Name: Turtle AI
 		Type: turtle
-		MinimumExcessPower: 60
-		MaximumExcessPower: 250
-		ExcessPowerIncrement: 50
-		ExcessPowerIncreaseThreshold: 4
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -182,44 +105,6 @@ Player:
 			Mcv: mcv
 			ExcludeFromSquads: harv
 			NavalUnits: ss,msub,dd,ca,lst,pt
-		BuildingLimits:
-			proc: 4
-			barr: 1
-			tent: 1
-			kenn: 1
-			dome: 1
-			weap: 1
-			spen: 1
-			syrd: 1
-			hpad: 4
-			afld: 4
-			afld.ukraine: 4
-			atek: 1
-			stek: 1
-			fix: 1
-		BuildingFractions:
-			proc: 30%
-			tent: 1%
-			barr: 1%
-			kenn: 0.5%
-			weap: 3%
-			hpad: 2%
-			afld: 2%
-			afld.ukraine: 2%
-			spen: 1%
-			syrd: 1%
-			pbox: 10%
-			gun: 10%
-			ftur: 10%
-			tsla: 7%
-			gap: 3%
-			fix: 0.1%
-			dome: 10%
-			agun: 5%
-			sam: 5%
-			atek: 1%
-			stek: 1%
-			mslo: 1%
 		UnitsToBuild:
 			e1: 65%
 			e2: 15%
@@ -257,10 +142,6 @@ Player:
 	HackyAI@NavalAI:
 		Name: Naval AI
 		Type: naval
-		MinimumExcessPower: 60
-		MaximumExcessPower: 200
-		ExcessPowerIncrement: 40
-		ExcessPowerIncreaseThreshold: 4
 		BuildingCommonNames:
 			ConstructionYard: fact
 			Refinery: proc
@@ -274,39 +155,6 @@ Player:
 			Mcv: mcv
 			ExcludeFromSquads: harv
 			NavalUnits: ss,msub,dd,ca,lst,pt
-		BuildingLimits:
-			proc: 4
-			dome: 1
-			barr: 1
-			tent: 1
-			spen: 1
-			syrd: 1
-			hpad: 8
-			afld: 8
-			afld.ukraine: 8
-			weap: 1
-			atek: 1
-			stek: 1
-			fix: 1
-		BuildingFractions:
-			proc: 30%
-			dome: 1%
-			weap: 1%
-			hpad: 20%
-			afld: 20%
-			afld.ukraine: 20%
-			atek: 1%
-			stek: 1%
-			spen: 1%
-			syrd: 1%
-			fix: 0.1%
-			pbox: 12%
-			gun: 12%
-			ftur: 12%
-			tsla: 12%
-			agun: 5%
-			sam: 5%
-			mslo: 1%
 		UnitsToBuild:
 			harv: 1%
 			heli: 30%
@@ -385,4 +233,197 @@ Player:
 		Condition: enable-naval-ai
 		Bots: naval
 	HarvesterBotModule:
+		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
+	BaseBuilderBotModule@rush:
+		RequiresCondition: enable-rush-ai
+		MinimumExcessPower: 60
+		MaximumExcessPower: 160
+		ExcessPowerIncrement: 40
+		ExcessPowerIncreaseThreshold: 4
+		ConstructionYardTypes: fact
+		RefineryTypes: proc
+		PowerTypes: powr,apwr
+		BarracksTypes: barr,tent
+		VehiclesFactoryTypes: weap
+		ProductionTypes: barr,tent,weap
+		SiloTypes: silo
+		BuildingLimits:
+			proc: 4
+			barr: 1
+			tent: 1
+			kenn: 1
+			dome: 1
+			weap: 1
+			atek: 1
+			stek: 1
+			fix: 1
+		BuildingFractions:
+			proc: 30
+			barr: 1
+			kenn: 1
+			tent: 1
+			weap: 1
+			pbox: 7
+			gun: 7
+			tsla: 5
+			gap: 2
+			ftur: 10
+			agun: 5
+			sam: 5
+			atek: 1
+			stek: 1
+			fix: 1
+			dome: 10
+			mslo: 1
+	BaseBuilderBotModule@normal:
+		RequiresCondition: enable-normal-ai
+		MinimumExcessPower: 60
+		MaximumExcessPower: 200
+		ExcessPowerIncrement: 40
+		ExcessPowerIncreaseThreshold: 4
+		ConstructionYardTypes: fact
+		RefineryTypes: proc
+		PowerTypes: powr,apwr
+		BarracksTypes: barr,tent
+		VehiclesFactoryTypes: weap
+		ProductionTypes: barr,tent,weap,afld,hpad
+		NavalProductionTypes: spen,syrd
+		SiloTypes: silo
+		BuildingLimits:
+			proc: 4
+			barr: 1
+			tent: 1
+			dome: 1
+			weap: 1
+			spen: 1
+			syrd: 1
+			hpad: 4
+			afld: 4
+			afld.ukraine: 4
+			atek: 1
+			stek: 1
+			fix: 1
+		BuildingFractions:
+			proc: 15
+			tent: 1
+			barr: 1
+			kenn: 1
+			dome: 1
+			weap: 6
+			hpad: 4
+			spen: 1
+			syrd: 1
+			afld: 4
+			afld.ukraine: 4
+			pbox: 7
+			gun: 7
+			ftur: 10
+			tsla: 5
+			gap: 2
+			fix: 1
+			agun: 5
+			sam: 1
+			atek: 1
+			stek: 1
+			mslo: 1
+	BaseBuilderBotModule@turtle:
+		RequiresCondition: enable-turtle-ai
+		MinimumExcessPower: 60
+		MaximumExcessPower: 250
+		ExcessPowerIncrement: 50
+		ExcessPowerIncreaseThreshold: 4
+		ConstructionYardTypes: fact
+		RefineryTypes: proc
+		PowerTypes: powr,apwr
+		BarracksTypes: barr,tent
+		VehiclesFactoryTypes: weap
+		ProductionTypes: barr,tent,weap,afld,hpad
+		NavalProductionTypes: spen,syrd
+		SiloTypes: silo
+		BuildingLimits:
+			proc: 4
+			barr: 1
+			tent: 1
+			kenn: 1
+			dome: 1
+			weap: 1
+			spen: 1
+			syrd: 1
+			hpad: 4
+			afld: 4
+			afld.ukraine: 4
+			atek: 1
+			stek: 1
+			fix: 1
+		BuildingFractions:
+			proc: 30
+			tent: 1
+			barr: 1
+			kenn: 1
+			weap: 3
+			hpad: 2
+			afld: 2
+			afld.ukraine: 2
+			spen: 1
+			syrd: 1
+			pbox: 10
+			gun: 10
+			ftur: 10
+			tsla: 7
+			gap: 3
+			fix: 1
+			dome: 10
+			agun: 5
+			sam: 5
+			atek: 1
+			stek: 1
+			mslo: 1
+	BaseBuilderBotModule@naval:
+		RequiresCondition: enable-naval-ai
+		MinimumExcessPower: 60
+		MaximumExcessPower: 200
+		ExcessPowerIncrement: 40
+		ExcessPowerIncreaseThreshold: 4
+		ConstructionYardTypes: fact
+		RefineryTypes: proc
+		PowerTypes: powr,apwr
+		BarracksTypes: barr,tent
+		VehiclesFactoryTypes: weap
+		ProductionTypes: barr,tent,weap,afld,hpad
+		NavalProductionTypes: spen,syrd
+		SiloTypes: silo
+		BuildingLimits:
+			proc: 4
+			dome: 1
+			barr: 1
+			tent: 1
+			spen: 1
+			syrd: 1
+			hpad: 8
+			afld: 8
+			afld.ukraine: 8
+			weap: 1
+			atek: 1
+			stek: 1
+			fix: 1
+		BuildingFractions:
+			proc: 30
+			dome: 1
+			weap: 1
+			hpad: 20
+			afld: 20
+			afld.ukraine: 20
+			atek: 1
+			stek: 1
+			spen: 1
+			syrd: 1
+			fix: 1
+			pbox: 12
+			gun: 12
+			ftur: 12
+			tsla: 12
+			agun: 5
+			sam: 5
+			mslo: 1
+	BuildingRepairBotModule:
 		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -2,10 +2,6 @@ Player:
 	HackyAI@TestAI:
 		Name: Test AI
 		Type: test
-		MinimumExcessPower: 30
-		ExcessPowerIncrement: 30
-		ExcessPowerIncreaseThreshold: 4
-		MaximumExcessPower: 200
 		BuildingCommonNames:
 			ConstructionYard: gacnst
 			Refinery: proc
@@ -17,43 +13,6 @@ Player:
 		UnitsCommonNames:
 			Mcv: mcv
 			ExcludeFromSquads: harv
-		BuildingLimits:
-			proc: 4
-			gasilo: 2
-			gapowr: 8
-			napowr: 8
-			gapile: 1
-			nahand: 1
-			gaweap: 1
-			naweap: 1
-			garadr: 1
-			naradr: 1
-			gatech: 1
-			natech: 1
-			nastlh: 1
-			gavulc: 8
-			garock: 2
-			gacsam: 4
-			naobel: 2
-			nalasr: 8
-			nasam: 4
-		BuildingFractions:
-			proc: 30%
-			gapile: 1%
-			nahand: 1%
-			gaweap: 1%
-			naweap: 1%
-			garadr: 1%
-			naradr: 1%
-			gatech: 1%
-			natech: 1%
-			nastlh: 1%
-			nalasr: 10%
-			gavulc: 10%
-			garock: 3%
-			gacsam: 6%
-			nasam: 6%
-			naobel: 3%
 		UnitsToBuild:
 			e1: 80%
 			e2: 25%
@@ -81,4 +40,56 @@ Player:
 		Condition: enable-test-ai
 		Bots: test
 	HarvesterBotModule:
+		RequiresCondition: enable-test-ai
+	BaseBuilderBotModule@test:
+		RequiresCondition: enable-test-ai
+		MinimumExcessPower: 30
+		MaximumExcessPower: 200
+		ExcessPowerIncrement: 30
+		ExcessPowerIncreaseThreshold: 4
+		ConstructionYardTypes: gacnst
+		RefineryTypes: proc
+		PowerTypes: gapowr, napowr, naapwr
+		BarracksTypes: gapile, nahand
+		VehiclesFactoryTypes: gaweap, naweap
+		ProductionTypes: gapile, nahand, gaweap, naweap
+		SiloTypes: gasilo
+		BuildingLimits:
+			proc: 4
+			gasilo: 2
+			gapowr: 8
+			napowr: 8
+			gapile: 1
+			nahand: 1
+			gaweap: 1
+			naweap: 1
+			garadr: 1
+			naradr: 1
+			gatech: 1
+			natech: 1
+			nastlh: 1
+			gavulc: 8
+			garock: 2
+			gacsam: 4
+			naobel: 2
+			nalasr: 8
+			nasam: 4
+		BuildingFractions:
+			proc: 30
+			gapile: 1
+			nahand: 1
+			gaweap: 1
+			naweap: 1
+			garadr: 1
+			naradr: 1
+			gatech: 1
+			natech: 1
+			nastlh: 1
+			nalasr: 10
+			gavulc: 10
+			garock: 3
+			gacsam: 6
+			nasam: 6
+			naobel: 3
+	BuildingRepairBotModule:
 		RequiresCondition: enable-test-ai


### PR DESCRIPTION
Extracts all logic related to base-building from `HackyAI` into a `BaseBuilderBotModule`. `BaseBuilder` is kept as separate .cs file, but of course adapted.

Additionally, replaced the `ShouldRepairBuildings` boolean with a separate `RepairBuildingsBotModule`, as some singleplayer missions may want only that.

Depends on #15786.