### PR TITLE
Cancel queued activities if AbortOnResupply is set.

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackLeap.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackLeap.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Cnc.Traits
 				leapToken = conditionManager.RevokeCondition(self, leapToken);
 		}
 
-		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
+		public override Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
 		{
 			return new LeapAttack(self, newTarget, allowMove, forceAttack, this, info, targetLineColor);
 		}

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTDGunboatTurreted.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTDGunboatTurreted.cs
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public AttackTDGunboatTurreted(Actor self, AttackTDGunboatTurretedInfo info)
 			: base(self, info) { }
 
-		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
+		public override Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
 		{
 			return new AttackTDGunboatTurretedActivity(self, newTarget, allowMove, forceAttack, targetLineColor);
 		}

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackTesla.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		void INotifyAttack.PreparingAttack(Actor self, Target target, Armament a, Barrel barrel) { }
 
-		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
+		public override Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 		{
 			return new ChargeAttack(this, newTarget, forceAttack, targetLineColor);
 		}

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			base.Activate(self, order, manager);
 
-			attack.AttackTarget(order.Target, false, false, true);
+			attack.AttackTarget(order.Target, AttackSource.Default, false, false, true);
 		}
 
 		protected override void Created(Actor self)

--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Mods.Common.Activities
 		readonly Aircraft aircraft;
 		readonly AttackAircraft attackAircraft;
 		readonly Rearmable rearmable;
+		readonly AttackSource source;
 		readonly bool forceAttack;
 		readonly Color? targetLineColor;
 
@@ -36,8 +37,9 @@ namespace OpenRA.Mods.Common.Activities
 		bool returnToBase;
 		int remainingTicksUntilTurn;
 
-		public FlyAttack(Actor self, Target target, bool forceAttack, Color? targetLineColor)
+		public FlyAttack(Actor self, AttackSource source, Target target, bool forceAttack, Color? targetLineColor)
 		{
+			this.source = source;
 			this.target = target;
 			this.forceAttack = forceAttack;
 			this.targetLineColor = targetLineColor;
@@ -120,6 +122,14 @@ namespace OpenRA.Mods.Common.Activities
 			// and resume the activity after reloading if AbortOnResupply is set to 'false'
 			if (rearmable != null && !useLastVisibleTarget && attackAircraft.Armaments.All(x => x.IsTraitPaused || !x.Weapon.IsValidAgainst(target, self.World, self)))
 			{
+				// Attack moves never resupply
+				if (source == AttackSource.AttackMove)
+					return true;
+
+				// AbortOnResupply cancels the current activity (after resupplying) plus any queued activities
+				if (attackAircraft.Info.AbortOnResupply && NextActivity != null)
+					NextActivity.Cancel(self);
+
 				QueueChild(new ReturnToBase(self));
 				returnToBase = true;
 				return attackAircraft.Info.AbortOnResupply;

--- a/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
+++ b/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Activities
 					ChildActivity.Cancel(self);
 					var attackBases = autoTarget.ActiveAttackBases;
 					foreach (var ab in attackBases)
-						QueueChild(ab.GetAttackActivity(self, target, false, false));
+						QueueChild(ab.GetAttackActivity(self, AttackSource.AttackMove, target, false, false));
 
 					// Make sure to continue moving when the attack activities have finished.
 					QueueChild(getInner());

--- a/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/CombatProperties.cs
@@ -98,7 +98,7 @@ namespace OpenRA.Mods.Common.Scripting
 				Log.Write("lua", "{1} is not revealed for player {0}!", Self.Owner, targetActor);
 
 			foreach (var attack in attackBases)
-				attack.AttackTarget(target, true, allowMove, forceAttack);
+				attack.AttackTarget(target, AttackSource.Default, true, allowMove, forceAttack);
 		}
 
 		[Desc("Checks if the targeted actor is a valid target for this actor.")]

--- a/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public override Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 		{
-			return new FlyAttack(self, newTarget, forceAttack, targetLineColor);
+			return new FlyAttack(self, source, newTarget, forceAttack, targetLineColor);
 		}
 
 		protected override bool CanAttack(Actor self, Target target)

--- a/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackAircraft.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 			aircraftInfo = self.Info.TraitInfo<AircraftInfo>();
 		}
 
-		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
+		public override Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 		{
 			return new FlyAttack(self, newTarget, forceAttack, targetLineColor);
 		}

--- a/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
+++ b/OpenRA.Mods.Common/Traits/Air/AttackBomber.cs
@@ -86,7 +86,7 @@ namespace OpenRA.Mods.Common.Traits
 			OnRemovedFromWorld(self);
 		}
 
