### PR TITLE
Move ProductionAirdrop & WithDeliveryAnimation to Mods.Common

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
@@ -14,11 +14,10 @@ using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Activities;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.Cnc.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Deliver the unit in production via skylift.")]
 	public class ProductionAirdropInfo : ProductionInfo
@@ -26,9 +25,10 @@ namespace OpenRA.Mods.Cnc.Traits
 		[NotificationReference("Speech")]
 		public readonly string ReadyAudio = "Reinforce";
 
+		[FieldLoader.Require]
 		[ActorReference(typeof(AircraftInfo))]
 		[Desc("Cargo aircraft used for delivery. Must have the `Aircraft` trait.")]
-		public readonly string ActorType = "c17";
+		public readonly string ActorType = null;
 
 		[Desc("The cargo aircraft will spawn at the player baseline (map edge closest to the player spawn)")]
 		public readonly bool BaselineSpawn = false;

--- a/OpenRA.Mods.Common/Traits/Render/WithDeliveryAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeliveryAnimation.cs
@@ -11,10 +11,9 @@
 
 using System.Linq;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.Cnc.Traits.Render
+namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Building animation to play when ProductionAirdrop is used to deliver units.")]
 	public class WithDeliveryAnimationInfo : ConditionalTraitInfo, Requires<WithSpriteBodyInfo>

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20191117/RemoveAirdropActorTypeDefault.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20191117/RemoveAirdropActorTypeDefault.cs
@@ -1,0 +1,56 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RemoveAirdropActorTypeDefault : UpdateRule
+	{
+		public override string Name { get { return "Removed internal default of ProductionAirdrop.ActorType"; } }
+		public override string Description
+		{
+			get
+			{
+				return "Removed internal default of 'c17' from ProductionAirdrop.ActorType.";
+			}
+		}
+
+		readonly List<Tuple<string, string>> missingActorTypes = new List<Tuple<string, string>>();
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			var message = "ProductionAirdrop.ActorType no longer defaults to 'c17' and must be defined explicitly.\n"
+				+ "You may have to define it manually now in the following places:\n"
+				+ UpdateUtils.FormatMessageList(missingActorTypes.Select(n => n.Item1 + " (" + n.Item2 + ")"));
+
+			if (missingActorTypes.Any())
+				yield return message;
+
+			missingActorTypes.Clear();
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var airProd = actorNode.LastChildMatching("ProductionAirdrop");
+			if (airProd != null)
+			{
+				var actorTypeNode = airProd.LastChildMatching("ActorType");
+				if (actorTypeNode == null)
+					missingActorTypes.Add(Tuple.Create(actorNode.Key, actorNode.Location.Filename));
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -142,6 +142,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				// Bleed only changes here
 				new RemoveYesNo(),
 				new RemoveInitialFacingHardcoding(),
+				new RemoveAirdropActorTypeDefault(),
 			})
 		};
 

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -438,6 +438,7 @@ AFLD:
 		ExitCell: 3,1
 	ProductionAirdrop:
 		Produces: Vehicle.Nod
+		ActorType: c17
 	WithBuildingBib:
 	WithIdleOverlay@DISH:
 		RequiresCondition: !build-incomplete


### PR DESCRIPTION
Nearly all logic in Mods.Cnc is mod/game-specific or at least Westwood-specific enough that their placement in Mods.Cnc is accurate.

However, I feel `ProductionAirdrop` (and `WithDeliveryAnimation`) is a bit of an edge case by now, and one of the more likely traits to be used by non-C&C-based downstream mods which may otherwise not want/need to use Mods.Cnc (this does apply to one of my downstream projects, at least).

Removing the TD-specific `c17` default from `ActorType` and making it `FieldLoader.Require` should be the only must-have prerequisite for moving it up to Mods.Common.

`WithDeliveryAnimation` is actually even `ProductionAirdrop`-agnostic, as it uses the `INotifyDelivery` interface only, which has been in Mods.Common for quite a while (this also means the animation can now be used together with `ProductionParadrop` without the need for Mods.Cnc).

Supersedes #17385.