### PR TITLE
Add check to prevent clearing path when unit is stopped in a tunnel.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -102,6 +102,7 @@ Also thanks to:
     * Matthijs Benschop (Nerdie)
     * Max621
     * Max Ugrumov (katzsmile)
+    * Mazar Farran (mazarf)
     * Michael Rätzel
     * Michael Silber (frühstück)
     * Michael Sztolcman (s1w_)

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -151,7 +151,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Although MoveFirstHalf and MoveSecondHalf can't be interrupted,
 			// we prevent them from moving forever by removing the path.
-			if (path != null)
+			if (path != null && self.Location.Layer != CustomMovementLayerType.Tunnel)
 				path.Clear();
 
 			// Remove queued activities


### PR DESCRIPTION
This fix prevents units from being stopped in the middle of a tunnel.  They will proceed to the end of the tunnel uninterrupted.

Related to issues #13239 and  #15853.