### PR TITLE
Add rebindable hotkeys for menu buttons

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -37,6 +37,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		bool leaving;
 		bool hideMenu;
 
+		int currentButtonNumber = 1;
+
 		[ObjectCreator.UseCtor]
 		public IngameMenuLogic(Widget widget, ModData modData, World world, Action onExit, WorldRenderer worldRenderer,
 			IngameInfoPanel activePanel, Dictionary<string, MiniYaml> logicArgs)
@@ -175,11 +177,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			button.Id = id;
+			button.Key = modData.Hotkeys["Menu" + currentButtonNumber.ToString("D2")];
 			button.IsDisabled = () => leaving;
 			button.GetText = () => text;
 			buttonContainer.AddChild(button);
 			buttons.Add(button);
 
+			currentButtonNumber++;
 			return button;
 		}
 

--- a/mods/cnc/chrome/mainmenu.yaml
+++ b/mods/cnc/chrome/mainmenu.yaml
@@ -64,30 +64,35 @@ Container@MENU_BACKGROUND:
 							Width: 140
 							Height: 35
 							Text: Singleplayer
+							Key: Menu01
 						Button@MULTIPLAYER_BUTTON:
 							X: 150
 							Y: 0
 							Width: 140
 							Height: 35
 							Text: Multiplayer
+							Key: Menu02
 						Button@SETTINGS_BUTTON:
 							X: 300
 							Y: 0
 							Width: 140
 							Height: 35
 							Text: Settings
+							Key: Menu03
 						Button@EXTRAS_BUTTON:
 							X: 450
 							Y: 0
 							Width: 140
 							Height: 35
 							Text: Extras
+							Key: Menu04
 						Button@CONTENT_BUTTON:
 							X: 600
 							Y: 0
 							Width: 140
 							Height: 35
 							Text: Manage Content
+							Key: Menu05
 						Button@QUIT_BUTTON:
 							X: 750
 							Y: 0
@@ -113,18 +118,21 @@ Container@MENU_BACKGROUND:
 							Width: 140
 							Height: 35
 							Text: Skirmish
+							Key: Menu01
 						Button@MISSIONS_BUTTON:
 							X: 150
 							Y: 0
 							Width: 140
 							Height: 35
 							Text: Missions
+							Key: Menu02
 						Button@LOAD_BUTTON:
 							X: 300
 							Y: 0
 							Width: 140
 							Height: 35
 							Text: Load
+							Key: Menu03
 						Button@BACK_BUTTON:
 							Key: escape
 							X: 450
@@ -151,12 +159,14 @@ Container@MENU_BACKGROUND:
 							Width: 140
 							Height: 35
 							Text: Replays
+							Key: Menu01
 						Button@MUSIC_BUTTON:
 							X: 150
 							Y: 0
 							Width: 140
 							Height: 35
 							Text: Music
+							Key: Menu02
 						Button@MAP_EDITOR_BUTTON:
 							X: 300
 							Y: 0
@@ -164,18 +174,21 @@ Container@MENU_BACKGROUND:
 							Height: 35
 							Text: Map Editor
 							Font: Bold
+							Key: Menu03
 						Button@ASSETBROWSER_BUTTON:
 							X: 450
 							Y: 0
 							Width: 140
 							Height: 35
 							Text: Asset Browser
+							Key: Menu04
 						Button@CREDITS_BUTTON:
 							X: 600
 							Y: 0
 							Width: 140
 							Height: 35
 							Text: Credits
+							Key: Menu05
 						Button@BACK_BUTTON:
 							Key: escape
 							X: 750
@@ -203,6 +216,7 @@ Container@MENU_BACKGROUND:
 							Height: 35
 							Text: New Map
 							Font: Bold
+							Key: Menu01
 						Button@LOAD_MAP_BUTTON:
 							X: 150
 							Y: 0
@@ -210,6 +224,7 @@ Container@MENU_BACKGROUND:
 							Height: 35
 							Text: Load Map
 							Font: Bold
+							Key: Menu02
 						Button@BACK_BUTTON:
 							X: 300
 							Y: 0

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -3,7 +3,7 @@ Container@SETTINGS_PANEL:
 		HotkeyGroups:
 			Game Commands:
 				Template: TWO_COLUMN
-				Types: OrderGenerator, World, Menu
+				Types: OrderGenerator, World
 			Viewport Commands:
 				Template: TWO_COLUMN
 				Types: Viewport
@@ -25,6 +25,12 @@ Container@SETTINGS_PANEL:
 			Music Commands:
 				Template: TWO_COLUMN
 				Types: Music
+			Menu Commands:
+				Template: TWO_COLUMN
+				Types: Menu
+			Global Commands:
+				Template: TWO_COLUMN
+				Types: Global
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
 	Width: 590
@@ -43,26 +49,31 @@ Container@SETTINGS_PANEL:
 					Width: 110
 					Height: 35
 					Text: Display
+					Key: Menu01
 				Button@AUDIO_TAB:
 					X: WIDTH + 10
 					Width: 110
 					Height: 35
 					Text: Audio
