### PR TITLE
Let immovable actors block individual minefield cells.

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/LayMines.cs
+++ b/OpenRA.Mods.Cnc/Activities/LayMines.cs
@@ -100,12 +100,17 @@ namespace OpenRA.Mods.Cnc.Activities
 			return true;
 		}
 
-		public void CleanPlacedMines(Actor self)
+		public void CleanMineField(Actor self)
 		{
 			// Remove cells that have already been mined
+			// or that are revealed to be unmineable.
 			if (minefield != null)
+			{
+				var positionable = (IPositionable)movement;
 				minefield.RemoveAll(c => self.World.ActorMap.GetActorsAt(c)
-					.Any(a => a.Info.Name == minelayer.Info.Mine.ToLowerInvariant()));
+					.Any(a => a.Info.Name == minelayer.Info.Mine.ToLowerInvariant()) ||
+						(!positionable.CanEnterCell(c, null, BlockedByActor.Immovable) && !self.World.FogObscures(c)));
+			}
 		}
 
 		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -499,6 +499,7 @@ MNLY:
 		Range: 4c0
 	Minelayer:
 		Mine: MINV
+		TileUnknownName: build-valid
 	MineImmune:
 	AmmoPool:
 		Ammo: 5


### PR DESCRIPTION
As referenced in #17019, this PR makes cells occupied by immovable actors appear red when ordering a minefield and filters them out of the minefield list upon ordering, just like we do with blocking terrain.