### PR TITLE
Replace $/min and increase the graph update rates

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -62,12 +62,17 @@ namespace OpenRA.Mods.Common.Traits
 		int ticks;
 		int replayTimestep;
 
+		bool armyGraphDisabled;
+		bool incomeGraphDisabled;
+
 		public PlayerStatistics(Actor self) { }
 
 		void INotifyCreated.Created(Actor self)
 		{
 			resources = self.TraitOrDefault<PlayerResources>();
 			experience = self.TraitOrDefault<PlayerExperience>();
+
+			incomeGraphDisabled = resources == null;
 		}
 
 		void ITick.Tick(Actor self)
@@ -79,11 +84,15 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				ticks = 0;
 
-				if (ArmyValue != 0 || self.Owner.WinState == WinState.Undefined)
+				if (!armyGraphDisabled && (ArmyValue != 0 || self.Owner.WinState == WinState.Undefined))
 					ArmySamples.Add(ArmyValue);
+				else
+					armyGraphDisabled = true;
 
-				if (resources != null && (Income != 0 || self.Owner.WinState == WinState.Undefined))
+				if (!incomeGraphDisabled && (Income != 0 || self.Owner.WinState == WinState.Undefined))
 					IncomeSamples.Add(Income);
+				else
+					incomeGraphDisabled = true;
 			}
 
 			if (resources == null)
@@ -134,8 +143,11 @@ namespace OpenRA.Mods.Common.Traits
 			if (w.IsReplay)
 				replayTimestep = w.WorldActor.Trait<MapOptions>().GameSpeed.Timestep;
 
-			ArmySamples.Add(ArmyValue);
-			IncomeSamples.Add(Income);
+			if (!armyGraphDisabled)
+				ArmySamples.Add(ArmyValue);
+
+			if (!incomeGraphDisabled)
+				IncomeSamples.Add(Income);
 		}
 	}
 

--- a/OpenRA.Mods.Common/Widgets/LineGraphWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LineGraphWidget.cs
@@ -35,6 +35,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public string YAxisValueFormat = "{0}";
 		public int XAxisSize = 10;
 		public int YAxisSize = 10;
+		public int XAxisTicksPerLabel = 1;
 		public string XAxisLabel = "";
 		public string YAxisLabel = "";
 		public bool DisplayFirstYAxisValue = false;
@@ -77,6 +78,7 @@ namespace OpenRA.Mods.Common.Widgets
 			YAxisValueFormat = other.YAxisValueFormat;
 			XAxisSize = other.XAxisSize;
 			YAxisSize = other.YAxisSize;
+			XAxisTicksPerLabel = other.XAxisTicksPerLabel;
 			XAxisLabel = other.XAxisLabel;
 			YAxisLabel = other.YAxisLabel;
 			DisplayFirstYAxisValue = other.DisplayFirstYAxisValue;
