### PR TITLE
Add Automatic/Manual/Disabled setting for target line display

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -21,6 +21,7 @@ namespace OpenRA
 {
 	public enum MouseScrollType { Disabled, Standard, Inverted, Joystick }
 	public enum StatusBarsType { Standard, DamageShow, AlwaysShow }
+	public enum TargetLinesType { Disabled, Manual, Automatic }
 
 	[Flags]
 	public enum MPGameFilters
@@ -208,8 +209,8 @@ namespace OpenRA
 
 		public bool UseClassicMouseStyle = false;
 		public StatusBarsType StatusBars = StatusBarsType.Standard;
+		public TargetLinesType TargetLines = TargetLinesType.Automatic;
 		public bool UsePlayerStanceColors = false;
-		public bool DrawTargetLine = true;
 
 		public bool AllowDownloading = true;
 

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -209,7 +209,7 @@ namespace OpenRA
 
 		public bool UseClassicMouseStyle = false;
 		public StatusBarsType StatusBars = StatusBarsType.Standard;
-		public TargetLinesType TargetLines = TargetLinesType.Automatic;
+		public TargetLinesType TargetLines = TargetLinesType.Manual;
 		public bool UsePlayerStanceColors = false;
 
 		public bool AllowDownloading = true;

--- a/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Common.Effects
 
 		IEnumerable<IRenderable> RenderInner(WorldRenderer wr)
 		{
-			if (Game.Settings.Game.DrawTargetLine)
+			if (Game.Settings.Game.TargetLines != TargetLinesType.Disabled)
 				yield return new TargetLineRenderable(targetLine, building.Owner.Color, rp.Info.LineWidth);
 
 			if (circles != null || flag != null)

--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -45,6 +45,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void ShowTargetLines(Actor self)
 		{
+			if (Game.Settings.Game.TargetLines < TargetLinesType.Automatic)
+				return;
+
 			// Target lines are only automatically shown for the owning player
 			// Spectators and allies must use the force-display modifier
 			if (self.IsIdle || self.Owner != self.World.LocalPlayer)
@@ -61,16 +64,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
-			if (!self.Owner.IsAlliedWith(self.World.LocalPlayer))
+			if (!self.Owner.IsAlliedWith(self.World.LocalPlayer) || Game.Settings.Game.TargetLines == TargetLinesType.Disabled)
 				return Enumerable.Empty<IRenderable>();
 
 			// Players want to see the lines when in waypoint mode.
 			var force = Game.GetModifierKeys().HasModifier(Modifiers.Shift) || self.World.OrderGenerator is ForceModifiersOrderGenerator;
 
 			if (--lifetime <= 0 && !force)
-				return Enumerable.Empty<IRenderable>();
-
-			if (!(force || Game.Settings.Game.DrawTargetLine))
 				return Enumerable.Empty<IRenderable>();
 
 			renderableCache.Clear();

--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -45,12 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void ShowTargetLines(Actor self)
 		{
-			if (Game.Settings.Game.TargetLines < TargetLinesType.Automatic)
-				return;
-
-			// Target lines are only automatically shown for the owning player
-			// Spectators and allies must use the force-display modifier
-			if (self.IsIdle || self.Owner != self.World.LocalPlayer)
+			if (Game.Settings.Game.TargetLines < TargetLinesType.Automatic || self.IsIdle)
 				return;
 
 			// Reset the order line timeout.
@@ -111,6 +106,8 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public static void ShowTargetLines(this Actor self)
 		{
+			// Target lines are only automatically shown for the owning player
+			// Spectators and allies must use the force-display modifier
 			if (self.Owner != self.World.LocalPlayer)
 				return;
 

--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -12,6 +12,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Orders;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -64,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 				return Enumerable.Empty<IRenderable>();
 
 			// Players want to see the lines when in waypoint mode.
-			var force = Game.GetModifierKeys().HasModifier(Modifiers.Shift);
+			var force = Game.GetModifierKeys().HasModifier(Modifiers.Shift) || self.World.OrderGenerator is ForceModifiersOrderGenerator;
 
 			if (--lifetime <= 0 && !force)
 				return Enumerable.Empty<IRenderable>();

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -589,7 +589,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 		}
 
-		static bool ShowMouseScrollDropdown(DropDownButtonWidget dropdown, GameSettings s, bool rightMouse)
+		static void ShowMouseScrollDropdown(DropDownButtonWidget dropdown, GameSettings s, bool rightMouse)
 		{
 			var options = new Dictionary<string, MouseScrollType>()
 			{
@@ -609,10 +609,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, setupItem);
-			return true;
 		}
 
-		static bool ShowZoomModifierDropdown(DropDownButtonWidget dropdown, GameSettings s)
+		static void ShowZoomModifierDropdown(DropDownButtonWidget dropdown, GameSettings s)
 		{
 			var options = new Dictionary<string, Modifiers>()
 			{
@@ -633,10 +632,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, setupItem);
-			return true;
 		}
 
-		bool ShowAudioDeviceDropdown(DropDownButtonWidget dropdown, SoundDevice[] devices)
+		void ShowAudioDeviceDropdown(DropDownButtonWidget dropdown, SoundDevice[] devices)
 		{
 			var i = 0;
 			var options = devices.ToDictionary(d => (i++).ToString(), d => d);
@@ -655,10 +653,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, setupItem);
-			return true;
 		}
 
-		static bool ShowWindowModeDropdown(DropDownButtonWidget dropdown, GraphicSettings s)
+		static void ShowWindowModeDropdown(DropDownButtonWidget dropdown, GraphicSettings s)
 		{
 			var options = new Dictionary<string, WindowMode>()
 			{
@@ -678,10 +675,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, setupItem);
-			return true;
 		}
 
-		static bool ShowLanguageDropdown(DropDownButtonWidget dropdown, IEnumerable<string> languages)
+		static void ShowLanguageDropdown(DropDownButtonWidget dropdown, IEnumerable<string> languages)
 		{
 			Func<string, ScrollItemWidget, ScrollItemWidget> setupItem = (o, itemTemplate) =>
 			{
@@ -694,10 +690,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, languages, setupItem);
-			return true;
 		}
 
-		static bool ShowStatusBarsDropdown(DropDownButtonWidget dropdown, GameSettings s)
+		static void ShowStatusBarsDropdown(DropDownButtonWidget dropdown, GameSettings s)
 		{
 			var options = new Dictionary<string, StatusBarsType>()
 			{
@@ -717,10 +712,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, setupItem);
-			return true;
 		}
 
-		static bool ShowTargetLinesDropdown(DropDownButtonWidget dropdown, GameSettings s)
+		static void ShowTargetLinesDropdown(DropDownButtonWidget dropdown, GameSettings s)
 		{
 			var options = new Dictionary<string, TargetLinesType>()
 			{
@@ -740,7 +734,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, setupItem);
-			return true;
 		}
 
 		void MakeMouseFocusSettingsLive()

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -205,7 +205,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			BindCheckboxPref(panel, "PIXELDOUBLE_CHECKBOX", ds, "PixelDouble");
 			BindCheckboxPref(panel, "CURSORDOUBLE_CHECKBOX", ds, "CursorDouble");
 			BindCheckboxPref(panel, "FRAME_LIMIT_CHECKBOX", ds, "CapFramerate");
-			BindCheckboxPref(panel, "DISPLAY_TARGET_LINES_CHECKBOX", gs, "DrawTargetLine");
 			BindCheckboxPref(panel, "PLAYER_STANCE_COLORS_CHECKBOX", gs, "UsePlayerStanceColors");
 
 			var languageDropDownButton = panel.Get<DropDownButtonWidget>("LANGUAGE_DROPDOWNBUTTON");
@@ -219,8 +218,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var statusBarsDropDown = panel.Get<DropDownButtonWidget>("STATUS_BAR_DROPDOWN");
 			statusBarsDropDown.OnMouseDown = _ => ShowStatusBarsDropdown(statusBarsDropDown, gs);
-			statusBarsDropDown.GetText = () => gs.StatusBars.ToString() == "Standard" ?
-				"Standard" : gs.StatusBars.ToString() == "DamageShow" ? "Show On Damage" : "Always Show";
+			statusBarsDropDown.GetText = () => gs.StatusBars == StatusBarsType.Standard ?
+				"Standard" : gs.StatusBars == StatusBarsType.DamageShow ? "Show On Damage" : "Always Show";
+
+			var targetLinesDropDown = panel.Get<DropDownButtonWidget>("TARGET_LINES_DROPDOWN");
+			targetLinesDropDown.OnMouseDown = _ => ShowTargetLinesDropdown(targetLinesDropDown, gs);
+			targetLinesDropDown.GetText = () => gs.TargetLines == TargetLinesType.Automatic ?
+				"Automatic" : gs.TargetLines == TargetLinesType.Manual ? "Manual" : "Disabled";
 
 			// Update zoom immediately
 			var pixelDoubleCheckbox = panel.Get<CheckboxWidget>("PIXELDOUBLE_CHECKBOX");
@@ -707,6 +711,29 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				var item = ScrollItemWidget.Setup(itemTemplate,
 					() => s.StatusBars == options[o],
 					() => s.StatusBars = options[o]);
+
+				item.Get<LabelWidget>("LABEL").GetText = () => o;
+				return item;
+			};
+
+			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, setupItem);
+			return true;
+		}
+
+		static bool ShowTargetLinesDropdown(DropDownButtonWidget dropdown, GameSettings s)
+		{
+			var options = new Dictionary<string, TargetLinesType>()
+			{
+				{ "Automatic", TargetLinesType.Automatic },
+				{ "Manual", TargetLinesType.Manual },
+				{ "Disabled", TargetLinesType.Disabled },
+			};
+
+			Func<string, ScrollItemWidget, ScrollItemWidget> setupItem = (o, itemTemplate) =>
+			{
+				var item = ScrollItemWidget.Setup(itemTemplate,
+					() => s.TargetLines == options[o],
+					() => s.TargetLines = options[o]);
 
 				item.Get<LabelWidget>("LABEL").GetText = () => o;
 				return item;

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -210,23 +210,29 @@ Container@SETTINGS_PANEL:
 									Width: PARENT_RIGHT - 35
 									Height: PARENT_BOTTOM - 12
 						Label@STATUS_BARS:
-							X: 310
+							X: 250
 							Y: 257
+							Width: 145
 							Text: Status Bars:
+							Align: Right
 						DropDownButton@STATUS_BAR_DROPDOWN:
 							X: 400
 							Y: 245
 							Width: 170
 							Height: 25
 							Font: Regular
-							Text: Standard
-						Checkbox@DISPLAY_TARGET_LINES_CHECKBOX:
-							X: 310
+						Label@TARGET_LINES:
+							X: 250
+							Y: 228
+							Width: 145
+							Text: Target Lines:
+							Align: Right
+						DropDownButton@TARGET_LINES_DROPDOWN:
+							X: 400
 							Y: 215
-							Width: 200
-							Height: 20
+							Width: 170
+							Height: 25
 							Font: Regular
-							Text: Display Target Lines
 						Label@LOCALIZATION_TITLE:
 							Y: 265
 							Width: PARENT_RIGHT

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -224,9 +224,11 @@ Background@SETTINGS_PANEL:
 							Width: PARENT_RIGHT - 35
 							Height: PARENT_BOTTOM - 12
 				Label@STATUS_BARS:
-					X: 310
+					X: 250
 					Y: 278
+					Width: 145
 					Text: Status Bars:
+					Align: Right
 				DropDownButton@STATUS_BAR_DROPDOWN:
 					X: 400
 					Y: 265
@@ -234,13 +236,18 @@ Background@SETTINGS_PANEL:
 					Height: 25
 					Font: Regular
 					Text: Standard
-				Checkbox@DISPLAY_TARGET_LINES_CHECKBOX:
-					X: 310
+				Label@TARGET_LINES:
+					X: 250
+					Y: 243
+					Width: 145
+					Text: Target Lines:
+					Align: Right
+				DropDownButton@TARGET_LINES_DROPDOWN:
+					X: 400
 					Y: 230
-					Width: 200
-					Height: 20
+					Width: 170
+					Height: 25
 					Font: Regular
-					Text: Display Target Lines
 				Label@LOCALIZATION_TITLE:
 					Y: 270
 					Width: PARENT_RIGHT


### PR DESCRIPTION
#16616 and followup discussion in the last couple of days in IRC and discord have raised the point that the current target line behaviour is really not ideal. It would be a shame and wasted opportunity if we don't at least try to improve this as part of our queued-order overhaul in the upcoming release.

This PR replaces the "Display Target Lines" checkbox in the settings menu with a dropdown that has three options:
* Automatic: Lines are automatically displayed for 2.4 seconds on selection / order, and are always visible while the waypoint mode (<kbd>shift</kbd>) is active (TS/RA2/previous-OpenRA style)
* Manual: Lines are only displayed while the waypoint mode is active (C&C3 style)
* Disabled: Lines are never displayed (TD/RA1 style)

The final commit switches the default behaviour from the TS/RA2 style to the C&C3 style, which dramatically cleans up the UI when commanding unit blobs. The order flash remains to provide visual confirmation of orders, and players who prefer the feedback of the lines are still able to switch back to Automatic in the settings. The so-far limited feedback from IRC and Discord has been inconclusive, so I would like to get this in to the first playtest to trigger wider discussion.

Closes #16892
Closes #5245 (the target lines provide the visual indication)