### PR TITLE
Allow queued structure rallypoints.

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/LayMines.cs
+++ b/OpenRA.Mods.Cnc/Activities/LayMines.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Cnc.Activities
 
 					// Add a CloseEnough range of 512 to the Rearm/Repair activities in order to ensure that we're at the host actor
 					QueueChild(new MoveAdjacentTo(self, Target.FromActor(rearmTarget)));
-					QueueChild(movement.MoveTo(self.World.Map.CellContaining(rearmTarget.CenterPosition), rearmTarget));
+					QueueChild(movement.MoveTo(self.World.Map.CellContaining(rearmTarget.CenterPosition), ignoreActor: rearmTarget));
 					QueueChild(new Resupply(self, rearmTarget, new WDist(512)));
 					returnToBase = true;
 					return false;

--- a/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
@@ -118,7 +118,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					self.QueueActivity(move.MoveWithinRange(order.Target, WDist.FromCells(maxDistance.Value), targetLineColor: Color.LawnGreen));
 
 				self.QueueActivity(new Teleport(self, cell, maxDistance, Info.KillCargo, Info.FlashScreen, Info.ChronoshiftSound));
-				self.QueueActivity(move.MoveTo(cell, 5, Color.LawnGreen));
+				self.QueueActivity(move.MoveTo(cell, 5, targetLineColor: Color.LawnGreen));
 				self.ShowTargetLines();
 			}
 		}

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -183,8 +183,8 @@ namespace OpenRA.Mods.Cnc.Traits
 			self.World.UpdateMaps(self, this);
 		}
 
-		public Activity MoveTo(CPos cell, int nearEnough, Color? targetLineColor = null) { return null; }
-		public Activity MoveTo(CPos cell, Actor ignoreActor, Color? targetLineColor = null) { return null; }
+		public Activity MoveTo(CPos cell, int nearEnough = 0, Actor ignoreActor = null,
+			bool evaluateNearestMovableCell = false, Color? targetLineColor = null) { return null; }
 		public Activity MoveWithinRange(Target target, WDist range,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null) { return null; }
 		public Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange,

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Common.Activities
 				// HACK: Repairable needs the actor to move to host center.
 				// TODO: Get rid of this or at least replace it with something less hacky.
 				if (repairableNear == null)
-					QueueChild(move.MoveTo(targetCell, host.Actor));
+					QueueChild(move.MoveTo(targetCell, ignoreActor: host.Actor));
 
 				var delta = (self.CenterPosition - host.CenterPosition).LengthSquared;
 				var transport = transportCallers.FirstOrDefault(t => t.MinimumDistance.LengthSquared < delta);
