### PR TITLE
Introduce AI production considerations

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/BotProductionConsideration.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotProductionConsideration.cs
@@ -1,0 +1,93 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Controls AI production.")]
+	public class BotProductionConsiderationInfo : ConditionalTraitInfo
+	{
+		[FieldLoader.LoadUsing("LoadActors", true)]
+		[Desc("Dictionary of [actor id]: [desired percentage of army/base composition].",
+			"Composition percentages are calculated for each queue counting only actors with considerations in that queue.",
+			"Limit and Delay nodes can be added to limit or delay when actors should be produced.")]
+		public readonly Dictionary<string, ActorConsideration> Actors = new Dictionary<string, ActorConsideration>();
+
+		[FieldLoader.Require]
+		[Desc("Production queues that the consideration applies to.")]
+		public readonly HashSet<string> Queues = new HashSet<string>();
+
+		[Desc("Considerations with larger priorities will override definitions from lower priorities.")]
+		public readonly int Priority = 1;
+
+		public override object Create(ActorInitializer init) { return new BotProductionConsideration(this); }
+
+		static object LoadActors(MiniYaml yaml)
+		{
+			var ret = new Dictionary<string, ActorConsideration>();
+			var actors = yaml.Nodes.FirstOrDefault(n => n.Key == "Actors");
+			if (actors != null)
+				foreach (var a in actors.Value.Nodes)
+					ret[a.Key] = new ActorConsideration(a.Value);
+
+			return ret;
+		}
+
+		public class ActorConsideration
+		{
+			public readonly int Percentage = -1;
+			public readonly int Limit = -1;
+			public readonly int Delay = -1;
+
+			public ActorConsideration(MiniYaml yaml)
+			{
+				if (!string.IsNullOrEmpty(yaml.Value))
+					Percentage = FieldLoader.GetValue<int>("Percentage", yaml.Value);
+
+				var limitsNode = yaml.Nodes.FirstOrDefault(n => n.Key == "Limit");
+				if (limitsNode != null)
+					Limit = FieldLoader.GetValue<int>("Limit", limitsNode.Value.Value);
+
+				var delayNode = yaml.Nodes.FirstOrDefault(n => n.Key == "Delay");
+				if (delayNode != null)
+					Delay = FieldLoader.GetValue<int>("Delay", delayNode.Value.Value);
+			}
+		}
+	}
+
+	public class BotProductionConsideration : ConditionalTrait<BotProductionConsiderationInfo>
+	{
+		IBotNotifyProductionConsiderationsUpdated[] production;
+
+		public BotProductionConsideration(BotProductionConsiderationInfo info)
+			: base(info) { }
+
+		protected override void Created(Actor self)
+		{
+			base.Created(self);
+			production = self.TraitsImplementing<IBotNotifyProductionConsiderationsUpdated>().ToArray();
+		}
+
+		protected override void TraitEnabled(Actor self)
+		{
+			foreach (var p in production.Where(Exts.IsTraitEnabled))
+				p.ProductionConsiderationsUpdated(Info.Queues);
+		}
+
+		protected override void TraitDisabled(Actor self)
+		{
+			foreach (var p in production.Where(Exts.IsTraitEnabled))
+				p.ProductionConsiderationsUpdated(Info.Queues);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
@@ -18,29 +18,22 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Controls AI unit production.")]
 	public class UnitBuilderBotModuleInfo : ConditionalTraitInfo
 	{
-		// TODO: Investigate whether this might the (or at least one) reason why bots occasionally get into a state of doing nothing.
-		// Reason: If this is less than SquadSize, the bot might get stuck between not producing more units due to this,
-		// but also not creating squads since there aren't enough idle units.
-		[Desc("Only produce units as long as there are less than this amount of units idling inside the base.")]
-		public readonly int IdleBaseUnitsMaximum = 12;
-
 		[Desc("Production queues AI uses for producing units.")]
 		public readonly HashSet<string> UnitQueues = new HashSet<string> { "Vehicle", "Infantry", "Plane", "Ship", "Aircraft" };
-
-		[Desc("What units to the AI should build.", "What relative share of the total army must be this type of unit.")]
-		public readonly Dictionary<string, int> UnitsToBuild = null;
-
-		[Desc("What units should the AI have a maximum limit to train.")]
-		public readonly Dictionary<string, int> UnitLimits = null;
-
-		[Desc("When should the AI start train specific units.")]
-		public readonly Dictionary<string, int> UnitDelays = null;
 
 		public override object Create(ActorInitializer init) { return new UnitBuilderBotModule(init.Self, this); }
 	}
 
-	public class UnitBuilderBotModule : ConditionalTrait<UnitBuilderBotModuleInfo>, IBotTick, IBotNotifyIdleBaseUnits, IBotRequestUnitProduction, IGameSaveTraitData
+	public class UnitBuilderBotModule : ConditionalTrait<UnitBuilderBotModuleInfo>, IBotTick, IBotRequestUnitProduction,
+		IGameSaveTraitData, IBotNotifyProductionConsiderationsUpdated
 	{
+		public class UnitProductionConsideration
+		{
+			public int Percentage;
+			public int Limit = -1;
+			public int Delay = -1;
+		}
+
 		public const int FeedbackTime = 30; // ticks; = a bit over 1s. must be >= netlag.
 
 		readonly World world;
@@ -49,7 +42,11 @@ namespace OpenRA.Mods.Common.Traits
 		readonly List<string> queuedBuildRequests = new List<string>();
 
 		IBotRequestPauseUnitProduction[] requestPause;
-		int idleUnitCount;
+		BotProductionConsideration[] considerations;
+		bool considerationsDirty = true;
+
+		readonly Dictionary<string, Dictionary<string, UnitProductionConsideration>> resolvedConsiderations =
+			new Dictionary<string, Dictionary<string, UnitProductionConsideration>>();
 
 		int ticks;
 
@@ -67,15 +64,44 @@ namespace OpenRA.Mods.Common.Traits
 			// so we must query player traits from self, which refers
 			// for bot modules always to the Player actor.
 			requestPause = self.TraitsImplementing<IBotRequestPauseUnitProduction>().ToArray();
-		}
-
-		void IBotNotifyIdleBaseUnits.UpdatedIdleBaseUnits(List<Actor> idleUnits)
-		{
-			idleUnitCount = idleUnits.Count;
+			considerations = self.TraitsImplementing<BotProductionConsideration>()
+				.Where(c => c.Info.Queues.Overlaps(Info.UnitQueues))
+				.OrderBy(c => c.Info.Priority)
+				.ToArray();
 		}
 
 		void IBotTick.BotTick(IBot bot)
 		{
+			if (considerationsDirty)
+			{
+				resolvedConsiderations.Clear();
+				foreach (var c in considerations)
+				{
+					if (c.IsTraitDisabled)
+						continue;
+
+					foreach (var queue in c.Info.Queues)
+					{
+						var queueConsideration = resolvedConsiderations.GetOrAdd(queue);
+						foreach (var a in c.Info.Actors)
+						{
+							var queueActorConsideration = queueConsideration.GetOrAdd(a.Key);
+
+							if (a.Value.Percentage >= 0)
+								queueActorConsideration.Percentage = a.Value.Percentage;
+
+							if (a.Value.Limit >= 0)
+								queueActorConsideration.Limit = a.Value.Limit;
+
+							if (a.Value.Delay >= 0)
+								queueActorConsideration.Delay = a.Value.Delay;
+						}
+					}
+				}
+
+				considerationsDirty = false;
+			}
+
 			if (requestPause.Any(rp => rp.PauseUnitProduction))
 				return;
 
@@ -90,8 +116,22 @@ namespace OpenRA.Mods.Common.Traits
 					queuedBuildRequests.Remove(buildRequest);
 				}
 
-				foreach (var q in Info.UnitQueues)
-					BuildUnit(bot, q, idleUnitCount < Info.IdleBaseUnitsMaximum);
+				var idleQueues = Info.UnitQueues.Select(queue => AIUtils.FindQueues(player, queue)
+					.FirstOrDefault(q => !q.AllQueued().Any()))
+					.Where(q => q != null)
+					.ToList();
+
+				if (idleQueues.Any())
+				{
+					var ownedActorCounts = player.World.Actors
+						.Where(a => a.Owner == player)
+						.Select(a => a.Info.Name)
+						.GroupBy(a => a)
+						.ToDictionary(a => a.Key, a => a.Count());
+
+					foreach (var q in idleQueues)
+						BuildUnit(bot, q, ownedActorCounts);
+				}
 			}
 		}
 
