### PR TITLE
Making units have different weight inside of transports.

### DIFF
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -263,6 +263,7 @@
 	Chronoshiftable:
 	Passenger:
 		CargoType: Vehicle
+		Weight: 4
 	AttackMove:
 	HiddenUnderFog:
 	ActorLostNotification:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -286,8 +286,8 @@ LST:
 		OpenTerrainTypes: Clear, Rough, Road, Ore, Gems, Beach
 	Cargo:
 		Types: Infantry, Vehicle
-		MaxWeight: 5
-		PipCount: 5
+		MaxWeight: 12
+		PipCount: 12
 		PassengerFacing: 0
 		LoadingCondition: notmobile
 	-Chronoshiftable:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -206,6 +206,8 @@ V2RL:
 	Mobile:
 		Speed: 50
 		Locomotor: heavytracked
+	Passenger:
+		Weight: 6
 	RevealsShroud:
 		Range: 7c0
 		RevealGeneratedShroud: False
@@ -363,6 +365,8 @@ MCV:
 	Mobile:
 		Speed: 71
 		Locomotor: heavywheeled
+	Passenger:
+		Weight: 6
 	RevealsShroud:
 		Range: 4c0
 	Transforms:
@@ -807,6 +811,8 @@ QTNK:
 		RequiresCondition: !deployed
 		PauseOnCondition: being-captured
 		Speed: 56
+	Passenger:
+		Weight: 6
 	Chronoshiftable:
 		RequiresCondition: !deployed && !being-captured
 	RevealsShroud:


### PR DESCRIPTION
Closes #3766

Weights would split into 3 tiers
1 - Infantry (1)
2 - Vehicles (4)
3 - Heavy Vehicles (6)
Heavy vehicles would include: MCV, Mammoth Tank, MAD Tank
Harvester is in question whether it should be a Heavy vehicle

<details><summary>Transport would get 12 slots to fill. It may be a visual problem: </summary><img width="97" alt="Screenshot 2019-05-29 at 17 13 25" src="https://user-images.githubusercontent.com/37534529/58566034-83a63c80-8238-11e9-87b8-304720db6207.png">
<img width="136" alt="Screenshot 2019-05-29 at 17 12 58" src="https://user-images.githubusercontent.com/37534529/58566038-85700000-8238-11e9-8672-12c32af46248.png"></details>

There is a way to avoid it by making its size 16, then following a new wight system 1/6/10 but with 12 it's just smoother. On a side note we should give modders tools to control how rows of pips are laid out.

In the end 12 infantry or 3 light/medium vehicles or 2 heavy vehicles would be able to fit inside transport. I think it's the perfect amount as it is easy to load/unload, 3 transports can carry a medium sized army and transports cost about the same as an average light vehicle $700.