### PR TITLE
Fix chinook being unable to land.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -575,7 +575,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 			else if (!Info.CanHover && !atLandAltitude)
 				self.QueueActivity(new FlyCircle(self, -1, Info.IdleTurnSpeed > -1 ? Info.IdleTurnSpeed : TurnSpeed));
-			else if (atLandAltitude && (Info.TakeOffOnResupply || ReservedActor == null))
+			else if (atLandAltitude && !CanLand(self.Location) && ReservedActor == null)
 				self.QueueActivity(new TakeOff(self));
 			else if (Info.CanHover && self.Info.HasTraitInfo<AutoCarryallInfo>() && Info.IdleTurnSpeed > -1)
 			{


### PR DESCRIPTION
Fixes #16368.

This regression was introduced by #16321. `Aircraft.OnBecomingIdle` didn't check whether an aircraft was allowed to land and just assumed it wasn't. I also removed a redundancy here. `ResupplyAircraft` already handles `TakeOffOnResupply`.