### PR TITLE
Fix AI harvester not resuming after chronoshift.

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -112,7 +112,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!h.Key.IsIdle)
 				{
 					var act = h.Key.CurrentActivity;
-					if (!h.Value.Harvester.LastSearchFailed || act.NextActivity == null || act.NextActivity.GetType() != typeof(FindAndDeliverResources))
+					if (!h.Value.Harvester.LastSearchFailed || act.NextActivity == null || !(act.NextActivity is FindAndDeliverResources))
 						continue;
 				}
 

--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -109,9 +109,6 @@ namespace OpenRA.Mods.Common.Traits
 			// Find idle harvesters and give them orders:
 			foreach (var h in harvesters)
 			{
-				if (!h.Value.Harvester.IsEmpty)
-					continue;
-
 				if (!h.Key.IsIdle)
 				{
 					var act = h.Key.CurrentActivity;


### PR DESCRIPTION
Fixes #16904 

Bots will now also order idle harvesters that are not empty.