### PR TITLE
Reimplement text contrast using greyscale dilation.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
@@ -41,6 +41,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public bool Shadow = ChromeMetrics.Get<bool>("ButtonTextShadow");
 		public Color ContrastColorDark = ChromeMetrics.Get<Color>("ButtonTextContrastColorDark");
 		public Color ContrastColorLight = ChromeMetrics.Get<Color>("ButtonTextContrastColorLight");
+		public int ContrastRadius = ChromeMetrics.Get<int>("ButtonTextContrastRadius");
 		public string ClickSound = ChromeMetrics.Get<string>("ClickSound");
 		public string ClickDisabledSound = ChromeMetrics.Get<string>("ClickDisabledSound");
 		public bool Disabled = false;
@@ -114,6 +115,7 @@ namespace OpenRA.Mods.Common.Widgets
 			GetColorDisabled = other.GetColorDisabled;
 			ContrastColorDark = other.ContrastColorDark;
 			ContrastColorLight = other.ContrastColorLight;
+			ContrastRadius = other.ContrastRadius;
 			GetContrastColorDark = other.GetContrastColorDark;
 			GetContrastColorLight = other.GetContrastColorLight;
 			OnMouseDown = other.OnMouseDown;
@@ -251,7 +253,7 @@ namespace OpenRA.Mods.Common.Widgets
 			DrawBackground(rb, disabled, Depressed, hover, highlighted);
 			if (Contrast)
 				font.DrawTextWithContrast(text, position + stateOffset,
-					disabled ? colordisabled : color, bgDark, bgLight, 2);
+					disabled ? colordisabled : color, bgDark, bgLight, ContrastRadius);
 			else if (Shadow)
 				font.DrawTextWithShadow(text, position, color, bgDark, bgLight, 1);
 			else

--- a/OpenRA.Mods.Common/Widgets/LabelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/LabelWidget.cs
@@ -31,6 +31,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public bool Shadow = ChromeMetrics.Get<bool>("TextShadow");
 		public Color ContrastColorDark = ChromeMetrics.Get<Color>("TextContrastColorDark");
 		public Color ContrastColorLight = ChromeMetrics.Get<Color>("TextContrastColorLight");
+		public int ContrastRadius = ChromeMetrics.Get<int>("TextContrastRadius");
 		public bool WordWrap = false;
 		public Func<string> GetText;
 		public Func<Color> GetColor;
@@ -56,6 +57,7 @@ namespace OpenRA.Mods.Common.Widgets
 			Contrast = other.Contrast;
 			ContrastColorDark = other.ContrastColorDark;
 			ContrastColorLight = other.ContrastColorLight;
+			ContrastRadius = other.ContrastRadius;
 			Shadow = other.Shadow;
 			WordWrap = other.WordWrap;
 			GetText = other.GetText;
@@ -100,7 +102,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var bgDark = GetContrastColorDark();
 			var bgLight = GetContrastColorLight();
 			if (Contrast)
-				font.DrawTextWithContrast(text, position, color, bgDark, bgLight, 2);
+				font.DrawTextWithContrast(text, position, color, bgDark, bgLight, ContrastRadius);
 			else if (Shadow)
 				font.DrawTextWithShadow(text, position, color, bgDark, bgLight, 1);
 			else

--- a/mods/common/metrics.yaml
+++ b/mods/common/metrics.yaml
@@ -6,6 +6,7 @@ Metrics:
 	ButtonTextContrast: false
 	ButtonTextContrastColorDark: 000000
 	ButtonTextContrastColorLight: 7F7F7F
+	ButtonTextContrastRadius: 1
 	ButtonTextShadow: false
 	CheckboxPressedState: false
 	GameStartedColor: FFA500
@@ -31,6 +32,7 @@ Metrics:
 	TextContrast: false
 	TextContrastColorDark: 000000
 	TextContrastColorLight: 7F7F7F
+	TextContrastRadius: 1
 	TextFont: Regular
 	TextShadow: false
 	TextfieldColor: FFFFFF


### PR DESCRIPTION
Our current text contrast rendering cheats by drawing four copies of the text, offset in x/y. This looks ok when the offset is small relative to the pixel scale, but completely breaks on high DPI displays (e.g. using 150% UI scaling on a 200% DPI display):

<img src="https://user-images.githubusercontent.com/167819/71519471-91e03800-28af-11ea-8738-447aef8dc1ec.png">

This PR implements the feature properly, calculating contrast glyphs by applying a modified greyscale dilation operator. Wikipedia has a helpful animation demonstrating the process: https://en.wikipedia.org/wiki/Dilation_%28morphology%29#/media/File:Grayscale_Morphological_Dilation.gif. The implementation here uses a floating point structural element, which lets us blend out partially overlapping pixels instead of having harsh edges.

This produces the intended result (150% UI scaling on a 200% DPI display):

<img src="https://user-images.githubusercontent.com/167819/71519515-bd632280-28af-11ea-8cdb-5659b7147154.png">

Now, this highlights that the default 2px contrast offset on `LabelWidget` is a bit ridiculous, so the second commit reduces this to 1px (150% UI scaling on a 200% DPI display):

<img src="https://user-images.githubusercontent.com/167819/71519543-e08dd200-28af-11ea-90c6-1a47fb3d8b98.png">

which still looks reasonable on normal systems (100% UI scaling on a 100% DPI display):
![](https://user-images.githubusercontent.com/167819/71519568-031feb00-28b0-11ea-9086-c2857fc66dbc.png)

Required for #10382.