### PR TITLE
Fix crash by chat commands in replay

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -85,8 +85,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					else if (chatTraits != null)
 					{
 						var text = chatText.Text.Trim();
+						var from = world.IsReplay ? null : orderManager.LocalClient.Name;
 						foreach (var trait in chatTraits)
-							trait.OnChat(orderManager.LocalClient.Name, text);
+							trait.OnChat(from, text);
 					}
 				}
 


### PR DESCRIPTION
In replay LocalClient can be null or different player than player viewing replay and using chat command.
For replay use null as player name for chat commands, it isn't used so far anyway.

Fixes #16046