### PR TITLE
Allow Attack Move and Guard OGs to be activated while shift is held.

### DIFF
--- a/OpenRA.Game/Orders/GenericSelectTarget.cs
+++ b/OpenRA.Game/Orders/GenericSelectTarget.cs
@@ -68,5 +68,7 @@ namespace OpenRA.Orders
 			// Custom order generators always override selection
 			return true;
 		}
+
+		public override bool ClearSelectionOnLeftClick { get { return false; } }
 	}
 }

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -204,5 +204,7 @@ namespace OpenRA.Orders
 				Target = target;
 			}
 		}
+
+		public virtual bool ClearSelectionOnLeftClick { get { return true; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -148,5 +148,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Custom order generators always override selection
 			return true;
 		}
+
+		public override bool ClearSelectionOnLeftClick { get { return false; } }
 	}
 }


### PR DESCRIPTION
This PR generalizes the fix from #15596 to also work for Attack Move and Guard.

Fixes #16907.
Fixes #16381.

In the future (it is well out of scope for this PR) we should consider expanding the hotkey system and UI to prevent players from rebinding these commands against Shift, which would prevent them from ever working.