### PR TITLE
Use SubCell.Any instead of Map.Grid.DefaultSubCell in the Mobile ctor

### DIFF
--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -73,7 +73,6 @@ namespace OpenRA.Mods.Common.Traits
 				td.Add(new LocationInit(exit));
 				td.Add(new CenterPositionInit(spawn));
 				td.Add(new FacingInit(initialFacing));
-				td.Add(new SubCellInit(SubCell.Any));
 				if (exitinfo != null)
 					td.Add(new MoveIntoWorldDelayInit(exitinfo.ExitDelay));
 			}


### PR DESCRIPTION
Reverts #17121 as discussed on IRC and implements a new fix for #17106. The revert commit must not be picked to stable (since the original commit is not on prep either).