### PR TITLE
RA balance change for December 2018

### DIFF
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -360,6 +360,10 @@
 	AttackMove:
 	Passenger:
 		CargoType: Infantry
+		CargoCondition: disable-experience
+	GainsExperienceMultiplier:
+		Modifier: 0
+		RequiresCondition: disable-experience
 	HiddenUnderFog:
 	ActorLostNotification:
 	GpsDot:


### PR DESCRIPTION
Orb has headed up the balance testing this time around. I posted his thoughts on the balance changes on [this forum thread](https://forum.openra.net/viewtopic.php?f=82&t=20826). Here is the summary for this PR:

- Infantry in pillboxes will no longer gain experience.

- ~~Reload delay increased from 85 to 90. Projectile speed decreased from 204 to 170. Accuracy increased from 1c938 to 0c614. Splash Damage now has a falloff range. Damage vs infantry reduced from 90% to 40%, and damage vs light armor reduced from 60% to 35%.~~

- ~~Chronoshift return duration reduced by 20%~~

- ~~Medic/Mechanic speed reduced to 50 from 56~~

- ~~Camo pillbox price increased to 800 from 700. Cloak delay increased from 60 to 125.~~

Edit: As discussed on Discord, I've reduced this PR to just the pillbox experience change. The other changes will be tested in custom maps when the playtest comes out.