### PR TITLE
OpenRa trees edition

### DIFF
--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -33,6 +33,8 @@ namespace OpenRA
 
 	public enum WinState { Undefined, Won, Lost }
 
+	public class PlayerBitMask { }
+
 	public class Player : IScriptBindable, IScriptNotifyBind, ILuaTableBinding, ILuaEqualityBinding, ILuaToStringBinding
 	{
 		struct StanceColors
@@ -70,6 +72,12 @@ namespace OpenRA
 
 		readonly bool inMissionMap;
 		readonly IUnlocksRenderPlayer[] unlockRenderPlayer;
+
+		// Each player is identified with a unique bit in the set
+		// Cache masks for the player's index and ally/enemy player indices for performance.
+		public LongBitSet<PlayerBitMask> PlayerMask;
+		public LongBitSet<PlayerBitMask> AllyMask = default(LongBitSet<PlayerBitMask>);
+		public LongBitSet<PlayerBitMask> EnemyMask = default(LongBitSet<PlayerBitMask>);
 
 		public bool UnlockedRenderPlayer
 		{
@@ -152,6 +160,9 @@ namespace OpenRA
 				Faction = ChooseFaction(world, pr.Faction, false);
 				DisplayFaction = ChooseDisplayFaction(world, pr.Faction);
 			}
+
+			if (!Spectating)
+				PlayerMask = new LongBitSet<PlayerBitMask>(InternalName);
 
 			var playerActorType = world.Type == WorldType.Editor ? "EditorPlayer" : "Player";
 			PlayerActor = world.CreateActor(playerActorType, new TypeDictionary { new OwnerInit(this) });

--- a/OpenRA.Game/Primitives/LongBitSet.cs
+++ b/OpenRA.Game/Primitives/LongBitSet.cs
@@ -1,0 +1,194 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace OpenRA.Primitives
+{
+	static class LongBitSetAllocator<T> where T : class
+	{
+		static readonly Cache<string, long> Bits = new Cache<string, long>(Allocate);
+		static long nextBits = 1;
+
+		static long Allocate(string value)
+		{
+			lock (Bits)
+			{
+				var bits = nextBits;
+				nextBits <<= 1;
+
+				if (nextBits == 0)
+					throw new OverflowException("Trying to allocate bit index outside of index 64.");
+
+				return bits;
+			}
+		}
+
+		public static long GetBits(string[] values)
+		{
+			long bits = 0;
+			lock (Bits)
+				foreach (var value in values)
+					bits |= Bits[value];
+
+			return bits;
+		}
+
+		public static long GetBitsNoAlloc(string[] values)
+		{
+			// Map strings to existing bits; do not allocate missing values new bits
+			long bits = 0;
+
+			lock (Bits)
+			{
+				foreach (var value in values)
+				{
+					long valueBit;
+					if (Bits.TryGetValue(value, out valueBit))
+						bits |= valueBit;
+				}
+			}
+
+			return bits;
+		}
+
+		public static IEnumerable<string> GetStrings(long bits)
+		{
+			var values = new List<string>();
+			lock (Bits)
+				foreach (var kvp in Bits)
+					if ((kvp.Value & bits) != 0)
+						values.Add(kvp.Key);
+
+			return values;
+		}
+
+		public static bool BitsContainString(long bits, string value)
+		{
+			long valueBit;
+			lock (Bits)
+				if (!Bits.TryGetValue(value, out valueBit))
+					return false;
+			return (bits & valueBit) != 0;
+		}
+
+		public static void Reset()
+		{
+			lock (Bits)
+			{
+				Bits.Clear();
+				nextBits = 1;
+			}
+		}
+	}
+
+	// Opitmized BitSet to be used only when guaranteed to be no more than 64 values.
+	public struct LongBitSet<T> : IEnumerable<string>, IEquatable<LongBitSet<T>> where T : class
+	{
+		readonly long bits;
+
+		public LongBitSet(params string[] values)
+			: this(LongBitSetAllocator<T>.GetBits(values)) { }
+
+		LongBitSet(long bits) { this.bits = bits; }
+
+		public static LongBitSet<T> FromStringsNoAlloc(string[] values)
+		{
+			return new LongBitSet<T>(LongBitSetAllocator<T>.GetBitsNoAlloc(values)) { };
+		}
+
+		public static void Reset()
+		{
+			LongBitSetAllocator<T>.Reset();
+		}
+
+		public override string ToString()
+		{
+			return BitSetAllocator<T>.GetStrings(bits).JoinWith(",");
+		}
+
+		public static bool operator ==(LongBitSet<T> me, LongBitSet<T> other) { return me.bits == other.bits; }
+		public static bool operator !=(LongBitSet<T> me, LongBitSet<T> other) { return !(me == other); }
+
+		public bool Equals(LongBitSet<T> other) { return other == this; }
+		public override bool Equals(object obj) { return obj is LongBitSet<T> && Equals((LongBitSet<T>)obj); }
+		public override int GetHashCode() { return bits.GetHashCode(); }
+
+		public bool IsEmpty { get { return bits == 0; } }
+
+		public bool IsProperSubsetOf(LongBitSet<T> other)
+		{
+			return IsSubsetOf(other) && !SetEquals(other);
+		}
+
+		public bool IsProperSupersetOf(LongBitSet<T> other)
+		{
+			return IsSupersetOf(other) && !SetEquals(other);
+		}
+
+		public bool IsSubsetOf(LongBitSet<T> other)
+		{
+			return (bits | other.bits) == other.bits;
+		}
+
+		public bool IsSupersetOf(LongBitSet<T> other)
+		{
+			return (bits | other.bits) == bits;
+		}
+
+		public bool Overlaps(LongBitSet<T> other)
+		{
+			return (bits & other.bits) != 0;
+		}
+
+		public bool SetEquals(LongBitSet<T> other)
+		{
+			return bits == other.bits;
+		}
+
+		public bool Contains(string value)
+		{
+			return BitSetAllocator<T>.BitsContainString(bits, value);
+		}
+
+		public IEnumerator<string> GetEnumerator()
+		{
+			return BitSetAllocator<T>.GetStrings(bits).GetEnumerator();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return GetEnumerator();
+		}
+
+		public LongBitSet<T> Except(LongBitSet<T> other)
+		{
+			return new LongBitSet<T>(bits & ~other.bits);
+		}
+
+		public LongBitSet<T> Intersect(LongBitSet<T> other)
+		{
+			return new LongBitSet<T>(bits & other.bits);
+		}
+
+		public LongBitSet<T> SymmetricExcept(LongBitSet<T> other)
+		{
+			return new LongBitSet<T>(bits ^ other.bits);
+		}
+
+		public LongBitSet<T> Union(LongBitSet<T> other)
+		{
+			return new LongBitSet<T>(bits | other.bits);
+		}
+	}
+}

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -259,6 +259,8 @@ namespace OpenRA.Traits
 
 		WDist LargestActorRadius { get; }
 		WDist LargestBlockingActorRadius { get; }
+
+		event Action<IEnumerable<CPos>> CellsUpdated;
 	}
 
 	[RequireExplicitImplementation]

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -43,6 +43,7 @@ namespace OpenRA
 		public readonly MersenneTwister SharedRandom;
 		public readonly MersenneTwister LocalRandom;
 		public readonly IModelCache ModelCache;
