### PR TITLE
Fixes for Soviet air attacks in RA allies missions

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// If all valid weapons have depleted their ammo and Rearmable trait exists, return to RearmActor to reload and then resume the activity
 			if (rearmable != null && !useLastVisibleTarget && attackAircraft.Armaments.All(x => x.IsTraitPaused || !x.Weapon.IsValidAgainst(target, self.World, self)))
-				return ActivityUtils.SequenceActivities(new ReturnToBase(self, aircraft.Info.AbortOnResupply), this);
+				return ActivityUtils.SequenceActivities(new ReturnToBase(self, aircraft.AbortOnResupply), this);
 
 			var pos = self.CenterPosition;
 			var checkTarget = useLastVisibleTarget ? lastVisibleTarget : target;

--- a/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// If all valid weapons have depleted their ammo and Rearmable trait exists, return to RearmActor to reload and then resume the activity
 			if (rearmable != null && !useLastVisibleTarget && attackAircraft.Armaments.All(x => x.IsTraitPaused || !x.Weapon.IsValidAgainst(target, self.World, self)))
-				return ActivityUtils.SequenceActivities(new HeliReturnToBase(self, aircraft.Info.AbortOnResupply), this);
+				return ActivityUtils.SequenceActivities(new HeliReturnToBase(self, aircraft.AbortOnResupply), this);
 
 			var pos = self.CenterPosition;
 			var checkTarget = useLastVisibleTarget ? lastVisibleTarget : target;

