### PR TITLE
Fix Juggernauts crashing on bleed

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithMoveAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMoveAnimation.cs
@@ -73,7 +73,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		protected override void TraitEnabled(Actor self)
 		{
-			UpdateAnimation(self, movement.CurrentMovementTypes);
+			// HACK: Use a FrameEndTask to avoid construction order issues with WithSpriteBody
+			self.World.AddFrameEndTask(w => UpdateAnimation(self, movement.CurrentMovementTypes));
 		}
 
 		protected override void TraitDisabled(Actor self)


### PR DESCRIPTION
Closes #16637.

The `TraitEnabled` of `WithMoveAnimation` hits before the one of `WithSpriteBody` (despite `Requires`) because it didn't define a required condition and traits without such get enabled directly in the `INotifyCreated.Created` callback.