### PR TITLE
Fix AutoTarget overriding demoted targets

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -68,6 +68,7 @@ namespace OpenRA.Mods.Common.Activities
 				{
 					attackAircraft.OpportunityTarget = attackAircraft.RequestedTarget;
 					attackAircraft.OpportunityForceAttack = attackAircraft.RequestedForceAttack;
+					attackAircraft.OpportunityTargetIsPersistentTarget = true;
 				}
 
 				attackAircraft.RequestedTarget = Target.Invalid;

--- a/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
@@ -66,6 +66,7 @@ namespace OpenRA.Mods.Common.Activities
 				{
 					attackAircraft.OpportunityTarget = attackAircraft.RequestedTarget;
 					attackAircraft.OpportunityForceAttack = attackAircraft.RequestedForceAttack;
+					attackAircraft.OpportunityTargetIsPersistentTarget = true;
 				}
 
 				attackAircraft.RequestedTarget = Target.Invalid;

--- a/OpenRA.Mods.Common/Traits/CaptureManager.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureManager.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class CaptureManager : INotifyCreated, INotifyCapture, ITick, IPreventsAutoTarget
+	public class CaptureManager : INotifyCreated, INotifyCapture, ITick, IDisableEnemyAutoTarget
 	{
 		readonly CaptureManagerInfo info;
 		ConditionManager conditionManager;
@@ -283,7 +283,7 @@ namespace OpenRA.Mods.Common.Traits
 				w.Update(currentTarget, self, currentTarget, currentTargetDelay, currentTargetTotal);
 		}
 
-		bool IPreventsAutoTarget.PreventsAutoTarget(Actor self, Actor attacker)
+		bool IDisableEnemyAutoTarget.DisableEnemyAutoTarget(Actor self, Actor attacker)
 		{
 			return info.PreventsAutoTarget && currentCaptors.Any(c => attacker.AppearsFriendlyTo(c));
 		}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -297,9 +297,16 @@ namespace OpenRA.Mods.Common.Traits
 		void ModifyTransformActorInit(Actor self, TypeDictionary init);
 	}
 
-	public interface IPreventsAutoTarget
+	[RequireExplicitImplementation]
+	public interface IDisableEnemyAutoTarget
 	{
-		bool PreventsAutoTarget(Actor self, Actor attacker);
+		bool DisableEnemyAutoTarget(Actor self, Actor attacker);
+	}
+
+	[RequireExplicitImplementation]
+	public interface IDisableAutoTarget
+	{
+		bool DisableAutoTarget(Actor self);
 	}
 
 	[RequireExplicitImplementation]


### PR DESCRIPTION
This PR fixes `AutoTarget` overriding targets that were initially ordered normally but then demoted to opportunity targets by the player issuing a different order. The unit will now keep its original target unless explicitly stopped (<kbd>S</kbd> or command bar) or moved out of range.

Fixes #16309 and hopefully all other complaints about the opportunity fire logic working unexpectedly.

I had initially implemented this using conditions to disable `AutoTarget`, but this requires a bunch of awkward and fragile yaml overrides to grant a condition on all units that inherit from `AttackFollow` to disable `AutoTarget`.  The underlying bug is caused by a hardcoded check that assumes idle == ok to assign a new target, so IMO there is no real issue with fixing this using an interface.