### PR TITLE
Make nudger and locomotor cache aware of temporary immovable units.

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -262,7 +262,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				});
 				var driverMobile = driver.TraitOrDefault<Mobile>();
 				if (driverMobile != null)
-					driverMobile.Nudge(driver, driver, true);
+					driverMobile.Nudge(driver);
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -331,8 +331,7 @@ namespace OpenRA.Mods.Common.Activities
 			else
 			{
 				var cellInfo = notStupidCells
-					.SelectMany(c => self.World.ActorMap.GetActorsAt(c)
-						.Where(a => a.IsIdle && a.Info.HasTraitInfo<MobileInfo>()),
+					.SelectMany(c => self.World.ActorMap.GetActorsAt(c).Where(Mobile.Ismovable),
 						(c, a) => new { Cell = c, Actor = a })
 					.RandomOrDefault(self.World.SharedRandom);
 				if (cellInfo != null)

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -273,7 +273,7 @@ namespace OpenRA.Mods.Common.Activities
 				else if (mobile.IsBlocking)
 				{
 					// If there is no way around the blocker and blocker will not move and we are blocking others, back up to let others pass.
-					var newCell = GetAdjacentCell(self, nextCell);
+					var newCell = mobile.GetAdjacentCell(nextCell);
 					if (newCell != null)
 					{
 						if ((nextCell - newCell).Value.LengthSquared > 2)
@@ -307,38 +307,6 @@ namespace OpenRA.Mods.Common.Activities
 			}
 
 			return true;
-		}
-
-		CPos? GetAdjacentCell(Actor self, CPos nextCell)
-		{
-			var availCells = new List<CPos>();
-			var notStupidCells = new List<CPos>();
-			for (var i = -1; i <= 1; i++)
-			{
-				for (var j = -1; j <= 1; j++)
-				{
-					var p = mobile.ToCell + new CVec(i, j);
-					if (mobile.CanEnterCell(p))
-						availCells.Add(p);
-					else if (p != nextCell && p != mobile.ToCell)
-						notStupidCells.Add(p);
-				}
-			}
-
-			CPos? newCell = null;
-			if (availCells.Count > 0)
-				newCell = availCells.Random(self.World.SharedRandom);
-			else
-			{
-				var cellInfo = notStupidCells
-					.SelectMany(c => self.World.ActorMap.GetActorsAt(c).Where(Mobile.Ismovable),
-						(c, a) => new { Cell = c, Actor = a })
-					.RandomOrDefault(self.World.SharedRandom);
-				if (cellInfo != null)
-					newCell = cellInfo.Cell;
-			}
-
-			return newCell;
 		}
 
 		public override void Cancel(Actor self, bool keepQueue = false)

--- a/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Leave the current position in a random direction.")]
 		public void Scatter()
 		{
-			mobile.Nudge(Self, Self, true);
+			mobile.Nudge(Self);
 		}
 
 		[ScriptActorPropertyActivity]

--- a/OpenRA.Mods.Common/Traits/Crushable.cs
+++ b/OpenRA.Mods.Common/Traits/Crushable.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var mobile = self.TraitOrDefault<Mobile>();
 			if (mobile != null && self.World.SharedRandom.Next(100) <= Info.WarnProbability)
-				mobile.Nudge(self, crusher, true);
+				mobile.Nudge(crusher);
 		}
 
 		void INotifyCrushed.OnCrush(Actor self, Actor crusher, BitSet<CrushClass> crushClasses)

--- a/OpenRA.Mods.Common/Traits/EjectOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/EjectOnDeath.cs
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.Traits
 
 					var pilotMobile = pilot.TraitOrDefault<Mobile>();
 					if (pilotMobile != null)
-						pilotMobile.Nudge(pilot, pilot, true);
+						pilotMobile.Nudge(pilot);
 				});
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
@@ -76,7 +76,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!Panicking)
 				return;
 
