### PR TITLE
Fix WithSpriteBody crashes

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Render/WithEmbeddedTurretSpriteBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithEmbeddedTurretSpriteBody.cs
@@ -58,6 +58,11 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 			: base(init, info, MakeTurretFacingFunc(init.Self))
 		{
 			turreted = init.Self.TraitsImplementing<Turreted>().FirstOrDefault();
+		}
+
+		protected override void TraitEnabled(Actor self)
+		{
+			base.TraitEnabled(self);
 			turreted.QuantizedFacings = DefaultAnimation.CurrentSequence.Facings;
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/Render/WithGunboatBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithGunboatBody.cs
@@ -62,11 +62,16 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 			var name = rs.GetImage(init.Self);
 			turret = init.Self.TraitsImplementing<Turreted>()
 				.First(t => t.Name == info.Turret);
-			turret.QuantizedFacings = DefaultAnimation.CurrentSequence.Facings;
 
 			wake = new Animation(init.World, name);
 			wake.PlayRepeating(info.WakeLeftSequence);
 			rs.Add(new AnimationWithOffset(wake, null, null, -87));
+		}
+
+		protected override void TraitEnabled(Actor self)
+		{
+			base.TraitEnabled(self);
+			turret.QuantizedFacings = DefaultAnimation.CurrentSequence.Facings;
 		}
 
 		void ITick.Tick(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/WithResourceLevelSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResourceLevelSpriteBody.cs
@@ -47,7 +47,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			this.info = info;
 			playerResources = init.Self.Owner.PlayerActor.Trait<PlayerResources>();
-			ConfigureAnimation(init.Self);
 		}
 
 		void ConfigureAnimation(Actor self)
@@ -65,7 +64,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		protected override void TraitEnabled(Actor self)
 		{
-			// Do nothing - we just want to disable the default WithSpriteBody implementation
+			base.TraitEnabled(self);
+			ConfigureAnimation(self);
 		}
 
 		public override void CancelCustomAnimation(Actor self)


### PR DESCRIPTION
by moving references to `DefaultAnimation.CurrentSequence` into `TraitEnabled`.
Fixes #16609.