### PR TITLE
Created ShakeScreenWarhead

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -33,12 +33,6 @@ namespace OpenRA.Mods.Cnc.Traits
 		[WeaponReference]
 		public readonly string ThumpDamageWeapon = "MADTankThump";
 
-		public readonly int ThumpShakeIntensity = 3;
-
-		public readonly float2 ThumpShakeMultiplier = new float2(1, 0);
-
-		public readonly int ThumpShakeTime = 10;
-
 		[Desc("Measured in ticks.")]
 		public readonly int ChargeDelay = 96;
 
@@ -219,8 +213,6 @@ namespace OpenRA.Mods.Cnc.Traits
 						// Use .FromPos since this weapon needs to affect more than just the MadTank actor
 						mad.info.ThumpDamageWeaponInfo.Impact(Target.FromPos(self.CenterPosition), self);
 					}
-
-					screenShaker.AddEffect(mad.info.ThumpShakeTime, self.CenterPosition, mad.info.ThumpShakeIntensity, mad.info.ThumpShakeMultiplier);
 				}
 
 				if (ticks == mad.info.ChargeDelay)

--- a/OpenRA.Mods.Common/Projectiles/NukeLaunch.cs
+++ b/OpenRA.Mods.Common/Projectiles/NukeLaunch.cs
@@ -151,8 +151,6 @@ namespace OpenRA.Mods.Common.Effects
 
 			weapon.Impact(target, warheadArgs);
 
-			world.WorldActor.Trait<ScreenShaker>().AddEffect(20, pos, 5);
-
 			foreach (var flash in world.WorldActor.TraitsImplementing<FlashPaletteEffect>())
 				if (flash.Info.Type == flashType)
 					flash.Enable(-1);

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20191117/CreateScreenShakeWarhead.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20191117/CreateScreenShakeWarhead.cs
@@ -1,0 +1,74 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class CreateScreenShakeWarhead : UpdateRule
+	{
+		public override string Name { get { return "Create ScreenShakeWarhead to replace hardcoded shaking."; } }
+
+		public override string Description
+		{
+			get
+			{
+				return "The traits MadTank and NukePower (via the NukeLaunch projectile that it uses) no longer have built-in screen shaking.";
+			}
+		}
+
+		readonly List<Tuple<string, string, string>> weaponsToUpdate = new List<Tuple<string, string, string>>();
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var madTankTraits = actorNode.ChildrenMatching("MadTank");
+			var nukePowerTraits = actorNode.ChildrenMatching("NukePower");
+
+			foreach (var madTankTrait in madTankTraits)
+			{
+				var traitName = madTankTrait.Key;
+				var weaponNode = madTankTrait.ChildrenMatching("MADTankThump").FirstOrDefault();
+				var weaponName = weaponNode != null ? weaponNode.Value.Value : "MADTankThump";
+
+				weaponsToUpdate.Add(new Tuple<string, string, string>(weaponName, traitName, "{0} ({1})".F(actorNode.Key, actorNode.Location.Filename)));
+
+				madTankTrait.RemoveNodes("ThumpShakeTime");
+				madTankTrait.RemoveNodes("ThumpShakeIntensity");
+				madTankTrait.RemoveNodes("ThumpShakeMultiplier");
+			}
+
+			foreach (var nukePowerTrait in nukePowerTraits)
+			{
+				var traitName = nukePowerTrait.Key;
+				var weaponNode = nukePowerTrait.ChildrenMatching("MissileWeapon").FirstOrDefault();
+				if (weaponNode == null)
+					continue;
+
+				var weaponName = weaponNode.Value.Value;
+
+				weaponsToUpdate.Add(new Tuple<string, string, string>(weaponName, traitName, "{0} ({1})".F(actorNode.Key, actorNode.Location.Filename)));
+			}
+
+			yield break;
+		}
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (weaponsToUpdate.Any())
+				yield return "Add a ScreenShakeWarhead to the following weapons:\n" +
+					UpdateUtils.FormatMessageList(weaponsToUpdate.Select(x => "Weapon `{0}`, used by trait `{1}` on actor {2}".F(x.Item1, x.Item2, x.Item3)));
+
+			weaponsToUpdate.Clear();
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -146,6 +146,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RenameProneTime(),
 				new ReplaceAttackTypeStrafe(),
 				new RemoveWithPermanentInjury(),
