### PR TITLE
Some Map Editor Actor cleanup

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -219,6 +219,7 @@ A10:
 	Contrail@2:
 		Offset: -640,-171,0
 		TrailLength: 15
+	-MapEditorData:
 
 TRAN.Husk:
 	Inherits: ^HelicopterHusk

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -190,6 +190,7 @@ C17:
 	Contrail@4:
 		Offset: -261,650,0
 		TrailLength: 15
+	-MapEditorData:
 
 A10:
 	Inherits: ^Plane

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -190,8 +190,6 @@ C17:
 	Contrail@4:
 		Offset: -261,650,0
 		TrailLength: 15
-	Buildable:
-		Description: Drops vehicle reinforcements on Airstrips
 
 A10:
 	Inherits: ^Plane
@@ -221,8 +219,6 @@ A10:
 	Contrail@2:
 		Offset: -640,-171,0
 		TrailLength: 15
-	Buildable:
-		Description: Used to deliver air strikes.
 
 TRAN.Husk:
 	Inherits: ^HelicopterHusk

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -1065,6 +1065,7 @@
 		GenericName: Destroyed Helicopter
 	BodyOrientation:
 		UseClassicFacingFudge: True
+	-MapEditorData:
 
 ^Bridge:
 	Inherits@shape: ^1x1Shape

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -113,6 +113,7 @@ ornithopter:
 		Actor: ornithopter.husk
 	RejectsOrders:
 	RevealOnFire:
+	-MapEditorData:
 
 ornithopter.husk:
 	Inherits: ^AircraftHusk

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -262,6 +262,7 @@
 		Spins: False
 		Moves: True
 		Explosion: UnitExplodeLarge
+	-MapEditorData:
 
 ^Infantry:
 	Inherits@1: ^ExistsInWorld

--- a/mods/d2k/rules/starport.yaml
+++ b/mods/d2k/rules/starport.yaml
@@ -5,6 +5,7 @@ mcv.starport:
 		Queue: Starport
 	Valued:
 		Cost: 2500
+	-MapEditorData:
 	RenderSprites:
 		Image: mcv
 
@@ -15,6 +16,7 @@ harvester.starport:
 		Queue: Starport
 	Valued:
 		Cost: 1500
+	-MapEditorData:
 	RenderSprites:
 		Image: harvester
 
@@ -25,6 +27,7 @@ trike.starport:
 		Queue: Starport
 	Valued:
 		Cost: 315
+	-MapEditorData:
 	RenderSprites:
 		Image: trike
 
@@ -35,6 +38,7 @@ quad.starport:
 		Queue: Starport
 	Valued:
 		Cost: 500
+	-MapEditorData:
 	RenderSprites:
 		Image: quad
 
@@ -45,6 +49,7 @@ siege_tank.starport:
 		Queue: Starport
 	Valued:
 		Cost: 1075
+	-MapEditorData:
 	RenderSprites:
 		Image: siege_tank
 
@@ -55,6 +60,7 @@ missile_tank.starport:
 		Queue: Starport
 	Valued:
 		Cost: 1250
+	-MapEditorData:
 	RenderSprites:
 		Image: missile_tank
 
@@ -65,6 +71,7 @@ combat_tank_a.starport:
 		Queue: Starport
 	Valued:
 		Cost: 875
+	-MapEditorData:
 	RenderSprites:
 		Image: combat_tank_a
 
@@ -75,6 +82,7 @@ combat_tank_h.starport:
 		Queue: Starport
 	Valued:
 		Cost: 875
+	-MapEditorData:
 	RenderSprites:
 		Image: combat_tank_h
 
@@ -85,6 +93,7 @@ combat_tank_o.starport:
 		Queue: Starport
 	Valued:
 		Cost: 875
+	-MapEditorData:
 	RenderSprites:
 		Image: combat_tank_o
 
@@ -95,3 +104,4 @@ carryall.starport:
 		Queue: Starport
 	Valued:
 		Cost: 1500
+	-MapEditorData:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -71,6 +71,7 @@ BADR.Bomber:
 		Offset: -432,-560,0
 		Interval: 2
 	-EjectOnDeath:
+	-MapEditorData:
 	RejectsOrders:
 	RenderSprites:
 		Image: badr
@@ -417,3 +418,4 @@ U2:
 		Interval: 2
 	RejectsOrders:
 	Interactable:
+	-MapEditorData:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -1003,8 +1003,7 @@
 		Moves: True
 		Velocity: 86
 		Explosion: UnitExplodePlane
-	MapEditorData:
-		Categories: Husk
+	-MapEditorData:
 	RevealOnDeath:
 		Duration: 60
 		Radius: 4c0
@@ -1023,6 +1022,7 @@
 		Explosion: UnitExplodeHeli
 	BodyOrientation:
 		UseClassicFacingFudge: True
+	-MapEditorData:
 	RevealOnDeath:
 		Duration: 60
 		Radius: 4c0

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -906,8 +906,6 @@
 		Moves: true
 		Velocity: 86
 	HitShape:
-	MapEditorData:
-		Categories: Husk
 
 ^Visceroid:
 	Inherits@1: ^ExistsInWorld

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -187,8 +187,6 @@ JUMPJET.Husk:
 	WithDeathAnimation@SPLASH:
 		RequiresCondition: water-death
 		FallbackSequence: die-splash
-	MapEditorData:
-		Categories: Husk
 	Interactable:
 
 GHOST:


### PR DESCRIPTION
Removes Aircraft Husks from map editor, they are no use to be preplaced, they are gonna explode instantly anyway. Closes #15562.

Removes D2k duplicate actors from map editor. They are no different from normal ones except cost which don't matter when they are preplaced.

Removes aircraft with AttackBomber trait from map editor. Such units are meant to be spawned with AirstrikePower. Otherwise they crash the game.

Also noticed C17 and A10 had Buildable traits leftover and removed them too while in it.