### PR TITLE
Refactor Lua code in GDI missions

### DIFF
--- a/mods/cnc/bits/scripts/campaign-global.lua
+++ b/mods/cnc/bits/scripts/campaign-global.lua
@@ -1,0 +1,81 @@
+--[[
+   Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+   This file is part of OpenRA, which is free software. It is made
+   available to you under the terms of the GNU General Public License
+   as published by the Free Software Foundation, either version 3 of
+   the License, or (at your option) any later version. For more
+   information, see COPYING.
+]]
+
+Nod = Player.GetPlayer("Nod")
+GDI = Player.GetPlayer("GDI")
+
+Difficulty = Map.LobbyOption("difficulty")
+
+function InitObjectives(player)
+	Trigger.OnObjectiveAdded(player, function(p, id)
+		Media.DisplayMessage(p.GetObjectiveDescription(id), "New " .. string.lower(p.GetObjectiveType(id)) .. " objective")
+	end)
+	Trigger.OnObjectiveCompleted(player, function(p, id)
+		Media.DisplayMessage(p.GetObjectiveDescription(id), "Objective completed")
+	end)
+	Trigger.OnObjectiveFailed(player, function(p, id)
+		Media.DisplayMessage(p.GetObjectiveDescription(id), "Objective failed")
+	end)
+
+	Trigger.OnPlayerWon(player, function()
+		Media.PlaySpeechNotification(player, "Win")
+	end)
+
+	Trigger.OnPlayerLost(player, function()
+		Media.PlaySpeechNotification(player, "Lose")
+	end)
+end
+
+
+function CheckForBase(player, buildingTypes)
+	local buildings = 0
+
+	Utils.Do(buildingTypes, function(name)
+		if #player.GetActorsByType(name) > 0 then
+			buildings = buildings + 1
+		end
+	end)
+
+	return buildings == #buildingTypes
+end
+
+
+function ReinforceWithLandingCraft(player, units, transportStart, transportUnload, rallypoint)
+	Media.PlaySpeechNotification(player, "Reinforce")
+	local transport = Actor.Create("oldlst", true, { Owner = player, Facing = 0, Location = transportStart })
+	local subcell = 0
+	Utils.Do(units, function(a)
+		 transport.LoadPassenger(Actor.Create(a, false, { Owner = transport.Owner, Facing = transport.Facing, Location = transportUnload, SubCell = subcell }))
+		 subcell = subcell + 1
+	end)
+
+	transport.ScriptedMove(transportUnload)
+
+	transport.CallFunc(function()
+		Utils.Do(units, function()
+			local a = transport.UnloadPassenger()
+			a.IsInWorld = true
+			a.MoveIntoWorld(transport.Location - CVec.New(0, 1))
+
+			if rallypoint ~= nil then
+				a.Move(rallypoint)
+			end
+		end)
+	end)
+
+	transport.Wait(5)
+	transport.ScriptedMove(transportStart)
+	transport.Destroy()
+end
+
+
+kills = 0
+
+
+function KillCounter() kills = kills + 1 end

--- a/mods/cnc/maps/gdi01/gdi01.lua
+++ b/mods/cnc/maps/gdi01/gdi01.lua
@@ -12,84 +12,28 @@ VehicleReinforcements = { "jeep" }
 NodPatrol = { "e1", "e1" }
 GDIBaseBuildings = { "pyle", "fact", "nuke" }
 
