### PR TITLE
Port debug overlays to IRenderAboveShroud

### DIFF
--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -92,6 +92,7 @@ namespace OpenRA
 		public bool FogObscures(CPos p) { return RenderPlayer != null && !RenderPlayer.Shroud.IsVisible(p); }
 		public bool FogObscures(WPos pos) { return RenderPlayer != null && !RenderPlayer.Shroud.IsVisible(pos); }
 		public bool ShroudObscures(CPos p) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(p); }
+		public bool ShroudObscures(MPos uv) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(uv); }
 		public bool ShroudObscures(WPos pos) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(pos); }
 		public bool ShroudObscures(PPos uv) { return RenderPlayer != null && !RenderPlayer.Shroud.IsExplored(uv); }
 

--- a/OpenRA.Mods.Common/Graphics/CircleAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/CircleAnnotationRenderable.cs
@@ -1,0 +1,75 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Graphics;
+using OpenRA.Primitives;
+
+namespace OpenRA.Mods.Common.Graphics
+{
+	public struct CircleAnnotationRenderable : IRenderable, IFinalizedRenderable
+	{
+		const int CircleSegments = 32;
+		static readonly WVec[] FacingOffsets = Exts.MakeArray(CircleSegments, i => new WVec(1024, 0, 0).Rotate(WRot.FromFacing(i * 256 / CircleSegments)));
+
+		readonly WPos centerPosition;
+		readonly WDist radius;
+		readonly int width;
+		readonly Color color;
+		readonly bool filled;
+
+		public CircleAnnotationRenderable(WPos centerPosition, WDist radius, int width, Color color, bool filled = false)
+		{
+			this.centerPosition = centerPosition;
+			this.radius = radius;
+			this.width = width;
+			this.color = color;
+			this.filled = filled;
+		}
+
+		public WPos Pos { get { return centerPosition; } }
+		public PaletteReference Palette { get { return null; } }
+		public int ZOffset { get { return 0; } }
+		public bool IsDecoration { get { return true; } }
+
+		public IRenderable WithPalette(PaletteReference newPalette) { return new CircleAnnotationRenderable(centerPosition, radius, width, color, filled); }
+		public IRenderable WithZOffset(int newOffset) { return new CircleAnnotationRenderable(centerPosition, radius, width, color, filled); }
+		public IRenderable OffsetBy(WVec vec) { return new CircleAnnotationRenderable(centerPosition + vec, radius, width, color, filled); }
+		public IRenderable AsDecoration() { return this; }
+
+		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
+		public void Render(WorldRenderer wr)
+		{
+			var wcr = Game.Renderer.WorldRgbaColorRenderer;
+			if (filled)
+			{
+				var offset = new WVec(radius.Length, radius.Length, 0);
+				var tl = wr.Screen3DPosition(centerPosition - offset);
+				var br = wr.Screen3DPosition(centerPosition + offset);
+
+				wcr.FillEllipse(tl, br, color);
+			}
+			else
+			{
+				var r = radius.Length;
+				var a = wr.Screen3DPosition(centerPosition + r * FacingOffsets[CircleSegments - 1] / 1024);
+				for (var i = 0; i < CircleSegments; i++)
+				{
+					var b = wr.Screen3DPosition(centerPosition + r * FacingOffsets[i] / 1024);
+					wcr.DrawLine(a, b, width / wr.Viewport.Zoom, color);
+					a = b;
+				}
+			}
+		}
+
+		public void RenderDebugGeometry(WorldRenderer wr) { }
+		public Rectangle ScreenBounds(WorldRenderer wr) { return Rectangle.Empty; }
+	}
+}

