### PR TITLE
Balance changes for 2019 July

### DIFF
--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -87,7 +87,6 @@ MIG:
 		BuildAtProductionType: Plane
 		BuildPaletteOrder: 50
 		Prerequisites: ~afld, stek, ~techlevel.high
-		BuildDurationModifier: 50
 		Description: Fast Ground-Attack Plane.\n  Strong vs Buildings, Vehicles\n  Weak vs Infantry, Aircraft
 	Valued:
 		Cost: 2000
@@ -277,7 +276,6 @@ HELI:
 		BuildAtProductionType: Helicopter
 		BuildPaletteOrder: 40
 		Prerequisites: ~hpad, atek, ~techlevel.high
-		BuildDurationModifier: 50
 		Description: Helicopter gunship armed\nwith multi-purpose missiles.\n  Strong vs Buildings, Vehicles, Aircraft\n  Weak vs Infantry
 	Valued:
 		Cost: 2000

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -100,20 +100,9 @@
 	ReloadDelayMultiplier@RANK-ELITE:
 		RequiresCondition: rank-elite
 		Modifier: 75
-	InaccuracyMultiplier@RANK-1:
-		RequiresCondition: rank-veteran == 1
-		Modifier: 90
-	InaccuracyMultiplier@RANK-2:
-		RequiresCondition: rank-veteran == 2
-		Modifier: 80
-	InaccuracyMultiplier@RANK-3:
-		RequiresCondition: rank-veteran == 3
-		Modifier: 70
-	InaccuracyMultiplier@RANK-ELITE:
-		RequiresCondition: rank-elite
-		Modifier: 50
 	SelfHealing@ELITE:
-		Step: 200
+		Step: 0
+		PercentageStep: 5
 		Delay: 100
 		HealIfBelow: 100
 		DamageCooldown: 125
@@ -123,6 +112,7 @@
 		Sequence: rank-veteran-1
 		Palette: effect
 		ReferencePoint: Bottom, Right
+		ValidStances: Ally, Enemy, Neutral
 		RequiresCondition: rank-veteran == 1
 		ZOffset: 256
 	WithDecoration@RANK-2:
@@ -130,6 +120,7 @@
 		Sequence: rank-veteran-2
 		Palette: effect
 		ReferencePoint: Bottom, Right
+		ValidStances: Ally, Enemy, Neutral
 		RequiresCondition: rank-veteran == 2
 		ZOffset: 256
 	WithDecoration@RANK-3:
@@ -137,6 +128,7 @@
 		Sequence: rank-veteran-3
 		Palette: effect
 		ReferencePoint: Bottom, Right
+		ValidStances: Ally, Enemy, Neutral
 		RequiresCondition: rank-veteran == 3
 		ZOffset: 256
 	WithDecoration@RANK-ELITE:
@@ -144,6 +136,7 @@
 		Sequence: rank-elite
 		Palette: effect
 		ReferencePoint: Bottom, Right
+		ValidStances: Ally, Enemy, Neutral
 		RequiresCondition: rank-elite
 		ZOffset: 256
 
@@ -442,6 +435,9 @@
 	MapEditorData:
 		Categories: Infantry
 	EdibleByLeap:
+	DetectCloaked:
+		CloakTypes: Cloak
+		Range: 1c0
 
 ^Soldier:
 	Inherits: ^Infantry
@@ -456,8 +452,6 @@
 	WithInfantryBody:
 		IdleSequences: idle1,idle2
 		StandSequences: stand,stand2
-	DetectCloaked:
-		CloakTypes: Thief
 	AttackFrontal:
 
 ^CivInfantry:

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -5,7 +5,7 @@ DOG:
 		BuildAtProductionType: Dog
 		BuildPaletteOrder: 50
 		Prerequisites: ~kenn, ~techlevel.infonly
-		Description: Anti-infantry unit.\nCan detect cloaked units and spies.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft
+		Description: Anti-infantry unit.\nCan detect spies.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft
 	Valued:
 		Cost: 200
 	Tooltip:
@@ -61,8 +61,6 @@ DOG:
 		Modifier: 150
 		RequiresCondition: run
 	IgnoresDisguise:
