### PR TITLE
Fix allies05a crashing

### DIFF
--- a/mods/ra/maps/allies-05a/allies05a.lua
+++ b/mods/ra/maps/allies-05a/allies05a.lua
@@ -6,6 +6,7 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
+
 if Map.LobbyOption("difficulty") == "easy" then
 	TanyaType = "e7"
 	ReinforceCash = 5000
@@ -234,12 +235,20 @@ end
 
 InitTriggers = function()
 	Trigger.OnInfiltrated(Warfactory, function()
+		if greece.IsObjectiveCompleted(infWarfactory) then
+			return
+		end
+
 		Trigger.ClearAll(Spy)
 		greece.MarkCompletedObjective(infWarfactory)
 		WarfactoryInfiltrated()
 	end)
 
 	Trigger.OnInfiltrated(Prison, function()
+		if greece.IsObjectiveCompleted(mainObj) then
+			return
+		end
+
 		if not greece.IsObjectiveCompleted(infWarfactory) then
 			Media.DisplayMessage("Good work! But next time skip the heroics!", "Battlefield Control")
 			greece.MarkCompletedObjective(infWarfactory)

--- a/mods/ra/maps/allies-05a/allies05a.lua
+++ b/mods/ra/maps/allies-05a/allies05a.lua
@@ -202,7 +202,7 @@ FreeTanya = function()
 		Media.PlaySpeechNotification(greece, "TargetFreed")
 	end
 
-	if not SpecialCameras then
+	if not SpecialCameras and PrisonCamera and PrisonCamera.IsInWorld then
 		PrisonCamera.Destroy()
 	end
 end
@@ -244,6 +244,15 @@ InitTriggers = function()
 			Media.DisplayMessage("Good work! But next time skip the heroics!", "Battlefield Control")
 			greece.MarkCompletedObjective(infWarfactory)
 		end
+
+		if not PrisonCamera then
+			if SpecialCameras then
+				PrisonCamera = Actor.Create("camera", true, { Owner = greece, Location = TrukWaypoint5.Location })
+			else
+				PrisonCamera = Actor.Create("camera.small", true, { Owner = greece, Location = Prison.Location + CVec.New(1, 1) })
+			end
+		end
+
 		Trigger.ClearAll(Spy)
 		Trigger.AfterDelay(DateTime.Seconds(2), MissInfiltrated)
 	end)
@@ -319,7 +328,7 @@ InitTriggers = function()
 					greece.MarkCompletedObjective(mainObj)
 					SendReinforcements()
 
-					if SpecialCameras then
+					if PrisonCamera and PrisonCamera.IsInWorld then
 						PrisonCamera.Destroy()
 					end
 				end)

--- a/mods/ra/maps/allies-05a/allies05a.lua
+++ b/mods/ra/maps/allies-05a/allies05a.lua
@@ -84,7 +84,7 @@ GroupPatrol = function(units, waypoints, delay)
 end
 
 Tick = function()
-	if FollowTruk then
+	if FollowTruk and not Truk.IsDead then
 		Camera.Position = Truk.CenterPosition
 	end
 
@@ -237,11 +237,25 @@ InitTriggers = function()
 	Trigger.OnInfiltrated(Warfactory, function()
 		if greece.IsObjectiveCompleted(infWarfactory) then
 			return
+		elseif Truk.IsDead then
+			if not greece.IsObjectiveCompleted(mainObj) then
+				ussr.MarkCompletedObjective(ussrObj)
+			end
+
+			return
 		end
 
 		Trigger.ClearAll(Spy)
 		greece.MarkCompletedObjective(infWarfactory)
 		WarfactoryInfiltrated()
+	end)
+
+	Trigger.OnKilled(Truk, function()
+		if not greece.IsObjectiveCompleted(infWarfactory) then
+			greece.MarkFailedObjective(infWarfactory)
+		elseif FollowTruk then
+			ussr.MarkCompletedObjective(ussrObj)
+		end
 	end)
 
 	Trigger.OnInfiltrated(Prison, function()
@@ -354,7 +368,7 @@ InitObjectives = function()
 	ussrObj = ussr.AddPrimaryObjective("Deny the Allies.")
 	mainObj = greece.AddPrimaryObjective("Rescue Tanya.")
 	KillAll = greece.AddPrimaryObjective("Eliminate all Soviet units in this area.")
-	infWarfactory = greece.AddPrimaryObjective("Infiltrate the Soviet warfactory.")
+	infWarfactory = greece.AddSecondaryObjective("Infiltrate the Soviet warfactory.")
 
 	Trigger.OnObjectiveCompleted(greece, function(p, id)
 		Media.DisplayMessage(p.GetObjectiveDescription(id), "Objective completed")

--- a/mods/ra/maps/allies-05a/allies05a.lua
+++ b/mods/ra/maps/allies-05a/allies05a.lua
@@ -276,6 +276,11 @@ InitTriggers = function()
 			end
 		end
 
+		if SpecialCameras and SpyCameraA and not SpyCameraA.IsDead then
+			SpyCameraA.Destroy()
+			SpyCameraB.Destroy()
+		end
+
 		Trigger.ClearAll(Spy)
 		Trigger.AfterDelay(DateTime.Seconds(2), MissInfiltrated)
 	end)


### PR DESCRIPTION
Fixes #16855.

Testcase was infiltrating the prison without infiltrating the warfactory. This should make the script more robust against all sorts of weird things that can happen when infiltrating the prison first. Also makes warfactory infiltration a secondary objective which isn't strictly necessary but works better imho. (E.g. if you somehow managed to get the truck killed you can still win, just not by infiltrating the warfactory.)