### PR TITLE
Migrate rendering to OpenGL 3.2 / OpenGL ES 3.0.

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -160,6 +160,9 @@ namespace OpenRA
 		[Desc("Disable separate OpenGL render thread on Windows operating systems.")]
 		public bool DisableWindowsRenderThread = true;
 
+		[Desc("Use OpenGL ES if both ES and regular OpenGL are available.")]
+		public bool PreferGLES = false;
+
 		public int BatchSize = 8192;
 		public int SheetSize = 2048;
 

--- a/OpenRA.Platforms.Default/FrameBuffer.cs
+++ b/OpenRA.Platforms.Default/FrameBuffer.cs
@@ -33,31 +33,32 @@ namespace OpenRA.Platforms.Default
 
 			OpenGL.glGenFramebuffers(1, out framebuffer);
 			OpenGL.CheckGLError();
-			OpenGL.glBindFramebuffer(OpenGL.FRAMEBUFFER_EXT, framebuffer);
+			OpenGL.glBindFramebuffer(OpenGL.GL_FRAMEBUFFER, framebuffer);
 			OpenGL.CheckGLError();
 
 			// Color
 			this.texture = texture;
 			texture.SetEmpty(size.Width, size.Height);
-			OpenGL.glFramebufferTexture2D(OpenGL.FRAMEBUFFER_EXT, OpenGL.COLOR_ATTACHMENT0_EXT, OpenGL.GL_TEXTURE_2D, texture.ID, 0);
+			OpenGL.glFramebufferTexture2D(OpenGL.GL_FRAMEBUFFER, OpenGL.GL_COLOR_ATTACHMENT0, OpenGL.GL_TEXTURE_2D, texture.ID, 0);
 			OpenGL.CheckGLError();
 
 			// Depth
 			OpenGL.glGenRenderbuffers(1, out depth);
 			OpenGL.CheckGLError();
 
-			OpenGL.glBindRenderbuffer(OpenGL.RENDERBUFFER_EXT, depth);
+			OpenGL.glBindRenderbuffer(OpenGL.GL_RENDERBUFFER, depth);
 			OpenGL.CheckGLError();
 
-			OpenGL.glRenderbufferStorage(OpenGL.RENDERBUFFER_EXT, OpenGL.GL_DEPTH_COMPONENT, size.Width, size.Height);
+			var glDepth = OpenGL.Features.HasFlag(OpenGL.GLFeatures.GLES) ? OpenGL.GL_DEPTH_COMPONENT16 : OpenGL.GL_DEPTH_COMPONENT;
+			OpenGL.glRenderbufferStorage(OpenGL.GL_RENDERBUFFER, glDepth, size.Width, size.Height);
 			OpenGL.CheckGLError();
 
-			OpenGL.glFramebufferRenderbuffer(OpenGL.FRAMEBUFFER_EXT, OpenGL.DEPTH_ATTACHMENT_EXT, OpenGL.RENDERBUFFER_EXT, depth);
+			OpenGL.glFramebufferRenderbuffer(OpenGL.GL_FRAMEBUFFER, OpenGL.GL_DEPTH_ATTACHMENT, OpenGL.GL_RENDERBUFFER, depth);
 			OpenGL.CheckGLError();
 
 			// Test for completeness
-			var status = OpenGL.glCheckFramebufferStatus(OpenGL.FRAMEBUFFER_EXT);
-			if (status != OpenGL.FRAMEBUFFER_COMPLETE_EXT)
+			var status = OpenGL.glCheckFramebufferStatus(OpenGL.GL_FRAMEBUFFER);
+			if (status != OpenGL.GL_FRAMEBUFFER_COMPLETE)
 			{
 				var error = "Error creating framebuffer: {0}\n{1}".F(status, new StackTrace());
 				OpenGL.WriteGraphicsLog(error);
@@ -65,19 +66,14 @@ namespace OpenRA.Platforms.Default
 			}
 
 			// Restore default buffer
