### PR TITLE
Added cursor palette support to GIMP/Jasc palette definitions

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/PaletteFromGimpOrJascFile.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromGimpOrJascFile.cs
@@ -60,9 +60,6 @@ namespace OpenRA.Mods.Common.Traits
 				var colors = new uint[Palette.Size];
 				using (var lines = s.ReadAllLines().GetEnumerator())
 				{
-					if (lines == null)
-						throw new InvalidDataException("File {0} is empty.".F(Filename));
-
 					if (!lines.MoveNext() || (lines.Current != "GIMP Palette" && lines.Current != "JASC-PAL"))
 						throw new InvalidDataException("File `{0}` is not a valid GIMP or JASC palette.".F(Filename));
 


### PR DESCRIPTION
Followup of https://github.com/OpenRA/OpenRA/pull/17538 which allows me to use the original palette without butchering the original cursor sprites. This may be a nice feature for other mods as well.

![image](https://user-images.githubusercontent.com/756669/71781377-61df1600-2fce-11ea-8a93-a1c9bcc0416d.png)

```
	PaletteFromGimpOrJascFile@cursor:
		Name: cursor
		Filename: palette.pal
		CursorPalette: true
		AllowModifiers: false
		TransparentIndex: 255
```