### PR TITLE
Fix save game loading screen stripe bounds.

### DIFF
--- a/mods/d2k/chrome.yaml
+++ b/mods/d2k/chrome.yaml
@@ -424,5 +424,5 @@ logos:
 
 loadscreen-stripe:
 	Inherits: ^LoadScreen
-	PanelRegion: 256, 0, 0, 0, 256, 256, 0, 0
+	PanelRegion: 258, 0, 0, 0, 253, 256, 0, 0
 	PanelSides: Center

--- a/mods/ts/chrome.yaml
+++ b/mods/ts/chrome.yaml
@@ -693,5 +693,5 @@ logos:
 
 loadscreen-stripe:
 	Inherits: ^LoadScreen
-	PanelRegion: 256, 0, 0, 0, 256, 256, 0, 0
+	PanelRegion: 258, 0, 0, 0, 253, 256, 0, 0
 	PanelSides: Center


### PR DESCRIPTION
Fixes a regression from #17495. This solves the gappy stripes when loading a saved game in D2k and TS.