### PR TITLE
Fix TS Stealth Generator ignoring EMP

### DIFF
--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -298,7 +298,7 @@ NASTLH:
 		Range: 6c0
 		MaxHeightDelta: 3
 	WithIdleOverlay@pulse:
-		RequiresCondition: !build-incomplete && !disabled
+		RequiresCondition: !build-incomplete && !empdisable && !disabled
 		Sequence: pulse
 	WithRangeCircle:
 		Range: 12c0
@@ -306,7 +306,7 @@ NASTLH:
 	Power:
 		Amount: -350
 	ProximityExternalCondition:
-		RequiresCondition: !disabled
+		RequiresCondition: !empdisable && !disabled
 		Condition: cloakgenerator
 		Range: 12c0
 		EnableSound: cloak5.aud


### PR DESCRIPTION
On bleed it continues to stealth the surrounding actors when EMP'd.
Fixes #16290.