### PR TITLE
Prefer target to lastVisible target if it is visible.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -195,8 +195,10 @@ namespace OpenRA.Mods.Common.Activities
 					return AttackStatus.UnableToAttack;
 
 				attackStatus |= AttackStatus.NeedsToMove;
+
+				var checkTarget = useLastVisibleTarget ? lastVisibleTarget : target;
 				moveActivity = ActivityUtils.SequenceActivities(
-					move.MoveWithinRange(target, minRange, maxRange, lastVisibleTarget.CenterPosition, Color.Red),
+					move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, Color.Red),
 					this);
 
 				return AttackStatus.NeedsToMove;


### PR DESCRIPTION
This PR changes `Attack.TickAttack` to use the standard `checkTarget` pattern instead of blindly using `lastVisibleTarget` even when the primary `target` is visible. 

This should fix #16143 even without having a specific repro case for it.