### PR TITLE
Add duplicate hotkey tracking in the hotkey definition

### DIFF
--- a/OpenRA.Game/HotkeyDefinition.cs
+++ b/OpenRA.Game/HotkeyDefinition.cs
@@ -20,6 +20,7 @@ namespace OpenRA
 		public readonly Hotkey Default = Hotkey.Invalid;
 		public readonly string Description = "";
 		public readonly HashSet<string> Types = new HashSet<string>();
+		public bool HasDuplicates = false;
 
 		public HotkeyDefinition(string name, MiniYaml node)
 		{

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -149,9 +149,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			remapButton.GetColor = () =>
 			{
-				return modData.Hotkeys.GetFirstDuplicate(hd.Name, modData.Hotkeys[hd.Name].GetValue(), hd) != null ?
-					hotkeyInvalidColor :
-					hotkeyValidColor;
+				return hd.HasDuplicates ? hotkeyInvalidColor : hotkeyValidColor;
 			};
 
 			if (selectedHotkeyDefinition == hd)
@@ -492,6 +490,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 								if (selectedHotkeyDefinition == null)
 									selectedHotkeyDefinition = hd;
 
+								if (modData.Hotkeys.GetFirstDuplicate(hd.Name, modData.Hotkeys[hd.Name].GetValue(), hd) != null)
+									hd.HasDuplicates = true;
+
 								BindHotkeyPref(hd, template, hotkeyList);
 							}
 						}
@@ -800,6 +801,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			WidgetUtils.TruncateButtonToTooltip(selectedHotkeyButton, hotkeyEntryWidget.Key.DisplayString());
 			modData.Hotkeys.Set(selectedHotkeyDefinition.Name, hotkeyEntryWidget.Key);
 			Game.Settings.Save();
+
+			foreach (var hd in modData.Hotkeys.Definitions)
+				hd.HasDuplicates = modData.Hotkeys.GetFirstDuplicate(hd.Name, modData.Hotkeys[hd.Name].GetValue(), hd) != null;
 		}
 
 		void ResetHotkey()


### PR DESCRIPTION
This is a follow up to #16816 (see https://github.com/OpenRA/OpenRA/pull/16816#discussion_r315102813). I opted for a boolean because it's easier to manage and I think it covers the base here.