### PR TITLE
Add support for linking HitShapes to turrets

### DIFF
--- a/OpenRA.Mods.Common/HitShapes/Capsule.cs
+++ b/OpenRA.Mods.Common/HitShapes/Capsule.cs
@@ -81,27 +81,23 @@ namespace OpenRA.Mods.Common.HitShapes
 			return new WDist(Math.Max(0, distance - Radius.Length));
 		}
 
-		public WDist DistanceFromEdge(WPos pos, Actor actor)
+		public WDist DistanceFromEdge(WPos pos, WPos origin, WRot orientation)
 		{
-			var actorPos = actor.CenterPosition;
+			if (pos.Z > origin.Z + VerticalTopOffset)
+				return DistanceFromEdge((pos - (origin + new WVec(0, 0, VerticalTopOffset))).Rotate(-orientation));
 
-			if (pos.Z > actorPos.Z + VerticalTopOffset)
-				return DistanceFromEdge((pos - (actorPos + new WVec(0, 0, VerticalTopOffset))).Rotate(-actor.Orientation));
+			if (pos.Z < origin.Z + VerticalBottomOffset)
+				return DistanceFromEdge((pos - (origin + new WVec(0, 0, VerticalBottomOffset))).Rotate(-orientation));
 
-			if (pos.Z < actorPos.Z + VerticalBottomOffset)
-				return DistanceFromEdge((pos - (actorPos + new WVec(0, 0, VerticalBottomOffset))).Rotate(-actor.Orientation));
-
-			return DistanceFromEdge((pos - new WPos(actorPos.X, actorPos.Y, pos.Z)).Rotate(-actor.Orientation));
+			return DistanceFromEdge((pos - new WPos(origin.X, origin.Y, pos.Z)).Rotate(-orientation));
 		}
 
-		IEnumerable<IRenderable> IHitShape.RenderDebugOverlay(WorldRenderer wr, Actor actor)
+		IEnumerable<IRenderable> IHitShape.RenderDebugOverlay(WorldRenderer wr, WPos origin, WRot orientation)
 		{
-			var actorPos = actor.CenterPosition;
-
-			var a = actorPos + new WVec(PointA.X, PointA.Y, VerticalTopOffset).Rotate(actor.Orientation);
-			var b = actorPos + new WVec(PointB.X, PointB.Y, VerticalTopOffset).Rotate(actor.Orientation);
-			var aa = actorPos + new WVec(PointA.X, PointA.Y, VerticalBottomOffset).Rotate(actor.Orientation);
-			var bb = actorPos + new WVec(PointB.X, PointB.Y, VerticalBottomOffset).Rotate(actor.Orientation);
+			var a = origin + new WVec(PointA.X, PointA.Y, VerticalTopOffset).Rotate(orientation);
+			var b = origin + new WVec(PointB.X, PointB.Y, VerticalTopOffset).Rotate(orientation);
+			var aa = origin + new WVec(PointA.X, PointA.Y, VerticalBottomOffset).Rotate(orientation);
+			var bb = origin + new WVec(PointB.X, PointB.Y, VerticalBottomOffset).Rotate(orientation);
 
 			var offset1 = new WVec(a.Y - b.Y, b.X - a.X, 0);
 			offset1 = offset1 * Radius.Length / offset1.Length;
@@ -112,7 +108,7 @@ namespace OpenRA.Mods.Common.HitShapes
 			yield return new CircleAnnotationRenderable(b, Radius, 1, Color.Yellow);
 			yield return new CircleAnnotationRenderable(aa, Radius, 1, Color.Yellow);
 			yield return new CircleAnnotationRenderable(bb, Radius, 1, Color.Yellow);
-			yield return new CircleAnnotationRenderable(actorPos, OuterRadius, 1,  Color.LimeGreen);
+			yield return new CircleAnnotationRenderable(origin, OuterRadius, 1,  Color.LimeGreen);
 			yield return new LineAnnotationRenderable(a - offset1, b - offset1, 1, Color.Yellow);
 			yield return new LineAnnotationRenderable(a + offset1, b + offset1, 1, Color.Yellow);
 			yield return new LineAnnotationRenderable(aa - offset2, bb - offset2, 1, Color.Yellow);

--- a/OpenRA.Mods.Common/HitShapes/Circle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Circle.cs
@@ -45,24 +45,21 @@ namespace OpenRA.Mods.Common.HitShapes
 			return new WDist(Math.Max(0, v.Length - Radius.Length));
 		}
 
