### PR TITLE
Switch release builds to the Roslyn compiler on mono 5.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 # Travis-CI Build for OpenRA
 # see travis-ci.org for details
 
+dist: xenial
 language: csharp
-mono: 4.6.1
-
-# http://docs.travis-ci.com/user/migrating-from-legacy
-sudo: false
+mono: 5.10.0
 
 cache:
   directories:
@@ -15,8 +13,6 @@ addons:
   apt:
     packages:
     - lua5.1
-    - nsis
-    - nsis-common
     - dpkg
     - markdown
     - zlib1g-dev
@@ -36,6 +32,11 @@ env:
 # call OpenRA to check for YAML errors
 # Run the NUnit tests
 script:
+ - wget http://mirrors.kernel.org/ubuntu/pool/universe/n/nsis/nsis-common_3.03-2_all.deb
+ - wget http://mirrors.kernel.org/ubuntu/pool/universe/n/nsis/nsis_3.03-2_amd64.deb
+ - sudo dpkg -i nsis-common_3.03-2_all.deb
+ - sudo dpkg -i nsis_3.03-2_amd64.deb
+ - makensis -VERSION
  - travis_retry make all-dependencies
  - make all SDK="-sdk:4.5"
  - make check

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
  - sudo dpkg -i nsis_3.03-2_amd64.deb
  - makensis -VERSION
  - travis_retry make all-dependencies
- - make all SDK="-sdk:4.5"
+ - make all
  - make check
  - make check-scripts
  - make test

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,15 +6,16 @@ The following lists per-platform dependencies required to build from source.
 Windows
 =======
 
