### PR TITLE
Fix FrozenUnderFog visibility calculation when fog is disabled.

### DIFF
--- a/OpenRA.Mods.Common/ShroudExts.cs
+++ b/OpenRA.Mods.Common/ShroudExts.cs
@@ -26,6 +26,16 @@ namespace OpenRA.Mods.Common
 			return false;
 		}
 
+		public static bool AnyExplored(this Shroud shroud, PPos[] puvs)
+		{
+			// PERF: Avoid LINQ.
+			foreach (var puv in puvs)
+				if (shroud.IsExplored(puv))
+					return true;
+
+			return false;
+		}
+
 		public static bool AnyVisible(this Shroud shroud, Pair<CPos, SubCell>[] cells)
 		{
 			// PERF: Avoid LINQ.

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			// If fog is disabled visibility is determined by shroud
 			if (!byPlayer.Shroud.FogEnabled)
-				return byPlayer.Shroud.AnyExplored(self.OccupiesSpace.OccupiedCells());
+				return byPlayer.Shroud.AnyExplored(footprint);
 
 			return frozenStates[byPlayer].IsVisible;
 		}


### PR DESCRIPTION
This PR fixes actors that have only _ and = footprint cells remaining invisible when the fog of war is disabled using the lobby option.

Supersedes #15720

A simple testcase is to change the footprint on the repair pad in TD or RA to `_=_ === _=_`.