### PR TITLE
Cancel carryall transport request when cancelling order.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -141,6 +141,14 @@ namespace OpenRA.Mods.Common.Activities
 			return false;
 		}
 
+		public override void Cancel(Actor self, bool keepQueue = false)
+		{
+			foreach (var t in transportCallers)
+				t.MovementCancelled(self);
+
+			base.Cancel(self, keepQueue);
+		}
+
 		void OnResupplyEnding(Actor self)
 		{
 			if (aircraft != null)

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -365,11 +365,6 @@ namespace OpenRA.Mods.Common.Traits
 				self.SetTargetLine(order.Target, Color.Green);
 				self.QueueActivity(order.Queued, new FindAndDeliverResources(self, targetActor));
 			}
-			else if (order.OrderString == "Stop" || order.OrderString == "Move")
-			{
-				foreach (var n in notifyHarvesterAction)
-					n.MovementCancelled(self);
-			}
 		}
 
 		PipType GetPipAt(int i)


### PR DESCRIPTION
Fixes #16811 

Activities requesting a transport now take care of cancelling the requests themselves. Removed the hack from `Harvester`.