### PR TITLE
Replace SequenceActivities with ChildActivity in several activities.

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
@@ -91,6 +91,13 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			public override Activity Tick(Actor self)
 			{
+				if (ChildActivity != null)
+				{
+					ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
+					if (ChildActivity != null)
+						return this;
+				}
+
 				if (IsCanceling || !attack.CanAttack(self, target))
 					return NextActivity;
 
@@ -103,7 +110,9 @@ namespace OpenRA.Mods.Cnc.Traits
 				if (!string.IsNullOrEmpty(attack.info.ChargeAudio))
 					Game.Sound.Play(SoundType.World, attack.info.ChargeAudio, self.CenterPosition);
 
-				return ActivityUtils.SequenceActivities(self, new Wait(attack.info.InitialChargeDelay), new ChargeFire(attack, target), this);
+				QueueChild(self, new Wait(attack.info.InitialChargeDelay), true);
+				QueueChild(self, new ChargeFire(attack, target));
+				return this;
 			}
 		}
 
@@ -120,6 +129,13 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			public override Activity Tick(Actor self)
 			{
+				if (ChildActivity != null)
+				{
+					ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
+					if (ChildActivity != null)
+						return this;
+				}
+
 				if (IsCanceling || !attack.CanAttack(self, target))
 					return NextActivity;
 
@@ -128,7 +144,8 @@ namespace OpenRA.Mods.Cnc.Traits
 
 				attack.DoAttack(self, target);
 
-				return ActivityUtils.SequenceActivities(self, new Wait(attack.info.ChargeDelay), this);
+				QueueChild(self, new Wait(attack.info.ChargeDelay), true);
+				return this;
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Activities/Hunt.cs
+++ b/OpenRA.Mods.Common/Activities/Hunt.cs
@@ -33,6 +33,13 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
+			if (ChildActivity != null)
+			{
+				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
+				if (ChildActivity != null)
+					return this;
+			}
+
 			if (IsCanceling)
 				return NextActivity;
 
@@ -40,10 +47,9 @@ namespace OpenRA.Mods.Common.Activities
 			if (target == null)
 				return this;
 
-			return ActivityUtils.SequenceActivities(self,
-				new AttackMoveActivity(self, () => move.MoveTo(target.Location, 2)),
-				new Wait(25),
-				this);
+			QueueChild(self, new AttackMoveActivity(self, () => move.MoveTo(target.Location, 2)), true);
+			QueueChild(self, new Wait(25));
+			return this;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Move/Follow.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Follow.cs
@@ -47,6 +47,13 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
+			if (ChildActivity != null)
+			{
+				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
+				if (ChildActivity != null)
+					return this;
+			}
+
 			if (IsCanceling)
 				return NextActivity;
 
@@ -83,9 +90,8 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Move into range
 			wasMovingWithinRange = true;
-			return ActivityUtils.SequenceActivities(self,
-				move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, targetLineColor),
-				this);
+			QueueChild(self, move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, targetLineColor), true);
+			return this;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -55,6 +55,13 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
+			if (ChildActivity != null)
+			{
+				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
+				if (ChildActivity != null)
+					return this;
+			}
+
 			cargo.Unloading = false;
 			if (IsCanceling || cargo.IsEmpty(self))
 				return NextActivity;
@@ -75,8 +82,8 @@ namespace OpenRA.Mods.Common.Activities
 			if (exitSubCell == null)
 			{
 				self.NotifyBlocker(BlockedExitCells(actor));
-
-				return ActivityUtils.SequenceActivities(self, new Wait(10), this);
+				QueueChild(self, new Wait(10), true);
+				return this;
 			}
 
 			cargo.Unload(self);

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -176,6 +176,13 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override Activity Tick(Actor self)
 			{
+				if (ChildActivity != null)
+				{
+					ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
+					if (ChildActivity != null)
+						return this;
+				}
+
 				if (IsCanceling)
 				{
 					// Cancel the requested target, but keep firing on it while in range
@@ -275,9 +282,8 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				wasMovingWithinRange = true;
-				return ActivityUtils.SequenceActivities(self,
-					move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, Color.Red),
-					this);
+				QueueChild(self, move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, Color.Red), true);
+				return this;
 			}
 		}
 	}


### PR DESCRIPTION
This replaces all remaining self-referential uses of `SequenceActivities` with childactivities for all activities except for the aircraft activities.