### PR TITLE
Fix spectator crash if replay does not define FinalGameTick.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameTimerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameTimerLogic.cs
@@ -66,8 +66,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (timerTooltip != null)
 			{
 				var connection = orderManager.Connection as ReplayConnection;
-				if (connection != null && connection.TickCount != 0)
+				if (connection != null && connection.FinalGameTick != 0)
 					timerTooltip.GetTooltipText = () => "{0}% complete".F(world.WorldTick * 100 / connection.FinalGameTick);
+				else if (connection != null && connection.TickCount != 0)
+					timerTooltip.GetTooltipText = () => "{0}% complete".F(orderManager.NetFrameNumber * 100 / connection.TickCount);
 				else
 					timerTooltip.GetTooltipText = null;
 			}


### PR DESCRIPTION
Fixes #15992 by falling back to the original behaviour (see #15704) if `FinalGameTick` is 0.