### PR TITLE
Warhead refactor - part 2: ValidImpactTypes

### DIFF
--- a/OpenRA.Mods.Common/UpdateRules/Rules/20191117/RemoveImpactActors.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20191117/RemoveImpactActors.cs
@@ -1,0 +1,68 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RemoveImpactActors : UpdateRule
+	{
+		public override string Name { get { return "Remove ImpactActors boolean from CreateEffect warhead"; } }
+		public override string Description
+		{
+			get
+			{
+				return "The ImpactActors boolean has been removed for code consistency reasons.";
+			}
+		}
+
+		readonly List<string> locations = new List<string>();
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			yield return "Note that due to larger internal refactoring of the warhead code,\n" +
+				"certain edge-case setups like submerged subs or aircraft husk explosions\n" +
+				"may no longer work as expected. Use the new ValidImpactTypes flag list to reconfigure such setups.\n" +
+				"Note that the impact type 'Actor' requires the targeted actor to have a valid target type.\n" +
+				"See the RA mods' new setup for examples.";
+
+			if (locations.Any())
+				yield return "The following weapons' CreateEffect warhead(s) had ImpactActors: false.\n" +
+					"Review their target types and, if necessary, change the target types\n" +
+					"to make them trigger on any actors:\n" +
+					UpdateUtils.FormatMessageList(locations);
+
+			locations.Clear();
+		}
+
+		public override IEnumerable<string> UpdateWeaponNode(ModData modData, MiniYamlNode weaponNode)
+		{
+			var addLocation = false;
+			foreach (var node in weaponNode.ChildrenMatching("Warhead"))
+			{
+				if (node.NodeValue<string>() == "CreateEffect")
+				{
+					foreach (var impactActorsNode in node.ChildrenMatching("ImpactActors"))
+						if (!impactActorsNode.NodeValue<bool>())
+							addLocation = true;
+
+					node.RemoveNodes("ImpactActors");
+				}
+
+				if (addLocation)
+					locations.Add("{0} ({1})".F(weaponNode.Key, node.Location.Filename));
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -143,6 +143,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveYesNo(),
 				new RemoveInitialFacingHardcoding(),
 				new RemoveAirdropActorTypeDefault(),
+				new RemoveImpactActors(),
 			})
 		};
 

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -43,77 +43,14 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("Chance of impact sound to play.")]
 		public readonly int ImpactSoundChance = 100;
 
-		[Desc("Consider explosion above this altitude an air explosion.",
-			"If that's the case, this warhead will consider the explosion position to have the 'Air' TargetType (in addition to any nearby actor's TargetTypes).")]
-		public readonly WDist AirThreshold = new WDist(128);
-
-		[Desc("Whether to consider actors in determining whether the explosion should happen. If false, only terrain will be considered.")]
-		public readonly bool ImpactActors = true;
-
-		static readonly BitSet<TargetableType> TargetTypeAir = new BitSet<TargetableType>("Air");
-
-		public ImpactType GetImpactType(World world, CPos cell, WPos pos, Actor firedBy)
-		{
-			// Matching target actor
-			if (ImpactActors)
-			{
-				var targetType = GetDirectHitTargetType(world, cell, pos, firedBy, true);
-				if (targetType == ImpactTargetType.ValidActor)
-					return ImpactType.TargetHit;
-				if (targetType == ImpactTargetType.InvalidActor)
-					return ImpactType.None;
-			}
-
-			var dat = world.Map.DistanceAboveTerrain(pos);
-			if (dat > AirThreshold)
-				return ImpactType.Air;
-
-			return ImpactType.Ground;
-		}
-
-		public ImpactTargetType GetDirectHitTargetType(World world, CPos cell, WPos pos, Actor firedBy, bool checkTargetValidity = false)
-		{
-			var victims = world.FindActorsOnCircle(pos, WDist.Zero);
-			var invalidHit = false;
-
-			foreach (var victim in victims)
-			{
-				if (!AffectsParent && victim == firedBy)
-					continue;
-
-				if (!victim.Info.HasTraitInfo<IHealthInfo>())
-					continue;
-
-				// If the impact position is within any HitShape, we have a direct hit
-				var activeShapes = victim.TraitsImplementing<HitShape>().Where(Exts.IsTraitEnabled);
-				var directHit = activeShapes.Any(i => i.Info.Type.DistanceFromEdge(pos, victim).Length <= 0);
-
-				// If the warhead landed outside the actor's hit-shape(s), we need to skip the rest so it won't be considered an invalidHit
-				if (!directHit)
-					continue;
-
-				if (!checkTargetValidity || IsValidAgainst(victim, firedBy))
-					return ImpactTargetType.ValidActor;
-
-				// If we got here, it must be an invalid target
-				invalidHit = true;
-			}
-
-			// If there was at least a single direct hit, but none on valid target(s), we return InvalidActor
-			return invalidHit ? ImpactTargetType.InvalidActor : ImpactTargetType.NoActor;
-		}
-
 		public override void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers)
 		{
 			if (!target.IsValidFor(firedBy))
 				return;
 
-			var pos = target.CenterPosition;
 			var world = firedBy.World;
-			var targetTile = world.Map.CellContaining(pos);
-			var isValid = IsValidImpact(pos, firedBy);
-
-			if ((!world.Map.Contains(targetTile)) || (!isValid))
+			var pos = target.CenterPosition;
+			if (!IsValidImpact(world, pos, firedBy))
 				return;
 
 			var palette = ExplosionPalette;
@@ -123,11 +60,9 @@ namespace OpenRA.Mods.Common.Warheads
 			var explosion = Explosions.RandomOrDefault(world.LocalRandom);
 			if (Image != null && explosion != null)
 			{
+				var dat = world.Map.DistanceAboveTerrain(pos);
 				if (ForceDisplayAtGroundLevel)
-				{
-					var dat = world.Map.DistanceAboveTerrain(pos);
-					pos = new WPos(pos.X, pos.Y, pos.Z - dat.Length);
-				}
+					pos -= new WVec(0, 0, dat.Length);
 
 				world.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, w, Image, explosion, palette)));
 			}
@@ -135,28 +70,6 @@ namespace OpenRA.Mods.Common.Warheads
 			var impactSound = ImpactSounds.RandomOrDefault(world.LocalRandom);
 			if (impactSound != null && world.LocalRandom.Next(0, 100) < ImpactSoundChance)
 				Game.Sound.Play(SoundType.World, impactSound, pos);
