### PR TITLE
Add SHA1 verification to package downloads

### DIFF
--- a/OpenRA.Mods.Common/ModContent.cs
+++ b/OpenRA.Mods.Common/ModContent.cs
@@ -76,6 +76,7 @@ namespace OpenRA
 			public readonly string Title;
 			public readonly string URL;
 			public readonly string MirrorList;
+			public readonly string SHA1;
 			public readonly Dictionary<string, string> Extract;
 
 			public ModDownload(MiniYaml yaml)

--- a/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Installation/DownloadPackageLogic.cs
@@ -137,6 +137,37 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					return;
 				}
 
+				// Validate integrity
+				if (!string.IsNullOrEmpty(download.SHA1))
+				{
+					getStatusText = () => "Verifying archive...";
+					progressBar.Indeterminate = true;
+
+					var archiveValid = false;
+					try
+					{
+						using (var stream = File.OpenRead(file))
+						{
+							var archiveSHA1 = CryptoUtil.SHA1Hash(stream);
+							Log.Write("install", "Downloaded SHA1: " + archiveSHA1);
+							Log.Write("install", "Expected SHA1: " + download.SHA1);
+
+							archiveValid = archiveSHA1 == download.SHA1;
+						}
+					}
+					catch (Exception e)
+					{
+						Log.Write("install", "SHA1 calculation failed: " + e.ToString());
+					}
+
+					if (!archiveValid)
+					{
+						onError("Archive validation failed");
+						deleteTempFile();
+						return;
+					}
+				}
+
 				// Automatically extract
 				getStatusText = () => "Extracting...";
 				progressBar.Indeterminate = true;

--- a/mods/cnc/installer/downloads.yaml
+++ b/mods/cnc/installer/downloads.yaml
@@ -1,4 +1,5 @@
 basefiles: Base Freeware Content
+	SHA1: 72f337464963fa37d3688eb03e80eefd33669a3d
 	MirrorList: http://www.openra.net/packages/cnc-mirrors.txt
 	Extract:
 		^Content/cnc/conquer.mix: conquer.mix
@@ -10,7 +11,9 @@ basefiles: Base Freeware Content
 		^Content/cnc/tempicnh.mix: tempicnh.mix
 		^Content/cnc/transit.mix: transit.mix
 		^Content/cnc/winter.mix: winter.mix
+
 music: Freeware Music
+	SHA1: c7f220aa59024f02932d5713b1aa6201113c03b5
 	MirrorList: http://www.openra.net/packages/cnc-music-mirrors.txt
 	Extract:
 		^Content/cnc/scores.mix: scores.mix

--- a/mods/d2k/installer/downloads.yaml
+++ b/mods/d2k/installer/downloads.yaml
@@ -1,4 +1,5 @@
 quickinstall: Quick Install Package
+	SHA1: eb9ff88ca24858bd06a752f923156a6480c25c06
 	MirrorList: http://www.openra.net/packages/d2k-quickinstall-mirrors.txt
 	Extract:
 		^Content/d2k/v2/BLOXBASE.R8: v2/BLOXBASE.R8
@@ -266,7 +267,9 @@ quickinstall: Quick Install Package
 		^Content/d2k/v2/SOUND.RS: v2/SOUND.RS
 		^Content/d2k/v2/BLOXXMAS.R8: v2/BLOXXMAS.R8
 		^Content/d2k/v2/DATA.R8: v2/DATA.R8
+
 basefiles: Base Content
+	SHA1: 82221691fe843a5a245969095f147e929c364234
 	MirrorList: http://www.openra.net/packages/d2k-base-mirrors.txt
 	Extract:
 		^Content/d2k/v2/BLOXBASE.R8: v2/BLOXBASE.R8
@@ -532,7 +535,9 @@ basefiles: Base Content
 		^Content/d2k/v2/MOUSE.R8: v2/MOUSE.R8
 		^Content/d2k/v2/PALETTE.BIN: v2/PALETTE.BIN
 		^Content/d2k/v2/SOUND.RS: v2/SOUND.RS
+
 patch106: Patch 1.06 Content
+	SHA1: 90924e5254468ec79c71e456384f5895a6c84bae
 	MirrorList: http://www.openra.net/packages/d2k-patch106-mirrors.txt
 	Extract:
 		^Content/d2k/v2/BLOXXMAS.R8: v2/BLOXXMAS.R8

--- a/mods/ra/installer/downloads.yaml
+++ b/mods/ra/installer/downloads.yaml
@@ -1,4 +1,5 @@
 quickinstall: Quick Install Package
