### PR TITLE
Implement ReloadAmmoDelayMultiplier

### DIFF
--- a/OpenRA.Mods.Common/Traits/Multipliers/ReloadAmmoDelayMultiplier.cs
+++ b/OpenRA.Mods.Common/Traits/Multipliers/ReloadAmmoDelayMultiplier.cs
@@ -1,0 +1,31 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("Modifies the reload time of ammo pools on this actor.")]
+	public class ReloadAmmoDelayMultiplierInfo : ConditionalTraitInfo
+	{
+		[FieldLoader.Require]
+		[Desc("Percentage modifier to apply.")]
+		public readonly int Modifier = 100;
+
+		public override object Create(ActorInitializer init) { return new ReloadAmmoDelayMultiplier(this); }
+	}
+
+	public class ReloadAmmoDelayMultiplier : ConditionalTrait<ReloadAmmoDelayMultiplierInfo>, IReloadAmmoModifier
+	{
+		public ReloadAmmoDelayMultiplier(ReloadAmmoDelayMultiplierInfo info)
+			: base(info) { }
+
+		int IReloadAmmoModifier.GetReloadAmmoModifier() { return IsTraitDisabled ? 100 : Info.Modifier; }
+	}
+}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -362,6 +362,9 @@ namespace OpenRA.Mods.Common.Traits
 	public interface IReloadModifier { int GetReloadModifier(); }
 
 	[RequireExplicitImplementation]
+	public interface IReloadAmmoModifier { int GetReloadAmmoModifier(); }
+
+	[RequireExplicitImplementation]
 	public interface IInaccuracyModifier { int GetInaccuracyModifier(); }
 
 	[RequireExplicitImplementation]


### PR DESCRIPTION
I have recently decided to write a new manager trait for the Sole Survivor mod multipliers, so i can implement team bonuses and properly revoke the bonuses when taking Wacky Crates or Flags.

On other hand, since i'm no longer using conditions, i can't make Reload Delay bonus properly apply the Mobile SSM/Orca/Apache since those units use Ammo Pools. So i implemented ReloadAmmoDelayMultiplier and IReloadAmmoMultiplier interface to use there.

We may also wanna use this on the default mods for the same reason the veterancy bonus don't change the ammo reload of some units and default mods don't have multipile ReloadAmmoPool traits like i used to use in SS either.

TESTCASE makes it so Orca reloads 4 times faster when you have a normal or advanced communications center in TD. Ignore the changes to TS, it was for testing #16678 and sneaked in. It is a part of the TESTCASE commit i can just remove it along with the TESTCASE.