### PR TITLE
Remove redundant burst delay from heavy tanks

### DIFF
--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -60,7 +60,6 @@
 	Inherits: ^Cannon
 	ReloadDelay: 70
 	Burst: 2
-	BurstDelays: 4
 	Warhead@1Dam: SpreadDamage
 		Versus:
 			Heavy: 115


### PR DESCRIPTION
By default burst delay is set to 5. This pr makes it so both heavy tank and mammoth tank have the default. The difference between 5 and 4 is practically invisible to a human eye

![Tanks](https://user-images.githubusercontent.com/37534529/61451054-29d11180-a961-11e9-9a27-567cbd0a24ec.gif)

in this gif mammoth has burst delay of 5 and heavy of 4