### PR TITLE
Make Queue Groups work with ClassicProductionQueue

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ClassicProductionLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ClassicProductionLogic.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			// Classic production queues are initialized at game start, and then never change.
 			var queues = world.LocalPlayer.PlayerActor.TraitsImplementing<ProductionQueue>()
-				.Where(q => q.Info.Type == button.ProductionGroup)
+				.Where(q => (q.Info.Group ?? q.Info.Type) == button.ProductionGroup)
 				.ToArray();
 
 			Action<bool> selectTab = reverse =>


### PR DESCRIPTION
This change was necessary for the General's Power stuff i used in Generals Alpha. So i can have seperate ClassicProductionQueues per faction which accessed from the same button. The queues are faction specific  so you could only get one at a time anyway.