### PR TITLE
Render editor cursor previews as part of the world

### DIFF
--- a/OpenRA.Game/Map/ActorReference.cs
+++ b/OpenRA.Game/Map/ActorReference.cs
@@ -71,5 +71,14 @@ namespace OpenRA
 		// for initialization syntax
 		public void Add(object o) { InitDict.Add(o); }
 		public IEnumerator GetEnumerator() { return InitDict.GetEnumerator(); }
+
+		public ActorReference Clone()
+		{
+			var clone = new ActorReference(Type);
+			foreach (var init in InitDict)
+				clone.InitDict.Add(init);
+
+			return clone;
+		}
 	}
 }

--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -824,6 +824,14 @@ namespace OpenRA
 			return new WDist(delta.Z);
 		}
 
+		public WVec Offset(CVec delta, int dz)
+		{
+			if (Grid.Type == MapGridType.Rectangular)
+				return new WVec(1024 * delta.X, 1024 * delta.Y, 0);
+
+			return new WVec(724 * (delta.X - delta.Y), 724 * (delta.X + delta.Y), 724 * dz);
+		}
+
 		/// <summary>
 		/// The size of the map Height step in world units
 		/// </summary>

--- a/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
@@ -58,9 +58,15 @@ namespace OpenRA.Mods.Cnc.Traits
 				var cell = location + cellOffset;
 
 				// Some mods may define terrain-specific bibs
-				var terrain = map.GetTerrainInfo(cell).Type;
-				var testSequence = Sequence + "-" + terrain;
-				var sequence = anim.HasSequence(testSequence) ? testSequence : Sequence;
+				var sequence = Sequence;
+				if (map.Tiles.Contains(cell))
+				{
+					var terrain = map.GetTerrainInfo(cell).Type;
+					var testSequence = Sequence + "-" + terrain;
+					if (anim.HasSequence(testSequence))
+						sequence = testSequence;
+				}
+
 				anim.PlayFetchIndex(sequence, () => index);
 				anim.IsDecoration = true;
 

--- a/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
+++ b/OpenRA.Mods.Common/EditorBrushes/EditorTileBrush.cs
@@ -14,7 +14,6 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
-using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.Widgets
 {
@@ -25,32 +24,26 @@ namespace OpenRA.Mods.Common.Widgets
 		readonly WorldRenderer worldRenderer;
 		readonly World world;
 		readonly EditorViewportControllerWidget editorWidget;
-		readonly TerrainTemplatePreviewWidget preview;
-		readonly Rectangle bounds;
 		readonly EditorActionManager editorActionManager;
+		readonly EditorCursorLayer editorCursor;
+		readonly int cursorToken;
 
 		bool painting;
 
-		public EditorTileBrush(EditorViewportControllerWidget editorWidget, ushort template, WorldRenderer wr)
+		public EditorTileBrush(EditorViewportControllerWidget editorWidget, ushort id, WorldRenderer wr)
 		{
 			this.editorWidget = editorWidget;
-			Template = template;
+			worldRenderer = wr;
+			world = wr.World;
+			editorActionManager = world.WorldActor.Trait<EditorActionManager>();
+			editorCursor = world.WorldActor.Trait<EditorCursorLayer>();
+
+			Template = id;
 			worldRenderer = wr;
 			world = wr.World;
 
-			editorActionManager = world.WorldActor.Trait<EditorActionManager>();
-
-			preview = editorWidget.Get<TerrainTemplatePreviewWidget>("DRAG_TILE_PREVIEW");
-			preview.GetScale = () => worldRenderer.Viewport.Zoom;
-			preview.IsVisible = () => editorWidget.CurrentBrush == this;
-
-			preview.Template = world.Map.Rules.TileSet.Templates.First(t => t.Value.Id == template).Value;
-			var grid = world.Map.Grid;
-			bounds = worldRenderer.Theater.TemplateBounds(preview.Template, grid.TileSize, grid.Type);
-
-			// The preview widget may be rendered by the higher-level code before it is ticked.
-			// Force a manual tick to ensure the bounds are set correctly for this first draw.
-			Tick();
+			var template = world.Map.Rules.TileSet.Templates.First(t => t.Value.Id == id).Value;
+			cursorToken = editorCursor.SetTerrainTemplate(wr, template);
 		}
 
 		public bool HandleMouseInput(MouseInput mi)
@@ -83,6 +76,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 			if (mi.Event != MouseInputEvent.Down && mi.Event != MouseInputEvent.Move)
 				return true;
+
+			if (editorCursor.CurrentToken != cursorToken)
+				return false;
 
 			var cell = worldRenderer.Viewport.ViewToWorld(mi.Location);
 			var isMoving = mi.Event == MouseInputEvent.Move;
@@ -205,23 +201,12 @@ namespace OpenRA.Mods.Common.Widgets
 			return false;
 		}
 
