### PR TITLE
Moved the hard-coded shroud palette to the C&C folder

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/World/ShroudPalette.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/ShroudPalette.cs
@@ -12,10 +12,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.Common.Traits
+namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Adds the hard-coded shroud palette to the game")]
 	class ShroudPaletteInfo : ITraitInfo


### PR DESCRIPTION
A small tidy-up. When developing third-party mods, none of this is useful. Not even TS and D2k use it.