### PR TITLE
Make chat labels configurable in mod.yaml

### DIFF
--- a/OpenRA.Game/ChatLabels.cs
+++ b/OpenRA.Game/ChatLabels.cs
@@ -1,0 +1,26 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+namespace OpenRA
+{
+	public class ChatLabels : IGlobalModData
+	{
+		public readonly string BattlefieldControl = "Battlefield Control";
+		public readonly string Mission = "Mission";
+		public readonly string Debug = "Debug";
+		public readonly string All = "All";
+		public readonly string Team = "Team";
+		public readonly string Spectators = "Spectators";
+		public readonly string Ally = "Ally";
+		public readonly string Spectator = "Spectator";
+		public readonly string Dead = "Dead";
+	}
+}

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -878,6 +878,11 @@ namespace OpenRA
 			state = RunStatus.Success;
 		}
 
+		public static void AddSystemLine(string text)
+		{
+			AddSystemLine("Battlefield Control", text);
+		}
+
 		public static void AddSystemLine(string name, string text)
 		{
 			OrderManager.AddChatLine(name, systemMessageColor, text, systemMessageColor);

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -880,7 +880,8 @@ namespace OpenRA
 
 		public static void AddSystemLine(string text)
 		{
-			AddSystemLine("Battlefield Control", text);
+			var chatLabels = Game.ModData.Manifest.Get<ChatLabels>();
+			AddSystemLine(chatLabels.BattlefieldControl, text);
 		}
 
 		public static void AddSystemLine(string name, string text)

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -21,7 +21,6 @@ namespace OpenRA.Network
 	public static class UnitOrders
 	{
 		public const int ChatMessageMaxLength = 2500;
-		const string ServerChatName = "Battlefield Control";
 
 		static Player FindPlayerByClient(this World world, Session.Client c)
 		{
@@ -41,7 +40,7 @@ namespace OpenRA.Network
 			{
 				// Server message
 				case "Message":
-					Game.AddSystemLine(ServerChatName, order.TargetString);
+					Game.AddSystemLine(order.TargetString);
 					break;
 
 				// Reports that the target player disconnected
@@ -137,7 +136,7 @@ namespace OpenRA.Network
 									FieldLoader.GetValue<int>("SaveSyncFrame", saveSyncFrame.Value.Value);
 						}
 						else
-							Game.AddSystemLine(ServerChatName, "The game has started.");
+							Game.AddSystemLine("The game has started.");
 
 						Game.StartGame(orderManager.LobbyInfo.GlobalSettings.Map, WorldType.Regular);
 						break;
@@ -156,7 +155,7 @@ namespace OpenRA.Network
 
 				case "GameSaved":
 					if (!orderManager.World.IsReplay)
-						Game.AddSystemLine(ServerChatName, "Game saved");
+						Game.AddSystemLine("Game saved");
 
 					foreach (var nsr in orderManager.World.WorldActor.TraitsImplementing<INotifyGameSaved>())
 						nsr.GameSaved(orderManager.World);
@@ -176,7 +175,7 @@ namespace OpenRA.Network
 							if (orderManager.World.Paused != pause && world != null && world.LobbyInfo.NonBotClients.Count() > 1)
 							{
 								var pausetext = "The game is {0} by {1}".F(pause ? "paused" : "un-paused", client.Name);
-								Game.AddSystemLine(ServerChatName, pausetext);
+								Game.AddSystemLine(pausetext);
 							}
 
 							orderManager.World.Paused = pause;

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -58,6 +58,8 @@ namespace OpenRA.Network
 						if (client == null)
 							break;
 
+						var chatLabels = Game.ModData.Manifest.Get<ChatLabels>();
+
 						// Cut chat messages to the hard limit to avoid exploits
 						var message = order.TargetString;
 						if (message.Length > ChatMessageMaxLength)
@@ -67,11 +69,11 @@ namespace OpenRA.Network
 						if (order.ExtraData == 0)
 						{
 							var p = world != null ? world.FindPlayerByClient(client) : null;
-							var suffix = (p != null && p.WinState == WinState.Lost) ? " (Dead)" : "";
-							suffix = client.IsObserver ? " (Spectator)" : suffix;
+							var suffix = (p != null && p.WinState == WinState.Lost) ? " (" + chatLabels.Dead + ")" : "";
+							suffix = client.IsObserver ? " (" + chatLabels.Spectator + ")" : suffix;
 
 							if (orderManager.LocalClient != null && client != orderManager.LocalClient && client.Team > 0 && client.Team == orderManager.LocalClient.Team)
-								suffix += " (Ally)";
+								suffix += " (" + chatLabels.Ally + ")";
 
 							Game.AddChatLine(client.Name + suffix, client.Color, message);
 							break;
@@ -80,7 +82,7 @@ namespace OpenRA.Network
 						// We are still in the lobby
 						if (world == null)
 						{
-							var prefix = order.ExtraData == uint.MaxValue ? "[Spectators] " : "[Team] ";
+							var prefix = order.ExtraData == uint.MaxValue ? "[" + chatLabels.Spectators + "] " : "[" + chatLabels.Team + "] ";
 							if (orderManager.LocalClient != null && client.Team == orderManager.LocalClient.Team)
 								Game.AddChatLine(prefix + client.Name, client.Color, message);
 
@@ -96,7 +98,7 @@ namespace OpenRA.Network
 						{
 							// Validate before adding the line
 							if (client.IsObserver || (player != null && player.WinState != WinState.Undefined))
-								Game.AddChatLine("[Spectators] " + client.Name, client.Color, message);
+								Game.AddChatLine("[" + chatLabels.Spectators + "] " + client.Name, client.Color, message);
 
 							break;
 						}
@@ -106,7 +108,7 @@ namespace OpenRA.Network
 							&& world.LocalPlayer != null && world.LocalPlayer.WinState == WinState.Undefined;
 
 						if (valid && (isSameTeam || world.IsReplay))
-							Game.AddChatLine("[Team" + (world.IsReplay ? " " + order.ExtraData : "") + "] " + client.Name, client.Color, message);
+							Game.AddChatLine("[" + chatLabels.Team + (world.IsReplay ? " " + order.ExtraData : "") + "] " + client.Name, client.Color, message);
 
 						break;
 					}

--- a/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
+++ b/OpenRA.Mods.Common/Scripting/Global/MediaGlobal.cs
@@ -188,21 +188,27 @@ namespace OpenRA.Mods.Common.Scripting
 			return true;
 		}
 
-		[Desc("Display a text message to the player.")]
-		public void DisplayMessage(string text, string prefix = "Mission", Color? color = null)
+		[Desc("Display a text message to the player. If 'prefix' is nil the default mission prefix from the mod data is used.")]
+		public void DisplayMessage(string text, string prefix = null, Color? color = null)
 		{
 			if (string.IsNullOrEmpty(text))
 				return;
+
+			if (string.IsNullOrEmpty(prefix))
+				prefix = Game.ModData.Manifest.Get<ChatLabels>().Mission;
 
 			var c = color.HasValue ? color.Value : Color.White;
 			Game.AddChatLine(prefix, c, text);
 		}
 
-		[Desc("Display a system message to the player.")]
-		public void DisplaySystemMessage(string text, string prefix = "Mission")
+		[Desc("Display a system message to the player. If 'prefix' is nil the default mission prefix from the mod data is used.")]
+		public void DisplaySystemMessage(string text, string prefix = null)
 		{
 			if (string.IsNullOrEmpty(text))
 				return;
+
+			if (string.IsNullOrEmpty(prefix))
+				Game.AddSystemLine(text);
 
 			Game.AddSystemLine(prefix, text);
 		}

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -100,7 +100,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.SuppressNotifications)
 				return;
 
-			Game.AddSystemLine("Battlefield Control", player.PlayerName + " is defeated.");
+			Game.AddSystemLine(player.PlayerName + " is defeated.");
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)
@@ -113,7 +113,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.SuppressNotifications)
 				return;
 