-		public void Tick()
+		public void Tick() { }
+
+		public void Dispose()
 		{
-			var cell = worldRenderer.Viewport.ViewToWorld(Viewport.LastMousePos);
-			var offset = WVec.Zero;
-			var location = world.Map.CenterOfCell(cell) + offset;
-
-			var cellScreenPosition = worldRenderer.ScreenPxPosition(location);
-			var cellScreenPixel = worldRenderer.Viewport.WorldToViewPx(cellScreenPosition);
-			var zoom = worldRenderer.Viewport.Zoom;
-
-			preview.Bounds.X = cellScreenPixel.X + (int)(zoom * bounds.X);
-			preview.Bounds.Y = cellScreenPixel.Y + (int)(zoom * bounds.Y);
-			preview.Bounds.Width = (int)(zoom * bounds.Width);
-			preview.Bounds.Height = (int)(zoom * bounds.Height);
+			editorCursor.Clear(cursorToken);
 		}
-
-		public void Dispose() { }
 	}
 
 	class PaintTileEditorAction : IEditorAction

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -263,8 +263,16 @@ namespace OpenRA.Mods.Common.Traits
 				return map.Grid.DefaultSubCell;
 
 			for (var i = (byte)SubCell.First; i < map.Grid.SubCellOffsets.Length; i++)
-				if (!previews.Any(p => p.Footprint[cell] == (SubCell)i))
+			{
+				var blocked = previews.Any(p =>
+				{
+					SubCell s;
+					return p.Footprint.TryGetValue(cell, out s) && s == (SubCell)i;
+				});
+
+				if (!blocked)
 					return (SubCell)i;
+			}
 
 			return SubCell.Invalid;
 		}

