### PR TITLE
Fix missing rules in prep update path

### DIFF
--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -129,10 +129,12 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemovePlaceBuildingPalettes(),
 				new RenameHoversOffsetModifier(),
 				new AddAirAttackTypes(),
+				new MoveAbortOnResupply(),
 				new RenameCarryallDelays(),
 				new AddCanSlide(),
 				new AddAircraftIdleBehavior(),
 				new RenameSearchRadius(),
+				new RenameChronoshiftFootprint(),
 				new RemoveMoveIntoWorldFromExit(),
 			}),
 


### PR DESCRIPTION
These update rules are present on prep branch, but were missing entries in its update path.

Intentionally didn't insert them at the end in a bid to (hopefully) avoid rebase conflicts when picking to prep.