-			Game.AddSystemLine("Battlefield Control", player.PlayerName + " is victorious.");
+			Game.AddSystemLine(player.PlayerName + " is victorious.");
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -141,7 +141,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.SuppressNotifications)
 				return;
 
-			Game.AddSystemLine("Battlefield Control", player.PlayerName + " is defeated.");
+			Game.AddSystemLine(player.PlayerName + " is defeated.");
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)
@@ -154,7 +154,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (info.SuppressNotifications)
 				return;
 
-			Game.AddSystemLine("Battlefield Control", player.PlayerName + " is victorious.");
+			Game.AddSystemLine(player.PlayerName + " is victorious.");
 			Game.RunAfterDelay(info.NotificationDelay, () =>
 			{
 				if (Game.IsCurrentWorld(player.World) && player == player.World.LocalPlayer)

--- a/OpenRA.Mods.Common/Traits/Player/TimeLimitManager.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TimeLimitManager.cs
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				if (ticksRemaining == m * 60 * ticksPerSecond)
 				{
-					Game.AddSystemLine("Battlefield Control", Notification.F(m, m > 1 ? "s" : null));
+					Game.AddSystemLine(Notification.F(m, m > 1 ? "s" : null));
 
 					var faction = self.World.LocalPlayer == null ? null : self.World.LocalPlayer.Faction.InternalName;
 					Game.Sound.PlayNotification(self.World.Map.Rules, self.World.LocalPlayer, "Speech", info.TimeLimitWarnings[m], faction);
@@ -172,7 +172,7 @@ namespace OpenRA.Mods.Common.Traits
 				countdownLabel.GetText = () => null;
 
 			if (!info.SkipTimerExpiredNotification)
-				Game.AddSystemLine("Battlefield Control", "Time limit has expired.");
+				Game.AddSystemLine("Time limit has expired.");
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/IngameChatLogic.cs
@@ -68,7 +68,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			chatChrome.Visible = true;
 
 			var chatMode = chatChrome.Get<ButtonWidget>("CHAT_MODE");
-			chatMode.GetText = () => teamChat && !disableTeamChat ? "Team" : "All";
+			var chatLabels = Game.ModData.Manifest.Get<ChatLabels>();
+			chatMode.GetText = () => teamChat && !disableTeamChat ? chatLabels.Team : chatLabels.All;
 			chatMode.OnClick = () => teamChat ^= true;
 
 			// Enable teamchat if we are a player and die,

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -391,7 +391,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				disconnectButton.Text = "Back";
 
 			var chatMode = lobby.Get<ButtonWidget>("CHAT_MODE");
-			chatMode.GetText = () => teamChat ? "Team" : "All";
+			var chatLabels = Game.ModData.Manifest.Get<ChatLabels>();
+			chatMode.GetText = () => teamChat ? chatLabels.Team : chatLabels.All;
 			chatMode.OnClick = () => teamChat ^= true;
 			chatMode.IsDisabled = () => disableTeamChat;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/MuteHotkeyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MuteHotkeyLogic.cs
@@ -30,12 +30,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (Game.Settings.Sound.Mute)
 			{
 				Game.Sound.MuteAudio();
-				Game.AddSystemLine("Battlefield Control", "Audio muted");
+				Game.AddSystemLine("Audio muted");
 			}
 			else
 			{
 				Game.Sound.UnmuteAudio();
-				Game.AddSystemLine("Battlefield Control", "Audio unmuted");
+				Game.AddSystemLine("Audio unmuted");
 			}
 
 			return true;

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -281,12 +281,12 @@ namespace OpenRA.Mods.Common.Widgets
 
 					// Check if selecting actors on the screen has selected new units
 					if (ownUnitsOnScreen.Count > World.Selection.Actors.Count())
-						Game.AddSystemLine("Battlefield Control", "Selected across screen");
+						Game.AddSystemLine("Selected across screen");
 					else
 					{
 						// Select actors in the world that have highest selection priority
 						ownUnitsOnScreen = SelectActorsInWorld(World, null, eligiblePlayers).SubsetWithHighestSelectionPriority(e.Modifiers).ToList();
-						Game.AddSystemLine("Battlefield Control", "Selected across map");
+						Game.AddSystemLine("Selected across map");
 					}
 
 					World.Selection.Combine(World, ownUnitsOnScreen, false, false);
@@ -313,12 +313,12 @@ namespace OpenRA.Mods.Common.Widgets
 
 					// Check if selecting actors on the screen has selected new units
 					if (newSelection.Count > World.Selection.Actors.Count())
-						Game.AddSystemLine("Battlefield Control", "Selected across screen");
+						Game.AddSystemLine("Selected across screen");
 					else
 					{
 						// Select actors in the world that have the same selection class as one of the already selected actors
 						newSelection = SelectActorsInWorld(World, selectedClasses, eligiblePlayers).ToList();
-						Game.AddSystemLine("Battlefield Control", "Selected across map");
+						Game.AddSystemLine("Selected across map");
 					}
 
 					World.Selection.Combine(World, newSelection, true, false);

--- a/mods/d2k/maps/atreides-01a/atreides01a.lua
+++ b/mods/d2k/maps/atreides-01a/atreides01a.lua
@@ -71,18 +71,18 @@ Tick = function()
 	-- player has no Wind Trap
 	if (player.PowerProvided <= 20 or player.PowerState ~= "Normal") and DateTime.GameTime % DateTime.Seconds(32) == 0 then
 		HasPower = false
-		Media.DisplayMessage(Messages[2], "Mentat")
+		Media.DisplayMessage(Messages[2])
 	else
 		HasPower = true
 	end
 
 	-- player has no Refinery and no Silos
 	if HasPower and player.ResourceCapacity == 0 and DateTime.GameTime % DateTime.Seconds(32) == 0 then
-		Media.DisplayMessage(Messages[3], "Mentat")
+		Media.DisplayMessage(Messages[3])
 	end
 
 	if HasPower and player.Resources > player.ResourceCapacity * 0.8 and DateTime.GameTime % DateTime.Seconds(32) == 0 then
-		Media.DisplayMessage(Messages[4], "Mentat")
+		Media.DisplayMessage(Messages[4])
 	end
 
 	UserInterface.SetMissionText("Harvested resources: " .. player.Resources .. "/" .. SpiceToHarvest, player.Color)
@@ -102,7 +102,7 @@ WorldLoaded = function()
 	local checkResourceCapacity = function()
 		Trigger.AfterDelay(0, function()
 			if player.ResourceCapacity < SpiceToHarvest then
-				Media.DisplayMessage("We don't have enough silo space to store the required amount of Spice!", "Mentat")
+				Media.DisplayMessage("We don't have enough silo space to store the required amount of Spice!")
 				Trigger.AfterDelay(DateTime.Seconds(3), function()
 					harkonnen.MarkCompletedObjective(KillAtreides)
 				end)
@@ -133,7 +133,7 @@ WorldLoaded = function()
 		end
 	end)
 
-	Media.DisplayMessage(Messages[1], "Mentat")
+	Media.DisplayMessage(Messages[1])
 
 	Trigger.AfterDelay(DateTime.Seconds(25), function()
 		Media.PlaySpeechNotification(player, "Reinforce")

--- a/mods/d2k/maps/atreides-01b/atreides01b.lua
+++ b/mods/d2k/maps/atreides-01b/atreides01b.lua
@@ -71,18 +71,18 @@ Tick = function()
 	-- player has no Wind Trap
 	if (player.PowerProvided <= 20 or player.PowerState ~= "Normal") and DateTime.GameTime % DateTime.Seconds(32) == 0 then
 		HasPower = false
-		Media.DisplayMessage(Messages[2], "Mentat")
+		Media.DisplayMessage(Messages[2])
 	else
 		HasPower = true
 	end
 
 	-- player has no Refinery and no Silos
 	if HasPower and player.ResourceCapacity == 0 and DateTime.GameTime % DateTime.Seconds(32) == 0 then
-		Media.DisplayMessage(Messages[3], "Mentat")
+		Media.DisplayMessage(Messages[3])
 	end
 
 	if HasPower and player.Resources > player.ResourceCapacity * 0.8 and DateTime.GameTime % DateTime.Seconds(32) == 0 then
-		Media.DisplayMessage(Messages[4], "Mentat")
+		Media.DisplayMessage(Messages[4])
 	end
 
 	UserInterface.SetMissionText("Harvested resources: " .. player.Resources .. "/" .. SpiceToHarvest, player.Color)
@@ -102,7 +102,7 @@ WorldLoaded = function()
 	local checkResourceCapacity = function()
 		Trigger.AfterDelay(0, function()
 			if player.ResourceCapacity < SpiceToHarvest then
-				Media.DisplayMessage("We don't have enough silo space to store the required amount of Spice!", "Mentat")
+				Media.DisplayMessage("We don't have enough silo space to store the required amount of Spice!")
 				Trigger.AfterDelay(DateTime.Seconds(3), function()
 					harkonnen.MarkCompletedObjective(KillAtreides)
 				end)
@@ -133,7 +133,7 @@ WorldLoaded = function()
 		end
 	end)
 
-	Media.DisplayMessage(Messages[1], "Mentat")
+	Media.DisplayMessage(Messages[1])
 
 	Trigger.AfterDelay(DateTime.Seconds(25), function()
 		Media.PlaySpeechNotification(player, "Reinforce")

--- a/mods/d2k/maps/atreides-02a/atreides02a.lua
+++ b/mods/d2k/maps/atreides-02a/atreides02a.lua
@@ -70,7 +70,7 @@ Tick = function()
 	end
 
 	if harkonnen.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillHarkonnen) then
-		Media.DisplayMessage("The Harkonnen have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Harkonnen have been annihilated!")
 		player.MarkCompletedObjective(KillHarkonnen)
 	end
 end

--- a/mods/d2k/maps/atreides-02b/atreides02b.lua
+++ b/mods/d2k/maps/atreides-02b/atreides02b.lua
@@ -70,7 +70,7 @@ Tick = function()
 	end
 
 	if harkonnen.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillHarkonnen) then
-		Media.DisplayMessage("The Harkonnen have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Harkonnen have been annihilated!")
 		player.MarkCompletedObjective(KillHarkonnen)
 	end
 end

--- a/mods/d2k/maps/atreides-03a/atreides03a.lua
+++ b/mods/d2k/maps/atreides-03a/atreides03a.lua
@@ -87,7 +87,7 @@ Tick = function()
 	end
 
 	if ordos.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillOrdos) then
-		Media.DisplayMessage("The Ordos have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Ordos have been annihilated!")
 		player.MarkCompletedObjective(KillOrdos)
 	end
 
@@ -105,7 +105,7 @@ Tick = function()
 	end
 
 	if DateTime.GameTime % DateTime.Seconds(32) == 0 and (MessageCheck(1) or MessageCheck(2)) then
-		Media.DisplayMessage("Upgrade barracks and light factory to produce more advanced units.", "Mentat")
+		Media.DisplayMessage("Upgrade barracks and light factory to produce more advanced units.")
 	end
 
 	UserInterface.SetMissionText("Harvested resources: " .. player.Resources .. "/" .. SpiceToHarvest, player.Color)
@@ -127,7 +127,7 @@ WorldLoaded = function()
 	local checkResourceCapacity = function()
 		Trigger.AfterDelay(0, function()
 			if player.ResourceCapacity < SpiceToHarvest then
-				Media.DisplayMessage("We don't have enough silo space to store the required amount of Spice!", "Mentat")
+				Media.DisplayMessage("We don't have enough silo space to store the required amount of Spice!")
 				Trigger.AfterDelay(DateTime.Seconds(3), function()
 					ordos.MarkCompletedObjective(KillAtreides)
 				end)

--- a/mods/d2k/maps/atreides-03b/atreides03b.lua
+++ b/mods/d2k/maps/atreides-03b/atreides03b.lua
@@ -87,7 +87,7 @@ Tick = function()
 	end
 
 	if ordos.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillOrdos) then
-		Media.DisplayMessage("The Ordos have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Ordos have been annihilated!")
 		player.MarkCompletedObjective(KillOrdos)
 	end
 
@@ -105,7 +105,7 @@ Tick = function()
 	end
 
 	if DateTime.GameTime % DateTime.Seconds(32) == 0 and (MessageCheck(1) or MessageCheck(2)) then
-		Media.DisplayMessage("Upgrade barracks and light factory to produce more advanced units.", "Mentat")
+		Media.DisplayMessage("Upgrade barracks and light factory to produce more advanced units.")
 	end
 
 	UserInterface.SetMissionText("Harvested resources: " .. player.Resources .. "/" .. SpiceToHarvest, player.Color)
@@ -127,7 +127,7 @@ WorldLoaded = function()
 	local checkResourceCapacity = function()
 		Trigger.AfterDelay(0, function()
 			if player.ResourceCapacity < SpiceToHarvest then
-				Media.DisplayMessage("We don't have enough silo space to store the required amount of Spice!", "Mentat")
+				Media.DisplayMessage("We don't have enough silo space to store the required amount of Spice!")
 				Trigger.AfterDelay(DateTime.Seconds(3), function()
 					ordos.MarkCompletedObjective(KillAtreides)
 				end)

--- a/mods/d2k/maps/atreides-04/atreides04.lua
+++ b/mods/d2k/maps/atreides-04/atreides04.lua
@@ -108,7 +108,7 @@ Tick = function()
 	end
 
 	if harkonnen.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillHarkonnen) then
-		Media.DisplayMessage("The Harkonnen have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Harkonnen have been annihilated!")
 		player.MarkCompletedObjective(KillHarkonnen)
 		player.MarkCompletedObjective(ProtectFremen)
 		player.MarkCompletedObjective(KeepIntegrity)
@@ -150,7 +150,7 @@ WorldLoaded = function()
 
 	Trigger.AfterDelay(DateTime.Seconds(2), function()
 		Beacon.New(player, Sietch.CenterPosition + WVec.New(0, 1024, 0))
-		Media.DisplayMessage("Fremen Sietch detected to the southeast.", "Mentat")
+		Media.DisplayMessage("Fremen Sietch detected to the southeast.")
 	end)
 
 	Trigger.OnAllKilledOrCaptured(HarkonnenBase, function()
@@ -166,7 +166,7 @@ WorldLoaded = function()
 		if AttackNotifier <= 0 then
 			AttackNotifier = DateTime.Seconds(10)
 			Beacon.New(player, Sietch.CenterPosition + WVec.New(0, 1024, 0), DateTime.Seconds(7))
-			Media.DisplayMessage("The Fremen Sietch is under attack!", "Mentat")
+			Media.DisplayMessage("The Fremen Sietch is under attack!")
 
 			local defenders = fremen.GetGroundAttackers()
 			if #defenders > 0 then

--- a/mods/d2k/maps/atreides-05/atreides05.lua
+++ b/mods/d2k/maps/atreides-05/atreides05.lua
@@ -186,7 +186,7 @@ SendMercenaries = function()
 	Trigger.AfterDelay(MercenaryAttackDelay[Difficulty], function()
 		mercWave = mercWave + 1
 
-		Media.DisplayMessage("Incoming hostile Mercenary force detected.", "Mentat")
+		Media.DisplayMessage("Incoming hostile Mercenary force detected.")
 
 		local units = Reinforcements.Reinforce(mercenary, MercenaryReinforcements[Difficulty][mercWave], MercenarySpawn)
 		Utils.Do(units, function(unit)
@@ -218,10 +218,10 @@ SendContraband = function(owner)
 	Trigger.AfterDelay(DateTime.Seconds(3), function()
 		if owner == player then
 			player.MarkCompletedObjective(CaptureStarport)
-			Media.DisplayMessage("Contraband has arrived and been confiscated.", "Mentat")
+			Media.DisplayMessage("Contraband has arrived and been confiscated.")
 		else
 			player.MarkFailedObjective(CaptureStarport)
-			Media.DisplayMessage("Smuggler contraband has arrived. It is too late to confiscate.", "Mentat")
+			Media.DisplayMessage("Smuggler contraband has arrived. It is too late to confiscate.")
 		end
 	end)
 
@@ -251,12 +251,12 @@ Tick = function()
 	end
 
 	if LastHarkonnenArrived and not player.IsObjectiveCompleted(KillHarkonnen) and harkonnen.HasNoRequiredUnits() then
-		Media.DisplayMessage("The Harkonnen have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Harkonnen have been annihilated!")
 		player.MarkCompletedObjective(KillHarkonnen)
 	end
 
 	if LastMercenariesArrived and not player.IsObjectiveCompleted(KillSmuggler) and smuggler.HasNoRequiredUnits() and mercenary.HasNoRequiredUnits() then
-		Media.DisplayMessage("The Smugglers have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Smugglers have been annihilated!")
 		player.MarkCompletedObjective(KillSmuggler)
 	end
 
@@ -302,7 +302,7 @@ WorldLoaded = function()
 
 	Trigger.AfterDelay(DateTime.Seconds(2), function()
 		TimerTicks = ContrabandTimes[Difficulty]
-		Media.DisplayMessage("The contraband is approaching the Starport to the north in " .. Utils.FormatTime(TimerTicks) .. ".", "Mentat")
+		Media.DisplayMessage("The contraband is approaching the Starport to the north in " .. Utils.FormatTime(TimerTicks) .. ".")
 	end)
 
 	Trigger.OnAllKilledOrCaptured(HarkonnenBase, function()
@@ -332,7 +332,7 @@ WorldLoaded = function()
 
 		if AttackNotifier <= 0 then
 			AttackNotifier = DateTime.Seconds(10)
-			Media.DisplayMessage("Don't destroy the Starport!", "Mentat")
+			Media.DisplayMessage("Don't destroy the Starport!")
 
 			local defenders = smuggler.GetGroundAttackers()
 			if #defenders > 0 then
@@ -364,11 +364,11 @@ WorldLoaded = function()
 	Trigger.OnDamaged(HarkonnenBarracks, function()
 		if AttackNotifier <= 0 and HarkonnenBarracks.Health < HarkonnenBarracks.MaxHealth * 3/4 then
 			AttackNotifier = DateTime.Seconds(10)
-			Media.DisplayMessage("Don't destroy the Barracks!", "Mentat")
+			Media.DisplayMessage("Don't destroy the Barracks!")
 		end
 	end)
 	Trigger.OnCapture(HarkonnenBarracks, function()
-		Media.DisplayMessage("Hostages Released!", "Mentat")
+		Media.DisplayMessage("Hostages Released!")
 
 		if DefendStarport then
 			player.MarkCompletedObjective(DefendStarport)
@@ -418,7 +418,7 @@ WorldLoaded = function()
 	Trigger.OnEnteredProximityTrigger(HarkonnenBarracks.CenterPosition, WDist.New(5 * 1024), function(a, id)
 		if a.Owner == player and a.Type ~= "carryall" then
 			Trigger.RemoveProximityTrigger(id)
-			Media.DisplayMessage("Capture the Harkonnen barracks to release the hostages.", "Mentat")
+			Media.DisplayMessage("Capture the Harkonnen barracks to release the hostages.")
 			StopInfantryProduction = true
 		end
 	end)

--- a/mods/d2k/maps/harkonnen-01a/harkonnen01a.lua
+++ b/mods/d2k/maps/harkonnen-01a/harkonnen01a.lua
@@ -71,18 +71,18 @@ Tick = function()
 	-- player has no Wind Trap
 	if (player.PowerProvided <= 20 or player.PowerState ~= "Normal") and DateTime.GameTime % DateTime.Seconds(32) == 0 then
 		HasPower = false
-		Media.DisplayMessage(Messages[2], "Mentat")
+		Media.DisplayMessage(Messages[2])
 	else
 		HasPower = true
 	end
 
 	-- player has no Refinery and no Silos
 	if HasPower and player.ResourceCapacity == 0 and DateTime.GameTime % DateTime.Seconds(32) == 0 then
-		Media.DisplayMessage(Messages[3], "Mentat")
+		Media.DisplayMessage(Messages[3])
 	end
 
 	if HasPower and player.Resources > player.ResourceCapacity * 0.8 and DateTime.GameTime % DateTime.Seconds(32) == 0 then
-		Media.DisplayMessage(Messages[4], "Mentat")
+		Media.DisplayMessage(Messages[4])
 	end
 
 	UserInterface.SetMissionText("Harvested resources: " .. player.Resources .. "/" .. SpiceToHarvest, player.Color)
@@ -102,7 +102,7 @@ WorldLoaded = function()
 	local checkResourceCapacity = function()
 		Trigger.AfterDelay(0, function()
 			if player.ResourceCapacity < SpiceToHarvest then
-				Media.DisplayMessage("We don't have enough silo space to store the required amount of Spice!", "Mentat")
+				Media.DisplayMessage("We don't have enough silo space to store the required amount of Spice!")
 				Trigger.AfterDelay(DateTime.Seconds(3), function()
 					harkonnen.MarkCompletedObjective(KillAtreides)
 				end)
@@ -134,7 +134,7 @@ WorldLoaded = function()
 		end
 	end)
 
-	Media.DisplayMessage(Messages[1], "Mentat")
+	Media.DisplayMessage(Messages[1])
 
 	Trigger.AfterDelay(DateTime.Seconds(25), function()
 		Media.PlaySpeechNotification(player, "Reinforce")

--- a/mods/d2k/maps/harkonnen-01b/harkonnen01b.lua
+++ b/mods/d2k/maps/harkonnen-01b/harkonnen01b.lua
@@ -71,18 +71,18 @@ Tick = function()
 	-- player has no Wind Trap
 	if (player.PowerProvided <= 20 or player.PowerState ~= "Normal") and DateTime.GameTime % DateTime.Seconds(32) == 0 then
 		HasPower = false
-		Media.DisplayMessage(Messages[2], "Mentat")
+		Media.DisplayMessage(Messages[2])
 	else
 		HasPower = true
 	end
 
 	-- player has no Refinery and no Silos
 	if HasPower and player.ResourceCapacity == 0 and DateTime.GameTime % DateTime.Seconds(32) == 0 then
-		Media.DisplayMessage(Messages[3], "Mentat")
+		Media.DisplayMessage(Messages[3])
 	end
 
 	if HasPower and player.Resources > player.ResourceCapacity * 0.8 and DateTime.GameTime % DateTime.Seconds(32) == 0 then
-		Media.DisplayMessage(Messages[4], "Mentat")
+		Media.DisplayMessage(Messages[4])
 	end
 
 	UserInterface.SetMissionText("Harvested resources: " .. player.Resources .. "/" .. SpiceToHarvest, player.Color)
@@ -102,7 +102,7 @@ WorldLoaded = function()
 	local checkResourceCapacity = function()
 		Trigger.AfterDelay(0, function()
 			if player.ResourceCapacity < SpiceToHarvest then
-				Media.DisplayMessage("We don't have enough silo space to store the required amount of Spice!", "Mentat")
+				Media.DisplayMessage("We don't have enough silo space to store the required amount of Spice!")
 				Trigger.AfterDelay(DateTime.Seconds(3), function()
 					harkonnen.MarkCompletedObjective(KillAtreides)
 				end)
@@ -134,7 +134,7 @@ WorldLoaded = function()
 		end
 	end)
 
-	Media.DisplayMessage(Messages[1], "Mentat")
+	Media.DisplayMessage(Messages[1])
 
 	Trigger.AfterDelay(DateTime.Seconds(25), function()
 		Media.PlaySpeechNotification(player, "Reinforce")

--- a/mods/d2k/maps/harkonnen-02a/harkonnen02a.lua
+++ b/mods/d2k/maps/harkonnen-02a/harkonnen02a.lua
@@ -70,7 +70,7 @@ Tick = function()
 	end
 
 	if atreides.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillAtreides) then
-		Media.DisplayMessage("The Atreides have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Atreides have been annihilated!")
 		player.MarkCompletedObjective(KillAtreides)
 	end
 end

--- a/mods/d2k/maps/harkonnen-02b/harkonnen02b.lua
+++ b/mods/d2k/maps/harkonnen-02b/harkonnen02b.lua
@@ -70,7 +70,7 @@ Tick = function()
 	end
 
 	if atreides.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillAtreides) then
-		Media.DisplayMessage("The Atreides have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Atreides have been annihilated!")
 		player.MarkCompletedObjective(KillAtreides)
 	end
 end

--- a/mods/d2k/maps/harkonnen-03a/harkonnen03a.lua
+++ b/mods/d2k/maps/harkonnen-03a/harkonnen03a.lua
@@ -103,7 +103,7 @@ Tick = function()
 	end
 
 	if atreides.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillAtreides) then
-		Media.DisplayMessage("The Atreides have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Atreides have been annihilated!")
 		player.MarkCompletedObjective(KillAtreides)
 	end
 
@@ -117,7 +117,7 @@ Tick = function()
 	end
 
 	if DateTime.GameTime % DateTime.Seconds(32) == 0 and (MessageCheck(1) or MessageCheck(2)) then
-		Media.DisplayMessage("Upgrade barracks and light factory to produce more advanced units.", "Mentat")
+		Media.DisplayMessage("Upgrade barracks and light factory to produce more advanced units.")
 	end
 end
 

--- a/mods/d2k/maps/harkonnen-03b/harkonnen03b.lua
+++ b/mods/d2k/maps/harkonnen-03b/harkonnen03b.lua
@@ -105,7 +105,7 @@ Tick = function()
 	end
 
 	if atreides.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillAtreides) then
-		Media.DisplayMessage("The Atreides have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Atreides have been annihilated!")
 		player.MarkCompletedObjective(KillAtreides)
 	end
 
@@ -119,7 +119,7 @@ Tick = function()
 	end
 
 	if DateTime.GameTime % DateTime.Seconds(32) == 0 and (MessageCheck(1) or MessageCheck(2)) then
-		Media.DisplayMessage("Upgrade barracks and light factory to produce more advanced units.", "Mentat")
+		Media.DisplayMessage("Upgrade barracks and light factory to produce more advanced units.")
 	end
 end
 

--- a/mods/d2k/maps/harkonnen-04/harkonnen04.lua
+++ b/mods/d2k/maps/harkonnen-04/harkonnen04.lua
@@ -133,12 +133,12 @@ Tick = function()
 	end
 
 	if atreides.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillAtreides) then
-		Media.DisplayMessage("The Atreides have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Atreides have been annihilated!")
 		player.MarkCompletedObjective(KillAtreides)
 	end
 
 	if fremen.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillFremen) then
-		Media.DisplayMessage("The Fremen have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Fremen have been annihilated!")
 		player.MarkCompletedObjective(KillFremen)
 	end
 
@@ -191,7 +191,7 @@ WorldLoaded = function()
 	end)
 
 	Trigger.AfterDelay(DateTime.Seconds(15), function()
-		Media.DisplayMessage("Fremen concentrations spotted to the North and Southwest.", "Mentat")
+		Media.DisplayMessage("Fremen concentrations spotted to the North and Southwest.")
 	end)
 
 	local atreidesCondition = function() return player.IsObjectiveCompleted(KillAtreides) end

--- a/mods/d2k/maps/harkonnen-05/harkonnen05.lua
+++ b/mods/d2k/maps/harkonnen-05/harkonnen05.lua
@@ -147,7 +147,7 @@ SendStarportReinforcements = function()
 			return
 		end
 
-		Media.DisplayMessage("Imperial ships penetrating defense grid!", "Mentat")
+		Media.DisplayMessage("Imperial ships penetrating defense grid!")
 	end)
 end
 
@@ -171,7 +171,7 @@ OrdosReinforcementNotification = function(currentWave, totalWaves)
 			return
 		end
 
-		Media.DisplayMessage("Enemy carryall drop detected!", "Mentat")
+		Media.DisplayMessage("Enemy carryall drop detected!")
 		
 		OrdosReinforcementNotification(currentWave, totalWaves)
 	end)
