### PR TITLE
Replace System.Drawing.Bitmap with Png for image saving

### DIFF
--- a/OpenRA.Game/Exts.cs
+++ b/OpenRA.Game/Exts.cs
@@ -12,7 +12,6 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Drawing.Imaging;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -447,8 +446,6 @@ namespace OpenRA
 
 			return result;
 		}
-
-		public static Rectangle Bounds(this Bitmap b) { return new Rectangle(0, 0, b.Width, b.Height); }
 
 		public static int ToBits(this IEnumerable<bool> bits)
 		{

--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -13,7 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
-using System.Drawing.Imaging;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -449,29 +448,6 @@ namespace OpenRA
 				{
 					return InvalidValueAction(value, fieldType, fieldName);
 				}
-			}
-			else if (fieldType == typeof(ImageFormat))
-			{
-				if (value != null)
-				{
-					switch (value.ToLowerInvariant())
-					{
-					case "bmp":
-						return ImageFormat.Bmp;
-					case "gif":
-						return ImageFormat.Gif;
-					case "jpg":
-					case "jpeg":
-						return ImageFormat.Jpeg;
-					case "tif":
-					case "tiff":
-						return ImageFormat.Tiff;
-					default:
-						return ImageFormat.Png;
-					}
-				}
-
-				return InvalidValueAction(value, fieldType, fieldName);
 			}
 			else if (fieldType == typeof(bool))
 				return ParseYesNo(value, fieldType, fieldName);

--- a/OpenRA.Game/FieldSaver.cs
+++ b/OpenRA.Game/FieldSaver.cs
@@ -13,7 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Drawing;
-using System.Drawing.Imaging;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -86,11 +85,6 @@ namespace OpenRA
 			if (t == typeof(HSLColor))
 			{
 				return ((HSLColor)v).ToHexString();
-			}
-
-			if (t == typeof(ImageFormat))
-			{
-				return ((ImageFormat)v).ToString();
 			}
 
 			if (t == typeof(Rectangle))

--- a/OpenRA.Game/FileFormats/Png.cs
+++ b/OpenRA.Game/FileFormats/Png.cs
@@ -161,6 +161,25 @@ namespace OpenRA.FileFormats
 			}
 		}
 
+		public Png(byte[] data, int width, int height, Color[] palette = null,
+			Dictionary<string, string> embeddedData = null)
+		{
+			var expectLength = width * height;
+			if (palette == null)
+				expectLength *= 4;
+
+			if (data.Length != expectLength)
+				throw new InvalidDataException("Input data does not match expected length");
+			Width = width;
+			Height = height;
+
+			Palette = palette;
+			Data = data;
+
+			if (embeddedData != null)
+				EmbeddedData = embeddedData;
+		}
+
 		public static bool Verify(Stream s)
 		{
 			var pos = s.Position;

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -530,31 +530,19 @@ namespace OpenRA
 
 		static void TakeScreenshotInner()
 		{
-			Log.Write("debug", "Taking screenshot");
-
-			Bitmap bitmap;
-			using (new PerfTimer("Renderer.TakeScreenshot"))
-				bitmap = Renderer.Context.TakeScreenshot();
-
-			ThreadPool.QueueUserWorkItem(_ =>
+			using (new PerfTimer("Renderer.SaveScreenshot"))
 			{
 				var mod = ModData.Manifest.Metadata;
 				var directory = Platform.ResolvePath(Platform.SupportDirPrefix, "Screenshots", ModData.Manifest.Id, mod.Version);
 				Directory.CreateDirectory(directory);
 
 				var filename = TimestampedFilename(true);
-				var format = Settings.Graphics.ScreenshotFormat;
-				var extension = ImageCodecInfo.GetImageEncoders().FirstOrDefault(x => x.FormatID == format.Guid)
-					.FilenameExtension.Split(';').First().ToLowerInvariant().Substring(1);
-				var destination = Path.Combine(directory, string.Concat(filename, extension));
+				var path = Path.Combine(directory, string.Concat(filename, ".png"));
+				Log.Write("debug", "Taking screenshot " + path);
 
-				using (new PerfTimer("Save Screenshot ({0})".F(format)))
-					bitmap.Save(destination, format);
-
-				bitmap.Dispose();
-
-				RunAfterTick(() => Debug("Saved screenshot " + filename));
-			});
+				Renderer.Context.SaveScreenshot(path);
+				Debug("Saved screenshot " + filename);
+			}
 		}
 
 		static void InnerLogicTick(OrderManager orderManager)

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -13,7 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
-using System.Drawing.Imaging;
 using System.Globalization;
 using System.IO;
 using System.Linq;

