### PR TITLE
Add an introduction dialog on first run.

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -241,6 +241,9 @@ namespace OpenRA
 
 		public bool FetchNews = true;
 
+		[Desc("Version of introduction prompt that the player last viewed.")]
+		public int IntroductionPromptVersion = 0;
+
 		public MPGameFilters MPGameFilters = MPGameFilters.Waiting | MPGameFilters.Empty | MPGameFilters.Protected | MPGameFilters.Started;
 	}
 

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -205,7 +205,7 @@ namespace OpenRA
 	{
 		[Desc("Sets the player nickname.")]
 		public string Name = "Commander";
-		public Color Color = Color.FromAhsl(75, 255, 180);
+		public Color Color = Color.FromArgb(200, 32, 32);
 		public string LastServer = "localhost:1234";
 		public Color[] CustomColors = { };
 	}

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -203,8 +203,8 @@ namespace OpenRA
 
 	public class PlayerSettings
 	{
-		[Desc("Sets the player nickname for in-game and IRC chat.")]
-		public string Name = "Newbie";
+		[Desc("Sets the player nickname.")]
+		public string Name = "Commander";
 		public Color Color = Color.FromAhsl(75, 255, 180);
 		public string LastServer = "localhost:1234";
 		public Color[] CustomColors = { };

--- a/OpenRA.Mods.Common/Widgets/Logic/IntroductionPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/IntroductionPromptLogic.cs
@@ -1,0 +1,147 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using OpenRA.Graphics;
+using OpenRA.Primitives;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+	public class IntroductionPromptLogic : ChromeLogic
+	{
+		// Increment the version number when adding new stats
+		const int IntroductionVersion = 1;
+
+		public static bool ShouldShowPrompt()
+		{
+			return Game.Settings.Game.IntroductionPromptVersion < IntroductionVersion;
+		}
+
+		[ObjectCreator.UseCtor]
+		public IntroductionPromptLogic(Widget widget, ModData modData, WorldRenderer worldRenderer, Action onComplete)
+		{
+			var ps = Game.Settings.Player;
+			var ds = Game.Settings.Graphics;
+			var gs = Game.Settings.Game;
+
+			var escPressed = false;
+			var nameTextfield = widget.Get<TextFieldWidget>("PLAYERNAME");
+			nameTextfield.IsDisabled = () => worldRenderer.World.Type != WorldType.Shellmap;
+			nameTextfield.Text = Settings.SanitizedPlayerName(ps.Name);
+			nameTextfield.OnLoseFocus = () =>
+			{
+				if (escPressed)
+				{
+					escPressed = false;
+					return;
+				}
+
+				nameTextfield.Text = nameTextfield.Text.Trim();
+				if (nameTextfield.Text.Length == 0)
+					nameTextfield.Text = Settings.SanitizedPlayerName(ps.Name);
+				else
+				{
+					nameTextfield.Text = Settings.SanitizedPlayerName(nameTextfield.Text);
+					ps.Name = nameTextfield.Text;
+				}
+			};
+
+			nameTextfield.OnEnterKey = () => { nameTextfield.YieldKeyboardFocus(); return true; };
+			nameTextfield.OnEscKey = () =>
+			{
+				nameTextfield.Text = Settings.SanitizedPlayerName(ps.Name);
+				escPressed = true;
+				nameTextfield.YieldKeyboardFocus();
+				return true;
+			};
+
+			var colorPreview = widget.Get<ColorPreviewManagerWidget>("COLOR_MANAGER");
+			colorPreview.Color = ps.Color;
+
+			var mouseControlDescClassic = widget.Get("MOUSE_CONTROL_DESC_CLASSIC");
+			mouseControlDescClassic.IsVisible = () => gs.UseClassicMouseStyle;
+
+			var classicScrollRight = mouseControlDescClassic.Get("DESC_SCROLL_RIGHT");
+			classicScrollRight.IsVisible = () => !gs.ClassicMouseMiddleScroll;
+
+			var classicScrollMiddle = mouseControlDescClassic.Get("DESC_SCROLL_MIDDLE");
+			classicScrollMiddle.IsVisible = () => gs.ClassicMouseMiddleScroll;
+
+			var mouseControlDescModern = widget.Get("MOUSE_CONTROL_DESC_MODERN");
+			mouseControlDescModern.IsVisible = () => !gs.UseClassicMouseStyle;
+
+			var mouseControlDropdown = widget.Get<DropDownButtonWidget>("MOUSE_CONTROL_DROPDOWN");
+			mouseControlDropdown.OnMouseDown = _ => SettingsLogic.ShowMouseControlDropdown(mouseControlDropdown, gs);
+			mouseControlDropdown.GetText = () => gs.UseClassicMouseStyle ? "Classic" : "Modern";
+
+			foreach (var container in new[] { mouseControlDescClassic, mouseControlDescModern })
+			{
+				var zoomDesc = container.Get("DESC_ZOOM");
+				zoomDesc.IsVisible = () => gs.ZoomModifier == Modifiers.None;
+
+				var zoomDescModifier = container.Get<LabelWidget>("DESC_ZOOM_MODIFIER");
+				zoomDescModifier.IsVisible = () => gs.ZoomModifier != Modifiers.None;
+
+				var zoomDescModifierTemplate = zoomDescModifier.Text;
+				var zoomDescModifierLabel = new CachedTransform<Modifiers, string>(
+					mod => zoomDescModifierTemplate.Replace("MODIFIER", mod.ToString()));
+				zoomDescModifier.GetText = () => zoomDescModifierLabel.Update(gs.ZoomModifier);
+
+				var edgescrollDesc = container.Get<LabelWidget>("DESC_EDGESCROLL");
+				edgescrollDesc.IsVisible = () => gs.ViewportEdgeScroll;
+			}
+
+			SettingsLogic.BindCheckboxPref(widget, "EDGESCROLL_CHECKBOX", gs, "ViewportEdgeScroll");
+
+			var colorDropdown = widget.Get<DropDownButtonWidget>("PLAYERCOLOR");
+			colorDropdown.IsDisabled = () => worldRenderer.World.Type != WorldType.Shellmap;
+			colorDropdown.OnMouseDown = _ => ColorPickerLogic.ShowColorDropDown(colorDropdown, colorPreview, worldRenderer.World);
+			colorDropdown.Get<ColorBlockWidget>("COLORBLOCK").GetColor = () => ps.Color;
+
+			var viewportSizes = modData.Manifest.Get<WorldViewportSizes>();
+			var battlefieldCameraDropDown = widget.Get<DropDownButtonWidget>("BATTLEFIELD_CAMERA_DROPDOWN");
+			var battlefieldCameraLabel = new CachedTransform<WorldViewport, string>(vs => SettingsLogic.ViewportSizeNames[vs]);
+			battlefieldCameraDropDown.OnMouseDown = _ => SettingsLogic.ShowBattlefieldCameraDropdown(battlefieldCameraDropDown, viewportSizes, ds);
+			battlefieldCameraDropDown.GetText = () => battlefieldCameraLabel.Update(ds.ViewportDistance);
+
+			var uiScaleDropdown = widget.Get<DropDownButtonWidget>("UI_SCALE_DROPDOWN");
+			var uiScaleLabel = new CachedTransform<float, string>(s => "{0}%".F((int)(100 * s)));
+			uiScaleDropdown.OnMouseDown = _ => SettingsLogic.ShowUIScaleDropdown(uiScaleDropdown, ds);
+			uiScaleDropdown.GetText = () => uiScaleLabel.Update(ds.UIScale);
+
+			var minResolution = viewportSizes.MinEffectiveResolution;
+			var resolution = Game.Renderer.Resolution;
+			var disableUIScale = worldRenderer.World.Type != WorldType.Shellmap ||
+				resolution.Width * ds.UIScale < 1.25f * minResolution.Width ||
+				resolution.Height * ds.UIScale < 1.25f * minResolution.Height;
+
+			uiScaleDropdown.IsDisabled = () => disableUIScale;
+
+			SettingsLogic.BindCheckboxPref(widget, "CURSORDOUBLE_CHECKBOX", ds, "CursorDouble");
+
+			widget.Get<ButtonWidget>("CONTINUE_BUTTON").OnClick = () =>
+			{
+				Game.Settings.Game.IntroductionPromptVersion = IntroductionVersion;
+				Game.Settings.Save();
+				Ui.CloseWindow();
+				onComplete();
+			};
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -226,21 +226,35 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			menuType = MenuType.StartupPrompts;
-			Action onSysInfoComplete = () =>
+
+			Action onIntroductionComplete = () =>
 			{
-				LoadAndDisplayNews(webServices.GameNews, newsBG);
-				SwitchMenu(MenuType.Main);
+				Action onSysInfoComplete = () =>
+				{
+					LoadAndDisplayNews(webServices.GameNews, newsBG);
+					SwitchMenu(MenuType.Main);
+				};
+
+				if (SystemInfoPromptLogic.ShouldShowPrompt())
+				{
+					Ui.OpenWindow("MAINMENU_SYSTEM_INFO_PROMPT", new WidgetArgs
+					{
+						{ "onComplete", onSysInfoComplete }
+					});
+				}
+				else
+					onSysInfoComplete();
 			};
 
-			if (SystemInfoPromptLogic.ShouldShowPrompt())
+			if (IntroductionPromptLogic.ShouldShowPrompt())
 			{
-				Ui.OpenWindow("MAINMENU_SYSTEM_INFO_PROMPT", new WidgetArgs
+				Game.OpenWindow("MAINMENU_INTRODUCTION_PROMPT", new WidgetArgs
 				{
-					{ "onComplete", onSysInfoComplete }
+					{ "onComplete", onIntroductionComplete }
 				});
 			}
 			else
-				onSysInfoComplete();
+				onIntroductionComplete();
 
 			Game.OnShellmapLoaded += OpenMenuBasedOnLastGame;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -22,11 +22,9 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	[SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1203:ConstantsMustAppearBeforeFields",
-		Justification = "SystemInformation version should be defined next to the dictionary it refers to.")]
 	public class MainMenuLogic : ChromeLogic
 	{
-		protected enum MenuType { Main, Singleplayer, Extras, MapEditor, SystemInfoPrompt, None }
+		protected enum MenuType { Main, Singleplayer, Extras, MapEditor, StartupPrompts, None }
 
 		protected enum MenuPanel { None, Missions, Skirmish, Multiplayer, MapEditor, Replays, GameSaves }
 
@@ -42,27 +40,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		protected static MenuPanel lastGameState = MenuPanel.None;
 
 		bool newsOpen;
-
-		// Increment the version number when adding new stats
-		const int SystemInformationVersion = 4;
-		Dictionary<string, Pair<string, string>> GetSystemInformation()
-		{
-			var lang = System.Globalization.CultureInfo.InstalledUICulture.TwoLetterISOLanguageName;
-			return new Dictionary<string, Pair<string, string>>()
-			{
-				{ "id", Pair.New("Anonymous ID", Game.Settings.Debug.UUID) },
-				{ "platform", Pair.New("OS Type", Platform.CurrentPlatform.ToString()) },
-				{ "os", Pair.New("OS Version", Environment.OSVersion.ToString()) },
-				{ "x64", Pair.New("OS is 64 bit", Environment.Is64BitOperatingSystem.ToString()) },
-				{ "x64process", Pair.New("Process is 64 bit", Environment.Is64BitProcess.ToString()) },
-				{ "runtime", Pair.New(".NET Runtime", Platform.RuntimeVersion) },
-				{ "gl", Pair.New("OpenGL Version", Game.Renderer.GLVersion) },
-				{ "windowsize", Pair.New("Window Size", "{0}x{1}".F(Game.Renderer.NativeResolution.Width, Game.Renderer.NativeResolution.Height)) },
-				{ "windowscale", Pair.New("Window Scale", Game.Renderer.NativeWindowScale.ToString("F2", CultureInfo.InvariantCulture)) },
-				{ "uiscale", Pair.New("UI Scale", Game.Settings.Graphics.UIScale.ToString("F2", CultureInfo.InvariantCulture)) },
-				{ "lang", Pair.New("System Language", lang) }
-			};
-		}
 
 		void SwitchMenu(MenuType type)
 		{
@@ -215,7 +192,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var newsBG = widget.GetOrNull("NEWS_BG");
 			if (newsBG != null)
 			{
-				newsBG.IsVisible = () => Game.Settings.Game.FetchNews && menuType != MenuType.None && menuType != MenuType.SystemInfoPrompt;
+				newsBG.IsVisible = () => Game.Settings.Game.FetchNews && menuType != MenuType.None && menuType != MenuType.StartupPrompts;
 
 				newsPanel = Ui.LoadWidget<ScrollPanelWidget>("NEWS_PANEL", null, new WidgetArgs());
 				newsTemplate = newsPanel.Get("NEWS_ITEM_TEMPLATE");
@@ -235,7 +212,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var updateLabel = rootMenu.GetOrNull("UPDATE_NOTICE");
 			if (updateLabel != null)
 				updateLabel.IsVisible = () => !newsOpen && menuType != MenuType.None &&
-					menuType != MenuType.SystemInfoPrompt &&
+					menuType != MenuType.StartupPrompts &&
 					webServices.ModVersionStatus == ModVersionStatus.Outdated;
 
 			var playerProfile = widget.GetOrNull("PLAYER_PROFILE_CONTAINER");
@@ -248,39 +225,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				});
 			}
 
-			// System information opt-out prompt
-			var sysInfoPrompt = widget.Get("SYSTEM_INFO_PROMPT");
-			sysInfoPrompt.IsVisible = () => menuType == MenuType.SystemInfoPrompt;
-			if (Game.Settings.Debug.SystemInformationVersionPrompt < SystemInformationVersion)
+			menuType = MenuType.StartupPrompts;
+			Action onSysInfoComplete = () =>
 			{
-				menuType = MenuType.SystemInfoPrompt;
+				LoadAndDisplayNews(webServices.GameNews, newsBG);
+				SwitchMenu(MenuType.Main);
+			};
 
-				var sysInfoCheckbox = sysInfoPrompt.Get<CheckboxWidget>("SYSINFO_CHECKBOX");
-				sysInfoCheckbox.IsChecked = () => Game.Settings.Debug.SendSystemInformation;
-				sysInfoCheckbox.OnClick = () => Game.Settings.Debug.SendSystemInformation ^= true;
-
-				var sysInfoData = sysInfoPrompt.Get<ScrollPanelWidget>("SYSINFO_DATA");
-				var template = sysInfoData.Get<LabelWidget>("DATA_TEMPLATE");
-				sysInfoData.RemoveChildren();
-
-				foreach (var info in GetSystemInformation().Values)
+			if (SystemInfoPromptLogic.ShouldShowPrompt())
+			{
+				Ui.OpenWindow("MAINMENU_SYSTEM_INFO_PROMPT", new WidgetArgs
 				{
-					var label = template.Clone() as LabelWidget;
-					var text = info.First + ": " + info.Second;
-					label.GetText = () => text;
-					sysInfoData.AddChild(label);
-				}
-
-				sysInfoPrompt.Get<ButtonWidget>("BACK_BUTTON").OnClick = () =>
-				{
-					Game.Settings.Debug.SystemInformationVersionPrompt = SystemInformationVersion;
-					Game.Settings.Save();
-					SwitchMenu(MenuType.Main);
-					LoadAndDisplayNews(webServices.GameNews, newsBG);
-				};
+					{ "onComplete", onSysInfoComplete }
+				});
 			}
 			else
-				LoadAndDisplayNews(webServices.GameNews, newsBG);
+				onSysInfoComplete();
 
 			Game.OnShellmapLoaded += OpenMenuBasedOnLastGame;
 		}
@@ -305,12 +265,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							Uri.EscapeUriString(Game.ModData.Manifest.Id),
 							Uri.EscapeUriString(Game.ModData.Manifest.Metadata.Version));
 