@@ -186,12 +186,12 @@ Tick = function()
 	end
 
 	if ordos_main.HasNoRequiredUnits() and ordos_small.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillOrdos) then
-		Media.DisplayMessage("The Ordos have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Ordos have been annihilated!")
 		player.MarkCompletedObjective(KillOrdos)
 	end
 
 	if corrino.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillCorrino) then
-		Media.DisplayMessage("The Emperor has been annihilated!", "Mentat")
+		Media.DisplayMessage("The Emperor has been annihilated!")
 		player.MarkCompletedObjective(KillCorrino)
 	end
 
@@ -254,7 +254,7 @@ WorldLoaded = function()
 	end)
 
 	Trigger.AfterDelay(DateTime.Seconds(5), function()
-		Media.DisplayMessage("Protect the Outpost from attack.", "Mentat")
+		Media.DisplayMessage("Protect the Outpost from attack.")
 	end)
 
 	local path = function() return Utils.Random(OrdosPaths) end

--- a/mods/d2k/maps/harkonnen-06a/harkonnen06a.lua
+++ b/mods/d2k/maps/harkonnen-06a/harkonnen06a.lua
@@ -125,7 +125,7 @@ SendStarportReinforcements = function()
 			IdleHunt(unit)
 		end)
 
-		Media.DisplayMessage("Ixian transports detected.", "Mentat")
+		Media.DisplayMessage("Ixian transports detected.")
 
 		SendStarportReinforcements()
 	end)
