### PR TITLE
Cache IMove in Actor

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -51,6 +51,7 @@ namespace OpenRA
 
 		public IEffectiveOwner EffectiveOwner { get; private set; }
 		public IOccupySpace OccupiesSpace { get; private set; }
+		public IMove Movement { get; private set; }
 		public ITargetable[] Targetables { get; private set; }
 
 		public bool IsIdle { get { return CurrentActivity == null; } }
@@ -114,6 +115,7 @@ namespace OpenRA
 			// PERF: Cache all these traits as soon as the actor is created. This is a fairly cheap one-off cost per
 			// actor that allows us to provide some fast implementations of commonly used methods that are relied on by
 			// performance-sensitive parts of the core game engine, such as pathfinding, visibility and rendering.
+			Movement = OccupiesSpace as IMove;
 			EffectiveOwner = TraitOrDefault<IEffectiveOwner>();
 			facing = TraitOrDefault<IFacing>();
 			health = TraitOrDefault<IHealth>();

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using OpenRA.Activities;
 using OpenRA.FileSystem;
 using OpenRA.Graphics;
 using OpenRA.Network;
@@ -30,6 +31,15 @@ namespace OpenRA.Traits
 		Heavy = 8,
 		Critical = 16,
 		Dead = 32
+	}
+
+	[Flags]
+	public enum MovementType
+	{
+		None = 0,
+		Horizontal = 1,
+		Vertical = 2,
+		Turn = 4
 	}
 
 	/// <summary>
@@ -455,6 +465,27 @@ namespace OpenRA.Traits
 	}
 
 	public interface IMoveInfo : ITraitInfoInterface { }
+
+	public interface IMove
+	{
+		Activity MoveTo(CPos cell, int nearEnough);
+		Activity MoveTo(CPos cell, Actor ignoreActor);
+		Activity MoveWithinRange(Target target, WDist range,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null);
+		Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null);
+		Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null);
+		Activity MoveToTarget(Actor self, Target target,
+			WPos? initialTargetPosition = null, Color? targetLineColor = null);
+		Activity MoveIntoWorld(Actor self, CPos cell, SubCell subCell = SubCell.Any);
+		Activity MoveIntoTarget(Actor self, Target target);
+		Activity VisualMove(Actor self, WPos fromPos, WPos toPos);
+		int EstimatedMoveDuration(Actor self, WPos fromPos, WPos toPos);
+		CPos NearestMoveableCell(CPos target);
+		MovementType CurrentMovementTypes { get; set; }
+		bool CanEnterTargetNow(Actor self, Target target);
+	}
 
 	[RequireExplicitImplementation]
 	public interface IGameOver { void GameOver(World world); }

--- a/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
+++ b/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
@@ -19,7 +19,6 @@ namespace OpenRA.Mods.Common.Activities
 	public class TakeOff : Activity
 	{
 		readonly Aircraft aircraft;
-		readonly IMove move;
 		Target target;
 		bool moveToRallyPoint;
 		bool assignTargetOnFirstRun;
@@ -27,7 +26,6 @@ namespace OpenRA.Mods.Common.Activities
 		public TakeOff(Actor self, Target target)
 		{
 			aircraft = self.Trait<Aircraft>();
-			move = self.Trait<IMove>();
 			this.target = target;
 		}
 
@@ -93,7 +91,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (!aircraft.Info.VTOL && assignTargetOnFirstRun)
 					return true;
 
-				QueueChild(new AttackMoveActivity(self, () => move.MoveToTarget(self, target)));
+				QueueChild(new AttackMoveActivity(self, () => self.Movement.MoveToTarget(self, target)));
 				moveToRallyPoint = false;
 				return false;
 			}

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Activities
 			facing = self.Trait<IFacing>();
 			positionable = self.Trait<IPositionable>();
 
-			move = allowMovement ? self.TraitOrDefault<IMove>() : null;
+			move = allowMovement ? self.Movement : null;
 
 			// The target may become hidden between the initial order request and the first tick (e.g. if queued)
 			// Moving to any position (even if quite stale) is still better than immediately giving up

