### PR TITLE
Add missing tooltip container to settings.yaml

### DIFF
--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -669,3 +669,4 @@ Background@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Enable Debug Commands in Replays
+		TooltipContainer@TOOLTIP_CONTAINER:


### PR DESCRIPTION
```yaml
 		TooltipContainer@TOOLTIP_CONTAINER:
```
^ was removed from `mods/common/chrome/settings.yaml` in 09c1611239b9a5327a9ba1fcef86ef7eca6ba565 causing a crash if there are hotkey buttons with tooltips.