### PR TITLE
Add --debug-chrome-regions utility command.

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/DebugChromeRegions.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/DebugChromeRegions.cs
@@ -1,0 +1,140 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using OpenRA.Graphics;
+using OpenRA.Primitives;
+
+namespace OpenRA.Mods.Common.UtilityCommands
+{
+	class DebugChromeRegions : IUtilityCommand
+	{
+		string IUtilityCommand.Name { get { return "--debug-chrome-regions"; } }
+
+		bool IUtilityCommand.ValidateArguments(string[] args)
+		{
+			return args.Length == 3;
+		}
+
+		[Desc("IMAGE", "ZOOM", "Write a html page showing mapped chrome images.")]
+		void IUtilityCommand.Run(Utility utility, string[] args)
+		{
+			// HACK: The engine code assumes that Game.modData is set.
+			var modData = Game.ModData = utility.ModData;
+
+			ChromeProvider.Initialize(modData);
+
+			var image = args[1];
+			var zoom = args[2];
+
+			var regions = new List<string>();
+			foreach (var c in ChromeProvider.Collections)
+			{
+				if (c.Value.Image != image)
+					continue;
+
+				var pr = c.Value.PanelRegion;
+				if (pr != null && pr.Length == 8)
+				{
+					var sides = new[]
+					{
+						Pair.New(PanelSides.Top | PanelSides.Left, new Rectangle(pr[0], pr[1], pr[2], pr[3])),
+						Pair.New(PanelSides.Top, new Rectangle(pr[0] + pr[2], pr[1], pr[4], pr[3])),
+						Pair.New(PanelSides.Top | PanelSides.Right, new Rectangle(pr[0] + pr[2] + pr[4], pr[1], pr[6], pr[3])),
+						Pair.New(PanelSides.Left, new Rectangle(pr[0], pr[1] + pr[3], pr[2], pr[5])),
+						Pair.New(PanelSides.Center, new Rectangle(pr[0] + pr[2], pr[1] + pr[3], pr[4], pr[5])),
+						Pair.New(PanelSides.Right, new Rectangle(pr[0] + pr[2] + pr[4], pr[1] + pr[3], pr[6], pr[5])),
+						Pair.New(PanelSides.Bottom | PanelSides.Left, new Rectangle(pr[0], pr[1] + pr[3] + pr[5], pr[2], pr[7])),
+						Pair.New(PanelSides.Bottom, new Rectangle(pr[0] + pr[2], pr[1] + pr[3] + pr[5], pr[4], pr[7])),
+						Pair.New(PanelSides.Bottom | PanelSides.Right, new Rectangle(pr[0] + pr[2] + pr[4], pr[1] + pr[3] + pr[5], pr[6], pr[7]))
+					};
+
+					foreach (var s in sides)
+					{
+						var r = s.Second;
+						if (c.Value.PanelSides.HasSide(s.First))
+							regions.Add("[\"{0}.<{1}>\",{2},{3},{4},{5}]".F(c.Key, s.First, r.X, r.Y, r.Width, r.Height));
+					}
+				}
+
+				foreach (var kv in c.Value.Regions)
+				{
+					var r = kv.Value;
+					regions.Add("[\"{0}\",{1},{2},{3},{4}]".F(c.Key + "." + kv.Key, r.X, r.Y, r.Width, r.Height));
+				}
+			}
+
+			var output = HtmlTemplate.JoinWith("\n").F(zoom, Convert.ToBase64String(modData.ModFiles.Open(image).ReadAllBytes()), "[" + regions.JoinWith(",") + "]");
+			var outputPath = Path.ChangeExtension(image, ".html");
+			File.WriteAllLines(outputPath, new[] { output });
+			Console.WriteLine("Saved {0}", outputPath);
+		}
+
+		static readonly string[] HtmlTemplate =
+		{
+			"<!DOCTYPE html>",
+			"<html>",
+			"<head>",
+			"<meta charset=\"utf-8\"/>",
+			"</head>",
+			"<body>",
+			"<canvas id=\"canvas\" style=\"cursor: crosshair;\"></canvas>",
+			"<script>",
+			"var zoom = {0};",
+			"var chromeImage = \"data:image/png;base64,{1}\";",
+			"var chromeRegions = {2}",
+			"function setup() {{",
+			"	var c = document.getElementById(\"canvas\");",
+			"	var ctx = c.getContext(\"2d\");",
+			"	var image = new Image;",
+			"	image.onload = function() {{",
+			"		c.width = zoom*image.width;",
+			"		c.height = zoom*image.height;",
+			"		ctx.fillStyle = \"#dddddd\";",
+			"		for (var j = 0; j < ctx.canvas.height / 4; j++)",
+			"			for (var i = j % 2; i < ctx.canvas.width / 4; i += 2)",
+			"				ctx.fillRect(4 * i, 4 * j, 4, 4);",
+			"		ctx.drawImage(image, 0, 0, c.width, c.height);",
+			"		ctx.strokeStyle = \"#ffff00\";",
+			"		ctx.lineWidth = 1;",
+			"		for (var i = 0; i < chromeRegions.length; i++) {{",
+			"			var r = chromeRegions[i];",
+			"			ctx.strokeRect(zoom*r[1], zoom*r[2], zoom*r[3], zoom*r[4]);",
+			"		}}",
+			"	}};",
+			"	var mouseover = undefined;",
+			"	c.addEventListener('mousemove', e => {{",
+			"	    var cr = c.getBoundingClientRect();",
+			"		var x = (e.clientX - cr.left) / (cr.right - cr.left) * c.width / zoom;",
+			"		var y = (e.clientY - cr.top) / (cr.bottom - cr.top) * c.height / zoom;",
+			"		var lastover = mouseover;",
+			"		mouseover = undefined;",
+			"		for (var i = 0; i < chromeRegions.length; i++) {{",
+			"			var r = chromeRegions[i];",
+			"			if (x >= r[1] && x < r[1] + r[3] && y >= r[2] && y < r[2] + r[4])",
+			"				mouseover = r[0];",
+			"		}}",
+			"		if (lastover != mouseover && mouseover)",
+			"			console.log(mouseover);",
+			"	}});",
+			"	image.src = chromeImage;",
+			"}}",
+			"window.onload = setup;",
+			"</script>",
+			"</body>",
+			"</html>",
+		};
+	}
+}


### PR DESCRIPTION
> Run e.g. `OpenRA.Utility.exe cnc --debug-chrome-regions chrome.png 4` and open the generated `chrome.html` page in a web browser. The image regions are shown in yellow, and, if you enable your browser's web console, mousing over a region will print its name to the console log.



This PR is low priority compared to the others, but will be useful for modders who will have to adjust their chrome mappings for the new scaling feature.