### PR TITLE
Replace SharpFont with minimal direct FreeType bindings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -162,9 +162,6 @@ the Apache 2.0 license.
 Using GeoLite2 data created by MaxMind and
 distributed under the CC BY-SA 3.0 license.
 
-Using SharpFont created by Robert Rouhani and
-distributed under the MIT license.
-
 Using SDL2-CS and OpenAL-CS created by Ethan
 Lee and released under the zlib license.
 

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ endif
 game_SRCS := $(shell find OpenRA.Game/ -iname '*.cs')
 game_TARGET = OpenRA.Game.exe
 game_KIND = winexe
-game_LIBS = $(COMMON_LIBS) $(game_DEPS) thirdparty/download/SharpFont.dll thirdparty/download/Open.Nat.dll
+game_LIBS = $(COMMON_LIBS) $(game_DEPS) thirdparty/download/Open.Nat.dll
 PROGRAMS += game
 game: $(game_TARGET)
 
@@ -111,7 +111,7 @@ pdefault_SRCS := $(shell find OpenRA.Platforms.Default/ -iname '*.cs')
 pdefault_TARGET = OpenRA.Platforms.Default.dll
 pdefault_KIND = library
 pdefault_DEPS = $(game_TARGET)
-pdefault_LIBS = $(COMMON_LIBS) thirdparty/download/SDL2-CS.dll thirdparty/download/OpenAL-CS.dll $(pdefault_DEPS)
+pdefault_LIBS = $(COMMON_LIBS) thirdparty/download/SDL2-CS.dll thirdparty/download/OpenAL-CS.dll thirdparty/download/SharpFont.dll $(pdefault_DEPS)
 PROGRAMS += pdefault
 platforms: $(pdefault_TARGET)
 

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ pdefault_SRCS := $(shell find OpenRA.Platforms.Default/ -iname '*.cs')
 pdefault_TARGET = OpenRA.Platforms.Default.dll
 pdefault_KIND = library
 pdefault_DEPS = $(game_TARGET)
-pdefault_LIBS = $(COMMON_LIBS) thirdparty/download/SDL2-CS.dll thirdparty/download/OpenAL-CS.dll thirdparty/download/SharpFont.dll $(pdefault_DEPS)
+pdefault_LIBS = $(COMMON_LIBS) thirdparty/download/SDL2-CS.dll thirdparty/download/OpenAL-CS.dll $(pdefault_DEPS)
 PROGRAMS += pdefault
 platforms: $(pdefault_TARGET)
 
@@ -355,8 +355,7 @@ install-engine:
 	@$(CP) Eluant* "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) ICSharpCode.SharpZipLib.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) FuzzyLogicLibrary.dll "$(DATA_INSTALL_DIR)"
-	@$(INSTALL_PROGRAM) SharpFont.dll "$(DATA_INSTALL_DIR)"
-	@$(CP) SharpFont.dll.config "$(DATA_INSTALL_DIR)"
+	@$(CP) OpenRA.Platforms.Default.dll.config "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) Open.Nat.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) MaxMind.Db.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) rix0rrr.BeaconLib.dll "$(DATA_INSTALL_DIR)"

--- a/Makefile
+++ b/Makefile
@@ -289,7 +289,8 @@ mods: mod_common mod_cnc mod_d2k
 all: dependencies core stylecheck
 
 clean:
-	@-$(RM_F) *.exe *.dll *.dylib *.dll.config ./OpenRA*/*.dll ./OpenRA*/*.mdb *.mdb mods/**/*.dll mods/**/*.mdb *.resources
+	@-$(RM_F) $(shell find . -maxdepth 1 -iname '*.dll.config' -a ! -iname 'OpenRA.Platforms.Default.dll.config')
+	@-$(RM_F) *.exe *.dll *.dylib ./OpenRA*/*.dll ./OpenRA*/*.mdb *.mdb mods/**/*.dll mods/**/*.mdb *.resources
 	@-$(RM_RF) ./*/bin ./*/obj
 	@-$(RM_RF) ./thirdparty/download
 
