### PR TITLE
Fix a crash in soviet05

### DIFF
--- a/mods/ra/maps/soviet-05/soviet05.lua
+++ b/mods/ra/maps/soviet-05/soviet05.lua
@@ -144,7 +144,10 @@ end
 Tick = function()
 	if Greece.HasNoRequiredUnits() and GoodGuy.HasNoRequiredUnits() then
 		player.MarkCompletedObjective(KillAll)
-		player.MarkCompletedObjective(HoldObjective)
+
+		if HoldObjective then
+			player.MarkCompletedObjective(HoldObjective)
+		end
 	end
 
 	if player.HasNoRequiredUnits() then
@@ -226,6 +229,11 @@ WorldLoaded = function()
 
 	RadarDome.GrantCondition("french")
 	Trigger.OnCapture(RadarDome, function()
+		if player.IsObjectiveCompleted(KillAll) then
+			player.MarkCompletedObjective(CaptureObjective)
+			return
+		end
+
 		HoldObjective = player.AddPrimaryObjective("Defend the Radar Dome.")
 		player.MarkCompletedObjective(CaptureObjective)
 		Beacon.New(player, MCVDeploy.CenterPosition)


### PR DESCRIPTION
Fixes #16204.

Any objections if I remove the `ObjectiveMet` sound (in a follow-up)? We are not consistently playing it on all missions and it overlaps with the capture notification (we could delay that one instead, though).