### PR TITLE
Empty the default of TrailSequences in NukePower

### DIFF
--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using OpenRA.Effects;
+using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
@@ -101,6 +101,9 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new NukePower(init.Self, this); }
 		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
+			if (!string.IsNullOrEmpty(TrailImage) && !TrailSequences.Any())
+				throw new YamlException("At least one entry in TrailSequences must be defined when TrailImage is defined.");
+
 			WeaponInfo weapon;
 			var weaponToLower = (MissileWeapon ?? string.Empty).ToLowerInvariant();
 			if (!rules.Weapons.TryGetValue(weaponToLower, out weapon))

--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string TrailImage = null;
 
 		[Desc("Loop a randomly chosen sequence of TrailImage from this list while this projectile is moving.")]
-		[SequenceReference("TrailImage")] public readonly string[] TrailSequences = { "idle" };
+		[SequenceReference("TrailImage")] public readonly string[] TrailSequences = { };
 
 		[Desc("Interval in ticks between each spawned Trail animation.")]
 		public readonly int TrailInterval = 1;

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -1164,6 +1164,7 @@ palace:
 		FlightVelocity: 384
 		TrailInterval: 0
 		TrailImage: large_trail
+		TrailSequences: idle
 	ProduceActorPower@fremen:
 		Description: Recruit Fremen
 		LongDesc: Elite infantry unit armed with assault rifles and rockets\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery\n  Special Ability: Invisibility

--- a/mods/ts/rules/nod-support.yaml
+++ b/mods/ts/rules/nod-support.yaml
@@ -376,6 +376,7 @@ NAMISL:
 		TrailImage: small_smoke_trail
 		TrailPalette: effectalpha75
 		TrailInterval: 0
+		TrailSequences: idle
 	WithNukeLaunchOverlay:
 	SelectionDecorations:
 


### PR DESCRIPTION
Closes #16449. (Which was a regression from #16399.)