### PR TITLE
Implement click-drag interface for minefields.

### DIFF
--- a/OpenRA.Game/Input/IInputHandler.cs
+++ b/OpenRA.Game/Input/IInputHandler.cs
@@ -48,7 +48,9 @@ namespace OpenRA
 		None = 0,
 		Left = 1,
 		Right = 2,
-		Middle = 4
+		Middle = 4,
+		XButton1 = 8,
+		XButton2 = 16,
 	}
 
 	[Flags]

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -18,6 +18,32 @@ namespace OpenRA.Orders
 {
 	public class UnitOrderGenerator : IOrderGenerator
 	{
+		readonly bool useClassicMouse = Game.Settings.Game.UseClassicMouseStyle;
+
+		List<UnitOrderResult> orderResults;
+		string lockedCursor;
+		bool canDrag;
+		int ticks;
+		int2 mouseStartPos;
+		CPos startCell;
+		MouseInput heldMouseInput;
+		bool actionButtonHeld;
+		public int2 MousePos;
+
+		public bool IsOrderDragging
+		{
+			get
+			{
+				if (!canDrag)
+					return false;
+
+				if (useClassicMouse)
+					return ticks >= Game.Settings.Game.LeftDragOrderDelay;
+
+				return ticks >= Game.Settings.Game.DragOrderDelay && (mouseStartPos - MousePos).Length > Game.Settings.Game.DragOrderDeadZone;
+			}
+		}
+
 		static Target TargetForInput(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			var actor = world.ScreenMap.ActorsAtMouse(mi)
@@ -37,39 +63,106 @@ namespace OpenRA.Orders
 			return Target.FromCell(world, cell);
 		}
 
-		public virtual IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		public void HoldActionButton(int2 mousePos, CPos cell, MouseInput mi)
+		{
+			mouseStartPos = mousePos;
+			actionButtonHeld = true;
+			startCell = cell;
+			heldMouseInput = mi;
+		}
+
+		public void HoldTarget(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			var target = TargetForInput(world, cell, worldPixel, mi);
 			var actorsAt = world.ActorMap.GetActorsAt(cell).ToList();
-			var orderResults = world.Selection.Actors
+			orderResults = world.Selection.Actors
 				.Select(a => OrderForUnit(a, target, actorsAt, cell, mi))
 				.Where(o => o != null)
 				.ToList();
+		}
 
-			var actorsInvolved = orderResults.Select(o => o.Actor).Distinct();
-			if (!actorsInvolved.Any())
+		public virtual IEnumerable<Order> Order(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		{
+			if (!IsOrderDragging)
+				HoldTarget(world, cell, worldPixel, mi);
+
+			if (orderResults == null)
 				yield break;
+
+			var selection = world.Selection.Actors;
+			var actorsInvolved = orderResults.Select(o => o.Actor).Distinct();
+			if (!actorsInvolved.Intersect(selection).Any())
+			{
+				orderResults.Clear();
+				actionButtonHeld = false;
+				yield break;
+			}
 
 			// HACK: This is required by the hacky player actions-per-minute calculation
 			// TODO: Reimplement APM properly and then remove this
 			yield return new Order("CreateGroup", actorsInvolved.First().Owner.PlayerActor, false, actorsInvolved.ToArray());
 
 			foreach (var o in orderResults)
-				yield return CheckSameOrder(o.OrderTargeter, o.Trait.IssueOrder(o.Actor, o.OrderTargeter, o.Target, mi.Modifiers.HasModifier(Modifiers.Shift)));
+			{
+				if (!o.Actor.IsInWorld || o.Actor.IsDead || !selection.Contains(o.Actor))
+					continue;
+
+				yield return CheckSameOrder(o.OrderTargeter, o.Trait.IssueOrder(o.Actor, o.OrderTargeter, o.Target, mi.Modifiers.HasModifier(Modifiers.Shift), cell));
+			}
+
+			orderResults.Clear();
+			actionButtonHeld = false;
 		}
 
-		public virtual void Tick(World world) { }
+		public virtual void Tick(World world)
+		{
+			if (actionButtonHeld && !IsOrderDragging && canDrag)
+			{
+				if (!useClassicMouse || (mouseStartPos - MousePos).Length <= Game.Settings.Game.SelectionDeadzone)
+					ticks++;
+
+				if (ticks == (useClassicMouse ? Game.Settings.Game.LeftDragOrderDelay : Game.Settings.Game.DragOrderDelay))
+					HoldTarget(world, startCell, mouseStartPos, heldMouseInput);
+			}
+
+			if (!actionButtonHeld)
+			{
+				ticks = 0;
+				lockedCursor = null;
+			}
+		}
+
 		public virtual IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
 		public virtual IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
-		public virtual IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world) { yield break; }
+
+		public virtual IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world)
+		{
+			if (orderResults == null || orderResults.Count == 0)
+				yield break;
+
+			if (!IsOrderDragging)
+				yield break;
+
+			foreach (var o in orderResults)
+			{
+				if (!o.Actor.IsInWorld || o.Actor.IsDead)
+					continue;
+
+				foreach (var r in o.OrderTargeter.RenderAnnotations(wr, world, o.Actor, o.Target))
+					yield return r;
+			}
+		}
 
 		public virtual string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
+			if (IsOrderDragging && lockedCursor != null && lockedCursor.Any())
+				return lockedCursor;
+
 			var target = TargetForInput(world, cell, worldPixel, mi);
 			var actorsAt = world.ActorMap.GetActorsAt(cell).ToList();
 
 			bool useSelect;
-			if (Game.Settings.Game.UseClassicMouseStyle && !InputOverridesSelection(world, worldPixel, mi))
+			if (useClassicMouse && !InputOverridesSelection(world, worldPixel, mi))
 				useSelect = target.Type == TargetType.Actor && target.Actor.Info.HasTraitInfo<SelectableInfo>();
 			else
 			{
@@ -79,7 +172,11 @@ namespace OpenRA.Orders
 
 				var cursorOrder = ordersWithCursor.MaxByOrDefault(o => o.OrderTargeter.OrderPriority);
 				if (cursorOrder != null)
-					return cursorOrder.Cursor;
+				{
+					lockedCursor = cursorOrder.Cursor;
+					canDrag = cursorOrder.OrderTargeter.CanDrag;
+					return lockedCursor;
+				}
 
 				useSelect = target.Type == TargetType.Actor && target.Actor.Info.HasTraitInfo<SelectableInfo>() &&
 				    (mi.Modifiers.HasModifier(Modifiers.Shift) || !world.Selection.Actors.Any());
@@ -131,9 +228,6 @@ namespace OpenRA.Orders
 		/// </summary>
 		static UnitOrderResult OrderForUnit(Actor self, Target target, List<Actor> actorsAt, CPos xy, MouseInput mi)
 		{
-			if (mi.Button != Game.Settings.Game.MouseButtonPreference.Action)
-				return null;
-
 			if (self.Owner != self.World.LocalPlayer)
 				return null;
 

--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -41,12 +41,12 @@ namespace OpenRA.Orders
 		{
 			var target = TargetForInput(world, cell, worldPixel, mi);
 			var actorsAt = world.ActorMap.GetActorsAt(cell).ToList();
-			var orders = world.Selection.Actors
+			var orderResults = world.Selection.Actors
 				.Select(a => OrderForUnit(a, target, actorsAt, cell, mi))
 				.Where(o => o != null)
 				.ToList();
 
-			var actorsInvolved = orders.Select(o => o.Actor).Distinct();
+			var actorsInvolved = orderResults.Select(o => o.Actor).Distinct();
 			if (!actorsInvolved.Any())
 				yield break;
 
@@ -54,8 +54,8 @@ namespace OpenRA.Orders
 			// TODO: Reimplement APM properly and then remove this
 			yield return new Order("CreateGroup", actorsInvolved.First().Owner.PlayerActor, false, actorsInvolved.ToArray());
 
-			foreach (var o in orders)
-				yield return CheckSameOrder(o.Order, o.Trait.IssueOrder(o.Actor, o.Order, o.Target, mi.Modifiers.HasModifier(Modifiers.Shift)));
+			foreach (var o in orderResults)
+				yield return CheckSameOrder(o.OrderTargeter, o.Trait.IssueOrder(o.Actor, o.OrderTargeter, o.Target, mi.Modifiers.HasModifier(Modifiers.Shift)));
 		}
 
 		public virtual void Tick(World world) { }
@@ -77,7 +77,7 @@ namespace OpenRA.Orders
 					.Select(a => OrderForUnit(a, target, actorsAt, cell, mi))
 					.Where(o => o != null && o.Cursor != null);
 
-				var cursorOrder = ordersWithCursor.MaxByOrDefault(o => o.Order.OrderPriority);
+				var cursorOrder = ordersWithCursor.MaxByOrDefault(o => o.OrderTargeter.OrderPriority);
 				if (cursorOrder != null)
 					return cursorOrder.Cursor;
 
@@ -117,7 +117,7 @@ namespace OpenRA.Orders
 			foreach (var a in world.Selection.Actors)
 			{
 				var o = OrderForUnit(a, target, actorsAt, cell, mi);
-				if (o != null && o.Order.TargetOverridesSelection(a, target, actorsAt, cell, modifiers))
+				if (o != null && o.OrderTargeter.TargetOverridesSelection(a, target, actorsAt, cell, modifiers))
 					return true;
 			}
 
@@ -158,9 +158,9 @@ namespace OpenRA.Orders
 			// Other action that replace the SelectManySingleSelectorIterator with a
 			// different enumerator type (e.g. .Where(true) or .ToList()) also work.
 			var orders = self.TraitsImplementing<IIssueOrder>()
-				.SelectMany(trait => trait.Orders.Select(x => new { Trait = trait, Order = x }))
+				.SelectMany(trait => trait.OrderTargeters.Select(x => new { Trait = trait, OrderTargeter = x }))
 				.Select(x => x)
-				.OrderByDescending(x => x.Order.OrderPriority);
+				.OrderByDescending(x => x.OrderTargeter.OrderPriority);
 
 			for (var i = 0; i < 2; i++)
 			{
@@ -168,8 +168,8 @@ namespace OpenRA.Orders
 				{
 					var localModifiers = modifiers;
 					string cursor = null;
-					if (o.Order.CanTarget(self, target, actorsAt, ref localModifiers, ref cursor))
-						return new UnitOrderResult(self, o.Order, o.Trait, cursor, target);
+					if (o.OrderTargeter.CanTarget(self, target, actorsAt, ref localModifiers, ref cursor))
+						return new UnitOrderResult(self, o.OrderTargeter, o.Trait, cursor, target);
 				}
 
 				// No valid orders, so check for orders against the cell
@@ -191,15 +191,15 @@ namespace OpenRA.Orders
 		class UnitOrderResult
 		{
 			public readonly Actor Actor;
-			public readonly IOrderTargeter Order;
+			public readonly IOrderTargeter OrderTargeter;
 			public readonly IIssueOrder Trait;
 			public readonly string Cursor;
 			public readonly Target Target;
 
-			public UnitOrderResult(Actor actor, IOrderTargeter order, IIssueOrder trait, string cursor, Target target)
+			public UnitOrderResult(Actor actor, IOrderTargeter orderTargeter, IIssueOrder trait, string cursor, Target target)
 			{
 				Actor = actor;
-				Order = order;
+				OrderTargeter = orderTargeter;
 				Trait = trait;
 				Cursor = cursor;
 				Target = target;

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -211,6 +211,9 @@ namespace OpenRA
 		public float ZoomSpeed = 0.04f;
 		public int SelectionDeadzone = 24;
 		public int MouseScrollDeadzone = 8;
+		public int DragOrderDeadZone = 12;
+		public int DragOrderDelay = 5;
+		public int LeftDragOrderDelay = 25;
 
 		public bool UseClassicMouseStyle = false;
 		public StatusBarsType StatusBars = StatusBarsType.Standard;

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -203,8 +203,8 @@ namespace OpenRA
 		public int ViewportEdgeScrollMargin = 5;
 
 		public bool LockMouseWindow = false;
-		public MouseScrollType MiddleMouseScroll = MouseScrollType.Standard;
-		public MouseScrollType RightMouseScroll = MouseScrollType.Disabled;
+		public MouseScrollType MouseScroll = MouseScrollType.Standard;
+		public MouseButton ScrollButton = MouseButton.Middle;
 		public MouseButtonPreference MouseButtonPreference = new MouseButtonPreference();
 		public float ViewportEdgeScrollStep = 30f;
 		public float UIScrollSpeed = 50f;

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -162,7 +162,7 @@ namespace OpenRA.Traits
 	public interface IIssueOrder
 	{
 		IEnumerable<IOrderTargeter> OrderTargeters { get; }
-		Order IssueOrder(Actor self, IOrderTargeter orderTargeter, Target target, bool queued);
+		Order IssueOrder(Actor self, IOrderTargeter orderTargeter, Target target, bool queued, CPos extraLoc);
 	}
 
 	[Flags]
@@ -181,9 +181,11 @@ namespace OpenRA.Traits
 	{
 		string OrderID { get; }
 		int OrderPriority { get; }
+		bool CanDrag { get; }
 		bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor);
 		bool IsQueued { get; }
 		bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers);
+		IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world, Actor self, Target target);
 	}
 
 	public interface IResolveOrder { void ResolveOrder(Actor self, Order order); }

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -161,8 +161,8 @@ namespace OpenRA.Traits
 
 	public interface IIssueOrder
 	{
-		IEnumerable<IOrderTargeter> Orders { get; }
-		Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued);
+		IEnumerable<IOrderTargeter> OrderTargeters { get; }
+		Order IssueOrder(Actor self, IOrderTargeter orderTargeter, Target target, bool queued);
 	}
 
 	[Flags]

--- a/OpenRA.Mods.Cnc/Activities/LayMines.cs
+++ b/OpenRA.Mods.Cnc/Activities/LayMines.cs
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.Cnc.Activities
 				yield return new TargetLineNode(Target.FromCell(self.World, nextCell.Value), Color.Crimson);
 
 			foreach (var c in minefield)
-				yield return new TargetLineNode(Target.FromCell(self.World, c), Color.Crimson, tile: minelayer.Tile);
+				yield return new TargetLineNode(Target.FromCell(self.World, c), Color.Crimson, tile: minelayer.TileOk);
 		}
 
 		static bool CanLayMine(Actor self, CPos p)

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -139,7 +139,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID == "Disguise")
 				return new Order(order.OrderID, self, target, queued);

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -131,7 +131,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			conditionManager = self.TraitOrDefault<ConditionManager>();
 		}
 
