### PR TITLE
TakeCover fixes

### DIFF
--- a/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class TakeCoverInfo : TurretedInfo
 	{
 		[Desc("How long (in ticks) the actor remains prone.")]
-		public readonly int ProneTime = 100;
+		public readonly int Duration = 100;
 
 		[Desc("Prone movement speed as a percentage of the normal speed.")]
 		public readonly int SpeedModifier = 50;
@@ -32,9 +32,11 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Damage modifiers for each damage type (defined on the warheads) while the unit is prone.")]
 		public readonly Dictionary<string, int> DamageModifiers = new Dictionary<string, int>();
 
+		[Desc("Muzzle offset modifier to apply while prone.")]
 		public readonly WVec ProneOffset = new WVec(500, 0, 0);
 
 		[SequenceReference(null, true)]
+		[Desc("Sequence prefix to apply while prone.")]
 		public readonly string ProneSequencePrefix = "prone-";
 
 		public override object Create(ActorInitializer init) { return new TakeCover(init, this); }
@@ -45,9 +47,9 @@ namespace OpenRA.Mods.Common.Traits
 		readonly TakeCoverInfo info;
 
 		[Sync]
-		int remainingProneTime = 0;
+		int remainingDuration = 0;
 
-		bool IsProne { get { return !IsTraitDisabled && remainingProneTime > 0; } }
+		bool IsProne { get { return !IsTraitDisabled && remainingDuration > 0; } }
 
 		bool IRenderInfantrySequenceModifier.IsModifyingSequence { get { return IsProne; } }
 		string IRenderInfantrySequenceModifier.SequencePrefix { get { return info.ProneSequencePrefix; } }
@@ -69,17 +71,17 @@ namespace OpenRA.Mods.Common.Traits
 			if (!IsProne)
 				localOffset = info.ProneOffset;
 
-			remainingProneTime = info.ProneTime;
+			remainingDuration = info.Duration;
 		}
 
 		protected override void Tick(Actor self)
 		{
 			base.Tick(self);
 
-			if (!IsTraitPaused && remainingProneTime > 0)
-				remainingProneTime--;
+			if (!IsTraitPaused && remainingDuration > 0)
+				remainingDuration--;
 
-			if (remainingProneTime == 0)
+			if (remainingDuration == 0)
 				localOffset = WVec.Zero;
 		}
 
@@ -107,7 +109,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override void TraitDisabled(Actor self)
 		{
-			remainingProneTime = 0;
+			remainingDuration = 0;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TakeCover.cs
@@ -43,10 +43,11 @@ namespace OpenRA.Mods.Common.Traits
 	public class TakeCover : Turreted, INotifyDamage, IDamageModifier, ISpeedModifier, ISync, IRenderInfantrySequenceModifier
 	{
 		readonly TakeCoverInfo info;
+
 		[Sync]
 		int remainingProneTime = 0;
 
-		bool IsProne { get { return remainingProneTime > 0; } }
+		bool IsProne { get { return !IsTraitDisabled && remainingProneTime > 0; } }
 
 		bool IRenderInfantrySequenceModifier.IsModifyingSequence { get { return IsProne; } }
 		string IRenderInfantrySequenceModifier.SequencePrefix { get { return info.ProneSequencePrefix; } }

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20191117/RenameProneTime.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20191117/RenameProneTime.cs
@@ -1,0 +1,35 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2019 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	class RenameProneTime : UpdateRule
+	{
+		public override string Name { get { return "Renamed ProneTime to Duration"; } }
+		public override string Description
+		{
+			get
+			{
+				return "Renamed TakeCover property ProneTime to Duration.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var takeCover in actorNode.ChildrenMatching("TakeCover"))
+				takeCover.RenameChildrenMatching("ProneTime", "Duration");
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -143,6 +143,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveYesNo(),
 				new RemoveInitialFacingHardcoding(),
 				new RemoveAirdropActorTypeDefault(),
+				new RenameProneTime(),
 			})
 		};
 


### PR DESCRIPTION
Makes `TakeCover` properly disableable, renames `ProneTime` to `Duration` and adds two property descriptions.

Split from #17264 to hopefully make the latter's diff less off-putting.