### PR TITLE
Add VSync and overhaul frame limiter options

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -774,6 +774,7 @@ namespace OpenRA
 			var nextLogic = RunTime;
 			var nextRender = RunTime;
 			var forcedNextRender = RunTime;
+			var renderBeforeNextTick = false;
 
 			while (state == RunStatus.Running)
 			{
@@ -802,9 +803,9 @@ namespace OpenRA
 				var nextUpdate = Math.Min(nextLogic, nextRender);
 				if (now >= nextUpdate)
 				{
-					var forceRender = now >= forcedNextRender;
+					var forceRender = renderBeforeNextTick || now >= forcedNextRender;
 
-					if (now >= nextLogic)
+					if (now >= nextLogic && !renderBeforeNextTick)
 					{
 						nextLogic += logicInterval;
 
@@ -812,7 +813,7 @@ namespace OpenRA
 
 						// Force at least one render per tick during regular gameplay
 						if (OrderManager.World != null && !OrderManager.World.IsLoadingGameSave && !OrderManager.World.IsReplay)
-							forceRender = true;
+							renderBeforeNextTick = true;
 					}
 
 					var haveSomeTimeUntilNextLogic = now < nextLogic;
@@ -831,6 +832,7 @@ namespace OpenRA
 						forcedNextRender = now + maxRenderInterval;
 
 						RenderTick();
+						renderBeforeNextTick = false;
 					}
 				}
 				else

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -73,6 +73,7 @@ namespace OpenRA
 		void DisableDepthBuffer();
 		void ClearDepthBuffer();
 		void SetBlendMode(BlendMode mode);
+		void SetVSyncEnabled(bool enabled);
 		string GLVersion { get; }
 	}
 

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -427,6 +427,11 @@ namespace OpenRA
 			Window.Dispose();
 		}
 
+		public void SetVSyncEnabled(bool enabled)
+		{
+			Window.Context.SetVSyncEnabled(enabled);
+		}
+
 		public string GetClipboardText()
 		{
 			return Window.GetClipboardText();

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -152,8 +152,8 @@ namespace OpenRA
 		public bool CursorDouble = false;
 		public WorldViewport ViewportDistance = WorldViewport.Medium;
 
-		[Desc("Add a frame rate limiter. It is recommended to not disable this.")]
-		public bool CapFramerate = true;
+		[Desc("Add a frame rate limiter.")]
+		public bool CapFramerate = false;
 
 		[Desc("At which frames per second to cap the framerate.")]
 		public int MaxFramerate = 60;

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -138,6 +138,9 @@ namespace OpenRA
 		[Desc("This can be set to Windowed, Fullscreen or PseudoFullscreen.")]
 		public WindowMode Mode = WindowMode.PseudoFullscreen;
 
+		[Desc("Enable VSync.")]
+		public bool VSync = true;
+
 		[Desc("Screen resolution in fullscreen mode.")]
 		public int2 FullscreenSize = new int2(0, 0);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -205,6 +205,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			BindCheckboxPref(panel, "HARDWARECURSORS_CHECKBOX", ds, "HardwareCursors");
 			BindCheckboxPref(panel, "CURSORDOUBLE_CHECKBOX", ds, "CursorDouble");
+			BindCheckboxPref(panel, "VSYNC_CHECKBOX", ds, "VSync");
 			BindCheckboxPref(panel, "FRAME_LIMIT_CHECKBOX", ds, "CapFramerate");
 			BindCheckboxPref(panel, "PLAYER_STANCE_COLORS_CHECKBOX", gs, "UsePlayerStanceColors");
 
@@ -231,6 +232,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var battlefieldCameraLabel = new CachedTransform<WorldViewport, string>(vs => ViewportSizeNames[vs]);
 			battlefieldCameraDropDown.OnMouseDown = _ => ShowBattlefieldCameraDropdown(battlefieldCameraDropDown, ds);
 			battlefieldCameraDropDown.GetText = () => battlefieldCameraLabel.Update(ds.ViewportDistance);
+
+			// Update vsync immediately
+			var vsyncCheckbox = panel.Get<CheckboxWidget>("VSYNC_CHECKBOX");
+			var vsyncOnClick = vsyncCheckbox.OnClick;
+			vsyncCheckbox.OnClick = () =>
+			{
+				vsyncOnClick();
+				Game.Renderer.SetVSyncEnabled(ds.VSync);
+			};
 
 			panel.Get("WINDOW_RESOLUTION").IsVisible = () => ds.Mode == WindowMode.Windowed;
 			var windowWidth = panel.Get<TextFieldWidget>("WINDOW_WIDTH");

--- a/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
@@ -231,6 +231,12 @@ namespace OpenRA.Platforms.Default
 			OpenGL.CheckGLError();
 		}
 
+		public void SetVSyncEnabled(bool enabled)
+		{
+			VerifyThreadAffinity();
+			SDL.SDL_GL_SetSwapInterval(enabled ? 1 : 0);
+		}
+
 		public void Dispose()
 		{
 			if (disposed)

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -241,6 +241,8 @@ namespace OpenRA.Platforms.Default
 			else
 				context = new ThreadedGraphicsContext(new Sdl2GraphicsContext(this), batchSize);
 
+			context.SetVSyncEnabled(Game.Settings.Graphics.VSync);
+
 			SDL.SDL_SetModState(SDL.SDL_Keymod.KMOD_NONE);
 			input = new Sdl2Input();
 		}

--- a/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
+++ b/OpenRA.Platforms.Default/ThreadedGraphicsContext.cs
@@ -49,6 +49,7 @@ namespace OpenRA.Platforms.Default
 		Action<object> doDrawPrimitives;
 		Action<object> doEnableScissor;
 		Action<object> doSetBlendMode;
