### PR TITLE
Always clear requested targets when exiting AttackActivity/Flyattack.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -70,11 +70,7 @@ namespace OpenRA.Mods.Common.Activities
 				Cancel(self);
 
 			if (IsCanceling)
-			{
-				// Cancel the requested target, but keep firing on it while in range
-				attackAircraft.ClearRequestedTarget();
 				return true;
-			}
 
 			// Check that AttackFollow hasn't cancelled the target by modifying attack.Target
 			// Having both this and AttackFollow modify that field is a horrible hack.
@@ -106,10 +102,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Target is hidden or dead, and we don't have a fallback position to move towards
 			if (useLastVisibleTarget && !lastVisibleTarget.IsValidFor(self))
-			{
-				attackAircraft.ClearRequestedTarget();
 				return true;
-			}
 
 			// If all valid weapons have depleted their ammo and Rearmable trait exists, return to RearmActor to reload
 			// and resume the activity after reloading if AbortOnResupply is set to 'false'
@@ -127,10 +120,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				// We've reached the assumed position but it is not there - give up
 				if (checkTarget.IsInRange(pos, lastVisibleMaximumRange))
-				{
-					attackAircraft.ClearRequestedTarget();
 					return true;
-				}
 
 				// Fly towards the last known position
 				QueueChild(new Fly(self, target, WDist.Zero, lastVisibleMaximumRange, checkTarget.CenterPosition, Color.Red));
@@ -162,6 +152,12 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			return false;
+		}
+
+		protected override void OnLastRun(Actor self)
+		{
+			// Cancel the requested target, but keep firing on it while in range
+			attackAircraft.ClearRequestedTarget();
 		}
 
 		void IActivityNotifyStanceChanged.StanceChanged(Actor self, AutoTarget autoTarget, UnitStance oldStance, UnitStance newStance)

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -258,11 +258,7 @@ namespace OpenRA.Mods.Common.Traits
 			public override bool Tick(Actor self)
 			{
 				if (IsCanceling)
-				{
-					// Cancel the requested target, but keep firing on it while in range
-					attack.ClearRequestedTarget();
 					return true;
-				}
 
 				// Check that AttackFollow hasn't cancelled the target by modifying attack.Target
 				// Having both this and AttackFollow modify that field is a horrible hack.
@@ -315,10 +311,7 @@ namespace OpenRA.Mods.Common.Traits
 				// If we are ticking again after previously sequencing a MoveWithRange then that move must have completed
 				// Either we are in range and can see the target, or we've lost track of it and should give up
 				if (wasMovingWithinRange && targetIsHiddenActor)
-				{
-					attack.ClearRequestedTarget();
 					return true;
-				}
 
 				// Update target lines if required
 				if (useLastVisibleTarget != oldUseLastVisibleTarget)
@@ -326,10 +319,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				// Target is hidden or dead, and we don't have a fallback position to move towards
 				if (useLastVisibleTarget && !lastVisibleTarget.IsValidFor(self))
-				{
-					attack.ClearRequestedTarget();
 					return true;
-				}
 
 				var pos = self.CenterPosition;
 				var checkTarget = useLastVisibleTarget ? lastVisibleTarget : target;
@@ -339,24 +329,24 @@ namespace OpenRA.Mods.Common.Traits
 				if (checkTarget.IsInRange(pos, maxRange) && !checkTarget.IsInRange(pos, minRange))
 				{
 					if (useLastVisibleTarget)
-					{
-						attack.ClearRequestedTarget();
 						return true;
-					}
 
 					return false;
 				}
 
 				// We can't move into range, so give up
 				if (move == null || maxRange == WDist.Zero || maxRange < minRange)
-				{
-					attack.ClearRequestedTarget();
 					return true;
-				}
 
 				wasMovingWithinRange = true;
 				QueueChild(move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, Color.Red));
 				return false;
+			}
+
+			protected override void OnLastRun(Actor self)
+			{
+				// Cancel the requested target, but keep firing on it while in range
+				attack.ClearRequestedTarget();
 			}
 
 			void IActivityNotifyStanceChanged.StanceChanged(Actor self, AutoTarget autoTarget, UnitStance oldStance, UnitStance newStance)


### PR DESCRIPTION
Fixes #16779 

When exiting the `FlyAttack` activity after a rearm, `attackAircraft.ClearRequestedTarget()` was omitted. Moving this line to `OnLastRun` makes it more robust against future regressions.