### PR TITLE
Make BuildingInfo.Render virtual

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -233,7 +233,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool IOccupySpaceInfo.SharesCell { get { return false; } }
 
-		public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
+		public virtual IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
 		{
 			if (!RequiresBaseProvider)
 				return SpriteRenderable.None;


### PR DESCRIPTION
d2 mod already uses class derived from BuildingInfo.
Function
`public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)`
need to be virtual for correct buildings drawing during building placement.
