### PR TITLE
Implement GrantPrerequisiteChargeDrainPower logic

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/DrainPrerequisitePowerOnDamage.cs
+++ b/OpenRA.Mods.Cnc/Traits/DrainPrerequisitePowerOnDamage.cs
@@ -1,0 +1,68 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Cnc.Traits
+{
+	[Desc("Converts damage to a charge level of a GrantPrerequisiteChargeDrainPower.")]
+	public class DrainPrerequisitePowerOnDamageInfo : ConditionalTraitInfo
+	{
+		[Desc("The OrderName of the GrantPrerequisiteChargeDrainPower to drain.")]
+		public readonly string OrderName = "GrantPrerequisiteChargeDrainPowerInfoOrder";
+
+		[Desc("Damage is multiplied by this number when converting damage to drain ticks.")]
+		public readonly int DamageMultiplier = 1;
+
+		[Desc("Damage is divided by this number when converting damage to drain ticks.")]
+		public readonly int DamageDivisor = 600;
+
+		public override object Create(ActorInitializer init) { return new DrainPrerequisitePowerOnDamage(init.Self, this); }
+	}
+
+	public class DrainPrerequisitePowerOnDamage : ConditionalTrait<DrainPrerequisitePowerOnDamageInfo>, INotifyOwnerChanged, IDamageModifier
+	{
+		SupportPowerManager spm;
+
+		public DrainPrerequisitePowerOnDamage(Actor self, DrainPrerequisitePowerOnDamageInfo info)
+			: base(info) { }
+
+		protected override void Created(Actor self)
+		{
+			base.Created(self);
+			spm = self.Owner.PlayerActor.Trait<SupportPowerManager>();
+		}
+
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		{
+			spm = newOwner.PlayerActor.Trait<SupportPowerManager>();
+		}
+
+		int IDamageModifier.GetDamageModifier(Actor self, Damage damage)
+		{
+			if (!IsTraitDisabled && damage != null)
+			{
+				var damageSubTicks = (int)(damage.Value * 100L * Info.DamageMultiplier / Info.DamageDivisor);
+
+				SupportPowerInstance spi;
+				if (spm.Powers.TryGetValue(Info.OrderName, out spi))
+				{
+					var dspi = spi as GrantPrerequisiteChargeDrainPower.DischargeableSupportPowerInstance;
+					if (dspi != null)
+						dspi.Discharge(damageSubTicks);
+				}
+			}
+
+			return 100;
+		}
+	}
+}

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/GrantPrerequisiteChargeDrainPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/GrantPrerequisiteChargeDrainPower.cs
@@ -1,0 +1,211 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Cnc.Traits
+{
+	[Desc("Grants a prerequisite while discharging at a configurable rate.")]
+	public class GrantPrerequisiteChargeDrainPowerInfo : SupportPowerInfo, ITechTreePrerequisiteInfo
+	{
+		[Desc("Rate at which the power discharges compared to charging")]
+		public readonly int DischargeModifier = 300;
+
+		[FieldLoader.Require]
+		[Desc("The prerequisite type that this provides.")]
+		public readonly string Prerequisite = null;
+
+		[Translate]
+		[Desc("Label to display over the support power icon and in its tooltip while the power is active.")]
+		public readonly string ActiveText = "ACTIVE";
+
+		[Translate]
+		[Desc("Label to display over the support power icon and in its tooltip while the power is available but not active.")]
+		public readonly string AvailableText = "READY";
+
+		IEnumerable<string> ITechTreePrerequisiteInfo.Prerequisites(ActorInfo info)
+		{
+			yield return Prerequisite;
+		}
+
+		public override object Create(ActorInitializer init) { return new GrantPrerequisiteChargeDrainPower(init.Self, this); }
+	}
+
+	public class GrantPrerequisiteChargeDrainPower : SupportPower, ITechTreePrerequisite, INotifyOwnerChanged
+	{
+		readonly GrantPrerequisiteChargeDrainPowerInfo info;
+		TechTree techTree;
+		bool active;
+
+		public GrantPrerequisiteChargeDrainPower(Actor self, GrantPrerequisiteChargeDrainPowerInfo info)
+			: base(self, info)
+		{
+			this.info = info;
+		}
+
+		protected override void Created(Actor self)
+		{
+			// Special case handling is required for the Player actor.
+			// Created is called before Player.PlayerActor is assigned,
+			// so we must query other player traits from self, knowing that
+			// it refers to the same actor as self.Owner.PlayerActor
+			var playerActor = self.Info.Name == "player" ? self : self.Owner.PlayerActor;
+
+			techTree = playerActor.Trait<TechTree>();
+
+			base.Created(self);
+		}
+
+		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
+		{
+			techTree = newOwner.PlayerActor.Trait<TechTree>();
+			active = false;
+		}
+
+		public override SupportPowerInstance CreateInstance(string key, SupportPowerManager manager)
+		{
+			return new DischargeableSupportPowerInstance(key, info, manager);
+		}
+
+		public void Activate(Actor self, SupportPowerInstance instance)
+		{
+			active = true;
+			techTree.ActorChanged(self);
+		}
+
+		public void Deactivate(Actor self, SupportPowerInstance instance)
+		{
+			active = false;
+			techTree.ActorChanged(self);
+		}
+
+		IEnumerable<string> ITechTreePrerequisite.ProvidesPrerequisites
+		{
+			get
+			{
+				if (!active)
+					yield break;
+
+				yield return info.Prerequisite;
+			}
+		}
+
+		public class DischargeableSupportPowerInstance : SupportPowerInstance
+		{
+			// Whether the power is available to activate (even if not fully charged)
+			bool available;
+
+			// Whether the power is active right now
+			// Note that this is fundamentally different to SupportPowerInstance.Active
+			// which has a much closer meaning to available above.
+			bool active;
+
+			// Additional discharge rate accrued from damage
+			int additionalDischargeSubTicks = 0;
+
+			public DischargeableSupportPowerInstance(string key, GrantPrerequisiteChargeDrainPowerInfo info, SupportPowerManager manager)
+				: base(key, info, manager) { }
+
+			void Deactivate()
+			{
+				active = false;
+				notifiedCharging = false;
+
+				// Fully depleting the charge disables the power until it is again fully charged
+				if (!Active || remainingSubTicks >= TotalTicks * 100)
+					available = false;
+
+				foreach (var p in Instances)
+					((GrantPrerequisiteChargeDrainPower)p).Deactivate(p.Self, this);
+			}
+
+			public override void Tick()
+			{
+				var orig = remainingSubTicks;
+				base.Tick();
+
+				if (Ready)
+					available = true;
+
+				if (active && !Active)
+					Deactivate();
+
+				if (active)
+				{
+					remainingSubTicks = orig + ((GrantPrerequisiteChargeDrainPowerInfo)Info).DischargeModifier + additionalDischargeSubTicks;
+					additionalDischargeSubTicks = 0;
+
+					if (remainingSubTicks > TotalTicks * 100)
+					{
+						remainingSubTicks = TotalTicks * 100;
+						Deactivate();
+					}
+				}
+			}
+
+			public void Discharge(int subTicks)
+			{
+				additionalDischargeSubTicks += subTicks;
+			}
+
+			public override void Target()
+			{
+				if (available && Active)
+					Manager.Self.World.IssueOrder(new Order(Key, Manager.Self, false) { ExtraData = active ? 0U : 1U });
+			}
+
+			public override void Activate(Order order)
+			{
+				if (active && order.ExtraData == 0)
+				{
+					Deactivate();
+					return;
+				}
+
+				if (!available || order.ExtraData != 1)
+					return;
+
+				var power = Instances.FirstOrDefault(i => !i.IsTraitPaused);
+				if (power == null)
+					return;
+
+				active = true;
+
+				// Only play the activation sound once!
+				power.PlayLaunchSounds();
+
+				foreach (var p in Instances)
+					((GrantPrerequisiteChargeDrainPower)p).Activate(p.Self, this);
+			}
+
+			public override string IconOverlayTextOverride()
+			{
+				var info = Info as GrantPrerequisiteChargeDrainPowerInfo;
+				if (info == null || !Active)
+					return null;
+
+				return active ? info.ActiveText : available ? info.AvailableText : null;
+			}
+
+			public override string TooltipTimeTextOverride()
+			{
+				var info = Info as GrantPrerequisiteChargeDrainPowerInfo;
+				if (info == null || !Active)
+					return null;
+
+				return active ? info.ActiveText : available ? info.AvailableText : null;
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
@@ -92,7 +92,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!IsProne)
 				return 100;
 
-			if (damage.DamageTypes.IsEmpty)
+			if (damage == null || damage.DamageTypes.IsEmpty)
 				return 100;
 
 			var modifierPercentages = info.DamageModifiers.Where(x => damage.DamageTypes.Contains(x.Key)).Select(x => x.Value);

--- a/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		int IDamageModifier.GetDamageModifier(Actor attacker, Damage damage)
 		{
-			if (attacker.Owner.IsAlliedWith(self.Owner) && damage.Value < 0 && !Info.ModifyHealing)
+			if (!Info.ModifyHealing && attacker.Owner.IsAlliedWith(self.Owner) && damage != null && damage.Value < 0)
 				return FullDamage;
 
 			var world = self.World;

--- a/OpenRA.Mods.Common/Traits/Render/SupportPowerChargeBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SupportPowerChargeBar.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (viewer != null && !Info.DisplayStances.HasStance(self.Owner.Stances[viewer]))
 				return 0;
 
-			return 1 - (float)power.RemainingTime / power.TotalTime;
+			return 1 - (float)power.RemainingTicks / power.TotalTicks;
 		}
 
 		Color ISelectionBar.GetColor() { return Info.Color; }

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
@@ -125,6 +125,11 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 		}
 
+		public virtual SupportPowerInstance CreateInstance(string key, SupportPowerManager manager)
+		{
+			return new SupportPowerInstance(key, info, manager);
+		}
+
 		public virtual void Charging(Actor self, string key)
 		{
 			Game.Sound.PlayToPlayer(SoundType.UI, self.Owner, Info.BeginChargeSound);

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -159,7 +159,7 @@ namespace OpenRA.Mods.Common.Traits
 		bool instancesEnabled;
 		bool prereqsAvailable = true;
 		bool oneShotFired;
-		bool notifiedCharging;
+		protected bool notifiedCharging;
 		bool notifiedReady;
 
 		public SupportPowerInstance(string key, SupportPowerInfo info, SupportPowerManager manager)

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -105,13 +105,6 @@ namespace OpenRA.Mods.Common.Traits
 				Powers[order.OrderString].Activate(order);
 		}
 
-		// Deprecated. Remove after SupportPowerBinWidget is removed.
-		public void Target(string key)
-		{
-			if (Powers.ContainsKey(key))
-				Powers[key].Target();
-		}
-
 		static readonly SupportPowerInstance[] NoInstances = { };
 
 		public IEnumerable<SupportPowerInstance> GetPowersForActor(Actor a)
@@ -259,6 +252,16 @@ namespace OpenRA.Mods.Common.Traits
 				PrerequisitesAvailable(false);
 				oneShotFired = true;
 			}
+		}
+
+		public virtual string IconOverlayTextOverride()
+		{
+			return null;
+		}
+
+		public virtual string TooltipTimeTextOverride()
+		{
+			return null;
 		}
 	}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
