### PR TITLE
Revert macOS dark mode (again).

### DIFF
--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -9,7 +9,7 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
 	command -v genisoimage >/dev/null 2>&1 || { echo >&2 "macOS packaging requires genisoimage."; exit 1; }
 fi
 
-LAUNCHER_TAG="osx-launcher-20181118"
+LAUNCHER_TAG="osx-launcher-20171118"
 
 if [ $# -ne "2" ]; then
 	echo "Usage: $(basename "$0") tag outputdir"

--- a/thirdparty/fetch-thirdparty-deps-osx.sh
+++ b/thirdparty/fetch-thirdparty-deps-osx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LAUNCHER_TAG="osx-launcher-20181118"
+LAUNCHER_TAG="osx-launcher-20171118"
 
 download_dir="${0%/*}/download/osx"
 mkdir -p "$download_dir"


### PR DESCRIPTION
The "modern" GL backend that this enables appears to have changed the vsync behaviour, and i'm seeing a lot of frame-pacing issues. We're run out of time to fix this properly, so reverting it from this cycle.