### PR TITLE
Reorder stance hotkeys in settings to match command bar

### DIFF
--- a/mods/common/hotkeys/game.yaml
+++ b/mods/common/hotkeys/game.yaml
@@ -74,20 +74,20 @@ Guard: D
 	Description: Guard
 	Types: Unit
 
-StanceHoldFire: F Alt
-	Description: Hold fire
-	Types: Stance
-
-StanceReturnFire: D Alt
-	Description: Return fire
+StanceAttackAnything: A Alt
+	Description: Attack anything
 	Types: Stance
 
 StanceDefend: S Alt
 	Description: Defend
 	Types: Stance
 
-StanceAttackAnything: A Alt
-	Description: Attack anything
+StanceReturnFire: D Alt
+	Description: Return fire
+	Types: Stance
+
+StanceHoldFire: F Alt
+	Description: Hold fire
 	Types: Stance
 
 StopMusic: AUDIOSTOP


### PR DESCRIPTION
This is a minor polishing fix. The hotkey settings for stances were in reverse order to the order seen in-game on the command bar. This made rebinding them more mentally taxing and prone to errors.