### PR TITLE
Fix transparent pixels in screenshots when using BlendMode.Subtractive

### DIFF
--- a/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
@@ -134,6 +134,16 @@ namespace OpenRA.Platforms.Default
 
 			OpenGL.glPopClientAttrib();
 
+			// Reset alpha channel to fully opaque
+			unsafe
+			{
+				var colors = (int*)data.Scan0;
+				var stride = data.Stride / 4;
+				for (var y = 0; y < rect.Height; y++)
+				for (var x = 0; x < rect.Width; x++)
+					colors[y * stride + x] |= 0xFF << 24;
+			}
+
 			bitmap.UnlockBits(data);
 
 			// OpenGL standard defines the origin in the bottom left corner which is why this is upside-down by default.


### PR DESCRIPTION
Fixes #12082.

This is another simple but noticable polish fix, so scope-creeping it into the milestone.