### PR TITLE
Prototype of new Easy, Normal, Hard, and Brutal AIs for RA Mod.

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/BuildingRepairBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BuildingRepairBotModule.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 			var rb = self.TraitOrDefault<RepairableBuilding>();
 			if (rb != null)
 			{
-				if (e.DamageState > DamageState.Light && e.PreviousDamageState <= DamageState.Light && !rb.RepairActive)
+				if (e.DamageState > DamageState.Undamaged && e.PreviousDamageState <= DamageState.Undamaged && !rb.RepairActive)
 				{
 					AIUtils.BotDebug("Bot noticed damage {0} {1}->{2}, repairing.",
 						self, e.PreviousDamageState, e.DamageState);

--- a/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/HarvesterBotModule.cs
@@ -25,6 +25,9 @@ namespace OpenRA.Mods.Common.Traits
 			"Leave empty to disable harvester replacement. Currently only needed by harvester replacement system.")]
 		public readonly HashSet<string> HarvesterTypes = new HashSet<string>();
 
+		[Desc("Number of harvesters per refinery to maintain.")]
+		public readonly int HarvestersPerRefinery = 1;
+
 		[Desc("Actor types that are counted as refineries. Currently only needed by harvester replacement system.")]
 		public readonly HashSet<string> RefineryTypes = new HashSet<string>();
 
@@ -132,7 +135,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (unitBuilder != null && Info.HarvesterTypes.Any())
 			{
 				var harvInfo = AIUtils.GetInfoByCommonName(Info.HarvesterTypes, player);
-				var harvCountTooLow = AIUtils.CountActorByCommonName(Info.HarvesterTypes, player) < AIUtils.CountBuildingByCommonName(Info.RefineryTypes, player);
+				var harvCountTooLow = AIUtils.CountActorByCommonName(Info.HarvesterTypes, player) < AIUtils.CountBuildingByCommonName(Info.RefineryTypes, player) * Info.HarvestersPerRefinery;
 				if (harvCountTooLow && unitBuilder.RequestedProductionCount(bot, harvInfo.Name) == 0)
 					unitBuilder.RequestUnitProduction(bot, harvInfo.Name);
 			}

--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -326,7 +326,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				var ownUnits = World.FindActorsInCircle(World.Map.CenterOfCell(GetRandomBaseCenter()), WDist.FromCells(Info.ProtectUnitScanRadius))
 					.Where(unit => unit.Owner == Player && !unit.Info.HasTraitInfo<BuildingInfo>() && !unit.Info.HasTraitInfo<HarvesterInfo>()
-						&& unit.Info.HasTraitInfo<AttackBaseInfo>());
+						&& !unit.Info.HasTraitInfo<AircraftInfo>() && !Info.NavalUnitsTypes.Contains(unit.Info.Name) && unit.Info.HasTraitInfo<AttackBaseInfo>());
 
 				foreach (var a in ownUnits)
 					protectSq.Units.Add(a);

--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -272,7 +272,15 @@ namespace OpenRA.Mods.Common.Traits
 
 				foreach (var a in unitsHangingAroundTheBase)
 					if (!a.Info.HasTraitInfo<AircraftInfo>() && !Info.NavalUnitsTypes.Contains(a.Info.Name))
+					{
+						var protectSq = GetSquadOfType(SquadType.Protection);
+						if (protectSq != null)
+						{
+							protectSq.Units.Remove(a);
+						}
+
 						attackForce.Units.Add(a);
+					}
 
 				unitsHangingAroundTheBase.Clear();
 				foreach (var n in notifyIdleBaseUnits)
@@ -306,7 +314,15 @@ namespace OpenRA.Mods.Common.Traits
 						rush = RegisterNewSquad(bot, SquadType.Rush, target);
 
 					foreach (var a3 in ownUnits)
+					{
+						var protectSq = GetSquadOfType(SquadType.Protection);
+						if (protectSq != null)
+						{
+							protectSq.Units.Remove(a3);
+						}
+
 						rush.Units.Add(a3);
+					}
 
 					return;
 				}

--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -151,6 +151,14 @@ namespace OpenRA.Mods.Common.Traits
 			AssignRolesToIdleUnits(bot);
 		}
 
+		internal Actor FindClosestEnemyBuilding(WPos pos)
+		{
+			var enemy = World.ActorsHavingTrait<Building>().Where(IsEnemyUnit).ClosestTo(pos);
+			if (enemy != null)
+				return enemy;
+			return World.Actors.Where(IsEnemyUnit).ClosestTo(pos);
+		}
+
 		internal Actor FindClosestEnemy(WPos pos)
 		{
 			return World.Actors.Where(IsEnemyUnit).ClosestTo(pos);

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
@@ -199,7 +199,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			if (!owner.IsTargetValid)
 			{
 				var a = owner.Units.Random(owner.Random);
-				var closestEnemy = owner.SquadManager.FindClosestEnemy(a.CenterPosition);
+				var closestEnemy = owner.SquadManager.FindClosestEnemyBuilding(a.CenterPosition);
 				if (closestEnemy != null)
 					owner.TargetActor = closestEnemy;
 				else

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
@@ -199,7 +199,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			if (!owner.IsTargetValid)
 			{
 				var a = owner.Units.Random(owner.Random);
-				var closestEnemy = owner.SquadManager.FindClosestEnemyBuilding(a.CenterPosition);
+				var closestEnemy = owner.SquadManager.FindClosestEnemy(a.CenterPosition);
 				if (closestEnemy != null)
 					owner.TargetActor = closestEnemy;
 				else

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			if (leader == null)
 				return;
 
-			var ownUnits = owner.World.FindActorsInCircle(leader.CenterPosition, WDist.FromCells(System.Math.Max(owner.Units.Count / 3, 3)))
+			var ownUnits = owner.World.FindActorsInCircle(leader.CenterPosition, WDist.FromCells(System.Math.Max(owner.Units.Count / 3, 4)))
 				.Where(a => a.Owner == owner.Units.First().Owner && owner.Units.Contains(a)).ToHashSet();
 
 			if (ownUnits.Count < owner.Units.Count)

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
@@ -21,6 +21,11 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			return ShouldFlee(owner, enemies => !AttackOrFleeFuzzy.Default.CanAttack(owner.Units, enemies));
 		}
 
+		protected Actor FindClosestEnemyBuilding(Squad owner)
+		{
+			return owner.SquadManager.FindClosestEnemyBuilding(owner.Units.First().CenterPosition);
+		}
+
 		protected Actor FindClosestEnemy(Squad owner)
 		{
 			return owner.SquadManager.FindClosestEnemy(owner.Units.First().CenterPosition);
@@ -77,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 
 			if (!owner.IsTargetValid)
 			{
-				var closestEnemy = FindClosestEnemy(owner);
+				var closestEnemy = FindClosestEnemyBuilding(owner);
 				if (closestEnemy != null)
 					owner.TargetActor = closestEnemy;
 				else
@@ -91,7 +96,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			if (leader == null)
 				return;
 
-			var ownUnits = owner.World.FindActorsInCircle(leader.CenterPosition, WDist.FromCells(owner.Units.Count) / 3)
+			var ownUnits = owner.World.FindActorsInCircle(leader.CenterPosition, WDist.FromCells(owner.Units.Count) / 2)
 				.Where(a => a.Owner == owner.Units.First().Owner && owner.Units.Contains(a)).ToHashSet();
 
 			if (ownUnits.Count < owner.Units.Count)
@@ -135,7 +140,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 
 			if (!owner.IsTargetValid)
 			{
-				var closestEnemy = FindClosestEnemy(owner);
+				var closestEnemy = FindClosestEnemyBuilding(owner);
 				if (closestEnemy != null)
 					owner.TargetActor = closestEnemy;
 				else

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			if (leader == null)
 				return;
 
-			var ownUnits = owner.World.FindActorsInCircle(leader.CenterPosition, WDist.FromCells(owner.Units.Count) / 2)
+			var ownUnits = owner.World.FindActorsInCircle(leader.CenterPosition, WDist.FromCells(System.Math.Max(owner.Units.Count / 3, 3)))
 				.Where(a => a.Owner == owner.Units.First().Owner && owner.Units.Contains(a)).ToHashSet();
 
 			if (ownUnits.Count < owner.Units.Count)

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
@@ -115,11 +115,10 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				if (target != null)
 				{
 					owner.TargetActor = target;
-					owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsAttackState(), true);
 				}
-				else
-					foreach (var a in owner.Units)
-						owner.Bot.QueueOrder(new Order("AttackMove", a, Target.FromCell(owner.World, owner.TargetActor.Location), false));
+
+				foreach (var a in owner.Units)
+				owner.Bot.QueueOrder(new Order("AttackMove", a, Target.FromCell(owner.World, owner.TargetActor.Location), false));
 			}
 
 			if (ShouldFlee(owner))

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/NavyStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/NavyStates.cs
@@ -112,38 +112,14 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				}
 			}
 
-			var leader = owner.Units.ClosestTo(owner.TargetActor.CenterPosition);
-			if (leader == null)
-				return;
-
-			var ownUnits = owner.World.FindActorsInCircle(leader.CenterPosition, WDist.FromCells(owner.Units.Count) / 3)
-				.Where(a => a.Owner == owner.Units.First().Owner && owner.Units.Contains(a)).ToHashSet();
-
-			if (ownUnits.Count < owner.Units.Count)
-			{
-				// Since units have different movement speeds, they get separated while approaching the target.
-				// Let them regroup into tighter formation.
-				owner.Bot.QueueOrder(new Order("Stop", leader, false));
-				foreach (var unit in owner.Units.Where(a => !ownUnits.Contains(a)))
-					owner.Bot.QueueOrder(new Order("AttackMove", unit, Target.FromCell(owner.World, leader.Location), false));
-			}
-			else
-			{
-				var enemies = owner.World.FindActorsInCircle(leader.CenterPosition, WDist.FromCells(owner.SquadManager.Info.AttackScanRadius))
-					.Where(owner.SquadManager.IsEnemyUnit);
-				var target = enemies.ClosestTo(leader.CenterPosition);
-				if (target != null)
-				{
-					owner.TargetActor = target;
-					owner.FuzzyStateMachine.ChangeState(owner, new NavyUnitsAttackState(), true);
-				}
-				else
-					foreach (var a in owner.Units)
-						owner.Bot.QueueOrder(new Order("AttackMove", a, Target.FromCell(owner.World, owner.TargetActor.Location), false));
-			}
+			foreach (var a in owner.Units)
+					owner.Bot.QueueOrder(new Order("AttackMove", a, Target.FromCell(owner.World, owner.TargetActor.Location), false));
 
 			if (ShouldFlee(owner))
+			{
 				owner.FuzzyStateMachine.ChangeState(owner, new NavyUnitsFleeState(), true);
+				hadNavalYard = false;
+			}
 		}
 
 		public void Deactivate(Squad owner) { }

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/NavyStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/NavyStates.cs
@@ -163,7 +163,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 
 			foreach (var a in owner.Units)
 				if (!BusyAttack(a))