-			mobile.Nudge(self, self, true);
+			mobile.Nudge(self);
 		}
 
 		void INotifyDamage.Damaged(Actor self, AttackInfo e)

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -334,7 +334,7 @@ namespace OpenRA.Mods.Common.Traits
 				self.Owner.Stances[otherActor.Owner] == Stance.Ally)
 			{
 				var mobile = otherActor.TraitOrDefault<Mobile>();
-				if (mobile != null && !mobile.IsTraitDisabled && !mobile.IsTraitPaused && !mobile.RequireForceMove)
+				if (mobile != null && !mobile.IsTraitDisabled && !mobile.IsTraitPaused && !mobile.IsImmovable)
 					return false;
 			}
 
@@ -487,7 +487,7 @@ namespace OpenRA.Mods.Common.Traits
 
 					var crushables = actor.TraitsImplementing<ICrushable>();
 					var mobile = actor.OccupiesSpace as Mobile;
-					var isMovable = mobile != null && !mobile.IsTraitDisabled && !mobile.IsTraitPaused && !mobile.RequireForceMove;
+					var isMovable = mobile != null && !mobile.IsTraitDisabled && !mobile.IsTraitPaused && !mobile.IsImmovable;
 					var isMoving = isMovable && mobile.CurrentMovementTypes.HasMovementType(MovementType.Horizontal);
 
 					if (crushables.Any())

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -331,9 +331,12 @@ namespace OpenRA.Mods.Common.Traits
 
 			// If the check allows: We are not blocked by units that we can force to move out of the way.
 			if (check <= BlockedByActor.Immovable && cellFlag.HasCellFlag(CellFlag.HasMovableActor) &&
-				self.Owner.Stances[otherActor.Owner] == Stance.Ally &&
-				otherActor.TraitOrDefault<IMove>() != null)
-				return false;
+				self.Owner.Stances[otherActor.Owner] == Stance.Ally)
+			{
+				var mobile = otherActor.TraitOrDefault<Mobile>();
+				if (mobile != null && !mobile.IsTraitDisabled && !mobile.IsTraitPaused && !mobile.RequireForceMove)
+					return false;
+			}
 
 			// If the check allows: we are not blocked by moving units.
 			if (check <= BlockedByActor.Stationary && cellFlag.HasCellFlag(CellFlag.HasMovingActor) &&
@@ -484,7 +487,7 @@ namespace OpenRA.Mods.Common.Traits
 
 					var crushables = actor.TraitsImplementing<ICrushable>();
 					var mobile = actor.OccupiesSpace as Mobile;
-					var isMovable = mobile != null;
+					var isMovable = mobile != null && !mobile.IsTraitDisabled && !mobile.IsTraitPaused && !mobile.RequireForceMove;
 					var isMoving = isMovable && mobile.CurrentMovementTypes.HasMovementType(MovementType.Horizontal);
 
 					if (crushables.Any())

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -332,6 +332,7 @@ JUGG:
 	Mobile:
 		Speed: 71
 		TurnSpeed: 5
+		ImmovableCondition: !undeployed
 		RequireForceMoveCondition: !undeployed
 	RevealsShroud:
 		RequiresCondition: !inside-tunnel

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -104,6 +104,7 @@ TTNK:
 	Mobile:
 		TurnSpeed: 5
 		Speed: 85
+		ImmovableCondition: !undeployed
 		RequireForceMoveCondition: !undeployed
 	Health:
 		HP: 35000
@@ -232,6 +233,7 @@ ART2:
 	Mobile:
 		Speed: 71
 		TurnSpeed: 2
+		ImmovableCondition: !undeployed
 		RequireForceMoveCondition: !undeployed
 	RevealsShroud:
 		RequiresCondition: !inside-tunnel

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -127,6 +127,7 @@ LPST:
 	Mobile:
 		Speed: 85
 		TurnSpeed: 5
+		ImmovableCondition: !undeployed
 		RequireForceMoveCondition: !undeployed
 	RevealsShroud:
 		RequiresCondition: !inside-tunnel && undeployed


### PR DESCRIPTION
Follow-up to #17114 

Fixes #17117.

Even though deployed units cannot be nudged, they were still regarded as movable for the purpose of pathfinding and cascading nudges. This PR changes units with the mobile trait disabled or paused to be regarded as immovable.