### PR TITLE
Fix map editor rendering glitches

### DIFF
--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -66,9 +66,10 @@ namespace OpenRA.Graphics
 			return new IRenderable[] { imageRenderable };
 		}
 
-		public IRenderable[] RenderUI(int2 pos, WVec offset, int zOffset, PaletteReference palette, float scale)
+		public IRenderable[] RenderUI(WorldRenderer wr, int2 pos, WVec offset, int zOffset, PaletteReference palette, float scale)
 		{
-			var imagePos = pos - new int2((int)(scale * Image.Size.X / 2), (int)(scale * Image.Size.Y / 2));
+			var screenOffset = (scale * wr.ScreenVectorComponents(offset)).XY.ToInt2();
+			var imagePos = pos + screenOffset - new int2((int)(scale * Image.Size.X / 2), (int)(scale * Image.Size.Y / 2));
 			var imageRenderable = new UISpriteRenderable(Image, WPos.Zero + offset, imagePos, CurrentSequence.ZOffset + zOffset, palette, scale);
 
 			if (CurrentSequence.ShadowStart >= 0)

--- a/OpenRA.Mods.Common/Effects/SpriteAnnotation.cs
+++ b/OpenRA.Mods.Common/Effects/SpriteAnnotation.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Effects
 		IEnumerable<IRenderable> IEffectAnnotation.RenderAnnotation(WorldRenderer wr)
 		{
 			var screenPos = wr.Viewport.WorldToViewPx(wr.ScreenPxPosition(pos));
-			return anim.RenderUI(screenPos, WVec.Zero, 0, wr.Palette(palette), 1f);
+			return anim.RenderUI(wr, screenPos, WVec.Zero, 0, wr.Palette(palette), 1f);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Graphics/SpriteActorPreview.cs
+++ b/OpenRA.Mods.Common/Graphics/SpriteActorPreview.cs
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Graphics
 
 		IEnumerable<IRenderable> IActorPreview.RenderUI(WorldRenderer wr, int2 pos, float scale)
 		{
-			return animation.RenderUI(pos, offset(), zOffset(), pr, scale);
+			return animation.RenderUI(wr, pos, offset(), zOffset(), pr, scale);
 		}
 
 		IEnumerable<IRenderable> IActorPreview.Render(WorldRenderer wr, WPos pos)

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new EditorActorLayer(init.Self, this); }
 	}
 
-	public class EditorActorLayer : IWorldLoaded, ITickRender, IRender, IRadarSignature, ICreatePlayers
+	public class EditorActorLayer : IWorldLoaded, ITickRender, IRender, IRadarSignature, ICreatePlayers, IRenderAnnotations
 	{
 		readonly EditorActorLayerInfo info;
 		readonly List<EditorActorPreview> previews = new List<EditorActorPreview>();
@@ -102,6 +102,17 @@ namespace OpenRA.Mods.Common.Traits
 			// World-actor render traits don't require screen bounds
 			yield break;
 		}
+
+		public IEnumerable<IRenderable> RenderAnnotations(Actor self, WorldRenderer wr)
+		{
+			if (wr.World.Type != WorldType.Editor)
+				return NoRenderables;
+
+			return PreviewsInBox(wr.Viewport.TopLeft, wr.Viewport.BottomRight)
+				.SelectMany(p => p.RenderAnnotations());
+		}
+
+		bool IRenderAnnotations.SpatiallyPartitionable { get { return false; } }
 
 		public EditorActorPreview Add(ActorReference reference) { return Add(NextActorName(), reference); }
 

--- a/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorPreview.cs
@@ -112,10 +112,16 @@ namespace OpenRA.Mods.Common.Traits
 				var highlight = worldRenderer.Palette("highlight");
 				var overlay = items.Where(r => !r.IsDecoration)
 					.Select(r => r.WithPalette(highlight));
-				return items.Concat(overlay).Append(SelectionBox);
+				return items.Concat(overlay);
 			}
 
 			return items;
+		}
+
+		public IEnumerable<IRenderable> RenderAnnotations()
+		{
+			if (Selected)
+				yield return SelectionBox;
 		}
 
 		public void ReplaceInit<T>(T init)


### PR DESCRIPTION
This PR follows up on #17026 and #17095, porting the editor selection box to the UI renderers, and fixes #17337.

For full disclosure, there is a small polish issue where turrets in the sidebar/placement cursor may be offset by a fraction of a (world) pixel relative to placed units. This is only really noticable when you place a unit and move the cursor on and off it to blink between the two.

This has the same underlying cause as the voxel rendering differences - actor previews rendering in the sidebar/cursor contexts are quantized to a different pixel scale, so the results of rounding is slightly different. Fixing this properly will take a big effort for only a minor polish improvement to a developer tool, so I am not planning to tackle this any time soon.