### PR TITLE
Remove duplicate Aircraft from TS jumpjet husk

### DIFF
--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -164,7 +164,6 @@ JUMPJET.Husk:
 	RenderSprites:
 	BodyOrientation:
 		QuantizedFacings: 1
-	Aircraft:
 	HiddenUnderFog:
 		Type: GroundPosition
 	ScriptTriggers:


### PR DESCRIPTION
The real entry is at https://github.com/reaperrr/OpenRA/blob/a77b75891b11cae78af736e801fd2bcbcc3e0525/mods/ts/rules/gdi-infantry.yaml#L175

I think a +1 is enough for this.

Split from #15803.