+		public LongBitSet<PlayerBitMask> AllPlayerMask = default(LongBitSet<PlayerBitMask>);
 
 		public Player[] Players = new Player[0];
 
@@ -196,15 +197,27 @@ namespace OpenRA
 			ScreenMap = WorldActor.Trait<ScreenMap>();
 			Selection = WorldActor.Trait<ISelection>();
 
+			// Reset mask
+			LongBitSet<PlayerBitMask>.Reset();
+
 			// Add players
 			foreach (var cmp in WorldActor.TraitsImplementing<ICreatePlayers>())
 				cmp.CreatePlayers(this);
 
 			// Set defaults for any unset stances
 			foreach (var p in Players)
+			{
+				if (!p.Spectating)
+					AllPlayerMask = AllPlayerMask.Union(p.PlayerMask);
+
 				foreach (var q in Players)
+				{
+					SetUpPlayerMask(p, q);
+
 					if (!p.Stances.ContainsKey(q))
 						p.Stances[q] = Stance.Neutral;
+				}
+			}
 
 			Game.Sound.SoundVolumeModifier = 1.0f;
 
@@ -218,6 +231,25 @@ namespace OpenRA
 			};
 
 			RulesContainTemporaryBlocker = map.Rules.Actors.Any(a => a.Value.HasTraitInfo<ITemporaryBlockerInfo>());
+		}
+
+		void SetUpPlayerMask(Player p, Player q)
+		{
+			if (q.Spectating)
+				return;
+
+			var bitSet = q.PlayerMask;
+
+			switch (p.Stances[q])
+			{
+				case Stance.Enemy:
+				case Stance.Neutral:
+					p.EnemyMask = p.EnemyMask.Union(bitSet);
+					break;
+				case Stance.Ally:
+					p.AllyMask = p.AllyMask.Union(bitSet);
+					break;
+			}
 		}
 
 		public void AddToMaps(Actor self, IOccupySpace ios)

--- a/OpenRA.Mods.Cnc/Traits/Mine.cs
+++ b/OpenRA.Mods.Cnc/Traits/Mine.cs
@@ -58,6 +58,13 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			return info.CrushClasses.Overlaps(crushClasses);
 		}
+
+		bool ICrushable.TryCalculatePlayerBlocking(Actor self, BitSet<CrushClass> crushClasses, out LongBitSet<PlayerBitMask> blocking)
+		{
+			// Fall back to the slow path
+			blocking = default(LongBitSet<PlayerBitMask>);
+			return false;
+		}
 	}
 
 	[Desc("Tag trait for stuff that should not trigger mines.")]

--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -188,7 +188,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Find any harvestable resources:
 			List<CPos> path;
