### PR TITLE
Support multiple QuickDownloads

### DIFF
--- a/OpenRA.Mods.Common/ModContent.cs
+++ b/OpenRA.Mods.Common/ModContent.cs
@@ -83,7 +83,7 @@ namespace OpenRA
 		}
 
 		public readonly string InstallPromptMessage;
-		public readonly string QuickDownload;
+		public readonly string[] QuickDownloads = { };
 		public readonly string HeaderMessage;
 		public readonly string ContentInstallerMod = "modcontent";
 

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -242,7 +242,7 @@ ColorValidator:
 
 ModContent:
 	InstallPromptMessage: Tiberian Dawn requires artwork and audio from the original game.\n\nQuick Install will automatically download this content (without music\nor videos) from a mirror of the 2007 C&C Gold freeware release.\n\nAdvanced Install includes options for downloading the music and for\ncopying the videos and other content from an original game disc.
-	QuickDownload: basefiles
+	QuickDownloads: basefiles
 	HeaderMessage: Game content may be extracted from the original game discs or an\nexisting digital install. OpenRA can also download the base game\nfiles from an online mirror of the 2007 freeware release of C&C.
 	Packages:
 		base: Base Game Files

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -220,7 +220,7 @@ ColorValidator:
 ModContent:
 	InstallPromptMessage: Dune 2000 requires artwork and audio from the original game.\n\nQuick Install will automatically download this content (without\nmusic or videos) from an online mirror of the game files.\n\nAdvanced Install includes options for copying the music, videos,\nand other content from an original game disc.
 	HeaderMessage: The original game content may be copied from an original game disc,\nor downloaded from an online mirror of the game files.
-	QuickDownload: quickinstall
+	QuickDownloads: quickinstall
 	Packages:
 		base: Base Game Files
 			TestFiles: ^Content/d2k/v2/BLOXBASE.R8, ^Content/d2k/v2/BLOXBAT.R8, ^Content/d2k/v2/BLOXBGBS.R8, ^Content/d2k/v2/BLOXICE.R8, ^Content/d2k/v2/BLOXTREE.R8, ^Content/d2k/v2/BLOXWAST.R8, ^Content/d2k/v2/SOUND.RS, ^Content/d2k/v2/PALETTE.BIN, ^Content/d2k/v2/FONT.BIN,  ^Content/d2k/v2/FONTCOL.FNT,  ^Content/d2k/v2/FONTCOL.FPL

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -244,7 +244,7 @@ ColorValidator:
 
 ModContent:
 	InstallPromptMessage: Red Alert requires artwork and audio from the original game.\n\nQuick Install will automatically download this content (without music\nor videos) from a mirror of the 2008 Red Alert freeware release.\n\nAdvanced Install includes options for downloading the music and for\ncopying the videos and other content from an original game disc.
-	QuickDownload: quickinstall
+	QuickDownloads: quickinstall
 	HeaderMessage: Game content may be extracted from the original game discs or an\nexisting digital install. OpenRA can also download the base game\nfiles from an online mirror of the 2008 freeware release of RA.
 	Packages:
 		base: Base Game Files

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -280,7 +280,7 @@ ColorValidator:
 
 ModContent:
 	InstallPromptMessage: Tiberian Sun requires artwork and audio from the original game.\n\nQuick Install will automatically download this content (without music\nor videos) from a mirror of the 2012 Tiberian Sun freeware release.\n\nAdvanced Install includes options for downloading the music and for\ncopying the videos and other content from an original game disc.
-	QuickDownload: quickinstall
+	QuickDownloads: quickinstall
 	HeaderMessage: Game content may be extracted from the original game discs or an\nexisting digital install. OpenRA can also download the base game\nfiles from an online mirror of the 2012 freeware release of TS.
 	Packages:
 		tibsun: Base Game Files


### PR DESCRIPTION
My mod has the base game files (demo release) and extra addon files released by the developer. The addon files have a distinct license so I would like to keep the packages separate.

I've changed ModContent>QuickDownload to QuickDownloads (string > string[]). When pressing Quick Install, the download process will install each package sequentially with a window shown for each. Cancelling any download will return to the main prompt window, and Quick Installing again will restart all downloads from the beginning.