### PR TITLE
Visualising waypoints 4

### DIFF
--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -23,13 +24,15 @@ namespace OpenRA.Activities
 	{
 		public readonly Target Target;
 		public readonly Color Color;
+		public readonly Sprite Tile;
 
-		public TargetLineNode(Target target, Color color)
+		public TargetLineNode(Target target, Color color, Sprite tile = null)
 		{
 			// Note: Not all activities are drawable. In that case, pass Target.Invalid as target,
 			// if "yield break" in TargetLineNode(Actor self) is not feasible.
 			Target = target;
 			Color = color;
+			Tile = tile;
 		}
 	}
 

--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -12,11 +12,26 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Activities
 {
 	public enum ActivityState { Queued, Active, Canceling, Done }
+
+	public class TargetLineNode
+	{
+		public readonly Target Target;
+		public readonly Color Color;
+
+		public TargetLineNode(Target target, Color color)
+		{
+			// Note: Not all activities are drawable. In that case, pass Target.Invalid as target,
+			// if "yield break" in TargetLineNode(Actor self) is not feasible.
+			Target = target;
+			Color = color;
+		}
+	}
 
 	/*
 	 * Things to be aware of when writing activities:
@@ -200,6 +215,11 @@ namespace OpenRA.Activities
 		}
 
 		public virtual IEnumerable<Target> GetTargets(Actor self)
+		{
+			yield break;
+		}
+
+		public virtual IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
 		{
 			yield break;
 		}

--- a/OpenRA.Game/Graphics/TargetLineRenderable.cs
+++ b/OpenRA.Game/Graphics/TargetLineRenderable.cs
@@ -19,11 +19,15 @@ namespace OpenRA.Graphics
 	{
 		readonly IEnumerable<WPos> waypoints;
 		readonly Color color;
+		readonly int width;
+		readonly int markerSize;
 
-		public TargetLineRenderable(IEnumerable<WPos> waypoints, Color color)
+		public TargetLineRenderable(IEnumerable<WPos> waypoints, Color color, int width = 1, int markerSize = 1)
 		{
 			this.waypoints = waypoints;
 			this.color = color;
+			this.width = width;
+			this.markerSize = markerSize;
 		}
 
 		public WPos Pos { get { return waypoints.First(); } }
@@ -42,23 +46,23 @@ namespace OpenRA.Graphics
 			if (!waypoints.Any())
 				return;
 
-			var iz = 1 / wr.Viewport.Zoom;
+			var sw = width / wr.Viewport.Zoom;
 			var first = wr.Screen3DPosition(waypoints.First());
 			var a = first;
 			foreach (var b in waypoints.Skip(1).Select(pos => wr.Screen3DPosition(pos)))
 			{
-				Game.Renderer.WorldRgbaColorRenderer.DrawLine(a, b, iz, color);
-				DrawTargetMarker(wr, color, b);
+				Game.Renderer.WorldRgbaColorRenderer.DrawLine(a, b, sw, color);
+				DrawTargetMarker(wr, color, b, markerSize);
 				a = b;
 			}
 
 			DrawTargetMarker(wr, color, first);
 		}
 
-		public static void DrawTargetMarker(WorldRenderer wr, Color color, float3 location)
+		public static void DrawTargetMarker(WorldRenderer wr, Color color, float3 location, int size = 1)
 		{
-			var iz = 1 / wr.Viewport.Zoom;
-			var offset = new float2(iz, iz);
+			var sw = size / wr.Viewport.Zoom;
+			var offset = new float2(sw, sw);
 			var tl = location - offset;
 			var br = location + offset;
 			Game.Renderer.WorldRgbaColorRenderer.FillRect(tl, br, color);

--- a/OpenRA.Mods.Cnc/Activities/Infiltrate.cs
+++ b/OpenRA.Mods.Cnc/Activities/Infiltrate.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Cnc.Activities
 		Actor enterActor;
 
 		public Infiltrate(Actor self, Target target, Infiltrates infiltrates)
-			: base(self, target, Color.Red)
+			: base(self, target, Color.Crimson)
 		{
 			this.infiltrates = infiltrates;
 			notifiers = self.TraitsImplementing<INotifyInfiltration>().ToArray();

--- a/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
+++ b/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Cnc.Traits;
@@ -27,6 +28,7 @@ namespace OpenRA.Mods.Cnc.Activities
 		readonly Mobile mobile;
 		readonly bool allowMovement;
 		readonly bool forceAttack;
+		readonly Color? targetLineColor;
 
 		Target target;
 		Target lastVisibleTarget;
@@ -36,9 +38,10 @@ namespace OpenRA.Mods.Cnc.Activities
 		BitSet<TargetableType> lastVisibleTargetTypes;
 		Player lastVisibleOwner;
 
-		public LeapAttack(Actor self, Target target, bool allowMovement, bool forceAttack, AttackLeap attack, AttackLeapInfo info)
+		public LeapAttack(Actor self, Target target, bool allowMovement, bool forceAttack, AttackLeap attack, AttackLeapInfo info, Color? targetLineColor = null)
 		{
 			this.target = target;
+			this.targetLineColor = targetLineColor;
 			this.info = info;
 			this.attack = attack;
 			this.allowMovement = allowMovement;
@@ -88,12 +91,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				lastVisibleTargetTypes = target.Actor.GetEnabledTargetTypes();
 			}
 
-			var oldUseLastVisibleTarget = useLastVisibleTarget;
 			useLastVisibleTarget = targetIsHiddenActor || !target.IsValidFor(self);
-
-			// Update target lines if required
-			if (useLastVisibleTarget != oldUseLastVisibleTarget)
-				self.SetTargetLine(useLastVisibleTarget ? lastVisibleTarget : target, Color.Red, false);
 
 			// Target is hidden or dead, and we don't have a fallback position to move towards
 			if (useLastVisibleTarget && !lastVisibleTarget.IsValidFor(self))
@@ -160,6 +158,12 @@ namespace OpenRA.Mods.Cnc.Activities
 
 			if (!autoTarget.HasValidTargetPriority(self, lastVisibleOwner, lastVisibleTargetTypes))
 				target = Target.Invalid;
+		}
+
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			if (targetLineColor != null)
+				yield return new TargetLineNode(useLastVisibleTarget ? lastVisibleTarget : target, targetLineColor.Value);
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackLeap.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackLeap.cs
@@ -12,6 +12,7 @@
 using OpenRA.Activities;
 using OpenRA.Mods.Cnc.Activities;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
@@ -71,9 +72,9 @@ namespace OpenRA.Mods.Cnc.Traits
 				leapToken = conditionManager.RevokeCondition(self, leapToken);
 		}
 
-		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack)
+		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
 		{
-			return new LeapAttack(self, newTarget, allowMove, forceAttack, this, info);
+			return new LeapAttack(self, newTarget, allowMove, forceAttack, this, info, targetLineColor);
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTDGunboatTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTDGunboatTurreted.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					hasTicked = true;
 				}
 
-				return true;
+				return false;
 			}
 		}
 	}

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTDGunboatTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTDGunboatTurreted.cs
@@ -9,9 +9,12 @@
  */
 #endregion
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
@@ -27,9 +30,9 @@ namespace OpenRA.Mods.Cnc.Traits
 		public AttackTDGunboatTurreted(Actor self, AttackTDGunboatTurretedInfo info)
 			: base(self, info) { }
 
-		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack)
+		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
 		{
-			return new AttackTDGunboatTurretedActivity(self, newTarget, allowMove, forceAttack);
+			return new AttackTDGunboatTurretedActivity(self, newTarget, allowMove, forceAttack, targetLineColor);
 		}
 
 		class AttackTDGunboatTurretedActivity : Activity
@@ -37,13 +40,15 @@ namespace OpenRA.Mods.Cnc.Traits
 			readonly AttackTDGunboatTurreted attack;
 			readonly Target target;
 			readonly bool forceAttack;
+			readonly Color? targetLineColor;
 			bool hasTicked;
 