--- a/OpenRA.Game/Graphics/Palette.cs
+++ b/OpenRA.Game/Graphics/Palette.cs
@@ -12,10 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
-using System.Reflection;
-using System.Runtime.InteropServices;
 
 namespace OpenRA.Graphics
 {
@@ -34,30 +31,6 @@ namespace OpenRA.Graphics
 		public static Color GetColor(this IPalette palette, int index)
 		{
 			return Color.FromArgb((int)palette[index]);
-		}
-
-		public static ColorPalette AsSystemPalette(this IPalette palette)
-		{
-			ColorPalette pal;
-			using (var b = new Bitmap(1, 1, PixelFormat.Format8bppIndexed))
-				pal = b.Palette;
-
-			for (var i = 0; i < Size; i++)
-				pal.Entries[i] = palette.GetColor(i);
-
-			return pal;
-		}
-
-		public static Bitmap AsBitmap(this IPalette palette)
-		{
-			var b = new Bitmap(Size, 1, PixelFormat.Format32bppArgb);
-			var data = b.LockBits(new Rectangle(0, 0, b.Width, b.Height),
-								  ImageLockMode.WriteOnly, PixelFormat.Format32bppArgb);
-			var temp = new uint[Size];
-			palette.CopyToArray(temp, 0);
-			Marshal.Copy((int[])(object)temp, 0, data.Scan0, Size);
-			b.UnlockBits(data);
-			return b;
 		}
 
 		public static IPalette AsReadOnly(this IPalette palette)

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -61,7 +61,7 @@ namespace OpenRA
 		IShader CreateShader(string name);
 		void EnableScissor(int left, int top, int width, int height);
 		void DisableScissor();
-		Bitmap TakeScreenshot();
+		void SaveScreenshot(string path);
 		void Present();
 		void DrawPrimitives(PrimitiveType pt, int firstVertex, int numVertices);
 		void Clear();

--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -11,9 +11,7 @@
 
 using System;
 using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
-using System.Runtime.InteropServices;
 using OpenRA.FileFormats;
 
 namespace OpenRA.Graphics
@@ -79,48 +77,27 @@ namespace OpenRA.Graphics
 			return texture;
 		}
 
-		public Bitmap AsBitmap()
+		public Png AsPng()
 		{
-			var d = GetData();
-			var dataStride = 4 * Size.Width;
-			var bitmap = new Bitmap(Size.Width, Size.Height);
-
-			var bd = bitmap.LockBits(bitmap.Bounds(),
-				ImageLockMode.WriteOnly, PixelFormat.Format32bppArgb);
-			for (var y = 0; y < Size.Height; y++)
-				Marshal.Copy(d, y * dataStride, IntPtr.Add(bd.Scan0, y * bd.Stride), dataStride);
-			bitmap.UnlockBits(bd);
-
-			return bitmap;
+			return new Png(GetData(), Size.Width, Size.Height);
 		}
 
-		public Bitmap AsBitmap(TextureChannel channel, IPalette pal)
+		public Png AsPng(TextureChannel channel, IPalette pal)
 		{
 			var d = GetData();
+			var plane = new byte[Size.Width * Size.Height];
 			var dataStride = 4 * Size.Width;
-			var bitmap = new Bitmap(Size.Width, Size.Height);
 			var channelOffset = (int)channel;
 
-			var bd = bitmap.LockBits(bitmap.Bounds(),
-				ImageLockMode.WriteOnly, PixelFormat.Format32bppArgb);
-			unsafe
-			{
-				var colors = (uint*)bd.Scan0;
-				for (var y = 0; y < Size.Height; y++)
-				{
-					var dataRowIndex = y * dataStride + channelOffset;
-					var bdRowIndex = y * bd.Stride / 4;
-					for (var x = 0; x < Size.Width; x++)
-					{
-						var paletteIndex = d[dataRowIndex + 4 * x];
-						colors[bdRowIndex + x] = pal[paletteIndex];
-					}
-				}
-			}
+			for (var y = 0; y < Size.Height; y++)
+				for (var x = 0; x < Size.Width; x++)
+					plane[y * Size.Width + x] = d[y * dataStride + channelOffset + 4 * x];
 
-			bitmap.UnlockBits(bd);
+			var palColors = new Color[Palette.Size];
+			for (var i = 0; i < Palette.Size; i++)
+				palColors[i] = pal.GetColor(i);
 
-			return bitmap;
+			return new Png(plane, Size.Width, Size.Height, palColors);
 		}
 
 		public void CreateBuffer()

