### PR TITLE
Cache IPathFinder in Mobile at creation

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -52,9 +52,10 @@ namespace OpenRA.Mods.Common.Activities
 				using (var search =
 					PathSearch.FromPoint(self.World, mobile.Locomotor, self, mobile.ToCell, destination, check)
 					.WithoutLaneBias())
-					path = self.World.WorldActor.Trait<IPathFinder>().FindPath(search);
+					path = mobile.Pathfinder.FindPath(search);
 				return path;
 			};
+
 			this.destination = destination;
 			this.targetLineColor = targetLineColor;
 			nearEnough = WDist.Zero;
@@ -70,8 +71,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (!this.destination.HasValue)
 					return NoPath;
 
-				return self.World.WorldActor.Trait<IPathFinder>()
-					.FindUnitPath(mobile.ToCell, this.destination.Value, self, ignoreActor, check);
+				return mobile.Pathfinder.FindUnitPath(mobile.ToCell, this.destination.Value, self, ignoreActor, check);
 			};
 
 			// Note: Will be recalculated from OnFirstRun if evaluateNearestMovableCell is true
@@ -87,8 +87,9 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			mobile = self.Trait<Mobile>();
 
-			getPath = check => self.World.WorldActor.Trait<IPathFinder>()
-				.FindUnitPathToRange(mobile.FromCell, subCell, self.World.Map.CenterOfSubCell(destination, subCell), nearEnough, self, check);
+			getPath = check => mobile.Pathfinder.FindUnitPathToRange(
+				mobile.FromCell, subCell, self.World.Map.CenterOfSubCell(destination, subCell), nearEnough, self, check);
+
 			this.destination = destination;
 			this.nearEnough = nearEnough;
 			this.targetLineColor = targetLineColor;
@@ -103,7 +104,7 @@ namespace OpenRA.Mods.Common.Activities
 				if (!target.IsValidFor(self))
 					return NoPath;
 
-				return self.World.WorldActor.Trait<IPathFinder>().FindUnitPathToRange(
+				return mobile.Pathfinder.FindUnitPathToRange(
 					mobile.ToCell, mobile.ToSubCell, target.CenterPosition, range, self, check);
 			};
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -211,6 +211,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public Locomotor Locomotor { get; private set; }
 
+		public IPathFinder Pathfinder { get; private set; }
+
 		#region IOccupySpace
 
 		[Sync]
@@ -269,6 +271,7 @@ namespace OpenRA.Mods.Common.Traits
 			notifyMoving = self.TraitsImplementing<INotifyMoving>().ToArray();
 			notifyFinishedMoving = self.TraitsImplementing<INotifyFinishedMoving>().ToArray();
 			moveWrappers = self.TraitsImplementing<IWrapMove>().ToArray();
+			Pathfinder = self.World.WorldActor.Trait<IPathFinder>();
 			Locomotor = self.World.WorldActor.TraitsImplementing<Locomotor>()
 				.Single(l => l.Info.Name == Info.Locomotor);
 


### PR DESCRIPTION
Avoiding look-ups on every move order, as well as reducing line lengths.

Likely not a measurable win in terms of performance, but if ~200 units are given a move order on the same tick, this is still 200 trait look-ups less on that tick.