### PR TITLE
Prevent a crash in AutoTarget.HasValidTargetPriority

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
+++ b/OpenRA.Mods.Cnc/Activities/LeapAttack.cs
@@ -156,7 +156,8 @@ namespace OpenRA.Mods.Cnc.Activities
 			if (newStance > oldStance || forceAttack)
 				return;
 
-			if (!autoTarget.HasValidTargetPriority(self, lastVisibleOwner, lastVisibleTargetTypes))
+			// If lastVisibleTarget is invalid we could never view the target in the first place, so we just drop it here too
+			if (!lastVisibleTarget.IsValidFor(self) || !autoTarget.HasValidTargetPriority(self, lastVisibleOwner, lastVisibleTargetTypes))
 				target = Target.Invalid;
 		}
 

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -184,7 +184,8 @@ namespace OpenRA.Mods.Common.Activities
 			if (newStance > oldStance || forceAttack)
 				return;
 
-			if (!autoTarget.HasValidTargetPriority(self, lastVisibleOwner, lastVisibleTargetTypes))
+			// If lastVisibleTarget is invalid we could never view the target in the first place, so we just drop it here too
+			if (!lastVisibleTarget.IsValidFor(self) || !autoTarget.HasValidTargetPriority(self, lastVisibleOwner, lastVisibleTargetTypes))
 				attackAircraft.ClearRequestedTarget();
 		}
 

--- a/OpenRA.Mods.Common/Activities/Attack.cs
+++ b/OpenRA.Mods.Common/Activities/Attack.cs
@@ -225,7 +225,8 @@ namespace OpenRA.Mods.Common.Activities
 			if (newStance > oldStance || forceAttack)
 				return;
 
-			if (!autoTarget.HasValidTargetPriority(self, lastVisibleOwner, lastVisibleTargetTypes))
+			// If lastVisibleTarget is invalid we could never view the target in the first place, so we just drop it here too
+			if (!lastVisibleTarget.IsValidFor(self) || !autoTarget.HasValidTargetPriority(self, lastVisibleOwner, lastVisibleTargetTypes))
 				target = Target.Invalid;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -364,7 +364,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (newStance > oldStance || forceAttack)
 					return;
 
-				if (!autoTarget.HasValidTargetPriority(self, lastVisibleOwner, lastVisibleTargetTypes))
+				// If lastVisibleTarget is invalid we could never view the target in the first place, so we just drop it here too
+				if (!lastVisibleTarget.IsValidFor(self) || !autoTarget.HasValidTargetPriority(self, lastVisibleOwner, lastVisibleTargetTypes))
 					attack.ClearRequestedTarget();
 			}
 

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -326,7 +326,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool HasValidTargetPriority(Actor self, Player owner, BitSet<TargetableType> targetTypes)
 		{
-			if (Stance <= UnitStance.ReturnFire)
+			if (owner == null || Stance <= UnitStance.ReturnFire)
 				return false;
 
 			return activeTargetPriorities.Any(ati =>


### PR DESCRIPTION
Fixes #17409.

This occurred when never saw the unit it was attacking and then had its stance changed.
The first commit makes `HasValidTargetPriority` more robust, while the second commit lets the caller account for the fact that `lastVisibleOwner` et al. can be null.