### PR TITLE
Implement game save plumbing and enable for missions

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -39,6 +39,7 @@ namespace OpenRA
 		public static ModData ModData;
 		public static Settings Settings;
 		public static ICursor Cursor;
+		public static bool HideCursor;
 		static WorldRenderer worldRenderer;
 
 		internal static OrderManager OrderManager;
@@ -659,8 +660,13 @@ namespace OpenRA
 
 					if (ModData != null && ModData.CursorProvider != null)
 					{
-						Cursor.SetCursor(Ui.Root.GetCursorOuter(Viewport.LastMousePos) ?? "default");
-						Cursor.Render(Renderer);
+						if (HideCursor)
+							Cursor.SetCursor(null);
+						else
+						{
+							Cursor.SetCursor(Ui.Root.GetCursorOuter(Viewport.LastMousePos) ?? "default");
+							Cursor.Render(Renderer);
+						}
 					}
 				}
 

--- a/OpenRA.Game/Network/GameSave.cs
+++ b/OpenRA.Game/Network/GameSave.cs
@@ -1,0 +1,313 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using OpenRA.Primitives;
+using OpenRA.Server;
+
+namespace OpenRA.Network
+{
+	public class SlotClient
+	{
+		public readonly Color Color;
+		public readonly string Faction;
+		public readonly int SpawnPoint;
+		public readonly int Team;
+		public readonly string Slot;
+		public readonly string Bot;
+		public readonly bool IsAdmin;
+
+		public readonly string BotName;
+
+		public SlotClient() { }
+
+		public SlotClient(Session.Client client)
+		{
+			Color = client.Color;
+			Faction = client.Faction;
+			SpawnPoint = client.SpawnPoint;
+			Team = client.Team;
+			Slot = client.Slot;
+			Bot = client.Bot;
+			IsAdmin = client.IsAdmin;
+
+			if (client.Bot != null)
+				BotName = client.Name;
+		}
+
+		public void ApplyTo(Session.Client client)
+		{
+			client.Color = Color;
+			client.Faction = Faction;
+			client.SpawnPoint = SpawnPoint;
+			client.Team = Team;
+			client.Slot = Slot;
+			client.Bot = Bot;
+			client.IsAdmin = IsAdmin;
+
+			if (Bot != null)
+				client.Name = BotName;
+		}
+
+		public static SlotClient Deserialize(MiniYaml data)
+		{
+			return FieldLoader.Load<SlotClient>(data);
+		}
+
+		public MiniYamlNode Serialize(string key)
+		{
+			return new MiniYamlNode("SlotClient@{0}".F(key), FieldSaver.Save(this));
+		}
+	}
+
+	public class GameSave
+	{
+		public const int EOFMarker = -2;
+		public const int MetadataMarker = -1;
+		public const int TraitDataMarker = -3;
+
+		readonly MemoryStream ordersStream = new MemoryStream();
+
+		// Loaded from file and updated during gameplay
+		public int LastOrdersFrame { get; private set; }
+		public int LastSyncFrame { get; private set; }
+		byte[] lastSyncPacket = new byte[0];
+
+		// Loaded from file or set on game start
+		public Session.Global GlobalSettings { get; private set; }
+		public Dictionary<string, Session.Slot> Slots { get; private set; }
+		public Dictionary<string, SlotClient> SlotClients { get; private set; }
+		public Dictionary<int, MiniYaml> TraitData = new Dictionary<int, MiniYaml>();
+
+		// Set on game start
+		int[] clientsBySlotIndex = { };
+		int firstBotSlotIndex = -1;
+
+		public GameSave()
+		{
+			LastOrdersFrame = -1;
+			Slots = new Dictionary<string, Session.Slot>();
+		}
+
+		public GameSave(string filepath)
+		{
+			using (var rs = File.OpenRead(filepath))
+			{
+				rs.Seek(-12, SeekOrigin.End);
+				var metadataOffset = rs.ReadInt32();
+				var traitDataOffset = rs.ReadInt32();
+				if (rs.ReadInt32() != EOFMarker)
+					throw new InvalidDataException("Invalid orasav file");
+
+				rs.Seek(metadataOffset, SeekOrigin.Begin);
+				if (rs.ReadInt32() != MetadataMarker)
+					throw new InvalidDataException("Invalid orasav file");
+
+				LastOrdersFrame = rs.ReadInt32();
+				LastSyncFrame = rs.ReadInt32();
+				lastSyncPacket = rs.ReadBytes(5);
+
+				var globalSettings = MiniYaml.FromString(rs.ReadString(Encoding.UTF8, Connection.MaxOrderLength));
+				GlobalSettings = Session.Global.Deserialize(globalSettings[0].Value);
+
+				var slots = MiniYaml.FromString(rs.ReadString(Encoding.UTF8, Connection.MaxOrderLength));
+				Slots = new Dictionary<string, Session.Slot>();
+				foreach (var s in slots)
+				{
+					var slot = Session.Slot.Deserialize(s.Value);
+					Slots.Add(slot.PlayerReference, slot);
+				}
+
+				var slotClients = MiniYaml.FromString(rs.ReadString(Encoding.UTF8, Connection.MaxOrderLength));
+				SlotClients = new Dictionary<string, SlotClient>();
+				foreach (var s in slotClients)
+				{
+					var slotClient = SlotClient.Deserialize(s.Value);
+					SlotClients.Add(slotClient.Slot, slotClient);
+				}
+
+				if (rs.Position != traitDataOffset || rs.ReadInt32() != TraitDataMarker)
+					throw new InvalidDataException("Invalid orasav file");
+
+				var traitData = MiniYaml.FromString(rs.ReadString(Encoding.UTF8, Connection.MaxOrderLength));
+				foreach (var td in traitData)
+					TraitData.Add(int.Parse(td.Key), td.Value);
+
+				rs.Seek(0, SeekOrigin.Begin);
+				ordersStream.Write(rs.ReadBytes(metadataOffset), 0, metadataOffset);
+			}
+		}
+
+		public void StartGame(Session lobbyInfo, MapPreview map)
+		{
+			// Game orders are mapped from a client index to the slot that they occupy
+			// Orders from spectators are ignored, which is not a problem in practice
+			// because all immediate orders are also ignored
+			clientsBySlotIndex = lobbyInfo.Slots.Keys.Select(s =>
+			{
+				var client = lobbyInfo.ClientInSlot(s);
+				return client != null ? client.Index : -1;
+			}).ToArray();
+
+			// Perform a deep clone by round-tripping the data
+			GlobalSettings = Session.Global.Deserialize(lobbyInfo.GlobalSettings.Serialize().Value);
+			Slots = new Dictionary<string, Session.Slot>();
+			SlotClients = new Dictionary<string, SlotClient>();
+			foreach (var s in lobbyInfo.Slots)
+			{
+				Slots[s.Key] = Session.Slot.Deserialize(s.Value.Serialize().Value);
+
+				var playerReference = map.Players.Players[s.Value.PlayerReference];
+				var client = lobbyInfo.ClientInSlot(s.Key);
+
+				// Only save the client state relevant to the game (faction, team, etc).
+				// Admin and bot controller state is inherited and/or reassigned by the server at load time
+				if (playerReference.Playable && client != null)
+				{
+					SlotClients[s.Key] = new SlotClient(client);
+
+					// See HACK comment in DispatchOrders about reassigning bot orders
+					if (client.Bot != null && firstBotSlotIndex < 0)
+						firstBotSlotIndex = clientsBySlotIndex.IndexOf(client.Index);
+				}
+			}
+		}
+
+		public void DispatchOrders(Connection conn, int frame, byte[] data)
+		{
+			// Sync packet - we only care about the last value
+			if (data.Length > 0 && data[0] == 0x65 && frame > LastSyncFrame)
+			{
+				LastSyncFrame = frame;
+				lastSyncPacket = data;
+			}
+
+			if (frame <= LastOrdersFrame)
+				return;
+
+			// Ignore immediate orders
+			if (data.Length > 0 && data[0] == 0xFE)
+				return;
+
+			var clientSlot = clientsBySlotIndex.IndexOf(conn.PlayerIndex);
+
+			// Handle orders that were sent by spectators
+			if (clientSlot == -1)
+			{
+				// HACK: Assume that this is a bot order sent by its controller client
+				// who is a spectator. The network data doesn't contain enough information
+				// for us to confirm this, or to know which bot this is supposed to belong to...
+				//
+				// For skirmish games it is sufficient to map everything to the first bot,
+				// because even if the bot choice is wrong, the bot-to-client remapping in ParseOrders
+				// will give the right client as there is only one human client to choose from!
+				// TODO: This will need to be fixed properly before implementing multiplayer saves
+				clientSlot = firstBotSlotIndex;
+			}
+
+			ordersStream.WriteArray(BitConverter.GetBytes(data.Length + 8));
+			ordersStream.WriteArray(BitConverter.GetBytes(frame));
+			ordersStream.WriteArray(BitConverter.GetBytes(clientSlot));
+			ordersStream.WriteArray(data);
+			LastOrdersFrame = frame;
+		}
+
+		public void ParseOrders(Session lobbyInfo, Action<int, int, byte[]> packetFn)
+		{
+			// Send the trait data first to guarantee that it is available when needed
+			foreach (var kv in TraitData)
+			{
+				var data = new List<MiniYamlNode>() { new MiniYamlNode(kv.Key.ToString(), kv.Value) }.WriteToString();
+				packetFn(0, 0, new ServerOrder("SaveTraitData", data).Serialize());
+			}
+
+			ordersStream.Seek(0, SeekOrigin.Begin);
+			while (ordersStream.Position < ordersStream.Length)
+			{
+				var dataLength = ordersStream.ReadInt32() - 8;
+				var frame = ordersStream.ReadInt32();
+				var slot = ordersStream.ReadInt32();
+				var data = ordersStream.ReadBytes(dataLength);
+
+				// Remap bot orders to their controller client
+				var clientIndex = clientsBySlotIndex[slot];
+				var client = lobbyInfo.ClientWithIndex(clientIndex);
+				if (client.Bot != null)
+					clientIndex = client.BotControllerClientIndex;
+
+				packetFn(frame, clientIndex, data);
+			}
+
+			// Send sync hash to validate restore
+			packetFn(LastSyncFrame, 0, lastSyncPacket);
+		}
+
+		public void AddTraitData(int traitIndex, MiniYaml data)
+		{
+			TraitData[traitIndex] = data;
+		}
+
+		public void Save(string path)
+		{
+			// File format:
+			// - List of orders in network frame format
+			// - Metadata start marker
+			//   - Last frame number containing orders (int32)
+			//   - Last frame number containing sync hash (int32)
+			//   - Last sync packet (5 x byte)
+			//   - Lobby global settings (yaml)
+			//   - Lobby slots (yaml)
+			//   - Lobby slot-client data (yaml)
+			// - Trait data start marker
+			//   - Custom trait yaml
+			// - File offset of metadata start marker
+			// - File offset of custom trait data
+			// - Metadata end marker
+			var file = File.Create(path);
+
+			ordersStream.Seek(0, SeekOrigin.Begin);
+			ordersStream.CopyTo(file);
+			file.Write(BitConverter.GetBytes(MetadataMarker), 0, 4);
+			file.Write(BitConverter.GetBytes(LastOrdersFrame), 0, 4);
+			file.Write(BitConverter.GetBytes(LastSyncFrame), 0, 4);
+			file.Write(lastSyncPacket, 0, 5);
+
+			var globalSettingsNodes = new List<MiniYamlNode>() { GlobalSettings.Serialize() };
+			file.WriteString(Encoding.UTF8, globalSettingsNodes.WriteToString());
+
+			var slotNodes = Slots
+				.Select(s => s.Value.Serialize())
+				.ToList();
+			file.WriteString(Encoding.UTF8, slotNodes.WriteToString());
+
+			var slotClientNodes = SlotClients
+				.Select(s => s.Value.Serialize(s.Key))
+				.ToList();
+			file.WriteString(Encoding.UTF8, slotClientNodes.WriteToString());
+
+			var traitDataOffset = file.Length;
+			file.Write(BitConverter.GetBytes(TraitDataMarker), 0, 4);
+
+			var traitDataNodes = TraitData
+				.Select(kv => new MiniYamlNode(kv.Key.ToString(), kv.Value))
+				.ToList();
+			file.WriteString(Encoding.UTF8, traitDataNodes.WriteToString());
+
+			file.Write(BitConverter.GetBytes(ordersStream.Length), 0, 4);
+			file.Write(BitConverter.GetBytes(traitDataOffset), 0, 4);
+			file.Write(BitConverter.GetBytes(EOFMarker), 0, 4);
+		}
+	}
+}

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -45,6 +45,9 @@ namespace OpenRA.Network
 		public bool GameStarted { get { return NetFrameNumber != 0; } }
 		public IConnection Connection { get; private set; }
 
