### PR TITLE
Fixed the namespace of D2kActorPreviewPlaceBuildingPreview

### DIFF
--- a/OpenRA.Mods.D2k/Traits/Buildings/D2kActorPreviewPlaceBuildingPreview.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/D2kActorPreviewPlaceBuildingPreview.cs
@@ -13,10 +13,11 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Orders;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Widgets;
 using OpenRA.Primitives;
 
-namespace OpenRA.Mods.Common.Traits
+namespace OpenRA.Mods.D2k.Traits
 {
 	[Desc("Creates a building placement preview based on the map editor actor preview.")]
 	public class D2kActorPreviewPlaceBuildingPreviewInfo : ActorPreviewPlaceBuildingPreviewInfo


### PR DESCRIPTION
Just noticed something is wrong while browsing https://docs.openra.net/en/latest/playtest/traits/?#d2kactorpreviewplacebuildingpreview