### PR TITLE
Add support for arbitrary objective type names

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/MissionObjectiveProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/MissionObjectiveProperties.cs
@@ -30,11 +30,19 @@ namespace OpenRA.Mods.Common.Scripting
 		}
 
 		[ScriptActorPropertyActivity]
+		[Desc("Add a mission objective for this player. The function returns the " +
+			"ID of the newly created objective, so that it can be referred to later.")]
+		public int AddObjective(string description, string type = "Primary", bool required = true)
+		{
+			return mo.Add(Player, description, type, required);
+		}
+
+		[ScriptActorPropertyActivity]
 		[Desc("Add a primary mission objective for this player. The function returns the " +
 			"ID of the newly created objective, so that it can be referred to later.")]
 		public int AddPrimaryObjective(string description)
 		{
-			return mo.Add(Player, description, ObjectiveType.Primary);
+			return AddObjective(description);
 		}
 
 		[ScriptActorPropertyActivity]
@@ -42,7 +50,7 @@ namespace OpenRA.Mods.Common.Scripting
 			"ID of the newly created objective, so that it can be referred to later.")]
 		public int AddSecondaryObjective(string description)
 		{
-			return mo.Add(Player, description, ObjectiveType.Secondary);
+			return AddObjective(description, "Secondary", false);
 		}
 
 		[ScriptActorPropertyActivity]
@@ -106,7 +114,7 @@ namespace OpenRA.Mods.Common.Scripting
 			if (id < 0 || id >= mo.Objectives.Count)
 				throw new LuaException("Objective ID is out of range.");
 
-			return mo.Objectives[id].Type == ObjectiveType.Primary ? "Primary" : "Secondary";
+			return mo.Objectives[id].Type;
 		}
 
 		[ScriptActorPropertyActivity]

--- a/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
+++ b/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Scripting
 
 	public sealed class ScriptTriggers : INotifyIdle, INotifyDamage, INotifyKilled, INotifyProduction, INotifyOtherProduction,
 		INotifyObjectivesUpdated, INotifyCapture, INotifyInfiltrated, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyDiscovered, INotifyActorDisposing,
-		INotifyPassengerEntered, INotifyPassengerExited, INotifySold
+		INotifyPassengerEntered, INotifyPassengerExited, INotifySold, INotifyWinStateChanged
 	{
 		readonly World world;
 		readonly Actor self;
@@ -176,7 +176,7 @@ namespace OpenRA.Mods.Common.Scripting
 			OnProducedInternal(self, other);
 		}
 
-		void INotifyObjectivesUpdated.OnPlayerWon(Player player)
+		void INotifyWinStateChanged.OnPlayerWon(Player player)
 		{
 			if (world.Disposing)
 				return;
@@ -196,7 +196,7 @@ namespace OpenRA.Mods.Common.Scripting
 			}
 		}
 
-		void INotifyObjectivesUpdated.OnPlayerLost(Player player)
+		void INotifyWinStateChanged.OnPlayerLost(Player player)
 		{
 			if (world.Disposing)
 				return;

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new ConquestVictoryConditions(init.Self, this); }
 	}
 
-	public class ConquestVictoryConditions : ITick, INotifyObjectivesUpdated
+	public class ConquestVictoryConditions : ITick, INotifyWinStateChanged
 	{
 		readonly ConquestVictoryConditionsInfo info;
 		readonly MissionObjectives mo;
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 			mo.MarkCompleted(self.Owner, objectiveID);
 		}
 
-		void INotifyObjectivesUpdated.OnPlayerLost(Player player)
+		void INotifyWinStateChanged.OnPlayerLost(Player player)
 		{
 			foreach (var a in player.World.ActorsWithTrait<INotifyOwnerLost>().Where(a => a.Actor.Owner == player))
 				a.Trait.OnOwnerLost(a.Actor);
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.Common.Traits
 			});
 		}
 
-		void INotifyObjectivesUpdated.OnPlayerWon(Player player)
+		void INotifyWinStateChanged.OnPlayerWon(Player player)
 		{
 			if (info.SuppressNotifications)
 				return;
@@ -96,9 +96,5 @@ namespace OpenRA.Mods.Common.Traits
 					Game.Sound.PlayNotification(player.World.Map.Rules, player, "Speech", mo.Info.WinNotification, player.Faction.InternalName);
 			});
 		}
