### PR TITLE
 Add lua function Media.DisplaySystemMessage 

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -198,6 +198,15 @@ namespace OpenRA.Mods.Common.Scripting
 			Game.AddChatLine(prefix, c, text);
 		}
 
+		[Desc("Display a system message to the player.")]
+		public void DisplaySystemMessage(string text, string prefix = "Mission")
+		{
+			if (string.IsNullOrEmpty(text))
+				return;
+
+			Game.AddSystemLine(prefix, text);
+		}
+
 		[Desc("Displays a debug message to the player, if \"Show Map Debug Messages\" is checked in the settings.")]
 		public void Debug(string text)
 		{


### PR DESCRIPTION
Color field in Media.DisplayMessage only affects the part before the \:. So i added a new function show yellow system messages.

Testcase makes Tanya's "According to the rules of engagement I need your explicit orders to fire, Commander!" in Allied 3a yellow.