### PR TITLE
Remove unused sanity checks from pathfinding

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -164,7 +164,7 @@ namespace OpenRA.Mods.Common.Activities
 			// path guarantees that they will return as soon as possible, once the actor is back in a
 			// valid position.
 			// This means that it is safe to unconditionally return true, which avoids breaking parent
-			// activities that rely on cancellation succeeding (but not necessarily immediately
+			// activities that rely on cancellation succeeding (but not necessarily immediately)
 			ChildActivity.Cancel(self, false);
 
 			return true;

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -197,10 +197,7 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 
 			if (path == null)
-			{
 				path = EvalPath();
-				SanityCheckPath(mobile);
-			}
 
 			if (path.Count == 0)
 			{
@@ -258,16 +255,6 @@ namespace OpenRA.Mods.Common.Activities
 			// If we only queue the activity and not run it, units will lose one tick and pause briefly!
 			ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
 			return this;
-		}
-
-		[Conditional("SANITY_CHECKS")]
-		void SanityCheckPath(Mobile mobile)
-		{
-			if (path.Count == 0)
-				return;
-			var d = path[path.Count - 1] - mobile.ToCell;
-			if (d.LengthSquared > 2)
-				throw new InvalidOperationException("(Move) Sanity check failed");
 		}
 
 		Pair<CPos, SubCell>? PopPath(Actor self)

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -84,8 +84,6 @@ namespace OpenRA.Mods.Common.Traits
 			using (var fromDest = PathSearch.FromPoint(world, li, self, source, target, true).WithIgnoredActor(ignoreActor).Reverse())
 				pb = FindBidiPath(fromSrc, fromDest);
 
-			CheckSanePath2(pb, source, target);
-
 			return pb;
 		}
 
@@ -197,7 +195,6 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			ret.Add(currentNode);
-			CheckSanePath(ret);
 			return ret;
 		}
 
@@ -226,35 +223,7 @@ namespace OpenRA.Mods.Common.Traits
 				ret.Add(q);
 			}
 
-			CheckSanePath(ret);
 			return ret;
-		}
-
-		[Conditional("SANITY_CHECKS")]
-		static void CheckSanePath(IList<CPos> path)
-		{
-			if (path.Count == 0)
-				return;
-			var prev = path[0];
-			foreach (var cell in path)
-			{
-				var d = cell - prev;
-				if (Math.Abs(d.X) > 1 || Math.Abs(d.Y) > 1)
-					throw new InvalidOperationException("(PathFinder) path sanity check failed");
-				prev = cell;
-			}
-		}
-
-		[Conditional("SANITY_CHECKS")]
-		static void CheckSanePath2(IList<CPos> path, CPos src, CPos dest)
-		{
-			if (path.Count == 0)
-				return;
-
-			if (path[0] != dest)
-				throw new InvalidOperationException("(PathFinder) sanity check failed: doesn't go to dest");
-			if (path[path.Count - 1] != src)
-				throw new InvalidOperationException("(PathFinder) sanity check failed: doesn't come from src");
 		}
 	}
 }


### PR DESCRIPTION
According to IRC discussions, these haven't been used, let alone enabled, for several years.