### PR TITLE
Work around harvester unloading activity queue issues.

### DIFF
--- a/OpenRA.Mods.Common/Activities/FindResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindResources.cs
@@ -53,7 +53,10 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 
 			if (harv.IsFull)
-				return ActivityUtils.SequenceActivities(new DeliverResources(self), NextActivity);
+			{
+				// HACK: DeliverResources is ignored if there are queued activities, so discard NextActivity
+				return ActivityUtils.SequenceActivities(new DeliverResources(self));
+			}
 
 			var closestHarvestablePosition = ClosestHarvestablePos(self);
 


### PR DESCRIPTION
This PR works around the regressions introduced by #15856 - hopefully without introducing any new ones. Harvesters still doesn't support queueing (see #16193) so this is probably going to be fine.

Fixes #16192.
Fixes #16249.
Probably fixes the complained about but not officially reported "harvesters go idle in resource patches" issue, as explained in #15856.