### PR TITLE
Normalize RA/TD track volumes

### DIFF
--- a/mods/cnc/audio/music.yaml
+++ b/mods/cnc/audio/music.yaml
@@ -1,66 +1,89 @@
 aoi: Act On Instinct
+	VolumeModifier: 0.65
 airstrik: Air Strike
+	VolumeModifier: 0.9
 ccthang: C&C Thang
+	VolumeModifier: 0.7
 ind2: Canyon Chase (Industrial 2)
+	VolumeModifier: 0.7
 heavyg: Demolition (Heavy Gear)
+	VolumeModifier: 0.7
 fwp: Fight Win Prevail
+	VolumeModifier: 0.7
 warfare: Full Stop (Warfare)
+	VolumeModifier: 0.6
 win1: Great Shot!
 	Hidden: true
+	VolumeModifier: 0.7
 win2: Great Shot! (SFX)
 	Filename: win1
 	Extension: var
 	Hidden: true
 iam: I Am - Times (Credits)
+	VolumeModifier: 0.6
 ind: Industrial
+	VolumeModifier: 0.65
 linefire: In The Line Of Fire
+	VolumeModifier: 0.7
 trouble: In Trouble
+	VolumeModifier: 0.65
 justdoit: Just Do It Up
+	VolumeModifier: 0.7
 justdoit2: Just Do It Up (SFX)
 	Filename: justdoit
 	Extension: var
+	VolumeModifier: 0.7
 jdi_v2: Just Do It Up 2 (Take 'Em Out)
+	VolumeModifier: 0.65
 map1: Map Theme
 	Hidden: true
+	VolumeModifier: 0.7
 march: March To Doom
+	VolumeModifier: 0.7
 nod_map1: Nod Map Theme
 	Hidden: true
 nod_win1: Nod Win Theme
 	Hidden: true
+	VolumeModifier: 0.9
 nomercy: No Mercy
+	VolumeModifier: 0.7
 nomercy2: No Mercy (SFX)
 	Filename: nomercy
 	Extension: var
+	VolumeModifier: 0.7
 otp: On The Prowl
+	VolumeModifier: 0.7
 outtakes: Outtakes (Censored)
 	Hidden: true
+	VolumeModifier: 0.65
 prp: Prepare For Battle
+	VolumeModifier: 0.6
 radio: Radio
+	VolumeModifier: 0.7
 rain: Rain In The Night
+	VolumeModifier: 0.7
 target: Target (Mechanical Man)
+	VolumeModifier: 0.7
 j1: Untamed Land (Jungle)
+	VolumeModifier: 0.7
 valkyrie: Ride Of The Valkyries
 	Hidden: true
 stopthem: We Will Stop Them (Deception)
+	VolumeModifier: 0.7
 deception: We Will Stop Them (SFX)
 	Filename: stopthem
 	Extension: var
-
-# Covert Operations tracks
+	VolumeModifier: 0.7
 aoi2: Act On Instinct (SFX)
 	Filename: aoi
 	Extension: var
 befeared: To Be Feared
+	VolumeModifier: 0.65
 befeared2: To Be Feared (SFX)
 	Filename: befeared
 	Extension: var
-80mx226m: C&C 80's Mix
-crep226m: Creeping Upon
-chrg226m: Depth Charge
 die: Die
-dril226m: Drill
-dron226m: Drone
-fist226m: Iron Fist
+	VolumeModifier: 0.6
 heart: Heartbreak
 	Extension: var
 trouble2: In Trouble (SFX)
@@ -68,5 +91,20 @@ trouble2: In Trouble (SFX)
 	Extension: var
 rout: Reaching Out
 	Extension: var
+
+# Covert Operations tracks
+80mx226m: C&C 80's Mix
+crep226m: Creeping Upon
+	VolumeModifier: 0.9
+chrg226m: Depth Charge
+	VolumeModifier: 0.9
+dril226m: Drill
+	VolumeModifier: 0.7
+dron226m: Drone
+	VolumeModifier: 0.9
+fist226m: Iron Fist
+	VolumeModifier: 0.85
 recn226m: Recon
+	VolumeModifier: 0.8
 voic226m: Voice Rhythm
+	VolumeModifier: 0.8

--- a/mods/ra/audio/music.yaml
+++ b/mods/ra/audio/music.yaml
@@ -1,43 +1,74 @@
 await_r: Afterlife (Await)
+	VolumeModifier: 0.7
 bigf226m: Bigfoot
+	VolumeModifier: 0.7
 crus226m: Crush
+	VolumeModifier: 0.7
 dense_r: Dense
+	VolumeModifier: 0.7
 fac1226m: Face to the Enemy 1
+	VolumeModifier: 0.85
 fac2226m: Face to the Enemy 2
+	VolumeModifier: 0.7
 fogger1a: Fogger
+	VolumeModifier: 0.8
 hell226m: Hell March
+	VolumeModifier: 0.7
 intro: Intro
 	Hidden: true
+	VolumeModifier: 0.9
 map: Map
 	Hidden: true
+	VolumeModifier: 0.6
 mud1a: Mud
+	VolumeModifier: 0.7
 radio2: Radio 2
+	VolumeModifier: 0.7
 credits: Reload Fire (Credits)
+	VolumeModifier: 0.9
 rollout: Roll Out
+	VolumeModifier: 0.7
 run1226m: Run (For Your Life)
+	VolumeModifier: 0.7
 score: Militant Force (Scores)
 	Hidden: true
+	VolumeModifier: 0.7
 smsh226m: Smash
+	VolumeModifier: 0.7
 snake: Snake
+	VolumeModifier: 0.7
 terminat: Terminate
+	VolumeModifier: 0.7
 tren226m: Trenches
+	VolumeModifier: 0.7
 twin: Twin Cannon
+	VolumeModifier: 0.7
 vector1a: Vector
+	VolumeModifier: 0.7
 work226m: Workmen
+	VolumeModifier: 0.7
 
 # Counterstrike tracks
 araziod: Arazoid
+	VolumeModifier: 0.8
 backstab: Backstab
+	VolumeModifier: 0.9
 chaos2: Chaos
+	VolumeModifier: 0.9
 shut_it: Shut It
+	VolumeModifier: 0.9
 2nd_hand: The Second Hand
 twinmix1: Twin Cannon (Remix)
+	VolumeModifier: 0.9
 under3: Underlying Thoughts
+	VolumeModifier: 0.95
 vr2: Voice Rhythm 2
+	VolumeModifier: 0.95
 
 # Aftermath tracks
 await: Afterlife (Await)
 bog: Bog
+	VolumeModifier: 0.9
 float_v2: Floating
 gloom: Gloom
 grndwire: Groundwire


### PR DESCRIPTION
Fixes #14231 for TD and RA, roughly based on @dan9550's ReplayGain values.

I also went through the D2k and TS tracks by ear, but in my opinion there aren't any outliers in them that justify touching these.

Also manually tested the tracks mentioned in #16140.
The 3 sfx tracks have nearly identical volume to their non-sfx counterparts.
Outtakes has a similar volume, too.

Furthermore, some TD tracks from the original were falsely listed under CovOps.
Only tracks with 226m in their filename are cov ops tracks.