### PR TITLE
Fix infantry having the wrong facing on creation.

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Render/WithEmbeddedTurretSpriteBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithEmbeddedTurretSpriteBody.cs
@@ -34,9 +34,10 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 			var wsb = init.Actor.TraitInfos<WithSpriteBodyInfo>().FirstOrDefault();
 
 			// Show the correct turret facing
+			Func<int> bodyFacing = init.GetFacing();
 			var facing = init.Contains<TurretFacingInit>() ? init.Get<TurretFacingInit>().Value(init.World) : t.InitialFacing;
 
-			var anim = new Animation(init.World, image, () => facing);
+			var anim = new Animation(init.World, image, () => facing + bodyFacing());
 			anim.PlayRepeating(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), wsb.Sequence));
 
 			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, p, rs.Scale);

--- a/OpenRA.Mods.Common/Activities/DeliverUnit.cs
+++ b/OpenRA.Mods.Common/Activities/DeliverUnit.cs
@@ -83,16 +83,9 @@ namespace OpenRA.Mods.Common.Activities
 				var localOffset = carryall.CarryableOffset.Rotate(body.QuantizeOrientation(self, self.Orientation));
 				var targetPosition = self.CenterPosition + body.LocalToWorld(localOffset);
 				var targetLocation = self.World.Map.CellContaining(targetPosition);
+
 				carryall.Carryable.Trait<IPositionable>().SetPosition(carryall.Carryable, targetLocation, SubCell.FullCell);
-
-				// HACK: directly manipulate the turret facings to match the new orientation
-				// This can eventually go away, when we make turret facings relative to the body
-				var carryableFacing = carryall.Carryable.Trait<IFacing>();
-				var facingDelta = facing.Facing - carryableFacing.Facing;
-				foreach (var t in carryall.Carryable.TraitsImplementing<Turreted>())
-					t.TurretFacing += facingDelta;
-
-				carryableFacing.Facing = facing.Facing;
+				carryall.Carryable.Trait<IFacing>().Facing = facing.Facing;
 
 				// Put back into world
 				self.World.AddFrameEndTask(w =>

--- a/OpenRA.Mods.Common/Activities/Parachute.cs
+++ b/OpenRA.Mods.Common/Activities/Parachute.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Activities
 		protected override void OnLastRun(Actor self)
 		{
 			var centerPosition = self.CenterPosition;
-			pos.SetPosition(self, centerPosition + new WVec(0, 0, groundLevel - centerPosition.Z));
+			pos.SetVisualPosition(self, centerPosition + new WVec(0, 0, groundLevel - centerPosition.Z));
 
 			foreach (var np in self.TraitsImplementing<INotifyParachute>())
 				np.OnLanded(self);

--- a/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorActorBrush.cs
@@ -60,7 +60,6 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var td = new TypeDictionary();
 			td.Add(new FacingInit(facing));
-			td.Add(new TurretFacingInit(facing));
 			td.Add(new OwnerInit(ownerName));
 			td.Add(new FactionInit(owner.Faction));
 			preview.SetPreview(actor, td);
@@ -179,9 +178,6 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (actor.HasTraitInfo<IFacingInfo>())
 				initDict.Add(new FacingInit(facing));
-
-			if (actor.HasTraitInfo<TurretedInfo>())
-				initDict.Add(new TurretFacingInit(facing));
 
 			editorActorPreview = editorLayer.Add(newActorReference);
 

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -359,9 +359,6 @@ namespace OpenRA.Mods.Common.Traits
 			var passengerFacing = passenger.TraitOrDefault<IFacing>();
 			if (passengerFacing != null)
 				passengerFacing.Facing = facing.Value.Facing + Info.PassengerFacing;
-
-			foreach (var t in passenger.TraitsImplementing<Turreted>())
-				t.TurretFacing = facing.Value.Facing + Info.PassengerFacing;
 		}
 
 		public IEnumerable<PipType> GetPips(Actor self)

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -119,26 +119,9 @@ namespace OpenRA.Mods.Common.Traits
 				},
 				(actor, value) =>
 				{
-					// TODO: This can all go away once turrets are properly defined as a relative facing
-					var turretInit = actor.Init<TurretFacingInit>();
-					var turretsInit = actor.Init<TurretFacingsInit>();
 					var facingInit = actor.Init<FacingInit>();
-
 					var oldFacing = facingInit != null ? facingInit.Value(world) : InitialFacing;
 					var newFacing = (int)value;
-
-					if (turretInit != null)
-					{
-						var newTurretFacing = (turretInit.Value(world) + newFacing - oldFacing + 255) % 255;
-						actor.ReplaceInit(new TurretFacingInit(newTurretFacing));
-					}
-
-					if (turretsInit != null)
-					{
-						var newTurretFacings = turretsInit.Value(world)
-							.ToDictionary(kv => kv.Key, kv => (kv.Value + newFacing - oldFacing + 255) % 255);
-						actor.ReplaceInit(new TurretFacingsInit(newTurretFacings));
-					}
 
 					actor.ReplaceInit(new FacingInit(newFacing));
 				});

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -262,14 +262,13 @@ namespace OpenRA.Mods.Common.Traits
 				SetVisualPosition(self, init.World.Map.CenterOfSubCell(FromCell, FromSubCell));
 			}
 
