### PR TITLE
Split ResupplyManager from Repairable

### DIFF
--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -502,6 +502,7 @@
     <Compile Include="Traits\Render\WithVoxelTurret.cs" />
     <Compile Include="Traits\Render\DrawLineToTarget.cs" />
     <Compile Include="Traits\RejectsOrders.cs" />
+    <Compile Include="Traits\ResupplyManager.cs" />
     <Compile Include="Traits\Repairable.cs" />
     <Compile Include="Traits\RepairableNear.cs" />
     <Compile Include="Traits\RepairsBridges.cs" />

--- a/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
+++ b/OpenRA.Mods.Common/OpenRA.Mods.Common.csproj
@@ -618,6 +618,7 @@
     <Compile Include="UpdateRules\Rules\20190314\MultipleDeploySounds.cs" />
     <Compile Include="UpdateRules\Rules\20190314\RemoveSimpleBeacon.cs" />
     <Compile Include="UpdateRules\Rules\20190314\SplitHarvesterSpriteBody.cs" />
+    <Compile Include="UpdateRules\Rules\20190314\AddResupplyManager.cs" />
     <Compile Include="UtilityCommands\CheckRuntimeAssembliesCommand.cs" />
     <Compile Include="UtilityCommands\CheckYaml.cs" />
     <Compile Include="UtilityCommands\ConvertPngToShpCommand.cs" />

--- a/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
@@ -50,27 +50,18 @@ namespace OpenRA.Mods.Common.Orders
 			if (underCursor.Owner != world.LocalPlayer)
 				yield break;
 
-			Actor repairBuilding = null;
-			var orderId = "Repair";
+			Actor resupplyActor = null;
+			var orderId = "Resupply";
 
-			// Test for generic Repairable (used on units).
-			var repairable = underCursor.TraitOrDefault<Repairable>();
-			if (repairable != null)
-				repairBuilding = repairable.FindRepairBuilding(underCursor);
-			else
-			{
-				var repairableNear = underCursor.TraitOrDefault<RepairableNear>();
-				if (repairableNear != null)
-				{
-					orderId = "RepairNear";
-					repairBuilding = repairableNear.FindRepairBuilding(underCursor);
-				}
-			}
+			// Test for ResupplyManager (used on units).
+			var resupplyManager = underCursor.TraitOrDefault<ResupplyManager>();
+			if (resupplyManager != null)
+				resupplyActor = resupplyManager.FindResupplyActor(underCursor);
 
-			if (repairBuilding == null)
+			if (resupplyActor == null)
 				yield break;
 
-			yield return new Order(orderId, underCursor, Target.FromActor(repairBuilding), false) { VisualFeedbackTarget = Target.FromActor(underCursor) };
+			yield return new Order(orderId, underCursor, Target.FromActor(resupplyActor), false) { VisualFeedbackTarget = Target.FromActor(underCursor) };
 		}
 
 		protected override void Tick(World world)

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -861,16 +861,13 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				yield return new EnterAlliedActorTargeter<BuildingInfo>("Resupply", 5,
-					target => AircraftCanEnter(target), target => Reservable.IsAvailableFor(target, self));
-
 				yield return new AircraftMoveOrderTargeter(Info);
 			}
 		}
 
 		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
-			if (order.OrderID == "Resupply" || order.OrderID == "Move")
+			if (order.OrderID == "Move")
 				return new Order(order.OrderID, self, target, queued);
 
 			return null;
@@ -878,9 +875,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		Order IIssueDeployOrder.IssueDeployOrder(Actor self, bool queued)
 		{
-			if (rearmable == null || !rearmable.Info.RearmActors.Any())
-				return null;
-
 			return new Order("ReturnToBase", self, queued);
 		}
 
@@ -898,8 +892,6 @@ namespace OpenRA.Mods.Common.Traits
 							return null;
 					}
 
-					return Info.Voice;
-				case "Resupply":
 					return Info.Voice;
 				case "Stop":
 				case "Scatter":
@@ -929,20 +921,6 @@ namespace OpenRA.Mods.Common.Traits
 					self.QueueActivity(order.Queued, new Fly(self, target));
 				else
 					self.QueueActivity(order.Queued, new HeliFlyAndLandWhenIdle(self, target, Info));
