### PR TITLE
Fix EngineerRepair stances and make the trait more customisable.

### DIFF
--- a/OpenRA.Mods.Common/Activities/RepairBuilding.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBuilding.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -16,17 +17,15 @@ namespace OpenRA.Mods.Common.Activities
 {
 	class RepairBuilding : Enter
 	{
-		readonly EnterBehaviour enterBehaviour;
-		readonly Stance validStances;
+		readonly EngineerRepairInfo info;
 
 		Actor enterActor;
 		IHealth enterHealth;
 
-		public RepairBuilding(Actor self, Target target, EnterBehaviour enterBehaviour, Stance validStances)
+		public RepairBuilding(Actor self, Target target, EngineerRepairInfo info)
 			: base(self, target, Color.Yellow)
 		{
-			this.enterBehaviour = enterBehaviour;
-			this.validStances = validStances;
+			this.info = info;
 		}
 
 		protected override bool TryStartEnter(Actor self, Actor targetActor)
@@ -37,7 +36,7 @@ namespace OpenRA.Mods.Common.Activities
 			// Make sure we can still repair the target before entering
 			// (but not before, because this may stop the actor in the middle of nowhere)
 			var stance = self.Owner.Stances[enterActor.Owner];
-			if (enterHealth == null || enterHealth.DamageState == DamageState.Undamaged || !stance.HasStance(validStances))
+			if (enterHealth == null || enterHealth.DamageState == DamageState.Undamaged || !info.ValidStances.HasStance(stance))
 			{
 				Cancel(self, true);
 				return false;
@@ -57,7 +56,7 @@ namespace OpenRA.Mods.Common.Activities
 				return;
 
 			var stance = self.Owner.Stances[enterActor.Owner];
-			if (!stance.HasStance(validStances))
+			if (!info.ValidStances.HasStance(stance))
 				return;
 
 			if (enterHealth.DamageState == DamageState.Undamaged)
@@ -65,9 +64,9 @@ namespace OpenRA.Mods.Common.Activities
 
 			enterActor.InflictDamage(self, new Damage(-enterHealth.MaxHP));
 
-			if (enterBehaviour == EnterBehaviour.Dispose)
+			if (info.EnterBehaviour == EnterBehaviour.Dispose)
 				self.Dispose();
-			else if (enterBehaviour == EnterBehaviour.Suicide)
+			else if (info.EnterBehaviour == EnterBehaviour.Suicide)
 				self.Kill(self);
 		}
 	}

--- a/OpenRA.Mods.Common/Activities/RepairBuilding.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBuilding.cs
@@ -63,6 +63,8 @@ namespace OpenRA.Mods.Common.Activities
 				return;
 
 			enterActor.InflictDamage(self, new Damage(-enterHealth.MaxHP));
+			if (!string.IsNullOrEmpty(info.RepairSound))
+				Game.Sound.Play(SoundType.World, info.RepairSound, enterActor.CenterPosition);
 
 			if (info.EnterBehaviour == EnterBehaviour.Dispose)
 				self.Dispose();

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Activities\WaitForTransport.cs" />
     <Compile Include="ActorExts.cs" />
     <Compile Include="AIUtils.cs" />
+    <Compile Include="Traits\EngineerRepairable.cs" />
     <Compile Include="Orders\OrderGenerator.cs" />
     <Compile Include="TargetExtensions.cs" />
     <Compile Include="Traits\BotModules\Squads\AttackOrFleeFuzzy.cs" />

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -29,6 +29,12 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("What diplomatic stances allow target to be repaired by this actor.")]
 		public readonly Stance ValidStances = Stance.Ally;
 
+		[Desc("Cursor to show when hovering over a valid actor to repair.")]
+		public readonly string Cursor = "goldwrench";
+
+		[Desc("Cursor to show when target actor has full health so it can't be repaired.")]
+		public readonly string RepairBlockedCursor = "goldwrench-blocked";
+
 		public object Create(ActorInitializer init) { return new EngineerRepair(init, this); }
 	}
 
@@ -88,7 +94,7 @@ namespace OpenRA.Mods.Common.Traits
 			EngineerRepairInfo info;
 
 			public EngineerRepairOrderTargeter(EngineerRepairInfo info)
-				: base("EngineerRepair", 6, "goldwrench", true, true)
+				: base("EngineerRepair", 6, info.Cursor, true, true)
 			{
 				this.info = info;
 			}
@@ -102,7 +108,7 @@ namespace OpenRA.Mods.Common.Traits
 					return false;
 
 				if (target.GetDamageState() == DamageState.Undamaged)
-					cursor = "goldwrench-blocked";
+					cursor = info.RepairBlockedCursor;
 
 				return true;
 			}
@@ -116,7 +122,7 @@ namespace OpenRA.Mods.Common.Traits
 					return false;
 
 				if (target.DamageState == DamageState.Undamaged)
