### PR TITLE
Add delay support to SpriteEffect

### DIFF
--- a/OpenRA.Mods.Common/Effects/SpriteEffect.cs
+++ b/OpenRA.Mods.Common/Effects/SpriteEffect.cs
@@ -23,31 +23,46 @@ namespace OpenRA.Mods.Common.Effects
 		readonly Animation anim;
 		readonly Func<WPos> posFunc;
 		readonly bool visibleThroughFog;
+		readonly string sequence;
 		WPos pos;
+		int delay;
+		bool initialized;
 
 		// Facing is last on these overloads partially for backwards compatibility with previous main ctor revision
-		// and partially because most effects don't need it.
-		public SpriteEffect(WPos pos, World world, string image, string sequence, string palette, bool visibleThroughFog = false, int facing = 0)
-			: this(() => pos, () => facing, world, image, sequence, palette, visibleThroughFog) { }
+		// and partially because most effects don't need it. The latter is also the reason for placement of 'delay'.
+		public SpriteEffect(WPos pos, World world, string image, string sequence, string palette,
+			bool visibleThroughFog = false, int facing = 0, int delay = 0)
+			: this(() => pos, () => facing, world, image, sequence, palette, visibleThroughFog, delay) { }
 
-		public SpriteEffect(Actor actor, World world, string image, string sequence, string palette, bool visibleThroughFog = false, int facing = 0)
-			: this(() => actor.CenterPosition, () => facing, world, image, sequence, palette, visibleThroughFog) { }
+		public SpriteEffect(Actor actor, World world, string image, string sequence, string palette,
+			bool visibleThroughFog = false, int facing = 0, int delay = 0)
+			: this(() => actor.CenterPosition, () => facing, world, image, sequence, palette, visibleThroughFog, delay) { }
 
 		public SpriteEffect(Func<WPos> posFunc, Func<int> facingFunc, World world, string image, string sequence, string palette,
-			bool visibleThroughFog = false)
+			bool visibleThroughFog = false, int delay = 0)
 		{
 			this.world = world;
 			this.posFunc = posFunc;
 			this.palette = palette;
+			this.sequence = sequence;
 			this.visibleThroughFog = visibleThroughFog;
+			this.delay = delay;
 			pos = posFunc();
 			anim = new Animation(world, image, facingFunc);
-			anim.PlayThen(sequence, () => world.AddFrameEndTask(w => { w.Remove(this); w.ScreenMap.Remove(this); }));
-			world.ScreenMap.Add(this, pos, anim.Image);
 		}
 
 		public void Tick(World world)
 		{
+			if (delay-- > 0)
+				return;
+
+			if (!initialized)
+			{
+				anim.PlayThen(sequence, () => world.AddFrameEndTask(w => { w.Remove(this); w.ScreenMap.Remove(this); }));
+				world.ScreenMap.Add(this, pos, anim.Image);
+				initialized = true;
+			}
+
 			anim.Tick();
 
 			pos = posFunc();

--- a/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeathAnimation.cs
@@ -53,6 +53,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Sequence to use when the actor is killed by some non-standard means (e.g. suicide).")]
 		public readonly string FallbackSequence = null;
 
+		[Desc("Delay the spawn of the death animation by this many ticks.")]
+		public readonly int Delay = 0;
+
 		public override object Create(ActorInitializer init) { return new WithDeathAnimation(init.Self, this); }
 	}
 
@@ -81,7 +84,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (e.Damage.DamageTypes.IsEmpty)
 			{
 				if (Info.FallbackSequence != null)
-					SpawnDeathAnimation(self, self.CenterPosition, rs.GetImage(self), Info.FallbackSequence, palette);
+					SpawnDeathAnimation(self, self.CenterPosition, rs.GetImage(self), Info.FallbackSequence, palette, Info.Delay);
 
 				return;
 			}
@@ -96,12 +99,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 				sequence += Info.DeathTypes[damageType].Random(self.World.SharedRandom);
 			}
 
-			SpawnDeathAnimation(self, self.CenterPosition, rs.GetImage(self), sequence, palette);
+			SpawnDeathAnimation(self, self.CenterPosition, rs.GetImage(self), sequence, palette, Info.Delay);
 		}
 
-		public void SpawnDeathAnimation(Actor self, WPos pos, string image, string sequence, string palette)
+		public void SpawnDeathAnimation(Actor self, WPos pos, string image, string sequence, string palette, int delay)
 		{
-			self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, w, image, sequence, palette)));
+			self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, w, image, sequence, palette, delay: delay)));
 		}
 
 		void INotifyCrushed.OnCrush(Actor self, Actor crusher, BitSet<CrushClass> crushClasses)
@@ -115,7 +118,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (Info.CrushedPaletteIsPlayerPalette)
 				crushPalette += self.Owner.InternalName;
 
-			SpawnDeathAnimation(self, self.CenterPosition, rs.GetImage(self), Info.CrushedSequence, crushPalette);
+			SpawnDeathAnimation(self, self.CenterPosition, rs.GetImage(self), Info.CrushedSequence, crushPalette, Info.Delay);
 		}
 
 		void INotifyCrushed.WarnCrush(Actor self, Actor crusher, BitSet<CrushClass> crushClasses) { }


### PR DESCRIPTION
I've had this sitting around locally for a while.
Might be useful for downstream mods or our own projectile trail code.

Also exposed the delay in `WithDeathAnimation` both as testcase and at request by Graion.