### PR TITLE
Remove ISync from AttackMove.

### DIFF
--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new AttackMove(init.Self, this); }
 	}
 
-	class AttackMove : INotifyCreated, ITick, IResolveOrder, IOrderVoice, ISync
+	class AttackMove : INotifyCreated, ITick, IResolveOrder, IOrderVoice
 	{
 		public readonly AttackMoveInfo Info;
 		readonly IMove move;


### PR DESCRIPTION
Fixes #16341.

The only member that used Sync was removed in #16105.