### PR TITLE
Allow PortableChrono to queue teleports

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/Teleport.cs
+++ b/OpenRA.Mods.Cnc/Activities/Teleport.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Cnc.Activities
 		public override Activity Tick(Actor self)
 		{
 			var pc = self.TraitOrDefault<PortableChrono>();
-			if (teleporter == self && pc != null && !pc.CanTeleport)
+			if (teleporter == self && pc != null && (!pc.CanTeleport || IsCanceling))
 			{
 				if (killOnFailure)
 					self.Kill(teleporter, killDamageTypes);


### PR DESCRIPTION
This fixes issue #16106.
It also adresses some concerns expressed in  issue #13105.

What this changes:
- Chronotanks can now be issued queued teleport orders.
-  If ordered to teleport outside of its range, the unit will now first move into teleport range and then teleport.
- If the unit is not able to teleport (because it is charging) it will fall back to a normal move instead. 
- When ordered to teleport, the unit displays a target line in the same color as the teleport range circle.
- All of the above works for both ForceMove orders and deploy orders.

This still does not allow the deploy hotkey to be used.