### PR TITLE
Move ChildActivity handling into base Activity class

### DIFF
--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -82,7 +82,13 @@ namespace OpenRA.Activities
 			return ret;
 		}
 
-		public abstract Activity Tick(Actor self);
+		/// <summary>
+		/// Runs every timestep as long as this activity is active.
+		/// </summary>
+		public virtual Activity Tick(Actor self)
+		{
+			return NextActivity;
+		}
 
 		/// <summary>
 		/// Runs once immediately before the first Tick() execution.

--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -31,13 +31,7 @@ namespace OpenRA.Activities
 	{
 		public ActivityState State { get; private set; }
 
-		Activity childActivity;
-		protected Activity ChildActivity
-		{
-			get { return childActivity != null && childActivity.State < ActivityState.Done ? childActivity : null; }
-			set { childActivity = value; }
-		}
-
+		protected Activity ChildActivity { get; private set; }
 		public Activity NextActivity { get; protected set; }
 
 		public bool IsInterruptible { get; protected set; }
@@ -52,7 +46,7 @@ namespace OpenRA.Activities
 
 		public Activity TickOuter(Actor self)
 		{
-			if (State == ActivityState.Done && Game.Settings.Debug.StrictActivityChecking)
+			if (State == ActivityState.Done)
 				throw new InvalidOperationException("Actor {0} attempted to tick activity {1} after it had already completed.".F(self, GetType()));
 
 			if (State == ActivityState.Queued)
@@ -188,14 +182,14 @@ namespace OpenRA.Activities
 			while (act != null)
 			{
 				yield return act.GetType().Name;
-				act = act.childActivity;
+				act = act.ChildActivity;
 			}
 		}
 
 		public IEnumerable<T> ActivitiesImplementing<T>(bool includeChildren = true) where T : IActivityInterface
 		{
-			if (includeChildren && childActivity != null)
-				foreach (var a in childActivity.ActivitiesImplementing<T>())
+			if (includeChildren && ChildActivity != null)
+				foreach (var a in ChildActivity.ActivitiesImplementing<T>())
 					yield return a;
 
 			if (this is T)

--- a/OpenRA.Game/Activities/CallFunc.cs
+++ b/OpenRA.Game/Activities/CallFunc.cs
@@ -24,10 +24,10 @@ namespace OpenRA.Activities
 
 		Action a;
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			if (a != null) a();
-			return NextActivity;
+			return true;
 		}
 	}
 }

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -222,7 +222,7 @@ namespace OpenRA
 			if (CurrentActivity == null)
 				CurrentActivity = nextActivity;
 			else
-				CurrentActivity.Queue(this, nextActivity);
+				CurrentActivity.Queue(nextActivity);
 		}
 
 		public void CancelActivity()

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -128,9 +128,6 @@ namespace OpenRA
 
 		[Desc("Throw an exception if the world sync hash changes while evaluating BotModules.")]
 		public bool SyncCheckBotModuleCode = false;
-
-		[Desc("Throw an exception if an actor activity is ticked after it has been marked as completed.")]
-		public bool StrictActivityChecking = false;
 	}
 
 	public class GraphicSettings

--- a/OpenRA.Game/Traits/ActivityUtils.cs
+++ b/OpenRA.Game/Traits/ActivityUtils.cs
@@ -51,10 +51,10 @@ namespace OpenRA.Traits
 			return act;
 		}
 
-		public static Activity SequenceActivities(Actor self, params Activity[] acts)
+		public static Activity SequenceActivities(params Activity[] acts)
 		{
 			return acts.Reverse().Aggregate(
-				(next, a) => { a.Queue(self, next); return a; });
+				(next, a) => { a.Queue(next); return a; });
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Activities/LayMines.cs
+++ b/OpenRA.Mods.Cnc/Activities/LayMines.cs
@@ -39,12 +39,6 @@ namespace OpenRA.Mods.Cnc.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				return this;
-			}
-
 			if (IsCanceling)
 				return NextActivity;
 
@@ -59,16 +53,16 @@ namespace OpenRA.Mods.Cnc.Activities
 					return NextActivity;
 
 				// Add a CloseEnough range of 512 to the Rearm/Repair activities in order to ensure that we're at the host actor
-				QueueChild(self, new MoveAdjacentTo(self, Target.FromActor(rearmTarget)), true);
-				QueueChild(self, movement.MoveTo(self.World.Map.CellContaining(rearmTarget.CenterPosition), rearmTarget));
-				QueueChild(self, new Resupply(self, rearmTarget, new WDist(512)));
+				QueueChild(new MoveAdjacentTo(self, Target.FromActor(rearmTarget)));
+				QueueChild(movement.MoveTo(self.World.Map.CellContaining(rearmTarget.CenterPosition), rearmTarget));
+				QueueChild(new Resupply(self, rearmTarget, new WDist(512)));
 				return this;
 			}
 
 			if ((minefield == null || minefield.Contains(self.Location)) && ShouldLayMine(self, self.Location))
 			{
 				LayMine(self);
-				QueueChild(self, new Wait(20), true); // A little wait after placing each mine, for show
+				QueueChild(new Wait(20)); // A little wait after placing each mine, for show
 				return this;
 			}
 
@@ -80,7 +74,7 @@ namespace OpenRA.Mods.Cnc.Activities
 					var p = minefield.Random(self.World.SharedRandom);
 					if (ShouldLayMine(self, p))
 					{
-						QueueChild(self, movement.MoveTo(p, 0), true);
+						QueueChild(movement.MoveTo(p, 0));
 						return this;
 					}
 				}

--- a/OpenRA.Mods.Cnc/Activities/Leap.cs
+++ b/OpenRA.Mods.Cnc/Activities/Leap.cs
@@ -72,18 +72,9 @@ namespace OpenRA.Mods.Cnc.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (canceled)
-				return NextActivity;
-
 			// Correct the visual position after we jumped
-			if (jumpComplete)
-			{
-				if (ChildActivity == null)
-					return NextActivity;
-
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				return this;
-			}
+			if (canceled || jumpComplete)
+				return NextActivity;
 
 			if (target.Type != TargetType.Invalid)
 				targetPosition = target.CenterPosition;
@@ -106,9 +97,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				attack.DoAttack(self, target);
 
 				jumpComplete = true;
-				QueueChild(self, mobile.VisualMove(self, position, self.World.Map.CenterOfSubCell(destinationCell, destinationSubCell)), true);
-
-				return this;
+				QueueChild(mobile.VisualMove(self, position, self.World.Map.CenterOfSubCell(destinationCell, destinationSubCell)));
 			}
 
 			return this;

--- a/OpenRA.Mods.Cnc/Activities/Leap.cs
+++ b/OpenRA.Mods.Cnc/Activities/Leap.cs
@@ -70,11 +70,11 @@ namespace OpenRA.Mods.Cnc.Activities
 			attack.GrantLeapCondition(self);
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			// Correct the visual position after we jumped
 			if (canceled || jumpComplete)
-				return NextActivity;
+				return true;
 
 			if (target.Type != TargetType.Invalid)
 				targetPosition = target.CenterPosition;
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				QueueChild(mobile.VisualMove(self, position, self.World.Map.CenterOfSubCell(destinationCell, destinationSubCell)));
 			}
 
-			return this;
+			return false;
 		}
 
 		protected override void OnLastRun(Actor self)

--- a/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
+++ b/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
@@ -74,13 +74,6 @@ namespace OpenRA.Mods.Cnc.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			// Run this even if the target became invalid to avoid visual glitches
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				return this;
-			}
-
 			if (IsCanceling)
 				return NextActivity;
 
@@ -114,7 +107,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				if (!allowMovement || lastVisibleMaxRange == WDist.Zero || lastVisibleMaxRange < lastVisibleMinRange)
 					return NextActivity;
 
-				QueueChild(self, mobile.MoveWithinRange(target, lastVisibleMinRange, lastVisibleMaxRange, checkTarget.CenterPosition, Color.Red), true);
+				QueueChild(mobile.MoveWithinRange(target, lastVisibleMinRange, lastVisibleMaxRange, checkTarget.CenterPosition, Color.Red));
 				return this;
 			}
 
@@ -144,11 +137,11 @@ namespace OpenRA.Mods.Cnc.Activities
 			var desiredFacing = (destination - origin).Yaw.Facing;
 			if (mobile.Facing != desiredFacing)
 			{
-				QueueChild(self, new Turn(self, desiredFacing), true);
+				QueueChild(new Turn(self, desiredFacing));
 				return this;
 			}
 
-			QueueChild(self, new Leap(self, target, mobile, targetMobile, info.Speed.Length, attack, edible), true);
+			QueueChild(new Leap(self, target, mobile, targetMobile, info.Speed.Length, attack, edible));
 
 			// Re-queue the child activities to kill the target if it didn't die in one go
 			return this;

--- a/OpenRA.Mods.Cnc/Activities/Teleport.cs
+++ b/OpenRA.Mods.Cnc/Activities/Teleport.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				IsInterruptible = false;
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			var pc = self.TraitOrDefault<PortableChrono>();
 			if (teleporter == self && pc != null && (!pc.CanTeleport || IsCanceling))
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				if (killOnFailure)
 					self.Kill(teleporter, killDamageTypes);
 
-				return NextActivity;
+				return true;
 			}
 
 			var bestCell = ChooseBestDestinationCell(self, destination);
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				if (killOnFailure)
 					self.Kill(teleporter, killDamageTypes);
 
-				return NextActivity;
+				return true;
 			}
 
 			destination = bestCell.Value;
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Cnc.Activities
 					building.PlayCustomAnimation(teleporter, "active");
 			}
 
-			return NextActivity;
+			return true;
 		}
 
 		CPos? ChooseBestDestinationCell(Actor self, CPos destination)

--- a/OpenRA.Mods.Cnc/Activities/VoxelHarvesterDockSequence.cs
+++ b/OpenRA.Mods.Cnc/Activities/VoxelHarvesterDockSequence.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Cnc.Activities
 			spriteOverlay = refinery.TraitOrDefault<WithDockingOverlay>();
 		}
 
-		public override Activity OnStateDock(Actor self)
+		public override void OnStateDock(Actor self)
 		{
 			body.Docked = true;
 
@@ -42,11 +42,9 @@ namespace OpenRA.Mods.Cnc.Activities
 			}
 			else
 				dockingState = DockingState.Loop;
-
-			return this;
 		}
 
-		public override Activity OnStateUndock(Actor self)
+		public override void OnStateUndock(Actor self)
 		{
 			dockingState = DockingState.Wait;
 
@@ -65,8 +63,6 @@ namespace OpenRA.Mods.Cnc.Activities
 				dockingState = DockingState.Complete;
 				body.Docked = false;
 			}
-
-			return this;
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTDGunboatTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTDGunboatTurreted.cs
@@ -46,13 +46,13 @@ namespace OpenRA.Mods.Cnc.Traits
 				this.forceAttack = forceAttack;
 			}
 
-			public override Activity Tick(Actor self)
+			public override bool Tick(Actor self)
 			{
 				if (IsCanceling || !target.IsValidFor(self))
-					return NextActivity;
+					return true;
 
 				if (attack.IsTraitDisabled)
-					return this;
+					return false;
 
 				var weapon = attack.ChooseArmamentsForTarget(target, forceAttack).FirstOrDefault();
 				if (weapon != null)
@@ -60,13 +60,13 @@ namespace OpenRA.Mods.Cnc.Traits
 					// Check that AttackTDGunboatTurreted hasn't cancelled the target by modifying attack.Target
 					// Having both this and AttackTDGunboatTurreted modify that field is a horrible hack.
 					if (hasTicked && attack.RequestedTarget.Type == TargetType.Invalid)
-						return NextActivity;
+						return true;
 
 					attack.SetRequestedTarget(self, target);
 					hasTicked = true;
 				}
 
-				return NextActivity;
+				return true;
 			}
 		}
 	}

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
@@ -94,13 +94,13 @@ namespace OpenRA.Mods.Cnc.Traits
 				this.forceAttack = forceAttack;
 			}
 
