### PR TITLE
Make RepairableNear inherit Repairable

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -128,7 +128,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (alwaysLand)
 				return true;
 
-			if (repairableInfo != null && repairableInfo.RepairBuildings.Contains(dest.Info.Name) && self.GetDamageState() != DamageState.Undamaged)
+			if (repairableInfo != null && repairableInfo.RepairActors.Contains(dest.Info.Name) && self.GetDamageState() != DamageState.Undamaged)
 				return true;
 
 			return rearmable != null && rearmable.Info.RearmActors.Contains(dest.Info.Name)

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (alwaysLand)
 				return true;
 
-			if (repairableInfo != null && repairableInfo.RepairBuildings.Contains(dest.Info.Name) && self.GetDamageState() != DamageState.Undamaged)
+			if (repairableInfo != null && repairableInfo.RepairActors.Contains(dest.Info.Name) && self.GetDamageState() != DamageState.Undamaged)
 				return true;
 
 			return rearmable != null && rearmable.Info.RearmActors.Contains(dest.Info.Name)

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -954,6 +954,7 @@
     <Compile Include="UpdateRules\Rules\20181215\RemovedAutoCarryallCircleTurnSpeed.cs" />
     <Compile Include="UpdateRules\Rules\20181215\ReplacedWithChargeAnimation.cs" />
     <Compile Include="UpdateRules\Rules\20181215\RefactorResourceLevelAnimating.cs" />
+    <Compile Include="UpdateRules\Rules\20190106\StreamlineRepairableTraits.cs" />
     <Compile Include="Traits\Player\PlayerResources.cs" />
     <Compile Include="UtilityCommands\DumpSequenceSheetsCommand.cs" />
     <Compile Include="Traits\Render\WithBuildingRepairDecoration.cs" />

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -473,7 +473,7 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			return (rearmableInfo != null && rearmableInfo.RearmActors.Contains(a.Info.Name))
-				|| (repairableInfo != null && repairableInfo.RepairBuildings.Contains(a.Info.Name));
+				|| (repairableInfo != null && repairableInfo.RepairActors.Contains(a.Info.Name));
 		}
 
 		public int MovementSpeed
@@ -513,7 +513,7 @@ namespace OpenRA.Mods.Common.Traits
 				yield return new Rearm(self, a, WDist.Zero);
 
 			// The ResupplyAircraft activity guarantees that we're on the helipad
