### PR TITLE
Childactivity fixes

### DIFF
--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -234,20 +234,20 @@ namespace OpenRA.Activities
 			return true;
 		}
 
-		public virtual void Queue(Activity activity)
+		public virtual void Queue(Actor self, Activity activity, bool pretick = false)
 		{
 			if (NextInQueue != null)
-				NextInQueue.Queue(activity);
+				NextInQueue.Queue(self, activity);
 			else
-				NextInQueue = activity;
+				NextInQueue = pretick ? ActivityUtils.RunActivity(self, activity) : activity;
 		}
 
-		public virtual void QueueChild(Activity activity)
+		public virtual void QueueChild(Actor self, Activity activity, bool pretick = false)
 		{
 			if (ChildActivity != null)
-				ChildActivity.Queue(activity);
+				ChildActivity.Queue(self, activity);
 			else
-				ChildActivity = activity;
+				ChildActivity = pretick ? ActivityUtils.RunActivity(self, activity) : activity;
 		}
 
 		/// <summary>
@@ -258,10 +258,10 @@ namespace OpenRA.Activities
 		/// </summary>
 		/// <param name="origin">Activity from which to start traversing, and which to mark. If null, mark the calling activity, and start traversal from the root.</param>
 		/// <param name="level">Initial level of indentation.</param>
-		protected void PrintActivityTree(Activity origin = null, int level = 0)
+		protected void PrintActivityTree(Actor self, Activity origin = null, int level = 0)
 		{
 			if (origin == null)
-				RootActivity.PrintActivityTree(this);
+				RootActivity.PrintActivityTree(self, this);
 			else
 			{
 				Console.Write(new string(' ', level * 2));
@@ -271,10 +271,10 @@ namespace OpenRA.Activities
 				Console.WriteLine(this.GetType().ToString().Split('.').Last());
 
 				if (ChildActivity != null)
-					ChildActivity.PrintActivityTree(origin, level + 1);
+					ChildActivity.PrintActivityTree(self, origin, level + 1);
 
 				if (NextInQueue != null)
-					NextInQueue.PrintActivityTree(origin, level);
+					NextInQueue.PrintActivityTree(self, origin, level);
 			}
 		}
 

--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -285,29 +285,6 @@ namespace OpenRA.Activities
 		}
 	}
 
-	/// <summary>
-	/// In contrast to the base activity class, which is responsible for running its children itself,
-	/// composite activities rely on the actor's activity-running logic for their children.
-	/// </summary>
-	public abstract class CompositeActivity : Activity
-	{
-		/// <summary>
-		/// The getter will return the first non-null value of either child, next or parent activity, in that order, or ultimately null.
-		/// </summary>
-		public override Activity NextActivity
-		{
-			get
-			{
-				if (ChildActivity != null)
-					return ChildActivity;
-				else if (NextInQueue != null)
-					return NextInQueue;
-				else
-					return ParentActivity;
-			}
-		}
-	}
-
 	public static class ActivityExts
 	{
 		public static IEnumerable<Target> GetTargetQueue(this Actor self)

--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Activities
 		{
 			get
 			{
-				return childActivity != null && childActivity.State < ActivityState.Done ? childActivity : null;
+				return childActivity != null && childActivity.State != ActivityState.Done ? childActivity : null;
 			}
 
 			set
@@ -229,7 +229,6 @@ namespace OpenRA.Activities
 			if (!keepQueue)
 				NextActivity = null;
 
-			ChildActivity = null;
 			State = ActivityState.Canceled;
 
 			return true;

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -222,7 +222,7 @@ namespace OpenRA
 			if (CurrentActivity == null)
 				CurrentActivity = nextActivity;
 			else
-				CurrentActivity.RootActivity.Queue(nextActivity);
+				CurrentActivity.RootActivity.Queue(this, nextActivity);
 		}
 
 		public bool CancelActivity()

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -225,12 +225,10 @@ namespace OpenRA
 				CurrentActivity.RootActivity.Queue(this, nextActivity);
 		}
 
-		public bool CancelActivity()
+		public void CancelActivity()
 		{
 			if (CurrentActivity != null)
-				return CurrentActivity.RootActivity.Cancel(this);
-
-			return true;
+				CurrentActivity.RootActivity.Cancel(this);
 		}
 
 		public override int GetHashCode()

--- a/OpenRA.Game/Traits/ActivityUtils.cs
+++ b/OpenRA.Game/Traits/ActivityUtils.cs
@@ -51,10 +51,10 @@ namespace OpenRA.Traits
 			return act;
 		}
 
-		public static Activity SequenceActivities(params Activity[] acts)
+		public static Activity SequenceActivities(Actor self, params Activity[] acts)
 		{
 			return acts.Reverse().Aggregate(
-				(next, a) => { a.Queue(next); return a; });
+				(next, a) => { a.Queue(self, next); return a; });
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Activities/LayMines.cs
+++ b/OpenRA.Mods.Cnc/Activities/LayMines.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Cnc.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (IsCanceled)
+			if (IsCanceling)
 				return NextActivity;
 
 			if (rearmableInfo != null && ammoPools.Any(p => p.Info.Name == info.AmmoPoolName && !p.HasAmmo()))

--- a/OpenRA.Mods.Cnc/Activities/LayMines.cs
+++ b/OpenRA.Mods.Cnc/Activities/LayMines.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Cnc.Activities
 					return new Wait(20);
 
 				// Add a CloseEnough range of 512 to the Rearm/Repair activities in order to ensure that we're at the host actor
-				return ActivityUtils.SequenceActivities(
+				return ActivityUtils.SequenceActivities(self,
 					new MoveAdjacentTo(self, Target.FromActor(rearmTarget)),
 					movement.MoveTo(self.World.Map.CellContaining(rearmTarget.CenterPosition), rearmTarget),
 					new Rearm(self, rearmTarget, new WDist(512)),
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Cnc.Activities
 			if (minelayer.Minefield.Contains(self.Location) && ShouldLayMine(self, self.Location))
 			{
 				LayMine(self);
-				return ActivityUtils.SequenceActivities(new Wait(20), this); // A little wait after placing each mine, for show
+				return ActivityUtils.SequenceActivities(self, new Wait(20), this); // A little wait after placing each mine, for show
 			}
 
 			if (minelayer.Minefield.Length > 0)
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				{
 					var p = minelayer.Minefield.Random(self.World.SharedRandom);
 					if (ShouldLayMine(self, p))
-						return ActivityUtils.SequenceActivities(movement.MoveTo(p, 0), this);
+						return ActivityUtils.SequenceActivities(self, movement.MoveTo(p, 0), this);
 				}
 			}
 

--- a/OpenRA.Mods.Cnc/Activities/Leap.cs
+++ b/OpenRA.Mods.Cnc/Activities/Leap.cs
@@ -108,7 +108,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				attack.DoAttack(self, target);
 
 				jumpComplete = true;
-				QueueChild(mobile.VisualMove(self, position, self.World.Map.CenterOfSubCell(destinationCell, destinationSubCell)));
+				QueueChild(self, mobile.VisualMove(self, position, self.World.Map.CenterOfSubCell(destinationCell, destinationSubCell)), true);
 
 				return this;
 			}

