### PR TITLE
Fix units from transports appearing at load point.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -140,6 +140,7 @@ Also thanks to:
     * Tim Mylemans (gecko)
     * Tirili
     * Tomas Einarsson (Mesacer)
+    * Tom van Leth (tovl)
     * Tristan Keating (Kilkakon)
     * Tristan Mühlbacher (MicroBit)
     * UnknownProgrammer

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -191,7 +191,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			WPos? initialTargetPosition = null, Color? targetLineColor = null) { return null; }
 		public Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null) { return null; }
-		public Activity MoveIntoWorld(Actor self, CPos cell, SubCell subCell = SubCell.Any) { return null; }
+		public Activity MoveIntoWorld(Actor self, int delay = 0) { return null; }
 		public Activity MoveToTarget(Actor self, Target target,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null) { return null; }
 		public Activity MoveIntoTarget(Actor self, Target target) { return null; }

--- a/OpenRA.Mods.Common/Activities/Enter.cs
+++ b/OpenRA.Mods.Common/Activities/Enter.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Activities
 
 	public abstract class Enter : Activity
 	{
-		enum EnterState { Approaching, Entering, Exiting }
+		enum EnterState { Approaching, Entering, Exiting, Finished }
 
 		readonly IMove move;
 		readonly Color? targetLineColor;
@@ -133,15 +133,18 @@ namespace OpenRA.Mods.Common.Activities
 						OnEnterComplete(self, target.Actor);
 
 					lastState = EnterState.Exiting;
-					QueueChild(move.MoveIntoWorld(self, self.Location));
 					return false;
 				}
 
 				case EnterState.Exiting:
-					return true;
+				{
+					QueueChild(move.MoveIntoWorld(self));
+					lastState = EnterState.Finished;
+					return false;
+				}
 			}
 
-			return false;
+			return true;
 		}
 
 		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)

--- a/OpenRA.Mods.Common/Activities/Parachute.cs
+++ b/OpenRA.Mods.Common/Activities/Parachute.cs
@@ -19,14 +19,12 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly IPositionable pos;
 		readonly WVec fallVector;
-		readonly Actor ignore;
 
 		int groundLevel;
 
-		public Parachute(Actor self, Actor ignoreActor = null)
+		public Parachute(Actor self)
 		{
 			pos = self.TraitOrDefault<IPositionable>();
-			ignore = ignoreActor;
 
 			fallVector = new WVec(0, 0, self.Info.TraitInfo<ParachutableInfo>().FallRate);
 			IsInterruptible = false;
@@ -56,7 +54,7 @@ namespace OpenRA.Mods.Common.Activities
 			pos.SetPosition(self, centerPosition + new WVec(0, 0, groundLevel - centerPosition.Z));
 
 			foreach (var np in self.TraitsImplementing<INotifyParachute>())
-				np.OnLanded(self, ignore);
+				np.OnLanded(self);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/RideTransport.cs
+++ b/OpenRA.Mods.Common/Activities/RideTransport.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
-	class EnterTransport : Enter
+	class RideTransport : Enter
 	{
 		readonly Passenger passenger;
 
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 		Cargo enterCargo;
 		Aircraft enterAircraft;
 
-		public EnterTransport(Actor self, Target target)
+		public RideTransport(Actor self, Target target)
 			: base(self, target, Color.Green)
 		{
 			passenger = self.Trait<Passenger>();
@@ -63,10 +63,6 @@ namespace OpenRA.Mods.Common.Activities
 
 				enterCargo.Load(enterActor, self);
 				w.Remove(self);
-
-				// Preemptively cancel any activities to avoid an edge-case where successively queued
-				// EnterTransports corrupt the actor state. Activities are cancelled again on unload
-				self.CancelActivity();
 			});
 		}
 

--- a/OpenRA.Mods.Common/Activities/UnloadCargo.cs
+++ b/OpenRA.Mods.Common/Activities/UnloadCargo.cs
@@ -121,9 +121,10 @@ namespace OpenRA.Mods.Common.Activities
 					var move = actor.Trait<IMove>();
 					var pos = actor.Trait<IPositionable>();
 
