### PR TITLE
Restore target line display for allied players and spectators.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -42,23 +42,25 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 		}
 
-		public void ShowTargetLines(Actor a)
+		public void ShowTargetLines(Actor self)
 		{
-			if (a.IsIdle)
+			// Target lines are only automatically shown for the owning player
+			// Spectators and allies must use the force-display modifier
+			if (self.IsIdle || self.Owner != self.World.LocalPlayer)
 				return;
 
 			// Reset the order line timeout.
 			lifetime = info.Delay;
 		}
 
-		void INotifySelected.Selected(Actor a)
+		void INotifySelected.Selected(Actor self)
 		{
-			ShowTargetLines(a);
+			ShowTargetLines(self);
 		}
 
 		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
-			if (self.Owner != self.World.LocalPlayer)
+			if (!self.Owner.IsAlliedWith(self.World.LocalPlayer))
 				yield break;
 
 			// Players want to see the lines when in waypoint mode.


### PR DESCRIPTION
Fixes a regression from #16549. IMO the pre-16549 behavior always felt unpolished (target lines popping out of nowhere without viewer action), so I have brought this back with a major tweak: the lines are now only visible when the queue-modifier (now shift) is held.