### PR TITLE
Replace MoveIntoWorld with ReturnToCell/AssociateWithAirfield.

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -191,7 +191,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			WPos? initialTargetPosition = null, Color? targetLineColor = null) { return null; }
 		public Activity MoveFollow(Actor self, Target target, WDist minRange, WDist maxRange,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null) { return null; }
-		public Activity MoveIntoWorld(Actor self, int delay = 0) { return null; }
+		public Activity ReturnToCell(Actor self) { return null; }
 		public Activity MoveToTarget(Actor self, Target target,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null) { return null; }
 		public Activity MoveIntoTarget(Actor self, Target target) { return null; }

--- a/OpenRA.Mods.Common/Activities/Enter.cs
+++ b/OpenRA.Mods.Common/Activities/Enter.cs
@@ -138,7 +138,7 @@ namespace OpenRA.Mods.Common.Activities
 
 				case EnterState.Exiting:
 				{
-					QueueChild(move.MoveIntoWorld(self));
+					QueueChild(move.ReturnToCell(self));
 					lastState = EnterState.Finished;
 					return false;
 				}

--- a/OpenRA.Mods.Common/ActorInitializer.cs
+++ b/OpenRA.Mods.Common/ActorInitializer.cs
@@ -24,13 +24,13 @@ namespace OpenRA.Mods.Common
 		public int Value(World world) { return value; }
 	}
 
-	public class MoveIntoWorldDelayInit : IActorInit<int>
+	public class CreationActivityDelayInit : IActorInit<int>
 	{
 		[FieldFromYamlKey]
 		readonly int value = 0;
 
-		public MoveIntoWorldDelayInit() { }
-		public MoveIntoWorldDelayInit(int init) { value = init; }
+		public CreationActivityDelayInit() { }
+		public CreationActivityDelayInit(int init) { value = init; }
 		public int Value(World world) { return value; }
 	}
 

--- a/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/MobileProperties.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Scripting
 			var pos = Self.CenterPosition;
 			mobile.SetPosition(Self, cell);
 			mobile.SetVisualPosition(Self, pos);
-			Self.QueueActivity(mobile.MoveIntoWorld(Self));
+			Self.QueueActivity(mobile.ReturnToCell(Self));
 		}
 
 		[ScriptActorPropertyActivity]

--- a/OpenRA.Mods.Common/Scripting/Properties/TransportProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/TransportProperties.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Linq;
+using Eluant;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Scripting;
@@ -35,7 +36,13 @@ namespace OpenRA.Mods.Common.Scripting
 		public int PassengerCount { get { return cargo.Passengers.Count(); } }
 
 		[Desc("Teleport an existing actor inside this transport.")]
-		public void LoadPassenger(Actor a) { cargo.Load(Self, a); }
+		public void LoadPassenger(Actor a)
+		{
+			if (!a.IsIdle)
+				throw new LuaException("LoadPassenger requires the passenger to be idle.");
+
+			cargo.Load(Self, a);
+		}
 
 		[Desc("Remove the first actor from the transport.  This actor is not added to the world.")]
 		public Actor UnloadPassenger() { return cargo.Unload(Self); }

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -251,9 +251,6 @@ namespace OpenRA.Mods.Common.Traits
 				SetPosition(self, init.Get<CenterPositionInit, WPos>());
 
 			Facing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : Info.InitialFacing;
-
-			// SkipMoveIntoWorldInit is deliberately ignored for Aircraft
-			// MoveIntoWorld must run for aircraft for map-placed actors to be associated with their airfields
 			moveIntoWorldDelay = init.Contains<MoveIntoWorldDelayInit>() ? init.Get<MoveIntoWorldDelayInit, int>() : 0;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -220,7 +220,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<CPos> landingCells = Enumerable.Empty<CPos>();
 		bool requireForceMove;
-		int moveIntoWorldDelay;
+		int creationActivityDelay;
 
 		public static WPos GroundPosition(Actor self)
 		{
@@ -251,7 +251,9 @@ namespace OpenRA.Mods.Common.Traits
 				SetPosition(self, init.Get<CenterPositionInit, WPos>());
 
 			Facing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : Info.InitialFacing;
-			moveIntoWorldDelay = init.Contains<MoveIntoWorldDelayInit>() ? init.Get<MoveIntoWorldDelayInit, int>() : 0;
+
+			if (init.Contains<CreationActivityDelayInit>())
+				creationActivityDelay = init.Get<CreationActivityDelayInit, int>();
 		}
 
 		public WDist LandAltitude
