### PR TITLE
Implement UI decoration rendering with *AnnotationRenderables

### DIFF
--- a/OpenRA.Game/Effects/IEffect.cs
+++ b/OpenRA.Game/Effects/IEffect.cs
@@ -24,4 +24,5 @@ namespace OpenRA.Effects
 	public interface ISpatiallyPartitionable { }
 
 	public interface IEffectAboveShroud { IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr); }
+	public interface IEffectAnnotation { IEnumerable<IRenderable> RenderAnnotation(WorldRenderer wr); }
 }

--- a/OpenRA.Game/Graphics/SpriteRenderable.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderable.cs
@@ -64,8 +64,10 @@ namespace OpenRA.Graphics
 
 		public void RenderDebugGeometry(WorldRenderer wr)
 		{
-			var screenOffset = ScreenPosition(wr) + sprite.Offset;
-			Game.Renderer.WorldRgbaColorRenderer.DrawRect(screenOffset, screenOffset + sprite.Size, 1 / wr.Viewport.Zoom, Color.Red);
+			var pos = ScreenPosition(wr) + sprite.Offset;
+			var tl = wr.Viewport.WorldToViewPx(pos);
+			var br = wr.Viewport.WorldToViewPx(pos + sprite.Size);
+			Game.Renderer.RgbaColorRenderer.DrawRect(tl, br, 1, Color.Red);
 		}
 
 		public Rectangle ScreenBounds(WorldRenderer wr)

--- a/OpenRA.Game/Graphics/TargetLineRenderable.cs
+++ b/OpenRA.Game/Graphics/TargetLineRenderable.cs
@@ -46,12 +46,11 @@ namespace OpenRA.Graphics
 			if (!waypoints.Any())
 				return;
 
-			var sw = width / wr.Viewport.Zoom;
-			var first = wr.Screen3DPosition(waypoints.First());
+			var first = wr.Viewport.WorldToViewPx(wr.Screen3DPosition(waypoints.First()));
 			var a = first;
-			foreach (var b in waypoints.Skip(1).Select(pos => wr.Screen3DPosition(pos)))
+			foreach (var b in waypoints.Skip(1).Select(pos => wr.Viewport.WorldToViewPx(wr.Screen3DPosition(pos))))
 			{
-				Game.Renderer.WorldRgbaColorRenderer.DrawLine(a, b, sw, color);
+				Game.Renderer.RgbaColorRenderer.DrawLine(a, b, width, color);
 				DrawTargetMarker(wr, color, b, markerSize);
 				a = b;
 			}
@@ -59,13 +58,12 @@ namespace OpenRA.Graphics
 			DrawTargetMarker(wr, color, first);
 		}
 
-		public static void DrawTargetMarker(WorldRenderer wr, Color color, float3 location, int size = 1)
+		public static void DrawTargetMarker(WorldRenderer wr, Color color, int2 screenPos, int size = 1)
 		{
-			var sw = size / wr.Viewport.Zoom;
-			var offset = new float2(sw, sw);
-			var tl = location - offset;
-			var br = location + offset;
-			Game.Renderer.WorldRgbaColorRenderer.FillRect(tl, br, color);
+			var offset = new int2(size, size);
+			var tl = screenPos - offset;
+			var br = screenPos + offset;
+			Game.Renderer.RgbaColorRenderer.FillRect(tl, br, color);
 		}
 
 		public void RenderDebugGeometry(WorldRenderer wr) { }

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -211,6 +211,7 @@ namespace OpenRA.Graphics
 
 		public int2 ViewToWorldPx(int2 view) { return (1f / Zoom * view.ToFloat2()).ToInt2() + TopLeft; }
 		public int2 WorldToViewPx(int2 world) { return (Zoom * (world - TopLeft).ToFloat2()).ToInt2(); }
+		public int2 WorldToViewPx(float3 world) { return (Zoom * (world - TopLeft).XY).ToInt2(); }
 
 		public void Center(IEnumerable<Actor> actors)
 		{

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -166,12 +166,17 @@ namespace OpenRA.Graphics
 					.Where(t => !t.SpatiallyPartitionable || onScreenActors.Contains(a))
 					.SelectMany(t => t.RenderAnnotations(a, this)));
 
+			var effects = World.Effects.Select(e => e as IEffectAnnotation)
+				.Where(e => e != null)
+				.SelectMany(e => e.RenderAnnotation(this));
+
 			var orderGenerator = SpriteRenderable.None;
 			if (World.OrderGenerator != null)
 				orderGenerator = World.OrderGenerator.RenderAnnotations(this, World);
 
 			return actors
 				.Concat(selected)
+				.Concat(effects)
 				.Concat(orderGenerator)
 				.Select(r => r.PrepareRender(this));
 		}

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -166,8 +166,13 @@ namespace OpenRA.Graphics
 					.Where(t => !t.SpatiallyPartitionable || onScreenActors.Contains(a))
 					.SelectMany(t => t.RenderAnnotations(a, this)));
 
+			var orderGenerator = SpriteRenderable.None;
+			if (World.OrderGenerator != null)
+				orderGenerator = World.OrderGenerator.RenderAnnotations(this, World);
+
 			return actors
 				.Concat(selected)
+				.Concat(orderGenerator)
 				.Select(r => r.PrepareRender(this));
 		}
 

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -247,39 +247,39 @@ namespace OpenRA.Graphics
 				foreach (var r in g)
 					r.Render(this);
 
-			if (debugVis.Value != null && debugVis.Value.RenderGeometry)
-			{
-				for (var i = 0; i < preparedRenderables.Count; i++)
-					preparedRenderables[i].RenderDebugGeometry(this);
-
-				foreach (var g in groupedOverlayRenderables)
-					foreach (var r in g)
-						r.RenderDebugGeometry(this);
-			}
-
-			if (debugVis.Value != null && debugVis.Value.ScreenMap)
-			{
-				foreach (var r in World.ScreenMap.RenderBounds(World.RenderPlayer))
-					Game.Renderer.WorldRgbaColorRenderer.DrawRect(
-						new float3(r.Left, r.Top, r.Bottom),
-						new float3(r.Right, r.Bottom, r.Bottom),
-						1 / Viewport.Zoom, Color.MediumSpringGreen);
-
-				foreach (var r in World.ScreenMap.MouseBounds(World.RenderPlayer))
-					Game.Renderer.WorldRgbaColorRenderer.DrawRect(
-						new float3(r.Left, r.Top, r.Bottom),
-						new float3(r.Right, r.Bottom, r.Bottom),
-						1 / Viewport.Zoom, Color.OrangeRed);
-			}
-
 			Game.Renderer.Flush();
 
 			for (var i = 0; i < preparedAnnotationRenderables.Count; i++)
 				preparedAnnotationRenderables[i].Render(this);
 
 			if (debugVis.Value != null && debugVis.Value.RenderGeometry)
+			{
+				for (var i = 0; i < preparedRenderables.Count; i++)
+					preparedRenderables[i].RenderDebugGeometry(this);
+
+				for (var i = 0; i < preparedOverlayRenderables.Count; i++)
+					preparedOverlayRenderables[i].RenderDebugGeometry(this);
+
 				for (var i = 0; i < preparedAnnotationRenderables.Count; i++)
 					preparedAnnotationRenderables[i].RenderDebugGeometry(this);
+			}
+
+			if (debugVis.Value != null && debugVis.Value.ScreenMap)
+			{
+				foreach (var r in World.ScreenMap.RenderBounds(World.RenderPlayer))
+				{
+					var tl = Viewport.WorldToViewPx(new float2(r.Left, r.Top));
+					var br = Viewport.WorldToViewPx(new float2(r.Right, r.Bottom));
+					Game.Renderer.RgbaColorRenderer.DrawRect(tl, br, 1, Color.MediumSpringGreen);
+				}
+
+				foreach (var r in World.ScreenMap.MouseBounds(World.RenderPlayer))
+				{
+					var tl = Viewport.WorldToViewPx(new float2(r.Left, r.Top));
+					var br = Viewport.WorldToViewPx(new float2(r.Right, r.Bottom));
+					Game.Renderer.RgbaColorRenderer.DrawRect(tl, br, 1, Color.OrangeRed);
+				}
+			}
 
 			Game.Renderer.Flush();
 			preparedRenderables.Clear();

--- a/OpenRA.Game/Orders/IOrderGenerator.cs
+++ b/OpenRA.Game/Orders/IOrderGenerator.cs
@@ -20,6 +20,7 @@ namespace OpenRA
 		void Tick(World world);
 		IEnumerable<IRenderable> Render(WorldRenderer wr, World world);
 		IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world);
+		IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world);
 		string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi);
 		void Deactivate();
 		bool HandleKeyPress(KeyInput e);

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -64,6 +64,7 @@ namespace OpenRA.Orders
 		public virtual void Tick(World world) { }
 		public virtual IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
 		public virtual IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
+		public virtual IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world) { yield break; }
 
 		public virtual string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -427,6 +427,18 @@ namespace OpenRA.Traits
 		bool SpatiallyPartitionable { get; }
 	}
 
+	public interface IRenderAnnotations
+	{
+		IEnumerable<IRenderable> RenderAnnotations(Actor self, WorldRenderer wr);
+		bool SpatiallyPartitionable { get; }
+	}
+
+	public interface IRenderAnnotationsWhenSelected
+	{
+		IEnumerable<IRenderable> RenderAnnotations(Actor self, WorldRenderer wr);
+		bool SpatiallyPartitionable { get; }
+	}
+
 	public interface ISelection
 	{
 		int Hash { get; }

--- a/OpenRA.Mods.Cnc/Effects/GpsDotEffect.cs
+++ b/OpenRA.Mods.Cnc/Effects/GpsDotEffect.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Effects
 {
-	class GpsDotEffect : IEffect, IEffectAboveShroud
+	class GpsDotEffect : IEffect, IEffectAnnotation
 	{
 		readonly Actor actor;
 		readonly GpsDotInfo info;
@@ -97,7 +97,7 @@ namespace OpenRA.Mods.Cnc.Effects
 			return SpriteRenderable.None;
 		}
 
-		IEnumerable<IRenderable> IEffectAboveShroud.RenderAboveShroud(WorldRenderer wr)
+		IEnumerable<IRenderable> IEffectAnnotation.RenderAnnotation(WorldRenderer wr)
 		{
 			if (actor.World.RenderPlayer == null || !dotStates[actor.World.RenderPlayer].Visible)
 				return SpriteRenderable.None;

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -222,6 +222,8 @@ namespace OpenRA.Mods.Cnc.Traits
 				}
 			}
 
+			protected override IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world) { yield break; }
+
 			protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 			{
 				return "ability";

--- a/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
@@ -227,7 +227,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (!self.Trait<PortableChrono>().Info.HasDistanceLimit)
 				yield break;
 
-			yield return new RangeCircleRenderable(
+			yield return new RangeCircleAnnotationRenderable(
 				self.CenterPosition,
 				WDist.FromCells(self.Trait<PortableChrono>().Info.MaxDistance),
 				0,

--- a/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
@@ -215,12 +215,11 @@ namespace OpenRA.Mods.Cnc.Traits
 				world.CancelInputMode();
 		}
 
-		protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world)
-		{
-			yield break;
-		}
+		protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
 
-		protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
+		protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
+
+		protected override IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world)
 		{
 			if (!self.IsInWorld || self.Owner != self.World.LocalPlayer)
 				yield break;

--- a/OpenRA.Mods.Cnc/Traits/Render/RenderJammerCircle.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/RenderJammerCircle.cs
@@ -36,14 +36,14 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			foreach (var a in w.ActorsWithTrait<RenderJammerCircle>())
 				if (a.Actor.Owner.IsAlliedWith(w.RenderPlayer))
-					foreach (var r in a.Trait.RenderAboveShroud(a.Actor, wr))
+					foreach (var r in a.Trait.RenderAnnotations(a.Actor, wr))
 						yield return r;
 		}
 	}
 
