### PR TITLE
Protocol winstate bitfield

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -72,10 +72,10 @@ namespace OpenRA
 			return om;
 		}
 
-		static string TimestampedFilename(bool includemilliseconds = false)
+		public static string TimestampedFilename(bool includemilliseconds = false, string extra = "")
 		{
 			var format = includemilliseconds ? "yyyy-MM-ddTHHmmssfffZ" : "yyyy-MM-ddTHHmmssZ";
-			return ModData.Manifest.Id + "-" + DateTime.UtcNow.ToString(format, CultureInfo.InvariantCulture);
+			return ModData.Manifest.Id + extra + "-" + DateTime.UtcNow.ToString(format, CultureInfo.InvariantCulture);
 		}
 
 		static void JoinInner(OrderManager om)

--- a/OpenRA.Game/GameInformation.cs
+++ b/OpenRA.Game/GameInformation.cs
@@ -179,6 +179,9 @@ namespace OpenRA
 			/// <summary>The time when this player won or lost the game.</summary>
 			public DateTime OutcomeTimestampUtc;
 
+			/// <summary>The frame at which this player disconnected.</summary>
+			public int DisconnectFrame;
+
 			#endregion
 		}
 	}

--- a/OpenRA.Game/Network/OrderIO.cs
+++ b/OpenRA.Game/Network/OrderIO.cs
@@ -31,13 +31,14 @@ namespace OpenRA.Network
 			return ret;
 		}
 
-		public static byte[] SerializeSync(int sync)
+		public static byte[] SerializeSync(int sync, ulong defeatState)
 		{
-			var ms = new MemoryStream(1 + 4);
+			var ms = new MemoryStream(1 + 4 + 8);
 			using (var writer = new BinaryWriter(ms))
 			{
 				writer.Write((byte)OrderType.SyncHash);
 				writer.Write(sync);
+				writer.Write(defeatState);
 			}
 
 			return ms.GetBuffer();

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Network
 					var frame = BitConverter.ToInt32(packet, 0);
 					if (packet.Length == 5 && packet[4] == (byte)OrderType.Disconnect)
 						frameData.ClientQuit(clientId, frame);
-					else if (packet.Length >= 5 && packet[4] == (byte)OrderType.SyncHash)
+					else if (packet.Length == 4 + 1 + 4 + 8 && packet[4] == (byte)OrderType.SyncHash)
 						CheckSync(packet);
 					else if (frame == 0)
 						immediatePackets.Add((clientId, packet));

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -192,9 +192,16 @@ namespace OpenRA.Network
 				UnitOrders.ProcessOrder(this, World, order.Client, order.Order);
 
 			if (NetFrameNumber + FramesAhead >= GameSaveLastSyncFrame)
-				Connection.SendSync(NetFrameNumber, OrderIO.SerializeSync(World.SyncHash()));
+			{
+				var defeatState = 0UL;
+				for (var i = 0; i < World.Players.Length; i++)
+					if (World.Players[i].WinState == WinState.Lost)
+						defeatState |= 1UL << i;
+
+				Connection.SendSync(NetFrameNumber, OrderIO.SerializeSync(World.SyncHash(), defeatState));
+			}
 			else
-				Connection.SendSync(NetFrameNumber, OrderIO.SerializeSync(0));
+				Connection.SendSync(NetFrameNumber, OrderIO.SerializeSync(0, 0));
 
 			if (generateSyncReport)
 				using (new PerfSample("sync_report"))

--- a/OpenRA.Game/Network/ReplayRecorder.cs
+++ b/OpenRA.Game/Network/ReplayRecorder.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using OpenRA.FileFormats;
@@ -83,6 +84,14 @@ namespace OpenRA.Network
 			writer.Write(clientID);
 			writer.Write(data.Length);
 			writer.Write(data);
+		}
+
+		public void ReceiveFrame(int clientID, int frame, byte[] data)
+		{
+			var ms = new MemoryStream(4 + data.Length);
+			ms.WriteArray(BitConverter.GetBytes(frame));
+			ms.WriteArray(data);
+			Receive(clientID, ms.GetBuffer());
 		}
 
 		bool disposed;

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -39,7 +39,13 @@ namespace OpenRA.Network
 					{
 						var client = orderManager.LobbyInfo.ClientWithIndex(clientId);
 						if (client != null)
+						{
 							client.State = Session.ClientState.Disconnected;
+							var player = world?.FindPlayerByClient(client);
+							if (player != null)
+								world.OnPlayerDisconnected(player);
+						}
+
 						break;
 					}
 

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -123,6 +123,18 @@ namespace OpenRA
 			return factions.FirstOrDefault(f => f.InternalName == factionName) ?? factions.First();
 		}
 
