### PR TITLE
Add StyleCheck.exe.config

### DIFF
--- a/OpenRA.StyleCheck.exe.config
+++ b/OpenRA.StyleCheck.exe.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <probing privatePath="mods/common"></probing>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/OpenRA.StyleCheck/App.config
+++ b/OpenRA.StyleCheck/App.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <probing privatePath="mods/common"></probing>
-    </assemblyBinding>
-  </runtime>
-</configuration>

--- a/OpenRA.StyleCheck/OpenRA.StyleCheck.csproj
+++ b/OpenRA.StyleCheck/OpenRA.StyleCheck.csproj
@@ -38,8 +38,5 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="App.config" />
-  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Since #16196, this was automatically created on compile every time (on Windows, at least).

That's quite annoying on bleed. Adding it to the repo directly should fix the original issue without that side-effect from #16196.