### PR TITLE
Added player viewport tracking

### DIFF
--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -48,10 +48,13 @@ namespace OpenRA.Graphics
 
 		public WPos CenterPosition { get { return worldRenderer.ProjectedPosition(CenterLocation); } }
 
-		public Rectangle Rectangle { get { return new Rectangle(TopLeft, new Size(viewportSize.X, viewportSize.Y)); } }
-		public int2 TopLeft { get { return CenterLocation - viewportSize / 2; } }
-		public int2 BottomRight { get { return CenterLocation + viewportSize / 2; } }
-		int2 viewportSize;
+		public int2 ViewportSize { get; private set; }
+
+		public int2 TopLeft { get { return CenterLocation - ViewportSize / 2; } }
+
+		public int2 BottomRight { get { return CenterLocation + ViewportSize / 2; } }
+
+		public Rectangle Rectangle { get { return new Rectangle(TopLeft, new Size(ViewportSize.X, ViewportSize.Y)); } }
 
 		public bool IsMovementLocked { get; set; }
 		public bool IsZoomingLocked { get; set; }
@@ -82,7 +85,7 @@ namespace OpenRA.Graphics
 			private set
 			{
 				zoom = value;
-				viewportSize = (1f / zoom * new float2(Game.Renderer.NativeResolution)).ToInt2();
+				ViewportSize = (1f / zoom * new float2(Game.Renderer.NativeResolution)).ToInt2();
 				cellsDirty = true;
 				allCellsDirty = true;
 			}

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -84,6 +84,11 @@ namespace OpenRA.Graphics
 			}
 		}
 