+				new CreateScreenShakeWarhead(),
 			})
 		};
 

--- a/OpenRA.Mods.Common/Warheads/ShakeScreenWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/ShakeScreenWarhead.cs
@@ -1,0 +1,34 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.GameRules;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Warheads
+{
+	[Desc("Makes the screen shake.")]
+	public class ShakeScreenWarhead : Warhead
+	{
+		[Desc("Duration of the shaking.")]
+		public readonly int Duration = 0;
+
+		[Desc("Shake intensity.")]
+		public readonly int Intensity = 0;
+
+		[Desc("Shake multipliers by the X and Y axis, comma-separated.")]
+		public readonly float2 Multiplier = new float2(0, 0);
+
+		public override void DoImpact(Target target, WarheadArgs args)
+		{
+			args.SourceActor.World.WorldActor.Trait<ScreenShaker>().AddEffect(Duration, target.CenterPosition, Intensity, Multiplier);
+		}
+	}
+}

--- a/mods/cnc/weapons/superweapons.yaml
+++ b/mods/cnc/weapons/superweapons.yaml
@@ -84,6 +84,10 @@ Atomic:
 		InvalidTargets: Vehicle, Structure, Wall
 		Size: 5
 		Delay: 9
+	Warhead@13Shake: ShakeScreen
+		Duration: 20
+		Intensity: 5
+		Multiplier: 1,1
 
 IonCannon:
 	ValidTargets: Ground, Air, Trees

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -116,6 +116,10 @@ DeathHand:
 		Explosions: nuke
 		ImpactSounds: EXPLLG2.WAV
 		ImpactActors: false
+	Warhead@Shake: ShakeScreen
+		Duration: 20
+		Intensity: 5
+		Multiplier: 1,1
 
 DeathHandCluster:
 	Inherits: Debris2

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -221,6 +221,10 @@ MADTankThump:
 		Spread: 7c0
 		Damage: 1
 		InvalidTargets: MADTank, Infantry
+	Warhead@Shake: ShakeScreen
+		Duration: 10
+		Intensity: 3
+		Multiplier: 1,0
 
 MADTankDetonate:
 	InvalidTargets: MADTank, Infantry

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -147,3 +147,7 @@ Atomic:
 		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees
 		Size: 5
 		Delay: 20
+	Warhead@21Shake: ShakeScreen
+		Duration: 20
+		Intensity: 5
+		Multiplier: 1,1

--- a/mods/ts/weapons/superweapons.yaml
+++ b/mods/ts/weapons/superweapons.yaml
@@ -53,6 +53,10 @@ ClusterMissile:
 		RandomClusterCount: 10
 		Dimensions: 7,7
 		Footprint: __xxx__ _xxxxx_ xxxxxxx xxxxxxx xxxxxxx _xxxxx_ __xxx__
+	Warhead@Shake: ShakeScreen
+		Duration: 20
+		Intensity: 5
+		Multiplier: 1,1
 
 SuicideBomb:
 	Range: 0c512


### PR DESCRIPTION
This is a small refactoring that decouples the `MadTank` trait and the `NukePower` trait (via its `NukeLaunch` projectile) from the `ScreenShaker` trait and allows for configurable screen shaking and screen shaking reusability.

Of the 3 references to `ScreenShaker` this addresses the two more specific ones. The third is the `ShakeOnDeath` trait, which this probably makes redundant but is a matter of taste as that doesn't require a weapon.