-		public WDist DistanceFromEdge(WPos pos, Actor actor)
+		public WDist DistanceFromEdge(WPos pos, WPos origin, WRot orientation)
 		{
-			var actorPos = actor.CenterPosition;
+			if (pos.Z > origin.Z + VerticalTopOffset)
+				return DistanceFromEdge(pos - (origin + new WVec(0, 0, VerticalTopOffset)));
 
-			if (pos.Z > actorPos.Z + VerticalTopOffset)
-				return DistanceFromEdge(pos - (actorPos + new WVec(0, 0, VerticalTopOffset)));
+			if (pos.Z < origin.Z + VerticalBottomOffset)
+				return DistanceFromEdge(pos - (origin + new WVec(0, 0, VerticalBottomOffset)));
 
-			if (pos.Z < actorPos.Z + VerticalBottomOffset)
-				return DistanceFromEdge(pos - (actorPos + new WVec(0, 0, VerticalBottomOffset)));
-
-			return DistanceFromEdge(pos - new WPos(actorPos.X, actorPos.Y, pos.Z));
+			return DistanceFromEdge(pos - new WPos(origin.X, origin.Y, pos.Z));
 		}
 
-		IEnumerable<IRenderable> IHitShape.RenderDebugOverlay(WorldRenderer wr, Actor actor)
+		IEnumerable<IRenderable> IHitShape.RenderDebugOverlay(WorldRenderer wr, WPos origin, WRot orientation)
 		{
-			var actorPos = actor.CenterPosition;
-			yield return new CircleAnnotationRenderable(actorPos + new WVec(0, 0, VerticalTopOffset), Radius, 1, Color.Yellow);
-			yield return new CircleAnnotationRenderable(actorPos + new WVec(0, 0, VerticalBottomOffset), Radius, 1, Color.Yellow);
+			yield return new CircleAnnotationRenderable(origin + new WVec(0, 0, VerticalTopOffset), Radius, 1, Color.Yellow);
+			yield return new CircleAnnotationRenderable(origin + new WVec(0, 0, VerticalBottomOffset), Radius, 1, Color.Yellow);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/HitShapes/IHitShape.cs
+++ b/OpenRA.Mods.Common/HitShapes/IHitShape.cs
@@ -19,9 +19,9 @@ namespace OpenRA.Mods.Common.HitShapes
 		WDist OuterRadius { get; }
 
 		WDist DistanceFromEdge(WVec v);
-		WDist DistanceFromEdge(WPos pos, Actor actor);
+		WDist DistanceFromEdge(WPos pos, WPos origin, WRot orientation);
 
 		void Initialize();
-		IEnumerable<IRenderable> RenderDebugOverlay(WorldRenderer wr, Actor actor);
+		IEnumerable<IRenderable> RenderDebugOverlay(WorldRenderer wr, WPos origin, WRot orientation);
 	}
 }

--- a/OpenRA.Mods.Common/HitShapes/Polygon.cs
+++ b/OpenRA.Mods.Common/HitShapes/Polygon.cs
@@ -99,25 +99,22 @@ namespace OpenRA.Mods.Common.HitShapes
 			return new WDist(Exts.ISqrt(min2 + z * z));
 		}
 
