### PR TITLE
Make RA bots not include dogs in their attacks

### DIFF
--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -8,6 +8,15 @@ Player:
 	ModularBot@HAL9001:
 		Name: HAL 9001
 		Type: hal9001
+	GrantConditionOnBotOwner@cabal:
+		Condition: enable-cabal-ai
+		Bots: cabal
+	GrantConditionOnBotOwner@watson:
+		Condition: enable-watson-ai
+		Bots: watson
+	GrantConditionOnBotOwner@hal9001:
+		Condition: enable-hal9001-ai
+		Bots: hal9001
 	SupportPowerBotModule:
 		RequiresCondition: enable-cabal-ai || enable-watson-ai || enable-hal9001-ai
 		Decisions:
@@ -69,15 +78,6 @@ Player:
 					Attractiveness: -10
 					TargetMetric: Value
 					CheckRadius: 7c0
-	GrantConditionOnBotOwner@cabal:
-		Condition: enable-cabal-ai
-		Bots: cabal
-	GrantConditionOnBotOwner@watson:
-		Condition: enable-watson-ai
-		Bots: watson
-	GrantConditionOnBotOwner@hal9001:
-		Condition: enable-hal9001-ai
-		Bots: hal9001
 	HarvesterBotModule:
 		RequiresCondition: enable-cabal-ai || enable-watson-ai || enable-hal9001-ai
 	BaseBuilderBotModule@cabal:

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -8,6 +8,15 @@ Player:
 	ModularBot@Gladius:
 		Name: Gladius
 		Type: gladius
+	GrantConditionOnBotOwner@omnius:
+		Condition: enable-omnius-ai
+		Bots: omnius
+	GrantConditionOnBotOwner@vidious:
+		Condition: enable-vidious-ai
+		Bots: vidious
+	GrantConditionOnBotOwner@gladius:
+		Condition: enable-gladius-ai
+		Bots: gladius
 	SupportPowerBotModule:
 		RequiresCondition: enable-omnius-ai || enable-vidious-ai || enable-gladius-ai
 		Decisions:
@@ -51,15 +60,6 @@ Player:
 				OrderName: ProduceActorPower.Fremen
 				Consideration@1:
 					Against: Ally
-	GrantConditionOnBotOwner@omnius:
-		Condition: enable-omnius-ai
-		Bots: omnius
-	GrantConditionOnBotOwner@vidious:
-		Condition: enable-vidious-ai
-		Bots: vidious
-	GrantConditionOnBotOwner@gladius:
-		Condition: enable-gladius-ai
-		Bots: gladius
 	HarvesterBotModule:
 		RequiresCondition: enable-omnius-ai || enable-vidious-ai || enable-gladius-ai
 	BaseBuilderBotModule@omnius:

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -272,7 +272,7 @@ Player:
 	SquadManagerBotModule@rush:
 		RequiresCondition: enable-rush-ai
 		SquadSize: 20
-		ExcludeFromSquadsTypes: harv, mcv
+		ExcludeFromSquadsTypes: harv, mcv, dog
 		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
 		ConstructionYardTypes: fact
 	McvManagerBotModule:
@@ -309,7 +309,7 @@ Player:
 	SquadManagerBotModule@normal:
 		RequiresCondition: enable-normal-ai
 		SquadSize: 40
-		ExcludeFromSquadsTypes: harv, mcv
+		ExcludeFromSquadsTypes: harv, mcv, dog
 		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
 		ConstructionYardTypes: fact
 		NavalProductionTypes: spen,syrd
@@ -351,7 +351,7 @@ Player:
 	SquadManagerBotModule@turtle:
 		RequiresCondition: enable-turtle-ai
 		SquadSize: 10
-		ExcludeFromSquadsTypes: harv, mcv
+		ExcludeFromSquadsTypes: harv, mcv, dog
 		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
 		ConstructionYardTypes: fact
 		NavalProductionTypes: spen,syrd
@@ -393,7 +393,7 @@ Player:
 	SquadManagerBotModule@naval:
 		RequiresCondition: enable-naval-ai
 		SquadSize: 1
-		ExcludeFromSquadsTypes: harv, mcv
+		ExcludeFromSquadsTypes: harv, mcv, dog
 		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
 		ConstructionYardTypes: fact
 		NavalProductionTypes: spen,syrd

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -11,6 +11,18 @@ Player:
 	ModularBot@NavalAI:
 		Name: Naval AI
 		Type: naval
+	GrantConditionOnBotOwner@rush:
+		Condition: enable-rush-ai
+		Bots: rush
+	GrantConditionOnBotOwner@normal:
+		Condition: enable-normal-ai
+		Bots: normal
+	GrantConditionOnBotOwner@turtle:
+		Condition: enable-turtle-ai
+		Bots: turtle
+	GrantConditionOnBotOwner@naval:
+		Condition: enable-naval-ai
+		Bots: naval
 	SupportPowerBotModule:
 		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
 		Decisions:
@@ -62,18 +74,6 @@ Player:
 					Attractiveness: -10
 					TargetMetric: Value
 					CheckRadius: 7c0
-	GrantConditionOnBotOwner@rush:
-		Condition: enable-rush-ai
-		Bots: rush
-	GrantConditionOnBotOwner@normal:
-		Condition: enable-normal-ai
-		Bots: normal
-	GrantConditionOnBotOwner@turtle:
-		Condition: enable-turtle-ai
-		Bots: turtle
-	GrantConditionOnBotOwner@naval:
-		Condition: enable-naval-ai
-		Bots: naval
 	HarvesterBotModule:
 		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
 	BaseBuilderBotModule@rush:


### PR DESCRIPTION
This prevents bots from using their up-to-4 dogs in attack squads.
Bots aren't good at using them effectively, so they're better left in the base as passive defense against infantry attacks or spies/engineers sent by human players (and maybe later bots, too).

Closes #15966.