### PR TITLE
Fix dogs won't be build in Fort Lonestar

### DIFF
--- a/mods/ra/maps/fort-lonestar/rules.yaml
+++ b/mods/ra/maps/fort-lonestar/rules.yaml
@@ -213,6 +213,7 @@ PBOX:
 DOG:
 	Buildable:
 		Prerequisites: barracks
+		BuildAtProductionType: Soldier
 	Valued:
 		Cost: 20
 


### PR DESCRIPTION
Okay this is my first PR i hope i've done evreything right.

Makes Dogs come out of the barracks/tent if build by players.

Fixes #16560