### PR TITLE
Add sprite trail support to NukeLaunch/NukePower and use it for D2k Death Hand

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -54,6 +54,18 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Loop a randomly chosen sequence of TrailImage from this list while this projectile is moving.")]
 		[SequenceReference("TrailImage")] public readonly string[] TrailSequences = { "idle" };
 
+		[Desc("Interval in ticks between each spawned Trail animation.")]
+		public readonly int TrailInterval = 2;
+
+		[Desc("Delay in ticks until trail animation is spawned.")]
+		public readonly int TrailDelay = 1;
+
+		[Desc("Palette used to render the trail sequence.")]
+		[PaletteReference("TrailUsePlayerPalette")] public readonly string TrailPalette = "effect";
+
+		[Desc("Use the Player Palette to render the trail sequence.")]
+		public readonly bool TrailUsePlayerPalette = false;
+
 		[Desc("Is this blocked by actors with BlocksProjectiles trait.")]
 		public readonly bool Blockable = true;
 
@@ -73,20 +85,8 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("If projectile touches an actor with one of these stances during or after the first bounce, trigger explosion.")]
 		public readonly Stance ValidBounceBlockerStances = Stance.Enemy | Stance.Neutral;
 
-		[Desc("Interval in ticks between each spawned Trail animation.")]
-		public readonly int TrailInterval = 2;
-
-		[Desc("Delay in ticks until trail animation is spawned.")]
-		public readonly int TrailDelay = 1;
-
 		[Desc("Altitude above terrain below which to explode. Zero effectively deactivates airburst.")]
 		public readonly WDist AirburstAltitude = WDist.Zero;
-
-		[Desc("Palette used to render the trail sequence.")]
-		[PaletteReference("TrailUsePlayerPalette")] public readonly string TrailPalette = "effect";
-
-		[Desc("Use the Player Palette to render the trail sequence.")]
-		public readonly bool TrailUsePlayerPalette = false;
 
 		public readonly int ContrailLength = 0;
 		public readonly int ContrailZOffset = 2047;

--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -41,6 +41,24 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Custom palette is a player palette BaseName.")]
 		public readonly bool IsPlayerPalette = false;
 
+		[Desc("Trail animation.")]
+		public readonly string TrailImage = null;
+
+		[Desc("Loop a randomly chosen sequence of TrailImage from this list while this projectile is moving.")]
+		[SequenceReference("TrailImage")] public readonly string[] TrailSequences = { "idle" };
+
+		[Desc("Interval in ticks between each spawned Trail animation.")]
+		public readonly int TrailInterval = 1;
+
+		[Desc("Delay in ticks until trail animation is spawned.")]
+		public readonly int TrailDelay = 1;
+
+		[Desc("Palette used to render the trail sequence.")]
+		[PaletteReference("TrailUsePlayerPalette")] public readonly string TrailPalette = "effect";
+
+		[Desc("Use the Player Palette to render the trail sequence.")]
+		public readonly bool TrailUsePlayerPalette = false;
+
 		[Desc("Travel time - split equally between ascent and descent.")]
 		public readonly int FlightDelay = 400;
 
@@ -117,7 +135,8 @@ namespace OpenRA.Mods.Common.Traits
 				self.CenterPosition + body.LocalToWorld(info.SpawnOffset),
 				targetPosition,
 				info.FlightVelocity, info.MissileDelay, info.FlightDelay, info.SkipAscent,
-				info.FlashType);
+				info.FlashType,
+				info.TrailImage, info.TrailSequences, info.TrailPalette, info.TrailUsePlayerPalette, info.TrailDelay, info.TrailInterval);
 
 			self.World.AddFrameEndTask(w => w.Add(missile));
 

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -1154,12 +1154,15 @@ palace:
 		LaunchSpeechNotification: MissileLaunchDetected
 		MissileWeapon: atomic
 		MissileDelay: 18
-		SpawnOffset: -512,1c171,0
+		SpawnOffset: 32,816,0
 		DisplayBeacon: True
 		DisplayRadarPing: True
 		CameraRange: 10c0
 		ArrowSequence: arrow
 		CircleSequence: circles
+		FlightVelocity: 384
+		TrailInterval: 0
+		TrailImage: large_trail
 	ProduceActorPower@fremen:
 		Description: Recruit Fremen
 		LongDesc: Elite infantry unit armed with assault rifles and rockets\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery\n  Special Ability: Invisibility

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -66,7 +66,7 @@ large_trail:
 	idle: DATA.R8
 		Start: 4126
 		Length: 4
-		Tick: 80
+		Tick: 120
 		BlendMode: Additive
 		ZOffset: 1023
 
@@ -263,10 +263,11 @@ atomic:
 	up: DATA.R8
 		Start: 2147
 		ZOffset: 1023
-		Offset: -9,-9
+		Offset: 2,0
 	down: DATA.R8
 		Start: 2148
 		ZOffset: 1023
+		Offset: -1,0
 
 fire:
 	1: DATA.R8

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -370,6 +370,10 @@ NAMISL:
 		DisplayRadarPing: True
 		BeaconPoster:
 		CameraRange: 10c0
+		FlightVelocity: 1c0
+		TrailImage: small_smoke_trail
+		TrailPalette: effectalpha75
+		TrailInterval: 0
 	WithNukeLaunchOverlay:
 	SelectionDecorations:
 

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -10,6 +10,7 @@
 		Inaccuracy: 128
 		Image: DRAGON
 		TrailImage: small_smoke_trail
+		TrailPalette: effectalpha75
 		HorizontalRateOfTurn: 8
 		RangeLimit: 8c0
 		Palette: ra


### PR DESCRIPTION
And use it for D2k Death Hand.
While working on #16363, I noticed that the Death Hand in original D2k had this.

Also added trail to TS nuke/"Cluster Missile" for some visual polish (and increased FlightVelocity), since who knows when we'll get around to implementing the real voxel projectile.