--- a/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
+++ b/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				return this;
 			}
 
-			if (IsCanceled)
+			if (IsCanceling)
 				return NextActivity;
 
 			bool targetIsHiddenActor;

--- a/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
+++ b/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				if (!allowMovement || lastVisibleMaxRange == WDist.Zero || lastVisibleMaxRange < lastVisibleMinRange)
 					return NextActivity;
 
-				QueueChild(mobile.MoveWithinRange(target, lastVisibleMinRange, lastVisibleMaxRange, checkTarget.CenterPosition, Color.Red));
+				QueueChild(self, mobile.MoveWithinRange(target, lastVisibleMinRange, lastVisibleMaxRange, checkTarget.CenterPosition, Color.Red), true);
 				return this;
 			}
 
@@ -127,11 +127,11 @@ namespace OpenRA.Mods.Cnc.Activities
 			var desiredFacing = (destination - origin).Yaw.Facing;
 			if (mobile.Facing != desiredFacing)
 			{
-				QueueChild(new Turn(self, desiredFacing));
+				QueueChild(self, new Turn(self, desiredFacing), true);
 				return this;
 			}
 
-			QueueChild(new Leap(self, target, mobile, targetMobile, info.Speed.Length, attack, edible));
+			QueueChild(self, new Leap(self, target, mobile, targetMobile, info.Speed.Length, attack, edible), true);
 
 			// Re-queue the child activities to kill the target if it didn't die in one go
 			return this;

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTDGunboatTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTDGunboatTurreted.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			public override Activity Tick(Actor self)
 			{
-				if (IsCanceled || !target.IsValidFor(self))
+				if (IsCanceling || !target.IsValidFor(self))
 					return NextActivity;
 
 				if (attack.IsTraitDisabled)

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
@@ -91,7 +91,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			public override Activity Tick(Actor self)
 			{
-				if (IsCanceled || !attack.CanAttack(self, target))
+				if (IsCanceling || !attack.CanAttack(self, target))
 					return NextActivity;
 
 				if (attack.charges == 0)
@@ -120,7 +120,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			public override Activity Tick(Actor self)
 			{
-				if (IsCanceled || !attack.CanAttack(self, target))
+				if (IsCanceling || !attack.CanAttack(self, target))
 					return NextActivity;
 
 				if (attack.charges == 0)

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
@@ -103,7 +103,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				if (!string.IsNullOrEmpty(attack.info.ChargeAudio))
 					Game.Sound.Play(SoundType.World, attack.info.ChargeAudio, self.CenterPosition);
 
-				return ActivityUtils.SequenceActivities(new Wait(attack.info.InitialChargeDelay), new ChargeFire(attack, target), this);
+				return ActivityUtils.SequenceActivities(self, new Wait(attack.info.InitialChargeDelay), new ChargeFire(attack, target), this);
 			}
 		}
 
@@ -128,7 +128,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 				attack.DoAttack(self, target);
 
-				return ActivityUtils.SequenceActivities(new Wait(attack.info.ChargeDelay), this);
+				return ActivityUtils.SequenceActivities(self, new Wait(attack.info.ChargeDelay), this);
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (aircraft.ForceLanding)
 				Cancel(self);
 
-			if (IsCanceled)
+			if (IsCanceling)
 				return NextActivity;
 
 			bool targetIsHiddenActor;

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// If all valid weapons have depleted their ammo and Rearmable trait exists, return to RearmActor to reload and then resume the activity
 			if (rearmable != null && !useLastVisibleTarget && attackAircraft.Armaments.All(x => x.IsTraitPaused || !x.Weapon.IsValidAgainst(target, self.World, self)))
-				return ActivityUtils.SequenceActivities(new ReturnToBase(self, aircraft.Info.AbortOnResupply), this);
+				return ActivityUtils.SequenceActivities(self, new ReturnToBase(self, aircraft.Info.AbortOnResupply), this);
 
 			var pos = self.CenterPosition;
 			var checkTarget = useLastVisibleTarget ? lastVisibleTarget : target;
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.Activities
 					return NextActivity;
 
 				// Fly towards the last known position
-				return ActivityUtils.SequenceActivities(
+				return ActivityUtils.SequenceActivities(self,
 					new Fly(self, target, WDist.Zero, lastVisibleMaximumRange, checkTarget.CenterPosition, Color.Red),
 					this);
 			}
@@ -103,18 +103,18 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				// TODO: This should fire each weapon at its maximum range
 				if (attackAircraft != null && target.IsInRange(self.CenterPosition, attackAircraft.GetMinimumRange()))
-					ChildActivity = ActivityUtils.SequenceActivities(
+					ChildActivity = ActivityUtils.SequenceActivities(self,
 						new FlyTimed(ticksUntilTurn, self),
 						new Fly(self, target, checkTarget.CenterPosition, Color.Red),
 						new FlyTimed(ticksUntilTurn, self));
 				else
-					ChildActivity = ActivityUtils.SequenceActivities(
+					ChildActivity = ActivityUtils.SequenceActivities(self,
 						new Fly(self, target, checkTarget.CenterPosition, Color.Red),
 						new FlyTimed(ticksUntilTurn, self));
 
 				// HACK: This needs to be done in this round-about way because TakeOff doesn't behave as expected when it doesn't have a NextActivity.
 				if (self.World.Map.DistanceAboveTerrain(self.CenterPosition).Length < aircraft.Info.MinAirborneAltitude)
-					ChildActivity = ActivityUtils.SequenceActivities(new TakeOff(self), ChildActivity);
+					ChildActivity = ActivityUtils.SequenceActivities(self, new TakeOff(self), ChildActivity);
 			}
 
 			ActivityUtils.RunActivity(self, ChildActivity);

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (aircraft.ForceLanding)
 				Cancel(self);
 
-			if (IsCanceled)
+			if (IsCanceling)
 				return NextActivity;
 
 			bool targetIsHiddenActor;

--- a/OpenRA.Mods.Common/Activities/Air/FlyCircle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyCircle.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 			}
 
-			if (IsCanceled)
+			if (IsCanceling)
 				return NextActivity;
 
 			if (remainingTicks > 0)

--- a/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (aircraft.ForceLanding)
 				Cancel(self);
 
-			if (IsCanceled)
+			if (IsCanceling)
 				return NextActivity;
 
 			bool targetIsHiddenActor;

--- a/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
@@ -89,7 +89,7 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			wasMovingWithinRange = true;
-			return ActivityUtils.SequenceActivities(
+			return ActivityUtils.SequenceActivities(self,
 				aircraft.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, targetLineColor),
 				this);
 		}

--- a/OpenRA.Mods.Common/Activities/Air/FlyOffMap.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyOffMap.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 			}
 
-			if (IsCanceled || !self.World.Map.Contains(self.Location))
+			if (IsCanceling || !self.World.Map.Contains(self.Location))
 				return NextActivity;
 
 			Fly.FlyToward(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);

