### PR TITLE
Reset nextScanTime only when actually scanning for targets.

### DIFF
--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -290,11 +290,11 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			if (nextScanTime <= 0 && ActiveAttackBases.Any())
 			{
-				nextScanTime = self.World.SharedRandom.Next(Info.MinimumScanTimeInterval, Info.MaximumScanTimeInterval);
-
 				foreach (var dat in disableAutoTarget)
 					if (dat.DisableAutoTarget(self, allowMove))
 						return Target.Invalid;
+
+				nextScanTime = self.World.SharedRandom.Next(Info.MinimumScanTimeInterval, Info.MaximumScanTimeInterval);
 
 				foreach (var ab in ActiveAttackBases)
 				{


### PR DESCRIPTION
Fixes #17691.

The problem occurs because `AutoTarget`'s `TickIdle` implementation would call `ScanAndAttack` each tick, which would reset `nextScanTime` and then do nothing because `AttackFollow` disables this kind of scanning. When `AttackFollow` then wants to scan, it can't do anything because `nextScanTime > 0`.  Moving the `nextScanTime` reset after the disable check prevents TickIdle from resetting it.