### PR TITLE
add OpenBSD to Eluant config dllmap

### DIFF
--- a/thirdparty/Eluant.dll.config.in
+++ b/thirdparty/Eluant.dll.config.in
@@ -1,3 +1,4 @@
 <configuration>
   <dllmap os="linux" dll="lua51.dll" target="@LIBLUA51@" />
+  <dllmap os="openbsd" dll="lua51.dll" target="liblua5.1.so" />
 </configuration>


### PR DESCRIPTION
simple addition of dllmap based on platform-specific Lua filenames.