### PR TITLE
Warhead refactor part 3: Add WarheadArgs

### DIFF
--- a/OpenRA.Game/Effects/DelayedImpact.cs
+++ b/OpenRA.Game/Effects/DelayedImpact.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Traits;
 
@@ -18,26 +19,23 @@ namespace OpenRA.Effects
 	public class DelayedImpact : IEffect
 	{
 		readonly Target target;
-		readonly Actor firedBy;
-		readonly IEnumerable<int> damageModifiers;
 		readonly IWarhead wh;
+		readonly WarheadArgs args;
 
 		int delay;
 
-		public DelayedImpact(int delay, IWarhead wh, Target target, Actor firedBy, IEnumerable<int> damageModifiers)
+		public DelayedImpact(int delay, IWarhead wh, Target target, WarheadArgs args)
 		{
 			this.wh = wh;
 			this.delay = delay;
-
 			this.target = target;
-			this.firedBy = firedBy;
-			this.damageModifiers = damageModifiers;
+			this.args = args;
 		}
 
 		public void Tick(World world)
 		{
 			if (--delay <= 0)
-				world.AddFrameEndTask(w => { w.Remove(this); wh.DoImpact(target, firedBy, damageModifiers); });
+				world.AddFrameEndTask(w => { w.Remove(this); wh.DoImpact(target, args); });
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr) { yield break; }

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using OpenRA.Activities;
 using OpenRA.FileSystem;
+using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Primitives;
@@ -490,7 +491,7 @@ namespace OpenRA.Traits
 		int Delay { get; }
 		bool IsValidAgainst(Actor victim, Actor firedBy);
 		bool IsValidAgainst(FrozenActor victim, Actor firedBy);
-		void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers);
+		void DoImpact(Target target, WarheadArgs args);
 	}
 
 	public interface IRulesetLoaded<TInfo> { void RulesetLoaded(Ruleset rules, TInfo info); }

--- a/OpenRA.Mods.Cnc/Projectiles/IonCannon.cs
+++ b/OpenRA.Mods.Cnc/Projectiles/IonCannon.cs
@@ -45,9 +45,18 @@ namespace OpenRA.Mods.Cnc.Effects
 		public void Tick(World world)
 		{
 			anim.Tick();
+
 			if (!impacted && weaponDelay-- <= 0)
 			{
-				weapon.Impact(target, firedBy.PlayerActor, Enumerable.Empty<int>());
+				var warheadArgs = new WarheadArgs
+				{
+					Weapon = weapon,
+					Source = target.CenterPosition,
+					SourceActor = firedBy.PlayerActor,
+					WeaponTarget = target
+				};
+
+				weapon.Impact(target, warheadArgs);
 				impacted = true;
 			}
 		}

--- a/OpenRA.Mods.Cnc/Projectiles/TeslaZap.cs
+++ b/OpenRA.Mods.Cnc/Projectiles/TeslaZap.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Cnc.Projectiles
 				target = args.Weapon.TargetActorCenter ? args.GuidedTarget.CenterPosition : args.GuidedTarget.Positions.PositionClosestTo(args.Source);
 
 			if (damageDuration-- > 0)
-				args.Weapon.Impact(Target.FromPos(target), args.SourceActor, args.DamageModifiers);
+				args.Weapon.Impact(Target.FromPos(target), new WarheadArgs(args));
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)

--- a/OpenRA.Mods.Cnc/Traits/EnergyWall.cs
+++ b/OpenRA.Mods.Cnc/Traits/EnergyWall.cs
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			{
 				var blockers = self.World.ActorMap.GetActorsAt(loc).Where(a => !a.IsDead && a != self);
 				foreach (var blocker in blockers)
-					info.WeaponInfo.Impact(Target.FromActor(blocker), self, Enumerable.Empty<int>());
+					info.WeaponInfo.Impact(Target.FromActor(blocker), self);
 			}
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -217,7 +217,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					if (mad.info.ThumpDamageWeapon != null)
 					{
 						// Use .FromPos since this weapon needs to affect more than just the MadTank actor
-						mad.info.ThumpDamageWeaponInfo.Impact(Target.FromPos(self.CenterPosition), self, Enumerable.Empty<int>());
+						mad.info.ThumpDamageWeaponInfo.Impact(Target.FromPos(self.CenterPosition), self);
 					}
 
 					screenShaker.AddEffect(mad.info.ThumpShakeTime, self.CenterPosition, mad.info.ThumpShakeIntensity, mad.info.ThumpShakeMultiplier);
