### PR TITLE
Use common notice colors for UPnP status labels

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/ServerCreationLogic.cs
@@ -154,9 +154,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				noticesLabelB.Text = status == UPnPStatus.Enabled ? "Enabled" :
 					status == UPnPStatus.NotSupported ? "Not Supported" : "Disabled";
 
-				noticesLabelB.TextColor = status == UPnPStatus.Enabled ? ChromeMetrics.Get<Color>("UPnPEnabledColor") :
-					status == UPnPStatus.NotSupported ? ChromeMetrics.Get<Color>("UPnPNotSupportedColor") :
-					ChromeMetrics.Get<Color>("UPnPDisabledColor");
+				noticesLabelB.TextColor = status == UPnPStatus.Enabled ? ChromeMetrics.Get<Color>("NoticeSuccessColor") :
+					status == UPnPStatus.NotSupported ? ChromeMetrics.Get<Color>("NoticeErrorColor") :
+					ChromeMetrics.Get<Color>("NoticeInfoColor");
 
 				var bWidth = Game.Renderer.Fonts[noticesLabelB.Font].Measure(noticesLabelB.Text).X;
 				noticesLabelB.Bounds.X = noticesLabelA.Bounds.Right;

--- a/mods/common/metrics.yaml
+++ b/mods/common/metrics.yaml
@@ -42,9 +42,6 @@ Metrics:
 	TextfieldColorHighlight: 195BC4
 	TextfieldFont: Regular
 	WaitingGameColor: 00FF00
-	UPnPDisabledColor: FFFFFF
-	UPnPEnabledColor: 00FF00
-	UPnPNotSupportedColor: FF0000
 	NoticeInfoColor: FFFFFF
 	NoticeWarningColor: FFA500
 	NoticeSuccessColor: 00FF00


### PR DESCRIPTION
These are not necessary now that we have generic notice colors:
```yaml
UPnPDisabledColor: FFFFFF
UPnPEnabledColor: 00FF00
UPnPNotSupportedColor: FF0000
```