### PR TITLE
Restore automatic target line display for spectators

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -130,9 +130,9 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public static void ShowTargetLines(this Actor self)
 		{
-			// Target lines are only automatically shown for the owning player
-			// Spectators and allies must use the force-display modifier
-			if (self.Owner != self.World.LocalPlayer)
+			// Target lines are only automatically shown for the owning player and spectators.
+			// Allies must use the force-display modifier.
+			if (self.Owner != self.World.LocalPlayer && self.World.LocalPlayer != null)
 				return;
 
 			// Draw after frame end so that all the queueing of activities are done before drawing.


### PR DESCRIPTION
This fixes a (voluntary) regression introduced in
https://github.com/OpenRA/OpenRA/pull/16876

In the current release (20190314) observer mode does automatically show
target lines for the selected units when a new order is issued by the
player. This is very convenient as an observer interested in
monitoring the player actions.

The behaviour changed for allied players but also for spectators in
b0e89cf1. While this makes sense in-game in order to not pollute allied
player visions, requiring spectators to hold the shift modifier
constantly to watch out for new actions is counter-productive.

This commit restores the old behaviour.