### PR TITLE
Fix MCV Manager glitch when restrict building area is enabled.

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -206,9 +206,6 @@ namespace OpenRA.Mods.Common.Traits
 					if (!world.CanPlaceBuilding(cell + offset, actorInfo, bi, null))
 						continue;
 
-					if (distanceToBaseIsImportant && !bi.IsCloseEnoughToBase(world, player, actorInfo, cell))
-						continue;
-
 					return cell;
 				}
 

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -202,12 +202,8 @@ namespace OpenRA.Mods.Common.Traits
 					cells = cells.Shuffle(world.LocalRandom);
 
 				foreach (var cell in cells)
-				{
-					if (!world.CanPlaceBuilding(cell + offset, actorInfo, bi, null))
-						continue;
-
-					return cell;
-				}
+					if (world.CanPlaceBuilding(cell + offset, actorInfo, bi, null))
+						return cell;
 
 				return null;
 			};


### PR DESCRIPTION
Fix MCV Manager glitch when restrict building area is enabled. It was checking if the location was close enough to the Base center instead of using the MCV Managers min and max ranges. This would cause it to often have no valid locations despite having a huge range.