### PR TITLE
Reduce thief speed and engineer CaptureDelay

### DIFF
--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -276,7 +276,7 @@ E6:
 		RequiresCondition: !global-reusable-engineers
 		CaptureTypes: building
 		PlayerExperience: 25
-		CaptureDelay: 200
+		CaptureDelay: 125
 	Captures@REUSABLE:
 		RequiresCondition: global-reusable-engineers
 		CaptureTypes: building
@@ -606,7 +606,7 @@ THF:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical
 	Mobile:
-		Speed: 85
+		Speed: 71
 
 SHOK:
 	Inherits: ^Soldier


### PR DESCRIPTION
Playtest [discussion](https://forum.openra.net/viewtopic.php?f=82&t=20826&start=22) on the engineer and thief changes had consensus that a) the engineer CaptureDelay is too long at 8 seconds, and b) the thief is too fast considering his new abilities.