### PR TITLE
Make service depots passable but not blockable

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -158,9 +158,7 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			mobile.TurnToMove = false;
 
-			// If the actor is inside a tunnel then we must let them move
-			// all the way through before moving to the next activity
-			if (IsCanceling && self.Location.Layer != CustomMovementLayerType.Tunnel && mobile.CanStayInCell(mobile.ToCell))
+			if (IsCanceling && mobile.CanStayInCell(mobile.ToCell))
 			{
 				if (path != null)
 					path.Clear();

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Common.Activities
 				// HACK: Repairable needs the actor to move to host center.
 				// TODO: Get rid of this or at least replace it with something less hacky.
 				if (repairableNear == null)
-					QueueChild(move.MoveTo(targetCell, ignoreActor: host.Actor));
+					QueueChild(move.MoveTo(targetCell));
 
 				var delta = (self.CenterPosition - host.CenterPosition).LengthSquared;
 				var transport = transportCallers.FirstOrDefault(t => t.MinimumDistance.LengthSquared < delta);

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -23,7 +23,8 @@ namespace OpenRA.Mods.Common.Traits
 		Empty = '_',
 		OccupiedPassable = '=',
 		Occupied = 'x',
-		OccupiedUntargetable = 'X'
+		OccupiedUntargetable = 'X',
+		OccupiedPassableTransitOnly = '+'
 	}
 
 	public class BuildingInfo : ITraitInfo, IOccupySpaceInfo, IPlaceBuildingDecorationInfo
@@ -107,6 +108,9 @@ namespace OpenRA.Mods.Common.Traits
 
 			foreach (var t in FootprintTiles(location, FootprintCellType.OccupiedUntargetable))
 				yield return t;
+
+			foreach (var t in FootprintTiles(location, FootprintCellType.OccupiedPassableTransitOnly))
+				yield return t;
 		}
 
 		public IEnumerable<CPos> FrozenUnderFogTiles(CPos location)
@@ -118,12 +122,15 @@ namespace OpenRA.Mods.Common.Traits
 				yield return t;
 		}
 
-		public IEnumerable<CPos> UnpathableTiles(CPos location)
+		public IEnumerable<CPos> OccupiedTiles(CPos location)
 		{
 			foreach (var t in FootprintTiles(location, FootprintCellType.Occupied))
 				yield return t;
 
 			foreach (var t in FootprintTiles(location, FootprintCellType.OccupiedUntargetable))
+				yield return t;
+
+			foreach (var t in FootprintTiles(location, FootprintCellType.OccupiedPassableTransitOnly))
 				yield return t;
 		}
 
@@ -133,6 +140,12 @@ namespace OpenRA.Mods.Common.Traits
 				yield return t;
 
 			foreach (var t in FootprintTiles(location, FootprintCellType.OccupiedPassable))
+				yield return t;
+		}
+
+		public IEnumerable<CPos> TransitOnlyTiles(CPos location)
+		{
+			foreach (var t in FootprintTiles(location, FootprintCellType.OccupiedPassableTransitOnly))
 				yield return t;
 		}
 
@@ -225,7 +238,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IReadOnlyDictionary<CPos, SubCell> OccupiedCells(ActorInfo info, CPos topLeft, SubCell subCell = SubCell.Any)
 		{
-			var occupied = UnpathableTiles(topLeft)
+			var occupied = OccupiedTiles(topLeft)
 				.ToDictionary(c => c, c => SubCell.FullCell);
 
 			return new ReadOnlyDictionary<CPos, SubCell>(occupied);
@@ -255,6 +268,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		Pair<CPos, SubCell>[] occupiedCells;
 		Pair<CPos, SubCell>[] targetableCells;
+		CPos[] transitOnlyCells;
 
 		public CPos TopLeft { get { return topLeft; } }
 		public WPos CenterPosition { get; private set; }
@@ -266,16 +280,20 @@ namespace OpenRA.Mods.Common.Traits
 			Info = info;
 			influence = self.World.WorldActor.Trait<BuildingInfluence>();
 
-			occupiedCells = Info.UnpathableTiles(TopLeft)
+			occupiedCells = Info.OccupiedTiles(TopLeft)
 				.Select(c => Pair.New(c, SubCell.FullCell)).ToArray();
 
 			targetableCells = Info.FootprintTiles(TopLeft, FootprintCellType.Occupied)
 				.Select(c => Pair.New(c, SubCell.FullCell)).ToArray();
 
+			transitOnlyCells = Info.TransitOnlyTiles(TopLeft).ToArray();
+
 			CenterPosition = init.World.Map.CenterOfCell(topLeft) + Info.CenterOffset(init.World);
 		}
 
 		public Pair<CPos, SubCell>[] OccupiedCells() { return occupiedCells; }
