### PR TITLE
Fix for mod credits overriding engine credits

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ Previous developers included:
     * Tom Roostan (RoosterDragon)
 
 Also thanks to:
+    * abmyii
     * Adam Valy (Tschokky)
     * Akseli Virtanen (RAGEQUIT)
     * Alexander Fast (mizipzor)

--- a/OpenRA.Mods.Common/Widgets/Logic/CreditsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/CreditsLogic.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using OpenRA.Widgets;
 
@@ -39,7 +40,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				onExit();
 			};
 
-			engineLines = ParseLines("AUTHORS");
+			engineLines = ParseLines(File.OpenRead(Platform.ResolvePath("./AUTHORS")));
 
 			var tabContainer = panel.Get("TAB_CONTAINER");
 			var modTab = tabContainer.Get<ButtonWidget>("MOD_TAB");
@@ -57,7 +58,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (hasModCredits)
 			{
 				var modCredits = modData.Manifest.Get<ModCredits>();
-				modLines = ParseLines(modCredits.ModCreditsFile);
+				modLines = ParseLines(modData.DefaultFileSystem.Open(modCredits.ModCreditsFile));
 				modTab.GetText = () => modCredits.ModTabTitle;
 
 				// Make space to show the tabs
@@ -82,12 +83,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 		}
 
-		IEnumerable<string> ParseLines(string file)
+		IEnumerable<string> ParseLines(Stream file)
 		{
-			return modData.DefaultFileSystem.Open(file)
-				.ReadAllLines()
-				.Select(l => l.Replace("\t", "    ").Replace("*", "\u2022"))
-				.ToList();
+			return file.ReadAllLines().Select(l => l.Replace("\t", "    ").Replace("*", "\u2022")).ToList();
 		}
 	}
 }


### PR DESCRIPTION
Fix for #17459. Adds a `bool` switch to decide whether to load file from base directory or mod directory. Not sure if this would be classed as a workaround or not, but works fine.