### PR TITLE
Enable "campaign" bot for scripted players in missions.

### DIFF
--- a/mods/cnc/maps/cnc64gdi01/map.yaml
+++ b/mods/cnc/maps/cnc64gdi01/map.yaml
@@ -25,6 +25,7 @@ Players:
 		Color: FE1100
 		Allies: Nod
 		Enemies: GDI
+		Bot: campaign
 	PlayerReference@GDI:
 		Name: GDI
 		AllowBots: False

--- a/mods/cnc/maps/funpark01/map.yaml
+++ b/mods/cnc/maps/funpark01/map.yaml
@@ -35,6 +35,7 @@ Players:
 		Faction: gdi
 		Color: 8C5033
 		Enemies: Nod, Civilian
+		Bot: campaign
 	PlayerReference@Nod:
 		Name: Nod
 		Playable: True

--- a/mods/cnc/maps/gdi01/map.yaml
+++ b/mods/cnc/maps/gdi01/map.yaml
@@ -25,6 +25,7 @@ Players:
 		Color: FE1100
 		Allies: Nod
 		Enemies: GDI
+		Bot: campaign
 	PlayerReference@GDI:
 		Name: GDI
 		Playable: True

--- a/mods/cnc/maps/gdi02/map.yaml
+++ b/mods/cnc/maps/gdi02/map.yaml
@@ -38,6 +38,7 @@ Players:
 		Color: FE1100
 		Allies: Nod
 		Enemies: GDI
+		Bot: campaign
 	PlayerReference@Neutral:
 		Name: Neutral
 		OwnsWorld: True

--- a/mods/cnc/maps/gdi03/map.yaml
+++ b/mods/cnc/maps/gdi03/map.yaml
@@ -25,6 +25,7 @@ Players:
 		Color: FE1100
 		Allies: Nod
 		Enemies: GDI
+		Bot: campaign
 	PlayerReference@Neutral:
 		Name: Neutral
 		OwnsWorld: True

--- a/mods/cnc/maps/gdi04a/map.yaml
+++ b/mods/cnc/maps/gdi04a/map.yaml
@@ -25,6 +25,7 @@ Players:
 		Color: FE1100
 		Allies: Nod
 		Enemies: GDI
+		Bot: campaign
 	PlayerReference@GDI:
 		Name: GDI
 		Playable: True

--- a/mods/cnc/maps/gdi04b/map.yaml
+++ b/mods/cnc/maps/gdi04b/map.yaml
@@ -25,6 +25,7 @@ Players:
 		Color: FE1100
 		Allies: Nod
 		Enemies: GDI
+		Bot: campaign
 	PlayerReference@GDI:
 		Name: GDI
 		Playable: True

--- a/mods/cnc/maps/gdi04c/map.yaml
+++ b/mods/cnc/maps/gdi04c/map.yaml
@@ -30,6 +30,7 @@ Players:
 		Color: FE1100
 		Allies: Nod
 		Enemies: GDI, Civilians
+		Bot: campaign
 	PlayerReference@GDI:
 		Name: GDI
 		Playable: True
@@ -48,6 +49,7 @@ Players:
 		NonCombatant: True
 		Faction: gdi
 		Enemies: Nod
+		Bot: campaign
 
 Actors:
 	Actor0: v17

--- a/mods/cnc/maps/gdi05a/map.yaml
+++ b/mods/cnc/maps/gdi05a/map.yaml
@@ -25,6 +25,7 @@ Players:
 		Color: FE1100
 		Allies: Nod
 		Enemies: GDI
+		Bot: campaign
 	PlayerReference@GDI:
 		Name: GDI
 		Playable: True
@@ -43,6 +44,7 @@ Players:
 		NonCombatant: True
 		Color: F5D378
 		Faction: gdi
+		Bot: campaign
 	PlayerReference@Neutral:
 		Name: Neutral
 		OwnsWorld: True

--- a/mods/cnc/maps/gdi05b/map.yaml
+++ b/mods/cnc/maps/gdi05b/map.yaml
@@ -24,6 +24,7 @@ Players:
 		Faction: nod
 		Color: FE1100
 		Enemies: GDI, AbandonedBase
+		Bot: campaign
 	PlayerReference@GDI:
 		Name: GDI
 		Playable: True
@@ -48,6 +49,7 @@ Players:
 		Faction: gdi
 		Color: F5D378
 		Enemies: Nod
+		Bot: campaign
 
 Actors:
 	Actor0: sbag

--- a/mods/cnc/maps/gdi06/map.yaml
+++ b/mods/cnc/maps/gdi06/map.yaml
@@ -30,6 +30,7 @@ Players:
 		Color: FE1100
 		Allies: Nod
 		Enemies: GDI
+		Bot: campaign
 	PlayerReference@GDI:
 		Name: GDI
 		AllowBots: False

--- a/mods/cnc/maps/gdi07/map.yaml
+++ b/mods/cnc/maps/gdi07/map.yaml
@@ -25,6 +25,7 @@ Players:
 		Color: FE1100
 		Allies: Nod
 		Enemies: GDI
+		Bot: campaign
 	PlayerReference@GDI:
 		Name: GDI
 		AllowBots: False

--- a/mods/cnc/maps/nod01/map.yaml
+++ b/mods/cnc/maps/nod01/map.yaml
@@ -28,12 +28,14 @@ Players:
 		Name: Villagers
 		NonCombatant: True
 		Faction: gdi
+		Bot: campaign
 	PlayerReference@GDI:
 		Name: GDI
 		Faction: gdi
 		Color: F5D378
 		Allies: Villagers
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Nod:
 		Name: Nod
 		Playable: True

--- a/mods/cnc/maps/nod02a/map.yaml
+++ b/mods/cnc/maps/nod02a/map.yaml
@@ -24,6 +24,7 @@ Players:
 		Faction: gdi
 		Color: F5D378
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Nod:
 		Name: Nod
 		Playable: True

--- a/mods/cnc/maps/nod02b/map.yaml
+++ b/mods/cnc/maps/nod02b/map.yaml
@@ -25,6 +25,7 @@ Players:
 		Color: F5D378
 		Allies: GDI
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Nod:
 		Name: Nod
 		Playable: True

--- a/mods/cnc/maps/nod03a/map.yaml
+++ b/mods/cnc/maps/nod03a/map.yaml
@@ -30,6 +30,7 @@ Players:
 		Color: F5D378
 		Allies: GDI
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Nod:
 		Name: Nod
 		Playable: True

--- a/mods/cnc/maps/nod03b/map.yaml
+++ b/mods/cnc/maps/nod03b/map.yaml
@@ -30,6 +30,7 @@ Players:
 		Color: F5D378
 		Allies: GDI
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Nod:
 		Name: Nod
 		Playable: True

--- a/mods/cnc/maps/nod04a/map.yaml
+++ b/mods/cnc/maps/nod04a/map.yaml
@@ -28,11 +28,13 @@ Players:
 		Name: NodSupporter
 		NonCombatant: True
 		Faction: nod
+		Bot: campaign
 	PlayerReference@GDI:
 		Name: GDI
 		Faction: gdi
 		Color: F5D378
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Nod:
 		Name: Nod
 		Playable: True

