### PR TITLE
Split attack aspect of CanHover to AttackType on AttackAircraft

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -157,7 +157,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (!isAirborne)
 				QueueChild(self, new TakeOff(self), true);
 
-			if (!aircraft.Info.CanHover)
+			if (attackAircraft.Info.AttackType == AirAttackType.Strafe)
 			{
 				if (target.IsInRange(pos, attackAircraft.GetMinimumRange()))
 					QueueChild(self, new FlyTimed(ticksUntilTurn, self), true);

--- a/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
@@ -15,9 +15,15 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	// TODO: Add CurleyShuffle (TD, TS), Circle (Generals Gunship-style)
+	public enum AirAttackType { Hover, Strafe }
+
 	public class AttackAircraftInfo : AttackFollowInfo, Requires<AircraftInfo>
 	{
-		[Desc("Delay, in game ticks, before non-hovering aircraft turns to attack.")]
+		[Desc("Attack behavior. Currently supported types are Strafe (default) and Hover.")]
+		public readonly AirAttackType AttackType = AirAttackType.Strafe;
+
+		[Desc("Delay, in game ticks, before strafing aircraft turns to attack.")]
 		public readonly int AttackTurnDelay = 50;
 
 		public override object Create(ActorInitializer init) { return new AttackAircraft(init.Self, this); }

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20190314/AddAirAttackTypes.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20190314/AddAirAttackTypes.cs
@@ -1,0 +1,74 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class AddAirAttackTypes : UpdateRule
+	{
+		public override string Name { get { return "Add AttackType field to AttackAircraft"; } }
+		public override string Description
+		{
+			get
+			{
+				return "Aircraft attack behavior now depends on AttackAircraft.AttackType\n"
+					+ "instead of Aircraft.CanHover.";
+			}
+		}
+
+		readonly List<Tuple<string, string>> hoveringActors = new List<Tuple<string, string>>();
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			var message = "Aircraft attack behavior (Hover or Strafe) is now controlled via AttackAircraft.AttackType.\n"
+				+ "Aircraft with CanHover: true will now also need AttackType: Hover on AttackAircraft\n"
+				+ "to maintain position while attacking as before.\n"
+				+ "The following places might need manual changes:\n"
+				+ UpdateUtils.FormatMessageList(hoveringActors.Select(n => n.Item1 + " (" + n.Item2 + ")"));
+
+			if (hoveringActors.Any())
+				yield return message;
+
+			hoveringActors.Clear();
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var aircraftTraits = actorNode.ChildrenMatching("Aircraft");
+			var attackAircraftTraits = actorNode.ChildrenMatching("AttackAircraft");
+			foreach (var attackAircraft in attackAircraftTraits)
+			{
+				var isHover = false;
+				foreach (var aircraft in aircraftTraits)
+				{
+					var canHoverNode = aircraft.LastChildMatching("CanHover");
+					if (canHoverNode != null)
+						isHover = canHoverNode.NodeValue<bool>();
+
+					if (isHover)
+						break;
+				}
+
+				// It's still possible that CanHover: true is inherited, so let modders check manually if 'false',
+				// otherwise add AttackType: Hover.
+				if (!isHover)
+					hoveringActors.Add(Tuple.Create(actorNode.Key, actorNode.Location.Filename));
+				else
+					attackAircraft.AddNode("AttackType", "Hover");
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -128,6 +128,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RenameAttackMoveConditions(),
 				new RemovePlaceBuildingPalettes(),
 				new RenameHoversOffsetModifier(),
+				new AddAirAttackTypes(),
 			})
 		};
 

--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -93,6 +93,7 @@ HELI:
 		FacingTolerance: 20
 		OpportunityFire: false
 		PersistentTargeting: false
+		AttackType: Hover
 	AmmoPool:
 		Ammo: 10
 		PipCount: 5
@@ -154,6 +155,7 @@ ORCA:
 		FacingTolerance: 20
 		OpportunityFire: false
 		PersistentTargeting: false
+		AttackType: Hover
 	AmmoPool:
 		Ammo: 6
 		PipCount: 6

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -305,6 +305,7 @@ HELI:
 	AttackAircraft:
 		FacingTolerance: 20
 		PersistentTargeting: false
+		AttackType: Hover
 	Aircraft:
 		LandWhenIdle: false
 		TurnSpeed: 4
@@ -373,6 +374,7 @@ HIND:
 	AttackAircraft:
 		FacingTolerance: 20
 		PersistentTargeting: false
+		AttackType: Hover
 	Aircraft:
 		LandWhenIdle: false
 		TurnSpeed: 4

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -109,6 +109,7 @@ ORCA:
 		PersistentTargeting: false
 		Voice: Attack
 		PauseOnCondition: empdisable
+		AttackType: Hover
 	AmmoPool:
 		Ammo: 5
 		PipCount: 5
@@ -352,6 +353,7 @@ APACHE:
 		PersistentTargeting: false
 		Voice: Attack
 		PauseOnCondition: empdisable
+		AttackType: Hover
 	AmmoPool:
 		Ammo: 12
 		PipCount: 4
@@ -391,6 +393,7 @@ HUNTER:
 		VTOL: true
 	AttackAircraft:
 		FacingTolerance: 128
+		AttackType: Hover
 	Armament@PRIMARY:
 		Weapon: SuicideBomb
 	GrantConditionOnAttack:


### PR DESCRIPTION
On bleed, `CanHover` currently affects 3 main aspects of aircraft behavior:
- how does it change flight direction (instant with only visual turning, or flying real curves)
- **how does it move on attack (hovering or strafing)**
- how does it move on idle (hover in place or circle, if `LandWhenIdle` is `false`)

However, there are cases - even in our official mods, namely D2k carryalls and TS Orca/Harpy - where we want some, but not all of bleed's `CanHover` behavior.

This PR splits the attack movement control to an `AttackType` on `AttackAircraft` (the other cases will be handled differently, in a separate PR).

Yaml changes were done via update rule.