### PR TITLE
Makes torpedoes damage walls

### DIFF
--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -224,7 +224,7 @@ TorpTube:
 	ReloadDelay: 100
 	Range: 9c0
 	Report: torpedo1.aud
-	ValidTargets: Water, Underwater, Bridge
+	ValidTargets: Water, Underwater, Bridge, Wall
 	Burst: 2
 	BurstDelays: 20
 	Projectile: Missile

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -241,7 +241,7 @@ TorpTube:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 18000
-		ValidTargets: Water, Underwater, Bridge
+		ValidTargets: Water, Underwater, Bridge, Wall
 		Versus:
 			Wood: 75
 			Light: 75


### PR DESCRIPTION
Currently Submarine is the only naval unit that cannot damage fences. This change will allow for more creative use of walls in making naval maps