-		IEnumerable<IOrderTargeter> IIssueOrder.Orders
+		IEnumerable<IOrderTargeter> IIssueOrder.OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID != "Infiltrate")
 				return null;

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public Infiltrates(InfiltratesInfo info)
 			: base(info) { }
 
-		public IEnumerable<IOrderTargeter> Orders
+		public IEnumerable<IOrderTargeter> OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -114,7 +114,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID != "DetonateAttack" && order.OrderID != "Detonate")
 				return null;

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			conditionManager = self.TraitOrDefault<ConditionManager>();
 		}
 
-		public IEnumerable<IOrderTargeter> Orders
+		public IEnumerable<IOrderTargeter> OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			switch (order.OrderID)
 			{
@@ -235,6 +235,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			public string OrderID { get { return "BeginMinefield"; } }
 			public int OrderPriority { get { return 5; } }
 			public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
+			public bool CanDrag { get { return false; } }
 
 			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 			{
@@ -249,6 +250,11 @@ namespace OpenRA.Mods.Cnc.Traits
 				IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
 
 				return modifiers.HasModifier(TargetModifiers.ForceAttack);
+			}
+
+			public IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world, Actor self, Target target)
+			{
+				yield break;
 			}
 
 			public bool IsQueued { get; protected set; }

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				Tile = self.World.Map.Rules.Sequences.GetSequence("overlay", "build-valid").GetSprite(0);
 		}
 
