### PR TITLE
Remove unused ClickSound definition from d2k sidebar.

### DIFF
--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -488,7 +488,6 @@ Container@PLAYER_WIDGETS:
 					MaximumRows: 6
 					HotkeyPrefix: Production
 					HotkeyCount: 24
-					ClickSound: TabClick
 				Container@PRODUCTION_TYPES:
 					X: 6
 					Y: 2


### PR DESCRIPTION
Fixes a crash introduced by #16083.