### PR TITLE
Change small caliber projectiles to instant hit

### DIFF
--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -3,9 +3,7 @@
 	Range: 8c0
 	Report: aacanon3.aud
 	ValidTargets: Air
-	Projectile: Bullet
-		Speed: 1c682
-		Blockable: false
+	Projectile: InstantHit
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 2000
@@ -27,8 +25,6 @@ ZSU-23:
 	BurstDelays: 0
 	ReloadDelay: 6
 	Range: 10c0
-	Projectile: Bullet
-		Speed: 3c340
 	Warhead@1Dam: SpreadDamage
 		Damage: 1200
 		Versus:
@@ -40,6 +36,9 @@ ZSU-23:
 
 FLAK-23-AA:
 	Inherits: ^AACannon
+	Projectile: Bullet
+		Speed: 1c682
+		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: Air, Ground, Water
 
@@ -61,8 +60,8 @@ FLAK-23-AG:
 	ReloadDelay: 30
 	Range: 6c0
 	Report: gun13.aud
-	Projectile: Bullet
-		Speed: 1c682
+	Projectile: InstantHit
+		Blockable: true
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 2500
@@ -209,7 +208,7 @@ ChainGun:
 	ReloadDelay: 10
 	Range: 5c0
 	MinRange: 0c768
-	Projectile: Bullet
+	Projectile: InstantHit
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Versus:
@@ -220,7 +219,7 @@ ChainGun.Yak:
 	ReloadDelay: 3
 	Range: 5c0
 	MinRange: 3c0
-	Projectile: Bullet
+	Projectile: InstantHit
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Damage: 4000
@@ -267,8 +266,8 @@ M60mg:
 	Report: gun5.aud
 	ValidTargets: Ground, Infantry
 	InvalidTargets: Vehicle, Water, Structure, Wall, Husk, Mine
-	Projectile: Bullet
-		Speed: 1c682
+	Projectile: InstantHit
+		Blockable: true
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 15000


### PR DESCRIPTION
Goal is to make damage more consistent, problems shown in #16038. Those bullet projectiles are already invisible to the human eye so the best solution is to make them instant hit. I didn't change the mobile flaks aa cannon as it has major balance implications. Currently it doesn't deal full damage to planes at longer range. This could be tackled in future balance changes