### PR TITLE
 Add "Spawn Child Actor" and "Deployed" checkboxes to the map editor.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -16,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Player receives a unit for free once the building is placed. This also works for structures.",
 		"If you want more than one unit to appear copy this section and assign IDs like FreeActor@2, ...")]
-	public class FreeActorInfo : ConditionalTraitInfo
+	public class FreeActorInfo : ConditionalTraitInfo, IEditorActorOptions
 	{
 		[ActorReference]
 		[FieldLoader.Require]
@@ -31,6 +32,26 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Whether another actor should spawn upon re-enabling the trait.")]
 		public readonly bool AllowRespawn = false;
+
+		[Desc("Display order for the free actor checkbox in the map editor")]
+		public readonly int EditorFreeActorDisplayOrder = 4;
+
+		IEnumerable<EditorActorOption> IEditorActorOptions.ActorOptions(ActorInfo ai, World world)
+		{
+			yield return new EditorActorCheckbox("Spawn Child Actor", EditorFreeActorDisplayOrder,
+				actor =>
+				{
+					var init = actor.Init<FreeActorInit>();
+					if (init != null)
+						return init.Value(world);
+
+					return true;
+				},
+				(actor, value) =>
+				{
+					actor.ReplaceInit(new FreeActorInit(value));
+				});
+		}
 
 		public override object Create(ActorInitializer init) { return new FreeActor(init, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Grants a condition when a deploy order is issued." +
 		"Can be paused with the granted condition to disable undeploying.")]
-	public class GrantConditionOnDeployInfo : PausableConditionalTraitInfo
+	public class GrantConditionOnDeployInfo : PausableConditionalTraitInfo, IEditorActorOptions
 	{
 		[GrantedConditionReference]
 		[Desc("The condition to grant while the actor is undeployed.")]
@@ -60,6 +60,26 @@ namespace OpenRA.Mods.Common.Traits
 
 		[VoiceReference]
 		public readonly string Voice = "Action";
+
+		[Desc("Display order for the deployed checkbox in the map editor")]
+		public readonly int EditorDeployedDisplayOrder = 4;
+
+		IEnumerable<EditorActorOption> IEditorActorOptions.ActorOptions(ActorInfo ai, World world)
+		{
+			yield return new EditorActorCheckbox("Deployed", EditorDeployedDisplayOrder,
+				actor =>
+				{
+					var init = actor.Init<DeployStateInit>();
+					if (init != null)
+						return init.Value(world) == DeployState.Deployed;
+
+					return false;
+				},
+				(actor, value) =>
+				{
+					actor.ReplaceInit(new DeployStateInit(value ? DeployState.Deployed : DeployState.Undeployed));
+				});
+		}
 
 		public override object Create(ActorInitializer init) { return new GrantConditionOnDeploy(init, this); }
 	}

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -555,6 +555,21 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
+	public class EditorActorCheckbox : EditorActorOption
+	{
+		public readonly Func<EditorActorPreview, bool> GetValue;
+		public readonly Action<EditorActorPreview, bool> OnChange;
+
+		public EditorActorCheckbox(string name, int displayOrder,
+			Func<EditorActorPreview, bool> getValue,
+			Action<EditorActorPreview, bool> onChange)
+			: base(name, displayOrder)
+		{
+			GetValue = getValue;
+			OnChange = onChange;
+		}
+	}
+
 	public class EditorActorSlider : EditorActorOption
 	{
 		public readonly float MinValue;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -36,6 +36,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly Widget initContainer;
 		readonly Widget buttonContainer;
 
+		readonly Widget checkboxOptionTemplate;
 		readonly Widget sliderOptionTemplate;
 		readonly Widget dropdownOptionTemplate;
 
@@ -91,6 +92,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			initContainer = actorEditPanel.Get("ACTOR_INIT_CONTAINER");
 			buttonContainer = actorEditPanel.Get("BUTTON_CONTAINER");
 
+			checkboxOptionTemplate = initContainer.Get("CHECKBOX_OPTION_TEMPLATE");
 			sliderOptionTemplate = initContainer.Get("SLIDER_OPTION_TEMPLATE");
 			dropdownOptionTemplate = initContainer.Get("DROPDOWN_OPTION_TEMPLATE");
 			initContainer.RemoveChildren();
@@ -264,7 +266,30 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					foreach (var o in options)
 					{
-						if (o is EditorActorSlider)
+						if (o is EditorActorCheckbox)
+						{
+							var co = (EditorActorCheckbox)o;
+							var checkboxContainer = checkboxOptionTemplate.Clone();
+							checkboxContainer.Bounds.Y = initContainer.Bounds.Height;
+							initContainer.Bounds.Height += checkboxContainer.Bounds.Height;
+
+							var checkbox = checkboxContainer.Get<CheckboxWidget>("OPTION");
+							checkbox.GetText = () => co.Name;
+
+							var editorActionHandle = new EditorActorOptionActionHandle<bool>(co.OnChange, co.GetValue(actor));
+							editActorPreview.Add(editorActionHandle);
+
+							checkbox.IsChecked = () => co.GetValue(actor);
+							checkbox.OnClick = () =>
+							{
+								var newValue = co.GetValue(actor) ^ true;
+								co.OnChange(actor, newValue);
+								editorActionHandle.OnChange(newValue);
+							};
+
+							initContainer.AddChild(checkboxContainer);
+						}
+						else if (o is EditorActorSlider)
 						{
 							var so = (EditorActorSlider)o;
 							var sliderContainer = sliderOptionTemplate.Clone();

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -258,6 +258,15 @@ Container@EDITOR_WORLD_ROOT:
 							Y: 57
 							Width: PARENT_RIGHT
 							Children:
+								Container@CHECKBOX_OPTION_TEMPLATE:
+									Width: PARENT_RIGHT
+									Height: 22
+									Children:
+										Checkbox@OPTION:
+											X: 67
+											Y: 1
+											Width: PARENT_RIGHT - 67
+											Height: 20
 								Container@SLIDER_OPTION_TEMPLATE:
 									Width: PARENT_RIGHT
 									Height: 22

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -251,6 +251,15 @@ Container@EDITOR_WORLD_ROOT:
 							Y: 73
 							Width: PARENT_RIGHT
 							Children:
+								Container@CHECKBOX_OPTION_TEMPLATE:
+									Width: PARENT_RIGHT
+									Height: 22
+									Children:
+										Checkbox@OPTION:
+											X: 84
+											Y: 1
+											Width: PARENT_RIGHT - 84
+											Height: 20
 								Container@SLIDER_OPTION_TEMPLATE:
 									Width: PARENT_RIGHT
 									Height: 22


### PR DESCRIPTION
This makes it easy for map authors to disable the free harvester spawning from refineries.