### PR TITLE
Render via an intermediate framebuffer

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -655,12 +655,26 @@ namespace OpenRA
 			{
 				++RenderFrame;
 
+				// Prepare renderables (i.e. render voxels) before calling BeginFrame
+				using (new PerfSample("render_prepare"))
+				{
+					Renderer.WorldModelRenderer.BeginFrame();
+
+					// World rendering is disabled while the loading screen is displayed
+					if (worldRenderer != null && !worldRenderer.World.IsLoadingGameSave)
+						worldRenderer.PrepareRenderables();
+
+					Ui.PrepareRenderables();
+					Renderer.WorldModelRenderer.EndFrame();
+				}
+
 				// worldRenderer is null during the initial install/download screen
 				if (worldRenderer != null)
 				{
 					Renderer.BeginFrame(worldRenderer.Viewport.TopLeft, worldRenderer.Viewport.Zoom);
 					Sound.SetListenerPosition(worldRenderer.Viewport.CenterPosition);
 
+					// World rendering is disabled while the loading screen is displayed
 					// Use worldRenderer.World instead of OrderManager.World to avoid a rendering mismatch while processing orders
 					if (!worldRenderer.World.IsLoadingGameSave)
 						worldRenderer.Draw();
@@ -670,10 +684,6 @@ namespace OpenRA
 
 				using (new PerfSample("render_widgets"))
 				{
-					Renderer.WorldModelRenderer.BeginFrame();
-					Ui.PrepareRenderables();
-					Renderer.WorldModelRenderer.EndFrame();
-
 					Ui.Draw();
 
 					if (ModData != null && ModData.CursorProvider != null)

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -550,7 +550,7 @@ namespace OpenRA
 				var path = Path.Combine(directory, string.Concat(filename, ".png"));
 				Log.Write("debug", "Taking screenshot " + path);
 
-				Renderer.Context.SaveScreenshot(path);
+				Renderer.SaveScreenshot(path);
 				Debug("Saved screenshot " + filename);
 			}
 		}

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -41,6 +41,8 @@ namespace OpenRA
 
 		Size WindowSize { get; }
 		float WindowScale { get; }
+		Size SurfaceSize { get; }
+
 		event Action<float, float> OnWindowScaleChanged;
 
 		void PumpInput(IInputHandler inputHandler);
@@ -62,7 +64,7 @@ namespace OpenRA
 		IFrameBuffer CreateFrameBuffer(Size s);
 		IFrameBuffer CreateFrameBuffer(Size s, Color clearColor);
 		IShader CreateShader(string name);
-		void EnableScissor(int left, int top, int width, int height);
+		void EnableScissor(int x, int y, int width, int height);
 		void DisableScissor();
 		void SaveScreenshot(string path);
 		void Present();

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -66,7 +66,6 @@ namespace OpenRA
 		IShader CreateShader(string name);
 		void EnableScissor(int x, int y, int width, int height);
 		void DisableScissor();
-		void SaveScreenshot(string path);
 		void Present();
 		void DrawPrimitives(PrimitiveType pt, int firstVertex, int numVertices);
 		void Clear();

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -60,6 +60,7 @@ namespace OpenRA
 		IVertexBuffer<Vertex> CreateVertexBuffer(int size);
 		ITexture CreateTexture();
 		IFrameBuffer CreateFrameBuffer(Size s);
+		IFrameBuffer CreateFrameBuffer(Size s, Color clearColor);
 		IShader CreateShader(string name);
 		void EnableScissor(int left, int top, int width, int height);
 		void DisableScissor();

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -160,9 +160,9 @@ namespace OpenRA.Graphics
 			shader.SetVec("Scroll", scroll.X, scroll.Y, scroll.Y);
 			shader.SetVec("r1",
 				zoom * 2f / screen.Width,
-				-zoom * 2f / screen.Height,
+				zoom * 2f / screen.Height,
 				-depthScale * zoom / screen.Height);
-			shader.SetVec("r2", -1, 1, 1 - depthOffset);
+			shader.SetVec("r2", -1, -1, 1 - depthOffset);
 
 			// Texture index is sampled as a float, so convert to pixels then scale
 			shader.SetVec("DepthTextureScale", 128 * depthScale * zoom / screen.Height);

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -39,6 +39,9 @@ namespace OpenRA.Graphics
 		readonly Func<string, PaletteReference> createPaletteReference;
 		readonly bool enableDepthBuffer;
 
+		readonly List<IFinalizedRenderable> preparedRenderables = new List<IFinalizedRenderable>();
+		readonly List<IFinalizedRenderable> preparedOverlayRenderables = new List<IFinalizedRenderable>();
+
 		bool lastDepthPreviewEnabled;
 
 		internal WorldRenderer(ModData modData, World world)
@@ -103,7 +106,7 @@ namespace OpenRA.Graphics
 				palettes[name].Palette = pal;
 		}
 
