### PR TITLE
Prevent harvesters getting stuck in gridlock by allowing units to give way.

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -32,6 +32,16 @@ namespace OpenRA.Traits
 		Dead = 32
 	}
 
+	// NOTE: Each subsequent category is a superset of the previous categories
+	// and categories are mutually exclusive.
+	public enum BlockedByActor
+	{
+		None,
+		Immovable,
+		Stationary,
+		All
+	}
+
 	/// <summary>
 	/// Type tag for DamageTypes <see cref="Primitives.BitSet{T}"/>.
 	/// </summary>
@@ -312,16 +322,16 @@ namespace OpenRA.Traits
 
 	public interface IPositionableInfo : IOccupySpaceInfo
 	{
-		bool CanEnterCell(World world, Actor self, CPos cell, Actor ignoreActor = null, bool checkTransientActors = true);
+		bool CanEnterCell(World world, Actor self, CPos cell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All);
 	}
 
 	public interface IPositionable : IOccupySpace
 	{
 		bool CanExistInCell(CPos location);
 		bool IsLeavingCell(CPos location, SubCell subCell = SubCell.Any);
-		bool CanEnterCell(CPos location, Actor ignoreActor = null, bool checkTransientActors = true);
+		bool CanEnterCell(CPos location, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All);
 		SubCell GetValidSubCell(SubCell preferred = SubCell.Any);
-		SubCell GetAvailableSubCell(CPos location, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, bool checkTransientActors = true);
+		SubCell GetAvailableSubCell(CPos location, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All);
 		void SetPosition(Actor self, CPos cell, SubCell subCell = SubCell.Any);
 		void SetPosition(Actor self, WPos pos);
 		void SetVisualPosition(Actor self, WPos pos);

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -107,7 +107,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				var movement = self.Trait<IPositionable>();
 
 				var minefield = GetMinefieldCells(minefieldStart, cell, Info.MinefieldDepth)
-					.Where(c => movement.CanEnterCell(c, null, false))
+					.Where(c => movement.CanEnterCell(c, null, BlockedByActor.None))
 					.OrderBy(c => (c - minefieldStart).LengthSquared).ToList();
 
 				self.QueueActivity(order.Queued, new LayMines(self, minefield));
@@ -222,7 +222,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				var pal = wr.Palette(TileSet.TerrainPaletteInternalName);
 				foreach (var c in minefield)
 				{
-					var tile = movement.CanEnterCell(c, null, false) && !world.ShroudObscures(c) ? tileOk : tileBlocked;
+					var tile = movement.CanEnterCell(c, null, BlockedByActor.None) && !world.ShroudObscures(c) ? tileOk : tileBlocked;
 					yield return new SpriteRenderable(tile, world.Map.CenterOfCell(c),
 						WVec.Zero, -511, pal, 1f, true);
 				}

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		bool IOccupySpaceInfo.SharesCell { get { return false; } }
 
 		// Used to determine if actor can spawn
-		public bool CanEnterCell(World world, Actor self, CPos cell, Actor ignoreActor = null, bool checkTransientActors = false)
+		public bool CanEnterCell(World world, Actor self, CPos cell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
 		{
 			if (!world.Map.Contains(cell))
 				return false;
@@ -158,9 +158,9 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public bool CanExistInCell(CPos cell) { return true; }
 		public bool IsLeavingCell(CPos location, SubCell subCell = SubCell.Any) { return false; }
-		public bool CanEnterCell(CPos cell, Actor ignoreActor = null, bool checkTransientActors = false) { return true; }
+		public bool CanEnterCell(CPos cell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All) { return true; }
 		public SubCell GetValidSubCell(SubCell preferred) { return SubCell.Invalid; }
-		public SubCell GetAvailableSubCell(CPos a, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, bool checkTransientActors = true)
+		public SubCell GetAvailableSubCell(CPos a, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
 		{
 			// Does not use any subcell
 			return SubCell.Invalid;

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -152,7 +152,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (!target.IsValidFor(self))
 				return AttackStatus.UnableToAttack;
 
-			if (attack.Info.AttackRequiresEnteringCell && !positionable.CanEnterCell(target.Actor.Location, null, false))
+			if (attack.Info.AttackRequiresEnteringCell && !positionable.CanEnterCell(target.Actor.Location, null, BlockedByActor.None))
 				return AttackStatus.UnableToAttack;
 
 			if (!attack.Info.TargetFrozenActors && !forceAttack && target.Type == TargetType.FrozenActor)

--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -194,7 +194,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Find any harvestable resources:
 			List<CPos> path;
-			using (var search = PathSearch.Search(self.World, mobile.Locomotor, self, true, loc =>
+			using (var search = PathSearch.Search(self.World, mobile.Locomotor, self, BlockedByActor.Stationary, loc =>
 					domainIndex.IsPassable(self.Location, loc, locomotorInfo) && harv.CanHarvestCell(self, loc) && claimLayer.CanClaimCell(self, loc))
 				.WithCustomCost(loc =>
 				{

--- a/OpenRA.Mods.Common/Activities/HarvestResource.cs
+++ b/OpenRA.Mods.Common/Activities/HarvestResource.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Activities
 				foreach (var n in notifyHarvesterActions)
 					n.MovingToResources(self, targetCell);
 
-				QueueChild(move.MoveTo(targetCell, 2));
+				QueueChild(move.MoveTo(targetCell, 0));
 				return false;
 			}
 

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected override void OnFirstRun(Actor self)
 		{
-			QueueChild(Mobile.MoveTo(() => CalculatePathToTarget(self)));
+			QueueChild(Mobile.MoveTo(check => CalculatePathToTarget(self, check)));
 		}
 
 		public override bool Tick(Actor self)
@@ -112,14 +112,14 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Target has moved, and MoveAdjacentTo is still valid.
 			if (!IsCanceling && shouldRepath)
-				QueueChild(Mobile.MoveTo(() => CalculatePathToTarget(self)));
+				QueueChild(Mobile.MoveTo(check => CalculatePathToTarget(self, check)));
 
 			// The last queued childactivity is guaranteed to be the inner move, so if the childactivity
 			// queue is empty it means we have reached our destination.
 			return TickChild(self);
 		}
 
-		List<CPos> CalculatePathToTarget(Actor self)
+		List<CPos> CalculatePathToTarget(Actor self, BlockedByActor check)
 		{
 			var targetCells = CandidateMovementCells(self);
 			var searchCells = new List<CPos>();
@@ -132,8 +132,8 @@ namespace OpenRA.Mods.Common.Activities
 			if (!searchCells.Any())
 				return NoPath;
 
-			using (var fromSrc = PathSearch.FromPoints(self.World, Mobile.Locomotor, self, searchCells, loc, true))
-			using (var fromDest = PathSearch.FromPoint(self.World, Mobile.Locomotor, self, loc, lastVisibleTargetLocation, true).Reverse())
+			using (var fromSrc = PathSearch.FromPoints(self.World, Mobile.Locomotor, self, searchCells, loc, check))
+			using (var fromDest = PathSearch.FromPoint(self.World, Mobile.Locomotor, self, loc, lastVisibleTargetLocation, check).Reverse())
 				return pathFinder.FindBidiPath(fromSrc, fromDest);
 		}
 

--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Find the cells that are blocked by transient actors
 			return cargo.CurrentAdjacentCells
-				.Where(c => pos.CanEnterCell(c, null, true) != pos.CanEnterCell(c, null, false));
+				.Where(c => pos.CanEnterCell(c, null, BlockedByActor.All) != pos.CanEnterCell(c, null, BlockedByActor.None));
 		}
 
 		protected override void OnFirstRun(Actor self)

--- a/OpenRA.Mods.Common/Pathfinder/PathFinderUnitPathCacheDecorator.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathFinderUnitPathCacheDecorator.cs
@@ -30,37 +30,47 @@ namespace OpenRA.Mods.Common.Pathfinder
 			this.cacheStorage = cacheStorage;
 		}
 
-		public List<CPos> FindUnitPath(CPos source, CPos target, Actor self, Actor ignoreActor)
+		public List<CPos> FindUnitPath(CPos source, CPos target, Actor self, Actor ignoreActor, BlockedByActor check)
 		{
 			using (new PerfSample("Pathfinder"))
 			{
 				var key = "FindUnitPath" + self.ActorID + source.X + source.Y + target.X + target.Y;
-				var cachedPath = cacheStorage.Retrieve(key);
 
-				if (cachedPath != null)
-					return cachedPath;
+				// Only cache path when transient actors are ignored, otherwise there is no guarantee that the path
+				// is still valid at the next check.
+				if (check == BlockedByActor.None)
+				{
+					var cachedPath = cacheStorage.Retrieve(key);
+					if (cachedPath != null)
+						return cachedPath;
+				}
 
-				var pb = pathFinder.FindUnitPath(source, target, self, ignoreActor);
+				var pb = pathFinder.FindUnitPath(source, target, self, ignoreActor, check);
 
-				cacheStorage.Store(key, pb);
+				if (check == BlockedByActor.None)
+					cacheStorage.Store(key, pb);
 
 				return pb;
 			}
 		}
 
-		public List<CPos> FindUnitPathToRange(CPos source, SubCell srcSub, WPos target, WDist range, Actor self)
+		public List<CPos> FindUnitPathToRange(CPos source, SubCell srcSub, WPos target, WDist range, Actor self, BlockedByActor check)
 		{
 			using (new PerfSample("Pathfinder"))
 			{
 				var key = "FindUnitPathToRange" + self.ActorID + source.X + source.Y + target.X + target.Y;
-				var cachedPath = cacheStorage.Retrieve(key);
 
-				if (cachedPath != null)
-					return cachedPath;
+				if (check == BlockedByActor.None)
+				{
+					var cachedPath = cacheStorage.Retrieve(key);
+					if (cachedPath != null)
+						return cachedPath;
+				}
 
-				var pb = pathFinder.FindUnitPathToRange(source, srcSub, target, range, self);
+				var pb = pathFinder.FindUnitPathToRange(source, srcSub, target, range, self, check);
 
-				cacheStorage.Store(key, pb);
+				if (check == BlockedByActor.None)
+					cacheStorage.Store(key, pb);
 
 				return pb;
 			}

--- a/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
+using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Pathfinder
 {
@@ -82,7 +83,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		public bool InReverse { get; set; }
 		public Actor IgnoreActor { get; set; }
 
-		readonly CellConditions checkConditions;
+		readonly BlockedByActor checkConditions;
 		readonly Locomotor locomotor;
 		readonly LocomotorInfo.WorldMovementInfo worldMovementInfo;
 		readonly CellInfoLayerPool.PooledCellInfoLayer pooledLayer;
@@ -92,7 +93,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		readonly Dictionary<byte, Pair<ICustomMovementLayer, CellLayer<CellInfo>>> customLayerInfo =
 			new Dictionary<byte, Pair<ICustomMovementLayer, CellLayer<CellInfo>>>();
 
-		public PathGraph(CellInfoLayerPool layerPool, Locomotor locomotor, Actor actor, World world, bool checkForBlocked)
+		public PathGraph(CellInfoLayerPool layerPool, Locomotor locomotor, Actor actor, World world, BlockedByActor check)
 		{
 			pooledLayer = layerPool.Get();
 			groundInfo = pooledLayer.GetLayer();
@@ -108,7 +109,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			worldMovementInfo = locomotorInfo.GetWorldMovementInfo(world);
 			Actor = actor;
 			LaneBias = 1;
-			checkConditions = checkForBlocked ? CellConditions.TransientActors : CellConditions.None;
+			checkConditions = check;
 			checkTerrainHeight = world.Map.Grid.MaximumTerrainHeight > 0;
 		}
 
@@ -172,8 +173,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 		int GetCostToNode(CPos destNode, CVec direction)
 		{
-			var movementCost = locomotor.MovementCostToEnterCell(Actor, destNode, IgnoreActor, checkConditions);
-
+			var movementCost = locomotor.MovementCostToEnterCell(Actor, destNode, checkConditions, IgnoreActor);
 			if (movementCost != short.MaxValue && !(CustomBlock != null && CustomBlock(destNode)))
 				return CalculateCellCost(destNode, direction, movementCost);
 

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
+using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Pathfinder
 {
@@ -45,18 +46,18 @@ namespace OpenRA.Mods.Common.Pathfinder
 			considered = new LinkedList<Pair<CPos, int>>();
 		}
 
-		public static IPathSearch Search(World world, Locomotor locomotor, Actor self, bool checkForBlocked, Func<CPos, bool> goalCondition)
+		public static IPathSearch Search(World world, Locomotor locomotor, Actor self, BlockedByActor check, Func<CPos, bool> goalCondition)
 		{
-			var graph = new PathGraph(LayerPoolForWorld(world), locomotor, self, world, checkForBlocked);
+			var graph = new PathGraph(LayerPoolForWorld(world), locomotor, self, world, check);
 			var search = new PathSearch(graph);
 			search.isGoal = goalCondition;
 			search.heuristic = loc => 0;
 			return search;
 		}
 
-		public static IPathSearch FromPoint(World world, Locomotor locomotor, Actor self, CPos @from, CPos target, bool checkForBlocked)
+		public static IPathSearch FromPoint(World world, Locomotor locomotor, Actor self, CPos @from, CPos target, BlockedByActor check)
 		{
-			var graph = new PathGraph(LayerPoolForWorld(world), locomotor, self, world, checkForBlocked);
+			var graph = new PathGraph(LayerPoolForWorld(world), locomotor, self, world, check);
 			var search = new PathSearch(graph)
 			{
 				heuristic = DefaultEstimator(target)
@@ -74,9 +75,9 @@ namespace OpenRA.Mods.Common.Pathfinder
 			return search;
 		}
 
-		public static IPathSearch FromPoints(World world, Locomotor locomotor, Actor self, IEnumerable<CPos> froms, CPos target, bool checkForBlocked)
+		public static IPathSearch FromPoints(World world, Locomotor locomotor, Actor self, IEnumerable<CPos> froms, CPos target, BlockedByActor check)
 		{
-			var graph = new PathGraph(LayerPoolForWorld(world), locomotor, self, world, checkForBlocked);
+			var graph = new PathGraph(LayerPoolForWorld(world), locomotor, self, world, check);
 			var search = new PathSearch(graph)
 			{
 				heuristic = DefaultEstimator(target)

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.Common.Traits
 		bool IOccupySpaceInfo.SharesCell { get { return false; } }
 
 		// Used to determine if an aircraft can spawn landed
-		public bool CanEnterCell(World world, Actor self, CPos cell, Actor ignoreActor = null, bool checkTransientActors = true)
+		public bool CanEnterCell(World world, Actor self, CPos cell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
 		{
 			if (!world.Map.Contains(cell))
 				return false;
@@ -170,7 +170,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (world.WorldActor.Trait<BuildingInfluence>().GetBuildingAt(cell) != null)
 				return false;
 
-			if (!checkTransientActors)
+			if (check == BlockedByActor.None)
 				return true;
 
 			return !world.ActorMap.GetActorsAt(cell).Any(x => x != ignoreActor);
@@ -721,9 +721,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool CanExistInCell(CPos cell) { return true; }
 		public bool IsLeavingCell(CPos location, SubCell subCell = SubCell.Any) { return false; } // TODO: Handle landing
-		public bool CanEnterCell(CPos cell, Actor ignoreActor = null, bool checkTransientActors = true) { return true; }
+		public bool CanEnterCell(CPos cell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All) { return true; }
 		public SubCell GetValidSubCell(SubCell preferred) { return SubCell.Invalid; }
-		public SubCell GetAvailableSubCell(CPos a, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, bool checkTransientActors = true)
+		public SubCell GetAvailableSubCell(CPos a, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
 		{
 			// Does not use any subcell
 			return SubCell.Invalid;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -231,7 +231,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (IsTraitDisabled)
 				return false;
 
-			if (Info.AttackRequiresEnteringCell && (positionable == null || !positionable.CanEnterCell(t.Actor.Location, null, false)))
+			if (Info.AttackRequiresEnteringCell && (positionable == null || !positionable.CanEnterCell(t.Actor.Location, null, BlockedByActor.None)))
 				return false;
 
 			// PERF: Avoid LINQ.

--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -146,7 +146,7 @@ namespace OpenRA.Mods.Common.Traits
 				claimLayer.CanClaimCell(actor, cell);
 
 			var path = pathfinder.FindPath(
-				PathSearch.Search(world, harv.Locomotor, actor, true, isValidResource)
+				PathSearch.Search(world, harv.Locomotor, actor, BlockedByActor.Stationary, isValidResource)
 					.WithCustomCost(loc => world.FindActorsInCircle(world.Map.CenterOfCell(loc), Info.HarvesterEnemyAvoidanceRadius)
 						.Where(u => !u.IsDead && actor.Owner.Stances[u.Owner] == Stance.Enemy)
 						.Sum(u => Math.Max(WDist.Zero.Length, Info.HarvesterEnemyAvoidanceRadius.Length - (world.Map.CenterOfCell(loc) - u.CenterPosition).Length)))

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
@@ -198,7 +198,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (mobile.locomotor.MovementCostForCell(cell) == short.MaxValue)
 					return false;
 
-				return mobile.locomotor.CanMoveFreelyInto(self, cell, null, CellConditions.BlockedByMovers);
+				return mobile.locomotor.CanMoveFreelyInto(self, cell, BlockedByActor.All, null);
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -218,7 +218,7 @@ namespace OpenRA.Mods.Common.Traits
 			return Util.AdjacentCells(self.World, Target.FromActor(self)).Where(c => self.Location != c);
 		}
 
-		public bool CanUnload(bool immediate = false)
+		public bool CanUnload(BlockedByActor check = BlockedByActor.None)
 		{
 			if (checkTerrainType)
 			{
@@ -229,7 +229,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			return !IsEmpty(self) && (aircraft == null || aircraft.CanLand(self.Location, blockedByMobile: false))
-				&& CurrentAdjacentCells != null && CurrentAdjacentCells.Any(c => Passengers.Any(p => !p.IsDead && p.Trait<IPositionable>().CanEnterCell(c, null, immediate)));
+				&& CurrentAdjacentCells != null && CurrentAdjacentCells.Any(c => Passengers.Any(p => !p.IsDead && p.Trait<IPositionable>().CanEnterCell(c, null, check)));
 		}
 
 		public bool CanLoad(Actor self, Actor a)
@@ -430,7 +430,7 @@ namespace OpenRA.Mods.Common.Traits
 		void INotifyKilled.Killed(Actor self, AttackInfo e)
 		{
 			if (Info.EjectOnDeath)
-				while (!IsEmpty(self) && CanUnload(true))
+				while (!IsEmpty(self) && CanUnload(BlockedByActor.All))
 				{
 					var passenger = Unload(self);
 					var cp = self.CenterPosition;
@@ -438,7 +438,7 @@ namespace OpenRA.Mods.Common.Traits
 					var positionable = passenger.Trait<IPositionable>();
 					positionable.SetPosition(passenger, self.Location);
 
-					if (!inAir && positionable.CanEnterCell(self.Location, self, false))
+					if (!inAir && positionable.CanEnterCell(self.Location, self, BlockedByActor.None))
 					{
 						self.World.AddFrameEndTask(w => w.Add(passenger));
 						var nbms = passenger.TraitsImplementing<INotifyBlockingMove>();

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -40,9 +40,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool IOccupySpaceInfo.SharesCell { get { return false; } }
 
-		public bool CanEnterCell(World world, Actor self, CPos cell, Actor ignoreActor = null, bool checkTransientActors = true)
+		public bool CanEnterCell(World world, Actor self, CPos cell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
 		{
-			return GetAvailableSubCell(world, cell, ignoreActor, checkTransientActors) != SubCell.Invalid;
+			return GetAvailableSubCell(world, cell, ignoreActor, check) != SubCell.Invalid;
 		}
 
 		public bool CanExistInCell(World world, CPos cell)
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 			return true;
 		}
 
-		public SubCell GetAvailableSubCell(World world, CPos cell, Actor ignoreActor = null, bool checkTransientActors = true)
+		public SubCell GetAvailableSubCell(World world, CPos cell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
 		{
 			if (!CanExistInCell(world, cell))
 				return SubCell.Invalid;
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (world.WorldActor.Trait<BuildingInfluence>().GetBuildingAt(cell) != null)
 				return SubCell.Invalid;
 
-			if (!checkTransientActors)
+			if (check == BlockedByActor.None)
 				return SubCell.FullCell;
 
 			return !world.ActorMap.GetActorsAt(cell).Any(x => x != ignoreActor)
@@ -208,16 +208,16 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool IsLeavingCell(CPos location, SubCell subCell = SubCell.Any) { return self.Location == location && ticks + 1 == info.Lifetime * 25; }
 		public SubCell GetValidSubCell(SubCell preferred = SubCell.Any) { return SubCell.FullCell; }
-		public SubCell GetAvailableSubCell(CPos cell, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, bool checkTransientActors = true)
+		public SubCell GetAvailableSubCell(CPos cell, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
 		{
-			return info.GetAvailableSubCell(self.World, cell, ignoreActor, checkTransientActors);
+			return info.GetAvailableSubCell(self.World, cell, ignoreActor, check);
 		}
 
 		public bool CanExistInCell(CPos cell) { return info.CanExistInCell(self.World, cell); }
 
-		public bool CanEnterCell(CPos a, Actor ignoreActor = null, bool checkTransientActors = true)
+		public bool CanEnterCell(CPos a, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
 		{
-			return GetAvailableSubCell(a, SubCell.Any, ignoreActor, checkTransientActors) != SubCell.Invalid;
+			return GetAvailableSubCell(a, SubCell.Any, ignoreActor, check) != SubCell.Invalid;
 		}
 
 		bool ICrushable.CrushableBy(Actor self, Actor crusher, BitSet<CrushClass> crushClasses)

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -184,7 +184,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Start a search from each refinery's delivery location:
 			List<CPos> path;
 
-			using (var search = PathSearch.FromPoints(self.World, mobile.Locomotor, self, refs.Values.Select(r => r.Location), self.Location, false)
+			using (var search = PathSearch.FromPoints(self.World, mobile.Locomotor, self, refs.Values.Select(r => r.Location), self.Location, BlockedByActor.None)
 				.WithCustomCost(loc =>
 				{
 					if (!refs.ContainsKey(loc))

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool IOccupySpaceInfo.SharesCell { get { return false; } }
 
-		public bool CanEnterCell(World world, Actor self, CPos cell, Actor ignoreActor = null, bool checkTransientActors = true)
+		public bool CanEnterCell(World world, Actor self, CPos cell, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
 		{
 			// IPositionable*Info*.CanEnterCell is only ever used for things like exiting production facilities,
 			// all places relevant for husks check IPositionable.CanEnterCell instead, so we can safely set this to true.
@@ -107,21 +107,21 @@ namespace OpenRA.Mods.Common.Traits
 		public Pair<CPos, SubCell>[] OccupiedCells() { return new[] { Pair.New(TopLeft, SubCell.FullCell) }; }
 		public bool IsLeavingCell(CPos location, SubCell subCell = SubCell.Any) { return false; }
 		public SubCell GetValidSubCell(SubCell preferred = SubCell.Any) { return SubCell.FullCell; }
-		public SubCell GetAvailableSubCell(CPos cell, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, bool checkTransientActors = true)
+		public SubCell GetAvailableSubCell(CPos cell, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
 		{
 			if (!CanExistInCell(cell))
 				return SubCell.Invalid;
 
-			if (!checkTransientActors)
+			if (check == BlockedByActor.None)
 				return SubCell.FullCell;
 
 			return self.World.ActorMap.GetActorsAt(cell)
 				.All(x => x == ignoreActor) ? SubCell.FullCell : SubCell.Invalid;
 		}
 
-		public bool CanEnterCell(CPos a, Actor ignoreActor = null, bool checkTransientActors = true)
+		public bool CanEnterCell(CPos a, Actor ignoreActor = null, BlockedByActor check = BlockedByActor.All)
 		{
-			return GetAvailableSubCell(a, SubCell.Any, ignoreActor, checkTransientActors) != SubCell.Invalid;
+			return GetAvailableSubCell(a, SubCell.Any, ignoreActor, check) != SubCell.Invalid;
 		}
 
 		public void SetPosition(Actor self, CPos cell, SubCell subCell = SubCell.Any) { SetPosition(self, self.World.Map.CenterOfCell(cell)); }

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -33,9 +33,9 @@ namespace OpenRA.Mods.Common.Traits
 		/// Calculates a path for the actor from source to destination
 		/// </summary>
 		/// <returns>A path from start to target</returns>
-		List<CPos> FindUnitPath(CPos source, CPos target, Actor self, Actor ignoreActor);
+		List<CPos> FindUnitPath(CPos source, CPos target, Actor self, Actor ignoreActor, BlockedByActor check);
 
-		List<CPos> FindUnitPathToRange(CPos source, SubCell srcSub, WPos target, WDist range, Actor self);
+		List<CPos> FindUnitPathToRange(CPos source, SubCell srcSub, WPos target, WDist range, Actor self, BlockedByActor check);
 
 		/// <summary>
 		/// Calculates a path given a search specification
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.world = world;
 		}
 
-		public List<CPos> FindUnitPath(CPos source, CPos target, Actor self, Actor ignoreActor)
+		public List<CPos> FindUnitPath(CPos source, CPos target, Actor self, Actor ignoreActor, BlockedByActor check)
 		{
 			var mobile = self.Trait<Mobile>();
 			var locomotor = mobile.Locomotor;
@@ -78,19 +78,23 @@ namespace OpenRA.Mods.Common.Traits
 				return EmptyPath;
 
 			var distance = source - target;
-			if (source.Layer == target.Layer && distance.LengthSquared < 3 && locomotor.CanMoveFreelyInto(self, target, null, CellConditions.All))
+			var canMoveFreely = locomotor.CanMoveFreelyInto(self, target, check, null);
+			if (distance.LengthSquared < 3 && !canMoveFreely)
+				return new List<CPos> { };
+
+			if (source.Layer == target.Layer && distance.LengthSquared < 3 && canMoveFreely)
 				return new List<CPos> { target };
 
 			List<CPos> pb;
 
-			using (var fromSrc = PathSearch.FromPoint(world, locomotor, self, target, source, true).WithIgnoredActor(ignoreActor))
-			using (var fromDest = PathSearch.FromPoint(world, locomotor, self, source, target, true).WithIgnoredActor(ignoreActor).Reverse())
+			using (var fromSrc = PathSearch.FromPoint(world, locomotor, self, target, source, check).WithIgnoredActor(ignoreActor))
+			using (var fromDest = PathSearch.FromPoint(world, locomotor, self, source, target, check).WithIgnoredActor(ignoreActor).Reverse())
 				pb = FindBidiPath(fromSrc, fromDest);
 
 			return pb;
 		}
 
-		public List<CPos> FindUnitPathToRange(CPos source, SubCell srcSub, WPos target, WDist range, Actor self)
+		public List<CPos> FindUnitPathToRange(CPos source, SubCell srcSub, WPos target, WDist range, Actor self, BlockedByActor check)
 		{
 			if (!cached)
 			{
@@ -123,8 +127,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			var locomotor = mobile.Locomotor;
 
-			using (var fromSrc = PathSearch.FromPoints(world, locomotor, self, tilesInRange, source, true))
-			using (var fromDest = PathSearch.FromPoint(world, locomotor, self, source, targetCell, true).Reverse())
+			using (var fromSrc = PathSearch.FromPoints(world, locomotor, self, tilesInRange, source, check))
+			using (var fromDest = PathSearch.FromPoint(world, locomotor, self, source, targetCell, check).Reverse())
 				return FindBidiPath(fromSrc, fromDest);
 		}
 

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.D2k.Activities
 					}
 
 					// The target reached solid ground
-					if (!positionable.CanEnterCell(targetLocation, null, false))
+					if (!positionable.CanEnterCell(targetLocation, null, BlockedByActor.None))
 					{
 						RevokeCondition(self);
 						return true;

--- a/OpenRA.Mods.D2k/Traits/Sandworm.cs
+++ b/OpenRA.Mods.D2k/Traits/Sandworm.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.D2k.Traits
 				if (!a.Info.HasTraitInfo<AttractsWormsInfo>())
 					return false;
 
-				return mobile.CanEnterCell(a.Location, null, false);
+				return mobile.CanEnterCell(a.Location, null, BlockedByActor.None);
 			};
 
 			var actorsInRange = self.World.FindActorsInCircle(self.CenterPosition, WormInfo.MaxSearchRadius)
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 			var moveTo = self.World.Map.CellContaining(self.CenterPosition + noiseDirection);
 
-			while (!self.World.Map.Contains(moveTo) || !mobile.CanEnterCell(moveTo, null, false))
+			while (!self.World.Map.Contains(moveTo) || !mobile.CanEnterCell(moveTo, null, BlockedByActor.None))
 			{
 				// without this check, this while can be infinity loop
 				if (moveTo == self.Location)


### PR DESCRIPTION
This fixes the issues with harvesters getting stuck around refineries and resource spawns as well as the majority of other gridlocks caused by units moving in opposite directions where no alternative paths are available.

Fixes #14752
Fixes #12817
Fixes #12576
Fixes #10565
Fixes #3089
Fixes #13260
Fixes #16412 
Fixes #3671

- ~The first commit in this PR contains a general refactor of `HarvestResources` such as was discussed in #16193.~
- The second commit contains changes to the pathfinding logic to allow moving units to give way when their only path is blocked by other moving units, essentially nudging themselves. To facilitate this I also refactored the transient actor checks in the pathfinding code.