### PR TITLE
Fix tooltip in Observer widgets

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ObserverSupportPowerIconsWidget.cs
@@ -46,6 +46,7 @@ namespace OpenRA.Mods.Common.Widgets
 		readonly List<SupportPowersWidget.SupportPowerIcon> supportPowerIconsIcons = new List<SupportPowersWidget.SupportPowerIcon>();
 		readonly List<Rectangle> supportPowerIconsBounds = new List<Rectangle>();
 		int lastIconIdx;
+		int currentTooltipToken;
 
 		[ObjectCreator.UseCtor]
 		public ObserverSupportPowerIconsWidget(World world, WorldRenderer worldRenderer)
@@ -164,32 +165,24 @@ namespace OpenRA.Mods.Common.Widgets
 			return new ObserverSupportPowerIconsWidget(this);
 		}
 
-		public override void MouseEntered()
-		{
-			if (TooltipContainer == null)
-				return;
-
-			tooltipContainer.Value.SetTooltip(TooltipTemplate,
-				new WidgetArgs() { { "world", worldRenderer.World }, { "player", GetPlayer() }, { "getTooltipIcon", GetTooltipIcon } });
-		}
-
-		public override void MouseExited()
-		{
-			if (TooltipContainer == null)
-				return;
-
-			tooltipContainer.Value.RemoveTooltip();
-		}
-
 		public override void Tick()
 		{
-			if (lastIconIdx >= supportPowerIconsBounds.Count)
+			if (TooltipContainer == null)
+				return;
+
+			if (Ui.MouseOverWidget != this)
 			{
-				TooltipIcon = null;
+				if (TooltipIcon != null)
+				{
+					tooltipContainer.Value.RemoveTooltip(currentTooltipToken);
+					lastIconIdx = 0;
+					TooltipIcon = null;
+				}
+
 				return;
 			}
 
-			if (TooltipIcon != null && supportPowerIconsBounds[lastIconIdx].Contains(Viewport.LastMousePos))
+			if (TooltipIcon != null && lastIconIdx < supportPowerIconsBounds.Count && supportPowerIconsIcons[lastIconIdx].Power == TooltipIcon.Power && supportPowerIconsBounds[lastIconIdx].Contains(Viewport.LastMousePos))
 				return;
 
 			for (var i = 0; i < supportPowerIconsBounds.Count; i++)
@@ -199,6 +192,8 @@ namespace OpenRA.Mods.Common.Widgets
 
 				lastIconIdx = i;
 				TooltipIcon = supportPowerIconsIcons[i];
+				currentTooltipToken = tooltipContainer.Value.SetTooltip(TooltipTemplate,
+					new WidgetArgs() { { "world", worldRenderer.World }, { "player", GetPlayer() }, { "getTooltipIcon", GetTooltipIcon } });
 				return;
 			}
 

--- a/OpenRA.Mods.Common/Widgets/TooltipContainerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TooltipContainerWidget.cs
@@ -53,7 +53,6 @@ namespace OpenRA.Mods.Common.Widgets
 
 			RemoveChildren();
 			BeforeRender = Nothing;
-			currentToken = -1;
 		}
 
 		public void RemoveTooltip()

--- a/OpenRA.Mods.Common/Widgets/TooltipContainerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TooltipContainerWidget.cs
@@ -27,6 +27,8 @@ namespace OpenRA.Mods.Common.Widgets
 		public Action BeforeRender = Nothing;
 		public int TooltipDelayMilliseconds = 200;
 		Widget tooltip;
+		int nextToken = 1;
+		int currentToken;
 
 		public TooltipContainerWidget()
 		{
@@ -34,16 +36,29 @@ namespace OpenRA.Mods.Common.Widgets
 			IsVisible = () => Game.RunTime > Viewport.LastMoveRunTime + TooltipDelayMilliseconds;
 		}
 
-		public void SetTooltip(string id, WidgetArgs args)
+		public int SetTooltip(string id, WidgetArgs args)
 		{
 			RemoveTooltip();
+			currentToken = nextToken++;
+
 			tooltip = Ui.LoadWidget(id, this, new WidgetArgs(args) { { "tooltipContainer", this } });
+
+			return currentToken;
+		}
+
+		public void RemoveTooltip(int token)
+		{
+			if (currentToken != token)
+				return;
+
+			RemoveChildren();
+			BeforeRender = Nothing;
+			currentToken = -1;
 		}
 
 		public void RemoveTooltip()
 		{
-			RemoveChildren();
-			BeforeRender = Nothing;
+			RemoveTooltip(currentToken);
 		}
 
 		public override void Draw() { BeforeRender(); }


### PR DESCRIPTION
This PR fixes several issues that was discovered with the tooltip in the widgets used in the Observer UI.

- Toolltip not updating when the item changed.
- Tooltip not showing when hovered over an icon with an index bigger or equal to the current amount of icons.