### PR TITLE
Set unicode without BOM as editor standard

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,6 @@
 ; Top-most http://editorconfig.org/ file
 root = true
+charset=utf-8
 
 ; Unix-style newlines
 [*]


### PR DESCRIPTION
to help enforce the https://github.com/OpenRA/OpenRA/wiki/Coding-Standard