### PR TITLE
Enable high resolution UI artwork and remove DisableWindowsDPIScaling.

### DIFF
--- a/OpenRA.Game/Graphics/CursorManager.cs
+++ b/OpenRA.Game/Graphics/CursorManager.cs
@@ -190,11 +190,17 @@ namespace OpenRA.Graphics
 			var doubleCursor = graphicSettings.CursorDouble;
 			var cursorSprite = cursor.Sprites[frame % cursor.Length];
 			var cursorSize = doubleCursor ? 2.0f * cursorSprite.Size : cursorSprite.Size;
-			var mousePos = isLocked ? lockedPosition : Viewport.LastMousePos;
 
+			// Cursor is rendered in native window coordinates
+			// Apply same scaling rules as hardware cursors
+			var ws = Game.Renderer.WindowScale;
+			if (ws > 1.5f)
+				cursorSize = 2 * cursorSize;
+
+			var mousePos = isLocked ? lockedPosition : Viewport.LastMousePos;
 			renderer.RgbaSpriteRenderer.DrawSprite(cursorSprite,
 				mousePos,
-				cursorSize);
+				cursorSize / ws);
 		}
 
 		public void Lock()

--- a/OpenRA.Game/Graphics/Sheet.cs
+++ b/OpenRA.Game/Graphics/Sheet.cs
@@ -25,6 +25,7 @@ namespace OpenRA.Graphics
 
 		public readonly Size Size;
 		public readonly SheetType Type;
+		public float DPIScale = 1f;
 
 		public byte[] GetData()
 		{

--- a/OpenRA.Game/Graphics/SheetBuilder.cs
+++ b/OpenRA.Game/Graphics/SheetBuilder.cs
@@ -36,6 +36,7 @@ namespace OpenRA.Graphics
 		public readonly SheetType Type;
 		readonly List<Sheet> sheets = new List<Sheet>();
 		readonly Func<Sheet> allocateSheet;
+		readonly int margin;
 
 		Sheet current;
 		TextureChannel channel;
@@ -60,16 +61,17 @@ namespace OpenRA.Graphics
 		public SheetBuilder(SheetType t)
 			: this(t, Game.Settings.Graphics.SheetSize) { }
 
-		public SheetBuilder(SheetType t, int sheetSize)
-			: this(t, () => AllocateSheet(t, sheetSize)) { }
+		public SheetBuilder(SheetType t, int sheetSize, int margin = 1)
+			: this(t, () => AllocateSheet(t, sheetSize), margin) { }
 
-		public SheetBuilder(SheetType t, Func<Sheet> allocateSheet)
+		public SheetBuilder(SheetType t, Func<Sheet> allocateSheet, int margin = 1)
 		{
 			channel = t == SheetType.Indexed ? TextureChannel.Red : TextureChannel.RGBA;
 			Type = t;
 			current = allocateSheet();
 			sheets.Add(current);
 			this.allocateSheet = allocateSheet;
+			this.margin = margin;
 		}
 
 		public Sprite Add(ISpriteFrame frame) { return Add(frame.Data, frame.Size, 0, frame.Offset); }
@@ -115,16 +117,16 @@ namespace OpenRA.Graphics
 		public Sprite Allocate(Size imageSize) { return Allocate(imageSize, 0, float3.Zero); }
 		public Sprite Allocate(Size imageSize, float zRamp, float3 spriteOffset)
 		{
-			if (imageSize.Width + p.X > current.Size.Width)
+			if (imageSize.Width + p.X + margin > current.Size.Width)
 			{
-				p = new int2(0, p.Y + rowHeight);
+				p = new int2(0, p.Y + rowHeight + margin);
 				rowHeight = imageSize.Height;
 			}
 
 			if (imageSize.Height > rowHeight)
 				rowHeight = imageSize.Height;
 
-			if (p.Y + imageSize.Height > current.Size.Height)
+			if (p.Y + imageSize.Height + margin > current.Size.Height)
 			{
 				var next = NextChannel(channel);
 				if (next == null)
@@ -141,8 +143,8 @@ namespace OpenRA.Graphics
 				p = int2.Zero;
 			}
 
-			var rect = new Sprite(current, new Rectangle(p.X, p.Y, imageSize.Width, imageSize.Height), zRamp, spriteOffset, channel, BlendMode.Alpha);
-			p += new int2(imageSize.Width, 0);
+			var rect = new Sprite(current, new Rectangle(p.X + margin, p.Y + margin, imageSize.Width, imageSize.Height), zRamp, spriteOffset, channel, BlendMode.Alpha);
+			p += new int2(imageSize.Width + margin, 0);
 
 			return rect;
 		}

--- a/OpenRA.Game/Graphics/Sprite.cs
+++ b/OpenRA.Game/Graphics/Sprite.cs
@@ -41,10 +41,10 @@ namespace OpenRA.Graphics
 			FractionalOffset = Size.Z != 0 ? offset / Size :
 				new float3(offset.X / Size.X, offset.Y / Size.Y, 0);
 
-			Left = (float)Math.Min(bounds.Left, bounds.Right) / sheet.Size.Width;
-			Top = (float)Math.Min(bounds.Top, bounds.Bottom) / sheet.Size.Height;
-			Right = (float)Math.Max(bounds.Left, bounds.Right) / sheet.Size.Width;
-			Bottom = (float)Math.Max(bounds.Top, bounds.Bottom) / sheet.Size.Height;
+			Left = (float)Math.Min(bounds.Left, bounds.Right) * sheet.DPIScale / sheet.Size.Width;
+			Top = (float)Math.Min(bounds.Top, bounds.Bottom) * sheet.DPIScale / sheet.Size.Height;
+			Right = (float)Math.Max(bounds.Left, bounds.Right) * sheet.DPIScale / sheet.Size.Width;
+			Bottom = (float)Math.Max(bounds.Top, bounds.Bottom) * sheet.DPIScale / sheet.Size.Height;
 		}
 	}
 
