### PR TITLE
Make Attack activities explicitly account for FrozenActors.

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -48,6 +48,7 @@ namespace OpenRA
 		public Activity CurrentActivity { get; private set; }
 
 		public int Generation;
+		public Actor ReplacedByActor;
 
 		public IEffectiveOwner EffectiveOwner { get; private set; }
 		public IOccupySpace OccupiesSpace { get; private set; }

--- a/OpenRA.Game/Network/Order.cs
+++ b/OpenRA.Game/Network/Order.cs
@@ -112,11 +112,10 @@ namespace OpenRA
 										if (world == null || !TryGetActorFromUInt(world, playerActorID, out playerActor))
 											break;
 
-										var frozenLayer = playerActor.TraitOrDefault<FrozenActorLayer>();
-										if (frozenLayer == null)
+										if (playerActor.Owner.FrozenActorLayer == null)
 											break;
 
-										var frozen = frozenLayer.FromID(frozenActorID);
+										var frozen = playerActor.Owner.FrozenActorLayer.FromID(frozenActorID);
 										if (frozen != null)
 											target = Target.FromFrozenActor(frozen);
 

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -56,6 +56,8 @@ namespace OpenRA
 		public readonly PlayerReference PlayerReference;
 		public readonly bool IsBot;
 		public readonly string BotType;
+		public readonly Shroud Shroud;
+		public readonly FrozenActorLayer FrozenActorLayer;
 
 		/// <summary>The faction (including Random, etc) that was selected in the lobby.</summary>
 		public readonly FactionInfo DisplayFaction;
@@ -65,7 +67,6 @@ namespace OpenRA
 		public bool HasObjectives = false;
 		public bool Spectating;
 
-		public Shroud Shroud;
 		public World World { get; private set; }
 
 		readonly bool inMissionMap;
@@ -156,6 +157,7 @@ namespace OpenRA
 			var playerActorType = world.Type == WorldType.Editor ? "EditorPlayer" : "Player";
 			PlayerActor = world.CreateActor(playerActorType, new TypeDictionary { new OwnerInit(this) });
 			Shroud = PlayerActor.Trait<Shroud>();
+			FrozenActorLayer = PlayerActor.TraitOrDefault<FrozenActorLayer>();
 
 			// Enable the bot logic on the host
 			IsBot = BotType != null;

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -46,7 +46,17 @@ namespace OpenRA.Traits
 		public DamageState DamageState { get; private set; }
 		readonly IHealth health;
 
+		// The Visible flag is tied directly to the actor visibility under the fog.
+		// If Visible is true, the actor is made invisible (via FrozenUnderFog/IDefaultVisibility)
+		// and this FrozenActor is rendered instead.
+		// The Hidden flag covers the edge case that occurs when the backing actor was last "seen"
+		// to be cloaked or otherwise not CanBeViewedByPlayer()ed. Setting Visible to true when
+		// the actor is hidden under the fog would leak the actors position via the tooltips and
+		// AutoTargetability, and keeping Visible as false would cause the actor to be rendered
+		// under the fog.
 		public bool Visible = true;
+		public bool Hidden = false;
+
 		public bool Shrouded { get; private set; }
 		public bool NeedRenderables { get; set; }
 		public IRenderable[] Renderables = NoRenderables;
@@ -101,6 +111,7 @@ namespace OpenRA.Traits
 		{
 			Owner = actor.Owner;
 			TargetTypes = actor.GetEnabledTargetTypes();
+			Hidden = !actor.CanBeViewedByPlayer(viewer);
 
 			if (health != null)
 			{
@@ -143,6 +154,11 @@ namespace OpenRA.Traits
 			}
 
 			NeedRenderables |= Visible && !wasVisible;
+		}
+
+		public void Invalidate()
+		{
+			Owner = null;
 		}
 
 		public void Flash()

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -80,13 +80,21 @@ namespace OpenRA.Traits
 
 		public bool IsValidFor(Actor targeter)
 		{
-			if (targeter == null || Type == TargetType.Invalid)
+			if (targeter == null)
 				return false;
 
-			if (actor != null && !actor.IsTargetableBy(targeter))
-				return false;
-
-			return true;
+			switch (Type)
+			{
+				case TargetType.Actor:
+					return actor.IsTargetableBy(targeter);
+				case TargetType.FrozenActor:
+					return frozen.IsValid && frozen.Visible && !frozen.Hidden;
+				case TargetType.Invalid:
+					return false;
+				default:
+				case TargetType.Terrain:
+					return true;
+			}
 		}
 
 		// Currently all or nothing.