+		public static string ResolvePlayerName(Session.Client client, IEnumerable<Session.Client> clients, IEnumerable<IBotInfo> botInfos)
+		{
+			if (client.Bot != null)
+			{
+				var botInfo = botInfos.First(b => b.Type == client.Bot);
+				var botsOfSameType = clients.Where(c => c.Bot == client.Bot).ToArray();
+				return botsOfSameType.Length == 1 ? botInfo.Name : "{0} {1}".F(botInfo.Name, botsOfSameType.IndexOf(client) + 1);
+			}
+
+			return client.Name;
+		}
+
 		public Player(World world, Session.Client client, PlayerReference pr)
 		{
 			World = world;
@@ -136,14 +148,7 @@ namespace OpenRA
 			{
 				ClientIndex = client.Index;
 				Color = client.Color;
-				if (client.Bot != null)
-				{
-					var botInfo = world.Map.Rules.Actors["player"].TraitInfos<IBotInfo>().First(b => b.Type == client.Bot);
-					var botsOfSameType = world.LobbyInfo.Clients.Where(c => c.Bot == client.Bot).ToArray();
-					PlayerName = botsOfSameType.Length == 1 ? botInfo.Name : "{0} {1}".F(botInfo.Name, botsOfSameType.IndexOf(client) + 1);
-				}
-				else
-					PlayerName = client.Name;
+				PlayerName = ResolvePlayerName(client, world.LobbyInfo.Clients, world.Map.Rules.Actors["player"].TraitInfos<IBotInfo>());
 
 				BotType = client.Bot;
 				Faction = ChooseFaction(world, client.Faction, !pr.LockFaction);

--- a/OpenRA.Game/Server/ProtocolVersion.cs
+++ b/OpenRA.Game/Server/ProtocolVersion.cs
@@ -25,6 +25,8 @@ namespace OpenRA.Server
 		// Order types are:
 		// - 0x65: World sync hash:
 		//   - Int32 containing the sync hash value
+		//   - UInt64 containing the current defeat state (a bit set
+		//     to 1 means the corresponding player is defeated)
 		// - 0xBF: Player disconnected
 		// - 0xFE: Handshake (also used for ServerOrders for ProtocolVersion.Orders < 8)
 		//   - Length-prefixed string specifying a name or key
@@ -66,6 +68,6 @@ namespace OpenRA.Server
 		// The protocol for server and world orders
 		// This applies after the handshake has completed, and is provided to support
 		// alternative server implementations that wish to support multiple versions in parallel
-		public const int Orders = 10;
+		public const int Orders = 11;
 	}
 }

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -1044,6 +1044,12 @@ namespace OpenRA.Server
 					// Send disconnected order, even if still in the lobby
 					DispatchOrdersToClients(toDrop, 0, Order.FromTargetString("Disconnected", "", true).Serialize());
 
+					if (gameInfo != null && !dropClient.IsObserver)
+					{
+						var disconnectedPlayer = gameInfo.Players.First(p => p.ClientIndex == toDrop.PlayerIndex);
+						disconnectedPlayer.DisconnectFrame = toDrop.MostRecentFrame;
+					}
+
 					LobbyInfo.Clients.RemoveAll(c => c.Index == toDrop.PlayerIndex);
 					LobbyInfo.ClientPings.RemoveAll(p => p.Index == toDrop.PlayerIndex);
 

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -88,6 +88,9 @@ namespace OpenRA
 		[Desc("Allow clients to see the country of other clients.")]
 		public bool EnableGeoIP = true;
 
+		[Desc("For dedicated servers only, save replays for all games played.")]
+		public bool RecordReplays = false;
+
 		public ServerSettings Clone()
 		{
 			return (ServerSettings)MemberwiseClone();

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -367,6 +367,12 @@ namespace OpenRA.Traits
 	[RequireExplicitImplementation]
 	public interface ICreatePlayers { void CreatePlayers(World w); }
 
+	[RequireExplicitImplementation]
+	public interface ICreatePlayersInfo : ITraitInfoInterface
+	{
+		void CreateServerPlayers(MapPreview map, Session lobbyInfo, List<GameInformation.Player> players);
+	}
+
 	public interface IBotInfo : ITraitInfoInterface
 	{
 		string Type { get; }

--- a/OpenRA.Game/World.cs
+++ b/OpenRA.Game/World.cs
@@ -552,6 +552,15 @@ namespace OpenRA
 			}
 		}
 
