### PR TITLE
Don't throw an exception when a field is missing

### DIFF
--- a/OpenRA.Game/GameRules/ActorInfo.cs
+++ b/OpenRA.Game/GameRules/ActorInfo.cs
@@ -44,7 +44,11 @@ namespace OpenRA
 				{
 					try
 					{
-						traits.Add(LoadTraitInfo(creator, t.Key.Split('@')[0], t.Value));
+						// HACK: The linter does not want to crash when a trait doesn't exist but only print an error instead
+						// LoadTraitInfo will only return null to signal us to abort here if the linter is running
+						var trait = LoadTraitInfo(creator, t.Key.Split('@')[0], t.Value);
+						if (trait != null)
+							traits.Add(trait);
 					}
 					catch (FieldLoader.MissingFieldsException e)
 					{
@@ -73,7 +77,13 @@ namespace OpenRA
 			if (!string.IsNullOrEmpty(my.Value))
 				throw new YamlException("Junk value `{0}` on trait node {1}"
 				.F(my.Value, traitName));
+
+			// HACK: The linter does not want to crash when a trait doesn't exist but only print an error instead
+			// ObjectCreator will only return null to signal us to abort here if the linter is running
 			var info = creator.CreateObject<ITraitInfo>(traitName + "Info");
+			if (info == null)
+				return null;
+
 			try
 			{
 				FieldLoader.Load(info, my);

--- a/OpenRA.Game/ObjectCreator.cs
+++ b/OpenRA.Game/ObjectCreator.cs
@@ -74,8 +74,8 @@ namespace OpenRA
 			return assemblies.Select(a => a.First).FirstOrDefault(a => a.FullName == e.Name);
 		}
 
-		public static Action<string> MissingTypeAction =
-			s => { throw new InvalidOperationException("Cannot locate type: {0}".F(s)); };
+		// Only used by the linter to prevent exceptions from being thrown during a lint run
+		public static Action<string> MissingTypeAction = null;
 
 		public T CreateObject<T>(string className)
 		{
@@ -87,7 +87,12 @@ namespace OpenRA
 			var type = typeCache[className];
 			if (type == null)
 			{
-				MissingTypeAction(className);
+				// HACK: The linter does not want to crash but only print an error instead
+				if (MissingTypeAction != null)
+					MissingTypeAction(className);
+				else
+					throw new InvalidOperationException("Cannot locate type: {0}".F(className));
+
 				return default(T);
 			}
 


### PR DESCRIPTION
Closes #17202.

Testcase: Add `JunkTrait:` to the world actor in `./mods/ra/maps/allies-01/rules.yaml`.
On bleed:
```
> OpenRA.Utility.exe ra --check-yaml ./mods/ra/maps/allies-01
OpenRA.Utility(1,1): Error: Missing Type: JunkTraitInfo
Testing map: 01:   In the thick of it
OpenRA.Utility(1,1): Error: System.AggregateException: Mindestens ein Fehler ist aufgetreten. ---> System.NullReferenceException: Der Objektverweis wurde nicht auf eine Objektinstanz festgelegt.
   bei System.Object.GetType()
   bei OpenRA.FieldLoader.Load(Object self, MiniYaml my)
   bei OpenRA.ActorInfo.LoadTraitInfo(ObjectCreator creator, String traitName, MiniYaml my)
   bei OpenRA.ActorInfo..ctor(ObjectCreator creator, String name, MiniYaml node)
   bei OpenRA.Ruleset.<>c__DisplayClass14_0.<Load>b__1(MiniYamlNode k)
   bei OpenRA.Exts.ToDictionaryWithConflictLog[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, String debugName, Func`2 logKey, Func`2 logValue)
   bei OpenRA.Ruleset.MergeOrDefault[T](String name, IReadOnlyFileSystem fileSystem, IEnumerable`1 files, MiniYaml additional, IReadOnlyDictionary`2 defaults, Func`2 makeObject, Func`2 filterNode)
   bei OpenRA.Ruleset.<>c__DisplayClass14_0.<Load>b__0()
   bei System.Threading.Tasks.Task.Execute()
   --- Ende der internen Ausnahmestapelüberwachung ---
   bei System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   bei System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   bei OpenRA.Ruleset.Load(ModData modData, IReadOnlyFileSystem fileSystem, String tileSet, MiniYaml mapRules, MiniYaml mapWeapons, MiniYaml mapVoices, MiniYaml mapNotifications, MiniYaml mapMusic, MiniYaml mapSequences, MiniYaml mapModelSequences)
   bei OpenRA.Map.PostInit()
---> (Interne Ausnahme #0) System.NullReferenceException: Der Objektverweis wurde nicht auf eine Objektinstanz festgelegt.
   bei System.Object.GetType()
   bei OpenRA.FieldLoader.Load(Object self, MiniYaml my)
   bei OpenRA.ActorInfo.LoadTraitInfo(ObjectCreator creator, String traitName, MiniYaml my)
   bei OpenRA.ActorInfo..ctor(ObjectCreator creator, String name, MiniYaml node)
   bei OpenRA.Ruleset.<>c__DisplayClass14_0.<Load>b__1(MiniYamlNode k)
   bei OpenRA.Exts.ToDictionaryWithConflictLog[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, String debugName, Func`2 logKey, Func`2 logValue)
   bei OpenRA.Ruleset.MergeOrDefault[T](String name, IReadOnlyFileSystem fileSystem, IEnumerable`1 files, MiniYaml additional, IReadOnlyDictionary`2 defaults, Func`2 makeObject, Func`2 filterNode)
   bei OpenRA.Ruleset.<>c__DisplayClass14_0.<Load>b__0()
   bei System.Threading.Tasks.Task.Execute()<---
```
This PR:
```
> OpenRA.Utility.exe ra --check-yaml ./mods/ra/maps/allies-01
OpenRA.Utility(1,1): Error: Missing Type: JunkTraitInfo
Testing map: 01:   In the thick of it
Errors: 1
```