### PR TITLE
Added field to ProductionQueue to customize ordering in ObserverProductionIconsWidget

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -26,6 +26,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("What kind of production will be added (e.g. Building, Infantry, Vehicle, ...)")]
 		public readonly string Type = null;
 
+		[Desc("The value used when ordering this for display (e.g. in the Spectator UI).")]
+		public readonly int DisplayOrder = 0;
+
 		[Desc("Group queues from separate buildings together into the same tab.")]
 		public readonly string Group = null;
 
@@ -614,6 +617,7 @@ namespace OpenRA.Mods.Common.Traits
 		public bool Started { get; private set; }
 		public int Slowdown { get; private set; }
 		public bool Infinite { get; set; }
+		public int BuildPaletteOrder { get; private set; }
 
 		readonly ActorInfo ai;
 		readonly BuildableInfo bi;
@@ -629,6 +633,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.pm = pm;
 			ai = Queue.Actor.World.Map.Rules.Actors[Item];
 			bi = ai.TraitInfo<BuildableInfo>();
+			BuildPaletteOrder = bi.BuildPaletteOrder;
 			Infinite = false;
 		}
 

--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -110,8 +110,8 @@ namespace OpenRA.Mods.Common.Widgets
 					.Select(a => a.Trait.CurrentItem())
 					.Where(pi => pi != null)
 					.GroupBy(pr => pr.Item)
-					.OrderBy(g => g.First().Queue.Info.Type)
-					.ThenBy(g => g.First().Item)
+					.OrderBy(g => g.First().Queue.Info.DisplayOrder)
+					.ThenBy(g => g.First().BuildPaletteOrder)
 					.ToList();
 
 			Bounds.Width = currentItemsByItem.Count * (IconWidth + IconSpacing);

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -30,6 +30,7 @@ FACT:
 		Prerequisites: global-factundeploy
 	ProductionQueue@GDIBuilding:
 		Type: Building.GDI
+		DisplayOrder: 0
 		Factions: gdi
 		Group: Building
 		LowPowerModifier: 200
@@ -41,6 +42,7 @@ FACT:
 		CancelledAudio: Cancelled
 	ProductionQueue@NodBuilding:
 		Type: Building.Nod
+		DisplayOrder: 0
 		Factions: nod
 		Group: Building
 		LowPowerModifier: 200
@@ -52,6 +54,7 @@ FACT:
 		CancelledAudio: Cancelled
 	ProductionQueue@GDIDefense:
 		Type: Defence.GDI
+		DisplayOrder: 1
 		Factions: gdi
 		Group: Defence
 		LowPowerModifier: 300
@@ -63,6 +66,7 @@ FACT:
 		CancelledAudio: Cancelled
 	ProductionQueue@NodDefense:
 		Type: Defence.Nod
+		DisplayOrder: 1
 		Factions: nod
 		Group: Defence
 		LowPowerModifier: 300
@@ -316,6 +320,7 @@ PYLE:
 		Condition: produced
 	ProductionQueue:
 		Type: Infantry.GDI
+		DisplayOrder: 2
 		Group: Infantry
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
@@ -367,6 +372,7 @@ HAND:
 		Produces: Infantry.Nod
 	ProductionQueue:
 		Type: Infantry.Nod
+		DisplayOrder: 2
 		Group: Infantry
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
@@ -428,6 +434,7 @@ AFLD:
 		RequiresCondition: !build-incomplete
 	ProductionQueue:
 		Type: Vehicle.Nod
+		DisplayOrder: 3
 		Group: Vehicle
 		LowPowerModifier: 300
 		BlockedAudio: NoBuild
@@ -486,6 +493,7 @@ WEAP:
 		Produces: Vehicle.GDI
 	ProductionQueue:
 		Type: Vehicle.GDI
+		DisplayOrder: 3
 		Group: Vehicle
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
@@ -538,6 +546,7 @@ HPAD:
 	RallyPoint:
 	ProductionQueue@GDI:
 		Type: Aircraft.GDI
+		DisplayOrder: 4
 		Factions: gdi
 		Group: Aircraft
 		LowPowerModifier: 300
@@ -549,6 +558,7 @@ HPAD:
 		CancelledAudio: Cancelled
 	ProductionQueue@Nod:
 		Type: Aircraft.Nod
+		DisplayOrder: 4
 		Factions: nod
 		Group: Aircraft
 		LowPowerModifier: 300

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -10,6 +10,7 @@ Player:
 	TechTree:
 	ClassicProductionQueue@Building:
 		Type: Building