-						// Append system profile data if the player has opted in
-						if (Game.Settings.Debug.SendSystemInformation)
-							newsURL += "&sysinfoversion={0}&".F(SystemInformationVersion)
-								+ GetSystemInformation()
-								.Select(kv => kv.Key + "=" + Uri.EscapeUriString(kv.Value.Second))
-								.JoinWith("&");
+						// Parameter string is blank if the player has opted out
+						newsURL += SystemInfoPromptLogic.CreateParameterString();
 
 						new Download(newsURL, cacheFile, e => { },
 							e => NewsDownloadComplete(e, cacheFile, currentNews,

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -135,7 +135,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 		}
 
-		static void BindCheckboxPref(Widget parent, string id, object group, string pref)
+		public static void BindCheckboxPref(Widget parent, string id, object group, string pref)
 		{
 			var field = group.GetType().GetField(pref);
 			if (field == null)
@@ -221,7 +221,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			resetPanelActions.Add(type, reset(panel));
 		}
 
-		static readonly Dictionary<WorldViewport, string> ViewportSizeNames = new Dictionary<WorldViewport, string>()
+		public static readonly Dictionary<WorldViewport, string> ViewportSizeNames = new Dictionary<WorldViewport, string>()
 		{
 			{ WorldViewport.Close, "Close" },
 			{ WorldViewport.Medium, "Medium" },
@@ -697,7 +697,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 		}
 
-		static void ShowMouseControlDropdown(DropDownButtonWidget dropdown, GameSettings s)
+		public static void ShowMouseControlDropdown(DropDownButtonWidget dropdown, GameSettings s)
 		{
 			var options = new Dictionary<string, bool>()
 			{
@@ -880,7 +880,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, setupItem);
 		}
 
-		static void ShowBattlefieldCameraDropdown(DropDownButtonWidget dropdown, WorldViewportSizes viewportSizes, GraphicSettings gs)
+		public static void ShowBattlefieldCameraDropdown(DropDownButtonWidget dropdown, WorldViewportSizes viewportSizes, GraphicSettings gs)
 		{
 			Func<WorldViewport, ScrollItemWidget, ScrollItemWidget> setupItem = (o, itemTemplate) =>
 			{
@@ -949,7 +949,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				RecalculateWidgetLayout(c, insideScrollPanel || w is ScrollPanelWidget);
 		}
 
-		static void ShowUIScaleDropdown(DropDownButtonWidget dropdown, GraphicSettings gs)
+		public static void ShowUIScaleDropdown(DropDownButtonWidget dropdown, GraphicSettings gs)
 		{
 			Func<float, ScrollItemWidget, ScrollItemWidget> setupItem = (o, itemTemplate) =>
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/SystemInfoPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SystemInfoPromptLogic.cs
@@ -1,0 +1,95 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using OpenRA.Primitives;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+	[SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1203:ConstantsMustAppearBeforeFields",
+		Justification = "SystemInformation version should be defined next to the dictionary it refers to.")]
+	public class SystemInfoPromptLogic : ChromeLogic
+	{
+		// Increment the version number when adding new stats
+		const int SystemInformationVersion = 4;
+
+		static Dictionary<string, Pair<string, string>> GetSystemInformation()
+		{
+			var lang = CultureInfo.InstalledUICulture.TwoLetterISOLanguageName;
+			return new Dictionary<string, Pair<string, string>>()
+			{
+				{ "id", Pair.New("Anonymous ID", Game.Settings.Debug.UUID) },
+				{ "platform", Pair.New("OS Type", Platform.CurrentPlatform.ToString()) },
+				{ "os", Pair.New("OS Version", Environment.OSVersion.ToString()) },
+				{ "x64", Pair.New("OS is 64 bit", Environment.Is64BitOperatingSystem.ToString()) },
+				{ "x64process", Pair.New("Process is 64 bit", Environment.Is64BitProcess.ToString()) },
+				{ "runtime", Pair.New(".NET Runtime", Platform.RuntimeVersion) },
+				{ "gl", Pair.New("OpenGL Version", Game.Renderer.GLVersion) },
+				{ "windowsize", Pair.New("Window Size", "{0}x{1}".F(Game.Renderer.NativeResolution.Width, Game.Renderer.NativeResolution.Height)) },
+				{ "windowscale", Pair.New("Window Scale", Game.Renderer.NativeWindowScale.ToString("F2", CultureInfo.InvariantCulture)) },
+				{ "uiscale", Pair.New("UI Scale", Game.Settings.Graphics.UIScale.ToString("F2", CultureInfo.InvariantCulture)) },
+				{ "lang", Pair.New("System Language", lang) }
+			};
+		}
+
+		public static bool ShouldShowPrompt()
+		{
+			return Game.Settings.Debug.SystemInformationVersionPrompt < SystemInformationVersion;
+		}
+
+		public static string CreateParameterString()
+		{
+			if (!Game.Settings.Debug.SendSystemInformation)
+				return "";
+
+			return "&sysinfoversion={0}&".F(SystemInformationVersion)
+			       + GetSystemInformation()
+				       .Select(kv => kv.Key + "=" + Uri.EscapeUriString(kv.Value.Second))
+				       .JoinWith("&");
+		}
+
+		[ObjectCreator.UseCtor]
+		public SystemInfoPromptLogic(Widget widget, Action onComplete)
+		{
+			var sysInfoCheckbox = widget.Get<CheckboxWidget>("SYSINFO_CHECKBOX");
+			sysInfoCheckbox.IsChecked = () => Game.Settings.Debug.SendSystemInformation;
+			sysInfoCheckbox.OnClick = () => Game.Settings.Debug.SendSystemInformation ^= true;
+
+			var sysInfoData = widget.Get<ScrollPanelWidget>("SYSINFO_DATA");
+			var template = sysInfoData.Get<LabelWidget>("DATA_TEMPLATE");
+			sysInfoData.RemoveChildren();
+
+			foreach (var info in GetSystemInformation().Values)
+			{
+				var label = template.Clone() as LabelWidget;
+				var text = info.First + ": " + info.Second;
+				label.GetText = () => text;
+				sysInfoData.AddChild(label);
+			}
+
+			widget.Get<ButtonWidget>("CONTINUE_BUTTON").OnClick = () =>
+			{
+				Game.Settings.Debug.SystemInformationVersionPrompt = SystemInformationVersion;
+				Game.Settings.Save();
+				Ui.CloseWindow();
+				onComplete();
+			};
+		}
+	}
+}

--- a/mods/cnc/chrome/mainmenu-prompts.yaml
+++ b/mods/cnc/chrome/mainmenu-prompts.yaml
@@ -1,0 +1,61 @@
+Container@MAINMENU_SYSTEM_INFO_PROMPT:
+	Logic: SystemInfoPromptLogic
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 490
+	Height: 222
+	Children:
+		Label@TITLE:
+			Width: PARENT_RIGHT
+			Y: 0 - 25
+			Font: BigBold
+			Contrast: true
+			Align: Center
+			Text: System Information
+		Background@bg:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Background: panel-black
+			Children:
+				Label@PROMPT_TEXT_A:
+					X: 15
+					Y: 15
+					Width: PARENT_RIGHT - 30
+					Height: 16
+					Align: Center
+					Text: We would like to collect some details that will help us optimize OpenRA.
+				Label@PROMPT_TEXT_B:
+					X: 15
+					Y: 33
+					Width: PARENT_RIGHT - 30
+					Height: 16
+					Align: Center
+					Text: With your permission, the following anonymous system data will be sent:
+				ScrollPanel@SYSINFO_DATA:
+					X: 15
+					Y: 63
+					Width: PARENT_RIGHT - 30
+					TopBottomSpacing: 4
+					ItemSpacing: 4
+					Height: 110
+					Children:
+						Label@DATA_TEMPLATE:
+							X: 8
+							Height: 13
+							VAlign: Top
+							Font: Small
+				Checkbox@SYSINFO_CHECKBOX:
+					X: PARENT_RIGHT - 15 - WIDTH
+					Y: PARENT_BOTTOM - 35
+					Width: 190
+					Height: 20
+					Font: Regular
+					Text: Send System Information
+		Button@CONTINUE_BUTTON:
+			X: PARENT_RIGHT - WIDTH
+			Y: PARENT_BOTTOM - 1
+			Width: 140
+			Height: 35
+			Text: Continue
+			Font: Bold
+			Key: return

--- a/mods/cnc/chrome/mainmenu-prompts.yaml
+++ b/mods/cnc/chrome/mainmenu-prompts.yaml
@@ -1,9 +1,9 @@
-Container@MAINMENU_SYSTEM_INFO_PROMPT:
-	Logic: SystemInfoPromptLogic
+Container@MAINMENU_INTRODUCTION_PROMPT:
+	Logic: IntroductionPromptLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
-	Width: 490
-	Height: 222
+	Width: 600
+	Height: 350
 	Children:
 		Label@TITLE:
 			Width: PARENT_RIGHT
@@ -11,7 +11,260 @@ Container@MAINMENU_SYSTEM_INFO_PROMPT:
 			Font: BigBold
 			Contrast: true
 			Align: Center
-			Text: System Information
+			Text: Establishing Battlefield Control
+		Background@bg:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Background: panel-black
+			Children:
+				Label@DESC_A:
+					Width: PARENT_RIGHT
+					Y: 15
+					Height: 16
+					Font: Regular
+					Align: Center
+					Text: Welcome back Commander! Initialize combat parameters using the options below.
+				Label@DESC_B:
+					Width: PARENT_RIGHT
+					Y: 33
+					Height: 16
+					Font: Regular
+					Align: Center
+					Text: Additional options can be configured later from the Settings menu.
+				Label@PROFILE_TITLE:
+					Width: PARENT_RIGHT
+					Y: 60
+					Height: 25
+					Font: Bold
+					Align: Center
+					Text: Profile
+				Label@PLAYER:
+					Text: Player Name:
+					X: 15
+					Y: 90
+					Width: 120
+					Height: 25
+					Align: Right
+				TextField@PLAYERNAME:
+					X: 140
+					Y: 90
+					Width: 160
+					Height: 25
+					MaxLength: 16
+				Label@COLOR:
+					X: 265 + 60
+					Y: 90
+					Width: 145
+					Height: 25
+					Text: Preferred Color:
+					Align: Right
+				ColorPreviewManager@COLOR_MANAGER:
+				DropDownButton@PLAYERCOLOR:
+					X: 415 + 60
+					Y: 90
+					Width: 75
+					Height: 25
+					IgnoreChildMouseOver: true
+					PanelAlign: Right
+					Children:
+						ColorBlock@COLORBLOCK:
+							X: 5
+							Y: 6
+							Width: PARENT_RIGHT - 35
+							Height: PARENT_BOTTOM - 12
+				Label@INPUT_TITLE:
+					Width: PARENT_RIGHT
+					Y: 120
+					Height: 25
+					Font: Bold
+					Align: Center
+					Text: Input
+				Label@MOUSE_CONTROL_LABEL:
+					X: 15
+					Y: 150
+					Width: 120
+					Height: 25
+					Font: Regular
+					Text: Control Scheme:
+					Align: Right
+				DropDownButton@MOUSE_CONTROL_DROPDOWN:
+					X: 140
+					Y: 150
+					Width: 160
+					Height: 25
+					Font: Regular
+				Checkbox@EDGESCROLL_CHECKBOX:
+					X: 365
+					Y: 153
+					Width: 180
+					Height: 20
+					Font: Regular
+					Text: Screen Edge Panning
+				Container@MOUSE_CONTROL_DESC_CLASSIC:
+					X: 25
+					Y: 180
+					Width: PARENT_RIGHT - 50
+					Children:
+						LabelWithHighlight@DESC_SELECTION:
+							Height: 16
+							Font: Small
+							Text: - Select units using the {Left} mouse button
+						LabelWithHighlight@DESC_COMMANDS:
+							Y: 17
+							Height: 16
+							Font: Small
+							Text: - Command units using the {Left} mouse button
+						LabelWithHighlight@DESC_BUILDIGS:
+							Y: 34
+							Height: 16
+							Font: Small
+							Text: - Place structures using the {Left} mouse button
+						LabelWithHighlight@DESC_SUPPORT:
+							X: 265
+							Height: 16
+							Font: Small
+							Text: - Target support powers using the {Left} mouse button
+						LabelWithHighlight@DESC_ZOOM:
+							X: 265
+							Y: 17
+							Height: 16
+							Font: Small
+							Text: - Zoom the battlefield using the {Scroll Wheel}
+						LabelWithHighlight@DESC_ZOOM_MODIFIER:
+							X: 265
+							Y: 17
+							Height: 16
+							Font: Small
+							Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
+						LabelWithHighlight@DESC_SCROLL_RIGHT:
+							X: 265
+							Y: 34
+							Height: 16
+							Font: Small
+							Text: - Pan the battlefield using the {Right} mouse button
+						LabelWithHighlight@DESC_SCROLL_MIDDLE:
+							X: 265
+							Y: 34
+							Height: 16
+							Font: Small
+							Text: - Pan the battlefield using the {Middle} mouse button
+						Label@DESC_EDGESCROLL:
+							X: 274
+							Y: 51
+							Height: 16
+							Font: Small
+							Text: or by moving the cursor to the edge of the screen
+				Container@MOUSE_CONTROL_DESC_MODERN:
+					X: 25
+					Y: 180
+					Width: PARENT_RIGHT - 50
+					Children:
+						LabelWithHighlight@DESC_SELECTION:
+							Height: 16
+							Font: Small
+							Text: - Select units using the {Left} mouse button
+						LabelWithHighlight@DESC_COMMANDS:
+							Y: 17
+							Height: 16
+							Font: Small
+							Text: - Command units using the {Right} mouse button
+						LabelWithHighlight@DESC_BUILDIGS:
+							Y: 34
+							Height: 16
+							Font: Small
+							Text: - Place structures using the {Left} mouse button
+						LabelWithHighlight@DESC_SUPPORT:
+							X: 265
+							Height: 16
+							Font: Small
+							Text: - Target support powers using the {Left} mouse button
+						LabelWithHighlight@DESC_ZOOM:
+							X: 265
+							Y: 17
+							Height: 16
+							Font: Small
+							Text: - Zoom the battlefield using the {Scroll Wheel}
+						LabelWithHighlight@DESC_ZOOM_MODIFIER:
+							X: 265
+							Y: 17
+							Height: 16
+							Font: Small
+							Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
+						LabelWithHighlight@DESC_SCROLL:
+							X: 265
+							Y: 34
+							Height: 16
+							Font: Small
+							Text: - Pan the battlefield using the {Middle} mouse button
+						Label@DESC_EDGESCROLL:
+							X: 274
+							Y: 51
+							Height: 16
+							Font: Small
+							Text: or by moving the cursor to the edge of the screen
+				Label@INPUT_TITLE:
+					Width: PARENT_RIGHT
+					Y: 250
+					Height: 25
+					Font: Bold
+					Align: Center
+					Text: Display
+				Label@BATTLEFIELD_CAMERA:
+					X: 15
+					Y: 280
+					Width: 120
+					Height: 25
+					Text: Battlefield Camera:
+					Align: Right
+				DropDownButton@BATTLEFIELD_CAMERA_DROPDOWN:
+					X: 140
+					Y: 280
+					Width: 160
+					Height: 25
+					Font: Regular
+				Label@UI_SCALE:
+					X: 275
+					Y: 280
+					Width: 145
+					Height: 25
+					Text: UI Scale:
+					Align: Right
+				DropDownButton@UI_SCALE_DROPDOWN:
+					X: 425
+					Y: 280
+					Width: 160
+					Height: 25
+					Font: Regular
+				Checkbox@CURSORDOUBLE_CHECKBOX:
+					X: 390
+					Y: 313
+					Width: 200
+					Height: 20
+					Font: Regular
+					Text: Increase Cursor Size
+		Button@CONTINUE_BUTTON:
+			X: PARENT_RIGHT - WIDTH
+			Y: PARENT_BOTTOM - 1
+			Width: 140
+			Height: 35
+			Text: Continue
+			Font: Bold
+			Key: return
+
+Container@MAINMENU_SYSTEM_INFO_PROMPT:
+	Logic: SystemInfoPromptLogic
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 600
+	Height: 350
+	Children:
+		Label@TITLE:
+			Width: PARENT_RIGHT
+			Y: 0 - 25
+			Font: BigBold
+			Contrast: true
+			Align: Center
+			Text: Establishing Battlefield Control
 		Background@bg:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
@@ -37,7 +290,7 @@ Container@MAINMENU_SYSTEM_INFO_PROMPT:
 					Width: PARENT_RIGHT - 30
 					TopBottomSpacing: 4
 					ItemSpacing: 4
-					Height: 110
+					Height: 240
 					Children:
 						Label@DATA_TEMPLATE:
 							X: 8
@@ -45,8 +298,8 @@ Container@MAINMENU_SYSTEM_INFO_PROMPT:
 							VAlign: Top
 							Font: Small
 				Checkbox@SYSINFO_CHECKBOX:
-					X: PARENT_RIGHT - 15 - WIDTH
-					Y: PARENT_BOTTOM - 35
+					X: 390
+					Y: 313
 					Width: 190
 					Height: 20
 					Font: Regular

--- a/mods/cnc/chrome/mainmenu.yaml
+++ b/mods/cnc/chrome/mainmenu.yaml
@@ -218,66 +218,6 @@ Container@MENU_BACKGROUND:
 							Text: Back
 							Font: Bold
 							Key: escape
-		Container@SYSTEM_INFO_PROMPT:
-			X: (WINDOW_RIGHT - WIDTH) / 2
-			Y: (WINDOW_BOTTOM - HEIGHT) / 2
-			Width: 490
-			Height: 222
-			Children:
-				Label@TITLE:
-					Width: PARENT_RIGHT
-					Y: 0 - 25
-					Font: BigBold
-					Contrast: true
-					Align: Center
-					Text: System Information
-				Background@bg:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
-					Background: panel-black
-					Children:
-						Label@PROMPT_TEXT_A:
-							X: 15
-							Y: 15
-							Width: PARENT_RIGHT - 30
-							Height: 16
-							Align: Center
-							Text: We would like to collect some details that will help us optimize OpenRA.
-						Label@PROMPT_TEXT_B:
-							X: 15
-							Y: 33
-							Width: PARENT_RIGHT - 30
-							Height: 16
-							Align: Center
-							Text: With your permission, the following anonymous system data will be sent:
-						ScrollPanel@SYSINFO_DATA:
-							X: 15
-							Y: 63
-							Width: PARENT_RIGHT - 30
-							TopBottomSpacing: 4
-							ItemSpacing: 4
-							Height: 110
-							Children:
-								Label@DATA_TEMPLATE:
-									X: 8
-									Height: 13
-									VAlign: Top
-									Font: Small
-						Checkbox@SYSINFO_CHECKBOX:
-							X: PARENT_RIGHT - 15 - WIDTH
-							Y: PARENT_BOTTOM - 35
-							Width: 190
-							Height: 20
-							Font: Regular
-							Text: Send System Information
-				Button@BACK_BUTTON:
-					X: PARENT_RIGHT - WIDTH
-					Y: PARENT_BOTTOM - 1
-					Width: 140
-					Height: 35
-					Text: Continue
-					Font: Bold
-					Key: return
 		Container@NEWS_BG:
 			Children:
 				DropDownButton@NEWS_BUTTON:

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -92,6 +92,7 @@ Assemblies:
 
 ChromeLayout:
 	cnc|chrome/mainmenu.yaml
+	cnc|chrome/mainmenu-prompts.yaml
 	cnc|chrome/playerprofile.yaml
 	cnc|chrome/multiplayer-browser.yaml
 	cnc|chrome/multiplayer-browserpanels.yaml

--- a/mods/common/chrome/mainmenu-prompts.yaml
+++ b/mods/common/chrome/mainmenu-prompts.yaml
@@ -1,0 +1,56 @@
+Background@MAINMENU_SYSTEM_INFO_PROMPT:
+	Logic: SystemInfoPromptLogic
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 520
+	Height: 260
+	Children:
+		Label@PROMPT_TITLE:
+			Width: PARENT_RIGHT
+			Y: 20
+			Height: 25
+			Font: Bold
+			Align: Center
+			Text: System Information
+		Label@PROMPT_TEXT_A:
+			X: 15
+			Y: 50
+			Width: PARENT_RIGHT - 30
+			Height: 16
+			Align: Center
+			Text: We would like to collect some details that will help us optimize OpenRA.
+		Label@PROMPT_TEXT_B:
+			X: 15
+			Y: 68
+			Width: PARENT_RIGHT - 30
+			Height: 16
+			Align: Center
+			Text: With your permission, the following anonymous system data will be sent:
+		ScrollPanel@SYSINFO_DATA:
+			X: 20
+			Y: 98
+			Width: PARENT_RIGHT - 40
+			TopBottomSpacing: 4
+			ItemSpacing: 4
+			Height: 110
+			Children:
+				Label@DATA_TEMPLATE:
+					X: 8
+					Height: 13
+					VAlign: Top
+					Font: Small
+		Checkbox@SYSINFO_CHECKBOX:
+			X: 40
+			Y: PARENT_BOTTOM - 42
+			Width: 200
+			Height: 20
+			Font: Regular
+			Text: Send System Information
+		Button@CONTINUE_BUTTON:
+			X: PARENT_RIGHT - WIDTH - 20
+			Y: PARENT_BOTTOM - 45
+			Width: 120
+			Height: 25
+			Text: Continue
+			Font: Bold
+			Key: return

--- a/mods/common/chrome/mainmenu-prompts.yaml
+++ b/mods/common/chrome/mainmenu-prompts.yaml
@@ -1,9 +1,9 @@
-Background@MAINMENU_SYSTEM_INFO_PROMPT:
-	Logic: SystemInfoPromptLogic
+Background@MAINMENU_INTRODUCTION_PROMPT:
+	Logic: IntroductionPromptLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
-	Width: 520
-	Height: 260
+	Width: 600
+	Height: 430
 	Children:
 		Label@PROMPT_TITLE:
 			Width: PARENT_RIGHT
@@ -11,28 +11,276 @@ Background@MAINMENU_SYSTEM_INFO_PROMPT:
 			Height: 25
 			Font: Bold
 			Align: Center
-			Text: System Information
+			Text: Establishing Battlefield Control
+		Label@DESC_A:
+			Width: PARENT_RIGHT
+			Y: 50
+			Height: 16
+			Font: Regular
+			Align: Center
+			Text: Welcome back Commander! Initialize combat parameters using the options below.
+		Label@DESC_B:
+			Width: PARENT_RIGHT
+			Y: 68
+			Height: 16
+			Font: Regular
+			Align: Center
+			Text: Additional options can be configured later from the Settings menu.
+		Label@PROFILE_TITLE:
+			Width: PARENT_RIGHT
+			Y: 100
+			Height: 25
+			Font: Bold
+			Align: Center
+			Text: Profile
+		Label@PLAYER:
+			Text: Player Name:
+			X: 20
+			Y: 130
+			Width: 120
+			Height: 25
+			Align: Right
+		TextField@PLAYERNAME:
+			X: 145
+			Y: 130
+			Width: 160
+			Height: 25
+			MaxLength: 16
+		Label@COLOR:
+			X: 265 + 60
+			Y: 130
+			Width: 145
+			Height: 25
+			Text: Preferred Color:
+			Align: Right
+		ColorPreviewManager@COLOR_MANAGER:
+		DropDownButton@PLAYERCOLOR:
+			X: 415 + 60
+			Y: 130
+			Width: 75
+			Height: 25
+			IgnoreChildMouseOver: true
+			PanelAlign: Right
+			Children:
+				ColorBlock@COLORBLOCK:
+					X: 5
+					Y: 6
+					Width: PARENT_RIGHT - 35
+					Height: PARENT_BOTTOM - 12
+		Label@INPUT_TITLE:
+			Width: PARENT_RIGHT
+			Y: 160
+			Height: 25
+			Font: Bold
+			Align: Center
+			Text: Input
+		Label@MOUSE_CONTROL_LABEL:
+			X: 20
+			Y: 190
+			Width: 120
+			Height: 25
+			Font: Regular
+			Text: Control Scheme:
+			Align: Right
+		DropDownButton@MOUSE_CONTROL_DROPDOWN:
+			X: 145
+			Y: 190
+			Width: 160
+			Height: 25
+			Font: Regular
+		Checkbox@EDGESCROLL_CHECKBOX:
+			X: 365
+			Y: 193
+			Width: 180
+			Height: 20
+			Font: Regular
+			Text: Screen Edge Panning
+		Container@MOUSE_CONTROL_DESC_CLASSIC:
+			X: 25
+			Y: 220
+			Width: PARENT_RIGHT - 50
+			Children:
+				LabelWithHighlight@DESC_SELECTION:
+					Height: 16
+					Font: Small
+					Text: - Select units using the {Left} mouse button
+				LabelWithHighlight@DESC_COMMANDS:
+					Y: 17
+					Height: 16
+					Font: Small
+					Text: - Command units using the {Left} mouse button
+				LabelWithHighlight@DESC_BUILDIGS:
+					Y: 34
+					Height: 16
+					Font: Small
+					Text: - Place structures using the {Left} mouse button
+				LabelWithHighlight@DESC_SUPPORT:
+					X: 265
+					Height: 16
+					Font: Small
+					Text: - Target support powers using the {Left} mouse button
+				LabelWithHighlight@DESC_ZOOM:
+					X: 265
+					Y: 17
+					Height: 16
+					Font: Small
+					Text: - Zoom the battlefield using the {Scroll Wheel}
+				LabelWithHighlight@DESC_ZOOM_MODIFIER:
+					X: 265
+					Y: 17
+					Height: 16
+					Font: Small
+					Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
+				LabelWithHighlight@DESC_SCROLL_RIGHT:
+					X: 265
+					Y: 34
+					Height: 16
+					Font: Small
+					Text: - Pan the battlefield using the {Right} mouse button
+				LabelWithHighlight@DESC_SCROLL_MIDDLE:
+					X: 265
+					Y: 34
+					Height: 16
+					Font: Small
+					Text: - Pan the battlefield using the {Middle} mouse button
+				Label@DESC_EDGESCROLL:
+					X: 274
+					Y: 51
+					Height: 16
+					Font: Small
+					Text: or by moving the cursor to the edge of the screen
+		Container@MOUSE_CONTROL_DESC_MODERN:
+			X: 25
+			Y: 220
+			Width: PARENT_RIGHT - 50
+			Children:
+				LabelWithHighlight@DESC_SELECTION:
+					Height: 16
+					Font: Small
+					Text: - Select units using the {Left} mouse button
+				LabelWithHighlight@DESC_COMMANDS:
+					Y: 17
+					Height: 16
+					Font: Small
+					Text: - Command units using the {Right} mouse button
+				LabelWithHighlight@DESC_BUILDIGS:
+					Y: 34
+					Height: 16
+					Font: Small
+					Text: - Place structures using the {Left} mouse button
+				LabelWithHighlight@DESC_SUPPORT:
+					X: 265
+					Height: 16
+					Font: Small
+					Text: - Target support powers using the {Left} mouse button
+				LabelWithHighlight@DESC_ZOOM:
+					X: 265
+					Y: 17
+					Height: 16
+					Font: Small
+					Text: - Zoom the battlefield using the {Scroll Wheel}
+				LabelWithHighlight@DESC_ZOOM_MODIFIER:
+					X: 265
+					Y: 17
+					Height: 16
+					Font: Small
+					Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
+				LabelWithHighlight@DESC_SCROLL:
+					X: 265
+					Y: 34
+					Height: 16
+					Font: Small
+					Text: - Pan the battlefield using the {Middle} mouse button
+				Label@DESC_EDGESCROLL:
+					X: 274
+					Y: 51
+					Height: 16
+					Font: Small
+					Text: or by moving the cursor to the edge of the screen
+		Label@INPUT_TITLE:
+			Width: PARENT_RIGHT
+			Y: 290
+			Height: 25
+			Font: Bold
+			Align: Center
+			Text: Display
+		Label@BATTLEFIELD_CAMERA:
+			X: 20
+			Y: 320
+			Width: 120
+			Height: 25
+			Text: Battlefield Camera:
+			Align: Right
+		DropDownButton@BATTLEFIELD_CAMERA_DROPDOWN:
+			X: 145
+			Y: 320
+			Width: 160
+			Height: 25
+			Font: Regular
+		Label@UI_SCALE:
+			X: 270
+			Y: 320
+			Width: 145
+			Height: 25
+			Text: UI Scale:
+			Align: Right
+		DropDownButton@UI_SCALE_DROPDOWN:
+			X: 420
+			Y: 320
+			Width: 160
+			Height: 25
+			Font: Regular
+		Checkbox@CURSORDOUBLE_CHECKBOX:
+			X: 390
+			Y: 353
+			Width: 200
+			Height: 20
+			Font: Regular
+			Text: Increase Cursor Size
+		Button@CONTINUE_BUTTON:
+			X: PARENT_RIGHT - 180
+			Y: PARENT_BOTTOM - 45 
+			Width: 160
+			Height: 25
+			Text: Continue
+			Font: Bold
+			Key: return
+
+Background@MAINMENU_SYSTEM_INFO_PROMPT:
+	Logic: SystemInfoPromptLogic
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 600
+	Height: 430
+	Children:
+		Label@PROMPT_TITLE:
+			Width: PARENT_RIGHT
+			Y: 20
+			Height: 25
+			Font: Bold
+			Align: Center
+			Text: Establishing Battlefield Control
 		Label@PROMPT_TEXT_A:
 			X: 15
 			Y: 50
 			Width: PARENT_RIGHT - 30
 			Height: 16
 			Align: Center
-			Text: We would like to collect some details that will help us optimize OpenRA.
+			Text: We would like to collect some system details that will help us optimize OpenRA.
 		Label@PROMPT_TEXT_B:
 			X: 15
 			Y: 68
 			Width: PARENT_RIGHT - 30
 			Height: 16
 			Align: Center
-			Text: With your permission, the following anonymous system data will be sent:
+			Text: With your permission, the following anonymous data will be sent each game launch:
 		ScrollPanel@SYSINFO_DATA:
 			X: 20
 			Y: 98
 			Width: PARENT_RIGHT - 40
+			Height: 355-98-10
 			TopBottomSpacing: 4
 			ItemSpacing: 4
-			Height: 110
 			Children:
 				Label@DATA_TEMPLATE:
 					X: 8
@@ -40,8 +288,8 @@ Background@MAINMENU_SYSTEM_INFO_PROMPT:
 					VAlign: Top
 					Font: Small
 		Checkbox@SYSINFO_CHECKBOX:
-			X: 40
-			Y: PARENT_BOTTOM - 42
+			X: 390
+			Y: 353
 			Width: 200
 			Height: 20
 			Font: Regular
@@ -49,7 +297,7 @@ Background@MAINMENU_SYSTEM_INFO_PROMPT:
 		Button@CONTINUE_BUTTON:
 			X: PARENT_RIGHT - WIDTH - 20
 			Y: PARENT_BOTTOM - 45
-			Width: 120
+			Width: 160
 			Height: 25
 			Text: Continue
 			Font: Bold

--- a/mods/common/chrome/mainmenu.yaml
+++ b/mods/common/chrome/mainmenu.yaml
@@ -218,61 +218,6 @@ Container@MAINMENU:
 							Height: 30
 							Text: Back
 							Font: Bold
-		Background@SYSTEM_INFO_PROMPT:
-			X: (WINDOW_RIGHT - WIDTH) / 2
-			Y: (WINDOW_BOTTOM - HEIGHT) / 2
-			Width: 520
-			Height: 260
-			Children:
-				Label@PROMPT_TITLE:
-					Width: PARENT_RIGHT
-					Y: 20
-					Height: 25
-					Font: Bold
-					Align: Center
-					Text: System Information
-				Label@PROMPT_TEXT_A:
-					X: 15
-					Y: 50
-					Width: PARENT_RIGHT - 30
-					Height: 16
-					Align: Center
-					Text: We would like to collect some details that will help us optimize OpenRA.
-				Label@PROMPT_TEXT_B:
-					X: 15
-					Y: 68
-					Width: PARENT_RIGHT - 30
-					Height: 16
-					Align: Center
-					Text: With your permission, the following anonymous system data will be sent:
-				ScrollPanel@SYSINFO_DATA:
-					X: 20
-					Y: 98
-					Width: PARENT_RIGHT - 40
-					TopBottomSpacing: 4
-					ItemSpacing: 4
-					Height: 110
-					Children:
-						Label@DATA_TEMPLATE:
-							X: 8
-							Height: 13
-							VAlign: Top
-							Font: Small
-				Checkbox@SYSINFO_CHECKBOX:
-					X: 40
-					Y: PARENT_BOTTOM - 42
-					Width: 200
-					Height: 20
-					Font: Regular
-					Text: Send System Information
-				Button@BACK_BUTTON:
-					X: PARENT_RIGHT - WIDTH - 20
-					Y: PARENT_BOTTOM - 45
-					Width: 120
-					Height: 25
-					Text: Continue
-					Font: Bold
-					Key: return
 		Container@PERFORMANCE_INFO:
 			Logic: PerfDebugLogic
 			Children:

--- a/mods/d2k/chrome/mainmenu.yaml
+++ b/mods/d2k/chrome/mainmenu.yaml
@@ -205,61 +205,6 @@ Container@MAINMENU:
 							Height: 30
 							Text: Back
 							Font: Bold
-		Background@SYSTEM_INFO_PROMPT:
-			X: (WINDOW_RIGHT - WIDTH) / 2
-			Y: (WINDOW_BOTTOM - HEIGHT) / 2
-			Width: 520
-			Height: 260
-			Children:
-				Label@PROMPT_TITLE:
-					Width: PARENT_RIGHT
-					Y: 21
-					Height: 25
-					Font: Bold
-					Align: Center
-					Text: System Information
-				Label@PROMPT_TEXT_A:
-					X: 15
-					Y: 51
-					Width: PARENT_RIGHT - 30
-					Height: 16
-					Align: Center
-					Text: We would like to collect some details that will help us optimize OpenRA.
-				Label@PROMPT_TEXT_B:
-					X: 15
-					Y: 69
-					Width: PARENT_RIGHT - 30
-					Height: 16
-					Align: Center
-					Text: With your permission, the following anonymous system data will be sent:
-				ScrollPanel@SYSINFO_DATA:
-					X: 20
-					Y: 98
-					Width: PARENT_RIGHT - 40
-					TopBottomSpacing: 4
-					ItemSpacing: 4
-					Height: 110
-					Children:
-						Label@DATA_TEMPLATE:
-							X: 8
-							Height: 13
-							VAlign: Top
-							Font: Small
-				Checkbox@SYSINFO_CHECKBOX:
-					X: 40
-					Y: PARENT_BOTTOM - 42
-					Width: 200
-					Height: 20
-					Font: Regular
-					Text: Send System Information
-				Button@BACK_BUTTON:
-					X: PARENT_RIGHT - WIDTH - 20
-					Y: PARENT_BOTTOM - 45
-					Width: 120
-					Height: 25
-					Text: Continue
-					Font: Bold
-					Key: return
 		Background@NEWS_BG:
 			X: (WINDOW_RIGHT - WIDTH) / 2
 			Y: 35

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -82,6 +82,7 @@ ChromeLayout:
 	common|chrome/ingame-debuginfo.yaml
 	common|chrome/ingame-infochat.yaml
 	d2k|chrome/mainmenu.yaml
+	common|chrome/mainmenu-prompts.yaml
 	common|chrome/settings.yaml
 	common|chrome/credits.yaml
 	common|chrome/lobby.yaml

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -97,6 +97,7 @@ ChromeLayout:
 	common|chrome/ingame-debuginfo.yaml
 	common|chrome/ingame-infochat.yaml
 	common|chrome/mainmenu.yaml
+	common|chrome/mainmenu-prompts.yaml
 	common|chrome/settings.yaml
 	common|chrome/credits.yaml
 	common|chrome/lobby.yaml

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -144,6 +144,7 @@ ChromeLayout:
 	common|chrome/ingame-debuginfo.yaml
 	common|chrome/ingame-infochat.yaml
 	common|chrome/mainmenu.yaml
+	common|chrome/mainmenu-prompts.yaml
 	ts|chrome/mainmenu-prerelease-notification.yaml
 	common|chrome/settings.yaml
 	common|chrome/credits.yaml


### PR DESCRIPTION
<img width="668" alt="Screenshot 2020-01-26 at 19 17 12" src="https://user-images.githubusercontent.com/167819/73140411-80d24480-4070-11ea-8a12-ac0b8307ef81.png">

Fixes #17345. Depends on ~#17581,~  ~#17621~.

Launch the game with `Game.IntroductionPromptVersion=0 Debug.SystemInformationVersionPrompt=0` to easily trigger both the introduction and tweaked sysinfo dialogs.