+		internal int GameSaveLastFrame = -1;
+		internal int GameSaveLastSyncFrame = -1;
+
 		List<Order> localOrders = new List<Order>();
 
 		List<ChatLine> chatCache = new List<ChatLine>();
@@ -70,8 +73,10 @@ namespace OpenRA.Network
 			generateSyncReport = !(Connection is ReplayConnection) && LobbyInfo.GlobalSettings.EnableSyncReports;
 
 			NetFrameNumber = 1;
-			for (var i = NetFrameNumber; i <= FramesAhead; i++)
-				Connection.Send(i, new List<byte[]>());
+
+			if (GameSaveLastFrame < 0)
+				for (var i = NetFrameNumber; i <= FramesAhead; i++)
+					Connection.Send(i, new List<byte[]>());
 		}
 
 		public OrderManager(string host, int port, string password, IConnection conn)
@@ -105,7 +110,7 @@ namespace OpenRA.Network
 		public void TickImmediate()
 		{
 			var immediateOrders = localOrders.Where(o => o.IsImmediate).ToList();
-			if (immediateOrders.Count != 0)
+			if (immediateOrders.Count != 0 && GameSaveLastFrame < NetFrameNumber + FramesAhead)
 				Connection.SendImmediate(immediateOrders.Select(o => o.Serialize()).ToList());
 			localOrders.RemoveAll(o => o.IsImmediate);
 
@@ -178,13 +183,18 @@ namespace OpenRA.Network
 			if (!IsReadyForNextFrame)
 				throw new InvalidOperationException();
 
-			Connection.Send(NetFrameNumber + FramesAhead, localOrders.Select(o => o.Serialize()).ToList());
+			if (GameSaveLastFrame < NetFrameNumber + FramesAhead)
+				Connection.Send(NetFrameNumber + FramesAhead, localOrders.Select(o => o.Serialize()).ToList());
+
 			localOrders.Clear();
 
 			foreach (var order in frameData.OrdersForFrame(World, NetFrameNumber))
 				UnitOrders.ProcessOrder(this, World, order.Client, order.Order);
 
-			Connection.SendSync(NetFrameNumber, OrderIO.SerializeSync(World.SyncHash()));
+			if (NetFrameNumber + FramesAhead >= GameSaveLastSyncFrame)
+				Connection.SendSync(NetFrameNumber, OrderIO.SerializeSync(World.SyncHash()));
+			else
+				Connection.SendSync(NetFrameNumber, OrderIO.SerializeSync(0));
 
 			if (generateSyncReport)
 				using (new PerfSample("sync_report"))

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -202,6 +202,7 @@ namespace OpenRA.Network
 			public bool EnableSingleplayer;
 			public bool EnableSyncReports;
 			public bool Dedicated;
+			public bool GameSavesEnabled;
 
 			[FieldLoader.Ignore]
 			public Dictionary<string, LobbyOptionState> LobbyOptions = new Dictionary<string, LobbyOptionState>();

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -100,6 +100,7 @@
     <Compile Include="CacheStorage.cs" />
     <Compile Include="FileFormats\Png.cs" />
     <Compile Include="FileSystem\IPackage.cs" />
+    <Compile Include="Network\GameSave.cs" />
     <Compile Include="Primitives\Color.cs" />
     <Compile Include="Primitives\Int32Matrix4x4.cs" />
     <Compile Include="LogProxy.cs" />

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -54,6 +54,7 @@ namespace OpenRA.Server
 
 		// Managed by LobbyCommands
 		public MapPreview Map;
+		public GameSave GameSave = null;
 
 		readonly int randomSeed;
 		readonly TcpListener listener;
@@ -558,6 +559,9 @@ namespace OpenRA.Server
 				InterpretServerOrders(conn, data);
 			else
 				DispatchOrdersToClients(conn, frame, data);
+
+			if (GameSave != null && conn != null)
+				GameSave.DispatchOrders(conn, frame, data);
 		}
 
 		void InterpretServerOrders(Connection conn, byte[] data)
@@ -659,6 +663,119 @@ namespace OpenRA.Server
 						pingFromClient.LatencyJitter = (history.Max() - history.Min()) / 2;
 						pingFromClient.LatencyHistory = history.ToArray();
 
+						SyncClientPing();
+
+						break;
+					}
+
+				case "GameSaveTraitData":
+					{
+						if (GameSave != null)
+						{
+							var data = MiniYaml.FromString(so.Data)[0];
+							GameSave.AddTraitData(int.Parse(data.Key), data.Value);
+						}
+
+						break;
+					}
+
+				case "CreateGameSave":
+					{
+						if (GameSave != null)
+						{
+							// Sanitize potentially malicious input
+							var filename = so.Data;
+							var invalidIndex = -1;
+							var invalidChars = Path.GetInvalidFileNameChars();
+							while ((invalidIndex = filename.IndexOfAny(invalidChars)) != -1)
+								filename = filename.Remove(invalidIndex, 1);
+
+							var baseSavePath = Platform.ResolvePath(
+								Platform.SupportDirPrefix,
+								"Saves",
+								ModData.Manifest.Id,
+								ModData.Manifest.Metadata.Version);
+
+							if (!Directory.Exists(baseSavePath))
+								Directory.CreateDirectory(baseSavePath);
+
+							GameSave.Save(Path.Combine(baseSavePath, filename));
+							DispatchOrdersToClients(null, 0, new ServerOrder("GameSaved", filename).Serialize());
+						}
+
+						break;
+					}
+
+				case "LoadGameSave":
+					{
+						if (Dedicated || State >= ServerState.GameStarted)
+							break;
+
+						// Sanitize potentially malicious input
+						var filename = so.Data;
+						var invalidIndex = -1;
+						var invalidChars = Path.GetInvalidFileNameChars();
+						while ((invalidIndex = filename.IndexOfAny(invalidChars)) != -1)
+							filename = filename.Remove(invalidIndex, 1);
+
+						var savePath = Platform.ResolvePath(
+							Platform.SupportDirPrefix,
+							"Saves",
+							ModData.Manifest.Id,
+							ModData.Manifest.Metadata.Version,
+							filename);
+
+						GameSave = new GameSave(savePath);
+						LobbyInfo.GlobalSettings = GameSave.GlobalSettings;
+						LobbyInfo.Slots = GameSave.Slots;
+
+						// Reassign clients to slots
+						//  - Bot ordering is preserved
+						//  - Humans are assigned on a first-come-first-serve basis
+						//  - Leftover humans become spectators
+
+						// Start by removing all bots and assigning all players as spectators
+						foreach (var c in LobbyInfo.Clients)
+						{
+							if (c.Bot != null)
+							{
+								LobbyInfo.Clients.Remove(c);
+								var ping = LobbyInfo.PingFromClient(c);
+								if (ping != null)
+									LobbyInfo.ClientPings.Remove(ping);
+							}
+							else
+								c.Slot = null;
+						}
+
+						// Rebuild/remap the saved client state
+						// TODO: Multiplayer saves should leave all humans as spectators so they can manually pick slots
+						var adminClientIndex = LobbyInfo.Clients.First(c => c.IsAdmin).Index;
+						foreach (var kv in GameSave.SlotClients)
+						{
+							if (kv.Value.Bot != null)
+							{
+								var bot = new Session.Client()
+								{
+									Index = ChooseFreePlayerIndex(),
+									State = Session.ClientState.NotReady,
+									BotControllerClientIndex = adminClientIndex
+								};
+
+								kv.Value.ApplyTo(bot);
+								LobbyInfo.Clients.Add(bot);
+							}
+							else
+							{
+								// This will throw if the server doesn't have enough human clients to fill all player slots
+								// See TODO above - this isn't a problem in practice because MP saves won't use this
+								var client = LobbyInfo.Clients.First(c => c.Slot == null);
+								kv.Value.ApplyTo(client);
+							}
+						}
+
+						SyncLobbyInfo();
+						SyncLobbyClients();
 						SyncClientPing();
 
 						break;
@@ -810,6 +927,12 @@ namespace OpenRA.Server
 			if (LobbyInfo.NonBotClients.Count() == 1)
 				LobbyInfo.GlobalSettings.OrderLatency = 1;
 
+			// Enable game saves for singleplayer missions only
+			// TODO: Enable for skirmish once the AI supports state-restoration
+			// TODO: Enable for multiplayer (non-dedicated servers only) once the lobby UI has been created
+			LobbyInfo.GlobalSettings.GameSavesEnabled = !Dedicated && Map.Visibility == MapVisibility.MissionSelector &&
+			                                           LobbyInfo.NonBotClients.Count() == 1;
+
 			SyncLobbyInfo();
 			State = ServerState.GameStarted;
 
@@ -817,11 +940,37 @@ namespace OpenRA.Server
 				foreach (var d in Conns)
 					DispatchOrdersToClient(c, d.PlayerIndex, 0x7FFFFFFF, new byte[] { 0xBF });
 
+			if (GameSave == null && LobbyInfo.GlobalSettings.GameSavesEnabled)
+				GameSave = new GameSave();
+
+			var startGameData = "";
+			if (GameSave != null)
+			{
+				GameSave.StartGame(LobbyInfo, Map);
+				if (GameSave.LastOrdersFrame >= 0)
+				{
+					startGameData = new List<MiniYamlNode>()
+					{
+						new MiniYamlNode("SaveLastOrdersFrame", GameSave.LastOrdersFrame.ToString()),
+						new MiniYamlNode("SaveSyncFrame", GameSave.LastSyncFrame.ToString())
+					}.WriteToString();
+				}
+			}
+
 			DispatchOrders(null, 0,
-				new ServerOrder("StartGame", "").Serialize());
+				new ServerOrder("StartGame", startGameData).Serialize());
 
 			foreach (var t in serverTraits.WithInterface<IStartGame>())
 				t.GameStarted(this);
+
+			if (GameSave != null && GameSave.LastOrdersFrame >= 0)
+			{
+				GameSave.ParseOrders(LobbyInfo, (frame, client, data) =>
+				{
+					foreach (var c in Conns)
+						DispatchOrdersToClient(c, client, frame, data);
+				});
+			}
 		}
 	}
 }

--- a/OpenRA.Game/Sound/Sound.cs
+++ b/OpenRA.Game/Sound/Sound.cs
@@ -111,7 +111,7 @@ namespace OpenRA
 
 		ISound Play(SoundType type, Player player, string name, bool headRelative, WPos pos, float volumeModifier = 1f, bool loop = false)
 		{
-			if (string.IsNullOrEmpty(name) || (DisableWorldSounds && type == SoundType.World))
+			if (string.IsNullOrEmpty(name) || DisableAllSounds || (DisableWorldSounds && type == SoundType.World))
 				return null;
 
 			if (player != null && player != player.World.LocalPlayer)
@@ -137,6 +137,7 @@ namespace OpenRA
 			soundEngine.Volume = 1f;
 		}
 
+		public bool DisableAllSounds { get; set; }
 		public bool DisableWorldSounds { get; set; }
 		public ISound Play(SoundType type, string name) { return Play(type, null, name, true, WPos.Zero, 1f); }
 		public ISound Play(SoundType type, string name, WPos pos) { return Play(type, null, name, false, pos, 1f); }
