### PR TITLE
WIP TS Drop Pod Reinforcements

### DIFF
--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -73,7 +73,7 @@
     <Compile Include="Traits\Render\WithDeliveryAnimation.cs" />
     <Compile Include="Traits\Render\WithRoof.cs" />
     <Compile Include="Traits\SupportPowers\IonCannonPower.cs" />
-	<Compile Include="Traits\SupportPowers\DropPodsPower.cs" />
+    <Compile Include="Traits\SupportPowers\DropPodsPower.cs" />
     <Compile Include="UtilityCommands\ImportTiberianDawnLegacyMapCommand.cs" />
     <Compile Include="Projectiles\IonCannon.cs" />
     <Compile Include="Activities\VoxelHarvesterDockSequence.cs" />

--- a/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
+++ b/OpenRA.Mods.Cnc/OpenRA.Mods.Cnc.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Traits\Render\WithDeliveryAnimation.cs" />
     <Compile Include="Traits\Render\WithRoof.cs" />
     <Compile Include="Traits\SupportPowers\IonCannonPower.cs" />
+	<Compile Include="Traits\SupportPowers\DropPodsPower.cs" />
     <Compile Include="UtilityCommands\ImportTiberianDawnLegacyMapCommand.cs" />
     <Compile Include="Projectiles\IonCannon.cs" />
     <Compile Include="Activities\VoxelHarvesterDockSequence.cs" />

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/DropPodsPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/DropPodsPower.cs
@@ -1,0 +1,158 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Activities;
+using OpenRA.GameRules;
+using OpenRA.Mods.Cnc.Effects;
+using OpenRA.Mods.Common;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Orders;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Cnc.Traits
+{
+	public class DropPodsPowerInfo : SupportPowerInfo, IRulesetLoaded
+	{
+		[Desc("DropPod Unit")]
+		[ActorReference(typeof(AircraftInfo))]
+		public readonly string UnitType = "badr";
+
+		[Desc("Notification to play when spawning drop pods.")]
+		public readonly string DropPodsAvailableNotification = null;
+
+		[ActorReference(typeof(PassengerInfo))]
+		[Desc("Troops to be delivered.  They will each get their own pod.")]
+		public readonly string[] DropItems = { };
+
+		[Desc("Integer determining the drop pod's facing if it moves.")]
+		public readonly int PodFacing = 32;
+
+		[Desc("Integer determining maximum offset of drop pod drop from targetLocation")]
+		public readonly int PodScatter = 3;
+
+		[Desc("Risks stuck units when they don't have the Paratrooper trait.")]
+		public readonly bool AllowImpassableCells = false;
+
+		[Desc("Effect sequence sprite image")]
+		public readonly string Effect = "explosion";
+
+		[Desc("Effect sequence to display")]
+		[SequenceReference("Effect")] public readonly string EffectSequence = "piffs";
+
+		[PaletteReference] public readonly string EffectPalette = "effect";
+
+		[Desc("Which weapon to fire"), WeaponReference]
+		public readonly string Weapon = "Vulcan2";
+
+		public WeaponInfo WeaponInfo { get; private set; }
+
+		[Desc("Apply the weapon impact this many ticks into the effect")]
+		public readonly int WeaponDelay = 0;
+
+		[Desc("Sound to instantly play at the targeted area.")]
+		public readonly string OnFireSound = null;
+
+		public override object Create(ActorInitializer init) { return new DropPodsPower(init.Self, this); }
+
+		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
+		{
+			WeaponInfo weapon;
+			var weaponToLower = (Weapon ?? string.Empty).ToLowerInvariant();
+			if (!rules.Weapons.TryGetValue(weaponToLower, out weapon))
+				throw new YamlException("Weapons Ruleset does not contain an entry '{0}'".F(weaponToLower));
+
+			WeaponInfo = weapon;
+
+			base.RulesetLoaded(rules, ai);
+		}
+	}
+
+	public class DropPodsPower : SupportPower
+	{
+		readonly DropPodsPowerInfo info;
+		public DropPodsPower(Actor self, DropPodsPowerInfo info) : base(self, info)
+		{
+			this.info = info;
+		}
+
+		public override void Activate(Actor self, Order order, SupportPowerManager manager)
+		{
+			base.Activate(self, order, manager);
+
+			SendDropPods(self, order, info.PodFacing);
+		}
+
+		public Actor[] SendDropPods(Actor self, Order order, int podFacing)
+		{
+			var units = new List<Actor>();
+			var info = Info as DropPodsPowerInfo;
+
+			var utLower = info.UnitType.ToLowerInvariant();
+			ActorInfo unitType;
+			if (!self.World.Map.Rules.Actors.TryGetValue(utLower, out unitType))
+				throw new YamlException("Actors ruleset does not include the entry '{0}'".F(utLower));
+
+			var altitude = unitType.TraitInfo<AircraftInfo>().CruiseAltitude.Length;
+			var approachRotation = WRot.FromFacing(podFacing);
+			var delta = new WVec(0, -altitude, 0).Rotate(approachRotation);
+
+			foreach (var p in info.DropItems)
+			{
+				var unit = self.World.CreateActor(false, p.ToLowerInvariant(),
+					new TypeDictionary { new OwnerInit(self.Owner) });
+
+				units.Add(unit);
+			}
+
+			self.World.AddFrameEndTask(w =>
+			{
+				PlayLaunchSounds();
+
+				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech",
+					info.DropPodsAvailableNotification, self.Owner.Faction.InternalName);
+
+				var target = order.Target.CenterPosition;
+				var targetCell = self.World.Map.CellContaining(target);
+				var PodLocations = self.World.Map.FindTilesInCircle(targetCell, info.PodScatter).Shuffle(self.World.SharedRandom);
+
+				using (var pe = PodLocations.GetEnumerator())
+					foreach (var u in units)
+					{
+						CPos podDropCellPos = pe.Current;
+						w.Add(new IonCannon(self.Owner, info.WeaponInfo, w, self.World.Map.CenterOfCell(podDropCellPos), Target.FromCell(w, podDropCellPos),
+						info.Effect, info.EffectSequence, info.EffectPalette, info.WeaponDelay));
+
+						var a = w.CreateActor(info.UnitType, new TypeDictionary
+						{
+							new CenterPositionInit(self.World.Map.CenterOfCell(podDropCellPos) - delta + new WVec(0, 0, altitude)),
+							new OwnerInit(self.Owner),
+							new FacingInit(podFacing)
+						});
+
+						var cargo = a.Trait<Cargo>();
+						cargo.Load(a, u);
+
+						a.QueueActivity(new Land(a, Target.FromCell(a.World, podDropCellPos)));
+						a.QueueActivity(new UnloadCargo(a, true));
+						a.QueueActivity(new CallFunc(() => a.Kill(a)));
+						pe.MoveNext();
+					}
+			});
+
+			return units.ToArray();
+		}
+	}
+}

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/DropPodsPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/DropPodsPower.cs
@@ -1,6 +1,6 @@
 #region Copyright & License Information
 /*
- * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of
@@ -26,9 +26,10 @@ namespace OpenRA.Mods.Cnc.Traits
 {
 	public class DropPodsPowerInfo : SupportPowerInfo, IRulesetLoaded
 	{
+		[FieldLoader.Require]
 		[Desc("DropPod Unit")]
 		[ActorReference(typeof(AircraftInfo))]
-		public readonly string UnitType = "badr";
+		public readonly string DropPodType = null;
 
 		[Desc("Notification to play when spawning drop pods.")]
 		public readonly string DropPodsAvailableNotification = null;
@@ -100,7 +101,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			var units = new List<Actor>();
 			var info = Info as DropPodsPowerInfo;
 
-			var utLower = info.UnitType.ToLowerInvariant();
+			var utLower = info.DropPodType.ToLowerInvariant();
 			ActorInfo unitType;
 			if (!self.World.Map.Rules.Actors.TryGetValue(utLower, out unitType))
 				throw new YamlException("Actors ruleset does not include the entry '{0}'".F(utLower));
@@ -135,7 +136,7 @@ namespace OpenRA.Mods.Cnc.Traits
 						w.Add(new IonCannon(self.Owner, info.WeaponInfo, w, self.World.Map.CenterOfCell(podDropCellPos), Target.FromCell(w, podDropCellPos),
 						info.Effect, info.EffectSequence, info.EffectPalette, info.WeaponDelay));
 
-						var a = w.CreateActor(info.UnitType, new TypeDictionary
+						var a = w.CreateActor(info.DropPodType, new TypeDictionary
 						{
 							new CenterPositionInit(self.World.Map.CenterOfCell(podDropCellPos) - delta + new WVec(0, 0, altitude)),
 							new OwnerInit(self.Owner),

--- a/OpenRA.Mods.Common/Traits/Sound/ActorLostNotification.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/ActorLostNotification.cs
@@ -33,8 +33,11 @@ namespace OpenRA.Mods.Common.Traits.Sound
 
 		void INotifyKilled.Killed(Actor self, AttackInfo e)
 		{
-			var player = info.NotifyAll ? self.World.LocalPlayer : self.Owner;
-			Game.Sound.PlayNotification(self.World.Map.Rules, player, "Speech", info.Notification, self.Owner.Faction.InternalName);
+			if (info.Notification != null && info.Notification != "")
+			{
+				var player = info.NotifyAll ? self.World.LocalPlayer : self.Owner;
+				Game.Sound.PlayNotification(self.World.Map.Rules, player, "Speech", info.Notification, self.Owner.Faction.InternalName);
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Sound/ActorLostNotification.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/ActorLostNotification.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 
 		void INotifyKilled.Killed(Actor self, AttackInfo e)
 		{
-			if (info.Notification != null && info.Notification != "")
+			if (!string.IsNullOrEmpty(info.Notification))
 			{
 				var player = info.NotifyAll ? self.World.LocalPlayer : self.Owner;
 				Game.Sound.PlayNotification(self.World.Map.Rules, player, "Speech", info.Notification, self.Owner.Faction.InternalName);

--- a/mods/ts/audio/speech-generic.yaml
+++ b/mods/ts/audio/speech-generic.yaml
@@ -26,6 +26,7 @@ Speech:
 		CriticalStructureLost: 00-i196
 		CriticalUnitLost: 00-i194
 		DisablePower: 00-i230
+        DropPodsAvailable: 00-i506
 		EnablePower: 00-i232
 		EmPulseCannonReady: 00-i158
 		EstablishingBattleControlStandBy: 01-n006

--- a/mods/ts/audio/speech-generic.yaml
+++ b/mods/ts/audio/speech-generic.yaml
@@ -26,7 +26,7 @@ Speech:
 		CriticalStructureLost: 00-i196
 		CriticalUnitLost: 00-i194
 		DisablePower: 00-i230
-        DropPodsAvailable: 00-i506
+		DropPodsAvailable: 00-i506
 		EnablePower: 00-i232
 		EmPulseCannonReady: 00-i158
 		EstablishingBattleControlStandBy: 01-n006

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -46,8 +46,8 @@ DPOD2:
 		TurnSpeed: 5
 		Speed: 300
 		CruiseAltitude: 8000
-        MaximumPitch: 110
-        LandableTerrainTypes: Clear,Road,Rail,DirtRoad,Rough,Tiberium,BlueTiberium,Veins
+		MaximumPitch: 110
+		LandableTerrainTypes: Clear,Road,Rail,DirtRoad,Rough,Tiberium,BlueTiberium,Veins
 	HiddenUnderFog:
 		Type: CenterPosition
 	BodyOrientation:
@@ -59,21 +59,21 @@ DPOD2:
 	SelectionDecorations:
 		Palette: pips
 	ActorLostNotification:
-        Notification:
+		Notification:
 	HitShape:
-    Cargo:
+	Cargo:
 		Types: Infantry
 		MaxWeight: 1
 		PipCount: 1
 		UnloadVoice: Move
 		EjectOnDeath: true
-    Interactable:
-    WithShadow:
-    SmokeTrailWhenDamaged:
-        Sprite: largesmoke
-        MinDamage: Undamaged
-    Explodes:
-        Weapon: DropPodExplode
+	Interactable:
+	WithShadow:
+	SmokeTrailWhenDamaged:
+		Sprite: largesmoke
+		MinDamage: Undamaged
+	Explodes:
+		Weapon: DropPodExplode
 
 DSHP:
 	Inherits: ^Helicopter

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -32,6 +32,49 @@ DPOD:
 		PipTypeEmpty: AmmoEmpty
 	-SpawnActorOnDeath:
 
+DPOD2:
+	Inherits@2: ^ExistsInWorld
+	Valued:
+		Cost: 10
+	Tooltip:
+		Name: Drop Pod
+	Health:
+		HP: 6000
+	Armor:
+		Type: Light
+	Aircraft:
+		TurnSpeed: 5
+		Speed: 300
+		CruiseAltitude: 8000
+        MaximumPitch: 110
+        LandableTerrainTypes: Clear,Road,Rail,DirtRoad,Rough,Tiberium,BlueTiberium,Veins
+	HiddenUnderFog:
+		Type: CenterPosition
+	BodyOrientation:
+		UseClassicPerspectiveFudge: False
+	RenderSprites:
+		Image: pod
+	WithFacingSpriteBody:
+	QuantizeFacingsFromSequence:
+	SelectionDecorations:
+		Palette: pips
+	ActorLostNotification:
+        Notification:
+	HitShape:
+    Cargo:
+		Types: Infantry
+		MaxWeight: 1
+		PipCount: 1
+		UnloadVoice: Move
+		EjectOnDeath: true
+    Interactable:
+    WithShadow:
+    SmokeTrailWhenDamaged:
+        Sprite: largesmoke
+        MinDamage: Undamaged
+    Explodes:
+        Weapon: DropPodExplode
+
 DSHP:
 	Inherits: ^Helicopter
 	Valued:

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -433,14 +433,13 @@ GAPLUG:
 		Footprint: xxx xxx
 		Dimensions: 2,3
 	WithIdleOverlay@DISH:
-		RequiresCondition: !build-incomplete
 		PauseOnCondition: disabled || empdisable
 		Sequence: idle-dish
 	WithIdleOverlay@LIGHTS:
-		RequiresCondition: !build-incomplete && !disabled && !empdisable
+		RequiresCondition: !disabled && !empdisable
 		Sequence: idle-lights
 	WithIdleOverlay@STRIP:
-		RequiresCondition: !build-incomplete && !disabled && !empdisable
+		RequiresCondition: !disabled && !empdisable
 		Sequence: idle-strip
 	Health:
 		HP: 100000
@@ -465,6 +464,20 @@ GAPLUG:
 		SelectTargetSpeechNotification: SelectTarget
 		DisplayRadarPing: True
 		CameraActor: camera
+    DropPodsPower:
+		Cursor: ioncannon
+		PauseOnCondition: disabled || empdisable
+		RequiresCondition: plug.droppoda || plug.droppodb
+		Icon: droppods
+		Description: Drop Pods
+		LongDesc: Drop Pod reinforcements.\nSmall team of elite soldiers orbital drops\nto target location.
+		DropPodsAvailableNotification: DropPodsAvailable
+		SelectTargetSpeechNotification: SelectTarget
+		DisplayRadarPing: True
+        ChargeInterval: 100
+        UnitType: DPOD2
+        DropItems: E1,E1,E2,E2
+        PodFacing: 32
 	ProduceActorPower:
 		PauseOnCondition: disabled || empdisable
 		RequiresCondition: plug.hunterseekera || plug.hunterseekerb
@@ -488,37 +501,52 @@ GAPLUG:
 	Power@hunterseeker:
 		RequiresCondition: (plug.hunterseekera || plug.hunterseekerb)
 		Amount: -50
+    Power@droppod:
+		RequiresCondition: (plug.droppoda || plug.droppodb)
+		Amount: -20
 	Pluggable@pluga:
 		Offset: 0,2
 		Conditions:
 			plug.ioncannon: plug.ioncannona
 			plug.hunterseeker: plug.hunterseekera
+            plug.droppod: plug.droppoda
 		Requirements:
-			plug.ioncannon: !build-incomplete && !plug.ioncannonb && !plug.ioncannona && !plug.hunterseekera
-			plug.hunterseeker: !build-incomplete && !plug.hunterseekerb && !plug.ioncannona && !plug.hunterseekera
+			plug.ioncannon: !plug.ioncannonb && !plug.ioncannona && !plug.hunterseekera && !plug.droppoda
+			plug.hunterseeker: !plug.hunterseekerb && !plug.ioncannona && !plug.hunterseekera && !plug.droppoda
+            plug.droppod: !plug.droppodb && !plug.ioncannona && !plug.hunterseekera && !plug.droppoda
 	WithIdleOverlay@ioncannona:
-		RequiresCondition: !build-incomplete && plug.ioncannona
+		RequiresCondition: plug.ioncannona
 		PauseOnCondition: disabled
 		Sequence: idle-ioncannona
 	WithIdleOverlay@hunterseekera:
-		RequiresCondition: !build-incomplete && plug.hunterseekera
+		RequiresCondition: plug.hunterseekera
 		PauseOnCondition: disabled
 		Sequence: idle-hunterseekera
+    WithIdleOverlay@droppoda:
+		RequiresCondition: plug.droppoda
+		PauseOnCondition: disabled
+		Sequence: idle-droppoda
 	Pluggable@plugb:
 		Offset: 1,2
 		Conditions:
 			plug.ioncannon: plug.ioncannonb
 			plug.hunterseeker: plug.hunterseekerb
+            plug.droppod: plug.droppodb
 		Requirements:
-			plug.ioncannon: !build-incomplete && !plug.ioncannona && !plug.ioncannonb && !plug.hunterseekerb
-			plug.hunterseeker: !build-incomplete && !plug.hunterseekera && !plug.ioncannonb && !plug.hunterseekerb
+			plug.ioncannon: !plug.ioncannona && !plug.ioncannonb && !plug.hunterseekerb && !plug.droppodb
+			plug.hunterseeker: !plug.hunterseekera && !plug.ioncannonb && !plug.hunterseekerb  && !plug.droppodb
+            plug.droppod: !plug.droppoda && !plug.ioncannonb && !plug.hunterseekerb  && !plug.droppodb
 	WithIdleOverlay@ioncannonb:
-		RequiresCondition: !build-incomplete && plug.ioncannonb
+		RequiresCondition: plug.ioncannonb
 		PauseOnCondition: disabled
 		Sequence: idle-ioncannonb
 	WithIdleOverlay@hunterseekerb:
-		RequiresCondition: !build-incomplete && plug.hunterseekerb
+		RequiresCondition: plug.hunterseekerb
 		PauseOnCondition: disabled
 		Sequence: idle-hunterseekerb
+    WithIdleOverlay@droppodb:
+		RequiresCondition: plug.droppodb
+		PauseOnCondition: disabled
+		Sequence: idle-droppodb
 	ProvidesPrerequisite@buildingname:
 	SelectionDecorations:

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -433,13 +433,14 @@ GAPLUG:
 		Footprint: xxx xxx
 		Dimensions: 2,3
 	WithIdleOverlay@DISH:
+		RequiresCondition: !build-incomplete
 		PauseOnCondition: disabled || empdisable
 		Sequence: idle-dish
 	WithIdleOverlay@LIGHTS:
-		RequiresCondition: !disabled && !empdisable
+		RequiresCondition: !build-incomplete && !disabled && !empdisable
 		Sequence: idle-lights
 	WithIdleOverlay@STRIP:
-		RequiresCondition: !disabled && !empdisable
+		RequiresCondition: !build-incomplete && !disabled && !empdisable
 		Sequence: idle-strip
 	Health:
 		HP: 100000
@@ -464,7 +465,7 @@ GAPLUG:
 		SelectTargetSpeechNotification: SelectTarget
 		DisplayRadarPing: True
 		CameraActor: camera
-    DropPodsPower:
+	DropPodsPower:
 		Cursor: ioncannon
 		PauseOnCondition: disabled || empdisable
 		RequiresCondition: plug.droppoda || plug.droppodb
@@ -474,10 +475,10 @@ GAPLUG:
 		DropPodsAvailableNotification: DropPodsAvailable
 		SelectTargetSpeechNotification: SelectTarget
 		DisplayRadarPing: True
-        ChargeInterval: 100
-        UnitType: DPOD2
-        DropItems: E1,E1,E2,E2
-        PodFacing: 32
+		ChargeInterval: 100
+		DropPodType: DPOD2
+		DropItems: E1,E1,E2,E2
+		PodFacing: 32
 	ProduceActorPower:
 		PauseOnCondition: disabled || empdisable
 		RequiresCondition: plug.hunterseekera || plug.hunterseekerb
@@ -501,7 +502,7 @@ GAPLUG:
 	Power@hunterseeker:
 		RequiresCondition: (plug.hunterseekera || plug.hunterseekerb)
 		Amount: -50
-    Power@droppod:
+	Power@droppod:
 		RequiresCondition: (plug.droppoda || plug.droppodb)
 		Amount: -20
 	Pluggable@pluga:
@@ -509,11 +510,11 @@ GAPLUG:
 		Conditions:
 			plug.ioncannon: plug.ioncannona
 			plug.hunterseeker: plug.hunterseekera
-            plug.droppod: plug.droppoda
+			plug.droppod: plug.droppoda
 		Requirements:
 			plug.ioncannon: !plug.ioncannonb && !plug.ioncannona && !plug.hunterseekera && !plug.droppoda
 			plug.hunterseeker: !plug.hunterseekerb && !plug.ioncannona && !plug.hunterseekera && !plug.droppoda
-            plug.droppod: !plug.droppodb && !plug.ioncannona && !plug.hunterseekera && !plug.droppoda
+			plug.droppod: !plug.droppodb && !plug.ioncannona && !plug.hunterseekera && !plug.droppoda
 	WithIdleOverlay@ioncannona:
 		RequiresCondition: plug.ioncannona
 		PauseOnCondition: disabled
@@ -522,7 +523,7 @@ GAPLUG:
 		RequiresCondition: plug.hunterseekera
 		PauseOnCondition: disabled
 		Sequence: idle-hunterseekera
-    WithIdleOverlay@droppoda:
+	WithIdleOverlay@droppoda:
 		RequiresCondition: plug.droppoda
 		PauseOnCondition: disabled
 		Sequence: idle-droppoda
@@ -531,11 +532,11 @@ GAPLUG:
 		Conditions:
 			plug.ioncannon: plug.ioncannonb
 			plug.hunterseeker: plug.hunterseekerb
-            plug.droppod: plug.droppodb
+			plug.droppod: plug.droppodb
 		Requirements:
 			plug.ioncannon: !plug.ioncannona && !plug.ioncannonb && !plug.hunterseekerb && !plug.droppodb
 			plug.hunterseeker: !plug.hunterseekera && !plug.ioncannonb && !plug.hunterseekerb  && !plug.droppodb
-            plug.droppod: !plug.droppoda && !plug.ioncannonb && !plug.hunterseekerb  && !plug.droppodb
+			plug.droppod: !plug.droppoda && !plug.ioncannonb && !plug.hunterseekerb  && !plug.droppodb
 	WithIdleOverlay@ioncannonb:
 		RequiresCondition: plug.ioncannonb
 		PauseOnCondition: disabled
@@ -544,7 +545,7 @@ GAPLUG:
 		RequiresCondition: plug.hunterseekerb
 		PauseOnCondition: disabled
 		Sequence: idle-hunterseekerb
-    WithIdleOverlay@droppodb:
+	WithIdleOverlay@droppodb:
 		RequiresCondition: plug.droppodb
 		PauseOnCondition: disabled
 		Sequence: idle-droppodb

--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -236,3 +236,19 @@ GAPLUG3:
 		Type: plug.ioncannon
 	Power:
 		Amount: -100
+
+GAPLUG4:
+	Inherits: ^BuildingPlug
+	Valued:
+		Cost: 1000
+	Tooltip:
+		Name: Drop Pod Node
+	Buildable:
+		Queue: Defense
+		BuildPaletteOrder: 180
+		Prerequisites: gaplug, gatech, ~structures.gdi, ~techlevel.superweapons
+		Description: Enables use of the Drop Pod Reinforcements.
+	Plug:
+		Type: plug.droppod
+	Power:
+		Amount: -20

--- a/mods/ts/sequences/aircraft.yaml
+++ b/mods/ts/sequences/aircraft.yaml
@@ -28,3 +28,9 @@ apache:
 
 orcatran:
 	icon: crryicon
+
+pod:
+    Inherits: ^VehicleOverlays
+    idle:
+		Facings: 1
+		Length: 1

--- a/mods/ts/sequences/aircraft.yaml
+++ b/mods/ts/sequences/aircraft.yaml
@@ -30,7 +30,7 @@ orcatran:
 	icon: crryicon
 
 pod:
-    Inherits: ^VehicleOverlays
-    idle:
+	Inherits: ^VehicleOverlays
+	idle:
 		Facings: 1
 		Length: 1

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -211,6 +211,9 @@ explosion:
 	small_grey_explosion: xgrysml2
 	medium_grey_explosion: xgrymed1
 	large_grey_explosion: xgrymed2
+    droppod_explosion: droppody
+        Length: 8
+        Tick: 750
 
 discus:
 	idle:
@@ -439,6 +442,7 @@ icon:
 	ioncannon: ioncicon
 	hunterseeker: detnicon
 	emp: pulsicon
+    droppods: podsicon
 
 clustermissile:
 	up: mltimisl-placeholder # TODO: use voxel

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -211,9 +211,9 @@ explosion:
 	small_grey_explosion: xgrysml2
 	medium_grey_explosion: xgrymed1
 	large_grey_explosion: xgrymed2
-    droppod_explosion: droppody
-        Length: 8
-        Tick: 750
+	droppod_explosion: droppody
+		Length: 8
+		Tick: 750
 
 discus:
 	idle:
@@ -442,7 +442,7 @@ icon:
 	ioncannon: ioncicon
 	hunterseeker: detnicon
 	emp: pulsicon
-    droppods: podsicon
+	droppods: podsicon
 
 clustermissile:
 	up: mltimisl-placeholder # TODO: use voxel

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -1958,7 +1958,7 @@ gaplug:
 		Length: 15
 		Reverses: true
 		Tick: 120
-    idle-droppoda: gaplug_d
+	idle-droppoda: gaplug_d
 		Length: 15
 		Tick: 120
 		Offset: -12, -42, 30

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -1958,6 +1958,13 @@ gaplug:
 		Length: 15
 		Reverses: true
 		Tick: 120
+    idle-droppoda: gaplug_d
+		Length: 15
+		Tick: 120
+		Offset: -12, -42, 30
+	idle-droppodb: gaplug_d
+		Length: 15
+		Tick: 120
 	make: gtplugmk
 		Length: 17
 		ShadowStart: 17
@@ -1978,3 +1985,6 @@ gaplug2:
 
 gaplug3:
 	icon: rad3icon
+
+gaplug4:
+	icon: rad1icon

--- a/mods/ts/weapons/explosions.yaml
+++ b/mods/ts/weapons/explosions.yaml
@@ -66,3 +66,8 @@ Demolish:
 		Explosions: large_twlt
 		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew09.aud
+
+DropPodExplode:
+	Warhead@1Eff: CreateEffect
+		Explosions: droppod_explosion
+		ExplosionPalette: effect-ignore-lighting-alpha75


### PR DESCRIPTION
Make test, and make check come back clear as of right now.

It is a little bit hacky, as the drop pods themselves don't actually fire the weapon, but it sort of does work.  I think with some adjustments to a couple variables for animation offsets, it will be indistinguishable from the original in TS.

I'm opening this PR before it's ready to be merged for two reasons.  The first being that I'm not sure I went about implementing this in a way that's in line with the other support powers, and would like some direction from someone more knowledgeable about the engine.  It's entirely possible I did a workaround to get some logic I didn't know existed elsewhere or couldn't find.

Second, I'm having a logic error around the creation of the units / drop pods that I can't seem to debug.  The first unit in the list is ignored and it is not spawned / dropped.

Any and all help / review is appreciated.  Thanks in advance.