--- a/OpenRA.Mods.Common/Activities/Air/FlyTimed.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyTimed.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 			}
 
-			if (IsCanceled || remainingTicks-- == 0)
+			if (IsCanceling || remainingTicks-- == 0)
 				return NextActivity;
 
 			Fly.FlyToward(self, aircraft, aircraft.Facing, cruiseAltitude);

--- a/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (aircraft.ForceLanding)
 				Cancel(self);
 
-			if (IsCanceled)
+			if (IsCanceling)
 				return NextActivity;
 
 			bool targetIsHiddenActor;

--- a/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// If all valid weapons have depleted their ammo and Rearmable trait exists, return to RearmActor to reload and then resume the activity
 			if (rearmable != null && !useLastVisibleTarget && attackAircraft.Armaments.All(x => x.IsTraitPaused || !x.Weapon.IsValidAgainst(target, self.World, self)))
-				return ActivityUtils.SequenceActivities(new HeliReturnToBase(self, aircraft.Info.AbortOnResupply), this);
+				return ActivityUtils.SequenceActivities(self, new HeliReturnToBase(self, aircraft.Info.AbortOnResupply), this);
 
 			var pos = self.CenterPosition;
 			var checkTarget = useLastVisibleTarget ? lastVisibleTarget : target;

--- a/OpenRA.Mods.Common/Activities/Air/HeliFly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliFly.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (aircraft.ForceLanding)
 				Cancel(self);
 
-			if (IsCanceled)
+			if (IsCanceling)
 				return NextActivity;
 
 			bool targetIsHiddenActor;
@@ -156,7 +156,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			var activity = base.Tick(self);
 
-			if (activity == null && !IsCanceled && info.LandWhenIdle)
+			if (activity == null && !IsCanceling && info.LandWhenIdle)
 			{
 				if (info.TurnToLand)
 					self.QueueActivity(new Turn(self, info.InitialFacing));

--- a/OpenRA.Mods.Common/Activities/Air/HeliFlyCircle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliFlyCircle.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 			}
 
-			if (IsCanceled)
+			if (IsCanceling)
 				return NextActivity;
 
 			if (HeliFly.AdjustAltitude(self, aircraft, aircraft.Info.CruiseAltitude))

--- a/OpenRA.Mods.Common/Activities/Air/HeliLand.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliLand.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (IsCanceled)
+			if (IsCanceling)
 				return NextActivity;
 
 			if (requireSpace && !aircraft.CanLand(self.Location))

--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (aircraft.ForceLanding)
 				return NextActivity;
 
-			if (IsCanceled)
+			if (IsCanceling)
 				return NextActivity;
 
 			if (dest == null || dest.IsDead || !Reservable.IsAvailableFor(dest, self))

--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (nearestResupplier == null && aircraft.Info.LandWhenIdle)
 				{
 					if (aircraft.Info.TurnToLand)
-						return ActivityUtils.SequenceActivities(new Turn(self, initialFacing), new HeliLand(self, true));
+						return ActivityUtils.SequenceActivities(self, new Turn(self, initialFacing), new HeliLand(self, true));
 
 					return new HeliLand(self, true);
 				}
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Activities
 
 						var target = Target.FromPos(nearestResupplier.CenterPosition + randomPosition);
 
-						return ActivityUtils.SequenceActivities(
+						return ActivityUtils.SequenceActivities(self,
 							new HeliFly(self, target, WDist.Zero, aircraft.Info.WaitDistanceFromResupplyBase, targetLineColor: Color.Green),
 							this);
 					}
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.Common.Activities
 			else
 				landingProcedures.Add(NextActivity);
 
-			return ActivityUtils.SequenceActivities(landingProcedures.ToArray());
+			return ActivityUtils.SequenceActivities(self, landingProcedures.ToArray());
 		}
 
 		bool ShouldLandAtBuilding(Actor self, Actor dest)

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (!target.IsValidFor(self))
 				Cancel(self);
 
-			if (IsCanceled)
+			if (IsCanceling)
 				return NextActivity;
 
 			if (!soundPlayed && aircraft.Info.LandingSounds.Length > 0 && !self.IsAtGroundLevel())

--- a/OpenRA.Mods.Common/Activities/Air/ResupplyAircraft.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ResupplyAircraft.cs
@@ -30,19 +30,15 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (!aircraft.Info.TakeOffOnResupply)
 			{
-				ChildActivity = ActivityUtils.SequenceActivities(
-					aircraft.GetResupplyActivities(host)
-					.Append(new AllowYieldingReservation(self))
-					.Append(new WaitFor(() => NextInQueue != null || aircraft.ReservedActor == null))
-					.ToArray());
+				ChildActivity = ActivityUtils.SequenceActivities(self, aircraft.GetResupplyActivities(host).ToArray());
+				QueueChild(self, new AllowYieldingReservation(self));
+				QueueChild(self, new WaitFor(() => NextInQueue != null || aircraft.ReservedActor == null));
 			}
 			else
 			{
-				ChildActivity = ActivityUtils.SequenceActivities(
-					aircraft.GetResupplyActivities(host)
-					.Append(new AllowYieldingReservation(self))
-					.Append(new TakeOff(self, (a, b, c) => NextInQueue == null && b.NextInQueue == null))
-					.ToArray());
+				ChildActivity = ActivityUtils.SequenceActivities(self, aircraft.GetResupplyActivities(host).ToArray());
+				QueueChild(self, new AllowYieldingReservation(self));
+				QueueChild(self, new TakeOff(self, (a, b, c) => NextInQueue == null && b.NextInQueue == null));
 			}
 		}
 

--- a/OpenRA.Mods.Common/Activities/Air/ResupplyAircraft.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ResupplyAircraft.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
-	public class ResupplyAircraft : CompositeActivity
+	public class ResupplyAircraft : Activity
 	{
 		public ResupplyAircraft(Actor self) { }
 
@@ -48,9 +48,18 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
+			if (ChildActivity != null)
+			{
+				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
+				return this;
+			}
+
 			// Conditional fixes being able to stop aircraft from resupplying.
 			if (IsCanceled && NextInQueue == null)
+			{
 				OnFirstRun(self);
+				return this;
+			}
 
 			return NextActivity;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/ResupplyAircraft.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ResupplyAircraft.cs
@@ -51,11 +51,8 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			// Conditional fixes being able to stop aircraft from resupplying.
-			if (IsCanceled && NextInQueue == null)
-			{
-				OnFirstRun(self);
-				return this;
-			}
+			if (IsCanceling && NextInQueue == null)
+				return new ResupplyAircraft(self);
 
 			return NextActivity;
 		}

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -135,7 +135,7 @@ namespace OpenRA.Mods.Common.Activities
 				var nearestResupplier = ChooseResupplier(self, false);
 
 				if (nearestResupplier != null)
