### PR TITLE
Improve discoverability of dummy sound device

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -353,6 +353,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var muteCheckbox = panel.Get<CheckboxWidget>("MUTE_SOUND");
 			var muteCheckboxOnClick = muteCheckbox.OnClick;
+			var muteCheckboxIsChecked = muteCheckbox.IsChecked;
+			muteCheckbox.IsChecked = () => muteCheckboxIsChecked() || Game.Sound.DummyEngine;
+			muteCheckbox.IsDisabled = () => Game.Sound.DummyEngine;
 			muteCheckbox.OnClick = () =>
 			{
 				muteCheckboxOnClick();
@@ -363,12 +366,23 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					Game.Sound.UnmuteAudio();
 			};
 
-			if (!ss.Mute)
-			{
-				panel.Get<SliderWidget>("SOUND_VOLUME").OnChange += x => Game.Sound.SoundVolume = x;
-				panel.Get<SliderWidget>("MUSIC_VOLUME").OnChange += x => Game.Sound.MusicVolume = x;
-				panel.Get<SliderWidget>("VIDEO_VOLUME").OnChange += x => Game.Sound.VideoVolume = x;
-			}
+			// Replace controls with a warning label if sound is disabled
+			var noDeviceLabel = panel.GetOrNull("NO_AUDIO_DEVICE");
+			if (noDeviceLabel != null)
+				noDeviceLabel.Visible = Game.Sound.DummyEngine;
+
+			var controlsContainer = panel.GetOrNull("AUDIO_CONTROLS");
+			if (controlsContainer != null)
+				controlsContainer.Visible = !Game.Sound.DummyEngine;
+
+			var soundVolumeSlider = panel.Get<SliderWidget>("SOUND_VOLUME");
+			soundVolumeSlider.OnChange += x => Game.Sound.SoundVolume = x;
+
+			var musicVolumeSlider = panel.Get<SliderWidget>("MUSIC_VOLUME");
+			musicVolumeSlider.OnChange += x => Game.Sound.MusicVolume = x;
+
+			var videoVolumeSlider = panel.Get<SliderWidget>("VIDEO_VOLUME");
+			videoVolumeSlider.OnChange += x => Game.Sound.VideoVolume = x;
 
 			var devices = Game.Sound.AvailableDevices();
 			soundDevice = devices.FirstOrDefault(d => d.Device == ss.Device) ?? devices.First();