--- a/mods/cnc/maps/nod04b/map.yaml
+++ b/mods/cnc/maps/nod04b/map.yaml
@@ -24,6 +24,7 @@ Players:
 		Faction: gdi
 		Color: F5D378
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Neutral:
 		Name: Neutral
 		OwnsWorld: True

--- a/mods/cnc/maps/nod05/map.yaml
+++ b/mods/cnc/maps/nod05/map.yaml
@@ -25,6 +25,7 @@ Players:
 		Color: F5D378
 		Allies: GDI
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Neutral:
 		Name: Neutral
 		OwnsWorld: True
@@ -35,6 +36,7 @@ Players:
 		NonCombatant: True
 		Faction: gdi
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Nod:
 		Name: Nod
 		Playable: True

--- a/mods/cnc/maps/nod06a/map.yaml
+++ b/mods/cnc/maps/nod06a/map.yaml
@@ -29,6 +29,7 @@ Players:
 		Faction: gdi
 		Color: F5D378
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Nod:
 		Name: Nod
 		AllowBots: False

--- a/mods/cnc/maps/nod06b/map.yaml
+++ b/mods/cnc/maps/nod06b/map.yaml
@@ -24,6 +24,7 @@ Players:
 		Faction: gdi
 		Color: F5D378
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Neutral:
 		Name: Neutral
 		OwnsWorld: True
@@ -34,6 +35,7 @@ Players:
 		NonCombatant: True
 		Faction: gdi
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Nod:
 		Name: Nod
 		AllowBots: False

--- a/mods/cnc/maps/nod06c/map.yaml
+++ b/mods/cnc/maps/nod06c/map.yaml
@@ -25,6 +25,7 @@ Players:
 		Faction: gdi
 		Color: F5D378
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Nod:
 		Name: Nod
 		Playable: True
@@ -42,6 +43,7 @@ Players:
 		OwnsWorld: True
 		NonCombatant: True
 		Faction: gdi
+		Bot: campaign
 
 Actors:
 	Actor0: brik

--- a/mods/cnc/maps/nod07a/map.yaml
+++ b/mods/cnc/maps/nod07a/map.yaml
@@ -25,17 +25,20 @@ Players:
 		Color: F5D378
 		Allies: Civilians
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Neutral:
 		Name: Neutral
 		OwnsWorld: True
 		NonCombatant: True
 		Faction: gdi
+		Bot: campaign
 	PlayerReference@Civilians:
 		Name: Civilians
 		NonCombatant: True
 		Faction: gdi
 		Allies: GDI
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Nod:
 		Name: Nod
 		Faction: nod
@@ -52,6 +55,7 @@ Players:
 		Name: NodBase
 		Faction: nod
 		Color: FE1100
+		Bot: campaign
 
 Actors:
 	Actor0: cycl

--- a/mods/cnc/maps/nod07b/map.yaml
+++ b/mods/cnc/maps/nod07b/map.yaml
@@ -25,6 +25,7 @@ Players:
 		Color: F5D378
 		Allies: Civilians
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Neutral:
 		Name: Neutral
 		OwnsWorld: True
@@ -36,6 +37,7 @@ Players:
 		Faction: gdi
 		Allies: GDI
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Nod:
 		Name: Nod
 		Faction: nod

--- a/mods/cnc/maps/nod07c/map.yaml
+++ b/mods/cnc/maps/nod07c/map.yaml
@@ -25,11 +25,13 @@ Players:
 		Color: F5D378
 		Allies: Civilians, Target
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Target:
 		Name: Target
 		Faction: gdi
 		Color: F5D378
 		Allies: Civilians, GDI
+		Bot: campaign
 	PlayerReference@Neutral:
 		Name: Neutral
 		OwnsWorld: True
@@ -41,6 +43,7 @@ Players:
 		Faction: gdi
 		Allies: GDI, Target
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Nod:
 		Name: Nod
 		AllowBots: False

--- a/mods/cnc/maps/nod08a/map.yaml
+++ b/mods/cnc/maps/nod08a/map.yaml
@@ -25,6 +25,7 @@ Players:
 		Color: F5D378
 		Allies: Outpost
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Neutral:
 		Name: Neutral
 		OwnsWorld: True
@@ -35,12 +36,14 @@ Players:
 		NonCombatant: True
 		Faction: gdi
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Outpost:
 		Name: Outpost
 		Faction: gdi
 		Color: F5D378
 		Allies: GDI
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Nod:
 		Name: Nod
 		AllowBots: False
@@ -59,6 +62,7 @@ Players:
 		Faction: nod
 		Color: FE1100
 		Enemies: Nod
+		Bot: campaign
 
 Actors:
 	Actor0: brik

--- a/mods/cnc/maps/nod08b/map.yaml
+++ b/mods/cnc/maps/nod08b/map.yaml
@@ -25,6 +25,7 @@ Players:
 		Color: F5D378
 		Allies: Outpost
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Neutral:
 		Name: Neutral
 		OwnsWorld: True
@@ -35,12 +36,14 @@ Players:
 		NonCombatant: True
 		Faction: gdi
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Outpost:
 		Name: Outpost
 		Faction: gdi
 		Color: F5D378
 		Allies: GDI
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Nod:
 		Name: Nod
 		AllowBots: False
@@ -59,6 +62,7 @@ Players:
 		Faction: nod
 		Color: FE1100
 		Enemies: Nod
+		Bot: campaign
 
 Actors:
 	Actor0: brik

--- a/mods/cnc/maps/nod09/map.yaml
+++ b/mods/cnc/maps/nod09/map.yaml
@@ -26,6 +26,7 @@ Players:
 		Color: F5D378
 		Allies: Outpost
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Neutral:
 		Name: Neutral
 		OwnsWorld: True
@@ -36,12 +37,14 @@ Players:
 		NonCombatant: True
 		Faction: gdi
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Outpost:
 		Name: Outpost
 		Faction: gdi
 		Color: F5D378
 		Allies: GDI
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Nod:
 		Name: Nod
 		AllowBots: False
@@ -59,6 +62,7 @@ Players:
 		Faction: nod
 		Color: FE1100
 		Enemies: Nod
+		Bot: campaign
 
 Actors:
 	Actor0: brik

--- a/mods/cnc/maps/nod10a/map.yaml
+++ b/mods/cnc/maps/nod10a/map.yaml
@@ -34,6 +34,7 @@ Players:
 		Color: F6D679
 		Allies: GDI
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Nod:
 		Name: Nod
 		AllowBots: False
@@ -46,6 +47,7 @@ Players:
 		LockTeam: True
 		Allies: Nod
 		Enemies: GDI, Creeps
+
 Actors:
 	Actor0: brik
 		Location: 34,34

--- a/mods/cnc/maps/nod10b/map.yaml
+++ b/mods/cnc/maps/nod10b/map.yaml
@@ -31,6 +31,7 @@ Players:
 		Faction: gdi
 		Color: F6D679
 		Enemies: Nod
+		Bot: campaign
 	PlayerReference@Nod:
 		Name: Nod
 		AllowBots: False
