### PR TITLE
Fix "game is full" error when the game is not full.

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -334,13 +334,6 @@ namespace OpenRA.Server
 					IsAdmin = !LobbyInfo.Clients.Any(c1 => c1.IsAdmin)
 				};
 
-				if (client.IsObserver && !LobbyInfo.GlobalSettings.AllowSpectators)
-				{
-					SendOrderTo(newConn, "ServerError", "The game is full");
-					DropClient(newConn);
-					return;
-				}
-
 				if (ModData.Manifest.Id != handshake.Mod)
 				{
 					Log.Write("server", "Rejected connection from {0}; mods do not match.",
@@ -374,6 +367,13 @@ namespace OpenRA.Server
 				Action completeConnection = () =>
 				{
 					client.Slot = LobbyInfo.FirstEmptySlot();
+
+					if (client.IsObserver && !LobbyInfo.GlobalSettings.AllowSpectators)
+					{
+						SendOrderTo(newConn, "ServerError", "The game is full");
+						DropClient(newConn);
+						return;
+					}
 
 					if (client.Slot != null)
 						SyncClientToPlayerReference(client, Map.Players.Players[client.Slot]);


### PR DESCRIPTION
Fixes #15926.

We can push a server hotfix branch once this has been reviewed.