-					owner.Bot.QueueOrder(new Order("Attack", a, Target.FromActor(owner.TargetActor), false));
+					owner.Bot.QueueOrder(new Order("Attack", a, Target.FromCell(owner.World, owner.TargetActor.Location), false));
 
 			if (ShouldFlee(owner))
 				owner.FuzzyStateMachine.ChangeState(owner, new NavyUnitsFleeState(), true);

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/StateBase.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/StateBase.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		{
 			var loc = RandomBuildingLocation(squad);
 			foreach (var a in squad.Units)
-				squad.Bot.QueueOrder(new Order("Move", a, Target.FromCell(squad.World, loc), false));
+				squad.Bot.QueueOrder(new Order("Move", a, Target.FromCell(squad.World, loc), true));
 		}
 
 		protected static CPos RandomBuildingLocation(Squad squad)

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/StateBase.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/StateBase.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		{
 			var loc = RandomBuildingLocation(squad);
 			foreach (var a in squad.Units)
-				squad.Bot.QueueOrder(new Order("Move", a, Target.FromCell(squad.World, loc), true));
+				squad.Bot.QueueOrder(new Order("Move", a, Target.FromCell(squad.World, loc), false));
 		}
 
 		protected static CPos RandomBuildingLocation(Squad squad)

--- a/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
@@ -39,6 +39,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("How often should the unit builder check to build more units")]
 		public readonly int UnitBuilderInterval = 0;
 
+		[Desc("Mininum amount of credits in reserve for the Unit Builder to be active.")]
+		public readonly int UnitBuilderMinCredits = 2000;
+
 		public override object Create(ActorInitializer init) { return new UnitBuilderBotModule(init.Self, this); }
 	}
 
@@ -89,8 +92,9 @@ namespace OpenRA.Mods.Common.Traits
 					queuedBuildRequests.Remove(buildRequest);
 				}
 
-				foreach (var q in Info.UnitQueues)
-					BuildUnit(bot, q, idleUnitCount < Info.IdleBaseUnitsMaximum);
+				if (player.PlayerActor.Trait<PlayerResources>().Cash + player.PlayerActor.Trait<PlayerResources>().Resources >= Info.UnitBuilderMinCredits)
+					foreach (var q in Info.UnitQueues)
+						BuildUnit(bot, q, idleUnitCount < Info.IdleBaseUnitsMaximum);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/UnitBuilderBotModule.cs
@@ -36,6 +36,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("When should the AI start train specific units.")]
 		public readonly Dictionary<string, int> UnitDelays = null;
 
+		[Desc("How often should the unit builder check to build more units")]
+		public readonly int UnitBuilderInterval = 0;
+
 		public override object Create(ActorInitializer init) { return new UnitBuilderBotModule(init.Self, this); }
 	}
 
@@ -77,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			ticks++;
 