@@ -340,7 +341,7 @@ namespace OpenRA
 			if (ruleset == null)
 				throw new ArgumentNullException("ruleset");
 
-			if (definition == null || (DisableWorldSounds && soundType == SoundType.World))
+			if (definition == null || DisableAllSounds || (DisableWorldSounds && soundType == SoundType.World))
 				return false;
 
 			if (ruleset.Voices == null || ruleset.Notifications == null)

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -356,6 +356,15 @@ namespace OpenRA.Traits
 	public interface INotifySelection { void SelectionChanged(); }
 
 	public interface IWorldLoaded { void WorldLoaded(World w, WorldRenderer wr); }
+	public interface INotifyGameLoading { void GameLoading(World w); }
+	public interface INotifyGameLoaded { void GameLoaded(World w); }
+	public interface INotifyGameSaved { void GameSaved(World w); }
+
+	public interface IGameSaveTraitData
+	{
+		List<MiniYamlNode> IssueTraitData(Actor self);
+		void ResolveTraitData(Actor self, List<MiniYamlNode> data);
+	}
 
 	[RequireExplicitImplementation]
 	public interface ICreatePlayers { void CreatePlayers(World w); }

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -234,15 +234,20 @@ namespace OpenRA
 			using (new PerfTimer("ScreenMap.WorldLoaded"))
 				ScreenMap.WorldLoaded(this, wr);
 
-			foreach (var wlh in WorldActor.TraitsImplementing<IWorldLoaded>())
+			foreach (var iwl in WorldActor.TraitsImplementing<IWorldLoaded>())
 			{
 				// These have already been initialized
-				if (wlh == ScreenMap)
+				if (iwl == ScreenMap)
 					continue;
 
-				using (new PerfTimer(wlh.GetType().Name + ".WorldLoaded"))
-					wlh.WorldLoaded(this, wr);
+				using (new PerfTimer(iwl.GetType().Name + ".WorldLoaded"))
+					iwl.WorldLoaded(this, wr);
 			}
+
+			foreach (var p in Players)
+				foreach (var iwl in p.PlayerActor.TraitsImplementing<IWorldLoaded>())
+					using (new PerfTimer(iwl.GetType().Name + ".WorldLoaded"))
+						iwl.WorldLoaded(this, wr);
 
 			gameInfo.StartTimeUtc = DateTime.UtcNow;
 			foreach (var player in Players)

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -636,6 +636,7 @@
     <Compile Include="Widgets\ExponentialSliderWidget.cs" />
     <Compile Include="Widgets\Logic\Ingame\GameSaveLoadingLogic.cs" />
     <Compile Include="Widgets\Logic\MusicHotkeyLogic.cs" />
+    <Compile Include="Widgets\Logic\GameSaveBrowserLogic.cs" />
     <Compile Include="WorldExtensions.cs" />
     <Compile Include="UtilityCommands\GetMapHashCommand.cs" />
     <Compile Include="UtilityCommands\Glob.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -634,6 +634,7 @@
     <Compile Include="UtilityCommands\PngSheetImportMetadataCommand.cs" />
     <Compile Include="Widgets\Logic\Editor\ActorEditLogic.cs" />
     <Compile Include="Widgets\ExponentialSliderWidget.cs" />
+    <Compile Include="Widgets\Logic\Ingame\GameSaveLoadingLogic.cs" />
     <Compile Include="Widgets\Logic\MusicHotkeyLogic.cs" />
     <Compile Include="WorldExtensions.cs" />
     <Compile Include="UtilityCommands\GetMapHashCommand.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -568,6 +568,7 @@
     <Compile Include="Traits\World\JumpjetLocomotor.cs" />
     <Compile Include="Traits\World\PaletteFromEmbeddedSpritePalette.cs" />
     <Compile Include="Traits\World\ResourceType.cs" />
+    <Compile Include="Traits\World\GameSaveViewportManager.cs" />
     <Compile Include="Traits\World\SubterraneanLocomotor.cs" />
     <Compile Include="Traits\World\LoadWidgetAtGameStart.cs" />
     <Compile Include="Traits\World\MPStartLocations.cs" />

