### PR TITLE
Make StoresResources trait public

### DIFF
--- a/OpenRA.Mods.Common/Traits/StoresResources.cs
+++ b/OpenRA.Mods.Common/Traits/StoresResources.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Adds capacity to a player's harvested resource limit.")]
-	class StoresResourcesInfo : ITraitInfo
+	public class StoresResourcesInfo : ITraitInfo
 	{
 		[FieldLoader.Require]
 		public readonly int Capacity = 0;
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new StoresResources(init.Self, this); }
 	}
 
-	class StoresResources : IPips, INotifyOwnerChanged, INotifyCapture, IStoreResources, ISync, INotifyKilled
+	public class StoresResources : IPips, INotifyOwnerChanged, INotifyCapture, IStoreResources, ISync, INotifyKilled
 	{
 		readonly StoresResourcesInfo info;
 		PlayerResources player;


### PR DESCRIPTION
`StoresResources` trait should be public to be able to get information about current `Stores` and `Capacity`

Needed for show information on side bar in d2 mod like this:
![Untitled](https://user-images.githubusercontent.com/3105609/58249591-f78fa300-7d67-11e9-8688-93f8aaf5a46b.png)


Needed for https://github.com/OpenRA/d2/issues/124