### PR TITLE
Fix Tick performance regression

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -446,7 +446,10 @@ namespace OpenRA.Mods.Common.Traits
 			self.World.AddFrameEndTask(s =>
 			{
 				if (CellsUpdated != null)
+				{
 					CellsUpdated(updatedCells);
+					updatedCells.Clear();
+				}
 			});
 		}
 


### PR DESCRIPTION
The first commit adds a new line to the perf graph (hide whitespace changes to see that it is effectively a one-line addition).

The second commit fixes the silly oversight that was eating all of our Tick performance - `CellsUpdated` was being called for every cell that ever changed, not just the ones that changed this tick.