### PR TITLE
Update packaged mono to 5.20.1.19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 
 dist: xenial
 language: csharp
-mono: 5.10.0
+mono: 5.20.1
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,6 @@ env:
 # call OpenRA to check for YAML errors
 # Run the NUnit tests
 script:
- - wget http://mirrors.kernel.org/ubuntu/pool/universe/n/nsis/nsis-common_3.03-2_all.deb
- - wget http://mirrors.kernel.org/ubuntu/pool/universe/n/nsis/nsis_3.03-2_amd64.deb
- - sudo dpkg -i nsis-common_3.03-2_all.deb
- - sudo dpkg -i nsis_3.03-2_amd64.deb
- - makensis -VERSION
  - travis_retry make all-dependencies
  - make all
  - make check
@@ -68,6 +63,11 @@ notifications:
     skip_join: true
 
 before_deploy:
+ - wget http://mirrors.kernel.org/ubuntu/pool/universe/n/nsis/nsis-common_3.03-2_all.deb
+ - wget http://mirrors.kernel.org/ubuntu/pool/universe/n/nsis/nsis_3.03-2_amd64.deb
+ - sudo dpkg -i nsis-common_3.03-2_all.deb
+ - sudo dpkg -i nsis_3.03-2_amd64.deb
+ - makensis -VERSION
  - export PATH=$PATH:$HOME/usr/bin
  - DOTVERSION=`echo ${TRAVIS_TAG} | sed "s/-/\\./g"`
  - cd packaging

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -7,7 +7,7 @@ command -v python >/dev/null 2>&1 || { echo >&2 "Linux packaging requires python
 command -v tar >/dev/null 2>&1 || { echo >&2 "Linux packaging requires tar."; exit 1; }
 command -v curl >/dev/null 2>&1 || command -v wget > /dev/null 2>&1 || { echo >&2 "Linux packaging requires curl or wget."; exit 1; }
 
-DEPENDENCIES_TAG="20190316"
+DEPENDENCIES_TAG="20190506"
 
 if [ $# -eq "0" ]; then
 	echo "Usage: $(basename "$0") version [outputdir]"

--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -9,7 +9,7 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
 	command -v genisoimage >/dev/null 2>&1 || { echo >&2 "macOS packaging requires genisoimage."; exit 1; }
 fi
 
-LAUNCHER_TAG="osx-launcher-20190317"
+LAUNCHER_TAG="osx-launcher-20190506"
 
 if [ $# -ne "2" ]; then
 	echo "Usage: $(basename "$0") tag outputdir"


### PR DESCRIPTION
Fixes #16512.

This PR updates the mono version used by travis and shipped in the AppImages and mac .apps to the latest stable release.

The base platform for building the Linux dependencies (pulled from the [AppImageSupport](https://github.com/OpenRA/AppImageSupport) repo by the packaging scripts) is also changed from Debian 7 to Ubuntu 14.04 because the Debian 7 update servers have been taken offline, breaking the automated compilation.

This change also raises our minimum macOS version requirement from 10.7 to 10.9 because mono >= 5.18 [have dropped support](https://www.mono-project.com/docs/about-mono/releases/5.18.0/#general) for these old versions (10.8 was released in 2012 and EOLed in 2015). The sysinfo stats for 2019 showed < 10 systems affected, and these players will still have the option of installing mono 5.16 and compiling OpenRA from source.

This also fixes travis downloading and installing the NSIS packages before every build - these are only needed during release packaging.

Test builds are available from https://github.com/pchote/OpenRA/releases/tag/pkgtest-20190506