### PR TITLE
Fix boxes not being placeable in Interior maps

### DIFF
--- a/mods/ra/rules/decoration.yaml
+++ b/mods/ra/rules/decoration.yaml
@@ -214,85 +214,31 @@ TC05:
 		Actor: TC05.Husk
 
 BOXES01:
-	Inherits: ^Tree
-	RenderSprites:
-		Palette: player
-	Tooltip:
-		Name: Boxes
-	MapEditorData:
-		Categories: Decoration
+	Inherits: ^Box
 
 BOXES02:
-	Inherits: ^Tree
-	RenderSprites:
-		Palette: player
-	Tooltip:
-		Name: Boxes
-	MapEditorData:
-		Categories: Decoration
+	Inherits: ^Box
 
 BOXES03:
-	Inherits: ^Tree
-	RenderSprites:
-		Palette: player
-	Tooltip:
-		Name: Boxes
-	MapEditorData:
-		Categories: Decoration
+	Inherits: ^Box
 
 BOXES04:
-	Inherits: ^Tree
-	RenderSprites:
-		Palette: player
-	Tooltip:
-		Name: Boxes
-	MapEditorData:
-		Categories: Decoration
+	Inherits: ^Box
 
 BOXES05:
-	Inherits: ^Tree
-	RenderSprites:
-		Palette: player
-	Tooltip:
-		Name: Boxes
-	MapEditorData:
-		Categories: Decoration
+	Inherits: ^Box
 
 BOXES06:
-	Inherits: ^Tree
-	RenderSprites:
-		Palette: player
-	Tooltip:
-		Name: Boxes
-	MapEditorData:
-		Categories: Decoration
+	Inherits: ^Box
 
 BOXES07:
-	Inherits: ^Tree
-	RenderSprites:
-		Palette: player
-	Tooltip:
-		Name: Boxes
-	MapEditorData:
-		Categories: Decoration
+	Inherits: ^Box
 
 BOXES08:
-	Inherits: ^Tree
-	RenderSprites:
-		Palette: player
-	Tooltip:
-		Name: Boxes
-	MapEditorData:
-		Categories: Decoration
+	Inherits: ^Box
 
 BOXES09:
-	Inherits: ^Tree
-	RenderSprites:
-		Palette: player
-	Tooltip:
-		Name: Boxes
-	MapEditorData:
-		Categories: Decoration
+	Inherits: ^Box
 
 ICE01:
 	Inherits: ^Tree

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -970,6 +970,15 @@
 	RequiresSpecificOwners:
 		ValidOwnerNames: Neutral
 
+^Box:
+	Inherits: ^Tree
+	RenderSprites:
+		Palette: player
+	Tooltip:
+		Name: Boxes
+	MapEditorData:
+		Categories: Decoration
+
 ^BasicHusk:
 	Inherits@1: ^SpriteActor
 	Interactable:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -977,6 +977,7 @@
 	Tooltip:
 		Name: Boxes
 	MapEditorData:
+		-ExcludeTilesets:
 		Categories: Decoration
 
 ^BasicHusk:


### PR DESCRIPTION
This fixes boxes not being available in the map editor for interior maps - reported by Blackened in Discord.

I believe the original may have limited boxes to *only* interior maps, but I know that mappers have used these in other tilesets so I expect it would be controversial to limit them again here.