### PR TITLE
Fix two typos in TD music.yaml

### DIFF
--- a/mods/cnc/audio/music.yaml
+++ b/mods/cnc/audio/music.yaml
@@ -19,7 +19,7 @@ justdoit: Just Do It Up
 justdoit2: Just Do It Up (SFX)
 	Filename: justdoit
 	Extension: var
-jdi_v2: Just Do It Up 2 (Take 'Em out)
+jdi_v2: Just Do It Up 2 (Take 'Em Out)
 map1: Map Theme
 	Hidden: true
 march: March To Doom
@@ -58,7 +58,7 @@ befeared2: To Be Feared (SFX)
 crep226m: Creeping Upon
 chrg226m: Depth Charge
 die: Die
-dril225m: Drill
+dril226m: Drill
 dron226m: Drone
 fist226m: Iron Fist
 heart: Heartbreak


### PR DESCRIPTION
One major (filename typo, track wouldn't show up) and one minor (titles should be all uppercase).