### PR TITLE
Require .NET Framework >= 4.7.2 on Windows.

### DIFF
--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -176,15 +176,12 @@ SectionEnd
 ;***************************
 Section "-DotNet" DotNet
 	ClearErrors
-	ReadRegDWORD $0 HKLM "SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Client" "Install"
+	; https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed
+	ReadRegDWORD $0 HKLM "SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full" "Release"
 	IfErrors error 0
-	IntCmp $0 1 0 error 0
-	ClearErrors
-	ReadRegDWORD $0 HKLM "SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full" "Install"
-	IfErrors error 0
-	IntCmp $0 1 done error done
+	IntCmp $0 461808 done error done
 	error:
-		MessageBox MB_OK ".NET Framework v4.5 or later is required to run OpenRA."
+		MessageBox MB_OK ".NET Framework v4.7.2 or later is required to run OpenRA."
 		Abort
 	done:
 SectionEnd


### PR DESCRIPTION
This PR raises our baseline .NET requirement on Windows from 4.5 to 4.7.2, working towards #15954.

.NET 4.7.2 is the minimum that Microsoft recomments for .NET standard 2.0 [[ref](https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support)], and does not drop support for any of our supported Windows versions [[ref](https://docs.microsoft.com/en-us/dotnet/framework/get-started/system-requirements#supported-client-operating-systems)].

I have a few more commits locally that improve the Windows packaging by updating NSIS to 3.0.3 to fix&nbsp;#11865 and add HiDPI support to the installer.  This change requires a switch to the Ubuntu 16.04 Travis VMs, which breaks the Mono 4.6.2 runtime we currently depend on.  This therefore needs to wait until we merge this PR, #16319, #16316, and then bump our Travis runtime to 5.10.0.