### PR TITLE
Fix "Max Speed" option when viewing replays.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -777,7 +777,7 @@ namespace OpenRA
 						LogicTick();
 
 						// Force at least one render per tick during regular gameplay
-						if (OrderManager.World != null && !OrderManager.World.IsLoadingGameSave)
+						if (OrderManager.World != null && !OrderManager.World.IsLoadingGameSave && !OrderManager.World.IsReplay)
 							forceRender = true;
 					}
 


### PR DESCRIPTION
Fixes #16474.

This was a regression from https://github.com/OpenRA/OpenRA/pull/16411/files#diff-5357f77faa279eefc8093422323d0fefR775.