### PR TITLE
Replace SequenceActivities with ChildActivity in several air activities.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
@@ -47,6 +47,13 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
+			if (ChildActivity != null)
+			{
+				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
+				if (ChildActivity != null)
+					return this;
+			}
+
 			// Refuse to take off if it would land immediately again.
 			if (aircraft.ForceLanding)
 				Cancel(self);
@@ -89,9 +96,8 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			wasMovingWithinRange = true;
-			return ActivityUtils.SequenceActivities(self,
-				aircraft.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, targetLineColor),
-				this);
+			QueueChild(self, aircraft.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, targetLineColor), true);
+			return this;
 		}
 	}
 }


### PR DESCRIPTION
Two more rather trivial activity refactors to get rid of `SequenceActivities(..., this)`. This leaves only `FlyAttack,` but that one is a bit more involved (It should probably be remodeled after `AttackFollows)`, so let's get this out of the way first.