+					Key: Menu02
 				Button@INPUT_TAB:
 					X: 2 * (WIDTH + 10)
 					Width: 110
 					Height: 35
 					Text: Input
+					Key: Menu03
 				Button@HOTKEYS_TAB:
 					X: 3 * (WIDTH + 10)
 					Width: 110
 					Height: 35
 					Text: Hotkeys
+					Key: Menu04
 				Button@ADVANCED_TAB:
 					X: 4 * (WIDTH + 10)
 					Width: 110
 					Height: 35
 					Text: Advanced
+					Key: Menu05
 		Background@bg:
 			Y: 34
 			Width: 590

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -149,6 +149,7 @@ Hotkeys:
 	common|hotkeys/production-peractor.yaml
 	common|hotkeys/supportpowers.yaml
 	common|hotkeys/viewport.yaml
+	common|hotkeys/menu.yaml
 	cnc|hotkeys.yaml
 
 LoadScreen: CncLoadScreen

--- a/mods/common/chrome/mainmenu.yaml
+++ b/mods/common/chrome/mainmenu.yaml
@@ -53,6 +53,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Singleplayer
 							Font: Bold
+							Key: Menu01
 						Button@MULTIPLAYER_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 100
@@ -60,6 +61,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Multiplayer
 							Font: Bold
+							Key: Menu02
 						Button@SETTINGS_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 140
@@ -67,6 +69,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Settings
 							Font: Bold
+							Key: Menu03
 						Button@EXTRAS_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 180
@@ -74,6 +77,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Extras
 							Font: Bold
+							Key: Menu04
 						Button@CONTENT_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 220
@@ -81,6 +85,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Manage Content
 							Font: Bold
+							Key: Menu05
 						Button@QUIT_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 260
@@ -107,6 +112,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Skirmish
 							Font: Bold
+							Key: Menu01
 						Button@MISSIONS_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 100
@@ -114,6 +120,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Missions
 							Font: Bold
+							Key: Menu02
 						Button@LOAD_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 140
@@ -121,6 +128,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Load
 							Font: Bold
+							Key: Menu03
 						Button@BACK_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Key: escape
@@ -148,6 +156,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Replays
 							Font: Bold
+							Key: Menu01
 						Button@MUSIC_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 100
@@ -155,6 +164,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Music
 							Font: Bold
+							Key: Menu02
 						Button@MAP_EDITOR_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 140
@@ -162,6 +172,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Map Editor
 							Font: Bold
+							Key: Menu03
 						Button@ASSETBROWSER_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 180
@@ -169,6 +180,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Asset Browser
 							Font: Bold
+							Key: Menu04
 						Button@CREDITS_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 220
@@ -176,6 +188,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Credits
 							Font: Bold
+							Key: Menu05
 						Button@BACK_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Key: escape
@@ -203,6 +216,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: New Map
 							Font: Bold
+							Key: Menu01
 						Button@LOAD_MAP_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 100
@@ -210,6 +224,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Load Map
 							Font: Bold
+							Key: Menu02
 						Button@BACK_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Key: escape

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -3,7 +3,7 @@ Background@SETTINGS_PANEL:
 		HotkeyGroups:
 			Game Commands:
 				Template: TWO_COLUMN
-				Types: OrderGenerator, World, Menu
+				Types: OrderGenerator, World
 			Viewport Commands:
 				Template: TWO_COLUMN
 				Types: Viewport
@@ -25,6 +25,12 @@ Background@SETTINGS_PANEL:
 			Music Commands:
 				Template: TWO_COLUMN
 				Types: Music
+			Menu Commands:
+				Template: TWO_COLUMN
+				Types: Menu
+			Global Commands:
+				Template: TWO_COLUMN
+				Types: Global
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM -  HEIGHT) / 2
 	Width: 600
@@ -63,30 +69,35 @@ Background@SETTINGS_PANEL:
 					Height: 25
 					Text: Display
 					Font: Bold
+					Key: Menu01
 				Button@AUDIO_TAB:
 					X: 70 + WIDTH
 					Width: 90
 					Height: 25
 					Text: Audio
 					Font: Bold
+					Key: Menu02
 				Button@INPUT_TAB:
 					X: 70 + 2 * WIDTH
 					Width: 90
 					Height: 25
 					Text: Input
 					Font: Bold
+					Key: Menu03
 				Button@HOTKEYS_TAB:
 					X: 70 + 3 * WIDTH
 					Width: 90
 					Height: 25
 					Text: Hotkeys
 					Font: Bold
+					Key: Menu04
 				Button@ADVANCED_TAB:
 					X: 70 + 4 * WIDTH
 					Width: 90
 					Height: 25
 					Text: Advanced
 					Font: Bold
+					Key: Menu05
 		Container@DISPLAY_PANEL:
 			X: 5
 			Y: 50

--- a/mods/common/hotkeys/game.yaml
+++ b/mods/common/hotkeys/game.yaml
@@ -48,7 +48,7 @@ CycleStatusBars: COMMA
 
 ToggleMute: M
 	Description: Toggle audio mute