-			using (var search = PathSearch.Search(self.World, locomotorInfo, self, true, loc =>
+			using (var search = PathSearch.Search(self.World, mobile.Locomotor, self, true, loc =>
 					domainIndex.IsPassable(self.Location, loc, locomotorInfo) && harv.CanHarvestCell(self, loc) && claimLayer.CanClaimCell(self, loc))
 				.WithCustomCost(loc =>
 				{

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				List<CPos> path;
 				using (var search =
-					PathSearch.FromPoint(self.World, mobile.Info.LocomotorInfo, self, mobile.ToCell, destination, false)
+					PathSearch.FromPoint(self.World, mobile.Locomotor, self, mobile.ToCell, destination, false)
 					.WithoutLaneBias())
 					path = self.World.WorldActor.Trait<IPathFinder>().FindPath(search);
 				return path;

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -150,8 +150,8 @@ namespace OpenRA.Mods.Common.Activities
 			if (!searchCells.Any())
 				return NoPath;
 
-			using (var fromSrc = PathSearch.FromPoints(self.World, Mobile.Info.LocomotorInfo, self, searchCells, loc, true))
-			using (var fromDest = PathSearch.FromPoint(self.World, Mobile.Info.LocomotorInfo, self, loc, lastVisibleTargetLocation, true).Reverse())
+			using (var fromSrc = PathSearch.FromPoints(self.World, Mobile.Locomotor, self, searchCells, loc, true))
+			using (var fromDest = PathSearch.FromPoint(self.World, Mobile.Locomotor, self, loc, lastVisibleTargetLocation, true).Reverse())
 				return pathFinder.FindBidiPath(fromSrc, fromDest);
 		}
 

--- a/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
@@ -172,7 +172,8 @@ namespace OpenRA.Mods.Common.Pathfinder
 
 		int GetCostToNode(CPos destNode, CVec direction)
 		{
-			var movementCost = locomotorInfo.MovementCostToEnterCell(worldMovementInfo, Actor, destNode, IgnoreActor, checkConditions);
+			var movementCost = locomotor.MovementCostToEnterCell(Actor, destNode, IgnoreActor, checkConditions);
+
 			if (movementCost != int.MaxValue && !(CustomBlock != null && CustomBlock(destNode)))
 				return CalculateCellCost(destNode, direction, movementCost);
 

--- a/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		public Actor IgnoreActor { get; set; }
 
 		readonly CellConditions checkConditions;
-		readonly LocomotorInfo locomotorInfo;
+		readonly Locomotor locomotor;
 		readonly LocomotorInfo.WorldMovementInfo worldMovementInfo;
 		readonly CellInfoLayerPool.PooledCellInfoLayer pooledLayer;
 		readonly bool checkTerrainHeight;
@@ -92,11 +92,12 @@ namespace OpenRA.Mods.Common.Pathfinder
 		readonly Dictionary<byte, Pair<ICustomMovementLayer, CellLayer<CellInfo>>> customLayerInfo =
 			new Dictionary<byte, Pair<ICustomMovementLayer, CellLayer<CellInfo>>>();
 
-		public PathGraph(CellInfoLayerPool layerPool, LocomotorInfo li, Actor actor, World world, bool checkForBlocked)
+		public PathGraph(CellInfoLayerPool layerPool, Locomotor locomotor, Actor actor, World world, bool checkForBlocked)
 		{
 			pooledLayer = layerPool.Get();
 			groundInfo = pooledLayer.GetLayer();
-			locomotorInfo = li;
+			var locomotorInfo = locomotor.Info;
+			this.locomotor = locomotor;
 			var layers = world.GetCustomMovementLayers().Values
 				.Where(cml => cml.EnabledForActor(actor.Info, locomotorInfo));
 
@@ -153,7 +154,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 				foreach (var cli in customLayerInfo.Values)
 				{
 					var layerPosition = new CPos(position.X, position.Y, cli.First.Index);
-					var entryCost = cli.First.EntryMovementCost(Actor.Info, locomotorInfo, layerPosition);
+					var entryCost = cli.First.EntryMovementCost(Actor.Info, locomotor.Info, layerPosition);
 					if (entryCost != Constants.InvalidNode)
 						validNeighbors.Add(new GraphConnection(layerPosition, entryCost));
 				}
@@ -161,7 +162,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 			else
 			{
 				var layerPosition = new CPos(position.X, position.Y, 0);
-				var exitCost = customLayerInfo[position.Layer].First.ExitMovementCost(Actor.Info, locomotorInfo, layerPosition);
+				var exitCost = customLayerInfo[position.Layer].First.ExitMovementCost(Actor.Info, locomotor.Info, layerPosition);
 				if (exitCost != Constants.InvalidNode)
 					validNeighbors.Add(new GraphConnection(layerPosition, exitCost));
 			}

--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -45,18 +45,18 @@ namespace OpenRA.Mods.Common.Pathfinder
 			considered = new LinkedList<Pair<CPos, int>>();
 		}
 
-		public static IPathSearch Search(World world, LocomotorInfo li, Actor self, bool checkForBlocked, Func<CPos, bool> goalCondition)
+		public static IPathSearch Search(World world, Locomotor locomotor, Actor self, bool checkForBlocked, Func<CPos, bool> goalCondition)
 		{
-			var graph = new PathGraph(LayerPoolForWorld(world), li, self, world, checkForBlocked);
+			var graph = new PathGraph(LayerPoolForWorld(world), locomotor, self, world, checkForBlocked);
 			var search = new PathSearch(graph);
 			search.isGoal = goalCondition;
 			search.heuristic = loc => 0;
 			return search;
 		}
 
-		public static IPathSearch FromPoint(World world, LocomotorInfo li, Actor self, CPos from, CPos target, bool checkForBlocked)
+		public static IPathSearch FromPoint(World world, Locomotor locomotor, Actor self, CPos @from, CPos target, bool checkForBlocked)
 		{
-			var graph = new PathGraph(LayerPoolForWorld(world), li, self, world, checkForBlocked);
+			var graph = new PathGraph(LayerPoolForWorld(world), locomotor, self, world, checkForBlocked);
 			var search = new PathSearch(graph)
 			{
 				heuristic = DefaultEstimator(target)
@@ -74,9 +74,9 @@ namespace OpenRA.Mods.Common.Pathfinder
 			return search;
 		}
 
-		public static IPathSearch FromPoints(World world, LocomotorInfo li, Actor self, IEnumerable<CPos> froms, CPos target, bool checkForBlocked)
+		public static IPathSearch FromPoints(World world, Locomotor locomotor, Actor self, IEnumerable<CPos> froms, CPos target, bool checkForBlocked)
 		{
-			var graph = new PathGraph(LayerPoolForWorld(world), li, self, world, checkForBlocked);
+			var graph = new PathGraph(LayerPoolForWorld(world), locomotor, self, world, checkForBlocked);
 			var search = new PathSearch(graph)
 			{
 				heuristic = DefaultEstimator(target)

--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -44,14 +44,15 @@ namespace OpenRA.Mods.Common.Traits
 			public readonly Actor Actor;
 			public readonly Harvester Harvester;
 			public readonly Parachutable Parachutable;
-			public readonly LocomotorInfo LocomotorInfo;
+			public readonly Locomotor Locomotor;
 
 			public HarvesterTraitWrapper(Actor actor)
 			{
 				Actor = actor;
 				Harvester = actor.Trait<Harvester>();
 				Parachutable = actor.TraitOrDefault<Parachutable>();
-				LocomotorInfo = actor.Info.TraitInfo<MobileInfo>().LocomotorInfo;
+				var mobile = actor.Trait<Mobile>();
+				Locomotor = mobile.Locomotor;
 			}
 		}
 
@@ -141,12 +142,12 @@ namespace OpenRA.Mods.Common.Traits
 		Target FindNextResource(Actor actor, HarvesterTraitWrapper harv)
 		{
 			Func<CPos, bool> isValidResource = cell =>
-				domainIndex.IsPassable(actor.Location, cell, harv.LocomotorInfo) &&
+				domainIndex.IsPassable(actor.Location, cell, harv.Locomotor.Info) &&
 				harv.Harvester.CanHarvestCell(actor, cell) &&
 				claimLayer.CanClaimCell(actor, cell);
 
 			var path = pathfinder.FindPath(
-				PathSearch.Search(world, harv.LocomotorInfo, actor, true, isValidResource)
+				PathSearch.Search(world, harv.Locomotor, actor, true, isValidResource)
 					.WithCustomCost(loc => world.FindActorsInCircle(world.Map.CenterOfCell(loc), Info.HarvesterEnemyAvoidanceRadius)
 						.Where(u => !u.IsDead && actor.Owner.Stances[u.Owner] == Stance.Enemy)
 						.Sum(u => Math.Max(WDist.Zero.Length, Info.HarvesterEnemyAvoidanceRadius.Length - (world.Map.CenterOfCell(loc) - u.CenterPosition).Length)))

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
@@ -57,6 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly Actor self;
 		Transforms[] transforms;
+		Locomotor locomotor;
 
 		public TransformsIntoMobile(ActorInitializer init, TransformsIntoMobileInfo info)
 			: base(info)
@@ -67,6 +68,8 @@ namespace OpenRA.Mods.Common.Traits
 		protected override void Created(Actor self)
 		{
 			transforms = self.TraitsImplementing<Transforms>().ToArray();
+			locomotor = self.World.WorldActor.TraitsImplementing<Locomotor>()
+				.Single(l => l.Info.Name == Info.Locomotor);
 			base.Created(self);
 		}
 
@@ -175,21 +178,20 @@ namespace OpenRA.Mods.Common.Traits
 				cursor = self.World.Map.Contains(location) ?
 					(self.World.Map.GetTerrainInfo(location).CustomCursor ?? mobile.Info.Cursor) : mobile.Info.BlockedCursor;
 
-				var locomotor = mobile.Info.LocomotorInfo;
 				if (!(self.CurrentActivity is Transform || mobile.transforms.Any(t => !t.IsTraitDisabled && !t.IsTraitPaused))
-					|| (!explored && !locomotor.MoveIntoShroud)
-					|| (explored && !CanEnterCell(self.World, self, location)))
+					|| (!explored && !mobile.locomotor.Info.MoveIntoShroud)
+					|| (explored && !CanEnterCell(self, location)))
 					cursor = mobile.Info.BlockedCursor;
 
 				return true;
 			}
 
-			bool CanEnterCell(World world, Actor self, CPos cell)
+			bool CanEnterCell(Actor self, CPos cell)
 			{
-				if (mobile.Info.LocomotorInfo.MovementCostForCell(world, cell) == int.MaxValue)
+				if (mobile.locomotor.MovementCostForCell(cell) == int.MaxValue)
 					return false;
 
-				return mobile.Info.LocomotorInfo.CanMoveFreelyInto(world, self, cell, null, CellConditions.BlockedByMovers);
+				return mobile.locomotor.CanMoveFreelyInto(self, cell, null, CellConditions.BlockedByMovers);
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -225,6 +225,16 @@ namespace OpenRA.Mods.Common.Traits
 			return self.IsAtGroundLevel() && crushClasses.Contains(info.CrushClass);
 		}
 
+		bool ICrushable.TryCalculatePlayerBlocking(Actor self, BitSet<CrushClass> crushClasses, out LongBitSet<PlayerBitMask> blocking)
+		{
+			if (self.IsAtGroundLevel() && crushClasses.Contains(info.CrushClass))
+				blocking = default(LongBitSet<PlayerBitMask>);
+			else
+				blocking = self.World.AllPlayerMask;
+
+			return true;
+		}
+
 		void INotifyAddedToWorld.AddedToWorld(Actor self)
 		{
 			self.World.AddToMaps(self, this);

--- a/OpenRA.Mods.Common/Traits/Crushable.cs
+++ b/OpenRA.Mods.Common/Traits/Crushable.cs
@@ -79,5 +79,15 @@ namespace OpenRA.Mods.Common.Traits
 
 			return Info.CrushClasses.Overlaps(crushClasses);
 		}
+
+		bool ICrushable.TryCalculatePlayerBlocking(Actor self, BitSet<CrushClass> crushClasses, out LongBitSet<PlayerBitMask> blocking)
+		{
+			if (IsTraitDisabled || !self.IsAtGroundLevel() || !Info.CrushClasses.Overlaps(crushClasses))
+				blocking = self.World.AllPlayerMask;
+			else
+				blocking = Info.CrushedByFriendlies ? default(LongBitSet<PlayerBitMask>) : self.Owner.AllyMask;
+
+			return true;
+		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -201,8 +201,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Start a search from each refinery's delivery location:
 			List<CPos> path;
-			var li = self.Info.TraitInfo<MobileInfo>().LocomotorInfo;
-			using (var search = PathSearch.FromPoints(self.World, li, self, refs.Values.Select(r => r.Location), self.Location, false)
+
+			using (var search = PathSearch.FromPoints(self.World, mobile.Locomotor, self, refs.Values.Select(r => r.Location), self.Location, false)
 				.WithCustomCost(loc =>
 				{
 					if (!refs.ContainsKey(loc))

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -185,6 +185,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Sync]
 		public int PathHash;	// written by Move.EvalPath, to temporarily debug this crap.
 
+		public Locomotor Locomotor { get; private set; }
+
 		#region IOccupySpace
 
 		[Sync]
@@ -235,6 +237,8 @@ namespace OpenRA.Mods.Common.Traits
 			notifyMoving = self.TraitsImplementing<INotifyMoving>().ToArray();
 			notifyFinishedMoving = self.TraitsImplementing<INotifyFinishedMoving>().ToArray();
 			moveWrappers = self.TraitsImplementing<IWrapMove>().ToArray();
+			Locomotor = self.World.WorldActor.TraitsImplementing<Locomotor>()
+				.Single(l => l.Info.Name == Info.Locomotor);
 
 			base.Created(self);
 		}
@@ -702,7 +706,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var pathFinder = self.World.WorldActor.Trait<IPathFinder>();
 			List<CPos> path;
-			using (var search = PathSearch.Search(self.World, Info.LocomotorInfo, self, true,
+			using (var search = PathSearch.Search(self.World, Locomotor, self, true,
 					loc => loc.Layer == 0 && CanEnterCell(loc))
 				.FromPoint(self.Location))
 				path = pathFinder.FindPath(search);

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -76,13 +76,21 @@ namespace OpenRA.Mods.Common.Traits
 
 		public int GetInitialFacing() { return InitialFacing; }
 
+		// initialized and used by CanEnterCell
+		Locomotor locomotor;
+
 		public bool CanEnterCell(World world, Actor self, CPos cell, Actor ignoreActor = null, bool checkTransientActors = true)
 		{
-			if (LocomotorInfo.MovementCostForCell(world, cell) == int.MaxValue)
+			// PERF: Avoid repeated trait queries on the hot path
+			if (locomotor == null)
+				locomotor = world.WorldActor.TraitsImplementing<Locomotor>()
+				   .SingleOrDefault(l => l.Info.Name == Locomotor);
+
+			if (locomotor.MovementCostForCell(cell) == int.MaxValue)
 				return false;
 
 			var check = checkTransientActors ? CellConditions.All : CellConditions.BlockedByMovers;
-			return LocomotorInfo.CanMoveFreelyInto(world, self, cell, ignoreActor, check);
+			return locomotor.CanMoveFreelyInto(self, cell, ignoreActor, check);
 		}
 
 		public IReadOnlyDictionary<CPos, SubCell> OccupiedCells(ActorInfo info, CPos location, SubCell subCell = SubCell.Any)
@@ -426,12 +434,12 @@ namespace OpenRA.Mods.Common.Traits
 		public SubCell GetAvailableSubCell(CPos a, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, bool checkTransientActors = true)
 		{
 			var cellConditions = checkTransientActors ? CellConditions.All : CellConditions.None;
-			return Info.LocomotorInfo.GetAvailableSubCell(self.World, self, a, preferredSubCell, ignoreActor, cellConditions);
+			return Locomotor.GetAvailableSubCell(self, a, preferredSubCell, ignoreActor, cellConditions);
 		}
 
 		public bool CanExistInCell(CPos cell)
 		{
-			return Info.LocomotorInfo.MovementCostForCell(self.World, cell) != int.MaxValue;
+			return Locomotor.MovementCostForCell(cell) != int.MaxValue;
 		}
 
 		public bool CanEnterCell(CPos cell, Actor ignoreActor = null, bool checkTransientActors = true)
@@ -665,11 +673,6 @@ namespace OpenRA.Mods.Common.Traits
 			return target;
 		}
 
-		public bool CanMoveFreelyInto(CPos cell, Actor ignoreActor = null, bool checkTransientActors = true)
-		{
-			return Info.LocomotorInfo.CanMoveFreelyInto(self.World, self, cell, ignoreActor, checkTransientActors ? CellConditions.All : CellConditions.BlockedByMovers);
-		}
-
 		public void EnteringCell(Actor self)
 		{
 			// Only make actor crush if it is on the ground
@@ -872,7 +875,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (mobile.IsTraitPaused
 					|| (!explored && !locomotorInfo.MoveIntoShroud)
-					|| (explored && locomotorInfo.MovementCostForCell(self.World, location) == int.MaxValue))
+					|| (explored && mobile.Locomotor.MovementCostForCell(location) == int.MaxValue))
 					cursor = mobile.Info.BlockedCursor;
 
 				return true;

--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -173,7 +173,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly CellLayer<InfluenceNode> influence;
 		readonly Dictionary<int, CellLayer<InfluenceNode>> customInfluence = new Dictionary<int, CellLayer<InfluenceNode>>();
 		public readonly Dictionary<int, ICustomMovementLayer> CustomMovementLayers = new Dictionary<int, ICustomMovementLayer>();
-
+		public event Action<IEnumerable<CPos>> CellsUpdated;
 		readonly Bin[] bins;
 		readonly int rows, cols;
 
@@ -182,6 +182,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly HashSet<Actor> addActorPosition = new HashSet<Actor>();
 		readonly HashSet<Actor> removeActorPosition = new HashSet<Actor>();
 		readonly Predicate<Actor> actorShouldBeRemoved;
+		readonly HashSet<CPos> updatedCells = new HashSet<CPos>();
 
 		public WDist LargestActorRadius { get; private set; }
 		public WDist LargestBlockingActorRadius { get; private set; }
@@ -370,6 +371,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (cellTriggerInfluence.TryGetValue(c.First, out triggers))
 					foreach (var t in triggers)
 						t.Dirty = true;
+
+				updatedCells.Add(c.First);
 			}
 		}
 
@@ -390,6 +393,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (cellTriggerInfluence.TryGetValue(c.First, out triggers))
 					foreach (var t in triggers)
 						t.Dirty = true;
+
+				updatedCells.Add(c.First);
 			}
 		}
 
@@ -437,6 +442,12 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var t in proximityTriggers)
 				t.Value.Tick(this);
+
+			self.World.AddFrameEndTask(s =>
+			{
+				if (CellsUpdated != null)
+					CellsUpdated(updatedCells);
+			});
 		}
 
 		public int AddCellTrigger(CPos[] cells, Action<Actor> onEntry, Action<Actor> onExit)
@@ -515,7 +526,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void AddPosition(Actor a, IOccupySpace ios)
 		{
-			UpdatePosition(a, ios);
+			addActorPosition.Add(a);
 		}
 
 		public void RemovePosition(Actor a, IOccupySpace ios)
@@ -526,7 +537,7 @@ namespace OpenRA.Mods.Common.Traits
 		public void UpdatePosition(Actor a, IOccupySpace ios)
 		{
 			RemovePosition(a, ios);
-			addActorPosition.Add(a);
+			AddPosition(a, ios);
 		}
 
 		int CellCoordToBinIndex(int cell)

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -79,9 +79,9 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					var nodesDict = t.Value.ToDictionary();
 					var cost = nodesDict.ContainsKey("PathingCost")
-						? FieldLoader.GetValue<int>("cost", nodesDict["PathingCost"].Value)
+						? FieldLoader.GetValue<short>("cost", nodesDict["PathingCost"].Value)
 						: 10000 / speed;
-					ret.Add(t.Key, new TerrainInfo(speed, cost));
+					ret.Add(t.Key, new TerrainInfo(speed, (short)cost));
 				}
 			}
 
@@ -108,16 +108,16 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			public static readonly TerrainInfo Impassable = new TerrainInfo();
 
-			public readonly int Cost;
+			public readonly short Cost;
 			public readonly int Speed;
 
 			public TerrainInfo()
 			{
-				Cost = int.MaxValue;
+				Cost = short.MaxValue;
 				Speed = 0;
 			}
 
-			public TerrainInfo(int speed, int cost)
+			public TerrainInfo(int speed, short cost)
 			{
 				Speed = speed;
 				Cost = cost;
@@ -168,7 +168,7 @@ namespace OpenRA.Mods.Common.Traits
 		public int CalculateTilesetMovementClass(TileSet tileset)
 		{
 			// collect our ability to cross *all* terraintypes, in a bitvector
-			return TilesetTerrainInfo[tileset].Select(ti => ti.Cost < int.MaxValue).ToBits();
+			return TilesetTerrainInfo[tileset].Select(ti => ti.Cost < short.MaxValue).ToBits();
 		}
 
 		public uint GetMovementClass(TileSet tileset)

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -26,12 +27,33 @@ namespace OpenRA.Mods.Common.Traits
 		All = TransientActors | BlockedByMovers
 	}
 
-	public static class CellConditionsExts
+	[Flags]
+	public enum CellBlocking : byte
+	{
+		Empty = 0,
+		HasActor = 1,
+		FreeSubCell = 2,
+		Crushable = 4
+	}
+
+	public static class LocomoterExts
 	{
 		public static bool HasCellCondition(this CellConditions c, CellConditions cellCondition)
 		{
 			// PERF: Enum.HasFlag is slower and requires allocations.
 			return (c & cellCondition) == cellCondition;
+		}
+
+		public static bool HasCellBlocking(this CellBlocking c, CellBlocking cellBlocking)
+		{
+			// PERF: Enum.HasFlag is slower and requires allocations.
+			return (c & cellBlocking) == cellBlocking;
+		}
+
+		public static bool HasMovementType(this MovementType m, MovementType movementType)
+		{
+			// PERF: Enum.HasFlag is slower and requires allocations.
+			return (m & movementType) == movementType;
 		}
 	}
 
@@ -78,9 +100,9 @@ namespace OpenRA.Mods.Common.Traits
 				if (speed > 0)
 				{
 					var nodesDict = t.Value.ToDictionary();
-					var cost = nodesDict.ContainsKey("PathingCost")
+					var cost = (nodesDict.ContainsKey("PathingCost")
 						? FieldLoader.GetValue<short>("cost", nodesDict["PathingCost"].Value)
-						: 10000 / speed;
+						: 10000 / speed);
 					ret.Add(t.Key, new TerrainInfo(speed, (short)cost));
 				}
 			}
@@ -146,25 +168,6 @@ namespace OpenRA.Mods.Common.Traits
 			TilesetMovementClass = new Cache<TileSet, int>(CalculateTilesetMovementClass);
 		}
 
-		public int MovementCostForCell(World world, CPos cell)
-		{
-			return MovementCostForCell(world, TilesetTerrainInfo[world.Map.Rules.TileSet], cell);
-		}
-
-		int MovementCostForCell(World world, TerrainInfo[] terrainInfos, CPos cell)
-		{
-			if (!world.Map.Contains(cell))
-				return int.MaxValue;
-
-			var index = cell.Layer == 0 ? world.Map.GetTerrainIndex(cell) :
-				world.GetCustomMovementLayers()[cell.Layer].GetTerrainIndex(cell);
-
-			if (index == byte.MaxValue)
-				return int.MaxValue;
-
-			return terrainInfos[index].Cost;
-		}
-
 		public int CalculateTilesetMovementClass(TileSet tileset)
 		{
 			// collect our ability to cross *all* terraintypes, in a bitvector
@@ -190,79 +193,142 @@ namespace OpenRA.Mods.Common.Traits
 			return new WorldMovementInfo(world, this);
 		}
 
-		public int MovementCostToEnterCell(WorldMovementInfo worldMovementInfo, Actor self, CPos cell, Actor ignoreActor = null, CellConditions check = CellConditions.All)
+		public virtual bool DisableDomainPassabilityCheck { get { return false; } }
+
+		public virtual object Create(ActorInitializer init) { return new Locomotor(init.Self, this); }
+	}
+
+	public class Locomotor : IWorldLoaded
+	{
+		struct CellCache
 		{
-			var cost = MovementCostForCell(worldMovementInfo.World, worldMovementInfo.TerrainInfos, cell);
-			if (cost == int.MaxValue || !CanMoveFreelyInto(worldMovementInfo.World, self, cell, ignoreActor, check))
-				return int.MaxValue;
-			return cost;
+			public readonly CellBlocking CellBlocking;
+			public readonly short Cost;
+			public readonly LongBitSet<PlayerBitMask> Blocking;
+
+			public CellCache(short cost, LongBitSet<PlayerBitMask> blocking, CellBlocking cellBlocking)
+			{
+				Cost = cost;
+				Blocking = blocking;
+				CellBlocking = cellBlocking;
+			}
+
+			public CellCache WithCost(short cost)
+			{
+				return new CellCache(cost, Blocking, CellBlocking);
+			}
+
+			public CellCache WithBlocking(LongBitSet<PlayerBitMask> blocking, CellBlocking cellBlocking)
+			{
+				return new CellCache(Cost, blocking, cellBlocking);
+			}
 		}
 
-		public SubCell GetAvailableSubCell(
-			World world, Actor self, CPos cell, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, CellConditions check = CellConditions.All)
+		public readonly LocomotorInfo Info;
+		CellLayer<CellCache> pathabilityCache;
+		LongBitSet<PlayerBitMask> allPlayerMask = default(LongBitSet<PlayerBitMask>);
+
+		LocomotorInfo.TerrainInfo[] terrainInfos;
+		World world;
+		readonly HashSet<CPos> updatedTerrainCells = new HashSet<CPos>();
+
+		IActorMap actorMap;
+		bool sharesCell;
+
+		public Locomotor(Actor self, LocomotorInfo info)
 		{
-			if (MovementCostForCell(world, cell) == int.MaxValue)
+			Info = info;
+			sharesCell = info.SharesCell;
+		}
+
+		public int MovementCostForCell(CPos cell)
+		{
+			if (!world.Map.Contains(cell))
+				return int.MaxValue;
+
+			return pathabilityCache[cell].Cost;
+		}
+
+		public int MovementCostToEnterCell(Actor actor, CPos destNode, Actor ignoreActor, CellConditions check)
+		{
+			if (!world.Map.Contains(destNode))
+				return int.MaxValue;
+
+			var cellCache = pathabilityCache[destNode];
+
+			if (cellCache.Cost == short.MaxValue ||
+				!CanMoveFreelyInto(actor, ignoreActor, destNode, check, cellCache))
+				return int.MaxValue;
+
+			return cellCache.Cost;
+		}
+
+		// Determines whether the actor is blocked by other Actors
+		public bool CanMoveFreelyInto(Actor actor, CPos cell, Actor ignoreActor, CellConditions check)
+		{
+			return CanMoveFreelyInto(actor, ignoreActor, cell, check, pathabilityCache[cell]);
+		}
+
+		bool CanMoveFreelyInto(Actor actor, Actor ignoreActor, CPos cell, CellConditions check, CellCache cellCache)
+		{
+			var cellBlocking = cellCache.CellBlocking;
+			var blocking = cellCache.Blocking;
+
+			if (!check.HasCellCondition(CellConditions.TransientActors))
+				return true;
+
+			// If actor is null we're just checking what would happen theoretically.
+			// In such a scenario - we'll just assume any other actor in the cell will block us by default.
+			// If we have a real actor, we can then perform the extra checks that allow us to avoid being blocked.
+			if (actor == null)
+				return true;
+
+			// No actor in cell
+			if (cellBlocking == CellBlocking.Empty)
+				return true;
+
+			// We are blocked
+			if (ignoreActor == null && blocking.Overlaps(actor.Owner.PlayerMask))
+				return false;
+
+			if (cellBlocking.HasCellBlocking(CellBlocking.Crushable))
+				return true;
+
+			if (sharesCell && cellBlocking.HasCellBlocking(CellBlocking.FreeSubCell))
+				return true;
+
+			foreach (var otherActor in world.ActorMap.GetActorsAt(cell))
+				if (IsBlockedBy(actor, otherActor, ignoreActor, check))
+					return false;
+
+			return true;
+		}
+
+		public SubCell GetAvailableSubCell(Actor self, CPos cell, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, CellConditions check = CellConditions.All)
+		{
+			if (MovementCostForCell(cell) == int.MaxValue)
 				return SubCell.Invalid;
 
 			if (check.HasCellCondition(CellConditions.TransientActors))
 			{
 				Func<Actor, bool> checkTransient = otherActor => IsBlockedBy(self, otherActor, ignoreActor, check);
 
-				if (!SharesCell)
+				if (!sharesCell)
 					return world.ActorMap.AnyActorsAt(cell, SubCell.FullCell, checkTransient) ? SubCell.Invalid : SubCell.FullCell;
 
 				return world.ActorMap.FreeSubCell(cell, preferredSubCell, checkTransient);
 			}
 
-			if (!SharesCell)
+			if (!sharesCell)
 				return world.ActorMap.AnyActorsAt(cell, SubCell.FullCell) ? SubCell.Invalid : SubCell.FullCell;
 
 			return world.ActorMap.FreeSubCell(cell, preferredSubCell);
 		}
 
-		static bool IsMovingInMyDirection(Actor self, Actor other)
-		{
-			var otherMobile = other.TraitOrDefault<Mobile>();
-			if (otherMobile == null || !otherMobile.CurrentMovementTypes.HasFlag(MovementType.Horizontal))
-				return false;
-
-			var selfMobile = self.TraitOrDefault<Mobile>();
-			if (selfMobile == null)
-				return false;
-
-			// Moving in the same direction if the facing delta is between +/- 90 degrees
-			var delta = Util.NormalizeFacing(otherMobile.Facing - selfMobile.Facing);
-			return delta < 64 || delta > 192;
-		}
-
-		// Determines whether the actor is blocked by other Actors
-		public bool CanMoveFreelyInto(World world, Actor self, CPos cell, Actor ignoreActor, CellConditions check)
-		{
-			if (!check.HasCellCondition(CellConditions.TransientActors))
-				return true;
-
-			if (SharesCell && world.ActorMap.HasFreeSubCell(cell))
-				return true;
-
-			// PERF: Avoid LINQ.
-			foreach (var otherActor in world.ActorMap.GetActorsAt(cell))
-				if (IsBlockedBy(self, otherActor, ignoreActor, check))
-					return false;
-
-			return true;
-		}
-
 		bool IsBlockedBy(Actor self, Actor otherActor, Actor ignoreActor, CellConditions check)
 		{
-			// We are not blocked by the actor we are ignoring.
 			if (otherActor == ignoreActor)
 				return false;
-
-			// If self is null, we don't have a real actor - we're just checking what would happen theoretically.
-			// In such a scenario - we'll just assume any other actor in the cell will block us by default.
-			// If we have a real actor, we can then perform the extra checks that allow us to avoid being blocked.
-			if (self == null)
-				return true;
 
 			// If the check allows: we are not blocked by allied units moving in our direction.
 			if (!check.HasCellCondition(CellConditions.BlockedByMovers) &&
@@ -280,31 +346,134 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// If we cannot crush the other actor in our way, we are blocked.
-			if (Crushes.IsEmpty)
+			if (Info.Crushes.IsEmpty)
 				return true;
 
 			// If the other actor in our way cannot be crushed, we are blocked.
 			// PERF: Avoid LINQ.
 			var crushables = otherActor.TraitsImplementing<ICrushable>();
 			foreach (var crushable in crushables)
-				if (crushable.CrushableBy(otherActor, self, Crushes))
+				if (crushable.CrushableBy(otherActor, self, Info.Crushes))
 					return false;
 
 			return true;
 		}
 
-		public virtual bool DisableDomainPassabilityCheck { get { return false; } }
-
-		public virtual object Create(ActorInitializer init) { return new Locomotor(init.Self, this); }
-	}
-
-	public class Locomotor
-	{
-		public readonly LocomotorInfo Info;
-
-		public Locomotor(Actor self, LocomotorInfo info)
+		static bool IsMovingInMyDirection(Actor self, Actor other)
 		{
-			Info = info;
+			// PERF: Because we can be sure that OccupiesSpace is Mobile here we can save some performance by avoiding querying for the trait.
+			var otherMobile = other.OccupiesSpace as Mobile;
+			if (otherMobile == null || !otherMobile.CurrentMovementTypes.HasMovementType(MovementType.Horizontal))
+				return false;
+
+			// PERF: Same here.
+			var selfMobile = self.OccupiesSpace as Mobile;
+			if (selfMobile == null)
+				return false;
+
+			// Moving in the same direction if the facing delta is between +/- 90 degrees
+			var delta = Util.NormalizeFacing(otherMobile.Facing - selfMobile.Facing);
+			return delta < 64 || delta > 192;
+		}
+
+		public void WorldLoaded(World w, WorldRenderer wr)
+		{
+			world = w;
+			var map = w.Map;
+			actorMap = w.ActorMap;
+			actorMap.CellsUpdated += CellsUpdated;
+			pathabilityCache = new CellLayer<CellCache>(map);
+
+			terrainInfos = Info.TilesetTerrainInfo[map.Rules.TileSet];
+
+			allPlayerMask = world.AllPlayerMask;
+
+			foreach (var cell in map.AllCells)
+				UpdateCellCost(cell);
+
+			map.CustomTerrain.CellEntryChanged += MapCellEntryChanged;
+			map.Tiles.CellEntryChanged += MapCellEntryChanged;
+		}
+
+		void CellsUpdated(IEnumerable<CPos> cells)
+		{
+			foreach (var cell in cells)
+				UpdateCellBlocking(cell);
+
+			foreach (var cell in updatedTerrainCells)
+				UpdateCellCost(cell);
+
+			updatedTerrainCells.Clear();
+		}
+
+		void UpdateCellCost(CPos cell)
+		{
+			var index = cell.Layer == 0
+				? world.Map.GetTerrainIndex(cell)
+				: world.GetCustomMovementLayers()[cell.Layer].GetTerrainIndex(cell);
+
+			var cost = short.MaxValue;
+
+			if (index != byte.MaxValue)
+				cost = terrainInfos[index].Cost;
+
+			var current = pathabilityCache[cell];
+			pathabilityCache[cell] = current.WithCost(cost);
+		}
+
+		void UpdateCellBlocking(CPos cell)
+		{
+			var current = pathabilityCache[cell];
+
+			var actors = actorMap.GetActorsAt(cell);
+
+			if (!actors.Any())
+			{
+				pathabilityCache[cell] = current.WithBlocking(default(LongBitSet<PlayerBitMask>), CellBlocking.Empty);
+				return;
+			}
+
+			var cellBlocking = CellBlocking.HasActor;
+			if (sharesCell && actorMap.HasFreeSubCell(cell))
+			{
+				pathabilityCache[cell] = current.WithBlocking(default(LongBitSet<PlayerBitMask>), cellBlocking | CellBlocking.FreeSubCell);
+				return;
+			}
+
+			var cellBits = default(LongBitSet<PlayerBitMask>);
+
+			foreach (var actor in actors)
+			{
+				var actorBits = default(LongBitSet<PlayerBitMask>);
+				var crushables = actor.TraitsImplementing<ICrushable>();
+				var mobile = actor.OccupiesSpace as Mobile;
+				var isMoving = mobile != null && mobile.CurrentMovementTypes.HasFlag(MovementType.Horizontal);
+
+				if (crushables.Any())
+				{
+					LongBitSet<PlayerBitMask> crushingBits;
+					foreach (var crushable in crushables)
+						if (crushable.TryCalculatePlayerBlocking(actor, Info.Crushes, out crushingBits))
+						{
+							actorBits = actorBits.Union(crushingBits);
+							cellBlocking |= CellBlocking.Crushable;
+						}
+
+					if (isMoving)
+						actorBits = actorBits.Except(actor.Owner.AllyMask);
+				}
+				else
+					actorBits = isMoving ? actor.Owner.EnemyMask : allPlayerMask;
+
+				cellBits = cellBits.Union(actorBits);
+			}
+
+			pathabilityCache[cell] = current.WithBlocking(cellBits, cellBlocking);
+		}
+
+		void MapCellEntryChanged(CPos cell)
+		{
+			updatedTerrainCells.Add(cell);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 				return EmptyPath;
 
 			var distance = source - target;
-			if (source.Layer == target.Layer && distance.LengthSquared < 3 && li.CanMoveFreelyInto(world, self, target, null, CellConditions.All))
+			if (source.Layer == target.Layer && distance.LengthSquared < 3 && locomotor.CanMoveFreelyInto(self, target, null, CellConditions.All))
 				return new List<CPos> { target };
 
 			List<CPos> pb;

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -64,7 +64,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public List<CPos> FindUnitPath(CPos source, CPos target, Actor self, Actor ignoreActor)
 		{
-			var li = self.Info.TraitInfo<MobileInfo>().LocomotorInfo;
+			var mobile = self.Trait<Mobile>();
+			var locomotor = mobile.Locomotor;
+
 			if (!cached)
 			{
 				domainIndex = world.WorldActor.TraitOrDefault<DomainIndex>();
@@ -72,7 +74,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// If a water-land transition is required, bail early
-			if (domainIndex != null && !domainIndex.IsPassable(source, target, li))
+			if (domainIndex != null && !domainIndex.IsPassable(source, target, locomotor.Info))
 				return EmptyPath;
 
 			var distance = source - target;
@@ -80,8 +82,9 @@ namespace OpenRA.Mods.Common.Traits
 				return new List<CPos> { target };
 
 			List<CPos> pb;
-			using (var fromSrc = PathSearch.FromPoint(world, li, self, target, source, true).WithIgnoredActor(ignoreActor))
-			using (var fromDest = PathSearch.FromPoint(world, li, self, source, target, true).WithIgnoredActor(ignoreActor).Reverse())
+
+			using (var fromSrc = PathSearch.FromPoint(world, locomotor, self, target, source, true).WithIgnoredActor(ignoreActor))
+			using (var fromDest = PathSearch.FromPoint(world, locomotor, self, source, target, true).WithIgnoredActor(ignoreActor).Reverse())
 				pb = FindBidiPath(fromSrc, fromDest);
 
 			return pb;
@@ -95,7 +98,8 @@ namespace OpenRA.Mods.Common.Traits
 				cached = true;
 			}
 
-			var mi = self.Info.TraitInfo<MobileInfo>();
+			var mobile = self.Trait<Mobile>();
+			var mi = mobile.Info;
 			var li = mi.LocomotorInfo;
 			var targetCell = world.Map.CellContaining(target);
 
@@ -117,8 +121,10 @@ namespace OpenRA.Mods.Common.Traits
 					return EmptyPath;
 			}
 
-			using (var fromSrc = PathSearch.FromPoints(world, li, self, tilesInRange, source, true))
-			using (var fromDest = PathSearch.FromPoint(world, li, self, source, targetCell, true).Reverse())
+			var locomotor = mobile.Locomotor;
+
+			using (var fromSrc = PathSearch.FromPoints(world, locomotor, self, tilesInRange, source, true))
+			using (var fromDest = PathSearch.FromPoint(world, locomotor, self, source, targetCell, true).Reverse())
 				return FindBidiPath(fromSrc, fromDest);
 		}
 

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -90,6 +90,7 @@ namespace OpenRA.Mods.Common.Traits
 	public interface ICrushable
 	{
 		bool CrushableBy(Actor self, Actor crusher, BitSet<CrushClass> crushClasses);
+		bool TryCalculatePlayerBlocking(Actor self, BitSet<CrushClass> crushClasses, out LongBitSet<PlayerBitMask> blocking);
 	}
 
 	[RequireExplicitImplementation]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/19173272/59549769-bfdcdb00-8f62-11e9-96af-4de567d8e4c4.png)

Adding a new trait, "Static" to mark actors that we can cache for the blocking check in the Pathfinder.

# Benchmark 1
## Map
- 256x256
- Over 8000 trees

![image](https://user-images.githubusercontent.com/19173272/59549833-9d978d00-8f63-11e9-949b-273868040018.png)

## Results

![bench_cell_cost_cache2](https://user-images.githubusercontent.com/19173272/59549810-35e14200-8f63-11e9-82ca-3ae1e46908a8.png)

# Benchmark 2
## Map
- 128x128
- More similar to a normal game with a lot of moving actors and some static

## Results
![image](https://user-images.githubusercontent.com/19173272/59549885-62498e00-8f64-11e9-9d5b-8d337a39146e.png)

And without log scale 
![image](https://user-images.githubusercontent.com/19173272/59549895-73929a80-8f64-11e9-89b4-37ec539e45a2.png)
