### PR TITLE
Remove client-side GeoIP and anonymise shared IPs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -163,9 +163,6 @@ Using OpenAL Soft distributed under the GNU LGPL.
 Using MaxMind GeoIP2 .NET API distributed under
 the Apache 2.0 license.
 
-Using GeoLite2 data created by MaxMind and
-distributed under the CC BY-SA 3.0 license.
-
 Using SDL2-CS and OpenAL-CS created by Ethan
 Lee and released under the zlib license.
 

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -338,8 +338,6 @@ namespace OpenRA
 				}
 			}
 
-			GeoIP.Initialize();
-
 			if (Settings.Server.DiscoverNatDevices)
 				discoverNat = UPnP.DiscoverNatDevices(Settings.Server.NatDiscoveryTimeout);
 

--- a/OpenRA.Game/Network/GameServer.cs
+++ b/OpenRA.Game/Network/GameServer.cs
@@ -97,6 +97,9 @@ namespace OpenRA.Network
 		/// <summary>URL to a 32x32 px icon for the mod.</summary>
 		public readonly string ModIcon32 = "";
 
+		/// <summary>GeoIP resolved server location.</summary>
+		public readonly string Location = "";
+
 		/// <summary>Password protected</summary>
 		public readonly bool Protected = false;
 

--- a/OpenRA.Game/Network/GeoIP.cs
+++ b/OpenRA.Game/Network/GeoIP.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Network
 				}
 			}
 
-			return "Unknown Location";
+			return null;
 		}
 	}
 }

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -133,7 +133,7 @@ namespace OpenRA.Network
 			// The full IP address is required for the IP banning moderation feature
 			// but we must not share the un-anonymized address with other players.
 			[FieldLoader.Ignore]
-			public string IpAddress;
+			public string IPAddress;
 			public string AnonymizedIPAddress;
 			public string Location;
 

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -12,6 +12,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 using OpenRA.Primitives;
 
 namespace OpenRA.Network
@@ -25,6 +27,18 @@ namespace OpenRA.Network
 		public Dictionary<string, Slot> Slots = new Dictionary<string, Slot>();
 
 		public Global GlobalSettings = new Global();
