### PR TITLE
Discourage harvesters from wandering too far from the refinery.

### DIFF
--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Pathfinder;
@@ -175,7 +176,8 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			// Determine where to search from and how far to search:
-			var searchFromLoc = lastHarvestedCell ?? GetSearchFromProcLocation(self);
+			var procLoc = GetSearchFromProcLocation(self);
+			var searchFromLoc = lastHarvestedCell ?? procLoc;
 			var searchRadius = lastHarvestedCell.HasValue ? harvInfo.SearchFromHarvesterRadius : harvInfo.SearchFromProcRadius;
 			if (!searchFromLoc.HasValue)
 			{
@@ -185,6 +187,9 @@ namespace OpenRA.Mods.Common.Activities
 
 			var searchRadiusSquared = searchRadius * searchRadius;
 
+			var procPos = procLoc.HasValue ? (WPos?)self.World.Map.CenterOfCell(procLoc.Value) : null;
+			var harvPos = self.CenterPosition;
+
 			// Find any harvestable resources:
 			List<CPos> path;
 			using (var search = PathSearch.Search(self.World, mobile.Locomotor, self, true, loc =>
@@ -193,6 +198,26 @@ namespace OpenRA.Mods.Common.Activities
 				{
 					if ((loc - searchFromLoc.Value).LengthSquared > searchRadiusSquared)
 						return int.MaxValue;
+
+					// Add a cost modifier to harvestable cells to prefer resources that are closer to the refinery.
+					// This reduces the tendancy for harvesters to move in straight lines
+					if (procPos.HasValue && harvInfo.ResourceRefineryDirectionPenalty > 0 && harv.CanHarvestCell(self, loc))
+					{
+						var pos = self.World.Map.CenterOfCell(loc);
+
+						// Calculate harv-cell-refinery angle (cosine rule)
+						var aSq = (harvPos - procPos.Value).LengthSquared;
+						var bSq = (pos - procPos.Value).LengthSquared;
+						var cSq = (pos - harvPos).LengthSquared;
+
+						if (bSq > 0 && cSq > 0)
+						{
+							var cosA = (int)(1024 * (bSq + cSq - aSq) / (2 * Exts.ISqrt(bSq * cSq)));
+
+							// Cost modifier varies between 0 and ResourceRefineryDirectionPenalty
+							return Math.Abs(harvInfo.ResourceRefineryDirectionPenalty / 2) + harvInfo.ResourceRefineryDirectionPenalty * cosA / 2048;
+						}
+					}
 
 					return 0;
 				})

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -71,6 +71,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The pathfinding cost penalty applied for each harvester waiting to unload at a refinery.")]
 		public readonly int UnloadQueueCostModifier = 12;
 
+		[Desc("The pathfinding cost penalty applied for cells directly away from the refinery.")]
+		public readonly int ResourceRefineryDirectionPenalty = 200;
+
 		[Desc("Does the unit queue harvesting runs instead of individual harvest actions?")]
 		public readonly bool QueueFullLoad = false;
 


### PR DESCRIPTION
One of the easier to address complaints about the "new" harvester behaviour is that they still tend to prefer to harvest in straight lines, moving much further from the refinery and therefore taking longer than necessary to complete each harvesting run.

This PR adds a cost penalty to the cell being harvested so the pathfinder should prefer cells that are closer to the refinery.