@@ -241,7 +241,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					if (mad.info.DetonationWeapon != null)
 					{
 						// Use .FromPos since this actor is killed. Cannot use Target.FromActor
-						mad.info.DetonationWeaponInfo.Impact(Target.FromPos(self.CenterPosition), self, Enumerable.Empty<int>());
+						mad.info.DetonationWeaponInfo.Impact(Target.FromPos(self.CenterPosition), self);
 					}
 
 					self.Kill(self, mad.info.DamageTypes);

--- a/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (info.ExplosionWeapon != null)
 				{
 					// Use .FromPos since this actor is killed. Cannot use Target.FromActor
-					info.ExplosionWeapon.Impact(Target.FromPos(self.CenterPosition), self, Enumerable.Empty<int>());
+					info.ExplosionWeapon.Impact(Target.FromPos(self.CenterPosition), self);
 				}
 
 				self.Kill(self);

--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
@@ -231,7 +232,13 @@ namespace OpenRA.Mods.Common.Projectiles
 				foreach (var a in actors)
 				{
 					var adjustedModifiers = args.DamageModifiers.Append(GetFalloff((args.Source - a.CenterPosition).Length));
-					args.Weapon.Impact(Target.FromActor(a), args.SourceActor, adjustedModifiers);
+
+					var warheadArgs = new WarheadArgs(args)
+					{
+						DamageModifiers = adjustedModifiers.ToArray(),
+					};
+
+					args.Weapon.Impact(Target.FromActor(a), warheadArgs);
 				}
 			}
 

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -280,7 +280,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			world.AddFrameEndTask(w => w.Remove(this));
 
-			args.Weapon.Impact(Target.FromPos(pos), args.SourceActor, args.DamageModifiers);
+			args.Weapon.Impact(Target.FromPos(pos), new WarheadArgs(args));
 		}
 
 		bool AnyValidTargetsInRadius(World world, WPos pos, WDist radius, Actor firedBy, bool checkTargetType)

--- a/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
@@ -89,7 +89,8 @@ namespace OpenRA.Mods.Common.Projectiles
 			{
 				pos += new WVec(0, 0, args.PassiveTarget.Z - pos.Z);
 				world.AddFrameEndTask(w => w.Remove(this));
-				args.Weapon.Impact(Target.FromPos(pos), args.SourceActor, args.DamageModifiers);
+
+				args.Weapon.Impact(Target.FromPos(pos), new WarheadArgs(args));
 			}
 
 			if (anim != null)

--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Projectiles
 					target = Target.FromPos(blockedPos);
 			}
 
-			args.Weapon.Impact(target, args.SourceActor, args.DamageModifiers);
+			args.Weapon.Impact(target, new WarheadArgs(args));
 			world.AddFrameEndTask(w => w.Remove(this));
 		}
 

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -165,7 +165,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			if (ticks < info.DamageDuration && --interval <= 0)
 			{
-				args.Weapon.Impact(Target.FromPos(target), args.SourceActor, args.DamageModifiers);
+				args.Weapon.Impact(Target.FromPos(target), new WarheadArgs(args));
 				interval = info.DamageInterval;
 			}
 

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -891,7 +891,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			if (ticks <= info.Arm)
 				return;
 
-			args.Weapon.Impact(Target.FromPos(pos), args.SourceActor, args.DamageModifiers);
+			args.Weapon.Impact(Target.FromPos(pos), new WarheadArgs(args));
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)