-		List<IFinalizedRenderable> GenerateRenderables()
+		IEnumerable<IFinalizedRenderable> GenerateRenderables()
 		{
 			var actors = onScreenActors.Append(World.WorldActor);
 			if (World.RenderPlayer != null)
@@ -122,14 +125,10 @@ namespace OpenRA.Graphics
 
 			worldRenderables = worldRenderables.OrderBy(RenderableScreenZPositionComparisonKey);
 
-			Game.Renderer.WorldModelRenderer.BeginFrame();
-			var renderables = worldRenderables.Select(r => r.PrepareRender(this)).ToList();
-			Game.Renderer.WorldModelRenderer.EndFrame();
-
-			return renderables;
+			return worldRenderables.Select(r => r.PrepareRender(this));
 		}
 
-		List<IFinalizedRenderable> GenerateOverlayRenderables()
+		IEnumerable<IFinalizedRenderable> GenerateOverlayRenderables()
 		{
 			var aboveShroud = World.ActorsWithTrait<IRenderAboveShroud>()
 				.Where(a => a.Actor.IsInWorld && !a.Actor.Disposed && (!a.Trait.SpatiallyPartitionable || onScreenActors.Contains(a.Actor)))
@@ -153,11 +152,21 @@ namespace OpenRA.Graphics
 				.Concat(aboveShroudEffects)
 				.Concat(aboveShroudOrderGenerator);
 
-			Game.Renderer.WorldModelRenderer.BeginFrame();
-			var finalOverlayRenderables = overlayRenderables.Select(r => r.PrepareRender(this)).ToList();
-			Game.Renderer.WorldModelRenderer.EndFrame();
+			return overlayRenderables.Select(r => r.PrepareRender(this));
+		}
 
-			return finalOverlayRenderables;
+		public void PrepareRenderables()
+		{
+			if (World.WorldActor.Disposed)
+				return;
+
+			RefreshPalette();
+
+			// PERF: Reuse collection to avoid allocations.
+			onScreenActors.UnionWith(World.ScreenMap.RenderableActorsInBox(Viewport.TopLeft, Viewport.BottomRight));
+			preparedRenderables.AddRange(GenerateRenderables());
+			preparedOverlayRenderables.AddRange(GenerateOverlayRenderables());
+			onScreenActors.Clear();
 		}
 
 		public void Draw()
@@ -171,10 +180,6 @@ namespace OpenRA.Graphics
 				Game.Renderer.WorldSpriteRenderer.SetDepthPreviewEnabled(lastDepthPreviewEnabled);
 			}
 
-			RefreshPalette();
-
-			onScreenActors.UnionWith(World.ScreenMap.RenderableActorsInBox(Viewport.TopLeft, Viewport.BottomRight));
-			var renderables = GenerateRenderables();
 			var bounds = Viewport.GetScissorBounds(World.Type != WorldType.Editor);
 			Game.Renderer.EnableScissor(bounds);
 
@@ -186,8 +191,8 @@ namespace OpenRA.Graphics
 
 			Game.Renderer.Flush();
 
