### PR TITLE
Fix auto-generated wiki docs

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/ExtractSettingsDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractSettingsDocsCommand.cs
@@ -23,14 +23,19 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			return true;
 		}
 
-		[Desc("Generate settings documentation in markdown format.")]
+		[Desc("[VERSION]", "Generate settings documentation in markdown format.")]
 		void IUtilityCommand.Run(Utility utility, string[] args)
 		{
 			Game.ModData = utility.ModData;
+
+			var version = utility.ModData.Manifest.Metadata.Version;
+			if (args.Length > 1)
+				version = args[1];
+
 			Console.WriteLine(
 				"This documentation displays annotated settings with default values and description. " +
 				"Please do not edit it directly, but add new `[Desc(\"String\")]` tags to the source code. This file has been " +
-				"automatically generated for version {0} of OpenRA.", utility.ModData.Manifest.Metadata.Version);
+				"automatically generated for version {0} of OpenRA.", version);
 			Console.WriteLine();
 			Console.WriteLine("All settings can be changed by starting the game via a command-line parameter like `Game.Mod=ra`.");
 			Console.WriteLine();

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
@@ -25,16 +25,20 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			return true;
 		}
 
-		[Desc("Generate trait documentation in MarkDown format.")]
+		[Desc("[VERSION]", "Generate trait documentation in MarkDown format.")]
 		void IUtilityCommand.Run(Utility utility, string[] args)
 		{
 			// HACK: The engine code assumes that Game.modData is set.
 			Game.ModData = utility.ModData;
 
+			var version = utility.ModData.Manifest.Metadata.Version;
+			if (args.Length > 1)
+				version = args[1];
+
 			Console.WriteLine(
 				"This documentation is aimed at modders. It displays all traits with default values and developer commentary. " +
 				"Please do not edit it directly, but add new `[Desc(\"String\")]` tags to the source code. This file has been " +
-				"automatically generated for version {0} of OpenRA.", utility.ModData.Manifest.Metadata.Version);
+				"automatically generated for version {0} of OpenRA.", version);
 			Console.WriteLine();
 
 			var toc = new StringBuilder();

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractWeaponDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractWeaponDocsCommand.cs
@@ -26,17 +26,21 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			return true;
 		}
 
-		[Desc("Generate weaponry documentation in MarkDown format.")]
+		[Desc("[VERSION]", "Generate weaponry documentation in MarkDown format.")]
 		void IUtilityCommand.Run(Utility utility, string[] args)
 		{
 			// HACK: The engine code assumes that Game.modData is set.
 			Game.ModData = utility.ModData;
 
+			var version = utility.ModData.Manifest.Metadata.Version;
+			if (args.Length > 1)
+				version = args[1];
+
 			Console.WriteLine(
 				"This documentation is aimed at modders. It displays a template for weapon definitions " +
 				"as well as its contained types (warheads and projectiles) with default values and developer commentary. " +
 				"Please do not edit it directly, but add new `[Desc(\"String\")]` tags to the source code. This file has been " +
-				"automatically generated for version {0} of OpenRA.", utility.ModData.Manifest.Metadata.Version);
+				"automatically generated for version {0} of OpenRA.", version);
 			Console.WriteLine();
 
 			var toc = new StringBuilder();

--- a/packaging/update-wiki.sh
+++ b/packaging/update-wiki.sh
@@ -37,6 +37,7 @@ git config --local user.email "orabot@users.noreply.github.com"
 git config --local user.name "orabot"
 git add "Traits${TAG}.md"
 git add "Lua API${TAG}.md"
+git add "Weapons${TAG}.md"
 git add "Settings${TAG}.md"
 git commit -m "Update trait and scripting documentation for branch $1" &&
 git push origin master

--- a/packaging/update-wiki.sh
+++ b/packaging/update-wiki.sh
@@ -27,10 +27,10 @@ chmod 0600 "$SSH_KEY"
 rm -rf "$HOME/openra-wiki"
 git clone git@github.com:OpenRA/OpenRA.wiki.git "$HOME/openra-wiki"
 
-mono --debug ../OpenRA.Utility.exe all --docs > "${HOME}/openra-wiki/Traits${TAG}.md"
-mono --debug ../OpenRA.Utility.exe all --weapon-docs > "${HOME}/openra-wiki/Weapons${TAG}.md"
-mono --debug ../OpenRA.Utility.exe all --lua-docs > "${HOME}/openra-wiki/Lua API${TAG}.md"
-mono --debug ../OpenRA.Utility.exe all --settings-docs > "${HOME}/openra-wiki/Settings${TAG}.md"
+mono --debug ../OpenRA.Utility.exe all --docs "$1" > "${HOME}/openra-wiki/Traits${TAG}.md"
+mono --debug ../OpenRA.Utility.exe all --weapon-docs "$1" > "${HOME}/openra-wiki/Weapons${TAG}.md"
+mono --debug ../OpenRA.Utility.exe all --lua-docs "$1" > "${HOME}/openra-wiki/Lua API${TAG}.md"
+mono --debug ../OpenRA.Utility.exe all --settings-docs "$1" > "${HOME}/openra-wiki/Settings${TAG}.md"
 
 pushd "$HOME/openra-wiki" || exit 1
 git config --local user.email "orabot@users.noreply.github.com"


### PR DESCRIPTION
This PR pushes the weapon docs to the wiki (#11913 generated them but forgot to actually commit them), and fixes the pages reporting "version {DEV_VERSION}".