-					return ActivityUtils.SequenceActivities(
+					return ActivityUtils.SequenceActivities(self,
 						new Fly(self, Target.FromActor(nearestResupplier), WDist.Zero, aircraft.Info.WaitDistanceFromResupplyBase, targetLineColor: Color.Green),
 						new FlyCircle(self, aircraft.Info.NumberOfTicksToVerifyAvailableAirport),
 						this);
@@ -168,7 +168,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (!abortOnResupply)
 				landingProcedures.Add(NextActivity);
 
-			return ActivityUtils.SequenceActivities(landingProcedures.ToArray());
+			return ActivityUtils.SequenceActivities(self, landingProcedures.ToArray());
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -124,7 +124,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (aircraft.ForceLanding)
 				return NextActivity;
 
-			if (IsCanceled || self.IsDead)
+			if (IsCanceling || self.IsDead)
 				return NextActivity;
 
 			if (!isCalculated)

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				// Move towards the last known position
 				wasMovingWithinRange = true;
-				return ActivityUtils.SequenceActivities(
+				return ActivityUtils.SequenceActivities(self,
 					move.MoveWithinRange(target, WDist.Zero, lastVisibleMaximumRange, checkTarget.CenterPosition, Color.Red),
 					this);
 			}
@@ -168,7 +168,7 @@ namespace OpenRA.Mods.Common.Activities
 				var sightRange = rs != null ? rs.Range : WDist.FromCells(2);
 
 				attackStatus |= AttackStatus.NeedsToMove;
-				moveActivity = ActivityUtils.SequenceActivities(
+				moveActivity = ActivityUtils.SequenceActivities(self,
 					move.MoveWithinRange(target, sightRange, target.CenterPosition, Color.Red),
 					this);
 
@@ -195,9 +195,8 @@ namespace OpenRA.Mods.Common.Activities
 					return AttackStatus.UnableToAttack;
 
 				attackStatus |= AttackStatus.NeedsToMove;
-
 				var checkTarget = useLastVisibleTarget ? lastVisibleTarget : target;
-				moveActivity = ActivityUtils.SequenceActivities(
+				moveActivity = ActivityUtils.SequenceActivities(self,
 					move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, Color.Red),
 					this);
 
@@ -209,7 +208,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (!Util.FacingWithinTolerance(facing.Facing, desiredFacing, ((AttackFrontalInfo)attack.Info).FacingTolerance))
 			{
 				attackStatus |= AttackStatus.NeedsToTurn;
-				turnActivity = ActivityUtils.SequenceActivities(new Turn(self, desiredFacing), this);
+				turnActivity = ActivityUtils.SequenceActivities(self, new Turn(self, desiredFacing), this);
 				return AttackStatus.NeedsToTurn;
 			}
 

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (IsCanceled)
+			if (IsCanceling)
 				return NextActivity;
 
 			bool targetIsHiddenActor;
@@ -145,7 +145,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected virtual AttackStatus TickAttack(Actor self, AttackFrontal attack)
 		{
-			if (IsCanceled)
+			if (IsCanceling)
 				return AttackStatus.UnableToAttack;
 
 			if (!target.IsValidFor(self))

--- a/OpenRA.Mods.Common/Activities/DeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverResources.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// No refineries exist; check again after delay defined in Harvester.
 			if (harv.LinkedProc == null)
-				return ActivityUtils.SequenceActivities(new Wait(harv.Info.SearchForDeliveryBuildingDelay), this);
+				return ActivityUtils.SequenceActivities(self, new Wait(harv.Info.SearchForDeliveryBuildingDelay), this);
 
 			var proc = harv.LinkedProc;
 			var iao = proc.Trait<IAcceptResources>();
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Activities
 				foreach (var n in self.TraitsImplementing<INotifyHarvesterAction>())
 					n.MovingToRefinery(self, proc, null);
 
-				return ActivityUtils.SequenceActivities(movement.MoveTo(proc.Location + iao.DeliveryOffset, 0), this);
+				return ActivityUtils.SequenceActivities(self, movement.MoveTo(proc.Location + iao.DeliveryOffset, 0), this);
 			}
 
 			if (!isDocking)
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Activities
 				iao.OnDock(self, this);
 			}
 
-			return ActivityUtils.SequenceActivities(new Wait(10), this);
+			return ActivityUtils.SequenceActivities(self, new Wait(10), this);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Activities
 					// Can't land, so wait at the target until something changes
 					if (!targetLocation.HasValue)
 					{
-						innerActivity = ActivityUtils.SequenceActivities(
+						innerActivity = ActivityUtils.SequenceActivities(self,
 							new HeliFly(self, Target.FromCell(self.World, destination)),
 							new Wait(25));
 
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.Common.Activities
 						{
 							var facing = (targetPosition - self.CenterPosition).Yaw.Facing;
 							localOffset = carryall.CarryableOffset.Rotate(body.QuantizeOrientation(self, WRot.FromFacing(facing)));
-							innerActivity = ActivityUtils.SequenceActivities(
+							innerActivity = ActivityUtils.SequenceActivities(self,
 								new HeliFly(self, Target.FromPos(targetPosition - body.LocalToWorld(localOffset))),
 								new Turn(self, facing));
 
@@ -170,7 +170,7 @@ namespace OpenRA.Mods.Common.Activities
 					return this;
 
 				case DeliveryState.TakeOff:
-					return ActivityUtils.SequenceActivities(new HeliFly(self, Target.FromPos(self.CenterPosition)), NextActivity);
+					return ActivityUtils.SequenceActivities(self, new HeliFly(self, Target.FromPos(self.CenterPosition)), NextActivity);
 
 				case DeliveryState.Aborted:
 					carryall.UnreserveCarryable(self);

--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -206,12 +206,12 @@ namespace OpenRA.Mods.Common.Activities
 			});
 		}
 
-		public override bool Cancel(Actor self, bool keepQueue = false)
+		public override void Cancel(Actor self, bool keepQueue = false)
 		{
 			if (!IsCanceling && innerActivity != null)
 				innerActivity.Cancel(self);
 
-			return base.Cancel(self);
+			base.Cancel(self);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Activities
 				return this;
 			}
 
-			if (IsCanceled)
+			if (IsCanceling)
 				return NextActivity;
 
 			if ((carryall.State == Carryall.CarryallState.Idle || carryall.Carryable.IsDead) && state != DeliveryState.TakeOff)
@@ -208,8 +208,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override bool Cancel(Actor self, bool keepQueue = false)
 		{
-			if (!IsCanceled && innerActivity != null && !innerActivity.Cancel(self))
-				return false;
+			if (!IsCanceling && innerActivity != null)
+				innerActivity.Cancel(self);
 
 			return base.Cancel(self);
 		}

--- a/OpenRA.Mods.Common/Activities/DeployForGrantedCondition.cs
+++ b/OpenRA.Mods.Common/Activities/DeployForGrantedCondition.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			// Without this, turn for facing deploy angle will be canceled and immediately deploy!
-			if (IsCanceled)
+			if (IsCanceling)
 				return NextActivity;
 
 			if (IsInterruptible)

--- a/OpenRA.Mods.Common/Activities/DeployForGrantedCondition.cs
+++ b/OpenRA.Mods.Common/Activities/DeployForGrantedCondition.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			// Turn to the required facing.
 			if (deploy.Info.Facing != -1 && canTurn)
-				QueueChild(new Turn(self, deploy.Info.Facing));
+				QueueChild(self, new Turn(self, deploy.Info.Facing));
 		}
 
 		public override Activity Tick(Actor self)

--- a/OpenRA.Mods.Common/Activities/Enter.cs
+++ b/OpenRA.Mods.Common/Activities/Enter.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Activities
 			useLastVisibleTarget = targetIsHiddenActor || !target.IsValidFor(self);
 
 			// Cancel immediately if the target died while we were entering it
-			if (!IsCanceled && useLastVisibleTarget && lastState == EnterState.Entering)
+			if (!IsCanceling && useLastVisibleTarget && lastState == EnterState.Entering)
 				Cancel(self, true);
 
 			TickInner(self, target, useLastVisibleTarget);
@@ -101,7 +101,7 @@ namespace OpenRA.Mods.Common.Activities
 				{
 					// NOTE: We can safely cancel in this case because we know the
 					// actor has finished any in-progress move activities
-					if (IsCanceled)
+					if (IsCanceling)
 						return NextActivity;
 
 					// Lost track of the target
@@ -134,7 +134,7 @@ namespace OpenRA.Mods.Common.Activities
 
 					// Subclasses can cancel the activity during TryStartEnter
 					// Return immediately to avoid an extra tick's delay
-					if (IsCanceled)
+					if (IsCanceling)
 						return NextActivity;
 
 					lastState = EnterState.Waiting;
@@ -145,7 +145,7 @@ namespace OpenRA.Mods.Common.Activities
 				{
 					// Check that we reached the requested position
 					var targetPos = target.Positions.PositionClosestTo(self.CenterPosition);
-					if (!IsCanceled && self.CenterPosition == targetPos && target.Type == TargetType.Actor)
+					if (!IsCanceling && self.CenterPosition == targetPos && target.Type == TargetType.Actor)
 						OnEnterComplete(self, target.Actor);
 
 					lastState = EnterState.Exiting;
@@ -164,8 +164,8 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			OnCancel(self);
 
-			if (!IsCanceled && moveActivity != null && !moveActivity.Cancel(self))
-				return false;
+			if (!IsCanceling && moveActivity != null)
+				moveActivity.Cancel(self);
 
 			return base.Cancel(self, keepQueue);
 		}

--- a/OpenRA.Mods.Common/Activities/Enter.cs
+++ b/OpenRA.Mods.Common/Activities/Enter.cs
@@ -160,14 +160,14 @@ namespace OpenRA.Mods.Common.Activities
 			return this;
 		}
 
-		public override bool Cancel(Actor self, bool keepQueue = false)
+		public override void Cancel(Actor self, bool keepQueue = false)
 		{
 			OnCancel(self);
 
 			if (!IsCanceling && moveActivity != null)
 				moveActivity.Cancel(self);
 
-			return base.Cancel(self, keepQueue);
+			base.Cancel(self, keepQueue);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/EnterTransport.cs
+++ b/OpenRA.Mods.Common/Activities/EnterTransport.cs
@@ -133,12 +133,12 @@ namespace OpenRA.Mods.Common.Activities
 			return NextActivity;
 		}
 
-		public override bool Cancel(Actor self, bool keepQueue = false)
+		public override void Cancel(Actor self, bool keepQueue = false)
 		{
 			if (!IsCanceling && enterTransport != null)
 				enterTransport.Cancel(self);
 
-			return base.Cancel(self, keepQueue);
+			base.Cancel(self, keepQueue);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/EnterTransport.cs
+++ b/OpenRA.Mods.Common/Activities/EnterTransport.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			// Try and find a new transport nearby
-			if (IsCanceled || string.IsNullOrEmpty(type))
+			if (IsCanceling || string.IsNullOrEmpty(type))
 				return NextActivity;
 
 			Func<Actor, bool> isValidTransport = a =>
@@ -135,8 +135,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override bool Cancel(Actor self, bool keepQueue = false)
 		{
-			if (!IsCanceled && enterTransport != null && !enterTransport.Cancel(self))
-				return false;
+			if (!IsCanceling && enterTransport != null)
+				enterTransport.Cancel(self);
 
 			return base.Cancel(self, keepQueue);
 		}

--- a/OpenRA.Mods.Common/Activities/FindResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindResources.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (IsCanceled)
+			if (IsCanceling)
 				return NextActivity;
 
 			if (harv.IsFull)

--- a/OpenRA.Mods.Common/Activities/FindResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindResources.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (harv.IsFull)
 			{
 				// HACK: DeliverResources is ignored if there are queued activities, so discard NextActivity
-				return ActivityUtils.SequenceActivities(new DeliverResources(self));
+				return ActivityUtils.SequenceActivities(self, new DeliverResources(self));
 			}
 
 			var closestHarvestablePosition = ClosestHarvestablePos(self);
@@ -82,13 +82,13 @@ namespace OpenRA.Mods.Common.Activities
 				// Avoid creating an activity cycle
 				var next = NextInQueue;
 				NextInQueue = null;
-				return ActivityUtils.SequenceActivities(next, new Wait(randFrames), this);
+				return ActivityUtils.SequenceActivities(self, next, new Wait(randFrames), this);
 			}
 			else
 			{
 				// Attempt to claim the target cell
 				if (!claimLayer.TryClaimCell(self, closestHarvestablePosition.Value))
-					return ActivityUtils.SequenceActivities(new Wait(25), this);
+					return ActivityUtils.SequenceActivities(self, new Wait(25), this);
 
 				harv.LastSearchFailed = false;
 
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Activities
 					n.MovingToResources(self, closestHarvestablePosition.Value, this);
 
 				self.SetTargetLine(Target.FromCell(self.World, closestHarvestablePosition.Value), Color.Red, false);
-				return ActivityUtils.SequenceActivities(mobile.MoveTo(closestHarvestablePosition.Value, 1), new HarvestResource(self), this);
+				return ActivityUtils.SequenceActivities(self, mobile.MoveTo(closestHarvestablePosition.Value, 1), new HarvestResource(self), this);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Activities/HarvestResource.cs
+++ b/OpenRA.Mods.Common/Activities/HarvestResource.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (IsCanceled)
+			if (IsCanceling)
 			{
 				claimLayer.RemoveClaim(self);
 				return NextActivity;

--- a/OpenRA.Mods.Common/Activities/HarvestResource.cs
+++ b/OpenRA.Mods.Common/Activities/HarvestResource.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Activities
 				var current = facing.Facing;
 				var desired = body.QuantizeFacing(current, harvInfo.HarvestFacings);
 				if (desired != current)
-					return ActivityUtils.SequenceActivities(new Turn(self, desired), this);
+					return ActivityUtils.SequenceActivities(self, new Turn(self, desired), this);
 			}
 
 			var resource = resLayer.Harvest(self.Location);
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Activities
 			foreach (var t in self.TraitsImplementing<INotifyHarvesterAction>())
 				t.Harvested(self, resource);
 
-			return ActivityUtils.SequenceActivities(new Wait(harvInfo.BaleLoadDelay), this);
+			return ActivityUtils.SequenceActivities(self, new Wait(harvInfo.BaleLoadDelay), this);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
@@ -54,8 +54,8 @@ namespace OpenRA.Mods.Common.Activities
 				case DockingState.Turn:
 					dockingState = DockingState.Dock;
 					if (IsDragRequired)
-						return ActivityUtils.SequenceActivities(new Turn(self, DockAngle), new Drag(self, StartDrag, EndDrag, DragLength), this);
-					return ActivityUtils.SequenceActivities(new Turn(self, DockAngle), this);
+						return ActivityUtils.SequenceActivities(self, new Turn(self, DockAngle), new Drag(self, StartDrag, EndDrag, DragLength), this);
+					return ActivityUtils.SequenceActivities(self, new Turn(self, DockAngle), this);
 				case DockingState.Dock:
 					if (Refinery.IsInWorld && !Refinery.IsDead)
 						foreach (var nd in Refinery.TraitsImplementing<INotifyDocking>())
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Activities
 					Harv.LastLinkedProc = Harv.LinkedProc;
 					Harv.LinkProc(self, null);
 					if (IsDragRequired)
-						return ActivityUtils.SequenceActivities(new Drag(self, EndDrag, StartDrag, DragLength), NextActivity);
+						return ActivityUtils.SequenceActivities(self, new Drag(self, EndDrag, StartDrag, DragLength), NextActivity);
 					return NextActivity;
 			}
 

--- a/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
@@ -81,10 +81,10 @@ namespace OpenRA.Mods.Common.Activities
 			throw new InvalidOperationException("Invalid harvester dock state");
 		}
 