-			public AttackTDGunboatTurretedActivity(Actor self, Target target, bool allowMove, bool forceAttack)
+			public AttackTDGunboatTurretedActivity(Actor self, Target target, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 			{
 				attack = self.Trait<AttackTDGunboatTurreted>();
 				this.target = target;
 				this.forceAttack = forceAttack;
+				this.targetLineColor = targetLineColor;
 			}
 
 			public override bool Tick(Actor self)
@@ -67,6 +72,12 @@ namespace OpenRA.Mods.Cnc.Traits
 				}
 
 				return false;
+			}
+
+			public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+			{
+				if (targetLineColor != null)
+					yield return new TargetLineNode(target, targetLineColor.Value);
 			}
 		}
 	}

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
@@ -9,9 +9,11 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
@@ -76,9 +78,9 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel) { }
 
-		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack)
+		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 		{
-			return new ChargeAttack(this, newTarget, forceAttack);
+			return new ChargeAttack(this, newTarget, forceAttack, targetLineColor);
 		}
 
 		class ChargeAttack : Activity, IActivityNotifyStanceChanged
@@ -86,12 +88,14 @@ namespace OpenRA.Mods.Cnc.Traits
 			readonly AttackTesla attack;
 			readonly Target target;
 			readonly bool forceAttack;
+			readonly Color? targetLineColor;
 
-			public ChargeAttack(AttackTesla attack, Target target, bool forceAttack)
+			public ChargeAttack(AttackTesla attack, Target target, bool forceAttack, Color? targetLineColor = null)
 			{
 				this.attack = attack;
 				this.target = target;
 				this.forceAttack = forceAttack;
+				this.targetLineColor = targetLineColor;
 			}
 
 			public override bool Tick(Actor self)
@@ -131,6 +135,12 @@ namespace OpenRA.Mods.Cnc.Traits
 					if (!autoTarget.HasValidTargetPriority(self, fa.Owner, fa.TargetTypes))
 						Cancel(self, true);
 				}
+			}
+
+			public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+			{
+				if (targetLineColor != null)
+					yield return new TargetLineNode(target, targetLineColor.Value);
 			}
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
@@ -117,8 +117,8 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (!order.Queued)
 				self.CancelActivity();
 
-			self.SetTargetLine(order.Target, Color.Red);
 			self.QueueActivity(new Infiltrate(self, order.Target, this));
+			self.ShowTargetLines();
 		}
 	}
 

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -141,8 +141,8 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			if (order.OrderString == "DetonateAttack")
 			{
-				self.SetTargetLine(order.Target, Color.Red);
 				self.QueueActivity(order.Queued, new DetonationSequence(self, this, order.Target));
+				self.ShowTargetLines();
 			}
 			else if (order.OrderString == "Detonate")
 				self.QueueActivity(order.Queued, new DetonationSequence(self, this));
@@ -246,6 +246,11 @@ namespace OpenRA.Mods.Cnc.Traits
 
 					self.Kill(self, mad.info.DamageTypes);
 				});
+			}
+
+			public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+			{
+				yield return new TargetLineNode(target, Color.Crimson);
 			}
 
 			void EjectDriver()

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -112,10 +112,9 @@ namespace OpenRA.Mods.Cnc.Traits
 				Minefield = GetMinefieldCells(minefieldStart, cell, info.MinefieldDepth)
 					.Where(p => movement.CanEnterCell(p, null, false)).ToArray();
 
-				if (Minefield.Length == 1 && Minefield[0] != self.Location)
-					self.SetTargetLine(Target.FromCell(self.World, Minefield[0]), Color.Red);
-
 				self.QueueActivity(order.Queued, new LayMines(self, Minefield));
+				if (Minefield.Length == 1 && Minefield[0] != self.Location)
+					self.ShowTargetLines();
 			}
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
@@ -114,12 +114,12 @@ namespace OpenRA.Mods.Cnc.Traits
 					self.CancelActivity();
 
 				var cell = self.World.Map.CellContaining(order.Target.CenterPosition);
-				self.SetTargetLine(order.Target, Color.LawnGreen);
 				if (maxDistance != null)
-					self.QueueActivity(move.MoveWithinRange(order.Target, WDist.FromCells(maxDistance.Value)));
+					self.QueueActivity(move.MoveWithinRange(order.Target, WDist.FromCells(maxDistance.Value), targetLineColor: Color.LawnGreen));
 
 				self.QueueActivity(new Teleport(self, cell, maxDistance, Info.KillCargo, Info.FlashScreen, Info.ChronoshiftSound));
-				self.QueueActivity(move.MoveTo(cell, 5));
+				self.QueueActivity(move.MoveTo(cell, 5, Color.LawnGreen));
+				self.ShowTargetLines();
 			}
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -183,8 +183,8 @@ namespace OpenRA.Mods.Cnc.Traits
 			self.World.UpdateMaps(self, this);
 		}
 
-		public Activity MoveTo(CPos cell, int nearEnough) { return null; }
-		public Activity MoveTo(CPos cell, Actor ignoreActor) { return null; }
+		public Activity MoveTo(CPos cell, int nearEnough, Color? targetLineColor = null) { return null; }
+		public Activity MoveTo(CPos cell, Actor ignoreActor, Color? targetLineColor = null) { return null; }
 		public Activity MoveWithinRange(Target target, WDist range,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null) { return null; }
 		public Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange,

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -139,12 +139,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (!targetIsHiddenActor && target.Type == TargetType.Actor)
 				lastVisibleTarget = Target.FromTargetPositions(target);
 
-			var oldUseLastVisibleTarget = useLastVisibleTarget;
 			useLastVisibleTarget = targetIsHiddenActor || !target.IsValidFor(self);
-
-			// Update target lines if required
-			if (useLastVisibleTarget != oldUseLastVisibleTarget && targetLineColor.HasValue)
-				self.SetTargetLine(useLastVisibleTarget ? lastVisibleTarget : target, targetLineColor.Value, false);
 
 			// Target is hidden or dead, and we don't have a fallback position to move towards
 			if (useLastVisibleTarget && !lastVisibleTarget.IsValidFor(self))
@@ -226,6 +221,12 @@ namespace OpenRA.Mods.Common.Activities
 		public override IEnumerable<Target> GetTargets(Actor self)
 		{
 			yield return target;
+		}
+
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			if (targetLineColor.HasValue)
+				yield return new TargetLineNode(useLastVisibleTarget ? lastVisibleTarget : target, targetLineColor.Value);
 		}
 
 		public static int CalculateTurnRadius(int speed, int turnSpeed)

--- a/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
@@ -59,7 +60,6 @@ namespace OpenRA.Mods.Common.Activities
 			if (!targetIsHiddenActor && target.Type == TargetType.Actor)
 				lastVisibleTarget = Target.FromTargetPositions(target);
 
-			var oldUseLastVisibleTarget = useLastVisibleTarget;
 			useLastVisibleTarget = targetIsHiddenActor || !target.IsValidFor(self);
 
 			// If we are ticking again after previously sequencing a MoveWithRange then that move must have completed
@@ -68,10 +68,6 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 
 			wasMovingWithinRange = false;
-
-			// Update target lines if required
-			if (useLastVisibleTarget != oldUseLastVisibleTarget && targetLineColor.HasValue)
-				self.SetTargetLine(useLastVisibleTarget ? lastVisibleTarget : target, targetLineColor.Value, false);
 
 			// Target is hidden or dead, and we don't have a fallback position to move towards
 			if (useLastVisibleTarget && !lastVisibleTarget.IsValidFor(self))
@@ -93,6 +89,12 @@ namespace OpenRA.Mods.Common.Activities
 			wasMovingWithinRange = true;
 			QueueChild(aircraft.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, targetLineColor));
 			return false;
+		}
+
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			if (targetLineColor != null)
+				yield return new TargetLineNode(useLastVisibleTarget ? lastVisibleTarget : target, targetLineColor.Value);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
@@ -25,6 +26,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly bool assignTargetOnFirstRun;
 		readonly CPos[] clearCells;
 		readonly WDist landRange;
+		readonly Color? targetLineColor;
 
 		Target target;
 		WPos targetPosition;
@@ -32,28 +34,29 @@ namespace OpenRA.Mods.Common.Activities
 		bool landingInitiated;
 		bool finishedApproach;
 
-		public Land(Actor self, int facing = -1)
+		public Land(Actor self, int facing = -1, Color? targetLineColor = null)
 			: this(self, Target.Invalid, new WDist(-1), WVec.Zero, facing, null)
 		{
 			assignTargetOnFirstRun = true;
 		}
 
