### PR TITLE
Force disable glDebugMessageCallback on Linux+AMD.

### DIFF
--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -501,6 +501,14 @@ namespace OpenRA.Platforms.Default
 			if (Features.HasFlag(GLFeatures.DebugMessagesCallback) && Game.Settings.Graphics.DisableGLDebugMessageCallback)
 				Features ^= GLFeatures.DebugMessagesCallback;
 
+			// Force disable the debug message callback feature on Linux + AMD GPU to work around a startup freeze
+			if (Features.HasFlag(GLFeatures.DebugMessagesCallback) && Platform.CurrentPlatform == PlatformType.Linux)
+			{
+				var renderer = glGetString(GL_RENDERER);
+				if (renderer.Contains("AMD") || renderer.Contains("Radeon"))
+					Features ^= GLFeatures.DebugMessagesCallback;
+			}
+
 			if (!Features.HasFlag(GLFeatures.Core))
 			{
 				WriteGraphicsLog("Unsupported OpenGL version: " + glGetString(GL_VERSION));


### PR DESCRIPTION
Closes #17391.

Ping @dragunoff: can you please try removing `DisableGLDebugMessageCallback` from your settings and confirm that this PR solves the freeze?