### PR TITLE
Fix for #7083: Fly stops turning when target is inside the turn radius

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -53,11 +53,6 @@ namespace OpenRA.Mods.Common.Activities
 				.ClosestTo(self);
 		}
 
-		int CalculateTurnRadius(int speed)
-		{
-			return 45 * speed / aircraft.Info.TurnSpeed;
-		}
-
 		void Calculate(Actor self)
 		{
 			if (dest == null || dest.IsDead || Reservable.IsReserved(dest))
@@ -77,7 +72,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Add 10% to the turning radius to ensure we have enough room
 			var speed = aircraft.MovementSpeed * 32 / 35;
-			var turnRadius = CalculateTurnRadius(speed);
+			var turnRadius = Fly.CalculateTurnRadius(speed, aircraft.Info.TurnSpeed);
 
 			// Find the center of the turning circles for clockwise and counterclockwise turns
 			var angle = WAngle.FromFacing(aircraft.Facing);
@@ -154,7 +149,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			List<Activity> landingProcedures = new List<Activity>();
 
-			var turnRadius = CalculateTurnRadius(aircraft.Info.Speed);
+			var turnRadius = Fly.CalculateTurnRadius(aircraft.Info.Speed, aircraft.Info.TurnSpeed);
 
 			landingProcedures.Add(new Fly(self, Target.FromPos(w1), WDist.Zero, new WDist(turnRadius * 3)));
 			landingProcedures.Add(new Fly(self, Target.FromPos(w2)));


### PR DESCRIPTION
Fly.cs
Calculate when the target point is within the aircraft's turn radius. In this case, the destination cannot be reached by simply turning, so fly away until it becomes reachable. 

This situation was very reproducible, by shift-clicking some move waypoints for a Yak: first two adjacent cells, and then a third one anywhere else. The Yak flies to the first waypoint, but then is stuck circling the second one because its turn isn't sharp enough to ever reach it.

I initially encountered AI yaks getting stuck in this way while playing the Allied campaign (mainly noticed on allies-06b). However, it does appear to solve the latest issue described in https://github.com/OpenRA/OpenRA/issues/7083. 