### PR TITLE
Fix duplicated/distorted SequencePlaceBuildingPreview annotations.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/SequencePlaceBuildingPreview.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/SequencePlaceBuildingPreview.cs
@@ -82,9 +82,6 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override IEnumerable<IRenderable> RenderInner(WorldRenderer wr, CPos topLeft, Dictionary<CPos, PlaceBuildingCellType> footprint)
 		{
-			foreach (var r in RenderAnnotations(wr, topLeft))
-				yield return r;
-
 			if (info.FootprintUnderPreview != PlaceBuildingCellType.None)
 				foreach (var r in RenderFootprint(wr, topLeft, footprint, info.FootprintUnderPreview))
 					yield return r;


### PR DESCRIPTION
Fixes an oversight / bug from #17095 which causes a second distorted building placement circle to be rendered when placing an ore refinery in RA.  In the final implementation `RenderAnnotations` is called via the base `FootprintPlaceBuildingPreviewPreview` - `SequencePlaceBuildingPreview` doesn't need know about it at all.