### PR TITLE
Truncate SLOT_OPTIONS and PLAYER_ACTION dropdown labels.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -405,7 +405,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var slot = parent.Get<DropDownButtonWidget>("SLOT_OPTIONS");
 			slot.IsVisible = () => true;
 			slot.IsDisabled = () => orderManager.LocalClient.IsReady;
-			slot.GetText = () => c != null ? c.Name : s.Closed ? "Closed" : "Open";
+
+			var truncated = new CachedTransform<string, string>(name =>
+				WidgetUtils.TruncateText(name, slot.Bounds.Width - slot.Bounds.Height - slot.LeftMargin - slot.RightMargin,
+				Game.Renderer.Fonts[slot.Font]));
+
+			slot.GetText = () => truncated.Update(c != null ? c.Name : s.Closed ? "Closed" : "Open");
 			slot.OnMouseDown = _ => ShowSlotDropDown(slot, s, c, orderManager, map);
 
 			// Ensure Name selector (if present) is hidden
@@ -428,7 +433,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var slot = parent.Get<DropDownButtonWidget>("PLAYER_ACTION");
 			slot.IsVisible = () => Game.IsHost && c.Index != orderManager.LocalClient.Index;
 			slot.IsDisabled = () => orderManager.LocalClient.IsReady;
-			slot.GetText = () => c != null ? c.Name : string.Empty;
+
+			var truncated = new CachedTransform<string, string>(name =>
+				WidgetUtils.TruncateText(name, slot.Bounds.Width - slot.Bounds.Height - slot.LeftMargin - slot.RightMargin,
+				Game.Renderer.Fonts[slot.Font]));
+
+			slot.GetText = () => truncated.Update(c != null ? c.Name : string.Empty);
 			slot.OnMouseDown = _ => ShowPlayerActionDropDown(slot, s, c, orderManager, lobby, before, after);
 
 			SetupProfileWidget(slot, c, orderManager, worldRenderer);


### PR DESCRIPTION
Before:
![Screenshot 2019-08-11 at 12 49 48](https://user-images.githubusercontent.com/167819/62833438-86f57580-bc36-11e9-907d-21865bf84138.png)

After: 
![Screenshot 2019-08-11 at 12 48 17](https://user-images.githubusercontent.com/167819/62833433-71804b80-bc36-11e9-842e-6ec5e01c2154.png)

Truncation is done at the Logic level rather than in the `DropDownWidget` for consistency with the rest of the lobby widget setup and avoid other unexpected regressions. This should all be fixed properly as #16821 develops.