+		Action<object> doSetVSync;
 
 		public ThreadedGraphicsContext(Sdl2GraphicsContext context, int batchSize)
 		{
@@ -107,6 +108,7 @@ namespace OpenRA.Platforms.Default
 							context.EnableScissor(t.Item1, t.Item2, t.Item3, t.Item4);
 						};
 					doSetBlendMode = mode => { context.SetBlendMode((BlendMode)mode); };
+					doSetVSync = enabled => { context.SetVSyncEnabled((bool)enabled); };
 
 					Monitor.Pulse(syncObject);
 				}
@@ -444,6 +446,11 @@ namespace OpenRA.Platforms.Default
 		public void SetBlendMode(BlendMode mode)
 		{
 			Post(doSetBlendMode, mode);
+		}
+
+		public void SetVSyncEnabled(bool enabled)
+		{
+			Post(doSetVSync, enabled);
 		}
 	}
 

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -159,25 +159,14 @@ Container@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Enable Frame Limiter
-						Label@FRAME_LIMIT_DESC_A:
+						Slider@FRAME_LIMIT_SLIDER:
 							X: 340
-							Y: 153
-							Width: 50
-							Height: 25
-							Text: Limit to
-							Align: Right
-						TextField@FRAME_LIMIT_TEXTFIELD:
-							X: 395
-							Y: 153
-							Width: 45
-							Height: 25
-							MaxLength: 3
-							Type: Integer
-						Label@FRAME_LIMIT_DESC_B:
-							X: 445
-							Y: 153
-							Height: 25
-							Text: FPS
+							Y: 150
+							Width: 200
+							Height: 20
+							Ticks: 20
+							MinimumValue: 50
+							MaximumValue: 240
 						Checkbox@PLAYER_STANCE_COLORS_CHECKBOX:
 							X: 310
 							Y: 185

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -145,29 +145,36 @@ Container@SETTINGS_PANEL:
 							Font: Tiny
 							Align: Center
 							Text: Mode, resolution, and cursor changes will be applied after the game is restarted
+						Checkbox@VSYNC_CHECKBOX:
+							X: 80
+							Y: 125
+							Width: 200
+							Height: 20
+							Font: Regular
+							Text: Enable VSync
 						Checkbox@FRAME_LIMIT_CHECKBOX:
-							X: 15
+							X: 310
 							Y: 125
 							Width: 200
 							Height: 20
 							Font: Regular
 							Text: Enable Frame Limiter
 						Label@FRAME_LIMIT_DESC_A:
-							X: 45
+							X: 340
 							Y: 153
 							Width: 50
 							Height: 25
 							Text: Limit to
 							Align: Right
 						TextField@FRAME_LIMIT_TEXTFIELD:
-							X: 100
+							X: 395
 							Y: 153
 							Width: 45
 							Height: 25
 							MaxLength: 3
 							Type: Integer
 						Label@FRAME_LIMIT_DESC_B:
-							X: 150
+							X: 445
 							Y: 153
 							Height: 25
 							Text: FPS

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -173,25 +173,14 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Enable Frame Limiter
-				Label@FRAME_LIMIT_DESC_A:
-					X: 340
-					Y: 159
-					Width: 50
-					Height: 25
-					Text: Limit to
-					Align: Right
-				TextField@FRAME_LIMIT_TEXTFIELD:
-					X: 395
-					Y: 158
-					Width: 45
-					Height: 25
-					MaxLength: 3
-					Type: Integer
-				Label@FRAME_LIMIT_DESC_B:
-					X: 445
-					Y: 159
-					Height: 25
-					Text: FPS
+				Slider@FRAME_LIMIT_SLIDER:
+					X: 330
+					Y: 150
+					Width: 200
+					Height: 20
+					Ticks: 20
+					MinimumValue: 50
+					MaximumValue: 240
 				Checkbox@PLAYER_STANCE_COLORS_CHECKBOX:
 					X: 310
 					Y: 195

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -159,29 +159,36 @@ Background@SETTINGS_PANEL:
 					Font: Tiny
 					Align: Center
 					Text: Mode, resolution, and cursor changes will be applied after the game is restarted
+				Checkbox@VSYNC_CHECKBOX:
+					X: 80
+					Y: 125
+					Width: 200
+					Height: 20
+					Font: Regular
+					Text: Enable VSync
 				Checkbox@FRAME_LIMIT_CHECKBOX:
-					X: 15
+					X: 310
 					Y: 125
 					Width: 200
 					Height: 20
 					Font: Regular
 					Text: Enable Frame Limiter
 				Label@FRAME_LIMIT_DESC_A:
-					X: 45
+					X: 340
 					Y: 159
 					Width: 50
 					Height: 25
 					Text: Limit to
 					Align: Right
 				TextField@FRAME_LIMIT_TEXTFIELD:
-					X: 100
+					X: 395
 					Y: 158
 					Width: 45
 					Height: 25
 					MaxLength: 3
 					Type: Integer
 				Label@FRAME_LIMIT_DESC_B:
-					X: 150
+					X: 445
 					Y: 159
 					Height: 25
 					Text: FPS


### PR DESCRIPTION
This PR:
 * Exposes an ingame setting for VSync
 * Fixes the frame limiter to properly account for logic ticks
 * Replaces the frame limiter with VSync for the default configuration
 * Replaces the free-form text field with a slider

Fixes #15223.
Depends on ~#17435~ (to make space in the settings menu).

The slider limits the minimum FPS to 50 (= tick rate of the Fastest game speed) to avoid the problem that the frame-limiter is ignored if it is set lower than the logic tick rate.

This deliberately ignores adaptive vsync because that won't be supported when we move to Veldrid (https://github.com/mellinoe/veldrid/issues/132)