-			OpenGL.glBindFramebuffer(OpenGL.FRAMEBUFFER_EXT, 0);
+			OpenGL.glBindFramebuffer(OpenGL.GL_FRAMEBUFFER, 0);
 			OpenGL.CheckGLError();
 		}
 
 		static int[] ViewportRectangle()
 		{
 			var v = new int[4];
-			unsafe
-			{
-				fixed (int* ptr = &v[0])
-					OpenGL.glGetIntegerv(OpenGL.GL_VIEWPORT, ptr);
-			}
-
+			OpenGL.glGetIntegerv(OpenGL.GL_VIEWPORT, out v[0]);
 			OpenGL.CheckGLError();
 			return v;
 		}
@@ -92,7 +88,7 @@ namespace OpenRA.Platforms.Default
 
 			OpenGL.glFlush();
 			OpenGL.CheckGLError();
-			OpenGL.glBindFramebuffer(OpenGL.FRAMEBUFFER_EXT, framebuffer);
+			OpenGL.glBindFramebuffer(OpenGL.GL_FRAMEBUFFER, framebuffer);
 			OpenGL.CheckGLError();
 			OpenGL.glViewport(0, 0, size.Width, size.Height);
 			OpenGL.CheckGLError();
@@ -107,7 +103,7 @@ namespace OpenRA.Platforms.Default
 			VerifyThreadAffinity();
 			OpenGL.glFlush();
 			OpenGL.CheckGLError();
-			OpenGL.glBindFramebuffer(OpenGL.FRAMEBUFFER_EXT, 0);
+			OpenGL.glBindFramebuffer(OpenGL.GL_FRAMEBUFFER, 0);
 			OpenGL.CheckGLError();
 			OpenGL.glViewport(cv[0], cv[1], cv[2], cv[3]);
 			OpenGL.CheckGLError();

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -297,6 +297,9 @@ namespace OpenRA.Platforms.Default
 		public delegate void DeleteTextures(int n, ref uint textures);
 		public static DeleteTextures glDeleteTextures { get; private set; }
 
+		public delegate bool IsTexture(uint texture);
+		public static IsTexture glIsTexture { get; private set; }
+
 		public delegate void BindTexture(int target, uint texture);
 		public static BindTexture glBindTexture { get; private set; }
 
@@ -423,6 +426,7 @@ namespace OpenRA.Platforms.Default
 				glReadPixels = Bind<ReadPixels>("glReadPixels");
 				glGenTextures = Bind<GenTextures>("glGenTextures");
 				glDeleteTextures = Bind<DeleteTextures>("glDeleteTextures");
+				glIsTexture = Bind<IsTexture>("glIsTexture");
 				glBindTexture = Bind<BindTexture>("glBindTexture");
 				glActiveTexture = Bind<ActiveTexture>("glActiveTexture");
 				glTexImage2D = Bind<TexImage2D>("glTexImage2D");

--- a/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
@@ -37,6 +37,13 @@ namespace OpenRA.Platforms.Default
 
 			OpenGL.Initialize();
 
+			uint vao;
+			OpenGL.CheckGLError();
+			OpenGL.glGenVertexArrays(1, out vao);
+			OpenGL.CheckGLError();
+			OpenGL.glBindVertexArray(vao);
+			OpenGL.CheckGLError();
+
 			OpenGL.glEnableVertexAttribArray(Shader.VertexPosAttributeIndex);
 			OpenGL.CheckGLError();
 			OpenGL.glEnableVertexAttribArray(Shader.TexCoordAttributeIndex);

--- a/OpenRA.Platforms.Default/Shader.cs
+++ b/OpenRA.Platforms.Default/Shader.cs
@@ -33,6 +33,9 @@ namespace OpenRA.Platforms.Default
 			var filename = Path.Combine(Platform.GameDir, "glsl", name + "." + ext);
 			var code = File.ReadAllText(filename);
 
+			var version = OpenGL.Features.HasFlag(OpenGL.GLFeatures.GLES) ? "300 es" : "140";
+			code = code.Replace("{VERSION}", version);
+
 			var shader = OpenGL.glCreateShader(type);
 			OpenGL.CheckGLError();
 			unsafe
@@ -77,6 +80,9 @@ namespace OpenRA.Platforms.Default
 			OpenGL.CheckGLError();
 			OpenGL.glBindAttribLocation(program, TexMetadataAttributeIndex, "aVertexTexMetadata");
 			OpenGL.CheckGLError();
