### PR TITLE
Add AI-only search radius overrides to Harvester

### DIFF
--- a/OpenRA.Mods.Common/Activities/FindResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindResources.cs
@@ -115,7 +115,9 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Determine where to search from and how far to search:
 			var searchFromLoc = GetSearchFromLocation(self);
-			var searchRadius = harv.LastOrderLocation.HasValue ? harvInfo.SearchFromOrderRadius : harvInfo.SearchFromProcRadius;
+			var fromOrderRadius = (self.Owner.IsBot || !self.Owner.Playable) ? harv.AIFromOrderScanRadius : harvInfo.SearchFromOrderRadius;
+			var fromRefineryRadius = (self.Owner.IsBot || !self.Owner.Playable) ? harv.AIFromRefineryScanRadius : harvInfo.SearchFromRefineryRadius;
+			var searchRadius = harv.LastOrderLocation.HasValue ? fromOrderRadius : fromRefineryRadius;
 			var searchRadiusSquared = searchRadius * searchRadius;
 
 			// Find any harvestable resources:

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -613,6 +613,7 @@
     <Compile Include="UpdateRules\Rules\20190106\MultipleDeploySounds.cs" />
     <Compile Include="UpdateRules\Rules\20190106\RemoveSimpleBeacon.cs" />
     <Compile Include="UtilityCommands\CheckRuntimeAssembliesCommand.cs" />
+    <Compile Include="UpdateRules\Rules\20190106\RenameSearchFromProcRadius.cs" />
     <Compile Include="UtilityCommands\CheckYaml.cs" />
     <Compile Include="UtilityCommands\ConvertPngToShpCommand.cs" />
     <Compile Include="UtilityCommands\ConvertSpriteToPngCommand.cs" />

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -56,11 +56,20 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Automatically scan for resources when created.")]
 		public readonly bool SearchOnCreation = true;
 
-		[Desc("Initial search radius (in cells) from the refinery that created us.")]
-		public readonly int SearchFromProcRadius = 24;
+		[Desc("Initial search radius (in cells) from the refinery (or factory) that created us.",
+			"Also used to perform fallback scan if nothing is found within SearchFromOrderRadius.")]
+		public readonly int SearchFromRefineryRadius = 24;
 
 		[Desc("Search radius (in cells) from the last harvest order location to find more resources.")]
 		public readonly int SearchFromOrderRadius = 12;
+
+		[Desc("AI override for initial search radius (in cells) from the refinery (or factory) that created us.",
+			"Negative values make it default to the normal SearchFromRefineryRadius.")]
+		public readonly int SearchFromRefineryRadiusAI = -1;
+
+		[Desc("AI override for search radius (in cells) from the last harvest order location to find more resources.",
+			"Negative values make it default to the normal SearchFromOrderRadius.")]
+		public readonly int SearchFromOrderRadiusAI = -1;
 
 		[Desc("Maximum duration of being idle before queueing a Wait activity.")]
 		public readonly int MaxIdleDuration = 25;
@@ -105,6 +114,22 @@ namespace OpenRA.Mods.Common.Traits
 		[Sync] int currentUnloadTicks;
 		public CPos? LastHarvestedCell = null;
 		public CPos? LastOrderLocation = null;
+
+		public int AIFromOrderScanRadius
+		{
+			get
+			{
+				return Info.SearchFromOrderRadiusAI > -1 ? Info.SearchFromOrderRadiusAI : Info.SearchFromOrderRadius;
+			}
+		}
+
+		public int AIFromRefineryScanRadius
+		{
+			get
+			{
+				return Info.SearchFromRefineryRadiusAI > -1 ? Info.SearchFromRefineryRadiusAI : Info.SearchFromRefineryRadius;
+			}
+		}
 
 		[Sync]
 		public int ContentValue

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20190106/RenameSearchFromProcRadius.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20190106/RenameSearchFromProcRadius.cs
@@ -1,0 +1,36 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RenameSearchFromProcRadius : UpdateRule
+	{
+		public override string Name { get { return "SearchFromProcRadius renamed to SearchFromRefineryRadius"; } }
+		public override string Description
+		{
+			get
+			{
+				return "'Proc' is the RA abbreviation for [Ore] Processor.\n" +
+					"'Refinery' is the established generic name for where harvesters dump their resources.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var harv in actorNode.ChildrenMatching("Harvester"))
+				harv.RenameChildrenMatching("SearchFromProcRadius", "SearchFromRefineryRadius");
+
+			yield break;
+		}
+	}
+}

--- a/mods/cnc/maps/gdi02/rules.yaml
+++ b/mods/cnc/maps/gdi02/rules.yaml
@@ -19,11 +19,6 @@ CYCL:
 	Buildable:
 		Prerequisites: ~disabled
 
