### PR TITLE
Feature/tooltips for truncated labels

### DIFF
--- a/OpenRA.Game/Graphics/SpriteFont.cs
+++ b/OpenRA.Game/Graphics/SpriteFont.cs
@@ -112,7 +112,7 @@ namespace OpenRA.Graphics
 
 		public void DrawTextWithContrast(string text, float2 location, Color fg, Color bgDark, Color bgLight, int offset)
 		{
-			DrawTextWithContrast(text, location, fg, WidgetUtils.GetContrastColor(fg, bgDark, bgLight), offset);
+			DrawTextWithContrast(text, location, fg, GetContrastColor(fg, bgDark, bgLight), offset);
 		}
 
 		public void DrawTextWithShadow(string text, float2 location, Color fg, Color bg, int offset)
@@ -125,7 +125,7 @@ namespace OpenRA.Graphics
 
 		public void DrawTextWithShadow(string text, float2 location, Color fg, Color bgDark, Color bgLight, int offset)
 		{
-			DrawTextWithShadow(text, location, fg, WidgetUtils.GetContrastColor(fg, bgDark, bgLight), offset);
+			DrawTextWithShadow(text, location, fg, GetContrastColor(fg, bgDark, bgLight), offset);
 		}
 
 		public int2 Measure(string text)
@@ -183,6 +183,11 @@ namespace OpenRA.Graphics
 			s.Sheet.CommitBufferedData();
 
 			return g;
+		}
+
+		static Color GetContrastColor(Color fgColor, Color bgDark, Color bgLight)
+		{
+			return fgColor == Color.White || fgColor.GetBrightness() > 0.33 ? bgDark : bgLight;
 		}
 
 		public void Dispose()

--- a/OpenRA.Mods.Cnc/CncLoadScreen.cs
+++ b/OpenRA.Mods.Cnc/CncLoadScreen.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.LoadScreens;
+using OpenRA.Mods.Common.Widgets;
 using OpenRA.Primitives;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/LoadScreens/LogoStripeLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/LogoStripeLoadScreen.cs
@@ -12,6 +12,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Widgets;
 using OpenRA.Primitives;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/LoadScreens/ModContentLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/ModContentLoadScreen.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Widgets;
 using OpenRA.Primitives;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Scripting/Global/UtilsGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/UtilsGlobal.cs
@@ -11,6 +11,7 @@
 
 using System.Linq;
 using Eluant;
+using OpenRA.Mods.Common.Widgets;
 using OpenRA.Scripting;
 using OpenRA.Widgets;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -287,7 +287,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				() => currentFilename == filepath && currentPackage == package,
 				() => { LoadAsset(package, filepath); });
 
