### PR TITLE
Fix CaptureManagerBotModule

### DIFF
--- a/OpenRA.Mods.Common/AIUtils.cs
+++ b/OpenRA.Mods.Common/AIUtils.cs
@@ -20,23 +20,6 @@ namespace OpenRA.Mods.Common
 
 	public enum WaterCheck { NotChecked, EnoughWater, NotEnoughWater }
 
-	public class CaptureTarget<TInfoType> where TInfoType : class, ITraitInfoInterface
-	{
-		internal readonly Actor Actor;
-		internal readonly TInfoType Info;
-
-		/// <summary>The order string given to the capturer so they can capture this actor.</summary>
-		/// <example>ExternalCaptureActor</example>
-		internal readonly string OrderString;
-
-		internal CaptureTarget(Actor actor, string orderString)
-		{
-			Actor = actor;
-			Info = actor.Info.TraitInfoOrDefault<TInfoType>();
-			OrderString = orderString;
-		}
-	}
-
 	public static class AIUtils
 	{
 		public static bool IsAreaAvailable<T>(World world, Player player, Map map, int radius, HashSet<string> terrainTypes)

--- a/OpenRA.Mods.Common/Traits/BotModules/CaptureManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/CaptureManagerBotModule.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly World world;
 		readonly Player player;
 		readonly Func<Actor, bool> isEnemyUnit;
-		readonly Predicate<Actor> unitCannotBeOrdered;
+		readonly Predicate<Actor> unitCannotBeOrderedOrIsIdle;
 		readonly int maximumCaptureTargetOptions;
 		int minCaptureDelayTicks;
 
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 					&& !unit.Info.HasTraitInfo<HuskInfo>()
 					&& unit.Info.HasTraitInfo<ITargetableInfo>();
 
-			unitCannotBeOrdered = a => a.Owner != player || a.IsDead || !a.IsInWorld;
+			unitCannotBeOrderedOrIsIdle = a => a.Owner != player || a.IsDead || !a.IsInWorld || a.IsIdle;
 
 			maximumCaptureTargetOptions = Math.Max(1, Info.MaximumCaptureTargetOptions);
 		}
@@ -118,7 +118,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!Info.CapturingActorTypes.Any() || player.WinState != WinState.Undefined)
 				return;
 
-			activeCapturers.RemoveAll(unitCannotBeOrdered);
+			activeCapturers.RemoveAll(unitCannotBeOrderedOrIsIdle);
 
 			var newUnits = world.ActorsHavingTrait<IPositionable>()
 				.Where(a => a.Owner == player && !activeCapturers.Contains(a));


### PR DESCRIPTION
Fixes #16102.
Also fixes that capturers who got ordered once would never be re-used again.

Testcase makes RA Rush AI use engineers to capture oil derricks, recommended test map is Tournament Island.