+		public void SetZoom(float newValue)
+		{
+			Zoom = newValue;
+		}
+
 		public void AdjustZoom(float dz)
 		{
 			// Exponential ensures that equal positive and negative steps have the same effect

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -67,6 +67,8 @@ namespace OpenRA
 		public int SpawnPoint;
 		public bool HasObjectives = false;
 		public bool Spectating;
+		public int2 ViewportTopLeft;
+		public int2 ViewportBottomRight;
 
 		public World World { get; private set; }
 

--- a/OpenRA.Game/Traits/Player/ViewportTracker.cs
+++ b/OpenRA.Game/Traits/Player/ViewportTracker.cs
@@ -1,0 +1,74 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Graphics;
+
+namespace OpenRA.Traits
+{
+	[Desc("Tracks the position of the player's viewport.", " Attach this to the player actor.")]
+	public class ViewportTrackerInfo : ITraitInfo
+	{
+		public object Create(ActorInitializer init) { return new ViewportTracker(); }
+	}
+
+	public class ViewportTracker : ITick, IResolveOrder, IWorldLoaded
+	{
+		static WorldRenderer worldRenderer;
+
+		public void WorldLoaded(World w, WorldRenderer wr)
+		{
+			worldRenderer = wr;
+		}
+
+		void ITick.Tick(Actor self)
+		{
+			if (self.Owner.IsBot || !self.Owner.Playable || self.Owner != self.World.LocalPlayer || worldRenderer == null)
+				return;
+
+			var centerPosition = worldRenderer.Viewport.CenterPosition;
+			var viewportSize = worldRenderer.Viewport.ViewportSize;
+			var zoom = worldRenderer.Viewport.Zoom;
+
+			self.World.IssueOrder(new Order("ViewportState", self, false)
+			{
+				IsImmediate = false,
+				TargetString = "{0},{1},{2},{3},{4},{5},{6}".F(self.ActorID, centerPosition.X, centerPosition.Y, centerPosition.Z, viewportSize.X, viewportSize.Y, zoom)
+			});
+		}
+
+		public void ResolveOrder(Actor self, Order order)
+		{
+			if (order.OrderString != "ViewportState")
+				return;
+
+			int x, y, z;
+			var numbers = order.TargetString.Split(',');
+			var playerId = int.Parse(numbers[0]);
+
+			x = int.Parse(numbers[1]);
+			y = int.Parse(numbers[2]);
+			z = int.Parse(numbers[3]);
+			var centerPosition = new WPos(x, y, z);
+
+			x = int.Parse(numbers[4]);
+			y = int.Parse(numbers[5]);
+			var viewportSize = new int2(x, y);
+
+			var zoom = float.Parse(numbers[6]);
+
+			var player = self.World.Players.First(p => p.PlayerActor.ActorID == playerId);
+			var screenCenterPosition = worldRenderer.ScreenPxPosition(centerPosition);
+			player.ViewportTopLeft = screenCenterPosition - viewportSize / 2;
+			player.ViewportBottomRight = screenCenterPosition + viewportSize / 2;
+		}
+	}
+}

--- a/OpenRA.Game/Traits/Player/ViewportTracker.cs
+++ b/OpenRA.Game/Traits/Player/ViewportTracker.cs
@@ -24,6 +24,10 @@ namespace OpenRA.Traits
 	{
 		static WorldRenderer worldRenderer;
 
+		public bool IsForceLocked { get; set; }
+
+		bool hasLockedViewport;
+
 		public void WorldLoaded(World w, WorldRenderer wr)
 		{
 			worldRenderer = wr;

--- a/OpenRA.Game/Traits/Player/ViewportTracker.cs
+++ b/OpenRA.Game/Traits/Player/ViewportTracker.cs
@@ -69,6 +69,35 @@ namespace OpenRA.Traits
 			var screenCenterPosition = worldRenderer.ScreenPxPosition(centerPosition);
 			player.ViewportTopLeft = screenCenterPosition - viewportSize / 2;
 			player.ViewportBottomRight = screenCenterPosition + viewportSize / 2;
+
+			// Only manipulate the viewport when observing a game or watching a replay.
+			if (self.Owner == self.World.RenderPlayer && self.World.LocalPlayer == null)
+			{
+				if (IsForceLocked)
+				{
+					hasLockedViewport = true;
+					worldRenderer.Viewport.IsMovementLocked = true;
+					worldRenderer.Viewport.IsZoomingLocked = true;
+					worldRenderer.Viewport.Center(centerPosition, true);
+					worldRenderer.Viewport.SetZoom(zoom, true);
+				}
+				else
+				{
+					if (hasLockedViewport)
+					{
+						worldRenderer.Viewport.IsMovementLocked = false;
+						worldRenderer.Viewport.IsZoomingLocked = false;
+					}
+				}
+			}
+			else
+			{
+				if (hasLockedViewport)
+				{
+					worldRenderer.Viewport.IsMovementLocked = false;
+					worldRenderer.Viewport.IsZoomingLocked = false;
+				}
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/Global/CameraGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/CameraGlobal.cs
@@ -19,11 +19,32 @@ namespace OpenRA.Mods.Common.Scripting
 		public CameraGlobal(ScriptContext context)
 			: base(context) { }
 
+		[Desc("Locks the player's viewport movement to prevent unwanted manipulations. Scripts can still manipulate it even when locked.")]
+		public bool IsViewportMovementLocked
+		{
+			get { return Context.WorldRenderer.Viewport.IsMovementLocked; }
+			set { Context.WorldRenderer.Viewport.IsMovementLocked = value; }
+		}
+
+		[Desc("Locks the player's viewport zooming to prevent unwanted manipulations. Scripts can still manipulate it even when locked.")]
+		public bool IsViewportZoomingLocked
+		{
+			get { return Context.WorldRenderer.Viewport.IsZoomingLocked; }
+			set { Context.WorldRenderer.Viewport.IsZoomingLocked = value; }
+		}
+
 		[Desc("The center of the visible viewport.")]
 		public WPos Position
 		{
 			get { return Context.WorldRenderer.Viewport.CenterPosition; }
-			set { Context.WorldRenderer.Viewport.Center(value); }
+			set { Context.WorldRenderer.Viewport.Center(value, true); }
+		}
+
+		[Desc("The zoom level. Only use allowed values to avoid rendering issues.")]
+		public double Zoom
+		{
+			get { return Context.WorldRenderer.Viewport.Zoom; }
+			set { Context.WorldRenderer.Viewport.SetZoom((float)value, true); }
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/CheckboxWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/CheckboxWidget.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public Func<bool> IsChecked = () => false;
 		public int CheckOffset = 2;
 		public bool HasPressedState = ChromeMetrics.Get<bool>("CheckboxPressedState");
+		public new string Background = "checkbox";
 
 		[ObjectCreator.UseCtor]
 		public CheckboxWidget(ModData modData)
@@ -39,6 +40,7 @@ namespace OpenRA.Mods.Common.Widgets
 			IsChecked = other.IsChecked;
 			CheckOffset = other.CheckOffset;
 			HasPressedState = other.HasPressedState;
+			Background = other.Background;
 		}
 
 		public override void Draw()
@@ -54,11 +56,13 @@ namespace OpenRA.Mods.Common.Widgets
 			var text = GetText();
 			var textSize = font.Measure(text);
 			var check = new Rectangle(rect.Location, new Size(Bounds.Height, Bounds.Height));
-			var state = disabled ? "checkbox-disabled" :
-						highlighted ? "checkbox-highlighted" :
-						Depressed && HasPressedState ? "checkbox-pressed" :
-						Ui.MouseOverWidget == this ? "checkbox-hover" :
-						"checkbox";
+			var stateSuffix = disabled ? "-disabled" :
+						highlighted ? "-highlighted" :
+						Depressed && HasPressedState ? "-pressed" :
+						Ui.MouseOverWidget == this ? "-hover" :
+						"";
+
+			var state = Background + stateSuffix;
 
 			WidgetUtils.DrawPanel(state, check);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
@@ -21,7 +21,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	[ChromeLogicArgsHotkeys("CombinedViewKey", "WorldViewKey")]
+	[ChromeLogicArgsHotkeys("CombinedViewKey", "WorldViewKey", "LockToPlayerCameraKey")]
 	public class ObserverShroudSelectorLogic : ChromeLogic
 	{
 		readonly CameraOption combined, disableShroud;
@@ -31,6 +31,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		readonly HotkeyReference combinedViewKey = new HotkeyReference();
 		readonly HotkeyReference worldViewKey = new HotkeyReference();
+		readonly HotkeyReference lockToPlayerCameraKey = new HotkeyReference();
 
 		readonly World world;
 
@@ -101,6 +102,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			if (logicArgs.TryGetValue("WorldViewKey", out yaml))
 				worldViewKey = modData.Hotkeys[yaml.Value];
+
+			if (logicArgs.TryGetValue("LockToPlayerCameraKey", out yaml))
+				lockToPlayerCameraKey = modData.Hotkeys[yaml.Value];
 
 			limitViews = world.Map.Visibility.HasFlag(MapVisibility.MissionSelector);
 
@@ -202,6 +206,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				{
 					selected = disableShroud;
 					selected.OnClick(isPlayerViewLocked);
+
+					return true;
+				}
+
+				if (lockToPlayerCameraKey.IsActivatedBy(e) && !lockCheckbox.IsDisabled())
+				{
+					lockCheckbox.OnClick();
 
 					return true;
 				}

--- a/OpenRA.Mods.Common/Widgets/RadarWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/RadarWidget.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Network;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 using OpenRA.Widgets;
@@ -38,6 +39,7 @@ namespace OpenRA.Mods.Common.Widgets
 		readonly int cellWidth;
 		readonly int previewWidth;
 		readonly int previewHeight;
+		readonly Dictionary<int, Session.Client> playerClients = new Dictionary<int, Session.Client>();
 
 		float radarMinimapHeight;
 		int frame;
@@ -391,6 +393,13 @@ namespace OpenRA.Mods.Common.Widgets
 
 			foreach (var player in players)
 			{
+				if (!playerClients.ContainsKey(player.ClientIndex))
+					playerClients.Add(player.ClientIndex, player.World.LobbyInfo.ClientWithIndex(player.ClientIndex));
+
+				var client = playerClients[player.ClientIndex];
+				if (client.State == Session.ClientState.Disconnected)
+					continue;
+
 				var tl2 = CellToMinimapPixel(world.Map.CellContaining(worldRenderer.ProjectedPosition(player.ViewportTopLeft)));
 				var br2 = CellToMinimapPixel(world.Map.CellContaining(worldRenderer.ProjectedPosition(player.ViewportBottomRight)));
 				Game.Renderer.RgbaColorRenderer.DrawRect(tl2, br2, 1, player.Color);

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -166,120 +166,132 @@ Container@OBSERVER_WIDGETS:
 					Width: PARENT_RIGHT - 2
 					Height: PARENT_BOTTOM - 2
 					Skippable: false
-		Background@REPLAY_PLAYER:
-			Logic: ReplayControlBarLogic
-			X: WINDOW_RIGHT - WIDTH - 5
-			Y: 283
-			Width: 256
-			Height: 46
-			Background: panel-black
-			Visible: false
-			Children:
-				Button@BUTTON_PAUSE:
-					X: 16
-					Y: 10
-					Width: 26
-					Height: 26
-					Key: Pause
-					TooltipText: Pause
-					TooltipContainer: TOOLTIP_CONTAINER
-					IgnoreChildMouseOver: true
-					Children:
-						Image@IMAGE_PAUSE:
-							X: 5
-							Y: 5
-							Width: 16
-							Height: 16
-							ImageCollection: music
-							ImageName: pause
-				Button@BUTTON_PLAY:
-					X: 16
-					Y: 10
-					Width: 26
-					Height: 26
-					Key: Pause
-					TooltipText: Play
-					TooltipContainer: TOOLTIP_CONTAINER
-					IgnoreChildMouseOver: true
-					Children:
-						Image@IMAGE_PLAY:
-							X: 5
-							Y: 5
-							Width: 16
-							Height: 16
-							ImageCollection: music
-							ImageName: play
-				Button@BUTTON_SLOW:
-					X: 57
-					Y: 13
-					Width: 36
-					Height: 20
-					Key: ReplaySpeedSlow
-					TooltipText: Slow speed
-					TooltipContainer: TOOLTIP_CONTAINER
-					VisualHeight: 0
-					Text: 50%
-					Font: TinyBold
-				Button@BUTTON_REGULAR:
-					X: 57 + 48
-					Y: 13
-					Width: 38
-					Height: 20
-					Key: ReplaySpeedRegular
-					TooltipText: Regular speed
-					TooltipContainer: TOOLTIP_CONTAINER
-					VisualHeight: 0
-					Text: 100%
-					Font: TinyBold
-				Button@BUTTON_FAST:
-					X: 57 + 48 * 2
-					Y: 13
-					Width: 38
-					Height: 20
-					Key: ReplaySpeedFast
-					TooltipText: Fast speed
-					TooltipContainer: TOOLTIP_CONTAINER
-					VisualHeight: 0
-					Text: 200%
-					Font: TinyBold
-				Button@BUTTON_MAXIMUM:
-					X: 57 + 48 * 3
-					Y: 13
-					Width: 38
-					Height: 20
-					Key: ReplaySpeedMax
-					TooltipText: Maximum speed
-					TooltipContainer: TOOLTIP_CONTAINER
-					VisualHeight: 0
-					Text: MAX
-					Font: TinyBold
-		DropDownButton@SHROUD_SELECTOR:
-			Logic: ObserverShroudSelectorLogic
-				CombinedViewKey: ObserverCombinedView
-				WorldViewKey: ObserverWorldView
-				LockToPlayerCameraKey: ObserverLockToPlayerCamera
+		Background@OBSERVER_CONTROL_BG:
 			X: WINDOW_RIGHT - WIDTH - 5
 			Y: 260
 			Width: 256
-			Height: 25
-			Font: Bold
+			Height: 55
+			Background: panel-black
+			Visible: true
 			Children:
-				LogicKeyListener@SHROUD_KEYHANDLER:
-				Image@FLAG:
-					X: 4
-					Y: 4
-					Width: 32
-					Height: 16
-				Label@LABEL:
-					X: 40
-					Width: 60
+				Checkbox@LOCK_CAMERA:
+					X: 16
+					Y: 30
+					Width: 200
+					Height: 20
+					Text: Lock camera to player view
+				DropDownButton@SHROUD_SELECTOR:
+					Logic: ObserverShroudSelectorLogic
+						CombinedViewKey: ObserverCombinedView
+						WorldViewKey: ObserverWorldView
+						LockToPlayerCameraKey: ObserverLockToPlayerCamera
+					X: 0
+					Y: 0
+					Width: 256
 					Height: 25
-					Shadow: True
-				Label@NOFLAG_LABEL:
-					X: 5
-					Width: PARENT_RIGHT
-					Height: 25
-					Shadow: True
+					Font: Bold
+					Children:
+						LogicKeyListener@SHROUD_KEYHANDLER:
+						Image@FLAG:
+							X: 4
+							Y: 4
+							Width: 32
+							Height: 16
+						Label@LABEL:
+							X: 40
+							Width: 60
+							Height: 25
+							Shadow: True
+						Label@NOFLAG_LABEL:
+							X: 5
+							Width: PARENT_RIGHT
+							Height: 25
+							Shadow: True
+				Container@REPLAY_PLAYER:
+					Logic: ReplayControlBarLogic
+					X: 0
+					Y: 55
+					Width: 256
+					Height: 46
+					Children:
+						Button@BUTTON_PAUSE:
+							X: 16
+							Y: 10
+							Width: 26
+							Height: 26
+							Key: Pause
+							TooltipText: Pause
+							TooltipContainer: TOOLTIP_CONTAINER
+							IgnoreChildMouseOver: true
+							Children:
+								Image@IMAGE_PAUSE:
+									X: 5
+									Y: 5
+									Width: 16
+									Height: 16
+									ImageCollection: music
+									ImageName: pause
+						Button@BUTTON_PLAY:
+							X: 16
+							Y: 10
+							Width: 26
+							Height: 26
+							Key: Pause
+							TooltipText: Play
+							TooltipContainer: TOOLTIP_CONTAINER
+							IgnoreChildMouseOver: true
+							Children:
+								Image@IMAGE_PLAY:
+									X: 5
+									Y: 5
+									Width: 16
+									Height: 16
+									ImageCollection: music
+									ImageName: play
+						Button@BUTTON_SLOW:
+							X: 57
+							Y: 13
+							Width: 36
+							Height: 20
+							Key: ReplaySpeedSlow
+							TooltipText: Slow speed
+							TooltipContainer: TOOLTIP_CONTAINER
+							VisualHeight: 0
+							Text: 50%
+							Font: TinyBold
+						Button@BUTTON_REGULAR:
+							X: 57 + 48
+							Y: 13
+							Width: 38
+							Height: 20
+							Key: ReplaySpeedRegular
+							TooltipText: Regular speed
+							TooltipContainer: TOOLTIP_CONTAINER
+							VisualHeight: 0
+							Text: 100%
+							Font: TinyBold
+						Button@BUTTON_FAST:
+							X: 57 + 48 * 2
+							Y: 13
+							Width: 38
+							Height: 20
+							Key: ReplaySpeedFast
+							TooltipText: Fast speed
+							TooltipContainer: TOOLTIP_CONTAINER
+							VisualHeight: 0
+							Text: 200%
+							Font: TinyBold
+						Button@BUTTON_MAXIMUM:
+							X: 57 + 48 * 3
+							Y: 13
+							Width: 38
+							Height: 20
+							Key: ReplaySpeedMax
+							TooltipText: Maximum speed
+							TooltipContainer: TOOLTIP_CONTAINER
+							VisualHeight: 0
+							Text: MAX
+							Font: TinyBold
 		Container@INGAME_OBSERVERSTATS_BG:
 			Logic: ObserverStatsLogic
 				StatisticsNoneKey: StatisticsNone

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -257,6 +257,7 @@ Container@OBSERVER_WIDGETS:
 			Logic: ObserverShroudSelectorLogic
 				CombinedViewKey: ObserverCombinedView
 				WorldViewKey: ObserverWorldView
+				LockToPlayerCameraKey: ObserverLockToPlayerCamera
 			X: WINDOW_RIGHT - WIDTH - 5
 			Y: 260
 			Width: 256

--- a/mods/cnc/rules/player.yaml
+++ b/mods/cnc/rules/player.yaml
@@ -61,3 +61,4 @@ Player:
 	ConditionManager:
 	GameSaveViewportManager:
 	PlayerRadarTerrain:
+	ViewportTracker:

--- a/mods/common/chrome/ingame-observer.yaml
+++ b/mods/common/chrome/ingame-observer.yaml
@@ -66,6 +66,7 @@ Container@OBSERVER_WIDGETS:
 					Logic: ObserverShroudSelectorLogic
 						CombinedViewKey: ObserverCombinedView
 						WorldViewKey: ObserverWorldView
+						LockToPlayerCameraKey: ObserverLockToPlayerCamera
 					X: 15
 					Y: 15
 					Width: 220

--- a/mods/common/chrome/ingame-observer.yaml
+++ b/mods/common/chrome/ingame-observer.yaml
@@ -54,8 +54,14 @@ Container@OBSERVER_WIDGETS:
 			X: WINDOW_RIGHT - 255
 			Y: 260
 			Width: 250
-			Height: 55
+			Height: 80
 			Children:
+				Checkbox@LOCK_CAMERA:
+					X: 15
+					Y: 45
+					Width: 200
+					Height: 20
+					Text: Lock camera to player view
 				DropDownButton@SHROUD_SELECTOR:
 					Logic: ObserverShroudSelectorLogic
 						CombinedViewKey: ObserverCombinedView
@@ -84,9 +90,9 @@ Container@OBSERVER_WIDGETS:
 							Shadow: True
 				Container@REPLAY_PLAYER:
 					Logic: ReplayControlBarLogic
-					Y: 39
+					Y: 60
 					Width: 160
-					Height: 35
+					Height: 30
 					Visible: false
 					Children:
 						Button@BUTTON_PAUSE:

--- a/mods/common/hotkeys/observer.yaml
+++ b/mods/common/hotkeys/observer.yaml
@@ -6,6 +6,10 @@ ObserverWorldView: EQUALS
 	Description: Disable Shroud
 	Types: Observer, Spectator
 
+ObserverLockToPlayerCamera: C
+	Description: Lock the observer view to the player view
+	Types: Observer
+
 ReplaySpeedSlow: F9
 	Description: Slow speed
 	Types: Replay, Spectator

--- a/mods/d2k/chrome/ingame-observer.yaml
+++ b/mods/d2k/chrome/ingame-observer.yaml
@@ -74,12 +74,19 @@ Container@OBSERVER_WIDGETS:
 			X: WINDOW_RIGHT - 255
 			Y: 260
 			Width: 250
-			Height: 55
+			Height: 80
 			Children:
+				Checkbox@LOCK_CAMERA:
+					X: 16
+					Y: 45
+					Width: 200
+					Height: 20
+					Text: Lock camera to player view
 				DropDownButton@SHROUD_SELECTOR:
 					Logic: ObserverShroudSelectorLogic
 						CombinedViewKey: ObserverCombinedView
 						WorldViewKey: ObserverWorldView
+						LockToPlayerCameraKey: ObserverLockToPlayerCamera
 					X: 15
 					Y: 15
 					Width: 220
@@ -104,9 +111,9 @@ Container@OBSERVER_WIDGETS:
 							Shadow: True
 				Container@REPLAY_PLAYER:
 					Logic: ReplayControlBarLogic
-					Y: 39
+					Y: 60
 					Width: 160
-					Height: 35
+					Height: 30
 					Visible: false
 					Children:
 						Button@BUTTON_PAUSE:

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -153,3 +153,4 @@ Player:
 	ConditionManager:
 	GameSaveViewportManager:
 	PlayerRadarTerrain:
+	ViewportTracker:

--- a/mods/ra/chrome/ingame-observer.yaml
+++ b/mods/ra/chrome/ingame-observer.yaml
@@ -24,7 +24,7 @@ Container@OBSERVER_WIDGETS:
 			X: WINDOW_RIGHT - 250
 			Y: 10
 			Width: 238
-			Height: 287
+			Height: 325
 			ImageCollection: sidebar-observer
 			ImageName: background
 			ClickThrough: false
@@ -87,6 +87,14 @@ Container@OBSERVER_WIDGETS:
 							Width: 220
 							Height: 220
 							Skippable: false
+				Checkbox@LOCK_CAMERA:
+					X: 15
+					Y: 294
+					Width: 200
+					Height: 20 
+					Background: sidebar-button-observer
+					Contrast: true
+					Text: Lock camera to player view
 				DropDownButton@SHROUD_SELECTOR:
 					Logic: ObserverShroudSelectorLogic
 						CombinedViewKey: ObserverCombinedView
@@ -121,15 +129,15 @@ Container@OBSERVER_WIDGETS:
 			X: WINDOW_RIGHT - 250
 			Y: 297
 			Width: 238
-			Height: 8
+			Height: 18
 			ImageCollection: sidebar-observer
 			ImageName: observer-bottom
 		Image@REPLAY_PLAYER:
 			Logic: ReplayControlBarLogic
 			X: WINDOW_RIGHT - 250
-			Y: 297
+			Y: 330
 			Width: 238
-			Height: 40
+			Height: 50
 			Visible: false
 			ImageCollection: sidebar-observer
 			ImageName: replay-bottom

--- a/mods/ra/chrome/ingame-observer.yaml
+++ b/mods/ra/chrome/ingame-observer.yaml
@@ -91,6 +91,7 @@ Container@OBSERVER_WIDGETS:
 					Logic: ObserverShroudSelectorLogic
 						CombinedViewKey: ObserverCombinedView
 						WorldViewKey: ObserverWorldView
+						LockToPlayerCameraKey: ObserverLockToPlayerCamera
 					X: 6
 					Y: 262
 					Width: 226

--- a/mods/ra/maps/allies-05a/allies05a.lua
+++ b/mods/ra/maps/allies-05a/allies05a.lua
@@ -149,6 +149,7 @@ SendWaterExtraction = function()
 end
 
 WarfactoryInfiltrated = function()
+	Camera.IsViewportMovementLocked = true
 	FollowTruk = true
 	Truk.GrantCondition("hijacked")
 
@@ -296,6 +297,7 @@ InitTriggers = function()
 			Media.PlaySoundNotification(greece, SpyVoice)
 
 			FollowTruk = false
+			Camera.IsViewportMovementLocked = false
 
 			if SpecialCameras then
 				PrisonCamera = Actor.Create("camera", true, { Owner = greece, Location = TrukWaypoint5.Location })

--- a/mods/ra/maps/infiltration/infiltration.lua
+++ b/mods/ra/maps/infiltration/infiltration.lua
@@ -163,8 +163,10 @@ InfiltrateLabFailed = function()
 	end)
 end
 
-ChangeOwnerOnAddedToWorld = function(actor, newOwner)
+OnSpyAddedToWorld = function(actor, newOwner)
 	Trigger.OnAddedToWorld(actor, function(unloadedActor)
+		Media.PlaySpeechNotification(player, "StartGame")
+		Camera.IsViewportMovementLocked = false
 		unloadedActor.Owner = newOwner
 		Trigger.Clear(unloadedActor, "OnAddedToWorld")
 	end)
@@ -203,16 +205,17 @@ InsertSpies = function()
 	local exit = { SpyReinforcementsExitPoint.Location }
 	local reinforcements = Reinforcements.ReinforceWithTransport(allies, TransportType, spyActors, entryPath, exit)
 
-	local transport = reinforcements[1]
-	Camera.Position = transport.CenterPosition
+	LandingTransport = reinforcements[1]
+	Camera.IsViewportMovementLocked = true
+	Camera.Position = LandingTransport.CenterPosition
 
 	spies = reinforcements[2]
 	Trigger.OnAnyKilled(spies, InfiltrateLabFailed)
 
-	ChangeOwnerOnAddedToWorld(spies[1], player1)
+	OnSpyAddedToWorld(spies[1], player1)
 
 	if player2 then
-		ChangeOwnerOnAddedToWorld(spies[2], player2)
+		OnSpyAddedToWorld(spies[2], player2)
 	end
 end
 
@@ -340,6 +343,10 @@ CheckLabSecured = function()
 end
 
 Tick = function()
+	if LandingTransport.IsInWorld and Camera.IsViewportMovementLocked then
+		Camera.Position = LandingTransport.CenterPosition
+	end
+
 	CapOre(soviets)
 	SecureLabTimer()
 	CheckLabSecured()

--- a/mods/ra/maps/infiltration/rules.yaml
+++ b/mods/ra/maps/infiltration/rules.yaml
@@ -1,4 +1,5 @@
 World:
+	-StartGameNotification:
 	GlobalLightingPaletteEffect@HAZE:
 		Red: 1
 		Green: 0.55

--- a/mods/ra/maps/monster-tank-madness/monster-tank-madness.lua
+++ b/mods/ra/maps/monster-tank-madness/monster-tank-madness.lua
@@ -269,9 +269,15 @@ end
 SetupMission = function()
 	TestCamera = Actor.Create("camera" ,true , { Owner = player, Location = ProvingGroundsCameraPoint.Location })
 	Camera.Position = ProvingGroundsCameraPoint.CenterPosition
+	Camera.IsViewportMovementLocked = true
+	Camera.IsViewportZoomingLocked = true
+	Camera.Zoom = 2.0
 	TimerColor = player.Color
 
 	Trigger.AfterDelay(DateTime.Seconds(12), function()
+		Camera.IsViewportMovementLocked = false
+		Camera.IsViewportZoomingLocked = false
+		Camera.Zoom = 1.0
 		Media.PlaySpeechNotification(player, "StartGame")
 		Trigger.AfterDelay(DateTime.Seconds(2), SendAlliedUnits)
 	end)

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -152,3 +152,4 @@ Player:
 	ConditionManager:
 	GameSaveViewportManager:
 	PlayerRadarTerrain:
+	ViewportTracker:

--- a/mods/ts/chrome/ingame-observer.yaml
+++ b/mods/ts/chrome/ingame-observer.yaml
@@ -86,6 +86,7 @@ Container@OBSERVER_WIDGETS:
 					Logic: ObserverShroudSelectorLogic
 						CombinedViewKey: ObserverCombinedView
 						WorldViewKey: ObserverWorldView
+						LockToPlayerCameraKey: ObserverLockToPlayerCamera
 					X: 15
 					Y: 15
 					Width: 220

--- a/mods/ts/chrome/ingame-observer.yaml
+++ b/mods/ts/chrome/ingame-observer.yaml
@@ -74,8 +74,14 @@ Container@OBSERVER_WIDGETS:
 			X: WINDOW_RIGHT - 255
 			Y: 260
 			Width: 250
-			Height: 55
+			Height: 80
 			Children:
+				Checkbox@LOCK_CAMERA:
+					X: 15
+					Y: 45
+					Width: 200
+					Height: 20
+					Text: Lock camera to player view
 				DropDownButton@SHROUD_SELECTOR:
 					Logic: ObserverShroudSelectorLogic
 						CombinedViewKey: ObserverCombinedView
@@ -104,9 +110,9 @@ Container@OBSERVER_WIDGETS:
 							Shadow: True
 				Container@REPLAY_PLAYER:
 					Logic: ReplayControlBarLogic
-					Y: 39
+					Y: 60
 					Width: 160
-					Height: 35
+					Height: 30
 					Visible: false
 					Children:
 						Button@BUTTON_PAUSE:

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -125,3 +125,4 @@ Player:
 	ConditionManager:
 	GameSaveViewportManager:
 	PlayerRadarTerrain:
+	ViewportTracker:


### PR DESCRIPTION
This was inspired by multiplayer game casting and the need at times to be able to see what the player sees. I hope this will be helpful to game casters be it in a live multiplayer game or from replays. I was also recently told this will be needed for game saves.

Viewport position and size are sent as regular orders by each player, so they can be monitored live by spectators *and* they go into replay files for later reference.

**_Edit 30.03.2020:_**
Things I am going to need help with:
 - [ ] Figuring out what to do regarding the choppy camera tracking (that is a result of how the orders with the coordinates are sent)
 - [ ] Polishing the UI in TD
 - [ ] Doing the UI in RA (images of what it used to look like can be found below and the corresponding version of the code can be found [in this commit](https://github.com/penev92/OpenRA/commit/9bf71e26219c22e40649be3b44f84edd77144f7e))
 - [ ] Finalize the overall UI layout for this (Also people have mentioned different ideas about the layout entirely, so the overall layout should be finalized sooner rather than later. That should probably also include an option to disable player viewports being drawn on the minimap (another checkbox?))