### PR TITLE
Move AUD support to Mods.Cnc

### DIFF
--- a/OpenRA.Mods.Cnc/AudioLoaders/AudLoader.cs
+++ b/OpenRA.Mods.Cnc/AudioLoaders/AudLoader.cs
@@ -11,9 +11,9 @@
 
 using System;
 using System.IO;
-using OpenRA.Mods.Common.FileFormats;
+using OpenRA.Mods.Cnc.FileFormats;
 
-namespace OpenRA.Mods.Common.AudioLoaders
+namespace OpenRA.Mods.Cnc.AudioLoaders
 {
 	public class AudLoader : ISoundLoader
 	{

--- a/OpenRA.Mods.Cnc/FileFormats/AudReader.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/AudReader.cs
@@ -12,9 +12,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using OpenRA.Mods.Common.FileFormats;
 using OpenRA.Primitives;
 
-namespace OpenRA.Mods.Common.FileFormats
+namespace OpenRA.Mods.Cnc.FileFormats
 {
 	[Flags]
 	enum SoundFlags

--- a/OpenRA.Mods.Common/FileFormats/ImaAdpcmReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/ImaAdpcmReader.cs
@@ -13,7 +13,7 @@ using System.IO;
 
 namespace OpenRA.Mods.Common.FileFormats
 {
-	struct ImaAdpcmChunk
+	public struct ImaAdpcmChunk
 	{
 		public int CompressedSize;
 		public int OutputSize;
@@ -23,14 +23,14 @@ namespace OpenRA.Mods.Common.FileFormats
 			ImaAdpcmChunk c;
 			c.CompressedSize = s.ReadUInt16();
 			c.OutputSize = s.ReadUInt16();
+
 			if (s.ReadUInt32() != 0xdeaf)
 				throw new InvalidDataException("Chunk header is bogus");
+
 			return c;
 		}
 	}
 
-	// Mostly a duplicate of AudReader, with some difference when loading
-	// TODO: Investigate whether they can be fused to get rid of some duplication
 	public class ImaAdpcmReader
 	{
 		static readonly int[] IndexAdjust = { -1, -1, -1, -1, 2, 4, 6, 8 };
@@ -48,21 +48,28 @@ namespace OpenRA.Mods.Common.FileFormats
 			16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767
 		};
 
-		static short DecodeImaAdpcmSample(byte b, ref int index, ref int current)
+		public static short DecodeImaAdpcmSample(byte b, ref int index, ref int current)
 		{
 			var sb = (b & 8) != 0;
 			b &= 7;
 
 			var delta = (StepTable[index] * b) / 4 + StepTable[index] / 8;
-			if (sb) delta = -delta;
+			if (sb)
+				delta = -delta;
 
 			current += delta;
-			if (current > short.MaxValue) current = short.MaxValue;
-			if (current < short.MinValue) current = short.MinValue;
+			if (current > short.MaxValue)
+				current = short.MaxValue;
+
+			if (current < short.MinValue)
+				current = short.MinValue;
 
 			index += IndexAdjust[b];
-			if (index < 0) index = 0;
-			if (index > 88) index = 88;
+			if (index < 0)
+				index = 0;
+
+			if (index > 88)
+				index = 88;
 
 			return (short)current;
 		}

--- a/OpenRA.Mods.Common/FileFormats/VqaReader.cs
+++ b/OpenRA.Mods.Common/FileFormats/VqaReader.cs
@@ -220,7 +220,7 @@ namespace OpenRA.Mods.Common.FileFormats
 			}
 
 			if (audioChannels == 1)
-				audioData = compressed ? AudReader.LoadSound(audio1.ToArray(), ref adpcmIndex) : audio1.ToArray();
+				audioData = compressed ? ImaAdpcmReader.LoadImaAdpcmSound(audio1.ToArray(), ref adpcmIndex) : audio1.ToArray();
 			else
 			{
 				byte[] leftData, rightData;
@@ -232,9 +232,9 @@ namespace OpenRA.Mods.Common.FileFormats
 				else
 				{
 					adpcmIndex = 0;
-					leftData = AudReader.LoadSound(audio1.ToArray(), ref adpcmIndex);
+					leftData = ImaAdpcmReader.LoadImaAdpcmSound(audio1.ToArray(), ref adpcmIndex);
 					adpcmIndex = 0;
-					rightData = AudReader.LoadSound(audio2.ToArray(), ref adpcmIndex);
+					rightData = ImaAdpcmReader.LoadImaAdpcmSound(audio2.ToArray(), ref adpcmIndex);
 				}
 
 				audioData = new byte[rightData.Length + leftData.Length];


### PR DESCRIPTION
I noticed that `VqaReader` doesn't actually depend on it, the `ImaAdpcmReader` is enough.
That means we can move the `AudLoader`/-`Reader` to `Mods.Cnc` independently from and ahead of the `VqaReader`.
Tested and confirmed that both VQA audio and regular sounds/music still work fine.