### PR TITLE
Fix multiple clients being assigned as admin.

### DIFF
--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -337,7 +337,6 @@ namespace OpenRA.Server
 					SpawnPoint = 0,
 					Team = 0,
 					State = Session.ClientState.Invalid,
-					IsAdmin = !LobbyInfo.Clients.Any(c1 => c1.IsAdmin)
 				};
 
 				if (ModData.Manifest.Id != handshake.Mod)
@@ -373,6 +372,7 @@ namespace OpenRA.Server
 				Action completeConnection = () =>
 				{
 					client.Slot = LobbyInfo.FirstEmptySlot();
+					client.IsAdmin = !LobbyInfo.Clients.Any(c1 => c1.IsAdmin);
 
 					if (client.IsObserver && !LobbyInfo.GlobalSettings.AllowSpectators)
 					{


### PR DESCRIPTION
Fixes #16395.

A simple way to reproduce the issue:
1. Add `Thread.Sleep(10000)` at the top of `onQueryComplete` in `ValidateClient`
2. Start a local dedicated server
3. Start two clients
4. Make both clients join the dedicated server within the 10s join window