### PR TITLE
Minor Cyborg Reaper preparations

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -68,8 +68,11 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Width of projectile (used for finding blocking actors).")]
 		public readonly WDist Width = new WDist(1);
 
-		[Desc("Maximum offset at the maximum range")]
+		[Desc("Maximum inaccuracy offset at the maximum range")]
 		public readonly WDist Inaccuracy = WDist.Zero;
+
+		[Desc("Inaccuracy override when sucessfully locked onto target. Defaults to Inaccuracy if negative.")]
+		public readonly WDist LockOnInaccuracy = new WDist(-1);
 
 		[Desc("Probability of locking onto and following target.")]
 		public readonly int LockOnProbability = 100;
@@ -219,9 +222,13 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			var world = args.SourceActor.World;
 
-			if (info.Inaccuracy.Length > 0)
+			if (world.SharedRandom.Next(100) <= info.LockOnProbability)
+				lockOn = true;
+
+			var inaccuracy = lockOn && info.LockOnInaccuracy.Length > -1 ? info.LockOnInaccuracy.Length : info.Inaccuracy.Length;
+			if (inaccuracy > 0)
 			{
-				var inaccuracy = Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
+				inaccuracy = Util.ApplyPercentageModifiers(inaccuracy, args.InaccuracyModifiers);
 				offset = WVec.FromPDF(world.SharedRandom, 2) * inaccuracy / 1024;
 			}
 
@@ -230,9 +237,6 @@ namespace OpenRA.Mods.Common.Projectiles
 			velocity = new WVec(0, -speed, 0)
 				.Rotate(new WRot(WAngle.FromFacing(vFacing), WAngle.Zero, WAngle.Zero))
 				.Rotate(new WRot(WAngle.Zero, WAngle.Zero, WAngle.FromFacing(hFacing)));
-
-			if (world.SharedRandom.Next(100) <= info.LockOnProbability)
-				lockOn = true;
 
 			if (!string.IsNullOrEmpty(info.Image))
 			{

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -74,12 +74,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 			// Cache the bounds from the default sequence to avoid flickering when the animation changes
 			boundsAnimation = new Animation(init.World, rs.GetImage(init.Self), baseFacing, paused);
 			boundsAnimation.PlayRepeating(info.Sequence);
-
-			if (info.StartSequence != null)
-				PlayCustomAnimation(init.Self, info.StartSequence,
-					() => DefaultAnimation.PlayRepeating(NormalizeSequence(init.Self, info.Sequence)));
-			else
-				DefaultAnimation.PlayRepeating(NormalizeSequence(init.Self, info.Sequence));
 		}
 
 		public string NormalizeSequence(Actor self, string sequence)
@@ -89,7 +83,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		protected override void TraitEnabled(Actor self)
 		{
-			DefaultAnimation.PlayRepeating(NormalizeSequence(self, Info.Sequence));
+			if (Info.StartSequence != null)
+				PlayCustomAnimation(self, Info.StartSequence,
+					() => DefaultAnimation.PlayRepeating(NormalizeSequence(self, Info.Sequence)));
+			else
+				DefaultAnimation.PlayRepeating(NormalizeSequence(self, Info.Sequence));
 		}
 
 		public virtual void PlayCustomAnimation(Actor self, string name, Action after = null)


### PR DESCRIPTION
Split from #16525 to reduce its diff.

`LockOnInaccuracy` may or may not get used by the Cyborg Reapers' missiles, but I could definitely use it in my MechWars mod, too. Other modders might want this as well.

The `WithSpriteBody.StartSequence` now behaves like I'd expect it to from a conditional trait (in fact, I was caught a bit off-guard by the fact that it didn't already).