@@ -340,6 +341,7 @@ install-engine:
 	@-echo "Installing OpenRA engine to $(DATA_INSTALL_DIR)"
 	@$(INSTALL_DIR) "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) $(foreach prog,$(CORE),$($(prog)_TARGET)) "$(DATA_INSTALL_DIR)"
+	@$(CP) OpenRA.Platforms.Default.dll.config "$(DATA_INSTALL_DIR)"
 
 	@$(INSTALL_DATA) "GeoLite2-Country.mmdb.gz" "$(DATA_INSTALL_DIR)/GeoLite2-Country.mmdb.gz"
 	@$(INSTALL_DATA) VERSION "$(DATA_INSTALL_DIR)/VERSION"

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -19,6 +19,7 @@ namespace OpenRA
 	{
 		IPlatformWindow CreateWindow(Size size, WindowMode windowMode, int batchSize);
 		ISoundEngine CreateSound(string device);
+		IFont CreateFont(byte[] data);
 	}
 
 	public interface IHardwareCursor : IDisposable { }
@@ -128,5 +129,18 @@ namespace OpenRA
 		Windowed,
 		Fullscreen,
 		PseudoFullscreen,
+	}
+
+	public interface IFont : IDisposable
+	{
+		FontGlyph CreateGlyph(char c, int size, float deviceScale);
+	}
+
+	public struct FontGlyph
+	{
+		public int2 Offset;
+		public Size Size;
+		public float Advance;
+		public byte[] Data;
 	}
 }

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -76,11 +76,6 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="SharpFont">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\thirdparty\download\SharpFont.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Open.Nat">
       <HintPath>..\thirdparty\download\Open.Nat.dll</HintPath>
     </Reference>

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -39,6 +39,7 @@ namespace OpenRA
 		readonly Stack<Rectangle> scissorState = new Stack<Rectangle>();
 
 		SheetBuilder fontSheetBuilder;
+		readonly IPlatform platform;
 
 		float depthScale;
 		float depthOffset;
@@ -51,6 +52,7 @@ namespace OpenRA
 
 		public Renderer(IPlatform platform, GraphicSettings graphicSettings)
 		{
+			this.platform = platform;
 			var resolution = GetResolution(graphicSettings);
 
 			Window = platform.CreateWindow(new Size(resolution.Width, resolution.Height), graphicSettings.Mode, graphicSettings.BatchSize);
@@ -289,6 +291,11 @@ namespace OpenRA
 		public string GLVersion
 		{
 			get { return Context.GLVersion; }
+		}
+
+		public IFont CreateFont(byte[] data)
+		{
+			return platform.CreateFont(data);
 		}
 	}
 }

--- a/OpenRA.Platforms.Default.dll.config
+++ b/OpenRA.Platforms.Default.dll.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+	<dllmap dll="freetype6" os="linux" target="libfreetype.so.6" />
+	<dllmap dll="freetype6" os="osx" target="/Library/Frameworks/Mono.framework/Libraries/libfreetype.6.dylib" />
+	<dllmap dll="freetype6" os="freebsd" target="libfreetype.so.6" />
+</configuration>

--- a/OpenRA.Platforms.Default/DefaultPlatform.cs
+++ b/OpenRA.Platforms.Default/DefaultPlatform.cs
@@ -24,5 +24,10 @@ namespace OpenRA.Platforms.Default
 		{
 			return new OpenAlSoundEngine(device);
 		}
+
+		public IFont CreateFont(byte[] data)
+		{
+			return new FreeTypeFont(data);
+		}
 	}
 }

