### PR TITLE
Consider dead aircraft to no longer be in range in AirstrikePower and ParatroopersPower

### DIFF
--- a/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
@@ -106,6 +106,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			Action<Actor> onRemovedFromWorld = a =>
 			{
+				aircraftInRange[a] = false;
+
 				// Checking for attack range is not relevant here because
 				// aircraft may be shot down before entering. Thus we remove
 				// the camera and beacon only if the whole squad is dead.

--- a/OpenRA.Mods.Common/Traits/SupportPowers/ParatroopersPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/ParatroopersPower.cs
@@ -133,6 +133,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			Action<Actor> onRemovedFromWorld = a =>
 			{
+				aircraftInRange[a] = false;
+
 				// Checking for attack range is not relevant here because
 				// aircraft may be shot down before entering. Thus we remove
 				// the camera and beacon only if the whole squad is dead.


### PR DESCRIPTION
Fixes #16137 

Dead aircraft weren't removed from the `aircraftInRange` array, so when the last aircraft leaves the range, it still thinks there are aircraft in range and the camera doesn't get removed.