### PR TITLE
Exception should inform which actors causes it.

### DIFF
--- a/OpenRA.Game/TraitDictionary.cs
+++ b/OpenRA.Game/TraitDictionary.cs
@@ -86,13 +86,13 @@ namespace OpenRA
 		public T Get<T>(Actor actor)
 		{
 			CheckDestroyed(actor);
-			return InnerGet<T>().Get(actor.ActorID);
+			return InnerGet<T>().Get(actor);
 		}
 
 		public T GetOrDefault<T>(Actor actor)
 		{
 			CheckDestroyed(actor);
-			return InnerGet<T>().GetOrDefault(actor.ActorID);
+			return InnerGet<T>().GetOrDefault(actor);
 		}
 
 		public IEnumerable<T> WithInterface<T>(Actor actor)
@@ -144,22 +144,22 @@ namespace OpenRA
 				traits.Insert(insertIndex, (T)trait);
 			}
 
-			public T Get(uint actor)
+			public T Get(Actor actor)
 			{
 				var result = GetOrDefault(actor);
 				if (result == null)
-					throw new InvalidOperationException("Actor does not have trait of type `{0}`".F(typeof(T)));
+					throw new InvalidOperationException("Actor {0} does not have trait of type `{1}`".F(actor.Info.Name, typeof(T)));
 				return result;
 			}
 
-			public T GetOrDefault(uint actor)
+			public T GetOrDefault(Actor actor)
 			{
 				++Queries;
-				var index = actors.BinarySearchMany(actor);
-				if (index >= actors.Count || actors[index].ActorID != actor)
+				var index = actors.BinarySearchMany(actor.ActorID);
+				if (index >= actors.Count || actors[index] != actor)
 					return default(T);
-				else if (index + 1 < actors.Count && actors[index + 1].ActorID == actor)
-					throw new InvalidOperationException("Actor {0} has multiple traits of type `{1}`".F(actors[index].Info.Name, typeof(T)));
+				else if (index + 1 < actors.Count && actors[index + 1] == actor)
+					throw new InvalidOperationException("Actor {0} has multiple traits of type `{1}`".F(actor.Info.Name, typeof(T)));
 				else return traits[index];
 			}
 


### PR DESCRIPTION
A common encountered exception, which informs about a missing trait should name who is missing the trait, otherwise you keep blindly searching for it.