### PR TITLE
Add new MCV placement logic

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits
 			var tileset = world.Map.Rules.TileSet;
 			var resourceTypeIndices = new BitArray(tileset.TerrainInfo.Length);
 
-			foreach (var t in world.Map.Rules.Actors["world"].TraitInfos<ResourceTypeInfo>())
+			foreach (var t in world.WorldActor.Info.TraitInfos<ResourceTypeInfo>())
 				resourceTypeIndices.Set(tileset.GetTerrainIndex(t.TerrainType), true);
 
 			var randomConstructionYard = world.Actors.Where(a => a.Owner == player &&
@@ -226,15 +226,15 @@ namespace OpenRA.Mods.Common.Traits
 			var actors = world.FindActorsInCircle(wPos, newBaseRadius)
 				.Where(a => !a.Disposed);
 
-			var enemies = actors.Where(a => player.Stances[a.Owner] == Stance.Enemy);
+			var enemies = actors.Any(a => player.Stances[a.Owner] == Stance.Enemy);
 
-			if (enemies.Count() > 0)
+			if (enemies)
 				return null;
 
-			var self = actors.Where(a => a.Owner == player
-					&& (Info.McvTypes.Contains(a.Info.Name) || (Info.ConstructionYardTypes.Contains(a.Info.Name) && a.Info.HasTraitInfo<BuildingInfo>())));
+			var self = actors.Any(a => a.Owner == player
+					&& (Info.McvTypes.Contains(a.Info.Name) || Info.ConstructionYardTypes.Contains(a.Info.Name)));
 
-			if (self.Count() > 0)
+			if (self)
 				return null;
 
 			return baseCenter;

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 			"AI will not send MCVs to locations containing enemies within the MaxBaseRadius of that location.",
 			"AI will not send MCVs to locations containing its own MCVs or construction yards within the MaxBaseRadius of that location.",
 			"In the case of less than 1 construction yard, the AI will choose a random new base center and place the MCV within the MaxBaseRadius of that location.",
-			"In the case of at least 1 construction yard, the AI will choose a location nearer resource fields outside of all bases MaxBaseRadius up to world.Map.Grid.MaximumTileSearchRange.")]
+			"In the case of at least 1 construction yard, the AI will choose a location nearer resource fields outside of all bases `MaxBaseRadius` up to `MapGrid.MaximumTileSearchRange` (from the mod's manifest).")]
 		public readonly int MaxBaseRadius = 20;
 
 		public override object Create(ActorInitializer init) { return new McvManagerBotModule(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/McvManagerBotModule.cs
@@ -54,12 +54,6 @@ namespace OpenRA.Mods.Common.Traits
 			if (!distanceToBaseIsImportant)
 				return initialBaseCenter;
 
-			var tileset = world.Map.Rules.TileSet;
-			var resourceTypeIndices = new BitArray(tileset.TerrainInfo.Length);
-
-			foreach (var t in world.WorldActor.Info.TraitInfos<ResourceTypeInfo>())
-				resourceTypeIndices.Set(tileset.GetTerrainIndex(t.TerrainType), true);
-
 			var randomConstructionYard = world.Actors.Where(a => a.Owner == player &&
 				Info.ConstructionYardTypes.Contains(a.Info.Name))
 				.RandomOrDefault(world.LocalRandom);
@@ -79,6 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 		IBotPositionsUpdated[] notifyPositionsUpdated;
 		IBotRequestUnitProduction[] requestUnitProduction;
 
+		BitArray resourceTypeIndices;
 		CPos initialBaseCenter;
 		int scanInterval;
 		bool firstTick = true;
@@ -89,6 +84,9 @@ namespace OpenRA.Mods.Common.Traits
 			world = self.World;
 			player = self.Owner;
 			unitCannotBeOrdered = a => a.Owner != player || a.IsDead || !a.IsInWorld;
+			resourceTypeIndices = new BitArray(world.Map.Rules.TileSet.TerrainInfo.Length);
+			foreach (var t in world.WorldActor.Info.TraitInfos<ResourceTypeInfo>())
+				resourceTypeIndices.Set(world.Map.Rules.TileSet.GetTerrainIndex(t.TerrainType), true);
 		}
 
 		protected override void Created(Actor self)
@@ -231,10 +229,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (enemies)
 				return null;
 
-			var self = actors.Any(a => a.Owner == player
+			var anyOwnBaseActorsNearbyDesiredCell = actors.Any(a => a.Owner == player
 					&& (Info.McvTypes.Contains(a.Info.Name) || Info.ConstructionYardTypes.Contains(a.Info.Name)));
 
-			if (self)
+			if (anyOwnBaseActorsNearbyDesiredCell)
 				return null;
 
 			return baseCenter;

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200202/RemoveRestrictMCVDeploymentFallbackToBase.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200202/RemoveRestrictMCVDeploymentFallbackToBase.cs
@@ -1,0 +1,38 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class RemoveRestrictMCVDeploymentFallbackToBase : UpdateRule
+	{
+		public override string Name { get { return "RestrictMCVDeploymentFallbackToBase trait has been removed from McvManagerBotModule."; } }
+		public override string Description
+		{
+			get
+			{
+				return "The RestrictMCVDeploymentFallbackToBase trait has been removed, and is replaced by a an AI \n" +
+					   "which will place new bases at resource locations, away from enemies and its own previous bases.\n" +
+					   "It will not place any bases within the MaxBaseRadius of its own MCVs, con yards or any enemy.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			foreach (var t in actorNode.ChildrenMatching("McvManagerBotModule"))
+				t.RemoveNodes("RestrictMCVDeploymentFallbackToBase");
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200202/RemoveRestrictMCVDeploymentFallbackToBase.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200202/RemoveRestrictMCVDeploymentFallbackToBase.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 		{
 			get
 			{
-				return "The RestrictMCVDeploymentFallbackToBase trait has been removed, and is replaced by a an AI \n" +
+				return "The RestrictMCVDeploymentFallbackToBase property has been removed, and is replaced by an AI \n" +
 					   "which will place new bases at resource locations, away from enemies and its own previous bases.\n" +
 					   "It will not place any bases within the MaxBaseRadius of its own MCVs, con yards or any enemy.";
 			}

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200202/RemoveRestrictMCVDeploymentFallbackToBase.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200202/RemoveRestrictMCVDeploymentFallbackToBase.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.UpdateRules.Rules
 {
 	public class RemoveRestrictMCVDeploymentFallbackToBase : UpdateRule
 	{
-		public override string Name { get { return "RestrictMCVDeploymentFallbackToBase trait has been removed from McvManagerBotModule."; } }
+		public override string Name { get { return "RestrictMCVDeploymentFallbackToBase has been removed from McvManagerBotModule."; } }
 		public override string Description
 		{
 			get

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -76,6 +76,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveTurnToDock(),
 				new RenameSmudgeSmokeFields(),
 				new RenameCircleContrast(),
+				new RemoveRestrictMCVDeploymentFallbackToBase(),
 			})
 		};
 


### PR DESCRIPTION
New PR opened due to my accidental merge on #17649

AI MCVs now place new MCVs near new tiberium fields, away from enemies buildings and its own previous con yards. Similar to a real player.

This modifies the previous logic, to:

1. Get a new random base center that is near a resource field, outside of the centered area of a previous random con yard location. Thus making the AI build outside of previous MCV locations.
2. The normal logic then is used (which selects a random location in the area based on step 1).
3. The MaxBaseRadius around the newly selected location is checked for enemies. If none exist we continue, otherwise we return null.
4. The MaxBaseRadius around the newly selected location is checked for previous construction yards (of the same player) or MCVs. If none exist in that location we continue, otherwise we return null.

Here are a few screenshots of a tweaked AI I created to produce the additional MCVs:
![image](https://user-images.githubusercontent.com/706132/73895994-602c9a80-4879-11ea-8506-8e8f617891ca.png)

![image](https://user-images.githubusercontent.com/706132/73896351-a8988800-487a-11ea-9179-f9144142c191.png)

![image](https://user-images.githubusercontent.com/706132/73896014-6fabe380-4879-11ea-8e52-9922cfe03d69.png)