### PR TITLE
Change existing husks to neutral when owner loses.

### DIFF
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -967,6 +967,8 @@
 		AllowedTerrain: Clear, Rough, Road, Ore, Gems, Beach
 	Burns:
 		Damage: 200
+	OwnerLostAction:
+		Action: ChangeOwner
 	CaptureManager:
 	Capturable:
 		Types: husk


### PR DESCRIPTION
The current behaviour on bleed regarding husks is:
* Actor dies during normal gameplay &rarr; Husk is owned by the original player
* Actor dies because owner loses &rarr; Husks is owned by the Neutral player
* Actor dies during normal gameplay, and the owner then loses &rarr; Husk is owned by the original player

Having different behaviour for husks spawned before and after a player loses is clearly a bug, so the obvious fix here is to change the owner for existing husks to neutral if the owner loses.  Remember that husks always show the tooltip and player colors for the original owner, even when owned by the neutral player.

It is important to fix this before the playtest because it leads to a nasty edge case with repairing ally MCV husks:
* MCV dies during normal gameplay &rarr; repaired MCV is restored to the original player
* MCV dies because owner loses &rarr; repaired MCV is restored to the mechanic's owner
* MCV dies during normal gameplay, and the owner then loses &rarr; repaired MCV is restored to the original player, who can then control and deploy it but not build anything because they have the observer interface instead of the sidebar.