### PR TITLE
Add MinRange support to AffectsShroud

### DIFF
--- a/OpenRA.Mods.Common/Effects/RevealShroudEffect.cs
+++ b/OpenRA.Mods.Common/Effects/RevealShroudEffect.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (range == WDist.Zero)
 				return NoCells;
 
-			return Shroud.ProjectedCellsInRange(map, pos, range)
+			return Shroud.ProjectedCellsInRange(map, pos, WDist.Zero, range)
 				.ToArray();
 		}
 

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -97,6 +97,7 @@ MIG:
 	Health:
 		HP: 7500
 	RevealsShroud:
+		MinRange: 11c0
 		Range: 13c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
@@ -161,6 +162,7 @@ YAK:
 	Health:
 		HP: 6000
 	RevealsShroud:
+		MinRange: 9c0
 		Range: 11c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
@@ -229,6 +231,7 @@ TRAN:
 	Health:
 		HP: 14000
 	RevealsShroud:
+		MinRange: 6c0
 		Range: 8c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
@@ -284,6 +287,7 @@ HELI:
 	Health:
 		HP: 12000
 	RevealsShroud:
+		MinRange: 10c0
 		Range: 12c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
@@ -349,6 +353,7 @@ HIND:
 	Health:
 		HP: 10000
 	RevealsShroud:
+		MinRange: 8c0
 		Range: 10c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
@@ -449,6 +454,7 @@ MH60:
 	Health:
 		HP: 10000
 	RevealsShroud:
+		MinRange: 8c0
 		Range: 10c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -86,6 +86,7 @@ FCOM:
 		Description: Capture to give buildable area.
 		ValidStances: Neutral, Enemy
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -401,6 +402,7 @@ MISS:
 	Health:
 		HP: 60000
 	RevealsShroud:
+		MinRange: 6c0
 		Range: 10c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:

--- a/mods/ra/rules/husks.yaml
+++ b/mods/ra/rules/husks.yaml
@@ -111,6 +111,7 @@ TRAN.Husk:
 		Offset: 597,0,213
 		Sequence: rotor2
 	RevealsShroud:
+		MinRange: 6c0
 		Range: 8c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
@@ -175,6 +176,7 @@ MIG.Husk:
 		Interval: 2
 		MinDamage: Undamaged
 	RevealsShroud:
+		MinRange: 11c0
 		Range: 13c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
@@ -198,6 +200,7 @@ YAK.Husk:
 		Interval: 2
 		MinDamage: Undamaged
 	RevealsShroud:
+		MinRange: 9c0
 		Range: 11c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
@@ -221,6 +224,7 @@ HELI.Husk:
 		Offset: -427,0,0
 		MinDamage: Undamaged
 	RevealsShroud:
+		MinRange: 10c0
 		Range: 12c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
@@ -243,6 +247,7 @@ HIND.Husk:
 		Offset: -427,0,0
 		MinDamage: Undamaged
 	RevealsShroud:
+		MinRange: 8c0
 		Range: 10c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False
@@ -454,6 +459,7 @@ MH60.Husk:
 		Offset: -427,0,0
 		MinDamage: Undamaged
 	RevealsShroud:
+		MinRange: 8c0
 		Range: 10c0
 		Type: GroundPosition
 		RevealGeneratedShroud: False

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -21,6 +21,7 @@ SS:
 		TurnSpeed: 4
 		Speed: 71
 	RevealsShroud:
+		MinRange: 5c0
 		Range: 8c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -90,6 +91,7 @@ MSUB:
 		TurnSpeed: 3
 		Speed: 42
 	RevealsShroud:
+		MinRange: 5c0
 		Range: 8c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -161,6 +163,7 @@ DD:
 		TurnSpeed: 7
 		Speed: 85
 	RevealsShroud:
+		MinRange: 5c0
 		Range: 6c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -213,6 +216,7 @@ CA:
 		TurnSpeed: 3
 		Speed: 42
 	RevealsShroud:
+		MinRange: 5c0
 		Range: 7c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -275,6 +279,7 @@ LST:
 		Speed: 113
 		PauseOnCondition: notmobile
 	RevealsShroud:
+		MinRange: 5c0
 		Range: 6c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -315,6 +320,7 @@ PT:
 		TurnSpeed: 7
 		Speed: 128
 	RevealsShroud:
+		MinRange: 5c0
 		Range: 7c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -944,7 +944,7 @@ ATEK:
 		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
-		Range: 6c0
+		Range: 4c0
 	WithBuildingBib:
 	GpsPower:
 		PauseOnCondition: disabled

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -22,6 +22,7 @@ MSLO:
 	Armor:
 		Type: Wood
 	RevealsShroud:
+		MinRange: 5c0
 		Range: 6c0
 		RequiresCondition: !disabled
 		RevealGeneratedShroud: False
@@ -87,6 +88,7 @@ GAP:
 	Armor:
 		Type: Heavy
 	RevealsShroud:
+		MinRange: 5c0
 		Range: 6c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -141,6 +143,7 @@ SPEN:
 	Armor:
 		Type: Wood
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -287,6 +290,7 @@ SYRD:
 	Armor:
 		Type: Wood
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -412,6 +416,7 @@ IRON:
 	Armor:
 		Type: Wood
 	RevealsShroud:
