### PR TITLE
Do not cancel parent activity when refinery is destroyed.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -131,10 +131,6 @@ namespace OpenRA.Mods.Common.Traits
 		void CancelDock(Actor self)
 		{
 			preventDock = true;
-
-			// Cancel the dock sequence
-			if (dockedHarv != null && !dockedHarv.IsDead)
-				dockedHarv.CancelActivity();
 		}
 
 		void ITick.Tick(Actor self)


### PR DESCRIPTION
Fixes #16570.

Another case of direct activity queue manipulation leading to trouble. Completely superfluous to boot because `HarvesterDockSequence` already checks for the refinery state and knows how to exit gracefully when the refinery disappears.