-	class RenderJammerCircle : IRenderAboveShroudWhenSelected
+	class RenderJammerCircle : IRenderAnnotationsWhenSelected
 	{
-		public IEnumerable<IRenderable> RenderAboveShroud(Actor self, WorldRenderer wr)
+		public IEnumerable<IRenderable> RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				yield break;
@@ -60,6 +60,6 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return false; } }
+		bool IRenderAnnotationsWhenSelected.SpatiallyPartitionable { get { return false; } }
 	}
 }

--- a/OpenRA.Mods.Cnc/Traits/Render/RenderJammerCircle.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/RenderJammerCircle.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			var jamsMissiles = ai.TraitInfoOrDefault<JamsMissilesInfo>();
 			if (jamsMissiles != null)
 			{
-				yield return new RangeCircleRenderable(
+				yield return new RangeCircleAnnotationRenderable(
 					centerPosition,
 					jamsMissiles.Range,
 					0,
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			var jamsMissiles = self.Info.TraitInfoOrDefault<JamsMissilesInfo>();
 			if (jamsMissiles != null)
 			{
-				yield return new RangeCircleRenderable(
+				yield return new RangeCircleAnnotationRenderable(
 					self.CenterPosition,
 					jamsMissiles.Range,
 					0,

--- a/OpenRA.Mods.Cnc/Traits/Render/RenderJammerCircle.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/RenderJammerCircle.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	// TODO: remove all the Render*Circle duplication
 	class RenderJammerCircleInfo : TraitInfo<RenderJammerCircle>, IPlaceBuildingDecorationInfo
 	{
-		public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
+		public IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
 		{
 			var jamsMissiles = ai.TraitInfoOrDefault<JamsMissilesInfo>();
 			if (jamsMissiles != null)

--- a/OpenRA.Mods.Cnc/Traits/Render/RenderShroudCircle.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/RenderShroudCircle.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Contrast color of the circle.")]
 		public readonly Color ContrastColor = Color.FromArgb(96, Color.Black);
 
-		public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
+		public IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
 		{
 			var localRange = ai.TraitInfos<CreatesShroudInfo>()
 				.Where(csi => csi.EnabledByDefault)

--- a/OpenRA.Mods.Cnc/Traits/Render/RenderShroudCircle.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/RenderShroudCircle.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public object Create(ActorInitializer init) { return new RenderShroudCircle(init.Self, this); }
 	}
 
-	class RenderShroudCircle : INotifyCreated, IRenderAboveShroudWhenSelected
+	class RenderShroudCircle : INotifyCreated, IRenderAnnotationsWhenSelected
 	{
 		readonly RenderShroudCircleInfo info;
 		WDist range;
@@ -82,11 +82,11 @@ namespace OpenRA.Mods.Cnc.Traits
 				info.ContrastColor);
 		}
 
-		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAnnotationsWhenSelected.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			return RangeCircleRenderables(self, wr);
 		}
 
-		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return false; } }
+		bool IRenderAnnotationsWhenSelected.SpatiallyPartitionable { get { return false; } }
 	}
 }

--- a/OpenRA.Mods.Cnc/Traits/Render/RenderShroudCircle.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/RenderShroudCircle.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				.DefaultIfEmpty(WDist.Zero)
 				.Max();
 
-			var localRangeRenderable = new RangeCircleRenderable(
+			var localRangeRenderable = new RangeCircleAnnotationRenderable(
 				centerPosition,
 				localRange,
 				0,
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				yield break;
 
-			yield return new RangeCircleRenderable(
+			yield return new RangeCircleAnnotationRenderable(
 				self.CenterPosition,
 				range,
 				0,

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
@@ -113,8 +113,9 @@ namespace OpenRA.Mods.Cnc.Traits
 		}
 
 		protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
+		protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
 
-		protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
+		protected override IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world)
 		{
 			foreach (var a in instance.Instances.Where(i => !i.IsTraitPaused))
 			{

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
@@ -119,14 +119,14 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			foreach (var a in instance.Instances.Where(i => !i.IsTraitPaused))
 			{
-				yield return new RangeCircleRenderable(
+				yield return new RangeCircleAnnotationRenderable(
 					a.Self.CenterPosition,
 					attack.GetMinimumRange(),
 					0,
 					Color.Red,
 					Color.FromArgb(96, Color.Black));
 
-				yield return new RangeCircleRenderable(
+				yield return new RangeCircleAnnotationRenderable(
 					a.Self.CenterPosition,
 					attack.GetMaximumRange(),
 					0,

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -179,7 +179,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					if (unit.CanBeViewedByPlayer(manager.Self.Owner))
 					{
 						var bounds = unit.TraitsImplementing<IDecorationBounds>().FirstNonEmptyBounds(unit, wr);
-						yield return new SelectionBoxRenderable(unit, bounds, Color.Red);
+						yield return new SelectionBoxAnnotationRenderable(unit, bounds, Color.Red);
 					}
 				}
 			}
@@ -302,7 +302,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					if (unit.CanBeViewedByPlayer(manager.Self.Owner))
 					{
 						var bounds = unit.TraitsImplementing<IDecorationBounds>().FirstNonEmptyBounds(unit, wr);
-						yield return new SelectionBoxRenderable(unit, bounds, Color.Red);
+						yield return new SelectionBoxAnnotationRenderable(unit, bounds, Color.Red);
 					}
 				}
 			}

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -167,7 +167,9 @@ namespace OpenRA.Mods.Cnc.Traits
 					world.CancelInputMode();
 			}
 
-			protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
+			protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
+
+			protected override IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world)
 			{
 				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 				var targetUnits = power.UnitsInRange(xy).Where(a => !world.FogObscures(a));
@@ -291,7 +293,10 @@ namespace OpenRA.Mods.Cnc.Traits
 						foreach (var r in unit.Render(wr))
 							yield return r.OffsetBy(offset);
 				}
+			}
 
+			protected override IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world)
+			{
 				foreach (var unit in power.UnitsInRange(sourceLocation))
 				{
 					if (unit.CanBeViewedByPlayer(manager.Self.Owner))

--- a/OpenRA.Mods.Common/Effects/FloatingText.cs
+++ b/OpenRA.Mods.Common/Effects/FloatingText.cs
@@ -18,7 +18,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.Effects
 {
-	public class FloatingText : IEffect, IEffectAboveShroud
+	public class FloatingText : IEffect, IEffectAnnotation
 	{
 		static readonly WVec Velocity = new WVec(0, 0, 86);
 
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Effects
 			remaining = duration;
 		}
 
-		public void Tick(World world)
+		void IEffect.Tick(World world)
 		{
 			if (--remaining <= 0)
 				world.AddFrameEndTask(w => w.Remove(this));
@@ -45,9 +45,9 @@ namespace OpenRA.Mods.Common.Effects
 			pos += Velocity;
 		}
 
-		public IEnumerable<IRenderable> Render(WorldRenderer wr) { return SpriteRenderable.None; }
+		IEnumerable<IRenderable> IEffect.Render(WorldRenderer wr) { return SpriteRenderable.None; }
 
-		public IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr)
+		IEnumerable<IRenderable> IEffectAnnotation.RenderAnnotation(WorldRenderer wr)
 		{
 			if (wr.World.FogObscures(pos) || wr.World.ShroudObscures(pos))
 				yield break;

--- a/OpenRA.Mods.Common/Effects/FloatingText.cs
+++ b/OpenRA.Mods.Common/Effects/FloatingText.cs
@@ -52,8 +52,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (wr.World.FogObscures(pos) || wr.World.ShroudObscures(pos))
 				yield break;
 
-			// Arbitrary large value used for the z-offset to try and ensure the text displays above everything else.
-			yield return new TextRenderable(font, pos, 4096, color, text);
+			yield return new TextRenderable(font, pos, 0, color, text);
 		}
 
 		public static string FormatCashTick(int cashAmount)

--- a/OpenRA.Mods.Common/Effects/FloatingText.cs
+++ b/OpenRA.Mods.Common/Effects/FloatingText.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (wr.World.FogObscures(pos) || wr.World.ShroudObscures(pos))
 				yield break;
 
-			yield return new TextRenderable(font, pos, 0, color, text);
+			yield return new TextAnnotationRenderable(font, pos, 0, color, text);
 		}
 
 		public static string FormatCashTick(int cashAmount)

--- a/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
@@ -10,13 +10,14 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Effects;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.Common.Effects
 {
-	class RallyPointIndicator : IEffect, IEffectAboveShroud
+	class RallyPointIndicator : IEffect, IEffectAboveShroud, IEffectAnnotation
 	{
 		readonly Actor building;
 		readonly RallyPoint rp;
@@ -92,26 +93,32 @@ namespace OpenRA.Mods.Common.Effects
 			if (!building.World.Selection.Contains(building))
 				return SpriteRenderable.None;
 
-			return RenderInner(wr);
-		}
-
-		IEnumerable<IRenderable> RenderInner(WorldRenderer wr)
-		{
-			if (Game.Settings.Game.TargetLines != TargetLinesType.Disabled)
-				yield return new TargetLineRenderable(targetLine, building.Owner.Color, rp.Info.LineWidth);
-
+			var renderables = SpriteRenderable.None;
 			if (circles != null || flag != null)
 			{
 				var palette = wr.Palette(rp.PaletteName);
-
 				if (circles != null)
-					foreach (var r in circles.Render(targetLine[1], palette))
-						yield return r;
+					renderables = renderables.Concat(circles.Render(targetLine[1], palette));
 
 				if (flag != null)
-					foreach (var r in flag.Render(targetLine[1], palette))
-						yield return r;
+					renderables = renderables.Concat(flag.Render(targetLine[1], palette));
 			}
+
+			return renderables;
+		}
+
+		IEnumerable<IRenderable> IEffectAnnotation.RenderAnnotation(WorldRenderer wr)
+		{
+			if (Game.Settings.Game.TargetLines == TargetLinesType.Disabled)
+				return SpriteRenderable.None;
+
+			if (!building.IsInWorld || !building.Owner.IsAlliedWith(building.World.LocalPlayer))
+				return SpriteRenderable.None;
+
+			if (!building.World.Selection.Contains(building))
+				return SpriteRenderable.None;
+
+			return new IRenderable[] { new TargetLineRenderable(targetLine, building.Owner.Color, rp.Info.LineWidth) };
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Effects/SpriteAnnotation.cs
+++ b/OpenRA.Mods.Common/Effects/SpriteAnnotation.cs
@@ -1,0 +1,48 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using OpenRA.Effects;
+using OpenRA.Graphics;
+
+namespace OpenRA.Mods.Common.Effects
+{
+	public class SpriteAnnotation : IEffect, IEffectAnnotation
+	{
+		readonly string palette;
+		readonly Animation anim;
+		readonly WPos pos;
+
+		public SpriteAnnotation(WPos pos, World world, string image, string sequence, string palette)
+		{
+			this.palette = palette;
+			this.pos = pos;
+			anim = new Animation(world, image);
+			anim.PlayThen(sequence, () => world.AddFrameEndTask(w => { w.Remove(this); w.ScreenMap.Remove(this); }));
+			world.ScreenMap.Add(this, pos, anim.Image);
+		}
+
+		void IEffect.Tick(World world)
+		{
+			anim.Tick();
+			world.ScreenMap.Update(this, pos, anim.Image);
+		}
+
+		IEnumerable<IRenderable> IEffect.Render(WorldRenderer wr) { yield break; }
+
+		IEnumerable<IRenderable> IEffectAnnotation.RenderAnnotation(WorldRenderer wr)
+		{
+			var screenPos = wr.Viewport.WorldToViewPx(wr.ScreenPxPosition(pos));
+			return anim.RenderUI(screenPos, WVec.Zero, 0, wr.Palette(palette), 1f);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Effects/SpriteEffect.cs
+++ b/OpenRA.Mods.Common/Effects/SpriteEffect.cs
@@ -23,24 +23,22 @@ namespace OpenRA.Mods.Common.Effects
 		readonly Animation anim;
 		readonly Func<WPos> posFunc;
 		readonly bool visibleThroughFog;
-		readonly bool scaleSizeWithZoom;
 		WPos pos;
 
 		// Facing is last on these overloads partially for backwards compatibility with previous main ctor revision
 		// and partially because most effects don't need it.
-		public SpriteEffect(WPos pos, World world, string image, string sequence, string palette, bool visibleThroughFog = false, bool scaleSizeWithZoom = false, int facing = 0)
-			: this(() => pos, () => facing, world, image, sequence, palette, visibleThroughFog, scaleSizeWithZoom) { }
+		public SpriteEffect(WPos pos, World world, string image, string sequence, string palette, bool visibleThroughFog = false, int facing = 0)
+			: this(() => pos, () => facing, world, image, sequence, palette, visibleThroughFog) { }
 
-		public SpriteEffect(Actor actor, World world, string image, string sequence, string palette, bool visibleThroughFog = false, bool scaleSizeWithZoom = false, int facing = 0)
-			: this(() => actor.CenterPosition, () => facing, world, image, sequence, palette, visibleThroughFog, scaleSizeWithZoom) { }
+		public SpriteEffect(Actor actor, World world, string image, string sequence, string palette, bool visibleThroughFog = false, int facing = 0)
+			: this(() => actor.CenterPosition, () => facing, world, image, sequence, palette, visibleThroughFog) { }
 
 		public SpriteEffect(Func<WPos> posFunc, Func<int> facingFunc, World world, string image, string sequence, string palette,
-			bool visibleThroughFog = false, bool scaleSizeWithZoom = false)
+			bool visibleThroughFog = false)
 		{
 			this.world = world;
 			this.posFunc = posFunc;
 			this.palette = palette;
-			this.scaleSizeWithZoom = scaleSizeWithZoom;
 			this.visibleThroughFog = visibleThroughFog;
 			pos = posFunc();
 			anim = new Animation(world, image, facingFunc);
@@ -61,8 +59,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (!visibleThroughFog && world.FogObscures(pos))
 				return SpriteRenderable.None;
 
-			var zoom = scaleSizeWithZoom ? 1f / wr.Viewport.Zoom : 1f;
-			return anim.Render(pos, WVec.Zero, 0, wr.Palette(palette), zoom);
+			return anim.Render(pos, wr.Palette(palette));
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Graphics/CircleAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/CircleAnnotationRenderable.cs
@@ -47,23 +47,23 @@ namespace OpenRA.Mods.Common.Graphics
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
 		public void Render(WorldRenderer wr)
 		{
-			var wcr = Game.Renderer.WorldRgbaColorRenderer;
+			var cr = Game.Renderer.RgbaColorRenderer;
 			if (filled)
 			{
 				var offset = new WVec(radius.Length, radius.Length, 0);
-				var tl = wr.Screen3DPosition(centerPosition - offset);
-				var br = wr.Screen3DPosition(centerPosition + offset);
+				var tl = wr.Viewport.WorldToViewPx(wr.ScreenPosition(centerPosition - offset));
+				var br = wr.Viewport.WorldToViewPx(wr.ScreenPosition(centerPosition + offset));
 
-				wcr.FillEllipse(tl, br, color);
+				cr.FillEllipse(tl, br, color);
 			}
 			else
 			{
 				var r = radius.Length;
-				var a = wr.Screen3DPosition(centerPosition + r * FacingOffsets[CircleSegments - 1] / 1024);
+				var a = wr.Viewport.WorldToViewPx(wr.ScreenPosition(centerPosition + r * FacingOffsets[CircleSegments - 1] / 1024));
 				for (var i = 0; i < CircleSegments; i++)
 				{
-					var b = wr.Screen3DPosition(centerPosition + r * FacingOffsets[i] / 1024);
-					wcr.DrawLine(a, b, width / wr.Viewport.Zoom, color);
+					var b = wr.Viewport.WorldToViewPx(wr.ScreenPosition(centerPosition + r * FacingOffsets[i] / 1024));
+					cr.DrawLine(a, b, width, color);
 					a = b;
 				}
 			}

--- a/OpenRA.Mods.Common/Graphics/DetectionCircleAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/DetectionCircleAnnotationRenderable.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Graphics
 				wcr.DrawLine(center, end, 1, Color.FromArgb(alpha, color));
 			}
 
-			RangeCircleRenderable.DrawRangeCircle(wr, centerPosition, radius, 1, color, 3, contrastColor);
+			RangeCircleAnnotationRenderable.DrawRangeCircle(wr, centerPosition, radius, 1, color, 3, contrastColor);
 		}
 
 		public void RenderDebugGeometry(WorldRenderer wr) { }

--- a/OpenRA.Mods.Common/Graphics/DetectionCircleAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/DetectionCircleAnnotationRenderable.cs
@@ -14,7 +14,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.Graphics
 {
-	public struct DetectionCircleRenderable : IRenderable, IFinalizedRenderable
+	public struct DetectionCircleAnnotationRenderable : IRenderable, IFinalizedRenderable
 	{
 		readonly WPos centerPosition;
 		readonly WDist radius;
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Graphics
 		readonly Color color;
 		readonly Color contrastColor;
 
-		public DetectionCircleRenderable(WPos centerPosition, WDist radius, int zOffset,
+		public DetectionCircleAnnotationRenderable(WPos centerPosition, WDist radius, int zOffset,
 			int lineTrails, WAngle trailSeparation, WAngle trailAngle, Color color, Color contrastColor)
 		{
 			this.centerPosition = centerPosition;
@@ -45,19 +45,19 @@ namespace OpenRA.Mods.Common.Graphics
 
 		public IRenderable WithPalette(PaletteReference newPalette)
 		{
-			return new DetectionCircleRenderable(centerPosition, radius, zOffset,
+			return new DetectionCircleAnnotationRenderable(centerPosition, radius, zOffset,
 				trailCount, trailSeparation, trailAngle, color, contrastColor);
 		}
 
 		public IRenderable WithZOffset(int newOffset)
 		{
-			return new DetectionCircleRenderable(centerPosition, radius, newOffset,
+			return new DetectionCircleAnnotationRenderable(centerPosition, radius, newOffset,
 				trailCount, trailSeparation, trailAngle, color, contrastColor);
 		}
 
 		public IRenderable OffsetBy(WVec vec)
 		{
-			return new DetectionCircleRenderable(centerPosition + vec, radius, zOffset,
+			return new DetectionCircleAnnotationRenderable(centerPosition + vec, radius, zOffset,
 				trailCount, trailSeparation, trailAngle, color, contrastColor);
 		}
 

--- a/OpenRA.Mods.Common/Graphics/LineAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/LineAnnotationRenderable.cs
@@ -52,7 +52,10 @@ namespace OpenRA.Mods.Common.Graphics
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
 		public void Render(WorldRenderer wr)
 		{
-			Game.Renderer.WorldRgbaColorRenderer.DrawLine(wr.Screen3DPosition(start), wr.Screen3DPosition(end), width / wr.Viewport.Zoom, startColor, endColor);
+			Game.Renderer.RgbaColorRenderer.DrawLine(
+				wr.Viewport.WorldToViewPx(wr.ScreenPosition(start)),
+				wr.Viewport.WorldToViewPx(wr.Screen3DPosition(end)),
+				width, startColor, endColor);
 		}
 
 		public void RenderDebugGeometry(WorldRenderer wr) { }

--- a/OpenRA.Mods.Common/Graphics/PolygonAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/PolygonAnnotationRenderable.cs
@@ -43,8 +43,8 @@ namespace OpenRA.Mods.Common.Graphics
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
 		public void Render(WorldRenderer wr)
 		{
-			var verts = vertices.Select(wr.Screen3DPosition).ToArray();
-			Game.Renderer.WorldRgbaColorRenderer.DrawPolygon(verts, width / wr.Viewport.Zoom, color);
+			var verts = vertices.Select(v => wr.Viewport.WorldToViewPx(wr.ScreenPosition(v)).ToFloat2()).ToArray();
+			Game.Renderer.RgbaColorRenderer.DrawPolygon(verts, width, color);
 		}
 
 		public void RenderDebugGeometry(WorldRenderer wr) { }

--- a/OpenRA.Mods.Common/Graphics/RangeCircleAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/RangeCircleAnnotationRenderable.cs
@@ -14,7 +14,7 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.Graphics
 {
-	public struct RangeCircleRenderable : IRenderable, IFinalizedRenderable
+	public struct RangeCircleAnnotationRenderable : IRenderable, IFinalizedRenderable
 	{
 		const int RangeCircleSegments = 32;
 		static readonly Int32Matrix4x4[] RangeCircleStartRotations = Exts.MakeArray(RangeCircleSegments, i => WRot.FromFacing(8 * i).AsMatrix());
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Graphics
 		readonly Color color;
 		readonly Color contrastColor;
 
-		public RangeCircleRenderable(WPos centerPosition, WDist radius, int zOffset, Color color, Color contrastColor)
+		public RangeCircleAnnotationRenderable(WPos centerPosition, WDist radius, int zOffset, Color color, Color contrastColor)
 		{
 			this.centerPosition = centerPosition;
 			this.radius = radius;
@@ -40,9 +40,9 @@ namespace OpenRA.Mods.Common.Graphics
 		public int ZOffset { get { return zOffset; } }
 		public bool IsDecoration { get { return true; } }
 
-		public IRenderable WithPalette(PaletteReference newPalette) { return new RangeCircleRenderable(centerPosition, radius, zOffset, color, contrastColor); }
-		public IRenderable WithZOffset(int newOffset) { return new RangeCircleRenderable(centerPosition, radius, newOffset, color, contrastColor); }
-		public IRenderable OffsetBy(WVec vec) { return new RangeCircleRenderable(centerPosition + vec, radius, zOffset, color, contrastColor); }
+		public IRenderable WithPalette(PaletteReference newPalette) { return new RangeCircleAnnotationRenderable(centerPosition, radius, zOffset, color, contrastColor); }
+		public IRenderable WithZOffset(int newOffset) { return new RangeCircleAnnotationRenderable(centerPosition, radius, newOffset, color, contrastColor); }
+		public IRenderable OffsetBy(WVec vec) { return new RangeCircleAnnotationRenderable(centerPosition + vec, radius, zOffset, color, contrastColor); }
 		public IRenderable AsDecoration() { return this; }
 
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }

--- a/OpenRA.Mods.Common/Graphics/RangeCircleRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/RangeCircleRenderable.cs
@@ -54,18 +54,18 @@ namespace OpenRA.Mods.Common.Graphics
 		public static void DrawRangeCircle(WorldRenderer wr, WPos centerPosition, WDist radius,
 			float width, Color color, float contrastWidth, Color contrastColor)
 		{
-			var wcr = Game.Renderer.WorldRgbaColorRenderer;
+			var cr = Game.Renderer.RgbaColorRenderer;
 			var offset = new WVec(radius.Length, 0, 0);
 			for (var i = 0; i < RangeCircleSegments; i++)
 			{
-				var a = wr.Screen3DPosition(centerPosition + offset.Rotate(ref RangeCircleStartRotations[i]));
-				var b = wr.Screen3DPosition(centerPosition + offset.Rotate(ref RangeCircleEndRotations[i]));
+				var a = wr.Viewport.WorldToViewPx(wr.ScreenPosition(centerPosition + offset.Rotate(ref RangeCircleStartRotations[i])));
+				var b = wr.Viewport.WorldToViewPx(wr.ScreenPosition(centerPosition + offset.Rotate(ref RangeCircleEndRotations[i])));
 
 				if (contrastWidth > 0)
-					wcr.DrawLine(a, b, contrastWidth / wr.Viewport.Zoom, contrastColor);
+					cr.DrawLine(a, b, contrastWidth, contrastColor);
 
 				if (width > 0)
-					wcr.DrawLine(a, b, width / wr.Viewport.Zoom, color);
+					cr.DrawLine(a, b, width, color);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Graphics/SelectionBarsAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBarsAnnotationRenderable.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Graphics
 {
-	public struct SelectionBarsRenderable : IRenderable, IFinalizedRenderable
+	public struct SelectionBarsAnnotationRenderable : IRenderable, IFinalizedRenderable
 	{
 		readonly WPos pos;
 		readonly Actor actor;
@@ -23,14 +23,14 @@ namespace OpenRA.Mods.Common.Graphics
 		readonly bool displayExtra;
 		readonly Rectangle decorationBounds;
 
-		public SelectionBarsRenderable(Actor actor, Rectangle decorationBounds, bool displayHealth, bool displayExtra)
+		public SelectionBarsAnnotationRenderable(Actor actor, Rectangle decorationBounds, bool displayHealth, bool displayExtra)
 			: this(actor.CenterPosition, actor, decorationBounds)
 		{
 			this.displayHealth = displayHealth;
 			this.displayExtra = displayExtra;
 		}
 
-		public SelectionBarsRenderable(WPos pos, Actor actor, Rectangle decorationBounds)
+		public SelectionBarsAnnotationRenderable(WPos pos, Actor actor, Rectangle decorationBounds)
 			: this()
 		{
 			this.pos = pos;
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Graphics
 
 		public IRenderable WithPalette(PaletteReference newPalette) { return this; }
 		public IRenderable WithZOffset(int newOffset) { return this; }
-		public IRenderable OffsetBy(WVec vec) { return new SelectionBarsRenderable(pos + vec, actor, decorationBounds); }
+		public IRenderable OffsetBy(WVec vec) { return new SelectionBarsAnnotationRenderable(pos + vec, actor, decorationBounds); }
 		public IRenderable AsDecoration() { return this; }
 
 		void DrawExtraBars(WorldRenderer wr, float2 start, float2 end)

--- a/OpenRA.Mods.Common/Graphics/SelectionBarsRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBarsRenderable.cs
@@ -51,14 +51,14 @@ namespace OpenRA.Mods.Common.Graphics
 		public IRenderable OffsetBy(WVec vec) { return new SelectionBarsRenderable(pos + vec, actor, decorationBounds); }
 		public IRenderable AsDecoration() { return this; }
 
-		void DrawExtraBars(WorldRenderer wr, float3 start, float3 end)
+		void DrawExtraBars(WorldRenderer wr, float2 start, float2 end)
 		{
 			foreach (var extraBar in actor.TraitsImplementing<ISelectionBar>())
 			{
 				var value = extraBar.GetValue();
 				if (value != 0 || extraBar.DisplayWhenEmpty)
 				{
-					var offset = new float3(0, (int)(4 / wr.Viewport.Zoom), 0);
+					var offset = new float2(0, 4);
 					start += offset;
 					end += offset;
 					DrawSelectionBar(wr, start, end, extraBar.GetValue(), extraBar.GetColor());
@@ -66,48 +66,46 @@ namespace OpenRA.Mods.Common.Graphics
 			}
 		}
 
-		void DrawSelectionBar(WorldRenderer wr, float3 start, float3 end, float value, Color barColor)
+		void DrawSelectionBar(WorldRenderer wr, float2 start, float2 end, float value, Color barColor)
 		{
-			var iz = 1 / wr.Viewport.Zoom;
 			var c = Color.FromArgb(128, 30, 30, 30);
 			var c2 = Color.FromArgb(128, 10, 10, 10);
-			var p = new float2(0, -4 * iz);
-			var q = new float2(0, -3 * iz);
-			var r = new float2(0, -2 * iz);
+			var p = new float2(0, -4);
+			var q = new float2(0, -3);
+			var r = new float2(0, -2);
 
 			var barColor2 = Color.FromArgb(255, barColor.R / 2, barColor.G / 2, barColor.B / 2);
 
 			var z = float3.Lerp(start, end, value);
-			var wcr = Game.Renderer.WorldRgbaColorRenderer;
-			wcr.DrawLine(start + p, end + p, iz, c);
-			wcr.DrawLine(start + q, end + q, iz, c2);
-			wcr.DrawLine(start + r, end + r, iz, c);
+			var cr = Game.Renderer.RgbaColorRenderer;
+			cr.DrawLine(start + p, end + p, 1, c);
+			cr.DrawLine(start + q, end + q, 1, c2);
+			cr.DrawLine(start + r, end + r, 1, c);
 
-			wcr.DrawLine(start + p, z + p, iz, barColor2);
-			wcr.DrawLine(start + q, z + q, iz, barColor);
-			wcr.DrawLine(start + r, z + r, iz, barColor2);
+			cr.DrawLine(start + p, z + p, 1, barColor2);
+			cr.DrawLine(start + q, z + q, 1, barColor);
+			cr.DrawLine(start + r, z + r, 1, barColor2);
 		}
 
 		Color GetHealthColor(IHealth health)
 		{
 			if (Game.Settings.Game.UsePlayerStanceColors)
 				return actor.Owner.PlayerStanceColor(actor);
-			else
-				return health.DamageState == DamageState.Critical ? Color.Red :
-					health.DamageState == DamageState.Heavy ? Color.Yellow : Color.LimeGreen;
+
+			return health.DamageState == DamageState.Critical ? Color.Red :
+				health.DamageState == DamageState.Heavy ? Color.Yellow : Color.LimeGreen;
 		}
 
-		void DrawHealthBar(WorldRenderer wr, IHealth health, float3 start, float3 end)
+		void DrawHealthBar(WorldRenderer wr, IHealth health, float2 start, float2 end)
 		{
 			if (health == null || health.IsDead)
 				return;
 
 			var c = Color.FromArgb(128, 30, 30, 30);
 			var c2 = Color.FromArgb(128, 10, 10, 10);
-			var iz = 1 / wr.Viewport.Zoom;
-			var p = new float2(0, -4 * iz);
-			var q = new float2(0, -3 * iz);
-			var r = new float2(0, -2 * iz);
+			var p = new float2(0, -4);
+			var q = new float2(0, -3);
+			var r = new float2(0, -2);
 
 			var healthColor = GetHealthColor(health);
 			var healthColor2 = Color.FromArgb(
@@ -118,14 +116,14 @@ namespace OpenRA.Mods.Common.Graphics
 
 			var z = float3.Lerp(start, end, (float)health.HP / health.MaxHP);
 
-			var wcr = Game.Renderer.WorldRgbaColorRenderer;
-			wcr.DrawLine(start + p, end + p, iz, c);
-			wcr.DrawLine(start + q, end + q, iz, c2);
-			wcr.DrawLine(start + r, end + r, iz, c);
+			var cr = Game.Renderer.RgbaColorRenderer;
+			cr.DrawLine(start + p, end + p, 1, c);
+			cr.DrawLine(start + q, end + q, 1, c2);
+			cr.DrawLine(start + r, end + r, 1, c);
 
-			wcr.DrawLine(start + p, z + p, iz, healthColor2);
-			wcr.DrawLine(start + q, z + q, iz, healthColor);
-			wcr.DrawLine(start + r, z + r, iz, healthColor2);
+			cr.DrawLine(start + p, z + p, 1, healthColor2);
+			cr.DrawLine(start + q, z + q, 1, healthColor);
+			cr.DrawLine(start + r, z + r, 1, healthColor2);
 
 			if (health.DisplayHP != health.HP)
 			{
@@ -137,9 +135,9 @@ namespace OpenRA.Mods.Common.Graphics
 					deltaColor.B / 2);
 				var zz = float3.Lerp(start, end, (float)health.DisplayHP / health.MaxHP);
 
-				wcr.DrawLine(z + p, zz + p, iz, deltaColor2);
-				wcr.DrawLine(z + q, zz + q, iz, deltaColor);
-				wcr.DrawLine(z + r, zz + r, iz, deltaColor2);
+				cr.DrawLine(z + p, zz + p, 1, deltaColor2);
+				cr.DrawLine(z + q, zz + q, 1, deltaColor);
+				cr.DrawLine(z + r, zz + r, 1, deltaColor2);
 			}
 		}
 
@@ -150,10 +148,8 @@ namespace OpenRA.Mods.Common.Graphics
 				return;
 
 			var health = actor.TraitOrDefault<IHealth>();
-
-			var screenPos = wr.Screen3DPxPosition(pos);
-			var start = new float3(decorationBounds.Left + 1, decorationBounds.Top, screenPos.Z);
-			var end = new float3(decorationBounds.Right - 1, decorationBounds.Top, screenPos.Z);
+			var start = wr.Viewport.WorldToViewPx(new float2(decorationBounds.Left + 1, decorationBounds.Top));
+			var end = wr.Viewport.WorldToViewPx(new float2(decorationBounds.Right - 1, decorationBounds.Top));
 
 			if (DisplayHealth)
 				DrawHealthBar(wr, health, start, end);

--- a/OpenRA.Mods.Common/Graphics/SelectionBoxAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBoxAnnotationRenderable.cs
@@ -14,16 +14,16 @@ using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.Graphics
 {
-	public struct SelectionBoxRenderable : IRenderable, IFinalizedRenderable
+	public struct SelectionBoxAnnotationRenderable : IRenderable, IFinalizedRenderable
 	{
 		readonly WPos pos;
 		readonly Rectangle decorationBounds;
 		readonly Color color;
 
-		public SelectionBoxRenderable(Actor actor, Rectangle decorationBounds, Color color)
+		public SelectionBoxAnnotationRenderable(Actor actor, Rectangle decorationBounds, Color color)
 			: this(actor.CenterPosition, decorationBounds, color) { }
 
-		public SelectionBoxRenderable(WPos pos, Rectangle decorationBounds, Color color)
+		public SelectionBoxAnnotationRenderable(WPos pos, Rectangle decorationBounds, Color color)
 		{
 			this.pos = pos;
 			this.decorationBounds = decorationBounds;
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Graphics
 
 		public IRenderable WithPalette(PaletteReference newPalette) { return this; }
 		public IRenderable WithZOffset(int newOffset) { return this; }
-		public IRenderable OffsetBy(WVec vec) { return new SelectionBoxRenderable(pos + vec, decorationBounds, color); }
+		public IRenderable OffsetBy(WVec vec) { return new SelectionBoxAnnotationRenderable(pos + vec, decorationBounds, color); }
 		public IRenderable AsDecoration() { return this; }
 
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }

--- a/OpenRA.Mods.Common/Graphics/SelectionBoxRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBoxRenderable.cs
@@ -44,20 +44,18 @@ namespace OpenRA.Mods.Common.Graphics
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
 		public void Render(WorldRenderer wr)
 		{
-			var iz = 1 / wr.Viewport.Zoom;
-			var screenDepth = wr.Screen3DPxPosition(pos).Z;
-			var tl = new float3(decorationBounds.Left, decorationBounds.Top, screenDepth);
-			var br = new float3(decorationBounds.Right, decorationBounds.Bottom, screenDepth);
-			var tr = new float3(br.X, tl.Y, screenDepth);
-			var bl = new float3(tl.X, br.Y, screenDepth);
-			var u = new float2(4 * iz, 0);
-			var v = new float2(0, 4 * iz);
+			var tl = wr.Viewport.WorldToViewPx(new float2(decorationBounds.Left, decorationBounds.Top)).ToFloat2();
+			var br = wr.Viewport.WorldToViewPx(new float2(decorationBounds.Right, decorationBounds.Bottom)).ToFloat2();
+			var tr = new float2(br.X, tl.Y);
+			var bl = new float2(tl.X, br.Y);
+			var u = new float2(4, 0);
+			var v = new float2(0, 4);
 
-			var wcr = Game.Renderer.WorldRgbaColorRenderer;
-			wcr.DrawLine(new[] { tl + u, tl, tl + v }, iz, color, true);
-			wcr.DrawLine(new[] { tr - u, tr, tr + v }, iz, color, true);
-			wcr.DrawLine(new[] { br - u, br, br - v }, iz, color, true);
-			wcr.DrawLine(new[] { bl + u, bl, bl - v }, iz, color, true);
+			var cr = Game.Renderer.RgbaColorRenderer;
+			cr.DrawLine(new float3[] { tl + u, tl, tl + v }, 1, color, true);
+			cr.DrawLine(new float3[] { tr - u, tr, tr + v }, 1, color, true);
+			cr.DrawLine(new float3[] { br - u, br, br - v }, 1, color, true);
+			cr.DrawLine(new float3[] { bl + u, bl, bl - v }, 1, color, true);
 		}
 
 		public void RenderDebugGeometry(WorldRenderer wr) { }

--- a/OpenRA.Mods.Common/Graphics/TextAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/TextAnnotationRenderable.cs
@@ -16,7 +16,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Graphics
 {
-	public struct TextRenderable : IRenderable, IFinalizedRenderable
+	public struct TextAnnotationRenderable : IRenderable, IFinalizedRenderable
 	{
 		readonly SpriteFont font;
 		readonly WPos pos;
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Graphics
 		readonly Color bgLight;
 		readonly string text;
 
-		public TextRenderable(SpriteFont font, WPos pos, int zOffset, Color color, Color bgDark, Color bgLight, string text)
+		public TextAnnotationRenderable(SpriteFont font, WPos pos, int zOffset, Color color, Color bgDark, Color bgLight, string text)
 		{
 			this.font = font;
 			this.pos = pos;
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Graphics
 			this.text = text;
 		}
 
-		public TextRenderable(SpriteFont font, WPos pos, int zOffset, Color color, string text)
+		public TextAnnotationRenderable(SpriteFont font, WPos pos, int zOffset, Color color, string text)
 			: this(font, pos, zOffset, color,
 				ChromeMetrics.Get<Color>("TextContrastColorDark"),
 				ChromeMetrics.Get<Color>("TextContrastColorLight"),
@@ -48,9 +48,9 @@ namespace OpenRA.Mods.Common.Graphics
 		public int ZOffset { get { return zOffset; } }
 		public bool IsDecoration { get { return true; } }
 
-		public IRenderable WithPalette(PaletteReference newPalette) { return new TextRenderable(font, pos, zOffset, color, text); }
-		public IRenderable WithZOffset(int newOffset) { return new TextRenderable(font, pos, zOffset, color, text); }
-		public IRenderable OffsetBy(WVec vec) { return new TextRenderable(font, pos + vec, zOffset, color, text); }
+		public IRenderable WithPalette(PaletteReference newPalette) { return new TextAnnotationRenderable(font, pos, zOffset, color, text); }
+		public IRenderable WithZOffset(int newOffset) { return new TextAnnotationRenderable(font, pos, zOffset, color, text); }
+		public IRenderable OffsetBy(WVec vec) { return new TextAnnotationRenderable(font, pos + vec, zOffset, color, text); }
 		public IRenderable AsDecoration() { return this; }
 
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }

--- a/OpenRA.Mods.Common/Graphics/TextRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/TextRenderable.cs
@@ -56,16 +56,15 @@ namespace OpenRA.Mods.Common.Graphics
 		public IFinalizedRenderable PrepareRender(WorldRenderer wr) { return this; }
 		public void Render(WorldRenderer wr)
 		{
-			var screenPos = wr.Viewport.Zoom * (wr.ScreenPosition(pos) - wr.Viewport.TopLeft.ToFloat2()) - 0.5f * font.Measure(text).ToFloat2();
-			var screenPxPos = new float2((float)Math.Round(screenPos.X), (float)Math.Round(screenPos.Y));
-			font.DrawTextWithContrast(text, screenPxPos, color, bgDark, bgLight, 1);
+			var screenPos = wr.Viewport.WorldToViewPx(wr.ScreenPosition(pos)) - 0.5f * font.Measure(text).ToFloat2();
+			font.DrawTextWithContrast(text, screenPos, color, bgDark, bgLight, 1);
 		}
 
 		public void RenderDebugGeometry(WorldRenderer wr)
 		{
 			var size = font.Measure(text).ToFloat2();
-			var offset = wr.Screen3DPxPosition(pos) - 0.5f * size;
-			Game.Renderer.WorldRgbaColorRenderer.DrawRect(offset, offset + size, 1 / wr.Viewport.Zoom, Color.Red);
+			var screenPos = wr.Viewport.WorldToViewPx(wr.ScreenPosition(pos));
+			Game.Renderer.RgbaColorRenderer.DrawRect(screenPos - 0.5f * size, screenPos + 0.5f * size, 1, Color.Red);
 		}
 
 		public Rectangle ScreenBounds(WorldRenderer wr) { return Rectangle.Empty; }

--- a/OpenRA.Mods.Common/Orders/BeaconOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/BeaconOrderGenerator.cs
@@ -28,6 +28,7 @@ namespace OpenRA.Mods.Common.Orders
 		protected override void Tick(World world) { }
 		protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
 		protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
+		protected override IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world) { yield break; }
 		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			return "ability";

--- a/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/GlobalButtonOrderGenerator.cs
@@ -63,6 +63,7 @@ namespace OpenRA.Mods.Common.Orders
 
 		protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
 		protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
+		protected override IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world) { yield break; }
 
 		protected abstract override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi);
 	}

--- a/OpenRA.Mods.Common/Orders/OrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/OrderGenerator.cs
@@ -28,6 +28,7 @@ namespace OpenRA.Mods.Common.Orders
 		void IOrderGenerator.Tick(World world) { Tick(world); }
 		IEnumerable<IRenderable> IOrderGenerator.Render(WorldRenderer wr, World world) { return Render(wr, world); }
 		IEnumerable<IRenderable> IOrderGenerator.RenderAboveShroud(WorldRenderer wr, World world) { return RenderAboveShroud(wr, world); }
+		IEnumerable<IRenderable> IOrderGenerator.RenderAnnotations(WorldRenderer wr, World world) { return RenderAnnotations(wr, world); }
 		string IOrderGenerator.GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi) { return GetCursor(world, cell, worldPixel, mi); }
 		void IOrderGenerator.Deactivate() { }
 		bool IOrderGenerator.HandleKeyPress(KeyInput e) { return false; }
@@ -35,6 +36,7 @@ namespace OpenRA.Mods.Common.Orders
 		protected abstract void Tick(World world);
 		protected abstract IEnumerable<IRenderable> Render(WorldRenderer wr, World world);
 		protected abstract IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world);
+		protected abstract IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world);
 		protected abstract string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi);
 		protected abstract IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi);
 	}

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -34,6 +34,7 @@ namespace OpenRA.Mods.Common.Orders
 		int2 TopLeftScreenOffset { get; }
 		void Tick();
 		IEnumerable<IRenderable> Render(WorldRenderer wr, CPos topLeft, Dictionary<CPos, PlaceBuildingCellType> footprint);
+		IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, CPos topLeft);
 	}
 
 	public class PlaceBuildingOrderGenerator : IOrderGenerator
@@ -281,7 +282,11 @@ namespace OpenRA.Mods.Common.Orders
 			return preview != null ? preview.Render(wr, topLeft, footprint) : Enumerable.Empty<IRenderable>();
 		}
 
-		IEnumerable<IRenderable> IOrderGenerator.RenderAnnotations(WorldRenderer wr, World world) { yield break; }
+		IEnumerable<IRenderable> IOrderGenerator.RenderAnnotations(WorldRenderer wr, World world)
+		{
+			var preview = variants[variant].Preview;
+			return preview != null ? preview.RenderAnnotations(wr, TopLeft) : Enumerable.Empty<IRenderable>();
+		}
 
 		string IOrderGenerator.GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi) { return "default"; }
 

--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -281,6 +281,8 @@ namespace OpenRA.Mods.Common.Orders
 			return preview != null ? preview.Render(wr, topLeft, footprint) : Enumerable.Empty<IRenderable>();
 		}
 
+		IEnumerable<IRenderable> IOrderGenerator.RenderAnnotations(WorldRenderer wr, World world) { yield break; }
+
 		string IOrderGenerator.GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi) { return "default"; }
 
 		bool IOrderGenerator.HandleKeyPress(KeyInput e)

--- a/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
@@ -85,6 +85,7 @@ namespace OpenRA.Mods.Common.Orders
 
 		protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
 		protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
+		protected override IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world) { yield break; }
 
 		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -211,7 +211,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			{
 				var delayedPos = WPos.LerpQuadratic(source, target, angle, ticks - info.TrailDelay, length);
 				world.AddFrameEndTask(w => w.Add(new SpriteEffect(delayedPos, w, info.TrailImage, info.TrailSequences.Random(world.SharedRandom),
-					trailPalette, false, false, GetEffectiveFacing())));
+					trailPalette, facing: GetEffectiveFacing())));
 
 				smokeTicks = info.TrailInterval;
 			}

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -858,7 +858,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			if (!string.IsNullOrEmpty(info.TrailImage) && --ticksToNextSmoke < 0 && (state != States.Freefall || info.TrailWhenDeactivated))
 			{
 				world.AddFrameEndTask(w => w.Add(new SpriteEffect(pos - 3 * move / 2, w, info.TrailImage, info.TrailSequences.Random(world.SharedRandom),
-					trailPalette, false, false, renderFacing)));
+					trailPalette, facing: renderFacing)));
 
 				ticksToNextSmoke = info.TrailInterval;
 			}

--- a/OpenRA.Mods.Common/Projectiles/NukeLaunch.cs
+++ b/OpenRA.Mods.Common/Projectiles/NukeLaunch.cs
@@ -118,7 +118,7 @@ namespace OpenRA.Mods.Common.Effects
 					: WPos.LerpQuadratic(descendSource, descendTarget, WAngle.Zero, ticks - turn - trailDelay, impactDelay - turn);
 
 				world.AddFrameEndTask(w => w.Add(new SpriteEffect(trailPos, w, trailImage, trailSequences.Random(world.SharedRandom),
-					trailPalette, false, false, 0)));
+					trailPalette)));
 
 				trailTicks = trailInterval;
 			}

