### PR TITLE
Implement "Battlefield Camera" setting and smooth zooming

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -673,7 +673,10 @@ namespace OpenRA
 
 					// World rendering is disabled while the loading screen is displayed
 					if (worldRenderer != null && !worldRenderer.World.IsLoadingGameSave)
+					{
+						worldRenderer.Viewport.Tick();
 						worldRenderer.PrepareRenderables();
+					}
 
 					Ui.PrepareRenderables();
 					Renderer.WorldModelRenderer.EndFrame();

--- a/OpenRA.Game/Graphics/SpriteRenderer.cs
+++ b/OpenRA.Game/Graphics/SpriteRenderer.cs
@@ -172,5 +172,10 @@ namespace OpenRA.Graphics
 		{
 			shader.SetBool("EnableDepthPreview", enabled);
 		}
+
+		public void SetAntialiasingPixelsPerTexel(float pxPerTx)
+		{
+			shader.SetVec("AntialiasPixelsPerTexel", pxPerTx);
+		}
 	}
 }

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -181,6 +181,9 @@ namespace OpenRA
 
 				// Render the world into a framebuffer at 1:1 scaling to allow the depth buffer to match the artwork at all zoom levels
 				worldBuffer = Context.CreateFrameBuffer(worldBufferSize);
+
+				// Pixel art scaling mode is a customized bilinear sampling
+				worldBuffer.Texture.ScaleFilter = TextureScaleFilter.Linear;
 			}
 
 			if (worldSprite == null || worldViewport.Size != worldSprite.Bounds.Size)
@@ -217,8 +220,11 @@ namespace OpenRA
 
 				var scale = Window.WindowScale;
 				var bufferSize = new Size((int)(screenSprite.Bounds.Width / scale), (int)(-screenSprite.Bounds.Height / scale));
+
+				SpriteRenderer.SetAntialiasingPixelsPerTexel(Window.SurfaceSize.Height * 1f / worldSprite.Bounds.Height);
 				RgbaSpriteRenderer.DrawSprite(worldSprite, float3.Zero, new float2(bufferSize));
 				Flush();
+				SpriteRenderer.SetAntialiasingPixelsPerTexel(0);
 			}
 			else
 			{

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -13,7 +13,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
@@ -33,6 +32,8 @@ namespace OpenRA
 		Started = 8,
 		Incompatible = 16
 	}
+
+	public enum WorldViewport { Native, Close, Medium, Far }
 
 	public class ServerSettings
 	{
@@ -145,8 +146,8 @@ namespace OpenRA
 
 		public bool HardwareCursors = true;
 
-		public bool PixelDouble = false;
 		public bool CursorDouble = false;
+		public WorldViewport ViewportDistance = WorldViewport.Medium;
 
 		[Desc("Add a frame rate limiter. It is recommended to not disable this.")]
 		public bool CapFramerate = true;
@@ -207,6 +208,7 @@ namespace OpenRA
 		public MouseButtonPreference MouseButtonPreference = new MouseButtonPreference();
 		public float ViewportEdgeScrollStep = 30f;
 		public float UIScrollSpeed = 50f;
+		public float ZoomSpeed = 0.04f;
 		public int SelectionDeadzone = 24;
 		public int MouseScrollDeadzone = 8;
 
@@ -220,8 +222,7 @@ namespace OpenRA
 		[Desc("Filename of the authentication profile to use.")]
 		public string AuthProfile = "player.oraid";
 
-		public bool AllowZoom = true;
-		public Modifiers ZoomModifier = Modifiers.Ctrl;
+		public Modifiers ZoomModifier = Modifiers.None;
 
 		public bool FetchNews = true;
 

--- a/OpenRA.Game/WorldViewportSizes.cs
+++ b/OpenRA.Game/WorldViewportSizes.cs
@@ -1,0 +1,33 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA
+{
+	public class WorldViewportSizes : IGlobalModData
+	{
+		public readonly int2 CloseWindowHeights = new int2(480, 600);
+		public readonly int2 MediumWindowHeights = new int2(600, 900);
+		public readonly int2 FarWindowHeights = new int2(900, 1300);
+
+		public readonly float MaxZoomScale = 2.0f;
+		public readonly int MaxZoomWindowHeight = 240;
+		public readonly bool AllowNativeZoom = true;
+
+		public int2 GetSizeRange(WorldViewport distance)
+		{
+			return distance == WorldViewport.Close ? CloseWindowHeights
+				: distance == WorldViewport.Medium ? MediumWindowHeights
+				: FarWindowHeights;
+		}
+	}
+}

--- a/OpenRA.Mods.Cnc/Effects/GpsDotEffect.cs
+++ b/OpenRA.Mods.Cnc/Effects/GpsDotEffect.cs
@@ -106,7 +106,8 @@ namespace OpenRA.Mods.Cnc.Effects
 				actor.EffectiveOwner.Owner : actor.Owner;
 
 			var palette = wr.Palette(info.IndicatorPalettePrefix + effectiveOwner.InternalName);
-			return anim.Render(actor.CenterPosition, palette);
+			var screenPos = wr.Viewport.WorldToViewPx(wr.ScreenPxPosition(actor.CenterPosition));
+			return anim.RenderUI(wr, screenPos, WVec.Zero, 0, palette, 1f);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/EditorViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/EditorViewportControllerWidget.cs
@@ -39,6 +39,9 @@ namespace OpenRA.Mods.Common.Widgets
 			editorActionManager = world.WorldActor.Trait<EditorActionManager>();
 
 			editorActionManager.OnChange += EditorActionManagerOnChange;
+
+			// Allow zooming out to full map size
+			worldRenderer.Viewport.UnlockMinimumZoom(0.25f);
 		}
 
 		void EditorActionManagerOnChange()