-* [Windows PowerShell >= 4.0](http://microsoft.com/powershell)
-* [.NET Framework >= 4.5 (Client Profile)](http://www.microsoft.com/en-us/download/details.aspx?id=30653)
-* [SDL 2](http://www.libsdl.org/download-2.0.php) (included)
-* [FreeType](http://gnuwin32.sourceforge.net/packages/freetype.htm) (included)
-* [zlib](http://gnuwin32.sourceforge.net/packages/zlib.htm) (included)
-* [OpenAL](http://kcat.strangesoft.net/openal.html) (included)
-* [liblua 5.1](http://luabinaries.sourceforge.net/download.html) (included)
+Compiling OpenRA requires the following dependencies:
+* [Windows PowerShell >= 4.0](http://microsoft.com/powershell) (included by default in recent Windows 10 versions)
+* [.NET Framework >= 4.7.2](https://dotnet.microsoft.com/download/dotnet-framework/net472) (included by default in recent Windows 10 versions)
 
-You need to fetch the thirdparty dependencies and place them at the appropriate places by typing `make dependencies` in a command terminal.
+Type `make dependencies` in a command terminal to download pre-compiled native libraries for:
+* [SDL 2](http://www.libsdl.org/download-2.0.php)
+* [FreeType](http://gnuwin32.sourceforge.net/packages/freetype.htm)
+* [zlib](http://gnuwin32.sourceforge.net/packages/zlib.htm)
+* [OpenAL](http://kcat.strangesoft.net/openal.html)
+* [liblua 5.1](http://luabinaries.sourceforge.net/download.html)
 
 To compile OpenRA, open the `OpenRA.sln` solution in the main folder, build it from the command-line with MSBuild or use the Makefile analogue command `make all` scripted in PowerShell syntax.
 
@@ -22,6 +23,8 @@ Run the game with `launch-game.cmd`. It can be handed arguments that specify the
 
 Linux
 =====
+
+Mono, version 5.4 or later, is required to compile OpenRA. You can add the [upstream mono repository](https://www.mono-project.com/download/stable/#download-lin) for your distro to obtain the latest version if your system packages are not sufficient.
 
 Use `make dependencies` to map the native libraries to your system and fetch the remaining CLI dependencies to place them at the appropriate places.
 
@@ -41,12 +44,21 @@ sudo pacman -S mono openal libgl freetype2 sdl2 lua51 xdg-utils zenity
 Debian/Ubuntu
 -------------
 
+:warning: The `mono` packages in the Ubuntu < 19.04 and Debian < 10 repositories are too old to support OpenRA. :warning:
+
+See the instructions under the *Linux* section above to upgrade `mono` using the upstream releases if needed.
+
 ```
 sudo apt install mono-devel libfreetype6 libopenal1 liblua5.1-0 libsdl2-2.0-0 xdg-utils zenity wget
 ```
 
 Fedora
 ------
+
+:warning: The `mono` packages in the Fedora repositories are too old to support OpenRA. :warning:
+
+See the instructions under the *Linux* section above to upgrade `mono` using the upstream releases.
+
 
 ```
 sudo dnf install "pkgconfig(mono)" SDL2 freetype "lua = 5.1" openal-soft xdg-utils zenity
@@ -85,7 +97,14 @@ sudo yum install "pkgconfig(mono)" SDL2 freetype "lua = 5.1" openal-soft xdg-uti
 OSX
 =====
 
-Use `make dependencies` to map the native libraries to your system.
+Before compiling OpenRA you must install the following dependencies:
+* [Mono >= 5.4](https://www.mono-project.com/download/stable/#download-mac)
+
+Use `make dependencies` to download pre-compiled native libraries for:
+* [SDL 2](http://www.libsdl.org/download-2.0.php)
+* [FreeType](http://gnuwin32.sourceforge.net/packages/freetype.htm)
+* [OpenAL](http://kcat.strangesoft.net/openal.html)
+* [liblua 5.1](http://luabinaries.sourceforge.net/download.html)
 
 To compile OpenRA, run `make` from the command line.
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ############################# INSTRUCTIONS #############################
 #
 # to compile, run:
-#   make [DEBUG=false]
+#   make [DEBUG=true]
 #
 # to check unit tests (requires NUnit version >= 2.6), run:
 #  make nunit [NUNIT_CONSOLE=<path-to/nunit[2]-console>] [NUNIT_LIBS_PATH=<path-to-libs-dir>] [NUNIT_LIBS=<nunit-libs>]
@@ -56,7 +56,7 @@ WHITELISTED_CORE_ASSEMBLIES = mscorlib.dll System.dll System.Configuration.dll S
 NUNIT_LIBS_PATH :=
 NUNIT_LIBS  := $(NUNIT_LIBS_PATH)nunit.framework.dll
 
-DEBUG = true
+DEBUG = false
 ifeq ($(DEBUG), $(filter $(DEBUG),false no n off 0))
 CSFLAGS   += -debug:pdbonly -optimize+
 else

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@
 
 ############################## TOOLCHAIN ###############################
 #
-CSC         = mcs
-CSFLAGS     = -nologo -warn:4 -codepage:utf8 -langversion:5 -unsafe -warnaserror
+CSC         = csc
+CSFLAGS     = -nologo -warn:4 -langversion:5 -unsafe -warnaserror
 DEFINE      = TRACE
 COMMON_LIBS = System.dll System.Core.dll System.Numerics.dll thirdparty/download/ICSharpCode.SharpZipLib.dll thirdparty/download/FuzzyLogicLibrary.dll thirdparty/download/MaxMind.Db.dll thirdparty/download/Eluant.dll thirdparty/download/rix0rrr.BeaconLib.dll
 

--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,7 @@
 
 ############################## TOOLCHAIN ###############################
 #
-SDK         ?=
-CSC         = mcs $(SDK)
+CSC         = mcs
 CSFLAGS     = -nologo -warn:4 -codepage:utf8 -langversion:5 -unsafe -warnaserror
 DEFINE      = TRACE
 COMMON_LIBS = System.dll System.Core.dll System.Numerics.dll thirdparty/download/ICSharpCode.SharpZipLib.dll thirdparty/download/FuzzyLogicLibrary.dll thirdparty/download/MaxMind.Db.dll thirdparty/download/Eluant.dll thirdparty/download/rix0rrr.BeaconLib.dll

--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -194,18 +194,10 @@
     <Copy
       SourceFiles="$(TargetPath)"
       DestinationFolder="$(SolutionDir)mods/common/"/>
-    <!--
-      csc generates .pdb symbol files (not `.dll.pdb`).
-      mcs generates .dll.mdb symbol files.
-    -->
     <Copy
       SourceFiles="$(TargetDir)$(TargetName).pdb"
       DestinationFolder="$(SolutionDir)mods/common/"
       Condition="Exists('$(TargetDir)$(TargetName).pdb')"/>
-    <Copy
-      SourceFiles="$(TargetPath).mdb"
-      DestinationFolder="$(SolutionDir)mods/common/"
-      Condition="Exists('$(TargetPath).mdb')"/>
     <!-- Uncomment these lines when debugging or adding to this target
     <Message Text="DEBUG OS:                     $(OS)"/>
     <Message Text="DEBUG SolutionDir:            $(SolutionDir)"/>

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -976,18 +976,10 @@
     <Copy
       SourceFiles="$(TargetPath)"
       DestinationFolder="$(SolutionDir)mods/common/"/>
-    <!--
-      csc generates .pdb symbol files (not `.dll.pdb`).
-      mcs generates .dll.mdb symbol files.
-    -->
     <Copy
       SourceFiles="$(TargetDir)$(TargetName).pdb"
       DestinationFolder="$(SolutionDir)mods/common/"
       Condition="Exists('$(TargetDir)$(TargetName).pdb')"/>
-    <Copy
-      SourceFiles="$(TargetPath).mdb"
-      DestinationFolder="$(SolutionDir)mods/common/"
-      Condition="Exists('$(TargetPath).mdb')"/>
     <!-- Uncomment these lines when debugging or adding to this target
     <Message Text="DEBUG OS:                     $(OS)"/>
     <Message Text="DEBUG SolutionDir:            $(SolutionDir)"/>

--- a/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj
+++ b/OpenRA.Mods.D2k/OpenRA.Mods.D2k.csproj
@@ -118,18 +118,10 @@
     <Copy
       SourceFiles="$(TargetPath)"
       DestinationFolder="$(SolutionDir)mods/d2k/"/>
-    <!--
-      csc generates .pdb symbol files (not `.dll.pdb`).
-      mcs generates .dll.mdb symbol files.
-    -->
     <Copy
       SourceFiles="$(TargetDir)$(TargetName).pdb"
       DestinationFolder="$(SolutionDir)mods/d2k/"
       Condition="Exists('$(TargetDir)$(TargetName).pdb')"/>
-    <Copy
-      SourceFiles="$(TargetPath).mdb"
-      DestinationFolder="$(SolutionDir)mods/d2k/"
-      Condition="Exists('$(TargetPath).mdb')"/>
     <!-- Uncomment these lines when debugging or adding to this target
     <Message Text="DEBUG OS:                     $(OS)"/>
     <Message Text="DEBUG SolutionDir:            $(SolutionDir)"/>

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -52,7 +52,7 @@ make clean
 make cli-dependencies geoip-dependencies
 sed "s/@LIBLUA51@/liblua5.1.so.0/" thirdparty/Eluant.dll.config.in > Eluant.dll.config
 
-make core SDK="-sdk:4.5"
+make core
 make version VERSION="${TAG}"
 make install-engine prefix="usr" DESTDIR="${BUILTDIR}/"
 make install-common-mod-files prefix="usr" DESTDIR="${BUILTDIR}/"

--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -73,7 +73,7 @@ echo "Building core files"
 pushd "${SRCDIR}" > /dev/null || exit 1
 make clean
 make osx-dependencies
-make core SDK="-sdk:4.5"
+make core
 make version VERSION="${TAG}"
 make install-core gameinstalldir="/Contents/Resources/" DESTDIR="${BUILTDIR}/OpenRA.app"
 popd > /dev/null || exit 1

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -22,6 +22,8 @@
 Name "OpenRA"
 OutFile "OpenRA.Setup.exe"
 
+ManifestDPIAware true
+
 InstallDir "$PROGRAMFILES\OpenRA${SUFFIX}"
 InstallDirRegKey HKLM "Software\OpenRA${SUFFIX}" "InstallDir"
 

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -30,7 +30,7 @@ fi
 function makelauncher()
 {
 	sed "s|DISPLAY_NAME|$2|" WindowsLauncher.cs.in | sed "s|MOD_ID|$3|" | sed "s|FAQ_URL|${FAQ_URL}|" > WindowsLauncher.cs
-	mcs -sdk:4.5 WindowsLauncher.cs -warn:4 -codepage:utf8 -warnaserror -out:"$1" -t:winexe ${LAUNCHER_LIBS} -win32icon:"$4"
+	mcs WindowsLauncher.cs -warn:4 -codepage:utf8 -warnaserror -out:"$1" -t:winexe ${LAUNCHER_LIBS} -win32icon:"$4"
 	rm WindowsLauncher.cs
 	mono "${SRCDIR}/fixheader.exe" "$1" > /dev/null
 }
@@ -40,7 +40,7 @@ echo "Building core files"
 pushd "${SRCDIR}" > /dev/null || exit 1
 make clean
 make windows-dependencies
-make core SDK="-sdk:4.5"
+make core
 make version VERSION="${TAG}"
 make install-core gameinstalldir="" DESTDIR="${BUILTDIR}"
 popd > /dev/null || exit 1

--- a/packaging/windows/buildpackage.sh
+++ b/packaging/windows/buildpackage.sh
@@ -30,7 +30,7 @@ fi
 function makelauncher()
 {
 	sed "s|DISPLAY_NAME|$2|" WindowsLauncher.cs.in | sed "s|MOD_ID|$3|" | sed "s|FAQ_URL|${FAQ_URL}|" > WindowsLauncher.cs
-	mcs WindowsLauncher.cs -warn:4 -codepage:utf8 -warnaserror -out:"$1" -t:winexe ${LAUNCHER_LIBS} -win32icon:"$4"
+	csc WindowsLauncher.cs -warn:4 -warnaserror -out:"$1" -t:winexe ${LAUNCHER_LIBS} -win32icon:"$4"
 	rm WindowsLauncher.cs
 	mono "${SRCDIR}/fixheader.exe" "$1" > /dev/null
 }


### PR DESCRIPTION
This PR updates our Travis build platform to newer versions of Ubuntu, Mono, and NSIS, and switches from the old `mcs` to the `csc`, aka Roslyn, complier. This takes us another step towards unifying our toolchain around modern .NET standards and eventually also supporting .NET core.

Depends on #16319.
Another major step towards #15954.
May help with #14182.

I have kept the Makefile targeting C#5, but we can consider (in a future issue/PR!) raising this and adopting some of the newer language features.

The changes in #16316, #16319, #16324 mean that this should not change the runtime requirements for players, but this will impact downstream packaging (ping @diddledan, @Unrud, @fusion809, @svenstaro) and anyone wanting to compile and run from source - particularly on Ubuntu, Debian, or Fedora.

Updating mono and switching to Roslyn should, in principle, produce more efficient builds with better performance. #8153 and #8282 demonstrated that its not that simple, however, and that stumbling into this blindly may cause significant perf *regressions*.

I'm PRing this as a draft to raise awareness and encourage people to start testing. We must properly benchmark this and resolve any potential performance regressions before merging.

Test builds are available from https://github.com/pchote/OpenRA/releases/tag/pkgtest-20190323.
At some point soon I will see how much of this can be backported to `release-20190314` so that we can do before/after benchmarks using RAGL or other game replays.