-		IEnumerable<IOrderTargeter> IIssueOrder.Orders
+		IEnumerable<IOrderTargeter> IIssueOrder.OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID == "PortableChronoDeploy")
 			{
@@ -158,6 +158,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public string OrderID { get { return "PortableChronoTeleport"; } }
 		public int OrderPriority { get { return 5; } }
+		public bool CanDrag { get { return false; } }
 		public bool IsQueued { get; protected set; }
 		public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
 
@@ -179,6 +180,11 @@ namespace OpenRA.Mods.Cnc.Traits
 			}
 
 			return false;
+		}
+
+		public IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world, Actor self, Target target)
+		{
+			yield break;
 		}
 	}
 

--- a/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				chargeTick--;
 		}
 
-		public IEnumerable<IOrderTargeter> Orders
+		public IEnumerable<IOrderTargeter> OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Orders/DeployOrderTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/DeployOrderTargeter.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using OpenRA.Graphics;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Orders
@@ -34,6 +35,7 @@ namespace OpenRA.Mods.Common.Orders
 		public string OrderID { get; private set; }
 		public int OrderPriority { get; private set; }
 		public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
+		public bool CanDrag { get { return false; } }
 
 		public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
 		{
@@ -44,6 +46,11 @@ namespace OpenRA.Mods.Common.Orders
 			cursor = this.cursor();
 
 			return self == target.Actor;
+		}
+
+		public IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world, Actor self, Target target)
+		{
+			yield break;
 		}
 
 		public bool IsQueued { get; protected set; }

