### PR TITLE
Fix mission specific buildings not granting prerequisites

### DIFF
--- a/mods/ra/maps/allies-05a/rules.yaml
+++ b/mods/ra/maps/allies-05a/rules.yaml
@@ -92,6 +92,8 @@ WEAP.infiltratable:
 		TargetTypes: Ground, C4, DetonateAttack, Structure, Mission Objectives
 	RenderSprites:
 		Image: WEAP
+	ProvidesPrerequisite:
+		Prerequisite: weap
 
 MISS:
 	Tooltip:

--- a/mods/ra/maps/monster-tank-madness/rules.yaml
+++ b/mods/ra/maps/monster-tank-madness/rules.yaml
@@ -196,6 +196,8 @@ DOME.NoInfiltrate:
 	-InfiltrateForExploration:
 	Targetable:
 		TargetTypes: Ground, Structure, C4, DetonateAttack, MissionObjective
+	ProvidesPrerequisite:
+		Prerequisite: dome
 
 SPY:
 	Infiltrates:


### PR DESCRIPTION
Closes #17613. All other missions mentioned in https://github.com/OpenRA/OpenRA/issues/17613#issuecomment-578421066 do not have this problem (no engineers, building not capturable, or not relying on `buildingname` to grant prerequisites).