### PR TITLE
Unify widget state image names (disabled, pressed, hover, focused)

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ButtonWidget.cs
@@ -292,13 +292,10 @@ namespace OpenRA.Mods.Common.Widgets
 			if (string.IsNullOrEmpty(baseName))
 				return;
 
-			var variant = highlighted ? "-highlighted" : "";
-			var state = disabled ? "-disabled" :
-						pressed ? "-pressed" :
-						hover ? "-hover" :
-						"";
+			var variantName = highlighted ? baseName + "-highlighted" : baseName;
+			var imageName = WidgetUtils.GetStatefulImageName(variantName, disabled, pressed, hover);
 
-			WidgetUtils.DrawPanel(baseName + variant + state, rect);
+			WidgetUtils.DrawPanel(imageName, rect);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/CheckboxWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/CheckboxWidget.cs
@@ -44,7 +44,6 @@ namespace OpenRA.Mods.Common.Widgets
 		public override void Draw()
 		{
 			var disabled = IsDisabled();
-			var highlighted = IsHighlighted();
 			var font = Game.Renderer.Fonts[Font];
 			var color = GetColor();
 			var colordisabled = GetColorDisabled();
@@ -54,11 +53,8 @@ namespace OpenRA.Mods.Common.Widgets
 			var text = GetText();
 			var textSize = font.Measure(text);
 			var check = new Rectangle(rect.Location, new Size(Bounds.Height, Bounds.Height));
-			var state = disabled ? "checkbox-disabled" :
-						highlighted ? "checkbox-highlighted" :
-						Depressed && HasPressedState ? "checkbox-pressed" :
-						Ui.MouseOverWidget == this ? "checkbox-hover" :
-						"checkbox";
+			var baseName = IsHighlighted() ? "checkbox-highlighted" : "checkbox";
+			var state = WidgetUtils.GetStatefulImageName(baseName, disabled, Depressed && HasPressedState, Ui.MouseOverWidget == this);
 
 			WidgetUtils.DrawPanel(state, check);
 

--- a/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/DropDownButtonWidget.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
 using OpenRA.Widgets;
@@ -19,7 +20,9 @@ namespace OpenRA.Mods.Common.Widgets
 {
 	public class DropDownButtonWidget : ButtonWidget
 	{
-		public readonly string SeparatorCollection = "dropdown";
+		public readonly string Decorations = "dropdown-decorations";
+		public readonly string DecorationMarker = "marker";
+		public readonly string Separators = "dropdown-separators";
 		public readonly string SeparatorImage = "separator";
 		public readonly TextAlign PanelAlign = TextAlign.Left;
 
@@ -45,13 +48,20 @@ namespace OpenRA.Mods.Common.Widgets
 			base.Draw();
 			var stateOffset = Depressed ? new int2(VisualHeight, VisualHeight) : new int2(0, 0);
 
-			var image = ChromeProvider.GetImage("scrollbar", IsDisabled() ? "down_pressed" : "down_arrow");
 			var rb = RenderBounds;
+			var isDisabled = IsDisabled();
+			var isHover = Ui.MouseOverWidget == this || Children.Any(c => c == Ui.MouseOverWidget);
 
-			WidgetUtils.DrawRGBA(image, stateOffset + new float2(rb.Right - (int)((rb.Height + image.Size.X) / 2), rb.Top + (int)((rb.Height - image.Size.Y) / 2)));
+			var markerImageName = WidgetUtils.GetStatefulImageName(DecorationMarker, isDisabled, Depressed, isHover);
+			var arrowImage = ChromeProvider.GetImage(Decorations, markerImageName) ?? ChromeProvider.GetImage(Decorations, DecorationMarker);
 
-			var separator = ChromeProvider.GetImage(SeparatorCollection, SeparatorImage);
-			WidgetUtils.DrawRGBA(separator, stateOffset + new float2(-3, 0) + new float2(rb.Right - rb.Height + 4, rb.Top + (rb.Height - separator.Size.Y) / 2));
+			WidgetUtils.DrawRGBA(arrowImage, stateOffset + new float2(rb.Right - (int)((rb.Height + arrowImage.Size.X) / 2), rb.Top + (int)((rb.Height - arrowImage.Size.Y) / 2)));
+
+			var separatorImageName = WidgetUtils.GetStatefulImageName(SeparatorImage, isDisabled, Depressed, isHover);
+			var separatorImage = ChromeProvider.GetImage(Separators, separatorImageName) ?? ChromeProvider.GetImage(Separators, SeparatorImage);
+
+			if (separatorImage != null)
+				WidgetUtils.DrawRGBA(separatorImage, stateOffset + new float2(-3, 0) + new float2(rb.Right - rb.Height + 4, rb.Top + (int)((rb.Height - separatorImage.Size.Y) / 2)));
 		}
 
 		public override Widget Clone() { return new DropDownButtonWidget(this); }

--- a/OpenRA.Mods.Common/Widgets/HotkeyEntryWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/HotkeyEntryWidget.cs
@@ -128,10 +128,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 			var disabled = IsDisabled();
 			var valid = IsValid();
-			var state = disabled ? "textfield-disabled" :
-				HasKeyboardFocus ? "textfield-focused" :
-					Ui.MouseOverWidget == this ? "textfield-hover" :
-					"textfield";
+			var state = WidgetUtils.GetStatefulImageName("textfield", disabled, false, Ui.MouseOverWidget == this, HasKeyboardFocus);
 
 			WidgetUtils.DrawPanel(state, RenderBounds);
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/CommandBarLogic.cs
@@ -12,7 +12,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Graphics;
 using OpenRA.Mods.Common.Orders;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Orders;
@@ -54,7 +53,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var attackMoveButton = widget.GetOrNull<ButtonWidget>("ATTACK_MOVE");
 			if (attackMoveButton != null)
 			{
-				BindButtonIcon(attackMoveButton);
+				WidgetUtils.BindButtonIcon(attackMoveButton);
 
 				attackMoveButton.IsDisabled = () => { UpdateStateIfNecessary(); return attackMoveDisabled; };
 				attackMoveButton.IsHighlighted = () => world.OrderGenerator is AttackMoveOrderGenerator;
@@ -77,7 +76,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var forceMoveButton = widget.GetOrNull<ButtonWidget>("FORCE_MOVE");
 			if (forceMoveButton != null)
 			{
-				BindButtonIcon(forceMoveButton);
+				WidgetUtils.BindButtonIcon(forceMoveButton);
 
 				forceMoveButton.IsDisabled = () => { UpdateStateIfNecessary(); return forceMoveDisabled; };
 				forceMoveButton.IsHighlighted = () => !forceMoveButton.IsDisabled() && IsForceModifiersActive(Modifiers.Alt);
@@ -93,7 +92,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var forceAttackButton = widget.GetOrNull<ButtonWidget>("FORCE_ATTACK");
 			if (forceAttackButton != null)
 			{
-				BindButtonIcon(forceAttackButton);
+				WidgetUtils.BindButtonIcon(forceAttackButton);
 
 				forceAttackButton.IsDisabled = () => { UpdateStateIfNecessary(); return forceAttackDisabled; };
 				forceAttackButton.IsHighlighted = () => !forceAttackButton.IsDisabled() && IsForceModifiersActive(Modifiers.Ctrl)
@@ -111,7 +110,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var guardButton = widget.GetOrNull<ButtonWidget>("GUARD");
 			if (guardButton != null)
 			{
-				BindButtonIcon(guardButton);
+				WidgetUtils.BindButtonIcon(guardButton);
 
 				guardButton.IsDisabled = () => { UpdateStateIfNecessary(); return guardDisabled; };
 				guardButton.IsHighlighted = () => world.OrderGenerator is GuardOrderGenerator;
@@ -135,7 +134,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var scatterButton = widget.GetOrNull<ButtonWidget>("SCATTER");
 			if (scatterButton != null)
 			{
-				BindButtonIcon(scatterButton);
+				WidgetUtils.BindButtonIcon(scatterButton);
 
 				scatterButton.IsDisabled = () => { UpdateStateIfNecessary(); return scatterDisabled; };
 				scatterButton.IsHighlighted = () => scatterHighlighted > 0;
@@ -153,7 +152,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var deployButton = widget.GetOrNull<ButtonWidget>("DEPLOY");
 			if (deployButton != null)
 			{
-				BindButtonIcon(deployButton);
+				WidgetUtils.BindButtonIcon(deployButton);
 
 				deployButton.IsDisabled = () =>
 				{
@@ -179,7 +178,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var stopButton = widget.GetOrNull<ButtonWidget>("STOP");
 			if (stopButton != null)
 			{
-				BindButtonIcon(stopButton);
+				WidgetUtils.BindButtonIcon(stopButton);
 
 				stopButton.IsDisabled = () => { UpdateStateIfNecessary(); return stopDisabled; };
 				stopButton.IsHighlighted = () => stopHighlighted > 0;
@@ -197,7 +196,7 @@ namespace OpenRA.Mods.Common.Widgets
 			var queueOrdersButton = widget.GetOrNull<ButtonWidget>("QUEUE_ORDERS");
 			if (queueOrdersButton != null)
 			{
-				BindButtonIcon(queueOrdersButton);
+				WidgetUtils.BindButtonIcon(queueOrdersButton);
 
 				queueOrdersButton.IsDisabled = () => { UpdateStateIfNecessary(); return waypointModeDisabled; };
 				queueOrdersButton.IsHighlighted = () => !queueOrdersButton.IsDisabled() && IsForceModifiersActive(Modifiers.Shift);
@@ -270,20 +269,6 @@ namespace OpenRA.Mods.Common.Widgets
 				stopHighlighted--;
 
 			base.Tick();
-		}
-
-		void BindButtonIcon(ButtonWidget button)
-		{
-			var icon = button.Get<ImageWidget>("ICON");
-			var hasDisabled = ChromeProvider.GetImage(icon.ImageCollection, icon.ImageName + "-disabled") != null;
-			var hasActive = ChromeProvider.GetImage(icon.ImageCollection, icon.ImageName + "-active") != null;
-			var hasActiveHover = ChromeProvider.GetImage(icon.ImageCollection, icon.ImageName + "-active-hover") != null;
-			var hasHover = ChromeProvider.GetImage(icon.ImageCollection, icon.ImageName + "-hover") != null;
-
-			icon.GetImageName = () => hasActive && button.IsHighlighted() ?
-						(hasActiveHover && Ui.MouseOverWidget == button ? icon.ImageName + "-active-hover" : icon.ImageName + "-active") :
-					hasDisabled && button.IsDisabled() ? icon.ImageName + "-disabled" :
-					hasHover && Ui.MouseOverWidget == button ? icon.ImageName + "-hover" : icon.ImageName;
 		}
 
 		bool IsForceModifiersActive(Modifiers modifiers)

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/StanceSelectorLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/StanceSelectorLogic.cs
@@ -10,7 +10,6 @@
 #endregion
 
 using System.Linq;
-using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Widgets;
 
@@ -47,16 +46,7 @@ namespace OpenRA.Mods.Common.Widgets
 
 		void BindStanceButton(ButtonWidget button, UnitStance stance)
 		{
-			var icon = button.Get<ImageWidget>("ICON");
-			var hasDisabled = ChromeProvider.GetImage(icon.ImageCollection, icon.ImageName + "-disabled") != null;
-			var hasActive = ChromeProvider.GetImage(icon.ImageCollection, icon.ImageName + "-active") != null;
-			var hasActiveHover = ChromeProvider.GetImage(icon.ImageCollection, icon.ImageName + "-active-hover") != null;
-			var hasHover = ChromeProvider.GetImage(icon.ImageCollection, icon.ImageName + "-hover") != null;
-
-			icon.GetImageName = () => hasActive && button.IsHighlighted() ?
-						(hasActiveHover && Ui.MouseOverWidget == button ? icon.ImageName + "-active-hover" : icon.ImageName + "-active") :
-					hasDisabled && button.IsDisabled() ? icon.ImageName + "-disabled" :
-					hasHover && Ui.MouseOverWidget == button ? icon.ImageName + "-hover" : icon.ImageName;
+			WidgetUtils.BindButtonIcon(button);
 
 			button.IsDisabled = () => { UpdateStateIfNecessary(); return !actorStances.Any(); };
 			button.IsHighlighted = () => actorStances.Any(

--- a/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ProductionTabsWidget.cs
@@ -83,6 +83,9 @@ namespace OpenRA.Mods.Common.Widgets
 
 		public string Button = "button";
 		public string Background = "panel-black";
+		public readonly string Decorations = "scrollpanel-decorations";
+		public readonly string DecorationScrollLeft = "left";
+		public readonly string DecorationScrollRight = "right";
 
 		int contentWidth = 0;
 		float listOffset = 0;
@@ -182,9 +185,14 @@ namespace OpenRA.Mods.Common.Widgets
 			ButtonWidget.DrawBackground(Button, leftButtonRect, leftDisabled, leftPressed, leftHover, false);
 			ButtonWidget.DrawBackground(Button, rightButtonRect, rightDisabled, rightPressed, rightHover, false);
 
-			WidgetUtils.DrawRGBA(ChromeProvider.GetImage("scrollbar", leftPressed || leftDisabled ? "left_pressed" : "left_arrow"),
+			var leftArrowImageName = WidgetUtils.GetStatefulImageName(DecorationScrollLeft, leftDisabled, leftPressed, leftHover);
+			var leftArrowImage = ChromeProvider.GetImage(Decorations, leftArrowImageName) ?? ChromeProvider.GetImage(Decorations, DecorationScrollLeft);
+			WidgetUtils.DrawRGBA(leftArrowImage,
 				new float2(leftButtonRect.Left + 2, leftButtonRect.Top + 2));
-			WidgetUtils.DrawRGBA(ChromeProvider.GetImage("scrollbar", rightPressed || rightDisabled ? "right_pressed" : "right_arrow"),
+
+			var rightArrowImageName = WidgetUtils.GetStatefulImageName(DecorationScrollRight, rightDisabled, rightPressed, rightHover);
+			var rightArrowImage = ChromeProvider.GetImage(Decorations, rightArrowImageName) ?? ChromeProvider.GetImage(Decorations, DecorationScrollRight);
+			WidgetUtils.DrawRGBA(rightArrowImage,
 				new float2(rightButtonRect.Left + 2, rightButtonRect.Top + 2));
 
 			// Draw tab buttons

--- a/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
@@ -48,6 +48,9 @@ namespace OpenRA.Mods.Common.Widgets
 		public string Background = "scrollpanel-bg";
 		public string ScrollBarBackground = "scrollpanel-bg";
 		public string Button = "scrollpanel-button";
+		public readonly string Decorations = "scrollpanel-decorations";
+		public readonly string DecorationScrollUp = "up";
+		public readonly string DecorationScrollDown = "down";
 		public int ContentHeight;
 		public ILayout Layout;
 		public int MinimumThumbSize = 10;
@@ -201,9 +204,14 @@ namespace OpenRA.Mods.Common.Widgets
 				var upOffset = !upPressed || upDisabled ? 4 : 4 + ButtonDepth;
 				var downOffset = !downPressed || downDisabled ? 4 : 4 + ButtonDepth;
 
-				WidgetUtils.DrawRGBA(ChromeProvider.GetImage("scrollbar", upPressed || upDisabled ? "up_pressed" : "up_arrow"),
+				var upArrowImageName = WidgetUtils.GetStatefulImageName(DecorationScrollUp, upDisabled, upPressed, upHover);
+				var upArrowImage = ChromeProvider.GetImage(Decorations, upArrowImageName) ?? ChromeProvider.GetImage(Decorations, DecorationScrollUp);
+				WidgetUtils.DrawRGBA(upArrowImage,
 					new float2(upButtonRect.Left + upOffset, upButtonRect.Top + upOffset));
-				WidgetUtils.DrawRGBA(ChromeProvider.GetImage("scrollbar", downPressed || downDisabled ? "down_pressed" : "down_arrow"),
+
+				var downArrowImageName = WidgetUtils.GetStatefulImageName(DecorationScrollDown, downDisabled, downPressed, downHover);
+				var downArrowImage = ChromeProvider.GetImage(Decorations, downArrowImageName) ?? ChromeProvider.GetImage(Decorations, DecorationScrollDown);
+				WidgetUtils.DrawRGBA(downArrowImage,
 					new float2(downButtonRect.Left + downOffset, downButtonRect.Top + downOffset));
 			}
 

--- a/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
@@ -566,10 +566,8 @@ namespace OpenRA.Mods.Common.Widgets
 			var cursorPosition = font.Measure(apparentText.Substring(0, CursorPosition));
 
 			var disabled = IsDisabled();
-			var state = disabled ? "textfield-disabled" :
-				HasKeyboardFocus ? "textfield-focused" :
-				Ui.MouseOverWidget == this || Children.Any(c => c == Ui.MouseOverWidget) ? "textfield-hover" :
-				"textfield";
+			var hover = Ui.MouseOverWidget == this || Children.Any(c => c == Ui.MouseOverWidget);
+			var state = WidgetUtils.GetStatefulImageName("textfield", disabled, false, hover, HasKeyboardFocus);
 
 			WidgetUtils.DrawPanel(state,
 				new Rectangle(pos.X, pos.Y, Bounds.Width, Bounds.Height));

--- a/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Network;
 using OpenRA.Primitives;
+using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Widgets
 {
@@ -281,6 +282,55 @@ namespace OpenRA.Mods.Common.Widgets
 				button.GetTooltipText = () => text;
 			else
 				button.GetTooltipText = null;
+		}
+
+		public static void BindButtonIcon(ButtonWidget button)
+		{
+			var icon = button.Get<ImageWidget>("ICON");
+
+			var hasActiveImage = ChromeProvider.GetImage(icon.ImageCollection, icon.ImageName + "-active") != null;
+			var hasActiveDisabledImage = ChromeProvider.GetImage(icon.ImageCollection, icon.ImageName + "-active-disabled") != null;
+			var hasActivePressedImage = ChromeProvider.GetImage(icon.ImageCollection, icon.ImageName + "-active-pressed") != null;
+			var hasActiveHoverImage = ChromeProvider.GetImage(icon.ImageCollection, icon.ImageName + "-active-hover") != null;
+
+			var hasImage = ChromeProvider.GetImage(icon.ImageCollection, icon.ImageName) != null;
+			var hasDisabledImage = ChromeProvider.GetImage(icon.ImageCollection, icon.ImageName + "-disabled") != null;
+			var hasPressedImage = ChromeProvider.GetImage(icon.ImageCollection, icon.ImageName + "-pressed") != null;
+			var hasHoverImage = ChromeProvider.GetImage(icon.ImageCollection, icon.ImageName + "-hover") != null;
+
+			icon.GetImageName = () =>
+			{
+				var isActive = button.IsHighlighted();
+				var isDisabled = button.IsDisabled();
+				var isPressed = button.Depressed;
+				var isHovered = Ui.MouseOverWidget == button;
+
+				var baseName = button.IsHighlighted() ? icon.ImageName + "-active" : icon.ImageName;
+				var stateName = WidgetUtils.GetStatefulImageName(baseName, isDisabled, isPressed, isHovered);
+
+				if (isActive)
+				{
+					if (isDisabled)
+						return hasActiveDisabledImage ? stateName : hasActiveImage ? baseName : icon.ImageName;
+					else if (isPressed)
+						return hasActivePressedImage ? stateName : hasActiveImage ? baseName : icon.ImageName;
+					else if (isHovered)
+						return hasActiveHoverImage ? stateName : hasActiveImage ? baseName : icon.ImageName;
+					else
+						return hasActiveImage ? baseName : icon.ImageName;
+				}
+				else
+				{
+					if (isDisabled)
+						return hasDisabledImage ? stateName : baseName;
+					else if (isPressed)
+						return hasPressedImage ? stateName : baseName;
+					else if (isHovered)
+						return hasHoverImage ? stateName : baseName;
+					else
+						return baseName;
+				}
+			};
 		}
 
 		public static void BindPlayerNameAndStatus(LabelWidget label, Player p)

--- a/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/WidgetUtils.cs
@@ -24,6 +24,17 @@ namespace OpenRA.Mods.Common.Widgets
 			return ChromeProvider.GetImage("chrome-" + world.LocalPlayer.Faction.InternalName, name);
 		}
 
+		public static string GetStatefulImageName(string baseName, bool disabled = false, bool pressed = false, bool hover = false, bool focused = false)
+		{
+			var suffix = disabled ? "-disabled" :
+				focused ? "-focused" :
+				pressed ? "-pressed" :
+				hover ? "-hover" :
+				"";
+
+			return baseName + suffix;
+		}
+
 		public static void DrawRGBA(Sprite s, float2 pos)
 		{
 			Game.Renderer.RgbaSpriteRenderer.DrawSprite(s, pos);

--- a/mods/cnc/chrome.yaml
+++ b/mods/cnc/chrome.yaml
@@ -201,6 +201,15 @@ checkbox-pressed:
 checkbox-highlighted:
 	Inherits: button-highlighted-pressed
 
+checkbox-highlighted-hover:
+	Inherits: button-highlighted-hover
+
+checkbox-highlighted-disabled:
+	Inherits: button-highlighted-disabled
+
+checkbox-highlighted-pressed:
+	Inherits: button-highlighted-pressed
+
 #
 # Panels
 # ===
@@ -337,18 +346,6 @@ checkbox-bits:
 		crossed: 972, 0, 16, 16
 		crossed-disabled: 989, 0, 16, 16
 
-scrollbar:
-	Inherits: ^Chrome
-	Regions:
-		down_arrow: 836, 17, 16, 16
-		down_pressed: 853, 17, 16, 16
-		up_arrow: 870, 17, 16, 16
-		up_pressed: 887, 17, 16, 16
-		right_arrow: 904, 17, 16, 16
-		right_pressed: 921, 17, 16, 16
-		left_arrow: 938, 17, 16, 16
-		left_pressed: 955, 17, 16, 16
-
 flags:
 	Inherits: ^Chrome
 	Regions:
@@ -364,10 +361,36 @@ strategic:
 		enemy_owned: 837, 223, 22, 22
 		player_owned: 883, 223, 22, 22
 
-dropdown:
+scrollpanel-decorations:
 	Inherits: ^Chrome
 	Regions:
-		separator: 65, 1, 1, 19
+		down: 836, 17, 16, 16
+		down-pressed: 836, 17, 16, 16
+		down-disabled: 853, 17, 16, 16
+		up: 870, 17, 16, 16
+		up-pressed: 870, 17, 16, 16
+		up-disabled: 887, 17, 16, 16
+		right: 904, 17, 16, 16
+		right-pressed: 904, 17, 16, 16
+		right-disabled: 921, 17, 16, 16
+		left: 938, 17, 16, 16
+		left-pressed: 938, 17, 16, 16
+		left-disabled: 955, 17, 16, 16
+
+dropdown-decorations:
+	Inherits: ^Chrome
+	Regions:
+		marker: 836, 17, 16, 16
+		marker-pressed: 836, 17, 16, 16
+		marker-disabled: 853, 17, 16, 16
+
+dropdown-separators:
+	Inherits: ^Chrome
+	Regions:
+		separator: 129, 2, 1, 19
+		separator-hover: 161, 2, 1, 19
+		separator-pressed: 129, 34, 1, 19
+		separator-disabled: 161, 34, 1, 19
 
 #
 # Common chrome

--- a/mods/d2k/chrome.yaml
+++ b/mods/d2k/chrome.yaml
@@ -283,14 +283,6 @@ music:
 		prev: 68, 0, 16, 16
 		fastforward: 85, 0, 16, 16
 
-scrollbar:
-	Inherits: ^Glyphs
-	Regions:
-		down_arrow: 119, 0, 16, 16
-		down_pressed: 119, 0, 16, 16
-		up_arrow: 102, 0, 16, 16
-		up_pressed: 102, 0, 16, 16
-
 progressbar-bg:
 	Inherits: button-pressed
 
@@ -400,6 +392,12 @@ checkbox-disabled:
 checkbox-highlighted:
 	Inherits: button-highlighted-pressed
 
+checkbox-highlighted-hover:
+	Inherits: checkbox-highlighted
+
+checkbox-highlighted-disabled:
+	Inherits: checkbox-disabled
+
 scrollitem-selected:
 	Inherits: button-pressed
 
@@ -412,10 +410,24 @@ scrollheader-selected:
 scrollitem-nohover:
 	Inherits: ^Dialog
 
-dropdown:
+scrollpanel-decorations:
+	Inherits: ^Glyphs
+	Regions:
+		down: 119, 0, 16, 16
+		up: 102, 0, 16, 16
+
+dropdown-decorations:
+	Inherits: ^Glyphs
+	Regions:
+		marker: 119, 0, 16, 16
+
+dropdown-separators:
 	Inherits: ^Dialog
 	Regions:
-		separator: 513, 1, 1, 19
+		separator: 513, 2, 1, 19
+		separator-hover: 513, 130, 1, 19
+		separator-pressed: 641, 2, 1, 19
+		separator-disabled: 513, 258, 1, 19
 
 logos:
 	Inherits: ^LoadScreen

--- a/mods/d2k/chrome/ingame-player.yaml
+++ b/mods/d2k/chrome/ingame-player.yaml
@@ -616,8 +616,8 @@ Container@PLAYER_WIDGETS:
 								Image@ICON:
 									X: 5
 									Y: 5
-									ImageCollection: scrollbar
-									ImageName: up_arrow
+									ImageCollection: scrollpanel-decorations
+									ImageName: up
 						Button@SCROLL_DOWN_BUTTON:
 							Y: 248
 							Width: 25
@@ -630,5 +630,5 @@ Container@PLAYER_WIDGETS:
 								Image@ICON:
 									X: 5
 									Y: 5
-									ImageCollection: scrollbar
-									ImageName: down_arrow
+									ImageCollection: scrollpanel-decorations
+									ImageName: down

--- a/mods/modcontent/chrome.yaml
+++ b/mods/modcontent/chrome.yaml
@@ -102,10 +102,10 @@ scrollpanel-button-disabled:
 scrollpanel-button-pressed:
 	Inherits: panel-thinborder-light
 
-scrollbar:
+scrollpanel-decorations:
 	Inherits: ^Chrome
 	Regions:
-		down_arrow: 453, 512, 16, 16
-		down_pressed: 453, 512, 16, 16
-		up_arrow: 470, 512, 16, 16
-		up_pressed: 470, 512, 16, 16
+		down: 453, 512, 16, 16
+		down-pressed: 453, 512, 16, 16
+		up: 470, 512, 16, 16
+		up-pressed: 470, 512, 16, 16

--- a/mods/ra/chrome.yaml
+++ b/mods/ra/chrome.yaml
@@ -394,18 +394,6 @@ music:
 		prev: 68, 0, 16, 16
 		fastforward: 85, 0, 16, 16
 
-scrollbar:
-	Inherits: ^Glyphs
-	Regions:
-		down_arrow: 68, 17, 16, 16
-		down_pressed: 85, 17, 16, 16
-		up_arrow: 102, 17, 16, 16
-		up_pressed: 119, 17, 16, 16
-		right_arrow: 136, 17, 16, 16
-		right_pressed: 153, 17, 16, 16
-		left_arrow: 170, 17, 16, 16
-		left_pressed: 187, 17, 16, 16
-
 progressbar-bg:
 	Inherits: button-pressed
 
@@ -533,6 +521,12 @@ checkbox-highlighted:
 	Inherits: ^Dialog
 	PanelRegion: 897, 1, 2, 2, 122, 122, 2, 2
 
+checkbox-highlighted-hover:
+	Inherits: checkbox-highlighted
+
+checkbox-highlighted-disabled:
+	Inherits: checkbox-disabled
+
 scrollitem-selected:
 	Inherits: button-pressed
 
@@ -559,8 +553,34 @@ mainmenu-border:
 	PanelRegion: 650, 389, 39, 39, 38, 38, 39, 39
 	PanelSides: Edges
 
-dropdown:
+scrollpanel-decorations:
+	Inherits: ^Glyphs
+	Regions:
+		down: 68, 17, 16, 16
+		down-pressed: 68, 17, 16, 16
+		down-disabled: 85, 17, 16, 16
+		up: 102, 17, 16, 16
+		up-pressed: 102, 17, 16, 16
+		up-disabled: 119, 17, 16, 16
+		right: 136, 17, 16, 16
+		right-pressed: 136, 17, 16, 16
+		right-disabled: 153, 17, 16, 16
+		left: 170, 17, 16, 16
+		left-pressed: 170, 17, 16, 16
+		left-disabled: 187, 17, 16, 16
+
+dropdown-decorations:
+	Inherits: ^Glyphs
+	Regions:
+		marker: 68, 17, 16, 16
+		marker-pressed: 68, 17, 16, 16
+		marker-disabled: 85, 17, 16, 16
+
+dropdown-separators:
 	Inherits: ^Dialog
 	Regions:
 		separator: 513, 2, 1, 19
-		observer-separator: 769, 257, 1, 19
+		separator-hover: 513, 130, 1, 19
+		separator-pressed: 766, 2, 1, 19
+		separator-disabled: 513, 258, 1, 19
+		observer-separator: 769, 258, 1, 19

--- a/mods/ra/chrome/ingame-player.yaml
+++ b/mods/ra/chrome/ingame-player.yaml
@@ -572,8 +572,8 @@ Container@PLAYER_WIDGETS:
 								Image@ICON:
 									X: 6
 									Y: 3
-									ImageCollection: scrollbar
-									ImageName: up_arrow
+									ImageCollection: scrollpanel-decorations
+									ImageName: up
 						Button@SCROLL_DOWN_BUTTON:
 							Logic: AddFactionSuffixLogic
 							Y: 211
@@ -587,8 +587,8 @@ Container@PLAYER_WIDGETS:
 								Image@ICON:
 									X: 6
 									Y: 3
-									ImageCollection: scrollbar
-									ImageName: down_arrow
+									ImageCollection: scrollpanel-decorations
+									ImageName: down
 		Image@SIDEBAR_MONEYBIN:
 			Logic: AddFactionSuffixLogic
 			X: WINDOW_RIGHT - 250

--- a/mods/ts/chrome.yaml
+++ b/mods/ts/chrome.yaml
@@ -500,18 +500,6 @@ music:
 		prev: 68, 0, 16, 16
 		fastforward: 85, 0, 16, 16
 
-scrollbar:
-	Inherits: ^Glyphs
-	Regions:
-		down_arrow: 68, 17, 16, 16
-		down_pressed: 85, 17, 16, 16
-		up_arrow: 102, 17, 16, 16
-		up_pressed: 119, 17, 16, 16
-		right_arrow: 136, 17, 16, 16
-		right_pressed: 153, 17, 16, 16
-		left_arrow: 170, 17, 16, 16
-		left_pressed: 187, 17, 16, 16
-
 # ----------------------------------------------------------------------
 # Other UI stuff
 # ----------------------------------------------------------------------
@@ -666,6 +654,12 @@ checkbox-highlighted:
 	Inherits: ^Dialog
 	PanelRegion: 897, 1, 2, 2, 122, 122, 2, 2
 
+checkbox-highlighted-hover:
+	Inherits: checkbox-highlighted
+
+checkbox-highlighted-disabled:
+	Inherits: checkbox-disabled
+
 scrollitem-selected:
 	Inherits: button-pressed
 
@@ -681,10 +675,36 @@ scrollheader-selected:
 mainmenu-border:
 	Inherits: ^Dialog
 
-dropdown:
+scrollpanel-decorations:
+	Inherits: ^Glyphs
+	Regions:
+		down: 68, 17, 16, 16
+		down-pressed: 68, 17, 16, 16
+		down-disabled: 85, 17, 16, 16
+		up: 102, 17, 16, 16
+		up-pressed: 102, 17, 16, 16
+		up-disabled: 119, 17, 16, 16
+		right: 136, 17, 16, 16
+		right-pressed: 136, 17, 16, 16
+		right-disabled: 153, 17, 16, 16
+		left: 170, 17, 16, 16
+		left-pressed: 170, 17, 16, 16
+		left-disabled: 187, 17, 16, 16
+
+dropdown-decorations:
+	Inherits: ^Glyphs
+	Regions:
+		marker: 68, 17, 16, 16
+		marker-pressed: 68, 17, 16, 16
+		marker-disabled: 85, 17, 16, 16
+
+dropdown-separators:
 	Inherits: ^Dialog
 	Regions:
-		separator: 513, 1, 1, 19
+		separator: 513, 2, 1, 19
+		separator-hover: 513, 130, 1, 19
+		separator-pressed: 766, 2, 1, 19
+		separator-disabled: 513, 258, 1, 19
 
 logos:
 	Inherits: ^LoadScreen


### PR DESCRIPTION
This PR attempts to unify state suffixes used in image names across various widgets. Currently all of these suffixes are managed in each widget resulting in some inconsistencies in the naming and in the precedence of states. I looked at the widgets that have stateful names and extracted these 4 common states (in order of precedence):

1. `disabled`
1. `pressed`
1. `hover`
1. `focused`

The stateful name is composed of the base name and a suffix (e.g. `button-hover`).

I was considering making `highlighted` a state as well, but after thinking about it I realized it should stay as a variant of the base name (e.g. `button-highlighted-hover`).

This stared as a take over of #17612 but as I went down the rabbit hole I decided to make an overhaul. The goal of #17612 is still achieved though - I have added properties to configure the image collection for separators in drop-downs and also for arrows in drop-downs, scrollbars and production tabs (these used to be hard-coded to "scrollbar").

There is some more to do in this direction (with regard to checkboxes and scroll items) but I'll leave that to follow-ups to make reviewing easier. The core idea is in this PR.