### PR TITLE
Improve performance of shroud updating.

### DIFF
--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -228,13 +228,11 @@ namespace OpenRA.Graphics
 				if (a.Actor.IsInWorld && !a.Actor.Disposed)
 					a.Trait.RenderAboveWorld(a.Actor, this);
 
-			var renderShroud = World.RenderPlayer != null ? World.RenderPlayer.Shroud : null;
-
 			if (enableDepthBuffer)
 				Game.Renderer.ClearDepthBuffer();
 
 			foreach (var a in World.ActorsWithTrait<IRenderShroud>())
-				a.Trait.RenderShroud(renderShroud, this);
+				a.Trait.RenderShroud(this);
 
 			if (enableDepthBuffer)
 				Game.Renderer.Context.DisableDepthBuffer();

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -410,7 +410,7 @@ namespace OpenRA.Traits
 	public interface INotifyIdle { void TickIdle(Actor self); }
 
 	public interface IRenderAboveWorld { void RenderAboveWorld(Actor self, WorldRenderer wr); }
-	public interface IRenderShroud { void RenderShroud(Shroud shroud, WorldRenderer wr); }
+	public interface IRenderShroud { void RenderShroud(WorldRenderer wr); }
 
 	[RequireExplicitImplementation]
 	public interface IRenderTerrain { void RenderTerrain(WorldRenderer wr, Viewport viewport); }

--- a/OpenRA.Mods.Common/Traits/AffectsShroud.cs
+++ b/OpenRA.Mods.Common/Traits/AffectsShroud.cs
@@ -32,7 +32,8 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly VisibilityType Type = VisibilityType.Footprint;
 	}
 
-	public abstract class AffectsShroud : ConditionalTrait<AffectsShroudInfo>, ITick, ISync, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyMoving
+	public abstract class AffectsShroud : ConditionalTrait<AffectsShroudInfo>, ISync, INotifyAddedToWorld,
+		INotifyRemovedFromWorld, INotifyMoving, INotifyVisualPositionChanged, ITick
 	{
 		static readonly PPos[] NoCells = { };
 
@@ -47,7 +48,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Sync]
 		protected bool CachedTraitDisabled { get; private set; }
 
-		bool dirty;
 		WPos cachedPos;
 
 		protected abstract void AddCellsToPlayerShroud(Actor self, Player player, PPos[] uv);
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Traits
 				.ToArray();
 		}
 
-		void ITick.Tick(Actor self)
+		void INotifyVisualPositionChanged.VisualPositionChanged(Actor self, byte oldLayer, byte newLayer)
 		{
 			if (!self.IsInWorld)
 				return;
@@ -94,22 +94,37 @@ namespace OpenRA.Mods.Common.Traits
 			var centerPosition = self.CenterPosition;
 			var projectedPos = centerPosition - new WVec(0, centerPosition.Z, centerPosition.Z);
 			var projectedLocation = self.World.Map.CellContaining(projectedPos);
-			var traitDisabled = IsTraitDisabled;
-			var range = Range;
 			var pos = self.CenterPosition;
 
-			if (Info.MoveRecalculationThreshold.Length > 0 && (pos - cachedPos).LengthSquared > Info.MoveRecalculationThreshold.LengthSquared)
-				dirty = true;
+			var dirty = Info.MoveRecalculationThreshold.Length > 0 && (pos - cachedPos).LengthSquared > Info.MoveRecalculationThreshold.LengthSquared;
+			if (!dirty && cachedLocation == projectedLocation)
+				return;
 
-			if (!dirty && cachedLocation == projectedLocation && cachedRange == range && traitDisabled == CachedTraitDisabled)
+			cachedLocation = projectedLocation;
+			cachedPos = pos;
+
+			UpdateShroudCells(self);
+		}
+
+		void ITick.Tick(Actor self)
+		{
+			if (!self.IsInWorld)
+				return;
+
+			var traitDisabled = IsTraitDisabled;
+			var range = Range;
+
+			if (cachedRange == range && traitDisabled == CachedTraitDisabled)
 				return;
 
 			cachedRange = range;
-			cachedLocation = projectedLocation;
 			CachedTraitDisabled = traitDisabled;
-			cachedPos = pos;
-			dirty = false;
 
+			UpdateShroudCells(self);
+		}
+
+		void UpdateShroudCells(Actor self)
+		{
 			var cells = ProjectedCells(self);
 			foreach (var p in self.World.Players)
 			{
@@ -123,6 +138,7 @@ namespace OpenRA.Mods.Common.Traits
 			var centerPosition = self.CenterPosition;
 			var projectedPos = centerPosition - new WVec(0, centerPosition.Z, centerPosition.Z);
 			cachedLocation = self.World.Map.CellContaining(projectedPos);
+			cachedPos = centerPosition;
 			CachedTraitDisabled = IsTraitDisabled;
 			var cells = ProjectedCells(self);
 
@@ -141,8 +157,18 @@ namespace OpenRA.Mods.Common.Traits
 		void INotifyMoving.MovementTypeChanged(Actor self, MovementType type)
 		{
 			// Recalculate the visiblity at our final stop position
-			if (type == MovementType.None)
-				dirty = true;
+			if (type == MovementType.None && self.IsInWorld)
+			{
+				var centerPosition = self.CenterPosition;
+				var projectedPos = centerPosition - new WVec(0, centerPosition.Z, centerPosition.Z);
+				var projectedLocation = self.World.Map.CellContaining(projectedPos);
+				var pos = self.CenterPosition;
+
+				cachedLocation = projectedLocation;
+				cachedPos = pos;
+
+				UpdateShroudCells(self);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #17377 
Fixes #16393

This improves the performance of shroud updating by only updating  each cell at most once per tick and getting rid of as much redundant memory allocations as possible. Especially operations like `HashSet.UnionWith` appear to be a major bottleneck. I tried to replace dynamic data structures with fixed-size data structures where reasonable (`CellLayer` in particular). I tried to reduce the number of operations in general by eliminating redundancies between `FrozenActorLayer`, `ShroudRenderer,` `RadarWidget` and `PlayerRadarTerrain`.

As a testcase I tried building 60 yaks on Pool Party: 
- On bleed framerate on my machine drops to 20 fps (down from 60 fps frame limited).
- If I set  `MoveRecalculationThreshold` to 0 (effectively reverting #16953) I get ~45 fps.
- On this PR I get 57&ndash;60 fps.