--- a/OpenRA.Mods.Common/Orders/UnitOrderTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/UnitOrderTargeter.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -31,6 +32,7 @@ namespace OpenRA.Mods.Common.Orders
 
 		public string OrderID { get; private set; }
 		public int OrderPriority { get; private set; }
+		public bool CanDrag { get { return false; } }
 		public bool? ForceAttack = null;
 		public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
 
@@ -61,6 +63,11 @@ namespace OpenRA.Mods.Common.Orders
 			return type == TargetType.FrozenActor ?
 				CanTargetFrozenActor(self, target.FrozenActor, modifiers, ref cursor) :
 				CanTargetActor(self, target.Actor, modifiers, ref cursor);
+		}
+
+		public IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world, Actor self, Target target)
+		{
+			yield break;
 		}
 
 		public virtual bool IsQueued { get; protected set; }

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
+using OpenRA.Graphics;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Primitives;
@@ -952,7 +953,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID == "Enter" || order.OrderID == "Move" || order.OrderID == "Land" || order.OrderID == "ForceEnter")
 				return new Order(order.OrderID, self, target, queued);
@@ -1170,6 +1171,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public string OrderID { get; protected set; }
 			public int OrderPriority { get { return 4; } }
+			public bool CanDrag { get { return false; } }
 			public bool IsQueued { get; protected set; }
 
 			public AircraftMoveOrderTargeter(Aircraft aircraft)
