### PR TITLE
Add proper EMP behavior to TS aircraft

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FallToEarth.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
@@ -20,15 +21,16 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly Aircraft aircraft;
 		readonly FallsToEarthInfo info;
-		int acceleration = 0;
-		int spin = 0;
+
+		int acceleration;
+		int spin;
 
 		public FallToEarth(Actor self, FallsToEarthInfo info)
 		{
 			this.info = info;
 			IsInterruptible = false;
 			aircraft = self.Trait<Aircraft>();
-			if (info.Spins)
+			if (info.MaximumSpinSpeed != 0)
 				acceleration = self.World.SharedRandom.Next(2) * 2 - 1;
 		}
 
@@ -47,9 +49,11 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 			}
 
-			if (info.Spins)
+			if (info.MaximumSpinSpeed != 0)
 			{
-				spin += acceleration;
+				if (info.MaximumSpinSpeed < 0 || Math.Abs(spin) < info.MaximumSpinSpeed)
+					spin += acceleration; // TODO: Possibly unhardcode this
+
 				aircraft.Facing = (aircraft.Facing + spin) % 256;
 			}
 

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -254,7 +254,7 @@ namespace OpenRA.Mods.Common.Activities
 			// turnSpeed -> divide into 256 to get the number of ticks per complete rotation
 			// speed -> multiply to get distance travelled per rotation (circumference)
 			// 45 -> divide by 2*pi to get the turn radius: 45==256/(2*pi), with some extra leeway
-			return 45 * speed / turnSpeed;
+			return turnSpeed > 0 ? 45 * speed / turnSpeed : 0;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -117,6 +117,13 @@ namespace OpenRA.Mods.Common.Activities
 				Cancel(self);
 
 			var dat = self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition);
+			var isLanded = dat <= aircraft.LandAltitude;
+
+			// HACK: Prevent paused (for example, EMP'd) aircraft from taking off.
+			// This is necessary until the TODOs in the IsCanceling block below are adressed.
+			if (isLanded && aircraft.IsTraitPaused)
+				return false;
+
 			if (IsCanceling)
 			{
 				// We must return the actor to a sensible height before continuing.
@@ -128,7 +135,7 @@ namespace OpenRA.Mods.Common.Activities
 				var skipHeightAdjustment = landWhenIdle && self.CurrentActivity.IsCanceling && self.CurrentActivity.NextActivity == null;
 				if (aircraft.Info.CanHover && !skipHeightAdjustment && dat != aircraft.Info.CruiseAltitude)
 				{
-					if (dat <= aircraft.LandAltitude)
+					if (isLanded)
 						QueueChild(new TakeOff(self));
 					else
 						VerticalTakeOffOrLandTick(self, aircraft, aircraft.Facing, aircraft.Info.CruiseAltitude);
@@ -138,7 +145,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				return true;
 			}
-			else if (dat <= aircraft.LandAltitude)
+			else if (isLanded)
 			{
 				QueueChild(new TakeOff(self));
 				return false;

--- a/OpenRA.Mods.Common/Traits/Air/FallsToEarth.cs
+++ b/OpenRA.Mods.Common/Traits/Air/FallsToEarth.cs
@@ -19,10 +19,17 @@ namespace OpenRA.Mods.Common.Traits
 	public class FallsToEarthInfo : ITraitInfo, IRulesetLoaded, Requires<AircraftInfo>
 	{
 		[WeaponReference]
+		[Desc("Explosion weapon that triggers when hitting ground.")]
 		public readonly string Explosion = "UnitExplode";
 
-		public readonly bool Spins = true;
+		[Desc("Limit the maximum spin (in facing units per tick) that can be achieved while crashing.",
+			"0 disables spinning. Negative values imply no limit.")]
+		public readonly int MaximumSpinSpeed = -1;
+
+		[Desc("Does the aircraft (husk) move forward at aircraft speed?")]
 		public readonly bool Moves = false;
+
+		[Desc("Velocity (per tick) at which aircraft falls to ground.")]
 		public readonly WDist Velocity = new WDist(43);
 
 		public WeaponInfo ExplosionWeapon { get; private set; }

--- a/OpenRA.Mods.Common/Traits/KillsSelf.cs
+++ b/OpenRA.Mods.Common/Traits/KillsSelf.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Actors can be created without being added to the world
 			// We want to make sure that this only triggers once they are inserted into the world
 			if (lifetime == 0 && self.IsInWorld)
-				Kill(self);
+				self.World.AddFrameEndTask(w => Kill(self));
 		}
 
 		protected override void Created(Actor self)
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			if (lifetime-- <= 0)
-				Kill(self);
+				self.World.AddFrameEndTask(w => Kill(self));
 		}
 
 		void Kill(Actor self)

--- a/OpenRA.Mods.Common/UpdateRules/Rules/RenameSpins.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/RenameSpins.cs
@@ -1,0 +1,60 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RenameSpins : UpdateRule
+	{
+		public override string Name { get { return "FallsToEarth.Spins has been refactored to MaximumSpinSpeed."; } }
+		public override string Description
+		{
+			get
+			{
+				return "The FallsToEarth.Spins property has been refactored to MaximumSpinSpeed.";
+			}
+		}
+
+		readonly List<string> locations = new List<string>();
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (locations.Any())
+				yield return "The Spins property has been refactored to MaximumSpinSpeed.\n" +
+				             "MaximumSpinSpeed defaults to 'unlimited', while disabling is done by setting it to 0.\n" +
+				             "You may want to set a custom MaximumSpinSpeed limiting value in the following places:\n" +
+				             UpdateUtils.FormatMessageList(locations);
+
+			locations.Clear();
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var fallsToEarth in actorNode.ChildrenMatching("FallsToEarth"))
+			{
+				var spinsNode = fallsToEarth.LastChildMatching("Spins");
+				if (spinsNode != null)
+				{
+					var spins = spinsNode.NodeValue<bool>();
+					if (!spins)
+						fallsToEarth.AddNode("MaximumSpinSpeed", "0");
+
+					fallsToEarth.RemoveNode(spinsNode);
+					locations.Add("{0} ({1})".F(actorNode.Key, actorNode.Location.Filename));
+				}
+			}
+
+			yield break;
+		}
+	}
+}