@@ -61,10 +61,10 @@ namespace OpenRA.Graphics
 			SecondarySheet = secondarySheet;
 			SecondaryBounds = secondaryBounds;
 			SecondaryChannel = secondaryChannel;
-			SecondaryLeft = (float)Math.Min(secondaryBounds.Left, secondaryBounds.Right) / s.Sheet.Size.Width;
-			SecondaryTop = (float)Math.Min(secondaryBounds.Top, secondaryBounds.Bottom) / s.Sheet.Size.Height;
-			SecondaryRight = (float)Math.Max(secondaryBounds.Left, secondaryBounds.Right) / s.Sheet.Size.Width;
-			SecondaryBottom = (float)Math.Max(secondaryBounds.Top, secondaryBounds.Bottom) / s.Sheet.Size.Height;
+			SecondaryLeft = (float)Math.Min(secondaryBounds.Left, secondaryBounds.Right) * secondarySheet.DPIScale / s.Sheet.Size.Width;
+			SecondaryTop = (float)Math.Min(secondaryBounds.Top, secondaryBounds.Bottom) * secondarySheet.DPIScale / s.Sheet.Size.Height;
+			SecondaryRight = (float)Math.Max(secondaryBounds.Left, secondaryBounds.Right) * secondarySheet.DPIScale / s.Sheet.Size.Width;
+			SecondaryBottom = (float)Math.Max(secondaryBounds.Top, secondaryBounds.Bottom) * secondarySheet.DPIScale / s.Sheet.Size.Height;
 		}
 	}
 

