### PR TITLE
Make FlyAttack use FlyFollow as a child.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
+++ b/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
@@ -39,6 +39,9 @@ namespace OpenRA.Mods.Common.Activities
 			if (aircraft.ForceLanding)
 				return;
 
+			if (self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition).Length >= aircraft.Info.MinAirborneAltitude)
+				return;
+
 			// We are taking off, so remove reservation and influence in ground cells.
 			aircraft.UnReserve();
 			aircraft.RemoveInfluence();


### PR DESCRIPTION
Fixes #16922.

`FlyTimed` is unneccesary because `Fly` itself already calculates the correct trajectory based on the turn radius.