### PR TITLE
Reset the client state when being moved to spectator

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -654,6 +654,7 @@ namespace OpenRA.Mods.Common.Server
 			targetClient.SpawnPoint = 0;
 			targetClient.Team = 0;
 			targetClient.Color = HSLColor.FromRGB(255, 255, 255);
+			targetClient.State = Session.ClientState.NotReady;
 			server.SendMessage("{0} moved {1} to spectators.".F(client.Name, targetClient.Name));
 			Log.Write("server", "{0} moved {1} to spectators.".F(client.Name, targetClient.Name));
 			server.SyncLobbyClients();


### PR DESCRIPTION
Reported by `.1` on Discord.

Reproduction case: Ready a client and then move it to spectators. The client will still be locked and can't untick the ready checkbox.