### PR TITLE
Reset movement inside leap to show attack animation

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/Leap.cs
+++ b/OpenRA.Mods.Cnc/Activities/Leap.cs
@@ -92,6 +92,10 @@ namespace OpenRA.Mods.Cnc.Activities
 				// (This does not update the visual position!)
 				mobile.SetLocation(destinationCell, destinationSubCell, destinationCell, destinationSubCell);
 
+				// Update movement which results in movementType set to MovementType.None.
+				// This is needed to prevent the move animation from playing.
+				mobile.UpdateMovement(self);
+
 				// Revoke the condition before attacking, as it is usually used to pause the attack trait
 				attack.RevokeLeapCondition(self);
 				attack.DoAttack(self, target);

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -256,6 +256,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ITick.Tick(Actor self)
 		{
+			UpdateMovement(self);
+		}
+
+		public void UpdateMovement(Actor self)
+		{
 			var newMovementTypes = MovementType.None;
 			if ((oldPos - CenterPosition).HorizontalLengthSquared != 0)
 				newMovementTypes |= MovementType.Horizontal;


### PR DESCRIPTION
Fixes #16747

The dog eat animation will not trigger because in the WithInfantryBody.cs Tick function the code has changed in commit a10af382 (WithInfantryBody.cs Line 143)
```diff
- if ((state != AnimationState.Moving || dirty) && move.IsMoving)
+ if ((state != AnimationState.Moving || dirty) && move.CurrentMovementTypes.HasFlag(MovementType.Horizontal))
```
Before the change the move animation would only trigger when `move.IsMoving` is explicitely set to `true`. Inside Leap.cs `move.IsMoving` was set to `false`, when the leaper reached its target, so the move animation will not run.

With the new code the move animation will run instead of the attack animation because the `currentMovementTypes` has the flag `MovementType.Horizontal` which will be set in the Mobile.cs `Tick` function. The Mobile.cs `Tick` function will count the leap as horizontal movement which is technically correct but in this case we want to directly set the leaper to its target position without setting the movement type.

To prevent the Mobile.cs `Tick` function to register a horizontal movement I set the `oldPosition` to the `CenterPosition` so it won't detect any movement which is what we want here.