### PR TITLE
Fix harvesters idling in some TD missions

### DIFF
--- a/mods/cnc/maps/gdi05a/rules.yaml
+++ b/mods/cnc/maps/gdi05a/rules.yaml
@@ -72,8 +72,6 @@ RMBO:
 		Prerequisites: ~disabled
 
 HARV:
-	Harvester:
-		SearchFromHarvesterRadius: 24
 	Buildable:
 		Prerequisites: ~disabled
 

--- a/mods/cnc/maps/nod05/rules.yaml
+++ b/mods/cnc/maps/nod05/rules.yaml
@@ -91,6 +91,7 @@ HARV:
 	Buildable:
 		Prerequisites: ~disabled
 	Harvester:
+		SearchFromProcRadius: 24
 		SearchFromHarvesterRadius: 24
 
 FTNK:

--- a/mods/cnc/maps/nod07a/rules.yaml
+++ b/mods/cnc/maps/nod07a/rules.yaml
@@ -67,6 +67,7 @@ E6:
 
 HARV:
 	Harvester:
+		SearchFromProcRadius: 45
 		SearchFromHarvesterRadius: 45
 
 HTNK:

--- a/mods/cnc/maps/nod07b/rules.yaml
+++ b/mods/cnc/maps/nod07b/rules.yaml
@@ -63,6 +63,7 @@ E5:
 
 HARV:
 	Harvester:
+		SearchFromProcRadius: 45
 		SearchFromHarvesterRadius: 45
 
 MTNK:

--- a/mods/cnc/maps/nod07c/rules.yaml
+++ b/mods/cnc/maps/nod07c/rules.yaml
@@ -70,6 +70,7 @@ E5:
 
 HARV:
 	Harvester:
+		SearchFromProcRadius: 30
 		SearchFromHarvesterRadius: 30
 
 HTNK:

--- a/mods/cnc/maps/nod08a/rules.yaml
+++ b/mods/cnc/maps/nod08a/rules.yaml
@@ -78,10 +78,6 @@ E5:
 E6:
 	-RepairsBridges:
 
-HARV:
-	Harvester:
-		SearchFromHarvesterRadius: 30
-
 MTNK:
 	Buildable:
 		Prerequisites: ~weap

--- a/mods/cnc/maps/nod08b/rules.yaml
+++ b/mods/cnc/maps/nod08b/rules.yaml
@@ -97,6 +97,7 @@ E6:
 
 HARV:
 	Harvester:
+		SearchFromProcRadius: 30
 		SearchFromHarvesterRadius: 30
 
 MTNK:

--- a/mods/cnc/maps/nod09/rules.yaml
+++ b/mods/cnc/maps/nod09/rules.yaml
@@ -83,10 +83,6 @@ E5:
 	Buildable:
 		Prerequisites: ~disabled
 
-HARV:
-	Harvester:
-		SearchFromHarvesterRadius: 45
-
 HTNK:
 	Buildable:
 		Prerequisites: ~disabled


### PR DESCRIPTION
`SearchFromHarvesterRadius` was set, but not `SearchFromProcRadius` which meant they would idle until you destroyed their refinery. Only then they would start harvesting. I also removed `SearchFromHarvesterRadius` from a few missions where I think it is unnecessary since the AI either has a big Tiberium patch, or at least one tree for regrowing Tiberium.