### PR TITLE
Transformation can pass exp/level to new actor

### DIFF
--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new GainsExperience(init, this); }
 	}
 
-	public class GainsExperience : INotifyCreated, ISync, IResolveOrder
+	public class GainsExperience : INotifyCreated, ISync, IResolveOrder, ITransformActorInitModifier
 	{
 		readonly Actor self;
 		readonly GainsExperienceInfo info;
@@ -142,6 +142,11 @@ namespace OpenRA.Mods.Common.Traits
 				else
 					GiveLevels(1);
 			}
+		}
+
+		void ITransformActorInitModifier.ModifyTransformActorInit(Actor self, TypeDictionary init)
+		{
+			init.Add(new ExperienceInit(experience));
 		}
 	}
 


### PR DESCRIPTION
Note:

To those who want to use this commit,

The experience in GainsExperience class is in fact an accumulating var, level up will not reduce it in GainsExperience, and its GiveExperience(...) function will do all the work to calculate how many levels it should have.

However, if you have requirement like pass levels from a 5000 credits unit to a 50 credits unit, you will need to modify the Transform class to calculate the exp-level ratio between new actor and old actor, which is beyond this commit.