### PR TITLE
Fix aircraft strafing behaviour.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -149,16 +149,22 @@ namespace OpenRA.Mods.Common.Activities
 			if (!targetIsHiddenActor && target.Type == TargetType.Actor)
 				lastVisibleTarget = Target.FromTargetPositions(target);
 
-			useLastVisibleTarget = targetIsHiddenActor || !target.IsValidFor(self);
+			// Only update the visibility state when the target is a valid actor, otherwise we keep the visibility state
+			// it had when it was still alive.
+			if (target.IsValidFor(self))
+				useLastVisibleTarget = targetIsHiddenActor;
 
-			// Target is hidden or dead, and we don't have a fallback position to move towards
+			// Target is hidden or dead, and we don't have a fallback position to move towards.
 			if (useLastVisibleTarget && !lastVisibleTarget.IsValidFor(self))
+				return true;
+
+			// Target is dead and we have seen it die.
+			if (!useLastVisibleTarget && !target.IsValidFor(self))
 				return true;
 
 			var checkTarget = useLastVisibleTarget ? lastVisibleTarget : target;
 			var pos = aircraft.GetPosition();
 			var delta = checkTarget.CenterPosition - pos;
-			var desiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : aircraft.Facing;
 
 			// Inside the target annulus, so we're done
 			var insideMaxRange = maxRange.Length > 0 && checkTarget.IsInRange(pos, maxRange);
@@ -167,12 +173,20 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 
 			var isSlider = aircraft.Info.CanSlide;
+			var desiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : aircraft.Facing;
 			var move = isSlider ? aircraft.FlyStep(desiredFacing) : aircraft.FlyStep(aircraft.Facing);
 
-			// Inside the minimum range, so reverse if we CanSlide
-			if (isSlider && insideMinRange)
+			// Inside the minimum range, so reverse if we CanSlide, otherwise face away from the target.
+			if (insideMinRange)
 			{
-				FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, -move);
+				if (isSlider)
+					FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, -move);
+				else
+				{
+					desiredFacing = Util.NormalizeFacing(desiredFacing + 128);
+					FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, move);
+				}
+
 				return false;
 			}
 

--- a/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
@@ -24,8 +24,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Attack behavior. Currently supported types are Strafe (default) and Hover.")]
 		public readonly AirAttackType AttackType = AirAttackType.Strafe;
 
-		[Desc("Delay, in game ticks, before strafing aircraft turns to attack.")]
-		public readonly int AttackTurnDelay = 50;
+		[Desc("Distance the strafing aircraft makes to a target before turning for another pass. When set to WDist.Zero this defaults to the maximum armament range.")]
+		public readonly WDist StrafeRunLength = WDist.Zero;
 
 		[Desc("Does this actor cancel its attack activity when it needs to resupply? Setting this to 'false' will make the actor resume attack after reloading.")]
 		public readonly bool AbortOnResupply = true;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20191117/ReplaceAttackTurnDelay.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20191117/ReplaceAttackTurnDelay.cs
@@ -1,0 +1,67 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Mods.Common.Traits;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class ReplaceAttackTurnDelay : UpdateRule
+	{
+		public override string Name { get { return "Removed AttackTurnDelay from AttackAircraft and replaced with StrafeRunLength."; } }
+		public override string Description
+		{
+			get
+			{
+				return "Removed AttackTurnDelay which defines the strafing run in ticks from AttackAircraft and\n"
+				+ "replaced it with StrafeRunLength which defines the strafing run in WDist distance.";
+			}
+		}
+
+		readonly List<Tuple<string, string>> strafers = new List<Tuple<string, string>>();
+
+		public override IEnumerable<string> AfterUpdate(ModData modData)
+		{
+			var message = "AttackTurnDelay is removed from AttackAircraft. Attack run lengths are now calculated dynamically.\n"
+				+ "You may want to manually override the lengths in the following places by defining StrafeRunLength:\n"
+				+ UpdateUtils.FormatMessageList(strafers.Select(n => n.Item1 + " (" + n.Item2 + ")"));
+
+			if (strafers.Any())
+				yield return message;
+
+			strafers.Clear();
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var aircraft = actorNode.LastChildMatching("Aircraft");
+			if (aircraft != null)
+			{
+				var attackAircraft = actorNode.LastChildMatching("AttackAircraft");
+				if (attackAircraft == null)
+					yield break;
+
+				var canHover = aircraft.LastChildMatching("CanHover");
+				var attackType = attackAircraft.LastChildMatching("AttackType");
+
+				if (canHover != null && canHover.NodeValue<bool>() == true && attackType != null && attackType.NodeValue<AirAttackType>() != AirAttackType.Strafe)
+					yield break;
+
+				attackAircraft.RemoveNodes("AttackTurnDelay");
+				strafers.Add(Tuple.Create(actorNode.Key, actorNode.Location.Filename));
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -143,6 +143,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveYesNo(),
 				new RemoveInitialFacingHardcoding(),
 				new RemoveAirdropActorTypeDefault(),
+				new ReplaceAttackTurnDelay(),
 			})
 		};
 

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -111,7 +111,6 @@ MIG:
 	AttackAircraft:
 		FacingTolerance: 20
 		PersistentTargeting: false
-		AttackTurnDelay: 30
 	Aircraft:
 		CruiseAltitude: 2560
 		InitialFacing: 192


### PR DESCRIPTION
Fixes #17413.

Fixing this without reregressing #16922 is a bit of a puzzle. This solution should keep both issues fixed while also dynamically determining the strafing run trajectory based on weapon range and turn speed instead of relying on an arbitrary tick count.

The one problem with this solution is that it changes aircraft to immediately cancel the attack when the target is killed instead of moving towards the last known position of the target when it was alive. Now, I do think that this is a good thing in and of itself (and we should do that for the other activities as well), but my current implementation would also leak the status of hidden targets. I haven't found a simple way to distinguish between actors that died while visible and actors that died while hidden under fog, so I hope that someone else has an idea for how to do this. If not, then I think this may be the lesser evil for the short term.

Incidentally, this also adds the correct behaviour for `Aircraft.MoveWithinRange` applied to fixed-wing aircraft and a minimum range.