### PR TITLE
Make repair/rearm of ground units queueable

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -111,11 +111,12 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 			}
 
-			// If all valid weapons have depleted their ammo and Rearmable trait exists, return to RearmActor to reload and then resume the activity
+			// If all valid weapons have depleted their ammo and Rearmable trait exists, return to RearmActor to reload
+			// and resume the activity after reloading if AbortOnResupply is set to 'false'
 			if (rearmable != null && !useLastVisibleTarget && attackAircraft.Armaments.All(x => x.IsTraitPaused || !x.Weapon.IsValidAgainst(target, self.World, self)))
 			{
 				QueueChild(new ReturnToBase(self));
-				return aircraft.Info.AbortOnResupply;
+				return attackAircraft.Info.AbortOnResupply;
 			}
 
 			var pos = self.CenterPosition;

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -120,9 +120,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				aircraft.MakeReservation(dest);
 				QueueChild(new Land(self, Target.FromActor(dest), offset, facing));
-				QueueChild(new Resupply(self, dest, WDist.Zero));
-				if (aircraft.Info.FlightDynamics.HasFlag(FlightDynamic.TakeOffOnResupply) && !alwaysLand)
-					QueueChild(new TakeOff(self));
+				QueueChild(new Resupply(self, dest, WDist.Zero, alwaysLand));
 
 				return true;
 			}

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -166,14 +166,6 @@ namespace OpenRA.Mods.Common.Activities
 			return false;
 		}
 
-		public override void Cancel(Actor self, bool keepQueue = false)
-		{
-			if (NextActivity != null)
-				return;
-
-			base.Cancel(self, keepQueue);
-		}
-
 		void RepairTick(Actor self)
 		{
 			// First active.

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -135,13 +135,6 @@ namespace OpenRA.Mods.Common.Activities
 				actualResupplyStarted = true;
 				foreach (var notifyResupply in notifyResupplies)
 					notifyResupply.BeforeResupply(host.Actor, self, activeResupplyTypes);
-
-				// Reset the ReloadDelay to avoid any issues with early cancellation
-				// from previous reload attempts (explicit order, host building died, etc).
-				// HACK: this really shouldn't be managed from here
-				if (activeResupplyTypes.HasFlag(ResupplyType.Rearm))
-					foreach (var pool in rearmable.RearmableAmmoPools)
-						pool.RemainingTicks = pool.Info.ReloadDelay;
 			}
 
 			if (activeResupplyTypes.HasFlag(ResupplyType.Repair))

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -358,7 +358,7 @@ namespace OpenRA.Mods.Common.Traits
 				ForceLanding = true;
 			}
 
-			// Add takeoff activity if LandOnCondidion resolves to false and the actor should not land when idle.
+			// Add takeoff activity if LandOnCondition resolves to false and the actor should not land when idle.
 			if (ForceLanding && landNow.HasValue && !landNow.Value && !cruising && !(self.CurrentActivity is TakeOff))
 			{
 				ForceLanding = false;

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -94,9 +94,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Will this actor try to land after it has no more commands?")]
 		public readonly bool LandWhenIdle = true;
 
-		[Desc("Does this actor cancel its previous activity after resupplying?")]
-		public readonly bool AbortOnResupply = true;
-
 		[Desc("Altitude at which the aircraft considers itself landed.")]
 		public readonly WDist LandAltitude = WDist.Zero;
 

--- a/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
@@ -26,6 +26,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Delay, in game ticks, before strafing aircraft turns to attack.")]
 		public readonly int AttackTurnDelay = 50;
 
+		[Desc("Does this actor cancel its attack activity when it needs to resupply? Setting this to 'false' will make the actor resume attack after reloading.")]
+		public readonly bool AbortOnResupply = true;
+
 		public override object Create(ActorInitializer init) { return new AttackAircraft(init.Self, this); }
 	}
 

--- a/OpenRA.Mods.Common/Traits/Rearmable.cs
+++ b/OpenRA.Mods.Common/Traits/Rearmable.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new Rearmable(this); }
 	}
 
-	public class Rearmable : INotifyCreated
+	public class Rearmable : INotifyCreated, INotifyResupply
 	{
 		public readonly RearmableInfo Info;
 
@@ -43,5 +43,18 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			RearmableAmmoPools = self.TraitsImplementing<AmmoPool>().Where(p => Info.AmmoPools.Contains(p.Info.Name)).ToArray();
 		}
