### PR TITLE
Drop attack targets when switching to a more restrictive stance.

### DIFF
--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -171,6 +171,20 @@ namespace OpenRA.Activities
 				act = act.childActivity;
 			}
 		}
+
+		public IEnumerable<T> ActivitiesImplementing<T>() where T : IActivityInterface
+		{
+			if (childActivity != null)
+				foreach (var a in childActivity.ActivitiesImplementing<T>())
+					yield return a;
+
+			if (this is T)
+				yield return (T)(object)this;
+
+			if (NextActivity != null)
+				foreach (var a in NextActivity.ActivitiesImplementing<T>())
+					yield return a;
+		}
 	}
 
 	public static class ActivityExts

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -350,6 +350,8 @@ namespace OpenRA.Traits
 	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1302:InterfaceNamesMustBeginWithI", Justification = "Not a real interface, but more like a tag.")]
 	public interface Requires<T> where T : class, ITraitInfoInterface { }
 
+	public interface IActivityInterface { }
+
 	[RequireExplicitImplementation]
 	public interface INotifySelected { void Selected(Actor self); }
 	[RequireExplicitImplementation]

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackLeap.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackLeap.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack)
 		{
-			return new LeapAttack(self, newTarget, allowMove, this, info);
+			return new LeapAttack(self, newTarget, allowMove, forceAttack, this, info);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/HeliAttack.cs
@@ -17,21 +17,25 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
-	public class HeliAttack : Activity
+	public class HeliAttack : Activity, IActivityNotifyStanceChanged
 	{
 		readonly Aircraft aircraft;
 		readonly AttackAircraft attackAircraft;
 		readonly Rearmable rearmable;
+		readonly bool forceAttack;
 
 		Target target;
 		Target lastVisibleTarget;
 		WDist lastVisibleMaximumRange;
+		BitSet<TargetableType> lastVisibleTargetTypes;
+		Player lastVisibleOwner;
 		bool useLastVisibleTarget;
 		bool hasTicked;
 
-		public HeliAttack(Actor self, Target target)
+		public HeliAttack(Actor self, Target target, bool forceAttack)
 		{
 			this.target = target;
+			this.forceAttack = forceAttack;
 			aircraft = self.Trait<Aircraft>();
 			attackAircraft = self.Trait<AttackAircraft>();
 			rearmable = self.TraitOrDefault<Rearmable>();
@@ -43,6 +47,17 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				lastVisibleTarget = Target.FromPos(target.CenterPosition);
 				lastVisibleMaximumRange = attackAircraft.GetMaximumRangeVersusTarget(target);
+
+				if (target.Type == TargetType.Actor)
+				{
+					lastVisibleOwner = target.Actor.Owner;
+					lastVisibleTargetTypes = target.Actor.GetEnabledTargetTypes();
+				}
+				else if (target.Type == TargetType.FrozenActor)
+				{
+					lastVisibleOwner = target.FrozenActor.Owner;
+					lastVisibleTargetTypes = target.FrozenActor.TargetTypes;
+				}
 			}
 		}
 
@@ -90,6 +105,8 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				lastVisibleTarget = Target.FromTargetPositions(target);
 				lastVisibleMaximumRange = attackAircraft.GetMaximumRangeVersusTarget(target);
+				lastVisibleOwner = target.Actor.Owner;
+				lastVisibleTargetTypes = target.Actor.GetEnabledTargetTypes();
 			}
 
 			var oldUseLastVisibleTarget = useLastVisibleTarget;
@@ -155,6 +172,16 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			return this;
+		}
+
+		void IActivityNotifyStanceChanged.StanceChanged(Actor self, AutoTarget autoTarget, UnitStance oldStance, UnitStance newStance)
+		{
+			// Cancel non-forced targets when switching to a more restrictive stance if they are no longer valid for auto-targeting
+			if (newStance > oldStance || forceAttack)
+				return;
+
+			if (!autoTarget.HasValidTargetPriority(self, lastVisibleOwner, lastVisibleTargetTypes))
+				attackAircraft.RequestedTarget = Target.Invalid;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
@@ -38,9 +38,9 @@ namespace OpenRA.Mods.Common.Traits
 		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack)
 		{
 			if (aircraftInfo.CanHover)
-				return new HeliAttack(self, newTarget);
+				return new HeliAttack(self, newTarget, forceAttack);
 
-			return new FlyAttack(self, newTarget);
+			return new FlyAttack(self, newTarget, forceAttack);
 		}
 
 		protected override bool CanAttack(Actor self, Target target)

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -313,6 +313,25 @@ namespace OpenRA.Mods.Common.Traits
 				ab.AttackTarget(target, false, allowMove);
 		}
 
+		public bool HasValidTargetPriority(Actor self, Player owner, BitSet<TargetableType> targetTypes)
+		{
+			if (Stance <= UnitStance.ReturnFire)
+				return false;
+
+			return activeTargetPriorities.Any(ati =>
+			{
+				// Incompatible stances
+				if (!ati.ValidStances.HasStance(self.Owner.Stances[owner]))
+					return false;
+
+				// Incompatible target types
+				if (!ati.ValidTargets.Overlaps(targetTypes) || ati.InvalidTargets.Overlaps(targetTypes))
+					return false;
+
+				return true;
+			});
+		}
+
 		Target ChooseTarget(Actor self, AttackBase ab, Stance attackStances, WDist scanRange, bool allowMove, bool allowTurn)
 		{
 			var chosenTarget = Target.Invalid;


### PR DESCRIPTION
This PR changes the attack activities to drop the current target when the unit's stance is changed if:
* The new stance is more restrictive than the previous one
* The target is not auto-targeted in the new stance
* The attack was not force-targeted

Fixes #8373.