--- a/OpenRA.Mods.Common/Traits/Buildings/ActorPreviewPlaceBuildingPreview.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ActorPreviewPlaceBuildingPreview.cs
@@ -91,9 +91,6 @@ namespace OpenRA.Mods.Common.Traits
 			if (palette != null)
 				previewRenderables = previewRenderables.Select(a => a.IsDecoration ? a : a.WithPalette(palette));
 
-			foreach (var r in RenderDecorations(wr, topLeft))
-				yield return r;
-
 			if (info.FootprintUnderPreview != PlaceBuildingCellType.None)
 				foreach (var r in RenderFootprint(wr, topLeft, footprint, info.FootprintUnderPreview))
 					yield return r;

--- a/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!ValidRenderPlayer())
 				yield break;
 
-			yield return new RangeCircleRenderable(
+			yield return new RangeCircleAnnotationRenderable(
 				self.CenterPosition,
 				Info.Range,
 				0,

--- a/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BaseProvider.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new BaseProvider(init.Self, this); }
 	}
 
-	public class BaseProvider : PausableConditionalTrait<BaseProviderInfo>, ITick, IRenderAboveShroudWhenSelected, ISelectionBar
+	public class BaseProvider : PausableConditionalTrait<BaseProviderInfo>, ITick, IRenderAnnotationsWhenSelected, ISelectionBar
 	{
 		readonly DeveloperMode devMode;
 		readonly Actor self;
@@ -89,12 +89,12 @@ namespace OpenRA.Mods.Common.Traits
 				Color.FromArgb(96, Color.Black));
 		}
 
