### PR TITLE
 Ensure that we never tick an activity before calling OnFirstRun 

### DIFF
--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -83,6 +83,7 @@ namespace OpenRA.Activities
 		public bool ChildHasPriority { get; protected set; }
 		public bool IsCanceling { get { return State == ActivityState.Canceling; } }
 		bool finishing;
+		bool firstRunCompleted;
 		bool lastRun;
 
 		public Activity()
@@ -99,8 +100,12 @@ namespace OpenRA.Activities
 			if (State == ActivityState.Queued)
 			{
 				OnFirstRun(self);
+				firstRunCompleted = true;
 				State = ActivityState.Active;
 			}
+
+			if (!firstRunCompleted)
+				throw new InvalidOperationException("Actor {0} attempted to tick activity {1} before running its OnFirstRun method.".F(self, GetType()));
 
 			// Only run the parent tick when the child is done.
 			// We must always let the child finish on its own before continuing.

--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -55,26 +55,23 @@ namespace OpenRA.Activities
 		Activity nextActivity;
 		public Activity NextActivity
 		{
-			get
-			{
-				// If Activity.NextActivity.Cancel() was called, NextActivity will be in the Canceling
-				// state rather than Queued (the activity system guarantees that it cannot be Active or Done).
-				// An unknown number of ticks may have elapsed between the Activity.NextActivity.Cancel() call
-				// and now, so we cannot make any assumptions on the value of Activity.NextActivity.NextActivity.
-				// We must not return nextActivity (ticking it would be bogus), but returning null would potentially
-				// drop valid activities queued after it. Walk the queue until we find a valid activity or
-				// (more likely) run out of activities.
-				var next = nextActivity;
-				while (next != null && next.State == ActivityState.Canceling)
-					next = next.NextActivity;
+			get { return SkipDoneActivities(nextActivity); }
+			private set { nextActivity = value; }
+		}
 
-				return next;
-			}
+		internal static Activity SkipDoneActivities(Activity first)
+		{
+			// If first.Cancel() was called while it was queued (i.e. before it first ticked), its state will be Done
+			// rather than Queued (the activity system guarantees that it cannot be Active or Canceling).
+			// An unknown number of ticks may have elapsed between the Cancel() call and now,
+			// so we cannot make any assumptions on the value of first.NextActivity.
+			// We must not return first (ticking it would be bogus), but returning null would potentially
+			// drop valid activities queued after it. Walk the queue until we find a valid activity or
+			// (more likely) run out of activities.
+			while (first != null && first.State == ActivityState.Done)
+				first = first.NextActivity;
 
-			private set
-			{
-				nextActivity = value;
-			}
+			return first;
 		}
 
 		public bool IsInterruptible { get; protected set; }
@@ -195,7 +192,8 @@ namespace OpenRA.Activities
 			if (ChildActivity != null)
 				ChildActivity.Cancel(self);
 
-			State = ActivityState.Canceling;
+			// Directly mark activities that are queued and therefore didn't run yet as done
+			State = State == ActivityState.Queued ? ActivityState.Done : ActivityState.Canceling;
 		}
 
 		public void Queue(Activity activity)

--- a/OpenRA.Game/Activities/Activity.cs
+++ b/OpenRA.Game/Activities/Activity.cs
@@ -50,7 +50,12 @@ namespace OpenRA.Activities
 	{
 		public ActivityState State { get; private set; }
 
-		protected Activity ChildActivity { get; private set; }
+		Activity childActivity;
+		protected Activity ChildActivity
+		{
+			get { return SkipDoneActivities(childActivity); }
+			private set { childActivity = value; }
+		}
 
 		Activity nextActivity;
 		public Activity NextActivity

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -44,7 +44,12 @@ namespace OpenRA
 		public bool WillDispose { get; private set; }
 		public bool Disposed { get; private set; }
 
-		public Activity CurrentActivity { get; private set; }
+		Activity currentActivity;
+		public Activity CurrentActivity
+		{
+			get { return Activity.SkipDoneActivities(currentActivity); }
+			private set { currentActivity = value; }
+		}
 
 		public int Generation;
 		public Actor ReplacedByActor;


### PR DESCRIPTION
This PR picks up where https://github.com/OpenRA/OpenRA/pull/17573#pullrequestreview-341537742 left. Fixes the crash described in https://github.com/OpenRA/OpenRA/pull/17477#issuecomment-583093128 and https://github.com/OpenRA/OpenRA/pull/17477#issuecomment-583297874.

With this PR activities that never ran once but are cancelled directly go from `Queued` into the `Done` state, skipping `Canceled`. We don't need the `Canceled` state in that case since the activity has nothing to clean up (it never ticked, and therefore shouldn't start ticking now).