+		MinRange: 5c0
 		Range: 6c0
 		RequiresCondition: !disabled
 		RevealGeneratedShroud: False
@@ -468,6 +473,7 @@ PDOX:
 	Armor:
 		Type: Wood
 	RevealsShroud:
+		MinRange: 5c0
 		Range: 6c0
 		RequiresCondition: !disabled
 		RevealGeneratedShroud: False
@@ -547,6 +553,7 @@ TSLA:
 	Armor:
 		Type: Heavy
 	RevealsShroud:
+		MinRange: 6c0
 		Range: 8c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -592,6 +599,7 @@ AGUN:
 	Armor:
 		Type: Heavy
 	RevealsShroud:
+		MinRange: 5c0
 		Range: 6c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -647,6 +655,7 @@ DOME:
 	Armor:
 		Type: Wood
 	RevealsShroud:
+		MinRange: 6c0
 		Range: 10c0
 		RequiresCondition: !disabled
 		RevealGeneratedShroud: False
@@ -687,6 +696,7 @@ PBOX:
 	Armor:
 		Type: Heavy
 	RevealsShroud:
+		MinRange: 5c0
 		Range: 6c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -737,6 +747,7 @@ HBOX:
 	Armor:
 		Type: Heavy
 	RevealsShroud:
+		MinRange: 5c0
 		Range: 6c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -792,6 +803,7 @@ GUN:
 	Armor:
 		Type: Heavy
 	RevealsShroud:
+		MinRange: 5c0
 		Range: 7c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -835,6 +847,7 @@ FTUR:
 	Armor:
 		Type: Heavy
 	RevealsShroud:
+		MinRange: 5c0
 		Range: 6c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -889,6 +902,7 @@ SAM:
 	Armor:
 		Type: Heavy
 	RevealsShroud:
+		MinRange: 5c0
 		Range: 8c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -941,6 +955,7 @@ ATEK:
 	Armor:
 		Type: Wood
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -985,6 +1000,7 @@ WEAP:
 	Armor:
 		Type: Wood
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -1124,6 +1140,7 @@ FACT:
 	Armor:
 		Type: Wood
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -1215,6 +1232,7 @@ PROC:
 	Armor:
 		Type: Wood
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -1333,6 +1351,7 @@ HPAD:
 	Armor:
 		Type: Wood
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -1426,6 +1445,7 @@ AFLD:
 	Armor:
 		Type: Wood
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -1667,6 +1687,7 @@ STEK:
 	Armor:
 		Type: Wood
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -1702,6 +1723,7 @@ BARR:
 	Armor:
 		Type: Wood
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -1881,6 +1903,7 @@ TENT:
 	Armor:
 		Type: Wood
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -1977,6 +2000,7 @@ FIX:
 	Armor:
 		Type: Wood
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -20,6 +20,7 @@ V2RL:
 	Mobile:
 		Speed: 85
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -70,6 +71,7 @@ V2RL:
 	Mobile:
 		Speed: 118
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -113,6 +115,7 @@ V2RL:
 	Mobile:
 		Speed: 85
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 6c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -159,6 +162,7 @@ V2RL:
 	Mobile:
 		Speed: 71
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 6c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -206,6 +210,7 @@ V2RL:
 		Speed: 50
 		Locomotor: heavytracked
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 6c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -265,6 +270,7 @@ ARTY:
 		Speed: 85
 		Locomotor: lighttracked
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -400,6 +406,7 @@ JEEP:
 		Speed: 170
 		PauseOnCondition: notmobile || being-captured
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 8c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -445,6 +452,7 @@ APC:
 		Speed: 142
 		PauseOnCondition: notmobile || being-captured
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -484,6 +492,7 @@ MNLY:
 	Mobile:
 		Speed: 128
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 5c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -554,6 +563,7 @@ MGG:
 		Offset: -299,0,171
 		Sequence: spinner
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 6c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -624,6 +634,7 @@ TTNK:
 	Mobile:
 		Speed: 99
 	RevealsShroud:
+		MinRange: 6c0
 		Range: 7c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -664,6 +675,7 @@ FTRK:
 		TurnSpeed: 10
 		Speed: 118
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 6c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -754,6 +766,7 @@ CTNK:
 		Speed: 113
 		Locomotor: heavywheeled
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 6c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -799,6 +812,7 @@ QTNK:
 	Chronoshiftable:
 		RequiresCondition: !deployed && !being-captured
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 6c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:
@@ -838,6 +852,7 @@ STNK:
 		Locomotor: heavywheeled
 		PauseOnCondition: notmobile || being-captured
 	RevealsShroud:
+		MinRange: 4c0
 		Range: 7c0
 		RevealGeneratedShroud: False
 	RevealsShroud@GAPGEN:


### PR DESCRIPTION
This is then used to remove the overlap between the two vision traits on RA actors. Testing against `release-20191117` with 100 Yaks shows a tick time improvement from ~50 to ~30ms. This plus #17397 should give the hotfix better vision performance than `release-20190314`.

This shouldn't conflict with #17383, and may give us a much smaller (possibly negligible) improvement on top of it. In any case, the minimum range support may be useful for modders.


This also fixes the bogus vision definition for the allied tech center in RA to avoid having a minrange > maxrange.