@@ -191,7 +191,7 @@ CheckSmugglerEnemies = function()
 			if attacker.Owner == player and not message_check then
 
 				message_check = true
-				Media.DisplayMessage("The Smugglers are now hostile!", "Mentat")
+				Media.DisplayMessage("The Smugglers are now hostile!")
 			end
 		end)
 	end)
@@ -204,12 +204,12 @@ Tick = function()
 	end
 
 	if ordos_main.HasNoRequiredUnits() and ordos_small.HasNoRequiredUnits() and not OrdosKilled then
-		Media.DisplayMessage("The Ordos have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Ordos have been annihilated!")
 		OrdosKilled = true
 	end
 
 	if smuggler_neutral.HasNoRequiredUnits() and smuggler_harkonnen.HasNoRequiredUnits() and smuggler_ordos.HasNoRequiredUnits() and smuggler_both.HasNoRequiredUnits() and not SmugglersKilled then
-		Media.DisplayMessage("The Smugglers have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Smugglers have been annihilated!")
 		SmugglersKilled = true
 	end
 

--- a/mods/d2k/maps/harkonnen-06b/harkonnen06b.lua
+++ b/mods/d2k/maps/harkonnen-06b/harkonnen06b.lua
@@ -112,7 +112,7 @@ SendStarportReinforcements = function()
 			IdleHunt(unit)
 		end)
 
