### PR TITLE
Overhaul cursor doubling feature

### DIFF
--- a/OpenRA.Game/Graphics/CursorProvider.cs
+++ b/OpenRA.Game/Graphics/CursorProvider.cs
@@ -20,6 +20,7 @@ namespace OpenRA.Graphics
 	{
 		public readonly IReadOnlyDictionary<string, CursorSequence> Cursors;
 		public readonly IReadOnlyDictionary<string, ImmutablePalette> Palettes;
+		public readonly bool DoubleCursorSize;
 
 		public CursorProvider(ModData modData)
 		{
@@ -47,9 +48,10 @@ namespace OpenRA.Graphics
 					cursors.Add(sequence.Key, new CursorSequence(frameCache, sequence.Key, s.Key, s.Value.Value, sequence.Value));
 
 			Cursors = cursors.AsReadOnly();
-		}
 
-		public static bool CursorViewportZoomed { get { return Game.Settings.Graphics.CursorDouble && Game.Settings.Graphics.PixelDouble; } }
+			// Cursor size changes are applied on game start
+			DoubleCursorSize = Game.Settings.Graphics.CursorDouble;
+		}
 
 		public bool HasCursorSequence(string cursor)
 		{

--- a/OpenRA.Game/Graphics/SoftwareCursor.cs
+++ b/OpenRA.Game/Graphics/SoftwareCursor.cs
@@ -81,11 +81,12 @@ namespace OpenRA.Graphics
 			if (cursorName == null)
 				return;
 
+			var doubleCursor = cursorProvider.DoubleCursorSize && cursorName != "default";
 			var cursorSequence = cursorProvider.GetCursorSequence(cursorName);
 			var cursorSprite = sprites[cursorName][(int)cursorFrame % cursorSequence.Length];
-			var cursorSize = CursorProvider.CursorViewportZoomed ? 2.0f * cursorSprite.Size : cursorSprite.Size;
+			var cursorSize = doubleCursor ? 2.0f * cursorSprite.Size : cursorSprite.Size;
 
-			var cursorOffset = CursorProvider.CursorViewportZoomed ?
+			var cursorOffset = doubleCursor ?
 				(2 * cursorSequence.Hotspot) + cursorSprite.Size.XY.ToInt2() :
 				cursorSequence.Hotspot + (0.5f * cursorSprite.Size.XY).ToInt2();
 

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -26,6 +26,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		static readonly WindowMode OriginalGraphicsMode;
 		static readonly int2 OriginalGraphicsWindowedSize;
 		static readonly int2 OriginalGraphicsFullscreenSize;
+		static readonly bool OriginalGraphicsHardwareCursors;
+		static readonly bool OriginalGraphicsCursorDouble;
 		static readonly bool OriginalServerDiscoverNatDevices;
 
 		readonly Dictionary<PanelType, Action> leavePanelActions = new Dictionary<PanelType, Action>();
@@ -52,6 +54,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			OriginalGraphicsMode = original.Graphics.Mode;
 			OriginalGraphicsWindowedSize = original.Graphics.WindowedSize;
 			OriginalGraphicsFullscreenSize = original.Graphics.FullscreenSize;
+			OriginalGraphicsHardwareCursors = original.Graphics.HardwareCursors;
+			OriginalGraphicsCursorDouble = original.Graphics.CursorDouble;
 			OriginalServerDiscoverNatDevices = original.Server.DiscoverNatDevices;
 		}
 
@@ -82,7 +86,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				    current.Graphics.Mode != OriginalGraphicsMode ||
 				    current.Graphics.WindowedSize != OriginalGraphicsWindowedSize ||
 					current.Graphics.FullscreenSize != OriginalGraphicsFullscreenSize ||