-		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
+		public override Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
 		{
 			throw new NotImplementedException("AttackBomber requires a scripted target");
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -21,6 +21,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	public enum AttackSource { Default, AutoTarget, AttackMove }
+
 	public abstract class AttackBaseInfo : PausableConditionalTraitInfo
 	{
 		[Desc("Armament names")]
@@ -199,7 +201,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!order.Target.IsValidFor(self))
 					return;
 
-				AttackTarget(order.Target, order.Queued, true, forceAttack, Info.TargetLineColor);
+				AttackTarget(order.Target, AttackSource.Default, order.Queued, true, forceAttack, Info.TargetLineColor);
 				self.ShowTargetLines();
 			}
 
@@ -224,7 +226,7 @@ namespace OpenRA.Mods.Common.Traits
 			return order.OrderString == attackOrderName || order.OrderString == forceAttackOrderName ? Info.Voice : null;
 		}
 
-		public abstract Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null);
+		public abstract Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null);
 
 		public bool HasAnyValidWeapons(Target t, bool checkForCenterTargetingWeapons = false)
 		{
@@ -391,7 +393,7 @@ namespace OpenRA.Mods.Common.Traits
 				&& a.Weapon.IsValidAgainst(t, self.World, self));
 		}
 
-		public void AttackTarget(Target target, bool queued, bool allowMove, bool forceAttack = false, Color? targetLineColor = null)
+		public void AttackTarget(Target target, AttackSource source, bool queued, bool allowMove, bool forceAttack = false, Color? targetLineColor = null)
 		{
 			if (IsTraitDisabled)
 				return;
@@ -399,7 +401,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!target.IsValidFor(self))
 				return;
 
-			var activity = GetAttackActivity(self, target, allowMove, forceAttack, targetLineColor);
+			var activity = GetAttackActivity(self, source, target, allowMove, forceAttack, targetLineColor);
 			self.QueueActivity(queued, activity);
 			OnResolveAttackOrder(self, activity, target, queued, forceAttack);
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -152,7 +152,7 @@ namespace OpenRA.Mods.Common.Traits
 			base.Tick(self);
 		}
 
-		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
+		public override Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 		{
 			return new AttackActivity(self, newTarget, allowMove, forceAttack, targetLineColor);
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFrontal.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 			return TargetInFiringArc(self, target, Info.FacingTolerance);
 		}
 
-		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
+		public override Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 		{
 			return new Activities.Attack(self, newTarget, allowMove, forceAttack, targetLineColor);
 		}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackOmni.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		public AttackOmni(Actor self, AttackOmniInfo info)
 			: base(self, info) { }
 
-		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
+		public override Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor = null)
 		{
 			return new SetTarget(this, newTarget, allowMove, forceAttack, targetLineColor);
 		}

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -321,7 +321,7 @@ namespace OpenRA.Mods.Common.Traits
 		void Attack(Actor self, Target target, bool allowMove)
 		{
 			foreach (var ab in ActiveAttackBases)
-				ab.AttackTarget(target, false, allowMove);
+				ab.AttackTarget(target, AttackSource.AutoTarget, false, allowMove);
 		}
 
 		public bool HasValidTargetPriority(Actor self, Player owner, BitSet<TargetableType> targetTypes)

--- a/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
+++ b/OpenRA.Mods.D2k/Traits/AttackSwallow.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.D2k.Traits
 			self.QueueActivity(false, new SwallowActor(self, target, a, facing));
 		}
 
-		public override Activity GetAttackActivity(Actor self, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
+		public override Activity GetAttackActivity(Actor self, AttackSource source, Target newTarget, bool allowMove, bool forceAttack, Color? targetLineColor)
 		{
 			return new SwallowTarget(self, newTarget, allowMove, forceAttack);
 		}

--- a/OpenRA.Mods.D2k/Traits/Sandworm.cs
+++ b/OpenRA.Mods.D2k/Traits/Sandworm.cs
@@ -89,7 +89,7 @@ namespace OpenRA.Mods.D2k.Traits
 
 			if (target.Type == TargetType.Actor)
 			{
-				attackTrait.AttackTarget(target, false, true, false);
+				attackTrait.AttackTarget(target, AttackSource.AutoTarget, false, true, false);
 				return;
 			}
 


### PR DESCRIPTION
This PR aims to fix #17525 by recreating the behaviour from `release-20190314` for both regular attacks and attack moves. This is a hack, but IMO not significantly worse than the rest of `AbortOnResupply`.

This is simple enough to also pick to the hotfix, if not rejected for being awful.

Fixes #17525.
Fixes #17249.