### PR TITLE
RA Balance Changes for March 2019

### DIFF
--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -341,7 +341,7 @@ HIND:
 		Prerequisites: ~hpad, ~techlevel.medium
 		Description: Helicopter gunship armed\nwith dual chainguns.\n  Strong vs Infantry, Light armor\n  Weak vs Tanks, Aircraft
 	Valued:
-		Cost: 1350
+		Cost: 1500
 	Tooltip:
 		Name: Hind
 	UpdatesPlayerStatistics:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -28,7 +28,7 @@ DOG:
 	Passenger:
 		Voice: Move
 	RevealsShroud:
-		Range: 5c0
+		Range: 5c512
 	Armament:
 		Weapon: DogJaw
 		ReloadingCondition: attack-cooldown
@@ -254,7 +254,7 @@ E6:
 		Prerequisites: ~barracks, ~techlevel.infonly
 		Description: Infiltrates and captures\nenemy structures.\n  Unarmed
 	Valued:
-		Cost: 500
+		Cost: 400
 	Tooltip:
 		Name: Engineer
 	UpdatesPlayerStatistics:
@@ -276,7 +276,7 @@ E6:
 		RequiresCondition: !global-reusable-engineers
 		CaptureTypes: building
 		PlayerExperience: 25
-		CaptureDelay: 125
+		CaptureDelay: 200
 	Captures@REUSABLE:
 		RequiresCondition: global-reusable-engineers
 		CaptureTypes: building
@@ -433,6 +433,8 @@ MEDI:
 		AddToArmyValue: true
 	Health:
 		HP: 6000
+	Mobile:
+		Speed: 50
 	RevealsShroud:
 		Range: 3c0
 	Passenger:
@@ -471,6 +473,7 @@ MECH:
 	Health:
 		HP: 8000
 	Mobile:
+		Speed: 50
 		Voice: Move
 	RevealsShroud:
 		Range: 3c0

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -495,7 +495,7 @@ PDOX:
 		InsufficientPowerSpeechNotification: InsufficientPower
 		BeginChargeSpeechNotification: ChronosphereCharging
 		EndChargeSpeechNotification: ChronosphereReady
-		Duration: 500
+		Duration: 400
 		KillCargo: yes
 		DisplayRadarPing: True
 	ChronoshiftPower@advancedchronoshift:
@@ -510,7 +510,7 @@ PDOX:
 		InsufficientPowerSpeechNotification: InsufficientPower
 		BeginChargeSpeechNotification: ChronosphereCharging
 		EndChargeSpeechNotification: ChronosphereReady
-		Duration: 500
+		Duration: 400
 		KillCargo: yes
 		DisplayRadarPing: True
 		Range: 2
@@ -729,9 +729,9 @@ HBOX:
 		Prerequisites: tent, ~structures.allies, ~techlevel.medium
 		Description: Camouflaged static defense with a fireport\nfor a garrisoned soldier.\nCan detect cloaked units.\n  Strong vs Infantry, Light armor\n  Weak vs Tanks, Aircraft
 	Valued:
-		Cost: 700
+		Cost: 750
 	CustomSellValue:
-		Value: 500
+		Value: 550
 	Health:
 		HP: 40000
 	Armor:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -553,7 +553,7 @@ MGG:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 99
+		Speed: 85
 	WithIdleOverlay@SPINNER:
 		Offset: -299,0,171
 		Sequence: spinner

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -571,7 +571,7 @@ MGG:
 MRJ:
 	Inherits: ^Vehicle
 	Valued:
-		Cost: 1100
+		Cost: 1000
 	Tooltip:
 		Name: Mobile Radar Jammer
 	UpdatesPlayerStatistics:
@@ -587,7 +587,7 @@ MRJ:
 	Armor:
 		Type: Heavy
 	Mobile:
-		Speed: 99
+		Speed: 85
 	RevealsShroud:
 		Range: 7c0
 	WithIdleOverlay@SPINNER:

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -118,6 +118,12 @@ TurretGun:
 	TargetActorCenter: true
 	Projectile: Bullet
 		ContrailLength: 30
