### PR TITLE
Fix RA desert tree fire palette

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
@@ -29,6 +29,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[SequenceReference("Image")]
 		public readonly string EndSequence = "end";
 
+		[PaletteReference("IsPlayerPalette")]
+		[Desc("Custom palette name.")]
+		public readonly string Palette = null;
+
+		[Desc("Custom palette is a player palette BaseName.")]
+		public readonly bool IsPlayerPalette = false;
+
 		[Desc("Damage types that this should be used for (defined on the warheads).",
 			"Leave empty to disable all filtering.")]
 		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
@@ -54,7 +61,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 			var rs = self.Trait<RenderSprites>();
 
 			anim = new Animation(self.World, info.Image);
-			rs.Add(new AnimationWithOffset(anim, null, () => !isSmoking));
+			rs.Add(new AnimationWithOffset(anim, null, () => !isSmoking),
+				info.Palette, info.IsPlayerPalette);
 		}
 
 		void INotifyDamage.Damaged(Actor self, AttackInfo e)

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -928,16 +928,19 @@
 	WithDamageOverlay@SmallBurn:
 		DamageTypes: Incendiary
 		Image: burn-s
+		Palette: effect
 		MinimumDamageState: Light
 		MaximumDamageState: Medium
 	WithDamageOverlay@MediumBurn:
 		DamageTypes: Incendiary
 		Image: burn-m
+		Palette: effect
 		MinimumDamageState: Medium
 		MaximumDamageState: Heavy
 	WithDamageOverlay@LargeBurn:
 		DamageTypes: Incendiary
 		Image: burn-l
+		Palette: effect
 		MinimumDamageState: Heavy
 		MaximumDamageState: Dead
 	HiddenUnderShroud:


### PR DESCRIPTION
By default, `WithDamageOverlay` uses the actors' palette, but RA's desert terrain uses the TD desert.pal, which isn't compatible with RA's fire animation shps.

Fixes #17367.