@@ -42,6 +43,7 @@ Players:
 		LockSpawn: True
 		LockTeam: True
 		Enemies: GDI
+
 Actors:
 	Actor0: brik
 		Location: 38,55

--- a/mods/cnc/rules/campaign-maprules.yaml
+++ b/mods/cnc/rules/campaign-maprules.yaml
@@ -28,6 +28,9 @@ Player:
 	PlayerResources:
 		DefaultCashDropdownLocked: True
 		DefaultCash: 5000
+	ModularBot@CampaignAI:
+		Name: Campaign Player AI
+		Type: campaign
 
 airstrike.proxy:
 	AlwaysVisible:

--- a/mods/d2k/maps/atreides-01a/map.yaml
+++ b/mods/d2k/maps/atreides-01a/map.yaml
@@ -44,6 +44,7 @@ Players:
 		Color: FE0000
 		LockColor: true
 		Enemies: Atreides, Creeps
+		Bot: campaign
 
 Actors:
 	Actor0: trike

--- a/mods/d2k/maps/atreides-01b/map.yaml
+++ b/mods/d2k/maps/atreides-01b/map.yaml
@@ -44,6 +44,7 @@ Players:
 		Color: FE0000
 		LockColor: true
 		Enemies: Atreides, Creeps
+		Bot: campaign
 
 Actors:
 	Actor0: light_inf

--- a/mods/d2k/maps/atreides-02a/map.yaml
+++ b/mods/d2k/maps/atreides-02a/map.yaml
@@ -42,6 +42,7 @@ Players:
 		LockColor: True
 		Color: FE0000
 		Enemies: Atreides, Creeps
+		Bot: campaign
 
 Actors:
 	Actor0: spicebloom.spawnpoint

--- a/mods/d2k/maps/atreides-02b/map.yaml
+++ b/mods/d2k/maps/atreides-02b/map.yaml
@@ -42,6 +42,7 @@ Players:
 		LockColor: True
 		Color: FE0000
 		Enemies: Atreides, Creeps
+		Bot: campaign
 
 Actors:
 	Actor0: light_inf

--- a/mods/d2k/maps/atreides-03a/map.yaml
+++ b/mods/d2k/maps/atreides-03a/map.yaml
@@ -42,6 +42,7 @@ Players:
 		LockColor: True
 		Color: B3EAA5
 		Enemies: Atreides, Creeps
+		Bot: campaign
 
 Actors:
 	Actor0: light_inf

--- a/mods/d2k/maps/atreides-03b/map.yaml
+++ b/mods/d2k/maps/atreides-03b/map.yaml
@@ -42,6 +42,7 @@ Players:
 		LockColor: True
 		Color: B3EAA5
 		Enemies: Atreides, Creeps
+		Bot: campaign
 
 Actors:
 	Actor3: wormspawner

--- a/mods/d2k/maps/atreides-04/map.yaml
+++ b/mods/d2k/maps/atreides-04/map.yaml
@@ -45,6 +45,7 @@ Players:
 		LockColor: True
 		Color: FE0000
 		Enemies: Atreides, Creeps, Fremen
+		Bot: campaign
 	PlayerReference@Fremen:
 		Name: Fremen
 		LockFaction: True
@@ -53,6 +54,7 @@ Players:
 		Color: DDDDDD
 		Allies: Atreides
 		Enemies: Harkonnen, Creeps
+		Bot: campaign
 
 Actors:
 	Actor0: wormspawner

--- a/mods/d2k/maps/atreides-05/map.yaml
+++ b/mods/d2k/maps/atreides-05/map.yaml
@@ -44,6 +44,7 @@ Players:
 		LockColor: True
 		Color: FE0000
 		Enemies: Atreides
+		Bot: campaign
 	PlayerReference@Smugglers:
 		Name: Smugglers
 		LockFaction: True
@@ -52,6 +53,7 @@ Players:
 		Color: 542209
 		Allies: Mercenaries
 		Enemies: Atreides
+		Bot: campaign
 	PlayerReference@Mercenaries:
 		Name: Mercenaries
 		LockFaction: True
@@ -60,6 +62,7 @@ Players:
 		Color: DDDD00
 		Allies: Smugglers
 		Enemies: Atreides
+		Bot: campaign
 
 Actors:
 	Actor4: trike

--- a/mods/d2k/maps/harkonnen-01a/map.yaml
+++ b/mods/d2k/maps/harkonnen-01a/map.yaml
@@ -43,6 +43,7 @@ Players:
 		LockColor: True
 		Color: 9191FF
 		Enemies: Harkonnen
+		Bot: campaign
 
 Actors:
 	Actor0: light_inf

--- a/mods/d2k/maps/harkonnen-01b/map.yaml
+++ b/mods/d2k/maps/harkonnen-01b/map.yaml
@@ -43,6 +43,7 @@ Players:
 		LockColor: True
 		Color: 9191FF
 		Enemies: Harkonnen
+		Bot: campaign
 
 Actors:
 	Actor0: light_inf

--- a/mods/d2k/maps/harkonnen-02a/map.yaml
+++ b/mods/d2k/maps/harkonnen-02a/map.yaml
@@ -42,6 +42,7 @@ Players:
 		LockColor: True
 		Color: 9191FF
 		Enemies: Harkonnen
+		Bot: campaign
 
 Actors:
 	Actor0: light_inf

--- a/mods/d2k/maps/harkonnen-02b/map.yaml
+++ b/mods/d2k/maps/harkonnen-02b/map.yaml
@@ -42,6 +42,7 @@ Players:
 		LockColor: True
 		Color: 9191FF
 		Enemies: Harkonnen
+		Bot: campaign
 
 Actors:
 	HConyard: construction_yard

--- a/mods/d2k/maps/harkonnen-03a/map.yaml
+++ b/mods/d2k/maps/harkonnen-03a/map.yaml
@@ -42,6 +42,7 @@ Players:
 		LockColor: True
 		Color: 9191FF
 		Enemies: Harkonnen
+		Bot: campaign
 
 Actors:
 	Actor0: light_inf

--- a/mods/d2k/maps/harkonnen-03b/map.yaml
+++ b/mods/d2k/maps/harkonnen-03b/map.yaml
@@ -42,6 +42,7 @@ Players:
 		LockColor: True
 		Color: 9191FF
 		Enemies: Harkonnen
+		Bot: campaign
 
 Actors:
 	Actor0: wall

--- a/mods/d2k/maps/harkonnen-04/map.yaml
+++ b/mods/d2k/maps/harkonnen-04/map.yaml
@@ -43,6 +43,7 @@ Players:
 		Color: 9191FF
 		Allies: Fremen
 		Enemies: Harkonnen
+		Bot: campaign
 	PlayerReference@Fremen:
 		Name: Fremen
 		LockFaction: True
@@ -51,6 +52,7 @@ Players:
 		Color: DDDDDD
 		Allies: Atreides
 		Enemies: Harkonnen
+		Bot: campaign
 
 Actors:
 	Actor0: spicebloom.spawnpoint

