### PR TITLE
Fix AutoTarget regression

### DIFF
--- a/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackFollow.cs
@@ -42,7 +42,6 @@ namespace OpenRA.Mods.Common.Traits
 		Activity requestedTargetPresetForActivity;
 		bool opportunityForceAttack;
 		bool opportunityTargetIsPersistentTarget;
-		bool scanningForOpportunityTarget;
 
 		public void SetRequestedTarget(Actor self, Target target, bool isForceAttack = false)
 		{
@@ -138,10 +137,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (!IsAiming && Info.OpportunityFire && autoTarget != null &&
 				    !autoTarget.IsTraitDisabled && autoTarget.Stance >= UnitStance.Defend)
 				{
-					scanningForOpportunityTarget = true;
 					OpportunityTarget = autoTarget.ScanForTarget(self, false, false);
-					scanningForOpportunityTarget = false;
-
 					opportunityForceAttack = false;
 					opportunityTargetIsPersistentTarget = false;
 
@@ -186,13 +182,8 @@ namespace OpenRA.Mods.Common.Traits
 			opportunityTargetIsPersistentTarget = false;
 		}
 
-		bool IDisableAutoTarget.DisableAutoTarget(Actor self, bool allowMove)
+		bool IDisableAutoTarget.DisableAutoTarget(Actor self)
 		{
-			// HACK: Disable standard AutoTarget scanning, which we want to be
-			// controlled by the opportunity target logic in this trait
-			if (!allowMove && !scanningForOpportunityTarget)
-				return true;
-
 			return RequestedTarget.Type != TargetType.Invalid ||
 				(opportunityTargetIsPersistentTarget && OpportunityTarget.Type != TargetType.Invalid);
 		}

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -40,6 +40,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("It will try to pivot to face the enemy if stance is not HoldFire.")]
 		public readonly bool AllowTurning = true;
 
+		[Desc("Scan for new targets when idle.")]
+		public readonly bool ScanOnIdle = true;
+
 		[Desc("Set to a value >1 to override weapons maximum range for this.")]
 		public readonly int ScanRadius = -1;
 
@@ -269,7 +272,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyIdle.TickIdle(Actor self)
 		{
-			if (IsTraitDisabled || Stance < UnitStance.Defend)
+			if (IsTraitDisabled || !Info.ScanOnIdle || Stance < UnitStance.Defend)
 				return;
 
 			var allowMove = allowMovement && Stance > UnitStance.Defend;

--- a/OpenRA.Mods.Common/Traits/AutoTarget.cs
+++ b/OpenRA.Mods.Common/Traits/AutoTarget.cs
@@ -236,9 +236,8 @@ namespace OpenRA.Mods.Common.Traits
 			if (attacker.Disposed)
 				return;
 
-			var allowMove = allowMovement && Stance > UnitStance.Defend;
 			foreach (var dat in disableAutoTarget)
-				if (dat.DisableAutoTarget(self, allowMove))
+				if (dat.DisableAutoTarget(self))
 					return;
 
 			if (!attacker.IsInWorld)
@@ -250,6 +249,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			// Don't fire at an invisible enemy when we can't move to reveal it
+			var allowMove = allowMovement && Stance > UnitStance.Defend;
 			if (!allowMove && !attacker.CanBeViewedByPlayer(self.Owner))
 				return;
 
@@ -291,7 +291,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (nextScanTime <= 0 && ActiveAttackBases.Any())
 			{
 				foreach (var dat in disableAutoTarget)
-					if (dat.DisableAutoTarget(self, allowMove))
+					if (dat.DisableAutoTarget(self))
 						return Target.Invalid;
 
 				nextScanTime = self.World.SharedRandom.Next(Info.MinimumScanTimeInterval, Info.MaximumScanTimeInterval);

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -310,7 +310,7 @@ namespace OpenRA.Mods.Common.Traits
 	[RequireExplicitImplementation]
 	public interface IDisableAutoTarget
 	{
-		bool DisableAutoTarget(Actor self, bool allowMove);
+		bool DisableAutoTarget(Actor self);
 	}
 
 	[RequireExplicitImplementation]

--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -120,6 +120,7 @@ MIG:
 		RepulsionSpeed: 40
 		MaximumPitch: 56
 	AutoTarget:
+		ScanOnIdle: false
 		InitialStance: HoldFire
 		InitialStanceAI: HoldFire
 	AmmoPool:
@@ -190,6 +191,7 @@ YAK:
 		RepulsionSpeed: 40
 		MaximumPitch: 56
 	AutoTarget:
+		ScanOnIdle: false
 		InitialStance: HoldFire
 		InitialStanceAI: HoldFire
 	AmmoPool:


### PR DESCRIPTION
This PR fixes #17751 by reverting #17619.

The original issue was introduced by #16797 making aircraft call TickIdle, so a much simpler "fix" for #17476 (i.e. restore the previous behaviour) is to simply disable the idle scanning from RA yak and Mig.