### PR TITLE
Performance - Replaced glGetError with glDebugMessageCallback

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,8 +41,9 @@ Also thanks to:
     * Brendan Gluth (Mechanical_Man)
     * Bryan Wilbur
     * Bugra Cuhadaroglu (BugraC)
-    * Christer Ulfsparre (Holloweye)
+    * Chris Cameron (Vesuvian)
     * Chris Grant (Unit158)
+    * Christer Ulfsparre (Holloweye)
     * clem
     * Cody Brittain (Generalcamo)
     * Constantin Helmig (CH4Code)


### PR DESCRIPTION
Some cursive profiling showed that a bunch of time was being spent calling glGetError about 1000 times a second on startup. Replacing this with a single callback to glDebugMessageCallback has entirely removed those calls and has simplified a lot of existing code. Further, glDebugMessageCallback will catch any cases where previously someone may have forgotten to call glGetError