### PR TITLE
Adjusted default edge scrollspeed

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -205,7 +205,7 @@ namespace OpenRA
 		public MouseScrollType MiddleMouseScroll = MouseScrollType.Standard;
 		public MouseScrollType RightMouseScroll = MouseScrollType.Disabled;
 		public MouseButtonPreference MouseButtonPreference = new MouseButtonPreference();
-		public float ViewportEdgeScrollStep = 10f;
+		public float ViewportEdgeScrollStep = 30f;
 		public float UIScrollSpeed = 50f;
 		public int SelectionDeadzone = 24;
 		public int MouseScrollDeadzone = 8;


### PR DESCRIPTION
Addressing #14603

Even though the issue has apparently been claimed, there was no update for more than 1.5 years.
In this pull request, the slider sits in the middle by default (compared to 10%ish before)

People downloading and playing OpenRA are likely to be returning veterans and/or are looking for more core strategy gameplay from their previous game/s and thus, are no newcomers. That means the players are already familiar with the concept of edge-scrolling and have no need for low scrolling speed.