### PR TITLE
Allow ReturnToBase to exit if actor does not land at building.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -126,7 +126,7 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			QueueChild(new Fly(self, Target.FromActor(dest)));
-			return false;
+			return true;
 		}
 	}
 }


### PR DESCRIPTION
Fixes a small oversight in #16481. 