-		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAnnotationsWhenSelected.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			return RangeCircleRenderables(wr);
 		}
 
-		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return false; } }
+		bool IRenderAnnotationsWhenSelected.SpatiallyPartitionable { get { return false; } }
 
 		float ISelectionBar.GetValue()
 		{

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -233,7 +233,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool IOccupySpaceInfo.SharesCell { get { return false; } }
 
-		public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
+		public IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
 		{
 			if (!RequiresBaseProvider)
 				return SpriteRenderable.None;

--- a/OpenRA.Mods.Common/Traits/Buildings/FootprintPlaceBuildingPreview.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FootprintPlaceBuildingPreview.cs
@@ -97,19 +97,16 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		protected IEnumerable<IRenderable> RenderDecorations(WorldRenderer wr, CPos topLeft)
+		protected virtual IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, CPos topLeft)
 		{
 			var centerPosition = wr.World.Map.CenterOfCell(topLeft) + centerOffset;
 			foreach (var d in decorations)
-				foreach (var r in d.Render(wr, wr.World, actorInfo, centerPosition))
+				foreach (var r in d.RenderAnnotations(wr, wr.World, actorInfo, centerPosition))
 					yield return r;
 		}
 
 		protected virtual IEnumerable<IRenderable> RenderInner(WorldRenderer wr, CPos topLeft, Dictionary<CPos, PlaceBuildingCellType> footprint)
 		{
-			foreach (var r in RenderDecorations(wr, topLeft))
-				yield return r;
-
 			foreach (var r in RenderFootprint(wr, topLeft, footprint))
 				yield return r;
 		}
@@ -117,6 +114,11 @@ namespace OpenRA.Mods.Common.Traits
 		IEnumerable<IRenderable> IPlaceBuildingPreview.Render(WorldRenderer wr, CPos topLeft, Dictionary<CPos, PlaceBuildingCellType> footprint)
 		{
 			return RenderInner(wr, topLeft, footprint);
+		}
+
+		IEnumerable<IRenderable> IPlaceBuildingPreview.RenderAnnotations(WorldRenderer wr, CPos topLeft)
+		{
+			return RenderAnnotations(wr, topLeft);
 		}
 
 		void IPlaceBuildingPreview.Tick() { TickInner(); }

--- a/OpenRA.Mods.Common/Traits/Buildings/SequencePlaceBuildingPreview.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/SequencePlaceBuildingPreview.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override IEnumerable<IRenderable> RenderInner(WorldRenderer wr, CPos topLeft, Dictionary<CPos, PlaceBuildingCellType> footprint)
 		{
-			foreach (var r in RenderDecorations(wr, topLeft))
+			foreach (var r in RenderAnnotations(wr, topLeft))
 				yield return r;
 
 			if (info.FootprintUnderPreview != PlaceBuildingCellType.None)

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new CombatDebugOverlay(init.Self); }
 	}
 
