### PR TITLE
Possible fix for #14102: Consider airfield available if already reserved for the same actor

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			return self.World.Actors.Where(a => a.Owner == self.Owner
 				&& rearmable.Info.RearmActors.Contains(a.Info.Name)
-				&& (!unreservedOnly || !Reservable.IsReserved(a)))
+				&& (!unreservedOnly || Reservable.IsAvailableFor(a, self)))
 				.ClosestTo(self);
 		}
 
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (IsCanceled)
 				return NextActivity;
 
-			if (dest == null || dest.IsDead || Reservable.IsReserved(dest))
+			if (dest == null || dest.IsDead || !Reservable.IsAvailableFor(dest, self))
 				dest = ChooseResupplier(self, true);
 
 			var initialFacing = aircraft.Info.InitialFacing;

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -49,13 +49,13 @@ namespace OpenRA.Mods.Common.Activities
 			return self.World.ActorsHavingTrait<Reservable>()
 				.Where(a => a.Owner == self.Owner
 					&& rearmInfo.RearmActors.Contains(a.Info.Name)
-					&& (!unreservedOnly || !Reservable.IsReserved(a)))
+					&& (!unreservedOnly || Reservable.IsAvailableFor(a, self)))
 				.ClosestTo(self);
 		}
 
 		void Calculate(Actor self)
 		{
-			if (dest == null || dest.IsDead || Reservable.IsReserved(dest))
+			if (dest == null || dest.IsDead || !Reservable.IsAvailableFor(dest, self))
 				dest = ChooseResupplier(self, true);
 
 			if (dest == null)

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -714,7 +714,7 @@ namespace OpenRA.Mods.Common.Traits
 			get
 			{
 				yield return new EnterAlliedActorTargeter<BuildingInfo>("Enter", 5,
-					target => AircraftCanEnter(target), target => !Reservable.IsReserved(target));
+					target => AircraftCanEnter(target), target => Reservable.IsAvailableFor(target, self));
 
 				yield return new AircraftMoveOrderTargeter(Info);
 			}
@@ -787,7 +787,7 @@ namespace OpenRA.Mods.Common.Traits
 					UnReserve();
 
 				var targetActor = order.Target.Actor;
-				if (Reservable.IsReserved(targetActor))
+				if (!Reservable.IsAvailableFor(targetActor, self))
 				{
 					if (!Info.CanHover)
 						self.QueueActivity(new ReturnToBase(self, Info.AbortOnResupply));

--- a/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
@@ -65,6 +65,12 @@ namespace OpenRA.Mods.Common.Traits
 			return res != null && res.reservedForAircraft != null && !res.reservedForAircraft.MayYieldReservation;
 		}
 
+		public static bool IsAvailableFor(Actor reservable, Actor forActor)
+		{
+			var res = reservable.TraitOrDefault<Reservable>();
+			return res == null || res.reservedForAircraft == null || res.reservedForAircraft.MayYieldReservation || res.reservedFor == forActor;
+		}
+
 		private void UnReserve()
 		{
 			if (reservedForAircraft != null)


### PR DESCRIPTION
ReturnToBase.cs/Reservable.cs
Support checking if the Reservable is available to the actor, instead of reserved at all. This prevents a situation where two aircraft could reserve two airfields, but then desire to swap them (possibly the opposite airfields are closer when return-to-base is reissued).

I encounted a pair of yaks unable to land on the two airfields in allies-06b. They were stuck in ReturnToBase, unable to reserve an airfield because they were both already reserved by each other. I have not been able to reproduce this issue since making this change. 

This AI behavior seems similar to the issue desribed in https://github.com/OpenRA/OpenRA/issues/14102.