### PR TITLE
Calc font size correctly and use it for valign

### DIFF
--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -133,7 +133,9 @@ namespace OpenRA
 
 	public interface IFont : IDisposable
 	{
-		FontGlyph CreateGlyph(char c, int size, float deviceScale);
+		FontGlyph CreateGlyph(char c);
+		void SetSize(int size, float deviceScale);
+		int Height { get; }
 	}
 
 	public struct FontGlyph

--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -19,6 +19,7 @@ namespace OpenRA.Graphics
 {
 	public sealed class SpriteFont : IDisposable
 	{
+		public int TopOffset { get; private set; }
 		readonly int size;
 		readonly SheetBuilder builder;
 		readonly Func<string, float> lineWidth;
@@ -37,6 +38,7 @@ namespace OpenRA.Graphics
 			this.builder = builder;
 
 			font = Game.Renderer.CreateFont(data);
+			font.SetSize(size, deviceScale);
 
 			glyphs = new Cache<Pair<char, Color>, GlyphInfo>(CreateGlyph, Pair<char, Color>.EqualityComparer);
 
@@ -46,12 +48,18 @@ namespace OpenRA.Graphics
 
 			if (size <= 24)
 				PrecacheColor(Color.White, name);
+
+			TopOffset = size - font.Height;
 		}
 
 		public void SetScale(float scale)
 		{
 			deviceScale = scale;
+
+			font.SetSize(size, scale);
 			glyphs.Clear();
+
+			TopOffset = size - font.Height;
 		}
 
 		void PrecacheColor(Color c, string name)
@@ -131,7 +139,7 @@ namespace OpenRA.Graphics
 
 		GlyphInfo CreateGlyph(Pair<char, Color> c)
 		{
-			var glyph = font.CreateGlyph(c.First, this.size, deviceScale);
+			var glyph = font.CreateGlyph(c.First);
 
 			if (glyph.Data == null)
 			{

--- a/OpenRA.Mods.Common/Widgets/LabelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LabelWidget.cs
@@ -49,6 +49,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			Text = other.Text;
 			Align = other.Align;
+			VAlign = other.VAlign;
 			Font = other.Font;
 			TextColor = other.TextColor;
 			Contrast = other.Contrast;
@@ -74,9 +75,13 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var textSize = font.Measure(text);
 			var position = RenderOrigin;
+			var offset = font.TopOffset;
+
+			if (VAlign == TextVAlign.Top)
+				position += new int2(0, -offset);
 
 			if (VAlign == TextVAlign.Middle)
-				position += new int2(0, (Bounds.Height - textSize.Y) / 2);
+				position += new int2(0, (Bounds.Height - textSize.Y - offset) / 2);
 
 			if (VAlign == TextVAlign.Bottom)
 				position += new int2(0, Bounds.Height - textSize.Y);

--- a/OpenRA.Platforms.Default/FreeTypeFont.cs
+++ b/OpenRA.Platforms.Default/FreeTypeFont.cs
@@ -27,6 +27,11 @@ namespace OpenRA.Platforms.Default
 		internal const int FT_LOAD_RENDER = 0x04;
 
 		internal static readonly int FaceRecGlyphOffset = IntPtr.Size == 8 ? 152 : 84; // offsetof(FT_FaceRec, glyph)
+		internal static readonly int FaceRecSizeOffset = IntPtr.Size == 8 ? 160 : 88; // offsetof(FT_FaceRec, size)
+		internal static readonly int SizeRecMetricsOffset = IntPtr.Size == 8 ? 24 : 12; // offsetof(FT_SizeRec, metrics)
+		internal static readonly int SizeMetricsAscenderOffset = IntPtr.Size == 8 ? 24 : 12; // offsetof(FT_Size_Metrics, ascender)
+		internal static readonly int SizeMetricsDescenderOffset = IntPtr.Size == 8 ? 32 : 16; // offsetof(FT_Size_Metrics, descender)
+
 		internal static readonly int GlyphSlotMetricsOffset = IntPtr.Size == 8 ? 48 : 24; // offsetof(FT_GlyphSlotRec, metrics)
 		internal static readonly int GlyphSlotBitmapOffset = IntPtr.Size == 8 ? 152 : 76; // offsetof(FT_GlyphSlotRec, bitmap)
 		internal static readonly int GlyphSlotBitmapLeftOffset = IntPtr.Size == 8 ? 192 : 100; // offsetof(FT_GlyphSlotRec, bitmap_left)
@@ -68,6 +73,8 @@ namespace OpenRA.Platforms.Default
 		readonly IntPtr face;
 		bool disposed;
 
+		public int Height { get; private set; }
+
 		public FreeTypeFont(byte[] data)
 		{
 			if (library == IntPtr.Zero && FreeType.FT_Init_FreeType(out library) != FreeType.OK)
@@ -78,12 +85,25 @@ namespace OpenRA.Platforms.Default
 				throw new InvalidDataException("Failed to initialize font");
 		}
 
-		public FontGlyph CreateGlyph(char c, int size, float deviceScale)
+		public void SetSize(int size, float deviceScale)
 		{
 			var scaledSize = (uint)(size * deviceScale);
 			if (FreeType.FT_Set_Pixel_Sizes(face, scaledSize, scaledSize) != FreeType.OK)
-				return EmptyGlyph;
+				throw new InvalidDataException("Failed to set size");
 
+			var faceSize = Marshal.ReadIntPtr(IntPtr.Add(face, FreeType.FaceRecSizeOffset)); // face->size
+			var metrics = IntPtr.Add(faceSize, FreeType.SizeRecMetricsOffset); // face->size->metrics
+			var ascender = Marshal.ReadIntPtr(IntPtr.Add(metrics, FreeType.SizeMetricsAscenderOffset)); // face->size->metrics.ascender
+			var descender = Marshal.ReadIntPtr(IntPtr.Add(metrics, FreeType.SizeMetricsDescenderOffset)); // face->size->metrics.descender
+
+			var ascenderValue = (int)ascender >> 6;
+			var descenderValue = (int)descender >> 6;
+
+			Height = (int)((ascenderValue - Math.Abs(descenderValue)) / deviceScale);
+		}
+
+		public FontGlyph CreateGlyph(char c)
+		{
 			if (FreeType.FT_Load_Char(face, c, FreeType.FT_LOAD_RENDER) != FreeType.OK)
 				return EmptyGlyph;
 


### PR DESCRIPTION
Calculate the font height with the ascender and descender values from the font and use that for valign top and middle.

Included a testcase

![image](https://user-images.githubusercontent.com/19173272/57096983-c860b580-6d16-11e9-874c-c27e6b8de3ab.png)


