### PR TITLE
Fix that VTOLs can ignore TurnToDock/-Land

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -129,15 +129,19 @@ namespace OpenRA.Mods.Common.Activities
 				}
 			}
 
-			// Move towards landing location
-			if (aircraft.Info.VTOL && (pos - targetPosition).HorizontalLengthSquared != 0)
+			// Move towards landing location/facing
+			if (aircraft.Info.VTOL)
 			{
-				QueueChild(new Fly(self, Target.FromPos(targetPosition)));
-
-				if (desiredFacing != -1)
+				if ((pos - targetPosition).HorizontalLengthSquared != 0)
+				{
+					QueueChild(new Fly(self, Target.FromPos(targetPosition)));
+					return false;
+				}
+				else if (desiredFacing != -1 && desiredFacing != aircraft.Facing)
+				{
 					QueueChild(new Turn(self, desiredFacing));
-
-				return false;
+					return false;
+				}
 			}
 
 			if (!aircraft.Info.VTOL && !finishedApproach)


### PR DESCRIPTION
When already at horizontal target position, no Turn was queued.

Fixes #16819.