-	public class CombatDebugOverlay : IRenderAboveShroud, INotifyDamage, INotifyCreated
+	public class CombatDebugOverlay : IRenderAnnotations, INotifyDamage, INotifyCreated
 	{
 		static readonly WVec TargetPosHLine = new WVec(0, 128, 0);
 		static readonly WVec TargetPosVLine = new WVec(128, 0, 0);
@@ -52,13 +52,10 @@ namespace OpenRA.Mods.Common.Traits
 			allBlockers = self.TraitsImplementing<IBlocksProjectiles>().ToArray();
 		}
 
-		IEnumerable<IRenderable> IRenderAboveShroud.RenderAboveShroud(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAnnotations.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			if (debugVis == null || !debugVis.CombatGeometry || self.World.FogObscures(self))
 				yield break;
-
-			var wcr = Game.Renderer.WorldRgbaColorRenderer;
-			var iz = 1 / wr.Viewport.Zoom;
 
 			var blockers = allBlockers.Where(Exts.IsTraitEnabled).ToList();
 			if (blockers.Count > 0)
@@ -80,13 +77,13 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			foreach (var attack in self.TraitsImplementing<AttackBase>().Where(x => !x.IsTraitDisabled))
-				foreach (var r in RenderArmaments(self, attack, wr, wcr, iz))
+				foreach (var r in RenderArmaments(self, attack))
 					yield return r;
 		}
 
