### PR TITLE
Remove ICrushable from Mine

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/LayMines.cs
+++ b/OpenRA.Mods.Cnc/Activities/LayMines.cs
@@ -27,6 +27,7 @@ namespace OpenRA.Mods.Cnc.Activities
 		readonly AmmoPool[] ammoPools;
 		readonly IMove movement;
 		readonly RearmableInfo rearmableInfo;
+		readonly MineLocations mineLocations;
 
 		List<CPos> minefield;
 		bool returnToBase;
@@ -38,6 +39,7 @@ namespace OpenRA.Mods.Cnc.Activities
 			ammoPools = self.TraitsImplementing<AmmoPool>().ToArray();
 			movement = self.Trait<IMove>();
 			rearmableInfo = self.Info.TraitInfoOrDefault<RearmableInfo>();
+			mineLocations = self.World.WorldActor.TraitOrDefault<MineLocations>();
 			this.minefield = minefield;
 		}
 
@@ -124,10 +126,10 @@ namespace OpenRA.Mods.Cnc.Activities
 				yield return new TargetLineNode(Target.FromCell(self.World, c), Color.Crimson, tile: minelayer.Tile);
 		}
 
-		static bool CanLayMine(Actor self, CPos p)
+		bool CanLayMine(Actor self, CPos p)
 		{
 			// If there is no unit (other than me) here, we can place a mine here
-			return self.World.ActorMap.GetActorsAt(p).All(a => a == self);
+			return self.World.ActorMap.GetActorsAt(p).All(a => a == self) && !mineLocations.Occupied(p);
 		}
 
 		void LayMine(Actor self)

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -201,6 +201,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Sync]
 		public int PathHash;	// written by Move.EvalPath, to temporarily debug this crap.
 
+		INotifyEnteredCell[] notifyEnteredCells;
+
 		public Locomotor Locomotor { get; private set; }
 
 		#region IOccupySpace
@@ -256,6 +258,8 @@ namespace OpenRA.Mods.Common.Traits
 			moveWrappers = self.TraitsImplementing<IWrapMove>().ToArray();
 			Locomotor = self.World.WorldActor.TraitsImplementing<Locomotor>()
 				.Single(l => l.Info.Name == Info.Locomotor);
+
+			notifyEnteredCells = self.World.WorldActor.TraitsImplementing<INotifyEnteredCell>().ToArray();
 
 			base.Created(self);
 		}
@@ -493,6 +497,9 @@ namespace OpenRA.Mods.Common.Traits
 			// Only make actor crush if it is on the ground
 			if (!self.IsAtGroundLevel())
 				return;
+
+			foreach (var notifyEnteredCell in notifyEnteredCells)
+                notifyEnteredCell.EnteredCell(self, fromCell);
 
 			var actors = self.World.ActorMap.GetActorsAt(ToCell).Where(a => a != self).ToList();
 			if (!AnyCrushables(actors))

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -76,6 +76,12 @@ namespace OpenRA.Mods.Common.Traits
 		void FinishedMoving(Actor self, byte oldLayer, byte newLayer);
 	}
 
+	[RequireExplicitImplementation]
+	public interface INotifyEnteredCell
+	{
+		void EnteredCell(Actor self, CPos cell);
+	}
+
 	public interface IDemolishableInfo : ITraitInfoInterface { bool IsValidTarget(ActorInfo actorInfo, Actor saboteur); }
 	public interface IDemolishable
 	{

--- a/OpenRA.Mods.Common/UpdateRules/Rules/AddMineDetonator.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/AddMineDetonator.cs
@@ -1,0 +1,121 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class AddMineDetonator : UpdateRule
+	{
+		public override string Name { get { return "Add MineDetonator"; } }
+		public override string Description
+		{
+			get
+			{
+				return "Mine detonation is now done via MineDetonator trait instead of crushing.";
+			}
+		}
+
+		List<string> collectingLocomotors = new List<string>();
+		List<MiniYamlNode> affectedActors = new List<MiniYamlNode>();
+
+		bool addedMineDetonator;
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (!addedMineDetonator)
+			{
+				addedMineDetonator = true;
+				foreach (var actor in affectedActors)
+					AddMineDetonatorIfNecessary(actor);
+			}
+
+			yield break;
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var mines = actorNode.ChildrenMatching("Mine");
+			foreach (var mine in mines)
+			{
+				var crushClasses = mine.LastChildMatching("CrushClass");
+				if (crushClasses != null)
+					crushClasses.RenameKey("ValidDetonatorTypes");
+			}
+
+			var locomotors = actorNode.ChildrenMatching("Locomotor");
+			foreach (var locomotor in locomotors)
+				CheckAndUpdateLocomotor(locomotor);
+
+			var jjLocomotors = actorNode.ChildrenMatching("JumpjetLocomotor");
+			foreach (var locomotor in jjLocomotors)
+				CheckAndUpdateLocomotor(locomotor);
+
+			var stLocomotors = actorNode.ChildrenMatching("SubterraneanLocomotor");
+			foreach (var locomotor in stLocomotors)
+				CheckAndUpdateLocomotor(locomotor);
+
+			// Caching actors with defined locomotor because we have to add CrateCollector in AfterUpdate,
+			// since otherwise it would be impossible to ensure we've checked the locomotors for crate collect ability.
+			var mobile = actorNode.LastChildMatching("Mobile");
+			if (mobile != null)
+			{
+				var locomotor = mobile.LastChildMatching("Locomotor");
+				if (locomotor != null)
+					affectedActors.Add(actorNode);
+			}
+
+			yield break;
+		}
+
+		void CheckAndUpdateLocomotor(MiniYamlNode locomotor)
+		{
+			var name = "default";
+			var nameNode = locomotor.LastChildMatching("Name");
+			if (nameNode != null)
+				name = nameNode.Value.Value;
+
+			var crushes = locomotor.LastChildMatching("Crushes");
+			if (crushes != null)
+			{
+				// If 'mine' is the only entry, remove Crushes node and add to list of crate crushing locos
+				if (crushes.Value.Value == "mine")
+				{
+					collectingLocomotors.Add(name);
+					locomotor.RemoveNode(crushes);
+				}
+				else
+				{
+					var oldCrushesEntries = FieldLoader.GetValue<string[]>("Crushes", crushes.Value.Value);
+					if (oldCrushesEntries.Any(e => e == "mine"))
+						collectingLocomotors.Add(name);
+
+					var newCrushesEntries = oldCrushesEntries.Where(e => e != "mine");
+					crushes.Value.Value = string.Join(", ", newCrushesEntries);
+				}
+			}
+		}
+
+		void AddMineDetonatorIfNecessary(MiniYamlNode actorNode)
+		{
+			// We only cached actors that have Mobile with a Locomotor: entry, so no null checks necessary here
+			var mobile = actorNode.LastChildMatching("Mobile");
+			var locomotorNode = mobile.LastChildMatching("Locomotor");
+
+			// Just to be on the safe side, we check if the actor for some reason already has the CrateCollector trait
+			var hasMineDetonator = actorNode.LastChildMatching("MineDetonator") != null;
+			var crateMineDetonatorNode = new MiniYamlNode("MineDetonator", "");
+			if (!hasMineDetonator && collectingLocomotors.Any(l => l == locomotorNode.Value.Value))
+				actorNode.AddNode(crateMineDetonatorNode);
+		}
+	}
+}

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -309,6 +309,7 @@
 	HitShape:
 	MapEditorData:
 		Categories: Vehicle
