### PR TITLE
Fix the expansion mcv in soviet05 being transported off the map

### DIFF
--- a/mods/ra/maps/soviet-05/soviet05.lua
+++ b/mods/ra/maps/soviet-05/soviet05.lua
@@ -6,6 +6,7 @@
    the License, or (at your option) any later version. For more
    information, see COPYING.
 ]]
+
 CheckForBase = function()
 	baseBuildings = Map.ActorsInBox(Map.TopLeft, CFBPoint.CenterPosition, function(actor)
 		return actor.Type == "fact" or actor.Type == "powr"
@@ -75,32 +76,29 @@ RunInitialActivities = function()
 end
 
 Expand = function()
-	if ExpansionCheck then
-		return
-	elseif mcvtransport.IsDead then
-		return
-	elseif mcvGG.IsDead then
+	if ExpansionCheck or mcvtransport.IsDead or mcvGG.IsDead then
 		return
 	end
 
-	mcvGG.Move(mcvGGLoadPoint.Location)
-	mcvtransport.Move(lstBeachPoint.Location)
+	ExpansionCheck = true
+	Trigger.ClearAll(mcvGG)
+	Trigger.ClearAll(mcvtransport)
 	Media.DisplayMessage("Allied MCV detected moving to the island.")
 
 	Reinforcements.Reinforce(GoodGuy, { "dd", "dd" }, ShipArrivePath, 0, function(ddsquad)
 		ddsquad.AttackMove(NearExpPoint.Location) end)
 
-	ExpansionCheck = true
-	Trigger.ClearAll(mcvGG)
-	Trigger.ClearAll(mcvtransport)
-	Trigger.AfterDelay(DateTime.Seconds(3), function()
-		if mcvtransport.IsDead then
-			return
-		elseif mcvGG.IsDead then
+
+	mcvtransport.Move(lstBeachPoint.Location)
+
+	mcvGG.Move(mcvGGLoadPoint.Location)
+	mcvGG.EnterTransport(mcvtransport)
+
+	Trigger.AfterDelay(DateTime.Seconds(5), function()
+		if mcvtransport.IsDead or mcvGG.IsDead then
 			return
 		end
 
-		mcvGG.EnterTransport(mcvtransport)
 		mcvtransport.Move(GGUnloadPoint.Location)
 		mcvtransport.UnloadPassengers()
 		Trigger.AfterDelay(DateTime.Seconds(12), function()


### PR DESCRIPTION
Loading a unit into a transport seems to cancel all queued activities of the transport, so we have to let the mcv enter before queueing the first transport movements in the delayed function. Otherwise the move queued to the island gets cancelled and then the transport moves off the map because of the orders in the later `Trigger.AfterDelay` functions.

Testcase is simple: Either start the mission on hard to trigger the movement, or start on a different difficulty and build a sub pen using the dev cheats. You'll notice the transport with the mcv leaving the map on bleed.