--- a/OpenRA.Mods.Common/Traits/World/GameSaveViewportManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/GameSaveViewportManager.cs
@@ -1,0 +1,53 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public class GameSaveViewportManagerInfo : ITraitInfo
+	{
+		public object Create(ActorInitializer init) { return new GameSaveViewportManager(); }
+	}
+
+	public class GameSaveViewportManager : IWorldLoaded, IGameSaveTraitData
+	{
+		WorldRenderer worldRenderer;
+
+		void IWorldLoaded.WorldLoaded(World w, WorldRenderer wr) { worldRenderer = wr; }
+
+		List<MiniYamlNode> IGameSaveTraitData.IssueTraitData(Actor self)
+		{
+			if (worldRenderer.World.LocalPlayer == null || self != worldRenderer.World.LocalPlayer.PlayerActor)
+				return null;
+
+			return new List<MiniYamlNode>()
+			{
+				new MiniYamlNode("Viewport", FieldSaver.FormatValue(worldRenderer.Viewport.CenterPosition)),
+				new MiniYamlNode("Selection", "", self.World.Selection.Serialize())
+			};
+		}
+
+		void IGameSaveTraitData.ResolveTraitData(Actor self, List<MiniYamlNode> data)
+		{
+			var viewportNode = data.FirstOrDefault(n => n.Key == "Viewport");
+			if (viewportNode != null)
+				worldRenderer.Viewport.Center(FieldLoader.GetValue<WPos>("data", viewportNode.Value.Value));
+
+			var selectionNode = data.FirstOrDefault(n => n.Key == "Selection");
+			if (selectionNode != null)
+				self.World.Selection.Deserialize(self.World, selectionNode.Value.Nodes);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/World/LoadWidgetAtGameStart.cs
+++ b/OpenRA.Mods.Common/Traits/World/LoadWidgetAtGameStart.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Widgets;
 using OpenRA.Traits;
 using OpenRA.Widgets;
 
@@ -26,31 +27,65 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The widget tree to open when the map editor is loaded.")]
 		public readonly string EditorRoot = "EDITOR_ROOT";
 
+		[Desc("The widget tree to open (in addition to INGAME_ROOT) while loading a saved game.")]
+		public readonly string GameSaveLoadingRoot = "GAMESAVE_LOADING_SCREEN";
+
 		[Desc("Remove any existing UI when a map is loaded.")]
 		public readonly bool ClearRoot = true;
 
 		public object Create(ActorInitializer init) { return new LoadWidgetAtGameStart(this); }
 	}
 
-	public class LoadWidgetAtGameStart : IWorldLoaded
+	public class LoadWidgetAtGameStart : IWorldLoaded, INotifyGameLoading, INotifyGameLoaded
 	{
 		readonly LoadWidgetAtGameStartInfo info;
+		Widget root;
 
 		public LoadWidgetAtGameStart(LoadWidgetAtGameStartInfo info)
 		{
 			this.info = info;
 		}
 
-		public void WorldLoaded(World world, WorldRenderer wr)
+		void INotifyGameLoading.GameLoading(World world)
 		{
 			// Clear any existing widget state
 			if (info.ClearRoot)
 				Ui.ResetAll();
 
+			Ui.OpenWindow(info.GameSaveLoadingRoot, new WidgetArgs()
+			{
+				{ "world", world }
+			});
+		}
+
+		void IWorldLoaded.WorldLoaded(World world, WorldRenderer wr)
+		{
+			if (!world.IsLoadingGameSave && info.ClearRoot)
+				Ui.ResetAll();
+
 			var widget = world.Type == WorldType.Shellmap ? info.ShellmapRoot :
 				world.Type == WorldType.Editor ? info.EditorRoot : info.IngameRoot;
 
-			Game.LoadWidget(world, widget, Ui.Root, new WidgetArgs());
+			root = Game.LoadWidget(world, widget, Ui.Root, new WidgetArgs());
+
+			// The Lua API requires the UI to available, so hide it instead
+			if (world.IsLoadingGameSave)
+				root.IsVisible = () => false;
+		}
+
+		void INotifyGameLoaded.GameLoaded(World world)
+		{
+			Ui.CloseWindow();
+			root.IsVisible = () => true;
+
+			// Open the options menu
+			if (!world.IsReplay)
+			{
+				var optionsButton = root.GetOrNull<MenuButtonWidget>("OPTIONS_BUTTON");
+				world.SetPauseState(false);
+				if (optionsButton != null)
+					Sync.RunUnsynced(Game.Settings.Debug.SyncCheckUnsyncedCode, world, optionsButton.OnClick);
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
+++ b/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Linq;
 using OpenRA.GameRules;
+using OpenRA.Graphics;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -38,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new MusicPlaylist(init.World, this); }
 	}
 
-	public class MusicPlaylist : INotifyActorDisposing, IGameOver
+	public class MusicPlaylist : INotifyActorDisposing, IGameOver, IWorldLoaded, INotifyGameLoaded
 	{
 		readonly MusicPlaylistInfo info;
 		readonly World world;
@@ -89,7 +90,16 @@ namespace OpenRA.Mods.Common.Traits
 				currentSong = world.Map.Rules.Music[info.StartingMusic];
 				CurrentSongIsBackground = false;
 			}
+		}
 
+		void IWorldLoaded.WorldLoaded(World world, WorldRenderer wr)
+		{
+			if (!world.IsLoadingGameSave)
+				Play();
+		}
+
+		void INotifyGameLoaded.GameLoaded(World world)
+		{
 			Play();
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
+++ b/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
@@ -30,9 +30,10 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 		}
 
-		public void WorldLoaded(World world, WorldRenderer wr)
+		void IWorldLoaded.WorldLoaded(World world, WorldRenderer wr)
 		{
-			Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", info.Notification, world.RenderPlayer == null ? null : world.RenderPlayer.Faction.InternalName);
+			if (!world.IsLoadingGameSave)
+				Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", info.Notification, world.RenderPlayer == null ? null : world.RenderPlayer.Faction.InternalName);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
+++ b/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
@@ -19,10 +19,16 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Speech")]
 		public readonly string Notification = "StartGame";
 
+		[NotificationReference("Speech")]
+		public readonly string LoadedNotification = "GameLoaded";
+
+		[NotificationReference("Speech")]
+		public readonly string SavedNotification = "GameSaved";
+
 		public object Create(ActorInitializer init) { return new StartGameNotification(this); }
 	}
 
-	class StartGameNotification : IWorldLoaded
+	class StartGameNotification : IWorldLoaded, INotifyGameLoaded, INotifyGameSaved
 	{
 		StartGameNotificationInfo info;
 		public StartGameNotification(StartGameNotificationInfo info)
@@ -34,6 +40,18 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (!world.IsLoadingGameSave)
 				Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", info.Notification, world.RenderPlayer == null ? null : world.RenderPlayer.Faction.InternalName);
+		}
+
+		void INotifyGameLoaded.GameLoaded(World world)
+		{
+			if (!world.IsReplay)
+				Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", info.LoadedNotification, world.RenderPlayer == null ? null : world.RenderPlayer.Faction.InternalName);
+		}
+
+		void INotifyGameSaved.GameSaved(World world)
+		{
+			if (!world.IsReplay)
+				Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", info.SavedNotification, world.RenderPlayer == null ? null : world.RenderPlayer.Faction.InternalName);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -1,0 +1,360 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using OpenRA.Network;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+	public class GameSaveBrowserLogic : ChromeLogic
+	{
+		readonly Widget panel;
+		readonly ScrollPanelWidget gameList;
+		readonly TextFieldWidget saveTextField;
+		readonly List<string> games = new List<string>();
+		readonly Action onStart;
+		readonly Action onExit;
+		readonly ModData modData;
+		readonly bool isSavePanel;
+		readonly string baseSavePath;
+
+		readonly string defaultSaveFilename;
+		string selectedSave;
+
+		[ObjectCreator.UseCtor]
+		public GameSaveBrowserLogic(Widget widget, ModData modData, Action onExit, Action onStart, bool isSavePanel, World world)
+		{
+			panel = widget;
+
+			this.modData = modData;
+			this.onStart = onStart;
+			this.onExit = onExit;
+			this.isSavePanel = isSavePanel;
+			Game.BeforeGameStart += OnGameStart;
+
+			panel.Get<ButtonWidget>("CANCEL_BUTTON").OnClick = () =>
+			{
+				Ui.CloseWindow();
+				onExit();
+			};
+
+			gameList = panel.Get<ScrollPanelWidget>("GAME_LIST");
+			var gameTemplate = panel.Get<ScrollItemWidget>("GAME_TEMPLATE");
+			var newTemplate = panel.Get<ScrollItemWidget>("NEW_TEMPLATE");
+
+			var mod = modData.Manifest;
+			baseSavePath = Platform.ResolvePath(Platform.SupportDirPrefix, "Saves", mod.Id, mod.Metadata.Version);
+
+			// Avoid filename conflicts when creating new saves
+			if (isSavePanel)
+			{
+				panel.Get("SAVE_TITLE").IsVisible = () => true;
+
+				defaultSaveFilename = world.Map.Title;
+				var filenameAttempt = 0;
+				while (true)
+				{
+					if (!File.Exists(Path.Combine(baseSavePath, defaultSaveFilename + ".orasav")))
+						break;
+
+					defaultSaveFilename = world.Map.Title + " ({0})".F(++filenameAttempt);
+				}
+
+				var saveButton = panel.Get<ButtonWidget>("SAVE_BUTTON");
+				saveButton.OnClick = () => { Save(world); };
+				saveButton.IsVisible = () => true;
+
+				var saveWidgets = panel.Get("SAVE_WIDGETS");
+				saveTextField = saveWidgets.Get<TextFieldWidget>("SAVE_TEXTFIELD");
+				gameList.Bounds.Height -= saveWidgets.Bounds.Height;
+				saveWidgets.IsVisible = () => true;
+			}
+			else
+			{
+				panel.Get("LOAD_TITLE").IsVisible = () => true;
+				var loadButton = panel.Get<ButtonWidget>("LOAD_BUTTON");
+				loadButton.IsVisible = () => true;
+				loadButton.IsDisabled = () => selectedSave == null;
+				loadButton.OnClick = () => { Load(); };
+			}
+
+			if (Directory.Exists(baseSavePath))
+				LoadGames(gameTemplate, newTemplate);
+
+			var renameButton = panel.Get<ButtonWidget>("RENAME_BUTTON");
+			renameButton.IsDisabled = () => selectedSave == null;
+			renameButton.OnClick = () =>
+			{
+				var initialName = Path.GetFileNameWithoutExtension(selectedSave);
+				var invalidChars = Path.GetInvalidFileNameChars();
+
+				ConfirmationDialogs.TextInputPrompt(
+					"Rename Save",
+					"Enter a new file name:",
+					initialName,
+					onAccept: newName => Rename(initialName, newName),
+					onCancel: null,
+					acceptText: "Rename",
+					cancelText: null,
+					inputValidator: newName =>
+					{
+						if (newName == initialName)
+							return false;
+
+						if (string.IsNullOrWhiteSpace(newName))
+							return false;
+
+						if (newName.IndexOfAny(invalidChars) >= 0)
+							return false;
+
+						if (File.Exists(Path.Combine(baseSavePath, newName)))
+							return false;
+
+						return true;
+					});
+			};
+
+			var deleteButton = panel.Get<ButtonWidget>("DELETE_BUTTON");
+			deleteButton.IsDisabled = () => selectedSave == null;
+			deleteButton.OnClick = () =>
+			{
+				ConfirmationDialogs.ButtonPrompt(
+					title: "Delete selected game save?",
+					text: "Delete '{0}'?".F(Path.GetFileNameWithoutExtension(selectedSave)),
+					onConfirm: () =>
+					{
+						Delete(selectedSave);
+
+						if (!games.Any() && !isSavePanel)
+						{
+							Ui.CloseWindow();
+							onExit();
+						}
+						else
+							SelectFirstVisible();
+					},
+					confirmText: "Delete",
+					onCancel: () => { });
+			};
+
+			var deleteAllButton = panel.Get<ButtonWidget>("DELETE_ALL_BUTTON");
+			deleteAllButton.IsDisabled = () => !games.Any();
+			deleteAllButton.OnClick = () =>
+			{
+				ConfirmationDialogs.ButtonPrompt(
+					title: "Delete all game saves?",
+					text: "Delete {0} game saves?".F(games.Count),
+					onConfirm: () =>
+					{
+						foreach (var s in games.ToList())
+							Delete(s);
+
+						Ui.CloseWindow();
+						onExit();
+					},
+					confirmText: "Delete All",
+					onCancel: () => { });
+			};
+
+			SelectFirstVisible();
+		}
+
+		void LoadGames(ScrollItemWidget gameTemplate, ScrollItemWidget newTemplate)
+		{
+			gameList.RemoveChildren();
+			if (isSavePanel)
+			{
+				var item = ScrollItemWidget.Setup(newTemplate,
+					() => selectedSave == null,
+					() => Select(null),
+					() => { });
+				gameList.AddChild(item);
+			}
+
+			var savePaths = Directory.GetFiles(baseSavePath, "*.orasav", SearchOption.AllDirectories)
+				.OrderByDescending(p => File.GetLastWriteTime(p))
+				.ToList();
+
+			foreach (var savePath in savePaths)
+			{
+				games.Add(savePath);
+
+				// Create the item manually so the click handlers can refer to itself
+				// This simplifies the rename handling (only needs to update ItemKey)
+				var item = gameTemplate.Clone() as ScrollItemWidget;
+				item.ItemKey = savePath;
+				item.IsVisible = () => true;
+				item.IsSelected = () => selectedSave == item.ItemKey;
+				item.OnClick = () => Select(item.ItemKey);
+				item.OnDoubleClick = Load;
+
+				var title = Path.GetFileNameWithoutExtension(savePath);
+				item.Get<LabelWidget>("TITLE").GetText = () => title;
+
+				var date = File.GetLastWriteTime(savePath).ToString("yyyy-MM-dd HH:mm:ss");
+				item.Get<LabelWidget>("DATE").GetText = () => date;
+
+				gameList.AddChild(item);
+			}
+		}
+
+		void Rename(string oldName, string newName)
+		{
+			try
+			{
+				var oldPath = Path.Combine(baseSavePath, oldName + ".orasav");
+				var newPath = Path.Combine(baseSavePath, newName + ".orasav");
+				File.Move(oldPath, newPath);
+
+				games[games.IndexOf(oldPath)] = newPath;
+				foreach (var c in gameList.Children)
+				{
+					var item = c as ScrollItemWidget;
+					if (item == null || item.ItemKey != oldPath)
+						continue;
+
+					item.ItemKey = newPath;
+					item.Get<LabelWidget>("TITLE").GetText = () => newName;
+				}
+
+				if (selectedSave == oldPath)
+					selectedSave = newPath;
+			}
+			catch (Exception ex)
+			{
+				Console.WriteLine(ex);
+				Log.Write("debug", ex.ToString());
+			}
+		}
+
+		void Delete(string savePath)
+		{
+			try
+			{
+				File.Delete(savePath);
+			}
+			catch (Exception ex)
+			{
+				Game.Debug("Failed to delete save file '{0}'. See the logs for details.", savePath);
+				Log.Write("debug", ex.ToString());
+				return;
+			}
+
+			if (savePath == selectedSave)
+				Select(null);
+
+			var item = gameList.Children
+				.Select(c => c as ScrollItemWidget)
+				.FirstOrDefault(c => c.ItemKey == savePath);
+
+			gameList.RemoveChild(item);
+			games.Remove(savePath);
+		}
+
+		void SelectFirstVisible()
+		{
+			Select(isSavePanel ? null : games.FirstOrDefault());
+		}
+
+		void Select(string savePath)
+		{
+			selectedSave = savePath;
+			if (isSavePanel)
+				saveTextField.Text = savePath == null ? defaultSaveFilename :
+					Path.GetFileNameWithoutExtension(savePath);
+		}
+
+		void Load()
+		{
+			if (selectedSave == null)
+				return;
+
+			// Parse the save to find the map UID
+			var save = new GameSave(selectedSave);
+			var map = modData.MapCache[save.GlobalSettings.Map];
+			if (map.Status != MapStatus.Available)
+				return;
+
+			var orders = new List<Order>()
+			{
+				new Order("LoadGameSave", null, false)
+				{
+					IsImmediate = true,
+					TargetString = Path.GetFileName(selectedSave)
+				},
+				Order.Command("state {0}".F(Session.ClientState.Ready))
+			};
+
+			Game.CreateAndStartLocalServer(map.Uid, orders);
+		}
+
+		void Save(World world)
+		{
+			var filename = saveTextField.Text + ".orasav";
+			var testPath = Platform.ResolvePath(
+				Platform.SupportDirPrefix,
+				"Saves",
+				modData.Manifest.Id,
+				modData.Manifest.Metadata.Version,
+				filename);
+
+			Action inner = () =>
+			{
+				world.RequestGameSave(filename);
+				Ui.CloseWindow();
+				onExit();
+			};
+
+			if (selectedSave != null || File.Exists(testPath))
+			{
+				ConfirmationDialogs.ButtonPrompt(
+					title: "Overwrite save game?",
+					text: "Overwrite {0}?".F(saveTextField.Text),
+					onConfirm: inner,
+					confirmText: "Overwrite",
+					onCancel: () => { });
+			}
+			else
+				inner();
+		}
+
+		void OnGameStart()
+		{
+			Ui.CloseWindow();
+			onStart();
+		}
+
+		bool disposed;
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && !disposed)
+			{
+				disposed = true;
+				Game.BeforeGameStart -= OnGameStart;
+			}
+
+			base.Dispose(disposing);
+		}
+
+		public static bool IsLoadPanelEnabled(Manifest mod)
+		{
+			var baseSavePath = Platform.ResolvePath(Platform.SupportDirPrefix, "Saves", mod.Id, mod.Metadata.Version);
+			if (!Directory.Exists(baseSavePath))
+				return false;
+
+			return Directory.GetFiles(baseSavePath, "*.orasav", SearchOption.AllDirectories).Any();
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameSaveLoadingLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameSaveLoadingLogic.cs
@@ -1,0 +1,49 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+	public class GameSaveLoadingLogic : ChromeLogic
+	{
+		[ObjectCreator.UseCtor]
+		public GameSaveLoadingLogic(Widget widget, ModData modData, World world)
+		{
+			widget.Get<ProgressBarWidget>("PROGRESS").GetPercentage = () => world.GameSaveLoadingPercentage;
+
+			var versionLabel = widget.GetOrNull<LabelWidget>("VERSION_LABEL");
+			if (versionLabel != null)
+				versionLabel.Text = modData.Manifest.Metadata.Version;
+
+			var keyhandler = widget.Get<LogicKeyListenerWidget>("CANCEL_HANDLER");
+			keyhandler.AddHandler(e =>
+			{
+				if (e.Event == KeyInputEvent.Down && e.Key == Keycode.ESCAPE)
+				{
+					Game.Disconnect();
+					Ui.ResetAll();
+					Game.LoadShellMap();
+					return true;
+				}
+
+				return false;
+			});
+
+			Game.HideCursor = true;
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			Game.HideCursor = false;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Scripting;
@@ -21,79 +22,169 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class IngameMenuLogic : ChromeLogic
 	{
 		readonly Widget menu;
+		readonly Widget buttonContainer;
+		readonly ButtonWidget buttonTemplate;
+		readonly int2 buttonStride;
+		readonly List<ButtonWidget> buttons = new List<ButtonWidget>();
+
+		readonly ModData modData;
+		readonly Action onExit;
+		readonly World world;
+		readonly WorldRenderer worldRenderer;
+		readonly MenuPaletteEffect mpe;
+		bool hasError;
+		bool leaving;
+		bool hideMenu;
 
 		[ObjectCreator.UseCtor]
-		public IngameMenuLogic(Widget widget, ModData modData, World world, Action onExit, WorldRenderer worldRenderer, IngameInfoPanel activePanel)
+		public IngameMenuLogic(Widget widget, ModData modData, World world, Action onExit, WorldRenderer worldRenderer,
+			IngameInfoPanel activePanel, Dictionary<string, MiniYaml> logicArgs)
 		{
-			var leaving = false;
+			this.modData = modData;
+			this.world = world;
+			this.worldRenderer = worldRenderer;
+			this.onExit = onExit;
+
+			var buttonHandlers = new Dictionary<string, Action>
+			{
+				{ "ABORT_MISSION", CreateAbortMissionButton },
+				{ "SURRENDER", CreateSurrenderButton },
+				{ "MUSIC", CreateMusicButton },
+				{ "SETTINGS", CreateSettingsButton },
+				{ "RESUME", CreateResumeButton },
+				{ "SAVE_MAP", CreateSaveMapButton },
+				{ "EXIT_EDITOR", CreateExitEditorButton }
+			};
+
 			menu = widget.Get("INGAME_MENU");
-			var mpe = world.WorldActor.TraitOrDefault<MenuPaletteEffect>();
+			mpe = world.WorldActor.TraitOrDefault<MenuPaletteEffect>();
 			if (mpe != null)
 				mpe.Fade(mpe.Info.MenuEffect);
 
 			menu.Get<LabelWidget>("VERSION_LABEL").Text = modData.Manifest.Metadata.Version;
 
-			var hideMenu = false;
-			menu.Get("MENU_BUTTONS").IsVisible = () => !hideMenu;
+			buttonContainer = menu.Get("MENU_BUTTONS");
+			buttonTemplate = buttonContainer.Get<ButtonWidget>("BUTTON_TEMPLATE");
+			buttonContainer.RemoveChild(buttonTemplate);
+			buttonContainer.IsVisible = () => !hideMenu;
+
+			MiniYaml buttonStrideNode;
+			if (logicArgs.TryGetValue("ButtonStride", out buttonStrideNode))
+				buttonStride = FieldLoader.GetValue<int2>("ButtonStride", buttonStrideNode.Value);
 
 			var scriptContext = world.WorldActor.TraitOrDefault<LuaScript>();
-			var hasError = scriptContext != null && scriptContext.FatalErrorOccurred;
+			hasError = scriptContext != null && scriptContext.FatalErrorOccurred;
 
-			// TODO: Create a mechanism to do things like this cleaner. Also needed for scripted missions
-			Action onQuit = () =>
+			MiniYaml buttonsNode;
+			if (logicArgs.TryGetValue("Buttons", out buttonsNode))
 			{
-				if (world.Type == WorldType.Regular)
+				Action createHandler;
+				var buttonIds = FieldLoader.GetValue<string[]>("Buttons", buttonsNode.Value);
+				foreach (var button in buttonIds)
+					if (buttonHandlers.TryGetValue(button, out createHandler))
+						createHandler();
+			}
+
+			// Recenter the button container
+			if (buttons.Count > 0)
+			{
+				var expand = (buttons.Count - 1) * buttonStride;
+				buttonContainer.Bounds.X -= expand.X / 2;
+				buttonContainer.Bounds.Y -= expand.Y / 2;
+				buttonContainer.Bounds.Width += expand.X;
+				buttonContainer.Bounds.Height += expand.Y;
+			}
+
+			var panelRoot = widget.GetOrNull("PANEL_ROOT");
+			if (panelRoot != null && world.Type != WorldType.Editor)
+			{
+				var gameInfoPanel = Game.LoadWidget(world, "GAME_INFO_PANEL", panelRoot, new WidgetArgs()
 				{
-					var moi = world.Map.Rules.Actors["player"].TraitInfoOrDefault<MissionObjectivesInfo>();
-					if (moi != null)
-					{
-						var faction = world.LocalPlayer == null ? null : world.LocalPlayer.Faction.InternalName;
-						Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", moi.LeaveNotification, faction);
-					}
-				}
+					{ "activePanel", activePanel }
+				});
 
-				leaving = true;
+				gameInfoPanel.IsVisible = () => !hideMenu;
+			}
+		}
 
-				var iop = world.WorldActor.TraitsImplementing<IObjectivesPanel>().FirstOrDefault();
-				var exitDelay = iop != null ? iop.ExitDelay : 0;
-				if (mpe != null)
+		void OnQuit()
+		{
+			// TODO: Create a mechanism to do things like this cleaner. Also needed for scripted missions
+			if (world.Type == WorldType.Regular)
+			{
+				var moi = world.Map.Rules.Actors["player"].TraitInfoOrDefault<MissionObjectivesInfo>();
+				if (moi != null)
 				{
-					Game.RunAfterDelay(exitDelay, () =>
-					{
-						if (Game.IsCurrentWorld(world))
-							mpe.Fade(MenuPaletteEffect.EffectType.Black);
-					});
-					exitDelay += 40 * mpe.Info.FadeLength;
+					var faction = world.LocalPlayer == null ? null : world.LocalPlayer.Faction.InternalName;
+					Game.Sound.PlayNotification(world.Map.Rules, null, "Speech", moi.LeaveNotification, faction);
 				}
+			}
 
+			leaving = true;
+
+			var iop = world.WorldActor.TraitsImplementing<IObjectivesPanel>().FirstOrDefault();
+			var exitDelay = iop != null ? iop.ExitDelay : 0;
+			if (mpe != null)
+			{
 				Game.RunAfterDelay(exitDelay, () =>
 				{
-					if (!Game.IsCurrentWorld(world))
-						return;
-
-					Game.Disconnect();
-					Ui.ResetAll();
-					Game.LoadShellMap();
+					if (Game.IsCurrentWorld(world))
+						mpe.Fade(MenuPaletteEffect.EffectType.Black);
 				});
-			};
+				exitDelay += 40 * mpe.Info.FadeLength;
+			}
 
-			Action closeMenu = () =>
+			Game.RunAfterDelay(exitDelay, () =>
 			{
-				Ui.CloseWindow();
-				if (mpe != null)
-					mpe.Fade(MenuPaletteEffect.EffectType.None);
-				onExit();
-			};
+				if (!Game.IsCurrentWorld(world))
+					return;
 
-			Action showMenu = () => hideMenu = false;
+				Game.Disconnect();
+				Ui.ResetAll();
+				Game.LoadShellMap();
+			});
+		}
 
-			var abortMissionButton = menu.Get<ButtonWidget>("ABORT_MISSION");
-			abortMissionButton.IsVisible = () => world.Type == WorldType.Regular;
-			abortMissionButton.IsDisabled = () => leaving;
-			if (world.IsGameOver)
-				abortMissionButton.GetText = () => "Leave";
+		void ShowMenu()
+		{
+			hideMenu = false;
+		}
 
-			abortMissionButton.OnClick = () =>
+		void CloseMenu()
+		{
+			Ui.CloseWindow();
+			if (mpe != null)
+				mpe.Fade(MenuPaletteEffect.EffectType.None);
+			onExit();
+		}
+
+		ButtonWidget AddButton(string id, string text)
+		{
+			var button = buttonTemplate.Clone() as ButtonWidget;
+			var lastButton = buttons.LastOrDefault();
+			if (lastButton != null)
+			{
+				button.Bounds.X = lastButton.Bounds.X + buttonStride.X;
+				button.Bounds.Y = lastButton.Bounds.Y + buttonStride.Y;
+			}
+
+			button.Id = id;
+			button.IsDisabled = () => leaving;
+			button.GetText = () => text;
+			buttonContainer.AddChild(button);
+			buttons.Add(button);
+
+			return button;
+		}
+
+		void CreateAbortMissionButton()
+		{
+			if (world.Type != WorldType.Regular)
+				return;
+
+			var button = AddButton("ABORT_MISSION", world.IsGameOver ? "Leave" : "Abort Mission");
+
+			button.OnClick = () =>
 			{
 				hideMenu = true;
 
@@ -122,54 +213,87 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					ConfirmationDialogs.ButtonPrompt(
 						title: "Leave Mission",
 						text: "Leave this game and return to the menu?",
-						onConfirm: onQuit,
-						onCancel: showMenu,
+						onConfirm: OnQuit,
+						onCancel: ShowMenu,
 						confirmText: "Leave",
 						cancelText: "Stay",
 						otherText: "Restart",
 						onOther: restartAction);
 				}
 				else
-					onQuit();
+					OnQuit();
 			};
+		}
 
-			var exitEditorButton = menu.Get<ButtonWidget>("EXIT_EDITOR");
-			exitEditorButton.IsVisible = () => world.Type == WorldType.Editor;
-			exitEditorButton.OnClick = () =>
-			{
-				hideMenu = true;
-				ConfirmationDialogs.ButtonPrompt(
-					title: "Exit Map Editor",
-					text: "Exit and lose all unsaved changes?",
-					onConfirm: onQuit,
-					onCancel: showMenu);
-			};
+		void CreateSurrenderButton()
+		{
+			if (world.Type != WorldType.Regular || world.Map.Visibility.HasFlag(MapVisibility.MissionSelector) || world.LocalPlayer == null)
+				return;
 
 			Action onSurrender = () =>
 			{
 				world.IssueOrder(new Order("Surrender", world.LocalPlayer.PlayerActor, false));
-				closeMenu();
+				CloseMenu();
 			};
-			var surrenderButton = menu.Get<ButtonWidget>("SURRENDER");
-			surrenderButton.IsVisible = () => world.Type == WorldType.Regular;
-			surrenderButton.IsDisabled = () =>
-				world.LocalPlayer == null || world.LocalPlayer.WinState != WinState.Undefined ||
-				world.Map.Visibility.HasFlag(MapVisibility.MissionSelector) || hasError;
-			surrenderButton.OnClick = () =>
+
+			var button = AddButton("SURRENDER", "Surrender");
+			button.IsDisabled = () => world.LocalPlayer.WinState != WinState.Undefined || hasError || leaving;
+			button.OnClick = () =>
 			{
 				hideMenu = true;
 				ConfirmationDialogs.ButtonPrompt(
 					title: "Surrender",
 					text: "Are you sure you want to surrender?",
 					onConfirm: onSurrender,
-					onCancel: showMenu,
+					onCancel: ShowMenu,
 					confirmText: "Surrender",
 					cancelText: "Stay");
 			};
+		}
 
-			var saveMapButton = menu.Get<ButtonWidget>("SAVE_MAP");
-			saveMapButton.IsVisible = () => world.Type == WorldType.Editor;
-			saveMapButton.OnClick = () =>
+		void CreateMusicButton()
+		{
+			var button = AddButton("MUSIC", "Music");
+			button.OnClick = () =>
+			{
+				hideMenu = true;
+				Ui.OpenWindow("MUSIC_PANEL", new WidgetArgs()
+				{
+					{ "onExit", () => hideMenu = false },
+					{ "world", world }
+				});
+			};
+		}
+
+		void CreateSettingsButton()
+		{
+			var button = AddButton("SETTINGS", "Settings");
+			button.OnClick = () =>
+			{
+				hideMenu = true;
+				Ui.OpenWindow("SETTINGS_PANEL", new WidgetArgs()
+				{
+					{ "world", world },
+					{ "worldRenderer", worldRenderer },
+					{ "onExit", () => hideMenu = false },
+				});
+			};
+		}
+
+		void CreateResumeButton()
+		{
+			var button = AddButton("RESUME", world.IsGameOver ? "Return to map" : "Resume");
+			button.Key = modData.Hotkeys["escape"];
+			button.OnClick = CloseMenu;
+		}
+
+		void CreateSaveMapButton()
+		{
+			if (world.Type != WorldType.Editor)
+				return;
+
+			var button = AddButton("SAVE_MAP", "Save Map");
+			button.OnClick = () =>
 			{
 				hideMenu = true;
 				var editorActorLayer = world.WorldActor.Trait<EditorActorLayer>();
@@ -182,49 +306,23 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					{ "actorDefinitions", editorActorLayer.Save() }
 				});
 			};
