### PR TITLE
Make Land activity self-contained and allow explicit landing orders

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
@@ -72,8 +72,8 @@ namespace OpenRA.Mods.Cnc.Traits
 					new FacingInit(64)
 				});
 
-				actor.QueueActivity(new Fly(actor, Target.FromPos(self.CenterPosition + new WVec(landDistance, 0, 0))));
-				actor.QueueActivity(new Land(actor, Target.FromActor(self)));
+				var exitCell = self.Location + exit.ExitCell;
+				actor.QueueActivity(new Land(actor, Target.FromActor(self), WDist.Zero, WVec.Zero, 64, clearCells: new CPos[1] { exitCell }));
 				actor.QueueActivity(new CallFunc(() =>
 				{
 					if (!self.IsInWorld || self.IsDead)

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -157,12 +157,13 @@ namespace OpenRA.Mods.Common.Activities
 				return NextActivity;
 
 			var checkTarget = useLastVisibleTarget ? lastVisibleTarget : target;
-			var delta = checkTarget.CenterPosition - self.CenterPosition;
+			var pos = aircraft.GetPosition();
+			var delta = checkTarget.CenterPosition - pos;
 			var desiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : aircraft.Facing;
 
 			// Inside the target annulus, so we're done
-			var insideMaxRange = maxRange.Length > 0 && checkTarget.IsInRange(aircraft.CenterPosition, maxRange);
-			var insideMinRange = minRange.Length > 0 && checkTarget.IsInRange(aircraft.CenterPosition, minRange);
+			var insideMaxRange = maxRange.Length > 0 && checkTarget.IsInRange(pos, maxRange);
+			var insideMinRange = minRange.Length > 0 && checkTarget.IsInRange(pos, minRange);
 			if (insideMaxRange && !insideMinRange)
 				return NextActivity;
 

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Common.Activities
 					return NextActivity;
 			}
 
-			var pos = aircraft.CenterPosition;
+			var pos = aircraft.GetPosition();
 
 			// Reevaluate target position in case the target has moved.
 			targetPosition = target.CenterPosition + offset;

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -9,6 +9,8 @@
  */
 #endregion
 
+using System;
+using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
@@ -17,25 +19,57 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class Land : Activity
 	{
-		readonly Target target;
 		readonly Aircraft aircraft;
 		readonly WVec offset;
+		readonly int desiredFacing;
+		readonly bool assignTargetOnFirstRun;
+		readonly CPos[] clearCells;
+		readonly WDist landRange;
 
+		Target target;
+		WPos targetPosition;
+		CPos landingCell;
 		bool landingInitiated;
-		bool soundPlayed;
+		bool finishedApproach;
 
-		public Land(Actor self, Target t, WVec offset)
+		public Land(Actor self, int facing = -1)
+			: this(self, Target.Invalid, new WDist(-1), WVec.Zero, facing, null)
 		{
-			target = t;
-			aircraft = self.Trait<Aircraft>();
-			this.offset = offset;
+			assignTargetOnFirstRun = true;
 		}
 
-		public Land(Actor self, Target t)
-			: this(self, t, WVec.Zero) { }
+		public Land(Actor self, Target target, int facing = -1)
+			: this(self, target, new WDist(-1), WVec.Zero, facing) { }
 
-		public Land(Actor self)
-			: this(self, Target.FromPos(Aircraft.GroundPosition(self)), WVec.Zero) { }
+		public Land(Actor self, Target target, WDist landRange, int facing = -1)
+			: this(self, target, landRange, WVec.Zero, facing) { }
+
+		public Land(Actor self, Target target, WVec offset, int facing = -1)
+			: this(self, target, WDist.Zero, offset, facing) { }
+
+		public Land(Actor self, Target target, WDist landRange, WVec offset, int facing = -1, CPos[] clearCells = null)
+		{
+			aircraft = self.Trait<Aircraft>();
+			this.target = target;
+			this.offset = offset;
+			this.clearCells = clearCells ?? new CPos[0];
+			this.landRange = landRange.Length >= 0 ? landRange : aircraft.Info.LandRange;
+
+			// NOTE: desiredFacing = -1 means we should not prefer any particular facing and instead just
+			// use whatever facing gives us the most direct path to the landing site.
+			if (facing == -1 && aircraft.Info.TurnToLand)
+				desiredFacing = aircraft.Info.InitialFacing;
+			else
+				desiredFacing = facing;
+		}
+
+		protected override void OnFirstRun(Actor self)
+		{
+			// When no target is provided we should land in the most direct manner possible.
+			// TODO: For fixed-wing aircraft self.Location is not necessarily the most direct landing site.
+			if (assignTargetOnFirstRun)
+				target = Target.FromCell(self.World, self.Location);
+		}
 
 		public override Activity Tick(Actor self)
 		{
@@ -48,73 +82,177 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (IsCanceling || target.Type == TargetType.Invalid)
 			{
-				// We must return the actor to a sensible height before continuing.
-				// If the aircraft lands when idle and is idle, continue landing,
-				// otherwise climb back to CruiseAltitude.
-				// TODO: Remove this after fixing all activities to work properly with arbitrary starting altitudes.
-				var continueLanding = aircraft.Info.LandWhenIdle && self.CurrentActivity.IsCanceling && self.CurrentActivity.NextActivity == null;
-				if (!continueLanding)
+				if (landingInitiated)
 				{
-					var dat = self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition);
-					if (dat > aircraft.LandAltitude && dat < aircraft.Info.CruiseAltitude)
+					// We must return the actor to a sensible height before continuing.
+					// If the aircraft lands when idle and is idle, continue landing,
+					// otherwise climb back to CruiseAltitude.
+					// TODO: Remove this after fixing all activities to work properly with arbitrary starting altitudes.
+					var continueLanding = aircraft.Info.LandWhenIdle && self.CurrentActivity.IsCanceling && self.CurrentActivity.NextActivity == null;
+					if (!continueLanding)
 					{
-						QueueChild(self, new TakeOff(self), true);
-						return this;
-					}
+						var dat = self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition);
+						if (dat > aircraft.LandAltitude && dat < aircraft.Info.CruiseAltitude)
+						{
+							QueueChild(self, new TakeOff(self), true);
+							return this;
+						}
 
-					aircraft.RemoveInfluence();
-					return NextActivity;
+						aircraft.RemoveInfluence();
+						return NextActivity;
+					}
 				}
+				else
+					return NextActivity;
+			}
+
+			var pos = aircraft.CenterPosition;
+
+			// Reevaluate target position in case the target has moved.
+			targetPosition = target.CenterPosition + offset;
+			landingCell = self.World.Map.CellContaining(targetPosition);
+
+			// We are already at the landing location.
+			if ((targetPosition - pos).LengthSquared == 0)
+				return NextActivity;
+
+			// Look for free landing cell
+			if (target.Type == TargetType.Terrain && !landingInitiated)
+			{
+				var targetLocation = aircraft.FindLandingLocation(landingCell, landRange);
+				if (!targetLocation.HasValue)
+				{
+					// Maintain holding pattern.
+					if (aircraft.Info.CanHover)
+						QueueChild(self, new Wait(25), true);
+					else
+						QueueChild(self, new FlyCircle(self, 25), true);
+					return this;
+				}
+
+				target = Target.FromCell(self.World, targetLocation.Value);
+				targetPosition = target.CenterPosition + offset;
+				landingCell = self.World.Map.CellContaining(targetPosition);
+			}
+
+			// Move towards landing location
+			if (aircraft.Info.VTOL && (pos - targetPosition).HorizontalLengthSquared != 0)
+			{
+				QueueChild(self, new Fly(self, Target.FromPos(targetPosition)), true);
+
+				if (desiredFacing != -1)
+					QueueChild(self, new Turn(self, desiredFacing));
+
+				return this;
+			}
+
+			if (!aircraft.Info.VTOL && !finishedApproach)
+			{
+				// Calculate approach trajectory
+				var altitude = aircraft.Info.CruiseAltitude.Length;
+
+				// Distance required for descent.
+				var landDistance = altitude * 1024 / aircraft.Info.MaximumPitch.Tan();
+
+				// Approach landing from the opposite direction of the desired facing
+				// TODO: Calculate sensible trajectory without preferred facing.
+				var rotation = WRot.Zero;
+				if (desiredFacing != -1)
+					rotation = WRot.FromFacing(desiredFacing);
+
+				var approachStart = targetPosition + new WVec(0, landDistance, altitude).Rotate(rotation);
+
+				// Add 10% to the turning radius to ensure we have enough room
+				var speed = aircraft.MovementSpeed * 32 / 35;
+				var turnRadius = Fly.CalculateTurnRadius(speed, aircraft.Info.TurnSpeed);
+
+				// Find the center of the turning circles for clockwise and counterclockwise turns
+				var angle = WAngle.FromFacing(aircraft.Facing);
+				var fwd = -new WVec(angle.Sin(), angle.Cos(), 0);
+
+				// Work out whether we should turn clockwise or counter-clockwise for approach
+				var side = new WVec(-fwd.Y, fwd.X, fwd.Z);
+				var approachDelta = self.CenterPosition - approachStart;
+				var sideTowardBase = new[] { side, -side }
+					.MinBy(a => WVec.Dot(a, approachDelta));
+
+				// Calculate the tangent line that joins the turning circles at the current and approach positions
+				var cp = self.CenterPosition + turnRadius * sideTowardBase / 1024;
+				var posCenter = new WPos(cp.X, cp.Y, altitude);
+				var approachCenter = approachStart + new WVec(0, turnRadius * Math.Sign(self.CenterPosition.Y - approachStart.Y), 0);
+				var tangentDirection = approachCenter - posCenter;
+				var tangentLength = tangentDirection.Length;
+				var tangentOffset = WVec.Zero;
+				if (tangentLength != 0)
+					tangentOffset = new WVec(-tangentDirection.Y, tangentDirection.X, 0) * turnRadius / tangentLength;
+
+				// TODO: correctly handle CCW <-> CW turns
+				if (tangentOffset.X > 0)
+					tangentOffset = -tangentOffset;
+
+				var w1 = posCenter + tangentOffset;
+				var w2 = approachCenter + tangentOffset;
+				var w3 = approachStart;
+
+				turnRadius = Fly.CalculateTurnRadius(aircraft.Info.Speed, aircraft.Info.TurnSpeed);
+
+				// Move along approach trajectory.
+				QueueChild(self, new Fly(self, Target.FromPos(w1), WDist.Zero, new WDist(turnRadius * 3)), true);
+				QueueChild(self, new Fly(self, Target.FromPos(w2)), true);
+
+				// Fix a problem when the airplane is sent to land near the landing cell
+				QueueChild(self, new Fly(self, Target.FromPos(w3), WDist.Zero, new WDist(turnRadius / 2)), true);
+				finishedApproach = true;
+				return this;
 			}
 
 			if (!landingInitiated)
 			{
-				var landingCell = !aircraft.Info.VTOL ? self.World.Map.CellContaining(target.CenterPosition + offset) : self.Location;
-				if (!aircraft.CanLand(landingCell, target.Actor))
+				var blockingCells = clearCells.Append(landingCell);
+
+				if (!aircraft.CanLand(blockingCells, target.Actor))
 				{
 					// Maintain holding pattern.
-					if (!aircraft.Info.CanHover)
+					if (aircraft.Info.CanHover)
+						QueueChild(self, new Wait(25), true);
+					else
 						QueueChild(self, new FlyCircle(self, 25), true);
 
-					self.NotifyBlocker(landingCell);
+					self.NotifyBlocker(blockingCells);
+					finishedApproach = false;
 					return this;
 				}
+
+				if (aircraft.Info.LandingSounds.Length > 0)
+					Game.Sound.Play(SoundType.World, aircraft.Info.LandingSounds, self.World, aircraft.CenterPosition);
 
 				aircraft.AddInfluence(landingCell);
 				aircraft.EnteringCell(self);
 				landingInitiated = true;
 			}
 
-			var altitude = self.World.Map.DistanceAboveTerrain(self.CenterPosition);
-			var landAltitude = self.World.Map.DistanceAboveTerrain(target.CenterPosition + offset) + aircraft.LandAltitude;
-
-			if (!soundPlayed && aircraft.Info.LandingSounds.Length > 0 && altitude != landAltitude)
-			{
-				Game.Sound.Play(SoundType.World, aircraft.Info.LandingSounds, self.World, aircraft.CenterPosition);
-				soundPlayed = true;
-			}
-
-			// For VTOLs we assume we've already arrived at the target location and just need to move downward
+			// Final descent.
 			if (aircraft.Info.VTOL)
 			{
+				var landAltitude = self.World.Map.DistanceAboveTerrain(targetPosition) + aircraft.LandAltitude;
 				if (Fly.VerticalTakeOffOrLandTick(self, aircraft, aircraft.Facing, landAltitude))
 					return this;
 
 				return NextActivity;
 			}
 
-			var d = (target.CenterPosition + offset) - self.CenterPosition;
+			var d = targetPosition - pos;
 
 			// The next move would overshoot, so just set the final position
 			var move = aircraft.FlyStep(aircraft.Facing);
 			if (d.HorizontalLengthSquared < move.HorizontalLengthSquared)
 			{
 				var landingAltVec = new WVec(WDist.Zero, WDist.Zero, aircraft.LandAltitude);
-				aircraft.SetPosition(self, target.CenterPosition + offset + landingAltVec);
+				aircraft.SetPosition(self, targetPosition + landingAltVec);
 				return NextActivity;
 			}
 
-			var landingAlt = self.World.Map.DistanceAboveTerrain(target.CenterPosition + offset) + aircraft.LandAltitude;
+			var landingAlt = self.World.Map.DistanceAboveTerrain(targetPosition) + aircraft.LandAltitude;
 			Fly.FlyTick(self, aircraft, d.Yaw.Facing, landingAlt);
 
 			return this;

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -119,20 +119,22 @@ namespace OpenRA.Mods.Common.Activities
 			// Look for free landing cell
 			if (target.Type == TargetType.Terrain && !landingInitiated)
 			{
-				var targetLocation = aircraft.FindLandingLocation(landingCell, landRange);
-				if (!targetLocation.HasValue)
+				var newLocation = aircraft.FindLandingLocation(landingCell, landRange);
+
+				// Cannot land so fly towards the last target location instead.
+				if (!newLocation.HasValue)
 				{
-					// Maintain holding pattern.
-					if (aircraft.Info.CanHover)
-						QueueChild(self, new Wait(25), true);
-					else
-						QueueChild(self, new FlyCircle(self, 25), true);
+					Cancel(self, true);
+					QueueChild(self, aircraft.MoveTo(landingCell, 0), true);
 					return this;
 				}
 
-				target = Target.FromCell(self.World, targetLocation.Value);
-				targetPosition = target.CenterPosition + offset;
-				landingCell = self.World.Map.CellContaining(targetPosition);
+				if (newLocation.Value != landingCell)
+				{
+					target = Target.FromCell(self.World, newLocation.Value);
+					targetPosition = target.CenterPosition + offset;
+					landingCell = self.World.Map.CellContaining(targetPosition);
+				}
 			}
 
 			// Move towards landing location

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -142,6 +142,8 @@ namespace OpenRA.Mods.Common.Activities
 				aircraft.MakeReservation(dest);
 				QueueChild(self, new Land(self, Target.FromActor(dest), offset, facing), true);
 				QueueChild(self, new Resupply(self, dest, WDist.Zero), true);
+				if (aircraft.Info.TakeOffOnResupply && !alwaysLand)
+					QueueChild(self, new TakeOff(self));
 			}
 			else
 				QueueChild(self, new Fly(self, Target.FromActor(dest)), true);

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -126,7 +126,7 @@ namespace OpenRA.Mods.Common.Activities
 				}
 
 				// Prevent an infinite loop in case we'd return to the activity that called ReturnToBase in the first place. Go idle instead.
