### PR TITLE
Fix AbortOnResupply not working as intended

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -142,7 +142,7 @@ namespace OpenRA.Mods.Common.Activities
 				resupplied = false;
 
 			if (resupplied && abortOnResupply)
-				Cancel(self);
+				self.CancelActivity();
 
 			if (resupplied || IsCanceling || self.IsDead)
 				return NextActivity;


### PR DESCRIPTION
`ReturnToBase` never properly canceled the activity queue after resupply, resulting in aircraft continuing their previous task (usually attacking) despite the yaml rules/default value claiming otherwise.

Set the flag to `false` in RA to maintain bleed behavior as people certainly are too used to it by now, but intentionally did not do so for TS, as in my opinion we should stick closer to the original game in this regard.

Fixes #10452 (technically bleed already does, but with this PR the behavior can now be controlled via `AbortOnResupply`).
Fixes #13474.