### PR TITLE
Replace pseudo-childactivities in AttackMoveActivity.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
+++ b/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
@@ -43,10 +43,10 @@ namespace OpenRA.Mods.Common.Activities
 			if (conditionManager == null || attackMove == null)
 				return;
 
-			if (!isAssaultMove && !string.IsNullOrEmpty(attackMove.Info.AttackMoveScanCondition))
-				token = conditionManager.GrantCondition(self, attackMove.Info.AttackMoveScanCondition);
-			else if (isAssaultMove && !string.IsNullOrEmpty(attackMove.Info.AssaultMoveScanCondition))
-				token = conditionManager.GrantCondition(self, attackMove.Info.AssaultMoveScanCondition);
+			if (!isAssaultMove && !string.IsNullOrEmpty(attackMove.Info.AttackMoveCondition))
+				token = conditionManager.GrantCondition(self, attackMove.Info.AttackMoveCondition);
+			else if (isAssaultMove && !string.IsNullOrEmpty(attackMove.Info.AssaultMoveCondition))
+				token = conditionManager.GrantCondition(self, attackMove.Info.AssaultMoveCondition);
 		}
 
 		public override Activity Tick(Actor self)

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -25,12 +25,12 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference] public readonly string Voice = "Action";
 
 		[GrantedConditionReference]
-		[Desc("The condition to grant to self while scanning for targets during an attack-move.")]
-		public readonly string AttackMoveScanCondition = null;
+		[Desc("The condition to grant to self while an attack-move is active.")]
+		public readonly string AttackMoveCondition = null;
 
 		[GrantedConditionReference]
-		[Desc("The condition to grant to self while scanning for targets during an assault-move.")]
-		public readonly string AssaultMoveScanCondition = null;
+		[Desc("The condition to grant to self while an assault-move is active.")]
+		public readonly string AssaultMoveCondition = null;
 
 		[Desc("Can the actor be ordered to move in to shroud?")]
 		public readonly bool MoveIntoShroud = true;

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -38,44 +38,15 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new AttackMove(init.Self, this); }
 	}
 
