### PR TITLE
Update packaging to Mono 6.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 
 dist: xenial
 language: csharp
-mono: 5.20.1
+mono: 6.4.0
 
 cache:
   directories:

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -7,7 +7,7 @@ command -v python >/dev/null 2>&1 || { echo >&2 "Linux packaging requires python
 command -v tar >/dev/null 2>&1 || { echo >&2 "Linux packaging requires tar."; exit 1; }
 command -v curl >/dev/null 2>&1 || command -v wget > /dev/null 2>&1 || { echo >&2 "Linux packaging requires curl or wget."; exit 1; }
 
-DEPENDENCIES_TAG="20190506"
+DEPENDENCIES_TAG="20191003"
 
 if [ $# -eq "0" ]; then
 	echo "Usage: $(basename "$0") version [outputdir]"

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -7,7 +7,7 @@ command -v python >/dev/null 2>&1 || { echo >&2 "Linux packaging requires python
 command -v tar >/dev/null 2>&1 || { echo >&2 "Linux packaging requires tar."; exit 1; }
 command -v curl >/dev/null 2>&1 || command -v wget > /dev/null 2>&1 || { echo >&2 "Linux packaging requires curl or wget."; exit 1; }
 
-DEPENDENCIES_TAG="20191003"
+DEPENDENCIES_TAG="20191004"
 
 if [ $# -eq "0" ]; then
 	echo "Usage: $(basename "$0") version [outputdir]"

--- a/packaging/osx/buildpackage.sh
+++ b/packaging/osx/buildpackage.sh
@@ -9,7 +9,7 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
 	command -v genisoimage >/dev/null 2>&1 || { echo >&2 "macOS packaging requires genisoimage."; exit 1; }
 fi
 
-LAUNCHER_TAG="osx-launcher-20190506"
+LAUNCHER_TAG="osx-launcher-20191003"
 
 if [ $# -ne "2" ]; then
 	echo "Usage: $(basename "$0") tag outputdir"

--- a/thirdparty/fetch-thirdparty-deps-osx.sh
+++ b/thirdparty/fetch-thirdparty-deps-osx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LAUNCHER_TAG="osx-launcher-20190506"
+LAUNCHER_TAG="osx-launcher-20191003"
 
 download_dir="${0%/*}/download/osx"
 mkdir -p "$download_dir"


### PR DESCRIPTION
This PR updates the compiler and macOS/Linux runtimes from Mono 5.20.1 to 6.4.0. The AppImage runtime also includes a [config change](https://github.com/OpenRA/AppImageSupport/commit/c5d2c8a809b968c8d2dd91a5a34f2bc5db5331ef) ~that may help with #16988 (@tttppp can you please test?)~ and updates cert-sync to match the runtime which fixes #16988.

Test builds (which also include the changes from #17167) can be found [here](https://github.com/pchote/OpenRA/releases/tag/devtest-20191003).

I have tested the runtime changes (but not the specific devtest build) on Ubuntu 18.04, Ubuntu 14.04, CentOS 7, Mint 19.1, MX 18.1 (the same VMs from the original PRs) and macOS without noticing any new regressions.