### PR TITLE
Fix incorrect end point rendering in DrawConnectedLine.

### DIFF
--- a/OpenRA.Game/Graphics/RgbaColorRenderer.cs
+++ b/OpenRA.Game/Graphics/RgbaColorRenderer.cs
@@ -153,8 +153,8 @@ namespace OpenRA.Graphics
 				var nextCorner = width / 2 * new float3(-nextDir.Y, nextDir.X, nextDir.Z);
 
 				// Vertices for the corners joining start-end to end-next
-				var cc = closed || i < limit ? IntersectionOf(end + corner, dir, end + nextCorner, nextDir) : end + corner;
-				var cd = closed || i < limit ? IntersectionOf(end - corner, dir, end - nextCorner, nextDir) : end - corner;
+				var cc = closed || i < limit - 1 ? IntersectionOf(end + corner, dir, end + nextCorner, nextDir) : end + corner;
+				var cd = closed || i < limit - 1 ? IntersectionOf(end - corner, dir, end - nextCorner, nextDir) : end - corner;
 
 				// Fill segment
 				vertices[0] = new Vertex(ca + Offset, r, g, b, a, 0, 0);


### PR DESCRIPTION
This PR fixes a long standing issue with rendering connected line segments: `i < limit` was true for *all* points in the loop, so we drew the end point of the last segment as if it were going to be connected back to the first point in the line.

This fixes a glitch with the selection box rendering that has become much more noticable with our expanded HiDPI and UI scaling support:

Before:
<img src="https://user-images.githubusercontent.com/167819/75484916-9b664900-59a1-11ea-9747-ed960bf691a6.png">

After:
<img src="https://user-images.githubusercontent.com/167819/75484960-b8028100-59a1-11ea-9571-d2197b5af509.png">

The scope for testing and regression here should be minor as the only code that calls `DrawConnectedLine` with `closed: false` is `DrawLine` with `connectSegments: true` - this is only used by the selection boxes, perf/spectator graphs, and railgun helix effect.
