### PR TITLE
Prevent AI from queuing more than 1 MCV at a time

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -144,25 +144,17 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Only build MCV if the conyardCount + mcvCount are lower than the minimum conyard count.
 			var conyardCount = AIUtils.CountBuildingByCommonName(Info.ConstructionYardTypes, player);
-			if (conyardCount + mcvCount >= Info.MinimumConstructionYardCount)
+			if (conyardCount >= Info.MinimumConstructionYardCount)
 				return false;
 
 			// Only build MCV if there isn't already one being built.
-			var blds = player.World.ActorsWithTrait<ProductionQueue>()
+			var queues = player.World.ActorsWithTrait<ProductionQueue>()
 				.Where(a => a.Actor.Owner == player && Info.McvFactoryTypes.Contains(a.Actor.Info.Name) && a.Trait.Enabled)
 				.Select(a => a.Trait);
 
-			int queuedMcvCount = 0;
-			foreach (var factory in blds)
-			{
-				var q = factory.AllQueued().Where(z => Info.McvTypes.Contains(z.Item));
-
-				if (q != null)
-					queuedMcvCount += q.Count();
-			}
-
-			if (queuedMcvCount > 0)
-				return false;
+			foreach (var factory in queues)
+				if (factory.AllQueued().Any(z => Info.McvTypes.Contains(z.Item)))
+					return false;
 
 			return true;
 		}

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -132,14 +132,39 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool ShouldBuildMCV()
 		{
-			// Only build MCV if we don't already have one in the field.
-			var allowedToBuildMCV = AIUtils.CountActorByCommonName(Info.McvTypes, player) == 0;
-			if (!allowedToBuildMCV)
+			// Only build MCV if we have a factory to build it with.
+			var enoughFactories = AIUtils.CountBuildingByCommonName(Info.McvFactoryTypes, player) > 0;
+			if (!enoughFactories)
 				return false;
 
-			// Build MCV if we don't have the desired number of construction yards, unless we have no factory (can't build it).
-			return AIUtils.CountBuildingByCommonName(Info.ConstructionYardTypes, player) < Info.MinimumConstructionYardCount &&
-				AIUtils.CountBuildingByCommonName(Info.McvFactoryTypes, player) > 0;
+			// Only build MCV if we don't already have one in the field.
+			var mcvCount = AIUtils.CountActorByCommonName(Info.McvTypes, player);
+			if (mcvCount > 0)
+				return false;
+
+			// Only build MCV if the conyardCount + mcvCount are lower than the minimum conyard count.
+			var conyardCount = AIUtils.CountBuildingByCommonName(Info.ConstructionYardTypes, player);
+			if (conyardCount + mcvCount >= Info.MinimumConstructionYardCount)
+				return false;
+
+			// Only build MCV if there isn't already one being built.
+			var blds = player.World.ActorsWithTrait<ProductionQueue>()
+				.Where(a => a.Actor.Owner == player && Info.McvFactoryTypes.Contains(a.Actor.Info.Name) && a.Trait.Enabled)
+				.Select(a => a.Trait);
+
+			int queuedMcvCount = 0;
+			foreach (var factory in blds)
+			{
+				var q = factory.AllQueued().Where(z => Info.McvTypes.Contains(z.Item));
+
+				if (q != null)
+					queuedMcvCount += q.Count();
+			}
+
+			if (queuedMcvCount > 0)
+				return false;
+
+			return true;
 		}
 
 		void DeployMcvs(IBot bot, bool chooseLocation)

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -132,17 +132,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool ShouldBuildMCV()
 		{
-			// Only build MCV if we have a factory to build it with.
 			var enoughFactories = AIUtils.CountBuildingByCommonName(Info.McvFactoryTypes, player) > 0;
 			if (!enoughFactories)
 				return false;
 
-			// Only build MCV if we don't already have one in the field.
 			var mcvCount = AIUtils.CountActorByCommonName(Info.McvTypes, player);
 			if (mcvCount > 0)
 				return false;
 
-			// Only build MCV if the conyardCount + mcvCount are lower than the minimum conyard count.
 			var conyardCount = AIUtils.CountBuildingByCommonName(Info.ConstructionYardTypes, player);
 			if (conyardCount >= Info.MinimumConstructionYardCount)
 				return false;

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -139,6 +139,9 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool ShouldBuildMCV()
 		{
+			if (world.WorldTick < newMcvInterval)
+				return false;
+
 			var enoughFactories = AIUtils.CountBuildingByCommonName(Info.McvFactoryTypes, player) > 0;
 			if (!enoughFactories)
 				return false;
@@ -152,9 +155,6 @@ namespace OpenRA.Mods.Common.Traits
 				return false;
 
 			if (conyardCount > 0 && world.WorldTick < buildAdditionalMcvDelay)
-				return false;
-
-			if (world.WorldTick < newMcvInterval)
 				return false;
 
 			// Only build MCV if there isn't already one being built.


### PR DESCRIPTION
This change prevents the AI from spam-creating MCVs when it is below the MinimumConstructionYardCount. It disallows the AI from queuing up more than one new MCV at a time.

This change was due to the behaviour I noticed when playing with MinimumConstructionYardCount = 2, the AI would often build 2 or more MCVs at a time and I noticed the pattern was one queued per factory which could support it.

It effectively stops the AI from bankrupting itself by buying several MCVs.