### PR TITLE
Signify next item in production queue

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ParallelProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ParallelProductionQueue.cs
@@ -50,6 +50,11 @@ namespace OpenRA.Mods.Common.Traits
 			return Queue.Contains(item);
 		}
 
+		public override bool IsNextInQueue(ProductionItem item)
+		{
+			return false;
+		}
+
 		protected override void BeginProduction(ProductionItem item, bool hasPriority)
 		{
 			// Ignore `hasPriority` as it's not relevant in parallel production context.

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -232,6 +232,11 @@ namespace OpenRA.Mods.Common.Traits
 			return Queue.Count > 0 && Queue[0] == item;
 		}
 
+		public virtual bool IsNextInQueue(ProductionItem item)
+		{
+			return Queue.Count > 1 && Queue[1] == item;
+		}
+
 		public virtual IEnumerable<ProductionItem> AllQueued()
 		{
 			return Queue;

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Widgets
 		readonly WorldRenderer worldRenderer;
 
 		SpriteFont overlayFont, symbolFont;
-		float2 holdOffset, readyOffset, timeOffset, queuedOffset, infiniteOffset, infiniteSymbolSize, nextOffset;
+		float2 iconOffset, holdOffset, readyOffset, timeOffset, queuedOffset, infiniteOffset, infiniteSymbolSize, nextOffset;
 
 		[CustomLintableHotkeyNames]
 		public static IEnumerable<string> LinterHotkeyNames(MiniYamlNode widgetNode, Action<string> emitError, Action<string> emitWarning)
@@ -154,6 +154,25 @@ namespace OpenRA.Mods.Common.Widgets
 
 			hotkeys = Exts.MakeArray(HotkeyCount,
 				i => modData.Hotkeys[HotkeyPrefix + (i + 1).ToString("D2")]);
+
+			iconOffset = 0.5f * IconSize.ToFloat2() + IconSpriteOffset;
+			timeOffset = iconOffset - overlayFont.Measure(WidgetUtils.FormatTime(0, World.Timestep)) / 2;
+			queuedOffset = new float2(4, 2);
+			holdOffset = iconOffset - overlayFont.Measure(HoldText) / 2;
+			readyOffset = iconOffset - overlayFont.Measure(ReadyText) / 2;
+
+			if (ChromeMetrics.TryGet("InfiniteProductionSymbolOffset", out infiniteOffset))
+				infiniteOffset += queuedOffset;
+			else
+				infiniteOffset = queuedOffset;
+
+			if (ChromeMetrics.TryGet("NextProductionSymbolOffset", out nextOffset))
+				nextOffset += queuedOffset;
+			else
+				nextOffset = queuedOffset;
+
+			if (!ChromeMetrics.TryGet("InfiniteProductionSymbolSize", out infiniteSymbolSize))
+				infiniteSymbolSize = overlayFont.Measure(InfiniteSymbol);
 		}
 
 		public void ScrollDown()
@@ -428,25 +447,6 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override void Draw()
 		{
-			var iconOffset = 0.5f * IconSize.ToFloat2() + IconSpriteOffset;
-			timeOffset = iconOffset - overlayFont.Measure(WidgetUtils.FormatTime(0, World.Timestep)) / 2;
-			queuedOffset = new float2(4, 2);
-			holdOffset = iconOffset - overlayFont.Measure(HoldText) / 2;
-			readyOffset = iconOffset - overlayFont.Measure(ReadyText) / 2;
-
-			if (ChromeMetrics.TryGet("InfiniteProductionSymbolOffset", out infiniteOffset))
-				infiniteOffset += queuedOffset;
-			else
-				infiniteOffset = queuedOffset;
-
-			if (ChromeMetrics.TryGet("NextProductionSymbolOffset", out nextOffset))
-				nextOffset += queuedOffset;
-			else
-				nextOffset = queuedOffset;
-
-			if (!ChromeMetrics.TryGet("InfiniteProductionSymbolSize", out infiniteSymbolSize))
-				infiniteSymbolSize = overlayFont.Measure(InfiniteSymbol);
-
 			if (CurrentQueue == null)
 				return;
 

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -187,6 +187,9 @@ Fonts:
 	Title:
 		Font: common|FreeSansBold.ttf
 		Size: 32
+	Symbols:
+		Font: common|FreeSans.ttf
+		Size: 10
 
 Missions:
 	./mods/cnc/missions.yaml

--- a/mods/common/metrics.yaml
+++ b/mods/common/metrics.yaml
@@ -18,6 +18,9 @@ Metrics:
 	IncompatibleProtectedGameColor: 8B0000
 	IncompatibleVersionColor: FF0000
 	IncompatibleWaitingGameColor: 32CD32
+	InfiniteProductionSymbolOffset: 0,1
+	InfiniteProductionSymbolSize: 8,2
+	NextProductionSymbolOffset: 1,-1
 	PlayerStanceColorAllies: FFFF00
 	PlayerStanceColorEnemies: FF0000
 	PlayerStanceColorNeutrals: D2B48C

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -174,6 +174,9 @@ Fonts:
 	Title:
 		Font: d2k|Dune2k.ttf
 		Size: 32
+	Symbols:
+		Font: common|FreeSans.ttf
+		Size: 10
 
 Missions:
 	d2k|missions.yaml

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -190,6 +190,9 @@ Fonts:
 	Title:
 		Font: ra|ZoodRangmah.ttf
 		Size: 48
+	Symbols:
+		Font: common|FreeSans.ttf
+		Size: 10
 
 Missions:
 	ra|missions.yaml

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -232,6 +232,9 @@ Fonts:
 	Title:
 		Font: common|FreeSansBold.ttf
 		Size: 32
+	Symbols:
+		Font: common|FreeSans.ttf
+		Size: 10
 
 SupportsMapsFrom: ts
 


### PR DESCRIPTION
This is an alternative implementation of the feature proposed in #15841

What's in the **first commit** of this PR:
* Add `NextSymbol` property to `ProductionPalleteWidget`;
* Add `NextProductionSymbolOffset` to metrics.yaml;
* Add `InfiniteProductionSymbolOffset` to metrics.yaml;
* Add `InfiniteProductionSymbolSize` to metrics.yaml;
* Add "Symbols" font definition;
* Add `IsNextInQueue` method to `ProductionQueue` trait (it returns
`false` in parallel production context);

The **second commit** is a refactor of `ProductionPaletteWidget.cs` that moves offset calculation logic from `Draw` to `Initialize`.

**Remarks**:
* The game would crash if "Symbols" font is not defined. Perhaps a fallback font should be set?
* The text flickers when priority queueing items (`Ctrl + Left Click`) and I have no idea how fix/work-around that;
* The glyph is very much up for discussion but this seemed like the most suitable one available in FreeSans font;

**Screenshots** from all default mods (including a test with `InfiniteBuildLimit` in CNC):
![openra-signify-next-production-item](https://user-images.githubusercontent.com/1355810/49343607-7a675900-f675-11e8-8605-f129898e9404.png)