--- a/OpenRA.Mods.Common/Graphics/LineAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/LineAnnotationRenderable.cs
@@ -1,0 +1,61 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Graphics;
+using OpenRA.Primitives;
+
+namespace OpenRA.Mods.Common.Graphics
+{
+	public struct LineAnnotationRenderable : IRenderable, IFinalizedRenderable
+	{
+		readonly WPos start;
+		readonly WPos end;
+		readonly float width;
+		readonly Color startColor;
+		readonly Color endColor;
+
+		public LineAnnotationRenderable(WPos start, WPos end, float width, Color color)
+		{
+			this.start = start;
+			this.end = end;
+			this.width = width;
+			startColor = endColor = color;
+		}
+
+		public LineAnnotationRenderable(WPos start, WPos end, float width, Color startColor, Color endColor)
+		{
+			this.start = start;
+			this.end = end;
+			this.width = width;
+			this.startColor = startColor;
+			this.endColor = endColor;
+		}
+
+		public WPos Pos { get { return start; } }
+		public PaletteReference Palette { get { return null; } }
+		public int ZOffset { get { return 0; } }
+		public bool IsDecoration { get { return true; } }
+
+		public IRenderable WithPalette(PaletteReference newPalette) { return new LineAnnotationRenderable(start, end, width, startColor, endColor); }
+		public IRenderable WithZOffset(int newOffset) { return new LineAnnotationRenderable(start, end, width, startColor, endColor); }
+		public IRenderable OffsetBy(WVec vec) { return new LineAnnotationRenderable(start + vec, end + vec, width, startColor, endColor); }
+		public IRenderable AsDecoration() { return this; }
+
+		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
+		public void Render(WorldRenderer wr)
+		{
+			Game.Renderer.WorldRgbaColorRenderer.DrawLine(wr.Screen3DPosition(start), wr.Screen3DPosition(end), width / wr.Viewport.Zoom, startColor, endColor);
+		}
+
+		public void RenderDebugGeometry(WorldRenderer wr) { }
+		public Rectangle ScreenBounds(WorldRenderer wr) { return Rectangle.Empty; }
+	}
+}

--- a/OpenRA.Mods.Common/Graphics/PolygonAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/PolygonAnnotationRenderable.cs
@@ -1,0 +1,53 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Primitives;
+
+namespace OpenRA.Mods.Common.Graphics
+{
+	public struct PolygonAnnotationRenderable : IRenderable, IFinalizedRenderable
+	{
+		readonly WPos[] vertices;
+		readonly WPos effectivePos;
+		readonly int width;
+		readonly Color color;
+
+		public PolygonAnnotationRenderable(WPos[] vertices, WPos effectivePos, int width, Color color)
+		{
+			this.vertices = vertices;
+			this.effectivePos = effectivePos;
+			this.width = width;
+			this.color = color;
+		}
+
+		public WPos Pos { get { return effectivePos; } }
+		public PaletteReference Palette { get { return null; } }
+		public int ZOffset { get { return 0; } }
+		public bool IsDecoration { get { return true; } }
+
+		public IRenderable WithPalette(PaletteReference newPalette) { return new PolygonAnnotationRenderable(vertices, effectivePos, width, color); }
+		public IRenderable WithZOffset(int newOffset) { return new PolygonAnnotationRenderable(vertices, effectivePos, width, color); }
+		public IRenderable OffsetBy(WVec vec) { return new PolygonAnnotationRenderable(vertices.Select(v => v + vec).ToArray(), effectivePos + vec, width, color); }
+		public IRenderable AsDecoration() { return this; }
+
+		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
+		public void Render(WorldRenderer wr)
+		{
+			var verts = vertices.Select(wr.Screen3DPosition).ToArray();
+			Game.Renderer.WorldRgbaColorRenderer.DrawPolygon(verts, width / wr.Viewport.Zoom, color);
+		}
+
+		public void RenderDebugGeometry(WorldRenderer wr) { }
+		public Rectangle ScreenBounds(WorldRenderer wr) { return Rectangle.Empty; }
+	}
+}

--- a/OpenRA.Mods.Common/HitShapes/Capsule.cs
+++ b/OpenRA.Mods.Common/HitShapes/Capsule.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Primitives;
@@ -93,7 +94,7 @@ namespace OpenRA.Mods.Common.HitShapes
 			return DistanceFromEdge((pos - new WPos(actorPos.X, actorPos.Y, pos.Z)).Rotate(-actor.Orientation));
 		}
 