-	DetectCloaked:
-		CloakTypes: Cloak, Thief
 	Voiced:
 		VoiceSet: DogVoice
 	-TakeCover:
@@ -297,7 +295,7 @@ SPY:
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 90
 		Prerequisites: ~!infantry.england, dome, ~tent, ~techlevel.medium
-		Description: Infiltrates enemy structures for intel or\nsabotage. Exact effect depends on the\nbuilding infiltrated.\nLoses disguise when attacking.\nCan detect cloaked units and spies.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft\n  Special Ability: Disguised
+		Description: Infiltrates enemy structures for intel or\nsabotage. Exact effect depends on the\nbuilding infiltrated.\nLoses disguise when attacking.\nCan detect spies.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft\n  Special Ability: Disguised
 	Valued:
 		Cost: 500
 	-Tooltip:
@@ -337,8 +335,6 @@ SPY:
 		ZOffset: 256
 		RequiresCondition: disguise
 	IgnoresDisguise:
-	DetectCloaked:
-		CloakTypes: Cloak, Thief
 	Armament:
 		Weapon: SilencedPPK
 	AttackMove:
@@ -368,7 +364,7 @@ E7:
 		BuildPaletteOrder: 120
 		Prerequisites: ~tent, atek, ~techlevel.high
 		BuildLimit: 1
-		Description: Elite commando infantry. Armed with\ndual pistols and C4.\nCan detect cloaked units.\nMaximum 1 can be trained.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles, Aircraft\n  Special Ability: Destroy Building with C4
+		Description: Elite commando infantry. Armed with\ndual pistols and C4.\nMaximum 1 can be trained.\n  Strong vs Infantry, Buildings\n  Weak vs Vehicles, Aircraft\n  Special Ability: Destroy Building with C4
 	Valued:
 		Cost: 1200
 	Tooltip:
@@ -407,8 +403,6 @@ E7:
 		RequiresCondition: produced
 		Voice: Build
 	AnnounceOnKill:
-	DetectCloaked:
-		CloakTypes: Cloak, Thief
 	Voiced:
 		VoiceSet: TanyaVoice
 	ProducibleWithLevel:
@@ -564,7 +558,7 @@ THF:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 110
-		Prerequisites: ~barr, fix, ~techlevel.medium
+		Prerequisites: ~barr, dome, ~techlevel.medium
 		Description: Steals enemy credits.\nHijacks enemy vehicles.\n  Unarmed
 	Valued:
 		Cost: 500
@@ -598,7 +592,7 @@ THF:
 		InitialDelay: 250
 		CloakDelay: 120
 		UncloakOn: Attack, Unload, Infiltrate, Demolish, Move
-		CloakTypes: Cloak, Thief
+		CloakTypes: Cloak
 		IsPlayerPalette: true
 		PauseOnCondition: cloak-force-disabled
 	GrantConditionOnDamageState@UNCLOAK:
@@ -700,9 +694,6 @@ SNIPER:
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical
-	DetectCloaked:
-		CloakTypes: Cloak, Thief
-		Range: 6c0
 	-MustBeDestroyed:
 	ProducibleWithLevel:
 		Prerequisites: barracks.upgraded

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -170,9 +170,6 @@ camera.spyplane:
 	Inherits: CAMERA
 	EditorOnlyTooltip:
 		Name: (support power proxy camera)
-	DetectCloaked:
-		Range: 10c0
-		CloakTypes: Cloak, Thief
 
 SONAR:
 	Inherits: camera.spyplane
@@ -181,6 +178,7 @@ SONAR:
 	-RevealsShroud:
 	DetectCloaked:
 		CloakTypes: Underwater
+		Range: 10c0
 
 FLARE:
 	Immobile:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -75,7 +75,6 @@ MSUB:
 		BuildAtProductionType: Submarine
 		BuildPaletteOrder: 60
 		Prerequisites: ~spen, stek, ~techlevel.high
