### PR TITLE
Fix some header dates

### DIFF
--- a/OpenRA.Mods.Common/Traits/AppearsOnMapPreview.cs
+++ b/OpenRA.Mods.Common/Traits/AppearsOnMapPreview.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20181215/RemoveAttackSuicides.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20181215/RemoveAttackSuicides.cs
@@ -1,6 +1,6 @@
 ﻿#region Copyright & License Information
 /*
- * Copyright 2007-2018 The OpenRA Developers (see AUTHORS)
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
  * available to you under the terms of the GNU General Public License
  * as published by the Free Software Foundation, either version 3 of


### PR DESCRIPTION
Seems these were overlooked or merged after the dates of the other files were updated.

Not much of a point this close to the new year, but it bugged me.
A +1 is certainly enough, doesn't need a changelog entry, either.