### PR TITLE
Added remappable support to production icons

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildable.cs
@@ -38,9 +38,12 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sequence of the actor that contains the icon.")]
 		public readonly string Icon = "icon";
 
-		[PaletteReference]
+		[PaletteReference("IconPaletteIsPlayerPalette")]
 		[Desc("Palette used for the production icon.")]
 		public readonly string IconPalette = "chrome";
+
+		[Desc("Custom palette is a player palette BaseName")]
+		public readonly bool IconPaletteIsPlayerPalette = false;
 
 		[Desc("Base build time in frames (-1 indicates to use the unit's Value).")]
 		public readonly int BuildDuration = -1;

--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -164,6 +164,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly ActorInfo ActorInfo;
 		public readonly Animation Icon;
 		public readonly string IconPalette;
+		public readonly bool IconPaletteIsPlayerPalette;
 		public readonly int ProductionQueueOrder;
 		public readonly int BuildPaletteOrder;
 		public readonly TooltipInfo TooltipInfo;
@@ -193,6 +194,7 @@ namespace OpenRA.Mods.Common.Traits
 				Icon = new Animation(owner.World, image);
 				Icon.Play(BuildableInfo.Icon);
 				IconPalette = BuildableInfo.IconPalette;
+				IconPaletteIsPlayerPalette = BuildableInfo.IconPaletteIsPlayerPalette;
 				BuildPaletteOrder = BuildableInfo.BuildPaletteOrder;
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/ObserverArmyIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverArmyIconsWidget.cs
@@ -107,7 +107,8 @@ namespace OpenRA.Mods.Common.Widgets
 				var iconTopLeft = RenderOrigin + topLeftOffset;
 				var centerPosition = iconTopLeft;
 
-				WidgetUtils.DrawSHPCentered(icon.Image, centerPosition + 0.5f * iconSize, worldRenderer.Palette(unit.IconPalette), 0.5f);
+				var palette = unit.IconPaletteIsPlayerPalette ? unit.IconPalette + player.InternalName : unit.IconPalette;
+				WidgetUtils.DrawSHPCentered(icon.Image, centerPosition + 0.5f * iconSize, worldRenderer.Palette(palette), 0.5f);
 
 				armyIcons.Add(new ArmyIcon
 				{

--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -147,7 +147,8 @@ namespace OpenRA.Mods.Common.Widgets
 				var iconTopLeft = RenderOrigin + topLeftOffset;
 				var centerPosition = iconTopLeft + 0.5f * iconSize;
 
-				WidgetUtils.DrawSHPCentered(icon.Image, centerPosition, worldRenderer.Palette(bi.IconPalette), 0.5f);
+				var palette = bi.IconPaletteIsPlayerPalette ? bi.IconPalette + player.InternalName : bi.IconPalette;
+				WidgetUtils.DrawSHPCentered(icon.Image, centerPosition, worldRenderer.Palette(palette), 0.5f);
 
 				var rect = new Rectangle((int)iconTopLeft.X, (int)iconTopLeft.Y, (int)iconSize.X, (int)iconSize.Y);
 				productionIcons.Add(new ProductionIcon

--- a/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionPaletteWidget.cs
@@ -407,13 +407,15 @@ namespace OpenRA.Mods.Common.Widgets
 				var bi = item.TraitInfo<BuildableInfo>();
 				icon.Play(bi.Icon);
 
+				var palette = bi.IconPaletteIsPlayerPalette ? bi.IconPalette + producer.Actor.Owner.InternalName : bi.IconPalette;
+
 				var pi = new ProductionIcon()
 				{
 					Actor = item,
 					Name = item.Name,
 					Hotkey = DisplayedIconCount < HotkeyCount ? hotkeys[DisplayedIconCount] : null,
 					Sprite = icon.Image,
-					Palette = worldRenderer.Palette(bi.IconPalette),
+					Palette = worldRenderer.Palette(palette),
 					IconClockPalette = worldRenderer.Palette(ClockPalette),
 					IconDarkenPalette = worldRenderer.Palette(NotBuildablePalette),
 					Pos = new float2(rect.Location),


### PR DESCRIPTION
The DOS versions had remappable icons. I would like to experiment with that as well.