### PR TITLE
Balancing changes TD

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -233,7 +233,7 @@ PROC:
 	StoresResources:
 		PipColor: Green
 		PipCount: 10
-		Capacity: 700
+		Capacity: 1000
 	Selectable:
 		Bounds: 72,56
 		DecorationBounds: 73,72
@@ -255,7 +255,7 @@ SILO:
 	Inherits: ^BaseBuilding
 	Inherits@shape: ^2x1Shape
 	Valued:
-		Cost: 300
+		Cost: 100
 	Tooltip:
 		Name: Tiberium Silo
 	Buildable:

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -222,10 +222,10 @@ TowerMissile:
 		Speed: 298
 		RangeLimit: 8c409
 	Warhead@1Dam: SpreadDamage
-		Spread: 683
+		Spread: 483
 		ValidTargets: Ground
 		Versus:
-			None: 48
+			None: 52
 			Wood: 24
 			Light: 100
 			Heavy: 100


### PR DESCRIPTION
Changed AGT spread damage from 683 to 483
Changed AGT infantry damage from 48 to 52
Changed Refinery tiberium holding from 700 to 1000.
Changed Silo cost from 300 to 100.