### PR TITLE
Rename fields on Repairable traits

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliReturnToBase.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (alwaysLand)
 				return true;
 
-			if (repairableInfo != null && repairableInfo.RepairBuildings.Contains(dest.Info.Name) && self.GetDamageState() != DamageState.Undamaged)
+			if (repairableInfo != null && repairableInfo.RepairActors.Contains(dest.Info.Name) && self.GetDamageState() != DamageState.Undamaged)
 				return true;
 
 			return rearmable != null && rearmable.Info.RearmActors.Contains(dest.Info.Name)

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -110,7 +110,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (alwaysLand)
 				return true;
 
-			if (repairableInfo != null && repairableInfo.RepairBuildings.Contains(dest.Info.Name) && self.GetDamageState() != DamageState.Undamaged)
+			if (repairableInfo != null && repairableInfo.RepairActors.Contains(dest.Info.Name) && self.GetDamageState() != DamageState.Undamaged)
 				return true;
 
 			return rearmable != null && rearmable.Info.RearmActors.Contains(dest.Info.Name)

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -952,6 +952,7 @@
     <Compile Include="UpdateRules\Rules\20181215\RemovedAutoCarryallCircleTurnSpeed.cs" />
     <Compile Include="UpdateRules\Rules\20181215\ReplacedWithChargeAnimation.cs" />
     <Compile Include="UpdateRules\Rules\20181215\RefactorResourceLevelAnimating.cs" />
+    <Compile Include="UpdateRules\Rules\20190106\StreamlineRepairableTraits.cs" />
     <Compile Include="Traits\Player\PlayerResources.cs" />
     <Compile Include="UtilityCommands\DumpSequenceSheetsCommand.cs" />
     <Compile Include="Traits\Render\WithBuildingRepairDecoration.cs" />

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -472,7 +472,7 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			return (rearmableInfo != null && rearmableInfo.RearmActors.Contains(a.Info.Name))
-				|| (repairableInfo != null && repairableInfo.RepairBuildings.Contains(a.Info.Name));
+				|| (repairableInfo != null && repairableInfo.RepairActors.Contains(a.Info.Name));
 		}
 
 		public int MovementSpeed
@@ -512,7 +512,7 @@ namespace OpenRA.Mods.Common.Traits
 				yield return new Rearm(self, a, WDist.Zero);
 
 			// The ResupplyAircraft activity guarantees that we're on the helipad
-			if (repairableInfo != null && repairableInfo.RepairBuildings.Contains(name))
+			if (repairableInfo != null && repairableInfo.RepairActors.Contains(name))
 				yield return new Repair(self, a, WDist.Zero);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -20,19 +20,20 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor can be sent to a structure for repairs.")]
-	class RepairableInfo : ITraitInfo, Requires<IHealthInfo>, Requires<IMoveInfo>
+	public class RepairableInfo : ITraitInfo, Requires<IHealthInfo>, Requires<IMoveInfo>
 	{
-		public readonly HashSet<string> RepairBuildings = new HashSet<string> { "fix" };
+		[FieldLoader.Require]
+		[ActorReference] public readonly HashSet<string> RepairActors = new HashSet<string> { };
 
 		[VoiceReference] public readonly string Voice = "Action";
 
-		[Desc("The amount the unit will be repaired at each step. Use -1 for fallback behavior where HpPerStep from RepairUnit trait will be used.")]
+		[Desc("The amount the unit will be repaired at each step. Use -1 for fallback behavior where HpPerStep from RepairsUnits trait will be used.")]
 		public readonly int HpPerStep = -1;
 
 		public virtual object Create(ActorInitializer init) { return new Repairable(init.Self, this); }
 	}
 