-		BuildDurationModifier: 50
 		Description: Submerged anti-ground siege unit\nwith anti-air capabilities.\nCan detect other submarines.\n  Strong vs Buildings, Ground units, Aircraft\n  Weak vs Naval units\n  Special Ability: Submerge
 	Valued:
 		Cost: 2000
@@ -199,7 +198,6 @@ CA:
 		BuildAtProductionType: Boat
 		BuildPaletteOrder: 50
 		Prerequisites: ~syrd, atek, ~techlevel.high
-		BuildDurationModifier: 50
 		Description: Very slow long-range ship.\n  Strong vs Buildings, Ground units\n  Weak vs Naval units, Aircraft
 	Valued:
 		Cost: 2400

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -631,7 +631,7 @@ DOME:
 		Queue: Building
 		BuildPaletteOrder: 90
 		Prerequisites: proc, ~techlevel.medium
-		Description: Provides an overview\nof the battlefield.\nCan detect cloaked units.\nRequires power to operate.
+		Description: Provides an overview\nof the battlefield.\nRequires power to operate.
 	Valued:
 		Cost: 1800
 	Tooltip:
@@ -661,10 +661,6 @@ DOME:
 		RequiresCondition: !jammed && !disabled
 	InfiltrateForExploration:
 		Types: SpyInfiltrate
-	DetectCloaked:
-		Range: 10c0
-		RequiresCondition: !disabled
-	RenderDetectionCircle:
 	Power:
 		Amount: -40
 	ProvidesPrerequisite@buildingname:
@@ -1213,7 +1209,7 @@ PROC:
 		DecorationBounds: 72,70,0,-2
 	SelectionDecorations:
 	Targetable:
-		TargetTypes: Ground, Structure, C4, DetonateAttack, ThiefInfiltrate
+		TargetTypes: Ground, Structure, C4, DetonateAttack, ThiefInfiltrate, SpyInfiltrate
 	Health:
 		HP: 90000
 	Armor:
@@ -1238,7 +1234,7 @@ PROC:
 		Facing: 64
 	InfiltrateForCash:
 		Percentage: 50
-		Types: ThiefInfiltrate
+		Types: SpyInfiltrate, ThiefInfiltrate
 		Notification: CreditsStolen
 	WithBuildingBib:
 	WithIdleOverlay@TOP:
@@ -1474,7 +1470,7 @@ AFLD:
 		Icon: spyplane
 		ChargeInterval: 3750
 		Description: Spy Plane
-		LongDesc: Reveals an area of the map\nand cloaked enemy units.
+		LongDesc: Reveals an area of the map.
 		SelectTargetSpeechNotification: SelectTarget
 		EndChargeSpeechNotification: SpyPlaneReady
 		CameraActor: camera.spyplane
@@ -1785,7 +1781,7 @@ KENN:
 		Prerequisites: anypower, ~structures.soviet, ~techlevel.infonly
 		Description: Trains Attack Dogs.
 	Valued:
-		Cost: 100
+		Cost: 200
 	Tooltip:
 		Name: Kennel
 	-GivesBuildableArea:
@@ -1982,7 +1978,7 @@ SBAG:
 		Prerequisites: fact, ~structures.allies, ~techlevel.low
 		Description: Stops infantry and light vehicles.\nCan be crushed by tanks.
 	Valued:
-		Cost: 50
+		Cost: 30
 	CustomSellValue:
 		Value: 0
 	Tooltip:
@@ -2006,7 +2002,7 @@ FENC:
 		Prerequisites: fact, ~structures.soviet, ~techlevel.low
 		Description: Stops infantry and light vehicles.\nCan be crushed by tanks.
 	Valued:
-		Cost: 50
+		Cost: 30
 	CustomSellValue:
 		Value: 0
 	Tooltip:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -190,8 +190,7 @@ V2RL:
 		Queue: Vehicle
 		BuildPaletteOrder: 180
 		Prerequisites: fix, stek, ~vehicles.soviet, ~techlevel.high
-		BuildDurationModifier: 50
-		Description: Big and slow tank, with anti-air capability.\nCan crush concrete walls.\nCan detect cloaked units.\n  Strong vs Vehicles, Infantry, Aircraft\n  Weak vs Nothing
+		Description: Big and slow tank, with anti-air capability.\nCan crush concrete walls.\n  Strong vs Vehicles, Infantry, Aircraft\n  Weak vs Nothing
 	Valued:
 		Cost: 2000
 	Tooltip:
