### PR TITLE
Make nearEnough on Move orders scale with army size

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -419,6 +419,7 @@ namespace OpenRA.Traits
 	{
 		int Hash { get; }
 		IEnumerable<Actor> Actors { get; }
+		int ActorCount { get; }
 
 		void Add(Actor a);
 		void Remove(Actor a);

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -53,9 +53,10 @@ namespace OpenRA.Mods.Common.Activities
 				using (var search =
 					PathSearch.FromPoint(self.World, mobile.Locomotor, self, mobile.ToCell, destination, false)
 					.WithoutLaneBias())
-					path = self.World.WorldActor.Trait<IPathFinder>().FindPath(search);
+					path = mobile.Pathfinder.FindPath(search);
 				return path;
 			};
+
 			this.destination = destination;
 			nearEnough = WDist.Zero;
 		}
@@ -69,8 +70,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (!this.destination.HasValue)
 					return NoPath;
 
-				return self.World.WorldActor.Trait<IPathFinder>()
-					.FindUnitPath(mobile.ToCell, this.destination.Value, self, ignoreActor);
+				return mobile.Pathfinder.FindUnitPath(mobile.ToCell, this.destination.Value, self, ignoreActor);
 			};
 
 			// Note: Will be recalculated from OnFirstRun if evaluateNearestMovableCell is true
@@ -85,8 +85,9 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			mobile = self.Trait<Mobile>();
 
-			getPath = () => self.World.WorldActor.Trait<IPathFinder>()
-				.FindUnitPathToRange(mobile.FromCell, subCell, self.World.Map.CenterOfSubCell(destination, subCell), nearEnough, self);
+			getPath = () => mobile.Pathfinder.FindUnitPathToRange(
+				mobile.FromCell, subCell, self.World.Map.CenterOfSubCell(destination, subCell), nearEnough, self);
+
 			this.destination = destination;
 			this.nearEnough = nearEnough;
 		}
@@ -100,7 +101,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (!target.IsValidFor(self))
 					return NoPath;
 
-				return self.World.WorldActor.Trait<IPathFinder>().FindUnitPathToRange(
+				return mobile.Pathfinder.FindUnitPathToRange(
 					mobile.ToCell, mobile.ToSubCell, target.CenterPosition, range, self);
 			};
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -195,6 +195,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Locomotor Locomotor { get; private set; }
 
+		public IPathFinder Pathfinder { get; private set; }
+
 		#region IOccupySpace
 
 		[Sync]
@@ -245,6 +247,7 @@ namespace OpenRA.Mods.Common.Traits
 			notifyMoving = self.TraitsImplementing<INotifyMoving>().ToArray();
 			notifyFinishedMoving = self.TraitsImplementing<INotifyFinishedMoving>().ToArray();
 			moveWrappers = self.TraitsImplementing<IWrapMove>().ToArray();
+			Pathfinder = self.World.WorldActor.Trait<IPathFinder>();
 			Locomotor = self.World.WorldActor.TraitsImplementing<Locomotor>()
 				.Single(l => l.Info.Name == Info.Locomotor);
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -811,7 +811,15 @@ namespace OpenRA.Mods.Common.Traits
 					self.CancelActivity();
 
 				self.SetTargetLine(Target.FromCell(self.World, cell), Color.Green);
-				self.QueueActivity(order.Queued, WrapMove(new Move(self, cell, WDist.FromCells(8), null, true)));
+
+				var selectionCount = self.World.Selection.ActorCount;
+
+				// Scale nearEnough by the formula square root of world selection divided by 2 + half a cell safety margin.
+				// If only a single unit is selected, set nearEnough to zero.
+				// If no units are selected (order is triggered by AI, triggers and the likes), use the old default of 8 cells.
+				var nearEnough = new WDist(selectionCount == 1 ? 0 : selectionCount > 1 ? (Exts.ISqrt(selectionCount) * 1024 / 2 + 512) : 8 * 1024);
+
+				self.QueueActivity(order.Queued, WrapMove(new Move(self, cell, nearEnough, null, true)));
 			}
 
 			// TODO: This should only cancel activities queued by this trait

--- a/OpenRA.Mods.Common/Traits/World/Selection.cs
+++ b/OpenRA.Mods.Common/Traits/World/Selection.cs
@@ -26,6 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public int Hash { get; private set; }
 		public IEnumerable<Actor> Actors { get { return actors; } }
+		public int ActorCount { get { return actors.Count; } }
 
 		readonly HashSet<Actor> actors = new HashSet<Actor>();
 		INotifySelection[] worldNotifySelection;


### PR DESCRIPTION
Instead of hard-coded 8 cell range, which is way too large for smaller armies.

Should improve or possibly fix #5968.