### PR TITLE
Propagate cancellation of activities through queue

### DIFF
--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Activities
 	*/
 	public abstract class Activity
 	{
-		public ActivityState State { get; private set; }
+		public ActivityState State { get; protected set; }
 
 		/// <summary>
 		/// Returns the top-most activity *from the point of view of the calling activity*. Note that the root activity
@@ -226,12 +226,10 @@ namespace OpenRA.Activities
 			if (ChildActivity != null && !ChildActivity.Cancel(self))
 				return false;
 
-			if (!keepQueue)
-				NextActivity = null;
+			if (!keepQueue && NextInQueue != null)
+				NextInQueue.Cancel(self);
 
-			ChildActivity = null;
 			State = ActivityState.Canceled;
-
 			return true;
 		}
 

--- a/OpenRA.Mods.Common/Activities/DeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverResources.cs
@@ -30,11 +30,14 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			movement = self.Trait<IMove>();
 			harv = self.Trait<Harvester>();
-			IsInterruptible = false;
+			IsInterruptible = true;
 		}
 
 		public override Activity Tick(Actor self)
 		{
+			if (IsCanceled)
+				return NextActivity;
+
 			if (NextInQueue != null)
 				return NextInQueue;
 

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -156,7 +156,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Remove queued activities
 			if (!keepQueue && NextInQueue != null)
-				NextInQueue = null;
+				NextInQueue.Cancel(self);
 
 			// In current implementation, ChildActivity can be Turn, MoveFirstHalf and MoveSecondHalf.
 			// Turn may be interrupted freely while they are turning.
@@ -166,7 +166,7 @@ namespace OpenRA.Mods.Common.Activities
 			// This means that it is safe to unconditionally return true, which avoids breaking parent
 			// activities that rely on cancellation succeeding (but not necessarily immediately
 			ChildActivity.Cancel(self, false);
-
+			State = ActivityState.Canceled;
 			return true;
 		}
 


### PR DESCRIPTION
I think this fixes issue #15632.

The Activity code now propagates Cancellation through all NextInQueue and ChildActivities. I've checked for any regressions this might cause and found only two, which I've adressed:

- Harvesters could not be ordered to stop when en-route to the refinery, because the DeliverResources activity was uninterruptible. I've changed it to be interruptible. I don't really know why it was uninterruptible in the first place?

- ~~The demo-truck would blow up on the spot the moment it's attack was cancelled. This is because it did not use a proper Activity, so there was nothing to cancel.  I've added a new activity KillSelf to adress this.~~

Other activities all seem to work fine already, though I might have missed something.