### PR TITLE
Revise AttackMoveActivity

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/ResupplyAircraft.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ResupplyAircraft.cs
@@ -50,10 +50,6 @@ namespace OpenRA.Mods.Common.Activities
 				return this;
 			}
 
-			// Conditional fixes being able to stop aircraft from resupplying.
-			if (IsCanceling && NextInQueue == null)
-				return new ResupplyAircraft(self);
-
 			return NextActivity;
 		}
 	}

--- a/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
+++ b/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
@@ -53,9 +53,9 @@ namespace OpenRA.Mods.Common.Activities
 				(hasHost ? self.World.Map.CellContaining(host.CenterPosition) : self.Location);
 
 			if (moveToRallyPoint(self, this, destination))
-				return new AttackMoveActivity(self, move.MoveTo(destination, 1));
-			else
-				return NextActivity;
+				return new AttackMoveActivity(self, () => move.MoveTo(destination, 1));
+
+			return NextActivity;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Hunt.cs
+++ b/OpenRA.Mods.Common/Activities/Hunt.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Activities
 				return this;
 
 			return ActivityUtils.SequenceActivities(self,
-				new AttackMoveActivity(self, move.MoveTo(target.Location, 2)),
+				new AttackMoveActivity(self, () => move.MoveTo(target.Location, 2)),
 				new Wait(25),
 				this);
 		}

--- a/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
+++ b/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
@@ -18,31 +19,75 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class AttackMoveActivity : Activity
 	{
-		const int ScanInterval = 7;
-
+		readonly Func<Activity> getInner;
+		public readonly bool IsAssaultMove;
 		Activity inner;
-		int scanTicks;
+		Activity attack;
 		AutoTarget autoTarget;
+		bool moving;
 
-		public AttackMoveActivity(Actor self, Activity inner)
+		public AttackMoveActivity(Actor self, Func<Activity> getInner, bool assaultMoving = false)
 		{
-			this.inner = inner;
+			this.getInner = getInner;
 			autoTarget = self.TraitOrDefault<AutoTarget>();
+			moving = false;
+			IsAssaultMove = assaultMoving;
 		}
 
 		public override Activity Tick(Actor self)
 		{
-			if (autoTarget != null && --scanTicks <= 0)
+			if (IsCanceling)
 			{
-				autoTarget.ScanAndAttack(self, true);
-				scanTicks = ScanInterval;
+				if (attack != null)
+				{
+					attack = ActivityUtils.RunActivity(self, attack);
+					return this;
+				}
+
+				if (inner != null)
+				{
+					inner = ActivityUtils.RunActivity(self, inner);
+					return this;
+				}
+
+				return NextActivity;
+			}
+
+			if (attack == null && autoTarget != null)
+			{
+				var target = autoTarget.ScanForTarget(self, true);
+				if (target.Type != TargetType.Invalid)
+				{
+					if (inner != null)
+						inner.Cancel(self);
+
+					var attackBases = autoTarget.ActiveAttackBases;
+					foreach (var ab in attackBases)
+					{
+						if (attack == null)
+							attack = ab.GetAttackActivity(self, target, true, false);
+						else
+							attack = ActivityUtils.SequenceActivities(self, attack, ab.GetAttackActivity(self, target, true, false));
+						ab.OnQueueAttackActivity(self, target, false, true, false);
+					}
+
+					moving = false;
+				}
+			}
+
+			if (attack == null && inner == null)
+			{
+				if (moving)
+					return NextActivity;
+
+				inner = getInner();
+				moving = true;
 			}
 
 			if (inner == null)
-				return NextActivity;
+				attack = ActivityUtils.RunActivity(self, attack);
 
 			inner = ActivityUtils.RunActivity(self, inner);
-
 			return this;
 		}
 
@@ -50,6 +95,9 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			if (!IsCanceling && inner != null)
 				inner.Cancel(self);
+
+			if (!IsCanceling && attack != null)
+				attack.Cancel(self);
 
 			base.Cancel(self, keepQueue);
 		}

--- a/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Linq;
 using Eluant;
 using OpenRA.Activities;
@@ -43,7 +44,7 @@ namespace OpenRA.Mods.Common.Scripting
 			"close enough to complete the activity.")]
 		public void AttackMove(CPos cell, int closeEnough = 0)
 		{
-			Self.QueueActivity(new AttackMoveActivity(Self, move.MoveTo(cell, closeEnough)));
+			Self.QueueActivity(new AttackMoveActivity(Self, () => move.MoveTo(cell, closeEnough)));
 		}
 
 		[ScriptActorPropertyActivity]
