### PR TITLE
Make normal difficulty on allies06b easier

### DIFF
--- a/mods/ra/maps/allies-06b/allies06b.lua
+++ b/mods/ra/maps/allies-06b/allies06b.lua
@@ -224,10 +224,14 @@ WorldLoaded = function()
 
 	if Map.LobbyOption("difficulty") ~= "hard" then
 		Trigger.OnKilled(DefBrl1, function(a, b)
-			DefenseFlame1.Kill()
+			if not DefenseFlame1.IsDead then
+				DefenseFlame1.Kill()
+			end
 		end)
 		Trigger.OnKilled(DefBrl2, function(a, b)
-			DefenseFlame2.Kill()
+			if not DefenseFlame2.IsDead then
+				DefenseFlame2.Kill()
+			end
 		end)
 	end
 

--- a/mods/ra/maps/allies-06b/allies06b.lua
+++ b/mods/ra/maps/allies-06b/allies06b.lua
@@ -204,7 +204,7 @@ WorldLoaded = function()
 
 	Camera.Position = DefaultCameraPosition.CenterPosition
 
-	if Map.LobbyOption("difficulty") ~= "hard" then
+	if Map.LobbyOption("difficulty") == "easy" then
 		Trigger.OnEnteredProximityTrigger(SovietDefenseCam.CenterPosition, WDist.New(1024 * 7), function(a, id)
 			if a.Owner == player then
 				Trigger.RemoveProximityTrigger(id)
@@ -220,15 +220,15 @@ WorldLoaded = function()
 				end
 			end
 		end)
+	end
 
-		if Map.LobbyOption("difficulty") == "easy" then
-			Trigger.OnKilled(DefBrl1, function(a, b)
-				DefenseFlame1.Kill()
-			end)
-			Trigger.OnKilled(DefBrl2, function(a, b)
-				DefenseFlame2.Kill()
-			end)
-		end
+	if Map.LobbyOption("difficulty") ~= "hard" then
+		Trigger.OnKilled(DefBrl1, function(a, b)
+			DefenseFlame1.Kill()
+		end)
+		Trigger.OnKilled(DefBrl2, function(a, b)
+			DefenseFlame2.Kill()
+		end)
 	end
 
 	Utils.Do(BadGuys, function(a)


### PR DESCRIPTION
Closes #16146.

When destroying the barrels on `normal`, the flamethrowers now get destroyed as well. In order to make it harder than `easy`, the flamethrowers will not be revealed by a camera.