### PR TITLE
 Expose common actor Inits in the map editor. 

### DIFF
--- a/OpenRA.Game/GameRules/ActorInfo.cs
+++ b/OpenRA.Game/GameRules/ActorInfo.cs
@@ -147,20 +147,6 @@ namespace OpenRA
 				.Select(t => t.GetGenericArguments()[0]);
 		}
 
-		public IEnumerable<Pair<string, Type>> GetInitKeys()
-		{
-			var inits = traits.WithInterface<ITraitInfo>().SelectMany(
-				t => t.GetType().GetInterfaces()
-					.Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(UsesInit<>))
-					.Select(i => i.GetGenericArguments()[0])).ToList();
-
-			inits.Add(typeof(OwnerInit));		/* not exposed by a trait; this is used by the Actor itself */
-
-			return inits.Select(
-				i => Pair.New(
-					i.Name.Replace("Init", ""), i));
-		}
-
 		public bool HasTraitInfo<T>() where T : ITraitInfoInterface { return traits.Contains<T>(); }
 		public T TraitInfo<T>() where T : ITraitInfoInterface { return traits.Get<T>(); }
 		public T TraitInfoOrDefault<T>() where T : ITraitInfoInterface { return traits.GetOrDefault<T>(); }

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -343,8 +343,6 @@ namespace OpenRA.Traits
 
 	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1302:InterfaceNamesMustBeginWithI", Justification = "Not a real interface, but more like a tag.")]
 	public interface Requires<T> where T : class, ITraitInfoInterface { }
-	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1302:InterfaceNamesMustBeginWithI", Justification = "Not a real interface, but more like a tag.")]
-	public interface UsesInit<T> : ITraitInfo where T : IActorInit { }
 
 	[RequireExplicitImplementation]
 	public interface INotifySelected { void Selected(Actor self); }

--- a/OpenRA.Mods.Cnc/Traits/Render/WithEmbeddedTurretSpriteBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithEmbeddedTurretSpriteBody.cs
@@ -34,7 +34,9 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 			var wsb = init.Actor.TraitInfos<WithSpriteBodyInfo>().FirstOrDefault();
 
 			// Show the correct turret facing
-			var anim = new Animation(init.World, image, () => t.InitialFacing);
+			var facing = init.Contains<TurretFacingInit>() ? init.Get<TurretFacingInit>().Value(init.World) : t.InitialFacing;
+
+			var anim = new Animation(init.World, image, () => facing);
 			anim.PlayRepeating(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), wsb.Sequence));
 
 			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, p, rs.Scale);

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -19,8 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	public class TDGunboatInfo : ITraitInfo, IPositionableInfo, IFacingInfo, IMoveInfo,
-		UsesInit<LocationInit>, UsesInit<FacingInit>, IActorPreviewInitInfo
+	public class TDGunboatInfo : ITraitInfo, IPositionableInfo, IFacingInfo, IMoveInfo, IActorPreviewInitInfo
 	{
 		public readonly int Speed = 28;
 

--- a/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorDefaultBrush.cs
@@ -102,24 +102,6 @@ namespace OpenRA.Mods.Common.Widgets
 				if (mapResources.Contains(cell) && mapResources[cell].Type != 0)
 					mapResources[cell] = new ResourceTile();
 			}
-			else if (mi.Event == MouseInputEvent.Scroll)
-			{
-				if (underCursor != null)
-				{
-					// Test case / demonstration of how to edit an existing actor
-					var facing = underCursor.Init<FacingInit>();
-					if (facing != null)
-						underCursor.ReplaceInit(new FacingInit((facing.Value(world) + mi.ScrollDelta) % 256));
-					else if (underCursor.Info.HasTraitInfo<UsesInit<FacingInit>>())
-						underCursor.ReplaceInit(new FacingInit(mi.ScrollDelta));
-
-					var turret = underCursor.Init<TurretFacingInit>();
-					if (turret != null)
-						underCursor.ReplaceInit(new TurretFacingInit((turret.Value(world) + mi.ScrollDelta) % 256));
-					else if (underCursor.Info.HasTraitInfo<UsesInit<TurretFacingInit>>())
-						underCursor.ReplaceInit(new TurretFacingInit(mi.ScrollDelta));
-				}
-			}
 
 			return true;
 		}