+		}
 
-			var musicButton = menu.Get<ButtonWidget>("MUSIC");
-			musicButton.IsDisabled = () => leaving;
-			musicButton.OnClick = () =>
+		void CreateExitEditorButton()
+		{
+			if (world.Type != WorldType.Editor)
+				return;
+
+			var button = AddButton("EXIT_EDITOR", "Exit Map Editor");
+			button.OnClick = () =>
 			{
 				hideMenu = true;
-				Ui.OpenWindow("MUSIC_PANEL", new WidgetArgs()
-				{
-					{ "onExit", () => hideMenu = false },
-					{ "world", world }
-				});
+				ConfirmationDialogs.ButtonPrompt(
+					title: "Exit Map Editor",
+					text: "Exit and lose all unsaved changes?",
+					onConfirm: OnQuit,
+					onCancel: ShowMenu);
 			};
-
-			var settingsButton = widget.Get<ButtonWidget>("SETTINGS");
-			settingsButton.IsDisabled = () => leaving;
-			settingsButton.OnClick = () =>
-			{
-				hideMenu = true;
-				Ui.OpenWindow("SETTINGS_PANEL", new WidgetArgs()
-				{
-					{ "world", world },
-					{ "worldRenderer", worldRenderer },
-					{ "onExit", () => hideMenu = false },
-				});
-			};
-
-			var resumeButton = menu.Get<ButtonWidget>("RESUME");
-			resumeButton.IsDisabled = () => leaving;
-			if (world.IsGameOver)
-				resumeButton.GetText = () => "Return to map";
-
-			resumeButton.OnClick = closeMenu;
-
-			var panelRoot = widget.GetOrNull("PANEL_ROOT");
-			if (panelRoot != null && world.Type != WorldType.Editor)
-			{
-				var gameInfoPanel = Game.LoadWidget(world, "GAME_INFO_PANEL", panelRoot, new WidgetArgs()
-				{
-					{ "activePanel", activePanel }
-				});
-
-				gameInfoPanel.IsVisible = () => !hideMenu;
-			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -49,6 +49,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				{ "ABORT_MISSION", CreateAbortMissionButton },
 				{ "SURRENDER", CreateSurrenderButton },
+				{ "LOAD_GAME", CreateLoadGameButton },
+				{ "SAVE_GAME", CreateSaveGameButton },
 				{ "MUSIC", CreateMusicButton },
 				{ "SETTINGS", CreateSettingsButton },
 				{ "RESUME", CreateResumeButton },
@@ -248,6 +250,46 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					onCancel: ShowMenu,
 					confirmText: "Surrender",
 					cancelText: "Stay");
+			};
+		}
+
+		void CreateLoadGameButton()
+		{
+			if (world.Type != WorldType.Regular || !world.LobbyInfo.GlobalSettings.GameSavesEnabled || world.IsReplay)
+				return;
+
+			var button = AddButton("LOAD_GAME", "Load Game");
+			button.IsDisabled = () => leaving || !GameSaveBrowserLogic.IsLoadPanelEnabled(modData.Manifest);
+			button.OnClick = () =>
+			{
+				hideMenu = true;
+				Ui.OpenWindow("GAMESAVE_BROWSER_PANEL", new WidgetArgs
+				{
+					{ "onExit", () => hideMenu = false },
+					{ "onStart", CloseMenu },
+					{ "isSavePanel", false },
+					{ "world", null }
+				});
+			};
+		}
+
+		void CreateSaveGameButton()
+		{
+			if (world.Type != WorldType.Regular || !world.LobbyInfo.GlobalSettings.GameSavesEnabled || world.IsReplay)
+				return;
+
+			var button = AddButton("SAVE_GAME", "Save Game");
+			button.IsDisabled = () => hasError || leaving || !world.Players.Any(p => p.Playable && p.WinState == WinState.Undefined);
+			button.OnClick = () =>
+			{
+				hideMenu = true;
+				Ui.OpenWindow("GAMESAVE_BROWSER_PANEL", new WidgetArgs
+				{
+					{ "onExit", () => hideMenu = false },
+					{ "onStart", () => { } },
+					{ "isSavePanel", true },
+					{ "world", world }
+				});
 			};
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	{
 		protected enum MenuType { Main, Singleplayer, Extras, MapEditor, SystemInfoPrompt, None }
 
-		protected enum MenuPanel { None, Missions, Skirmish, Multiplayer, MapEditor, Replays }
+		protected enum MenuPanel { None, Missions, Skirmish, Multiplayer, MapEditor, Replays, GameSaves }
 
 		protected MenuType menuType = MenuType.Main;
 		readonly Widget rootMenu;
@@ -126,6 +126,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var skirmishButton = singleplayerMenu.Get<ButtonWidget>("SKIRMISH_BUTTON");
 			skirmishButton.OnClick = StartSkirmishGame;
 			skirmishButton.Disabled = !hasMaps;
+
+			var loadButton = singleplayerMenu.Get<ButtonWidget>("LOAD_BUTTON");
+			loadButton.IsDisabled = () => !GameSaveBrowserLogic.IsLoadPanelEnabled(modData.Manifest);
+			loadButton.OnClick = OpenGameSaveBrowserPanel;
 
 			singleplayerMenu.Get<ButtonWidget>("BACK_BUTTON").OnClick = () => SwitchMenu(MenuType.Main);
 
@@ -500,6 +504,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			});
 		}
 