-		bool IRenderAboveShroud.SpatiallyPartitionable { get { return true; } }
+		bool IRenderAnnotations.SpatiallyPartitionable { get { return true; } }
 
-		IEnumerable<IRenderable> RenderArmaments(Actor self, AttackBase attack, WorldRenderer wr, RgbaColorRenderer wcr, float iz)
+		IEnumerable<IRenderable> RenderArmaments(Actor self, AttackBase attack)
 		{
 			// Fire ports on garrisonable structures
 			var garrison = attack as AttackGarrisoned;

--- a/OpenRA.Mods.Common/Traits/ExitsDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/ExitsDebugOverlay.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 		object ITraitInfo.Create(ActorInitializer init) { return new ExitsDebugOverlay(init.Self, this); }
 	}
 
-	public class ExitsDebugOverlay : IRenderAboveShroudWhenSelected
+	public class ExitsDebugOverlay : IRenderAnnotationsWhenSelected
 	{
 		readonly ExitsDebugOverlayManager manager;
 		readonly ExitsDebugOverlayInfo info;
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits
 			exits = self.Info.TraitInfos<ExitInfo>().ToArray();
 		}
 
-		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAnnotationsWhenSelected.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			if (manager == null || !manager.Enabled)
 				yield break;
@@ -101,6 +101,6 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return true; } }
+		bool IRenderAnnotationsWhenSelected.SpatiallyPartitionable { get { return true; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/ExitsDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/ExitsDebugOverlay.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 					var color = self.Owner.Color;
 					var vec = exitCell - self.Location;
 					var center = wr.World.Map.CenterOfCell(exitCell);
-					yield return new TextRenderable(manager.Font, center, 0, color, vec.ToString());
+					yield return new TextAnnotationRenderable(manager.Font, center, 0, color, vec.ToString());
 				}
 			}
 
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Traits
 
 					var vec = perimCell - self.Location;
 					var center = wr.World.Map.CenterOfCell(perimCell);
-					yield return new TextRenderable(manager.Font, center, 0, color, vec.ToString());
+					yield return new TextAnnotationRenderable(manager.Font, center, 0, color, vec.ToString());
 				}
 			}
 

--- a/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new CustomTerrainDebugOverlay(init.Self, this); }
 	}
 
-	class CustomTerrainDebugOverlay : IWorldLoaded, IChatCommand, IRenderAboveShroud
+	class CustomTerrainDebugOverlay : IWorldLoaded, IChatCommand, IRenderAnnotations
 	{
 		const string CommandName = "debugcustomterrain";
 		const string CommandDesc = "toggles the custom terrain debug overlay.";
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 				Enabled ^= true;
 		}
 
-		IEnumerable<IRenderable> IRenderAboveShroud.RenderAboveShroud(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAnnotations.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			if (!Enabled)
 				yield break;
@@ -78,6 +78,6 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		bool IRenderAboveShroud.SpatiallyPartitionable { get { return false; } }
+		bool IRenderAnnotations.SpatiallyPartitionable { get { return false; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Traits
 					continue;
 
 				var info = wr.World.Map.GetTerrainInfo(cell);
-				yield return new TextRenderable(font, center, 0, info.Color, info.Type);
+				yield return new TextAnnotationRenderable(font, center, 0, info.Color, info.Type);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
+++ b/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
@@ -126,7 +126,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 				if ((Info.TerrainTypes.Count == 0 || Info.TerrainTypes.Contains(type)) && !string.IsNullOrEmpty(Info.Image))
 					self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, self.World, Info.Image,
-						Info.Sequences.Random(Game.CosmeticRandom), Info.Palette, Info.VisibleThroughFog, false, spawnFacing)));
+						Info.Sequences.Random(Game.CosmeticRandom), Info.Palette, Info.VisibleThroughFog, spawnFacing)));
 
 				cachedPosition = self.CenterPosition;
 				cachedFacing = facing != null ? facing.Facing : 0;

--- a/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
@@ -75,12 +75,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (debugVis == null || !debugVis.ActorTags)
 				yield break;
 
-			yield return new TextRenderable(font, self.CenterPosition - offset, 0, color, tagString);
+			yield return new TextAnnotationRenderable(font, self.CenterPosition - offset, 0, color, tagString);
 
 			// Get the actor's activity.
 			var activity = self.CurrentActivity;
 			if (activity != null)
-				yield return new TextRenderable(font, self.CenterPosition, 0, color, activity.DebugLabelComponents().JoinWith("."));
+				yield return new TextAnnotationRenderable(font, self.CenterPosition, 0, color, activity.DebugLabelComponents().JoinWith("."));
 
 			// Get the AI squad that this actor belongs to.
 			if (!self.Owner.IsBot)
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				yield break;
 
 			var aiSquadInfo = "{0}, {1}".F(squad.Type, squad.TargetActor);