--- a/OpenRA.Mods.Cnc/Effects/GpsDotEffect.cs
+++ b/OpenRA.Mods.Cnc/Effects/GpsDotEffect.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Cnc.Effects
 			visibilityModifiers = actor.TraitsImplementing<IVisibilityModifier>().ToArray();
 
 			dotStates = new PlayerDictionary<DotState>(actor.World,
-				p => new DotState(actor, p.PlayerActor.Trait<GpsWatcher>(), p.PlayerActor.TraitOrDefault<FrozenActorLayer>()));
+				p => new DotState(actor, p.PlayerActor.Trait<GpsWatcher>(), p.FrozenActorLayer));
 		}
 
 		bool ShouldRender(DotState state, Player toPlayer)

--- a/OpenRA.Mods.Cnc/Traits/FrozenUnderFogUpdatedByGps.cs
+++ b/OpenRA.Mods.Cnc/Traits/FrozenUnderFogUpdatedByGps.cs
@@ -39,6 +39,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		static readonly FrozenActorAction Remove = (fufubg, fal, gps, fa) =>
 		{
 			// Removes the frozen actor. Once done, we no longer need to track GPS updates.
+			fa.Invalidate();
 			fal.Remove(fa);
 			gps.UnregisterForOnGpsRefreshed(fufubg.self, fufubg);
 		};

--- a/OpenRA.Mods.Cnc/Traits/FrozenUnderFogUpdatedByGps.cs
+++ b/OpenRA.Mods.Cnc/Traits/FrozenUnderFogUpdatedByGps.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			public readonly GpsWatcher GpsWatcher;
 			public Traits(Player player, FrozenUnderFogUpdatedByGps frozenUnderFogUpdatedByGps)
 			{
-				FrozenActorLayer = player.PlayerActor.TraitOrDefault<FrozenActorLayer>();
+				FrozenActorLayer = player.FrozenActorLayer;
 				GpsWatcher = player.PlayerActor.TraitOrDefault<GpsWatcher>();
 				GpsWatcher.RegisterForOnGpsRefreshed(frozenUnderFogUpdatedByGps.self, frozenUnderFogUpdatedByGps);
 			}

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -18,10 +18,10 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class FlyAttack : Activity
 	{
-		readonly Target target;
 		readonly Aircraft aircraft;
 		readonly AttackAircraft attackAircraft;
 		readonly Rearmable rearmable;
+		Target target;
 
 		int ticksUntilTurn;
 
@@ -42,6 +42,8 @@ namespace OpenRA.Mods.Common.Activities
 				Cancel(self);
 				return NextActivity;
 			}
+
+			target = target.Recalculate(self.Owner);
 
 			if (!target.IsValidFor(self))
 				return NextActivity;

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -74,6 +74,8 @@ namespace OpenRA.Mods.Common.Activities
 			return NextActivity;
 		}
 
