### PR TITLE
Make Attack activities explicitly account for hidden actors.

### DIFF
--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -24,15 +24,17 @@ namespace OpenRA.Traits
 		readonly TargetType type;
 		readonly Actor actor;
 		readonly FrozenActor frozen;
-		readonly WPos pos;
+		readonly WPos terrainCenterPosition;
+		readonly WPos[] terrainPositions;
 		readonly CPos? cell;
 		readonly SubCell? subCell;
 		readonly int generation;
 
-		Target(WPos pos)
+		Target(WPos terrainCenterPosition, WPos[] terrainPositions = null)
 		{
 			type = TargetType.Terrain;
-			this.pos = pos;
+			this.terrainCenterPosition = terrainCenterPosition;
+			this.terrainPositions = terrainPositions ?? new[] { terrainCenterPosition };
 
 			actor = null;
 			frozen = null;
@@ -44,7 +46,8 @@ namespace OpenRA.Traits
 		Target(World w, CPos c, SubCell subCell)
 		{
 			type = TargetType.Terrain;
-			pos = w.Map.CenterOfSubCell(c, subCell);
+			terrainCenterPosition = w.Map.CenterOfSubCell(c, subCell);
+			terrainPositions = new[] { terrainCenterPosition };
 			cell = c;
 			this.subCell = subCell;
 
@@ -59,7 +62,8 @@ namespace OpenRA.Traits
 			actor = a;
 			generation = a.Generation;
 
-			pos = WPos.Zero;
+			terrainCenterPosition = WPos.Zero;
+			terrainPositions = null;
 			frozen = null;
 			cell = null;
 			subCell = null;
@@ -70,7 +74,8 @@ namespace OpenRA.Traits
 			type = TargetType.FrozenActor;
 			frozen = fa;
 
-			pos = WPos.Zero;
+			terrainCenterPosition = WPos.Zero;
+			terrainPositions = null;
 			actor = null;
 			cell = null;
 			subCell = null;
@@ -78,6 +83,7 @@ namespace OpenRA.Traits
 		}
 
 		public static Target FromPos(WPos p) { return new Target(p); }
+		public static Target FromTargetPositions(Target t) { return new Target(t.CenterPosition, t.Positions.ToArray()); }
 		public static Target FromCell(World w, CPos c, SubCell subCell = SubCell.FullCell) { return new Target(w, c, subCell); }
 		public static Target FromActor(Actor a) { return a != null ? new Target(a) : Invalid; }
 		public static Target FromFrozenActor(FrozenActor fa) { return new Target(fa); }
@@ -160,7 +166,7 @@ namespace OpenRA.Traits
 					case TargetType.FrozenActor:
 						return frozen.CenterPosition;
 					case TargetType.Terrain:
-						return pos;
+						return terrainCenterPosition;
 					default:
 					case TargetType.Invalid:
 						throw new InvalidOperationException("Attempting to query the position of an invalid Target");
@@ -184,7 +190,7 @@ namespace OpenRA.Traits
 					case TargetType.FrozenActor:
 						return new[] { frozen.CenterPosition };
 					case TargetType.Terrain:
-						return new[] { pos };
+						return terrainPositions;
 					default:
 					case TargetType.Invalid:
 						return NoPositions;
@@ -212,7 +218,7 @@ namespace OpenRA.Traits
 					return frozen.ToString();
 
 				case TargetType.Terrain:
-					return pos.ToString();
+					return terrainCenterPosition.ToString();
 
 				default:
 				case TargetType.Invalid:
@@ -225,6 +231,6 @@ namespace OpenRA.Traits
 		internal Actor SerializableActor { get { return actor; } }
 		internal CPos? SerializableCell { get { return cell; } }
 		internal SubCell? SerializableSubCell { get { return subCell; } }
-		internal WPos SerializablePos { get { return pos; } }
+		internal WPos SerializablePos { get { return terrainCenterPosition; } }
 	}
 }

--- a/OpenRA.Game/Traits/Target.cs
+++ b/OpenRA.Game/Traits/Target.cs
@@ -19,42 +19,68 @@ namespace OpenRA.Traits
 	public struct Target
 	{
 		public static readonly Target[] None = { };
-		public static readonly Target Invalid = new Target { type = TargetType.Invalid };
+		public static readonly Target Invalid = new Target();
 
-		TargetType type;
-		Actor actor;
-		FrozenActor frozen;
-		WPos pos;
-		CPos? cell;
-		SubCell? subCell;
-		int generation;
+		readonly TargetType type;
+		readonly Actor actor;
+		readonly FrozenActor frozen;
+		readonly WPos pos;
+		readonly CPos? cell;
+		readonly SubCell? subCell;
+		readonly int generation;
 
-		public static Target FromPos(WPos p) { return new Target { pos = p, type = TargetType.Terrain }; }
-		public static Target FromCell(World w, CPos c, SubCell subCell = SubCell.FullCell)
+		Target(WPos pos)
 		{
-			return new Target
-			{
-				pos = w.Map.CenterOfSubCell(c, subCell),
-				cell = c,
-				subCell = subCell,
-				type = TargetType.Terrain
-			};
+			type = TargetType.Terrain;
+			this.pos = pos;
+
+			actor = null;
+			frozen = null;
+			cell = null;
+			subCell = null;
+			generation = 0;
 		}
 
-		public static Target FromActor(Actor a)
+		Target(World w, CPos c, SubCell subCell)
 		{
-			if (a == null)
-				return Invalid;
+			type = TargetType.Terrain;
+			pos = w.Map.CenterOfSubCell(c, subCell);
+			cell = c;
+			this.subCell = subCell;
 
-			return new Target
-			{
-				actor = a,
-				type = TargetType.Actor,
-				generation = a.Generation,
-			};
+			actor = null;
+			frozen = null;
+			generation = 0;
 		}
 
-		public static Target FromFrozenActor(FrozenActor a) { return new Target { frozen = a, type = TargetType.FrozenActor }; }
+		Target(Actor a)
+		{
+			type = TargetType.Actor;
+			actor = a;
+			generation = a.Generation;
+
+			pos = WPos.Zero;
+			frozen = null;
+			cell = null;
+			subCell = null;
+		}
+
+		Target(FrozenActor fa)
+		{
+			type = TargetType.FrozenActor;
+			frozen = fa;
+
+			pos = WPos.Zero;
+			actor = null;
+			cell = null;
+			subCell = null;
+			generation = 0;
+		}
+
+		public static Target FromPos(WPos p) { return new Target(p); }
+		public static Target FromCell(World w, CPos c, SubCell subCell = SubCell.FullCell) { return new Target(w, c, subCell); }
+		public static Target FromActor(Actor a) { return a != null ? new Target(a) : Invalid; }
+		public static Target FromFrozenActor(FrozenActor fa) { return new Target(fa); }
 
 		public Actor Actor { get { return actor; } }
 		public FrozenActor FrozenActor { get { return frozen; } }

--- a/OpenRA.Mods.Cnc/Activities/Infiltrate.cs
+++ b/OpenRA.Mods.Cnc/Activities/Infiltrate.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Drawing;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Cnc.Traits;
@@ -25,7 +26,7 @@ namespace OpenRA.Mods.Cnc.Activities
 		readonly INotifyInfiltration[] notifiers;
 
 		public Infiltrate(Actor self, Actor target, Infiltrates infiltrate)
-			: base(self, target, infiltrate.Info.EnterBehaviour)
+			: base(self, target, infiltrate.Info.EnterBehaviour, targetLineColor: Color.Red)
 		{
 			this.target = target;
 			infiltrates  = infiltrate;

--- a/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
+++ b/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Drawing;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Cnc.Traits;
@@ -73,7 +74,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				if (!allowMovement)
 					return NextActivity;
 
-				QueueChild(new MoveWithinRange(self, target, minRange, maxRange));
+				QueueChild(mobile.MoveWithinRange(target, minRange, maxRange, targetLineColor: Color.Red));
 				return this;
 			}
 

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTDGunboatTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTDGunboatTurreted.cs
@@ -59,10 +59,10 @@ namespace OpenRA.Mods.Cnc.Traits
 				{
 					// Check that AttackTDGunboatTurreted hasn't cancelled the target by modifying attack.Target
 					// Having both this and AttackTDGunboatTurreted modify that field is a horrible hack.
-					if (hasTicked && attack.Target.Type == TargetType.Invalid)
+					if (hasTicked && attack.requestedTarget.Type == TargetType.Invalid)
 						return NextActivity;
 
-					attack.Target = target;
+					attack.requestedTarget = target;
 					hasTicked = true;
 				}
 

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -205,7 +205,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					self.CancelActivity();
 
 				self.SetTargetLine(target, Color.Red);
-				self.QueueActivity(new MoveAdjacentTo(self, target));
+				self.QueueActivity(new MoveAdjacentTo(self, target, targetLineColor: Color.Red));
 				self.QueueActivity(new CallFunc(StartDetonationSequence));
 			}
 			else if (order.OrderString == "Detonate")

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common;
@@ -181,11 +182,11 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public Activity MoveTo(CPos cell, int nearEnough) { return null; }
 		public Activity MoveTo(CPos cell, Actor ignoreActor) { return null; }