-			public override Activity Tick(Actor self)
+			public override bool Tick(Actor self)
 			{
 				if (IsCanceling || !attack.CanAttack(self, target))
-					return NextActivity;
+					return true;
 
 				if (attack.charges == 0)
-					return this;
+					return false;
 
 				foreach (var notify in self.TraitsImplementing<INotifyTeslaCharging>())
 					notify.Charging(self, target);
@@ -110,7 +110,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 				QueueChild(new Wait(attack.info.InitialChargeDelay));
 				QueueChild(new ChargeFire(attack, target));
-				return this;
+				return false;
 			}
 
 			void IActivityNotifyStanceChanged.StanceChanged(Actor self, AutoTarget autoTarget, UnitStance oldStance, UnitStance newStance)
@@ -145,18 +145,18 @@ namespace OpenRA.Mods.Cnc.Traits
 				this.target = target;
 			}
 
-			public override Activity Tick(Actor self)
+			public override bool Tick(Actor self)
 			{
 				if (IsCanceling || !attack.CanAttack(self, target))
-					return NextActivity;
+					return true;
 
 				if (attack.charges == 0)
-					return NextActivity;
+					return true;
 
 				attack.DoAttack(self, target);
 
 				QueueChild(new Wait(attack.info.ChargeDelay));
-				return this;
+				return false;
 			}
 		}
 	}

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
@@ -96,13 +96,6 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			public override Activity Tick(Actor self)
 			{
-				if (ChildActivity != null)
-				{
-					ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-					if (ChildActivity != null)
-						return this;
-				}
-
 				if (IsCanceling || !attack.CanAttack(self, target))
 					return NextActivity;
 
@@ -115,8 +108,8 @@ namespace OpenRA.Mods.Cnc.Traits
 				if (!string.IsNullOrEmpty(attack.info.ChargeAudio))
 					Game.Sound.Play(SoundType.World, attack.info.ChargeAudio, self.CenterPosition);
 
-				QueueChild(self, new Wait(attack.info.InitialChargeDelay), true);
-				QueueChild(self, new ChargeFire(attack, target));
+				QueueChild(new Wait(attack.info.InitialChargeDelay));
+				QueueChild(new ChargeFire(attack, target));
 				return this;
 			}
 
@@ -154,13 +147,6 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			public override Activity Tick(Actor self)
 			{
-				if (ChildActivity != null)
-				{
-					ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-					if (ChildActivity != null)
-						return this;
-				}
-
 				if (IsCanceling || !attack.CanAttack(self, target))
 					return NextActivity;
 
@@ -169,7 +155,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 				attack.DoAttack(self, target);
 
-				QueueChild(self, new Wait(attack.info.ChargeDelay), true);
+				QueueChild(new Wait(attack.info.ChargeDelay));
 				return this;
 			}
 		}

--- a/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Activities
 				acceleration = self.World.SharedRandom.Next(2) * 2 - 1;
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			if (self.World.Map.DistanceAboveTerrain(self.CenterPosition).Length <= 0)
 			{
@@ -43,7 +43,8 @@ namespace OpenRA.Mods.Common.Activities
 				}
 
 				self.Kill(self);
-				return null;
+				Cancel(self);
+				return true;
 			}
 
 			if (info.Spins)
@@ -56,7 +57,7 @@ namespace OpenRA.Mods.Common.Activities
 			move -= new WVec(WDist.Zero, WDist.Zero, info.Velocity);
 			aircraft.SetPosition(self, aircraft.CenterPosition + move);
 
-			return this;
+			return false;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -102,13 +102,6 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
-
 			// Refuse to take off if it would land immediately again.
 			if (aircraft.ForceLanding)
 				Cancel(self);
@@ -125,7 +118,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (aircraft.Info.CanHover && !skipHeightAdjustment && dat != aircraft.Info.CruiseAltitude)
 				{
 					if (dat <= aircraft.LandAltitude)
-						QueueChild(self, new TakeOff(self, target), true);
+						QueueChild(new TakeOff(self, target));
 					else
 						VerticalTakeOffOrLandTick(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);
 
@@ -136,7 +129,7 @@ namespace OpenRA.Mods.Common.Activities
 			}
 			else if (dat <= aircraft.LandAltitude)
 			{
-				QueueChild(self, new TakeOff(self, target), true);
+				QueueChild(new TakeOff(self, target));
 				return this;
 			}
 

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Activities
 			return true;
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			// Refuse to take off if it would land immediately again.
 			if (aircraft.ForceLanding)
@@ -122,15 +122,15 @@ namespace OpenRA.Mods.Common.Activities
 					else
 						VerticalTakeOffOrLandTick(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);
 
-					return this;
+					return false;
 				}
 
-				return NextActivity;
+				return true;
 			}
 			else if (dat <= aircraft.LandAltitude)
 			{
 				QueueChild(new TakeOff(self, target));
-				return this;
+				return false;
 			}
 
 			bool targetIsHiddenActor;
@@ -147,7 +147,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Target is hidden or dead, and we don't have a fallback position to move towards
 			if (useLastVisibleTarget && !lastVisibleTarget.IsValidFor(self))
-				return NextActivity;
+				return true;
 
 			var checkTarget = useLastVisibleTarget ? lastVisibleTarget : target;
 			var pos = aircraft.GetPosition();
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.Common.Activities
 			var insideMaxRange = maxRange.Length > 0 && checkTarget.IsInRange(pos, maxRange);
 			var insideMinRange = minRange.Length > 0 && checkTarget.IsInRange(pos, minRange);
 			if (insideMaxRange && !insideMinRange)
-				return NextActivity;
+				return true;
 
 			var move = aircraft.Info.CanHover ? aircraft.FlyStep(desiredFacing) : aircraft.FlyStep(aircraft.Facing);
 
@@ -166,7 +166,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (aircraft.Info.CanHover && insideMinRange)
 			{
 				FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, -move);
-				return this;
+				return false;
 			}
 
 			// The next move would overshoot, so consider it close enough or set final position if CanHover
@@ -186,11 +186,11 @@ namespace OpenRA.Mods.Common.Activities
 					if (dat != aircraft.Info.CruiseAltitude)
 					{
 						Fly.VerticalTakeOffOrLandTick(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);
-						return this;
+						return false;
 					}
 				}
 
-				return NextActivity;
+				return true;
 			}
 
 			if (!aircraft.Info.CanHover)
@@ -216,7 +216,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude);
 
-			return this;
+			return false;
 		}
 
 		public override IEnumerable<Target> GetTargets(Actor self)

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -114,8 +114,8 @@ namespace OpenRA.Mods.Common.Activities
 			// If all valid weapons have depleted their ammo and Rearmable trait exists, return to RearmActor to reload and then resume the activity
 			if (rearmable != null && !useLastVisibleTarget && attackAircraft.Armaments.All(x => x.IsTraitPaused || !x.Weapon.IsValidAgainst(target, self.World, self)))
 			{
-				QueueChild(new ReturnToBase(self, aircraft.Info.AbortOnResupply));
-				return false;
+				QueueChild(new ReturnToBase(self));
+				return aircraft.Info.AbortOnResupply;
 			}
 
 			var pos = self.CenterPosition;

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -65,13 +65,6 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
-
 			// Refuse to take off if it would land immediately again.
 			if (aircraft.ForceLanding)
 				Cancel(self);
@@ -121,7 +114,7 @@ namespace OpenRA.Mods.Common.Activities
 			// If all valid weapons have depleted their ammo and Rearmable trait exists, return to RearmActor to reload and then resume the activity
 			if (rearmable != null && !useLastVisibleTarget && attackAircraft.Armaments.All(x => x.IsTraitPaused || !x.Weapon.IsValidAgainst(target, self.World, self)))
 			{
-				QueueChild(self, new ReturnToBase(self, aircraft.Info.AbortOnResupply), true);
+				QueueChild(new ReturnToBase(self, aircraft.Info.AbortOnResupply));
 				return this;
 			}
 
@@ -139,7 +132,7 @@ namespace OpenRA.Mods.Common.Activities
 				}
 
 				// Fly towards the last known position
-				QueueChild(self, new Fly(self, target, WDist.Zero, lastVisibleMaximumRange, checkTarget.CenterPosition, Color.Red), true);
+				QueueChild(new Fly(self, target, WDist.Zero, lastVisibleMaximumRange, checkTarget.CenterPosition, Color.Red));
 				return this;
 			}
 
@@ -148,21 +141,21 @@ namespace OpenRA.Mods.Common.Activities
 			var isAirborne = self.World.Map.DistanceAboveTerrain(pos).Length >= aircraft.Info.MinAirborneAltitude;
 
 			if (!isAirborne)
-				QueueChild(self, new TakeOff(self), true);
+				QueueChild(new TakeOff(self));
 
 			if (attackAircraft.Info.AttackType == AirAttackType.Strafe)
 			{
 				if (target.IsInRange(pos, attackAircraft.GetMinimumRange()))
-					QueueChild(self, new FlyTimed(ticksUntilTurn, self), true);
+					QueueChild(new FlyTimed(ticksUntilTurn, self));
 
-				QueueChild(self, new Fly(self, target, target.CenterPosition, Color.Red), true);
-				QueueChild(self, new FlyTimed(ticksUntilTurn, self));
+				QueueChild(new Fly(self, target, target.CenterPosition, Color.Red));
+				QueueChild(new FlyTimed(ticksUntilTurn, self));
 			}
 			else
 			{
 				var minimumRange = attackAircraft.GetMinimumRangeVersusTarget(target);
 				if (!target.IsInRange(pos, lastVisibleMaximumRange) || target.IsInRange(pos, minimumRange))
-					QueueChild(self, new Fly(self, target, minimumRange, lastVisibleMaximumRange, target.CenterPosition, Color.Red), true);
+					QueueChild(new Fly(self, target, minimumRange, lastVisibleMaximumRange, target.CenterPosition, Color.Red));
 				else if (isAirborne) // Don't use 'else' to avoid conflict with TakeOff
 					Fly.VerticalTakeOffOrLandTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude);
 			}

--- a/OpenRA.Mods.Common/Activities/Air/FlyCircle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyCircle.cs
@@ -27,20 +27,20 @@ namespace OpenRA.Mods.Common.Activities
 			this.turnSpeedOverride = turnSpeedOverride;
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			if (remainingTicks == 0 || (NextActivity != null && remainingTicks < 0))
-				return NextActivity;
+				return true;
 
 			// Refuse to take off if it would land immediately again.
 			if (aircraft.ForceLanding)
 			{
 				Cancel(self);
-				return NextActivity;
+				return true;
 			}
 
 			if (IsCanceling)
-				return NextActivity;
+				return true;
 
 			if (remainingTicks > 0)
 				remainingTicks--;
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			Fly.FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, move, turnSpeedOverride);
 
-			return this;
+			return false;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
@@ -47,13 +47,6 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
-
 			// Refuse to take off if it would land immediately again.
 			if (aircraft.ForceLanding)
 				Cancel(self);
@@ -96,7 +89,7 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			wasMovingWithinRange = true;
-			QueueChild(self, aircraft.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, targetLineColor), true);
+			QueueChild(aircraft.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, targetLineColor));
 			return this;
 		}
 	}

--- a/OpenRA.Mods.Common/Activities/Air/FlyOffMap.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyOffMap.cs
@@ -23,20 +23,20 @@ namespace OpenRA.Mods.Common.Activities
 			aircraft = self.Trait<Aircraft>();
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			// Refuse to take off if it would land immediately again.
 			if (aircraft.ForceLanding)
 			{
 				Cancel(self);
-				return NextActivity;
+				return true;
 			}
 
 			if (IsCanceling || !self.World.Map.Contains(self.Location))
-				return NextActivity;
+				return true;
 
 			Fly.FlyTick(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);
-			return this;
+			return false;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/FlyTimed.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyTimed.cs
@@ -27,21 +27,21 @@ namespace OpenRA.Mods.Common.Activities
 			cruiseAltitude = aircraft.Info.CruiseAltitude;
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			// Refuse to take off if it would land immediately again.
 			if (aircraft.ForceLanding)
 			{
 				Cancel(self);
-				return NextActivity;
+				return true;
 			}
 
 			if (IsCanceling || remainingTicks-- == 0)
-				return NextActivity;
+				return true;
 
 			Fly.FlyTick(self, aircraft, aircraft.Facing, cruiseAltitude);
 