@@ -105,36 +145,64 @@ namespace OpenRA.Mods.Common.Traits
 			return queuedBuildRequests.Count(r => r == requestedActor);
 		}
 
-		void BuildUnit(IBot bot, string category, bool buildRandom)
+		void BuildUnit(IBot bot, ProductionQueue queue, Dictionary<string, int> ownedActorCounts)
 		{
-			// Pick a free queue
-			var queue = AIUtils.FindQueues(player, category).FirstOrDefault(q => !q.AllQueued().Any());
-			if (queue == null)
+			Dictionary<string, UnitProductionConsideration> queueConsiderations;
+			if (!resolvedConsiderations.TryGetValue(queue.Info.Type, out queueConsiderations))
 				return;
 
-			var unit = buildRandom ?
-				ChooseRandomUnitToBuild(queue) :
-				ChooseUnitToBuild(queue);
+			// Create a random list of actors that are buildable and valid considerations
+			var buildableConsiderations = queue.BuildableItems().Where(ai =>
+			{
+				UnitProductionConsideration unitConsideratation;
+				if (!queueConsiderations.TryGetValue(ai.Name, out unitConsideratation))
+					return false;
 
-			if (unit == null)
+				if (unitConsideratation.Delay > world.WorldTick || unitConsideratation.Limit == 0)
+					return false;
+
+				int ownedActorCount;
+				if (unitConsideratation.Limit > 0 && ownedActorCounts.TryGetValue(ai.Name, out ownedActorCount) && ownedActorCount > unitConsideratation.Limit)
+					return false;
+
+				return HasAdequateAirUnitReloadBuildings(ai);
+			}).Select(b => b.Name).Shuffle(world.LocalRandom).ToList();
+
+			if (!buildableConsiderations.Any())
 				return;
 
-			var name = unit.Name;
+			var queueTotal = ownedActorCounts
+				.Where(c => queueConsiderations.ContainsKey(c.Key))
+				.Select(c => c.Value)
+				.Sum();
 
-			if (Info.UnitsToBuild != null && !Info.UnitsToBuild.ContainsKey(name))
-				return;
+			// Choose an actor to try and balance out the defined composition percentages
+			string build = null;
+			foreach (var b in buildableConsiderations)
+			{
+				int owned = 0;
+				ownedActorCounts.TryGetValue(b, out owned);
 
-			if (Info.UnitDelays != null &&
-				Info.UnitDelays.ContainsKey(name) &&
-				Info.UnitDelays[name] > world.WorldTick)
-				return;
+				var desiredPercentage = queueConsiderations[b].Percentage;
+				if (owned * 100 < desiredPercentage * queueTotal)
+				{
+					AIUtils.BotDebug("{0} decided to build {1}: Desired is {2:F1} current is {3}",
+						queue.Actor.Owner, b, desiredPercentage * queueTotal / 100.0, owned);
 
-			if (Info.UnitLimits != null &&
-				Info.UnitLimits.ContainsKey(name) &&
-				world.Actors.Count(a => a.Owner == player && a.Info.Name == name) >= Info.UnitLimits[name])
-				return;
+					build = b;
+					break;
+				}
+			}
 
-			bot.QueueOrder(Order.StartProduction(queue.Actor, name, 1));
+			// Pick first random choice if there is no preference
+			if (build == null)
+			{
+				build = buildableConsiderations.First();
+				AIUtils.BotDebug("{0} decided to build {1}: Random available consideration",
+					queue.Actor.Owner, build);
+			}
+
+			bot.QueueOrder(Order.StartProduction(queue.Actor, build, 1));
 		}
 
 		// In cases where we want to build a specific unit but don't know the queue name (because there's more than one possibility)
@@ -161,36 +229,6 @@ namespace OpenRA.Mods.Common.Traits
 				bot.QueueOrder(Order.StartProduction(queue.Actor, name, 1));
 				AIUtils.BotDebug("AI: {0} decided to build {1} (external request)", queue.Actor.Owner, name);
 			}
-		}
-
-		ActorInfo ChooseRandomUnitToBuild(ProductionQueue queue)
-		{
-			var buildableThings = queue.BuildableItems();
-			if (!buildableThings.Any())
-				return null;
-
-			var unit = buildableThings.Random(world.LocalRandom);
-			return HasAdequateAirUnitReloadBuildings(unit) ? unit : null;
-		}
-
-		ActorInfo ChooseUnitToBuild(ProductionQueue queue)
-		{
-			var buildableThings = queue.BuildableItems();
-			if (!buildableThings.Any())
-				return null;
-
-			var myUnits = player.World
-				.ActorsHavingTrait<IPositionable>()
-				.Where(a => a.Owner == player)
-				.Select(a => a.Info.Name).ToList();
-
-			foreach (var unit in Info.UnitsToBuild.Shuffle(world.LocalRandom))
-				if (buildableThings.Any(b => b.Name == unit.Key))
-					if (myUnits.Count(a => a == unit.Key) * 100 < unit.Value * myUnits.Count)
-						if (HasAdequateAirUnitReloadBuildings(world.Map.Rules.Actors[unit.Key]))
-							return world.Map.Rules.Actors[unit.Key];
-
-			return null;
 		}
 
 		// For mods like RA (number of RearmActors must match the number of aircraft)
@@ -221,7 +259,6 @@ namespace OpenRA.Mods.Common.Traits
 			return new List<MiniYamlNode>()
 			{
 				new MiniYamlNode("QueuedBuildRequests", FieldSaver.FormatValue(queuedBuildRequests.ToArray())),
-				new MiniYamlNode("IdleUnitCount", FieldSaver.FormatValue(idleUnitCount))
 			};
 		}
 
@@ -236,10 +273,12 @@ namespace OpenRA.Mods.Common.Traits
 				queuedBuildRequests.Clear();
 				queuedBuildRequests.AddRange(FieldLoader.GetValue<string[]>("QueuedBuildRequests", queuedBuildRequestsNode.Value.Value));
 			}
+		}
 