-				Cancel(self);
+				self.CancelActivity();
 				return NextActivity;
 			}
 

--- a/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
+++ b/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
@@ -97,6 +97,9 @@ namespace OpenRA.Mods.Common.Activities
 			// Checking for NextActivity == null again in case another activity was queued while taking off
 			if (moveToRallyPoint && NextActivity == null)
 			{
+				if (!aircraft.Info.VTOL && assignTargetOnFirstRun)
+					return NextActivity;
+
 				QueueChild(self, new AttackMoveActivity(self, () => move.MoveToTarget(self, target)), true);
 				moveToRallyPoint = false;
 				return this;

--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Activities
 				destination = Target.FromCell(self.World, self.Location);
 
 			QueueChild(self, new Land(self, destination, deliverRange), true);
-			QueueChild(self, new Wait(carryall.Info.UnloadingDelay, false), true);
+			QueueChild(self, new Wait(carryall.Info.BeforeUnloadDelay, false), true);
 			QueueChild(self, new ReleaseUnit(self));
 			QueueChild(self, new TakeOff(self));
 		}

--- a/OpenRA.Mods.Common/Activities/EnterTransport.cs
+++ b/OpenRA.Mods.Common/Activities/EnterTransport.cs
@@ -24,6 +24,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		Actor enterActor;
 		Cargo enterCargo;
