### PR TITLE
Updated launch dedicated to work with AppImages

### DIFF
--- a/launch-dedicated-appimage.sh
+++ b/launch-dedicated-appimage.sh
@@ -2,8 +2,8 @@
 # example launch script, see https://github.com/OpenRA/OpenRA/wiki/Dedicated for details
 
 # Usage:
-#  $ ./launch-dedicated.sh # Launch a dedicated server with default settings
-#  $ Mod="d2k" ./launch-dedicated.sh # Launch a dedicated server with default settings but override the Mod
+#  $ ./launch-dedicated-appimage.sh # Launch a dedicated server with default settings
+#  $ Mod="d2k" ./launch-dedicated-appimage.sh # Launch a dedicated server with default settings but override the Mod
 #  Read the file to see which settings you can override
 
 Name="${Name:-"Dedicated Server"}"

--- a/launch-dedicated-appimage.sh
+++ b/launch-dedicated-appimage.sh
@@ -22,11 +22,11 @@ EnableSyncReports="${EnableSyncReports:-"False"}"
 if [ "$Mod" = "d2k" ]; then
     App="OpenRA-Dune-2000-x86_64.AppImage"
 elif [ "$Mod" = "cnc" ]; then
-    App="OpenRA-Tiberium-Dawn-x86_64.AppImage"
+    App="OpenRA-Tiberian-Dawn-x86_64.AppImage"
 elif [ "$Mod" = "ra" ]; then
     App="OpenRA-Red-Alert-x86_64.AppImage"
 else
-    printf "Invalid Mod value %s provided. Allowed values are ra, cnc and d2k" $Mod
+    printf "Invalid Mod value %s provided. Allowed values are ra, cnc and d2k." $Mod
     exit 1
 fi
 

--- a/launch-dedicated-appimage.sh
+++ b/launch-dedicated-appimage.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# example launch script, see https://github.com/OpenRA/OpenRA/wiki/Dedicated for details
+
+# Usage:
+#  $ ./launch-dedicated.sh # Launch a dedicated server with default settings
+#  $ Mod="d2k" ./launch-dedicated.sh # Launch a dedicated server with default settings but override the Mod
+#  Read the file to see which settings you can override
+
+Name="${Name:-"Dedicated Server"}"
+Mod="${Mod:-"ra"}"
+ListenPort="${ListenPort:-"1234"}"
+AdvertiseOnline="${AdvertiseOnline:-"True"}"
+Password="${Password:-""}"
+
+RequireAuthentication="${RequireAuthentication:-"False"}"
+ProfileIDBlacklist="${ProfileIDBlacklist:-""}"
+ProfileIDWhitelist="${ProfileIDWhitelist:-""}"
+
+EnableSingleplayer="${EnableSingleplayer:-"False"}"
+EnableSyncReports="${EnableSyncReports:-"False"}"
+
+if [ "$Mod" = "d2k" ]; then
+    App="OpenRA-Dune-2000-x86_64.AppImage"
+elif [ "$Mod" = "cnc" ]; then
+    App="OpenRA-Tiberium-Dawn-x86_64.AppImage"
+elif [ "$Mod" = "ra" ]; then
+    App="OpenRA-Red-Alert-x86_64.AppImage"
+else
+    printf "Invalid Mod value %s provided. Allowed values are ra, cnc and d2k" $Mod
+    exit 1
+fi
+
+if [ ! -f "$App" ]; then
+    printf "Could not find AppImage %s for Mod %s in the current folder. Has it been downloaded?" $App $Mod
+    exit 1
+fi
+
+eval "./$App" --server \
+Server.Name="$Name" \
+Server.ListenPort="$ListenPort" \
+Server.AdvertiseOnline="$AdvertiseOnline" \
+Server.EnableSingleplayer="$EnableSingleplayer" \
+Server.Password="$Password" \
+Server.RequireAuthentication="$RequireAuthentication" \
+Server.ProfileIDBlacklist="$ProfileIDBlacklist" \
+Server.ProfileIDWhitelist="$ProfileIDWhitelist" \
+Server.EnableSyncReports="$EnableSyncReports"

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -19,15 +19,29 @@ ProfileIDWhitelist="${ProfileIDWhitelist:-""}"
 EnableSingleplayer="${EnableSingleplayer:-"False"}"
 EnableSyncReports="${EnableSyncReports:-"False"}"
 