+		DisplayOrder: 0
 		BuildDurationModifier: 250
 		LowPowerModifier: 300
 		ReadyAudio: BuildingReady
@@ -20,6 +21,7 @@ Player:
 		SpeedUp: true
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
+		DisplayOrder: 1
 		BuildDurationModifier: 250
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
@@ -30,6 +32,7 @@ Player:
 		SpeedUp: true
 	ClassicProductionQueue@Vehicle:
 		Type: Vehicle
+		DisplayOrder: 2
 		BuildDurationModifier: 250
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
@@ -40,6 +43,7 @@ Player:
 		SpeedUp: true
 	ClassicProductionQueue@Armor:
 		Type: Armor
+		DisplayOrder: 3
 		BuildDurationModifier: 250
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
@@ -50,6 +54,7 @@ Player:
 		SpeedUp: true
 	ClassicProductionQueue@Starport:
 		Type: Starport
+		DisplayOrder: 4
 		BuildDurationModifier: 212
 		BlockedAudio: NoRoom
 		QueuedAudio: OrderPlaced
@@ -57,6 +62,7 @@ Player:
 		CancelledAudio: Cancelled
 	ClassicProductionQueue@Aircraft:
 		Type: Aircraft
+		DisplayOrder: 5
 		BuildDurationModifier: 312
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady

--- a/mods/ra/rules/player.yaml
+++ b/mods/ra/rules/player.yaml
@@ -10,6 +10,7 @@ Player:
 	TechTree:
 	ClassicProductionQueue@Building:
 		Type: Building
+		DisplayOrder: 0
 		LowPowerModifier: 300
 		ReadyAudio: ConstructionComplete
 		BlockedAudio: NoBuild
@@ -20,6 +21,7 @@ Player:
 		SpeedUp: True
 	ClassicProductionQueue@Defense:
 		Type: Defense
+		DisplayOrder: 1
 		LowPowerModifier: 300
 		ReadyAudio: ConstructionComplete
 		BlockedAudio: NoBuild
@@ -30,6 +32,7 @@ Player:
 		SpeedUp: True
 	ClassicProductionQueue@Vehicle:
 		Type: Vehicle
+		DisplayOrder: 3
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
 		BlockedAudio: NoBuild
@@ -41,6 +44,7 @@ Player:
 		BuildTimeSpeedReduction: 100, 75, 60, 50
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
+		DisplayOrder: 2
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
 		BlockedAudio: NoBuild
@@ -51,6 +55,7 @@ Player:
 		SpeedUp: True
 	ClassicProductionQueue@Ship:
 		Type: Ship
+		DisplayOrder: 5
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
 		BlockedAudio: NoBuild
@@ -61,6 +66,7 @@ Player:
 		SpeedUp: True
 	ClassicProductionQueue@Aircraft:
 		Type: Aircraft
+		DisplayOrder: 4
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
 		BlockedAudio: NoBuild

--- a/mods/ts/rules/player.yaml
+++ b/mods/ts/rules/player.yaml
@@ -11,6 +11,7 @@ Player:
 	GrantConditionOnPrerequisiteManager:
 	ClassicProductionQueue@Building:
 		Type: Building
+		DisplayOrder: 0
 		BuildDurationModifier: 120
 		LowPowerModifier: 300
 		ReadyAudio: ConstructionComplete
@@ -21,6 +22,7 @@ Player:
 		SpeedUp: True
 	ClassicProductionQueue@Defense:
 		Type: Defense
+		DisplayOrder: 1
 		BuildDurationModifier: 120
 		LowPowerModifier: 300
 		ReadyAudio: ConstructionComplete
@@ -31,6 +33,7 @@ Player:
 		SpeedUp: True
 	ClassicProductionQueue@Vehicle:
 		Type: Vehicle
+		DisplayOrder: 3
 		BuildDurationModifier: 120
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
@@ -41,6 +44,7 @@ Player:
 		SpeedUp: True
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
+		DisplayOrder: 2
 		BuildDurationModifier: 120
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
@@ -51,6 +55,7 @@ Player:
 		SpeedUp: True
 	ClassicProductionQueue@Air:
 		Type: Air
+		DisplayOrder: 4
 		BuildDurationModifier: 120
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady


### PR DESCRIPTION
Closes #16585 
 
Changed the order of the icons in ClassicProductionQueue to structure-support-infantry-vehicle-aircraft-ship so it matches the order in the right sidebar.