+
+		public static string AnonymizeIP(IPAddress ip)
+		{
+			if (ip.AddressFamily == AddressFamily.InterNetwork)
+			{
+				// Follow convention used by Google Analytics: remove last octet
+				var b = ip.GetAddressBytes();
+				return "{0}.{1}.{2}.*".F(b[0], b[1], b[2]);
+			}
+
+			return null;
+		}
 
 		public static Session Deserialize(string data)
 		{
@@ -115,8 +129,14 @@ namespace OpenRA.Network
 			public string Faction;
 			public int SpawnPoint;
 			public string Name;
+
+			// The full IP address is required for the IP banning moderation feature
+			// but we must not share the un-anonymized address with other players.
+			[FieldLoader.Ignore]
 			public string IpAddress;
+			public string AnonymizedIPAddress;
 			public string Location;
+
 			public ClientState State = ClientState.Invalid;
 			public int Team;
 			public string Slot; // Slot ID, or null for observer

--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -116,6 +116,7 @@ namespace OpenRA.Network
 			public int SpawnPoint;
 			public string Name;
 			public string IpAddress;
+			public string Location;
 			public ClientState State = ClientState.Invalid;
 			public int Team;
 			public string Slot; // Slot ID, or null for observer

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -348,6 +348,7 @@ namespace OpenRA.Server
 				{
 					Name = OpenRA.Settings.SanitizedPlayerName(handshake.Client.Name),
 					IpAddress = ipAddress.ToString(),
+					AnonymizedIPAddress = Settings.ShareAnonymizedIPs ? Session.AnonymizeIP(ipAddress) : null,
 					Location = GeoIP.LookupCountry(ipAddress),
 					Index = newConn.PlayerIndex,
 					PreferredColor = handshake.Client.PreferredColor,

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -347,7 +347,7 @@ namespace OpenRA.Server
 				var client = new Session.Client
 				{
 					Name = OpenRA.Settings.SanitizedPlayerName(handshake.Client.Name),
-					IpAddress = ipAddress.ToString(),
+					IPAddress = ipAddress.ToString(),
 					AnonymizedIPAddress = Settings.ShareAnonymizedIPs ? Session.AnonymizeIP(ipAddress) : null,
 					Location = GeoIP.LookupCountry(ipAddress),
 					Index = newConn.PlayerIndex,
@@ -391,10 +391,10 @@ namespace OpenRA.Server
 
 				// Check if IP is banned
 				var bans = Settings.Ban.Union(TempBans);
-				if (bans.Contains(client.IpAddress))
+				if (bans.Contains(client.IPAddress))
 				{
 					Log.Write("server", "Rejected connection from {0}; Banned.", newConn.Socket.RemoteEndPoint);
-					SendOrderTo(newConn, "ServerError", "You have been {0} from the server".F(Settings.Ban.Contains(client.IpAddress) ? "banned" : "temporarily banned"));
+					SendOrderTo(newConn, "ServerError", "You have been {0} from the server".F(Settings.Ban.Contains(client.IPAddress) ? "banned" : "temporarily banned"));
 					DropClient(newConn);
 					return;
 				}

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -149,6 +149,8 @@ namespace OpenRA.Server
 
 			randomSeed = (int)DateTime.Now.ToBinary();
 
+			GeoIP.Initialize();
+
 			if (UPnP.Status == UPnPStatus.Enabled)
 				UPnP.ForwardPort(Settings.ListenPort, Settings.ListenPort).Wait();
 
@@ -341,10 +343,12 @@ namespace OpenRA.Server
 					return;
 				}
 
+				var ipAddress = ((IPEndPoint)newConn.Socket.RemoteEndPoint).Address;
 				var client = new Session.Client
 				{
 					Name = OpenRA.Settings.SanitizedPlayerName(handshake.Client.Name),
-					IpAddress = ((IPEndPoint)newConn.Socket.RemoteEndPoint).Address.ToString(),
+					IpAddress = ipAddress.ToString(),
+					Location = GeoIP.LookupCountry(ipAddress.ToString()),
 					Index = newConn.PlayerIndex,
 					PreferredColor = handshake.Client.PreferredColor,
 					Color = handshake.Client.Color,

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -149,7 +149,7 @@ namespace OpenRA.Server
 
 			randomSeed = (int)DateTime.Now.ToBinary();
 
-			GeoIP.Initialize();
+			GeoIP.Initialize(settings.GeoIPDatabase);
 
 			if (UPnP.Status == UPnPStatus.Enabled)
 				UPnP.ForwardPort(Settings.ListenPort, Settings.ListenPort).Wait();
@@ -348,7 +348,7 @@ namespace OpenRA.Server
 				{
 					Name = OpenRA.Settings.SanitizedPlayerName(handshake.Client.Name),
 					IpAddress = ipAddress.ToString(),
-					Location = GeoIP.LookupCountry(ipAddress.ToString()),
+					Location = GeoIP.LookupCountry(ipAddress),
 					Index = newConn.PlayerIndex,
 					PreferredColor = handshake.Client.PreferredColor,
 					Color = handshake.Client.Color,

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -82,6 +82,10 @@ namespace OpenRA
 		[Desc("Sets the timestamp format. Defaults to the ISO 8601 standard.")]
 		public string TimestampFormat = "yyyy-MM-ddTHH:mm:ss";
 
+		[Desc("Path to a MaxMind GeoLite2 database to use for player geo-location.",
+			"Database files can be downloaded from https://dev.maxmind.com/geoip/geoip2/geolite2/")]
+		public string GeoIPDatabase = null;
+
 		public ServerSettings Clone()
 		{
 			return (ServerSettings)MemberwiseClone();

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -86,6 +86,9 @@ namespace OpenRA
 			"Database files can be downloaded from https://dev.maxmind.com/geoip/geoip2/geolite2/")]
 		public string GeoIPDatabase = null;
 
+		[Desc("Allow clients to see anonymised IPs for other clients.")]
+		public bool ShareAnonymizedIPs = true;
+
 		public ServerSettings Clone()
 		{
 			return (ServerSettings)MemberwiseClone();

--- a/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
+++ b/OpenRA.Mods.Common/ServerTraits/LobbyCommands.cs
@@ -595,9 +595,9 @@ namespace OpenRA.Mods.Common.Server
 
 			if (tempBan)
 			{
-				Log.Write("server", "Temporarily banning client {0} ({1}).", kickClientID, kickClient.IpAddress);
+				Log.Write("server", "Temporarily banning client {0} ({1}).", kickClientID, kickClient.IPAddress);
 				server.SendMessage("{0} temporarily banned {1} from the server.".F(client.Name, kickClient.Name));
-				server.TempBans.Add(kickClient.IpAddress);
+				server.TempBans.Add(kickClient.IPAddress);
 			}
 
 			server.SyncLobbyClients();

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -593,20 +593,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			HideChildWidget(parent, "STATUS_IMAGE");
 		}
 
-		public static string GetExternalIP(Session.Client client, OrderManager orderManager)
-		{
-			var address = client != null ? client.IpAddress : "";
-			var lc = orderManager.LocalClient;
-			if (lc != null && lc.Index == client.Index && address == IPAddress.Loopback.ToString())
-			{
-				var externalIP = UPnP.ExternalIP;
-				if (externalIP != null)
-					address = externalIP.ToString();
-			}
-
-			return address;
-		}
-
 		public static void SetupChatLine(ContainerWidget template, DateTime time, string name, Color nameColor, string text, Color textColor)
 		{
 			var nameLabel = template.Get<LabelWidget>("NAME");

--- a/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
@@ -316,16 +316,30 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var nameFont = Game.Renderer.Fonts[nameLabel.Font];
 			widget.Bounds.Width = nameFont.Measure(nameLabel.Text).X + 2 * nameLabel.Bounds.Left;
 
-			var ipLabel = widget.Get<LabelWidget>("IP");
-			ipLabel.GetText = () => client.IpAddress;
-
 			var locationLabel = widget.Get<LabelWidget>("LOCATION");
-			locationLabel.GetText = () => client.Location;
+			var ipLabel = widget.Get<LabelWidget>("IP");
+			var adminLabel = widget.Get("GAME_ADMIN");
+
+			if (client.Location != null)
+			{
+				locationLabel.IsVisible = () => true;
+				locationLabel.GetText = () => client.Location;
+				widget.Bounds.Height += locationLabel.Bounds.Height;
+				ipLabel.Bounds.Y += locationLabel.Bounds.Height;
+				adminLabel.Bounds.Y += locationLabel.Bounds.Height;
+			}
+
+			if (client.IpAddress != null)
+			{
+				ipLabel.IsVisible = () => true;
+				ipLabel.GetText = () => client.IpAddress;
+				widget.Bounds.Height += ipLabel.Bounds.Height;
+				adminLabel.Bounds.Y += locationLabel.Bounds.Height;
+			}
 
 			if (client.IsAdmin)
 			{
-				var adminLabel = widget.Get("GAME_ADMIN");
-				adminLabel.IsVisible = () => client.IsAdmin;
+				adminLabel.IsVisible = () => true;
 				widget.Bounds.Height += adminLabel.Bounds.Height;
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
@@ -329,10 +329,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				adminLabel.Bounds.Y += locationLabel.Bounds.Height;
 			}
 
-			if (client.IpAddress != null)
+			if (client.AnonymizedIPAddress != null)
 			{
 				ipLabel.IsVisible = () => true;
-				ipLabel.GetText = () => client.IpAddress;
+				ipLabel.GetText = () => client.AnonymizedIPAddress;
 				widget.Bounds.Height += ipLabel.Bounds.Height;
 				adminLabel.Bounds.Y += locationLabel.Bounds.Height;
 			}

--- a/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
@@ -312,19 +312,15 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		[ObjectCreator.UseCtor]
 		public AnonymousProfileTooltipLogic(Widget widget, OrderManager orderManager, Session.Client client)
 		{
-			var address = LobbyUtils.GetExternalIP(client, orderManager);
-			var cachedDescriptiveIP = address ?? "Unknown IP";
-
 			var nameLabel = widget.Get<LabelWidget>("NAME");
 			var nameFont = Game.Renderer.Fonts[nameLabel.Font];
 			widget.Bounds.Width = nameFont.Measure(nameLabel.Text).X + 2 * nameLabel.Bounds.Left;
 
 			var ipLabel = widget.Get<LabelWidget>("IP");
-			ipLabel.GetText = () => cachedDescriptiveIP;
+			ipLabel.GetText = () => client.IpAddress;
 
 			var locationLabel = widget.Get<LabelWidget>("LOCATION");
-			var cachedCountryLookup = GeoIP.LookupCountry(address);
-			locationLabel.GetText = () => cachedCountryLookup;
+			locationLabel.GetText = () => client.Location;
 
 			if (client.IsAdmin)
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerListLogic.cs
@@ -370,6 +370,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							if (addressNode != null)
 								addressNode.Value.Value = bl.Address.ToString().Split(':')[0] + ":" + addressNode.Value.Value.Split(':')[1];
 
+							game.Nodes.Add(new MiniYamlNode("Location", "Local Network"));
+
 							lanGames.Add(new GameServer(game));
 						}
 					}
@@ -658,8 +660,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						if (location != null)
 						{
 							var font = Game.Renderer.Fonts[location.Font];
-							var cachedServerLocation = game.Id != -1 ? GeoIP.LookupCountry(game.Address.Split(':')[0]) : "Local Network";
-							var label = WidgetUtils.TruncateText(cachedServerLocation, location.Bounds.Width, font);
+							var label = WidgetUtils.TruncateText(game.Location, location.Bounds.Width, font);
 							location.GetText = () => label;
 							location.GetColor = () => canJoin ? location.TextColor : incompatibleGameColor;
 						}

--- a/launch-dedicated.cmd
+++ b/launch-dedicated.cmd
@@ -8,6 +8,8 @@ set ListenPort=1234
 set AdvertiseOnline=True
 set Password=""
 
+set GeoIPDatabase=""
+
 set RequireAuthentication=False
 set ProfileIDBlacklist=""
 set ProfileIDWhitelist=""
@@ -17,6 +19,6 @@ set EnableSyncReports=False
 
 :loop
 
-OpenRA.Server.exe Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports%
+OpenRA.Server.exe Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.GeoIPDatabase=%GeoIPDatabase% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports%
 
 goto loop

--- a/launch-dedicated.cmd
+++ b/launch-dedicated.cmd
@@ -16,9 +16,10 @@ set ProfileIDWhitelist=""
 
 set EnableSingleplayer=False
 set EnableSyncReports=False
+set ShareAnonymizedIPs=True
 
 :loop
 
-OpenRA.Server.exe Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.GeoIPDatabase=%GeoIPDatabase% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports%
+OpenRA.Server.exe Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.GeoIPDatabase=%GeoIPDatabase% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports% Server.ShareAnonymizedIPs=%ShareAnonymizedIPs%
 
 goto loop

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -12,6 +12,8 @@ ListenPort="${ListenPort:-"1234"}"
 AdvertiseOnline="${AdvertiseOnline:-"True"}"
 Password="${Password:-""}"
 
+GeoIPDatabase="${GeoIPDatabase:-""}"
+
 RequireAuthentication="${RequireAuthentication:-"False"}"
 ProfileIDBlacklist="${ProfileIDBlacklist:-""}"
 ProfileIDWhitelist="${ProfileIDWhitelist:-""}"
@@ -26,6 +28,7 @@ while true; do
      Server.AdvertiseOnline="$AdvertiseOnline" \
      Server.EnableSingleplayer="$EnableSingleplayer" \
      Server.Password="$Password" \
+     Server.GeoIPDatabase="$GeoIPDatabase" \
      Server.RequireAuthentication="$RequireAuthentication" \
      Server.ProfileIDBlacklist="$ProfileIDBlacklist" \
      Server.ProfileIDWhitelist="$ProfileIDWhitelist" \

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -20,6 +20,7 @@ ProfileIDWhitelist="${ProfileIDWhitelist:-""}"
 
 EnableSingleplayer="${EnableSingleplayer:-"False"}"
 EnableSyncReports="${EnableSyncReports:-"False"}"
+ShareAnonymizedIPs="${ShareAnonymizedIPs:-"True"}"
 
 while true; do
      mono --debug OpenRA.Server.exe Game.Mod="$Mod" \
@@ -32,5 +33,6 @@ while true; do
      Server.RequireAuthentication="$RequireAuthentication" \
      Server.ProfileIDBlacklist="$ProfileIDBlacklist" \
      Server.ProfileIDWhitelist="$ProfileIDWhitelist" \
-     Server.EnableSyncReports="$EnableSyncReports"
+     Server.EnableSyncReports="$EnableSyncReports" \
+     Server.ShareAnonymizedIPs="$ShareAnonymizedIPs"
 done

--- a/mods/cnc/chrome/tooltips.yaml
+++ b/mods/cnc/chrome/tooltips.yaml
@@ -400,7 +400,7 @@ Background@LATENCY_TOOLTIP:
 Background@ANONYMOUS_PLAYER_TOOLTIP:
 	Logic: AnonymousProfileTooltipLogic
 	Background: panel-black
-	Height: 55
+	Height: 30
 	Width: 200
 	Children:
 		Label@NAME:
@@ -411,30 +411,31 @@ Background@ANONYMOUS_PLAYER_TOOLTIP:
 			Font: MediumBold
 		Label@LOCATION:
 			X: 5
-			Y: 24
+			Y: 25
 			Height: 12
+			Visible: False
 			Font: TinyBold
 		Label@IP:
 			X: 5
-			Y: 37
+			Y: 25
 			Height: 12
+			Visible: False
 			Font: TinyBold
 		Container@GAME_ADMIN:
 			X: 5
-			Y: 49
+			Y: 25
 			Height: 12
 			Visible: False
 			Children:
 				Image@ICON:
 					X: 1
-					Y: 5
+					Y: 4
 					Width: 7
 					Height: 5
 					ImageCollection: lobby-bits
 					ImageName: admin
 				Label@LABEL:
 					X: 10
-					Y: 1
 					Height: 12
 					Text: Game Admin
 					Font: TinyBold

--- a/mods/common/chrome/tooltips.yaml
+++ b/mods/common/chrome/tooltips.yaml
@@ -133,7 +133,7 @@ Background@LATENCY_TOOLTIP:
 Background@ANONYMOUS_PLAYER_TOOLTIP:
 	Logic: AnonymousProfileTooltipLogic
 	Background: dialog4
-	Height: 56
+	Height: 30
 	Width: 200
 	Children:
 		Label@NAME:
@@ -144,29 +144,31 @@ Background@ANONYMOUS_PLAYER_TOOLTIP:
 			Font: MediumBold
 		Label@LOCATION:
 			X: 7
-			Y: 24
+			Y: 25
 			Height: 12
+			Visible: False
 			Font: TinyBold
 		Label@IP:
 			X: 7
-			Y: 37
+			Y: 25
 			Height: 12
+			Visible: False
 			Font: TinyBold
 		Container@GAME_ADMIN:
 			X: 7
-			Y: 49
+			Y: 25
 			Height: 12
 			Visible: False
 			Children:
 				Image@ICON:
-					Y: 5
+					X: 1
+					Y: 4
 					Width: 7
 					Height: 5
 					ImageCollection: lobby-bits
 					ImageName: admin
 				Label@LABEL:
-					X: 9
-					Y: 1
+					X: 10
 					Height: 12
 					Text: Game Admin
 					Font: TinyBold

--- a/mods/d2k/chrome/tooltips.yaml
+++ b/mods/d2k/chrome/tooltips.yaml
@@ -133,32 +133,35 @@ Background@LATENCY_TOOLTIP:
 Background@ANONYMOUS_PLAYER_TOOLTIP:
 	Logic: AnonymousProfileTooltipLogic
 	Background: dialog3
-	Height: 57
+	Height: 32
 	Width: 200
 	Children:
 		Label@NAME:
 			X: 7
-			Y: 2
+			Y: 3
 			Text: Anonymous Player
 			Height: 24
 			Font: MediumBold
 		Label@LOCATION:
 			X: 7
-			Y: 25
+			Y: 26
 			Height: 12
+			Visible: False
 			Font: TinyBold
 		Label@IP:
 			X: 7
-			Y: 38
+			Y: 26
 			Height: 12
+			Visible: False
 			Font: TinyBold
 		Container@GAME_ADMIN:
 			X: 7
-			Y: 50
+			Y: 26
 			Height: 12
 			Visible: False
 			Children:
 				Image@ICON:
+					X: 1
 					Y: 4
 					Width: 7
 					Height: 5
@@ -166,7 +169,6 @@ Background@ANONYMOUS_PLAYER_TOOLTIP:
 					ImageName: admin
 				Label@LABEL:
 					X: 10
-					Y: 3
 					Height: 12
 					Text: Game Admin
 					Font: TinyBold


### PR DESCRIPTION
This PR:
 * Moves the GeoIP country lookup from the game client to an opt-in server feature.
 * Anonymises client IPs before sharing them with other players.
 * Allows server hosts to opt out of sharing IPs completely.

https://github.com/OpenRA/OpenRA/wiki/Dedicated will need to be updated to reference https://dev.maxmind.com/geoip/geoipupdate/ once we are ready to ship the Next + 1 playtests.

Closes #17529.
Closes #15647.
Closes #17343.
Closes #17534.