+			OpenGL.glBindFragDataLocation(program, 0, "fragColor");
+			OpenGL.CheckGLError();
+
 			OpenGL.glAttachShader(program, vertexShader);
 			OpenGL.CheckGLError();
 			OpenGL.glAttachShader(program, fragmentShader);
@@ -135,6 +141,7 @@ namespace OpenRA.Platforms.Default
 		{
 			VerifyThreadAffinity();
 			OpenGL.glUseProgram(program);
+			OpenGL.CheckGLError();
 
 			// bind the textures
 			foreach (var kv in textures)

--- a/OpenRA.Platforms.Default/Texture.cs
+++ b/OpenRA.Platforms.Default/Texture.cs
@@ -85,7 +85,8 @@ namespace OpenRA.Platforms.Default
 				{
 					var intPtr = new IntPtr((void*)ptr);
 					PrepareTexture();
-					OpenGL.glTexImage2D(OpenGL.GL_TEXTURE_2D, 0, OpenGL.GL_RGBA8, width, height,
+					var glInternalFormat = OpenGL.Features.HasFlag(OpenGL.GLFeatures.GLES) ? OpenGL.GL_BGRA : OpenGL.GL_RGBA8;
+					OpenGL.glTexImage2D(OpenGL.GL_TEXTURE_2D, 0, glInternalFormat, width, height,
 						0, OpenGL.GL_BGRA, OpenGL.GL_UNSIGNED_BYTE, intPtr);
 					OpenGL.CheckGLError();
 				}
@@ -109,7 +110,8 @@ namespace OpenRA.Platforms.Default
 				{
 					var intPtr = new IntPtr((void*)ptr);
 					PrepareTexture();
-					OpenGL.glTexImage2D(OpenGL.GL_TEXTURE_2D, 0, OpenGL.GL_RGBA8, width, height,
+					var glInternalFormat = OpenGL.Features.HasFlag(OpenGL.GLFeatures.GLES) ? OpenGL.GL_BGRA : OpenGL.GL_RGBA8;
+					OpenGL.glTexImage2D(OpenGL.GL_TEXTURE_2D, 0, glInternalFormat, width, height,
 						0, OpenGL.GL_BGRA, OpenGL.GL_UNSIGNED_BYTE, intPtr);
 					OpenGL.CheckGLError();
 				}
@@ -121,19 +123,51 @@ namespace OpenRA.Platforms.Default
 			VerifyThreadAffinity();
 			var data = new byte[4 * Size.Width * Size.Height];
 
-			OpenGL.CheckGLError();
-			OpenGL.glBindTexture(OpenGL.GL_TEXTURE_2D, texture);
-			unsafe
+			// GLES doesn't support glGetTexImage so data must be read back via a frame buffer
+			if (OpenGL.Features.HasFlag(OpenGL.GLFeatures.GLES))
 			{
-				fixed (byte* ptr = &data[0])
+				// Query the active framebuffer so we can restore it afterwards
+				int lastFramebuffer;
+				OpenGL.glGetIntegerv(OpenGL.GL_FRAMEBUFFER_BINDING, out lastFramebuffer);
+
+				uint framebuffer;
+				OpenGL.glGenFramebuffers(1, out framebuffer);
+				OpenGL.glBindFramebuffer(OpenGL.GL_FRAMEBUFFER, framebuffer);
+				OpenGL.CheckGLError();
+
+				OpenGL.glFramebufferTexture2D(OpenGL.GL_FRAMEBUFFER, OpenGL.GL_COLOR_ATTACHMENT0, OpenGL.GL_TEXTURE_2D, texture, 0);
+				OpenGL.CheckGLError();
+
+				unsafe
 				{
-					var intPtr = new IntPtr((void*)ptr);
-					OpenGL.glGetTexImage(OpenGL.GL_TEXTURE_2D, 0, OpenGL.GL_BGRA,
-						OpenGL.GL_UNSIGNED_BYTE, intPtr);
+					fixed (byte* ptr = &data[0])
+					{
+						var intPtr = new IntPtr((void*)ptr);
+						OpenGL.glReadPixels(0, 0, Size.Width, Size.Height, OpenGL.GL_BGRA, OpenGL.GL_UNSIGNED_BYTE, intPtr);
+						OpenGL.CheckGLError();
+					}
 				}
+
+				OpenGL.glBindFramebuffer(OpenGL.GL_FRAMEBUFFER, (uint)lastFramebuffer);
+				OpenGL.glDeleteFramebuffers(1, ref framebuffer);
+				OpenGL.CheckGLError();
+			}
+			else
+			{
+				OpenGL.glBindTexture(OpenGL.GL_TEXTURE_2D, texture);
+				unsafe
+				{
+					fixed (byte* ptr = &data[0])
+					{
+						var intPtr = new IntPtr((void*)ptr);
+						OpenGL.glGetTexImage(OpenGL.GL_TEXTURE_2D, 0, OpenGL.GL_BGRA,
+							OpenGL.GL_UNSIGNED_BYTE, intPtr);
+					}
+				}
+
+				OpenGL.CheckGLError();
 			}
 
-			OpenGL.CheckGLError();
 			return data;
 		}
 
@@ -145,7 +179,8 @@ namespace OpenRA.Platforms.Default
 
 			Size = new Size(width, height);
 			PrepareTexture();
-			OpenGL.glTexImage2D(OpenGL.GL_TEXTURE_2D, 0, OpenGL.GL_RGBA8, width, height,
+			var glInternalFormat = OpenGL.Features.HasFlag(OpenGL.GLFeatures.GLES) ? OpenGL.GL_BGRA : OpenGL.GL_RGBA8;
+			OpenGL.glTexImage2D(OpenGL.GL_TEXTURE_2D, 0, glInternalFormat, width, height,
 				0, OpenGL.GL_BGRA, OpenGL.GL_UNSIGNED_BYTE, IntPtr.Zero);
 			OpenGL.CheckGLError();
 		}

--- a/OpenRA.Platforms.Default/Texture.cs
+++ b/OpenRA.Platforms.Default/Texture.cs
@@ -72,6 +72,15 @@ namespace OpenRA.Platforms.Default
 			OpenGL.CheckGLError();
 		}
 
+		void SetData(IntPtr data, int width, int height)
+		{
+			PrepareTexture();
+			var glInternalFormat = OpenGL.Features.HasFlag(OpenGL.GLFeatures.GLES) ? OpenGL.GL_BGRA : OpenGL.GL_RGBA8;
+			OpenGL.glTexImage2D(OpenGL.GL_TEXTURE_2D, 0, glInternalFormat, width, height,
+				0, OpenGL.GL_BGRA, OpenGL.GL_UNSIGNED_BYTE, data);
+			OpenGL.CheckGLError();
+		}
+
 		public void SetData(byte[] colors, int width, int height)
 		{
 			VerifyThreadAffinity();
@@ -82,14 +91,7 @@ namespace OpenRA.Platforms.Default
 			unsafe
 			{
 				fixed (byte* ptr = &colors[0])
-				{
-					var intPtr = new IntPtr((void*)ptr);
-					PrepareTexture();
-					var glInternalFormat = OpenGL.Features.HasFlag(OpenGL.GLFeatures.GLES) ? OpenGL.GL_BGRA : OpenGL.GL_RGBA8;
-					OpenGL.glTexImage2D(OpenGL.GL_TEXTURE_2D, 0, glInternalFormat, width, height,
-						0, OpenGL.GL_BGRA, OpenGL.GL_UNSIGNED_BYTE, intPtr);
-					OpenGL.CheckGLError();
-				}
+					SetData(new IntPtr(ptr), width, height);
 			}
 		}
 
@@ -107,14 +109,7 @@ namespace OpenRA.Platforms.Default
 			unsafe
 			{
 				fixed (uint* ptr = &colors[0, 0])
-				{
-					var intPtr = new IntPtr((void*)ptr);
-					PrepareTexture();
-					var glInternalFormat = OpenGL.Features.HasFlag(OpenGL.GLFeatures.GLES) ? OpenGL.GL_BGRA : OpenGL.GL_RGBA8;
-					OpenGL.glTexImage2D(OpenGL.GL_TEXTURE_2D, 0, glInternalFormat, width, height,
-						0, OpenGL.GL_BGRA, OpenGL.GL_UNSIGNED_BYTE, intPtr);
-					OpenGL.CheckGLError();
-				}
+					SetData(new IntPtr(ptr), width, height);
 			}
 		}
 