-		public override bool Cancel(Actor self, bool keepQueue = false)
+		public override void Cancel(Actor self, bool keepQueue = false)
 		{
 			dockingState = DockingState.Undock;
-			return base.Cancel(self);
+			base.Cancel(self);
 		}
 
 		public override IEnumerable<Target> GetTargets(Actor self)

--- a/OpenRA.Mods.Common/Activities/Hunt.cs
+++ b/OpenRA.Mods.Common/Activities/Hunt.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (target == null)
 				return this;
 
-			return ActivityUtils.SequenceActivities(
+			return ActivityUtils.SequenceActivities(self,
 				new AttackMoveActivity(self, move.MoveTo(target.Location, 2)),
 				new Wait(25),
 				this);

--- a/OpenRA.Mods.Common/Activities/Hunt.cs
+++ b/OpenRA.Mods.Common/Activities/Hunt.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (IsCanceled)
+			if (IsCanceling)
 				return NextActivity;
 
 			var target = targets.ClosestTo(self);

--- a/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
+++ b/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
@@ -48,8 +48,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override bool Cancel(Actor self, bool keepQueue = false)
 		{
-			if (!IsCanceled && inner != null && !inner.Cancel(self))
-				return false;
+			if (!IsCanceling && inner != null)
+				inner.Cancel(self);
 
 			return base.Cancel(self, keepQueue);
 		}

--- a/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
+++ b/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
@@ -46,12 +46,12 @@ namespace OpenRA.Mods.Common.Activities
 			return this;
 		}
 