-	class AttackMove : INotifyCreated, ITick, IResolveOrder, IOrderVoice
+	class AttackMove : IResolveOrder, IOrderVoice
 	{
 		public readonly AttackMoveInfo Info;
 		readonly IMove move;
-
-		ConditionManager conditionManager;
-		int attackMoveToken = ConditionManager.InvalidConditionToken;
-		int assaultMoveToken = ConditionManager.InvalidConditionToken;
 
 		public AttackMove(Actor self, AttackMoveInfo info)
 		{
 			move = self.Trait<IMove>();
 			Info = info;
-		}
-
-		void INotifyCreated.Created(Actor self)
-		{
-			conditionManager = self.TraitOrDefault<ConditionManager>();
-		}
-
-		void ITick.Tick(Actor self)
-		{
-			if (conditionManager == null)
-				return;
-
-			var activity = self.CurrentActivity as AttackMoveActivity;
-			var attackActive = activity != null && !activity.IsAssaultMove;
-			var assaultActive = activity != null && activity.IsAssaultMove;
-
-			if (attackActive && attackMoveToken == ConditionManager.InvalidConditionToken && !string.IsNullOrEmpty(Info.AttackMoveScanCondition))
-				attackMoveToken = conditionManager.GrantCondition(self, Info.AttackMoveScanCondition);
-			else if (!attackActive && attackMoveToken != ConditionManager.InvalidConditionToken)
-				attackMoveToken = conditionManager.RevokeCondition(self, attackMoveToken);
-
-			if (assaultActive && assaultMoveToken == ConditionManager.InvalidConditionToken && !string.IsNullOrEmpty(Info.AssaultMoveScanCondition))
-				assaultMoveToken = conditionManager.GrantCondition(self, Info.AssaultMoveScanCondition);
-			else if (!assaultActive && assaultMoveToken != ConditionManager.InvalidConditionToken)
-				assaultMoveToken = conditionManager.RevokeCondition(self, assaultMoveToken);
 		}
 
 		string IOrderVoice.VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20190314/RenameAttackMoveConditions.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20190314/RenameAttackMoveConditions.cs
@@ -1,0 +1,43 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RenameAttackMoveConditions : UpdateRule
+	{
+		public override string Name { get { return "Rename AttackMove *ScanConditions"; } }
+		public override string Description
+		{
+			get
+			{
+				return "AttackMove's AttackMoveScanCondition and AssaultMoveScanCondition\n" +
+					"now remain active while attacking, and are have been renamed to\n" +
+					"AttackMoveCondition and AssaultMoveCondition to reflect this.\n";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var at in actorNode.ChildrenMatching("AttackMove"))
+			{
+				foreach (var node in at.ChildrenMatching("AttackMoveScanCondition"))
+					node.RenameKey("AttackMoveCondition");
+
+				foreach (var node in at.ChildrenMatching("AssaultMoveScanCondition"))
+					node.RenameKey("AssaultMoveCondition");
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -125,6 +125,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new ReplaceSpecialMoveConsiderations(),
 				new RefactorHarvesterIdle(),
 				new SplitHarvesterSpriteBody(),
+				new RenameAttackMoveConditions(),
 			})
 		};
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -199,7 +199,7 @@
 	AutoTargetPriority@ATTACKANYTHING:
 		RequiresCondition: stance-attackanything || assault-move
 	AttackMove:
-		AssaultMoveScanCondition: assault-move
+		AssaultMoveCondition: assault-move
 
 ^AutoTargetAir:
 	AutoTarget:
@@ -226,7 +226,7 @@
 	AutoTargetPriority@ATTACKANYTHING:
 		RequiresCondition: stance-attackanything || assault-move
 	AttackMove:
-		AssaultMoveScanCondition: assault-move
+		AssaultMoveCondition: assault-move
 
 ^AcceptsCloakCrate:
 	Cloak:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -140,7 +140,7 @@
 	AutoTargetPriority@ATTACKANYTHING:
 		RequiresCondition: stance-attackanything || assault-move
 	AttackMove:
-		AssaultMoveScanCondition: assault-move
+		AssaultMoveCondition: assault-move
 
 ^AutoTargetAll:
 	AutoTarget:
@@ -161,7 +161,7 @@
 	AutoTargetPriority@ATTACKANYTHING:
 		RequiresCondition: stance-attackanything || assault-move
 	AttackMove:
-		AssaultMoveScanCondition: assault-move
+		AssaultMoveCondition: assault-move
 
 ^Vehicle:
 	Inherits@1: ^ExistsInWorld

--- a/mods/ra/rules/campaign-rules.yaml
+++ b/mods/ra/rules/campaign-rules.yaml
@@ -41,7 +41,7 @@ E7.noautotarget:
 	-AutoTargetPriority@DEFAULT:
 	-AutoTargetPriority@ATTACKANYTHING:
 	AttackMove:
-		-AssaultMoveScanCondition:
+		-AssaultMoveCondition:
 	RenderSprites:
 		Image: E7
 

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -195,7 +195,7 @@
 	AutoTargetPriority@ATTACKANYTHING:
 		RequiresCondition: stance-attackanything || assault-move
 	AttackMove:
-		AssaultMoveScanCondition: assault-move
+		AssaultMoveCondition: assault-move
 
 ^AutoTargetAir:
 	AutoTarget:
@@ -222,7 +222,7 @@
 	AutoTargetPriority@ATTACKANYTHING:
 		RequiresCondition: stance-attackanything || assault-move
 	AttackMove:
-		AssaultMoveScanCondition: assault-move
+		AssaultMoveCondition: assault-move
 
 ^GlobalBounty:
 	GrantConditionOnPrerequisite@GLOBALBOUNTY:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -32,7 +32,7 @@ DOG:
 	Armament:
 		Weapon: DogJaw
 		ReloadingCondition: attack-cooldown
-	-AttackFrontal:	
+	-AttackFrontal:
 	AttackLeap:
 		Voice: Attack
 		PauseOnCondition: attacking || attack-cooldown

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -150,7 +150,7 @@
 	AutoTargetPriority@ATTACKANYTHING:
 		RequiresCondition: stance-attackanything || assault-move
 	AttackMove:
-		AssaultMoveScanCondition: assault-move
+		AssaultMoveCondition: assault-move
 
 ^AutoTargetAir:
 	AutoTarget:
@@ -177,7 +177,7 @@
 	AutoTargetPriority@ATTACKANYTHING:
 		RequiresCondition: stance-attackanything || assault-move
 	AttackMove:
-		AssaultMoveScanCondition: assault-move
+		AssaultMoveCondition: assault-move
 
 ^2x1Shape:
 	HitShape:


### PR DESCRIPTION
This PR refactors `AttackMoveActivity` to get rid of the pseudo-childactivities and replace them with an approach based on `ChildActivity`. Behaviour should be the same as #16105.

Depends on #16369 just to be sure no weird regressions are happening due to `SequenceActivities`.

This is the last activity that still rolled its own pseudo-childactivities.