+
+		public CPos[] TransitOnlyCells() { return transitOnlyCells; }
 
 		Pair<CPos, SubCell>[] ITargetableCells.TargetableCells() { return targetableCells; }
 

--- a/OpenRA.Mods.Common/Traits/Explodes.cs
+++ b/OpenRA.Mods.Common/Traits/Explodes.cs
@@ -118,7 +118,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (Info.Type == ExplosionType.Footprint && buildingInfo != null)
 			{
-				var cells = buildingInfo.UnpathableTiles(self.Location);
+				var cells = buildingInfo.OccupiedTiles(self.Location);
 				foreach (var c in cells)
 					weapon.Impact(Target.FromPos(self.World.Map.CenterOfCell(c)), source, Enumerable.Empty<int>());
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -109,6 +109,9 @@ namespace OpenRA.Mods.Common.Traits
 				locomotor = world.WorldActor.TraitsImplementing<Locomotor>()
 				   .SingleOrDefault(l => l.Info.Name == Locomotor);
 
+			if (cell.Layer == CustomMovementLayerType.Tunnel)
+				return false;
+
 			return locomotor.CanStayInCell(cell);
 		}
 

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -27,7 +27,8 @@ namespace OpenRA.Mods.Common.Traits
 		HasStationaryActor = 2,
 		HasMovableActor = 4,
 		HasCrushableActor = 8,
-		HasTemporaryBlocker = 16
+		HasTemporaryBlocker = 16,
+		HasTransitOnlyActor = 32,
 	}
 
 	public static class LocomoterExts
@@ -309,6 +310,11 @@ namespace OpenRA.Mods.Common.Traits
 			return true;
 		}
 