--- a/OpenRA.Mods.Common/Activities/DeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverResources.cs
@@ -18,13 +18,11 @@ namespace OpenRA.Mods.Common.Activities
 {
 	public class DeliverResources : Activity
 	{
-		readonly IMove movement;
 		readonly Harvester harv;
 		readonly Actor targetActor;
 
 		public DeliverResources(Actor self, Actor targetActor = null)
 		{
-			movement = self.Trait<IMove>();
 			harv = self.Trait<Harvester>();
 			this.targetActor = targetActor;
 		}
@@ -60,7 +58,7 @@ namespace OpenRA.Mods.Common.Activities
 				foreach (var n in self.TraitsImplementing<INotifyHarvesterAction>())
 					n.MovingToRefinery(self, proc);
 
-				QueueChild(movement.MoveTo(proc.Location + iao.DeliveryOffset, 0));
+				QueueChild(self.Movement.MoveTo(proc.Location + iao.DeliveryOffset, 0));
 				return false;
 			}
 

--- a/OpenRA.Mods.Common/Activities/Enter.cs
+++ b/OpenRA.Mods.Common/Activities/Enter.cs
@@ -22,7 +22,6 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		enum EnterState { Approaching, Entering, Exiting }
 
-		readonly IMove move;
 		readonly Color? targetLineColor;
 
 		Target target;
@@ -32,7 +31,6 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected Enter(Actor self, Target target, Color? targetLineColor = null)
 		{
-			move = self.Trait<IMove>();
 			this.target = target;
 			this.targetLineColor = targetLineColor;
 			ChildHasPriority = false;
@@ -99,11 +97,11 @@ namespace OpenRA.Mods.Common.Activities
 						return true;
 
 					// We are not next to the target - lets fix that
-					if (target.Type != TargetType.Invalid && !move.CanEnterTargetNow(self, target))
+					if (target.Type != TargetType.Invalid && !self.Movement.CanEnterTargetNow(self, target))
 					{
 						// Target lines are managed by this trait, so we do not pass targetLineColor
 						var initialTargetPosition = (useLastVisibleTarget ? lastVisibleTarget : target).CenterPosition;
-						QueueChild(move.MoveToTarget(self, target, initialTargetPosition));
+						QueueChild(self.Movement.MoveToTarget(self, target, initialTargetPosition));
 						return false;
 					}
 
@@ -116,7 +114,7 @@ namespace OpenRA.Mods.Common.Activities
 					if (TryStartEnter(self, target.Actor))
 					{
 						lastState = EnterState.Entering;
-						QueueChild(move.MoveIntoTarget(self, target));
+						QueueChild(self.Movement.MoveIntoTarget(self, target));
 						return false;
 					}
 
@@ -136,7 +134,7 @@ namespace OpenRA.Mods.Common.Activities
 						OnEnterComplete(self, target.Actor);
 
 					lastState = EnterState.Exiting;
-					QueueChild(move.MoveIntoWorld(self, self.Location));
+					QueueChild(self.Movement.MoveIntoWorld(self, self.Location));
 					return false;
 				}
 

--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			harv = self.Trait<Harvester>();
 			harvInfo = self.Info.TraitInfo<HarvesterInfo>();
-			mobile = self.Trait<Mobile>();
+			mobile = self.Movement as Mobile;
 			locomotorInfo = mobile.Info.LocomotorInfo;
 			claimLayer = self.World.WorldActor.Trait<ResourceClaimLayer>();
 			pathFinder = self.World.WorldActor.Trait<IPathFinder>();

--- a/OpenRA.Mods.Common/Activities/HarvestResource.cs
+++ b/OpenRA.Mods.Common/Activities/HarvestResource.cs
@@ -24,16 +24,14 @@ namespace OpenRA.Mods.Common.Activities
 		readonly ResourceClaimLayer claimLayer;
 		readonly ResourceLayer resLayer;
 		readonly BodyOrientation body;
-		readonly IMove move;
 		readonly CPos targetCell;
 
 		public HarvestResource(Actor self, CPos targetCell)
 		{
 			harv = self.Trait<Harvester>();
 			harvInfo = self.Info.TraitInfo<HarvesterInfo>();
-			facing = self.Trait<IFacing>();
+			facing = self.Movement as IFacing;
 			body = self.Trait<BodyOrientation>();
-			move = self.Trait<IMove>();
 			claimLayer = self.World.WorldActor.Trait<ResourceClaimLayer>();
 			resLayer = self.World.WorldActor.Trait<ResourceLayer>();
 			this.targetCell = targetCell;
@@ -59,7 +57,7 @@ namespace OpenRA.Mods.Common.Activities
 					n.MovingToResources(self, targetCell);
 
 				self.SetTargetLine(Target.FromCell(self.World, targetCell), Color.Red, false);
-				QueueChild(move.MoveTo(targetCell, 2));
+				QueueChild(self.Movement.MoveTo(targetCell, 2));
 				return false;
 			}
 

--- a/OpenRA.Mods.Common/Activities/Hunt.cs
+++ b/OpenRA.Mods.Common/Activities/Hunt.cs
@@ -20,11 +20,9 @@ namespace OpenRA.Mods.Common.Activities
 	public class Hunt : Activity
 	{
 		readonly IEnumerable<Actor> targets;
-		readonly IMove move;
 
 		public Hunt(Actor self)
 		{
-			move = self.Trait<IMove>();
 			var attack = self.Trait<AttackBase>();
 			targets = self.World.ActorsHavingTrait<Huntable>().Where(
 				a => self != a && !a.IsDead && a.IsInWorld && a.AppearsHostileTo(self)
@@ -40,7 +38,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (target == null)
 				return false;
 
-			QueueChild(new AttackMoveActivity(self, () => move.MoveTo(target.Location, 2)));
+			QueueChild(new AttackMoveActivity(self, () => self.Movement.MoveTo(target.Location, 2)));
 			QueueChild(new Wait(25));
 			return false;
 		}

--- a/OpenRA.Mods.Common/Activities/Move/Drag.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Drag.cs
@@ -26,8 +26,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Drag(Actor self, WPos start, WPos end, int length)
 		{
-			positionable = self.Trait<IPositionable>();
-			disableable = self.TraitOrDefault<IMove>() as IDisabledTrait;
+			positionable = self.Movement as IPositionable;
+			disableable = self.Movement as IDisabledTrait;
 			this.start = start;
 			this.end = end;
 			this.length = length;

--- a/OpenRA.Mods.Common/Activities/Move/Follow.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Follow.cs
@@ -20,7 +20,6 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly WDist minRange;
 		readonly WDist maxRange;
-		readonly IMove move;
 		readonly Color? targetLineColor;
 		Target target;
 		Target lastVisibleTarget;
@@ -34,7 +33,6 @@ namespace OpenRA.Mods.Common.Activities
 			this.minRange = minRange;
 			this.maxRange = maxRange;
 			this.targetLineColor = targetLineColor;
-			move = self.Trait<IMove>();
 
 			// The target may become hidden between the initial order request and the first tick (e.g. if queued)
 			// Moving to any position (even if quite stale) is still better than immediately giving up
@@ -83,7 +81,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			// Move into range
 			wasMovingWithinRange = true;
-			QueueChild(move.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, targetLineColor));
+			QueueChild(self.Movement.MoveWithinRange(target, minRange, maxRange, checkTarget.CenterPosition, targetLineColor));
 			return false;
 		}
 	}

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Activities
 		// Ignores lane bias and nearby units
 		public Move(Actor self, CPos destination)
 		{
-			mobile = self.Trait<Mobile>();
+			mobile = self.Movement as Mobile;
 
 			getPath = () =>
 			{
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Move(Actor self, CPos destination, WDist nearEnough, Actor ignoreActor = null, bool evaluateNearestMovableCell = false)
 		{
-			mobile = self.Trait<Mobile>();
+			mobile = self.Movement as Mobile;
 
 			getPath = () =>
 			{
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Move(Actor self, CPos destination, SubCell subCell, WDist nearEnough)
 		{
-			mobile = self.Trait<Mobile>();
+			mobile = self.Movement as Mobile;
 
 			getPath = () => self.World.WorldActor.Trait<IPathFinder>()
 				.FindUnitPathToRange(mobile.FromCell, subCell, self.World.Map.CenterOfSubCell(destination, subCell), nearEnough, self);
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Move(Actor self, Target target, WDist range)
 		{
-			mobile = self.Trait<Mobile>();
+			mobile = self.Movement as Mobile;
 
 			getPath = () =>
 			{
@@ -110,7 +110,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Move(Actor self, Func<List<CPos>> getPath)
 		{
-			mobile = self.Trait<Mobile>();
+			mobile = self.Movement as Mobile;
 
 			this.getPath = getPath;
 

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			this.target = target;
 			this.targetLineColor = targetLineColor;
-			Mobile = self.Trait<Mobile>();
+			Mobile = self.Movement as Mobile;
 			pathFinder = self.World.WorldActor.Trait<IPathFinder>();
 			domainIndex = self.World.WorldActor.Trait<DomainIndex>();
 			ChildHasPriority = false;

--- a/OpenRA.Mods.Common/Activities/Move/VisualMoveIntoTarget.cs
+++ b/OpenRA.Mods.Common/Activities/Move/VisualMoveIntoTarget.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public VisualMoveIntoTarget(Actor self, Target target, WDist targetMovementThreshold)
 		{
-			mobile = self.Trait<Mobile>();
+			mobile = self.Movement as Mobile;
 			this.target = target;
 			this.targetMovementThreshold = targetMovementThreshold;
 		}

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -19,7 +19,6 @@ namespace OpenRA.Mods.Common.Activities
 	public class PickupUnit : Activity
 	{
 		readonly Actor cargo;
-		readonly IMove movement;
 
 		readonly Carryall carryall;
 		readonly IFacing carryallFacing;
@@ -42,7 +41,6 @@ namespace OpenRA.Mods.Common.Activities
 			carryableFacing = cargo.Trait<IFacing>();
 			carryableBody = cargo.Trait<BodyOrientation>();
 
-			movement = self.Trait<IMove>();
 			carryall = self.Trait<Carryall>();
 			carryallFacing = self.Trait<IFacing>();
 
@@ -79,7 +77,7 @@ namespace OpenRA.Mods.Common.Activities
 			switch (state)
 			{
 				case PickupState.Intercept:
-					QueueChild(movement.MoveWithinRange(Target.FromActor(cargo), WDist.FromCells(4), targetLineColor: Color.Yellow));
+					QueueChild(self.Movement.MoveWithinRange(Target.FromActor(cargo), WDist.FromCells(4), targetLineColor: Color.Yellow));
 					state = PickupState.LockCarryable;
 					return false;
 

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Activities
 			rearmable = self.TraitOrDefault<Rearmable>();
 			notifyResupplies = host.TraitsImplementing<INotifyResupply>().ToArray();
 			transportCallers = self.TraitsImplementing<ICallForTransport>().ToArray();
-			move = self.Trait<IMove>();
+			move = self.Movement;
 			aircraft = move as Aircraft;
 
 			var cannotRepairAtHost = health == null || health.DamageState == DamageState.Undamaged

--- a/OpenRA.Mods.Common/Activities/Turn.cs
+++ b/OpenRA.Mods.Common/Activities/Turn.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Turn(Actor self, int desiredFacing)
 		{
-			mobile = self.TraitOrDefault<Mobile>();
+			mobile = self.Movement as Mobile;
 			facing = self.Trait<IFacing>();
 			this.desiredFacing = desiredFacing;
 		}

--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -116,8 +116,8 @@ namespace OpenRA.Mods.Common.Activities
 					if (actor.Disposed)
 						return;
 
-					var move = actor.Trait<IMove>();
-					var pos = actor.Trait<IPositionable>();
+					var move = actor.Movement;
+					var pos = move as IPositionable;
 
 					actor.CancelActivity();
 					pos.SetVisualPosition(actor, spawn);

--- a/OpenRA.Mods.Common/Effects/SpawnActorEffect.cs
+++ b/OpenRA.Mods.Common/Effects/SpawnActorEffect.cs
@@ -25,7 +25,6 @@ namespace OpenRA.Mods.Common.Effects
 		readonly Actor actor;
 		readonly CPos[] pathAfterSpawn;
 		readonly Activity activityAtDestination;
-		readonly IMove move;
 		int remainingDelay;
 
 		public SpawnActorEffect(Actor actor)
@@ -40,7 +39,6 @@ namespace OpenRA.Mods.Common.Effects
 			remainingDelay = delay;
 			this.pathAfterSpawn = pathAfterSpawn;
 			this.activityAtDestination = activityAtDestination;
-			move = actor.TraitOrDefault<IMove>();
 		}
 
 		public void Tick(World world)
@@ -49,9 +47,9 @@ namespace OpenRA.Mods.Common.Effects
 				return;
 
 			world.Add(actor);
-			if (move != null)
+			if (actor.Movement != null)
 				for (var j = 0; j < pathAfterSpawn.Length; j++)
-					actor.QueueActivity(move.MoveTo(pathAfterSpawn[j], 2));
+					actor.QueueActivity(actor.Movement.MoveTo(pathAfterSpawn[j], 2));
 
 			if (activityAtDestination != null)
 				actor.QueueActivity(activityAtDestination);

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -306,7 +306,7 @@ namespace OpenRA.Mods.Common.Orders
 
 			var blockers = allTiles.SelectMany(world.ActorMap.GetActorsAt)
 				.Where(a => a.Owner == queue.Actor.Owner && a.IsIdle)
-				.Select(a => new TraitPair<Mobile>(a, a.TraitOrDefault<Mobile>()));
+				.Select(a => new TraitPair<Mobile>(a, a.Movement as Mobile));
 
 			foreach (var blocker in blockers.Where(x => x.Trait != null))
 			{

--- a/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/ReinforcementsGlobal.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Scripting
 
 		void Move(Actor actor, CPos dest)
 		{
-			var move = actor.TraitOrDefault<IMove>();
+			var move = actor.Movement;
 			if (move == null)
 				return;
 

--- a/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Scripting
 		public CombatProperties(ScriptContext context, Actor self)
 			: base(context, self)
 		{
-			move = self.Trait<IMove>();
+			move = self.Movement;
 		}
 
 		[ScriptActorPropertyActivity]

--- a/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Scripting
 		public MobileProperties(ScriptContext context, Actor self)
 			: base(context, self)
 		{
-			mobile = self.Trait<Mobile>();
+			mobile = self.Movement as Mobile;
 		}
 
 		[ScriptActorPropertyActivity]

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -621,8 +621,9 @@ namespace OpenRA.Mods.Common.Traits
 
 			// We are not blocked by actors we can nudge out of the way
 			// TODO: Generalize blocker checks and handling here and in Locomotor
+			var otherActorMobile = otherActor.Movement as Mobile;
 			if (!blockedByMobile && self.Owner.Stances[otherActor.Owner] == Stance.Ally &&
-				otherActor.TraitOrDefault<Mobile>() != null && otherActor.CurrentActivity == null)
+				otherActorMobile != null && otherActor.CurrentActivity == null)
 				return false;
 
 			// PERF: Only perform ITemporaryBlocker trait look-up if mod/map rules contain any actors that are temporary blockers

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -70,6 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected IFacing facing;
 		protected IPositionable positionable;
+		protected Mobile mobile;
 		protected INotifyAiming[] notifyAiming;
 		protected Func<IEnumerable<Armament>> getArmaments;
 
@@ -87,6 +88,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			facing = self.TraitOrDefault<IFacing>();
 			positionable = self.TraitOrDefault<IPositionable>();
+			mobile = self.Movement as Mobile;
 			notifyAiming = self.TraitsImplementing<INotifyAiming>().ToArray();
 
 			getArmaments = InitializeGetArmaments(self);
@@ -145,7 +147,6 @@ namespace OpenRA.Mods.Common.Traits
 			if (!HasAnyValidWeapons(target))
 				return false;
 
-			var mobile = self.TraitOrDefault<Mobile>();
 			if (mobile != null && !mobile.CanInteractWithGroundLayer(self))
 				return false;
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -35,7 +35,6 @@ namespace OpenRA.Mods.Common.Traits
 		public Target RequestedTarget { get; private set; }
 		public Target OpportunityTarget { get; private set; }
 
-		Mobile mobile;
 		AutoTarget autoTarget;
 		bool requestedForceAttack;
 		Activity requestedTargetPresetForActivity;
@@ -70,7 +69,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override void Created(Actor self)
 		{
-			mobile = self.TraitOrDefault<Mobile>();
 			autoTarget = self.TraitOrDefault<AutoTarget>();
 			base.Created(self);
 		}
@@ -227,7 +225,7 @@ namespace OpenRA.Mods.Common.Traits
 			public AttackActivity(Actor self, Target target, bool allowMove, bool forceAttack)
 			{
 				attack = self.Trait<AttackFollow>();
-				move = allowMove ? self.TraitOrDefault<IMove>() : null;
+				move = allowMove ? self.Movement : null;
 				revealsShroud = self.TraitsImplementing<RevealsShroud>().ToArray();
 
 				this.target = target;

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -42,11 +42,9 @@ namespace OpenRA.Mods.Common.Traits
 	class AttackMove : IResolveOrder, IOrderVoice
 	{
 		public readonly AttackMoveInfo Info;
-		readonly IMove move;
 
 		public AttackMove(Actor self, AttackMoveInfo info)
 		{
-			move = self.Trait<IMove>();
 			Info = info;
 		}
 
@@ -76,10 +74,10 @@ namespace OpenRA.Mods.Common.Traits
 				if (!Info.MoveIntoShroud && !self.Owner.Shroud.IsExplored(cell))
 					return;
 
-				var targetLocation = move.NearestMoveableCell(cell);
+				var targetLocation = self.Movement.NearestMoveableCell(cell);
 				self.SetTargetLine(Target.FromCell(self.World, targetLocation), Color.Red);
 				var assaultMoving = order.OrderString == "AssaultMove";
-				self.QueueActivity(new AttackMoveActivity(self, () => move.MoveTo(targetLocation, 1), assaultMoving));
+				self.QueueActivity(new AttackMoveActivity(self, () => self.Movement.MoveTo(targetLocation, 1), assaultMoving));
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/CaptureManager.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureManager.cs
@@ -59,7 +59,6 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly CaptureManagerInfo info;
 		ConditionManager conditionManager;
-		IMove move;
 		ICaptureProgressWatcher[] progressWatchers;
 
 		BitSet<CaptureType> allyCapturableTypes;
@@ -91,7 +90,6 @@ namespace OpenRA.Mods.Common.Traits
 		void INotifyCreated.Created(Actor self)
 		{
 			conditionManager = self.TraitOrDefault<ConditionManager>();
-			move = self.TraitOrDefault<IMove>();
 			progressWatchers = self.TraitsImplementing<ICaptureProgressWatcher>().ToArray();
 
 			enabledCapturable = self.TraitsImplementing<Capturable>()
@@ -224,10 +222,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (progressWatchers.Any() || targetManager.progressWatchers.Any())
 			{
 				currentTargetTotal = captures.Info.CaptureDelay;
-				if (move != null && captures.Info.ConsumedByCapture)
+				if (self.Movement != null && captures.Info.ConsumedByCapture)
 				{
 					var pos = target.GetTargetablePositions().PositionClosestTo(self.CenterPosition);
-					currentTargetTotal += move.EstimatedMoveDuration(self, self.CenterPosition, pos);
+					currentTargetTotal += self.Movement.EstimatedMoveDuration(self, self.CenterPosition, pos);
 				}
 
 				foreach (var w in progressWatchers)

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -70,7 +70,6 @@ namespace OpenRA.Mods.Common.Traits
 		readonly AircraftInfo aircraftInfo;
 		readonly Aircraft aircraft;
 		readonly BodyOrientation body;
-		readonly IMove move;
 		readonly IFacing facing;
 		readonly Actor self;
 
@@ -93,11 +92,10 @@ namespace OpenRA.Mods.Common.Traits
 			Carryable = null;
 			State = CarryallState.Idle;
 
-			aircraftInfo = self.Info.TraitInfoOrDefault<AircraftInfo>();
-			aircraft = self.Trait<Aircraft>();
 			body = self.Trait<BodyOrientation>();
-			move = self.Trait<IMove>();
-			facing = self.Trait<IFacing>();
+			facing = self.Movement as IFacing;
+			aircraft = self.Movement as Aircraft;
+			aircraftInfo = self.Info.TraitInfoOrDefault<AircraftInfo>();
 			this.self = self;
 		}
 
@@ -176,7 +174,8 @@ namespace OpenRA.Mods.Common.Traits
 			self.World.ScreenMap.AddOrUpdate(self);
 
 			CarryableOffset = OffsetForCarryable(self, carryable);
-			landableTerrainTypes = Carryable.Trait<Mobile>().Info.LocomotorInfo.TerrainSpeeds.Keys.ToHashSet();
+			var mobile = Carryable.Movement as Mobile;
+			landableTerrainTypes = mobile.Info.LocomotorInfo.TerrainSpeeds.Keys.ToHashSet();
 
 			return true;
 		}
@@ -296,7 +295,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!aircraftInfo.MoveIntoShroud && !self.Owner.Shroud.IsExplored(cell))
 					return;
 
-				var targetLocation = move.NearestMoveableCell(cell);
+				var targetLocation = self.Movement.NearestMoveableCell(cell);
 				self.SetTargetLine(Target.FromCell(self.World, targetLocation), Color.Yellow);
 				self.QueueActivity(order.Queued, new DeliverUnit(self, order.Target, Info.DropRange));
 			}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -72,7 +72,6 @@ namespace OpenRA.Mods.Common.Traits
 		readonly Actor self;
 		readonly bool checkTerrainType;
 		readonly bool canTurn;
-		readonly IMove move;
 
 		DeployState deployState;
 		ConditionManager conditionManager;
@@ -88,7 +87,6 @@ namespace OpenRA.Mods.Common.Traits
 			self = init.Self;
 			checkTerrainType = info.AllowedTerrainTypes.Count > 0;
 			canTurn = self.Info.HasTraitInfo<IFacingInfo>();
-			move = self.TraitOrDefault<IMove>();
 			if (init.Contains<DeployStateInit>())
 				deployState = init.Get<DeployStateInit, DeployState>();
 		}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnMovement.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnMovement.cs
@@ -28,15 +28,11 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class GrantConditionOnMovement : ConditionalTrait<GrantConditionOnMovementInfo>, INotifyMoving
 	{
-		readonly IMove movement;
 		ConditionManager conditionManager;
 		int conditionToken = ConditionManager.InvalidConditionToken;
 
 		public GrantConditionOnMovement(Actor self, GrantConditionOnMovementInfo info)
-			: base(info)
-		{
-			movement = self.Trait<IMove>();
-		}
+			: base(info) { }
 
 		protected override void Created(Actor self)
 		{
@@ -64,12 +60,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override void TraitEnabled(Actor self)
 		{
-			UpdateCondition(self, movement.CurrentMovementTypes);
+			UpdateCondition(self, self.Movement.CurrentMovementTypes);
 		}
 
 		protected override void TraitDisabled(Actor self)
 		{
-			UpdateCondition(self, movement.CurrentMovementTypes);
+			UpdateCondition(self, self.Movement.CurrentMovementTypes);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Crushable.cs
+++ b/OpenRA.Mods.Common/Traits/Crushable.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!CrushableInner(crushClasses, crusher.Owner))
 				return;
 
-			var mobile = self.TraitOrDefault<Mobile>();
+			var mobile = self.Movement as Mobile;
 			if (mobile != null && self.World.SharedRandom.Next(100) <= Info.WarnProbability)
 				mobile.Nudge(self, crusher, true);
 		}
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			Game.Sound.Play(SoundType.World, Info.CrushSound, crusher.CenterPosition);
 
-			var crusherMobile = crusher.TraitOrDefault<Mobile>();
+			var crusherMobile = crusher.Movement as Mobile;
 			self.Kill(crusher, crusherMobile != null ? crusherMobile.Info.LocomotorInfo.CrushDamageTypes : default(BitSet<DamageType>));
 		}
 

--- a/OpenRA.Mods.Common/Traits/EjectOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/EjectOnDeath.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Traits
 					w.Add(pilot);
 					pilotPositionable.SetPosition(pilot, pilotCell, pilotSubCell);
 
-					var pilotMobile = pilot.TraitOrDefault<Mobile>();
+					var pilotMobile = pilot.Movement as Mobile;
 					if (pilotMobile != null)
 						pilotMobile.Nudge(pilot, pilot, true);
 				});

--- a/OpenRA.Mods.Common/Traits/EntersTunnels.cs
+++ b/OpenRA.Mods.Common/Traits/EntersTunnels.cs
@@ -38,13 +38,11 @@ namespace OpenRA.Mods.Common.Traits
 	public class EntersTunnels : IIssueOrder, IResolveOrder, IOrderVoice, IObservesVariables
 	{
 		readonly EntersTunnelsInfo info;
-		readonly IMove move;
 		bool requireForceMove;
 
 		public EntersTunnels(Actor self, EntersTunnelsInfo info)
 		{
 			this.info = info;
-			move = self.Trait<IMove>();
 		}
 
 		public IEnumerable<IOrderTargeter> Orders
@@ -86,8 +84,8 @@ namespace OpenRA.Mods.Common.Traits
 				self.CancelActivity();
 
 			self.SetTargetLine(Target.FromCell(self.World, tunnel.Exit.Value), Color.Green);
-			self.QueueActivity(move.MoveTo(tunnel.Entrance, tunnel.NearEnough));
-			self.QueueActivity(move.MoveTo(tunnel.Exit.Value, tunnel.NearEnough));
+			self.QueueActivity(self.Movement.MoveTo(tunnel.Entrance, tunnel.NearEnough));
+			self.QueueActivity(self.Movement.MoveTo(tunnel.Exit.Value, tunnel.NearEnough));
 		}
 
 		IEnumerable<VariableObserver> IObservesVariables.GetVariableObservers()

--- a/OpenRA.Mods.Common/Traits/Guard.cs
+++ b/OpenRA.Mods.Common/Traits/Guard.cs
@@ -24,19 +24,13 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new Guard(this); }
 	}
 
-	public class Guard : IResolveOrder, IOrderVoice, INotifyCreated
+	public class Guard : IResolveOrder, IOrderVoice
 	{
 		readonly GuardInfo info;
-		IMove move;
 
 		public Guard(GuardInfo info)
 		{
 			this.info = info;
-		}
-
-		void INotifyCreated.Created(Actor self)
-		{
-			move = self.Trait<IMove>();
 		}
 
 		public void ResolveOrder(Actor self, Order order)
@@ -56,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 			self.SetTargetLine(target, Color.Yellow);
 
 			var range = target.Actor.Info.TraitInfo<GuardableInfo>().Range;
-			self.QueueActivity(new AttackMoveActivity(self, () => move.MoveFollow(self, target, WDist.Zero, range, targetLineColor: Color.Yellow)));
+			self.QueueActivity(new AttackMoveActivity(self, () => self.Movement.MoveFollow(self, target, WDist.Zero, range, targetLineColor: Color.Yellow)));
 		}
 
 		public string VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -130,7 +130,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Harvester(Actor self, HarvesterInfo info)
 		{
 			Info = info;
-			mobile = self.Trait<Mobile>();
+			mobile = self.Movement as Mobile;
 			resLayer = self.World.WorldActor.Trait<ResourceLayer>();
 			claimLayer = self.World.WorldActor.Trait<ResourceClaimLayer>();
 

--- a/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.self = self;
 			this.info = info;
-			mobile = self.Trait<Mobile>();
+			mobile = self.Movement as Mobile;
 		}
 
 		void Panic()

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				var newUnit = self.World.CreateActor(producee.Name, td);
 
-				var move = newUnit.TraitOrDefault<IMove>();
+				var move = newUnit.Movement;
 				if (exitinfo != null && move != null)
 				{
 					if (exitinfo.MoveIntoWorld)

--- a/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
@@ -89,7 +89,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				var newUnit = self.World.CreateActor(producee.Name, td);
 
-				var move = newUnit.TraitOrDefault<IMove>();
+				var move = newUnit.Movement;
 				if (move != null)
 					newUnit.QueueActivity(move.MoveTo(destination, 2));
 

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -136,7 +136,7 @@ namespace OpenRA.Mods.Common.Traits
 				var newUnit = self.World.CreateActor(producee.Name, td);
 
 				newUnit.QueueActivity(new Parachute(newUnit, self));
-				var move = newUnit.TraitOrDefault<IMove>();
+				var move = newUnit.Movement;
 				if (move != null)
 				{
 					if (exitinfo.MoveIntoWorld)

--- a/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithInfantryBody.cs
@@ -53,7 +53,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 	public class WithInfantryBody : ConditionalTrait<WithInfantryBodyInfo>, ITick, INotifyAttack, INotifyIdle
 	{
-		readonly IMove move;
 		protected readonly Animation DefaultAnimation;
 
 		bool dirty;
@@ -74,8 +73,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 			DefaultAnimation = new Animation(init.World, rs.GetImage(self), RenderSprites.MakeFacingFunc(self));
 			rs.Add(new AnimationWithOffset(DefaultAnimation, null, () => IsTraitDisabled));
 			PlayStandAnimation(self);
-
-			move = init.Self.Trait<IMove>();
 		}
 
 		public void PlayStandAnimation(Actor self)
@@ -147,12 +144,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 				wasModifying = rsm.IsModifyingSequence;
 			}
 
-			if ((state != AnimationState.Moving || dirty) && move.CurrentMovementTypes.HasFlag(MovementType.Horizontal))
+			if ((state != AnimationState.Moving || dirty) && self.Movement.CurrentMovementTypes.HasFlag(MovementType.Horizontal))
 			{
 				state = AnimationState.Moving;
 				DefaultAnimation.PlayRepeating(NormalizeInfantrySequence(self, Info.MoveSequence));
 			}
-			else if (((state == AnimationState.Moving || dirty) && !move.CurrentMovementTypes.HasFlag(MovementType.Horizontal))
+			else if (((state == AnimationState.Moving || dirty) && !self.Movement.CurrentMovementTypes.HasFlag(MovementType.Horizontal))
 				|| ((state == AnimationState.Idle || state == AnimationState.IdleAnimating) && !self.IsIdle))
 				PlayStandAnimation(self);
 

--- a/OpenRA.Mods.Common/Traits/Render/WithMoveAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMoveAnimation.cs
@@ -40,13 +40,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 	public class WithMoveAnimation : ConditionalTrait<WithMoveAnimationInfo>, INotifyMoving
 	{
-		readonly IMove movement;
 		readonly WithSpriteBody wsb;
 
 		public WithMoveAnimation(ActorInitializer init, WithMoveAnimationInfo info)
 			: base(info)
 		{
-			movement = init.Self.Trait<IMove>();
 			wsb = init.Self.TraitsImplementing<WithSpriteBody>().Single(w => w.Info.Name == Info.Body);
 		}
 
@@ -74,12 +72,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 		protected override void TraitEnabled(Actor self)
 		{
 			// HACK: Use a FrameEndTask to avoid construction order issues with WithSpriteBody
-			self.World.AddFrameEndTask(w => UpdateAnimation(self, movement.CurrentMovementTypes));
+			self.World.AddFrameEndTask(w => UpdateAnimation(self, self.Movement.CurrentMovementTypes));
 		}
 
 		protected override void TraitDisabled(Actor self)
 		{
-			UpdateAnimation(self, movement.CurrentMovementTypes);
+			UpdateAnimation(self, self.Movement.CurrentMovementTypes);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Wanders.cs
+++ b/OpenRA.Mods.Common/Traits/Wanders.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override void Created(Actor self)
 		{
-			move = self.Trait<IMove>() as IResolveOrder;
+			move = self.Movement as IResolveOrder;
 
 			base.Created(self);
 		}

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -222,11 +222,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		static bool IsMovingInMyDirection(Actor self, Actor other)
 		{
-			var otherMobile = other.TraitOrDefault<Mobile>();
+			var otherMobile = other.Movement as Mobile;
 			if (otherMobile == null || !otherMobile.CurrentMovementTypes.HasFlag(MovementType.Horizontal))
 				return false;
 
-			var selfMobile = self.TraitOrDefault<Mobile>();
+			var selfMobile = self.Movement as Mobile;
 			if (selfMobile == null)
 				return false;
 

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -422,27 +422,6 @@ namespace OpenRA.Mods.Common.Traits
 		IEnumerable<object> ActorPreviewInits(ActorInfo ai, ActorPreviewType type);
 	}
 
-	public interface IMove
-	{
-		Activity MoveTo(CPos cell, int nearEnough);
-		Activity MoveTo(CPos cell, Actor ignoreActor);
-		Activity MoveWithinRange(Target target, WDist range,
-			WPos? initialTargetPosition = null, Color? targetLineColor = null);
-		Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange,
-			WPos? initialTargetPosition = null, Color? targetLineColor = null);
-		Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange,
-			WPos? initialTargetPosition = null, Color? targetLineColor = null);
-		Activity MoveToTarget(Actor self, Target target,
-			WPos? initialTargetPosition = null, Color? targetLineColor = null);
-		Activity MoveIntoWorld(Actor self, CPos cell, SubCell subCell = SubCell.Any);
-		Activity MoveIntoTarget(Actor self, Target target);
-		Activity VisualMove(Actor self, WPos fromPos, WPos toPos);
-		int EstimatedMoveDuration(Actor self, WPos fromPos, WPos toPos);
-		CPos NearestMoveableCell(CPos target);
-		MovementType CurrentMovementTypes { get; set; }
-		bool CanEnterTargetNow(Actor self, Target target);
-	}
-
 	public interface IWrapMove
 	{
 		Activity WrapMove(Activity moveInner);
@@ -598,15 +577,6 @@ namespace OpenRA.Mods.Common.Traits
 	public interface IPreventMapSpawn
 	{
 		bool PreventMapSpawn(World world, ActorReference actorReference);
-	}
-
-	[Flags]
-	public enum MovementType
-	{
-		None = 0,
-		Horizontal = 1,
-		Vertical = 2,
-		Turn = 4
 	}
 
 	[RequireExplicitImplementation]


### PR DESCRIPTION
All current `IMove` implementations implement `IPositionable`, which implements `IOccupySpace`. Therefore, this is a cheap way to cache `IMove`, and we even get the benefit of it getting cached earlier than other traits, avoiding trait order issues.

While in most cases this only gets rid of one additional look-up at actor creation (probably no measurable difference except maybe on map load), this also gets rid of some `Mobile` look-ups in the `Crushable` and `Locomotor.IsMovingInMyDirection` code, which could slightly improve pathfinding performance.