-		public Land(Actor self, Target target, int facing = -1)
-			: this(self, target, new WDist(-1), WVec.Zero, facing) { }
+		public Land(Actor self, Target target, int facing = -1, Color? targetLineColor = null)
+			: this(self, target, new WDist(-1), WVec.Zero, facing, targetLineColor: targetLineColor) { }
 
-		public Land(Actor self, Target target, WDist landRange, int facing = -1)
-			: this(self, target, landRange, WVec.Zero, facing) { }
+		public Land(Actor self, Target target, WDist landRange, int facing = -1, Color? targetLineColor = null)
+			: this(self, target, landRange, WVec.Zero, facing, targetLineColor: targetLineColor) { }
 
-		public Land(Actor self, Target target, WVec offset, int facing = -1)
-			: this(self, target, WDist.Zero, offset, facing) { }
+		public Land(Actor self, Target target, WVec offset, int facing = -1, Color? targetLineColor = null)
+			: this(self, target, WDist.Zero, offset, facing, targetLineColor: targetLineColor) { }
 
-		public Land(Actor self, Target target, WDist landRange, WVec offset, int facing = -1, CPos[] clearCells = null)
+		public Land(Actor self, Target target, WDist landRange, WVec offset, int facing = -1, CPos[] clearCells = null, Color? targetLineColor = null)
 		{
 			aircraft = self.Trait<Aircraft>();
 			this.target = target;
 			this.offset = offset;
 			this.clearCells = clearCells ?? new CPos[0];
 			this.landRange = landRange.Length >= 0 ? landRange : aircraft.Info.LandRange;
+			this.targetLineColor = targetLineColor;
 
 			// NOTE: desiredFacing = -1 means we should not prefer any particular facing and instead just
 			// use whatever facing gives us the most direct path to the landing site.
@@ -255,6 +258,12 @@ namespace OpenRA.Mods.Common.Activities
 			Fly.FlyTick(self, aircraft, d.Yaw.Facing, landingAlt);
 
 			return false;
+		}
+
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			if (targetLineColor != null)
+				yield return new TargetLineNode(target, targetLineColor.Value);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -119,14 +119,22 @@ namespace OpenRA.Mods.Common.Activities
 					facing = 192;
 
 				aircraft.MakeReservation(dest);
-				QueueChild(new Land(self, Target.FromActor(dest), offset, facing));
+				QueueChild(new Land(self, Target.FromActor(dest), offset, facing, Color.Green));
 				QueueChild(new Resupply(self, dest, WDist.Zero, alwaysLand));
-
 				return true;
 			}
 
 			QueueChild(new Fly(self, Target.FromActor(dest)));
 			return true;
+		}
+
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			if (ChildActivity == null)
+				yield return new TargetLineNode(Target.FromActor(dest), Color.Green);
+			else
+				foreach (var n in ChildActivity.TargetLineNodes(self))
+					yield return n;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/CaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/CaptureActor.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 		CaptureManager enterCaptureManager;
 
 		public CaptureActor(Actor self, Target target)
-			: base(self, target, Color.Red)
+			: base(self, target, Color.Crimson)
 		{
 			manager = self.Trait<CaptureManager>();
 		}

--- a/OpenRA.Mods.Common/Activities/DeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverResources.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
@@ -23,6 +24,8 @@ namespace OpenRA.Mods.Common.Activities
 		readonly Harvester harv;
 		readonly Actor targetActor;
 		readonly INotifyHarvesterAction[] notifyHarvesterActions;
+
+		Actor proc;
 
 		public DeliverResources(Actor self, Actor targetActor = null)
 		{
@@ -54,10 +57,9 @@ namespace OpenRA.Mods.Common.Activities
 				return false;
 			}
 
-			var proc = harv.LinkedProc;
+			proc = harv.LinkedProc;
 			var iao = proc.Trait<IAcceptResources>();
 
-			self.SetTargetLine(Target.FromActor(proc), Color.Green, false);
 			if (self.Location != proc.Location + iao.DeliveryOffset)
 			{
 				foreach (var n in notifyHarvesterActions)
@@ -78,6 +80,14 @@ namespace OpenRA.Mods.Common.Activities
 				n.MovementCancelled(self);
 
 			base.Cancel(self, keepQueue);
+		}
+
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			if (proc != null)
+				yield return new TargetLineNode(Target.FromActor(proc), Color.Green);
+			else
+				yield return new TargetLineNode(Target.FromActor(harv.LinkedProc), Color.Green);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -9,8 +9,10 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
@@ -54,6 +56,11 @@ namespace OpenRA.Mods.Common.Activities
 			QueueChild(new Wait(carryall.Info.BeforeUnloadDelay, false));
 			QueueChild(new ReleaseUnit(self));
 			QueueChild(new TakeOff(self));
+		}
+
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			yield return new TargetLineNode(destination, Color.Yellow);
 		}
 
 		class ReleaseUnit : Activity

--- a/OpenRA.Mods.Common/Activities/Demolish.cs
+++ b/OpenRA.Mods.Common/Activities/Demolish.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Demolish(Actor self, Target target, EnterBehaviour enterBehaviour, int delay,
 			int flashes, int flashesDelay, int flashInterval)
-			: base(self, target, Color.Red)
+			: base(self, target, Color.Crimson)
 		{
 			notifiers = self.TraitsImplementing<INotifyDemolition>().ToArray();
 			this.delay = delay;

--- a/OpenRA.Mods.Common/Activities/Enter.cs
+++ b/OpenRA.Mods.Common/Activities/Enter.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
@@ -74,10 +75,6 @@ namespace OpenRA.Mods.Common.Activities
 				Cancel(self, true);
 
 			TickInner(self, target, useLastVisibleTarget);
-
-			// Update target lines if required
-			if (useLastVisibleTarget != oldUseLastVisibleTarget && targetLineColor.HasValue)
-				self.SetTargetLine(useLastVisibleTarget ? lastVisibleTarget : target, targetLineColor.Value, false);
 
 			// We need to wait for movement to finish before transitioning to
 			// the next state or next activity
@@ -145,6 +142,12 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			return false;
+		}
+
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			if (targetLineColor != null)
+				yield return new TargetLineNode(useLastVisibleTarget ? lastVisibleTarget : target, targetLineColor.Value);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/EnterTransport.cs
+++ b/OpenRA.Mods.Common/Activities/EnterTransport.cs
@@ -9,9 +9,6 @@
  */
 #endregion
 
-using System;
-using System.Linq;
-using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Activities/HarvestResource.cs
+++ b/OpenRA.Mods.Common/Activities/HarvestResource.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
@@ -61,7 +62,6 @@ namespace OpenRA.Mods.Common.Activities
 				foreach (var n in notifyHarvesterActions)
 					n.MovingToResources(self, targetCell);
 
-				self.SetTargetLine(Target.FromCell(self.World, targetCell), Color.Red, false);
 				QueueChild(move.MoveTo(targetCell, 2));
 				return false;
 			}
@@ -105,6 +105,11 @@ namespace OpenRA.Mods.Common.Activities
 				n.MovementCancelled(self);
 
 			base.Cancel(self, keepQueue);
+		}
+
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			yield return new TargetLineNode(Target.FromCell(self.World, targetCell), Color.Green);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
+++ b/OpenRA.Mods.Common/Activities/HarvesterDockSequence.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
@@ -102,6 +103,11 @@ namespace OpenRA.Mods.Common.Activities
 		public override IEnumerable<Target> GetTargets(Actor self)
 		{
 			yield return Target.FromActor(Refinery);
+		}
+
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			yield return new TargetLineNode(Target.FromActor(Refinery), Color.Green);
 		}
 
 		public abstract void OnStateDock(Actor self);

--- a/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
+++ b/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
@@ -92,5 +92,13 @@ namespace OpenRA.Mods.Common.Activities
 
 			return Target.None;
 		}
+
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			foreach (var n in getInner().TargetLineNodes(self))
+				yield return n;
+
+			yield break;
+		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Move/Drag.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Drag.cs
@@ -12,6 +12,7 @@
 using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
