### PR TITLE
Ship a minimal mono 5.10 runtime in the AppImage packages.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,18 @@ CSC         = mcs $(SDK)
 CSFLAGS     = -nologo -warn:4 -codepage:utf8 -langversion:5 -unsafe -warnaserror
 DEFINE      = TRACE
 COMMON_LIBS = System.dll System.Core.dll System.Numerics.dll thirdparty/download/ICSharpCode.SharpZipLib.dll thirdparty/download/FuzzyLogicLibrary.dll thirdparty/download/MaxMind.Db.dll thirdparty/download/Eluant.dll thirdparty/download/rix0rrr.BeaconLib.dll
+
+# List of .NET assemblies that we can guarantee exist
+# OpenRA.Game.dll is a harmless false positive that we can ignore
+WHITELISTED_OPENRA_ASSEMBLIES = $(game_TARGET) $(utility_TARGET) $(pdefault_TARGET) $(mod_common_TARGET) $(mod_cnc_TARGET) $(mod_d2k_TARGET) OpenRA.Game.dll
+
+# These are explicitly shipped alongside our core files by the packaging script
+WHITELISTED_THIRDPARTY_ASSEMBLIES = ICSharpCode.SharpZipLib.dll FuzzyLogicLibrary.dll MaxMind.Db.dll Eluant.dll rix0rrr.BeaconLib.dll Open.Nat.dll SDL2-CS.dll OpenAL-CS.dll 
+
+# These are shipped in our custom minimal mono runtime and also available in the full system-installed .NET/mono stack
+# This list *must* be kept in sync with the files packaged by the AppImageSupport repository
+WHITELISTED_CORE_ASSEMBLIES = mscorlib.dll System.dll System.Configuration.dll System.Core.dll System.Numerics.dll System.Security.dll System.Xml.dll Mono.Security.dll
+
 NUNIT_LIBS_PATH :=
 NUNIT_LIBS  := $(NUNIT_LIBS_PATH)nunit.framework.dll
 
