### PR TITLE
Fix Exceptions in VocLoader

### DIFF
--- a/OpenRA.Mods.Common/AudioLoaders/VocLoader.cs
+++ b/OpenRA.Mods.Common/AudioLoaders/VocLoader.cs
@@ -51,6 +51,7 @@ namespace OpenRA.Mods.Common.AudioLoaders
 		readonly int totalSamples;
 
 		IEnumerator<VocBlock> currentBlock;
+		bool currentBlockEnded;
 		int samplesLeftInBlock;
 		int samplePosition;
 
@@ -120,8 +121,8 @@ namespace OpenRA.Mods.Common.AudioLoaders
 				throw new InvalidDataException("Voc header description not recognized");
 			if (vfh.DatablockOffset != 26)
 				throw new InvalidDataException("Voc header offset is wrong");
-			if (vfh.Version != 0x010A)
-				throw new InvalidDataException("Voc header version not recognized");
+			if (vfh.Version < 0x0100 || vfh.Version >= 0x0200)
+				throw new InvalidDataException("Voc header version " + vfh.Version.ToString("X") + " not supported");
 			if (vfh.ID != ~vfh.Version + 0x1234)
 				throw new InvalidDataException("Voc header id is bogus - expected: " +
 					(~vfh.Version + 0x1234).ToString("X") + " but value is : " + vfh.ID.ToString("X"));
@@ -271,7 +272,8 @@ namespace OpenRA.Mods.Common.AudioLoaders
 
 		void Rewind()
 		{
-			currentBlock = (IEnumerator<VocBlock>)blocks.GetEnumerator();
+			currentBlock = ((IEnumerable<VocBlock>)blocks).GetEnumerator();
+			currentBlockEnded = false;
 			samplesLeftInBlock = 0;
 			samplePosition = 0;
 
@@ -284,9 +286,10 @@ namespace OpenRA.Mods.Common.AudioLoaders
 					return;
 				}
 			}
+			currentBlockEnded = true;
 		}
 
-		bool EndOfData { get { return currentBlock.Current.Equals(blocks.Last()) && samplesLeftInBlock == 0; } }
+		bool EndOfData { get { return currentBlockEnded && samplesLeftInBlock == 0; } }
 
 		int FillBuffer(int maxSamples)
 		{
@@ -324,6 +327,7 @@ namespace OpenRA.Mods.Common.AudioLoaders
 					samplesLeftInBlock = currentBlock.Current.SampleBlock.Samples;
 					return;
 				}
+				currentBlockEnded = true;
 			}
 		}
 


### PR DESCRIPTION
VocLoader in OpenRA do not work because of System.IO.InvalidDataException.
I think it was broken by Enumerators changes in .Net.

The line:
```currentBlock = (IEnumerator<VocBlock>)blocks.GetEnumerator();``` 
produce **System.IO.InvalidDataException**
and should be changed to this:
```currentBlock = ((IEnumerable<VocBlock>)blocks).GetEnumerator();```

and
```blocks.Last()```
also produce exception **System.InvalidOperationException: Enumeration already finished**, so it should be in try/catch block.