### PR TITLE
Render world via an intermediate FrameBuffer

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -458,6 +458,7 @@ namespace OpenRA
 
 			PerfHistory.Items["render"].HasNormalTick = false;
 			PerfHistory.Items["batches"].HasNormalTick = false;
+			PerfHistory.Items["render_world"].HasNormalTick = false;
 			PerfHistory.Items["render_widgets"].HasNormalTick = false;
 			PerfHistory.Items["render_flip"].HasNormalTick = false;
 
@@ -685,7 +686,8 @@ namespace OpenRA
 				{
 					Renderer.BeginWorld(worldRenderer.Viewport.Rectangle);
 					Sound.SetListenerPosition(worldRenderer.Viewport.CenterPosition);
-					worldRenderer.Draw();
+					using (new PerfSample("render_world"))
+						worldRenderer.Draw();
 				}
 
 				using (new PerfSample("render_widgets"))
@@ -721,6 +723,7 @@ namespace OpenRA
 
 			PerfHistory.Items["render"].Tick();
 			PerfHistory.Items["batches"].Tick();
+			PerfHistory.Items["render_world"].Tick();
 			PerfHistory.Items["render_widgets"].Tick();
 			PerfHistory.Items["render_flip"].Tick();
 		}

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -679,21 +679,18 @@ namespace OpenRA
 				}
 
 				// worldRenderer is null during the initial install/download screen
-				if (worldRenderer != null)
+				// World rendering is disabled while the loading screen is displayed
+				// Use worldRenderer.World instead of OrderManager.World to avoid a rendering mismatch while processing orders
+				if (worldRenderer != null && !worldRenderer.World.IsLoadingGameSave)
 				{
-					Renderer.BeginFrame(worldRenderer.Viewport.TopLeft, worldRenderer.Viewport.Zoom);
+					Renderer.BeginWorld(worldRenderer.Viewport.TopLeft, worldRenderer.Viewport.Zoom);
 					Sound.SetListenerPosition(worldRenderer.Viewport.CenterPosition);
-
-					// World rendering is disabled while the loading screen is displayed
-					// Use worldRenderer.World instead of OrderManager.World to avoid a rendering mismatch while processing orders
-					if (!worldRenderer.World.IsLoadingGameSave)
-						worldRenderer.Draw();
+					worldRenderer.Draw();
 				}
-				else
-					Renderer.BeginFrame(int2.Zero, 1f);
 
 				using (new PerfSample("render_widgets"))
 				{
+					Renderer.BeginUI();
 					Ui.Draw();
 
 					if (ModData != null && ModData.CursorProvider != null)

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -683,7 +683,7 @@ namespace OpenRA
 				// Use worldRenderer.World instead of OrderManager.World to avoid a rendering mismatch while processing orders
 				if (worldRenderer != null && !worldRenderer.World.IsLoadingGameSave)
 				{
-					Renderer.BeginWorld(worldRenderer.Viewport.TopLeft, worldRenderer.Viewport.Zoom);
+					Renderer.BeginWorld(worldRenderer.Viewport.Rectangle);
 					Sound.SetListenerPosition(worldRenderer.Viewport.CenterPosition);
 					worldRenderer.Draw();
 				}
@@ -691,6 +691,10 @@ namespace OpenRA
 				using (new PerfSample("render_widgets"))
 				{
 					Renderer.BeginUI();
+
+					if (worldRenderer != null && !worldRenderer.World.IsLoadingGameSave)
+						worldRenderer.DrawAnnotations();
+
 					Ui.Draw();
 
 					if (ModData != null && ModData.CursorProvider != null)

--- a/OpenRA.Game/Graphics/ModelRenderer.cs
+++ b/OpenRA.Game/Graphics/ModelRenderer.cs
@@ -64,10 +64,10 @@ namespace OpenRA.Graphics
 			shader.SetTexture("Palette", palette);
 		}
 
-		public void SetViewportParams(Size screen, float zoom, int2 scroll)
+		public void SetViewportParams(Size screen, int2 scroll)
 		{
 			var a = 2f / renderer.SheetSize;
-			var view = new float[]
+			var view = new[]
 			{
 				a, 0, 0, 0,
 				0, -a, 0, 0,

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -111,6 +111,8 @@ namespace OpenRA
 	{
 		void Bind();
 		void Unbind();
+		void EnableScissor(Rectangle rect);
+		void DisableScissor();
 		ITexture Texture { get; }
 	}
 

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -155,17 +155,17 @@ namespace OpenRA.Graphics
 			shader.SetTexture("Palette", palette);
 		}
 
-		public void SetViewportParams(Size screen, float depthScale, float depthOffset, float zoom, int2 scroll)
+		public void SetViewportParams(Size screen, float depthScale, float depthOffset, int2 scroll)
 		{
 			shader.SetVec("Scroll", scroll.X, scroll.Y, scroll.Y);
 			shader.SetVec("r1",
-				zoom * 2f / screen.Width,
-				zoom * 2f / screen.Height,
-				-depthScale * zoom / screen.Height);
+				2f / screen.Width,
+				2f / screen.Height,
+				-depthScale / screen.Height);
 			shader.SetVec("r2", -1, -1, 1 - depthOffset);
 
 			// Texture index is sampled as a float, so convert to pixels then scale
-			shader.SetVec("DepthTextureScale", 128 * depthScale * zoom / screen.Height);
+			shader.SetVec("DepthTextureScale", 128 * depthScale / screen.Height);
 		}
 
 		public void SetDepthPreviewEnabled(bool enabled)

--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -46,6 +46,7 @@ namespace OpenRA.Graphics
 
 		public WPos CenterPosition { get { return worldRenderer.ProjectedPosition(CenterLocation); } }
 
+		public Rectangle Rectangle { get { return new Rectangle(TopLeft, new Size(viewportSize.X, viewportSize.Y)); } }
 		public int2 TopLeft { get { return CenterLocation - viewportSize / 2; } }
 		public int2 BottomRight { get { return CenterLocation + viewportSize / 2; } }
 		int2 viewportSize;
@@ -240,7 +241,6 @@ namespace OpenRA.Graphics
 		}
 
 		// Rectangle (in viewport coords) that contains things to be drawn
