### PR TITLE
Add extra MCV placement logic

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -37,7 +37,7 @@ namespace OpenRA.GameRules
 	{
 		public WeaponInfo Weapon;
 		public int[] DamageModifiers = { };
-		public WPos Source;
+		public WPos? Source;
 		public Actor SourceActor;
 		public Target WeaponTarget;
 

--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -203,12 +203,10 @@ namespace OpenRA.GameRules
 			var world = args.SourceActor.World;
 			foreach (var warhead in Warheads)
 			{
-				var wh = warhead; // force the closure to bind to the current warhead
-
-				if (wh.Delay > 0)
-			 		world.AddFrameEndTask(w => w.Add(new DelayedImpact(wh.Delay, wh, target, args)));
+				if (warhead.Delay > 0)
+					world.AddFrameEndTask(w => w.Add(new DelayedImpact(warhead.Delay, warhead, target, args)));
 				else
-					wh.DoImpact(target, args);
+					warhead.DoImpact(target, args);
 			}
 		}
 

--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -219,10 +219,12 @@ namespace OpenRA.GameRules
 			var args = new WarheadArgs
 			{
 				Weapon = this,
-				Source = firedBy.CenterPosition,
 				SourceActor = firedBy,
 				WeaponTarget = target
 			};
+
+			if (firedBy.OccupiesSpace != null)
+				args.Source = firedBy.CenterPosition;
 
 			Impact(target, args);
 		}

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -17,7 +17,7 @@ namespace OpenRA
 {
 	public interface IPlatform
 	{
-		IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int batchSize);
+		IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int batchSize, int videoDisplay);
 		ISoundEngine CreateSound(string device);
 		IFont CreateFont(byte[] data);
 	}
@@ -44,6 +44,8 @@ namespace OpenRA
 		float NativeWindowScale { get; }
 		float EffectiveWindowScale { get; }
 		Size SurfaceSize { get; }
+		int DisplayCount { get; }
+		int CurrentDisplay { get; }
 
 		event Action<float, float, float, float> OnWindowScaleChanged;
 

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -66,7 +66,7 @@ namespace OpenRA
 			this.platform = platform;
 			var resolution = GetResolution(graphicSettings);
 
-			Window = platform.CreateWindow(new Size(resolution.Width, resolution.Height), graphicSettings.Mode, graphicSettings.UIScale, graphicSettings.BatchSize);
+			Window = platform.CreateWindow(new Size(resolution.Width, resolution.Height), graphicSettings.Mode, graphicSettings.UIScale, graphicSettings.BatchSize, graphicSettings.VideoDisplay);
 			Context = Window.Context;
 
 			TempBufferSize = graphicSettings.BatchSize;
@@ -477,6 +477,16 @@ namespace OpenRA
 		public IFont CreateFont(byte[] data)
 		{
 			return platform.CreateFont(data);
+		}
+
+		public int DisplayCount
+		{
+			get { return Window.DisplayCount; }
+		}
+
+		public int CurrentDisplay
+		{
+			get { return Window.CurrentDisplay; }
 		}
 	}
 }

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -241,6 +241,9 @@ namespace OpenRA
 
 		public bool FetchNews = true;
 
+		[Desc("Version of introduction prompt that the player last viewed.")]
+		public int IntroductionPromptVersion = 0;
+
 		public MPGameFilters MPGameFilters = MPGameFilters.Waiting | MPGameFilters.Empty | MPGameFilters.Protected | MPGameFilters.Started;
 	}
 

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -176,6 +176,9 @@ namespace OpenRA
 		[Desc("Use OpenGL ES if both ES and regular OpenGL are available.")]
 		public bool PreferGLES = false;
 
+		[Desc("Display index to use in a multi-monitor fullscreen setup.")]
+		public int VideoDisplay = 0;
+
 		public int BatchSize = 8192;
 		public int SheetSize = 2048;
 

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -205,7 +205,7 @@ namespace OpenRA
 	{
 		[Desc("Sets the player nickname.")]
 		public string Name = "Commander";
-		public Color Color = Color.FromAhsl(75, 255, 180);
+		public Color Color = Color.FromArgb(200, 32, 32);
 		public string LastServer = "localhost:1234";
 		public Color[] CustomColors = { };
 	}

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -203,8 +203,8 @@ namespace OpenRA
 
 	public class PlayerSettings
 	{
-		[Desc("Sets the player nickname for in-game and IRC chat.")]
-		public string Name = "Newbie";
+		[Desc("Sets the player nickname.")]
+		public string Name = "Commander";
 		public Color Color = Color.FromAhsl(75, 255, 180);
 		public string LastServer = "localhost:1234";
 		public Color[] CustomColors = { };

--- a/OpenRA.Mods.Cnc/Activities/LayMines.cs
+++ b/OpenRA.Mods.Cnc/Activities/LayMines.cs
@@ -100,12 +100,17 @@ namespace OpenRA.Mods.Cnc.Activities
 			return true;
 		}
 
-		public void CleanPlacedMines(Actor self)
+		public void CleanMineField(Actor self)
 		{
 			// Remove cells that have already been mined
+			// or that are revealed to be unmineable.
 			if (minefield != null)
+			{
+				var positionable = (IPositionable)movement;
 				minefield.RemoveAll(c => self.World.ActorMap.GetActorsAt(c)
-					.Any(a => a.Info.Name == minelayer.Info.Mine.ToLowerInvariant()));
+					.Any(a => a.Info.Name == minelayer.Info.Mine.ToLowerInvariant()) ||
+						(!positionable.CanEnterCell(c, null, BlockedByActor.Immovable) && !self.World.FogObscures(c)));
+			}
 		}
 
 		public override IEnumerable<TargetLineNode> TargetLineNodes(Actor self)

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/AttackOrderPower.cs
@@ -45,6 +45,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override void Activate(Actor self, Order order, SupportPowerManager manager)
 		{
 			base.Activate(self, order, manager);
+			PlayLaunchSounds();
 
 			attack.AttackTarget(order.Target, AttackSource.Default, false, false, true);
 		}

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -70,6 +70,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		public override void Activate(Actor self, Order order, SupportPowerManager manager)
 		{
 			base.Activate(self, order, manager);
+			PlayLaunchSounds();
 
 			var info = (ChronoshiftPowerInfo)Info;
 			var targetDelta = self.World.Map.CellContaining(order.Target.CenterPosition) - order.ExtraLocation;

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/GpsPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/GpsPower.cs
@@ -79,9 +79,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			self.World.AddFrameEndTask(w =>
 			{
-				Game.Sound.PlayToPlayer(SoundType.World, self.Owner, Info.LaunchSound);
-				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech",
-					Info.LaunchSpeechNotification, self.Owner.Faction.InternalName);
+				PlayLaunchSounds();
 
 				w.Add(new SatelliteLaunch(self, info));
 			});

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -187,7 +187,7 @@ namespace OpenRA.Mods.Common.Activities
 			{
 				if (wasRepaired || isHostInvalid || (!stayOnResupplier && aircraft.Info.TakeOffOnResupply))
 				{
-					if (self.CurrentActivity.NextActivity == null && rp != null)
+					if (self.CurrentActivity.NextActivity == null && rp != null && rp.Path.Count > 0)
 						foreach (var cell in rp.Path)
 							QueueChild(move.MoveTo(cell, 1, ignoreActor: repairableNear != null ? null : host.Actor, targetLineColor: Color.Green));
 					else
@@ -208,7 +208,7 @@ namespace OpenRA.Mods.Common.Activities
 				// If there's a next activity and we're not RepairableNear, first leave host if the next activity is not a Move.
 				if (self.CurrentActivity.NextActivity == null)
 				{
-					if (rp != null)
+					if (rp != null && rp.Path.Count > 0)
 						foreach (var cell in rp.Path)
 							QueueChild(move.MoveTo(cell, 1, repairableNear != null ? null : host.Actor, true));
 					else if (repairableNear == null)

--- a/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
+++ b/OpenRA.Mods.Common/Effects/RallyPointIndicator.cs
@@ -73,6 +73,9 @@ namespace OpenRA.Mods.Common.Effects
 			foreach (var c in cachedLocations)
 				targetLineNodes.Add(world.Map.CenterOfCell(c));
 
+			if (targetLineNodes.Count == 0)
+				return;
+
 			var exitPos = building.CenterPosition;
 
 			// Find closest exit

--- a/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
@@ -121,6 +121,9 @@ namespace OpenRA.Mods.Common.LoadScreens
 				Game.Renderer.SetUIScale(1.0f);
 			}
 
+			// Saved settings may have been invalidated by a hardware change
+			Game.Settings.Graphics.VideoDisplay = Game.Renderer.CurrentDisplay;
+
 			// If a ModContent section is defined then we need to make sure that the
 			// required content is installed or switch to the defined content installer.
 			if (!ModData.Manifest.Contains<ModContent>())

--- a/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
@@ -79,8 +79,21 @@ namespace OpenRA.Mods.Common.Scripting
 		[Desc("Query or set a factory's rally point.")]
 		public CPos RallyPoint
 		{
-			get { return rp.Path.Last(); }
-			set { rp.Path = new List<CPos> { value }; }
+			get
+			{
+				if (rp.Path.Count > 0)
+					return rp.Path.Last();
+
+				var exit = Self.FirstExitOrDefault();
+				if (exit != null)
+					return Self.Location + exit.Info.ExitCell;
+
+				return Self.Location;
+			}
+			set
+			{
+				rp.Path = new List<CPos> { value };
+			}
 		}
 	}
 

--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -228,8 +228,10 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			foreach (var rp in world.ActorsWithTrait<RallyPoint>())
 			{
-				if (rp.Actor.Owner == player &&
-					!IsRallyPointValid(rp.Trait.Path[0], rp.Actor.Info.TraitInfoOrDefault<BuildingInfo>()))
+				if (rp.Actor.Owner != player)
+					continue;
+
+				if (rp.Trait.Path.Count == 0 || !IsRallyPointValid(rp.Trait.Path[0], rp.Actor.Info.TraitInfoOrDefault<BuildingInfo>()))
 				{
 					bot.QueueOrder(new Order("SetRallyPoint", rp.Actor, Target.FromCell(world, ChooseRallyLocationNear(rp.Actor)), false)
 					{

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -144,25 +144,17 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Only build MCV if the conyardCount + mcvCount are lower than the minimum conyard count.
 			var conyardCount = AIUtils.CountBuildingByCommonName(Info.ConstructionYardTypes, player);
-			if (conyardCount + mcvCount >= Info.MinimumConstructionYardCount)
+			if (conyardCount >= Info.MinimumConstructionYardCount)
 				return false;
 
 			// Only build MCV if there isn't already one being built.
-			var blds = player.World.ActorsWithTrait<ProductionQueue>()
+			var queues = player.World.ActorsWithTrait<ProductionQueue>()
 				.Where(a => a.Actor.Owner == player && Info.McvFactoryTypes.Contains(a.Actor.Info.Name) && a.Trait.Enabled)
 				.Select(a => a.Trait);
 
-			int queuedMcvCount = 0;
-			foreach (var factory in blds)
-			{
-				var q = factory.AllQueued().Where(z => Info.McvTypes.Contains(z.Item));
-
-				if (q != null)
-					queuedMcvCount += q.Count();
-			}
-
-			if (queuedMcvCount > 0)
-				return false;
+			foreach (var factory in queues)
+				if (factory.AllQueued().Any(z => Info.McvTypes.Contains(z.Item)))
+					return false;
 
 			return true;
 		}

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public CPos GetRandomBaseCenter(bool distanceToBaseIsImportant)
 		{
-			if (distanceToBaseIsImportant == false)
+			if (!distanceToBaseIsImportant)
 				return initialBaseCenter;
 
 			var tileset = world.Map.Rules.TileSet;
@@ -233,8 +233,7 @@ namespace OpenRA.Mods.Common.Traits
 			var actors = world.FindActorsInCircle(wPos, newBaseRadius)
 				.Where(a => !a.Disposed);
 
-			var enemies = actors.Where(a => player.Stances[a.Owner] == Stance.Enemy
-				&& a.Info.HasTraitInfo<BuildingInfo>());
+			var enemies = actors.Where(a => player.Stances[a.Owner] == Stance.Enemy);
 
 			if (enemies.Count() > 0)
 				return null;

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -132,14 +132,39 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool ShouldBuildMCV()
 		{
-			// Only build MCV if we don't already have one in the field.
-			var allowedToBuildMCV = AIUtils.CountActorByCommonName(Info.McvTypes, player) == 0;
-			if (!allowedToBuildMCV)
+			// Only build MCV if we have a factory to build it with.
+			var enoughFactories = AIUtils.CountBuildingByCommonName(Info.McvFactoryTypes, player) > 0;
+			if (!enoughFactories)
 				return false;
 
-			// Build MCV if we don't have the desired number of construction yards, unless we have no factory (can't build it).
-			return AIUtils.CountBuildingByCommonName(Info.ConstructionYardTypes, player) < Info.MinimumConstructionYardCount &&
-				AIUtils.CountBuildingByCommonName(Info.McvFactoryTypes, player) > 0;
+			// Only build MCV if we don't already have one in the field.
+			var mcvCount = AIUtils.CountActorByCommonName(Info.McvTypes, player);
+			if (mcvCount > 0)
+				return false;
+
+			// Only build MCV if the conyardCount + mcvCount are lower than the minimum conyard count.
+			var conyardCount = AIUtils.CountBuildingByCommonName(Info.ConstructionYardTypes, player);
+			if (conyardCount + mcvCount >= Info.MinimumConstructionYardCount)
+				return false;
+
+			// Only build MCV if there isn't already one being built.
+			var blds = player.World.ActorsWithTrait<ProductionQueue>()
+				.Where(a => a.Actor.Owner == player && Info.McvFactoryTypes.Contains(a.Actor.Info.Name) && a.Trait.Enabled)
+				.Select(a => a.Trait);
+
+			int queuedMcvCount = 0;
+			foreach (var factory in blds)
+			{
+				var q = factory.AllQueued().Where(z => Info.McvTypes.Contains(z.Item));
+
+				if (q != null)
+					queuedMcvCount += q.Count();
+			}
+
+			if (queuedMcvCount > 0)
+				return false;
+
+			return true;
 		}
 
 		void DeployMcvs(IBot bot, bool chooseLocation)

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -40,11 +40,11 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int MinBaseRadius = 2;
 
 		[Desc("Maximum distance in cells from center of the base when checking for MCV deployment location.",
-			"AI will not send MCVs to locations containing enemies within the MaxBaseRadius of that location.",
-			"AI will not send MCVs to locations containing its own MCVs or construction yards within the MaxBaseRadius of that location.",
-			"In the case of less than 1 construction yard, the AI will choose a random new base center and place the MCV within the MaxBaseRadius of that location.",
-			"In the case of at least 1 construction yard, the AI will choose a location nearer resource fields outside of all bases MaxBaseRadius up to world.Map.Grid.MaximumTileSearchRange.")]
+			"Only applies if RestrictMCVDeploymentFallbackToBase is enabled and there's at least one construction yard.")]
 		public readonly int MaxBaseRadius = 20;
+
+		[Desc("Should deployment of additional MCVs be restricted to MaxBaseRadius if explicit deploy locations are missing or occupied?")]
+		public readonly bool RestrictMCVDeploymentFallbackToBase = true;
 
 		public override object Create(ActorInitializer init) { return new McvManagerBotModule(init.Self, this); }
 	}
@@ -236,7 +236,8 @@ namespace OpenRA.Mods.Common.Traits
 
 			var baseCenter = GetRandomBaseCenter(distanceToBaseIsImportant);
 
-			var bc = findPos(baseCenter, baseCenter, Info.MinBaseRadius, Info.MaxBaseRadius);
+			var bc = findPos(baseCenter, baseCenter, Info.MinBaseRadius,
+				distanceToBaseIsImportant ? Info.MaxBaseRadius : world.Map.Grid.MaximumTileSearchRange);
 
 			if (!bc.HasValue)
 				return null;

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -40,11 +40,11 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int MinBaseRadius = 2;
 
 		[Desc("Maximum distance in cells from center of the base when checking for MCV deployment location.",
-			"Only applies if RestrictMCVDeploymentFallbackToBase is enabled and there's at least one construction yard.")]
+			"AI will not send MCVs to locations containing enemies within the MaxBaseRadius of that location.",
+			"AI will not send MCVs to locations containing its own MCVs or construction yards within the MaxBaseRadius of that location.",
+			"In the case of less than 1 construction yard, the AI will choose a random new base center and place the MCV within the MaxBaseRadius of that location.",
+			"In the case of at least 1 construction yard, the AI will choose a location nearer resource fields outside of all bases MaxBaseRadius up to world.Map.Grid.MaximumTileSearchRange.")]
 		public readonly int MaxBaseRadius = 20;
-
-		[Desc("Should deployment of additional MCVs be restricted to MaxBaseRadius if explicit deploy locations are missing or occupied?")]
-		public readonly bool RestrictMCVDeploymentFallbackToBase = true;
 
 		public override object Create(ActorInitializer init) { return new McvManagerBotModule(init.Self, this); }
 	}
@@ -236,8 +236,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			var baseCenter = GetRandomBaseCenter(distanceToBaseIsImportant);
 
-			var bc = findPos(baseCenter, baseCenter, Info.MinBaseRadius,
-				distanceToBaseIsImportant ? Info.MaxBaseRadius : world.Map.Grid.MaximumTileSearchRange);
+			var bc = findPos(baseCenter, baseCenter, Info.MinBaseRadius, Info.MaxBaseRadius);
 
 			if (!bc.HasValue)
 				return null;

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -57,9 +57,8 @@ namespace OpenRA.Mods.Common.Traits
 				return initialBaseCenter;
 
 			var tileset = world.Map.Rules.TileSet;
-			BitArray resourceTypeIndices;
+			var resourceTypeIndices = new BitArray(tileset.TerrainInfo.Length);
 
-			resourceTypeIndices = new BitArray(tileset.TerrainInfo.Length);
 			foreach (var t in world.Map.Rules.Actors["world"].TraitInfos<ResourceTypeInfo>())
 				resourceTypeIndices.Set(tileset.GetTerrainIndex(t.TerrainType), true);
 
@@ -218,9 +217,9 @@ namespace OpenRA.Mods.Common.Traits
 				return null;
 			};
 
-			CPos baseCenter = GetRandomBaseCenter(distanceToBaseIsImportant);
+			var baseCenter = GetRandomBaseCenter(distanceToBaseIsImportant);
 