@@ -61,6 +62,11 @@ namespace OpenRA.Mods.Common.Activities
 		public override IEnumerable<Target> GetTargets(Actor self)
 		{
 			yield return Target.FromPos(end);
+		}
+
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			yield return new TargetLineNode(Target.FromPos(end), Color.Green);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Move/Follow.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Follow.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
@@ -55,7 +56,6 @@ namespace OpenRA.Mods.Common.Activities
 			if (!targetIsHiddenActor && target.Type == TargetType.Actor)
 				lastVisibleTarget = Target.FromTargetPositions(target);
 
-			var oldUseLastVisibleTarget = useLastVisibleTarget;
 			useLastVisibleTarget = targetIsHiddenActor || !target.IsValidFor(self);
 
 			// If we are ticking again after previously sequencing a MoveWithRange then that move must have completed
@@ -64,10 +64,6 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 
 			wasMovingWithinRange = false;
-
-			// Update target lines if required
-			if (useLastVisibleTarget != oldUseLastVisibleTarget && targetLineColor.HasValue)
-				self.SetTargetLine(useLastVisibleTarget ? lastVisibleTarget : target, targetLineColor.Value, false);
 
 			// Target is hidden or dead, and we don't have a fallback position to move towards
 			if (useLastVisibleTarget && !lastVisibleTarget.IsValidFor(self))
@@ -85,6 +81,12 @@ namespace OpenRA.Mods.Common.Activities
 			wasMovingWithinRange = true;
 			QueueChild(move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, targetLineColor));
 			return false;
+		}
+
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			if (targetLineColor != null)
+				yield return new TargetLineNode(useLastVisibleTarget ? lastVisibleTarget : target, targetLineColor.Value);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -29,6 +29,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly WDist nearEnough;
 		readonly Func<List<CPos>> getPath;
 		readonly Actor ignoreActor;
+		readonly Color? targetLineColor;
 
 		List<CPos> path;
 		CPos? destination;
@@ -43,7 +44,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		// Scriptable move order
 		// Ignores lane bias and nearby units
-		public Move(Actor self, CPos destination)
+		public Move(Actor self, CPos destination, Color? targetLineColor = null)
 		{
 			mobile = self.Trait<Mobile>();
 
@@ -57,10 +58,12 @@ namespace OpenRA.Mods.Common.Activities
 				return path;
 			};
 			this.destination = destination;
+			this.targetLineColor = targetLineColor;
 			nearEnough = WDist.Zero;
 		}
 
-		public Move(Actor self, CPos destination, WDist nearEnough, Actor ignoreActor = null, bool evaluateNearestMovableCell = false)
+		public Move(Actor self, CPos destination, WDist nearEnough, Actor ignoreActor = null, bool evaluateNearestMovableCell = false,
+			Color? targetLineColor = null)
 		{
 			mobile = self.Trait<Mobile>();
 
@@ -79,9 +82,10 @@ namespace OpenRA.Mods.Common.Activities
 			this.nearEnough = nearEnough;
 			this.ignoreActor = ignoreActor;
 			this.evaluateNearestMovableCell = evaluateNearestMovableCell;
+			this.targetLineColor = targetLineColor;
 		}
 
-		public Move(Actor self, CPos destination, SubCell subCell, WDist nearEnough)
+		public Move(Actor self, CPos destination, SubCell subCell, WDist nearEnough, Color? targetLineColor = null)
 		{
 			mobile = self.Trait<Mobile>();
 
@@ -89,9 +93,10 @@ namespace OpenRA.Mods.Common.Activities
 				.FindUnitPathToRange(mobile.FromCell, subCell, self.World.Map.CenterOfSubCell(destination, subCell), nearEnough, self);
 			this.destination = destination;
 			this.nearEnough = nearEnough;
+			this.targetLineColor = targetLineColor;
 		}
 
-		public Move(Actor self, Target target, WDist range)
+		public Move(Actor self, Target target, WDist range, Color? targetLineColor = null)
 		{
 			mobile = self.Trait<Mobile>();
 
@@ -106,9 +111,10 @@ namespace OpenRA.Mods.Common.Activities
 
 			destination = null;
 			nearEnough = range;
+			this.targetLineColor = targetLineColor;
 		}
 
-		public Move(Actor self, Func<List<CPos>> getPath)
+		public Move(Actor self, Func<List<CPos>> getPath, Color? targetLineColor = null)
 		{
 			mobile = self.Trait<Mobile>();
 
@@ -116,6 +122,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			destination = null;
 			nearEnough = WDist.Zero;
+			this.targetLineColor = targetLineColor;
 		}
 
 		static int HashList<T>(List<T> xs)
@@ -259,6 +266,12 @@ namespace OpenRA.Mods.Common.Activities
 			if (destination != null)
 				return new Target[] { Target.FromCell(self.World, destination.Value) };
 			return Target.None;
+		}
+
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			if (targetLineColor != null)
+				yield return new TargetLineNode(Target.FromCell(self.World, destination.Value), targetLineColor.Value);
 		}
 
 		abstract class MovePart : Activity

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -99,12 +99,7 @@ namespace OpenRA.Mods.Common.Activities
 			// Target is equivalent to checkTarget variable in other activities
 			// value is either lastVisibleTarget or target based on visibility and validity
 			var targetIsValid = Target.IsValidFor(self);
-			var oldUseLastVisibleTarget = useLastVisibleTarget;
 			useLastVisibleTarget = targetIsHiddenActor || !targetIsValid;
-
-			// Update target lines if required
-			if (useLastVisibleTarget != oldUseLastVisibleTarget && targetLineColor.HasValue)
-				self.SetTargetLine(useLastVisibleTarget ? lastVisibleTarget : target, targetLineColor.Value, false);
 
 			// Target is hidden or dead, and we don't have a fallback position to move towards
 			var noTarget = useLastVisibleTarget && !lastVisibleTarget.IsValidFor(self);
@@ -148,6 +143,12 @@ namespace OpenRA.Mods.Common.Activities
 				return ChildActivity.GetTargets(self);
 
 			return Target.None;
+		}
+
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			if (targetLineColor.HasValue)
+				yield return new TargetLineNode(useLastVisibleTarget ? lastVisibleTarget : target, targetLineColor.Value);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Move/VisualMoveIntoTarget.cs
+++ b/OpenRA.Mods.Common/Activities/Move/VisualMoveIntoTarget.cs
@@ -12,6 +12,7 @@
 using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
@@ -20,14 +21,16 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly Mobile mobile;
 		readonly Target target;
+		readonly Color? targetLineColor;
 		readonly WDist targetMovementThreshold;
 		WPos targetStartPos;
 
-		public VisualMoveIntoTarget(Actor self, Target target, WDist targetMovementThreshold)
+		public VisualMoveIntoTarget(Actor self, Target target, WDist targetMovementThreshold, Color? targetLineColor = null)
 		{
 			mobile = self.Trait<Mobile>();
 			this.target = target;
 			this.targetMovementThreshold = targetMovementThreshold;
+			this.targetLineColor = targetLineColor;
 		}
 
 		protected override void OnFirstRun(Actor self)
