### PR TITLE
Add hotkey for removing selected actors from control groups

### DIFF
--- a/OpenRA.Game/Selection.cs
+++ b/OpenRA.Game/Selection.cs
@@ -187,6 +187,13 @@ namespace OpenRA
 				controlGroups[group].Add(a);
 		}
 
+		public void RemoveFromControlGroup(Actor a)
+		{
+			var group = GetControlGroupForActor(a);
+			if (group.HasValue)
+				controlGroups[group.Value].Remove(a);
+		}
+
 		public int? GetControlGroupForActor(Actor a)
 		{
 			return controlGroups.Where(g => g.Value.Contains(a))

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -892,6 +892,7 @@
     <Compile Include="Widgets\Logic\Ingame\Hotkeys\TogglePlayerStanceColorHotkeyLogic.cs" />
     <Compile Include="Widgets\Logic\Ingame\Hotkeys\PauseHotkeyLogic.cs" />
     <Compile Include="Widgets\Logic\Ingame\Hotkeys\CycleStatusBarsHotkeyLogic.cs" />
+    <Compile Include="Widgets\Logic\Ingame\Hotkeys\RemoveFromControlGroupHotkeyLogic.cs" />
     <Compile Include="Widgets\Logic\Lobby\LobbyOptionsLogic.cs" />
     <Compile Include="Traits\World\LobbyPrerequisiteCheckbox.cs" />
     <Compile Include="Widgets\Logic\DirectConnectLogic.cs" />

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/RemoveFromControlGroupHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/RemoveFromControlGroupHotkeyLogic.cs
@@ -1,0 +1,45 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Lint;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
+{
+	[ChromeLogicArgsHotkeys("RemoveFromControlGroupKey")]
+	public class RemoveFromControlGroupHotkeyLogic : SingleHotkeyBaseLogic
+	{
+		readonly Selection selection;
+		readonly World world;
+
+		[ObjectCreator.UseCtor]
+		public RemoveFromControlGroupHotkeyLogic(Widget widget, ModData modData, World world, Dictionary<string, MiniYaml> logicArgs)
+			: base(widget, modData, "RemoveFromControlGroupKey", "WORLD_KEYHANDLER", logicArgs)
+		{
+			selection = world.Selection;
+			this.world = world;
+		}
+
+		protected override bool OnHotkeyActivated(KeyInput e)
+		{
+			var selectedActors = selection.Actors
+				.Where(a => a.Owner == world.LocalPlayer && a.IsInWorld && !a.IsDead)
+				.ToArray();
+
+			foreach (var a in selectedActors)
+				selection.RemoveFromControlGroup(a);
+
+			return true;
+		}
+	}
+}

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -10,7 +10,8 @@ Container@INGAME_ROOT:
 				TakeScreenshotKey: TakeScreenshot
 				MuteAudioKey: ToggleMute
 		LogicKeyListener@WORLD_KEYHANDLER:
-			Logic: CycleBasesHotkeyLogic, CycleProductionActorsHotkeyLogic, JumpToLastEventHotkeyLogic, JumpToSelectedActorsHotkeyLogic, TogglePixelDoubleHotkeyLogic, TogglePlayerStanceColorHotkeyLogic, CycleStatusBarsHotkeyLogic, PauseHotkeyLogic
+			Logic: CycleBasesHotkeyLogic, CycleProductionActorsHotkeyLogic, JumpToLastEventHotkeyLogic, JumpToSelectedActorsHotkeyLogic, TogglePixelDoubleHotkeyLogic, TogglePlayerStanceColorHotkeyLogic, CycleStatusBarsHotkeyLogic, PauseHotkeyLogic, RemoveFromControlGroupHotkeyLogic
+				RemoveFromControlGroupKey: RemoveFromControlGroup
 				CycleBasesKey: CycleBase
 				CycleProductionActorsKey: CycleProductionBuildings
 				JumpToLastEventKey: ToLastEvent

--- a/mods/common/chrome/ingame.yaml
+++ b/mods/common/chrome/ingame.yaml
@@ -10,7 +10,8 @@ Container@INGAME_ROOT:
 				TakeScreenshotKey: TakeScreenshot
 				MuteAudioKey: ToggleMute
 		LogicKeyListener@WORLD_KEYHANDLER:
-			Logic: CycleBasesHotkeyLogic, CycleProductionActorsHotkeyLogic, JumpToLastEventHotkeyLogic, JumpToSelectedActorsHotkeyLogic, TogglePixelDoubleHotkeyLogic, TogglePlayerStanceColorHotkeyLogic, CycleStatusBarsHotkeyLogic, PauseHotkeyLogic
+			Logic: CycleBasesHotkeyLogic, CycleProductionActorsHotkeyLogic, JumpToLastEventHotkeyLogic, JumpToSelectedActorsHotkeyLogic, TogglePixelDoubleHotkeyLogic, TogglePlayerStanceColorHotkeyLogic, CycleStatusBarsHotkeyLogic, PauseHotkeyLogic, RemoveFromControlGroupHotkeyLogic
+				RemoveFromControlGroupKey: RemoveFromControlGroup
 				CycleBasesKey: CycleBase
 				CycleProductionActorsKey: CycleProductionBuildings
 				JumpToLastEventKey: ToLastEvent

--- a/mods/common/hotkeys/game.yaml
+++ b/mods/common/hotkeys/game.yaml
@@ -18,6 +18,10 @@ SelectUnitsByType: W
 	Description: Select units by type
 	Types: World
 
+RemoveFromControlGroup:
+	Description: Remove from control group
+	Types: World
+
 Pause: PAUSE
 	Description: Pause / Unpause
 	Types: World


### PR DESCRIPTION
In this PR:
* Add `RemoveFromControlGroup` hotkey (defaults to `Unknown`)
* Add `RemoveFromControlGroup` method to `OpenRA.Game.Selection`

~~The default hotkey is up for discussion but I think it's a good choice because it's on the same row as the numbers, is easy to reach and is functions similarly to how control groups are assigned~~.

Closes #15961 