-	class Repairable : IIssueOrder, IResolveOrder, IOrderVoice, INotifyCreated
+	public class Repairable : IIssueOrder, IResolveOrder, IOrderVoice, INotifyCreated
 	{
 		public readonly RepairableInfo Info;
 		readonly IHealth health;
@@ -69,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool CanRepairAt(Actor target)
 		{
-			return Info.RepairBuildings.Contains(target.Info.Name);
+			return Info.RepairActors.Contains(target.Info.Name);
 		}
 
 		bool CanRearmAt(Actor target)
@@ -157,7 +158,7 @@ namespace OpenRA.Mods.Common.Traits
 			var repairBuilding = self.World.ActorsWithTrait<RepairsUnits>()
 				.Where(a => !a.Actor.IsDead && a.Actor.IsInWorld
 					&& a.Actor.Owner.IsAlliedWith(self.Owner) &&
-					Info.RepairBuildings.Contains(a.Actor.Info.Name))
+					Info.RepairActors.Contains(a.Actor.Info.Name))
 				.OrderBy(p => (self.Location - p.Actor.Location).LengthSquared);
 
 			// Worst case FirstOrDefault() will return a TraitPair<null, null>, which is OK.

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -20,7 +20,9 @@ namespace OpenRA.Mods.Common.Traits
 {
 	class RepairableNearInfo : ITraitInfo, Requires<IHealthInfo>, Requires<IMoveInfo>
 	{
-		[ActorReference] public readonly HashSet<string> Buildings = new HashSet<string> { "spen", "syrd" };
+		[FieldLoader.Require]
+		[ActorReference] public readonly HashSet<string> RepairActors = new HashSet<string> { };
+
 		public readonly WDist CloseEnough = WDist.FromCells(4);
 		[VoiceReference] public readonly string Voice = "Action";
 
@@ -59,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool CanRepairAt(Actor target)
 		{
-			return info.Buildings.Contains(target.Info.Name);
+			return info.RepairActors.Contains(target.Info.Name);
 		}
 
 		bool ShouldRepair()
@@ -96,7 +98,7 @@ namespace OpenRA.Mods.Common.Traits
 			var repairBuilding = self.World.ActorsWithTrait<RepairsUnits>()
 				.Where(a => !a.Actor.IsDead && a.Actor.IsInWorld
 					&& a.Actor.Owner.IsAlliedWith(self.Owner) &&
-					info.Buildings.Contains(a.Actor.Info.Name))
+					info.RepairActors.Contains(a.Actor.Info.Name))
 				.OrderBy(p => (self.Location - p.Actor.Location).LengthSquared);
 
 			// Worst case FirstOrDefault() will return a TraitPair<null, null>, which is OK.

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20190106/StreamlineRepairableTraits.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20190106/StreamlineRepairableTraits.cs
@@ -1,0 +1,56 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class StreamlineRepairableTraits : UpdateRule
+	{
+		public override string Name { get { return "Streamline RepairableNear and Repairable"; } }
+		public override string Description
+		{
+			get
+			{
+				return "Renamed Repairable.RepairBuildings and RepairableNear.Buildings to RepairActors,\n" +
+				"for consistency with RearmActors (and since repairing at other actors should already be possible).\n" +
+				"Additionally, removed internal 'fix' and 'spen, syrd' default values.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			// Repairable isn't conditional or otherwise supports multiple traits, so LastChildMatching should be fine.
+			var repairableNode = actorNode.LastChildMatching("Repairable");
+			if (repairableNode != null)
+			{
+				var repairBuildings = repairableNode.LastChildMatching("RepairBuildings");
+				if (repairBuildings != null)
+					repairBuildings.RenameKey("RepairActors");
+				else
+					repairableNode.AddNode(new MiniYamlNode("RepairActors", "fix"));
+			}
+
+			// RepairableNear isn't conditional or otherwise supports multiple traits, so LastChildMatching should be fine.
+			var repairableNearNode = actorNode.LastChildMatching("RepairableNear");
+			if (repairableNearNode != null)
+			{
+				var repairBuildings = repairableNearNode.LastChildMatching("Buildings");
+				if (repairBuildings != null)
+					repairBuildings.RenameKey("RepairActors");
+				else
+					repairableNearNode.AddNode(new MiniYamlNode("RepairActors", "spen, syrd"));
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -88,7 +88,6 @@ namespace OpenRA.Mods.Common.UpdateRules
 
 			new UpdatePath("release-20181215", "playtest-20190106", new UpdateRule[]
 			{
-				// Bleed only changes here
 				new AddCarryableHarvester(),
 				new RenameEditorTilesetFilter(),
 				new DefineNotificationDefaults(),
@@ -117,8 +116,10 @@ namespace OpenRA.Mods.Common.UpdateRules
 
 			new UpdatePath("playtest-20190106", new UpdateRule[]
 			{
+				// Bleed only changes here
 				new RemoveAttackSuicides(),
 				new MakeMobilePausableConditional(),
+				new StreamlineRepairableTraits(),
 			})
 		};
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -258,6 +258,7 @@
 	Targetable:
 		TargetTypes: Ground, Vehicle
 	Repairable:
+		RepairActors: fix
 	Passenger:
 		CargoType: Vehicle
 	ActorLostNotification:
@@ -309,7 +310,7 @@
 	Selectable:
 		Bounds: 24,24
 	Repairable:
-		RepairBuildings: hpad
+		RepairActors: hpad
 	Aircraft:
 		LandWhenIdle: false
 		AirborneCondition: airborne

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -188,7 +188,7 @@
 	HiddenUnderFog:
 	ActorLostNotification:
 	Repairable:
-		RepairBuildings: repair_pad
+		RepairActors: repair_pad
 	Guard:
 		Voice: Guard
 	Guardable:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -259,6 +259,7 @@
 		Condition: damaged
 		ValidDamageStates: Light, Medium, Heavy, Critical
 	Repairable:
+		RepairActors: fix
 	Chronoshiftable:
 	Passenger:
 		CargoType: Vehicle
@@ -512,6 +513,7 @@
 		Types: Ship
 	Chronoshiftable:
 	RepairableNear:
+		RepairActors: spen, syrd
 	GpsDot:
 		String: Ship
 	WithDamageOverlay:
@@ -603,7 +605,7 @@
 	Inherits: ^NeutralPlane
 	Inherits@2: ^GainsExperience
 	Repairable:
-		RepairBuildings: fix
+		RepairActors: fix
 
 ^Helicopter:
 	Inherits: ^Plane

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -749,7 +749,7 @@
 		Condition: damaged
 		ValidDamageStates: Light, Medium, Heavy, Critical
 	Repairable:
-		RepairBuildings: gadept
+		RepairActors: gadept
 		Voice: Move
 	Passenger:
 		CargoType: Vehicle
@@ -841,7 +841,7 @@
 	SelectionDecorations:
 		Palette: pips
 	Repairable:
-		RepairBuildings: gadept
+		RepairActors: gadept
 		Voice: Move
 	Aircraft:
 		AirborneCondition: airborne


### PR DESCRIPTION
To bring them in line with `Rearmable.RearmActors`, `Repairable.RepairBuildings` and `RepairableNear.Buildings` have been renamed to `*.RepairActors`.
Additionally, their RA/C&C-specific internal defaults were removed and the FieldLoader now requires them to be set explicitly.

Split from future merge of `RepairableNear` into `Repairable`.