### PR TITLE
Ignore the types of an exit when the production type is null or empty

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -111,7 +111,7 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (ShouldLandAtBuilding(self, dest))
 			{
-				var exit = dest.FirstExitOrDefault(null);
+				var exit = dest.FirstExitOrDefault();
 				var offset = exit != null ? exit.Info.SpawnOffset : WVec.Zero;
 				if (aircraft.Info.TurnToDock || !aircraft.Info.VTOL)
 					facing = aircraft.Info.InitialFacing;

--- a/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/ProductionProperties.cs
@@ -34,19 +34,22 @@ namespace OpenRA.Mods.Common.Scripting
 
 		[ScriptActorPropertyActivity]
 		[Desc("Build a unit, ignoring the production queue. The activity will wait if the exit is blocked.",
-			"If productionType is nil or unavailable, then an exit will be selected based on Buildable info.")]
+			"If productionType is nil or unavailable, then an exit will be selected based on 'Buildable.BuildAtProductionType'.",
+			"If 'Buildable.BuildAtProductionType' is not set either, a random exit will be selected.")]
 		public void Produce(string actorType, string factionVariant = null, string productionType = null)
 		{
 			ActorInfo actorInfo;
 			if (!Self.World.Map.Rules.Actors.TryGetValue(actorType, out actorInfo))
 				throw new LuaException("Unknown actor type '{0}'".F(actorType));
 
+			var bi = actorInfo.TraitInfo<BuildableInfo>();
 			Self.QueueActivity(new WaitFor(() =>
 			{
 				// Go through all available traits and see which one successfully produces
 				foreach (var p in productionTraits)
 				{
-					if (!string.IsNullOrEmpty(productionType) && !p.Info.Produces.Contains(productionType))
+					var type = productionType ?? bi.BuildAtProductionType;
+					if (!string.IsNullOrEmpty(type) && !p.Info.Produces.Contains(type))
 						continue;
 
 					var inits = new TypeDictionary
@@ -55,7 +58,7 @@ namespace OpenRA.Mods.Common.Scripting
 						new FactionInit(factionVariant ?? BuildableInfo.GetInitialFaction(actorInfo, p.Faction))
 					};
 
-					if (p.Produce(Self, actorInfo, productionType, inits))
+					if (p.Produce(Self, actorInfo, type, inits))
 						return true;
 				}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Exit.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 				.OrderBy(e => e.Info.Priority);
 
 			if (string.IsNullOrEmpty(productionType))
-				return all.FirstOrDefault(e => e.Info.ProductionTypes.Count == 0);
+				return all.FirstOrDefault();
 
 			return all.FirstOrDefault(e => e.Info.ProductionTypes.Count == 0 || e.Info.ProductionTypes.Contains(productionType));
 		}
@@ -64,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits
 				.Where(Exts.IsTraitEnabled);
 
 			if (string.IsNullOrEmpty(productionType))
-				return all.Where(e => e.Info.ProductionTypes.Count == 0);
+				return all;
 
 			return all.Where(e => e.Info.ProductionTypes.Count == 0 || e.Info.ProductionTypes.Contains(productionType));
 		}


### PR DESCRIPTION
On bleed only `Exit`s that have no types themselves are chosen when no production type is given. That does not make any sense to me and causes things like #17727 since we didn't define any types in Lua. If you wanted to have such a kind of restriction you could easily define an `empty` type and give that to exits and as production type.
Changed the code to choose any exit when no type is given.
Closes #17727.