+		void OpenGameSaveBrowserPanel()
+		{
+			SwitchMenu(MenuType.None);
+			Ui.OpenWindow("GAMESAVE_BROWSER_PANEL", new WidgetArgs
+			{
+				{ "onExit", () => SwitchMenu(MenuType.Singleplayer) },
+				{ "onStart", () => { RemoveShellmapUI(); lastGameState = MenuPanel.GameSaves; } },
+				{ "isSavePanel", false },
+				{ "world", null }
+			});
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing)
@@ -534,6 +550,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				case MenuPanel.MapEditor:
 					SwitchMenu(MenuType.MapEditor);
+					break;
+
+				case MenuPanel.GameSaves:
+					SwitchMenu(MenuType.Singleplayer);
 					break;
 			}
 

--- a/mods/cnc/audio/notifications.yaml
+++ b/mods/cnc/audio/notifications.yaml
@@ -39,7 +39,9 @@ Speech:
 		Repairing: repair1
 		SelectTarget: select1
 		SilosNeeded: silos1
-		StartGame:
+		StartGame: 
+		GameLoaded:
+		GameSaved: scold1
 		Training: bldging1
 		UnitDestroyed: dead1
 		UnitLost: unitlost

--- a/mods/cnc/chrome/dialogs.yaml
+++ b/mods/cnc/chrome/dialogs.yaml
@@ -262,7 +262,7 @@ Container@TEXT_INPUT_PROMPT:
 			X: PARENT_RIGHT - 160
 			Y: PARENT_BOTTOM - 1
 			Width: 160
-			Height: 30
+			Height: 34
 			Text: OK
 			Font: Bold
 			Key: return
@@ -270,7 +270,7 @@ Container@TEXT_INPUT_PROMPT:
 			X: 0
 			Y: PARENT_BOTTOM - 1
 			Width: 160
-			Height: 30
+			Height: 35
 			Text: Cancel
 			Font: Bold
 			Key: escape

--- a/mods/cnc/chrome/gamesave-browser.yaml
+++ b/mods/cnc/chrome/gamesave-browser.yaml
@@ -1,0 +1,115 @@
+Container@GAMESAVE_BROWSER_PANEL:
+	Logic: GameSaveBrowserLogic
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 600
+	Height: 400
+	Children:
+		Label@LOAD_TITLE:
+			Width: PARENT_RIGHT
+			Y: 0 - 25
+			Font: BigBold
+			Contrast: true
+			Align: Center
+			Text: Load game
+			Visible: False
+		Label@SAVE_TITLE:
+			Width: PARENT_RIGHT
+			Y: 0 - 25
+			Font: BigBold
+			Contrast: true
+			Align: Center
+			Text: Save game
+			Visible: False
+		Background@bg:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Background: panel-black
+			Children:
+				ScrollPanel@GAME_LIST:
+					X: 10
+					Y: 10
+					Width: PARENT_RIGHT - 20
+					Height: PARENT_BOTTOM - 20
+					Children:
+						ScrollItem@NEW_TEMPLATE:
+							Width: PARENT_RIGHT - 27
+							Height: 25
+							X: 2
+							Visible: false
+							Children:
+								Label@TITLE:
+									Width: PARENT_RIGHT
+									Height: PARENT_BOTTOM
+									Align: Center
+									Text: [CREATE NEW FILE]
+						ScrollItem@GAME_TEMPLATE:
+							Width: PARENT_RIGHT - 27
+							Height: 25
+							X: 2
+							Visible: false
+							Children:
+								Label@TITLE:
+									X: 10
+									Width: PARENT_RIGHT - 200 - 10
+									Height: 25
+								Label@DATE:
+									X: PARENT_RIGHT - WIDTH - 10
+									Width: 200
+									Height: 25
+									Align: Right
+				Container@SAVE_WIDGETS:
+					X: 10
+					Y: PARENT_BOTTOM - 35
+					Width: PARENT_RIGHT - 20
+					Height: 35
+					Visible: False
+					Children:
+						TextField@SAVE_TEXTFIELD:
+							Width: PARENT_RIGHT
+							Height: 25
+							Type: Filename
+				Button@CANCEL_BUTTON:
+					Key: escape
+					X: 0
+					Y: PARENT_BOTTOM - 1
+					Width: 100
+					Height: 35
+					Text: Back
+				Button@DELETE_ALL_BUTTON:
+					X: PARENT_RIGHT - 330 - WIDTH
+					Y: PARENT_BOTTOM - 1
+					Width: 100
+					Height: 35
+					Text: Delete All
+				Button@DELETE_BUTTON:
+					X: PARENT_RIGHT - 220 - WIDTH
+					Y: PARENT_BOTTOM - 1
+					Width: 100
+					Height: 35
+					Text: Delete
+					Key: Delete
+				Button@RENAME_BUTTON:
+					X: PARENT_RIGHT - 110 - WIDTH
+					Y: PARENT_BOTTOM - 1
+					Width: 100
+					Height: 35
+					Text: Rename
+					Key: F2
+				Button@LOAD_BUTTON:
+					Key: return
+					X: PARENT_RIGHT - WIDTH
+					Y: PARENT_BOTTOM - 1
+					Width: 100
+					Height: 35
+					Text: Load
+					Visible: False
+				Button@SAVE_BUTTON:
+					Key: return
+					X: PARENT_RIGHT - WIDTH
+					Y: PARENT_BOTTOM - 1
+					Width: 100
+					Height: 35
+					Text: Save
+					Visible: False
+				TooltipContainer@TOOLTIP_CONTAINER:

--- a/mods/cnc/chrome/gamesave-loading.yaml
+++ b/mods/cnc/chrome/gamesave-loading.yaml
@@ -1,0 +1,52 @@
+Container@GAMESAVE_LOADING_SCREEN:
+	Logic: GameSaveLoadingLogic
+	Width: WINDOW_RIGHT
+	Height: WINDOW_BOTTOM
+	Children:
+		LogicKeyListener@CANCEL_HANDLER:
+		Image@NOD:
+			X: WINDOW_RIGHT / 2 - 384
+			Y: (WINDOW_BOTTOM - 256) / 2
+			ImageCollection: logos
+			ImageName: nod-load
+		Image@GDI:
+			X: WINDOW_RIGHT / 2 + 128
+			Y: (WINDOW_BOTTOM - 256) / 2
+			ImageCollection: logos
+			ImageName: gdi-load
+		Image@EVA:
+			X: WINDOW_RIGHT - 128 - 43
+			Y: 43
+			Width: 128
+			Height: 64
+			ImageCollection: logos
+			ImageName: eva
+		Label@VERSION_LABEL:
+			X: WINDOW_RIGHT - 128 - 43
+			Y: 115
+			Width: 128
+			Align: Center
+			Shadow: true
+		Background@BORDER:
+			Width: WINDOW_RIGHT
+			Height: WINDOW_BOTTOM
+			Background: shellmapborder
+		Label@TITLE:
+			Width: WINDOW_RIGHT
+			Y: 3 * WINDOW_BOTTOM / 4 - 30
+			Height: 25
+			Font: Bold
+			Align: Center
+			Text: Loading Saved Game
+		ProgressBar@PROGRESS:
+			X: (WINDOW_RIGHT - 500) / 2
+			Y: 3 * WINDOW_BOTTOM / 4
+			Width: 500
+			Height: 20
+		Label@DESC:
+			Width: WINDOW_RIGHT
+			Y: 3 * WINDOW_BOTTOM / 4 + 20
+			Height: 25
+			Font: Regular
+			Align: Center
+			Text: Press Escape to cancel loading and return to the main menu

