### PR TITLE
Simplifying Selection Tiers

### DIFF
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -626,7 +626,7 @@
 		RequiresCondition: cruising
 	BodyOrientation:
 		UseClassicFacingFudge: True
-		 
+	
 ^BasicBuilding:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^IronCurtainable

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -626,7 +626,7 @@
 		RequiresCondition: cruising
 	BodyOrientation:
 		UseClassicFacingFudge: True
-
+		 
 ^BasicBuilding:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^IronCurtainable

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -633,10 +633,9 @@
 	Inherits@3: ^SpriteActor
 	Inherits@shape: ^1x1Shape
 	Inherits@bounty: ^GlobalBounty
+	Inherits@SELECTION_TIER: ^SelectableBuilding
 	SelectionDecorations:
 	WithSpriteControlGroupDecoration:
-	Selectable:
-		Priority: 3
 	Targetable:
 		TargetTypes: Ground, C4, DetonateAttack, Structure
 	Building:
@@ -718,6 +717,7 @@
 
 ^Defense:
 	Inherits: ^Building
+	Inherits@SELECTION_TIER: ^SelectableCombatBuilding
 	Selectable:
 		Bounds: 24,24
 	Targetable:
@@ -1212,3 +1212,24 @@
 		Types: SpyInfiltrate
 	Power:
 		RequiresCondition: !disabled
+
+
+^SelectableCombatUnit:
+	Selectable:
+		Priority: 10
+
+^SelectableSupportUnit:
+	Selectable:
+		Priority: 8
+
+^SelectableEconomicUnit:
+	Selectable:
+		Priority: 6
+
+^SelectableCombatBuilding:
+	Selectable:
+		Priority: 4
+
+^SelectableBuilding:
+	Selectable:
+		Priority: 2

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -650,7 +650,7 @@
 	SoundOnDamageTransition:
 		DamagedSounds: kaboom1.aud
 		DestroyedSounds: kaboom22.aud
-	WithSpriteBody:
+	WithSpriteBody:  
 	Explodes:
 		Type: Footprint
 		Weapon: BuildingExplode

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -244,6 +244,7 @@ E4:
 
 E6:
 	Inherits: ^Soldier
+	Inherits@SELECTION_TIER: ^SelectableSupportUnit
 	Buildable:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
@@ -284,8 +285,6 @@ E6:
 		EnterBlockedCursor: move-blocked
 	Voiced:
 		VoiceSet: EngineerVoice
-	Selectable:
-		Priority: 5
 	-AttackFrontal:
 
 SPY:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -193,7 +193,7 @@ E3:
 		Prerequisites: barracks.upgraded
 	AutoTarget:
 		ScanRadius: 5
-
+	 	 
 E3R1:
 	Inherits: E3
 	RenderSprites:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -193,7 +193,7 @@ E3:
 		Prerequisites: barracks.upgraded
 	AutoTarget:
 		ScanRadius: 5
-	 	 
+	
 E3R1:
 	Inherits: E3
 	RenderSprites:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -666,7 +666,7 @@ DOME:
 	ProvidesPrerequisite@buildingname:
 	ExternalCondition@JAMMED:
 		Condition: jammed
-
+ 
 PBOX:
 	Inherits: ^Defense
 	Inherits@AUTOTARGET: ^AutoTargetAll

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -289,6 +289,7 @@ ARTY:
 
 HARV:
 	Inherits: ^Vehicle
+	Inherits@SELECTION_TIER: ^SelectableEconomicUnit
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 10
@@ -300,7 +301,6 @@ HARV:
 		Name: Ore Truck
 		GenericName: Harvester
 	Selectable:
-		Priority: 7
 		DecorationBounds: 42,42
 	SelectionDecorations:
 	Harvester:
@@ -342,6 +342,7 @@ HARV:
 
 MCV:
 	Inherits: ^Vehicle
+	Inherits@SELECTION_TIER: ^SelectableSupportUnit
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 90
@@ -353,7 +354,6 @@ MCV:
 	Tooltip:
 		Name: Mobile Construction Vehicle
 	Selectable:
-		Priority: 4
 		DecorationBounds: 42,42
 	SelectionDecorations:
 	Health:
@@ -468,6 +468,7 @@ APC:
 
 MNLY:
 	Inherits: ^TrackedVehicle
+	Inherits@SELECTION_TIER: ^SelectableSupportUnit
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 100
@@ -480,7 +481,6 @@ MNLY:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Selectable:
-		Priority: 5
 	Health:
 		HP: 15000
 	Armor:
@@ -511,6 +511,7 @@ MNLY:
 
 TRUK:
 	Inherits: ^Vehicle
+	Inherits@SELECTION_TIER: ^SelectableEconomicUnit
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 20
@@ -520,8 +521,6 @@ TRUK:
 		Cost: 500
 	Tooltip:
 		Name: Supply Truck
-	Selectable:
-		Priority: 6
 	Health:
 		HP: 11000
 	Armor:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -286,7 +286,7 @@ ARTY:
 		LoadedChance: 75
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
-
+ 
 HARV:
 	Inherits: ^Vehicle
 	Inherits@SELECTION_TIER: ^SelectableEconomicUnit


### PR DESCRIPTION
This is in regard to https://github.com/OpenRA/OpenRA/issues/16555

Simplifies the way selection tiers works and changes some of them so that selections work in a way that further prioritizes combat units and buildings.