-					actor.CancelActivity();
+					pos.SetPosition(self, exitSubCell.Value.First, exitSubCell.Value.Second);
 					pos.SetVisualPosition(actor, spawn);
-					actor.QueueActivity(move.MoveIntoWorld(actor, exitSubCell.Value.First, exitSubCell.Value.Second));
+
+					actor.CancelActivity();
 					w.Add(actor);
 				});
 			}

--- a/OpenRA.Mods.Common/ActorInitializer.cs
+++ b/OpenRA.Mods.Common/ActorInitializer.cs
@@ -24,6 +24,16 @@ namespace OpenRA.Mods.Common
 		public int Value(World world) { return value; }
 	}
 
+	public class MoveIntoWorldDelayInit : IActorInit<int>
+	{
+		[FieldFromYamlKey]
+		readonly int value = 0;
+
+		public MoveIntoWorldDelayInit() { }
+		public MoveIntoWorldDelayInit(int init) { value = init; }
+		public int Value(World world) { return value; }
+	}
+
 	public class DynamicFacingInit : IActorInit<Func<int>>
 	{
 		readonly Func<int> func;

--- a/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
@@ -46,7 +46,10 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Moves from outside the world into the cell grid.")]
 		public void MoveIntoWorld(CPos cell)
 		{
-			Self.QueueActivity(mobile.MoveIntoWorld(Self, cell, mobile.ToSubCell));
+			var pos = Self.CenterPosition;
+			mobile.SetPosition(Self, cell);
+			mobile.SetVisualPosition(Self, pos);
+			Self.QueueActivity(mobile.MoveIntoWorld(Self));
 		}
 
 		[ScriptActorPropertyActivity]
@@ -60,7 +63,7 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Move to and enter the transport.")]
 		public void EnterTransport(Actor transport)
 		{
-			Self.QueueActivity(new EnterTransport(Self, Target.FromActor(transport)));
+			Self.QueueActivity(new RideTransport(Self, Target.FromActor(transport)));
 		}
 
 		[Desc("Whether the actor can move (false if immobilized).")]

--- a/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
@@ -29,9 +29,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Type tags on this exit.")]
 		public readonly HashSet<string> ProductionTypes = new HashSet<string>();
 
-		[Desc("AttackMove to a RallyPoint or stay where you are spawned.")]
-		public readonly bool MoveIntoWorld = true;
-
 		[Desc("Number of ticks to wait before moving into the world.")]
 		public readonly int ExitDelay = 0;
 

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -106,7 +107,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		void INotifyParachute.OnParachute(Actor self) { }
-		void INotifyParachute.OnLanded(Actor self, Actor ignore)
+		void INotifyParachute.OnLanded(Actor self)
 		{
 			// Check whether the crate landed on anything
 			var landedOn = self.World.ActorMap.GetActorsAt(self.Location)
@@ -237,6 +238,9 @@ namespace OpenRA.Mods.Common.Traits
 			var cs = self.World.WorldActor.TraitOrDefault<CrateSpawner>();
 			if (cs != null)
 				cs.IncrementCrates();
+
+			if (self.World.Map.DistanceAboveTerrain(CenterPosition) > WDist.Zero && self.TraitOrDefault<Parachutable>() != null)
+				self.QueueActivity(new Parachute(self));
 		}
 
 		void INotifyRemovedFromWorld.RemovedFromWorld(Actor self)

--- a/OpenRA.Mods.Common/Traits/EjectOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/EjectOnDeath.cs
@@ -82,11 +82,10 @@ namespace OpenRA.Mods.Common.Traits
 				self.World.AddFrameEndTask(w =>
 				{
 					pilotPositionable.SetPosition(pilot, pilotCell, pilotSubCell);
-					w.Add(pilot);
-
 					var dropPosition = pilot.CenterPosition + new WVec(0, 0, self.CenterPosition.Z - pilot.CenterPosition.Z);
 					pilotPositionable.SetVisualPosition(pilot, dropPosition);
-					pilot.QueueActivity(new Parachute(pilot));
+
+					w.Add(pilot);
 				});
 
 				Game.Sound.Play(SoundType.World, Info.ChuteSound, cp);

--- a/OpenRA.Mods.Common/Traits/ParaDrop.cs
+++ b/OpenRA.Mods.Common/Traits/ParaDrop.cs
@@ -105,12 +105,10 @@ namespace OpenRA.Mods.Common.Traits
 			self.World.AddFrameEndTask(w =>
 			{
 				dropPositionable.SetPosition(dropActor, dropCell, dropSubCell);
-				w.Add(dropActor);
 
 				var dropPosition = dropActor.CenterPosition + new WVec(0, 0, self.CenterPosition.Z - dropActor.CenterPosition.Z);
 				dropPositionable.SetVisualPosition(dropActor, dropPosition);
-
-				dropActor.QueueActivity(new Parachute(dropActor));
+				w.Add(dropActor);
 			});
 
 			Game.Sound.Play(SoundType.World, info.ChuteSound, self.CenterPosition);

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -62,6 +62,8 @@ namespace OpenRA.Mods.Common.Traits
 		readonly ParachutableInfo info;
 		readonly IPositionable positionable;
 
+		public Actor IgnoreActor;
+
 		ConditionManager conditionManager;
 		int parachutingToken = ConditionManager.InvalidConditionToken;
 
@@ -86,7 +88,7 @@ namespace OpenRA.Mods.Common.Traits
 				parachutingToken = conditionManager.GrantCondition(self, info.ParachutingCondition);
 		}
 