@@ -841,18 +843,15 @@ namespace OpenRA.Mods.Common.Traits
 				initialTargetPosition, targetLineColor);
 		}
 
-		public Activity MoveIntoWorld(Actor self, int delay = 0)
-		{
-			return new MoveIntoWorldActivity(self, delay);
-		}
+		public Activity ReturnToCell(Actor self) { return null; }
 
-		class MoveIntoWorldActivity : Activity
+		class AssociateWithAirfieldActivity : Activity
 		{
 			readonly Actor self;
 			readonly Aircraft aircraft;
 			readonly int delay;
 
-			public MoveIntoWorldActivity(Actor self, int delay = 0)
+			public AssociateWithAirfieldActivity(Actor self, int delay = 0)
 			{
 				this.self = self;
 				aircraft = self.Trait<Aircraft>();
@@ -1164,7 +1163,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		Activity ICreationActivity.GetCreationActivity()
 		{
-			return MoveIntoWorld(self, moveIntoWorldDelay);
+			return new AssociateWithAirfieldActivity(self, creationActivityDelay);
 		}
 
 		public class AircraftMoveOrderTargeter : IOrderTargeter

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -406,11 +406,11 @@ namespace OpenRA.Mods.Common.Traits
 			// If not initialized then this will be notified in the first tick
 			if (initialized)
 			{
-				foreach (var npe in self.TraitsImplementing<INotifyPassengerEntered>())
-					npe.OnPassengerEntered(self, a);
-
 				foreach (var nec in a.TraitsImplementing<INotifyEnteredCargo>())
 					nec.OnEnteredCargo(a, self);
+
+				foreach (var npe in self.TraitsImplementing<INotifyPassengerEntered>())
+					npe.OnPassengerEntered(self, a);
 			}
 
 			var p = a.Trait<Passenger>();
@@ -507,11 +507,11 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					c.Trait<Passenger>().Transport = self;
 
-					foreach (var npe in self.TraitsImplementing<INotifyPassengerEntered>())
-						npe.OnPassengerEntered(self, c);
-
 					foreach (var nec in c.TraitsImplementing<INotifyEnteredCargo>())
 						nec.OnEnteredCargo(c, self);
+
+					foreach (var npe in self.TraitsImplementing<INotifyPassengerEntered>())
+						npe.OnPassengerEntered(self, c);
 				}
 
 				initialized = true;

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -143,7 +143,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly Actor self;
 		readonly Lazy<IEnumerable<int>> speedModifiers;
-		readonly int? moveIntoWorldDelay;
+		readonly int moveIntoWorldDelay;
 
 		#region IMove CurrentMovementTypes
 		MovementType movementTypes;
@@ -243,8 +243,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (init.Contains<CenterPositionInit>())
 				SetVisualPosition(self, init.Get<CenterPositionInit, WPos>());
 
-			if (!init.Contains<SkipMoveIntoWorldInit>())
-				moveIntoWorldDelay = init.Contains<MoveIntoWorldDelayInit>() ? init.Get<MoveIntoWorldDelayInit, int>() : 0;
+			moveIntoWorldDelay = init.Contains<MoveIntoWorldDelayInit>() ? init.Get<MoveIntoWorldDelayInit, int>() : 0;
 		}
 
 		protected override void Created(Actor self)
@@ -899,7 +898,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		Activity ICreationActivity.GetCreationActivity()
 		{
-			return moveIntoWorldDelay.HasValue ? MoveIntoWorld(self, moveIntoWorldDelay.Value) : null;
+			return MoveIntoWorld(self, moveIntoWorldDelay);
 		}
 
 		class MoveOrderTargeter : IOrderTargeter

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -131,6 +131,16 @@ namespace OpenRA.Mods.Common.Traits
 				if (specificCargoToken == ConditionManager.InvalidConditionToken && Info.CargoConditions.TryGetValue(cargo.Info.Name, out specificCargoCondition))
 					specificCargoToken = conditionManager.GrantCondition(self, specificCargoCondition);
 			}
+
+			// Allow scripted / initial actors to move from the unload point back into the cell grid on unload
+			// This is handled by the RideTransport activity for player-loaded cargo
+			if (self.IsIdle)
+			{
+				// IMove is not used anywhere else in this trait, there is no benefit to caching it from Created.
+				var move = self.TraitOrDefault<IMove>();
+				if (move != null)
+					self.QueueActivity(move.ReturnToCell(self));
+			}
 		}
 
 		void INotifyExitedCargo.OnExitedCargo(Actor self, Actor cargo)

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -74,7 +74,7 @@ namespace OpenRA.Mods.Common.Traits
 				td.Add(new CenterPositionInit(spawn));
 				td.Add(new FacingInit(initialFacing));
 				if (exitinfo != null)