-		Media.DisplayMessage("Ixian transports detected.", "Mentat")
+		Media.DisplayMessage("Ixian transports detected.")
 
 		SendStarportReinforcements()
 	end)
@@ -149,7 +149,7 @@ CheckSmugglerEnemies = function()
 			if attacker.Owner == player and not message_check then
 
 				message_check = true
-				Media.DisplayMessage("The Smugglers are now hostile!", "Mentat")
+				Media.DisplayMessage("The Smugglers are now hostile!")
 			end
 		end)
 	end)
@@ -162,12 +162,12 @@ Tick = function()
 	end
 
 	if ordos_main.HasNoRequiredUnits() and ordos_small.HasNoRequiredUnits() and not OrdosKilled then
-		Media.DisplayMessage("The Ordos have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Ordos have been annihilated!")
 		OrdosKilled = true
 	end
 
 	if smuggler_neutral.HasNoRequiredUnits() and smuggler_harkonnen.HasNoRequiredUnits() and smuggler_ordos.HasNoRequiredUnits() and smuggler_both.HasNoRequiredUnits() and not SmugglersKilled then
-		Media.DisplayMessage("The Smugglers have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Smugglers have been annihilated!")
 		SmugglersKilled = true
 	end
 

--- a/mods/d2k/maps/harkonnen-07/harkonnen07.lua
+++ b/mods/d2k/maps/harkonnen-07/harkonnen07.lua
@@ -177,12 +177,12 @@ Tick = function()
 	end
 
 	if atreides_main.HasNoRequiredUnits() and atreides_small.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillAtreides) then