-			for (var i = 0; i < renderables.Count; i++)
-				renderables[i].Render(this);
+			for (var i = 0; i < preparedRenderables.Count; i++)
+				preparedRenderables[i].Render(this);
 
 			if (enableDepthBuffer)
 				Game.Renderer.ClearDepthBuffer();
@@ -209,18 +214,16 @@ namespace OpenRA.Graphics
 
 			Game.Renderer.DisableScissor();
 
-			var finalOverlayRenderables = GenerateOverlayRenderables();
-
 			// HACK: Keep old grouping behaviour
-			var groupedOverlayRenderables = finalOverlayRenderables.GroupBy(prs => prs.GetType());
+			var groupedOverlayRenderables = preparedOverlayRenderables.GroupBy(prs => prs.GetType());
 			foreach (var g in groupedOverlayRenderables)
 				foreach (var r in g)
 					r.Render(this);
 
 			if (debugVis.Value != null && debugVis.Value.RenderGeometry)
 			{
-				for (var i = 0; i < renderables.Count; i++)
-					renderables[i].RenderDebugGeometry(this);
+				for (var i = 0; i < preparedRenderables.Count; i++)
+					preparedRenderables[i].RenderDebugGeometry(this);
 
 				foreach (var g in groupedOverlayRenderables)
 					foreach (var r in g)
@@ -243,9 +246,8 @@ namespace OpenRA.Graphics
 			}
 
 			Game.Renderer.Flush();
-
-			// PERF: Reuse collection to avoid allocations.
-			onScreenActors.Clear();
+			preparedRenderables.Clear();
+			preparedOverlayRenderables.Clear();
 		}
 
 		public void RefreshPalette()

