### PR TITLE
Empty the default of TrailSequences in NukePower (version 2)

### DIFF
--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		[SequenceReference("TrailImage")]
 		[Desc("Loop a randomly chosen sequence of TrailImage from this list while this projectile is moving.")]
-		public readonly string[] TrailSequences = { "idle" };
+		public readonly string[] TrailSequences = { };
 
 		[Desc("Interval in ticks between each spawned Trail animation.")]
 		public readonly int TrailInterval = 1;


### PR DESCRIPTION
Second attempt to do #16546 after #16532 accidentally reverted it again.

Closes #16591.