### PR TITLE
Give bots ability to auto-replace harvesters

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class HarvesterBotModuleInfo : ConditionalTraitInfo
 	{
 		[Desc("Interval (in ticks) between giving out orders to idle harvesters.")]
-		public readonly int ScanForIdleHarvestersInterval = 20;
+		public readonly int ScanForIdleHarvestersInterval = 50;
 
 		[Desc("Avoid enemy actors nearby when searching for a new resource patch. Should be somewhere near the max weapon range.")]
 		public readonly WDist HarvesterEnemyAvoidanceRadius = WDist.FromCells(8);

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		CPos initialBaseCenter;
 		int scanInterval;
-		int ticks;
+		bool firstTick = true;
 
 		// MCVs that the bot already knows about. Any MCV not on this list needs to be given an order.
 		List<Actor> activeMCVs = new List<Actor>();
@@ -101,10 +101,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		void IBotTick.BotTick(IBot bot)
 		{
-			ticks++;
-
-			if (ticks == 1)
+			if (firstTick)
+			{
 				DeployMcvs(bot, false);
+				firstTick = false;
+			}
 
 			if (--scanInterval <= 0)
 			{

--- a/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
@@ -126,16 +126,6 @@ namespace OpenRA.Mods.Common.Traits
 			bot.QueueOrder(Order.StartProduction(queue.Actor, name, 1));
 		}
 
-		void BuildUnit(IBot bot, string category, string name)
-		{
-			var queue = AIUtils.FindQueues(player, category).FirstOrDefault(q => !q.AllQueued().Any());
-			if (queue == null)
-				return;
-
-			if (world.Map.Rules.Actors[name] != null)
-				bot.QueueOrder(Order.StartProduction(queue.Actor, name, 1));
-		}
-
 		// In cases where we want to build a specific unit but don't know the queue name (because there's more than one possibility)
 		void BuildUnit(IBot bot, string name)
 		{

--- a/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
@@ -146,7 +146,10 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			if (queue != null)
+			{
 				bot.QueueOrder(Order.StartProduction(queue.Actor, name, 1));
+				AIUtils.BotDebug("AI: {0} decided to build {1} (external request)", queue.Actor.Owner, name);
+			}
 		}
 
 		ActorInfo ChooseRandomUnitToBuild(ProductionQueue queue)

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -80,6 +80,8 @@ Player:
 					CheckRadius: 7c0
 	HarvesterBotModule:
 		RequiresCondition: enable-cabal-ai || enable-watson-ai || enable-hal9001-ai
+		HarvesterTypes: harv
+		RefineryTypes: proc
 	BaseBuilderBotModule@cabal:
 		RequiresCondition: enable-cabal-ai
 		BuildingQueues: Building.Nod, Building.GDI

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -62,6 +62,8 @@ Player:
 					Against: Ally
 	HarvesterBotModule:
 		RequiresCondition: enable-omnius-ai || enable-vidious-ai || enable-gladius-ai
+		HarvesterTypes: harvester
+		RefineryTypes: refinery
 	BaseBuilderBotModule@omnius:
 		RequiresCondition: enable-omnius-ai
 		BuildingQueues: Building, Upgrade

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -76,6 +76,8 @@ Player:
 					CheckRadius: 7c0
 	HarvesterBotModule:
 		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
+		HarvesterTypes: harv
+		RefineryTypes: proc
 	BaseBuilderBotModule@rush:
 		RequiresCondition: enable-rush-ai
 		MinimumExcessPower: 60

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -7,6 +7,8 @@ Player:
 		Bots: test
 	HarvesterBotModule:
 		RequiresCondition: enable-test-ai
+		HarvesterTypes: harv
+		RefineryTypes: proc
 	BaseBuilderBotModule@test:
 		RequiresCondition: enable-test-ai
 		MinimumExcessPower: 30


### PR DESCRIPTION
...when their number drops below the number of refineries.

~Depends on #15982.~

Closes #15962.