### PR TITLE
Increase default HeuristicWeightPercentage

### DIFF
--- a/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
+++ b/OpenRA.Mods.Common/Pathfinder/PathSearch.cs
@@ -72,8 +72,8 @@ namespace OpenRA.Mods.Common.Pathfinder
 			// e.g. a weight of 110% will find a path no more than 10% longer than the shortest possible.
 			// The benefit of allowing the search to return suboptimal paths is faster computation time.
 			// The search can skip some areas of the search space, meaning it has less work to do.
-			// We allow paths up to 25% longer than the shortest, optimal path, to improve pathfinding time.
-			search.heuristicWeightPercentage = 125;
+			// We allow paths up to 75% longer than the shortest, optimal path, to improve pathfinding time.
+			search.heuristicWeightPercentage = 175;
 
 			search.isGoal = loc =>
 			{


### PR DESCRIPTION
By increasing the maximum path length allowed by A* weight, we can cut the average number of considered nodes to significantly less than half (according to #17274) compared to the old default of 125%, reducing the average performance hit of the pathfinder.

My own, unprofessional testing with perf graph on shows a small, but visible reduction of the initial spike in RA on Jungle Law when giving a larger number of idle actors a move order over a longer distance, and a _considerable_ reduction (I estimate about 1/3) with just Heavy GDI starting units in TS on A River Runs Near It.

Originally I wanted to propose a value of 150%, however I didn't notice a significant quality difference in chosen paths between 150% and 175%, so I decided to give the latter a chance.
In fact, paths didn't look bad even with a value of 200%, but going by the numbers in #17274 the returns would be diminishing, so I refrained from going that far.

Feel free to test with values of 150% and 200% as well though, if you have the time.

Note: #17274 and #17281 both have rebase conflicts with prep, which I've already fixed locally. I'll file them along with the changes here against a prep-2001 directly, if we decide to go ahead with the bugfix/perf release after Next.