### PR TITLE
Fix a division by zero error in FindAndDeliverResources

### DIFF
--- a/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
+++ b/OpenRA.Mods.Common/Activities/FindAndDeliverResources.cs
@@ -214,7 +214,7 @@ namespace OpenRA.Mods.Common.Activities
 
 						if (b != WVec.Zero && c != WVec.Zero)
 						{
-							var cosA = (int)(1024 * (b.LengthSquared + c.LengthSquared - a.LengthSquared) / (2 * b.Length * c.Length));
+							var cosA = (int)(512 * (b.LengthSquared + c.LengthSquared - a.LengthSquared) / b.Length / c.Length);
 
 							// Cost modifier varies between 0 and ResourceRefineryDirectionPenalty
 							return Math.Abs(harvInfo.ResourceRefineryDirectionPenalty / 2) + harvInfo.ResourceRefineryDirectionPenalty * cosA / 2048;


### PR DESCRIPTION
by preventing an overflow. See the inline comment/IRC yesterday evening.

Fixes https://www.openra.net/news/playtest-20190825/#comment-4604395315.