-		public void DrawCombatOverlay(WorldRenderer wr, RgbaColorRenderer wcr, Actor actor)
+		IEnumerable<IRenderable> IHitShape.RenderDebugOverlay(WorldRenderer wr, Actor actor)
 		{
 			var actorPos = actor.CenterPosition;
 
@@ -107,18 +108,15 @@ namespace OpenRA.Mods.Common.HitShapes
 			var offset2 = new WVec(aa.Y - bb.Y, bb.X - aa.X, 0);
 			offset2 = offset2 * Radius.Length / offset2.Length;
 
-			var c = Color.Yellow;
-			RangeCircleRenderable.DrawRangeCircle(wr, a, Radius, 1, c, 0, c);
-			RangeCircleRenderable.DrawRangeCircle(wr, b, Radius, 1, c, 0, c);
-			wcr.DrawLine(new[] { wr.Screen3DPosition(a - offset1), wr.Screen3DPosition(b - offset1) }, 1, c);
-			wcr.DrawLine(new[] { wr.Screen3DPosition(a + offset1), wr.Screen3DPosition(b + offset1) }, 1, c);
-
-			RangeCircleRenderable.DrawRangeCircle(wr, aa, Radius, 1, c, 0, c);
-			RangeCircleRenderable.DrawRangeCircle(wr, bb, Radius, 1, c, 0, c);
-			wcr.DrawLine(new[] { wr.Screen3DPosition(aa - offset2), wr.Screen3DPosition(bb - offset2) }, 1, c);
-			wcr.DrawLine(new[] { wr.Screen3DPosition(aa + offset2), wr.Screen3DPosition(bb + offset2) }, 1, c);
-
-			RangeCircleRenderable.DrawRangeCircle(wr, actorPos, OuterRadius, 1, Color.LimeGreen, 0, Color.LimeGreen);
+			yield return new CircleAnnotationRenderable(a, Radius, 1, Color.Yellow);
+			yield return new CircleAnnotationRenderable(b, Radius, 1, Color.Yellow);
+			yield return new CircleAnnotationRenderable(aa, Radius, 1, Color.Yellow);
+			yield return new CircleAnnotationRenderable(bb, Radius, 1, Color.Yellow);
+			yield return new CircleAnnotationRenderable(actorPos, OuterRadius, 1,  Color.LimeGreen);
+			yield return new LineAnnotationRenderable(a - offset1, b - offset1, 1, Color.Yellow);
+			yield return new LineAnnotationRenderable(a + offset1, b + offset1, 1, Color.Yellow);
+			yield return new LineAnnotationRenderable(aa - offset2, bb - offset2, 1, Color.Yellow);
+			yield return new LineAnnotationRenderable(aa + offset2, bb + offset2, 1, Color.Yellow);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/HitShapes/Circle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Circle.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Primitives;
@@ -57,14 +58,11 @@ namespace OpenRA.Mods.Common.HitShapes
 			return DistanceFromEdge(pos - new WPos(actorPos.X, actorPos.Y, pos.Z));
 		}
 
-		public void DrawCombatOverlay(WorldRenderer wr, RgbaColorRenderer wcr, Actor actor)
+		IEnumerable<IRenderable> IHitShape.RenderDebugOverlay(WorldRenderer wr, Actor actor)
 		{
 			var actorPos = actor.CenterPosition;
-
-			RangeCircleRenderable.DrawRangeCircle(
-				wr, actorPos + new WVec(0, 0, VerticalTopOffset), Radius, 1, Color.Yellow, 0, Color.Yellow);
-			RangeCircleRenderable.DrawRangeCircle(
-				wr, actorPos + new WVec(0, 0, VerticalBottomOffset), Radius, 1, Color.Yellow, 0, Color.Yellow);
+			yield return new CircleAnnotationRenderable(actorPos + new WVec(0, 0, VerticalTopOffset), Radius, 1, Color.Yellow);
+			yield return new CircleAnnotationRenderable(actorPos + new WVec(0, 0, VerticalBottomOffset), Radius, 1, Color.Yellow);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/HitShapes/IHitShape.cs
+++ b/OpenRA.Mods.Common/HitShapes/IHitShape.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Graphics;
 
 namespace OpenRA.Mods.Common.HitShapes
@@ -21,6 +22,6 @@ namespace OpenRA.Mods.Common.HitShapes
 		WDist DistanceFromEdge(WPos pos, Actor actor);
 
 		void Initialize();
-		void DrawCombatOverlay(WorldRenderer wr, RgbaColorRenderer wcr, Actor actor);
+		IEnumerable<IRenderable> RenderDebugOverlay(WorldRenderer wr, Actor actor);
 	}
 }

--- a/OpenRA.Mods.Common/HitShapes/Polygon.cs
+++ b/OpenRA.Mods.Common/HitShapes/Polygon.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
@@ -112,17 +113,17 @@ namespace OpenRA.Mods.Common.HitShapes
 			return DistanceFromEdge((pos - new WPos(actorPos.X, actorPos.Y, pos.Z)).Rotate(-orientation));
 		}
 
