### PR TITLE
Created FlashPaletteEffectWarhead

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/NukeLaunch.cs
+++ b/OpenRA.Mods.Common/Projectiles/NukeLaunch.cs
@@ -27,7 +27,6 @@ namespace OpenRA.Mods.Common.Effects
 		readonly string weaponPalette;
 		readonly string upSequence;
 		readonly string downSequence;
-		readonly string flashType;
 
 		readonly WPos ascendSource;
 		readonly WPos ascendTarget;
@@ -51,7 +50,7 @@ namespace OpenRA.Mods.Common.Effects
 
 		public NukeLaunch(Player firedBy, string name, WeaponInfo weapon, string weaponPalette, string upSequence, string downSequence,
 			WPos launchPos, WPos targetPos, WDist detonationAltitude, bool removeOnDetonation, WDist velocity, int launchDelay, int impactDelay,
-			bool skipAscent, string flashType,
+			bool skipAscent,
 			string trailImage, string[] trailSequences, string trailPalette, bool trailUsePlayerPalette, int trailDelay, int trailInterval)
 		{
 			this.firedBy = firedBy;
@@ -62,7 +61,6 @@ namespace OpenRA.Mods.Common.Effects
 			this.launchDelay = launchDelay;
 			this.impactDelay = impactDelay;
 			turn = skipAscent ? 0 : impactDelay / 2;
-			this.flashType = flashType;
 			this.trailImage = trailImage;
 			this.trailSequences = trailSequences;
 			this.trailPalette = trailPalette;
@@ -150,10 +148,6 @@ namespace OpenRA.Mods.Common.Effects
 			};
 
 			weapon.Impact(target, warheadArgs);
-
-			foreach (var flash in world.WorldActor.TraitsImplementing<FlashPaletteEffect>())
-				if (flash.Info.Type == flashType)
-					flash.Enable(-1);
 
 			detonated = true;
 		}

--- a/OpenRA.Mods.Common/Projectiles/NukeLaunch.cs
+++ b/OpenRA.Mods.Common/Projectiles/NukeLaunch.cs
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Effects
 			this.trailSequences = trailSequences;
 			this.trailPalette = trailPalette;
 			if (trailUsePlayerPalette)
-				trailPalette += firedBy.InternalName;
+				this.trailPalette += firedBy.InternalName;
 
 			this.trailInterval = trailInterval;
 			this.trailDelay = trailDelay;

--- a/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/NukePower.cs
@@ -99,9 +99,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Amount of time after detonation to remove the camera.")]
 		public readonly int CameraRemoveDelay = 25;
 
-		[Desc("Corresponds to `Type` from `FlashPaletteEffect` on the world actor.")]
-		public readonly string FlashType = null;
-
 		public WeaponInfo WeaponInfo { get; private set; }
 
 		public override object Create(ActorInitializer init) { return new NukePower(init.Self, this); }
@@ -156,7 +153,6 @@ namespace OpenRA.Mods.Common.Traits
 				launchPos,
 				targetPosition, info.DetonationAltitude, info.RemoveMissileOnDetonation,
 				info.FlightVelocity, info.MissileDelay, info.FlightDelay, skipAscent,
-				info.FlashType,
 				info.TrailImage, info.TrailSequences, info.TrailPalette, info.TrailUsePlayerPalette, info.TrailDelay, info.TrailInterval);
 
 			self.World.AddFrameEndTask(w => w.Add(missile));

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200202/RenameSpins.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200202/RenameSpins.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200503/CreateFlashPaletteEffectWarhead.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200503/CreateFlashPaletteEffectWarhead.cs
@@ -1,0 +1,61 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class CreateFlashPaletteEffectWarhead : UpdateRule
+	{
+		public override string Name { get { return "Create FlashPaletteEffectWarhead to replace hardcoded nuke flashing."; } }
+
+		public override string Description
+		{
+			get
+			{
+				return "The trait NukePower (via the NukeLaunch projectile that it uses) no longer has built-in palette flashing.";
+			}
+		}
+
+		readonly List<Tuple<string, string, string>> weaponsToUpdate = new List<Tuple<string, string, string>>();
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var nukePowerTraits = actorNode.ChildrenMatching("NukePower");
+			foreach (var nukePowerTrait in nukePowerTraits)
+			{
+				var traitName = nukePowerTrait.Key;
+				var weaponNode = nukePowerTrait.ChildrenMatching("MissileWeapon").FirstOrDefault();
+				if (weaponNode == null)
+					continue;
+
+				var weaponName = weaponNode.Value.Value;
+
+				weaponsToUpdate.Add(new Tuple<string, string, string>(weaponName, traitName, "{0} ({1})".F(actorNode.Key, actorNode.Location.Filename)));
+
+				nukePowerTrait.RemoveNodes("FlashType");
+			}
+
+			yield break;
+		}
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			if (weaponsToUpdate.Any())
+				yield return "Add a FlashPaletteEffectWarhead to the following weapons:\n" +
+					UpdateUtils.FormatMessageList(weaponsToUpdate.Select(x => "Weapon `{0}`, used by trait `{1}` on actor {2}".F(x.Item1, x.Item2, x.Item3)));
+
+			weaponsToUpdate.Clear();
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -67,6 +67,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new ConvertSupportPowerRangesToFootprint(),
 				new UpdateTilesetColors(),
 				new UpdateMapInits(),