@@ -178,11 +173,7 @@ namespace OpenRA.Platforms.Default
 				throw new InvalidDataException("Non-power-of-two array {0}x{1}".F(width, height));
 
 			Size = new Size(width, height);
-			PrepareTexture();
-			var glInternalFormat = OpenGL.Features.HasFlag(OpenGL.GLFeatures.GLES) ? OpenGL.GL_BGRA : OpenGL.GL_RGBA8;
-			OpenGL.glTexImage2D(OpenGL.GL_TEXTURE_2D, 0, glInternalFormat, width, height,
-				0, OpenGL.GL_BGRA, OpenGL.GL_UNSIGNED_BYTE, IntPtr.Zero);
-			OpenGL.CheckGLError();
+			SetData(IntPtr.Zero, width, height);
 		}
 
 		public void Dispose()

--- a/glsl/combined.frag
+++ b/glsl/combined.frag
@@ -1,3 +1,10 @@
+#version {VERSION}
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+in vec4 vColor;
+
 uniform sampler2D Texture0;
 uniform sampler2D Texture1;
 uniform sampler2D Texture2;
@@ -10,15 +17,17 @@ uniform sampler2D Palette;
 uniform bool EnableDepthPreview;
 uniform float DepthTextureScale;
 
-varying vec4 vTexCoord;
-varying vec2 vTexMetadata;
-varying vec4 vChannelMask;
-varying vec4 vDepthMask;
-varying vec2 vTexSampler;
+in vec4 vTexCoord;
+in vec2 vTexMetadata;
+in vec4 vChannelMask;
+in vec4 vDepthMask;
+in vec2 vTexSampler;
 