+		protected virtual bool IgnoresVisibility { get { return false; } }
+
 		protected virtual AttackStatus TickAttack(Actor self, AttackBase attack)
 		{
 			if (IsCanceled)
@@ -90,7 +92,7 @@ namespace OpenRA.Mods.Common.Activities
 			// HACK: This would otherwise break targeting frozen actors
 			// The problem is that Shroud.IsTargetable returns false (as it should) for
 			// frozen actors, but we do want to explicitly target the underlying actor here.
-			if (!attack.Info.IgnoresVisibility && type == TargetType.Actor
+			if (!IgnoresVisibility && type == TargetType.Actor
 					&& !Target.Actor.Info.HasTraitInfo<FrozenUnderFogInfo>()
 					&& !Target.Actor.CanBeViewedByPlayer(self.Owner))
 				return AttackStatus.UnableToAttack;

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -132,6 +132,8 @@ namespace OpenRA.Mods.Common.Activities
 				foreach (var nt in self.TraitsImplementing<INotifyTransform>())
 					nt.AfterTransform(a);
 
+				self.ReplacedByActor = a;
+
 				if (selected)
 					w.Selection.Add(w, a);
 

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -592,6 +592,7 @@
     <Compile Include="Traits\World\WeatherOverlay.cs" />
     <Compile Include="Traits\World\ActorSpawnManager.cs" />
     <Compile Include="Traits\ActorSpawner.cs" />
+    <Compile Include="UpdateRules\Rules\20180923\RemoveAttackIgnoresVisibility.cs" />
     <Compile Include="UpdateRules\Rules\20180923\RemovedDemolishLocking.cs" />
     <Compile Include="UpdateRules\Rules\20180923\RemoveNegativeDamageFullHealthCheck.cs" />
     <Compile Include="UpdateRules\Rules\20180923\RemoveResourceExplodeModifier.cs" />

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -31,9 +31,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Does the attack type require the attacker to enter the target's cell?")]
 		public readonly bool AttackRequiresEnteringCell = false;
 
-		[Desc("Does not care about shroud or fog. Enables the actor to launch an attack against a target even if he has no visibility of it.")]
-		public readonly bool IgnoresVisibility = false;
-
 		[VoiceReference] public readonly string Voice = "Action";
 
 		public override abstract object Create(ActorInitializer init);

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack)
 		{
-			return new Activities.Attack(self, newTarget, allowMove, forceAttack, info.FacingTolerance);
+			return new Activities.Attack(self, newTarget, allowMove, forceAttack);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using OpenRA.Activities;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -32,9 +33,9 @@ namespace OpenRA.Mods.Common.Traits
 		// Some 3rd-party mods rely on this being public
 		public class SetTarget : Activity
 		{
-			readonly Target target;
 			readonly AttackOmni attack;
 			readonly bool allowMove;
+			Target target;
 
 			public SetTarget(AttackOmni attack, Target target, bool allowMove)
 			{
@@ -45,6 +46,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override Activity Tick(Actor self)
 			{
+				target = target.Recalculate(self.Owner);
 				if (IsCanceled || !target.IsValidFor(self) || !attack.IsReachableTarget(target, allowMove))
 					return NextActivity;
 

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		/// <summary>Evaluates the attractiveness of a position according to all considerations</summary>
-		public int GetAttractiveness(WPos pos, Player firedBy, FrozenActorLayer frozenLayer)
+		public int GetAttractiveness(WPos pos, Player firedBy)
 		{
 			var answer = 0;
 			var world = firedBy.World;
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 				var delta = new WVec(radiusToUse, radiusToUse, WDist.Zero);
 				var tl = world.Map.CellContaining(pos - delta);
 				var br = world.Map.CellContaining(pos + delta);
-				var checkFrozen = frozenLayer.FrozenActorsInRegion(new CellRegion(world.Map.Grid.Type, tl, br));
+				var checkFrozen = firedBy.FrozenActorLayer.FrozenActorsInRegion(new CellRegion(world.Map.Grid.Type, tl, br));
 
 				// IsValid check filters out Frozen Actors that have not initizialized their Owner
 				foreach (var scrutinized in checkFrozen)

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/SupportPowerDecision.cs
@@ -81,8 +81,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				// IsValid check filters out Frozen Actors that have not initizialized their Owner
 				foreach (var scrutinized in checkFrozen)
-					if (scrutinized.IsValid)
-						answer += consideration.GetAttractiveness(scrutinized, firedBy.Stances[scrutinized.Owner], firedBy);
+					answer += consideration.GetAttractiveness(scrutinized, firedBy.Stances[scrutinized.Owner], firedBy);
 			}
 
 			return answer;

--- a/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
@@ -41,7 +41,6 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly World world;
 		readonly Player player;
-		FrozenActorLayer frozenLayer;
 		SupportPowerManager supportPowerManager;
 		Dictionary<SupportPowerInstance, int> waitingPowers = new Dictionary<SupportPowerInstance, int>();
 		Dictionary<string, SupportPowerDecision> powerDecisions = new Dictionary<string, SupportPowerDecision>();
@@ -55,7 +54,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override void TraitEnabled(Actor self)
 		{
-			frozenLayer = player.PlayerActor.TraitOrDefault<FrozenActorLayer>();
 			supportPowerManager = player.PlayerActor.Trait<SupportPowerManager>();
 			foreach (var decision in Info.Decisions)
 				powerDecisions.Add(decision.OrderName, decision);
@@ -140,7 +138,7 @@ namespace OpenRA.Mods.Common.Traits
 					var wbr = world.Map.CenterOfCell(br.ToCPos(map));
 					var targets = world.ActorMap.ActorsInBox(wtl, wbr);
 
-					var frozenTargets = frozenLayer != null ? frozenLayer.FrozenActorsInRegion(region) : Enumerable.Empty<FrozenActor>();
+					var frozenTargets = player.FrozenActorLayer != null ? player.FrozenActorLayer.FrozenActorsInRegion(region) : Enumerable.Empty<FrozenActor>();
 					var consideredAttractiveness = powerDecision.GetAttractiveness(targets, player) + powerDecision.GetAttractiveness(frozenTargets, player);
 					if (consideredAttractiveness <= bestAttractiveness || consideredAttractiveness < powerDecision.MinimumAttractiveness)
 						continue;
@@ -176,7 +174,7 @@ namespace OpenRA.Mods.Common.Traits
 					var y = checkPos.Y + j;
 					var pos = world.Map.CenterOfCell(new CPos(x, y));
 					var consideredAttractiveness = 0;
-					consideredAttractiveness += powerDecision.GetAttractiveness(pos, player, frozenLayer);
+					consideredAttractiveness += powerDecision.GetAttractiveness(pos, player);
 
 					if (consideredAttractiveness <= bestAttractiveness || consideredAttractiveness < powerDecision.MinimumAttractiveness)
 						continue;

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -68,11 +68,13 @@ namespace OpenRA.Mods.Common.Traits
 			frozenStates = new PlayerDictionary<FrozenState>(self.World, (player, playerIndex) =>
 			{
 				var frozenActor = new FrozenActor(self, footprint, player, startsRevealed);
-				if (startsRevealed)
-					UpdateFrozenActor(self, frozenActor, playerIndex);
 				player.PlayerActor.Trait<FrozenActorLayer>().Add(frozenActor);
 				return new FrozenState(frozenActor) { IsVisible = startsRevealed };
 			});
+
+			if (startsRevealed)
+				for (var playerIndex = 0; playerIndex < frozenStates.Count; playerIndex++)
+					UpdateFrozenActor(self, frozenStates[playerIndex].FrozenActor, playerIndex);
 		}
 
 		void UpdateFrozenActor(Actor self, FrozenActor frozenActor, int playerIndex)

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20180923/RemoveAttackIgnoresVisibility.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20180923/RemoveAttackIgnoresVisibility.cs
@@ -1,0 +1,66 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RemoveAttackIgnoresVisibility : UpdateRule
+	{
+		public override string Name { get { return "IgnoresVisibility has been removed from Attack* traits."; } }
+		public override string Description
+		{
+			get
+			{
+				return "The IgnoresVisibility flag has been removed from the Attack* traits as part of a\n" +
+				       "wider rework of the fog-targeting behaviour. Mods that rely on this logic must\n" +
+				       "implement their own Attack* trait, similar to the AttackSwallow trait.";
+			}
+		}
+
+		static readonly string[] Traits =
+		{
+			"AttackFrontal",
+			"AttackFollow",
+			"AttackTurreted",
+			"AttackOmni",
+			"AttackBomber",
+			"AttackPopupTurreted",
+			"AttackTesla",
+			"AttackSwallow"
+		};
+
+		readonly List<string> locations = new List<string>();
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (locations.Any())
+				yield return "The IgnoresVisibility flag has been removed from the targeting logic on the following actors:\n" +
+					UpdateUtils.FormatMessageList(locations) + "\n\n" +
+					"You may wish to enable TargetFrozenActors, or implement a custom Attack* trait like AttackSwallow\n" +
+					"if you require visibility to be completely ignored.";
+
+			locations.Clear();
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var trait in Traits)
+				foreach (var t in actorNode.ChildrenMatching(trait))
+					if (t.RemoveNodes("IgnoresVisibility") > 0)
+						locations.Add("{0} ({1})".F(actorNode.Key, actorNode.Location.Filename));
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -110,6 +110,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveResourceExplodeModifier(),
 				new DefineLevelUpImageDefault(),
 				new RemovedAutoCarryallCircleTurnSpeed(),
+				new RemoveAttackIgnoresVisibility(),
 			})
 		};
 

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -246,26 +246,20 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 
 			var frozen = world.ScreenMap.FrozenActorsAtMouse(world.RenderPlayer, worldPixel)
-				.Where(a => a.TooltipInfo != null && a.IsValid)
+				.Where(a => a.TooltipInfo != null && a.IsValid && a.Visible && !a.Hidden)
 				.WithHighestSelectionPriority(worldPixel);
 
 			if (frozen != null)
 			{
-				var actor = frozen.Actor;
+				FrozenActorTooltip = frozen;
 
-				// HACK: This leaks the cloak state through the fog (cloaked buildings will not show tooltips)
-				if (actor == null || actor.TraitsImplementing<IVisibilityModifier>().All(t => t.IsVisible(actor, world.RenderPlayer)))
-				{
-					FrozenActorTooltip = frozen;
+				// HACK: This leaks the tooltip state through the fog
+				// This will cause issues for any downstream mods that use IProvideTooltipInfo on enemy actors
+				if (frozen.Actor != null)
+					ActorTooltipExtra = frozen.Actor.TraitsImplementing<IProvideTooltipInfo>().ToArray();
 
-					// HACK: This leaks the tooltip state through the fog
-					// This will cause issues for any downstream mods that use IProvideTooltipInfo on enemy actors
-					if (frozen.Actor != null)
-						ActorTooltipExtra = frozen.Actor.TraitsImplementing<IProvideTooltipInfo>().ToArray();
-
-					TooltipType = WorldTooltipType.FrozenActor;
-					return;
-				}
+				TooltipType = WorldTooltipType.FrozenActor;
+				return;
 			}
 
 			if (resourceLayer != null)

--- a/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
+++ b/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
@@ -11,6 +11,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Activities;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.D2k.Activities;
 using OpenRA.Traits;
@@ -66,6 +68,20 @@ namespace OpenRA.Mods.D2k.Traits
 
 			self.CancelActivity();
 			self.QueueActivity(new SwallowActor(self, target, a, facing));
+		}
+
+		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack)
+		{
+			return new SwallowTarget(self, newTarget, allowMove, forceAttack, Info.FacingTolerance);
+		}
+
+		public class SwallowTarget : Attack
+		{
+			public SwallowTarget(Actor self, Target target, bool allowMovement, bool forceAttack, int facingTolerance)
+				: base(self, target, allowMovement, forceAttack, facingTolerance) { }
+
+			// Worms ignore visibility, so don't need to recalculate targets
+			protected override bool IgnoresVisibility { get { return true; } }
 		}
 	}
 }

