### PR TITLE
Add VolumeModifier support to music.

### DIFF
--- a/OpenRA.Game/GameRules/MusicInfo.cs
+++ b/OpenRA.Game/GameRules/MusicInfo.cs
@@ -19,6 +19,7 @@ namespace OpenRA.GameRules
 		public readonly string Filename;
 		public readonly string Title;
 		public readonly bool Hidden;
+		public readonly float VolumeModifier = 1f;
 
 		public int Length { get; private set; } // seconds
 		public bool Exists { get; private set; }
@@ -30,6 +31,9 @@ namespace OpenRA.GameRules
 			var nd = value.ToDictionary();
 			if (nd.ContainsKey("Hidden"))
 				bool.TryParse(nd["Hidden"].Value, out Hidden);
+
+			if (nd.ContainsKey("VolumeModifier"))
+				VolumeModifier = FieldLoader.GetValue<float>("VolumeModifier", nd["VolumeModifier"].Value);
 
 			var ext = nd.ContainsKey("Extension") ? nd["Extension"].Value : "aud";
 			Filename = (nd.ContainsKey("Filename") ? nd["Filename"].Value : key) + "." + ext;

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -214,7 +214,7 @@ namespace OpenRA
 
 			Func<ISoundFormat, ISound> stream = soundFormat => soundEngine.Play2DStream(
 				soundFormat.GetPCMInputStream(), soundFormat.Channels, soundFormat.SampleBits, soundFormat.SampleRate,
-				false, true, WPos.Zero, MusicVolume);
+				false, true, WPos.Zero, MusicVolume * m.VolumeModifier);
 			music = LoadSound(m.Filename, stream);
 
 			if (music == null)


### PR DESCRIPTION
This PR adds the engine support for #14231.  I don't have the expansion sound files to test with, so I will leave the yaml changes to @reaperrr of @dan9550.

Note that we cannot reliably boost volume using modifiers > 1, and will instead need to reduce the volume of all tracks, with the noted tracks reduced less.

Quote from the OpenAL 1.1 specification:
> AL_GAIN larger than one (i.e. amplification) is permitted for source and listener. However, the implementation is free to clamp the total gain (effective gain per-sourcemultiplied by the listener gain) to one to prevent overflow

On my system VolumeModifiers > 1 appear to make no difference, so it seems that macOS is clamping the total gain to one.