### PR TITLE
Fixes in locomotor path cache

### DIFF
--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -76,8 +76,8 @@ namespace OpenRA
 		// Each player is identified with a unique bit in the set
 		// Cache masks for the player's index and ally/enemy player indices for performance.
 		public LongBitSet<PlayerBitMask> PlayerMask;
-		public LongBitSet<PlayerBitMask> AllyMask = default(LongBitSet<PlayerBitMask>);
-		public LongBitSet<PlayerBitMask> EnemyMask = default(LongBitSet<PlayerBitMask>);
+		public LongBitSet<PlayerBitMask> AlliedPlayersMask = default(LongBitSet<PlayerBitMask>);
+		public LongBitSet<PlayerBitMask> EnemyPlayersMask = default(LongBitSet<PlayerBitMask>);
 
 		public bool UnlockedRenderPlayer
 		{

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -260,7 +260,7 @@ namespace OpenRA.Traits
 		WDist LargestActorRadius { get; }
 		WDist LargestBlockingActorRadius { get; }
 
-		event Action<IEnumerable<CPos>> CellsUpdated;
+		event Action<CPos> CellUpdated;
 	}
 
 	[RequireExplicitImplementation]

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -43,7 +43,8 @@ namespace OpenRA
 		public readonly MersenneTwister SharedRandom;
 		public readonly MersenneTwister LocalRandom;
 		public readonly IModelCache ModelCache;
-		public LongBitSet<PlayerBitMask> AllPlayerMask = default(LongBitSet<PlayerBitMask>);
+		public LongBitSet<PlayerBitMask> AllPlayersMask = default(LongBitSet<PlayerBitMask>);
+		public readonly LongBitSet<PlayerBitMask> NoPlayersMask = default(LongBitSet<PlayerBitMask>);
 
 		public Player[] Players = new Player[0];
 
@@ -208,7 +209,7 @@ namespace OpenRA
 			foreach (var p in Players)
 			{
 				if (!p.Spectating)
-					AllPlayerMask = AllPlayerMask.Union(p.PlayerMask);
+					AllPlayersMask = AllPlayersMask.Union(p.PlayerMask);
 
 				foreach (var q in Players)
 				{
@@ -244,10 +245,10 @@ namespace OpenRA
 			{
 				case Stance.Enemy:
 				case Stance.Neutral:
-					p.EnemyMask = p.EnemyMask.Union(bitSet);
+					p.EnemyPlayersMask = p.EnemyPlayersMask.Union(bitSet);
 					break;
 				case Stance.Ally:
-					p.AllyMask = p.AllyMask.Union(bitSet);
+					p.AlliedPlayersMask = p.AlliedPlayersMask.Union(bitSet);
 					break;
 			}
 		}

--- a/OpenRA.Mods.Cnc/Traits/Mine.cs
+++ b/OpenRA.Mods.Cnc/Traits/Mine.cs
@@ -59,11 +59,13 @@ namespace OpenRA.Mods.Cnc.Traits
 			return info.CrushClasses.Overlaps(crushClasses);
 		}
 
-		bool ICrushable.TryCalculatePlayerBlocking(Actor self, BitSet<CrushClass> crushClasses, out LongBitSet<PlayerBitMask> blocking)
+		LongBitSet<PlayerBitMask> ICrushable.CrushableBy(Actor self, BitSet<CrushClass> crushClasses)
 		{
-			// Fall back to the slow path
-			blocking = default(LongBitSet<PlayerBitMask>);
-			return false;
+			if (!info.CrushClasses.Overlaps(crushClasses))
+				return self.World.NoPlayersMask;
+
+			// Friendly units should move around!
+			return info.BlockFriendly ? self.Owner.EnemyPlayersMask : self.World.AllPlayersMask;
 		}
 	}
 

