### PR TITLE
Update the description of EnemyWatcher and AnnounceOnSeen

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Global/TriggerGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/TriggerGlobal.cs
@@ -420,7 +420,7 @@ namespace OpenRA.Mods.Common.Scripting
 
 		[Desc("Call a function when this actor is discovered by an enemy or a player with a Neutral stance. " +
 			"The callback function will be called as func(Actor discovered, Player discoverer). " +
-			"The player actor needs the 'EnemyWatcher' trait.")]
+			"The player actor needs the 'EnemyWatcher' trait. The actors to discover need the 'AnnounceOnSeen' trait.")]
 		public void OnDiscovered(Actor a, LuaFunction func)
 		{
 			GetScriptTriggers(a).RegisterCallback(Trigger.OnDiscovered, func, Context);
@@ -428,7 +428,7 @@ namespace OpenRA.Mods.Common.Scripting
 
 		[Desc("Call a function when this player is discovered by an enemy or neutral player. " +
 			"The callback function will be called as func(Player discovered, Player discoverer, Actor discoveredActor)." +
-			"The player actor needs the 'EnemyWatcher' trait.")]
+			"The player actor needs the 'EnemyWatcher' trait. The actors to discover need the 'AnnounceOnSeen' trait.")]
 		public void OnPlayerDiscovered(Player discovered, LuaFunction func)
 		{
 			GetScriptTriggers(discovered.PlayerActor).RegisterCallback(Trigger.OnPlayerDiscovered, func, Context);

--- a/OpenRA.Mods.Common/Scripting/Global/TriggerGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/TriggerGlobal.cs
@@ -419,7 +419,7 @@ namespace OpenRA.Mods.Common.Scripting
 		}
 
 		[Desc("Call a function when this actor is discovered by an enemy or a player with a Neutral stance. " +
-			"The callback function will be called as func(Actor discovered, Player discoverer). +" +
+			"The callback function will be called as func(Actor discovered, Player discoverer). " +
 			"The player actor needs the 'EnemyWatcher' trait.")]
 		public void OnDiscovered(Actor a, LuaFunction func)
 		{

--- a/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
+++ b/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Tracks neutral and enemy actors' visibility and notifies the player.",
-		"Attach this to the player actor.")]
+		"Attach this to the player actor. The actors to track need the 'AnnounceOnSeen' trait.")]
 	class EnemyWatcherInfo : ITraitInfo
 	{
 		[Desc("Interval in ticks between scanning for enemies.")]

--- a/OpenRA.Mods.Common/Traits/Sound/AnnounceOnSeen.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AnnounceOnSeen.cs
@@ -15,7 +15,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Sound
 {
-	[Desc("Players will be notified when this actor becomes visible to them.")]
+	[Desc("Players will be notified when this actor becomes visible to them.",
+		"Requires the 'EnemyWatcher' trait on the player actor.")]
 	public class AnnounceOnSeenInfo : ITraitInfo
 	{
 		[Desc("Should there be a radar ping on enemies' radar at the actor's location when they see him")]


### PR DESCRIPTION
Also fixes the descriptions for On(Player)Discovered in the Lua API.

EnemyWatcher loops over `World.ActorsWithTrait<AnnounceOnSeen>`, so `AnnounceOnSeen` is a must for any of the methods to work.