### PR TITLE
Make attack moving and guarding use a grouped order 

### DIFF
--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -338,7 +338,12 @@ namespace OpenRA.Network
 
 				default:
 					{
-						ResolveOrder(order);
+						if (order.GroupedActors == null)
+							ResolveOrder(order);
+						else
+							foreach (var subject in order.GroupedActors)
+								ResolveOrder(Order.FromGroupedOrder(order, subject));
+
 						break;
 					}
 			}

--- a/OpenRA.Game/Orders/GenericSelectTarget.cs
+++ b/OpenRA.Game/Orders/GenericSelectTarget.cs
@@ -10,7 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
-using OpenRA.Graphics;
+using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Orders
@@ -53,8 +53,7 @@ namespace OpenRA.Orders
 				world.CancelInputMode();
 
 				var queued = mi.Modifiers.HasModifier(Modifiers.Shift);
-				foreach (var subject in Subjects)
-					yield return new Order(OrderName, subject, Target.FromCell(world, cell), queued);
+				yield return new Order(OrderName, null, Target.FromCell(world, cell), queued, null, Subjects.ToArray());
 			}
 		}
 

--- a/OpenRA.Game/Server/ProtocolVersion.cs
+++ b/OpenRA.Game/Server/ProtocolVersion.cs
@@ -66,6 +66,6 @@ namespace OpenRA.Server
 		// The protocol for server and world orders
 		// This applies after the handshake has completed, and is provided to support
 		// alternative server implementations that wish to support multiple versions in parallel
-		public const int Orders = 9;
+		public const int Orders = 10;
 	}
 }

--- a/OpenRA.Game/VoiceExts.cs
+++ b/OpenRA.Game/VoiceExts.cs
@@ -57,7 +57,13 @@ namespace OpenRA
 				if (o == null)
 					continue;
 
-				if (PlayVoiceForOrder(o))
+				if (o.GroupedActors != null)
+				{
+					foreach (var subject in o.GroupedActors)
+						if (PlayVoiceForOrder(Order.FromGroupedOrder(o, subject)))
+							return;
+				}
+				else if (PlayVoiceForOrder(o))
 					return;
 			}
 		}

--- a/OpenRA.Mods.Common/Orders/GuardOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/GuardOrderGenerator.cs
@@ -34,9 +34,7 @@ namespace OpenRA.Mods.Common.Orders
 			world.CancelInputMode();
 
 			var queued = mi.Modifiers.HasModifier(Modifiers.Shift);
-			foreach (var subject in Subjects)
-				if (subject != target)
-					yield return new Order(OrderName, subject, Target.FromActor(target), queued);
+			yield return new Order(OrderName, null, Target.FromActor(target), queued, null, Subjects.Where(s => s != target).ToArray());
 		}
 
 		public override void Tick(World world)

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -117,8 +117,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				// Cells outside the playable area should be clamped to the edge for consistency with move orders
 				cell = world.Map.Clamp(cell);
-				foreach (var s in subjects)
-					yield return new Order(orderName, s.Actor, Target.FromCell(world, cell), queued);
+				yield return new Order(orderName, null, Target.FromCell(world, cell), queued, null, subjects.Select(s => s.Actor).ToArray());
 			}
 		}
 


### PR DESCRIPTION
Currently issuing an attack move order for n selected units means the game sends n orders over the network. This PR reduces that to a single order by introducing a new `Grouped` flag for orders which indicates that the order is to be carried out for each actor in `ExtraActors` individually.

I only made attack moving and guarding use that grouping since it is very simple to implement for them and shouldn't bring many surprises. That way we can hopefully get this PR quicker out of the way (I still might split a few things off into new PRs although I tried to use commits for easy reviewing) and only then in a follow-up look at introducing this for the more general `UnitOrderGenerator`. (If we don't figure it is not worth the complexity.)

Out of curiosity I did two quick tests on how much this actually helps (if it is worth, and because I was too lazy to calculate this theoretically [we mostly save the bytes for the order string]).

Ordering 20 attack moves for 5 units:

|  | On bleed | On this PR |
| --- | --- | --- |
| Length of serialized orders | 2318 bytes | 922 bytes |
| Number of orders sent | 100 | 20 |

Ordering 10 attack moves for 100 units:

|  | On bleed | On this PR |
| --- | --- | --- |
| Length of serialized orders | 23751 bytes | 4964 bytes |
| Number of orders sent | 1000 | 10 |