### PR TITLE
Remove landing behaviour from force-move orders on selectable buildings.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -1169,6 +1169,7 @@ namespace OpenRA.Mods.Common.Traits
 		public class AircraftMoveOrderTargeter : IOrderTargeter
 		{
 			readonly Aircraft aircraft;
+			readonly BuildingInfluence bi;
 
 			public string OrderID { get; protected set; }
 			public int OrderPriority { get { return 4; } }
@@ -1177,6 +1178,7 @@ namespace OpenRA.Mods.Common.Traits
 			public AircraftMoveOrderTargeter(Aircraft aircraft)
 			{
 				this.aircraft = aircraft;
+				bi = aircraft.self.World.WorldActor.TraitOrDefault<BuildingInfluence>();
 				OrderID = "Move";
 			}
 
@@ -1190,10 +1192,18 @@ namespace OpenRA.Mods.Common.Traits
 				if (target.Type != TargetType.Terrain || (aircraft.requireForceMove && !modifiers.HasModifier(TargetModifiers.ForceMove)))
 					return false;
 
-				if (modifiers.HasModifier(TargetModifiers.ForceMove) && aircraft.Info.CanForceLand)
-					OrderID = "Land";
-
 				var location = self.World.Map.CellContaining(target.CenterPosition);
+
+				// Aircraft can be force-landed by issuing a force-move order on a clear terrain cell
+				// Cells that contain a blocking building are treated as regular force move orders, overriding
+				// selection for left-mouse orders
+				if (modifiers.HasModifier(TargetModifiers.ForceMove) && aircraft.Info.CanForceLand)
+				{
+					var building = bi.GetBuildingAt(location);
+					if (building == null || building.TraitOrDefault<Selectable>() == null || aircraft.CanLand(location, blockedByMobile: false))
+						OrderID = "Land";
+				}
+
 				var explored = self.Owner.Shroud.IsExplored(location);
 				cursor = self.World.Map.Contains(location) ?
 					(self.World.Map.GetTerrainInfo(location).CustomCursor ?? "move") :


### PR DESCRIPTION
Fixes #17262.

Our definition for what constitutes a force move vs a force land is arbitrary to start with, so IMO it is perfectly reasonable to tweak that definition to be that force-move over a building† remains a move, and a force-move over anything else is a land.

† using "building" here from a player perspective, i.e. a player-built or civilian/tech structure, not trees or other actors that use the `Building` trait.