### PR TITLE
Render waypoint lines below actors.

### DIFF
--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -111,6 +111,12 @@ namespace OpenRA.Traits
 		IEnumerable<Rectangle> ScreenBounds(Actor self, WorldRenderer wr);
 	}
 
+	public interface IRenderUnder
+	{
+		IEnumerable<IRenderable> RenderUnder(Actor self, WorldRenderer wr);
+		IEnumerable<Rectangle> ScreenBounds(Actor self, WorldRenderer wr);
+	}
+
 	// TODO: Replace Rectangle with an int2[] polygon
 	public interface IMouseBounds { Rectangle MouseoverBounds(Actor self, WorldRenderer wr); }
 	public interface IMouseBoundsInfo : ITraitInfoInterface { }
@@ -412,6 +418,12 @@ namespace OpenRA.Traits
 	public interface IRenderAboveShroudWhenSelected
 	{
 		IEnumerable<IRenderable> RenderAboveShroud(Actor self, WorldRenderer wr);
+		bool SpatiallyPartitionable { get; }
+	}
+
+	public interface IRenderAboveTerrainWhenSelected
+	{
+		IEnumerable<IRenderable> RenderAboveTerrain(Actor self, WorldRenderer wr);
 		bool SpatiallyPartitionable { get; }
 	}
 

--- a/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				var offset = self.World.Map.CenterOfCell(cell) - self.World.Map.CenterOfCell(location) - centerOffset;
 				var awo = new AnimationWithOffset(anim, () => offset, null, -(offset.Y + centerOffset.Y + 512));
 				anims.Add(awo);
-				rs.Add(awo, info.Palette);
+				rs.AddUnder(awo, info.Palette);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		public virtual object Create(ActorInitializer init) { return new DrawLineToTarget(init.Self, this); }
 	}
 
-	public class DrawLineToTarget : IRenderAboveShroudWhenSelected, INotifySelected
+	public class DrawLineToTarget : IRenderAboveTerrainWhenSelected, INotifySelected
 	{
 		readonly DrawLineToTargetInfo info;
 		readonly List<IRenderable> renderableCache = new List<IRenderable>();
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 			ShowTargetLines(self);
 		}
 
-		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAboveTerrainWhenSelected.RenderAboveTerrain(Actor self, WorldRenderer wr)
 		{
 			if (!self.Owner.IsAlliedWith(self.World.LocalPlayer))
 				return Enumerable.Empty<IRenderable>();
@@ -103,7 +103,7 @@ namespace OpenRA.Mods.Common.Traits
 			return renderableCache;
 		}
 
-		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return false; } }
+		bool IRenderAboveTerrainWhenSelected.SpatiallyPartitionable { get { return false; } }
 	}
 
 	public static class LineTargetExts


### PR DESCRIPTION
A proposal to address #16616.

Target lines are drawn under actors which prevent them from obscuring units. For visual appeal they are still drawn above building bibs. This results in something that looks very similar to how waypoint lines are drawn in C&C3. As a bonus this makes the minefield overlay look much less intrusive.

