### PR TITLE
Move VocLoader from D2k to Cnc

### DIFF
--- a/OpenRA.Mods.Cnc/AudioLoaders/VocLoader.cs
+++ b/OpenRA.Mods.Cnc/AudioLoaders/VocLoader.cs
@@ -15,7 +15,7 @@ using System.IO;
 using System.Linq;
 using OpenRA.Primitives;
 
-namespace OpenRA.Mods.D2k.AudioLoaders
+namespace OpenRA.Mods.Cnc.AudioLoaders
 {
 	public class VocLoader : ISoundLoader
 	{


### PR DESCRIPTION
As discussed in #17357, my assumption that the D2 mod would want, let alone need, to use Mods.D2k was wrong.
Meanwhile, it does need Mods.Cnc for at least the Pak format support as well, so this is a good enough compromise place for the `VocLoader`, allowing the D2 mod to skip Mods.D2k while keeping the VocLoader out of Mods.Common.