--- a/OpenRA.Platforms.Default/FrameBuffer.cs
+++ b/OpenRA.Platforms.Default/FrameBuffer.cs
@@ -20,12 +20,14 @@ namespace OpenRA.Platforms.Default
 	{
 		readonly ITexture texture;
 		readonly Size size;
+		readonly Color clearColor;
 		uint framebuffer, depth;
 		bool disposed;
 
-		public FrameBuffer(Size size, ITextureInternal texture)
+		public FrameBuffer(Size size, ITextureInternal texture, Color clearColor)
 		{
 			this.size = size;
+			this.clearColor = clearColor;
 			if (!Exts.IsPowerOf2(size.Width) || !Exts.IsPowerOf2(size.Height))
 				throw new InvalidDataException("Frame buffer size ({0}x{1}) must be a power of two".F(size.Width, size.Height));
 
@@ -94,7 +96,7 @@ namespace OpenRA.Platforms.Default
 			OpenGL.CheckGLError();
 			OpenGL.glViewport(0, 0, size.Width, size.Height);
 			OpenGL.CheckGLError();
-			OpenGL.glClearColor(0, 0, 0, 0);
+			OpenGL.glClearColor(clearColor.R, clearColor.G, clearColor.B, clearColor.A);
 			OpenGL.CheckGLError();
 			OpenGL.glClear(OpenGL.GL_COLOR_BUFFER_BIT | OpenGL.GL_DEPTH_BUFFER_BIT);
 			OpenGL.CheckGLError();

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -287,15 +287,6 @@ namespace OpenRA.Platforms.Default
 		public delegate void Scissor(int x, int y, int width, int height);
 		public static Scissor glScissor { get; private set; }
 
-		public delegate void PushClientAttrib(int mask);
-		public static PushClientAttrib glPushClientAttrib { get; private set; }
-
-		public delegate void PopClientAttrib();
-		public static PopClientAttrib glPopClientAttrib { get; private set; }
-
-		public delegate void PixelStoref(int param, float pname);
-		public static PixelStoref glPixelStoref { get; private set; }
-
 		public delegate void ReadPixels(int x, int y, int width, int height,
 			int format, int type, IntPtr data);
 		public static ReadPixels glReadPixels { get; private set; }
@@ -429,9 +420,6 @@ namespace OpenRA.Platforms.Default
 				glBlendFunc = Bind<BlendFunc>("glBlendFunc");
 				glDepthFunc = Bind<DepthFunc>("glDepthFunc");
 				glScissor = Bind<Scissor>("glScissor");
-				glPushClientAttrib = Bind<PushClientAttrib>("glPushClientAttrib");
-				glPopClientAttrib = Bind<PopClientAttrib>("glPopClientAttrib");
-				glPixelStoref = Bind<PixelStoref>("glPixelStoref");
 				glReadPixels = Bind<ReadPixels>("glReadPixels");
 				glGenTextures = Bind<GenTextures>("glGenTextures");
 				glDeleteTextures = Bind<DeleteTextures>("glDeleteTextures");

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -275,6 +275,9 @@ namespace OpenRA.Platforms.Default
 		public delegate void BlendEquation(int mode);
 		public static BlendEquation glBlendEquation { get; private set; }
 
+		public delegate void BlendEquationSeparate(int modeRGB, int modeAlpha);
+		public static BlendEquationSeparate glBlendEquationSeparate { get; private set; }
+
 		public delegate void BlendFunc(int sfactor, int dfactor);
 		public static BlendFunc glBlendFunc { get; private set; }
 
@@ -422,6 +425,7 @@ namespace OpenRA.Platforms.Default
 				glEnable = Bind<Enable>("glEnable");
 				glDisable = Bind<Disable>("glDisable");
 				glBlendEquation = Bind<BlendEquation>("glBlendEquation");
+				glBlendEquationSeparate = Bind<BlendEquationSeparate>("glBlendEquationSeparate");
 				glBlendFunc = Bind<BlendFunc>("glBlendFunc");
 				glDepthFunc = Bind<DepthFunc>("glDepthFunc");
 				glScissor = Bind<Scissor>("glScissor");

--- a/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
@@ -241,7 +241,7 @@ namespace OpenRA.Platforms.Default
 					if (mode == BlendMode.Subtractive)
 					{
 						OpenGL.CheckGLError();
-						OpenGL.glBlendEquation(OpenGL.GL_FUNC_REVERSE_SUBTRACT);
+						OpenGL.glBlendEquationSeparate(OpenGL.GL_FUNC_REVERSE_SUBTRACT, OpenGL.GL_FUNC_ADD);
 					}
 
 					break;

--- a/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
@@ -62,13 +62,19 @@ namespace OpenRA.Platforms.Default
 		public IFrameBuffer CreateFrameBuffer(Size s)
 		{
 			VerifyThreadAffinity();
-			return new FrameBuffer(s, new Texture());
+			return new FrameBuffer(s, new Texture(), Color.FromArgb(0));
 		}
 
-		public IFrameBuffer CreateFrameBuffer(Size s, ITextureInternal texture)
+		public IFrameBuffer CreateFrameBuffer(Size s, Color clearColor)
 		{
 			VerifyThreadAffinity();
-			return new FrameBuffer(s, texture);
+			return new FrameBuffer(s, new Texture(), clearColor);
+		}
+
+		public IFrameBuffer CreateFrameBuffer(Size s, ITextureInternal texture, Color clearColor)
+		{
+			VerifyThreadAffinity();
+			return new FrameBuffer(s, texture, clearColor);
 		}
 
 		public IShader CreateShader(string name)

--- a/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Platforms.Default
 			return new Shader(name);
 		}
 
-		public void EnableScissor(int left, int top, int width, int height)
+		public void EnableScissor(int x, int y, int width, int height)
 		{
 			VerifyThreadAffinity();
 
@@ -97,16 +97,15 @@ namespace OpenRA.Platforms.Default
 			var windowScale = window.WindowScale;
 			var surfaceSize = window.SurfaceSize;
 
-			var bottom = windowSize.Height - (top + height);
 			if (windowSize != surfaceSize)
 			{
-				left = (int)Math.Round(windowScale * left);
-				bottom = (int)Math.Round(windowScale * bottom);
+				x = (int)Math.Round(windowScale * x);
+				y = (int)Math.Round(windowScale * y);
 				width = (int)Math.Round(windowScale * width);
 				height = (int)Math.Round(windowScale * height);
 			}
 
-			OpenGL.glScissor(left, bottom, width, height);
+			OpenGL.glScissor(x, y, width, height);
 			OpenGL.CheckGLError();
 			OpenGL.glEnable(OpenGL.GL_SCISSOR_TEST);
 			OpenGL.CheckGLError();

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -59,7 +59,7 @@ namespace OpenRA.Platforms.Default
 			}
 		}
 
