### PR TITLE
Bypass fingerprint validation for skirmish/mission servers.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -22,6 +22,7 @@ using System.Threading.Tasks;
 using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Primitives;
+using OpenRA.Server;
 using OpenRA.Support;
 using OpenRA.Widgets;
 
@@ -915,7 +916,7 @@ namespace OpenRA
 
 		public static void CreateServer(ServerSettings settings)
 		{
-			server = new Server.Server(new IPEndPoint(IPAddress.Any, settings.ListenPort), settings, ModData, false);
+			server = new Server.Server(new IPEndPoint(IPAddress.Any, settings.ListenPort), settings, ModData, ServerType.Multiplayer);
 		}
 
 		public static int CreateLocalServer(string map)
@@ -927,7 +928,7 @@ namespace OpenRA
 				AdvertiseOnline = false
 			};
 
-			server = new Server.Server(new IPEndPoint(IPAddress.Loopback, 0), settings, ModData, false);
+			server = new Server.Server(new IPEndPoint(IPAddress.Loopback, 0), settings, ModData, ServerType.Local);
 
 			return server.Port;
 		}

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -461,7 +461,13 @@ namespace OpenRA.Server
 						SendOrderTo(newConn, "Message", "Bots have been disabled on this map.");
 				};
 
-				if (!string.IsNullOrEmpty(handshake.Fingerprint) && !string.IsNullOrEmpty(handshake.AuthSignature))
+				if (Type == ServerType.Local)
+				{
+					// Local servers can only be joined by the local client, so we can trust their identity without validation
+					client.Fingerprint = handshake.Fingerprint;
+					completeConnection();
+				}
+				else if (!string.IsNullOrEmpty(handshake.Fingerprint) && !string.IsNullOrEmpty(handshake.AuthSignature))
 				{
 					waitingForAuthenticationCallback++;
 

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -32,6 +32,13 @@ namespace OpenRA.Server
 		ShuttingDown = 3
 	}
 
+	public enum ServerType
+	{
+		Local = 0,
+		Multiplayer = 1,
+		Dedicated = 2
+	}
+
 	public class Server
 	{
 		public readonly string TwoHumansRequiredText = "This server requires at least two human players to start a match.";
@@ -39,7 +46,7 @@ namespace OpenRA.Server
 		public readonly IPAddress Ip;
 		public readonly int Port;
 		public readonly MersenneTwister Random = new MersenneTwister();
-		public readonly bool Dedicated;
+		public readonly ServerType Type;
 
 		// Valid player connections
 		public List<Connection> Conns = new List<Connection>();
@@ -122,7 +129,7 @@ namespace OpenRA.Server
 				t.GameEnded(this);
 		}
 
-		public Server(IPEndPoint endpoint, ServerSettings settings, ModData modData, bool dedicated)
+		public Server(IPEndPoint endpoint, ServerSettings settings, ModData modData, ServerType type)
 		{
 			Log.AddChannel("server", "server.log", true);
 
@@ -131,7 +138,7 @@ namespace OpenRA.Server
 			var localEndpoint = (IPEndPoint)listener.LocalEndpoint;
 			Ip = localEndpoint.Address;
 			Port = localEndpoint.Port;
-			Dedicated = dedicated;
+			Type = type;
 			Settings = settings;
 
 			Settings.Name = OpenRA.Settings.SanitizedServerName(Settings.Name);
@@ -157,10 +164,10 @@ namespace OpenRA.Server
 					RandomSeed = randomSeed,
 					Map = settings.Map,
 					ServerName = settings.Name,
-					EnableSingleplayer = settings.EnableSingleplayer || !dedicated,
+					EnableSingleplayer = settings.EnableSingleplayer || Type != ServerType.Dedicated,
 					EnableSyncReports = settings.EnableSyncReports,
 					GameUid = Guid.NewGuid().ToString(),
-					Dedicated = dedicated
+					Dedicated = Type == ServerType.Dedicated
 				}
 			};
 
@@ -216,7 +223,7 @@ namespace OpenRA.Server
 					delayedActions.PerformActions(0);
 
 					// PERF: Dedicated servers need to drain the action queue to remove references blocking the GC from cleaning up disposed objects.
-					if (dedicated)
+					if (Type == ServerType.Dedicated)
 						Game.PerformDelayedActions();
 
 					foreach (var t in serverTraits.WithInterface<ITick>())
@@ -434,7 +441,7 @@ namespace OpenRA.Server
 					// Send initial ping
 					SendOrderTo(newConn, "Ping", Game.RunTime.ToString(CultureInfo.InvariantCulture));
 
