### PR TITLE
Fix Enter cursor for fully armed non-TakeOffOnResupply aircraft

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -931,7 +931,8 @@ namespace OpenRA.Mods.Common.Traits
 					target => Reservable.IsAvailableFor(target, self) && AircraftCanResupplyAt(target, true));
 
 				yield return new EnterAlliedActorTargeter<BuildingInfo>("Enter", 5,
-					AircraftCanEnter, target => Reservable.IsAvailableFor(target, self) && AircraftCanResupplyAt(target));
+					AircraftCanEnter,
+					target => Reservable.IsAvailableFor(target, self) && AircraftCanResupplyAt(target, !Info.TakeOffOnResupply));
 
 				yield return new AircraftMoveOrderTargeter(this);
 			}


### PR DESCRIPTION
If the aircraft does not take off on resupply, we allow it to enter resuppliers without `ForceMove` modifier.

`ResolveOrder` already handled this correctly, only the cursor shown was wrong.

Should fix #16936.