@@ -75,6 +78,12 @@ namespace OpenRA.Mods.Common.Activities
 		public override IEnumerable<Target> GetTargets(Actor self)
 		{
 			yield return target;
+		}
+
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			if (targetLineColor != null)
+				yield return new TargetLineNode(target, targetLineColor.Value);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
@@ -79,7 +80,7 @@ namespace OpenRA.Mods.Common.Activities
 			switch (state)
 			{
 				case PickupState.Intercept:
-					QueueChild(movement.MoveWithinRange(Target.FromActor(cargo), WDist.FromCells(4), targetLineColor: Color.Yellow));
+					QueueChild(movement.MoveWithinRange(Target.FromActor(cargo), WDist.FromCells(4)));
 					state = PickupState.LockCarryable;
 					return false;
 
@@ -108,6 +109,11 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			return true;
+		}
+
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			yield return new TargetLineNode(Target.FromActor(cargo), Color.Yellow);
 		}
 
 		class AttachUnit : Activity

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -149,6 +149,15 @@ namespace OpenRA.Mods.Common.Activities
 			base.Cancel(self, keepQueue);
 		}
 
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			if (ChildActivity == null)
+				yield return new TargetLineNode(host, Color.Green);
+			else
+				foreach (var n in ChildActivity.TargetLineNodes(self))
+					yield return n;
+		}
+
 		void OnResupplyEnding(Actor self)
 		{
 			if (aircraft != null)

--- a/OpenRA.Mods.Common/Activities/Transform.cs
+++ b/OpenRA.Mods.Common/Activities/Transform.cs
@@ -9,7 +9,7 @@
  */
 #endregion
 
-using System;
+using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Render;
@@ -149,16 +149,24 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly string orderString;
 		readonly Target target;
+		readonly Color? targetLineColor;
 
-		public IssueOrderAfterTransform(string orderString, Target target)
+		public IssueOrderAfterTransform(string orderString, Target target, Color? targetLineColor = null)
 		{
 			this.orderString = orderString;
 			this.target = target;
+			this.targetLineColor = targetLineColor;
 		}
 
 		public Order IssueOrderForTransformedActor(Actor newActor)
 		{
 			return new Order(orderString, newActor, target, true);
+		}
+
+		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+		{
+			if (targetLineColor != null)
+				yield return new TargetLineNode(target, targetLineColor.Value);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -122,7 +122,6 @@ namespace OpenRA.Mods.Common.Activities
 					actor.CancelActivity();
 					pos.SetVisualPosition(actor, spawn);
 					actor.QueueActivity(move.MoveIntoWorld(actor, exitSubCell.Value.First, exitSubCell.Value.Second));
-					actor.SetTargetLine(Target.FromCell(w, exitSubCell.Value.First, exitSubCell.Value.Second), Color.Green, false);
 					w.Add(actor);
 				});
 			}

--- a/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Effects
 		IEnumerable<IRenderable> RenderInner(WorldRenderer wr)
 		{
 			if (Game.Settings.Game.DrawTargetLine)
-				yield return new TargetLineRenderable(targetLine, building.Owner.Color);
+				yield return new TargetLineRenderable(targetLine, building.Owner.Color, rp.Info.LineWidth);
 
 			if (circles != null || flag != null)
 			{

--- a/OpenRA.Mods.Common/Scripting/Properties/DeliveryProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/DeliveryProperties.cs
@@ -34,8 +34,8 @@ namespace OpenRA.Mods.Common.Scripting
 		public void DeliverCash(Actor target)
 		{
 			var t = Target.FromActor(target);
-			Self.SetTargetLine(t, Color.Yellow);
 			Self.QueueActivity(new DonateCash(Self, t, info.Payload, info.PlayerExperience));
+			Self.ShowTargetLines();
 		}
 	}
 
@@ -66,8 +66,8 @@ namespace OpenRA.Mods.Common.Scripting
 			var level = gainsExperience.Level;
 
 			var t = Target.FromActor(target);
-			Self.SetTargetLine(t, Color.Yellow);
 			Self.QueueActivity(new DonateExperience(Self, t, level, deliversExperience.PlayerExperience));
+			Self.ShowTargetLines();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -830,14 +830,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		#region Implement IMove
 
-		public Activity MoveTo(CPos cell, int nearEnough)
+		public Activity MoveTo(CPos cell, int nearEnough, Color? targetLineColor = null)
 		{
-			return new Fly(self, Target.FromCell(self.World, cell));
+			return new Fly(self, Target.FromCell(self.World, cell), targetLineColor: targetLineColor);
 		}
 
-		public Activity MoveTo(CPos cell, Actor ignoreActor)
+		public Activity MoveTo(CPos cell, Actor ignoreActor, Color? targetLineColor = null)
 		{
-			return new Fly(self, Target.FromCell(self.World, cell));
+			return new Fly(self, Target.FromCell(self.World, cell), targetLineColor: targetLineColor);
 		}
 
 		public Activity MoveWithinRange(Target target, WDist range,
@@ -993,8 +993,8 @@ namespace OpenRA.Mods.Common.Traits
 					UnReserve();
 
 				var target = Target.FromCell(self.World, cell);
-				self.SetTargetLine(target, Color.Green);
-				self.QueueActivity(order.Queued, new Fly(self, target));
+				self.QueueActivity(order.Queued, new Fly(self, target, targetLineColor: Color.Green));
+				self.ShowTargetLines();
 			}
 			else if (orderString == "Land")
 			{
@@ -1007,8 +1007,8 @@ namespace OpenRA.Mods.Common.Traits
 
 				var target = Target.FromCell(self.World, cell);
 
-				self.SetTargetLine(target, Color.Green);
-				self.QueueActivity(order.Queued, new Land(self, target));
+				self.QueueActivity(order.Queued, new Land(self, target, targetLineColor: Color.Green));
+				self.ShowTargetLines();
 			}
 			else if (orderString == "Enter" || orderString == "ForceEnter" || orderString == "Repair")
 			{
@@ -1029,13 +1029,12 @@ namespace OpenRA.Mods.Common.Traits
 				if (!order.Queued)
 					UnReserve();
 
-				self.SetTargetLine(Target.FromActor(targetActor), Color.Green);
-
 				// Aircraft with TakeOffOnResupply would immediately take off again, so there's no point in automatically forcing
 				// them to land on a resupplier. For aircraft without it, it makes more sense to land than to idle above a
 				// free resupplier.
 				var forceLand = isForceEnter || !Info.TakeOffOnResupply;
 				self.QueueActivity(order.Queued, new ReturnToBase(self, targetActor, forceLand));
+				self.ShowTargetLines();
 			}
 			else if (orderString == "Stop")
 			{
@@ -1077,9 +1076,8 @@ namespace OpenRA.Mods.Common.Traits
 				.Rotate(WRot.FromFacing(self.World.SharedRandom.Next(256)));
 			var target = Target.FromPos(self.CenterPosition + offset);
 
-			self.CancelActivity();
-			self.SetTargetLine(target, Color.Green, false);
-			self.QueueActivity(new Fly(self, target));
+			self.QueueActivity(false, new Fly(self, target));
+			self.ShowTargetLines();
 			UnReserve();
 		}
 

--- a/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
@@ -11,6 +11,7 @@
 
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -44,9 +45,9 @@ namespace OpenRA.Mods.Common.Traits
 			aircraftInfo = self.Info.TraitInfo<AircraftInfo>();
 		}
 
-		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack)
+		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 		{
-			return new FlyAttack(self, newTarget, forceAttack);
+			return new FlyAttack(self, newTarget, forceAttack, targetLineColor);
 		}
 
 		protected override bool CanAttack(Actor self, Target target)

--- a/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Linq;
 using OpenRA.Activities;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -85,7 +86,7 @@ namespace OpenRA.Mods.Common.Traits
 			OnRemovedFromWorld(self);
 		}
 
-		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack)
+		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
 		{
 			throw new NotImplementedException("AttackBomber requires a scripted target");
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -30,6 +30,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly string OutsideRangeCursor = null;
 
+		[Desc("Color to use for the target line.")]
+		public readonly Color TargetLineColor = Color.Red;
+
 		[Desc("Does the attack type require the attacker to enter the target's cell?")]
 		public readonly bool AttackRequiresEnteringCell = false;
 
@@ -196,8 +199,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (!order.Target.IsValidFor(self))
 					return;
 
-				self.SetTargetLine(order.Target, Color.Red);
-				AttackTarget(order.Target, order.Queued, true, forceAttack);
+				AttackTarget(order.Target, order.Queued, true, forceAttack, Info.TargetLineColor);
+				self.ShowTargetLines();
 			}
 
 			if (order.OrderString == "Stop")
@@ -221,7 +224,7 @@ namespace OpenRA.Mods.Common.Traits
 			return order.OrderString == attackOrderName || order.OrderString == forceAttackOrderName ? Info.Voice : null;
 		}
 
-		public abstract Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack);
+		public abstract Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null);
 
 		public bool HasAnyValidWeapons(Target t, bool checkForCenterTargetingWeapons = false)
 		{
@@ -388,7 +391,7 @@ namespace OpenRA.Mods.Common.Traits
 				&& a.Weapon.IsValidAgainst(t, self.World, self));
 		}
 
-		public void AttackTarget(Target target, bool queued, bool allowMove, bool forceAttack = false)
+		public void AttackTarget(Target target, bool queued, bool allowMove, bool forceAttack = false, Color? targetLineColor = null)
 		{
 			if (IsTraitDisabled)
 				return;
@@ -399,7 +402,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!queued)
 				self.CancelActivity();
 