--- a/OpenRA.Mods.Common/Traits/World/EditorCursorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorCursorLayer.cs
@@ -1,0 +1,170 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public enum EditorCursorType { None, Actor }
+
+	[Desc("Required for the map editor to work. Attach this to the world actor.")]
+	public class EditorCursorLayerInfo : ITraitInfo, Requires<EditorActorLayerInfo>
+	{
+		public readonly int PreviewFacing = 96;
+
+		public object Create(ActorInitializer init) { return new EditorCursorLayer(init.Self, this); }
+	}
+
+	public class EditorCursorLayer : ITickRender, IRenderAboveShroud, IRenderAnnotations
+	{
+		readonly EditorCursorLayerInfo info;
+		readonly EditorActorLayer editorLayer;
+		readonly World world;
+
+		public int CurrentToken { get; private set; }
+		public EditorCursorType Type { get; private set; }
+		public EditorActorPreview Actor { get; private set; }
+		CPos actorLocation;
+		SubCell actorSubCell;
+		WVec actorCenterOffset;
+		bool actorSharesCell;
+
+		public EditorCursorLayer(Actor self, EditorCursorLayerInfo info)
+		{
+			this.info = info;
+			world = self.World;
+			editorLayer = self.Trait<EditorActorLayer>();
+
+			Type = EditorCursorType.None;
+		}
+
+		void ITickRender.TickRender(WorldRenderer wr, Actor self)
+		{
+			if (wr.World.Type != WorldType.Editor)
+				return;
+
+			if (Actor != null)
+			{
+				// Offset mouse position by the center offset (in world pixels)
+				var worldPx = wr.Viewport.ViewToWorldPx(Viewport.LastMousePos) - wr.ScreenPxOffset(actorCenterOffset);
+				var cell = wr.Viewport.ViewToWorld(wr.Viewport.WorldToViewPx(worldPx));
+				var subCell = actorSharesCell ? editorLayer.FreeSubCellAt(cell) : SubCell.Invalid;
+				var updated = false;
+				if (actorLocation != cell)
+				{
+					actorLocation = cell;
+					Actor.Actor.InitDict.Remove(Actor.Actor.InitDict.Get<LocationInit>());
+					Actor.Actor.InitDict.Add(new LocationInit(cell));
+					updated = true;
+				}
+
+				if (actorSubCell != subCell)
+				{
+					actorSubCell = subCell;
+
+					var subcellInit = Actor.Actor.InitDict.GetOrDefault<SubCellInit>();
+					if (subcellInit != null)
+					{
+						Actor.Actor.InitDict.Remove(subcellInit);
+						updated = true;
+					}
+
+					var subcell = world.Map.Tiles.Contains(cell) ? editorLayer.FreeSubCellAt(cell) : SubCell.Invalid;
+					if (subcell != SubCell.Invalid)
+					{
+						Actor.Actor.InitDict.Add(new SubCellInit(subcell));
+						updated = true;
+					}
+				}
+
+				if (updated)
+					Actor = new EditorActorPreview(wr, null, Actor.Actor, Actor.Owner);
+			}
+		}
+
+		static readonly IEnumerable<IRenderable> NoRenderables = Enumerable.Empty<IRenderable>();
+		IEnumerable<IRenderable> IRenderAboveShroud.RenderAboveShroud(Actor self, WorldRenderer wr)
+		{
+			if (wr.World.Type != WorldType.Editor)
+				return NoRenderables;
+
+			if (Type == EditorCursorType.Actor)
+				return Actor.Render().OrderBy(WorldRenderer.RenderableScreenZPositionComparisonKey);
+
+			return NoRenderables;
+		}
+
+		bool IRenderAboveShroud.SpatiallyPartitionable { get { return false; } }
+
+		public IEnumerable<IRenderable> RenderAnnotations(Actor self, WorldRenderer wr)
+		{
+			if (wr.World.Type != WorldType.Editor)
+				return NoRenderables;
+
+			return Actor != null ? Actor.RenderAnnotations() : NoRenderables;
+		}
+
+		bool IRenderAnnotations.SpatiallyPartitionable { get { return false; } }
+
+		public int SetActor(WorldRenderer wr, ActorInfo actor, PlayerReference owner)
+		{
+			var ios = actor.TraitInfoOrDefault<IOccupySpaceInfo>();
+			var buildingInfo = ios as BuildingInfo;
+			actorCenterOffset = buildingInfo != null ? buildingInfo.CenterOffset(world) : WVec.Zero;
+			actorSharesCell = ios != null && ios.SharesCell;
+			actorSubCell = SubCell.Invalid;
+
+			// Enforce first entry of ValidOwnerNames as owner if the actor has RequiresSpecificOwners
+			var ownerName = owner.Name;
+			var specificOwnerInfo = actor.TraitInfoOrDefault<RequiresSpecificOwnersInfo>();
+			if (specificOwnerInfo != null && !specificOwnerInfo.ValidOwnerNames.Contains(ownerName))
+				ownerName = specificOwnerInfo.ValidOwnerNames.First();
+
+			var reference = new ActorReference(actor.Name);
+			reference.InitDict.Add(new OwnerInit(ownerName));
+			reference.InitDict.Add(new FactionInit(owner.Faction));
+
+			var worldPx = wr.Viewport.ViewToWorldPx(Viewport.LastMousePos) - wr.ScreenPxOffset(actorCenterOffset);
+			var cell = wr.Viewport.ViewToWorld(wr.Viewport.WorldToViewPx(worldPx));
+
+			reference.InitDict.Add(new LocationInit(cell));
+			if (ios != null && ios.SharesCell)
+			{
+				actorSubCell = editorLayer.FreeSubCellAt(cell);
+				if (actorSubCell != SubCell.Invalid)
+					reference.InitDict.Add(new SubCellInit(actorSubCell));
+			}
+
+			if (actor.HasTraitInfo<IFacingInfo>())
+				reference.InitDict.Add(new FacingInit(info.PreviewFacing));
+
+			if (actor.HasTraitInfo<TurretedInfo>())
+				reference.InitDict.Add(new TurretFacingInit(info.PreviewFacing));
+
+			Type = EditorCursorType.Actor;
+			Actor = new EditorActorPreview(wr, null, reference, owner);
+
+			return ++CurrentToken;
+		}
+
+		public void Clear(int token)
+		{
+			if (token != CurrentToken)
+				return;
+
+			Type = EditorCursorType.None;
+			Actor = null;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorSelectorLogic.cs
@@ -40,6 +40,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly DropDownButtonWidget ownersDropDown;
 		readonly Ruleset mapRules;
 		readonly ActorSelectorActor[] allActors;
+		readonly EditorCursorLayer editorCursor;
 
 		PlayerReference selectedOwner;
 
@@ -49,6 +50,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			mapRules = world.Map.Rules;
 			ownersDropDown = widget.Get<DropDownButtonWidget>("OWNERS_DROPDOWN");
+			editorCursor = world.WorldActor.Trait<EditorCursorLayer>();
 			var editorLayer = world.WorldActor.Trait<EditorActorLayer>();
 
 			selectedOwner = editorLayer.Players.Players.Values.First();
@@ -181,7 +183,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				try
 				{
 					var item = ScrollItemWidget.Setup(ItemTemplate,
-						() => { var brush = Editor.CurrentBrush as EditorActorBrush; return brush != null && brush.Actor == actor; },
+						() => editorCursor.Type == EditorCursorType.Actor && editorCursor.Actor.Info == actor,
 						() => Editor.SetBrush(new EditorActorBrush(Editor, actor, selectedOwner, WorldRenderer)));
 
 					var preview = item.Get<ActorPreviewWidget>("ACTOR_PREVIEW");

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/LayerSelectorLogic.cs
@@ -20,6 +20,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 	{
 		readonly EditorViewportControllerWidget editor;
 		readonly WorldRenderer worldRenderer;
+		readonly EditorCursorLayer editorCursor;
 
 		readonly ScrollPanelWidget layerTemplateList;
 		readonly ScrollItemWidget layerPreviewTemplate;
@@ -29,6 +30,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			this.worldRenderer = worldRenderer;
 			editor = widget.Parent.Get<EditorViewportControllerWidget>("MAP_EDITOR");
+			editorCursor = worldRenderer.World.WorldActor.Trait<EditorCursorLayer>();
 
 			layerTemplateList = widget.Get<ScrollPanelWidget>("LAYERTEMPLATE_LIST");
 			layerTemplateList.Layout = new GridLayout(layerTemplateList);
@@ -46,7 +48,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			foreach (var resource in resources)
 			{
 				var newResourcePreviewTemplate = ScrollItemWidget.Setup(layerPreviewTemplate,
-					() => { var brush = editor.CurrentBrush as EditorResourceBrush; return brush != null && brush.ResourceType == resource; },
+					() => editorCursor.Type == EditorCursorType.Resource && editorCursor.Resource == resource,
 					() => editor.SetBrush(new EditorResourceBrush(editor, resource, worldRenderer)));
 
 				newResourcePreviewTemplate.Bounds.X = 0;

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/TileSelectorLogic.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
@@ -36,6 +37,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		readonly TileSet tileset;
 		readonly TileSelectorTemplate[] allTemplates;
+		readonly EditorCursorLayer editorCursor;
 
 		[ObjectCreator.UseCtor]
 		public TileSelectorLogic(Widget widget, World world, WorldRenderer worldRenderer)
@@ -43,6 +45,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			tileset = world.Map.Rules.TileSet;
 			allTemplates = tileset.Templates.Values.Select(t => new TileSelectorTemplate(t)).ToArray();
+			editorCursor = world.WorldActor.Trait<EditorCursorLayer>();
 
 			allCategories = allTemplates.SelectMany(t => t.Categories)
 				.Distinct()
@@ -98,7 +101,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 				var tileId = t.Template.Id;
 				var item = ScrollItemWidget.Setup(ItemTemplate,
-					() => { var brush = Editor.CurrentBrush as EditorTileBrush; return brush != null && brush.Template == tileId; },
+					() => editorCursor.Type == EditorCursorType.TerrainTemplate && editorCursor.TerrainTemplate.Id == tileId,
 					() => Editor.SetBrush(new EditorTileBrush(Editor, tileId, WorldRenderer)));
 
 				var preview = item.Get<TerrainTemplatePreviewWidget>("TILE_PREVIEW");

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -220,10 +220,6 @@ Container@EDITOR_WORLD_ROOT:
 			TooltipContainer: TOOLTIP_CONTAINER
 			TooltipTemplate: SIMPLE_TOOLTIP
 			Children:
-				TerrainTemplatePreview@DRAG_TILE_PREVIEW:
-					Visible: false
-				Sprite@DRAG_LAYER_PREVIEW:
-					Visible: false
 				Background@ACTOR_EDIT_PANEL:
 					Background: panel-black
 					Width: 269

--- a/mods/cnc/chrome/editor.yaml
+++ b/mods/cnc/chrome/editor.yaml
@@ -224,8 +224,6 @@ Container@EDITOR_WORLD_ROOT:
 					Visible: false
 				Sprite@DRAG_LAYER_PREVIEW:
 					Visible: false
-				ActorPreview@DRAG_ACTOR_PREVIEW:
-					Visible: false
 				Background@ACTOR_EDIT_PANEL:
 					Background: panel-black
 					Width: 269

--- a/mods/cnc/rules/world.yaml
+++ b/mods/cnc/rules/world.yaml
@@ -265,6 +265,7 @@ World:
 EditorWorld:
 	Inherits: ^BaseWorld
 	EditorActorLayer:
+	EditorCursorLayer:
 	EditorResourceLayer:
 	EditorSelectionLayer:
 	LoadWidgetAtGameStart:

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -211,8 +211,6 @@ Container@EDITOR_WORLD_ROOT:
 			TooltipContainer: TOOLTIP_CONTAINER
 			TooltipTemplate: SIMPLE_TOOLTIP
 			Children:
-				ActorPreview@DRAG_ACTOR_PREVIEW:
-					Visible: false
 				TerrainTemplatePreview@DRAG_TILE_PREVIEW:
 					Visible: false
 				Sprite@DRAG_LAYER_PREVIEW:

--- a/mods/common/chrome/editor.yaml
+++ b/mods/common/chrome/editor.yaml
@@ -211,10 +211,6 @@ Container@EDITOR_WORLD_ROOT:
 			TooltipContainer: TOOLTIP_CONTAINER
 			TooltipTemplate: SIMPLE_TOOLTIP
 			Children:
-				TerrainTemplatePreview@DRAG_TILE_PREVIEW:
-					Visible: false
-				Sprite@DRAG_LAYER_PREVIEW:
-					Visible: false
 				Background@ACTOR_EDIT_PANEL:
 					X: 32
 					Y: 32

--- a/mods/d2k/rules/world.yaml
+++ b/mods/d2k/rules/world.yaml
@@ -240,6 +240,7 @@ World:
 EditorWorld:
 	Inherits: ^BaseWorld
 	EditorActorLayer:
+	EditorCursorLayer:
 	D2kEditorResourceLayer:
 	EditorSelectionLayer:
 	LoadWidgetAtGameStart:

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -281,6 +281,7 @@ World:
 EditorWorld:
 	Inherits: ^BaseWorld
 	EditorActorLayer:
+	EditorCursorLayer:
 	EditorResourceLayer:
 	EditorSelectionLayer:
 	LoadWidgetAtGameStart:

--- a/mods/ts/rules/world.yaml
+++ b/mods/ts/rules/world.yaml
@@ -375,6 +375,7 @@ World:
 EditorWorld:
 	Inherits: ^BaseWorld
 	EditorActorLayer:
+	EditorCursorLayer:
 	EditorResourceLayer:
 	EditorSelectionLayer:
 		Palette: placefootprint


### PR DESCRIPTION
This PR fixes the rendering glitches (too-smooth voxels, gaps between terrain tiles, the turret positioning issue noted in #17431, plus some others that would be introduced by the UI scaling options) which are currently caused by rendering these in the UI layer.

Required for #10382.