--- a/OpenRA.Platforms.Default/FreeTypeFont.cs
+++ b/OpenRA.Platforms.Default/FreeTypeFont.cs
@@ -1,0 +1,83 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Primitives;
+using SharpFont;
+
+namespace OpenRA.Platforms.Default
+{
+	public sealed class FreeTypeFont : IFont
+	{
+		static readonly Library Library = new Library();
+		readonly Face face;
+
+		public FreeTypeFont(byte[] data)
+		{
+			face = new Face(Library, data, 0);
+		}
+
+		public FontGlyph CreateGlyph(char c, int size, float deviceScale)
+		{
+			try
+			{
+				var scaledSize = (uint) (size * deviceScale);
+				face.SetPixelSizes(scaledSize, scaledSize);
+			
+				face.LoadChar(c, LoadFlags.Default, LoadTarget.Normal);
+				face.Glyph.RenderGlyph(RenderMode.Normal);
+
+				var glyphSize = new Size((int)face.Glyph.Metrics.Width, (int)face.Glyph.Metrics.Height);
+
+				var g = new FontGlyph
+				{
+					Advance = (float)face.Glyph.Metrics.HorizontalAdvance,
+					Offset = new int2(face.Glyph.BitmapLeft, -face.Glyph.BitmapTop),
+					Size = glyphSize,
+					Data = new byte[glyphSize.Width * glyphSize.Height]
+				};
+
+				// A new bitmap is generated each time this property is accessed, so we do need to dispose it.
+				using (var bitmap = face.Glyph.Bitmap)
+				{
+					unsafe
+					{
+						var p = (byte*)bitmap.Buffer;
+						var k = 0;
+						for (var j = 0; j < glyphSize.Height; j++)
+						{
+							for (var i = 0; i < glyphSize.Width; i++)
+								g.Data[k++] = p[i];
+
+							p += bitmap.Pitch;
+						}
+					}
+				}
+
+				return g;
+			}
+			catch (FreeTypeException)
+			{
+				return new FontGlyph
+				{
+					Offset = int2.Zero,
+					Size = new Size(0, 0),
+					Advance = 0,
+					Data = null
+				};
+			}
+		}
+
+		public void Dispose()
+		{
+			face.Dispose();
+		}
+	}
+}

--- a/OpenRA.Platforms.Default/FreeTypeFont.cs
+++ b/OpenRA.Platforms.Default/FreeTypeFont.cs
@@ -9,75 +9,140 @@
  */
 #endregion
 
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Runtime.InteropServices;
 using OpenRA.Primitives;
