### PR TITLE
Fix production tooltip padding.

### DIFF
--- a/mods/cnc/chrome/tooltips.yaml
+++ b/mods/cnc/chrome/tooltips.yaml
@@ -102,18 +102,19 @@ Background@PRODUCTION_TOOLTIP:
 		Label@REQUIRES:
 			X: 5
 			Y: 19
-			Height: 23
+			Height: 15
 			Font: TinyBold
 			Text: Requires {0}
 		Label@DESC:
 			X: 5
-			Y: 39
-			Height: 23
+			Y: 19
+			Height: 5
 			Font: TinyBold
 			VAlign: Top
 		Image@COST_ICON:
 			Y: 5
 			Width: 16
+			Height: 16
 			ImageCollection: sidebar-bits
 			ImageName: production-tooltip-cost
 		Label@COST:
@@ -123,6 +124,7 @@ Background@PRODUCTION_TOOLTIP:
 			X: 3
 			Y: 24
 			Width: 16
+			Height: 16
 			ImageCollection: sidebar-bits
 			ImageName: production-tooltip-time
 		Label@TIME:
@@ -132,6 +134,7 @@ Background@PRODUCTION_TOOLTIP:
 		Image@POWER_ICON:
 			Y: 44
 			Width: 16
+			Height: 16
 			ImageCollection: sidebar-bits
 			ImageName: production-tooltip-power
 		Label@POWER:

--- a/mods/common/chrome/tooltips.yaml
+++ b/mods/common/chrome/tooltips.yaml
@@ -246,19 +246,20 @@ Background@PRODUCTION_TOOLTIP:
 			Font: Bold
 		Label@REQUIRES:
 			X: 7
-			Y: 21
-			Height: 23
+			Y: 25
+			Height: 15
 			Font: TinyBold
 			Text: Requires {0}
 		Label@DESC:
 			X: 7
-			Y: 41
-			Height: 23
+			Y: 25
+			Height: 2
 			Font: TinyBold
 			VAlign: Top
 		Image@COST_ICON:
 			Y: 5
 			Width: 16
+			Height: 16
 			ImageCollection: sidebar-bits
 			ImageName: production-tooltip-cost
 		Label@COST:
@@ -268,6 +269,7 @@ Background@PRODUCTION_TOOLTIP:
 			X: 3
 			Y: 26
 			Width: 16
+			Height: 16
 			ImageCollection: sidebar-bits
 			ImageName: production-tooltip-time
 		Label@TIME:
@@ -277,6 +279,7 @@ Background@PRODUCTION_TOOLTIP:
 		Image@POWER_ICON:
 			Y: 46
 			Width: 16
+			Height: 16
 			ImageCollection: sidebar-bits
 			ImageName: production-tooltip-power
 		Label@POWER:

--- a/mods/d2k/chrome/tooltips.yaml
+++ b/mods/d2k/chrome/tooltips.yaml
@@ -250,18 +250,19 @@ Background@PRODUCTION_TOOLTIP:
 		Label@REQUIRES:
 			X: 7
 			Y: 21
-			Height: 23
+			Height: 15
 			Font: TinyBold
 			Text: Requires {0}
 		Label@DESC:
 			X: 7
-			Y: 41
-			Height: 23
+			Y: 21
+			Height: 5
 			Font: TinyBold
 			VAlign: Top
 		Image@COST_ICON:
 			Y: 5
 			Width: 16
+			Height: 16
 			ImageCollection: sidebar-bits
 			ImageName: production-tooltip-cost
 		Label@COST:
@@ -271,6 +272,7 @@ Background@PRODUCTION_TOOLTIP:
 			X: 3
 			Y: 26
 			Width: 16
+			Height: 16
 			ImageCollection: sidebar-bits
 			ImageName: production-tooltip-time
 		Label@TIME:
@@ -280,6 +282,7 @@ Background@PRODUCTION_TOOLTIP:
 		Image@POWER_ICON:
 			Y: 46
 			Width: 16
+			Height: 16
 			ImageCollection: sidebar-bits
 			ImageName: production-tooltip-power
 		Label@POWER:


### PR DESCRIPTION
This PR fixes the background padding calculation used by the produciton tooltip, which gets proportionally more wrong as the description size gets bigger.

Before:
<img width="279" alt="image" src="https://user-images.githubusercontent.com/167819/49545843-aae41700-f943-11e8-8d7c-e4c55cf466d6.png">

After:
<img width="288" alt="image" src="https://user-images.githubusercontent.com/167819/49546470-31e5bf00-f945-11e8-8932-65a903a8c171.png">