+				new CreateFlashPaletteEffectWarhead(),
 			})
 		};
 

--- a/OpenRA.Mods.Common/Warheads/FlashPaletteEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/FlashPaletteEffectWarhead.cs
@@ -1,0 +1,35 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.GameRules;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Warheads
+{
+	[Desc("Used to trigger a FlashPaletteEffect trait on the world actor.")]
+	public class FlashPaletteEffectWarhead : Warhead
+	{
+		[Desc("Corresponds to `Type` from `FlashPaletteEffect` on the world actor.")]
+		public readonly string FlashType = null;
+
+		[FieldLoader.Require]
+		[Desc("Duration of the flashing, measured in ticks. Set to -1 to default to the `Length` of the `FlashPaletteEffect`.")]
+		public readonly int Duration = 0;
+
+		public override void DoImpact(Target target, WarheadArgs args)
+		{
+			foreach (var flash in args.SourceActor.World.WorldActor.TraitsImplementing<FlashPaletteEffect>())
+				if (flash.Info.Type == FlashType)
+					flash.Enable(Duration);
+		}
+	}
+}

--- a/mods/cnc/weapons/superweapons.yaml
+++ b/mods/cnc/weapons/superweapons.yaml
@@ -88,6 +88,8 @@ Atomic:
 		Duration: 20
 		Intensity: 5
 		Multiplier: 1,1
+	Warhead@14FlashEffect: FlashPaletteEffect
+		Duration: 20
 
 IonCannon:
 	ValidTargets: Ground, Water, Air, Trees

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -123,6 +123,8 @@ DeathHand:
 		Duration: 20
 		Intensity: 5
 		Multiplier: 1,1
+	Warhead@FlashEffect: FlashPaletteEffect
+		Duration: 20
 
 DeathHandCluster:
 	Inherits: Debris2

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -123,8 +123,6 @@ DeathHand:
 		Duration: 20
 		Intensity: 5
 		Multiplier: 1,1
-	Warhead@FlashEffect: FlashPaletteEffect
-		Duration: 20
 
 DeathHandCluster:
 	Inherits: Debris2

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -51,7 +51,6 @@ MSLO:
 		DisplayBeacon: True
 		DisplayRadarPing: True
 		BeaconPoster: atomicon
-		FlashType: Nuke
 		CameraRange: 10c0
 		ArrowSequence: arrow
 		ClockSequence: clock

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -250,6 +250,9 @@ CrateNuke:
 		ValidTargets: Ground, Infantry
 		Size: 4
 		Delay: 5
+	Warhead@7FlashEffect: FlashPaletteEffect
+		Duration: 20
+		FlashType: Nuke
 
 MiniNuke:
 	ValidTargets: Ground, GroundActor, Trees, Water, WaterActor, Underwater, Air, AirborneActor
@@ -321,3 +324,6 @@ MiniNuke:
 		ValidTargets: Ground, Infantry
 		Size: 4
 		Delay: 15
+	Warhead@14FlashEffect: FlashPaletteEffect
+		Duration: 20
+		FlashType: Nuke

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -134,3 +134,6 @@ Atomic:
 		Duration: 20
 		Intensity: 5
 		Multiplier: 1,1
+	Warhead@22FlashEffect: FlashPaletteEffect
+		Duration: 20
+		FlashType: Nuke


### PR DESCRIPTION
This is a small refactoring that decouples the `NukePower` trait (via its `NukeLaunch` projectile) from the `FlashPaletteEffect` trait and allows for better reusability.

This somewhat makes `FlashPaletteEffectInfo.Length` redundant, as well as the -1 tick special case tied to it.

Depends on #17283.