### PR TITLE
Remove ISync from RallyPoint

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new RallyPoint(init.Self, this); }
 	}
 
-	public class RallyPoint : IIssueOrder, IResolveOrder, ISync, INotifyOwnerChanged, INotifyCreated
+	public class RallyPoint : IIssueOrder, IResolveOrder, INotifyOwnerChanged, INotifyCreated
 	{
 		const string OrderID = "SetRallyPoint";
 


### PR DESCRIPTION
Resolves the `OpenRA.Utility(1,1): Warning: OpenRA.Mods.Common.Traits.RallyPoint implements ISync but does not use the Sync attribute on any members.` warning `make test` produces on bleed. #17021 removed the last `Sync` attribute from `RallyPoint`.