-		void INotifyParachute.OnLanded(Actor self, Actor ignore)
+		void INotifyParachute.OnLanded(Actor self)
 		{
 			IsInAir = false;
 
@@ -100,7 +102,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (positionable.CanEnterCell(cell, self))
 				return;
 
-			if (ignore != null && self.World.ActorMap.GetActorsAt(cell).Any(a => a != ignore))
+			if (IgnoreActor != null && self.World.ActorMap.GetActorsAt(cell).Any(a => a != IgnoreActor))
 				return;
 
 			var onWater = info.WaterTerrainTypes.Contains(self.World.Map.GetTerrainInfo(cell).Type);

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -162,7 +162,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!order.Queued)
 				self.CancelActivity();
 
-			self.QueueActivity(new EnterTransport(self, order.Target));
+			self.QueueActivity(new RideTransport(self, order.Target));
 			self.ShowTargetLines();
 		}
 

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -73,6 +73,8 @@ namespace OpenRA.Mods.Common.Traits
 				td.Add(new LocationInit(exit));
 				td.Add(new CenterPositionInit(spawn));
 				td.Add(new FacingInit(initialFacing));
+				if (exitinfo != null)
+					td.Add(new MoveIntoWorldDelayInit(exitinfo.ExitDelay));
 			}
 
 			self.World.AddFrameEndTask(w =>
@@ -81,16 +83,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				var move = newUnit.TraitOrDefault<IMove>();
 				if (exitinfo != null && move != null)
-				{
-					if (exitinfo.MoveIntoWorld)
-					{
-						if (exitinfo.ExitDelay > 0)
-							newUnit.QueueActivity(new Wait(exitinfo.ExitDelay, false));
-
-						newUnit.QueueActivity(move.MoveIntoWorld(newUnit, exit));
-						newUnit.QueueActivity(new AttackMoveActivity(newUnit, () => move.MoveTo(exitLocation, 1, targetLineColor: Color.OrangeRed)));
-					}
-				}
+					newUnit.QueueActivity(new AttackMoveActivity(newUnit, () => move.MoveTo(exitLocation, 1, targetLineColor: Color.OrangeRed)));
 
 				if (!self.IsDead)
 					foreach (var t in self.TraitsImplementing<INotifyProduction>())

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -127,25 +127,17 @@ namespace OpenRA.Mods.Common.Traits
 				td.Add(new LocationInit(exit));
 				td.Add(new CenterPositionInit(spawn));
 				td.Add(new FacingInit(initialFacing));
+				td.Add(new MoveIntoWorldDelayInit(exitinfo.ExitDelay));
 			}
 
 			self.World.AddFrameEndTask(w =>
 			{
 				var newUnit = self.World.CreateActor(producee.Name, td);
+				newUnit.Trait<Parachutable>().IgnoreActor = self;
 
-				newUnit.QueueActivity(new Parachute(newUnit, self));
 				var move = newUnit.TraitOrDefault<IMove>();
 				if (move != null)
-				{
-					if (exitinfo.MoveIntoWorld)
-					{
-						if (exitinfo.ExitDelay > 0)
-							newUnit.QueueActivity(new Wait(exitinfo.ExitDelay, false));
-
-						newUnit.QueueActivity(move.MoveIntoWorld(newUnit, exit));
-						newUnit.QueueActivity(new AttackMoveActivity(newUnit, () => move.MoveTo(exitLocation, 1, targetLineColor: Color.OrangeRed)));
-					}
-				}
+					newUnit.QueueActivity(new AttackMoveActivity(newUnit, () => move.MoveTo(exitLocation, 1, targetLineColor: Color.OrangeRed)));
 
 				if (!self.IsDead)
 					foreach (var t in self.TraitsImplementing<INotifyProduction>())

--- a/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		void INotifyParachute.OnParachute(Actor self) { }
 
-		void INotifyParachute.OnLanded(Actor self, Actor ignore)
+		void INotifyParachute.OnLanded(Actor self)
 		{
 			PlaySequence();
 		}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -145,7 +145,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	[RequireExplicitImplementation]
 	public interface INotifyResourceAccepted { void OnResourceAccepted(Actor self, Actor refinery, int amount); }
-	public interface INotifyParachute { void OnParachute(Actor self); void OnLanded(Actor self, Actor ignore); }
+	public interface INotifyParachute { void OnParachute(Actor self); void OnLanded(Actor self); }
 
 	[RequireExplicitImplementation]
 	public interface INotifyCapture { void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner, BitSet<CaptureType> captureTypes); }
@@ -435,7 +435,7 @@ namespace OpenRA.Mods.Common.Traits
 			WPos? initialTargetPosition = null, Color? targetLineColor = null);
 		Activity MoveToTarget(Actor self, Target target,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null);
