### PR TITLE
Prevent iron curtaining or chronoshifting an empty selection

### DIFF
--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			Game.Sound.Play(SoundType.World, info.OnFireSound, order.Target.CenterPosition);
 
-			foreach (var a in UnitsInRange(self.World.Map.CellContaining(order.Target.CenterPosition)))
+			foreach (var a in order.ExtraActors)
 			{
 				var external = a.TraitsImplementing<ExternalCondition>()
 					.FirstOrDefault(t => t.Info.Condition == info.Condition && t.CanGrantCondition(a, self));
@@ -127,8 +127,13 @@ namespace OpenRA.Mods.Common.Traits
 			protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
 			{
 				world.CancelInputMode();
-				if (mi.Button == MouseButton.Left && power.UnitsInRange(cell).Any())
-					yield return new Order(order, manager.Self, Target.FromCell(world, cell), false) { SuppressVisualFeedback = true };
+
+				if (mi.Button != MouseButton.Left)
+					yield break;
+
+				var units = power.UnitsInRange(cell);
+				if (units.Any())
+					yield return new Order(order, manager.Self, Target.FromCell(world, cell), false, units.ToArray()) { SuppressVisualFeedback = true };
 			}
 
 			protected override void Tick(World world)


### PR DESCRIPTION
fixes #17064.

depends on #16999.

Reproduction case: build medium tanks and try to iron curtain one of them when they pass half of the selected cell. Iron curtain will sometimes fire without taking effect on any unit.
Testcase: try the thing described above but on this branch, this is the best I could come up with.