### PR TITLE
Fix resupply anim continuing if docked actor dies during resupply

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithResupplyAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResupplyAnimation.cs
@@ -63,6 +63,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 				wsb.CancelCustomAnimation(self);
 				animPlaying = false;
 			}
+
+			// If an actor died before finishing resupply, there will never be a ResupplyTick call
+			// with ResupplyType.None (as activities tick before ITick), so reset here every tick
+			// to prevent the animation from continuing after the resupplied actor died.
+			repairing = false;
+			rearming = false;
 		}
 
 		void INotifyResupply.BeforeResupply(Actor self, Actor target, ResupplyType types)


### PR DESCRIPTION
Fixes #16785.

Resetting repairing/rearming at the end of every tick should be fine, for as long as the actor being resupplied is still alive and resupplying, they should be updated before the next ITick.