### PR TITLE
Fixed SupportPower.Icon not being required

### DIFF
--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPower.cs
@@ -17,6 +17,8 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		[Desc("Measured in ticks.")]
 		public readonly int ChargeInterval = 0;
+
+		[FieldLoader.Require]
 		public readonly string Icon = null;
 		public readonly string Description = "";
 		public readonly string LongDesc = "";


### PR DESCRIPTION
Catches a crash like this:

```
Exception of type `System.ArgumentNullException`: Value cannot be null.
Parameter name: key
  at System.Collections.Generic.Dictionary`2[TKey,TValue].FindEntry (TKey key) [0x00175] in /home/abuild/rpmbuild/BUILD/mono-6.4.0.198/external/corefx/src/Common/src/CoreLib/System/Collections/Generic/Dictionary.cs:470 
  at System.Collections.Generic.Dictionary`2[TKey,TValue].TryGetValue (TKey key, TValue& value) [0x00000] in /home/abuild/rpmbuild/BUILD/mono-6.4.0.198/external/corefx/src/Common/src/CoreLib/System/Collections/Generic/Dictionary.cs:888 
  at OpenRA.ReadOnlyDictionary`2[TKey,TValue].TryGetValue (TKey key, TValue& value) [0x00000] in /home/matthias/Entwicklung/OpenHV/engine/OpenRA.Game/Primitives/ReadOnlyDictionary.cs:73 
  at OpenRA.Graphics.SequenceProvider.GetSequence (System.String unitName, System.String sequenceName) [0x0002f] in /home/matthias/Entwicklung/OpenHV/engine/OpenRA.Game/Graphics/SequenceProvider.cs:77 
  at OpenRA.Graphics.Animation.GetSequence (System.String sequenceName) [0x00000] in /home/matthias/Entwicklung/OpenHV/engine/OpenRA.Game/Graphics/Animation.cs:234 
  at OpenRA.Graphics.Animation.PlaySequence (System.String sequenceName) [0x00000] in /home/matthias/Entwicklung/OpenHV/engine/OpenRA.Game/Graphics/Animation.cs:115 
  at OpenRA.Graphics.Animation.PlayThen (System.String sequenceName, System.Action after) [0x00022] in /home/matthias/Entwicklung/OpenHV/engine/OpenRA.Game/Graphics/Animation.cs:149 
  at OpenRA.Graphics.Animation.Play (System.String sequenceName) [0x00000] in /home/matthias/Entwicklung/OpenHV/engine/OpenRA.Game/Graphics/Animation.cs:104 
  at OpenRA.Mods.Common.Widgets.SupportPowersWidget.RefreshIcons () [0x0011d] in /home/matthias/Entwicklung/OpenHV/engine/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs:141 
  at OpenRA.Mods.Common.Widgets.SupportPowersWidget.Tick () [0x00000] in /home/matthias/Entwicklung/OpenHV/engine/OpenRA.Mods.Common/Widgets/SupportPowersWidget.cs:244 
  at OpenRA.Widgets.Widget.TickOuter () [0x0000d] in /home/matthias/Entwicklung/OpenHV/engine/OpenRA.Game/Widgets/Widget.cs:469 
  at OpenRA.Widgets.Widget.TickOuter () [0x00029] in /home/matthias/Entwicklung/OpenHV/engine/OpenRA.Game/Widgets/Widget.cs:471 
  at OpenRA.Widgets.Widget.TickOuter () [0x00029] in /home/matthias/Entwicklung/OpenHV/engine/OpenRA.Game/Widgets/Widget.cs:471 
  at OpenRA.Widgets.Widget.TickOuter () [0x00029] in /home/matthias/Entwicklung/OpenHV/engine/OpenRA.Game/Widgets/Widget.cs:471 
  at OpenRA.Widgets.Widget.TickOuter () [0x00029] in /home/matthias/Entwicklung/OpenHV/engine/OpenRA.Game/Widgets/Widget.cs:471 
  at OpenRA.Widgets.Widget.TickOuter () [0x00029] in /home/matthias/Entwicklung/OpenHV/engine/OpenRA.Game/Widgets/Widget.cs:471 
  at OpenRA.Widgets.Widget.TickOuter () [0x00029] in /home/matthias/Entwicklung/OpenHV/engine/OpenRA.Game/Widgets/Widget.cs:471 
  at OpenRA.Widgets.Ui.Tick () [0x00000] in /home/matthias/Entwicklung/OpenHV/engine/OpenRA.Game/Widgets/Widget.cs:88 
  at OpenRA.Sync+<>c__DisplayClass13_0.<RunUnsynced>b__0 () [0x00000] in /home/matthias/Entwicklung/OpenHV/engine/OpenRA.Game/Sync.cs:166 
  at OpenRA.Sync.RunUnsynced[T] (System.Boolean checkSyncHash, OpenRA.World world, System.Func`1[TResult] fn) [0x00023] in /home/matthias/Entwicklung/OpenHV/engine/OpenRA.Game/Sync.cs:182 
