### PR TITLE
Fix for #14013: App config for StyleCheck

### DIFF
--- a/OpenRA.StyleCheck/App.config
+++ b/OpenRA.StyleCheck/App.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <probing privatePath="mods/common"></probing>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/OpenRA.StyleCheck/OpenRA.StyleCheck.csproj
+++ b/OpenRA.StyleCheck/OpenRA.StyleCheck.csproj
@@ -38,5 +38,8 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Fixes https://github.com/OpenRA/OpenRA/issues/14013

Running "make check" causes a ReflectionTypeLoadException to be thrown (at least, on my machine). The exception is that it cannot find the "OpenRA.Mods.Common" assembly. Only building from MonoDevelop seems to have this problem. Cleaning and rebuilding with "make all" allows "make check" to temporarily work again. 

This PR copies the same "App.config" from OpenRA.Test, into OpenRA.StyleCheck. Since that config includes "mods/common" as a search path, the exception no longer occurs after building from MonoDevelop. I am unsure exactly how the two build processes differ. 