### PR TITLE
Default LocalClientId in ReplayConnection to -1

### DIFF
--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Network
 		int ordersFrame;
 		Dictionary<int, int> lastClientsFrame = new Dictionary<int, int>();
 
-		public int LocalClientId { get { return 0; } }
+		public int LocalClientId { get { return -1; } }
 		public ConnectionState ConnectionState { get { return ConnectionState.Connected; } }
 		public readonly int TickCount;
 		public readonly int FinalGameTick;


### PR DESCRIPTION
We do not have a local client in replays. This change prevents anything from accidentally using (sometimes there might be clients with ID 0 present), e.g. #17381.

I checked all uses of `LocalClientId` and this should be fine, but think it's better not to put this on the hotfix release.


