### PR TITLE
Move LCWCompression support to Mods.Cnc

### DIFF
--- a/OpenRA.Mods.Cnc/FileFormats/LCWCompression.cs
+++ b/OpenRA.Mods.Cnc/FileFormats/LCWCompression.cs
@@ -11,8 +11,9 @@
 
 using System;
 using System.IO;
+using OpenRA.Mods.Common.FileFormats;
 
-namespace OpenRA.Mods.Common.FileFormats
+namespace OpenRA.Mods.Cnc.FileFormats
 {
 	// Lempel - Castle - Welch algorithm (aka Format80)
 	public static class LCWCompression

--- a/OpenRA.Mods.Cnc/SpriteLoaders/ShpD2Loader.cs
+++ b/OpenRA.Mods.Cnc/SpriteLoaders/ShpD2Loader.cs
@@ -12,6 +12,7 @@
 using System;
 using System.IO;
 using OpenRA.Graphics;
+using OpenRA.Mods.Cnc.FileFormats;
 using OpenRA.Mods.Common.FileFormats;
 using OpenRA.Primitives;
 

--- a/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertLegacyMapCommand.cs
+++ b/OpenRA.Mods.Cnc/UtilityCommands/ImportRedAlertLegacyMapCommand.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using OpenRA.Mods.Cnc.FileFormats;
 using OpenRA.Mods.Common.FileFormats;
 using OpenRA.Mods.Common.UtilityCommands;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.Common/FileFormats/LCWCompression.cs
+++ b/OpenRA.Mods.Common/FileFormats/LCWCompression.cs
@@ -22,14 +22,11 @@ namespace OpenRA.Mods.Common.FileFormats
 			if (srcIndex > destIndex)
 				throw new NotImplementedException("srcIndex > destIndex {0} {1}".F(srcIndex, destIndex));
 
-			if (destIndex - srcIndex == 1)
+			for (var i = 0; i < count; i++)
 			{
-				for (var i = 0; i < count; i++)
+				if (destIndex - srcIndex == 1)
 					dest[destIndex + i] = dest[destIndex - 1];
-			}
-			else
-			{
-				for (var i = 0; i < count; i++)
+				else
 					dest[destIndex + i] = dest[srcIndex + i];
 			}
 		}
@@ -76,21 +73,10 @@ namespace OpenRA.Mods.Common.FileFormats
 						for (var end = destIndex + count; destIndex < end; destIndex++)
 							dest[destIndex] = color;
 					}
-					else if (count3 == 0x3F)
-					{
-						// case 5
-						var count = ctx.ReadWord();
-						var srcIndex = reverse ? destIndex - ctx.ReadWord() : ctx.ReadWord();
-						if (srcIndex >= destIndex)
-							throw new NotImplementedException("srcIndex >= destIndex {0} {1}".F(srcIndex, destIndex));
-
-						for (var end = destIndex + count; destIndex < end; destIndex++)
-							dest[destIndex] = dest[srcIndex++];
-					}
 					else
 					{
-						// case 3
-						var count = count3 + 3;
+						// If count3 == 0x3F it's case 5, else case 3
+						var count = count3 == 0x3F ? ctx.ReadWord() : count3 + 3;
 						var srcIndex = reverse ? destIndex - ctx.ReadWord() : ctx.ReadWord();
 						if (srcIndex >= destIndex)
 							throw new NotImplementedException("srcIndex >= destIndex {0} {1}".F(srcIndex, destIndex));


### PR DESCRIPTION
While the `VqaReader` still needs it, the required part is small enough that I figured we might as well duplicate it (temporarily) so we can move the full `LCWCompression` to `Mods.Cnc` _now_, and don't need to worry about it while solving the dependencies for moving the `VqaReader` to `Mods.Cnc`.