-using SharpFont;
 
 namespace OpenRA.Platforms.Default
 {
+	[SuppressMessage("Microsoft.StyleCop.CSharp.NamingRules", "SA1307:AccessibleFieldsMustBeginWithUpperCaseLetter",
+		Justification = "C-style naming is kept for consistency with the underlying native API.")]
+	[SuppressMessage("Microsoft.StyleCop.CSharp.NamingRules", "SA1310:FieldNamesMustNotContainUnderscore",
+		Justification = "C-style naming is kept for consistency with the underlying native API.")]
+	internal static class FreeType
+	{
+		internal const uint OK = 0x00;
+		internal const int FT_LOAD_RENDER = 0x04;
+
+		internal static readonly int FaceRecGlyphOffset = IntPtr.Size == 8 ? 152 : 84; // offsetof(FT_FaceRec, glyph)
+		internal static readonly int GlyphSlotMetricsOffset = IntPtr.Size == 8 ? 48 : 24; // offsetof(FT_GlyphSlotRec, metrics)
+		internal static readonly int GlyphSlotBitmapOffset = IntPtr.Size == 8 ? 152 : 76; // offsetof(FT_GlyphSlotRec, bitmap)
+		internal static readonly int GlyphSlotBitmapLeftOffset = IntPtr.Size == 8 ? 192 : 100; // offsetof(FT_GlyphSlotRec, bitmap_left)
+		internal static readonly int GlyphSlotBitmapTopOffset = IntPtr.Size == 8 ? 196 : 104; // offsetof(FT_GlyphSlotRec, bitmap_top)
+		internal static readonly int MetricsWidthOffset = 0; // offsetof(FT_Glyph_Metrics, width)
+		internal static readonly int MetricsHeightOffset = IntPtr.Size == 8 ? 8 : 4; // offsetof(FT_Glyph_Metrics, height)
+		internal static readonly int MetricsAdvanceOffset = IntPtr.Size == 8 ? 32 : 16; // offsetof(FT_Glyph_Metrics, horiAdvance)
+		internal static readonly int BitmapPitchOffset = 8; // offsetof(FT_Bitmap, pitch)
+		internal static readonly int BitmapBufferOffset = IntPtr.Size == 8 ? 16 : 12; // offsetof(FT_Bitmap, buffer)
+
+		[DllImport("freetype6", CallingConvention = CallingConvention.Cdecl)]
+		internal static extern uint FT_Init_FreeType(out IntPtr library);
+
+		[DllImport("freetype6", CallingConvention = CallingConvention.Cdecl)]
+		internal static extern uint FT_New_Memory_Face(IntPtr library, IntPtr file_base, int file_size, int face_index, out IntPtr aface);
+
+		[DllImport("freetype6", CallingConvention = CallingConvention.Cdecl)]
+		internal static extern uint FT_Done_Face(IntPtr face);
+
+		[DllImport("freetype6", CallingConvention = CallingConvention.Cdecl)]
+		internal static extern uint FT_Set_Pixel_Sizes(IntPtr face, uint pixel_width, uint pixel_height);
+
+		[DllImport("freetype6", CallingConvention = CallingConvention.Cdecl)]
+		internal static extern uint FT_Load_Char(IntPtr face, uint char_code, int load_flags);
+	}
+
 	public sealed class FreeTypeFont : IFont
 	{
-		static readonly Library Library = new Library();
-		readonly Face face;
+		static readonly FontGlyph EmptyGlyph = new FontGlyph
+		{
+			Offset = int2.Zero,
+			Size = new Size(0, 0),
+			Advance = 0,
+			Data = null
+		};
+
+		static IntPtr library = IntPtr.Zero;
+		readonly GCHandle faceHandle;
+		readonly IntPtr face;
+		bool disposed;
 
 		public FreeTypeFont(byte[] data)
 		{
-			face = new Face(Library, data, 0);
+			if (library == IntPtr.Zero && FreeType.FT_Init_FreeType(out library) != FreeType.OK)
+				throw new InvalidOperationException("Failed to initialize FreeType");
+
+			faceHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
+			if (FreeType.FT_New_Memory_Face(library, faceHandle.AddrOfPinnedObject(), data.Length, 0, out face) != FreeType.OK)
+				throw new InvalidDataException("Failed to initialize font");
 		}
 
 		public FontGlyph CreateGlyph(char c, int size, float deviceScale)
 		{
-			try
+			var scaledSize = (uint)(size * deviceScale);
+			if (FreeType.FT_Set_Pixel_Sizes(face, scaledSize, scaledSize) != FreeType.OK)
+				return EmptyGlyph;
+
+			if (FreeType.FT_Load_Char(face, c, FreeType.FT_LOAD_RENDER) != FreeType.OK)
+				return EmptyGlyph;
+
+			// Extract the glyph data we care about
+			// HACK: This uses raw pointer offsets to avoid defining structs and types that are 95% unnecessary
+			var glyph = Marshal.ReadIntPtr(IntPtr.Add(face, FreeType.FaceRecGlyphOffset)); // face->glyph
+
+			var metrics = IntPtr.Add(glyph, FreeType.GlyphSlotMetricsOffset); // face->glyph->metrics
+			var metricsWidth = Marshal.ReadIntPtr(IntPtr.Add(metrics, FreeType.MetricsWidthOffset)); // face->glyph->metrics.width
+			var metricsHeight = Marshal.ReadIntPtr(IntPtr.Add(metrics, FreeType.MetricsHeightOffset)); // face->glyph->metrics.width
+			var metricsAdvance = Marshal.ReadIntPtr(IntPtr.Add(metrics, FreeType.MetricsAdvanceOffset)); // face->glyph->metrics.horiAdvance
+
+			var bitmap = IntPtr.Add(glyph, FreeType.GlyphSlotBitmapOffset); // face->glyph->bitmap
+			var bitmapPitch = Marshal.ReadInt32(IntPtr.Add(bitmap, FreeType.BitmapPitchOffset)); // face->glyph->bitmap.pitch
+			var bitmapBuffer = Marshal.ReadIntPtr(IntPtr.Add(bitmap, FreeType.BitmapBufferOffset)); // face->glyph->bitmap.buffer
+
+			var bitmapLeft = Marshal.ReadInt32(IntPtr.Add(glyph, FreeType.GlyphSlotBitmapLeftOffset)); // face->glyph.bitmap_left
+			var bitmapTop = Marshal.ReadInt32(IntPtr.Add(glyph, FreeType.GlyphSlotBitmapTopOffset)); // face->glyph.bitmap_top
+
+			// Convert FreeType's 26.6 fixed point format to integers by discarding fractional bits
+			var glyphSize = new Size((int)metricsWidth >> 6, (int)metricsHeight >> 6);
+			var glyphAdvance = (int)metricsAdvance >> 6;
+
+			var g = new FontGlyph
 			{
-				var scaledSize = (uint) (size * deviceScale);
-				face.SetPixelSizes(scaledSize, scaledSize);
-			
-				face.LoadChar(c, LoadFlags.Default, LoadTarget.Normal);
-				face.Glyph.RenderGlyph(RenderMode.Normal);
+				Advance = glyphAdvance,
+				Offset = new int2(bitmapLeft, -bitmapTop),
+				Size = glyphSize,
+				Data = new byte[glyphSize.Width * glyphSize.Height]
+			};
 
-				var glyphSize = new Size((int)face.Glyph.Metrics.Width, (int)face.Glyph.Metrics.Height);
-
-				var g = new FontGlyph
+			unsafe
+			{
+				var p = (byte*)bitmapBuffer;
+				var k = 0;
+				for (var j = 0; j < glyphSize.Height; j++)
 				{
-					Advance = (float)face.Glyph.Metrics.HorizontalAdvance,
-					Offset = new int2(face.Glyph.BitmapLeft, -face.Glyph.BitmapTop),
-					Size = glyphSize,
-					Data = new byte[glyphSize.Width * glyphSize.Height]
-				};
+					for (var i = 0; i < glyphSize.Width; i++)
+						g.Data[k++] = p[i];
 
-				// A new bitmap is generated each time this property is accessed, so we do need to dispose it.
-				using (var bitmap = face.Glyph.Bitmap)
-				{
-					unsafe
-					{
-						var p = (byte*)bitmap.Buffer;
-						var k = 0;
-						for (var j = 0; j < glyphSize.Height; j++)
-						{
-							for (var i = 0; i < glyphSize.Width; i++)
-								g.Data[k++] = p[i];
-
-							p += bitmap.Pitch;
-						}
-					}
+					p += bitmapPitch;
 				}
+			}
 
-				return g;
-			}
-			catch (FreeTypeException)
-			{
-				return new FontGlyph
-				{
-					Offset = int2.Zero,
-					Size = new Size(0, 0),
-					Advance = 0,
-					Data = null
-				};
-			}
+			return g;
 		}
 
 		public void Dispose()
 		{
-			face.Dispose();
+			if (!disposed)
+			{
+				if (faceHandle.IsAllocated)
+				{
+					FreeType.FT_Done_Face(face);
+
+					faceHandle.Free();
+					disposed = true;
+				}
+			}
 		}
 	}
 }

