### PR TITLE
Define nearenough parameter for aircraft 

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
@@ -23,9 +24,18 @@ namespace OpenRA.Mods.Common.Activities
 		readonly WDist maxRange;
 		readonly WDist minRange;
 		readonly Color? targetLineColor;
+		readonly WDist nearEnough;
+
 		Target target;
 		Target lastVisibleTarget;
 		bool useLastVisibleTarget;
+		readonly List<WPos> positionBuffer = new List<WPos>();
+
+		public Fly(Actor self, Target t, WDist nearEnough, WPos? initialTargetPosition = null, Color? targetLineColor = null)
+			: this(self, t, initialTargetPosition, targetLineColor)
+		{
+			this.nearEnough = nearEnough;
+		}
 
 		public Fly(Actor self, Target t, WPos? initialTargetPosition = null, Color? targetLineColor = null)
 		{
@@ -166,6 +176,12 @@ namespace OpenRA.Mods.Common.Activities
 				return false;
 			}
 
+			// HACK: Consider ourselves blocked if we have moved by less than 64 WDist in the last five ticks
+			// Stop if we are blocked and close enough
+			if (positionBuffer.Count >= 5 && (positionBuffer.Last() - positionBuffer[0]).LengthSquared < 4096 &&
+				delta.HorizontalLengthSquared <= nearEnough.LengthSquared)
+				return true;
+
 			// The next move would overshoot, so consider it close enough or set final position if we CanSlide
 			if (delta.HorizontalLengthSquared < move.HorizontalLengthSquared)
 			{
@@ -212,6 +228,10 @@ namespace OpenRA.Mods.Common.Activities
 				if ((checkTarget.CenterPosition - turnCenter).HorizontalLengthSquared < turnRadius * turnRadius)
 					desiredFacing = aircraft.Facing;
 			}
+
+			positionBuffer.Add(self.CenterPosition);
+			if (positionBuffer.Count > 5)
+				positionBuffer.RemoveAt(0);
 
 			FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude);
 

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -217,6 +217,7 @@ namespace OpenRA.Mods.Common.Traits
 		public Actor ReservedActor { get; private set; }
 		public bool MayYieldReservation { get; private set; }
 		public bool ForceLanding { get; private set; }
+
 		IEnumerable<CPos> landingCells = Enumerable.Empty<CPos>();
 		bool requireForceMove;
 
@@ -840,7 +841,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Activity MoveTo(CPos cell, int nearEnough, Color? targetLineColor = null)
 		{
-			return new Fly(self, Target.FromCell(self.World, cell), targetLineColor: targetLineColor);
+			return new Fly(self, Target.FromCell(self.World, cell), WDist.FromCells(nearEnough), targetLineColor: targetLineColor);
 		}
 
 		public Activity MoveTo(CPos cell, Actor ignoreActor, Color? targetLineColor = null)
@@ -1002,7 +1003,9 @@ namespace OpenRA.Mods.Common.Traits
 					UnReserve();
 
 				var target = Target.FromCell(self.World, cell);
-				self.QueueActivity(order.Queued, new Fly(self, target, targetLineColor: Color.Green));
+
+				// TODO: this should scale with unit selection group size.
+				self.QueueActivity(order.Queued, new Fly(self, target, WDist.FromCells(8), targetLineColor: Color.Green));
 				self.ShowTargetLines();
 			}
 			else if (orderString == "Land")

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -78,7 +78,9 @@ namespace OpenRA.Mods.Common.Traits
 
 				var targetLocation = move.NearestMoveableCell(cell);
 				var assaultMoving = order.OrderString == "AssaultMove";
-				self.QueueActivity(new AttackMoveActivity(self, () => move.MoveTo(targetLocation, 1, targetLineColor: Color.OrangeRed), assaultMoving));
+
+				// TODO: this should scale with unit selection group size.
+				self.QueueActivity(new AttackMoveActivity(self, () => move.MoveTo(targetLocation, 8, targetLineColor: Color.OrangeRed), assaultMoving));
 				self.ShowTargetLines();
 			}
 		}


### PR DESCRIPTION
Introduces a `nearEnough` parameter for the `Fly` activity similar to the one in `Move.` This allows aircraft to exit early when they get stuck during their movement and prevents queued aircraft orders from never being executed.

It doesn't really solve the jostling for position problem, but at least lets the aircraft snap out of it after a while.

Fixes #11521
Split from #16883 