-		public void DrawCombatOverlay(WorldRenderer wr, RgbaColorRenderer wcr, Actor actor)
+		IEnumerable<IRenderable> IHitShape.RenderDebugOverlay(WorldRenderer wr, Actor actor)
 		{
 			var actorPos = actor.CenterPosition;
 			var orientation = actor.Orientation + WRot.FromYaw(LocalYaw);
 
-			var vertsTop = combatOverlayVertsTop.Select(v => wr.Screen3DPosition(actorPos + v.Rotate(orientation)));
-			var vertsBottom = combatOverlayVertsBottom.Select(v => wr.Screen3DPosition(actorPos + v.Rotate(orientation)));
-			wcr.DrawPolygon(vertsTop.ToArray(), 1, Color.Yellow);
-			wcr.DrawPolygon(vertsBottom.ToArray(), 1, Color.Yellow);
+			var vertsTop = combatOverlayVertsTop.Select(v => actorPos + v.Rotate(orientation)).ToArray();
+			var vertsBottom = combatOverlayVertsBottom.Select(v => actorPos + v.Rotate(orientation)).ToArray();
 
-			RangeCircleRenderable.DrawRangeCircle(wr, actorPos, OuterRadius, 1, Color.LimeGreen, 0, Color.LimeGreen);
+			yield return new PolygonAnnotationRenderable(vertsTop, actorPos, 1, Color.Yellow);
+			yield return new PolygonAnnotationRenderable(vertsBottom, actorPos, 1, Color.Yellow);
+			yield return new CircleAnnotationRenderable(actorPos, OuterRadius, 1, Color.LimeGreen);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/HitShapes/Rectangle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Rectangle.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
@@ -107,17 +108,17 @@ namespace OpenRA.Mods.Common.HitShapes
 			return DistanceFromEdge((pos - new WPos(actorPos.X, actorPos.Y, pos.Z)).Rotate(-orientation));
 		}
 
-		public void DrawCombatOverlay(WorldRenderer wr, RgbaColorRenderer wcr, Actor actor)
+		IEnumerable<IRenderable> IHitShape.RenderDebugOverlay(WorldRenderer wr, Actor actor)
 		{
 			var actorPos = actor.CenterPosition;
 			var orientation = actor.Orientation + WRot.FromYaw(LocalYaw);
 
-			var vertsTop = combatOverlayVertsTop.Select(v => wr.Screen3DPosition(actorPos + v.Rotate(orientation)));
-			var vertsBottom = combatOverlayVertsBottom.Select(v => wr.Screen3DPosition(actorPos + v.Rotate(orientation)));
-			wcr.DrawPolygon(vertsTop.ToArray(), 1, Color.Yellow);
-			wcr.DrawPolygon(vertsBottom.ToArray(), 1, Color.Yellow);
+			var vertsTop = combatOverlayVertsTop.Select(v => actorPos + v.Rotate(orientation)).ToArray();
+			var vertsBottom = combatOverlayVertsBottom.Select(v => actorPos + v.Rotate(orientation)).ToArray();
 
-			RangeCircleRenderable.DrawRangeCircle(wr, actorPos, OuterRadius, 1, Color.LimeGreen, 0, Color.LimeGreen);
+			yield return new PolygonAnnotationRenderable(vertsTop, actorPos, 1, Color.Yellow);
+			yield return new PolygonAnnotationRenderable(vertsBottom, actorPos, 1, Color.Yellow);
+			yield return new CircleAnnotationRenderable(actorPos, OuterRadius, 1, Color.LimeGreen);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 				foreach (var a in w.ActorsWithTrait<WithRangeCircle>())
 					if (a.Trait.Info.Type == Type)
-						foreach (var r in a.Trait.RenderRangeCircle(a.Actor, wr))
+						foreach (var r in a.Trait.RenderRangeCircle(a.Actor, wr, RangeCircleVisibility.WhenSelected))
 							yield return r;
 			}
 		}
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithRangeCircle(init.Self, this); }
 	}
 
-	class WithRangeCircle : ConditionalTrait<WithRangeCircleInfo>, IRenderAboveShroudWhenSelected, IRenderAboveWorld
+	class WithRangeCircle : ConditionalTrait<WithRangeCircleInfo>, IRenderAboveShroudWhenSelected, IRenderAboveShroud
 	{
 		readonly Actor self;
 
@@ -84,37 +84,29 @@ namespace OpenRA.Mods.Common.Traits.Render
 			}
 		}
 
