### PR TITLE
Fix map preview generation for isometric terrain

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -664,6 +664,7 @@ namespace OpenRA
 					bitmapWidth = 2 * bitmapWidth - 1;
 
 				var stride = bitmapWidth * 4;
+				var pxStride = 4;
 				var minimapData = new byte[stride * height];
 				Color leftColor, rightColor;
 				for (var y = 0; y < height; y++)
@@ -693,18 +694,19 @@ namespace OpenRA
 						{
 							// Odd rows are shifted right by 1px
 							var dx = uv.V & 1;
+							var xOffset = pxStride * (2 * x + dx);
 							if (x + dx > 0)
 							{
-								var z = y * stride + 8 * x + dx - 4;
+								var z = y * stride + xOffset - pxStride;
 								minimapData[z++] = leftColor.R;
 								minimapData[z++] = leftColor.G;
 								minimapData[z++] = leftColor.B;
 								minimapData[z++] = leftColor.A;
 							}
 
-							if (2 * x + dx < stride)
+							if (xOffset < stride)
 							{
-								var z = y * stride + 8 * x + dx;
+								var z = y * stride + xOffset;
 								minimapData[z++] = rightColor.R;
 								minimapData[z++] = rightColor.G;
 								minimapData[z++] = rightColor.B;
@@ -713,7 +715,7 @@ namespace OpenRA
 						}
 						else
 						{
-							var z = y * stride + 4 * x;
+							var z = y * stride + pxStride * x;
 							minimapData[z++] = leftColor.R;
 							minimapData[z++] = leftColor.G;
 							minimapData[z++] = leftColor.B;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/SaveMapLogic.cs
@@ -203,6 +203,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				catch (Exception e)
 				{
 					Log.Write("debug", "Failed to save map at {0}: {1}", combinedPath, e.Message);
+					Log.Write("debug", "{0}", e.StackTrace);
 
 					ConfirmationDialogs.ButtonPrompt(
 						title: "Failed to save map",


### PR DESCRIPTION
Regression from #16218.
It errors on bleed as we need to multiply `dx` by `4` in order to shift a cell.