### PR TITLE
RA - Fix Veterancy removal on shellmap rules.

### DIFF
--- a/mods/ra/maps/desert-shellmap/rules.yaml
+++ b/mods/ra/maps/desert-shellmap/rules.yaml
@@ -72,6 +72,10 @@ World:
 	DamageMultiplier:
 		Modifier: 0
 
+^Wall:
+	DamageMultiplier:
+		Modifier: 0
+
 OILB:
 	CashTrickler:
 		ShowTicks: false

--- a/mods/ra/maps/desert-shellmap/rules.yaml
+++ b/mods/ra/maps/desert-shellmap/rules.yaml
@@ -23,9 +23,11 @@ World:
 			Soviets: 229, 230, 231, 232, 233, 234, 235, 8, 236, 237, 238, 239, 221, 222, 223, 223
 			Allies: 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175
 
+^ExistsInWorld:
+	GivesExperience:
+		ActorExperienceModifier: 0
+
 ^Vehicle:
-	GainsExperience:
-		Conditions:
 	DamageMultiplier@UNKILLABLE:
 		RequiresCondition: unkillable
 		Modifier: 0
@@ -33,8 +35,6 @@ World:
 		Condition: unkillable
 
 ^Infantry:
-	GainsExperience:
-		Conditions:
 	DeathSounds@NORMAL:
 		VolumeMultiplier: 0.1
 	DeathSounds@BURNED:
@@ -48,8 +48,6 @@ World:
 		Condition: unkillable
 
 ^Ship:
-	GainsExperience:
-		Conditions:
 	DamageMultiplier@UNKILLABLE:
 		RequiresCondition: unkillable
 		Modifier: 0

--- a/mods/ts/maps/fields-of-green/map.yaml
+++ b/mods/ts/maps/fields-of-green/map.yaml
@@ -1437,6 +1437,9 @@ Rules:
 		GlobalLightingPaletteEffect:
 			Blue: 0.7
 			Ambient: 0.7
+	^ExistsInWorld:
+		GivesExperience:
+			ActorExperienceModifier: 0
 	HARV:
 		-Targetable:
 	GALITE:


### PR DESCRIPTION
Since we moved GainsExperience inheritance from defaults to units, the current implementation on RA shellmap causes crashes if a unit without GainsExperience kills something somehow (i.e Crushing).

D2k Shellmap seems to be already set up this way.