--- a/OpenRA.Platforms.Default/DummySoundEngine.cs
+++ b/OpenRA.Platforms.Default/DummySoundEngine.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Platforms.Default
 		{
 			var defaultDevices = new[]
 			{
-				new SoundDevice(null, "Default Output"),
+				new SoundDevice(null, "No Sound Output"),
 			};
 
 			return defaultDevices;

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -286,59 +286,68 @@ Container@SETTINGS_PANEL:
 							Font: Bold
 							Text: Audio
 							Align: Center
-						Label@SOUND_LABEL:
-							X: PARENT_RIGHT - WIDTH - 270
-							Y: 38
-							Width: 95
-							Height: 25
-							Align: Right
-							Text: Sound Volume:
-						ExponentialSlider@SOUND_VOLUME:
-							X: PARENT_RIGHT - WIDTH - 15
-							Y: 43
-							Width: 250
-							Height: 20
-							Ticks: 7
-						Checkbox@CASH_TICKS:
-							X: 15
-							Y: 40
-							Width: 200
-							Height: 20
-							Font: Regular
-							Text: Cash Ticks
-						Checkbox@MUTE_SOUND:
-							X: 15
-							Y: 70
-							Width: 200
-							Height: 20
-							Font: Regular
-							Text: Mute Sound
-						Label@MUSIC_LABEL:
-							X: PARENT_RIGHT - WIDTH - 270
-							Y: 68
-							Width: 95
-							Height: 25
-							Align: Right
-							Text: Music Volume:
-						ExponentialSlider@MUSIC_VOLUME:
-							X: PARENT_RIGHT - WIDTH - 15
-							Y: 73
-							Width: 250
-							Height: 20
-							Ticks: 7
-						Label@VIDEO_LABEL:
-							X: PARENT_RIGHT - WIDTH - 270
-							Y: 98
-							Width: 95
-							Height: 25
-							Align: Right
-							Text: Video Volume:
-						ExponentialSlider@VIDEO_VOLUME:
-							X: PARENT_RIGHT - WIDTH - 15
-							Y: 103
-							Width: 250
-							Height: 20
-							Ticks: 7
+						Label@NO_AUDIO_DEVICE:
+							Y: 50
+							Width: PARENT_RIGHT
+							Align: Center
+							Text: Audio controls require an active sound device
+						Container@AUDIO_CONTROLS:
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Children:
+								Label@SOUND_LABEL:
+									X: PARENT_RIGHT - WIDTH - 270
+									Y: 38
+									Width: 95
+									Height: 25
+									Align: Right
+									Text: Sound Volume:
+								ExponentialSlider@SOUND_VOLUME:
+									X: PARENT_RIGHT - WIDTH - 15
+									Y: 43
+									Width: 250
+									Height: 20
+									Ticks: 7
+								Checkbox@CASH_TICKS:
+									X: 15
+									Y: 40
+									Width: 200
+									Height: 20
+									Font: Regular
+									Text: Cash Ticks
+								Checkbox@MUTE_SOUND:
+									X: 15
+									Y: 70
+									Width: 200
+									Height: 20
+									Font: Regular
+									Text: Mute Sound
+								Label@MUSIC_LABEL:
+									X: PARENT_RIGHT - WIDTH - 270
+									Y: 68
+									Width: 95
+									Height: 25
+									Align: Right
+									Text: Music Volume:
+								ExponentialSlider@MUSIC_VOLUME:
+									X: PARENT_RIGHT - WIDTH - 15
+									Y: 73
+									Width: 250
+									Height: 20
+									Ticks: 7
+								Label@VIDEO_LABEL:
+									X: PARENT_RIGHT - WIDTH - 270
+									Y: 98
+									Width: 95
+									Height: 25
+									Align: Right
+									Text: Video Volume:
+								ExponentialSlider@VIDEO_VOLUME:
+									X: PARENT_RIGHT - WIDTH - 15
+									Y: 103
+									Width: 250
+									Height: 20
+									Ticks: 7
 						Label@AUDIO_DEVICE_LABEL:
 							X: 190 - WIDTH - 5
 							Y: 245

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -296,59 +296,68 @@ Background@SETTINGS_PANEL:
 			Width: PARENT_RIGHT - 10
 			Height: PARENT_BOTTOM
 			Children:
-				Label@SOUND_LABEL:
-					X: PARENT_RIGHT - WIDTH - 270
-					Y: 39
-					Width: 95
-					Height: 25
-					Align: Right
-					Text: Sound Volume:
-				ExponentialSlider@SOUND_VOLUME:
-					X: PARENT_RIGHT - WIDTH - 15
-					Y: 43
-					Width: 250
-					Height: 20
-					Ticks: 7
-				Checkbox@CASH_TICKS:
-					X: 15
-					Y: 40
-					Width: 200
-					Height: 20
-					Font: Regular
-					Text: Cash Ticks
-				Checkbox@MUTE_SOUND:
-					X: 15
-					Y: 70
-					Width: 200
-					Height: 20
-					Font: Regular
-					Text: Mute Sound
-				Label@MUSIC_LABEL:
-					X: PARENT_RIGHT - WIDTH - 270
-					Y: 69
-					Width: 95
-					Height: 25
-					Align: Right
-					Text: Music Volume:
-				ExponentialSlider@MUSIC_VOLUME:
-					X: PARENT_RIGHT - WIDTH - 15
-					Y: 73
-					Width: 250
-					Height: 20
-					Ticks: 7
-				Label@VIDEO_LABEL:
-					X: PARENT_RIGHT - WIDTH - 270
-					Y: 99
-					Width: 95
-					Height: 25
-					Align: Right
-					Text: Video Volume:
-				ExponentialSlider@VIDEO_VOLUME:
-					X: PARENT_RIGHT - WIDTH - 15
-					Y: 103
-					Width: 250
-					Height: 20
-					Ticks: 7
+				Label@NO_AUDIO_DEVICE:
+					Y: 50
+					Width: PARENT_RIGHT
+					Align: Center
+					Text: Audio controls require an active sound device
+				Container@AUDIO_CONTROLS:
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
+					Children:
+						Label@SOUND_LABEL:
+							X: PARENT_RIGHT - WIDTH - 270
+							Y: 39
+							Width: 95
+							Height: 25
+							Align: Right
+							Text: Sound Volume:
+						ExponentialSlider@SOUND_VOLUME:
+							X: PARENT_RIGHT - WIDTH - 15
+							Y: 43
+							Width: 250
+							Height: 20
+							Ticks: 7
+						Checkbox@CASH_TICKS:
+							X: 15
+							Y: 40
+							Width: 200
+							Height: 20
+							Font: Regular
+							Text: Cash Ticks
+						Checkbox@MUTE_SOUND:
+							X: 15
+							Y: 70
+							Width: 200
+							Height: 20
+							Font: Regular
+							Text: Mute Sound
+						Label@MUSIC_LABEL:
+							X: PARENT_RIGHT - WIDTH - 270
+							Y: 69
+							Width: 95
+							Height: 25
+							Align: Right
+							Text: Music Volume:
+						ExponentialSlider@MUSIC_VOLUME:
+							X: PARENT_RIGHT - WIDTH - 15
+							Y: 73
+							Width: 250
+							Height: 20
+							Ticks: 7
+						Label@VIDEO_LABEL:
+							X: PARENT_RIGHT - WIDTH - 270
+							Y: 99
+							Width: 95
+							Height: 25
+							Align: Right
+							Text: Video Volume:
+						ExponentialSlider@VIDEO_VOLUME:
+							X: PARENT_RIGHT - WIDTH - 15
+							Y: 103
+							Width: 250
+							Height: 20
+							Ticks: 7
 				Label@AUDIO_DEVICE_LABEL:
 					X: 190 - WIDTH - 5
 					Y: 245


### PR DESCRIPTION
This PR expands on #17245 to make it more obvious to players why their sound isn't working when the dummy sound device is active.

The first commit renames the sound device exposed in the settings.
The second commit disables the options when the sound is disabled or muted. It also fixes a silly bug where the sliders won't work at all if the sound is muted when the settings menu is first opened.

If the second commit is considered weird, I could instead display a label warning that the sound is disabled so changing them won't do anything, and find a different fix to whatever the mute code was trying to do.