-		static readonly Rectangle ScreenClip = Rectangle.FromLTRB(0, 0, Game.Renderer.Resolution.Width, Game.Renderer.Resolution.Height);
 		public Rectangle GetScissorBounds(bool insideBounds)
 		{
 			// Visible rectangle in world coordinates (expanded to the corners of the cells)
@@ -250,12 +250,12 @@ namespace OpenRA.Graphics
 			var cbr = map.CenterOfCell(((MPos)bounds.BottomRight).ToCPos(map)) + new WVec(512, 512, 0);
 
 			// Convert to screen coordinates
-			var tl = WorldToViewPx(worldRenderer.ScreenPxPosition(ctl - new WVec(0, 0, ctl.Z))).Clamp(ScreenClip);
-			var br = WorldToViewPx(worldRenderer.ScreenPxPosition(cbr - new WVec(0, 0, cbr.Z))).Clamp(ScreenClip);
+			var tl = worldRenderer.ScreenPxPosition(ctl - new WVec(0, 0, ctl.Z)) - TopLeft;
+			var br = worldRenderer.ScreenPxPosition(cbr - new WVec(0, 0, cbr.Z)) - TopLeft;
 
-			// Add an extra one cell fudge in each direction for safety
-			return Rectangle.FromLTRB(tl.X - tileSize.Width, tl.Y - tileSize.Height,
-				br.X + tileSize.Width, br.Y + tileSize.Height);
+			// Add an extra half-cell fudge to avoid clipping isometric tiles
+			return Rectangle.FromLTRB(tl.X - tileSize.Width / 2, tl.Y - tileSize.Height / 2,
+				br.X + tileSize.Width / 2, br.Y + tileSize.Height / 2);
 		}
 
 		ProjectedCellRegion CalculateVisibleCells(bool insideBounds)

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -248,10 +248,14 @@ namespace OpenRA.Graphics
 					r.Render(this);
 
 			Game.Renderer.Flush();
+		}
 
