### PR TITLE
Implement WithCargoSounds

### DIFF
--- a/OpenRA.Mods.Common/Traits/Sound/WithCargoSounds.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/WithCargoSounds.cs
@@ -1,0 +1,69 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Linq;
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	public class WithCargoSoundsInfo : ConditionalTraitInfo, Requires<CargoInfo>
+	{
+		[NotificationReference("Speech")]
+		[Desc("Speech notification played when a passenger enters this actor.")]
+		public readonly string EnterNotification = null;
+
+		[NotificationReference("Speech")]
+		[Desc("Speech notification played when a passenger leaves this actor.")]
+		public readonly string ExitNotification = null;
+
+		[Desc("List of sounds which a random one is played when the a passenger enters this actor.")]
+		public readonly string[] EnterSounds = { };
+
+		[Desc("List of sounds which a random one is played when the a passenger exits this actor.")]
+		public readonly string[] ExitSounds = { };
+
+		public override object Create(ActorInitializer init) { return new WithCargoSounds(init.Self, this); }
+
+		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
+		{
+			base.RulesetLoaded(rules, ai);
+
+			if (EnterNotification == null && ExitNotification == null && !EnterSounds.Any() && !ExitSounds.Any())
+				throw new YamlException("Actor '{0}' has WithCargoSounds trait, but doesn't define any sounds or notifications.".F(ai.Name));
+		}
+	}
+
+	public class WithCargoSounds : ConditionalTrait<WithCargoSoundsInfo>, INotifyPassengerEntered, INotifyPassengerExited
+	{
+		public WithCargoSounds(Actor self, WithCargoSoundsInfo info)
+            : base(info) { }
+
+		void INotifyPassengerEntered.OnPassengerEntered(Actor self, Actor passenger)
+		{
+			if (IsTraitDisabled)
+				return;
+
+			if (Info.EnterSounds.Any())
+				Game.Sound.Play(SoundType.World, Info.EnterSounds.Random(self.World.LocalRandom), self.CenterPosition);
+			Game.Sound.PlayNotification(self.World.Map.Rules, passenger.Owner, "Speech", Info.EnterNotification, passenger.Owner.Faction.InternalName);
+		}
+
+		void INotifyPassengerExited.OnPassengerExited(Actor self, Actor passenger)
+		{
+			if (IsTraitDisabled)
+				return;
+
+			if (Info.ExitSounds.Any())
+				Game.Sound.Play(SoundType.World, Info.ExitSounds.Random(self.World.LocalRandom), self.CenterPosition);
+			Game.Sound.PlayNotification(self.World.Map.Rules, passenger.Owner, "Speech", Info.ExitNotification, passenger.Owner.Faction.InternalName);
+		}
+	}
+}

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -713,6 +713,14 @@ PBOX:
 		MaxWeight: 1
 		PipCount: 1
 		InitialUnits: e1
+		LoadedCondition: loaded
+	WithCargoSounds:
+		EnterNotification: BuildingInfiltrated
+		EnterSounds: placbldg.aud, radaron2.aud
+		RequiresCondition: !loaded
+	WithCargoSounds@Exit:
+		ExitNotification: Cancelled
+		ExitSounds: cashturn.aud, radardn1.aud
 	-SpawnActorsOnSell:
 	AttackGarrisoned:
 		RequiresCondition: !build-incomplete

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -468,6 +468,14 @@ APC:
 		MaxWeight: 5
 		PipCount: 5
 		LoadingCondition: notmobile
+		LoadedCondition: loaded
+	WithCargoSounds:
+		EnterNotification: BuildingInfiltrated
+		EnterSounds: placbldg.aud, radaron2.aud
+	WithCargoSounds@Exit:
+		ExitNotification: Cancelled
+		ExitSounds: cashturn.aud, radardn1.aud
+		RequiresCondition: loaded == 1
 	ProducibleWithLevel:
 		Prerequisites: vehicles.upgraded
 


### PR DESCRIPTION
Red Alert 2 had sounds for units entering transports and seperate ones for entering and exiting IFV.

I added the notification ones too, because i took sound code from Garrison code we have on RV, which had those but not sure how useful it would be. Still shouldn't hurt to have it.

There is still the issue of sound overlapping due to how loading/unloading work on OpenRA, which is different to original. But the sounds has been in RV for a while now and it still sounds ok. Notifications logic already supports limiting them if someone decides to use it.

Testcase adds some random sounds and notifications for these to RA PillBox and APC, you can see the above issue with the APC loading.