@@ -188,7 +188,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (wasRepaired || isHostInvalid || (!stayOnResupplier && aircraft.Info.TakeOffOnResupply))
 				{
 					if (self.CurrentActivity.NextActivity == null && rp != null)
-						QueueChild(move.MoveTo(rp.Location, repairableNear != null ? null : host.Actor, targetLineColor: Color.Green));
+						QueueChild(move.MoveTo(rp.Location, ignoreActor: repairableNear != null ? null : host.Actor, targetLineColor: Color.Green));
 					else
 						QueueChild(new TakeOff(self));
 
@@ -208,7 +208,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (self.CurrentActivity.NextActivity == null)
 				{
 					if (rp != null)
-						QueueChild(move.MoveTo(rp.Location, repairableNear != null ? null : host.Actor));
+						QueueChild(move.MoveTo(rp.Location, ignoreActor: repairableNear != null ? null : host.Actor));
 					else if (repairableNear == null)
 						QueueChild(move.MoveToTarget(self, host));
 				}

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -188,7 +188,8 @@ namespace OpenRA.Mods.Common.Activities
 				if (wasRepaired || isHostInvalid || (!stayOnResupplier && aircraft.Info.TakeOffOnResupply))
 				{
 					if (self.CurrentActivity.NextActivity == null && rp != null)
-						QueueChild(move.MoveTo(rp.Location, ignoreActor: repairableNear != null ? null : host.Actor, targetLineColor: Color.Green));
+						foreach (var cell in rp.Path)
+							QueueChild(move.MoveTo(cell, 1, ignoreActor: repairableNear != null ? null : host.Actor, targetLineColor: Color.Green));
 					else
 						QueueChild(new TakeOff(self));
 
@@ -208,7 +209,8 @@ namespace OpenRA.Mods.Common.Activities
 				if (self.CurrentActivity.NextActivity == null)
 				{
 					if (rp != null)
-						QueueChild(move.MoveTo(rp.Location, ignoreActor: repairableNear != null ? null : host.Actor));
+						foreach (var cell in rp.Path)
+							QueueChild(move.MoveTo(cell, 1, repairableNear != null ? null : host.Actor, true));
 					else if (repairableNear == null)
 						QueueChild(move.MoveToTarget(self, host));
 				}

--- a/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
@@ -79,8 +79,8 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Query or set a factory's rally point.")]
 		public CPos RallyPoint
 		{
-			get { return rp.Location; }
-			set { rp.Location = value; }
+			get { return rp.Path.Last(); }
+			set { rp.Path = new List<CPos> { value }; }
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -813,14 +813,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		#region Implement IMove
 
-		public Activity MoveTo(CPos cell, int nearEnough, Color? targetLineColor = null)
+		public Activity MoveTo(CPos cell, int nearEnough = 0, Actor ignoreActor = null,
+			bool evaluateNearestMovableCell = false, Color? targetLineColor = null)
 		{
 			return new Fly(self, Target.FromCell(self.World, cell), WDist.FromCells(nearEnough), targetLineColor: targetLineColor);
-		}
-
-		public Activity MoveTo(CPos cell, Actor ignoreActor, Color? targetLineColor = null)
-		{
-			return new Fly(self, Target.FromCell(self.World, cell), targetLineColor: targetLineColor);
 		}
 
 		public Activity MoveWithinRange(Target target, WDist range,

--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -219,7 +219,7 @@ namespace OpenRA.Mods.Common.Traits
 			foreach (var rp in world.ActorsWithTrait<RallyPoint>())
 			{
 				if (rp.Actor.Owner == player &&
-					!IsRallyPointValid(rp.Trait.Location, rp.Actor.Info.TraitInfoOrDefault<BuildingInfo>()))
+					!IsRallyPointValid(rp.Trait.Path[0], rp.Actor.Info.TraitInfoOrDefault<BuildingInfo>()))
 				{
 					bot.QueueOrder(new Order("SetRallyPoint", rp.Actor, Target.FromCell(world, ChooseRallyLocationNear(rp.Actor)), false)
 					{

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -48,23 +48,22 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		const string OrderID = "SetRallyPoint";
 
-		[Sync]
-		public CPos Location;
+		public List<CPos> Path;
 
 		public RallyPointInfo Info;
 		public string PaletteName { get; private set; }
 
 		const uint ForceSet = 1;
 
-		public void ResetLocation(Actor self)
+		public void ResetPath(Actor self)
 		{
-			Location = self.Location + Info.Offset;
+			Path = new List<CPos> { self.Location + Info.Offset };
 		}
 
 		public RallyPoint(Actor self, RallyPointInfo info)
 		{
 			Info = info;
-			ResetLocation(self);
+			ResetPath(self);
 			PaletteName = info.IsPlayerPalette ? info.Palette + self.Owner.InternalName : info.Palette;
 		}
 
@@ -78,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (Info.IsPlayerPalette)
 				PaletteName = Info.Palette + newOwner.InternalName;
 
-			ResetLocation(self);
+			ResetPath(self);
 		}
 
 		public IEnumerable<IOrderTargeter> Orders
@@ -90,7 +89,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (order.OrderID == OrderID)
 			{
-				return new Order(order.OrderID, self, target, false)
+				return new Order(order.OrderID, self, target, queued)
 				{
 					SuppressVisualFeedback = true,
 					ExtraData = ((RallyPointOrderTargeter)order).ForceSet ? ForceSet : 0
@@ -102,8 +101,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void ResolveOrder(Actor self, Order order)
 		{
-			if (order.OrderString == OrderID)
-				Location = self.World.Map.CellContaining(order.Target.CenterPosition);
+			if (order.OrderString != OrderID)
+				return;
+
+			if (!order.Queued)
+				Path.Clear();
+
+			Path.Add(self.World.Map.CellContaining(order.Target.CenterPosition));
 		}
 
 		public static bool IsForceSet(Order order)
@@ -124,11 +128,14 @@ namespace OpenRA.Mods.Common.Traits
 			public int OrderPriority { get { return 0; } }
 			public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
 			public bool ForceSet { get; private set; }
+			public bool IsQueued { get; protected set; }
 
 			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 			{
 				if (target.Type != TargetType.Terrain)
 					return false;
+
+				IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
 
 				var location = self.World.Map.CellContaining(target.CenterPosition);
 				if (self.World.Map.Contains(location))
@@ -148,8 +155,6 @@ namespace OpenRA.Mods.Common.Traits
 
 				return false;
 			}
-
-			public bool IsQueued { get { return false; } } // unused
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Reservable.cs
@@ -85,7 +85,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (reservedForAircraft.GetActorBelow() == self)
 				{
 					if (rallyPoint != null)
-						reservedFor.QueueActivity(reservedForAircraft.MoveTo(rallyPoint.Location, null, targetLineColor: Color.Green));
+						foreach (var cell in rallyPoint.Path)
+							reservedFor.QueueActivity(reservedForAircraft.MoveTo(cell, 1, targetLineColor: Color.Green));
 					else
 						reservedFor.QueueActivity(new TakeOff(reservedFor));
 				}

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -579,14 +579,10 @@ namespace OpenRA.Mods.Common.Traits
 			return inner;
 		}
 
-		public Activity MoveTo(CPos cell, int nearEnough, Color? targetLineColor = null)
+		public Activity MoveTo(CPos cell, int nearEnough = 0, Actor ignoreActor = null,
+			bool evaluateNearestMovableCell = false, Color? targetLineColor = null)
 		{
-			return WrapMove(new Move(self, cell, WDist.FromCells(nearEnough), targetLineColor: targetLineColor));
-		}
-
-		public Activity MoveTo(CPos cell, Actor ignoreActor, Color? targetLineColor = null)
-		{
-			return WrapMove(new Move(self, cell, WDist.Zero, ignoreActor, targetLineColor: targetLineColor));
+			return WrapMove(new Move(self, cell, WDist.FromCells(nearEnough), ignoreActor, evaluateNearestMovableCell, targetLineColor));
 		}
 
 		public Activity MoveWithinRange(Target target, WDist range,

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -42,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 		public virtual void DoProduction(Actor self, ActorInfo producee, ExitInfo exitinfo, string productionType, TypeDictionary inits)
 		{
 			var exit = CPos.Zero;
-			var exitLocation = CPos.Zero;
+			var exitLocations = new List<CPos>();
 
 			// Clone the initializer dictionary for the new actor
 			var td = new TypeDictionary();
@@ -68,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 						initialFacing = delta.Yaw.Facing;
 				}
 
-				exitLocation = rp.Value != null ? rp.Value.Location : exit;
+				exitLocations = rp.Value != null ? rp.Value.Path : new List<CPos> { exit };
 
 				td.Add(new LocationInit(exit));
 				td.Add(new CenterPositionInit(spawn));
@@ -83,7 +84,8 @@ namespace OpenRA.Mods.Common.Traits
 
 				var move = newUnit.TraitOrDefault<IMove>();
 				if (exitinfo != null && move != null)
-					newUnit.QueueActivity(new AttackMoveActivity(newUnit, () => move.MoveTo(exitLocation, 1, targetLineColor: Color.OrangeRed)));
+					foreach (var cell in exitLocations)
+						newUnit.QueueActivity(new AttackMoveActivity(newUnit, () => move.MoveTo(cell, 1, evaluateNearestMovableCell: true, targetLineColor: Color.OrangeRed)));
 
 				if (!self.IsDead)
 					foreach (var t in self.TraitsImplementing<INotifyProduction>())

--- a/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
@@ -9,8 +9,8 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Primitives;
-using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 			var aircraftInfo = producee.TraitInfoOrDefault<AircraftInfo>();
 			var mobileInfo = producee.TraitInfoOrDefault<MobileInfo>();
 
-			var destination = rp != null ? rp.Location : self.Location;
+			var destinations = rp != null ? rp.Path : new List<CPos> { self.Location };
 
 			var location = spawnLocation;
 			if (!location.HasValue)
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					var locomotorInfo = mobileInfo.LocomotorInfo;
 					location = self.World.Map.ChooseClosestMatchingEdgeCell(self.Location,
-						c => mobileInfo.CanEnterCell(self.World, null, c) && domainIndex.IsPassable(c, destination, locomotorInfo));
+						c => mobileInfo.CanEnterCell(self.World, null, c) && domainIndex.IsPassable(c, destinations[0], locomotorInfo));
 				}
 			}
 
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (aircraftInfo != null)
 				pos += new WVec(0, 0, aircraftInfo.CruiseAltitude.Length);
 
-			var initialFacing = self.World.Map.FacingBetween(location.Value, destination, 0);
+			var initialFacing = self.World.Map.FacingBetween(location.Value, destinations[0], 0);
 
 			self.World.AddFrameEndTask(w =>
 			{
@@ -91,11 +91,12 @@ namespace OpenRA.Mods.Common.Traits
 
 				var move = newUnit.TraitOrDefault<IMove>();
 				if (move != null)
-					newUnit.QueueActivity(move.MoveTo(destination, 2));
+					foreach (var cell in destinations)
+						newUnit.QueueActivity(move.MoveTo(cell, 2, evaluateNearestMovableCell: true));
 
 				if (!self.IsDead)
 					foreach (var t in self.TraitsImplementing<INotifyProduction>())
-						t.UnitProduced(self, newUnit, destination);
+						t.UnitProduced(self, newUnit, destinations[0]);
 
 				var notifyOthers = self.World.ActorsWithTrait<INotifyOtherProduction>();
 				foreach (var notify in notifyOthers)

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Primitives;
@@ -102,7 +103,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override void DoProduction(Actor self, ActorInfo producee, ExitInfo exitinfo, string productionType, TypeDictionary inits)
 		{
 			var exit = CPos.Zero;
-			var exitLocation = CPos.Zero;
+			var exitLocations = new List<CPos>();
 
 			var info = (ProductionParadropInfo)Info;
 			var actorType = info.ActorType;
@@ -122,7 +123,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				var initialFacing = exitinfo.Facing < 0 ? (to - spawn).Yaw.Facing : exitinfo.Facing;
 
-				exitLocation = rp.Value != null ? rp.Value.Location : exit;
+				exitLocations = rp.Value != null ? rp.Value.Path : new List<CPos> { exit };
 
 				td.Add(new LocationInit(exit));
 				td.Add(new CenterPositionInit(spawn));
@@ -137,7 +138,8 @@ namespace OpenRA.Mods.Common.Traits
 
 				var move = newUnit.TraitOrDefault<IMove>();
 				if (move != null)
-					newUnit.QueueActivity(new AttackMoveActivity(newUnit, () => move.MoveTo(exitLocation, 1, targetLineColor: Color.OrangeRed)));
+					foreach (var cell in exitLocations)
+						newUnit.QueueActivity(new AttackMoveActivity(newUnit, () => move.MoveTo(cell, 1, evaluateNearestMovableCell: true, targetLineColor: Color.OrangeRed)));
 
 				if (!self.IsDead)
 					foreach (var t in self.TraitsImplementing<INotifyProduction>())

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -425,8 +425,8 @@ namespace OpenRA.Mods.Common.Traits
 
 	public interface IMove
 	{
-		Activity MoveTo(CPos cell, int nearEnough, Color? targetLineColor = null);
-		Activity MoveTo(CPos cell, Actor ignoreActor, Color? targetLineColor = null);
+		Activity MoveTo(CPos cell, int nearEnough = 0, Actor ignoreActor = null,
+		 	bool evaluateNearestMovableCell = false, Color? targetLineColor = null);
 		Activity MoveWithinRange(Target target, WDist range,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null);
 		Activity MoveWithinRange(Target target, WDist minRange, WDist maxRange,


### PR DESCRIPTION
Fixes #15371.
Fixes  #15995.

This adds a way to make units exiting a structure use a specific route to the rallypoint. This can be done by holding shift when ordering the rally point in the same manner as queueing unit orders.