+	SHA1: 44241f68e69db9511db82cf83c174737ccda300b
 	MirrorList: http://www.openra.net/packages/ra-quickinstall-mirrors.txt
 	Extract:
 		^Content/ra/v2/allies.mix: allies.mix
@@ -40,7 +41,9 @@ quickinstall: Quick Install Package
 		^Content/ra/v2/expand/myeehaw1.aud: expand/myeehaw1.aud
 		^Content/ra/v2/expand/myes1.aud: expand/myes1.aud
 		^Content/ra/v2/cnc/desert.mix: cnc/desert.mix
+
 basefiles: Base Freeware Content
+	SHA1: aa022b208a3b45b4a45c00fdae22ccf3c6de3e5c
 	MirrorList: http://www.openra.net/packages/ra-base-mirrors.txt
 	Extract:
 		^Content/ra/v2/allies.mix: allies.mix
@@ -54,7 +57,9 @@ basefiles: Base Freeware Content
 		^Content/ra/v2/sounds.mix: sounds.mix
 		^Content/ra/v2/speech.mix: speech.mix
 		^Content/ra/v2/temperat.mix: temperat.mix
+
 aftermath: Aftermath Expansion Files
+	SHA1: d511d4363b485e11c63eecf96d4365d42ec4ef5e
 	MirrorList: http://www.openra.net/packages/ra-aftermath-mirrors.txt
 	Extract:
 		^Content/ra/v2/expand/chrotnk1.aud: expand/chrotnk1.aud
@@ -84,11 +89,15 @@ aftermath: Aftermath Expansion Files
 		^Content/ra/v2/expand/mwrench1.aud: expand/mwrench1.aud
 		^Content/ra/v2/expand/myeehaw1.aud: expand/myeehaw1.aud
 		^Content/ra/v2/expand/myes1.aud: expand/myes1.aud
+
 cncdesert: C&C Desert Tileset
+	SHA1: 039849f16e39e4722e8c838a393c8a0d6529fd59
 	MirrorList: http://www.openra.net/packages/ra-cncdesert-mirrors.txt
 	Extract:
 		^Content/ra/v2/cnc/desert.mix: cnc/desert.mix
+
 music: Freeware Music
+	SHA1: 134200e10b6e85b2d9bd4f0fe370ab57b75d1563
 	MirrorList: http://www.openra.net/packages/ra-scores-mirrors.txt
 	Extract:
 		^Content/ra/v2/scores.mix: scores.mix

--- a/mods/ts/installer/downloads.yaml
+++ b/mods/ts/installer/downloads.yaml
@@ -1,4 +1,5 @@
 basefiles: Base Freeware Content
+	SHA1: 824df30de0004ad13fac29cf16450caafee9fb1b
 	MirrorList: http://www.openra.net/packages/ts-mirrors.txt
 	Extract:
 		^Content/ts/cache.mix: cache.mix
@@ -17,11 +18,13 @@ basefiles: Base Freeware Content
 		^Content/ts/temperat.mix: temperat.mix
 
 tibsun-music: Base Freeware Music
+	SHA1: f445cf47ffa343d9e211ec31f29fb45c8aefac80
 	MirrorList: http://www.openra.net/packages/ts-music-mirrors.txt
 	Extract:
 		^Content/ts/scores.mix: scores.mix
 
 fstorm: Expansion Freeware Content
+	SHA1: 8bff90870a9348b72cbe91314aec7d3a50311aa9
 	MirrorList: http://www.openra.net/packages/fs-mirrors.txt
 	Extract:
 		^Content/ts/firestorm/c_kodiak.shp: firestorm/c_kodiak.shp
@@ -204,6 +207,7 @@ fstorm: Expansion Freeware Content
 		^Content/ts/firestorm/bigblue3.tem: firestorm/bigblue3.tem
 
 fstorm-music: Expansion Freeware Music
+	SHA1: 74b1ec47ea8c9815fb85c998963229aa0a8f8619
 	MirrorList: http://www.openra.net/packages/fs-music-mirrors.txt
 	Extract:
 		^Content/ts/firestorm/dmachine.aud: firestorm/dmachine.aud
@@ -218,6 +222,7 @@ fstorm-music: Expansion Freeware Music
 		^Content/ts/firestorm/slavesys.aud: firestorm/slavesys.aud
 
 quickinstall: Quick Install Package
+	SHA1: d9339e7b6ecf624ac6ca91d25c58b88fb88a49d2
 	MirrorList: http://www.openra.net/packages/ts-quickinstall-mirrors.txt
 	Extract:
 		^Content/ts/cache.mix: cache.mix


### PR DESCRIPTION
This PR makes sure that the downloaded files contain the data that we expect before extracting them to disk.

I have verified that all the existing mirrors host valid files.