@@ -1216,6 +1218,11 @@ namespace OpenRA.Mods.Common.Traits
 					cursor = "move-blocked";
 
 				return true;
+			}
+
+			public IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world, Actor self, Target target)
+			{
+				yield break;
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -936,7 +936,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		#region Implement order interfaces
 
-		public IEnumerable<IOrderTargeter> Orders
+		public IEnumerable<IOrderTargeter> OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -168,7 +168,7 @@ namespace OpenRA.Mods.Common.Traits
 				a.CheckFire(self, facing, target);
 		}
 
-		IEnumerable<IOrderTargeter> IIssueOrder.Orders
+		IEnumerable<IOrderTargeter> IIssueOrder.OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -13,10 +13,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
+using OpenRA.Graphics;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Warheads;
 using OpenRA.Primitives;
-using OpenRA.Support;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -183,7 +183,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order is AttackOrderTargeter)
 				return new Order(order.OrderID, self, target, queued);
@@ -437,6 +437,7 @@ namespace OpenRA.Mods.Common.Traits
 			public string OrderID { get; private set; }
 			public int OrderPriority { get; private set; }
 			public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
+			public bool CanDrag { get { return false; } }
 
 			bool CanTargetActor(Actor self, Target target, ref TargetModifiers modifiers, ref string cursor)
 			{
@@ -526,6 +527,11 @@ namespace OpenRA.Mods.Common.Traits
 					default:
 						return false;
 				}
+			}
+
+			public IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world, Actor self, Target target)
+			{
+				yield break;
 			}
 
 			public bool IsQueued { get; protected set; }

--- a/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 			base.Created(self);
 		}
 
-		IEnumerable<IOrderTargeter> IIssueOrder.Orders
+		IEnumerable<IOrderTargeter> IIssueOrder.OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID == OrderID)
 				return new Order(order.OrderID, self, false);

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Traits
 			ResetPath(self);
 		}
 
-		public IEnumerable<IOrderTargeter> Orders
+		public IEnumerable<IOrderTargeter> OrderTargeters
 		{
 			get { yield return new RallyPointOrderTargeter(Info.Cursor); }
 		}

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Graphics;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Traits;
 
@@ -91,7 +92,7 @@ namespace OpenRA.Mods.Common.Traits
 			get { yield return new RallyPointOrderTargeter(Info.Cursor); }
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID == OrderID)
 			{
@@ -133,6 +134,7 @@ namespace OpenRA.Mods.Common.Traits
 			public string OrderID { get { return "SetRallyPoint"; } }
 			public int OrderPriority { get { return 0; } }
 			public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
+			public bool CanDrag { get { return false; } }
 			public bool ForceSet { get; private set; }
 			public bool IsQueued { get; protected set; }
 
@@ -160,6 +162,11 @@ namespace OpenRA.Mods.Common.Traits
 				}
 
 				return false;
+			}
+
+			public IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world, Actor self, Target target)
+			{
+				yield break;
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
@@ -9,10 +9,9 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Activities;
+using OpenRA.Graphics;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Primitives;
@@ -83,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		// Note: Returns a valid order even if the unit can't move to the target
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID == "Enter" || order.OrderID == "Move")
 				return new Order(order.OrderID, self, target, queued);
@@ -174,6 +173,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public string OrderID { get { return "Move"; } }
 			public int OrderPriority { get { return 4; } }
+			public bool CanDrag { get { return false; } }
 			public bool IsQueued { get; protected set; }
 
 			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
@@ -193,6 +193,11 @@ namespace OpenRA.Mods.Common.Traits
 					cursor = "move-blocked";
 
 				return true;
+			}
+
+			public IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world, Actor self, Target target)
+			{
+				yield break;
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 			base.Created(self);
 		}
 
-		IEnumerable<IOrderTargeter> IIssueOrder.Orders
+		IEnumerable<IOrderTargeter> IIssueOrder.OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoEntersTunnels.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoEntersTunnels.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 			base.Created(self);
 		}
 
-		IEnumerable<IOrderTargeter> IIssueOrder.Orders
+		IEnumerable<IOrderTargeter> IIssueOrder.OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoEntersTunnels.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoEntersTunnels.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Traits
 			return self.CurrentActivity is Transform || transforms.Any(t => !t.IsTraitDisabled && !t.IsTraitPaused);
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID == "EnterTunnel")
 				return new Order(order.OrderID, self, target, queued) { SuppressVisualFeedback = true };

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
@@ -9,10 +9,9 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Activities;
+using OpenRA.Graphics;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -83,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		// Note: Returns a valid order even if the unit can't move to the target
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order is MoveOrderTargeter)
 				return new Order("Move", self, target, queued);