--- a/OpenRA.Platforms.Default/OpenRA.Platforms.Default.csproj
+++ b/OpenRA.Platforms.Default/OpenRA.Platforms.Default.csproj
@@ -33,6 +33,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="SharpFont">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\thirdparty\download\SharpFont.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Eluant">
       <HintPath>..\thirdparty\download\Eluant.dll</HintPath>
     </Reference>
@@ -45,6 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DefaultPlatform.cs" />
+    <Compile Include="FreeTypeFont.cs" />
     <Compile Include="Sdl2PlatformWindow.cs" />
     <Compile Include="ITextureInternal.cs" />
     <Compile Include="Sdl2Input.cs" />

--- a/OpenRA.Platforms.Default/OpenRA.Platforms.Default.csproj
+++ b/OpenRA.Platforms.Default/OpenRA.Platforms.Default.csproj
@@ -33,11 +33,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="SharpFont">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\thirdparty\download\SharpFont.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Eluant">
       <HintPath>..\thirdparty\download\Eluant.dll</HintPath>
     </Reference>

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -115,7 +115,6 @@ Section "Game" GAME
 	File "${SRCDIR}\RedAlert.ico"
 	File "${SRCDIR}\TiberianDawn.ico"
 	File "${SRCDIR}\Dune2000.ico"