--- a/mods/d2k/maps/harkonnen-05/map.yaml
+++ b/mods/d2k/maps/harkonnen-05/map.yaml
@@ -43,6 +43,7 @@ Players:
 		Color: B3EAA5
 		Allies: Ordos Small Base, Corrino
 		Enemies: Harkonnen
+		Bot: campaign
 	PlayerReference@Ordos Small Base:
 		Name: Ordos Small Base
 		LockFaction: True
@@ -51,6 +52,7 @@ Players:
 		Color: B3EAA5
 		Allies: Ordos Main Base, Corrino
 		Enemies: Harkonnen
+		Bot: campaign
 	PlayerReference@Corrino:
 		Name: Corrino
 		LockFaction: True
@@ -59,6 +61,7 @@ Players:
 		Color: 7D00FE
 		Allies: Ordos Main Base, Ordos Small Base
 		Enemies: Harkonnen
+		Bot: campaign
 
 Actors:
 	Actor0: wall

--- a/mods/d2k/maps/harkonnen-06a/map.yaml
+++ b/mods/d2k/maps/harkonnen-06a/map.yaml
@@ -43,6 +43,7 @@ Players:
 		Color: B3EAA5
 		Allies: Ordos Small Base
 		Enemies: Harkonnen, Smugglers - Enemy to Ordos, Smugglers - Enemy to Both
+		Bot: campaign
 	PlayerReference@Ordos Small Base:
 		Name: Ordos Small Base
 		LockFaction: True
@@ -51,6 +52,7 @@ Players:
 		Color: B3EAA5
 		Allies: Ordos Main Base
 		Enemies: Harkonnen, Smugglers - Enemy to Ordos, Smugglers - Enemy to Both
+		Bot: campaign
 	PlayerReference@Smugglers - Neutral:
 		Name: Smugglers - Neutral
 		NonCombatant: True
@@ -58,6 +60,7 @@ Players:
 		Faction: smuggler
 		LockColor: True
 		Color: 542209
+		Bot: campaign
 	PlayerReference@Smugglers - Enemy to Harkonnen:
 		Name: Smugglers - Enemy to Harkonnen
 		NonCombatant: True
@@ -66,6 +69,7 @@ Players:
 		LockColor: True
 		Color: 542209
 		Enemies: Harkonnen
+		Bot: campaign
 	PlayerReference@Smugglers - Enemy to Ordos:
 		Name: Smugglers - Enemy to Ordos
 		NonCombatant: True
@@ -74,6 +78,7 @@ Players:
 		LockColor: True
 		Color: 542209
 		Enemies: Ordos Main Base, Ordos Small Base
+		Bot: campaign
 	PlayerReference@Smugglers - Enemy to Both:
 		Name: Smugglers - Enemy to Both
 		NonCombatant: True
@@ -82,6 +87,7 @@ Players:
 		LockColor: True
 		Color: 542209
 		Enemies: Harkonnen, Ordos Main Base, Ordos Small Base
+		Bot: campaign
 
 Actors:
 	Actor0: wormspawner

--- a/mods/d2k/maps/harkonnen-06b/map.yaml
+++ b/mods/d2k/maps/harkonnen-06b/map.yaml
@@ -43,6 +43,7 @@ Players:
 		Color: B3EAA5
 		Allies: Ordos Small Base
 		Enemies: Harkonnen, Smugglers - Enemy to Ordos, Smugglers - Enemy to Both
+		Bot: campaign
 	PlayerReference@Ordos Small Base:
 		Name: Ordos Small Base
 		LockFaction: True
@@ -51,6 +52,7 @@ Players:
 		Color: B3EAA5
 		Allies: Ordos Main Base
 		Enemies: Harkonnen, Smugglers - Enemy to Ordos, Smugglers - Enemy to Both
+		Bot: campaign
 	PlayerReference@Smugglers - Neutral:
 		Name: Smugglers - Neutral
 		NonCombatant: True
@@ -58,6 +60,7 @@ Players:
 		Faction: smuggler
 		LockColor: True
 		Color: 542209
+		Bot: campaign
 	PlayerReference@Smugglers - Enemy to Harkonnen:
 		Name: Smugglers - Enemy to Harkonnen
 		NonCombatant: True
@@ -66,6 +69,7 @@ Players:
 		LockColor: True
 		Color: 542209
 		Enemies: Harkonnen
+		Bot: campaign
 	PlayerReference@Smugglers - Enemy to Ordos:
 		Name: Smugglers - Enemy to Ordos
 		NonCombatant: True
@@ -74,6 +78,7 @@ Players:
 		LockColor: True
 		Color: 542209
 		Enemies: Ordos Main Base, Ordos Small Base
+		Bot: campaign
 	PlayerReference@Smugglers - Enemy to Both:
 		Name: Smugglers - Enemy to Both
 		NonCombatant: True
@@ -82,6 +87,7 @@ Players:
 		LockColor: True
 		Color: 542209
 		Enemies: Harkonnen, Ordos Main Base, Ordos Small Base
+		Bot: campaign
 
 Actors:
 	Actor0: wall

--- a/mods/d2k/maps/harkonnen-07/map.yaml
+++ b/mods/d2k/maps/harkonnen-07/map.yaml
@@ -43,6 +43,7 @@ Players:
 		Color: 9191FF
 		Allies: Atreides Small Base, Corrino
 		Enemies: Harkonnen
+		Bot: campaign
 	PlayerReference@Atreides Small Base:
 		Name: Atreides Small Base
 		LockFaction: True
@@ -51,6 +52,7 @@ Players:
 		Color: 9191FF
 		Allies: Atreides Main Base, Corrino
 		Enemies: Harkonnen
+		Bot: campaign
 	PlayerReference@Corrino:
 		Name: Corrino
 		LockFaction: True
@@ -59,6 +61,7 @@ Players:
 		Color: 7D00FE
 		Allies: Atreides Main Base, Atreides Small Base
 		Enemies: Harkonnen
+		Bot: campaign
 
 Actors:
 	Actor0: wormspawner

--- a/mods/d2k/maps/harkonnen-08/map.yaml
+++ b/mods/d2k/maps/harkonnen-08/map.yaml
@@ -44,12 +44,14 @@ Players:
 		Color: 9191FF
 		Allies: Ordos, Ordos Aligned Mercenaries
 		Enemies: Harkonnen, Harkonnen Aligned Mercenaries
+		Bot: campaign
 	PlayerReference@Neutral Atreides:
 		Name: Neutral Atreides
 		LockFaction: True
 		Faction: atreides
 		LockColor: True
 		Color: 9191FF
+		Bot: campaign
 	PlayerReference@Ordos:
 		Name: Ordos
 		LockFaction: True
@@ -58,6 +60,7 @@ Players:
 		Color: B3EAA5
 		Allies: Ordos Aligned Atreides, Ordos Aligned Mercenaries
 		Enemies: Harkonnen, Harkonnen Aligned Mercenaries
+		Bot: campaign
 	PlayerReference@Ordos Aligned Mercenaries:
 		Name: Ordos Aligned Mercenaries
 		LockFaction: True
@@ -66,6 +69,7 @@ Players:
 		Color: DDDD00
 		Allies: Ordos, Ordos Aligned Atreides
 		Enemies: Harkonnen
