### PR TITLE
Fixed NuGet-related dependency fetching on Windows

### DIFF
--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -8,7 +8,7 @@ if (!(Test-Path "nuget.exe"))
 	# Work around PowerShell's Invoke-WebRequest not being available on some versions of PowerShell by using the BCL.
 	# To do that we need to work around further and use absolute paths because DownloadFile is not aware of PowerShell's current directory.
 	$target = Join-Path $pwd.ToString() "nuget.exe"
-	(New-Object System.Net.WebClient).DownloadFile("http://nuget.org/nuget.exe", $target)
+	(New-Object System.Net.WebClient).DownloadFile("https://dist.nuget.org/win-x86-commandline/latest/nuget.exe", $target)
 }
 
 if (!(Test-Path "StyleCopPlus.dll"))

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -14,7 +14,7 @@ if (!(Test-Path "nuget.exe"))
 if (!(Test-Path "StyleCopPlus.dll"))
 {
 	echo "Fetching StyleCopPlus from NuGet."
-	./nuget.exe install StyleCopPlus.MSBuild -Version 4.7.49.5 -ExcludeVersion -Verbosity quiet
+	./nuget.exe install StyleCopPlus.MSBuild -Version 4.7.49.5 -ExcludeVersion -Verbosity quiet -Source nuget.org
 	cp StyleCopPlus.MSBuild/tools/StyleCopPlus.dll .
 	rmdir StyleCopPlus.MSBuild -Recurse
 }
@@ -22,7 +22,7 @@ if (!(Test-Path "StyleCopPlus.dll"))
 if (!(Test-Path "StyleCop.dll"))
 {
 	echo "Fetching StyleCop files from NuGet."
-	./nuget.exe install StyleCop.MSBuild -Version 4.7.49.0 -ExcludeVersion -Verbosity quiet
+	./nuget.exe install StyleCop.MSBuild -Version 4.7.49.0 -ExcludeVersion -Verbosity quiet -Source nuget.org
 	cp StyleCop.MSBuild/tools/StyleCop*.dll .
 	rmdir StyleCop.MSBuild -Recurse
 }
@@ -30,7 +30,7 @@ if (!(Test-Path "StyleCop.dll"))
 if (!(Test-Path "ICSharpCode.SharpZipLib.dll"))
 {
 	echo "Fetching ICSharpCode.SharpZipLib from NuGet."
-	./nuget.exe install SharpZipLib -Version 0.86.0 -ExcludeVersion -Verbosity quiet
+	./nuget.exe install SharpZipLib -Version 0.86.0 -ExcludeVersion -Verbosity quiet -Source nuget.org
 	cp SharpZipLib/lib/20/ICSharpCode.SharpZipLib.dll .
 	rmdir SharpZipLib -Recurse
 }
@@ -38,7 +38,7 @@ if (!(Test-Path "ICSharpCode.SharpZipLib.dll"))
 if (!(Test-Path "MaxMind.Db.dll"))
 {
 	echo "Fetching MaxMind.Db from NuGet."
-	./nuget.exe install MaxMind.Db -Version 2.0.0 -ExcludeVersion -Verbosity quiet
+	./nuget.exe install MaxMind.Db -Version 2.0.0 -ExcludeVersion -Verbosity quiet -Source nuget.org
 	cp MaxMind.Db/lib/net45/MaxMind.Db.* .
 	rmdir MaxMind.Db -Recurse
 }
