### PR TITLE
Fix SupportPowerBotModule references to invalid support powers

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
@@ -208,8 +208,14 @@ namespace OpenRA.Mods.Common.Traits
 
 			var waitingPowersNode = data.FirstOrDefault(n => n.Key == "WaitingPowers");
 			if (waitingPowersNode != null)
+			{
 				foreach (var n in waitingPowersNode.Value.Nodes)
-					waitingPowers[supportPowerManager.Powers[n.Key]] = FieldLoader.GetValue<int>("WaitingPowers", n.Value.Value);
+				{
+					SupportPowerInstance instance;
+					if (supportPowerManager.Powers.TryGetValue(n.Key, out instance))
+						waitingPowers[instance] = FieldLoader.GetValue<int>("WaitingPowers", n.Value.Value);
+				}
+			}
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SupportPowerBotModule.cs
@@ -40,9 +40,10 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly World world;
 		readonly Player player;
+		readonly Dictionary<SupportPowerInstance, int> waitingPowers = new Dictionary<SupportPowerInstance, int>();
+		readonly Dictionary<string, SupportPowerDecision> powerDecisions = new Dictionary<string, SupportPowerDecision>();
+		readonly List<SupportPowerInstance> stalePowers = new List<SupportPowerInstance>();
 		SupportPowerManager supportPowerManager;
-		Dictionary<SupportPowerInstance, int> waitingPowers = new Dictionary<SupportPowerInstance, int>();
-		Dictionary<string, SupportPowerDecision> powerDecisions = new Dictionary<string, SupportPowerDecision>();
 
 		public SupportPowerBotModule(Actor self, SupportPowerBotModuleInfo info)
 			: base(info)
@@ -108,6 +109,13 @@ namespace OpenRA.Mods.Common.Traits
 					bot.QueueOrder(new Order(sp.Key, supportPowerManager.Self, Target.FromCell(world, attackLocation.Value), false) { SuppressVisualFeedback = true });
 				}
 			}
+
+			// Remove stale powers
+			stalePowers.AddRange(waitingPowers.Keys.Where(wp => !supportPowerManager.Powers.ContainsKey(wp.Key)));
+			foreach (var p in stalePowers)
+				waitingPowers.Remove(p);
+
+			stalePowers.Clear();
 		}
 
 		/// <summary>Scans the map in chunks, evaluating all actors in each.</summary>


### PR DESCRIPTION
Fixes #16995.

The issue happens because `SupportPowerBotModule` doesn't clean up references to invalid power instances (associated with structures that have been killed). These pile up over time, are added to the save game, and then crash when trying to restore them.

The first commit adds a sanity check during loading to ignore any invalid powers. The second commit removes them properly, which should allow the GC to reclaim those objects and anything they reference.