### PR TITLE
Allow players to mute shellmap background music

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -199,6 +199,7 @@ namespace OpenRA
 
 		public bool CashTicks = true;
 		public bool Mute = false;
+		public bool MuteBackgroundMusic = false;
 	}
 
 	public class PlayerSettings

--- a/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
+++ b/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
@@ -33,6 +33,9 @@ namespace OpenRA.Mods.Common.Traits
 			"It cannot be paused, but can be overridden by selecting a new track.")]
 		public readonly string BackgroundMusic = null;
 
+		[Desc("Allow the background music to be muted by the player.")]
+		public readonly bool AllowMuteBackgroundMusic = false;
+
 		[Desc("Disable all world sounds (combat etc).")]
 		public readonly bool DisableWorldSounds = false;
 
@@ -49,6 +52,13 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly bool IsMusicInstalled;
 		public readonly bool IsMusicAvailable;
+		public readonly bool AllowMuteBackgroundMusic;
+
+		public bool IsBackgroundMusicMuted
+		{
+			get { return AllowMuteBackgroundMusic && Game.Settings.Sound.MuteBackgroundMusic; }
+		}
+
 		public bool CurrentSongIsBackground { get; private set; }
 
 		MusicInfo currentSong;
@@ -73,6 +83,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			random = playlist.Shuffle(Game.CosmeticRandom).ToArray();
 			IsMusicAvailable = playlist.Any();
+			AllowMuteBackgroundMusic = info.AllowMuteBackgroundMusic;
 
 			if (SongExists(info.BackgroundMusic))
 			{
@@ -150,7 +161,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void Play()
 		{
-			if (!SongExists(currentSong))
+			if (!SongExists(currentSong) || (CurrentSongIsBackground && IsBackgroundMusicMuted))
 				return;
 
 			Game.Sound.PlayMusicThen(currentSong, () =>
@@ -228,7 +239,9 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				currentSong = currentBackgroundSong;
 				CurrentSongIsBackground = true;
-				Play();
+
+				if (!IsBackgroundMusicMuted)
+					Play();
 			}
 		}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Support;
 using OpenRA.Widgets;
@@ -401,10 +402,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 		Action InitAudioPanel(Widget panel)
 		{
+			var musicPlaylist = worldRenderer.World.WorldActor.Trait<MusicPlaylist>();
 			var ss = Game.Settings.Sound;
 
 			BindCheckboxPref(panel, "CASH_TICKS", ss, "CashTicks");
 			BindCheckboxPref(panel, "MUTE_SOUND", ss, "Mute");
+			BindCheckboxPref(panel, "MUTE_BACKGROUND_MUSIC", ss, "MuteBackgroundMusic");
 
 			BindSliderPref(panel, "SOUND_VOLUME", ss, "SoundVolume");
 			BindSliderPref(panel, "MUSIC_VOLUME", ss, "MusicVolume");
@@ -423,6 +426,19 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					Game.Sound.MuteAudio();
 				else
 					Game.Sound.UnmuteAudio();
+			};
+
+			var muteBackgroundMusicCheckbox = panel.Get<CheckboxWidget>("MUTE_BACKGROUND_MUSIC");
+			var muteBackgroundMusicCheckboxOnClick = muteBackgroundMusicCheckbox.OnClick;
+			muteBackgroundMusicCheckbox.OnClick = () =>
+			{
+				muteBackgroundMusicCheckboxOnClick();
+
+				if (!musicPlaylist.AllowMuteBackgroundMusic)
+					return;
+
+				if (musicPlaylist.CurrentSongIsBackground)
+					musicPlaylist.Stop();
 			};
 
 			// Replace controls with a warning label if sound is disabled
@@ -471,6 +487,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ss.VideoVolume = dss.VideoVolume;
 				ss.CashTicks = dss.CashTicks;
 				ss.Mute = dss.Mute;
+				ss.MuteBackgroundMusic = dss.MuteBackgroundMusic;
 				ss.Device = dss.Device;
 
 				panel.Get<SliderWidget>("SOUND_VOLUME").Value = ss.SoundVolume;

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -311,6 +311,13 @@ Container@SETTINGS_PANEL:
 									Height: 20
 									Font: Regular
 									Text: Mute Sound
+								Checkbox@MUTE_BACKGROUND_MUSIC:
+									X: 15
+									Y: 103
+									Width: 200
+									Height: 20
+									Font: Regular
+									Text: Mute Background Music
 								Label@SOUND_LABEL:
 									X: PARENT_RIGHT - WIDTH - 270
 									Y: 40

--- a/mods/cnc/maps/blank-shellmap/map.yaml
+++ b/mods/cnc/maps/blank-shellmap/map.yaml
@@ -32,4 +32,5 @@ Rules:
 		-CrateSpawner:
 		MusicPlaylist:
 			BackgroundMusic: map1
+			AllowMuteBackgroundMusic: true
 			DisableWorldSounds: true

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -322,6 +322,13 @@ Background@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Mute Sound
+						Checkbox@MUTE_BACKGROUND_MUSIC:
+							X: 15
+							Y: 103
+							Width: 200
+							Height: 20
+							Font: Regular
+							Text: Mute Background Music
 						Label@SOUND_LABEL:
 							X: PARENT_RIGHT - WIDTH - 270
 							Y: 40

--- a/mods/d2k/maps/shellmap/rules.yaml
+++ b/mods/d2k/maps/shellmap/rules.yaml
@@ -13,6 +13,7 @@ World:
 		Maximum: 3
 	MusicPlaylist:
 		BackgroundMusic: options
+		AllowMuteBackgroundMusic: true
 		DisableWorldSounds: true
 	LuaScript:
 		Scripts: d2k-shellmap.lua

--- a/mods/ra/maps/desert-shellmap/rules.yaml
+++ b/mods/ra/maps/desert-shellmap/rules.yaml
@@ -10,6 +10,7 @@ World:
 	-MPStartLocations:
 	MusicPlaylist:
 		BackgroundMusic: intro
+		AllowMuteBackgroundMusic: true
 		DisableWorldSounds: true
 	ResourceType@ore:
 		ValuePerUnit: 0

--- a/mods/ts/maps/fields-of-green/rules.yaml
+++ b/mods/ts/maps/fields-of-green/rules.yaml
@@ -13,6 +13,7 @@ World:
 	MusicPlaylist:
 		BackgroundMusic: intro
 		DisableWorldSounds: true
+		AllowMuteBackgroundMusic: true
 	GlobalLightingPaletteEffect:
 		Blue: 0.7
 		Ambient: 0.7


### PR DESCRIPTION
Adds a checkbox to the Audio settings that allows the player to mute the background music on the shellmap. This effectively mutes the background music in the menus before a game has started. Normal music tracks are not affected.

The ability to mute the music is managed on the map level like this:
```yaml
MusicPlaylist:
	AllowMuteBackgroundMusic: true
```

![mute-background-music](https://user-images.githubusercontent.com/1355810/74548097-e326b280-4f55-11ea-96e8-331c52919f5a.png)


Closes #17584 