-			if (repairableInfo != null && repairableInfo.RepairBuildings.Contains(name))
+			if (repairableInfo != null && repairableInfo.RepairActors.Contains(name))
 				yield return new Repair(self, a, WDist.Zero);
 		}
 

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20190106/StreamlineRepairableTraits.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20190106/StreamlineRepairableTraits.cs
@@ -1,0 +1,60 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class StreamlineRepairableTraits : UpdateRule
+	{
+		public override string Name { get { return "Streamline RepairableNear and Repairable"; } }
+		public override string Description
+		{
+			get
+			{
+				return "Renamed Repairable.RepairBuildings and RepairableNear.Buildings to RepairActors,\n" +
+				"for consistency with RearmActors (and since repairing at other actors should already be possible).\n" +
+				"Additionally, removed internal 'fix' and 'spen, syrd' default values.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			// Repairable isn't conditional or otherwise supports multiple traits, so LastChildMatching should be fine.
+			var repairableNode = actorNode.LastChildMatching("Repairable");
+			if (repairableNode != null)
+			{
+				var repairBuildings = repairableNode.LastChildMatching("RepairBuildings");
+				if (repairBuildings != null)
+					repairBuildings.RenameKey("RepairActors");
+				else
+					repairableNode.AddNode(new MiniYamlNode("RepairActors", "fix"));
+			}
+
+			// RepairableNear isn't conditional or otherwise supports multiple traits, so LastChildMatching should be fine.
+			var repairableNearNode = actorNode.LastChildMatching("RepairableNear");
+			if (repairableNearNode != null)
+			{
+				var repairBuildings = repairableNearNode.LastChildMatching("Buildings");
+				if (repairBuildings != null)
+					repairBuildings.RenameKey("RepairActors");
+				else
+					repairableNearNode.AddNode(new MiniYamlNode("RepairActors", "spen, syrd"));
+
+				var closeEnough = repairableNearNode.LastChildMatching("CloseEnough");
+				if (closeEnough == null)
+					repairableNearNode.AddNode(new MiniYamlNode("CloseEnough", "4c0"));
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -86,9 +86,8 @@ namespace OpenRA.Mods.Common.UpdateRules
 
 			new UpdatePath("release-20180923", "release-20181215", new UpdateRule[0]),
 
-			new UpdatePath("release-20181215", new UpdateRule[]
+			new UpdatePath("release-20181215", "playtest-20190106", new UpdateRule[]
 			{
-				// Bleed only changes here
 				new AddCarryableHarvester(),
 				new RenameEditorTilesetFilter(),
 				new DefineNotificationDefaults(),
@@ -113,6 +112,12 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveAttackIgnoresVisibility(),
 				new ReplacedWithChargeAnimation(),
 				new RefactorResourceLevelAnimating(),
+			}),
+
+			new UpdatePath("playtest-20190106", new UpdateRule[]
+			{
+				// Bleed only changes here
+				new StreamlineRepairableTraits(),
 			})
 		};
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -258,6 +258,7 @@
 	Targetable:
 		TargetTypes: Ground, Vehicle
 	Repairable:
+		RepairActors: fix
 	Passenger:
 		CargoType: Vehicle
 	ActorLostNotification:
@@ -309,7 +310,7 @@
 	Selectable:
 		Bounds: 24,24
 	Repairable:
-		RepairBuildings: hpad
+		RepairActors: hpad
 	Aircraft:
 		LandWhenIdle: false
 		AirborneCondition: airborne

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -188,7 +188,7 @@
 	HiddenUnderFog:
 	ActorLostNotification:
 	Repairable:
-		RepairBuildings: repair_pad
+		RepairActors: repair_pad
 	Guard:
 		Voice: Guard
 	Guardable:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -259,6 +259,7 @@
 		Condition: damaged
 		ValidDamageStates: Light, Medium, Heavy, Critical
 	Repairable:
+		RepairActors: fix
 	Chronoshiftable:
 	Passenger:
 		CargoType: Vehicle
@@ -512,6 +513,8 @@
 		Types: Ship
 	Chronoshiftable:
 	RepairableNear:
+		RepairActors: spen, syrd
+		CloseEnough: 4c0
 	GpsDot:
 		String: Ship
 	WithDamageOverlay:
@@ -603,7 +606,7 @@
 	Inherits: ^NeutralPlane
 	Inherits@2: ^GainsExperience
 	Repairable:
-		RepairBuildings: fix
+		RepairActors: fix
 
 ^Helicopter:
 	Inherits: ^Plane

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -749,7 +749,7 @@
 		Condition: damaged
 		ValidDamageStates: Light, Medium, Heavy, Critical
 	Repairable:
-		RepairBuildings: gadept
+		RepairActors: gadept
 		Voice: Move
 	Passenger:
 		CargoType: Vehicle
@@ -841,7 +841,7 @@
 	SelectionDecorations:
 		Palette: pips
 	Repairable:
-		RepairBuildings: gadept
+		RepairActors: gadept
 		Voice: Move
 	Aircraft:
 		AirborneCondition: airborne


### PR DESCRIPTION
And made various smaller improvements to `Repairable`.

There already was a lot of duplication between these traits.
Large step towards merging them.

Note: The reason I'm doing this intermediate step first instead of going all the way towards https://github.com/OpenRA/OpenRA/pull/15780#issuecomment-435584729 is - apart from reviewability - that the old property names are sort of blocking a rebase of a local branch.

I plan to follow up on this with a dedicated PR for the exit/docking stuff.