@@ -80,26 +83,11 @@ namespace OpenRA.Mods.Common.Widgets
 				tooltipContainer.Value.RemoveTooltip();
 		}
 
-		void Zoom(int amount)
-		{
-			var zoomSteps = worldRenderer.Viewport.AvailableZoomSteps;
-			var currentZoom = worldRenderer.Viewport.Zoom;
-
-			var nextIndex = zoomSteps.IndexOf(currentZoom) - amount;
-			if (nextIndex < 0 || nextIndex >= zoomSteps.Length)
-				return;
-
-			var zoom = zoomSteps[nextIndex];
-			Parent.Get<DropDownButtonWidget>("ZOOM_BUTTON").SelectedItem = zoom.ToString();
-			worldRenderer.Viewport.Zoom = zoom;
-		}
-
 		public override bool HandleMouseInput(MouseInput mi)
 		{
-			if (mi.Event == MouseInputEvent.Scroll &&
-				Game.Settings.Game.AllowZoom && mi.Modifiers.HasModifier(Game.Settings.Game.ZoomModifier))
+			if (mi.Event == MouseInputEvent.Scroll && mi.Modifiers.HasModifier(Game.Settings.Game.ZoomModifier))
 			{
-				Zoom(mi.Delta.Y);
+				worldRenderer.Viewport.AdjustZoom(mi.Delta.Y * Game.Settings.Game.ZoomSpeed);
 				return true;
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/MapEditorLogic.cs
@@ -25,13 +25,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		MapCopyFilters copyFilters = MapCopyFilters.All;
 
 		[ObjectCreator.UseCtor]
-		public MapEditorLogic(Widget widget, ModData modData, World world, WorldRenderer worldRenderer, Dictionary<string, MiniYaml> logicArgs)
+		public MapEditorLogic(Widget widget, World world, WorldRenderer worldRenderer)
 		{
-			MiniYaml yaml;
-			var changeZoomKey = new HotkeyReference();
-			if (logicArgs.TryGetValue("ChangeZoomKey", out yaml))
-				changeZoomKey = modData.Hotkeys[yaml.Value];
-
 			var editorViewport = widget.Get<EditorViewportControllerWidget>("MAP_EDITOR");
 
 			var gridButton = widget.GetOrNull<ButtonWidget>("GRID_BUTTON");
@@ -41,48 +36,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				gridButton.OnClick = () => terrainGeometryTrait.Enabled ^= true;
 				gridButton.IsHighlighted = () => terrainGeometryTrait.Enabled;
-			}
-
-			var zoomDropdown = widget.GetOrNull<DropDownButtonWidget>("ZOOM_BUTTON");
-			if (zoomDropdown != null)
-			{
-				var selectedZoom = (Game.Settings.Graphics.PixelDouble ? 2f : 1f).ToString();
-
-				zoomDropdown.SelectedItem = selectedZoom;
-				Func<float, ScrollItemWidget, ScrollItemWidget> setupItem = (zoom, itemTemplate) =>
-				{
-					var item = ScrollItemWidget.Setup(
-						itemTemplate,
-						() =>
-						{
-							return float.Parse(zoomDropdown.SelectedItem) == zoom;
-						},
-						() =>
-						{
-							zoomDropdown.SelectedItem = selectedZoom = zoom.ToString();
-							worldRenderer.Viewport.Zoom = float.Parse(selectedZoom);
-						});
-
-					var label = zoom.ToString();
-					item.Get<LabelWidget>("LABEL").GetText = () => label;
-
-					return item;
-				};
-
-				var options = worldRenderer.Viewport.AvailableZoomSteps;
-				zoomDropdown.OnMouseDown = _ => zoomDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 150, options, setupItem);
-				zoomDropdown.GetText = () => zoomDropdown.SelectedItem;
-				zoomDropdown.OnKeyPress = e =>
-				{
-					if (!changeZoomKey.IsActivatedBy(e))
-						return;
-
-					var selected = (options.IndexOf(float.Parse(selectedZoom)) + 1) % options.Length;
-					var zoom = options[selected];
-					worldRenderer.Viewport.Zoom = zoom;
-					selectedZoom = zoom.ToString();
-					zoomDropdown.SelectedItem = zoom.ToString();
-				};
 			}
 
 			var copypasteButton = widget.GetOrNull<ButtonWidget>("COPYPASTE_BUTTON");

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/ResetZoomHotkey.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/Hotkeys/ResetZoomHotkey.cs
@@ -16,31 +16,21 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic.Ingame
 {
-	[ChromeLogicArgsHotkeys("TogglePixelDoubleKey")]
-	public class TogglePixelDoubleHotkeyLogic : SingleHotkeyBaseLogic
+	[ChromeLogicArgsHotkeys("ResetZoomKey")]
+	public class ResetZoomHotkeyLogic : SingleHotkeyBaseLogic
 	{
 		readonly Viewport viewport;
 
 		[ObjectCreator.UseCtor]
-		public TogglePixelDoubleHotkeyLogic(Widget widget, ModData modData, WorldRenderer worldRenderer, Dictionary<string, MiniYaml> logicArgs)
-			: base(widget, modData, "TogglePixelDoubleKey", "WORLD_KEYHANDLER", logicArgs)
+		public ResetZoomHotkeyLogic(Widget widget, ModData modData, WorldRenderer worldRenderer, Dictionary<string, MiniYaml> logicArgs)
+			: base(widget, modData, "ResetZoomKey", "WORLD_KEYHANDLER", logicArgs)
 		{
 			viewport = worldRenderer.Viewport;
 		}
 
 		protected override bool OnHotkeyActivated(KeyInput e)
 		{
-			// Zoom is currently always set directly, so we don't need to worry about floating point imprecision
-			if (viewport.Zoom == 1f)
-				viewport.Zoom = 2f;
-			else
-			{
-				// Reset zoom to regular view if it was anything else before
-				// (like a zoom level only reachable by using the scroll wheel).
-				viewport.Zoom = 1f;
-			}
-
-			Game.Settings.Graphics.PixelDouble = viewport.Zoom == 2f;
+			viewport.ToggleZoom();
 
 			return true;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverShroudSelectorLogic.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.Graphics;
 using OpenRA.Mods.Common.Lint;
 using OpenRA.Network;
 using OpenRA.Primitives;
@@ -64,7 +65,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		}
 
 		[ObjectCreator.UseCtor]
-		public ObserverShroudSelectorLogic(Widget widget, ModData modData, World world, Dictionary<string, MiniYaml> logicArgs)
+		public ObserverShroudSelectorLogic(Widget widget, ModData modData, World world, WorldRenderer worldRenderer, Dictionary<string, MiniYaml> logicArgs)
 		{
 			this.world = world;
 
@@ -145,6 +146,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			selected = limitViews ? groups.First().Value.First() : world.WorldActor.Owner.Shroud.ExploreMapEnabled ? combined : disableShroud;
 			selected.OnClick();
+
+			// Enable zooming out to fractional zoom levels
+			worldRenderer.Viewport.UnlockMinimumZoom(0.5f);
 		}
 
 		public bool HandleKeyPress(KeyInput e)

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -27,6 +27,9 @@ namespace OpenRA.Mods.Common.Widgets
 		readonly ModData modData;
 		readonly ResourceLayer resourceLayer;
 
+		public readonly HotkeyReference ZoomInKey = new HotkeyReference();
+		public readonly HotkeyReference ZoomOutKey = new HotkeyReference();
+
 		public readonly HotkeyReference ScrollUpKey = new HotkeyReference();
 		public readonly HotkeyReference ScrollDownKey = new HotkeyReference();
 		public readonly HotkeyReference ScrollLeftKey = new HotkeyReference();
@@ -422,6 +425,18 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (e.Event != KeyInputEvent.Down)
 				return false;
+
+			if (ZoomInKey.IsActivatedBy(e))
+			{
+				worldRenderer.Viewport.AdjustZoom(0.25f);
+				return true;
+			}
+
+			if (ZoomOutKey.IsActivatedBy(e))
+			{
+				worldRenderer.Viewport.AdjustZoom(-0.25f);
+				return true;
+			}
 
 			if (JumpToTopEdgeKey.IsActivatedBy(e))
 			{

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -306,38 +306,11 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 		}
 
-		bool IsZoomAllowed(float zoom)
-		{
-			return world.IsGameOver || zoom >= 1.0f || world.IsReplay || world.LocalPlayer == null || world.LocalPlayer.Spectating;
-		}
-
-		void Zoom(int direction)
-		{
-			var zoomSteps = worldRenderer.Viewport.AvailableZoomSteps;
-			var currentZoom = worldRenderer.Viewport.Zoom;
-			var nextIndex = zoomSteps.IndexOf(currentZoom);
-
-			if (direction < 0)
-				nextIndex++;
-			else
-				nextIndex--;
-
-			if (nextIndex < 0 || nextIndex >= zoomSteps.Count())
-				return;
-
-			var zoom = zoomSteps.ElementAt(nextIndex);
-			if (!IsZoomAllowed(zoom))
-				return;
-
-			worldRenderer.Viewport.Zoom = zoom;
-		}
-
 		public override bool HandleMouseInput(MouseInput mi)
 		{
-			if (mi.Event == MouseInputEvent.Scroll &&
-				Game.Settings.Game.AllowZoom && mi.Modifiers.HasModifier(Game.Settings.Game.ZoomModifier))
+			if (mi.Event == MouseInputEvent.Scroll && mi.Modifiers.HasModifier(Game.Settings.Game.ZoomModifier))
 			{
-				Zoom(mi.Delta.Y);
+				worldRenderer.Viewport.AdjustZoom(mi.Delta.Y * Game.Settings.Game.ZoomSpeed);
 				return true;
 			}
 

--- a/glsl/combined.frag
+++ b/glsl/combined.frag
@@ -16,6 +16,7 @@ uniform sampler2D Palette;
 
 uniform bool EnableDepthPreview;
 uniform float DepthTextureScale;
+uniform float AntialiasPixelsPerTexel;
 
 in vec4 vTexCoord;
 in vec2 vTexMetadata;
@@ -44,6 +45,24 @@ float jet_b(float x)
 	return x < 0.3 ? 4.0 * x + 0.5 : -4.0 * x + 2.5;
 }
 
+ivec2 Size(float samplerIndex)
+{
+	if (samplerIndex < 0.5)
+		return textureSize(Texture0, 0);
+	else if (samplerIndex < 1.5)
+		return textureSize(Texture1, 0);
+	else if (samplerIndex < 2.5)
+		return textureSize(Texture2, 0);
+	else if (samplerIndex < 3.5)
+		return textureSize(Texture3, 0);
+	else if (samplerIndex < 4.5)
+		return textureSize(Texture4, 0);
+	else if (samplerIndex < 5.5)
+		return textureSize(Texture5, 0);
+
+	return textureSize(Texture6, 0);
+}
+
 vec4 Sample(float samplerIndex, vec2 pos)
 {
 	if (samplerIndex < 0.5)
@@ -64,7 +83,23 @@ vec4 Sample(float samplerIndex, vec2 pos)
 
 void main()
 {
-	vec4 x = Sample(vTexSampler.s, vTexCoord.st);
+	vec2 coords = vTexCoord.st;
+
+	if (AntialiasPixelsPerTexel > 0)
+	{
+		vec2 textureSize = Size(vTexSampler.s);
+		vec2 offset = fract(coords.st * textureSize);
+
+		// Offset the sampling point to simulate bilinear intepolation in window coordinates instead of texture coordinates
+		// https://csantosbh.wordpress.com/2014/01/25/manual-texture-filtering-for-pixelated-games-in-webgl/
+		// https://csantosbh.wordpress.com/2014/02/05/automatically-detecting-the-texture-filter-threshold-for-pixelated-magnifications/
+		// ik is defined as 1/k from the articles, set to 1/0.7 because it looks good 
+		float ik = 1.43;
+		vec2 interp = clamp(offset * ik * AntialiasPixelsPerTexel, 0.0, .5) + clamp((offset - 1.0) * ik * AntialiasPixelsPerTexel + .5, 0.0, .5);
+		coords = (floor(coords.st * textureSize) + interp) / textureSize;
+	}
+
+	vec4 x = Sample(vTexSampler.s, coords);
 	vec2 p = vec2(dot(x, vChannelMask), vTexMetadata.s);
 	vec4 c = vPalettedFraction * texture(Palette, p) + vRGBAFraction * x + vColorFraction * vTexCoord;
 

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -323,6 +323,8 @@ Container@EDITOR_WORLD_ROOT:
 			Width: WINDOW_RIGHT
 			Height: WINDOW_BOTTOM
 			IgnoreMouseOver: True
+			ZoomInKey: ZoomIn
+			ZoomOutKey: ZoomOut
 			ScrollUpKey: MapScrollUp
 			ScrollDownKey: MapScrollDown
 			ScrollLeftKey: MapScrollLeft

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -202,13 +202,15 @@ Container@EDITOR_ROOT:
 				NextMusicKey: NextMusic
 				TakeScreenshotKey: TakeScreenshot
 				MuteAudioKey: ToggleMute
+		LogicKeyListener@WORLD_KEYHANDLER:
+			Logic: ResetZoomHotkeyLogic
+				ResetZoomKey: ResetZoom
 		Container@WORLD_ROOT:
 		Container@MENU_ROOT:
 		TooltipContainer@TOOLTIP_CONTAINER:
 
 Container@EDITOR_WORLD_ROOT:
 	Logic: LoadIngamePerfLogic, MapEditorLogic, ActorEditLogic
-		ChangeZoomKey: TogglePixelDouble
 		EditPanelPadding: 5
 	Children:
 		Container@PERF_ROOT:
@@ -578,6 +580,28 @@ Container@EDITOR_WORLD_ROOT:
 					Height: 25
 					Text: History
 					Font: Bold
+		Button@UNDO_BUTTON:
+			X: WINDOW_RIGHT - 910
+			Y: 5
+			Height: 25
+			Width: 100
+			Text: Undo
+			Font: Bold
+			Key: z ctrl
+			TooltipTemplate: BUTTON_TOOLTIP
+			TooltipText: Undo last step
+			TooltipContainer: TOOLTIP_CONTAINER
+		Button@REDO_BUTTON:
+			X: WINDOW_RIGHT - 800
+			Y: 5
+			Height: 25
+			Width: 100
+			Text: Redo
+			Font: Bold
+			Key: y ctrl
+			TooltipTemplate: BUTTON_TOOLTIP
+			TooltipText: Redo last step
+			TooltipContainer: TOOLTIP_CONTAINER
 		Button@GRID_BUTTON:
 			X: WINDOW_RIGHT - 690
 			Y: 5
@@ -588,25 +612,6 @@ Container@EDITOR_WORLD_ROOT:
 			Key: f1
 			TooltipTemplate: BUTTON_TOOLTIP
 			TooltipText: Toggle the terrain grid
-			TooltipContainer: TOOLTIP_CONTAINER
-		Label@ZOOM_LABEL:
-			X: WINDOW_RIGHT - 770 - 55
-			Y: 5
-			Width: 50
-			Height: 25
-			Text: Zoom:
-			Align: Right
-			Font: Bold
-			Contrast: true
-		DropDownButton@ZOOM_BUTTON:
-			X: WINDOW_RIGHT - 770
-			Y: 5
-			Width: 70
-			Height: 25
-			Font: Bold
-			Key: TogglePixelDouble
-			TooltipTemplate: BUTTON_TOOLTIP
-			TooltipText: Zoom
 			TooltipContainer: TOOLTIP_CONTAINER
 		Button@COPYPASTE_BUTTON:
 			X: WINDOW_RIGHT - 580
@@ -639,26 +644,6 @@ Container@EDITOR_WORLD_ROOT:
 			Align: Left
 			Font: Bold
 			Contrast: true
-		Button@UNDO_BUTTON:
-			X: 200
-			Height: 25
-			Width: 100
-			Text: Undo
-			Font: Bold
-			Key: z ctrl
-			TooltipTemplate: BUTTON_TOOLTIP
-			TooltipText: Undo last step
-			TooltipContainer: TOOLTIP_CONTAINER
-		Button@REDO_BUTTON:
-			X: 305
-			Height: 25
-			Width: 100
-			Text: Redo
-			Font: Bold
-			Key: y ctrl
-			TooltipTemplate: BUTTON_TOOLTIP
-			TooltipText: Redo last step
-			TooltipContainer: TOOLTIP_CONTAINER
 
 ScrollPanel@CATEGORY_FILTER_PANEL:
 	Width: 190

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -77,6 +77,8 @@ Container@OBSERVER_WIDGETS:
 			Width: WINDOW_RIGHT
 			Height: WINDOW_BOTTOM
 			TooltipContainer: TOOLTIP_CONTAINER
+			ZoomInKey: ZoomIn
+			ZoomOutKey: ZoomOut
 			ScrollUpKey: MapScrollUp
 			ScrollDownKey: MapScrollDown
 			ScrollLeftKey: MapScrollLeft
@@ -1048,6 +1050,8 @@ Container@PLAYER_WIDGETS:
 			Height: WINDOW_BOTTOM
 			TooltipTemplate: WORLD_TOOLTIP_FACTIONSUFFIX
 			TooltipContainer: TOOLTIP_CONTAINER
+			ZoomInKey: ZoomIn
+			ZoomOutKey: ZoomOut
 			ScrollUpKey: MapScrollUp
 			ScrollDownKey: MapScrollDown
 			ScrollLeftKey: MapScrollLeft

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -10,13 +10,13 @@ Container@INGAME_ROOT:
 				TakeScreenshotKey: TakeScreenshot
 				MuteAudioKey: ToggleMute
 		LogicKeyListener@WORLD_KEYHANDLER:
-			Logic: CycleBasesHotkeyLogic, CycleProductionActorsHotkeyLogic, JumpToLastEventHotkeyLogic, JumpToSelectedActorsHotkeyLogic, TogglePixelDoubleHotkeyLogic, TogglePlayerStanceColorHotkeyLogic, CycleStatusBarsHotkeyLogic, PauseHotkeyLogic, RemoveFromControlGroupHotkeyLogic
+			Logic: CycleBasesHotkeyLogic, CycleProductionActorsHotkeyLogic, JumpToLastEventHotkeyLogic, JumpToSelectedActorsHotkeyLogic, ResetZoomHotkeyLogic, TogglePlayerStanceColorHotkeyLogic, CycleStatusBarsHotkeyLogic, PauseHotkeyLogic, RemoveFromControlGroupHotkeyLogic
 				RemoveFromControlGroupKey: RemoveFromControlGroup
 				CycleBasesKey: CycleBase
 				CycleProductionActorsKey: CycleProductionBuildings
 				JumpToLastEventKey: ToLastEvent
 				JumpToSelectedActorsKey: ToSelection
-				TogglePixelDoubleKey: TogglePixelDouble
+				ResetZoomKey: ResetZoom
 				TogglePlayerStanceColorKey: TogglePlayerStanceColor
 				CycleStatusBarsKey: CycleStatusBars
 				PauseKey: Pause

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -132,7 +132,7 @@ Container@SETTINGS_PANEL:
 							Font: Regular
 							Text: Use Hardware Cursors
 						Checkbox@CURSORDOUBLE_CHECKBOX:
-							X: 300
+							X: 310
 							Y: 75
 							Width: 200
 							Height: 20
@@ -152,13 +152,6 @@ Container@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Enable Frame Limiter
-						Checkbox@PIXELDOUBLE_CHECKBOX:
-							X: 310
-							Y: 125
-							Width: 200
-							Height: 20
-							Font: Regular
-							Text: Enable Pixel Doubling
 						Label@FRAME_LIMIT_DESC_A:
 							X: 45
 							Y: 153
@@ -209,6 +202,18 @@ Container@SETTINGS_PANEL:
 									Y: 6
 									Width: PARENT_RIGHT - 35
 									Height: PARENT_BOTTOM - 12
+						Label@BATTLEFIELD_CAMERA:
+							X: 15
+							Y: 227
+							Width: 120
+							Text: Battlefield Camera:
+							Align: Right
+						DropDownButton@BATTLEFIELD_CAMERA_DROPDOWN:
+							X: 140
+							Y: 215
+							Width: 145
+							Height: 25
+							Font: Regular
 						Label@STATUS_BARS:
 							X: 250
 							Y: 257
@@ -223,7 +228,7 @@ Container@SETTINGS_PANEL:
 							Font: Regular
 						Label@TARGET_LINES:
 							X: 250
-							Y: 228
+							Y: 227
 							Width: 145
 							Text: Target Lines:
 							Align: Right
@@ -404,7 +409,7 @@ Container@SETTINGS_PANEL:
 							Width: 160
 							Height: 20
 							Font: Regular
-							Text: Scroll-zoom Modifier:
+							Text: Mouse Wheel Zoom Modifier:
 							Align: Right
 						DropDownButton@ZOOM_MODIFIER:
 							X: PARENT_RIGHT - WIDTH - 15
@@ -420,29 +425,22 @@ Container@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Edge Scrolling
-						Checkbox@ALLOW_ZOOM_CHECKBOX:
+						Checkbox@LOCKMOUSE_CHECKBOX:
 							X: 15
 							Y: 100
 							Width: 130
 							Height: 20
 							Font: Regular
-							Text: Scroll Zooming
-						Checkbox@LOCKMOUSE_CHECKBOX:
-							X: 15
-							Y: 130
-							Width: 130
-							Height: 20
-							Font: Regular
 							Text: Lock Mouse to Window
 						Label@SCROLL_SPEED_LABEL:
-							X: PARENT_RIGHT - WIDTH - 270
+							X: 15
 							Y: 128
-							Width: 95
+							Width: 85
 							Height: 25
 							Text: Scroll Speed:
 							Align: Right
 						Slider@SCROLLSPEED_SLIDER:
-							X: PARENT_RIGHT - WIDTH - 170
+							X: 95
 							Y: 133
 							Width: 100
 							Height: 20
@@ -450,20 +448,35 @@ Container@SETTINGS_PANEL:
 							MinimumValue: 10
 							MaximumValue: 50
 						Label@UI_SCROLL_SPEED_LABEL:
-							X: PARENT_RIGHT - WIDTH - 106
+							X: PARENT_RIGHT - WIDTH - 320
 							Y: 128
 							Width: 95
 							Height: 25
 							Text: UI Scroll:
 							Align: Right
 						Slider@UI_SCROLLSPEED_SLIDER:
-							X: PARENT_RIGHT - WIDTH - 6
+							X: PARENT_RIGHT - WIDTH - 220
 							Y: 133
 							Width: 100
 							Height: 20
 							Ticks: 5
 							MinimumValue: 1
 							MaximumValue: 100
+						Label@ZOOM_SPEED_LABEL:
+							X: PARENT_RIGHT - WIDTH - 106
+							Y: 129
+							Width: 95
+							Height: 25
+							Text: Zoom Speed:
+							Align: Right
+						ExponentialSlider@ZOOMSPEED_SLIDER:
+							X: PARENT_RIGHT - WIDTH - 6
+							Y: 133
+							Width: 100
+							Height: 20
+							Ticks: 5
+							MinimumValue: 0.01
+							MaximumValue: 0.4
 				Container@HOTKEYS_PANEL:
 					X: 15
 					Y: 15

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -193,13 +193,15 @@ Container@EDITOR_ROOT:
 				NextMusicKey: NextMusic
 				TakeScreenshotKey: TakeScreenshot
 				MuteAudioKey: ToggleMute
+		LogicKeyListener@WORLD_KEYHANDLER:
+			Logic: ResetZoomHotkeyLogic
+				ResetZoomKey: ResetZoom
 		Container@WORLD_ROOT:
 		Container@MENU_ROOT:
 		TooltipContainer@TOOLTIP_CONTAINER:
 
 Container@EDITOR_WORLD_ROOT:
 	Logic: LoadIngamePerfLogic, MapEditorLogic, ActorEditLogic
-		ChangeZoomKey: TogglePixelDouble
 		EditPanelPadding: 14
 	Children:
 		Container@PERF_ROOT:
@@ -584,25 +586,8 @@ Container@EDITOR_WORLD_ROOT:
 			TooltipContainer: TOOLTIP_CONTAINER
 			Font: Bold
 			Key: f1
-		Label@ZOOM_LABEL:
-			X: 495
-			Width: 50
-			Height: 25
-			Text: Zoom:
-			Align: Right
-			Font: Bold
-			Contrast: true
-		DropDownButton@ZOOM_BUTTON:
-			X: 550
-			Width: 70
-			Height: 25
-			Font: Bold
-			Key: TogglePixelDouble
-			TooltipTemplate: BUTTON_TOOLTIP
-			TooltipText: Zoom
-			TooltipContainer: TOOLTIP_CONTAINER
 		Button@UNDO_BUTTON:
-			X: 630
+			X: 500
 			Height: 25
 			Width: 90
 			Text: Undo
@@ -612,7 +597,7 @@ Container@EDITOR_WORLD_ROOT:
 			TooltipText: Undo last step
 			TooltipContainer: TOOLTIP_CONTAINER
 		Button@REDO_BUTTON:
-			X: 730
+			X: 600
 			Height: 25
 			Width: 90
 			Text: Redo

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -318,6 +318,8 @@ Container@EDITOR_WORLD_ROOT:
 			Width: WINDOW_RIGHT
 			Height: WINDOW_BOTTOM
 			IgnoreMouseOver: True
+			ZoomInKey: ZoomIn
+			ZoomOutKey: ZoomOut
 			ScrollUpKey: MapScrollUp
 			ScrollDownKey: MapScrollDown
 			ScrollLeftKey: MapScrollLeft

--- a/mods/common/chrome/ingame.yaml
+++ b/mods/common/chrome/ingame.yaml
@@ -42,6 +42,8 @@ Container@INGAME_ROOT:
 					Width: WINDOW_RIGHT
 					Height: WINDOW_BOTTOM
 					TooltipContainer: TOOLTIP_CONTAINER
+					ZoomInKey: ZoomIn
+					ZoomOutKey: ZoomOut
 					ScrollUpKey: MapScrollUp
 					ScrollDownKey: MapScrollDown
 					ScrollLeftKey: MapScrollLeft

--- a/mods/common/chrome/ingame.yaml
+++ b/mods/common/chrome/ingame.yaml
@@ -10,13 +10,13 @@ Container@INGAME_ROOT:
 				TakeScreenshotKey: TakeScreenshot
 				MuteAudioKey: ToggleMute
 		LogicKeyListener@WORLD_KEYHANDLER:
-			Logic: CycleBasesHotkeyLogic, CycleProductionActorsHotkeyLogic, JumpToLastEventHotkeyLogic, JumpToSelectedActorsHotkeyLogic, TogglePixelDoubleHotkeyLogic, TogglePlayerStanceColorHotkeyLogic, CycleStatusBarsHotkeyLogic, PauseHotkeyLogic, RemoveFromControlGroupHotkeyLogic
+			Logic: CycleBasesHotkeyLogic, CycleProductionActorsHotkeyLogic, JumpToLastEventHotkeyLogic, JumpToSelectedActorsHotkeyLogic, ResetZoomHotkeyLogic, TogglePlayerStanceColorHotkeyLogic, CycleStatusBarsHotkeyLogic, PauseHotkeyLogic, RemoveFromControlGroupHotkeyLogic
 				RemoveFromControlGroupKey: RemoveFromControlGroup
 				CycleBasesKey: CycleBase
 				CycleProductionActorsKey: CycleProductionBuildings
 				JumpToLastEventKey: ToLastEvent
 				JumpToSelectedActorsKey: ToSelection
-				TogglePixelDoubleKey: TogglePixelDouble
+				ResetZoomKey: ResetZoom
 				TogglePlayerStanceColorKey: TogglePlayerStanceColor
 				CycleStatusBarsKey: CycleStatusBars
 				PauseKey: Pause

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -95,7 +95,7 @@ Background@SETTINGS_PANEL:
 			Children:
 				Label@MODE_LABEL:
 					X: 110
-					Y: 41
+					Y: 40
 					Width: 45
 					Height: 25
 					Align: Right
@@ -146,7 +146,7 @@ Background@SETTINGS_PANEL:
 					Font: Regular
 					Text: Use Hardware Cursors
 				Checkbox@CURSORDOUBLE_CHECKBOX:
-					X: 300
+					X: 310
 					Y: 75
 					Width: 200
 					Height: 20
@@ -166,13 +166,6 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Enable Frame Limiter
-				Checkbox@PIXELDOUBLE_CHECKBOX:
-					X: 310
-					Y: 125
-					Width: 200
-					Height: 20
-					Font: Regular
-					Text: Enable Pixel Doubling
 				Label@FRAME_LIMIT_DESC_A:
 					X: 45
 					Y: 159
@@ -223,29 +216,41 @@ Background@SETTINGS_PANEL:
 							Y: 6
 							Width: PARENT_RIGHT - 35
 							Height: PARENT_BOTTOM - 12
+				Label@BATTLEFIELD_CAMERA:
+					X: 15
+					Y: 242
+					Width: 120
+					Text: Battlefield Camera:
+					Align: Right
+				DropDownButton@BATTLEFIELD_CAMERA_DROPDOWN:
+					X: 140
+					Y: 230
+					Width: 145
+					Height: 25
+					Font: Regular
 				Label@STATUS_BARS:
 					X: 250
-					Y: 278
+					Y: 277
 					Width: 145
 					Text: Status Bars:
 					Align: Right
 				DropDownButton@STATUS_BAR_DROPDOWN:
 					X: 400
 					Y: 265
-					Width: 170
+					Width: 180
 					Height: 25
 					Font: Regular
 					Text: Standard
 				Label@TARGET_LINES:
 					X: 250
-					Y: 243
+					Y: 242
 					Width: 145
 					Text: Target Lines:
 					Align: Right
 				DropDownButton@TARGET_LINES_DROPDOWN:
 					X: 400
 					Y: 230
-					Width: 170
+					Width: 180
 					Height: 25
 					Font: Regular
 				Label@LOCALIZATION_TITLE:
@@ -410,7 +415,7 @@ Background@SETTINGS_PANEL:
 					Width: 160
 					Height: 20
 					Font: Regular
-					Text: Scroll-zoom Modifier:
+					Text: Mouse Wheel Zoom Modifier:
 					Align: Right
 				DropDownButton@ZOOM_MODIFIER:
 					X: PARENT_RIGHT - WIDTH - 15
@@ -426,29 +431,22 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Edge Scrolling
-				Checkbox@ALLOW_ZOOM_CHECKBOX:
+				Checkbox@LOCKMOUSE_CHECKBOX:
 					X: 15
 					Y: 100
 					Width: 130
 					Height: 20
 					Font: Regular
-					Text: Scroll Zooming
-				Checkbox@LOCKMOUSE_CHECKBOX:
-					X: 15
-					Y: 130
-					Width: 130
-					Height: 20
-					Font: Regular
 					Text: Lock mouse to window
 				Label@SCROLL_SPEED_LABEL:
-					X: PARENT_RIGHT - WIDTH - 270
+					X: 15
 					Y: 129
-					Width: 95
+					Width: 85
 					Height: 25
 					Text: Scroll Speed:
 					Align: Right
 				Slider@SCROLLSPEED_SLIDER:
-					X: PARENT_RIGHT - WIDTH - 170
+					X: 95
 					Y: 133
 					Width: 100
 					Height: 20
@@ -456,20 +454,35 @@ Background@SETTINGS_PANEL:
 					MinimumValue: 10
 					MaximumValue: 50
 				Label@UI_SCROLL_SPEED_LABEL:
-					X: PARENT_RIGHT - WIDTH - 106
+					X: PARENT_RIGHT - WIDTH - 320
 					Y: 129
 					Width: 95
 					Height: 25
 					Text: UI Scroll:
 					Align: Right
 				Slider@UI_SCROLLSPEED_SLIDER:
-					X: PARENT_RIGHT - WIDTH - 6
+					X: PARENT_RIGHT - WIDTH - 220
 					Y: 133
 					Width: 100
 					Height: 20
 					Ticks: 5
 					MinimumValue: 1
 					MaximumValue: 100
+				Label@ZOOM_SPEED_LABEL:
+					X: PARENT_RIGHT - WIDTH - 106
+					Y: 129
+					Width: 95
+					Height: 25
+					Text: Zoom Speed:
+					Align: Right
+				ExponentialSlider@ZOOMSPEED_SLIDER:
+					X: PARENT_RIGHT - WIDTH - 6
+					Y: 133
+					Width: 95
+					Height: 20
+					Ticks: 5
+					MinimumValue: 0.01
+					MaximumValue: 0.4
 		Container@HOTKEYS_PANEL:
 			X: 5
 			Y: 50

--- a/mods/common/hotkeys/game.yaml
+++ b/mods/common/hotkeys/game.yaml
@@ -42,10 +42,6 @@ CycleStatusBars: COMMA
 	Description: Cycle status bars display
 	Types: World, Player, Spectator
 
-ResetZoom: PERIOD
-	Description: Reset zoom
-	Types: World, Player, Spectator
-
 ToggleMute: M
 	Description: Toggle audio mute
 	Types: World, Menu, Player, Spectator

--- a/mods/common/hotkeys/game.yaml
+++ b/mods/common/hotkeys/game.yaml
@@ -42,8 +42,8 @@ CycleStatusBars: COMMA
 	Description: Cycle status bars display
 	Types: World, Player, Spectator
 
-TogglePixelDouble: PERIOD
-	Description: Toggle pixel doubling
+ResetZoom: PERIOD
+	Description: Reset zoom
 	Types: World, Player, Spectator
 
 ToggleMute: M

--- a/mods/common/hotkeys/viewport.yaml
+++ b/mods/common/hotkeys/viewport.yaml
@@ -61,3 +61,15 @@ MapBookmarkSave04: R Ctrl
 MapBookmarkRestore04: R Alt
 	Description: Jump to bookmark 4
 	Types: Viewport, Player, Spectator
+
+ZoomIn: RIGHTBRACKET
+	Description: Zoom in
+	Types: Viewport, Player, Spectator
+
+ZoomOut: LEFTBRACKET
+	Description: Zoom out
+	Types: Viewport, Player, Spectator
+
+ResetZoom: PERIOD
+	Description: Reset zoom
+	Types: Viewport, Player, Spectator


### PR DESCRIPTION
This PR builds on #17308 and its prerequisites to finally implement the world "camera height" / custom resolution setting outlined in #10382. This also adds smooth mouse-wheel zooming and makes several changes to the zoom hotkeys and configuration to fit with the new and next changes.

A key part of this PR is an implementation of a custom scaling filter (inspired by [this article](https://colececil.io/blog/2017/scaling-pixel-art-without-destroying-it/)) that resamples the world frame buffer without excessive blurring or artifacting.

The focus for this PR is to support players (myself included) who have monitors where the native scaling is uncomfortably small, but pixel doubling is uncomfortably large. I've tried to take into account the feedback from the Discord discussion I started a few months ago, and think I've found a good solution that improves the default configuration for many players while giving people who prefer the old behaviour ways to preserve it.

There are several scope creeps that I considered but ruled out from implementing in this PR:

* Supporting zooms < 1, aside from keeping compatibility with the existing ability for spectators and the map editor - this requires deeper changes to the viewport scrolling code to work well, and opens up a can of wormy gameplay implications. More discussion and experimentation is required.
* Supporting zoom ranges more than just 1-2 - this requires deeper thought and community relations wrt the impact on the toggle zoom (now reset zoom) hotkey and breaking/changing muscle memory.
* Allowing missions / lobby options to restrict the maximum viewport size - this one should be fairly  safe, but is better as its own PR.
* Implementing the UI scaling half of #10382 - this is another large pile of work, which I will be continuing with in the next set of PRs.
* Scaling health bars etc - this is part of the UI scaling, above.


Depends on ~#17308~, ~#17431~, ~#17435.~

People on Windows with their DPI/desktop scaling not at 100% may need to disable `Graphics.DisableWindowsDPIScaling` to see the proper effect of this PR. This setting will be removed as part of the UI scaling overhaul.