### PR TITLE
Fix for RA2 Mod: cloning vats

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Buildings/ClonesProducedUnits.cs
+++ b/OpenRA.Mods.Cnc/Traits/Buildings/ClonesProducedUnits.cs
@@ -24,6 +24,10 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Uses the \"Cloneable\" trait to determine whether or not we should clone a produced unit.")]
 		public readonly BitSet<CloneableType> CloneableTypes = default(BitSet<CloneableType>);
 
+		[FieldLoader.Require]
+		[Desc("e.g. Infantry, Vehicles, Aircraft, Buildings")]
+		public readonly string ProductionType = "";
+
 		public override object Create(ActorInitializer init) { return new ClonesProducedUnits(init, this); }
 	}
 
@@ -55,7 +59,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			// Stop as soon as one production trait successfully produced
 			foreach (var p in productionTraits)
 			{
-				if (!string.IsNullOrEmpty(productionType) && !p.Info.Produces.Contains(productionType))
+				if (!string.IsNullOrEmpty(Info.ProductionType) && !p.Info.Produces.Contains(Info.ProductionType))
 					continue;
 
 				var inits = new TypeDictionary
@@ -64,7 +68,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					factionInit ?? new FactionInit(BuildableInfo.GetInitialFaction(produced.Info, p.Faction))
 				};
 
-				if (p.Produce(self, produced.Info, productionType, inits))
+				if (p.Produce(self, produced.Info, Info.ProductionType, inits))
 					return;
 			}
 		}


### PR DESCRIPTION
Fixes #17396

This fix will allow cloning vats in the RA2 mod to work correctly. 

The RA2 mod currently has a bug where the cloning vats don't work. This is because they're set to have a production type of Dummy, so that they can produce units. However there is a check in the OpenRA engine prevents new units of only the same type being produced. Because cloning vats should not be able to allow the construction of new units (you need a barracks to do this), it's set to a fake Dummy type. 

I was tempted to rip out the check altogether, however I'm unsure if other mods have buildings that use the cloning feature.

I've pulled the check out of the main function into its own function for readability. 