-		Media.DisplayMessage("The Atreides have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Atreides have been annihilated!")
 		player.MarkCompletedObjective(KillAtreides)
 	end
 
 	if corrino.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillCorrino) then
-		Media.DisplayMessage("The Emperor have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Emperor have been annihilated!")
 		player.MarkCompletedObjective(KillCorrino)
 	end
 
@@ -191,7 +191,7 @@ Tick = function()
 	end
 
 	if (AHiTechFactory.IsDead or AHiTechFactory.Owner ~= atreides_main) and not HiTechIsDead then
-		Media.DisplayMessage("High Tech Factory neutralized! Atreides cut off from Imperial reinforcement!", "Mentat")
+		Media.DisplayMessage("High Tech Factory neutralized! Atreides cut off from Imperial reinforcement!")
 		HiTechIsDead = true
 	end
 
@@ -228,7 +228,7 @@ WorldLoaded = function()
 	KillHarkonnen2 = atreides_small.AddPrimaryObjective("Kill all Harkonnen units.")
 	KillHarkonnen3 = corrino.AddPrimaryObjective("Kill all Harkonnen units.")
 
-	Media.DisplayMessage("Destroy Atreides High Tech Factory to cut off Atreides from Imperial reinforcements.", "Mentat")
+	Media.DisplayMessage("Destroy Atreides High Tech Factory to cut off Atreides from Imperial reinforcements.")
 
 	Camera.Position = HEngineer.CenterPosition
 	AtreidesAttackLocation = AConYard2.Location

--- a/mods/d2k/maps/harkonnen-08/harkonnen08.lua
+++ b/mods/d2k/maps/harkonnen-08/harkonnen08.lua
@@ -201,7 +201,7 @@ CheckAttackToAtreides = function()
 				end)
 
 				check = true
-				Media.DisplayMessage("The Atreides are now hostile!", "Mentat")
+				Media.DisplayMessage("The Atreides are now hostile!")
 			end
 		end)
 	end)
@@ -223,17 +223,17 @@ Tick = function()
 	end
 
 	if ordos.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillOrdos) then
