### PR TITLE
Queue the goto Random Building orders (Prep Edition)

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/StateBase.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/StateBase.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		{
 			var loc = RandomBuildingLocation(squad);
 			foreach (var a in squad.Units)
-				squad.Bot.QueueOrder(new Order("Move", a, Target.FromCell(squad.World, loc), false));
+				squad.Bot.QueueOrder(new Order("Move", a, Target.FromCell(squad.World, loc), true));
 		}
 
 		protected static CPos RandomBuildingLocation(Squad squad)


### PR DESCRIPTION
Queue the goto Random Building orders instead of doing them instantly in case we are finishing an action.

Split from #17312 and filed directly against prep.

I don't think #17312 as a whole would be suitable for a hotfix release even if it were finished and merged in time, but this kind of straight-forward fix is.