@@ -175,6 +174,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public string OrderID { get { return "Move"; } }
 			public int OrderPriority { get { return 4; } }
+			public bool CanDrag { get { return false; } }
 			public bool IsQueued { get; protected set; }
 
 			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
@@ -203,6 +203,11 @@ namespace OpenRA.Mods.Common.Traits
 					return false;
 
 				return mobile.locomotor.CanMoveFreelyInto(self, cell, BlockedByActor.All, null);
+			}
+
+			public IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world, Actor self, Target target)
+			{
+				yield break;
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 			base.Created(self);
 		}
 
-		IEnumerable<IOrderTargeter> IIssueOrder.Orders
+		IEnumerable<IOrderTargeter> IIssueOrder.OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoPassenger.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoPassenger.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 			base.Created(self);
 		}
 
-		IEnumerable<IOrderTargeter> IIssueOrder.Orders
+		IEnumerable<IOrderTargeter> IIssueOrder.OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoPassenger.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoPassenger.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID == "EnterTransport")
 				return new Order(order.OrderID, self, target, queued);

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoRepairable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoRepairable.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 			base.Created(self);
 		}
 
-		IEnumerable<IOrderTargeter> IIssueOrder.Orders
+		IEnumerable<IOrderTargeter> IIssueOrder.OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoRepairable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoRepairable.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Common.Traits
 			return Info.RepairActors.Contains(target.Info.Name);
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID == "Repair")
 				return new Order(order.OrderID, self, target, queued);

--- a/OpenRA.Mods.Common/Traits/Captures.cs
+++ b/OpenRA.Mods.Common/Traits/Captures.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID != "CaptureActor")
 				return null;

--- a/OpenRA.Mods.Common/Traits/Captures.cs
+++ b/OpenRA.Mods.Common/Traits/Captures.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 			captureManager = self.Trait<CaptureManager>();
 		}
 
-		public IEnumerable<IOrderTargeter> Orders
+		public IEnumerable<IOrderTargeter> OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -175,7 +175,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		static int GetWeight(Actor a) { return a.Info.TraitInfo<PassengerInfo>().Weight; }
 
-		public IEnumerable<IOrderTargeter> Orders
+		public IEnumerable<IOrderTargeter> OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -184,7 +184,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID == "Unload")
 				return new Order(order.OrderID, self, queued);

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -273,7 +273,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID == "PickupUnit" || order.OrderID == "DeliverUnit" || order.OrderID == "Unload")
 				return new Order(order.OrderID, self, target, queued);
@@ -371,6 +371,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public string OrderID { get { return "DeliverUnit"; } }
 			public int OrderPriority { get { return 6; } }
+			public bool CanDrag { get { return false; } }
 			public bool IsQueued { get; protected set; }
 			public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
 
@@ -407,6 +408,11 @@ namespace OpenRA.Mods.Common.Traits
 					cursor = info.DropOffBlockedCursor;
 
 				return true;
+			}
+
+			public IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world, Actor self, Target target)
+			{
+				yield break;
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -262,7 +262,7 @@ namespace OpenRA.Mods.Common.Traits
 			return Carryable != null && aircraft.CanLand(targetCell, blockedByMobile: false);
 		}
 
-		IEnumerable<IOrderTargeter> IIssueOrder.Orders
+		IEnumerable<IOrderTargeter> IIssueOrder.OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -181,7 +181,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID == "GrantConditionOnDeploy")
 				return new Order(order.OrderID, self, target, queued);

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -171,7 +171,7 @@ namespace OpenRA.Mods.Common.Traits
 			return false;
 		}
 
-		IEnumerable<IOrderTargeter> IIssueOrder.Orders
+		IEnumerable<IOrderTargeter> IIssueOrder.OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Traits/DeliversCash.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversCash.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 			get { yield return new DeliversCashOrderTargeter(); }
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID != "DeliverCash")
 				return null;

--- a/OpenRA.Mods.Common/Traits/DeliversCash.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversCash.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 		}
 
-		public IEnumerable<IOrderTargeter> Orders
+		public IEnumerable<IOrderTargeter> OrderTargeters
 		{
 			get { yield return new DeliversCashOrderTargeter(); }
 		}

--- a/OpenRA.Mods.Common/Traits/DeliversExperience.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversExperience.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 			gainsExperience = self.Trait<GainsExperience>();
 		}
 
-		public IEnumerable<IOrderTargeter> Orders
+		public IEnumerable<IOrderTargeter> OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Traits/DeliversExperience.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversExperience.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID != "DeliverExperience")
 				return null;

--- a/OpenRA.Mods.Common/Traits/Demolition.cs
+++ b/OpenRA.Mods.Common/Traits/Demolition.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 			get { yield return new DemolitionOrderTargeter(info); }
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID != "C4")
 				return null;

