### PR TITLE
Fix lastVisibleTarget not being set in FlyAttack when target is invisible.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -99,6 +99,17 @@ namespace OpenRA.Mods.Common.Activities
 				lastVisibleTargetTypes = target.Actor.GetEnabledTargetTypes();
 			}
 
+			// The target may become hidden in the same tick the FlyAttack constructor is called,
+			// causing lastVisible* to remain uninitialized.
+			// Fix the fallback values based on the frozen actor properties
+			else if (target.Type == TargetType.FrozenActor && !lastVisibleTarget.IsValidFor(self))
+			{
+				lastVisibleTarget = Target.FromTargetPositions(target);
+				lastVisibleMaximumRange = attackAircraft.GetMaximumRangeVersusTarget(target);
+				lastVisibleOwner = target.FrozenActor.Owner;
+				lastVisibleTargetTypes = target.FrozenActor.TargetTypes;
+			}
+
 			useLastVisibleTarget = targetIsHiddenActor || !target.IsValidFor(self);
 
 			// Target is hidden or dead, and we don't have a fallback position to move towards

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -293,6 +293,17 @@ namespace OpenRA.Mods.Common.Traits
 					}
 				}
 
+				// The target may become hidden in the same tick the AttackActivity constructor is called,
+				// causing lastVisible* to remain uninitialized.
+				// Fix the fallback values based on the frozen actor properties
+				else if (target.Type == TargetType.FrozenActor && !lastVisibleTarget.IsValidFor(self))
+				{
+					lastVisibleTarget = Target.FromTargetPositions(target);
+					lastVisibleMaximumRange = attack.GetMaximumRangeVersusTarget(target);
+					lastVisibleOwner = target.FrozenActor.Owner;
+					lastVisibleTargetTypes = target.FrozenActor.TargetTypes;
+				}
+
 				var maxRange = lastVisibleMaximumRange;
 				var minRange = lastVisibleMinimumRange;
 				useLastVisibleTarget = targetIsHiddenActor || !target.IsValidFor(self);


### PR DESCRIPTION
Fixes #17050 

This issue happens when an attack order is given the moment the unit disappears under fog. At that point the actor is invisible to the player, but `target` is not yet updated to be a frozen actor and so lastvisible* is never set. This results in a `Fly` activity being queued with a max range of zero and the target only being updated after that `Fly` activity is finished.

There seems to be no clear reason to exclude targets that are invisible to the player here, because `lastVisibleTarget` is immediately converted to a terrain type anyway. I may be missing something though. Ping @pchote 