### PR TITLE
Use system chat line for audio muted/unmuted notifications

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/MuteHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MuteHotkeyLogic.cs
@@ -30,12 +30,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (Game.Settings.Sound.Mute)
 			{
 				Game.Sound.MuteAudio();
-				Game.AddChatLine("Battlefield Control", Color.White, "Audio muted");
+				Game.AddSystemLine("Battlefield Control", "Audio muted");
 			}
 			else
 			{
 				Game.Sound.UnmuteAudio();
-				Game.AddChatLine("Battlefield Control", Color.White, "Audio unmuted");
+				Game.AddSystemLine("Battlefield Control", "Audio unmuted");
 			}
 
 			return true;


### PR DESCRIPTION
Notifications for audio mute/unmute come from "Battlefield Control" but were displayed in the regular chat color instead of the system chat color.