### PR TITLE
Move Westwood file formats to Mods.Cnc/D2k

### DIFF
--- a/OpenRA.Mods.Cnc/AudioLoaders/AudLoader.cs
+++ b/OpenRA.Mods.Cnc/AudioLoaders/AudLoader.cs
@@ -11,9 +11,9 @@
 
 using System;
 using System.IO;
-using OpenRA.Mods.Common.FileFormats;
+using OpenRA.Mods.Cnc.FileFormats;
 
-namespace OpenRA.Mods.Common.AudioLoaders
+namespace OpenRA.Mods.Cnc.AudioLoaders
 {
 	public class AudLoader : ISoundLoader
 	{

--- a/OpenRA.Mods.Cnc/FileFormats/AudReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/AudReader.cs
@@ -14,7 +14,7 @@ using System.Collections.Generic;
 using System.IO;
 using OpenRA.Primitives;
 
-namespace OpenRA.Mods.Common.FileFormats
+namespace OpenRA.Mods.Cnc.FileFormats
 {
 	[Flags]
 	enum SoundFlags

--- a/OpenRA.Mods.Cnc/FileFormats/LCWCompression.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/LCWCompression.cs
@@ -11,8 +11,9 @@
 
 using System;
 using System.IO;
+using OpenRA.Mods.Common.FileFormats;
 
-namespace OpenRA.Mods.Common.FileFormats
+namespace OpenRA.Mods.Cnc.FileFormats
 {
 	// Lempel - Castle - Welch algorithm (aka Format80)
 	public static class LCWCompression

--- a/OpenRA.Mods.Cnc/FileFormats/VqaReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/VqaReader.cs
@@ -11,8 +11,9 @@
 
 using System;
 using System.IO;
+using OpenRA.Mods.Common.FileFormats;
 
-namespace OpenRA.Mods.Common.FileFormats
+namespace OpenRA.Mods.Cnc.FileFormats
 {
 	public class VqaReader
 	{

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpD2Loader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpD2Loader.cs
@@ -12,6 +12,7 @@
 using System;
 using System.IO;
 using OpenRA.Graphics;
+using OpenRA.Mods.Cnc.FileFormats;
 using OpenRA.Mods.Common.FileFormats;
 using OpenRA.Primitives;
 

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertLegacyMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertLegacyMapCommand.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using OpenRA.Mods.Cnc.FileFormats;
 using OpenRA.Mods.Common.FileFormats;
 using OpenRA.Mods.Common.UtilityCommands;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -176,15 +176,9 @@ namespace OpenRA.Mods.Common.Scripting
 				return false;
 			}
 
-			AsyncLoader l = new AsyncLoader(Media.LoadVqa);
-			IAsyncResult ar = l.BeginInvoke(s, null, null);
-			Action onLoadComplete = () =>
-			{
-				Media.StopFMVInRadar();
-				world.AddFrameEndTask(_ => Media.PlayFMVInRadar(world, l.EndInvoke(ar), onCompleteRadar));
-			};
+			Media.StopFMVInRadar();
+			world.AddFrameEndTask(_ => Media.PlayFMVInRadar(world, movie, onCompleteRadar));
 
-			world.AddFrameEndTask(w => w.Add(new AsyncAction(ar, onLoadComplete)));
 			return true;
 		}
 
@@ -225,7 +219,5 @@ namespace OpenRA.Mods.Common.Scripting
 			var c = color.HasValue ? color.Value : Color.White;
 			world.AddFrameEndTask(w => w.Add(new FloatingText(position, c, text, duration)));
 		}
-
-		public delegate VqaReader AsyncLoader(Stream s);
 	}
 }

--- a/OpenRA.Mods.Common/Scripting/Media.cs
+++ b/OpenRA.Mods.Common/Scripting/Media.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Scripting
 		public static void PlayFMVFullscreen(World w, string movie, Action onComplete)
 		{
 			var playerRoot = Game.OpenWindow(w, "FMVPLAYER");
-			var player = playerRoot.Get<VqaPlayerWidget>("PLAYER");
+			var player = playerRoot.Get<VideoPlayerWidget>("PLAYER");
 
 			try
 			{
@@ -60,10 +60,10 @@ namespace OpenRA.Mods.Common.Scripting
 			});
 		}
 
