### PR TITLE
Allow deploy orders on units with the Cargo trait to be queued

### DIFF
--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -60,6 +60,12 @@ namespace OpenRA.Mods.Common.Activities
 			if (IsCanceled || cargo.IsEmpty(self))
 				return NextActivity;
 
+			if (!cargo.CanUnload())
+			{
+				Cancel(self, true);
+				return NextActivity;
+			}
+
 			foreach (var inu in notifiers)
 				inu.Unloading(self);
 

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -185,11 +185,13 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (order.OrderString == "Unload")
 			{
-				if (!CanUnload())
+				if (!order.Queued && !CanUnload())
 					return;
 
+				if (!order.Queued)
+					self.CancelActivity();
+
 				Unloading = true;
-				self.CancelActivity();
 				if (aircraft != null)
 					self.QueueActivity(new HeliLand(self, true));
 				self.QueueActivity(new UnloadCargo(self, true));
@@ -201,7 +203,7 @@ namespace OpenRA.Mods.Common.Traits
 			return Util.AdjacentCells(self.World, Target.FromActor(self)).Where(c => self.Location != c);
 		}
 
-		bool CanUnload()
+		public bool CanUnload()
 		{
 			if (checkTerrainType)
 			{


### PR DESCRIPTION
In response to issue #16026.
This extends the functionality which now exists to queue deploy orders for units with the Transform trait (such as MCVs) to units with the Cargo trait (APC, Chinook, etc.).

Fixes #4774.