### PR TITLE
Fix horizontal positioning of dropdown arrow glyph.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var image = ChromeProvider.GetImage("scrollbar", IsDisabled() ? "down_pressed" : "down_arrow");
 			var rb = RenderBounds;
 
-			WidgetUtils.DrawRGBA(image, stateOffset + new float2(rb.Right - rb.Height + 4, rb.Top + (rb.Height - image.Bounds.Height) / 2));
+			WidgetUtils.DrawRGBA(image, stateOffset + new float2(rb.Right - rb.Height + 5, rb.Top + (rb.Height - image.Bounds.Height) / 2));
 
 			var separator = ChromeProvider.GetImage(SeparatorCollection, SeparatorImage);
 			WidgetUtils.DrawRGBA(separator, new float2(-3, 0) + new float2(rb.Right - rb.Height + 4, rb.Top + (rb.Height - separator.Bounds.Height) / 2));


### PR DESCRIPTION
This PR fixes the positioning issue reported in https://github.com/OpenRA/OpenRA/pull/17504#issuecomment-576004204 and https://github.com/OpenRA/OpenRA/pull/17506#issuecomment-576005289. It seems that this has always been broken, for all mods, but nobody noticed before now.