-		public override bool Cancel(Actor self, bool keepQueue = false)
+		public override void Cancel(Actor self, bool keepQueue = false)
 		{
 			if (!IsCanceling && inner != null)
 				inner.Cancel(self);
 
-			return base.Cancel(self, keepQueue);
+			base.Cancel(self, keepQueue);
 		}
 
 		public override IEnumerable<Target> GetTargets(Actor self)

--- a/OpenRA.Mods.Common/Activities/Move/Follow.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Follow.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Move into range
 			wasMovingWithinRange = true;
-			return ActivityUtils.SequenceActivities(
+			return ActivityUtils.SequenceActivities(self,
 				move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, targetLineColor),
 				this);
 		}

--- a/OpenRA.Mods.Common/Activities/Move/Follow.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Follow.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (IsCanceled)
+			if (IsCanceling)
 				return NextActivity;
 
 			bool targetIsHiddenActor;

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -227,8 +227,7 @@ namespace OpenRA.Mods.Common.Activities
 				// To avoid issues, we also make these mini-turns uninterruptible (like MovePart activities) to ensure the actor
 				// finishes that mini-turn before starting something else.
 				var facingWithinTolerance = Util.FacingWithinTolerance(mobile.Facing, firstFacing, mobile.TurnSpeed);
-				QueueChild(new Turn(self, firstFacing, facingWithinTolerance, !facingWithinTolerance));
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
+				QueueChild(self, new Turn(self, firstFacing, facingWithinTolerance, !facingWithinTolerance), true);
 				return this;
 			}
 
@@ -242,18 +241,7 @@ namespace OpenRA.Mods.Common.Activities
 			var to = Util.BetweenCells(self.World, mobile.FromCell, mobile.ToCell) +
 				(map.Grid.OffsetOfSubCell(mobile.FromSubCell) + map.Grid.OffsetOfSubCell(mobile.ToSubCell)) / 2;
 
-			QueueChild(new MoveFirstHalf(
-				this,
-				from,
-				to,
-				mobile.Facing,
-				mobile.Facing,
-				0));
-
-			// While carrying out one Move order, MoveSecondHalf finishes its work from time to time and returns null.
-			// That causes the ChildActivity to be null and makes us return to this part of code.
-			// If we only queue the activity and not run it, units will lose one tick and pause briefly!
-			ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
+			QueueChild(self, new MoveFirstHalf(this, from, to, mobile.Facing, mobile.Facing, 0), true);
 			return this;
 		}
 
@@ -387,7 +375,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (ret == this)
 					return ret;
 
-				Queue(ret);
+				Queue(self, ret);
 				return NextActivity;
 			}
 

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -167,12 +167,12 @@ namespace OpenRA.Mods.Common.Activities
 			return Target.None;
 		}
 
-		public override bool Cancel(Actor self, bool keepQueue = false)
+		public override void Cancel(Actor self, bool keepQueue = false)
 		{
 			if (!IsCanceling && inner != null)
 				inner.Cancel(self);
 
-			return base.Cancel(self);
+			base.Cancel(self);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				// We are done here if the order was cancelled for any
 				// reason except the target moving.
-				if (IsCanceled || !repath || !targetIsValid)
+				if (IsCanceling || !repath || !targetIsValid)
 					return NextActivity;
 
 				// Target has moved, and MoveAdjacentTo is still valid.
@@ -169,8 +169,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override bool Cancel(Actor self, bool keepQueue = false)
 		{
-			if (!IsCanceled && inner != null && !inner.Cancel(self))
-				return false;
+			if (!IsCanceling && inner != null)
+				inner.Cancel(self);
 
 			return base.Cancel(self);
 		}

--- a/OpenRA.Mods.Common/Activities/Move/VisualMoveIntoTarget.cs
+++ b/OpenRA.Mods.Common/Activities/Move/VisualMoveIntoTarget.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Activities
 					return this;
 			}
 