--- a/OpenRA.Mods.Common/Traits/Demolition.cs
+++ b/OpenRA.Mods.Common/Traits/Demolition.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 		}
 
-		public IEnumerable<IOrderTargeter> Orders
+		public IEnumerable<IOrderTargeter> OrderTargeters
 		{
 			get { yield return new DemolitionOrderTargeter(info); }
 		}

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 		public EngineerRepair(ActorInitializer init, EngineerRepairInfo info)
 			: base(info) { }
 
-		public IEnumerable<IOrderTargeter> Orders
+		public IEnumerable<IOrderTargeter> OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID != "EngineerRepair")
 				return null;

--- a/OpenRA.Mods.Common/Traits/EntersTunnels.cs
+++ b/OpenRA.Mods.Common/Traits/EntersTunnels.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 			move = self.Trait<IMove>();
 		}
 
-		public IEnumerable<IOrderTargeter> Orders
+		public IEnumerable<IOrderTargeter> OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Traits/EntersTunnels.cs
+++ b/OpenRA.Mods.Common/Traits/EntersTunnels.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits
 			return !requireForceMove || modifiers.HasModifier(TargetModifiers.ForceMove);
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID != "EnterTunnel")
 				return null;

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -277,7 +277,7 @@ namespace OpenRA.Mods.Common.Traits
 			return Info.Resources.Contains(resType.Info.Type);
 		}
 
-		IEnumerable<IOrderTargeter> IIssueOrder.Orders
+		IEnumerable<IOrderTargeter> IIssueOrder.OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -13,10 +13,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
+using OpenRA.Graphics;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.Common.Pathfinder;
-using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -288,7 +288,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID == "Deliver" || order.OrderID == "Harvest")
 				return new Order(order.OrderID, self, target, queued);
@@ -378,6 +378,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			public string OrderID { get { return "Harvest"; } }
 			public int OrderPriority { get { return 10; } }
+			public bool CanDrag { get { return false; } }
 			public bool IsQueued { get; protected set; }
 			public bool TargetOverridesSelection(Actor self, Target target, List<Actor> actorsAt, CPos xy, TargetModifiers modifiers) { return true; }
 
@@ -405,6 +406,11 @@ namespace OpenRA.Mods.Common.Traits
 				IsQueued = modifiers.HasModifier(TargetModifiers.ForceQueue);
 
 				return true;
+			}
+
+			public IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world, Actor self, Target target)
+			{
+				yield break;
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
+using OpenRA.Graphics;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Pathfinder;
 using OpenRA.Primitives;
@@ -897,7 +898,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		// Note: Returns a valid order even if the unit can't move to the target
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order is MoveOrderTargeter)
 				return new Order("Move", self, target, queued);
@@ -980,6 +981,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			public string OrderID { get { return "Move"; } }
 			public int OrderPriority { get { return 4; } }
+			public bool CanDrag { get { return false; } }
 			public bool IsQueued { get; protected set; }
 
 			public bool CanTarget(Actor self, Target target, List<Actor> othersAtTarget, ref TargetModifiers modifiers, ref string cursor)
@@ -1000,6 +1002,11 @@ namespace OpenRA.Mods.Common.Traits
 					cursor = mobile.Info.BlockedCursor;
 
 				return true;
+			}
+
+			public IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world, Actor self, Target target)
+			{
+				yield break;
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -887,7 +887,7 @@ namespace OpenRA.Mods.Common.Traits
 				self.World.ActorMap.UpdateOccupiedCells(self.OccupiesSpace);
 		}
 
-		IEnumerable<IOrderTargeter> IIssueOrder.Orders
+		IEnumerable<IOrderTargeter> IIssueOrder.OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -77,7 +77,7 @@ namespace OpenRA.Mods.Common.Traits
 			conditionManager = self.TraitOrDefault<ConditionManager>();
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID == "EnterTransport")
 				return new Order(order.OrderID, self, target, queued);

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Cargo ReservedCargo { get; private set; }
 
-		IEnumerable<IOrderTargeter> IIssueOrder.Orders
+		IEnumerable<IOrderTargeter> IIssueOrder.OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID == "Repair")
 				return new Order(order.OrderID, self, target, queued);

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits
 			isAircraft = self.Info.HasTraitInfo<AircraftInfo>();
 		}
 
-		IEnumerable<IOrderTargeter> IIssueOrder.Orders
+		IEnumerable<IOrderTargeter> IIssueOrder.OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		Order IIssueOrder.IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID == "RepairNear")
 				return new Order(order.OrderID, self, target, queued);

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 			Info = info;
 		}
 
-		IEnumerable<IOrderTargeter> IIssueOrder.Orders
+		IEnumerable<IOrderTargeter> IIssueOrder.OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Traits/RepairsBridges.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsBridges.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.info = info;
 		}
 
