### PR TITLE
Fix Warhead.IsValidAgainst crash 

### DIFF
--- a/OpenRA.Mods.Common/Warheads/Warhead.cs
+++ b/OpenRA.Mods.Common/Warheads/Warhead.cs
@@ -82,6 +82,9 @@ namespace OpenRA.Mods.Common.Warheads
 		/// <summary>Checks if the warhead is valid against (can do something to) the frozen actor.</summary>
 		public bool IsValidAgainst(FrozenActor victim, Actor firedBy)
 		{
+			if (!victim.IsValid)
+				return false;
+
 			// AffectsParent checks do not make sense for FrozenActors, so skip to stance checks
 			var stance = firedBy.Owner.Stances[victim.Owner];
 			if (!ValidStances.HasStance(stance))


### PR DESCRIPTION
It happened for FrozenActors - victim.Owner == null so no stance. If it can't happen for Actor, we could use victim.IsValid check instead of Owner or keep Owner as more explicit here.

Fixes #16019