@@ -178,7 +180,10 @@ namespace OpenRA.Mods.Common.Widgets
 			for (int n = pointStart, x = 0; n <= pointEnd; n++, x += xStep)
 			{
 				cr.DrawLine(graphOrigin + new float2(x, 0), graphOrigin + new float2(x, -5), 1, Color.White);
-				var xAxisText = GetXAxisValueFormat().F(n);
+				if (n % XAxisTicksPerLabel != 0)
+					continue;
+
+				var xAxisText = GetXAxisValueFormat().F(n / XAxisTicksPerLabel);
 				var xAxisTickTextWidth = labelFont.Measure(xAxisText).X;
 				var xLocation = x - (xAxisTickTextWidth / 2);
 				labelFont.DrawTextWithShadow(xAxisText, graphOrigin + new float2(xLocation, 2), Color.White, BackgroundColorDark, BackgroundColorLight, 1);

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -383,7 +383,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var res = player.PlayerActor.Trait<PlayerResources>();
 			template.Get<LabelWidget>("CASH").GetText = () => "$" + (res.Cash + res.Resources);
-			template.Get<LabelWidget>("EARNED_MIN").GetText = () => AverageEarnedPerMinute(res.Earned);
 
 			var powerRes = player.PlayerActor.TraitOrDefault<PowerManager>();
 			if (powerRes != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -488,9 +488,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			headerTemplate.Get<GradientColorBlockWidget>("HEADER_GRADIENT").Bounds.X += offset;
 
 			foreach (var headerLabel in headerTemplate.Children.OfType<LabelWidget>())
-			{
 				headerLabel.Bounds.X += offset;
-			}
 		}
 
 		static void AddPlayerFlagAndName(ScrollItemWidget template, Player player)
@@ -526,8 +524,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		static Color GetPowerColor(PowerState state)
 		{
-			if (state == PowerState.Critical) return Color.Red;
-			if (state == PowerState.Low) return Color.Orange;
+			if (state == PowerState.Critical)
+				return Color.Red;
+
+			if (state == PowerState.Low)
+				return Color.Orange;
+
 			return Color.LimeGreen;
 		}
 

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -288,7 +288,7 @@ Container@OBSERVER_WIDGETS:
 						Container@BASIC_STATS_HEADERS:
 							X: 0
 							Y: 0
-							Width: 765
+							Width: 705
 							Height: PARENT_BOTTOM
 							Children:
 								ColorBlock@HEADER_COLOR:
@@ -322,17 +322,8 @@ Container@OBSERVER_WIDGETS:
 									Text: Cash
 									Align: Right
 									Shadow: True
-								Label@EARNED_MIN_HEADER:
-									X: 240
-									Y: 0
-									Width: 60
-									Height: PARENT_BOTTOM
-									Font: Bold
-									Text: $/min
-									Align: Right
-									Shadow: True
 								Label@POWER_HEADER:
-									X: 300
+									X: 240
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
@@ -341,7 +332,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Center
 									Shadow: True
 								Label@KILLS_HEADER:
-									X: 380
+									X: 320
 									Y: 0
 									Width: 40
 									Height: PARENT_BOTTOM
@@ -350,7 +341,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@DEATHS_HEADER:
-									X: 420
+									X: 360
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
@@ -359,7 +350,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@ASSETS_DESTROYED_HEADER:
-									X: 480
+									X: 420
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
@@ -368,7 +359,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@ASSETS_LOST_HEADER:
-									X: 560
+									X: 500
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
@@ -377,7 +368,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@EXPERIENCE_HEADER:
-									X: 640
+									X: 580
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
@@ -386,7 +377,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@ACTIONS_MIN_HEADER:
-									X: 700
+									X: 640
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
@@ -679,7 +670,7 @@ Container@OBSERVER_WIDGETS:
 						ScrollItem@BASIC_PLAYER_TEMPLATE:
 							X: 0
 							Y: 0
-							Width: 765
+							Width: 705
 							Height: 24
 							BaseName: scrollitem-nohover
 							Children:
@@ -714,57 +705,50 @@ Container@OBSERVER_WIDGETS:
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
-								Label@EARNED_MIN:
-									X: 240
-									Y: 0
-									Width: 60
-									Height: PARENT_BOTTOM
-									Align: Right
-									Shadow: True
 								Label@POWER:
-									X: 300
+									X: 240
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Center
 									Shadow: True
 								Label@KILLS:
-									X: 380
+									X: 320
 									Y: 0
 									Width: 40
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@DEATHS:
-									X: 420
+									X: 360
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ASSETS_DESTROYED:
-									X: 480
+									X: 420
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ASSETS_LOST:
-									X: 560
+									X: 500
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@EXPERIENCE:
-									X: 640
+									X: 580
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ACTIONS_MIN:
-									X: 700
+									X: 640
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -388,7 +388,7 @@ Container@OBSERVER_WIDGETS:
 						Container@ECONOMY_STATS_HEADERS:
 							X: 0
 							Y: 0
-							Width: 715
+							Width: 735
 							Height: PARENT_BOTTOM
 							Children:
 								ColorBlock@HEADER_COLOR:
@@ -419,16 +419,16 @@ Container@OBSERVER_WIDGETS:
 									Text: Cash
 									Align: Right
 									Shadow: True
-								Label@EARNED_MIN_HEADER:
+								Label@INCOME_HEADER:
 									X: 240
-									Width: 60
+									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: $/min
+									Text: Income
 									Align: Right
 									Shadow: True
 								Label@ASSETS_HEADER:
-									X: 300
+									X: 320
 									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
@@ -436,7 +436,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@EARNED_HEADER:
-									X: 380
+									X: 400
 									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
@@ -444,7 +444,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@SPENT_HEADER:
-									X: 460
+									X: 480
 									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
@@ -452,7 +452,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@HARVESTERS_HEADER:
-									X: 540
+									X: 560
 									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
@@ -460,7 +460,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@DERRICKS_HEADER:
-									X: 630
+									X: 650
 									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
@@ -757,7 +757,7 @@ Container@OBSERVER_WIDGETS:
 						ScrollItem@ECONOMY_PLAYER_TEMPLATE:
 							X: 0
 							Y: 0
-							Width: 715
+							Width: 735
 							Height: 24
 							BaseName: scrollitem-nohover
 							Children:
@@ -792,43 +792,43 @@ Container@OBSERVER_WIDGETS:
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
-								Label@EARNED_MIN:
+								Label@INCOME:
 									X: 240
 									Y: 0
-									Width: 60
+									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ASSETS:
-									X: 300
+									X: 320
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@EARNED:
-									X: 380
+									X: 400
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@SPENT:
-									X: 460
+									X: 480
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@HARVESTERS:
-									X: 540
+									X: 560
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@DERRICKS:
-									X: 630
+									X: 650
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
@@ -988,7 +988,7 @@ Container@OBSERVER_WIDGETS:
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
-				Container@EARNED_THIS_MIN_GRAPH_CONTAINER:
+				Container@INCOME_GRAPH_CONTAINER:
 					X: 0
 					Y: 30
 					Width: PARENT_RIGHT
@@ -1001,21 +1001,20 @@ Container@OBSERVER_WIDGETS:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							Color: 00000090
-						LineGraph@EARNED_THIS_MIN_GRAPH:
+						LineGraph@INCOME_GRAPH:
 							X: 0
 							Y: 0
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							ValueFormat: ${0}
-							XAxisValueFormat: {0}
 							YAxisValueFormat: ${0:F0}
-							XAxisSize: 20
-							YAxisSize: 10
+							XAxisSize: 40
+							XAxisTicksPerLabel: 2
 							XAxisLabel: Game Minute
 							YAxisLabel: Earnings
 							LabelFont: TinyBold
 							AxisFont: TinyBold
-				Container@ARMY_THIS_MIN_GRAPH_CONTAINER:
+				Container@ARMY_VALUE_GRAPH_CONTAINER:
 					X: 0
 					Y: 30
 					Width: PARENT_RIGHT
@@ -1028,16 +1027,15 @@ Container@OBSERVER_WIDGETS:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							Color: 00000090
-						LineGraph@ARMY_THIS_MIN_GRAPH:
+						LineGraph@ARMY_VALUE_GRAPH:
 							X: 0
 							Y: 0
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							ValueFormat: ${0}
-							XAxisValueFormat: {0}
 							YAxisValueFormat: ${0:F0}
-							XAxisSize: 20
-							YAxisSize: 10
+							XAxisSize: 40
+							XAxisTicksPerLabel: 2
 							XAxisLabel: Game Minute
 							YAxisLabel: Army Value
 							LabelFont: TinyBold

--- a/mods/common/chrome/ingame-observer.yaml
+++ b/mods/common/chrome/ingame-observer.yaml
@@ -192,7 +192,7 @@ Container@OBSERVER_WIDGETS:
 						Container@BASIC_STATS_HEADERS:
 							X: 0
 							Y: 0
-							Width: 760
+							Width: 700
 							Height: PARENT_BOTTOM
 							Children:
 								ColorBlock@HEADER_COLOR:
@@ -226,17 +226,8 @@ Container@OBSERVER_WIDGETS:
 									Text: Cash
 									Align: Right
 									Shadow: True
-								Label@EARNED_MIN_HEADER:
-									X: 235
-									Y: 0
-									Width: 60
-									Height: PARENT_BOTTOM
-									Font: Bold
-									Text: $/min
-									Align: Right
-									Shadow: True
 								Label@POWER_HEADER:
-									X: 295
+									X: 235
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
@@ -245,7 +236,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Center
 									Shadow: True
 								Label@KILLS_HEADER:
-									X: 375
+									X: 315
 									Y: 0
 									Width: 40
 									Height: PARENT_BOTTOM
@@ -254,7 +245,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@DEATHS_HEADER:
-									X: 415
+									X: 355
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
@@ -263,7 +254,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@ASSETS_DESTROYED_HEADER:
-									X: 475
+									X: 415
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
@@ -272,7 +263,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@ASSETS_LOST_HEADER:
-									X: 555
+									X: 495
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
@@ -281,7 +272,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@EXPERIENCE_HEADER:
-									X: 635
+									X: 575
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
@@ -290,7 +281,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@ACTIONS_MIN_HEADER:
-									X: 695
+									X: 635
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
@@ -575,7 +566,7 @@ Container@OBSERVER_WIDGETS:
 						ScrollItem@BASIC_PLAYER_TEMPLATE:
 							X: 0
 							Y: 0
-							Width: 760
+							Width: 700
 							Height: 25
 							BaseName: scrollitem-nohover
 							Children:
@@ -608,57 +599,50 @@ Container@OBSERVER_WIDGETS:
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
-								Label@EARNED_MIN:
-									X: 235
-									Y: 0
-									Width: 60
-									Height: PARENT_BOTTOM
-									Align: Right
-									Shadow: True
 								Label@POWER:
-									X: 295
+									X: 235
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Center
 									Shadow: True
 								Label@KILLS:
-									X: 375
+									X: 315
 									Y: 0
 									Width: 40
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@DEATHS:
-									X: 415
+									X: 355
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ASSETS_DESTROYED:
-									X: 475
+									X: 415
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ASSETS_LOST:
-									X: 555
+									X: 495
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@EXPERIENCE:
-									X: 635
+									X: 575
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ACTIONS_MIN:
-									X: 695
+									X: 635
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM

--- a/mods/common/chrome/ingame-observer.yaml
+++ b/mods/common/chrome/ingame-observer.yaml
@@ -292,7 +292,7 @@ Container@OBSERVER_WIDGETS:
 						Container@ECONOMY_STATS_HEADERS:
 							X: 0
 							Y: 0
-							Width: 620
+							Width: 640
 							Height: PARENT_BOTTOM
 							Children:
 								ColorBlock@HEADER_COLOR:
@@ -323,16 +323,16 @@ Container@OBSERVER_WIDGETS:
 									Text: Cash
 									Align: Right
 									Shadow: True
-								Label@EARNED_MIN_HEADER:
+								Label@INCOME_HEADER:
 									X: 235
-									Width: 60
+									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: $/min
+									Text: Income
 									Align: Right
 									Shadow: True
 								Label@ASSETS_HEADER:
-									X: 295
+									X: 315
 									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
@@ -340,7 +340,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@EARNED_HEADER:
-									X: 375
+									X: 395
 									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
@@ -348,7 +348,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@SPENT_HEADER:
-									X: 455
+									X: 475
 									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
@@ -356,7 +356,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@HARVESTERS_HEADER:
-									X: 535
+									X: 555
 									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
@@ -651,7 +651,7 @@ Container@OBSERVER_WIDGETS:
 						ScrollItem@ECONOMY_PLAYER_TEMPLATE:
 							X: 0
 							Y: 0
-							Width: 620
+							Width: 640
 							Height: 25
 							BaseName: scrollitem-nohover
 							Children:
@@ -684,36 +684,36 @@ Container@OBSERVER_WIDGETS:
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
-								Label@EARNED_MIN:
+								Label@INCOME:
 									X: 235
 									Y: 0
-									Width: 60
+									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ASSETS:
-									X: 295
+									X: 315
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@EARNED:
-									X: 375
+									X: 395
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@SPENT:
-									X: 455
+									X: 475
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@HARVESTERS:
-									X: 535
+									X: 555
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
@@ -867,7 +867,7 @@ Container@OBSERVER_WIDGETS:
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
-				Container@EARNED_THIS_MIN_GRAPH_CONTAINER:
+				Container@INCOME_GRAPH_CONTAINER:
 					X: 0
 					Y: 30
 					Width: PARENT_RIGHT
@@ -880,21 +880,20 @@ Container@OBSERVER_WIDGETS:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							Color: 00000090
-						LineGraph@EARNED_THIS_MIN_GRAPH:
+						LineGraph@INCOME_GRAPH:
 							X: 0
 							Y: 0
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							ValueFormat: ${0}
-							XAxisValueFormat: {0}
 							YAxisValueFormat: ${0:F0}
-							XAxisSize: 20
-							YAxisSize: 10
+							XAxisSize: 40
+							XAxisTicksPerLabel: 2
 							XAxisLabel: Game Minute
 							YAxisLabel: Earnings
 							LabelFont: TinyBold
 							AxisFont: TinyBold
-				Container@ARMY_THIS_MIN_GRAPH_CONTAINER:
+				Container@ARMY_VALUE_GRAPH_CONTAINER:
 					X: 0
 					Y: 30
 					Width: PARENT_RIGHT
@@ -907,16 +906,15 @@ Container@OBSERVER_WIDGETS:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							Color: 00000090
-						LineGraph@ARMY_THIS_MIN_GRAPH:
+						LineGraph@ARMY_VALUE_GRAPH:
 							X: 0
 							Y: 0
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							ValueFormat: ${0}
-							XAxisValueFormat: {0}
 							YAxisValueFormat: ${0:F0}
-							XAxisSize: 20
-							YAxisSize: 10
+							XAxisSize: 40
+							XAxisTicksPerLabel: 2
 							XAxisLabel: Game Minute
 							YAxisLabel: Army Value
 							LabelFont: TinyBold

--- a/mods/ra/chrome/ingame-observer.yaml
+++ b/mods/ra/chrome/ingame-observer.yaml
@@ -224,7 +224,7 @@ Container@OBSERVER_WIDGETS:
 						Container@BASIC_STATS_HEADERS:
 							X: 0
 							Y: 0
-							Width: 765
+							Width: 705
 							Height: PARENT_BOTTOM
 							Children:
 								ColorBlock@HEADER_COLOR:
@@ -258,17 +258,8 @@ Container@OBSERVER_WIDGETS:
 									Text: Cash
 									Align: Right
 									Shadow: True
-								Label@EARNED_MIN_HEADER:
-									X: 240
-									Y: 0
-									Width: 60
-									Height: PARENT_BOTTOM
-									Font: Bold
-									Text: $/min
-									Align: Right
-									Shadow: True
 								Label@POWER_HEADER:
-									X: 300
+									X: 240
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
@@ -277,7 +268,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Center
 									Shadow: True
 								Label@KILLS_HEADER:
-									X: 380
+									X: 320
 									Y: 0
 									Width: 40
 									Height: PARENT_BOTTOM
@@ -286,7 +277,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@DEATHS_HEADER:
-									X: 420
+									X: 360
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
@@ -295,7 +286,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@ASSETS_DESTROYED_HEADER:
-									X: 480
+									X: 420
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
@@ -304,7 +295,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@ASSETS_LOST_HEADER:
-									X: 560
+									X: 500
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
@@ -313,7 +304,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@EXPERIENCE_HEADER:
-									X: 640
+									X: 580
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
@@ -322,7 +313,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@ACTIONS_MIN_HEADER:
-									X: 700
+									X: 640
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
@@ -591,7 +582,7 @@ Container@OBSERVER_WIDGETS:
 						ScrollItem@TEAM_TEMPLATE:
 							X: 0
 							Y: 0
-							Width: 650 #PARENT_RIGHT - 35
+							Width: 650
 							Height: 24
 							Children:
 								ColorBlock@TEAM_COLOR:
@@ -617,7 +608,7 @@ Container@OBSERVER_WIDGETS:
 						ScrollItem@BASIC_PLAYER_TEMPLATE:
 							X: 0
 							Y: 0
-							Width: 765
+							Width: 705
 							Height: 24
 							BaseName: scrollitem-nohover
 							Children:
@@ -652,57 +643,50 @@ Container@OBSERVER_WIDGETS:
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
-								Label@EARNED_MIN:
-									X: 240
-									Y: 0
-									Width: 60
-									Height: PARENT_BOTTOM
-									Align: Right
-									Shadow: True
 								Label@POWER:
-									X: 300
+									X: 240
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Center
 									Shadow: True
 								Label@KILLS:
-									X: 380
+									X: 320
 									Y: 0
 									Width: 40
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@DEATHS:
-									X: 420
+									X: 360
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ASSETS_DESTROYED:
-									X: 480
+									X: 420
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ASSETS_LOST:
-									X: 560
+									X: 500
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@EXPERIENCE:
-									X: 640
+									X: 580
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ACTIONS_MIN:
-									X: 700
+									X: 640
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM

--- a/mods/ra/chrome/ingame-observer.yaml
+++ b/mods/ra/chrome/ingame-observer.yaml
@@ -324,7 +324,7 @@ Container@OBSERVER_WIDGETS:
 						Container@ECONOMY_STATS_HEADERS:
 							X: 0
 							Y: 0
-							Width: 715
+							Width: 735
 							Height: PARENT_BOTTOM
 							Children:
 								ColorBlock@HEADER_COLOR:
@@ -355,16 +355,16 @@ Container@OBSERVER_WIDGETS:
 									Text: Cash
 									Align: Right
 									Shadow: True
-								Label@EARNED_MIN_HEADER:
+								Label@INCOME_HEADER:
 									X: 240
-									Width: 60
+									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: $/min
+									Text: Income
 									Align: Right
 									Shadow: True
 								Label@ASSETS_HEADER:
-									X: 300
+									X: 320
 									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
@@ -372,7 +372,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@EARNED_HEADER:
-									X: 380
+									X: 400
 									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
@@ -380,7 +380,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@SPENT_HEADER:
-									X: 460
+									X: 480
 									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
@@ -388,7 +388,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@HARVESTERS_HEADER:
-									X: 540
+									X: 560
 									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
@@ -396,7 +396,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@DERRICKS_HEADER:
-									X: 630
+									X: 650
 									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
@@ -695,7 +695,7 @@ Container@OBSERVER_WIDGETS:
 						ScrollItem@ECONOMY_PLAYER_TEMPLATE:
 							X: 0
 							Y: 0
-							Width: 715
+							Width: 735
 							Height: 24
 							BaseName: scrollitem-nohover
 							Children:
@@ -730,43 +730,43 @@ Container@OBSERVER_WIDGETS:
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
-								Label@EARNED_MIN:
+								Label@INCOME:
 									X: 240
 									Y: 0
-									Width: 60
+									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ASSETS:
-									X: 300
+									X: 320
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@EARNED:
-									X: 380
+									X: 400
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@SPENT:
-									X: 460
+									X: 480
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@HARVESTERS:
-									X: 540
+									X: 560
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@DERRICKS:
-									X: 630
+									X: 650
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
@@ -926,7 +926,7 @@ Container@OBSERVER_WIDGETS:
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
-				Container@EARNED_THIS_MIN_GRAPH_CONTAINER:
+				Container@INCOME_GRAPH_CONTAINER:
 					X: 0
 					Y: 30
 					Width: PARENT_RIGHT
@@ -939,21 +939,20 @@ Container@OBSERVER_WIDGETS:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							Color: 00000090
-						LineGraph@EARNED_THIS_MIN_GRAPH:
+						LineGraph@INCOME_GRAPH:
 							X: 0
 							Y: 0
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							ValueFormat: ${0}
-							XAxisValueFormat: {0}
 							YAxisValueFormat: ${0:F0}
-							XAxisSize: 20
-							YAxisSize: 10
+							XAxisSize: 40
+							XAxisTicksPerLabel: 2
 							XAxisLabel: Game Minute
 							YAxisLabel: Earnings
 							LabelFont: TinyBold
 							AxisFont: TinyBold
-				Container@ARMY_THIS_MIN_GRAPH_CONTAINER:
+				Container@ARMY_VALUE_GRAPH_CONTAINER:
 					X: 0
 					Y: 30
 					Width: PARENT_RIGHT
@@ -966,16 +965,15 @@ Container@OBSERVER_WIDGETS:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							Color: 00000090
-						LineGraph@ARMY_THIS_MIN_GRAPH:
+						LineGraph@ARMY_VALUE_GRAPH:
 							X: 0
 							Y: 0
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							ValueFormat: ${0}
-							XAxisValueFormat: {0}
 							YAxisValueFormat: ${0:F0}
-							XAxisSize: 20
-							YAxisSize: 10
+							XAxisSize: 40
+							XAxisTicksPerLabel: 2
 							XAxisLabel: Game Minute
 							YAxisLabel: Army Value
 							LabelFont: TinyBold

--- a/mods/ts/chrome/ingame-observer.yaml
+++ b/mods/ts/chrome/ingame-observer.yaml
@@ -192,7 +192,7 @@ Container@OBSERVER_WIDGETS:
 						Container@BASIC_STATS_HEADERS:
 							X: 0
 							Y: 0
-							Width: 765
+							Width: 705
 							Height: PARENT_BOTTOM
 							Children:
 								ColorBlock@HEADER_COLOR:
@@ -226,17 +226,8 @@ Container@OBSERVER_WIDGETS:
 									Text: Cash
 									Align: Right
 									Shadow: True
-								Label@EARNED_MIN_HEADER:
-									X: 240
-									Y: 0
-									Width: 60
-									Height: PARENT_BOTTOM
-									Font: Bold
-									Text: $/min
-									Align: Right
-									Shadow: True
 								Label@POWER_HEADER:
-									X: 300
+									X: 240
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
@@ -245,7 +236,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Center
 									Shadow: True
 								Label@KILLS_HEADER:
-									X: 380
+									X: 320
 									Y: 0
 									Width: 40
 									Height: PARENT_BOTTOM
@@ -254,7 +245,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@DEATHS_HEADER:
-									X: 420
+									X: 360
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
@@ -263,7 +254,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@ASSETS_DESTROYED_HEADER:
-									X: 480
+									X: 420
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
@@ -272,7 +263,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@ASSETS_LOST_HEADER:
-									X: 560
+									X: 500
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
@@ -281,7 +272,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@EXPERIENCE_HEADER:
-									X: 640
+									X: 580
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
@@ -290,7 +281,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@ACTIONS_MIN_HEADER:
-									X: 700
+									X: 640
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
@@ -575,7 +566,7 @@ Container@OBSERVER_WIDGETS:
 						ScrollItem@BASIC_PLAYER_TEMPLATE:
 							X: 0
 							Y: 0
-							Width: 765
+							Width: 705
 							Height: 24
 							BaseName: scrollitem-nohover
 							Children:
@@ -610,57 +601,50 @@ Container@OBSERVER_WIDGETS:
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
-								Label@EARNED_MIN:
-									X: 240
-									Y: 0
-									Width: 60
-									Height: PARENT_BOTTOM
-									Align: Right
-									Shadow: True
 								Label@POWER:
-									X: 300
+									X: 240
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Center
 									Shadow: True
 								Label@KILLS:
-									X: 380
+									X: 320
 									Y: 0
 									Width: 40
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@DEATHS:
-									X: 420
+									X: 360
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ASSETS_DESTROYED:
-									X: 480
+									X: 420
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ASSETS_LOST:
-									X: 560
+									X: 500
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@EXPERIENCE:
-									X: 640
+									X: 580
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ACTIONS_MIN:
-									X: 700
+									X: 640
 									Y: 0
 									Width: 60
 									Height: PARENT_BOTTOM

--- a/mods/ts/chrome/ingame-observer.yaml
+++ b/mods/ts/chrome/ingame-observer.yaml
@@ -292,7 +292,7 @@ Container@OBSERVER_WIDGETS:
 						Container@ECONOMY_STATS_HEADERS:
 							X: 0
 							Y: 0
-							Width: 625
+							Width: 645
 							Height: PARENT_BOTTOM
 							Children:
 								ColorBlock@HEADER_COLOR:
@@ -323,16 +323,16 @@ Container@OBSERVER_WIDGETS:
 									Text: Cash
 									Align: Right
 									Shadow: True
-								Label@EARNED_MIN_HEADER:
+								Label@INCOME_HEADER:
 									X: 240
-									Width: 60
+									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
-									Text: $/min
+									Text: Income
 									Align: Right
 									Shadow: True
 								Label@ASSETS_HEADER:
-									X: 300
+									X: 320
 									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
@@ -340,7 +340,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@EARNED_HEADER:
-									X: 380
+									X: 400
 									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
@@ -348,7 +348,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@SPENT_HEADER:
-									X: 460
+									X: 480
 									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
@@ -356,7 +356,7 @@ Container@OBSERVER_WIDGETS:
 									Align: Right
 									Shadow: True
 								Label@HARVESTERS_HEADER:
-									X: 540
+									X: 560
 									Width: 80
 									Height: PARENT_BOTTOM
 									Font: Bold
@@ -653,7 +653,7 @@ Container@OBSERVER_WIDGETS:
 						ScrollItem@ECONOMY_PLAYER_TEMPLATE:
 							X: 0
 							Y: 0
-							Width: 625
+							Width: 645
 							Height: 24
 							BaseName: scrollitem-nohover
 							Children:
@@ -688,36 +688,36 @@ Container@OBSERVER_WIDGETS:
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
-								Label@EARNED_MIN:
+								Label@INCOME:
 									X: 240
 									Y: 0
-									Width: 60
+									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@ASSETS:
-									X: 300
+									X: 320
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@EARNED:
-									X: 380
+									X: 400
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@SPENT:
-									X: 460
+									X: 480
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
 								Label@HARVESTERS:
-									X: 540
+									X: 560
 									Y: 0
 									Width: 80
 									Height: PARENT_BOTTOM
@@ -879,7 +879,7 @@ Container@OBSERVER_WIDGETS:
 									Height: PARENT_BOTTOM
 									Align: Right
 									Shadow: True
-				Container@EARNED_THIS_MIN_GRAPH_CONTAINER:
+				Container@INCOME_GRAPH_CONTAINER:
 					X: 0
 					Y: 30
 					Width: PARENT_RIGHT
@@ -892,21 +892,20 @@ Container@OBSERVER_WIDGETS:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							Color: 00000090
-						LineGraph@EARNED_THIS_MIN_GRAPH:
+						LineGraph@INCOME_GRAPH:
 							X: 0
 							Y: 0
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							ValueFormat: ${0}
-							XAxisValueFormat: {0}
 							YAxisValueFormat: ${0:F0}
-							XAxisSize: 20
-							YAxisSize: 10
+							XAxisSize: 40
+							XAxisTicksPerLabel: 2
 							XAxisLabel: Game Minute
 							YAxisLabel: Earnings
 							LabelFont: TinyBold
 							AxisFont: TinyBold
-				Container@ARMY_THIS_MIN_GRAPH_CONTAINER:
+				Container@ARMY_VALUE_GRAPH_CONTAINER:
 					X: 0
 					Y: 30
 					Width: PARENT_RIGHT
@@ -919,16 +918,15 @@ Container@OBSERVER_WIDGETS:
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							Color: 00000090
-						LineGraph@ARMY_THIS_MIN_GRAPH:
+						LineGraph@ARMY_VALUE_GRAPH:
 							X: 0
 							Y: 0
 							Width: PARENT_RIGHT
 							Height: PARENT_BOTTOM
 							ValueFormat: ${0}
-							XAxisValueFormat: {0}
 							YAxisValueFormat: ${0:F0}
-							XAxisSize: 20
-							YAxisSize: 10
+							XAxisSize: 40
+							XAxisTicksPerLabel: 2
 							XAxisLabel: Game Minute
 							YAxisLabel: Army Value
 							LabelFont: TinyBold


### PR DESCRIPTION
~~Depends on #17022 and #16858. (With those two merged I'll polish the code here a bit.)~~

Closes #17044.
Closes #3451.
Closes #10090.

Testcase is currently the earnings graph in TD, it will update every twenty seconds.
`$/min` in TD is also replaced by the "Income during the last 60 seconds" (just not renamed yet) as discussed on IRC.