### PR TITLE
Remove bogus shadow remapping from TD and RA cursors.

### DIFF
--- a/mods/cnc/cursors.yaml
+++ b/mods/cnc/cursors.yaml
@@ -1,5 +1,5 @@
 Cursors:
-	mouse2.shp: chrome
+	mouse2.shp: cursor
 		scroll-t:
 			Start: 1
 			Y: -12
@@ -136,7 +136,7 @@ Cursors:
 		sell-vehicle:
 			Start: 154
 			Length: 24
-	mouse3.shp: chrome
+	mouse3.shp: cursor
 		default:
 			Start: 0
 			X: -16
@@ -148,7 +148,7 @@ Cursors:
 		deploy-blocked:
 			Start: 1
 			Length: 1
-	mouse4.shp: chrome
+	mouse4.shp: cursor
 		move:
 			Start: 0
 			Length: 8
@@ -188,14 +188,14 @@ Cursors:
 		assaultmove-blocked-minimap:
 			Start: 40
 			Length: 1
-	mouse5.shp: chrome
+	mouse5.shp: cursor
 		guard:
 			Start: 0
 			Length: 8
 		guard-minimap:
 			Start: 8
 			Length: 8
-	mouse6.shp: chrome
+	mouse6.shp: cursor
 		goldwrench:
 			Start: 0
 			Length: 3
@@ -226,7 +226,7 @@ Cursors:
 		enter-blocked-minimap:
 			Start: 17
 			Length: 1
-	mouse7.shp: chrome
+	mouse7.shp: cursor
 		attackoutsiderange:
 			Start: 0
 			Length: 8

--- a/mods/cnc/rules/palettes.yaml
+++ b/mods/cnc/rules/palettes.yaml
@@ -54,6 +54,10 @@
 		Filename: temperat.pal
 		ShadowIndex: 3
 		AllowModifiers: false
+	PaletteFromFile@cursor:
+		Name: cursor
+		Filename: temperat.pal
+		AllowModifiers: false
 		CursorPalette: true
 	PaletteFromFile@beaconposter:
 		Name: beaconposter

--- a/mods/ra/cursors.yaml
+++ b/mods/ra/cursors.yaml
@@ -1,5 +1,5 @@
 Cursors:
-	mouse.shp: chrome
+	mouse.shp: cursor
 		scroll-t:
 			Start: 1
 			Y: -7
@@ -200,14 +200,14 @@ Cursors:
 		sell2:
 			Start: 148
 			Length: 12
-	nopower.shp: chrome
+	nopower.shp: cursor
 		powerdown-blocked:
 			Start: 0
 			Length: 1
 		powerdown:
 			Start: 1
 			Length: 3
-	attackmove.shp: chrome
+	attackmove.shp: cursor
 		attackmove:
 			Start: 0
 			Length: 4

--- a/mods/ra/rules/palettes.yaml
+++ b/mods/ra/rules/palettes.yaml
@@ -28,6 +28,10 @@
 		Filename: temperat.pal
 		ShadowIndex: 3
 		AllowModifiers: false
+	PaletteFromFile@cursor:
+		Name: cursor
+		Filename: temperat.pal
+		AllowModifiers: false
 		CursorPalette: true
 	PaletteFromFile@effect:
 		Name: effect


### PR DESCRIPTION
Fixes #16256. D2K and TS are already set up correctly.