-		public static void PlayFMVInRadar(World w, VqaReader movie, Action onComplete)
+		public static void PlayFMVInRadar(World w, string movie, Action onComplete)
 		{
-			var player = Ui.Root.Get<VqaPlayerWidget>("PLAYER");
-			player.Open(movie);
+			var player = Ui.Root.Get<VideoPlayerWidget>("PLAYER");
+			player.Load(movie);
 
 			player.PlayThen(() =>
 			{
@@ -74,13 +74,8 @@ namespace OpenRA.Mods.Common.Scripting
 
 		public static void StopFMVInRadar()
 		{
-			var player = Ui.Root.Get<VqaPlayerWidget>("PLAYER");
+			var player = Ui.Root.Get<VideoPlayerWidget>("PLAYER");
 			player.Stop();
-		}
-
-		public static VqaReader LoadVqa(Stream s)
-		{
-			return new VqaReader(s);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/AssetBrowserLogic.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		string currentFilename;
 		IReadOnlyPackage currentPackage;
 		Sprite[] currentSprites;
-		VqaPlayerWidget player = null;
+		VideoPlayerWidget player = null;
 		bool isVideoLoaded = false;
 		bool isLoadError = false;
 		int currentFrame;
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				spriteWidget.IsVisible = () => !isVideoLoaded && !isLoadError;
 			}
 
-			var playerWidget = panel.GetOrNull<VqaPlayerWidget>("PLAYER");
+			var playerWidget = panel.GetOrNull<VideoPlayerWidget>("PLAYER");
 			if (playerWidget != null)
 				playerWidget.IsVisible = () => isVideoLoaded && !isLoadError;
 
@@ -122,7 +122,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var frameContainer = panel.GetOrNull("FRAME_SELECTOR");
 			if (frameContainer != null)
 				frameContainer.IsVisible = () => (currentSprites != null && currentSprites.Length > 1) ||
-					(isVideoLoaded && player != null && player.Video != null && player.Video.Frames > 1);
+					(isVideoLoaded && player != null && player.VideoFrameCount > 1);
 
 			frameSlider = panel.Get<SliderWidget>("FRAME_SLIDER");
 			if (frameSlider != null)
@@ -133,7 +133,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						currentFrame = (int)Math.Round(x);
 				};
 
-				frameSlider.GetValue = () => isVideoLoaded ? player.Video.CurrentFrame : currentFrame;
+				frameSlider.GetValue = () => isVideoLoaded ? player.VideoCurrentFrame : currentFrame;
 				frameSlider.IsDisabled = () => isVideoLoaded;
 			}
 
@@ -142,7 +142,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				frameText.GetText = () =>
 					isVideoLoaded ?
-					"{0} / {1}".F(player.Video.CurrentFrame + 1, player.Video.Frames) :
+					"{0} / {1}".F(player.VideoCurrentFrame + 1, player.VideoFrameCount) :
 					"{0} / {1}".F(currentFrame, currentSprites.Length - 1);
 			}
 
@@ -337,11 +337,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				if (Path.GetExtension(filename.ToLowerInvariant()) == ".vqa")
 				{
-					player = panel.Get<VqaPlayerWidget>("PLAYER");
+					player = panel.Get<VideoPlayerWidget>("PLAYER");
 					player.Load(prefix + filename);
 					player.DrawOverlay = false;
 					isVideoLoaded = true;
-					frameSlider.MaximumValue = (float)player.Video.Frames - 1;
+					frameSlider.MaximumValue = (float)player.VideoFrameCount - 1;
 					frameSlider.Ticks = 0;
 					return true;
 				}

--- a/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MissionBrowserLogic.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly ButtonWidget stopBriefingVideoButton;
 		readonly ButtonWidget startInfoVideoButton;
 		readonly ButtonWidget stopInfoVideoButton;
-		readonly VqaPlayerWidget videoPlayer;
+		readonly VideoPlayerWidget videoPlayer;
 		readonly BackgroundWidget fullscreenVideoPlayer;
 
 		readonly ScrollPanelWidget missionList;
@@ -71,7 +71,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			previewWidget.Preview = () => selectedMap;
 			previewWidget.IsVisible = () => playingVideo == PlayingVideo.None;
 
