### PR TITLE
Remove Selectable from planes in TD

### DIFF
--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -644,7 +644,6 @@
 ^Plane:
 	Inherits@1: ^ExistsInWorld
 	Inherits@2: ^SpriteActor
-	Inherits@SELECTION_MODE: ^FlatSelectionMode
 	Huntable:
 	OwnerLostAction:
 		Action: Kill


### PR DESCRIPTION
Fixes the
```
OpenRA.Utility(1,1): Warning: Actor c17 defines both Interactable and Selectable traits. This may cause unexpected results.
OpenRA.Utility(1,1): Warning: Actor a10 defines both Interactable and Selectable traits. This may cause unexpected results.
```
warnings of `make test` accidentally introduced in #15839.