### PR TITLE
Update SDL2 dependencies to 2.0.10

### DIFF
--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -7,7 +7,7 @@ command -v python >/dev/null 2>&1 || { echo >&2 "Linux packaging requires python
 command -v tar >/dev/null 2>&1 || { echo >&2 "Linux packaging requires tar."; exit 1; }
 command -v curl >/dev/null 2>&1 || command -v wget > /dev/null 2>&1 || { echo >&2 "Linux packaging requires curl or wget."; exit 1; }
 
-DEPENDENCIES_TAG="20191004"
+DEPENDENCIES_TAG="20200202"
 
 if [ $# -eq "0" ]; then
 	echo "Usage: $(basename "$0") version [outputdir]"

--- a/thirdparty/fetch-thirdparty-deps-osx.sh
+++ b/thirdparty/fetch-thirdparty-deps-osx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LAUNCHER_TAG="osx-launcher-20191007"
+LAUNCHER_TAG="osx-launcher-20200209"
 
 download_dir="${0%/*}/download/osx"
 mkdir -p "$download_dir"

--- a/thirdparty/fetch-thirdparty-deps-windows.sh
+++ b/thirdparty/fetch-thirdparty-deps-windows.sh
@@ -21,13 +21,13 @@ cd "${download_dir}" || exit 1
 if [ ! -f SDL2.dll ]; then
 	echo "Fetching SDL2 from libsdl.org"
 	if [ "$1" = "x86" ]; then
-		curl -LOs https://www.libsdl.org/release/SDL2-2.0.5-win32-x86.zip
-		unzip SDL2-2.0.5-win32-x86.zip SDL2.dll
-		rm SDL2-2.0.5-win32-x86.zip
+		curl -LOs https://www.libsdl.org/release/SDL2-2.0.10-win32-x86.zip
+		unzip SDL2-2.0.10-win32-x86.zip SDL2.dll
+		rm SDL2-2.0.10-win32-x86.zip
 	else
-		curl -LOs https://www.libsdl.org/release/SDL2-2.0.5-win32-x64.zip
-		unzip SDL2-2.0.5-win32-x64.zip SDL2.dll
-		rm SDL2-2.0.5-win32-x64.zip
+		curl -LOs https://www.libsdl.org/release/SDL2-2.0.10-win32-x64.zip
+		unzip SDL2-2.0.10-win32-x64.zip SDL2.dll
+		rm SDL2-2.0.10-win32-x64.zip
 	fi
 fi
 

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -40,7 +40,7 @@ if (!(Test-Path "windows/SDL2.dll"))
 	echo "Fetching SDL2 from libsdl.org"
 	
 	# Download zip:
-	$zipFileName = "SDL2-2.0.5-win32-x64.zip"
+	$zipFileName = "SDL2-2.0.10-win32-x64.zip"
 	$target = Join-Path $pwd.ToString() $zipFileName
 	(New-Object System.Net.WebClient).DownloadFile("https://www.libsdl.org/release/" + $zipFileName, $target)
 	


### PR DESCRIPTION
Originally prompted by [this forum thread](https://forum.openra.net/viewtopic.php?f=82&t=21093). Test builds available [here](https://github.com/pchote/OpenRA/releases/tag/devtest-20200202).