--- a/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
+++ b/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
@@ -72,16 +72,19 @@ namespace OpenRA.Mods.D2k.Traits
 
 		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack)
 		{
-			return new SwallowTarget(self, newTarget, allowMove, forceAttack, Info.FacingTolerance);
+			return new SwallowTarget(self, newTarget, allowMove, forceAttack);
 		}
 
 		public class SwallowTarget : Attack
 		{
-			public SwallowTarget(Actor self, Target target, bool allowMovement, bool forceAttack, int facingTolerance)
-				: base(self, target, allowMovement, forceAttack, facingTolerance) { }
+			public SwallowTarget(Actor self, Target target, bool allowMovement, bool forceAttack)
+				: base(self, target, allowMovement, forceAttack) { }
 
-			// Worms ignore visibility, so don't need to recalculate targets
-			protected override bool IgnoresVisibility { get { return true; } }
+			protected override Target RecalculateTarget(Actor self)
+			{
+				// Worms ignore visibility, so don't need to recalculate targets
+				return target;
+			}
 		}
 	}
 }

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -174,6 +174,7 @@ ARTY:
 		LocalOffset: 624,0,208
 		MuzzleSequence: muzzle
 	AttackFrontal:
+		TargetFrozenActors: True
 	WithMuzzleOverlay:
 	AutoTarget:
 		InitialStanceAI: Defend
