### PR TITLE
Clean up usage of CancelActivity.

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
+++ b/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
@@ -80,8 +80,6 @@ namespace OpenRA.Mods.Cnc.Traits
 			// Return to original location
 			if (--ReturnTicks == 0)
 			{
-				self.CancelActivity();
-
 				// The Move activity is not immediately cancelled, which, combined
 				// with Activity.Cancel discarding NextActivity without checking the
 				// IsInterruptable flag, means that a well timed order can cancel the
@@ -95,7 +93,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					typeof(Actor).GetProperty("CurrentActivity").SetValue(self, null);
 
 				// The actor is killed using Info.DamageTypes if the teleport fails
-				self.QueueActivity(new Teleport(chronosphere, Origin, null, true, killCargo, Info.ChronoshiftSound,
+				self.QueueActivity(false, new Teleport(chronosphere, Origin, null, true, killCargo, Info.ChronoshiftSound,
 					false, true, Info.DamageTypes));
 			}
 		}
@@ -144,8 +142,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			this.killCargo = killCargo;
 
 			// Set up the teleport
-			self.CancelActivity();
-			self.QueueActivity(new Teleport(chronosphere, targetLocation, null, killCargo, true, Info.ChronoshiftSound));
+			self.QueueActivity(false, new Teleport(chronosphere, targetLocation, null, killCargo, true, Info.ChronoshiftSound));
 
 			return true;
 		}

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForTransform.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForTransform.cs
@@ -61,8 +61,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (facing != null)
 				transform.Facing = facing.Facing;
 
-			self.CancelActivity();
-			self.QueueActivity(transform);
+			self.QueueActivity(false, transform);
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
@@ -114,10 +114,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (!CanInfiltrateTarget(self, order.Target))
 				return;
 
-			if (!order.Queued)
-				self.CancelActivity();
-
-			self.QueueActivity(new Infiltrate(self, order.Target, this));
+			self.QueueActivity(order.Queued, new Infiltrate(self, order.Target, this));
 			self.ShowTargetLines();
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -354,8 +354,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!ForceLanding && landNow.HasValue && landNow.Value && airborne && CanLand(self.Location)
 				&& !((self.CurrentActivity is Land) || self.CurrentActivity is Turn))
 			{
-				self.CancelActivity();
-				self.QueueActivity(new Land(self));
+				self.QueueActivity(false, new Land(self));
 				ForceLanding = true;
 			}
 
@@ -365,10 +364,7 @@ namespace OpenRA.Mods.Common.Traits
 				ForceLanding = false;
 
 				if (Info.IdleBehavior != IdleBehaviorType.Land)
-				{
-					self.CancelActivity();
-					self.QueueActivity(new TakeOff(self));
-				}
+					self.QueueActivity(false, new TakeOff(self));
 			}
 
 			var oldCachedFacing = cachedFacing;

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -69,9 +69,6 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (order.OrderString == "AttackMove" || order.OrderString == "AssaultMove")
 			{
-				if (!order.Queued)
-					self.CancelActivity();
-
 				var cell = self.World.Map.Clamp(self.World.Map.CellContaining(order.Target.CenterPosition));
 				if (!Info.MoveIntoShroud && !self.Owner.Shroud.IsExplored(cell))
 					return;
@@ -80,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 				var assaultMoving = order.OrderString == "AssaultMove";
 
 				// TODO: this should scale with unit selection group size.
-				self.QueueActivity(new AttackMoveActivity(self, () => move.MoveTo(targetLocation, 8, targetLineColor: Color.OrangeRed), assaultMoving));
+				self.QueueActivity(order.Queued, new AttackMoveActivity(self, () => move.MoveTo(targetLocation, 8, targetLineColor: Color.OrangeRed), assaultMoving));
 				self.ShowTargetLines();
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/Captures.cs
+++ b/OpenRA.Mods.Common/Traits/Captures.cs
@@ -95,10 +95,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (order.OrderString != "CaptureActor" || IsTraitDisabled)
 				return;
 
-			if (!order.Queued)
-				self.CancelActivity();
-
-			self.QueueActivity(new CaptureActor(self, order.Target));
+			self.QueueActivity(order.Queued, new CaptureActor(self, order.Target));
 			self.ShowTargetLines();
 		}
 

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -206,10 +206,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!order.Queued && !CanUnload())
 					return;
 
-				if (!order.Queued)
-					self.CancelActivity();
-
-				self.QueueActivity(new UnloadCargo(self, Info.LoadRange));
+				self.QueueActivity(order.Queued, new UnloadCargo(self, Info.LoadRange));
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -313,9 +313,6 @@ namespace OpenRA.Mods.Common.Traits
 				if (order.Target.Type != TargetType.Actor)
 					return;
 
