### PR TITLE
Remove pretick argument from Activity.Queue()

### DIFF
--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -215,12 +215,12 @@ namespace OpenRA.Activities
 			State = ActivityState.Canceling;
 		}
 
-		public virtual void Queue(Actor self, Activity activity, bool pretick = false)
+		public virtual void Queue(Actor self, Activity activity)
 		{
 			if (NextInQueue != null)
 				NextInQueue.Queue(self, activity);
 			else
-				NextInQueue = pretick ? ActivityUtils.RunActivity(self, activity) : activity;
+				NextInQueue = activity;
 		}
 
 		public virtual void QueueChild(Actor self, Activity activity, bool pretick = false)

--- a/OpenRA.Mods.Common/Activities/Parachute.cs
+++ b/OpenRA.Mods.Common/Activities/Parachute.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Activities
 		}
 
 		// Only the last queued activity (given order) is kept
-		public override void Queue(Actor self, Activity activity, bool pretick = false)
+		public override void Queue(Actor self, Activity activity)
 		{
 			NextActivity = activity;
 		}


### PR DESCRIPTION
Pre-ticking makes sense for child activities, since they basically run concurrently to their parents. Next activities, however, should not run in parallel but strictly in sequence.

If pretick was set, you could end up with the following sequence of events, which would run counter to general expectations:

A.Tick()
A.Tick()
A.Queue(self, new B(), true)
B.OnFirstRun()
B.Tick()
A.Tick()
A.Tick()
A.OnLastRun()
B.Tick()

Therefore the pretick argument to Activity.Queue() should be removed again.