### PR TITLE
Create StackablePlug Property

### DIFF
--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -44,7 +44,7 @@ GAPOWR:
 		Conditions:
 			powrup: powrup.a
 		Requirements:
-			powrup: !build-incomplete
+			powrup: !build-incomplete && !powrup.a
 	Power@pluga:
 		RequiresCondition: !empdisable && powrup.a
 		Amount: 50
@@ -57,7 +57,7 @@ GAPOWR:
 		Conditions:
 			powrup: powrup.b
 		Requirements:
-			powrup: !build-incomplete
+			powrup: !build-incomplete && !powrup.b
 	WithIdleOverlay@plugb:
 		RequiresCondition: !build-incomplete && powrup.b
 		PauseOnCondition: empdisable

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -133,9 +133,9 @@ GACTWR:
 			tower.rocket: tower.rocket
 			tower.sam: tower.sam
 		Requirements:
-			tower.vulcan: !build-incomplete
-			tower.rocket: !build-incomplete
-			tower.sam: !build-incomplete
+			tower.vulcan: !build-incomplete && !tower.vulcan && !tower.rocket && !tower.sam
+			tower.rocket: !build-incomplete && !tower.rocket && !tower.vulcan && !tower.sam
+			tower.sam: !build-incomplete && !tower.vulcan && !tower.rocket && !tower.sam
 	ProvidesPrerequisite@buildingname:
 	SelectionDecorations:
 	Replacement:


### PR DESCRIPTION
This is my attempt at a fix to multiple plugs of the same kind being
allowed to place on a single pluggable, losing money in the process.
StackablePlug is a boolean on a pluggable that allows for multiple
upgrades to be placed on that slot.

StackablePlug defaults to false, as no upgrade I know of is ever placed on
the same slot in the games, but someone may want the functionality.

`make test` and `make check` come back clear for me.

Testing the functionality wherever I can find it seems to fix #16325 without issue.