--- a/OpenRA.Mods.Common/Projectiles/NukeLaunch.cs
+++ b/OpenRA.Mods.Common/Projectiles/NukeLaunch.cs
@@ -140,7 +140,17 @@ namespace OpenRA.Mods.Common.Effects
 			if (detonated)
 				return;
 
-			weapon.Impact(Target.FromPos(pos), firedBy.PlayerActor, Enumerable.Empty<int>());
+			var target = Target.FromPos(pos);
+			var warheadArgs = new WarheadArgs
+			{
+				Weapon = weapon,
+				Source = target.CenterPosition,
+				SourceActor = firedBy.PlayerActor,
+				WeaponTarget = target
+			};
+
+			weapon.Impact(target, warheadArgs);
+
 			world.WorldActor.Trait<ScreenShaker>().AddEffect(20, pos, 5);
 
 			foreach (var flash in world.WorldActor.TraitsImplementing<FlashPaletteEffect>())

--- a/OpenRA.Mods.Common/Projectiles/Railgun.cs
+++ b/OpenRA.Mods.Common/Projectiles/Railgun.cs
@@ -188,12 +188,12 @@ namespace OpenRA.Mods.Common.Projectiles
 					animationComplete = true;
 
 				if (!info.DamageActorsInLine)
-					args.Weapon.Impact(Target.FromPos(target), args.SourceActor, args.DamageModifiers);
+					args.Weapon.Impact(Target.FromPos(target), new WarheadArgs(args));
 				else
 				{
 					var actors = world.FindActorsOnLine(args.Source, target, info.BeamWidth);
 					foreach (var a in actors)
-						args.Weapon.Impact(Target.FromActor(a), args.SourceActor, args.DamageModifiers);
+						args.Weapon.Impact(Target.FromActor(a), new WarheadArgs(args));
 				}
 			}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -376,7 +376,7 @@ namespace OpenRA.Mods.Common.Traits
 			self.World.AddFrameEndTask(w =>
 			{
 				// Use .FromPos since this actor is killed. Cannot use Target.FromActor
-				info.DemolishWeaponInfo.Impact(Target.FromPos(self.CenterPosition), saboteur, Enumerable.Empty<int>());
+				info.DemolishWeaponInfo.Impact(Target.FromPos(self.CenterPosition), saboteur);
 
 				self.Kill(saboteur);
 			});

--- a/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
@@ -116,7 +116,7 @@ namespace OpenRA.Mods.Common.Traits
 					return;
 
 				// Use .FromPos since this actor is dead. Cannot use Target.FromActor
-				Info.DemolishWeaponInfo.Impact(Target.FromPos(self.CenterPosition), saboteur, Enumerable.Empty<int>());
+				Info.DemolishWeaponInfo.Impact(Target.FromPos(self.CenterPosition), saboteur);
 
 				self.Kill(saboteur);
 			});

--- a/OpenRA.Mods.Common/Traits/Crates/ExplodeCrateAction.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/ExplodeCrateAction.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override void Activate(Actor collector)
 		{
 			var weapon = collector.World.Map.Rules.Weapons[info.Weapon.ToLowerInvariant()];
-			weapon.Impact(Target.FromPos(collector.CenterPosition), collector, Enumerable.Empty<int>());
+			weapon.Impact(Target.FromPos(collector.CenterPosition), collector);
 
 			base.Activate(collector);
 		}

--- a/OpenRA.Mods.Common/Traits/Explodes.cs
+++ b/OpenRA.Mods.Common/Traits/Explodes.cs
@@ -120,13 +120,13 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				var cells = buildingInfo.UnpathableTiles(self.Location);
 				foreach (var c in cells)
-					weapon.Impact(Target.FromPos(self.World.Map.CenterOfCell(c)), source, Enumerable.Empty<int>());
+					weapon.Impact(Target.FromPos(self.World.Map.CenterOfCell(c)), source);
 
 				return;
 			}
 
 			// Use .FromPos since this actor is killed. Cannot use Target.FromActor
