### PR TITLE
Add sliding to Orka and Harpy

### DIFF
--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -90,7 +90,6 @@ ORCA:
 		TakeoffSounds: orcaup1.aud
 		LandingSounds: orcadwn1.aud
 		AltitudeVelocity: 128
-		CanSlide: false
 		TakeOffOnResupply: true
 	Health:
 		HP: 20000
@@ -333,7 +332,6 @@ APACHE:
 	Aircraft:
 		TurnSpeed: 5
 		Speed: 130
-		CanSlide: false
 		TakeOffOnResupply: true
 	Health:
 		HP: 22500


### PR DESCRIPTION
It was removed with the aircraft logic rework but I'm not really sure if that was intentional. Atliest It is not mentioned in the commit. Harpy is helicopter and Orka is a helicopter like aircraft, both should have the ability to slide. It feels horrible to control them without it.