### PR TITLE
Replace many Aircraft booleans with FlightDynamics

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ProductionAirdrop.cs
@@ -46,13 +46,10 @@ namespace OpenRA.Mods.Cnc.Traits
 			var owner = self.Owner;
 			var aircraftInfo = self.World.Map.Rules.Actors[info.ActorType].TraitInfo<AircraftInfo>();
 
-			// WDist required to take off or land
-			var landDistance = aircraftInfo.CruiseAltitude.Length * 1024 / aircraftInfo.MaximumPitch.Tan();
-
 			// Start a fixed distance away: the width of the map.
 			// This makes the production timing independent of spawnpoint
 			var startPos = self.Location + new CVec(owner.World.Map.Bounds.Width, 0);
-			var endPos = new CPos(owner.World.Map.Bounds.Left - 2 * landDistance / 1024, self.Location.Y);
+			var endPos = new CPos(owner.World.Map.Bounds.Left, self.Location.Y);
 
 			// Assume a single exit point for simplicity
 			var exit = self.Info.TraitInfos<ExitInfo>().First();

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -53,7 +53,8 @@ namespace OpenRA.Mods.Common.Activities
 		public static void FlyTick(Actor self, Aircraft aircraft, int desiredFacing, WDist desiredAltitude, WVec moveOverride, int turnSpeedOverride = -1)
 		{
 			var dat = self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition);
-			var move = aircraft.Info.CanHover ? aircraft.FlyStep(desiredFacing) : aircraft.FlyStep(aircraft.Facing);
+			var isSlider = aircraft.Info.FlightDynamics.HasFlag(FlightDynamic.Slide);
+			var move = isSlider ? aircraft.FlyStep(desiredFacing) : aircraft.FlyStep(aircraft.Facing);
 			if (moveOverride != WVec.Zero)
 				move = moveOverride;
 
@@ -115,7 +116,7 @@ namespace OpenRA.Mods.Common.Activities
 				// If the aircraft lands when idle and is idle, we let the default idle handler manage this.
 				// TODO: Remove this after fixing all activities to work properly with arbitrary starting altitudes.
 				var skipHeightAdjustment = aircraft.Info.LandWhenIdle && self.CurrentActivity.IsCanceling && self.CurrentActivity.NextActivity == null;
-				if (aircraft.Info.CanHover && !skipHeightAdjustment && dat != aircraft.Info.CruiseAltitude)
+				if (aircraft.Info.FlightDynamics.HasFlag(FlightDynamic.Hover) && !skipHeightAdjustment && dat != aircraft.Info.CruiseAltitude)
 				{
 					if (dat <= aircraft.LandAltitude)
 						QueueChild(new TakeOff(self, target));
@@ -160,19 +161,22 @@ namespace OpenRA.Mods.Common.Activities
 			if (insideMaxRange && !insideMinRange)
 				return true;
 
-			var move = aircraft.Info.CanHover ? aircraft.FlyStep(desiredFacing) : aircraft.FlyStep(aircraft.Facing);
+			var isSlider = aircraft.Info.FlightDynamics.HasFlag(FlightDynamic.Slide);
+			var move = isSlider ? aircraft.FlyStep(desiredFacing) : aircraft.FlyStep(aircraft.Facing);
 
-			// Inside the minimum range, so reverse if CanHover
-			if (aircraft.Info.CanHover && insideMinRange)
+			// Inside the minimum range, so reverse if we have Slide flag
+			if (isSlider && insideMinRange)
 			{
 				FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, -move);
 				return false;
 			}
 
