### PR TITLE
Allow minefields to start and end on occupied cells.

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -185,13 +185,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					yield break;
 				}
 
-				var underCursor = world.ScreenMap.ActorsAtMouse(mi)
-					.Select(a => a.Actor)
-					.Where(a => !world.FogObscures(a))
-					.MaxByOrDefault(a => a.Info.HasTraitInfo<SelectableInfo>()
-						? a.Info.TraitInfo<SelectableInfo>().Priority : int.MinValue);
-
-				if (mi.Button == Game.Settings.Game.MouseButtonPreference.Action && underCursor == null)
+				if (mi.Button == Game.Settings.Game.MouseButtonPreference.Action)
 				{
 					minelayers.First().World.CancelInputMode();
 					foreach (var minelayer in minelayers)
@@ -252,7 +246,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				cursor = "ability";
 				IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
 
-				return !othersAtTarget.Any() && modifiers.HasModifier(TargetModifiers.ForceAttack);
+				return modifiers.HasModifier(TargetModifiers.ForceAttack);
 			}
 
 			public bool IsQueued { get; protected set; }


### PR DESCRIPTION
Fixes #15728
Fixes #14077
Fixes #3156

There is no reason for these checks to exist: The cells between them are most likely still valid and the blocking unit might be impermanent anyway. We also don't prevent the order when given on (permanent) blocking terrain either.

We can polish this further once #16408 is merged, so cells occupied by immovable actors are shown in red and removed from the selection (like we do with impassable terrain).