### PR TITLE
Add OccupiesSpace check to production cycling

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/CycleProductionActorsHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/CycleProductionActorsHotkeyLogic.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 			var player = world.RenderPlayer ?? world.LocalPlayer;
 
 			var facilities = world.ActorsHavingTrait<Production>()
-				.Where(a => a.Owner == player && !a.Info.HasTraitInfo<BaseBuildingInfo>()
+				.Where(a => a.Owner == player && a.OccupiesSpace != null && !a.Info.HasTraitInfo<BaseBuildingInfo>()
 					&& a.TraitsImplementing<Production>().Any(t => !t.IsTraitDisabled))
 				.OrderBy(f => f.TraitsImplementing<Production>().First(t => !t.IsTraitDisabled).Info.Produces.First())
 				.ToList();

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -389,7 +389,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var facility = CurrentQueue.MostLikelyProducer().Actor;
 
-			if (facility == null)
+			if (facility == null || facility.OccupiesSpace == null)
 				return true;
 
 			if (selection.Actors.Count() == 1 && selection.Contains(facility))


### PR DESCRIPTION
Closes #16703.

~The first commit removes the `BaseBuilding` requirement for production cycling, since e.g. mobile actors without that trait can be producers as well. Testcase: Add any production to any mobile actor.~

The ~second~ commit prevents cycling to an actor that does not occupy space, e.g. the player actor.