-varying vec4 vColorFraction;
-varying vec4 vRGBAFraction;
-varying vec4 vPalettedFraction;
+in vec4 vColorFraction;
+in vec4 vRGBAFraction;
+in vec4 vPalettedFraction;
+
+out vec4 fragColor;
 
 float jet_r(float x)
 {
@@ -38,26 +47,26 @@ float jet_b(float x)
 vec4 Sample(float samplerIndex, vec2 pos)
 {
 	if (samplerIndex < 0.5)
-		return texture2D(Texture0, pos);
+		return texture(Texture0, pos);
 	else if (samplerIndex < 1.5)
-		return texture2D(Texture1, pos);
+		return texture(Texture1, pos);
 	else if (samplerIndex < 2.5)
-		return texture2D(Texture2, pos);
+		return texture(Texture2, pos);
 	else if (samplerIndex < 3.5)
-		return texture2D(Texture3, pos);
+		return texture(Texture3, pos);
 	else if (samplerIndex < 4.5)
-		return texture2D(Texture4, pos);
+		return texture(Texture4, pos);
 	else if (samplerIndex < 5.5)
-		return texture2D(Texture5, pos);
+		return texture(Texture5, pos);
 
-	return texture2D(Texture6, pos);
+	return texture(Texture6, pos);
 }
 
 void main()
 {
 	vec4 x = Sample(vTexSampler.s, vTexCoord.st);
 	vec2 p = vec2(dot(x, vChannelMask), vTexMetadata.s);
-	vec4 c = vPalettedFraction * texture2D(Palette, p) + vRGBAFraction * x + vColorFraction * vTexCoord;
+	vec4 c = vPalettedFraction * texture(Palette, p) + vRGBAFraction * x + vColorFraction * vTexCoord;
 
 	// Discard any transparent fragments (both color and depth)
 	if (c.a == 0.0)
@@ -79,8 +88,8 @@ void main()
 		float r = clamp(jet_r(x), 0.0, 1.0);
 		float g = clamp(jet_g(x), 0.0, 1.0);
 		float b = clamp(jet_b(x), 0.0, 1.0);
-		gl_FragColor = vec4(r, g, b, 1.0);
+		fragColor = vec4(r, g, b, 1.0);
 	}
 	else
-		gl_FragColor = c;
+		fragColor = c;
 }

--- a/glsl/combined.vert
+++ b/glsl/combined.vert
@@ -1,19 +1,21 @@
+#version {VERSION}
+
 uniform vec3 Scroll;
 uniform vec3 r1, r2;
 
