### PR TITLE
Place pluggable on another position when clicked position has no plug or is already used

### DIFF
--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -229,7 +229,7 @@ namespace OpenRA.Mods.Common.Orders
 				return false;
 
 			var location = host.Location;
-			return host.TraitsImplementing<Pluggable>().Any(p => location + p.Info.Offset == cell && p.AcceptsPlug(host, plug.Type));
+			return host.TraitsImplementing<Pluggable>().Any(p => p.AcceptsPlug(host, plug.Type));
 		}
 
 		IEnumerable<IRenderable> IOrderGenerator.Render(WorldRenderer wr, World world) { yield break; }

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -144,8 +144,11 @@ namespace OpenRA.Mods.Common.Traits
 						return;
 
 					var location = host.Location;
-					var pluggable = host.TraitsImplementing<Pluggable>()
-						.FirstOrDefault(p => location + p.Info.Offset == targetLocation && p.AcceptsPlug(host, plugInfo.Type));
+					var pluggableLocations = host.TraitsImplementing<Pluggable>()
+						.Where(p => p.AcceptsPlug(host, plugInfo.Type));
+
+					var pluggable = pluggableLocations.FirstOrDefault(p => location + p.Info.Offset == targetLocation)
+						?? pluggableLocations.FirstOrDefault();
 
 					if (pluggable == null)
 						return;


### PR DESCRIPTION
Closes #14331.

When placing a pluggable, you can now click anywhere on the building. The next free place will be used.