### PR TITLE
Reuse GPSDotEffect for the lifetime of the actor.

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/GpsDot.cs
+++ b/OpenRA.Mods.Cnc/Traits/GpsDot.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public object Create(ActorInitializer init) { return new GpsDot(this); }
 	}
 
-	class GpsDot : INotifyAddedToWorld, INotifyRemovedFromWorld
+	class GpsDot : INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld
 	{
 		readonly GpsDotInfo info;
 		GpsDotEffect effect;
@@ -38,9 +38,13 @@ namespace OpenRA.Mods.Cnc.Traits
 			this.info = info;
 		}
 
-		void INotifyAddedToWorld.AddedToWorld(Actor self)
+		void INotifyCreated.Created(Actor self)
 		{
 			effect = new GpsDotEffect(self, info);
+		}
+
+		void INotifyAddedToWorld.AddedToWorld(Actor self)
+		{
 			self.World.AddFrameEndTask(w => w.Add(effect));
 		}
 


### PR DESCRIPTION
Fixes #16200.