+		public void DrawAnnotations()
+		{
 			for (var i = 0; i < preparedAnnotationRenderables.Count; i++)
 				preparedAnnotationRenderables[i].Render(this);
 
+			// Engine debugging overlays
 			if (debugVis.Value != null && debugVis.Value.RenderGeometry)
 			{
 				for (var i = 0; i < preparedRenderables.Count; i++)
@@ -282,6 +286,7 @@ namespace OpenRA.Graphics
 			}
 
 			Game.Renderer.Flush();
+
 			preparedRenderables.Clear();
 			preparedOverlayRenderables.Clear();
 			preparedAnnotationRenderables.Clear();

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -45,15 +45,18 @@ namespace OpenRA
 		IFrameBuffer screenBuffer;
 		Sprite screenSprite;
 
+		IFrameBuffer worldBuffer;
+		Sprite worldSprite;
+
 		SheetBuilder fontSheetBuilder;
 		readonly IPlatform platform;
 
-		float depthScale;
-		float depthOffset;
+		float depthMargin;
 
 		Size lastBufferSize = new Size(-1, -1);
-		int2 lastScroll = new int2(-1, -1);
-		float lastZoom = -1f;
+
+		Size lastWorldBufferSize = new Size(-1, -1);
+		Rectangle lastWorldViewport = Rectangle.Empty;
 		ITexture currentPaletteTexture;
 		IBatchRenderer currentBatchRenderer;
 		RenderType renderType = RenderType.None;
@@ -122,10 +125,7 @@ namespace OpenRA
 			//  - a small margin so that tiles rendered partially above the top edge of the screen aren't pushed behind the clip plane
 			// We need an offset of mapGrid.MaximumTerrainHeight * mapGrid.TileSize.Height / 2 to cover the terrain height
 			// and choose to use mapGrid.MaximumTerrainHeight * mapGrid.TileSize.Height / 4 for each of the actor and top-edge cases
-			depthScale = mapGrid == null || !mapGrid.EnableDepthBuffer ? 0 :
-				(float)Resolution.Height / (Resolution.Height + mapGrid.TileSize.Height * mapGrid.MaximumTerrainHeight);
-
-			depthOffset = depthScale / 2;
+			depthMargin = mapGrid == null || !mapGrid.EnableDepthBuffer ? 0 : mapGrid.TileSize.Height * mapGrid.MaximumTerrainHeight;
 		}
 
 		void BeginFrame()
@@ -153,8 +153,6 @@ namespace OpenRA
 				screenSprite = new Sprite(screenSheet, screenBounds, TextureChannel.RGBA);
 			}
 
-			screenBuffer.Bind();
-
 			// In HiDPI windows we follow Apple's convention of defining window coordinates as for standard resolution windows
 			// but to have a higher resolution backing surface with more than 1 texture pixel per viewport pixel.
 			// We must convert the surface buffer size to a viewport size - in general this is NOT just the window size
@@ -168,25 +166,39 @@ namespace OpenRA
 			}
 		}
 