-		public Activity MoveWithinRange(Target target, WDist range) { return null; }
-		public Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange) { return null; }
-		public Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange) { return null; }
+		public Activity MoveWithinRange(Target target, WDist range, Color? targetLineColor = null) { return null; }
+		public Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null) { return null; }
+		public Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null) { return null; }
 		public Activity MoveIntoWorld(Actor self, CPos cell, SubCell subCell = SubCell.Any) { return null; }
-		public Activity MoveToTarget(Actor self, Target target) { return null; }
+		public Activity MoveToTarget(Actor self, Target target, Color? targetLineColor = null) { return null; }
 		public Activity MoveIntoTarget(Actor self, Target target) { return null; }
 		public Activity VisualMove(Actor self, WPos fromPos, WPos toPos) { return null; }
 

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -182,11 +182,15 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public Activity MoveTo(CPos cell, int nearEnough) { return null; }
 		public Activity MoveTo(CPos cell, Actor ignoreActor) { return null; }
-		public Activity MoveWithinRange(Target target, WDist range, Color? targetLineColor = null) { return null; }
-		public Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null) { return null; }
-		public Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null) { return null; }
+		public Activity MoveWithinRange(Target target, WDist range,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null) { return null; }
+		public Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null) { return null; }
+		public Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null) { return null; }
 		public Activity MoveIntoWorld(Actor self, CPos cell, SubCell subCell = SubCell.Any) { return null; }
-		public Activity MoveToTarget(Actor self, Target target, Color? targetLineColor = null) { return null; }
+		public Activity MoveToTarget(Actor self, Target target,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null) { return null; }
 		public Activity MoveIntoTarget(Actor self, Target target) { return null; }
 		public Activity VisualMove(Actor self, WPos fromPos, WPos toPos) { return null; }
 

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Drawing;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
@@ -24,13 +25,13 @@ namespace OpenRA.Mods.Common.Activities
 		readonly WDist minRange;
 		bool soundPlayed;
 
-		public Fly(Actor self, Target t)
+		public Fly(Actor self, Target t, Color? targetLineColor = null)
 		{
 			aircraft = self.Trait<Aircraft>();
 			target = t;
 		}
 
