### PR TITLE
Split fixed-wing attack and strafe attack types.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/Fly.cs
+++ b/OpenRA.Mods.Common/Activities/Air/Fly.cs
@@ -158,7 +158,6 @@ namespace OpenRA.Mods.Common.Activities
 			var checkTarget = useLastVisibleTarget ? lastVisibleTarget : target;
 			var pos = aircraft.GetPosition();
 			var delta = checkTarget.CenterPosition - pos;
-			var desiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : aircraft.Facing;
 
 			// Inside the target annulus, so we're done
 			var insideMaxRange = maxRange.Length > 0 && checkTarget.IsInRange(pos, maxRange);
@@ -167,12 +166,20 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 
 			var isSlider = aircraft.Info.CanSlide;
+			var desiredFacing = delta.HorizontalLengthSquared != 0 ? delta.Yaw.Facing : aircraft.Facing;
 			var move = isSlider ? aircraft.FlyStep(desiredFacing) : aircraft.FlyStep(aircraft.Facing);
 
-			// Inside the minimum range, so reverse if we CanSlide
-			if (isSlider && insideMinRange)
+			// Inside the minimum range, so reverse if we CanSlide, otherwise face away from the target.
+			if (insideMinRange)
 			{
-				FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, -move);
+				if (isSlider)
+					FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, -move);
+				else
+				{
+					desiredFacing = Util.NormalizeFacing(desiredFacing + 128);
+					FlyTick(self, aircraft, desiredFacing, aircraft.Info.CruiseAltitude, move);
+				}
+
 				return false;
 			}
 

--- a/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
@@ -24,8 +24,6 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Attack behavior. Currently supported types are Strafe (default) and Hover.")]
 		public readonly AirAttackType AttackType = AirAttackType.Strafe;
 
-		[Desc("Delay, in game ticks, before strafing aircraft turns to attack.")]
-		public readonly int AttackTurnDelay = 50;
 
 		[Desc("Does this actor cancel its attack activity when it needs to resupply? Setting this to 'false' will make the actor resume attack after reloading.")]
 		public readonly bool AbortOnResupply = true;

--- a/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
@@ -17,13 +17,18 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	// TODO: Add CurleyShuffle (TD, TS), Circle (Generals Gunship-style)
-	public enum AirAttackType { Hover, Strafe }
+	public enum AirAttackType { Default, Hover, Strafe }
 
 	public class AttackAircraftInfo : AttackFollowInfo, Requires<AircraftInfo>
 	{
-		[Desc("Attack behavior. Currently supported types are Strafe (default) and Hover.")]
-		public readonly AirAttackType AttackType = AirAttackType.Strafe;
+		[Desc("Attack behavior. Currently supported types are:",
+			"Default: Attack while following the default movement rules.",
+			"Hover: Hover, even if the Aircraft can't hover while idle.",
+			"Strafe: Perform a fixed-length attack run on the target.")]
+		public readonly AirAttackType AttackType = AirAttackType.Default;
 
+		[Desc("Distance the strafing aircraft makes to a target before turning for another pass. When set to WDist.Zero this defaults to the maximum armament range.")]
+		public readonly WDist StrafeRunLength = WDist.Zero;
 
 		[Desc("Does this actor cancel its attack activity when it needs to resupply? Setting this to 'false' will make the actor resume attack after reloading.")]
 		public readonly bool AbortOnResupply = true;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20191117/ReplaceAttackTypeStrafe.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20191117/ReplaceAttackTypeStrafe.cs
@@ -1,0 +1,48 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using OpenRA.Mods.Common.Traits;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class ReplaceAttackTypeStrafe : UpdateRule
+	{
+		public override string Name { get { return "Replaced AttackAircraft AttackType: Strafe logic."; } }
+		public override string Description
+		{
+			get
+			{
+				return "The AttackType: Strafe behaviour on AttackAircraft has been renamed to Default,\n"
+					+ "and AttackTurnDelay has been removed. A new AttackType: Strafe has been added, with a\n"
+					+ "new StrafeRunLength parameter, designed for use with the FirstBurstTargetOffset and\n"
+					+ "FollowingBurstTargetOffset weapon parameters.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var aircraft = actorNode.LastChildMatching("Aircraft");
+			if (aircraft != null)
+			{
+				var attackAircraft = actorNode.LastChildMatching("AttackAircraft");
+				if (attackAircraft == null)
+					yield break;
+
+				var attackType = attackAircraft.LastChildMatching("AttackType");
+				if (attackType.NodeValue<AirAttackType>() == AirAttackType.Strafe)
+					attackAircraft.RemoveNode(attackType);
+
+				attackAircraft.RemoveNodes("AttackTurnDelay");
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -144,6 +144,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveInitialFacingHardcoding(),
 				new RemoveAirdropActorTypeDefault(),
 				new RenameProneTime(),
+				new ReplaceAttackTypeStrafe(),
 			})
 		};
 

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -112,7 +112,6 @@ MIG:
 	AttackAircraft:
 		FacingTolerance: 20
 		PersistentTargeting: false
-		AttackTurnDelay: 30
 	Aircraft:
 		CruiseAltitude: 2560
 		InitialFacing: 192


### PR DESCRIPTION
A lot of the problems we're having with strafing attacks seem to come down to the fact that it is trying to solve two mutually incompatible use cases:
* Making fixed-wing aircraft attacks work like other units.
* Implementing strafing attacks, which don't work like other units.

This PR aims to solve both usecases by 
* Renaming the current `AirAttackType.Strafe` to `AirAttackType.Default` and making sure that both #17413 and #16922 are fixed.
* Adding a new `AirAttackType.Strafe` that performs a fixed-length strafing run on a target, fixing the issue where strafes stop mid-run if the targeted actor is killed.

The first commit is basically #17418, modified to remove the update rule (this is now in the second commit) and to use a wrapper activity to cancel the attack pass instead of changing `Fly`. This allows aircraft to continue moving to the previous target position if it is killed while they are en route (like all other units and later C&C games), and also allows them to break off immediately (again like all other units) if the target is killed while they are actively attacking/repositioning;

The second commit renames the fixed behaviour to `Default` and introduces the new actually-strafing behaviour. This works by targeting the ground rather than the actor, and keeps firing on the last known position of the target is killed. In the future I can see us expanding this to move the target position along the ground path instead of relying on `FirstBurstTargetOffset` / `FollowingBurstTargetOffset` - but this is out of scope of this issue. This also adds an amended update rule to migrate any old uses of `Strafe` over to the `Default`.

The third commit is a quick testcase that demonstrates the improved strafing logic.

Fixes #17413.
Supersedes #17418.