### PR TITLE
Load badges on the main thread.

### DIFF
--- a/OpenRA.Game/PlayerProfile.cs
+++ b/OpenRA.Game/PlayerProfile.cs
@@ -35,19 +35,20 @@ namespace OpenRA
 			var badgesNode = yaml.Nodes.FirstOrDefault(n => n.Key == "Badges");
 			if (badgesNode != null)
 			{
-				try
+				var playerDatabase = Game.ModData.Manifest.Get<PlayerDatabase>();
+				foreach (var badgeNode in badgesNode.Value.Nodes)
 				{
-					var playerDatabase = Game.ModData.Manifest.Get<PlayerDatabase>();
-					foreach (var badgeNode in badgesNode.Value.Nodes)
+					Game.RunAfterTick(() =>
 					{
-						var badge = playerDatabase.LoadBadge(badgeNode.Value);
-						if (badge != null)
-							badges.Add(badge);
-					}
-				}
-				catch
-				{
-					// Discard badges on error
+						// Discard badge on error
+						try
+						{
+							var badge = playerDatabase.LoadBadge(badgeNode.Value);
+							if (badge != null)
+								badges.Add(badge);
+						}
+						catch { }
+					});
 				}
 			}
 


### PR DESCRIPTION
Fixes #17714.

Note that the issue only occurs on the non-threaded renderer, so Linux/macOS testers will need to change https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs#L285 to `var threadedRenderer = false;` to reproduce the issue.