### PR TITLE
MoveIntoWorld should take consideration to subcell

### DIFF
--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -73,6 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 				td.Add(new LocationInit(exit));
 				td.Add(new CenterPositionInit(spawn));
 				td.Add(new FacingInit(initialFacing));
+				td.Add(new SubCellInit(SubCell.Any));
 				if (exitinfo != null)
 					td.Add(new MoveIntoWorldDelayInit(exitinfo.ExitDelay));
 			}


### PR DESCRIPTION
Closes #17106

Not sure what the proper handling of the paratroopers is supposed to be now, with this PR they will die if they try to land in a full cell. Ping @pchote 

Think we have a hidden bug here in `Production`

Between when we check if the cell is empty 
https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Traits/Production.cs#L133
and in the `AddFrameEndTask` an actor could theoretical enter this cell. 
https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Mods.Common/Traits/Production.cs#L82