### PR TITLE
Fix production of dummy actors from producers without Exit trait

### DIFF
--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -126,7 +126,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (exit != null || self.OccupiesSpace == null)
 			{
-				DoProduction(self, producee, exit.Info, productionType, inits);
+				DoProduction(self, producee, exit == null ? null : exit.Info, productionType, inits);
 
 				return true;
 			}

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var init in inits)
 				td.Add(init);
 
-			if (exitinfo != null && self.OccupiesSpace != null)
+			if (exitinfo != null && self.OccupiesSpace != null && producee.HasTraitInfo<IOccupySpaceInfo>())
 			{
 				exit = self.Location + exitinfo.ExitCell;
 				var spawn = self.CenterPosition + exitinfo.SpawnOffset;
@@ -124,7 +124,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Pick a spawn/exit point pair
 			var exit = SelectExit(self, producee, productionType);
 
-			if (exit != null || self.OccupiesSpace == null)
+			if (exit != null || self.OccupiesSpace == null || !producee.HasTraitInfo<IOccupySpaceInfo>())
 			{
 				DoProduction(self, producee, exit == null ? null : exit.Info, productionType, inits);
 

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var init in inits)
 				td.Add(init);
 
-			if (self.OccupiesSpace != null)
+			if (exitinfo != null && self.OccupiesSpace != null)
 			{
 				exit = self.Location + exitinfo.ExitCell;
 				var spawn = self.CenterPosition + exitinfo.SpawnOffset;
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits
 				var newUnit = self.World.CreateActor(producee.Name, td);
 
 				var move = newUnit.TraitOrDefault<IMove>();
-				if (move != null)
+				if (exitinfo != null && move != null)
 				{
 					if (exitinfo.MoveIntoWorld)
 					{

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -78,7 +78,6 @@ construction_yard:
 		Range: 5c768
 	Production:
 		Produces: Building, Upgrade
-	Exit:
 	Valued:
 		Cost: 2000
 	Tooltip:


### PR DESCRIPTION
The Conditional Exit PR broke this because it is now passing exit.Info instead of exit, which when exit is null is crashing. DoProduction has necessary checks in it that passing null there do not crash the game.