-			Facing = oldFacing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : info.InitialFacing;
+			Facing = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : info.InitialFacing;
 
 			// Sets the initial visual position
 			// Unit will move into the cell grid (defined by LocationInit) as its initial activity
 			if (init.Contains<CenterPositionInit>())
 			{
-				oldPos = init.Get<CenterPositionInit, WPos>();
-				SetVisualPosition(self, oldPos);
+				SetVisualPosition(self, init.Get<CenterPositionInit, WPos>());
 				returnToCellOnCreation = true;
 			}
 

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -131,16 +131,6 @@ namespace OpenRA.Mods.Common.Traits
 				if (specificCargoToken == ConditionManager.InvalidConditionToken && Info.CargoConditions.TryGetValue(cargo.Info.Name, out specificCargoCondition))
 					specificCargoToken = conditionManager.GrantCondition(self, specificCargoCondition);
 			}
-
-			// Allow scripted / initial actors to move from the unload point back into the cell grid on unload
-			// This is handled by the RideTransport activity for player-loaded cargo
-			if (self.IsIdle)
-			{
-				// IMove is not used anywhere else in this trait, there is no benefit to caching it from Created.
-				var move = self.TraitOrDefault<IMove>();
-				if (move != null)
-					self.QueueActivity(move.ReturnToCell(self));
-			}
 		}
 
 		void INotifyExitedCargo.OnExitedCargo(Actor self, Actor cargo)

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -54,28 +54,15 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				exit = self.Location + exitinfo.ExitCell;
 				var spawn = self.CenterPosition + exitinfo.SpawnOffset;
-				var to = self.World.Map.CenterOfCell(exit);
-
 				var initialFacing = exitinfo.Facing;
-				if (exitinfo.Facing < 0)
-				{
-					var delta = to - spawn;
-					if (delta.HorizontalLengthSquared == 0)
-					{
-						var fi = producee.TraitInfoOrDefault<IFacingInfo>();
-						initialFacing = fi != null ? fi.GetInitialFacing() : 0;
-					}
-					else
-						initialFacing = delta.Yaw.Facing;
-				}
 
 				exitLocations = rp.Value != null ? rp.Value.Path : new List<CPos> { exit };
 
 				td.Add(new LocationInit(exit));
 				td.Add(new CenterPositionInit(spawn));
-				td.Add(new FacingInit(initialFacing));
-				if (exitinfo != null)
-					td.Add(new CreationActivityDelayInit(exitinfo.ExitDelay));
+				td.Add(new CreationActivityDelayInit(exitinfo.ExitDelay));
+				if (initialFacing >= 0)
+					td.Add(new FacingInit(initialFacing));
 			}
 
 			self.World.AddFrameEndTask(w =>

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -119,16 +119,15 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				exit = self.Location + exitinfo.ExitCell;
 				var spawn = self.World.Map.CenterOfCell(exit) + new WVec(WDist.Zero, WDist.Zero, altitude);
-				var to = self.World.Map.CenterOfCell(exit);
-
-				var initialFacing = exitinfo.Facing < 0 ? (to - spawn).Yaw.Facing : exitinfo.Facing;
+				var initialFacing = exitinfo.Facing;
 
 				exitLocations = rp.Value != null ? rp.Value.Path : new List<CPos> { exit };
 
 				td.Add(new LocationInit(exit));
 				td.Add(new CenterPositionInit(spawn));
-				td.Add(new FacingInit(initialFacing));
 				td.Add(new CreationActivityDelayInit(exitinfo.ExitDelay));
+				if (initialFacing >= 0)
+					td.Add(new FacingInit(initialFacing));
 			}
 
 			self.World.AddFrameEndTask(w =>

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
@@ -45,11 +45,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var t = init.Actor.TraitInfos<TurretedInfo>()
 				.First(tt => tt.Turret == armament.Turret);
 
-			var turretFacing = Turreted.TurretFacingFromInit(init, t.InitialFacing, armament.Turret);
+			Func<int> facing = init.GetFacing();
+			var turretFacing = Turreted.TurretFacingFromInit(init, t.InitialFacing, facing, armament.Turret);
 			var anim = new Animation(init.World, image, turretFacing);
 			anim.Play(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence));
 