-			return this;
+			return false;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -117,9 +117,8 @@ namespace OpenRA.Mods.Common.Activities
 				// Cannot land so fly towards the last target location instead.
 				if (!newLocation.HasValue)
 				{
-					Cancel(self, true);
 					QueueChild(aircraft.MoveTo(landingCell, 0));
-					return false;
+					return true;
 				}
 
 				if (newLocation.Value != landingCell)

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -73,13 +73,6 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
-
 			if (IsCanceling || target.Type == TargetType.Invalid)
 			{
 				if (landingInitiated)
@@ -94,7 +87,7 @@ namespace OpenRA.Mods.Common.Activities
 						var dat = self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition);
 						if (dat > aircraft.LandAltitude && dat < aircraft.Info.CruiseAltitude)
 						{
-							QueueChild(self, new TakeOff(self), true);
+							QueueChild(new TakeOff(self));
 							return this;
 						}
 
@@ -125,7 +118,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (!newLocation.HasValue)
 				{
 					Cancel(self, true);
-					QueueChild(self, aircraft.MoveTo(landingCell, 0), true);
+					QueueChild(aircraft.MoveTo(landingCell, 0));
 					return this;
 				}
 
@@ -140,10 +133,10 @@ namespace OpenRA.Mods.Common.Activities
 			// Move towards landing location
 			if (aircraft.Info.VTOL && (pos - targetPosition).HorizontalLengthSquared != 0)
 			{
-				QueueChild(self, new Fly(self, Target.FromPos(targetPosition)), true);
+				QueueChild(new Fly(self, Target.FromPos(targetPosition)));
 
 				if (desiredFacing != -1)
-					QueueChild(self, new Turn(self, desiredFacing));
+					QueueChild(new Turn(self, desiredFacing));
 
 				return this;
 			}
@@ -199,11 +192,11 @@ namespace OpenRA.Mods.Common.Activities
 				turnRadius = Fly.CalculateTurnRadius(aircraft.Info.Speed, aircraft.Info.TurnSpeed);
 
 				// Move along approach trajectory.
-				QueueChild(self, new Fly(self, Target.FromPos(w1), WDist.Zero, new WDist(turnRadius * 3)), true);
-				QueueChild(self, new Fly(self, Target.FromPos(w2)), true);
+				QueueChild(new Fly(self, Target.FromPos(w1), WDist.Zero, new WDist(turnRadius * 3)));
+				QueueChild(new Fly(self, Target.FromPos(w2)));
 
 				// Fix a problem when the airplane is sent to land near the landing cell
-				QueueChild(self, new Fly(self, Target.FromPos(w3), WDist.Zero, new WDist(turnRadius / 2)), true);
+				QueueChild(new Fly(self, Target.FromPos(w3), WDist.Zero, new WDist(turnRadius / 2)));
 				finishedApproach = true;
 				return this;
 			}
@@ -216,9 +209,9 @@ namespace OpenRA.Mods.Common.Activities
 				{
 					// Maintain holding pattern.
 					if (aircraft.Info.CanHover)
-						QueueChild(self, new Wait(25), true);
+						QueueChild(new Wait(25));
 					else
-						QueueChild(self, new FlyCircle(self, 25), true);
+						QueueChild(new FlyCircle(self, 25));
 
 					self.NotifyBlocker(blockingCells);
 					finishedApproach = false;

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -68,13 +68,6 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
-
 			// Refuse to take off if it would land immediately again.
 			// Special case: Don't kill other deploy hotkey activities.
 			if (aircraft.ForceLanding)
@@ -113,15 +106,14 @@ namespace OpenRA.Mods.Common.Activities
 							var randomPosition = WVec.FromPDF(self.World.SharedRandom, 2) * distanceLength / 1024;
 							var target = Target.FromPos(nearestResupplier.CenterPosition + randomPosition);
 
-							QueueChild(self, new Fly(self, target, WDist.Zero, aircraft.Info.WaitDistanceFromResupplyBase, targetLineColor: Color.Green), true);
+							QueueChild(new Fly(self, target, WDist.Zero, aircraft.Info.WaitDistanceFromResupplyBase, targetLineColor: Color.Green));
 						}
 
 						return this;
 					}
 
-					QueueChild(self, new Fly(self, Target.FromActor(nearestResupplier), WDist.Zero, aircraft.Info.WaitDistanceFromResupplyBase, targetLineColor: Color.Green),
-							true);
-					QueueChild(self, new FlyCircle(self, aircraft.Info.NumberOfTicksToVerifyAvailableAirport), true);
+					QueueChild(new Fly(self, Target.FromActor(nearestResupplier), WDist.Zero, aircraft.Info.WaitDistanceFromResupplyBase, targetLineColor: Color.Green));
+					QueueChild(new FlyCircle(self, aircraft.Info.NumberOfTicksToVerifyAvailableAirport));
 					return this;
 				}
 
@@ -140,13 +132,13 @@ namespace OpenRA.Mods.Common.Activities
 					facing = 192;
 
 				aircraft.MakeReservation(dest);
-				QueueChild(self, new Land(self, Target.FromActor(dest), offset, facing), true);
-				QueueChild(self, new Resupply(self, dest, WDist.Zero), true);
+				QueueChild(new Land(self, Target.FromActor(dest), offset, facing));
+				QueueChild(new Resupply(self, dest, WDist.Zero));
 				if (aircraft.Info.TakeOffOnResupply && !alwaysLand)
-					QueueChild(self, new TakeOff(self));
+					QueueChild(new TakeOff(self));
 			}
 			else
-				QueueChild(self, new Fly(self, Target.FromActor(dest)), true);
+				QueueChild(new Fly(self, Target.FromActor(dest)));
 
 			resupplied = true;
 			return this;

--- a/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
+++ b/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
@@ -62,13 +62,13 @@ namespace OpenRA.Mods.Common.Activities
 				Game.Sound.Play(SoundType.World, aircraft.Info.TakeoffSounds, self.World, aircraft.CenterPosition);
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			// Refuse to take off if it would land immediately again.
 			if (aircraft.ForceLanding)
 			{
 				Cancel(self);
-				return NextActivity;
+				return true;
 			}
 
 			var dat = self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition);
@@ -78,12 +78,12 @@ namespace OpenRA.Mods.Common.Activities
 				if (aircraft.Info.VTOL)
 				{
 					Fly.VerticalTakeOffOrLandTick(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);
-					return this;
+					return false;
 				}
 				else
 				{
 					Fly.FlyTick(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);
-					return this;
+					return false;
 				}
 			}
 
@@ -91,14 +91,14 @@ namespace OpenRA.Mods.Common.Activities
 			if (moveToRallyPoint && NextActivity == null)
 			{
 				if (!aircraft.Info.VTOL && assignTargetOnFirstRun)
-					return NextActivity;
+					return true;
 
 				QueueChild(new AttackMoveActivity(self, () => move.MoveToTarget(self, target)));
 				moveToRallyPoint = false;
-				return this;
+				return false;
 			}
 
-			return NextActivity;
+			return true;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
+++ b/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
@@ -64,13 +64,6 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
-
 			// Refuse to take off if it would land immediately again.
 			if (aircraft.ForceLanding)
 			{
@@ -100,7 +93,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (!aircraft.Info.VTOL && assignTargetOnFirstRun)
 					return NextActivity;
 
-				QueueChild(self, new AttackMoveActivity(self, () => move.MoveToTarget(self, target)), true);
+				QueueChild(new AttackMoveActivity(self, () => move.MoveToTarget(self, target)));
 				moveToRallyPoint = false;
 				return this;
 			}

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -85,12 +85,6 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				return this;
-			}
-
 			if (IsCanceling)
 				return NextActivity;
 
@@ -135,7 +129,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				// Move towards the last known position
 				wasMovingWithinRange = true;
-				QueueChild(self, move.MoveWithinRange(target, WDist.Zero, lastVisibleMaximumRange, checkTarget.CenterPosition, Color.Red), true);
+				QueueChild(move.MoveWithinRange(target, WDist.Zero, lastVisibleMaximumRange, checkTarget.CenterPosition, Color.Red));
 				return this;
 			}
 
@@ -178,7 +172,7 @@ namespace OpenRA.Mods.Common.Activities
 				var sightRange = rs != null ? rs.Range : WDist.FromCells(2);
 
 				attackStatus |= AttackStatus.NeedsToMove;
-				QueueChild(self, move.MoveWithinRange(target, sightRange, target.CenterPosition, Color.Red), true);
+				QueueChild(move.MoveWithinRange(target, sightRange, target.CenterPosition, Color.Red));
 				return AttackStatus.NeedsToMove;
 			}
 
@@ -203,7 +197,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				attackStatus |= AttackStatus.NeedsToMove;
 				var checkTarget = useLastVisibleTarget ? lastVisibleTarget : target;
-				QueueChild(self, move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, Color.Red), true);
+				QueueChild(move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, Color.Red));
 				return AttackStatus.NeedsToMove;
 			}
 
@@ -211,7 +205,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				var desiredFacing = (attack.GetTargetPosition(pos, target) - pos).Yaw.Facing;
 				attackStatus |= AttackStatus.NeedsToTurn;
-				QueueChild(self, new Turn(self, desiredFacing), true);
+				QueueChild(new Turn(self, desiredFacing));
 				return AttackStatus.NeedsToTurn;
 			}
 

--- a/OpenRA.Mods.Common/Activities/DeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverResources.cs
@@ -22,8 +22,6 @@ namespace OpenRA.Mods.Common.Activities
 		readonly Harvester harv;
 		readonly Actor targetActor;
 
-		bool isDocking;
-
 		public DeliverResources(Actor self, Actor targetActor = null)
 		{
 			movement = self.Trait<IMove>();
@@ -39,7 +37,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override bool Tick(Actor self)
 		{
-			if (IsCanceling || isDocking)
+			if (IsCanceling)
 				return true;
 
 			// Find the nearest best refinery if not explicitly ordered to a specific refinery:
@@ -66,14 +64,8 @@ namespace OpenRA.Mods.Common.Activities
 				return false;
 			}
 
-			if (!isDocking)
-			{
-				QueueChild(new Wait(10));
-				isDocking = true;
-				iao.OnDock(self, this);
-				return false;
-			}
-
+			QueueChild(new Wait(10));
+			iao.OnDock(self, this);
 			return true;
 		}
 	}

--- a/OpenRA.Mods.Common/Activities/DeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverResources.cs
@@ -37,10 +37,10 @@ namespace OpenRA.Mods.Common.Activities
 				harv.LinkProc(self, targetActor);
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			if (IsCanceling || isDocking)
-				return NextActivity;
+				return true;
 
 			// Find the nearest best refinery if not explicitly ordered to a specific refinery:
 			if (harv.LinkedProc == null || !harv.LinkedProc.IsInWorld)
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (harv.LinkedProc == null)
 			{
 				QueueChild(new Wait(harv.Info.SearchForDeliveryBuildingDelay));
-				return this;
+				return false;
 			}
 
 			var proc = harv.LinkedProc;
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Activities
 					n.MovingToRefinery(self, proc, new FindAndDeliverResources(self));
 
 				QueueChild(movement.MoveTo(proc.Location + iao.DeliveryOffset, 0));
-				return this;
+				return false;
 			}
 
 			if (!isDocking)
@@ -71,10 +71,10 @@ namespace OpenRA.Mods.Common.Activities
 				QueueChild(new Wait(10));
 				isDocking = true;
 				iao.OnDock(self, this);
-				return this;
+				return false;
 			}
 
-			return NextActivity;
+			return true;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/DeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverResources.cs
@@ -39,13 +39,6 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
-
 			if (IsCanceling || isDocking)
 				return NextActivity;
 
@@ -56,7 +49,7 @@ namespace OpenRA.Mods.Common.Activities
 			// No refineries exist; check again after delay defined in Harvester.
 			if (harv.LinkedProc == null)
 			{
-				QueueChild(self, new Wait(harv.Info.SearchForDeliveryBuildingDelay), true);
+				QueueChild(new Wait(harv.Info.SearchForDeliveryBuildingDelay));
 				return this;
 			}
 
