### PR TITLE
Use SegmentStream.CreateWithoutOwningStream to avoid reading data into memory

### DIFF
--- a/OpenRA.Mods.Cnc/FileSystem/BigFile.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/BigFile.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using OpenRA.FileSystem;
+using OpenRA.Primitives;
 using FS = OpenRA.FileSystem.FileSystem;
 
 namespace OpenRA.Mods.Cnc.FileSystem
@@ -62,36 +63,28 @@ namespace OpenRA.Mods.Cnc.FileSystem
 
 			class Entry
 			{
-				readonly Stream s;
-				readonly uint offset;
-				readonly uint size;
+				public readonly uint Offset;
+				public readonly uint Size;
 				public readonly string Path;
 
 				public Entry(Stream s)
 				{
-					this.s = s;
-
-					offset = s.ReadUInt32();
-					size = s.ReadUInt32();
+					Offset = s.ReadUInt32();
+					Size = s.ReadUInt32();
 					if (BitConverter.IsLittleEndian)
 					{
-						offset = int2.Swap(offset);
-						size = int2.Swap(size);
+						Offset = int2.Swap(Offset);
+						Size = int2.Swap(Size);
 					}
 
 					Path = s.ReadASCIIZ();
-				}
-
-				public Stream GetData()
-				{
-					s.Position = offset;
-					return new MemoryStream(s.ReadBytes((int)size));
 				}
 			}
 
 			public Stream GetStream(string filename)
 			{
-				return index[filename].GetData();
+				var entry = index[filename];
+				return SegmentStream.CreateWithoutOwningStream(s, entry.Offset, (int)entry.Size);
 			}
 
 			public bool Contains(string filename)

--- a/OpenRA.Mods.Cnc/FileSystem/Pak.cs
+++ b/OpenRA.Mods.Cnc/FileSystem/Pak.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using OpenRA.FileSystem;
+using OpenRA.Primitives;
 using FS = OpenRA.FileSystem.FileSystem;
 
 namespace OpenRA.Mods.Cnc.FileSystem
@@ -69,9 +70,7 @@ namespace OpenRA.Mods.Cnc.FileSystem
 				if (!index.TryGetValue(filename, out entry))
 					return null;
 
-				stream.Seek(entry.Offset, SeekOrigin.Begin);
-				var data = stream.ReadBytes((int)entry.Length);
-				return new MemoryStream(data);
+				return SegmentStream.CreateWithoutOwningStream(stream, entry.Offset, (int)entry.Length);
 			}
 
 			public bool Contains(string filename)

--- a/OpenRA.Mods.D2k/PackageLoaders/D2kSoundResources.cs
+++ b/OpenRA.Mods.D2k/PackageLoaders/D2kSoundResources.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using OpenRA.FileSystem;
+using OpenRA.Primitives;
 
 namespace OpenRA.Mods.D2k.PackageLoaders
 {
@@ -67,8 +68,7 @@ namespace OpenRA.Mods.D2k.PackageLoaders
 				if (!index.TryGetValue(filename, out e))
 					return null;
 
-				s.Seek(e.Offset, SeekOrigin.Begin);
-				return new MemoryStream(s.ReadBytes((int)e.Length));
+				return SegmentStream.CreateWithoutOwningStream(s, e.Offset, (int)e.Length);
 			}
 
 			public IReadOnlyPackage OpenPackage(string filename, FileSystem.FileSystem context)


### PR DESCRIPTION
To avoid creating copied data in memory (e.g. via MemoryStream), this method can be used to reference offsets on files on disk, reducing memory requirements.