### PR TITLE
Add SupportDir argument to launch-dedicated.sh.

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -266,7 +266,7 @@ namespace OpenRA
 		static void Initialize(Arguments args)
 		{
 			var supportDirArg = args.GetValue("Engine.SupportDir", null);
-			if (supportDirArg != null)
+			if (!string.IsNullOrEmpty(supportDirArg))
 				Platform.OverrideSupportDir(supportDirArg);
 
 			Console.WriteLine("Platform is {0}", Platform.CurrentPlatform);

--- a/OpenRA.Server/Program.cs
+++ b/OpenRA.Server/Program.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Server
 		{
 			var arguments = new Arguments(args);
 			var supportDirArg = arguments.GetValue("Engine.SupportDir", null);
-			if (supportDirArg != null)
+			if (!string.IsNullOrEmpty(supportDirArg))
 				Platform.OverrideSupportDir(supportDirArg);
 
 			Log.AddChannel("debug", "dedicated-debug.log", true);

--- a/launch-dedicated.cmd
+++ b/launch-dedicated.cmd
@@ -18,8 +18,10 @@ set EnableSingleplayer=False
 set EnableSyncReports=False
 set ShareAnonymizedIPs=True
 
+set SupportDir=""
+
 :loop
 
-OpenRA.Server.exe Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.GeoIPDatabase=%GeoIPDatabase% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports% Server.ShareAnonymizedIPs=%ShareAnonymizedIPs%
+OpenRA.Server.exe Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.GeoIPDatabase=%GeoIPDatabase% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports% Server.ShareAnonymizedIPs=%ShareAnonymizedIPs% Engine.SupportDir=%SupportDir%
 
 goto loop

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -22,6 +22,8 @@ EnableSingleplayer="${EnableSingleplayer:-"False"}"
 EnableSyncReports="${EnableSyncReports:-"False"}"
 ShareAnonymizedIPs="${ShareAnonymizedIPs:-"True"}"
 
+SupportDir="${SupportDir:-""}"
+
 while true; do
      mono --debug OpenRA.Server.exe Game.Mod="$Mod" \
      Server.Name="$Name" \
@@ -34,5 +36,6 @@ while true; do
      Server.ProfileIDBlacklist="$ProfileIDBlacklist" \
      Server.ProfileIDWhitelist="$ProfileIDWhitelist" \
      Server.EnableSyncReports="$EnableSyncReports" \
-     Server.ShareAnonymizedIPs="$ShareAnonymizedIPs"
+     Server.ShareAnonymizedIPs="$ShareAnonymizedIPs" \
+     Engine.SupportDir="$SupportDir"
 done


### PR DESCRIPTION
Added in response to a discussion with @jaZzKCS in the community Discord - this should make life easier for server admins who want to host multiple servers with separate log directories from a single game install. May also be useful for @rmoriz's docker image.