@@ -164,6 +176,9 @@ check-scripts:
 	@luac -p $(shell find lua/* -iname '*.lua')
 
 check: utility stylecheck mods
+	@echo
+	@echo "Checking runtime assemblies..."
+	@mono --debug OpenRA.Utility.exe all --check-runtime-assemblies $(WHITELISTED_OPENRA_ASSEMBLIES) $(WHITELISTED_THIRDPARTY_ASSEMBLIES) $(WHITELISTED_CORE_ASSEMBLIES)
 	@echo
 	@echo "Checking for explicit interface violations..."
 	@mono --debug OpenRA.Utility.exe all --check-explicit-interfaces

--- a/Makefile
+++ b/Makefile
@@ -295,9 +295,9 @@ $(foreach prog,$(PROGRAMS),$(eval $(call BUILD_ASSEMBLY,$(prog))))
 
 ########################## MAKE/INSTALL RULES ##########################
 #
-default: core
+default: dependencies core
 
-core: dependencies game platforms mods utility server
+core: game platforms mods utility server
 
 mods: mod_common mod_cnc mod_d2k
 

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -611,6 +611,7 @@
     <Compile Include="UpdateRules\Rules\20190106\MakeMobilePausableConditional.cs" />
     <Compile Include="UpdateRules\Rules\20190106\MultipleDeploySounds.cs" />
     <Compile Include="UpdateRules\Rules\20190106\RemoveSimpleBeacon.cs" />
+    <Compile Include="UtilityCommands\CheckRuntimeAssembliesCommand.cs" />
     <Compile Include="UtilityCommands\CheckYaml.cs" />
     <Compile Include="UtilityCommands\ConvertPngToShpCommand.cs" />
     <Compile Include="UtilityCommands\ConvertSpriteToPngCommand.cs" />

--- a/OpenRA.Mods.Common/UtilityCommands/CheckRuntimeAssembliesCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckRuntimeAssembliesCommand.cs
@@ -1,0 +1,58 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace OpenRA.Mods.Common.UtilityCommands
+{
+	public class CheckRuntimeAssembliesCommand : IUtilityCommand
+	{
+		string IUtilityCommand.Name { get { return "--check-runtime-assemblies"; } }
+
+		bool IUtilityCommand.ValidateArguments(string[] args)
+		{
+			return true;
+		}
+
+		[Desc("ASSEMBLY [ASSEMBLY ...]", "Check the runtime dependencies of the mod against a given whitelist of " +
+				"assembly (dll and exe) names and generate an error if any unlisted files are required.")]
+		void IUtilityCommand.Run(Utility utility, string[] args)
+		{
+			var whitelist = args
+				.Skip(1)
+				.Select(a => Path.GetFileName(a))
+				.ToArray();
+
+			// Load the renderer assembly so we can check its dependencies
+			Assembly.LoadFile(Platform.ResolvePath(Path.Combine(".", "OpenRA.Platforms.Default.dll")));
+
+			var missing = new List<string>();
+			foreach (var a in AppDomain.CurrentDomain.GetAssemblies())
+			{
+				var assemblyName = Path.GetFileName(a.Location);
+				if (!whitelist.Contains(assemblyName))
+					missing.Add(assemblyName);
+			}
+
+			if (missing.Any())
+			{
+				Console.WriteLine("error: The following assemblies are referenced but not whitelisted:");
+				foreach (var m in missing)
+					Console.WriteLine("   " + m);
+				Environment.Exit(1);
+			}
+		}
+	}
+}

--- a/packaging/linux/AppRun.in
+++ b/packaging/linux/AppRun.in
@@ -1,71 +1,23 @@
 #!/bin/sh
 
-# Make sure the user has a sufficiently recent version of mono on the PATH
-MINIMUM_MONO_VERSION="4.2"
-
-prompt_apt_install_mono_complete() {
-  command -v mono >/dev/null 2>&1 && command -v cert-sync >/dev/null 2>&1 && return 1
-  command -v apt-cache > /dev/null || return 1
-  command -v xdg-mime > /dev/null || return 1
-  command -v xdg-open > /dev/null || return 1
-  [ ! "$(xdg-mime query default x-scheme-handler/apt)" ] && return 1
-  apt-cache search --names-only mono-complete | cut -d' ' -f1 | grep "^mono-complete$" > /dev/null || return 1
-  return 0
-}
-
-make_version() {
-  echo "$1" | tr '.' '\n' | head -n 4 | xargs printf "%03d%03d%03d%03d";
-}
-
-mono_missing_or_old() {
-  command -v mono >/dev/null 2>&1 || return 0
-  command -v cert-sync >/dev/null 2>&1 || return 0
-  MONO_VERSION=$(mono --version | head -n1 | cut -d' ' -f5)
-  [ "$(make_version "${MONO_VERSION}")" -lt "$(make_version "${MINIMUM_MONO_VERSION}")" ] && return 0
-  return 1
-}
-
 HERE="$(dirname "$(readlink -f "${0}")")"
-export PATH="${HERE}"/usr/bin/:"${PATH}"
-export XDG_DATA_DIRS="${HERE}"/usr/share/:"${XDG_DATA_DIRS}"
 
-# If mono is not installed, and the user has apt-cache, apt-url,
-# xdg-open, and either zenity or kdialog, then we can prompt to
-# automatically install the mono-complete package
-if prompt_apt_install_mono_complete; then
-  PROMPT_MESSAGE="{MODNAME} requires the Mono runtime.\nWould you like to install it now?"
-  if command -v zenity > /dev/null; then
-    zenity --no-wrap --question --title "{MODNAME}" --text "${PROMPT_MESSAGE}" 2> /dev/null && xdg-open apt://mono-complete && exit 0
-  elif command -v kdialog > /dev/null; then
-    kdialog --title "{MODNAME}" --yesno "${PROMPT_MESSAGE}" && xdg-open apt://mono-complete && exit 0
-  elif "${HERE}/usr/bin/gtk-dialog.py" test > /dev/null; then
-    "${HERE}/usr/bin/gtk-dialog.py" question --title "{MODNAME}" --text "${PROMPT_MESSAGE}" 2> /dev/null && xdg-open apt://mono-complete && exit 0
-  fi
-fi
+# Override runtime paths
+export PATH="${HERE}/usr/bin:${PATH}"
+export XDG_DATA_DIRS="${HERE}/usr/share:${XDG_DATA_DIRS}"
+export DYLD_LIBRARY_PATH="${HERE}/usr/lib:$DYLD_LIBRARY_PATH"
+export LD_LIBRARY_PATH="${HERE}/usr/lib:$LD_LIBRARY_PATH"
+export MONO_PATH="${HERE}/usr/lib/mono/4.5"
+export MONO_CFG_DIR="${HERE}/etc"
+export MONO_CONFIG="${HERE}/etc/mono/config"
 
-if mono_missing_or_old; then
-  ERROR_MESSAGE="{MODNAME} requires Mono ${MINIMUM_MONO_VERSION} or greater and the cert-sync utility.\nPlease install Mono using your system package manager.\n\nSee http://wiki.openra.net/AppImages for more information."
-  if command -v zenity > /dev/null; then
-    zenity --no-wrap --error --title "{MODNAME}" --text "${ERROR_MESSAGE}" 2> /dev/null
-  elif command -v kdialog > /dev/null; then
-    kdialog --title "{MODNAME}" --error "${ERROR_MESSAGE}"
-  elif "${HERE}/usr/bin/gtk-dialog.py" test > /dev/null; then
-    "${HERE}/usr/bin/gtk-dialog.py" error --title "{MODNAME}" --text "${ERROR_MESSAGE}" 2> /dev/null
-  else
-    printf "${ERROR_MESSAGE}"
-  fi
-  exit 1
-fi
-
-# Some distros and self-compiled mono installations don't set up
-# the SSL required for http web queries. If we detect that these
-# are missing we can try and create a local sync as a fallback.
-if [ ! -d "/usr/share/.mono/certs" ] && [ ! -d "${HOME}/.config/.mono/certs" ]; then
-  if [ -f "/etc/pki/tls/certs/ca-bundle.crt" ]; then
-    cert-sync --quiet --user /etc/pki/tls/certs/ca-bundle.crt
-  elif [ -f "/etc/ssl/certs/ca-certificates.crt" ]; then
-    cert-sync --quiet --user /etc/ssl/certs/ca-certificates.crt
-  fi
+# Update/create the mono certificate store to enable https web queries
+if [ -f "/etc/pki/tls/certs/ca-bundle.crt" ]; then
+  mono "${HERE}/usr/lib/mono/4.5/cert-sync.exe" --quiet --user /etc/pki/tls/certs/ca-bundle.crt
+elif [ -f "/etc/ssl/certs/ca-certificates.crt" ]; then
+  mono "${HERE}/usr/lib/mono/4.5/cert-sync.exe" --quiet --user /etc/ssl/certs/ca-certificates.crt
+else
+  echo "WARNING: Unable to sync system certificate store - https requests will fail"
 fi
 
 # Run the game or server

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -45,8 +45,13 @@ fi
 echo "Building core files"
 
 pushd "${SRCDIR}" > /dev/null || exit 1
-make linux-dependencies
+
+make clean
+
+# linux-dependencies target will trigger the lua detection script, which we don't want during packaging
+make cli-dependencies geoip-dependencies
 sed "s/@LIBLUA51@/liblua5.1.so.0/" thirdparty/Eluant.dll.config.in > Eluant.dll.config
+
 make core SDK="-sdk:4.5"
 make version VERSION="${TAG}"
 make install-engine prefix="usr" DESTDIR="${BUILTDIR}/"

--- a/packaging/linux/openra-utility.appimage.in
+++ b/packaging/linux/openra-utility.appimage.in
@@ -2,4 +2,4 @@
 
 # OpenRA.Utility relies on keeping the original working directory, so don't change directory
 HERE="$(dirname "$(readlink -f "${0}")")"
-mono --debug ${HERE}/../lib/openra/OpenRA.Utility.exe {MODID} "$@"
+mono --debug "${HERE}/../lib/openra/OpenRA.Utility.exe" {MODID} "$@"

--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -71,6 +71,7 @@ modify_plist "{FAQ_URL}" "http://wiki.openra.net/FAQ" "${BUILTDIR}/OpenRA.app/Co
 echo "Building core files"
 
 pushd "${SRCDIR}" > /dev/null || exit 1
+make clean
 make osx-dependencies
 make core SDK="-sdk:4.5"
 make version VERSION="${TAG}"

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -38,6 +38,7 @@ function makelauncher()
 echo "Building core files"
 
 pushd "${SRCDIR}" > /dev/null || exit 1
+make clean
 make windows-dependencies
 make core SDK="-sdk:4.5"
 make version VERSION="${TAG}"


### PR DESCRIPTION
This PR makes our Linux packages properly stand-alone by shipping a minimal mono runtime inside the AppImages.

Fixes #15965.

This is a significant win, even if we ignore the AppImage philosophy, because it removes the resriction of having to support mono 4.2 and 4.6.  These aren't going away any time soon, and hold us back from the modern .NET ecosystem which requires mono >= 5.4 (#15954).

The first commit adds a new check that will fail if the runtime dependencies change. We only ship the parts of the core runtime that we actually use, so we may accidentally introduce a new dependency in the future that works fine when compiled and run from source, but crashes when players try to run the packaged builds.

The second commit adjusts the AppImage packaging to pull in the changes from https://github.com/OpenRA/AppImageSupport/commit/b21c85b933c43ea44f76ba13a0475c226740aff7 and https://github.com/OpenRA/AppImageSupport/commit/bbfb0f908db5019d9147175c9a0a25a218eba584.  These use the runtime files provided by Microsoft for the `mkbundle` cross-compiler toolchain - we currently target Debian 7 as our glibc baseline, so 5.10 is the latest version we can use.

The third commit fixes a facepalm I discovered while working on this PR, making sure that each platform's build starts from a clean slate and fixing a build failure when the host doesn't have lua installed.

Test packages are available from https://github.com/pchote/OpenRA/releases/tag/pkgtest-20190316.
I have already tested under:
* Ubuntu 18.04.2
* Ubuntu 14.04.6 (runs but https queries fail - maybe outdated system TLS support?)
* CentOS 7
* MX Linux 18.1 (ref #15311)
* Linux Mint 19.1 (ref #15450)