### PR TITLE
Throw a lua exception when setting an owner to null/nil

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
@@ -60,6 +60,9 @@ namespace OpenRA.Mods.Common.Scripting
 
 			set
 			{
+				if (value == null)
+					throw new LuaException("Attempted to change the owner of actor '{0}' to nil value.".F(Self));
+
 				if (Self.Owner != value)
 					Self.ChangeOwner(value);
 			}


### PR DESCRIPTION
Closes #14224.

We already prevent setting an invalid `OwnerInit`.