+
+		void INotifyResupply.BeforeResupply(Actor self, Actor target, ResupplyType types)
+		{
+			if (!types.HasFlag(ResupplyType.Rearm))
+				return;
+
+			// Reset the ReloadDelay to avoid any issues with early cancellation
+			// from previous reload attempts (explicit order, host building died, etc).
+			foreach (var pool in RearmableAmmoPools)
+				pool.RemainingTicks = pool.Info.ReloadDelay;
+		}
+
+		void INotifyResupply.ResupplyTick(Actor self, Actor target, ResupplyType types) { }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits
 			isAircraft = self.Info.HasTraitInfo<AircraftInfo>();
 		}
 
-		public IEnumerable<IOrderTargeter> Orders
+		IEnumerable<IOrderTargeter> IIssueOrder.Orders
 		{
 			get
 			{
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
 			if (order.OrderID == "Repair")
 				return new Order(order.OrderID, self, target, queued);
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.Traits
 			return rearmable != null && rearmable.RearmableAmmoPools.Any(p => !p.FullAmmo());
 		}
 
-		public string VoicePhraseForOrder(Actor self, Order order)
+		string IOrderVoice.VoicePhraseForOrder(Actor self, Order order)
 		{
 			return order.OrderString == "Repair" && (CanRepair() || CanRearm()) ? Info.Voice : null;
 		}

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -41,14 +41,12 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public readonly RepairableNearInfo Info;
 		readonly Actor self;
-		readonly IMove movement;
 		bool requireForceMove;
 
 		public RepairableNear(Actor self, RepairableNearInfo info)
 		{
 			this.self = self;
 			Info = info;
-			movement = self.Trait<IMove>();
 		}
 
 		public IEnumerable<IOrderTargeter> Orders
@@ -104,10 +102,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (!order.Queued)
 				self.CancelActivity();
 
-			self.QueueActivity(movement.MoveWithinRange(order.Target, Info.CloseEnough, targetLineColor: Color.Green));
+			self.SetTargetLine(order.Target, Color.Green);
 			self.QueueActivity(new Resupply(self, order.Target.Actor, Info.CloseEnough));
-
-			self.SetTargetLine(order.Target, Color.Green, false);
 		}
 
 		public Actor FindRepairBuilding(Actor self)

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 			Info = info;
 		}
 
-		public IEnumerable<IOrderTargeter> Orders
+		IEnumerable<IOrderTargeter> IIssueOrder.Orders
 		{
 			get
 			{
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
 		{
 			if (order.OrderID == "RepairNear")
 				return new Order(order.OrderID, self, target, queued);
@@ -84,12 +84,12 @@ namespace OpenRA.Mods.Common.Traits
 			return self.GetDamageState() > DamageState.Undamaged;
 		}
 
-		public string VoicePhraseForOrder(Actor self, Order order)
+		string IOrderVoice.VoicePhraseForOrder(Actor self, Order order)
 		{
 			return order.OrderString == "RepairNear" && ShouldRepair() ? Info.Voice : null;
 		}
 
-		public void ResolveOrder(Actor self, Order order)
+		void IResolveOrder.ResolveOrder(Actor self, Order order)
 		{
 			// RepairNear orders are only valid for own/allied actors,
 			// which are guaranteed to never be frozen.

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20190314/MoveAbortOnResupply.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20190314/MoveAbortOnResupply.cs
@@ -1,0 +1,60 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class MoveAbortOnResupply : UpdateRule
+	{
+		public override string Name { get { return "Moved AbortOnResupply from Aircraft to AttackAircraft"; } }
+		public override string Description
+		{
+			get
+			{
+				return "AbortOnResupply boolean was moved to AttackAircraft.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var aircraft = actorNode.LastChildMatching("Aircraft");
+			var attackAircraft = actorNode.ChildrenMatching("AttackAircraft");
+
+			if (aircraft != null)
+			{
+				var abortOnResupply = aircraft.LastChildMatching("AbortOnResupply");
+				if (abortOnResupply == null)
+					yield break;
+
+				// Only add field to AttackAircraft if explicitly set to 'false'
+				if (!abortOnResupply.NodeValue<bool>())
+				{
+					if (attackAircraft.Any())
+						foreach (var a in attackAircraft)
+							a.AddNode(abortOnResupply);
+					else
+					{
+						var newAttackAircraft = new MiniYamlNode("AttackAircraft", "");
+						newAttackAircraft.AddNode(abortOnResupply);
+						actorNode.AddNode(newAttackAircraft);
+					}
+				}
+
+				aircraft.RemoveNode(abortOnResupply);
+			}
+
+			yield break;
+		}
+	}
+}


### PR DESCRIPTION
Moves `Repairable(Near)` activity handling to `Resupply` activity, plus a few fixes.

Implements first step of https://github.com/OpenRA/OpenRA/issues/15023#issuecomment-489332380

Fixes #16462.
Fixes #16463.
Fixes #16761.
Fixes #16492.