-		Media.DisplayMessage("The Ordos have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Ordos have been annihilated!")
 		player.MarkCompletedObjective(KillOrdos)
 	end
 
 	if atreides_enemy.HasNoRequiredUnits() and atreides_neutral.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillAtreides) then
-		Media.DisplayMessage("The Atreides have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Atreides have been annihilated!")
 		player.MarkCompletedObjective(KillAtreides)
 	end
 
 	if mercenary_enemy.HasNoRequiredUnits() and mercenary_ally.HasNoRequiredUnits() and not MercenariesDestroyed then
-		Media.DisplayMessage("The Mercenaries have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Mercenaries have been annihilated!")
 		MercenariesDestroyed = true
 	end
 
@@ -280,7 +280,7 @@ WorldLoaded = function()
 
 	Trigger.OnCapture(MHeavyFactory, function()
 		player.MarkCompletedObjective(AllyWithMercenaries)
-		Media.DisplayMessage("Leader Captured. Mercenaries have been persuaded to fight with House Harkonnen.", "Mentat")
+		Media.DisplayMessage("Leader Captured. Mercenaries have been persuaded to fight with House Harkonnen.")
 		MercenaryAttackLocation = OPalace.Location
 
 		ChangeOwner(mercenary_enemy, mercenary_ally)

--- a/mods/d2k/maps/harkonnen-09a/harkonnen09a.lua
+++ b/mods/d2k/maps/harkonnen-09a/harkonnen09a.lua
@@ -220,12 +220,12 @@ Tick = function()
 	end
 
 	if atreides_main.HasNoRequiredUnits() and atreides_small_1.HasNoRequiredUnits() and atreides_small_2.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillAtreides) then
-		Media.DisplayMessage("The Atreides have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Atreides have been annihilated!")
 		player.MarkCompletedObjective(KillAtreides)
 	end
 
 	if corrino_main.HasNoRequiredUnits() and corrino_small.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillCorrino) then
-		Media.DisplayMessage("The Emperor has been annihilated!", "Mentat")
+		Media.DisplayMessage("The Emperor has been annihilated!")
 		player.MarkCompletedObjective(KillCorrino)
 	end
 

--- a/mods/d2k/maps/harkonnen-09b/harkonnen09b.lua
+++ b/mods/d2k/maps/harkonnen-09b/harkonnen09b.lua
@@ -267,7 +267,7 @@ CheckSmugglerEnemies = function()
 			if attacker.Owner == player and not message_check then
 
 				message_check = true
-				Media.DisplayMessage("The Smugglers are now hostile!", "Mentat")
+				Media.DisplayMessage("The Smugglers are now hostile!")
 			end
 		end)
 	end)
@@ -282,17 +282,17 @@ Tick = function()
 	end
 
 	if atreides_main.HasNoRequiredUnits() and atreides_small.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillAtreides) then
-		Media.DisplayMessage("The Atreides have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Atreides have been annihilated!")
 		player.MarkCompletedObjective(KillAtreides)
 	end
 
 	if corrino_main.HasNoRequiredUnits() and corrino_small.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillCorrino) then
-		Media.DisplayMessage("The Emperor has been annihilated!", "Mentat")
+		Media.DisplayMessage("The Emperor has been annihilated!")
 		player.MarkCompletedObjective(KillCorrino)
 	end
 
 	if smuggler_neutral.HasNoRequiredUnits() and smuggler_harkonnen.HasNoRequiredUnits() and smuggler_ai.HasNoRequiredUnits() and smuggler_both.HasNoRequiredUnits() and not SmugglersKilled then
-		Media.DisplayMessage("The Smugglers have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Smugglers have been annihilated!")
 		SmugglersKilled = true
 	end
 

--- a/mods/d2k/maps/ordos-01a/ordos01a.lua
+++ b/mods/d2k/maps/ordos-01a/ordos01a.lua
@@ -71,18 +71,18 @@ Tick = function()
 	-- player has no Wind Trap
 	if (player.PowerProvided <= 20 or player.PowerState ~= "Normal") and DateTime.GameTime % DateTime.Seconds(32) == 0 then
 		HasPower = false
-		Media.DisplayMessage(Messages[2], "Mentat")
+		Media.DisplayMessage(Messages[2])
 	else
 		HasPower = true
 	end
 
 	-- player has no Refinery and no Silos
 	if HasPower and player.ResourceCapacity == 0 and DateTime.GameTime % DateTime.Seconds(32) == 0 then
-		Media.DisplayMessage(Messages[3], "Mentat")
+		Media.DisplayMessage(Messages[3])
 	end
 
 	if HasPower and player.Resources > player.ResourceCapacity * 0.8 and DateTime.GameTime % DateTime.Seconds(32) == 0 then
-		Media.DisplayMessage(Messages[4], "Mentat")
+		Media.DisplayMessage(Messages[4])
 	end
 
 	UserInterface.SetMissionText("Harvested resources: " .. player.Resources .. "/" .. SpiceToHarvest, player.Color)
@@ -102,7 +102,7 @@ WorldLoaded = function()
 	local checkResourceCapacity = function()
 		Trigger.AfterDelay(0, function()
 			if player.ResourceCapacity < SpiceToHarvest then
-				Media.DisplayMessage("We don't have enough silo space to store the required amount of Spice!", "Mentat")
+				Media.DisplayMessage("We don't have enough silo space to store the required amount of Spice!")
 				Trigger.AfterDelay(DateTime.Seconds(3), function()
 					harkonnen.MarkCompletedObjective(KillAtreides)
 				end)
@@ -134,7 +134,7 @@ WorldLoaded = function()
 		end
 	end)
 