@@ -69,13 +62,13 @@ namespace OpenRA.Mods.Common.Activities
 				foreach (var n in self.TraitsImplementing<INotifyHarvesterAction>())
 					n.MovingToRefinery(self, proc, new FindAndDeliverResources(self));
 
-				QueueChild(self, movement.MoveTo(proc.Location + iao.DeliveryOffset, 0), true);
+				QueueChild(movement.MoveTo(proc.Location + iao.DeliveryOffset, 0));
 				return this;
 			}
 
 			if (!isDocking)
 			{
-				QueueChild(self, new Wait(10), true);
+				QueueChild(new Wait(10));
 				isDocking = true;
 				iao.OnDock(self, this);
 				return this;

--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -50,12 +50,6 @@ namespace OpenRA.Mods.Common.Activities
 			QueueChild(new TakeOff(self));
 		}
 
-		public override Activity Tick(Actor self)
-		{
-
-			return NextActivity;
-		}
-
 		class ReleaseUnit : Activity
 		{
 			readonly Carryall carryall;
@@ -97,11 +91,6 @@ namespace OpenRA.Mods.Common.Activities
 					carryable.UnReserve(cargo);
 					carryable.Detached(cargo);
 				});
-			}
-
-			public override Activity Tick(Actor self)
-			{
-				return NextActivity;
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -44,20 +44,14 @@ namespace OpenRA.Mods.Common.Activities
 			if (assignTargetOnFirstRun)
 				destination = Target.FromCell(self.World, self.Location);
 
-			QueueChild(self, new Land(self, destination, deliverRange), true);
-			QueueChild(self, new Wait(carryall.Info.BeforeUnloadDelay, false), true);
-			QueueChild(self, new ReleaseUnit(self));
-			QueueChild(self, new TakeOff(self));
+			QueueChild(new Land(self, destination, deliverRange));
+			QueueChild(new Wait(carryall.Info.BeforeUnloadDelay, false));
+			QueueChild(new ReleaseUnit(self));
+			QueueChild(new TakeOff(self));
 		}
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
 
 			return NextActivity;
 		}

--- a/OpenRA.Mods.Common/Activities/DeployForGrantedCondition.cs
+++ b/OpenRA.Mods.Common/Activities/DeployForGrantedCondition.cs
@@ -36,15 +36,15 @@ namespace OpenRA.Mods.Common.Activities
 				QueueChild(new Turn(self, deploy.Info.Facing));
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			if (IsCanceling || initiated || (deploy.DeployState != DeployState.Deployed && moving))
-				return NextActivity;
+				return true;
 
 			QueueChild(new DeployInner(self, deploy));
 
 			initiated = true;
-			return this;
+			return false;
 		}
 	}
 
@@ -61,14 +61,14 @@ namespace OpenRA.Mods.Common.Activities
 			IsInterruptible = false;
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			// Wait for deployment
 			if (deployment.DeployState == DeployState.Deploying || deployment.DeployState == DeployState.Undeploying)
-				return this;
+				return false;
 
 			if (initiated)
-				return NextActivity;
+				return true;
 
 			if (deployment.DeployState == DeployState.Undeployed)
 				deployment.Deploy();
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.Activities
 				deployment.Undeploy();
 
 			initiated = true;
-			return this;
+			return false;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/DeployForGrantedCondition.cs
+++ b/OpenRA.Mods.Common/Activities/DeployForGrantedCondition.cs
@@ -33,22 +33,15 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			// Turn to the required facing.
 			if (deploy.DeployState == DeployState.Undeployed && deploy.Info.Facing != -1 && canTurn && !moving)
-				QueueChild(self, new Turn(self, deploy.Info.Facing));
+				QueueChild(new Turn(self, deploy.Info.Facing));
 		}
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
-
 			if (IsCanceling || initiated || (deploy.DeployState != DeployState.Deployed && moving))
 				return NextActivity;
 
-			QueueChild(self, new DeployInner(self, deploy), true);
+			QueueChild(new DeployInner(self, deploy));
 
 			initiated = true;
 			return this;

--- a/OpenRA.Mods.Common/Activities/DeployForGrantedCondition.cs
+++ b/OpenRA.Mods.Common/Activities/DeployForGrantedCondition.cs
@@ -20,7 +20,6 @@ namespace OpenRA.Mods.Common.Activities
 		readonly GrantConditionOnDeploy deploy;
 		readonly bool canTurn;
 		readonly bool moving;
-		bool initiated;
 
 		public DeployForGrantedCondition(Actor self, GrantConditionOnDeploy deploy, bool moving = false)
 		{
@@ -38,13 +37,11 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override bool Tick(Actor self)
 		{
-			if (IsCanceling || initiated || (deploy.DeployState != DeployState.Deployed && moving))
+			if (IsCanceling || (deploy.DeployState != DeployState.Deployed && moving))
 				return true;
 
 			QueueChild(new DeployInner(self, deploy));
-
-			initiated = true;
-			return false;
+			return true;
 		}
 	}
 

--- a/OpenRA.Mods.Common/Activities/Enter.cs
+++ b/OpenRA.Mods.Common/Activities/Enter.cs
@@ -35,6 +35,7 @@ namespace OpenRA.Mods.Common.Activities
 			move = self.Trait<IMove>();
 			this.target = target;
 			this.targetLineColor = targetLineColor;
+			ChildHasPriority = false;
 		}
 
 		/// <summary>
@@ -80,12 +81,9 @@ namespace OpenRA.Mods.Common.Activities
 
 			// We need to wait for movement to finish before transitioning to
 			// the next state or next activity
+			ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
 			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
+				return this;
 
 			// Note that lastState refers to what we have just *finished* doing
 			switch (lastState)
@@ -106,7 +104,7 @@ namespace OpenRA.Mods.Common.Activities
 					{
 						// Target lines are managed by this trait, so we do not pass targetLineColor
 						var initialTargetPosition = (useLastVisibleTarget ? lastVisibleTarget : target).CenterPosition;
-						QueueChild(self, move.MoveToTarget(self, target, initialTargetPosition), true);
+						QueueChild(move.MoveToTarget(self, target, initialTargetPosition));
 						return this;
 					}
 
@@ -119,7 +117,7 @@ namespace OpenRA.Mods.Common.Activities
 					if (TryStartEnter(self, target.Actor))
 					{
 						lastState = EnterState.Entering;
-						QueueChild(self, move.MoveIntoTarget(self, target), true);
+						QueueChild(move.MoveIntoTarget(self, target));
 						return this;
 					}
 
@@ -139,7 +137,7 @@ namespace OpenRA.Mods.Common.Activities
 						OnEnterComplete(self, target.Actor);
 
 					lastState = EnterState.Exiting;
-					QueueChild(self, move.MoveIntoWorld(self, self.Location), true);
+					QueueChild(move.MoveIntoWorld(self, self.Location));
 					return this;
 				}
 

--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -65,26 +65,19 @@ namespace OpenRA.Mods.Common.Activities
 				// We have to make sure the actual "harvest" order is not skipped if a third order is queued,
 				// so we keep deliveredLoad false.
 				if (harv.IsFull)
-					QueueChild(self, new DeliverResources(self), true);
+					QueueChild(new DeliverResources(self));
 			}
 
 			// If an explicit "deliver" order is given, the harvester goes immediately to the refinery.
 			if (deliverActor != null)
 			{
-				QueueChild(self, new DeliverResources(self, deliverActor), true);
+				QueueChild(new DeliverResources(self, deliverActor));
 				hasDeliveredLoad = true;
 			}
 		}
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
-
 			if (IsCanceling)
 				return NextActivity;
 
@@ -102,7 +95,7 @@ namespace OpenRA.Mods.Common.Activities
 			// Are we full or have nothing more to gather? Deliver resources.
 			if (harv.IsFull || (!harv.IsEmpty && harv.LastSearchFailed))
 			{
-				QueueChild(self, new DeliverResources(self), true);
+				QueueChild(new DeliverResources(self));
 				hasDeliveredLoad = true;
 				return this;
 			}
@@ -110,7 +103,7 @@ namespace OpenRA.Mods.Common.Activities
 			// After a failed search, wait and sit still for a bit before searching again.
 			if (harv.LastSearchFailed && !hasWaited)
 			{
-				QueueChild(self, new Wait(harv.Info.WaitDuration), true);
+				QueueChild(new Wait(harv.Info.WaitDuration));
 				hasWaited = true;
 				return this;
 			}
@@ -147,7 +140,7 @@ namespace OpenRA.Mods.Common.Activities
 						var unblockCell = deliveryLoc + harv.Info.UnblockCell;
 						var moveTo = mobile.NearestMoveableCell(unblockCell, 1, 5);
 						self.SetTargetLine(Target.FromCell(self.World, moveTo), Color.Green, false);
-						QueueChild(self, mobile.MoveTo(moveTo, 1), true);
+						QueueChild(mobile.MoveTo(moveTo, 1));
 					}
 				}
 
@@ -155,7 +148,7 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			// If we get here, our search for resources was successful. Commence harvesting.
-			QueueChild(self, new HarvestResource(self, closestHarvestableCell.Value), true);
+			QueueChild(new HarvestResource(self, closestHarvestableCell.Value));
 			lastHarvestedCell = closestHarvestableCell.Value;
 			hasHarvestedCell = true;
 			return this;

--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -76,20 +76,20 @@ namespace OpenRA.Mods.Common.Activities
 			}
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			if (IsCanceling)
-				return NextActivity;
+				return true;
 
 			if (NextActivity != null)
 			{
 				// Interrupt automated harvesting after clearing the first cell.
 				if (!harvInfo.QueueFullLoad && (hasHarvestedCell || harv.LastSearchFailed))
-					return NextActivity;
+					return true;
 
 				// Interrupt automated harvesting after first complete harvest cycle.
 				if (hasDeliveredLoad || harv.IsFull)
-					return NextActivity;
+					return true;
 			}
 
 			// Are we full or have nothing more to gather? Deliver resources.
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				QueueChild(new DeliverResources(self));
 				hasDeliveredLoad = true;
-				return this;
+				return false;
 			}
 
 			// After a failed search, wait and sit still for a bit before searching again.
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				QueueChild(new Wait(harv.Info.WaitDuration));
 				hasWaited = true;
-				return this;
+				return false;
 			}
 
 			hasWaited = false;
@@ -144,14 +144,14 @@ namespace OpenRA.Mods.Common.Activities
 					}
 				}
 
-				return this;
+				return false;
 			}
 
 			// If we get here, our search for resources was successful. Commence harvesting.
 			QueueChild(new HarvestResource(self, closestHarvestableCell.Value));
 			lastHarvestedCell = closestHarvestableCell.Value;
 			hasHarvestedCell = true;
-			return this;
+			return false;
 		}
 
 		/// <summary>

--- a/OpenRA.Mods.Common/Activities/HarvestResource.cs
+++ b/OpenRA.Mods.Common/Activities/HarvestResource.cs
@@ -49,13 +49,6 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
-
 			if (IsCanceling || harv.IsFull)
 				return NextActivity;
 
@@ -66,7 +59,7 @@ namespace OpenRA.Mods.Common.Activities
 					n.MovingToResources(self, targetCell, new FindAndDeliverResources(self));
 
 				self.SetTargetLine(Target.FromCell(self.World, targetCell), Color.Red, false);
-				QueueChild(self, move.MoveTo(targetCell, 2), true);
+				QueueChild(move.MoveTo(targetCell, 2));
 				return this;
 			}
 
@@ -80,7 +73,7 @@ namespace OpenRA.Mods.Common.Activities
 				var desired = body.QuantizeFacing(current, harvInfo.HarvestFacings);
 				if (desired != current)
 				{
-					QueueChild(self, new Turn(self, desired), true);
+					QueueChild(new Turn(self, desired));
 					return this;
 				}
 			}
@@ -94,7 +87,7 @@ namespace OpenRA.Mods.Common.Activities
 			foreach (var t in self.TraitsImplementing<INotifyHarvesterAction>())
 				t.Harvested(self, resource);
 
-			QueueChild(self, new Wait(harvInfo.BaleLoadDelay), true);
+			QueueChild(new Wait(harvInfo.BaleLoadDelay));
 			return this;
 		}
 

