### PR TITLE
Notify players when a vehicle have been lost to a Thief.

### DIFF
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -281,6 +281,7 @@
 		CancelActivity: True
 	CaptureNotification:
 		Notification: UnitStolen
+		LoseNotification: UnitLost
 	MustBeDestroyed:
 	Voiced:
 		VoiceSet: VehicleVoice


### PR DESCRIPTION
Fixes #16243.
This adds the "Unit Lost" notification - "Unit Stolen" is already used for the player doing the capturing.