### PR TITLE
Fix linux packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,10 +66,10 @@ notifications:
 
 before_deploy:
  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-     wget http://mirrors.kernel.org/ubuntu/pool/universe/n/nsis/nsis-common_3.03-2_all.deb;
-     wget http://mirrors.kernel.org/ubuntu/pool/universe/n/nsis/nsis_3.03-2_amd64.deb;
-     sudo dpkg -i nsis-common_3.03-2_all.deb;
-     sudo dpkg -i nsis_3.03-2_amd64.deb;
+     wget https://mirrors.edge.kernel.org/ubuntu/pool/universe/n/nsis/nsis-common_3.04-1_all.deb;
+     wget https://mirrors.edge.kernel.org/ubuntu/pool/universe/n/nsis/nsis_3.04-1_amd64.deb;
+     sudo dpkg -i nsis-common_3.04-1_all.deb;
+     sudo dpkg -i nsis_3.04-1_amd64.deb;
    fi;
  - export PATH=$PATH:$HOME/usr/bin
  - DOTVERSION=`echo ${TRAVIS_TAG} | sed "s/-/\\./g"`

--- a/packaging/linux/buildpackage.sh
+++ b/packaging/linux/buildpackage.sh
@@ -7,7 +7,7 @@ command -v python >/dev/null 2>&1 || { echo >&2 "Linux packaging requires python
 command -v tar >/dev/null 2>&1 || { echo >&2 "Linux packaging requires tar."; exit 1; }
 command -v curl >/dev/null 2>&1 || command -v wget > /dev/null 2>&1 || { echo >&2 "Linux packaging requires curl or wget."; exit 1; }
 
-DEPENDENCIES_TAG="20200202"
+DEPENDENCIES_TAG="20200222"
 
 if [ $# -eq "0" ]; then
 	echo "Usage: $(basename "$0") version [outputdir]"


### PR DESCRIPTION
* Fixes a regression from #17640 - [2.0.10 fails to compile](https://travis-ci.org/OpenRA/AppImageSupport/builds/645024518#L1207) (already seems to be fixed for the next SDL release), so is missing from our libs.tar.gz. I missed this while testing because the AppImage was silently falling back to my system version
* Package Freetype instead of falling back to the system version - to match AppImage expectations and our other platforms
* Fix packaging errors caused by the manually installed nsis debs moving.

Test appimages: https://github.com/pchote/OpenRA/releases/tag/pkgtest-20200222