+	MineDetonator:
 
 ^TrackedVehicle:
 	Inherits: ^Vehicle
@@ -438,6 +439,7 @@
 	DetectCloaked:
 		CloakTypes: Cloak
 		Range: 1c0
+	MineDetonator:
 
 ^Soldier:
 	Inherits: ^Infantry
@@ -625,7 +627,7 @@
 		TakeOffOnResupply: true
 		VTOL: true
 		LandableTerrainTypes: Clear, Rough, Road, Ore, Beach, Gems
-		Crushes: crate, mine, infantry
+		Crushes: crate, infantry
 		InitialFacing: 224
 		CanSlide: True
 	GpsDot:
@@ -634,6 +636,7 @@
 		RequiresCondition: cruising
 	BodyOrientation:
 		UseClassicFacingFudge: True
+	MineDetonator:
 
 ^BasicBuilding:
 	Inherits@1: ^ExistsInWorld
@@ -1163,10 +1166,7 @@
 	WithSpriteBody:
 	HiddenUnderFog:
 	Mine:
-		CrushClasses: mine
-		DetonateClasses: mine
 		AvoidFriendly: false
-		BlockFriendly: false
 	Health:
 		HP: 10000
 		NotifyAppliedDamage: false
@@ -1183,7 +1183,7 @@
 	Targetable:
 		TargetTypes: Ground, Mine
 	Immobile:
-		OccupiesSpace: true
+		OccupiesSpace: false
 	HitShape:
 	MapEditorData:
 		Categories: System

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -11,7 +11,7 @@
 	DebugVisualizations:
 	Locomotor@FOOT:
 		Name: foot
-		Crushes: mine, crate
+		Crushes: crate
 		SharesCell: true
 		TerrainSpeeds:
 			Clear: 90
@@ -23,7 +23,7 @@
 			Beach: 80
 	Locomotor@WHEELED:
 		Name: wheeled
-		Crushes: mine, crate
+		Crushes: crate
 		TerrainSpeeds:
 			Clear: 80
 			Rough: 40
@@ -34,7 +34,7 @@
 			Beach: 40
 	Locomotor@HEAVYWHEELED:
 		Name: heavywheeled
-		Crushes: wall, mine, crate, infantry
+		Crushes: wall, crate, infantry
 		TerrainSpeeds:
 			Clear: 80
 			Rough: 40
@@ -45,7 +45,7 @@
 			Beach: 40
 	Locomotor@LIGHTTRACKED:
 		Name: lighttracked
-		Crushes: wall, mine, crate
+		Crushes: wall, crate
 		TerrainSpeeds:
 			Clear: 80
 			Rough: 70
@@ -56,7 +56,7 @@
 			Beach: 70
 	Locomotor@TRACKED:
 		Name: tracked
-		Crushes: wall, infantry, mine, crate
+		Crushes: wall, infantry, crate
 		TerrainSpeeds:
 			Clear: 80
 			Rough: 70
@@ -67,7 +67,7 @@
 			Beach: 70
 	Locomotor@HEAVYTRACKED:
 		Name: heavytracked
-		Crushes: wall, infantry, mine, crate, heavywall
+		Crushes: wall, infantry, crate, heavywall
 		TerrainSpeeds:
 			Clear: 80
 			Rough: 70
@@ -196,6 +196,7 @@ World:
 		WaterChance: 20
 		InitialSpawnDelay: 1500
 		CheckboxDisplayOrder: 1
+	MineLocations:
 	DomainIndex:
 	SmudgeLayer@SCORCH:
 		Type: Scorch


### PR DESCRIPTION
Should fix the Mine part of #4826 and also is the first step to remove ICrushable interface (or remove Mine and Crate from that interface to remove Crushes from most of the locomotors in the default mods)