--- a/mods/cnc/rules/defaults.yaml
+++ b/mods/cnc/rules/defaults.yaml
@@ -1087,7 +1087,6 @@
 		VTOL: true
 		CanSlide: True
 	FallsToEarth:
-		Spins: True
 		Moves: False
 		Explosion: HeliCrash
 	Tooltip:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -262,7 +262,7 @@
 		GenericName: Unit
 	WithShadow:
 	FallsToEarth:
-		Spins: False
+		MaximumSpinSpeed: 0
 		Moves: True
 		Explosion: UnitExplodeLarge
 	-MapEditorData:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -1030,10 +1030,10 @@
 		GenericName: Destroyed Plane
 	Aircraft:
 	FallsToEarth:
-		Spins: False
 		Moves: True
 		Velocity: 86
 		Explosion: UnitExplodePlane
+		MaximumSpinSpeed: 0
 	-MapEditorData:
 	RevealOnDeath:
 		Duration: 60

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -180,6 +180,7 @@ ORCAB:
 
 ORCATRAN:
 	Inherits: ^Aircraft
+	Inherits@EMPDISABLE: ^EmpDisable
 	Valued:
 		Cost: 1200
 	Tooltip:
@@ -219,6 +220,7 @@ ORCATRAN:
 
 TRNSPORT:
 	Inherits: ^Aircraft
+	Inherits@EMPDISABLE: ^EmpDisable
 	Valued:
 		Cost: 750
 	Tooltip:

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -116,6 +116,10 @@ ORCA:
 	RenderSprites:
 	SpawnActorOnDeath:
 		Actor: ORCA.Husk
+		RequiresCondition: !empdisable
+	SpawnActorOnDeath@EMP:
+		Actor: ORCA.Husk.EMP
+		RequiresCondition: empdisable
 	Rearmable:
 		RearmActors: gahpad, nahpad
 
@@ -173,6 +177,10 @@ ORCAB:
 		RequiresCondition: cruising
 	SpawnActorOnDeath:
 		Actor: ORCAB.Husk
+		RequiresCondition: !empdisable
+	SpawnActorOnDeath@EMP:
+		Actor: ORCAB.Husk.EMP
+		RequiresCondition: empdisable
 	Rearmable:
 		RearmActors: gahpad, nahpad
 
@@ -313,6 +321,10 @@ SCRIN:
 	DeathSounds:
 	SpawnActorOnDeath:
 		Actor: SCRIN.Husk
+		RequiresCondition: !empdisable
+	SpawnActorOnDeath@EMP:
+		Actor: SCRIN.Husk.EMP
+		RequiresCondition: empdisable
 	Rearmable:
 		RearmActors: gahpad, nahpad
 
@@ -371,6 +383,10 @@ APACHE:
 	RenderSprites:
 	SpawnActorOnDeath:
 		Actor: APACHE.Husk
+		RequiresCondition: !empdisable
+	SpawnActorOnDeath@EMP:
+		Actor: APACHE.Husk.EMP
+		RequiresCondition: empdisable
 	Rearmable:
 		RearmActors: gahpad, nahpad
 

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -67,10 +67,9 @@ DSHP:
 		Actor: DSHP.Husk
 
 ORCA:
-	Inherits: ^Aircraft
+	Inherits: ^EMPableAircraft
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
-	Inherits@EMPDISABLE: ^EmpDisable
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -121,10 +120,9 @@ ORCA:
 		RearmActors: gahpad, nahpad
 
 ORCAB:
-	Inherits: ^Aircraft
+	Inherits: ^EMPableAircraft
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
-	Inherits@EMPDISABLE: ^EmpDisable
 	Valued:
 		Cost: 1600
 	Tooltip:
@@ -179,8 +177,7 @@ ORCAB:
 		RearmActors: gahpad, nahpad
 
 ORCATRAN:
-	Inherits: ^Aircraft
-	Inherits@EMPDISABLE: ^EmpDisable
+	Inherits: ^EMPableAircraft
 	Valued:
 		Cost: 1200
 	Tooltip:
@@ -217,10 +214,13 @@ ORCATRAN:
 		AfterUnloadDelay: 40
 	SpawnActorOnDeath:
 		Actor: ORCATRAN.Husk
+		RequiresCondition: !empdisable
+	SpawnActorOnDeath@EMP:
+		Actor: ORCATRAN.Husk.EMP
+		RequiresCondition: empdisable
 
 TRNSPORT:
-	Inherits: ^Aircraft
-	Inherits@EMPDISABLE: ^EmpDisable
+	Inherits: ^EMPableAircraft
 	Valued:
 		Cost: 750
 	Tooltip:
@@ -255,12 +255,15 @@ TRNSPORT:
 		Bounds: 44,32,0,-8
 	SpawnActorOnDeath:
 		Actor: TRNSPORT.Husk
+		RequiresCondition: !empdisable
+	SpawnActorOnDeath@EMP:
+		Actor: TRNSPORT.Husk.EMP
+		RequiresCondition: empdisable
 
 SCRIN:
-	Inherits: ^Aircraft
+	Inherits: ^EMPableAircraft
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
-	Inherits@EMPDISABLE: ^EmpDisable
 	Valued:
 		Cost: 1500
 	Tooltip:
@@ -280,7 +283,6 @@ SCRIN:
 		CruiseAltitude: 5c0
 		TurnSpeed: 3
 		Speed: 168
-		AirborneCondition: airborne
 		TakeoffSounds: dropup1.aud
 		LandingSounds: dropdwn1.aud
 		CanHover: false
@@ -315,10 +317,9 @@ SCRIN:
 		RearmActors: gahpad, nahpad
 
 APACHE:
-	Inherits: ^Aircraft
+	Inherits: ^EMPableAircraft
 	Inherits@EXPERIENCE: ^GainsExperience
 	Inherits@AUTOTARGET: ^AutoTargetGroundAssaultMove
-	Inherits@EMPDISABLE: ^EmpDisable
 	Valued:
 		Cost: 1000
 	Tooltip:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -100,16 +100,21 @@
 	ExternalCondition@CRATE-SPEED:
 		Condition: crate-speed
 
+^EmpVisualEffects:
+	WithColoredOverlay@EMPDISABLE:
+		Palette: disabled
+	WithIdleOverlay@EMPDISABLE:
+		Sequence: emp-overlay
+		Palette: effect
+
 ^EmpDisable:
+	Inherits: ^EmpVisualEffects
 	WithColoredOverlay@EMPDISABLE:
 		RequiresCondition: empdisable
-		Palette: disabled
 	TimedConditionBar@EMPDISABLE:
 		Condition: empdisable
 		Color: FFFFFF
 	WithIdleOverlay@EMPDISABLE:
-		Sequence: emp-overlay
-		Palette: effect
 		RequiresCondition: empdisable
 	PowerMultiplier@EMPDISABLE:
 		RequiresCondition: empdisable
@@ -912,6 +917,14 @@
 		BobDistance: -64
 		InitialHeight: 64
 
+^EMPableAircraft:
+	Inherits: ^Aircraft
+	Inherits@EMP: ^EmpDisable
+	Aircraft:
+		PauseOnCondition: empdisable
+	KillsSelf:
+		RequiresCondition: airborne && empdisable
+
 ^AircraftHusk:
 	RenderVoxels:
 	RenderSprites:
@@ -934,7 +947,7 @@
 	FallsToEarth:
 		Spins: true
 		Moves: true
-		Velocity: 86
+		Velocity: 112
 	HitShape:
 
 ^Visceroid:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -945,9 +945,9 @@
 	Tooltip:
 		GenericName: Destroyed Aircraft
 	FallsToEarth:
-		Spins: true
 		Moves: true
 		Velocity: 112
+		MaximumSpinSpeed: 10
 	HitShape:
 
 ^Visceroid:

--- a/mods/ts/rules/husks.yaml
+++ b/mods/ts/rules/husks.yaml
@@ -97,7 +97,7 @@ APACHE.Husk:
 		TurnSpeed: 5
 		Speed: 130
 	WithIdleOverlay:
-		Offset: 85,0,384
+		Offset: 85,0,598
 		Sequence: rotor
 	RenderSprites:
 		Image: apache

--- a/mods/ts/rules/husks.yaml
+++ b/mods/ts/rules/husks.yaml
@@ -21,6 +21,10 @@ ORCA.Husk:
 	RenderVoxels:
 		Image: orca
 
+ORCA.Husk.EMP:
+	Inherits: ORCA.Husk
+	Inherits@EMP: ^EmpVisualEffects
+
 ORCAB.Husk:
 	Inherits: ^AircraftHusk
 	Tooltip:
@@ -32,6 +36,10 @@ ORCAB.Husk:
 		Image: orcab
 	RenderVoxels:
 		Image: orcab
+
+ORCAB.Husk.EMP:
+	Inherits: ORCAB.Husk
+	Inherits@EMP: ^EmpVisualEffects
 
 ORCATRAN.Husk:
 	Inherits: ^AircraftHusk
@@ -45,6 +53,10 @@ ORCATRAN.Husk:
 	RenderVoxels:
 		Image: orcatran
 
+ORCATRAN.Husk.EMP:
+	Inherits: ORCATRAN.Husk
+	Inherits@EMP: ^EmpVisualEffects
+
 TRNSPORT.Husk:
 	Inherits: ^AircraftHusk
 	Tooltip:
@@ -57,6 +69,10 @@ TRNSPORT.Husk:
 	RenderVoxels:
 		Image: trnsport
 
+TRNSPORT.Husk.EMP:
+	Inherits: TRNSPORT.Husk
+	Inherits@EMP: ^EmpVisualEffects
+
 SCRIN.Husk:
 	Inherits: ^AircraftHusk
 	Tooltip:
@@ -68,6 +84,10 @@ SCRIN.Husk:
 		Image: scrin
 	RenderVoxels:
 		Image: scrin
+
+SCRIN.Husk.EMP:
+	Inherits: SCRIN.Husk
+	Inherits@EMP: ^EmpVisualEffects
 
 APACHE.Husk:
 	Inherits: ^AircraftHusk
@@ -83,3 +103,7 @@ APACHE.Husk:
 		Image: apache
 	RenderVoxels:
 		Image: apache
+
+APACHE.Husk.EMP:
+	Inherits: APACHE.Husk
+	Inherits@EMP: ^EmpVisualEffects

--- a/mods/ts/rules/husks.yaml
+++ b/mods/ts/rules/husks.yaml
@@ -30,8 +30,10 @@ ORCAB.Husk:
 	Tooltip:
 		Name: Orca Bomber
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 3
 		Speed: 96
+	FallsToEarth:
+		MaximumSpinSpeed: 6
 	RenderSprites:
 		Image: orcab
 	RenderVoxels:
@@ -78,8 +80,10 @@ SCRIN.Husk:
 	Tooltip:
 		Name: Banshee Fighter
 	Aircraft:
-		TurnSpeed: 5
+		TurnSpeed: 3
 		Speed: 168
+	FallsToEarth:
+		MaximumSpinSpeed: 6
 	RenderSprites:
 		Image: scrin
 	RenderVoxels:

--- a/mods/ts/sequences/aircraft.yaml
+++ b/mods/ts/sequences/aircraft.yaml
@@ -7,6 +7,7 @@ orcab:
 	icon: obmbicon
 
 trnsport:
+	Inherits: ^VehicleOverlays
 	icon: otrnicon
 
 scrin:
@@ -27,4 +28,5 @@ apache:
 		ZRamp: 1
 
 orcatran:
+	Inherits: ^VehicleOverlays
 	icon: crryicon

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -119,14 +119,14 @@ EMPulseCannon:
 		Speed: 425
 		Blockable: false
 		Shadow: true
-		LaunchAngle: 62
+		LaunchAngle: 96
 		Image: pulsball
 	Warhead@1Eff: CreateEffect
 		Explosions: pulse_explosion
 		ExplosionPalette: effect-ignore-lighting-alpha75
 		ImpactActors: false
 	Warhead@emp: GrantExternalCondition
-		Range: 4c0
+		Range: 6c0
 		Duration: 250
 		Condition: empdisable
-		ValidTargets: Ground, Water, Underground
+		ValidTargets: Ground, Water, Air, Underground


### PR DESCRIPTION
This PR
- makes `Aircraft` pausable-conditional
- makes landed, EMP'd TS aircraft behave like EMP'd ground vehicles
- makes airborne TS aircraft crash when EMP'd

Closes #17096.
Fixes #16421.