### PR TITLE
Add DisableActorsPreview and DisableFootprint to PlaceBuilding trait

### DIFF
--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -64,11 +64,14 @@ namespace OpenRA.Mods.Common.Orders
 			faction = buildableInfo.ForceFaction
 				?? (mostLikelyProducer.Trait != null ? mostLikelyProducer.Trait.Faction : queue.Actor.Owner.Faction.InternalName);
 
-			if (map.Rules.Sequences.HasSequence("overlay", "build-valid-{0}".F(tileset)))
-				buildOk = map.Rules.Sequences.GetSequence("overlay", "build-valid-{0}".F(tileset)).GetSprite(0);
-			else
-				buildOk = map.Rules.Sequences.GetSequence("overlay", "build-valid").GetSprite(0);
-			buildBlocked = map.Rules.Sequences.GetSequence("overlay", "build-invalid").GetSprite(0);
+			if (!placeBuildingInfo.DisableFootprint)
+			{
+				if (map.Rules.Sequences.HasSequence("overlay", "build-valid-{0}".F(tileset)))
+					buildOk = map.Rules.Sequences.GetSequence("overlay", "build-valid-{0}".F(tileset)).GetSprite(0);
+				else
+					buildOk = map.Rules.Sequences.GetSequence("overlay", "build-valid").GetSprite(0);
+				buildBlocked = map.Rules.Sequences.GetSequence("overlay", "build-invalid").GetSprite(0);
+			}
 
 			buildingInfluence = world.WorldActor.Trait<BuildingInfluence>();
 		}
@@ -236,10 +239,13 @@ namespace OpenRA.Mods.Common.Orders
 				foreach (var r in previewRenderables)
 					yield return r;
 
-				var res = world.WorldActor.TraitOrDefault<ResourceLayer>();
-				var isCloseEnough = buildingInfo.IsCloseEnoughToBase(world, world.LocalPlayer, actorInfo, topLeft);
-				foreach (var t in buildingInfo.Tiles(topLeft))
-					cells.Add(t, MakeCellType(isCloseEnough && world.IsCellBuildable(t, actorInfo, buildingInfo) && (res == null || res.GetResource(t) == null)));
+				if (!placeBuildingInfo.DisableFootprint)
+				{
+					var res = world.WorldActor.TraitOrDefault<ResourceLayer>();
+					var isCloseEnough = buildingInfo.IsCloseEnoughToBase(world, world.LocalPlayer, actorInfo, topLeft);
+					foreach (var t in buildingInfo.Tiles(topLeft))
+						cells.Add(t, MakeCellType(isCloseEnough && world.IsCellBuildable(t, actorInfo, buildingInfo) && (res == null || res.GetResource(t) == null)));
+				}
 			}
 
 			var cellPalette = wr.Palette(placeBuildingInfo.Palette);

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -212,14 +212,19 @@ namespace OpenRA.Mods.Common.Orders
 						new OwnerInit(queue.Actor.Owner),
 					};
 
-					foreach (var api in actorInfo.TraitInfos<IActorPreviewInitInfo>())
-						foreach (var o in api.ActorPreviewInits(actorInfo, ActorPreviewType.PlaceBuilding))
-							td.Add(o);
+					if (!placeBuildingInfo.DisableActorPreview)
+					{
+						foreach (var api in actorInfo.TraitInfos<IActorPreviewInitInfo>())
+							foreach (var o in api.ActorPreviewInits(actorInfo, ActorPreviewType.PlaceBuilding))
+								td.Add(o);
 
-					var init = new ActorPreviewInitializer(actorInfo, wr, td);
-					preview = actorInfo.TraitInfos<IRenderActorPreviewInfo>()
-						.SelectMany(rpi => rpi.RenderPreview(init))
-						.ToArray();
+						var init = new ActorPreviewInitializer(actorInfo, wr, td);
+						preview = actorInfo.TraitInfos<IRenderActorPreviewInfo>()
+							.SelectMany(rpi => rpi.RenderPreview(init))
+							.ToArray();
+					}
+					else
+						preview = new IActorPreview[0];
 
 					initialized = true;
 				}

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -33,6 +33,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Disable actor preview during building placement.")]
 		public readonly bool DisableActorPreview = false;
 
+		[Desc("Disable footprint overlay during building placement.")]
+		public readonly bool DisableFootprint = false;
+
 		[NotificationReference("Speech")]
 		[Desc("Notification to play after building placement if new construction options are available.")]
 		public readonly string NewOptionsNotification = null;

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -30,6 +30,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Play NewOptionsNotification this many ticks after building placement.")]
 		public readonly int NewOptionsNotificationDelay = 10;
 
+		[Desc("Disable actor preview during building placement.")]
+		public readonly bool DisableActorPreview = false;
+
 		[NotificationReference("Speech")]
 		[Desc("Notification to play after building placement if new construction options are available.")]
 		public readonly string NewOptionsNotification = null;


### PR DESCRIPTION
Closes #16538 

To test, modify /mods/d2k/rules/player.yaml and add `DisableActorPreview` to `PlaceBuilding` trait  
```
	PlaceBuilding:
		DisableActorPreview: True
```

Original:
![current](https://user-images.githubusercontent.com/3105609/57798751-17b2d700-7756-11e9-9c2a-6d6988ffcba3.png)

Result should be like that:
![after](https://user-images.githubusercontent.com/3105609/57798757-1aadc780-7756-11e9-87fb-ff7fdb48c395.png)
