### PR TITLE
Allow attack orders to preempt move completion for turreted units.

### DIFF
--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -18,6 +18,11 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Traits
 {
+	public interface ICreatesFrozenActors
+	{
+		void OnVisibilityChanged(FrozenActor frozen);
+	}
+
 	[Desc("Required for FrozenUnderFog to work. Attach this to the player actor.")]
 	public class FrozenActorLayerInfo : Requires<ShroudInfo>, ITraitInfo
 	{
@@ -32,6 +37,7 @@ namespace OpenRA.Traits
 		public readonly PPos[] Footprint;
 		public readonly WPos CenterPosition;
 		readonly Actor actor;
+		readonly ICreatesFrozenActors frozenTrait;
 		readonly Player viewer;
 		readonly Shroud shroud;
 
@@ -70,9 +76,10 @@ namespace OpenRA.Traits
 
 		int flashTicks;
 
-		public FrozenActor(Actor actor, PPos[] footprint, Player viewer, bool startsRevealed)
+		public FrozenActor(Actor actor, ICreatesFrozenActors frozenTrait, PPos[] footprint, Player viewer, bool startsRevealed)
 		{
 			this.actor = actor;
+			this.frozenTrait = frozenTrait;
 			this.viewer = viewer;
 			shroud = viewer.Shroud;
 			NeedRenderables = startsRevealed;
@@ -152,6 +159,11 @@ namespace OpenRA.Traits
 				if (Shrouded && shroud.IsExplored(puv))
 					Shrouded = false;
 			}
+
+			// Force the backing trait to update so other actors can't
+			// query inconsistent state (both hidden or both visible)
+			if (Visible != wasVisible)
+				frozenTrait.OnVisibilityChanged(this);
 
 			NeedRenderables |= Visible && !wasVisible;
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -358,7 +358,10 @@ namespace OpenRA.Mods.Common.Traits
 				self.CancelActivity();
 
 			self.QueueActivity(GetAttackActivity(self, target, allowMove, forceAttack));
+			OnQueueAttackActivity(self, target, queued, allowMove, forceAttack);
 		}
+
+		public virtual void OnQueueAttackActivity(Actor self, Target target, bool queued, bool allowMove, bool forceAttack) { }
 
 		public bool IsReachableTarget(Target target, bool allowMove)
 		{


### PR DESCRIPTION
Fixes #14824.

This PR ~~(the last commit, after the changes from #16067)~~ adds an `OnQueueAttackActivity` notification that is called when an attack order is added to the activity queue.

`AttackFollow` uses this notification to set the target if the order is not queued.  This allows turrets to start tracking immediately, instead of waiting for an existing move order to complete and the attack order to tick for the first time.

This sits in the middle of the other targeting changes, so makes sense to include in the playtest. The improvement in perceived responsiveness should help soften the blow from turrets no longer tracking targets that are outside of range.