-		Activity MoveIntoWorld(Actor self, CPos cell, SubCell subCell = SubCell.Any);
+		Activity MoveIntoWorld(Actor self, int delay = 0);
 		Activity MoveIntoTarget(Actor self, Target target);
 		Activity VisualMove(Actor self, WPos fromPos, WPos toPos);
 		int EstimatedMoveDuration(Actor self, WPos fromPos, WPos toPos);

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20190314/RemoveMoveIntoWorldFromExit.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20190314/RemoveMoveIntoWorldFromExit.cs
@@ -1,0 +1,38 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RemoveMoveIntoWorldFromExit : UpdateRule
+	{
+		public override string Name { get { return "Remove MoveIntoWorld from Exit."; } }
+		public override string Description
+		{
+			get
+			{
+				return "The MoveIntoWorld parameter has been removed from the Exit trait because it no\n" +
+    				"longer serves a purpose (aircraft can now use the same exit procedure as other\n" +
+					"units).";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var t in actorNode.ChildrenMatching("Exit"))
+				t.RemoveNodes("MoveIntoWorld");
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -133,6 +133,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new AddCanSlide(),
 				new AddAircraftIdleBehavior(),
 				new RenameSearchRadius(),
+				new RemoveMoveIntoWorldFromExit(),
 			})
 		};
 

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1344,7 +1344,6 @@ HPAD:
 		RequiresCondition: !being-captured
 		SpawnOffset: 0,-256,0
 		ExitCell: 0,0
-		MoveIntoWorld: false
 		Facing: 224
 	RallyPoint:
 	Production:
@@ -1435,7 +1434,6 @@ AFLD:
 		RequiresCondition: !being-captured
 		ExitCell: 1,1
 		Facing: 192
-		MoveIntoWorld: false
 	RallyPoint:
 	Production:
 		Produces: Aircraft, Plane


### PR DESCRIPTION
Fixes #16901

The `MoveIntoWorld` activity must not be interruptible and `Enter` should always be allowed to exit gracefully on its own because that would otherwise cause other glitches. So instead make sure that `Enter` chooses the current location for exiting and just let that handle the unload movement.