### PR TITLE
Update the displayed replay filename after renaming.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ReplayBrowserLogic.cs
@@ -465,8 +465,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			try
 			{
+				var item = replayState[replay].Item;
 				replay.RenameFile(newFilenameWithoutExtension);
-				replayState[replay].Item.Text = newFilenameWithoutExtension;
+				item.Text = newFilenameWithoutExtension;
+
+				var label = item.Get<LabelWithTooltipWidget>("TITLE");
+				WidgetUtils.TruncateLabelToTooltip(label, item.Text);
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
Fixes #16985.

Can be added to the changelog entry for
> Fixed several other minor UI polish and usability issues