### PR TITLE
Remove some legacy activity cruft from Aircraft

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -37,17 +37,6 @@ namespace OpenRA.Mods.Common.Activities
 			this.dest = dest;
 		}
 
-		public Actor ChooseResupplier(Actor self, bool unreservedOnly)
-		{
-			if (rearmable == null)
-				return null;
-
-			return self.World.Actors.Where(a => a.Owner == self.Owner
-				&& rearmable.Info.RearmActors.Contains(a.Info.Name)
-				&& (!unreservedOnly || Reservable.IsAvailableFor(a, self)))
-				.ClosestTo(self);
-		}
-
 		public override Activity Tick(Actor self)
 		{
 			// Refuse to take off if it would land immediately again.
@@ -59,13 +48,13 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 
 			if (dest == null || dest.IsDead || !Reservable.IsAvailableFor(dest, self))
-				dest = ChooseResupplier(self, true);
+				dest = ReturnToBase.ChooseResupplier(self, true);
 
 			var initialFacing = aircraft.Info.InitialFacing;
 
 			if (dest == null || dest.IsDead)
 			{
-				var nearestResupplier = ChooseResupplier(self, false);
+				var nearestResupplier = ReturnToBase.ChooseResupplier(self, false);
 
 				// If a heli was told to return and there's no (available) RearmBuilding, going to the probable next queued activity (HeliAttack)
 				// would be pointless (due to lack of ammo), and possibly even lead to an infinite loop due to HeliAttack.cs:L79.

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -787,43 +787,15 @@ namespace OpenRA.Mods.Common.Traits
 					UnReserve();
 
 				var targetActor = order.Target.Actor;
-				if (!Reservable.IsAvailableFor(targetActor, self))
-				{
-					if (!Info.CanHover)
-						self.QueueActivity(new ReturnToBase(self, Info.AbortOnResupply));
-					else
-						self.QueueActivity(new HeliReturnToBase(self, Info.AbortOnResupply));
-				}
-				else
-				{
+
+				// We only want to set a target line if the order will (most likely) succeed
+				if (Reservable.IsAvailableFor(targetActor, self))
 					self.SetTargetLine(Target.FromActor(targetActor), Color.Green);
 
-					if (!Info.CanHover && !Info.VTOL)
-					{
-						self.QueueActivity(order.Queued, ActivityUtils.SequenceActivities(
-							new ReturnToBase(self, Info.AbortOnResupply, targetActor),
-							new ResupplyAircraft(self)));
-					}
-					else
-					{
-						MakeReservation(targetActor);
-
-						Action enter = () =>
-						{
-							var exit = targetActor.FirstExitOrDefault(null);
-							var offset = exit != null ? exit.Info.SpawnOffset : WVec.Zero;
-
-							self.QueueActivity(new HeliFly(self, Target.FromPos(targetActor.CenterPosition + offset)));
-							if (Info.TurnToDock)
-								self.QueueActivity(new Turn(self, Info.InitialFacing));
-
-							self.QueueActivity(new HeliLand(self, false));
-							self.QueueActivity(new ResupplyAircraft(self));
-						};
-
-						self.QueueActivity(order.Queued, new CallFunc(enter));
-					}
-				}
+				if (!Info.CanHover && !Info.VTOL)
+					self.QueueActivity(order.Queued, new ReturnToBase(self, Info.AbortOnResupply, targetActor));
+				else
+					self.QueueActivity(order.Queued, new HeliReturnToBase(self, Info.AbortOnResupply, targetActor));
 			}
 			else if (order.OrderString == "Stop")
 			{


### PR DESCRIPTION
You only need to look at the RTB activities to tell that `Aircraft` doing its own stuff here was somewhat redundant and just made things worse regarding debugging and code consistency.

Fixed some inconsistencies with the 'targetActor not available' case as well.

This is just a bit of clean-up before the upcoming larger refactor(s), so it would be nice to get this merged quickly.