@@ -207,7 +206,7 @@ V2RL:
 		Speed: 50
 		Locomotor: heavytracked
 	RevealsShroud:
-		Range: 7c0
+		Range: 6c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 4c0
@@ -239,8 +238,6 @@ V2RL:
 	SelectionDecorations:
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
-	DetectCloaked:
-		Range: 6c0
 	Selectable:
 		DecorationBounds: 44,38,0,-4
 
@@ -443,7 +440,7 @@ APC:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 30000
+		HP: 35000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -485,7 +482,7 @@ MNLY:
 	Selectable:
 		Priority: 5
 	Health:
-		HP: 15000
+		HP: 30000
 	Armor:
 		Type: Heavy
 	Mobile:
@@ -546,10 +543,9 @@ MGG:
 		Queue: Vehicle
 		BuildPaletteOrder: 150
 		Prerequisites: atek, ~vehicles.england, ~techlevel.high
-		BuildDurationModifier: 50
 		Description: Regenerates the shroud nearby, \nobscuring the area.\n  Unarmed
 	Valued:
-		Cost: 1200
+		Cost: 1000
 	Tooltip:
 		Name: Mobile Gap Generator
 	UpdatesPlayerStatistics:
@@ -586,8 +582,7 @@ MRJ:
 		Queue: Vehicle
 		BuildPaletteOrder: 140
 		Prerequisites: atek, ~vehicles.allies, ~techlevel.high
-		BuildDurationModifier: 50
-		Description: Jams nearby enemy radar domes\nand deflects incoming missiles.\nCan detect cloaked units.\n  Unarmed
+		Description: Jams nearby enemy radar domes\nand deflects incoming missiles.\n  Unarmed
 	Health:
 		HP: 22000
 	Armor:
@@ -611,8 +606,6 @@ MRJ:
 		Range: 5c0
 		DeflectionStances: Neutral, Enemy
 	RenderJammerCircle:
-	DetectCloaked:
-		Range: 6c0
 
 TTNK:
 	Inherits: ^TrackedVehicle
@@ -622,7 +615,6 @@ TTNK:
 		Queue: Vehicle
 		BuildPaletteOrder: 170
 		Prerequisites: tsla, stek, ~vehicles.russia, ~techlevel.high
-		BuildDurationModifier: 50
 		Description: Tank with mounted Tesla coil.\n  Strong vs Infantry, Vehicles, Buildings\n  Weak vs Aircraft
 	Valued:
 		Cost: 1350
@@ -632,7 +624,7 @@ TTNK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 45000
+		HP: 40000
 	Armor:
 		Type: Light
 	Mobile:
@@ -676,7 +668,7 @@ FTRK:
 		Type: Light
 	Mobile:
 		TurnSpeed: 10
-		Speed: 128
+		Speed: 118
 	RevealsShroud:
 		Range: 6c0
 		RevealGeneratedShroud: False
@@ -821,6 +813,9 @@ QTNK:
 	SelectionDecorations:
 	MadTank:
 		DeployedCondition: deployed
+	WithRangeCircle:
+		Color: FFFF0080
+		Range: 7c0
 	Targetable:
 		TargetTypes: Ground, MADTank, Vehicle
 	Selectable:
@@ -835,15 +830,15 @@ STNK:
 		BuildPaletteOrder: 130
 		Prerequisites: atek, ~vehicles.france, ~techlevel.high
 		BuildDurationModifier: 50
-		Description: Lightly armored infantry transport which\ncan cloak. Armed with anti-ground missiles.\nCan detect cloaked units.\n  Strong vs Light armor\n  Weak vs Infantry, Tanks, Aircraft
+		Description: Lightly armored infantry transport which\ncan cloak. Armed with anti-ground missiles.\n  Strong vs Light armor\n  Weak vs Infantry, Tanks, Aircraft
 	Valued:
-		Cost: 1350
+		Cost: 1000
 	Tooltip:
 		Name: Phase Transport
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 30000
+		HP: 35000
 	Armor:
 		Type: Light
 	Mobile:
@@ -880,8 +875,6 @@ STNK:
 	GrantConditionOnDamageState@UNCLOAK:
 		Condition: cloak-force-disabled
 		ValidDamageStates: Critical
-	DetectCloaked:
-		Range: 7c0
 	-MustBeDestroyed:
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -31,7 +31,7 @@
 25mm:
 	Inherits: ^Cannon
 	ReloadDelay: 21
-	Range: 4c0
+	Range: 4c768
 	Report: cannon2.aud
 	Projectile: Bullet
 		Speed: 853

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -111,7 +111,7 @@ HellfireAA:
 MammothTusk:
 	Inherits: ^AntiGroundMissile
 	ReloadDelay: 60
-	Range: 8c0
+	Range: 6c512
 	Burst: 2
 	ValidTargets: Air, Infantry
 	Projectile: Missile

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -47,6 +47,8 @@ FLAK-23-AG:
 	Inherits: ^AACannon
 	Range: 6c0
 	ValidTargets: Ground, Water
+	Projectile: Bullet
+		Blockable: True
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: Air, Ground, Water
 	Warhead@2Eff: CreateEffect

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -5,7 +5,7 @@ ParaBomb:
 	Projectile: GravityBomb
 		Image: PARABOMB
 		OpenSequence: open
-		Velocity: 0, 0, -86
+		Velocity: 0, 0, -40
 		Acceleration: 0, 0, 0
 		Shadow: False
 	Warhead@1Dam: SpreadDamage


### PR DESCRIPTION
# Core Aims
- Streamlining and improving mechanics that became overcomplicated over time
- Addressing the imbalance consequences that Opportunity Fire introduced for turreted actors
- Miscellaneous changes addressing specific past or future issues

This PR is the result of various balance works been initiated and commenced by numerous people, as well as countless discussions held over the past several months. 

# Stealth Rework

Currently stealth mechanics are targeted at just one unit, slightly at two others (Phase Transport, Thief (when idle) and Camo Pillbox). For it to work we have a large number of arbitrary stealth detectors - Dogs, Spies, Tanya, Mobile Radar Jammers, Mammonth Tanks, Spy Plane, Radar Dome. It is not easy to memorise this list for newer players. It also is not good game design to force players to include Dogs / Spies into army compositions as they require a great deal of micro management, Dogs are faster then infantry and Spies do not adhere to common attack-move. Note that there is no counter-play against Spy detection as they just disguise as their own. Mammoths on the other hand are easy to use as detectors, but they are a staple Soviet unit that is built regardless of Phase Transport presence, making it commonly hard-countered without that being intentional. All of this mess is just to counter one faction-specific unit. Thieves have a different infantry detection rule making things even worse as it is not explicitly clear.

   A decision was made to streamline stealth down to how it worked in the original and in TD - just infantry (1 cell) and defence structures (6 cells).

- Removed detection from Radar Dome, Phase Transport, Mammoth Tanks, Mobile Radar Jammer, Spy Plane
- Added DetectCloaked: 1c0 to ^Infantry

The only significant change in gameplay is that Phase Transport infantry crushes become less viable. Subsequently Phase Transport is getting buffed, shifting its role from a cheesy blob crusher more to a stealth transport and occasional blob crusher

### Phase Transport
- Transport cost from 1350 to 1000 
- Health from 30000 to 35000
   - Phase Transport will survive a Tesla Coil hit instead of being one-shot

# Veterancy
- Removed accuracy improvements
   - It is completely redundant for most units and in case of cruisers it nerfs their anti-infantry capabilities
- Regeneration rate on elite from 200 hp per 4 seconds to 5% per 4 seconds
   - Low health units regenerate a lot faster than those with higher health pools. Now it is all percentage based. For reference Heavy Tank normally takes more then seven minutes to fully regenerate
- Ranks are visible to opponents
   - Gives better counterplay
   - After a spy infiltration its victim will now see that it happened

# Changes in Response to Opportunity Fire

