### PR TITLE
Prevent bogus attackmove on take-off.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -129,7 +129,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (aircraft.Info.CanHover && !skipHeightAdjustment && dat != aircraft.Info.CruiseAltitude)
 				{
 					if (dat <= aircraft.LandAltitude)
-						QueueChild(new TakeOff(self, target));
+						QueueChild(new TakeOff(self));
 					else
 						VerticalTakeOffOrLandTick(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);
 
@@ -140,7 +140,7 @@ namespace OpenRA.Mods.Common.Activities
 			}
 			else if (dat <= aircraft.LandAltitude)
 			{
-				QueueChild(new TakeOff(self, target));
+				QueueChild(new TakeOff(self));
 				return false;
 			}
 

--- a/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
+++ b/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
@@ -36,8 +36,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition).Length >= aircraft.Info.MinAirborneAltitude)
 				return;
 
-			// We are taking off, so remove reservation and influence in ground cells.
-			aircraft.UnReserve();
+			// We are taking off, so remove influence in ground cells.
 			aircraft.RemoveInfluence();
 
 			if (aircraft.Info.TakeoffSounds.Length > 0)

--- a/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
+++ b/OpenRA.Mods.Common/Activities/Air/TakeOff.cs
@@ -21,18 +21,12 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly Aircraft aircraft;
 		readonly IMove move;
-		Target fallbackTarget;
-		bool movedToTarget = false;
 
-		public TakeOff(Actor self, Target fallbackTarget)
+		public TakeOff(Actor self)
 		{
 			aircraft = self.Trait<Aircraft>();
 			move = self.Trait<IMove>();
-			this.fallbackTarget = fallbackTarget;
 		}
-
-		public TakeOff(Actor self)
-			: this(self, Target.Invalid) { }
 
 		protected override void OnFirstRun(Actor self)
 		{
@@ -73,24 +67,7 @@ namespace OpenRA.Mods.Common.Activities
 				return false;
 			}
 
-			// Only move to the fallback target if we don't have anything better to do
-			if (NextActivity == null && fallbackTarget.IsValidFor(self) && !movedToTarget)
-			{
-				QueueChild(new AttackMoveActivity(self, () => move.MoveToTarget(self, fallbackTarget, targetLineColor: Color.OrangeRed)));
-				movedToTarget = true;
-				return false;
-			}
-
 			return true;
-		}
-
-		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)
-		{
-			if (ChildActivity != null)
-				foreach (var n in ChildActivity.TargetLineNodes(self))
-					yield return n;
-			else
-				yield return new TargetLineNode(fallbackTarget, Color.OrangeRed);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -188,7 +188,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (wasRepaired || isHostInvalid || (!stayOnResupplier && aircraft.Info.TakeOffOnResupply))
 				{
 					if (rp != null)
-						QueueChild(move.MoveTo(rp.Location, repairableNear != null ? null : host.Actor));
+						QueueChild(move.MoveTo(rp.Location, repairableNear != null ? null : host.Actor, targetLineColor: Color.Green));
 					else
 						QueueChild(new TakeOff(self));
 

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -187,7 +187,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				if (wasRepaired || isHostInvalid || (!stayOnResupplier && aircraft.Info.TakeOffOnResupply))
 				{
-					if (rp != null)
+					if (self.CurrentActivity.NextActivity == null && rp != null)
 						QueueChild(move.MoveTo(rp.Location, repairableNear != null ? null : host.Actor, targetLineColor: Color.Green));
 					else
 						QueueChild(new TakeOff(self));

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -191,6 +191,8 @@ namespace OpenRA.Mods.Common.Activities
 						QueueChild(move.MoveTo(rp.Location, repairableNear != null ? null : host.Actor));
 					else
 						QueueChild(new TakeOff(self));
+
+					aircraft.UnReserve();
 				}
 
 				// Aircraft without TakeOffOnResupply remain on the resupplier until something else needs it

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -506,25 +506,15 @@ namespace OpenRA.Mods.Common.Traits
 			MayYieldReservation = true;
 		}
 
-		public void UnReserve(bool takeOff = false)
+		public void UnReserve()
 		{
 			if (reservation == null)
 				return;
-
-			// Move to the host's rally point if it has one
-			var rp = ReservedActor != null ? ReservedActor.TraitOrDefault<RallyPoint>() : null;
 
 			reservation.Dispose();
 			reservation = null;
 			ReservedActor = null;
 			MayYieldReservation = false;
-
-			if (takeOff && self.World.Map.DistanceAboveTerrain(CenterPosition).Length <= LandAltitude.Length)
-			{
-				self.QueueActivity(new TakeOff(self));
-				if (rp != null)
-					self.QueueActivity(new AttackMoveActivity(self, () => MoveTo(rp.Location, null, targetLineColor: Color.OrangeRed)));
-			}
 		}
 
 		bool AircraftCanEnter(Actor a, TargetModifiers modifiers)

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -521,10 +521,9 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (takeOff && self.World.Map.DistanceAboveTerrain(CenterPosition).Length <= LandAltitude.Length)
 			{
+				self.QueueActivity(new TakeOff(self));
 				if (rp != null)
-					self.QueueActivity(new TakeOff(self, Target.FromCell(self.World, rp.Location)));
-				else
-					self.QueueActivity(new TakeOff(self));
+					self.QueueActivity(new AttackMoveActivity(self, () => MoveTo(rp.Location, null, targetLineColor: Color.OrangeRed)));
 			}
 		}
 


### PR DESCRIPTION
It was reported in the forums that aircraft will attack-move when taking off after being force-landed. This PR fixes that issue while untangling some of the TakeOff/unreserve/rallypoint mess.

Fixes #17054.