### PR TITLE
Fix and enable SA1133, SA1134 style rules.

### DIFF
--- a/OpenRA.Game/Map/ActorInitializer.cs
+++ b/OpenRA.Game/Map/ActorInitializer.cs
@@ -49,7 +49,9 @@ namespace OpenRA
 
 	public class LocationInit : IActorInit<CPos>
 	{
-		[FieldFromYamlKey] readonly CPos value = CPos.Zero;
+		[FieldFromYamlKey]
+		readonly CPos value = CPos.Zero;
+
 		public LocationInit() { }
 		public LocationInit(CPos init) { value = init; }
 		public CPos Value(World world) { return value; }
@@ -57,7 +59,9 @@ namespace OpenRA
 
 	public class OwnerInit : IActorInit<Player>
 	{
-		[FieldFromYamlKey] public readonly string PlayerName = "Neutral";
+		[FieldFromYamlKey]
+		public readonly string PlayerName = "Neutral";
+
 		Player player;
 
 		public OwnerInit() { }

--- a/OpenRA.Game/Network/GeoIP.cs
+++ b/OpenRA.Game/Network/GeoIP.cs
@@ -21,7 +21,8 @@ namespace OpenRA.Network
 	{
 		public class GeoIP2Record
 		{
-			[MaxMind.Db.Constructor] public GeoIP2Record(GeoIP2Country country)
+			[Constructor]
+			public GeoIP2Record(GeoIP2Country country)
 			{
 				Country = country;
 			}
@@ -31,7 +32,8 @@ namespace OpenRA.Network
 
 		public class GeoIP2Country
 		{
-			[MaxMind.Db.Constructor] public GeoIP2Country(GeoIP2CountryNames names)
+			[Constructor]
+			public GeoIP2Country(GeoIP2CountryNames names)
 			{
 				Names = names;
 			}
@@ -41,7 +43,8 @@ namespace OpenRA.Network
 
 		public class GeoIP2CountryNames
 		{
-			[MaxMind.Db.Constructor] public GeoIP2CountryNames(string en)
+			[Constructor]
+			public GeoIP2CountryNames(string en)
 			{
 				English = en;
 			}

--- a/OpenRA.Game/Network/Handshake.cs
+++ b/OpenRA.Game/Network/Handshake.cs
@@ -46,7 +46,8 @@ namespace OpenRA.Network
 		public string Fingerprint;
 		public string AuthSignature;
 
-		[FieldLoader.Ignore] public Session.Client Client;
+		[FieldLoader.Ignore]
+		public Session.Client Client;
 
 		public static HandshakeResponse Deserialize(string data)
 		{

--- a/OpenRA.Game/Traits/DebugPauseState.cs
+++ b/OpenRA.Game/Traits/DebugPauseState.cs
@@ -20,7 +20,8 @@ namespace OpenRA.Traits
 	public class DebugPauseState : ISync
 	{
 		readonly World world;
-		[Sync] public bool Paused { get { return world.Paused; } }
+		[Sync]
+		public bool Paused { get { return world.Paused; } }
 		public DebugPauseState(World world) { this.world = world; }
 	}
 }

--- a/OpenRA.Game/Traits/Player/FixedColorPalette.cs
+++ b/OpenRA.Game/Traits/Player/FixedColorPalette.cs
@@ -17,11 +17,13 @@ namespace OpenRA.Traits
 	[Desc("Add this to the World actor definition.")]
 	public class FixedColorPaletteInfo : ITraitInfo
 	{
+		[PaletteReference]
 		[Desc("The name of the palette to base off.")]
-		[PaletteReference] public readonly string Base = TileSet.TerrainPaletteInternalName;
+		public readonly string Base = TileSet.TerrainPaletteInternalName;
 
+		[PaletteDefinition]
 		[Desc("The name of the resulting palette")]
-		[PaletteDefinition] public readonly string Name = "resources";
+		public readonly string Name = "resources";
 
 		[Desc("Remap these indices to pre-defined colors.")]
 		public readonly int[] RemapIndex = { };

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -204,8 +204,11 @@ namespace OpenRA.Traits
 
 	public class FrozenActorLayer : IRender, ITick, ISync
 	{
-		[Sync] public int VisibilityHash;
-		[Sync] public int FrozenHash;
+		[Sync]
+		public int VisibilityHash;
+
+		[Sync]
+		public int FrozenHash;
 
 		readonly int binSize;
 		readonly World world;

--- a/OpenRA.Game/Traits/Player/IndexedPlayerPalette.cs
+++ b/OpenRA.Game/Traits/Player/IndexedPlayerPalette.cs
@@ -19,11 +19,13 @@ namespace OpenRA.Traits
 	[Desc("Define a player palette by swapping palette indices.")]
 	public class IndexedPlayerPaletteInfo : ITraitInfo, IRulesetLoaded
 	{
+		[PaletteReference]
 		[Desc("The name of the palette to base off.")]
-		[PaletteReference] public readonly string BasePalette = null;
+		public readonly string BasePalette = null;
 
+		[PaletteDefinition(true)]
 		[Desc("The prefix for the resulting player palettes")]
-		[PaletteDefinition(true)] public readonly string BaseName = "player";
+		public readonly string BaseName = "player";
 
 		[Desc("Remap these indices to player colors.")]
 		public readonly int[] RemapIndex = { };

--- a/OpenRA.Game/Traits/Player/PlayerColorPalette.cs
+++ b/OpenRA.Game/Traits/Player/PlayerColorPalette.cs
@@ -17,11 +17,13 @@ namespace OpenRA.Traits
 	[Desc("Add this to the Player actor definition.")]
 	public class PlayerColorPaletteInfo : ITraitInfo
 	{
+		[PaletteReference]
 		[Desc("The name of the palette to base off.")]
-		[PaletteReference] public readonly string BasePalette = null;
+		public readonly string BasePalette = null;
 
+		[PaletteDefinition(true)]
 		[Desc("The prefix for the resulting player palettes")]
-		[PaletteDefinition(true)] public readonly string BaseName = "player";
+		public readonly string BaseName = "player";
 
 		[Desc("Remap these indices to player colors.")]
 		public readonly int[] RemapIndex = { };

--- a/OpenRA.Game/Traits/Player/PlayerHighlightPalette.cs
+++ b/OpenRA.Game/Traits/Player/PlayerHighlightPalette.cs
@@ -18,8 +18,9 @@ namespace OpenRA.Traits
 	[Desc("Add this to the Player actor definition.")]
 	public class PlayerHighlightPaletteInfo : ITraitInfo
 	{
+		[PaletteDefinition(true)]
 		[Desc("The prefix for the resulting player palettes")]
-		[PaletteDefinition(true)] public readonly string BaseName = "highlight";
+		public readonly string BaseName = "highlight";
 
 		public object Create(ActorInitializer init) { return new PlayerHighlightPalette(this); }
 	}

--- a/OpenRA.Game/Traits/Player/Shroud.cs
+++ b/OpenRA.Game/Traits/Player/Shroud.cs
@@ -102,7 +102,8 @@ namespace OpenRA.Traits
 		// Per-cell cache of the resolved cell type (shroud/fog/visible)
 		readonly CellLayer<ShroudCellType> resolvedType;
 
-		[Sync] bool disabled;
+		[Sync]
+		bool disabled;
 		public bool Disabled
 		{
 			get

--- a/OpenRA.Game/Traits/Selectable.cs
+++ b/OpenRA.Game/Traits/Selectable.cs
@@ -20,7 +20,8 @@ namespace OpenRA.Traits
 		+ "Defaults to the actor name when not defined or inherited.")]
 		public readonly string Class = null;
 
-		[VoiceReference] public readonly string Voice = "Select";
+		[VoiceReference]
+		public readonly string Voice = "Select";
 
 		public override object Create(ActorInitializer init) { return new Selectable(init.Self, this); }
 	}

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -154,7 +154,8 @@ namespace OpenRA.Traits
 		Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued);
 	}
 
-	[Flags] public enum TargetModifiers { None = 0, ForceAttack = 1, ForceQueue = 2, ForceMove = 4 }
+	[Flags]
+	public enum TargetModifiers { None = 0, ForceAttack = 1, ForceQueue = 2, ForceMove = 4 }
 
 	public static class TargetModifiersExts
 	{

--- a/OpenRA.Mods.Cnc/Projectiles/TeslaZap.cs
+++ b/OpenRA.Mods.Cnc/Projectiles/TeslaZap.cs
@@ -21,10 +21,14 @@ namespace OpenRA.Mods.Cnc.Projectiles
 	{
 		public readonly string Image = "litning";
 
-		[SequenceReference("Image")] public readonly string BrightSequence = "bright";
-		[SequenceReference("Image")] public readonly string DimSequence = "dim";
+		[SequenceReference("Image")]
+		public readonly string BrightSequence = "bright";
 
-		[PaletteReference] public readonly string Palette = "effect";
+		[SequenceReference("Image")]
+		public readonly string DimSequence = "dim";
+
+		[PaletteReference]
+		public readonly string Palette = "effect";
 
 		public readonly int BrightZaps = 1;
 		public readonly int DimZaps = 2;
@@ -45,7 +49,9 @@ namespace OpenRA.Mods.Cnc.Projectiles
 		TeslaZapRenderable zap;
 		int ticksUntilRemove;
 		int damageDuration;
-		[Sync] WPos target;
+
+		[Sync]
+		WPos target;
 
 		public TeslaZap(TeslaZapInfo info, ProjectileArgs args)
 		{

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackPopupTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackPopupTurreted.cs
@@ -28,14 +28,17 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("The percentage of damage that is received while this actor is closed.")]
 		public readonly int ClosedDamageMultiplier = 50;
 
+		[SequenceReference]
 		[Desc("Sequence to play when opening.")]
-		[SequenceReference] public readonly string OpeningSequence = "opening";
+		public readonly string OpeningSequence = "opening";
 
+		[SequenceReference]
 		[Desc("Sequence to play when closing.")]
-		[SequenceReference] public readonly string ClosingSequence = "closing";
+		public readonly string ClosingSequence = "closing";
 
+		[SequenceReference]
 		[Desc("Idle sequence to play when closed.")]
-		[SequenceReference] public readonly string ClosedIdleSequence = "closed-idle";
+		public readonly string ClosedIdleSequence = "closed-idle";
 
 		[Desc("Which sprite body to play the animation on.")]
 		public readonly string Body = "body";

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
@@ -41,8 +41,11 @@ namespace OpenRA.Mods.Cnc.Traits
 	{
 		readonly AttackTeslaInfo info;
 
-		[Sync] int charges;
-		[Sync] int timeToRecharge;
+		[Sync]
+		int charges;
+
+		[Sync]
+		int timeToRecharge;
 
 		public AttackTesla(Actor self, AttackTeslaInfo info)
 			: base(self, info)

--- a/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
@@ -25,8 +25,9 @@ namespace OpenRA.Mods.Cnc.Traits
 		[NotificationReference("Speech")]
 		public readonly string ReadyAudio = "Reinforce";
 
+		[ActorReference(typeof(AircraftInfo))]
 		[Desc("Cargo aircraft used for delivery. Must have the `Aircraft` trait.")]
-		[ActorReference(typeof(AircraftInfo))] public readonly string ActorType = "c17";
+		public readonly string ActorType = "c17";
 
 		public override object Create(ActorInitializer init) { return new ProductionAirdrop(init, this); }
 	}

--- a/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
+++ b/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
@@ -48,8 +48,11 @@ namespace OpenRA.Mods.Cnc.Traits
 		IPositionable iPositionable;
 
 		// Return-to-origin logic
-		[Sync] public CPos Origin;
-		[Sync] public int ReturnTicks = 0;
+		[Sync]
+		public CPos Origin;
+
+		[Sync]
+		public int ReturnTicks = 0;
 
 		public Chronoshiftable(ActorInitializer init, ChronoshiftableInfo info)
 			: base(info)
@@ -180,7 +183,9 @@ namespace OpenRA.Mods.Cnc.Traits
 
 	public class ChronoshiftReturnInit : IActorInit<int>
 	{
-		[FieldFromYamlKey] readonly int value = 0;
+		[FieldFromYamlKey]
+		readonly int value = 0;
+
 		public ChronoshiftReturnInit() { }
 		public ChronoshiftReturnInit(int init) { value = init; }
 		public int Value(World world) { return value; }
@@ -188,7 +193,9 @@ namespace OpenRA.Mods.Cnc.Traits
 
 	public class ChronoshiftDurationInit : IActorInit<int>
 	{
-		[FieldFromYamlKey] readonly int value = 0;
+		[FieldFromYamlKey]
+		readonly int value = 0;
+
 		public ChronoshiftDurationInit() { }
 		public ChronoshiftDurationInit(int init) { value = init; }
 		public int Value(World world) { return value; }
@@ -196,7 +203,9 @@ namespace OpenRA.Mods.Cnc.Traits
 
 	public class ChronoshiftOriginInit : IActorInit<CPos>
 	{
-		[FieldFromYamlKey] readonly CPos value;
+		[FieldFromYamlKey]
+		readonly CPos value;
+
 		public ChronoshiftOriginInit(CPos init) { value = init; }
 		public CPos Value(World world) { return value; }
 	}

--- a/OpenRA.Mods.Cnc/Traits/ConyardChronoReturn.cs
+++ b/OpenRA.Mods.Cnc/Traits/ConyardChronoReturn.cs
@@ -25,7 +25,8 @@ namespace OpenRA.Mods.Cnc.Traits
 		"Otherwise, a vortex animation is played and damage is dealt each tick, ignoring modifiers.")]
 	public class ConyardChronoReturnInfo : IObservesVariablesInfo, Requires<HealthInfo>, Requires<WithSpriteBodyInfo>
 	{
-		[Desc("Sequence name with the baked-in vortex animation"), SequenceReference]
+		[SequenceReference]
+		[Desc("Sequence name with the baked-in vortex animation")]
 		public readonly string Sequence = "pdox";
 
 		[Desc("Sprite body to play the vortex animation on.")]

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -73,7 +73,8 @@ namespace OpenRA.Mods.Cnc.Traits
 	[Desc("Provides access to the disguise command, which makes the actor appear to be another player's actor.")]
 	class DisguiseInfo : ITraitInfo
 	{
-		[VoiceReference] public readonly string Voice = "Action";
+		[VoiceReference]
+		public readonly string Voice = "Action";
 
 		[GrantedConditionReference]
 		[Desc("The condition to grant to self while disguised.")]

--- a/OpenRA.Mods.Cnc/Traits/GpsDot.cs
+++ b/OpenRA.Mods.Cnc/Traits/GpsDot.cs
@@ -20,10 +20,12 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sprite collection for symbols.")]
 		public readonly string Image = "gpsdot";
 
+		[SequenceReference("Image")]
 		[Desc("Sprite used for this actor.")]
-		[SequenceReference("Image")] public readonly string String = "Infantry";
+		public readonly string String = "Infantry";
 
-		[PaletteReference(true)] public readonly string IndicatorPalettePrefix = "player";
+		[PaletteReference(true)]
+		public readonly string IndicatorPalettePrefix = "player";
 
 		public object Create(ActorInitializer init) { return new GpsDot(this); }
 	}

--- a/OpenRA.Mods.Cnc/Traits/GpsWatcher.cs
+++ b/OpenRA.Mods.Cnc/Traits/GpsWatcher.cs
@@ -26,12 +26,18 @@ namespace OpenRA.Mods.Cnc.Traits
 
 	class GpsWatcher : ISync, IPreventsShroudReset
 	{
-		[Sync] public bool Launched { get; private set; }
-		[Sync] public bool GrantedAllies { get; private set; }
-		[Sync] public bool Granted { get; private set; }
+		[Sync]
+		public bool Launched { get; private set; }
+
+		[Sync]
+		public bool GrantedAllies { get; private set; }
+
+		[Sync]
+		public bool Granted { get; private set; }
 
 		// Whether this watcher has explored the terrain (by becoming Launched, or an ally becoming Launched)
-		[Sync] bool explored;
+		[Sync]
+		bool explored;
 
 		readonly Player owner;
 

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPower.cs
@@ -17,7 +17,9 @@ namespace OpenRA.Mods.Cnc.Traits
 {
 	class InfiltrateForSupportPowerInfo : ITraitInfo
 	{
-		[ActorReference, FieldLoader.Require] public readonly string Proxy = null;
+		[ActorReference]
+		[FieldLoader.Require]
+		public readonly string Proxy = null;
 
 		public readonly BitSet<TargetableType> Types = default(BitSet<TargetableType>);
 

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForTransform.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForTransform.cs
@@ -21,7 +21,8 @@ namespace OpenRA.Mods.Cnc.Traits
 	[Desc("Transform into a different actor type.")]
 	class InfiltrateForTransformInfo : ITraitInfo
 	{
-		[ActorReference, FieldLoader.Require]
+		[ActorReference]
+		[FieldLoader.Require]
 		public readonly string IntoActor = null;
 
 		public readonly int ForceHealthPercentage = 0;

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -25,40 +25,52 @@ namespace OpenRA.Mods.Cnc.Traits
 {
 	class MadTankInfo : ITraitInfo, IRulesetLoaded, Requires<ExplodesInfo>, Requires<WithFacingSpriteBodyInfo>
 	{
-		[SequenceReference] public readonly string ThumpSequence = "piston";
+		[SequenceReference]
+		public readonly string ThumpSequence = "piston";
+
 		public readonly int ThumpInterval = 8;
+
 		[WeaponReference]
 		public readonly string ThumpDamageWeapon = "MADTankThump";
+
 		public readonly int ThumpShakeIntensity = 3;
+
 		public readonly float2 ThumpShakeMultiplier = new float2(1, 0);
+
 		public readonly int ThumpShakeTime = 10;
 
 		[Desc("Measured in ticks.")]
 		public readonly int ChargeDelay = 96;
+
 		public readonly string ChargeSound = "madchrg2.aud";
 
 		[Desc("Measured in ticks.")]
 		public readonly int DetonationDelay = 42;
+
 		public readonly string DetonationSound = "madexplo.aud";
+
 		[WeaponReference]
 		public readonly string DetonationWeapon = "MADTankDetonate";
 
 		[ActorReference]
 		public readonly string DriverActor = "e1";
 
-		[VoiceReference] public readonly string Voice = "Action";
+		[VoiceReference]
+		public readonly string Voice = "Action";
 
 		[GrantedConditionReference]
 		[Desc("The condition to grant to self while deployed.")]
 		public readonly string DeployedCondition = null;
 
 		public WeaponInfo ThumpDamageWeaponInfo { get; private set; }
+
 		public WeaponInfo DetonationWeaponInfo { get; private set; }
 
 		[Desc("Types of damage that this trait causes to self while self-destructing. Leave empty for no damage types.")]
 		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
 
 		public object Create(ActorInitializer init) { return new MadTank(init.Self, this); }
+
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
 			WeaponInfo thumpDamageWeapon;

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -23,14 +23,16 @@ namespace OpenRA.Mods.Cnc.Traits
 {
 	public class MinelayerInfo : ITraitInfo, Requires<RearmableInfo>
 	{
-		[ActorReference] public readonly string Mine = "minv";
+		[ActorReference]
+		public readonly string Mine = "minv";
 
 		public readonly string AmmoPoolName = "primary";
 
 		public readonly WDist MinefieldDepth = new WDist(1536);
 
+		[VoiceReference]
 		[Desc("Voice to use when ordered to lay a minefield.")]
-		[VoiceReference] public readonly string Voice = "Action";
+		public readonly string Voice = "Action";
 
 		public object Create(ActorInitializer init) { return new Minelayer(init.Self, this); }
 	}
@@ -39,10 +41,13 @@ namespace OpenRA.Mods.Cnc.Traits
 	{
 		readonly MinelayerInfo info;
 
-		/* TODO: [Sync] when sync can cope with arrays! */
+		// TODO: [Sync] when sync can cope with arrays!
 		public CPos[] Minefield = null;
+
 		readonly Sprite tile;
-		[Sync] CPos minefieldStart;
+
+		[Sync]
+		CPos minefieldStart;
 
 		public Minelayer(Actor self, MinelayerInfo info)
 		{

--- a/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
@@ -52,7 +52,8 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Flash the screen on teleporting.")]
 		public readonly bool FlashScreen = false;
 
-		[VoiceReference] public readonly string Voice = "Action";
+		[VoiceReference]
+		public readonly string Voice = "Action";
 
 		public object Create(ActorInitializer init) { return new PortableChrono(init.Self, this); }
 	}
@@ -61,7 +62,8 @@ namespace OpenRA.Mods.Cnc.Traits
 	{
 		public readonly PortableChronoInfo Info;
 		readonly IMove move;
-		[Sync] int chargeTick = 0;
+		[Sync]
+		int chargeTick = 0;
 
 		public PortableChrono(Actor self, PortableChronoInfo info)
 		{

--- a/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
@@ -20,9 +20,11 @@ namespace OpenRA.Mods.Cnc.Traits
 {
 	public class WithBuildingBibInfo : ITraitInfo, Requires<BuildingInfo>, IRenderActorPreviewSpritesInfo, IActorPreviewInitInfo, Requires<RenderSpritesInfo>
 	{
-		[SequenceReference] public readonly string Sequence = "bib";
+		[SequenceReference]
+		public readonly string Sequence = "bib";
 
-		[PaletteReference] public readonly string Palette = TileSet.TerrainPaletteInternalName;
+		[PaletteReference]
+		public readonly string Palette = TileSet.TerrainPaletteInternalName;
 
 		public readonly bool HasMinibib = false;
 
@@ -130,7 +132,9 @@ namespace OpenRA.Mods.Cnc.Traits
 
 	class HideBibPreviewInit : IActorInit<bool>, ISuppressInitExport
 	{
-		[FieldFromYamlKey] readonly bool value = true;
+		[FieldFromYamlKey]
+		readonly bool value = true;
+
 		public HideBibPreviewInit() { }
 		public HideBibPreviewInit(bool init) { value = init; }
 		public bool Value(World world) { return value; }

--- a/OpenRA.Mods.Cnc/Traits/Render/WithDeliveryAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithDeliveryAnimation.cs
@@ -19,7 +19,8 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 	[Desc("Building animation to play when ProductionAirdrop is used to deliver units.")]
 	public class WithDeliveryAnimationInfo : ConditionalTraitInfo, Requires<WithSpriteBodyInfo>
 	{
-		[SequenceReference] public readonly string ActiveSequence = "active";
+		[SequenceReference]
+		public readonly string ActiveSequence = "active";
 
 		[Desc("Which sprite body to play the animation on.")]
 		public readonly string Body = "body";

--- a/OpenRA.Mods.Cnc/Traits/Render/WithDockingOverlay.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithDockingOverlay.cs
@@ -19,14 +19,16 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 	[Desc("Rendered on the refinery when a voxel harvester is docking and undocking.")]
 	public class WithDockingOverlayInfo : PausableConditionalTraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
+		[SequenceReference]
 		[Desc("Sequence name to use")]
-		[SequenceReference] public readonly string Sequence = "unload-overlay";
+		public readonly string Sequence = "unload-overlay";
 
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
+		[PaletteReference("IsPlayerPalette")]
 		[Desc("Custom palette name")]
-		[PaletteReference("IsPlayerPalette")] public readonly string Palette = null;
+		public readonly string Palette = null;
 
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;

--- a/OpenRA.Mods.Cnc/Traits/Render/WithGunboatBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithGunboatBody.cs
@@ -23,10 +23,17 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		[Desc("Turreted 'Turret' key to display")]
 		public readonly string Turret = "primary";
 
-		[SequenceReference] public readonly string LeftSequence = "left";
-		[SequenceReference] public readonly string RightSequence = "right";
-		[SequenceReference] public readonly string WakeLeftSequence = "wake-left";
-		[SequenceReference] public readonly string WakeRightSequence = "wake-right";
+		[SequenceReference]
+		public readonly string LeftSequence = "left";
+
+		[SequenceReference]
+		public readonly string RightSequence = "right";
+
+		[SequenceReference]
+		public readonly string WakeLeftSequence = "wake-left";
+
+		[SequenceReference]
+		public readonly string WakeRightSequence = "wake-right";
 
 		public override object Create(ActorInitializer init) { return new WithGunboatBody(init, this); }
 	}

--- a/OpenRA.Mods.Cnc/Traits/Render/WithLandingCraftAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithLandingCraftAnimation.cs
@@ -20,9 +20,15 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 	public class WithLandingCraftAnimationInfo : ITraitInfo, Requires<IMoveInfo>, Requires<WithSpriteBodyInfo>, Requires<CargoInfo>
 	{
 		public readonly HashSet<string> OpenTerrainTypes = new HashSet<string> { "Clear" };
-		[SequenceReference] public readonly string OpenSequence = "open";
-		[SequenceReference] public readonly string CloseSequence = "close";
-		[SequenceReference] public readonly string UnloadSequence = "unload";
+
+		[SequenceReference]
+		public readonly string OpenSequence = "open";
+
+		[SequenceReference]
+		public readonly string CloseSequence = "close";
+
+		[SequenceReference]
+		public readonly string UnloadSequence = "unload";
 
 		[Desc("Which sprite body to play the animation on.")]
 		public readonly string Body = "body";

--- a/OpenRA.Mods.Cnc/Traits/Render/WithRoof.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithRoof.cs
@@ -18,7 +18,8 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 	[Desc("Provides an overlay for the Tiberian Dawn hover craft.")]
 	public class WithRoofInfo : ITraitInfo, Requires<RenderSpritesInfo>
 	{
-		[SequenceReference] public readonly string Sequence = "roof";
+		[SequenceReference]
+		public readonly string Sequence = "roof";
 
 		public object Create(ActorInitializer init) { return new WithRoof(init.Self, this); }
 	}

--- a/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeAnimation.cs
@@ -18,8 +18,9 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 	[Desc("This actor displays a charge-up animation before firing.")]
 	public class WithTeslaChargeAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<RenderSpritesInfo>
 	{
+		[SequenceReference]
 		[Desc("Sequence to use for charge animation.")]
-		[SequenceReference] public readonly string ChargeSequence = "active";
+		public readonly string ChargeSequence = "active";
 
 		[Desc("Which sprite body to play the animation on.")]
 		public readonly string Body = "body";

--- a/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeOverlay.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeOverlay.cs
@@ -19,11 +19,13 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 	[Desc("Rendered together with AttackCharge.")]
 	public class WithTeslaChargeOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>
 	{
+		[SequenceReference]
 		[Desc("Sequence name to use")]
-		[SequenceReference] public readonly string Sequence = "active";
+		public readonly string Sequence = "active";
 
+		[PaletteReference("IsPlayerPalette")]
 		[Desc("Custom palette name")]
-		[PaletteReference("IsPlayerPalette")] public readonly string Palette = null;
+		public readonly string Palette = null;
 
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;

--- a/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
@@ -97,7 +97,9 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 
 	public class BodyAnimationFrameInit : IActorInit<uint>
 	{
-		[FieldFromYamlKey] readonly uint value = 0;
+		[FieldFromYamlKey]
+		readonly uint value = 0;
+
 		public BodyAnimationFrameInit() { }
 		public BodyAnimationFrameInit(uint init) { value = init; }
 		public uint Value(World world) { return value; }

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -28,12 +28,19 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Ticks until returning after teleportation.")]
 		public readonly int Duration = 750;
 
-		[PaletteReference] public readonly string TargetOverlayPalette = TileSet.TerrainPaletteInternalName;
+		[PaletteReference]
+		public readonly string TargetOverlayPalette = TileSet.TerrainPaletteInternalName;
 
 		public readonly string OverlaySpriteGroup = "overlay";
-		[SequenceReference("OverlaySpriteGroup", true)] public readonly string ValidTileSequencePrefix = "target-valid-";
-		[SequenceReference("OverlaySpriteGroup")] public readonly string InvalidTileSequence = "target-invalid";
-		[SequenceReference("OverlaySpriteGroup")] public readonly string SourceTileSequence = "target-select";
+
+		[SequenceReference("OverlaySpriteGroup", true)]
+		public readonly string ValidTileSequencePrefix = "target-valid-";
+
+		[SequenceReference("OverlaySpriteGroup")]
+		public readonly string InvalidTileSequence = "target-invalid";
+
+		[SequenceReference("OverlaySpriteGroup")]
+		public readonly string SourceTileSequence = "target-select";
 
 		public readonly bool KillCargo = true;
 

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/GpsPower.cs
@@ -24,19 +24,25 @@ namespace OpenRA.Mods.Cnc.Traits
 		public readonly int RevealDelay = 0;
 
 		public readonly string DoorImage = "atek";
-		[SequenceReference("DoorImage")] public readonly string DoorSequence = "active";
 
+		[SequenceReference("DoorImage")]
+		public readonly string DoorSequence = "active";
+
+		[PaletteReference("DoorPaletteIsPlayerPalette")]
 		[Desc("Palette to use for rendering the launch animation")]
-		[PaletteReference("DoorPaletteIsPlayerPalette")] public readonly string DoorPalette = "player";
+		public readonly string DoorPalette = "player";
 
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool DoorPaletteIsPlayerPalette = true;
 
 		public readonly string SatelliteImage = "sputnik";
-		[SequenceReference("SatelliteImage")] public readonly string SatelliteSequence = "idle";
 
+		[SequenceReference("SatelliteImage")]
+		public readonly string SatelliteSequence = "idle";
+
+		[PaletteReference("SatellitePaletteIsPlayerPalette")]
 		[Desc("Palette to use for rendering the satellite projectile")]
-		[PaletteReference("SatellitePaletteIsPlayerPalette")] public readonly string SatellitePalette = "player";
+		public readonly string SatellitePalette = "player";
 
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool SatellitePaletteIsPlayerPalette = true;

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/IonCannonPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/IonCannonPower.cs
@@ -30,12 +30,15 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Effect sequence sprite image")]
 		public readonly string Effect = "ionsfx";
 
+		[SequenceReference("Effect")]
 		[Desc("Effect sequence to display")]
-		[SequenceReference("Effect")] public readonly string EffectSequence = "idle";
+		public readonly string EffectSequence = "idle";
 
-		[PaletteReference] public readonly string EffectPalette = "effect";
+		[PaletteReference]
+		public readonly string EffectPalette = "effect";
 
-		[Desc("Which weapon to fire"), WeaponReference]
+		[WeaponReference]
+		[Desc("Which weapon to fire")]
 		public readonly string Weapon = "IonCannon";
 
 		public WeaponInfo WeaponInfo { get; private set; }

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -64,8 +64,12 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		IEnumerable<int> speedModifiers;
 
-		[Sync] public int Facing { get; set; }
-		[Sync] public WPos CenterPosition { get; private set; }
+		[Sync]
+		public int Facing { get; set; }
+
+		[Sync]
+		public WPos CenterPosition { get; private set; }
+
 		public CPos TopLeft { get { return self.World.Map.CellContaining(CenterPosition); } }
 
 		// Isn't used anyway

--- a/OpenRA.Mods.Cnc/Traits/World/TSShroudPalette.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSShroudPalette.cs
@@ -21,7 +21,8 @@ namespace OpenRA.Mods.Cnc.Traits
 	[Desc("Adds the hard-coded shroud palette to the game")]
 	class TSShroudPaletteInfo : ITraitInfo
 	{
-		[FieldLoader.Require, PaletteDefinition]
+		[PaletteDefinition]
+		[FieldLoader.Require]
 		[Desc("Internal palette name")]
 		public readonly string Name = "shroud";
 

--- a/OpenRA.Mods.Common/ActorInitializer.cs
+++ b/OpenRA.Mods.Common/ActorInitializer.cs
@@ -16,7 +16,9 @@ namespace OpenRA.Mods.Common
 {
 	public class FacingInit : IActorInit<int>
 	{
-		[FieldFromYamlKey] readonly int value = 128;
+		[FieldFromYamlKey]
+		readonly int value = 128;
+
 		public FacingInit() { }
 		public FacingInit(int init) { value = init; }
 		public int Value(World world) { return value; }
@@ -25,13 +27,16 @@ namespace OpenRA.Mods.Common
 	public class DynamicFacingInit : IActorInit<Func<int>>
 	{
 		readonly Func<int> func;
+
 		public DynamicFacingInit(Func<int> func) { this.func = func; }
 		public Func<int> Value(World world) { return func; }
 	}
 
 	public class SubCellInit : IActorInit<SubCell>
 	{
-		[FieldFromYamlKey] readonly byte value = (byte)SubCell.FullCell;
+		[FieldFromYamlKey]
+		readonly byte value = (byte)SubCell.FullCell;
+
 		public SubCellInit() { }
 		public SubCellInit(byte init) { value = init; }
 		public SubCellInit(SubCell init) { value = (byte)init; }
@@ -40,7 +45,9 @@ namespace OpenRA.Mods.Common
 
 	public class CenterPositionInit : IActorInit<WPos>
 	{
-		[FieldFromYamlKey] readonly WPos value = WPos.Zero;
+		[FieldFromYamlKey]
+		readonly WPos value = WPos.Zero;
+
 		public CenterPositionInit() { }
 		public CenterPositionInit(WPos init) { value = init; }
 		public WPos Value(World world) { return value; }
@@ -49,7 +56,8 @@ namespace OpenRA.Mods.Common
 	// Allows maps / transformations to specify the faction variant of an actor.
 	public class FactionInit : IActorInit<string>
 	{
-		[FieldFromYamlKey] public readonly string Faction;
+		[FieldFromYamlKey]
+		public readonly string Faction;
 
 		public FactionInit() { }
 		public FactionInit(string faction) { Faction = faction; }
@@ -58,7 +66,8 @@ namespace OpenRA.Mods.Common
 
 	public class EffectiveOwnerInit : IActorInit<Player>
 	{
-		[FieldFromYamlKey] readonly Player value = null;
+		[FieldFromYamlKey]
+		readonly Player value = null;
 
 		public EffectiveOwnerInit() { }
 		public EffectiveOwnerInit(Player owner) { value = owner; }

--- a/OpenRA.Mods.Common/ModContent.cs
+++ b/OpenRA.Mods.Common/ModContent.cs
@@ -49,8 +49,11 @@ namespace OpenRA
 
 			public readonly string Title;
 
-			[FieldLoader.Ignore] public readonly MiniYaml IDFiles;
-			[FieldLoader.Ignore] public readonly List<MiniYamlNode> Install;
+			[FieldLoader.Ignore]
+			public readonly MiniYaml IDFiles;
+
+			[FieldLoader.Ignore]
+			public readonly List<MiniYamlNode> Install;
 
 			public ModSource(MiniYaml yaml)
 			{

--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -82,9 +82,15 @@ namespace OpenRA.Mods.Common.Projectiles
 		readonly Color color;
 		readonly WDist speed;
 
-		[Sync] WPos headPos;
-		[Sync] WPos tailPos;
-		[Sync] WPos target;
+		[Sync]
+		WPos headPos;
+
+		[Sync]
+		WPos tailPos;
+
+		[Sync]
+		WPos target;
+
 		int length;
 		int towardsTargetFacing;
 		int headTicks;

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -33,11 +33,13 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Image to display.")]
 		public readonly string Image = null;
 
+		[SequenceReference("Image")]
 		[Desc("Loop a randomly chosen sequence of Image from this list while this projectile is moving.")]
-		[SequenceReference("Image")] public readonly string[] Sequences = { "idle" };
+		public readonly string[] Sequences = { "idle" };
 
+		[PaletteReference]
 		[Desc("The palette used to draw this projectile.")]
-		[PaletteReference] public readonly string Palette = "effect";
+		public readonly string Palette = "effect";
 
 		[Desc("Palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;
@@ -45,14 +47,16 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Does this projectile have a shadow?")]
 		public readonly bool Shadow = false;
 
+		[PaletteReference]
 		[Desc("Palette to use for this projectile's shadow if Shadow is true.")]
-		[PaletteReference] public readonly string ShadowPalette = "shadow";
+		public readonly string ShadowPalette = "shadow";
 
 		[Desc("Trail animation.")]
 		public readonly string TrailImage = null;
 
+		[SequenceReference("TrailImage")]
 		[Desc("Loop a randomly chosen sequence of TrailImage from this list while this projectile is moving.")]
-		[SequenceReference("TrailImage")] public readonly string[] TrailSequences = { "idle" };
+		public readonly string[] TrailSequences = { "idle" };
 
 		[Desc("Interval in ticks between each spawned Trail animation.")]
 		public readonly int TrailInterval = 2;
@@ -60,8 +64,9 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Delay in ticks until trail animation is spawned.")]
 		public readonly int TrailDelay = 1;
 
+		[PaletteReference("TrailUsePlayerPalette")]
 		[Desc("Palette used to render the trail sequence.")]
-		[PaletteReference("TrailUsePlayerPalette")] public readonly string TrailPalette = "effect";
+		public readonly string TrailPalette = "effect";
 
 		[Desc("Use the Player Palette to render the trail sequence.")]
 		public readonly bool TrailUsePlayerPalette = false;

--- a/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
@@ -20,21 +20,25 @@ namespace OpenRA.Mods.Common.Projectiles
 	{
 		public readonly string Image = null;
 
+		[SequenceReference("Image")]
 		[Desc("Loop a randomly chosen sequence of Image from this list while falling.")]
-		[SequenceReference("Image")] public readonly string[] Sequences = { "idle" };
+		public readonly string[] Sequences = { "idle" };
 
+		[SequenceReference("Image")]
 		[Desc("Sequence to play when launched. Skipped if null or empty.")]
-		[SequenceReference("Image")] public readonly string OpenSequence = null;
+		public readonly string OpenSequence = null;
 
+		[PaletteReference]
 		[Desc("The palette used to draw this projectile.")]
-		[PaletteReference] public readonly string Palette = "effect";
+		public readonly string Palette = "effect";
 
 		[Desc("Palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;
 
 		public readonly bool Shadow = false;
 
-		[PaletteReference] public readonly string ShadowPalette = "shadow";
+		[PaletteReference]
+		public readonly string ShadowPalette = "shadow";
 
 		[Desc("Projectile movement vector per tick (forward, right, up), use negative values for opposite directions.")]
 		public readonly WVec Velocity = WVec.Zero;

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -75,19 +75,23 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Impact animation.")]
 		public readonly string HitAnim = null;
 
+		[SequenceReference("HitAnim")]
 		[Desc("Sequence of impact animation to use.")]
-		[SequenceReference("HitAnim")] public readonly string HitAnimSequence = "idle";
+		public readonly string HitAnimSequence = "idle";
 
-		[PaletteReference] public readonly string HitAnimPalette = "effect";
+		[PaletteReference]
+		public readonly string HitAnimPalette = "effect";
 
 		[Desc("Image containing launch effect sequence.")]
 		public readonly string LaunchEffectImage = null;
 
+		[SequenceReference("LaunchEffectImage")]
 		[Desc("Launch effect sequence to play.")]
-		[SequenceReference("LaunchEffectImage")] public readonly string LaunchEffectSequence = null;
+		public readonly string LaunchEffectSequence = null;
 
+		[PaletteReference]
 		[Desc("Palette to use for launch effect.")]
-		[PaletteReference] public readonly string LaunchEffectPalette = "effect";
+		public readonly string LaunchEffectPalette = "effect";
 
 		public IProjectile Create(ProjectileArgs args)
 		{

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -26,11 +26,13 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Name of the image containing the projectile sequence.")]
 		public readonly string Image = null;
 
+		[SequenceReference("Image")]
 		[Desc("Loop a randomly chosen sequence of Image from this list while this projectile is moving.")]
-		[SequenceReference("Image")] public readonly string[] Sequences = { "idle" };
+		public readonly string[] Sequences = { "idle" };
 
+		[PaletteReference]
 		[Desc("Palette used to render the projectile sequence.")]
-		[PaletteReference] public readonly string Palette = "effect";
+		public readonly string Palette = "effect";
 
 		[Desc("Palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;
@@ -101,11 +103,13 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Image that contains the trail animation.")]
 		public readonly string TrailImage = null;
 
+		[SequenceReference("TrailImage")]
 		[Desc("Loop a randomly chosen sequence of TrailImage from this list while this projectile is moving.")]
-		[SequenceReference("TrailImage")] public readonly string[] TrailSequences = { "idle" };
+		public readonly string[] TrailSequences = { "idle" };
 
+		[PaletteReference("TrailUsePlayerPalette")]
 		[Desc("Palette used to render the trail sequence.")]
-		[PaletteReference("TrailUsePlayerPalette")] public readonly string TrailPalette = "effect";
+		public readonly string TrailPalette = "effect";
 
 		[Desc("Use the Player Palette to render the trail sequence.")]
 		public readonly bool TrailUsePlayerPalette = false;

--- a/OpenRA.Mods.Common/SpriteLoaders/ShpD2Loader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/ShpD2Loader.cs
@@ -19,7 +19,8 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 {
 	public class ShpD2Loader : ISpriteLoader
 	{
-		[Flags] enum FormatFlags : int
+		[Flags]
+		enum FormatFlags : int
 		{
 			PaletteTable = 1,
 			NotLCWCompressed = 2,

--- a/OpenRA.Mods.Common/Traits/AffectsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/AffectsShroud.cs
@@ -33,9 +33,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		readonly HashSet<PPos> footprint;
 
-		[Sync] CPos cachedLocation;
-		[Sync] WDist cachedRange;
-		[Sync] protected bool CachedTraitDisabled { get; private set; }
+		[Sync]
+		CPos cachedLocation;
+
+		[Sync]
+		WDist cachedRange;
+
+		[Sync]
+		protected bool CachedTraitDisabled { get; private set; }
 
 		protected abstract void AddCellsToPlayerShroud(Actor self, Player player, PPos[] uv);
 		protected abstract void RemoveCellsFromPlayerShroud(Actor self, Player player);

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -58,7 +58,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Types of damage that are caused while crushing. Leave empty for no damage types.")]
 		public readonly BitSet<DamageType> CrushDamageTypes = default(BitSet<DamageType>);
 
-		[VoiceReference] public readonly string Voice = "Action";
+		[VoiceReference]
+		public readonly string Voice = "Action";
 
 		[GrantedConditionReference]
 		[Desc("The condition to grant to self while airborne.")]
@@ -184,8 +185,12 @@ namespace OpenRA.Mods.Common.Traits
 		IEnumerable<int> speedModifiers;
 		INotifyMoving[] notifyMoving;
 
-		[Sync] public int Facing { get; set; }
-		[Sync] public WPos CenterPosition { get; private set; }
+		[Sync]
+		public int Facing { get; set; }
+
+		[Sync]
+		public WPos CenterPosition { get; private set; }
+
 		public CPos TopLeft { get { return self.World.Map.CellContaining(CenterPosition); } }
 		public int TurnSpeed { get { return Info.TurnSpeed; } }
 		public Actor ReservedActor { get; private set; }

--- a/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
@@ -27,9 +27,15 @@ namespace OpenRA.Mods.Common.Traits
 	public class AttackBomber : AttackBase, ITick, ISync, INotifyRemovedFromWorld
 	{
 		readonly AttackBomberInfo info;
-		[Sync] Target target;
-		[Sync] bool inAttackRange;
-		[Sync] bool facingTarget = true;
+
+		[Sync]
+		Target target;
+
+		[Sync]
+		bool inAttackRange;
+
+		[Sync]
+		bool facingTarget = true;
 
 		public event Action<Actor> OnRemovedFromWorld = self => { };
 		public event Action<Actor> OnEnteredAttackRange = self => { };

--- a/OpenRA.Mods.Common/Traits/AmmoPool.cs
+++ b/OpenRA.Mods.Common/Traits/AmmoPool.cs
@@ -63,9 +63,11 @@ namespace OpenRA.Mods.Common.Traits
 		ConditionManager conditionManager;
 
 		// HACK: Temporarily needed until Rearm activity is gone for good
-		[Sync] public int RemainingTicks;
+		[Sync]
+		public int RemainingTicks;
 
-		[Sync] int currentAmmo;
+		[Sync]
+		int currentAmmo;
 
 		public AmmoPool(Actor self, AmmoPoolInfo info)
 		{

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -29,7 +29,8 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public readonly string Name = "primary";
 
-		[WeaponReference, FieldLoader.Require]
+		[WeaponReference]
+		[FieldLoader.Require]
 		[Desc("Has to be defined in weapons.yaml as well.")]
 		public readonly string Weapon = null;
 
@@ -55,8 +56,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Muzzle flash sequence to render")]
 		public readonly string MuzzleSequence = null;
 
+		[PaletteReference]
 		[Desc("Palette to render Muzzle flash sequence in")]
-		[PaletteReference] public readonly string MuzzlePalette = "effect";
+		public readonly string MuzzlePalette = "effect";
 
 		[Desc("Use multiple muzzle images if non-zero")]
 		public readonly int MuzzleSplitFacings = 0;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -37,7 +37,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Force-fire mode ignores actors and targets the ground instead.")]
 		public readonly bool ForceFireIgnoresActors = false;
 
-		[VoiceReference] public readonly string Voice = "Action";
+		[VoiceReference]
+		public readonly string Voice = "Action";
 
 		[Desc("Tolerance for attack angle. Range [0, 128], 128 covers 360 degrees.")]
 		public readonly int FacingTolerance = 128;
@@ -58,7 +59,9 @@ namespace OpenRA.Mods.Common.Traits
 		readonly string attackOrderName = "Attack";
 		readonly string forceAttackOrderName = "ForceAttack";
 
-		[Sync] public bool IsAiming { get; set; }
+		[Sync]
+		public bool IsAiming { get; set; }
+
 		public IEnumerable<Armament> Armaments { get { return getArmaments(); } }
 
 		protected IFacing facing;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -44,7 +44,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public FirePort[] Ports { get; private set; }
 
-		[PaletteReference] public readonly string MuzzlePalette = "effect";
+		[PaletteReference]
+		public readonly string MuzzlePalette = "effect";
 
 		public override object Create(ActorInitializer init) { return new AttackGarrisoned(init.Self, this); }
 		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -22,7 +22,8 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Provides access to the attack-move command, which will make the actor automatically engage viable targets while moving to the destination.")]
 	class AttackMoveInfo : ITraitInfo, Requires<IMoveInfo>
 	{
-		[VoiceReference] public readonly string Voice = "Action";
+		[VoiceReference]
+		public readonly string Voice = "Action";
 
 		[GrantedConditionReference]
 		[Desc("The condition to grant to self while an attack-move is active.")]

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -127,11 +127,13 @@ namespace OpenRA.Mods.Common.Traits
 	public class AutoTarget : ConditionalTrait<AutoTargetInfo>, INotifyIdle, INotifyDamage, ITick, IResolveOrder, ISync, INotifyCreated, INotifyOwnerChanged
 	{
 		public readonly IEnumerable<AttackBase> ActiveAttackBases;
-		[Sync] int nextScanTime = 0;
+		[Sync]
+		int nextScanTime = 0;
 
 		public UnitStance Stance { get { return stance; } }
 
-		[Sync] public Actor Aggressor;
+		[Sync]
+		public Actor Aggressor;
 
 		// NOT SYNCED: do not refer to this anywhere other than UI code
 		public UnitStance PredictedStance;
@@ -441,7 +443,9 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class StanceInit : IActorInit<UnitStance>
 	{
-		[FieldFromYamlKey] readonly UnitStance value = UnitStance.AttackAnything;
+		[FieldFromYamlKey]
+		readonly UnitStance value = UnitStance.AttackAnything;
+
 		public StanceInit() { }
 		public StanceInit(UnitStance init) { value = init; }
 		public UnitStance Value(World world) { return value; }

--- a/OpenRA.Mods.Common/Traits/BodyOrientation.cs
+++ b/OpenRA.Mods.Common/Traits/BodyOrientation.cs
@@ -66,7 +66,8 @@ namespace OpenRA.Mods.Common.Traits
 		readonly BodyOrientationInfo info;
 		readonly Lazy<int> quantizedFacings;
 
-		[Sync] public int QuantizedFacings { get { return quantizedFacings.Value; } }
+		[Sync]
+		public int QuantizedFacings { get { return quantizedFacings.Value; } }
 
 		public BodyOrientation(ActorInitializer init, BodyOrientationInfo info)
 		{

--- a/OpenRA.Mods.Common/Traits/Buildable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildable.cs
@@ -34,11 +34,13 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Force a specific faction variant, overriding the faction of the producing actor.")]
 		public readonly string ForceFaction = null;
 
+		[SequenceReference]
 		[Desc("Sequence of the actor that contains the icon.")]
-		[SequenceReference] public readonly string Icon = "icon";
+		public readonly string Icon = "icon";
 
+		[PaletteReference]
 		[Desc("Palette used for the production icon.")]
-		[PaletteReference] public readonly string IconPalette = "chrome";
+		public readonly string IconPalette = "chrome";
 
 		[Desc("Base build time in frames (-1 indicates to use the unit's Value).")]
 		public readonly int BuildDuration = -1;
@@ -49,8 +51,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sort order for the production palette. Smaller numbers are presented earlier.")]
 		public readonly int BuildPaletteOrder = 9999;
 
+		[Translate]
 		[Desc("Text shown in the production tooltip.")]
-		[Translate] public readonly string Description = "";
+		public readonly string Description = "";
 
 		public static string GetInitialFaction(ActorInfo ai, string defaultFaction)
 		{

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -40,8 +40,9 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int[] NorthOffset = null;
 		public readonly int[] SouthOffset = null;
 
+		[WeaponReference]
 		[Desc("The name of the weapon to use when demolishing the bridge")]
-		[WeaponReference] public readonly string DemolishWeapon = "Demolish";
+		public readonly string DemolishWeapon = "Demolish";
 
 		public WeaponInfo DemolishWeaponInfo { get; private set; }
 

--- a/OpenRA.Mods.Common/Traits/Buildings/BridgePlaceholder.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BridgePlaceholder.cs
@@ -21,8 +21,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly DamageState DamageState = DamageState.Undamaged;
 
+		[ActorReference]
 		[Desc("Actor type to replace with on repair.")]
-		[ActorReference] public readonly string ReplaceWithActor = null;
+		public readonly string ReplaceWithActor = null;
 
 		public readonly CVec[] NeighbourOffsets = { };
 

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -247,7 +247,9 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public readonly BuildingInfo Info;
 
-		[Sync] readonly CPos topLeft;
+		[Sync]
+		readonly CPos topLeft;
+
 		readonly Actor self;
 		readonly BuildingInfluence influence;
 

--- a/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
@@ -18,7 +18,8 @@ namespace OpenRA.Mods.Common.Traits
 		"If you want more than one unit to appear copy this section and assign IDs like FreeActor@2, ...")]
 	public class FreeActorInfo : ConditionalTraitInfo
 	{
-		[ActorReference, FieldLoader.Require]
+		[ActorReference]
+		[FieldLoader.Require]
 		[Desc("Name of the actor.")]
 		public readonly string Actor = null;
 

--- a/OpenRA.Mods.Common/Traits/Buildings/FreeActorWithDelivery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FreeActorWithDelivery.cs
@@ -19,7 +19,8 @@ namespace OpenRA.Mods.Common.Traits
 		"If you want more than one unit to be delivered, copy this section and assign IDs like FreeActorWithDelivery@2, ...")]
 	public class FreeActorWithDeliveryInfo : FreeActorInfo
 	{
-		[ActorReference, FieldLoader.Require]
+		[ActorReference]
+		[FieldLoader.Require]
 		[Desc("Name of the delivering actor. This actor must have the `Carryall` trait")]
 		public readonly string DeliveringActor = null;
 

--- a/OpenRA.Mods.Common/Traits/Buildings/Gate.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Gate.cs
@@ -42,7 +42,10 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly IEnumerable<CPos> Footprint;
 
 		public readonly int OpenPosition;
-		[Sync] public int Position { get; private set; }
+
+		[Sync]
+		public int Position { get; private set; }
+
 		int desiredPosition;
 		int remainingOpenTime;
 

--- a/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
@@ -26,8 +26,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly CVec[] NeighbourOffsets = { };
 
+		[WeaponReference]
 		[Desc("The name of the weapon to use when demolishing the bridge")]
-		[WeaponReference] public readonly string DemolishWeapon = "Demolish";
+		public readonly string DemolishWeapon = "Demolish";
 
 		public WeaponInfo DemolishWeaponInfo { get; private set; }
 

--- a/OpenRA.Mods.Common/Traits/Buildings/LineBuild.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/LineBuild.cs
@@ -18,7 +18,9 @@ namespace OpenRA.Mods.Common.Traits
 	public enum LineBuildDirection { Unset, X, Y }
 	public class LineBuildDirectionInit : IActorInit<LineBuildDirection>
 	{
-		[FieldFromYamlKey] readonly LineBuildDirection value = LineBuildDirection.Unset;
+		[FieldFromYamlKey]
+		readonly LineBuildDirection value = LineBuildDirection.Unset;
+
 		public LineBuildDirectionInit() { }
 		public LineBuildDirectionInit(LineBuildDirection init) { value = init; }
 		public LineBuildDirection Value(World world) { return value; }
@@ -26,7 +28,9 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class LineBuildParentInit : IActorInit<Actor[]>
 	{
-		[FieldFromYamlKey] public readonly string[] ParentNames = new string[0];
+		[FieldFromYamlKey]
+		public readonly string[] ParentNames = new string[0];
+
 		readonly Actor[] parents = null;
 
 		public LineBuildParentInit() { }

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -20,13 +20,18 @@ namespace OpenRA.Mods.Common.Traits
 	public class RallyPointInfo : ITraitInfo
 	{
 		public readonly string Image = "rallypoint";
-		[SequenceReference("Image")] public readonly string FlagSequence = "flag";
-		[SequenceReference("Image")] public readonly string CirclesSequence = "circles";
+
+		[SequenceReference("Image")]
+		public readonly string FlagSequence = "flag";
+
+		[SequenceReference("Image")]
+		public readonly string CirclesSequence = "circles";
 
 		public readonly string Cursor = "ability";
 
+		[PaletteReference("IsPlayerPalette")]
 		[Desc("Custom indicator palette name")]
-		[PaletteReference("IsPlayerPalette")] public readonly string Palette = "player";
+		public readonly string Palette = "player";
 
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = true;
@@ -40,7 +45,9 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		const string OrderID = "SetRallyPoint";
 
-		[Sync] public CPos Location;
+		[Sync]
+		public CPos Location;
+
 		public RallyPointInfo Info;
 		public string PaletteName { get; private set; }
 

--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -63,8 +63,11 @@ namespace OpenRA.Mods.Common.Traits
 		int currentDisplayTick = 0;
 		int currentDisplayValue = 0;
 
-		[Sync] Actor dockedHarv = null;
-		[Sync] bool preventDock = false;
+		[Sync]
+		Actor dockedHarv = null;
+
+		[Sync]
+		bool preventDock = false;
 
 		public bool AllowDocking { get { return !preventDock; } }
 		public CVec DeliveryOffset { get { return info.DockOffset; } }

--- a/OpenRA.Mods.Common/Traits/Burns.cs
+++ b/OpenRA.Mods.Common/Traits/Burns.cs
@@ -28,7 +28,8 @@ namespace OpenRA.Mods.Common.Traits
 	class Burns : ITick, ISync
 	{
 		readonly BurnsInfo info;
-		[Sync] int ticks;
+		[Sync]
+		int ticks;
 
 		public Burns(Actor self, BurnsInfo info)
 		{

--- a/OpenRA.Mods.Common/Traits/Captures.cs
+++ b/OpenRA.Mods.Common/Traits/Captures.cs
@@ -50,7 +50,8 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string EnterCursor = "enter";
 		public readonly string EnterBlockedCursor = "enter-blocked";
 
-		[VoiceReference] public readonly string Voice = "Action";
+		[VoiceReference]
+		public readonly string Voice = "Action";
 
 		public override object Create(ActorInitializer init) { return new Captures(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -43,8 +43,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Terrain types that this actor is allowed to eject actors onto. Leave empty for all terrain types.")]
 		public readonly HashSet<string> UnloadTerrainTypes = new HashSet<string>();
 
+		[VoiceReference]
 		[Desc("Voice to play when ordered to unload the passengers.")]
-		[VoiceReference] public readonly string UnloadVoice = "Action";
+		public readonly string UnloadVoice = "Action";
 
 		[Desc("Which direction the passenger will face (relative to the transport) when unloading.")]
 		public readonly int PassengerFacing = 128;

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -75,7 +75,8 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Actor self;
 
 		// The actor we are currently carrying.
-		[Sync] public Actor Carryable { get; private set; }
+		[Sync]
+		public Actor Carryable { get; private set; }
 		public CarryallState State { get; private set; }
 
 		int cachedFacing;

--- a/OpenRA.Mods.Common/Traits/CashTrickler.cs
+++ b/OpenRA.Mods.Common/Traits/CashTrickler.cs
@@ -40,7 +40,8 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly CashTricklerInfo info;
 		PlayerResources resources;
-		[Sync] public int Ticks { get; private set; }
+		[Sync]
+		public int Ticks { get; private set; }
 
 		public CashTrickler(CashTricklerInfo info)
 			: base(info)

--- a/OpenRA.Mods.Common/Traits/ChangesTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/ChangesTerrain.cs
@@ -16,7 +16,8 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Modifies the terrain type underneath the actors location.")]
 	class ChangesTerrainInfo : ITraitInfo, Requires<ImmobileInfo>
 	{
-		[FieldLoader.Require] public readonly string TerrainType = null;
+		[FieldLoader.Require]
+		public readonly string TerrainType = null;
 
 		public object Create(ActorInitializer init) { return new ChangesTerrain(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -53,7 +53,8 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string CloakSound = null;
 		public readonly string UncloakSound = null;
 
-		[PaletteReference("IsPlayerPalette")] public readonly string Palette = "cloak";
+		[PaletteReference("IsPlayerPalette")]
+		public readonly string Palette = "cloak";
 		public readonly bool IsPlayerPalette = false;
 
 		public readonly BitSet<CloakType> CloakTypes = new BitSet<CloakType>("Cloak");
@@ -68,7 +69,9 @@ namespace OpenRA.Mods.Common.Traits
 	public class Cloak : PausableConditionalTrait<CloakInfo>, IRenderModifier, INotifyDamage, INotifyUnload, INotifyDemolition, INotifyInfiltration,
 		INotifyAttack, ITick, IVisibilityModifier, IRadarColorModifier, INotifyCreated, INotifyHarvesterAction
 	{
-		[Sync] int remainingTime;
+		[Sync]
+		int remainingTime;
+
 		bool isDocking;
 		ConditionManager conditionManager;
 		Cloak[] otherCloaks;

--- a/OpenRA.Mods.Common/Traits/Conditions/ConditionalTrait.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ConditionalTrait.cs
@@ -51,7 +51,8 @@ namespace OpenRA.Mods.Common.Traits
 				yield return new VariableObserver(RequiredConditionsChanged, Info.RequiresCondition.Variables);
 		}
 
-		[Sync] public bool IsTraitDisabled { get; private set; }
+		[Sync]
+		public bool IsTraitDisabled { get; private set; }
 
 		public ConditionalTrait(InfoType info)
 		{

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -54,7 +54,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Skip make/deploy animation?")]
 		public readonly bool SkipMakeAnimation = false;
 
-		[VoiceReference] public readonly string Voice = "Action";
+		[VoiceReference]
+		public readonly string Voice = "Action";
 
 		public override object Create(ActorInitializer init) { return new GrantConditionOnDeploy(init, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnProduction.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnProduction.cs
@@ -44,7 +44,9 @@ namespace OpenRA.Mods.Common.Traits
 		ConditionManager conditionManager;
 
 		int token = ConditionManager.InvalidConditionToken;
-		[Sync] int ticks;
+
+		[Sync]
+		int ticks;
 
 		public GrantConditionOnProduction(Actor self, GrantConditionOnProductionInfo info)
 		{

--- a/OpenRA.Mods.Common/Traits/Conditions/PausableConditionalTrait.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/PausableConditionalTrait.cs
@@ -38,7 +38,8 @@ namespace OpenRA.Mods.Common.Traits
 	/// </summary>
 	public abstract class PausableConditionalTrait<InfoType> : ConditionalTrait<InfoType> where InfoType : PausableConditionalTraitInfo
 	{
-		[Sync] public bool IsTraitPaused { get; private set; }
+		[Sync]
+		public bool IsTraitPaused { get; private set; }
 
 		protected PausableConditionalTrait(InfoType info) : base(info) { IsTraitPaused = info.PausedByDefault; }
 

--- a/OpenRA.Mods.Common/Traits/Conditions/ToggleConditionOnOrder.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ToggleConditionOnOrder.cs
@@ -46,7 +46,8 @@ namespace OpenRA.Mods.Common.Traits
 		int conditionToken = ConditionManager.InvalidConditionToken;
 
 		// If the trait is paused this may be true with no condition granted
-		[Sync] bool enabled = false;
+		[Sync]
+		bool enabled = false;
 
 		public ToggleConditionOnOrder(Actor self, ToggleConditionOnOrderInfo info)
 			: base(info) { }

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -79,8 +79,11 @@ namespace OpenRA.Mods.Common.Traits
 		readonly CrateInfo info;
 		bool collected;
 
-		[Sync] int ticks;
-		[Sync] public CPos Location;
+		[Sync]
+		int ticks;
+
+		[Sync]
+		public CPos Location;
 
 		public Crate(ActorInitializer init, CrateInfo info)
 		{

--- a/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/CrateAction.cs
@@ -23,17 +23,20 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Image containing the crate effect animation sequence.")]
 		public readonly string Image = "crate-effects";
 
+		[SequenceReference("Image")]
 		[Desc("Animation sequence played when collected. Leave empty for no effect.")]
-		[SequenceReference("Image")] public readonly string Sequence = null;
+		public readonly string Sequence = null;
 
+		[PaletteReference]
 		[Desc("Palette to draw the animation in.")]
-		[PaletteReference] public readonly string Palette = "effect";
+		public readonly string Palette = "effect";
 
 		[Desc("Audio clip to play when the crate is collected.")]
 		public readonly string Sound = null;
 
+		[NotificationReference("Speech")]
 		[Desc("Notification to play when the crate is collected.")]
-		[NotificationReference("Speech")] public readonly string Notification = null;
+		public readonly string Notification = null;
 
 		[Desc("The earliest time (in ticks) that this crate action can occur on.")]
 		public readonly int TimeDelay = 0;
@@ -41,8 +44,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Only allow this crate action when the collector has these prerequisites")]
 		public readonly string[] Prerequisites = { };
 
+		[ActorReference]
 		[Desc("Actor types that this crate action will not occur for.")]
-		[ActorReference] public string[] ExcludedActorTypes = { };
+		public string[] ExcludedActorTypes = { };
 
 		public override object Create(ActorInitializer init) { return new CrateAction(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Crates/ExplodeCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/ExplodeCrateAction.cs
@@ -17,8 +17,10 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Fires a weapon at the location when collected.")]
 	class ExplodeCrateActionInfo : CrateActionInfo
 	{
+		[WeaponReference]
+		[FieldLoader.Require]
 		[Desc("The weapon to fire upon collection.")]
-		[WeaponReference, FieldLoader.Require] public string Weapon = null;
+		public string Weapon = null;
 
 		public override object Create(ActorInitializer init) { return new ExplodeCrateAction(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/GiveUnitCrateAction.cs
@@ -19,8 +19,9 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Spawns units when collected.")]
 	class GiveUnitCrateActionInfo : CrateActionInfo
 	{
+		[ActorReference]
+		[FieldLoader.Require]
 		[Desc("The list of units to spawn.")]
-		[ActorReference, FieldLoader.Require]
 		public readonly string[] Units = { };
 
 		[Desc("Factions that are allowed to trigger this action.")]

--- a/OpenRA.Mods.Common/Traits/Crates/SupportPowerCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/SupportPowerCrateAction.cs
@@ -17,8 +17,10 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Gives a supportpower to the collector.")]
 	class SupportPowerCrateActionInfo : CrateActionInfo
 	{
+		[ActorReference]
+		[FieldLoader.Require]
 		[Desc("Which proxy actor, which grants the support power, to spawn.")]
-		[ActorReference, FieldLoader.Require] public readonly string Proxy = null;
+		public readonly string Proxy = null;
 
 		public override object Create(ActorInitializer init) { return new SupportPowerCrateAction(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs
@@ -18,8 +18,9 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("This actor receives damage from the given weapon when on the specified terrain type.")]
 	class DamagedByTerrainInfo : ConditionalTraitInfo, Requires<IHealthInfo>
 	{
+		[FieldLoader.Require]
 		[Desc("Amount of damage received per DamageInterval ticks.")]
-		[FieldLoader.Require] public readonly int Damage = 0;
+		public readonly int Damage = 0;
 
 		[Desc("Delay between receiving damage.")]
 		public readonly int DamageInterval = 0;
@@ -27,8 +28,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Apply the damage using these damagetypes.")]
 		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
 
+		[FieldLoader.Require]
 		[Desc("Terrain types where the actor will take damage.")]
-		[FieldLoader.Require] public readonly string[] Terrain = { };
+		public readonly string[] Terrain = { };
 
 		[Desc("Percentage health below which the actor will not receive further damage.")]
 		public readonly int DamageThreshold = 0;
@@ -43,8 +45,11 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly IHealth health;
 
-		[Sync] int damageTicks;
-		[Sync] int damageThreshold;
+		[Sync]
+		int damageTicks;
+
+		[Sync]
+		int damageThreshold;
 
 		public DamagedByTerrain(Actor self, DamagedByTerrainInfo info) : base(info)
 		{

--- a/OpenRA.Mods.Common/Traits/DeliversCash.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversCash.cs
@@ -32,7 +32,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sound to play when delivering cash")]
 		public readonly string[] Sounds = { };
 
-		[VoiceReference] public readonly string Voice = "Action";
+		[VoiceReference]
+		public readonly string Voice = "Action";
 
 		public object Create(ActorInitializer init) { return new DeliversCash(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/DeliversExperience.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversExperience.cs
@@ -26,7 +26,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Identifier checked against AcceptsDeliveredExperience.ValidTypes. Only needed if the latter is not empty.")]
 		public readonly string Type = null;
 
-		[VoiceReference] public readonly string Voice = "Action";
+		[VoiceReference]
+		public readonly string Voice = "Action";
 
 		public object Create(ActorInitializer init) { return new DeliversExperience(init, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Demolition.cs
+++ b/OpenRA.Mods.Common/Traits/Demolition.cs
@@ -37,8 +37,9 @@ namespace OpenRA.Mods.Common.Traits
 			"Possible values are Exit, Suicide, Dispose.")]
 		public readonly EnterBehaviour EnterBehaviour = EnterBehaviour.Exit;
 
+		[VoiceReference]
 		[Desc("Voice string when planting explosive charges.")]
-		[VoiceReference] public readonly string Voice = "Action";
+		public readonly string Voice = "Action";
 
 		public readonly Stance TargetStances = Stance.Enemy | Stance.Neutral;
 		public readonly Stance ForceTargetStances = Stance.Enemy | Stance.Neutral | Stance.Ally;

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -24,7 +24,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Uses the \"EngineerRepairable\" trait to determine repairability.")]
 		public readonly BitSet<EngineerRepairType> Types = default(BitSet<EngineerRepairType>);
 
-		[VoiceReference] public readonly string Voice = "Action";
+		[VoiceReference]
+		public readonly string Voice = "Action";
 
 		[Desc("Behaviour when entering the structure.",
 			"Possible values are Exit, Suicide, Dispose.")]

--- a/OpenRA.Mods.Common/Traits/EntersTunnels.cs
+++ b/OpenRA.Mods.Common/Traits/EntersTunnels.cs
@@ -23,7 +23,8 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string EnterCursor = "enter";
 		public readonly string EnterBlockedCursor = "enter-blocked";
 
-		[VoiceReference] public readonly string Voice = "Action";
+		[VoiceReference]
+		public readonly string Voice = "Action";
 
 		public object Create(ActorInitializer init) { return new EntersTunnels(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/ExperienceTrickler.cs
+++ b/OpenRA.Mods.Common/Traits/ExperienceTrickler.cs
@@ -32,7 +32,9 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly ExperienceTricklerInfo info;
 		GainsExperience gainsExperience;
-		[Sync] int ticks;
+
+		[Sync]
+		int ticks;
 
 		public ExperienceTrickler(Actor self, ExperienceTricklerInfo info)
 			: base(info)

--- a/OpenRA.Mods.Common/Traits/Explodes.cs
+++ b/OpenRA.Mods.Common/Traits/Explodes.cs
@@ -23,10 +23,13 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("This actor explodes when killed.")]
 	public class ExplodesInfo : ConditionalTraitInfo, Requires<IHealthInfo>
 	{
-		[WeaponReference, FieldLoader.Require, Desc("Default weapon to use for explosion if ammo/payload is loaded.")]
+		[WeaponReference]
+		[FieldLoader.Require]
+		[Desc("Default weapon to use for explosion if ammo/payload is loaded.")]
 		public readonly string Weapon = null;
 
-		[WeaponReference, Desc("Fallback weapon to use for explosion if empty (no ammo/payload).")]
+		[WeaponReference]
+		[Desc("Fallback weapon to use for explosion if empty (no ammo/payload).")]
 		public readonly string EmptyWeapon = "UnitExplode";
 
 		[Desc("Chance that the explosion will use Weapon instead of EmptyWeapon when exploding, provided the actor has ammo/payload.")]

--- a/OpenRA.Mods.Common/Traits/ExplosionOnDamageTransition.cs
+++ b/OpenRA.Mods.Common/Traits/ExplosionOnDamageTransition.cs
@@ -18,7 +18,9 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("This actor triggers an explosion on itself when transitioning to a specific damage state.")]
 	public class ExplosionOnDamageTransitionInfo : ITraitInfo, IRulesetLoaded, Requires<IHealthInfo>
 	{
-		[WeaponReference, FieldLoader.Require, Desc("Weapon to use for explosion.")]
+		[WeaponReference]
+		[FieldLoader.Require]
+		[Desc("Weapon to use for explosion.")]
 		public readonly string Weapon = null;
 
 		[Desc("At which damage state explosion will trigger.")]

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -32,11 +32,13 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Image for the level up sprite.")]
 		public readonly string LevelUpImage = null;
 
+		[SequenceReference("Image")]
 		[Desc("Sequence for the level up sprite. Needs to be present on Image.")]
-		[SequenceReference("Image")] public readonly string LevelUpSequence = "levelup";
+		public readonly string LevelUpSequence = "levelup";
 
+		[PaletteReference]
 		[Desc("Palette for the level up sprite.")]
-		[PaletteReference] public readonly string LevelUpPalette = "effect";
+		public readonly string LevelUpPalette = "effect";
 
 		[Desc("Multiplier to apply to the Conditions keys. Defaults to the actor's value.")]
 		public readonly int ExperienceModifier = -1;
@@ -60,9 +62,11 @@ namespace OpenRA.Mods.Common.Traits
 		ConditionManager conditionManager;
 
 		// Stored as a percentage of our value
-		[Sync] int experience = 0;
+		[Sync]
+		int experience = 0;
 
-		[Sync] public int Level { get; private set; }
+		[Sync]
+		public int Level { get; private set; }
 		public readonly int MaxLevel;
 
 		public GainsExperience(ActorInitializer init, GainsExperienceInfo info)
@@ -137,7 +141,9 @@ namespace OpenRA.Mods.Common.Traits
 
 	class ExperienceInit : IActorInit<int>
 	{
-		[FieldFromYamlKey] readonly int value;
+		[FieldFromYamlKey]
+		readonly int value;
+
 		public ExperienceInit() { }
 		public ExperienceInit(int init) { value = init; }
 		public int Value(World world) { return value; }

--- a/OpenRA.Mods.Common/Traits/Guard.cs
+++ b/OpenRA.Mods.Common/Traits/Guard.cs
@@ -18,7 +18,8 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("The player can give this unit the order to follow and protect friendly units with the Guardable trait.")]
 	public class GuardInfo : ITraitInfo, Requires<IMoveInfo>
 	{
-		[VoiceReference] public readonly string Voice = "Action";
+		[VoiceReference]
+		public readonly string Voice = "Action";
 
 		public object Create(ActorInitializer init) { return new Guard(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -78,8 +78,11 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Condition to grant while empty.")]
 		public readonly string EmptyCondition = null;
 
-		[VoiceReference] public readonly string HarvestVoice = "Action";
-		[VoiceReference] public readonly string DeliverVoice = "Action";
+		[VoiceReference]
+		public readonly string HarvestVoice = "Action";
+
+		[VoiceReference]
+		public readonly string DeliverVoice = "Action";
 
 		public object Create(ActorInitializer init) { return new Harvester(init.Self, this); }
 	}
@@ -97,11 +100,20 @@ namespace OpenRA.Mods.Common.Traits
 		int conditionToken = ConditionManager.InvalidConditionToken;
 		HarvesterResourceMultiplier[] resourceMultipliers;
 
-		[Sync] public bool LastSearchFailed;
-		[Sync] public Actor OwnerLinkedProc = null;
-		[Sync] public Actor LastLinkedProc = null;
-		[Sync] public Actor LinkedProc = null;
-		[Sync] int currentUnloadTicks;
+		[Sync]
+		public bool LastSearchFailed;
+
+		[Sync]
+		public Actor OwnerLinkedProc = null;
+
+		[Sync]
+		public Actor LastLinkedProc = null;
+
+		[Sync]
+		public Actor LinkedProc = null;
+
+		[Sync]
+		int currentUnloadTicks;
 
 		[Sync]
 		public int ContentValue

--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -60,7 +60,8 @@ namespace OpenRA.Mods.Common.Traits
 		INotifyKilled[] notifyKilled;
 		INotifyKilled[] notifyKilledPlayer;
 
-		[Sync] int hp;
+		[Sync]
+		int hp;
 
 		public int DisplayHP { get; private set; }
 
@@ -232,7 +233,9 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class HealthInit : IActorInit<int>
 	{
-		[FieldFromYamlKey] readonly int value = 100;
+		[FieldFromYamlKey]
+		readonly int value = 100;
+
 		readonly bool allowZero;
 		public HealthInit() { }
 		public HealthInit(int init)

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -60,9 +60,14 @@ namespace OpenRA.Mods.Common.Traits
 		readonly int dragSpeed;
 		readonly WPos finalPosition;
 
-		[Sync] public CPos TopLeft { get; private set; }
-		[Sync] public WPos CenterPosition { get; private set; }
-		[Sync] public int Facing { get; set; }
+		[Sync]
+		public CPos TopLeft { get; private set; }
+
+		[Sync]
+		public WPos CenterPosition { get; private set; }
+
+		[Sync]
+		public int Facing { get; set; }
 
 		public int TurnSpeed { get { return 0; } }
 
@@ -159,7 +164,9 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class HuskSpeedInit : IActorInit<int>
 	{
-		[FieldFromYamlKey] readonly int value = 0;
+		[FieldFromYamlKey]
+		readonly int value = 0;
+
 		public HuskSpeedInit() { }
 		public HuskSpeedInit(int init) { value = init; }
 		public int Value(World world) { return value; }

--- a/OpenRA.Mods.Common/Traits/Immobile.cs
+++ b/OpenRA.Mods.Common/Traits/Immobile.cs
@@ -33,8 +33,12 @@ namespace OpenRA.Mods.Common.Traits
 
 	class Immobile : IOccupySpace, ISync, INotifyAddedToWorld, INotifyRemovedFromWorld
 	{
-		[Sync] readonly CPos location;
-		[Sync] readonly WPos position;
+		[Sync]
+		readonly CPos location;
+
+		[Sync]
+		readonly WPos position;
+
 		readonly Pair<CPos, SubCell>[] occupied;
 
 		public Immobile(ActorInitializer init, ImmobileInfo info)

--- a/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
@@ -25,7 +25,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Chance (out of 100) the unit has to enter panic mode when attacked.")]
 		public readonly int AttackPanicChance = 20;
 
-		[SequenceReference(null, true)] public readonly string PanicSequencePrefix = "panic-";
+		[SequenceReference(null, true)]
+		public readonly string PanicSequencePrefix = "panic-";
 
 		public object Create(ActorInitializer init) { return new ScaredyCat(init.Self, this); }
 	}
@@ -34,8 +35,10 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly ScaredyCatInfo info;
 		readonly Mobile mobile;
-		[Sync] readonly Actor self;
-		[Sync] int panicStartedTick;
+		readonly Actor self;
+
+		[Sync]
+		int panicStartedTick;
 		bool Panicking { get { return panicStartedTick > 0; } }
 
 		bool IRenderInfantrySequenceModifier.IsModifyingSequence { get { return Panicking; } }

--- a/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
@@ -34,7 +34,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly WVec ProneOffset = new WVec(500, 0, 0);
 
-		[SequenceReference(null, true)] public readonly string ProneSequencePrefix = "prone-";
+		[SequenceReference(null, true)]
+		public readonly string ProneSequencePrefix = "prone-";
 
 		public override object Create(ActorInitializer init) { return new TakeCover(init, this); }
 	}
@@ -42,7 +43,9 @@ namespace OpenRA.Mods.Common.Traits
 	public class TakeCover : Turreted, INotifyDamage, IDamageModifier, ISpeedModifier, ISync, IRenderInfantrySequenceModifier
 	{
 		readonly TakeCoverInfo info;
-		[Sync] int remainingProneTime = 0;
+		[Sync]
+		int remainingProneTime = 0;
+
 		bool IsProne { get { return remainingProneTime > 0; } }
 
 		bool IRenderInfantrySequenceModifier.IsModifyingSequence { get { return IsProne; } }

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -24,8 +24,9 @@ namespace OpenRA.Mods.Common.Traits
 	public class MobileInfo : PausableConditionalTraitInfo, IMoveInfo, IPositionableInfo, IFacingInfo, IActorPreviewInitInfo,
 		IEditorActorOptions
 	{
+		[LocomotorReference]
+		[FieldLoader.Require]
 		[Desc("Which Locomotor does this trait use. Must be defined on the World actor.")]
-		[LocomotorReference, FieldLoader.Require]
 		public readonly string Locomotor = null;
 
 		public readonly int InitialFacing = 0;
@@ -38,7 +39,8 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Cursor = "move";
 		public readonly string BlockedCursor = "move-blocked";
 
-		[VoiceReference] public readonly string Voice = "Action";
+		[VoiceReference]
+		public readonly string Voice = "Action";
 
 		[Desc("Facing to use for actor previews (map editor, color picker, etc)")]
 		public readonly int PreviewFacing = 92;
@@ -157,7 +159,8 @@ namespace OpenRA.Mods.Common.Traits
 		INotifyFinishedMoving[] notifyFinishedMoving;
 
 		#region IFacing
-		[Sync] public int Facing
+		[Sync]
+		public int Facing
 		{
 			get { return facing; }
 			set { facing = value; }
@@ -166,13 +169,20 @@ namespace OpenRA.Mods.Common.Traits
 		public int TurnSpeed { get { return Info.TurnSpeed; } }
 		#endregion
 
-		[Sync] public CPos FromCell { get { return fromCell; } }
-		[Sync] public CPos ToCell { get { return toCell; } }
+		[Sync]
+		public CPos FromCell { get { return fromCell; } }
 
-		[Sync] public int PathHash;	// written by Move.EvalPath, to temporarily debug this crap.
+		[Sync]
+		public CPos ToCell { get { return toCell; } }
+
+		[Sync]
+		public int PathHash;	// written by Move.EvalPath, to temporarily debug this crap.
 
 		#region IOccupySpace
-		[Sync] public WPos CenterPosition { get; private set; }
+
+		[Sync]
+		public WPos CenterPosition { get; private set; }
+
 		public CPos TopLeft { get { return ToCell; } }
 
 		public Pair<CPos, SubCell>[] OccupiedCells()

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -29,7 +29,8 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class FrozenUnderFog : ICreatesFrozenActors, IRenderModifier, IDefaultVisibility, ITick, ITickRender, ISync, INotifyCreated, INotifyOwnerChanged, INotifyActorDisposing
 	{
-		[Sync] public int VisibilityHash;
+		[Sync]
+		public int VisibilityHash;
 
 		readonly FrozenUnderFogInfo info;
 		readonly bool startsRevealed;

--- a/OpenRA.Mods.Common/Traits/Modifiers/WithColoredOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/WithColoredOverlay.cs
@@ -19,8 +19,9 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Display a colored overlay when a timed condition is active.")]
 	public class WithColoredOverlayInfo : ConditionalTraitInfo
 	{
+		[PaletteReference]
 		[Desc("Palette to use when rendering the overlay")]
-		[PaletteReference] public readonly string Palette = "invuln";
+		public readonly string Palette = "invuln";
 
 		public override object Create(ActorInitializer init) { return new WithColoredOverlay(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/ParaDrop.cs
+++ b/OpenRA.Mods.Common/Traits/ParaDrop.cs
@@ -39,8 +39,11 @@ namespace OpenRA.Mods.Common.Traits
 		public event Action<Actor> OnEnteredDropRange = self => { };
 		public event Action<Actor> OnExitedDropRange = self => { };
 
-		[Sync] bool inDropRange;
-		[Sync] Target target;
+		[Sync]
+		bool inDropRange;
+
+		[Sync]
+		Target target;
 
 		bool checkForSuitableCell;
 

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -29,15 +29,19 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Image where Ground/WaterCorpseSequence is looked up.")]
 		public readonly string Image = "explosion";
 
-		[SequenceReference("Image")] public readonly string GroundCorpseSequence = null;
+		[SequenceReference("Image")]
+		public readonly string GroundCorpseSequence = null;
 
-		[PaletteReference] public readonly string GroundCorpsePalette = "effect";
+		[PaletteReference]
+		public readonly string GroundCorpsePalette = "effect";
 
 		public readonly string GroundImpactSound = null;
 
-		[SequenceReference("Image")] public readonly string WaterCorpseSequence = null;
+		[SequenceReference("Image")]
+		public readonly string WaterCorpseSequence = null;
 
-		[PaletteReference] public readonly string WaterCorpsePalette = "effect";
+		[PaletteReference]
+		public readonly string WaterCorpsePalette = "effect";
 
 		[Desc("Terrain types on which to display WaterCorpseSequence.")]
 		public readonly HashSet<string> WaterTerrainTypes = new HashSet<string> { "Water" };

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -46,7 +46,8 @@ namespace OpenRA.Mods.Common.Traits
 		[GrantedConditionReference]
 		public IEnumerable<string> LinterCargoConditions { get { return CargoConditions.Values; } }
 
-		[VoiceReference] public readonly string Voice = "Action";
+		[VoiceReference]
+		public readonly string Voice = "Action";
 
 		public object Create(ActorInitializer init) { return new Passenger(this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -21,8 +21,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Delay for the end game notification in milliseconds.")]
 		public readonly int NotificationDelay = 1500;
 
+		[Translate]
 		[Desc("Description of the objective.")]
-		[Translate] public readonly string Objective = "Destroy all opposition!";
+		public readonly string Objective = "Destroy all opposition!";
 
 		[Desc("Disable the win/loss messages and audio notifications?")]
 		public readonly bool SuppressNotifications = false;

--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
@@ -76,13 +76,26 @@ namespace OpenRA.Mods.Common.Traits
 		readonly DeveloperModeInfo info;
 		public bool Enabled { get; private set; }
 
-		[Sync] bool fastCharge;
-		[Sync] bool allTech;
-		[Sync] bool fastBuild;
-		[Sync] bool disableShroud;
-		[Sync] bool pathDebug;
-		[Sync] bool unlimitedPower;
-		[Sync] bool buildAnywhere;
+		[Sync]
+		bool fastCharge;
+
+		[Sync]
+		bool allTech;
+
+		[Sync]
+		bool fastBuild;
+
+		[Sync]
+		bool disableShroud;
+
+		[Sync]
+		bool pathDebug;
+
+		[Sync]
+		bool unlimitedPower;
+
+		[Sync]
+		bool buildAnywhere;
 
 		public bool FastCharge { get { return Enabled && fastCharge; } }
 		public bool AllTech { get { return Enabled && allTech; } }

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
@@ -25,12 +25,20 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Notification = "Beacon";
 
 		public readonly bool IsPlayerPalette = true;
-		[PaletteReference("IsPlayerPalette")] public readonly string Palette = "player";
+
+		[PaletteReference("IsPlayerPalette")]
+		public readonly string Palette = "player";
 
 		public readonly string BeaconImage = "beacon";
-		[SequenceReference("BeaconImage")] public readonly string BeaconSequence = null;
-		[SequenceReference("BeaconImage")] public readonly string ArrowSequence = "arrow";
-		[SequenceReference("BeaconImage")] public readonly string CircleSequence = "circles";
+
+		[SequenceReference("BeaconImage")]
+		public readonly string BeaconSequence = null;
+
+		[SequenceReference("BeaconImage")]
+		public readonly string ArrowSequence = "arrow";
+
+		[SequenceReference("BeaconImage")]
+		public readonly string CircleSequence = "circles";
 
 		public object Create(ActorInitializer init) { return new PlaceBeacon(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -21,11 +21,13 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Allows the player to execute build orders.", " Attach this to the player actor.")]
 	public class PlaceBuildingInfo : ITraitInfo
 	{
+		[PaletteReference]
 		[Desc("Palette to use for rendering the placement sprite.")]
-		[PaletteReference] public readonly string Palette = TileSet.TerrainPaletteInternalName;
+		public readonly string Palette = TileSet.TerrainPaletteInternalName;
 
+		[PaletteReference]
 		[Desc("Palette to use for rendering the placement sprite for line build segments.")]
-		[PaletteReference] public readonly string LineBuildSegmentPalette = TileSet.TerrainPaletteInternalName;
+		public readonly string LineBuildSegmentPalette = TileSet.TerrainPaletteInternalName;
 
 		[Desc("Play NewOptionsNotification this many ticks after building placement.")]
 		public readonly int NewOptionsNotificationDelay = 10;

--- a/OpenRA.Mods.Common/Traits/Player/PlayerExperience.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerExperience.cs
@@ -23,7 +23,8 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class PlayerExperience : ISync
 	{
-		[Sync] public int Experience { get; private set; }
+		[Sync]
+		public int Experience { get; private set; }
 
 		public void GiveExperience(int num)
 		{

--- a/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
@@ -83,10 +83,14 @@ namespace OpenRA.Mods.Common.Traits
 				Cash = info.DefaultCash;
 		}
 
-		[Sync] public int Cash;
+		[Sync]
+		public int Cash;
 
-		[Sync] public int Resources;
-		[Sync] public int ResourceCapacity;
+		[Sync]
+		public int Resources;
+
+		[Sync]
+		public int ResourceCapacity;
 
 		public int Earned;
 		public int Spent;

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -115,10 +115,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Actor Actor { get { return self; } }
 
-		[Sync] public bool Enabled { get; protected set; }
+		[Sync]
+		public bool Enabled { get; protected set; }
 
 		public string Faction { get; private set; }
-		[Sync] public bool IsValidFaction { get; private set; }
+
+		[Sync]
+		public bool IsValidFaction { get; private set; }
 
 		public ProductionQueue(ActorInitializer init, Actor playerActor, ProductionQueueInfo info)
 		{

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -36,8 +36,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Delay for the end game notification in milliseconds.")]
 		public readonly int NotificationDelay = 1500;
 
+		[Translate]
 		[Desc("Description of the objective")]
-		[Translate] public readonly string Objective = "Hold all the strategic positions!";
+		public readonly string Objective = "Hold all the strategic positions!";
 
 		[Desc("Disable the win/loss messages and audio notifications?")]
 		public readonly bool SuppressNotifications = false;
@@ -49,7 +50,9 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly StrategicVictoryConditionsInfo info;
 
-		[Sync] public int TicksLeft;
+		[Sync]
+		public int TicksLeft;
+
 		readonly Player player;
 		readonly MissionObjectives mo;
 		readonly bool shortGame;

--- a/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
@@ -34,10 +34,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		readonly Dictionary<Actor, int> powerDrain = new Dictionary<Actor, int>();
 
-		[Sync] int totalProvided;
+		[Sync]
+		int totalProvided;
+
 		public int PowerProvided { get { return totalProvided; } }
 
-		[Sync] int totalDrained;
+		[Sync]
+		int totalDrained;
+
 		public int PowerDrained { get { return totalDrained; } }
 
 		public int ExcessPower { get { return totalProvided - totalDrained; } }

--- a/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
@@ -110,7 +110,9 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class ProductionSpawnLocationInit : IActorInit<CPos>
 	{
-		[FieldFromYamlKey] readonly CPos value = CPos.Zero;
+		[FieldFromYamlKey]
+		readonly CPos value = CPos.Zero;
+
 		public ProductionSpawnLocationInit() { }
 		public ProductionSpawnLocationInit(CPos init) { value = init; }
 		public CPos Value(World world) { return value; }

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -20,8 +20,9 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Deliver the unit in production via paradrop.")]
 	public class ProductionParadropInfo : ProductionInfo, Requires<ExitInfo>
 	{
+		[ActorReference(typeof(AircraftInfo))]
 		[Desc("Cargo aircraft used. Must have Aircraft trait.")]
-		[ActorReference(typeof(AircraftInfo))] public readonly string ActorType = "badr";
+		public readonly string ActorType = "badr";
 
 		[Desc("Sound to play when dropping the unit.")]
 		public readonly string ChuteSound = null;

--- a/OpenRA.Mods.Common/Traits/QuantizeFacingsFromSequence.cs
+++ b/OpenRA.Mods.Common/Traits/QuantizeFacingsFromSequence.cs
@@ -19,7 +19,8 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Derive facings from sprite body sequence.")]
 	public class QuantizeFacingsFromSequenceInfo : ConditionalTraitInfo, IQuantizeBodyOrientationInfo, Requires<RenderSpritesInfo>
 	{
-		[Desc("Defines sequence to derive facings from."), SequenceReference]
+		[SequenceReference]
+		[Desc("Defines sequence to derive facings from.")]
 		public readonly string Sequence = "idle";
 
 		public int QuantizedBodyFacings(ActorInfo ai, SequenceProvider sequenceProvider, string race)

--- a/OpenRA.Mods.Common/Traits/Radar/RadarColorFromTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/Radar/RadarColorFromTerrain.cs
@@ -16,7 +16,9 @@ namespace OpenRA.Mods.Common.Traits.Radar
 {
 	public class RadarColorFromTerrainInfo : ITraitInfo
 	{
-		[FieldLoader.Require] public readonly string Terrain;
+		[FieldLoader.Require]
+		public readonly string Terrain;
+
 		public object Create(ActorInitializer init) { return new RadarColorFromTerrain(init.Self, Terrain); }
 	}
 

--- a/OpenRA.Mods.Common/Traits/Rearmable.cs
+++ b/OpenRA.Mods.Common/Traits/Rearmable.cs
@@ -17,9 +17,10 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public class RearmableInfo : ITraitInfo
 	{
-		[Desc("Actors that this actor can dock to and get rearmed by.")]
+		[ActorReference]
 		[FieldLoader.Require]
-		[ActorReference] public readonly HashSet<string> RearmActors = new HashSet<string> { };
+		[Desc("Actors that this actor can dock to and get rearmed by.")]
+		public readonly HashSet<string> RearmActors = new HashSet<string> { };
 
 		[Desc("Name(s) of AmmoPool(s) that use this trait to rearm.")]
 		public readonly HashSet<string> AmmoPools = new HashSet<string> { "primary" };

--- a/OpenRA.Mods.Common/Traits/ReloadAmmoPool.cs
+++ b/OpenRA.Mods.Common/Traits/ReloadAmmoPool.cs
@@ -47,7 +47,8 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		AmmoPool ammoPool;
 
-		[Sync] int remainingTicks;
+		[Sync]
+		int remainingTicks;
 
 		public ReloadAmmoPool(ReloadAmmoPoolInfo info)
 			: base(info) { }

--- a/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
+++ b/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
@@ -25,7 +25,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[SequenceReference("Image")]
 		public readonly string[] Sequences = { "idle" };
 
-		[PaletteReference] public readonly string Palette = "effect";
+		[PaletteReference]
+		public readonly string Palette = "effect";
 
 		[Desc("Only leave trail on listed terrain types. Leave empty to leave trail on all terrain types.")]
 		public readonly HashSet<string> TerrainTypes = new HashSet<string>();

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -33,11 +33,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("A dictionary of faction-specific image overrides.")]
 		public readonly Dictionary<string, string> FactionImages = null;
 
+		[PaletteReference]
 		[Desc("Custom palette name")]
-		[PaletteReference] public readonly string Palette = null;
+		public readonly string Palette = null;
 
+		[PaletteReference(true)]
 		[Desc("Custom PlayerColorPalette: BaseName")]
-		[PaletteReference(true)] public readonly string PlayerPalette = "player";
+		public readonly string PlayerPalette = "player";
 
 		[Desc("Change the sprite image size.")]
 		public readonly float Scale = 1f;

--- a/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
@@ -31,12 +31,18 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly string Image = null;
 
 		[Desc("Custom palette name")]
-		[PaletteReference] public readonly string Palette = null;
+		[PaletteReference]
+		public readonly string Palette = null;
 
+		[PaletteReference]
 		[Desc("Custom PlayerColorPalette: BaseName")]
-		[PaletteReference] public readonly string PlayerPalette = "player";
-		[PaletteReference] public readonly string NormalsPalette = "normals";
-		[PaletteReference] public readonly string ShadowPalette = "shadow";
+		public readonly string PlayerPalette = "player";
+
+		[PaletteReference]
+		public readonly string NormalsPalette = "normals";
+
+		[PaletteReference]
+		public readonly string ShadowPalette = "shadow";
 
 		[Desc("Change the image size.")]
 		public readonly float Scale = 12;

--- a/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
@@ -20,7 +20,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 {
 	public class SelectionDecorationsInfo : ITraitInfo, Requires<IDecorationBoundsInfo>
 	{
-		[PaletteReference] public readonly string Palette = "chrome";
+		[PaletteReference]
+		public readonly string Palette = "chrome";
 
 		[Desc("Health bar, production progress bar etc.")]
 		public readonly bool RenderSelectionBars = true;

--- a/OpenRA.Mods.Common/Traits/Render/VeteranProductionIconOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/VeteranProductionIconOverlay.cs
@@ -24,11 +24,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Image used for the overlay.")]
 		public readonly string Image = null;
 
+		[SequenceReference("Image")]
 		[Desc("Sequence used for the overlay (cannot be animated).")]
-		[SequenceReference("Image")] public readonly string Sequence = null;
+		public readonly string Sequence = null;
 
+		[PaletteReference]
 		[Desc("Palette to render the sprite in. Reference the world actor's PaletteFrom* traits.")]
-		[PaletteReference] public readonly string Palette = "chrome";
+		public readonly string Palette = "chrome";
 
 		[Desc("Point on the production icon's used as reference for offsetting the overlay. ",
 			"Possible values are combinations of Center, Top, Bottom, Left, Right.")]

--- a/OpenRA.Mods.Common/Traits/Render/WithAcceptDeliveredCashAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAcceptDeliveredCashAnimation.cs
@@ -17,8 +17,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Replaces the building animation when it accepts a cash delivery unit.")]
 	public class WithAcceptDeliveredCashAnimationInfo : ConditionalTraitInfo, Requires<WithSpriteBodyInfo>
 	{
+		[SequenceReference]
 		[Desc("Sequence name to use")]
-		[SequenceReference] public readonly string Sequence = "active";
+		public readonly string Sequence = "active";
 
 		[Desc("Which sprite body to play the animation on.")]
 		public readonly string Body = "body";

--- a/OpenRA.Mods.Common/Traits/Render/WithAimAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAimAnimation.cs
@@ -19,9 +19,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Armament name")]
 		public readonly string Armament = "primary";
 
-		[Desc("Displayed while targeting.")]
+		[SequenceReference]
 		[FieldLoader.Require]
-		[SequenceReference] public readonly string Sequence = null;
+		[Desc("Displayed while targeting.")]
+		public readonly string Sequence = null;
 
 		[Desc("Which sprite body to modify.")]
 		public readonly string Body = "body";

--- a/OpenRA.Mods.Common/Traits/Render/WithAttackAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAttackAnimation.cs
@@ -19,8 +19,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Armament name")]
 		public readonly string Armament = "primary";
 
+		[SequenceReference]
 		[Desc("Displayed while attacking.")]
-		[SequenceReference] public readonly string Sequence = null;
+		public readonly string Sequence = null;
 
 		[Desc("Delay in ticks before animation starts, either relative to attack preparation or attack.")]
 		public readonly int Delay = 0;

--- a/OpenRA.Mods.Common/Traits/Render/WithAttackOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAttackOverlay.cs
@@ -17,12 +17,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Rendered together with an attack.")]
 	public class WithAttackOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>
 	{
+		[SequenceReference]
 		[FieldLoader.Require]
 		[Desc("Sequence name to use")]
-		[SequenceReference] public readonly string Sequence = null;
+		public readonly string Sequence = null;
 
+		[PaletteReference("IsPlayerPalette")]
 		[Desc("Custom palette name")]
-		[PaletteReference("IsPlayerPalette")] public readonly string Palette = null;
+		public readonly string Palette = null;
 
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedAnimation.cs
@@ -17,7 +17,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Changes the animation when the actor constructed a building.")]
 	public class WithBuildingPlacedAnimationInfo : ConditionalTraitInfo, Requires<WithSpriteBodyInfo>
 	{
-		[Desc("Sequence name to use"), SequenceReference]
+		[SequenceReference]
+		[Desc("Sequence name to use")]
 		public readonly string Sequence = "build";
 
 		[Desc("Which sprite body to play the animation on.")]

--- a/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBuildingPlacedOverlay.cs
@@ -17,14 +17,16 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Rendered when the actor constructed a building.")]
 	public class WithBuildingPlacedOverlayInfo : ConditionalTraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
+		[SequenceReference]
 		[Desc("Sequence name to use")]
-		[SequenceReference] public readonly string Sequence = "crane-overlay";
+		public readonly string Sequence = "crane-overlay";
 
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
+		[PaletteReference("IsPlayerPalette")]
 		[Desc("Custom palette name")]
-		[PaletteReference("IsPlayerPalette")] public readonly string Palette = null;
+		public readonly string Palette = null;
 
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;

--- a/OpenRA.Mods.Common/Traits/Render/WithChargeOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithChargeOverlay.cs
@@ -21,8 +21,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence to use for the charge levels.")]
 		public readonly string Sequence = "active";
 
+		[PaletteReference("IsPlayerPalette")]
 		[Desc("Custom palette name")]
-		[PaletteReference("IsPlayerPalette")] public readonly string Palette = null;
+		public readonly string Palette = null;
 
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;

--- a/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
@@ -27,9 +27,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Terrain types on which to display WaterSequence.")]
 		public readonly HashSet<string> WaterTerrainTypes = new HashSet<string> { "Water" };
 
-		[SequenceReference] public readonly string IdleSequence = "idle";
-		[SequenceReference] public readonly string WaterSequence = null;
-		[SequenceReference] public readonly string LandSequence = null;
+		[SequenceReference]
+		public readonly string IdleSequence = "idle";
+
+		[SequenceReference]
+		public readonly string WaterSequence = null;
+
+		[SequenceReference]
+		public readonly string LandSequence = null;
 
 		public object Create(ActorInitializer init) { return new WithCrateBody(init.Self, this); }
 

--- a/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
@@ -20,9 +20,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 	{
 		public readonly string Image = "smoke_m";
 
-		[SequenceReference("Image")] public readonly string IdleSequence = "idle";
-		[SequenceReference("Image")] public readonly string LoopSequence = "loop";
-		[SequenceReference("Image")] public readonly string EndSequence = "end";
+		[SequenceReference("Image")]
+		public readonly string IdleSequence = "idle";
+
+		[SequenceReference("Image")]
+		public readonly string LoopSequence = "loop";
+
+		[SequenceReference("Image")]
+		public readonly string EndSequence = "end";
 
 		[Desc("Damage types that this should be used for (defined on the warheads).",
 			"Leave empty to disable all filtering.")]

--- a/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
@@ -20,11 +20,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("This actor has a death animation.")]
 	public class WithDeathAnimationInfo : ConditionalTraitInfo, Requires<RenderSpritesInfo>
 	{
+		[SequenceReference(null, true)]
 		[Desc("Sequence prefix to play when this actor is killed by a warhead.")]
-		[SequenceReference(null, true)] public readonly string DeathSequence = "die";
+		public readonly string DeathSequence = "die";
 
+		[PaletteReference("DeathPaletteIsPlayerPalette")]
 		[Desc("The palette used for `DeathSequence`.")]
-		[PaletteReference("DeathPaletteIsPlayerPalette")] public readonly string DeathSequencePalette = "player";
+		public readonly string DeathSequencePalette = "player";
 
 		[Desc("Custom death animation palette is a player palette BaseName")]
 		public readonly bool DeathPaletteIsPlayerPalette = true;
@@ -32,11 +34,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Should DeathType-specific sequences be used (sequence name = DeathSequence + DeathType).")]
 		public readonly bool UseDeathTypeSuffix = true; // TODO: check the complete sequence with lint rules
 
+		[SequenceReference]
 		[Desc("Sequence to play when this actor is crushed.")]
-		[SequenceReference] public readonly string CrushedSequence = null;
+		public readonly string CrushedSequence = null;
 
+		[PaletteReference("CrushedPaletteIsPlayerPalette")]
 		[Desc("The palette used for `CrushedSequence`.")]
-		[PaletteReference("CrushedPaletteIsPlayerPalette")] public readonly string CrushedSequencePalette = "effect";
+		public readonly string CrushedSequencePalette = "effect";
 
 		[Desc("Custom crushed animation palette is a player palette BaseName")]
 		public readonly bool CrushedPaletteIsPlayerPalette = false;
@@ -45,8 +49,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 			"Is only used if UseDeathTypeSuffix is `True`.")]
 		public readonly Dictionary<string, string[]> DeathTypes = new Dictionary<string, string[]>();
 
+		[SequenceReference]
 		[Desc("Sequence to use when the actor is killed by some non-standard means (e.g. suicide).")]
-		[SequenceReference] public readonly string FallbackSequence = null;
+		public readonly string FallbackSequence = null;
 
 		public override object Create(ActorInitializer init) { return new WithDeathAnimation(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
@@ -39,8 +39,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence used for this decoration (can be animated).")]
 		public readonly string Sequence = null;
 
+		[PaletteReference("IsPlayerPalette")]
 		[Desc("Palette to render the sprite in. Reference the world actor's PaletteFrom* traits.")]
-		[PaletteReference("IsPlayerPalette")] public readonly string Palette = "chrome";
+		public readonly string Palette = "chrome";
 
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;

--- a/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDockedOverlay.cs
@@ -17,14 +17,16 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Rendered when a harvester is docked.")]
 	public class WithDockedOverlayInfo : PausableConditionalTraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
+		[SequenceReference]
 		[Desc("Sequence name to use")]
-		[SequenceReference] public readonly string Sequence = "docking-overlay";
+		public readonly string Sequence = "docking-overlay";
 
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
+		[PaletteReference("IsPlayerPalette")]
 		[Desc("Custom palette name")]
-		[PaletteReference("IsPlayerPalette")] public readonly string Palette = null;
+		public readonly string Palette = null;
 
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;

--- a/OpenRA.Mods.Common/Traits/Render/WithDockingAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDockingAnimation.cs
@@ -15,11 +15,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 {
 	public class WithDockingAnimationInfo : TraitInfo<WithDockingAnimation>, Requires<WithSpriteBodyInfo>, Requires<HarvesterInfo>
 	{
+		[SequenceReference]
 		[Desc("Displayed when docking to refinery.")]
-		[SequenceReference] public readonly string DockSequence = "dock";
+		public readonly string DockSequence = "dock";
 
+		[SequenceReference]
 		[Desc("Looped while unloading at refinery.")]
-		[SequenceReference] public readonly string DockLoopSequence = "dock-loop";
+		public readonly string DockLoopSequence = "dock-loop";
 	}
 
 	public class WithDockingAnimation { }

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
@@ -17,8 +17,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 {
 	public class WithHarvestAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<HarvesterInfo>
 	{
+		[SequenceReference]
 		[Desc("Displayed while harvesting.")]
-		[SequenceReference] public readonly string HarvestSequence = "harvest";
+		public readonly string HarvestSequence = "harvest";
 
 		[Desc("Which sprite body to play the animation on.")]
 		public readonly string Body = "body";

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
@@ -18,13 +18,15 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Displays an overlay whenever resources are harvested by the actor.")]
 	class WithHarvestOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
+		[SequenceReference]
 		[Desc("Sequence name to use")]
-		[SequenceReference] public readonly string Sequence = "harvest";
+		public readonly string Sequence = "harvest";
 
 		[Desc("Position relative to body")]
 		public readonly WVec LocalOffset = WVec.Zero;
 
-		[PaletteReference] public readonly string Palette = "effect";
+		[PaletteReference]
+		public readonly string Palette = "effect";
 
 		public object Create(ActorInitializer init) { return new WithHarvestOverlay(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleAnimation.cs
@@ -17,7 +17,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Periodically plays an idle animation, replacing the default body animation.")]
 	public class WithIdleAnimationInfo : ConditionalTraitInfo, Requires<WithSpriteBodyInfo>
 	{
-		[SequenceReference, Desc("Sequence names to use.")]
+		[SequenceReference]
+		[Desc("Sequence names to use.")]
 		public readonly string[] Sequences = { "active" };
 
 		public readonly int Interval = 750;

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -20,17 +20,20 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Renders a decorative animation on units and buildings.")]
 	public class WithIdleOverlayInfo : PausableConditionalTraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
+		[SequenceReference]
 		[Desc("Animation to play when the actor is created.")]
-		[SequenceReference] public readonly string StartSequence = null;
+		public readonly string StartSequence = null;
 
+		[SequenceReference]
 		[Desc("Sequence name to use")]
-		[SequenceReference] public readonly string Sequence = "idle-overlay";
+		public readonly string Sequence = "idle-overlay";
 
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
+		[PaletteReference("IsPlayerPalette")]
 		[Desc("Custom palette name")]
-		[PaletteReference("IsPlayerPalette")] public readonly string Palette = null;
+		public readonly string Palette = null;
 
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;

--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -22,14 +22,21 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly int MinIdleDelay = 30;
 		public readonly int MaxIdleDelay = 110;
 
-		[SequenceReference] public readonly string MoveSequence = "run";
-		[SequenceReference] public readonly string DefaultAttackSequence = null;
+		[SequenceReference]
+		public readonly string MoveSequence = "run";
+
+		[SequenceReference]
+		public readonly string DefaultAttackSequence = null;
 
 		// TODO: [SequenceReference] isn't smart enough to use Dictionaries.
 		[Desc("Attack sequence to use for each armament.")]
 		public readonly Dictionary<string, string> AttackSequences = new Dictionary<string, string>();
-		[SequenceReference] public readonly string[] IdleSequences = { };
-		[SequenceReference] public readonly string[] StandSequences = { "stand" };
+
+		[SequenceReference]
+		public readonly string[] IdleSequences = { };
+
+		[SequenceReference]
+		public readonly string[] StandSequences = { "stand" };
 
 		public override object Create(ActorInitializer init) { return new WithInfantryBody(init, this); }
 

--- a/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
@@ -19,8 +19,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Replaces the sprite during construction/deploy/undeploy.")]
 	public class WithMakeAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>
 	{
+		[SequenceReference]
 		[Desc("Sequence name to use.")]
-		[SequenceReference] public readonly string Sequence = "make";
+		public readonly string Sequence = "make";
 
 		[GrantedConditionReference]
 		[Desc("The condition to grant to self while the make animation is playing.")]

--- a/OpenRA.Mods.Common/Traits/Render/WithMoveAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMoveAnimation.cs
@@ -16,8 +16,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 {
 	public class WithMoveAnimationInfo : ConditionalTraitInfo, Requires<WithSpriteBodyInfo>, Requires<IMoveInfo>
 	{
+		[SequenceReference]
 		[Desc("Displayed while moving.")]
-		[SequenceReference] public readonly string MoveSequence = "move";
+		public readonly string MoveSequence = "move";
 
 		[Desc("Which sprite body to modify.")]
 		public readonly string Body = "body";

--- a/OpenRA.Mods.Common/Traits/Render/WithNukeLaunchAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithNukeLaunchAnimation.cs
@@ -17,8 +17,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Replaces the building animation when `NukePower` is triggered.")]
 	public class WithNukeLaunchAnimationInfo : ConditionalTraitInfo, Requires<WithSpriteBodyInfo>
 	{
+		[SequenceReference]
 		[Desc("Sequence name to use")]
-		[SequenceReference] public readonly string Sequence = "active";
+		public readonly string Sequence = "active";
 
 		[Desc("Which sprite body to play the animation on.")]
 		public readonly string Body = "body";

--- a/OpenRA.Mods.Common/Traits/Render/WithNukeLaunchOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithNukeLaunchOverlay.cs
@@ -17,14 +17,16 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Displays an overlay when `NukePower` is triggered.")]
 	public class WithNukeLaunchOverlayInfo : ConditionalTraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
+		[SequenceReference]
 		[Desc("Sequence name to use")]
-		[SequenceReference] public readonly string Sequence = "active";
+		public readonly string Sequence = "active";
 
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
+		[PaletteReference("IsPlayerPalette")]
 		[Desc("Custom palette name")]
-		[PaletteReference("IsPlayerPalette")] public readonly string Palette = null;
+		public readonly string Palette = null;
 
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;

--- a/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithParachute.cs
@@ -25,17 +25,22 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("The image that contains the parachute sequences.")]
 		public readonly string Image = null;
 
+		[SequenceReference("Image")]
 		[Desc("Parachute opening sequence.")]
-		[SequenceReference("Image")] public readonly string OpeningSequence = null;
+		public readonly string OpeningSequence = null;
 
+		[SequenceReference("Image")]
 		[Desc("Parachute idle sequence.")]
-		[SequenceReference("Image")] public readonly string Sequence = null;
+		public readonly string Sequence = null;
 
+		[SequenceReference("Image")]
 		[Desc("Parachute closing sequence. Defaults to opening sequence played backwards.")]
-		[SequenceReference("Image")] public readonly string ClosingSequence = null;
+		public readonly string ClosingSequence = null;
 
+		[PaletteReference("IsPlayerPalette")]
 		[Desc("Palette used to render the parachute.")]
-		[PaletteReference("IsPlayerPalette")] public readonly string Palette = "player";
+		public readonly string Palette = "player";
+
 		public readonly bool IsPlayerPalette = true;
 
 		[Desc("Parachute position relative to the paradropped unit.")]
@@ -44,11 +49,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("The image that contains the shadow sequence for the paradropped unit.")]
 		public readonly string ShadowImage = null;
 
+		[SequenceReference("ShadowImage")]
 		[Desc("Paradropped unit's shadow sequence.")]
-		[SequenceReference("ShadowImage")] public readonly string ShadowSequence = null;
+		public readonly string ShadowSequence = null;
 
+		[PaletteReference(false)]
 		[Desc("Palette used to render the paradropped unit's shadow.")]
-		[PaletteReference(false)] public readonly string ShadowPalette = "shadow";
+		public readonly string ShadowPalette = "shadow";
 
 		[Desc("Shadow position relative to the paradropped unit's intended landing position.")]
 		public readonly WVec ShadowOffset = new WVec(0, 128, 0);

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionOverlay.cs
@@ -23,14 +23,16 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Queues that should be producing for this overlay to render.")]
 		public readonly HashSet<string> Queues = new HashSet<string>();
 
+		[SequenceReference]
 		[Desc("Sequence name to use")]
-		[SequenceReference] public readonly string Sequence = "production-overlay";
+		public readonly string Sequence = "production-overlay";
 
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
+		[PaletteReference("IsPlayerPalette")]
 		[Desc("Custom palette name")]
-		[PaletteReference("IsPlayerPalette")] public readonly string Palette = null;
+		public readonly string Palette = null;
 
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;

--- a/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRepairOverlay.cs
@@ -18,20 +18,24 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Displays an overlay when the building is being repaired by the player.")]
 	public class WithRepairOverlayInfo : PausableConditionalTraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
+		[SequenceReference("Image")]
 		[Desc("Sequence to use upon repair beginning.")]
-		[SequenceReference("Image")] public readonly string StartSequence = null;
+		public readonly string StartSequence = null;
 
+		[SequenceReference]
 		[Desc("Sequence name to play once during repair intervals or repeatedly if a start sequence is set.")]
-		[SequenceReference] public readonly string Sequence = "active";
+		public readonly string Sequence = "active";
 
+		[SequenceReference("Image")]
 		[Desc("Sequence to use after repairing has finished.")]
-		[SequenceReference("Image")] public readonly string EndSequence = null;
+		public readonly string EndSequence = null;
 
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
+		[PaletteReference("IsPlayerPalette")]
 		[Desc("Custom palette name")]
-		[PaletteReference("IsPlayerPalette")] public readonly string Palette = null;
+		public readonly string Palette = null;
 
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;

--- a/OpenRA.Mods.Common/Traits/Render/WithResourceLevelOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResourceLevelOverlay.cs
@@ -17,8 +17,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Displays the fill status of PlayerResources with an extra sprite overlay on the actor.")]
 	class WithResourceLevelOverlayInfo : ConditionalTraitInfo, Requires<WithSpriteBodyInfo>, Requires<RenderSpritesInfo>
 	{
+		[SequenceReference]
 		[Desc("Sequence name to use")]
-		[SequenceReference] public readonly string Sequence = "resources";
+		public readonly string Sequence = "resources";
 
 		public override object Create(ActorInitializer init) { return new WithResourceLevelOverlay(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Render/WithResupplyAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResupplyAnimation.cs
@@ -18,8 +18,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Replaces the default animation when actor resupplies a unit.")]
 	public class WithResupplyAnimationInfo : ConditionalTraitInfo, Requires<WithSpriteBodyInfo>
 	{
+		[SequenceReference]
 		[Desc("Sequence name to use")]
-		[SequenceReference] public readonly string Sequence = "active";
+		public readonly string Sequence = "active";
 
 		[Desc("Which sprite body to play the animation on.")]
 		public readonly string Body = "body";

--- a/OpenRA.Mods.Common/Traits/Render/WithShadow.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithShadow.cs
@@ -20,7 +20,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Clones the actor sprite with another palette below it.")]
 	public class WithShadowInfo : ConditionalTraitInfo
 	{
-		[PaletteReference] public readonly string Palette = "shadow";
+		[PaletteReference]
+		public readonly string Palette = "shadow";
 
 		[Desc("Shadow position offset relative to actor position (ground level).")]
 		public readonly WVec Offset = WVec.Zero;

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
@@ -22,8 +22,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 	public class WithSpriteBarrelInfo : ConditionalTraitInfo, IRenderActorPreviewSpritesInfo, Requires<TurretedInfo>,
 		Requires<ArmamentInfo>, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
+		[SequenceReference]
 		[Desc("Sequence name to use.")]
-		[SequenceReference] public readonly string Sequence = "barrel";
+		public readonly string Sequence = "barrel";
 
 		[Desc("Armament to use for recoil.")]
 		public readonly string Armament = "primary";

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -21,10 +21,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Default trait for rendering sprite-based actors.")]
 	public class WithSpriteBodyInfo : PausableConditionalTraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>
 	{
-		[Desc("Animation to play when the actor is created."), SequenceReference]
+		[SequenceReference]
+		[Desc("Animation to play when the actor is created.")]
 		public readonly string StartSequence = null;
 
-		[Desc("Animation to play when the actor is idle."), SequenceReference]
+		[SequenceReference]
+		[Desc("Animation to play when the actor is idle.")]
 		public readonly string Sequence = "idle";
 
 		[Desc("Identifier used to assign modifying traits to this sprite body.")]

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
@@ -19,12 +19,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Renders Ctrl groups using pixel art.")]
 	public class WithSpriteControlGroupDecorationInfo : ITraitInfo, Requires<IDecorationBoundsInfo>
 	{
-		[PaletteReference] public readonly string Palette = "chrome";
+		[PaletteReference]
+		public readonly string Palette = "chrome";
 
 		public readonly string Image = "pips";
 
+		[SequenceReference("Image")]
 		[Desc("Sprite sequence used to render the control group 0-9 numbers.")]
-		[SequenceReference("Image")] public readonly string GroupSequence = "groups";
+		public readonly string GroupSequence = "groups";
 
 		[Desc("Point in the actor's selection box used as reference for offsetting the decoration image. " +
 			"Possible values are combinations of Center, Top, Bottom, Left, Right.")]

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -22,11 +22,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 	public class WithSpriteTurretInfo : ConditionalTraitInfo, IRenderActorPreviewSpritesInfo,
 		Requires<RenderSpritesInfo>, Requires<TurretedInfo>, Requires<BodyOrientationInfo>, Requires<ArmamentInfo>
 	{
+		[SequenceReference]
 		[Desc("Sequence name to use")]
-		[SequenceReference] public readonly string Sequence = "turret";
+		public readonly string Sequence = "turret";
 
+		[PaletteReference("IsPlayerPalette")]
 		[Desc("Custom palette name")]
-		[PaletteReference("IsPlayerPalette")] public readonly string Palette = null;
+		public readonly string Palette = null;
 
 		[Desc("Palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;

--- a/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
@@ -21,7 +21,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Displays a text overlay relative to the selection box.")]
 	public class WithTextDecorationInfo : ConditionalTraitInfo, Requires<IDecorationBoundsInfo>
 	{
-		[FieldLoader.Require] [Translate] public readonly string Text = null;
+		[Translate]
+		[FieldLoader.Require]
+		public readonly string Text = null;
 
 		public readonly string Font = "TinyBold";
 

--- a/OpenRA.Mods.Common/Traits/Render/WithTurretAimAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurretAimAnimation.cs
@@ -22,9 +22,10 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Turret name")]
 		public readonly string Turret = "primary";
 
-		[Desc("Displayed while targeting.")]
+		[SequenceReference]
 		[FieldLoader.Require]
-		[SequenceReference] public readonly string Sequence = null;
+		[Desc("Displayed while targeting.")]
+		public readonly string Sequence = null;
 
 		public override object Create(ActorInitializer init) { return new WithTurretAimAnimation(init, this); }
 

--- a/OpenRA.Mods.Common/Traits/Render/WithTurretAttackAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTurretAttackAnimation.cs
@@ -22,8 +22,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Turret name")]
 		public readonly string Turret = "primary";
 
+		[SequenceReference]
 		[Desc("Displayed while attacking.")]
-		[SequenceReference] public readonly string Sequence = null;
+		public readonly string Sequence = null;
 
 		[Desc("Delay in ticks before animation starts, either relative to attack preparation or attack.")]
 		public readonly int Delay = 0;

--- a/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
@@ -169,7 +169,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 	public class RuntimeNeighbourInit : IActorInit<Dictionary<CPos, string[]>>, ISuppressInitExport
 	{
-		[FieldFromYamlKey] readonly Dictionary<CPos, string[]> value = null;
+		[FieldFromYamlKey]
+		readonly Dictionary<CPos, string[]> value = null;
+
 		public RuntimeNeighbourInit() { }
 		public RuntimeNeighbourInit(Dictionary<CPos, string[]> init) { value = init; }
 		public Dictionary<CPos, string[]> Value(World world) { return value; }

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -22,10 +22,12 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("This actor can be sent to a structure for repairs.")]
 	public class RepairableInfo : ITraitInfo, Requires<IHealthInfo>, Requires<IMoveInfo>
 	{
+		[ActorReference]
 		[FieldLoader.Require]
-		[ActorReference] public readonly HashSet<string> RepairActors = new HashSet<string> { };
+		public readonly HashSet<string> RepairActors = new HashSet<string> { };
 
-		[VoiceReference] public readonly string Voice = "Action";
+		[VoiceReference]
+		public readonly string Voice = "Action";
 
 		[Desc("The amount the unit will be repaired at each step. Use -1 for fallback behavior where HpPerStep from RepairsUnits trait will be used.")]
 		public readonly int HpPerStep = -1;

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -20,11 +20,14 @@ namespace OpenRA.Mods.Common.Traits
 {
 	class RepairableNearInfo : ITraitInfo, Requires<IHealthInfo>, Requires<IMoveInfo>
 	{
+		[ActorReference]
 		[FieldLoader.Require]
-		[ActorReference] public readonly HashSet<string> RepairActors = new HashSet<string> { };
+		public readonly HashSet<string> RepairActors = new HashSet<string> { };
 
 		public readonly WDist CloseEnough = WDist.FromCells(4);
-		[VoiceReference] public readonly string Voice = "Action";
+
+		[VoiceReference]
+		public readonly string Voice = "Action";
 
 		public object Create(ActorInitializer init) { return new RepairableNear(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/RepairsBridges.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsBridges.cs
@@ -20,7 +20,8 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Can enter a BridgeHut or LegacyBridgeHut to trigger a repair.")]
 	class RepairsBridgesInfo : ITraitInfo
 	{
-		[VoiceReference] public readonly string Voice = "Action";
+		[VoiceReference]
+		public readonly string Voice = "Action";
 
 		[Desc("Behaviour when entering the structure.",
 			"Possible values are Exit, Suicide, Dispose.")]

--- a/OpenRA.Mods.Common/Traits/ScriptTags.cs
+++ b/OpenRA.Mods.Common/Traits/ScriptTags.cs
@@ -50,7 +50,9 @@ namespace OpenRA.Mods.Common.Traits
 	/// <summary>Allows mappers to 'tag' actors with arbitrary strings that may have meaning in their scripts.</summary>
 	public class ScriptTagsInit : IActorInit<string[]>
 	{
-		[FieldFromYamlKey] readonly string[] value = new string[0];
+		[FieldFromYamlKey]
+		readonly string[] value = new string[0];
+
 		public ScriptTagsInit() { }
 		public ScriptTagsInit(string[] init) { value = init; }
 		public string[] Value(World world) { return value; }

--- a/OpenRA.Mods.Common/Traits/SelfHealing.cs
+++ b/OpenRA.Mods.Common/Traits/SelfHealing.cs
@@ -41,8 +41,11 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly IHealth health;
 
-		[Sync] int ticks;
-		[Sync] int damageTicks;
+		[Sync]
+		int ticks;
+
+		[Sync]
+		int damageTicks;
 
 		public SelfHealing(Actor self, SelfHealingInfo info)
 			: base(info)

--- a/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
+++ b/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
@@ -18,10 +18,16 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
+
 		public readonly int Interval = 3;
+
 		public readonly string Sprite = "smokey";
-		[SequenceReference("Sprite")] public readonly string Sequence = "idle";
+
+		[SequenceReference("Sprite")]
+		public readonly string Sequence = "idle";
+
 		public readonly string Palette = "effect";
+
 		public readonly DamageState MinDamage = DamageState.Heavy;
 
 		public object Create(ActorInitializer init) { return new SmokeTrailWhenDamaged(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/Sound/AnnounceOnKill.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AnnounceOnKill.cs
@@ -19,8 +19,9 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		[Desc("Minimum duration (in seconds) between sound events.")]
 		public readonly int Interval = 5;
 
+		[VoiceReference]
 		[Desc("Voice to use when killing something.")]
-		[VoiceReference] public readonly string Voice = "Kill";
+		public readonly string Voice = "Kill";
 
 		public object Create(ActorInitializer init) { return new AnnounceOnKill(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Sound/DeathSounds.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/DeathSounds.cs
@@ -17,8 +17,9 @@ namespace OpenRA.Mods.Common.Traits.Sound
 	[Desc("Sounds to play when killed.")]
 	public class DeathSoundsInfo : ConditionalTraitInfo
 	{
+		[VoiceReference]
 		[Desc("Death notification voice.")]
-		[VoiceReference] public readonly string Voice = "Die";
+		public readonly string Voice = "Die";
 
 		[Desc("Multiply volume with this factor.")]
 		public readonly float VolumeMultiplier = 1f;

--- a/OpenRA.Mods.Common/Traits/Sound/VoiceAnnouncement.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/VoiceAnnouncement.cs
@@ -16,9 +16,10 @@ namespace OpenRA.Mods.Common.Traits.Sound
 	[Desc("Plays a voice clip when the trait is enabled.")]
 	public class VoiceAnnouncementInfo : ConditionalTraitInfo
 	{
+		[VoiceReference]
 		[FieldLoader.Require]
 		[Desc("Voice to play.")]
-		[VoiceReference] public readonly string Voice = null;
+		public readonly string Voice = null;
 
 		[Desc("Player stances who can hear this voice.")]
 		public readonly Stance ValidStances = Stance.Ally | Stance.Neutral | Stance.Enemy;

--- a/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/SpawnActorOnDeath.cs
@@ -20,7 +20,8 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Spawn another actor immediately upon death.")]
 	public class SpawnActorOnDeathInfo : ConditionalTraitInfo
 	{
-		[ActorReference, FieldLoader.Require]
+		[ActorReference]
+		[FieldLoader.Require]
 		[Desc("Actor to spawn on death.")]
 		public readonly string Actor = null;
 

--- a/OpenRA.Mods.Common/Traits/SpawnActorsOnSell.cs
+++ b/OpenRA.Mods.Common/Traits/SpawnActorsOnSell.cs
@@ -22,7 +22,8 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int ValuePercent = 40;
 		public readonly int MinHpPercent = 30;
 
-		[ActorReference, FieldLoader.Require]
+		[ActorReference]
+		[FieldLoader.Require]
 		[Desc("Actor types to spawn on sell. Be sure to use lowercase.")]
 		public readonly string[] ActorTypes = null;
 

--- a/OpenRA.Mods.Common/Traits/StoresResources.cs
+++ b/OpenRA.Mods.Common/Traits/StoresResources.cs
@@ -36,7 +36,8 @@ namespace OpenRA.Mods.Common.Traits
 		readonly StoresResourcesInfo info;
 		PlayerResources player;
 
-		[Sync] public int Stored { get { return player.ResourceCapacity == 0 ? 0 : (int)((long)info.Capacity * player.Resources / player.ResourceCapacity); } }
+		[Sync]
+		public int Stored { get { return player.ResourceCapacity == 0 ? 0 : (int)((long)info.Capacity * player.Resources / player.ResourceCapacity); } }
 
 		public StoresResources(Actor self, StoresResourcesInfo info)
 		{

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
@@ -38,7 +38,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Player stances which condition can be applied to.")]
 		public readonly Stance ValidStances = Stance.Ally;
 
-		[SequenceReference, Desc("Sequence to play for granting actor when activated.",
+		[SequenceReference]
+		[Desc("Sequence to play for granting actor when activated.",
 			"This requires the actor to have the WithSpriteBody trait or one of its derivatives.")]
 		public readonly string Sequence = "active";
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -18,7 +18,8 @@ namespace OpenRA.Mods.Common.Traits
 {
 	class NukePowerInfo : SupportPowerInfo, IRulesetLoaded, Requires<BodyOrientationInfo>
 	{
-		[WeaponReference, FieldLoader.Require]
+		[WeaponReference]
+		[FieldLoader.Require]
 		[Desc("Weapon to use for the impact.",
 			"Also image to use for the missile.")]
 		public readonly string MissileWeapon = "";
@@ -26,11 +27,13 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Delay (in ticks) after launch until the missile is spawned.")]
 		public readonly int MissileDelay = 0;
 
+		[SequenceReference("MissileWeapon")]
 		[Desc("Sprite sequence for the ascending missile.")]
-		[SequenceReference("MissileWeapon")] public readonly string MissileUp = "up";
+		public readonly string MissileUp = "up";
 
+		[SequenceReference("MissileWeapon")]
 		[Desc("Sprite sequence for the descending missile.")]
-		[SequenceReference("MissileWeapon")] public readonly string MissileDown = "down";
+		public readonly string MissileDown = "down";
 
 		[Desc("Offset from the actor the missile spawns on.")]
 		public readonly WVec SpawnOffset = WVec.Zero;
@@ -42,8 +45,9 @@ namespace OpenRA.Mods.Common.Traits
 			"'False' will make the missile continue until it hits the ground and disappears (without triggering another explosion).")]
 		public readonly bool RemoveMissileOnDetonation = true;
 
+		[PaletteReference("IsPlayerPalette")]
 		[Desc("Palette to use for the missile weapon image.")]
-		[PaletteReference("IsPlayerPalette")] public readonly string MissilePalette = "effect";
+		public readonly string MissilePalette = "effect";
 
 		[Desc("Custom palette is a player palette BaseName.")]
 		public readonly bool IsPlayerPalette = false;
@@ -51,8 +55,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Trail animation.")]
 		public readonly string TrailImage = null;
 
+		[SequenceReference("TrailImage")]
 		[Desc("Loop a randomly chosen sequence of TrailImage from this list while this projectile is moving.")]
-		[SequenceReference("TrailImage")] public readonly string[] TrailSequences = { };
+		public readonly string[] TrailSequences = { "idle" };
 
 		[Desc("Interval in ticks between each spawned Trail animation.")]
 		public readonly int TrailInterval = 1;
@@ -60,8 +65,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Delay in ticks until trail animation is spawned.")]
 		public readonly int TrailDelay = 1;
 
+		[PaletteReference("TrailUsePlayerPalette")]
 		[Desc("Palette used to render the trail sequence.")]
-		[PaletteReference("TrailUsePlayerPalette")] public readonly string TrailPalette = "effect";
+		public readonly string TrailPalette = "effect";
 
 		[Desc("Use the Player Palette to render the trail sequence.")]
 		public readonly bool TrailUsePlayerPalette = false;

--- a/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
@@ -18,7 +18,8 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Produces an actor without using the standard production queue.")]
 	public class ProduceActorPowerInfo : SupportPowerInfo
 	{
-		[ActorReference, FieldLoader.Require]
+		[ActorReference]
+		[FieldLoader.Require]
 		[Desc("Actors to produce.")]
 		public readonly string[] Actors = null;
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SpawnActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SpawnActorPower.cs
@@ -19,7 +19,8 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Spawns an actor that stays for a limited amount of time.")]
 	public class SpawnActorPowerInfo : SupportPowerInfo
 	{
-		[ActorReference, FieldLoader.Require]
+		[ActorReference]
+		[FieldLoader.Require]
 		[Desc("Actor to spawn.")]
 		public readonly string Actor = null;
 
@@ -29,8 +30,12 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string DeploySound = null;
 
 		public readonly string EffectImage = null;
-		[SequenceReference("EffectImage")] public readonly string EffectSequence = "idle";
-		[PaletteReference] public readonly string EffectPalette = null;
+
+		[SequenceReference("EffectImage")]
+		public readonly string EffectSequence = "idle";
+
+		[PaletteReference]
+		public readonly string EffectPalette = null;
 
 		public override object Create(ActorInitializer init) { return new SpawnActorPower(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
@@ -64,22 +64,37 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Defines to which players the timer is shown.")]
 		public readonly Stance DisplayTimerStances = Stance.None;
 
+		[PaletteReference]
 		[Desc("Palette used for the icon.")]
-		[PaletteReference] public readonly string IconPalette = "chrome";
+		public readonly string IconPalette = "chrome";
 
 		[Desc("Beacons are only supported on the Airstrike, Paratroopers, and Nuke powers")]
 		public readonly bool DisplayBeacon = false;
 
 		public readonly bool BeaconPaletteIsPlayerPalette = true;
-		[PaletteReference("BeaconPaletteIsPlayerPalette")] public readonly string BeaconPalette = "player";
+
+		[PaletteReference("BeaconPaletteIsPlayerPalette")]
+		public readonly string BeaconPalette = "player";
 
 		public readonly string BeaconImage = "beacon";
-		[SequenceReference("BeaconImage")] public readonly string BeaconPoster = null;
-		[PaletteReference] public readonly string BeaconPosterPalette = "chrome";
-		[SequenceReference("BeaconImage")] public readonly string ClockSequence = null;
-		[SequenceReference("BeaconImage")] public readonly string BeaconSequence = null;
-		[SequenceReference("BeaconImage")] public readonly string ArrowSequence = null;
-		[SequenceReference("BeaconImage")] public readonly string CircleSequence = null;
+
+		[SequenceReference("BeaconImage")]
+		public readonly string BeaconPoster = null;
+
+		[PaletteReference]
+		public readonly string BeaconPosterPalette = "chrome";
+
+		[SequenceReference("BeaconImage")]
+		public readonly string ClockSequence = null;
+
+		[SequenceReference("BeaconImage")]
+		public readonly string BeaconSequence = null;
+
+		[SequenceReference("BeaconImage")]
+		public readonly string ArrowSequence = null;
+
+		[SequenceReference("BeaconImage")]
+		public readonly string CircleSequence = null;
 
 		[Desc("Delay after launch, measured in ticks.")]
 		public readonly int BeaconDelay = 0;

--- a/OpenRA.Mods.Common/Traits/TemporaryOwnerManager.cs
+++ b/OpenRA.Mods.Common/Traits/TemporaryOwnerManager.cs
@@ -30,7 +30,8 @@ namespace OpenRA.Mods.Common.Traits
 		Player originalOwner;
 		Player changingOwner;
 
-		[Sync] int remaining = -1;
+		[Sync]
+		int remaining = -1;
 		int duration;
 
 		public TemporaryOwnerManager(Actor self, TemporaryOwnerManagerInfo info)

--- a/OpenRA.Mods.Common/Traits/ThrowsShrapnel.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsShrapnel.cs
@@ -18,7 +18,8 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Throws particles when the actor is destroyed that do damage on impact.")]
 	public class ThrowsShrapnelInfo : ConditionalTraitInfo, IRulesetLoaded
 	{
-		[WeaponReference, FieldLoader.Require]
+		[WeaponReference]
+		[FieldLoader.Require]
 		[Desc("The weapons used for shrapnel.")]
 		public readonly string[] Weapons = { };
 

--- a/OpenRA.Mods.Common/Traits/Tooltip.cs
+++ b/OpenRA.Mods.Common/Traits/Tooltip.cs
@@ -15,7 +15,8 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public abstract class TooltipInfoBase : ConditionalTraitInfo, Requires<IMouseBoundsInfo>
 	{
-		[Translate] public readonly string Name = "";
+		[Translate]
+		public readonly string Name = "";
 	}
 
 	[Desc("Shown in map editor.")]
@@ -27,21 +28,25 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Shown in the build palette widget.")]
 	public class TooltipInfo : TooltipInfoBase, ITooltipInfo
 	{
+		[Translate]
 		[Desc("An optional generic name (i.e. \"Soldier\" or \"Structure\")" +
 			"to be shown to chosen players.")]
-		[Translate] public readonly string GenericName = null;
+		public readonly string GenericName = null;
 
 		[Desc("Prefix generic tooltip name with 'Ally/Neutral/EnemyPrefix'.")]
 		public readonly bool GenericStancePrefix = true;
 
+		[Translate]
 		[Desc("Prefix to display in the tooltip for allied units.")]
-		[Translate] public readonly string AllyPrefix = "Allied";
+		public readonly string AllyPrefix = "Allied";
 
+		[Translate]
 		[Desc("Prefix to display in the tooltip for neutral units.")]
-		[Translate] public readonly string NeutralPrefix = null;
+		public readonly string NeutralPrefix = null;
 
+		[Translate]
 		[Desc("Prefix to display in the tooltip for enemy units.")]
-		[Translate] public readonly string EnemyPrefix = "Enemy";
+		public readonly string EnemyPrefix = "Enemy";
 
 		[Desc("Player stances that the generic name should be shown to.")]
 		public readonly Stance GenericVisibility = Stance.None;

--- a/OpenRA.Mods.Common/Traits/TransformCrusherOnCrush.cs
+++ b/OpenRA.Mods.Common/Traits/TransformCrusherOnCrush.cs
@@ -18,7 +18,9 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Put this on the actor that gets crushed to replace the crusher with a new actor.")]
 	public class TransformCrusherOnCrushInfo : ITraitInfo
 	{
-		[ActorReference, FieldLoader.Require] public readonly string IntoActor = null;
+		[ActorReference]
+		[FieldLoader.Require]
+		public readonly string IntoActor = null;
 
 		public readonly bool SkipMakeAnims = true;
 

--- a/OpenRA.Mods.Common/Traits/TransformOnCapture.cs
+++ b/OpenRA.Mods.Common/Traits/TransformOnCapture.cs
@@ -18,8 +18,12 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Replaces the captured actor with a new one.")]
 	public class TransformOnCaptureInfo : ITraitInfo
 	{
-		[ActorReference, FieldLoader.Require] public readonly string IntoActor = null;
+		[ActorReference]
+		[FieldLoader.Require]
+		public readonly string IntoActor = null;
+
 		public readonly int ForceHealthPercentage = 0;
+
 		public readonly bool SkipMakeAnims = true;
 
 		[Desc("Transform only if the capturer's CaptureTypes overlap with these types. Leave empty to allow all types.")]

--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -19,7 +19,9 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Actor becomes a specified actor type when this trait is triggered.")]
 	public class TransformsInfo : PausableConditionalTraitInfo
 	{
-		[Desc("Actor to transform into."), ActorReference, FieldLoader.Require]
+		[ActorReference]
+		[FieldLoader.Require]
+		[Desc("Actor to transform into.")]
 		public readonly string IntoActor = null;
 
 		[Desc("Offset to spawn the transformed actor relative to the current cell.")]
@@ -48,7 +50,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Cursor to display when unable to (un)deploy the actor.")]
 		public readonly string DeployBlockedCursor = "deploy-blocked";
 
-		[VoiceReference] public readonly string Voice = "Action";
+		[VoiceReference]
+		public readonly string Voice = "Action";
 
 		public override object Create(ActorInitializer init) { return new Transforms(init, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -79,8 +79,12 @@ namespace OpenRA.Mods.Common.Traits
 		IFacing facing;
 		BodyOrientation body;
 
-		[Sync] public int QuantizedFacings = 0;
-		[Sync] public int TurretFacing = 0;
+		[Sync]
+		public int QuantizedFacings = 0;
+
+		[Sync]
+		public int TurretFacing = 0;
+
 		public int? DesiredFacing;
 		int realignTick = 0;
 
@@ -259,7 +263,9 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class TurretFacingInit : IActorInit<int>
 	{
-		[FieldFromYamlKey] readonly int value = 128;
+		[FieldFromYamlKey]
+		readonly int value = 128;
+
 		public TurretFacingInit() { }
 		public TurretFacingInit(int init) { value = init; }
 		public int Value(World world) { return value; }
@@ -269,6 +275,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[DictionaryFromYamlKey]
 		readonly Dictionary<string, int> value = new Dictionary<string, int>();
+
 		public TurretFacingsInit() { }
 		public TurretFacingsInit(Dictionary<string, int> init) { value = init; }
 		public Dictionary<string, int> Value(World world) { return value; }

--- a/OpenRA.Mods.Common/Traits/Voiced.cs
+++ b/OpenRA.Mods.Common/Traits/Voiced.cs
@@ -16,9 +16,10 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("This actor has a voice.")]
 	public class VoicedInfo : ITraitInfo
 	{
+		[VoiceSetReference]
 		[FieldLoader.Require]
 		[Desc("Which voice set to use.")]
-		[VoiceSetReference] public readonly string VoiceSet = null;
+		public readonly string VoiceSet = null;
 
 		[Desc("Multiply volume with this factor.")]
 		public readonly float Volume = 1f;

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromEmbeddedSpritePalette.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromEmbeddedSpritePalette.cs
@@ -20,7 +20,8 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public class PaletteFromEmbeddedSpritePaletteInfo : ITraitInfo, IProvidesCursorPaletteInfo
 	{
-		[FieldLoader.Require, PaletteDefinition]
+		[PaletteDefinition]
+		[FieldLoader.Require]
 		[Desc("Internal palette name")]
 		public readonly string Name = null;
 

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromFile.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromFile.cs
@@ -19,7 +19,8 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Load VGA palette (.pal) registers.")]
 	class PaletteFromFileInfo : ITraitInfo, IProvidesCursorPaletteInfo
 	{
-		[FieldLoader.Require, PaletteDefinition]
+		[PaletteDefinition]
+		[FieldLoader.Require]
 		[Desc("internal palette name")]
 		public readonly string Name = null;
 

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromGimpOrJascFile.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromGimpOrJascFile.cs
@@ -21,7 +21,8 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Load a GIMP .gpl or JASC .pal palette file. Supports per-color alpha. Index 0 is hardcoded to be fully transparent/invisible.")]
 	class PaletteFromGimpOrJascFileInfo : ITraitInfo
 	{
-		[FieldLoader.Require, PaletteDefinition]
+		[PaletteDefinition]
+		[FieldLoader.Require]
 		[Desc("Palette name used internally.")]
 		public readonly string Name = null;
 

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromPaletteWithAlpha.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromPaletteWithAlpha.cs
@@ -19,11 +19,13 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Create a palette by applying alpha transparency to another palette.")]
 	class PaletteFromPaletteWithAlphaInfo : ITraitInfo
 	{
-		[FieldLoader.Require, PaletteDefinition]
+		[PaletteDefinition]
+		[FieldLoader.Require]
 		[Desc("Internal palette name")]
 		public readonly string Name = null;
 
-		[FieldLoader.Require, PaletteReference]
+		[PaletteReference]
+		[FieldLoader.Require]
 		[Desc("The name of the palette to base off.")]
 		public readonly string BasePalette = null;
 

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromPlayerPaletteWithAlpha.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromPlayerPaletteWithAlpha.cs
@@ -19,12 +19,14 @@ namespace OpenRA.Mods.Common.Traits
 	class PaletteFromPlayerPaletteWithAlphaInfo : ITraitInfo
 	{
 		[FieldLoader.Require]
+		[PaletteDefinition(true)]
 		[Desc("The prefix for the resulting player palettes")]
-		[PaletteDefinition(true)] public readonly string BaseName = null;
+		public readonly string BaseName = null;
 
 		[FieldLoader.Require]
+		[PaletteReference(true)]
 		[Desc("The name of the player palette to base off.")]
-		[PaletteReference(true)] public readonly string BasePalette = null;
+		public readonly string BasePalette = null;
 
 		[Desc("Allow palette modifiers to change the palette.")]
 		public readonly bool AllowModifiers = true;

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromPng.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromPng.cs
@@ -20,7 +20,8 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Load a PNG and use its embedded palette.")]
 	class PaletteFromPngInfo : ITraitInfo, IProvidesCursorPaletteInfo
 	{
-		[FieldLoader.Require, PaletteDefinition]
+		[PaletteDefinition]
+		[FieldLoader.Require]
 		[Desc("Internal palette name")]
 		public readonly string Name = null;
 

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromRGBA.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromRGBA.cs
@@ -19,7 +19,8 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Creates a single color palette without any base palette file.")]
 	class PaletteFromRGBAInfo : ITraitInfo
 	{
-		[FieldLoader.Require, PaletteDefinition]
+		[PaletteDefinition]
+		[FieldLoader.Require]
 		[Desc("internal palette name")]
 		public readonly string Name = null;
 

--- a/OpenRA.Mods.Common/Traits/World/ShroudPalette.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudPalette.cs
@@ -20,8 +20,9 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Adds the hard-coded shroud palette to the game")]
 	class ShroudPaletteInfo : ITraitInfo
 	{
+		[PaletteDefinition]
+		[FieldLoader.Require]
 		[Desc("Internal palette name")]
-		[FieldLoader.Require, PaletteDefinition]
 		public readonly string Name = "shroud";
 
 		[Desc("Palette type")]

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -21,25 +21,35 @@ namespace OpenRA.Mods.Common.Traits
 	public class ShroudRendererInfo : ITraitInfo
 	{
 		public readonly string Sequence = "shroud";
-		[SequenceReference("Sequence")] public readonly string[] ShroudVariants = new[] { "shroud" };
-		[SequenceReference("Sequence")] public readonly string[] FogVariants = new[] { "fog" };
+		[SequenceReference("Sequence")]
+		public readonly string[] ShroudVariants = { "shroud" };
 
-		[PaletteReference] public readonly string ShroudPalette = "shroud";
-		[PaletteReference] public readonly string FogPalette = "fog";
+		[SequenceReference("Sequence")]
+		public readonly string[] FogVariants = { "fog" };
+
+		[PaletteReference]
+		public readonly string ShroudPalette = "shroud";
+
+		[PaletteReference]
+		public readonly string FogPalette = "fog";
 
 		[Desc("Bitfield of shroud directions for each frame. Lower four bits are",
 			"corners clockwise from TL; upper four are edges clockwise from top")]
-		public readonly int[] Index = new[] { 12, 9, 8, 3, 1, 6, 4, 2, 13, 11, 7, 14 };
+		public readonly int[] Index = { 12, 9, 8, 3, 1, 6, 4, 2, 13, 11, 7, 14 };
 
 		[Desc("Use the upper four bits when calculating frame")]
 		public readonly bool UseExtendedIndex = false;
 
+		[SequenceReference("Sequence")]
 		[Desc("Override for source art that doesn't define a fully shrouded tile")]
-		[SequenceReference("Sequence")] public readonly string OverrideFullShroud = null;
+		public readonly string OverrideFullShroud = null;
+
 		public readonly int OverrideShroudIndex = 15;
 
+		[SequenceReference("Sequence")]
 		[Desc("Override for source art that doesn't define a fully fogged tile")]
-		[SequenceReference("Sequence")] public readonly string OverrideFullFog = null;
+		public readonly string OverrideFullFog = null;
+
 		public readonly int OverrideFogIndex = 15;
 
 		public readonly BlendMode ShroudBlend = BlendMode.Alpha;

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -36,11 +36,15 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Sprite sequence name")]
 		public readonly string SmokeType = "smoke_m";
-		[SequenceReference("SmokeType")] public readonly string SmokeSequence = "idle";
 
-		[PaletteReference] public readonly string SmokePalette = "effect";
+		[SequenceReference("SmokeType")]
+		public readonly string SmokeSequence = "idle";
 
-		[PaletteReference] public readonly string Palette = TileSet.TerrainPaletteInternalName;
+		[PaletteReference]
+		public readonly string SmokePalette = "effect";
+
+		[PaletteReference]
+		public readonly string Palette = TileSet.TerrainPaletteInternalName;
 
 		[FieldLoader.LoadUsing("LoadInitialSmudges")]
 		public readonly Dictionary<CPos, MapSmudge> InitialSmudges;

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -20,13 +20,15 @@ namespace OpenRA.Mods.Common.Warheads
 {
 	public class CreateEffectWarhead : Warhead
 	{
+		[SequenceReference("Image")]
 		[Desc("List of explosion sequences that can be used.")]
-		[SequenceReference("Image")] public readonly string[] Explosions = new string[0];
+		public readonly string[] Explosions = new string[0];
 
 		[Desc("Image containing explosion effect sequence.")]
 		public readonly string Image = "explosion";
 
-		[Desc("Palette to use for explosion effect."), PaletteReference("UsePlayerPalette")]
+		[PaletteReference("UsePlayerPalette")]
+		[Desc("Palette to use for explosion effect.")]
 		public readonly string ExplosionPalette = "effect";
 
 		[Desc("Remap explosion effect to player color, if art supports it.")]

--- a/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
@@ -19,7 +19,8 @@ namespace OpenRA.Mods.Common.Warheads
 {
 	public class FireClusterWarhead : Warhead, IRulesetLoaded<WeaponInfo>
 	{
-		[WeaponReference, FieldLoader.Require]
+		[WeaponReference]
+		[FieldLoader.Require]
 		[Desc("Has to be defined in weapons.yaml as well.")]
 		public readonly string Weapon = null;
 

--- a/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
@@ -25,7 +25,8 @@ namespace OpenRA.Mods.Common.Widgets
 		public bool DisableKeyRepeat = false;
 		public bool DisableKeySound = false;
 
-		[Translate] public string Text = "";
+		[Translate]
+		public string Text = "";
 		public TextAlign Align = TextAlign.Center;
 		public int LeftMargin = 5;
 		public int RightMargin = 5;
@@ -55,9 +56,13 @@ namespace OpenRA.Mods.Common.Widgets
 		public Action<MouseInput> OnMouseUp = _ => { };
 
 		protected Lazy<TooltipContainerWidget> tooltipContainer;
-		[Translate] public string TooltipText;
+
+		[Translate]
+		public string TooltipText;
 		public Func<string> GetTooltipText;
-		[Translate] public string TooltipDesc;
+
+		[Translate]
+		public string TooltipDesc;
 		public Func<string> GetTooltipDesc;
 
 		// Equivalent to OnMouseUp, but without an input arg

--- a/OpenRA.Mods.Common/Widgets/ImageWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ImageWidget.cs
@@ -26,7 +26,8 @@ namespace OpenRA.Mods.Common.Widgets
 		public Func<string> GetImageName;
 		public Func<string> GetImageCollection;
 
-		[Translate] public string TooltipText;
+		[Translate]
+		public string TooltipText;
 
 		Lazy<TooltipContainerWidget> tooltipContainer;
 		public Func<string> GetTooltipText;

--- a/OpenRA.Mods.Common/Widgets/LabelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LabelWidget.cs
@@ -21,7 +21,8 @@ namespace OpenRA.Mods.Common.Widgets
 
 	public class LabelWidget : Widget
 	{
-		[Translate] public string Text = null;
+		[Translate]
+		public string Text = null;
 		public TextAlign Align = TextAlign.Left;
 		public TextVAlign VAlign = TextVAlign.Middle;
 		public string Font = ChromeMetrics.Get<string>("TextFont");

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -21,7 +21,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	public class ActorEditLogic : ChromeLogic
 	{
 		// Error states define overlapping bits to simplify panel reflow logic
-		[Flags] enum ActorIDStatus { Normal = 0, Duplicate = 1, Empty = 3 }
+		[Flags]
+		enum ActorIDStatus { Normal = 0, Duplicate = 1, Empty = 3 }
 
 		readonly WorldRenderer worldRenderer;
 		readonly EditorActorLayer editorActorLayer;

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -66,9 +66,14 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public readonly bool DrawTime = true;
 
-		[Translate] public readonly string ReadyText = "";
-		[Translate] public readonly string HoldText = "";
-		[Translate] public readonly string InfiniteSymbol = "\u221E";
+		[Translate]
+		public readonly string ReadyText = "";
+
+		[Translate]
+		public readonly string HoldText = "";
+
+		[Translate]
+		public readonly string InfiniteSymbol = "\u221E";
 
 		public int DisplayedIconCount { get; private set; }
 		public int TotalIconCount { get; private set; }

--- a/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
@@ -22,8 +22,11 @@ namespace OpenRA.Mods.Common.Widgets
 {
 	public class SupportPowersWidget : Widget
 	{
-		[Translate] public readonly string ReadyText = "";
-		[Translate] public readonly string HoldText = "";
+		[Translate]
+		public readonly string ReadyText = "";
+
+		[Translate]
+		public readonly string HoldText = "";
 
 		public readonly int2 IconSize = new int2(64, 48);
 		public readonly int IconMargin = 10;

--- a/OpenRA.Mods.D2k/Traits/Render/WithCrumbleOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithCrumbleOverlay.cs
@@ -19,11 +19,13 @@ namespace OpenRA.Mods.D2k.Traits.Render
 	[Desc("Rendered together with the \"make\" animation.")]
 	public class WithCrumbleOverlayInfo : ConditionalTraitInfo, Requires<RenderSpritesInfo>
 	{
+		[SequenceReference]
 		[Desc("Sequence name to use")]
-		[SequenceReference] public readonly string Sequence = "crumble-overlay";
+		public readonly string Sequence = "crumble-overlay";
 
+		[PaletteReference("IsPlayerPalette")]
 		[Desc("Custom palette name")]
-		[PaletteReference("IsPlayerPalette")] public readonly string Palette = null;
+		public readonly string Palette = null;
 
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;

--- a/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
+++ b/OpenRA.Mods.D2k/Traits/Render/WithDeliveryOverlay.cs
@@ -19,14 +19,16 @@ namespace OpenRA.Mods.D2k.Traits.Render
 	[Desc("Rendered when ProductionAirdrop is in progress.")]
 	public class WithDeliveryOverlayInfo : PausableConditionalTraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
+		[SequenceReference]
 		[Desc("Sequence name to use")]
-		[SequenceReference] public readonly string Sequence = "active";
+		public readonly string Sequence = "active";
 
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
+		[PaletteReference("IsPlayerPalette")]
 		[Desc("Custom palette name")]
-		[PaletteReference("IsPlayerPalette")] public readonly string Palette = null;
+		public readonly string Palette = null;
 
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;

--- a/OpenRA.Mods.D2k/Traits/World/D2kFogPalette.cs
+++ b/OpenRA.Mods.D2k/Traits/World/D2kFogPalette.cs
@@ -18,11 +18,13 @@ namespace OpenRA.Mods.D2k.Traits
 {
 	class D2kFogPaletteInfo : ITraitInfo
 	{
-		[FieldLoader.Require, PaletteDefinition]
+		[PaletteDefinition]
+		[FieldLoader.Require]
 		[Desc("Internal palette name")]
 		public readonly string Name = null;
 
-		[FieldLoader.Require, PaletteReference]
+		[PaletteReference]
+		[FieldLoader.Require]
 		[Desc("The name of the shroud palette to base off.")]
 		public readonly string BasePalette = null;
 

--- a/OpenRA.Mods.D2k/Traits/World/D2kResourceLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/D2kResourceLayer.cs
@@ -25,7 +25,8 @@ namespace OpenRA.Mods.D2k.Traits
 
 	public class D2kResourceLayer : ResourceLayer
 	{
-		[Flags] public enum ClearSides : byte
+		[Flags]
+		public enum ClearSides : byte
 		{
 			None = 0x0,
 			Left = 0x1,

--- a/OpenRA.Mods.D2k/Traits/World/PaletteFromScaledPalette.cs
+++ b/OpenRA.Mods.D2k/Traits/World/PaletteFromScaledPalette.cs
@@ -20,11 +20,13 @@ namespace OpenRA.Mods.D2k.Traits
 	[Desc("Create a palette by applying a scale and offset to the colors in another palette.")]
 	class PaletteFromScaledPaletteInfo : ITraitInfo
 	{
-		[FieldLoader.Require, PaletteDefinition]
+		[PaletteDefinition]
+		[FieldLoader.Require]
 		[Desc("Internal palette name")]
 		public readonly string Name = null;
 
-		[FieldLoader.Require, PaletteReference]
+		[PaletteReference]
+		[FieldLoader.Require]
 		[Desc("The name of the palette to base off.")]
 		public readonly string BasePalette = null;
 

--- a/OpenRA.ruleset
+++ b/OpenRA.ruleset
@@ -41,8 +41,6 @@
     <Rule Id="SA1128" Action="None" /><!-- ConstructorInitializerMustBeOnOwnLine -->
     <Rule Id="SA1129" Action="None" /><!-- DoNotUseDefaultValueTypeConstructor -->
     <Rule Id="SA1132" Action="None" /><!-- DoNotCombineFields -->
-    <Rule Id="SA1133" Action="None" /><!-- DoNotCombineAttributes -->
-    <Rule Id="SA1134" Action="None" /><!-- AttributesMustNotShareLine -->
     <Rule Id="SA1204" Action="None" /><!-- StaticElementsMustAppearBeforeInstanceElements -->
     <Rule Id="SA1214" Action="None" /><!-- ReadonlyElementsMustAppearBeforeNonReadonlyElements -->
     <Rule Id="SA1413" Action="None" /><!-- UseTrailingCommasInMultiLineInitializers -->


### PR DESCRIPTION
Followup to #16506.

This enables the style checks [DoNotCombineAttributes](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1133.md) and [AttributesMustNotShareLine](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1134.md).

There are a couple of cases (mainly the `[Sync]` annotations) that i'm not entirely keen on, but the overall win in readability and consistency is still IMO worthwhile.

I've tried to follow the ordering `[*Reference]`, `[Fieldloader.Require]`, `[Desc]` in traitinfos.