### PR TITLE
Fix the Build function in gdi04b

### DIFF
--- a/mods/cnc/maps/gdi04b/gdi04b.lua
+++ b/mods/cnc/maps/gdi04b/gdi04b.lua
@@ -60,6 +60,10 @@ SendGDIReinforcements = function()
 end
 
 Build = function(unitTypes, repeats, func)
+	if HandOfNod.IsDead then
+		return
+	end
+
 	local after = function(units)
 		Utils.Do(units, func)
 		if repeats then
@@ -69,7 +73,7 @@ Build = function(unitTypes, repeats, func)
 		end
 	end
 
-	if not HandOfNod.Build(unitTypes, innerFunc) then
+	if not HandOfNod.Build(unitTypes, after) then
 		Trigger.AfterDelay(DateTime.Seconds(5), function()
 			Build(unitTypes, repeats, func)
 		end)


### PR DESCRIPTION
Apparently I forgot to finish whatever I planned for that almost a year back (see `innerFunc` instead of `after`). :(
Anyway, this fixes #17567.
The `innerFunc` instead of `after` just silently failed, no crash there.