--- a/OpenRA.Mods.Common/Activities/HarvestResource.cs
+++ b/OpenRA.Mods.Common/Activities/HarvestResource.cs
@@ -47,10 +47,10 @@ namespace OpenRA.Mods.Common.Activities
 			claimLayer.TryClaimCell(self, targetCell);
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			if (IsCanceling || harv.IsFull)
-				return NextActivity;
+				return true;
 
 			// Move towards the target cell
 			if (self.Location != targetCell)
@@ -60,11 +60,11 @@ namespace OpenRA.Mods.Common.Activities
 
 				self.SetTargetLine(Target.FromCell(self.World, targetCell), Color.Red, false);
 				QueueChild(move.MoveTo(targetCell, 2));
-				return this;
+				return false;
 			}
 
 			if (!harv.CanHarvestCell(self, self.Location))
-				return NextActivity;
+				return true;
 
 			// Turn to one of the harvestable facings
 			if (harvInfo.HarvestFacings != 0)
@@ -74,13 +74,13 @@ namespace OpenRA.Mods.Common.Activities
 				if (desired != current)
 				{
 					QueueChild(new Turn(self, desired));
-					return this;
+					return false;
 				}
 			}
 
 			var resource = resLayer.Harvest(self.Location);
 			if (resource == null)
-				return NextActivity;
+				return true;
 
 			harv.AcceptResource(self, resource);
 
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Activities
 				t.Harvested(self, resource);
 
 			QueueChild(new Wait(harvInfo.BaleLoadDelay));
-			return this;
+			return false;
 		}
 
 		protected override void OnLastRun(Actor self)

--- a/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
@@ -47,13 +47,6 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
-
 			switch (dockingState)
 			{
 				case DockingState.Wait:
@@ -61,9 +54,9 @@ namespace OpenRA.Mods.Common.Activities
 
 				case DockingState.Turn:
 					dockingState = DockingState.Dock;
-					QueueChild(self, new Turn(self, DockAngle), true);
+					QueueChild(new Turn(self, DockAngle));
 					if (IsDragRequired)
-						QueueChild(self, new Drag(self, StartDrag, EndDrag, DragLength));
+						QueueChild(new Drag(self, StartDrag, EndDrag, DragLength));
 					return this;
 
 				case DockingState.Dock:
@@ -90,7 +83,7 @@ namespace OpenRA.Mods.Common.Activities
 					Harv.LastLinkedProc = Harv.LinkedProc;
 					Harv.LinkProc(self, null);
 					if (IsDragRequired)
-						QueueChild(self, new Drag(self, EndDrag, StartDrag, DragLength), true);
+						QueueChild(new Drag(self, EndDrag, StartDrag, DragLength));
 
 					dockingState = DockingState.Finished;
 					return this;

--- a/OpenRA.Mods.Common/Activities/Hunt.cs
+++ b/OpenRA.Mods.Common/Activities/Hunt.cs
@@ -31,18 +31,18 @@ namespace OpenRA.Mods.Common.Activities
 				&& a.IsTargetableBy(self) && attack.HasAnyValidWeapons(Target.FromActor(a)));
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			if (IsCanceling)
-				return NextActivity;
+				return true;
 
 			var target = targets.ClosestTo(self);
 			if (target == null)
-				return this;
+				return false;
 
 			QueueChild(new AttackMoveActivity(self, () => move.MoveTo(target.Location, 2)));
 			QueueChild(new Wait(25));
-			return this;
+			return false;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Hunt.cs
+++ b/OpenRA.Mods.Common/Activities/Hunt.cs
@@ -33,13 +33,6 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
-
 			if (IsCanceling)
 				return NextActivity;
 
@@ -47,8 +40,8 @@ namespace OpenRA.Mods.Common.Activities
 			if (target == null)
 				return this;
 
-			QueueChild(self, new AttackMoveActivity(self, () => move.MoveTo(target.Location, 2)), true);
-			QueueChild(self, new Wait(25));
+			QueueChild(new AttackMoveActivity(self, () => move.MoveTo(target.Location, 2)));
+			QueueChild(new Wait(25));
 			return this;
 		}
 	}

--- a/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
+++ b/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Activities
 				token = conditionManager.GrantCondition(self, attackMove.Info.AssaultMoveCondition);
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			// We are not currently attacking a target, so scan for new targets.
 			if (!IsCanceling && ChildActivity != null && ChildActivity.NextActivity == null && autoTarget != null)
@@ -74,13 +74,9 @@ namespace OpenRA.Mods.Common.Activities
 				}
 			}
 
-			ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-			if (ChildActivity != null)
-				return this;
-
-			// The last queued childactivity is guaranteed to be the inner move, so if we get here it means
-			// we have reached our destination and there are no more enemies on our path.
-			return NextActivity;
+			// The last queued childactivity is guaranteed to be the inner move, so if the childactivity
+			// queue is empty it means we have reached our destination and there are no more enemies on our path.
+			return TickChild(self);
 		}
 
 		protected override void OnLastRun(Actor self)

--- a/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
+++ b/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
@@ -33,12 +33,13 @@ namespace OpenRA.Mods.Common.Activities
 			conditionManager = self.TraitOrDefault<ConditionManager>();
 			attackMove = self.TraitOrDefault<AttackMove>();
 			isAssaultMove = assaultMoving;
+			ChildHasPriority = false;
 		}
 
 		protected override void OnFirstRun(Actor self)
 		{
 			// Start moving.
-			QueueChild(self, getInner());
+			QueueChild(getInner());
 
 			if (conditionManager == null || attackMove == null)
 				return;
@@ -64,21 +65,18 @@ namespace OpenRA.Mods.Common.Activities
 					foreach (var ab in attackBases)
 					{
 						var activity = ab.GetAttackActivity(self, target, true, false);
-						QueueChild(self, activity);
+						QueueChild(activity);
 						ab.OnQueueAttackActivity(self, activity, target, true, false);
 					}
 
 					// Make sure to continue moving when the attack activities have finished.
-					QueueChild(self, getInner());
+					QueueChild(getInner());
 				}
 			}
 
+			ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
 			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
+				return this;
 
 			// The last queued childactivity is guaranteed to be the inner move, so if we get here it means
 			// we have reached our destination and there are no more enemies on our path.

--- a/OpenRA.Mods.Common/Activities/Move/Drag.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Drag.cs
@@ -34,10 +34,10 @@ namespace OpenRA.Mods.Common.Activities
 			IsInterruptible = false;
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			if (disableable != null && disableable.IsTraitDisabled)
-				return this;
+				return false;
 
 			var pos = length > 1
 				? WPos.Lerp(start, end, ticks, length - 1)
@@ -45,9 +45,9 @@ namespace OpenRA.Mods.Common.Activities
 
 			positionable.SetVisualPosition(self, pos);
 			if (++ticks >= length)
-				return NextActivity;
+				return true;
 
-			return this;
+			return false;
 		}
 
 		public override IEnumerable<Target> GetTargets(Actor self)

--- a/OpenRA.Mods.Common/Activities/Move/Follow.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Follow.cs
@@ -47,13 +47,6 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
-
 			if (IsCanceling)
 				return NextActivity;
 
@@ -90,7 +83,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Move into range
 			wasMovingWithinRange = true;
-			QueueChild(self, move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, targetLineColor), true);
+			QueueChild(move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, targetLineColor));
 			return this;
 		}
 	}

--- a/OpenRA.Mods.Common/Activities/Move/Follow.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Follow.cs
@@ -45,10 +45,10 @@ namespace OpenRA.Mods.Common.Activities
 				lastVisibleTarget = Target.FromPos(initialTargetPosition.Value);
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			if (IsCanceling)
-				return NextActivity;
+				return true;
 
 			bool targetIsHiddenActor;
 			target = target.Recalculate(self.Owner, out targetIsHiddenActor);
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Activities
 			// If we are ticking again after previously sequencing a MoveWithRange then that move must have completed
 			// Either we are in range and can see the target, or we've lost track of it and should give up
 			if (wasMovingWithinRange && targetIsHiddenActor)
-				return NextActivity;
+				return true;
 
 			wasMovingWithinRange = false;
 
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Target is hidden or dead, and we don't have a fallback position to move towards
 			if (useLastVisibleTarget && !lastVisibleTarget.IsValidFor(self))
-				return NextActivity;
+				return true;
 
 			var pos = self.CenterPosition;
 			var checkTarget = useLastVisibleTarget ? lastVisibleTarget : target;
@@ -79,12 +79,12 @@ namespace OpenRA.Mods.Common.Activities
 			// We've reached the required range - if the target is visible and valid then we wait
 			// otherwise if it is hidden or dead we give up
 			if (checkTarget.IsInRange(pos, maxRange) && !checkTarget.IsInRange(pos, minRange))
-				return useLastVisibleTarget ? NextActivity : this;
+				return useLastVisibleTarget;
 
 			// Move into range
 			wasMovingWithinRange = true;
 			QueueChild(move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, targetLineColor));
-			return this;
+			return false;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -144,18 +144,18 @@ namespace OpenRA.Mods.Common.Activities
 			}
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			// If the actor is inside a tunnel then we must let them move
 			// all the way through before moving to the next activity
 			if (IsCanceling && self.Location.Layer != CustomMovementLayerType.Tunnel)
-				return NextActivity;
+				return true;
 
 			if (mobile.IsTraitDisabled || mobile.IsTraitPaused)
-				return this;
+				return false;
 
 			if (destination == mobile.ToCell)
-				return NextActivity;
+				return true;
 
 			if (path == null)
 				path = EvalPath();
@@ -163,22 +163,21 @@ namespace OpenRA.Mods.Common.Activities
 			if (path.Count == 0)
 			{
 				destination = mobile.ToCell;
-				return this;
+				return false;
 			}
 
 			destination = path[0];
 
 			var nextCell = PopPath(self);
 			if (nextCell == null)
-				return this;
+				return false;
 
 			var firstFacing = self.World.Map.FacingBetween(mobile.FromCell, nextCell.Value.First, mobile.Facing);
 			if (firstFacing != mobile.Facing)
 			{
 				path.Add(nextCell.Value.First);
-
 				QueueChild(new Turn(self, firstFacing));
-				return this;
+				return false;
 			}
 
 			mobile.SetLocation(mobile.FromCell, mobile.FromSubCell, nextCell.Value.First, nextCell.Value.Second);
@@ -192,7 +191,7 @@ namespace OpenRA.Mods.Common.Activities
 				(map.Grid.OffsetOfSubCell(mobile.FromSubCell) + map.Grid.OffsetOfSubCell(mobile.ToSubCell)) / 2;
 
 			QueueChild(new MoveFirstHalf(this, from, to, mobile.Facing, mobile.Facing, 0));
-			return this;
+			return false;
 		}
 
 		Pair<CPos, SubCell>? PopPath(Actor self)
@@ -309,10 +308,10 @@ namespace OpenRA.Mods.Common.Activities
 				}
 			}
 
-			public override Activity Tick(Actor self)
+			public override bool Tick(Actor self)
 			{
 				if (Move.mobile.IsTraitDisabled)
-					return this;
+					return false;
 
 				var ret = InnerTick(self, Move.mobile);
 
@@ -322,10 +321,10 @@ namespace OpenRA.Mods.Common.Activities
 				UpdateCenterLocation(self, Move.mobile);
 
 				if (ret == this)
-					return ret;
+					return false;
 
 				Queue(ret);
-				return NextActivity;
+				return true;
 			}
 
 			Activity InnerTick(Actor self, Mobile mobile)

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -146,17 +146,6 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			// Let the child be run so that units will not end up in an odd place.
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-
-				// Child activities such as Turn might have finished.
-				// If we "return this" in this situation, the unit loses one tick and pauses movement briefly.
-				if (ChildActivity != null)
-					return this;
-			}
-
 			// If the actor is inside a tunnel then we must let them move
 			// all the way through before moving to the next activity
 			if (IsCanceling && self.Location.Layer != CustomMovementLayerType.Tunnel)
@@ -188,7 +177,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				path.Add(nextCell.Value.First);
 
-				QueueChild(self, new Turn(self, firstFacing), true);
+				QueueChild(new Turn(self, firstFacing));
 				return this;
 			}
 
