### PR TITLE
Prevent users from selecting a directional target outside the map

### DIFF
--- a/OpenRA.Mods.Common/Traits/SupportPowers/SelectDirectionalTarget.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SelectDirectionalTarget.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (mi.Button == MouseButton.Left && mi.Event == MouseInputEvent.Down)
 			{
-				if (!activated)
+				if (!activated && world.Map.Contains(cell))
 				{
 					targetCell = cell;
 					targetLocation = mi.Location;
@@ -119,7 +119,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<IRenderable> IOrderGenerator.RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
 
-		string IOrderGenerator.GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi) { return cursor; }
+		string IOrderGenerator.GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		{
+			return world.Map.Contains(cell) ? cursor : "generic-blocked";
+		}
 
 		bool IOrderGenerator.HandleKeyPress(KeyInput e) { return false; }
 


### PR DESCRIPTION
This is basically a regression from the directional targeting PR since the generic target selector is preventing the user from placing a power outside of the map.