### PR TITLE
Silence some doc errors in VS2019.

### DIFF
--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -135,6 +135,7 @@ namespace OpenRA.Activities
 		/// Call this method from any place that's called during a tick, such as the Tick() method itself or
 		/// the Before(First|Last)Run() methods. The origin activity will be marked in the output.
 		/// </summary>
+		/// <param name="self">The actor performing this activity.</param>
 		/// <param name="origin">Activity from which to start traversing, and which to mark. If null, mark the calling activity, and start traversal from the top.</param>
 		/// <param name="level">Initial level of indentation.</param>
 		protected void PrintActivityTree(Actor self, Activity origin = null, int level = 0)

--- a/OpenRA.Mods.Common/Traits/Conditions/ConditionManager.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ConditionManager.cs
@@ -114,9 +114,12 @@ namespace OpenRA.Mods.Common.Traits
 			return token;
 		}
 
-		/// <summary>Revokes a previously granted condition.</summary>
-		/// <returns>The invalid token ID.</returns>
+		/// <summary>
+		/// Revokes a previously granted condition.
+		/// </summary>
+		/// <param name="self">The actor to which this trait is attached.</param>
 		/// <param name="token">The token ID returned by GrantCondition.</param>
+		/// <returns>The invalid token ID.</returns>
 		public int RevokeCondition(Actor self, int token)
 		{
 			string condition;

--- a/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
+++ b/OpenRA.Mods.Common/Traits/World/DomainIndex.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 			return domainIndexes[movementClass].IsPassable(p1, p2);
 		}
 
-		/// Regenerate the domain index for a group of cells
+		/// <summary>Regenerate the domain index for a group of cells.</summary>
 		public void UpdateCells(World world, IEnumerable<CPos> cells)
 		{
 			var dirty = cells.ToHashSet();

--- a/OpenRA.Mods.Common/Traits/World/ResourceClaimLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceClaimLayer.cs
@@ -59,7 +59,6 @@ namespace OpenRA.Mods.Common.Traits
 		/// <summary>
 		/// Release the last resource claim made by this actor.
 		/// </summary>
-		/// <param name="claimer"></param>
 		public void RemoveClaim(Actor claimer)
 		{
 			CPos lastClaim;

--- a/OpenRA.ruleset
+++ b/OpenRA.ruleset
@@ -42,5 +42,12 @@
     <Rule Id="SA1214" Action="None" /><!-- ReadonlyElementsMustAppearBeforeNonReadonlyElements -->
     <Rule Id="SA1413" Action="None" /><!-- UseTrailingCommasInMultiLineInitializers -->
     <Rule Id="SA1516" Action="None" /><!-- ElementsMustBeSeparatedByBlankLine -->
+    <Rule Id="SA1604" Action="None" /><!-- ElementDocumentationShouldHaveSummary -->
+    <Rule Id="SA1611" Action="None" /><!-- ElementParametersShouldBeDocumented -->
+    <Rule Id="SA1615" Action="None" /><!-- ElementReturnValueShouldBeDocumented -->
+    <Rule Id="SA1618" Action="None" /><!-- GenericTypeParametersShouldBeDocumented -->
+    <Rule Id="SA1623" Action="None" /><!-- PropertySummaryDocumentationShouldMatchAccessors -->
+    <Rule Id="SA1629" Action="None" /><!-- DocumentationTextShouldEndWithAPeriod -->
+    <Rule Id="SA1642" Action="None" /><!-- ConstructorSummaryDocumentationShouldBeginWithStandardText -->
   </Rules>
 </RuleSet>


### PR DESCRIPTION
Needed to suppress some style rules which VS2019 is reporting as errors. Fixed rules with only one or two breakages and suppressed the rest.

(I figure this must be VS specific or it would've otherwise been noted by now...)