-			Func<int> facing = init.GetFacing();
 			Func<WRot> orientation = () => body.QuantizeOrientation(WRot.FromFacing(facing()), facings);
 			Func<WVec> turretOffset = () => body.LocalToWorld(t.Offset.Rotate(orientation()));
 			Func<int> zOffset = () =>

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -50,11 +50,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var t = init.Actor.TraitInfos<TurretedInfo>()
 				.First(tt => tt.Turret == Turret);
 
-			var turretFacing = Turreted.TurretFacingFromInit(init, t.InitialFacing, Turret);
+			Func<int> facing = init.GetFacing();
+			var turretFacing = Turreted.TurretFacingFromInit(init, t.InitialFacing, facing, Turret);
 			var anim = new Animation(init.World, image, turretFacing);
 			anim.Play(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence));
 
-			Func<int> facing = init.GetFacing();
 			Func<WRot> orientation = () => body.QuantizeOrientation(WRot.FromFacing(facing()), facings);
 			Func<WVec> offset = () => body.LocalToWorld(t.Offset.Rotate(orientation()));
 			Func<int> zOffset = () =>

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelBarrel.cs
@@ -51,7 +51,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			var model = init.World.ModelCache.GetModelSequence(image, Sequence);
 
-			var turretFacing = Turreted.TurretFacingFromInit(init, t.InitialFacing, t.Turret);
+			Func<int> facing = init.GetFacing();
+			var turretFacing = Turreted.TurretFacingFromInit(init, t.InitialFacing, facing, t.Turret);
 			Func<WRot> turretOrientation = () => body.QuantizeOrientation(WRot.FromYaw(WAngle.FromFacing(turretFacing()) - orientation().Yaw), facings);
 
 			Func<WRot> quantizedTurret = () => body.QuantizeOrientation(turretOrientation(), facings);

--- a/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithVoxelTurret.cs
@@ -44,7 +44,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var model = init.World.ModelCache.GetModelSequence(image, Sequence);
 			Func<WVec> turretOffset = () => body.LocalToWorld(t.Offset.Rotate(orientation()));
 
-			var turretFacing = Turreted.TurretFacingFromInit(init, t.InitialFacing, Turret);
+			Func<int> facing = init.GetFacing();
+			var turretFacing = Turreted.TurretFacingFromInit(init, t.InitialFacing, facing, Turret);
 			Func<WRot> turretBodyOrientation = () => WRot.FromYaw(WAngle.FromFacing(turretFacing()) - orientation().Yaw);
 			yield return new ModelAnimation(model, turretOffset,
 				() => new[] { turretBodyOrientation(), body.QuantizeOrientation(orientation(), facings) }, () => false, () => 0, ShowShadow);

--- a/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
@@ -67,7 +67,8 @@ namespace OpenRA.Mods.Common.Traits
 			// TODO: Carry orientation over from the parent instead of just facing
 			var bodyFacing = init.Contains<DynamicFacingInit>() ? init.Get<DynamicFacingInit, Func<int>>()()
 				: init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : 0;
-			facing = WAngle.FromFacing(Turreted.TurretFacingFromInit(init, 0)());
+
+			facing = WAngle.FromFacing(Turreted.TurretFacingFromInit(init, 0, () => bodyFacing)());
 
 			// Calculate final position
 			var throwRotation = WRot.FromFacing(Game.CosmeticRandom.Next(1024));

--- a/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
@@ -111,13 +111,10 @@ namespace OpenRA.Mods.Common.Traits
 					continue;
 				}
 
-				var subCell = ip.SharesCell ? w.ActorMap.FreeSubCell(validCell) : 0;
-
 				w.CreateActor(s.ToLowerInvariant(), new TypeDictionary
 				{
 					new OwnerInit(p),
 					new LocationInit(validCell),
-					new SubCellInit(subCell),
 					new FacingInit(unitGroup.SupportActorsFacing < 0 ? w.SharedRandom.Next(256) : unitGroup.SupportActorsFacing)
 				});
 			}


### PR DESCRIPTION
Fixes the problem of infantry having to turn immediately after being created at the barracks as described in https://github.com/OpenRA/OpenRA/issues/17252#issuecomment-544157804.

~This will have to aim for Next+1 as I already noticed a new regression here: Turreted vehicles will exit the warfactory with their turrets turning. The proper solution to that would be to finally define turret facings as relative to the body.~

Turrets are now also internally defined as a facing relative to the body.
Fixes #15843.

This supersedes #17253 (or at least the first commit there).