-			if (IsCanceled || target.Type == TargetType.Invalid)
+			if (IsCanceling || target.Type == TargetType.Invalid)
 				return NextActivity;
 
 			if (mobile.IsTraitDisabled || mobile.IsTraitPaused)

--- a/OpenRA.Mods.Common/Activities/Move/VisualMoveIntoTarget.cs
+++ b/OpenRA.Mods.Common/Activities/Move/VisualMoveIntoTarget.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				var turn = ActivityUtils.RunActivity(self, new Turn(self, facing));
 				if (turn != null)
-					QueueChild(turn);
+					QueueChild(self, turn);
 
 				return this;
 			}

--- a/OpenRA.Mods.Common/Activities/Parachute.cs
+++ b/OpenRA.Mods.Common/Activities/Parachute.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Activities
 		}
 
 		// Only the last queued activity (given order) is kept
-		public override void Queue(Activity activity)
+		public override void Queue(Actor self, Activity activity, bool pretick = false)
 		{
 			NextActivity = activity;
 		}

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -159,12 +159,12 @@ namespace OpenRA.Mods.Common.Activities
 			});
 		}
 
-		public override bool Cancel(Actor self, bool keepQueue = false)
+		public override void Cancel(Actor self, bool keepQueue = false)
 		{
 			if (!IsCanceling && innerActivity != null)
 				innerActivity.Cancel(self);
 
-			return base.Cancel(self, keepQueue);
+			base.Cancel(self, keepQueue);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (cargo != carryall.Carryable)
 				return NextActivity;
 
-			if (cargo.IsDead || IsCanceled || carryable.IsTraitDisabled || !cargo.AppearsFriendlyTo(self))
+			if (cargo.IsDead || IsCanceling || carryable.IsTraitDisabled || !cargo.AppearsFriendlyTo(self))
 			{
 				carryall.UnreserveCarryable(self);
 				return NextActivity;
@@ -161,8 +161,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override bool Cancel(Actor self, bool keepQueue = false)
 		{
-			if (!IsCanceled && innerActivity != null && !innerActivity.Cancel(self))
-				return false;
+			if (!IsCanceling && innerActivity != null)
+				innerActivity.Cancel(self);
 
 			return base.Cancel(self, keepQueue);
 		}

--- a/OpenRA.Mods.Common/Activities/Rearm.cs
+++ b/OpenRA.Mods.Common/Activities/Rearm.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (IsCanceled)
+			if (IsCanceling)
 				return NextActivity;
 
 			if (host.Type == TargetType.Invalid)

--- a/OpenRA.Mods.Common/Activities/RemoveSelf.cs
+++ b/OpenRA.Mods.Common/Activities/RemoveSelf.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		public override Activity Tick(Actor self)
 		{
-			if (IsCanceled) return NextActivity;
+			if (IsCanceling) return NextActivity;
 			self.Dispose();
 			return null;
 		}

--- a/OpenRA.Mods.Common/Activities/Repair.cs
+++ b/OpenRA.Mods.Common/Activities/Repair.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (IsCanceled)
+			if (IsCanceling)
 			{
 				if (remainingTicks-- == 0)
 					return NextActivity;

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -36,10 +36,10 @@ namespace OpenRA.Mods.Common.Activities
 		protected override void OnFirstRun(Actor self)
 		{
 			if (self.Info.HasTraitInfo<IFacingInfo>())
-				QueueChild(new Turn(self, Facing));
+				QueueChild(self, new Turn(self, Facing));
 
 			if (self.Info.HasTraitInfo<AircraftInfo>())
-				QueueChild(new HeliLand(self, true));
+				QueueChild(self, new HeliLand(self, true));
 		}
 
 		public override Activity Tick(Actor self)
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Activities
 				IsInterruptible = false;
 
 				// Wait forever
-				QueueChild(new WaitFor(() => false));
+				QueueChild(self, new WaitFor(() => false));
 				makeAnimation.Reverse(self, () => DoTransform(self));
 				return this;
 			}

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (IsCanceled)
+			if (IsCanceling)
 				return NextActivity;
 
 			if (ChildActivity != null)
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected override void OnLastRun(Actor self)
 		{
-			if (!IsCanceled)
+			if (!IsCanceling)
 				DoTransform(self);
 		}
 

--- a/OpenRA.Mods.Common/Activities/Turn.cs
+++ b/OpenRA.Mods.Common/Activities/Turn.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (IsInterruptible && IsCanceled)
+			if (IsInterruptible && IsCanceling)
 				return NextActivity;
 
 			if (disablable != null && disablable.IsTraitDisabled)

--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Activities
 		public override Activity Tick(Actor self)
 		{
 			cargo.Unloading = false;
-			if (IsCanceled || cargo.IsEmpty(self))
+			if (IsCanceling || cargo.IsEmpty(self))
 				return NextActivity;
 
 			foreach (var inu in notifiers)

--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				self.NotifyBlocker(BlockedExitCells(actor));
 
-				return ActivityUtils.SequenceActivities(new Wait(10), this);
+				return ActivityUtils.SequenceActivities(self, new Wait(10), this);
 			}
 
 			cargo.Unload(self);

--- a/OpenRA.Mods.Common/Activities/Wait.cs
+++ b/OpenRA.Mods.Common/Activities/Wait.cs
@@ -27,16 +27,10 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
+			if (IsCanceling)
+				return NextActivity;
+
 			return (remainingTicks-- == 0) ? NextActivity : this;
-		}
-
-		public override bool Cancel(Actor self, bool keepQueue = false)
-		{
-			if (!base.Cancel(self, keepQueue))
-				return false;
-
-			remainingTicks = 0;
-			return true;
 		}
 	}
 
@@ -53,16 +47,10 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
+			if (IsCanceling)
+				return NextActivity;
+
 			return (f == null || f()) ? NextActivity : this;
-		}
-
-		public override bool Cancel(Actor self, bool keepQueue = false)
-		{
-			if (!base.Cancel(self, keepQueue))
-				return false;
-
-			f = null;
-			return true;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/WaitForTransport.cs
+++ b/OpenRA.Mods.Common/Activities/WaitForTransport.cs
@@ -43,8 +43,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override bool Cancel(Actor self, bool keepQueue = false)
 		{
-			if (!IsCanceled && inner != null && !inner.Cancel(self))
-				return false;
+			if (!IsCanceling && inner != null)
+				inner.Cancel(self);
 
 			return base.Cancel(self, keepQueue);
 		}

--- a/OpenRA.Mods.Common/Activities/WaitForTransport.cs
+++ b/OpenRA.Mods.Common/Activities/WaitForTransport.cs
@@ -41,12 +41,12 @@ namespace OpenRA.Mods.Common.Activities
 			return this;
 		}
 