@@ -46,7 +46,7 @@ if (!(Test-Path "MaxMind.Db.dll"))
 if (!(Test-Path "SharpFont.dll"))
 {
 	echo "Fetching SharpFont from NuGet."
-	./nuget.exe install SharpFont -Version 4.0.1 -ExcludeVersion -Verbosity quiet
+	./nuget.exe install SharpFont -Version 4.0.1 -ExcludeVersion -Verbosity quiet -Source nuget.org
 	cp SharpFont/lib/net45/SharpFont* .
 	cp SharpFont/config/SharpFont.dll.config .
 	rmdir SharpFont -Recurse
@@ -56,7 +56,7 @@ if (!(Test-Path "SharpFont.dll"))
 if (!(Test-Path "nunit.framework.dll"))
 {
 	echo "Fetching NUnit from NuGet."
-	./nuget.exe install NUnit -Version 3.0.1 -ExcludeVersion -Verbosity quiet
+	./nuget.exe install NUnit -Version 3.0.1 -ExcludeVersion -Verbosity quiet -Source nuget.org
 	cp NUnit/lib/net40/nunit.framework* .
 	rmdir NUnit -Recurse
 }
@@ -85,7 +85,7 @@ if (!(Test-Path "windows/SDL2.dll"))
 if (!(Test-Path "Open.Nat.dll"))
 {
 	echo "Fetching Open.Nat from NuGet."
-	./nuget.exe install Open.Nat -Version 2.1.0 -ExcludeVersion -Verbosity quiet
+	./nuget.exe install Open.Nat -Version 2.1.0 -ExcludeVersion -Verbosity quiet -Source nuget.org
 	cp Open.Nat/lib/net45/Open.Nat.dll .
 	rmdir Open.Nat -Recurse
 }
@@ -93,7 +93,7 @@ if (!(Test-Path "Open.Nat.dll"))
 if (!(Test-Path "windows/lua51.dll"))
 {
 	echo "Fetching Lua 5.1 from NuGet."
-	./nuget.exe install lua.binaries -Version 5.1.5 -ExcludeVersion -Verbosity quiet
+	./nuget.exe install lua.binaries -Version 5.1.5 -ExcludeVersion -Verbosity quiet -Source nuget.org
 	cp lua.binaries/bin/win32/dll8/lua5.1.dll ./windows/lua51.dll
 	rmdir lua.binaries -Recurse
 }
@@ -101,7 +101,7 @@ if (!(Test-Path "windows/lua51.dll"))
 if (!(Test-Path "windows/freetype6.dll"))
 {
 	echo "Fetching FreeType2 from NuGet."
-	./nuget.exe install SharpFont.Dependencies -Version 2.6.0 -ExcludeVersion -Verbosity quiet
+	./nuget.exe install SharpFont.Dependencies -Version 2.6.0 -ExcludeVersion -Verbosity quiet -Source nuget.org
 	cp SharpFont.Dependencies/bin/msvc9/x86/freetype6.dll ./windows/freetype6.dll
 	rmdir SharpFont.Dependencies -Recurse
 }
@@ -109,7 +109,7 @@ if (!(Test-Path "windows/freetype6.dll"))
 if (!(Test-Path "windows/soft_oal.dll"))
 {
 	echo "Fetching OpenAL Soft from NuGet."
-	./nuget.exe install OpenAL-Soft -Version 1.16.0 -ExcludeVersion -Verbosity quiet
+	./nuget.exe install OpenAL-Soft -Version 1.16.0 -ExcludeVersion -Verbosity quiet -Source nuget.org
 	cp OpenAL-Soft/bin/Win32/soft_oal.dll windows/soft_oal.dll
 	rmdir OpenAL-Soft -Recurse
 }
@@ -117,7 +117,7 @@ if (!(Test-Path "windows/soft_oal.dll"))
 if (!(Test-Path "FuzzyLogicLibrary.dll"))
 {
 	echo "Fetching FuzzyLogicLibrary from NuGet."
-	./nuget.exe install FuzzyLogicLibrary -Version 1.2.0 -ExcludeVersion -Verbosity quiet
+	./nuget.exe install FuzzyLogicLibrary -Version 1.2.0 -ExcludeVersion -Verbosity quiet -Source nuget.org
 	cp FuzzyLogicLibrary/bin/Release/FuzzyLogicLibrary.dll .
 	rmdir FuzzyLogicLibrary -Recurse
 }
@@ -125,7 +125,7 @@ if (!(Test-Path "FuzzyLogicLibrary.dll"))
 if (!(Test-Path "rix0rrr.BeaconLib.dll"))
 {
 	echo "Fetching rix0rrr.BeaconLib from NuGet."
-	./nuget.exe install rix0rrr.BeaconLib -Version 1.0.1 -ExcludeVersion -Verbosity quiet
+	./nuget.exe install rix0rrr.BeaconLib -Version 1.0.1 -ExcludeVersion -Verbosity quiet -Source nuget.org
 	cp rix0rrr.BeaconLib/lib/net40/rix0rrr.BeaconLib.dll .
 	rmdir rix0rrr.BeaconLib -Recurse
 }


### PR DESCRIPTION
Noticed a couple of issues today after `make clean` on Windows.
The dependency fetching script somehow was downloading an ancient version of NuGet (2.8.6 vs the currently latest 4.9.3), which was refusing to work.
After that it turned out that NuGet breaks if you have alternative (private, for example) feeds set up and one of them isn't responding.

You can test the alternative feed issue by adding a dummy entry in `%AppData%\NuGet\NuGet.Config` (Windows) or `~/.nuget/NuGet/NuGet.Config` (Mac/Linux). Just add
```
<add key="DummyFeed" value="http://openra.org/nuget" />
```
and try running `make dependencies`.
I do fully expect to have to apply this fix for Linux/MacOS as well.