-		public Fly(Actor self, Target t, WDist minRange, WDist maxRange)
+		public Fly(Actor self, Target t, WDist minRange, WDist maxRange, Color? targetLineColor = null)
 			: this(self, t)
 		{
 			this.maxRange = maxRange;

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -25,14 +25,15 @@ namespace OpenRA.Mods.Common.Activities
 		readonly WDist minRange;
 		bool soundPlayed;
 
-		public Fly(Actor self, Target t, Color? targetLineColor = null)
+		public Fly(Actor self, Target t, WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
 			aircraft = self.Trait<Aircraft>();
 			target = t;
 		}
 
-		public Fly(Actor self, Target t, WDist minRange, WDist maxRange, Color? targetLineColor = null)
-			: this(self, t)
+		public Fly(Actor self, Target t, WDist minRange, WDist maxRange,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null)
+			: this(self, t, initialTargetPosition, targetLineColor)
 		{
 			this.maxRange = maxRange;
 			this.minRange = minRange;

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 			}
 
-			target = target.Recalculate(self.Owner);
+			target = target.RecalculateInvalidatingHiddenTargets(self.Owner);
 
 			if (!target.IsValidFor(self))
 				return NextActivity;

--- a/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
@@ -24,7 +24,8 @@ namespace OpenRA.Mods.Common.Activities
 		readonly Color? targetLineColor;
 		Target target;
 
-		public FlyFollow(Actor self, Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null)
+		public FlyFollow(Actor self, Target target, WDist minRange, WDist maxRange,
+			WPos? initialTargetPosition, Color? targetLineColor = null)
 		{
 			this.target = target;
 			aircraft = self.Trait<Aircraft>();

--- a/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
@@ -23,6 +23,9 @@ namespace OpenRA.Mods.Common.Activities
 		readonly WDist maxRange;
 		readonly Color? targetLineColor;
 		Target target;
+		Target lastVisibleTarget;
+		bool useLastVisibleTarget;
+		bool wasMovingWithinRange;
 
 		public FlyFollow(Actor self, Target target, WDist minRange, WDist maxRange,
 			WPos? initialTargetPosition, Color? targetLineColor = null)
@@ -32,27 +35,63 @@ namespace OpenRA.Mods.Common.Activities
 			this.minRange = minRange;
 			this.maxRange = maxRange;
 			this.targetLineColor = targetLineColor;
+
+			// The target may become hidden between the initial order request and the first tick (e.g. if queued)
+			// Moving to any position (even if quite stale) is still better than immediately giving up
+			if ((target.Type == TargetType.Actor && target.Actor.CanBeViewedByPlayer(self.Owner))
+			    || target.Type == TargetType.FrozenActor || target.Type == TargetType.Terrain)
+				lastVisibleTarget = Target.FromPos(target.CenterPosition);
+			else if (initialTargetPosition.HasValue)
+				lastVisibleTarget = Target.FromPos(initialTargetPosition.Value);
 		}
 
 		public override Activity Tick(Actor self)
 		{
 			// Refuse to take off if it would land immediately again.
 			if (aircraft.ForceLanding)
-			{
 				Cancel(self);
-				return NextActivity;
-			}
 
-			if (IsCanceled || !target.IsValidFor(self))
+			if (IsCanceled)
 				return NextActivity;
 
-			if (target.IsInRange(self.CenterPosition, maxRange) && !target.IsInRange(self.CenterPosition, minRange))
+			bool targetIsHiddenActor;
+			target = target.Recalculate(self.Owner, out targetIsHiddenActor);
+			if (!targetIsHiddenActor && target.Type == TargetType.Actor)
+				lastVisibleTarget = Target.FromTargetPositions(target);
+
+			var oldUseLastVisibleTarget = useLastVisibleTarget;
+			useLastVisibleTarget = targetIsHiddenActor || !target.IsValidFor(self);
+
+			// If we are ticking again after previously sequencing a MoveWithRange then that move must have completed
+			// Either we are in range and can see the target, or we've lost track of it and should give up
+			if (wasMovingWithinRange && targetIsHiddenActor)
+				return NextActivity;
+
+			wasMovingWithinRange = false;
+
+			// Update target lines if required
+			if (useLastVisibleTarget != oldUseLastVisibleTarget && targetLineColor.HasValue)
+				self.SetTargetLine(useLastVisibleTarget ? lastVisibleTarget : target, targetLineColor.Value, false);
+
+			// Target is hidden or dead, and we don't have a fallback position to move towards
+			if (useLastVisibleTarget && !lastVisibleTarget.IsValidFor(self))
+				return NextActivity;
+
+			var pos = self.CenterPosition;
+			var checkTarget = useLastVisibleTarget ? lastVisibleTarget : target;
+
+			// We've reached the required range - if the target is visible and valid then we wait
+			// otherwise if it is hidden or dead we give up
+			if (checkTarget.IsInRange(pos, maxRange) && !checkTarget.IsInRange(pos, minRange))
 			{
 				Fly.FlyToward(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);
-				return this;
+				return useLastVisibleTarget ? NextActivity : this;
 			}
 
-			return ActivityUtils.SequenceActivities(new Fly(self, target, minRange, maxRange, targetLineColor: targetLineColor), this);
+			wasMovingWithinRange = true;
+			return ActivityUtils.SequenceActivities(
+				aircraft.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, targetLineColor),
+				this);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Drawing;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
@@ -17,17 +18,19 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class FlyFollow : Activity
 	{
+		readonly Aircraft aircraft;
+		readonly WDist minRange;
+		readonly WDist maxRange;
+		readonly Color? targetLineColor;
 		Target target;
-		Aircraft aircraft;
-		WDist minRange;
-		WDist maxRange;
 
-		public FlyFollow(Actor self, Target target, WDist minRange, WDist maxRange)
+		public FlyFollow(Actor self, Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null)
 		{
 			this.target = target;
 			aircraft = self.Trait<Aircraft>();
 			this.minRange = minRange;
 			this.maxRange = maxRange;
+			this.targetLineColor = targetLineColor;
 		}
 
 		public override Activity Tick(Actor self)
@@ -48,7 +51,7 @@ namespace OpenRA.Mods.Common.Activities
 				return this;
 			}
 
-			return ActivityUtils.SequenceActivities(new Fly(self, target, minRange, maxRange), this);
+			return ActivityUtils.SequenceActivities(new Fly(self, target, minRange, maxRange, targetLineColor: targetLineColor), this);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/HeliFly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliFly.cs
@@ -25,14 +25,15 @@ namespace OpenRA.Mods.Common.Activities
 		readonly WDist minRange;
 		bool soundPlayed;
 
-		public HeliFly(Actor self, Target t, Color? targetLineColor = null)
+		public HeliFly(Actor self, Target t, WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
 			aircraft = self.Trait<Aircraft>();
 			target = t;
 		}
 
-		public HeliFly(Actor self, Target t, WDist minRange, WDist maxRange, Color? targetLineColor = null)
-			: this(self, t)
+		public HeliFly(Actor self, Target t, WDist minRange, WDist maxRange,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null)
+			: this(self, t, initialTargetPosition, targetLineColor)
 		{
 			this.maxRange = maxRange;
 			this.minRange = minRange;

--- a/OpenRA.Mods.Common/Activities/Air/HeliFly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliFly.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Drawing;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
@@ -24,13 +25,13 @@ namespace OpenRA.Mods.Common.Activities
 		readonly WDist minRange;
 		bool soundPlayed;
 
-		public HeliFly(Actor self, Target t)
+		public HeliFly(Actor self, Target t, Color? targetLineColor = null)
 		{
 			aircraft = self.Trait<Aircraft>();
 			target = t;
 		}
 
-		public HeliFly(Actor self, Target t, WDist minRange, WDist maxRange)
+		public HeliFly(Actor self, Target t, WDist minRange, WDist maxRange, Color? targetLineColor = null)
 			: this(self, t)
 		{
 			this.maxRange = maxRange;

--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
@@ -89,7 +90,9 @@ namespace OpenRA.Mods.Common.Activities
 
 						var target = Target.FromPos(nearestResupplier.CenterPosition + randomPosition);
 
-						return ActivityUtils.SequenceActivities(new HeliFly(self, target, WDist.Zero, aircraft.Info.WaitDistanceFromResupplyBase), this);
+						return ActivityUtils.SequenceActivities(
+							new HeliFly(self, target, WDist.Zero, aircraft.Info.WaitDistanceFromResupplyBase, targetLineColor: Color.Green),
+							this);
 					}
 
 					return this;

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
@@ -140,7 +141,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				if (nearestResupplier != null)
 					return ActivityUtils.SequenceActivities(
-						new Fly(self, Target.FromActor(nearestResupplier), WDist.Zero, aircraft.Info.WaitDistanceFromResupplyBase),
+						new Fly(self, Target.FromActor(nearestResupplier), WDist.Zero, aircraft.Info.WaitDistanceFromResupplyBase, targetLineColor: Color.Green),
 						new FlyCircle(self, aircraft.Info.NumberOfTicksToVerifyAvailableAirport),
 						this);
 				else

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Drawing;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
@@ -104,7 +105,7 @@ namespace OpenRA.Mods.Common.Activities
 				var sightRange = rs != null ? rs.Range : WDist.FromCells(2);
 
 				attackStatus |= AttackStatus.NeedsToMove;
-				moveActivity = ActivityUtils.SequenceActivities(move.MoveWithinRange(target, sightRange), this);
+				moveActivity = ActivityUtils.SequenceActivities(move.MoveWithinRange(target, sightRange, targetLineColor: Color.Red), this);
 				return AttackStatus.NeedsToMove;
 			}
 
@@ -128,7 +129,7 @@ namespace OpenRA.Mods.Common.Activities
 					return AttackStatus.UnableToAttack;
 
 				attackStatus |= AttackStatus.NeedsToMove;
-				moveActivity = ActivityUtils.SequenceActivities(move.MoveWithinRange(target, minRange, maxRange), this);
+				moveActivity = ActivityUtils.SequenceActivities(move.MoveWithinRange(target, minRange, maxRange, targetLineColor: Color.Red), this);
 				return AttackStatus.NeedsToMove;
 			}
 

--- a/OpenRA.Mods.Common/Activities/CaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/CaptureActor.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Drawing;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
@@ -22,7 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly CaptureManager manager;
 
 		public CaptureActor(Actor self, Actor target)
