### PR TITLE
Fix D2k bots wasting cash on building repairs

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/BuildingRepairBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BuildingRepairBotModule.cs
@@ -26,6 +26,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		void IBotRespondToAttack.RespondToAttack(IBot bot, Actor self, AttackInfo e)
 		{
+			// HACK: We don't want D2k bots to repair all their buildings on placement
+			// where half their HP is removed via neutral terrain damage.
+			// TODO: Implement concrete placement for D2k bots and remove this hack.
+			if (e.Attacker.Owner.Stances[self.Owner] == Stance.Neutral)
+				return;
+
 			var rb = self.TraitOrDefault<RepairableBuilding>();
 			if (rb != null)
 			{


### PR DESCRIPTION
D2k bots not repairing buildings when damaged due to placement without concrete (damage is dealt by 'neutral') was intentional, and this was actually bleed's default behavior before `BuildingRepairBotModule` got introduced, too.

Fixes #16063.