-		public void BeginWorld(int2 scroll, float zoom)
+		public void BeginWorld(Rectangle worldViewport)
 		{
 			if (renderType != RenderType.None)
 				throw new InvalidOperationException("BeginWorld called with renderType = {0}, expected RenderType.None.".F(renderType));
 
-			var oldLastBufferSize = lastBufferSize;
 			BeginFrame();
 
-			var scale = Window.WindowScale;
-			var surfaceSize = Window.SurfaceSize;
-			var surfaceBufferSize = surfaceSize.NextPowerOf2();
-			var bufferSize = new Size((int)(surfaceBufferSize.Width / scale), (int)(surfaceBufferSize.Height / scale));
-			if (oldLastBufferSize != bufferSize || lastScroll != scroll || lastZoom != zoom)
+			var worldBufferSize = worldViewport.Size.NextPowerOf2();
+			if (worldSprite == null || worldSprite.Sheet.Size != worldBufferSize)
 			{
-				WorldSpriteRenderer.SetViewportParams(bufferSize, depthScale, depthOffset, zoom, scroll);
-				WorldModelRenderer.SetViewportParams(bufferSize, zoom, scroll);
+				if (worldBuffer != null)
+					worldBuffer.Dispose();
 
-				lastScroll = scroll;
-				lastZoom = zoom;
+				// Render the world into a framebuffer at 1:1 scaling to allow the depth buffer to match the artwork at all zoom levels
+				worldBuffer = Context.CreateFrameBuffer(worldBufferSize);
+			}
+
+			if (worldSprite == null || worldViewport.Size != worldSprite.Bounds.Size)
+			{
+				var worldSheet = new Sheet(SheetType.BGRA, worldBuffer.Texture);
+				worldSprite = new Sprite(worldSheet, new Rectangle(int2.Zero, worldViewport.Size), TextureChannel.RGBA);
+			}
+
+			worldBuffer.Bind();
+
+			if (worldBufferSize != lastWorldBufferSize || lastWorldViewport != worldViewport)
+			{
+				var depthScale = worldBufferSize.Height / (worldBufferSize.Height + depthMargin);
+				WorldSpriteRenderer.SetViewportParams(worldBufferSize, depthScale, depthScale / 2, 1f, worldViewport.Location);
+				WorldModelRenderer.SetViewportParams(worldBufferSize, 1f, worldViewport.Location);
+
+				lastWorldViewport = worldViewport;
+				lastWorldBufferSize = worldBufferSize;
 			}
 
 			renderType = RenderType.World;
@@ -194,8 +206,26 @@ namespace OpenRA
 
 		public void BeginUI()
 		{
-			if (renderType == RenderType.None)
+			if (renderType == RenderType.World)
+			{
+				// Complete world rendering
+				Flush();
+				worldBuffer.Unbind();
+
+				// Render the world buffer into the UI buffer
+				screenBuffer.Bind();
+
+				var scale = Window.WindowScale;
+				var bufferSize = new Size((int)(screenSprite.Bounds.Width / scale), (int)(-screenSprite.Bounds.Height / scale));
+				RgbaSpriteRenderer.DrawSprite(worldSprite, float3.Zero, new float2(bufferSize));
+				Flush();
+			}
+			else
+			{
+				// World rendering was skipped
 				BeginFrame();
+				screenBuffer.Bind();
+			}
 
 			renderType = RenderType.UI;
 		}
@@ -222,7 +252,7 @@ namespace OpenRA
 
 			screenBuffer.Unbind();
 
-			// Render the compositor buffer to the screen
+			// Render the compositor buffers to the screen
 			// HACK / PERF: Fudge the coordinates to cover the actual window while keeping the buffer viewport parameters
 			// This saves us two redundant (and expensive) SetViewportParams each frame
 			RgbaSpriteRenderer.DrawSprite(screenSprite, new float3(0, lastBufferSize.Height, 0), new float3(lastBufferSize.Width, -lastBufferSize.Height, 0));
@@ -288,7 +318,12 @@ namespace OpenRA
 				rect = Rectangle.Intersect(rect, scissorState.Peek());
 
 			Flush();
-			Context.EnableScissor(rect.Left, rect.Top, rect.Width, rect.Height);
+
+			if (renderType == RenderType.World)
+				worldBuffer.EnableScissor(rect);
+			else
+				Context.EnableScissor(rect.X, rect.Y, rect.Width, rect.Height);
+
 			scissorState.Push(rect);
 		}
 
@@ -297,14 +332,25 @@ namespace OpenRA
 			scissorState.Pop();
 			Flush();
 
-			// Restore previous scissor rect
-			if (scissorState.Any())
+			if (renderType == RenderType.World)
 			{
-				var rect = scissorState.Peek();
-				Context.EnableScissor(rect.Left, rect.Top, rect.Width, rect.Height);
+				// Restore previous scissor rect
+				if (scissorState.Any())
+					worldBuffer.EnableScissor(scissorState.Peek());
+				else
+					worldBuffer.DisableScissor();
 			}
 			else
-				Context.DisableScissor();
+			{
+				// Restore previous scissor rect
+				if (scissorState.Any())
+				{
+					var rect = scissorState.Peek();
+					Context.EnableScissor(rect.X, rect.Y, rect.Width, rect.Height);
+				}
+				else
+					Context.DisableScissor();
+			}
 		}
 
 		public void EnableDepthBuffer()

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -161,7 +161,7 @@ namespace OpenRA
 			var bufferSize = new Size((int)(surfaceBufferSize.Width / scale), (int)(surfaceBufferSize.Height / scale));
 			if (lastBufferSize != bufferSize)
 			{
-				SpriteRenderer.SetViewportParams(bufferSize, 0f, 0f, 1f, int2.Zero);
+				SpriteRenderer.SetViewportParams(bufferSize, 0f, 0f, int2.Zero);
 				lastBufferSize = bufferSize;
 			}
 		}