-			: base(self, target, EnterBehaviour.Exit)
+			: base(self, target, EnterBehaviour.Exit, targetLineColor: Color.Red)
 		{
 			actor = target;
 			manager = self.Trait<CaptureManager>();

--- a/OpenRA.Mods.Common/Activities/Demolish.cs
+++ b/OpenRA.Mods.Common/Activities/Demolish.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Drawing;
 using System.Linq;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits;
@@ -27,7 +28,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Demolish(Actor self, Actor target, EnterBehaviour enterBehaviour, int delay,
 			int flashes, int flashesDelay, int flashInterval)
-			: base(self, target, enterBehaviour)
+			: base(self, target, enterBehaviour, targetLineColor: Color.Red)
 		{
 			this.target = target;
 			demolishables = target.TraitsImplementing<IDemolishable>().ToArray();

--- a/OpenRA.Mods.Common/Activities/DonateCash.cs
+++ b/OpenRA.Mods.Common/Activities/DonateCash.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Drawing;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits;
 
@@ -21,7 +22,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly int experience;
 
 		public DonateCash(Actor self, Actor target, int payload, int playerExperience)
-			: base(self, target, EnterBehaviour.Dispose)
+			: base(self, target, EnterBehaviour.Dispose, targetLineColor: Color.Yellow)
 		{
 			this.target = target;
 			this.payload = payload;

--- a/OpenRA.Mods.Common/Activities/DonateExperience.cs
+++ b/OpenRA.Mods.Common/Activities/DonateExperience.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Drawing;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 
@@ -22,7 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly int playerExperience;
 
 		public DonateExperience(Actor self, Actor target, int level, int playerExperience, GainsExperience targetGainsExperience)
-			: base(self, target, EnterBehaviour.Dispose)
+			: base(self, target, EnterBehaviour.Dispose, targetLineColor: Color.Yellow)
 		{
 			this.target = target;
 			this.level = level;

--- a/OpenRA.Mods.Common/Activities/Enter.cs
+++ b/OpenRA.Mods.Common/Activities/Enter.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Drawing;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
@@ -28,6 +29,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly int maxTries = 0;
 		readonly EnterBehaviour enterBehaviour;
 		readonly bool repathWhileMoving;
+		readonly Color? targetLineColor;
 
 		public Target Target { get { return target; } }
 		Target target;
@@ -37,13 +39,15 @@ namespace OpenRA.Mods.Common.Activities
 		Activity inner;
 		bool firstApproach = true;
 
-		protected Enter(Actor self, Actor target, EnterBehaviour enterBehaviour, int maxTries = 1, bool repathWhileMoving = true)
+		protected Enter(Actor self, Actor target, EnterBehaviour enterBehaviour, int maxTries = 1,
+			bool repathWhileMoving = true, Color? targetLineColor = null)
 		{
 			move = self.Trait<IMove>();
 			this.target = Target.FromActor(target);
 			this.maxTries = maxTries;
 			this.enterBehaviour = enterBehaviour;
 			this.repathWhileMoving = repathWhileMoving;
+			this.targetLineColor = targetLineColor;
 		}
 
 		// CanEnter(target) should to be true; otherwise, Enter may abort.
@@ -183,7 +187,7 @@ namespace OpenRA.Mods.Common.Activities
 						case ReserveStatus.TooFar:
 						{
 							var moveTarget = repathWhileMoving ? target : Target.FromPos(target.Positions.PositionClosestTo(self.CenterPosition));
-							inner = move.MoveToTarget(self, moveTarget); // Approach
+							inner = move.MoveToTarget(self, moveTarget, targetLineColor: targetLineColor); // Approach
 							return EnterState.ApproachingOrEntering;
 						}
 

--- a/OpenRA.Mods.Common/Activities/EnterTransport.cs
+++ b/OpenRA.Mods.Common/Activities/EnterTransport.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Drawing;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -23,7 +24,7 @@ namespace OpenRA.Mods.Common.Activities
 		Cargo cargo;
 
 		public EnterTransport(Actor self, Actor transport, int maxTries = 0, bool repathWhileMoving = true)
-			: base(self, transport, EnterBehaviour.Exit, maxTries, repathWhileMoving)
+			: base(self, transport, EnterBehaviour.Exit, maxTries, repathWhileMoving, Color.Green)
 		{
 			this.transport = transport;
 			this.maxTries = maxTries;

--- a/OpenRA.Mods.Common/Activities/Move/Follow.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Follow.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Drawing;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
@@ -21,12 +22,14 @@ namespace OpenRA.Mods.Common.Activities
 		readonly WDist minRange;
 		readonly WDist maxRange;
 		readonly IMove move;
+		readonly Color? targetLineColor;
 
-		public Follow(Actor self, Target target, WDist minRange, WDist maxRange)
+		public Follow(Actor self, Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null)
 		{
 			this.target = target;
 			this.minRange = minRange;
 			this.maxRange = maxRange;
+			this.targetLineColor = targetLineColor;
 
 			move = self.Trait<IMove>();
 		}
@@ -37,7 +40,7 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 
 			var cachedPosition = target.CenterPosition;
-			var path = move.MoveWithinRange(target, minRange, maxRange);
+			var path = move.MoveWithinRange(target, minRange, maxRange, targetLineColor: targetLineColor);
 
 			// We are already in range, so wait until the target moves before doing anything
 			if (target.IsInRange(self.CenterPosition, maxRange) && !target.IsInRange(self.CenterPosition, minRange))

--- a/OpenRA.Mods.Common/Activities/Move/Follow.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Follow.cs
@@ -18,11 +18,14 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class Follow : Activity
 	{
-		readonly Target target;
 		readonly WDist minRange;
 		readonly WDist maxRange;
 		readonly IMove move;
 		readonly Color? targetLineColor;
+		Target target;
+		Target lastVisibleTarget;
+		bool useLastVisibleTarget;
+		bool wasMovingWithinRange;
 
 		public Follow(Actor self, Target target, WDist minRange, WDist maxRange,
 			WPos? initialTargetPosition, Color? targetLineColor = null)
@@ -31,26 +34,58 @@ namespace OpenRA.Mods.Common.Activities
 			this.minRange = minRange;
 			this.maxRange = maxRange;
 			this.targetLineColor = targetLineColor;
-
 			move = self.Trait<IMove>();
+
+			// The target may become hidden between the initial order request and the first tick (e.g. if queued)
+			// Moving to any position (even if quite stale) is still better than immediately giving up
+			if ((target.Type == TargetType.Actor && target.Actor.CanBeViewedByPlayer(self.Owner))
+			    || target.Type == TargetType.FrozenActor || target.Type == TargetType.Terrain)
+				lastVisibleTarget = Target.FromPos(target.CenterPosition);
+			else if (initialTargetPosition.HasValue)
+				lastVisibleTarget = Target.FromPos(initialTargetPosition.Value);
 		}
 
 		public override Activity Tick(Actor self)
 		{
-			if (IsCanceled || !target.IsValidFor(self))
+			if (IsCanceled)
 				return NextActivity;
 
-			var cachedPosition = target.CenterPosition;
-			var path = move.MoveWithinRange(target, minRange, maxRange, targetLineColor: targetLineColor);
+			bool targetIsHiddenActor;
+			target = target.Recalculate(self.Owner, out targetIsHiddenActor);
+			if (!targetIsHiddenActor && target.Type == TargetType.Actor)
+				lastVisibleTarget = Target.FromTargetPositions(target);
 
-			// We are already in range, so wait until the target moves before doing anything
-			if (target.IsInRange(self.CenterPosition, maxRange) && !target.IsInRange(self.CenterPosition, minRange))
-			{
-				var wait = new WaitFor(() => !target.IsValidFor(self) || target.CenterPosition != cachedPosition);
-				return ActivityUtils.SequenceActivities(wait, path, this);
-			}
+			var oldUseLastVisibleTarget = useLastVisibleTarget;
+			useLastVisibleTarget = targetIsHiddenActor || !target.IsValidFor(self);
 
-			return ActivityUtils.SequenceActivities(path, this);
+			// If we are ticking again after previously sequencing a MoveWithRange then that move must have completed
+			// Either we are in range and can see the target, or we've lost track of it and should give up
+			if (wasMovingWithinRange && targetIsHiddenActor)
+				return NextActivity;
+
+			wasMovingWithinRange = false;
+
+			// Update target lines if required
+			if (useLastVisibleTarget != oldUseLastVisibleTarget && targetLineColor.HasValue)
+				self.SetTargetLine(useLastVisibleTarget ? lastVisibleTarget : target, targetLineColor.Value, false);
+
+			// Target is hidden or dead, and we don't have a fallback position to move towards
+			if (useLastVisibleTarget && !lastVisibleTarget.IsValidFor(self))
+				return NextActivity;
+
+			var pos = self.CenterPosition;
+			var checkTarget = useLastVisibleTarget ? lastVisibleTarget : target;
+
+			// We've reached the required range - if the target is visible and valid then we wait
+			// otherwise if it is hidden or dead we give up
+			if (checkTarget.IsInRange(pos, maxRange) && !checkTarget.IsInRange(pos, minRange))
+				return useLastVisibleTarget ? NextActivity : this;
+
+			// Move into range
+			wasMovingWithinRange = true;
+			return ActivityUtils.SequenceActivities(
+				move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, targetLineColor),
+				this);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Move/Follow.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Follow.cs
@@ -24,7 +24,8 @@ namespace OpenRA.Mods.Common.Activities
 		readonly IMove move;
 		readonly Color? targetLineColor;
 
-		public Follow(Actor self, Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null)
+		public Follow(Actor self, Target target, WDist minRange, WDist maxRange,
+			WPos? initialTargetPosition, Color? targetLineColor = null)
 		{
 			this.target = target;
 			this.minRange = minRange;

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Activities
 		Activity inner;
 		bool repath;
 
-		public MoveAdjacentTo(Actor self, Target target, Color? targetLineColor = null)
+		public MoveAdjacentTo(Actor self, Target target, WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
 			Target = target;
 
@@ -56,7 +56,9 @@ namespace OpenRA.Mods.Common.Activities
 			pathFinder = self.World.WorldActor.Trait<IPathFinder>();
 			domainIndex = self.World.WorldActor.Trait<DomainIndex>();
 
-			if (target.IsValidFor(self))
+			if (initialTargetPosition.HasValue)
+				targetPosition = self.World.Map.CellContaining(initialTargetPosition.Value);
+			else if (target.IsValidFor(self) && target.Actor.CanBeViewedByPlayer(self.Owner))
 				targetPosition = self.World.Map.CellContaining(target.CenterPosition);
 
 			repath = true;

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Activities
 		Activity inner;
 		bool repath;
 
-		public MoveAdjacentTo(Actor self, Target target)
+		public MoveAdjacentTo(Actor self, Target target, Color? targetLineColor = null)
 		{
 			Target = target;
 

--- a/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using OpenRA.Traits;
 
@@ -20,8 +21,8 @@ namespace OpenRA.Mods.Common.Activities
 		readonly WDist maxRange;
 		readonly WDist minRange;
 
-		public MoveWithinRange(Actor self, Target target, WDist minRange, WDist maxRange)
-			: base(self, target)
+		public MoveWithinRange(Actor self, Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null)
+			: base(self, target, targetLineColor)
 		{
 			this.minRange = minRange;
 			this.maxRange = maxRange;

--- a/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected override bool ShouldRepath(Actor self, CPos oldTargetPosition)
 		{
-			return targetPosition != oldTargetPosition && (!AtCorrectRange(self.CenterPosition)
+			return lastVisibleTargetLocation != oldTargetPosition && (!AtCorrectRange(self.CenterPosition)
 				|| !Mobile.CanInteractWithGroundLayer(self));
 		}
 
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Activities
 			var maxCells = (maxRange.Length + 1023) / 1024;
 			var minCells = minRange.Length / 1024;
 
-			return map.FindTilesInAnnulus(targetPosition, minCells, maxCells)
+			return map.FindTilesInAnnulus(lastVisibleTargetLocation, minCells, maxCells)
 				.Where(c => AtCorrectRange(map.CenterOfSubCell(c, Mobile.FromSubCell)));
 		}
 

--- a/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs
@@ -21,8 +21,9 @@ namespace OpenRA.Mods.Common.Activities
 		readonly WDist maxRange;
 		readonly WDist minRange;
 
-		public MoveWithinRange(Actor self, Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null)
-			: base(self, target, targetLineColor)
+		public MoveWithinRange(Actor self, Target target, WDist minRange, WDist maxRange,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null)
+			: base(self, target, initialTargetPosition, targetLineColor)
 		{
 			this.minRange = minRange;
 			this.maxRange = maxRange;

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Drawing;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
@@ -72,7 +73,8 @@ namespace OpenRA.Mods.Common.Activities
 			switch (state)
 			{
 				case PickupState.Intercept:
-					innerActivity = movement.MoveWithinRange(Target.FromActor(cargo), WDist.FromCells(4));
+					innerActivity = movement.MoveWithinRange(Target.FromActor(cargo), WDist.FromCells(4),
+						targetLineColor: Color.Yellow);
 					state = PickupState.LockCarryable;
 					return this;
 

--- a/OpenRA.Mods.Common/Activities/RepairBridge.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBridge.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Drawing;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -22,7 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly string notification;
 
 		public RepairBridge(Actor self, Actor target, EnterBehaviour enterBehaviour, string notification)
-			: base(self, target, enterBehaviour)
+			: base(self, target, enterBehaviour, targetLineColor: Color.Yellow)
 		{
 			this.target = target;
 			legacyHut = target.TraitOrDefault<LegacyBridgeHut>();

--- a/OpenRA.Mods.Common/Activities/RepairBuilding.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBuilding.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Drawing;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
@@ -20,7 +21,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly Stance validStances;
 
 		public RepairBuilding(Actor self, Actor target, EnterBehaviour enterBehaviour, Stance validStances)
-			: base(self, target, enterBehaviour)
+			: base(self, target, enterBehaviour, targetLineColor: Color.Yellow)
 		{
 			this.target = target;
 			this.validStances = validStances;

--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common
 		/// <summary>
 		/// DEPRECATED: Write code that can handle FrozenActors correctly instead.
 		/// </summary>
-		public static Target ResolveFrozenActorOrder(this Actor self, Order order, Color targetLine)
+		public static Target ResolveFrozenActorOrder(this Actor self, Order order, Color targetLineColor)
 		{
 			// Not targeting a frozen actor
 			if (order.Target.Type != TargetType.FrozenActor)
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common
 
 			var frozen = order.Target.FrozenActor;
 
-			self.SetTargetLine(order.Target, targetLine, true);
+			self.SetTargetLine(order.Target, targetLineColor, true);
 
 			// Target is still alive - resolve the real order
 			if (frozen.Actor != null && frozen.Actor.IsInWorld)
@@ -89,7 +89,8 @@ namespace OpenRA.Mods.Common
 					.Append(WDist.FromCells(2))
 					.Max();
 
-				self.QueueActivity(move.MoveWithinRange(Target.FromPos(frozen.CenterPosition), range));
+				self.QueueActivity(move.MoveWithinRange(Target.FromPos(frozen.CenterPosition), range,
+					targetLineColor: targetLineColor));
 			}
 
 			return Target.Invalid;

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Activities\WaitForTransport.cs" />
     <Compile Include="ActorExts.cs" />
     <Compile Include="AIUtils.cs" />
+    <Compile Include="TargetExtensions.cs" />
     <Compile Include="Traits\BotModules\Squads\AttackOrFleeFuzzy.cs" />
     <Compile Include="Traits\BotModules\BotModuleLogic\BaseBuilderQueueManager.cs" />
     <Compile Include="Traits\Player\ModularBot.cs" />

--- a/OpenRA.Mods.Common/TargetExtensions.cs
+++ b/OpenRA.Mods.Common/TargetExtensions.cs
@@ -1,0 +1,79 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common
+{
+	public static class TargetExtensions
+	{
+		/// <summary>
+		/// Update (Frozen)Actor targets to account for visibility changes or actor replacement.
+		/// If the target actor becomes hidden without a FrozenActor, the target is invalidated.
+		/// /// </summary>
+		public static Target RecalculateInvalidatingHiddenTargets(this Target t, Player viewer)
+		{
+			bool targetIsHiddenActor;
+			var updated = t.Recalculate(viewer, out targetIsHiddenActor);
+			return targetIsHiddenActor ? Target.Invalid : updated;
+		}
+
+		/// <summary>
+		/// Update (Frozen)Actor targets to account for visibility changes or actor replacement.
+		/// If the target actor becomes hidden without a FrozenActor, the target actor is kept
+		/// and the actorHidden flag is set to true.
+		/// </summary>
+		public static Target Recalculate(this Target t, Player viewer, out bool targetIsHiddenActor)
+		{
+			targetIsHiddenActor = false;
+
+			// Check whether the target has transformed into something else
+			// HACK: This relies on knowing the internal implementation details of Target
+			if (t.Type == TargetType.Invalid && t.Actor != null && t.Actor.ReplacedByActor != null)
+				t = Target.FromActor(t.Actor.ReplacedByActor);
+
+			// Bot-controlled units aren't yet capable of understanding visibility changes
+			if (viewer.IsBot)
+				return t;
+
+			if (t.Type == TargetType.Actor)
+			{
+				// Actor has been hidden under the fog
+				if (!t.Actor.CanBeViewedByPlayer(viewer))
+				{
+					// Replace with FrozenActor if applicable, otherwise return target unmodified
+					var frozen = viewer.FrozenActorLayer.FromID(t.Actor.ActorID);
+					if (frozen != null)
+						return Target.FromFrozenActor(frozen);
+
+					targetIsHiddenActor = true;
+					return t;
+				}
+			}
+			else if (t.Type == TargetType.FrozenActor)
+			{
+				// Frozen actor has been revealed
+				if (!t.FrozenActor.Visible || !t.FrozenActor.IsValid)
+				{
+					// Original actor is still alive
+					if (t.FrozenActor.Actor != null && t.FrozenActor.Actor.CanBeViewedByPlayer(viewer))
+						return Target.FromActor(t.FrozenActor.Actor);
+
+					// Original actor was killed while hidden
+					if (t.Actor == null)
+						return Target.Invalid;
+				}
+			}
+
+			return t;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -605,28 +605,28 @@ namespace OpenRA.Mods.Common.Traits
 			return new HeliFly(self, Target.FromCell(self.World, cell));
 		}
 
-		public Activity MoveWithinRange(Target target, WDist range)
+		public Activity MoveWithinRange(Target target, WDist range, Color? targetLineColor = null)
 		{
 			if (!Info.CanHover)
-				return new Fly(self, target, WDist.Zero, range);
+				return new Fly(self, target, WDist.Zero, range, targetLineColor);
 
-			return new HeliFly(self, target, WDist.Zero, range);
+			return new HeliFly(self, target, WDist.Zero, range, targetLineColor);
 		}
 
-		public Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange)
+		public Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null)
 		{
 			if (!Info.CanHover)
-				return new Fly(self, target, minRange, maxRange);
+				return new Fly(self, target, minRange, maxRange, targetLineColor);
 
-			return new HeliFly(self, target, minRange, maxRange);
+			return new HeliFly(self, target, minRange, maxRange, targetLineColor);
 		}
 
-		public Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange)
+		public Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null)
 		{
 			if (!Info.CanHover)
-				return new FlyFollow(self, target, minRange, maxRange);
+				return new FlyFollow(self, target, minRange, maxRange, targetLineColor);
 
-			return new Follow(self, target, minRange, maxRange);
+			return new Follow(self, target, minRange, maxRange, targetLineColor);
 		}
 
 		public Activity MoveIntoWorld(Actor self, CPos cell, SubCell subCell = SubCell.Any)
@@ -637,12 +637,12 @@ namespace OpenRA.Mods.Common.Traits
 			return new HeliFly(self, Target.FromCell(self.World, cell, subCell));
 		}
 
-		public Activity MoveToTarget(Actor self, Target target)
+		public Activity MoveToTarget(Actor self, Target target, Color? targetLineColor = null)
 		{
 			if (!Info.CanHover)
-				return new Fly(self, target, WDist.FromCells(3), WDist.FromCells(5));
+				return new Fly(self, target, WDist.FromCells(3), WDist.FromCells(5), targetLineColor);
 
-			return ActivityUtils.SequenceActivities(new HeliFly(self, target), new Turn(self, Info.InitialFacing));
+			return ActivityUtils.SequenceActivities(new HeliFly(self, target, targetLineColor), new Turn(self, Info.InitialFacing));
 		}
 
 		public Activity MoveIntoTarget(Actor self, Target target)

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -605,28 +605,35 @@ namespace OpenRA.Mods.Common.Traits
 			return new HeliFly(self, Target.FromCell(self.World, cell));
 		}
 
-		public Activity MoveWithinRange(Target target, WDist range, Color? targetLineColor = null)
+		public Activity MoveWithinRange(Target target, WDist range,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
 			if (!Info.CanHover)
-				return new Fly(self, target, WDist.Zero, range, targetLineColor);
+				return new Fly(self, target, WDist.Zero, range, initialTargetPosition, targetLineColor);
 
-			return new HeliFly(self, target, WDist.Zero, range, targetLineColor);
+			return new HeliFly(self, target, WDist.Zero, range, initialTargetPosition, targetLineColor);
 		}
 
-		public Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null)
+		public Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
 			if (!Info.CanHover)
-				return new Fly(self, target, minRange, maxRange, targetLineColor);
+				return new Fly(self, target, minRange, maxRange,
+					initialTargetPosition, targetLineColor);
 
-			return new HeliFly(self, target, minRange, maxRange, targetLineColor);
+			return new HeliFly(self, target, minRange, maxRange,
+				initialTargetPosition, targetLineColor);
 		}
 
-		public Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null)
+		public Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
 			if (!Info.CanHover)
-				return new FlyFollow(self, target, minRange, maxRange, targetLineColor);
+				return new FlyFollow(self, target, minRange, maxRange,
+					initialTargetPosition, targetLineColor);
 
-			return new Follow(self, target, minRange, maxRange, targetLineColor);
+			return new Follow(self, target, minRange, maxRange,
+				initialTargetPosition, targetLineColor);
 		}
 
 		public Activity MoveIntoWorld(Actor self, CPos cell, SubCell subCell = SubCell.Any)
@@ -637,12 +644,16 @@ namespace OpenRA.Mods.Common.Traits
 			return new HeliFly(self, Target.FromCell(self.World, cell, subCell));
 		}
 
-		public Activity MoveToTarget(Actor self, Target target, Color? targetLineColor = null)
+		public Activity MoveToTarget(Actor self, Target target,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
 			if (!Info.CanHover)
-				return new Fly(self, target, WDist.FromCells(3), WDist.FromCells(5), targetLineColor);
+				return new Fly(self, target, WDist.FromCells(3), WDist.FromCells(5),
+					initialTargetPosition, targetLineColor);
 
-			return ActivityUtils.SequenceActivities(new HeliFly(self, target, targetLineColor), new Turn(self, Info.InitialFacing));
+			return ActivityUtils.SequenceActivities(
+				new HeliFly(self, target, initialTargetPosition, targetLineColor),
+				new Turn(self, Info.InitialFacing));
 		}
 
 		public Activity MoveIntoTarget(Actor self, Target target)

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Drawing;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
@@ -122,7 +123,10 @@ namespace OpenRA.Mods.Common.Traits
 					hasTicked = true;
 
 					if (move != null)
-						return ActivityUtils.SequenceActivities(move.MoveFollow(self, target, weapon.Weapon.MinRange, maxRange), this);
+						return ActivityUtils.SequenceActivities(
+							move.MoveFollow(self, target, weapon.Weapon.MinRange, maxRange, targetLineColor: Color.Red),
+							this);
+
 					if (target.IsInRange(self.CenterPosition, weapon.MaxRange()) &&
 						!target.IsInRange(self.CenterPosition, weapon.Weapon.MinRange))
 						return this;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
@@ -46,7 +46,9 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override Activity Tick(Actor self)
 			{
-				target = target.Recalculate(self.Owner);
+				// This activity can't move to reacquire hidden targets, so use the
+				// Recalculate overload that invalidates hidden targets.
+				target = target.RecalculateInvalidatingHiddenTargets(self.Owner);
 				if (IsCanceled || !target.IsValidFor(self) || !attack.IsReachableTarget(target, allowMove))
 					return NextActivity;
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackSuicides.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackSuicides.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				self.SetTargetLine(target, Color.Red);
 
-				self.QueueActivity(move.MoveToTarget(self, target));
+				self.QueueActivity(move.MoveToTarget(self, target, targetLineColor: Color.Red));
 
 				self.QueueActivity(new CallFunc(() => self.Kill(self, Info.DamageTypes)));
 			}

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -236,7 +236,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			// PERF: Avoid LINQ.
 			foreach (var attackFollow in attackFollows)
-				if (!attackFollow.IsTraitDisabled && attackFollow.IsReachableTarget(attackFollow.Target, allowMove))
+				if (!attackFollow.IsTraitDisabled && attackFollow.HasReachableTarget(allowMove))
 					return false;
 
 			return true;

--- a/OpenRA.Mods.Common/Traits/Guard.cs
+++ b/OpenRA.Mods.Common/Traits/Guard.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 			self.SetTargetLine(target, Color.Yellow);
 
 			var range = target.Actor.Info.TraitInfo<GuardableInfo>().Range;
-			self.QueueActivity(new AttackMoveActivity(self, move.MoveFollow(self, target, WDist.Zero, range)));
+			self.QueueActivity(new AttackMoveActivity(self, move.MoveFollow(self, target, WDist.Zero, range, targetLineColor: Color.Yellow)));
 		}
 
 		public string VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -467,19 +467,22 @@ namespace OpenRA.Mods.Common.Traits
 			return new Move(self, cell, WDist.Zero, ignoreActor);
 		}
 
-		public Activity MoveWithinRange(Target target, WDist range, Color? targetLineColor = null)
+		public Activity MoveWithinRange(Target target, WDist range,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
-			return new MoveWithinRange(self, target, WDist.Zero, range, targetLineColor);
+			return new MoveWithinRange(self, target, WDist.Zero, range, initialTargetPosition, targetLineColor);
 		}
 
-		public Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null)
+		public Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
-			return new MoveWithinRange(self, target, minRange, maxRange, targetLineColor);
+			return new MoveWithinRange(self, target, minRange, maxRange, initialTargetPosition, targetLineColor);
 		}
 