-HARV:
-	Harvester:
-		SearchFromProcRadius: 32
-		SearchFromOrderRadius: 20
-
 PROC:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/cnc/maps/gdi05a/rules.yaml
+++ b/mods/cnc/maps/gdi05a/rules.yaml
@@ -72,8 +72,6 @@ RMBO:
 		Prerequisites: ~disabled
 
 HARV:
-	Harvester:
-		SearchFromOrderRadius: 24
 	Buildable:
 		Prerequisites: ~disabled
 

--- a/mods/cnc/maps/nod05/rules.yaml
+++ b/mods/cnc/maps/nod05/rules.yaml
@@ -90,8 +90,6 @@ ATWR:
 HARV:
 	Buildable:
 		Prerequisites: ~disabled
-	Harvester:
-		SearchFromOrderRadius: 24
 
 FTNK:
 	Buildable:

--- a/mods/cnc/maps/nod06a/rules.yaml
+++ b/mods/cnc/maps/nod06a/rules.yaml
@@ -27,10 +27,6 @@ Player:
 ^Infantry:
 	AnnounceOnSeen:
 
-HARV:
-	Harvester:
-		SearchFromProcRadius: 64
-
 FLARE:
 	Tooltip:
 		ShowOwnerRow: false

--- a/mods/cnc/maps/nod07a/rules.yaml
+++ b/mods/cnc/maps/nod07a/rules.yaml
@@ -65,10 +65,6 @@ E5:
 E6:
 	-RepairsBridges:
 
-HARV:
-	Harvester:
-		SearchFromOrderRadius: 45
-
 HTNK:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/cnc/maps/nod07b/rules.yaml
+++ b/mods/cnc/maps/nod07b/rules.yaml
@@ -61,10 +61,6 @@ E5:
 	Buildable:
 		Prerequisites: ~disabled
 
-HARV:
-	Harvester:
-		SearchFromOrderRadius: 45
-
 MTNK:
 	Buildable:
 		Prerequisites: ~weap

--- a/mods/cnc/maps/nod07c/rules.yaml
+++ b/mods/cnc/maps/nod07c/rules.yaml
@@ -68,10 +68,6 @@ E5:
 	Buildable:
 		Prerequisites: ~disabled
 
-HARV:
-	Harvester:
-		SearchFromOrderRadius: 30
-
 HTNK:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/cnc/maps/nod08a/rules.yaml
+++ b/mods/cnc/maps/nod08a/rules.yaml
@@ -78,10 +78,6 @@ E5:
 E6:
 	-RepairsBridges:
 
-HARV:
-	Harvester:
-		SearchFromOrderRadius: 30
-
 MTNK:
 	Buildable:
 		Prerequisites: ~weap

--- a/mods/cnc/maps/nod08b/rules.yaml
+++ b/mods/cnc/maps/nod08b/rules.yaml
@@ -95,10 +95,6 @@ E5:
 E6:
 	-RepairsBridges:
 
-HARV:
-	Harvester:
-		SearchFromOrderRadius: 30
-
 MTNK:
 	Buildable:
 		Prerequisites: ~weap

--- a/mods/cnc/maps/nod09/rules.yaml
+++ b/mods/cnc/maps/nod09/rules.yaml
@@ -83,10 +83,6 @@ E5:
 	Buildable:
 		Prerequisites: ~disabled
 
-HARV:
-	Harvester:
-		SearchFromOrderRadius: 45
-
 HTNK:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -64,7 +64,7 @@ HARV:
 		Capacity: 20
 		BaleLoadDelay: 12
 		BaleUnloadDelay: 6
-		SearchFromProcRadius: 25
+		SearchFromRefineryRadius: 25
 		SearchFromOrderRadius: 15
 		EmptyCondition: no-tiberium
 	Mobile:

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -66,6 +66,8 @@ HARV:
 		BaleUnloadDelay: 6
 		SearchFromRefineryRadius: 25
 		SearchFromOrderRadius: 15
+		SearchFromRefineryRadiusAI: 60
+		SearchFromOrderRadiusAI: 30
 		EmptyCondition: no-tiberium
 	Mobile:
 		Speed: 85

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -73,6 +73,8 @@ harvester:
 		BaleUnloadDelay: 5
 		SearchFromRefineryRadius: 30
 		SearchFromOrderRadius: 15
+		SearchFromRefineryRadiusAI: 60
+		SearchFromOrderRadiusAI: 30
 	CarryableHarvester:
 	Health:
 		HP: 45000

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -71,7 +71,7 @@ harvester:
 		HarvestFacings: 8
 		Resources: Spice
 		BaleUnloadDelay: 5
