### PR TITLE
Reduce cash tick volume

### DIFF
--- a/OpenRA.Game/GameRules/SoundInfo.cs
+++ b/OpenRA.Game/GameRules/SoundInfo.cs
@@ -33,7 +33,7 @@ namespace OpenRA.GameRules
 		{
 			FieldLoader.Load(this, y);
 
-			VoicePools = Exts.Lazy(() => Voices.ToDictionary(a => a.Key, a => new SoundPool(0, a.Value)));
+			VoicePools = Exts.Lazy(() => Voices.ToDictionary(a => a.Key, a => new SoundPool(0, 1f, a.Value)));
 			NotificationsPools = Exts.Lazy(() => ParseSoundPool(y, "Notifications"));
 		}
 
@@ -48,8 +48,13 @@ namespace OpenRA.GameRules
 				if (rateLimitNode != null)
 					rateLimit = FieldLoader.GetValue<int>(rateLimitNode.Key, rateLimitNode.Value.Value);
 
+				var volumeModifier = 1f;
+				var volumeModifierNode = t.Value.Nodes.FirstOrDefault(x => x.Key == "VolumeModifier");
+				if (volumeModifierNode != null)
+					volumeModifier = FieldLoader.GetValue<float>(volumeModifierNode.Key, volumeModifierNode.Value.Value);
+
 				var names = FieldLoader.GetValue<string[]>(t.Key, t.Value.Value);
-				var sp = new SoundPool(rateLimit, names);
+				var sp = new SoundPool(rateLimit, volumeModifier, names);
 				ret.Add(t.Key, sp);
 			}
 
@@ -59,13 +64,15 @@ namespace OpenRA.GameRules
 
 	public class SoundPool
 	{
+		public readonly float VolumeModifier;
 		readonly string[] clips;
 		readonly int rateLimit;
 		readonly List<string> liveclips = new List<string>();
 		long lastPlayed = 0;
 
-		public SoundPool(int rateLimit, params string[] clips)
+		public SoundPool(int rateLimit, float volumeModifier, params string[] clips)
 		{
+			VolumeModifier = volumeModifier;
 			this.clips = clips;
 			this.rateLimit = rateLimit;
 		}

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -352,7 +352,7 @@ namespace OpenRA
 
 			var id = voicedActor != null ? voicedActor.ActorID : 0;
 
-			string clip;
+			SoundPool pool;
 			var suffix = rules.DefaultVariant;
 			var prefix = rules.DefaultPrefix;
 
@@ -361,16 +361,17 @@ namespace OpenRA
 				if (!rules.VoicePools.Value.ContainsKey(definition))
 					throw new InvalidOperationException("Can't find {0} in voice pool.".F(definition));
 
-				clip = rules.VoicePools.Value[definition].GetNext();
+				pool = rules.VoicePools.Value[definition];
 			}
 			else
 			{
 				if (!rules.NotificationsPools.Value.ContainsKey(definition))
 					throw new InvalidOperationException("Can't find {0} in notification pool.".F(definition));
 
-				clip = rules.NotificationsPools.Value[definition].GetNext();
+				pool = rules.NotificationsPools.Value[definition];
 			}
 
+			var clip = pool.GetNext();
 			if (string.IsNullOrEmpty(clip))
 				return false;
 
@@ -388,7 +389,7 @@ namespace OpenRA
 			{
 				var sound = soundEngine.Play2D(sounds[name],
 					false, relative, pos,
-					InternalSoundVolume * volumeModifier, attenuateVolume);
+					InternalSoundVolume * volumeModifier * pool.VolumeModifier, attenuateVolume);
 				if (id != 0)
 				{
 					if (currentSounds.ContainsKey(id))

--- a/mods/cnc/audio/notifications.yaml
+++ b/mods/cnc/audio/notifications.yaml
@@ -60,6 +60,7 @@ Sounds:
 		Beepy6: beepy6
 		CashTickDown: tone16
 		CashTickUp: tone15
+			VolumeModifier: 0.33
 		ChatLine: scold1
 		ClickDisabledSound: scold2
 		ClickSound: button

--- a/mods/ra/audio/notifications.yaml
+++ b/mods/ra/audio/notifications.yaml
@@ -123,7 +123,9 @@ Sounds:
 		RadarUp: radaron2
 		RadarDown: radardn1
 		CashTickUp: cashup1
+			VolumeModifier: 0.33
 		CashTickDown: cashdn1
+			VolumeModifier: 0.33
 		LevelUp: hydrod1
 		DisablePower: bleep11
 		EnablePower: bleep12

--- a/mods/ts/audio/sounds-generic.yaml
+++ b/mods/ts/audio/sounds-generic.yaml
@@ -9,7 +9,9 @@ Sounds:
 		Button: button
 		CantPushButtonSound: scold8
 		CashTickDown: creddwn1
+			VolumeModifier: 0.33
 		CashTickUp: credup1
+			VolumeModifier: 0.33
 		ChatLine: message1
 		ClickDisabledSound: wrong1
 		ClickSound: clicky1


### PR DESCRIPTION
This PR adds the ability to define volume modifiers on individual notifications, and uses this to make the cash ticks a bit less prominent (and balance out the up/down volume mismatch in TD).

This is pretty simple polish, so i'm not sure whether we want to sneak this in for the next playtest or defer it to next + 1.