### PR TITLE
Add shortcut for Copy in Map editor

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
@@ -88,6 +88,16 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var copypasteButton = widget.GetOrNull<ButtonWidget>("COPYPASTE_BUTTON");
 			if (copypasteButton != null)
 			{
+				// HACK: Replace Ctrl with Cmd on macOS
+				// TODO: Add platform-specific override support to HotkeyManager
+				// and then port the editor hotkeys to this system.
+				var copyPasteKey = copypasteButton.Key.GetValue();
+				if (Platform.CurrentPlatform == PlatformType.OSX && copyPasteKey.Modifiers.HasModifier(Modifiers.Ctrl))
+				{
+					var modified = new Hotkey(copyPasteKey.Key, copyPasteKey.Modifiers & ~Modifiers.Ctrl | Modifiers.Meta);
+					copypasteButton.Key = FieldLoader.GetValue<HotkeyReference>("Key", modified.ToString());
+				}
+
 				copypasteButton.OnClick = () => editorViewport.SetBrush(new EditorCopyPasteBrush(editorViewport, worldRenderer, () => copyFilters));
 				copypasteButton.IsHighlighted = () => editorViewport.CurrentBrush is EditorCopyPasteBrush;
 			}

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -548,12 +548,19 @@ Container@EDITOR_WORLD_ROOT:
 			Height: 25
 			Font: Bold
 			Key: TogglePixelDouble
+			TooltipTemplate: BUTTON_TOOLTIP
+			TooltipText: Zoom
+			TooltipContainer: TOOLTIP_CONTAINER
 		Button@COPYPASTE_BUTTON:
 			X: WINDOW_RIGHT - 540
 			Y: 5
 			Width: 96
 			Height: 25
 			Text: Copy/Paste
+			Key: c ctrl
+			TooltipTemplate: BUTTON_TOOLTIP
+			TooltipText: Copy
+			TooltipContainer: TOOLTIP_CONTAINER
 		DropDownButton@COPYFILTER_BUTTON:
 			X: WINDOW_RIGHT - 435
 			Y: 5

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -508,7 +508,11 @@ Container@EDITOR_WORLD_ROOT:
 			Width: 90
 			Height: 25
 			Text: Copy/Paste
+			TooltipTemplate: BUTTON_TOOLTIP
+			TooltipText: Copy
+			TooltipContainer: TOOLTIP_CONTAINER
 			Font: Bold
+			Key: c ctrl
 		DropDownButton@COPYFILTER_BUTTON:
 			X: 270
 			Width: 140
@@ -539,6 +543,9 @@ Container@EDITOR_WORLD_ROOT:
 			Height: 25
 			Font: Bold
 			Key: TogglePixelDouble
+			TooltipTemplate: BUTTON_TOOLTIP
+			TooltipText: Zoom
+			TooltipContainer: TOOLTIP_CONTAINER
 		Label@COORDINATE_LABEL:
 			X: 635
 			Width: 50


### PR DESCRIPTION
Add Ctrl+C shortcut for Copy in Map editor
(Grid already has F1 key)

Closes #14723