### PR TITLE
Show dialogue only when there are unsaved changes

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/EditorActionManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActionManager.cs
@@ -29,6 +29,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		int nextId;
 
+		public bool Modified;
+
 		public void WorldLoaded(World w, WorldRenderer wr)
 		{
 			Add(new OpenMapAction());
@@ -36,6 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void Add(IEditorAction editorAction)
 		{
+			Modified = true;
 			editorAction.Execute();
 
 			if (undoStack.Count > 0)
@@ -54,6 +57,8 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (!HasUndos())
 				return;
+
+			Modified = true;
 
 			var editorAction = undoStack.Pop();
 			undoStack.Peek().Status = EditorActionStatus.Active;
@@ -80,6 +85,8 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (!HasRedos())
 				return;
+
+			Modified = true;
 
 			var editorAction = redoStack.Pop();
 
@@ -113,6 +120,12 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			while (undoStack.Peek().Id != id)
 				Redo();
+		}
+
+		public bool HasUnsavedItems()
+		{
+			// Modified and last action isn't the OpenMapAction (+ no redos)
+			return Modified && !(undoStack.Peek().Action is OpenMapAction && !HasRedos());
 		}
 	}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameMenuLogic.cs
@@ -339,9 +339,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				hideMenu = true;
 				var editorActorLayer = world.WorldActor.Trait<EditorActorLayer>();
+				var actionManager = world.WorldActor.Trait<EditorActionManager>();
 				Ui.OpenWindow("SAVE_MAP_PANEL", new WidgetArgs()
 				{
-					{ "onSave", (Action<string>)(_ => hideMenu = false) },
+					{ "onSave", (Action<string>)(_ => { hideMenu = false; actionManager.Modified = false; }) },
 					{ "onExit", () => hideMenu = false },
 					{ "map", world.Map },
 					{ "playerDefinitions", editorActorLayer.Players.ToMiniYaml() },
@@ -355,15 +356,23 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (world.Type != WorldType.Editor)
 				return;
 
+			var actionManager = world.WorldActor.Trait<EditorActionManager>();
 			var button = AddButton("EXIT_EDITOR", "Exit Map Editor");
+
+			// Show dialog only if updated since last save
 			button.OnClick = () =>
 			{
-				hideMenu = true;
-				ConfirmationDialogs.ButtonPrompt(
-					title: "Exit Map Editor",
-					text: "Exit and lose all unsaved changes?",
-					onConfirm: OnQuit,
-					onCancel: ShowMenu);
+				if (actionManager.HasUnsavedItems())
+				{
+					hideMenu = true;
+					ConfirmationDialogs.ButtonPrompt(
+						title: "Exit Map Editor",
+						text: "Exit and lose all unsaved changes?",
+						onConfirm: OnQuit,
+						onCancel: ShowMenu);
+				}
+				else
+					OnQuit();
 			};
 		}
 	}


### PR DESCRIPTION
Fix for #17212. Just a POC for now, requires a few changes. Is this an ideal solution - I couldn't find a function that is called on every change so I've got the update counter code in each change function.
Also, would you like me to amend any changes to the commit rather than make new ones?