-			// The next move would overshoot, so consider it close enough or set final position if CanHover
+			// The next move would overshoot, so consider it close enough or set final position if we have Slide flag
 			if (delta.HorizontalLengthSquared < move.HorizontalLengthSquared)
 			{
-				if (aircraft.Info.CanHover)
+				// For VTOL landing to succeed, it must reach the exact target position,
+				// so for the final move it needs to behave as if it had the Slide flag.
+				if (isSlider || aircraft.Info.FlightDynamics.HasFlag(FlightDynamic.VTOL))
 				{
 					// Set final (horizontal) position
 					if (delta.HorizontalLengthSquared != 0)
@@ -193,7 +197,7 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 			}
 
-			if (!aircraft.Info.CanHover)
+			if (!isSlider)
 			{
 				// Using the turn rate, compute a hypothetical circle traced by a continuous turn.
 				// If it contains the destination point, it's unreachable without more complex manuvering.

--- a/OpenRA.Mods.Common/Activities/Air/FlyCircle.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyCircle.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Activities
 			// We can't possibly turn this fast
 			var desiredFacing = aircraft.Facing + 64;
 
-			// This override is necessary, otherwise CanHover aircraft would circle sideways
+			// This override is necessary, otherwise aircraft with Slide flag would circle sideways
 			var move = aircraft.FlyStep(aircraft.Facing);
 
 			Fly.FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, move, turnSpeedOverride);

--- a/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyFollow.cs
@@ -84,7 +84,9 @@ namespace OpenRA.Mods.Common.Activities
 			// otherwise if it is hidden or dead we give up
 			if (checkTarget.IsInRange(pos, maxRange) && !checkTarget.IsInRange(pos, minRange))
 			{
-				Fly.FlyTick(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);
+				if (!aircraft.Info.FlightDynamics.HasFlag(FlightDynamic.Hover))
+					Fly.FlyTick(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);
+
 				return useLastVisibleTarget;
 			}
 

--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// NOTE: desiredFacing = -1 means we should not prefer any particular facing and instead just
 			// use whatever facing gives us the most direct path to the landing site.
-			if (facing == -1 && aircraft.Info.TurnToLand)
+			if (facing == -1 && aircraft.Info.FlightDynamics.HasFlag(FlightDynamic.TurnToLand))
 				desiredFacing = aircraft.Info.InitialFacing;
 			else
 				desiredFacing = facing;
@@ -130,7 +130,7 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			// Move towards landing location
-			if (aircraft.Info.VTOL && (pos - targetPosition).HorizontalLengthSquared != 0)
+			if (aircraft.Info.FlightDynamics.HasFlag(FlightDynamic.VTOL) && (pos - targetPosition).HorizontalLengthSquared != 0)
 			{
 				QueueChild(new Fly(self, Target.FromPos(targetPosition)));
 
@@ -140,7 +140,7 @@ namespace OpenRA.Mods.Common.Activities
 				return false;
 			}
 
-			if (!aircraft.Info.VTOL && !finishedApproach)
+			if (!aircraft.Info.FlightDynamics.HasFlag(FlightDynamic.VTOL) && !finishedApproach)
 			{
 				// Calculate approach trajectory
 				var altitude = aircraft.Info.CruiseAltitude.Length;
@@ -207,7 +207,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (!aircraft.CanLand(blockingCells, target.Actor))
 				{
 					// Maintain holding pattern.
-					if (aircraft.Info.CanHover)
+					if (aircraft.Info.FlightDynamics.HasFlag(FlightDynamic.Hover))
 						QueueChild(new Wait(25));
 					else
 						QueueChild(new FlyCircle(self, 25));
@@ -226,7 +226,7 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			// Final descent.
-			if (aircraft.Info.VTOL)
+			if (aircraft.Info.FlightDynamics.HasFlag(FlightDynamic.VTOL))
 			{
 				var landAltitude = self.World.Map.DistanceAboveTerrain(targetPosition) + aircraft.LandAltitude;
 				if (Fly.VerticalTakeOffOrLandTick(self, aircraft, aircraft.Facing, landAltitude))

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				if (nearestResupplier != null)
 				{
-					if (aircraft.Info.CanHover)
+					if (aircraft.Info.FlightDynamics.HasFlag(FlightDynamic.Hover))
 					{
 						var distanceFromResupplier = (nearestResupplier.CenterPosition - self.CenterPosition).HorizontalLength;
 						var distanceLength = aircraft.Info.WaitDistanceFromResupplyBase.Length;
@@ -113,15 +113,15 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				var exit = dest.FirstExitOrDefault(null);
 				var offset = exit != null ? exit.Info.SpawnOffset : WVec.Zero;
-				if (aircraft.Info.TurnToDock)
+				if (aircraft.Info.FlightDynamics.HasFlag(FlightDynamic.TurnToDock))
 					facing = aircraft.Info.InitialFacing;
-				if (!aircraft.Info.VTOL)
+				if (!aircraft.Info.FlightDynamics.HasFlag(FlightDynamic.VTOL))
 					facing = 192;
 
 				aircraft.MakeReservation(dest);
 				QueueChild(new Land(self, Target.FromActor(dest), offset, facing));
 				QueueChild(new Resupply(self, dest, WDist.Zero));
-				if (aircraft.Info.TakeOffOnResupply && !alwaysLand)
+				if (aircraft.Info.FlightDynamics.HasFlag(FlightDynamic.TakeOffOnResupply) && !alwaysLand)
 					QueueChild(new TakeOff(self));
 
 				return true;

--- a/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
+++ b/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (dat < aircraft.Info.CruiseAltitude)
 			{
 				// If we're a VTOL, rise before flying forward
-				if (aircraft.Info.VTOL)
+				if (aircraft.Info.FlightDynamics.HasFlag(FlightDynamic.VTOL))
 				{
 					Fly.VerticalTakeOffOrLandTick(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);
 					return false;
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.Activities
 			// Checking for NextActivity == null again in case another activity was queued while taking off
 			if (moveToRallyPoint && NextActivity == null)
 			{
-				if (!aircraft.Info.VTOL && assignTargetOnFirstRun)
+				if (!aircraft.Info.FlightDynamics.HasFlag(FlightDynamic.VTOL) && assignTargetOnFirstRun)
 					return true;
 
 				QueueChild(new AttackMoveActivity(self, () => move.MoveToTarget(self, target)));

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -21,9 +21,34 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	[Flags]
+	public enum FlightDynamic
+	{
+		None = 0,
+		MoveIntoShroud = 1,
+		Slide = 2,
+		Hover = 4,
+		VTOL = 8,
+		TurnToLand = 16,
+		TurnToDock = 32,
+		TakeOffOnResupply = 64,
+		TakeOffOnCreation = 128,
+	}
+
 	public class AircraftInfo : ITraitInfo, IPositionableInfo, IFacingInfo, IMoveInfo, ICruiseAltitudeInfo,
 		IActorPreviewInitInfo, IEditorActorOptions, IObservesVariablesInfo
 	{
+		[Desc("List of flags that alter the movement behavior. Options:",
+			"MoveIntoShroud = Can be ordered to move into shroud.",
+			"Slide = Changes direction immediately, independently of current facing. Without this flag, needs to fly a curve.",
+			"Hover = Able to statically hover in air while idle or waiting. Without this flag, aircraft will fly in circles.",
+			"VTOL = Vertical-only take-off/land. Without this flag, lands/takes off diagonally.",
+			"TurnToLand = Does the aircraft need to turn towards InitialFacing before landing on terrain? No effect if VTOL flag is missing.",
+			"TurnToDock = Does the aircraft need to turn towards InitialFacing before landing on dock? No effect if VTOL flag is missing.",
+			"TakeOffOnResupply = Take off as soon as resupplies/repairs are finished.",
+			"TakeOffOnCreation = Take off from creator when spawned.")]
+		public readonly FlightDynamic FlightDynamics = FlightDynamic.TakeOffOnCreation | FlightDynamic.MoveIntoShroud;
+
 		public readonly WDist CruiseAltitude = new WDist(1280);
 
 		[Desc("Whether the aircraft can be repulsed.")]
@@ -49,9 +74,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly HashSet<string> LandableTerrainTypes = new HashSet<string>();
 
-		[Desc("Can the actor be ordered to move in to shroud?")]
-		public readonly bool MoveIntoShroud = true;
-
 		[Desc("e.g. crate, wall, infantry")]
 		public readonly BitSet<CrushClass> Crushes = default(BitSet<CrushClass>);
 
@@ -69,29 +91,11 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The condition to grant to self while at cruise altitude.")]
 		public readonly string CruisingCondition = null;
 
-		[Desc("Can the actor hover in place mid-air? If not, then the actor will have to remain in motion (circle around).")]
-		public readonly bool CanHover = false;
-
-		[Desc("Does the actor land and take off vertically?")]
-		public readonly bool VTOL = false;
-
 		[Desc("Will this actor try to land after it has no more commands?")]
 		public readonly bool LandWhenIdle = true;
 
-		[Desc("Does this VTOL actor need to turn before landing (on terrain)?")]
-		public readonly bool TurnToLand = false;
-
-		[Desc("Does this VTOL actor need to turn before landing on a resupplier?")]
-		public readonly bool TurnToDock = true;
-
 		[Desc("Does this actor cancel its previous activity after resupplying?")]
 		public readonly bool AbortOnResupply = true;
-
-		[Desc("Does this actor automatically take off after resupplying?")]
-		public readonly bool TakeOffOnResupply = false;
-
-		[Desc("Does this actor automatically take off after creation?")]
-		public readonly bool TakeOffOnCreation = true;
 
 		[Desc("Altitude at which the aircraft considers itself landed.")]
 		public readonly WDist LandAltitude = WDist.Zero;
@@ -344,7 +348,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				MakeReservation(host);
 
-				if (Info.TakeOffOnCreation)
+				if (Info.FlightDynamics.HasFlag(FlightDynamic.TakeOffOnCreation))
 					self.QueueActivity(new TakeOff(self));
 			}
 
@@ -440,7 +444,7 @@ namespace OpenRA.Mods.Common.Traits
 				repulsionForce += new WVec(1024, 0, 0).Rotate(WRot.FromYaw((self.CenterPosition - center).Yaw));
 			}
 
-			if (Info.CanHover)
+			if (Info.FlightDynamics.HasFlag(FlightDynamic.Slide))
 				return repulsionForce;
 
 			// Non-hovering actors mush always keep moving forward, so they need extra calculations.
@@ -681,18 +685,13 @@ namespace OpenRA.Mods.Common.Traits
 				}
 			}
 
+			var isCircler = !Info.FlightDynamics.HasFlag(FlightDynamic.Hover);
 			if (!atLandAltitude && Info.LandWhenIdle && Info.LandableTerrainTypes.Count > 0)
 				self.QueueActivity(new Land(self));
-			else if (!Info.CanHover && !atLandAltitude)
+			else if (isCircler && !atLandAltitude)
 				self.QueueActivity(new FlyCircle(self, -1, Info.IdleTurnSpeed > -1 ? Info.IdleTurnSpeed : TurnSpeed));
 			else if (atLandAltitude && !CanLand(self.Location) && ReservedActor == null)
 				self.QueueActivity(new TakeOff(self));
-			else if (Info.CanHover && Info.IdleTurnSpeed > 0)
-			{
-				// Temporary HACK for the AutoCarryall special case (needs CanHover, but also FlyCircle on idle).
-				// Will go away soon (in a separate PR) with the arrival of ActionsWhenIdle.
-				self.QueueActivity(new FlyCircle(self, -1, Info.IdleTurnSpeed > -1 ? Info.IdleTurnSpeed : TurnSpeed));
-			}
 			else if (!atLandAltitude && altitude != Info.CruiseAltitude && !Info.LandWhenIdle)
 				self.QueueActivity(new TakeOff(self));
 		}
@@ -834,11 +833,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
-			if (!Info.CanHover)
-				return new FlyFollow(self, target, minRange, maxRange,
-					initialTargetPosition, targetLineColor);
-
-			return new Follow(self, target, minRange, maxRange,
+			return new FlyFollow(self, target, minRange, maxRange,
 				initialTargetPosition, targetLineColor);
 		}
 
@@ -943,7 +938,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				case "Land":
 				case "Move":
-					if (!Info.MoveIntoShroud && order.Target.Type != TargetType.Invalid)
+					if (!Info.FlightDynamics.HasFlag(FlightDynamic.MoveIntoShroud) && order.Target.Type != TargetType.Invalid)
 					{
 						var cell = self.World.Map.CellContaining(order.Target.CenterPosition);
 						if (!self.Owner.Shroud.IsExplored(cell))
@@ -968,7 +963,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (orderString == "Move")
 			{
 				var cell = self.World.Map.Clamp(self.World.Map.CellContaining(order.Target.CenterPosition));
-				if (!Info.MoveIntoShroud && !self.Owner.Shroud.IsExplored(cell))
+				if (!Info.FlightDynamics.HasFlag(FlightDynamic.MoveIntoShroud) && !self.Owner.Shroud.IsExplored(cell))
 					return;
 
 				if (!order.Queued)
@@ -981,7 +976,7 @@ namespace OpenRA.Mods.Common.Traits
 			else if (orderString == "Land")
 			{
 				var cell = self.World.Map.Clamp(self.World.Map.CellContaining(order.Target.CenterPosition));
-				if (!Info.MoveIntoShroud && !self.Owner.Shroud.IsExplored(cell))
+				if (!Info.FlightDynamics.HasFlag(FlightDynamic.MoveIntoShroud) && !self.Owner.Shroud.IsExplored(cell))
 					return;
 
 				if (!order.Queued)
@@ -1011,7 +1006,7 @@ namespace OpenRA.Mods.Common.Traits
 				// Aircraft with TakeOffOnResupply would immediately take off again, so there's no point in automatically forcing
 				// them to land on a resupplier. For aircraft without it, it makes more sense to land than to idle above a
 				// free resupplier.
-				var forceLand = orderString == "ForceEnter" || !Info.TakeOffOnResupply;
+				var forceLand = orderString == "ForceEnter" || !Info.FlightDynamics.HasFlag(FlightDynamic.TakeOffOnResupply);
 				self.QueueActivity(order.Queued, new ReturnToBase(self, targetActor, forceLand));
 			}
 			else if (orderString == "Stop")
@@ -1036,7 +1031,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				// Aircraft with TakeOffOnResupply would immediately take off again, so there's no point in forcing them to land
 				// on a resupplier. For aircraft without it, it makes more sense to land than to idle above a free resupplier.
-				self.QueueActivity(order.Queued, new ReturnToBase(self, null, !Info.TakeOffOnResupply));
+				self.QueueActivity(order.Queued, new ReturnToBase(self, null, !Info.FlightDynamics.HasFlag(FlightDynamic.TakeOffOnResupply)));
 			}
 			else if (orderString == "Scatter")
 				Nudge(self);
@@ -1154,7 +1149,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
 
-				if (!explored && !aircraft.Info.MoveIntoShroud)
+				if (!explored && !aircraft.Info.FlightDynamics.HasFlag(FlightDynamic.MoveIntoShroud))
 					cursor = "move-blocked";
 
 				return true;

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -293,7 +293,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (order.OrderString == "DeliverUnit")
 			{
 				var cell = self.World.Map.Clamp(self.World.Map.CellContaining(order.Target.CenterPosition));
-				if (!aircraftInfo.MoveIntoShroud && !self.Owner.Shroud.IsExplored(cell))
+				if (!aircraftInfo.FlightDynamics.HasFlag(FlightDynamic.MoveIntoShroud) && !self.Owner.Shroud.IsExplored(cell))
 					return;
 
 				var targetLocation = move.NearestMoveableCell(cell);
@@ -406,7 +406,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
 
-				if (!explored && !aircraftInfo.MoveIntoShroud)
+				if (!explored && !aircraftInfo.FlightDynamics.HasFlag(FlightDynamic.MoveIntoShroud))
 					cursor = info.DropOffBlockedCursor;
 
 				return true;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20190314/AddFlightDynamics.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20190314/AddFlightDynamics.cs
@@ -1,0 +1,75 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class AddFlightDynamics : UpdateRule
+	{
+		public override string Name { get { return "Replaced Aircraft boolean fields with FlightDynamics"; } }
+		public override string Description
+		{
+			get
+			{
+				return "Various Aircraft boolean fields have been replaced with a single FlightDynamics flag list.\n"
+					+ "Additionally, the old 'CanHover' behavior has been split into two flags:\n"
+					+ "'Slide' to change flight direction independent of facing, and 'Hover' to be able to stand still mid-air.";
+			}
+		}
+
+		static readonly string[] Properties =
+		{
+			"MoveIntoShroud",
+			"CanHover",
+			"VTOL",
+			"TurnToLand",
+			"TurnToDock",
+			"TakeOffOnResupply",
+			"TakeOffOnCreation",
+		};
+
+		readonly Dictionary<string, List<string>> locations = new Dictionary<string, List<string>>();
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (locations.Any())
+				yield return "The following aircraft definitions did not use the internal defaults\n" +
+					"and likely need a customized FlightDynamics flag list (and removal of the old booleans):\n" +
+					UpdateUtils.FormatMessageList(locations.Select(
+						kv => kv.Key + ":\n" + UpdateUtils.FormatMessageList(kv.Value)));
+
+			locations.Clear();
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var aircraftTraits = actorNode.ChildrenMatching("Aircraft");
+			foreach (var aircraft in aircraftTraits)
+			{
+				var used = new List<string>();
+				foreach (var p in Properties)
+					if (aircraft.LastChildMatching(p) != null)
+						used.Add(p);
+
+				if (used.Any())
+				{
+					var location = "{0} ({1})".F(actorNode.Key, actorNode.Location.Filename);
+					locations[location] = used;
+				}
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -130,6 +130,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RenameHoversOffsetModifier(),
 				new AddAirAttackTypes(),
 				new RenameCarryallDelays(),
+				new AddFlightDynamics(),
 			})
 		};
 

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -325,11 +325,9 @@
 		LandWhenIdle: false
 		AirborneCondition: airborne
 		CruisingCondition: cruising
-		CanHover: True
-		TakeOffOnResupply: true
-		VTOL: true
 		LandableTerrainTypes: Clear, Rough, Road, Beach, Tiberium, BlueTiberium
 		Crushes: crate, infantry
+		FlightDynamics: VTOL, Slide, Hover, MoveIntoShroud, TakeOffOnCreation, TakeOffOnResupply, TurnToDock
 		InitialFacing: 224
 	HiddenUnderFog:
 		Type: GroundPosition
@@ -1089,8 +1087,7 @@
 		Offset: 43, 128, 0
 		ZOffset: -129
 	Aircraft:
-		CanHover: True
-		VTOL: true
+		FlightDynamics: VTOL, Slide, Hover, MoveIntoShroud, TakeOffOnCreation
 	FallsToEarth:
 		Spins: True
 		Moves: False

--- a/mods/d2k/maps/atreides-05/rules.yaml
+++ b/mods/d2k/maps/atreides-05/rules.yaml
@@ -26,7 +26,6 @@ carryall.reinforce:
 frigate:
 	Aircraft:
 		LandableTerrainTypes: Sand, Rock, Transition, Spice, SpiceSand, Dune, Concrete
-		VTOL: true # The frigate would teleport to land otherwise
 
 barracks.harkonnen:
 	Inherits: barracks

--- a/mods/d2k/maps/harkonnen-05/rules.yaml
+++ b/mods/d2k/maps/harkonnen-05/rules.yaml
@@ -32,7 +32,6 @@ carryall.reinforce:
 frigate:
 	Aircraft:
 		LandableTerrainTypes: Sand, Rock, Transition, Spice, SpiceSand, Dune, Concrete
-		VTOL: true # The frigate would teleport to land otherwise
 
 concreteb:
 	Buildable:

--- a/mods/d2k/maps/harkonnen-06a/rules.yaml
+++ b/mods/d2k/maps/harkonnen-06a/rules.yaml
@@ -36,7 +36,6 @@ carryall.reinforce:
 frigate:
 	Aircraft:
 		LandableTerrainTypes: Sand, Rock, Transition, Spice, SpiceSand, Dune, Concrete
-		VTOL: true # The frigate would teleport to land otherwise
 
 concreteb:
 	Buildable:

--- a/mods/d2k/maps/harkonnen-06b/rules.yaml
+++ b/mods/d2k/maps/harkonnen-06b/rules.yaml
@@ -36,7 +36,6 @@ carryall.reinforce:
 frigate:
 	Aircraft:
 		LandableTerrainTypes: Sand, Rock, Transition, Spice, SpiceSand, Dune, Concrete
-		VTOL: true # The frigate would teleport to land otherwise
 
 concreteb:
 	Buildable:

--- a/mods/d2k/maps/harkonnen-08/rules.yaml
+++ b/mods/d2k/maps/harkonnen-08/rules.yaml
@@ -34,7 +34,6 @@ carryall.reinforce:
 frigate:
 	Aircraft:
 		LandableTerrainTypes: Sand, Rock, Transition, Spice, SpiceSand, Dune, Concrete
-		VTOL: true # The frigate would teleport to land otherwise
 
 mpsardaukar:
 	Buildable:

--- a/mods/d2k/maps/harkonnen-09a/rules.yaml
+++ b/mods/d2k/maps/harkonnen-09a/rules.yaml
@@ -35,7 +35,6 @@ carryall.reinforce:
 frigate:
 	Aircraft:
 		LandableTerrainTypes: Sand, Rock, Transition, Spice, SpiceSand, Dune, Concrete
-		VTOL: true # The frigate would teleport to land otherwise
 
 mpsardaukar:
 	Buildable:

--- a/mods/d2k/maps/harkonnen-09b/rules.yaml
+++ b/mods/d2k/maps/harkonnen-09b/rules.yaml
@@ -38,7 +38,6 @@ carryall.reinforce:
 frigate:
 	Aircraft:
 		LandableTerrainTypes: Sand, Rock, Transition, Spice, SpiceSand, Dune, Concrete
-		VTOL: true # The frigate would teleport to land otherwise
 
 mpsardaukar:
 	Buildable:

--- a/mods/d2k/maps/ordos-05/rules.yaml
+++ b/mods/d2k/maps/ordos-05/rules.yaml
@@ -34,7 +34,6 @@ carryall.reinforce:
 frigate:
 	Aircraft:
 		LandableTerrainTypes: Sand, Rock, Transition, Spice, SpiceSand, Dune, Concrete
-		VTOL: true # The frigate would teleport to land otherwise
 
 concreteb:
 	Buildable:

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -9,6 +9,7 @@ carryall.reinforce:
 	Armor:
 		Type: light
 	Aircraft:
+		FlightDynamics: VTOL, Slide, MoveIntoShroud, TakeOffOnCreation
 		CruiseAltitude: 2160
 		CruisingCondition: cruising
 		InitialFacing: 0
@@ -18,8 +19,6 @@ carryall.reinforce:
 		Repulsable: False
 		LandWhenIdle: False
 		AirborneCondition: airborne
-		CanHover: True
-		VTOL: true
 		IdleTurnSpeed: 1
 	Targetable@GROUND:
 		TargetTypes: Ground, Vehicle
@@ -77,6 +76,7 @@ frigate:
 	Tooltip:
 		Name: Frigate
 	Aircraft:
+		FlightDynamics: VTOL, Hover, MoveIntoShroud, TakeOffOnCreation
 		Speed: 189
 		TurnSpeed: 1
 		Repulsable: False
@@ -99,12 +99,11 @@ ornithopter:
 	Armor:
 		Type: light
 	Aircraft:
+		FlightDynamics: MoveIntoShroud, TakeOffOnCreation
 		Speed: 224
 		TurnSpeed: 2
 		Repulsable: False
-		CanHover: True
 		CruiseAltitude: 1920
-		VTOL: true
 	AmmoPool:
 		Ammo: 5
 	Tooltip:
@@ -132,8 +131,7 @@ carryall.husk:
 	Aircraft:
 		TurnSpeed: 4
 		Speed: 144
-		CanHover: True
-		VTOL: true
+		FlightDynamics: VTOL, Slide, MoveIntoShroud, TakeOffOnCreation
 	RenderSprites:
 		Image: carryall
 
@@ -146,7 +144,6 @@ carryall.huskVTOL:
 		Velocity: 0c128
 	Aircraft:
 		TurnSpeed: 4
-		CanHover: True
-		VTOL: true
+		FlightDynamics: VTOL, Slide, MoveIntoShroud, TakeOffOnCreation
 	RenderSprites:
 		Image: carryall

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -626,14 +626,12 @@
 	Tooltip:
 		GenericName: Helicopter
 	Aircraft:
-		CanHover: True
 		CruisingCondition: cruising
 		WaitDistanceFromResupplyBase: 4c0
-		TakeOffOnResupply: true
-		VTOL: true
 		LandableTerrainTypes: Clear, Rough, Road, Ore, Beach, Gems
 		Crushes: crate, mine, infantry
 		InitialFacing: 224
+		FlightDynamics: VTOL, Slide, Hover, MoveIntoShroud, TakeOffOnCreation, TakeOffOnResupply, TurnToDock
 	GpsDot:
 		String: Helicopter
 	Hovers@CRUISING:
@@ -1045,8 +1043,7 @@
 	Tooltip:
 		GenericName: Destroyed Helicopter
 	Aircraft:
-		CanHover: True
-		VTOL: true
+		FlightDynamics: VTOL, Slide, Hover, MoveIntoShroud, TakeOffOnCreation
 	FallsToEarth:
 		Explosion: UnitExplodeHeli
 	BodyOrientation:

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -1,5 +1,5 @@
 DPOD:
-	Inherits: ^Helicopter
+	Inherits: ^Aircraft
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Valued:
 		Cost: 10
@@ -32,7 +32,7 @@ DPOD:
 	-SpawnActorOnDeath:
 
 DSHP:
-	Inherits: ^Helicopter
+	Inherits: ^Aircraft
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -49,6 +49,7 @@ DSHP:
 		IdealSeparation: 1275
 		CruiseAltitude: 12c512
 		AltitudeVelocity: 256
+		FlightDynamics: VTOL, Hover, MoveIntoShroud, TakeOffOnCreation, TurnToDock
 	Health:
 		HP: 20000
 	Armor:
@@ -66,7 +67,7 @@ DSHP:
 		Actor: DSHP.Husk
 
 ORCA:
-	Inherits: ^Helicopter
+	Inherits: ^Aircraft
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Inherits@EMPDISABLE: ^EmpDisable
@@ -86,10 +87,10 @@ ORCA:
 	Aircraft:
 		TurnSpeed: 5
 		Speed: 186
-		MoveIntoShroud: false
 		TakeoffSounds: orcaup1.aud
 		LandingSounds: orcadwn1.aud
 		AltitudeVelocity: 128
+		FlightDynamics: VTOL, Hover, TakeOffOnCreation, TakeOffOnResupply, TurnToDock
 	Health:
 		HP: 20000
 	Armor:
@@ -141,7 +142,6 @@ ORCAB:
 		TurnSpeed: 3
 		Speed: 96
 		CruisingCondition: cruising
-		MoveIntoShroud: false
 		TakeoffSounds: orcaup1.aud
 		LandingSounds: orcadwn1.aud
 	ReturnOnIdle:
@@ -177,7 +177,7 @@ ORCAB:
 		RearmActors: gahpad, nahpad
 
 ORCATRAN:
-	Inherits: ^Helicopter
+	Inherits: ^Aircraft
 	Valued:
 		Cost: 1200
 	Tooltip:
@@ -194,9 +194,12 @@ ORCATRAN:
 		TurnSpeed: 5
 		Speed: 84
 		InitialFacing: 0
+		LandableTerrainTypes: Clear, Road, Rail, DirtRoad, Rough, Tiberium, BlueTiberium, Veins
+		Crushes: crate, infantry
 		TakeoffSounds: orcaup1.aud
 		LandingSounds: orcadwn1.aud
 		IdealSeparation: 1275
+		FlightDynamics: VTOL, Hover, MoveIntoShroud, TakeOffOnCreation, TurnToDock
 	Health:
 		HP: 20000
 	Armor:
@@ -215,7 +218,7 @@ ORCATRAN:
 		Actor: ORCATRAN.Husk
 
 TRNSPORT:
-	Inherits: ^Helicopter
+	Inherits: ^Aircraft
 	Valued:
 		Cost: 750
 	Tooltip:
@@ -233,7 +236,6 @@ TRNSPORT:
 		InitialFacing: 0
 		TakeoffSounds: dropup1.aud
 		LandingSounds: dropdwn1.aud
-		MoveIntoShroud: false
 	Carryall:
 		Voice: Move
 		LocalOffset: 0,0,-317
@@ -277,7 +279,6 @@ SCRIN:
 		TurnSpeed: 3
 		Speed: 168
 		AirborneCondition: airborne
-		MoveIntoShroud: false
 		TakeoffSounds: dropup1.aud
 		LandingSounds: dropdwn1.aud
 	ReturnOnIdle:
@@ -311,7 +312,7 @@ SCRIN:
 		RearmActors: gahpad, nahpad
 
 APACHE:
-	Inherits: ^Helicopter
+	Inherits: ^Aircraft
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
 	Inherits@EMPDISABLE: ^EmpDisable
@@ -331,7 +332,7 @@ APACHE:
 	Aircraft:
 		TurnSpeed: 5
 		Speed: 130
-		MoveIntoShroud: false
+		FlightDynamics: VTOL, Hover, TakeOffOnCreation, TakeOffOnResupply, TurnToDock
 	Health:
 		HP: 22500
 	Armor:
@@ -382,9 +383,8 @@ HUNTER:
 		TurnSpeed: 16
 		Speed: 355
 		CruiseAltitude: 3c128
-		CanHover: True
 		CruisingCondition: cruising
-		VTOL: true
+		FlightDynamics: VTOL, Slide, Hover, MoveIntoShroud, TakeOffOnCreation
 	AttackAircraft:
 		FacingTolerance: 128
 		AttackType: Hover

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -871,12 +871,16 @@
 		Voice: Move
 	Aircraft:
 		AirborneCondition: airborne
+		CruisingCondition: cruising
+		CruiseAltitude: 4c704
+		AltitudeVelocity: 96
 		LandWhenIdle: false
 		Voice: Move
 		IdealSeparation: 853
 		MaximumPitch: 120
 		LandableTerrainTypes: Clear, Road, Rail, DirtRoad, Rough, Tiberium, BlueTiberium, Veins
 		Crushes: crate, infantry
+		FlightDynamics: VTOL, TakeOffOnCreation, TakeOffOnResupply, TurnToDock
 	Voiced:
 		VoiceSet: Heli
 	HiddenUnderFog:
@@ -900,16 +904,6 @@
 		Categories: Aircraft
 	SpawnActorOnDeath:
 		RequiresCondition: airborne
-
-^Helicopter:
-	Inherits: ^Aircraft
-	Aircraft:
-		CruiseAltitude: 4c704
-		AltitudeVelocity: 96
-		CanHover: True
-		CruisingCondition: cruising
-		TakeOffOnResupply: true
-		VTOL: true
 	Hovers@CRUISING:
 		RequiresCondition: cruising
 		BobDistance: -64

--- a/mods/ts/rules/gdi-infantry.yaml
+++ b/mods/ts/rules/gdi-infantry.yaml
@@ -174,8 +174,7 @@ JUMPJET.Husk:
 		Explosion:
 	Aircraft:
 		Speed: 186
-		CanHover: True
-		VTOL: true
+		FlightDynamics: VTOL, Slide, Hover, MoveIntoShroud
 	RenderSprites:
 		Image: jumpjet
 	WithSpriteBody:


### PR DESCRIPTION
This PR gets rid of a lot of booleans and two traits in favor of one list of flags that controls aircraft movement behavior, and one enum that controls behavior on becoming idle.

Note 1: Not providing an update rule yet, as I expect at least some flag names to change during review process, also inheritance makes it impossible to set the correct flags on all aircraft so the update rule will be mostly about pointing modders to places that need manual changes.

Note 2: I decided against trying to stuff the idle behavior into `FlightDynamics` as well, because that would only cause headaches if someone set multiple idle flags.