@@ -202,7 +191,7 @@ namespace OpenRA.Mods.Common.Activities
 			var to = Util.BetweenCells(self.World, mobile.FromCell, mobile.ToCell) +
 				(map.Grid.OffsetOfSubCell(mobile.FromSubCell) + map.Grid.OffsetOfSubCell(mobile.ToSubCell)) / 2;
 
-			QueueChild(self, new MoveFirstHalf(this, from, to, mobile.Facing, mobile.Facing, 0), true);
+			QueueChild(new MoveFirstHalf(this, from, to, mobile.Facing, mobile.Facing, 0));
 			return this;
 		}
 
@@ -335,7 +324,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (ret == this)
 					return ret;
 
-				Queue(self, ret);
+				Queue(ret);
 				return NextActivity;
 			}
 

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Activities
 			QueueChild(Mobile.MoveTo(() => CalculatePathToTarget(self)));
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			bool targetIsHiddenActor;
 			var oldTargetLocation = lastVisibleTargetLocation;
@@ -119,11 +119,9 @@ namespace OpenRA.Mods.Common.Activities
 			if (!IsCanceling && shouldRepath)
 				QueueChild(Mobile.MoveTo(() => CalculatePathToTarget(self)));
 
-			ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-			if (ChildActivity != null)
-				return this;
-
-			return NextActivity;
+			// The last queued childactivity is guaranteed to be the inner move, so if the childactivity
+			// queue is empty it means we have reached our destination.
+			return TickChild(self);
 		}
 
 		List<CPos> CalculatePathToTarget(Actor self)

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -48,6 +48,7 @@ namespace OpenRA.Mods.Common.Activities
 			Mobile = self.Trait<Mobile>();
 			pathFinder = self.World.WorldActor.Trait<IPathFinder>();
 			domainIndex = self.World.WorldActor.Trait<DomainIndex>();
+			ChildHasPriority = false;
 
 			// The target may become hidden between the initial order request and the first tick (e.g. if queued)
 			// Moving to any position (even if quite stale) is still better than immediately giving up
@@ -81,7 +82,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected override void OnFirstRun(Actor self)
 		{
-			QueueChild(self, Mobile.MoveTo(() => CalculatePathToTarget(self)));
+			QueueChild(Mobile.MoveTo(() => CalculatePathToTarget(self)));
 		}
 
 		public override Activity Tick(Actor self)
@@ -116,7 +117,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Target has moved, and MoveAdjacentTo is still valid.
 			if (!IsCanceling && shouldRepath)
-				QueueChild(self, Mobile.MoveTo(() => CalculatePathToTarget(self)));
+				QueueChild(Mobile.MoveTo(() => CalculatePathToTarget(self)));
 
 			ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
 			if (ChildActivity != null)

--- a/OpenRA.Mods.Common/Activities/Move/VisualMoveIntoTarget.cs
+++ b/OpenRA.Mods.Common/Activities/Move/VisualMoveIntoTarget.cs
@@ -35,31 +35,28 @@ namespace OpenRA.Mods.Common.Activities
 			targetStartPos = target.Positions.PositionClosestTo(self.CenterPosition);
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			if (IsCanceling || target.Type == TargetType.Invalid)
-				return NextActivity;
+				return true;
 
 			if (mobile.IsTraitDisabled || mobile.IsTraitPaused)
-				return this;
+				return false;
 
 			var currentPos = self.CenterPosition;
 			var targetPos = target.Positions.PositionClosestTo(currentPos);
 
 			// Give up if the target has moved too far
 			if (targetMovementThreshold > WDist.Zero && (targetPos - targetStartPos).LengthSquared > targetMovementThreshold.LengthSquared)
-				return NextActivity;
+				return true;
 
 			// Turn if required
 			var delta = targetPos - currentPos;
 			var facing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : mobile.Facing;
 			if (facing != mobile.Facing)
 			{
-				var turn = ActivityUtils.RunActivity(self, new Turn(self, facing));
-				if (turn != null)
-					QueueChild(turn);
-
-				return this;
+				QueueChild(new Turn(self, facing));
+				return false;
 			}
 
 			// Can complete the move in this step
@@ -67,13 +64,12 @@ namespace OpenRA.Mods.Common.Activities
 			if (delta.LengthSquared <= speed * speed)
 			{
 				mobile.SetVisualPosition(self, targetPos);
-				return NextActivity;
+				return true;
 			}
 
 			// Move towards the target
 			mobile.SetVisualPosition(self, currentPos + delta * speed / delta.Length);
-
-			return this;
+			return false;
 		}
 
 		public override IEnumerable<Target> GetTargets(Actor self)

--- a/OpenRA.Mods.Common/Activities/Move/VisualMoveIntoTarget.cs
+++ b/OpenRA.Mods.Common/Activities/Move/VisualMoveIntoTarget.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Activities
 			var facing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : mobile.Facing;
 			if (facing != mobile.Facing)
 			{
-				QueueChild(new Turn(self, facing));
+				mobile.Facing = Util.TickFacing(mobile.Facing, facing, mobile.TurnSpeed);
 				return false;
 			}
 

--- a/OpenRA.Mods.Common/Activities/Move/VisualMoveIntoTarget.cs
+++ b/OpenRA.Mods.Common/Activities/Move/VisualMoveIntoTarget.cs
@@ -37,13 +37,6 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
-
 			if (IsCanceling || target.Type == TargetType.Invalid)
 				return NextActivity;
 
@@ -64,7 +57,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				var turn = ActivityUtils.RunActivity(self, new Turn(self, facing));
 				if (turn != null)
-					QueueChild(self, turn);
+					QueueChild(turn);
 
 				return this;
 			}

--- a/OpenRA.Mods.Common/Activities/Parachute.cs
+++ b/OpenRA.Mods.Common/Activities/Parachute.cs
@@ -39,15 +39,15 @@ namespace OpenRA.Mods.Common.Activities
 				np.OnParachute(self);
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			var nextPosition = self.CenterPosition - fallVector;
 			if (nextPosition.Z < groundLevel)
-				return NextActivity;
+				return true;
 
 			pos.SetVisualPosition(self, nextPosition);
 
-			return this;
+			return false;
 		}
 
 		protected override void OnLastRun(Actor self)

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -56,13 +56,6 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
-
 			if (cargo != carryall.Carryable)
 				return NextActivity;
 
@@ -86,7 +79,7 @@ namespace OpenRA.Mods.Common.Activities
 			switch (state)
 			{
 				case PickupState.Intercept:
-					QueueChild(self, movement.MoveWithinRange(Target.FromActor(cargo), WDist.FromCells(4), targetLineColor: Color.Yellow), true);
+					QueueChild(movement.MoveWithinRange(Target.FromActor(cargo), WDist.FromCells(4), targetLineColor: Color.Yellow));
 					state = PickupState.LockCarryable;
 					return this;
 
@@ -101,15 +94,15 @@ namespace OpenRA.Mods.Common.Activities
 				{
 					// Land at the target location
 					var localOffset = carryall.OffsetForCarryable(self, cargo).Rotate(carryableBody.QuantizeOrientation(self, cargo.Orientation));
-					QueueChild(self, new Land(self, Target.FromActor(cargo), -carryableBody.LocalToWorld(localOffset), carryableFacing.Facing), true);
+					QueueChild(new Land(self, Target.FromActor(cargo), -carryableBody.LocalToWorld(localOffset), carryableFacing.Facing));
 
 					// Pause briefly before attachment for visual effect
 					if (delay > 0)
-						QueueChild(self, new Wait(delay, false));
+						QueueChild(new Wait(delay, false));
 
 					// Remove our carryable from world
-					QueueChild(self, new CallFunc(() => Attach(self)));
-					QueueChild(self, new TakeOff(self));
+					QueueChild(new CallFunc(() => Attach(self)));
+					QueueChild(new TakeOff(self));
 					return this;
 				}
 			}

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -54,41 +54,41 @@ namespace OpenRA.Mods.Common.Activities
 			carryall.ReserveCarryable(self, cargo);
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			if (cargo != carryall.Carryable)
-				return NextActivity;
+				return true;
 
 			if (IsCanceling)
 			{
 				if (carryall.State == Carryall.CarryallState.Reserved)
 					carryall.UnreserveCarryable(self);
 
-				return NextActivity;
+				return true;
 			}
 
 			if (cargo.IsDead || carryable.IsTraitDisabled || !cargo.AppearsFriendlyTo(self))
 			{
 				carryall.UnreserveCarryable(self);
-				return NextActivity;
+				return true;
 			}
 
 			if (carryall.State != Carryall.CarryallState.Reserved)
-				return NextActivity;
+				return true;
 
 			switch (state)
 			{
 				case PickupState.Intercept:
 					QueueChild(movement.MoveWithinRange(Target.FromActor(cargo), WDist.FromCells(4), targetLineColor: Color.Yellow));
 					state = PickupState.LockCarryable;
-					return this;
+					return false;
 
 				case PickupState.LockCarryable:
 					if (!carryable.LockForPickup(cargo, self))
 						Cancel(self);
 
 					state = PickupState.Pickup;
-					return this;
+					return false;
 
 				case PickupState.Pickup:
 				{
@@ -103,11 +103,11 @@ namespace OpenRA.Mods.Common.Activities
 					// Remove our carryable from world
 					QueueChild(new CallFunc(() => Attach(self)));
 					QueueChild(new TakeOff(self));
-					return this;
+					return false;
 				}
 			}
 
-			return NextActivity;
+			return true;
 		}
 
 		void Attach(Actor self)

--- a/OpenRA.Mods.Common/Activities/RemoveSelf.cs
+++ b/OpenRA.Mods.Common/Activities/RemoveSelf.cs
@@ -15,11 +15,12 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class RemoveSelf : Activity
 	{
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
-			if (IsCanceling) return NextActivity;
+			if (IsCanceling) return true;
 			self.Dispose();
-			return null;
+			Cancel(self);
+			return true;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.Activities
 					pool.RemainingTicks = pool.Info.ReloadDelay;
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			// HACK: If the activity is cancelled while we're already resupplying (or about to start resupplying),
 			// move actor outside the resupplier footprint
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.Common.Activities
 				foreach (var notifyResupply in notifyResupplies)
 					notifyResupply.ResupplyTick(host.Actor, self, ResupplyType.None);
 
-				return this;
+				return false;
 			}
 
 			if (IsCanceling || host.Type == TargetType.Invalid
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.Common.Activities
 				foreach (var notifyResupply in notifyResupplies)
 					notifyResupply.ResupplyTick(host.Actor, self, ResupplyType.None);
 
-				return NextActivity;
+				return true;
 			}
 
 			if (activeResupplyTypes.HasFlag(ResupplyType.Repair))
@@ -112,10 +112,10 @@ namespace OpenRA.Mods.Common.Activities
 				if (aircraft != null)
 					aircraft.AllowYieldingReservation();
 
-				return NextActivity;
+				return true;
 			}
 
-			return this;
+			return false;
 		}
 
 		public override void Cancel(Actor self, bool keepQueue = false)

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -75,19 +75,12 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
-
 			// HACK: If the activity is cancelled while we're already resupplying (or about to start resupplying),
 			// move actor outside the resupplier footprint
 			// TODO: This check is nowhere near robust enough, and should be rewritten
 			if (IsCanceling && host.IsInRange(self.CenterPosition, closeEnough))
 			{
-				QueueChild(self, self.Trait<IMove>().MoveToTarget(self, host), true);
+				QueueChild(self.Trait<IMove>().MoveToTarget(self, host));
 				foreach (var notifyResupply in notifyResupplies)
 					notifyResupply.ResupplyTick(host.Actor, self, ResupplyType.None);
 

--- a/OpenRA.Mods.Common/Activities/Sell.cs
+++ b/OpenRA.Mods.Common/Activities/Sell.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Activities
 			IsInterruptible = false;
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			var sellValue = self.GetSellValue();
 
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Activities
 				self.World.AddFrameEndTask(w => w.Add(new FloatingText(self.CenterPosition, self.Owner.Color, FloatingText.FormatCashTick(refund), 30)));
 
 			self.Dispose();
-			return this;
+			return false;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/SimpleTeleport.cs
+++ b/OpenRA.Mods.Common/Activities/SimpleTeleport.cs
@@ -20,11 +20,11 @@ namespace OpenRA.Mods.Common.Activities
 
 		public SimpleTeleport(CPos destination) { this.destination = destination; }
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			self.Trait<IPositionable>().SetPosition(self, destination);
 			self.Generation++;
-			return NextActivity;
+			return true;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/SpriteHarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/SpriteHarvesterDockSequence.cs
@@ -27,17 +27,16 @@ namespace OpenRA.Mods.Common.Activities
 			wda = self.Info.TraitInfo<WithDockingAnimationInfo>();
 		}
 
