### PR TITLE
Disable mp syncreports and other minor server cleanups

### DIFF
--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using OpenRA.Primitives;
+using OpenRA.Support;
 
 namespace OpenRA.Network
 {
@@ -67,7 +68,7 @@ namespace OpenRA.Network
 
 			// Generating sync reports is expensive, so only do it if we have
 			// other players to compare against if a desync did occur
-			generateSyncReport = !(Connection is ReplayConnection) && LobbyInfo.NonBotClients.Count() > 1;
+			generateSyncReport = !(Connection is ReplayConnection) && LobbyInfo.GlobalSettings.EnableSyncReports;
 
 			NetFrameNumber = 1;
 			for (var i = NetFrameNumber; i <= FramesAhead; i++)

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -187,7 +187,8 @@ namespace OpenRA.Network
 			Connection.SendSync(NetFrameNumber, OrderIO.SerializeSync(World.SyncHash()));
 
 			if (generateSyncReport)
-				syncReport.UpdateSyncReport();
+				using (new PerfSample("sync_report"))
+					syncReport.UpdateSyncReport();
 
 			++NetFrameNumber;
 		}

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -201,6 +201,7 @@ namespace OpenRA.Network
 			public bool AllowVersionMismatch;
 			public string GameUid;
 			public bool EnableSingleplayer;
+			public bool EnableSyncReports;
 			public bool Dedicated;
 
 			[FieldLoader.Ignore]

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -198,7 +198,6 @@ namespace OpenRA.Network
 			public int OrderLatency = 3; // net tick frames (x 120 = ms)
 			public int RandomSeed = 0;
 			public bool AllowSpectators = true;
-			public bool AllowVersionMismatch;
 			public string GameUid;
 			public bool EnableSingleplayer;
 			public bool EnableSyncReports;

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -351,7 +351,7 @@ namespace OpenRA.Server
 					return;
 				}
 
-				if (ModData.Manifest.Metadata.Version != handshake.Version && !LobbyInfo.GlobalSettings.AllowVersionMismatch)
+				if (ModData.Manifest.Metadata.Version != handshake.Version)
 				{
 					Log.Write("server", "Rejected connection from {0}; Not running the same version.",
 						newConn.Socket.RemoteEndPoint);

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -157,6 +157,7 @@ namespace OpenRA.Server
 					Map = settings.Map,
 					ServerName = settings.Name,
 					EnableSingleplayer = settings.EnableSingleplayer || !dedicated,
+					EnableSyncReports = settings.EnableSyncReports,
 					GameUid = Guid.NewGuid().ToString(),
 					Dedicated = dedicated
 				}

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -74,6 +74,9 @@ namespace OpenRA
 		[Desc("Query map information from the Resource Center if they are not available locally.")]
 		public bool QueryMapRepository = true;
 
+		[Desc("Enable client-side report generation to help debug desync errors.")]
+		public bool EnableSyncReports = false;
+
 		public string TimestampFormat = "s";
 
 		public ServerSettings Clone()

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -98,9 +98,6 @@ namespace OpenRA
 		public bool SanityCheckUnsyncedCode = false;
 		public int Samples = 25;
 
-		[Desc("Show incompatible games in server browser.")]
-		public bool IgnoreVersionMismatch = false;
-
 		public bool StrictActivityChecking = false;
 
 		[Desc("Check whether a newer version is available online.")]

--- a/launch-dedicated.cmd
+++ b/launch-dedicated.cmd
@@ -6,11 +6,17 @@ set Name="Dedicated Server"
 set Mod=ra
 set ListenPort=1234
 set AdvertiseOnline=True
-set EnableSingleplayer=False
 set Password=""
+
+set RequireAuthentication=False
+set ProfileIDBlacklist=""
+set ProfileIDWhitelist=""
+
+set EnableSingleplayer=False
+set EnableSyncReports=False
 
 :loop
 
-OpenRA.Server.exe Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password%
+OpenRA.Server.exe Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports%
 
 goto loop

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -10,12 +10,24 @@ Name="${Name:-"Dedicated Server"}"
 Mod="${Mod:-"ra"}"
 ListenPort="${ListenPort:-"1234"}"
 AdvertiseOnline="${AdvertiseOnline:-"True"}"
-EnableSingleplayer="${EnableSingleplayer:-"False"}"
 Password="${Password:-""}"
+
+RequireAuthentication="${RequireAuthentication:-"False"}"
+ProfileIDBlacklist="${ProfileIDBlacklist:-""}"
+ProfileIDWhitelist="${ProfileIDWhitelist:-""}"
+
+EnableSingleplayer="${EnableSingleplayer:-"False"}"
+EnableSyncReports="${EnableSyncReports:-"False"}"
 
 while true; do
      mono --debug OpenRA.Server.exe Game.Mod="$Mod" \
-     Server.Name="$Name" Server.ListenPort="$ListenPort" \
+     Server.Name="$Name" \
+     Server.ListenPort="$ListenPort" \
      Server.AdvertiseOnline="$AdvertiseOnline" \
-     Server.EnableSingleplayer="$EnableSingleplayer" Server.Password="$Password"
+     Server.EnableSingleplayer="$EnableSingleplayer" \
+     Server.Password="$Password" \
+     Server.RequireAuthentication="$RequireAuthentication" \
+     Server.ProfileIDBlacklist="$ProfileIDBlacklist" \
+     Server.ProfileIDWhitelist="$ProfileIDWhitelist" \
+     Server.EnableSyncReports="$EnableSyncReports"
 done


### PR DESCRIPTION
* Fixes #15790.
* SyncReport generation is now profiled using its own line on the graph
* Removed the `IgnoreVersionMismatch` setting, which appears to have been broken years ago (the setting is not propagated to the GlobalSettings) and stopped making sense when the server started doing things with the mod rules server-side.
* Added newer server settings to the dedicated launch scripts.