-		public override bool Cancel(Actor self, bool keepQueue = false)
+		public override void Cancel(Actor self, bool keepQueue = false)
 		{
 			if (!IsCanceling && inner != null)
 				inner.Cancel(self);
 
-			return base.Cancel(self, keepQueue);
+			base.Cancel(self, keepQueue);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/CallLuaFunc.cs
+++ b/OpenRA.Mods.Common/Scripting/CallLuaFunc.cs
@@ -43,11 +43,11 @@ namespace OpenRA.Mods.Common.Activities
 			return NextActivity;
 		}
 
-		public override bool Cancel(Actor self, bool keepQueue = false)
+		public override void Cancel(Actor self, bool keepQueue = false)
 		{
 			base.Cancel(self, keepQueue);
 			Dispose();
-			return true;
+			return;
 		}
 
 		public void Dispose()

--- a/OpenRA.Mods.Common/Scripting/CallLuaFunc.cs
+++ b/OpenRA.Mods.Common/Scripting/CallLuaFunc.cs
@@ -45,9 +45,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override bool Cancel(Actor self, bool keepQueue = false)
 		{
-			if (!base.Cancel(self, keepQueue))
-				return false;
-
+			base.Cancel(self, keepQueue);
 			Dispose();
 			return true;
 		}

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -657,7 +657,7 @@ namespace OpenRA.Mods.Common.Traits
 				return new Fly(self, target, WDist.FromCells(3), WDist.FromCells(5),
 					initialTargetPosition, targetLineColor);
 
-			return ActivityUtils.SequenceActivities(
+			return ActivityUtils.SequenceActivities(self,
 				new HeliFly(self, target, initialTargetPosition, targetLineColor),
 				new Turn(self, Info.InitialFacing));
 		}
@@ -674,11 +674,11 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// TODO: Ignore repulsion when moving
 			if (!Info.CanHover)
-				return ActivityUtils.SequenceActivities(
+				return ActivityUtils.SequenceActivities(self,
 					new CallFunc(() => SetVisualPosition(self, fromPos)),
 					new Fly(self, Target.FromPos(toPos)));
 
-			return ActivityUtils.SequenceActivities(
+			return ActivityUtils.SequenceActivities(self,
 				new CallFunc(() => SetVisualPosition(self, fromPos)),
 				new HeliFly(self, Target.FromPos(toPos)));
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -275,7 +275,7 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				wasMovingWithinRange = true;
-				return ActivityUtils.SequenceActivities(
+				return ActivityUtils.SequenceActivities(self,
 					move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, Color.Red),
 					this);
 			}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -176,7 +176,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override Activity Tick(Actor self)
 			{
-				if (IsCanceled)
+				if (IsCanceling)
 				{
 					// Cancel the requested target, but keep firing on it while in range
 					attack.opportunityTarget = attack.requestedTarget;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 				// This activity can't move to reacquire hidden targets, so use the
 				// Recalculate overload that invalidates hidden targets.
 				target = target.RecalculateInvalidatingHiddenTargets(self.Owner);
-				if (IsCanceled || !target.IsValidFor(self) || !attack.IsReachableTarget(target, allowMove))
+				if (IsCanceling || !target.IsValidFor(self) || !attack.IsReachableTarget(target, allowMove))
 					return NextActivity;
 
 				attack.DoAttack(self, target);

--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -144,12 +144,12 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (!preventDock)
 			{
-				dockOrder.Queue(new CallFunc(() => dockedHarv = harv, false));
-				dockOrder.Queue(DockSequence(harv, self));
-				dockOrder.Queue(new CallFunc(() => dockedHarv = null, false));
+				dockOrder.Queue(self, new CallFunc(() => dockedHarv = harv, false));
+				dockOrder.Queue(self, DockSequence(harv, self));
+				dockOrder.Queue(self, new CallFunc(() => dockedHarv = null, false));
 			}
 
-			dockOrder.Queue(new CallFunc(() => harv.Trait<Harvester>().ContinueHarvesting(harv)));
+			dockOrder.Queue(self, new CallFunc(() => harv.Trait<Harvester>().ContinueHarvesting(harv)));
 		}
 
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -271,7 +271,7 @@ namespace OpenRA.Mods.Common.Traits
 					var notifyBlocking = new CallFunc(() => self.NotifyBlocker(cellInfo.Cell));
 					var waitFor = new WaitFor(() => CanEnterCell(cellInfo.Cell));
 					var move = new Move(self, cellInfo.Cell);
-					self.QueueActivity(ActivityUtils.SequenceActivities(notifyBlocking, waitFor, move));
+					self.QueueActivity(ActivityUtils.SequenceActivities(self, notifyBlocking, waitFor, move));
 
 					Log.Write("debug", "OnNudge (notify next blocking actor, wait and move) #{0} from {1} to {2}",
 						self.ActorID, self.Location, cellInfo.Cell);
@@ -628,7 +628,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var delta = toPos - fromPos;
 			var facing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : Facing;
-			return ActivityUtils.SequenceActivities(new Turn(self, facing), new Drag(self, fromPos, toPos, length));
+			return ActivityUtils.SequenceActivities(self, new Turn(self, facing), new Drag(self, fromPos, toPos, length));
 		}
 
 		CPos? ClosestGroundCell()

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -112,13 +112,11 @@ namespace OpenRA.Mods.Common.Traits
 					self.CancelActivity();
 
 				self.SetTargetLine(order.Target, Color.Green);
-
-				var activities = ActivityUtils.SequenceActivities(
+				var activities = ActivityUtils.SequenceActivities(self,
 					movement.MoveToTarget(self, order.Target, targetLineColor: Color.Green),
 					new CallFunc(() => AfterReachActivities(self, order, movement)));
 
 				self.QueueActivity(new WaitForTransport(self, activities));
-
 				TryCallTransport(self, order.Target, new CallFunc(() => AfterReachActivities(self, order, movement)));
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/TransformCrusherOnCrush.cs
+++ b/OpenRA.Mods.Common/Traits/TransformCrusherOnCrush.cs
@@ -51,8 +51,8 @@ namespace OpenRA.Mods.Common.Traits
 				transform.Facing = facing.Facing;
 
 			transform.SkipMakeAnims = info.SkipMakeAnims;
-			if (crusher.CancelActivity())
-				crusher.QueueActivity(transform);
+			crusher.CancelActivity();
+			crusher.QueueActivity(transform);
 		}
 	}
 }


### PR DESCRIPTION
This PR makes some improvements to the `Activity` code relevant for the handling of childactivities. This was split from #16217 and is a prerequisite for that and #16193.

- `ResupplyActivity` is changed from a `CompositeActivity` to a regular  `Activity`.
- `CompositeActivity` is removed.
- Made changes to activity `Cancel` method and `ChildActivity` getter to prevent nested childactivities from prematurely being cancelled.
- Added Actor self as a required parameter for the `Queue,` `QueueChild` and `PrintActivityTree` methods of `Activity.` Also added `Actor self `as a required parameter for `SequenceActivities.`
- added optional `pretick` parameter to `QueueChild` to make it easier to prevent activities from skipping one tick.

Fixes #15853.