### PR TITLE
Update macOS launcher to fix "View Logs" button.

### DIFF
--- a/packaging/macos/buildpackage.sh
+++ b/packaging/macos/buildpackage.sh
@@ -13,7 +13,7 @@
 #   MACOS_DEVELOPER_PASSWORD: App-specific password for the developer account
 #
 
-LAUNCHER_TAG="osx-launcher-20200209"
+LAUNCHER_TAG="osx-launcher-20200306"
 
 if [ $# -ne "2" ]; then
 	echo "Usage: $(basename "$0") tag outputdir"

--- a/thirdparty/fetch-thirdparty-deps-osx.sh
+++ b/thirdparty/fetch-thirdparty-deps-osx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LAUNCHER_TAG="osx-launcher-20200209"
+LAUNCHER_TAG="osx-launcher-20200306"
 
 download_dir="${0%/*}/download/osx"
 mkdir -p "$download_dir"


### PR DESCRIPTION
This PR pulls in https://github.com/OpenRA/OpenRALauncherOSX/commit/d0316df15c8727aa87ac652c180c61ff7499850c to fix #17765.