### PR TITLE
Restore old visibility recalc frequency (Prep Edition)

### DIFF
--- a/mods/cnc/rules/aircraft.yaml
+++ b/mods/cnc/rules/aircraft.yaml
@@ -21,6 +21,7 @@ TRAN:
 		Type: Light
 	RevealsShroud:
 		Range: 10c0
+		MoveRecalculationThreshold: 0
 		Type: GroundPosition
 	WithIdleOverlay@ROTOR1AIR:
 		Offset: 597,0,85
@@ -73,6 +74,7 @@ HELI:
 		Type: Light
 	RevealsShroud:
 		Range: 10c0
+		MoveRecalculationThreshold: 0
 		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: HeliAGGun
@@ -138,6 +140,7 @@ ORCA:
 		Type: Light
 	RevealsShroud:
 		Range: 10c0
+		MoveRecalculationThreshold: 0
 		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: OrcaAGMissiles
@@ -242,6 +245,7 @@ TRAN.Husk:
 		Speed: 140
 	RevealsShroud:
 		Range: 10c0
+		MoveRecalculationThreshold: 0
 		Type: GroundPosition
 	WithIdleOverlay@ROTOR1:
 		Offset: 597,0,85
@@ -261,6 +265,7 @@ HELI.Husk:
 		Speed: 186
 	RevealsShroud:
 		Range: 10c0
+		MoveRecalculationThreshold: 0
 		Type: GroundPosition
 	WithIdleOverlay:
 		Offset: 0,0,85
@@ -277,6 +282,7 @@ ORCA.Husk:
 		Speed: 186
 	RevealsShroud:
 		Range: 10c0
+		MoveRecalculationThreshold: 0
 		Type: GroundPosition
 	RenderSprites:
 		Image: orca

--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -58,10 +58,12 @@ carryall:
 		MinAirborneAltitude: 400
 	RevealsShroud@lifting_low:
 		Range: 2c512
+		MoveRecalculationThreshold: 0
 		Type: GroundPosition
 		RequiresCondition: !airborne
 	RevealsShroud@lifting_high:
 		Range: 1c256
+		MoveRecalculationThreshold: 0
 		Type: GroundPosition
 		RequiresCondition: !cruising
 	Buildable:

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -98,10 +98,12 @@ MIG:
 		HP: 7500
 	RevealsShroud:
 		Range: 13c0
+		MoveRecalculationThreshold: 0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 11c0
+		MoveRecalculationThreshold: 0
 		Type: GroundPosition
 	Armament:
 		Weapon: Maverick
@@ -162,10 +164,12 @@ YAK:
 		HP: 6000
 	RevealsShroud:
 		Range: 11c0
+		MoveRecalculationThreshold: 0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 9c0
+		MoveRecalculationThreshold: 0
 		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: ChainGun.Yak
@@ -230,10 +234,12 @@ TRAN:
 		HP: 14000
 	RevealsShroud:
 		Range: 8c0
+		MoveRecalculationThreshold: 0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 6c0
+		MoveRecalculationThreshold: 0
 		Type: GroundPosition
 	Aircraft:
 		TurnSpeed: 5
@@ -285,10 +291,12 @@ HELI:
 		HP: 12000
 	RevealsShroud:
 		Range: 12c0
+		MoveRecalculationThreshold: 0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 10c0
+		MoveRecalculationThreshold: 0
 		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: HellfireAA
@@ -350,10 +358,12 @@ HIND:
 		HP: 10000
 	RevealsShroud:
 		Range: 10c0
+		MoveRecalculationThreshold: 0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 8c0
+		MoveRecalculationThreshold: 0
 		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: ChainGun
@@ -450,10 +460,12 @@ MH60:
 		HP: 10000
 	RevealsShroud:
 		Range: 10c0
+		MoveRecalculationThreshold: 0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
 		Range: 8c0
+		MoveRecalculationThreshold: 0
 		Type: GroundPosition
 	Armament@PRIMARY:
 		Weapon: ChainGun


### PR DESCRIPTION
The increased recalc frequency has shown to cause serious performance issues with fast-moving units like aircraft.
Disabling it for aircraft in the hotfix release.

Filed directly against prep.

Fixes #17377 for prep.