### PR TITLE
Added a --check-tileset-images command

### DIFF
--- a/OpenRA.Game/Graphics/Theater.cs
+++ b/OpenRA.Game/Graphics/Theater.cs
@@ -68,6 +68,9 @@ namespace OpenRA.Graphics
 					var indices = t.Value.Frames != null ? t.Value.Frames : Enumerable.Range(0, frameCount);
 					variants.Add(indices.Select(j =>
 					{
+						if (j >= allFrames.Length)
+							throw new InvalidDataException("{0} defined more frames than the sprite has on template id {1}".F(i, t.Key));
+
 						var f = allFrames[j];
 						var tile = t.Value.Contains(j) ? t.Value[j] : null;
 

--- a/OpenRA.Game/Map/TileSet.cs
+++ b/OpenRA.Game/Map/TileSet.cs
@@ -74,7 +74,10 @@ namespace OpenRA
 				{
 					int key;
 					if (!int.TryParse(node.Key, out key) || key < 0 || key >= tileInfo.Length)
-						throw new InvalidDataException("Invalid tile key '{0}' on template '{1}' of tileset '{2}'.".F(node.Key, Id, tileSet.Id));
+					{
+						Game.ModData.SpriteSequenceLoader.OnMissingSpriteError("Invalid tile key '{0}' on template '{1}' of tileset '{2}'.".F(node.Key, Id, tileSet.Id));
+						continue;
+					}
 
 					tileInfo[key] = LoadTileInfo(tileSet, node.Value);
 				}
@@ -88,7 +91,10 @@ namespace OpenRA
 				{
 					int key;
 					if (!int.TryParse(node.Key, out key) || key != i++)
-						throw new InvalidDataException("Invalid tile key '{0}' on template '{1}' of tileset '{2}'.".F(node.Key, Id, tileSet.Id));
+					{
+						Game.ModData.SpriteSequenceLoader.OnMissingSpriteError("Invalid tile key '{0}' on template '{1}' of tileset '{2}'.".F(node.Key, Id, tileSet.Id));
+						continue;
+					}
 
 					tileInfo[key] = LoadTileInfo(tileSet, node.Value);
 				}

--- a/OpenRA.Mods.Common/UtilityCommands/CheckImageReferences.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckImageReferences.cs
@@ -55,6 +55,14 @@ namespace OpenRA.Mods.Common.UtilityCommands
 						var sprites = sc[image];
 						if (template.Value.TilesCount > sprites.Length)
 							modData.SpriteSequenceLoader.OnMissingSpriteError("Tileset tile {0} has frames defined without matching artwork.".F(template.Key));
+
+						var frames = template.Value.Frames;
+						if (frames == null)
+							continue;
+
+						foreach (var frame in frames)
+							if (sprites.Length < frame)
+								modData.SpriteSequenceLoader.OnMissingSpriteError("Tileset tile {0} has more frames defined than the sprite has.".F(template.Key));
 					}
 				}
 			}

--- a/OpenRA.Mods.Common/UtilityCommands/CheckImageReferences.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckImageReferences.cs
@@ -48,16 +48,13 @@ namespace OpenRA.Mods.Common.UtilityCommands
 					{
 						if (!modData.DefaultFileSystem.Exists(image))
 						{
-							failed = true;
-							Console.WriteLine("\t" + "Tileset file {0} not found.".F(image));
+							modData.SpriteSequenceLoader.OnMissingSpriteError("Tileset file {0} not found.".F(image));
+							continue;
 						}
 
 						var sprites = sc[image];
 						if (template.Value.TilesCount > sprites.Length)
-						{
-							failed = true;
-							Console.WriteLine("\t" + "Tileset tile {0} has frames defined without matching artwork.".F(template.Key));
-						}
+							modData.SpriteSequenceLoader.OnMissingSpriteError("Tileset tile {0} has frames defined without matching artwork.".F(template.Key));
 					}
 				}
 			}

--- a/OpenRA.Mods.Common/UtilityCommands/CheckImageReferences.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckImageReferences.cs
@@ -15,9 +15,9 @@ using OpenRA.Graphics;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
-	class CheckSquenceSprites : IUtilityCommand
+	class CheckImageReferences : IUtilityCommand
 	{
-		string IUtilityCommand.Name { get { return "--check-sequence-sprites"; } }
+		string IUtilityCommand.Name { get { return "--check-image-references"; } }
 
 		bool IUtilityCommand.ValidateArguments(string[] args)
 		{

--- a/OpenRA.Mods.Common/UtilityCommands/CheckSequenceSprites.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/CheckSequenceSprites.cs
@@ -41,6 +41,25 @@ namespace OpenRA.Mods.Common.UtilityCommands
 				var nodes = MiniYaml.Merge(modData.Manifest.Sequences.Select(s => MiniYaml.FromStream(modData.DefaultFileSystem.Open(s), s)));
 				foreach (var n in nodes.Where(node => !node.Key.StartsWith(ActorInfo.AbstractActorPrefix, StringComparison.Ordinal)))
 					modData.SpriteSequenceLoader.ParseSequences(modData, ts, sc, n);
+
+				foreach (var template in ts.Templates)
+				{
+					foreach (var image in template.Value.Images)
+					{
+						if (!modData.DefaultFileSystem.Exists(image))
+						{
+							failed = true;
+							Console.WriteLine("\t" + "Tileset file {0} not found.".F(image));
+						}
+
+						var sprites = sc[image];
+						if (template.Value.TilesCount > sprites.Length)
+						{
+							failed = true;
+							Console.WriteLine("\t" + "Tileset tile {0} has frames defined without matching artwork.".F(template.Key));
+						}
+					}
+				}
 			}
 
 			if (failed)


### PR DESCRIPTION
This is basically `CheckSequenceSprites`, but for tileset images. Closes https://github.com/OpenRA/OpenRA/issues/17596.

To be fair this is QA for everyone setting up a large tileset by hand. Not too interesting for the official mods. Don't worry. All files are found.