+		Speed: 170
+		Inaccuracy: 1c138
+	Warhead@1Dam: SpreadDamage
+		Falloff: 100, 55, 20, 5
+		Versus:
+			None: 60
 
 8Inch:
 	Inherits: ^Artillery

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -53,7 +53,7 @@ Maverick:
 	BurstDelays: 7
 	Projectile: Missile
 		Speed: 256
-		Inaccuracy: 512
+		Inaccuracy: 316
 		CruiseAltitude: 2c0
 		RangeLimit: 14c410
 	Warhead@1Dam: SpreadDamage


### PR DESCRIPTION
Followup on #15907.  With the rather recent of addition of #16112, and the still unforeseen consequences on balance, I've gone with a more conservative set of changes. This set of changes is a cut down version of the changes that have been tested thoroughly on the playtest.

The goal of these changes is to give Allies tools for breaking through defensive positions, while also nerfing some overperforming allied assets. Additionally, there are several speed tweaks to allow easier usage of utility units.

**Changes:**

**Hind Cost: 1350 -> 1500**

Hinds overperform at their current price point. Their ability to snipe out rocket soldiers, and therefore their counter, allows a snowballing effect that can be difficult to stop. However, most players like this interaction as a mechanic, due to the skill and precision involved. Therefore, a small price increase should nudge them to be a little less expendable/easy to mass.

**Artillery:
Projectile Speed: 204 -> 170
Inaccuracy: 1c938 -> 1c138
Custom Falloff: 100, 55, 20, 5
Damage vs None: 90 -> 60**

The Artillery changes have been adjusted based on feedback since #15907.  The accuracy increase has been reduced and the damage model has been simplified. Artillery is capable of punching through defensive lines now if needed, which is something Allies have struggled with. Additionally, its potency vs infantry has been reduced, which has long been a complaint of players. 

**Chronosphere Duration: 500 -> 400**

A minor buff to this underutilized superweapon. A shorter shift time allows less time for your chrono'd units to get caught, and therefore killed, making Chronosphere use a less risky endeavor. Most uses of the Chronosphere (harassment, crushing, tech sniping) can be done in less than 400.

**Medic and Mechanic Speed Change: 56 -> 50**

A minor reduction in speed encourages these utility units to stay in the back of your army. 

**Camo Pillbox Cost: 700 -> 750**

Feedback since #15907 has shown I was a little too hasty to nerf Camo Pillboxes. #15866 has fixed several frustrating bugs with the defense, and combined with artillery changes has made them less of a problem. However, 100 cost for invisibility is still too cheap (Normal Pillboxes cost 600). At 750, Camo's will cost 150 more than pillboxes, which is a more fair trade off.

**Mobile Radar Jammer:
Cost: 1100 -> 1000
Speed: 99 -> 85**

MRJ's have always been an underutilized unit. A slight cost decrease should encourage more use. This change is also an attempt to balance out the buffs to the mammoth tank resulting from #16112.

Their speed has also been adjusted to match Medium Tanks, which should help prevent them from suiciding into enemy armies.

**Engineer:
Cost: 500 -> 400
CaptureDelay: 125-> 200**

#15661 prompted a long look by the community to figure out how to make it work in competitive. A cost decrease was necessary due to the move from reusable to consumable. A moderate capture delay of 8 seconds allows some time for counter play, but is still short enough to cap if there are no enemy units nearby.

**MIG: Inaccuracy: 512 -> 316**

There were a lot of tests this playtest to figure out how to buff Migs, but ultimately attempts proved to make them too powerful. Regardless, it was discovered Migs deal inconsistent damage. An accuracy increase should help make their use more consistent.

**DOG: Vision 5c- > 5c512**

Dogs are most often used due to their higher vision than rifles (4c vs 5c) in the opening stages of a match. However, the vision advantage is difficult to use due to the way openRA handles vision, resulting in wonky plays such as moving only in cardinal directions (N/S/E/W). By giving them an additional half cell vision, this widens the vision advantage, making their use more consistent. An additional benefit is it's easier to activate their new running attack.