@@ -59,11 +59,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				descLabel.Text = sp.Info.LongDesc.Replace("\\n", "\n");
 				var descSize = descFont.Measure(descLabel.Text);
 
-				var remaining = WidgetUtils.FormatTime(sp.RemainingTicks, world.Timestep);
-				var total = WidgetUtils.FormatTime(sp.Info.ChargeInterval, world.Timestep);
-				timeLabel.Text = "{0} / {1}".F(remaining, total);
-				var timeSize = timeFont.Measure(timeLabel.Text);
+				var customLabel = sp.TooltipTimeTextOverride();
+				if (customLabel == null)
+				{
+					var remaining = WidgetUtils.FormatTime(sp.RemainingTicks, world.Timestep);
+					var total = WidgetUtils.FormatTime(sp.Info.ChargeInterval, world.Timestep);
+					timeLabel.Text = "{0} / {1}".F(remaining, total);
+				}
+				else
+					timeLabel.Text = customLabel;
 
+				var timeSize = timeFont.Measure(timeLabel.Text);
 				var hotkeyWidth = 0;
 				hotkeyLabel.Visible = hotkey.IsValid();
 				if (hotkeyLabel.Visible)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/SupportPowerTooltipLogic.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				// HACK: This abuses knowledge of the internals of WidgetUtils.FormatTime
 				// to efficiently work when the label is going to change, requiring a panel relayout
