### PR TITLE
Fix ants teleporting into the map area in ant-01

### DIFF
--- a/mods/ra/maps/ant-01/ant-attack.lua
+++ b/mods/ra/maps/ant-01/ant-attack.lua
@@ -13,8 +13,9 @@ SendAnts = true
 
 AttackAngles = {
 	{ waypoint4.Location, waypoint18.Location, waypoint5.Location, waypoint15.Location },
-	{ waypoint20.Location, waypoint10.Location, waypoint2.Location },
-	{ waypoint17.Location, waypoint1.Location },
+	{ waypoint20.Location, waypoint2.Location },
+	{ waypoint21.Location, waypoint10.Location, waypoint2.Location },
+	{ waypoint7.Location, waypoint17.Location, waypoint1.Location },
 	{ waypoint8.Location, waypoint9.Location, waypoint19.Location }
 }
 


### PR DESCRIPTION
Waypoint17 is not at the map edge, waypoint7 is.
Also fixes a path, since waypoint20 -> waypoint10 is going back and makes no sense.
Going directly waypoint20 -> waypoint2 works and as compensation I added
waypoint21 -> waypoint10 -> waypoint2.