### PR TITLE
Add UseResourceStorage trait to CashTrickler

### DIFF
--- a/OpenRA.Mods.Common/Traits/CashTrickler.cs
+++ b/OpenRA.Mods.Common/Traits/CashTrickler.cs
@@ -33,6 +33,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("How long to show the cash tick indicator when enabled.")]
 		public readonly int DisplayDuration = 30;
 
+		[Desc("Use resource storage for cash granted.")]
+		public readonly bool UseResourceStorage = false;
+
 		public override object Create(ActorInitializer init) { return new CashTrickler(this); }
 	}
 
@@ -87,7 +90,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ModifyCash(Actor self, Player newOwner, int amount)
 		{
-			amount = resources.ChangeCash(amount);
+			if (info.UseResourceStorage)
+			{
+				var initialAmount = resources.Resources;
+				resources.GiveResources(amount);
+				amount = resources.Resources - initialAmount;
+			}
+			else
+				amount = resources.ChangeCash(amount);
 
 			if (info.ShowTicks && amount != 0)
 				AddCashTick(self, amount);


### PR DESCRIPTION
Add UseResourceStorage trait to CashTrickler. It defaults to false. When true the cash trickle will be added to the resource storage. It obeys the same rules that harvesters dumping resources do. The cash tick will show the amount granted. If silos are needed it will either show nothing or a partial tick depending on how much free space is available.