-SendNodPatrol = function()
-	Reinforcements.Reinforce(enemy, NodPatrol, { nod0.Location, nod1.Location }, 15, function(soldier)
+
+function SendNodPatrol()
+	Reinforcements.Reinforce(Nod, NodPatrol, { nod0.Location, nod1.Location }, 15, function(soldier)
 		soldier.AttackMove(nod2.Location)
 		soldier.Move(nod3.Location)
 		soldier.Hunt()
 	end)
 end
 
-ReinforceWithLandingCraft = function(units, transportStart, transportUnload, rallypoint)
-	local transport = Actor.Create("oldlst", true, { Owner = player, Facing = 0, Location = transportStart })
-	local subcell = 0
-	Utils.Do(units, function(a)
-		transport.LoadPassenger(Actor.Create(a, false, { Owner = transport.Owner, Facing = transport.Facing, Location = transportUnload, SubCell = subcell }))
-		subcell = subcell + 1
-	end)
 
-	transport.ScriptedMove(transportUnload)
-
-	transport.CallFunc(function()
-		Utils.Do(units, function()
-			local a = transport.UnloadPassenger()
-			a.IsInWorld = true
-			a.MoveIntoWorld(transport.Location - CVec.New(0, 1))
-
-			if rallypoint ~= nil then
-				a.Move(rallypoint)
-			end
-		end)
-	end)
-
-	transport.Wait(5)
-	transport.ScriptedMove(transportStart)
-	transport.Destroy()
+function Reinforce(units)
+	ReinforceWithLandingCraft(GDI, units, lstStart.Location, lstEnd.Location, reinforcementsTarget.Location)
 end
 
-Reinforce = function(units)
-	Media.PlaySpeechNotification(player, "Reinforce")
-	ReinforceWithLandingCraft(units, lstStart.Location, lstEnd.Location, reinforcementsTarget.Location)
-end
 
-CheckForBase = function(player)
-	local buildings = 0
+function WorldLoaded()
+	InitObjectives(GDI)
 
-	Utils.Do(GDIBaseBuildings, function(name)
-		if #player.GetActorsByType(name) > 0 then
-			buildings = buildings + 1
-		end
-	end)
+	secureAreaObjective = GDI.AddPrimaryObjective("Eliminate all Nod forces in the area.")
+	beachheadObjective = GDI.AddSecondaryObjective("Establish a beachhead.")
 
-	return buildings == #GDIBaseBuildings
-end
-
-WorldLoaded = function()
-	player = Player.GetPlayer("GDI")
-	enemy = Player.GetPlayer("Nod")
-
-	Trigger.OnObjectiveAdded(player, function(p, id)
-		Media.DisplayMessage(p.GetObjectiveDescription(id), "New " .. string.lower(p.GetObjectiveType(id)) .. " objective")
-	end)
-	Trigger.OnObjectiveCompleted(player, function(p, id)
-		Media.DisplayMessage(p.GetObjectiveDescription(id), "Objective completed")
-	end)
-	Trigger.OnObjectiveFailed(player, function(p, id)
-		Media.DisplayMessage(p.GetObjectiveDescription(id), "Objective failed")
-	end)
-
-	Trigger.OnPlayerWon(player, function()
-		Media.PlaySpeechNotification(player, "Win")
-	end)
-
-	Trigger.OnPlayerLost(player, function()
-		Media.PlaySpeechNotification(player, "Lose")
-	end)
-
-	secureAreaObjective = player.AddPrimaryObjective("Eliminate all Nod forces in the area.")
-	beachheadObjective = player.AddSecondaryObjective("Establish a beachhead.")
-
-	ReinforceWithLandingCraft(MCVReinforcements, lstStart.Location + CVec.New(2, 0), lstEnd.Location + CVec.New(2, 0), mcvTarget.Location)
+	ReinforceWithLandingCraft(GDI, MCVReinforcements, lstStart.Location + CVec.New(2, 0), lstEnd.Location + CVec.New(2, 0), mcvTarget.Location)
 	Reinforce(InfantryReinforcements)
 
 	SendNodPatrol()
@@ -98,17 +42,18 @@ WorldLoaded = function()
 	Trigger.AfterDelay(DateTime.Seconds(60), function() Reinforce(VehicleReinforcements) end)
 end
 
-Tick = function()
-	if enemy.HasNoRequiredUnits() then
-		player.MarkCompletedObjective(secureAreaObjective)
+
+function Tick()
+	if Nod.HasNoRequiredUnits() then
+		GDI.MarkCompletedObjective(secureAreaObjective)
 	end
 
-	if DateTime.GameTime > DateTime.Seconds(5) and player.HasNoRequiredUnits() then
-		player.MarkFailedObjective(beachheadObjective)
-		player.MarkFailedObjective(secureAreaObjective)
+	if DateTime.GameTime > DateTime.Seconds(5) and GDI.HasNoRequiredUnits() then
+		GDI.MarkFailedObjective(beachheadObjective)
+		GDI.MarkFailedObjective(secureAreaObjective)
 	end
 
-	if DateTime.GameTime % DateTime.Seconds(1) == 0 and not player.IsObjectiveCompleted(beachheadObjective) and CheckForBase(player) then
-		player.MarkCompletedObjective(beachheadObjective)
+	if DateTime.GameTime % DateTime.Seconds(1) == 0 and not GDI.IsObjectiveCompleted(beachheadObjective) and CheckForBase(GDI, GDIBaseBuildings) then
+		GDI.MarkCompletedObjective(beachheadObjective)
 	end
 end

--- a/mods/cnc/maps/gdi01/rules.yaml
+++ b/mods/cnc/maps/gdi01/rules.yaml
@@ -1,6 +1,6 @@
 World:
 	LuaScript:
-		Scripts: gdi01.lua
+		Scripts: campaign-global.lua, gdi01.lua
 	MusicPlaylist:
 		StartingMusic: aoi
 	MissionData:

--- a/mods/cnc/maps/gdi02/gdi02.lua
+++ b/mods/cnc/maps/gdi02/gdi02.lua
@@ -13,47 +13,22 @@ VehicleReinforcements = { "jeep" }
 
 AttackerSquadSize = 3
 
-ReinforceWithLandingCraft = function(units, transportStart, transportUnload, rallypoint)
-	local transport = Actor.Create("oldlst", true, { Owner = player, Facing = 0, Location = transportStart })
-	local subcell = 0
-	Utils.Do(units, function(a)
-		transport.LoadPassenger(Actor.Create(a, false, { Owner = transport.Owner, Facing = transport.Facing, Location = transportUnload, SubCell = subcell }))
-		subcell = subcell + 1
-	end)
 
-	transport.ScriptedMove(transportUnload)
-
-	transport.CallFunc(function()
-		Utils.Do(units, function()
-			local a = transport.UnloadPassenger()
-			a.IsInWorld = true
-			a.MoveIntoWorld(transport.Location - CVec.New(0, 1))
-
-			if rallypoint ~= nil then
-				a.Move(rallypoint)
-			end
-		end)
-	end)
-
-	transport.Wait(5)
-	transport.ScriptedMove(transportStart)
-	transport.Destroy()
+function Reinforce(units)
+	ReinforceWithLandingCraft(GDI, units, lstStart.Location, lstEnd.Location)
 end
 
-Reinforce = function(units)
-	Media.PlaySpeechNotification(player, "Reinforce")
-	ReinforceWithLandingCraft(units, lstStart.Location, lstEnd.Location)
-end
 
-BridgeheadSecured = function()
+function BridgeheadSecured()
 	Reinforce(MobileConstructionVehicle)
 	Trigger.AfterDelay(DateTime.Seconds(15), NodAttack)
 	Trigger.AfterDelay(DateTime.Seconds(30), function() Reinforce(EngineerReinforcements) end)
 	Trigger.AfterDelay(DateTime.Seconds(120), function() Reinforce(VehicleReinforcements) end)
 end
 
-NodAttack = function()
-	local nodUnits = enemy.GetGroundAttackers()
+
+function NodAttack()
+	local nodUnits = Nod.GetGroundAttackers()
 	if #nodUnits > AttackerSquadSize * 2 then
 		local attackers = Utils.Skip(nodUnits, #nodUnits - AttackerSquadSize)
 		Utils.Do(attackers, function(unit)
@@ -64,43 +39,26 @@ NodAttack = function()
 	end
 end
 
-WorldLoaded = function()
-	player = Player.GetPlayer("GDI")
-	enemy = Player.GetPlayer("Nod")
 
-	Trigger.OnObjectiveAdded(player, function(p, id)
-		Media.DisplayMessage(p.GetObjectiveDescription(id), "New " .. string.lower(p.GetObjectiveType(id)) .. " objective")
-	end)
-	Trigger.OnObjectiveCompleted(player, function(p, id)
-		Media.DisplayMessage(p.GetObjectiveDescription(id), "Objective completed")
-	end)
-	Trigger.OnObjectiveFailed(player, function(p, id)
-		Media.DisplayMessage(p.GetObjectiveDescription(id), "Objective failed")
-	end)
+function WorldLoaded()
+	InitObjectives(GDI)
 
-	Trigger.OnPlayerWon(player, function()
-		Media.PlaySpeechNotification(player, "Win")
-	end)
+	nodObjective = Nod.AddPrimaryObjective("Destroy all GDI troops.")
+	gdiObjective1 = GDI.AddPrimaryObjective("Eliminate all Nod forces in the area.")
+	gdiObjective2 = GDI.AddSecondaryObjective("Capture the Tiberium refinery.")
 
-	Trigger.OnPlayerLost(player, function()
-		Media.PlaySpeechNotification(player, "Lose")
-	end)
-
-	nodObjective = enemy.AddPrimaryObjective("Destroy all GDI troops.")
-	gdiObjective1 = player.AddPrimaryObjective("Eliminate all Nod forces in the area.")
-	gdiObjective2 = player.AddSecondaryObjective("Capture the Tiberium refinery.")
-
-	Trigger.OnCapture(NodRefinery, function() player.MarkCompletedObjective(gdiObjective2) end)
-	Trigger.OnKilled(NodRefinery, function() player.MarkFailedObjective(gdiObjective2) end)
+	Trigger.OnCapture(NodRefinery, function() GDI.MarkCompletedObjective(gdiObjective2) end)
+	Trigger.OnKilled(NodRefinery, function() GDI.MarkFailedObjective(gdiObjective2) end)
 
 	Trigger.OnAllKilled(nodInBaseTeam, BridgeheadSecured)
 end
 
-Tick = function()
-	if player.HasNoRequiredUnits() then
-		enemy.MarkCompletedObjective(nodObjective)
+
+function Tick()
+	if GDI.HasNoRequiredUnits() then
+		Nod.MarkCompletedObjective(nodObjective)
 	end
-	if enemy.HasNoRequiredUnits() then
-		player.MarkCompletedObjective(gdiObjective1)
+	if Nod.HasNoRequiredUnits() then
+		GDI.MarkCompletedObjective(gdiObjective1)
 	end
 end

--- a/mods/cnc/maps/gdi02/rules.yaml
+++ b/mods/cnc/maps/gdi02/rules.yaml
@@ -1,6 +1,6 @@
 World:
 	LuaScript:
-		Scripts: gdi02.lua
+		Scripts: campaign-global.lua, gdi02.lua
 	MusicPlaylist:
 		StartingMusic: befeared
 	MissionData:

--- a/mods/cnc/maps/gdi03/rules.yaml
+++ b/mods/cnc/maps/gdi03/rules.yaml
@@ -1,6 +1,6 @@
 World:
 	LuaScript:
-		Scripts: gdi03.lua
+		Scripts: campaign-global.lua, gdi03.lua
 	MusicPlaylist:
 		StartingMusic: crep226m
 	MissionData:

--- a/mods/cnc/maps/gdi04a/rules.yaml
+++ b/mods/cnc/maps/gdi04a/rules.yaml
@@ -1,6 +1,6 @@
 World:
 	LuaScript:
-		Scripts: gdi04a.lua
+		Scripts: campaign-global.lua, gdi04a.lua
 	MusicPlaylist:
 		StartingMusic: fist226m
 	MissionData:

--- a/mods/cnc/maps/gdi04b/rules.yaml
+++ b/mods/cnc/maps/gdi04b/rules.yaml
@@ -1,6 +1,6 @@
 World:
 	LuaScript:
-		Scripts: gdi04b.lua
+		Scripts: campaign-global.lua, gdi04b.lua
 	MusicPlaylist:
 		StartingMusic: fist226m
 	MissionData:

--- a/mods/cnc/maps/gdi04c/rules.yaml
+++ b/mods/cnc/maps/gdi04c/rules.yaml
@@ -1,6 +1,6 @@
 World:
 	LuaScript:
-		Scripts: gdi04c.lua
+		Scripts: campaign-global.lua, gdi04c.lua
 	MusicPlaylist:
 		StartingMusic: ind
 	MissionData:

--- a/mods/cnc/maps/gdi05a/rules.yaml
+++ b/mods/cnc/maps/gdi05a/rules.yaml
@@ -1,6 +1,6 @@
 World:
 	LuaScript:
-		Scripts: gdi05a.lua
+		Scripts: campaign-global.lua, gdi05a.lua
 	MusicPlaylist:
 		StartingMusic: rain
 	MissionData:

--- a/mods/cnc/maps/gdi05b/rules.yaml
+++ b/mods/cnc/maps/gdi05b/rules.yaml
@@ -1,6 +1,6 @@
 World:
 	LuaScript:
-		Scripts: gdi05b.lua
+		Scripts: campaign-global.lua, gdi05b.lua
 	MusicPlaylist:
 		StartingMusic: rain
 	MissionData:

--- a/mods/cnc/maps/gdi06/rules.yaml
+++ b/mods/cnc/maps/gdi06/rules.yaml
@@ -1,6 +1,6 @@
 World:
 	LuaScript:
-		Scripts: gdi06.lua
+		Scripts: campaign-global.lua, gdi06.lua
 	MusicPlaylist:
 		BackgroundMusic: rain-ambient
 		StartingMusic: rain

--- a/mods/cnc/maps/gdi07/gdi07.lua
+++ b/mods/cnc/maps/gdi07/gdi07.lua
@@ -16,67 +16,29 @@ SamSites = { sam1, sam2, sam3, sam4 }
 NodBase = { handofnod, nodpower1, nodpower2, nodpower3, nodairfield, nodrefinery, nodconyard }
 HiddenNodUnits = { sleeper1, sleeper2, sleeper3, sleeper4 }
 
-ReinforceWithLandingCraft = function(units, transportStart, transportUnload, rallypoint)
-	local transport = Actor.Create("oldlst", true, { Owner = GDI, Facing = 0, Location = transportStart })
-	local subcell = 0
-	Utils.Do(units, function(a)
-		transport.LoadPassenger(Actor.Create(a, false, { Owner = transport.Owner, Facing = transport.Facing, Location = transportUnload, SubCell = subcell }))
-		subcell = subcell + 1
-	end)
 
-	transport.ScriptedMove(transportUnload)
-	Media.PlaySpeechNotification(player, "Reinforce")
-
-	transport.CallFunc(function()
-		Utils.Do(units, function()
-			local a = transport.UnloadPassenger()
-			a.IsInWorld = true
-			a.MoveIntoWorld(transport.Location - CVec.New(0, 1))
-
-			if rallypoint ~= nil then
-				a.Move(rallypoint)
-			end
-		end)
-	end)
-
-	transport.Wait(5)
-	transport.ScriptedMove(transportStart)
-	transport.Destroy()
-end
-
-CheckForBase = function(player)
-	local buildings = 0
-
-	Utils.Do(GDIBaseBuildings, function(name)
-		if #GDI.GetActorsByType(name) > 0 then
-			buildings = buildings + 1
-		end
-	end)
-
-	return buildings == #GDIBaseBuildings
-end
-
-SendReinforcements = function()
+function SendReinforcements()
 	Trigger.AfterDelay(DateTime.Seconds(20), function()
-		ReinforceWithLandingCraft(BaseReinforcements, spawnpoint3.Location - CVec.New(0, -4), spawnpoint3.Location - CVec.New(0, -1), waypoint26.Location)
+		ReinforceWithLandingCraft(GDI, BaseReinforcements, spawnpoint3.Location - CVec.New(0, -4), spawnpoint3.Location - CVec.New(0, -1), waypoint26.Location)
 	end)
 
 	Trigger.AfterDelay(DateTime.Seconds(10), function()
-		ReinforceWithLandingCraft(TankReinforcements, spawnpoint2.Location - CVec.New(0, -4), spawnpoint2.Location - CVec.New(0, -1), waypoint10.Location)
+		ReinforceWithLandingCraft(GDI, TankReinforcements, spawnpoint2.Location - CVec.New(0, -4), spawnpoint2.Location - CVec.New(0, -1), waypoint10.Location)
 
-		ReinforceWithLandingCraft(TankReinforcements, spawnpoint3.Location - CVec.New(0, -4), spawnpoint3.Location - CVec.New(0, -1), waypoint10.Location)
+		ReinforceWithLandingCraft(GDI, TankReinforcements, spawnpoint3.Location - CVec.New(0, -4), spawnpoint3.Location - CVec.New(0, -1), waypoint10.Location)
 	end)
 
 	Trigger.AfterDelay(DateTime.Seconds(5), function()
-		ReinforceWithLandingCraft(JeepReinforcements, spawnpoint1.Location - CVec.New(0, -4), spawnpoint1.Location - CVec.New(0, -1), waypoint10.Location)
+		ReinforceWithLandingCraft(GDI, JeepReinforcements, spawnpoint1.Location - CVec.New(0, -4), spawnpoint1.Location - CVec.New(0, -1), waypoint10.Location)
 	end)
 
-	ReinforceWithLandingCraft(InfantryReinforcements, spawnpoint2.Location - CVec.New(0, -4), spawnpoint2.Location - CVec.New(0, -1), waypoint10.Location)
+	ReinforceWithLandingCraft(GDI, InfantryReinforcements, spawnpoint2.Location - CVec.New(0, -4), spawnpoint2.Location - CVec.New(0, -1), waypoint10.Location)
 
-	ReinforceWithLandingCraft(InfantryReinforcements, spawnpoint3.Location - CVec.New(0, -4), spawnpoint3.Location - CVec.New(0, -1), waypoint10.Location)
+	ReinforceWithLandingCraft(GDI, InfantryReinforcements, spawnpoint3.Location - CVec.New(0, -4), spawnpoint3.Location - CVec.New(0, -1), waypoint10.Location)
 end
 
-AttackPlayer = function()
+
+function AttackPlayer()
 
 	Trigger.AfterDelay(DateTime.Seconds(40), function()
 		for type, count in pairs({ ['e3'] = 3, ['e4'] = 2 }) do
@@ -157,31 +119,11 @@ AttackPlayer = function()
 
 end
 
-WorldLoaded = function()
-	GDI = Player.GetPlayer("GDI")
-	Nod = Player.GetPlayer("Nod")
+
+function WorldLoaded()
+	InitObjectives(GDI)
 
 	Camera.Position = spawnpoint2.CenterPosition
-
-	Trigger.OnObjectiveAdded(GDI, function(p, id)
-		Media.DisplayMessage(p.GetObjectiveDescription(id), "New " .. string.lower(p.GetObjectiveType(id)) .. " objective")
-	end)
-
-	Trigger.OnObjectiveCompleted(GDI, function(p, id)
-		Media.DisplayMessage(p.GetObjectiveDescription(id), "Objective completed")
-	end)
-
-	Trigger.OnObjectiveFailed(GDI, function(p, id)
-		Media.DisplayMessage(p.GetObjectiveDescription(id), "Objective failed")
-	end)
-
-	Trigger.OnPlayerWon(GDI, function()
-		Media.PlaySpeechNotification(Nod, "Win")
-	end)
-
-	Trigger.OnPlayerLost(GDI, function()
-		Media.PlaySpeechNotification(Nod, "Lose")
-	end)
 
 	gdiMainObjective = GDI.AddPrimaryObjective("Destroy remaining Nod structures and units.")
 	gdiBaseObjective = GDI.AddSecondaryObjective("Construct all available buildings.")
@@ -198,7 +140,8 @@ WorldLoaded = function()
 	AttackPlayer()
 end
 
-Tick = function()
+
+function Tick()
 	if DateTime.GameTime > DateTime.Seconds(5) then
 		if GDI.HasNoRequiredUnits()  then
 			Nod.MarkCompletedObjective(nodObjective)
@@ -206,7 +149,7 @@ Tick = function()
 		if Nod.HasNoRequiredUnits() then
 			GDI.MarkCompletedObjective(gdiMainObjective)
 		end
-		if not GDI.IsObjectiveCompleted(gdiBaseObjective) and DateTime.GameTime % DateTime.Seconds(1) == 0 and CheckForBase() then
+		if not GDI.IsObjectiveCompleted(gdiBaseObjective) and DateTime.GameTime % DateTime.Seconds(1) == 0 and CheckForBase(GDI, GDIBaseBuildings) then
 			GDI.MarkCompletedObjective(gdiBaseObjective)
 		end
 	end

--- a/mods/cnc/maps/gdi07/rules.yaml
+++ b/mods/cnc/maps/gdi07/rules.yaml
@@ -1,6 +1,6 @@
 World:
 	LuaScript:
-		Scripts: gdi07.lua
+		Scripts: campaign-global.lua, gdi07.lua
 	MissionData:
 		Briefing: Previous mission objective not complete.\nAirfield was to be targeted. \n\nNew objective:  Build up a base and Destroy remaining Nod structures and units.\n\nReinforcements will be provided.
 		BriefingVideo: gdi7.vqa

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -26,6 +26,7 @@ Packages:
 	~transit.mix
 	cnc|bits/snow.mix
 	cnc|bits
+	cnc|bits/scripts
 	cnc|bits/jungle
 	cnc|bits/desert
 	cnc|bits/ss


### PR DESCRIPTION
This is a refactor of Lua code of Tiberian Dawn GDI missions, a lot of the ideas are borrowed from a [similar file with global campaign functions for Dune 2k](https://github.com/OpenRA/OpenRA/blob/bleed/mods/d2k/bits/scripts/campaign-global.lua) 

This changeset will:
1. Add `mods/cnc/bits/scripts/campaign-global.lua` file with functions and variables that are used numerous times in missions.
1. Remove all occurances of `enemy = Player.GetPlayer("Nod")` and `player = Player.GetPlayer("GDI")` and replace all usage of `enemy` with `Nod` and `player` with `GDI` (unless it's a local variable)
1. Replace all occurances of `Map.LobbyOption("difficulty")` with the `Difficulty` variable
1. Replace the boilerplate for objectives with `InitObjectives` function
1. Remove all copies of `ReinforceWithLandingCraft`
1. Remove all copies of `CheckForBase`
1. Remove all copies of `KillCounter`
1. Change the function naming scheme from `FunctionName = function()` to `function FunctionName()`