### PR TITLE
Prevent movement pausing at invalid position.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -25,6 +25,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly WDist minRange;
 		readonly Color? targetLineColor;
 		readonly WDist nearEnough;
+		readonly WVec offset;
 
 		Target target;
 		Target lastVisibleTarget;
@@ -35,6 +36,12 @@ namespace OpenRA.Mods.Common.Activities
 			: this(self, t, initialTargetPosition, targetLineColor)
 		{
 			this.nearEnough = nearEnough;
+		}
+
+		public Fly(Actor self, Target t, WVec offset)
+			: this(self, t)
+		{
+			this.offset = offset;
 		}
 
 		public Fly(Actor self, Target t, WPos? initialTargetPosition = null, Color? targetLineColor = null)
@@ -157,12 +164,12 @@ namespace OpenRA.Mods.Common.Activities
 
 			var checkTarget = useLastVisibleTarget ? lastVisibleTarget : target;
 			var pos = aircraft.GetPosition();
-			var delta = checkTarget.CenterPosition - pos;
+			var delta = checkTarget.CenterPosition - pos + offset;
 			var desiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : aircraft.Facing;
 
 			// Inside the target annulus, so we're done
-			var insideMaxRange = maxRange.Length > 0 && checkTarget.IsInRange(pos, maxRange);
-			var insideMinRange = minRange.Length > 0 && checkTarget.IsInRange(pos, minRange);
+			var insideMaxRange = maxRange.Length > 0 && checkTarget.IsInRange(pos - offset, maxRange);
+			var insideMinRange = minRange.Length > 0 && checkTarget.IsInRange(pos - offset, minRange);
 			if (insideMaxRange && !insideMinRange)
 				return true;
 

--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -210,6 +210,13 @@ namespace OpenRA.Mods.Common.Activities
 
 			var nextCell = path[path.Count - 1];
 
+			// Something else might have moved us, so the path is no longer valid.
+			if (!Util.AreAdjacentCells(mobile.ToCell, nextCell))
+			{
+				path = EvalPath(BlockedByActor.Immovable);
+				return null;
+			}
+
 			var containsTemporaryBlocker = WorldUtils.ContainsTemporaryBlocker(self.World, nextCell, self);
 
 			// Next cell in the move is blocked by another actor
@@ -407,9 +414,6 @@ namespace OpenRA.Mods.Common.Activities
 
 			public override bool Tick(Actor self)
 			{
-				if (Move.mobile.IsTraitDisabled || Move.mobile.IsTraitPaused)
-					return false;
-
 				var ret = InnerTick(self, Move.mobile);
 
 				if (moveFraction > MoveFractionTotal)
@@ -491,7 +495,7 @@ namespace OpenRA.Mods.Common.Activities
 				var nextCell = parent.PopPath(self);
 				if (nextCell != null)
 				{
-					if (IsTurn(mobile, nextCell.Value.First, map))
+					if (!mobile.IsTraitPaused && !mobile.IsTraitDisabled && IsTurn(mobile, nextCell.Value.First, map))
 					{
 						var nextSubcellOffset = map.Grid.OffsetOfSubCell(nextCell.Value.Second);
 						var ret = new MoveFirstHalf(

--- a/OpenRA.Mods.Common/Traits/AutoCarryable.cs
+++ b/OpenRA.Mods.Common/Traits/AutoCarryable.cs
@@ -104,7 +104,7 @@ namespace OpenRA.Mods.Common.Traits
 		// Prepare for transport pickup
 		public override bool LockForPickup(Actor self, Actor carrier)
 		{
-			if (state == State.Locked || !WantsTransport)
+			if ((state == State.Locked && Carrier != carrier) || !WantsTransport)
 				return false;
 
 			// Last chance to change our mind...

--- a/OpenRA.Mods.Common/Traits/CaptureManager.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureManager.cs
@@ -221,6 +221,11 @@ namespace OpenRA.Mods.Common.Traits
 			if (captures == null)
 				return false;
 
+			// Make sure we are in a valid state first.
+			var enterMobile = target.TraitOrDefault<Mobile>();
+			if (enterMobile != null && enterMobile.IsMovingBetweenCells)
+				return false;
+
 			if (progressWatchers.Any() || targetManager.progressWatchers.Any())
 			{
 				currentTargetTotal = captures.Info.CaptureDelay;

--- a/OpenRA.Mods.Common/Traits/Carryable.cs
+++ b/OpenRA.Mods.Common/Traits/Carryable.cs
@@ -113,14 +113,17 @@ namespace OpenRA.Mods.Common.Traits
 		// Prepare for transport pickup
 		public virtual bool LockForPickup(Actor self, Actor carrier)
 		{
-			if (state == State.Locked)
+			if (state == State.Locked && Carrier != carrier)
 				return false;
 
-			state = State.Locked;
-			Carrier = carrier;
+			if (state != State.Locked)
+			{
+				state = State.Locked;
+				Carrier = carrier;
 
-			if (lockedToken == ConditionManager.InvalidConditionToken && !string.IsNullOrEmpty(Info.LockedCondition))
-				lockedToken = conditionManager.GrantCondition(self, Info.LockedCondition);
+				if (lockedToken == ConditionManager.InvalidConditionToken && !string.IsNullOrEmpty(Info.LockedCondition))
+					lockedToken = conditionManager.GrantCondition(self, Info.LockedCondition);
+			}
 
 			return true;
 		}

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -181,6 +181,11 @@ namespace OpenRA.Mods.Common.Traits
 		public bool TurnToMove;
 		public bool IsBlocking { get; private set; }
 
+		public bool IsMovingBetweenCells
+		{
+			get { return FromCell != ToCell; }
+		}
+
 		#region IFacing
 		[Sync]
 		public int Facing

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -141,6 +141,12 @@ namespace OpenRA.Mods.Common
 			}
 		}
 
+		public static bool AreAdjacentCells(CPos a, CPos b)
+		{
+			var offset = b - a;
+			return Math.Abs(offset.X) < 2 && Math.Abs(offset.Y) < 2;
+		}
+
 		public static IEnumerable<CPos> ExpandFootprint(IEnumerable<CPos> cells, bool allowDiagonal)
 		{
 			return cells.SelectMany(c => Neighbours(c, allowDiagonal)).Distinct();


### PR DESCRIPTION
Fixes #17209 

Reverts #17189 and provides a proper fix for #17043 instead that still allows units to finish moving to a valid position before being halted by the thief/hijacker.

This also prevents a potential glitch if the carryall would be too quick to allow the unit to properly finish moving after locking. This same logic would also be needed for #17211, so this PR already brings us halfway on that. 