### PR TITLE
Adjust waypoint linewidths.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly string Image = "rallypoint";
 
 		[Desc("Width (in pixels) of the rallypoint line.")]
-		public readonly int LineWidth = 2;
+		public readonly int LineWidth = 1;
 
 		[SequenceReference("Image")]
 		public readonly string FlagSequence = "flag";

--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -24,10 +24,16 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int Delay = 60;
 
 		[Desc("Width (in pixels) of the target lines.")]
-		public readonly int LineWidth = 2;
+		public readonly int LineWidth = 1;
+
+		[Desc("Width (in pixels) of the queued target lines.")]
+		public readonly int QueuedLineWidth = 1;
 
 		[Desc("Width (in pixels) of the end node markers.")]
-		public readonly int MarkerWidth = 3;
+		public readonly int MarkerWidth = 2;
+
+		[Desc("Width (in pixels) of the queued end node markers.")]
+		public readonly int QueuedMarkerWidth = 2;
 
 		public virtual object Create(ActorInitializer init) { return new DrawLineToTarget(init.Self, this); }
 	}
@@ -80,12 +86,15 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					if (n.Target.Type != TargetType.Invalid)
 					{
+						var lineWidth = renderableCache.Any() ? info.QueuedLineWidth : info.LineWidth;
+						var markerWidth = renderableCache.Any() ? info.QueuedMarkerWidth : info.MarkerWidth;
+
 						var pal = wr.Palette(TileSet.TerrainPaletteInternalName);
 						var tile = n.Tile;
 						var pos = n.Target.CenterPosition;
 
 						if (tile == null)
-							renderableCache.Add(new TargetLineRenderable(new[] { prev, pos }, n.Color, info.LineWidth, info.MarkerWidth));
+							renderableCache.Add(new TargetLineRenderable(new[] { prev, pos }, n.Color, lineWidth, markerWidth));
 						else
 							renderableCache.Add(new SpriteRenderable(tile, pos, WVec.Zero, -511, pal, 1f, true));
 

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -550,6 +550,8 @@
 		Action: Kill
 		DeathTypes: BulletDeath
 	DrawLineToTarget:
+		QueuedLineWidth: 2
+		QueuedMarkerWidth: 3
 	Health:
 		HP: 5000
 	Armor:
@@ -752,6 +754,8 @@
 	OwnerLostAction:
 		Action: Kill
 	DrawLineToTarget:
+		QueuedLineWidth: 2
+		QueuedMarkerWidth: 3
 	Mobile:
 		PauseOnCondition: empdisable || being-captured || carried
 		Locomotor: wheeled
@@ -855,6 +859,8 @@
 	OwnerLostAction:
 		Action: Kill
 	DrawLineToTarget:
+		QueuedLineWidth: 2
+		QueuedMarkerWidth: 3
 	AppearsOnRadar:
 		UseLocation: true
 	Targetable@GROUND:
@@ -945,6 +951,8 @@
 	Inherits@SELECTION_MODE: ^FlatSelectionMode
 	Huntable:
 	DrawLineToTarget:
+		QueuedLineWidth: 2
+		QueuedMarkerWidth: 3
 	Health:
 	Armor:
 		Type: Light
@@ -1100,6 +1108,8 @@
 	RenderSprites:
 	WithVoxelBody:
 	DrawLineToTarget:
+		QueuedLineWidth: 2
+		QueuedMarkerWidth: 3
 	Mobile:
 		TurnSpeed: 5
 		Voice: Move

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -99,6 +99,7 @@ GAPILE:
 		Offset: 2,3
 		Palette: mouse
 		IsPlayerPalette: false
+		LineWidth: 2
 	Exit@1:
 		SpawnOffset: -256,1024,0
 		ExitCell: 2,2
@@ -163,6 +164,7 @@ GAWEAP:
 		Offset: 4,1
 		Palette: mouse
 		IsPlayerPalette: false
+		LineWidth: 2
 	Exit@1:
 		SpawnOffset: -384,-384,0
 		ExitCell: 3,1
@@ -231,6 +233,7 @@ GAHPAD:
 	RallyPoint:
 		Palette: mouse
 		IsPlayerPalette: false
+		LineWidth: 2
 	Production:
 		Produces: Air
 		PauseOnCondition: empdisable
@@ -301,6 +304,7 @@ GADEPT:
 	RallyPoint:
 		Palette: mouse
 		IsPlayerPalette: false
+		LineWidth: 2
 	WithIdleOverlay@LIGHT:
 		RequiresCondition: !build-incomplete
 		Sequence: idle-light

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -112,6 +112,7 @@ NAHAND:
 		Offset: 3,3
 		Palette: mouse
 		IsPlayerPalette: false
+		LineWidth: 2
 	Production:
 		Produces: Infantry
 		PauseOnCondition: empdisable
@@ -169,6 +170,7 @@ NAWEAP:
 		Offset: 4,1
 		Palette: mouse
 		IsPlayerPalette: false
+		LineWidth: 2
 	Exit@1:
 		SpawnOffset: -384,-384,0
 		ExitCell: 3,1
@@ -231,6 +233,7 @@ NAHPAD:
 	RallyPoint:
 		Palette: mouse
 		IsPlayerPalette: false
+		LineWidth: 2
 	Production:
 		Produces: Air
 		PauseOnCondition: empdisable


### PR DESCRIPTION
- Reduces all target lines in gen1 mods to 1 pixel width
- In gen2 mods active lines are now 1 pixel width and queued waypoints are 2 pixel width (similar to RA2 waypoint mode)

(hopefully) closes #16616 