-		public IEnumerable<IOrderTargeter> Orders
+		public IEnumerable<IOrderTargeter> OrderTargeters
 		{
 			get { yield return new RepairBridgeOrderTargeter(info); }
 		}

--- a/OpenRA.Mods.Common/Traits/RepairsBridges.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsBridges.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 			get { yield return new RepairBridgeOrderTargeter(info); }
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID == "RepairBridge")
 				return new Order(order.OrderID, self, target, queued);

--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -108,7 +108,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
+		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued, CPos extraLoc)
 		{
 			if (order.OrderID == "DeployTransform")
 				return new Order(order.OrderID, self, queued);

--- a/OpenRA.Mods.Common/Traits/Transforms.cs
+++ b/OpenRA.Mods.Common/Traits/Transforms.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Traits
 			};
 		}
 
-		public IEnumerable<IOrderTargeter> Orders
+		public IEnumerable<IOrderTargeter> OrderTargeters
 		{
 			get
 			{

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -317,14 +317,8 @@ namespace OpenRA.Mods.Common.Widgets
 				return true;
 			}
 
-			var scrollType = MouseScrollType.Disabled;
-
-			if (mi.Button.HasFlag(MouseButton.Middle) || mi.Button.HasFlag(MouseButton.Left | MouseButton.Right))
-				scrollType = Game.Settings.Game.MiddleMouseScroll;
-			else if (mi.Button.HasFlag(MouseButton.Right) && Game.Settings.Game.UseClassicMouseStyle)
-				scrollType = Game.Settings.Game.RightMouseScroll;
-
-			if (scrollType == MouseScrollType.Disabled)
+			var scrollType = Game.Settings.Game.MouseScroll;
+			if (scrollType == MouseScrollType.Disabled || !mi.Button.HasFlag(Game.Settings.Game.ScrollButton))
 				return IsJoystickScrolling || isStandardScrolling;
 
 			if (scrollType == MouseScrollType.Standard || scrollType == MouseScrollType.Inverted)

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -321,7 +321,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (mi.Button.HasFlag(MouseButton.Middle) || mi.Button.HasFlag(MouseButton.Left | MouseButton.Right))
 				scrollType = Game.Settings.Game.MiddleMouseScroll;
-			else if (mi.Button.HasFlag(MouseButton.Right))
+			else if (mi.Button.HasFlag(MouseButton.Right) && Game.Settings.Game.UseClassicMouseStyle)
 				scrollType = Game.Settings.Game.RightMouseScroll;
 
 			if (scrollType == MouseScrollType.Disabled)

--- a/OpenRA.Platforms.Default/Sdl2Input.cs
+++ b/OpenRA.Platforms.Default/Sdl2Input.cs
@@ -28,6 +28,8 @@ namespace OpenRA.Platforms.Default
 			return b == SDL.SDL_BUTTON_LEFT ? MouseButton.Left
 				: b == SDL.SDL_BUTTON_RIGHT ? MouseButton.Right
 				: b == SDL.SDL_BUTTON_MIDDLE ? MouseButton.Middle
+				: b == SDL.SDL_BUTTON_X1 ? MouseButton.XButton1
+				: b == SDL.SDL_BUTTON_X2 ? MouseButton.XButton2
 				: 0;
 		}
 

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -387,23 +387,23 @@ Background@SETTINGS_PANEL:
 					Width: 160
 					Height: 20
 					Font: Regular
-					Text: Middle-mouse Scrolling:
+					Text: Mouse Scrolling Mode:
 					Align: Right
-				DropDownButton@MIDDLE_MOUSE_SCROLL:
+				DropDownButton@MOUSE_SCROLL:
 					X: PARENT_RIGHT - WIDTH - 15
 					Y: 38
 					Width: 100
 					Height: 25
 					Font: Regular
-				Label@MIDDLE_MOUSE_SCROLL_LABEL:
+				Label@MSCROLL_BUTTON_LABEL:
 					X: PARENT_RIGHT - WIDTH - 120
 					Y: 71
 					Width: 160
 					Height: 20
 					Font: Regular
-					Text: Right-mouse Scrolling:
+					Text: Mouse Scrolling Button:
 					Align: Right
-				DropDownButton@RIGHT_MOUSE_SCROLL:
+				DropDownButton@SCROLL_BUTTON:
 					X: PARENT_RIGHT - WIDTH - 15
 					Y: 68
 					Width: 100


### PR DESCRIPTION
Fixes #4380.

This reworks the place-minefield order to use a click and drag interface similar to the one for direction airstrikes. This solves a part of #16669 because it is no longer a separate order generator and is now consistent with other unit actions (the other part being attack-move/guard-move).

This is implemented by building the necessary hooks for click-drag orders into the generic unit order code. In this way it can be easily reused for other advanced unit controls such as #4525, #4813 or C&C3 style formations.