### PR TITLE
Fix OccupiedCells for units sharing cells

### DIFF
--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -229,6 +229,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (FromCell == ToCell)
 				return new[] { Pair.New(FromCell, FromSubCell) };
 
+			// HACK: Should be fixed properly, see https://github.com/OpenRA/OpenRA/pull/17292 for an explanation
+			if (Info.LocomotorInfo.SharesCell)
+				return new[] { Pair.New(ToCell, ToSubCell) };
+
 			return new[] { Pair.New(FromCell, FromSubCell), Pair.New(ToCell, ToSubCell) };
 		}
 		#endregion


### PR DESCRIPTION
Fixes #17290

Disclaimer: The OccuipedCells and crushing logic is wonky as a donkey in the previous release. 
I did some testing with adding the Crushable trait to a unit that does not share cells  and setting WarnProbability to 100. I observed that the unit had nearly zero chance to dodge a crush successful. 

If you log the OccuipedCells during a move you can observe why this is the case (hint: look for when the unit exist in the `FromCell`)
```
...
FromCell
FromCell
FromCell
ToCell
FromCell-ToCell
FromCell-ToCell
FromCell-ToCell
FromCell-ToCell
FromCell-ToCell
FromCell-ToCell
FromCell-ToCell
FromCell-ToCell
FromCell-ToCell
FromCell-ToCell
FromCell
FromCell
FromCell
...
```


Unit thats share cells have this pattern when moving to a new cell with at least 2 empty subcells
```
...
FromCell
FromCell
ToCell
ToCell
ToCell
ToCell
ToCell
ToCell
ToCell
ToCell
ToCell
ToCell
ToCell
ToCell
FromCell
FromCell
...
```
Compare to when there is only 1 free subcell.
```
...
FromCell
FromCell
FromCell
ToCell
FromCell-ToCell
FromCell-ToCell
FromCell-ToCell
FromCell-ToCell
FromCell-ToCell
FromCell-ToCell
FromCell-ToCell
FromCell-ToCell
FromCell-ToCell
FromCell-ToCell
FromCell
FromCell
FromCell
...
```

Its probably ok to draw the conclusion that subcell units that trying to dodge a crush by moving to a cell with only 1 free sub cell will fail more often.

Also if the unit need to turn before the move it will fail (depending on how long the turn takes.)

This fix here will hopefully be good enough for fixing the dodging for Infantry.  