### PR TITLE
Fix Texture.GetData under GLES.

### DIFF
--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -31,7 +31,8 @@ namespace OpenRA.Platforms.Default
 			None = 0,
 			Core = 1,
 			GLES = 2,
-			DebugMessagesCallback = 4
+			DebugMessagesCallback = 4,
+			ESReadFormatBGRA = 8
 		}
 
 		public static GLFeatures Features { get; private set; }
@@ -122,6 +123,7 @@ namespace OpenRA.Platforms.Default
 
 		// OpenGL 1.1 - 1.5
 		public const int GL_CLIENT_PIXEL_STORE_BIT = 0x0001;
+		public const int GL_RGBA = 0x1908;
 		public const int GL_BGRA = 0x80E1;
 		public const int GL_RGBA8 = 0x8058;
 		public const int GL_CLAMP_TO_EDGE = 0x812F;
@@ -625,7 +627,12 @@ namespace OpenRA.Platforms.Default
 				// Core features are defined as the shared feature set of GL 3.2 and (GLES 3 + BGRA extension)
 				var hasBGRA = SDL.SDL_GL_ExtensionSupported("GL_EXT_texture_format_BGRA8888") == SDL.SDL_bool.SDL_TRUE;
 				if (Version.Contains(" ES") && hasBGRA && major >= 3)
+				{
 					Features = GLFeatures.Core | GLFeatures.GLES;
+
+					if (SDL.SDL_GL_ExtensionSupported("GL_EXT_read_format_bgra") == SDL.SDL_bool.SDL_TRUE)
+						Features |= GLFeatures.ESReadFormatBGRA;
+				}
 				else if (major > 3 || (major == 3 && minor >= 2))
 					Features = GLFeatures.Core;
 

--- a/OpenRA.Platforms.Default/Texture.cs
+++ b/OpenRA.Platforms.Default/Texture.cs
@@ -133,13 +133,28 @@ namespace OpenRA.Platforms.Default
 				OpenGL.glFramebufferTexture2D(OpenGL.GL_FRAMEBUFFER, OpenGL.GL_COLOR_ATTACHMENT0, OpenGL.GL_TEXTURE_2D, texture, 0);
 				OpenGL.CheckGLError();
 
+				var canReadBGRA = OpenGL.Features.HasFlag(OpenGL.GLFeatures.ESReadFormatBGRA);
+
 				unsafe
 				{
 					fixed (byte* ptr = &data[0])
 					{
-						var intPtr = new IntPtr((void*)ptr);
-						OpenGL.glReadPixels(0, 0, Size.Width, Size.Height, OpenGL.GL_BGRA, OpenGL.GL_UNSIGNED_BYTE, intPtr);
+						var intPtr = new IntPtr(ptr);
+
+						var format = canReadBGRA ? OpenGL.GL_BGRA : OpenGL.GL_RGBA;
+						OpenGL.glReadPixels(0, 0, Size.Width, Size.Height, format, OpenGL.GL_UNSIGNED_BYTE, intPtr);
 						OpenGL.CheckGLError();
+					}
+				}
+
+				// Convert RGBA to BGRA
+				if (!canReadBGRA)
+				{
+					for (var i = 0; i < 4 * Size.Width * Size.Height; i += 4)
+					{
+						var temp = data[i];
+						data[i] = data[i + 2];
+						data[i + 2] = temp;
 					}
 				}
 


### PR DESCRIPTION
Fixes #17087.

Note that this only touches GLES code paths, so make sure to confirm that the startup logging reports the GLES renderer is active while testing.

It may be useful to change https://github.com/OpenRA/OpenRA/blob/23b3c237b7071fd308c4664b0b6c5d719c0f3c74/OpenRA.Game/Graphics/SequenceProvider.cs#L131-L137 while testing to
```csharp
 public void Preload() 
 { 
	foreach (var sheet in SpriteCache.SheetBuilder.AllSheets)
		sheet.CreateBuffer(); 
 	foreach (var unitSeq in sequences.Value.Values) 
 		foreach (var seq in unitSeq.Value.Values) { } 
 	foreach (var sheet in SpriteCache.SheetBuilder.AllSheets)
		sheet.ReleaseBuffer(); 
 } 
```

to force all sequence artwork to be read back from the GPU. This makes it simple to demonstrate that e.g. things break if `GL_RGBA` is used without manually swapping color channels.