### PR TITLE
Replace pseudo-childactivities in several activities.

### DIFF
--- a/OpenRA.Mods.Common/Activities/CaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/CaptureActor.cs
@@ -136,9 +136,10 @@ namespace OpenRA.Mods.Common.Activities
 			base.OnActorDispose(self);
 		}
 
-		protected override void OnCancel(Actor self)
+		public override void Cancel(Actor self, bool keepQueue = false)
 		{
 			CancelCapture(self);
+			base.Cancel(self, keepQueue);
 		}
 
 		void CancelCapture(Actor self)

--- a/OpenRA.Mods.Common/Activities/WaitForTransport.cs
+++ b/OpenRA.Mods.Common/Activities/WaitForTransport.cs
@@ -19,34 +19,25 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly ICallForTransport transportable;
 
-		Activity inner;
-
 		public WaitForTransport(Actor self, Activity innerActivity)
 		{
 			transportable = self.TraitOrDefault<ICallForTransport>();
-			inner = innerActivity;
+			QueueChild(self, innerActivity);
 		}
 
 		public override Activity Tick(Actor self)
 		{
-			if (inner == null)
+			if (ChildActivity != null)
 			{
-				if (transportable != null)
-					transportable.MovementCancelled(self);
-
-				return NextActivity;
+				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
+				if (ChildActivity != null)
+					return this;
 			}
 
-			inner = ActivityUtils.RunActivity(self, inner);
-			return this;
-		}
+			if (transportable != null)
+				transportable.MovementCancelled(self);
 
-		public override void Cancel(Actor self, bool keepQueue = false)
-		{
-			if (!IsCanceling && inner != null)
-				inner.Cancel(self);
-
-			base.Cancel(self, keepQueue);
+			return NextActivity;
 		}
 	}
 }


### PR DESCRIPTION
Continuing the work of #16374 this PR replaces pseudo-childactivites by actual usage of `Childactivity` in `Enter` and related activities as well as in the `WaitForTransport` activity. I also made some slight simplifications in the `Enter` activity. The only pseudo-childactivities remaining now are in `AttackMoveActivity`, which would need to be based on #16369 to work properly on aircraft.