-attribute vec4 aVertexPosition;
-attribute vec4 aVertexTexCoord;
-attribute vec2 aVertexTexMetadata;
+in vec4 aVertexPosition;
+in vec4 aVertexTexCoord;
+in vec2 aVertexTexMetadata;
 
-varying vec4 vTexCoord;
-varying vec2 vTexMetadata;
-varying vec4 vChannelMask;
-varying vec4 vDepthMask;
-varying vec2 vTexSampler;
+out vec4 vTexCoord;
+out vec2 vTexMetadata;
+out vec4 vChannelMask;
+out vec4 vDepthMask;
+out vec2 vTexSampler;
 
-varying vec4 vColorFraction;
-varying vec4 vRGBAFraction;
-varying vec4 vPalettedFraction;
+out vec4 vColorFraction;
+out vec4 vRGBAFraction;
+out vec4 vPalettedFraction;
 
 vec4 UnpackChannelAttributes(float x)
 {

--- a/glsl/model.frag
+++ b/glsl/model.frag
@@ -1,22 +1,28 @@
+#version {VERSION}
+#ifdef GL_ES
+precision mediump float;
+#endif
+
 uniform sampler2D Palette, DiffuseTexture;
 uniform vec2 PaletteRows;
 
 uniform vec4 LightDirection;
 uniform vec3 AmbientLight, DiffuseLight;
 
-varying vec4 vTexCoord;
-varying vec4 vChannelMask;
-varying vec4 vNormalsMask;
+in vec4 vTexCoord;
+in vec4 vChannelMask;
+in vec4 vNormalsMask;
+out vec4 fragColor;
 
 void main()
 {
-	vec4 x = texture2D(DiffuseTexture, vTexCoord.st);
-	vec4 color = texture2D(Palette, vec2(dot(x, vChannelMask), PaletteRows.x));
+	vec4 x = texture(DiffuseTexture, vTexCoord.st);
+	vec4 color = texture(Palette, vec2(dot(x, vChannelMask), PaletteRows.x));
 	if (color.a < 0.01)
 		discard;
 
-	vec4 y = texture2D(DiffuseTexture, vTexCoord.pq);
-	vec4 normal = (2.0 * texture2D(Palette, vec2(dot(y, vNormalsMask), PaletteRows.y)) - 1.0);
+	vec4 y = texture(DiffuseTexture, vTexCoord.pq);
+	vec4 normal = (2.0 * texture(Palette, vec2(dot(y, vNormalsMask), PaletteRows.y)) - 1.0);
 	vec3 intensity = AmbientLight + DiffuseLight * max(dot(normal, LightDirection), 0.0);
-	gl_FragColor = vec4(intensity * color.rgb, color.a);
+	fragColor = vec4(intensity * color.rgb, color.a);
 }

--- a/glsl/model.vert
+++ b/glsl/model.vert
@@ -1,12 +1,14 @@
+#version {VERSION}
+
 uniform mat4 View;
 uniform mat4 TransformMatrix;
 
-attribute vec4 aVertexPosition;
-attribute vec4 aVertexTexCoord;
-attribute vec2 aVertexTexMetadata;
-varying vec4 vTexCoord;
-varying vec4 vChannelMask;
-varying vec4 vNormalsMask;
+in vec4 aVertexPosition;
+in vec4 aVertexTexCoord;
+in vec2 aVertexTexMetadata;
+out vec4 vTexCoord;
+out vec4 vChannelMask;
+out vec4 vNormalsMask;
 
 vec4 DecodeMask(float x)
 {


### PR DESCRIPTION
This PR finally makes our long delayed jump from OpenGL 2.1 to 3.2 Core profile. OpenGL ES 3.0 is also supported - mainly for the Raspberry Pi 4 (3 and earlier now fall below our minspec), but a future PR could investigate using [ANGLE](http://angleproject.org/) to support Windows systems without a GL driver.

This PR focuses on migrating the API, future ones will take advantage of the new capabilities to simplify and improve our use of it. The longer term goal is to align our renderer with modern concepts to simplify the eventual switch to Veldrid and dropping all our native GL code.

Switching away from the legacy GL driver code could potentially fix some of the weird driver bugs that we have seen, but could also expose new issues where long-standing mistakes in our code now trigger different assumptions in the more modern driver code (such as the disposed texture issue fixed here).

Depends on #16996.