### PR TITLE
Remove bogus and unnecessary Color[] FieldLoader override.

### DIFF
--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -233,22 +233,6 @@ namespace OpenRA
 
 				return InvalidValueAction(value, fieldType, fieldName);
 			}
-			else if (fieldType == typeof(Color[]))
-			{
-				if (value != null)
-				{
-					var parts = value.Split(',');
-					var colors = new Color[parts.Length];
-
-					for (var i = 0; i < colors.Length; i++)
-						if (!Color.TryParse(parts[i], out colors[i]))
-							return InvalidValueAction(value, fieldType, fieldName);
-
-					return colors;
-				}
-
-				return InvalidValueAction(value, fieldType, fieldName);
-			}
 			else if (fieldType == typeof(Hotkey))
 			{
 				Hotkey res;


### PR DESCRIPTION
Fixes #16285.

This code has always been wrong, but was never used because `HSLColor` did not define a corresponding array override. The default array parsing works fine for `Color`, so we can remove this override completely.