### PR TITLE
Improve sending of immediate orders

### DIFF
--- a/OpenRA.Game/Network/Connection.cs
+++ b/OpenRA.Game/Network/Connection.cs
@@ -68,11 +68,13 @@ namespace OpenRA.Network
 
 		public virtual void SendImmediate(IEnumerable<byte[]> orders)
 		{
-			var ms = new MemoryStream();
-			ms.WriteArray(BitConverter.GetBytes(0));
 			foreach (var o in orders)
+			{
+				var ms = new MemoryStream();
+				ms.WriteArray(BitConverter.GetBytes(0));
 				ms.WriteArray(o);
-			Send(ms.ToArray());
+				Send(ms.ToArray());
+			}
 		}
 
 		public virtual void SendSync(int frame, byte[] syncData)

--- a/OpenRA.Game/Network/Connection.cs
+++ b/OpenRA.Game/Network/Connection.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Network
 		int LocalClientId { get; }
 		ConnectionState ConnectionState { get; }
 		void Send(int frame, List<byte[]> orders);
-		void SendImmediate(List<byte[]> orders);
+		void SendImmediate(IEnumerable<byte[]> orders);
 		void SendSync(int frame, byte[] syncData);
 		void Receive(Action<int, byte[]> packetFn);
 	}
@@ -66,7 +66,7 @@ namespace OpenRA.Network
 			Send(ms.ToArray());
 		}
 
-		public virtual void SendImmediate(List<byte[]> orders)
+		public virtual void SendImmediate(IEnumerable<byte[]> orders)
 		{
 			var ms = new MemoryStream();
 			ms.WriteArray(BitConverter.GetBytes(0));

--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -125,7 +125,7 @@ namespace OpenRA.Network
 
 		// Do nothing: ignore locally generated orders
 		public void Send(int frame, List<byte[]> orders) { }
-		public void SendImmediate(List<byte[]> orders) { }
+		public void SendImmediate(IEnumerable<byte[]> orders) { }
 
 		public void SendSync(int frame, byte[] syncData)
 		{


### PR DESCRIPTION
If immediate orders are attached to a tick, they are completely ignored by the server. This is probably not the intended behaviour for server orders but I also can't see any reason to do that for any other type of immediate order.

The second commit makes sure that every immediate order ends up with its own framing. There is no reason to pack multiple immediate orders into a single framing and this change allows the server to process huge groups in pieces without reading everything at once.