--- a/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathGraph.cs
@@ -174,7 +174,7 @@ namespace OpenRA.Mods.Common.Pathfinder
 		{
 			var movementCost = locomotor.MovementCostToEnterCell(Actor, destNode, IgnoreActor, checkConditions);
 
-			if (movementCost != int.MaxValue && !(CustomBlock != null && CustomBlock(destNode)))
+			if (movementCost != short.MaxValue && !(CustomBlock != null && CustomBlock(destNode)))
 				return CalculateCellCost(destNode, direction, movementCost);
 
 			return Constants.InvalidNode;

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
@@ -195,7 +195,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			bool CanEnterCell(Actor self, CPos cell)
 			{
-				if (mobile.locomotor.MovementCostForCell(cell) == int.MaxValue)
+				if (mobile.locomotor.MovementCostForCell(cell) == short.MaxValue)
 					return false;
 
 				return mobile.locomotor.CanMoveFreelyInto(self, cell, null, CellConditions.BlockedByMovers);

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -225,14 +225,9 @@ namespace OpenRA.Mods.Common.Traits
 			return self.IsAtGroundLevel() && crushClasses.Contains(info.CrushClass);
 		}
 
-		bool ICrushable.TryCalculatePlayerBlocking(Actor self, BitSet<CrushClass> crushClasses, out LongBitSet<PlayerBitMask> blocking)
+		LongBitSet<PlayerBitMask> ICrushable.CrushableBy(Actor self, BitSet<CrushClass> crushClasses)
 		{
-			if (self.IsAtGroundLevel() && crushClasses.Contains(info.CrushClass))
-				blocking = default(LongBitSet<PlayerBitMask>);
-			else
-				blocking = self.World.AllPlayerMask;
-
-			return true;
+			return self.IsAtGroundLevel() && crushClasses.Contains(info.CrushClass) ? self.World.AllPlayersMask : self.World.NoPlayersMask;
 		}
 
 		void INotifyAddedToWorld.AddedToWorld(Actor self)

--- a/OpenRA.Mods.Common/Traits/Crushable.cs
+++ b/OpenRA.Mods.Common/Traits/Crushable.cs
@@ -87,5 +87,15 @@ namespace OpenRA.Mods.Common.Traits
 
 			return Info.CrushClasses.Overlaps(crushClasses);
 		}
+
+		protected override void TraitEnabled(Actor self)
+		{
+			self.World.ActorMap.UpdatePosition(self, self.OccupiesSpace);
+		}
+
+		protected override void TraitDisabled(Actor self)
+		{
+			self.World.ActorMap.UpdatePosition(self, self.OccupiesSpace);
+		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Crushable.cs
+++ b/OpenRA.Mods.Common/Traits/Crushable.cs
@@ -65,6 +65,14 @@ namespace OpenRA.Mods.Common.Traits
 			return CrushableInner(crushClasses, crusher.Owner);
 		}
 
+		LongBitSet<PlayerBitMask> ICrushable.CrushableBy(Actor self, BitSet<CrushClass> crushClasses)
+		{
+			if (IsTraitDisabled || !self.IsAtGroundLevel() || !Info.CrushClasses.Overlaps(crushClasses))
+				return self.World.NoPlayersMask;
+
+			return Info.CrushedByFriendlies ? self.World.AllPlayersMask : self.Owner.EnemyPlayersMask;
+		}
+
 		bool CrushableInner(BitSet<CrushClass> crushClasses, Player crushOwner)
 		{
 			if (IsTraitDisabled)
@@ -78,16 +86,6 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			return Info.CrushClasses.Overlaps(crushClasses);
-		}
-
-		bool ICrushable.TryCalculatePlayerBlocking(Actor self, BitSet<CrushClass> crushClasses, out LongBitSet<PlayerBitMask> blocking)
-		{
-			if (IsTraitDisabled || !self.IsAtGroundLevel() || !Info.CrushClasses.Overlaps(crushClasses))
-				blocking = self.World.AllPlayerMask;
-			else
-				blocking = Info.CrushedByFriendlies ? default(LongBitSet<PlayerBitMask>) : self.Owner.AllyMask;
-
-			return true;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -71,6 +71,9 @@ namespace OpenRA.Mods.Common.Traits
 			else if (locomotorInfos.Count(li => li.Name == Locomotor) > 1)
 				throw new YamlException("There is more than one locomotor named '{0}'.".F(Locomotor));
 
+			// We need to reset the reference to the locomotor between each worlds, otherwise we are reference the previous state.
+			locomotor = null;
+
 			base.RulesetLoaded(rules, ai);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Traits
 				locomotor = world.WorldActor.TraitsImplementing<Locomotor>()
 				   .SingleOrDefault(l => l.Info.Name == Locomotor);
 
-			if (locomotor.MovementCostForCell(cell) == int.MaxValue)
+			if (locomotor.MovementCostForCell(cell) == short.MaxValue)
 				return false;
 
 			var check = checkTransientActors ? CellConditions.All : CellConditions.BlockedByMovers;
@@ -438,7 +438,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool CanExistInCell(CPos cell)
 		{
-			return Locomotor.MovementCostForCell(cell) != int.MaxValue;
+			return Locomotor.MovementCostForCell(cell) != short.MaxValue;
 		}
 
 		public bool CanEnterCell(CPos cell, Actor ignoreActor = null, bool checkTransientActors = true)
@@ -878,7 +878,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (mobile.IsTraitPaused
 					|| (!explored && !locomotorInfo.MoveIntoShroud)
-					|| (explored && mobile.Locomotor.MovementCostForCell(location) == int.MaxValue))
+					|| (explored && mobile.Locomotor.MovementCostForCell(location) == short.MaxValue))
 					cursor = mobile.Info.BlockedCursor;
 
 				return true;