-					current.Server.DiscoverNatDevices != OriginalServerDiscoverNatDevices)
+					current.Server.DiscoverNatDevices != OriginalServerDiscoverNatDevices ||
+					current.Graphics.HardwareCursors != OriginalGraphicsHardwareCursors ||
+					current.Graphics.CursorDouble != OriginalGraphicsCursorDouble)
 				{
 					Action restart = () =>
 					{
@@ -222,13 +228,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				pixelDoubleOnClick();
 				worldRenderer.Viewport.Zoom = ds.PixelDouble ? 2 : 1;
 			};
-
-			// Cursor doubling is only supported with software cursors and when pixel doubling is enabled
-			var cursorDoubleCheckbox = panel.Get<CheckboxWidget>("CURSORDOUBLE_CHECKBOX");
-			cursorDoubleCheckbox.IsDisabled = () => !ds.PixelDouble || Game.Cursor is HardwareCursor;
-
-			var cursorDoubleIsChecked = cursorDoubleCheckbox.IsChecked;
-			cursorDoubleCheckbox.IsChecked = () => !cursorDoubleCheckbox.IsDisabled() && cursorDoubleIsChecked();
 
 			panel.Get("WINDOW_RESOLUTION").IsVisible = () => ds.Mode == WindowMode.Windowed;
 			var windowWidth = panel.Get<TextFieldWidget>("WINDOW_WIDTH");

--- a/OpenRA.Mods.Common/Widgets/MouseAttachmentWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MouseAttachmentWidget.cs
@@ -20,12 +20,14 @@ namespace OpenRA.Mods.Common.Widgets
 
 		Sprite sprite;
 		readonly WorldRenderer worldRenderer;
+		readonly CursorProvider cursorProvider;
 		string palette;
 		int2 location;
 
 		[ObjectCreator.UseCtor]
-		public MouseAttachmentWidget(WorldRenderer worldRenderer)
+		public MouseAttachmentWidget(ModData modData, WorldRenderer worldRenderer)
 		{
+			cursorProvider = modData.CursorProvider;
 			this.worldRenderer = worldRenderer;
 		}
 
@@ -33,7 +35,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			if (sprite != null && palette != null)
 			{
-				var scale = Game.Cursor is SoftwareCursor && CursorProvider.CursorViewportZoomed ? 2 : 1;
+				var scale = Game.Cursor is SoftwareCursor && cursorProvider.DoubleCursorSize ? 2 : 1;
 				var directionPalette = worldRenderer.Palette(palette);
 				WidgetUtils.DrawSHPCentered(sprite, ChildOrigin, directionPalette, scale);
 			}

--- a/OpenRA.Mods.Common/Widgets/TooltipContainerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TooltipContainerWidget.cs
@@ -19,6 +19,7 @@ namespace OpenRA.Mods.Common.Widgets
 	public class TooltipContainerWidget : Widget
 	{
 		static readonly Action Nothing = () => { };
+		readonly CursorProvider cursorProvider;
 
 		public int2 CursorOffset = new int2(0, 20);
 		public int BottomEdgeYOffset = -5;
@@ -29,6 +30,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public TooltipContainerWidget()
 		{
+			cursorProvider = Game.ModData.CursorProvider;
 			IsVisible = () => Game.RunTime > Viewport.LastMoveRunTime + TooltipDelayMilliseconds;
 		}
 
@@ -52,7 +54,7 @@ namespace OpenRA.Mods.Common.Widgets
 		{
 			get
 			{
-				var pos = Viewport.LastMousePos + (CursorProvider.CursorViewportZoomed ? CursorOffset * 2 : CursorOffset);
+				var pos = Viewport.LastMousePos + (cursorProvider.DoubleCursorSize ? CursorOffset * 2 : CursorOffset);
 				if (tooltip != null)
 				{
 					// If the tooltip overlaps the right edge of the screen, move it left until it fits
@@ -61,7 +63,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 					// If the tooltip overlaps the bottom edge of the screen, switch tooltip above cursor
 					if (pos.Y + tooltip.Bounds.Bottom > Game.Renderer.Resolution.Height)
-						pos = pos.WithY(Viewport.LastMousePos.Y + (CursorProvider.CursorViewportZoomed ? 2 : 1) * BottomEdgeYOffset - tooltip.Bounds.Height);
+						pos = pos.WithY(Viewport.LastMousePos.Y + (cursorProvider.DoubleCursorSize ? 2 : 1) * BottomEdgeYOffset - tooltip.Bounds.Height);
 				}
 
 				return pos;

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -245,6 +245,24 @@ namespace OpenRA.Platforms.Default
 			input = new Sdl2Input();
 		}
 
+		byte[] DoublePixelData(byte[] data, Size size)
+		{
+			var scaledData = new byte[4 * data.Length];
+			for (var y = 0; y < size.Height; y++)
+			{
+				for (var x = 0; x < size.Width; x++)
+				{
+					var a = 4 * (y * size.Width + x);
+					var b = 8 * (2 * y * size.Width + x);
+					var c = b + 8 * size.Width;
+					for (var i = 0; i < 4; i++)
+						scaledData[b + i] = scaledData[b + 4 + i] = scaledData[c + i] = scaledData[c + 4 + i] = data[a + i];
+				}
+			}
+
+			return scaledData;
+		}
+
 		public IHardwareCursor CreateHardwareCursor(string name, Size size, byte[] data, int2 hotspot)
 		{
 			VerifyThreadAffinity();
@@ -254,23 +272,9 @@ namespace OpenRA.Platforms.Default
 				// OSX does this for us automatically
 				if (Platform.CurrentPlatform != PlatformType.OSX && WindowScale > 1.5)
 				{
-					var scaledData = new byte[4 * data.Length];
-					for (var y = 0; y < size.Height * 4; y += 4)
-					{
-						for (var x = 0; x < size.Width * 4; x += 4)
-						{
-							var a = 4 * (y * size.Width + x);
-							var b = 4 * ((y + 1) * size.Width + x);
-							for (var i = 0; i < 4; i++)
-							{
-								scaledData[2 * a + i] = scaledData[2 * a + 4 + i] = data[a + i];
-								scaledData[2 * b + i] = scaledData[2 * b + 4 + i] = data[b + i];
-							}
-						}
-					}
-
+					data = DoublePixelData(data, size);
 					size = new Size(2 * size.Width, 2 * size.Height);
-					data = scaledData;
+					hotspot *= 2;
 				}
 
 				return new Sdl2HardwareCursor(size, data, hotspot);

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -277,6 +277,14 @@ namespace OpenRA.Platforms.Default
 					hotspot *= 2;
 				}
 
+				// Scale all but the "default" cursor if requested by the player
+				if (Game.Settings.Graphics.CursorDouble && name != "default")
+				{
+					data = DoublePixelData(data, size);
+					size = new Size(2 * size.Width, 2 * size.Height);
+					hotspot *= 2;
+				}
+
 				return new Sdl2HardwareCursor(size, data, hotspot);
 			}
 			catch (Exception ex)

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -125,14 +125,21 @@ Container@SETTINGS_PANEL:
 									MaxLength: 5
 									Type: Integer
 						Checkbox@HARDWARECURSORS_CHECKBOX:
-							X: 310
+							X: 80
 							Y: 75
 							Width: 200
 							Height: 20
 							Font: Regular
 							Text: Use Hardware Cursors
+						Checkbox@CURSORDOUBLE_CHECKBOX:
+							X: 300
+							Y: 75
+							Width: 200
+							Height: 20
+							Font: Regular
+							Text: Increase Command Cursor Size
 						Label@VIDEO_DESC:
-							Y: 92
+							Y: 97
 							Width: PARENT_RIGHT
 							Height: 25
 							Font: Tiny
@@ -152,13 +159,6 @@ Container@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Enable Pixel Doubling
-						Checkbox@CURSORDOUBLE_CHECKBOX:
-							X: 340
-							Y: 155
-							Width: 200
-							Height: 20
-							Font: Regular
-							Text: Also Double Cursor
 						Label@FRAME_LIMIT_DESC_A:
 							X: 45
 							Y: 153

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -139,14 +139,21 @@ Background@SETTINGS_PANEL:
 							MaxLength: 5
 							Type: Integer
 				Checkbox@HARDWARECURSORS_CHECKBOX:
-					X: 310
+					X: 80
 					Y: 75
 					Width: 200
 					Height: 20
 					Font: Regular
 					Text: Use Hardware Cursors
+				Checkbox@CURSORDOUBLE_CHECKBOX:
+					X: 300
+					Y: 75
+					Width: 200
+					Height: 20
+					Font: Regular
+					Text: Increase Command Cursor Size
 				Label@VIDEO_DESC:
-					Y: 93
+					Y: 97
 					Width: PARENT_RIGHT
 					Height: 25
 					Font: Tiny
@@ -166,13 +173,6 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Enable Pixel Doubling
-				Checkbox@CURSORDOUBLE_CHECKBOX:
-					X: 340
-					Y: 160
-					Width: 200
-					Height: 20
-					Font: Regular
-					Text: Also Double Cursor
 				Label@FRAME_LIMIT_DESC_A:
 					X: 45
 					Y: 159


### PR DESCRIPTION
This PR overhauls the cursor doubling feature in preparation for arbitrary zooming. The previous implementation was a limited hack, in that it only worked with software cursors, and only when pixel doubling is enabled.

The option now applies all the time when enabled (regardless of zoom state), except to the default pointer cursor - in both hardware and software cursor modes. This also fixes an issue with the pixel doubling code that meant we always fell back to software cursors on systems with >150% DPI scaling, and fixes the restart prompt not showing after changing the cursor settings.

Split from #17424 to simplify review and allow other PRs to be based on this.