--- a/OpenRA.Mods.Common/Scripting/Properties/AircraftProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/AircraftProperties.cs
@@ -19,19 +19,25 @@ namespace OpenRA.Mods.Common.Scripting
 	[ScriptPropertyGroup("Movement")]
 	public class AircraftProperties : ScriptActorProperties, Requires<AircraftInfo>
 	{
-		readonly AircraftInfo aircraftInfo;
+		readonly Aircraft aircraft;
 
 		public AircraftProperties(ScriptContext context, Actor self)
 			: base(context, self)
 		{
-			aircraftInfo = self.Info.TraitInfo<AircraftInfo>();
+			aircraft = self.Trait<Aircraft>();
+		}
+
+		[Desc("Boolean for whether the aircraft's activity is cancelled when returning to base.")]
+		public bool AbortOnResupply {
+			get { return aircraft.AbortOnResupply; }
+			set { aircraft.AbortOnResupply = value; }
 		}
 
 		[ScriptActorPropertyActivity]
 		[Desc("Fly within the cell grid.")]
 		public void Move(CPos cell)
 		{
-			if (!aircraftInfo.CanHover)
+			if (!aircraft.Info.CanHover)
 				Self.QueueActivity(new Fly(Self, Target.FromCell(Self.World, cell)));
 			else
 				Self.QueueActivity(new HeliFly(Self, Target.FromCell(Self.World, cell)));
@@ -41,10 +47,10 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Return to the base, which is either the destination given, or an auto-selected one otherwise.")]
 		public void ReturnToBase(Actor destination = null)
 		{
-			if (!aircraftInfo.CanHover)
-				Self.QueueActivity(new ReturnToBase(Self, false, destination));
+			if (!aircraft.Info.CanHover)
+				Self.QueueActivity(new ReturnToBase(Self, aircraft.AbortOnResupply, destination));
 			else
-				Self.QueueActivity(new HeliReturnToBase(Self, false, destination));
+				Self.QueueActivity(new HeliReturnToBase(Self, aircraft.AbortOnResupply, destination));
 		}
 
 		[ScriptActorPropertyActivity]

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -186,6 +186,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Actor ReservedActor { get; private set; }
 		public bool MayYieldReservation { get; private set; }
 		public bool ForceLanding { get; private set; }
+		public bool AbortOnResupply { get; set; }
 
 		bool airborne;
 		bool cruising;
@@ -210,6 +211,7 @@ namespace OpenRA.Mods.Common.Traits
 				SetPosition(self, init.Get<CenterPositionInit, WPos>());
 
 			Facing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : Info.InitialFacing;
+			AbortOnResupply = Info.AbortOnResupply;
 		}
 
 		public virtual IEnumerable<VariableObserver> GetVariableObservers()
@@ -790,9 +792,9 @@ namespace OpenRA.Mods.Common.Traits
 				if (!Reservable.IsAvailableFor(targetActor, self))
 				{
 					if (!Info.CanHover)
-						self.QueueActivity(new ReturnToBase(self, Info.AbortOnResupply));
+						self.QueueActivity(new ReturnToBase(self, AbortOnResupply));
 					else
-						self.QueueActivity(new HeliReturnToBase(self, Info.AbortOnResupply));
+						self.QueueActivity(new HeliReturnToBase(self, AbortOnResupply));
 				}
 				else
 				{
@@ -801,7 +803,7 @@ namespace OpenRA.Mods.Common.Traits
 					if (!Info.CanHover && !Info.VTOL)
 					{
 						self.QueueActivity(order.Queued, ActivityUtils.SequenceActivities(
-							new ReturnToBase(self, Info.AbortOnResupply, targetActor),
+							new ReturnToBase(self, AbortOnResupply, targetActor),
 							new ResupplyAircraft(self)));
 					}
 					else
@@ -842,9 +844,9 @@ namespace OpenRA.Mods.Common.Traits
 					UnReserve();
 
 				if (!Info.CanHover)
-					self.QueueActivity(order.Queued, new ReturnToBase(self, Info.AbortOnResupply, null, false));
+					self.QueueActivity(order.Queued, new ReturnToBase(self, AbortOnResupply, null, false));
 				else
-					self.QueueActivity(order.Queued, new HeliReturnToBase(self, Info.AbortOnResupply, null, false));
+					self.QueueActivity(order.Queued, new HeliReturnToBase(self, AbortOnResupply, null, false));
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Air/ReturnOnIdle.cs
+++ b/OpenRA.Mods.Common/Traits/Air/ReturnOnIdle.cs
@@ -23,23 +23,23 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class ReturnOnIdle : INotifyIdle
 	{
-		readonly AircraftInfo aircraftInfo;
+		readonly Aircraft aircraft;
 
 		public ReturnOnIdle(Actor self, ReturnOnIdleInfo info)
 		{
-			aircraftInfo = self.Info.TraitInfo<AircraftInfo>();
+			aircraft = self.Trait<Aircraft>();
 		}
 
 		void INotifyIdle.TickIdle(Actor self)
 		{
 			// We're on the ground, let's stay there.
-			if (self.World.Map.DistanceAboveTerrain(self.CenterPosition).Length < aircraftInfo.MinAirborneAltitude)
+			if (self.World.Map.DistanceAboveTerrain(self.CenterPosition).Length < aircraft.Info.MinAirborneAltitude)
 				return;
 
 			var resupplier = ReturnToBase.ChooseResupplier(self, true);
 			if (resupplier != null)
 			{
-				self.QueueActivity(new ReturnToBase(self, aircraftInfo.AbortOnResupply, resupplier));
+				self.QueueActivity(new ReturnToBase(self, aircraft.AbortOnResupply, resupplier));
 				self.QueueActivity(new ResupplyAircraft(self));
 			}
 			else

--- a/OpenRA.sln
+++ b/OpenRA.sln
@@ -100,6 +100,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Red Alert Lua scripts", "Re
 		mods\ra\maps\soviet-soldier-volkov-n-chitzkoi\scu35ea-AI.lua = mods\ra\maps\soviet-soldier-volkov-n-chitzkoi\scu35ea-AI.lua
 		mods\ra\maps\survival01\survival01.lua = mods\ra\maps\survival01\survival01.lua
 		mods\ra\maps\survival02\survival02.lua = mods\ra\maps\survival02\survival02.lua
+                mods\ra\maps\allies-04\allies04.lua = mods\ra\maps\allies-04\allies04.lua
+                mods\ra\maps\allies-04\allies04-AI.lua = mods\ra\maps\allies-04\allies04-AI.lua
+                mods\ra\maps\allies-07\allies07.lua = mods\ra\maps\allies-07\allies07.lua
+                mods\ra\maps\allies-07\allies07-AI.lua = mods\ra\maps\allies-07\allies07-AI.lua
+                mods\ra\maps\allies-08a\allies08a.lua = mods\ra\maps\allies-08a\allies08a.lua
+                mods\ra\maps\allies-08a\allies08a-AI.lua = mods\ra\maps\allies-08a\allies08a-AI.lua
+                mods\ra\maps\allies-08b\allies08b.lua = mods\ra\maps\allies-08b\allies08b.lua
+                mods\ra\maps\allies-08b\allies08b-AI.lua = mods\ra\maps\allies-08b\allies08b-AI.lua
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Dune 2000 Lua scripts", "Dune 2000 Lua scripts", "{06B1AE07-DDB0-4287-8700-A8CD9A0E652E}"

--- a/mods/ra/maps/allies-04/allies04-AI.lua
+++ b/mods/ra/maps/allies-04/allies04-AI.lua
@@ -245,6 +245,10 @@ ProduceAircraft = function()
 end
 
 TargetAndAttack = function(yak, target)
+	if yak.IsDead then
+		return
+	end
+
 	if not target or target.IsDead or (not target.IsInWorld) then
 		local enemies = Utils.Where(Map.ActorsInWorld, function(self) return self.Owner == player and self.HasProperty("Health") and yak.CanTarget(self) end)
 
@@ -253,14 +257,16 @@ TargetAndAttack = function(yak, target)
 		end
 	end
 
-	if target and yak.AmmoCount() > 0 and yak.CanTarget(target) then
+	-- Attack, and keep attacking even after automatic return to base
+	if yak.CanTarget(target) then
+		yak.AbortOnResupply = false
 		yak.Attack(target)
-	else
-		yak.ReturnToBase()
 	end
 
+	-- Next activity is to do this again
+	-- Short delay guards against fatal CallFunc loop, if Attack() was not possible or fails to queue an activity
 	yak.CallFunc(function()
-		TargetAndAttack(yak, target)
+		Trigger.AfterDelay(DateTime.Seconds(1), function() TargetAndAttack(yak, target) end)
 	end)
 end
 

--- a/mods/ra/maps/allies-06a/allies06a-AI.lua
+++ b/mods/ra/maps/allies-06a/allies06a-AI.lua
@@ -159,6 +159,10 @@ ProduceAircraft = function()
 end
 
 TargetAndAttack = function(yak, target)
+	if yak.IsDead then
+		return
+	end
+
 	if not target or target.IsDead or (not target.IsInWorld) then
 		local enemies = Utils.Where(Map.ActorsInWorld, function(self) return self.Owner == player and self.HasProperty("Health") and yak.CanTarget(self) end)
 		if #enemies > 0 then
@@ -166,14 +170,16 @@ TargetAndAttack = function(yak, target)
 		end
 	end
 
-	if target and yak.AmmoCount() > 0 and yak.CanTarget(target) then
+	-- Attack, and keep attacking even after automatic return to base
+	if yak.CanTarget(target) then
+		yak.AbortOnResupply = false
 		yak.Attack(target)
-	else
-		yak.ReturnToBase()
 	end
 
+	-- Next activity is to do this again
+	-- Short delay guards against fatal CallFunc loop, if Attack() was not possible or fails to queue an activity
 	yak.CallFunc(function()
-		TargetAndAttack(yak, target)
+		Trigger.AfterDelay(DateTime.Seconds(1), function() TargetAndAttack(yak, target) end)
 	end)
 end
 

--- a/mods/ra/maps/allies-06b/allies06b-AI.lua
+++ b/mods/ra/maps/allies-06b/allies06b-AI.lua
@@ -171,6 +171,10 @@ ProduceAircraft = function()
 end
 
 TargetAndAttack = function(yak, target)
+	if yak.IsDead then
+		return
+	end
+
 	if not target or target.IsDead or (not target.IsInWorld) then
 		local enemies = Utils.Where(Map.ActorsInWorld, function(self) return self.Owner == player and self.HasProperty("Health") and yak.CanTarget(self) end)
 		if #enemies > 0 then
@@ -178,14 +182,16 @@ TargetAndAttack = function(yak, target)
 		end
 	end
 
-	if target and yak.AmmoCount() > 0 and yak.CanTarget(target) then
+	-- Attack, and keep attacking even after automatic return to base
+	if yak.CanTarget(target) then
+		yak.AbortOnResupply = false
 		yak.Attack(target)
-	else
-		yak.ReturnToBase()
 	end
 
+	-- Next activity is to do this again
+	-- Short delay guards against fatal CallFunc loop, if Attack() was not possible or fails to queue an activity
 	yak.CallFunc(function()
-		TargetAndAttack(yak, target)
+		Trigger.AfterDelay(DateTime.Seconds(1), function() TargetAndAttack(yak, target) end)
 	end)
 end
 

--- a/mods/ra/maps/allies-06b/allies06b.lua
+++ b/mods/ra/maps/allies-06b/allies06b.lua
@@ -238,10 +238,14 @@ WorldLoaded = function()
 
 		if Map.LobbyOption("difficulty") == "easy" then
 			Trigger.OnKilled(DefBrl1, function(a, b)
-				DefenseFlame1.Kill()
+				if not DefenseFlame1.IsDead then
+					DefenseFlame1.Kill()
+				end
 			end)
 			Trigger.OnKilled(DefBrl2, function(a, b)
-				DefenseFlame2.Kill()
+				if not DefenseFlame2.IsDead then
+					DefenseFlame2.Kill()
+				end
 			end)
 		end
 	end

--- a/mods/ra/maps/allies-07/allies07-AI.lua
+++ b/mods/ra/maps/allies-07/allies07-AI.lua
@@ -134,6 +134,10 @@ ProduceAircraft = function()
 end
 
 TargetAndAttack = function(yak, target)
+	if yak.IsDead then
+		return
+	end
+
 	if not target or target.IsDead or (not target.IsInWorld) then
 		local enemies = Utils.Where(Map.ActorsInWorld, function(self) return self.Owner == greece and self.HasProperty("Health") and yak.CanTarget(self) end)
 		if #enemies > 0 then
@@ -141,14 +145,16 @@ TargetAndAttack = function(yak, target)
 		end
 	end
 
-	if target and yak.AmmoCount() > 0 and yak.CanTarget(target) then
+	-- Attack, and keep attacking even after automatic return to base
+	if yak.CanTarget(target) then
+		yak.AbortOnResupply = false
 		yak.Attack(target)
-	else
-		yak.ReturnToBase()
 	end
 
+	-- Next activity is to do this again
+	-- Short delay guards against fatal CallFunc loop, if Attack() was not possible or fails to queue an activity
 	yak.CallFunc(function()
-		TargetAndAttack(yak, target)
+		Trigger.AfterDelay(DateTime.Seconds(1), function() TargetAndAttack(yak, target) end)
 	end)
 end
 

--- a/mods/ra/maps/allies-08b/allies08b-AI.lua
+++ b/mods/ra/maps/allies-08b/allies08b-AI.lua
@@ -129,6 +129,10 @@ ProduceAircraft = function()
 end
 
 TargetAndAttack = function(mig, target)
+	if mig.IsDead then
+		return
+	end
+
 	if not target or target.IsDead or (not target.IsInWorld) then
 		local enemies = Utils.Where(greece.GetActors(), function(actor)
 			return actor.HasProperty("Health") and actor.Type ~= "brik"
@@ -138,14 +142,16 @@ TargetAndAttack = function(mig, target)
 		end
 	end
 
-	if target and mig.AmmoCount() > 0 and mig.CanTarget(target) then
+	-- Attack, and keep attacking even after automatic return to base
+	if mig.CanTarget(target) then
+		mig.AbortOnResupply = false
 		mig.Attack(target)
-	else
-		mig.ReturnToBase()
 	end
 
+	-- Next activity is to do this again
+	-- Short delay guards against fatal CallFunc loop, if Attack() was not possible or fails to queue an activity
 	mig.CallFunc(function()
-		TargetAndAttack(mig, target)
+		Trigger.AfterDelay(DateTime.Seconds(1), function() TargetAndAttack(mig, target) end)
 	end)
 end
 


### PR DESCRIPTION
While playing the Allied campaign missions, newly spawned aircraft often cause the game to hang/crash (stuck in CallFunc loop).

*.lua
Updated TargetAndAttack() function:
1. Use a delayed trigger (6 seconds) to generate the repeated attack/return-to-base instructions. This replaces the more immediate CallFunc() chaining.
2. First call Stop() to clear any previously queued activities.
3. Use attack move instead of direct attack. 

Note: This PR originally contained additional aircraft changes. These have been pulled into https://github.com/OpenRA/OpenRA/pull/16054 and https://github.com/OpenRA/OpenRA/pull/16055 instead. 