### PR TITLE
Fix gate animations.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/Gate.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Gate.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 			: base(info)
 		{
 			self = init.Self;
-			OpenPosition = Info.TransitionDelay;
+			Position = OpenPosition = Info.TransitionDelay;
 			building = self.Trait<Building>();
 			blockedPositions = building.Info.Tiles(self.Location);
 			Footprint = blockedPositions;

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -1162,11 +1162,9 @@
 	-Capturable:
 	-GivesBuildableArea:
 	-MustBeDestroyed:
-	WithMakeAnimation:
-		Condition: build-incomplete
+	-WithMakeAnimation:
 	-WithSpriteBody:
 	WithGateSpriteBody:
-		PauseOnCondition: !build-incomplete
 		OpenSequence: open
 	Tooltip:
 	Buildable:
@@ -1180,10 +1178,12 @@
 	MapEditorData:
 		Categories: Wall
 	Gate:
-		PauseOnCondition: empdisable || build-incomplete
+		PauseOnCondition: empdisable
 		OpeningSound: gateup1.aud
 		ClosingSound: gatedwn1.aud
 		BlocksProjectilesHeight: 768
+	Sellable:
+		RequiresCondition: !being-demolished
 
 ^Gate_A:
 	Inherits: ^Gate

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -706,9 +706,6 @@ gagate_a:
 		Start: 20
 		Tick: 400
 		ShadowStart: 41
-	make:
-		Frames: 9, 8, 7, 6, 5, 4, 3, 2, 1
-		Length: 9
 	emp-overlay: emp_fx01
 		Length: *
 		Offset: 0, 0, 25
@@ -750,9 +747,6 @@ gagate_b:
 		Start: 20
 		Tick: 400
 		ShadowStart: 41
-	make:
-		Frames: 9, 8, 7, 6, 5, 4, 3, 2, 1
-		Length: 9
 	emp-overlay: emp_fx01
 		Length: *
 		Offset: 0, 0, 25
@@ -799,9 +793,6 @@ nagate_a:
 		Start: 14
 		Tick: 400
 		ShadowStart: 29
-	make:
-		Frames: 6, 5, 4, 3, 2, 1
-		Length: 6
 	emp-overlay: emp_fx01
 		Length: *
 		Offset: 0, 0, 25
@@ -844,9 +835,6 @@ nagate_b:
 		Start: 14
 		Tick: 400
 		ShadowStart: 29
-	make:
-		Frames: 6, 5, 4, 3, 2, 1
-		Length: 6
 	emp-overlay: emp_fx01
 		Length: *
 		Offset: 0, 0, 25


### PR DESCRIPTION
Gates on bleed do not animate open/closed. This is caused by a badly thought workaround that disables the animation using a condition when the make animation *isn't* playing!

Considering that the make animation is simply the gate closing, the simple fix here is to start the gate in the open position with zero close delay, and remove the MakeAnimation trait completely.  This has a side bonus of allowing the gates to respond and reopen faster after placement.
