### PR TITLE
Add button to override duplicate hotkeys

### DIFF
--- a/OpenRA.Mods.Common/Widgets/HotkeyEntryWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/HotkeyEntryWidget.cs
@@ -24,6 +24,7 @@ namespace OpenRA.Mods.Common.Widgets
 		public int LeftMargin = 5;
 		public int RightMargin = 5;
 
+		public Action OnEscKey = () => { };
 		public Action OnLoseFocus = () => { };
 
 		public Func<bool> IsDisabled = () => false;
@@ -86,7 +87,8 @@ namespace OpenRA.Mods.Common.Widgets
 			Keycode.RSHIFT, Keycode.LSHIFT,
 			Keycode.RCTRL, Keycode.LCTRL,
 			Keycode.RALT, Keycode.LALT,
-			Keycode.RGUI, Keycode.LGUI
+			Keycode.RGUI, Keycode.LGUI,
+			Keycode.RETURN, Keycode.KP_ENTER
 		};
 
 		public override bool HandleKeyPress(KeyInput e)
@@ -97,8 +99,16 @@ namespace OpenRA.Mods.Common.Widgets
 			if (!HasKeyboardFocus || IgnoreKeys.Contains(e.Key))
 				return false;
 
-			if (e.Key != Keycode.ESCAPE && e.Key != Keycode.RETURN && e.Key != Keycode.KP_ENTER)
-				Key = Hotkey.FromKeyInput(e);
+			switch (e.Key)
+			{
+				case Keycode.ESCAPE:
+					OnEscKey();
+					break;
+
+				default:
+					Key = Hotkey.FromKeyInput(e);
+					break;
+			}
 
 			YieldKeyboardFocus();
 

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -1023,6 +1023,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			hotkeyEntryWidget = panel.Get<HotkeyEntryWidget>("HOTKEY_ENTRY");
 			hotkeyEntryWidget.IsValid = () => isHotkeyValid;
 			hotkeyEntryWidget.OnLoseFocus = ValidateHotkey;
+			hotkeyEntryWidget.OnEscKey = () =>
+			{
+				hotkeyEntryWidget.Key = modData.Hotkeys[selectedHotkeyDefinition.Name].GetValue();
+			};
 		}
 
 		void ValidateHotkey()
@@ -1033,6 +1037,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			if (isHotkeyValid)
 				SaveHotkey();
+			else
+				hotkeyEntryWidget.TakeKeyboardFocus();
 		}
 
 		void SaveHotkey()

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -687,6 +687,12 @@ Container@SETTINGS_PANEL:
 											Font: Tiny
 											Align: Left
 											Text: This is already used for "{0}"
+								Button@OVERRIDE_HOTKEY_BUTTON:
+									X: PARENT_RIGHT - 50 - 15 - WIDTH - 20
+									Y: 20
+									Width: 70
+									Height: 25
+									Text: Override
 								Button@CLEAR_HOTKEY_BUTTON:
 									X: PARENT_RIGHT - 25 - 15 - WIDTH - 10
 									Y: 20

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -701,6 +701,13 @@ Background@SETTINGS_PANEL:
 									Font: Tiny
 									Align: Left
 									Text: This is already used for "{0}"
+						Button@OVERRIDE_HOTKEY_BUTTON:
+							X: PARENT_RIGHT - 3 * WIDTH - 30
+							Y: 20
+							Width: 70
+							Height: 25
+							Text: Override
+							Font: Bold
 						Button@CLEAR_HOTKEY_BUTTON:
 							X: PARENT_RIGHT - 2 * WIDTH - 30
 							Y: 20


### PR DESCRIPTION
1. Add a button to override duplicate hotkeys (the button is the size of the "Logout" button and is not visible if there are no duplicates).
1. Make the <kbd>Esc</kbd> key cancel an active rebind (to give the user a way out of the focused state).

![override-common](https://user-images.githubusercontent.com/1355810/74184984-71e2b900-4c50-11ea-8e74-3c299effa7bc.png)

Closes #17599 