-				if (!order.Queued)
-					self.CancelActivity();
-
 				self.QueueActivity(order.Queued, new PickupUnit(self, order.Target.Actor, Info.BeforeLoadDelay));
 				self.ShowTargetLines();
 			}

--- a/OpenRA.Mods.Common/Traits/DeliversCash.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversCash.cs
@@ -73,10 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (order.OrderString != "DeliverCash")
 				return;
 
-			if (!order.Queued)
-				self.CancelActivity();
-
-			self.QueueActivity(new DonateCash(self, order.Target, info.Payload, info.PlayerExperience));
+			self.QueueActivity(order.Queued, new DonateCash(self, order.Target, info.Payload, info.PlayerExperience));
 			self.ShowTargetLines();
 		}
 

--- a/OpenRA.Mods.Common/Traits/DeliversExperience.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversExperience.cs
@@ -84,10 +84,7 @@ namespace OpenRA.Mods.Common.Traits
 			else if (order.Target.Type != TargetType.FrozenActor)
 				return;
 
-			if (!order.Queued)
-				self.CancelActivity();
-
-			self.QueueActivity(new DonateExperience(self, order.Target, gainsExperience.Level, info.PlayerExperience));
+			self.QueueActivity(order.Queued, new DonateExperience(self, order.Target, gainsExperience.Level, info.PlayerExperience));
 			self.ShowTargetLines();
 		}
 

--- a/OpenRA.Mods.Common/Traits/Demolition.cs
+++ b/OpenRA.Mods.Common/Traits/Demolition.cs
@@ -83,10 +83,7 @@ namespace OpenRA.Mods.Common.Traits
 					return;
 			}
 
-			if (!order.Queued)
-				self.CancelActivity();
-
-			self.QueueActivity(new Demolish(self, order.Target, info.EnterBehaviour, info.DetonationDelay,
+			self.QueueActivity(order.Queued, new Demolish(self, order.Target, info.EnterBehaviour, info.DetonationDelay,
 				info.Flashes, info.FlashesDelay, info.FlashInterval));
 
 			self.ShowTargetLines();

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -92,10 +92,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (order.OrderString != "EngineerRepair" || !IsValidOrder(self, order))
 				return;
 
-			if (!order.Queued)
-				self.CancelActivity();
-
-			self.QueueActivity(new RepairBuilding(self, order.Target, Info));
+			self.QueueActivity(order.Queued, new RepairBuilding(self, order.Target, Info));
 			self.ShowTargetLines();
 		}
 

--- a/OpenRA.Mods.Common/Traits/EntersTunnels.cs
+++ b/OpenRA.Mods.Common/Traits/EntersTunnels.cs
@@ -82,10 +82,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (tunnel == null || !tunnel.Exit.HasValue)
 				return;
 
-			if (!order.Queued)
-				self.CancelActivity();
-
-			self.QueueActivity(move.MoveTo(tunnel.Entrance, tunnel.NearEnough, targetLineColor: Color.Green));
+			self.QueueActivity(order.Queued, move.MoveTo(tunnel.Entrance, tunnel.NearEnough, targetLineColor: Color.Green));
 			self.QueueActivity(move.MoveTo(tunnel.Exit.Value, tunnel.NearEnough, targetLineColor: Color.Green));
 			self.ShowTargetLines();
 		}