-					if (Dedicated)
+					if (Type == ServerType.Dedicated)
 					{
 						var motdFile = Platform.ResolvePath(Platform.SupportDirPrefix, "motd.txt");
 						if (!File.Exists(motdFile))
@@ -502,9 +509,9 @@ namespace OpenRA.Server
 
 						delayedActions.Add(() =>
 						{
-							var notAuthenticated = Dedicated && profile == null && (Settings.RequireAuthentication || Settings.ProfileIDWhitelist.Any());
-							var blacklisted = Dedicated && profile != null && Settings.ProfileIDBlacklist.Contains(profile.ProfileID);
-							var notWhitelisted = Dedicated && Settings.ProfileIDWhitelist.Any() &&
+							var notAuthenticated = Type == ServerType.Dedicated && profile == null && (Settings.RequireAuthentication || Settings.ProfileIDWhitelist.Any());
+							var blacklisted = Type == ServerType.Dedicated && profile != null && Settings.ProfileIDBlacklist.Contains(profile.ProfileID);
+							var notWhitelisted = Type == ServerType.Dedicated && Settings.ProfileIDWhitelist.Any() &&
 								(profile == null || !Settings.ProfileIDWhitelist.Contains(profile.ProfileID));
 
 							if (notAuthenticated)
@@ -534,7 +541,7 @@ namespace OpenRA.Server
 				}
 				else
 				{
-					if (Dedicated && (Settings.RequireAuthentication || Settings.ProfileIDWhitelist.Any()))
+					if (Type == ServerType.Dedicated && (Settings.RequireAuthentication || Settings.ProfileIDWhitelist.Any()))
 					{
 						Log.Write("server", "Rejected connection from {0}; Not authenticated.", newConn.Socket.RemoteEndPoint);
 						SendOrderTo(newConn, "ServerError", "Server requires players to have an OpenRA forum account");
@@ -616,7 +623,7 @@ namespace OpenRA.Server
 		{
 			DispatchOrdersToClients(conn, 0, Order.FromTargetString("Message", text, true).Serialize());
 
-			if (Dedicated)
+			if (Type == ServerType.Dedicated)
 				Console.WriteLine("[{0}] {1}".F(DateTime.Now.ToString(Settings.TimestampFormat), text));
 		}
 
@@ -731,7 +738,7 @@ namespace OpenRA.Server
 
 				case "LoadGameSave":
 					{
-						if (Dedicated || State >= ServerState.GameStarted)
+						if (Type == ServerType.Dedicated || State >= ServerState.GameStarted)
 							break;
 
 						// Sanitize potentially malicious input
@@ -834,7 +841,7 @@ namespace OpenRA.Server
 
 				// Client was the server admin
 				// TODO: Reassign admin for game in progress via an order
-				if (Dedicated && dropClient.IsAdmin && State == ServerState.WaitingPlayers)
+				if (Type == ServerType.Dedicated && dropClient.IsAdmin && State == ServerState.WaitingPlayers)
 				{
 					// Remove any bots controlled by the admin
 					LobbyInfo.Clients.RemoveAll(c => c.Bot != null && c.BotControllerClientIndex == toDrop.PlayerIndex);
@@ -856,10 +863,10 @@ namespace OpenRA.Server
 					foreach (var t in serverTraits.WithInterface<INotifyServerEmpty>())
 						t.ServerEmpty(this);
 
-				if (Conns.Any() || Dedicated)
+				if (Conns.Any() || Type == ServerType.Dedicated)
 					SyncLobbyClients();
 
-				if (!Dedicated && dropClient.IsAdmin)
+				if (Type != ServerType.Dedicated && dropClient.IsAdmin)
 					Shutdown();
 			}
 
@@ -952,7 +959,7 @@ namespace OpenRA.Server
 
 			// Enable game saves for singleplayer missions only
 			// TODO: Enable for multiplayer (non-dedicated servers only) once the lobby UI has been created
-			LobbyInfo.GlobalSettings.GameSavesEnabled = !Dedicated && LobbyInfo.NonBotClients.Count() == 1;
+			LobbyInfo.GlobalSettings.GameSavesEnabled = Type != ServerType.Dedicated && LobbyInfo.NonBotClients.Count() == 1;
 
 			SyncLobbyInfo();
 			State = ServerState.GameStarted;

--- a/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
+++ b/OpenRA.Mods.Common/ServerTraits/PlayerPinger.cs
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Server
 				lastPing = Game.RunTime;
 
 				// Ignore client timeout in singleplayer games to make debugging easier
-				if (server.LobbyInfo.NonBotClients.Count() < 2 && !server.Dedicated)
+				if (server.LobbyInfo.NonBotClients.Count() < 2 && server.Type != ServerType.Dedicated)
 					foreach (var c in server.Conns.ToList())
 						server.SendOrderTo(c, "Ping", Game.RunTime.ToString());
 				else

--- a/OpenRA.Server/Program.cs
+++ b/OpenRA.Server/Program.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Server
 
 				settings.Map = modData.MapCache.ChooseInitialMap(settings.Map, new MersenneTwister());
 
-				var server = new Server(new IPEndPoint(IPAddress.Any, settings.ListenPort), settings, modData, true);
+				var server = new Server(new IPEndPoint(IPAddress.Any, settings.ListenPort), settings, modData, ServerType.Dedicated);
 				GC.Collect();
 				while (true)
 				{


### PR DESCRIPTION
This PR addresses the easy part of #17536. Servers created for mission/skirmish games will start immediately without attempting to validate the fingerprint.