### PR TITLE
Added Support for Multi Aircraft per Building

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -111,10 +111,11 @@ namespace OpenRA.Mods.Common.Activities
 
 			if (ShouldLandAtBuilding(self, dest))
 			{
-				var exit = dest.FirstExitOrDefault();
-				var offset = exit != null ? exit.Info.SpawnOffset : WVec.Zero;
-				if (aircraft.Info.TurnToDock || !aircraft.Info.VTOL)
-					facing = aircraft.Info.InitialFacing;
+				var exits = dest.Exits(null);
+				int cell = Reservable.GetFreeReservation(dest, self);
+				WVec offset = cell == -1 ? WVec.Zero : exits.ElementAt(cell).Info.SpawnOffset;
+				if (cell < 0)
+					return true;
 
 				aircraft.MakeReservation(dest);
 				QueueChild(new Land(self, Target.FromActor(dest), offset, facing, Color.Green));


### PR DESCRIPTION
I am bug bounty hunting, this modification was required to make multiple harriers per AirForce Headquarters (Red Alert 2 mod) possible.

default behavior is exact as previous when the default `MaxReservations` is chosen.