### PR TITLE
Add support power palette order

### DIFF
--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
@@ -106,6 +106,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly string OrderName;
 
+		[Desc("Sort order for the support power palette. Smaller numbers are presented earlier.")]
+		public readonly int SupportPowerPaletteOrder = 9999;
+
 		public SupportPowerInfo() { OrderName = GetType().Name + "Order"; }
 	}
 

--- a/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
@@ -102,7 +102,9 @@ namespace OpenRA.Mods.Common.Widgets
 				return;
 
 			var powers = player.PlayerActor.Trait<SupportPowerManager>().Powers
-				.Where(x => !x.Value.Disabled).Select((a, i) => new { a, i })
+				.Where(x => !x.Value.Disabled)
+				.OrderBy(p => p.Value.Info.SupportPowerPaletteOrder)
+				.Select((a, i) => new { a, i })
 				.ToList();
 
 			foreach (var power in powers)

--- a/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
@@ -123,7 +123,8 @@ namespace OpenRA.Mods.Common.Widgets
 		public void RefreshIcons()
 		{
 			icons = new Dictionary<Rectangle, SupportPowerIcon>();
-			var powers = spm.Powers.Values.Where(p => !p.Disabled);
+			var powers = spm.Powers.Values.Where(p => !p.Disabled)
+				.OrderBy(p => p.Info.SupportPowerPaletteOrder);
 
 			var oldIconCount = IconCount;
 			IconCount = 0;

--- a/mods/cnc/rules/campaign-maprules.yaml
+++ b/mods/cnc/rules/campaign-maprules.yaml
@@ -54,6 +54,7 @@ airstrike.proxy:
 		ArrowSequence: arrow
 		ClockSequence: clock
 		CircleSequence: circles
+		SupportPowerPaletteOrder: 10
 
 TRUCK:
 	Buildable:

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -657,6 +657,7 @@ HQ:
 		UseDirectionalTarget: True
 		TargetPlaceholderCursorAnimation: airstriketarget
 		DirectionArrowAnimation: airstrikedirection
+		SupportPowerPaletteOrder: 10
 	SupportPowerChargeBar:
 	Power:
 		Amount: -50
@@ -757,6 +758,7 @@ EYE:
 		OnFireSound: ion1.aud
 		DisplayRadarPing: True
 		CameraActor: camera.small
+		SupportPowerPaletteOrder: 20
 	SupportPowerChargeBar:
 	Power:
 		Amount: -200
@@ -820,6 +822,7 @@ TMPL:
 		ArrowSequence: arrow
 		ClockSequence: clock
 		CircleSequence: circles
+		SupportPowerPaletteOrder: 30
 	WithBuildingBib:
 	WithNukeLaunchAnimation:
 		RequiresCondition: !build-incomplete

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -999,6 +999,7 @@ high_tech_factory:
 		CameraActor: camera
 		ArrowSequence: arrow
 		CircleSequence: circles
+		SupportPowerPaletteOrder: 10
 	Power:
 		Amount: -75
 	GrantConditionOnPrerequisite:
@@ -1168,6 +1169,7 @@ palace:
 		TrailInterval: 0
 		TrailImage: large_trail
 		TrailSequences: idle
+		SupportPowerPaletteOrder: 40
 	ProduceActorPower@fremen:
 		Description: Recruit Fremen
 		LongDesc: Elite infantry unit armed with assault rifles and rockets\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery\n  Special Ability: Invisibility
@@ -1181,6 +1183,7 @@ palace:
 		ReadyAudio: Reinforce
 		BlockedAudio: NoRoom
 		OrderName: ProduceActorPower.Fremen
+		SupportPowerPaletteOrder: 20
 	ProduceActorPower@saboteur:
 		Description: Recruit Saboteur
 		LongDesc: Sneaky infantry, armed with explosives\n  Strong vs Buildings\n  Weak vs Everything\n  Special Ability: destroy buildings
@@ -1194,6 +1197,7 @@ palace:
 		ReadyAudio: Reinforce
 		BlockedAudio: NoRoom
 		OrderName: ProduceActorPower.Saboteur
+		SupportPowerPaletteOrder: 30
 	Exit@1:
 		SpawnOffset: -704,768,0
 		ExitCell: -1,2

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -340,6 +340,7 @@ powerproxy.sonarpulse:
 		DeploySound: sonpulse.aud
 		EffectImage: moveflsh
 		EffectPalette: moveflash
+		SupportPowerPaletteOrder: 80
 
 powerproxy.paratroopers:
 	AlwaysVisible:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -55,6 +55,7 @@ MSLO:
 		ArrowSequence: arrow
 		ClockSequence: clock
 		CircleSequence: circles
+		SupportPowerPaletteOrder: 70
 	SupportPowerChargeBar:
 	Power:
 		Amount: -150
@@ -436,6 +437,7 @@ IRON:
 		DisplayRadarPing: True
 		Condition: invulnerability
 		OnFireSound: ironcur9.aud
+		SupportPowerPaletteOrder: 10
 	SupportPowerChargeBar:
 	Power:
 		Amount: -200
@@ -498,6 +500,7 @@ PDOX:
 		Duration: 400
 		KillCargo: yes
 		DisplayRadarPing: True
+		SupportPowerPaletteOrder: 20
 	ChronoshiftPower@advancedchronoshift:
 		OrderName: AdvancedChronoshift
 		PauseOnCondition: disabled
@@ -514,6 +517,7 @@ PDOX:
 		KillCargo: yes
 		DisplayRadarPing: True
 		Range: 2
+		SupportPowerPaletteOrder: 30
 	SupportPowerChargeBar:
 	Power:
 		Amount: -200
@@ -956,6 +960,7 @@ ATEK:
 		RevealDelay: 375
 		LaunchSpeechNotification: SatelliteLaunched
 		DisplayTimerStances: Ally, Neutral, Enemy
+		SupportPowerPaletteOrder: 90
 	SupportPowerChargeBar:
 	Power:
 		Amount: -200
@@ -1484,6 +1489,7 @@ AFLD:
 		UseDirectionalTarget: True
 		TargetPlaceholderCursorAnimation: paratarget
 		DirectionArrowAnimation: paradirection
+		SupportPowerPaletteOrder: 60
 	ParatroopersPower@paratroopers:
 		OrderName: SovietParatroopers
 		Prerequisites: aircraft.soviet
@@ -1505,6 +1511,7 @@ AFLD:
 		UseDirectionalTarget: True
 		TargetPlaceholderCursorAnimation: paratarget
 		DirectionArrowAnimation: paradirection
+		SupportPowerPaletteOrder: 50
 	AirstrikePower@parabombs:
 		OrderName: UkraineParabombs
 		Prerequisites: aircraft.ukraine
@@ -1527,6 +1534,7 @@ AFLD:
 		UseDirectionalTarget: True
 		TargetPlaceholderCursorAnimation: paratarget
 		DirectionArrowAnimation: paradirection
+		SupportPowerPaletteOrder: 40
 	ProductionBar:
 		ProductionType: Aircraft
 	SupportPowerChargeBar:


### PR DESCRIPTION
As suggested in #16383 and discussed on discord around the same time. This is very similar to `BuildPaletteOrder`. The order is as follows:

Index | RA | TD | d2k
---: | :--- | :--- | :---
10 | Spy Plane | Airstrike | Airstrike
20 | Paradrop | Ion Canon | Fremen
30 | Parabombs | Nuke | Saboteur
40 | Iron Curtain | | Nuke
50 | Chronoshift | | 
60 | Adv. Chronoshift | | 
70 | Nuke | | 
80 | Sonar Pulse | | 
90 | GPS | | 

I have not ordered the TS powers because not all have been implemented yet.