### PR TITLE
Use Actor.OccupiesSpace to save Mobile trait look-ups

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Activities
 		// Ignores lane bias and nearby units
 		public Move(Actor self, CPos destination)
 		{
-			mobile = self.Trait<Mobile>();
+			mobile = self.OccupiesSpace as Mobile;
 
 			getPath = () =>
 			{
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Move(Actor self, CPos destination, WDist nearEnough, Actor ignoreActor = null, bool evaluateNearestMovableCell = false)
 		{
-			mobile = self.Trait<Mobile>();
+			mobile = self.OccupiesSpace as Mobile;
 
 			getPath = () =>
 			{
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Move(Actor self, CPos destination, SubCell subCell, WDist nearEnough)
 		{
-			mobile = self.Trait<Mobile>();
+			mobile = self.OccupiesSpace as Mobile;
 
 			getPath = () => self.World.WorldActor.Trait<IPathFinder>()
 				.FindUnitPathToRange(mobile.FromCell, subCell, self.World.Map.CenterOfSubCell(destination, subCell), nearEnough, self);
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Move(Actor self, Target target, WDist range)
 		{
-			mobile = self.Trait<Mobile>();
+			mobile = self.OccupiesSpace as Mobile;
 
 			getPath = () =>
 			{
@@ -110,7 +110,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Move(Actor self, Func<List<CPos>> getPath)
 		{
-			mobile = self.Trait<Mobile>();
+			mobile = self.OccupiesSpace as Mobile;
 
 			this.getPath = getPath;
 

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			this.target = target;
 			this.targetLineColor = targetLineColor;
-			Mobile = self.Trait<Mobile>();
+			Mobile = self.OccupiesSpace as Mobile;
 			pathFinder = self.World.WorldActor.Trait<IPathFinder>();
 			domainIndex = self.World.WorldActor.Trait<DomainIndex>();
 			ChildHasPriority = false;

--- a/OpenRA.Mods.Common/Activities/Move/VisualMoveIntoTarget.cs
+++ b/OpenRA.Mods.Common/Activities/Move/VisualMoveIntoTarget.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public VisualMoveIntoTarget(Actor self, Target target, WDist targetMovementThreshold)
 		{
-			mobile = self.Trait<Mobile>();
+			mobile = self.OccupiesSpace as Mobile;
 			this.target = target;
 			this.targetMovementThreshold = targetMovementThreshold;
 		}

--- a/OpenRA.Mods.Common/Activities/Turn.cs
+++ b/OpenRA.Mods.Common/Activities/Turn.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		public Turn(Actor self, int desiredFacing)
 		{
-			mobile = self.TraitOrDefault<Mobile>();
+			mobile = self.OccupiesSpace as Mobile;
 			facing = self.Trait<IFacing>();
 			this.desiredFacing = desiredFacing;
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -70,6 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected IFacing facing;
 		protected IPositionable positionable;
+		protected Mobile mobile;
 		protected INotifyAiming[] notifyAiming;
 		protected Func<IEnumerable<Armament>> getArmaments;
 
@@ -86,7 +87,8 @@ namespace OpenRA.Mods.Common.Traits
 		protected override void Created(Actor self)
 		{
 			facing = self.TraitOrDefault<IFacing>();
-			positionable = self.TraitOrDefault<IPositionable>();
+			positionable = self.OccupiesSpace as IPositionable;
+			mobile = positionable as Mobile;
 			notifyAiming = self.TraitsImplementing<INotifyAiming>().ToArray();
 
 			getArmaments = InitializeGetArmaments(self);
@@ -145,7 +147,6 @@ namespace OpenRA.Mods.Common.Traits
 			if (!HasAnyValidWeapons(target))
 				return false;
 
-			var mobile = self.TraitOrDefault<Mobile>();
 			if (mobile != null && !mobile.CanInteractWithGroundLayer(self))
 				return false;
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -35,7 +35,6 @@ namespace OpenRA.Mods.Common.Traits
 		public Target RequestedTarget { get; private set; }
 		public Target OpportunityTarget { get; private set; }
 
-		Mobile mobile;
 		AutoTarget autoTarget;
 		bool requestedForceAttack;
 		Activity requestedTargetPresetForActivity;
@@ -70,7 +69,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override void Created(Actor self)
 		{
-			mobile = self.TraitOrDefault<Mobile>();
 			autoTarget = self.TraitOrDefault<AutoTarget>();
 			base.Created(self);
 		}

--- a/OpenRA.Mods.Common/Traits/Crushable.cs
+++ b/OpenRA.Mods.Common/Traits/Crushable.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!CrushableInner(crushClasses, crusher.Owner))
 				return;
 
-			var mobile = self.TraitOrDefault<Mobile>();
+			var mobile = self.OccupiesSpace as Mobile;
 			if (mobile != null && self.World.SharedRandom.Next(100) <= Info.WarnProbability)
 				mobile.Nudge(self, crusher, true);
 		}
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			Game.Sound.Play(SoundType.World, Info.CrushSound, crusher.CenterPosition);
 
-			var crusherMobile = crusher.TraitOrDefault<Mobile>();
+			var crusherMobile = crusher.OccupiesSpace as Mobile;
 			self.Kill(crusher, crusherMobile != null ? crusherMobile.Info.LocomotorInfo.CrushDamageTypes : default(BitSet<DamageType>));
 		}
 


### PR DESCRIPTION
Less invasive alternative to #16804.

As discussed on IRC, we know `Mobile` implements `IOccupySpace` through `IPositionable`, so we can use `Actor.OccupiesSpace` to save `Mobile` trait look-ups.
Only done in places where it might make a measureable difference (at least with larger numbers of moving ground actors).