-			CPos? bc = findPos(baseCenter, baseCenter, Info.MinBaseRadius,
+			var bc = findPos(baseCenter, baseCenter, Info.MinBaseRadius,
 				distanceToBaseIsImportant ? Info.MaxBaseRadius : world.Map.Grid.MaximumTileSearchRange);
 
 			if (!bc.HasValue)
@@ -228,17 +227,19 @@ namespace OpenRA.Mods.Common.Traits
 
 			baseCenter = bc.Value;
 
-			WPos wPos = world.Map.CenterOfCell(bc.Value);
-			WDist newBaseRadius = new WDist(Info.MaxBaseRadius * 1024);
+			var wPos = world.Map.CenterOfCell(baseCenter);
+			var newBaseRadius = new WDist(Info.MaxBaseRadius * 1024);
 
-			var enemies = world.FindActorsInCircle(wPos, newBaseRadius)
-				.Where(a => !a.Disposed && player.Stances[a.Owner] == Stance.Enemy && a.Info.HasTraitInfo<BuildingInfo>());
+			var actors = world.FindActorsInCircle(wPos, newBaseRadius)
+				.Where(a => !a.Disposed);
+
+			var enemies = actors.Where(a => player.Stances[a.Owner] == Stance.Enemy
+				&& a.Info.HasTraitInfo<BuildingInfo>());
 
 			if (enemies.Count() > 0)
 				return null;
 
-			var self = world.FindActorsInCircle(wPos, newBaseRadius)
-				.Where(a => !a.Disposed && a.Owner == player
+			var self = actors.Where(a => a.Owner == player
 					&& (Info.McvTypes.Contains(a.Info.Name) || (Info.ConstructionYardTypes.Contains(a.Info.Name) && a.Info.HasTraitInfo<BuildingInfo>())));
 
 			if (self.Count() > 0)

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -51,13 +51,27 @@ namespace OpenRA.Mods.Common.Traits
 
 	public class McvManagerBotModule : ConditionalTrait<McvManagerBotModuleInfo>, IBotTick, IBotPositionsUpdated, IGameSaveTraitData
 	{
-		public CPos GetRandomBaseCenter()
+		public CPos GetRandomBaseCenter(bool distanceToBaseIsImportant)
 		{
+			if (distanceToBaseIsImportant == false)
+				return initialBaseCenter;
+
+			var tileset = world.Map.Rules.TileSet;
+			BitArray resourceTypeIndices;
+
+			resourceTypeIndices = new BitArray(tileset.TerrainInfo.Length);
+			foreach (var t in world.Map.Rules.Actors["world"].TraitInfos<ResourceTypeInfo>())
+				resourceTypeIndices.Set(tileset.GetTerrainIndex(t.TerrainType), true);
+
 			var randomConstructionYard = world.Actors.Where(a => a.Owner == player &&
 				Info.ConstructionYardTypes.Contains(a.Info.Name))
 				.RandomOrDefault(world.LocalRandom);
 
-			return randomConstructionYard != null ? randomConstructionYard.Location : initialBaseCenter;
+			var newResources = world.Map.FindTilesInAnnulus(randomConstructionYard.Location, Info.MaxBaseRadius, world.Map.Grid.MaximumTileSearchRange)
+				.Where(a => resourceTypeIndices.Get(world.Map.GetTerrainIndex(a)))
+				.Shuffle(world.LocalRandom).FirstOrDefault();
+
+			return newResources;
 		}
 
 		readonly World world;
@@ -157,7 +171,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (move)
 			{
 				// If we lack a base, we need to make sure we don't restrict deployment of the MCV to the base!
-				var restrictToBase = Info.RestrictMCVDeploymentFallbackToBase && AIUtils.CountBuildingByCommonName(Info.ConstructionYardTypes, player) > 0;
+				var restrictToBase = AIUtils.CountBuildingByCommonName(Info.ConstructionYardTypes, player) > 0;
 
 				var transformsInfo = mcv.Info.TraitInfo<TransformsInfo>();
 				var desiredLocation = ChooseMcvDeployLocation(transformsInfo.IntoActor, transformsInfo.Offset, restrictToBase);
@@ -204,10 +218,33 @@ namespace OpenRA.Mods.Common.Traits
 				return null;
 			};
 
-			var baseCenter = GetRandomBaseCenter();
+			CPos baseCenter = GetRandomBaseCenter(distanceToBaseIsImportant);
 
-			return findPos(baseCenter, baseCenter, Info.MinBaseRadius,
+			CPos? bc = findPos(baseCenter, baseCenter, Info.MinBaseRadius,
 				distanceToBaseIsImportant ? Info.MaxBaseRadius : world.Map.Grid.MaximumTileSearchRange);
+
+			if (!bc.HasValue)
+				return null;
+
+			baseCenter = bc.Value;
+
+			WPos wPos = world.Map.CenterOfCell(bc.Value);
+			WDist newBaseRadius = new WDist(Info.MaxBaseRadius * 1024);
+
+			var enemies = world.FindActorsInCircle(wPos, newBaseRadius)
+				.Where(a => !a.Disposed && player.Stances[a.Owner] == Stance.Enemy && a.Info.HasTraitInfo<BuildingInfo>());
+
+			if (enemies.Count() > 0)
+				return null;
+
+			var self = world.FindActorsInCircle(wPos, newBaseRadius)
+				.Where(a => !a.Disposed && a.Owner == player
+					&& (Info.McvTypes.Contains(a.Info.Name) || (Info.ConstructionYardTypes.Contains(a.Info.Name) && a.Info.HasTraitInfo<BuildingInfo>())));
+
+			if (self.Count() > 0)
+				return null;
+
+			return baseCenter;
 		}
 
 		List<MiniYamlNode> IGameSaveTraitData.IssueTraitData(Actor self)

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -39,7 +39,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = true;
 
-		public readonly CVec Offset = new CVec(1, 3);
+		[Desc("A list of 0 or more offsets defining the initial rally point path.")]
+		public readonly CVec[] Path = { new CVec(1, 3) };
 
 		public object Create(ActorInitializer init) { return new RallyPoint(init.Self, this); }
 	}
@@ -57,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public void ResetPath(Actor self)
 		{
-			Path = new List<CPos> { self.Location + Info.Offset };
+			Path = Info.Path.Select(p => self.Location + p).ToList();
 		}
 
 		public RallyPoint(Actor self, RallyPointInfo info)

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool IsPlayerPalette = true;
 
 		[Desc("A list of 0 or more offsets defining the initial rally point path.")]
-		public readonly CVec[] Path = { new CVec(1, 3) };
+		public readonly CVec[] Path = { };
 
 		public object Create(ActorInitializer init) { return new RallyPoint(init.Self, this); }
 	}

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -560,7 +560,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!self.IsAtGroundLevel())
 				return;
 
-			var actors = self.World.ActorMap.GetActorsAt(ToCell).Where(a => a != self).ToList();
+			var actors = self.World.ActorMap.GetActorsAt(ToCell, ToSubCell).Where(a => a != self).ToList();
 			if (!AnyCrushables(actors))
 				return;
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -636,7 +636,7 @@ namespace OpenRA.Mods.Common.Traits
 			return new ReturnToCellActivity(self);
 		}
 
-		class ReturnToCellActivity : Activity
+		public class ReturnToCellActivity : Activity
 		{
 			readonly Mobile mobile;
 			readonly bool recalculateSubCell;

--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -10,7 +10,11 @@
 #endregion
 
 using System.Collections.Generic;
+using System.Linq;
+using OpenRA;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits.Render;
+using OpenRA.Primitives;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -64,8 +68,12 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool armyGraphDisabled;
 		bool incomeGraphDisabled;
+		public readonly Cache<string, ArmyUnit> Units;
 
-		public PlayerStatistics(Actor self) { }
+		public PlayerStatistics(Actor self)
+		{
+			Units = new Cache<string, ArmyUnit>(name => new ArmyUnit(self.World.Map.Rules.Actors[name], self.Owner));
+		}
 
 		void INotifyCreated.Created(Actor self)
 		{
@@ -151,28 +159,74 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
+	public class ArmyUnit
+	{
+		public readonly ActorInfo ActorInfo;
+		public readonly Animation Icon;
+		public readonly string IconPalette;
+		public readonly int ProductionQueueOrder;
+		public readonly int BuildPaletteOrder;
+		public readonly TooltipInfo TooltipInfo;
+		public readonly BuildableInfo BuildableInfo;
+
+		public int Count { get; set; }
+
+		public ArmyUnit(ActorInfo actorInfo, Player owner)
+		{
+			ActorInfo = actorInfo;
+
+			var queues = owner.World.Map.Rules.Actors.Values
+				.SelectMany(a => a.TraitInfos<ProductionQueueInfo>());
+
+			BuildableInfo = actorInfo.TraitInfoOrDefault<BuildableInfo>();
+			TooltipInfo = actorInfo.TraitInfos<TooltipInfo>().FirstOrDefault(info => info.EnabledByDefault);
+
+			ProductionQueueOrder = queues.Where(q => BuildableInfo.Queue.Contains(q.Type))
+				.Select(q => q.DisplayOrder)
+				.MinByOrDefault(o => o);
+
+			var rsi = actorInfo.TraitInfoOrDefault<RenderSpritesInfo>();
+
+			if (BuildableInfo != null && rsi != null)
+			{
+				var image = rsi.GetImage(actorInfo, owner.World.Map.Rules.Sequences, owner.Faction.Name);
+				Icon = new Animation(owner.World, image);
+				Icon.Play(BuildableInfo.Icon);
+				IconPalette = BuildableInfo.IconPalette;
+				BuildPaletteOrder = BuildableInfo.BuildPaletteOrder;
+			}
+		}
+	}
+
 	[Desc("Attach this to a unit to update observer stats.")]
 	public class UpdatesPlayerStatisticsInfo : ITraitInfo
 	{
 		[Desc("Add to army value in statistics")]
 		public bool AddToArmyValue = false;
 
+		[ActorReference]
+		[Desc("Count this actor as a different type in the spectator army display.")]
+		public string OverrideActor = null;
+
 		public object Create(ActorInitializer init) { return new UpdatesPlayerStatistics(this, init.Self); }
 	}
 
 	public class UpdatesPlayerStatistics : INotifyKilled, INotifyCreated, INotifyOwnerChanged, INotifyActorDisposing
 	{
-		UpdatesPlayerStatisticsInfo info;
+		readonly UpdatesPlayerStatisticsInfo info;
+		readonly string actorName;
+		readonly int cost = 0;
+
 		PlayerStatistics playerStats;
-		int cost = 0;
 		bool includedInArmyValue = false;
 
 		public UpdatesPlayerStatistics(UpdatesPlayerStatisticsInfo info, Actor self)
 		{
 			this.info = info;
-			if (self.Info.HasTraitInfo<ValuedInfo>())
-				cost = self.Info.TraitInfo<ValuedInfo>().Cost;
+			var valuedInfo = self.Info.TraitInfoOrDefault<ValuedInfo>();
+			cost = valuedInfo != null ? valuedInfo.Cost : 0;
 			playerStats = self.Owner.PlayerActor.Trait<PlayerStatistics>();
+			actorName = info.OverrideActor ?? self.Info.Name;
 		}
 
 		void INotifyKilled.Killed(Actor self, AttackInfo e)
@@ -199,14 +253,19 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				defenderStats.ArmyValue -= cost;
 				includedInArmyValue = false;
+				playerStats.Units[actorName].Count--;
 			}
 		}
 
 		void INotifyCreated.Created(Actor self)
 		{
 			includedInArmyValue = info.AddToArmyValue;
+
 			if (includedInArmyValue)
+			{
 				playerStats.ArmyValue += cost;
+				playerStats.Units[actorName].Count++;
+			}
 		}
 
 		void INotifyOwnerChanged.OnOwnerChanged(Actor self, Player oldOwner, Player newOwner)
@@ -216,6 +275,8 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				playerStats.ArmyValue -= cost;
 				newOwnerStats.ArmyValue += cost;
+				playerStats.Units[actorName].Count--;
+				newOwnerStats.Units[actorName].Count++;
 			}
 
 			playerStats = newOwnerStats;
@@ -227,6 +288,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				playerStats.ArmyValue -= cost;
 				includedInArmyValue = false;
+				playerStats.Units[actorName].Count--;
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -69,7 +69,7 @@ namespace OpenRA.Mods.Common.Traits
 						initialFacing = delta.Yaw.Facing;
 				}
 
-				exitLocations = rp.Value != null ? rp.Value.Path : new List<CPos> { exit };
+				exitLocations = rp.Value != null && rp.Value.Path.Count > 0 ? rp.Value.Path : new List<CPos> { exit };
 
 				td.Add(new LocationInit(exit));
 				td.Add(new CenterPositionInit(spawn));

--- a/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionFromMapEdge.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 			var aircraftInfo = producee.TraitInfoOrDefault<AircraftInfo>();
 			var mobileInfo = producee.TraitInfoOrDefault<MobileInfo>();
 
-			var destinations = rp != null ? rp.Path : new List<CPos> { self.Location };
+			var destinations = rp != null && rp.Path.Count > 0 ? rp.Path : new List<CPos> { self.Location };
 
 			var location = spawnLocation;
 			if (!location.HasValue)

--- a/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionParadrop.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				var initialFacing = exitinfo.Facing < 0 ? (to - spawn).Yaw.Facing : exitinfo.Facing;
 
-				exitLocations = rp.Value != null ? rp.Value.Path : new List<CPos> { exit };
+				exitLocations = rp.Value != null && rp.Value.Path.Count > 0 ? rp.Value.Path : new List<CPos> { exit };
 
 				td.Add(new LocationInit(exit));
 				td.Add(new CenterPositionInit(spawn));

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
@@ -40,6 +40,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		readonly Animation door;
 		int desiredFrame;
 		CPos openExit;
+		Actor exitingActor;
 
 		public WithProductionDoorOverlay(Actor self, WithProductionDoorOverlayInfo info)
 			: base(info)
@@ -57,8 +58,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		void ITick.Tick(Actor self)
 		{
-			if (desiredFrame > 0 && !self.World.ActorMap.GetActorsAt(openExit).Any(a => a != self))
+			if (exitingActor == null)
+				return;
+
+			if (!exitingActor.IsInWorld || exitingActor.Location != openExit || !(exitingActor.CurrentActivity is Mobile.ReturnToCellActivity))
+			{
 				desiredFrame = 0;
+				exitingActor = null;
+			}
 		}
 
 		void INotifyDamageStateChanged.DamageStateChanged(Actor self, AttackInfo e)