-			var activity = GetAttackActivity(self, target, allowMove, forceAttack);
+			var activity = GetAttackActivity(self, target, allowMove, forceAttack, targetLineColor);
 			self.QueueActivity(activity);
 			OnQueueAttackActivity(self, activity, target, allowMove, forceAttack);
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string OutsideRangeCursor = null;
 
 		[Desc("Color to use for the target line.")]
-		public readonly Color TargetLineColor = Color.Red;
+		public readonly Color TargetLineColor = Color.Crimson;
 
 		[Desc("Does the attack type require the attacker to enter the target's cell?")]
 		public readonly bool AttackRequiresEnteringCell = false;

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using OpenRA.Activities;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -41,9 +42,9 @@ namespace OpenRA.Mods.Common.Traits
 			return TargetInFiringArc(self, target, Info.FacingTolerance);
 		}
 
-		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack)
+		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 		{
-			return new Activities.Attack(self, newTarget, allowMove, forceAttack);
+			return new Activities.Attack(self, newTarget, allowMove, forceAttack, targetLineColor);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
@@ -9,8 +9,10 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -25,9 +27,9 @@ namespace OpenRA.Mods.Common.Traits
 		public AttackOmni(Actor self, AttackOmniInfo info)
 			: base(self, info) { }
 
-		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack)
+		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 		{
-			return new SetTarget(this, newTarget, allowMove, forceAttack);
+			return new SetTarget(this, newTarget, allowMove, forceAttack, targetLineColor);
 		}
 
 		// Some 3rd-party mods rely on this being public
@@ -36,11 +38,13 @@ namespace OpenRA.Mods.Common.Traits
 			readonly AttackOmni attack;
 			readonly bool allowMove;
 			readonly bool forceAttack;
+			readonly Color? targetLineColor;
 			Target target;
 
-			public SetTarget(AttackOmni attack, Target target, bool allowMove, bool forceAttack)
+			public SetTarget(AttackOmni attack, Target target, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 			{
 				this.target = target;
+				this.targetLineColor = targetLineColor;
 				this.attack = attack;
 				this.allowMove = allowMove;
 				this.forceAttack = forceAttack;
@@ -76,6 +80,12 @@ namespace OpenRA.Mods.Common.Traits
 					if (!autoTarget.HasValidTargetPriority(self, fa.Owner, fa.TargetTypes))
 						target = Target.Invalid;
 				}
+			}
+
+			public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
+			{
+				if (targetLineColor != null)
+					yield return new TargetLineNode(target, targetLineColor.Value);
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				var targetLocation = move.NearestMoveableCell(cell);
 				var assaultMoving = order.OrderString == "AssaultMove";
-				self.QueueActivity(new AttackMoveActivity(self, () => move.MoveTo(targetLocation, 1, targetLineColor: Color.Red), assaultMoving));
+				self.QueueActivity(new AttackMoveActivity(self, () => move.MoveTo(targetLocation, 1, targetLineColor: Color.OrangeRed), assaultMoving));
 				self.ShowTargetLines();
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -77,9 +77,9 @@ namespace OpenRA.Mods.Common.Traits
 					return;
 
 				var targetLocation = move.NearestMoveableCell(cell);
-				self.SetTargetLine(Target.FromCell(self.World, targetLocation), Color.Red);
 				var assaultMoving = order.OrderString == "AssaultMove";
-				self.QueueActivity(new AttackMoveActivity(self, () => move.MoveTo(targetLocation, 1), assaultMoving));
+				self.QueueActivity(new AttackMoveActivity(self, () => move.MoveTo(targetLocation, 1, targetLineColor: Color.Red), assaultMoving));
+				self.ShowTargetLines();
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -311,8 +311,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		void Attack(Actor self, Target target, bool allowMove)
 		{
-			self.SetTargetLine(target, Color.Red, false);
-
 			foreach (var ab in ActiveAttackBases)
 				ab.AttackTarget(target, false, allowMove);
 		}

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -21,6 +21,9 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public readonly string Image = "rallypoint";
 
+		[Desc("Width (in pixels) of the rallypoint line.")]
+		public readonly int LineWidth = 2;
+
 		[SequenceReference("Image")]
 		public readonly string FlagSequence = "flag";
 

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
@@ -103,8 +103,6 @@ namespace OpenRA.Mods.Common.Traits
 					return;
 
 				var target = Target.FromCell(self.World, cell);
-
-				self.SetTargetLine(target, Color.Green);
 			}
 			else if (order.OrderString == "Enter")
 			{
@@ -114,10 +112,6 @@ namespace OpenRA.Mods.Common.Traits
 					return;
 
 				var targetActor = order.Target.Actor;
-
-				// We only want to set a target line if the order will (most likely) succeed
-				if (Reservable.IsAvailableFor(targetActor, self))
-					self.SetTargetLine(Target.FromActor(targetActor), Color.Green);
 			}
 
 			var currentTransform = self.CurrentActivity as Transform;
@@ -130,10 +124,12 @@ namespace OpenRA.Mods.Common.Traits
 			if (!order.Queued && activity.NextActivity != null)
 				activity.NextActivity.Cancel(self);
 
-			activity.Queue(new IssueOrderAfterTransform(order.OrderString, order.Target));
+			activity.Queue(new IssueOrderAfterTransform(order.OrderString, order.Target, Color.Green));
 
 			if (currentTransform == null)
 				self.QueueActivity(order.Queued, activity);
+
+			self.ShowTargetLines();
 		}
 
 		string IOrderVoice.VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoEntersTunnels.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoEntersTunnels.cs
@@ -93,17 +93,17 @@ namespace OpenRA.Mods.Common.Traits
 			if (transform == null && currentTransform == null)
 				return;
 
-			self.SetTargetLine(order.Target, Color.Green);
-
 			// Manually manage the inner activity queue
 			var activity = currentTransform ?? transform.GetTransformActivity(self);
 			if (!order.Queued && activity.NextActivity != null)
 				activity.NextActivity.Cancel(self);
 
-			activity.Queue(new IssueOrderAfterTransform(order.OrderString, order.Target));
+			activity.Queue(new IssueOrderAfterTransform(order.OrderString, order.Target, Color.Green));
 
 			if (currentTransform == null)
 				self.QueueActivity(order.Queued, activity);
+
+			self.ShowTargetLines();
 		}
 
 		string IOrderVoice.VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
@@ -107,17 +107,17 @@ namespace OpenRA.Mods.Common.Traits
 				if (transform == null && currentTransform == null)
 					return;
 
-				self.SetTargetLine(Target.FromCell(self.World, cell), Color.Green);
-
 				// Manually manage the inner activity queue
 				var activity = currentTransform ?? transform.GetTransformActivity(self);
 				if (!order.Queued && activity.NextActivity != null)
 					activity.NextActivity.Cancel(self);
 
-				activity.Queue(new IssueOrderAfterTransform("Move", order.Target));
+				activity.Queue(new IssueOrderAfterTransform("Move", order.Target, Color.Green));
 
 				if (currentTransform == null)
 					self.QueueActivity(order.Queued, activity);
+
+				self.ShowTargetLines();
 			}
 			else if (order.OrderString == "Stop")
 			{

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoPassenger.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoPassenger.cs
@@ -117,17 +117,17 @@ namespace OpenRA.Mods.Common.Traits
 			if (transform == null && currentTransform == null)
 				return;
 
-			self.SetTargetLine(order.Target, Color.Green);
-
 			// Manually manage the inner activity queue
 			var activity = currentTransform ?? transform.GetTransformActivity(self);
 			if (!order.Queued && activity.NextActivity != null)
 				activity.NextActivity.Cancel(self);
 
-			activity.Queue(new IssueOrderAfterTransform(order.OrderString, order.Target));
+			activity.Queue(new IssueOrderAfterTransform(order.OrderString, order.Target, Color.Green));
 
 			if (currentTransform == null)
 				self.QueueActivity(order.Queued, activity);
+
+			self.ShowTargetLines();
 		}
 
 		string IOrderVoice.VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoRepairable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoRepairable.cs