-			}
-			else if (order.OrderString == "Resupply")
-			{
-				// Resupply orders are only valid for own/allied actors,
-				// which are guaranteed to never be frozen.
-				if (order.Target.Type != TargetType.Actor)
-					return;
-
-				if (!order.Queued)
-					UnReserve();
-
-				var targetActor = order.Target.Actor;
-				self.SetTargetLine(Target.FromActor(targetActor), Color.Green);
-				self.QueueActivity(order.Queued, new ReturnToBase(self, Info.AbortOnResupply, targetActor));
 			}
 			else if (order.OrderString == "Stop")
 			{

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -929,7 +929,7 @@ namespace OpenRA.Mods.Common.Traits
 				else
 					self.QueueActivity(order.Queued, new HeliFlyAndLandWhenIdle(self, target, Info));
 			}
-			else if (order.OrderString == "Enter" || order.OrderString == "Repair")
+			else if (order.OrderString == "Enter" || order.OrderString == "Resupply")
 			{
 				// Enter and Repair orders are only valid for own/allied actors,
 				// which are guaranteed to never be frozen.

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -861,7 +861,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				yield return new EnterAlliedActorTargeter<BuildingInfo>("Enter", 5,
+				yield return new EnterAlliedActorTargeter<BuildingInfo>("Resupply", 5,
 					target => AircraftCanEnter(target), target => Reservable.IsAvailableFor(target, self));
 
 				yield return new AircraftMoveOrderTargeter(Info);
@@ -870,7 +870,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
-			if (order.OrderID == "Enter" || order.OrderID == "Move")
+			if (order.OrderID == "Resupply" || order.OrderID == "Move")
 				return new Order(order.OrderID, self, target, queued);
 
 			return null;
@@ -899,7 +899,8 @@ namespace OpenRA.Mods.Common.Traits
 					}
 
 					return Info.Voice;
-				case "Enter":
+				case "Resupply":
+					return Info.Voice;
 				case "Stop":
 				case "Scatter":
 					return Info.Voice;
@@ -929,9 +930,9 @@ namespace OpenRA.Mods.Common.Traits
 				else
 					self.QueueActivity(order.Queued, new HeliFlyAndLandWhenIdle(self, target, Info));
 			}
-			else if (order.OrderString == "Enter" || order.OrderString == "Resupply")
+			else if (order.OrderString == "Resupply")
 			{
-				// Enter and Repair orders are only valid for own/allied actors,
+				// Resupply orders are only valid for own/allied actors,
 				// which are guaranteed to never be frozen.
 				if (order.Target.Type != TargetType.Actor)
 					return;
@@ -940,11 +941,7 @@ namespace OpenRA.Mods.Common.Traits
 					UnReserve();
 
 				var targetActor = order.Target.Actor;
-
-				// We only want to set a target line if the order will (most likely) succeed
-				if (Reservable.IsAvailableFor(targetActor, self))
-					self.SetTargetLine(Target.FromActor(targetActor), Color.Green);
-
+				self.SetTargetLine(Target.FromActor(targetActor), Color.Green);
 				self.QueueActivity(order.Queued, new ReturnToBase(self, Info.AbortOnResupply, targetActor));
 			}
 			else if (order.OrderString == "Stop")

--- a/OpenRA.Mods.Common/Traits/Rearmable.cs
+++ b/OpenRA.Mods.Common/Traits/Rearmable.cs
@@ -15,6 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[Desc("This actor can be sent to a structure for reloading ammo.")]
 	public class RearmableInfo : ITraitInfo
 	{
 		[Desc("Actors that this actor can dock to and get rearmed by.")]
@@ -27,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new Rearmable(this); }
 	}
 
-	public class Rearmable : INotifyCreated
+	public class Rearmable : IResupplyable, INotifyCreated
 	{
 		public readonly RearmableInfo Info;
 
@@ -42,5 +43,22 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			RearmableAmmoPools = self.TraitsImplementing<AmmoPool>().Where(p => Info.AmmoPools.Contains(p.Info.Name)).ToArray();
 		}
