### PR TITLE
Reduce the range of DogJaw from 3c0 to 2c0

### DIFF
--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -107,7 +107,7 @@ TTankZap:
 DogJaw:
 	ValidTargets: Infantry
 	ReloadDelay: 10
-	Range: 3c0
+	Range: 2c0
 	Report: dogg5p.aud
 	TargetActorCenter: true
 	Projectile: InstantHit


### PR DESCRIPTION
The final step towards closing #7506.
This will prevent dogs from jumping over cliffs (as cliffs are two cells wide).