### PR TITLE
Fix InstantHit crashing if blockable and target is dead

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -65,10 +65,17 @@ namespace OpenRA.Mods.Common.Projectiles
 		{
 			// Check for blocking actors
 			WPos blockedPos;
-			if (info.Blockable && BlocksProjectiles.AnyBlockingActorsBetween(world, args.Source, target.CenterPosition,
-				info.Width, out blockedPos))
+			if (info.Blockable)
 			{
-				target = Target.FromPos(blockedPos);
+				// If GuidedTarget has become invalid due to getting killed the same tick,
+				// we need to set target to args.PassiveTarget to prevent target.CenterPosition below from crashing.
+				// The warheads have target validity checks themselves so they don't need this, but AnyBlockingActorsBetween does.
+				if (target.Type == TargetType.Invalid)
+					target = Target.FromPos(args.PassiveTarget);
+
+				if (BlocksProjectiles.AnyBlockingActorsBetween(world, args.Source, target.CenterPosition,
+					info.Width, out blockedPos))
+					target = Target.FromPos(blockedPos);
 			}
 
 			args.Weapon.Impact(target, args.SourceActor, args.DamageModifiers);


### PR DESCRIPTION
If the weapon has `TargetActorCenter`, the projectile is `Blockable` and the target dies the same tick the projectile is fired but before the 'blocked' check is performed, the `target.CenterPosition` lookup would crash since the target has become invalid.

Work around this by ignoring weapons' `TargetActorCenter` and using `args.PassiveTarget` position instead if the target is already dead.

Fixes #15338.