+		Bot: campaign
 	PlayerReference@Harkonnen Aligned Mercenaries:
 		Name: Harkonnen Aligned Mercenaries
 		LockFaction: True
@@ -74,6 +78,7 @@ Players:
 		Color: DDDD00
 		Allies: Harkonnen
 		Enemies: Ordos, Ordos Aligned Atreides
+		Bot: campaign
 
 Actors:
 	AOutpost: outpost

--- a/mods/d2k/maps/harkonnen-09a/map.yaml
+++ b/mods/d2k/maps/harkonnen-09a/map.yaml
@@ -43,6 +43,7 @@ Players:
 		Color: 9191FF
 		Allies: Atreides Small Base 1, Atreides Small Base 2, Corrino Main Base, Corrino Small Base
 		Enemies: Harkonnen
+		Bot: campaign
 	PlayerReference@Atreides Small Base 1:
 		Name: Atreides Small Base 1
 		LockFaction: True
@@ -51,6 +52,7 @@ Players:
 		Color: 9191FF
 		Allies: Atreides Main Base, Atreides Small Base 2, Corrino Main Base, Corrino Small Base
 		Enemies: Harkonnen
+		Bot: campaign
 	PlayerReference@Atreides Small Base 2:
 		Name: Atreides Small Base 2
 		LockFaction: True
@@ -59,6 +61,7 @@ Players:
 		Color: 9191FF
 		Allies: Atreides Main Base, Atreides Small Base 1, Corrino Main Base, Corrino Small Base
 		Enemies: Harkonnen
+		Bot: campaign
 	PlayerReference@Corrino Main Base:
 		Name: Corrino Main Base
 		LockFaction: True
@@ -67,6 +70,7 @@ Players:
 		Color: 7D00FE
 		Allies: Atreides Main Base, Atreides Small Base 1, Atreides Small Base 2, Corrino Small Base
 		Enemies: Harkonnen
+		Bot: campaign
 	PlayerReference@Corrino Small Base:
 		Name: Corrino Small Base
 		LockFaction: True
@@ -75,6 +79,7 @@ Players:
 		Color: 7D00FE
 		Allies: Atreides Main Base, Atreides Small Base 1, Atreides Small Base 2, Corrino Main Base
 		Enemies: Harkonnen
+		Bot: campaign
 
 Actors:
 	Actor0: combat_tank_a

--- a/mods/d2k/maps/harkonnen-09b/map.yaml
+++ b/mods/d2k/maps/harkonnen-09b/map.yaml
@@ -43,6 +43,7 @@ Players:
 		Color: 9191FF
 		Allies: Atreides Small Base, Corrino Main Base, Corrino Small Base
 		Enemies: Harkonnen, Smugglers - Enemy to AI, Smugglers - Enemy to Both
+		Bot: campaign
 	PlayerReference@Atreides Small Base:
 		Name: Atreides Small Base
 		LockFaction: True
@@ -51,6 +52,7 @@ Players:
 		Color: 9191FF
 		Allies: Atreides Main Base, Corrino Main Base, Corrino Small Base
 		Enemies: Harkonnen, Smugglers - Enemy to AI, Smugglers - Enemy to Both
+		Bot: campaign
 	PlayerReference@Corrino Main Base:
 		Name: Corrino Main Base
 		LockFaction: True
@@ -59,6 +61,7 @@ Players:
 		Color: 7D00FE
 		Allies: Atreides Main Base, Atreides Small Base, Corrino Small Base
 		Enemies: Harkonnen, Smugglers - Enemy to AI, Smugglers - Enemy to Both
+		Bot: campaign
 	PlayerReference@Corrino Small Base:
 		Name: Corrino Small Base
 		LockFaction: True
@@ -67,6 +70,7 @@ Players:
 		Color: 7D00FE
 		Allies: Atreides Main Base, Atreides Small Base, Corrino Main Base
 		Enemies: Harkonnen, Smugglers - Enemy to AI, Smugglers - Enemy to Both
+		Bot: campaign
 	PlayerReference@Smugglers - Neutral:
 		Name: Smugglers - Neutral
 		NonCombatant: True
@@ -74,6 +78,7 @@ Players:
 		Faction: smuggler
 		LockColor: True
 		Color: 542209
+		Bot: campaign
 	PlayerReference@Smugglers - Enemy to Harkonnen:
 		Name: Smugglers - Enemy to Harkonnen
 		NonCombatant: True
@@ -82,6 +87,7 @@ Players:
 		LockColor: True
 		Color: 542209
 		Enemies: Harkonnen
+		Bot: campaign
 	PlayerReference@Smugglers - Enemy to AI:
 		Name: Smugglers - Enemy to AI
 		NonCombatant: True
@@ -90,6 +96,7 @@ Players:
 		LockColor: True
 		Color: 542209
 		Enemies: Atreides Main Base, Atreides Small Base, Corrino Main Base, Corrino Small Base
+		Bot: campaign
 	PlayerReference@Smugglers - Enemy to Both:
 		Name: Smugglers - Enemy to Both
 		NonCombatant: True
@@ -98,6 +105,7 @@ Players:
 		LockColor: True
 		Color: 542209
 		Enemies: Harkonnen, Atreides Main Base, Atreides Small Base, Corrino Main Base, Corrino Small Base
+		Bot: campaign
 
 Actors:
 	Actor0: trooper

--- a/mods/d2k/maps/ordos-01a/map.yaml
+++ b/mods/d2k/maps/ordos-01a/map.yaml
@@ -44,6 +44,7 @@ Players:
 		LockColor: True
 		Color: FE0000
 		Enemies: Ordos
+		Bot: campaign
 
 Actors:
 	Actor0: light_inf

--- a/mods/d2k/maps/ordos-01b/map.yaml
+++ b/mods/d2k/maps/ordos-01b/map.yaml
@@ -44,6 +44,7 @@ Players:
 		LockColor: True
 		Color: FE0000
 		Enemies: Ordos
+		Bot: campaign
 
 Actors:
 	Actor0: light_inf

--- a/mods/d2k/maps/ordos-02a/map.yaml
+++ b/mods/d2k/maps/ordos-02a/map.yaml
@@ -44,6 +44,7 @@ Players:
 		LockColor: True
 		Color: FE0000
 		Enemies: Ordos
+		Bot: campaign
 
 Actors:
 	Actor0: spicebloom.spawnpoint

--- a/mods/d2k/maps/ordos-02b/map.yaml
+++ b/mods/d2k/maps/ordos-02b/map.yaml
@@ -44,6 +44,7 @@ Players:
 		LockColor: True
 		Color: FE0000
 		Enemies: Ordos
+		Bot: campaign
 
 Actors:
 	Actor0: light_inf

--- a/mods/d2k/maps/ordos-03a/map.yaml
+++ b/mods/d2k/maps/ordos-03a/map.yaml
@@ -44,6 +44,7 @@ Players:
 		LockColor: True
 		Color: FE0000
 		Enemies: Ordos
+		Bot: campaign
 
 Actors:
 	Actor0: light_inf