-		public WDist DistanceFromEdge(WPos pos, Actor actor)
+		public WDist DistanceFromEdge(WPos pos, WPos origin, WRot orientation)
 		{
-			var actorPos = actor.CenterPosition;
-			var orientation = actor.Orientation + WRot.FromYaw(LocalYaw);
+			orientation += WRot.FromYaw(LocalYaw);
 
-			if (pos.Z > actorPos.Z + VerticalTopOffset)
-				return DistanceFromEdge((pos - (actorPos + new WVec(0, 0, VerticalTopOffset))).Rotate(-orientation));
+			if (pos.Z > origin.Z + VerticalTopOffset)
+				return DistanceFromEdge((pos - (origin + new WVec(0, 0, VerticalTopOffset))).Rotate(-orientation));
 
-			if (pos.Z < actorPos.Z + VerticalBottomOffset)
-				return DistanceFromEdge((pos - (actorPos + new WVec(0, 0, VerticalBottomOffset))).Rotate(-orientation));
+			if (pos.Z < origin.Z + VerticalBottomOffset)
+				return DistanceFromEdge((pos - (origin + new WVec(0, 0, VerticalBottomOffset))).Rotate(-orientation));
 
-			return DistanceFromEdge((pos - new WPos(actorPos.X, actorPos.Y, pos.Z)).Rotate(-orientation));
+			return DistanceFromEdge((pos - new WPos(origin.X, origin.Y, pos.Z)).Rotate(-orientation));
 		}
 
-		IEnumerable<IRenderable> IHitShape.RenderDebugOverlay(WorldRenderer wr, Actor actor)
+		IEnumerable<IRenderable> IHitShape.RenderDebugOverlay(WorldRenderer wr, WPos actorPos, WRot orientation)
 		{
-			var actorPos = actor.CenterPosition;
-			var orientation = actor.Orientation + WRot.FromYaw(LocalYaw);
-
+			orientation += WRot.FromYaw(LocalYaw);
 			var vertsTop = combatOverlayVertsTop.Select(v => actorPos + v.Rotate(orientation)).ToArray();
 			var vertsBottom = combatOverlayVertsBottom.Select(v => actorPos + v.Rotate(orientation)).ToArray();
 

--- a/OpenRA.Mods.Common/HitShapes/Rectangle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Rectangle.cs
@@ -94,31 +94,29 @@ namespace OpenRA.Mods.Common.HitShapes
 			return new WDist(r.HorizontalLength);
 		}
 
-		public WDist DistanceFromEdge(WPos pos, Actor actor)
+		public WDist DistanceFromEdge(WPos pos, WPos origin, WRot orientation)
 		{
-			var actorPos = actor.CenterPosition;
-			var orientation = actor.Orientation + WRot.FromYaw(LocalYaw);
+			orientation += WRot.FromYaw(LocalYaw);
 
-			if (pos.Z > actorPos.Z + VerticalTopOffset)
-				return DistanceFromEdge((pos - (actorPos + new WVec(0, 0, VerticalTopOffset))).Rotate(-orientation));
+			if (pos.Z > origin.Z + VerticalTopOffset)
+				return DistanceFromEdge((pos - (origin + new WVec(0, 0, VerticalTopOffset))).Rotate(-orientation));
 
-			if (pos.Z < actorPos.Z + VerticalBottomOffset)
-				return DistanceFromEdge((pos - (actorPos + new WVec(0, 0, VerticalBottomOffset))).Rotate(-orientation));
+			if (pos.Z < origin.Z + VerticalBottomOffset)
+				return DistanceFromEdge((pos - (origin + new WVec(0, 0, VerticalBottomOffset))).Rotate(-orientation));
 
-			return DistanceFromEdge((pos - new WPos(actorPos.X, actorPos.Y, pos.Z)).Rotate(-orientation));
+			return DistanceFromEdge((pos - new WPos(origin.X, origin.Y, pos.Z)).Rotate(-orientation));
 		}
 
