### PR TITLE
Add explicitly defined version strings to the lua docs.

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractLuaDocsCommand.cs
@@ -31,7 +31,11 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			// HACK: The engine code assumes that Game.modData is set.
 			Game.ModData = utility.ModData;
 
-			Console.WriteLine("This is an automatically generated listing of the new Lua map scripting API, generated for {0} of OpenRA.", Game.ModData.Manifest.Metadata.Version);
+			var version = utility.ModData.Manifest.Metadata.Version;
+			if (args.Length > 1)
+				version = args[1];
+
+			Console.WriteLine("This is an automatically generated listing of the Lua map scripting API for version {0} of OpenRA.", version);
 			Console.WriteLine();
 			Console.WriteLine("OpenRA allows custom maps and missions to be scripted using Lua 5.1.\n" +
 				"These scripts run in a sandbox that prevents access to unsafe functions (e.g. OS or file access), " +


### PR DESCRIPTION
Fixes #16159 by adding the same version override used in the other documentation commands.