### PR TITLE
Change LST turn speed to the default maximum

### DIFF
--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -272,7 +272,6 @@ LST:
 		Type: Heavy
 	Mobile:
 		Locomotor: lcraft
-		TurnSpeed: 10
 		Speed: 113
 		RequiresCondition: !notmobile
 	RevealsShroud:


### PR DESCRIPTION
As the transport looks like an omni-directional unit, turn speed doesn't add realism; just frustration at a unit that looks unresponsive.

Closes #16021