### PR TITLE
Ship a minimal mono 5.10 runtime in the macOS .app bundles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ WHITELISTED_OPENRA_ASSEMBLIES = $(game_TARGET) $(utility_TARGET) $(pdefault_TARG
 WHITELISTED_THIRDPARTY_ASSEMBLIES = ICSharpCode.SharpZipLib.dll FuzzyLogicLibrary.dll MaxMind.Db.dll Eluant.dll rix0rrr.BeaconLib.dll Open.Nat.dll SDL2-CS.dll OpenAL-CS.dll 
 
 # These are shipped in our custom minimal mono runtime and also available in the full system-installed .NET/mono stack
-# This list *must* be kept in sync with the files packaged by the AppImageSupport repository
+# This list *must* be kept in sync with the files packaged by the AppImageSupport and OpenRALauncherOSX repositories
 WHITELISTED_CORE_ASSEMBLIES = mscorlib.dll System.dll System.Configuration.dll System.Core.dll System.Numerics.dll System.Security.dll System.Xml.dll Mono.Security.dll
 
 NUNIT_LIBS_PATH :=

--- a/OpenRA.Platforms.Default.dll.config
+++ b/OpenRA.Platforms.Default.dll.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
 	<dllmap dll="freetype6" os="linux" target="libfreetype.so.6" />
-	<dllmap dll="freetype6" os="osx" target="/Library/Frameworks/Mono.framework/Libraries/libfreetype.6.dylib" />
+	<dllmap dll="freetype6" os="osx" target="libfreetype.6.dylib" />
 	<dllmap dll="freetype6" os="freebsd" target="libfreetype.so.6" />
 </configuration>

--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -9,7 +9,7 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
 	command -v genisoimage >/dev/null 2>&1 || { echo >&2 "macOS packaging requires genisoimage."; exit 1; }
 fi
 
-LAUNCHER_TAG="osx-launcher-20171118"
+LAUNCHER_TAG="osx-launcher-20190317"
 
 if [ $# -ne "2" ]; then
 	echo "Usage: $(basename "$0") tag outputdir"

--- a/thirdparty/fetch-thirdparty-deps-osx.sh
+++ b/thirdparty/fetch-thirdparty-deps-osx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LAUNCHER_TAG="osx-launcher-20171118"
+LAUNCHER_TAG="osx-launcher-20190317"
 
 download_dir="${0%/*}/download/osx"
 mkdir -p "$download_dir"
@@ -18,5 +18,10 @@ fi
 
 if [ ! -f Eluant.dll.config ]; then
 	echo "Fetching OS X Lua configuration file from GitHub."
-	curl -LOs https://raw.githubusercontent.com/OpenRA/OpenRALauncherOSX/${LAUNCHER_TAG}/dependencies/Eluant.dll.config
+	curl -LOs https://raw.githubusercontent.com/OpenRA/OpenRALauncherOSX/${LAUNCHER_TAG}/Eluant.dll.config
+fi
+
+if [ ! -f libfreetype.6.dylib ]; then
+	echo "Fetching OS X FreeType library from GitHub."
+	curl -LOs https://github.com/OpenRA/OpenRALauncherOSX/releases/download/${LAUNCHER_TAG}/libfreetype.6.dylib
 fi


### PR DESCRIPTION
This PR continues the work from #16316 (which it also depends on) by shipping the runtime on macOS too.

This pulls in a number of [macOS launcher changes](https://github.com/OpenRA/OpenRALauncherOSX/compare/osx-launcher-20171118..osx-launcher-20190317):
 * Update SDL to 2.0.9 (this was done last year, but was un-shipped as part of the dark mode revert)
 * Compile our own FreeType 2.10.0 library to remove Mono dependency
 * Remove the mono version check and download/update prompt
 * Replace the `launchgame` executable that linked against the system `libmono2.dylib` with the `mono` executable and runtime provided by Microsoft for the mkbundle cross-compiler toolchain. 

This ships mono 5.10 so that we can keep a standard version between the AppImages, macOS, and the compiler used to build releases (which will be updated from 4.6 to 5.10 in a future PR). Ideally, before shipping the first playtest with these changes, we can review our baseline OS requirements and bump the mono version to something newer in all three places at once.

Fixes #12170
Closes #14879

Test build: [OpenRA-pkgtest-20190317.dmg](https://github.com/pchote/OpenRA/releases/download/pkgtest-20190317/OpenRA-pkgtest-20190317.dmg)