--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Drawing;
-using System.Drawing.Imaging;
 using OpenRA.FileFormats;
 
 namespace OpenRA.Graphics

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
@@ -166,8 +165,6 @@ namespace OpenRA
 
 		public string Language = "english";
 		public string DefaultLanguage = "english";
-
-		public ImageFormat ScreenshotFormat = ImageFormat.Png;
 	}
 
 	public class SoundSettings

--- a/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ConvertSpriteToPngCommand.cs
@@ -11,10 +11,8 @@
 
 using System;
 using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using OpenRA.FileFormats;
 using OpenRA.Graphics;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/DumpSequenceSheetsCommand.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			{
 				var max = s == sb.Current ? (int)sb.CurrentChannel + 1 : 4;
 				for (var i = 0; i < max; i++)
-					s.AsBitmap((TextureChannel)ChannelMasks[i], palette).Save("{0}.png".F(count++));
+					s.AsPng((TextureChannel)ChannelMasks[i], palette).Save("{0}.png".F(count++));
 			}
 
 			Console.WriteLine("Saved [0..{0}].png", count - 1);

--- a/OpenRA.Mods.Common/Widgets/HueSliderWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/HueSliderWidget.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Drawing;
-using System.Drawing.Imaging;
 using OpenRA.Graphics;
 using OpenRA.Widgets;
 

--- a/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
+++ b/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
@@ -43,13 +43,13 @@ namespace OpenRA.Platforms.Default
 		Action doPresent;
 		Func<string> getGLVersion;
 		Func<ITexture> getCreateTexture;
-		Func<Bitmap> getTakeScreenshot;
 		Func<object, IFrameBuffer> getCreateFrameBuffer;
 		Func<object, IShader> getCreateShader;
 		Func<object, IVertexBuffer<Vertex>> getCreateVertexBuffer;
 		Action<object> doDrawPrimitives;
 		Action<object> doEnableScissor;
 		Action<object> doSetBlendMode;
+		Action<object> doSaveScreenshot;
 
 		public ThreadedGraphicsContext(Sdl2GraphicsContext context, int batchSize)
 		{
@@ -86,7 +86,6 @@ namespace OpenRA.Platforms.Default
 					doPresent = () => context.Present();
 					getGLVersion = () => context.GLVersion;
 					getCreateTexture = () => new ThreadedTexture(this, (ITextureInternal)context.CreateTexture());
-					getTakeScreenshot = () => context.TakeScreenshot();
 					getCreateFrameBuffer = s => new ThreadedFrameBuffer(this, context.CreateFrameBuffer((Size)s, (ITextureInternal)CreateTexture()));
 					getCreateShader = name => new ThreadedShader(this, context.CreateShader((string)name));
 					getCreateVertexBuffer = length => new ThreadedVertexBuffer(this, context.CreateVertexBuffer((int)length));
@@ -103,6 +102,7 @@ namespace OpenRA.Platforms.Default
 							context.EnableScissor(t.Item1, t.Item2, t.Item3, t.Item4);
 						};
 					doSetBlendMode = mode => { context.SetBlendMode((BlendMode)mode); };
+					doSaveScreenshot = path => context.SaveScreenshot((string)path);
 
 					Monitor.Pulse(syncObject);
 				}
@@ -437,9 +437,9 @@ namespace OpenRA.Platforms.Default
 			Post(doSetBlendMode, mode);
 		}
 
-		public Bitmap TakeScreenshot()
+		public void SaveScreenshot(string path)
 		{
-			return Send(getTakeScreenshot);
+			Post(doSaveScreenshot, path);
 		}
 	}
 


### PR DESCRIPTION
This PR continues the work from #15973 by extending our `Png` class to support image saving (using `Bitmap` internally for now, to be replaced in a followup PR), and porting all consumers to the new API.

This also changes the way screenshot saving works so that more work can be done from the worker thread.  This should reduce the size of the perf hitch when saving screenshots.

Dependency for #15973.
