### PR TITLE
QueryRemoteMapDetails sets each maps's status now correctly

### DIFF
--- a/OpenRA.Game/Map/MapCache.cs
+++ b/OpenRA.Game/Map/MapCache.cs
@@ -205,6 +205,10 @@ namespace OpenRA
 					var yaml = MiniYaml.FromString(data);
 					foreach (var kv in yaml)
 						maps[kv.Key].UpdateRemoteSearch(MapStatus.DownloadAvailable, kv.Value, mapDetailsReceived);
+
+					foreach (var map in maps)
+						if (map.Value.Status != MapStatus.DownloadAvailable)
+							map.Value.UpdateRemoteSearch(MapStatus.Unavailable, null);
 				}
 				catch (Exception e)
 				{


### PR DESCRIPTION
Closes #15913 

Maps will not remain in Status Searching, if the search is already over.

This is my first PR. Hope I did everything right :).