@@ -70,6 +77,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		void INotifyProduction.UnitProduced(Actor self, Actor other, CPos exit)
 		{
 			openExit = exit;
+			exitingActor = other;
 			desiredFrame = door.CurrentSequence.Length - 1;
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/GrantExternalConditionPower.cs
@@ -68,6 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override void Activate(Actor self, Order order, SupportPowerManager manager)
 		{
 			base.Activate(self, order, manager);
+			PlayLaunchSounds();
 
 			var wsb = self.TraitOrDefault<WithSpriteBody>();
 			if (wsb != null && wsb.DefaultAnimation.HasSequence(info.Sequence))

--- a/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/ProduceActorPower.cs
@@ -58,6 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override void Activate(Actor self, Order order, SupportPowerManager manager)
 		{
 			base.Activate(self, order, manager);
+			PlayLaunchSounds();
 
 			var info = Info as ProduceActorPowerInfo;
 			var producers = self.World.ActorsWithTrait<Production>()

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -282,8 +282,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (check <= BlockedByActor.Immovable && !cellCache.Immovable.Overlaps(actor.Owner.PlayerMask))
 				return true;
 
-			// Cache doesn't account for ignored actors or temporary blockers - these must use the slow path.
-			if (ignoreActor == null && !cellFlag.HasCellFlag(CellFlag.HasTemporaryBlocker))
+			// Cache doesn't account for ignored actors, temporary blockers, or subcells - these must use the slow path.
+			if (ignoreActor == null && !cellFlag.HasCellFlag(CellFlag.HasTemporaryBlocker) && subCell == SubCell.FullCell)
 			{
 				// We already know there are uncrushable actors in the cell so we are always blocked.
 				if (check == BlockedByActor.All)

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20191117/RenameRallyPointPath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20191117/RenameRallyPointPath.cs
@@ -1,0 +1,35 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	class RenameRallyPointPath : UpdateRule
+	{
+		public override string Name { get { return "Renamed RallyPoint Offset to Path"; } }
+		public override string Description
+		{
+			get
+			{
+				return "The RallyPoint Offset property has been renamed to Path and now accepts multiple (or no) values.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var rp in actorNode.ChildrenMatching("RallyPoint"))
+				rp.RenameChildrenMatching("Offset", "Path");
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20191117/ReplaceAttackTypeStrafe.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20191117/ReplaceAttackTypeStrafe.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 					yield break;
 
 				var attackType = attackAircraft.LastChildMatching("AttackType");
-				if (attackType.NodeValue<AirAttackType>() == AirAttackType.Strafe)
+				if (attackType != null && attackType.NodeValue<AirAttackType>() == AirAttackType.Strafe)
 					attackAircraft.RemoveNode(attackType);
 
 				attackAircraft.RemoveNodes("AttackTurnDelay");

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -98,6 +98,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new ReformatChromeProvider(),
 				new RenameSpins(),
 				new CreateScreenShakeWarhead(),
+				new RenameRallyPointPath(),
 			})
 		};
 

--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var image = ChromeProvider.GetImage("scrollbar", IsDisabled() ? "down_pressed" : "down_arrow");
 			var rb = RenderBounds;
 
-			WidgetUtils.DrawRGBA(image, stateOffset + new float2(rb.Right - rb.Height + 5, rb.Top + (rb.Height - image.Bounds.Height) / 2));
+			WidgetUtils.DrawRGBA(image, stateOffset + new float2((rb.Right - (rb.Height + image.Bounds.Width) / 2), rb.Top + (rb.Height - image.Bounds.Height) / 2));
 
 			var separator = ChromeProvider.GetImage(SeparatorCollection, SeparatorImage);
 			WidgetUtils.DrawRGBA(separator, new float2(-3, 0) + new float2(rb.Right - rb.Height + 4, rb.Top + (rb.Height - separator.Bounds.Height) / 2));

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ArmyTooltipLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ArmyTooltipLogic.cs
@@ -1,0 +1,67 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Linq;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+	public class ArmyTooltipLogic : ChromeLogic
+	{
+		[ObjectCreator.UseCtor]
+		public ArmyTooltipLogic(Widget widget, TooltipContainerWidget tooltipContainer, Func<ArmyUnit> getTooltipUnit)
+		{
+			widget.IsVisible = () => getTooltipUnit() != null;
+			var nameLabel = widget.Get<LabelWidget>("NAME");
+			var descLabel = widget.Get<LabelWidget>("DESC");
+
+			var font = Game.Renderer.Fonts[nameLabel.Font];
+			var descFont = Game.Renderer.Fonts[descLabel.Font];
+
+			ArmyUnit lastArmyUnit = null;
+			var descLabelPadding = descLabel.Bounds.Height;
+
+			tooltipContainer.BeforeRender = () =>
+			{
+				var armyUnit = getTooltipUnit();
+
+				if (armyUnit == null || armyUnit == lastArmyUnit)
+					return;
+
+				var tooltip = armyUnit.TooltipInfo;
+				var name = tooltip != null ? tooltip.Name : armyUnit.ActorInfo.Name;
+				var buildable = armyUnit.BuildableInfo;
+
+				nameLabel.Text = name;
+
+				var nameSize = font.Measure(name);
+
+				descLabel.Text = buildable.Description.Replace("\\n", "\n");
+				var descSize = descFont.Measure(descLabel.Text);
+				descLabel.Bounds.Width = descSize.X;
+				descLabel.Bounds.Height = descSize.Y + descLabelPadding;
+
+				var leftWidth = Math.Max(nameSize.X, descSize.X);
+
+				widget.Bounds.Width = leftWidth + 2 * nameLabel.Bounds.X;
+
+				// Set the bottom margin to match the left margin
+				var leftHeight = descLabel.Bounds.Bottom + descLabel.Bounds.X;
+
+				widget.Bounds.Height = leftHeight;
+
+				lastArmyUnit = armyUnit;
+			};
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/ObserverStatsLogic.cs
@@ -21,9 +21,9 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	public enum ObserverStatsPanel { None, Basic, Economy, Production, SupportPowers, Combat, Graph, ArmyGraph }
+	public enum ObserverStatsPanel { None, Basic, Economy, Production, SupportPowers, Combat, Army, Graph, ArmyGraph }
 
-	[ChromeLogicArgsHotkeys("StatisticsBasicKey", "StatisticsEconomyKey", "StatisticsProductionKey", "StatisticsSupportPowersKey", "StatisticsCombatKey", "StatisticsGraphKey",
+	[ChromeLogicArgsHotkeys("StatisticsBasicKey", "StatisticsEconomyKey", "StatisticsProductionKey", "StatisticsSupportPowersKey", "StatisticsCombatKey", "StatisticsArmyKey", "StatisticsGraphKey",
 		"StatisticsArmyGraphKey")]
 	public class ObserverStatsLogic : ChromeLogic
 	{
@@ -32,11 +32,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		readonly ContainerWidget productionStatsHeaders;
 		readonly ContainerWidget supportPowerStatsHeaders;
 		readonly ContainerWidget combatStatsHeaders;
+		readonly ContainerWidget armyHeaders;
 		readonly ScrollPanelWidget playerStatsPanel;
 		readonly ScrollItemWidget basicPlayerTemplate;
 		readonly ScrollItemWidget economyPlayerTemplate;
 		readonly ScrollItemWidget productionPlayerTemplate;
 		readonly ScrollItemWidget supportPowersPlayerTemplate;
+		readonly ScrollItemWidget armyPlayerTemplate;
 		readonly ScrollItemWidget combatPlayerTemplate;
 		readonly ContainerWidget incomeGraphContainer;
 		readonly ContainerWidget armyValueGraphContainer;
@@ -72,6 +74,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			economyStatsHeaders = widget.Get<ContainerWidget>("ECONOMY_STATS_HEADERS");
 			productionStatsHeaders = widget.Get<ContainerWidget>("PRODUCTION_STATS_HEADERS");
 			supportPowerStatsHeaders = widget.Get<ContainerWidget>("SUPPORT_POWERS_HEADERS");
+			armyHeaders = widget.Get<ContainerWidget>("ARMY_HEADERS");
 			combatStatsHeaders = widget.Get<ContainerWidget>("COMBAT_STATS_HEADERS");
 
 			playerStatsPanel = widget.Get<ScrollPanelWidget>("PLAYER_STATS_PANEL");
@@ -87,12 +90,14 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				AdjustHeader(productionStatsHeaders);
 				AdjustHeader(supportPowerStatsHeaders);
 				AdjustHeader(combatStatsHeaders);
+				AdjustHeader(armyHeaders);
 			}
 
 			basicPlayerTemplate = playerStatsPanel.Get<ScrollItemWidget>("BASIC_PLAYER_TEMPLATE");
 			economyPlayerTemplate = playerStatsPanel.Get<ScrollItemWidget>("ECONOMY_PLAYER_TEMPLATE");
 			productionPlayerTemplate = playerStatsPanel.Get<ScrollItemWidget>("PRODUCTION_PLAYER_TEMPLATE");
 			supportPowersPlayerTemplate = playerStatsPanel.Get<ScrollItemWidget>("SUPPORT_POWERS_PLAYER_TEMPLATE");
+			armyPlayerTemplate = playerStatsPanel.Get<ScrollItemWidget>("ARMY_PLAYER_TEMPLATE");
 			combatPlayerTemplate = playerStatsPanel.Get<ScrollItemWidget>("COMBAT_PLAYER_TEMPLATE");
 
 			incomeGraphContainer = widget.Get<ContainerWidget>("INCOME_GRAPH_CONTAINER");
@@ -144,6 +149,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				createStatsOption("Production", ObserverStatsPanel.Production, productionPlayerTemplate, () => DisplayStats(ProductionStats)),
 				createStatsOption("Support Powers", ObserverStatsPanel.SupportPowers, supportPowersPlayerTemplate, () => DisplayStats(SupportPowerStats)),
 				createStatsOption("Combat", ObserverStatsPanel.Combat, combatPlayerTemplate, () => DisplayStats(CombatStats)),
+				createStatsOption("Army", ObserverStatsPanel.Army, armyPlayerTemplate, () => DisplayStats(ArmyStats)),
 				createStatsOption("Earnings (graph)", ObserverStatsPanel.Graph, null, () => IncomeGraph()),
 				createStatsOption("Army (graph)", ObserverStatsPanel.ArmyGraph, null, () => ArmyValueGraph()),
 			};
@@ -157,7 +163,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			var statsDropDownPanelTemplate = logicArgs.TryGetValue("StatsDropDownPanelTemplate", out yaml) ? yaml.Value : "LABEL_DROPDOWN_TEMPLATE";
 
-			statsDropDown.OnMouseDown = _ => statsDropDown.ShowDropDown(statsDropDownPanelTemplate, 205, statsDropDownOptions, setupItem);
+			statsDropDown.OnMouseDown = _ => statsDropDown.ShowDropDown(statsDropDownPanelTemplate, 230, statsDropDownOptions, setupItem);
 			statsDropDownOptions[0].OnClick();
 
 			var keyListener = statsDropDown.Get<LogicKeyListenerWidget>("STATS_DROPDOWN_KEYHANDLER");
@@ -190,6 +196,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			economyStatsHeaders.Visible = false;
 			productionStatsHeaders.Visible = false;
 			supportPowerStatsHeaders.Visible = false;
+			armyHeaders.Visible = false;
 			combatStatsHeaders.Visible = false;
 
 			incomeGraphContainer.Visible = false;
@@ -338,6 +345,27 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			SetupPlayerColor(player, template, playerColor, playerGradient);
 
 			template.Get<ObserverSupportPowerIconsWidget>("SUPPORT_POWER_ICONS").GetPlayer = () => player;
+			template.IgnoreChildMouseOver = false;
+
+			return template;
+		}
+
+		ScrollItemWidget ArmyStats(Player player)
+		{
+			armyHeaders.Visible = true;
+			var template = SetupPlayerScrollItemWidget(armyPlayerTemplate, player);
+
+			AddPlayerFlagAndName(template, player);
+
+			var playerName = template.Get<LabelWidget>("PLAYER");
+			playerName.GetColor = () => Color.White;
+
+			var playerColor = template.Get<ColorBlockWidget>("PLAYER_COLOR");
+			var playerGradient = template.Get<GradientColorBlockWidget>("PLAYER_GRADIENT");
+
+			SetupPlayerColor(player, template, playerColor, playerGradient);
+
+			template.Get<ObserverArmyIconsWidget>("ARMY_ICONS").GetPlayer = () => player;
 			template.IgnoreChildMouseOver = false;
 
 			return template;

--- a/OpenRA.Mods.Common/Widgets/Logic/IntroductionPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/IntroductionPromptLogic.cs
@@ -1,0 +1,147 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using OpenRA.Graphics;
+using OpenRA.Primitives;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+	public class IntroductionPromptLogic : ChromeLogic
+	{
+		// Increment the version number when adding new stats
+		const int IntroductionVersion = 1;
+
+		public static bool ShouldShowPrompt()
+		{
+			return Game.Settings.Game.IntroductionPromptVersion < IntroductionVersion;
+		}
+
+		[ObjectCreator.UseCtor]
+		public IntroductionPromptLogic(Widget widget, ModData modData, WorldRenderer worldRenderer, Action onComplete)
+		{
+			var ps = Game.Settings.Player;
+			var ds = Game.Settings.Graphics;
+			var gs = Game.Settings.Game;
+
+			var escPressed = false;
+			var nameTextfield = widget.Get<TextFieldWidget>("PLAYERNAME");
+			nameTextfield.IsDisabled = () => worldRenderer.World.Type != WorldType.Shellmap;
+			nameTextfield.Text = Settings.SanitizedPlayerName(ps.Name);
+			nameTextfield.OnLoseFocus = () =>
+			{
+				if (escPressed)
+				{
+					escPressed = false;
+					return;
+				}
+
+				nameTextfield.Text = nameTextfield.Text.Trim();
+				if (nameTextfield.Text.Length == 0)
+					nameTextfield.Text = Settings.SanitizedPlayerName(ps.Name);
+				else
+				{
+					nameTextfield.Text = Settings.SanitizedPlayerName(nameTextfield.Text);
+					ps.Name = nameTextfield.Text;
+				}
+			};
+
+			nameTextfield.OnEnterKey = () => { nameTextfield.YieldKeyboardFocus(); return true; };
+			nameTextfield.OnEscKey = () =>
+			{
+				nameTextfield.Text = Settings.SanitizedPlayerName(ps.Name);
+				escPressed = true;
+				nameTextfield.YieldKeyboardFocus();
+				return true;
+			};
+
+			var colorPreview = widget.Get<ColorPreviewManagerWidget>("COLOR_MANAGER");
+			colorPreview.Color = ps.Color;
+
+			var mouseControlDescClassic = widget.Get("MOUSE_CONTROL_DESC_CLASSIC");
+			mouseControlDescClassic.IsVisible = () => gs.UseClassicMouseStyle;
+
+			var classicScrollRight = mouseControlDescClassic.Get("DESC_SCROLL_RIGHT");
+			classicScrollRight.IsVisible = () => !gs.ClassicMouseMiddleScroll;
+
+			var classicScrollMiddle = mouseControlDescClassic.Get("DESC_SCROLL_MIDDLE");
+			classicScrollMiddle.IsVisible = () => gs.ClassicMouseMiddleScroll;
+
+			var mouseControlDescModern = widget.Get("MOUSE_CONTROL_DESC_MODERN");
+			mouseControlDescModern.IsVisible = () => !gs.UseClassicMouseStyle;
+
+			var mouseControlDropdown = widget.Get<DropDownButtonWidget>("MOUSE_CONTROL_DROPDOWN");
+			mouseControlDropdown.OnMouseDown = _ => SettingsLogic.ShowMouseControlDropdown(mouseControlDropdown, gs);
+			mouseControlDropdown.GetText = () => gs.UseClassicMouseStyle ? "Classic" : "Modern";
+
+			foreach (var container in new[] { mouseControlDescClassic, mouseControlDescModern })
+			{
+				var zoomDesc = container.Get("DESC_ZOOM");
+				zoomDesc.IsVisible = () => gs.ZoomModifier == Modifiers.None;
+
+				var zoomDescModifier = container.Get<LabelWidget>("DESC_ZOOM_MODIFIER");
+				zoomDescModifier.IsVisible = () => gs.ZoomModifier != Modifiers.None;
+
+				var zoomDescModifierTemplate = zoomDescModifier.Text;
+				var zoomDescModifierLabel = new CachedTransform<Modifiers, string>(
+					mod => zoomDescModifierTemplate.Replace("MODIFIER", mod.ToString()));
+				zoomDescModifier.GetText = () => zoomDescModifierLabel.Update(gs.ZoomModifier);
+
+				var edgescrollDesc = container.Get<LabelWidget>("DESC_EDGESCROLL");
+				edgescrollDesc.IsVisible = () => gs.ViewportEdgeScroll;
+			}
+
+			SettingsLogic.BindCheckboxPref(widget, "EDGESCROLL_CHECKBOX", gs, "ViewportEdgeScroll");
+
+			var colorDropdown = widget.Get<DropDownButtonWidget>("PLAYERCOLOR");
+			colorDropdown.IsDisabled = () => worldRenderer.World.Type != WorldType.Shellmap;
+			colorDropdown.OnMouseDown = _ => ColorPickerLogic.ShowColorDropDown(colorDropdown, colorPreview, worldRenderer.World);
+			colorDropdown.Get<ColorBlockWidget>("COLORBLOCK").GetColor = () => ps.Color;
+
+			var viewportSizes = modData.Manifest.Get<WorldViewportSizes>();
+			var battlefieldCameraDropDown = widget.Get<DropDownButtonWidget>("BATTLEFIELD_CAMERA_DROPDOWN");
+			var battlefieldCameraLabel = new CachedTransform<WorldViewport, string>(vs => SettingsLogic.ViewportSizeNames[vs]);
+			battlefieldCameraDropDown.OnMouseDown = _ => SettingsLogic.ShowBattlefieldCameraDropdown(battlefieldCameraDropDown, viewportSizes, ds);
+			battlefieldCameraDropDown.GetText = () => battlefieldCameraLabel.Update(ds.ViewportDistance);
+
+			var uiScaleDropdown = widget.Get<DropDownButtonWidget>("UI_SCALE_DROPDOWN");
+			var uiScaleLabel = new CachedTransform<float, string>(s => "{0}%".F((int)(100 * s)));
+			uiScaleDropdown.OnMouseDown = _ => SettingsLogic.ShowUIScaleDropdown(uiScaleDropdown, ds);
+			uiScaleDropdown.GetText = () => uiScaleLabel.Update(ds.UIScale);
+
+			var minResolution = viewportSizes.MinEffectiveResolution;
+			var resolution = Game.Renderer.Resolution;
+			var disableUIScale = worldRenderer.World.Type != WorldType.Shellmap ||
+				resolution.Width * ds.UIScale < 1.25f * minResolution.Width ||
+				resolution.Height * ds.UIScale < 1.25f * minResolution.Height;
+
+			uiScaleDropdown.IsDisabled = () => disableUIScale;
+
+			SettingsLogic.BindCheckboxPref(widget, "CURSORDOUBLE_CHECKBOX", ds, "CursorDouble");
+
+			widget.Get<ButtonWidget>("CONTINUE_BUTTON").OnClick = () =>
+			{
+				Game.Settings.Game.IntroductionPromptVersion = IntroductionVersion;
+				Game.Settings.Save();
+				Ui.CloseWindow();
+				onComplete();
+			};
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -226,21 +226,35 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			}
 
 			menuType = MenuType.StartupPrompts;
-			Action onSysInfoComplete = () =>
+
+			Action onIntroductionComplete = () =>
 			{
-				LoadAndDisplayNews(webServices.GameNews, newsBG);
-				SwitchMenu(MenuType.Main);
+				Action onSysInfoComplete = () =>
+				{
+					LoadAndDisplayNews(webServices.GameNews, newsBG);
+					SwitchMenu(MenuType.Main);
+				};
+
+				if (SystemInfoPromptLogic.ShouldShowPrompt())
+				{
+					Ui.OpenWindow("MAINMENU_SYSTEM_INFO_PROMPT", new WidgetArgs
+					{
+						{ "onComplete", onSysInfoComplete }
+					});
+				}
+				else
+					onSysInfoComplete();
 			};
 
-			if (SystemInfoPromptLogic.ShouldShowPrompt())
+			if (IntroductionPromptLogic.ShouldShowPrompt())
 			{
-				Ui.OpenWindow("MAINMENU_SYSTEM_INFO_PROMPT", new WidgetArgs
+				Game.OpenWindow("MAINMENU_INTRODUCTION_PROMPT", new WidgetArgs
 				{
-					{ "onComplete", onSysInfoComplete }
+					{ "onComplete", onIntroductionComplete }
 				});
 			}
 			else
-				onSysInfoComplete();
+				onIntroductionComplete();
 
 			Game.OnShellmapLoaded += OpenMenuBasedOnLastGame;
 		}

--- a/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/MainMenuLogic.cs
@@ -22,11 +22,9 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets.Logic
 {
-	[SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1203:ConstantsMustAppearBeforeFields",
-		Justification = "SystemInformation version should be defined next to the dictionary it refers to.")]
 	public class MainMenuLogic : ChromeLogic
 	{
-		protected enum MenuType { Main, Singleplayer, Extras, MapEditor, SystemInfoPrompt, None }
+		protected enum MenuType { Main, Singleplayer, Extras, MapEditor, StartupPrompts, None }
 
 		protected enum MenuPanel { None, Missions, Skirmish, Multiplayer, MapEditor, Replays, GameSaves }
 
@@ -42,27 +40,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		protected static MenuPanel lastGameState = MenuPanel.None;
 
 		bool newsOpen;
-
-		// Increment the version number when adding new stats
-		const int SystemInformationVersion = 4;
-		Dictionary<string, Pair<string, string>> GetSystemInformation()
-		{
-			var lang = System.Globalization.CultureInfo.InstalledUICulture.TwoLetterISOLanguageName;
-			return new Dictionary<string, Pair<string, string>>()
-			{
-				{ "id", Pair.New("Anonymous ID", Game.Settings.Debug.UUID) },
-				{ "platform", Pair.New("OS Type", Platform.CurrentPlatform.ToString()) },
-				{ "os", Pair.New("OS Version", Environment.OSVersion.ToString()) },
-				{ "x64", Pair.New("OS is 64 bit", Environment.Is64BitOperatingSystem.ToString()) },
-				{ "x64process", Pair.New("Process is 64 bit", Environment.Is64BitProcess.ToString()) },
-				{ "runtime", Pair.New(".NET Runtime", Platform.RuntimeVersion) },
-				{ "gl", Pair.New("OpenGL Version", Game.Renderer.GLVersion) },
-				{ "windowsize", Pair.New("Window Size", "{0}x{1}".F(Game.Renderer.NativeResolution.Width, Game.Renderer.NativeResolution.Height)) },
-				{ "windowscale", Pair.New("Window Scale", Game.Renderer.NativeWindowScale.ToString("F2", CultureInfo.InvariantCulture)) },
-				{ "uiscale", Pair.New("UI Scale", Game.Settings.Graphics.UIScale.ToString("F2", CultureInfo.InvariantCulture)) },
-				{ "lang", Pair.New("System Language", lang) }
-			};
-		}
 
 		void SwitchMenu(MenuType type)
 		{
@@ -215,7 +192,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var newsBG = widget.GetOrNull("NEWS_BG");
 			if (newsBG != null)
 			{
-				newsBG.IsVisible = () => Game.Settings.Game.FetchNews && menuType != MenuType.None && menuType != MenuType.SystemInfoPrompt;
+				newsBG.IsVisible = () => Game.Settings.Game.FetchNews && menuType != MenuType.None && menuType != MenuType.StartupPrompts;
 
 				newsPanel = Ui.LoadWidget<ScrollPanelWidget>("NEWS_PANEL", null, new WidgetArgs());
 				newsTemplate = newsPanel.Get("NEWS_ITEM_TEMPLATE");
@@ -235,7 +212,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var updateLabel = rootMenu.GetOrNull("UPDATE_NOTICE");
 			if (updateLabel != null)
 				updateLabel.IsVisible = () => !newsOpen && menuType != MenuType.None &&
-					menuType != MenuType.SystemInfoPrompt &&
+					menuType != MenuType.StartupPrompts &&
 					webServices.ModVersionStatus == ModVersionStatus.Outdated;
 
 			var playerProfile = widget.GetOrNull("PLAYER_PROFILE_CONTAINER");
@@ -248,39 +225,22 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				});
 			}
 
-			// System information opt-out prompt
-			var sysInfoPrompt = widget.Get("SYSTEM_INFO_PROMPT");
-			sysInfoPrompt.IsVisible = () => menuType == MenuType.SystemInfoPrompt;
-			if (Game.Settings.Debug.SystemInformationVersionPrompt < SystemInformationVersion)
+			menuType = MenuType.StartupPrompts;
+			Action onSysInfoComplete = () =>
 			{
-				menuType = MenuType.SystemInfoPrompt;
+				LoadAndDisplayNews(webServices.GameNews, newsBG);
+				SwitchMenu(MenuType.Main);
+			};
 
-				var sysInfoCheckbox = sysInfoPrompt.Get<CheckboxWidget>("SYSINFO_CHECKBOX");
-				sysInfoCheckbox.IsChecked = () => Game.Settings.Debug.SendSystemInformation;
-				sysInfoCheckbox.OnClick = () => Game.Settings.Debug.SendSystemInformation ^= true;
-
-				var sysInfoData = sysInfoPrompt.Get<ScrollPanelWidget>("SYSINFO_DATA");
-				var template = sysInfoData.Get<LabelWidget>("DATA_TEMPLATE");
-				sysInfoData.RemoveChildren();
-
-				foreach (var info in GetSystemInformation().Values)
+			if (SystemInfoPromptLogic.ShouldShowPrompt())
+			{
+				Ui.OpenWindow("MAINMENU_SYSTEM_INFO_PROMPT", new WidgetArgs
 				{
-					var label = template.Clone() as LabelWidget;
-					var text = info.First + ": " + info.Second;
-					label.GetText = () => text;
-					sysInfoData.AddChild(label);
-				}
-
-				sysInfoPrompt.Get<ButtonWidget>("BACK_BUTTON").OnClick = () =>
-				{
-					Game.Settings.Debug.SystemInformationVersionPrompt = SystemInformationVersion;
-					Game.Settings.Save();
-					SwitchMenu(MenuType.Main);
-					LoadAndDisplayNews(webServices.GameNews, newsBG);
-				};
+					{ "onComplete", onSysInfoComplete }
+				});
 			}
 			else
-				LoadAndDisplayNews(webServices.GameNews, newsBG);
+				onSysInfoComplete();
 
 			Game.OnShellmapLoaded += OpenMenuBasedOnLastGame;
 		}
@@ -305,12 +265,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 							Uri.EscapeUriString(Game.ModData.Manifest.Id),
 							Uri.EscapeUriString(Game.ModData.Manifest.Metadata.Version));
 
-						// Append system profile data if the player has opted in
-						if (Game.Settings.Debug.SendSystemInformation)
-							newsURL += "&sysinfoversion={0}&".F(SystemInformationVersion)
-								+ GetSystemInformation()
-								.Select(kv => kv.Key + "=" + Uri.EscapeUriString(kv.Value.Second))
-								.JoinWith("&");
+						// Parameter string is blank if the player has opted out
+						newsURL += SystemInfoPromptLogic.CreateParameterString();
 
 						new Download(newsURL, cacheFile, e => { },
 							e => NewsDownloadComplete(e, cacheFile, currentNews,

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -135,7 +135,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 		}
 
-		static void BindCheckboxPref(Widget parent, string id, object group, string pref)
+		public static void BindCheckboxPref(Widget parent, string id, object group, string pref)
 		{
 			var field = group.GetType().GetField(pref);
 			if (field == null)
@@ -221,7 +221,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			resetPanelActions.Add(type, reset(panel));
 		}
 
-		static readonly Dictionary<WorldViewport, string> ViewportSizeNames = new Dictionary<WorldViewport, string>()
+		public static readonly Dictionary<WorldViewport, string> ViewportSizeNames = new Dictionary<WorldViewport, string>()
 		{
 			{ WorldViewport.Close, "Close" },
 			{ WorldViewport.Medium, "Medium" },
@@ -697,7 +697,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			};
 		}
 
-		static void ShowMouseControlDropdown(DropDownButtonWidget dropdown, GameSettings s)
+		public static void ShowMouseControlDropdown(DropDownButtonWidget dropdown, GameSettings s)
 		{
 			var options = new Dictionary<string, bool>()
 			{
@@ -880,7 +880,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			dropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 500, options.Keys, setupItem);
 		}
 
-		static void ShowBattlefieldCameraDropdown(DropDownButtonWidget dropdown, WorldViewportSizes viewportSizes, GraphicSettings gs)
+		public static void ShowBattlefieldCameraDropdown(DropDownButtonWidget dropdown, WorldViewportSizes viewportSizes, GraphicSettings gs)
 		{
 			Func<WorldViewport, ScrollItemWidget, ScrollItemWidget> setupItem = (o, itemTemplate) =>
 			{
@@ -949,7 +949,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				RecalculateWidgetLayout(c, insideScrollPanel || w is ScrollPanelWidget);
 		}
 
-		static void ShowUIScaleDropdown(DropDownButtonWidget dropdown, GraphicSettings gs)
+		public static void ShowUIScaleDropdown(DropDownButtonWidget dropdown, GraphicSettings gs)
 		{
 			Func<float, ScrollItemWidget, ScrollItemWidget> setupItem = (o, itemTemplate) =>
 			{

--- a/OpenRA.Mods.Common/Widgets/Logic/SystemInfoPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SystemInfoPromptLogic.cs
@@ -1,0 +1,95 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using OpenRA.Primitives;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+	[SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1203:ConstantsMustAppearBeforeFields",
+		Justification = "SystemInformation version should be defined next to the dictionary it refers to.")]
+	public class SystemInfoPromptLogic : ChromeLogic
+	{
+		// Increment the version number when adding new stats
+		const int SystemInformationVersion = 4;
+
+		static Dictionary<string, Pair<string, string>> GetSystemInformation()
+		{
+			var lang = CultureInfo.InstalledUICulture.TwoLetterISOLanguageName;
+			return new Dictionary<string, Pair<string, string>>()
+			{
+				{ "id", Pair.New("Anonymous ID", Game.Settings.Debug.UUID) },
+				{ "platform", Pair.New("OS Type", Platform.CurrentPlatform.ToString()) },
+				{ "os", Pair.New("OS Version", Environment.OSVersion.ToString()) },
+				{ "x64", Pair.New("OS is 64 bit", Environment.Is64BitOperatingSystem.ToString()) },
+				{ "x64process", Pair.New("Process is 64 bit", Environment.Is64BitProcess.ToString()) },
+				{ "runtime", Pair.New(".NET Runtime", Platform.RuntimeVersion) },
+				{ "gl", Pair.New("OpenGL Version", Game.Renderer.GLVersion) },
+				{ "windowsize", Pair.New("Window Size", "{0}x{1}".F(Game.Renderer.NativeResolution.Width, Game.Renderer.NativeResolution.Height)) },
+				{ "windowscale", Pair.New("Window Scale", Game.Renderer.NativeWindowScale.ToString("F2", CultureInfo.InvariantCulture)) },
+				{ "uiscale", Pair.New("UI Scale", Game.Settings.Graphics.UIScale.ToString("F2", CultureInfo.InvariantCulture)) },
+				{ "lang", Pair.New("System Language", lang) }
+			};
+		}
+
+		public static bool ShouldShowPrompt()
+		{
+			return Game.Settings.Debug.SystemInformationVersionPrompt < SystemInformationVersion;
+		}
+
+		public static string CreateParameterString()
+		{
+			if (!Game.Settings.Debug.SendSystemInformation)
+				return "";
+
+			return "&sysinfoversion={0}&".F(SystemInformationVersion)
+			       + GetSystemInformation()
+				       .Select(kv => kv.Key + "=" + Uri.EscapeUriString(kv.Value.Second))
+				       .JoinWith("&");
+		}
+
+		[ObjectCreator.UseCtor]
+		public SystemInfoPromptLogic(Widget widget, Action onComplete)
+		{
+			var sysInfoCheckbox = widget.Get<CheckboxWidget>("SYSINFO_CHECKBOX");
+			sysInfoCheckbox.IsChecked = () => Game.Settings.Debug.SendSystemInformation;
+			sysInfoCheckbox.OnClick = () => Game.Settings.Debug.SendSystemInformation ^= true;
+
+			var sysInfoData = widget.Get<ScrollPanelWidget>("SYSINFO_DATA");
+			var template = sysInfoData.Get<LabelWidget>("DATA_TEMPLATE");
+			sysInfoData.RemoveChildren();
+
+			foreach (var info in GetSystemInformation().Values)
+			{
+				var label = template.Clone() as LabelWidget;
+				var text = info.First + ": " + info.Second;
+				label.GetText = () => text;
+				sysInfoData.AddChild(label);
+			}
+
+			widget.Get<ButtonWidget>("CONTINUE_BUTTON").OnClick = () =>
+			{
+				Game.Settings.Debug.SystemInformationVersionPrompt = SystemInformationVersion;
+				Game.Settings.Save();
+				Ui.CloseWindow();
+				onComplete();
+			};
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/ObserverArmyIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverArmyIconsWidget.cs
@@ -1,0 +1,209 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
+using OpenRA.Primitives;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets
+{
+	public class ObserverArmyIconsWidget : Widget
+	{
+		public Func<Player> GetPlayer;
+		readonly World world;
+		readonly WorldRenderer worldRenderer;
+
+		public int IconWidth = 32;
+		public int IconHeight = 24;
+		public int IconSpacing = 1;
+
+		float2 iconSize;
+		public int MinWidth = 240;
+
+		public ArmyUnit TooltipUnit { get; private set; }
+		public Func<ArmyUnit> GetTooltipUnit;
+
+		public readonly string TooltipTemplate = "ARMY_TOOLTIP";
+		public readonly string TooltipContainer;
+
+		readonly Lazy<TooltipContainerWidget> tooltipContainer;
+		readonly List<ArmyIcon> armyIcons = new List<ArmyIcon>();
+
+		readonly CachedTransform<Player, PlayerStatistics> stats = new CachedTransform<Player, PlayerStatistics>(player => player.PlayerActor.TraitOrDefault<PlayerStatistics>());
+
+		int lastIconIdx;
+		Rectangle currentIconBounds;
+
+		[ObjectCreator.UseCtor]
+		public ObserverArmyIconsWidget(World world, WorldRenderer worldRenderer)
+		{
+			this.world = world;
+			this.worldRenderer = worldRenderer;
+
+			GetTooltipUnit = () => TooltipUnit;
+			tooltipContainer = Exts.Lazy(() =>
+				Ui.Root.Get<TooltipContainerWidget>(TooltipContainer));
+		}
+
+		protected ObserverArmyIconsWidget(ObserverArmyIconsWidget other)
+			: base(other)
+		{
+			GetPlayer = other.GetPlayer;
+			world = other.world;
+			worldRenderer = other.worldRenderer;
+
+			IconWidth = other.IconWidth;
+			IconHeight = other.IconHeight;
+			IconSpacing = other.IconSpacing;
+			iconSize = new float2(IconWidth, IconHeight);
+
+			MinWidth = other.MinWidth;
+
+			TooltipUnit = other.TooltipUnit;
+			GetTooltipUnit = () => TooltipUnit;
+
+			TooltipTemplate = other.TooltipTemplate;
+			TooltipContainer = other.TooltipContainer;
+
+			tooltipContainer = Exts.Lazy(() =>
+				Ui.Root.Get<TooltipContainerWidget>(TooltipContainer));
+		}
+
+		public override void Draw()
+		{
+			armyIcons.Clear();
+
+			var player = GetPlayer();
+			if (player == null)
+				return;
+
+			var playerStatistics = stats.Update(player);
+
+			var items = playerStatistics.Units.Values
+				.Where(u => u.Count > 0 && u.Icon != null)
+				.OrderBy(u => u.ProductionQueueOrder)
+				.ThenBy(u => u.BuildPaletteOrder);
+
+			Game.Renderer.EnableAntialiasingFilter();
+
+			var queueCol = 0;
+			foreach (var unit in items)
+			{
+				var icon = unit.Icon;
+				var topLeftOffset = new int2(queueCol * (IconWidth + IconSpacing), 0);
+
+				var iconTopLeft = RenderOrigin + topLeftOffset;
+				var centerPosition = iconTopLeft;
+
+				WidgetUtils.DrawSHPCentered(icon.Image, centerPosition + 0.5f * iconSize, worldRenderer.Palette(unit.IconPalette), 0.5f);
+
+				armyIcons.Add(new ArmyIcon
+				{
+					Bounds = new Rectangle(iconTopLeft.X, iconTopLeft.Y, (int)iconSize.X, (int)iconSize.Y),
+					Unit = unit
+				});
+
+				queueCol++;
+			}
+
+			Bounds.Width = queueCol * (IconWidth + IconSpacing);
+
+			Game.Renderer.DisableAntialiasingFilter();
+
+			var bold = Game.Renderer.Fonts["TinyBold"];
+			foreach (var armyIcon in armyIcons)
+			{
+				var text = armyIcon.Unit.Count.ToString();
+				bold.DrawTextWithContrast(text, armyIcon.Bounds.Location + new float2(iconSize.X, 0) - new float2(bold.Measure(text).X, bold.TopOffset),
+					Color.White, Color.Black, 1);
+			}
+
+			var parentWidth = Bounds.X + Bounds.Width;
+			Parent.Bounds.Width = parentWidth;
+
+			var gradient = Parent.Get<GradientColorBlockWidget>("PLAYER_GRADIENT");
+
+			var offset = gradient.Bounds.X - Bounds.X;
+			var gradientWidth = Math.Max(MinWidth - offset, queueCol * (IconWidth + IconSpacing));
+
+			gradient.Bounds.Width = gradientWidth;
+			var widestChildWidth = Parent.Parent.Children.Max(x => x.Bounds.Width);
+
+			Parent.Parent.Bounds.Width = Math.Max(25 + widestChildWidth, Bounds.Left + MinWidth);
+		}
+
+		public override Widget Clone()
+		{
+			return new ObserverArmyIconsWidget(this);
+		}
+
+		public override void MouseEntered()
+		{
+			if (TooltipContainer == null)
+				return;
+
+			foreach (var armyIcon in armyIcons)
+			{
+				if (!armyIcon.Bounds.Contains(Viewport.LastMousePos))
+					continue;
+
+				TooltipUnit = armyIcon.Unit;
+				break;
+			}
+
+			tooltipContainer.Value.SetTooltip(TooltipTemplate, new WidgetArgs { { "getTooltipUnit", GetTooltipUnit } });
+		}
+
+		public override void MouseExited()
+		{
+			if (TooltipContainer == null)
+				return;
+
+			tooltipContainer.Value.RemoveTooltip();
+		}
+
+		public override void Tick()
+		{
+			if (lastIconIdx >= armyIcons.Count)
+			{
+				TooltipUnit = null;
+				return;
+			}
+
+			if (TooltipUnit != null && currentIconBounds.Contains(Viewport.LastMousePos))
+				return;
+
+			for (var i = 0; i < armyIcons.Count; i++)
+			{
+				var armyIcon = armyIcons[i];
+				if (!armyIcon.Bounds.Contains(Viewport.LastMousePos))
+					continue;
+
+				lastIconIdx = i;
+				currentIconBounds = armyIcon.Bounds;
+				TooltipUnit = armyIcon.Unit;
+				return;
+			}
+
+			TooltipUnit = null;
+		}
+
+		class ArmyIcon
+		{
+			public Rectangle Bounds { get; set; }
+			public ArmyUnit Unit { get; set; }
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverProductionIconsWidget.cs
@@ -47,6 +47,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		float2 iconSize;
 		int lastIconIdx;
+		public int MinWidth = 240;
 
 		[ObjectCreator.UseCtor]
 		public ObserverProductionIconsWidget(World world, WorldRenderer worldRenderer)
@@ -82,6 +83,8 @@ namespace OpenRA.Mods.Common.Widgets
 			TooltipIcon = other.TooltipIcon;
 			GetTooltipIcon = () => TooltipIcon;
 
+			MinWidth = other.MinWidth;
+
 			TooltipTemplate = other.TooltipTemplate;
 			TooltipContainer = other.TooltipContainer;
 
@@ -114,7 +117,7 @@ namespace OpenRA.Mods.Common.Widgets
 					.ThenBy(g => g.First().BuildPaletteOrder)
 					.ToList();
 
-			Bounds.Width = currentItemsByItem.Count * (IconWidth + IconSpacing);
+			Bounds.Width = Math.Max(currentItemsByItem.Count * (IconWidth + IconSpacing), MinWidth);
 
 			Game.Renderer.EnableAntialiasingFilter();
 
@@ -193,6 +196,19 @@ namespace OpenRA.Mods.Common.Widgets
 						Color.White, Color.Black, 1);
 				}
 			}
+
+			var parentWidth = Bounds.X + Bounds.Width;
+			Parent.Bounds.Width = parentWidth;
+
+			var gradient = Parent.Get<GradientColorBlockWidget>("PLAYER_GRADIENT");
+
+			var offset = gradient.Bounds.X - Bounds.X;
+			var gradientWidth = Math.Max(MinWidth - offset, currentItemsByItem.Count * (IconWidth + IconSpacing));
+
+			gradient.Bounds.Width = gradientWidth;
+			var widestChildWidth = Parent.Parent.Children.Max(x => x.Bounds.Width);
+
+			Parent.Parent.Bounds.Width = Math.Max(25 + widestChildWidth, Bounds.Left + MinWidth);
 		}
 
 		static string GetOverlayForItem(ProductionItem item, int timestep)

--- a/OpenRA.Platforms.Default/DefaultPlatform.cs
+++ b/OpenRA.Platforms.Default/DefaultPlatform.cs
@@ -16,9 +16,9 @@ namespace OpenRA.Platforms.Default
 {
 	public class DefaultPlatform : IPlatform
 	{
-		public IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int batchSize)
+		public IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int batchSize, int videoDisplay)
 		{
-			return new Sdl2PlatformWindow(size, windowMode, scaleModifier, batchSize);
+			return new Sdl2PlatformWindow(size, windowMode, scaleModifier, batchSize, videoDisplay);
 		}
 
 		public ISoundEngine CreateSound(string device)

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -267,6 +267,7 @@ Container@OBSERVER_WIDGETS:
 				StatisticsProductionKey: StatisticsProduction
 				StatisticsSupportPowersKey: StatisticsSupportPowers
 				StatisticsCombatKey: StatisticsCombat
+				StatisticsArmyKey: StatisticsArmy
 				StatisticsGraphKey: StatisticsGraph
 				StatisticsArmyGraphKey: StatisticsArmyGraph
 			X: 5
@@ -541,6 +542,42 @@ Container@OBSERVER_WIDGETS:
 									Height: PARENT_BOTTOM
 									Font: Bold
 									Text: Support Powers
+									Shadow: True
+						Container@ARMY_HEADERS:
+							X: 0
+							Y: 0
+							Width: 400
+							Height: PARENT_BOTTOM
+							Children:
+								ColorBlock@HEADER_COLOR:
+									X: 0
+									Y: 0
+									Color: 00000090
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@HEADER_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									TopLeftColor: 00000090
+									BottomLeftColor: 00000090
+									Width: 200
+									Height: PARENT_BOTTOM
+								Label@PLAYER_HEADER:
+									X: 40
+									Y: 0
+									Width: 120
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Player
+									Align: Left
+									Shadow: True
+								Label@ARMY_HEADER:
+									X: 160
+									Y: 0
+									Width: 100
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Army
 									Shadow: True
 						Container@COMBAT_STATS_HEADERS:
 							X: 0
@@ -906,6 +943,43 @@ Container@OBSERVER_WIDGETS:
 									Font: Bold
 									Shadow: True
 								ObserverSupportPowerIcons@SUPPORT_POWER_ICONS:
+									X: 160
+									Y: 0
+									Width: 0
+									Height: PARENT_BOTTOM
+									TooltipContainer: TOOLTIP_CONTAINER
+						ScrollItem@ARMY_PLAYER_TEMPLATE:
+							X: 0
+							Y: 0
+							Width: 400
+							Height: 24
+							BaseName: scrollitem-nohover
+							Children:
+								ColorBlock@PLAYER_COLOR:
+									X: 0
+									Y: 0
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@PLAYER_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									Width: 200
+									Height: PARENT_BOTTOM 
+								Image@FLAG:
+									X: 5
+									Y: 4
+									Width: 35
+									Height: PARENT_BOTTOM - 4
+									ImageName: random
+									ImageCollection: flags
+								Label@PLAYER:
+									X: 40
+									Y: 0
+									Width: 120
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Shadow: True
+								ObserverArmyIcons@ARMY_ICONS:
 									X: 160
 									Y: 0
 									Width: 0

--- a/mods/cnc/chrome/mainmenu-prompts.yaml
+++ b/mods/cnc/chrome/mainmenu-prompts.yaml
@@ -1,0 +1,61 @@
+Container@MAINMENU_SYSTEM_INFO_PROMPT:
+	Logic: SystemInfoPromptLogic
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 490
+	Height: 222
+	Children:
+		Label@TITLE:
+			Width: PARENT_RIGHT
+			Y: 0 - 25
+			Font: BigBold
+			Contrast: true
+			Align: Center
+			Text: System Information
+		Background@bg:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Background: panel-black
+			Children:
+				Label@PROMPT_TEXT_A:
+					X: 15
+					Y: 15
+					Width: PARENT_RIGHT - 30
+					Height: 16
+					Align: Center
+					Text: We would like to collect some details that will help us optimize OpenRA.
+				Label@PROMPT_TEXT_B:
+					X: 15
+					Y: 33
+					Width: PARENT_RIGHT - 30
+					Height: 16
+					Align: Center
+					Text: With your permission, the following anonymous system data will be sent:
+				ScrollPanel@SYSINFO_DATA:
+					X: 15
+					Y: 63
+					Width: PARENT_RIGHT - 30
+					TopBottomSpacing: 4
+					ItemSpacing: 4
+					Height: 110
+					Children:
+						Label@DATA_TEMPLATE:
+							X: 8
+							Height: 13
+							VAlign: Top
+							Font: Small
+				Checkbox@SYSINFO_CHECKBOX:
+					X: PARENT_RIGHT - 15 - WIDTH
+					Y: PARENT_BOTTOM - 35
+					Width: 190
+					Height: 20
+					Font: Regular
+					Text: Send System Information
+		Button@CONTINUE_BUTTON:
+			X: PARENT_RIGHT - WIDTH
+			Y: PARENT_BOTTOM - 1
+			Width: 140
+			Height: 35
+			Text: Continue
+			Font: Bold
+			Key: return

--- a/mods/cnc/chrome/mainmenu-prompts.yaml
+++ b/mods/cnc/chrome/mainmenu-prompts.yaml
@@ -1,9 +1,9 @@
-Container@MAINMENU_SYSTEM_INFO_PROMPT:
-	Logic: SystemInfoPromptLogic
+Container@MAINMENU_INTRODUCTION_PROMPT:
+	Logic: IntroductionPromptLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
-	Width: 490
-	Height: 222
+	Width: 600
+	Height: 350
 	Children:
 		Label@TITLE:
 			Width: PARENT_RIGHT
@@ -11,7 +11,260 @@ Container@MAINMENU_SYSTEM_INFO_PROMPT:
 			Font: BigBold
 			Contrast: true
 			Align: Center
-			Text: System Information
+			Text: Establishing Battlefield Control
+		Background@bg:
+			Width: PARENT_RIGHT
+			Height: PARENT_BOTTOM
+			Background: panel-black
+			Children:
+				Label@DESC_A:
+					Width: PARENT_RIGHT
+					Y: 15
+					Height: 16
+					Font: Regular
+					Align: Center
+					Text: Welcome back Commander! Initialize combat parameters using the options below.
+				Label@DESC_B:
+					Width: PARENT_RIGHT
+					Y: 33
+					Height: 16
+					Font: Regular
+					Align: Center
+					Text: Additional options can be configured later from the Settings menu.
+				Label@PROFILE_TITLE:
+					Width: PARENT_RIGHT
+					Y: 60
+					Height: 25
+					Font: Bold
+					Align: Center
+					Text: Profile
+				Label@PLAYER:
+					Text: Player Name:
+					X: 15
+					Y: 90
+					Width: 120
+					Height: 25
+					Align: Right
+				TextField@PLAYERNAME:
+					X: 140
+					Y: 90
+					Width: 160
+					Height: 25
+					MaxLength: 16
+				Label@COLOR:
+					X: 265 + 60
+					Y: 90
+					Width: 145
+					Height: 25
+					Text: Preferred Color:
+					Align: Right
+				ColorPreviewManager@COLOR_MANAGER:
+				DropDownButton@PLAYERCOLOR:
+					X: 415 + 60
+					Y: 90
+					Width: 75
+					Height: 25
+					IgnoreChildMouseOver: true
+					PanelAlign: Right
+					Children:
+						ColorBlock@COLORBLOCK:
+							X: 5
+							Y: 6
+							Width: PARENT_RIGHT - 35
+							Height: PARENT_BOTTOM - 12
+				Label@INPUT_TITLE:
+					Width: PARENT_RIGHT
+					Y: 120
+					Height: 25
+					Font: Bold
+					Align: Center
+					Text: Input
+				Label@MOUSE_CONTROL_LABEL:
+					X: 15
+					Y: 150
+					Width: 120
+					Height: 25
+					Font: Regular
+					Text: Control Scheme:
+					Align: Right
+				DropDownButton@MOUSE_CONTROL_DROPDOWN:
+					X: 140
+					Y: 150
+					Width: 160
+					Height: 25
+					Font: Regular
+				Checkbox@EDGESCROLL_CHECKBOX:
+					X: 365
+					Y: 153
+					Width: 180
+					Height: 20
+					Font: Regular
+					Text: Screen Edge Panning
+				Container@MOUSE_CONTROL_DESC_CLASSIC:
+					X: 25
+					Y: 180
+					Width: PARENT_RIGHT - 50
+					Children:
+						LabelWithHighlight@DESC_SELECTION:
+							Height: 16
+							Font: Small
+							Text: - Select units using the {Left} mouse button
+						LabelWithHighlight@DESC_COMMANDS:
+							Y: 17
+							Height: 16
+							Font: Small
+							Text: - Command units using the {Left} mouse button
+						LabelWithHighlight@DESC_BUILDIGS:
+							Y: 34
+							Height: 16
+							Font: Small
+							Text: - Place structures using the {Left} mouse button
+						LabelWithHighlight@DESC_SUPPORT:
+							X: 265
+							Height: 16
+							Font: Small
+							Text: - Target support powers using the {Left} mouse button
+						LabelWithHighlight@DESC_ZOOM:
+							X: 265
+							Y: 17
+							Height: 16
+							Font: Small
+							Text: - Zoom the battlefield using the {Scroll Wheel}
+						LabelWithHighlight@DESC_ZOOM_MODIFIER:
+							X: 265
+							Y: 17
+							Height: 16
+							Font: Small
+							Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
+						LabelWithHighlight@DESC_SCROLL_RIGHT:
+							X: 265
+							Y: 34
+							Height: 16
+							Font: Small
+							Text: - Pan the battlefield using the {Right} mouse button
+						LabelWithHighlight@DESC_SCROLL_MIDDLE:
+							X: 265
+							Y: 34
+							Height: 16
+							Font: Small
+							Text: - Pan the battlefield using the {Middle} mouse button
+						Label@DESC_EDGESCROLL:
+							X: 274
+							Y: 51
+							Height: 16
+							Font: Small
+							Text: or by moving the cursor to the edge of the screen
+				Container@MOUSE_CONTROL_DESC_MODERN:
+					X: 25
+					Y: 180
+					Width: PARENT_RIGHT - 50
+					Children:
+						LabelWithHighlight@DESC_SELECTION:
+							Height: 16
+							Font: Small
+							Text: - Select units using the {Left} mouse button
+						LabelWithHighlight@DESC_COMMANDS:
+							Y: 17
+							Height: 16
+							Font: Small
+							Text: - Command units using the {Right} mouse button
+						LabelWithHighlight@DESC_BUILDIGS:
+							Y: 34
+							Height: 16
+							Font: Small
+							Text: - Place structures using the {Left} mouse button
+						LabelWithHighlight@DESC_SUPPORT:
+							X: 265
+							Height: 16
+							Font: Small
+							Text: - Target support powers using the {Left} mouse button
+						LabelWithHighlight@DESC_ZOOM:
+							X: 265
+							Y: 17
+							Height: 16
+							Font: Small
+							Text: - Zoom the battlefield using the {Scroll Wheel}
+						LabelWithHighlight@DESC_ZOOM_MODIFIER:
+							X: 265
+							Y: 17
+							Height: 16
+							Font: Small
+							Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
+						LabelWithHighlight@DESC_SCROLL:
+							X: 265
+							Y: 34
+							Height: 16
+							Font: Small
+							Text: - Pan the battlefield using the {Middle} mouse button
+						Label@DESC_EDGESCROLL:
+							X: 274
+							Y: 51
+							Height: 16
+							Font: Small
+							Text: or by moving the cursor to the edge of the screen
+				Label@INPUT_TITLE:
+					Width: PARENT_RIGHT
+					Y: 250
+					Height: 25
+					Font: Bold
+					Align: Center
+					Text: Display
+				Label@BATTLEFIELD_CAMERA:
+					X: 15
+					Y: 280
+					Width: 120
+					Height: 25
+					Text: Battlefield Camera:
+					Align: Right
+				DropDownButton@BATTLEFIELD_CAMERA_DROPDOWN:
+					X: 140
+					Y: 280
+					Width: 160
+					Height: 25
+					Font: Regular
+				Label@UI_SCALE:
+					X: 275
+					Y: 280
+					Width: 145
+					Height: 25
+					Text: UI Scale:
+					Align: Right
+				DropDownButton@UI_SCALE_DROPDOWN:
+					X: 425
+					Y: 280
+					Width: 160
+					Height: 25
+					Font: Regular
+				Checkbox@CURSORDOUBLE_CHECKBOX:
+					X: 390
+					Y: 313
+					Width: 200
+					Height: 20
+					Font: Regular
+					Text: Increase Cursor Size
+		Button@CONTINUE_BUTTON:
+			X: PARENT_RIGHT - WIDTH
+			Y: PARENT_BOTTOM - 1
+			Width: 140
+			Height: 35
+			Text: Continue
+			Font: Bold
+			Key: return
+
+Container@MAINMENU_SYSTEM_INFO_PROMPT:
+	Logic: SystemInfoPromptLogic
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 600
+	Height: 350
+	Children:
+		Label@TITLE:
+			Width: PARENT_RIGHT
+			Y: 0 - 25
+			Font: BigBold
+			Contrast: true
+			Align: Center
+			Text: Establishing Battlefield Control
 		Background@bg:
 			Width: PARENT_RIGHT
 			Height: PARENT_BOTTOM
@@ -37,7 +290,7 @@ Container@MAINMENU_SYSTEM_INFO_PROMPT:
 					Width: PARENT_RIGHT - 30
 					TopBottomSpacing: 4
 					ItemSpacing: 4
-					Height: 110
+					Height: 240
 					Children:
 						Label@DATA_TEMPLATE:
 							X: 8
@@ -45,8 +298,8 @@ Container@MAINMENU_SYSTEM_INFO_PROMPT:
 							VAlign: Top
 							Font: Small
 				Checkbox@SYSINFO_CHECKBOX:
-					X: PARENT_RIGHT - 15 - WIDTH
-					Y: PARENT_BOTTOM - 35
+					X: 390
+					Y: 313
 					Width: 190
 					Height: 20
 					Font: Regular

--- a/mods/cnc/chrome/mainmenu.yaml
+++ b/mods/cnc/chrome/mainmenu.yaml
@@ -218,66 +218,6 @@ Container@MENU_BACKGROUND:
 							Text: Back
 							Font: Bold
 							Key: escape
-		Container@SYSTEM_INFO_PROMPT:
-			X: (WINDOW_RIGHT - WIDTH) / 2
-			Y: (WINDOW_BOTTOM - HEIGHT) / 2
-			Width: 490
-			Height: 222
-			Children:
-				Label@TITLE:
-					Width: PARENT_RIGHT
-					Y: 0 - 25
-					Font: BigBold
-					Contrast: true
-					Align: Center
-					Text: System Information
-				Background@bg:
-					Width: PARENT_RIGHT
-					Height: PARENT_BOTTOM
-					Background: panel-black
-					Children:
-						Label@PROMPT_TEXT_A:
-							X: 15
-							Y: 15
-							Width: PARENT_RIGHT - 30
-							Height: 16
-							Align: Center
-							Text: We would like to collect some details that will help us optimize OpenRA.
-						Label@PROMPT_TEXT_B:
-							X: 15
-							Y: 33
-							Width: PARENT_RIGHT - 30
-							Height: 16
-							Align: Center
-							Text: With your permission, the following anonymous system data will be sent:
-						ScrollPanel@SYSINFO_DATA:
-							X: 15
-							Y: 63
-							Width: PARENT_RIGHT - 30
-							TopBottomSpacing: 4
-							ItemSpacing: 4
-							Height: 110
-							Children:
-								Label@DATA_TEMPLATE:
-									X: 8
-									Height: 13
-									VAlign: Top
-									Font: Small
-						Checkbox@SYSINFO_CHECKBOX:
-							X: PARENT_RIGHT - 15 - WIDTH
-							Y: PARENT_BOTTOM - 35
-							Width: 190
-							Height: 20
-							Font: Regular
-							Text: Send System Information
-				Button@BACK_BUTTON:
-					X: PARENT_RIGHT - WIDTH
-					Y: PARENT_BOTTOM - 1
-					Width: 140
-					Height: 35
-					Text: Continue
-					Font: Bold
-					Key: return
 		Container@NEWS_BG:
 			Children:
 				DropDownButton@NEWS_BUTTON:

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -200,13 +200,6 @@ Container@SETTINGS_PANEL:
 							Height: 25
 							Font: Regular
 							Text: Windowed
-						Label@MODE_CHANGES_DESC:
-							X: 100
-							Y: 237
-							Width: 200
-							Height: 15
-							Font: Tiny
-							Text: Video mode changes require restart
 						Container@WINDOW_RESOLUTION:
 							Y: 240
 							Children:
@@ -242,6 +235,27 @@ Container@SETTINGS_PANEL:
 									Height: 15
 									Font: Tiny
 									Text: Video mode and window size changes require restart
+						Container@DISPLAY_SELECTION:
+							Y: 240
+							Children:
+								Label@DISPLAY_SELECTION_LABEL:
+									X: 15
+									Height: 25
+									Width: 120
+									Align: Right
+									Text: Select Display:
+								DropDownButton@DISPLAY_SELECTION_DROPDOWN:
+									X: 140
+									Width: 160
+									Height: 25
+									Font: Regular
+								Label@MODE_CHANGES_DESC:
+									X: 60
+									Y: 27
+									Width: 200
+									Height: 15
+									Font: Tiny
+									Text: Video mode and display changes require restart
 						Checkbox@VSYNC_CHECKBOX:
 							X: 310
 							Y: 210

--- a/mods/cnc/chrome/tooltips.yaml
+++ b/mods/cnc/chrome/tooltips.yaml
@@ -353,6 +353,24 @@ Background@SUPPORT_POWER_TOOLTIP_FACTIONSUFFIX:
 			Font: TinyBold
 			VAlign: Top
 
+Background@ARMY_TOOLTIP:
+	Logic: ArmyTooltipLogic
+	Background: panel-black
+	Width: 200
+	Height: 65
+	Children:
+		Label@NAME:
+			X: 5
+			Y: 1
+			Height: 23
+			Font: Bold
+		Label@DESC:
+			X: 5
+			Y: 20
+			Height: 5
+			Font: TinyBold
+			VAlign: Top
+
 Background@SPAWN_TOOLTIP:
 	Logic: SpawnSelectorTooltipLogic
 	Background: panel-black

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -92,6 +92,7 @@ Assemblies:
 
 ChromeLayout:
 	cnc|chrome/mainmenu.yaml
+	cnc|chrome/mainmenu-prompts.yaml
 	cnc|chrome/playerprofile.yaml
 	cnc|chrome/multiplayer-browser.yaml
 	cnc|chrome/multiplayer-browserpanels.yaml

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -376,7 +376,6 @@ HAND:
 		Range: 5c0
 	WithBuildingBib:
 	RallyPoint:
-		Path: 1,2
 	Exit@1:
 		SpawnOffset: 512,1024,0
 		ExitCell: 1,2
@@ -432,7 +431,6 @@ AFLD:
 	RevealsShroud:
 		Range: 7c0
 	RallyPoint:
-		Path: 4,2
 	Exit@1:
 		SpawnOffset: -1024,0,0
 		ExitCell: 3,1
@@ -497,7 +495,6 @@ WEAP:
 		RequiresCondition: !build-incomplete
 		Sequence: build-top
 	RallyPoint:
-		Path: 0,2
 	Exit@1:
 		SpawnOffset: -512,-512,0
 		ExitCell: 0,1

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -376,7 +376,7 @@ HAND:
 		Range: 5c0
 	WithBuildingBib:
 	RallyPoint:
-		Offset: 1,2
+		Path: 1,2
 	Exit@1:
 		SpawnOffset: 512,1024,0
 		ExitCell: 1,2
@@ -432,7 +432,7 @@ AFLD:
 	RevealsShroud:
 		Range: 7c0
 	RallyPoint:
-		Offset: 4,2
+		Path: 4,2
 	Exit@1:
 		SpawnOffset: -1024,0,0
 		ExitCell: 3,1
@@ -497,7 +497,7 @@ WEAP:
 		RequiresCondition: !build-incomplete
 		Sequence: build-top
 	RallyPoint:
-		Offset: 0,2
+		Path: 0,2
 	Exit@1:
 		SpawnOffset: -512,-512,0
 		ExitCell: 0,1

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -106,7 +106,6 @@ BIO:
 	ProductionBar:
 		ProductionType: Biolab
 	RallyPoint:
-		Path: -1,-1
 	SpawnActorOnDeath:
 		Actor: BIO.Husk
 	ProvidesPrerequisite@buildingname:

--- a/mods/cnc/rules/tech.yaml
+++ b/mods/cnc/rules/tech.yaml
@@ -106,7 +106,7 @@ BIO:
 	ProductionBar:
 		ProductionType: Biolab
 	RallyPoint:
-		Offset: -1,-1
+		Path: -1,-1
 	SpawnActorOnDeath:
 		Actor: BIO.Husk
 	ProvidesPrerequisite@buildingname:

--- a/mods/common/chrome/ingame-observer.yaml
+++ b/mods/common/chrome/ingame-observer.yaml
@@ -167,6 +167,7 @@ Container@OBSERVER_WIDGETS:
 				StatisticsProductionKey: StatisticsProduction
 				StatisticsSupportPowersKey: StatisticsSupportPowers
 				StatisticsCombatKey: StatisticsCombat
+				StatisticsArmyKey: StatisticsArmy
 				StatisticsGraphKey: StatisticsGraph
 				StatisticsArmyGraphKey: StatisticsArmyGraph
 			X: 5
@@ -433,6 +434,42 @@ Container@OBSERVER_WIDGETS:
 									Height: PARENT_BOTTOM
 									Font: Bold
 									Text: Support Powers
+									Shadow: True
+						Container@ARMY_HEADERS:
+							X: 0
+							Y: 0
+							Width: 400
+							Height: PARENT_BOTTOM
+							Children:
+								ColorBlock@HEADER_COLOR:
+									X: 0
+									Y: 0
+									Color: 00000090
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@HEADER_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									TopLeftColor: 00000090
+									BottomLeftColor: 00000090
+									Width: 200
+									Height: PARENT_BOTTOM
+								Label@PLAYER_HEADER:
+									X: 40
+									Y: 0
+									Width: 120
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Player
+									Align: Left
+									Shadow: True
+								Label@ARMY_HEADER:
+									X: 160
+									Y: 0
+									Width: 100
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Army
 									Shadow: True
 						Container@COMBAT_STATS_HEADERS:
 							X: 0
@@ -783,6 +820,43 @@ Container@OBSERVER_WIDGETS:
 									Font: Bold
 									Shadow: True
 								ObserverSupportPowerIcons@SUPPORT_POWER_ICONS:
+									X: 155
+									Y: 0
+									Width: 0
+									Height: PARENT_BOTTOM
+									TooltipContainer: TOOLTIP_CONTAINER
+						ScrollItem@ARMY_PLAYER_TEMPLATE:
+							X: 0
+							Y: 0
+							Width: 400
+							Height: 25
+							BaseName: scrollitem-nohover
+							Children:
+								ColorBlock@PLAYER_COLOR:
+									X: 0
+									Y: 0
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@PLAYER_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									Width: 200
+									Height: PARENT_BOTTOM 
+								Image@FLAG:
+									X: 5
+									Y: 4
+									Width: 35
+									Height: PARENT_BOTTOM - 4
+									ImageName: random
+									ImageCollection: flags
+								Label@PLAYER:
+									X: 35
+									Y: 0
+									Width: 120
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Shadow: True
+								ObserverArmyIcons@ARMY_ICONS:
 									X: 155
 									Y: 0
 									Width: 0

--- a/mods/common/chrome/mainmenu-prompts.yaml
+++ b/mods/common/chrome/mainmenu-prompts.yaml
@@ -1,0 +1,56 @@
+Background@MAINMENU_SYSTEM_INFO_PROMPT:
+	Logic: SystemInfoPromptLogic
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 520
+	Height: 260
+	Children:
+		Label@PROMPT_TITLE:
+			Width: PARENT_RIGHT
+			Y: 20
+			Height: 25
+			Font: Bold
+			Align: Center
+			Text: System Information
+		Label@PROMPT_TEXT_A:
+			X: 15
+			Y: 50
+			Width: PARENT_RIGHT - 30
+			Height: 16
+			Align: Center
+			Text: We would like to collect some details that will help us optimize OpenRA.
+		Label@PROMPT_TEXT_B:
+			X: 15
+			Y: 68
+			Width: PARENT_RIGHT - 30
+			Height: 16
+			Align: Center
+			Text: With your permission, the following anonymous system data will be sent:
+		ScrollPanel@SYSINFO_DATA:
+			X: 20
+			Y: 98
+			Width: PARENT_RIGHT - 40
+			TopBottomSpacing: 4
+			ItemSpacing: 4
+			Height: 110
+			Children:
+				Label@DATA_TEMPLATE:
+					X: 8
+					Height: 13
+					VAlign: Top
+					Font: Small
+		Checkbox@SYSINFO_CHECKBOX:
+			X: 40
+			Y: PARENT_BOTTOM - 42
+			Width: 200
+			Height: 20
+			Font: Regular
+			Text: Send System Information
+		Button@CONTINUE_BUTTON:
+			X: PARENT_RIGHT - WIDTH - 20
+			Y: PARENT_BOTTOM - 45
+			Width: 120
+			Height: 25
+			Text: Continue
+			Font: Bold
+			Key: return

--- a/mods/common/chrome/mainmenu-prompts.yaml
+++ b/mods/common/chrome/mainmenu-prompts.yaml
@@ -1,9 +1,9 @@
-Background@MAINMENU_SYSTEM_INFO_PROMPT:
-	Logic: SystemInfoPromptLogic
+Background@MAINMENU_INTRODUCTION_PROMPT:
+	Logic: IntroductionPromptLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
-	Width: 520
-	Height: 260
+	Width: 600
+	Height: 430
 	Children:
 		Label@PROMPT_TITLE:
 			Width: PARENT_RIGHT
@@ -11,28 +11,276 @@ Background@MAINMENU_SYSTEM_INFO_PROMPT:
 			Height: 25
 			Font: Bold
 			Align: Center
-			Text: System Information
+			Text: Establishing Battlefield Control
+		Label@DESC_A:
+			Width: PARENT_RIGHT
+			Y: 50
+			Height: 16
+			Font: Regular
+			Align: Center
+			Text: Welcome back Commander! Initialize combat parameters using the options below.
+		Label@DESC_B:
+			Width: PARENT_RIGHT
+			Y: 68
+			Height: 16
+			Font: Regular
+			Align: Center
+			Text: Additional options can be configured later from the Settings menu.
+		Label@PROFILE_TITLE:
+			Width: PARENT_RIGHT
+			Y: 100
+			Height: 25
+			Font: Bold
+			Align: Center
+			Text: Profile
+		Label@PLAYER:
+			Text: Player Name:
+			X: 20
+			Y: 130
+			Width: 120
+			Height: 25
+			Align: Right
+		TextField@PLAYERNAME:
+			X: 145
+			Y: 130
+			Width: 160
+			Height: 25
+			MaxLength: 16
+		Label@COLOR:
+			X: 265 + 60
+			Y: 130
+			Width: 145
+			Height: 25
+			Text: Preferred Color:
+			Align: Right
+		ColorPreviewManager@COLOR_MANAGER:
+		DropDownButton@PLAYERCOLOR:
+			X: 415 + 60
+			Y: 130
+			Width: 75
+			Height: 25
+			IgnoreChildMouseOver: true
+			PanelAlign: Right
+			Children:
+				ColorBlock@COLORBLOCK:
+					X: 5
+					Y: 6
+					Width: PARENT_RIGHT - 35
+					Height: PARENT_BOTTOM - 12
+		Label@INPUT_TITLE:
+			Width: PARENT_RIGHT
+			Y: 160
+			Height: 25
+			Font: Bold
+			Align: Center
+			Text: Input
+		Label@MOUSE_CONTROL_LABEL:
+			X: 20
+			Y: 190
+			Width: 120
+			Height: 25
+			Font: Regular
+			Text: Control Scheme:
+			Align: Right
+		DropDownButton@MOUSE_CONTROL_DROPDOWN:
+			X: 145
+			Y: 190
+			Width: 160
+			Height: 25
+			Font: Regular
+		Checkbox@EDGESCROLL_CHECKBOX:
+			X: 365
+			Y: 193
+			Width: 180
+			Height: 20
+			Font: Regular
+			Text: Screen Edge Panning
+		Container@MOUSE_CONTROL_DESC_CLASSIC:
+			X: 25
+			Y: 220
+			Width: PARENT_RIGHT - 50
+			Children:
+				LabelWithHighlight@DESC_SELECTION:
+					Height: 16
+					Font: Small
+					Text: - Select units using the {Left} mouse button
+				LabelWithHighlight@DESC_COMMANDS:
+					Y: 17
+					Height: 16
+					Font: Small
+					Text: - Command units using the {Left} mouse button
+				LabelWithHighlight@DESC_BUILDIGS:
+					Y: 34
+					Height: 16
+					Font: Small
+					Text: - Place structures using the {Left} mouse button
+				LabelWithHighlight@DESC_SUPPORT:
+					X: 265
+					Height: 16
+					Font: Small
+					Text: - Target support powers using the {Left} mouse button
+				LabelWithHighlight@DESC_ZOOM:
+					X: 265
+					Y: 17
+					Height: 16
+					Font: Small
+					Text: - Zoom the battlefield using the {Scroll Wheel}
+				LabelWithHighlight@DESC_ZOOM_MODIFIER:
+					X: 265
+					Y: 17
+					Height: 16
+					Font: Small
+					Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
+				LabelWithHighlight@DESC_SCROLL_RIGHT:
+					X: 265
+					Y: 34
+					Height: 16
+					Font: Small
+					Text: - Pan the battlefield using the {Right} mouse button
+				LabelWithHighlight@DESC_SCROLL_MIDDLE:
+					X: 265
+					Y: 34
+					Height: 16
+					Font: Small
+					Text: - Pan the battlefield using the {Middle} mouse button
+				Label@DESC_EDGESCROLL:
+					X: 274
+					Y: 51
+					Height: 16
+					Font: Small
+					Text: or by moving the cursor to the edge of the screen
+		Container@MOUSE_CONTROL_DESC_MODERN:
+			X: 25
+			Y: 220
+			Width: PARENT_RIGHT - 50
+			Children:
+				LabelWithHighlight@DESC_SELECTION:
+					Height: 16
+					Font: Small
+					Text: - Select units using the {Left} mouse button
+				LabelWithHighlight@DESC_COMMANDS:
+					Y: 17
+					Height: 16
+					Font: Small
+					Text: - Command units using the {Right} mouse button
+				LabelWithHighlight@DESC_BUILDIGS:
+					Y: 34
+					Height: 16
+					Font: Small
+					Text: - Place structures using the {Left} mouse button
+				LabelWithHighlight@DESC_SUPPORT:
+					X: 265
+					Height: 16
+					Font: Small
+					Text: - Target support powers using the {Left} mouse button
+				LabelWithHighlight@DESC_ZOOM:
+					X: 265
+					Y: 17
+					Height: 16
+					Font: Small
+					Text: - Zoom the battlefield using the {Scroll Wheel}
+				LabelWithHighlight@DESC_ZOOM_MODIFIER:
+					X: 265
+					Y: 17
+					Height: 16
+					Font: Small
+					Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
+				LabelWithHighlight@DESC_SCROLL:
+					X: 265
+					Y: 34
+					Height: 16
+					Font: Small
+					Text: - Pan the battlefield using the {Middle} mouse button
+				Label@DESC_EDGESCROLL:
+					X: 274
+					Y: 51
+					Height: 16
+					Font: Small
+					Text: or by moving the cursor to the edge of the screen
+		Label@INPUT_TITLE:
+			Width: PARENT_RIGHT
+			Y: 290
+			Height: 25
+			Font: Bold
+			Align: Center
+			Text: Display
+		Label@BATTLEFIELD_CAMERA:
+			X: 20
+			Y: 320
+			Width: 120
+			Height: 25
+			Text: Battlefield Camera:
+			Align: Right
+		DropDownButton@BATTLEFIELD_CAMERA_DROPDOWN:
+			X: 145
+			Y: 320
+			Width: 160
+			Height: 25
+			Font: Regular
+		Label@UI_SCALE:
+			X: 270
+			Y: 320
+			Width: 145
+			Height: 25
+			Text: UI Scale:
+			Align: Right
+		DropDownButton@UI_SCALE_DROPDOWN:
+			X: 420
+			Y: 320
+			Width: 160
+			Height: 25
+			Font: Regular
+		Checkbox@CURSORDOUBLE_CHECKBOX:
+			X: 390
+			Y: 353
+			Width: 200
+			Height: 20
+			Font: Regular
+			Text: Increase Cursor Size
+		Button@CONTINUE_BUTTON:
+			X: PARENT_RIGHT - 180
+			Y: PARENT_BOTTOM - 45 
+			Width: 160
+			Height: 25
+			Text: Continue
+			Font: Bold
+			Key: return
+
+Background@MAINMENU_SYSTEM_INFO_PROMPT:
+	Logic: SystemInfoPromptLogic
+	X: (WINDOW_RIGHT - WIDTH) / 2
+	Y: (WINDOW_BOTTOM - HEIGHT) / 2
+	Width: 600
+	Height: 430
+	Children:
+		Label@PROMPT_TITLE:
+			Width: PARENT_RIGHT
+			Y: 20
+			Height: 25
+			Font: Bold
+			Align: Center
+			Text: Establishing Battlefield Control
 		Label@PROMPT_TEXT_A:
 			X: 15
 			Y: 50
 			Width: PARENT_RIGHT - 30
 			Height: 16
 			Align: Center
-			Text: We would like to collect some details that will help us optimize OpenRA.
+			Text: We would like to collect some system details that will help us optimize OpenRA.
 		Label@PROMPT_TEXT_B:
 			X: 15
 			Y: 68
 			Width: PARENT_RIGHT - 30
 			Height: 16
 			Align: Center
-			Text: With your permission, the following anonymous system data will be sent:
+			Text: With your permission, the following anonymous data will be sent each game launch:
 		ScrollPanel@SYSINFO_DATA:
 			X: 20
 			Y: 98
 			Width: PARENT_RIGHT - 40
+			Height: 355-98-10
 			TopBottomSpacing: 4
 			ItemSpacing: 4
-			Height: 110
 			Children:
 				Label@DATA_TEMPLATE:
 					X: 8
@@ -40,8 +288,8 @@ Background@MAINMENU_SYSTEM_INFO_PROMPT:
 					VAlign: Top
 					Font: Small
 		Checkbox@SYSINFO_CHECKBOX:
-			X: 40
-			Y: PARENT_BOTTOM - 42
+			X: 390
+			Y: 353
 			Width: 200
 			Height: 20
 			Font: Regular
@@ -49,7 +297,7 @@ Background@MAINMENU_SYSTEM_INFO_PROMPT:
 		Button@CONTINUE_BUTTON:
 			X: PARENT_RIGHT - WIDTH - 20
 			Y: PARENT_BOTTOM - 45
-			Width: 120
+			Width: 160
 			Height: 25
 			Text: Continue
 			Font: Bold

--- a/mods/common/chrome/mainmenu.yaml
+++ b/mods/common/chrome/mainmenu.yaml
@@ -218,61 +218,6 @@ Container@MAINMENU:
 							Height: 30
 							Text: Back
 							Font: Bold
-		Background@SYSTEM_INFO_PROMPT:
-			X: (WINDOW_RIGHT - WIDTH) / 2
-			Y: (WINDOW_BOTTOM - HEIGHT) / 2
-			Width: 520
-			Height: 260
-			Children:
-				Label@PROMPT_TITLE:
-					Width: PARENT_RIGHT
-					Y: 20
-					Height: 25
-					Font: Bold
-					Align: Center
-					Text: System Information
-				Label@PROMPT_TEXT_A:
-					X: 15
-					Y: 50
-					Width: PARENT_RIGHT - 30
-					Height: 16
-					Align: Center
-					Text: We would like to collect some details that will help us optimize OpenRA.
-				Label@PROMPT_TEXT_B:
-					X: 15
-					Y: 68
-					Width: PARENT_RIGHT - 30
-					Height: 16
-					Align: Center
-					Text: With your permission, the following anonymous system data will be sent:
-				ScrollPanel@SYSINFO_DATA:
-					X: 20
-					Y: 98
-					Width: PARENT_RIGHT - 40
-					TopBottomSpacing: 4
-					ItemSpacing: 4
-					Height: 110
-					Children:
-						Label@DATA_TEMPLATE:
-							X: 8
-							Height: 13
-							VAlign: Top
-							Font: Small
-				Checkbox@SYSINFO_CHECKBOX:
-					X: 40
-					Y: PARENT_BOTTOM - 42
-					Width: 200
-					Height: 20
-					Font: Regular
-					Text: Send System Information
-				Button@BACK_BUTTON:
-					X: PARENT_RIGHT - WIDTH - 20
-					Y: PARENT_BOTTOM - 45
-					Width: 120
-					Height: 25
-					Text: Continue
-					Font: Bold
-					Key: return
 		Container@PERFORMANCE_INFO:
 			Logic: PerfDebugLogic
 			Children:

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -214,13 +214,6 @@ Background@SETTINGS_PANEL:
 					Height: 25
 					Font: Regular
 					Text: Windowed
-				Label@MODE_CHANGES_DESC:
-					X: 100
-					Y: 237
-					Width: 200
-					Height: 15
-					Font: Tiny
-					Text: Video mode changes require restart
 				Checkbox@VSYNC_CHECKBOX:
 					X: 310
 					Y: 213
@@ -263,6 +256,28 @@ Background@SETTINGS_PANEL:
 							Height: 15
 							Font: Tiny
 							Text: Video mode and window size changes require restart
+				Container@DISPLAY_SELECTION:
+					Y: 240
+					Children:
+						Label@DISPLAY_SELECTION_LABEL:
+							X: 15
+							Height: 25
+							Width: 120
+							Align: Right
+							Text: Select Display:
+						DropDownButton@DISPLAY_SELECTION_DROPDOWN:
+							X: 140
+							Width: 160
+							Height: 25
+							Font: Regular
+							Text: Standard
+						Label@MODE_CHANGES_DESC:
+							X: 60
+							Y: 27
+							Width: 200
+							Height: 15
+							Font: Tiny
+							Text: Video mode and display changes require restart
 				Checkbox@FRAME_LIMIT_CHECKBOX:
 					X: 310
 					Y: 243

--- a/mods/common/chrome/tooltips.yaml
+++ b/mods/common/chrome/tooltips.yaml
@@ -319,3 +319,21 @@ Background@SUPPORT_POWER_TOOLTIP:
 			Y: 24
 			Font: TinyBold
 			VAlign: Top
+
+Background@ARMY_TOOLTIP:
+	Logic: ArmyTooltipLogic
+	Background: dialog4
+	Width: 200
+	Height: 65
+	Children:
+		Label@NAME:
+			X: 7
+			Y: 3
+			Height: 23
+			Font: Bold
+		Label@DESC:
+			X: 7
+			Y: 27
+			Height: 2
+			Font: TinyBold
+			VAlign: Top

--- a/mods/common/hotkeys/observer.yaml
+++ b/mods/common/hotkeys/observer.yaml
@@ -46,10 +46,14 @@ StatisticsCombat: F6
 	Description: Combat statistics
 	Types: Observer, Replay, Spectator
 
-StatisticsGraph: F7
+StatisticsArmy: F7
+	Description: Army statistics
+	Types: Observer, Replay, Spectator
+
+StatisticsGraph:
 	Description: Statistics graph
 	Types: Observer, Replay, Spectator
 
-StatisticsArmyGraph: F8
+StatisticsArmyGraph:
 	Description: Army value graph
 	Types: Observer, Replay, Spectator

--- a/mods/d2k/chrome/ingame-observer.yaml
+++ b/mods/d2k/chrome/ingame-observer.yaml
@@ -1,0 +1,997 @@
+Container@OBSERVER_WIDGETS:
+	Logic: MenuButtonsChromeLogic
+	Children:
+		LogicKeyListener@OBSERVER_KEY_LISTENER:
+		MenuButton@OPTIONS_BUTTON:
+			X: 5
+			Y: 5
+			Width: 160
+			Height: 25
+			Text: Options (Esc)
+			Font: Bold
+			Key: escape
+			DisableWorldSounds: true
+		Container@GAME_TIMER_BLOCK:
+			Logic: GameTimerLogic
+			X: (WINDOW_RIGHT - WIDTH) / 2
+			Width: 100
+			Height: 55
+			Children:
+				LabelWithTooltip@GAME_TIMER:
+					Width: PARENT_RIGHT
+					Height: 30
+					Align: Center
+					Font: Title
+					Contrast: true
+					TooltipContainer: TOOLTIP_CONTAINER
+					TooltipTemplate: SIMPLE_TOOLTIP
+				Label@GAME_TIMER_STATUS:
+					Y: 32
+					Width: PARENT_RIGHT
+					Height: 15
+					Align: Center
+					Font: Bold
+					Contrast: true
+		Background@RADAR_BG:
+			X: WINDOW_RIGHT - 255
+			Y: 5
+			Width: 250
+			Height: 250
+			Children:
+				Radar@INGAME_RADAR:
+					X: 10
+					Y: 10
+					Width: PARENT_RIGHT - 19
+					Height: PARENT_BOTTOM - 19
+					WorldInteractionController: INTERACTION_CONTROLLER
+				VqaPlayer@PLAYER:
+					X: 10
+					Y: 10
+					Width: PARENT_RIGHT - 20
+					Height: PARENT_BOTTOM - 20
+					Skippable: false
+		Background@OBSERVER_CONTROL_BG:
+			X: WINDOW_RIGHT - 255
+			Y: 260
+			Width: 250
+			Height: 55
+			Children:
+				DropDownButton@SHROUD_SELECTOR:
+					Logic: ObserverShroudSelectorLogic
+						CombinedViewKey: ObserverCombinedView
+						WorldViewKey: ObserverWorldView
+					X: 15
+					Y: 15
+					Width: 220
+					Height: 25
+					Font: Bold
+					Children:
+						LogicKeyListener@SHROUD_KEYHANDLER:
+						Image@FLAG:
+							Width: 23
+							Height: 23
+							X: 4
+							Y: 2
+						Label@LABEL:
+							X: 34
+							Width: 60
+							Height: 25
+							Shadow: True
+						Label@NOFLAG_LABEL:
+							X: 5
+							Width: PARENT_RIGHT
+							Height: 25
+							Shadow: True
+				Container@REPLAY_PLAYER:
+					Logic: ReplayControlBarLogic
+					Y: 39
+					Width: 160
+					Height: 35
+					Visible: false
+					Children:
+						Button@BUTTON_PAUSE:
+							X: 15
+							Y: 10
+							Width: 26
+							Height: 26
+							Key: Pause
+							TooltipText: Pause
+							TooltipContainer: TOOLTIP_CONTAINER
+							IgnoreChildMouseOver: true
+							Children:
+								Image@IMAGE_PAUSE:
+									X: 5
+									Y: 5
+									ImageCollection: music
+									ImageName: pause
+						Button@BUTTON_PLAY:
+							X: 15
+							Y: 10
+							Width: 26
+							Height: 26
+							Key: Pause
+							IgnoreChildMouseOver: true
+							TooltipText: Play
+							TooltipContainer: TOOLTIP_CONTAINER
+							Children:
+								Image@IMAGE_PLAY:
+									X: 5
+									Y: 5
+									ImageCollection: music
+									ImageName: play
+						Button@BUTTON_SLOW:
+							X: 55
+							Y: 13
+							Width: 36
+							Height: 20
+							Key: ReplaySpeedSlow
+							TooltipText: Slow speed
+							TooltipContainer: TOOLTIP_CONTAINER
+							Text: 50%
+							Font: TinyBold
+						Button@BUTTON_REGULAR:
+							X: 55 + 45
+							Y: 13
+							Width: 38
+							Height: 20
+							Key: ReplaySpeedRegular
+							TooltipText: Regular speed
+							TooltipContainer: TOOLTIP_CONTAINER
+							Text: 100%
+							Font: TinyBold
+						Button@BUTTON_FAST:
+							X: 55 + 45 * 2
+							Y: 13
+							Width: 38
+							Height: 20
+							Key: ReplaySpeedFast
+							TooltipText: Fast speed
+							TooltipContainer: TOOLTIP_CONTAINER
+							Text: 200%
+							Font: TinyBold
+						Button@BUTTON_MAXIMUM:
+							X: 55 + 45 * 3
+							Y: 13
+							Width: 38
+							Height: 20
+							Key: ReplaySpeedMax
+							TooltipText: Maximum speed
+							TooltipContainer: TOOLTIP_CONTAINER
+							Text: MAX
+							Font: TinyBold
+		Container@INGAME_OBSERVERSTATS_BG:
+			Logic: ObserverStatsLogic
+				StatisticsNoneKey: StatisticsNone
+				StatisticsBasicKey: StatisticsBasic
+				StatisticsEconomyKey: StatisticsEconomy
+				StatisticsProductionKey: StatisticsProduction
+				StatisticsSupportPowersKey: StatisticsSupportPowers
+				StatisticsCombatKey: StatisticsCombat
+				StatisticsArmyKey: StatisticsArmy
+				StatisticsGraphKey: StatisticsGraph
+				StatisticsArmyGraphKey: StatisticsArmyGraph
+			X: 5
+			Y: 5
+			Width: 760
+			Height: 250
+			Children:
+				DropDownButton@STATS_DROPDOWN:
+					X: 165
+					Y: 0
+					Width: 185
+					Height: 25
+					Font: Bold
+					Children:
+						LogicKeyListener@STATS_DROPDOWN_KEYHANDLER:
+				Container@GRAPH_BG:
+					Y: 30
+					X: 0
+					Width: PARENT_RIGHT
+					Height: 25
+					Children:
+						Container@BASIC_STATS_HEADERS:
+							X: 0
+							Y: 0
+							Width: 700
+							Height: PARENT_BOTTOM
+							Children:
+								ColorBlock@HEADER_COLOR:
+									X: 0
+									Y: 0
+									Color: 00000090
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@HEADER_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									TopLeftColor: 00000090
+									BottomLeftColor: 00000090
+									Width: 200
+									Height: PARENT_BOTTOM
+								Label@PLAYER_HEADER:
+									X: 35
+									Y: 0
+									Width: 120
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Player
+									Align: Left
+									Shadow: True
+								Label@CASH_HEADER:
+									X: 155
+									Y: 0
+									Width: 80
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Cash
+									Align: Right
+									Shadow: True
+								Label@POWER_HEADER:
+									X: 235
+									Y: 0
+									Width: 80
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Power
+									Align: Center
+									Shadow: True
+								Label@KILLS_HEADER:
+									X: 315
+									Y: 0
+									Width: 40
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Kills
+									Align: Right
+									Shadow: True
+								Label@DEATHS_HEADER:
+									X: 355
+									Y: 0
+									Width: 60
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Deaths
+									Align: Right
+									Shadow: True
+								Label@ASSETS_DESTROYED_HEADER:
+									X: 415
+									Y: 0
+									Width: 80
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Destroyed
+									Align: Right
+									Shadow: True
+								Label@ASSETS_LOST_HEADER:
+									X: 495
+									Y: 0
+									Width: 80
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Lost
+									Align: Right
+									Shadow: True
+								Label@EXPERIENCE_HEADER:
+									X: 575
+									Y: 0
+									Width: 60
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Score
+									Align: Right
+									Shadow: True
+								Label@ACTIONS_MIN_HEADER:
+									X: 635
+									Y: 0
+									Width: 60
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: APM
+									Align: Right
+									Shadow: True
+						Container@ECONOMY_STATS_HEADERS:
+							X: 0
+							Y: 0
+							Width: 640
+							Height: PARENT_BOTTOM
+							Children:
+								ColorBlock@HEADER_COLOR:
+									X: 0
+									Y: 0
+									Color: 00000090
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@HEADER_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									TopLeftColor: 00000090
+									BottomLeftColor: 00000090
+									Width: 200
+									Height: PARENT_BOTTOM
+								Label@PLAYER_HEADER:
+									X: 35
+									Width: 120
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Player
+									Shadow: True
+								Label@CASH_HEADER:
+									X: 155
+									Width: 80
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Cash
+									Align: Right
+									Shadow: True
+								Label@INCOME_HEADER:
+									X: 235
+									Width: 80
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Income
+									Align: Right
+									Shadow: True
+								Label@ASSETS_HEADER:
+									X: 315
+									Width: 80
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Assets
+									Align: Right
+									Shadow: True
+								Label@EARNED_HEADER:
+									X: 395
+									Width: 80
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Earned
+									Align: Right
+									Shadow: True
+								Label@SPENT_HEADER:
+									X: 475
+									Width: 80
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Spent
+									Align: Right
+									Shadow: True
+								Label@HARVESTERS_HEADER:
+									X: 555
+									Width: 80
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Harvesters
+									Align: Right
+									Shadow: True
+						Container@PRODUCTION_STATS_HEADERS:
+							X: 0
+							Y: 0
+							Width: 400
+							Height: PARENT_BOTTOM
+							Children:
+								ColorBlock@HEADER_COLOR:
+									X: 0
+									Y: 0
+									Color: 00000090
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@HEADER_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									TopLeftColor: 00000090
+									BottomLeftColor: 00000090
+									Width: 200
+									Height: PARENT_BOTTOM
+								Label@PLAYER_HEADER:
+									X: 35
+									Y: 0
+									Width: 120
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Player
+									Align: Left
+									Shadow: True
+								Label@PRODUCTION_HEADER:
+									X: 155
+									Y: 0
+									Width: 100
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Production
+									Shadow: True
+						Container@SUPPORT_POWERS_HEADERS:
+							X: 0
+							Y: 0
+							Width: 400
+							Height: PARENT_BOTTOM
+							Children:
+								ColorBlock@HEADER_COLOR:
+									X: 0
+									Y: 0
+									Color: 00000090
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@HEADER_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									TopLeftColor: 00000090
+									BottomLeftColor: 00000090
+									Width: 200
+									Height: PARENT_BOTTOM
+								Label@PLAYER_HEADER:
+									X: 35
+									Y: 0
+									Width: 120
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Player
+									Align: Left
+									Shadow: True
+								Label@SUPPORT_POWERS_HEADER:
+									X: 155
+									Y: 0
+									Width: 100
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Support Powers
+									Shadow: True
+						Container@ARMY_HEADERS:
+							X: 0
+							Y: 0
+							Width: 400
+							Height: PARENT_BOTTOM
+							Children:
+								ColorBlock@HEADER_COLOR:
+									X: 0
+									Y: 0
+									Color: 00000090
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@HEADER_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									TopLeftColor: 00000090
+									BottomLeftColor: 00000090
+									Width: 200
+									Height: PARENT_BOTTOM
+								Label@PLAYER_HEADER:
+									X: 35
+									Y: 0
+									Width: 120
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Player
+									Align: Left
+									Shadow: True
+								Label@ARMY_HEADER:
+									X: 155
+									Y: 0
+									Width: 100
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Army
+									Shadow: True
+						Container@COMBAT_STATS_HEADERS:
+							X: 0
+							Y: 0
+							Width: 735
+							Height: PARENT_BOTTOM
+							Children:
+								ColorBlock@HEADER_COLOR:
+									X: 0
+									Y: 0
+									Color: 00000090
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@HEADER_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									TopLeftColor: 00000090
+									BottomLeftColor: 00000090
+									Width: 200
+									Height: PARENT_BOTTOM
+								Label@PLAYER_HEADER:
+									X: 35
+									Y: 0
+									Width: 120
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Player
+									Align: Left
+									Shadow: True
+								Label@ASSETS_DESTROYED_HEADER:
+									X: 155
+									Y: 0
+									Width: 75
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Destroyed
+									Align: Right
+									Shadow: True
+								Label@ASSETS_LOST_HEADER:
+									X: 230
+									Y: 0
+									Width: 75
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Lost
+									Align: Right
+									Shadow: True
+								Label@UNITS_KILLED_HEADER:
+									X: 305
+									Y: 0
+									Width: 90
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Units Killed
+									Align: Right
+									Shadow: True
+								Label@UNITS_DEAD_HEADER:
+									X: 395
+									Y: 0
+									Width: 80
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Units Lost
+									Align: Right
+									Shadow: True
+								Label@BUILDINGS_KILLED_HEADER:
+									X: 475
+									Y: 0
+									Width: 85
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Bldg Killed
+									Align: Right
+									Shadow: True
+								Label@BUILDINGS_DEAD_HEADER:
+									X: 560
+									Y: 0
+									Width: 80
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Bldg Lost
+									Align: Right
+									Shadow: True
+								Label@ARMY_VALUE_HEADER:
+									X: 640
+									Y: 0
+									Width: 90
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Army Value
+									Align: Right
+									Shadow: True
+				ScrollPanel@PLAYER_STATS_PANEL:
+					X: 0
+					Y: 55
+					Width: PARENT_RIGHT
+					Height: 250
+					TopBottomSpacing: 0
+					BorderWidth: 0
+					Background:
+					ScrollbarWidth: 25
+					ScrollBar: Hidden
+					Children:
+						ScrollItem@TEAM_TEMPLATE:
+							X: 0
+							Y: 0
+							Width: 650 #PARENT_RIGHT - 35
+							Height: 25
+							Children:
+								ColorBlock@TEAM_COLOR:
+									X: 0
+									Y: 0
+									Color: 00000090
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@TEAM_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									TopLeftColor: 00000090
+									BottomLeftColor: 00000090
+									Width: 200
+									Height: PARENT_BOTTOM
+								Label@TEAM:
+									X: 10
+									Y: 0
+									Width: PARENT_RIGHT
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Shadow: True
+						ScrollItem@BASIC_PLAYER_TEMPLATE:
+							X: 0
+							Y: 0
+							Width: 700
+							Height: 25
+							BaseName: scrollitem-nohover
+							Children:
+								ColorBlock@PLAYER_COLOR:
+									X: 0
+									Y: 0
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@PLAYER_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									Width: 200
+									Height: PARENT_BOTTOM
+								Image@FLAG:
+									X: 2
+									Y: 2
+									ImageName: random
+									ImageCollection: flags
+								Label@PLAYER:
+									X: 35
+									Y: 0
+									Width: 120
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Shadow: True
+								Label@CASH:
+									X: 155
+									Y: 0
+									Width: 80
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@POWER:
+									X: 235
+									Y: 0
+									Width: 80
+									Height: PARENT_BOTTOM
+									Align: Center
+									Shadow: True
+								Label@KILLS:
+									X: 315
+									Y: 0
+									Width: 40
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@DEATHS:
+									X: 355
+									Y: 0
+									Width: 60
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@ASSETS_DESTROYED:
+									X: 415
+									Y: 0
+									Width: 80
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@ASSETS_LOST:
+									X: 495
+									Y: 0
+									Width: 80
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@EXPERIENCE:
+									X: 575
+									Y: 0
+									Width: 60
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@ACTIONS_MIN:
+									X: 635
+									Y: 0
+									Width: 60
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+						ScrollItem@ECONOMY_PLAYER_TEMPLATE:
+							X: 0
+							Y: 0
+							Width: 640
+							Height: 25
+							BaseName: scrollitem-nohover
+							Children:
+								ColorBlock@PLAYER_COLOR:
+									X: 0
+									Y: 0
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@PLAYER_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									Width: 200
+									Height: PARENT_BOTTOM
+								Image@FLAG:
+									X: 2
+									Y: 2
+									ImageName: random
+									ImageCollection: flags
+								Label@PLAYER:
+									X: 35
+									Y: 0
+									Width: 120
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Shadow: True
+								Label@CASH:
+									X: 155
+									Y: 0
+									Width: 80
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@INCOME:
+									X: 235
+									Y: 0
+									Width: 80
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@ASSETS:
+									X: 315
+									Y: 0
+									Width: 80
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@EARNED:
+									X: 395
+									Y: 0
+									Width: 80
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@SPENT:
+									X: 475
+									Y: 0
+									Width: 80
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@HARVESTERS:
+									X: 555
+									Y: 0
+									Width: 80
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+						ScrollItem@PRODUCTION_PLAYER_TEMPLATE:
+							X: 0
+							Y: 0
+							Width: 400
+							Height: 25
+							BaseName: scrollitem-nohover
+							Children:
+								ColorBlock@PLAYER_COLOR:
+									X: 0
+									Y: 0
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@PLAYER_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									Width: 200
+									Height: PARENT_BOTTOM
+								Image@FLAG:
+									X: 2
+									Y: 2
+									ImageName: random
+									ImageCollection: flags
+								Label@PLAYER:
+									X: 35
+									Y: 0
+									Width: 120
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Shadow: True
+								ObserverProductionIcons@PRODUCTION_ICONS:
+									X: 155
+									Y: 1
+									Width: 0
+									IconWidth: 30
+									Height: PARENT_BOTTOM
+									TooltipContainer: TOOLTIP_CONTAINER
+						ScrollItem@SUPPORT_POWERS_PLAYER_TEMPLATE:
+							X: 0
+							Y: 0
+							Width: 400
+							Height: 25
+							BaseName: scrollitem-nohover
+							Children:
+								ColorBlock@PLAYER_COLOR:
+									X: 0
+									Y: 0
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@PLAYER_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									Width: 200
+									Height: PARENT_BOTTOM
+								Image@FLAG:
+									X: 2
+									Y: 2
+									ImageName: random
+									ImageCollection: flags
+								Label@PLAYER:
+									X: 35
+									Y: 0
+									Width: 120
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Shadow: True
+								ObserverSupportPowerIcons@SUPPORT_POWER_ICONS:
+									X: 155
+									Y: 1
+									Width: 0
+									Height: PARENT_BOTTOM
+									IconWidth: 30
+									TooltipContainer: TOOLTIP_CONTAINER
+						ScrollItem@ARMY_PLAYER_TEMPLATE:
+							X: 0
+							Y: 0
+							Width: 400
+							Height: 25
+							BaseName: scrollitem-nohover
+							Children:
+								ColorBlock@PLAYER_COLOR:
+									X: 0
+									Y: 0
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@PLAYER_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									Width: 200
+									Height: PARENT_BOTTOM 
+								Image@FLAG:
+									X: 2
+									Y: 2
+									Width: 35
+									Height: PARENT_BOTTOM - 4
+									ImageName: random
+									ImageCollection: flags
+								Label@PLAYER:
+									X: 35
+									Y: 0
+									Width: 120
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Shadow: True
+								ObserverArmyIcons@ARMY_ICONS:
+									X: 155
+									Y: 1
+									Width: 0
+									Height: PARENT_BOTTOM
+									IconWidth: 30
+									TooltipContainer: TOOLTIP_CONTAINER
+						ScrollItem@COMBAT_PLAYER_TEMPLATE:
+							X: 0
+							Y: 0
+							Width: 735
+							Height: 25
+							BaseName: scrollitem-nohover
+							Children:
+								ColorBlock@PLAYER_COLOR:
+									X: 0
+									Y: 0
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@PLAYER_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									Width: 200
+									Height: PARENT_BOTTOM
+								Image@FLAG:
+									X: 2
+									Y: 2
+									ImageName: random
+									ImageCollection: flags
+								Label@PLAYER:
+									X: 35
+									Y: 0
+									Width: 120
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Shadow: True
+								Label@ASSETS_DESTROYED:
+									X: 155
+									Y: 0
+									Width: 75
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@ASSETS_LOST:
+									X: 230
+									Y: 0
+									Width: 75
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@UNITS_KILLED:
+									X: 305
+									Y: 0
+									Width: 90
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@UNITS_DEAD:
+									X: 395
+									Y: 0
+									Width: 80
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@BUILDINGS_KILLED:
+									X: 475
+									Y: 0
+									Width: 85
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@BUILDINGS_DEAD:
+									X: 560
+									Y: 0
+									Width: 80
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+								Label@ARMY_VALUE:
+									X: 640
+									Y: 0
+									Width: 90
+									Height: PARENT_BOTTOM
+									Align: Right
+									Shadow: True
+				Container@INCOME_GRAPH_CONTAINER:
+					X: 0
+					Y: 30
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
+					Visible: False
+					Children:
+						ColorBlock@GRAPH_BACKGROUND:
+							X: 0
+							Y: 0
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Color: 00000090
+						LineGraph@INCOME_GRAPH:
+							X: 0
+							Y: 0
+							Width: PARENT_RIGHT - 5
+							Height: PARENT_BOTTOM
+							ValueFormat: ${0}
+							YAxisValueFormat: ${0:F0}
+							XAxisSize: 40
+							XAxisTicksPerLabel: 2
+							XAxisLabel: Game Minute
+							YAxisLabel: Earnings
+							LabelFont: TinyBold
+							AxisFont: TinyBold
+				Container@ARMY_VALUE_GRAPH_CONTAINER:
+					X: 0
+					Y: 30
+					Width: PARENT_RIGHT
+					Height: PARENT_BOTTOM
+					Visible: False
+					Children:
+						ColorBlock@GRAPH_BACKGROUND:
+							X: 0
+							Y: 0
+							Width: PARENT_RIGHT
+							Height: PARENT_BOTTOM
+							Color: 00000090
+						LineGraph@ARMY_VALUE_GRAPH:
+							X: 0
+							Y: 0
+							Width: PARENT_RIGHT - 5
+							Height: PARENT_BOTTOM
+							ValueFormat: ${0}
+							YAxisValueFormat: ${0:F0}
+							XAxisSize: 40
+							XAxisTicksPerLabel: 2
+							XAxisLabel: Game Minute
+							YAxisLabel: Army Value
+							LabelFont: TinyBold
+							AxisFont: TinyBold

--- a/mods/d2k/chrome/mainmenu.yaml
+++ b/mods/d2k/chrome/mainmenu.yaml
@@ -205,61 +205,6 @@ Container@MAINMENU:
 							Height: 30
 							Text: Back
 							Font: Bold
-		Background@SYSTEM_INFO_PROMPT:
-			X: (WINDOW_RIGHT - WIDTH) / 2
-			Y: (WINDOW_BOTTOM - HEIGHT) / 2
-			Width: 520
-			Height: 260
-			Children:
-				Label@PROMPT_TITLE:
-					Width: PARENT_RIGHT
-					Y: 21
-					Height: 25
-					Font: Bold
-					Align: Center
-					Text: System Information
-				Label@PROMPT_TEXT_A:
-					X: 15
-					Y: 51
-					Width: PARENT_RIGHT - 30
-					Height: 16
-					Align: Center
-					Text: We would like to collect some details that will help us optimize OpenRA.
-				Label@PROMPT_TEXT_B:
-					X: 15
-					Y: 69
-					Width: PARENT_RIGHT - 30
-					Height: 16
-					Align: Center
-					Text: With your permission, the following anonymous system data will be sent:
-				ScrollPanel@SYSINFO_DATA:
-					X: 20
-					Y: 98
-					Width: PARENT_RIGHT - 40
-					TopBottomSpacing: 4
-					ItemSpacing: 4
-					Height: 110
-					Children:
-						Label@DATA_TEMPLATE:
-							X: 8
-							Height: 13
-							VAlign: Top
-							Font: Small
-				Checkbox@SYSINFO_CHECKBOX:
-					X: 40
-					Y: PARENT_BOTTOM - 42
-					Width: 200
-					Height: 20
-					Font: Regular
-					Text: Send System Information
-				Button@BACK_BUTTON:
-					X: PARENT_RIGHT - WIDTH - 20
-					Y: PARENT_BOTTOM - 45
-					Width: 120
-					Height: 25
-					Text: Continue
-					Font: Bold
-					Key: return
 		Background@NEWS_BG:
 			X: (WINDOW_RIGHT - WIDTH) / 2
 			Y: 35

--- a/mods/d2k/chrome/tooltips.yaml
+++ b/mods/d2k/chrome/tooltips.yaml
@@ -321,3 +321,21 @@ Background@SUPPORT_POWER_TOOLTIP:
 			Y: 30
 			Font: TinyBold
 			VAlign: Top
+
+Background@ARMY_TOOLTIP:
+	Logic: ArmyTooltipLogic
+	Background: dialog3
+	Width: 200
+	Height: 65
+	Children:
+		Label@NAME:
+			X: 7
+			Y: 3
+			Height: 23
+			Font: Bold
+		Label@DESC:
+			X: 7
+			Y: 23
+			Height: 3
+			Font: TinyBold
+			VAlign: Top

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -75,7 +75,7 @@ ChromeLayout:
 	common|chrome/ingame-infobriefing.yaml
 	common|chrome/ingame-infoobjectives.yaml
 	d2k|chrome/ingame-infostats.yaml
-	common|chrome/ingame-observer.yaml
+	d2k|chrome/ingame-observer.yaml
 	d2k|chrome/ingame-player.yaml
 	common|chrome/ingame-perf.yaml
 	common|chrome/ingame-debug.yaml

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -82,6 +82,7 @@ ChromeLayout:
 	common|chrome/ingame-debuginfo.yaml
 	common|chrome/ingame-infochat.yaml
 	d2k|chrome/mainmenu.yaml
+	common|chrome/mainmenu-prompts.yaml
 	common|chrome/settings.yaml
 	common|chrome/credits.yaml
 	common|chrome/lobby.yaml

--- a/mods/d2k/rules/starport.yaml
+++ b/mods/d2k/rules/starport.yaml
@@ -8,6 +8,8 @@ mcv.starport:
 	-MapEditorData:
 	RenderSprites:
 		Image: mcv
+	UpdatesPlayerStatistics:
+		OverrideActor: mcv
 
 harvester.starport:
 	Inherits: harvester
@@ -19,6 +21,8 @@ harvester.starport:
 	-MapEditorData:
 	RenderSprites:
 		Image: harvester
+	UpdatesPlayerStatistics:
+		OverrideActor: harvester
 
 trike.starport:
 	Inherits: trike
@@ -30,6 +34,8 @@ trike.starport:
 	-MapEditorData:
 	RenderSprites:
 		Image: trike
+	UpdatesPlayerStatistics:
+		OverrideActor: trike
 
 quad.starport:
 	Inherits: quad
@@ -41,6 +47,8 @@ quad.starport:
 	-MapEditorData:
 	RenderSprites:
 		Image: quad
+	UpdatesPlayerStatistics:
+		OverrideActor: quad
 
 siege_tank.starport:
 	Inherits: siege_tank
@@ -52,6 +60,8 @@ siege_tank.starport:
 	-MapEditorData:
 	RenderSprites:
 		Image: siege_tank
+	UpdatesPlayerStatistics:
+		OverrideActor: siege_tank
 
 missile_tank.starport:
 	Inherits: missile_tank
@@ -63,6 +73,8 @@ missile_tank.starport:
 	-MapEditorData:
 	RenderSprites:
 		Image: missile_tank
+	UpdatesPlayerStatistics:
+		OverrideActor: missile_tank
 
 combat_tank_a.starport:
 	Inherits: combat_tank_a
@@ -74,6 +86,8 @@ combat_tank_a.starport:
 	-MapEditorData:
 	RenderSprites:
 		Image: combat_tank_a
+	UpdatesPlayerStatistics:
+		OverrideActor: combat_tank_a
 
 combat_tank_h.starport:
 	Inherits: combat_tank_h
@@ -85,6 +99,8 @@ combat_tank_h.starport:
 	-MapEditorData:
 	RenderSprites:
 		Image: combat_tank_h
+	UpdatesPlayerStatistics:
+		OverrideActor: combat_tank_h
 
 combat_tank_o.starport:
 	Inherits: combat_tank_o
@@ -96,6 +112,8 @@ combat_tank_o.starport:
 	-MapEditorData:
 	RenderSprites:
 		Image: combat_tank_o
+	UpdatesPlayerStatistics:
+		OverrideActor: combat_tank_o
 
 carryall.starport:
 	Inherits: carryall
@@ -105,3 +123,5 @@ carryall.starport:
 	Valued:
 		Cost: 1500
 	-MapEditorData:
+	UpdatesPlayerStatistics:
+		OverrideActor: carryall

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -202,7 +202,6 @@ barracks:
 	RevealsShroud:
 		Range: 3c768
 	RallyPoint:
-		Path: 1,2
 	Exit@1:
 		SpawnOffset: 352,576,0
 		ExitCell: 0,2
@@ -418,7 +417,6 @@ light_factory:
 		Queues: Vehicle
 		Sequence: production-welding
 	RallyPoint:
-		Path: 2,2
 	Exit@1:
 		SpawnOffset: 544,-224,0
 		ExitCell: 2,1
@@ -500,7 +498,6 @@ heavy_factory:
 	RevealsShroud:
 		Range: 4c768
 	RallyPoint:
-		Path: 0,3
 	Exit@1:
 		SpawnOffset: 256,192,0
 		ExitCell: 0,2
@@ -652,7 +649,6 @@ starport:
 	RevealsShroud:
 		Range: 3c768
 	RallyPoint:
-		Path: 1,3
 	Exit@1:
 		SpawnOffset: 0,-480,0
 		ExitCell: 2,2
@@ -907,7 +903,6 @@ repair_pad:
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
 	RallyPoint:
-		Path: 1,3
 	RenderSprites:
 		Image: repair_pad.ordos
 		FactionImages:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -202,7 +202,7 @@ barracks:
 	RevealsShroud:
 		Range: 3c768
 	RallyPoint:
-		Offset: 1,2
+		Path: 1,2
 	Exit@1:
 		SpawnOffset: 352,576,0
 		ExitCell: 0,2
@@ -418,7 +418,7 @@ light_factory:
 		Queues: Vehicle
 		Sequence: production-welding
 	RallyPoint:
-		Offset: 2,2
+		Path: 2,2
 	Exit@1:
 		SpawnOffset: 544,-224,0
 		ExitCell: 2,1
@@ -500,7 +500,7 @@ heavy_factory:
 	RevealsShroud:
 		Range: 4c768
 	RallyPoint:
-		Offset: 0,3
+		Path: 0,3
 	Exit@1:
 		SpawnOffset: 256,192,0
 		ExitCell: 0,2
@@ -652,7 +652,7 @@ starport:
 	RevealsShroud:
 		Range: 3c768
 	RallyPoint:
-		Offset: 1,3
+		Path: 1,3
 	Exit@1:
 		SpawnOffset: 0,-480,0
 		ExitCell: 2,2
@@ -907,7 +907,7 @@ repair_pad:
 		FinishRepairingNotification: UnitRepaired
 		PlayerExperience: 15
 	RallyPoint:
-		Offset: 1,3
+		Path: 1,3
 	RenderSprites:
 		Image: repair_pad.ordos
 		FactionImages:

--- a/mods/ra/chrome/ingame-observer.yaml
+++ b/mods/ra/chrome/ingame-observer.yaml
@@ -203,6 +203,7 @@ Container@OBSERVER_WIDGETS:
 				StatisticsProductionKey: StatisticsProduction
 				StatisticsSupportPowersKey: StatisticsSupportPowers
 				StatisticsCombatKey: StatisticsCombat
+				StatisticsArmyKey: StatisticsArmy
 				StatisticsGraphKey: StatisticsGraph
 				StatisticsArmyGraphKey: StatisticsArmyGraph
 				StatsDropDownPanelTemplate: SPECTATOR_LABEL_DROPDOWN_TEMPLATE
@@ -480,6 +481,42 @@ Container@OBSERVER_WIDGETS:
 									Height: PARENT_BOTTOM
 									Font: Bold
 									Text: Support Powers
+									Shadow: True
+						Container@ARMY_HEADERS:
+							X: 0
+							Y: 0
+							Width: 400
+							Height: PARENT_BOTTOM
+							Children:
+								ColorBlock@HEADER_COLOR:
+									X: 0
+									Y: 0
+									Color: 00000090
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@HEADER_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									TopLeftColor: 00000090
+									BottomLeftColor: 00000090
+									Width: 200
+									Height: PARENT_BOTTOM
+								Label@PLAYER_HEADER:
+									X: 40
+									Y: 0
+									Width: 120
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Player
+									Align: Left
+									Shadow: True
+								Label@ARMY_HEADER:
+									X: 160
+									Y: 0
+									Width: 100
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Army
 									Shadow: True
 						Container@COMBAT_STATS_HEADERS:
 							X: 0
@@ -847,6 +884,43 @@ Container@OBSERVER_WIDGETS:
 									Font: Bold
 									Shadow: True
 								ObserverSupportPowerIcons@SUPPORT_POWER_ICONS:
+									X: 160
+									Y: 0
+									Width: 0
+									Height: PARENT_BOTTOM
+									TooltipContainer: TOOLTIP_CONTAINER
+						ScrollItem@ARMY_PLAYER_TEMPLATE:
+							X: 0
+							Y: 0
+							Width: 400
+							Height: 24
+							BaseName: scrollitem-nohover
+							Children:
+								ColorBlock@PLAYER_COLOR:
+									X: 0
+									Y: 0
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@PLAYER_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									Width: 200
+									Height: PARENT_BOTTOM 
+								Image@FLAG:
+									X: 5
+									Y: 4
+									Width: 35
+									Height: PARENT_BOTTOM - 4
+									ImageName: random
+									ImageCollection: flags
+								Label@PLAYER:
+									X: 40
+									Y: 0
+									Width: 120
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Shadow: True
+								ObserverArmyIcons@ARMY_ICONS:
 									X: 160
 									Y: 0
 									Width: 0

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -97,6 +97,7 @@ ChromeLayout:
 	common|chrome/ingame-debuginfo.yaml
 	common|chrome/ingame-infochat.yaml
 	common|chrome/mainmenu.yaml
+	common|chrome/mainmenu-prompts.yaml
 	common|chrome/settings.yaml
 	common|chrome/credits.yaml
 	common|chrome/lobby.yaml

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -106,6 +106,8 @@ E1R1:
 	ProducibleWithLevel:
 		Prerequisites: techlevel.infonly
 		InitialLevels: 1
+	UpdatesPlayerStatistics:
+		OverrideActor: e1
 	-Buildable:
 
 E2:
@@ -199,6 +201,8 @@ E3R1:
 	ProducibleWithLevel:
 		Prerequisites: techlevel.infonly
 		InitialLevels: 1
+	UpdatesPlayerStatistics:
+		OverrideActor: e3
 	-Buildable:
 
 E4:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1814,7 +1814,6 @@ KENN:
 	WithBuildingBib:
 		HasMinibib: True
 	RallyPoint:
-		Path: 0,2
 	Exit@0:
 		RequiresCondition: !being-captured
 		SpawnOffset: -280,400,0

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1814,7 +1814,7 @@ KENN:
 	WithBuildingBib:
 		HasMinibib: True
 	RallyPoint:
-		Offset: 0,2
+		Path: 0,2
 	Exit@0:
 		RequiresCondition: !being-captured
 		SpawnOffset: -280,400,0

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -499,6 +499,7 @@ MNLY:
 		Range: 4c0
 	Minelayer:
 		Mine: MINV
+		TileUnknownName: build-valid
 	MineImmune:
 	AmmoPool:
 		Ammo: 5

--- a/mods/ts/chrome/ingame-observer.yaml
+++ b/mods/ts/chrome/ingame-observer.yaml
@@ -167,6 +167,7 @@ Container@OBSERVER_WIDGETS:
 				StatisticsProductionKey: StatisticsProduction
 				StatisticsSupportPowersKey: StatisticsSupportPowers
 				StatisticsCombatKey: StatisticsCombat
+				StatisticsArmyKey: StatisticsArmy
 				StatisticsGraphKey: StatisticsGraph
 				StatisticsArmyGraphKey: StatisticsArmyGraph
 			X: 5
@@ -433,6 +434,42 @@ Container@OBSERVER_WIDGETS:
 									Height: PARENT_BOTTOM
 									Font: Bold
 									Text: Support Powers
+									Shadow: True
+						Container@ARMY_HEADERS:
+							X: 0
+							Y: 0
+							Width: 400
+							Height: PARENT_BOTTOM
+							Children:
+								ColorBlock@HEADER_COLOR:
+									X: 0
+									Y: 0
+									Color: 00000090
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@HEADER_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									TopLeftColor: 00000090
+									BottomLeftColor: 00000090
+									Width: 200
+									Height: PARENT_BOTTOM
+								Label@PLAYER_HEADER:
+									X: 40
+									Y: 0
+									Width: 120
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Player
+									Align: Left
+									Shadow: True
+								Label@ARMY_HEADER:
+									X: 160
+									Y: 0
+									Width: 100
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Text: Army
 									Shadow: True
 						Container@COMBAT_STATS_HEADERS:
 							X: 0
@@ -797,6 +834,43 @@ Container@OBSERVER_WIDGETS:
 									Width: 0
 									Height: PARENT_BOTTOM
 									ClockPalette: iconclock
+									TooltipContainer: TOOLTIP_CONTAINER
+						ScrollItem@ARMY_PLAYER_TEMPLATE:
+							X: 0
+							Y: 0
+							Width: 400
+							Height: 24
+							BaseName: scrollitem-nohover
+							Children:
+								ColorBlock@PLAYER_COLOR:
+									X: 0
+									Y: 0
+									Width: PARENT_RIGHT - 200
+									Height: PARENT_BOTTOM
+								GradientColorBlock@PLAYER_GRADIENT:
+									X: PARENT_RIGHT - 200
+									Y: 0
+									Width: 200
+									Height: PARENT_BOTTOM 
+								Image@FLAG:
+									X: 5
+									Y: 4
+									Width: 35
+									Height: PARENT_BOTTOM - 4
+									ImageName: random
+									ImageCollection: flags
+								Label@PLAYER:
+									X: 40
+									Y: 0
+									Width: 120
+									Height: PARENT_BOTTOM
+									Font: Bold
+									Shadow: True
+								ObserverArmyIcons@ARMY_ICONS:
+									X: 160
+									Y: 0
+									Width: 0
+									Height: PARENT_BOTTOM
 									TooltipContainer: TOOLTIP_CONTAINER
 						ScrollItem@COMBAT_PLAYER_TEMPLATE:
 							X: 0

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -144,6 +144,7 @@ ChromeLayout:
 	common|chrome/ingame-debuginfo.yaml
 	common|chrome/ingame-infochat.yaml
 	common|chrome/mainmenu.yaml
+	common|chrome/mainmenu-prompts.yaml
 	ts|chrome/mainmenu-prerelease-notification.yaml
 	common|chrome/settings.yaml
 	common|chrome/credits.yaml

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -96,7 +96,7 @@ GAPILE:
 		Range: 5c0
 		MaxHeightDelta: 3
 	RallyPoint:
-		Offset: 2,3
+		Path: 2,3
 		Palette: mouse
 		IsPlayerPalette: false
 		LineWidth: 2
@@ -196,7 +196,7 @@ GAWEAP:
 	Armor:
 		Type: Heavy
 	RallyPoint:
-		Offset: 4,1
+		Path: 4,1
 		Palette: mouse
 		IsPlayerPalette: false
 		LineWidth: 2

--- a/mods/ts/rules/gdi-structures.yaml
+++ b/mods/ts/rules/gdi-structures.yaml
@@ -96,7 +96,6 @@ GAPILE:
 		Range: 5c0
 		MaxHeightDelta: 3
 	RallyPoint:
-		Path: 2,3
 		Palette: mouse
 		IsPlayerPalette: false
 		LineWidth: 2
@@ -196,7 +195,6 @@ GAWEAP:
 	Armor:
 		Type: Heavy
 	RallyPoint:
-		Path: 4,1
 		Palette: mouse
 		IsPlayerPalette: false
 		LineWidth: 2

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -150,7 +150,7 @@ NAHAND:
 		ExitCell: 0,2
 	ExitsDebugOverlay:
 	RallyPoint:
-		Offset: 3,3
+		Path: 3,3
 		Palette: mouse
 		IsPlayerPalette: false
 		LineWidth: 2
@@ -208,7 +208,7 @@ NAWEAP:
 		Range: 4c0
 		MaxHeightDelta: 3
 	RallyPoint:
-		Offset: 4,1
+		Path: 4,1
 		Palette: mouse
 		IsPlayerPalette: false
 		LineWidth: 2

--- a/mods/ts/rules/nod-structures.yaml
+++ b/mods/ts/rules/nod-structures.yaml
@@ -150,7 +150,6 @@ NAHAND:
 		ExitCell: 0,2
 	ExitsDebugOverlay:
 	RallyPoint:
-		Path: 3,3
 		Palette: mouse
 		IsPlayerPalette: false
 		LineWidth: 2
@@ -208,7 +207,6 @@ NAWEAP:
 		Range: 4c0
 		MaxHeightDelta: 3
 	RallyPoint:
-		Path: 4,1
 		Palette: mouse
 		IsPlayerPalette: false
 		LineWidth: 2


### PR DESCRIPTION
AI MCVs now place new MCVs near new tiberium fields, away from enemies buildings and its own previous con yards. Similar to a real player.

This modifies the previous logic, to:

1. Get a new random base center that is near a resource field, outside of the centered area of a previous random con yard location. Thus making the AI build outside of previous MCV locations.
2. The normal logic then is used (which selects a random location in the area based on step 1).
3. The MaxBaseRadius around the newly selected location is checked for enemies. If none exist we continue, otherwise we return null.
4. The MaxBaseRadius around the newly selected location is checked for previous construction yards (of the same player) or MCVs. If none exist in that location we continue, otherwise we return null.

Here are a few screenshots of a tweaked AI I created to produce the additional MCVs:
![image](https://user-images.githubusercontent.com/706132/73895994-602c9a80-4879-11ea-8506-8e8f617891ca.png)

![image](https://user-images.githubusercontent.com/706132/73896351-a8988800-487a-11ea-9179-f9144142c191.png)


![image](https://user-images.githubusercontent.com/706132/73896014-6fabe380-4879-11ea-8e52-9922cfe03d69.png)