@@ -53,7 +54,7 @@ namespace OpenRA.Mods.Common.Scripting
 		{
 			foreach (var wpt in waypoints)
 			{
-				Self.QueueActivity(new AttackMoveActivity(Self, move.MoveTo(wpt, 2)));
+				Self.QueueActivity(new AttackMoveActivity(Self, () => move.MoveTo(wpt, 2)));
 				Self.QueueActivity(new Wait(wait));
 			}
 

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -163,7 +163,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public class Aircraft : ITick, ISync, IFacing, IPositionable, IMove, IIssueOrder, IResolveOrder, IOrderVoice, IDeathActorInitModifier,
-		INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyActorDisposing,
+		INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyActorDisposing, INotifyBecomingIdle,
 		IActorPreviewInitModifier, IIssueDeployOrder, IObservesVariables
 	{
 		static readonly Pair<CPos, SubCell>[] NoCells = { };
@@ -519,7 +519,7 @@ namespace OpenRA.Mods.Common.Traits
 			init.Add(new FacingInit(Facing));
 		}
 
-		protected virtual void OnBecomingIdle(Actor self)
+		void INotifyBecomingIdle.OnBecomingIdle(Actor self)
 		{
 			if (Info.VTOL && Info.LandWhenIdle)
 			{

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -163,7 +163,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public class Aircraft : ITick, ISync, IFacing, IPositionable, IMove, IIssueOrder, IResolveOrder, IOrderVoice, IDeathActorInitModifier,
-		INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyActorDisposing, INotifyBecomingIdle,
+		INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyActorDisposing,
 		IActorPreviewInitModifier, IIssueDeployOrder, IObservesVariables
 	{
 		static readonly Pair<CPos, SubCell>[] NoCells = { };
@@ -173,7 +173,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		RepairableInfo repairableInfo;
 		RearmableInfo rearmableInfo;
-		AttackMove attackMove;
 		ConditionManager conditionManager;
 		IDisposable reservation;
 		IEnumerable<int> speedModifiers;
@@ -231,7 +230,6 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			repairableInfo = self.Info.TraitInfoOrDefault<RepairableInfo>();
 			rearmableInfo = self.Info.TraitInfoOrDefault<RearmableInfo>();
-			attackMove = self.TraitOrDefault<AttackMove>();
 			conditionManager = self.TraitOrDefault<ConditionManager>();
 			speedModifiers = self.TraitsImplementing<ISpeedModifier>().ToArray().Select(sm => sm.GetSpeedModifier());
 			cachedPosition = self.CenterPosition;
@@ -519,16 +517,6 @@ namespace OpenRA.Mods.Common.Traits
 		public void ModifyDeathActorInit(Actor self, TypeDictionary init)
 		{
 			init.Add(new FacingInit(Facing));
-		}
-
-		void INotifyBecomingIdle.OnBecomingIdle(Actor self)
-		{
-			// HACK: Work around AttackMove relying on INotifyIdle.TickIdle to continue its path
-			// AttackMoveActivity needs to be rewritten to use child activities instead!
-			if (attackMove != null && attackMove.TargetLocation.HasValue)
-				((INotifyIdle)attackMove).TickIdle(self);
-			else
-				OnBecomingIdle(self);
 		}
 
 		protected virtual void OnBecomingIdle(Actor self)

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -110,7 +110,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class AutoTarget : ConditionalTrait<AutoTargetInfo>, INotifyIdle, INotifyDamage, ITick, IResolveOrder, ISync, INotifyCreated, INotifyOwnerChanged
 	{
-		readonly IEnumerable<AttackBase> activeAttackBases;
+		public readonly IEnumerable<AttackBase> ActiveAttackBases;
 		[Sync] int nextScanTime = 0;
 
 		public UnitStance Stance { get { return stance; } }
@@ -151,7 +151,7 @@ namespace OpenRA.Mods.Common.Traits
 			: base(info)
 		{
 			var self = init.Self;
-			activeAttackBases = self.TraitsImplementing<AttackBase>().ToArray().Where(Exts.IsTraitEnabled);
+			ActiveAttackBases = self.TraitsImplementing<AttackBase>().ToArray().Where(Exts.IsTraitEnabled);
 
 			if (init.Contains<StanceInit>())
 				stance = init.Get<StanceInit, UnitStance>();
@@ -209,7 +209,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Not a lot we can do about things we can't hurt... although maybe we should automatically run away?
 			var attackerAsTarget = Target.FromActor(attacker);
-			if (!activeAttackBases.Any(a => a.HasAnyValidWeapons(attackerAsTarget)))
+			if (!ActiveAttackBases.Any(a => a.HasAnyValidWeapons(attackerAsTarget)))
 				return;
 
 			// Don't retaliate against own units force-firing on us. It's usually not what the player wanted.
@@ -242,11 +242,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Target ScanForTarget(Actor self, bool allowMove)
 		{
-			if (nextScanTime <= 0 && activeAttackBases.Any())
+			if (nextScanTime <= 0 && ActiveAttackBases.Any())
 			{
 				nextScanTime = self.World.SharedRandom.Next(Info.MinimumScanTimeInterval, Info.MaximumScanTimeInterval);
 
-				foreach (var ab in activeAttackBases)
+				foreach (var ab in ActiveAttackBases)
 				{
 					// If we can't attack right now, there's no need to try and find a target.
 					var attackStances = ab.UnforcedAttackTargetStances();
@@ -272,7 +272,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			self.SetTargetLine(target, Color.Red, false);
 
-			foreach (var ab in activeAttackBases)
+			foreach (var ab in ActiveAttackBases)
 				ab.AttackTarget(target, false, allowMove);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Guard.cs
+++ b/OpenRA.Mods.Common/Traits/Guard.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 			self.SetTargetLine(target, Color.Yellow);
 
 			var range = target.Actor.Info.TraitInfo<GuardableInfo>().Range;
-			self.QueueActivity(new AttackMoveActivity(self, move.MoveFollow(self, target, WDist.Zero, range, targetLineColor: Color.Yellow)));
+			self.QueueActivity(new AttackMoveActivity(self, () => move.MoveFollow(self, target, WDist.Zero, range, targetLineColor: Color.Yellow)));
 		}
 
 		public string VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -90,8 +90,7 @@ namespace OpenRA.Mods.Common.Traits
 							newUnit.QueueActivity(new Wait(exitinfo.ExitDelay, false));
 
 						newUnit.QueueActivity(move.MoveIntoWorld(newUnit, exit));
-						newUnit.QueueActivity(new AttackMoveActivity(
-							newUnit, move.MoveTo(exitLocation, 1)));
+						newUnit.QueueActivity(new AttackMoveActivity(newUnit, () => move.MoveTo(exitLocation, 1)));
 					}
 				}
 

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -144,7 +144,7 @@ namespace OpenRA.Mods.Common.Traits
 							newUnit.QueueActivity(new Wait(exitinfo.ExitDelay, false));
 
 						newUnit.QueueActivity(move.MoveIntoWorld(newUnit, exit));
-						newUnit.QueueActivity(new AttackMoveActivity(newUnit, move.MoveTo(exitLocation, 1)));
+						newUnit.QueueActivity(new AttackMoveActivity(newUnit, () => move.MoveTo(exitLocation, 1)));
 					}
 				}
 


### PR DESCRIPTION
Since this seems to be the underlying cause of many glitches, I decided to tackle this issue.

Improvements:
- The AttackMove behavior is now completely contained inside AttackMoveActivity. 
- Reliance on INotifyIdle.IsIdle is eliminated, thus avoiding a major source of glitchiness.
- AttackMove now also respects any orders queued after it.

Fixes #16092 
Fixes #14822
Fixes #11439
Fixes #9908
Fixes #7454
Fixes #15854 
Fixes #13136
Fixes #16100

~~The only sacrifice that has to be made is that the inner activity can now no longer be an arbitrary activity. The reason is that the inner activity has to be freshly initialized inside AttackMoveActivity. You cannot restart an activity that is already cancelled, which is what the old implementation tried to do. Therefore, the caller to MoveTo is now hardcoded inside AttackMoveActivity. I am not very experienced with C# so perhaps there is a way to achieve this anyway that I do not now of.~~

~~Regardless, there is only one reference to AttackMoveActivity that needs anything other than MoveTo to initialize the inner activity. Therefore, I made a separate activity for Guard, which needs MoveFollow to initialize it's inner activity.~~
 