### PR TITLE
Fix team chat messages not always being displayed

### DIFF
--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -88,14 +88,12 @@ namespace OpenRA.Network
 							break;
 						}
 
-						if (orderManager.LocalClient == null)
-							break;
-
 						var player = world.FindPlayerByClient(client);
-						var localClientIsObserver = orderManager.LocalClient.IsObserver || (world.LocalPlayer != null && world.LocalPlayer.WinState != WinState.Undefined);
+						var localClientIsObserver = world.IsReplay || (orderManager.LocalClient != null && orderManager.LocalClient.IsObserver)
+							|| (world.LocalPlayer != null && world.LocalPlayer.WinState != WinState.Undefined);
 
 						// ExtraData gives us the team number, uint.MaxValue means Spectators
-						if (order.ExtraData == uint.MaxValue && (localClientIsObserver || world.IsReplay))
+						if (order.ExtraData == uint.MaxValue && localClientIsObserver)
 						{
 							// Validate before adding the line
 							if (client.IsObserver || (player != null && player.WinState != WinState.Undefined))
@@ -105,8 +103,8 @@ namespace OpenRA.Network
 						}
 
 						var valid = client.Team == order.ExtraData && player != null && player.WinState == WinState.Undefined;
-						var isSameTeam = order.ExtraData == orderManager.LocalClient.Team && world.LocalPlayer != null
-							&& world.LocalPlayer.WinState == WinState.Undefined;
+						var isSameTeam = orderManager.LocalClient != null && order.ExtraData == orderManager.LocalClient.Team
+							&& world.LocalPlayer != null && world.LocalPlayer.WinState == WinState.Undefined;
 
 						if (valid && (isSameTeam || world.IsReplay))
 							Game.AddChatLine("[Team" + (world.IsReplay ? " " + order.ExtraData : "") + "] " + client.Name, client.Color, message);


### PR DESCRIPTION
Reported by Eskimo/Arbiter on Discord. Regression from #15615.

Apparently `OrderManager.LocalClient` is not always `null` in replay connections, only sometimes, namely when no client with ID 0 is present in the game (because of [this line in `ReplayConnection.cs`](https://github.com/OpenRA/OpenRA/blob/bfddfec461cd646a34243a35290f4f99b71c5175/OpenRA.Game/Network/ReplayConnection.cs#L33)). And during testing nobody noticed that it is not always guaranteed to be the first client (but can be null), since we most likely always had a client with ID 0 present.
It's probably best to use one of the replays posted on Discord to verify this bugfix (the changes should be compatible with the latest release and don't cause desyncs).

We circumvent this now by not (bogusly) bailing when `LocalClient` is `null`, but instead always explicitly checking for `null` and ignoring `LocalClient` when we are in a replay.