### PR TITLE
Fix MAD tanks always being repairable

### DIFF
--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -818,7 +818,7 @@ QTNK:
 	MadTank:
 		DeployedCondition: deployed
 	Targetable:
-		TargetTypes: Ground, MADTank, Repair, Vehicle
+		TargetTypes: Ground, MADTank, Vehicle
 	Selectable:
 		DecorationBounds: 44,38,0,-4
 


### PR DESCRIPTION
Fixes #16638.

`Targetable@REPAIR` from `^Vehicle` in defaults.yaml will take care of enabling the repair target type once the MAD tank is damaged.