### PR TITLE
Restore MODIFIER_OVERRIDES handling of unmodified attack move hotkey.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
@@ -210,9 +210,6 @@ namespace OpenRA.Mods.Common.Widgets
 				var noShiftButtons = new[] { guardButton, deployButton, attackMoveButton };
 				keyOverrides.AddHandler(e =>
 				{
-					if (e.Event != KeyInputEvent.Down)
-						return false;
-
 					// HACK: allow command buttons to be triggered if the shift (queue order modifier) key is held
 					if (e.Modifiers.HasModifier(Modifiers.Shift))
 					{
@@ -229,18 +226,15 @@ namespace OpenRA.Mods.Common.Widgets
 						}
 					}
 
-					// HACK: allow attack move to be triggered if the ctrl (assault move modifier)
-					// or shift (queue order modifier) keys are pressed
-					if (e.Modifiers.HasModifier(Modifiers.Ctrl))
-					{
-						var eNoMods = e;
-						eNoMods.Modifiers &= ~(Modifiers.Ctrl | Modifiers.Shift);
+					// HACK: Attack move can be triggered if the ctrl (assault move modifier)
+					// or shift (queue order modifier) keys are pressed, on both key down and key up
+					var eNoMods = e;
+					eNoMods.Modifiers &= ~(Modifiers.Ctrl | Modifiers.Shift);
 
-						if (attackMoveButton != null && !attackMoveDisabled && attackMoveButton.Key.IsActivatedBy(eNoMods))
-						{
-							attackMoveButton.OnKeyPress(e);
-							return true;
-						}
+					if (attackMoveButton != null && !attackMoveDisabled && attackMoveButton.Key.IsActivatedBy(eNoMods))
+					{
+						attackMoveButton.OnKeyPress(e);
+						return true;
 					}
 
 					return false;


### PR DESCRIPTION
This PR implements a simple speculative fix for #17438.

I am not able to reproduce the original issue, so cannot test this myself. Ping @Orb370 and @dragunoff to confirm whether this helps.

There is a strong chance that the PR as it currently stands won't work - I suspect that the underlying issue may be related to filtering out `KeyInputEvent.Up`, which was previously handled by `MODIFIER_OVERRIDES` but never by `ButtonWidget`. If this is the case, and we decide that we want to work around it despite it being user-error, then that is an extra 1 line tweak.