### PR TITLE
Make the command bar directly check if a GuardOrderGenerator is active

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
@@ -114,8 +114,7 @@ namespace OpenRA.Mods.Common.Widgets
 				BindButtonIcon(guardButton);
 
 				guardButton.IsDisabled = () => { UpdateStateIfNecessary(); return guardDisabled; };
-				guardButton.IsHighlighted = () => world.OrderGenerator is GenericSelectTarget
-					&& ((GenericSelectTarget)world.OrderGenerator).OrderName == "Guard";
+				guardButton.IsHighlighted = () => world.OrderGenerator is GuardOrderGenerator;
 
 				Action<bool> toggle = allowCancel =>
 				{


### PR DESCRIPTION
Not sure why it was checking against `GenericOrderGenerator` (which `GuardOrderGenerator` inherits) and the `OrderString` in the first place. The command bar explicitly sets `world.OrderGenerator` to an instance of `GuardOrderGenerator` when the hotkey or button is pressed, so this should be a safe change (and I didn't spot a regression ingame either).