### PR TITLE
Don't hard-code the transparent background color

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/PaletteFromGimpOrJascFile.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromGimpOrJascFile.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	[Desc("Load a GIMP .gpl or JASC .pal palette file. Supports per-color alpha. Index 0 is hardcoded to be fully transparent/invisible.")]
+	[Desc("Load a GIMP .gpl or JASC .pal palette file. Supports per-color alpha.")]
 	class PaletteFromGimpOrJascFileInfo : ITraitInfo
 	{
 		[PaletteDefinition]
@@ -41,6 +41,9 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool Premultiply = true;
 
 		public readonly bool AllowModifiers = true;
+
+		[Desc("Index set to be fully transparent/invisible.")]
+		public readonly int TransparentIndex = 0;
 
 		public object Create(ActorInitializer init) { return new PaletteFromGimpOrJascFile(init.World, this); }
 	}
@@ -96,8 +99,8 @@ namespace OpenRA.Mods.Common.Traits
 						// Note: We can't throw on "rgba.Length > 3 but parse failed", because in GIMP palettes the 'invalid' value is probably a color name string.
 						var noAlpha = rgba.Length > 3 ? !byte.TryParse(rgba[3], out a) : true;
 
-						// Index 0 should always be completely transparent/background color
-						if (i == 0)
+						// Index should be completely transparent/background color
+						if (i == info.TransparentIndex)
 							colors[i] = 0;
 						else if (noAlpha)
 							colors[i] = (uint)Color.FromArgb(r, g, b).ToArgb();

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromRGBA.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromRGBA.cs
@@ -41,6 +41,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly bool AllowModifiers = true;
 
+		[Desc("Index set to be fully transparent/invisible.")]
+		public readonly int TransparentIndex = 0;
+
 		public object Create(ActorInitializer init) { return new PaletteFromRGBA(init.World, this); }
 	}
 
@@ -65,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 			var g = (int)(a * info.G + 0.5f).Clamp(0, 255);
 			var b = (int)(a * info.B + 0.5f).Clamp(0, 255);
 			var c = (uint)Color.FromArgb(info.A, r, g, b).ToArgb();
-			wr.AddPalette(info.Name, new ImmutablePalette(Enumerable.Range(0, Palette.Size).Select(i => (i == 0) ? 0 : c)), info.AllowModifiers);
+			wr.AddPalette(info.Name, new ImmutablePalette(Enumerable.Range(0, Palette.Size).Select(i => (i == info.TransparentIndex) ? 0 : c)), info.AllowModifiers);
 		}
 	}
 }


### PR DESCRIPTION
My small mod project https://github.com/Mailaender/OpenHV needs a palette definition like this:

```
	PaletteFromGimpOrJascFile@player:
		Name: player
		Filename: palette.pal
		TransparentIndex: 255
```