### PR TITLE
Cells with Temporary blockers should not exit early in locomotor cache

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -278,8 +278,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (cellCache.Crushable.Overlaps(actor.Owner.PlayerMask))
 				return true;
 
-			// Cache doesn't account for ignored actors - these must use the slow path
-			if (ignoreActor == null)
+			// Cache doesn't account for ignored actors or temporary blockers - these must use the slow path.
+			if (ignoreActor == null && !cellFlag.HasCellFlag(CellFlag.HasTemporaryBlocker))
 			{
 				// We are blocked by another actor in the cell.
 				if (cellCache.Blocking.Overlaps(actor.Owner.PlayerMask))


### PR DESCRIPTION
Fixes #16863