@@ -194,8 +194,8 @@ namespace OpenRA
 			if (worldBufferSize != lastWorldBufferSize || lastWorldViewport != worldViewport)
 			{
 				var depthScale = worldBufferSize.Height / (worldBufferSize.Height + depthMargin);
-				WorldSpriteRenderer.SetViewportParams(worldBufferSize, depthScale, depthScale / 2, 1f, worldViewport.Location);
-				WorldModelRenderer.SetViewportParams(worldBufferSize, 1f, worldViewport.Location);
+				WorldSpriteRenderer.SetViewportParams(worldBufferSize, depthScale, depthScale / 2, worldViewport.Location);
+				WorldModelRenderer.SetViewportParams(worldBufferSize, worldViewport.Location);
 
 				lastWorldViewport = worldViewport;
 				lastWorldBufferSize = worldBufferSize;

--- a/OpenRA.Mods.Cnc/CncLoadScreen.cs
+++ b/OpenRA.Mods.Cnc/CncLoadScreen.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Cnc
 			loadTimer.Restart();
 
 			loadTick = ++loadTick % 8;
-			r.BeginFrame(int2.Zero, 1f);
+			r.BeginUI();
 			r.RgbaSpriteRenderer.DrawSprite(gdiLogo, gdiPos);
 			r.RgbaSpriteRenderer.DrawSprite(nodLogo, nodPos);
 			r.RgbaSpriteRenderer.DrawSprite(evaLogo, evaPos);

--- a/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.LoadScreens
 				return;
 
 			// Draw a black screen
-			Game.Renderer.BeginFrame(int2.Zero, 1f);
+			Game.Renderer.BeginUI();
 			Game.Renderer.EndFrame(new NullInputHandler());
 		}
 

--- a/OpenRA.Mods.Common/LoadScreens/LogoStripeLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/LogoStripeLoadScreen.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Common.LoadScreens
 			var text = messages.Random(Game.CosmeticRandom);
 			var textSize = r.Fonts["Bold"].Measure(text);
 
-			r.BeginFrame(int2.Zero, 1f);
+			r.BeginUI();
 
 			if (stripe != null)
 				WidgetUtils.FillRectWithSprite(stripeRect, stripe);

--- a/OpenRA.Mods.Common/LoadScreens/ModContentLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/ModContentLoadScreen.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.LoadScreens
 			if (r == null)
 				return;
 
-			r.BeginFrame(int2.Zero, 1f);
+			r.BeginUI();
 			WidgetUtils.FillRectWithSprite(bounds, sprite);
 			r.EndFrame(new NullInputHandler());
 		}

--- a/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
+++ b/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
@@ -454,6 +454,8 @@ namespace OpenRA.Platforms.Default
 		readonly Action bind;
 		readonly Action unbind;
 		readonly Action dispose;
+		readonly Action<object> enableScissor;
+		readonly Action disableScissor;
 
 		public ThreadedFrameBuffer(ThreadedGraphicsContext device, IFrameBuffer frameBuffer)
 		{
@@ -462,6 +464,9 @@ namespace OpenRA.Platforms.Default
 			bind = frameBuffer.Bind;
 			unbind = frameBuffer.Unbind;
 			dispose = frameBuffer.Dispose;
+
+			enableScissor = rect => frameBuffer.EnableScissor((Rectangle)rect);
+			disableScissor = frameBuffer.DisableScissor;
 		}
 
 		public ITexture Texture
@@ -480,6 +485,16 @@ namespace OpenRA.Platforms.Default
 		public void Unbind()
 		{
 			device.Post(unbind);
+		}
+
+		public void EnableScissor(Rectangle rect)
+		{
+			device.Post(enableScissor, rect);
+		}
+
+		public void DisableScissor()
+		{
+			device.Post(disableScissor);
 		}
 
 		public void Dispose()


### PR DESCRIPTION
This PR completes the series of changes that started with #16996, #17026, #17042, #17095. The basic idea here is that everything in the world (i.e. drawn by the `WorldRenderer` that isn't an annotation) is first drawn into an offscreen buffer at 1:1 zoom. This guarantees that each world pixel maps to exactly one pixel in the depth buffer, which is the only reasonable way to avoid bugs like #12876.

When rendering switches to the UI layer we flush everything in the world layer and render that into the screen buffer as a single textured quad. Annotations and Widgets are then drawn on top as before.

Fixes #12876.
Fixes #11332.

This also lays the groundwork for a bunch of future renderer improvements:

* Distortion effects like #12289 and #9778 and RGBA-sprite aware color effects (#6734 etc) by ping-ponging between a pair of frame buffers with custom shaders that resample the world texture.
* Moving the world rendering into its own widget instead of relying on a collection of engine-level hacks.
* The world part of #10382 and arbitrary mouse zooming after implementing a contrast-preserving fractional-pixel sampler (proof of concept in a027222a641b8cf593be3a30fa7b75129ad79df4)
* Full-map editor previews (#2762) by implementing a bodge that renders the full map into the world frame buffer then saves that directly to disk instead of to the screen (proof of concept in ff84d2f626)
