### PR TITLE
Make VisualMove uninterruptible by making Turn a Child of Drag.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Drag.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Drag.cs
@@ -23,15 +23,23 @@ namespace OpenRA.Mods.Common.Activities
 		WPos start, end;
 		int length;
 		int ticks = 0;
+		int desiredFacing;
 
-		public Drag(Actor self, WPos start, WPos end, int length)
+		public Drag(Actor self, WPos start, WPos end, int length, int facing = -1)
 		{
 			positionable = self.Trait<IPositionable>();
 			disableable = self.TraitOrDefault<IMove>() as IDisabledTrait;
 			this.start = start;
 			this.end = end;
 			this.length = length;
+			desiredFacing = facing;
 			IsInterruptible = false;
+		}
+
+		protected override void OnFirstRun(Actor self)
+		{
+			if (desiredFacing != -1)
+				QueueChild(new Turn(self, desiredFacing));
 		}
 
 		public override bool Tick(Actor self)

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -698,9 +698,7 @@ namespace OpenRA.Mods.Common.Traits
 			var delta = toPos - fromPos;
 			var facing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : Facing;
 
-			var activities = new Turn(self, facing);
-			activities.Queue(new Drag(self, fromPos, toPos, length));
-			return activities;
+			return new Drag(self, fromPos, toPos, length, facing);
 		}
 
 		CPos? ClosestGroundCell()


### PR DESCRIPTION
Fixes #16826.

`IMove.MoveIntoWorld` is queued as a child by `Enter` when `Enter` gets cancelled. If it then gets cancelled again while the unit is still turning, `Enter` exits immediately while still off-grid because `Turn` is an interruptible activity (unlike `Drag`). This can cause units to teleport when a move order is given twice while entering a transport or deploy inside a transport when a deploy order is given twice while entering.

This PR solves the issue by making the `Turn` inside `IMove.VisualMove` a childactivity of `Drag`.