-					td.Add(new MoveIntoWorldDelayInit(exitinfo.ExitDelay));
+					td.Add(new CreationActivityDelayInit(exitinfo.ExitDelay));
 			}
 
 			self.World.AddFrameEndTask(w =>

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -73,7 +73,6 @@ namespace OpenRA.Mods.Common.Traits
 				td.Add(new LocationInit(exit));
 				td.Add(new CenterPositionInit(spawn));
 				td.Add(new FacingInit(initialFacing));
-				td.Add(new SubCellInit(SubCell.Any));
 				if (exitinfo != null)
 					td.Add(new MoveIntoWorldDelayInit(exitinfo.ExitDelay));
 			}

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -127,7 +127,7 @@ namespace OpenRA.Mods.Common.Traits
 				td.Add(new LocationInit(exit));
 				td.Add(new CenterPositionInit(spawn));
 				td.Add(new FacingInit(initialFacing));
-				td.Add(new MoveIntoWorldDelayInit(exitinfo.ExitDelay));
+				td.Add(new CreationActivityDelayInit(exitinfo.ExitDelay));
 			}
 
 			self.World.AddFrameEndTask(w =>

--- a/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
@@ -90,7 +90,6 @@ namespace OpenRA.Mods.Common.Traits
 					new LocationInit(sp + unitGroup.BaseActorOffset),
 					new OwnerInit(p),
 					new SkipMakeAnimsInit(),
-					new SkipMoveIntoWorldInit(),
 					new FacingInit(unitGroup.BaseActorFacing < 0 ? w.SharedRandom.Next(256) : unitGroup.BaseActorFacing),
 				});
 			}

--- a/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMapActors.cs
@@ -41,7 +41,6 @@ namespace OpenRA.Mods.Common.Traits
 
 				var initDict = actorReference.InitDict;
 				initDict.Add(new SkipMakeAnimsInit());
-				initDict.Add(new SkipMoveIntoWorldInit());
 				initDict.Add(new SpawnedByMapInit(kv.Key));
 
 				if (PreventMapSpawn(world, actorReference, preventMapSpawns))
@@ -64,7 +63,6 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	public class SkipMakeAnimsInit : IActorInit, ISuppressInitExport { }
-	public class SkipMoveIntoWorldInit : IActorInit, ISuppressInitExport { }
 	public class SpawnedByMapInit : IActorInit<string>, ISuppressInitExport
 	{
 		public readonly string Name;

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -435,7 +435,7 @@ namespace OpenRA.Mods.Common.Traits
 			WPos? initialTargetPosition = null, Color? targetLineColor = null);
 		Activity MoveToTarget(Actor self, Target target,
 			WPos? initialTargetPosition = null, Color? targetLineColor = null);
-		Activity MoveIntoWorld(Actor self, int delay = 0);
+		Activity ReturnToCell(Actor self);
 		Activity MoveIntoTarget(Actor self, Target target);
 		Activity VisualMove(Actor self, WPos fromPos, WPos toPos);
 		int EstimatedMoveDuration(Actor self, WPos fromPos, WPos toPos);


### PR DESCRIPTION
This PR reworks the problematic part of #16938  and the subsequent workarounds.

The specific changes and motivations are:
* `MoveIntoWorld` is renamed to `ReturnToCell`, making it clearer that the actual purpose of this activity is to visually move the `CenterPosition` to match the already defined `Location` and `ToSubCell`. A `recalculateSubCell` argument allows the subcell calculation to be explicitly deferred until the activity runs. These changes resolve my complaints about the activity relying on undefined state, without throwing the baby out with the bathwater.
* `ReturnToCell` is now only queued as a creation activity if `CenterPositionInit` is defined. This saves us from queuing the activity when it isn't needed, and provides a cleaner fix for #17184 than #17187 did.
* Transport exits for scripted/initial cargo is now managed by the `Passenger` trait: `ReturnToCell` is now queued on idle actors when they are inserted into the transport, which fixes actors that are loaded into the transport (either through Lua or a custom trait) at some point after their initial creation.
* Aircraft-airfield association is decoupled from `ReturnToCell`/`MoveIntoWorld` - this is a creation activity, not a positioning one.

Supersedes #17218.

This should hopefully cover all our current issues and workarounds (except for #17209 and the paradrop issue #17223 fixes), but I may have missed some details while tweaking and testing.