### PR TITLE
Remove a nowadays unnecessary loop safeguard

### DIFF
--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -213,9 +213,8 @@ namespace OpenRA.Mods.Common.Widgets
 			world.PlayVoiceForOrders(orders);
 
 			var flashed = false;
-			foreach (var order in orders)
+			foreach (var o in orders)
 			{
-				var o = order;
 				if (o == null)
 					continue;
 


### PR DESCRIPTION
Split from #17472. This change is trivial and hopefully easy/quick to review. This will help to reduce the diff at #17472 so we can focus on the order changes there.
Afaik this issue was fixed in C# >= 5.0.