### PR TITLE
Skip MoveIntoWorld creation activity for map-placed Mobile actors

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -251,6 +251,9 @@ namespace OpenRA.Mods.Common.Traits
 				SetPosition(self, init.Get<CenterPositionInit, WPos>());
 
 			Facing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : Info.InitialFacing;
+
+			// SkipMoveIntoWorldInit is deliberately ignored for Aircraft
+			// MoveIntoWorld must run for aircraft for map-placed actors to be associated with their airfields
 			moveIntoWorldDelay = init.Contains<MoveIntoWorldDelayInit>() ? init.Get<MoveIntoWorldDelayInit, int>() : 0;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly Actor self;
 		readonly Lazy<IEnumerable<int>> speedModifiers;
-		readonly int moveIntoWorldDelay;
+		readonly int? moveIntoWorldDelay;
 
 		#region IMove CurrentMovementTypes
 		MovementType movementTypes;
@@ -243,7 +243,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (init.Contains<CenterPositionInit>())
 				SetVisualPosition(self, init.Get<CenterPositionInit, WPos>());
 
-			moveIntoWorldDelay = init.Contains<MoveIntoWorldDelayInit>() ? init.Get<MoveIntoWorldDelayInit, int>() : 0;
+			if (!init.Contains<SkipMoveIntoWorldInit>())
+				moveIntoWorldDelay = init.Contains<MoveIntoWorldDelayInit>() ? init.Get<MoveIntoWorldDelayInit, int>() : 0;
 		}
 
 		protected override void Created(Actor self)
@@ -898,7 +899,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		Activity ICreationActivity.GetCreationActivity()
 		{
-			return MoveIntoWorld(self, moveIntoWorldDelay);
+			return moveIntoWorldDelay.HasValue ? MoveIntoWorld(self, moveIntoWorldDelay.Value) : null;
 		}
 
 		class MoveOrderTargeter : IOrderTargeter

--- a/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
@@ -90,6 +90,7 @@ namespace OpenRA.Mods.Common.Traits
 					new LocationInit(sp + unitGroup.BaseActorOffset),
 					new OwnerInit(p),
 					new SkipMakeAnimsInit(),
+					new SkipMoveIntoWorldInit(),
 					new FacingInit(unitGroup.BaseActorFacing < 0 ? w.SharedRandom.Next(256) : unitGroup.BaseActorFacing),
 				});
 			}

--- a/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
@@ -41,6 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				var initDict = actorReference.InitDict;
 				initDict.Add(new SkipMakeAnimsInit());
+				initDict.Add(new SkipMoveIntoWorldInit());
 				initDict.Add(new SpawnedByMapInit(kv.Key));
 
 				if (PreventMapSpawn(world, actorReference, preventMapSpawns))
@@ -63,6 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public class SkipMakeAnimsInit : IActorInit, ISuppressInitExport { }
+	public class SkipMoveIntoWorldInit : IActorInit, ISuppressInitExport { }
 	public class SpawnedByMapInit : IActorInit<string>, ISuppressInitExport
 	{
 		public readonly string Name;


### PR DESCRIPTION
Fixes #17184.

This PR follows the approach of `SkipMakeAnimations` to disable the activity in the remaining case that we know to be broken and can easily test. This is less risky than my original request from #16938 to make production / transports / etc explicitly request `MoveIntoWorld`, but we should move to that if any further regressions become obvious.

Depends on #17133.