-			weapon.Impact(Target.FromPos(self.CenterPosition), source, Enumerable.Empty<int>());
+			weapon.Impact(Target.FromPos(self.CenterPosition), source);
 		}
 
 		WeaponInfo ChooseWeaponForExplosion(Actor self)

--- a/OpenRA.Mods.Common/Traits/ExplosionOnDamageTransition.cs
+++ b/OpenRA.Mods.Common/Traits/ExplosionOnDamageTransition.cs
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Traits
 					triggered = true;
 
 				// Use .FromPos since the actor might have been killed, don't use Target.FromActor
-				info.WeaponInfo.Impact(Target.FromPos(self.CenterPosition), e.Attacker, Enumerable.Empty<int>());
+				info.WeaponInfo.Impact(Target.FromPos(self.CenterPosition), e.Attacker);
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Warheads/ChangeOwnerWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/ChangeOwnerWarhead.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -23,8 +24,9 @@ namespace OpenRA.Mods.Common.Warheads
 
 		public readonly WDist Range = WDist.FromCells(1);
 
-		public override void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers)
+		public override void DoImpact(Target target, WarheadArgs args)
 		{
+			var firedBy = args.SourceActor;
 			var actors = target.Type == TargetType.Actor ? new[] { target.Actor } :
 				firedBy.World.FindActorsInCircle(target.CenterPosition, Range);
 

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.GameRules;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
@@ -103,8 +104,9 @@ namespace OpenRA.Mods.Common.Warheads
 			return invalidHit ? ImpactTargetType.InvalidActor : ImpactTargetType.NoActor;
 		}
 
-		public override void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers)
+		public override void DoImpact(Target target, WarheadArgs args)
 		{
+			var firedBy = args.SourceActor;
 			if (!target.IsValidFor(firedBy))
 				return;
 

--- a/OpenRA.Mods.Common/Warheads/CreateResourceWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateResourceWarhead.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -25,11 +26,12 @@ namespace OpenRA.Mods.Common.Warheads
 		public readonly string AddsResourceType = null;
 
 		// TODO: Allow maximum resource splatter to be defined. (Per tile, and in total).
-		public override void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers)
+		public override void DoImpact(Target target, WarheadArgs args)
 		{
 			if (string.IsNullOrEmpty(AddsResourceType))
 				return;
 
+			var firedBy = args.SourceActor;
 			var world = firedBy.World;
 			var targetTile = world.Map.CellContaining(target.CenterPosition);
 			var resLayer = world.WorldActor.Trait<ResourceLayer>();

--- a/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -57,8 +58,10 @@ namespace OpenRA.Mods.Common.Warheads
 			victim.InflictDamage(firedBy, new Damage(damage, DamageTypes));
 		}
 
-		public override void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers)
+		public override void DoImpact(Target target, WarheadArgs args)
 		{
+			var firedBy = args.SourceActor;
+
 			// Used by traits or warheads that damage a single actor, rather than a position
 			if (target.Type == TargetType.Actor)
 			{
@@ -74,10 +77,10 @@ namespace OpenRA.Mods.Common.Warheads
 				if (closestActiveShape == null)
 					return;
 
-				InflictDamage(victim, firedBy, closestActiveShape.Info, damageModifiers);
+				InflictDamage(victim, firedBy, closestActiveShape.Info, args.DamageModifiers);
 			}
 			else if (target.Type != TargetType.Invalid)
-				DoImpact(target.CenterPosition, firedBy, damageModifiers);
+				DoImpact(target.CenterPosition, firedBy, args.DamageModifiers);
 		}
 
 		public abstract void DoImpact(WPos pos, Actor firedBy, IEnumerable<int> damageModifiers);

--- a/OpenRA.Mods.Common/Warheads/DestroyResourceWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DestroyResourceWarhead.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -21,8 +22,9 @@ namespace OpenRA.Mods.Common.Warheads
 		public readonly int[] Size = { 0, 0 };
 
 		// TODO: Allow maximum resource removal to be defined. (Per tile, and in total).