-			item.Get<LabelWidget>("TITLE").GetText = () => filepath;
+			var label = item.Get<LabelWithTooltipWidget>("TITLE");
+			WidgetUtils.TruncateLabelToTooltip(label, filepath);
+
 			item.IsVisible = () =>
 			{
 				bool visible;

--- a/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/GameSaveBrowserLogic.cs
@@ -201,7 +201,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				item.OnDoubleClick = Load;
 
 				var title = Path.GetFileNameWithoutExtension(savePath);
-				item.Get<LabelWidget>("TITLE").GetText = () => title;
+				var label = item.Get<LabelWithTooltipWidget>("TITLE");
+				WidgetUtils.TruncateLabelToTooltip(label, title);
 
 				var date = File.GetLastWriteTime(savePath).ToString("yyyy-MM-dd HH:mm:ss");
 				item.Get<LabelWidget>("DATE").GetText = () => date;

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -185,10 +185,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			header.Get<LabelWidget>("LABEL").GetText = () => title;
 			missionList.AddChild(header);
 
-			foreach (var p in previews)
+			foreach (var preview in previews)
 			{
-				var preview = p;
-
 				var item = ScrollItemWidget.Setup(template,
 					() => selectedMap != null && selectedMap.Uid == preview.Uid,
 					() => SelectMap(preview),

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -192,7 +192,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					() => SelectMap(preview),
 					StartMissionClicked);
 
-				item.Get<LabelWidget>("TITLE").GetText = () => preview.Title;
+				var label = item.Get<LabelWithTooltipWidget>("TITLE");
+				WidgetUtils.TruncateLabelToTooltip(label, preview.Title);
+
 				missionList.AddChild(item);
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
@@ -135,7 +135,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			foreach (var song in music)
 			{
 				var item = ScrollItemWidget.Setup(song.Filename, itemTemplate, () => currentSong == song, () => { currentSong = song; Play(); }, () => { });
-				item.Get<LabelWidget>("TITLE").GetText = () => song.Title;
+				var label = item.Get<LabelWithTooltipWidget>("TITLE");
+				WidgetUtils.TruncateLabelToTooltip(label, song.Title);
+
 				item.Get<LabelWidget>("LENGTH").GetText = () => SongLengthLabel(song);
 				musicList.AddChild(item);
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MusicPlayerLogic.cs
@@ -132,9 +132,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			currentSong = musicPlaylist.CurrentSong();
 
 			musicList.RemoveChildren();
-			foreach (var s in music)
+			foreach (var song in music)
 			{
-				var song = s;
 				var item = ScrollItemWidget.Setup(song.Filename, itemTemplate, () => currentSong == song, () => { currentSong = song; Play(); }, () => { });
 				item.Get<LabelWidget>("TITLE").GetText = () => song.Title;
 				item.Get<LabelWidget>("LENGTH").GetText = () => SongLengthLabel(song);

--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -709,7 +709,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			item.Text = Path.GetFileNameWithoutExtension(replay.FilePath);
-			item.Get<LabelWidget>("TITLE").GetText = () => item.Text;
+			var label = item.Get<LabelWithTooltipWidget>("TITLE");
+			WidgetUtils.TruncateLabelToTooltip(label, item.Text);
+
 			item.IsVisible = () => replayState[replay].Visible;
 			replayList.AddChild(item);
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -594,12 +594,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 						var canJoin = game.IsJoinable;
 						var item = ScrollItemWidget.Setup(serverTemplate, () => currentServer == game, () => SelectServer(game), () => onJoin(game));
-						var title = item.GetOrNull<LabelWidget>("TITLE");
+						var title = item.GetOrNull<LabelWithTooltipWidget>("TITLE");
 						if (title != null)
 						{
-							var font = Game.Renderer.Fonts[title.Font];
-							var label = WidgetUtils.TruncateText(game.Name, title.Bounds.Width, font);
-							title.GetText = () => label;
+							WidgetUtils.TruncateLabelToTooltip(title, game.Name);
 							title.GetColor = () => canJoin ? title.TextColor : incompatibleGameColor;
 						}
 

--- a/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
@@ -14,7 +14,7 @@ using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
 
-namespace OpenRA.Widgets
+namespace OpenRA.Mods.Common.Widgets
 {
 	public static class WidgetUtils
 	{
@@ -265,9 +265,16 @@ namespace OpenRA.Widgets
 			return trimmed;
 		}
 
-		public static Color GetContrastColor(Color fgColor, Color bgDark, Color bgLight)
+		public static void TruncateLabelToTooltip(LabelWithTooltipWidget label, string text)
 		{
-			return fgColor == Color.White || fgColor.GetBrightness() > 0.33 ? bgDark : bgLight;
+			var truncatedText = TruncateText(text, label.Bounds.Width, Game.Renderer.Fonts[label.Font]);
+
+			label.GetText = () => truncatedText;
+
+			if (text != truncatedText)
+				label.GetTooltipText = () => text;
+			else
+				label.GetTooltipText = null;
 		}
 	}
 

--- a/mods/cnc/chrome/assetbrowser.yaml
+++ b/mods/cnc/chrome/assetbrowser.yaml
@@ -48,11 +48,14 @@ Container@ASSETBROWSER_PANEL:
 							X: 2
 							Y: 0
 							Visible: false
+							EnableChildMouseOver: True
 							Children:
-								Label@TITLE:
+								LabelWithTooltip@TITLE:
 									X: 10
 									Width: PARENT_RIGHT - 15
 									Height: 25
+									TooltipContainer: TOOLTIP_CONTAINER
+									TooltipTemplate: SIMPLE_TOOLTIP
 				Label@FILENAME_DESC:
 					X: 15
 					Y: 340
@@ -200,3 +203,4 @@ Container@ASSETBROWSER_PANEL:
 			Width: 140
 			Height: 35
 			Text: Back
+		TooltipContainer@TOOLTIP_CONTAINER:

--- a/mods/cnc/chrome/gamesave-browser.yaml
+++ b/mods/cnc/chrome/gamesave-browser.yaml
@@ -48,11 +48,14 @@ Container@GAMESAVE_BROWSER_PANEL:
 							Height: 25
 							X: 2
 							Visible: false
+							EnableChildMouseOver: True
 							Children:
-								Label@TITLE:
+								LabelWithTooltip@TITLE:
 									X: 10
 									Width: PARENT_RIGHT - 200 - 10
 									Height: 25
+									TooltipContainer: GAMESAVE_TOOLTIP_CONTAINER
+									TooltipTemplate: SIMPLE_TOOLTIP
 								Label@DATE:
 									X: PARENT_RIGHT - WIDTH - 10
 									Width: 200
@@ -112,4 +115,4 @@ Container@GAMESAVE_BROWSER_PANEL:
 					Height: 35
 					Text: Save
 					Visible: False
-				TooltipContainer@TOOLTIP_CONTAINER:
+		TooltipContainer@GAMESAVE_TOOLTIP_CONTAINER:

--- a/mods/cnc/chrome/lobby-music.yaml
+++ b/mods/cnc/chrome/lobby-music.yaml
@@ -154,11 +154,14 @@ Container@LOBBY_MUSIC_BIN:
 					Height: 25
 					X: 2
 					Visible: false
+					EnableChildMouseOver: True
 					Children:
-						Label@TITLE:
+						LabelWithTooltip@TITLE:
 							X: 10
 							Width: PARENT_RIGHT - 50
 							Height: 25
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
 						Label@LENGTH:
 							X: PARENT_RIGHT - 60
 							Width: 50

--- a/mods/cnc/chrome/lobby-servers.yaml
+++ b/mods/cnc/chrome/lobby-servers.yaml
@@ -85,10 +85,12 @@ Container@LOBBY_SERVERS_BIN:
 					X: 2
 					EnableChildMouseOver: True
 					Children:
-						Label@TITLE:
+						LabelWithTooltip@TITLE:
 							X: 5
 							Width: 245
 							Height: 25
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
 						Image@PASSWORD_PROTECTED:
 							X: 272
 							Y: 6

--- a/mods/cnc/chrome/missionbrowser.yaml
+++ b/mods/cnc/chrome/missionbrowser.yaml
@@ -39,11 +39,14 @@ Container@MISSIONBROWSER_PANEL:
 							Height: 25
 							X: 2
 							Visible: False
+							EnableChildMouseOver: True
 							Children:
-								Label@TITLE:
+								LabelWithTooltip@TITLE:
 									X: 10
 									Width: PARENT_RIGHT - 20
 									Height: 25
+									TooltipContainer: TOOLTIP_CONTAINER
+									TooltipTemplate: SIMPLE_TOOLTIP
 				Container@MISSION_INFO:
 					X: 337
 					Y: 15
@@ -148,6 +151,7 @@ Container@MISSIONBROWSER_PANEL:
 					Y: 1
 					Width: 712
 					Height: 418
+		TooltipContainer@TOOLTIP_CONTAINER:
 
 Background@FULLSCREEN_PLAYER:
 	Width: WINDOW_RIGHT

--- a/mods/cnc/chrome/multiplayer-browser.yaml
+++ b/mods/cnc/chrome/multiplayer-browser.yaml
@@ -106,10 +106,12 @@ Container@MULTIPLAYER_PANEL:
 							X: 2
 							EnableChildMouseOver: True
 							Children:
-								Label@TITLE:
+								LabelWithTooltip@TITLE:
 									X: 5
 									Width: 245
 									Height: 25
+									TooltipContainer: TOOLTIP_CONTAINER
+									TooltipTemplate: SIMPLE_TOOLTIP
 								Image@PASSWORD_PROTECTED:
 									X: 272
 									Y: 6

--- a/mods/cnc/chrome/music.yaml
+++ b/mods/cnc/chrome/music.yaml
@@ -30,11 +30,14 @@ Container@MUSIC_PANEL:
 							X: 2
 							Y: 0
 							Visible: false
+							EnableChildMouseOver: True
 							Children:
-								Label@TITLE:
+								LabelWithTooltip@TITLE:
 									X: 10
 									Width: PARENT_RIGHT - 50
 									Height: 25
+									TooltipContainer: TOOLTIP_CONTAINER
+									TooltipTemplate: SIMPLE_TOOLTIP
 								Label@LENGTH:
 									Width: 50
 									X: PARENT_RIGHT - 60
@@ -192,3 +195,4 @@ Container@MUSIC_PANEL:
 			Width: 300
 			Height: 20
 			Font: Small
+		TooltipContainer@TOOLTIP_CONTAINER:

--- a/mods/cnc/chrome/replaybrowser.yaml
+++ b/mods/cnc/chrome/replaybrowser.yaml
@@ -167,7 +167,7 @@ Container@REPLAYBROWSER_PANEL:
 				Container@REPLAY_LIST_CONTAINER:
 					X: 310
 					Y: 20
-					Width: 245
+					Width: 250
 					Height: PARENT_BOTTOM - 20 - 20
 					Children:
 						Label@REPLAYBROWSER_LABEL_TITLE:
@@ -188,11 +188,14 @@ Container@REPLAYBROWSER_PANEL:
 									Height: 25
 									X: 2
 									Visible: false
+									EnableChildMouseOver: True
 									Children:
-										Label@TITLE:
+										LabelWithTooltip@TITLE:
 											X: 10
 											Width: PARENT_RIGHT - 20
 											Height: 25
+											TooltipContainer: TOOLTIP_CONTAINER
+											TooltipTemplate: SIMPLE_TOOLTIP
 				Container@MAP_PREVIEW_ROOT:
 					X: PARENT_RIGHT - WIDTH - 20
 					Y: 50

--- a/mods/common/chrome/assetbrowser.yaml
+++ b/mods/common/chrome/assetbrowser.yaml
@@ -43,11 +43,14 @@ Background@ASSETBROWSER_PANEL:
 					X: 2
 					Y: 0
 					Visible: false
+					EnableChildMouseOver: True
 					Children:
-						Label@TITLE:
+						LabelWithTooltip@TITLE:
 							X: 10
 							Width: PARENT_RIGHT - 20
 							Height: 25
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
 		Label@FILENAME_DESC:
 			X: 20
 			Y: 370
@@ -203,3 +206,4 @@ Background@ASSETBROWSER_PANEL:
 			Height: 25
 			Font: Bold
 			Text: Close
+		TooltipContainer@TOOLTIP_CONTAINER:

--- a/mods/common/chrome/gamesave-browser.yaml
+++ b/mods/common/chrome/gamesave-browser.yaml
@@ -43,11 +43,14 @@ Background@GAMESAVE_BROWSER_PANEL:
 					Height: 25
 					X: 2
 					Visible: false
+					EnableChildMouseOver: True
 					Children:
-						Label@TITLE:
+						LabelWithTooltip@TITLE:
 							X: 10
 							Width: PARENT_RIGHT - 200 - 10
 							Height: 25
+							TooltipContainer: GAMESAVE_TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
 						Label@DATE:
 							X: PARENT_RIGHT - WIDTH - 10
 							Width: 200
@@ -113,4 +116,4 @@ Background@GAMESAVE_BROWSER_PANEL:
 			Text: Save
 			Font: Bold
 			Visible: False
-		TooltipContainer@TOOLTIP_CONTAINER:
+		TooltipContainer@GAMESAVE_TOOLTIP_CONTAINER:

--- a/mods/common/chrome/lobby-music.yaml
+++ b/mods/common/chrome/lobby-music.yaml
@@ -144,11 +144,14 @@ Container@LOBBY_MUSIC_BIN:
 					Height: 25
 					X: 2
 					Visible: false
+					EnableChildMouseOver: True
 					Children:
-						Label@TITLE:
+						LabelWithTooltip@TITLE:
 							X: 10
 							Width: PARENT_RIGHT - 50
 							Height: 25
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
 						Label@LENGTH:
 							X: PARENT_RIGHT - 60
 							Width: 50

--- a/mods/common/chrome/lobby-servers.yaml
+++ b/mods/common/chrome/lobby-servers.yaml
@@ -82,10 +82,12 @@ Container@LOBBY_SERVERS_BIN:
 					Height: 25
 					EnableChildMouseOver: True
 					Children:
-						Label@TITLE:
+						LabelWithTooltip@TITLE:
 							X: 5
 							Width: 245
 							Height: 25
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
 						Image@PASSWORD_PROTECTED:
 							X: 272
 							Y: 6

--- a/mods/common/chrome/missionbrowser.yaml
+++ b/mods/common/chrome/missionbrowser.yaml
@@ -34,11 +34,14 @@ Background@MISSIONBROWSER_PANEL:
 					Width: PARENT_RIGHT - 27
 					Height: 25
 					X: 2
+					EnableChildMouseOver: True
 					Children:
-						Label@TITLE:
+						LabelWithTooltip@TITLE:
 							X: 10
 							Width: PARENT_RIGHT - 20
 							Height: 25
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
 		Container@MISSION_INFO:
 			X: 300
 			Y: 50
@@ -149,6 +152,7 @@ Background@MISSIONBROWSER_PANEL:
 					Y: 1
 					Width: 640
 					Height: 375
+		TooltipContainer@TOOLTIP_CONTAINER:
 
 Background@FULLSCREEN_PLAYER:
 	Width: WINDOW_RIGHT

--- a/mods/common/chrome/multiplayer-browser.yaml
+++ b/mods/common/chrome/multiplayer-browser.yaml
@@ -98,10 +98,12 @@ Background@MULTIPLAYER_PANEL:
 					Height: 25
 					EnableChildMouseOver: True
 					Children:
-						Label@TITLE:
+						LabelWithTooltip@TITLE:
 							X: 5
 							Width: 245
 							Height: 25
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
 						Image@PASSWORD_PROTECTED:
 							X: 272
 							Y: 6

--- a/mods/common/chrome/musicplayer.yaml
+++ b/mods/common/chrome/musicplayer.yaml
@@ -18,11 +18,14 @@ Background@MUSIC_PANEL:
 					X: 2
 					Y: 0
 					Visible: false
+					EnableChildMouseOver: True
 					Children:
-						Label@TITLE:
+						LabelWithTooltip@TITLE:
 							X: 10
 							Width: PARENT_RIGHT - 50
 							Height: 25
+							TooltipContainer: MUSIC_TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
 						Label@LENGTH:
 							Width: 50
 							X: PARENT_RIGHT - 60
@@ -180,3 +183,4 @@ Background@MUSIC_PANEL:
 			Width: 300
 			Height: 20
 			Font: Small
+		TooltipContainer@MUSIC_TOOLTIP_CONTAINER:

--- a/mods/common/chrome/replaybrowser.yaml
+++ b/mods/common/chrome/replaybrowser.yaml
@@ -155,7 +155,7 @@ Background@REPLAYBROWSER_PANEL:
 		Container@REPLAY_LIST_CONTAINER:
 			X: 310
 			Y: 20
-			Width: 245
+			Width: 250
 			Height: PARENT_BOTTOM - 20 - 55
 			Children:
 				Label@REPLAYBROWSER_LABEL_TITLE:
@@ -176,11 +176,14 @@ Background@REPLAYBROWSER_PANEL:
 							Height: 25
 							X: 2
 							Visible: false
+							EnableChildMouseOver: True
 							Children:
-								Label@TITLE:
+								LabelWithTooltip@TITLE:
 									X: 10
 									Width: PARENT_RIGHT - 20
 									Height: 25
+									TooltipContainer: TOOLTIP_CONTAINER
+									TooltipTemplate: SIMPLE_TOOLTIP
 		Container@MAP_PREVIEW_ROOT:
 			X: PARENT_RIGHT - WIDTH - 20
 			Y: 50

--- a/mods/d2k/chrome/missionbrowser.yaml
+++ b/mods/d2k/chrome/missionbrowser.yaml
@@ -34,11 +34,14 @@ Background@MISSIONBROWSER_PANEL:
 					Width: PARENT_RIGHT - 27
 					Height: 25
 					X: 2
+					EnableChildMouseOver: True
 					Children:
-						Label@TITLE:
+						LabelWithTooltip@TITLE:
 							X: 10
 							Width: PARENT_RIGHT - 20
 							Height: 25
+							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipTemplate: SIMPLE_TOOLTIP
 		Label@DIFFICULTY_DESC:
 			X: 210 - WIDTH - 125
 			Y: 468
@@ -152,6 +155,7 @@ Background@MISSIONBROWSER_PANEL:
 					Height: 480
 					AspectRatio: 1.2
 					DrawOverlay: False
+		TooltipContainer@TOOLTIP_CONTAINER:
 
 Background@FULLSCREEN_PLAYER:
 	Width: WINDOW_RIGHT


### PR DESCRIPTION
Truncate text labels that are overflowing their containers and add tooltips to them that display the full text.

Affected panels:
- Savegame browser
- Assets browser
- Replay browser
- Mission browser
- Music player
- Lobby music player
- Server list
- Lobby server list

Notes:
- In a few places I had to add TooltipContainer with a unique name because the tooltips were rendering behind the panel
- ~~Also fixes a bug where tooltips in `lobby-servers.yaml` were not displayed at all~~ (no bug here, that was my bad)

A few screens:
![replay-browser](https://user-images.githubusercontent.com/1355810/58367849-fcca2a80-7eec-11e9-8c42-c5928433b322.png)
Replay browser

![lobby-server-list](https://user-images.githubusercontent.com/1355810/58367884-77934580-7eed-11e9-96ee-f161b76e5d67.png)
Lobby server list

![muisc-player](https://user-images.githubusercontent.com/1355810/58367887-87128e80-7eed-11e9-9ff0-499effcbcc23.png)
Music player

TESTCASE changes the width of some containers to cause an overflow and adds long text to music and mission panels. To test savegame browser type a long name for the save file.

Closes #15026