-	Types: World, Menu, Player, Spectator
+	Types: Global, Player, Spectator
 
 TogglePlayerStanceColor: COMMA Ctrl
 	Description: Toggle player stance colors
@@ -56,7 +56,7 @@ TogglePlayerStanceColor: COMMA Ctrl
 
 TakeScreenshot: P Ctrl
 	Description: Take screenshot
-	Types: World, Menu, Player, Spectator
+	Types: Global, Player, Spectator
 
 AttackMove: A
 	Description: Attack Move

--- a/mods/common/hotkeys/menu.yaml
+++ b/mods/common/hotkeys/menu.yaml
@@ -1,0 +1,47 @@
+Menu01: F1
+	Description: Menu Button 01
+	Types: Menu
+
+Menu02: F2
+	Description: Menu Button 02
+	Types: Menu
+
+Menu03: F3
+	Description: Menu Button 03
+	Types: Menu
+
+Menu04: F4
+	Description: Menu Button 04
+	Types: Menu
+
+Menu05: F5
+	Description: Menu Button 05
+	Types: Menu
+
+Menu06: F6
+	Description: Menu Button 06
+	Types: Menu
+
+Menu07: F7
+	Description: Menu Button 07
+	Types: Menu
+
+Menu08: F8
+	Description: Menu Button 08
+	Types: Menu
+
+Menu09: F9
+	Description: Menu Button 09
+	Types: Menu
+
+Menu10: F10
+	Description: Menu Button 10
+	Types: Menu
+
+Menu11: F11
+	Description: Menu Button 11
+	Types: Menu
+
+Menu12: F12
+	Description: Menu Button 12
+	Types: Menu

--- a/mods/d2k/chrome/mainmenu.yaml
+++ b/mods/d2k/chrome/mainmenu.yaml
@@ -40,6 +40,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Singleplayer
 							Font: Bold
+							Key: Menu01
 						Button@MULTIPLAYER_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 100
@@ -47,6 +48,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Multiplayer
 							Font: Bold
+							Key: Menu02
 						Button@SETTINGS_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 140
@@ -54,6 +56,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Settings
 							Font: Bold
+							Key: Menu03
 						Button@EXTRAS_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 180
@@ -61,6 +64,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Extras
 							Font: Bold
+							Key: Menu04
 						Button@CONTENT_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 220
@@ -68,6 +72,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Manage Content
 							Font: Bold
+							Key: Menu05
 						Button@QUIT_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 260
@@ -94,6 +99,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Skirmish
 							Font: Bold
+							Key: Menu01
 						Button@MISSIONS_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 100
@@ -101,6 +107,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Missions
 							Font: Bold
+							Key: Menu02
 						Button@LOAD_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 140
@@ -108,6 +115,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Load
 							Font: Bold
+							Key: Menu03
 						Button@BACK_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Key: escape
@@ -135,6 +143,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Replays
 							Font: Bold
+							Key: Menu01
 						Button@MUSIC_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 100
@@ -142,6 +151,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Music
 							Font: Bold
+							Key: Menu02
 						Button@MAP_EDITOR_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 140
@@ -149,6 +159,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Map Editor
 							Font: Bold
+							Key: Menu03
 						Button@ASSETBROWSER_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 180
@@ -156,6 +167,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Asset Browser
 							Font: Bold
+							Key: Menu04
 						Button@CREDITS_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 220
@@ -163,6 +175,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Credits
 							Font: Bold
+							Key: Menu05
 						Button@BACK_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Key: escape
@@ -190,6 +203,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: New Map
 							Font: Bold
+							Key: Menu01
 						Button@LOAD_MAP_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 100
@@ -197,6 +211,7 @@ Container@MAINMENU:
 							Height: 30
 							Text: Load Map
 							Font: Bold
+							Key: Menu02
 						Button@BACK_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Key: escape

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -135,6 +135,7 @@ Hotkeys:
 	common|hotkeys/production-common.yaml
 	common|hotkeys/supportpowers.yaml
 	common|hotkeys/viewport.yaml
+	common|hotkeys/menu.yaml
 	d2k|hotkeys.yaml
 
 LoadScreen: LogoStripeLoadScreen

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -151,6 +151,7 @@ Hotkeys:
 	common|hotkeys/production-common.yaml
 	common|hotkeys/supportpowers.yaml
 	common|hotkeys/viewport.yaml
+	common|hotkeys/menu.yaml
 	ra|hotkeys.yaml
 
 LoadScreen: LogoStripeLoadScreen

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -193,6 +193,7 @@ Hotkeys:
 	common|hotkeys/production-common.yaml
 	common|hotkeys/supportpowers.yaml
 	common|hotkeys/viewport.yaml
+	common|hotkeys/menu.yaml
 	ts|hotkeys.yaml
 
 LoadScreen: LogoStripeLoadScreen


### PR DESCRIPTION
This PR:
- Implements hotkeys for menu buttons (main menu, ingame menu and settings tabs)
- Defines 12 default bindings (F1 - F12) and adds them to a new group "Menu commands"
- Moves screenshot and mute hotkeys to a new group "Global commands"

Related issue: #15347 