### PR TITLE
Adjust height of multiplayer-browser chrome

### DIFF
--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -101,9 +101,13 @@ namespace OpenRA.Mods.Common.Widgets
 			panelRoot.AddChild(fullscreenMask);
 
 			var oldBounds = panel.Bounds;
+			var panelY = RenderOrigin.Y + Bounds.Height - panelRoot.RenderOrigin.Y;
+			if (panelY + oldBounds.Height > Game.Renderer.Resolution.Height)
+				panelY -= (Bounds.Height + oldBounds.Height);
+
 			panel.Bounds = new Rectangle(
 				RenderOrigin.X - panelRoot.RenderOrigin.X,
-				RenderOrigin.Y + Bounds.Height - panelRoot.RenderOrigin.Y,
+				panelY,
 				oldBounds.Width,
 				oldBounds.Height);
 			panelRoot.AddChild(panel);

--- a/mods/common/chrome/multiplayer-browser.yaml
+++ b/mods/common/chrome/multiplayer-browser.yaml
@@ -3,7 +3,7 @@ Background@MULTIPLAYER_PANEL:
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
 	Width: 808
-	Height: 550
+	Height: 600
 	Children:
 		Label@TITLE:
 			Y: 15


### PR DESCRIPTION
This PR adjusts the multiplayer browser panel height to be in line with the rest of the large panels. I guess it was made shorter intenionally when the dropdown for filtering games was introduced. This however created a visual jump in the UI when clicking the "Leave Game" button in a lobby. A picture that explains it:

![изображение](https://user-images.githubusercontent.com/1355810/59068204-3c651f00-88bc-11e9-815f-d279e5991f3a.png)

Since the filter dropdown would no longer fit on a 768px tall viewport I made the widget open upwards if it were to be clipped by the viewport:

![изображение](https://user-images.githubusercontent.com/1355810/59068271-6ae2fa00-88bc-11e9-8f02-5f384463cbab.png)


A small step towards #16596 