### PR TITLE
Added 'Symbols' option to the 'Fonts' Issue #15958

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ChatDisplayWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ChatDisplayWidget.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Widgets
 				var textSize = font.Measure(text).Y;
 				var offset = font.TopOffset;
 
-				if (chatPos.Y < pos.Y)
+				if (chatPos.Y - font.TopOffset < pos.Y)
 					break;
 
 				var textLineHeight = lineHeight;

--- a/OpenRA.Mods.Common/Widgets/ChatDisplayWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ChatDisplayWidget.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Widgets
 				var textSize = font.Measure(text).Y;
 				var offset = font.TopOffset;
 
-				if (chatPos.Y - font.TopOffset < pos.Y)
+				if (chatPos.Y < pos.Y)
 					break;
 
 				var textLineHeight = lineHeight;

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -197,6 +197,10 @@ Fonts:
 		Font: common|FreeSansBold.ttf
 		Size: 32
 		Ascender: 24
+	Symbols:
+		Font: common|FreeSans.ttf
+		Size: 14
+		Ascender: 11
 
 Missions:
 	./mods/cnc/missions.yaml

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -184,6 +184,10 @@ Fonts:
 		Font: d2k|Dune2k.ttf
 		Size: 32
 		Ascender: 23
+	Symbols:
+		Font: common|FreeSans.ttf
+		Size: 14
+		Ascender: 11
 
 Missions:
 	d2k|missions.yaml

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -200,6 +200,10 @@ Fonts:
 		Font: ra|ZoodRangmah.ttf
 		Size: 48
 		Ascender: 26
+	Symbols:
+		Font: common|FreeSans.ttf
+		Size: 14
+		Ascender: 11
 
 Missions:
 	ra|missions.yaml

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -242,6 +242,10 @@ Fonts:
 		Font: common|FreeSansBold.ttf
 		Size: 32
 		Ascender: 24
+	Symbols:
+		Font: common|FreeSans.ttf
+		Size: 14
+		Ascender: 11
 
 SupportsMapsFrom: ts
 


### PR DESCRIPTION
Fixes #15958

When adding `InfiniteBuildLimit` to the `player.yaml` after that limit is hit, an infinity symbols is displayed in the corner of the building. The problem when you go over this limit is that the `Symbols` font was not defined. My fix is adding the `Symbols` font to a `mod.yaml` file or an alternate fix would be changing the font in `ProductionPaletteWidget` line 152 to "Regular".