@@ -520,6 +521,7 @@ MSAM:
 		Weapon: 227mm
 		LocalOffset: 213,-128,0, 213,128,0
 	AttackFrontal:
+		TargetFrozenActors: True
 	WithSpriteTurret:
 	SpawnActorOnDeath:
 		Actor: MSAM.Husk

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -104,7 +104,6 @@ sandworm:
 		UseLocation: true
 	AttackSwallow:
 		AttackRequiresEnteringCell: true
-		IgnoresVisibility: true
 		AttackingCondition: attacking
 	Armament:
 		Weapon: WormJaw

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -118,6 +118,7 @@ MSUB:
 		LocalOffset: 0,-171,0, 0,171,0
 		FireDelay: 2
 	AttackFrontal:
+		TargetFrozenActors: True
 	SelectionDecorations:
 	AutoTarget:
 		InitialStance: HoldFire
@@ -234,6 +235,7 @@ CA:
 		MuzzleSequence: muzzle
 	AttackTurreted:
 		Turrets: primary, secondary
+		TargetFrozenActors: True
 	WithMuzzleOverlay:
 	SelectionDecorations:
 	WithSpriteTurret@PRIMARY:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -28,6 +28,7 @@ V2RL:
 	AutoTarget:
 		ScanRadius: 10
 	AttackFrontal:
+		TargetFrozenActors: True
 	WithFacingSpriteBody:
 		RequiresCondition: !reloading
 		Name: loaded
@@ -263,6 +264,7 @@ ARTY:
 		LocalOffset: 624,0,208
 		MuzzleSequence: muzzle
 	AttackFrontal:
+		TargetFrozenActors: True
 	WithMuzzleOverlay:
 	Explodes:
 		Weapon: ArtilleryExplode

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -363,6 +363,7 @@ JUGG:
 		Turrets: deployed
 		RequiresCondition: deployed
 		PauseOnCondition: empdisable
+		TargetFrozenActors: True
 	Armament@deployed:
 		Name: deployed
 		Turret: deployed

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -258,6 +258,7 @@ ART2:
 		Turrets: deployed
 		RequiresCondition: deployed
 		PauseOnCondition: empdisable
+		TargetFrozenActors: True
 	Armament@deployed:
 		Name: deployed
 		Turret: deployed


### PR DESCRIPTION
With the dust from #13995, #15176 and all the related PRs sufficiently settled, we can now progress to fixing the actor-side logic.

The workarounds that replaced FrozenActors with Actors in the order resolving, and to allow the attack activities to target actors that are hidden under the fog have been removed, and the attack activities can now fire on FrozenActors directly.  The FrozenActor &lrarr; Actor switching when a structure becomes/loses visibility is handled by making the activity `Target`s non-readonly and introducing a `Target.Recalculate` extension method that switches between them when needed.  This also lets us propagate targets across Actor &rarr; Actor transformations for (almost) free.

Fixes #11265.
Fixes #14872.
Fixes #12856.
Fixes #10004.
Fixes #10887.
Fixes #14616.
Supersedes #12333 / #13363.

This fixes a couple of high-impact bugs in the RA mod (artillery sometimes rushing forward when ordered to attack, units refusing to target camo-pillboxes), and one of our biggest blockers for TS (stealth generators make the camo-pillbox bug affect everything).  I'd therefore like to get this in for the playtest, and once the dust settles we can migrate the remaining activities over to the new system for Next + 1.

One of the side-effects of these fixes is that artillery in the "attack everything" stance will now automatically target structures within range that are under the fog, and any attacks (including manually ordered ones) will only automatically stop once another actor reveals that the target is dead.  This has caused some controversy in IRC as it is arguably a gameplay regression.  I'm moving forward with that here because we can't think of a better alternative: never fixing the targeting isn't viable, and dropping targets when they become hidden under fog seems like a bigger gameplay regression (but does remain an option if needed).