### PR TITLE
Replace pseudo-childactivities in carryall logic.

### DIFF
--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -33,7 +33,6 @@ namespace OpenRA.Mods.Common.Activities
 		enum PickupState { Intercept, LockCarryable, MoveToCarryable, Turn, Land, Wait, Pickup, Aborted }
 
 		PickupState state;
-		Activity innerActivity;
 
 		public PickupUnit(Actor self, Actor cargo, int delay)
 		{
@@ -52,10 +51,11 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (innerActivity != null)
+			if (ChildActivity != null)
 			{
-				innerActivity = ActivityUtils.RunActivity(self, innerActivity);
-				return this;
+				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
+				if (ChildActivity != null)
+					return this;
 			}
 
 			if (cargo != carryall.Carryable)
@@ -73,8 +73,7 @@ namespace OpenRA.Mods.Common.Activities
 			switch (state)
 			{
 				case PickupState.Intercept:
-					innerActivity = movement.MoveWithinRange(Target.FromActor(cargo), WDist.FromCells(4),
-						targetLineColor: Color.Yellow);
+					QueueChild(self, movement.MoveWithinRange(Target.FromActor(cargo), WDist.FromCells(4), targetLineColor: Color.Yellow), true);
 					state = PickupState.LockCarryable;
 					return this;
 
@@ -91,8 +90,7 @@ namespace OpenRA.Mods.Common.Activities
 					var targetPosition = cargo.CenterPosition - carryableBody.LocalToWorld(localOffset);
 					if ((self.CenterPosition - targetPosition).HorizontalLengthSquared != 0)
 					{
-						// Run the first tick of the move activity immediately to avoid a one-frame pause
-						innerActivity = ActivityUtils.RunActivity(self, new HeliFly(self, Target.FromPos(targetPosition)));
+						QueueChild(self, new HeliFly(self, Target.FromPos(targetPosition)), true);
 						return this;
 					}
 
@@ -103,7 +101,7 @@ namespace OpenRA.Mods.Common.Activities
 				case PickupState.Turn:
 					if (carryallFacing.Facing != carryableFacing.Facing)
 					{
-						innerActivity = new Turn(self, carryableFacing.Facing);
+						QueueChild(self, new Turn(self, carryableFacing.Facing), true);
 						return this;
 					}
 
@@ -122,7 +120,7 @@ namespace OpenRA.Mods.Common.Activities
 
 					if (targetPosition.Z != self.CenterPosition.Z)
 					{
-						innerActivity = new HeliLand(self, false, self.World.Map.DistanceAboveTerrain(targetPosition));
+						QueueChild(self, new HeliLand(self, false, self.World.Map.DistanceAboveTerrain(targetPosition)), true);
 						return this;
 					}
 
@@ -132,7 +130,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				case PickupState.Wait:
 					state = PickupState.Pickup;
-					innerActivity = new Wait(delay, false);
+					QueueChild(self, new Wait(delay, false), true);
 					return this;
 
 				case PickupState.Pickup:
@@ -157,14 +155,6 @@ namespace OpenRA.Mods.Common.Activities
 				carryable.Attached(cargo);
 				carryall.AttachCarryable(self, cargo);
 			});
-		}
-
-		public override void Cancel(Actor self, bool keepQueue = false)
-		{
-			if (!IsCanceling && innerActivity != null)
-				innerActivity.Cancel(self);
-
-			base.Cancel(self, keepQueue);
 		}
 	}
 }


### PR DESCRIPTION
After getting rid of all the self-referential instances of `QueueActivities`, the next step is to get rid of activities rolling their own pseudo-childactivities instead of using the common `ChildActivity` logic. To begin with, these are the activities that determine the carryall behaviour.

I've made it dependent on #16372 because it was rather difficult to test otherwise.