### PR TITLE
Fix a crash in allies03a

### DIFF
--- a/mods/ra/maps/allies-03a/allies03a.lua
+++ b/mods/ra/maps/allies-03a/allies03a.lua
@@ -189,8 +189,8 @@ InitTriggers = function()
 			end
 		end)
 	end)
-	Trigger.OnAllRemovedFromWorld(FirstUSSRBase, function()
-		if baseCamera then
+	Trigger.OnAllKilledOrCaptured(FirstUSSRBase, function()
+		if baseCamera and baseCamera.IsInWorld then
 			baseCamera.Destroy()
 		end
 	end)

--- a/mods/ra/maps/allies-03b/allies03b.lua
+++ b/mods/ra/maps/allies-03b/allies03b.lua
@@ -252,8 +252,8 @@ InitTriggers = function()
 			AlertFirstBase()
 		end)
 	end)
-	Trigger.OnAllRemovedFromWorld(FirstUSSRBase, function()
-		if baseCamera then
+	Trigger.OnAllKilledOrCaptured(FirstUSSRBase, function()
+		if baseCamera and baseCamera.IsInWorld then
 			baseCamera.Destroy()
 		end
 	end)

--- a/mods/ra/maps/allies-07/allies07.lua
+++ b/mods/ra/maps/allies-07/allies07.lua
@@ -85,7 +85,7 @@ BaseRaids = function()
 	if Map.LobbyOption("difficulty") == "easy" then
 		return
 	else
-		Trigger.AfterDelay(Utils.RandomInteger(BaseRaidDelay1[1], BaseRaidDelay1[2]), function()	
+		Trigger.AfterDelay(Utils.RandomInteger(BaseRaidDelay1[1], BaseRaidDelay1[2]), function()
 			local raiders = Reinforcements.ReinforceWithTransport(ussr, "lst", RaidingParty, RaidOnePath, { RaidOneEntry.Location })[2]
 			Utils.Do(raiders, function(a)
 				Trigger.OnAddedToWorld(a, function()
@@ -95,7 +95,7 @@ BaseRaids = function()
 			end)
 		end)
 
-		Trigger.AfterDelay(Utils.RandomInteger(BaseRaidDelay2[1], BaseRaidDelay2[2]), function()	
+		Trigger.AfterDelay(Utils.RandomInteger(BaseRaidDelay2[1], BaseRaidDelay2[2]), function()
 			local raiders = Reinforcements.ReinforceWithTransport(ussr, "lst", RaidingParty, RaidTwoPath, { RaidTwoEntry.Location })[2]
 			Utils.Do(raiders, function(a)
 				Trigger.OnAddedToWorld(a, function()
@@ -126,7 +126,7 @@ FinishTimer = function()
 	Trigger.AfterDelay(DateTime.Seconds(6), function() UserInterface.SetMissionText("") end)
 end
 
-BattalionWays = 
+BattalionWays =
 {
 	{ HardEntry1.Location, HardLanding1.Location },
 	{ HardEntry2.Location, HardLanding2.Location },
@@ -138,7 +138,7 @@ BattalionWays =
 
 SendArmoredBattalion = function()
 	Media.PlaySpeechNotification(greece, "EnemyUnitsApproaching")
-	Utils.Do(BattalionWays, function(way) 
+	Utils.Do(BattalionWays, function(way)
 		local units = { "3tnk", "3tnk", "3tnk", "4tnk", "4tnk" }
 		local armor = Reinforcements.ReinforceWithTransport(ussr, "lst", units , way, { way[2], way[1] })[2]
 		Utils.Do(armor, function(a)
@@ -146,7 +146,7 @@ SendArmoredBattalion = function()
 				a.AttackMove(PlayerBase.Location)
 				IdleHunt(a)
 			end)
-		end)	
+		end)
 	end)
 end
 
@@ -217,6 +217,6 @@ WorldLoaded = function()
 	Trigger.AfterDelay(ActivateAIDelay, ActivateAI)
 	Trigger.AfterDelay(StartTimerDelay, StartTimerFunction)
 
-	Trigger.OnAllRemovedFromWorld(DestroySubPensTriggerActivator, DestroySubPensCompleted)
+	Trigger.OnAllKilledOrCaptured(DestroySubPensTriggerActivator, DestroySubPensCompleted)
 	Trigger.OnAllRemovedFromWorld(ClearSubActivityTriggerActivator, ClearSubActivityCompleted)
 end

--- a/mods/ra/maps/infiltration/infiltration.lua
+++ b/mods/ra/maps/infiltration/infiltration.lua
@@ -282,8 +282,7 @@ end
 
 SovietBaseMaintenanceSetup = function()
 	local sovietbuildings = Utils.Where(Map.NamedActors, function(a)
-		return a.Owner == soviets
-			and a.HasProperty("StartBuildingRepairs") and a.HasProperty("Sell")
+		return a.Owner == soviets and a.HasProperty("StartBuildingRepairs")
 	end)
 
 	Trigger.OnAllKilledOrCaptured(sovietbuildings, function()
@@ -294,14 +293,8 @@ SovietBaseMaintenanceSetup = function()
 
 	Utils.Do(sovietbuildings, function(sovietbuilding)
 		Trigger.OnDamaged(sovietbuilding, function(building)
-			if building.Owner ~= soviets then
-				return
-			end
-			if building.Health < building.MaxHealth * 3/4 then
+			if building.Owner == soviets and building.Health < building.MaxHealth * 3/4 then
 				building.StartBuildingRepairs()
-			end
-			if building.Health < building.MaxHealth * 1/4 then
-				building.Sell()
 			end
 		end)
 	end)

--- a/mods/ra/maps/infiltration/infiltration.lua
+++ b/mods/ra/maps/infiltration/infiltration.lua
@@ -286,8 +286,7 @@ SovietBaseMaintenanceSetup = function()
 			and a.HasProperty("StartBuildingRepairs") and a.HasProperty("Sell")
 	end)
 
-	-- This includes killed, captured (actor is temporarily removed) and sold.
-	Trigger.OnAllRemovedFromWorld(sovietbuildings, function()
+	Trigger.OnAllKilledOrCaptured(sovietbuildings, function()
 		Utils.Do(humans, function(player)
 			player.MarkCompletedObjective(destroyBase)
 		end)


### PR DESCRIPTION
Fixes #17062 which is a regression from #15680.

Testcase: Destroy the entire base except the construction yard. Then capture it. That triggers the camera removal. Then sell or undeploy it (triggering it a second time).