### PR TITLE
Fix Commando / Tanya voice announcements

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -312,6 +312,7 @@
     <Compile Include="Traits\CaptureProgressBar.cs" />
     <Compile Include="Traits\CaptureProgressBlink.cs" />
     <Compile Include="Traits\Conditions\GrantConditionOnPlayerResources.cs" />
+    <Compile Include="Traits\GrantExternalConditionToProduced.cs" />
     <Compile Include="Traits\Multipliers\CreatesShroudMultiplier.cs" />
     <Compile Include="Traits\Multipliers\RevealsShroudMultiplier.cs" />
     <Compile Include="Traits\RepairsUnits.cs" />

--- a/OpenRA.Mods.Common/Traits/GrantExternalConditionToProduced.cs
+++ b/OpenRA.Mods.Common/Traits/GrantExternalConditionToProduced.cs
@@ -1,0 +1,47 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Grants a condition to actors produced by this actor.")]
+	public class GrantExternalConditionToProducedInfo : ConditionalTraitInfo
+	{
+		[FieldLoader.Require]
+		[Desc("The condition to apply. Must be included in the produced actor's ExternalConditions list.")]
+		public readonly string Condition = null;
+
+		[Desc("Duration of the condition (in ticks). Set to 0 for a permanent condition.")]
+		public readonly int Duration = 0;
+
+		public override object Create(ActorInitializer init) { return new GrantExternalConditionToProduced(init.Self, this); }
+	}
+
+	public class GrantExternalConditionToProduced : ConditionalTrait<GrantExternalConditionToProducedInfo>, INotifyProduction
+	{
+		public GrantExternalConditionToProduced(Actor self, GrantExternalConditionToProducedInfo info)
+			: base(info) { }
+
+		void INotifyProduction.UnitProduced(Actor self, Actor other, CPos exit)
+		{
+			if (IsTraitDisabled || other.IsDead)
+				return;
+
+			var external = other.TraitsImplementing<ExternalCondition>()
+				.FirstOrDefault(t => t.Info.Condition == Info.Condition && t.CanGrantCondition(other, self));
+
+			if (external != null)
+				external.GrantCondition(other, self, Info.Duration);
+		}
+	}
+}

--- a/mods/cnc/rules/infantry.yaml
+++ b/mods/cnc/rules/infantry.yaml
@@ -227,7 +227,10 @@ RMBO:
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
 		IdleSequences: idle1,idle2,idle3
+	ExternalCondition@PRODUCED:
+		Condition: produced
 	VoiceAnnouncement:
+		RequiresCondition: produced
 		Voice: Build
 	AnnounceOnKill:
 	Voiced:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -311,6 +311,8 @@ PYLE:
 		ExitCell: 1,1
 	Production:
 		Produces: Infantry.GDI
+	GrantExternalConditionToProduced:
+		Condition: produced
 	ProductionQueue:
 		Type: Infantry.GDI
 		Group: Infantry

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -372,7 +372,10 @@ E7:
 	WithInfantryBody:
 		DefaultAttackSequence: shoot
 		StandSequences: stand
+	ExternalCondition@PRODUCED:
+		Condition: produced
 	VoiceAnnouncement:
+		RequiresCondition: produced
 		Voice: Build
 	AnnounceOnKill:
 	DetectCloaked:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1685,6 +1685,8 @@ BARR:
 		ProductionTypes: Soldier, Infantry
 	Production:
 		Produces: Infantry, Soldier
+	GrantExternalConditionToProduced:
+		Condition: produced
 	PrimaryBuilding:
 		PrimaryCondition: primary
 		SelectionNotification: PrimaryBuildingSelected
@@ -1829,6 +1831,8 @@ TENT:
 		ProductionTypes: Soldier, Infantry
 	Production:
 		Produces: Infantry, Soldier
+	GrantExternalConditionToProduced:
+		Condition: produced
 	PrimaryBuilding:
 		PrimaryCondition: primary
 		SelectionNotification: PrimaryBuildingSelected


### PR DESCRIPTION
This PR fixes the Commando / Tanya announcements playing when they are pre-placed on maps or created through scripts. Supersedes #15797, fixing a regression introduced by #15743.