### PR TITLE
Prevent Windows make clean from removing OpenRA.Platforms.Default.dll.config

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -38,8 +38,8 @@ function Clean-Command
 	{
 		$proc = Start-Process $msBuild $msBuildArguments -NoNewWindow -PassThru -Wait
 		rm *.dll
-		rm *.dll.config
 		rm mods/*/*.dll
+		Get-ChildItem *.dll.config -exclude OpenRA.Platforms.Default.dll.config | Remove-Item
 		rm *.pdb
 		rm mods/*/*.pdb
 		rm *.exe


### PR DESCRIPTION
`OpenRA.Platforms.Default.dll.config` is part of the repo.
Fixes that `OpenRA.Platforms.Default.dll.config` gets removed every time you run `make clean` on Windows.

Linux makefile already excludes the file from removal.