+		public void OnPlayerDisconnected(Player player)
+		{
+			var pi = gameInfo.GetPlayer(player);
+			if (pi == null)
+				return;
+
+			pi.DisconnectFrame = OrderManager.NetFrameNumber;
+		}
+
 		public void RequestGameSave(string filename)
 		{
 			// Allow traits to save arbitrary data that will be passed back via IGameSaveTraitData.ResolveTraitData

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -14,16 +14,22 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits.Render;
+using OpenRA.Network;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Required for the map editor to work. Attach this to the world actor.")]
-	public class EditorActorLayerInfo : TraitInfo
+	public class EditorActorLayerInfo : TraitInfo, ICreatePlayersInfo
 	{
 		[Desc("Size of partition bins (world pixels)")]
 		public readonly int BinSize = 250;
+
+		void ICreatePlayersInfo.CreateServerPlayers(MapPreview map, Session lobbyInfo, List<GameInformation.Player> players)
+		{
+			throw new NotImplementedException("EditorActorLayer must not be defined on the world actor");
+		}
 
 		public override object Create(ActorInitializer init) { return new EditorActorLayer(init.Self, this); }
 	}

--- a/launch-dedicated.cmd
+++ b/launch-dedicated.cmd
@@ -7,6 +7,7 @@ set Mod=ra
 set ListenPort=1234
 set AdvertiseOnline=True
 set Password=""
+set RecordReplays=False
 
 set RequireAuthentication=False
 set ProfileIDBlacklist=""
@@ -21,6 +22,6 @@ set SupportDir=""
 
 :loop
 
-OpenRA.Server.exe Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports% Server.EnableGeoIP=%EnableGeoIP% Server.ShareAnonymizedIPs=%ShareAnonymizedIPs% Engine.SupportDir=%SupportDir%
+OpenRA.Server.exe Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.RecordReplays=%RecordReplays% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports% Server.EnableGeoIP=%EnableGeoIP% Server.ShareAnonymizedIPs=%ShareAnonymizedIPs% Engine.SupportDir=%SupportDir%
 
 goto loop

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -11,6 +11,7 @@ Mod="${Mod:-"ra"}"
 ListenPort="${ListenPort:-"1234"}"
 AdvertiseOnline="${AdvertiseOnline:-"True"}"
 Password="${Password:-""}"
+RecordReplays="${RecordReplays:-"False"}"
 
 RequireAuthentication="${RequireAuthentication:-"False"}"
 ProfileIDBlacklist="${ProfileIDBlacklist:-""}"
@@ -30,6 +31,7 @@ while true; do
      Server.AdvertiseOnline="$AdvertiseOnline" \
      Server.EnableSingleplayer="$EnableSingleplayer" \
      Server.Password="$Password" \
+     Server.RecordReplays="$RecordReplays" \
      Server.GeoIPDatabase="$GeoIPDatabase" \
      Server.RequireAuthentication="$RequireAuthentication" \
      Server.ProfileIDBlacklist="$ProfileIDBlacklist" \


### PR DESCRIPTION
This is a PoC implementing pchote' suggestion on how to make the server aware of the player win state. See also https://github.com/OpenRA/OpenRA/issues/14686.

Currently, this seems to be the last missing bit of information required for the server to be able to record valid replays. Indeed, the GameInformation footer in the replay contains the win-state but the server doesn't emulate the game state so is not aware of the outcome.

In the bigger picture, this protocol change is the first essential brick to make a server-side ladder. I actually have an external PoC ladder working with local replays (RA, 1v1 and authenticated users only):

![2020-01-12-132259_725x596_scrot](https://user-images.githubusercontent.com/34467/72218742-ab83af80-353e-11ea-85ec-7b9f3f0ecca5.png)

Having this ready for production involve a few more changes after this protocol change such as the replay recording server side mentioned earlier, but this does not need to be tied to a release like this change is. Typically, @jrb0001 server might be implementing it before the upstream, so as long as the clients are sending the win-state, everything can be done outside of a release.

There is still the tricky situation where someone disconnects instead of surrendering that needs to be addressed, but the information present in the replay is enough to figure out the proper outcome (it requires the full parsing of the replay though).

Regarding the changes in that PR in particular, here are a few notes/questions:
- ~I needed all kind of operator overload in the `SyncHash` structure. I'm not sure this is normal in C#, but it sounds overly complex, so maybe there is a way to simplify this (I copied bits here and there to make it work)~
- Moving from `ulong` to `LongBitSet<PlayerBitMask>` for the win-state might be cleaner and more consistent, but it seems to make the code much more complex. Tell me if I need to do that instead anyway
- ~The de-serialization is currently manual in `Server.cs`, I'm not sure if it's the correct way of doing that, but it was simple enough~
- ~In `Server.cs` again, what should I do about the `XXX` question?~
- ~Do I need to bump a version of something in `ProtocolVersion.cs` or somewhere else?~