--- a/mods/cnc/chrome/ingame-menu.yaml
+++ b/mods/cnc/chrome/ingame-menu.yaml
@@ -2,6 +2,8 @@ Container@INGAME_MENU:
 	Width: WINDOW_RIGHT
 	Height: WINDOW_BOTTOM
 	Logic: IngameMenuLogic
+		Buttons: EXIT_EDITOR, SAVE_MAP, ABORT_MISSION, SURRENDER, LOAD_GAME, SAVE_GAME, MUSIC, SETTINGS, RESUME
+		ButtonStride: 130, 0
 	Children:
 		Image@EVA:
 			X: WINDOW_RIGHT - 128 - 43
@@ -24,49 +26,9 @@ Container@INGAME_MENU:
 		Container@MENU_BUTTONS:
 			X: (WINDOW_RIGHT - WIDTH) / 2
 			Y: WINDOW_BOTTOM - 33 - HEIGHT - 10
-			Width: 740
+			Width: 120
 			Height: 35
 			Children:
-				Button@ABORT_MISSION:
-					X: 0
-					Y: 0
-					Width: 140
+				Button@BUTTON_TEMPLATE:
+					Width: 120
 					Height: 35
-					Text: Abort Mission
-				Button@EXIT_EDITOR:
-					X: 0
-					Y: 0
-					Width: 140
-					Height: 35
-					Text: Exit Map Editor
-				Button@SURRENDER:
-					X: 150
-					Y: 0
-					Width: 140
-					Height: 35
-					Text: Surrender
-				Button@SAVE_MAP:
-					X: 150
-					Y: 0
-					Width: 140
-					Height: 35
-					Text: Save Map
-				Button@MUSIC:
-					X: 300
-					Y: 0
-					Width: 140
-					Height: 35
-					Text: Music
-				Button@SETTINGS:
-					X: 450
-					Y: 0
-					Width: 140
-					Height: 35
-					Text: Settings
-				Button@RESUME:
-					Key: escape
-					X: 600
-					Y: 0
-					Width: 140
-					Height: 35
-					Text: Resume

--- a/mods/cnc/chrome/mainmenu.yaml
+++ b/mods/cnc/chrome/mainmenu.yaml
@@ -119,6 +119,12 @@ Container@MENU_BACKGROUND:
 							Width: 140
 							Height: 35
 							Text: Missions
+						Button@LOAD_BUTTON:
+							X: 300
+							Y: 0
+							Width: 140
+							Height: 35
+							Text: Load
 						Button@BACK_BUTTON:
 							Key: escape
 							X: 450

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -107,6 +107,7 @@ ChromeLayout:
 	cnc|chrome/color-picker.yaml
 	cnc|chrome/mapchooser.yaml
 	cnc|chrome/replaybrowser.yaml
+	cnc|chrome/gamesave-loading.yaml
 	cnc|chrome/ingame.yaml
 	cnc|chrome/ingame-chat.yaml
 	cnc|chrome/ingame-menu.yaml

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -107,6 +107,7 @@ ChromeLayout:
 	cnc|chrome/color-picker.yaml
 	cnc|chrome/mapchooser.yaml
 	cnc|chrome/replaybrowser.yaml
+	cnc|chrome/gamesave-browser.yaml
 	cnc|chrome/gamesave-loading.yaml
 	cnc|chrome/ingame.yaml
 	cnc|chrome/ingame-chat.yaml

--- a/mods/cnc/rules/player.yaml
+++ b/mods/cnc/rules/player.yaml
@@ -59,3 +59,4 @@ Player:
 	ResourceStorageWarning:
 	PlayerExperience:
 	ConditionManager:
+	GameSaveViewportManager:

--- a/mods/common/chrome/gamesave-browser.yaml
+++ b/mods/common/chrome/gamesave-browser.yaml
@@ -1,0 +1,116 @@
+Background@GAMESAVE_BROWSER_PANEL:
+	Logic: GameSaveBrowserLogic
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 600
+	Height: 400
+	Children:
+		Label@LOAD_TITLE:
+			Width: PARENT_RIGHT
+			Y: 20
+			Height: 25
+			Font: Bold
+			Align: Center
+			Text: Load game
+			Visible: False
+		Label@SAVE_TITLE:
+			Width: PARENT_RIGHT
+			Y: 20
+			Height: 25
+			Font: Bold
+			Align: Center
+			Text: Save game
+			Visible: False
+		ScrollPanel@GAME_LIST:
+			X: 20
+			Y: 50
+			Width: PARENT_RIGHT - 40
+			Height: PARENT_BOTTOM - 102
+			Children:
+				ScrollItem@NEW_TEMPLATE:
+					Width: PARENT_RIGHT - 27
+					Height: 25
+					X: 2
+					Visible: false
+					Children:
+						Label@TITLE:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Align: Center
+							Text: [CREATE NEW FILE]
+				ScrollItem@GAME_TEMPLATE:
+					Width: PARENT_RIGHT - 27
+					Height: 25
+					X: 2
+					Visible: false
+					Children:
+						Label@TITLE:
+							X: 10
+							Width: PARENT_RIGHT - 200 - 10
+							Height: 25
+						Label@DATE:
+							X: PARENT_RIGHT - WIDTH - 10
+							Width: 200
+							Height: 25
+							Align: Right
+		Container@SAVE_WIDGETS:
+			X: 20
+			Y: PARENT_BOTTOM - 77
+			Width: PARENT_RIGHT - 40
+			Height: 32
+			Visible: False
+			Children:
+				TextField@SAVE_TEXTFIELD:
+					Width: PARENT_RIGHT
+					Height: 25
+					Type: Filename
+		Button@CANCEL_BUTTON:
+			Key: escape
+			X: 20
+			Y: PARENT_BOTTOM - 45
+			Width: 100
+			Height: 25
+			Text: Back
+			Font: Bold
+		Button@DELETE_ALL_BUTTON:
+			X: PARENT_RIGHT - 350 - WIDTH
+			Y: PARENT_BOTTOM - 45
+			Width: 100
+			Height: 25
+			Text: Delete All
+			Font: Bold
+		Button@DELETE_BUTTON:
+			X: PARENT_RIGHT - 240 - WIDTH
+			Y: PARENT_BOTTOM - 45
+			Width: 100
+			Height: 25
+			Text: Delete
+			Font: Bold
+			Key: Delete
+		Button@RENAME_BUTTON:
+			X: PARENT_RIGHT - 130 - WIDTH
+			Y: PARENT_BOTTOM - 45
+			Width: 100
+			Height: 25
+			Text: Rename
+			Font: Bold
+			Key: F2
+		Button@LOAD_BUTTON:
+			Key: return
+			X: PARENT_RIGHT - WIDTH - 20
+			Y: PARENT_BOTTOM - 45
+			Width: 100
+			Height: 25
+			Text: Load
+			Font: Bold
+			Visible: False
+		Button@SAVE_BUTTON:
+			Key: return
+			X: PARENT_RIGHT - WIDTH - 20
+			Y: PARENT_BOTTOM - 45
+			Width: 100
+			Height: 25
+			Text: Save
+			Font: Bold
+			Visible: False
+		TooltipContainer@TOOLTIP_CONTAINER:

--- a/mods/common/chrome/gamesave-loading.yaml
+++ b/mods/common/chrome/gamesave-loading.yaml
@@ -1,0 +1,35 @@
+Container@GAMESAVE_LOADING_SCREEN:
+	Logic: GameSaveLoadingLogic
+	Width: WINDOW_RIGHT
+	Height: WINDOW_BOTTOM
+	Children:
+		LogicKeyListener@CANCEL_HANDLER:
+		Background@STRIPE:
+			Y: (WINDOW_BOTTOM - HEIGHT) / 2
+			Width: WINDOW_RIGHT
+			Height: 256
+			Background: loadscreen-stripe
+		Image@LOGO:
+			X: (WINDOW_RIGHT - 256) / 2
+			Y: (WINDOW_BOTTOM - 256) / 2
+			ImageCollection: logos
+			ImageName: logo
+		Label@TITLE:
+			Width: WINDOW_RIGHT
+			Y: 3 * WINDOW_BOTTOM / 4 - 30
+			Height: 25
+			Font: Bold
+			Align: Center
+			Text: Loading Saved Game
+		ProgressBar@PROGRESS:
+			X: (WINDOW_RIGHT - 500) / 2
+			Y: 3 * WINDOW_BOTTOM / 4
+			Width: 500
+			Height: 20
+		Label@DESC:
+			Width: WINDOW_RIGHT
+			Y: 3 * WINDOW_BOTTOM / 4 + 20
+			Height: 25
+			Font: Regular
+			Align: Center
+			Text: Press Escape to cancel loading and return to the main menu

--- a/mods/common/chrome/ingame-menu.yaml
+++ b/mods/common/chrome/ingame-menu.yaml
@@ -2,6 +2,8 @@ Container@INGAME_MENU:
 	Width: WINDOW_RIGHT
 	Height: WINDOW_BOTTOM
 	Logic: IngameMenuLogic
+		Buttons: RESUME, LOAD_GAME, SAVE_GAME, SETTINGS, MUSIC, SURRENDER, ABORT_MISSION, SAVE_MAP, EXIT_EDITOR
+		ButtonStride: 0, 40
 	Children:
 		Background@BORDER:
 			X: 0 - 15
@@ -27,7 +29,7 @@ Container@INGAME_MENU:
 			X: 13 + (WINDOW_RIGHT - 522) / 4 - WIDTH / 2
 			Y: (WINDOW_BOTTOM - HEIGHT) / 2
 			Width: 200
-			Height: 295
+			Height: 120
 			Children:
 				Label@LABEL_TITLE:
 					X: (PARENT_RIGHT - WIDTH) / 2
@@ -37,53 +39,9 @@ Container@INGAME_MENU:
 					Text: Options
 					Align: Center
 					Font: Bold
-				Button@RESUME:
+				Button@BUTTON_TEMPLATE:
 					X: (PARENT_RIGHT - WIDTH) / 2
 					Y: 60
 					Width: 140
 					Height: 30
-					Text: Resume
-					Font: Bold
-					Key: escape
-				Button@SETTINGS:
-					X: (PARENT_RIGHT - WIDTH) / 2
-					Y: 100
-					Width: 140
-					Height: 30
-					Text: Settings
-					Font: Bold
-				Button@MUSIC:
-					X: (PARENT_RIGHT - WIDTH) / 2
-					Y: 140
-					Width: 140
-					Height: 30
-					Text: Music
-					Font: Bold
-				Button@SURRENDER:
-					X: (PARENT_RIGHT - WIDTH) / 2
-					Y: 180
-					Width: 140
-					Height: 30
-					Text: Surrender
-					Font: Bold
-				Button@SAVE_MAP:
-					X: (PARENT_RIGHT - WIDTH) / 2
-					Y: 180
-					Width: 140
-					Height: 30
-					Text: Save Map
-					Font: Bold
-				Button@ABORT_MISSION:
-					X: (PARENT_RIGHT - WIDTH) / 2
-					Y: 220
-					Width: 140
-					Height: 30
-					Text: Abort Mission
-					Font: Bold
-				Button@EXIT_EDITOR:
-					X: (PARENT_RIGHT - WIDTH) / 2
-					Y: 220
-					Width: 140
-					Height: 30
-					Text: Exit Map Editor
 					Font: Bold

