### PR TITLE
Fix an integer overflow when calculating selection priorities.

### DIFF
--- a/OpenRA.Game/SelectableExts.cs
+++ b/OpenRA.Game/SelectableExts.cs
@@ -83,7 +83,7 @@ namespace OpenRA.Traits
 				bounds.Top + bounds.Size.Height / 2);
 
 			var pixelDistance = (centerPixel - selectionPixel).Length;
-			return ((long)-pixelDistance << 32) + info.SelectionPriority(modifiers);
+			return info.SelectionPriority(modifiers) - (long)pixelDistance << 16;
 		}
 
 		static readonly Actor[] NoActors = { };


### PR DESCRIPTION
This PR fixes a regression introduced by #17291 - the actual bug is much older, but the bad behaviour didn't break anything obvious ingame before that PR.

Repro case:
 * Start a skirmish in TD
 * Enable left-click / classic orders
 * Disable the shroud
 * Select one of the starting forces and mouse-over the enemy construction yard.

Before: the attack cursor would disappear when mousing over the middle of the conyard.
After: the attack cursor works over the entire actor.


Closes #17681.

Its a shame that nobody thought to report this earlier, otherwise this could have been included in the hotfix.