-	File "${SRCDIR}\SharpFont.dll"
 	File "${SRCDIR}\SDL2-CS.dll"
 	File "${SRCDIR}\OpenAL-CS.dll"
 	File "${SRCDIR}\global mix database.dat"
@@ -229,7 +228,6 @@ Function ${UN}Clean
 	Delete $INSTDIR\ICSharpCode.SharpZipLib.dll
 	Delete $INSTDIR\FuzzyLogicLibrary.dll
 	Delete $INSTDIR\Open.Nat.dll
-	Delete $INSTDIR\SharpFont.dll
 	Delete $INSTDIR\VERSION
 	Delete $INSTDIR\AUTHORS
 	Delete $INSTDIR\COPYING

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -43,16 +43,6 @@ if (!(Test-Path "MaxMind.Db.dll"))
 	rmdir MaxMind.Db -Recurse
 }
 
-if (!(Test-Path "SharpFont.dll"))
-{
-	echo "Fetching SharpFont from NuGet."
-	./nuget.exe install SharpFont -Version 4.0.1 -ExcludeVersion -Verbosity quiet -Source nuget.org
-	cp SharpFont/lib/net45/SharpFont* .
-	cp SharpFont/config/SharpFont.dll.config .
-	rmdir SharpFont -Recurse
-	rmdir SharpFont.Dependencies -Recurse
-}
-
 if (!(Test-Path "nunit.framework.dll"))
 {
 	echo "Fetching NUnit from NuGet."

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -41,14 +41,6 @@ if [ ! -f MaxMind.Db.dll ]; then
 	rm -rf MaxMind.Db
 fi
 
-if [ ! -f SharpFont.dll ]; then
-	echo "Fetching SharpFont from NuGet"
-	../noget.sh SharpFont 4.0.1
-	cp ./SharpFont/lib/net45/SharpFont* .
-	cp ./SharpFont/config/SharpFont.dll.config .
-	rm -rf SharpFont SharpFont.Dependencies
-fi
-
 if [ ! -f nunit.framework.dll ]; then
 	echo "Fetching NUnit from NuGet"
 	../noget.sh NUnit 3.0.1


### PR DESCRIPTION
SharpFont presents us with two problems in the short term:
* It depends on System.Drawing, blocking #15955
* It doesn't target .net Standard, blocking #15954 

Closes #15955.

The maintenance status of SharpFont isn't clear - a couple of patches were merged during 2018, but https://github.com/Robmaister/SharpFont/issues/126 has not received any response. The project doesn't build under mono, which is a significant barrier to developing our own forked version and trying to contribute patches back upstream.

We only use a tiny part of the FreeType API, so IMO the simplest path forward is to ship our own minimal native binding, like we did for OpenGL (#10288). The FreeType interactions are based in part on [SceneFlipEngine/font.c](https://github.com/pchote/SceneFlipEngine/blob/master/engine/font.c) and in part by inspecting the SharpFont source.

Test builds are available from https://github.com/pchote/OpenRA/releases/tag/pkgtest-20190307, which i've already verified work under macOS/Linux/Windows.