### PR TITLE
Move unit order resolving into a helper function

### DIFF
--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -338,13 +338,17 @@ namespace OpenRA.Network
 
 				default:
 					{
-						if (order.Subject != null && !order.Subject.IsDead)
-							foreach (var t in order.Subject.TraitsImplementing<IResolveOrder>())
-								t.ResolveOrder(order.Subject, order);
-
+						ResolveOrder(order);
 						break;
 					}
 			}
+		}
+
+		static void ResolveOrder(Order order)
+		{
+			if (order.Subject != null && !order.Subject.IsDead)
+				foreach (var t in order.Subject.TraitsImplementing<IResolveOrder>())
+					t.ResolveOrder(order.Subject, order);
 		}
 
 		static void SetOrderLag(OrderManager o)


### PR DESCRIPTION
Split from #17472. This change is trivial and hopefully easy/quick to review. This will help to reduce the diff at #17472 so we can focus on the order changes there.