-			videoPlayer = widget.Get<VqaPlayerWidget>("MISSION_VIDEO");
+			videoPlayer = widget.Get<VideoPlayerWidget>("MISSION_VIDEO");
 			widget.Get("MISSION_BIN").IsVisible = () => playingVideo != PlayingVideo.None;
 			fullscreenVideoPlayer = Ui.LoadWidget<BackgroundWidget>("FULLSCREEN_PLAYER", Ui.Root, new WidgetArgs { { "world", world } });
 
@@ -326,7 +326,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				Game.Sound.MusicVolume = cachedMusicVolume;
 		}
 
-		void PlayVideo(VqaPlayerWidget player, string video, PlayingVideo pv, Action onComplete = null)
+		void PlayVideo(VideoPlayerWidget player, string video, PlayingVideo pv, Action onComplete = null)
 		{
 			if (!modData.DefaultFileSystem.Exists(video))
 			{
@@ -356,7 +356,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 		}
 
-		void StopVideo(VqaPlayerWidget player)
+		void StopVideo(VideoPlayerWidget player)
 		{
 			if (playingVideo == PlayingVideo.None)
 				return;
@@ -383,7 +383,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var missionData = selectedMap.Rules.Actors["world"].TraitInfoOrDefault<MissionDataInfo>();
 			if (missionData != null && missionData.StartVideo != null && modData.DefaultFileSystem.Exists(missionData.StartVideo))
 			{
-				var fsPlayer = fullscreenVideoPlayer.Get<VqaPlayerWidget>("PLAYER");
+				var fsPlayer = fullscreenVideoPlayer.Get<VideoPlayerWidget>("PLAYER");
 				fullscreenVideoPlayer.Visible = true;
 				PlayVideo(fsPlayer, missionData.StartVideo, PlayingVideo.GameStart, () =>
 				{

--- a/OpenRA.Mods.Common/Widgets/VideoPlayerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/VideoPlayerWidget.cs
@@ -1,0 +1,98 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.FileFormats;
+using OpenRA.Primitives;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets
+{
+	// This is a base/placeholder class
+	public class VideoPlayerWidget : Widget
+	{
+		public Hotkey CancelKey = new Hotkey(Keycode.ESCAPE, Modifiers.None);
+		public float AspectRatio = 1.2f;
+		public bool DrawOverlay = true;
+		public bool Skippable = true;
+
+		public bool Paused { get { return paused; } }
+		public virtual int VideoFrameCount { get { return 0; } }
+		public virtual int VideoCurrentFrame { get { return 0; } }
+
+		string cachedVideo;
+		bool stopped;
+		bool paused;
+
+		public virtual void Load(string filename)
+		{
+			if (filename == cachedVideo)
+				return;
+
+			cachedVideo = filename;
+
+			stopped = true;
+			paused = true;
+			Game.Sound.StopVideo();
+		}
+
+		public override bool HandleKeyPress(KeyInput e)
+		{
+			if (Hotkey.FromKeyInput(e) != CancelKey || e.Event != KeyInputEvent.Down || !Skippable)
+				return false;
+
+			Stop();
+			return true;
+		}
+
+		public override bool HandleMouseInput(MouseInput mi)
+		{
+			return RenderBounds.Contains(mi.Location) && Skippable;
+		}
+
+		public override string GetCursor(int2 pos)
+		{
+			return null;
+		}
+
+		public virtual void Play()
+		{
+			PlayThen(() => { });
+		}
+
+		public virtual void PlayThen(Action after) { }
+
+		public virtual void Pause()
+		{
+			if (stopped || paused)
+				return;
+
+			paused = true;
+			Game.Sound.PauseVideo();
+		}
+
+		public virtual void Stop()
+		{
+			if (stopped)
+				return;
+
+			stopped = true;
+			paused = true;
+			Game.Sound.StopVideo();
+		}
+
+		public virtual void CloseVideo()
+		{
+			Stop();
+		}
+	}
+}


### PR DESCRIPTION
This PR moves all remaining proprietary WW file formats to the Westwood-specific mod code, except (for now) ShpTS, due to its non-proprietary RLEZeros encoding and good community tool support.

The idea is to make it unnecessary for potential downstream commercial games to rip stuff out of Mods.Common out of legal concerns.

Note: The VQA changes are actually still somewhat WIP, as playing FMV in radar is untested (potentially broken) and playing in Asset Browser is broken (not sure why).
Help would be appreciated.

Closes #12775.