### PR TITLE
Fix position of lobby admin icon in player tooltips for TD

### DIFF
--- a/mods/cnc/chrome.yaml
+++ b/mods/cnc/chrome.yaml
@@ -787,7 +787,7 @@ music: chrome.png
 lobby-bits: chrome.png
 	spawn-unclaimed: 776,420,19,19
 	spawn-claimed: 776,440,19,19
-	admin: 928,0,7,5
+	admin: 928,0,6,5
 	colorpicker: 880,0,14,14
 	huepicker: 896,0,7,15
 	kick: 912,0,11,11

--- a/mods/cnc/chrome/tooltips.yaml
+++ b/mods/cnc/chrome/tooltips.yaml
@@ -403,6 +403,7 @@ Background@ANONYMOUS_PLAYER_TOOLTIP:
 			Visible: False
 			Children:
 				Image@ICON:
+					X: 1
 					Y: 5
 					Width: 7
 					Height: 5
@@ -446,6 +447,7 @@ Container@REGISTERED_PLAYER_TOOLTIP:
 							Visible: False
 							Children:
 								Image@ICON:
+									X: 1
 									Y: 5
 									Width: 7
 									Height: 5


### PR DESCRIPTION
It was 1px off-left compared to release. This was a regression from #16359 because the sprite was moved 1px to the left.

Mentioned in #16606