-		}
-
-		public bool IsValidImpact(WPos pos, Actor firedBy)
-		{
-			var world = firedBy.World;
-			var targetTile = world.Map.CellContaining(pos);
-			if (!world.Map.Contains(targetTile))
-				return false;
-
-			var impactType = GetImpactType(world, targetTile, pos, firedBy);
-			switch (impactType)
-			{
-				case ImpactType.TargetHit:
-					return true;
-				case ImpactType.Air:
-					return IsValidTarget(TargetTypeAir);
-				case ImpactType.Ground:
-					var tileInfo = world.Map.GetTerrainInfo(targetTile);
-					return IsValidTarget(tileInfo.TargetTypes);
-				default:
-					return false;
-			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Warheads/LeaveSmudgeWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/LeaveSmudgeWarhead.cs
@@ -25,9 +25,6 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("Type of smudge to apply to terrain.")]
 		public readonly HashSet<string> SmudgeType = new HashSet<string>();
 
-		[Desc("How close to ground must the impact happen to spawn smudges.")]
-		public readonly WDist AirThreshold = new WDist(128);
-
 		[Desc("Percentual chance the smudge is created.")]
 		public readonly int Chance = 100;
 

--- a/mods/cnc/weapons/ballistics.yaml
+++ b/mods/cnc/weapons/ballistics.yaml
@@ -21,7 +21,6 @@
 	Warhead@3Eff: CreateEffect
 		Explosions: small_frag
 		ImpactSounds: xplos.aud
-		ImpactActors: false
 
 70mm:
 	Inherits: ^BallisticWeapon

--- a/mods/cnc/weapons/explosions.yaml
+++ b/mods/cnc/weapons/explosions.yaml
@@ -11,7 +11,6 @@
 	Warhead@2Eff: CreateEffect
 		Explosions: poof
 		ImpactSounds: xplos.aud
-		ImpactActors: false
 	Warhead@3Smu: LeaveSmudge
 		SmudgeType: Crater
 		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees, Creep
@@ -90,7 +89,6 @@ BuildingExplode:
 	Warhead@1Eff: CreateEffect
 		Explosions: building, building_napalm, med_frag, poof, small_building
 		Delay: 1
-		ImpactActors: false
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 		Delay: 1

--- a/mods/cnc/weapons/missiles.yaml
+++ b/mods/cnc/weapons/missiles.yaml
@@ -31,12 +31,10 @@
 	Warhead@3Eff: CreateEffect
 		Explosions: small_frag
 		ImpactSounds: xplos.aud
-		ImpactActors: false
 		ValidTargets: Ground, Water
 	Warhead@4EffAir: CreateEffect
 		Explosions: small_poof
 		ImpactSounds: xplos.aud
-		ImpactActors: false
 		ValidTargets: Air
 
 Dragon:

--- a/mods/cnc/weapons/other.yaml
+++ b/mods/cnc/weapons/other.yaml
@@ -23,7 +23,6 @@
 	Warhead@3Eff: CreateEffect
 		Explosions: small_napalm
 		ImpactSounds: flamer2.aud
-		ImpactActors: false
 
 Flamethrower:
 	Inherits: ^FlameWeapon
@@ -144,4 +143,3 @@ Demolish:
 	Warhead@2Eff: CreateEffect
 		Explosions: building
 		ImpactSounds: xplobig6.aud
-		ImpactActors: false

--- a/mods/cnc/weapons/smallcaliber.yaml
+++ b/mods/cnc/weapons/smallcaliber.yaml
@@ -29,7 +29,6 @@ Sniper:
 		DamageTypes: Prone50Percent, TriggerProne, RippedApartDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
-		ImpactActors: false
 		ValidTargets: Ground, Water, Air
 
 HighV:

--- a/mods/cnc/weapons/superweapons.yaml
+++ b/mods/cnc/weapons/superweapons.yaml
@@ -16,7 +16,6 @@ Atomic:
 	Warhead@2Eff_impact: CreateEffect
 		Explosions: nuke_explosion
 		ImpactSounds: nukexplo.aud
-		ImpactActors: false
 	Warhead@3Dam_areanukea: SpreadDamage
 		Spread: 2c512
 		Damage: 11000
@@ -41,7 +40,6 @@ Atomic:
 	Warhead@6Eff_areanukea: CreateEffect
 		ImpactSounds: xplobig4.aud
 		Delay: 3
-		ImpactActors: false
 	Warhead@7Dam_areanukeb: SpreadDamage
 		Spread: 3c768
 		Damage: 5000

--- a/mods/d2k/weapons/debris.yaml
+++ b/mods/d2k/weapons/debris.yaml
@@ -31,7 +31,6 @@ Debris:
 		InvalidTargets: Vehicle, Structure
 	Warhead@3Eff: CreateEffect
 		Explosions: tiny_explosion
-		ImpactActors: false
 	Warhead@4Concrete: DamagesConcrete
 		Damage: 300
 

--- a/mods/d2k/weapons/largeguns.yaml
+++ b/mods/d2k/weapons/largeguns.yaml
@@ -25,7 +25,6 @@
 		InvalidTargets: Vehicle, Structure
 	Warhead@3Eff: CreateEffect
 		Explosions: small_napalm
-		ImpactActors: false
 	Warhead@4Concrete: DamagesConcrete
 		Damage: 540
 

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -30,7 +30,6 @@
 		InvalidTargets: Vehicle, Structure
 	Warhead@3Eff: CreateEffect
 		Explosions: tiny_explosion
-		ImpactActors: false
 		ValidTargets: Ground, Air
 	Warhead@3Concrete: DamagesConcrete
 		Damage: 240

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -87,7 +87,6 @@ OrniBomb:
 	Warhead@3Eff: CreateEffect
 		Explosions: large_explosion
 		ImpactSounds: EXPLSML4.WAV
-		ImpactActors: false
 	Warhead@4Concrete: DamagesConcrete
 		Damage: 6750
 
@@ -104,7 +103,6 @@ Demolish:
 	Warhead@2Eff: CreateEffect
 		Explosions: building
 		ImpactSounds: EXPLLG2.WAV
-		ImpactActors: false
 
 DeathHand:
 	Warhead@Cluster: FireCluster
@@ -115,7 +113,6 @@ DeathHand:
 	Warhead@2Eff: CreateEffect
 		Explosions: nuke
 		ImpactSounds: EXPLLG2.WAV
-		ImpactActors: false
 
 DeathHandCluster:
 	Inherits: Debris2
@@ -169,7 +166,6 @@ CrateExplosion:
 	Warhead@2Eff: CreateEffect
 		Explosions: large_explosion
 		ImpactSounds: EXPLSML4.WAV
-		ImpactActors: false
 	Warhead@2Concrete: DamagesConcrete
 		Damage: 4500
 
@@ -177,30 +173,25 @@ UnitExplodeSmall:
 	Warhead@1Eff: CreateEffect
 		Explosions: self_destruct
 		ImpactSounds: EXPLSML1.WAV
-		ImpactActors: false
 
 UnitExplodeMed:
 	Warhead@1Eff: CreateEffect
 		Explosions: building
 		ImpactSounds: EXPLSML2.WAV
-		ImpactActors: false
 
 UnitExplodeLarge:
 	Warhead@1Eff: CreateEffect
 		Explosions: large_explosion
 		ImpactSounds: EXPLLG2.WAV
-		ImpactActors: false
 
 BuildingExplode:
 	Warhead@1Eff: CreateEffect
 		Explosions: building, self_destruct, large_explosion
-		ImpactActors: false
 
 WallExplode:
 	Warhead@1Eff: CreateEffect
 		Explosions: wall_explosion
 		ImpactSounds: EXPLHG1.WAV
-		ImpactActors: false
 
 grenade:
 	ReloadDelay: 50
@@ -231,7 +222,6 @@ grenade:
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion
 		ImpactSounds: EXPLMD2.WAV
-		ImpactActors: false
 	Warhead@4Concrete: DamagesConcrete
 		Damage: 1875
 
@@ -254,7 +244,6 @@ GrenDeath:
 	Warhead@3Eff: CreateEffect
 		Explosions: building
 		ImpactSounds: EXPLSML4.WAV
-		ImpactActors: false
 	Warhead@4Concrete: DamagesConcrete
 		Damage: 1875
 
@@ -278,7 +267,6 @@ SardDeath:
 	Warhead@3Eff: CreateEffect
 		Explosions: small_napalm
 		ImpactSounds: EXPLSML2.WAV
-		ImpactActors: false
 	Warhead@4Concrete: DamagesConcrete
 		Damage: 450
 
@@ -310,7 +298,6 @@ SpiceExplosion:
 		Size: 1
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion
-		ImpactActors: false
 
 BloomExplosion:
 	Report: EXPLMD1.WAV

--- a/mods/d2k/weapons/smallguns.yaml
+++ b/mods/d2k/weapons/smallguns.yaml
@@ -19,7 +19,6 @@
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
-		ImpactActors: false
 	Warhead@3Concrete: DamagesConcrete
 		Damage: 1250
 

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -1034,6 +1034,9 @@
 		Moves: True
 		Velocity: 86
 		Explosion: UnitExplodePlane
+	Targetable:
+		TargetTypes: Air, NoAutoTarget
+		RequiresForceFire: true
 	-MapEditorData:
 	RevealOnDeath:
 		Duration: 60
@@ -1052,6 +1055,9 @@
 		CanSlide: True
 	FallsToEarth:
 		Explosion: UnitExplodeHeli
+	Targetable:
+		TargetTypes: Air, NoAutoTarget
+		RequiresForceFire: true
 	BodyOrientation:
 		UseClassicFacingFudge: True
 	-MapEditorData:

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -18,15 +18,29 @@
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees
-	Warhead@3Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
 		Explosions: small_explosion
 		ImpactSounds: kaboom12.aud
-		ValidTargets: Ground, Ship, Trees
-	Warhead@4EffWater: CreateEffect
+		ValidImpactTypes: Actor
+		AffectsParent: true
+		ValidTargets: Ground, Water, Air, Trees
+		InvalidTargets: Underwater
+	Warhead@EffSubmergedHit: CreateEffect
 		Explosions: small_splash
 		ImpactSounds: splash9.aud
-		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+		ValidTargets: Underwater
+		ValidImpactTypes: Actor
+	Warhead@EffGround: CreateEffect
+		Explosions: small_explosion
+		ImpactSounds: kaboom12.aud
+		ValidImpactTypes: Terrain
+		ValidTargets: Ground, Air
+		InvalidTargets: Water
+	Warhead@EffWater: CreateEffect
+		Explosions: small_splash
+		ImpactSounds: splash9.aud
+		ValidTargets: Water
+		ValidImpactTypes: Terrain
 
 25mm:
 	Inherits: ^Cannon
@@ -45,9 +59,13 @@
 			Heavy: 48
 			Concrete: 32
 	-Warhead@2Smu:
-	Warhead@3Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
 		-ImpactSounds:
-	Warhead@4EffWater: CreateEffect
+	Warhead@EffSubmergedHit: CreateEffect
+		-ImpactSounds:
+	Warhead@EffGround: CreateEffect
+		-ImpactSounds:
+	Warhead@EffWater: CreateEffect
 		-ImpactSounds:
 
 90mm:
@@ -104,10 +122,15 @@ TurretGun:
 			Light: 60
 			Heavy: 25
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
-	Warhead@3Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
 		Explosions: artillery_explosion
 		ImpactSounds: kaboom15.aud
-	Warhead@4EffWater: CreateEffect
+	Warhead@EffSubmergedHit: CreateEffect
+		Explosions: med_splash
+	Warhead@EffGround: CreateEffect
+		Explosions: artillery_explosion
+		ImpactSounds: kaboom15.aud
+	Warhead@EffWater: CreateEffect
 		Explosions: med_splash
 
 155mm:
@@ -145,7 +168,9 @@ TurretGun:
 			Light: 60
 			Heavy: 25
 			Concrete: 100
-	Warhead@4EffWater: CreateEffect
+	Warhead@EffSubmergedHit: CreateEffect
+		Explosions: large_splash
+	Warhead@EffWater: CreateEffect
 		Explosions: large_splash
 
 2Inch:
@@ -182,10 +207,15 @@ Grenade:
 			Light: 25
 			Heavy: 25
 			Concrete: 100
-	Warhead@3Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
 		Explosions: med_explosion
 		ImpactSounds: kaboom25.aud
-	Warhead@4EffWater: CreateEffect
+	Warhead@EffSubmergedHit: CreateEffect
+		Explosions: small_splash
+	Warhead@EffGround: CreateEffect
+		Explosions: med_explosion
+		ImpactSounds: kaboom25.aud
+	Warhead@EffWater: CreateEffect
 		Explosions: small_splash
 
 DepthCharge:
@@ -205,11 +235,16 @@ DepthCharge:
 		Versus:
 			Light: 75
 		DamageTypes: ExplosionDeath
-	Warhead@4EffWater: CreateEffect
-		Explosions: large_splash
-		ImpactSounds: h2obomb2.aud
-		ValidTargets: Water, Underwater
-	Warhead@3Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
 		Explosions: small_explosion
 		ImpactSounds: kaboom15.aud
-		ValidTargets: Submarine
+		ValidTargets: Ship, Submarine
+	Warhead@EffSubmergedHit: CreateEffect
+		Explosions: large_splash
+		ImpactSounds: h2obomb2.aud
+	Warhead@EffGround: CreateEffect
+		Explosions: small_explosion
+		ImpactSounds: kaboom15.aud
+	Warhead@EffWater: CreateEffect
+		Explosions: large_splash
+		ImpactSounds: h2obomb2.aud

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -13,15 +13,30 @@
 	Warhead@Smu: LeaveSmudge
 		SmudgeType: Crater
 		InvalidTargets: Structure, Wall, Trees
-	Warhead@2Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
 		Explosions: self_destruct
 		ImpactSounds: kaboom22.aud
-		ValidTargets: Ground, Air, Ship, Trees
-	Warhead@3EffWater: CreateEffect
+		ValidImpactTypes: Actor
+		AffectsParent: true
+		ValidTargets: Ground, Water, Air, Trees
+		InvalidTargets: Underwater
+	Warhead@EffGround: CreateEffect
+		Explosions: self_destruct
+		ImpactSounds: kaboom22.aud
+		ValidImpactTypes: Terrain
+		ValidTargets: Ground, Air
+		InvalidTargets: Water
+	Warhead@EffSubmergedHit: CreateEffect
 		Explosions: large_splash
 		ImpactSounds: splash9.aud
-		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+		ValidImpactTypes: Actor
+		AffectsParent: true
+		ValidTargets: Underwater
+	Warhead@EffWater: CreateEffect
+		Explosions: large_splash
+		ImpactSounds: splash9.aud
+		ValidImpactTypes: Terrain
+		ValidTargets: Water
 
 CrateNapalm:
 	Inherits: ^Explosion
@@ -36,11 +51,14 @@ CrateNapalm:
 			Concrete: 50
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
-	Warhead@2Eff: CreateEffect
+	Warhead@EffGround: CreateEffect
 		Explosions: napalm
 		ImpactSounds: firebl3.aud
+		ValidImpactTypes: Actor, Terrain
 		ValidTargets: Ground, Water, Air, Trees
-	-Warhead@3EffWater:
+	-Warhead@EffDirectHit:
+	-Warhead@EffWater:
+	-Warhead@EffSubmergedHit:
 	Warhead@Smu: LeaveSmudge
 		SmudgeType: Scorch
 
@@ -49,9 +67,12 @@ CrateExplosion:
 	Warhead@1Dam: SpreadDamage
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		AffectsParent: true
-	Warhead@2Eff: CreateEffect
+	Warhead@EffGround: CreateEffect
+		ValidImpactTypes: Actor, Terrain
 		ValidTargets: Ground, Water, Air
-	-Warhead@3EffWater:
+	-Warhead@EffDirectHit:
+	-Warhead@EffWater:
+	-Warhead@EffSubmergedHit:
 
 UnitExplode:
 	Inherits: ^Explosion
@@ -60,59 +81,72 @@ UnitExplode:
 
 UnitExplodePlane:
 	Inherits: UnitExplode
-	Warhead@2Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
+		Explosions: large_napalm
+	Warhead@EffGround: CreateEffect
 		Explosions: large_napalm
 
 UnitExplodeHeli:
 	Inherits: UnitExplode
-	Warhead@2Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
+		Explosions: napalm
+	Warhead@EffGround: CreateEffect
 		Explosions: napalm
 
 VisualExplode:
 	Inherits: ^Explosion
 	-Warhead@1Dam:
-	Warhead@2Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
+		Explosions: offseted_napalm
+		ImpactSounds: firebl3.aud
+	Warhead@EffGround: CreateEffect
 		Explosions: offseted_napalm
 		ImpactSounds: firebl3.aud
 
 UnitExplodeShip:
 	Inherits: ^Explosion
 	-Warhead@Smu:
-	Warhead@2Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
 		Explosions: building
 		ImpactSounds: kaboom25.aud
-		ValidTargets: Ground, Water
+	Warhead@EffGround: CreateEffect
+		Explosions: building
+		ImpactSounds: kaboom25.aud
 
 UnitExplodeSubmarine:
 	Inherits: ^Explosion
 	-Warhead@Smu:
-	Warhead@2Eff: CreateEffect
+	-Warhead@EffDirectHit:
+	-Warhead@EffGround:
+	-Warhead@EffSubmergedHit:
+	Warhead@EffWater: CreateEffect
 		Explosions: large_splash
 		ImpactSounds: splash9.aud
-		ValidTargets: Ground, Water
+		ValidImpactTypes: Actor, Terrain
+		ValidTargets: Water, Underwater
 
 UnitExplodeSmall:
 	Inherits: ^Explosion
 	Warhead@1Dam: SpreadDamage
 		Damage: 4000
-	Warhead@2Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
 		Explosions: large_explosion
 		ImpactSounds: kaboom15.aud
+	Warhead@EffGround: CreateEffect
+		Explosions: large_explosion
+		ImpactSounds: kaboom15.aud	
 
 ArtilleryExplode:
 	Inherits: ^Explosion
 	Warhead@1Dam: SpreadDamage
 		Damage: 15000
-	Warhead@2Eff: CreateEffect
-		Explosions: self_destruct
-		ImpactSounds: kaboom22.aud
 
 V2Explode:
 	Inherits: SCUD
 	-Report:
 
 BuildingExplode:
-	Warhead@2Eff: CreateEffect
+	Warhead@Eff: CreateEffect
 		Explosions: building, building_napalm, large_explosion, self_destruct, large_napalm
 	Warhead@Smu: LeaveSmudge
 		SmudgeType: Crater
@@ -120,7 +154,7 @@ BuildingExplode:
 
 SmallBuildingExplode:
 	Inherits: BuildingExplode
-	Warhead@2Eff: CreateEffect
+	Warhead@Eff: CreateEffect
 		Explosions: building, building_napalm, large_explosion, self_destruct
 
 CivPanicExplosion:
@@ -142,11 +176,15 @@ BarrelExplode:
 			Light: 50
 			Concrete: 10
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath, Incendiary
-	Warhead@2Eff: CreateEffect
+	Warhead@EffGround: CreateEffect
+		ValidImpactTypes: Actor, Terrain
+		ValidTargets: Ground, Water, Air, Trees
 		Explosions: napalm
 		ImpactSounds: firebl3.aud
 		Delay: 5
-	-Warhead@3EffWater:
+	-Warhead@EffDirectHit:
+	-Warhead@EffWater:
+	-Warhead@EffSubmergedHit:
 	Warhead@Smu: LeaveSmudge
 		SmudgeType: Scorch
 		Size: 2
@@ -159,7 +197,7 @@ ATMine:
 		AffectsParent: true
 		InvalidTargets: Mine
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
-	Warhead@2Eff: CreateEffect
+	Warhead@Eff: CreateEffect
 		Explosions: large_explosion
 		ImpactSounds: mineblo1.aud
 	Warhead@Smu: LeaveSmudge
@@ -170,7 +208,7 @@ APMine:
 	Inherits: ATMine
 	Warhead@1Dam: SpreadDamage
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
-	Warhead@2Eff: CreateEffect
+	Warhead@Eff: CreateEffect
 		Explosions: napalm
 		ImpactSounds: mine1.aud
 	Warhead@Smu: LeaveSmudge

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -208,7 +208,6 @@ CrateNuke:
 	Warhead@3Eff_impact: CreateEffect
 		Explosions: nuke
 		ImpactSounds: kaboom1.aud
-		ImpactActors: false
 	Warhead@4Dam_areanuke1: SpreadDamage
 		Spread: 1c0
 		Damage: 6000
@@ -225,7 +224,6 @@ CrateNuke:
 	Warhead@6Eff_areanuke1: CreateEffect
 		ImpactSounds: kaboom22.aud
 		Delay: 5
-		ImpactActors: false
 	Warhead@6Smu_areanuke1: LeaveSmudge
 		SmudgeType: Scorch
 		InvalidTargets: Vehicle, Structure, Wall, Trees
@@ -256,7 +254,6 @@ MiniNuke:
 	Warhead@3Eff_impact: CreateEffect
 		Explosions: nuke
 		ImpactSounds: kaboom1.aud
-		ImpactActors: false
 	Warhead@4Dam_areanuke1: SpreadDamage
 		Spread: 2c0
 		Damage: 6000
@@ -274,7 +271,6 @@ MiniNuke:
 	Warhead@6Eff_areanuke1: CreateEffect
 		ImpactSounds: kaboom22.aud
 		Delay: 5
-		ImpactActors: false
 	Warhead@7Dam_areanuke2: SpreadDamage
 		Spread: 3c0
 		Damage: 6000

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -40,8 +40,6 @@
 ^AntiAirMissile:
 	Inherits: ^AntiGroundMissile
 	ValidTargets: Air
-	Warhead@3Eff: CreateEffect
-		ImpactActors: false
 
 Maverick:
 	Inherits: ^AntiGroundMissile

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -27,15 +27,30 @@
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees
-	Warhead@3Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
 		Explosions: med_explosion
 		ImpactSounds: kaboom25.aud
-		ValidTargets: Ground, Air, Ship, Trees
-	Warhead@4EffWater: CreateEffect
+		ValidImpactTypes: Actor
+		AffectsParent: true
+		ValidTargets: Ground, Water, Air, Trees
+		InvalidTargets: Underwater
+	Warhead@EffSubmergedHit: CreateEffect
 		Explosions: med_splash
 		ImpactSounds: splash9.aud
-		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+		ValidTargets: Underwater
+		ValidImpactTypes: Actor
+		AffectsParent: true
+	Warhead@EffGround: CreateEffect
+		Explosions: med_explosion
+		ImpactSounds: kaboom25.aud
+		ValidImpactTypes: Terrain
+		ValidTargets: Ground, Air
+		InvalidTargets: Water
+	Warhead@EffWater: CreateEffect
+		Explosions: med_splash
+		ImpactSounds: splash9.aud
+		ValidTargets: Water
+		ValidImpactTypes: Terrain
 
 ^AntiAirMissile:
 	Inherits: ^AntiGroundMissile
@@ -103,7 +118,9 @@ HellfireAA:
 		Versus:
 			Wood: 75
 			Light: 75
-	Warhead@3Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
+		Explosions: med_explosion_air
+	Warhead@EffGround: CreateEffect
 		Explosions: med_explosion_air
 
 MammothTusk:
@@ -125,10 +142,13 @@ MammothTusk:
 			Heavy: 24
 			Concrete: 50
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
-	Warhead@3Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
 		ImpactSounds: kaboom12.aud
 		ValidTargets: Ground, Trees
-	Warhead@5EffAir: CreateEffect
+	Warhead@EffGround: CreateEffect
+		ImpactSounds: kaboom12.aud
+		ValidTargets: Ground, Trees
+	Warhead@EffAir: CreateEffect
 		Explosions: med_explosion_air
 		ImpactSounds: kaboom25.aud
 		ValidTargets: Air
@@ -150,9 +170,10 @@ Nike:
 		ValidTargets: Air
 		Versus:
 			Light: 90
-	Warhead@3Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
 		Explosions: med_explosion_air
-		ImpactSounds: kaboom25.aud
+	Warhead@EffGround: CreateEffect
+		Explosions: med_explosion_air
 
 RedEye:
 	Inherits: Nike
@@ -196,9 +217,8 @@ StingerAA:
 	Projectile: Missile
 		Speed: 255
 		CloseEnough: 298
-	Warhead@3Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
 		Explosions: med_explosion_air
-		ImpactSounds: kaboom25.aud
 
 APTusk:
 	Inherits: ^AntiGroundMissile
@@ -246,15 +266,17 @@ TorpTube:
 			Heavy: 100
 			Concrete: 500
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
-	Warhead@3Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
 		Explosions: artillery_explosion
 		ImpactSounds: kaboom15.aud
-		ValidTargets: Ship, Structure, Underwater, Ground, Bridge
-	Warhead@4EffWater: CreateEffect
+	Warhead@EffGround: CreateEffect
+		Explosions: artillery_explosion
+		ImpactSounds: kaboom15.aud
+		ValidTargets: Ground, Bridge
+	Warhead@EffSubmergedHit: CreateEffect
 		Explosions: large_splash
-		ImpactSounds: splash9.aud
-		ValidTargets: Water
-		InvalidTargets: Ship, Structure, Underwater, Bridge
+	Warhead@EffWater: CreateEffect
+		Explosions: large_splash
 
 ^SubMissileDefault:
 	Inherits: ^AntiGroundMissile
@@ -280,12 +302,16 @@ TorpTube:
 			Heavy: 30
 			Concrete: 100
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
-	Warhead@3Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
 		Explosions: artillery_explosion
 		ImpactSounds: kaboom15.aud
-	Warhead@4EffWater: CreateEffect
+	Warhead@EffGround: CreateEffect
+		Explosions: artillery_explosion
+		ImpactSounds: kaboom15.aud
+	Warhead@EffSubmergedHit: CreateEffect
 		Explosions: large_splash
-		ImpactSounds: splash9.aud
+	Warhead@EffWater: CreateEffect
+		Explosions: large_splash
 
 SubMissile:
 	Inherits: ^SubMissileDefault
@@ -336,8 +362,13 @@ SCUD:
 			Heavy: 40
 			Concrete: 100
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath, Incendiary
-	Warhead@3Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
 		Explosions: napalm
 		ImpactSounds: firebl3.aud
-	Warhead@4EffWater: CreateEffect
+	Warhead@EffGround: CreateEffect
+		Explosions: napalm
+		ImpactSounds: firebl3.aud
+	Warhead@EffSubmergedHit: CreateEffect
+		Explosions: large_splash
+	Warhead@EffWater: CreateEffect
 		Explosions: large_splash

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -19,6 +19,7 @@
 	Warhead@3Eff: CreateEffect
 		Explosions: napalm
 		ImpactSounds: firebl3.aud
+		ValidTargets: Ground, Water, Trees
 
 FireballLauncher:
 	Inherits: ^FireWeapon

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -19,7 +19,6 @@
 	Warhead@3Eff: CreateEffect
 		Explosions: napalm
 		ImpactSounds: firebl3.aud
-		ImpactActors: false
 
 FireballLauncher:
 	Inherits: ^FireWeapon
@@ -234,4 +233,3 @@ MADTankDetonate:
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion
 		ImpactSounds: mineblo1.aud
-		ImpactActors: false

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -51,13 +51,26 @@ FLAK-23-AG:
 		Blockable: True
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: Air, Ground, Water
-	Warhead@2Eff: CreateEffect
-		Explosions: flak_explosion_ground
-		ValidTargets: Ground, Ship, Air, Trees
-	Warhead@3EffWater: CreateEffect
+	-Warhead@2Eff:
+	Warhead@EffDirectHit: CreateEffect
+		Explosions: small_explosion_air
+		ValidImpactTypes: Actor
+		AffectsParent: true
+		ValidTargets: Ground, Water, Air, Trees
+		InvalidTargets: Underwater
+	Warhead@EffGround: CreateEffect
+		Explosions: small_explosion_air
+		ValidImpactTypes: Terrain
+		ValidTargets: Ground, Air
+		InvalidTargets: Water
+	Warhead@EffSubmergedHit: CreateEffect
 		Explosions: small_splash
-		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+		ValidTargets: Underwater
+		ValidImpactTypes: Actor
+	Warhead@EffWater: CreateEffect
+		Explosions: small_splash
+		ValidTargets: Water
+		ValidImpactTypes: Terrain
 
 ^HeavyMG:
 	ReloadDelay: 30
@@ -75,13 +88,25 @@ FLAK-23-AG:
 			Heavy: 28
 			Concrete: 28
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
-	Warhead@2Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground, Ship, Air, Trees
-	Warhead@3EffWater: CreateEffect
+		ValidImpactTypes: Actor
+		AffectsParent: true
+		ValidTargets: Ground, Water, Air, Trees
+		InvalidTargets: Underwater
+	Warhead@EffGround: CreateEffect
+		Explosions: piffs
+		ValidImpactTypes: Terrain
+		ValidTargets: Ground, Air
+		InvalidTargets: Water
+	Warhead@EffSubmergedHit: CreateEffect
 		Explosions: water_piffs
-		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+		ValidTargets: Underwater
+		ValidImpactTypes: Actor
+	Warhead@EffWater: CreateEffect
+		Explosions: water_piffs
+		ValidTargets: Water
+		ValidImpactTypes: Terrain
 
 ^LightMG:
 	Inherits: ^HeavyMG
@@ -116,14 +141,27 @@ Vulcan:
 			Heavy: 20
 			Concrete: 20
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
-	Warhead@4Eff_2: CreateEffect
+	Warhead@EffDirectHit_2: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground, Ship, Trees
+		ValidImpactTypes: Actor
+		AffectsParent: true
+		ValidTargets: Ground, Water, Air, Trees
+		InvalidTargets: Underwater
 		Delay: 2
-	Warhead@4Eff_2Water: CreateEffect
+	Warhead@EffGround_2: CreateEffect
+		Explosions: piffs
+		ValidImpactTypes: Terrain
+		InvalidTargets: Water
+		Delay: 2
+	Warhead@EffSubmergedHit_2: CreateEffect
 		Explosions: water_piffs
-		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+		ValidTargets: Underwater
+		ValidImpactTypes: Actor
+		Delay: 2
+	Warhead@EffWater_2: CreateEffect
+		Explosions: water_piffs
+		ValidTargets: Water
+		ValidImpactTypes: Terrain
 		Delay: 2
 	Warhead@5Dam_3: SpreadDamage
 		Spread: 128
@@ -136,14 +174,27 @@ Vulcan:
 			Heavy: 20
 			Concrete: 20
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
-	Warhead@6Eff_3: CreateEffect
+	Warhead@EffDirectHit_3: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground, Ship, Trees
+		ValidImpactTypes: Actor
+		AffectsParent: true
+		ValidTargets: Ground, Water, Air, Trees
+		InvalidTargets: Underwater
 		Delay: 4
-	Warhead@6Eff_3Water: CreateEffect
+	Warhead@EffGround_3: CreateEffect
+		Explosions: piffs
+		ValidImpactTypes: Terrain
+		InvalidTargets: Water
+		Delay: 4
+	Warhead@EffSubmergedHit_3: CreateEffect
 		Explosions: water_piffs
-		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+		ValidTargets: Underwater
+		ValidImpactTypes: Actor
+		Delay: 4
+	Warhead@EffWater_3: CreateEffect
+		Explosions: water_piffs
+		ValidTargets: Water
+		ValidImpactTypes: Terrain
 		Delay: 4
 	Warhead@7Dam_4: SpreadDamage
 		Spread: 128
@@ -156,14 +207,27 @@ Vulcan:
 			Heavy: 20
 			Concrete: 20
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
-	Warhead@8Eff_4: CreateEffect
+	Warhead@EffDirectHit_4: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground, Ship, Trees
+		ValidImpactTypes: Actor
+		AffectsParent: true
+		ValidTargets: Ground, Water, Air, Trees
+		InvalidTargets: Underwater
 		Delay: 6
-	Warhead@8Eff_4Water: CreateEffect
+	Warhead@EffGround_4: CreateEffect
+		Explosions: piffs
+		ValidImpactTypes: Terrain
+		InvalidTargets: Water
+		Delay: 6
+	Warhead@EffSubmergedHit_4: CreateEffect
 		Explosions: water_piffs
-		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+		ValidTargets: Underwater
+		ValidImpactTypes: Actor
+		Delay: 6
+	Warhead@EffWater_4: CreateEffect
+		Explosions: water_piffs
+		ValidTargets: Water
+		ValidImpactTypes: Terrain
 		Delay: 6
 	Warhead@9Dam_5: SpreadDamage
 		Spread: 128
@@ -176,14 +240,27 @@ Vulcan:
 			Heavy: 20
 			Concrete: 20
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
-	Warhead@10Eff_5: CreateEffect
+	Warhead@EffDirectHit_5: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground, Ship, Trees
+		ValidImpactTypes: Actor
+		AffectsParent: true
+		ValidTargets: Ground, Water, Air, Trees
+		InvalidTargets: Underwater
 		Delay: 8
-	Warhead@10Eff_5Water: CreateEffect
+	Warhead@EffGround_5: CreateEffect
+		Explosions: piffs
+		ValidImpactTypes: Terrain
+		InvalidTargets: Water
+		Delay: 8
+	Warhead@EffSubmergedHit_5: CreateEffect
 		Explosions: water_piffs
-		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+		ValidTargets: Underwater
+		ValidImpactTypes: Actor
+		Delay: 8
+	Warhead@EffWater_5: CreateEffect
+		Explosions: water_piffs
+		ValidTargets: Water
+		ValidImpactTypes: Terrain
 		Delay: 8
 	Warhead@11Dam_6: SpreadDamage
 		Spread: 128
@@ -196,14 +273,27 @@ Vulcan:
 			Heavy: 20
 			Concrete: 20
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
-	Warhead@12Eff_6: CreateEffect
+	Warhead@EffDirectHit_6: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground, Ship, Trees
+		ValidImpactTypes: Actor
+		AffectsParent: true
+		ValidTargets: Ground, Water, Air, Trees
+		InvalidTargets: Underwater
 		Delay: 10
-	Warhead@12Eff_6Water: CreateEffect
+	Warhead@EffGround_6: CreateEffect
+		Explosions: piffs
+		ValidImpactTypes: Terrain
+		InvalidTargets: Water
+		Delay: 10
+	Warhead@EffSubmergedHit_6: CreateEffect
 		Explosions: water_piffs
-		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+		ValidTargets: Underwater
+		ValidImpactTypes: Actor
+		Delay: 10
+	Warhead@EffWater_6: CreateEffect
+		Explosions: water_piffs
+		ValidTargets: Water
+		ValidImpactTypes: Terrain
 		Delay: 10
 
 ChainGun:
@@ -242,9 +332,13 @@ Pistol:
 		Damage: 100
 		Versus:
 			None: 100
-	Warhead@2Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
 		Explosions: piff
-	Warhead@3EffWater: CreateEffect
+	Warhead@EffGround: CreateEffect
+		Explosions: piff
+	Warhead@EffSubmergedHit: CreateEffect
+		Explosions: water_piff
+	Warhead@EffWater: CreateEffect
 		Explosions: water_piff
 
 M1Carbine:
@@ -279,19 +373,39 @@ M60mg:
 		Damage: 15000
 		ValidTargets: Barrel, Infantry
 		DamageTypes: Prone50Percent, TriggerProne, DefaultDeath
+	Warhead@EffDirectHit: CreateEffect
+		Explosions: piff
+		ValidImpactTypes: Actor
+		AffectsParent: true
+		ValidTargets: Ground, Water, Air, Trees
+		InvalidTargets: Underwater
+	Warhead@EffGround: CreateEffect
+		Explosions: piff
+		ValidImpactTypes: Terrain
+		ValidTargets: Ground, Air
+		InvalidTargets: Water
+	Warhead@EffSubmergedHit: CreateEffect
+		Explosions: water_piff
+		ValidTargets: Underwater
+		ValidImpactTypes: Actor
+	Warhead@EffWater: CreateEffect
+		Explosions: water_piff
+		ValidTargets: Water
+		ValidImpactTypes: Terrain
 
 SilencedPPK:
 	Inherits: ^SnipeWeapon
 	Report: silppk.aud
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
-	Warhead@2Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground, Ship, Air, Trees
-	Warhead@3EffWater: CreateEffect
+	Warhead@EffGround: CreateEffect
+		Explosions: piffs
+	Warhead@EffSubmergedHit: CreateEffect
 		Explosions: water_piffs
-		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+	Warhead@EffWater: CreateEffect
+		Explosions: water_piffs
 
 Colt45:
 	Inherits: ^SnipeWeapon
@@ -299,13 +413,6 @@ Colt45:
 	Range: 7c0
 	Warhead@1Dam: SpreadDamage
 		Damage: 5000
-	Warhead@2Eff: CreateEffect
-		Explosions: piff
-		ValidTargets: Ground, Ship, Air, Trees
-	Warhead@3EffWater: CreateEffect
-		Explosions: water_piff
-		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
 
 Sniper:
 	Inherits: ^SnipeWeapon

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -50,7 +50,6 @@ Atomic:
 	Warhead@4Eff_impact: CreateEffect
 		Explosions: nuke
 		ImpactSounds: kaboom1.aud
-		ImpactActors: false
 		ValidTargets: Ground, Water, Air
 	Warhead@5Dam_areanuke1: SpreadDamage
 		Spread: 2c0
@@ -73,7 +72,6 @@ Atomic:
 	Warhead@8Eff_areanuke1: CreateEffect
 		ImpactSounds: kaboom22.aud
 		Delay: 5
-		ImpactActors: false
 	Warhead@9Dam_areanuke2: SpreadDamage
 		Spread: 3c0
 		Damage: 6000

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -20,15 +20,28 @@ ParaBomb:
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
 		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees
-	Warhead@3Eff: CreateEffect
+	Warhead@EffDirectHit: CreateEffect
 		Explosions: artillery_explosion
 		ImpactSounds: kaboom15.aud
-		ValidTargets: Ground, Ship, Trees
-	Warhead@4EffWater: CreateEffect
+		ValidImpactTypes: Actor
+		AffectsParent: true
+		ValidTargets: Ground, Air, Ship, Trees
+		InvalidTargets: Underwater
+	Warhead@EffSubmergedHit: CreateEffect
 		Explosions: small_splash
 		ImpactSounds: splash9.aud
-		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure
+		ValidTargets: Underwater
+		ValidImpactTypes: Actor
+	Warhead@EffGround: CreateEffect
+		Explosions: artillery_explosion
+		ImpactSounds: kaboom15.aud
+		ValidImpactTypes: Terrain
+		InvalidTargets: Water
+	Warhead@EffWater: CreateEffect
+		Explosions: small_splash
+		ImpactSounds: splash9.aud
+		ValidTargets: Water
+		ValidImpactTypes: Terrain
 
 Atomic:
 	ValidTargets: Ground, Trees, Water, Underwater, Air

--- a/mods/ts/weapons/missiles.yaml
+++ b/mods/ts/weapons/missiles.yaml
@@ -35,17 +35,23 @@
 			Heavy: 100
 			Concrete: 60
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
+	Warhead@EffActorHit: CreateEffect
+		Explosions: small_clsn
+		ExplosionPalette: effect-ignore-lighting-alpha75
+		ImpactSounds: expnew12.aud
+		ValidImpactTypes: Actor
 	Warhead@2Eff: CreateEffect
 		Explosions: small_clsn
 		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew12.aud
 		ValidTargets: Ground, Air
+		ValidImpactTypes: Terrain
 	Warhead@3EffWater: CreateEffect
 		Explosions: small_watersplash
 		ExplosionPalette: player
 		ImpactSounds: ssplash3.aud
 		ValidTargets: Water
-		InvalidTargets: Vehicle
+		ValidImpactTypes: Terrain
 	Warhead@Smu: LeaveSmudge
 		SmudgeType: SmallCrater
 		InvalidTargets: Vehicle, Building, Wall
@@ -85,11 +91,12 @@ MammothTusk:
 			Heavy: 35
 			Concrete: 28
 		DamageTypes: Explosion
-	Warhead@2Eff: CreateEffect
-		ImpactActors: false
+	Warhead@EffActorHit: CreateEffect
 		Explosions: medium_twlt
 		ImpactSounds: expnew07.aud
-	-Warhead@3EffWater:
+	Warhead@2Eff: CreateEffect
+		Explosions: medium_twlt
+		ImpactSounds: expnew07.aud
 
 BikeMissile:
 	Inherits: ^DefaultMissile
@@ -144,7 +151,9 @@ RedEye2:
 		Damage: 3300
 		ValidTargets: Air, Ground
 		DamageTypes: SmallExplosionDeath
+	Warhead@EffActorHit: CreateEffect
+		Explosions: large_grey_explosion
+		ImpactSounds: expnew13.aud
 	Warhead@2Eff: CreateEffect
 		Explosions: large_grey_explosion
 		ImpactSounds: expnew13.aud
-		ImpactActors: false

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -22,8 +22,10 @@ MultiCluster:
 			Heavy: 35
 			Concrete: 28
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+	Warhead@EffActorHit: CreateEffect
+		Explosions: large_twlt
+		ImpactSounds: expnew09.aud
 	Warhead@2Eff: CreateEffect
-		ImpactActors: false
 		Explosions: large_twlt
 		ImpactSounds: expnew09.aud
 	Warhead@ResourceDestruction: DestroyResource
@@ -46,8 +48,7 @@ ClusterMissile:
 		Explosions: large_twlt
 		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: expnew19.aud
-		ImpactActors: false
-		ValidTargets: Ground Water, Air
+		ValidTargets: Ground, Water, Air
 	Warhead@Cluster: FireCluster
 		Weapon: MultiCluster
 		RandomClusterCount: 10
@@ -89,27 +90,21 @@ IonCannon:
 		Explosions: ionbeam
 		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactSounds: ion1.aud
-		ImpactActors: false
 	Warhead@5Effect: CreateEffect
 		Explosions: ionbeam2
 		ExplosionPalette: effect-ignore-lighting-alpha75
-		ImpactActors: false
 	Warhead@6Effect: CreateEffect
 		Explosions: ionbeam3
 		ExplosionPalette: effect-ignore-lighting-alpha75
-		ImpactActors: false
 	Warhead@7Effect: CreateEffect
 		Explosions: ionbeam4
 		ExplosionPalette: effect-ignore-lighting-alpha75
-		ImpactActors: false
 	Warhead@8Effect: CreateEffect
 		Explosions: ionbeam5
 		ExplosionPalette: effect-ignore-lighting-alpha75
-		ImpactActors: false
 	Warhead@9Effect: CreateEffect
 		Explosions: ionbeam6
 		ExplosionPalette: effect-ignore-lighting-alpha75
-		ImpactActors: false
 
 EMPulseCannon:
 	ReloadDelay: 100
@@ -124,7 +119,6 @@ EMPulseCannon:
 	Warhead@1Eff: CreateEffect
 		Explosions: pulse_explosion
 		ExplosionPalette: effect-ignore-lighting-alpha75
-		ImpactActors: false
 	Warhead@emp: GrantExternalCondition
 		Range: 4c0
 		Duration: 250


### PR DESCRIPTION
This is basically https://github.com/OpenRA/OpenRA/pull/16312 done right, adressing its shortcomings and implementing some warhead generalizations discussed in that PR and on IRC.

#16312 can be removed from 'Future' milestone once this is merged.

Note1: I do plan to make `LeaveSmudgeWarhead` and `CreateResourceWarhead` `ValidImpactTypes`-aware in a follow-up, but I wanted to keep that out of this PR to keep possible distractions and delays to a minimum.
With this PR, those 2 warheads should just continue to work like on bleed, so there's no immediate pressure to adapt them here.

Note2: Turned the former testcase for RA into a fully-fledged refactor of the yaml setup, since there would have been a few regressions otherwise, afterall.