### PR TITLE
Fix actors returning fire at invisible attackers

### DIFF
--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -127,6 +127,9 @@ namespace OpenRA.Mods.Common.Traits
 	public class AutoTarget : ConditionalTrait<AutoTargetInfo>, INotifyIdle, INotifyDamage, ITick, IResolveOrder, ISync, INotifyOwnerChanged
 	{
 		public readonly IEnumerable<AttackBase> ActiveAttackBases;
+
+		readonly bool allowMovement;
+
 		[Sync]
 		int nextScanTime = 0;
 
@@ -187,6 +190,8 @@ namespace OpenRA.Mods.Common.Traits
 				stance = self.Owner.IsBot || !self.Owner.Playable ? info.InitialStanceAI : info.InitialStance;
 
 			PredictedStance = stance;
+
+			allowMovement = Info.AllowMovement && self.TraitOrDefault<IMove>() != null;
 		}
 
 		protected override void Created(Actor self)
@@ -244,7 +249,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// Don't fire at an invisible enemy when we can't move to reveal it
-			var allowMove = Info.AllowMovement && Stance > UnitStance.Defend;
+			var allowMove = allowMovement && Stance > UnitStance.Defend;
 			if (!allowMove && !attacker.CanBeViewedByPlayer(self.Owner))
 				return;
 
@@ -267,7 +272,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (IsTraitDisabled || Stance < UnitStance.Defend)
 				return;
 
-			var allowMove = Info.AllowMovement && Stance > UnitStance.Defend;
+			var allowMove = allowMovement && Stance > UnitStance.Defend;
 			var allowTurn = Info.AllowTurning && Stance > UnitStance.HoldFire;
 			ScanAndAttack(self, allowMove, allowTurn);
 		}

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -243,6 +243,11 @@ namespace OpenRA.Mods.Common.Traits
 					attacker = passenger.Transport;
 			}
 
+			// Don't fire at an invisible enemy when we can't move to reveal it
+			var allowMove = Info.AllowMovement && Stance > UnitStance.Defend;
+			if (!allowMove && !attacker.CanBeViewedByPlayer(self.Owner))
+				return;
+
 			// Not a lot we can do about things we can't hurt... although maybe we should automatically run away?
 			var attackerAsTarget = Target.FromActor(attacker);
 			if (!ActiveAttackBases.Any(a => a.HasAnyValidWeapons(attackerAsTarget)))
@@ -254,7 +259,6 @@ namespace OpenRA.Mods.Common.Traits
 
 			Aggressor = attacker;
 
-			var allowMove = Info.AllowMovement && Stance > UnitStance.Defend;
 			Attack(self, Target.FromActor(Aggressor), allowMove);
 		}
 


### PR DESCRIPTION
Closes #16335.
Closes #16461.

Reproduction case:
- Place two teslas inside arms range, but outside vision range
- Move a single rifle man right next to one coil into the vision range of the other coil
- The other coil will kill the rifle man and although not doing damage still hit the first coil
- The first coil will start firing at the unrevealed tesla coil

Illustration:
![grafik](https://user-images.githubusercontent.com/7704140/65717576-fec21700-e0a1-11e9-9aa0-7955053c7748.png)