### PR TITLE
Update macOS launcher tag in fetch-thirdparty-deps-osx.sh.

### DIFF
--- a/thirdparty/fetch-thirdparty-deps-osx.sh
+++ b/thirdparty/fetch-thirdparty-deps-osx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LAUNCHER_TAG="osx-launcher-20190317"
+LAUNCHER_TAG="osx-launcher-20190506"
 
 download_dir="${0%/*}/download/osx"
 mkdir -p "$download_dir"


### PR DESCRIPTION
Fixes an oversight from #16516.