### PR TITLE
#17018 Gets rid of cutoff line in chat window

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ChatDisplayWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ChatDisplayWidget.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Widgets
 				var textSize = font.Measure(text).Y;
 				var offset = font.TopOffset;
 
-				if (chatPos.Y < pos.Y)
+				if (chatPos.Y - font.TopOffset < pos.Y)
 					break;
 
 				var textLineHeight = lineHeight;


### PR DESCRIPTION
Fixes #17018 

The fix involves taking away the offset of a `SpriteFont` object to basically cut off the top part of the chat window so that lower hanging letters like 'y' are considered outside of the chat window.