-				var remainingSeconds = (int)Math.Ceiling(sp.RemainingTime * world.Timestep / 1000f);
+				var remainingSeconds = (int)Math.Ceiling(sp.RemainingTicks * world.Timestep / 1000f);
 
 				var hotkey = icon.Hotkey != null ? icon.Hotkey.GetValue() : Hotkey.Invalid;
 				if (sp == lastPower && hotkey == lastHotkey && lastRemainingSeconds == remainingSeconds)
@@ -59,7 +59,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				descLabel.Text = sp.Info.LongDesc.Replace("\\n", "\n");
 				var descSize = descFont.Measure(descLabel.Text);
 
-				var remaining = WidgetUtils.FormatTime(sp.RemainingTime, world.Timestep);
+				var remaining = WidgetUtils.FormatTime(sp.RemainingTicks, world.Timestep);
 				var total = WidgetUtils.FormatTime(sp.Info.ChargeInterval, world.Timestep);
 				timeLabel.Text = "{0} / {1}".F(remaining, total);
 				var timeSize = timeFont.Measure(timeLabel.Text);

--- a/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
@@ -132,8 +132,8 @@ namespace OpenRA.Mods.Common.Widgets
 
 				var clock = clocks[power.a.Key];
 				clock.PlayFetchIndex(ClockSequence,
-					() => item.TotalTime == 0 ? 0 : ((item.TotalTime - item.RemainingTime)
-						* (clock.CurrentSequence.Length - 1) / item.TotalTime));
+					() => item.TotalTicks == 0 ? 0 : ((item.TotalTicks - item.RemainingTicks)
+						* (clock.CurrentSequence.Length - 1) / item.TotalTicks));
 				clock.Tick();
 				WidgetUtils.DrawSHPCentered(clock.Image, location + 0.5f * iconSize, worldRenderer.Palette(ClockPalette), 0.5f);
 
