### PR TITLE
Fix player color when a client is bumped to a spectator slot.

### DIFF
--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -422,6 +422,8 @@ namespace OpenRA.Mods.Common.Server
 					}
 					else if (c.Bot != null)
 						server.LobbyInfo.Clients.Remove(c);
+					else
+						c.Color = Color.White;
 				}
 
 				// Validate if color is allowed and get an alternative if it isn't


### PR DESCRIPTION
Fixes a polish issue reported on Discord.

Testcase:
* Select a map with N > 2 players
* Move to the last player slot
* Fill the rest of the slots with bots
* Change to a map with less players

The spectator's color is now correctly reset.