### PR TITLE
Remove unused and buggy stand2 sequence from ants

### DIFF
--- a/mods/ra/sequences/infantry.yaml
+++ b/mods/ra/sequences/infantry.yaml
@@ -1288,9 +1288,6 @@ zombie:
 ant:
 	stand: ant1
 		Facings: 8
-	stand2: ant1
-		Start: 8
-		Length: 8
 	run: ant1
 		Start: 8
 		Length: 8
@@ -1313,9 +1310,6 @@ ant:
 fireant:
 	stand: ant2
 		Facings: 8
-	stand2: ant2
-		Start: 8
-		Length: 8
 	run: ant2
 		Start: 8
 		Length: 8
@@ -1338,9 +1332,6 @@ fireant:
 scoutant:
 	stand: ant3
 		Facings: 8
-	stand2: ant3
-		Start: 8
-		Length: 8
 	run: ant3
 		Start: 8
 		Length: 8


### PR DESCRIPTION
They were unused and their settings were wrong (should have been `Facings: 8` and `Stride: 8` instead of `Length: 8`).
Initially I wanted to fix them, but when fixed and enabled they'd still make idle ants look glitchy, because the game switches between stand sequences randomly and it just looks bad.