-					cursor = "goldwrench-blocked";
+					cursor = info.RepairBlockedCursor;
 
 				return true;
 			}

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Primitives;
@@ -20,6 +21,9 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Can instantly repair other actors, but gets consumed afterwards.")]
 	class EngineerRepairInfo : ITraitInfo
 	{
+		[Desc("Uses the \"EngineerRepairable\" trait to determine repairability.")]
+		public readonly BitSet<EngineerRepairType> Types = default(BitSet<EngineerRepairType>);
+
 		[VoiceReference] public readonly string Voice = "Action";
 
 		[Desc("Behaviour when entering the structure.",
@@ -104,7 +108,11 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor)
 			{
-				if (!target.Info.HasTraitInfo<EngineerRepairableInfo>())
+				var engineerRepairable = target.Info.TraitInfoOrDefault<EngineerRepairableInfo>();
+				if (engineerRepairable == null)
+					return false;
+
+				if (!engineerRepairable.Types.IsEmpty && !engineerRepairable.Types.Overlaps(info.Types))
 					return false;
 
 				if (!info.ValidStances.HasStance(self.Owner.Stances[target.Owner]))
@@ -118,7 +126,11 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override bool CanTargetFrozenActor(Actor self, FrozenActor target, TargetModifiers modifiers, ref string cursor)
 			{
-				if (!target.Info.HasTraitInfo<EngineerRepairableInfo>())
+				var engineerRepairable = target.Info.TraitInfoOrDefault<EngineerRepairableInfo>();
+				if (engineerRepairable == null)
+					return false;
+
+				if (!engineerRepairable.Types.IsEmpty && !engineerRepairable.Types.Overlaps(info.Types))
 					return false;
 
 				if (!info.ValidStances.HasStance(self.Owner.Stances[target.Owner]))

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -117,9 +117,4 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 	}
-
-	[Desc("Eligible for instant repair.")]
-	class EngineerRepairableInfo : TraitInfo<EngineerRepairable> { }
-
-	class EngineerRepairable { }
 }

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -29,6 +29,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("What diplomatic stances allow target to be repaired by this actor.")]
 		public readonly Stance ValidStances = Stance.Ally;
 
+		[Desc("Sound to play when repairing is done.")]
+		public readonly string RepairSound = null;
+
 		[Desc("Cursor to show when hovering over a valid actor to repair.")]
 		public readonly string Cursor = "goldwrench";
 

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -80,20 +80,25 @@ namespace OpenRA.Mods.Common.Traits
 				self.CancelActivity();
 
 			self.SetTargetLine(order.Target, Color.Yellow);
-			self.QueueActivity(new RepairBuilding(self, order.Target, info.EnterBehaviour, info.ValidStances));
+			self.QueueActivity(new RepairBuilding(self, order.Target, info));
 		}
 
 		class EngineerRepairOrderTargeter : UnitOrderTargeter
 		{
-			public EngineerRepairOrderTargeter()
-				: base("EngineerRepair", 6, "goldwrench", false, true) { }
+			EngineerRepairInfo info;
+
+			public EngineerRepairOrderTargeter(EngineerRepairInfo info)
+				: base("EngineerRepair", 6, "goldwrench", true, true)
+			{
+				this.info = info;
+			}
 
 			public override bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor)
 			{
 				if (!target.Info.HasTraitInfo<EngineerRepairableInfo>())
 					return false;
 
-				if (self.Owner.Stances[target.Owner] != Stance.Ally)
+				if (!info.ValidStances.HasStance(self.Owner.Stances[target.Owner]))
 					return false;
 
 				if (target.GetDamageState() == DamageState.Undamaged)
@@ -107,7 +112,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!target.Info.HasTraitInfo<EngineerRepairableInfo>())
 					return false;
 
-				if (self.Owner.Stances[target.Owner] != Stance.Ally)
+				if (!info.ValidStances.HasStance(self.Owner.Stances[target.Owner]))
 					return false;
 
 				if (target.DamageState == DamageState.Undamaged)

--- a/OpenRA.Mods.Common/Traits/EngineerRepairable.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepairable.cs
@@ -1,0 +1,20 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Eligible for instant repair.")]
+	class EngineerRepairableInfo : TraitInfo<EngineerRepairable> { }
+
+	class EngineerRepairable { }
+}

--- a/OpenRA.Mods.Common/Traits/EngineerRepairable.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepairable.cs
@@ -9,12 +9,19 @@
  */
 #endregion
 
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	public class EngineerRepairType { }
+
 	[Desc("Eligible for instant repair.")]
-	class EngineerRepairableInfo : TraitInfo<EngineerRepairable> { }
+	class EngineerRepairableInfo : TraitInfo<EngineerRepairable>
+	{
+		[Desc("Actors with these Types under EngineerRepair trait can repair me.")]
+		public readonly BitSet<EngineerRepairType> Types = default(BitSet<EngineerRepairType>);
+	}
 
 	class EngineerRepairable { }
 }


### PR DESCRIPTION
Engineer Repair stances didn't work for 2 reasons. In the order generator it was not actually checking info.ValidStances, but directly if the target is Ally or not. 2 the Stance check in the activity was wrong way around.

This PR in addition to that:
- Adds Types: to EngineerRepair and EngineerRepairable. Both being empty is also a valid match.
- Made cusors definable in yaml, it was hardcoded to `goldwrench` and `goldwrench-blocked`.
- Made EngineerRepair conditional, tho not EngineerRepairable.
- Added RepairSounds to EngineerRepair. In RA2 repairing structures played a sound.

TESTCASE is only for stance fix. I didn't set up for anything else.