### PR TITLE
Prevent showing wall connections in unexplored terrain

### DIFF
--- a/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PlaceBuildingOrderGenerator.cs
@@ -244,6 +244,7 @@ namespace OpenRA.Mods.Common.Orders
 			var plugInfo = activeVariant.PlugInfo;
 			var lineBuildInfo = activeVariant.LineBuildInfo;
 			var preview = activeVariant.Preview;
+			var owner = queue.Actor.Owner;
 
 			if (plugInfo != null)
 			{
@@ -252,7 +253,7 @@ namespace OpenRA.Mods.Common.Orders
 
 				footprint.Add(topLeft, MakeCellType(AcceptsPlug(topLeft, plugInfo)));
 			}
-			else if (lineBuildInfo != null)
+			else if (lineBuildInfo != null && owner.Shroud.IsExplored(topLeft))
 			{
 				// Linebuild for walls.
 				if (buildingInfo.Dimensions.X != 1 || buildingInfo.Dimensions.Y != 1)
@@ -260,7 +261,7 @@ namespace OpenRA.Mods.Common.Orders
 
 				if (!Game.GetModifierKeys().HasModifier(Modifiers.Shift))
 				{
-					foreach (var t in BuildingUtils.GetLineBuildCells(world, topLeft, actorInfo, buildingInfo))
+					foreach (var t in BuildingUtils.GetLineBuildCells(world, topLeft, actorInfo, buildingInfo, owner))
 					{
 						var lineBuildable = world.IsCellBuildable(t.First, actorInfo, buildingInfo);
 						var lineCloseEnough = buildingInfo.IsCloseEnoughToBase(world, world.LocalPlayer, actorInfo, t.First);

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits
 					world.IsCellBuildable(t, ai, bi, toIgnore));
 		}
 
-		public static IEnumerable<Pair<CPos, Actor>> GetLineBuildCells(World world, CPos cell, ActorInfo ai, BuildingInfo bi)
+		public static IEnumerable<Pair<CPos, Actor>> GetLineBuildCells(World world, CPos cell, ActorInfo ai, BuildingInfo bi, Player owner)
 		{
 			var lbi = ai.TraitInfo<LineBuildInfo>();
 			var topLeft = cell;	// 1x1 assumption!
@@ -81,9 +81,10 @@ namespace OpenRA.Mods.Common.Traits
 					if (dirs[d] != 0)
 						continue;
 
+					// Continue the search if the cell is empty or not visible
 					var c = topLeft + i * vecs[d];
-					if (world.IsCellBuildable(c, ai, bi))
-						continue; // Cell is empty; continue search
+					if (world.IsCellBuildable(c, ai, bi) || !owner.Shroud.IsExplored(c))
+						continue;
 
 					// Cell contains an actor. Is it the type we want?
 					connectors[d] = world.ActorMap.GetActorsAt(c)

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -117,7 +117,7 @@ namespace OpenRA.Mods.Common.Traits
 					if (string.IsNullOrEmpty(segmentType))
 						segmentType = actorInfo.Name;
 
-					foreach (var t in BuildingUtils.GetLineBuildCells(w, targetLocation, actorInfo, buildingInfo))
+					foreach (var t in BuildingUtils.GetLineBuildCells(w, targetLocation, actorInfo, buildingInfo, order.Player))
 					{
 						if (t.First == targetLocation)
 							continue;


### PR DESCRIPTION
Fixes #17228. I'm not sure if I put the condition in the correct condition block since now rather than simply showing only the `buildBlocked` sprite (red cross-hatched sprite), the wall sprite (e.g. sandbag) is shown above the `buildBlocked` sprite. Also, my condition is that the cell has to be explored, not necessarily visible - I'm not sure if it should be changed to visible cells only.

I noticed too late that I worked off the `master` branch rather than the `bleed` branch, so apologies for that.