+		public bool CanStayInCell(CPos cell)
+		{
+			return !GetCache(cell).CellFlag.HasCellFlag(CellFlag.HasTransitOnlyActor);
+		}
+
 		public SubCell GetAvailableSubCell(Actor self, CPos cell, BlockedByActor check, SubCell preferredSubCell = SubCell.Any, Actor ignoreActor = null)
 		{
 			if (MovementCostForCell(cell) == short.MaxValue)
@@ -495,6 +501,15 @@ namespace OpenRA.Mods.Common.Traits
 					var mobile = actor.OccupiesSpace as Mobile;
 					var isMovable = mobile != null && !mobile.IsTraitDisabled && !mobile.IsTraitPaused && !mobile.IsImmovable;
 					var isMoving = isMovable && mobile.CurrentMovementTypes.HasMovementType(MovementType.Horizontal);
+
+					var building = actor.OccupiesSpace as Building;
+					var isTransitOnly = building != null && building.TransitOnlyCells().Contains(cell);
+
+					if (isTransitOnly)
+					{
+						cellFlag |= CellFlag.HasTransitOnlyActor;
+						continue;
+					}
 
 					if (crushables.Any())
 					{

--- a/OpenRA.Mods.D2k/Traits/Buildings/D2kActorPreviewPlaceBuildingPreview.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/D2kActorPreviewPlaceBuildingPreview.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 			buildBlocked = sequences.GetSequence("overlay", "build-invalid").GetSprite(0);
 
 			var buildingInfo = ai.TraitInfo<BuildingInfo>();
-			unpathableCells = new CachedTransform<CPos, List<CPos>>(topLeft => buildingInfo.UnpathableTiles(topLeft).ToList());
+			unpathableCells = new CachedTransform<CPos, List<CPos>>(topLeft => buildingInfo.OccupiedTiles(topLeft).ToList());
 		}
 
 		protected override IEnumerable<IRenderable> RenderFootprint(WorldRenderer wr, CPos topLeft, Dictionary<CPos, PlaceBuildingCellType> footprint,

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -678,7 +678,7 @@ FIX:
 		Queue: Building.GDI, Building.Nod
 		Description: Repairs vehicles
 	Building:
-		Footprint: _X_ xxx _X_
+		Footprint: _=_ === _=_
 		Dimensions: 3,3
 	Selectable:
 		Bounds: 64,34,0,3

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -678,7 +678,7 @@ FIX:
 		Queue: Building.GDI, Building.Nod
 		Description: Repairs vehicles
 	Building:
-		Footprint: _=_ === _=_
+		Footprint: _+_ +++ _+_
 		Dimensions: 3,3
 	Selectable:
 		Bounds: 64,34,0,3

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -881,7 +881,7 @@ repair_pad:
 	Tooltip:
 		Name: Repair Pad
 	Building:
-		Footprint: =x= xxx =x=
+		Footprint: === === ===
 		Dimensions: 3,3
 	Health:
 		HP: 30000

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -881,7 +881,7 @@ repair_pad:
 	Tooltip:
 		Name: Repair Pad
 	Building:
-		Footprint: === === ===
+		Footprint: +++ +++ +++
 		Dimensions: 3,3
 	Health:
 		HP: 30000

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1989,7 +1989,7 @@ FIX:
 	Tooltip:
 		Name: Service Depot
 	Building:
-		Footprint: _=_ === _=_
+		Footprint: _+_ +++ _+_
 		Dimensions: 3,3
 	Selectable:
 		Bounds: 68,34,0,3

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1989,7 +1989,7 @@ FIX:
 	Tooltip:
 		Name: Service Depot
 	Building:
-		Footprint: _=_ xxx _=_
+		Footprint: _=_ === _=_
 		Dimensions: 3,3
 	Selectable:
 		Bounds: 68,34,0,3

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -320,7 +320,7 @@ GADEPT:
 		Queue: Building
 		Description: Repairs vehicles.
 	Building:
-		Footprint: =x= xxx =x=
+		Footprint: === x== x==
 		Dimensions: 3,3
 	Selectable:
 		Bounds: 96, 64, -6, -6

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -320,7 +320,7 @@ GADEPT:
 		Queue: Building
 		Description: Repairs vehicles.
 	Building:
-		Footprint: === x== x==
+		Footprint: =+= x++ x+=
 		Dimensions: 3,3
 	Selectable:
 		Bounds: 96, 64, -6, -6

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -183,7 +183,7 @@ GAWEAP:
 		Prerequisites: proc, ~structures.gdi, ~techlevel.low
 		Description: Produces vehicles.
 	Building:
-		Footprint: xxX= xxX= xxX=
+		Footprint: xxX+ xxX+ xxX+
 		Dimensions: 4,3
 	Selectable:
 		Bounds: 154, 96, -2, -12

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -195,7 +195,7 @@ NAWEAP:
 		Prerequisites: proc, ~structures.nod, ~techlevel.low
 		Description: Produces vehicles.
 	Building:
-		Footprint: xxX= xxX= xxX=
+		Footprint: xxX+ xxX+ xxX+
 		Dimensions: 4,3
 	Selectable:
 		Bounds: 149, 80, -3, -10

--- a/mods/ts/rules/shared-structures.yaml
+++ b/mods/ts/rules/shared-structures.yaml
@@ -97,7 +97,7 @@ PROC:
 		Prerequisites: anypower, ~techlevel.low
 		Description: Processes raw Tiberium\ninto useable resources.
 	Building:
-		Footprint: xxX= xx== xxX=
+		Footprint: xxX+ xx++ xxX+
 		Dimensions: 4,3
 	Selectable:
 		Bounds: 134, 96, 0, -12


### PR DESCRIPTION
Fixes #16934 
Fixes #16465 

This makes all service depots passable for the pathfinder, but prevents units from stopping on the service depot when not ordered to repair. It also fixes the repair arm in TS from being passable. 

The same logic is also applied to the bibs of weapon factories and refineries in TS to prevent production blocking and to make them more in line with the original (https://github.com/OpenRA/OpenRA/pull/17105#issuecomment-532802439).