--- a/OpenRA.Mods.Common/Traits/Guard.cs
+++ b/OpenRA.Mods.Common/Traits/Guard.cs
@@ -47,14 +47,11 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void GuardTarget(Actor self, Target target, bool queued = false)
 		{
-			if (!queued)
-				self.CancelActivity();
-
 			if (target.Type != TargetType.Actor)
 				return;
 
 			var range = target.Actor.Info.TraitInfo<GuardableInfo>().Range;
-			self.QueueActivity(new AttackMoveActivity(self, () => move.MoveFollow(self, target, WDist.Zero, range, targetLineColor: Color.OrangeRed)));
+			self.QueueActivity(queued, new AttackMoveActivity(self, () => move.MoveFollow(self, target, WDist.Zero, range, targetLineColor: Color.OrangeRed)));
 			self.ShowTargetLines();
 		}
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -325,8 +325,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (moveTo.HasValue)
 			{
-				self.CancelActivity();
-				self.QueueActivity(new Move(self, moveTo.Value, WDist.Zero));
+				self.QueueActivity(false, new Move(self, moveTo.Value, WDist.Zero));
 				self.ShowTargetLines();
 
 				Log.Write("debug", "OnNudge #{0} from {1} to {2}",
@@ -342,8 +341,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (cellInfo != null)
 				{
-					self.CancelActivity();
-					self.QueueActivity(new CallFunc(() => self.NotifyBlocker(cellInfo.Cell)));
+					self.QueueActivity(false, new CallFunc(() => self.NotifyBlocker(cellInfo.Cell)));
 					self.QueueActivity(new WaitFor(() => CanEnterCell(cellInfo.Cell)));
 					self.QueueActivity(new Move(self, cellInfo.Cell));
 
@@ -850,9 +848,6 @@ namespace OpenRA.Mods.Common.Traits
 				var cell = self.World.Map.Clamp(this.self.World.Map.CellContaining(order.Target.CenterPosition));
 				if (!Info.LocomotorInfo.MoveIntoShroud && !self.Owner.Shroud.IsExplored(cell))
 					return;
-
-				if (!order.Queued)
-					self.CancelActivity();
 
 				self.QueueActivity(order.Queued, WrapMove(new Move(self, cell, WDist.FromCells(8), null, true, Color.Green)));
 				self.ShowTargetLines();

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -159,10 +159,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!IsCorrectCargoType(targetActor))
 				return;
 
-			if (!order.Queued)
-				self.CancelActivity();
-
-			self.QueueActivity(new RideTransport(self, order.Target));
+			self.QueueActivity(order.Queued, new RideTransport(self, order.Target));
 			self.ShowTargetLines();
 		}
 

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -99,10 +99,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!CanRepairAt(order.Target.Actor) || !ShouldRepair())
 				return;
 
-			if (!order.Queued)
-				self.CancelActivity();
-
-			self.QueueActivity(new Resupply(self, order.Target.Actor, Info.CloseEnough));
+			self.QueueActivity(order.Queued, new Resupply(self, order.Target.Actor, Info.CloseEnough));
 			self.ShowTargetLines();
 		}
 

--- a/OpenRA.Mods.Common/Traits/RepairsBridges.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsBridges.cs
@@ -102,10 +102,7 @@ namespace OpenRA.Mods.Common.Traits
 				else
 					return;
 
-				if (!order.Queued)
-					self.CancelActivity();
-
-				self.QueueActivity(new RepairBridge(self, order.Target, info.EnterBehaviour, info.RepairNotification));
+				self.QueueActivity(order.Queued, new RepairBridge(self, order.Target, info.EnterBehaviour, info.RepairNotification));
 				self.ShowTargetLines();
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/TransformCrusherOnCrush.cs
+++ b/OpenRA.Mods.Common/Traits/TransformCrusherOnCrush.cs
@@ -53,8 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 				transform.Facing = facing.Facing;
 
 			transform.SkipMakeAnims = info.SkipMakeAnims;
-			crusher.CancelActivity();
-			crusher.QueueActivity(transform);
+			crusher.QueueActivity(false, transform);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/TransformOnCapture.cs
+++ b/OpenRA.Mods.Common/Traits/TransformOnCapture.cs
@@ -52,8 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 			var transform = new Transform(self, info.IntoActor) { ForceHealthPercentage = info.ForceHealthPercentage, Faction = faction };
 			if (facing != null) transform.Facing = facing.Facing;
 			transform.SkipMakeAnims = info.SkipMakeAnims;
-			self.CancelActivity();
-			self.QueueActivity(transform);
+			self.QueueActivity(false, transform);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
@@ -160,8 +160,7 @@ namespace OpenRA.Mods.Common.Traits
 					drop.SetLZ(p, true);
 					plane.Trait<Cargo>().Load(plane, crate);
 
-					plane.CancelActivity();
-					plane.QueueActivity(new Fly(plane, Target.FromPos(finishEdge)));
+					plane.QueueActivity(false, new Fly(plane, Target.FromPos(finishEdge)));
 					plane.QueueActivity(new RemoveSelf());
 				}
 				else

--- a/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
+++ b/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
@@ -67,8 +67,7 @@ namespace OpenRA.Mods.D2k.Traits
 			if (!target.IsInRange(self.CenterPosition, a.MaxRange()))
 				return;
 
-			self.CancelActivity();
-			self.QueueActivity(new SwallowActor(self, target, a, facing));
+			self.QueueActivity(false, new SwallowActor(self, target, a, facing));
 		}
 
 		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)


### PR DESCRIPTION
This is a simple clean-up PR to remove unnecessary manual cancelling of the activity queue when that can be handled by `QueueActivity` instead.