--- a/OpenRA.Game/Graphics/WorldRenderer.cs
+++ b/OpenRA.Game/Graphics/WorldRenderer.cs
@@ -250,8 +250,10 @@ namespace OpenRA.Graphics
 
 		public void DrawAnnotations()
 		{
+			Game.Renderer.EnableAntialiasingFilter();
 			for (var i = 0; i < preparedAnnotationRenderables.Count; i++)
 				preparedAnnotationRenderables[i].Render(this);
+			Game.Renderer.DisableAntialiasingFilter();
 
 			// Engine debugging overlays
 			if (debugVis.Value != null && debugVis.Value.RenderGeometry)

--- a/OpenRA.Game/PlayerDatabase.cs
+++ b/OpenRA.Game/PlayerDatabase.cs
@@ -57,6 +57,7 @@ namespace OpenRA
 				if (!spriteCache.TryGetValue(icon24Node.Value.Value, out sprite))
 				{
 					sprite = spriteCache[icon24Node.Value.Value] = sheetBuilder.Allocate(new Size(24, 24));
+					sprite.Sheet.GetTexture().ScaleFilter = TextureScaleFilter.Linear;
 
 					Action<DownloadDataCompletedEventArgs> onComplete = i =>
 					{

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -110,6 +110,8 @@ namespace OpenRA
 			{
 				Game.RunAfterTick(() =>
 				{
+					ChromeProvider.SetDPIScale(after);
+
 					foreach (var f in Fonts)
 						f.Value.SetScale(after);
 				});

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -377,6 +377,24 @@ namespace OpenRA
 			Context.ClearDepthBuffer();
 		}
 
+		public void EnableAntialiasingFilter()
+		{
+			if (renderType != RenderType.UI)
+				throw new InvalidOperationException("EndFrame called with renderType = {0}, expected RenderType.UI.".F(renderType));
+
+			Flush();
+			SpriteRenderer.SetAntialiasingPixelsPerTexel(Window.WindowScale);
+		}
+
+		public void DisableAntialiasingFilter()
+		{
+			if (renderType != RenderType.UI)
+				throw new InvalidOperationException("EndFrame called with renderType = {0}, expected RenderType.UI.".F(renderType));
+
+			Flush();
+			SpriteRenderer.SetAntialiasingPixelsPerTexel(0);
+		}
+
 		public void GrabWindowMouseFocus()
 		{
 			Window.GrabWindowMouseFocus();

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -163,9 +163,6 @@ namespace OpenRA
 		[Desc("At which frames per second to cap the framerate.")]
 		public int MaxFramerate = 60;
 
-		[Desc("Disable high resolution DPI scaling on Windows operating systems.")]
-		public bool DisableWindowsDPIScaling = true;
-
 		[Desc("Disable separate OpenGL render thread on Windows operating systems.")]
 		public bool DisableWindowsRenderThread = true;
 

--- a/OpenRA.Mods.Cnc/CncLoadScreen.cs
+++ b/OpenRA.Mods.Cnc/CncLoadScreen.cs
@@ -10,108 +10,101 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.LoadScreens;
 using OpenRA.Mods.Common.Widgets;
 using OpenRA.Primitives;
-using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Cnc
 {
-	public sealed class CncLoadScreen : BlankLoadScreen
+	public sealed class CncLoadScreen : SheetLoadScreen
 	{
-		readonly NullInputHandler nih = new NullInputHandler();
-
-		Dictionary<string, string> loadInfo;
-		Stopwatch loadTimer = Stopwatch.StartNew();
-		Sheet sheet;
-		Sprite[] border;
 		int loadTick;
-		float2 nodPos, gdiPos, evaPos;
+
 		Sprite nodLogo, gdiLogo, evaLogo, brightBlock, dimBlock;
+		Sprite[] border;
+		float2 nodPos, gdiPos, evaPos;
 		Rectangle bounds;
-		Renderer r;
+
+		SpriteFont loadingFont, versionFont;
+		string loadingText, versionText;
+		float2 loadingPos, versionPos;
+
+		Sheet lastSheet;
+		Size lastResolution;
+		IReadOnlyDictionary<string, SpriteFont> lastFonts;
 
 		public override void Init(ModData modData, Dictionary<string, string> info)
 		{
 			base.Init(modData, info);
 
-			loadInfo = info;
-
-			// Avoid standard loading mechanisms so we
-			// can display loadscreen as early as possible
-			r = Game.Renderer;
-			if (r == null) return;
-
-			using (var stream = modData.DefaultFileSystem.Open(info["Image"]))
-				sheet = new Sheet(SheetType.BGRA, stream);
-
-			var res = r.Resolution;
-			bounds = new Rectangle(0, 0, res.Width, res.Height);
-
-			border = new[]
-			{
-				new Sprite(sheet, new Rectangle(129, 129, 32, 32), TextureChannel.RGBA),
-				new Sprite(sheet, new Rectangle(161, 129, 62, 32), TextureChannel.RGBA),
-				new Sprite(sheet, new Rectangle(223, 129, 32, 32), TextureChannel.RGBA),
-				new Sprite(sheet, new Rectangle(129, 161, 32, 62), TextureChannel.RGBA),
-				null,
-				new Sprite(sheet, new Rectangle(223, 161, 32, 62), TextureChannel.RGBA),
-				new Sprite(sheet, new Rectangle(129, 223, 32, 32), TextureChannel.RGBA),
-				new Sprite(sheet, new Rectangle(161, 223, 62, 32), TextureChannel.RGBA),
-				new Sprite(sheet, new Rectangle(223, 223, 32, 32), TextureChannel.RGBA)
-			};
-
-			nodLogo = new Sprite(sheet, new Rectangle(0, 256, 256, 256), TextureChannel.RGBA);
-			gdiLogo = new Sprite(sheet, new Rectangle(256, 256, 256, 256), TextureChannel.RGBA);
-			evaLogo = new Sprite(sheet, new Rectangle(769, 320, 128, 64), TextureChannel.RGBA);
-			nodPos = new float2(bounds.Width / 2 - 384, bounds.Height / 2 - 128);
-			gdiPos = new float2(bounds.Width / 2 + 128, bounds.Height / 2 - 128);
-			evaPos = new float2(bounds.Width - 43 - 128, 43);
-
-			brightBlock = new Sprite(sheet, new Rectangle(777, 385, 16, 35), TextureChannel.RGBA);
-			dimBlock = new Sprite(sheet, new Rectangle(794, 385, 16, 35), TextureChannel.RGBA);
-
 			versionText = modData.Manifest.Metadata.Version;
 		}
 
-		object rendererFonts;
-		SpriteFont loadingFont, versionFont;
-		string loadingText, versionText;
-		float2 loadingPos, versionPos;
-
-		public override void Display()
+		public override void DisplayInner(Renderer r, Sheet s)
 		{
-			if (r == null || loadTimer.Elapsed.TotalSeconds < 0.25)
-				return;
+			if (s != lastSheet)
+			{
+				lastSheet = s;
 
-			loadTimer.Restart();
+				border = new[]
+				{
+					new Sprite(s, new Rectangle(129, 129, 32, 32), TextureChannel.RGBA),
+					new Sprite(s, new Rectangle(161, 129, 62, 32), TextureChannel.RGBA),
+					new Sprite(s, new Rectangle(223, 129, 32, 32), TextureChannel.RGBA),
+					new Sprite(s, new Rectangle(129, 161, 32, 62), TextureChannel.RGBA),
+					null,
+					new Sprite(s, new Rectangle(223, 161, 32, 62), TextureChannel.RGBA),
+					new Sprite(s, new Rectangle(129, 223, 32, 32), TextureChannel.RGBA),
+					new Sprite(s, new Rectangle(161, 223, 62, 32), TextureChannel.RGBA),
+					new Sprite(s, new Rectangle(223, 223, 32, 32), TextureChannel.RGBA)
+				};
+
+				nodLogo = new Sprite(s, new Rectangle(0, 256, 256, 256), TextureChannel.RGBA);
+				gdiLogo = new Sprite(s, new Rectangle(256, 256, 256, 256), TextureChannel.RGBA);
+				evaLogo = new Sprite(s, new Rectangle(769, 320, 128, 64), TextureChannel.RGBA);
+
+				brightBlock = new Sprite(s, new Rectangle(777, 385, 16, 35), TextureChannel.RGBA);
+				dimBlock = new Sprite(s, new Rectangle(794, 385, 16, 35), TextureChannel.RGBA);
+			}
+
+			if (r.Resolution != lastResolution)
+			{
+				lastResolution = r.Resolution;
+
+				bounds = new Rectangle(0, 0, lastResolution.Width, lastResolution.Height);
+				nodPos = new float2(bounds.Width / 2 - 384, bounds.Height / 2 - 128);
+				gdiPos = new float2(bounds.Width / 2 + 128, bounds.Height / 2 - 128);
+				evaPos = new float2(bounds.Width - 43 - 128, 43);
+			}
+
+			var barY = bounds.Height - 78;
+
+			// The fonts dictionary may change when switching between the mod and content installer
+			if (r.Fonts != lastFonts)
+			{
+				lastFonts = r.Fonts;
+
+				loadingFont = lastFonts["BigBold"];
+				loadingText = Info["Text"];
+				loadingPos = new float2((bounds.Width - loadingFont.Measure(loadingText).X) / 2, barY);
+
+				versionFont = lastFonts["Regular"];
+				var versionSize = versionFont.Measure(versionText);
+				versionPos = new float2(bounds.Width - 107 - versionSize.X / 2, 115 - versionSize.Y / 2);
+			}
 
 			loadTick = ++loadTick % 8;
-			r.BeginUI();
+
 			r.RgbaSpriteRenderer.DrawSprite(gdiLogo, gdiPos);
 			r.RgbaSpriteRenderer.DrawSprite(nodLogo, nodPos);
 			r.RgbaSpriteRenderer.DrawSprite(evaLogo, evaPos);
 
 			WidgetUtils.DrawPanel(bounds, border);
-			var barY = bounds.Height - 78;
-
-			// The fonts dictionary may change when switching between the mod and content installer
-			if (r.Fonts != rendererFonts)
-			{
-				rendererFonts = r.Fonts;
-				loadingFont = r.Fonts["BigBold"];
-				loadingText = loadInfo["Text"];
-				loadingPos = new float2((bounds.Width - loadingFont.Measure(loadingText).X) / 2, barY);
-
-				versionFont = r.Fonts["Regular"];
-				var versionSize = versionFont.Measure(versionText);
-				versionPos = new float2(bounds.Width - 107 - versionSize.X / 2, 115 - versionSize.Y / 2);
-			}
 
 			if (loadingFont != null)
 				loadingFont.DrawText(loadingText, loadingPos, Color.Gray);
+
 			if (versionFont != null)
 				versionFont.DrawTextWithContrast(versionText, versionPos, Color.White, Color.Black, 2);
 
@@ -123,16 +116,6 @@ namespace OpenRA.Mods.Cnc
 				r.RgbaSpriteRenderer.DrawSprite(block,
 					new float2(bounds.Width / 2 + 114 + i * 32 - 16, barY));
 			}
-
-			r.EndFrame(nih);
-		}
-
-		protected override void Dispose(bool disposing)
-		{
-			if (disposing && sheet != null)
-				sheet.Dispose();
-
-			base.Dispose(disposing);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
@@ -22,11 +22,11 @@ namespace OpenRA.Mods.Common.LoadScreens
 	public class BlankLoadScreen : ILoadScreen
 	{
 		public LaunchArguments Launch;
-		ModData modData;
+		protected ModData ModData { get; private set; }
 
 		public virtual void Init(ModData modData, Dictionary<string, string> info)
 		{
-			this.modData = modData;
+			ModData = modData;
 		}
 
 		public virtual void Display()
@@ -110,14 +110,14 @@ namespace OpenRA.Mods.Common.LoadScreens
 			GC.SuppressFinalize(this);
 		}
 
-		public bool BeforeLoad()
+		public virtual bool BeforeLoad()
 		{
 			// If a ModContent section is defined then we need to make sure that the
 			// required content is installed or switch to the defined content installer.
-			if (!modData.Manifest.Contains<ModContent>())
+			if (!ModData.Manifest.Contains<ModContent>())
 				return true;
 
-			var content = modData.Manifest.Get<ModContent>();
+			var content = ModData.Manifest.Get<ModContent>();
 			var contentInstalled = content.Packages
 				.Where(p => p.Value.Required)
 				.All(p => p.Value.TestFiles.All(f => File.Exists(Platform.ResolvePath(f))));
@@ -125,7 +125,7 @@ namespace OpenRA.Mods.Common.LoadScreens
 			if (contentInstalled)
 				return true;
 
-			Game.InitializeMod(content.ContentInstallerMod, new Arguments(new[] { "Content.Mod=" + modData.Manifest.Id }));
+			Game.InitializeMod(content.ContentInstallerMod, new Arguments(new[] { "Content.Mod=" + ModData.Manifest.Id }));
 			return false;
 		}
 	}

--- a/OpenRA.Mods.Common/LoadScreens/SheetLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/SheetLoadScreen.cs
@@ -1,0 +1,62 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using OpenRA.Graphics;
+
+namespace OpenRA.Mods.Common.LoadScreens
+{
+	public abstract class SheetLoadScreen : BlankLoadScreen
+	{
+		Stopwatch lastUpdate;
+
+		protected Dictionary<string, string> Info { get; private set; }
+		Sheet sheet;
+
+		public override void Init(ModData modData, Dictionary<string, string> info)
+		{
+			base.Init(modData, info);
+			Info = info;
+		}
+
+		public abstract void DisplayInner(Renderer r, Sheet s);
+
+		public override void Display()
+		{
+			// Limit load screens to at most 5 FPS
+			if (Game.Renderer == null || (lastUpdate != null && lastUpdate.Elapsed.TotalSeconds < 0.2))
+				return;
+
+			// Start the timer on the first render
+			if (lastUpdate == null)
+				lastUpdate = Stopwatch.StartNew();
+
+			if (sheet == null && Info.ContainsKey("Image"))
+				using (var stream = ModData.DefaultFileSystem.Open(Info["Image"]))
+					sheet = new Sheet(SheetType.BGRA, stream);
+
+			Game.Renderer.BeginUI();
+			DisplayInner(Game.Renderer, sheet);
+			Game.Renderer.EndFrame(new NullInputHandler());
+
+			lastUpdate.Restart();
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && sheet != null)
+				sheet.Dispose();
+
+			base.Dispose(disposing);
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ActorPreviewWidget.cs
@@ -74,8 +74,10 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public override void Draw()
 		{
+			Game.Renderer.EnableAntialiasingFilter();
 			foreach (var r in renderables)
 				r.Render(worldRenderer);
+			Game.Renderer.DisableAntialiasingFilter();
 		}
 
 		public override void Tick()

--- a/OpenRA.Mods.Common/Widgets/MouseAttachmentWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/MouseAttachmentWidget.cs
@@ -36,7 +36,12 @@ namespace OpenRA.Mods.Common.Widgets
 			if (sprite != null && palette != null)
 			{
 				var directionPalette = worldRenderer.Palette(palette);
-				WidgetUtils.DrawSHPCentered(sprite, ChildOrigin, directionPalette, graphicSettings.CursorDouble ? 2 : 1);
+
+				// Cursor is rendered in native window coordinates
+				// Apply same scaling rules as hardware cursors
+				var ws = Game.Renderer.WindowScale;
+				var scale = (graphicSettings.CursorDouble ? 2 : 1) * (ws > 1.5f ? 2 : 1);
+				WidgetUtils.DrawSHPCentered(sprite, ChildOrigin, directionPalette, scale / ws);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
@@ -115,6 +115,8 @@ namespace OpenRA.Mods.Common.Widgets
 
 			Bounds.Width = powers.Count() * (IconWidth + IconSpacing);
 
+			Game.Renderer.EnableAntialiasingFilter();
+
 			var iconSize = new float2(IconWidth, IconHeight);
 			foreach (var power in powers)
 			{
@@ -125,7 +127,7 @@ namespace OpenRA.Mods.Common.Widgets
 				icon.Play(item.Info.Icon);
 				var location = new float2(RenderBounds.Location) + new float2(power.i * (IconWidth + IconSpacing), 0);
 
-				supportPowerIconsIcons.Add(new SupportPowersWidget.SupportPowerIcon { Power = item });
+				supportPowerIconsIcons.Add(new SupportPowersWidget.SupportPowerIcon { Power = item, Pos = location });
 				supportPowerIconsBounds.Add(new Rectangle((int)location.X, (int)location.Y, (int)iconSize.X, (int)iconSize.Y));
 
 				WidgetUtils.DrawSHPCentered(icon.Image, location + 0.5f * iconSize, worldRenderer.Palette(item.Info.IconPalette), 0.5f);
@@ -136,11 +138,16 @@ namespace OpenRA.Mods.Common.Widgets
 						* (clock.CurrentSequence.Length - 1) / item.TotalTicks));
 				clock.Tick();
 				WidgetUtils.DrawSHPCentered(clock.Image, location + 0.5f * iconSize, worldRenderer.Palette(ClockPalette), 0.5f);
+			}
 
-				var tiny = Game.Renderer.Fonts["Tiny"];
-				var text = GetOverlayForItem(item, timestep);
+			Game.Renderer.DisableAntialiasingFilter();
+
+			var tiny = Game.Renderer.Fonts["Tiny"];
+			foreach (var icon in supportPowerIconsIcons)
+			{
+				var text = GetOverlayForItem(icon.Power, timestep);
 				tiny.DrawTextWithContrast(text,
-					location + new float2(16, 12) - new float2(tiny.Measure(text).X / 2, 0),
+					icon.Pos + new float2(16, 12) - new float2(tiny.Measure(text).X / 2, 0),
 					Color.White, Color.Black, 1);
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -453,6 +453,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var pios = currentQueue.Actor.Owner.PlayerActor.TraitsImplementing<IProductionIconOverlay>();
 
 			// Icons
+			Game.Renderer.EnableAntialiasingFilter();
 			foreach (var icon in icons.Values)
 			{
 				WidgetUtils.DrawSHPCentered(icon.Sprite, icon.Pos + iconOffset, icon.Palette);
@@ -476,6 +477,8 @@ namespace OpenRA.Mods.Common.Widgets
 				else if (!buildableItems.Any(a => a.Name == icon.Name))
 					WidgetUtils.DrawSHPCentered(cantBuild.Image, icon.Pos + iconOffset, icon.IconDarkenPalette);
 			}
+
+			Game.Renderer.DisableAntialiasingFilter();
 
 			// Overlays
 			foreach (var icon in icons.Values)

--- a/OpenRA.Mods.Common/Widgets/SpriteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SpriteWidget.cs
@@ -78,7 +78,9 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 
 			var size = new float2(sprite.Size.X * scale, sprite.Size.Y * scale);
+			Game.Renderer.EnableAntialiasingFilter();
 			Game.Renderer.SpriteRenderer.DrawSprite(sprite, RenderOrigin + offset, pr, size);
+			Game.Renderer.DisableAntialiasingFilter();
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs
@@ -198,6 +198,7 @@ namespace OpenRA.Mods.Common.Widgets
 			timeOffset = iconOffset - overlayFont.Measure(WidgetUtils.FormatTime(0, worldRenderer.World.Timestep)) / 2;
 
 			// Icons
+			Game.Renderer.EnableAntialiasingFilter();
 			foreach (var p in icons.Values)
 			{
 				WidgetUtils.DrawSHPCentered(p.Sprite, p.Pos + iconOffset, p.Palette);
@@ -211,6 +212,8 @@ namespace OpenRA.Mods.Common.Widgets
 				clock.Tick();
 				WidgetUtils.DrawSHPCentered(clock.Image, p.Pos + iconOffset, p.IconClockPalette);
 			}
+
+			Game.Renderer.DisableAntialiasingFilter();
 
 			// Overlay
 			foreach (var p in icons.Values)

--- a/OpenRA.Platforms.Default/Sdl2Input.cs
+++ b/OpenRA.Platforms.Default/Sdl2Input.cs
@@ -148,7 +148,9 @@ namespace OpenRA.Platforms.Default
 						{
 							int x, y;
 							SDL.SDL_GetMouseState(out x, out y);
-							inputHandler.OnMouseInput(new MouseInput(MouseInputEvent.Scroll, MouseButton.None, new int2(x, y), new int2(0, e.wheel.y), mods, 0));
+
+							var pos = EventPosition(device, x, y);
+							inputHandler.OnMouseInput(new MouseInput(MouseInputEvent.Scroll, MouseButton.None, pos, new int2(0, e.wheel.y), mods, 0));
 
 							break;
 						}

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Platforms.Default
 				windowSize = requestWindowSize;
 
 				// Disable legacy scaling on Windows
-				if (Platform.CurrentPlatform == PlatformType.Windows && !Game.Settings.Graphics.DisableWindowsDPIScaling)
+				if (Platform.CurrentPlatform == PlatformType.Windows)
 					SetProcessDPIAware();
 
 				SDL.SDL_Init(SDL.SDL_INIT_NOPARACHUTE | SDL.SDL_INIT_VIDEO);
@@ -173,7 +173,7 @@ namespace OpenRA.Platforms.Default
 				else if (Platform.CurrentPlatform == PlatformType.Windows)
 				{
 					float ddpi, hdpi, vdpi;
-					if (!Game.Settings.Graphics.DisableWindowsDPIScaling && SDL.SDL_GetDisplayDPI(0, out ddpi, out hdpi, out vdpi) == 0)
+					if (SDL.SDL_GetDisplayDPI(0, out ddpi, out hdpi, out vdpi) == 0)
 					{
 						windowScale = ddpi / 96;
 						windowSize = new Size((int)(surfaceSize.Width / windowScale), (int)(surfaceSize.Height / windowScale));

--- a/mods/cnc/chrome.yaml
+++ b/mods/cnc/chrome.yaml
@@ -1,5 +1,7 @@
 ^Chrome:
 	Image: chrome.png
+	Image2x: chrome-2x.png
+	Image3x: chrome-3x.png
 
 logos:
 	Inherits: ^Chrome

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -153,6 +153,8 @@ Hotkeys:
 
 LoadScreen: CncLoadScreen
 	Image: cnc|uibits/chrome.png
+	Image2x: cnc|uibits/chrome-2x.png
+	Image3x: cnc|uibits/chrome-3x.png
 	Text: Loading
 
 ServerTraits:

--- a/mods/d2k/chrome.yaml
+++ b/mods/d2k/chrome.yaml
@@ -6,6 +6,8 @@
 
 ^Glyphs:
 	Image: glyphs.png
+	Image2x: glyphs-2x.png
+	Image3x: glyphs-3x.png
 
 ^LoadScreen:
 	Image: loadscreen.png

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -139,6 +139,8 @@ Hotkeys:
 
 LoadScreen: LogoStripeLoadScreen
 	Image: d2k|uibits/loadscreen.png
+	Image2x: d2k|uibits/loadscreen-2x.png
+	Image3x: d2k|uibits/loadscreen-3x.png
 	Text: Filling Crates..., Breeding Sandworms..., Fuelling carryalls..., Deploying harvesters..., Preparing thopters..., Summoning mentats...
 
 ServerTraits:

--- a/mods/modcontent/chrome.yaml
+++ b/mods/modcontent/chrome.yaml
@@ -1,5 +1,7 @@
 ^Chrome:
 	Image: chrome.png
+	Image2x: chrome-2x.png
+	Image3x: chrome-3x.png
 
 panel-header:
 	Inherits: ^Chrome

--- a/mods/modcontent/mod.yaml
+++ b/mods/modcontent/mod.yaml
@@ -28,6 +28,8 @@ Notifications:
 
 LoadScreen: ModContentLoadScreen
 	Image: ./mods/modcontent/chrome.png
+	Image2x: ./mods/modcontent/chrome-2x.png
+	Image3x: ./mods/modcontent/chrome-3x.png
 
 ChromeMetrics:
 	common|metrics.yaml

--- a/mods/ra/chrome.yaml
+++ b/mods/ra/chrome.yaml
@@ -6,9 +6,13 @@
 
 ^Glyphs:
 	Image: glyphs.png
+	Image2x: glyphs-2x.png
+	Image3x: glyphs-3x.png
 
 ^LoadScreen:
 	Image: loadscreen.png
+	Image2x: loadscreen-2x.png
+	Image3x: loadscreen-3x.png
 
 sidebar-allies:
 	Inherits: ^Sidebar

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -155,6 +155,8 @@ Hotkeys:
 
 LoadScreen: LogoStripeLoadScreen
 	Image: ra|uibits/loadscreen.png
+	Image2x: ra|uibits/loadscreen-2x.png
+	Image3x: ra|uibits/loadscreen-3x.png
 	Text: Filling Crates..., Charging Capacitors..., Reticulating Splines..., Planting Trees..., Building Bridges..., Aging Empires..., Compiling EVA..., Constructing Pylons..., Activating Skynet..., Splitting Atoms...
 
 ServerTraits:

--- a/mods/ts/chrome.yaml
+++ b/mods/ts/chrome.yaml
@@ -9,6 +9,8 @@
 
 ^Glyphs:
 	Image: glyphs.png
+	Image2x: glyphs-2x.png
+	Image3x: glyphs-3x.png
 
 ^LoadScreen:
 	Image: loadscreen.png


### PR DESCRIPTION
This PR takes the groundwork laid by #17489, #17494, #17495, #17504, #17506, #17509, #17511 and gives us some rewarding features to justify the hard slog. The changes here should noticeably improve rendering quality on systems with more than 96 / 100% DPI. This also implements most of the remaining work towards #10382.

The first few commits fix issues that become obvious at fractional scales, and allows UI sprites (icons, color pickers) to be cleanly rendered (which should also help with #16709). The final two commits enable our new higher resolution UI artwork, and finally removes the `DisableWindowsDPIScaling` workaround that made everything blurry for many Windows players.

This can be tested on Windows by running the game with different system DPI scales. It can be tested on Linux by launching with fractional `OPENRA_DISPLAY_SCALE` values (e.g. 1.5). Testing on macOS can show that we correctly switch between different sheets when moving the window between standard and Retina Displays.

Followup PRs will enable higher resolution badge artwork (which needs to be coordinates with forum changes), add the UI Scale option to the settings, and enable automatic DPI detection on Linux.
