### PR TITLE
Add Shift+Tab hotkey for switching between team/all chat

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -141,7 +141,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				chatText.Text = tabCompletion.Complete(chatText.Text);
 				chatText.CursorPosition = chatText.Text.Length;
 
-				if (chatText.Text == previousText && !disableTeamChat)
+				if ((chatText.Text == previousText || Game.GetModifierKeys().HasModifier(Modifiers.Shift)) && !disableTeamChat)
 					teamChat ^= true;
 
 				return true;
@@ -169,6 +169,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 					if (!chatChrome.IsVisible() && (e.Key == Keycode.RETURN || e.Key == Keycode.KP_ENTER))
 					{
+						// If enabled, set to team chat without Shift modifier otherwise all chat
+						teamChat = !disableTeamChat & !Game.GetModifierKeys().HasModifier(Modifiers.Shift);
+
 						OpenChat();
 						return true;
 					}

--- a/mods/common/chrome/ingame-chat.yaml
+++ b/mods/common/chrome/ingame-chat.yaml
@@ -25,6 +25,8 @@ Container@CHAT_PANEL:
 					Height: 25
 					Text: Team
 					Font: Bold
+					TooltipContainer: TOOLTIP_CONTAINER
+					TooltipText: Enter/Shift+Enter for team/all chat
 				TextField@CHAT_TEXTFIELD:
 					X: 55
 					Y: PARENT_BOTTOM - HEIGHT


### PR DESCRIPTION
Fixes #17446. Adds Shift+Tab hotkey for switching between chat types, but keeps prior functionality.