### PR TITLE
Distribute aircraft move orders over area.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/Land.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Land.cs
@@ -27,6 +27,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly CPos[] clearCells;
 		readonly WDist landRange;
 		readonly Color? targetLineColor;
+		readonly Target? orderTarget;
 
 		Target target;
 		WPos targetPosition;
@@ -38,6 +39,12 @@ namespace OpenRA.Mods.Common.Activities
 			: this(self, Target.Invalid, new WDist(-1), WVec.Zero, facing, null)
 		{
 			assignTargetOnFirstRun = true;
+		}
+
+		public Land(Actor self, Target target, Target orderTarget, int facing = -1, Color? targetLineColor = null)
+			: this(self, target, facing, targetLineColor)
+		{
+			this.orderTarget = orderTarget;
 		}
 
 		public Land(Actor self, Target target, int facing = -1, Color? targetLineColor = null)
@@ -260,7 +267,12 @@ namespace OpenRA.Mods.Common.Activities
 		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
 		{
 			if (targetLineColor != null)
-				yield return new TargetLineNode(target, targetLineColor.Value);
+			{
+				if (orderTarget.HasValue)
+					yield return new TargetLineNode(orderTarget.Value, targetLineColor.Value);
+				else
+					yield return new TargetLineNode(target, targetLineColor.Value);
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool Repulsable = true;
 
 		[Desc("The distance it tries to maintain from other aircraft if repulsable.")]
-		public readonly WDist IdealSeparation = new WDist(1706);
+		public readonly WDist IdealSeparation = new WDist(1024);
 
 		[Desc("The speed at which the aircraft is repulsed from other aircraft. Specify -1 for normal movement speed.")]
 		public readonly int RepulsionSpeed = -1;

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -46,7 +46,7 @@ DSHP:
 		InitialFacing: 0
 		TakeoffSounds: dropup1.aud
 		LandingSounds: dropdwn1.aud
-		IdealSeparation: 1275
+		IdealSeparation: 2048
 		CruiseAltitude: 12c512
 		AltitudeVelocity: 256
 		MoveIntoShroud: true
@@ -199,7 +199,7 @@ ORCATRAN:
 		Crushes: crate, infantry
 		TakeoffSounds: orcaup1.aud
 		LandingSounds: orcadwn1.aud
-		IdealSeparation: 1275
+		IdealSeparation: 2048
 	Health:
 		HP: 20000
 	Armor:


### PR DESCRIPTION
When a group of aircraft receives a `Move,` `Land` or `AttackMove` order the aircraft will now intelligently distribute themselves around the target location instead of  butting heads trying to enter the same pixel. This prevents the aircraft from stalling when given queued orders. Any edge cases where the aircraft would still stall somehow are resolved by implementing a `nearEnough` parameter in `Fly`.

Fixes #13753 
Fixes #11521
Fixes #17293
(Note that this does not yet resolve #10449 because the repulsion logic is still wonky and this PR does not cover that.)

The aircraft will try to maintain their current formation but they can be bunched up by clicking in the middle of the group.

In order to make `Land` orders more reliable I have adapted the repulsion distances to be only multiples of single cell distances. This means that the aircraft formation can be aligned to the grid. Otherwise aircraft might not be able to land in a grid cell.