--- a/mods/d2k/maps/ordos-03b/map.yaml
+++ b/mods/d2k/maps/ordos-03b/map.yaml
@@ -44,6 +44,7 @@ Players:
 		LockColor: True
 		Color: FE0000
 		Enemies: Ordos
+		Bot: campaign
 
 Actors:
 	Actor0: spicebloom.spawnpoint

--- a/mods/d2k/maps/ordos-04/map.yaml
+++ b/mods/d2k/maps/ordos-04/map.yaml
@@ -45,6 +45,7 @@ Players:
 		Color: FE0000
 		Allies: Smugglers
 		Enemies: Ordos
+		Bot: campaign
 	PlayerReference@Smugglers:
 		Name: Smugglers
 		LockFaction: True
@@ -53,6 +54,7 @@ Players:
 		Color: 542209
 		Allies: Harkonnen
 		Enemies: Ordos
+		Bot: campaign
 
 Actors:
 	Actor0: wall

--- a/mods/d2k/maps/ordos-05/map.yaml
+++ b/mods/d2k/maps/ordos-05/map.yaml
@@ -45,6 +45,7 @@ Players:
 		Color: 9191FF
 		Allies: AtreidesSmallBase1, AtreidesSmallBase2
 		Enemies: Ordos
+		Bot: campaign
 	PlayerReference@AtreidesSmallBase1:
 		Name: AtreidesSmallBase1
 		LockFaction: True
@@ -53,6 +54,7 @@ Players:
 		Color: 9191FF
 		Allies: AtreidesMainBase, AtreidesSmallBase2, AtreidesSmallBase3
 		Enemies: Ordos
+		Bot: campaign
 	PlayerReference@AtreidesSmallBase2:
 		Name: AtreidesSmallBase2
 		LockFaction: True
@@ -61,6 +63,7 @@ Players:
 		Color: 9191FF
 		Allies: AtreidesMainBase, AtreidesSmallBase1, AtreidesSmallBase3
 		Enemies: Ordos
+		Bot: campaign
 	PlayerReference@AtreidesSmallBase3:
 		Name: AtreidesSmallBase3
 		LockFaction: True
@@ -69,6 +72,7 @@ Players:
 		Color: 9191FF
 		Allies: AtreidesMainBase, AtreidesSmallBase1, AtreidesSmallBase2
 		Enemies: Ordos
+		Bot: campaign
 
 Actors:
 	Actor0: wall

--- a/mods/d2k/rules/campaign-rules.yaml
+++ b/mods/d2k/rules/campaign-rules.yaml
@@ -9,6 +9,9 @@ Player:
 		ExploredMapCheckboxEnabled: False
 	PlayerResources:
 		DefaultCashDropdownLocked: True
+	ModularBot@CampaignAI:
+		Name: Campaign Player AI
+		Type: campaign
 
 World:
 	-CrateSpawner:

--- a/mods/ra/maps/allies-01/map.yaml
+++ b/mods/ra/maps/allies-01/map.yaml
@@ -24,6 +24,7 @@ Players:
 		Faction: soviet
 		Color: FE1100
 		Enemies: Greece, England
+		Bot: campaign
 	PlayerReference@Neutral:
 		Name: Neutral
 		OwnsWorld: True
@@ -48,6 +49,7 @@ Players:
 		Color: A1EF8C
 		Allies: Greece
 		Enemies: USSR
+		Bot: campaign
 
 Actors:
 	Actor0: t16

--- a/mods/ra/maps/allies-02/map.yaml
+++ b/mods/ra/maps/allies-02/map.yaml
@@ -24,6 +24,7 @@ Players:
 		Faction: soviet
 		Color: FE1100
 		Enemies: Greece, England
+		Bot: campaign
 	PlayerReference@England:
 		Name: England
 		NonCombatant: True
@@ -31,6 +32,7 @@ Players:
 		Color: A1EF8C
 		Allies: Greece
 		Enemies: USSR
+		Bot: campaign
 	PlayerReference@Neutral:
 		Name: Neutral
 		OwnsWorld: True

--- a/mods/ra/maps/allies-03a/map.yaml
+++ b/mods/ra/maps/allies-03a/map.yaml
@@ -29,6 +29,7 @@ Players:
 		Faction: soviet
 		Color: FE1100
 		Enemies: Greece
+		Bot: campaign
 	PlayerReference@Greece:
 		Name: Greece
 		Playable: True

--- a/mods/ra/maps/allies-03b/map.yaml
+++ b/mods/ra/maps/allies-03b/map.yaml
@@ -29,6 +29,7 @@ Players:
 		Faction: soviet
 		Color: FE1100
 		Enemies: Greece
+		Bot: campaign
 	PlayerReference@Greece:
 		Name: Greece
 		Playable: True
@@ -42,6 +43,7 @@ Players:
 		Name: England
 		Color: A1EF8C
 		Faction: allies
+		Bot: campaign
 
 Actors:
 	Actor0: cycl

--- a/mods/ra/maps/allies-04/map.yaml
+++ b/mods/ra/maps/allies-04/map.yaml
@@ -29,6 +29,7 @@ Players:
 		Faction: soviet
 		Color: FE1100
 		Enemies: Greece
+		Bot: campaign
 	PlayerReference@Greece:
 		Name: Greece
 		Playable: True

--- a/mods/ra/maps/allies-05a/map.yaml
+++ b/mods/ra/maps/allies-05a/map.yaml
@@ -29,6 +29,7 @@ Players:
 		Faction: soviet
 		Color: FE1100
 		Enemies: Greece
+		Bot: campaign
 	PlayerReference@Greece:
 		Name: Greece
 		Playable: True

--- a/mods/ra/maps/allies-06a/map.yaml
+++ b/mods/ra/maps/allies-06a/map.yaml
@@ -29,6 +29,7 @@ Players:
 		Faction: soviet
 		Color: FF1400
 		Enemies: USSR, Greece
+		Bot: campaign
 	PlayerReference@Greece:
 		Name: Greece
 		AllowBots: False

--- a/mods/ra/maps/allies-06b/map.yaml
+++ b/mods/ra/maps/allies-06b/map.yaml
@@ -33,6 +33,7 @@ Players:
 		Faction: soviet
 		Color: FF1400
 		Enemies: Greece
+		Bot: campaign
 	PlayerReference@Greece:
 		Name: Greece
 		AllowBots: False

--- a/mods/ra/maps/allies-07/map.yaml
+++ b/mods/ra/maps/allies-07/map.yaml
@@ -34,18 +34,21 @@ Players:
 		Color: FF1400
 		Allies: BadGuy
 		Enemies: England, Greece
+		Bot: campaign
 	PlayerReference@BadGuy:
 		Name: BadGuy
 		Faction: soviet
 		Color: FF1400
 		Allies: USSR
 		Enemies: England, Greece
+		Bot: campaign
 	PlayerReference@England:
 		Name: England
 		Faction: allies
 		Color: A0F08C
 		Allies: Greece
 		Enemies: USSR, BadGuy
+		Bot: campaign
 	PlayerReference@Greece:
 		Name: Greece
 		AllowBots: False

--- a/mods/ra/maps/allies-08a/map.yaml
+++ b/mods/ra/maps/allies-08a/map.yaml
@@ -33,11 +33,13 @@ Players:
 		Faction: soviet
 		Color: FF1400
 		Enemies: Greece, Germany