+		Aircraft enterAircraft;
 
 		public EnterTransport(Actor self, Target target)
 			: base(self, target, Color.Green)
@@ -35,6 +36,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			enterActor = targetActor;
 			enterCargo = targetActor.TraitOrDefault<Cargo>();
+			enterAircraft = targetActor.TraitOrDefault<Aircraft>();
 
 			// Make sure we can still enter the transport
 			// (but not before, because this may stop the actor in the middle of nowhere)
@@ -43,6 +45,9 @@ namespace OpenRA.Mods.Common.Activities
 				Cancel(self, true);
 				return false;
 			}
+
+			if (enterAircraft != null && !enterAircraft.AtLandAltitude)
+				return false;
 
 			return true;
 		}

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -117,16 +117,20 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				var aircraft = self.TraitOrDefault<Aircraft>();
 				if (aircraft != null)
-				{
 					aircraft.AllowYieldingReservation();
-					if (aircraft.Info.TakeOffOnResupply)
-						Queue(self, new TakeOff(self));
-				}
 
 				return NextActivity;
 			}
 
 			return this;
+		}
+
+		public override void Cancel(Actor self, bool keepQueue = false)
+		{
+			if (NextActivity != null)
+				return;
+
+			base.Cancel(self, keepQueue);
 		}
 
 		void RepairTick(Actor self)