### APC 
- Health from 30000 to 35000
   - Opportunity fire has buffed all light vehicles except for the APC. This change counteracts their relative nerf and resolves this dynamic where APC drops get shut down by 1 Tesla Coil while Allies have a far more difficult time dealing with it
### Mobile Flak
- Speed from 128 to 118
   - Mobile Flak is a powerful unit that is useful in all stages of the game. It is a counter to almost all radar tech units and was significantly buffed with the introduction of opportunity fire. It is being slowed down to the speed of Hinds, that gives them a better chance to fly away 
- It can no longer shoot over walls at ground targets
   - It is implausible and has very minor balance implications
### Tesla Tank 
- Health from 45000 to 40000
   - Tesla Tanks were on the threshold between balanced and overpowered, opportunity fire has tipped that scale and coupled with improved Mobile Flaks Tesla Tank spam became very hard to stop once gaining traction
   - Yaks / Hinds are now able to kill a Tesla Tank with one ammo clip
- Note: the build time decrease below is going to affect it significantly as it is one of the few high tech units that is spammed
### Mammoth Tank
- Tusk Missile range reduced from 8c0 to 6c512
   - They are over-performing against infantry and aircraft as they now able to fire when retreating
   - For reference V2 Rocket Launcher has 10c0 weapon range, meaning that Mammoth Tusk is just 2 cells short of it
- Vision range from 7c0 to 6c0
   - Same as other tanks with the exception of Light Tank (5c0)
- Note: the build time decrease below is going to affect it significantly as it is one of the few high tech units that is spammed

# Miscellaneous changes

### High tech units no longer build faster
- This high tech unit buff is not explicitly clear and has multiple exceptions
- High tech units should be made not because they build faster, but because they are valuable tools. If high tech units underperform they need to be buffed individually
### Thief
- Moved from Service Depot tech to Radar tech
   - Hijack fix made Thieves into very powerful tools, this change makes them require additional investment into tech and moves them to a later stages of the game where stealing Ore Trucks is harder and less significant
- Note: idle Thieves will be detected by infantry in 1c0 range instead of 5c0
### Light Tank 
- Weapon range from 4c0 to 4c768
   - Light Tank has poor staying power. It fills the same roles Medium Tank which when compared is better at them. This buff will make it easier to use it later on the game for sniping Artillery, V2s and Mobile Flaks
   - Its weapon range is now the same as all other tanks
### Spy 
- Can steal money from Refineries
   - Getting veterancy is a one-time use for Spies, after which they can only be used for light scouting and for sabotaging Power Plants, the former being very situational. Removal of this feature in favour of Thieves was not thought of in this regard
### Kennel
- Cost from 100 to 200
   - In the previous patch Dog vision was increases by half a cell with the goal of making Dog not only have a vision advantage perpendicularly but also diagonally. It tilted the current meta in favour of Soviets in early game as a single dog provides a very significant advantage in fights that Allies can not keep up with until acquiring a Ranger. Increasing Kennels cost demands a larger commitment for utilising this strategy but does not punish players who want to open more than 1 Dog
### Parabombs
- Projectile Z velocity from -86 to -40
   - Counters the introduced ability to choose the direction of support powers. Parabombs were always too potent at the map edges but randomness balanced it for the most part. With its removal a nerf is necessary. Reducing Bomb fall speed makes them easier to dodge
   - Since directional support powers are not in a finished version of the game we can not do proper testing. Although it does not take a leap of logic to figure out how Parabombs will work when they get the perfect angle every time. More nerfs may be necessary in the future
### Mobile Gap Generator 
- Cost from 1200 to 1000
   - As a non-combat unit, MGG has a very low value/cost ratio. This is one of the easier changes of a potential Allied tech tier rework
### Minelayer
 - Health from 15000 to 30000
   - Yaks will require more than one ammo clip to kill a single Minelayer unit
### Sandbags / Wire Fence 
 - Cost from 50 to 30
   - Improves usefulness as it is now builds faster
### MAD Tank
- Added weapon range circle

Note that this list does not contain all planned changes as they still need a more refinement, main ones being: Chrono Tank overhaul, second half of veterancy changes