-			if (ticks % FeedbackTime == 0)
+			if (ticks % (FeedbackTime + Info.UnitBuilderInterval) == 0)
 			{
 				var buildRequest = queuedBuildRequests.FirstOrDefault();
 				if (buildRequest != null)

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -654,7 +654,7 @@ Player:
 		IdleScanRadius: 18
 		AttackScanRadius: 9
 		MaxBaseRadius: 16
-		RushInterval: 600
+		RushInterval: 1200
 		RushAttackScanRadius: 25
 		ProtectUnitScanRadius: 20
 		ProtectionScanRadius: 15
@@ -718,7 +718,7 @@ Player:
 		IdleScanRadius: 18
 		AttackScanRadius: 9
 		MaxBaseRadius: 16
-		RushInterval: 600
+		RushInterval: 1200
 		RushAttackScanRadius: 25
 		ProtectUnitScanRadius: 20
 		ProtectionScanRadius: 15
@@ -782,9 +782,9 @@ Player:
 		IdleScanRadius: 18
 		AttackScanRadius: 9
 		MaxBaseRadius: 16
-		RushInterval: 600
+		RushInterval: 1200
 		RushAttackScanRadius: 25
-		ProtectUnitScanRadius: 20
+		ProtectUnitScanRadius: 24
 		ProtectionScanRadius: 15
 		AssignRolesInterval: 50
 		AttackForceInterval: 75
@@ -845,9 +845,9 @@ Player:
 		IdleScanRadius: 18
 		AttackScanRadius: 9
 		MaxBaseRadius: 16
-		RushInterval: 600
+		RushInterval: 1200
 		RushAttackScanRadius: 25
-		ProtectUnitScanRadius: 20
+		ProtectUnitScanRadius: 28
 		ProtectionScanRadius: 15
 		AssignRolesInterval: 50
 		AttackForceInterval: 75

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -661,7 +661,7 @@ Player:
 		ProtectionScanRadius: 10
 		AssignRolesInterval: 200
 		AttackForceInterval: 75
-		DangerScanRadius: 10
+		DangerScanRadius: 8
 		MinimumAttackForceDelay: 6000
 	UnitBuilderBotModule@easy:
 		RequiresCondition: enable-easy-ai
@@ -726,7 +726,7 @@ Player:
 		ProtectionScanRadius: 10
 		AssignRolesInterval: 50
 		AttackForceInterval: 75
-		DangerScanRadius: 10
+		DangerScanRadius: 8
 		MinimumAttackForceDelay: 6000
 	UnitBuilderBotModule@normal:
 		RequiresCondition: enable-normal-ai
@@ -792,7 +792,7 @@ Player:
 		ProtectionScanRadius: 10
 		AssignRolesInterval: 50
 		AttackForceInterval: 75
-		DangerScanRadius: 10
+		DangerScanRadius: 8
 		MinimumAttackForceDelay: 6000
 	UnitBuilderBotModule@hard:
 		RequiresCondition: enable-hard-ai
@@ -858,7 +858,7 @@ Player:
 		ProtectionScanRadius: 10
 		AssignRolesInterval: 50
 		AttackForceInterval: 75
-		DangerScanRadius: 10
+		DangerScanRadius: 8
 		MinimumAttackForceDelay: 6000
 	UnitBuilderBotModule@brutal:
 		RequiresCondition: enable-brutal-ai

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -11,38 +11,26 @@ Player:
 	ModularBot@BrutalAI:
 		Name: Brutal AI
 		Type: brutal
-	ModularBot@RushAI:
-		Name: Rush AI
-		Type: rush
-	ModularBot@TurtleAI:
-		Name: Turtle AI
-		Type: turtle
 	ModularBot@NavalAI:
 		Name: Naval AI
 		Type: naval
-	GrantConditionOnBotOwner@rush:
-		Condition: enable-rush-ai
-		Bots: rush
 	GrantConditionOnBotOwner@easy:
 		Condition: enable-easy-ai
 		Bots: easy
 	GrantConditionOnBotOwner@normal:
 		Condition: enable-normal-ai
 		Bots: normal
-	GrantConditionOnBotOwner@turtle:
-		Condition: enable-turtle-ai
-		Bots: turtle
-	GrantConditionOnBotOwner@naval:
-		Condition: enable-naval-ai
-		Bots: naval
 	GrantConditionOnBotOwner@hard:
 		Condition: enable-hard-ai
 		Bots: hard
 	GrantConditionOnBotOwner@brutal:
 		Condition: enable-brutal-ai
 		Bots: brutal
+	GrantConditionOnBotOwner@naval:
+		Condition: enable-naval-ai
+		Bots: naval
 	SupportPowerBotModule:
-		RequiresCondition: enable-rush-ai || enable-easy-ai  || enable-normal-ai || enable-turtle-ai || enable-naval-ai || enable-hard-ai || enable-brutal-ai
+		RequiresCondition: enable-easy-ai  || enable-normal-ai || enable-naval-ai || enable-hard-ai || enable-brutal-ai
 		Decisions:
 			spyplane:
 				OrderName: SovietSpyPlane
@@ -117,103 +105,10 @@ Player:
 					TargetMetric: Value
 					CheckRadius: 1c768
 	HarvesterBotModule:
-		RequiresCondition: enable-rush-ai || enable-easy-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai || enable-hard-ai || enable-brutal-ai
+		RequiresCondition: enable-easy-ai || enable-normal-ai || enable-naval-ai || enable-hard-ai || enable-brutal-ai
 		HarvesterTypes: harv
 		HarvestersPerRefinery: 2
 		RefineryTypes: proc
-	BaseBuilderBotModule@rush:
-		RequiresCondition: enable-rush-ai
-		MinimumExcessPower: 60
-		MaximumExcessPower: 160
-		ExcessPowerIncrement: 40
-		ExcessPowerIncreaseThreshold: 4
-		ConstructionYardTypes: fact
-		RefineryTypes: proc
-		PowerTypes: powr,apwr
-		BarracksTypes: barr,tent
-		VehiclesFactoryTypes: weap
-		ProductionTypes: barr,tent,weap
-		SiloTypes: silo
-		BuildingLimits:
-			proc: 4
-			barr: 1
-			tent: 1
-			kenn: 1
-			dome: 1
-			weap: 1
-			atek: 1
-			stek: 1
-			fix: 1
-		BuildingFractions:
-			proc: 30
-			barr: 1
-			kenn: 1
-			tent: 1
-			weap: 1
-			pbox: 7
-			gun: 7
-			tsla: 5
-			gap: 2
-			ftur: 10
-			agun: 5
-			sam: 5
-			atek: 1
-			stek: 1
-			fix: 1
-			dome: 10
-			mslo: 1
-	BaseBuilderBotModule@turtle:
-		RequiresCondition: enable-turtle-ai
-		MinimumExcessPower: 60
-		MaximumExcessPower: 250
-		ExcessPowerIncrement: 50
-		ExcessPowerIncreaseThreshold: 4
-		ConstructionYardTypes: fact
-		RefineryTypes: proc
-		PowerTypes: powr,apwr
-		BarracksTypes: barr,tent
-		VehiclesFactoryTypes: weap
-		ProductionTypes: barr,tent,weap,afld,hpad,afld.ukraine
-		NavalProductionTypes: spen,syrd
-		SiloTypes: silo
-		BuildingLimits:
-			proc: 4
-			barr: 1
-			tent: 1
-			kenn: 1
-			dome: 1
-			weap: 1
-			spen: 1
-			syrd: 1
-			hpad: 4
-			afld: 4
-			afld.ukraine: 4
-			atek: 1
-			stek: 1
-			fix: 1
-		BuildingFractions:
-			proc: 30
-			tent: 1
-			barr: 1
-			kenn: 1
-			weap: 3
-			hpad: 2
-			afld: 2
-			afld.ukraine: 2
-			spen: 1
-			syrd: 1
-			pbox: 10
-			gun: 10
-			ftur: 10
-			tsla: 7
-			gap: 3
-			fix: 1
-			dome: 10
-			agun: 5
-			sam: 5
-			atek: 1
-			stek: 1
-			mslo: 1
 	BaseBuilderBotModule@easy:
 		RequiresCondition: enable-easy-ai
 		MinimumExcessPower: 50
@@ -509,8 +404,8 @@ Player:
 			dome: 1
 			barr: 1
 			tent: 1
-			spen: 1
-			syrd: 1
+			spen: 2
+			syrd: 2
 			hpad: 8
 			afld: 8
 			afld.ukraine: 8
@@ -527,8 +422,8 @@ Player:
 			afld.ukraine: 20
 			atek: 1
 			stek: 1
-			spen: 1
-			syrd: 1
+			spen: 2
+			syrd: 2
 			fix: 1
 			pbox: 12
 			gun: 12
@@ -538,7 +433,7 @@ Player:
 			sam: 5
 			mslo: 1
 	BuildingRepairBotModule:
-		RequiresCondition: enable-rush-ai || enable-easy-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai || enable-hard-ai || enable-brutal-ai
+		RequiresCondition: enable-easy-ai || enable-normal-ai || enable-naval-ai || enable-hard-ai || enable-brutal-ai
 	SquadManagerBotModule@rush:
 		RequiresCondition: enable-rush-ai
 		SquadSize: 20
@@ -546,7 +441,7 @@ Player:
 		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
 		ConstructionYardTypes: fact
 	McvManagerBotModule:
-		RequiresCondition: enable-rush-ai || enable-easy-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
+		RequiresCondition: enable-easy-ai || enable-normal-ai || enable-naval-ai
 		McvTypes: mcv
 		ConstructionYardTypes: fact
 		McvFactoryTypes: weap
@@ -575,74 +470,6 @@ Player:
 		MinBaseRadius: 20
 		MaxBaseRadius: 25
 		ScanForNewMcvInterval: 80
-	UnitBuilderBotModule@rush:
-		RequiresCondition: enable-rush-ai
-		UnitsToBuild:
-			e1: 65
-			e2: 15
-			e3: 30
-			e4: 15
-			dog: 15
-			shok: 15
-			harv: 10
-			apc: 30
-			jeep: 20
-			arty: 15
-			v2rl: 40
-			ftrk: 30
-			1tnk: 50
-			2tnk: 50
-			3tnk: 50
-			4tnk: 25
-			ttnk: 25
-			stnk: 5
-		UnitLimits:
-			dog: 4
-			harv: 8
-			jeep: 4
-			ftrk: 4
-	SquadManagerBotModule@turtle:
-		RequiresCondition: enable-turtle-ai
-		SquadSize: 10
-		ExcludeFromSquadsTypes: harv, mcv, dog
-		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
-		ConstructionYardTypes: fact
-		NavalProductionTypes: spen,syrd
-	UnitBuilderBotModule@turtle:
-		RequiresCondition: enable-turtle-ai
-		UnitsToBuild:
-			e1: 65
-			e2: 15
-			e3: 30
-			e4: 15
-			dog: 15
-			shok: 15
-			harv: 15
-			apc: 30
-			jeep: 20
-			arty: 15
-			v2rl: 40
-			ftrk: 50
-			1tnk: 50
-			2tnk: 50
-			3tnk: 50
-			4tnk: 25
-			ttnk: 25
-			stnk: 10
-			heli: 30
-			mh60: 30
-			mig: 30
-			yak: 30
-			ss: 10
-			msub: 10
-			dd: 10
-			ca: 10
-			pt: 10
-		UnitLimits:
-			dog: 4
-			harv: 8
-			jeep: 4
-			ftrk: 4
 	SquadManagerBotModule@easy:
 		RequiresCondition: enable-easy-ai
 		SquadSize: 2
@@ -924,7 +751,7 @@ Player:
 			ca: 20
 			pt: 10
 		UnitLimits:
-			harv: 8
+			harv: 10
 	CaptureManagerBotModule@AIEasy:
 		RequiresCondition: enable-easy-ai
 		CapturingActorTypes: e6

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -665,7 +665,7 @@ Player:
 	UnitBuilderBotModule@easy:
 		RequiresCondition: enable-easy-ai
 		IdleBaseUnitsMaximum: 20
-		UnitBuilderInterval: 750
+		UnitBuilderInterval: 200
 		UnitsToBuild:
 			e1: 5
 			e2: 15
@@ -729,7 +729,7 @@ Player:
 	UnitBuilderBotModule@normal:
 		RequiresCondition: enable-normal-ai
 		IdleBaseUnitsMaximum: 45
-		UnitBuilderInterval: 500
+		UnitBuilderInterval: 100
 		UnitsToBuild:
 			e1: 5
 			e2: 15

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -1,10 +1,19 @@
 Player:
-	ModularBot@RushAI:
-		Name: Rush AI
-		Type: rush
+	ModularBot@EasyAI:
+		Name: Easy AI
+		Type: easy
 	ModularBot@NormalAI:
 		Name: Normal AI
 		Type: normal
+	ModularBot@HardAI:
+		Name: Hard AI
+		Type: hard
+	ModularBot@BrutalAI:
+		Name: Brutal AI
+		Type: brutal
+	ModularBot@RushAI:
+		Name: Rush AI
+		Type: rush
 	ModularBot@TurtleAI:
 		Name: Turtle AI
 		Type: turtle
@@ -14,6 +23,9 @@ Player:
 	GrantConditionOnBotOwner@rush:
 		Condition: enable-rush-ai
 		Bots: rush
+	GrantConditionOnBotOwner@easy:
+		Condition: enable-easy-ai
+		Bots: easy
 	GrantConditionOnBotOwner@normal:
 		Condition: enable-normal-ai
 		Bots: normal
@@ -23,8 +35,14 @@ Player:
 	GrantConditionOnBotOwner@naval:
 		Condition: enable-naval-ai
 		Bots: naval
+	GrantConditionOnBotOwner@hard:
+		Condition: enable-hard-ai
+		Bots: hard
+	GrantConditionOnBotOwner@brutal:
+		Condition: enable-brutal-ai
+		Bots: brutal
 	SupportPowerBotModule:
-		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
+		RequiresCondition: enable-rush-ai || enable-easy-ai  || enable-normal-ai || enable-turtle-ai || enable-naval-ai || enable-hard-ai || enable-brutal-ai
 		Decisions:
 			spyplane:
 				OrderName: SovietSpyPlane
@@ -59,6 +77,12 @@ Player:
 					Attractiveness: 1
 					TargetMetric: None
 					CheckRadius: 5c0
+				Consideration@2:
+					Against: Enemy
+					Types: Structure
+					Attractiveness: 15
+					TargetMetric: None
+					CheckRadius: 0c1
 			nukepower:
 				OrderName: NukePowerInfoOrder
 				MinimumAttractiveness: 3000
@@ -74,8 +98,26 @@ Player:
 					Attractiveness: -10
 					TargetMetric: Value
 					CheckRadius: 7c0
+				Consideration@3:
+					Against: Enemy
+					Types: Structure
+					Attractiveness: 2
+					TargetMetric: Value
+					CheckRadius: 1c768
+				Consideration@4:
+					Against: Enemy
+					Types: Refinery
+					Attractiveness: 10000
+					TargetMetric: None
+					CheckRadius: 1c768
+				Consideration@5:
+					Against: Enemy
+					Types: Defense
+					Attractiveness: -2
+					TargetMetric: Value
+					CheckRadius: 1c768
 	HarvesterBotModule:
-		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
+		RequiresCondition: enable-rush-ai || enable-easy-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai || enable-hard-ai || enable-brutal-ai
 		HarvesterTypes: harv
 		RefineryTypes: proc
 	BaseBuilderBotModule@rush:
@@ -119,57 +161,6 @@ Player:
 			fix: 1
 			dome: 10
 			mslo: 1
-	BaseBuilderBotModule@normal:
-		RequiresCondition: enable-normal-ai
-		MinimumExcessPower: 60
-		MaximumExcessPower: 200
-		ExcessPowerIncrement: 40
-		ExcessPowerIncreaseThreshold: 4
-		ConstructionYardTypes: fact
-		RefineryTypes: proc
-		PowerTypes: powr,apwr
-		BarracksTypes: barr,tent
-		VehiclesFactoryTypes: weap
-		ProductionTypes: barr,tent,weap,afld,hpad
-		NavalProductionTypes: spen,syrd
-		SiloTypes: silo
-		BuildingLimits:
-			proc: 4
-			barr: 1
-			tent: 1
-			dome: 1
-			weap: 1
-			spen: 1
-			syrd: 1
-			hpad: 4
-			afld: 4
-			afld.ukraine: 4
-			atek: 1
-			stek: 1
-			fix: 1
-		BuildingFractions:
-			proc: 15
-			tent: 1
-			barr: 1
-			kenn: 1
-			dome: 1
-			weap: 6
-			hpad: 4
-			spen: 1
-			syrd: 1
-			afld: 4
-			afld.ukraine: 4
-			pbox: 7
-			gun: 7
-			ftur: 10
-			tsla: 5
-			gap: 2
-			fix: 1
-			agun: 5
-			sam: 1
-			atek: 1
-			stek: 1
-			mslo: 1
 	BaseBuilderBotModule@turtle:
 		RequiresCondition: enable-turtle-ai
 		MinimumExcessPower: 60
@@ -181,7 +172,7 @@ Player:
 		PowerTypes: powr,apwr
 		BarracksTypes: barr,tent
 		VehiclesFactoryTypes: weap
-		ProductionTypes: barr,tent,weap,afld,hpad
+		ProductionTypes: barr,tent,weap,afld,hpad,afld.ukraine
 		NavalProductionTypes: spen,syrd
 		SiloTypes: silo
 		BuildingLimits:
@@ -222,6 +213,282 @@ Player:
 			atek: 1
 			stek: 1
 			mslo: 1
+	BaseBuilderBotModule@easy:
+		RequiresCondition: enable-easy-ai
+		MinimumExcessPower: 50
+		MaximumExcessPower: 250
+		ExcessPowerIncrement: 10
+		ExcessPowerIncreaseThreshold: 1
+		ConstructionYardTypes: fact
+		RefineryTypes: proc
+		PowerTypes: powr,apwr
+		BarracksTypes: barr,tent
+		VehiclesFactoryTypes: weap
+		ProductionTypes: barr,tent,weap,afld,hpad,afld.ukraine
+		NavalProductionTypes: spen,syrd
+		SiloTypes: silo
+		MinimumDefenseRadius:5
+		MaximumDefenseRadius:20
+		MaxBaseRadius: 20
+		PlaceDefenseTowardsEnemyChance: 25
+		StructureProductionRandomBonusDelay: 0
+		StructureProductionActiveDelay: 240
+		NewProductionCashThreshold: 7500
+		BuildingLimits:
+			proc: 2
+			barr: 1
+			tent: 1
+			dome: 1
+			weap: 1
+			spen: 1
+			syrd: 1
+			hpad: 1
+			afld: 1
+			afld.ukraine: 1
+			atek: 1
+			stek: 1
+			fix: 1
+			silo: 2
+			mslo: 0
+			kenn: 0
+		BuildingDelays:
+			weap: 2800
+			dome: 6500
+			afld: 7500
+			afld.ukraine: 7500
+			hpad: 7500
+			syrd: 8500
+			spen: 8500
+		BuildingFractions:
+			proc: 6
+			tent: 3
+			barr: 3
+			kenn: 0
+			dome: 3
+			weap: 3
+			hpad: 3
+			spen: 1
+			syrd: 1
+			afld: 3
+			afld.ukraine: 3
+			pbox: 12
+			gun: 12
+			ftur: 16
+			tsla: 8
+			gap: 1
+			fix: 3
+			agun: 14
+			sam: 14
+			atek: 2
+			stek: 2
+			mslo: 0
+	BaseBuilderBotModule@normal:
+		RequiresCondition: enable-normal-ai
+		MinimumExcessPower: 50
+		MaximumExcessPower: 300
+		ExcessPowerIncrement: 10
+		ExcessPowerIncreaseThreshold: 1
+		ConstructionYardTypes: fact
+		RefineryTypes: proc
+		PowerTypes: powr,apwr
+		BarracksTypes: barr,tent
+		VehiclesFactoryTypes: weap
+		ProductionTypes: barr,tent,weap,afld,hpad,afld.ukraine
+		NavalProductionTypes: spen,syrd
+		SiloTypes: silo
+		MinimumDefenseRadius:5
+		MaximumDefenseRadius:20
+		MaxBaseRadius: 20
+		PlaceDefenseTowardsEnemyChance: 25
+		StructureProductionRandomBonusDelay: 0
+		StructureProductionActiveDelay: 120
+		NewProductionCashThreshold: 10000
+		BuildingLimits:
+			proc: 4
+			barr: 1
+			tent: 1
+			dome: 1
+			weap: 1
+			spen: 1
+			syrd: 1
+			hpad: 2
+			afld: 2
+			afld.ukraine: 2
+			atek: 1
+			stek: 1
+			fix: 1
+			silo: 2
+			mslo: 1
+			kenn: 0
+		BuildingDelays:
+			weap: 2800
+			dome: 5500
+			afld: 5500
+			afld.ukraine: 5500
+			hpad: 5500
+			syrd: 6500
+			spen: 6500
+		BuildingFractions:
+			proc: 8
+			tent: 2
+			barr: 2
+			kenn: 0
+			dome: 3
+			weap: 2
+			hpad: 3
+			spen: 1
+			syrd: 1
+			afld: 3
+			afld.ukraine: 3
+			pbox: 16
+			gun: 16
+			ftur: 22
+			tsla: 10
+			gap: 2
+			fix: 3
+			agun: 16
+			sam: 16
+			atek: 2
+			stek: 2
+			mslo: 1
+	BaseBuilderBotModule@hard:
+		RequiresCondition: enable-hard-ai
+		MinimumExcessPower: 50
+		MaximumExcessPower: 300
+		ExcessPowerIncrement: 10
+		ExcessPowerIncreaseThreshold: 1
+		ConstructionYardTypes: fact
+		RefineryTypes: proc
+		PowerTypes: powr,apwr
+		BarracksTypes: barr,tent
+		VehiclesFactoryTypes: weap
+		ProductionTypes: barr,tent,weap,afld,hpad,afld.ukraine
+		NavalProductionTypes: spen,syrd
+		SiloTypes: silo
+		MinimumDefenseRadius:5
+		MaximumDefenseRadius:25
+		MaxBaseRadius: 32
+		PlaceDefenseTowardsEnemyChance: 25
+		StructureProductionRandomBonusDelay: 0
+		StructureProductionActiveDelay: 60
+		NewProductionCashThreshold: 12500
+		BuildingLimits:
+			proc: 4
+			barr: 2
+			tent: 2
+			dome: 1
+			weap: 2
+			spen: 1
+			syrd: 1
+			hpad: 4
+			afld: 4
+			afld.ukraine: 4
+			atek: 1
+			stek: 1
+			fix: 1
+			silo: 2
+			mslo: 1
+			kenn: 0
+		BuildingDelays:
+			weap: 2800
+			dome: 5000
+			afld: 5000
+			afld.ukraine: 5000
+			hpad: 5000
+			syrd: 6500
+			spen: 6500
+		BuildingFractions:
+			proc: 8
+			tent: 3
+			barr: 3
+			kenn: 0
+			dome: 3
+			weap: 3
+			hpad: 3
+			spen: 1
+			syrd: 1
+			afld: 3
+			afld.ukraine: 3
+			pbox: 20
+			gun: 20
+			ftur: 28
+			tsla: 12
+			gap: 2
+			fix: 3
+			agun: 18
+			sam: 18
+			atek: 2
+			stek: 2
+			mslo: 1
+	BaseBuilderBotModule@brutal:
+		RequiresCondition: enable-brutal-ai
+		MinimumExcessPower: 50
+		MaximumExcessPower: 300
+		ExcessPowerIncrement: 10
+		ExcessPowerIncreaseThreshold: 1
+		ConstructionYardTypes: fact
+		RefineryTypes: proc
+		PowerTypes: powr,apwr
+		BarracksTypes: barr,tent
+		VehiclesFactoryTypes: weap
+		ProductionTypes: barr,tent,weap,afld,hpad,afld.ukraine
+		NavalProductionTypes: spen,syrd
+		SiloTypes: silo
+		MinimumDefenseRadius:5
+		MaximumDefenseRadius:25
+		MaxBaseRadius: 36
+		PlaceDefenseTowardsEnemyChance: 25
+		StructureProductionRandomBonusDelay: 0
+		StructureProductionActiveDelay: 10
+		NewProductionCashThreshold: 15000
+		BuildingLimits:
+			proc: 4
+			barr: 4
+			tent: 4
+			dome: 1
+			weap: 4
+			spen: 1
+			syrd: 1
+			hpad: 4
+			afld: 4
+			afld.ukraine: 4
+			atek: 1
+			stek: 1
+			fix: 1
+			silo: 4
+			mslo: 1
+			kenn: 0
+		BuildingDelays:
+			weap: 2800
+			dome: 4500
+			afld: 5000
+			afld.ukraine: 5000
+			hpad: 5000
+			syrd: 6000
+			spen: 6000
+		BuildingFractions:
+			proc: 8
+			tent: 4
+			barr: 4
+			kenn: 0
+			dome: 3
+			weap: 4
+			hpad: 4
+			spen: 1
+			syrd: 1
+			afld: 4
+			afld.ukraine: 4
+			pbox: 20
+			gun: 20
+			ftur: 28
+			tsla: 12
+			gap: 2
+			fix: 3
+			agun: 18
+			sam: 18
+			atek: 2
+			stek: 2
+			mslo: 1
 	BaseBuilderBotModule@naval:
 		RequiresCondition: enable-naval-ai
 		MinimumExcessPower: 60
@@ -233,7 +500,7 @@ Player:
 		PowerTypes: powr,apwr
 		BarracksTypes: barr,tent
 		VehiclesFactoryTypes: weap
-		ProductionTypes: barr,tent,weap,afld,hpad
+		ProductionTypes: barr,tent,weap,afld,hpad,afld.ukraine
 		NavalProductionTypes: spen,syrd
 		SiloTypes: silo
 		BuildingLimits:
@@ -270,7 +537,7 @@ Player:
 			sam: 5
 			mslo: 1
 	BuildingRepairBotModule:
-		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
+		RequiresCondition: enable-rush-ai || enable-easy-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai || enable-hard-ai || enable-brutal-ai
 	SquadManagerBotModule@rush:
 		RequiresCondition: enable-rush-ai
 		SquadSize: 20
@@ -278,10 +545,35 @@ Player:
 		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
 		ConstructionYardTypes: fact
 	McvManagerBotModule:
-		RequiresCondition: enable-rush-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
+		RequiresCondition: enable-rush-ai || enable-easy-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
 		McvTypes: mcv
 		ConstructionYardTypes: fact
 		McvFactoryTypes: weap
+		MinimumConstructionYardCount: 1
+		RestrictMCVDeploymentFallbackToBase: true
+		MinBaseRadius: 14
+		MaxBaseRadius: 18
+		ScanForNewMcvInterval: 80
+	McvManagerBotModule@hard:
+		RequiresCondition: enable-hard-ai
+		McvTypes: mcv
+		ConstructionYardTypes: fact
+		McvFactoryTypes: weap
+		MinimumConstructionYardCount: 2
+		RestrictMCVDeploymentFallbackToBase: true
+		MinBaseRadius: 14
+		MaxBaseRadius: 18
+		ScanForNewMcvInterval: 80
+	McvManagerBotModule@brutal:
+		RequiresCondition: enable-brutal-ai
+		McvTypes: mcv
+		ConstructionYardTypes: fact
+		McvFactoryTypes: weap
+		MinimumConstructionYardCount: 2
+		RestrictMCVDeploymentFallbackToBase: true
+		MinBaseRadius: 20
+		MaxBaseRadius: 25
+		ScanForNewMcvInterval: 80
 	UnitBuilderBotModule@rush:
 		RequiresCondition: enable-rush-ai
 		UnitsToBuild:
@@ -303,48 +595,6 @@ Player:
 			4tnk: 25
 			ttnk: 25
 			stnk: 5
-		UnitLimits:
-			dog: 4
-			harv: 8
-			jeep: 4
-			ftrk: 4
-	SquadManagerBotModule@normal:
-		RequiresCondition: enable-normal-ai
-		SquadSize: 40
-		ExcludeFromSquadsTypes: harv, mcv, dog
-		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
-		ConstructionYardTypes: fact
-		NavalProductionTypes: spen,syrd
-	UnitBuilderBotModule@normal:
-		RequiresCondition: enable-normal-ai
-		UnitsToBuild:
-			e1: 65
-			e2: 15
-			e3: 30
-			e4: 15
-			dog: 15
-			shok: 15
-			harv: 15
-			apc: 30
-			jeep: 20
-			arty: 15
-			v2rl: 40
-			ftrk: 30
-			1tnk: 40
-			2tnk: 50
-			3tnk: 50
-			4tnk: 25
-			ttnk: 25
-			stnk: 5
-			heli: 30
-			mh60: 30
-			mig: 30
-			yak: 30
-			ss: 10
-			msub: 10
-			dd: 10
-			ca: 10
-			pt: 10
 		UnitLimits:
 			dog: 4
 			harv: 8
@@ -392,6 +642,261 @@ Player:
 			harv: 8
 			jeep: 4
 			ftrk: 4
+	SquadManagerBotModule@easy:
+		RequiresCondition: enable-easy-ai
+		SquadSize: 15
+		SquadSizeRandomBonus: 5
+		ExcludeFromSquadsTypes: harv, mcv, dog, e6
+		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
+		ConstructionYardTypes: fact
+		NavalProductionTypes: spen,syrd
+		IdleScanRadius: 18
+		AttackScanRadius: 9
+		MaxBaseRadius: 16
+		RushInterval: 600
+		RushAttackScanRadius: 25
+		ProtectUnitScanRadius: 20
+		ProtectionScanRadius: 20
+		AssignRolesInterval: 200
+		AttackForceInterval: 75
+		DangerScanRadius: 10
+		MinimumAttackForceDelay: 30
+	UnitBuilderBotModule@easy:
+		RequiresCondition: enable-easy-ai
+		IdleBaseUnitsMaximum: 0
+		IdleBaseUnitsMaximum: 20
+		UnitBuilderInterval: 750
+		UnitsToBuild:
+			e1: 5
+			e2: 15
+			e3: 30
+			e4: 30
+			e6: 1
+			dog: 1
+			shok: 30
+			harv: 50
+			apc: 5
+			jeep: 5
+			arty: 5
+			v2rl: 15
+			ftrk: 5
+			1tnk: 30
+			2tnk: 60
+			3tnk: 30
+			4tnk: 40
+			ttnk: 40
+			stnk: 5
+			heli: 30
+			mh60: 30
+			mig: 30
+			yak: 30
+			ss: 1
+			msub: 1
+			dd: 1
+			ca: 1
+			pt: 1
+		UnitLimits:
+			dog: 4
+			e6: 4
+			harv: 6
+			jeep: 4
+			ftrk: 4
+			apc: 4
+			ss: 3
+			msub: 2
+			dd: 2
+			ca: 1
+			pt: 2
+	SquadManagerBotModule@normal:
+		RequiresCondition: enable-normal-ai
+		SquadSize: 30
+		SquadSizeRandomBonus: 15
+		ExcludeFromSquadsTypes: harv, mcv, dog, e6
+		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
+		ConstructionYardTypes: fact
+		NavalProductionTypes: spen,syrd
+		IdleScanRadius: 18
+		AttackScanRadius: 9
+		MaxBaseRadius: 16
+		RushInterval: 600
+		RushAttackScanRadius: 25
+		ProtectUnitScanRadius: 20
+		ProtectionScanRadius: 20
+		AssignRolesInterval: 50
+		AttackForceInterval: 75
+		DangerScanRadius: 10
+		MinimumAttackForceDelay: 30
+	UnitBuilderBotModule@normal:
+		RequiresCondition: enable-normal-ai
+		IdleBaseUnitsMaximum: 45
+		UnitBuilderInterval: 500
+		UnitsToBuild:
+			e1: 5
+			e2: 15
+			e3: 30
+			e4: 30
+			e6: 1
+			dog: 1
+			shok: 30
+			harv: 50
+			apc: 5
+			jeep: 5
+			arty: 10
+			v2rl: 25
+			ftrk: 5
+			1tnk: 30
+			2tnk: 60
+			3tnk: 30
+			4tnk: 40
+			ttnk: 40
+			stnk: 5
+			heli: 30
+			mh60: 30
+			mig: 30
+			yak: 30
+			ss: 1
+			msub: 1
+			dd: 1
+			ca: 1
+			pt: 1
+		UnitLimits:
+			dog: 4
+			e6: 4
+			harv: 10
+			jeep: 4
+			ftrk: 4
+			apc: 4
+			ss: 4
+			msub: 5
+			dd: 3
+			ca: 3
+			pt: 3
+	SquadManagerBotModule@hard:
+		RequiresCondition: enable-hard-ai
+		SquadSize: 40
+		SquadSizeRandomBonus: 20
+		ExcludeFromSquadsTypes: harv, mcv, dog, e6
+		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
+		ConstructionYardTypes: fact
+		NavalProductionTypes: spen,syrd
+		IdleScanRadius: 18
+		AttackScanRadius: 9
+		MaxBaseRadius: 16
+		RushInterval: 600
+		RushAttackScanRadius: 25
+		ProtectUnitScanRadius: 32
+		ProtectionScanRadius: 20
+		AssignRolesInterval: 50
+		AttackForceInterval: 75
+		DangerScanRadius: 10
+		MinimumAttackForceDelay: 30
+	UnitBuilderBotModule@hard:
+		RequiresCondition: enable-hard-ai
+		IdleBaseUnitsMaximum: 60
+		UnitsToBuild:
+			e1: 5
+			e2: 15
+			e3: 30
+			e4: 30
+			e6: 1
+			dog: 1
+			shok: 30
+			harv: 50
+			apc: 5
+			jeep: 5
+			arty: 10
+			v2rl: 25
+			ftrk: 5
+			1tnk: 30
+			2tnk: 60
+			3tnk: 30
+			4tnk: 40
+			ttnk: 40
+			stnk: 5
+			heli: 30
+			mh60: 30
+			mig: 30
+			yak: 30
+			ss: 1
+			msub: 1
+			dd: 1
+			ca: 1
+			pt: 1
+		UnitLimits:
+			dog: 4
+			e6: 4
+			harv: 8
+			jeep: 4
+			ftrk: 4
+			apc: 4
+			ss: 4
+			msub: 5
+			dd: 3
+			ca: 3
+			pt: 3
+	SquadManagerBotModule@brutal:
+		RequiresCondition: enable-brutal-ai
+		SquadSize: 60
+		SquadSizeRandomBonus: 20
+		ExcludeFromSquadsTypes: harv, mcv, dog, e6
+		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
+		ConstructionYardTypes: fact
+		NavalProductionTypes: spen,syrd
+		IdleScanRadius: 18
+		AttackScanRadius: 9
+		MaxBaseRadius: 16
+		RushInterval: 600
+		RushAttackScanRadius: 25
+		ProtectUnitScanRadius: 36
+		ProtectionScanRadius: 20
+		AssignRolesInterval: 50
+		AttackForceInterval: 75
+		DangerScanRadius: 10
+		MinimumAttackForceDelay: 30
+	UnitBuilderBotModule@brutal:
+		RequiresCondition: enable-brutal-ai
+		IdleBaseUnitsMaximum: 90
+		UnitsToBuild:
+			e1: 5
+			e2: 15
+			e3: 30
+			e4: 30
+			e6: 1
+			dog: 1
+			shok: 30
+			harv: 50
+			apc: 5
+			jeep: 5
+			arty: 15
+			v2rl: 30
+			ftrk: 5
+			1tnk: 30
+			2tnk: 60
+			3tnk: 30
+			4tnk: 40
+			ttnk: 40
+			stnk: 5
+			heli: 30
+			mh60: 30
+			mig: 30
+			yak: 30
+			ss: 1
+			msub: 1
+			dd: 1
+			ca: 1
+			pt: 1
+		UnitLimits:
+			dog: 4
+			e6: 4
+			harv: 8
+			jeep: 4
+			ftrk: 4
+			apc: 4
+			ss: 5
+			msub: 7
+			dd: 4
+			ca: 4
+			pt: 4
 	SquadManagerBotModule@naval:
 		RequiresCondition: enable-naval-ai
 		SquadSize: 1
@@ -414,3 +919,8 @@ Player:
 			pt: 10
 		UnitLimits:
 			harv: 8
+	CaptureManagerBotModule@AI:
+		RequiresCondition: enable-easy-ai || enable-normal-ai || enable-hard-ai || enable-brutal-ai
+		CapturingActorTypes: e6
+		CheckCaptureTargetsForVisibility: true
+		MinimumCaptureDelay: 50

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -657,7 +657,7 @@ Player:
 		RushInterval: 1200
 		RushAttackScanRadius: 25
 		ProtectUnitScanRadius: 20
-		ProtectionScanRadius: 15
+		ProtectionScanRadius: 10
 		AssignRolesInterval: 200
 		AttackForceInterval: 75
 		DangerScanRadius: 10
@@ -721,7 +721,7 @@ Player:
 		RushInterval: 1200
 		RushAttackScanRadius: 25
 		ProtectUnitScanRadius: 20
-		ProtectionScanRadius: 15
+		ProtectionScanRadius: 10
 		AssignRolesInterval: 50
 		AttackForceInterval: 75
 		DangerScanRadius: 10
@@ -785,7 +785,7 @@ Player:
 		RushInterval: 1200
 		RushAttackScanRadius: 25
 		ProtectUnitScanRadius: 24
-		ProtectionScanRadius: 15
+		ProtectionScanRadius: 10
 		AssignRolesInterval: 50
 		AttackForceInterval: 75
 		DangerScanRadius: 10
@@ -848,14 +848,14 @@ Player:
 		RushInterval: 1200
 		RushAttackScanRadius: 25
 		ProtectUnitScanRadius: 28
-		ProtectionScanRadius: 15
+		ProtectionScanRadius: 10
 		AssignRolesInterval: 50
 		AttackForceInterval: 75
 		DangerScanRadius: 10
 		MinimumAttackForceDelay: 30
 	UnitBuilderBotModule@brutal:
 		RequiresCondition: enable-brutal-ai
-		IdleBaseUnitsMaximum: 90
+		IdleBaseUnitsMaximum: 160
 		UnitsToBuild:
 			e1: 5
 			e2: 15

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -657,7 +657,7 @@ Player:
 		RushInterval: 600
 		RushAttackScanRadius: 25
 		ProtectUnitScanRadius: 20
-		ProtectionScanRadius: 20
+		ProtectionScanRadius: 15
 		AssignRolesInterval: 200
 		AttackForceInterval: 75
 		DangerScanRadius: 10
@@ -721,7 +721,7 @@ Player:
 		RushInterval: 600
 		RushAttackScanRadius: 25
 		ProtectUnitScanRadius: 20
-		ProtectionScanRadius: 20
+		ProtectionScanRadius: 15
 		AssignRolesInterval: 50
 		AttackForceInterval: 75
 		DangerScanRadius: 10
@@ -784,8 +784,8 @@ Player:
 		MaxBaseRadius: 16
 		RushInterval: 600
 		RushAttackScanRadius: 25
-		ProtectUnitScanRadius: 32
-		ProtectionScanRadius: 20
+		ProtectUnitScanRadius: 20
+		ProtectionScanRadius: 15
 		AssignRolesInterval: 50
 		AttackForceInterval: 75
 		DangerScanRadius: 10
@@ -847,8 +847,8 @@ Player:
 		MaxBaseRadius: 16
 		RushInterval: 600
 		RushAttackScanRadius: 25
-		ProtectUnitScanRadius: 36
-		ProtectionScanRadius: 20
+		ProtectUnitScanRadius: 20
+		ProtectionScanRadius: 15
 		AssignRolesInterval: 50
 		AttackForceInterval: 75
 		DangerScanRadius: 10

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -645,7 +645,7 @@ Player:
 			ftrk: 4
 	SquadManagerBotModule@easy:
 		RequiresCondition: enable-easy-ai
-		SquadSize: 15
+		SquadSize: 10
 		SquadSizeRandomBonus: 5
 		ExcludeFromSquadsTypes: harv, mcv, dog, e6
 		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
@@ -664,7 +664,6 @@ Player:
 		MinimumAttackForceDelay: 30
 	UnitBuilderBotModule@easy:
 		RequiresCondition: enable-easy-ai
-		IdleBaseUnitsMaximum: 0
 		IdleBaseUnitsMaximum: 20
 		UnitBuilderInterval: 750
 		UnitsToBuild:
@@ -698,7 +697,7 @@ Player:
 			pt: 1
 		UnitLimits:
 			dog: 4
-			e6: 4
+			e6: 2
 			harv: 6
 			jeep: 4
 			ftrk: 4

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -448,8 +448,8 @@ Player:
 			tent: 4
 			dome: 1
 			weap: 4
-			spen: 1
-			syrd: 1
+			spen: 2
+			syrd: 2
 			hpad: 4
 			afld: 4
 			afld.ukraine: 4
@@ -475,8 +475,8 @@ Player:
 			dome: 3
 			weap: 4
 			hpad: 4
-			spen: 1
-			syrd: 1
+			spen: 2
+			syrd: 2
 			afld: 4
 			afld.ukraine: 4
 			pbox: 20
@@ -736,6 +736,7 @@ Player:
 			e3: 30
 			e4: 30
 			e6: 1
+			e7: 1
 			dog: 1
 			shok: 30
 			harv: 50
@@ -762,6 +763,7 @@ Player:
 		UnitLimits:
 			dog: 4
 			e6: 4
+			e7: 1
 			harv: 10
 			jeep: 8
 			ftrk: 6
@@ -799,6 +801,7 @@ Player:
 			e3: 30
 			e4: 30
 			e6: 1
+			e7: 1
 			dog: 1
 			shok: 30
 			harv: 50
@@ -825,6 +828,7 @@ Player:
 		UnitLimits:
 			dog: 4
 			e6: 4
+			e7: 1
 			harv: 10
 			jeep: 8
 			ftrk: 6
@@ -862,6 +866,7 @@ Player:
 			e3: 30
 			e4: 30
 			e6: 1
+			e7: 1
 			dog: 1
 			shok: 30
 			harv: 50
@@ -888,6 +893,7 @@ Player:
 		UnitLimits:
 			dog: 4
 			e6: 4
+			e7: 1
 			harv: 10
 			jeep: 8
 			ftrk: 6

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -119,6 +119,7 @@ Player:
 	HarvesterBotModule:
 		RequiresCondition: enable-rush-ai || enable-easy-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai || enable-hard-ai || enable-brutal-ai
 		HarvesterTypes: harv
+		HarvestersPerRefinery: 2
 		RefineryTypes: proc
 	BaseBuilderBotModule@rush:
 		RequiresCondition: enable-rush-ai

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -424,7 +424,7 @@ Player:
 	BaseBuilderBotModule@brutal:
 		RequiresCondition: enable-brutal-ai
 		MinimumExcessPower: 50
-		MaximumExcessPower: 300
+		MaximumExcessPower: 350
 		ExcessPowerIncrement: 10
 		ExcessPowerIncreaseThreshold: 1
 		ConstructionYardTypes: fact
@@ -675,11 +675,11 @@ Player:
 			dog: 1
 			shok: 30
 			harv: 50
-			apc: 5
+			apc: 3
 			jeep: 5
 			arty: 5
 			v2rl: 15
-			ftrk: 5
+			ftrk: 2
 			1tnk: 30
 			2tnk: 60
 			3tnk: 30
@@ -697,11 +697,11 @@ Player:
 			pt: 1
 		UnitLimits:
 			dog: 4
-			e6: 2
+			e6: 1
 			harv: 6
-			jeep: 4
-			ftrk: 4
-			apc: 4
+			jeep: 8
+			ftrk: 6
+			apc: 8
 			ss: 3
 			msub: 2
 			dd: 2
@@ -739,11 +739,11 @@ Player:
 			dog: 1
 			shok: 30
 			harv: 50
-			apc: 5
+			apc: 3
 			jeep: 5
 			arty: 10
 			v2rl: 25
-			ftrk: 5
+			ftrk: 2
 			1tnk: 30
 			2tnk: 60
 			3tnk: 30
@@ -763,9 +763,9 @@ Player:
 			dog: 4
 			e6: 4
 			harv: 10
-			jeep: 4
-			ftrk: 4
-			apc: 4
+			jeep: 8
+			ftrk: 6
+			apc: 8
 			ss: 4
 			msub: 5
 			dd: 3
@@ -802,11 +802,11 @@ Player:
 			dog: 1
 			shok: 30
 			harv: 50
-			apc: 5
+			apc: 3
 			jeep: 5
 			arty: 10
 			v2rl: 25
-			ftrk: 5
+			ftrk: 2
 			1tnk: 30
 			2tnk: 60
 			3tnk: 30
@@ -826,9 +826,9 @@ Player:
 			dog: 4
 			e6: 4
 			harv: 8
-			jeep: 4
-			ftrk: 4
-			apc: 4
+			jeep: 8
+			ftrk: 6
+			apc: 8
 			ss: 4
 			msub: 5
 			dd: 3
@@ -865,11 +865,11 @@ Player:
 			dog: 1
 			shok: 30
 			harv: 50
-			apc: 5
+			apc: 3
 			jeep: 5
 			arty: 15
 			v2rl: 30
-			ftrk: 5
+			ftrk: 2
 			1tnk: 30
 			2tnk: 60
 			3tnk: 30
@@ -889,9 +889,9 @@ Player:
 			dog: 4
 			e6: 4
 			harv: 8
-			jeep: 4
-			ftrk: 4
-			apc: 4
+			jeep: 8
+			ftrk: 6
+			apc: 8
 			ss: 5
 			msub: 7
 			dd: 4
@@ -919,8 +919,13 @@ Player:
 			pt: 10
 		UnitLimits:
 			harv: 8
-	CaptureManagerBotModule@AI:
-		RequiresCondition: enable-easy-ai || enable-normal-ai || enable-hard-ai || enable-brutal-ai
+	CaptureManagerBotModule@AIEasy:
+		RequiresCondition: enable-easy-ai
 		CapturingActorTypes: e6
 		CheckCaptureTargetsForVisibility: true
+		MinimumCaptureDelay: 100
+	CaptureManagerBotModule@AI:
+		RequiresCondition: enable-normal-ai || enable-hard-ai || enable-brutal-ai
+		CapturingActorTypes: e6
+		CheckCaptureTargetsForVisibility: false
 		MinimumCaptureDelay: 50

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -11,26 +11,38 @@ Player:
 	ModularBot@BrutalAI:
 		Name: Brutal AI
 		Type: brutal
+	ModularBot@RushAI:
+		Name: Rush AI
+		Type: rush
+	ModularBot@TurtleAI:
+		Name: Turtle AI
+		Type: turtle
 	ModularBot@NavalAI:
 		Name: Naval AI
 		Type: naval
+	GrantConditionOnBotOwner@rush:
+		Condition: enable-rush-ai
+		Bots: rush
 	GrantConditionOnBotOwner@easy:
 		Condition: enable-easy-ai
 		Bots: easy
 	GrantConditionOnBotOwner@normal:
 		Condition: enable-normal-ai
 		Bots: normal
+	GrantConditionOnBotOwner@turtle:
+		Condition: enable-turtle-ai
+		Bots: turtle
+	GrantConditionOnBotOwner@naval:
+		Condition: enable-naval-ai
+		Bots: naval
 	GrantConditionOnBotOwner@hard:
 		Condition: enable-hard-ai
 		Bots: hard
 	GrantConditionOnBotOwner@brutal:
 		Condition: enable-brutal-ai
 		Bots: brutal
-	GrantConditionOnBotOwner@naval:
-		Condition: enable-naval-ai
-		Bots: naval
 	SupportPowerBotModule:
-		RequiresCondition: enable-easy-ai  || enable-normal-ai || enable-naval-ai || enable-hard-ai || enable-brutal-ai
+		RequiresCondition: enable-rush-ai || enable-easy-ai  || enable-normal-ai || enable-turtle-ai || enable-naval-ai || enable-hard-ai || enable-brutal-ai
 		Decisions:
 			spyplane:
 				OrderName: SovietSpyPlane
@@ -105,10 +117,103 @@ Player:
 					TargetMetric: Value
 					CheckRadius: 1c768
 	HarvesterBotModule:
-		RequiresCondition: enable-easy-ai || enable-normal-ai || enable-naval-ai || enable-hard-ai || enable-brutal-ai
+		RequiresCondition: enable-rush-ai || enable-easy-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai || enable-hard-ai || enable-brutal-ai
 		HarvesterTypes: harv
 		HarvestersPerRefinery: 2
 		RefineryTypes: proc
+	BaseBuilderBotModule@rush:
+		RequiresCondition: enable-rush-ai
+		MinimumExcessPower: 60
+		MaximumExcessPower: 160
+		ExcessPowerIncrement: 40
+		ExcessPowerIncreaseThreshold: 4
+		ConstructionYardTypes: fact
+		RefineryTypes: proc
+		PowerTypes: powr,apwr
+		BarracksTypes: barr,tent
+		VehiclesFactoryTypes: weap
+		ProductionTypes: barr,tent,weap
+		SiloTypes: silo
+		BuildingLimits:
+			proc: 4
+			barr: 1
+			tent: 1
+			kenn: 1
+			dome: 1
+			weap: 1
+			atek: 1
+			stek: 1
+			fix: 1
+		BuildingFractions:
+			proc: 30
+			barr: 1
+			kenn: 1
+			tent: 1
+			weap: 1
+			pbox: 7
+			gun: 7
+			tsla: 5
+			gap: 2
+			ftur: 10
+			agun: 5
+			sam: 5
+			atek: 1
+			stek: 1
+			fix: 1
+			dome: 10
+			mslo: 1
+	BaseBuilderBotModule@turtle:
+		RequiresCondition: enable-turtle-ai
+		MinimumExcessPower: 60
+		MaximumExcessPower: 250
+		ExcessPowerIncrement: 50
+		ExcessPowerIncreaseThreshold: 4
+		ConstructionYardTypes: fact
+		RefineryTypes: proc
+		PowerTypes: powr,apwr
+		BarracksTypes: barr,tent
+		VehiclesFactoryTypes: weap
+		ProductionTypes: barr,tent,weap,afld,hpad,afld.ukraine
+		NavalProductionTypes: spen,syrd
+		SiloTypes: silo
+		BuildingLimits:
+			proc: 4
+			barr: 1
+			tent: 1
+			kenn: 1
+			dome: 1
+			weap: 1
+			spen: 1
+			syrd: 1
+			hpad: 4
+			afld: 4
+			afld.ukraine: 4
+			atek: 1
+			stek: 1
+			fix: 1
+		BuildingFractions:
+			proc: 30
+			tent: 1
+			barr: 1
+			kenn: 1
+			weap: 3
+			hpad: 2
+			afld: 2
+			afld.ukraine: 2
+			spen: 1
+			syrd: 1
+			pbox: 10
+			gun: 10
+			ftur: 10
+			tsla: 7
+			gap: 3
+			fix: 1
+			dome: 10
+			agun: 5
+			sam: 5
+			atek: 1
+			stek: 1
+			mslo: 1
 	BaseBuilderBotModule@easy:
 		RequiresCondition: enable-easy-ai
 		MinimumExcessPower: 50
@@ -404,8 +509,8 @@ Player:
 			dome: 1
 			barr: 1
 			tent: 1
-			spen: 2
-			syrd: 2
+			spen: 1
+			syrd: 1
 			hpad: 8
 			afld: 8
 			afld.ukraine: 8
@@ -422,8 +527,8 @@ Player:
 			afld.ukraine: 20
 			atek: 1
 			stek: 1
-			spen: 2
-			syrd: 2
+			spen: 1
+			syrd: 1
 			fix: 1
 			pbox: 12
 			gun: 12
@@ -433,7 +538,7 @@ Player:
 			sam: 5
 			mslo: 1
 	BuildingRepairBotModule:
-		RequiresCondition: enable-easy-ai || enable-normal-ai || enable-naval-ai || enable-hard-ai || enable-brutal-ai
+		RequiresCondition: enable-rush-ai || enable-easy-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai || enable-hard-ai || enable-brutal-ai
 	SquadManagerBotModule@rush:
 		RequiresCondition: enable-rush-ai
 		SquadSize: 20
@@ -441,7 +546,7 @@ Player:
 		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
 		ConstructionYardTypes: fact
 	McvManagerBotModule:
-		RequiresCondition: enable-easy-ai || enable-normal-ai || enable-naval-ai
+		RequiresCondition: enable-rush-ai || enable-easy-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai
 		McvTypes: mcv
 		ConstructionYardTypes: fact
 		McvFactoryTypes: weap
@@ -470,6 +575,74 @@ Player:
 		MinBaseRadius: 20
 		MaxBaseRadius: 25
 		ScanForNewMcvInterval: 80
+	UnitBuilderBotModule@rush:
+		RequiresCondition: enable-rush-ai
+		UnitsToBuild:
+			e1: 65
+			e2: 15
+			e3: 30
+			e4: 15
+			dog: 15
+			shok: 15
+			harv: 10
+			apc: 30
+			jeep: 20
+			arty: 15
+			v2rl: 40
+			ftrk: 30
+			1tnk: 50
+			2tnk: 50
+			3tnk: 50
+			4tnk: 25
+			ttnk: 25
+			stnk: 5
+		UnitLimits:
+			dog: 4
+			harv: 8
+			jeep: 4
+			ftrk: 4
+	SquadManagerBotModule@turtle:
+		RequiresCondition: enable-turtle-ai
+		SquadSize: 10
+		ExcludeFromSquadsTypes: harv, mcv, dog
+		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
+		ConstructionYardTypes: fact
+		NavalProductionTypes: spen,syrd
+	UnitBuilderBotModule@turtle:
+		RequiresCondition: enable-turtle-ai
+		UnitsToBuild:
+			e1: 65
+			e2: 15
+			e3: 30
+			e4: 15
+			dog: 15
+			shok: 15
+			harv: 15
+			apc: 30
+			jeep: 20
+			arty: 15
+			v2rl: 40
+			ftrk: 50
+			1tnk: 50
+			2tnk: 50
+			3tnk: 50
+			4tnk: 25
+			ttnk: 25
+			stnk: 10
+			heli: 30
+			mh60: 30
+			mig: 30
+			yak: 30
+			ss: 10
+			msub: 10
+			dd: 10
+			ca: 10
+			pt: 10
+		UnitLimits:
+			dog: 4
+			harv: 8
+			jeep: 4
+			ftrk: 4
 	SquadManagerBotModule@easy:
 		RequiresCondition: enable-easy-ai
 		SquadSize: 2
@@ -751,7 +924,7 @@ Player:
 			ca: 20
 			pt: 10
 		UnitLimits:
-			harv: 10
+			harv: 8
 	CaptureManagerBotModule@AIEasy:
 		RequiresCondition: enable-easy-ai
 		CapturingActorTypes: e6

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -825,7 +825,7 @@ Player:
 		UnitLimits:
 			dog: 4
 			e6: 4
-			harv: 8
+			harv: 10
 			jeep: 8
 			ftrk: 6
 			apc: 8
@@ -888,7 +888,7 @@ Player:
 		UnitLimits:
 			dog: 4
 			e6: 4
-			harv: 8
+			harv: 10
 			jeep: 8
 			ftrk: 6
 			apc: 8

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -119,7 +119,7 @@ Player:
 	HarvesterBotModule:
 		RequiresCondition: enable-rush-ai || enable-easy-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai || enable-hard-ai || enable-brutal-ai
 		HarvesterTypes: harv
-		HarvestersPerRefinery: 2
+		HarvestersPerRefinery: 3
 		RefineryTypes: proc
 	BaseBuilderBotModule@rush:
 		RequiresCondition: enable-rush-ai
@@ -585,7 +585,7 @@ Player:
 			e4: 15
 			dog: 15
 			shok: 15
-			harv: 10
+			harv: 12
 			apc: 30
 			jeep: 20
 			arty: 15
@@ -599,7 +599,7 @@ Player:
 			stnk: 5
 		UnitLimits:
 			dog: 4
-			harv: 8
+			harv: 12
 			jeep: 4
 			ftrk: 4
 	SquadManagerBotModule@turtle:
@@ -641,7 +641,7 @@ Player:
 			pt: 10
 		UnitLimits:
 			dog: 4
-			harv: 8
+			harv: 12
 			jeep: 4
 			ftrk: 4
 	SquadManagerBotModule@easy:
@@ -766,7 +766,7 @@ Player:
 			dog: 4
 			e6: 4
 			e7: 1
-			harv: 10
+			harv: 12
 			jeep: 8
 			ftrk: 6
 			apc: 8
@@ -832,7 +832,7 @@ Player:
 			dog: 4
 			e6: 4
 			e7: 1
-			harv: 10
+			harv: 12
 			jeep: 8
 			ftrk: 6
 			apc: 8
@@ -898,7 +898,7 @@ Player:
 			dog: 4
 			e6: 4
 			e7: 1
-			harv: 10
+			harv: 12
 			jeep: 8
 			ftrk: 6
 			apc: 8
@@ -928,7 +928,7 @@ Player:
 			ca: 20
 			pt: 10
 		UnitLimits:
-			harv: 10
+			harv: 12
 	CaptureManagerBotModule@AIEasy:
 		RequiresCondition: enable-easy-ai
 		CapturingActorTypes: e6

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -493,7 +493,7 @@ Player:
 	BaseBuilderBotModule@naval:
 		RequiresCondition: enable-naval-ai
 		MinimumExcessPower: 60
-		MaximumExcessPower: 200
+		MaximumExcessPower: 300
 		ExcessPowerIncrement: 40
 		ExcessPowerIncreaseThreshold: 4
 		ConstructionYardTypes: fact
@@ -504,13 +504,14 @@ Player:
 		ProductionTypes: barr,tent,weap,afld,hpad,afld.ukraine
 		NavalProductionTypes: spen,syrd
 		SiloTypes: silo
+		PlaceDefenseTowardsEnemyChance: 0
 		BuildingLimits:
 			proc: 4
 			dome: 1
 			barr: 1
 			tent: 1
-			spen: 1
-			syrd: 1
+			spen: 2
+			syrd: 2
 			hpad: 8
 			afld: 8
 			afld.ukraine: 8
@@ -527,15 +528,15 @@ Player:
 			afld.ukraine: 20
 			atek: 1
 			stek: 1
-			spen: 1
-			syrd: 1
+			spen: 2
+			syrd: 2
 			fix: 1
-			pbox: 12
-			gun: 12
-			ftur: 12
-			tsla: 12
-			agun: 5
-			sam: 5
+			pbox: 18
+			gun: 18
+			ftur: 21
+			tsla: 15
+			agun: 10
+			sam: 10
 			mslo: 1
 	BuildingRepairBotModule:
 		RequiresCondition: enable-rush-ai || enable-easy-ai || enable-normal-ai || enable-turtle-ai || enable-naval-ai || enable-hard-ai || enable-brutal-ai
@@ -924,7 +925,7 @@ Player:
 			ca: 20
 			pt: 10
 		UnitLimits:
-			harv: 8
+			harv: 10
 	CaptureManagerBotModule@AIEasy:
 		RequiresCondition: enable-easy-ai
 		CapturingActorTypes: e6

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -236,7 +236,7 @@ Player:
 		StructureProductionActiveDelay: 240
 		NewProductionCashThreshold: 7500
 		BuildingLimits:
-			proc: 3
+			proc: 2
 			barr: 1
 			tent: 1
 			dome: 1
@@ -665,7 +665,7 @@ Player:
 	UnitBuilderBotModule@easy:
 		RequiresCondition: enable-easy-ai
 		IdleBaseUnitsMaximum: 20
-		UnitBuilderInterval: 200
+		UnitBuilderInterval: 400
 		UnitsToBuild:
 			e1: 5
 			e2: 15

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -667,6 +667,7 @@ Player:
 		RequiresCondition: enable-easy-ai
 		IdleBaseUnitsMaximum: 20
 		UnitBuilderInterval: 400
+		UnitBuilderMinCredits: 1000
 		UnitsToBuild:
 			e1: 5
 			e2: 15
@@ -730,7 +731,7 @@ Player:
 	UnitBuilderBotModule@normal:
 		RequiresCondition: enable-normal-ai
 		IdleBaseUnitsMaximum: 45
-		UnitBuilderInterval: 100
+		UnitBuilderMinCredits: 450
 		UnitsToBuild:
 			e1: 5
 			e2: 15
@@ -796,6 +797,7 @@ Player:
 	UnitBuilderBotModule@hard:
 		RequiresCondition: enable-hard-ai
 		IdleBaseUnitsMaximum: 60
+		UnitBuilderMinCredits: 2000
 		UnitsToBuild:
 			e1: 5
 			e2: 15
@@ -861,6 +863,7 @@ Player:
 	UnitBuilderBotModule@brutal:
 		RequiresCondition: enable-brutal-ai
 		IdleBaseUnitsMaximum: 160
+		UnitBuilderMinCredits: 2000
 		UnitsToBuild:
 			e1: 5
 			e2: 15

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -448,7 +448,7 @@ Player:
 			tent: 4
 			dome: 1
 			weap: 4
-			spen: 2
+			spen: 0
 			syrd: 2
 			hpad: 4
 			afld: 4
@@ -645,8 +645,8 @@ Player:
 			ftrk: 4
 	SquadManagerBotModule@easy:
 		RequiresCondition: enable-easy-ai
-		SquadSize: 10
-		SquadSizeRandomBonus: 5
+		SquadSize: 2
+		SquadSizeRandomBonus: 0
 		ExcludeFromSquadsTypes: harv, mcv, dog, e6
 		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
 		ConstructionYardTypes: fact
@@ -661,7 +661,7 @@ Player:
 		AssignRolesInterval: 200
 		AttackForceInterval: 75
 		DangerScanRadius: 10
-		MinimumAttackForceDelay: 30
+		MinimumAttackForceDelay: 6000
 	UnitBuilderBotModule@easy:
 		RequiresCondition: enable-easy-ai
 		IdleBaseUnitsMaximum: 20
@@ -709,8 +709,8 @@ Player:
 			pt: 2
 	SquadManagerBotModule@normal:
 		RequiresCondition: enable-normal-ai
-		SquadSize: 30
-		SquadSizeRandomBonus: 15
+		SquadSize: 3
+		SquadSizeRandomBonus: 0
 		ExcludeFromSquadsTypes: harv, mcv, dog, e6
 		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
 		ConstructionYardTypes: fact
@@ -718,14 +718,14 @@ Player:
 		IdleScanRadius: 18
 		AttackScanRadius: 9
 		MaxBaseRadius: 16
-		RushInterval: 1200
+		RushInterval: 600
 		RushAttackScanRadius: 25
 		ProtectUnitScanRadius: 20
 		ProtectionScanRadius: 10
 		AssignRolesInterval: 50
 		AttackForceInterval: 75
 		DangerScanRadius: 10
-		MinimumAttackForceDelay: 30
+		MinimumAttackForceDelay: 6000
 	UnitBuilderBotModule@normal:
 		RequiresCondition: enable-normal-ai
 		IdleBaseUnitsMaximum: 45
@@ -775,8 +775,8 @@ Player:
 			pt: 3
 	SquadManagerBotModule@hard:
 		RequiresCondition: enable-hard-ai
-		SquadSize: 50
-		SquadSizeRandomBonus: 25
+		SquadSize: 3
+		SquadSizeRandomBonus: 0
 		ExcludeFromSquadsTypes: harv, mcv, dog, e6
 		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
 		ConstructionYardTypes: fact
@@ -784,14 +784,14 @@ Player:
 		IdleScanRadius: 18
 		AttackScanRadius: 9
 		MaxBaseRadius: 16
-		RushInterval: 1200
+		RushInterval: 600
 		RushAttackScanRadius: 25
 		ProtectUnitScanRadius: 24
 		ProtectionScanRadius: 10
 		AssignRolesInterval: 50
 		AttackForceInterval: 75
 		DangerScanRadius: 10
-		MinimumAttackForceDelay: 30
+		MinimumAttackForceDelay: 6000
 	UnitBuilderBotModule@hard:
 		RequiresCondition: enable-hard-ai
 		IdleBaseUnitsMaximum: 60
@@ -840,8 +840,8 @@ Player:
 			pt: 3
 	SquadManagerBotModule@brutal:
 		RequiresCondition: enable-brutal-ai
-		SquadSize: 70
-		SquadSizeRandomBonus: 30
+		SquadSize: 3
+		SquadSizeRandomBonus: 0
 		ExcludeFromSquadsTypes: harv, mcv, dog, e6
 		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
 		ConstructionYardTypes: fact
@@ -849,14 +849,14 @@ Player:
 		IdleScanRadius: 18
 		AttackScanRadius: 9
 		MaxBaseRadius: 16
-		RushInterval: 1200
+		RushInterval: 600
 		RushAttackScanRadius: 25
 		ProtectUnitScanRadius: 28
 		ProtectionScanRadius: 10
 		AssignRolesInterval: 50
 		AttackForceInterval: 75
 		DangerScanRadius: 10
-		MinimumAttackForceDelay: 30
+		MinimumAttackForceDelay: 6000
 	UnitBuilderBotModule@brutal:
 		RequiresCondition: enable-brutal-ai
 		IdleBaseUnitsMaximum: 160

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -448,7 +448,7 @@ Player:
 			tent: 4
 			dome: 1
 			weap: 4
-			spen: 0
+			spen: 2
 			syrd: 2
 			hpad: 4
 			afld: 4

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -330,7 +330,7 @@ Player:
 			syrd: 6500
 			spen: 6500
 		BuildingFractions:
-			proc: 8
+			proc: 10
 			tent: 2
 			barr: 2
 			kenn: 0
@@ -667,7 +667,7 @@ Player:
 		RequiresCondition: enable-easy-ai
 		IdleBaseUnitsMaximum: 20
 		UnitBuilderInterval: 400
-		UnitBuilderMinCredits: 1000
+		UnitBuilderMinCredits: 900
 		UnitsToBuild:
 			e1: 5
 			e2: 15
@@ -731,7 +731,7 @@ Player:
 	UnitBuilderBotModule@normal:
 		RequiresCondition: enable-normal-ai
 		IdleBaseUnitsMaximum: 45
-		UnitBuilderMinCredits: 450
+		UnitBuilderMinCredits: 900
 		UnitsToBuild:
 			e1: 5
 			e2: 15

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -236,7 +236,7 @@ Player:
 		StructureProductionActiveDelay: 240
 		NewProductionCashThreshold: 7500
 		BuildingLimits:
-			proc: 2
+			proc: 3
 			barr: 1
 			tent: 1
 			dome: 1

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -797,7 +797,7 @@ Player:
 	UnitBuilderBotModule@hard:
 		RequiresCondition: enable-hard-ai
 		IdleBaseUnitsMaximum: 60
-		UnitBuilderMinCredits: 2000
+		UnitBuilderMinCredits: 1350
 		UnitsToBuild:
 			e1: 5
 			e2: 15
@@ -863,7 +863,7 @@ Player:
 	UnitBuilderBotModule@brutal:
 		RequiresCondition: enable-brutal-ai
 		IdleBaseUnitsMaximum: 160
-		UnitBuilderMinCredits: 2000
+		UnitBuilderMinCredits: 1800
 		UnitsToBuild:
 			e1: 5
 			e2: 15

--- a/mods/ra/rules/ai.yaml
+++ b/mods/ra/rules/ai.yaml
@@ -773,8 +773,8 @@ Player:
 			pt: 3
 	SquadManagerBotModule@hard:
 		RequiresCondition: enable-hard-ai
-		SquadSize: 40
-		SquadSizeRandomBonus: 20
+		SquadSize: 50
+		SquadSizeRandomBonus: 25
 		ExcludeFromSquadsTypes: harv, mcv, dog, e6
 		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
 		ConstructionYardTypes: fact
@@ -836,8 +836,8 @@ Player:
 			pt: 3
 	SquadManagerBotModule@brutal:
 		RequiresCondition: enable-brutal-ai
-		SquadSize: 60
-		SquadSizeRandomBonus: 20
+		SquadSize: 70
+		SquadSizeRandomBonus: 30
 		ExcludeFromSquadsTypes: harv, mcv, dog, e6
 		NavalUnitsTypes: ss,msub,dd,ca,lst,pt
 		ConstructionYardTypes: fact

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -51,7 +51,6 @@ SS:
 	SelectionDecorations:
 	AutoTarget:
 		InitialStance: HoldFire
-		InitialStanceAI: ReturnFire
 	AutoTargetPriority@DEFAULT:
 		ValidTargets: Water, Underwater
 	AutoTargetPriority@ATTACKANYTHING:
@@ -126,7 +125,6 @@ MSUB:
 	SelectionDecorations:
 	AutoTarget:
 		InitialStance: HoldFire
-		InitialStanceAI: ReturnFire
 	DetectCloaked:
 		CloakTypes: Underwater
 		Range: 4c0

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1209,7 +1209,7 @@ PROC:
 		DecorationBounds: 72,70,0,-2
 	SelectionDecorations:
 	Targetable:
-		TargetTypes: Ground, Structure, C4, DetonateAttack, ThiefInfiltrate, SpyInfiltrate
+		TargetTypes: Ground, Structure, C4, DetonateAttack, ThiefInfiltrate, SpyInfiltrate, Refinery
 	Health:
 		HP: 90000
 	Armor:
@@ -1264,6 +1264,24 @@ PROC:
 	SequencePlaceBuildingPreview:
 		Sequence: idle
 		SequencePalette: placebuilding
+	GrantConditionOnBotOwner@AICheaterHard:
+		Condition: AICheaterHard
+		Bots: hard
+	GrantConditionOnBotOwner@AICheaterBrutal:
+		Condition: AICheaterBrutal
+		Bots: brutal
+	CashTrickler@Hard:
+		Amount: 100
+		Interval: 100
+		RequiresCondition: AICheaterHard
+		ShowTicks: false
+		UseResourceStorage: true
+	CashTrickler@Brutal:
+		Amount: 200
+		Interval: 100
+		RequiresCondition: AICheaterBrutal
+		ShowTicks: false
+		UseResourceStorage: true
 
 SILO:
 	Inherits: ^Building

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -337,6 +337,8 @@ HARV:
 	WithHarvesterSpriteBody:
 		ImageByFullness: harvempty, harvhalf, harv
 	-WithFacingSpriteBody:
+	Targetable:
+		TargetTypes: Ground, Vehicle, Harvester
 
 MCV:
 	Inherits: ^Vehicle


### PR DESCRIPTION
Prototype of new Easy, Normal, Hard, and Brutal AIs. This includes several fixes the the bot modules to reduce the glitchy behavior.
-Added new targeting code to select the nearest building for attack move rather than nearest unit which is often an aircraft or harvester. If no buildings exist it will revert to selecting the nearest unit.
-Remove the regrouping code from naval squads as many maps have the water around the border which means that the leader unit may technically closer to the base its actual has a further distance to travel so the squad endlessly drives back towards it.
-Fix the repairbot module to repair buildings if they have any damage rather than waiting for them to be below 75%.
-Hard and brutal AI bots will build a second MCV to expand their base area so that they don't run out of room.
-Change default AI stance on subs to be default (defend) instead of return fire. Player stance is unchanged.
-Add in slight money trickles for hard and brutal AI. This is tied to the refineries and uses the resource storage.

This resolves issue #16126 for the RA mod. 

Some features of this rely on PR's #17309 #17236 #17276 #17298. It will function without those but the intended behavior includes those PRs. 