--- a/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
@@ -177,19 +177,7 @@ namespace OpenRA.Mods.Common.Scripting
 						}
 					}
 
-					if (aircraft.Info.VTOL)
-					{
-						if (destination != entryPath.Last())
-							Move(transport, destination);
-
-						transport.QueueActivity(new Turn(transport, aircraft.Info.InitialFacing));
-						transport.QueueActivity(new Land(transport));
-					}
-					else
-					{
-						transport.QueueActivity(new Land(transport, Target.FromCell(transport.World, destination)));
-					}
-
+					transport.QueueActivity(new Land(transport, Target.FromCell(transport.World, destination), facing: aircraft.Info.InitialFacing));
 					transport.QueueActivity(new Wait(15));
 				}
 

--- a/OpenRA.Mods.Common/Scripting/Properties/TransportProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/TransportProperties.cs
@@ -42,9 +42,15 @@ namespace OpenRA.Mods.Common.Scripting
 
 		[ScriptActorPropertyActivity]
 		[Desc("Command transport to unload passengers.")]
-		public void UnloadPassengers()
+		public void UnloadPassengers(CPos? cell = null, int unloadRange = 5)
 		{
-			Self.QueueActivity(new UnloadCargo(Self, true));
+			if (cell.HasValue)
+			{
+				var destination = Target.FromCell(Self.World, cell.Value);
+				Self.QueueActivity(new UnloadCargo(Self, destination, WDist.FromCells(unloadRange)));
+			}
+			else
+				Self.QueueActivity(new UnloadCargo(Self, WDist.FromCells(unloadRange)));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -664,7 +664,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected virtual void OnBecomingIdle(Actor self)
 		{
-			var atLandAltitude = self.World.Map.DistanceAboveTerrain(CenterPosition) == LandAltitude;
+			var altitude = self.World.Map.DistanceAboveTerrain(CenterPosition);
+			var atLandAltitude = altitude == LandAltitude;
 
 			// Work-around to prevent players from accidentally canceling resupply by pressing 'Stop',
 			// by re-queueing Resupply as long as resupply hasn't finished and aircraft is still on resupplier.
@@ -692,6 +693,8 @@ namespace OpenRA.Mods.Common.Traits
 				// Will go away soon (in a separate PR) with the arrival of ActionsWhenIdle.
 				self.QueueActivity(new FlyCircle(self, -1, Info.IdleTurnSpeed > -1 ? Info.IdleTurnSpeed : TurnSpeed));
 			}
+			else if (!atLandAltitude && altitude != Info.CruiseAltitude && !Info.LandWhenIdle)
+				self.QueueActivity(new TakeOff(self));
 		}
 
 		#region Implement IPositionable