-		IEnumerable<IRenderable> IHitShape.RenderDebugOverlay(WorldRenderer wr, Actor actor)
+		IEnumerable<IRenderable> IHitShape.RenderDebugOverlay(WorldRenderer wr, WPos origin, WRot orientation)
 		{
-			var actorPos = actor.CenterPosition;
-			var orientation = actor.Orientation + WRot.FromYaw(LocalYaw);
+			orientation += WRot.FromYaw(LocalYaw);
 
-			var vertsTop = combatOverlayVertsTop.Select(v => actorPos + v.Rotate(orientation)).ToArray();
-			var vertsBottom = combatOverlayVertsBottom.Select(v => actorPos + v.Rotate(orientation)).ToArray();
+			var vertsTop = combatOverlayVertsTop.Select(v => origin + v.Rotate(orientation)).ToArray();
+			var vertsBottom = combatOverlayVertsBottom.Select(v => origin + v.Rotate(orientation)).ToArray();
 
-			yield return new PolygonAnnotationRenderable(vertsTop, actorPos, 1, Color.Yellow);
-			yield return new PolygonAnnotationRenderable(vertsBottom, actorPos, 1, Color.Yellow);
-			yield return new CircleAnnotationRenderable(actorPos, OuterRadius, 1, Color.LimeGreen);
+			yield return new PolygonAnnotationRenderable(vertsTop, origin, 1, Color.Yellow);
+			yield return new PolygonAnnotationRenderable(vertsBottom, origin, 1, Color.Yellow);
+			yield return new CircleAnnotationRenderable(origin, OuterRadius, 1, Color.LimeGreen);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/HitShapes/Rectangle.cs
+++ b/OpenRA.Mods.Common/HitShapes/Rectangle.cs
@@ -43,6 +43,8 @@ namespace OpenRA.Mods.Common.HitShapes
 
 		WVec[] combatOverlayVertsTop;
 		WVec[] combatOverlayVertsBottom;
+		WVec[] combatOverlayVertsSide1;
+		WVec[] combatOverlayVertsSide2;
 
 		public RectangleShape() { }
 
@@ -73,7 +75,7 @@ namespace OpenRA.Mods.Common.HitShapes
 				new WVec(TopLeft.X, TopLeft.Y, VerticalTopOffset),
 				new WVec(BottomRight.X, TopLeft.Y, VerticalTopOffset),
 				new WVec(BottomRight.X, BottomRight.Y, VerticalTopOffset),
-				new WVec(TopLeft.X, BottomRight.Y, VerticalTopOffset)
+				new WVec(TopLeft.X, BottomRight.Y, VerticalTopOffset),
 			};
 
 			combatOverlayVertsBottom = new WVec[]
@@ -81,7 +83,23 @@ namespace OpenRA.Mods.Common.HitShapes
 				new WVec(TopLeft.X, TopLeft.Y, VerticalBottomOffset),
 				new WVec(BottomRight.X, TopLeft.Y, VerticalBottomOffset),
 				new WVec(BottomRight.X, BottomRight.Y, VerticalBottomOffset),
-				new WVec(TopLeft.X, BottomRight.Y, VerticalBottomOffset)
+				new WVec(TopLeft.X, BottomRight.Y, VerticalBottomOffset),
+			};
+
+			combatOverlayVertsSide1 = new WVec[]
+			{
+				new WVec(TopLeft.X, TopLeft.Y, VerticalBottomOffset),
+				new WVec(TopLeft.X, TopLeft.Y, VerticalTopOffset),
+				new WVec(TopLeft.X, BottomRight.Y, VerticalTopOffset),
+				new WVec(TopLeft.X, BottomRight.Y, VerticalBottomOffset),
+			};
+
+			combatOverlayVertsSide2 = new WVec[]
+			{
+				new WVec(BottomRight.X, TopLeft.Y, VerticalBottomOffset),
+				new WVec(BottomRight.X, TopLeft.Y, VerticalTopOffset),
+				new WVec(BottomRight.X, BottomRight.Y, VerticalTopOffset),
+				new WVec(BottomRight.X, BottomRight.Y, VerticalBottomOffset),
 			};
 		}
 
@@ -113,9 +131,13 @@ namespace OpenRA.Mods.Common.HitShapes
 
 			var vertsTop = combatOverlayVertsTop.Select(v => origin + v.Rotate(orientation)).ToArray();
 			var vertsBottom = combatOverlayVertsBottom.Select(v => origin + v.Rotate(orientation)).ToArray();