-		public override Activity OnStateDock(Actor self)
+		public override void OnStateDock(Actor self)
 		{
 			foreach (var trait in self.TraitsImplementing<INotifyHarvesterAction>())
 				trait.Docked();
 
 			wsb.PlayCustomAnimation(self, wda.DockSequence, () => wsb.PlayCustomAnimationRepeating(self, wda.DockLoopSequence));
 			dockingState = DockingState.Loop;
-			return this;
 		}
 
-		public override Activity OnStateUndock(Actor self)
+		public override void OnStateUndock(Actor self)
 		{
 			wsb.PlayCustomAnimationBackwards(self, wda.DockSequence,
 				() =>
@@ -47,8 +46,6 @@ namespace OpenRA.Mods.Common.Activities
 						trait.Undocked();
 				});
 			dockingState = DockingState.Wait;
-
-			return this;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -168,11 +168,5 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			return new Order(orderString, newActor, target, true);
 		}
-
-		public override Activity Tick(Actor self)
-		{
-			// Activity is a placeholder that should never run
-			return NextActivity;
-		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -37,22 +37,16 @@ namespace OpenRA.Mods.Common.Activities
 		protected override void OnFirstRun(Actor self)
 		{
 			if (self.Info.HasTraitInfo<IFacingInfo>())
-				QueueChild(self, new Turn(self, Facing));
+				QueueChild(new Turn(self, Facing));
 
 			if (self.Info.HasTraitInfo<AircraftInfo>())
-				QueueChild(self, new Land(self));
+				QueueChild(new Land(self));
 		}
 
 		public override Activity Tick(Actor self)
 		{
 			if (IsCanceling)
 				return NextActivity;
-
-			if (ChildActivity != null)
-			{
-				ActivityUtils.RunActivity(self, ChildActivity);
-				return this;
-			}
 
 			// Prevent deployment in bogus locations
 			var transforms = self.TraitOrDefault<Transforms>();
@@ -72,7 +66,7 @@ namespace OpenRA.Mods.Common.Activities
 				IsInterruptible = false;
 
 				// Wait forever
-				QueueChild(self, new WaitFor(() => false));
+				QueueChild(new WaitFor(() => false));
 				makeAnimation.Reverse(self, () => DoTransform(self));
 				return this;
 			}

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -43,17 +43,17 @@ namespace OpenRA.Mods.Common.Activities
 				QueueChild(new Land(self));
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			if (IsCanceling)
-				return NextActivity;
+				return true;
 
 			// Prevent deployment in bogus locations
 			var transforms = self.TraitOrDefault<Transforms>();
 			if (transforms != null && !transforms.CanDeploy())
 			{
 				Cancel(self, true);
-				return NextActivity;
+				return true;
 			}
 
 			foreach (var nt in self.TraitsImplementing<INotifyTransform>())
@@ -68,10 +68,10 @@ namespace OpenRA.Mods.Common.Activities
 				// Wait forever
 				QueueChild(new WaitFor(() => false));
 				makeAnimation.Reverse(self, () => DoTransform(self));
-				return this;
+				return false;
 			}
 
-			return NextActivity;
+			return true;
 		}
 
 		protected override void OnLastRun(Actor self)

--- a/OpenRA.Mods.Common/Activities/Turn.cs
+++ b/OpenRA.Mods.Common/Activities/Turn.cs
@@ -28,20 +28,20 @@ namespace OpenRA.Mods.Common.Activities
 			this.desiredFacing = desiredFacing;
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			if (IsCanceling)
-				return NextActivity;
+				return true;
 
 			if (mobile != null && (mobile.IsTraitDisabled || mobile.IsTraitPaused))
-				return this;
+				return false;
 
 			if (desiredFacing == facing.Facing)
-				return NextActivity;
+				return true;
 
 			facing.Facing = Util.TickFacing(facing.Facing, desiredFacing, facing.TurnSpeed);
 
-			return this;
+			return false;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -77,27 +77,20 @@ namespace OpenRA.Mods.Common.Activities
 			if (aircraft != null)
 			{
 				// Queue the activity even if already landed in case self.Location != destination
-				QueueChild(self, new Land(self, destination, unloadRange));
+				QueueChild(new Land(self, destination, unloadRange));
 				takeOffAfterUnload = !aircraft.AtLandAltitude;
 			}
 			else
 			{
 				var cell = self.World.Map.Clamp(this.self.World.Map.CellContaining(destination.CenterPosition));
-				QueueChild(self, new Move(self, cell, unloadRange));
+				QueueChild(new Move(self, cell, unloadRange));
 			}
 
-			QueueChild(self, new Wait(cargo.Info.BeforeUnloadDelay));
+			QueueChild(new Wait(cargo.Info.BeforeUnloadDelay));
 		}
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
-
 			if (IsCanceling || cargo.IsEmpty(self))
 				return NextActivity;
 
@@ -113,7 +106,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (exitSubCell == null)
 				{
 					self.NotifyBlocker(BlockedExitCells(actor));
-					QueueChild(self, new Wait(10), true);
+					QueueChild(new Wait(10));
 					return this;
 				}
 
@@ -138,10 +131,10 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				Cancel(self, true);
 				if (cargo.Info.AfterUnloadDelay > 0)
-					QueueChild(self, new Wait(cargo.Info.AfterUnloadDelay, false), true);
+					QueueChild(new Wait(cargo.Info.AfterUnloadDelay, false));
 
 				if (takeOffAfterUnload)
-					QueueChild(self, new TakeOff(self), true);
+					QueueChild(new TakeOff(self));
 			}
 
 			return this;

--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -89,10 +89,10 @@ namespace OpenRA.Mods.Common.Activities
 			QueueChild(new Wait(cargo.Info.BeforeUnloadDelay));
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			if (IsCanceling || cargo.IsEmpty(self))
-				return NextActivity;
+				return true;
 
 			if (cargo.CanUnload())
 			{
@@ -107,7 +107,7 @@ namespace OpenRA.Mods.Common.Activities
 				{
 					self.NotifyBlocker(BlockedExitCells(actor));
 					QueueChild(new Wait(10));
-					return this;
+					return false;
 				}
 
 				cargo.Unload(self);
@@ -130,6 +130,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (!unloadAll || !cargo.CanUnload())
 			{
 				Cancel(self, true);
+
 				if (cargo.Info.AfterUnloadDelay > 0)
 					QueueChild(new Wait(cargo.Info.AfterUnloadDelay, false));
 
@@ -137,7 +138,7 @@ namespace OpenRA.Mods.Common.Activities
 					QueueChild(new TakeOff(self));
 			}
 
-			return this;
+			return false;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -129,13 +129,13 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (!unloadAll || !cargo.CanUnload())
 			{
-				Cancel(self, true);
-
 				if (cargo.Info.AfterUnloadDelay > 0)
 					QueueChild(new Wait(cargo.Info.AfterUnloadDelay, false));
 
 				if (takeOffAfterUnload)
 					QueueChild(new TakeOff(self));
+
+				return true;
 			}
 
 			return false;

--- a/OpenRA.Mods.Common/Activities/Wait.cs
+++ b/OpenRA.Mods.Common/Activities/Wait.cs
@@ -25,12 +25,12 @@ namespace OpenRA.Mods.Common.Activities
 			IsInterruptible = interruptible;
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			if (IsCanceling)
-				return NextActivity;
+				return true;
 
-			return (remainingTicks-- == 0) ? NextActivity : this;
+			return remainingTicks-- == 0;
 		}
 	}
 
@@ -45,12 +45,12 @@ namespace OpenRA.Mods.Common.Activities
 			IsInterruptible = interruptible;
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			if (IsCanceling)
-				return NextActivity;
+				return true;
 
-			return (f == null || f()) ? NextActivity : this;
+			return f == null || f();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/WaitForTransport.cs
+++ b/OpenRA.Mods.Common/Activities/WaitForTransport.cs
@@ -30,12 +30,12 @@ namespace OpenRA.Mods.Common.Activities
 			QueueChild(inner);
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			if (transportable != null)
 				transportable.MovementCancelled(self);
 
-			return NextActivity;
+			return true;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/WaitForTransport.cs
+++ b/OpenRA.Mods.Common/Activities/WaitForTransport.cs
@@ -11,7 +11,6 @@
 
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
@@ -28,18 +27,11 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected override void OnFirstRun(Actor self)
 		{
-			QueueChild(self, inner);
+			QueueChild(inner);
 		}
 
 		public override Activity Tick(Actor self)
 		{
-			if (ChildActivity != null)
-			{
-				ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-				if (ChildActivity != null)
-					return this;
-			}
-
 			if (transportable != null)
 				transportable.MovementCancelled(self);
 

--- a/OpenRA.Mods.Common/Activities/WaitForTransport.cs
+++ b/OpenRA.Mods.Common/Activities/WaitForTransport.cs
@@ -18,11 +18,17 @@ namespace OpenRA.Mods.Common.Activities
 	public class WaitForTransport : Activity
 	{
 		readonly ICallForTransport transportable;
+		readonly Activity inner;
 
-		public WaitForTransport(Actor self, Activity innerActivity)
+		public WaitForTransport(Actor self, Activity inner)
 		{
 			transportable = self.TraitOrDefault<ICallForTransport>();
-			QueueChild(self, innerActivity);
+			this.inner = inner;
+		}
+
+		protected override void OnFirstRun(Actor self)
+		{
+			QueueChild(self, inner);
 		}
 
 		public override Activity Tick(Actor self)

--- a/OpenRA.Mods.Common/Scripting/CallLuaFunc.cs
+++ b/OpenRA.Mods.Common/Scripting/CallLuaFunc.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Activities
 			this.context = context;
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			try
 			{
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			Dispose();
-			return NextActivity;
+			return true;
 		}
 
 		public override void Cancel(Actor self, bool keepQueue = false)

--- a/OpenRA.Mods.Common/Scripting/Properties/AircraftProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/AircraftProperties.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Return to the base, which is either the destination given, or an auto-selected one otherwise.")]
 		public void ReturnToBase(Actor destination = null)
 		{
-			Self.QueueActivity(new ReturnToBase(Self, false, destination));
+			Self.QueueActivity(new ReturnToBase(Self, destination));
 		}
 
 		[ScriptActorPropertyActivity]

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -1012,7 +1012,7 @@ namespace OpenRA.Mods.Common.Traits
 				// them to land on a resupplier. For aircraft without it, it makes more sense to land than to idle above a
 				// free resupplier.
 				var forceLand = orderString == "ForceEnter" || !Info.TakeOffOnResupply;
-				self.QueueActivity(order.Queued, new ReturnToBase(self, Info.AbortOnResupply, targetActor, forceLand));
+				self.QueueActivity(order.Queued, new ReturnToBase(self, targetActor, forceLand));
 			}
 			else if (orderString == "Stop")
 			{
@@ -1036,7 +1036,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				// Aircraft with TakeOffOnResupply would immediately take off again, so there's no point in forcing them to land
 				// on a resupplier. For aircraft without it, it makes more sense to land than to idle above a free resupplier.
-				self.QueueActivity(order.Queued, new ReturnToBase(self, Info.AbortOnResupply, null, !Info.TakeOffOnResupply));
+				self.QueueActivity(order.Queued, new ReturnToBase(self, null, !Info.TakeOffOnResupply));
 			}
 			else if (orderString == "Scatter")
 				Nudge(self);

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -861,7 +861,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Activity VisualMove(Actor self, WPos fromPos, WPos toPos)
 		{
 			// TODO: Ignore repulsion when moving
-			return ActivityUtils.SequenceActivities(self,
+			return ActivityUtils.SequenceActivities(
 				new CallFunc(() => SetVisualPosition(self, fromPos)),
 				new Fly(self, Target.FromPos(toPos)));
 		}

--- a/OpenRA.Mods.Common/Traits/Air/ReturnOnIdle.cs
+++ b/OpenRA.Mods.Common/Traits/Air/ReturnOnIdle.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var resupplier = ReturnToBase.ChooseResupplier(self, true);
 			if (resupplier != null)
-				self.QueueActivity(new ReturnToBase(self, aircraftInfo.AbortOnResupply, resupplier));
+				self.QueueActivity(new ReturnToBase(self, resupplier));
 			else
 			{
 				// nowhere to land, pick something friendly and circle over it.

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -255,22 +255,22 @@ namespace OpenRA.Mods.Common.Traits
 				}
 			}
 
-			public override Activity Tick(Actor self)
+			public override bool Tick(Actor self)
 			{
 				if (IsCanceling)
 				{
 					// Cancel the requested target, but keep firing on it while in range
 					attack.ClearRequestedTarget();
-					return NextActivity;
+					return true;
 				}
 
 				// Check that AttackFollow hasn't cancelled the target by modifying attack.Target
 				// Having both this and AttackFollow modify that field is a horrible hack.
 				if (hasTicked && attack.RequestedTarget.Type == TargetType.Invalid)
-					return NextActivity;
+					return true;
 
 				if (attack.IsTraitPaused)
-					return this;
+					return false;
 
 				bool targetIsHiddenActor;
 				target = target.Recalculate(self.Owner, out targetIsHiddenActor);
@@ -317,7 +317,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (wasMovingWithinRange && targetIsHiddenActor)
 				{
 					attack.ClearRequestedTarget();
-					return NextActivity;
+					return true;
 				}
 
 				// Update target lines if required
@@ -328,7 +328,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (useLastVisibleTarget && !lastVisibleTarget.IsValidFor(self))
 				{
 					attack.ClearRequestedTarget();
-					return NextActivity;
+					return true;
 				}
 
 				var pos = self.CenterPosition;
@@ -341,22 +341,22 @@ namespace OpenRA.Mods.Common.Traits
 					if (useLastVisibleTarget)
 					{
 						attack.ClearRequestedTarget();
-						return NextActivity;
+						return true;
 					}
 
-					return this;
+					return false;
 				}
 
 				// We can't move into range, so give up
 				if (move == null || maxRange == WDist.Zero || maxRange < minRange)
 				{
 					attack.ClearRequestedTarget();
-					return NextActivity;
+					return true;
 				}
 
 				wasMovingWithinRange = true;
 				QueueChild(move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, Color.Red));
