### PR TITLE
Increase FlyCircle ticks to 1 when idling

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/FlyCircle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyCircle.cs
@@ -29,6 +29,9 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
+			if (NextActivity != null && remainingTicks <= 0)
+				return NextActivity;
+
 			// Refuse to take off if it would land immediately again.
 			if (aircraft.ForceLanding)
 			{
@@ -41,8 +44,6 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (remainingTicks > 0)
 				remainingTicks--;
-			else if (remainingTicks == 0)
-				return NextActivity;
 
 			// We can't possibly turn this fast
 			var desiredFacing = aircraft.Facing + 64;


### PR DESCRIPTION
fixes issue #16134.

FlyCircle would run indefinitely and queued activities don't cancel a running activity, so changed FlyCircle to run 1 tick instead of infinite ticks. 