@@ -149,7 +149,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			if (item.Disabled) return "ON HOLD";
 			if (item.Ready) return "READY";
-			return WidgetUtils.FormatTime(item.RemainingTime, timestep);
+			return WidgetUtils.FormatTime(item.RemainingTicks, timestep);
 		}
 
 		public override Widget Clone()

--- a/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowerTimerWidget.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			texts = displayedPowers.Select(p =>
 			{
-				var time = WidgetUtils.FormatTime(p.RemainingTime, false, timestep);
+				var time = WidgetUtils.FormatTime(p.RemainingTicks, false, timestep);
 				var text = Format.F(p.Info.Description, time);
 				var self = p.Instances[0].Self;
 				var playerColor = self.Owner.Color;

--- a/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
@@ -215,7 +215,15 @@ namespace OpenRA.Mods.Common.Widgets
 			// Overlay
 			foreach (var p in icons.Values)
 			{
-				if (p.Power.Ready)
+				var customText = p.Power.IconOverlayTextOverride();
+				if (customText != null)
+				{
+					var customOffset = iconOffset - overlayFont.Measure(customText) / 2;
+					overlayFont.DrawTextWithContrast(customText,
+						p.Pos + customOffset,
+						Color.White, Color.Black, 1);
+				}
+				else if (p.Power.Ready)
 					overlayFont.DrawTextWithContrast(ReadyText,
 						p.Pos + readyOffset,
 						Color.White, Color.Black, 1);

--- a/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
@@ -205,8 +205,8 @@ namespace OpenRA.Mods.Common.Widgets
 				// Charge progress
 				var sp = p.Power;
 				clock.PlayFetchIndex(ClockSequence,
-					() => sp.TotalTime == 0 ? clock.CurrentSequence.Length - 1 : (sp.TotalTime - sp.RemainingTime)
-					* (clock.CurrentSequence.Length - 1) / sp.TotalTime);
+					() => sp.TotalTicks == 0 ? clock.CurrentSequence.Length - 1 : (sp.TotalTicks - sp.RemainingTicks)
+					* (clock.CurrentSequence.Length - 1) / sp.TotalTicks);
 
 				clock.Tick();
 				WidgetUtils.DrawSHPCentered(clock.Image, p.Pos + iconOffset, p.IconClockPalette);
@@ -224,7 +224,7 @@ namespace OpenRA.Mods.Common.Widgets
 						p.Pos + holdOffset,
 						Color.White, Color.Black, 1);
 				else
-					overlayFont.DrawTextWithContrast(WidgetUtils.FormatTime(p.Power.RemainingTime, worldRenderer.World.Timestep),
+					overlayFont.DrawTextWithContrast(WidgetUtils.FormatTime(p.Power.RemainingTicks, worldRenderer.World.Timestep),
 						p.Pos + timeOffset,
 						Color.White, Color.Black, 1);
 			}


### PR DESCRIPTION
This PR generalizes the the support power logic to give implementations more flexibility in overriding their charging and targeting behaviour, and adds two new traits:

* `GrantPrerequisiteChargeDrainPower`: Grants a prerequisite when activated, and then counts backwards at a rate controlled by `DischargeModifier` until the timer reaches 0. The player can deactivate the power before it runs out by selecting it again, and the timer will recharge from the intermediate point.  If the power was disabled manually (i.e. did not completely run out) then the player can reactivate it at any time.

* `DrainPrerequisitePowerOnDamage`: If enabled, any damage recieved by this actor will be converted to a time using `DamageMultiplier` and `DamageDivisor` which will be subtracted from the `GrantPrerequisiteChargeDrainPower` with matching `OrderName`.

These traits implement the special case behaviour for the TS Firestorm Defense support power described by [UseChargeDrain](https://www.modenc.renegadeprojects.com/UseChargeDrain), [ChargeToDrainRatio](https://www.modenc.renegadeprojects.com/ChargeToDrainRatio), [FirestormWall](https://www.modenc.renegadeprojects.com/FirestormWall), and [DamageToFirestormDamageCoefficient](https://www.modenc.renegadeprojects.com/DamageToFirestormDamageCoefficient).

This is the first of three PRs that will resolve #10789.  The second PR will overhaul projectile blocking and effects before a third PR implements the Fire Storm Generator / Firestorm Wall / Firestorm Defense properly in TS.

The testcase demonstrates its use on the RA Iron Curtain. 