### PR TITLE
Lua API - Added Actor.TooltipName

### DIFF
--- a/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/GeneralProperties.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System.Linq;
 using Eluant;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Effects;
@@ -100,6 +101,7 @@ namespace OpenRA.Mods.Common.Scripting
 		readonly IFacing facing;
 		readonly AutoTarget autotarget;
 		readonly ScriptTags scriptTags;
+		readonly Tooltip[] tooltips;
 
 		public GeneralProperties(ScriptContext context, Actor self)
 			: base(context, self)
@@ -107,6 +109,7 @@ namespace OpenRA.Mods.Common.Scripting
 			facing = self.TraitOrDefault<IFacing>();
 			autotarget = self.TraitOrDefault<AutoTarget>();
 			scriptTags = self.TraitOrDefault<ScriptTags>();
+			tooltips = self.TraitsImplementing<Tooltip>().ToArray();
 		}
 
 		[Desc("The actor position in cell coordinates.")]
@@ -183,6 +186,19 @@ namespace OpenRA.Mods.Common.Scripting
 
 				autotarget.PredictedStance = stance;
 				autotarget.SetStance(Self, stance);
+			}
+		}
+
+		[Desc("The actor's tooltip name. Returns nil if the actor has no tooltip.")]
+		public string TooltipName
+		{
+			get
+			{
+				var tooltip = tooltips.FirstEnabledTraitOrDefault();
+				if (tooltip == null)
+					return null;
+
+				return tooltip.Info.Name;
 			}
 		}
 


### PR DESCRIPTION
This adds a new Lua actor property, `TooltipName`. 

It returns the actor's tooltip name (e.g. `apwr.TooltipName` = `'Advanced Power Plant'`). 

A test case is attached, will remove it if approved.