-		public Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null)
+		public Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
-			return new Follow(self, target, minRange, maxRange, targetLineColor);
+			return new Follow(self, target, minRange, maxRange, initialTargetPosition, targetLineColor);
 		}
 
 		public Activity MoveIntoWorld(Actor self, CPos cell, SubCell subCell = SubCell.Any)
@@ -500,12 +503,13 @@ namespace OpenRA.Mods.Common.Traits
 			return VisualMove(self, pos, self.World.Map.CenterOfSubCell(cell, subCell), cell);
 		}
 
-		public Activity MoveToTarget(Actor self, Target target, Color? targetLineColor = null)
+		public Activity MoveToTarget(Actor self, Target target,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
 			if (target.Type == TargetType.Invalid)
 				return null;
 
-			return new MoveAdjacentTo(self, target, targetLineColor);
+			return new MoveAdjacentTo(self, target, initialTargetPosition, targetLineColor);
 		}
 
 		public Activity MoveIntoTarget(Actor self, Target target)

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -457,11 +457,30 @@ namespace OpenRA.Mods.Common.Traits
 
 		#region IMove
 
-		public Activity MoveTo(CPos cell, int nearEnough) { return new Move(self, cell, WDist.FromCells(nearEnough)); }
-		public Activity MoveTo(CPos cell, Actor ignoreActor) { return new Move(self, cell, WDist.Zero, ignoreActor); }
-		public Activity MoveWithinRange(Target target, WDist range) { return new MoveWithinRange(self, target, WDist.Zero, range); }
-		public Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange) { return new MoveWithinRange(self, target, minRange, maxRange); }
-		public Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange) { return new Follow(self, target, minRange, maxRange); }
+		public Activity MoveTo(CPos cell, int nearEnough)
+		{
+			return new Move(self, cell, WDist.FromCells(nearEnough));
+		}
+
+		public Activity MoveTo(CPos cell, Actor ignoreActor)
+		{
+			return new Move(self, cell, WDist.Zero, ignoreActor);
+		}
+
+		public Activity MoveWithinRange(Target target, WDist range, Color? targetLineColor = null)
+		{
+			return new MoveWithinRange(self, target, WDist.Zero, range, targetLineColor);
+		}
+
+		public Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null)
+		{
+			return new MoveWithinRange(self, target, minRange, maxRange, targetLineColor);
+		}
+
+		public Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null)
+		{
+			return new Follow(self, target, minRange, maxRange, targetLineColor);
+		}
 
 		public Activity MoveIntoWorld(Actor self, CPos cell, SubCell subCell = SubCell.Any)
 		{
@@ -481,12 +500,12 @@ namespace OpenRA.Mods.Common.Traits
 			return VisualMove(self, pos, self.World.Map.CenterOfSubCell(cell, subCell), cell);
 		}
 
