### PR TITLE
Improve TS altitude values and Harpy rotor offsets

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/JumpjetActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/JumpjetActorLayer.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string TerrainType = "Jumpjet";
 
 		[Desc("Height offset relative to the smoothed terrain for movement.")]
-		public readonly WDist HeightOffset = new WDist(2304);
+		public readonly WDist HeightOffset = new WDist(3992);
 
 		[Desc("Cell radius for smoothing adjacent cell heights.")]
 		public readonly int SmoothingRadius = 2;

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -51,6 +51,8 @@ DSHP:
 		TakeoffSounds: dropup1.aud
 		LandingSounds: dropdwn1.aud
 		IdealSeparation: 1275
+		CruiseAltitude: 12c512
+		AltitudeVelocity: 256
 	Health:
 		HP: 20000
 	Armor:
@@ -91,6 +93,7 @@ ORCA:
 		MoveIntoShroud: false
 		TakeoffSounds: orcaup1.aud
 		LandingSounds: orcadwn1.aud
+		AltitudeVelocity: 128
 	Health:
 		HP: 20000
 	Armor:
@@ -136,7 +139,7 @@ ORCAB:
 	Selectable:
 		Bounds: 30,24
 	Aircraft:
-		CruiseAltitude: 3072
+		CruiseAltitude: 5c512
 		MaximumPitch: 120
 		TurnSpeed: 3
 		Speed: 96
@@ -236,7 +239,6 @@ TRNSPORT:
 		Crushes: crate, infantry
 		TakeoffSounds: dropup1.aud
 		LandingSounds: dropdwn1.aud
-		AltitudeVelocity: 64
 		MoveIntoShroud: false
 	Carryall:
 		Voice: Move
@@ -275,7 +277,7 @@ SCRIN:
 	Voiced:
 		VoiceSet: Scrin
 	Aircraft:
-		CruiseAltitude: 2560
+		CruiseAltitude: 5c0
 		MaximumPitch: 90
 		TurnSpeed: 3
 		Speed: 168
@@ -381,7 +383,7 @@ HUNTER:
 	Aircraft:
 		TurnSpeed: 16
 		Speed: 355
-		CruiseAltitude: 256
+		CruiseAltitude: 3c128
 		CanHover: True
 		CruisingCondition: cruising
 		VTOL: true

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -357,11 +357,11 @@ APACHE:
 		PipTypeEmpty: AmmoEmpty
 		AmmoCondition: ammo
 	WithIdleOverlay@ROTORAIR:
-		Offset: 85,0,384
+		Offset: 85,0,598
 		Sequence: rotor
 		RequiresCondition: airborne
 	WithIdleOverlay@ROTORGROUND:
-		Offset: 85,0,384
+		Offset: 85,0,598
 		Sequence: slow-rotor
 		RequiresCondition: !airborne
 	RenderSprites:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -876,7 +876,8 @@
 ^Helicopter:
 	Inherits: ^Aircraft
 	Aircraft:
-		CruiseAltitude: 2048
+		CruiseAltitude: 4c704
+		AltitudeVelocity: 96
 		CanHover: True
 		CruisingCondition: cruising
 		TakeOffOnResupply: true


### PR DESCRIPTION
Considering what I saw in original TS and original rules.ini, I strongly assume that 128 "FlightLevel" units in TS equal 1 cell/1024 WDist in OpenRA.
Orcas in TS were flying at roughly double the altitude of the visual height of the GDI Titan (including its antenna).

Adjusting the values in our TS mod accordingly looked pretty accurate, so here we are.

Also increased `AltitudeVelocity` values to make up for the higher altitudes, and fixed Harpy rotor offset while I was at it.