### PR TITLE
Remove ShowTargetLines from delivery Lua API calls.

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/DeliveryProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/DeliveryProperties.cs
@@ -35,7 +35,6 @@ namespace OpenRA.Mods.Common.Scripting
 		{
 			var t = Target.FromActor(target);
 			Self.QueueActivity(new DonateCash(Self, t, info.Payload, info.PlayerExperience));
-			Self.ShowTargetLines();
 		}
 	}
 
@@ -67,7 +66,6 @@ namespace OpenRA.Mods.Common.Scripting
 
 			var t = Target.FromActor(target);
 			Self.QueueActivity(new DonateExperience(Self, t, level, deliversExperience.PlayerExperience));
-			Self.ShowTargetLines();
 		}
 	}
 }


### PR DESCRIPTION
Lines should only be activated in response to an explicit player action. This fixes an existing inconsistency I noticed while reviewing #16549.