--- a/mods/common/chrome/mainmenu.yaml
+++ b/mods/common/chrome/mainmenu.yaml
@@ -114,6 +114,13 @@ Container@MAINMENU:
 							Height: 30
 							Text: Missions
 							Font: Bold
+						Button@LOAD_BUTTON:
+							X: PARENT_RIGHT / 2 - WIDTH / 2
+							Y: 140
+							Width: 140
+							Height: 30
+							Text: Load
+							Font: Bold
 						Button@BACK_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Key: escape

--- a/mods/d2k/chrome.yaml
+++ b/mods/d2k/chrome.yaml
@@ -638,4 +638,10 @@ scrollheader-selected: dialog.png
 	corner-br: 639,127,1,1
 
 dropdown: dialog.png
-    separator: 512,1,1,19
+	separator: 512,1,1,19
+
+logos: loadscreen.png
+	logo: 0,0,256,256
+
+loadscreen-stripe: loadscreen.png
+	background: 256,0,256,256

--- a/mods/d2k/chrome/ingame-menu.yaml
+++ b/mods/d2k/chrome/ingame-menu.yaml
@@ -2,6 +2,8 @@ Container@INGAME_MENU:
 	Width: WINDOW_RIGHT
 	Height: WINDOW_BOTTOM
 	Logic: IngameMenuLogic
+		Buttons: RESUME, LOAD_GAME, SAVE_GAME, SETTINGS, MUSIC, SURRENDER, ABORT_MISSION, SAVE_MAP, EXIT_EDITOR
+		ButtonStride: 0, 40
 	Children:
 		Label@VERSION_LABEL:
 			X: WINDOW_RIGHT - 10
@@ -14,7 +16,7 @@ Container@INGAME_MENU:
 			X: 13 + (WINDOW_RIGHT - 522) / 4 - WIDTH / 2
 			Y: (WINDOW_BOTTOM - HEIGHT) / 2
 			Width: 200
-			Height: 295
+			Height: 120
 			Children:
 				Label@LABEL_TITLE:
 					X: (PARENT_RIGHT - WIDTH) / 2
@@ -24,53 +26,9 @@ Container@INGAME_MENU:
 					Text: Options
 					Align: Center
 					Font: Bold
-				Button@RESUME:
+				Button@BUTTON_TEMPLATE:
 					X: (PARENT_RIGHT - WIDTH) / 2
 					Y: 60
 					Width: 140
 					Height: 30
-					Text: Resume
-					Font: Bold
-					Key: escape
-				Button@SETTINGS:
-					X: (PARENT_RIGHT - WIDTH) / 2
-					Y: 100
-					Width: 140
-					Height: 30
-					Text: Settings
-					Font: Bold
-				Button@MUSIC:
-					X: (PARENT_RIGHT - WIDTH) / 2
-					Y: 140
-					Width: 140
-					Height: 30
-					Text: Music
-					Font: Bold
-				Button@SURRENDER:
-					X: (PARENT_RIGHT - WIDTH) / 2
-					Y: 180
-					Width: 140
-					Height: 30
-					Text: Surrender
-					Font: Bold
-				Button@SAVE_MAP:
-					X: (PARENT_RIGHT - WIDTH) / 2
-					Y: 180
-					Width: 140
-					Height: 30
-					Text: Save Map
-					Font: Bold
-				Button@ABORT_MISSION:
-					X: (PARENT_RIGHT - WIDTH) / 2
-					Y: 220
-					Width: 140
-					Height: 30
-					Text: Abort Mission
-					Font: Bold
-				Button@EXIT_EDITOR:
-					X: (PARENT_RIGHT - WIDTH) / 2
-					Y: 220
-					Width: 140
-					Height: 30
-					Text: Exit Map Editor
 					Font: Bold

--- a/mods/d2k/chrome/mainmenu.yaml
+++ b/mods/d2k/chrome/mainmenu.yaml
@@ -101,6 +101,13 @@ Container@MAINMENU:
 							Height: 30
 							Text: Missions
 							Font: Bold
+						Button@LOAD_BUTTON:
+							X: PARENT_RIGHT / 2 - WIDTH / 2
+							Y: 140
+							Width: 140
+							Height: 30
+							Text: Load
+							Font: Bold
 						Button@BACK_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Key: escape

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -107,6 +107,7 @@ ChromeLayout:
 	common|chrome/confirmation-dialogs.yaml
 	common|chrome/editor.yaml
 	common|chrome/replaybrowser.yaml
+	common|chrome/gamesave-browser.yaml
 	common|chrome/gamesave-loading.yaml
 
 Weapons:

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -107,6 +107,7 @@ ChromeLayout:
 	common|chrome/confirmation-dialogs.yaml
 	common|chrome/editor.yaml
 	common|chrome/replaybrowser.yaml
+	common|chrome/gamesave-loading.yaml
 
 Weapons:
 	d2k|weapons/debris.yaml

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -145,3 +145,4 @@ Player:
 		AdviceInterval: 26
 	PlayerExperience:
 	ConditionManager:
+	GameSaveViewportManager:

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -233,6 +233,7 @@ World:
 		PanelName: SKIRMISH_STATS
 	LoadWidgetAtGameStart:
 	ScriptTriggers:
+	StartGameNotification:
 
 EditorWorld:
 	Inherits: ^BaseWorld

--- a/mods/ra/audio/notifications.yaml
+++ b/mods/ra/audio/notifications.yaml
@@ -53,8 +53,6 @@ Speech:
 		MercenaryRescued: mercr1
 		MissionAccomplished: misnwon1
 		MissionFailed: misnlst1
-		MissionLoaded: load1
-		MissionSaved: save1
 		MissionTimerInitialised: mtimein1
 		NavalUnitLost: navylst1
 		NewOptions: newopt1
@@ -85,6 +83,8 @@ Speech:
 		SovietReinforcementsArrived: sovrein1
 		SpyPlaneReady: spypln1
 		StartGame: bctrinit
+		GameLoaded: load1
+		GameSaved: save1
 		StructureDestroyed: strckil1
 		StructureSold: strusld1
 		TanyaFreed: tanyaf1

--- a/mods/ra/chrome.yaml
+++ b/mods/ra/chrome.yaml
@@ -1046,6 +1046,9 @@ scrollheader-selected: dialog.png
 logos: loadscreen.png
 	logo: 0,0,256,256
 
+loadscreen-stripe: loadscreen.png
+	background: 256,0,256,256
+
 mainmenu-border: dialog.png
 	border-r: 728,427,40,40
 	border-l: 648,427,40,40

--- a/mods/ra/chrome/gamesave-loading.yaml
+++ b/mods/ra/chrome/gamesave-loading.yaml
@@ -1,0 +1,37 @@
+Container@GAMESAVE_LOADING_SCREEN:
+	Logic: GameSaveLoadingLogic
+	Width: WINDOW_RIGHT
+	Height: WINDOW_BOTTOM
+	Children:
+		LogicKeyListener@CANCEL_HANDLER:
+		Background@STRIPE:
+			Y: (WINDOW_BOTTOM - HEIGHT) / 2
+			Width: WINDOW_RIGHT
+			Height: 256
+			Background: loadscreen-stripe
+		Image@LOGO:
+			X: (WINDOW_RIGHT - 256) / 2
+			Y: (WINDOW_BOTTOM - 256) / 2
+			ImageCollection: logos
+			ImageName: logo
+		Label@TITLE:
+			Width: WINDOW_RIGHT
+			Y: 3 * WINDOW_BOTTOM / 4 - 30
+			Height: 25
+			Font: Bold
+			Align: Center
+			Text: Loading Saved Game
+		ProgressBar@PROGRESS:
+			X: (WINDOW_RIGHT - 500) / 2
+			Y: 3 * WINDOW_BOTTOM / 4
+			Width: 500
+			Height: 20
+			Background: observer-scrollpanel-button-pressed
+			Bar: observer-scrollpanel-button
+		Label@DESC:
+			Width: WINDOW_RIGHT
+			Y: 3 * WINDOW_BOTTOM / 4 + 20
+			Height: 25
+			Font: Regular
+			Align: Center
+			Text: Press Escape to cancel loading and return to the main menu

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -114,6 +114,7 @@ ChromeLayout:
 	common|chrome/multiplayer-directconnect.yaml
 	common|chrome/connection.yaml
 	common|chrome/replaybrowser.yaml
+	common|chrome/gamesave-browser.yaml
 	ra|chrome/gamesave-loading.yaml
 	common|chrome/dropdowns.yaml
 	common|chrome/musicplayer.yaml

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -114,6 +114,7 @@ ChromeLayout:
 	common|chrome/multiplayer-directconnect.yaml
 	common|chrome/connection.yaml
 	common|chrome/replaybrowser.yaml
+	ra|chrome/gamesave-loading.yaml
 	common|chrome/dropdowns.yaml
 	common|chrome/musicplayer.yaml
 	common|chrome/tooltips.yaml

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -144,3 +144,4 @@ Player:
 	ResourceStorageWarning:
 	PlayerExperience:
 	ConditionManager:
+	GameSaveViewportManager:

--- a/mods/ts/audio/speech-generic.yaml
+++ b/mods/ts/audio/speech-generic.yaml
@@ -64,6 +64,8 @@ Speech:
 		SpyKilledMissionFailed: 01-n284
 		SpyLostMissionFailed: 01-n210
 		StartGame: 00-i200
+		GameLoaded: 00-i200
+		GameSaved:
 		StructureSold: 00-i228
 		SubterraneanUnitDetected: 00-i174
 		TertiaryObjectiveAchieved: 00-i104

--- a/mods/ts/chrome.yaml
+++ b/mods/ts/chrome.yaml
@@ -932,3 +932,9 @@ mainmenu-border: dialog.png
 
 dropdown: dialog.png
 	separator: 512,1,1,19
+
+logos: loadscreen.png
+	logo: 0,0,256,256
+
+loadscreen-stripe: loadscreen.png
+	background: 256,0,256,256

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -163,6 +163,7 @@ ChromeLayout:
 	common|chrome/multiplayer-directconnect.yaml
 	common|chrome/connection.yaml
 	common|chrome/replaybrowser.yaml
+	common|chrome/gamesave-browser.yaml
 	common|chrome/gamesave-loading.yaml
 	ts|chrome/dropdowns.yaml
 	common|chrome/musicplayer.yaml

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -163,6 +163,7 @@ ChromeLayout:
 	common|chrome/multiplayer-directconnect.yaml
 	common|chrome/connection.yaml
 	common|chrome/replaybrowser.yaml
+	common|chrome/gamesave-loading.yaml
 	ts|chrome/dropdowns.yaml
 	common|chrome/musicplayer.yaml
 	common|chrome/tooltips.yaml

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -120,3 +120,4 @@ Player:
 	ResourceStorageWarning:
 	PlayerExperience:
 	ConditionManager:
+	GameSaveViewportManager:


### PR DESCRIPTION
This PR implements game saving and loading using order resimulation.

This implements a couple of tricks to speed the process up vs replays:
 * World rendering is disabled, and UI rendering capped at 5 FPS
 * Sync calculations are disabled until the very end

Also note that chat and other immediate orders are not saved (to save confusion when clients change in MP saves).

On my machine I see a 30-40x real time restoration for one of the TD campaign missions.

Another big difference from replays is that traits can store arbitrary data that is returned on load - this is used to restore the viewport and selection groups. In the future we could expand on this if we want to implement a proper save/load using serialization.

Saves are enabled for campaign missions, and compatible with (but disabled for) skirmishes. A followup PR will enable skirmish savegames after implementing `IGameSaveTraitData` on the bot modules to properly restore their state.

This also lays the groundwork for multiplayer saves, with several TODOs noting the remaining work to implement these.

Closes #2743.
Supersedes #6287.