-			yield return new TextRenderable(font, self.CenterPosition + offset, 0, color, aiSquadInfo);
+			yield return new TextAnnotationRenderable(font, self.CenterPosition + offset, 0, color, aiSquadInfo);
 		}
 
 		bool IRenderAnnotationsWhenSelected.SpatiallyPartitionable { get { return true; } }

--- a/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public object Create(ActorInitializer init) { return new RenderDebugState(init.Self, this); }
 	}
 
-	class RenderDebugState : INotifyAddedToWorld, INotifyOwnerChanged, INotifyCreated, IRenderAboveShroudWhenSelected
+	class RenderDebugState : INotifyAddedToWorld, INotifyOwnerChanged, INotifyCreated, IRenderAnnotationsWhenSelected
 	{
 		readonly DebugVisualizations debugVis;
 		readonly SpriteFont font;
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return self.EffectiveOwner != null && self.EffectiveOwner.Disguised ? self.EffectiveOwner.Owner.Color : self.Owner.Color;
 		}
 
-		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAnnotationsWhenSelected.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			if (debugVis == null || !debugVis.ActorTags)
 				yield break;
@@ -98,6 +98,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 			yield return new TextRenderable(font, self.CenterPosition + offset, 0, color, aiSquadInfo);
 		}
 
-		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return true; } }
+		bool IRenderAnnotationsWhenSelected.SpatiallyPartitionable { get { return true; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/RenderDetectionCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDetectionCircle.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (range == WDist.Zero)
 				yield break;
 
-			yield return new DetectionCircleRenderable(
+			yield return new DetectionCircleAnnotationRenderable(
 				self.CenterPosition,
 				range,
 				0,

--- a/OpenRA.Mods.Common/Traits/Render/RenderDetectionCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDetectionCircle.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public object Create(ActorInitializer init) { return new RenderDetectionCircle(init.Self, this); }
 	}
 
-	class RenderDetectionCircle : ITick, IRenderAboveShroudWhenSelected
+	class RenderDetectionCircle : ITick, IRenderAnnotationsWhenSelected
 	{
 		readonly RenderDetectionCircleInfo info;
 		WAngle lineAngle;
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			this.info = info;
 		}
 
-		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAnnotationsWhenSelected.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			if (!self.Owner.IsAlliedWith(self.World.RenderPlayer))
 				yield break;
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				info.ContrastColor);
 		}
 
-		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return false; } }
+		bool IRenderAnnotationsWhenSelected.SpatiallyPartitionable { get { return false; } }
 
 		void ITick.Tick(Actor self)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/RenderNameTag.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderNameTag.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var spaceBuffer = (int)(10 / wr.Viewport.Zoom);
 			var effectPos = wr.ProjectedPosition(new int2((bounds.Left + bounds.Right) / 2, bounds.Y - spaceBuffer));
 
-			yield return new TextRenderable(font, effectPos, 0, color, name);
+			yield return new TextAnnotationRenderable(font, effectPos, 0, color, name);
 		}
 
 		bool IRenderAnnotations.SpatiallyPartitionable { get { return false; } }

--- a/OpenRA.Mods.Common/Traits/Render/RenderNameTag.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderNameTag.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public object Create(ActorInitializer init) { return new RenderNameTag(init.Self, this); }
 	}
 
-	class RenderNameTag : IRender
+	class RenderNameTag : IRenderAnnotations
 	{
 		readonly SpriteFont font;
 		readonly Color color;
@@ -48,19 +48,18 @@ namespace OpenRA.Mods.Common.Traits.Render
 			decorationBounds = self.TraitsImplementing<IDecorationBounds>().ToArray();
 		}
 
-		public IEnumerable<IRenderable> Render(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAnnotations.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
+			if (self.World.FogObscures(self))
+				yield break;
+
 			var bounds = decorationBounds.FirstNonEmptyBounds(self, wr);
 			var spaceBuffer = (int)(10 / wr.Viewport.Zoom);
 			var effectPos = wr.ProjectedPosition(new int2((bounds.Left + bounds.Right) / 2, bounds.Y - spaceBuffer));
 
-			return new IRenderable[] { new TextRenderable(font, effectPos, 0, color, name) };
+			yield return new TextRenderable(font, effectPos, 0, color, name);
 		}
 
-		IEnumerable<Rectangle> IRender.ScreenBounds(Actor self, WorldRenderer wr)
-		{
-			// Name tags don't contribute to actor bounds
-			yield break;
-		}
+		bool IRenderAnnotations.SpatiallyPartitionable { get { return false; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	class RenderRangeCircle : IRenderAboveShroudWhenSelected
+	class RenderRangeCircle : IRenderAnnotationsWhenSelected
 	{
 		public readonly RenderRangeCircleInfo Info;
 		readonly Actor self;
@@ -108,11 +108,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 				Info.BorderColor);
 		}
 
-		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAnnotationsWhenSelected.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			return RangeCircleRenderables(wr);
 		}
 
-		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return false; } }
+		bool IRenderAnnotationsWhenSelected.SpatiallyPartitionable { get { return false; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (range == null || range.Value == WDist.Zero)
 				return SpriteRenderable.None;
 
-			var localRange = new RangeCircleRenderable(
+			var localRange = new RangeCircleAnnotationRenderable(
 				centerPosition,
 				range.Value,
 				0,
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (range == WDist.Zero)
 				yield break;
 
-			yield return new RangeCircleRenderable(
+			yield return new RangeCircleAnnotationRenderable(
 				self.CenterPosition,
 				range,
 				0,

--- a/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		// Computed range
 		Lazy<WDist> range;
 
-		public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
+		public IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
 		{
 			if (range == null || range.Value == WDist.Zero)
 				return SpriteRenderable.None;

--- a/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public object Create(ActorInitializer init) { return new SelectionDecorations(init.Self, this); }
 	}
 
-	public class SelectionDecorations : ISelectionDecorations, IRenderAboveShroud, INotifyCreated, ITick
+	public class SelectionDecorations : ISelectionDecorations, IRenderAnnotations, INotifyCreated, ITick
 	{
 		// depends on the order of pips in TraitsInterfaces.cs!
 		static readonly string[] PipStrings = { "pip-empty", "pip-green", "pip-yellow", "pip-red", "pip-gray", "pip-blue", "pip-ammo", "pip-ammoempty" };
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			}
 		}
 
-		IEnumerable<IRenderable> IRenderAboveShroud.RenderAboveShroud(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAnnotations.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			if (self.World.FogObscures(self))
 				return Enumerable.Empty<IRenderable>();
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return DrawDecorations(self, wr);
 		}
 
-		bool IRenderAboveShroud.SpatiallyPartitionable { get { return true; } }
+		bool IRenderAnnotations.SpatiallyPartitionable { get { return true; } }
 
 		IEnumerable<IRenderable> DrawDecorations(Actor self, WorldRenderer wr)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
@@ -106,7 +106,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var displayExtra = selected || (regularWorld && statusBars != StatusBarsType.Standard);
 
 			if (Info.RenderSelectionBox && selected)
-				yield return new SelectionBoxRenderable(self, bounds, Info.SelectionBoxColor);
+				yield return new SelectionBoxAnnotationRenderable(self, bounds, Info.SelectionBoxColor);
 
 			if (Info.RenderSelectionBars && (displayHealth || displayExtra))
 				yield return new SelectionBarsAnnotationRenderable(self, bounds, displayHealth, displayExtra);

--- a/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
@@ -109,7 +109,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				yield return new SelectionBoxRenderable(self, bounds, Info.SelectionBoxColor);
 
 			if (Info.RenderSelectionBars && (displayHealth || displayExtra))
-				yield return new SelectionBarsRenderable(self, bounds, displayHealth, displayExtra);
+				yield return new SelectionBarsAnnotationRenderable(self, bounds, displayHealth, displayExtra);
 
 			// Target lines and pips are always only displayed for selected allied actors
 			if (!selected || !self.Owner.IsAlliedWith(wr.World.RenderPlayer))
@@ -125,7 +125,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public void DrawRollover(Actor self, WorldRenderer worldRenderer)
 		{
 			var bounds = decorationBounds.FirstNonEmptyBounds(self, worldRenderer);
-			new SelectionBarsRenderable(self, bounds, true, true).Render(worldRenderer);
+			new SelectionBarsAnnotationRenderable(self, bounds, true, true).Render(worldRenderer);
 		}
 
 		IEnumerable<IRenderable> DrawPips(Actor self, Rectangle bounds, WorldRenderer wr)

--- a/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDecoration.cs
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithDecoration(init.Self, this); }
 	}
 
-	public class WithDecoration : ConditionalTrait<WithDecorationInfo>, ITick, IRenderAboveShroud, IRenderAboveShroudWhenSelected
+	public class WithDecoration : ConditionalTrait<WithDecorationInfo>, ITick, IRenderAnnotations, IRenderAnnotationsWhenSelected
 	{
 		protected Animation anim;
 		readonly IDecorationBounds[] decorationBounds;
@@ -124,18 +124,18 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return wr.Palette(Info.Palette + (Info.IsPlayerPalette ? self.Owner.InternalName : ""));
 		}
 
-		IEnumerable<IRenderable> IRenderAboveShroud.RenderAboveShroud(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAnnotations.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			return !Info.RequiresSelection ? RenderInner(self, wr) : SpriteRenderable.None;
 		}
 
-		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAnnotationsWhenSelected.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			return Info.RequiresSelection ? RenderInner(self, wr) : SpriteRenderable.None;
 		}
 
-		bool IRenderAboveShroud.SpatiallyPartitionable { get { return true; } }
-		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return true; } }
+		bool IRenderAnnotations.SpatiallyPartitionable { get { return true; } }
+		bool IRenderAnnotationsWhenSelected.SpatiallyPartitionable { get { return true; } }
 
 		IEnumerable<IRenderable> RenderInner(Actor self, WorldRenderer wr)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new WithRangeCircle(init.Self, this); }
 	}
 
-	class WithRangeCircle : ConditionalTrait<WithRangeCircleInfo>, IRenderAboveShroudWhenSelected, IRenderAboveShroud
+	class WithRangeCircle : ConditionalTrait<WithRangeCircleInfo>, IRenderAnnotationsWhenSelected, IRenderAboveShroud
 	{
 		readonly Actor self;
 
@@ -95,12 +95,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 					Color.FromArgb(96, Color.Black));
 		}
 
-		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAnnotationsWhenSelected.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			return RenderRangeCircle(self, wr, RangeCircleVisibility.WhenSelected);
 		}
 