--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -173,7 +173,7 @@ namespace OpenRA.Mods.Common.Traits
 		readonly CellLayer<InfluenceNode> influence;
 		readonly Dictionary<int, CellLayer<InfluenceNode>> customInfluence = new Dictionary<int, CellLayer<InfluenceNode>>();
 		public readonly Dictionary<int, ICustomMovementLayer> CustomMovementLayers = new Dictionary<int, ICustomMovementLayer>();
-		public event Action<IEnumerable<CPos>> CellsUpdated;
+		public event Action<CPos> CellUpdated;
 		readonly Bin[] bins;
 		readonly int rows, cols;
 
@@ -182,7 +182,6 @@ namespace OpenRA.Mods.Common.Traits
 		readonly HashSet<Actor> addActorPosition = new HashSet<Actor>();
 		readonly HashSet<Actor> removeActorPosition = new HashSet<Actor>();
 		readonly Predicate<Actor> actorShouldBeRemoved;
-		readonly HashSet<CPos> updatedCells = new HashSet<CPos>();
 
 		public WDist LargestActorRadius { get; private set; }
 		public WDist LargestBlockingActorRadius { get; private set; }
@@ -372,7 +371,8 @@ namespace OpenRA.Mods.Common.Traits
 					foreach (var t in triggers)
 						t.Dirty = true;
 
-				updatedCells.Add(c.First);
+				if (CellUpdated != null)
+					CellUpdated(c.First);
 			}
 		}
 
@@ -394,7 +394,8 @@ namespace OpenRA.Mods.Common.Traits
 					foreach (var t in triggers)
 						t.Dirty = true;
 
-				updatedCells.Add(c.First);
+				if (CellUpdated != null)
+					CellUpdated(c.First);
 			}
 		}
 
@@ -442,15 +443,6 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var t in proximityTriggers)
 				t.Value.Tick(this);
-
-			self.World.AddFrameEndTask(s =>
-			{
-				if (CellsUpdated != null)
-				{
-					CellsUpdated(updatedCells);
-					updatedCells.Clear();
-				}
-			});
 		}
 
 		public int AddCellTrigger(CPos[] cells, Action<Actor> onEntry, Action<Actor> onExit)

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -380,7 +380,6 @@ namespace OpenRA.Mods.Common.Traits
 			blockingCache = new CellLayer<CellCache>(map);
 			cellsCost = new CellLayer<short>(map);
 
-
 			terrainInfos = Info.TilesetTerrainInfo[map.Rules.TileSet];
 
 			foreach (var cell in map.AllCells)

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -242,24 +242,24 @@ namespace OpenRA.Mods.Common.Traits
 			sharesCell = info.SharesCell;
 		}
 
-		public int MovementCostForCell(CPos cell)
+		public short MovementCostForCell(CPos cell)
 		{
 			if (!world.Map.Contains(cell))
-				return int.MaxValue;
+				return short.MaxValue;
 
 			return pathabilityCache[cell].Cost;
 		}
 
-		public int MovementCostToEnterCell(Actor actor, CPos destNode, Actor ignoreActor, CellConditions check)
+		public short MovementCostToEnterCell(Actor actor, CPos destNode, Actor ignoreActor, CellConditions check)
 		{
 			if (!world.Map.Contains(destNode))
-				return int.MaxValue;
+				return short.MaxValue;
 
 			var cellCache = pathabilityCache[destNode];
 
 			if (cellCache.Cost == short.MaxValue ||
 				!CanMoveFreelyInto(actor, ignoreActor, destNode, check, cellCache))
-				return int.MaxValue;
+				return short.MaxValue;
 
 			return cellCache.Cost;
 		}
@@ -307,7 +307,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public SubCell GetAvailableSubCell(Actor self, CPos cell, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null, CellConditions check = CellConditions.All)
 		{
-			if (MovementCostForCell(cell) == int.MaxValue)
+			if (MovementCostForCell(cell) == short.MaxValue)
 				return SubCell.Invalid;
 
 			if (check.HasCellCondition(CellConditions.TransientActors))

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.Traits
 	public interface ICrushable
 	{
 		bool CrushableBy(Actor self, Actor crusher, BitSet<CrushClass> crushClasses);
-		bool TryCalculatePlayerBlocking(Actor self, BitSet<CrushClass> crushClasses, out LongBitSet<PlayerBitMask> blocking);
+		LongBitSet<PlayerBitMask> CrushableBy(Actor self, BitSet<CrushClass> crushClasses);
 	}
 
 	[RequireExplicitImplementation]


### PR DESCRIPTION
Fixes #16845 
Fixes #16848
Fixes #16863
Fixes: #16862
Fixes: #16880

Note: Is not dependent on the suggested change on setting  MovementType to none after the movement is finished. But if we fix that we can cache the case when a crushable unit has moved.