### PR TITLE
Allow to load paletted image in ChromeProvider, using SpriteLoaders and IPalette

### DIFF
--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -58,6 +58,16 @@ namespace OpenRA.Graphics
 			ReleaseBuffer();
 		}
 
+		public Sheet(SheetType type, ISpriteFrame frame, IPalette palette)
+		{
+			Size = new Size(frame.FrameSize.Width, frame.FrameSize.Height).NextPowerOf2();
+			data = new byte[4 * Size.Width * Size.Height];
+			Util.FastCopyIntoSprite(new Sprite(this, new Rectangle(0, 0, Size.Width, Size.Height), TextureChannel.Red), frame, palette);
+
+			Type = type;
+			ReleaseBuffer();
+		}
+
 		public ITexture GetTexture()
 		{
 			if (texture == null)

--- a/OpenRA.Game/Graphics/Util.cs
+++ b/OpenRA.Game/Graphics/Util.cs
@@ -121,6 +121,35 @@ namespace OpenRA.Graphics
 			}
 		}
 
+		public static void FastCopyIntoSprite(Sprite dest, ISpriteFrame src, IPalette palette)
+		{
+			var destData = dest.Sheet.GetData();
+			var destStride = dest.Sheet.Size.Width;
+			var width = src.FrameSize.Width;
+			var height = src.FrameSize.Height;
+
+			unsafe
+			{
+				// Cast the data to an int array so we can copy the src data directly
+				fixed (byte* bd = &destData[0])
+				{
+					var data = (int*)bd;
+					var x = dest.Bounds.Left;
+					var y = dest.Bounds.Top;
+
+					var k = 0;
+					for (var j = 0; j < height; j++)
+					{
+						for (var i = 0; i < width; i++)
+						{
+							Color cc = Color.FromArgb(palette[src.Data[k++]]);
+							data[(y + j) * destStride + x + i] = PremultiplyAlpha(cc).ToArgb();
+						}
+					}
+				}
+			}
+		}
+
 		public static Color PremultiplyAlpha(Color c)
 		{
 			if (c.A == byte.MaxValue)


### PR DESCRIPTION
This Pull Request is needed for d2 mod (for https://github.com/OpenRA/d2/issues/149 )
d2 mod can’t just convert existing CPS files to PNG because CPS files is copyrighted.
CPS files is paletted and can be loaded using corresponding SpriteLoader and Palette.

This PR already used in d2 mod in draw-slices branch, and can be tested using it:  https://github.com/evgeniysergeev/d2/tree/draw-slices.
It is used to draw topbar and vertical line using player color on this screenshot:

![d2-topbar](https://user-images.githubusercontent.com/3105609/69538329-19761680-0f93-11ea-9394-cf133e7896fc.PNG)

