### PR TITLE
Make harvester orders queueable

### DIFF
--- a/OpenRA.Mods.Common/Activities/HarvestResource.cs
+++ b/OpenRA.Mods.Common/Activities/HarvestResource.cs
@@ -39,7 +39,8 @@ namespace OpenRA.Mods.Common.Activities
 			if (ChildActivity != null)
 			{
 				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				return this;
+				if (ChildActivity != null)
+					return this;
 			}
 
 			if (IsCanceling)

--- a/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
@@ -50,7 +50,8 @@ namespace OpenRA.Mods.Common.Activities
 			if (ChildActivity != null)
 			{
 				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				return this;
+				if (ChildActivity != null)
+					return this;
 			}
 
 			switch (dockingState)

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -961,6 +961,7 @@
     <Compile Include="UpdateRules\Rules\20181215\RefactorResourceLevelAnimating.cs" />
     <Compile Include="UpdateRules\Rules\20190314\StreamlineRepairableTraits.cs" />
     <Compile Include="UpdateRules\Rules\20190314\ReplaceSpecialMoveConsiderations.cs" />
+    <Compile Include="UpdateRules\Rules\20190314\RefactorHarvesterIdle.cs" />
     <Compile Include="Traits\Player\PlayerResources.cs" />
     <Compile Include="UtilityCommands\DumpSequenceSheetsCommand.cs" />
     <Compile Include="Traits\Render\WithBuildingRepairDecoration.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -89,7 +89,7 @@
     <Compile Include="Activities\DonateExperience.cs" />
     <Compile Include="Activities\Enter.cs" />
     <Compile Include="Activities\EnterTransport.cs" />
-    <Compile Include="Activities\FindResources.cs" />
+    <Compile Include="Activities\FindAndDeliverResources.cs" />
     <Compile Include="Activities\HarvestResource.cs" />
     <Compile Include="Activities\HarvesterDockSequence.cs" />
     <Compile Include="Activities\Hunt.cs" />

--- a/OpenRA.Mods.Common/Scripting/Properties/HarvesterProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/HarvesterProperties.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Scripting;
 using OpenRA.Traits;
@@ -18,19 +19,15 @@ namespace OpenRA.Mods.Common.Scripting
 	[ScriptPropertyGroup("Movement")]
 	public class HarvesterProperties : ScriptActorProperties, Requires<HarvesterInfo>
 	{
-		readonly Harvester harvester;
-
 		public HarvesterProperties(ScriptContext context, Actor self)
 			: base(context, self)
-		{
-			harvester = self.Trait<Harvester>();
-		}
+		{ }
 
 		[ScriptActorPropertyActivity]
 		[Desc("Search for nearby resources and begin harvesting.")]
 		public void FindResources()
 		{
-			harvester.ContinueHarvesting(Self);
+			Self.QueueActivity(new FindAndDeliverResources(Self));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!h.Key.IsIdle)
 				{
 					var act = h.Key.CurrentActivity;
-					if (!h.Value.Harvester.LastSearchFailed || act.NextActivity == null || act.NextActivity.GetType() != typeof(FindResources))
+					if (!h.Value.Harvester.LastSearchFailed || act.NextActivity == null || act.NextActivity.GetType() != typeof(FindAndDeliverResources))
 						continue;
 				}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -144,12 +144,12 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (!preventDock)
 			{
-				dockOrder.Queue(self, new CallFunc(() => dockedHarv = harv, false));
-				dockOrder.Queue(self, DockSequence(harv, self));
-				dockOrder.Queue(self, new CallFunc(() => dockedHarv = null, false));
+				dockOrder.QueueChild(self, new CallFunc(() => dockedHarv = harv, false));
+				dockOrder.QueueChild(self, DockSequence(harv, self));
+				dockOrder.QueueChild(self, new CallFunc(() => dockedHarv = null, false));
 			}
 
-			dockOrder.Queue(self, new CallFunc(() => harv.Trait<Harvester>().ContinueHarvesting(harv)));
+			dockOrder.QueueChild(self, new CallFunc(() => harv.Trait<Harvester>().ContinueHarvesting(harv)));
 		}
 
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)

--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -148,8 +148,6 @@ namespace OpenRA.Mods.Common.Traits
 				dockOrder.QueueChild(self, DockSequence(harv, self));
 				dockOrder.QueueChild(self, new CallFunc(() => dockedHarv = null, false));
 			}
-
-			dockOrder.QueueChild(self, new CallFunc(() => harv.Trait<Harvester>().ContinueHarvesting(harv)));
 		}
 
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -89,7 +89,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly ResourceLayer resLayer;
 		readonly ResourceClaimLayer claimLayer;
 		readonly Dictionary<ResourceTypeInfo, int> contents = new Dictionary<ResourceTypeInfo, int>();
-		bool idleSmart = true;
+		bool idleSmart = false;
 		INotifyHarvesterAction[] notifyHarvesterAction;
 		ConditionManager conditionManager;
 		int conditionToken = ConditionManager.InvalidConditionToken;
@@ -130,10 +130,8 @@ namespace OpenRA.Mods.Common.Traits
 			notifyHarvesterAction = self.TraitsImplementing<INotifyHarvesterAction>().ToArray();
 			conditionManager = self.TraitOrDefault<ConditionManager>();
 			UpdateCondition(self);
