### PR TITLE
Make Huntable Conditional

### DIFF
--- a/OpenRA.Mods.Common/Activities/Hunt.cs
+++ b/OpenRA.Mods.Common/Activities/Hunt.cs
@@ -26,9 +26,10 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			move = self.Trait<IMove>();
 			var attack = self.Trait<AttackBase>();
-			targets = self.World.ActorsHavingTrait<Huntable>().Where(
-				a => self != a && !a.IsDead && a.IsInWorld && a.AppearsHostileTo(self)
-				&& a.IsTargetableBy(self) && attack.HasAnyValidWeapons(Target.FromActor(a)));
+			targets = self.World.ActorsWithTrait<Huntable>().Where(
+				a => !a.Trait.IsTraitDisabled && self != a.Actor && !a.Actor.IsDead && a.Actor.IsInWorld
+				&& a.Actor.AppearsHostileTo(self) && a.Actor.IsTargetableBy(self)
+				&& attack.HasAnyValidWeapons(Target.FromActor(a.Actor))).Select(a => a.Actor);
 		}
 
 		public override Activity Tick(Actor self)

--- a/OpenRA.Mods.Common/Traits/Huntable.cs
+++ b/OpenRA.Mods.Common/Traits/Huntable.cs
@@ -14,6 +14,14 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor can be targeted by the Hunt activity.")]
-	public class HuntableInfo : TraitInfo<Huntable> { }
-	public class Huntable { }
+	public class HuntableInfo : ConditionalTraitInfo
+	{
+		public override object Create(ActorInitializer init) { return new Huntable(init.Self, this); }
+	}
+
+	public class Huntable : ConditionalTrait<HuntableInfo>
+	{
+		public Huntable(Actor self, HuntableInfo info)
+			: base(info) { }
+	}
 }


### PR DESCRIPTION
Wanted to look back to https://github.com/OpenRA/OpenRA/issues/12596, i made it so the AI will ignore the driverless vehicles laying around. Giving them NoAutoTarget target type wasn't enough since it still tries to IdleHunt them, but don't actually target them. Making huntable conditional and disabling it in such case solves the issue.