### PR TITLE
Normalise Construction Yard Cost

### DIFF
--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1135,7 +1135,7 @@ FACT:
 	Production:
 		Produces: Building, Defense
 	Valued:
-		Cost: 2500
+		Cost: 2000
 	Tooltip:
 		Name: Construction Yard
 	SpawnActorsOnSell:


### PR DESCRIPTION
A leftover from an old commit https://github.com/OpenRA/OpenRA/commit/55cb2d49a4b58d3303681cda6db573969eb95497 . Originally MCV and ConYard costed 2500. Then MCVs cost cost was reduced to 2000 and ConYards one was forgotten. This pr attempts to make them equal again.

One concern is that after reducing its cost an engineer will not always be spawned after selling it. Sadly with the current cost It is already the case 