-		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return false; } }
+		bool IRenderAnnotationsWhenSelected.SpatiallyPartitionable { get { return false; } }
 
 		IEnumerable<IRenderable> IRenderAboveShroud.RenderAboveShroud(Actor self, WorldRenderer wr)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		{
 			if (EnabledByDefault)
 			{
-				yield return new RangeCircleRenderable(
+				yield return new RangeCircleAnnotationRenderable(
 					centerPosition,
 					Range,
 					0,
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public IEnumerable<IRenderable> RenderRangeCircle(Actor self, WorldRenderer wr, RangeCircleVisibility visibility)
 		{
 			if (Info.Visible == visibility && Visible)
-				yield return new RangeCircleRenderable(
+				yield return new RangeCircleAnnotationRenderable(
 					self.CenterPosition,
 					Info.Range,
 					0,

--- a/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithRangeCircle.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Range of the circle")]
 		public readonly WDist Range = WDist.Zero;
 
-		public IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
+		public IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition)
 		{
 			if (EnabledByDefault)
 			{

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public object Create(ActorInitializer init) { return new WithSpriteControlGroupDecoration(init.Self, this); }
 	}
 
-	public class WithSpriteControlGroupDecoration : IRenderAboveShroudWhenSelected
+	public class WithSpriteControlGroupDecoration : IRenderAnnotationsWhenSelected
 	{
 		public readonly WithSpriteControlGroupDecorationInfo Info;
 		readonly IDecorationBounds[] decorationBounds;
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			pipImages = new Animation(self.World, Info.Image);
 		}
 
-		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAnnotationsWhenSelected.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			if (self.Owner != wr.World.LocalPlayer)
 				yield break;
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				yield return r;
 		}
 
-		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return true; } }
+		bool IRenderAnnotationsWhenSelected.SpatiallyPartitionable { get { return true; } }
 
 		IEnumerable<IRenderable> DrawControlGroup(Actor self, WorldRenderer wr, PaletteReference palette)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public object Create(ActorInitializer init) { return new WithTextControlGroupDecoration(init.Self, this); }
 	}
 
-	public class WithTextControlGroupDecoration : IRenderAboveShroudWhenSelected, INotifyOwnerChanged
+	public class WithTextControlGroupDecoration : IRenderAnnotationsWhenSelected, INotifyOwnerChanged
 	{
 		readonly WithTextControlGroupDecorationInfo info;
 		readonly IDecorationBounds[] decorationBounds;
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			color = info.UsePlayerColor ? self.Owner.Color : info.Color;
 		}
 
-		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAnnotationsWhenSelected.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			if (self.Owner != wr.World.LocalPlayer)
 				yield break;
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				yield return r;
 		}
 
-		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return true; } }
+		bool IRenderAnnotationsWhenSelected.SpatiallyPartitionable { get { return true; } }
 
 		IEnumerable<IRenderable> DrawControlGroup(Actor self, WorldRenderer wr)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			var screenPos = boundsOffset + sizeOffset + info.ScreenOffset;
 
-			yield return new TextRenderable(font, wr.ProjectedPosition(screenPos), info.ZOffset, color, number);
+			yield return new TextAnnotationRenderable(font, wr.ProjectedPosition(screenPos), info.ZOffset, color, number);
 		}
 
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)

--- a/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		}
 	}
 
-	public class WithTextDecoration : ConditionalTrait<WithTextDecorationInfo>, IRender, IRenderAboveShroudWhenSelected, INotifyOwnerChanged
+	public class WithTextDecoration : ConditionalTrait<WithTextDecorationInfo>, IRender, IRenderAnnotationsWhenSelected, INotifyOwnerChanged
 	{
 		readonly SpriteFont font;
 		readonly IDecorationBounds[] decorationBounds;
@@ -84,12 +84,12 @@ namespace OpenRA.Mods.Common.Traits.Render
 			yield break;
 		}
 
-		IEnumerable<IRenderable> IRenderAboveShroudWhenSelected.RenderAboveShroud(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAnnotationsWhenSelected.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			return Info.RequiresSelection ? RenderInner(self, wr) : SpriteRenderable.None;
 		}
 
-		bool IRenderAboveShroudWhenSelected.SpatiallyPartitionable { get { return true; } }
+		bool IRenderAnnotationsWhenSelected.SpatiallyPartitionable { get { return true; } }
 
 		IEnumerable<IRenderable> RenderInner(Actor self, WorldRenderer wr)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
@@ -133,7 +133,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				sizeOffset -= new int2(halfSize.X, 0);
 			}
 
-			return new IRenderable[] { new TextRenderable(font, wr.ProjectedPosition(boundsOffset + sizeOffset), Info.ZOffset, color, Info.Text) };
+			return new IRenderable[] { new TextAnnotationRenderable(font, wr.ProjectedPosition(boundsOffset + sizeOffset), Info.ZOffset, color, Info.Text) };
 		}
 
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)

--- a/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
+++ b/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					var offset = info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation));
 					var pos = position + body.LocalToWorld(offset);
-					self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, w, info.Sprite, info.Sequence, info.Palette, false, false, getFacing)));
+					self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, w, info.Sprite, info.Sequence, info.Palette, facing: getFacing)));
 				}
 
 				ticks = info.Interval;

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
@@ -138,7 +138,9 @@ namespace OpenRA.Mods.Common.Traits
 					world.CancelInputMode();
 			}
 
-			protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world)
+			protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
+
+			protected override IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world)
 			{
 				var xy = wr.Viewport.ViewToWorld(Viewport.LastMousePos);
 				foreach (var unit in power.UnitsInRange(xy))

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
@@ -146,7 +146,7 @@ namespace OpenRA.Mods.Common.Traits
 				foreach (var unit in power.UnitsInRange(xy))
 				{
 					var bounds = unit.TraitsImplementing<IDecorationBounds>().FirstNonEmptyBounds(unit, wr);
-					yield return new SelectionBoxRenderable(unit, bounds, Color.Red);
+					yield return new SelectionBoxAnnotationRenderable(unit, bounds, Color.Red);
 				}
 			}
 

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SelectDirectionalTarget.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SelectDirectionalTarget.cs
@@ -118,6 +118,7 @@ namespace OpenRA.Mods.Common.Traits
 		IEnumerable<IRenderable> IOrderGenerator.Render(WorldRenderer wr, World world) { yield break; }
 
 		IEnumerable<IRenderable> IOrderGenerator.RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
+		IEnumerable<IRenderable> IOrderGenerator.RenderAnnotations(WorldRenderer wr, World world) { yield break; }
 
 		string IOrderGenerator.GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -296,6 +296,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
 		protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
+		protected override IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world) { yield break; }
 		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			return world.Map.Contains(cell) ? cursor : "generic-blocked";

--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly WPos CenterPosition;
 		public readonly IReadOnlyDictionary<CPos, SubCell> Footprint;
 		public readonly Rectangle Bounds;
-		public readonly SelectionBoxRenderable SelectionBox;
+		public readonly SelectionBoxAnnotationRenderable SelectionBox;
 		public readonly ActorReference Actor;
 
 		public string Tooltip
@@ -94,7 +94,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			Bounds = r.Union();
 
-			SelectionBox = new SelectionBoxRenderable(new WPos(CenterPosition.X, CenterPosition.Y, 8192),
+			SelectionBox = new SelectionBoxAnnotationRenderable(new WPos(CenterPosition.X, CenterPosition.Y, 8192),
 				new Rectangle(Bounds.X, Bounds.Y, Bounds.Width, Bounds.Height), Color.White);
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainGeometryOverlay.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Renders a debug overlay showing the terrain cells. Attach this to the world actor.")]
 	public class TerrainGeometryOverlayInfo : TraitInfo<TerrainGeometryOverlay> { }
 
-	public class TerrainGeometryOverlay : IRenderAboveShroud, IWorldLoaded, IChatCommand
+	public class TerrainGeometryOverlay : IRenderAnnotations, IWorldLoaded, IChatCommand
 	{
 		const string CommandName = "terrainoverlay";
 		const string CommandDesc = "toggles the terrain geometry overlay.";
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 				Enabled ^= true;
 		}
 
-		IEnumerable<IRenderable> IRenderAboveShroud.RenderAboveShroud(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAnnotations.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			if (!Enabled)
 				yield break;
@@ -98,6 +98,6 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		bool IRenderAboveShroud.SpatiallyPartitionable { get { return false; } }
+		bool IRenderAnnotations.SpatiallyPartitionable { get { return false; } }
 	}
 }

--- a/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new WarheadDebugOverlay(this); }
 	}
 
-	public class WarheadDebugOverlay : IRenderAboveShroud
+	public class WarheadDebugOverlay : IRenderAnnotations
 	{
 		class WHImpact
 		{
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 			impacts.Add(new WHImpact(pos, range, info.DisplayDuration, color));
 		}
 
-		IEnumerable<IRenderable> IRenderAboveShroud.RenderAboveShroud(Actor self, WorldRenderer wr)
+		IEnumerable<IRenderable> IRenderAnnotations.RenderAnnotations(Actor self, WorldRenderer wr)
 		{
 			foreach (var i in impacts)
 			{
@@ -83,6 +83,6 @@ namespace OpenRA.Mods.Common.Traits
 			impacts.RemoveAll(i => i.Time == 0);
 		}
 
-		bool IRenderAboveShroud.SpatiallyPartitionable { get { return false; } }
+		bool IRenderAnnotations.SpatiallyPartitionable { get { return false; } }
 	}
 }

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public interface IPlaceBuildingDecorationInfo : ITraitInfo
 	{
-		IEnumerable<IRenderable> Render(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition);
+		IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition);
 	}
 
 	[RequireExplicitImplementation]

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -215,7 +215,7 @@ namespace OpenRA.Mods.Common.Widgets
 					}
 					else if (visualTarget.Type == TargetType.Terrain)
 					{
-						world.AddFrameEndTask(w => w.Add(new SpriteEffect(visualTarget.CenterPosition, world, "moveflsh", "idle", "moveflash", true, true)));
+						world.AddFrameEndTask(w => w.Add(new SpriteAnnotation(visualTarget.CenterPosition, world, "moveflsh", "idle", "moveflash")));
 						flashed = true;
 					}
 				}

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -59,11 +59,11 @@ namespace OpenRA.Mods.Common.Widgets
 			var modifiers = Game.GetModifierKeys();
 			if (IsValidDragbox)
 			{
+				var a = worldRenderer.Viewport.WorldToViewPx(dragStart);
+				var b = worldRenderer.Viewport.WorldToViewPx(mousePos);
+				Game.Renderer.RgbaColorRenderer.DrawRect(a, b, 1, Color.White);
+
 				// Render actors in the dragbox
-				var a = new float3(dragStart.X, dragStart.Y, dragStart.Y);
-				var b = new float3(mousePos.X, mousePos.Y, mousePos.Y);
-				Game.Renderer.WorldRgbaColorRenderer.DrawRect(a, b,
-					1 / worldRenderer.Viewport.Zoom, Color.White);
 				foreach (var u in SelectActorsInBoxWithDeadzone(World, dragStart, mousePos, modifiers))
 					DrawRollover(u);
 			}


### PR DESCRIPTION
This PR implements another significant chunk of preparation for #10382.

The concept of an "Annotation" is introduced to represent overlays drawn in the UI that give the player extra info, but doesn't physically exist in the game world. This covers range circles, target lines, selection boxes / bars, debug overlays and so on. Annotations render at the native screen resolution, and their size is determined by the UI zoom (to be implemented in a future PR) rather than the world zoom.

The goal for testing should be to show that there are no visual regressions compared to bleed. The new behavior will only be useful once we implement the world framebuffer and enable arbitrary zooming. This can be tested using my `render-wip` branch, but expect other regressions there.

There are three obvious questions, which I am deliberately deferring to future PRs:
* Changing beacons and rally point indicators is controversial, and further discussion about them is best left until we have the final world and UI zoom behaviors so everyone can fully understand the questions being debated.
* The map editor overlays may require similar changes, to be handled in a followup.
* I plan to document the different rendering stages / renderable interfaces in `WorldRenderer` and for the [book](https://github.com/OpenRA/book), but not here. This will be part of the world framebuffer PR.