--- a/OpenRA.Mods.Common/Traits/AutoCarryall.cs
+++ b/OpenRA.Mods.Common/Traits/AutoCarryall.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (ReserveCarryable(self, carryable))
 			{
 				self.QueueActivity(false, new PickupUnit(self, carryable, 0));
-				self.QueueActivity(true, new DeliverUnit(self, destination));
+				self.QueueActivity(true, new DeliverUnit(self, Target.FromCell(self.World, destination), Info.DropRange));
 				return true;
 			}
 
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					busy = true;
 					self.QueueActivity(false, new PickupUnit(self, p.Actor, 0));
-					self.QueueActivity(true, new DeliverUnit(self, p.Trait.Destination.Value));
+					self.QueueActivity(true, new DeliverUnit(self, Target.FromCell(self.World, p.Trait.Destination.Value), Info.DropRange));
 					break;
 				}
 			}

--- a/OpenRA.Mods.Common/Traits/Buildings/FreeActorWithDelivery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FreeActorWithDelivery.cs
@@ -30,6 +30,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Offset relative to the top-left cell of the building.")]
 		public readonly CVec DeliveryOffset = CVec.Zero;
 
+		[Desc("Range to search for an alternative delivery location if the DeliveryOffset cell is blocked.")]
+		public readonly WDist DeliveryRange = WDist.Zero;
+
 		public override object Create(ActorInitializer init) { return new FreeActorWithDelivery(init, this); }
 	}
 
@@ -58,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 			carryable.Reserve(cargo, carrier);
 
 			carrier.Trait<Carryall>().AttachCarryable(carrier, cargo);
-			carrier.QueueActivity(new DeliverUnit(carrier, location));
+			carrier.QueueActivity(new DeliverUnit(carrier, Target.FromCell(self.World, location), Info.DeliveryRange));
 			carrier.QueueActivity(new Fly(carrier, Target.FromCell(self.World, self.World.Map.ChooseRandomEdgeCell(self.World.SharedRandom))));
 			carrier.QueueActivity(new RemoveSelf());
 

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -23,11 +23,11 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Transports actors with the `Carryable` trait.")]
 	public class CarryallInfo : ITraitInfo, Requires<BodyOrientationInfo>, Requires<AircraftInfo>
 	{
-		[Desc("Delay on the ground while attaching an actor to the carryall.")]
-		public readonly int LoadingDelay = 0;
+		[Desc("Delay (in ticks) on the ground while attaching an actor to the carryall.")]
+		public readonly int BeforeLoadDelay = 0;
 
-		[Desc("Delay on the ground while detacting an actor to the carryall.")]
-		public readonly int UnloadingDelay = 0;
+		[Desc("Delay (in ticks) on the ground while detaching an actor from the carryall.")]
+		public readonly int BeforeUnloadDelay = 0;
 
 		[Desc("Carryable attachment point relative to body.")]
 		public readonly WVec LocalOffset = WVec.Zero;
@@ -317,7 +317,7 @@ namespace OpenRA.Mods.Common.Traits
 					self.CancelActivity();
 
 				self.SetTargetLine(order.Target, Color.Yellow);
-				self.QueueActivity(order.Queued, new PickupUnit(self, order.Target.Actor, Info.LoadingDelay));
+				self.QueueActivity(order.Queued, new PickupUnit(self, order.Target.Actor, Info.BeforeLoadDelay));
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public class Carryall : INotifyKilled, ISync, ITick, IRender, INotifyActorDisposing, IIssueOrder, IResolveOrder,
-		IOrderVoice, IIssueDeployOrder
+		IOrderVoice, IIssueDeployOrder, IAircraftCenterPositionOffset, IOverrideAircraftLanding
 	{
 		public enum CarryallState
 		{
@@ -80,7 +80,8 @@ namespace OpenRA.Mods.Common.Traits
 		public CarryallState State { get; private set; }
 
 		int cachedFacing;
-		IActorPreview[] carryablePreview = null;
+		IActorPreview[] carryablePreview;
+		HashSet<string> landableTerrainTypes;
 
 		/// <summary>Offset between the carryall's and the carried actor's CenterPositions</summary>
 		public WVec CarryableOffset { get; private set; }
@@ -154,6 +155,17 @@ namespace OpenRA.Mods.Common.Traits
 			return Info.LocalOffset - carryable.Info.TraitInfo<CarryableInfo>().LocalOffset;
 		}
 
+		WVec IAircraftCenterPositionOffset.PositionOffset
+		{
+			get
+			{
+				var localOffset = CarryableOffset.Rotate(body.QuantizeOrientation(self, self.Orientation));
+				return body.LocalToWorld(localOffset);
+			}
+		}
+
+		HashSet<string> IOverrideAircraftLanding.LandableTerrainTypes { get { return landableTerrainTypes ?? aircraft.Info.LandableTerrainTypes; } }
+
 		public virtual bool AttachCarryable(Actor self, Actor carryable)
 		{
 			if (State == CarryallState.Carrying)
@@ -164,7 +176,8 @@ namespace OpenRA.Mods.Common.Traits
 			self.World.ScreenMap.AddOrUpdate(self);
 
 			CarryableOffset = OffsetForCarryable(self, carryable);
-			aircraft.AddLandingOffset(-CarryableOffset.Z);
+			landableTerrainTypes = Carryable.Trait<Mobile>().Info.LocomotorInfo.TerrainSpeeds.Keys.ToHashSet();
+
 			return true;
 		}
 
@@ -174,7 +187,7 @@ namespace OpenRA.Mods.Common.Traits
 			self.World.ScreenMap.AddOrUpdate(self);
 
 			carryablePreview = null;
-			aircraft.SubtractLandingOffset(-CarryableOffset.Z);
+			landableTerrainTypes = null;
 			CarryableOffset = WVec.Zero;
 		}
 
@@ -245,9 +258,8 @@ namespace OpenRA.Mods.Common.Traits
 		// Check if we can drop the unit at our current location.
 		public bool CanUnload()
 		{
-			var localOffset = CarryableOffset.Rotate(body.QuantizeOrientation(self, self.Orientation));
-			var targetCell = self.World.Map.CellContaining(self.CenterPosition + body.LocalToWorld(localOffset));
-			return Carryable != null && Carryable.Trait<IPositionable>().CanEnterCell(targetCell, self);
+			var targetCell = self.World.Map.CellContaining(aircraft.GetPosition());
+			return Carryable != null && aircraft.CanLand(targetCell, blockedByMobile: false);
 		}
 
 		IEnumerable<IOrderTargeter> IIssueOrder.Orders
@@ -286,14 +298,14 @@ namespace OpenRA.Mods.Common.Traits
 
 				var targetLocation = move.NearestMoveableCell(cell);
 				self.SetTargetLine(Target.FromCell(self.World, targetLocation), Color.Yellow);
-				self.QueueActivity(order.Queued, new DeliverUnit(self, targetLocation));
+				self.QueueActivity(order.Queued, new DeliverUnit(self, order.Target, Info.DropRange));
 			}
 			else if (order.OrderString == "Unload")
 			{
 				if (!order.Queued && !CanUnload())
 					return;
 
-				self.QueueActivity(order.Queued, new DeliverUnit(self));
+				self.QueueActivity(order.Queued, new DeliverUnit(self, Info.DropRange));
 			}
 
 			if (order.OrderString == "PickupUnit")

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -168,9 +168,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool Reserve(Actor self, Cargo cargo)
 		{
+			if (cargo == ReservedCargo)
+				return true;
+
 			Unreserve(self);
 			if (!cargo.ReserveSpace(self))
 				return false;
+
 			ReservedCargo = cargo;
 			return true;
 		}