@@ -111,17 +111,17 @@ namespace OpenRA.Mods.Common.Traits
 			if (transform == null && currentTransform == null)
 				return;
 
-			self.SetTargetLine(order.Target, Color.Green);
-
 			// Manually manage the inner activity queue
 			var activity = currentTransform ?? transform.GetTransformActivity(self);
 			if (!order.Queued && activity.NextActivity != null)
 				activity.NextActivity.Cancel(self);
 
-			activity.Queue(new IssueOrderAfterTransform(order.OrderString, order.Target));
+			activity.Queue(new IssueOrderAfterTransform(order.OrderString, order.Target, Color.Green));
 
 			if (currentTransform == null)
 				self.QueueActivity(order.Queued, activity);
+
+			self.ShowTargetLines();
 		}
 
 		string IOrderVoice.VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/Captures.cs
+++ b/OpenRA.Mods.Common/Traits/Captures.cs
@@ -98,8 +98,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!order.Queued)
 				self.CancelActivity();
 
-			self.SetTargetLine(order.Target, Color.Red);
 			self.QueueActivity(new CaptureActor(self, order.Target));
+			self.ShowTargetLines();
 		}
 
 		protected override void TraitEnabled(Actor self) { captureManager.RefreshCaptures(self); }

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -297,8 +297,8 @@ namespace OpenRA.Mods.Common.Traits
 					return;
 
 				var targetLocation = move.NearestMoveableCell(cell);
-				self.SetTargetLine(Target.FromCell(self.World, targetLocation), Color.Yellow);
 				self.QueueActivity(order.Queued, new DeliverUnit(self, order.Target, Info.DropRange));
+				self.ShowTargetLines();
 			}
 			else if (order.OrderString == "Unload")
 			{
@@ -316,8 +316,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (!order.Queued)
 					self.CancelActivity();
 
-				self.SetTargetLine(order.Target, Color.Yellow);
 				self.QueueActivity(order.Queued, new PickupUnit(self, order.Target.Actor, Info.BeforeLoadDelay));
+				self.ShowTargetLines();
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/DeliversCash.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversCash.cs
@@ -76,8 +76,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!order.Queued)
 				self.CancelActivity();
 
-			self.SetTargetLine(order.Target, Color.Yellow);
 			self.QueueActivity(new DonateCash(self, order.Target, info.Payload, info.PlayerExperience));
+			self.ShowTargetLines();
 		}
 
 		void INotifyCashTransfer.OnAcceptingCash(Actor self, Actor donor) { }

--- a/OpenRA.Mods.Common/Traits/DeliversExperience.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversExperience.cs
@@ -87,8 +87,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!order.Queued)
 				self.CancelActivity();
 
-			self.SetTargetLine(order.Target, Color.Yellow);
 			self.QueueActivity(new DonateExperience(self, order.Target, gainsExperience.Level, info.PlayerExperience));
+			self.ShowTargetLines();
 		}
 
 		public class DeliversExperienceOrderTargeter : UnitOrderTargeter

--- a/OpenRA.Mods.Common/Traits/Demolition.cs
+++ b/OpenRA.Mods.Common/Traits/Demolition.cs
@@ -86,9 +86,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (!order.Queued)
 				self.CancelActivity();
 
-			self.SetTargetLine(order.Target, Color.Red);
 			self.QueueActivity(new Demolish(self, order.Target, info.EnterBehaviour, info.DetonationDelay,
 				info.Flashes, info.FlashesDelay, info.FlashInterval));
+
+			self.ShowTargetLines();
 		}
 
 		public string VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -95,8 +95,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!order.Queued)
 				self.CancelActivity();
 
-			self.SetTargetLine(order.Target, Color.Yellow);
 			self.QueueActivity(new RepairBuilding(self, order.Target, Info));
+			self.ShowTargetLines();
 		}
 
 		class EngineerRepairOrderTargeter : UnitOrderTargeter

--- a/OpenRA.Mods.Common/Traits/EntersTunnels.cs
+++ b/OpenRA.Mods.Common/Traits/EntersTunnels.cs
@@ -85,9 +85,9 @@ namespace OpenRA.Mods.Common.Traits
 			if (!order.Queued)
 				self.CancelActivity();
 
-			self.SetTargetLine(Target.FromCell(self.World, tunnel.Exit.Value), Color.Green);
-			self.QueueActivity(move.MoveTo(tunnel.Entrance, tunnel.NearEnough));
-			self.QueueActivity(move.MoveTo(tunnel.Exit.Value, tunnel.NearEnough));
+			self.QueueActivity(move.MoveTo(tunnel.Entrance, tunnel.NearEnough, targetLineColor: Color.Green));
+			self.QueueActivity(move.MoveTo(tunnel.Exit.Value, tunnel.NearEnough, targetLineColor: Color.Green));
+			self.ShowTargetLines();
 		}
 
 		IEnumerable<VariableObserver> IObservesVariables.GetVariableObservers()

--- a/OpenRA.Mods.Common/Traits/Guard.cs
+++ b/OpenRA.Mods.Common/Traits/Guard.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			var range = target.Actor.Info.TraitInfo<GuardableInfo>().Range;
-			self.QueueActivity(new AttackMoveActivity(self, () => move.MoveFollow(self, target, WDist.Zero, range, targetLineColor: Color.Yellow)));
+			self.QueueActivity(new AttackMoveActivity(self, () => move.MoveFollow(self, target, WDist.Zero, range, targetLineColor: Color.OrangeRed)));
 			self.ShowTargetLines();
 		}
 

--- a/OpenRA.Mods.Common/Traits/Guard.cs
+++ b/OpenRA.Mods.Common/Traits/Guard.cs
@@ -53,10 +53,9 @@ namespace OpenRA.Mods.Common.Traits
 			if (target.Type != TargetType.Actor)
 				return;
 
-			self.SetTargetLine(target, Color.Yellow);
-
 			var range = target.Actor.Info.TraitInfo<GuardableInfo>().Range;
 			self.QueueActivity(new AttackMoveActivity(self, () => move.MoveFollow(self, target, WDist.Zero, range, targetLineColor: Color.Yellow)));
+			self.ShowTargetLines();
 		}
 
 		public string VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -149,24 +149,9 @@ namespace OpenRA.Mods.Common.Traits
 				self.World.AddFrameEndTask(w => self.QueueActivity(new FindAndDeliverResources(self)));
 		}
 
-		public void SetProcLines(Actor proc)
-		{
-			if (proc == null || proc.IsDead)
-				return;
-
-			var linkedHarvs = proc.World.ActorsHavingTrait<Harvester>(h => h.LinkedProc == proc)
-				.Select(a => Target.FromActor(a))
-				.ToList();
-
-			proc.SetTargetLines(linkedHarvs, Color.Gold);
-		}
-
 		public void LinkProc(Actor self, Actor proc)
 		{
-			var oldProc = LinkedProc;
 			LinkedProc = proc;
-			SetProcLines(oldProc);
-			SetProcLines(proc);
 		}
 
 		public void UnlinkProc(Actor self, Actor proc)
@@ -345,10 +330,9 @@ namespace OpenRA.Mods.Common.Traits
 					loc = self.Location;
 				}
 
-				self.SetTargetLine(Target.FromCell(self.World, loc), Color.Red);
-
 				// FindResources takes care of calling INotifyHarvesterAction
 				self.QueueActivity(order.Queued, new FindAndDeliverResources(self, loc));
