### PR TITLE
Implement IEquatable on structs.

### DIFF
--- a/OpenRA.Game/Input/Hotkey.cs
+++ b/OpenRA.Game/Input/Hotkey.cs
@@ -9,9 +9,11 @@
  */
 #endregion
 
+using System;
+
 namespace OpenRA
 {
-	public struct Hotkey
+	public struct Hotkey : IEquatable<Hotkey>
 	{
 		public static Hotkey Invalid = new Hotkey(Keycode.UNKNOWN, Modifiers.None);
 		public bool IsValid()
@@ -73,6 +75,11 @@ namespace OpenRA
 		}
 
 		public override int GetHashCode() { return Key.GetHashCode() ^ Modifiers.GetHashCode(); }
+
+		public bool Equals(Hotkey other)
+		{
+			return other == this;
+		}
 
 		public override bool Equals(object obj)
 		{

--- a/OpenRA.Game/Primitives/Color.cs
+++ b/OpenRA.Game/Primitives/Color.cs
@@ -15,7 +15,7 @@ using OpenRA.Scripting;
 
 namespace OpenRA.Primitives
 {
-	public struct Color : IScriptBindable
+	public struct Color : IEquatable<Color>, IScriptBindable
 	{
 		readonly long argb;
 
@@ -199,6 +199,11 @@ namespace OpenRA.Primitives
 		public byte R { get { return (byte)(argb >> 16); } }
 		public byte G { get { return (byte)(argb >> 8); } }
 		public byte B { get { return (byte)argb; } }
+
+		public bool Equals(Color other)
+		{
+			return this == other;
+		}
 
 		public override bool Equals(object obj)
 		{

--- a/OpenRA.Game/Primitives/Pair.cs
+++ b/OpenRA.Game/Primitives/Pair.cs
@@ -66,17 +66,5 @@ namespace OpenRA.Primitives
 	public static class Pair
 	{
 		public static Pair<T, U> New<T, U>(T t, U u) { return new Pair<T, U>(t, u); }
-
-		static Pair()
-		{
-			Pair<char, Color>.Ucomparer = new ColorEqualityComparer();
-		}
-
-		// avoid the default crappy one
-		class ColorEqualityComparer : IEqualityComparer<Color>
-		{
-			public bool Equals(Color x, Color y) { return x.ToArgb() == y.ToArgb(); }
-			public int GetHashCode(Color obj) { return obj.GetHashCode(); }
-		}
 	}
 }

--- a/OpenRA.Game/Primitives/Rectangle.cs
+++ b/OpenRA.Game/Primitives/Rectangle.cs
@@ -13,7 +13,7 @@ using System;
 
 namespace OpenRA.Primitives
 {
-	public struct Rectangle
+	public struct Rectangle : IEquatable<Rectangle>
 	{
 		// TODO: Make these readonly: this will require a lot of changes to the UI logic
 		public int X;
@@ -74,6 +74,11 @@ namespace OpenRA.Primitives
 		public bool Contains(int2 pt)
 		{
 			return Contains(pt.X, pt.Y);
+		}
+
+		public bool Equals(Rectangle other)
+		{
+			return this == other;
 		}
 
 		public override bool Equals(object obj)

--- a/OpenRA.Game/Primitives/Size.cs
+++ b/OpenRA.Game/Primitives/Size.cs
@@ -13,7 +13,7 @@ using System;
 
 namespace OpenRA.Primitives
 {
-	public struct Size
+	public struct Size : IEquatable<Size>
 	{
 		public readonly int Width;
 		public readonly int Height;
@@ -45,6 +45,11 @@ namespace OpenRA.Primitives
 		}
 
 		public bool IsEmpty { get { return Width == 0 && Height == 0; } }
+
+		public bool Equals(Size other)
+		{
+			return this == other;
+		}
 
 		public override bool Equals(object obj)
 		{

--- a/OpenRA.Game/Primitives/float3.cs
+++ b/OpenRA.Game/Primitives/float3.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
@@ -16,7 +17,7 @@ namespace OpenRA
 {
 	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:ElementMustBeginWithUpperCaseLetter", Justification = "Mimic a built-in type alias.")]
 	[StructLayout(LayoutKind.Sequential)]
-	public struct float3
+	public struct float3 : IEquatable<float3>
 	{
 		public readonly float X, Y, Z;
 		public float2 XY { get { return new float2(X, Y); } }
@@ -46,6 +47,11 @@ namespace OpenRA
 		public static bool operator ==(float3 me, float3 other) { return me.X == other.X && me.Y == other.Y && me.Z == other.Z; }
 		public static bool operator !=(float3 me, float3 other) { return !(me == other); }
 		public override int GetHashCode() { return X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode(); }
+
+		public bool Equals(float3 other)
+		{
+			return other == this;
+		}
 
 		public override bool Equals(object obj)
 		{


### PR DESCRIPTION
Any struct which overrides object.Equals(object obj) should implement IEquatable<T> to gain a more efficient Equals(T other) overload. This overload will be used by hashing collections like Dictionary which enables them to check equality without boxing the struct.

(As a bonus, since we now own `Color`, we can remove the hack in `Pair` for a better comparer, since we already have one!)