+			var side1 = combatOverlayVertsSide1.Select(v => origin + v.Rotate(orientation)).ToArray();
+			var side2 = combatOverlayVertsSide2.Select(v => origin + v.Rotate(orientation)).ToArray();
 
 			yield return new PolygonAnnotationRenderable(vertsTop, origin, 1, Color.Yellow);
 			yield return new PolygonAnnotationRenderable(vertsBottom, origin, 1, Color.Yellow);
+			yield return new PolygonAnnotationRenderable(side1, origin, 1, Color.Yellow);
+			yield return new PolygonAnnotationRenderable(side2, origin, 1, Color.Yellow);
 			yield return new CircleAnnotationRenderable(origin, OuterRadius, 1, Color.LimeGreen);
 		}
 	}

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -295,7 +295,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 				// If the impact position is within any actor's HitShape, we have a direct hit
 				var activeShapes = victim.TraitsImplementing<HitShape>().Where(Exts.IsTraitEnabled);
-				if (activeShapes.Any(i => i.Info.Type.DistanceFromEdge(pos, victim).Length <= 0))
+				if (activeShapes.Any(i => i.DistanceFromEdge(victim, pos).Length <= 0))
 					return true;
 			}
 

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var activeShapes = shapes.Where(Exts.IsTraitEnabled);
 			foreach (var s in activeShapes)
-				foreach (var r in s.Info.Type.RenderDebugOverlay(wr, self))
+				foreach (var r in s.RenderDebugOverlay(self, wr))
 					yield return r;
 
 			var positions = Target.FromActor(self).Positions;

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Warheads
 
 				// If the impact position is within any HitShape, we have a direct hit
 				var activeShapes = victim.TraitsImplementing<HitShape>().Where(Exts.IsTraitEnabled);
-				var directHit = activeShapes.Any(i => i.Info.Type.DistanceFromEdge(pos, victim).Length <= 0);
+				var directHit = activeShapes.Any(i => i.DistanceFromEdge(victim, pos).Length <= 0);
 
 				// If the warhead landed outside the actor's hit-shape(s), we need to skip the rest so it won't be considered an invalidHit
 				if (!directHit)

--- a/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Warheads
 					return;
 
 				var closestActiveShape = victim.TraitsImplementing<HitShape>().Where(Exts.IsTraitEnabled)
-					.MinByOrDefault(t => t.Info.Type.DistanceFromEdge(victim.CenterPosition, victim));
+					.MinByOrDefault(t => t.DistanceFromEdge(victim, victim.CenterPosition));
 
 				// Cannot be damaged without an active HitShape
 				if (closestActiveShape == null)

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Warheads
 
 				var closestActiveShape = victim.TraitsImplementing<HitShape>()
 					.Where(Exts.IsTraitEnabled)
-					.Select(s => Pair.New(s, s.Info.Type.DistanceFromEdge(pos, victim)))
+					.Select(s => Pair.New(s, s.DistanceFromEdge(victim, pos)))
 					.MinByOrDefault(s => s.Second);
 
 				// Cannot be damaged without an active HitShape

--- a/OpenRA.Mods.Common/Warheads/TargetDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/TargetDamageWarhead.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Warheads
 
 				var closestActiveShape = victim.TraitsImplementing<HitShape>()
 					.Where(Exts.IsTraitEnabled)
-					.Select(s => Pair.New(s, s.Info.Type.DistanceFromEdge(pos, victim)))
+					.Select(s => Pair.New(s, s.DistanceFromEdge(victim, pos)))
 					.MinByOrDefault(s => s.Second);
 
 				// Cannot be damaged without an active HitShape or if HitShape is outside Spread


### PR DESCRIPTION
Allows to link a `HitShape` to the position and facing of a turret.

I need this downstream, and I assume some other (next-gen, a.k.a. isometric 2.5D) projects might find this useful as well, especially once directional armor comes into play.