### PR TITLE
Fix GrantConditionOnProduction not using ShowSelectionBar

### DIFF
--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnProduction.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnProduction.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		float ISelectionBar.GetValue()
 		{
-			if (info.Duration < 0 || token == ConditionManager.InvalidConditionToken)
+			if (!info.ShowSelectionBar || info.Duration < 0 || token == ConditionManager.InvalidConditionToken)
 				return 0;
 
 			return (float)ticks / info.Duration;


### PR DESCRIPTION
Closes #17702.
Apparently @MustaphaTR forgot to use this in https://github.com/OpenRA/OpenRA/commit/b53c13dca423e9a0b513cade3c17a0946880562d so this was broken from the start.