-while true; do
-     mono --debug OpenRA.Server.exe Game.Mod="$Mod" \
-     Server.Name="$Name" \
-     Server.ListenPort="$ListenPort" \
-     Server.AdvertiseOnline="$AdvertiseOnline" \
-     Server.EnableSingleplayer="$EnableSingleplayer" \
-     Server.Password="$Password" \
-     Server.RequireAuthentication="$RequireAuthentication" \
-     Server.ProfileIDBlacklist="$ProfileIDBlacklist" \
-     Server.ProfileIDWhitelist="$ProfileIDWhitelist" \
-     Server.EnableSyncReports="$EnableSyncReports"
-done
+if [ "$Mod" = "d2k" ]; then
+    App="OpenRA-Dune-2000-x86_64.AppImage"
+elif [ "$Mod" = "cnc" ]; then
+    App="OpenRA-Tiberium-Dawn-x86_64.AppImage"
+elif [ "$Mod" = "ra" ]; then
+    App="OpenRA-Red-Alert-x86_64.AppImage"
+else
+    printf "Invalid Mod value %s provided. Allowed values are ra, cnc and d2k" $Mod
+    exit 1
+fi
+
+if [ ! -f "$App" ]; then
+    printf "Could not find AppImage %s for Mod %s in the current folder. Has it been downloaded?" $App $Mod
+    exit 1
+fi
+
+eval "./$App" --server \
+Server.Name="$Name" \
+Server.ListenPort="$ListenPort" \
+Server.AdvertiseOnline="$AdvertiseOnline" \
+Server.EnableSingleplayer="$EnableSingleplayer" \
+Server.Password="$Password" \
+Server.RequireAuthentication="$RequireAuthentication" \
+Server.ProfileIDBlacklist="$ProfileIDBlacklist" \
+Server.ProfileIDWhitelist="$ProfileIDWhitelist" \
+Server.EnableSyncReports="$EnableSyncReports"

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -19,29 +19,15 @@ ProfileIDWhitelist="${ProfileIDWhitelist:-""}"
 EnableSingleplayer="${EnableSingleplayer:-"False"}"
 EnableSyncReports="${EnableSyncReports:-"False"}"
 
-if [ "$Mod" = "d2k" ]; then
-    App="OpenRA-Dune-2000-x86_64.AppImage"
-elif [ "$Mod" = "cnc" ]; then
-    App="OpenRA-Tiberium-Dawn-x86_64.AppImage"
-elif [ "$Mod" = "ra" ]; then
-    App="OpenRA-Red-Alert-x86_64.AppImage"
-else
-    printf "Invalid Mod value %s provided. Allowed values are ra, cnc and d2k" $Mod
-    exit 1
-fi
-
-if [ ! -f "$App" ]; then
-    printf "Could not find AppImage %s for Mod %s in the current folder. Has it been downloaded?" $App $Mod
-    exit 1
-fi
-
-eval "./$App" --server \
-Server.Name="$Name" \
-Server.ListenPort="$ListenPort" \
-Server.AdvertiseOnline="$AdvertiseOnline" \
-Server.EnableSingleplayer="$EnableSingleplayer" \
-Server.Password="$Password" \
-Server.RequireAuthentication="$RequireAuthentication" \
-Server.ProfileIDBlacklist="$ProfileIDBlacklist" \
-Server.ProfileIDWhitelist="$ProfileIDWhitelist" \
-Server.EnableSyncReports="$EnableSyncReports"
+while true; do
+     mono --debug OpenRA.Server.exe Game.Mod="$Mod" \
+     Server.Name="$Name" \
+     Server.ListenPort="$ListenPort" \
+     Server.AdvertiseOnline="$AdvertiseOnline" \
+     Server.EnableSingleplayer="$EnableSingleplayer" \
+     Server.Password="$Password" \
+     Server.RequireAuthentication="$RequireAuthentication" \
+     Server.ProfileIDBlacklist="$ProfileIDBlacklist" \
+     Server.ProfileIDWhitelist="$ProfileIDWhitelist" \
+     Server.EnableSyncReports="$EnableSyncReports"
+done


### PR DESCRIPTION
This is an update the the launch-dedicated.sh shell script to work with AppImages. It chooses the AppImage to execute based on the provided Mod value and provides the --server flag to the AppImage on execution. 