-
-		void INotifyObjectivesUpdated.OnObjectiveAdded(Player player, int id) { }
-		void INotifyObjectivesUpdated.OnObjectiveCompleted(Player player, int id) { }
-		void INotifyObjectivesUpdated.OnObjectiveFailed(Player player, int id) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -46,10 +46,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ITick.Tick(Actor self)
 		{
-			if (self.Owner.WinState != WinState.Undefined || self.Owner.NonCombatant) return;
+			if (self.Owner.WinState != WinState.Undefined || self.Owner.NonCombatant)
+				return;
 
 			if (objectiveID < 0)
-				objectiveID = mo.Add(self.Owner, info.Objective, ObjectiveType.Primary, true);
+				objectiveID = mo.Add(self.Owner, info.Objective, "Primary", inhibitAnnouncement: true);
 
 			if (!self.Owner.NonCombatant && self.Owner.HasNoRequiredUnits(shortGame))
 				mo.MarkFailed(self.Owner, objectiveID);

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			if (objectiveID < 0)
-				objectiveID = mo.Add(player, info.Objective, ObjectiveType.Primary, true);
+				objectiveID = mo.Add(player, info.Objective, "Primary", inhibitAnnouncement: true);
 
 			if (!self.Owner.NonCombatant && self.Owner.HasNoRequiredUnits(shortGame))
 				mo.MarkFailed(self.Owner, objectiveID);

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new StrategicVictoryConditions(init.Self, this); }
 	}
 
-	public class StrategicVictoryConditions : ITick, ISync, INotifyObjectivesUpdated
+	public class StrategicVictoryConditions : ITick, ISync, INotifyWinStateChanged
 	{
 		readonly StrategicVictoryConditionsInfo info;
 
@@ -75,7 +75,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ITick.Tick(Actor self)
 		{
-			if (player.WinState != WinState.Undefined || player.NonCombatant) return;
+			if (player.WinState != WinState.Undefined || player.NonCombatant)
+				return;
 
 			if (objectiveID < 0)
 				objectiveID = mo.Add(player, info.Objective, ObjectiveType.Primary, true);
@@ -107,7 +108,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		void INotifyObjectivesUpdated.OnPlayerLost(Player player)
+		void INotifyWinStateChanged.OnPlayerLost(Player player)
 		{
 			foreach (var a in player.World.ActorsWithTrait<INotifyOwnerLost>().Where(a => a.Actor.Owner == player))
 				a.Trait.OnOwnerLost(a.Actor);
@@ -123,7 +124,7 @@ namespace OpenRA.Mods.Common.Traits
 			});
 		}
 
-		void INotifyObjectivesUpdated.OnPlayerWon(Player player)
+		void INotifyWinStateChanged.OnPlayerWon(Player player)
 		{
 			if (info.SuppressNotifications)
 				return;
@@ -135,9 +136,5 @@ namespace OpenRA.Mods.Common.Traits
 					Game.Sound.PlayNotification(player.World.Map.Rules, player, "Speech", mo.Info.WinNotification, player.Faction.InternalName);
 			});
 		}
-
-		void INotifyObjectivesUpdated.OnObjectiveAdded(Player player, int id) { }
-		void INotifyObjectivesUpdated.OnObjectiveCompleted(Player player, int id) { }
-		void INotifyObjectivesUpdated.OnObjectiveFailed(Player player, int id) { }
 	}
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -430,11 +430,16 @@ namespace OpenRA.Mods.Common.Traits
 	[RequireExplicitImplementation]
 	public interface INotifyObjectivesUpdated
 	{
-		void OnPlayerWon(Player winner);
-		void OnPlayerLost(Player loser);
 		void OnObjectiveAdded(Player player, int objectiveID);
 		void OnObjectiveCompleted(Player player, int objectiveID);
 		void OnObjectiveFailed(Player player, int objectiveID);
+	}
+
+	[RequireExplicitImplementation]
+	public interface INotifyWinStateChanged
+	{
+		void OnPlayerWon(Player winner);
+		void OnPlayerLost(Player loser);
 	}
 
 	public interface INotifyCashTransfer

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoObjectivesLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoObjectivesLogic.cs
@@ -62,13 +62,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			parent.RemoveChildren();
 
-			foreach (var o in mo.Objectives.OrderBy(o => o.Type))
+			foreach (var objective in mo.Objectives.OrderBy(o => o.Type))
 			{
-				var objective = o; // Work around the loop closure issue in older versions of C#
 				var widget = template.Clone();
-
 				var label = widget.Get<LabelWidget>("OBJECTIVE_TYPE");
-				label.GetText = () => objective.Type == ObjectiveType.Primary ? "Primary" : "Secondary";
+				label.GetText = () => objective.Type;
 
 				var checkbox = widget.Get<CheckboxWidget>("OBJECTIVE_STATUS");
 				checkbox.IsChecked = () => objective.State != ObjectiveState.Incomplete;


### PR DESCRIPTION
First commit splits an `INotifyWinstateChanged` interface from `INotifyObjectivesUpdated` which just reduces the amount of empty methods and unnecessary calls to traits implementing the latter.

Testcase: Start Allies01, you should see announcements for the usual objectives and the fake objective, but not the tertiary one (no blinking of the objectives icon, too, once the tertiary is added 7 seconds into the map). The tertiary objective will appear in the list once it is completed and the mission won't fail when the fake objective is marked as failed (both 17 seconds in).