### PR TITLE
Fix FreeActorWithDelivery not being properly conditional

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FreeActor.cs
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class FreeActor : ConditionalTrait<FreeActorInfo>
 	{
-		bool allowSpawn;
+		protected bool allowSpawn;
 
 		public FreeActor(ActorInitializer init, FreeActorInfo info)
 			: base(info)

--- a/OpenRA.Mods.Common/Traits/Buildings/FreeActorWithDelivery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/FreeActorWithDelivery.cs
@@ -36,18 +36,26 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new FreeActorWithDelivery(init, this); }
 	}
 
-	public class FreeActorWithDelivery
+	public class FreeActorWithDelivery : FreeActor
 	{
-		public readonly FreeActorWithDeliveryInfo Info;
-
+		readonly FreeActorWithDeliveryInfo info;
 		readonly Actor self;
 
 		public FreeActorWithDelivery(ActorInitializer init, FreeActorWithDeliveryInfo info)
+			: base(init, info)
 		{
 			self = init.Self;
-			Info = info;
+			this.info = info;
+		}
 
-			DoDelivery(self.Location + info.DeliveryOffset, info.Actor, info.DeliveringActor);
+		protected override void TraitEnabled(Actor self)
+		{
+			if (!allowSpawn)
+				return;
+
+			allowSpawn = info.AllowRespawn;
+
+			DoDelivery(self.Location + info.DeliveryOffset, Info.Actor, info.DeliveringActor);
 		}
 
 		public void DoDelivery(CPos location, string actorName, string carrierActorName)
@@ -61,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 			carryable.Reserve(cargo, carrier);
 
 			carrier.Trait<Carryall>().AttachCarryable(carrier, cargo);
-			carrier.QueueActivity(new DeliverUnit(carrier, Target.FromCell(self.World, location), Info.DeliveryRange));
+			carrier.QueueActivity(new DeliverUnit(carrier, Target.FromCell(self.World, location), info.DeliveryRange));
 			carrier.QueueActivity(new Fly(carrier, Target.FromCell(self.World, self.World.Map.ChooseRandomEdgeCell(self.World.SharedRandom))));
 			carrier.QueueActivity(new RemoveSelf());
 
@@ -71,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 		void CreateActors(string actorName, string deliveringActorName, out Actor cargo, out Actor carrier)
 		{
 			// Get a carryall spawn location
-			var location = Info.SpawnLocation;
+			var location = info.SpawnLocation;
 			if (location == CPos.Zero)
 				location = self.World.Map.ChooseClosestEdgeCell(self.Location);
 

--- a/OpenRA.Mods.D2k/Traits/Player/HarvesterInsurance.cs
+++ b/OpenRA.Mods.D2k/Traits/Player/HarvesterInsurance.cs
@@ -41,7 +41,8 @@ namespace OpenRA.Mods.D2k.Traits
 				return;
 
 			var delivery = refinery.Trait<FreeActorWithDelivery>();
-			delivery.DoDelivery(refinery.Location + delivery.Info.DeliveryOffset, delivery.Info.Actor, delivery.Info.DeliveringActor);
+			var deliveryInfo = delivery.Info as FreeActorWithDeliveryInfo;
+			delivery.DoDelivery(refinery.Location + deliveryInfo.DeliveryOffset, deliveryInfo.Actor, deliveryInfo.DeliveringActor);
 		}
 	}
 }


### PR DESCRIPTION
https://github.com/OpenRA/OpenRA/wiki/Traits#freeactorwithdelivery gives the impression `FreeActorWithDelivery` works with conditions while it does not.

Testcase is simply using the following on D2k (`vehicles.yaml`):
```diff
@@ -302,10 +302,19 @@ refinery:
 	FreeActorWithDelivery:
 		Actor: harvester
 		DeliveryOffset: 2,2
 		DeliveringActor: carryall.reinforce
 		Facing: 160
+		RequiresCondition: unfulfilled
+	FreeActorWithDelivery@2:
+		Actor: mcv
+		DeliveryOffset: 2,2
+		DeliveringActor: carryall.reinforce
+		Facing: 160
+		RequiresCondition: !unfulfilled
+	ExternalCondition:
+		Condition: unfulfilled
```

Without this PR both harvester and mcv will be delivered.

Reported by @KOYK on Discord.