### PR TITLE
Prevent unit requests from stacking during production.

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -118,7 +118,8 @@ namespace OpenRA.Mods.Common.Traits
 					if (unitBuilder != null)
 					{
 						var mcvInfo = AIUtils.GetInfoByCommonName(Info.McvTypes, player);
-						unitBuilder.RequestUnitProduction(bot, mcvInfo.Name);
+						if (unitBuilder.RequestedProductionCount(bot, mcvInfo.Name) == 0)
+							unitBuilder.RequestUnitProduction(bot, mcvInfo.Name);
 					}
 				}
 			}

--- a/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;
@@ -94,6 +92,11 @@ namespace OpenRA.Mods.Common.Traits
 		void IBotRequestUnitProduction.RequestUnitProduction(IBot bot, string requestedActor)
 		{
 			queuedBuildRequests.Add(requestedActor);
+		}
+
+		int IBotRequestUnitProduction.RequestedProductionCount(IBot bot, string requestedActor)
+		{
+			return queuedBuildRequests.Count(r => r == requestedActor);
 		}
 
 		void BuildUnit(IBot bot, string category, bool buildRandom)

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -472,6 +472,7 @@ namespace OpenRA.Mods.Common.Traits
 	public interface IBotRequestUnitProduction
 	{
 		void RequestUnitProduction(IBot bot, string requestedActor);
+		int RequestedProductionCount(IBot bot, string requestedActor);
 	}
 
 	[RequireExplicitImplementation]


### PR DESCRIPTION
Consumers of `IBotRequestUnitProduction` need to be able to check what is already in the queue so that they don't request N duplicates while the first one is still building.

Note that this is a speculative fix that I haven't yet tested ingame. @reaperrr did you have a simple way to test the behaviour of this module?