-	Media.DisplayMessage(Messages[1], "Mentat")
+	Media.DisplayMessage(Messages[1])
 
 	Trigger.AfterDelay(DateTime.Seconds(25), function()
 		Media.PlaySpeechNotification(player, "Reinforce")

--- a/mods/d2k/maps/ordos-01b/ordos01b.lua
+++ b/mods/d2k/maps/ordos-01b/ordos01b.lua
@@ -71,18 +71,18 @@ Tick = function()
 	-- player has no Wind Trap
 	if (player.PowerProvided <= 20 or player.PowerState ~= "Normal") and DateTime.GameTime % DateTime.Seconds(32) == 0 then
 		HasPower = false
-		Media.DisplayMessage(Messages[2], "Mentat")
+		Media.DisplayMessage(Messages[2])
 	else
 		HasPower = true
 	end
 
 	-- player has no Refinery and no Silos
 	if HasPower and player.ResourceCapacity == 0 and DateTime.GameTime % DateTime.Seconds(32) == 0 then
-		Media.DisplayMessage(Messages[3], "Mentat")
+		Media.DisplayMessage(Messages[3])
 	end
 
 	if HasPower and player.Resources > player.ResourceCapacity * 0.8 and DateTime.GameTime % DateTime.Seconds(32) == 0 then
-		Media.DisplayMessage(Messages[4], "Mentat")
+		Media.DisplayMessage(Messages[4])
 	end
 
 	UserInterface.SetMissionText("Harvested resources: " .. player.Resources .. "/" .. SpiceToHarvest, player.Color)
@@ -102,7 +102,7 @@ WorldLoaded = function()
 	local checkResourceCapacity = function()
 		Trigger.AfterDelay(0, function()
 			if player.ResourceCapacity < SpiceToHarvest then
-				Media.DisplayMessage("We don't have enough silo space to store the required amount of Spice!", "Mentat")
+				Media.DisplayMessage("We don't have enough silo space to store the required amount of Spice!")
 				Trigger.AfterDelay(DateTime.Seconds(3), function()
 					harkonnen.MarkCompletedObjective(KillAtreides)
 				end)
@@ -134,7 +134,7 @@ WorldLoaded = function()
 		end
 	end)
 
-	Media.DisplayMessage(Messages[1], "Mentat")
+	Media.DisplayMessage(Messages[1])
 
 	Trigger.AfterDelay(DateTime.Seconds(25), function()
 		Media.PlaySpeechNotification(player, "Reinforce")

--- a/mods/d2k/maps/ordos-02a/ordos02a.lua
+++ b/mods/d2k/maps/ordos-02a/ordos02a.lua
@@ -86,7 +86,7 @@ Tick = function()
 	end
 
 	if harkonnen.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillHarkonnen) then
-		Media.DisplayMessage("The Harkonnen have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Harkonnen have been annihilated!")
 		player.MarkCompletedObjective(KillHarkonnen)
 	end
 end

--- a/mods/d2k/maps/ordos-02b/ordos02b.lua
+++ b/mods/d2k/maps/ordos-02b/ordos02b.lua
@@ -70,7 +70,7 @@ Tick = function()
 	end
 
 	if harkonnen.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillHarkonnen) then
-		Media.DisplayMessage("The Harkonnen have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Harkonnen have been annihilated!")
 		player.MarkCompletedObjective(KillHarkonnen)
 	end
 end

--- a/mods/d2k/maps/ordos-03a/ordos03a.lua
+++ b/mods/d2k/maps/ordos-03a/ordos03a.lua
@@ -86,7 +86,7 @@ Tick = function()
 	end
 
 	if harkonnen.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillHarkonnen) then
-		Media.DisplayMessage("The Harkonnen have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Harkonnen have been annihilated!")
 		player.MarkCompletedObjective(KillHarkonnen)
 	end
 
@@ -100,7 +100,7 @@ Tick = function()
 	end
 
 	if DateTime.GameTime % DateTime.Seconds(32) == 0 and (MessageCheck(1) or MessageCheck(2)) then
-		Media.DisplayMessage("Upgrade barracks and light factory to produce more advanced units.", "Mentat")
+		Media.DisplayMessage("Upgrade barracks and light factory to produce more advanced units.")
 	end
 end
 

--- a/mods/d2k/maps/ordos-03b/ordos03b.lua
+++ b/mods/d2k/maps/ordos-03b/ordos03b.lua
@@ -123,7 +123,7 @@ Tick = function()
 	end
 
 	if harkonnen.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillHarkonnen) then
-		Media.DisplayMessage("The Harkonnen have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Harkonnen have been annihilated!")
 		player.MarkCompletedObjective(KillHarkonnen)
 	end
 
@@ -137,7 +137,7 @@ Tick = function()
 	end
 
 	if DateTime.GameTime % DateTime.Seconds(32) == 0 and (MessageCheck(1) or MessageCheck(2)) then
-		Media.DisplayMessage("Upgrade barracks and light factory to produce more advanced units.", "Mentat")
+		Media.DisplayMessage("Upgrade barracks and light factory to produce more advanced units.")
 	end
 end
 

--- a/mods/d2k/maps/ordos-04/ordos04.lua
+++ b/mods/d2k/maps/ordos-04/ordos04.lua
@@ -90,7 +90,7 @@ Tick = function()
 	end
 
 	if harkonnen.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillHarkonnen) then
-		Media.DisplayMessage("The Harkonnen have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Harkonnen have been annihilated!")
 		player.MarkCompletedObjective(KillHarkonnen)
 	end
 
@@ -146,7 +146,7 @@ WorldLoaded = function()
 
 		if AttackNotifier <= 0 then
 			AttackNotifier = DateTime.Seconds(10)
-			Media.DisplayMessage("Don't destroy the Outpost!", "Mentat")
+			Media.DisplayMessage("Don't destroy the Outpost!")
 		end
 	end)
 
@@ -156,6 +156,6 @@ WorldLoaded = function()
 	end)
 
 	Trigger.AfterDelay(HarkonnenAttackDelay[Difficulty], function()
-		Media.DisplayMessage("WARNING: Large force approaching!", "Mentat")
+		Media.DisplayMessage("WARNING: Large force approaching!")
 	end)
 end

--- a/mods/d2k/maps/ordos-05/ordos05.lua
+++ b/mods/d2k/maps/ordos-05/ordos05.lua
@@ -121,7 +121,7 @@ Tick = function()
 	end
 
 	if atreides_main.HasNoRequiredUnits() and atreides_small_1.HasNoRequiredUnits() and atreides_small_2.HasNoRequiredUnits() and atreides_small_3.HasNoRequiredUnits() and not player.IsObjectiveCompleted(KillAtreides) then
-		Media.DisplayMessage("The Atreides have been annihilated!", "Mentat")
+		Media.DisplayMessage("The Atreides have been annihilated!")
 		player.MarkCompletedObjective(KillAtreides)
 	end
 

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -227,6 +227,17 @@ GameSpeeds:
 ColorValidator:
 	TeamColorPresets: ffc9ca, f53333, ffae00, fff830, 87f506, f872ad, da06f3, ddb8ff, def7b2, 39c46f, 200738, 280df6, 2f86f2, 76d2f8, 498221, 000000
 
+ChatLabels:
+	BattlefieldControl: Mentat
+	Mission: Mentat
+	Debug: Developer
+	All: Everyone
+	Spectators: Observers
+	Team: Allies
+	Ally: Friendly
+	Spectator: Observer
+	Dead: Defeated
+
 ModContent:
 	InstallPromptMessage: Dune 2000 requires artwork and audio from the original game.\n\nQuick Install will automatically download this content (without\nmusic or videos) from an online mirror of the game files.\n\nAdvanced Install includes options for copying the music, videos,\nand other content from an original game disc.
 	HeaderMessage: The original game content may be copied from an original game disc,\nor downloaded from an online mirror of the game files.


### PR DESCRIPTION
This PR:
- Removes hard-coded chat labels and makes them configurable in `mod.yaml` as `IGlobalModData` (this includes the labels for the "Team/All" chat toggle button)
- Adds a method overload for `AddSystemLine` that omits the `name` parameter to reduce duplication (this is in a separate commit but I will squash it if need be)
- TESTCASE changes the labels in D2k mod like this and removes "Mentat" strings hard-coded in lua scripts:
```yaml
ChatLabels:
	BattlefieldControl: Mentat
	Mission: Mentat
	Debug: Developer
	All: Everyone
	Spectators: Observers
	Team: Allies
	Ally: Friendly
	Spectator: Observer
	Dead: Defeated
```

Closes #17551 