### PR TITLE
Add a hotkey to select the current production facility

### DIFF
--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -1798,6 +1798,7 @@ Container@PLAYER_WIDGETS:
 			HoldText: On Hold
 			HotkeyPrefix: Production
 			HotkeyCount: 24
+			SelectProductionBuildingHotkey: SelectProductionBuilding
 		ProductionTabs@PRODUCTION_TABS:
 			Logic: AddFactionSuffixLogic, ProductionTabsLogic
 			PaletteWidget: PRODUCTION_PALETTE

--- a/mods/common/hotkeys/production-common.yaml
+++ b/mods/common/hotkeys/production-common.yaml
@@ -1,8 +1,8 @@
-CycleProductionBuildings: TAB
+CycleProductionBuildings: TAB Ctrl
 	Description: Next facility
 	Types: Production, Player, Spectator
 
-SelectProductionBuilding:
+SelectProductionBuilding: TAB
 	Description: Current facility
 	Types: Production, Player
 

--- a/mods/common/hotkeys/production-common.yaml
+++ b/mods/common/hotkeys/production-common.yaml
@@ -2,6 +2,10 @@ CycleProductionBuildings: TAB
 	Description: Next facility
 	Types: Production, Player, Spectator
 
+SelectProductionBuilding:
+	Description: Current facility
+	Types: Production, Player
+
 Production01: F1
 	Description: Slot 01
 	Types: ProductionSlot, Player

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -472,6 +472,7 @@ Container@PLAYER_WIDGETS:
 					MaximumRows: 6
 					HotkeyPrefix: Production
 					HotkeyCount: 24
+					SelectProductionBuildingHotkey: SelectProductionBuilding
 					ClickSound: TabClick
 				Container@PRODUCTION_TYPES:
 					X: 6

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -428,6 +428,7 @@ Container@PLAYER_WIDGETS:
 					IconSpriteOffset: -1, -1
 					HotkeyPrefix: Production
 					HotkeyCount: 24
+					SelectProductionBuildingHotkey: SelectProductionBuilding
 				Container@PALETTE_FOREGROUND:
 					Children:
 						Image@ROW_TEMPLATE:

--- a/mods/ts/chrome/ingame-player.yaml
+++ b/mods/ts/chrome/ingame-player.yaml
@@ -471,6 +471,7 @@ Container@PLAYER_WIDGETS:
 					MaximumRows: 6
 					HotkeyPrefix: Production
 					HotkeyCount: 24
+					SelectProductionBuildingHotkey: SelectProductionBuilding
 				Container@PRODUCTION_TYPES:
 					X: 0
 					Y: 0 - 32


### PR DESCRIPTION
The hotkey works like this:
- Selects the facility associated with the current production tab (the primary building in classic queues)
- If the building is already selected (i.e. doble-tap the hotkey) - center the viewport on the facility

The second commit binds the hotkey to <kbd>Tab</kbd> and changes the binding for "Next facility" hotkey to <kbd>Ctrl</kbd> + <kbd>Tab</kbd> (I think Ctrl+Tab is better suited for cycling). I'd be fine with leaving it undefined if that's controversial.

Remarks:
- In case of classic queues the most recently constructed facility gets selected
- In case of different buildings that operate on the same queue (barracks and kennel in RA) the most recently constructed one is selected
- In both cases the primary building is selected if the player has manually set one
- This hotkey is most useful with multiple production queues (e.g. in Tiberian Dawn) because in mid to late-game it's quite common to have a lot of facilities scattered across the map and it's difficult to locate them and rally the production

Closes #5486
Closes #15842