@@ -181,6 +185,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (ReservedCargo == null)
 				return;
+
 			ReservedCargo.UnreserveSpace(self);
 			ReservedCargo = null;
 		}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -448,6 +448,16 @@ namespace OpenRA.Mods.Common.Traits
 		Activity WrapMove(Activity moveInner);
 	}
 
+	public interface IAircraftCenterPositionOffset
+	{
+		WVec PositionOffset { get; }
+	}
+
+	public interface IOverrideAircraftLanding
+	{
+		HashSet<string> LandableTerrainTypes { get; }
+	}
+
 	public interface IRadarSignature
 	{
 		void PopulateRadarSignatureCells(Actor self, List<Pair<CPos, Color>> destinationBuffer);

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20190314/RenameCarryallDelays.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20190314/RenameCarryallDelays.cs
@@ -1,0 +1,42 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RenameCarryallDelays : UpdateRule
+	{
+		public override string Name { get { return "Rename Carryall and Cargo delay parameters"; } }
+		public override string Description
+		{
+			get
+			{
+				return "Carryall's LoadingDelay and UnloadingDelay parameters have been renamed\n"
+					+ "to BeforeLoadDelay and BeforeUnloadDelay to match new parameters on Cargo.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var carryall in actorNode.ChildrenMatching("Carryall"))
+			{
+				foreach (var node in carryall.ChildrenMatching("LoadingDelay"))
+					node.RenameKey("BeforeLoadDelay");
+
+				foreach (var node in carryall.ChildrenMatching("UnloadingDelay"))
+					node.RenameKey("BeforeUnloadDelay");
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -129,6 +129,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemovePlaceBuildingPalettes(),
 				new RenameHoversOffsetModifier(),
 				new AddAirAttackTypes(),
+				new RenameCarryallDelays(),
 			})
 		};
 

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -1209,7 +1209,7 @@ Container@PLAYER_WIDGETS:
 					Background: chrome-button-background
 					DisableKeySound: true
 					TooltipText: Force Move
-					TooltipDesc: Selected units will move to the desired location\n - Default activity for the target is suppressed\n - Vehicles will attempt to crush enemies at the target location\n\nLeft-click icon then right-click on target.\nHold {(Alt)} to activate temporarily while commanding units.
+					TooltipDesc: Selected units will move to the desired location\n - Default activity for the target is suppressed\n - Vehicles will attempt to crush enemies at the target location\n - Helicopters will land at the target location\n\nLeft-click icon then right-click on target.\nHold {(Alt)} to activate temporarily while commanding units.
 					TooltipContainer: TOOLTIP_CONTAINER
 					TooltipTemplate: BUTTON_WITH_DESC_HIGHLIGHT_TOOLTIP_FACTIONSUFFIX
 					Children:

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -12,7 +12,7 @@ TRAN:
 		Queue: Aircraft.GDI, Aircraft.Nod
 		Description: Fast Infantry Transport Helicopter.\n  Unarmed
 	Aircraft:
-		LandWhenIdle: true
+		LandWhenIdle: false
 		TurnSpeed: 5
 		Speed: 150
 		AltitudeVelocity: 0c100
@@ -43,6 +43,7 @@ TRAN:
 		Types: Infantry
 		MaxWeight: 10
 		PipCount: 10
+		AfterUnloadDelay: 40
 	SpawnActorOnDeath:
 		Actor: TRAN.Husk
 	SelectionDecorations:

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -15,8 +15,6 @@ TRAN:
 		LandWhenIdle: true
 		TurnSpeed: 5
 		Speed: 150
-		LandableTerrainTypes: Clear, Rough, Road, Beach, Tiberium, BlueTiberium
-		Crushes: crate, infantry
 		AltitudeVelocity: 0c100
 	Health:
 		HP: 9000

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -183,7 +183,6 @@ C17:
 		Speed: 326
 		Repulsable: False
 		MaximumPitch: 36
-		LandableTerrainTypes: Clear, Rough, Road, Beach
 	HiddenUnderFog:
 		AlwaysVisibleStances: None
 		Type: CenterPosition

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -328,6 +328,8 @@
 		CanHover: True
 		TakeOffOnResupply: true
 		VTOL: true
+		LandableTerrainTypes: Clear, Rough, Road, Beach, Tiberium, BlueTiberium
+		Crushes: crate, infantry
 		InitialFacing: 224
 	HiddenUnderFog:
 		Type: GroundPosition

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -34,8 +34,8 @@ carryall.reinforce:
 		Actor: carryall.huskVTOL
 		RequiresCondition: !cruising
 	Carryall:
-		LoadingDelay: 10
-		UnloadingDelay: 15
+		BeforeLoadDelay: 10
+		BeforeUnloadDelay: 15
 		LocalOffset: 0, 0, -128
 	RenderSprites:
 		Image: carryall
@@ -52,8 +52,8 @@ carryall:
 	Inherits: carryall.reinforce
 	-Carryall:
 	AutoCarryall:
-		LoadingDelay: 10
-		UnloadingDelay: 15
+		BeforeLoadDelay: 10
+		BeforeUnloadDelay: 15
 		LocalOffset: 0, 0, -128
 	Aircraft:
 		MinAirborneAltitude: 400

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -82,7 +82,6 @@ frigate:
 		Repulsable: False
 		MaximumPitch: 20
 		CruiseAltitude: 2048
-		LandableTerrainTypes: Rock, Concrete
 	-AppearsOnRadar:
 	Cargo:
 		MaxWeight: 20

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -73,7 +73,7 @@ Container@PLAYER_WIDGETS:
 					Background: command-button
 					DisableKeySound: true
 					TooltipText: Force Move
-					TooltipDesc: Selected units will move to the desired location\n - Default activity for the target is suppressed\n - Vehicles will attempt to crush enemies at the target location\n - Chrono Tanks will teleport towards the target location\n\nLeft-click icon then right-click on target.\nHold {(Alt)} to activate temporarily while commanding units.
+					TooltipDesc: Selected units will move to the desired location\n - Default activity for the target is suppressed\n - Vehicles will attempt to crush enemies at the target location\n - Helicopters will land at the target location\n - Chrono Tanks will teleport towards the target location\n\nLeft-click icon then right-click on target.\nHold {(Alt)} to activate temporarily while commanding units.
 					TooltipContainer: TOOLTIP_CONTAINER
 					TooltipTemplate: BUTTON_WITH_DESC_HIGHLIGHT_TOOLTIP
 					Children:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -240,8 +240,6 @@ TRAN:
 	Aircraft:
 		TurnSpeed: 5
 		Speed: 128
-		LandableTerrainTypes: Clear,Rough,Road,Ore,Beach,Gems
-		Crushes: crate, mine, infantry
 		AltitudeVelocity: 0c58
 	WithIdleOverlay@ROTOR1AIR:
 		Offset: 597,0,213

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -238,6 +238,7 @@ TRAN:
 		Range: 6c0
 		Type: GroundPosition
 	Aircraft:
+		LandWhenIdle: false
 		TurnSpeed: 5
 		Speed: 128
 		AltitudeVelocity: 0c58
@@ -261,6 +262,7 @@ TRAN:
 		Types: Infantry
 		MaxWeight: 8
 		PipCount: 8
+		AfterUnloadDelay: 40
 	SpawnActorOnDeath:
 		Actor: TRAN.Husk
 	SelectionDecorations:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -631,6 +631,8 @@
 		WaitDistanceFromResupplyBase: 4c0
 		TakeOffOnResupply: true
 		VTOL: true
+		LandableTerrainTypes: Clear, Rough, Road, Ore, Beach, Gems
+		Crushes: crate, mine, infantry
 		InitialFacing: 224
 	GpsDot:
 		String: Helicopter

--- a/mods/ts/chrome/ingame-player.yaml
+++ b/mods/ts/chrome/ingame-player.yaml
@@ -61,7 +61,7 @@ Container@PLAYER_WIDGETS:
 					Background:
 					DisableKeySound: true
 					TooltipText: Force Move
-					TooltipDesc: Selected units will move to the desired location\n - Default activity for the target is suppressed\n - Vehicles will attempt to crush enemies at the target location\n - Deployed units will undeploy and move to the target location\n - Carryalls will not release their cargo at the target location\n\nLeft-click icon then right-click on target.\nHold {(Alt)} to activate temporarily while commanding units.
+					TooltipDesc: Selected units will move to the desired location\n - Default activity for the target is suppressed\n - Vehicles will attempt to crush enemies at the target location\n - Deployed units will undeploy and move to the target location\n - Helicopters will land at the target location\n\nLeft-click icon then right-click on target.\nHold {(Alt)} to activate temporarily while commanding units.
 					TooltipContainer: TOOLTIP_CONTAINER
 					TooltipTemplate: BUTTON_WITH_DESC_HIGHLIGHT_TOOLTIP
 					Children:

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -190,7 +190,7 @@ ORCATRAN:
 		Prerequisites: ~disabled
 	RenderSprites:
 	Aircraft:
-		LandWhenIdle: true
+		LandWhenIdle: false
 		TurnSpeed: 5
 		Speed: 84
 		InitialFacing: 0
@@ -210,6 +210,7 @@ ORCATRAN:
 		PipCount: 5
 		UnloadVoice: Move
 		EjectOnDeath: true
+		AfterUnloadDelay: 40
 	SpawnActorOnDeath:
 		Actor: ORCATRAN.Husk
 
@@ -236,6 +237,8 @@ TRNSPORT:
 	Carryall:
 		Voice: Move
 		LocalOffset: 0,0,-317
+		BeforeLoadDelay: 10
+		BeforeUnloadDelay: 10
 	Health:
 		HP: 17500
 	Armor:

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -10,8 +10,6 @@ DPOD:
 		TurnSpeed: 5
 		Speed: 149
 		InitialFacing: 0
-		LandableTerrainTypes: Clear,Road,Rail,DirtRoad,Rough,Tiberium,BlueTiberium,Veins
-		Crushes: crate, infantry
 	Health:
 		HP: 6000
 	Armor:
@@ -46,8 +44,6 @@ DSHP:
 		TurnSpeed: 5
 		Speed: 168
 		InitialFacing: 0
-		LandableTerrainTypes: Clear,Road,Rail,DirtRoad,Rough,Tiberium,BlueTiberium,Veins
-		Crushes: crate, infantry
 		TakeoffSounds: dropup1.aud
 		LandingSounds: dropdwn1.aud
 		IdealSeparation: 1275
@@ -198,8 +194,6 @@ ORCATRAN:
 		TurnSpeed: 5
 		Speed: 84
 		InitialFacing: 0
-		LandableTerrainTypes: Clear,Road,Rail,DirtRoad,Rough,Tiberium,BlueTiberium,Veins
-		Crushes: crate, infantry
 		TakeoffSounds: orcaup1.aud
 		LandingSounds: orcadwn1.aud
 		IdealSeparation: 1275
@@ -233,12 +227,9 @@ TRNSPORT:
 		Prerequisites: ~gahpad, gadept
 		Description: VTOL aircraft capable of lifting\nand transporting vehicles.\n  Unarmed
 	Aircraft:
-		LandWhenIdle: true
 		TurnSpeed: 5
 		Speed: 149
 		InitialFacing: 0
-		LandableTerrainTypes: Clear,Road,Rail,DirtRoad,Rough,Tiberium,BlueTiberium,Veins
-		Crushes: crate, infantry
 		TakeoffSounds: dropup1.aud
 		LandingSounds: dropdwn1.aud
 		MoveIntoShroud: false

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -875,6 +875,8 @@
 		Voice: Move
 		IdealSeparation: 853
 		MaximumPitch: 120
+		LandableTerrainTypes: Clear, Road, Rail, DirtRoad, Rough, Tiberium, BlueTiberium, Veins
+		Crushes: crate, infantry
 	Voiced:
 		VoiceSet: Heli
 	HiddenUnderFog:

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -91,8 +91,10 @@ HVR:
 		RequiresCondition: !empdisable
 		BobDistance: -64
 		InitialHeight: 384
+	Carryable:
+		CarriedCondition: carried
 	LeavesTrails:
-		RequiresCondition: !inside-tunnel
+		RequiresCondition: !inside-tunnel && !carried
 		Image: wake
 		Palette: effect
 		TerrainTypes: Water


### PR DESCRIPTION
Depends on #16417 and #16365.

Implements features requested in https://github.com/OpenRA/OpenRA/pull/16417#pullrequestreview-229217672.
Implements refactor requested in https://github.com/OpenRA/OpenRA/pull/16365#discussion_r279190928.
Fixes #16331.
Fixes #12464.
Fixes #12201.
Fixes #4642.
Fixes #12081.
Fixes #11748.
Fixes #16572.
Fixes #16646.

This PR moves all the approach before landing logic into the `Land` activity itself. This includes flying and turning for VTOL aircraft. It also includes and generalizes the approach logic for non-VTOL aircraft found in `ReturnToBase` and the logic from `DeliverUnit` that looks for suitable landing locations. This makes the `Land` activity completely self-contained and flexible. No other activity should bother with the specifics of landing, but just queue a `Land` activity with a desired `target,` `offset` and `facing` (all optional parameters) instead.

Furthermore, this implements explicit land orders and reworks the carryall and transport logic to support transport craft remaining airborne when idle.

Changes in behaviour:
- Orca carryalls, orca transports and chinooks remain airborn when idle.
- All aircraft with `LandableTerraintypes` defined can be ordered to land at a location using force-move.
- All VTOL aircraft in the default mods have `LandableTerrainTypes` defined and can therefore be ordered to land.
- When ordered to land at a cell (not a docking actor) occupied by an actor that cannot be crushed or nudged, aircraft will land at a nearby cell instead. (This was generalized from `DeliverUnit`)
- When infantry try to enter an aerial transport, it will automatically land and the infantry will wait for it to do so.
- Carryalls will automatically lift off after picking up or delivering a unit.
- Scripted unload orders may optionally include a destination and `UnloadCargo` will then take care of getting close to that destination.
- Non-VTOL carryalls are fully supported. (Replace `Inherits: ^Helicopter` with `Inherits: ^Aircraft` in the TS carryall to test)
