### PR TITLE
Fixed incorrect sequence frame amount checks using Stride.

### DIFF
--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -204,16 +204,16 @@ namespace OpenRA.Mods.Common.Graphics
 							"{0}: Sequence {1}.{2}: Length must be <= Frames.Length"
 							.F(info.Nodes[0].Location, sequence, animation));
 
-					if (Start < 0 || Start + Facings * Stride > frameCount)
+					if (Start < 0 || Start + (Facings - 1) * Stride + Length > frameCount)
 						throw new InvalidOperationException(
 							"{5}: Sequence {0}.{1} uses frames [{2}..{3}], but only 0..{4} actually exist"
-							.F(sequence, animation, Start, Start + Facings * Stride - 1, frameCount - 1,
+							.F(sequence, animation, Start, Start + (Facings - 1) * Stride + Length - 1, frameCount - 1,
 								info.Nodes[0].Location));
 
-					if (ShadowStart + Facings * Stride > frameCount)
+					if (ShadowStart + (Facings - 1) * Stride + Length > frameCount)
 						throw new InvalidOperationException(
 							"{5}: Sequence {0}.{1}'s shadow frames use frames [{2}..{3}], but only [0..{4}] actually exist"
-							.F(sequence, animation, ShadowStart, ShadowStart + Facings * Stride - 1, frameCount - 1,
+							.F(sequence, animation, ShadowStart, ShadowStart + (Facings - 1) * Stride + Length - 1, frameCount - 1,
 								info.Nodes[0].Location));
 
 					var usedFrames = new List<int>();


### PR DESCRIPTION
This fixes a problem caused by Stride in combination with Start.
Example: Imagine a frame input source not sorted by animation but by facing. So the order will be:
- idle north
- move north
- idle east
- move east
- idle south
- move south
- idle west
- move west

Idle having the length of 1, move of 3.
The correct sequence data for move would be:
Start: 1
Length: 3
Facings: 4
Stride: 4

Simply multiplying the facings with Stride and adding the Start will be: 4 * 4 + 1 = 17, so the game assumes Frames 2...17 are used. However only frames 1...16 exist. The reason is the last facing does not need to "fill up" to the whole stride length of 4, but has simply its proper Length of 3, ending on the last frame. So the correct frame range would be 2...16

This PR fixes this bug obviously.