+
+		bool CanRearmAt(Actor target)
+		{
+			return Info.RearmActors.Contains(target.Info.Name);
+		}
+
+		bool IResupplyable.CanResupplyAt(Actor target)
+		{
+			return CanRearmAt(target);
+		}
+
+		bool IResupplyable.NeedsResupplyAt(Actor target)
+		{
+			return CanRearmAt(target) && RearmableAmmoPools.Any(p => !p.FullAmmo());
+		}
+
+		WDist IResupplyable.CloseEnough { get { return new WDist(512); } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -11,21 +11,15 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Activities;
-using OpenRA.Mods.Common.Activities;
-using OpenRA.Mods.Common.Orders;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor can be sent to a structure for repairs.")]
-	public class RepairableInfo : ITraitInfo, Requires<IHealthInfo>, Requires<IMoveInfo>
+	public class RepairableInfo : ITraitInfo, Requires<IHealthInfo>
 	{
 		[FieldLoader.Require]
 		[ActorReference] public readonly HashSet<string> RepairActors = new HashSet<string> { };
-
-		[VoiceReference] public readonly string Voice = "Action";
 
 		[Desc("The amount the unit will be repaired at each step. Use -1 for fallback behavior where HpPerStep from RepairsUnits trait will be used.")]
 		public readonly int HpPerStep = -1;
@@ -33,39 +27,15 @@ namespace OpenRA.Mods.Common.Traits
 		public virtual object Create(ActorInitializer init) { return new Repairable(init.Self, this); }
 	}
 
-	public class Repairable : IIssueOrder, IResolveOrder, IOrderVoice, INotifyCreated
+	public class Repairable : IResupplyable
 	{
 		public readonly RepairableInfo Info;
 		readonly IHealth health;
-		readonly IMove movement;
-		Rearmable rearmable;
 
 		public Repairable(Actor self, RepairableInfo info)
 		{
 			Info = info;
 			health = self.Trait<IHealth>();
-			movement = self.Trait<IMove>();
-		}
-
-		void INotifyCreated.Created(Actor self)
-		{
-			rearmable = self.TraitOrDefault<Rearmable>();
-		}
-
-		public IEnumerable<IOrderTargeter> Orders
-		{
-			get
-			{
-				yield return new EnterAlliedActorTargeter<BuildingInfo>("Repair", 5, CanRepairAt, _ => CanRepair() || CanRearm());
-			}
-		}
-
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
-		{
-			if (order.OrderID == "Repair")
-				return new Order(order.OrderID, self, target, queued);
-
-			return null;
 		}
 
 		bool CanRepairAt(Actor target)
@@ -73,103 +43,16 @@ namespace OpenRA.Mods.Common.Traits
 			return Info.RepairActors.Contains(target.Info.Name);
 		}
 
-		bool CanRearmAt(Actor target)
+		bool IResupplyable.CanResupplyAt(Actor target)
 		{
-			return rearmable != null && rearmable.Info.RearmActors.Contains(target.Info.Name);
+			return CanRepairAt(target);
 		}
 
-		bool CanRepair()
+		bool IResupplyable.NeedsResupplyAt(Actor target)
 		{
-			return health.DamageState > DamageState.Undamaged;
+			return CanRepairAt(target) && health.DamageState > DamageState.Undamaged;
 		}
 
-		bool CanRearm()
-		{
-			return rearmable != null && rearmable.RearmableAmmoPools.Any(p => !p.FullAmmo());
-		}
-
-		public string VoicePhraseForOrder(Actor self, Order order)
-		{
-			return order.OrderString == "Repair" && (CanRepair() || CanRearm()) ? Info.Voice : null;
-		}
-
-		public void ResolveOrder(Actor self, Order order)
-		{
-			if (order.OrderString == "Repair")
-			{
-				// Repair orders are only valid for own/allied actors,
-				// which are guaranteed to never be frozen.
-				if (order.Target.Type != TargetType.Actor)
-					return;
-
-				// Aircraft handle Repair orders directly in the Aircraft trait
-				if (self.Info.HasTraitInfo<AircraftInfo>())
-					return;
-
-				if (!CanRepairAt(order.Target.Actor) || (!CanRepair() && !CanRearm()))
-					return;
-
-				if (!order.Queued)
-					self.CancelActivity();
-
-				self.SetTargetLine(order.Target, Color.Green);
-				var activities = ActivityUtils.SequenceActivities(self,
-					movement.MoveToTarget(self, order.Target, targetLineColor: Color.Green),
-					new CallFunc(() => AfterReachActivities(self, order, movement)));
-
-				self.QueueActivity(new WaitForTransport(self, activities));
-				TryCallTransport(self, order.Target, new CallFunc(() => AfterReachActivities(self, order, movement)));
-			}
-		}
-
-		void AfterReachActivities(Actor self, Order order, IMove movement)
-		{
-			if (order.Target.Type != TargetType.Actor)
-				return;
-
-			var targetActor = order.Target.Actor;
-			if (!targetActor.IsInWorld || targetActor.IsDead || targetActor.TraitsImplementing<RepairsUnits>().All(r => r.IsTraitDisabled))
-				return;
-
-			// TODO: This is hacky, but almost every single component affected
-			// will need to be rewritten anyway, so this is OK for now.
-			self.QueueActivity(movement.MoveTo(self.World.Map.CellContaining(targetActor.CenterPosition), targetActor));
-
-			// Add a CloseEnough range of 512 to ensure we're at the host actor
-			self.QueueActivity(new Resupply(self, targetActor, new WDist(512)));
-
-			var rp = targetActor.TraitOrDefault<RallyPoint>();
-			if (rp != null)
-			{
-				self.QueueActivity(new CallFunc(() =>
-				{
-					self.SetTargetLine(Target.FromCell(self.World, rp.Location), Color.Green);
-					self.QueueActivity(movement.MoveTo(rp.Location, targetActor));
-				}));
-			}
-		}
-
-		public Actor FindRepairBuilding(Actor self)
-		{
-			var repairBuilding = self.World.ActorsWithTrait<RepairsUnits>()
-				.Where(a => !a.Actor.IsDead && a.Actor.IsInWorld
-					&& a.Actor.Owner.IsAlliedWith(self.Owner) &&
-					Info.RepairActors.Contains(a.Actor.Info.Name))
-				.OrderBy(p => (self.Location - p.Actor.Location).LengthSquared);
-
-			// Worst case FirstOrDefault() will return a TraitPair<null, null>, which is OK.
-			return repairBuilding.FirstOrDefault().Actor;
-		}
-
-		static void TryCallTransport(Actor self, Target target, Activity nextActivity)
-		{
-			var targetCell = self.World.Map.CellContaining(target.CenterPosition);
-			var delta = (self.CenterPosition - target.CenterPosition).LengthSquared;
-			var transports = self.TraitsImplementing<ICallForTransport>()
-				.Where(t => t.MinimumDistance.LengthSquared < delta);
-
-			foreach (var t in transports)
-				t.RequestTransport(self, targetCell, nextActivity);
-		}
+		WDist IResupplyable.CloseEnough { get { return new WDist(512); } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -11,52 +11,30 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Mods.Common.Activities;
-using OpenRA.Mods.Common.Orders;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class RepairableNearInfo : ITraitInfo, Requires<IHealthInfo>, Requires<IMoveInfo>
+	[Desc("SOON TO BE DEPRECATED. This actor can be sent near a structure for repairs.")]
+	class RepairableNearInfo : ITraitInfo, Requires<IHealthInfo>
 	{
 		[FieldLoader.Require]
 		[ActorReference] public readonly HashSet<string> RepairActors = new HashSet<string> { };
 
 		public readonly WDist CloseEnough = WDist.FromCells(4);
-		[VoiceReference] public readonly string Voice = "Action";
 
 		public object Create(ActorInitializer init) { return new RepairableNear(init.Self, this); }
 	}
 
-	class RepairableNear : IIssueOrder, IResolveOrder, IOrderVoice
+	class RepairableNear : IResupplyable
 	{
 		public readonly RepairableNearInfo Info;
-		readonly Actor self;
-		readonly IMove movement;
+		readonly IHealth health;
 
 		public RepairableNear(Actor self, RepairableNearInfo info)
 		{
-			this.self = self;
 			Info = info;
-			movement = self.Trait<IMove>();
-		}
-
-		public IEnumerable<IOrderTargeter> Orders
-		{
-			get
-			{
-				yield return new EnterAlliedActorTargeter<BuildingInfo>("RepairNear", 5,
-					target => CanRepairAt(target), _ => ShouldRepair());
-			}
-		}
-
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
-		{
-			if (order.OrderID == "RepairNear")
-				return new Order(order.OrderID, self, target, queued);
-
-			return null;
+			health = self.Trait<IHealth>();
 		}
 
 		bool CanRepairAt(Actor target)
@@ -64,45 +42,16 @@ namespace OpenRA.Mods.Common.Traits
 			return Info.RepairActors.Contains(target.Info.Name);
 		}
 
-		bool ShouldRepair()
+		bool IResupplyable.CanResupplyAt(Actor target)
 		{
-			return self.GetDamageState() > DamageState.Undamaged;
+			return CanRepairAt(target);
 		}
 
-		public string VoicePhraseForOrder(Actor self, Order order)
+		bool IResupplyable.NeedsResupplyAt(Actor target)
 		{
-			return order.OrderString == "RepairNear" && ShouldRepair() ? Info.Voice : null;
+			return CanRepairAt(target) && health.DamageState > DamageState.Undamaged;
 		}
 
-		public void ResolveOrder(Actor self, Order order)
-		{
-			// RepairNear orders are only valid for own/allied actors,
-			// which are guaranteed to never be frozen.
-			if (order.OrderString != "RepairNear" || order.Target.Type != TargetType.Actor)
-				return;
-
-			if (!CanRepairAt(order.Target.Actor) || !ShouldRepair())
-				return;
-
-			if (!order.Queued)
-				self.CancelActivity();
-
-			self.QueueActivity(movement.MoveWithinRange(order.Target, Info.CloseEnough, targetLineColor: Color.Green));
-			self.QueueActivity(new Resupply(self, order.Target.Actor, Info.CloseEnough));
-
-			self.SetTargetLine(order.Target, Color.Green, false);
-		}
-
-		public Actor FindRepairBuilding(Actor self)
-		{
-			var repairBuilding = self.World.ActorsWithTrait<RepairsUnits>()
-				.Where(a => !a.Actor.IsDead && a.Actor.IsInWorld
-					&& a.Actor.Owner.IsAlliedWith(self.Owner) &&
-					Info.RepairActors.Contains(a.Actor.Info.Name))
-				.OrderBy(p => (self.Location - p.Actor.Location).LengthSquared);
-
-			// Worst case FirstOrDefault() will return a TraitPair<null, null>, which is OK.
-			return repairBuilding.FirstOrDefault().Actor;
-		}
+		WDist IResupplyable.CloseEnough { get { return Info.CloseEnough; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/RepairsUnits.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsUnits.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new RepairsUnits(this); }
 	}
 
-	public class RepairsUnits : PausableConditionalTrait<RepairsUnitsInfo>
+	public class RepairsUnits : PausableConditionalTrait<RepairsUnitsInfo>, IResupplier
 	{
 		public RepairsUnits(RepairsUnitsInfo info) : base(info) { }
 	}

--- a/OpenRA.Mods.Common/Traits/ResupplyManager.cs
+++ b/OpenRA.Mods.Common/Traits/ResupplyManager.cs
@@ -1,0 +1,175 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Activities;
+using OpenRA.Mods.Common.Activities;
+using OpenRA.Mods.Common.Orders;
+using OpenRA.Primitives;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("This actor can be sent to a structure for resupply.")]
+	public class ResupplyManagerInfo : ITraitInfo, Requires<IMoveInfo>
+	{
+		[VoiceReference] public readonly string Voice = "Action";
+
+		public virtual object Create(ActorInitializer init) { return new ResupplyManager(init.Self, this); }
+	}
+
+	public class ResupplyManager : IIssueOrder, IResolveOrder, IOrderVoice, INotifyCreated
+	{
+		public readonly ResupplyManagerInfo Info;
+		readonly IMove movement;
+		IResupplyable[] resupplyables;
+
+		public ResupplyManager(Actor self, ResupplyManagerInfo info)
+		{
+			Info = info;
+			movement = self.Trait<IMove>();
+		}
+
+		void INotifyCreated.Created(Actor self)
+		{
+			resupplyables = self.TraitsImplementing<IResupplyable>().ToArray();
+		}
+
+		public IEnumerable<IOrderTargeter> Orders
+		{
+			get
+			{
+				yield return new EnterAlliedActorTargeter<BuildingInfo>("Resupply", 5, CanResupplyAt, NeedsResupplyAt);
+			}
+		}
+
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		{
+			if (order.OrderID == "Resupply")
+				return new Order(order.OrderID, self, target, queued);
+
+			return null;
+		}
+
+		bool CanResupplyAt(Actor target)
+		{
+			foreach (var r in resupplyables)
+				if (r.CanResupplyAt(target))
+					return true;
+
+			return false;
+		}
+
+		bool NeedsResupplyAt(Actor target)
+		{
+			foreach (var r in resupplyables)
+				if (r.NeedsResupplyAt(target))
+					return true;
+
+			return false;
+		}
+
+		public string VoicePhraseForOrder(Actor self, Order order)
+		{
+			return order.OrderString == "Resupply" ? Info.Voice : null;
+		}
+
+		public void ResolveOrder(Actor self, Order order)
+		{
+			if (order.OrderString == "Resupply")
+			{
+				// Resupply orders are only valid for own/allied actors,
+				// which are guaranteed to never be frozen.
+				if (order.Target.Type != TargetType.Actor)
+					return;
+
+				// Aircraft handle Resupply orders directly in the Aircraft trait
+				if (self.Info.HasTraitInfo<AircraftInfo>())
+					return;
+
+				if (!order.Queued)
+					self.CancelActivity();
+
+				self.SetTargetLine(order.Target, Color.Green);
+				var activities = ActivityUtils.SequenceActivities(self,
+					movement.MoveToTarget(self, order.Target, targetLineColor: Color.Green),
+					new CallFunc(() => AfterReachActivities(self, order, movement)));
+
+				self.QueueActivity(new WaitForTransport(self, activities));
+				TryCallTransport(self, order.Target, new CallFunc(() => AfterReachActivities(self, order, movement)));
+			}
+		}
+
+		void AfterReachActivities(Actor self, Order order, IMove movement)
+		{
+			if (order.Target.Type != TargetType.Actor)
+				return;
+
+			var targetActor = order.Target.Actor;
+			if (!targetActor.IsInWorld || targetActor.IsDead || !targetActor.TraitsImplementing<IResupplier>().Any(Exts.IsTraitEnabled))
+				return;
+
+			if (!NeedsResupplyAt(order.Target.Actor))
+				return;
+
+			// Return if we no longer need resupplies (for example if we were resupplied through other means since the order was given)
+			var validResupplyables = resupplyables.Where(r => r.NeedsResupplyAt(targetActor));
+			if (!validResupplyables.Any())
+				return;
+
+			var closeEnough = validResupplyables.OrderByDescending(c => c.CloseEnough).First().CloseEnough;
+
+			// If closeEnough is not 512, this (currently) means it has to be RepairableNear.
+			// TODO: This is hacky, but will be rewritten soon anyway, so this is OK for now.
+			if (closeEnough.Length != 512)
+				self.QueueActivity(movement.MoveWithinRange(order.Target, closeEnough, targetLineColor: Color.Green));
+			else
+				self.QueueActivity(movement.MoveTo(self.World.Map.CellContaining(targetActor.CenterPosition), targetActor));
+
+			// Add a CloseEnough range to ensure we're at or close enough to the host actor
+			self.QueueActivity(new Resupply(self, targetActor, closeEnough));
+
+			var rp = targetActor.TraitOrDefault<RallyPoint>();
+			if (rp != null)
+			{
+				self.QueueActivity(new CallFunc(() =>
+				{
+					self.SetTargetLine(Target.FromCell(self.World, rp.Location), Color.Green);
+					self.QueueActivity(movement.MoveTo(rp.Location, targetActor));
+				}));
+			}
+		}
+
+		public Actor FindResupplyActor(Actor self)
+		{
+			var resupplyActor = self.World.ActorsWithTrait<IResupplier>()
+				.Where(a => !a.Actor.IsDead && a.Actor.IsInWorld
+					&& a.Actor.Owner.IsAlliedWith(self.Owner) &&
+					resupplyables.Any(r => r.NeedsResupplyAt(a.Actor)))
+				.OrderBy(p => (self.Location - p.Actor.Location).LengthSquared);
+
+			// Worst case FirstOrDefault() will return a TraitPair<null, null>, which is OK.
+			return resupplyActor.FirstOrDefault().Actor;
+		}
+
+		static void TryCallTransport(Actor self, Target target, Activity nextActivity)
+		{
+			var targetCell = self.World.Map.CellContaining(target.CenterPosition);
+			var delta = (self.CenterPosition - target.CenterPosition).LengthSquared;
+			var transports = self.TraitsImplementing<ICallForTransport>()
+				.Where(t => t.MinimumDistance.LengthSquared < delta);
+
+			foreach (var t in transports)
+				t.RequestTransport(self, targetCell, nextActivity);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -32,6 +32,17 @@ namespace OpenRA.Mods.Common.Traits
 		Repair = 2
 	}
 
+	public interface IResupplyable
+	{
+		bool CanResupplyAt(Actor target);
+		bool NeedsResupplyAt(Actor target);
+
+		// Temporary shim
+		WDist CloseEnough { get; }
+	}
+
+	public interface IResupplier { }
+
 	public interface IQuantizeBodyOrientationInfo : ITraitInfo
 	{
 		int QuantizedBodyFacings(ActorInfo ai, SequenceProvider sequenceProvider, string race);

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20190314/AddResupplyManager.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20190314/AddResupplyManager.cs
@@ -1,0 +1,41 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class AddResupplyManager : UpdateRule
+	{
+		public override string Name { get { return "Split ResupplyManager from Repairable(Near)"; } }
+		public override string Description
+		{
+			get
+			{
+				return "Split a ResupplyManager trait from Repairable(Near) that does all order handling.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var repairable = actorNode.ChildrenMatching("Repairable", true, false);
+			if (!repairable.Any())
+				repairable = actorNode.ChildrenMatching("RepairableNear", true, false);
+
+			foreach (var r in repairable)
+				actorNode.AddNode("ResupplyManager", "");
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -125,6 +125,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new ReplaceSpecialMoveConsiderations(),
 				new RefactorHarvesterIdle(),
 				new SplitHarvesterSpriteBody(),
+				new AddResupplyManager(),
 			})
 		};
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -259,6 +259,7 @@
 		TargetTypes: Ground, Vehicle
 	Repairable:
 		RepairActors: fix
+	ResupplyManager:
 	Passenger:
 		CargoType: Vehicle
 	ActorLostNotification:
@@ -311,6 +312,7 @@
 		Bounds: 24,24
 	Repairable:
 		RepairActors: hpad
+	ResupplyManager:
 	Aircraft:
 		LandWhenIdle: false
 		AirborneCondition: airborne

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -189,6 +189,7 @@
 	ActorLostNotification:
 	Repairable:
 		RepairActors: repair_pad
+	ResupplyManager:
 	Guard:
 		Voice: Guard
 	Guardable:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -260,6 +260,7 @@
 		ValidDamageStates: Light, Medium, Heavy, Critical
 	Repairable:
 		RepairActors: fix
+	ResupplyManager:
 	Chronoshiftable:
 	Passenger:
 		CargoType: Vehicle
@@ -515,6 +516,7 @@
 	Chronoshiftable:
 	RepairableNear:
 		RepairActors: spen, syrd
+	ResupplyManager:
 	GpsDot:
 		String: Ship
 	WithDamageOverlay:
@@ -605,6 +607,7 @@
 ^Plane:
 	Inherits: ^NeutralPlane
 	Inherits@2: ^GainsExperience
+	ResupplyManager:
 	Repairable:
 		RepairActors: fix
 

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -751,6 +751,7 @@
 		ValidDamageStates: Light, Medium, Heavy, Critical
 	Repairable:
 		RepairActors: gadept
+	ResupplyManager:
 		Voice: Move
 	Passenger:
 		CargoType: Vehicle
@@ -843,6 +844,7 @@
 		Palette: pips
 	Repairable:
 		RepairActors: gadept
+	ResupplyManager:
 		Voice: Move
 	Aircraft:
 		AirborneCondition: airborne


### PR DESCRIPTION
This moves all "Resupply" order handling and activity queueing from `Repairable` (and `RepairableNear` and `Aircraft`) to a new `ResupplyManager`.

Disclaimer: This PR intentionally focuses on moving those parts, not improving/refactoring them. That will come in follow-ups.

~Depends on #16352.~
Closes points 2 and 3 of #16403.