### PR TITLE
Add AttackMove workaround for Aircraft.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -174,6 +174,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		RepairableInfo repairableInfo;
 		RearmableInfo rearmableInfo;
+		AttackMove attackMove;
 		ConditionManager conditionManager;
 		IDisposable reservation;
 		IEnumerable<int> speedModifiers;
@@ -231,6 +232,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			repairableInfo = self.Info.TraitInfoOrDefault<RepairableInfo>();
 			rearmableInfo = self.Info.TraitInfoOrDefault<RearmableInfo>();
+			attackMove = self.TraitOrDefault<AttackMove>();
 			conditionManager = self.TraitOrDefault<ConditionManager>();
 			speedModifiers = self.TraitsImplementing<ISpeedModifier>().ToArray().Select(sm => sm.GetSpeedModifier());
 			cachedPosition = self.CenterPosition;
@@ -522,7 +524,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyBecomingIdle.OnBecomingIdle(Actor self)
 		{
-			OnBecomingIdle(self);
+			// HACK: Work around AttackMove relying on INotifyIdle.TickIdle to continue its path
+			// AttackMoveActivity needs to be rewritten to use child activities instead!
+			if (attackMove != null && attackMove.TargetLocation.HasValue)
+				((INotifyIdle)attackMove).TickIdle(self);
+			else
+				OnBecomingIdle(self);
 		}
 
 		protected virtual void OnBecomingIdle(Actor self)


### PR DESCRIPTION
Closes #16092.

This is awful, but better than the alternative of reverting #15848 and stalling the improvements that depend on it.