### PR TITLE
 Add a boolean to show or not Refund X$ on the tooltip while selling. 

### DIFF
--- a/OpenRA.Mods.Common/Traits/Sellable.cs
+++ b/OpenRA.Mods.Common/Traits/Sellable.cs
@@ -20,8 +20,13 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Actor can be sold")]
 	public class SellableInfo : ConditionalTraitInfo
 	{
+		[Desc("Percentage of units value to give back after selling.")]
 		public readonly int RefundPercent = 50;
+
+		[Desc("List of audio clips to play when the actor is being sold.")]
 		public readonly string[] SellSounds = { };
+
+		[Desc("Whether to show the cash tick indicators rising from the actor.")]
 		public readonly bool ShowTicks = true;
 
 		[Desc("Skip playing (reversed) make animation.")]

--- a/OpenRA.Mods.Common/Traits/Sellable.cs
+++ b/OpenRA.Mods.Common/Traits/Sellable.cs
@@ -29,6 +29,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Whether to show the cash tick indicators rising from the actor.")]
 		public readonly bool ShowTicks = true;
 
+		[Desc("Whether to show the refund text on the tooltip, when actor is hovered over with sell order.")]
+		public readonly bool ShowTooltipText = true;
+
 		[Desc("Skip playing (reversed) make animation.")]
 		public readonly bool SkipMakeAnimation = false;
 
@@ -86,7 +89,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool IsTooltipVisible(Player forPlayer)
 		{
-			if (!IsTraitDisabled && self.World.OrderGenerator is SellOrderGenerator)
+			if (info.ShowTooltipText && !IsTraitDisabled && self.World.OrderGenerator is SellOrderGenerator)
 				return forPlayer == self.Owner;
 			return false;
 		}


### PR DESCRIPTION
This logic don't have a check for wether of not if you are gonna get any cash out of it, so if the unit worts nothing (like GLA holes in my case) it shows Refund 0$. I added this boolean to not show it for the Holes.

I didn't really wanna add a check for 0$, because it makes sense to show that if the actor is valued but it is so damaged that it won't give anything back.

Also added descriptions for stuff in Sellable that didn't have one.