### PR TITLE
Allow turreted units to acquire targets of opportunity while moving

### DIFF
--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -112,7 +112,6 @@ namespace OpenRA.Mods.Common.Traits
 	public class AutoTarget : ConditionalTrait<AutoTargetInfo>, INotifyIdle, INotifyDamage, ITick, IResolveOrder, ISync, INotifyCreated
 	{
 		readonly IEnumerable<AttackBase> activeAttackBases;
-		readonly AttackFollow[] attackFollows;
 		[Sync] int nextScanTime = 0;
 
 		public UnitStance Stance { get { return stance; } }
@@ -161,7 +160,6 @@ namespace OpenRA.Mods.Common.Traits
 				stance = self.Owner.IsBot || !self.Owner.Playable ? info.InitialStanceAI : info.InitialStance;
 
 			PredictedStance = stance;
-			attackFollows = self.TraitsImplementing<AttackFollow>().ToArray();
 		}
 
 		void INotifyCreated.Created(Actor self)
@@ -215,9 +213,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			Aggressor = attacker;
 
-			bool allowMove;
-			if (ShouldAttack(out allowMove))
-				Attack(self, Target.FromActor(Aggressor), allowMove);
+			var allowMove = Info.AllowMovement && Stance > UnitStance.Defend;
+			Attack(self, Target.FromActor(Aggressor), allowMove);
 		}
 
 		void INotifyIdle.TickIdle(Actor self)
@@ -225,21 +222,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (IsTraitDisabled || Stance < UnitStance.Defend)
 				return;
 
-			bool allowMove;
-			if (ShouldAttack(out allowMove))
-				ScanAndAttack(self, allowMove);
-		}
-
-		bool ShouldAttack(out bool allowMove)
-		{
-			allowMove = Info.AllowMovement && Stance > UnitStance.Defend;
-
-			// PERF: Avoid LINQ.
-			foreach (var attackFollow in attackFollows)
-				if (!attackFollow.IsTraitDisabled && attackFollow.HasReachableTarget(allowMove))
-					return false;
-
-			return true;
+			var allowMove = Info.AllowMovement && Stance > UnitStance.Defend;
+			ScanAndAttack(self, allowMove);
 		}
 
 		void ITick.Tick(Actor self)

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -288,6 +288,7 @@ SONIC:
 	AttackTurreted:
 		Voice: Attack
 		PauseOnCondition: empdisable
+		OpportunityFire: False
 	Turreted:
 		TurnSpeed: 5
 		Offset: -170,0,0


### PR DESCRIPTION
Fixes #14009.
Fixes https://github.com/IceReaper/KKnD/issues/19.

~Depends on #16067 and #16110.~

This PR (last three commits) implements an `OpportunityFire` flag on `AttackFollows`, which works [as described](https://github.com/OpenRA/OpenRA/issues/14009#issuecomment-328349817) for RA2. It is enabled by default for all turreted units, but can be disabled on specific units by setting `OpportunityFire: False` on `AttackTurreted` in the yaml.

I raised the idea of implementing this several days ago in the Discord channel, and the response was a rather enthusiastic yes, but that this really wanted to be included in the playtest so that rebalancing can be done at the same time as for the fog targeting.