### PR TITLE
Move ShpTDLoader, LZO and XORDelta formats to Mods.Cnc

### DIFF
--- a/OpenRA.Mods.Cnc/FileFormats/LZOCompression.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/LZOCompression.cs
@@ -67,7 +67,7 @@
 
 using System;
 
-namespace OpenRA.Mods.Common.FileFormats
+namespace OpenRA.Mods.Cnc.FileFormats
 {
 	public static class LZOCompression
 	{

--- a/OpenRA.Mods.Cnc/FileFormats/XORDeltaCompression.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/XORDeltaCompression.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
-namespace OpenRA.Mods.Common.FileFormats
+using OpenRA.Mods.Common.FileFormats;
+
+namespace OpenRA.Mods.Cnc.FileFormats
 {
 	// Data that is to be XORed against another set of data (aka Format40)
 	public static class XORDeltaCompression

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpTDLoader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpTDLoader.cs
@@ -14,10 +14,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Cnc.FileFormats;
 using OpenRA.Mods.Common.FileFormats;
 using OpenRA.Primitives;
 
-namespace OpenRA.Mods.Common.SpriteLoaders
+namespace OpenRA.Mods.Cnc.SpriteLoaders
 {
 	public class ShpTDLoader : ISpriteLoader
 	{

--- a/OpenRA.Mods.Cnc/UtilityCommands/ConvertPngToShpCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ConvertPngToShpCommand.cs
@@ -14,7 +14,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using OpenRA.FileFormats;
-using OpenRA.Mods.Common.SpriteLoaders;
+using OpenRA.Mods.Cnc.SpriteLoaders;
 using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Cnc.UtilityCommands

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportTSMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportTSMapCommand.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using OpenRA.FileSystem;
+using OpenRA.Mods.Cnc.FileFormats;
 using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.FileFormats;
 using OpenRA.Mods.Common.Traits;

--- a/OpenRA.Mods.Cnc/UtilityCommands/RemapShpCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/RemapShpCommand.cs
@@ -14,7 +14,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using OpenRA.Graphics;
-using OpenRA.Mods.Common.SpriteLoaders;
+using OpenRA.Mods.Cnc.SpriteLoaders;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 


### PR DESCRIPTION
They're pretty much RA/TD-specific formats.

Another (and presumably the last) split from #17355.