+		Bot: campaign
 	PlayerReference@Germany:
 		Name: Germany
 		Faction: allies
 		Color: 505050
 		Enemies: USSR
+		Bot: campaign
 	PlayerReference@Greece:
 		Name: Greece
 		AllowBots: False

--- a/mods/ra/maps/allies-08b/map.yaml
+++ b/mods/ra/maps/allies-08b/map.yaml
@@ -33,11 +33,13 @@ Players:
 		Faction: soviet
 		Color: FF1400
 		Enemies: Greece, England
+		Bot: campaign
 	PlayerReference@England:
 		Name: England
 		Faction: allies
 		Color: A0F08C
 		Enemies: USSR
+		Bot: campaign
 	PlayerReference@Greece:
 		Name: Greece
 		AllowBots: False

--- a/mods/ra/maps/ant-01/map.yaml
+++ b/mods/ra/maps/ant-01/map.yaml
@@ -46,6 +46,7 @@ Players:
 		Name: AntMan 
 		Faciton: soviet
 		Enemies: Spain, Creeps
+		Bot: campaign
 
 Actors:
 	Actor0: brik

--- a/mods/ra/maps/evacuation/map.yaml
+++ b/mods/ra/maps/evacuation/map.yaml
@@ -54,11 +54,13 @@ Players:
 		Color: 5CC1A3
 		Allies: Allies1, Allies2
 		Enemies: Soviets
+		Bot: campaign
 	PlayerReference@Soviets:
 		Name: Soviets
 		Faction: soviet
 		Color: FE1100
 		Enemies: Allies1, Allies2, Allies
+		Bot: campaign
 
 Actors:
 	Actor1: v07

--- a/mods/ra/maps/exodus/map.yaml
+++ b/mods/ra/maps/exodus/map.yaml
@@ -53,11 +53,13 @@ Players:
 		Color: 5CC1A3
 		Allies: Allies1, Allies2
 		Enemies: Soviets
+		Bot: campaign
 	PlayerReference@Soviets:
 		Name: Soviets
 		Faction: soviet
 		Color: FE1100
 		Enemies: Allies1, Allies2
+		Bot: campaign
 
 Actors:
 	Actor239: dog

--- a/mods/ra/maps/infiltration/map.yaml
+++ b/mods/ra/maps/infiltration/map.yaml
@@ -58,11 +58,13 @@ Players:
 		Color: 5CC1A3
 		Allies: Allies1, Allies2
 		Enemies: Soviets
+		Bot: campaign
 	PlayerReference@Soviets:
 		Name: Soviets
 		Faction: soviet
 		Color: FE1100
 		Enemies: Allies1, Allies2, Allies, Creeps
+		Bot: campaign
 
 Actors:
 	Actor2: v07

--- a/mods/ra/maps/intervention/map.yaml
+++ b/mods/ra/maps/intervention/map.yaml
@@ -48,6 +48,7 @@ Players:
 		Faction: soviet
 		Color: FE1100
 		Enemies: Civilians, Allies
+		Bot: campaign
 
 Actors:
 	Actor1: mine

--- a/mods/ra/maps/monster-tank-madness/map.yaml
+++ b/mods/ra/maps/monster-tank-madness/map.yaml
@@ -37,12 +37,14 @@ Players:
 		Color: FE1100
 		Allies: USSR
 		Enemies: Greece, Turkey
+		Bot: campaign
 	PlayerReference@USSR:
 		Name: USSR
 		Faction: soviet
 		Color: FE1100
 		Allies: BadGuy, Ukraine
 		Enemies: Greece, Turkey
+		Bot: campaign
 	PlayerReference@Neutral:
 		Name: Neutral
 		OwnsWorld: True
@@ -54,22 +56,26 @@ Players:
 		Color: FFE495
 		Allies: BadGuy, USSR
 		Enemies: Greece, Turkey
+		Bot: campaign
 	PlayerReference@Turkey:
 		Name: Turkey
 		Faction: soviet
 		Color: D1987C
 		Enemies: Greece, BadGuy, USSR, Ukraine, Outpost
+		Bot: campaign
 	PlayerReference@FriendlyMadTanks:
 		Name: FriendlyMadTanks
 		Faction: soviet
 		Color: D1987C
 		Allies: Greece
 		Enemies: BadGuy, USSR, Ukraine
+		Bot: campaign
 	PlayerReference@Outpost:
 		Name: Outpost
 		NonCombatant: True
 		Faction: allies
 		Enemies: BadGuy, USSR, Ukraine, Turkey
+		Bot: campaign
 
 Actors:
 	Actor0: sbag

--- a/mods/ra/maps/sarin-gas-1-crackdown/map.yaml
+++ b/mods/ra/maps/sarin-gas-1-crackdown/map.yaml
@@ -34,18 +34,21 @@ Players:
 		Color: FF1400
 		Allies: Ukraine, Turkey, BadGuy
 		Enemies: Greece
+		Bot: campaign
 	PlayerReference@BadGuy:
 		Name: BadGuy
 		Faction: soviet
 		Color: FF1400
 		Allies: USSR, Ukraine, Turkey
 		Enemies: Greece
+		Bot: campaign
 	PlayerReference@Ukraine:
 		Name: Ukraine
 		Faction: soviet
 		Color: FFE695
 		Allies: USSR, Turkey, BadGuy
 		Enemies: Greece
+		Bot: campaign
 	PlayerReference@Greece:
 		Name: Greece
 		AllowBots: False
@@ -64,6 +67,7 @@ Players:
 		Color: D2997D
 		Allies: USSR, Ukraine, BadGuy
 		Enemies: Greece
+		Bot: campaign
 
 Actors:
 	Actor0: brik

--- a/mods/ra/maps/soviet-01/map.yaml
+++ b/mods/ra/maps/soviet-01/map.yaml
@@ -25,6 +25,7 @@ Players:
 		Color: 5CC1A3
 		Allies: Germany
 		Enemies: USSR
+		Bot: campaign
 	PlayerReference@Germany:
 		Name: Germany
 		NonCombatant: True
@@ -32,6 +33,7 @@ Players:
 		Color: 505050
 		Allies: France
 		Enemies: USSR
+		Bot: campaign
 	PlayerReference@USSR:
 		Name: USSR
 		Playable: True

--- a/mods/ra/maps/soviet-02a/map.yaml
+++ b/mods/ra/maps/soviet-02a/map.yaml
@@ -36,6 +36,7 @@ Players:
 		Faction: allies
 		Color: E2E6F5
 		Enemies: USSR
+		Bot: campaign
 	PlayerReference@Neutral:
 		Name: Neutral
 		OwnsWorld: True

--- a/mods/ra/maps/soviet-02b/map.yaml
+++ b/mods/ra/maps/soviet-02b/map.yaml
@@ -33,6 +33,7 @@ Players:
 		Faction: allies
 		Color: E2E6F5
 		Enemies: USSR
+		Bot: campaign
 	PlayerReference@USSR:
 		Name: USSR
 		AllowBots: False

