### PR TITLE
Place default rally point of WEAP, BARR and TENT closer to exit

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -998,6 +998,7 @@ WEAP:
 		RequiresCondition: !build-incomplete
 		Sequence: build-top
 	RallyPoint:
+		Offset: 1,2
 	Exit@1:
 		RequiresCondition: !being-captured
 		SpawnOffset: 213,-128,0
@@ -1717,6 +1718,7 @@ BARR:
 		Range: 4c0
 	WithBuildingBib:
 	RallyPoint:
+		Offset: 1,2
 	Exit@1:
 		RequiresCondition: !being-captured
 		SpawnOffset: -170,810,0
@@ -1863,6 +1865,7 @@ TENT:
 		Range: 4c0
 	WithBuildingBib:
 	RallyPoint:
+		Offset: 1,2
 	Exit@1:
 		RequiresCondition: !being-captured
 		SpawnOffset: -42,810,0


### PR DESCRIPTION
There is a long-standing issue with rally points in that if they are placed into an impassable cell, units do not go to the location and instead just exit the production facility and stop there. Particularly annoying consequence of that is that if you place War Factory close to a building, a cliff or a tree, thus overlapping the default rally point into an impassable cell, Ore Trucks exiting that War Factory will drop their default orders to gather nearby ore and just stop beside the War Factory.

Placing the rally point closer (onto the building's bib) ensures that the target location is always a passable terrain.

Barracks' rally points are modified just for the consistency.

![image](https://user-images.githubusercontent.com/1614714/59565702-4a0a6980-905f-11e9-8b81-2576fbd7ab9c.png)

All in all, a minor QoL fix until #15995 gets properly fixed.