--- a/OpenRA.Mods.Common/Graphics/ActorPreview.cs
+++ b/OpenRA.Mods.Common/Graphics/ActorPreview.cs
@@ -96,16 +96,16 @@ namespace OpenRA.Mods.Common.Graphics
 			if (hf <= 0)
 				return DamageState.Dead;
 
-			if (hf < 0.25f)
+			if (hf < 25)
 				return DamageState.Critical;
 
-			if (hf < 0.5f)
+			if (hf < 50)
 				return DamageState.Heavy;
 
-			if (hf < 0.75f)
+			if (hf < 75)
 				return DamageState.Medium;
 
-			if (hf < 1.0f)
+			if (hf < 100)
 				return DamageState.Light;
 
 			return DamageState.Undamaged;

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -23,7 +23,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	public class AircraftInfo : ITraitInfo, IPositionableInfo, IFacingInfo, IMoveInfo, ICruiseAltitudeInfo,
-		IActorPreviewInitInfo
+		IActorPreviewInitInfo, IEditorActorOptions
 	{
 		public readonly WDist CruiseAltitude = new WDist(1280);
 
@@ -111,6 +111,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Facing to use for actor previews (map editor, color picker, etc)")]
 		public readonly int PreviewFacing = 92;
 
+		[Desc("Display order for the facing slider in the map editor")]
+		public readonly int EditorFacingDisplayOrder = 3;
+
 		public int GetInitialFacing() { return InitialFacing; }
 		public WDist GetCruiseAltitude() { return CruiseAltitude; }
 
@@ -146,6 +149,17 @@ namespace OpenRA.Mods.Common.Traits
 				return true;
 
 			return !world.ActorMap.GetActorsAt(cell).Any(x => x != ignoreActor);
+		}
+
+		IEnumerable<EditorActorOption> IEditorActorOptions.ActorOptions(ActorInfo ai, World world)
+		{
+			yield return new EditorActorSlider("Facing", EditorFacingDisplayOrder, 0, 255, 8,
+				actor =>
+				{
+					var init = actor.Init<FacingInit>();
+					return init != null ? init.Value(world) : InitialFacing;
+				},
+				(actor, value) => actor.ReplaceInit(new FacingInit((int)value)));
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -23,7 +23,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	public class AircraftInfo : ITraitInfo, IPositionableInfo, IFacingInfo, IMoveInfo, ICruiseAltitudeInfo,
-		UsesInit<LocationInit>, UsesInit<FacingInit>, IActorPreviewInitInfo
+		IActorPreviewInitInfo
 	{
 		public readonly WDist CruiseAltitude = new WDist(1280);
 

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("The actor will automatically engage the enemy when it is in range.")]
-	public class AutoTargetInfo : ConditionalTraitInfo, IRulesetLoaded, Requires<AttackBaseInfo>, UsesInit<StanceInit>
+	public class AutoTargetInfo : ConditionalTraitInfo, IRulesetLoaded, Requires<AttackBaseInfo>
 	{
 		[Desc("It will try to hunt down the enemy if it is set to AttackAnything.")]
 		public readonly bool AllowMovement = true;

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		OccupiedUntargetable = 'X'
 	}
 
-	public class BuildingInfo : ITraitInfo, IOccupySpaceInfo, IPlaceBuildingDecorationInfo, UsesInit<LocationInit>
+	public class BuildingInfo : ITraitInfo, IOccupySpaceInfo, IPlaceBuildingDecorationInfo
 	{
 		[Desc("Where you are allowed to place the building (Water, Clear, ...)")]
 		public readonly HashSet<string> TerrainTypes = new HashSet<string>();

--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class HealthInfo : IHealthInfo, UsesInit<HealthInit>, IRulesetLoaded
+	public class HealthInfo : IHealthInfo, IRulesetLoaded
 	{
 		[Desc("HitPoints")]
 		public readonly int HP = 0;

--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -9,19 +9,23 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class HealthInfo : IHealthInfo, IRulesetLoaded
+	public class HealthInfo : IHealthInfo, IRulesetLoaded, IEditorActorOptions
 	{
 		[Desc("HitPoints")]
 		public readonly int HP = 0;
 
 		[Desc("Trigger interfaces such as AnnounceOnKill?")]
 		public readonly bool NotifyAppliedDamage = true;
+
+		[Desc("Display order for the health slider in the map editor")]
+		public readonly int EditorHealthDisplayOrder = 2;
 
 		public virtual object Create(ActorInitializer init) { return new Health(init, this); }
 
@@ -32,6 +36,17 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		int IHealthInfo.MaxHP { get { return HP; } }
+
+		IEnumerable<EditorActorOption> IEditorActorOptions.ActorOptions(ActorInfo ai, World world)
+		{
+			yield return new EditorActorSlider("Health", EditorHealthDisplayOrder, 0, 100, 5,
+				actor =>
+				{
+					var init = actor.Init<HealthInit>();
+					return init != null ? init.Value(world) : 100;
+				},
+				(actor, value) => actor.ReplaceInit(new HealthInit((int)value)));
+		}
 	}
 
 	public class Health : IHealth, ISync, ITick, INotifyCreated, INotifyOwnerChanged

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -22,8 +22,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Unit is able to move.")]
-	public class MobileInfo : ConditionalTraitInfo, IMoveInfo, IPositionableInfo, IFacingInfo,
-		UsesInit<FacingInit>, UsesInit<LocationInit>, UsesInit<SubCellInit>, IActorPreviewInitInfo
+	public class MobileInfo : ConditionalTraitInfo, IMoveInfo, IPositionableInfo, IFacingInfo, IActorPreviewInitInfo
 	{
 		[Desc("Which Locomotor does this trait use. Must be defined on the World actor.")]
 		[LocomotorReference, FieldLoader.Require]

--- a/OpenRA.Mods.Common/Traits/Pluggable.cs
+++ b/OpenRA.Mods.Common/Traits/Pluggable.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class PluggableInfo : ITraitInfo, UsesInit<PlugsInit>
+	public class PluggableInfo : ITraitInfo
 	{
 		[Desc("Footprint cell offset where a plug can be placed.")]
 		public readonly CVec Offset = CVec.Zero;

--- a/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Produce a unit on the closest map edge cell and move into the world.")]
-	class ProductionFromMapEdgeInfo : ProductionInfo, UsesInit<ProductionSpawnLocationInit>
+	class ProductionFromMapEdgeInfo : ProductionInfo
 	{
 		public override object Create(ActorInitializer init) { return new ProductionFromMapEdge(init, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/ScriptTags.cs
+++ b/OpenRA.Mods.Common/Traits/ScriptTags.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Allows this actor to be 'tagged' with arbitrary strings. Tags must be unique or they will be rejected.")]
-	public class ScriptTagsInfo : UsesInit<ScriptTagsInit>
+	public class ScriptTagsInfo : ITraitInfo
 	{
 		object ITraitInfo.Create(ActorInitializer init) { return new ScriptTags(init, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class TurretedInfo : PausableConditionalTraitInfo, UsesInit<TurretFacingInit>, Requires<BodyOrientationInfo>, IActorPreviewInitInfo
+	public class TurretedInfo : PausableConditionalTraitInfo, Requires<BodyOrientationInfo>, IActorPreviewInitInfo
 	{
 		public readonly string Turret = "primary";
 		[Desc("Speed at which the turret turns.")]

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class TurretedInfo : PausableConditionalTraitInfo, Requires<BodyOrientationInfo>, IActorPreviewInitInfo
+	public class TurretedInfo : PausableConditionalTraitInfo, Requires<BodyOrientationInfo>, IActorPreviewInitInfo, IEditorActorOptions
 	{
 		public readonly string Turret = "primary";
 		[Desc("Speed at which the turret turns.")]
@@ -33,12 +33,41 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Facing to use for actor previews (map editor, color picker, etc)")]
 		public readonly int PreviewFacing = 92;
 
+		[Desc("Display order for the turret facing slider in the map editor")]
+		public readonly int EditorTurretFacingDisplayOrder = 4;
+
 		IEnumerable<object> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)
 		{
 			// HACK: The ActorInit system does not support multiple instances of the same type
 			// Make sure that we only return one TurretFacingInit, even for actors with multiple turrets
 			if (ai.TraitInfos<TurretedInfo>().FirstOrDefault() == this)
 				yield return new TurretFacingInit(PreviewFacing);
+		}
+
+		IEnumerable<EditorActorOption> IEditorActorOptions.ActorOptions(ActorInfo ai, World world)
+		{
+			// TODO: Handle multiple turrets properly (will probably require a rewrite of the Init system)
+			if (ai.TraitInfos<TurretedInfo>().FirstOrDefault() != this)
+				yield break;
+
+			yield return new EditorActorSlider("Turret", EditorTurretFacingDisplayOrder, 0, 255, 8,
+				actor =>
+				{
+					var init = actor.Init<TurretFacingInit>();
+					if (init != null)
+						return init.Value(world);
+
+					var facingInit = actor.Init<FacingInit>();
+					if (facingInit != null)
+						return facingInit.Value(world);
+
+					return InitialFacing;
+				},
+				(actor, value) =>
+				{
+					actor.RemoveInit<TurretFacingsInit>();
+					actor.ReplaceInit(new TurretFacingInit((int)value));
+				});
 		}
 
 		public override object Create(ActorInitializer init) { return new Turreted(init, this); }

--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -134,6 +134,14 @@ namespace OpenRA.Mods.Common.Traits
 			GeneratePreviews();
 		}
 
+		public void RemoveInit<T>()
+		{
+			var original = actor.InitDict.GetOrDefault<T>();
+			if (original != null)
+				actor.InitDict.Remove(original);
+			GeneratePreviews();
+		}
+
 		public T Init<T>()
 		{
 			return actor.InitDict.GetOrDefault<T>();

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using OpenRA.Activities;
@@ -450,4 +451,62 @@ namespace OpenRA.Mods.Common.Traits
 
 	[RequireExplicitImplementation]
 	public interface IBotTick { void BotTick(IBot bot); }
+
+	[RequireExplicitImplementation]
+	public interface IEditorActorOptions : ITraitInfoInterface
+	{
+		IEnumerable<EditorActorOption> ActorOptions(ActorInfo ai, World world);
+	}
+
+	public abstract class EditorActorOption
+	{
+		public readonly string Name;
+		public readonly int DisplayOrder;
+
+		public EditorActorOption(string name, int displayOrder)
+		{
+			Name = name;
+			DisplayOrder = displayOrder;
+		}
+	}
+
+	public class EditorActorSlider : EditorActorOption
+	{
+		public readonly float MinValue;
+		public readonly float MaxValue;
+		public readonly int Ticks;
+		public readonly Func<EditorActorPreview, float> GetValue;
+		public readonly Action<EditorActorPreview, float> OnChange;
+
+		public EditorActorSlider(string name, int displayOrder,
+			float minValue, float maxValue, int ticks,
+			Func<EditorActorPreview, float> getValue,
+			Action<EditorActorPreview, float> onChange)
+			: base(name, displayOrder)
+		{
+			MinValue = minValue;
+			MaxValue = maxValue;
+			Ticks = ticks;
+			GetValue = getValue;
+			OnChange = onChange;
+		}
+	}
+
+	public class EditorActorDropdown : EditorActorOption
+	{
+		public readonly Dictionary<string, string> Labels;
+		public readonly Func<EditorActorPreview, string> GetValue;
+		public readonly Action<EditorActorPreview, string> OnChange;
+
+		public EditorActorDropdown(string name, int displayOrder,
+			Dictionary<string, string> labels,
+			Func<EditorActorPreview, string> getValue,
+			Action<EditorActorPreview, string> onChange)
+			: base(name, displayOrder)
+		{
+			Labels = labels;
+			GetValue = getValue;
+			OnChange = onChange;
+		}
+	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -31,14 +31,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly LabelWidget typeLabel;
 		readonly TextFieldWidget actorIDField;
 		readonly LabelWidget actorIDErrorLabel;
-		readonly DropDownButtonWidget ownersDropDown;
+
 		readonly Widget initContainer;
 		readonly Widget buttonContainer;
+
+		readonly Widget sliderOptionTemplate;
+		readonly Widget dropdownOptionTemplate;
 
 		readonly int editPanelPadding; // Padding between right edge of actor and the edit panel.
 		readonly long scrollVisibleTimeout = 100; // Delay after scrolling map before edit widget becomes visible again.
 		long lastScrollTime = 0;
-		PlayerReference selectedOwner;
 
 		ActorIDStatus actorIDStatus = ActorIDStatus.Normal;
 		ActorIDStatus nextActorIDStatus = ActorIDStatus.Normal;
@@ -78,10 +80,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			typeLabel = actorEditPanel.Get<LabelWidget>("ACTOR_TYPE_LABEL");
 			actorIDField = actorEditPanel.Get<TextFieldWidget>("ACTOR_ID");
 
-			ownersDropDown = actorEditPanel.Get<DropDownButtonWidget>("OWNERS_DROPDOWN");
-
 			initContainer = actorEditPanel.Get("ACTOR_INIT_CONTAINER");
 			buttonContainer = actorEditPanel.Get("BUTTON_CONTAINER");
+
+			sliderOptionTemplate = initContainer.Get("SLIDER_OPTION_TEMPLATE");
+			dropdownOptionTemplate = initContainer.Get("DROPDOWN_OPTION_TEMPLATE");
+			initContainer.RemoveChildren();
 
 			var deleteButton = actorEditPanel.Get<ButtonWidget>("DELETE_BUTTON");
 			var closeButton = actorEditPanel.Get<ButtonWidget>("CLOSE_BUTTON");
@@ -137,34 +141,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (actorIDStatus != ActorIDStatus.Normal)
 					SetActorID(world, initialActorID);
 			};
-
-			// Setup owners drop down
-			selectedOwner = editorActorLayer.Players.Players.Values.First();
-			Func<PlayerReference, ScrollItemWidget, ScrollItemWidget> setupItem = (option, template) =>
-			{
-				var item = ScrollItemWidget.Setup(template, () => selectedOwner == option, () =>
-				{
-					ownersDropDown.Text = option.Name;
-					ownersDropDown.TextColor = option.Color.RGB;
-					selectedOwner = option;
-
-					CurrentActor.Owner = selectedOwner;
-					CurrentActor.ReplaceInit(new OwnerInit(selectedOwner.Name));
-				});
-
-				item.Get<LabelWidget>("LABEL").GetText = () => option.Name;
-				item.GetColor = () => option.Color.RGB;
-				return item;
-			};
-
-			ownersDropDown.OnClick = () =>
-			{
-				var owners = editorActorLayer.Players.Players.Values.OrderBy(p => p.Name);
-				ownersDropDown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 270, owners, setupItem);
-			};
-
-			ownersDropDown.Text = selectedOwner.Name;
-			ownersDropDown.TextColor = selectedOwner.Color.RGB;
 		}
 
 		void SetActorID(World world, string actorId)
@@ -206,10 +182,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				if (CurrentActor != actor)
 				{
 					lastScrollTime = 0; // Ensure visible
-					selectedOwner = actor.Owner;
-					ownersDropDown.Text = selectedOwner.Name;
-					ownersDropDown.TextColor = selectedOwner.Color.RGB;
-
 					CurrentActor = actor;
 
 					initialActorID = actorIDField.Text = actor.ID;
@@ -222,6 +194,96 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					actorSelectBorder.Bounds.Width = actor.Bounds.Width * 2;
 					actorSelectBorder.Bounds.Height = actor.Bounds.Height * 2;
 					nextActorIDStatus = ActorIDStatus.Normal;
+
+					// Remove old widgets
+					var oldInitHeight = initContainer.Bounds.Height;
+					initContainer.Bounds.Height = 0;
+					initContainer.RemoveChildren();
+
+					// Add owner dropdown
+					var ownerContainer = dropdownOptionTemplate.Clone();
+					ownerContainer.Get<LabelWidget>("LABEL").GetText = () => "Owner";
+					var ownerDropdown = ownerContainer.Get<DropDownButtonWidget>("OPTION");
+					var selectedOwner = actor.Owner;
+
+					Func<PlayerReference, ScrollItemWidget, ScrollItemWidget> setupItem = (option, template) =>
+					{
+						var item = ScrollItemWidget.Setup(template, () => selectedOwner == option, () =>
+						{
+							selectedOwner = option;
+							CurrentActor.Owner = selectedOwner;
+							CurrentActor.ReplaceInit(new OwnerInit(selectedOwner.Name));
+						});
+
+						item.Get<LabelWidget>("LABEL").GetText = () => option.Name;
+						item.GetColor = () => option.Color.RGB;
+						return item;
+					};
+
+					ownerDropdown.GetText = () => selectedOwner.Name;
+					ownerDropdown.GetColor = () => selectedOwner.Color.RGB;
+					ownerDropdown.OnClick = () =>
+					{
+						var owners = editorActorLayer.Players.Players.Values.OrderBy(p => p.Name);
+						ownerDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 270, owners, setupItem);
+					};
+
+					initContainer.Bounds.Height += ownerContainer.Bounds.Height;
+					initContainer.AddChild(ownerContainer);
+
+					// Add new children for inits
+					var options = actor.Info.TraitInfos<IEditorActorOptions>()
+						.SelectMany(t => t.ActorOptions(actor.Info, worldRenderer.World))
+						.OrderBy(o => o.DisplayOrder);
+
+					foreach (var o in options)
+					{
+						if (o is EditorActorSlider)
+						{
+							var so = (EditorActorSlider)o;
+							var sliderContainer = sliderOptionTemplate.Clone();
+							sliderContainer.Bounds.Y = initContainer.Bounds.Height;
+							initContainer.Bounds.Height += sliderContainer.Bounds.Height;
+							sliderContainer.Get<LabelWidget>("LABEL").GetText = () => so.Name;
+
+							var slider = sliderContainer.Get<SliderWidget>("OPTION");
+							slider.MinimumValue = so.MinValue;
+							slider.MaximumValue = so.MaxValue;
+							slider.Ticks = so.Ticks;
+
+							slider.GetValue = () => so.GetValue(actor);
+							slider.OnChange += value => so.OnChange(actor, value);
+
+							initContainer.AddChild(sliderContainer);
+						}
+						else if (o is EditorActorDropdown)
+						{
+							var ddo = (EditorActorDropdown)o;
+							var dropdownContainer = dropdownOptionTemplate.Clone();
+							dropdownContainer.Bounds.Y = initContainer.Bounds.Height;
+							initContainer.Bounds.Height += dropdownContainer.Bounds.Height;
+							dropdownContainer.Get<LabelWidget>("LABEL").GetText = () => ddo.Name;
+
+							var dropdown = dropdownContainer.Get<DropDownButtonWidget>("OPTION");
+							Func<KeyValuePair<string, string>, ScrollItemWidget, ScrollItemWidget> dropdownSetup = (option, template) =>
+							{
+								var item = ScrollItemWidget.Setup(template,
+									() => ddo.GetValue(actor) == option.Key,
+									() => ddo.OnChange(actor, option.Key));
+
+								item.Get<LabelWidget>("LABEL").GetText = () => option.Value;
+								return item;
+							};
+
+							dropdown.GetText = () => ddo.Labels[ddo.GetValue(actor)];
+							dropdown.OnClick = () => dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 270, ddo.Labels, dropdownSetup);
+
+							initContainer.AddChild(dropdownContainer);
+						}
+					}
+
+					actorEditPanel.Bounds.Height += initContainer.Bounds.Height - oldInitHeight;
+					buttonContainer.Bounds.Y += initContainer.Bounds.Height - oldInitHeight;
 				}
 
 				actorSelectBorder.Bounds.X = origin.X;

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -232,7 +232,7 @@ Container@EDITOR_WORLD_ROOT:
 				Background@ACTOR_EDIT_PANEL:
 					Background: panel-black
 					Width: 269
-					Height: 114
+					Height: 89
 					Children:
 						Label@ACTOR_TYPE_LABEL:
 							X: 2
@@ -242,21 +242,20 @@ Container@EDITOR_WORLD_ROOT:
 							Align: Center
 							Font: Bold
 						Label@ACTOR_ID_LABEL:
-							X: 0
 							Y: 29
 							Width: 55
 							Height: 24
 							Text: ID
 							Align: Right
 						TextField@ACTOR_ID:
-							X: 65
+							X: 67
 							Y: 29
-							Width: 200
+							Width: 189
 							Height: 25
 						Label@ACTOR_ID_ERROR_LABEL:
-							X: 65
+							X: 67
 							Y: 54
-							Width: 260
+							Width: 189
 							Height: 15
 							Font: TinyBold
 							TextColor: FF0000
@@ -264,18 +263,36 @@ Container@EDITOR_WORLD_ROOT:
 							Y: 57
 							Width: PARENT_RIGHT
 							Children:
-								Label@OWNERS_LABEL:
-									Width: 55
-									Height: 24
-									Text: Owner
-									Align: Right
-								DropDownButton@OWNERS_DROPDOWN:
-									X: 65
-									Width: 200
-									Height: 25
-									Font: Bold
+								Container@SLIDER_OPTION_TEMPLATE:
+									Width: PARENT_RIGHT
+									Height: 22
+									Children:
+										Label@LABEL:
+											Width: 55
+											Height: 16
+											Align: Right
+										Slider@OPTION:
+											X: 58
+											Y: 1
+											Width: 207
+											Height: 20
+								Container@DROPDOWN_OPTION_TEMPLATE:
+									Width: PARENT_RIGHT
+									Height: 27
+									Children:
+										Label@LABEL:
+											Y: 1
+											Width: 55
+											Height: 24
+											Align: Right
+										DropDownButton@OPTION:
+											X: 67
+											Y: 1
+											Width: 189
+											Height: 25
+											Font: Bold
 						Container@BUTTON_CONTAINER:
-							Y: 85
+							Y: 60
 							Children:
 								Button@DELETE_BUTTON:
 									X: 4

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -224,11 +224,6 @@ Container@EDITOR_WORLD_ROOT:
 					Visible: false
 				ActorPreview@DRAG_ACTOR_PREVIEW:
 					Visible: false
-				Container@ACTOR_SELECT_BORDER:
-					X: 32
-					Y: 32
-					Width: 32
-					Height: 32
 				Background@ACTOR_EDIT_PANEL:
 					Background: panel-black
 					Width: 269

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -224,7 +224,7 @@ Container@EDITOR_WORLD_ROOT:
 					X: 32
 					Y: 32
 					Width: 294
-					Height: 144
+					Height: 114
 					Children:
 						Label@ACTOR_TYPE_LABEL:
 							X: 15
@@ -241,34 +241,53 @@ Container@EDITOR_WORLD_ROOT:
 							Text: ID
 							Align: Right
 						TextField@ACTOR_ID:
-							X: 80
+							X: 84
 							Y: 45
-							Width: 200
+							Width: 192
 							Height: 25
 						Label@ACTOR_ID_ERROR_LABEL:
-							X: 80
+							X: 84
 							Y: 70
-							Width: 260
+							Width: 192
 							Height: 15
 							Font: TinyBold
 							TextColor: FF0000
 						Container@ACTOR_INIT_CONTAINER:
-							Y: 75
+							Y: 73
 							Width: PARENT_RIGHT
 							Children:
-								Label@OWNERS_LABEL:
-									X: 15
-									Width: 55
-									Height: 24
-									Text: Owner
-									Align: Right
-								DropDownButton@OWNERS_DROPDOWN:
-									X: 80
-									Width: 200
-									Height: 25
-									Font: Bold
+								Container@SLIDER_OPTION_TEMPLATE:
+									Width: PARENT_RIGHT
+									Height: 22
+									Children:
+										Label@LABEL:
+											X: 15
+											Width: 55
+											Height: 16
+											Align: Right
+										Slider@OPTION:
+											X: 75
+											Y: 1
+											Width: 210
+											Height: 20
+								Container@DROPDOWN_OPTION_TEMPLATE:
+									Width: PARENT_RIGHT
+									Height: 27
+									Children:
+										Label@LABEL:
+											X: 15
+											Y: 1
+											Width: 55
+											Height: 24
+											Align: Right
+										DropDownButton@OPTION:
+											X: 84
+											Y: 1
+											Width: 192
+											Height: 25
+											Font: Bold
 						Container@BUTTON_CONTAINER:
-							Y: 105
+							Y: 75
 							Children:
 								Button@DELETE_BUTTON:
 									X: 15

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -215,11 +215,6 @@ Container@EDITOR_WORLD_ROOT:
 					Visible: false
 				Sprite@DRAG_LAYER_PREVIEW:
 					Visible: false
-				Container@ACTOR_SELECT_BORDER:
-					X: 32
-					Y: 32
-					Width: 32
-					Height: 32
 				Background@ACTOR_EDIT_PANEL:
 					X: 32
 					Y: 32


### PR DESCRIPTION
This PR expands on #15551 by adding plumbing for trait-defined actor properties in the editor, and wiring up actor health, facing, turret facing and stance:

<img width="389" alt="screenshot 2018-12-03 at 11 40 05" src="https://user-images.githubusercontent.com/167819/49351875-56952900-f6f0-11e8-8f91-2f9e521b7cd5.png">

Fixes #15849.
Fixes #10818.