--- a/mods/ra/maps/soviet-03/map.yaml
+++ b/mods/ra/maps/soviet-03/map.yaml
@@ -34,17 +34,20 @@ Players:
 		Color: E2E6F5
 		Allies: Greece, BadGuy
 		Enemies: USSR
+		Bot: campaign
 	PlayerReference@BadGuy:
 		Name: BadGuy
 		Faction: soviet
 		Color: FE1100
 		Allies: England, Greece, USSR
+		Bot: campaign
 	PlayerReference@Greece:
 		Name: Greece
 		Faction: allies
 		Color: E2E6F5
 		Allies: England, BadGuy
 		Enemies: USSR, Creeps
+		Bot: campaign
 	PlayerReference@USSR:
 		Name: USSR
 		AllowBots: False

--- a/mods/ra/maps/soviet-04a/map.yaml
+++ b/mods/ra/maps/soviet-04a/map.yaml
@@ -29,12 +29,14 @@ Players:
 		Faction: england
 		Allies: Greece
 		Enemies: USSR
+		Bot: campaign
 	PlayerReference@Greece:
 		Name: Greece
 		Faction: allies
 		Color: E2E6F5
 		Allies: Spain
 		Enemies: USSR
+		Bot: campaign
 	PlayerReference@USSR:
 		Name: USSR
 		Playable: True

--- a/mods/ra/maps/soviet-04b/map.yaml
+++ b/mods/ra/maps/soviet-04b/map.yaml
@@ -29,12 +29,14 @@ Players:
 		Faction: england
 		Allies: Greece
 		Enemies: USSR
+		Bot: campaign
 	PlayerReference@Greece:
 		Name: Greece
 		Faction: allies
 		Color: E2E6F5
 		Allies: Spain
 		Enemies: USSR
+		Bot: campaign
 	PlayerReference@USSR:
 		Name: USSR
 		Playable: True

--- a/mods/ra/maps/soviet-05/map.yaml
+++ b/mods/ra/maps/soviet-05/map.yaml
@@ -30,6 +30,7 @@ Players:
 		Color: E2E6F5
 		Allies: GoodGuy, France
 		Enemies: USSR
+		Bot: campaign
 	PlayerReference@USSR:
 		Name: USSR
 		Faction: soviet
@@ -48,12 +49,14 @@ Players:
 		Color: E2E6F5
 		Allies: Greece, France
 		Enemies: USSR
+		Bot: campaign
 	PlayerReference@France:
 		Name: France
 		Faction: allies
 		Color: 0CF7B2
 		Allies: Greece, GoodGuy
 		Enemies: USSR
+		Bot: campaign
 
 Actors:
 	Actor0: sbag

--- a/mods/ra/maps/soviet-06a/map.yaml
+++ b/mods/ra/maps/soviet-06a/map.yaml
@@ -29,6 +29,7 @@ Players:
 		Faction: allies
 		Color: E2E6F5
 		Enemies: USSR
+		Bot: campaign
 	PlayerReference@USSR:
 		Name: USSR
 		AllowBots: False

--- a/mods/ra/maps/soviet-06b/map.yaml
+++ b/mods/ra/maps/soviet-06b/map.yaml
@@ -29,6 +29,7 @@ Players:
 		Faction: allies
 		Color: E2E6F5
 		Enemies: USSR
+		Bot: campaign
 	PlayerReference@USSR:
 		Name: USSR
 		AllowBots: False

--- a/mods/ra/maps/soviet-07/map.yaml
+++ b/mods/ra/maps/soviet-07/map.yaml
@@ -35,6 +35,7 @@ Players:
 		Color: E2E6F5
 		Allies: Soviet
 		Enemies: USSR, Creeps
+		Bot: campaign
 	PlayerReference@USSR:
 		Name: USSR
 		AllowBots: False
@@ -53,10 +54,12 @@ Players:
 		Faction: soviet
 		Color: FE1100
 		Allies: USSR, Greece
+		Bot: campaign
 	PlayerReference@Spain:
 		Name: Spain
 		Faction: allies
 		Color: 0CBB4A
+		Bot: campaign
 
 Actors:
 	Actor0: boxes01

--- a/mods/ra/maps/soviet-08a/map.yaml
+++ b/mods/ra/maps/soviet-08a/map.yaml
@@ -42,12 +42,14 @@ Players:
 		Color: 505050
 		Allies: Greece
 		Enemies: USSR
+		Bot: campaign
 	PlayerReference@Greece:
 		Name: Greece
 		Faction: allies
 		Color: E2E6F6
 		Allies: Germany
 		Enemies: USSR
+		Bot: campaign
 
 Actors:
 	Actor0: brik

--- a/mods/ra/maps/soviet-soldier-volkov-n-chitzkoi/map.yaml
+++ b/mods/ra/maps/soviet-soldier-volkov-n-chitzkoi/map.yaml
@@ -35,6 +35,7 @@ Players:
 		Color: ABB7E4
 		Allies: Spain, France, GoodGuy
 		Enemies: USSR, Creeps
+		Bot: campaign
 	PlayerReference@USSR:
 		Name: USSR
 		AllowBots: False
@@ -53,18 +54,21 @@ Players:
 		Color: ABB7E4
 		Allies: Greece, Spain, France
 		Enemies: USSR, Creeps
+		Bot: campaign
 	PlayerReference@Spain:
 		Name: Spain
 		Faction: allies
 		Color: F6D679
 		Allies: Greece, GoodGuy, France
 		Enemies: USSR, Creeps
+		Bot: campaign
 	PlayerReference@France:
 		Name: France
 		Faction: allies
 		Color: 5DC2A5
 		Allies: Greece, GoodGuy, Spain
 		Enemies: USSR, Creeps
+		Bot: campaign
 
 Actors:
 	Actor0: cycl

--- a/mods/ra/maps/survival01/map.yaml
+++ b/mods/ra/maps/survival01/map.yaml
@@ -41,6 +41,7 @@ Players:
 		Faction: soviet
 		Color: FF0101
 		Enemies: Allies
+		Bot: campaign
 
 Actors:
 	Actor113: fenc

--- a/mods/ra/maps/survival02/map.yaml
+++ b/mods/ra/maps/survival02/map.yaml
@@ -41,6 +41,7 @@ Players:
 		Faction: soviet
 		Color: FF0101
 		Enemies: Allies
+		Bot: campaign
 
 Actors:
 	Actor0: tc05

--- a/mods/ra/rules/campaign-rules.yaml
+++ b/mods/ra/rules/campaign-rules.yaml
@@ -10,6 +10,9 @@ Player:
 	PlayerResources:
 		DefaultCashDropdownLocked: True
 		DefaultCash: 0
+	ModularBot@CampaignAI:
+		Name: Campaign Player AI
+		Type: campaign
 
 World:
 	CrateSpawner:


### PR DESCRIPTION
This PR defines a (so far) dummy "campaign" `ModularBot` instance, and sets all scripted players in missions to use it. This should restore the pre-fog-targeting behaviour, as bot-controlled units are allowed to keep pursuing targets that are hidden by fog/shroud.

Fixes #16020.
Fixes #16031.
Fixes #16078.