### PR TITLE
Generate version for make all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ test: core
 
 ########################## MAKE/INSTALL RULES ##########################
 #
-all: dependencies core
+all: dependencies core version
 
 core:
 	@command -v $(MSBUILD) >/dev/null || (echo "OpenRA requires the '$(MSBUILD)' tool provided by Mono >= 5.4."; exit 1)


### PR DESCRIPTION
The assumption is `make all` should take care of all the heavy lifting to fully compile the project. Without a generated version the default goes to "{DEV_VERSION}" which gets displayed through the UI. This also becomes the default save-game location \*/{DEV_VERSION}/\*. If the user
ever decides to generate a version afterward they will lose access to their saved games, as the save path changes. Providing this all up front with `make all` yields a more intuitive experience for beginners to get setup with.