### PR TITLE
Fix DisguiseTooltip condtionality

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -25,16 +25,15 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override object Create(ActorInitializer init) { return new DisguiseTooltip(init.Self, this); }
 	}
 
-	class DisguiseTooltip : ITooltip
+	class DisguiseTooltip : ConditionalTrait<DisguiseTooltipInfo>, ITooltip
 	{
 		readonly Actor self;
 		readonly Disguise disguise;
-		TooltipInfo info;
 
-		public DisguiseTooltip(Actor self, TooltipInfo info)
+		public DisguiseTooltip(Actor self, DisguiseTooltipInfo info)
+			: base(info)
 		{
 			this.self = self;
-			this.info = info;
 			disguise = self.Trait<Disguise>();
 		}
 
@@ -42,7 +41,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		{
 			get
 			{
-				return disguise.Disguised ? disguise.AsTooltipInfo : info;
+				return disguise.Disguised ? disguise.AsTooltipInfo : Info;
 			}
 		}
 


### PR DESCRIPTION
Trait didn't implement ConditionalTrait<T> so it didn't work properly, even tho the TraitInfo implements ConditionalTraitInfo.

Testcase makes their normal name change depending on if you have a Radar Dome or not.