-		internal Size SurfaceSize
+		public Size SurfaceSize
 		{
 			get
 			{

--- a/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
+++ b/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
@@ -49,7 +49,6 @@ namespace OpenRA.Platforms.Default
 		Action<object> doDrawPrimitives;
 		Action<object> doEnableScissor;
 		Action<object> doSetBlendMode;
-		Action<object> doSaveScreenshot;
 
 		public ThreadedGraphicsContext(Sdl2GraphicsContext context, int batchSize)
 		{
@@ -108,7 +107,6 @@ namespace OpenRA.Platforms.Default
 							context.EnableScissor(t.Item1, t.Item2, t.Item3, t.Item4);
 						};
 					doSetBlendMode = mode => { context.SetBlendMode((BlendMode)mode); };
-					doSaveScreenshot = path => context.SaveScreenshot((string)path);
 
 					Monitor.Pulse(syncObject);
 				}
@@ -446,11 +444,6 @@ namespace OpenRA.Platforms.Default
 		public void SetBlendMode(BlendMode mode)
 		{
 			Post(doSetBlendMode, mode);
-		}
-
-		public void SaveScreenshot(string path)
-		{
-			Post(doSaveScreenshot, path);
 		}
 	}
 

--- a/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
+++ b/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
@@ -86,7 +86,13 @@ namespace OpenRA.Platforms.Default
 					doPresent = () => context.Present();
 					getGLVersion = () => context.GLVersion;
 					getCreateTexture = () => new ThreadedTexture(this, (ITextureInternal)context.CreateTexture());
-					getCreateFrameBuffer = s => new ThreadedFrameBuffer(this, context.CreateFrameBuffer((Size)s, (ITextureInternal)CreateTexture()));
+					getCreateFrameBuffer =
+						tuple =>
+						{
+							var t = (Tuple<Size, Color>)tuple;
+							return new ThreadedFrameBuffer(this,
+								context.CreateFrameBuffer(t.Item1, (ITextureInternal)CreateTexture(), t.Item2));
+						};
 					getCreateShader = name => new ThreadedShader(this, context.CreateShader((string)name));
 					getCreateVertexBuffer = length => new ThreadedVertexBuffer(this, context.CreateVertexBuffer((int)length));
 					doDrawPrimitives =
@@ -384,7 +390,12 @@ namespace OpenRA.Platforms.Default
 
 		public IFrameBuffer CreateFrameBuffer(Size s)
 		{
-			return Send(getCreateFrameBuffer, s);
+			return Send(getCreateFrameBuffer, Tuple.Create(s, Color.FromArgb(0)));
+		}
+
+		public IFrameBuffer CreateFrameBuffer(Size s, Color clearColor)
+		{
+			return Send(getCreateFrameBuffer, Tuple.Create(s, clearColor));
 		}
 
 		public IShader CreateShader(string name)


### PR DESCRIPTION
This PR kicks off the next set of renderer changes, which I'm hoping to complete during the Next + 1 cycle. This sets up a frame buffer to render everything into, which is then displayed as a quad over the game window. The screenshot code has been rewritten (removing the legacy GL2-only code) to fetch the texture data from the frame buffer.

This sets the foundation for two sets of future PRs:
* Adding additional framebuffers for the world and world overlays (target lines, selection boxes), and using these to solve #10382, #6734, #9778, #12876, etc.
* Porting to GL 3.2 and removing our GL2 hacks and workarounds.