-		SearchFromProcRadius: 30
+		SearchFromRefineryRadius: 30
 		SearchFromOrderRadius: 15
 	CarryableHarvester:
 	Health:

--- a/mods/ra/maps/soviet-02a/rules.yaml
+++ b/mods/ra/maps/soviet-02a/rules.yaml
@@ -88,11 +88,6 @@ AFLD:
 	ParatroopersPower@paratroopers:
 		Prerequisites: ~disabled
 
-HARV:
-	Harvester:
-		SearchFromProcRadius: 50
-		SearchFromOrderRadius: 50
-
 powerproxy.paratroopers:
 	ParatroopersPower:
 		DropItems: E2,E2,E2,E2,E2

--- a/mods/ra/maps/soviet-02b/rules.yaml
+++ b/mods/ra/maps/soviet-02b/rules.yaml
@@ -92,11 +92,6 @@ GUN:
 	-RepairableBuilding:
 	-WithBuildingRepairDecoration:
 
-HARV:
-	Harvester:
-		SearchFromProcRadius: 50
-		SearchFromOrderRadius: 50
-
 powerproxy.paratroopers:
 	ParatroopersPower:
 		DropItems: E1,E1,E2,E2,E2

--- a/mods/ra/maps/soviet-06a/rules.yaml
+++ b/mods/ra/maps/soviet-06a/rules.yaml
@@ -142,11 +142,6 @@ MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 
-HARV:
-	Harvester:
-		SearchFromProcRadius: 50
-		SearchFromOrderRadius: 50
-
 AFLD:
 	ParatroopersPower@paratroopers:
 		DropItems: E1,E1,E1,E1,E1

--- a/mods/ra/maps/soviet-06b/rules.yaml
+++ b/mods/ra/maps/soviet-06b/rules.yaml
@@ -142,11 +142,6 @@ MNLY:
 	Buildable:
 		Prerequisites: ~disabled
 
-HARV:
-	Harvester:
-		SearchFromProcRadius: 50
-		SearchFromOrderRadius: 50
-
 AFLD:
 	ParatroopersPower@paratroopers:
 		DropItems: E1,E1,E1,E1,E1

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -307,7 +307,7 @@ HARV:
 		Capacity: 20
 		Resources: Ore,Gems
 		BaleUnloadDelay: 1
-		SearchFromProcRadius: 30
+		SearchFromRefineryRadius: 30
 		SearchFromOrderRadius: 11
 		EmptyCondition: no-ore
 	Health:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -309,6 +309,8 @@ HARV:
 		BaleUnloadDelay: 1
 		SearchFromRefineryRadius: 30
 		SearchFromOrderRadius: 11
+		SearchFromRefineryRadiusAI: 60
+		SearchFromOrderRadiusAI: 30
 		EmptyCondition: no-ore
 	Health:
 		HP: 60000

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -338,7 +338,7 @@ WEED:
 		Resources: Veins
 		BaleUnloadDelay: 20
 		BaleLoadDelay: 40
-		SearchFromProcRadius: 72
+		SearchFromRefineryRadius: 72
 		SearchFromOrderRadius: 36
 		HarvestVoice: Attack
 		DeliverVoice: Move

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -63,7 +63,7 @@ HARV:
 		BaleLoadDelay: 15
 		BaleUnloadDelay: 15
 		FullyLoadedSpeed: 100
-		SearchFromProcRadius: 36
+		SearchFromRefineryRadius: 36
 		SearchFromOrderRadius: 18
 		HarvestVoice: Attack
 		DeliverVoice: Move

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -65,6 +65,8 @@ HARV:
 		FullyLoadedSpeed: 100
 		SearchFromRefineryRadius: 36
 		SearchFromOrderRadius: 18
+		SearchFromRefineryRadiusAI: 72
+		SearchFromOrderRadiusAI: 36
 		HarvestVoice: Attack
 		DeliverVoice: Move
 		EmptyCondition: no-tiberium


### PR DESCRIPTION
The performance difference between `HarvesterManagerBotModule`'s resource scan logic for idle harvesters and regular `FindResources` activity is massive, so for AI, (much) higher regular scan radii would be better, to degrade the expensive map-wide fallback scan from the module to a rare occurence.

We cannot increase the regular scan radii though, as gameplay for human players relies on harvesters becoming idle when nearby fields are depleted (instead of running off to a distant field near the enemy), so AI-only overrides are the best of both worlds. We already take the same approach on `AutoTarget`'s `InitialStanceAI`, for example.

Additionally, this allows us to drop all those custom scan radii values from TD and RA singleplayer missions.

Closes #16163.