### PR TITLE
Remove default rally point from production structures

### DIFF
--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -187,7 +187,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				if (wasRepaired || isHostInvalid || (!stayOnResupplier && aircraft.Info.TakeOffOnResupply))
 				{
-					if (self.CurrentActivity.NextActivity == null && rp != null)
+					if (self.CurrentActivity.NextActivity == null && rp != null && rp.Path.Count > 0)
 						foreach (var cell in rp.Path)
 							QueueChild(move.MoveTo(cell, 1, ignoreActor: repairableNear != null ? null : host.Actor, targetLineColor: Color.Green));
 					else
@@ -208,7 +208,7 @@ namespace OpenRA.Mods.Common.Activities
 				// If there's a next activity and we're not RepairableNear, first leave host if the next activity is not a Move.
 				if (self.CurrentActivity.NextActivity == null)
 				{
-					if (rp != null)
+					if (rp != null && rp.Path.Count > 0)
 						foreach (var cell in rp.Path)
 							QueueChild(move.MoveTo(cell, 1, repairableNear != null ? null : host.Actor, true));
 					else if (repairableNear == null)

--- a/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
@@ -73,6 +73,9 @@ namespace OpenRA.Mods.Common.Effects
 			foreach (var c in cachedLocations)
 				targetLineNodes.Add(world.Map.CenterOfCell(c));
 
+			if (targetLineNodes.Count == 0)
+				return;
+
 			var exitPos = building.CenterPosition;
 
 			// Find closest exit

--- a/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
@@ -79,8 +79,21 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Query or set a factory's rally point.")]
 		public CPos RallyPoint
 		{
-			get { return rp.Path.Last(); }
-			set { rp.Path = new List<CPos> { value }; }
+			get
+			{
+				if (rp.Path.Count > 0)
+					return rp.Path.Last();
+
+				var exit = Self.FirstExitOrDefault();
+				if (exit != null)
+					return Self.Location + exit.Info.ExitCell;
+
+				return Self.Location;
+			}
+			set
+			{
+				rp.Path = new List<CPos> { value };
+			}
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -228,8 +228,10 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			foreach (var rp in world.ActorsWithTrait<RallyPoint>())
 			{
-				if (rp.Actor.Owner == player &&
-					!IsRallyPointValid(rp.Trait.Path[0], rp.Actor.Info.TraitInfoOrDefault<BuildingInfo>()))
+				if (rp.Actor.Owner != player)
+					continue;
+
+				if (rp.Trait.Path.Count == 0 || !IsRallyPointValid(rp.Trait.Path[0], rp.Actor.Info.TraitInfoOrDefault<BuildingInfo>()))
 				{
 					bot.QueueOrder(new Order("SetRallyPoint", rp.Actor, Target.FromCell(world, ChooseRallyLocationNear(rp.Actor)), false)
 					{

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -39,7 +39,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = true;
 
-		public readonly CVec Offset = new CVec(1, 3);
+		[Desc("A list of 0 or more offsets defining the initial rally point path.")]
+		public readonly CVec[] Path = { new CVec(1, 3) };
 
 		public object Create(ActorInitializer init) { return new RallyPoint(init.Self, this); }
 	}
@@ -57,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void ResetPath(Actor self)
 		{
-			Path = new List<CPos> { self.Location + Info.Offset };
+			Path = Info.Path.Select(p => self.Location + p).ToList();
 		}
 
 		public RallyPoint(Actor self, RallyPointInfo info)

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool IsPlayerPalette = true;
 
 		[Desc("A list of 0 or more offsets defining the initial rally point path.")]
-		public readonly CVec[] Path = { new CVec(1, 3) };
+		public readonly CVec[] Path = { };
 
 		public object Create(ActorInitializer init) { return new RallyPoint(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -636,7 +636,7 @@ namespace OpenRA.Mods.Common.Traits
 			return new ReturnToCellActivity(self);
 		}
 
-		class ReturnToCellActivity : Activity
+		public class ReturnToCellActivity : Activity
 		{
 			readonly Mobile mobile;
 			readonly bool recalculateSubCell;

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 						initialFacing = delta.Yaw.Facing;
 				}
 
-				exitLocations = rp.Value != null ? rp.Value.Path : new List<CPos> { exit };
+				exitLocations = rp.Value != null && rp.Value.Path.Count > 0 ? rp.Value.Path : new List<CPos> { exit };
 
 				td.Add(new LocationInit(exit));
 				td.Add(new CenterPositionInit(spawn));

--- a/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 			var aircraftInfo = producee.TraitInfoOrDefault<AircraftInfo>();
 			var mobileInfo = producee.TraitInfoOrDefault<MobileInfo>();
 
-			var destinations = rp != null ? rp.Path : new List<CPos> { self.Location };
+			var destinations = rp != null && rp.Path.Count > 0 ? rp.Path : new List<CPos> { self.Location };
 
 			var location = spawnLocation;
 			if (!location.HasValue)

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				var initialFacing = exitinfo.Facing < 0 ? (to - spawn).Yaw.Facing : exitinfo.Facing;
 
-				exitLocations = rp.Value != null ? rp.Value.Path : new List<CPos> { exit };
+				exitLocations = rp.Value != null && rp.Value.Path.Count > 0 ? rp.Value.Path : new List<CPos> { exit };
 
 				td.Add(new LocationInit(exit));
 				td.Add(new CenterPositionInit(spawn));

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
@@ -40,6 +40,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		readonly Animation door;
 		int desiredFrame;
 		CPos openExit;
+		Actor exitingActor;
 
 		public WithProductionDoorOverlay(Actor self, WithProductionDoorOverlayInfo info)
 			: base(info)
@@ -57,8 +58,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		void ITick.Tick(Actor self)
 		{
-			if (desiredFrame > 0 && !self.World.ActorMap.GetActorsAt(openExit).Any(a => a != self))
+			if (exitingActor == null)
+				return;
+
+			if (!exitingActor.IsInWorld || exitingActor.Location != openExit || !(exitingActor.CurrentActivity is Mobile.ReturnToCellActivity))
+			{
 				desiredFrame = 0;
+				exitingActor = null;
+			}
 		}
 
 		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
@@ -70,6 +77,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		void INotifyProduction.UnitProduced(Actor self, Actor other, CPos exit)
 		{
 			openExit = exit;
+			exitingActor = other;
 			desiredFrame = door.CurrentSequence.Length - 1;
 		}
 	}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20191117/RenameRallyPointPath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20191117/RenameRallyPointPath.cs
@@ -1,0 +1,35 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	class RenameRallyPointPath : UpdateRule
+	{
+		public override string Name { get { return "Renamed RallyPoint Offset to Path"; } }
+		public override string Description
+		{
+			get
+			{
+				return "The RallyPoint Offset property has been renamed to Path and now accepts multiple (or no) values.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var rp in actorNode.ChildrenMatching("RallyPoint"))
+				rp.RenameChildrenMatching("Offset", "Path");
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -98,6 +98,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new ReformatChromeProvider(),
 				new RenameSpins(),
 				new CreateScreenShakeWarhead(),
+				new RenameRallyPointPath(),
 			})
 		};
 

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -376,7 +376,6 @@ HAND:
 		Range: 5c0
 	WithBuildingBib:
 	RallyPoint:
-		Path: 1,2
 	Exit@1:
 		SpawnOffset: 512,1024,0
 		ExitCell: 1,2
@@ -432,7 +431,6 @@ AFLD:
 	RevealsShroud:
 		Range: 7c0
 	RallyPoint:
-		Path: 4,2
 	Exit@1:
 		SpawnOffset: -1024,0,0
 		ExitCell: 3,1
@@ -497,7 +495,6 @@ WEAP:
 		RequiresCondition: !build-incomplete
 		Sequence: build-top
 	RallyPoint:
-		Path: 0,2
 	Exit@1:
 		SpawnOffset: -512,-512,0
 		ExitCell: 0,1

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -376,7 +376,7 @@ HAND:
 		Range: 5c0
 	WithBuildingBib:
 	RallyPoint:
-		Offset: 1,2
+		Path: 1,2
 	Exit@1:
 		SpawnOffset: 512,1024,0
 		ExitCell: 1,2
@@ -432,7 +432,7 @@ AFLD:
 	RevealsShroud:
 		Range: 7c0
 	RallyPoint:
-		Offset: 4,2
+		Path: 4,2
 	Exit@1:
 		SpawnOffset: -1024,0,0
 		ExitCell: 3,1
@@ -497,7 +497,7 @@ WEAP:
 		RequiresCondition: !build-incomplete
 		Sequence: build-top
 	RallyPoint:
-		Offset: 0,2
+		Path: 0,2
 	Exit@1:
 		SpawnOffset: -512,-512,0
 		ExitCell: 0,1

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -106,7 +106,6 @@ BIO:
 	ProductionBar:
 		ProductionType: Biolab
 	RallyPoint:
-		Path: -1,-1
 	SpawnActorOnDeath:
 		Actor: BIO.Husk
 	ProvidesPrerequisite@buildingname:

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -106,7 +106,7 @@ BIO:
 	ProductionBar:
 		ProductionType: Biolab
 	RallyPoint:
-		Offset: -1,-1
+		Path: -1,-1
 	SpawnActorOnDeath:
 		Actor: BIO.Husk
 	ProvidesPrerequisite@buildingname:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -202,7 +202,6 @@ barracks:
 	RevealsShroud:
 		Range: 3c768
 	RallyPoint:
-		Path: 1,2
 	Exit@1:
 		SpawnOffset: 352,576,0
 		ExitCell: 0,2
@@ -418,7 +417,6 @@ light_factory:
 		Queues: Vehicle
 		Sequence: production-welding
 	RallyPoint:
-		Path: 2,2
 	Exit@1:
 		SpawnOffset: 544,-224,0
 		ExitCell: 2,1
@@ -500,7 +498,6 @@ heavy_factory:
 	RevealsShroud:
 		Range: 4c768
 	RallyPoint:
-		Path: 0,3
 	Exit@1:
 		SpawnOffset: 256,192,0
 		ExitCell: 0,2
@@ -652,7 +649,6 @@ starport:
 	RevealsShroud:
 		Range: 3c768
 	RallyPoint:
-		Path: 1,3
 	Exit@1:
 		SpawnOffset: 0,-480,0
 		ExitCell: 2,2
@@ -907,7 +903,6 @@ repair_pad:
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
 	RallyPoint:
-		Path: 1,3
 	RenderSprites:
 		Image: repair_pad.ordos
 		FactionImages:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -202,7 +202,7 @@ barracks:
 	RevealsShroud:
 		Range: 3c768
 	RallyPoint:
-		Offset: 1,2
+		Path: 1,2
 	Exit@1:
 		SpawnOffset: 352,576,0
 		ExitCell: 0,2
@@ -418,7 +418,7 @@ light_factory:
 		Queues: Vehicle
 		Sequence: production-welding
 	RallyPoint:
-		Offset: 2,2
+		Path: 2,2
 	Exit@1:
 		SpawnOffset: 544,-224,0
 		ExitCell: 2,1
@@ -500,7 +500,7 @@ heavy_factory:
 	RevealsShroud:
 		Range: 4c768
 	RallyPoint:
-		Offset: 0,3
+		Path: 0,3
 	Exit@1:
 		SpawnOffset: 256,192,0
 		ExitCell: 0,2
@@ -652,7 +652,7 @@ starport:
 	RevealsShroud:
 		Range: 3c768
 	RallyPoint:
-		Offset: 1,3
+		Path: 1,3
 	Exit@1:
 		SpawnOffset: 0,-480,0
 		ExitCell: 2,2
@@ -907,7 +907,7 @@ repair_pad:
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
 	RallyPoint:
-		Offset: 1,3
+		Path: 1,3
 	RenderSprites:
 		Image: repair_pad.ordos
 		FactionImages:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1814,7 +1814,6 @@ KENN:
 	WithBuildingBib:
 		HasMinibib: True
 	RallyPoint:
-		Path: 0,2
 	Exit@0:
 		RequiresCondition: !being-captured
 		SpawnOffset: -280,400,0

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1814,7 +1814,7 @@ KENN:
 	WithBuildingBib:
 		HasMinibib: True
 	RallyPoint:
-		Offset: 0,2
+		Path: 0,2
 	Exit@0:
 		RequiresCondition: !being-captured
 		SpawnOffset: -280,400,0

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -96,7 +96,7 @@ GAPILE:
 		Range: 5c0
 		MaxHeightDelta: 3
 	RallyPoint:
-		Offset: 2,3
+		Path: 2,3
 		Palette: mouse
 		IsPlayerPalette: false
 		LineWidth: 2
@@ -196,7 +196,7 @@ GAWEAP:
 	Armor:
 		Type: Heavy
 	RallyPoint:
-		Offset: 4,1
+		Path: 4,1
 		Palette: mouse
 		IsPlayerPalette: false
 		LineWidth: 2

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -96,7 +96,6 @@ GAPILE:
 		Range: 5c0
 		MaxHeightDelta: 3
 	RallyPoint:
-		Path: 2,3
 		Palette: mouse
 		IsPlayerPalette: false
 		LineWidth: 2
@@ -196,7 +195,6 @@ GAWEAP:
 	Armor:
 		Type: Heavy
 	RallyPoint:
-		Path: 4,1
 		Palette: mouse
 		IsPlayerPalette: false
 		LineWidth: 2

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -150,7 +150,7 @@ NAHAND:
 		ExitCell: 0,2
 	ExitsDebugOverlay:
 	RallyPoint:
-		Offset: 3,3
+		Path: 3,3
 		Palette: mouse
 		IsPlayerPalette: false
 		LineWidth: 2
@@ -208,7 +208,7 @@ NAWEAP:
 		Range: 4c0
 		MaxHeightDelta: 3
 	RallyPoint:
-		Offset: 4,1
+		Path: 4,1
 		Palette: mouse
 		IsPlayerPalette: false
 		LineWidth: 2

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -150,7 +150,6 @@ NAHAND:
 		ExitCell: 0,2
 	ExitsDebugOverlay:
 	RallyPoint:
-		Path: 3,3
 		Palette: mouse
 		IsPlayerPalette: false
 		LineWidth: 2
@@ -208,7 +207,6 @@ NAWEAP:
 		Range: 4c0
 		MaxHeightDelta: 3
 	RallyPoint:
-		Path: 4,1
 		Palette: mouse
 		IsPlayerPalette: false
 		LineWidth: 2


### PR DESCRIPTION
This PR aims to pick up where #16701 left off, implementing the rally point behaviour from the original games (TS and later):
* By default, structures will not display a rally point, and units will stop at the exit cell. 
* Rally points can be activated by clicking anywhere (we still have the rally point mouse cursor for discovery).
* Rally points, once set, can't be cleared - it would have been nice if we could clear them by clicking on the structure, but this conflicts with the primary building order. None of the original games AFAIK offered a solution, so I think its fine that we don't either.

Mods can restore the previous behaviour by explicitly defining a `Path` on all production structures, and multiple offsets can be specified to provide a queued path.

~This still suffers from the factory door problem raised in #16701, and this will need to be fixed before merging - I'm opening this now for discussion and testing (and so we can close #16701).~