-				return this;
+				return false;
 			}
 
 			void IActivityNotifyStanceChanged.StanceChanged(Actor self, AutoTarget autoTarget, UnitStance oldStance, UnitStance newStance)

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -257,13 +257,6 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override Activity Tick(Actor self)
 			{
-				if (ChildActivity != null)
-				{
-					ChildActivity = ActivityUtils.RunActivity(self, ChildActivity);
-					if (ChildActivity != null)
-						return this;
-				}
-
 				if (IsCanceling)
 				{
 					// Cancel the requested target, but keep firing on it while in range
@@ -362,7 +355,7 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				wasMovingWithinRange = true;
-				QueueChild(self, move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, Color.Red), true);
+				QueueChild(move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, Color.Red));
 				return this;
 			}
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
@@ -46,16 +46,16 @@ namespace OpenRA.Mods.Common.Traits
 				this.forceAttack = forceAttack;
 			}
 
-			public override Activity Tick(Actor self)
+			public override bool Tick(Actor self)
 			{
 				// This activity can't move to reacquire hidden targets, so use the
 				// Recalculate overload that invalidates hidden targets.
 				target = target.RecalculateInvalidatingHiddenTargets(self.Owner);
 				if (IsCanceling || !target.IsValidFor(self) || !attack.IsReachableTarget(target, allowMove))
-					return NextActivity;
+					return true;
 
 				attack.DoAttack(self, target);
-				return this;
+				return false;
 			}
 
 			void IActivityNotifyStanceChanged.StanceChanged(Actor self, AutoTarget autoTarget, UnitStance oldStance, UnitStance newStance)

--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -164,9 +164,9 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (!preventDock)
 			{
-				dockOrder.QueueChild(self, new CallFunc(() => dockedHarv = harv, false));
-				dockOrder.QueueChild(self, DockSequence(harv, self));
-				dockOrder.QueueChild(self, new CallFunc(() => dockedHarv = null, false));
+				dockOrder.QueueChild(new CallFunc(() => dockedHarv = harv, false));
+				dockOrder.QueueChild(DockSequence(harv, self));
+				dockOrder.QueueChild(new CallFunc(() => dockedHarv = null, false));
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
@@ -130,7 +130,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!order.Queued && activity.NextActivity != null)
 				activity.NextActivity.Cancel(self);
 
-			activity.Queue(self, new IssueOrderAfterTransform(order.OrderString, order.Target));
+			activity.Queue(new IssueOrderAfterTransform(order.OrderString, order.Target));
 
 			if (currentTransform == null)
 				self.QueueActivity(order.Queued, activity);

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoEntersTunnels.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoEntersTunnels.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!order.Queued && activity.NextActivity != null)
 				activity.NextActivity.Cancel(self);
 
-			activity.Queue(self, new IssueOrderAfterTransform(order.OrderString, order.Target));
+			activity.Queue(new IssueOrderAfterTransform(order.OrderString, order.Target));
 
 			if (currentTransform == null)
 				self.QueueActivity(order.Queued, activity);

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
@@ -111,7 +111,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!order.Queued && activity.NextActivity != null)
 					activity.NextActivity.Cancel(self);
 
-				activity.Queue(self, new IssueOrderAfterTransform("Move", order.Target));
+				activity.Queue(new IssueOrderAfterTransform("Move", order.Target));
 
 				if (currentTransform == null)
 					self.QueueActivity(order.Queued, activity);

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoPassenger.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoPassenger.cs
@@ -124,7 +124,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!order.Queued && activity.NextActivity != null)
 				activity.NextActivity.Cancel(self);
 
-			activity.Queue(self, new IssueOrderAfterTransform(order.OrderString, order.Target));
+			activity.Queue(new IssueOrderAfterTransform(order.OrderString, order.Target));
 
 			if (currentTransform == null)
 				self.QueueActivity(order.Queued, activity);

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoRepairable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoRepairable.cs
@@ -118,7 +118,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!order.Queued && activity.NextActivity != null)
 				activity.NextActivity.Cancel(self);
 
-			activity.Queue(self, new IssueOrderAfterTransform(order.OrderString, order.Target));
+			activity.Queue(new IssueOrderAfterTransform(order.OrderString, order.Target));
 
 			if (currentTransform == null)
 				self.QueueActivity(order.Queued, activity);

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -132,7 +132,7 @@ namespace OpenRA.Mods.Common.Traits
 				return moveInner;
 
 			var activity = new DeployForGrantedCondition(self, this, true);
-			activity.Queue(self, moveInner);
+			activity.Queue(moveInner);
 			return activity;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -322,7 +322,7 @@ namespace OpenRA.Mods.Common.Traits
 					var notifyBlocking = new CallFunc(() => self.NotifyBlocker(cellInfo.Cell));
 					var waitFor = new WaitFor(() => CanEnterCell(cellInfo.Cell));
 					var move = new Move(self, cellInfo.Cell);
-					self.QueueActivity(ActivityUtils.SequenceActivities(self, notifyBlocking, waitFor, move));
+					self.QueueActivity(ActivityUtils.SequenceActivities(notifyBlocking, waitFor, move));
 
 					Log.Write("debug", "OnNudge (notify next blocking actor, wait and move) #{0} from {1} to {2}",
 						self.ActorID, self.Location, cellInfo.Cell);
@@ -691,7 +691,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var delta = toPos - fromPos;
 			var facing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : Facing;
-			return ActivityUtils.SequenceActivities(self, new Turn(self, facing), new Drag(self, fromPos, toPos, length));
+			return ActivityUtils.SequenceActivities(new Turn(self, facing), new Drag(self, fromPos, toPos, length));
 		}
 
 		CPos? ClosestGroundCell()

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -124,7 +124,7 @@ namespace OpenRA.Mods.Common.Traits
 					self.CancelActivity();
 
 				self.SetTargetLine(order.Target, Color.Green);
-				var activities = ActivityUtils.SequenceActivities(self,
+				var activities = ActivityUtils.SequenceActivities(
 					movement.MoveToTarget(self, order.Target, targetLineColor: Color.Green),
 					new CallFunc(() => AfterReachActivities(self, order, movement)));
 

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -556,7 +556,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			BindCheckboxPref(panel, "REPLAY_COMMANDS_CHECKBOX", ds, "EnableDebugCommandsInReplays");
 			BindCheckboxPref(panel, "CHECKUNSYNCED_CHECKBOX", ds, "SyncCheckUnsyncedCode");
 			BindCheckboxPref(panel, "CHECKBOTSYNC_CHECKBOX", ds, "SyncCheckBotModuleCode");
-			BindCheckboxPref(panel, "STRICTACTIVITY_CHECKBOX", ds, "StrictActivityChecking");
 
 			panel.Get("DEBUG_OPTIONS").IsVisible = () => ds.DisplayDeveloperSettings;
 			panel.Get("DEBUG_HIDDEN_LABEL").IsVisible = () => !ds.DisplayDeveloperSettings;

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.D2k.Activities
 			return true;
 		}
 
-		public override Activity Tick(Actor self)
+		public override bool Tick(Actor self)
 		{
 			switch (stance)
 			{
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.D2k.Activities
 					break;
 				case AttackState.Burrowed:
 					if (--countdown > 0)
-						return this;
+						return false;
 
 					var targetLocation = target.Actor.Location;
 
@@ -117,14 +117,14 @@ namespace OpenRA.Mods.D2k.Activities
 					if ((burrowLocation - targetLocation).Length > NearEnough)
 					{
 						RevokeCondition(self);
-						return NextActivity;
+						return true;
 					}
 
 					// The target reached solid ground
 					if (!positionable.CanEnterCell(targetLocation, null, false))
 					{
 						RevokeCondition(self);
-						return NextActivity;
+						return true;
 					}
 
 					var targets = self.World.ActorMap.GetActorsAt(targetLocation)
@@ -133,7 +133,7 @@ namespace OpenRA.Mods.D2k.Activities
 					if (!targets.Any())
 					{
 						RevokeCondition(self);
-						return NextActivity;
+						return true;
 					}
 
 					stance = AttackState.Attacking;
@@ -144,7 +144,7 @@ namespace OpenRA.Mods.D2k.Activities
 					break;
 				case AttackState.Attacking:
 					if (--countdown > 0)
-						return this;
+						return false;
 
 					sandworm.IsAttacking = false;
 
@@ -156,10 +156,10 @@ namespace OpenRA.Mods.D2k.Activities
 					}
 
 					RevokeCondition(self);
-					return NextActivity;
+					return true;
 			}
 
-			return this;
+			return false;
 		}
 
 		void RevokeCondition(Actor self)

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -659,13 +659,6 @@ Container@SETTINGS_PANEL:
 									Height: 20
 									Font: Regular
 									Text: Enable Debug Commands in Replays
-								Checkbox@STRICTACTIVITY_CHECKBOX:
-									X: 310
-									Y: 280
-									Width: 300
-									Height: 20
-									Font: Regular
-									Text: Strict Activity checking
 		Button@BACK_BUTTON:
 			Key: escape
 			Y: 393

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -669,11 +669,3 @@ Background@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Enable Debug Commands in Replays
-						Checkbox@STRICTACTIVITY_CHECKBOX:
-							X: 310
-							Y: 280
-							Width: 300
-							Height: 20
-							Font: Regular
-							Text: Strict Activity checking
-		TooltipContainer@TOOLTIP_CONTAINER:


### PR DESCRIPTION
Depends on #16369 and #16382.

With all activities now converted to the `ChildActivity` paradigm, some common patterns can be deduplicated by letting `Activity.TickOuter` handle childactivities.