-		public Activity MoveToTarget(Actor self, Target target)
+		public Activity MoveToTarget(Actor self, Target target, Color? targetLineColor = null)
 		{
 			if (target.Type == TargetType.Invalid)
 				return null;
 
-			return new MoveAdjacentTo(self, target);
+			return new MoveAdjacentTo(self, target, targetLineColor);
 		}
 
 		public Activity MoveIntoTarget(Actor self, Target target)

--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -115,15 +115,12 @@ namespace OpenRA.Mods.Common.Traits
 			if (!self.Owner.IsAlliedWith(self.World.LocalPlayer))
 				return;
 
-			self.World.AddFrameEndTask(w =>
-			{
-				if (self.Disposed)
-					return;
+			if (self.Disposed)
+				return;
 
-				var line = self.TraitOrDefault<DrawLineToTarget>();
-				if (line != null)
-					line.SetTarget(self, target, color, display);
-			});
+			var line = self.TraitOrDefault<DrawLineToTarget>();
+			if (line != null)
+				line.SetTarget(self, target, color, display);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return false; } }
 
-		void INotifyBecomingIdle.OnBecomingIdle(Actor a)
+		void INotifyBecomingIdle.OnBecomingIdle(Actor self)
 		{
 			targets = null;
 		}

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -112,8 +112,12 @@ namespace OpenRA.Mods.Common.Traits
 					self.CancelActivity();
 
 				self.SetTargetLine(order.Target, Color.Green);
