### PR TITLE
Make EngineerRepairable conditional

### DIFF
--- a/OpenRA.Mods.Common/Activities/RepairBuilding.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBuilding.cs
@@ -21,6 +21,7 @@ namespace OpenRA.Mods.Common.Activities
 
 		Actor enterActor;
 		IHealth enterHealth;
+		EngineerRepairable enterEngineerRepariable;
 
 		public RepairBuilding(Actor self, Target target, EngineerRepairInfo info)
 			: base(self, target, Color.Yellow)
@@ -32,11 +33,12 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			enterActor = targetActor;
 			enterHealth = targetActor.TraitOrDefault<IHealth>();
+			enterEngineerRepariable = targetActor.TraitOrDefault<EngineerRepairable>();
 
 			// Make sure we can still repair the target before entering
 			// (but not before, because this may stop the actor in the middle of nowhere)
 			var stance = self.Owner.Stances[enterActor.Owner];
-			if (enterHealth == null || enterHealth.DamageState == DamageState.Undamaged || !info.ValidStances.HasStance(stance))
+			if (enterHealth == null || enterHealth.DamageState == DamageState.Undamaged || enterEngineerRepariable == null || enterEngineerRepariable.IsTraitDisabled || !info.ValidStances.HasStance(stance))
 			{
 				Cancel(self, true);
 				return false;
@@ -50,6 +52,9 @@ namespace OpenRA.Mods.Common.Activities
 			// Make sure the target hasn't changed while entering
 			// OnEnterComplete is only called if targetActor is alive
 			if (targetActor != enterActor)
+				return;
+
+			if (enterEngineerRepariable.IsTraitDisabled)
 				return;
 
 			if (enterHealth.DamageState == DamageState.Undamaged)

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -108,11 +108,11 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor)
 			{
-				var engineerRepairable = target.Info.TraitInfoOrDefault<EngineerRepairableInfo>();
-				if (engineerRepairable == null)
+				var engineerRepairable = target.TraitOrDefault<EngineerRepairable>();
+				if (engineerRepairable == null || engineerRepairable.IsTraitDisabled)
 					return false;
 
-				if (!engineerRepairable.Types.IsEmpty && !engineerRepairable.Types.Overlaps(info.Types))
+				if (!engineerRepairable.Info.Types.IsEmpty && !engineerRepairable.Info.Types.Overlaps(info.Types))
 					return false;
 
 				if (!info.ValidStances.HasStance(self.Owner.Stances[target.Owner]))
@@ -126,6 +126,10 @@ namespace OpenRA.Mods.Common.Traits
 
 			public override bool CanTargetFrozenActor(Actor self, FrozenActor target, TargetModifiers modifiers, ref string cursor)
 			{
+				// TODO: FrozenActors don't yet have a way of caching conditions, so we can't filter disabled traits
+				// This therefore assumes that all EngineerRepairable traits are enabled, which is probably wrong.
+				// Actors with FrozenUnderFog should therefore not disable the EngineerRepairable trait if
+				// ValidStances includes Enemy actors.
 				var engineerRepairable = target.Info.TraitInfoOrDefault<EngineerRepairableInfo>();
 				if (engineerRepairable == null)
 					return false;

--- a/OpenRA.Mods.Common/Traits/EngineerRepairable.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepairable.cs
@@ -17,11 +17,17 @@ namespace OpenRA.Mods.Common.Traits
 	public class EngineerRepairType { }
 
 	[Desc("Eligible for instant repair.")]
-	class EngineerRepairableInfo : TraitInfo<EngineerRepairable>
+	class EngineerRepairableInfo : ConditionalTraitInfo
 	{
 		[Desc("Actors with these Types under EngineerRepair trait can repair me.")]
 		public readonly BitSet<EngineerRepairType> Types = default(BitSet<EngineerRepairType>);
+
+		public override object Create(ActorInitializer init) { return new EngineerRepairable(init, this); }
 	}
 
-	class EngineerRepairable { }
+	class EngineerRepairable : ConditionalTrait<EngineerRepairableInfo>
+	{
+		public EngineerRepairable(ActorInitializer init, EngineerRepairableInfo info)
+			: base(info) { }
+	}
 }

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -708,6 +708,11 @@ PBOX:
 	-QuantizeFacingsFromSequence:
 	BodyOrientation:
 		QuantizedFacings: 8
+	EngineerRepairable:
+		RequiresCondition: damaged
+	GrantConditionOnDamageState@DAMAGED:
+		Condition: damaged
+		ValidDamageStates: Light, Medium, Heavy, Critical
 	Cargo:
 		Types: Infantry
 		MaxWeight: 1
@@ -765,6 +770,11 @@ HBOX:
 	-QuantizeFacingsFromSequence:
 	BodyOrientation:
 		QuantizedFacings: 8
+	EngineerRepairable:
+		RequiresCondition: damaged
+	GrantConditionOnDamageState@DAMAGED:
+		Condition: damaged
+		ValidDamageStates: Light, Medium, Heavy, Critical
 	Cargo:
 		Types: Infantry
 		MaxWeight: 1


### PR DESCRIPTION
In RV we wanted to make engineers able to garrison civilan structures (like pretty much every infantry except dogs) if the building is on full health. But since EngineerRepair order has higher priority than EnterCargo/Garrsion it showed "Can't Repair" cursor instead. I had the idea of making EngineerRepairable conditional so i can disable it when building is on full health, so the Engi can enter.

I noticed this was an issue with RA's pillboxes too, so this also fixes #13449.
