### PR TITLE
Fix FlyAttack invalid target crash.

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -222,8 +222,14 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected override void OnFirstRun(Actor self)
 		{
-			QueueChild(new Fly(self, target, target.CenterPosition));
-			QueueChild(new Fly(self, target, exitRange, WDist.MaxValue, target.CenterPosition));
+			// The target may have died while this activity was queued
+			if (target.IsValidFor(self))
+			{
+				QueueChild(new Fly(self, target, target.CenterPosition));
+				QueueChild(new Fly(self, target, exitRange, WDist.MaxValue, target.CenterPosition));
+			}
+			else
+				Cancel(self);
 		}
 
 		public override bool Tick(Actor self)
@@ -261,8 +267,14 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected override void OnFirstRun(Actor self)
 		{
-			QueueChild(new Fly(self, target, target.CenterPosition));
-			QueueChild(new Fly(self, target, exitRange, WDist.MaxValue, target.CenterPosition));
+			// The target may have died while this activity was queued
+			if (target.IsValidFor(self))
+			{
+				QueueChild(new Fly(self, target, target.CenterPosition));
+				QueueChild(new Fly(self, target, exitRange, WDist.MaxValue, target.CenterPosition));
+			}
+			else
+				Cancel(self);
 		}
 
 		public override bool Tick(Actor self)


### PR DESCRIPTION
Fixes #17688.

Testcase:
```diff
diff --git a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
index 67ab3cf86b..f7907a2ac6 100644
--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -167,7 +167,10 @@ public override bool Tick(Actor self)
                        else if (attackAircraft.Info.AttackType == AirAttackType.Strafe)
                                QueueChild(new StrafeAttackRun(self, attackAircraft, target, strafeDistance != WDist.Zero ? strafeDistance : lastVisibleMaximumRange));
                        else if (attackAircraft.Info.AttackType == AirAttackType.Default && !aircraft.Info.CanHover)
+                       {
+                               target.Actor.Kill(self);
                                QueueChild(new FlyAttackRun(self, target, lastVisibleMaximumRange));
+                       }
 
                        // Turn to face the target if required.
                        else if (!attackAircraft.TargetInFiringArc(self, target, attackAircraft.Info.FacingTolerance))
```