-				self.QueueActivity(new WaitForTransport(self, ActivityUtils.SequenceActivities(movement.MoveToTarget(self, order.Target),
-					new CallFunc(() => AfterReachActivities(self, order, movement)))));
+
+				var activities = ActivityUtils.SequenceActivities(
+					movement.MoveToTarget(self, order.Target, targetLineColor: Color.Green),
+					new CallFunc(() => AfterReachActivities(self, order, movement)));
+
+				self.QueueActivity(new WaitForTransport(self, activities));
 
 				TryCallTransport(self, order.Target, new CallFunc(() => AfterReachActivities(self, order, movement)));
 			}

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!order.Queued)
 				self.CancelActivity();
 
-			self.QueueActivity(movement.MoveWithinRange(order.Target, info.CloseEnough));
+			self.QueueActivity(movement.MoveWithinRange(order.Target, info.CloseEnough, targetLineColor: Color.Green));
 			self.QueueActivity(new Repair(self, order.Target.Actor, info.CloseEnough));
 
 			self.SetTargetLine(order.Target, Color.Green, false);

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -255,12 +255,6 @@ namespace OpenRA.Mods.Common.Traits
 			if (attack != null && attack.IsAiming)
 				attack.OnStopOrder(self);
 		}
-
-		protected override void TraitResumed(Actor self)
-		{
-			if (attack != null)
-				FaceTarget(self, attack.Target);
-		}
 	}
 
 	public class TurretFacingInit : IActorInit<int>

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -397,11 +397,15 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		Activity MoveTo(CPos cell, int nearEnough);
 		Activity MoveTo(CPos cell, Actor ignoreActor);