-		public override void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers)
+		public override void DoImpact(Target target, WarheadArgs args)
 		{
+			var firedBy = args.SourceActor;
 			var world = firedBy.World;
 			var targetTile = world.Map.CellContaining(target.CenterPosition);
 			var resLayer = world.WorldActor.Trait<ResourceLayer>();

--- a/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
@@ -44,13 +44,15 @@ namespace OpenRA.Mods.Common.Warheads
 				throw new YamlException("Weapons Ruleset does not contain an entry '{0}'".F(Weapon.ToLowerInvariant()));
 		}
 
-		public override void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers)
+		public override void DoImpact(Target target, WarheadArgs args)
 		{
+			var firedBy = args.SourceActor;
 			if (!target.IsValidFor(firedBy))
 				return;
 
 			var map = firedBy.World.Map;
 			var targetCell = map.CellContaining(target.CenterPosition);
+			var damageModifiers = args.DamageModifiers;
 
 			var targetCells = CellsMatching(targetCell, false);
 			foreach (var c in targetCells)

--- a/OpenRA.Mods.Common/Warheads/GrantExternalConditionWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/GrantExternalConditionWarhead.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -27,8 +28,9 @@ namespace OpenRA.Mods.Common.Warheads
 
 		public readonly WDist Range = WDist.FromCells(1);
 
-		public override void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers)
+		public override void DoImpact(Target target, WarheadArgs args)
 		{
+			var firedBy = args.SourceActor;
 			var actors = target.Type == TargetType.Actor ? new[] { target.Actor } :
 				firedBy.World.FindActorsInCircle(target.CenterPosition, Range);
 

--- a/OpenRA.Mods.Common/Warheads/LeaveSmudgeWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/LeaveSmudgeWarhead.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -31,8 +32,9 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("Percentual chance the smudge is created.")]
 		public readonly int Chance = 100;
 
-		public override void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers)
+		public override void DoImpact(Target target, WarheadArgs args)
 		{
+			var firedBy = args.SourceActor;
 			var world = firedBy.World;
 
 			if (Chance < world.LocalRandom.Next(100))

--- a/OpenRA.Mods.Common/Warheads/Warhead.cs
+++ b/OpenRA.Mods.Common/Warheads/Warhead.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using OpenRA.GameRules;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -59,7 +60,7 @@ namespace OpenRA.Mods.Common.Warheads
 		}
 
 		/// <summary>Applies the warhead's effect against the target.</summary>
-		public abstract void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers);
+		public abstract void DoImpact(Target target, WarheadArgs args);
 
 		/// <summary>Checks if the warhead is valid against (can do something to) the actor.</summary>
 		public virtual bool IsValidAgainst(Actor victim, Actor firedBy)

--- a/OpenRA.Mods.D2k/Warheads/DamagesConcreteWarhead.cs
+++ b/OpenRA.Mods.D2k/Warheads/DamagesConcreteWarhead.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using OpenRA.GameRules;
 using OpenRA.Mods.Common.Warheads;
 using OpenRA.Mods.D2k.Traits;
 using OpenRA.Traits;
@@ -23,11 +24,12 @@ namespace OpenRA.Mods.D2k.Warheads
 		[FieldLoader.Require]
 		public readonly int Damage = 0;
 
-		public override void DoImpact(Target target, Actor firedBy, IEnumerable<int> damageModifiers)
+		public override void DoImpact(Target target, WarheadArgs args)
 		{
 			if (target.Type == TargetType.Invalid)
 				return;
 
+			var firedBy = args.SourceActor;
 			var world = firedBy.World;
 			var layer = world.WorldActor.Trait<BuildableTerrainLayer>();
 			var cell = world.Map.CellContaining(target.CenterPosition);


### PR DESCRIPTION
Adds `WarheadArgs` to simplify warhead code and make it easier to add more arguments in the future without having to update the warheads and their methods each time.

On the code side, the main concern is whether the initial set of args is sufficient and conceptually sound.
On the testing side, you only need to check whether this causes any regressions (which it shouldn't, but you never know).