### PR TITLE
Add sanity checking to server handshakes

### DIFF
--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -45,6 +45,8 @@ namespace OpenRA.Network
 		public bool GameStarted { get { return NetFrameNumber != 0; } }
 		public IConnection Connection { get; private set; }
 
+		public bool HandshakeSent { get; private set; }
+
 		internal int GameSaveLastFrame = -1;
 		internal int GameSaveLastSyncFrame = -1;
 
@@ -99,6 +101,9 @@ namespace OpenRA.Network
 
 		public void IssueOrder(Order order)
 		{
+			if (order.OrderString == "HandshakeResponse")
+				HandshakeSent = true;
+
 			if (order.IsImmediate)
 				localImmediateOrders.Add(order);
 			else

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -188,6 +188,10 @@ namespace OpenRA.Network
 
 				case "HandshakeRequest":
 					{
+						// Ignore duplicated handshake requests
+						if (orderManager.HandshakeSent)
+							break;
+
 						// Switch to the server's mod if we need and are able to
 						var mod = Game.ModData.Manifest;
 						var request = HandshakeRequest.Deserialize(order.TargetString);

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -228,7 +228,7 @@ namespace OpenRA.Network
 							Client = info,
 							Mod = mod.Id,
 							Version = mod.Metadata.Version,
-							Password = orderManager.Password,
+							Password = CryptoUtil.SHA1Hash(request.AuthToken + orderManager.Password),
 							Fingerprint = localProfile.Fingerprint,
 							OrdersProtocol = ProtocolVersion.Orders
 						};

--- a/OpenRA.Game/Server/Connection.cs
+++ b/OpenRA.Game/Server/Connection.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net.Sockets;
 
@@ -19,7 +20,7 @@ namespace OpenRA.Server
 	public class Connection
 	{
 		public const int MaxOrderLength = 131072;
-		public Socket Socket;
+		public readonly Socket Socket;
 		public List<byte> Data = new List<byte>();
 		public ReceiveState State = ReceiveState.Header;
 		public int ExpectLength = 8;
@@ -30,6 +31,16 @@ namespace OpenRA.Server
 		public long TimeSinceLastResponse { get { return Game.RunTime - lastReceivedTime; } }
 		public bool TimeoutMessageShown = false;
 		long lastReceivedTime = 0;
+
+		readonly Stopwatch stopwatch;
+		public long ConnectedTime { get { return stopwatch.ElapsedMilliseconds; } }
+
+		public Connection(Socket socket)
+		{
+			Socket = socket;
+			lastReceivedTime = Game.RunTime;
+			stopwatch = Stopwatch.StartNew();
+		}
 
 		/* client data */
 		public int PlayerIndex;

--- a/OpenRA.Game/Server/ProtocolVersion.cs
+++ b/OpenRA.Game/Server/ProtocolVersion.cs
@@ -66,6 +66,6 @@ namespace OpenRA.Server
 		// The protocol for server and world orders
 		// This applies after the handshake has completed, and is provided to support
 		// alternative server implementations that wish to support multiple versions in parallel
-		public const int Orders = 9;
+		public const int Orders = 10;
 	}
 }

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -213,7 +213,16 @@ namespace OpenRA.Server
 						var preConn = PreConns.SingleOrDefault(c => c.Socket == s);
 						if (preConn != null)
 						{
+							// Drop the client if they have taken more than 5 seconds to respond to the handshake request
+							// They either have an unusably bad connection or are trying something malicious
+							if (preConn.ConnectedTime > 5000)
+							{
+								DropClient(preConn);
+								Log.Write("server", "Dropping client {0} because handshake timed out", preConn.PlayerIndex.ToString(CultureInfo.InvariantCulture));
+							}
+
 							preConn.ReadData(this);
+
 							continue;
 						}
 
@@ -275,7 +284,7 @@ namespace OpenRA.Server
 				return;
 			}
 
-			var newConn = new Connection { Socket = newSocket };
+			var newConn = new Connection(newSocket);
 			try
 			{
 				newConn.Socket.Blocking = false;

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -343,8 +343,9 @@ namespace OpenRA.Server
 				}
 
 				var handshake = HandshakeResponse.Deserialize(data);
+				var passwordHash = CryptoUtil.SHA1Hash(newConn.AuthToken + Settings.Password);
 
-				if (!string.IsNullOrEmpty(Settings.Password) && handshake.Password != Settings.Password)
+				if (!string.IsNullOrEmpty(Settings.Password) && handshake.Password != passwordHash)
 				{
 					var message = string.IsNullOrEmpty(handshake.Password) ? "Server requires a password" : "Incorrect password";
 					SendOrderTo(newConn, "AuthenticationError", message);


### PR DESCRIPTION
This PR adds some additional validation checks to make life more difficult for anybody who might want to try and abuse the handshake for malicous purposes:
* Clients only respond to the initial handshake request
* Servers drop clients that take more than 5 seconds to respond (does not impact passworded servers, these create a new connection for each try)
* Salt and hash the server password so it can't be trivially extracted from replays

Ping @jrb0001 who raised the original HandshakeRequest duplication issue.