-			var idleUnitCountNode = data.FirstOrDefault(n => n.Key == "IdleUnitCount");
-			if (idleUnitCountNode != null)
-				idleUnitCount = FieldLoader.GetValue<int>("IdleUnitCount", idleUnitCountNode.Value.Value);
+		void IBotNotifyProductionConsiderationsUpdated.ProductionConsiderationsUpdated(HashSet<string> queues)
+		{
+			if (queues.Overlaps(Info.UnitQueues))
+				considerationsDirty = true;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -518,6 +518,12 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[RequireExplicitImplementation]
+	public interface IBotNotifyProductionConsiderationsUpdated
+	{
+		void ProductionConsiderationsUpdated(HashSet<string> queues);
+	}
+
+	[RequireExplicitImplementation]
 	public interface IEditorActorOptions : ITraitInfoInterface
 	{
 		IEnumerable<EditorActorOption> ActorOptions(ActorInfo ai, World world);

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ExtractBotProductionConsiderations.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/ExtractBotProductionConsiderations.cs
@@ -1,0 +1,116 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Primitives;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class ExtractBotProductionConsiderations : UpdateRule
+	{
+		public override string Name { get { return "Extract BotProductionConsiderations"; } }
+		public override string Description
+		{
+			get
+			{
+				return "UnitsToBuild/UnitLimits/UnitDelays have been extracted from UnitBuilderBotModule\n" +
+				"and BuildingFractions/BuildingLimits/BuildingDelays from BaseBuilderBotModule\n" +
+				"into a new BotProductionConsideration trait.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var actors = new Dictionary<string, MiniYaml>();
+			var addNodes = new List<MiniYamlNode>();
+
+			var modules = new List<Tuple<string, string, string, string, string[], string>>
+			{
+				new Tuple<string, string, string, string, string[], string>(
+					"UnitBuilderBotModule", "UnitsToBuild", "UnitLimits", "UnitDelays",
+					new[] { "UnitQueues" }, "units"),
+				new Tuple<string, string, string, string, string[], string>(
+					"BaseBuilderBotModule", "BuildingFractions", "BuildingLimits", "BuildingDelays",
+					new[] { "BuildingQueues", "DefenseQueues" }, "buildings")
+			};
+
+			foreach (var module in modules)
+			{
+				foreach (var moduleNode in actorNode.ChildrenMatching(module.Item1))
+				{
+					actors.Clear();
+
+					var fractionsNode = moduleNode.LastChildMatching(module.Item2);
+					if (fractionsNode != null)
+					{
+						foreach (var kv in fractionsNode.Value.Nodes)
+							actors[kv.Key] = new MiniYaml(kv.Value.Value);
+						moduleNode.RemoveNode(fractionsNode);
+					}
+
+					var limitsNode = moduleNode.LastChildMatching(module.Item3);
+					if (limitsNode != null)
+					{
+						MiniYaml sharesNode;
+						foreach (var kv in limitsNode.Value.Nodes)
+							if (actors.TryGetValue(kv.Key, out sharesNode))
+								sharesNode.Nodes.Add(new MiniYamlNode("Limit", kv.Value.Value));
+						moduleNode.RemoveNode(limitsNode);
+					}
+
+					var delayNode = moduleNode.LastChildMatching(module.Item4);
+					if (delayNode != null)
+					{
+						MiniYaml sharesNode;
+						foreach (var kv in delayNode.Value.Nodes)
+							if (actors.TryGetValue(kv.Key, out sharesNode))
+								sharesNode.Nodes.Add(new MiniYamlNode("Delay", kv.Value.Value));
+						moduleNode.RemoveNode(delayNode);
+					}
+
+					var requiresNode = moduleNode.LastChildMatching("RequiresCondition");
+
+					var considerationKey = "BotProductionConsideration@" + module.Item6;
+					var suffix = moduleNode.KeySuffix();
+					if (!string.IsNullOrEmpty(suffix))
+						considerationKey += "-" + suffix;
+
+					var considerationNodes = new List<MiniYamlNode>();
+					if (requiresNode != null)
+						considerationNodes.Add(requiresNode);
+
+					var queues = new HashSet<string>();
+					foreach (var queueKey in module.Item5)
+					{
+						var queueNode = moduleNode.LastChildMatching(queueKey);
+						if (queueNode != null)
+							foreach (var queue in FieldLoader.GetValue<string[]>(queueKey, queueNode.Value.Value))
+								queues.Add(queue);
+					}
+
+					considerationNodes.Add(new MiniYamlNode("Queues", FieldSaver.FormatValue(queues)));
+
+					considerationNodes.Add(new MiniYamlNode("Actors", "", actors.Select(
+						kv => new MiniYamlNode(kv.Key, kv.Value)).ToList()));
+
+					addNodes.Add(new MiniYamlNode(considerationKey, "", considerationNodes));
+				}
+			}
+
+			foreach (var node in addNodes)
+				actorNode.AddNode(node);
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -65,6 +65,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new SpawnActorPowerDefaultEffect(),
 				new RemoveConditionManager(),
 				new ConvertSupportPowerRangesToFootprint(),
+				new ExtractBotProductionConsiderations(),
 			})
 		};
 

--- a/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdateUtils.cs
@@ -274,6 +274,12 @@ namespace OpenRA.Mods.Common.UpdateRules
 				node.Key = prefix + newKey;
 		}
 
+		public static string KeySuffix(this MiniYamlNode node)
+		{
+			var split = node.Key.IndexOf("@", StringComparison.Ordinal);
+			return split > -1 ? node.Key.Substring(split + 1) : "";
+		}
+
 		public static T NodeValue<T>(this MiniYamlNode node)
 		{
 			return FieldLoader.GetValue<T>(node.Key, node.Value.Value);

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -158,80 +158,103 @@ Player:
 	UnitBuilderBotModule@hal9001:
 		RequiresCondition: enable-hal9001-ai
 		UnitQueues: Vehicle.Nod, Vehicle.GDI, Infantry.Nod, Infantry.GDI, Aircraft.Nod, Aircraft.GDI
-	BotProductionConsideration@units-cabal:
-		RequiresCondition: enable-cabal-ai
+	BotProductionConsideration@units-default:
+		RequiresCondition: enable-cabal-ai || enable-watson-ai || enable-hal9001-ai
 		Queues: Vehicle.Nod, Vehicle.GDI, Infantry.Nod, Infantry.GDI, Aircraft.Nod, Aircraft.GDI
 		Actors:
 			e1: 65
-			e2: 25
+			e2: 30
 			e3: 40
 			e4: 15
 			e5: 15
 			harv: 10
 				Limit: 8
-			bggy: 5
-			bike: 40
-			ltnk: 25
+			bggy: 10
+			bike: 10
+			ltnk: 40
 			ftnk: 10
 			arty: 60
 			stnk: 40
+			jeep: 20
+			mtnk: 50
+			msam: 50
+			htnk: 50
+			heli: 10
+			orca: 10
+	BotProductionConsideration@units-cabal:
+		RequiresCondition: enable-cabal-ai
+		Queues: Vehicle.Nod, Vehicle.GDI, Infantry.Nod, Infantry.GDI, Aircraft.Nod, Aircraft.GDI
+		Priority: 2
+		Actors:
+			e2: 25
+			e4: 15
+			e5: 15
+			bggy: 5
+			bike: 40
+			ltnk: 25
+			arty: 60
 			jeep: 5
 			mtnk: 20
 			msam: 40
-			htnk: 50
 			heli: 5
 			orca: 5
 	BotProductionConsideration@units-watson:
 		RequiresCondition: enable-watson-ai
 		Queues: Vehicle.Nod, Vehicle.GDI, Infantry.Nod, Infantry.GDI, Aircraft.Nod, Aircraft.GDI
+		Priority: 2
 		Actors:
-			e1: 65
-			e2: 30
-			e3: 40
 			e4: 30
 			e5: 30
-			harv: 10
-				Limit: 8
-			bggy: 10
-			ftnk: 10
 			arty: 40
-			bike: 10
-			heli: 10
-			ltnk: 40
-			stnk: 40
-			orca: 10
-			msam: 50
-			htnk: 50
-			jeep: 20
-			mtnk: 50
 	BotProductionConsideration@units-hal9001:
 		RequiresCondition: enable-hal9001-ai
 		Queues: Vehicle.Nod, Vehicle.GDI, Infantry.Nod, Infantry.GDI, Aircraft.Nod, Aircraft.GDI
+		Priority: 2
 		Actors:
-			e1: 65
-			e2: 30
-			e3: 40
 			e4: 50
 			e5: 50
 			harv: 16
 				Limit: 8
-			bggy: 10
-			bike: 10
-			ltnk: 40
 			arty: 20
 			ftnk: 5
-			stnk: 40
 			mlrs: 5
-			heli: 10
-			jeep: 20
 			apc: 10
-			mtnk: 50
-			msam: 50
-			htnk: 50
-			orca: 10
+	BotProductionConsideration@buildings-default:
+		RequiresCondition: enable-cabal-ai || enable-watson-ai || enable-hal9001-ai
+		Queues: Building.Nod, Building.GDI, Defence.Nod, Defence.GDI
+		Actors:
+			nuke: 10
+			nuk2: 10
+			proc: 20
+				Limit: 4
+			silo: 10
+			pyle: 5
+				Limit: 3
+			hand: 5
+				Limit: 3
+			afld: 9
+				Limit: 3
+			weap: 9
+				Limit: 3
+			hpad: 4
+				Limit: 0
+			hq: 1
+				Limit: 1
+			fix: 1
+				Limit: 1
+			eye: 1
+				Limit: 1
+			tmpl: 1
+				Limit: 1
+			gun: 5
+			sam: 7
+			obli: 7
+			gtwr: 5
+			atwr: 9
 	BotProductionConsideration@buildings-cabal:
 		RequiresCondition: enable-cabal-ai
 		Queues: Building.Nod, Building.GDI, Defence.Nod, Defence.GDI
+		Priority: 2
 		Actors:
 			proc: 20
 				Limit: 4
@@ -239,28 +262,18 @@ Player:
 				Limit: 3
 			hand: 5
 				Limit: 3
-			hq: 4
-				Limit: 1
-			weap: 9
-				Limit: 3
 			afld: 9
 				Limit: 3
-			gtwr: 5
-			gun: 5
-			atwr: 9
-			obli: 7
-			sam: 7
-			eye: 1
-				Limit: 1
-			tmpl: 1
-				Limit: 1
-			fix: 1
-				Limit: 1
+			weap: 9
+				Limit: 3
 			hpad: 2
 				Limit: 0
+			hq: 4
+				Limit: 1
 	BotProductionConsideration@buildings-watson:
 		RequiresCondition: enable-watson-ai
 		Queues: Building.Nod, Building.GDI, Defence.Nod, Defence.GDI
+		Priority: 2
 		Actors:
 			proc: 17
 				Limit: 4
@@ -268,51 +281,32 @@ Player:
 				Limit: 3
 			hand: 2
 				Limit: 3
-			hq: 1
-				Limit: 1
-			weap: 5
-				Limit: 3
 			afld: 5
 				Limit: 3
-			hpad: 4
-				Limit: 2
-			gtwr: 5
-			gun: 5
-			atwr: 9
-			obli: 7
-			eye: 1
-				Limit: 1
-			tmpl: 1
-				Limit: 1
-			sam: 7
-			fix: 1
-				Limit: 1
+			weap: 5
+				Limit: 3
 	BotProductionConsideration@buildings-hal9001:
 		RequiresCondition: enable-hal9001-ai
 		Queues: Building.Nod, Building.GDI, Defence.Nod, Defence.GDI
+		Priority: 2
 		Actors:
 			proc: 17
 				Limit: 4
-			pyle: 7
+			pyle: 8
 				Limit: 4
-			hand: 9
-				Limit: 4
-			hq: 1
-				Limit: 1
-			weap: 8
+			hand: 8
 				Limit: 4
 			afld: 6
 				Limit: 4
-			hpad: 4
+			weap: 8
+				Limit: 4
+	GrantConditionOnPrerequisite@enable-ai-hpad:
+		Condition: enable-ai-hpad
+		Prerequisites: anyhq
+	BotProductionConsideration@enable-ai-hpad:
+		RequiresCondition: (enable-cabal-ai || enable-watson-ai || enable-hal9001-ai) && enable-ai-hpad
+		Queues: Building.Nod, Building.GDI
+		Priority: 3
+		Actors:
+			hpad:
 				Limit: 2
-			gtwr: 5
-			gun: 5
-			atwr: 9
-			obli: 7
-			eye: 1
-				Limit: 1
-			tmpl: 1
-				Limit: 1
-			sam: 7
-			fix: 1
-				Limit: 1

--- a/mods/cnc/rules/ai.yaml
+++ b/mods/cnc/rules/ai.yaml
@@ -97,34 +97,6 @@ Player:
 		VehiclesFactoryTypes: weap,afld
 		ProductionTypes: pyle,hand,weap,afld,hpad
 		SiloTypes: silo
-		BuildingLimits:
-			proc: 4
-			pyle: 3
-			hand: 3
-			hq: 1
-			weap: 3
-			afld: 3
-			hpad: 0
-			eye: 1
-			tmpl: 1
-			fix: 1
-			silo: 1
-		BuildingFractions:
-			proc: 20
-			pyle: 5
-			hand: 5
-			hq: 4
-			weap: 9
-			afld: 9
-			gtwr: 5
-			gun: 5
-			atwr: 9
-			obli: 7
-			sam: 7
-			eye: 1
-			tmpl: 1
-			fix: 1
-			hpad: 2
 	BaseBuilderBotModule@watson:
 		RequiresCondition: enable-watson-ai
 		BuildingQueues: Building.Nod, Building.GDI
@@ -140,34 +112,6 @@ Player:
 		VehiclesFactoryTypes: weap,afld
 		ProductionTypes: pyle,hand,weap,afld,hpad
 		SiloTypes: silo
-		BuildingLimits:
-			proc: 4
-			pyle: 3
-			hand: 3
-			hq: 1
-			weap: 3
-			afld: 3
-			hpad: 2
-			eye: 1
-			tmpl: 1
-			fix: 1
-			silo: 1
-		BuildingFractions:
-			proc: 17
-			pyle: 2
-			hand: 2
-			hq: 1
-			weap: 5
-			afld: 5
-			hpad: 4
-			gtwr: 5
-			gun: 5
-			atwr: 9
-			obli: 7
-			eye: 1
-			tmpl: 1
-			sam: 7
-			fix: 1
 	BaseBuilderBotModule@hal9001:
 		RequiresCondition: enable-hal9001-ai
 		BuildingQueues: Building.Nod, Building.GDI
@@ -183,34 +127,6 @@ Player:
 		VehiclesFactoryTypes: weap,afld
 		ProductionTypes: pyle,hand,weap,afld,hpad
 		SiloTypes: silo
-		BuildingLimits:
-			proc: 4
-			pyle: 4
-			hand: 4
-			hq: 1
-			weap: 4
-			afld: 4
-			hpad: 2
-			eye: 1
-			tmpl: 1
-			fix: 1
-			silo: 1
-		BuildingFractions:
-			proc: 17
-			pyle: 7
-			hand: 9
-			hq: 1
-			weap: 8
-			afld: 6
-			hpad: 4
-			gtwr: 5
-			gun: 5
-			atwr: 9
-			obli: 7
-			eye: 1
-			tmpl: 1
-			sam: 7
-			fix: 1
 	BuildingRepairBotModule:
 		RequiresCondition: enable-cabal-ai || enable-watson-ai || enable-hal9001-ai
 	SquadManagerBotModule@cabal:
@@ -221,27 +137,6 @@ Player:
 	UnitBuilderBotModule@cabal:
 		RequiresCondition: enable-cabal-ai
 		UnitQueues: Vehicle.Nod, Vehicle.GDI, Infantry.Nod, Infantry.GDI, Aircraft.Nod, Aircraft.GDI
-		UnitsToBuild:
-			e1: 65
-			e2: 25
-			e3: 40
-			e4: 15
-			e5: 15
-			harv: 10
-			bggy: 5
-			bike: 40
-			ltnk: 25
-			ftnk: 10
-			arty: 60
-			stnk: 40
-			jeep: 5
-			mtnk: 20
-			msam: 40
-			htnk: 50
-			heli: 5
-			orca: 5
-		UnitLimits:
-			harv: 8
 	McvManagerBotModule:
 		RequiresCondition: enable-cabal-ai || enable-watson-ai || enable-hal9001-ai
 		McvTypes: mcv
@@ -255,13 +150,48 @@ Player:
 	UnitBuilderBotModule@watson:
 		RequiresCondition: enable-watson-ai
 		UnitQueues: Vehicle.Nod, Vehicle.GDI, Infantry.Nod, Infantry.GDI, Aircraft.Nod, Aircraft.GDI
-		UnitsToBuild:
+	SquadManagerBotModule@hal9001:
+		RequiresCondition: enable-hal9001-ai
+		SquadSize: 8
+		ExcludeFromSquadsTypes: harv, mcv
+		ConstructionYardTypes: fact
+	UnitBuilderBotModule@hal9001:
+		RequiresCondition: enable-hal9001-ai
+		UnitQueues: Vehicle.Nod, Vehicle.GDI, Infantry.Nod, Infantry.GDI, Aircraft.Nod, Aircraft.GDI
+	BotProductionConsideration@units-cabal:
+		RequiresCondition: enable-cabal-ai
+		Queues: Vehicle.Nod, Vehicle.GDI, Infantry.Nod, Infantry.GDI, Aircraft.Nod, Aircraft.GDI
+		Actors:
+			e1: 65
+			e2: 25
+			e3: 40
+			e4: 15
+			e5: 15
+			harv: 10
+				Limit: 8
+			bggy: 5
+			bike: 40
+			ltnk: 25
+			ftnk: 10
+			arty: 60
+			stnk: 40
+			jeep: 5
+			mtnk: 20
+			msam: 40
+			htnk: 50
+			heli: 5
+			orca: 5
+	BotProductionConsideration@units-watson:
+		RequiresCondition: enable-watson-ai
+		Queues: Vehicle.Nod, Vehicle.GDI, Infantry.Nod, Infantry.GDI, Aircraft.Nod, Aircraft.GDI
+		Actors:
 			e1: 65
 			e2: 30
 			e3: 40
 			e4: 30
 			e5: 30
 			harv: 10
+				Limit: 8
 			bggy: 10
 			ftnk: 10
 			arty: 40
@@ -274,23 +204,17 @@ Player:
 			htnk: 50
 			jeep: 20
 			mtnk: 50
-		UnitLimits:
-			harv: 8
-	SquadManagerBotModule@hal9001:
+	BotProductionConsideration@units-hal9001:
 		RequiresCondition: enable-hal9001-ai
-		SquadSize: 8
-		ExcludeFromSquadsTypes: harv, mcv
-		ConstructionYardTypes: fact
-	UnitBuilderBotModule@hal9001:
-		RequiresCondition: enable-hal9001-ai
-		UnitQueues: Vehicle.Nod, Vehicle.GDI, Infantry.Nod, Infantry.GDI, Aircraft.Nod, Aircraft.GDI
-		UnitsToBuild:
+		Queues: Vehicle.Nod, Vehicle.GDI, Infantry.Nod, Infantry.GDI, Aircraft.Nod, Aircraft.GDI
+		Actors:
 			e1: 65
 			e2: 30
 			e3: 40
 			e4: 50
 			e5: 50
 			harv: 16
+				Limit: 8
 			bggy: 10
 			bike: 10
 			ltnk: 40
@@ -305,5 +229,90 @@ Player:
 			msam: 50
 			htnk: 50
 			orca: 10
-		UnitLimits:
-			harv: 8
+	BotProductionConsideration@buildings-cabal:
+		RequiresCondition: enable-cabal-ai
+		Queues: Building.Nod, Building.GDI, Defence.Nod, Defence.GDI
+		Actors:
+			proc: 20
+				Limit: 4
+			pyle: 5
+				Limit: 3
+			hand: 5
+				Limit: 3
+			hq: 4
+				Limit: 1
+			weap: 9
+				Limit: 3
+			afld: 9
+				Limit: 3
+			gtwr: 5
+			gun: 5
+			atwr: 9
+			obli: 7
+			sam: 7
+			eye: 1
+				Limit: 1
+			tmpl: 1
+				Limit: 1
+			fix: 1
+				Limit: 1
+			hpad: 2
+				Limit: 0
+	BotProductionConsideration@buildings-watson:
+		RequiresCondition: enable-watson-ai
+		Queues: Building.Nod, Building.GDI, Defence.Nod, Defence.GDI
+		Actors:
+			proc: 17
+				Limit: 4
+			pyle: 2
+				Limit: 3
+			hand: 2
+				Limit: 3
+			hq: 1
+				Limit: 1
+			weap: 5
+				Limit: 3
+			afld: 5
+				Limit: 3
+			hpad: 4
+				Limit: 2
+			gtwr: 5
+			gun: 5
+			atwr: 9
+			obli: 7
+			eye: 1
+				Limit: 1
+			tmpl: 1
+				Limit: 1
+			sam: 7
+			fix: 1
+				Limit: 1
+	BotProductionConsideration@buildings-hal9001:
+		RequiresCondition: enable-hal9001-ai
+		Queues: Building.Nod, Building.GDI, Defence.Nod, Defence.GDI
+		Actors:
+			proc: 17
+				Limit: 4
+			pyle: 7
+				Limit: 4
+			hand: 9
+				Limit: 4
+			hq: 1
+				Limit: 1
+			weap: 8
+				Limit: 4
+			afld: 6
+				Limit: 4
+			hpad: 4
+				Limit: 2
+			gtwr: 5
+			gun: 5
+			atwr: 9
+			obli: 7
+			eye: 1
+				Limit: 1
+			tmpl: 1
+				Limit: 1
+			sam: 7
+			fix: 1
+				Limit: 1

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -78,42 +78,6 @@ Player:
 		VehiclesFactoryTypes: light_factory, heavy_factory, starport
 		ProductionTypes: light_factory, heavy_factory, barracks, starport
 		SiloTypes: silo
-		BuildingLimits:
-			barracks: 1
-			refinery: 4
-			outpost: 1
-			high_tech_factory: 1
-			light_factory: 1
-			heavy_factory: 1
-			starport: 1
-			repair_pad: 1
-			research_centre: 1
-			palace: 1
-			upgrade.conyard: 1
-			upgrade.barracks: 1
-			upgrade.light: 1
-			upgrade.heavy: 1
-			upgrade.hightech: 1
-		BuildingFractions:
-			barracks: 1
-			refinery: 20
-			medium_gun_turret: 8
-			outpost: 1
-			high_tech_factory: 1
-			large_gun_turret: 6
-			light_factory: 1
-			heavy_factory: 1
-			starport: 1
-			repair_pad: 1
-			research_centre: 1
-			palace: 1
-			upgrade.conyard: 1
-			upgrade.barracks: 1
-			upgrade.light: 1
-			upgrade.heavy: 1
-			upgrade.hightech: 1
-		BuildingDelays:
-			upgrade.conyard: 3750
 	BaseBuilderBotModule@vidious:
 		RequiresCondition: enable-vidious-ai
 		BuildingQueues: Building, Upgrade
@@ -128,42 +92,6 @@ Player:
 		VehiclesFactoryTypes: light_factory, heavy_factory, starport
 		ProductionTypes: light_factory, heavy_factory, barracks, starport
 		SiloTypes: silo
-		BuildingLimits:
-			barracks: 1
-			refinery: 4
-			outpost: 1
-			high_tech_factory: 1
-			light_factory: 1
-			heavy_factory: 1
-			starport: 1
-			repair_pad: 1
-			research_centre: 1
-			palace: 1
-			upgrade.conyard: 1
-			upgrade.barracks: 1
-			upgrade.light: 1
-			upgrade.heavy: 1
-			upgrade.hightech: 1
-		BuildingFractions:
-			barracks: 1
-			refinery: 20
-			medium_gun_turret: 5
-			outpost: 1
-			high_tech_factory: 1
-			large_gun_turret: 10
-			light_factory: 1
-			heavy_factory: 1
-			starport: 1
-			repair_pad: 1
-			research_centre: 1
-			palace: 1
-			upgrade.conyard: 1
-			upgrade.barracks: 1
-			upgrade.light: 1
-			upgrade.heavy: 1
-			upgrade.hightech: 1
-		BuildingDelays:
-			upgrade.conyard: 3750
 	BaseBuilderBotModule@gladius:
 		RequiresCondition: enable-gladius-ai
 		BuildingQueues: Building, Upgrade
@@ -178,41 +106,6 @@ Player:
 		VehiclesFactoryTypes: light_factory, heavy_factory, starport
 		ProductionTypes: light_factory, heavy_factory, barracks, starport
 		SiloTypes: silo
-		BuildingLimits:
-			barracks: 1
-			refinery: 4
-			outpost: 1
-			high_tech_factory: 1
-			light_factory: 1
-			heavy_factory: 1
-			starport: 1
-			repair_pad: 1
-			research_centre: 1
-			palace: 1
-			upgrade.conyard: 1
-			upgrade.barracks: 1
-			upgrade.light: 1
-			upgrade.heavy: 1
-			upgrade.hightech: 1
-		BuildingFractions:
-			barracks: 1
-			refinery: 20
-			medium_gun_turret: 4
-			outpost: 1
-			high_tech_factory: 1
-			large_gun_turret: 12
-			light_factory: 1
-			heavy_factory: 1
-			repair_pad: 1
-			research_centre: 1
-			palace: 1
-			upgrade.conyard: 1
-			upgrade.barracks: 1
-			upgrade.light: 1
-			upgrade.heavy: 1
-			upgrade.hightech: 1
-		BuildingDelays:
-			upgrade.conyard: 3750
 	BuildingRepairBotModule:
 		RequiresCondition: enable-omnius-ai || enable-vidious-ai || enable-gladius-ai
 	SquadManagerBotModule@omnius:
@@ -225,13 +118,41 @@ Player:
 	UnitBuilderBotModule@omnius:
 		RequiresCondition: enable-omnius-ai
 		UnitQueues: Infantry, Vehicle, Armor, Starport, Aircraft
-		UnitsToBuild:
+	McvManagerBotModule:
+		RequiresCondition: enable-omnius-ai || enable-vidious-ai || enable-gladius-ai
+		McvTypes: mcv
+		ConstructionYardTypes: construction_yard
+		McvFactoryTypes: heavy_factory, starport
+	SquadManagerBotModule@vidious:
+		RequiresCondition: enable-vidious-ai
+		SquadSize: 6
+		MaxBaseRadius: 40
+		ExcludeFromSquadsTypes: harvester, mcv
+		ConstructionYardTypes: construction_yard
+	UnitBuilderBotModule@vidious:
+		RequiresCondition: enable-vidious-ai
+		UnitQueues: Infantry, Vehicle, Armor, Starport, Aircraft
+	SquadManagerBotModule@gladius:
+		RequiresCondition: enable-gladius-ai
+		SquadSize: 10
+		MaxBaseRadius: 40
+		ExcludeFromSquadsTypes: harvester, mcv
+		ConstructionYardTypes: construction_yard
+	UnitBuilderBotModule@gladius:
+		RequiresCondition: enable-gladius-ai
+		UnitQueues: Infantry, Vehicle, Armor, Starport, Aircraft
+	BotProductionConsideration@units-omnius:
+		RequiresCondition: enable-omnius-ai
+		Queues: Infantry, Vehicle, Armor, Starport, Aircraft
+		Actors:
 			carryall: 1
+				Limit: 4
 			light_inf: 65
 			trooper: 40
 			mpsardaukar: 20
 			grenadier: 20
 			harvester: 1
+				Limit: 8
 			trike.starport: 5
 			quad.starport: 7
 			siege_tank.starport: 5
@@ -251,6 +172,7 @@ Player:
 			combat_tank_a: 100
 			combat_tank_h: 100
 			combat_tank_o: 100
+<<<<<<< HEAD
 		UnitLimits:
 			harvester: 8
 			carryall: 4
@@ -267,15 +189,20 @@ Player:
 		ConstructionYardTypes: construction_yard
 		IgnoredEnemyTargetTypes: Creep
 	UnitBuilderBotModule@vidious:
+=======
+	BotProductionConsideration@units-vidious:
+>>>>>>> c91beaba0b... Overhaul bot production logic.
 		RequiresCondition: enable-vidious-ai
-		UnitQueues: Infantry, Vehicle, Armor, Starport, Aircraft
-		UnitsToBuild:
+		Queues: Infantry, Vehicle, Armor, Starport, Aircraft
+		Actors:
 			carryall: 1
+				Limit: 4
 			light_inf: 65
 			trooper: 40
 			mpsardaukar: 20
 			grenadier: 20
 			harvester: 1
+				Limit: 8
 			trike.starport: 7
 			quad.starport: 12
 			siege_tank.starport: 5
@@ -295,6 +222,7 @@ Player:
 			combat_tank_a: 100
 			combat_tank_h: 100
 			combat_tank_o: 100
+<<<<<<< HEAD
 		UnitLimits:
 			harvester: 8
 			carryall: 4
@@ -306,15 +234,20 @@ Player:
 		ConstructionYardTypes: construction_yard
 		IgnoredEnemyTargetTypes: Creep
 	UnitBuilderBotModule@gladius:
+=======
+	BotProductionConsideration@units-gladius:
+>>>>>>> c91beaba0b... Overhaul bot production logic.
 		RequiresCondition: enable-gladius-ai
-		UnitQueues: Infantry, Vehicle, Armor, Starport, Aircraft
-		UnitsToBuild:
+		Queues: Infantry, Vehicle, Armor, Starport, Aircraft
+		Actors:
 			carryall: 1
+				Limit: 4
 			light_inf: 65
 			trooper: 40
 			mpsardaukar: 20
 			grenadier: 20
 			harvester: 1
+				Limit: 8
 			trike.starport: 5
 			quad.starport: 7
 			siege_tank.starport: 5
@@ -334,6 +267,112 @@ Player:
 			combat_tank_a: 100
 			combat_tank_h: 100
 			combat_tank_o: 100
-		UnitLimits:
-			harvester: 8
-			carryall: 4
+	BotProductionConsideration@buildings-omnius:
+		RequiresCondition: enable-omnius-ai
+		Queues: Building, Upgrade
+		Actors:
+			barracks: 1
+				Limit: 1
+			refinery: 20
+				Limit: 4
+			medium_gun_turret: 8
+			outpost: 1
+				Limit: 1
+			high_tech_factory: 1
+				Limit: 1
+			large_gun_turret: 6
+			light_factory: 1
+				Limit: 1
+			heavy_factory: 1
+				Limit: 1
+			starport: 1
+				Limit: 1
+			repair_pad: 1
+				Limit: 1
+			research_centre: 1
+				Limit: 1
+			palace: 1
+				Limit: 1
+			upgrade.conyard: 1
+				Limit: 1
+				Delay: 3750
+			upgrade.barracks: 1
+				Limit: 1
+			upgrade.light: 1
+				Limit: 1
+			upgrade.heavy: 1
+				Limit: 1
+			upgrade.hightech: 1
+				Limit: 1
+	BotProductionConsideration@buildings-vidious:
+		RequiresCondition: enable-vidious-ai
+		Queues: Building, Upgrade
+		Actors:
+			barracks: 1
+				Limit: 1
+			refinery: 20
+				Limit: 4
+			medium_gun_turret: 5
+			outpost: 1
+				Limit: 1
+			high_tech_factory: 1
+				Limit: 1
+			large_gun_turret: 10
+			light_factory: 1
+				Limit: 1
+			heavy_factory: 1
+				Limit: 1
+			starport: 1
+				Limit: 1
+			repair_pad: 1
+				Limit: 1
+			research_centre: 1
+				Limit: 1
+			palace: 1
+				Limit: 1
+			upgrade.conyard: 1
+				Limit: 1
+				Delay: 3750
+			upgrade.barracks: 1
+				Limit: 1
+			upgrade.light: 1
+				Limit: 1
+			upgrade.heavy: 1
+				Limit: 1
+			upgrade.hightech: 1
+				Limit: 1
+	BotProductionConsideration@buildings-gladius:
+		RequiresCondition: enable-gladius-ai
+		Queues: Building, Upgrade
+		Actors:
+			barracks: 1
+				Limit: 1
+			refinery: 20
+				Limit: 4
+			medium_gun_turret: 4
+			outpost: 1
+				Limit: 1
+			high_tech_factory: 1
+				Limit: 1
+			large_gun_turret: 12
+			light_factory: 1
+				Limit: 1
+			heavy_factory: 1
+				Limit: 1
+			repair_pad: 1
+				Limit: 1
+			research_centre: 1
+				Limit: 1
+			palace: 1
+				Limit: 1
+			upgrade.conyard: 1
+				Limit: 1
+				Delay: 3750
+			upgrade.barracks: 1
+				Limit: 1
+			upgrade.light: 1
+				Limit: 1
+			upgrade.heavy: 1
+				Limit: 1
+			upgrade.hightech: 1
+				Limit: 1

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -91,34 +91,6 @@ Player:
 		VehiclesFactoryTypes: weap
 		ProductionTypes: barr,tent,weap
 		SiloTypes: silo
-		BuildingLimits:
-			proc: 4
-			barr: 1
-			tent: 1
-			kenn: 1
-			dome: 1
-			weap: 1
-			atek: 1
-			stek: 1
-			fix: 1
-		BuildingFractions:
-			proc: 30
-			barr: 1
-			kenn: 1
-			tent: 1
-			weap: 1
-			pbox: 7
-			gun: 7
-			tsla: 5
-			gap: 2
-			ftur: 10
-			agun: 5
-			sam: 5
-			atek: 1
-			stek: 1
-			fix: 1
-			dome: 10
-			mslo: 1
 	BaseBuilderBotModule@normal:
 		RequiresCondition: enable-normal-ai
 		MinimumExcessPower: 60
@@ -133,43 +105,6 @@ Player:
 		ProductionTypes: barr,tent,weap,afld,hpad
 		NavalProductionTypes: spen,syrd
 		SiloTypes: silo
-		BuildingLimits:
-			proc: 4
-			barr: 1
-			tent: 1
-			dome: 1
-			weap: 1
-			spen: 1
-			syrd: 1
-			hpad: 4
-			afld: 4
-			afld.ukraine: 4
-			atek: 1
-			stek: 1
-			fix: 1
-		BuildingFractions:
-			proc: 15
-			tent: 1
-			barr: 1
-			kenn: 1
-			dome: 1
-			weap: 6
-			hpad: 4
-			spen: 1
-			syrd: 1
-			afld: 4
-			afld.ukraine: 4
-			pbox: 7
-			gun: 7
-			ftur: 10
-			tsla: 5
-			gap: 2
-			fix: 1
-			agun: 5
-			sam: 1
-			atek: 1
-			stek: 1
-			mslo: 1
 	BaseBuilderBotModule@turtle:
 		RequiresCondition: enable-turtle-ai
 		MinimumExcessPower: 60
@@ -184,44 +119,6 @@ Player:
 		ProductionTypes: barr,tent,weap,afld,hpad
 		NavalProductionTypes: spen,syrd
 		SiloTypes: silo
-		BuildingLimits:
-			proc: 4
-			barr: 1
-			tent: 1
-			kenn: 1
-			dome: 1
-			weap: 1
-			spen: 1
-			syrd: 1
-			hpad: 4
-			afld: 4
-			afld.ukraine: 4
-			atek: 1
-			stek: 1
-			fix: 1
-		BuildingFractions:
-			proc: 30
-			tent: 1
-			barr: 1
-			kenn: 1
-			weap: 3
-			hpad: 2
-			afld: 2
-			afld.ukraine: 2
-			spen: 1
-			syrd: 1
-			pbox: 10
-			gun: 10
-			ftur: 10
-			tsla: 7
-			gap: 3
-			fix: 1
-			dome: 10
-			agun: 5
-			sam: 5
-			atek: 1
-			stek: 1
-			mslo: 1
 	BaseBuilderBotModule@naval:
 		RequiresCondition: enable-naval-ai
 		MinimumExcessPower: 60
@@ -236,39 +133,6 @@ Player:
 		ProductionTypes: barr,tent,weap,afld,hpad
 		NavalProductionTypes: spen,syrd
 		SiloTypes: silo
-		BuildingLimits:
-			proc: 4
-			dome: 1
-			barr: 1
-			tent: 1
-			spen: 1
-			syrd: 1
-			hpad: 8
-			afld: 8
-			afld.ukraine: 8
-			weap: 1
-			atek: 1
-			stek: 1
-			fix: 1
-		BuildingFractions:
-			proc: 30
-			dome: 1
-			weap: 1
-			hpad: 20
-			afld: 20
-			afld.ukraine: 20
-			atek: 1
-			stek: 1
-			spen: 1
-			syrd: 1
-			fix: 1
-			pbox: 12
-			gun: 12
-			ftur: 12
-			tsla: 12
-			agun: 5
-			sam: 5
-			mslo: 1
 	BuildingRepairBotModule:
 		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
 	SquadManagerBotModule@rush:
@@ -284,30 +148,6 @@ Player:
 		McvFactoryTypes: weap
 	UnitBuilderBotModule@rush:
 		RequiresCondition: enable-rush-ai
-		UnitsToBuild:
-			e1: 65
-			e2: 15
-			e3: 30
-			e4: 15
-			dog: 15
-			shok: 15
-			harv: 10
-			apc: 30
-			jeep: 20
-			arty: 15
-			v2rl: 40
-			ftrk: 30
-			1tnk: 50
-			2tnk: 50
-			3tnk: 50
-			4tnk: 25
-			ttnk: 25
-			stnk: 5
-		UnitLimits:
-			dog: 4
-			harv: 8
-			jeep: 4
-			ftrk: 4
 	SquadManagerBotModule@normal:
 		RequiresCondition: enable-normal-ai
 		SquadSize: 40
@@ -317,19 +157,70 @@ Player:
 		NavalProductionTypes: spen,syrd
 	UnitBuilderBotModule@normal:
 		RequiresCondition: enable-normal-ai
-		UnitsToBuild:
+	SquadManagerBotModule@turtle:
+		RequiresCondition: enable-turtle-ai
+		SquadSize: 10
+		ExcludeFromSquadsTypes: harv, mcv, dog
+		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
+		ConstructionYardTypes: fact
+		NavalProductionTypes: spen,syrd
+	UnitBuilderBotModule@turtle:
+		RequiresCondition: enable-turtle-ai
+	SquadManagerBotModule@naval:
+		RequiresCondition: enable-naval-ai
+		SquadSize: 1
+		ExcludeFromSquadsTypes: harv, mcv, dog
+		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
+		ConstructionYardTypes: fact
+		NavalProductionTypes: spen,syrd
+	UnitBuilderBotModule@naval:
+		RequiresCondition: enable-naval-ai
+	BotProductionConsideration@units-rush:
+		RequiresCondition: enable-rush-ai
+		Queues:
+		Actors:
 			e1: 65
 			e2: 15
 			e3: 30
 			e4: 15
 			dog: 15
+				Limit: 4
 			shok: 15
-			harv: 15
+			harv: 10
+				Limit: 8
 			apc: 30
 			jeep: 20
+				Limit: 4
 			arty: 15
 			v2rl: 40
 			ftrk: 30
+				Limit: 4
+			1tnk: 50
+			2tnk: 50
+			3tnk: 50
+			4tnk: 25
+			ttnk: 25
+			stnk: 5
+	BotProductionConsideration@units-normal:
+		RequiresCondition: enable-normal-ai
+		Queues:
+		Actors:
+			e1: 65
+			e2: 15
+			e3: 30
+			e4: 15
+			dog: 15
+				Limit: 4
+			shok: 15
+			harv: 15
+				Limit: 8
+			apc: 30
+			jeep: 20
+				Limit: 4
+			arty: 15
+			v2rl: 40
+			ftrk: 30
+				Limit: 4
 			1tnk: 40
 			2tnk: 50
 			3tnk: 50
@@ -345,33 +236,26 @@ Player:
 			dd: 10
 			ca: 10
 			pt: 10
-		UnitLimits:
-			dog: 4
-			harv: 8
-			jeep: 4
-			ftrk: 4
-	SquadManagerBotModule@turtle:
+	BotProductionConsideration@units-turtle:
 		RequiresCondition: enable-turtle-ai
-		SquadSize: 10
-		ExcludeFromSquadsTypes: harv, mcv, dog
-		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
-		ConstructionYardTypes: fact
-		NavalProductionTypes: spen,syrd
-	UnitBuilderBotModule@turtle:
-		RequiresCondition: enable-turtle-ai
-		UnitsToBuild:
+		Queues:
+		Actors:
 			e1: 65
 			e2: 15
 			e3: 30
 			e4: 15
 			dog: 15
+				Limit: 4
 			shok: 15
 			harv: 15
+				Limit: 8
 			apc: 30
 			jeep: 20
+				Limit: 4
 			arty: 15
 			v2rl: 40
 			ftrk: 50
+				Limit: 4
 			1tnk: 50
 			2tnk: 50
 			3tnk: 50
@@ -387,22 +271,12 @@ Player:
 			dd: 10
 			ca: 10
 			pt: 10
-		UnitLimits:
-			dog: 4
-			harv: 8
-			jeep: 4
-			ftrk: 4
-	SquadManagerBotModule@naval:
+	BotProductionConsideration@units-naval:
 		RequiresCondition: enable-naval-ai
-		SquadSize: 1
-		ExcludeFromSquadsTypes: harv, mcv, dog
-		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
-		ConstructionYardTypes: fact
-		NavalProductionTypes: spen,syrd
-	UnitBuilderBotModule@naval:
-		RequiresCondition: enable-naval-ai
-		UnitsToBuild:
+		Queues:
+		Actors:
 			harv: 1
+				Limit: 8
 			heli: 30
 			mh60: 30
 			mig: 30
@@ -412,5 +286,145 @@ Player:
 			dd: 30
 			ca: 20
 			pt: 10
-		UnitLimits:
-			harv: 8
+	BotProductionConsideration@buildings-rush:
+		RequiresCondition: enable-rush-ai
+		Queues:
+		Actors:
+			proc: 30
+				Limit: 4
+			barr: 1
+				Limit: 1
+			kenn: 1
+				Limit: 1
+			tent: 1
+				Limit: 1
+			weap: 1
+				Limit: 1
+			pbox: 7
+			gun: 7
+			tsla: 5
+			gap: 2
+			ftur: 10
+			agun: 5
+			sam: 5
+			atek: 1
+				Limit: 1
+			stek: 1
+				Limit: 1
+			fix: 1
+				Limit: 1
+			dome: 10
+				Limit: 1
+			mslo: 1
+	BotProductionConsideration@buildings-normal:
+		RequiresCondition: enable-normal-ai
+		Queues:
+		Actors:
+			proc: 15
+				Limit: 4
+			tent: 1
+				Limit: 1
+			barr: 1
+				Limit: 1
+			kenn: 1
+			dome: 1
+				Limit: 1
+			weap: 6
+				Limit: 1
+			hpad: 4
+				Limit: 4
+			spen: 1
+				Limit: 1
+			syrd: 1
+				Limit: 1
+			afld: 4
+				Limit: 4
+			afld.ukraine: 4
+				Limit: 4
+			pbox: 7
+			gun: 7
+			ftur: 10
+			tsla: 5
+			gap: 2
+			fix: 1
+				Limit: 1
+			agun: 5
+			sam: 1
+			atek: 1
+				Limit: 1
+			stek: 1
+				Limit: 1
+			mslo: 1
+	BotProductionConsideration@buildings-turtle:
+		RequiresCondition: enable-turtle-ai
+		Queues:
+		Actors:
+			proc: 30
+				Limit: 4
+			tent: 1
+				Limit: 1
+			barr: 1
+				Limit: 1
+			kenn: 1
+				Limit: 1
+			weap: 3
+				Limit: 1
+			hpad: 2
+				Limit: 4
+			afld: 2
+				Limit: 4
+			afld.ukraine: 2
+				Limit: 4
+			spen: 1
+				Limit: 1
+			syrd: 1
+				Limit: 1
+			pbox: 10
+			gun: 10
+			ftur: 10
+			tsla: 7
+			gap: 3
+			fix: 1
+				Limit: 1
+			dome: 10
+				Limit: 1
+			agun: 5
+			sam: 5
+			atek: 1
+				Limit: 1
+			stek: 1
+				Limit: 1
+			mslo: 1
+	BotProductionConsideration@buildings-naval:
+		RequiresCondition: enable-naval-ai
+		Queues:
+		Actors:
+			proc: 30
+				Limit: 4
+			dome: 1
+				Limit: 1
+			weap: 1
+				Limit: 1
+			hpad: 20
+				Limit: 8
+			afld: 20
+				Limit: 8
+			afld.ukraine: 20
+				Limit: 8
+			atek: 1
+				Limit: 1
+			stek: 1
+				Limit: 1
+			spen: 1
+				Limit: 1
+			syrd: 1
+				Limit: 1
+			fix: 1
+				Limit: 1
+			pbox: 12
+			gun: 12
+			ftur: 12
+			tsla: 12
+			agun: 5
+			sam: 5
+			mslo: 1

--- a/mods/ts/rules/ai.yaml
+++ b/mods/ts/rules/ai.yaml
@@ -22,6 +22,7 @@ Player:
 		VehiclesFactoryTypes: gaweap, naweap
 		ProductionTypes: gapile, nahand, gaweap, naweap, gahpad, nahpad
 		SiloTypes: gasilo
+<<<<<<< HEAD
 		BuildingLimits:
 			proc: 4
 			gasilo: 2
@@ -63,6 +64,8 @@ Player:
 			gacsam: 6
 			nasam: 6
 			naobel: 3
+=======
+>>>>>>> c91beaba0b... Overhaul bot production logic.
 	BuildingRepairBotModule:
 		RequiresCondition: enable-test-ai
 	SquadManagerBotModule@test:
@@ -72,16 +75,31 @@ Player:
 		ConstructionYardTypes: gacnst
 	UnitBuilderBotModule@test:
 		RequiresCondition: enable-test-ai
+<<<<<<< HEAD
 		UnitQueues: Vehicle, Infantry, Air
 		UnitsToBuild:
+=======
+	McvManagerBotModule@test:
+		RequiresCondition: enable-test-ai
+		McvTypes: mcv
+		ConstructionYardTypes: gacnst
+		McvFactoryTypes: gaweap, naweap
+	BotProductionConsideration@units-test:
+		RequiresCondition: enable-test-ai
+		Queues:
+		Actors:
+>>>>>>> c91beaba0b... Overhaul bot production logic.
 			e1: 80
 			e2: 25
 			e3: 25
 			cyborg: 15
 			jumpjet: 15
 			repair: 2
+				Limit: 3
 			medic: 2
+				Limit: 3
 			harv: 10
+				Limit: 12
 			mmch: 15
 			ttnk: 15
 			smech: 25
@@ -91,6 +109,7 @@ Player:
 			subtank: 10
 			sonic: 10
 			stnk: 8
+<<<<<<< HEAD
 			orca: 5
 			orcab: 4
 			apache: 5
@@ -100,7 +119,41 @@ Player:
 			medic: 3
 			repair: 3
 	McvManagerBotModule@test:
+=======
+	BotProductionConsideration@buildings-test:
+>>>>>>> c91beaba0b... Overhaul bot production logic.
 		RequiresCondition: enable-test-ai
-		McvTypes: mcv
-		ConstructionYardTypes: gacnst
-		McvFactoryTypes: gaweap, naweap
+		Queues:
+		Actors:
+			proc: 30
+				Limit: 4
+			gapile: 1
+				Limit: 1
+			nahand: 1
+				Limit: 1
+			gaweap: 1
+				Limit: 1
+			naweap: 1
+				Limit: 1
+			garadr: 1
+				Limit: 1
+			naradr: 1
+				Limit: 1
+			gatech: 1
+				Limit: 1
+			natech: 1
+				Limit: 1
+			nastlh: 1
+				Limit: 1
+			nalasr: 10
+				Limit: 8
+			gavulc: 10
+				Limit: 8
+			garock: 3
+				Limit: 2
+			gacsam: 6
+				Limit: 4
+			nasam: 6
+				Limit: 4
+			naobel: 3
+				Limit: 2


### PR DESCRIPTION
This PR extracts the metadata that the AI uses to decide what to build into its own trait, and generalizes the capabilities to be much more useful. The new `BotProductionConsideration` traits can be combined to reduce duplication, and can be toggled using conditions to modify the AI build priorities at runtime.

The main usecase for this is to let us define production overrides for the different difficulty levels (e.g. capping harvesters to 3 for Easy AI) without having to duplicate the entire module. I've implemented priority levels and the ability to toggle considerations using conditions which means that these overrides can be changed at runtime, opening up possibilities such as tech transitions and in the future replacing the hardcoded priority overrides. I've implemented an example of this in TD, with the AI only building helipads once they have a comm center, as it is useless to them earlier.

In the future I expect `BotProductionConsideration` can be superseded by more specialized traits defining team types for units, and build orders for buildings.

Prerequisite for #16126 (which I still believe is important for the next release)
Fixes #8029

I've set up TD reasonably well in the new system, but i'm at a complete loss at how to handle RA and D2K - opening as a draft to get some feedback and ideas on how to proceed.

The production percentages for these mods are just completely bogus with arbitrary numbers that are nowhere close to adding up to 100%. This partially explains why the AI production has always been wonky - in practice it is driven by priority overrides and limit caps, and otherwise basically random.

Consider the unit percentages: if we ignore the issue where they are completely ignored unless there are more than 12 idle units in the base (which is rare), then the percentages are still likely to be ignored. Many of the units define percentages in the 25-60% range, which will never be achievable. These units will therefore always pass the test to be built if they are picked by the random shuffle. Buildings have the opposite issue, with most structures requesting a 1% fraction, meaning that the AI wants to build approximately 0 of everything, which is rounded up to 1.

Migrating the numbers as they are doesn't make much sense and will probably regress behaviour - I have fixed several bugs that caused the limits and time delays to be ignored in some cases, and the unit percentages to be ignored almost all of the time.

I think the best option forward will be to get rid of the rush/normal/turtle/naval AIs here, and implement new production considerations from scratch that make some degree of sense. We can then have variants that e.g. build twice as many infantry/vehicles/air/defenses, and expose them either explicitly as "&lt;X&gt; AI"'s, or scope creep towards #16126 by going straight to a single "Normal AI" with the variants as random choices.