-
-			// Note: This is queued in a FrameEndTask because otherwise the activity is dropped/overridden while moving out of a factory.
 			if (Info.SearchOnCreation)
-				self.World.AddFrameEndTask(w => self.QueueActivity(new FindResources(self)));
+				idleSmart = true;
 		}
 
 		public void SetProcLines(Actor proc)
@@ -280,8 +278,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (LastSearchFailed)
 			{
 				// Wait a bit before searching again.
-				idleDuration += 1;
-				if (idleDuration <= Info.WaitDuration)
+				if (idleDuration++ < Info.WaitDuration)
 					return;
 			}
 

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -397,7 +397,8 @@ namespace OpenRA.Mods.Common.Traits
 				LinkProc(self, OwnerLinkedProc = null);
 				idleSmart = true;
 
-				self.CancelActivity();
+				if (!order.Queued)
+					self.CancelActivity();
 
 				CPos loc;
 				if (order.Target.Type != TargetType.Invalid)
@@ -442,7 +443,9 @@ namespace OpenRA.Mods.Common.Traits
 
 				self.SetTargetLine(order.Target, Color.Green);
 
-				self.CancelActivity();
+				if (!order.Queued)
+					self.CancelActivity();
+
 				self.QueueActivity(new DeliverResources(self));
 
 				foreach (var n in notifyHarvesterAction)

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -397,9 +397,6 @@ namespace OpenRA.Mods.Common.Traits
 				LinkProc(self, OwnerLinkedProc = null);
 				idleSmart = true;
 
-				if (!order.Queued)
-					self.CancelActivity();
-
 				CPos loc;
 				if (order.Target.Type != TargetType.Invalid)
 				{
@@ -416,7 +413,7 @@ namespace OpenRA.Mods.Common.Traits
 				self.SetTargetLine(Target.FromCell(self.World, loc), Color.Red);
 
 				// FindResources takes care of calling INotifyHarvesterAction
-				self.QueueActivity(new FindResources(self));
+				self.QueueActivity(order.Queued, new FindResources(self));
 
 				LastOrderLocation = loc;
 
@@ -442,11 +439,7 @@ namespace OpenRA.Mods.Common.Traits
 				idleSmart = true;
 
 				self.SetTargetLine(order.Target, Color.Green);
-
-				if (!order.Queued)
-					self.CancelActivity();
-
-				self.QueueActivity(new DeliverResources(self));
+				self.QueueActivity(order.Queued, new DeliverResources(self));
 
 				foreach (var n in notifyHarvesterAction)
 					n.MovingToRefinery(self, targetActor, null);

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20190314/RefactorHarvesterIdle.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20190314/RefactorHarvesterIdle.cs
@@ -28,15 +28,6 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 
 		readonly List<string> locations = new List<string>();
 
-		public override IEnumerable<string> AfterUpdate(ModData modData)
-		{
-			if (locations.Any())
-				yield return "The MaxIdleDuration parameter has been removed from the harvester logic on the following actors:\n" +
-					UpdateUtils.FormatMessageList(locations) + "\n\n";
-
-			locations.Clear();
-		}
-
 		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
 		{
 			foreach (var t in actorNode.ChildrenMatching("Harvester"))

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20190314/RefactorHarvesterIdle.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20190314/RefactorHarvesterIdle.cs
@@ -1,0 +1,49 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RefactorHarvesterIdle : UpdateRule
+	{
+		public override string Name { get { return "Refactor harvester idle behavior."; } }
+		public override string Description
+		{
+			get
+			{
+				return "The MaxIdleDuration parameter has been removed from the Harvester trait as part of a\n" +
+					   " refactoring of harvester idling behavior.";
+			}
+		}
+
+		readonly List<string> locations = new List<string>();
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (locations.Any())
+				yield return "The MaxIdleDuration parameter has been removed from the harvester logic on the following actors:\n" +
+					UpdateUtils.FormatMessageList(locations) + "\n\n";
+
+			locations.Clear();
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var t in actorNode.ChildrenMatching("Harvester"))
+				if (t.RemoveNodes("MaxIdleDuration") > 0)
+					locations.Add("{0} ({1})".F(actorNode.Key, actorNode.Location.Filename));
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -123,6 +123,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new MakeMobilePausableConditional(),
 				new StreamlineRepairableTraits(),
 				new ReplaceSpecialMoveConsiderations(),
+				new RefactorHarvesterIdle(),
 			})
 		};
 


### PR DESCRIPTION
Fixes #14775
Fixes #11264
Fixes #16205  
Fixes #15997 

Harvester commands can now be queued before or after any other command without overwriting existing order queues. This PR is also part of the effort to get rid of all self-referential uses of `SequenceActivities` and replace them with an approach based on ChildActivities as discussed in #15632 and #16069.

In order to make `Move` work as a `ChildActivity` without glitches I had to change one line in `Activity.` This is because otherwise the childactivities of `Move` itself will not finish properly. This change doesn't seem to have any adverse consequences, but perhaps @obrakmann can comment on whether this is a good approach.