### PR TITLE
Let civilians use the normal stand animation when panicking

### DIFF
--- a/mods/cnc/sequences/civilian.yaml
+++ b/mods/cnc/sequences/civilian.yaml
@@ -2,8 +2,6 @@ c1:
 	stand:
 		Facings: 8
 	panic-stand:
-		Start: 8
-		Length: 6
 		Facings: 8
 	panic-run:
 		Start: 8
@@ -87,9 +85,6 @@ moebius:
 	stand:
 		Facings: 8
 	panic-stand:
-		Start: 8
-		Length: 1
-		Stride: 6
 		Facings: 8
 	panic-run:
 		Start: 8

--- a/mods/ra/sequences/infantry.yaml
+++ b/mods/ra/sequences/infantry.yaml
@@ -964,8 +964,6 @@ c1:
 	stand:
 		Facings: 8
 	panic-stand:
-		Start: 8
-		Stride: 6
 		Facings: 8
 	panic-run:
 		Start: 8
@@ -1014,8 +1012,6 @@ c2:
 	stand:
 		Facings: 8
 	panic-stand:
-		Start: 8
-		Stride: 6
 		Facings: 8
 	panic-run:
 		Start: 8
@@ -1064,8 +1060,6 @@ c3:
 	stand:
 		Facings: 8
 	panic-stand:
-		Start: 8
-		Stride: 6
 		Facings: 8
 	panic-run:
 		Start: 8
@@ -1113,13 +1107,11 @@ c3:
 einstein:
 	stand:
 		Facings: 8
+	panic-stand:
+		Facings: 8
 	panic-run:
 		Start: 8
 		Length: 6
-		Facings: 8
-	panic-stand:
-		Start: 8
-		Stride: 6
 		Facings: 8
 	run:
 		Start: 56
@@ -1159,13 +1151,11 @@ einstein:
 delphi:
 	stand:
 		Facings: 8
+	panic-stand:
+		Facings: 8
 	panic-run:
 		Start: 8
 		Length: 6
-		Facings: 8
-	panic-stand:
-		Start: 8
-		Stride: 6
 		Facings: 8
 	run:
 		Start: 56
@@ -1205,13 +1195,11 @@ delphi:
 chan:
 	stand:
 		Facings: 8
+	panic-stand:
+		Facings: 8
 	panic-run:
 		Start: 8
 		Length: 6
-		Facings: 8
-	panic-stand:
-		Start: 8
-		Stride: 6
 		Facings: 8
 	run:
 		Start: 56

--- a/mods/ts/sequences/infantry.yaml
+++ b/mods/ts/sequences/infantry.yaml
@@ -159,10 +159,8 @@ civ1:
 		Facings: 8
 		ShadowStart: 378
 	panic-stand:
-		Start: 86
 		Facings: 8
-		Stride: 6
-		ShadowStart: 378
+		ShadowStart: 292
 
 civ2:
 	Inherits: ^BasicInfantry
@@ -172,10 +170,8 @@ civ2:
 		Facings: 8
 		ShadowStart: 378
 	panic-stand:
-		Start: 86
 		Facings: 8
-		Stride: 6
-		ShadowStart: 378
+		ShadowStart: 292
 
 civ3:
 	Inherits: civ1


### PR DESCRIPTION
It looked really odd when infantry are attacking (see gifs below) and doesn't make a difference for when they are running, imho. (The civs in cnc were not set up correctly anyway.)

Before:
![civshooting](https://user-images.githubusercontent.com/7704140/54032520-27d89400-41b2-11e9-95db-f3b2c0892b19.gif)

After:
![civshooting2](https://user-images.githubusercontent.com/7704140/54032524-2a3aee00-41b2-11e9-9264-49fddaea73ff.gif)