+				self.ShowTargetLines();
 			}
 			else if (order.OrderString == "Deliver")
 			{
@@ -362,8 +346,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (iao == null || !iao.AllowDocking || !IsAcceptableProcType(targetActor))
 					return;
 
-				self.SetTargetLine(order.Target, Color.Green);
 				self.QueueActivity(order.Queued, new FindAndDeliverResources(self, targetActor));
+				self.ShowTargetLines();
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -314,8 +314,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (moveTo.HasValue)
 			{
 				self.CancelActivity();
-				self.SetTargetLine(Target.FromCell(self.World, moveTo.Value), Color.Green, false);
 				self.QueueActivity(new Move(self, moveTo.Value, WDist.Zero));
+				self.ShowTargetLines();
 
 				Log.Write("debug", "OnNudge #{0} from {1} to {2}",
 					self.ActorID, self.Location, moveTo.Value);
@@ -527,14 +527,14 @@ namespace OpenRA.Mods.Common.Traits
 			return inner;
 		}
 
-		public Activity MoveTo(CPos cell, int nearEnough)
+		public Activity MoveTo(CPos cell, int nearEnough, Color? targetLineColor = null)
 		{
-			return WrapMove(new Move(self, cell, WDist.FromCells(nearEnough), null));
+			return WrapMove(new Move(self, cell, WDist.FromCells(nearEnough), targetLineColor: targetLineColor));
 		}
 
-		public Activity MoveTo(CPos cell, Actor ignoreActor)
+		public Activity MoveTo(CPos cell, Actor ignoreActor, Color? targetLineColor = null)
 		{
-			return WrapMove(new Move(self, cell, WDist.Zero, ignoreActor));
+			return WrapMove(new Move(self, cell, WDist.Zero, ignoreActor, targetLineColor: targetLineColor));
 		}
 
 		public Activity MoveWithinRange(Target target, WDist range,
@@ -805,8 +805,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (!order.Queued)
 					self.CancelActivity();
 
-				self.SetTargetLine(Target.FromCell(self.World, cell), Color.Green);
-				self.QueueActivity(order.Queued, WrapMove(new Move(self, cell, WDist.FromCells(8), null, true)));
+				self.QueueActivity(order.Queued, WrapMove(new Move(self, cell, WDist.FromCells(8), null, true, Color.Green)));
+				self.ShowTargetLines();
 			}
 
 			// TODO: This should only cancel activities queued by this trait

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -162,8 +162,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!order.Queued)
 				self.CancelActivity();
 
-			self.SetTargetLine(order.Target, Color.Green);
 			self.QueueActivity(new EnterTransport(self, order.Target));
+			self.ShowTargetLines();
 		}
 
 		public bool Reserve(Actor self, Cargo cargo)

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -43,7 +43,6 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var exit = CPos.Zero;
 			var exitLocation = CPos.Zero;
-			var target = Target.Invalid;
 
 			// Clone the initializer dictionary for the new actor
 			var td = new TypeDictionary();
@@ -70,7 +69,6 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				exitLocation = rp.Value != null ? rp.Value.Location : exit;
-				target = Target.FromCell(self.World, exitLocation);
 
 				td.Add(new LocationInit(exit));
 				td.Add(new CenterPositionInit(spawn));
@@ -93,8 +91,6 @@ namespace OpenRA.Mods.Common.Traits
 						newUnit.QueueActivity(new AttackMoveActivity(newUnit, () => move.MoveTo(exitLocation, 1)));
 					}
 				}
-
-				newUnit.SetTargetLine(target, rp.Value != null ? Color.Red : Color.Green, false);
 
 				if (!self.IsDead)
 					foreach (var t in self.TraitsImplementing<INotifyProduction>())

--- a/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
@@ -93,8 +93,6 @@ namespace OpenRA.Mods.Common.Traits
 				if (move != null)
 					newUnit.QueueActivity(move.MoveTo(destination, 2));
 
-				newUnit.SetTargetLine(Target.FromCell(self.World, destination), Color.Green, false);
-
 				if (!self.IsDead)
 					foreach (var t in self.TraitsImplementing<INotifyProduction>())
 						t.UnitProduced(self, newUnit, destination);

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -103,7 +103,6 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			var exit = CPos.Zero;
 			var exitLocation = CPos.Zero;
-			var target = Target.Invalid;
 
 			var info = (ProductionParadropInfo)Info;
 			var actorType = info.ActorType;
@@ -124,7 +123,6 @@ namespace OpenRA.Mods.Common.Traits
 				var initialFacing = exitinfo.Facing < 0 ? (to - spawn).Yaw.Facing : exitinfo.Facing;
 
 				exitLocation = rp.Value != null ? rp.Value.Location : exit;
-				target = Target.FromCell(self.World, exitLocation);
 
 				td.Add(new LocationInit(exit));
 				td.Add(new CenterPositionInit(spawn));
@@ -148,8 +146,6 @@ namespace OpenRA.Mods.Common.Traits
 						newUnit.QueueActivity(new AttackMoveActivity(newUnit, () => move.MoveTo(exitLocation, 1)));
 					}
 				}
-
-				newUnit.SetTargetLine(target, rp.Value != null ? Color.Red : Color.Green, false);
 
 				if (!self.IsDead)
 					foreach (var t in self.TraitsImplementing<INotifyProduction>())

--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -81,8 +81,16 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					if (n.Target.Type != TargetType.Invalid)
 					{
-						yield return new TargetLineRenderable(new[] { prev, n.Target.CenterPosition }, n.Color, info.LineWidth, info.MarkerWidth);
-						prev = n.Target.CenterPosition;
+						var pal = wr.Palette(TileSet.TerrainPaletteInternalName);
+						var tile = n.Tile;
+						var pos = n.Target.CenterPosition;
+
+						if (tile == null)
+							yield return new TargetLineRenderable(new[] { prev, pos }, n.Color, info.LineWidth, info.MarkerWidth);
+						else
+							yield return new SpriteRenderable(tile, pos, WVec.Zero, -511, pal, 1f, true);
+
+						prev = pos;
 					}
 				}
 			}

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -123,8 +123,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!CanRepairAt(order.Target.Actor) || (!CanRepair() && !CanRearm()))
 				return;
 
-			self.SetTargetLine(order.Target, Color.Green);
 			self.QueueActivity(order.Queued, new Resupply(self, order.Target.Actor, new WDist(512)));
+			self.ShowTargetLines();
 		}
 
 		IEnumerable<VariableObserver> IObservesVariables.GetVariableObservers()

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -102,8 +102,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!order.Queued)
 				self.CancelActivity();
 
-			self.SetTargetLine(order.Target, Color.Green);
 			self.QueueActivity(new Resupply(self, order.Target.Actor, Info.CloseEnough));
+			self.ShowTargetLines();
 		}
 
 		public Actor FindRepairBuilding(Actor self)

--- a/OpenRA.Mods.Common/Traits/RepairsBridges.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsBridges.cs
@@ -105,8 +105,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (!order.Queued)
 					self.CancelActivity();
 
-				self.SetTargetLine(order.Target, Color.Yellow);
 				self.QueueActivity(new RepairBridge(self, order.Target, info.EnterBehaviour, info.RepairNotification));
+				self.ShowTargetLines();
 			}
 		}
 

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -425,8 +425,8 @@ namespace OpenRA.Mods.Common.Traits
 
 	public interface IMove
 	{
-		Activity MoveTo(CPos cell, int nearEnough);
-		Activity MoveTo(CPos cell, Actor ignoreActor);
+		Activity MoveTo(CPos cell, int nearEnough, Color? targetLineColor = null);
+		Activity MoveTo(CPos cell, Actor ignoreActor, Color? targetLineColor = null);
 		Activity MoveWithinRange(Target target, WDist range,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null);
 		Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange,

--- a/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
+++ b/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
@@ -15,6 +15,7 @@ using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.D2k.Activities;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits
@@ -70,7 +71,7 @@ namespace OpenRA.Mods.D2k.Traits
 			self.QueueActivity(new SwallowActor(self, target, a, facing));
 		}
 
-		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack)
+		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
 		{
 			return new SwallowTarget(self, newTarget, allowMove, forceAttack);
 		}


### PR DESCRIPTION
Fixes #2598
Fixes #12019

This is completing the work that @Turupawn started and @forcecore continued in #14384 .
I've rebased it on top of #16481 to complete the general activity rework and added a few modifications of my own:

- Made target lines thicker (Maybe it's because of my high-resolution monitor or my eyes are just bad, but I found the single pixel lines hard to read when planning queued orders)
- Omitted target lines from autotarget attacks and AttackMove/Guard attacks.
- Changed some colors of target lines: 
  - AttackMove and Guard get yellow (because they mix move -> green and attack -> red, yellow seems intuitive)
  - ~~'Special' non-aggressive actions changed from yellow to blue.~~

In general only actions that directly correspond to given orders should have wapoint lines rendered. I may possibly reintroduce special target lines for autotarget, AttackMove/Guard and opportunity fire targets in a future PR. These target lines would be completely seperate from the waypoint lines, not part of the chain and rendered in thinner lines.

