### PR TITLE
Add Graphics.DisableGLDebugMessageCallback setting.

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -171,6 +171,9 @@ namespace OpenRA
 		[Desc("Disable separate OpenGL render thread on Windows operating systems.")]
 		public bool DisableWindowsRenderThread = true;
 
+		[Desc("Disable the OpenGL debug message callback feature.")]
+		public bool DisableGLDebugMessageCallback = false;
+
 		[Desc("Use OpenGL ES if both ES and regular OpenGL are available.")]
 		public bool PreferGLES = false;
 

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -512,8 +512,9 @@ namespace OpenRA.Platforms.Default
 			{
 				try
 				{
-					glDebugMessageCallback = Bind<DebugMessageCallback>("glDebugMessageCallback");
-					glDebugMessageInsert = Bind<DebugMessageInsert>("glDebugMessageInsert");
+					var suffix = Features.HasFlag(GLFeatures.GLES) ? "KHR" : "";
+					glDebugMessageCallback = Bind<DebugMessageCallback>("glDebugMessageCallback" + suffix);
+					glDebugMessageInsert = Bind<DebugMessageInsert>("glDebugMessageInsert" + suffix);
 
 					glEnable(GL_DEBUG_OUTPUT);
 					glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -497,6 +497,10 @@ namespace OpenRA.Platforms.Default
 
 			DetectGLFeatures();
 
+			// Allow users to force-disable the debug message callback feature to work around driver bugs
+			if (Features.HasFlag(GLFeatures.DebugMessagesCallback) && Game.Settings.Graphics.DisableGLDebugMessageCallback)
+				Features ^= GLFeatures.DebugMessagesCallback;
+
 			if (!Features.HasFlag(GLFeatures.Core))
 			{
 				WriteGraphicsLog("Unsupported OpenGL version: " + glGetString(GL_VERSION));


### PR DESCRIPTION
The first commit adds a workaround for #17391, since we don't currently have any ideas on how to fix it.

The second commit fixes the following point in the [KHR_debug](https://www.khronos.org/registry/OpenGL/extensions/KHR/KHR_debug.txt) spec:
> New Procedures and Functions
>    
>    NOTE: when implemented in an OpenGL ES context, all entry points defined
>    by this extension must have a "KHR" suffix. When implemented in an
>    OpenGL context, all entry points must have NO suffix, as shown below.

I have tested this on my RPi4 and verified that both commits function as intended.

Closes #17528.