### PR TITLE
Allow carryall pickup orders on deployed vehicles (prep edition)

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -208,6 +208,13 @@ namespace OpenRA.Mods.Common.Activities
 
 			var nextCell = path[path.Count - 1];
 
+			// Something else might have moved us, so the path is no longer valid.
+			if (!Util.AreAdjacentCells(mobile.ToCell, nextCell))
+			{
+				path = EvalPath();
+				return null;
+			}
+
 			var containsTemporaryBlocker = WorldUtils.ContainsTemporaryBlocker(self.World, nextCell, self);
 
 			// Next cell in the move is blocked by another actor
@@ -331,9 +338,6 @@ namespace OpenRA.Mods.Common.Activities
 
 			public override bool Tick(Actor self)
 			{
-				if (Move.mobile.IsTraitDisabled || Move.mobile.IsTraitPaused)
-					return false;
-
 				var ret = InnerTick(self, Move.mobile);
 
 				if (moveFraction > MoveFractionTotal)
@@ -412,7 +416,7 @@ namespace OpenRA.Mods.Common.Activities
 				var nextCell = parent.PopPath(self);
 				if (nextCell != null)
 				{
-					if (IsTurn(mobile, nextCell.Value.First))
+					if (!mobile.IsTraitPaused && !mobile.IsTraitDisabled && IsTurn(mobile, nextCell.Value.First))
 					{
 						var nextSubcellOffset = map.Grid.OffsetOfSubCell(nextCell.Value.Second);
 						var ret = new MoveFirstHalf(

--- a/OpenRA.Mods.Common/Activities/PickupUnit.cs
+++ b/OpenRA.Mods.Common/Activities/PickupUnit.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using OpenRA.Activities;
 using OpenRA.Mods.Common.Traits;
@@ -20,20 +21,18 @@ namespace OpenRA.Mods.Common.Activities
 	public class PickupUnit : Activity
 	{
 		readonly Actor cargo;
-		readonly IMove movement;
-
 		readonly Carryall carryall;
-		readonly IFacing carryallFacing;
-
 		readonly Carryable carryable;
 		readonly IFacing carryableFacing;
 		readonly BodyOrientation carryableBody;
 
 		readonly int delay;
 
-		enum PickupState { Intercept, LockCarryable, Pickup }
+		// TODO: Expose this to yaml
+		readonly WDist targetLockRange = WDist.FromCells(4);
 
-		PickupState state;
+		enum PickupState { Intercept, LockCarryable, Pickup }
+		PickupState state = PickupState.Intercept;
 
 		public PickupUnit(Actor self, Actor cargo, int delay)
 		{
@@ -43,16 +42,20 @@ namespace OpenRA.Mods.Common.Activities
 			carryableFacing = cargo.Trait<IFacing>();
 			carryableBody = cargo.Trait<BodyOrientation>();
 
-			movement = self.Trait<IMove>();
 			carryall = self.Trait<Carryall>();
-			carryallFacing = self.Trait<IFacing>();
 
-			state = PickupState.Intercept;
+			ChildHasPriority = false;
 		}
 
 		protected override void OnFirstRun(Actor self)
 		{
-			carryall.ReserveCarryable(self, cargo);
+			if (carryall.ReserveCarryable(self, cargo))
+			{
+				// Fly to the target and wait for it to be locked for pickup
+				// These activities will be cancelled and replaced by Land once the target has been locked
+				QueueChild(new Fly(self, Target.FromActor(cargo)));
+				QueueChild(new FlyCircle(self));
+			}
 		}
 
 		public override bool Tick(Actor self)
@@ -74,26 +77,21 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 			}
 
-			if (carryall.State != Carryall.CarryallState.Reserved)
-				return true;
+			// Wait until we are near the target before we try to lock it
+			var distSq = (cargo.CenterPosition - self.CenterPosition).HorizontalLengthSquared;
+			if (state == PickupState.Intercept && distSq <= targetLockRange.LengthSquared)
+				state = PickupState.LockCarryable;
 
-			switch (state)
+			if (state == PickupState.LockCarryable)
 			{
-				case PickupState.Intercept:
-					QueueChild(movement.MoveWithinRange(Target.FromActor(cargo), WDist.FromCells(4)));
-					state = PickupState.LockCarryable;
-					return false;
-
-				case PickupState.LockCarryable:
-					if (!carryable.LockForPickup(cargo, self))
-						Cancel(self);
-
-					state = PickupState.Pickup;
-					return false;
-
-				case PickupState.Pickup:
+				var lockResponse = carryable.LockForPickup(cargo, self);
+				if (lockResponse == LockResponse.Failed)
+					Cancel(self);
+				else if (lockResponse == LockResponse.Success)
 				{
-					// Land at the target location
+					// Pickup position and facing are now known - swap the fly/wait activity with Land
+					ChildActivity.Cancel(self);
+
 					var localOffset = carryall.OffsetForCarryable(self, cargo).Rotate(carryableBody.QuantizeOrientation(self, cargo.Orientation));
 					QueueChild(new Land(self, Target.FromActor(cargo), -carryableBody.LocalToWorld(localOffset), carryableFacing.Facing));
 
@@ -104,11 +102,13 @@ namespace OpenRA.Mods.Common.Activities
 					// Remove our carryable from world
 					QueueChild(new AttachUnit(self, cargo));
 					QueueChild(new TakeOff(self));
-					return false;
+
+					state = PickupState.Pickup;
 				}
 			}
 
-			return true;
+			// Return once we are in the pickup state and the pickup activities have completed
+			return TickChild(self) && state == PickupState.Pickup;
 		}
 
 		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)

--- a/OpenRA.Mods.Common/Traits/AutoCarryable.cs
+++ b/OpenRA.Mods.Common/Traits/AutoCarryable.cs
@@ -102,10 +102,10 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		// Prepare for transport pickup
-		public override bool LockForPickup(Actor self, Actor carrier)
+		public override LockResponse LockForPickup(Actor self, Actor carrier)
 		{
-			if (state == State.Locked || !WantsTransport)
-				return false;
+			if ((state == State.Locked && Carrier != carrier) || !WantsTransport)
+				return LockResponse.Failed;
 
 			// Last chance to change our mind...
 			var delta = self.World.Map.CenterOfCell(Destination.Value) - self.CenterPosition;
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				// Cancel pickup
 				MovementCancelled(self);
-				return false;
+				return LockResponse.Failed;
 			}
 
 			return base.LockForPickup(self, carrier);

--- a/OpenRA.Mods.Common/Traits/CaptureManager.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureManager.cs
@@ -221,6 +221,11 @@ namespace OpenRA.Mods.Common.Traits
 			if (captures == null)
 				return false;
 
+			// HACK: Make sure the target is not moving and at its normal position with respect to the cell grid
+			var enterMobile = target.TraitOrDefault<Mobile>();
+			if (enterMobile != null && enterMobile.IsMovingBetweenCells)
+				return false;
+
 			if (progressWatchers.Any() || targetManager.progressWatchers.Any())
 			{
 				currentTargetTotal = captures.Info.CaptureDelay;

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -58,6 +58,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Undeploy before the actor tries to move?")]
 		public readonly bool UndeployOnMove = false;
 
+		[Desc("Undeploy before the actor is picked up by a Carryall?")]
+		public readonly bool UndeployOnPickup = false;
+
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
@@ -67,7 +70,7 @@ namespace OpenRA.Mods.Common.Traits
 	public enum DeployState { Undeployed, Deploying, Deployed, Undeploying }
 
 	public class GrantConditionOnDeploy : PausableConditionalTrait<GrantConditionOnDeployInfo>, IResolveOrder, IIssueOrder,
-		INotifyDeployComplete, IIssueDeployOrder, IOrderVoice, IWrapMove
+		INotifyDeployComplete, IIssueDeployOrder, IOrderVoice, IWrapMove, IDelayCarryallPickup
 	{
 		readonly Actor self;
 		readonly bool checkTerrainType;
@@ -135,6 +138,17 @@ namespace OpenRA.Mods.Common.Traits
 			var activity = new DeployForGrantedCondition(self, this, true);
 			activity.Queue(moveInner);
 			return activity;
+		}
+
+		bool IDelayCarryallPickup.TryLockForPickup(Actor self, Actor carrier)
+		{
+			if (!Info.UndeployOnPickup || deployState == DeployState.Undeployed || IsTraitDisabled)
+				return true;
+
+			if (deployState == DeployState.Deployed && !IsTraitPaused)
+				Undeploy();
+
+			return false;
 		}
 
 		IEnumerable<IOrderTargeter> IIssueOrder.Orders

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -183,6 +183,11 @@ namespace OpenRA.Mods.Common.Traits
 		IWrapMove[] moveWrappers;
 		bool requireForceMove;
 
+		public bool IsMovingBetweenCells
+		{
+			get { return FromCell != ToCell; }
+		}
+
 		#region IFacing
 		[Sync]
 		public int Facing

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -141,6 +141,12 @@ namespace OpenRA.Mods.Common
 			}
 		}
 
+		public static bool AreAdjacentCells(CPos a, CPos b)
+		{
+			var offset = b - a;
+			return Math.Abs(offset.X) < 2 && Math.Abs(offset.Y) < 2;
+		}
+
 		public static IEnumerable<CPos> ExpandFootprint(IEnumerable<CPos> cells, bool allowDiagonal)
 		{
 			return cells.SelectMany(c => Neighbours(c, allowDiagonal)).Distinct();

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -354,6 +354,7 @@ JUGG:
 		DeployedCondition: deployed
 		UndeployedCondition: undeployed
 		UndeployOnMove: true
+		UndeployOnPickup: true
 		Facing: 96
 		AllowedTerrainTypes: Clear, Road, DirtRoad, Rough
 		DeploySounds: place2.aud
@@ -405,8 +406,6 @@ JUGG:
 		MuzzleSequence: muzzle
 		MuzzlePalette: effect-ignore-lighting
 	WithMuzzleOverlay:
-	Carryable:
-		RequiresCondition: undeployed
 	RevealOnFire:
 		ArmamentNames: deployed
 	SelectionDecorations:

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -135,6 +135,7 @@ TTNK:
 		DeployedCondition: deployed
 		UndeployedCondition: undeployed
 		UndeployOnMove: true
+		UndeployOnPickup: true
 		Facing: 160
 		AllowedTerrainTypes: Clear, Road, DirtRoad, Rough
 		DeploySounds: place2.aud
@@ -199,8 +200,6 @@ TTNK:
 		Range: 1c768
 		RequiresCondition: rank-elite
 	RenderDetectionCircle:
-	Carryable:
-		RequiresCondition: undeployed
 	RevealOnFire:
 		ArmamentNames: primary, deployed
 	RenderVoxels:
@@ -248,6 +247,7 @@ ART2:
 		DeployedCondition: deployed
 		UndeployedCondition: undeployed
 		UndeployOnMove: true
+		UndeployOnPickup: true
 		Facing: 96
 		AllowedTerrainTypes: Clear, Road, DirtRoad, Rough
 		DeploySounds: place2.aud
@@ -297,8 +297,6 @@ ART2:
 		MuzzleSequence: muzzle
 		MuzzlePalette: effect-ignore-lighting
 	WithMuzzleOverlay:
-	Carryable:
-		RequiresCondition: undeployed
 	RevealOnFire:
 		ArmamentNames: deployed
 

--- a/mods/ts/rules/nod-vehicles.yaml
+++ b/mods/ts/rules/nod-vehicles.yaml
@@ -422,6 +422,8 @@ SAPC:
 		SubterraneanTransitionImage: dig
 		SubterraneanTransitionSequence: idle
 		SubterraneanTransitionSound: subdril1.aud
+	Carryable:
+		RequiresCondition: !submerged
 
 SUBTANK:
 	Inherits: ^Tank
@@ -465,6 +467,8 @@ SUBTANK:
 		SubterraneanTransitionImage: dig
 		SubterraneanTransitionSequence: idle
 		SubterraneanTransitionSound: subdril1.aud
+	Carryable:
+		RequiresCondition: !submerged
 
 STNK:
 	Inherits: ^Tank

--- a/mods/ts/rules/shared-vehicles.yaml
+++ b/mods/ts/rules/shared-vehicles.yaml
@@ -149,6 +149,7 @@ LPST:
 		DeployedCondition: deployed
 		UndeployedCondition: undeployed
 		UndeployOnMove: true
+		UndeployOnPickup: true
 		Facing: 160
 		AllowedTerrainTypes: Clear, Road, DirtRoad, Rough
 		DeploySounds: place2.aud
@@ -169,7 +170,5 @@ LPST:
 		Range: 18c0
 	RenderDetectionCircle:
 		TrailCount: 3
-	Carryable:
-		RequiresCondition: undeployed
 	RenderVoxels:
 		Scale: 11.5


### PR DESCRIPTION
#17221 rebased and adapted for the prep branch.

The changes compared with the original PR are:
* Removed `BlockedByActor.Immovable` from `Move.EvalPath` - related to #16408, changes in `EvalPath` do not impact this PR.
* Changed `MoveFirstHalf.OnComplete` to call `IsTurn` with two args instead of three  - related to #16408, changes in `EvalPath` do not impact this PR.
* Replaced `FlyIdle` with `FlyCircle` and dropped the `FlyIdle` changes - This changes the carryall behaviour in TS (it circles instead of hovers), but this IMO is a perfectly reasonable tradeoff vs implementing custom code that won't actually be used.