-		public IEnumerable<IRenderable> RenderRangeCircle(Actor self, WorldRenderer wr)
+		public IEnumerable<IRenderable> RenderRangeCircle(Actor self, WorldRenderer wr, RangeCircleVisibility visibility)
 		{
-			if (Info.Visible == RangeCircleVisibility.WhenSelected && Visible)
+			if (Info.Visible == visibility && Visible)
 				yield return new RangeCircleRenderable(
 					self.CenterPosition,
 					Info.Range,
 					0,
 					Info.UsePlayerColor ? self.Owner.Color : Info.Color,
 					Color.FromArgb(96, Color.Black));
-
-			yield break;
 		}
 
 		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
-			return RenderRangeCircle(self, wr);
+			return RenderRangeCircle(self, wr, RangeCircleVisibility.WhenSelected);
 		}
 
 		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return false; } }
 
-		void IRenderAboveWorld.RenderAboveWorld(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAboveShroud.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
-			if (Info.Visible == RangeCircleVisibility.Always && Visible)
-				RangeCircleRenderable.DrawRangeCircle(
-					wr,
-					self.CenterPosition,
-					Info.Range,
-					1,
-					Info.UsePlayerColor ? self.Owner.Color : Info.Color,
-					3,
-					Color.FromArgb(96, Color.Black));
+			return RenderRangeCircle(self, wr, RangeCircleVisibility.Always);
 		}
+
+		bool IRenderAboveShroud.SpatiallyPartitionable { get { return false; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Collections.Generic;
 using OpenRA.Graphics;
 using OpenRA.Traits;
 
@@ -35,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		public virtual object Create(ActorInitializer init) { return new EditorSelectionLayer(init.Self, this); }
 	}
 
-	public class EditorSelectionLayer : IWorldLoaded, IRenderAboveWorld
+	public class EditorSelectionLayer : IWorldLoaded, IRenderAboveShroud
 	{
 		readonly EditorSelectionLayerInfo info;
 		readonly Map map;
@@ -80,20 +81,22 @@ namespace OpenRA.Mods.Common.Traits
 			CopyRegion = PasteRegion = null;
 		}
 
-		void IRenderAboveWorld.RenderAboveWorld(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAboveShroud.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{
 			if (wr.World.Type != WorldType.Editor)
-				return;
+				yield break;
 
 			if (CopyRegion != null)
 				foreach (var c in CopyRegion)
-					new SpriteRenderable(copySprite, wr.World.Map.CenterOfCell(c),
-						WVec.Zero, -511, palette, 1f, true).PrepareRender(wr).Render(wr);
+					yield return new SpriteRenderable(copySprite, wr.World.Map.CenterOfCell(c),
+						WVec.Zero, -511, palette, 1f, true);
 
 			if (PasteRegion != null)
 				foreach (var c in PasteRegion)
-					new SpriteRenderable(pasteSprite, wr.World.Map.CenterOfCell(c),
-						WVec.Zero, -511, palette, 1f, true).PrepareRender(wr).Render(wr);
+					yield return new SpriteRenderable(pasteSprite, wr.World.Map.CenterOfCell(c),
+						WVec.Zero, -511, palette, 1f, true);
 		}
+
+		bool IRenderAboveShroud.SpatiallyPartitionable { get { return false; } }
 	}
 }


### PR DESCRIPTION
This PR implements another (and the messiest) prereq for #10382. Most of the debug overlays were previously using the old `IRenderAboveWorld` interface, which meant they would be drawn at the world resolution (which looks really bad) when we switch to the split rendering model.

This ports them over to `IRenderAboveShroud` and adds new `IRenderable` types to clean up their rendering. The `*AnnotationRenderable` naming scheme is chosen to match the next PR, which will split an `IRenderAnnotation` interface from `IRenderAboveShroud` - `IRenderAboveShroud` will be drawn as part of the world (zoom and GPU-based scroll), while `IRenderAnnotation` is drawn as part of the UI (different zoom, CPU-based scroll).

The main visible change is that the `TerrainGeometryOverlay` is no longer hidden by the shroud borders. Moving to solid circles and dropping target markers cause some minor visual tweaks for the sake of simplicity.

This also fixes the always-visible rendering mode for `WithRangeCircle` to match the on-selection mode wrt shroud and annotations.