-		Activity MoveWithinRange(Target target, WDist range, Color? targetLineColor = null);
-		Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null);
-		Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null);
+		Activity MoveWithinRange(Target target, WDist range,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null);
+		Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null);
+		Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null);
+		Activity MoveToTarget(Actor self, Target target,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null);
 		Activity MoveIntoWorld(Actor self, CPos cell, SubCell subCell = SubCell.Any);
-		Activity MoveToTarget(Actor self, Target target, Color? targetLineColor = null);
 		Activity MoveIntoTarget(Actor self, Target target);
 		Activity VisualMove(Actor self, WPos fromPos, WPos toPos);
 		int EstimatedMoveDuration(Actor self, WPos fromPos, WPos toPos);

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -397,11 +397,11 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		Activity MoveTo(CPos cell, int nearEnough);
 		Activity MoveTo(CPos cell, Actor ignoreActor);
-		Activity MoveWithinRange(Target target, WDist range);
-		Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange);
-		Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange);
+		Activity MoveWithinRange(Target target, WDist range, Color? targetLineColor = null);
+		Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null);
+		Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange, Color? targetLineColor = null);
 		Activity MoveIntoWorld(Actor self, CPos cell, SubCell subCell = SubCell.Any);
-		Activity MoveToTarget(Actor self, Target target);
+		Activity MoveToTarget(Actor self, Target target, Color? targetLineColor = null);
 		Activity MoveIntoTarget(Actor self, Target target);
 		Activity VisualMove(Actor self, WPos fromPos, WPos toPos);
 		int EstimatedMoveDuration(Actor self, WPos fromPos, WPos toPos);

--- a/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
+++ b/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
@@ -80,9 +80,10 @@ namespace OpenRA.Mods.D2k.Traits
 			public SwallowTarget(Actor self, Target target, bool allowMovement, bool forceAttack)
 				: base(self, target, allowMovement, forceAttack) { }
 
-			protected override Target RecalculateTarget(Actor self)
+			protected override Target RecalculateTarget(Actor self, out bool targetIsHiddenActor)
 			{
 				// Worms ignore visibility, so don't need to recalculate targets
+				targetIsHiddenActor = false;
 				return target;
 			}
 		}

--- a/OpenRA.Mods.D2k/Traits/Sandworm.cs
+++ b/OpenRA.Mods.D2k/Traits/Sandworm.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Drawing;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
@@ -66,7 +67,7 @@ namespace OpenRA.Mods.D2k.Traits
 			if (IsMovingTowardTarget)
 				return;
 
-			self.QueueActivity(mobile.MoveWithinRange(Target.FromCell(self.World, targetCell, SubCell.Any), WDist.FromCells(1)));
+			self.QueueActivity(mobile.MoveWithinRange(Target.FromCell(self.World, targetCell, SubCell.Any), WDist.FromCells(1), targetLineColor: Color.Red));
 		}
 
 		void ITick.Tick(Actor self)


### PR DESCRIPTION
Part two of #15866, addressing a major oversight that nobody realized before the first playtest.

This PR overhauls the activities used by the attack logic to bring a unit into firing range of a target.
The old behaviour that (rather inconsistently) either cancelled the activity or returned a move order when the target becomes hidden under the fog or is killed has been replaced with:
* Unit continues moving towards the last known location of the target
* Unit will reacquire the original target if it is revealed before it reaches the last known location
* Unit drops the target only once it reaches the last known location and the target remains hidden

Fixes #16010.
Fixes #10224.
Closes #10223.

Note that this does not change units dropping targets that become hidden while inside firing range -- this isn't a bug (see my final comment in #10223), and will instead be addressed by #11663.

I strongly suggest reviewing individual commits in order, which by themselves should be straightforward enough.
* The first four commits address limitations in `Target` and `DrawLineToTarget` needed by the later commits, and fix some code style issues while i'm there.
* The "Pass target line color to inner move activities." commit introduces the plumbing needed to be able to swap back and forward between the original target and the static "last seen" position.  This also fixes the major blocker that kept sinking the various attempts at #12019, so I expect that we will be able to resurrect #14384 for Next + 1. We will be able to remove all of the `SetTargetLine(..., false)` calls introduced in the later commits once this happens.
* The "Define plumbing to pass initial target positions..." commit adds a parameter to the move interface and activities that lets outer activities pass a fallback position to inner activities.  This allows us to propagate the last known position to child activities to preserve the behaviour explained above. Doing the plumbing change in its own commit allows us to split the implementation across multiple commits without breaking the build.
* The remaining commits implement the behaviour described above in all of the attack-related activities (non-attack targeting activities fall under #16048).  The same code pattern is used in all of them, so once you understand (and agree with) the basic logic, reviewing is just a case of making sure I have used `checkTarget` etc in the right places.

When testing, I expect that regressions will either take the form of "Attempting to query the position of an invalid Target" crashes, target line weirdness, or actors abandoning (or not) targets too early (or never). I have tried to test all of the specific behaviour cases, but have not had time to play general games to look for unexpected regressions.