### PR TITLE
Language Localization Module

### DIFF
--- a/OpenRA.Game/FieldLoader.cs
+++ b/OpenRA.Game/FieldLoader.cs
@@ -223,7 +223,7 @@ namespace OpenRA
 			else if (fieldType == typeof(string))
 			{
 				if (field != null && MemberHasTranslateAttribute[field] && value != null)
-					return Regex.Replace(value, "@[^@]+@", m => Translate(m.Value.Substring(1, m.Value.Length - 2)), RegexOptions.Compiled);
+					return Regex.Replace(value, "(?s)^(?:(?!:).)+:(?:(?!:).)+$", m => Translate(value), RegexOptions.Compiled);
 				return value;
 			}
 			else if (fieldType == typeof(Color))

--- a/OpenRA.Game/Fonts.cs
+++ b/OpenRA.Game/Fonts.cs
@@ -9,8 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
-
 namespace OpenRA
 {
 	public class FontData
@@ -18,20 +16,5 @@ namespace OpenRA
 		public readonly string Font;
 		public readonly int Size;
 		public readonly int Ascender;
-	}
-
-	public class Fonts : IGlobalModData
-	{
-		[FieldLoader.LoadUsing("LoadFonts")]
-		public readonly Dictionary<string, FontData> FontList;
-
-		static object LoadFonts(MiniYaml y)
-		{
-			var ret = new Dictionary<string, FontData>();
-			foreach (var node in y.Nodes)
-				ret.Add(node.Key, FieldLoader.Load<FontData>(node.Value));
-
-			return ret;
-		}
 	}
 }

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -43,10 +43,10 @@ namespace OpenRA
 		public static bool HideCursor;
 		static WorldRenderer worldRenderer;
 		static string modLaunchWrapper;
+		public static Translator Translator;
 
 		internal static OrderManager OrderManager;
 		static Server.Server server;
-
 		public static MersenneTwister CosmeticRandom = new MersenneTwister(); // not synced
 
 		public static Renderer Renderer;
@@ -426,6 +426,8 @@ namespace OpenRA
 			using (new PerfTimer("LoadMaps"))
 				ModData.MapCache.LoadMaps();
 
+			Translator = new Translator();
+			Translator.LoadTranslations(ModData);
 			ModData.InitializeLoaders(ModData.DefaultFileSystem);
 			Renderer.InitializeFonts(ModData);
 

--- a/OpenRA.Game/ModData.cs
+++ b/OpenRA.Game/ModData.cs
@@ -137,7 +137,7 @@ namespace OpenRA
 			CursorProvider = new CursorProvider(this);
 		}
 
-		public IEnumerable<string> Languages { get; private set; }
+		public IEnumerable<string> Languages { get; set; }
 
 		void LoadTranslations(Map map)
 		{
@@ -187,7 +187,7 @@ namespace OpenRA
 			using (new Support.PerfTimer("Map"))
 				map = new Map(this, MapCache[uid].Package);
 
-			LoadTranslations(map);
+			// LoadTranslations(map);
 
 			// Reinitialize all our assets
 			InitializeLoaders(map);

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -106,7 +106,7 @@ namespace OpenRA
 				if (fontSheetBuilder != null)
 					fontSheetBuilder.Dispose();
 				fontSheetBuilder = new SheetBuilder(SheetType.BGRA, 512);
-				Fonts = modData.Manifest.Get<Fonts>().FontList.ToDictionary(x => x.Key,
+				Fonts = Game.Translator.CurrentFontList.ToDictionary(x => x.Key,
 					x => new SpriteFont(x.Value.Font, modData.DefaultFileSystem.Open(x.Value.Font).ReadAllBytes(),
 										x.Value.Size, x.Value.Ascender, Window.EffectiveWindowScale, fontSheetBuilder)).AsReadOnly();
 			}

--- a/OpenRA.Game/Translator.cs
+++ b/OpenRA.Game/Translator.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA
+{
+	public class Translator
+	{
+		public Dictionary<string, FontData> CurrentFontList { get; private set; }
+
+		public void LoadTranslations(ModData modData)
+		{
+			var selectedTranslations = new Dictionary<string, string>();
+			var defaultTranslations = new Dictionary<string, string>();
+
+			var selectedFonts = new Dictionary<string, FontData>();
+			var defaultFonts = new Dictionary<string, FontData>();
+
+			if (!modData.Manifest.Translations.Any())
+			{
+				modData.Languages = new string[0];
+				return;
+			}
+
+			var yaml = MiniYaml.Load(modData.DefaultFileSystem, modData.Manifest.Translations, null);
+			modData.Languages = yaml.Select(t => t.Key).ToArray();
+
+			MiniYaml temp;
+
+			foreach (var language in yaml)
+			{
+				if (language.Key == Game.Settings.Graphics.Language)
+				{
+					if (language.Value.ToDictionary().TryGetValue("Translations", out temp))
+					{
+						foreach (var cls in temp.Nodes)
+						{
+							foreach (var item in cls.Value.Nodes)
+							{
+								if (selectedTranslations.ContainsKey(cls.Key + ":" + item.Key))
+								{
+									continue;
+								}
+								else
+								{
+									selectedTranslations.Add(cls.Key + ":" + item.Key, item.Value.Value.Replace("\\n", "\n") ?? string.Empty);
+								}
+							}
+						}
+					}
+
+					if (language.Value.ToDictionary().TryGetValue("Fonts", out temp))
+					{
+						foreach (var node in temp.Nodes)
+						{
+							selectedFonts.Add(node.Key, FieldLoader.Load<FontData>(node.Value));
+						}
+					}
+				}
+
+				if (language.Key == Game.Settings.Graphics.DefaultLanguage)
+				{
+					if (language.Value.ToDictionary().TryGetValue("Translations", out temp))
+					{
+						foreach (var cls in temp.Nodes)
+						{
+							foreach (var item in cls.Value.Nodes)
+							{
+								if (defaultTranslations.ContainsKey(cls.Key + ":" + item.Key))
+								{
+									continue;
+								}
+								else
+								{
+									defaultTranslations.Add(cls.Key + ":" + item.Key, item.Value.Value.Replace("\\n", "\n") ?? string.Empty);
+								}
+							}
+						}
+					}
+
+					if (language.Value.ToDictionary().TryGetValue("Fonts", out temp))
+					{
+						foreach (var node in temp.Nodes)
+						{
+							defaultFonts.Add(node.Key, FieldLoader.Load<FontData>(node.Value));
+						}
+					}
+				}
+			}
+
+			var translations = new Dictionary<string, string>();
+			foreach (var tkv in defaultTranslations.Concat(selectedTranslations))
+			{
+				if (translations.ContainsKey(tkv.Key))
+				{
+					continue;
+				}
+
+				if (selectedTranslations.ContainsKey(tkv.Key))
+				{
+					translations.Add(tkv.Key, selectedTranslations[tkv.Key]);
+				}
+				else
+				{
+					translations.Add(tkv.Key, tkv.Value);
+				}
+			}
+
+			FieldLoader.SetTranslations(translations);
+			CurrentFontList = selectedFonts.Count > 0 ? selectedFonts : defaultFonts;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		void IRulesetLoaded<ActorInfo>.RulesetLoaded(Ruleset rules, ActorInfo info)
 		{
-			if (!Game.ModData.Manifest.Get<Fonts>().FontList.ContainsKey(Font))
+			if (!Game.Translator.CurrentFontList.ContainsKey(Font))
 				throw new YamlException("Font '{0}' is not listed in the mod.yaml's Fonts section".F(Font));
 		}
 

--- a/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextDecoration.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
-			if (!Game.ModData.Manifest.Get<Fonts>().FontList.ContainsKey(Font))
+			if (!Game.Translator.CurrentFontList.ContainsKey(Font))
 				throw new YamlException("Font '{0}' is not listed in the mod.yaml's Fonts section".F(Font));
 
 			base.RulesetLoaded(rules, ai);

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -264,7 +264,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 						{
 							teamOptions.Add(new DropDownOption
 							{
-								Title = "Humans vs Bots",
+								Title = FieldLoader.Translate("UI_LOBBY:TEAM_OPTIONS-HUMANS_VS_BOTS"),
 								IsSelected = () => false,
 								OnClick = () => orderManager.IssueOrder(Order.Command("assignteams 1"))
 							});
@@ -388,7 +388,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			disconnectButton.OnClick = () => { Ui.CloseWindow(); onExit(); };
 
 			if (skirmishMode)
-				disconnectButton.Text = "Back";
+				disconnectButton.Text = FieldLoader.Translate("UI_LOBBY:SKIRMISH_MODE-BACK");
 
 			var chatMode = lobby.Get<ButtonWidget>("CHAT_MODE");
 			chatMode.GetText = () => teamChat ? "Team" : "All";

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -40,27 +40,33 @@ Container@SETTINGS_PANEL:
 		Container@TAB_CONTAINER:
 			Children:
 				Button@DISPLAY_TAB:
-					Width: 110
+					Width: 90
 					Height: 35
 					Text: Display
-				Button@AUDIO_TAB:
+				Button@LANGUAGE_TAB:
 					X: WIDTH + 10
-					Width: 110
+					Width: 90
+					Height: 35
+					Text: Language
+					Font: Bold
+				Button@AUDIO_TAB:
+					X: 2 * (WIDTH + 10)
+					Width: 90
 					Height: 35
 					Text: Audio
 				Button@INPUT_TAB:
-					X: 2 * (WIDTH + 10)
-					Width: 110
+					X: 3 * (WIDTH + 10)
+					Width: 90
 					Height: 35
 					Text: Input
 				Button@HOTKEYS_TAB:
-					X: 3 * (WIDTH + 10)
-					Width: 110
+					X: 4 * (WIDTH + 10)
+					Width: 90
 					Height: 35
 					Text: Hotkeys
 				Button@ADVANCED_TAB:
-					X: 4 * (WIDTH + 10)
-					Width: 110
+					X: 5 * (WIDTH + 10)
+					Width: 90
 					Height: 35
 					Text: Advanced
 		Background@bg:
@@ -278,6 +284,49 @@ Container@SETTINGS_PANEL:
 							Ticks: 20
 							MinimumValue: 50
 							MaximumValue: 240
+				Container@LANGUAGE_PANEL:
+					X: 5
+					Y: 50
+					Width: PARENT_RIGHT - 10
+					Height: PARENT_BOTTOM
+					Children:
+						Label@LOCALIZATION_TITLE:
+							Y: 70
+							Width: PARENT_RIGHT
+							Font: Bold
+							Text: SETTING:LOCALIZATION_TITLE
+							Align: Center
+							Visible: true
+						Label@LANGUAGE_LABEL:
+							X: 230 - WIDTH - 5
+							Y: 89
+							Width: 75
+							Height: 25
+							Align: Right
+							Text: SETTING:LANGUAGE-LABEL
+							Visible: true
+						DropDownButton@LANGUAGE_DROPDOWNBUTTON:
+							X: 230
+							Y: 90
+							Width: 200
+							Height: 25
+							Visible: true
+						Label@LANGUAGE_DESC_A:
+							Y: 110
+							Width: PARENT_RIGHT
+							Height: 25
+							Font: Tiny
+							Align: Center
+							Text: SETTING:LANGUAGE-DESC_A
+							Visible: true
+						Label@LANGUAGE_DESC_B:
+							Y: 125
+							Width: PARENT_RIGHT
+							Height: 25
+							Font: Tiny
+							Align: Center
+							Text: SETTING:LANGUAGE-DESC_B
+							Visible: true
 				Container@AUDIO_PANEL:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM

--- a/mods/cnc/languages/chinese.yaml
+++ b/mods/cnc/languages/chinese.yaml
@@ -1,0 +1,35 @@
+chinese:
+
+	Fonts:
+		Tiny:
+			Font: common|SourceHanSansK-Light.ttf
+			Size: 10
+			Ascender: 8
+		TinyBold:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 10
+			Ascender: 8
+		Small:
+			Font: common|SourceHanSansK-Light.ttf
+			Size: 12
+			Ascender: 9
+		Regular:
+			Font: common|SourceHanSansK-Light.ttf
+			Size: 14
+			Ascender: 11
+		Bold:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 14
+			Ascender: 11
+		MediumBold:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 18
+			Ascender: 14
+		BigBold:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 24
+			Ascender: 18
+		Title:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 32
+			Ascender: 24

--- a/mods/cnc/languages/english.yaml
+++ b/mods/cnc/languages/english.yaml
@@ -1,3 +1,36 @@
 english:
-	english: English
 
+	Fonts:
+		Tiny:
+			Font: common|FreeSans.ttf
+			Size: 10
+			Ascender: 8
+		TinyBold:
+			Font: common|FreeSansBold.ttf
+			Size: 10
+			Ascender: 8
+		Small:
+			Font: common|FreeSans.ttf
+			Size: 12
+			Ascender: 9
+		Regular:
+			Font: common|FreeSans.ttf
+			Size: 14
+			Ascender: 11
+		Bold:
+			Font: common|FreeSansBold.ttf
+			Size: 14
+			Ascender: 11
+		MediumBold:
+			Font: common|FreeSansBold.ttf
+			Size: 18
+			Ascender: 14
+		BigBold:
+			Font: common|FreeSansBold.ttf
+			Size: 24
+			Ascender: 18
+		Title:
+			Font: common|FreeSansBold.ttf
+			Size: 32
+			Ascender: 24
+	

--- a/mods/cnc/mod.yaml
+++ b/mods/cnc/mod.yaml
@@ -141,7 +141,10 @@ Music:
 	cnc|audio/music.yaml
 
 Translations:
+	common|languages/english.yaml
+	common|languages/chinese.yaml
 	cnc|languages/english.yaml
+	cnc|languages/chinese.yaml
 
 Hotkeys:
 	common|hotkeys/game.yaml
@@ -167,40 +170,6 @@ ServerTraits:
 ChromeMetrics:
 	common|metrics.yaml
 	cnc|metrics.yaml
-
-Fonts:
-	Tiny:
-		Font: common|FreeSans.ttf
-		Size: 10
-		Ascender: 8
-	TinyBold:
-		Font: common|FreeSansBold.ttf
-		Size: 10
-		Ascender: 8
-	Small:
-		Font: common|FreeSans.ttf
-		Size: 12
-		Ascender: 9
-	Regular:
-		Font: common|FreeSans.ttf
-		Size: 14
-		Ascender: 11
-	Bold:
-		Font: common|FreeSansBold.ttf
-		Size: 14
-		Ascender: 11
-	MediumBold:
-		Font: common|FreeSansBold.ttf
-		Size: 18
-		Ascender: 14
-	BigBold:
-		Font: common|FreeSansBold.ttf
-		Size: 24
-		Ascender: 18
-	Title:
-		Font: common|FreeSansBold.ttf
-		Size: 32
-		Ascender: 24
 
 Missions:
 	./mods/cnc/missions.yaml

--- a/mods/common/chrome/mainmenu.yaml
+++ b/mods/common/chrome/mainmenu.yaml
@@ -43,7 +43,7 @@ Container@MAINMENU:
 							Y: 22
 							Width: 200
 							Height: 30
-							Text: OpenRA
+							Text: UI_MENU:MAIN_MENU_TITLE
 							Align: Center
 							Font: Bold
 						Button@SINGLEPLAYER_BUTTON:
@@ -51,42 +51,42 @@ Container@MAINMENU:
 							Y: 60
 							Width: 140
 							Height: 30
-							Text: Singleplayer
+							Text: UI_MENU:SINGLEPLAYER_BUTTON
 							Font: Bold
 						Button@MULTIPLAYER_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 100
 							Width: 140
 							Height: 30
-							Text: Multiplayer
+							Text: UI_MENU:MULTIPLAYER_BUTTON
 							Font: Bold
 						Button@SETTINGS_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 140
 							Width: 140
 							Height: 30
-							Text: Settings
+							Text: UI_MENU:SETTINGS_BUTTON
 							Font: Bold
 						Button@EXTRAS_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 180
 							Width: 140
 							Height: 30
-							Text: Extras
+							Text: UI_MENU:EXTRAS_BUTTON
 							Font: Bold
 						Button@CONTENT_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 220
 							Width: 140
 							Height: 30
-							Text: Manage Content
+							Text: UI_MENU:CONTENT_BUTTON
 							Font: Bold
 						Button@QUIT_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 260
 							Width: 140
 							Height: 30
-							Text: Quit
+							Text: UI_MENU:QUIT_BUTTON
 							Font: Bold
 				Background@SINGLEPLAYER_MENU:
 					Width: PARENT_RIGHT
@@ -97,7 +97,7 @@ Container@MAINMENU:
 							Y: 20
 							Width: 200
 							Height: 30
-							Text: Singleplayer
+							Text: UI_MENU:SINGLEPLAYER_MENU_TITLE
 							Align: Center
 							Font: Bold
 						Button@SKIRMISH_BUTTON:
@@ -105,21 +105,21 @@ Container@MAINMENU:
 							Y: 60
 							Width: 140
 							Height: 30
-							Text: Skirmish
+							Text: UI_MENU:SKIRMISH_BUTTON
 							Font: Bold
 						Button@MISSIONS_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 100
 							Width: 140
 							Height: 30
-							Text: Missions
+							Text: UI_MENU:MISSIONS_BUTTON
 							Font: Bold
 						Button@LOAD_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 140
 							Width: 140
 							Height: 30
-							Text: Load
+							Text: UI_MENU:LOAD_BUTTON
 							Font: Bold
 						Button@BACK_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
@@ -127,7 +127,7 @@ Container@MAINMENU:
 							Y: 260
 							Width: 140
 							Height: 30
-							Text: Back
+							Text: UI_MENU:BACK_BUTTON
 							Font: Bold
 				Background@EXTRAS_MENU:
 					Width: PARENT_RIGHT
@@ -138,7 +138,7 @@ Container@MAINMENU:
 							Y: 20
 							Width: 200
 							Height: 30
-							Text: Extras
+							Text: UI_MENU:EXTRAS_MENU_TITLE
 							Align: Center
 							Font: Bold
 						Button@REPLAYS_BUTTON:
@@ -146,35 +146,35 @@ Container@MAINMENU:
 							Y: 60
 							Width: 140
 							Height: 30
-							Text: Replays
+							Text: UI_MENU:REPLAYS_BUTTON
 							Font: Bold
 						Button@MUSIC_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 100
 							Width: 140
 							Height: 30
-							Text: Music
+							Text: UI_MENU:MUSIC_BUTTON
 							Font: Bold
 						Button@MAP_EDITOR_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 140
 							Width: 140
 							Height: 30
-							Text: Map Editor
+							Text: UI_MENU:MAP_EDITOR_BUTTON
 							Font: Bold
 						Button@ASSETBROWSER_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 180
 							Width: 140
 							Height: 30
-							Text: Asset Browser
+							Text: UI_MENU:ASSET_BROWSER_BUTTON
 							Font: Bold
 						Button@CREDITS_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 220
 							Width: 140
 							Height: 30
-							Text: Credits
+							Text: UI_MENU:CREDITS_BUTTON
 							Font: Bold
 						Button@BACK_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
@@ -182,7 +182,7 @@ Container@MAINMENU:
 							Y: 260
 							Width: 140
 							Height: 30
-							Text: Back
+							Text: UI_MENU:BACK_BUTTON
 							Font: Bold
 				Background@MAP_EDITOR_MENU:
 					Width: PARENT_RIGHT
@@ -193,7 +193,7 @@ Container@MAINMENU:
 							Y: 20
 							Width: 200
 							Height: 30
-							Text: Map Editor
+							Text: UI_MENU:MAP_EDITOR_MENU_TITLE
 							Align: Center
 							Font: Bold
 						Button@NEW_MAP_BUTTON:
@@ -201,14 +201,14 @@ Container@MAINMENU:
 							Y: 60
 							Width: 140
 							Height: 30
-							Text: New Map
+							Text: UI_MENU:NEW_MAP_BUTTON
 							Font: Bold
 						Button@LOAD_MAP_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
 							Y: 100
 							Width: 140
 							Height: 30
-							Text: Load Map
+							Text: UI_MENU:LOAD_MAP_BUTTON
 							Font: Bold
 						Button@BACK_BUTTON:
 							X: PARENT_RIGHT / 2 - WIDTH / 2
@@ -216,7 +216,7 @@ Container@MAINMENU:
 							Y: 260
 							Width: 140
 							Height: 30
-							Text: Back
+							Text: UI_MENU:BACK_BUTTON
 							Font: Bold
 		Container@PERFORMANCE_INFO:
 			Logic: PerfDebugLogic
@@ -252,7 +252,7 @@ Container@MAINMENU:
 					Y: 15
 					Width: 400
 					Height: 25
-					Text: Battlefield News
+					Text: UI_MENU:NEWS_BUTTON
 					Font: Bold
 		Container@UPDATE_NOTICE:
 			X: (WINDOW_RIGHT - WIDTH) / 2
@@ -264,14 +264,14 @@ Container@MAINMENU:
 					Height: 25
 					Align: Center
 					Shadow: true
-					Text: You are running an outdated version of OpenRA.
+					Text: UI_MENU:UPDATE_LABEL_A
 				Label@B:
 					Y: 20
 					Width: PARENT_RIGHT
 					Height: 25
 					Align: Center
 					Shadow: true
-					Text: Download the latest version from www.openra.net
+					Text: UI_MENU:UPDATE_LABEL_B
 		Container@PLAYER_PROFILE_CONTAINER:
 			X: 25
 			Y: 25

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -34,7 +34,7 @@ Background@SETTINGS_PANEL:
 			Y: 20
 			Width: PARENT_RIGHT
 			Height: 25
-			Text: Settings
+			Text: SETTING:TITLE
 			Align: Center
 			Font: Bold
 		Button@RESET_BUTTON:
@@ -42,7 +42,7 @@ Background@SETTINGS_PANEL:
 			Y: PARENT_BOTTOM - 45
 			Width: 160
 			Height: 25
-			Text: Reset
+			Text: SETTING:RESET_BUTTON
 			Font: Bold
 		Button@BACK_BUTTON:
 			Key: escape
@@ -50,7 +50,7 @@ Background@SETTINGS_PANEL:
 			Y: PARENT_BOTTOM - 45 
 			Width: 160
 			Height: 25
-			Text: Back
+			Text: SETTING:BACK_BUTTON
 			Font: Bold
 		Container@TAB_CONTAINER:
 			Y: 50
@@ -58,34 +58,40 @@ Background@SETTINGS_PANEL:
 			Height: 25
 			Children:
 				Button@DISPLAY_TAB:
-					X: 70
+					X: (PARENT_RIGHT - 540) / 2
 					Width: 90
 					Height: 25
-					Text: Display
+					Text: SETTING:DISPLAY_TAB_TEXT
+					Font: Bold
+				Button@LANGUAGE_TAB:
+					X: (PARENT_RIGHT - 540) / 2 + 90
+					Width: 90
+					Height: 25
+					Text: SETTING:LANGUAGE_TAB_TEXT
 					Font: Bold
 				Button@AUDIO_TAB:
-					X: 70 + WIDTH
+					X: (PARENT_RIGHT - 540) / 2 + 180
 					Width: 90
 					Height: 25
-					Text: Audio
+					Text: SETTING:AUDIO_TAB_TEXT
 					Font: Bold
 				Button@INPUT_TAB:
-					X: 70 + 2 * WIDTH
+					X: (PARENT_RIGHT - 540) / 2 + 270
 					Width: 90
 					Height: 25
-					Text: Input
+					Text: SETTING:INPUT_TAB_TEXT
 					Font: Bold
 				Button@HOTKEYS_TAB:
-					X: 70 + 3 * WIDTH
+					X: (PARENT_RIGHT - 540) / 2 + 360
 					Width: 90
 					Height: 25
-					Text: Hotkeys
+					Text: SETTING:HOTKEYS_TAB_TEXT
 					Font: Bold
 				Button@ADVANCED_TAB:
-					X: 70 + 4 * WIDTH
+					X: (PARENT_RIGHT - 540) / 2 + 450
 					Width: 90
 					Height: 25
-					Text: Advanced
+					Text: SETTING:ADVANCED_TAB_TEXT
 					Font: Bold
 		Container@DISPLAY_PANEL:
 			X: 5
@@ -146,7 +152,7 @@ Background@SETTINGS_PANEL:
 					Y: 70
 					Width: 145
 					Height: 25
-					Text: Target Lines:
+					Text: SETTING:TARGET_LINES-LABEL
 					Align: Right
 				DropDownButton@TARGET_LINES_DROPDOWN:
 					X: 415
@@ -172,7 +178,7 @@ Background@SETTINGS_PANEL:
 					Y: 100
 					Width: 145
 					Height: 25
-					Text: Status Bars:
+					Text: SETTING:STATUS_BAR-LABEL
 					Align: Right
 				DropDownButton@STATUS_BAR_DROPDOWN:
 					X: 415
@@ -193,7 +199,7 @@ Background@SETTINGS_PANEL:
 					Width: 200
 					Height: 20
 					Font: Regular
-					Text: Player Stance Colors
+					Text: SETTING:PLAYER_STANCE_COLORS
 				Label@VIDEO_TITLE:
 					Y: 190
 					Width: PARENT_RIGHT
@@ -206,7 +212,7 @@ Background@SETTINGS_PANEL:
 					Width: 120
 					Height: 25
 					Align: Right
-					Text: Video Mode:
+					Text: SETTING:VIDEO_MODE-LABEL
 				DropDownButton@MODE_DROPDOWN:
 					X: 140
 					Y: 210
@@ -284,7 +290,7 @@ Background@SETTINGS_PANEL:
 					Width: 200
 					Height: 20
 					Font: Regular
-					Text: Enable Frame Limiter
+					Text: SETTING:FRAME_LIMIT
 				Slider@FRAME_LIMIT_SLIDER:
 					X: 340
 					Y: 265
@@ -293,6 +299,49 @@ Background@SETTINGS_PANEL:
 					Ticks: 20
 					MinimumValue: 50
 					MaximumValue: 240
+		Container@LANGUAGE_PANEL:
+			X: 5
+			Y: 50
+			Width: PARENT_RIGHT - 10
+			Height: PARENT_BOTTOM
+			Children:
+				Label@LOCALIZATION_TITLE:
+					Y: 70
+					Width: PARENT_RIGHT
+					Font: Bold
+					Text: SETTING:LOCALIZATION_TITLE
+					Align: Center
+					Visible: true
+				Label@LANGUAGE_LABEL:
+					X: 230 - WIDTH - 5
+					Y: 89
+					Width: 75
+					Height: 25
+					Align: Right
+					Text: SETTING:LANGUAGE-LABEL
+					Visible: true
+				DropDownButton@LANGUAGE_DROPDOWNBUTTON:
+					X: 230
+					Y: 90
+					Width: 200
+					Height: 25
+					Visible: true
+				Label@LANGUAGE_DESC_A:
+					Y: 110
+					Width: PARENT_RIGHT
+					Height: 25
+					Font: Tiny
+					Align: Center
+					Text: SETTING:LANGUAGE-DESC_A
+					Visible: true
+				Label@LANGUAGE_DESC_B:
+					Y: 125
+					Width: PARENT_RIGHT
+					Height: 25
+					Font: Tiny
+					Align: Center
+					Text: SETTING:LANGUAGE-DESC_B
+					Visible: true
 		Container@AUDIO_PANEL:
 			X: 5
 			Y: 50
@@ -303,7 +352,7 @@ Background@SETTINGS_PANEL:
 					Y: 50
 					Width: PARENT_RIGHT
 					Align: Center
-					Text: Audio controls require an active sound device
+					Text: SETTING:NO_AUDIO_DEVICE-LABEL
 				Container@AUDIO_CONTROLS:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM
@@ -314,14 +363,14 @@ Background@SETTINGS_PANEL:
 							Width: 200
 							Height: 20
 							Font: Regular
-							Text: Cash Ticks
+							Text: SETTING:CASH_TICKS
 						Checkbox@MUTE_SOUND:
 							X: 15
 							Y: 73
 							Width: 200
 							Height: 20
 							Font: Regular
-							Text: Mute Sound
+							Text: SETTING:MUTE_SOUND
 						Checkbox@MUTE_BACKGROUND_MUSIC:
 							X: 15
 							Y: 103
@@ -335,7 +384,7 @@ Background@SETTINGS_PANEL:
 							Width: 95
 							Height: 25
 							Align: Right
-							Text: Sound Volume:
+							Text: SETTING:SOUND_LABEL
 						ExponentialSlider@SOUND_VOLUME:
 							X: PARENT_RIGHT - WIDTH - 15
 							Y: 45
@@ -348,7 +397,7 @@ Background@SETTINGS_PANEL:
 							Width: 95
 							Height: 25
 							Align: Right
-							Text: Music Volume:
+							Text: SETTING:MUSIC_LABEL
 						ExponentialSlider@MUSIC_VOLUME:
 							X: PARENT_RIGHT - WIDTH - 15
 							Y: 75
@@ -361,7 +410,7 @@ Background@SETTINGS_PANEL:
 							Width: 95
 							Height: 25
 							Align: Right
-							Text: Video Volume:
+							Text: SETTING:VIDEO_LABEL
 						ExponentialSlider@VIDEO_VOLUME:
 							X: PARENT_RIGHT - WIDTH - 15
 							Y: 105
@@ -374,7 +423,7 @@ Background@SETTINGS_PANEL:
 					Width: 75
 					Height: 25
 					Align: Right
-					Text: Audio Device:
+					Text: SETTING:AUDIO_DEVICE-LABEL
 				DropDownButton@AUDIO_DEVICE:
 					X: 190
 					Y: 240
@@ -386,7 +435,7 @@ Background@SETTINGS_PANEL:
 					Height: 25
 					Font: Tiny
 					Align: Center
-					Text: Device changes will be applied after the game is restarted
+					Text: SETTING:AUDIO_DEVICE-DESC
 		Container@INPUT_PANEL:
 			X: 5
 			Y: 50
@@ -563,7 +612,7 @@ Background@SETTINGS_PANEL:
 					Y: 215
 					Width: 165
 					Height: 20
-					Ticks: 5
+					Ticks: 7
 					MinimumValue: 10
 					MaximumValue: 50
 				Label@ZOOM_SPEED_LABEL:
@@ -593,7 +642,7 @@ Background@SETTINGS_PANEL:
 					Y: 275
 					Width: 165
 					Height: 20
-					Ticks: 5
+					Ticks: 7
 					MinimumValue: 1
 					MaximumValue: 100
 		Container@HOTKEYS_PANEL:
@@ -695,25 +744,25 @@ Background@SETTINGS_PANEL:
 									Height: PARENT_BOTTOM
 									Font: Tiny
 									Align: Left
-									Text: This is the default
+									Text: SETTING:DEFAULT_NOTICE
 								Label@ORIGINAL_NOTICE:
 									Width: PARENT_RIGHT
 									Height: PARENT_BOTTOM
 									Font: Tiny
 									Align: Left
-									Text: The default is "{0}"
+									Text: SETTING:ORIGINAL_NOTICE
 								Label@DUPLICATE_NOTICE:
 									Width: PARENT_RIGHT
 									Height: PARENT_BOTTOM
 									Font: Tiny
 									Align: Left
-									Text: This is already used for "{0}"
+									Text: SETTING:DUPLICATE_NOTICE
 						Button@CLEAR_HOTKEY_BUTTON:
 							X: PARENT_RIGHT - 2 * WIDTH - 30
 							Y: 20
 							Width: 65
 							Height: 25
-							Text: Clear
+							Text: SETTING:CLEAR_HOTKEY_BUTTON
 							Font: Bold
 							TooltipText: Unbind the hotkey
 							TooltipContainer: TOOLTIP_CONTAINER
@@ -723,7 +772,7 @@ Background@SETTINGS_PANEL:
 							Y: 20
 							Width: 65
 							Height: 25
-							Text: Reset
+							Text: SETTING:RESET_HOTKEY_BUTTON
 							Font: Bold
 							TooltipText: Reset to default
 							TooltipContainer: TOOLTIP_CONTAINER
@@ -740,42 +789,42 @@ Background@SETTINGS_PANEL:
 					Width: 200
 					Height: 20
 					Font: Regular
-					Text: Enable Network Discovery (UPnP)
+					Text: SETTING:NAT_DISCOVERY
 				Checkbox@PERFTEXT_CHECKBOX:
 					X: 15
 					Y: 73
 					Width: 300
 					Height: 20
 					Font: Regular
-					Text: Show Performance Text
+					Text: SETTING:PERF_TEXT
 				Checkbox@PERFGRAPH_CHECKBOX:
 					X: 15
 					Y: 103
 					Width: 300
 					Height: 20
 					Font: Regular
-					Text: Show Performance Graph
+					Text: SETTING:PERF_GRAPH
 				Checkbox@FETCH_NEWS_CHECKBOX:
 					X: 310
 					Y: 43
 					Width: 300
 					Height: 20
 					Font: Regular
-					Text: Fetch Community News
+					Text: SETTING:FETCH_NEWS
 				Checkbox@CHECK_VERSION_CHECKBOX:
 					X: 310
 					Y: 73
 					Width: 300
 					Height: 20
 					Font: Regular
-					Text: Check for Updates
+					Text: SETTING:CHECK_VERSION
 				Checkbox@SENDSYSINFO_CHECKBOX:
 					X: 310
 					Y: 103
 					Width: 300
 					Height: 20
 					Font: Regular
-					Text: Send System Information
+					Text: SETTING:SEND_SYS_INFO
 				Label@SENDSYSINFO_DESC:
 					X: 310
 					Y: 118
@@ -783,12 +832,12 @@ Background@SETTINGS_PANEL:
 					Height: 30
 					Font: Tiny
 					WordWrap: True
-					Text: Your Operating System, OpenGL and .NET runtime versions, and language settings will be sent along with an anonymous ID to help prioritize future development.
+					Text: SETTING:SEND_SYS_INFO-DESC
 				Label@DEBUG_TITLE:
 					Y: 190
 					Width: PARENT_RIGHT
 					Font: Bold
-					Text: Developer
+					Text: SETTING:DEBUG_TITLE
 					Align: Center
 				Container@DEBUG_HIDDEN_LABEL:
 					Y: 245
@@ -798,14 +847,14 @@ Background@SETTINGS_PANEL:
 							Width: PARENT_RIGHT
 							Height: 20
 							Font: Regular
-							Text: Additional developer-specific options can be enabled via the
+							Text: SETTING:DEBUG_HIDDEN_DESC_A
 							Align: Center
 						Label@B:
 							Y: 20
 							Width: PARENT_RIGHT
 							Height: 20
 							Font: Regular
-							Text: Debug.DisplayDeveloperSettings setting or launch flag
+							Text: SETTING:DEBUG_HIDDEN_DESC_B
 							Align: Center
 				Container@DEBUG_OPTIONS:
 					Width: PARENT_RIGHT
@@ -817,33 +866,33 @@ Background@SETTINGS_PANEL:
 							Width: 300
 							Height: 20
 							Font: Regular
-							Text: Show Bot Debug Messages
+							Text: SETTING:BOT_DEBUG
 						Checkbox@CHECKUNSYNCED_CHECKBOX:
 							X: 15
 							Y: 243
 							Width: 300
 							Height: 20
 							Font: Regular
-							Text: Check Sync around Unsynced Code
+							Text: SETTING:CHECK_UNSYNCED
 						Checkbox@CHECKBOTSYNC_CHECKBOX:
 							X: 15
 							Y: 273
 							Width: 300
 							Height: 20
 							Font: Regular
-							Text: Check Sync around BotModule Code
+							Text: SETTING:CHECK_BOT_SYNC
 						Checkbox@LUADEBUG_CHECKBOX:
 							X: 310
 							Y: 213
 							Width: 300
 							Height: 20
 							Font: Regular
-							Text: Show Map Debug Messages
+							Text: SETTING:LUA_DEBUG
 						Checkbox@REPLAY_COMMANDS_CHECKBOX:
 							X: 310
 							Y: 243
 							Width: 300
 							Height: 20
 							Font: Regular
-							Text: Enable Debug Commands in Replays
+							Text: SETTING:REPLAY_COMMANDS
 		TooltipContainer@TOOLTIP_CONTAINER:

--- a/mods/common/languages/chinese.yaml
+++ b/mods/common/languages/chinese.yaml
@@ -1,0 +1,120 @@
+chinese:
+	Translations:
+		LANGUAGES:
+			english: 英文
+			chinese: 简体中文
+
+		SETTING:
+			TITLE: 设置
+
+			RESET_BUTTON: 重置
+			BACK_BUTTON: 返回
+
+			RESTART_DIANLOGS-TITLE: 现在重启?
+			RESTART_DIANLOGS-TEXT: 部分设置将在重启后生效, 现在重启?
+			RESTART_DIANLOGS-OK_BUTTON-TEXT: 立即重启
+			RESTART_DIANLOGS-CANCEL_BUTTON-TEXT: 稍后重启
+
+			DISPLAY_TAB_TEXT: 显示
+			LANGUAGE_TAB_TEXT: 语言
+			AUDIO_TAB_TEXT: 音频
+			INPUT_TAB_TEXT: 输入
+			HOTKEYS_TAB_TEXT: 快捷键
+			ADVANCED_TAB_TEXT: 高级
+
+			# Display Panel
+			WINDOW_MODE-WINDOWED: 窗口化
+			WINDOW_MODE-FULLSCREEN_LEGSCY: 全屏化 (旧方法)
+			WINDOW_MODE-FULLSCREEN: 全屏化
+
+			VIDEO_MODE-LABEL: 视频模式:
+			
+			FRAME_LIMIT: 限制帧率
+
+			STATUS_BAR-STANDARD: 标准
+			STATUS_BAR-SHOW_ON_DAMAGE: 受损时显示
+			STATUS_BAR-ALWAYS_SHOW: 一直显示
+			STATUS_BAR-LABEL: 生命条显示：
+
+			PLAYER_STANCE_COLORS: 敌友颜色模式
+
+			TARGET_LINES-AUTO: 自动
+			TARGET_LINES-MANUAL: 手动
+			TARGET_LINES-DISABLE: 禁用
+			TARGET_LINES-LABEL: 显示目标线：
+
+			#Language Panel
+			LOCALIZATION_TITLE: 本地化
+			
+			LANGUAGE-LABEL: 语言：
+			LANGUAGE-DESC_A: 语言更改将在重启后生效。
+			LANGUAGE-DESC_B: 翻译仅适用于文本字符串； 语音和构建图标将保留为英文
+
+			#Audio Panel
+			NO_AUDIO_DEVICE-LABEL: 未检测到音频设备
+			AUDIO_DEVICE-LABEL: 音频设备：
+			AUDIO_DEVICE-DESC: 音频设备更改将在重启后生效。
+			CASH_TICKS: 音频变动音效
+			MUTE_SOUND: 静音
+			SOUND_LABEL: 音效音量：
+			MUSIC_LABEL: 音乐音量：
+			VIDEO_LABEL: 视频音量：
+
+			#Input Panel
+			MOUSE_SCROLL-DISABLE: 禁用
+			MOUSE_SCROLL-INVERTED: 反向
+			MOUSE_SCROLL-JOYSTICK: 摇杆
+			MOUSE_SCROLL-STANDARD: 标准
+
+			ZOOM_MODIFIER-NONE: 无
+
+			#Hotkeys Panel
+			DEFAULT_NOTICE: 当前为默认设置
+			ORIGINAL_NOTICE: 默认设置为"{0}"
+			DUPLICATE_NOTICE: 该键已被"{0}"使用
+
+			CLEAR_HOTKEY_BUTTON: 清除
+			RESET_HOTKEY_BUTTON: 重置
+
+		UI_MENU:
+			#Main Menu
+			MAIN_MENU_TITLE: OpenRA
+			SINGLEPLAYER_BUTTON: 单人游戏
+			MULTIPLAYER_BUTTON: 多人游戏
+			SETTINGS_BUTTON: 设置
+			EXTRAS_BUTTON: 附加功能
+			CONTENT_BUTTON: 资源管理
+			QUIT_BUTTON: 退出
+
+			#Single Player Menu
+			SINGLEPLAYER_MENU_TITLE: 单人游戏
+			SKIRMISH_BUTTON: 遭遇战
+			MISSIONS_BUTTON: 任务
+			LOAD_BUTTON: 加载游戏
+			BACK_BUTTON: 退出
+
+			#Extras Menu
+			EXTRAS_MENU_TITLE: 附加功能
+			REPLAYS_BUTTON: 录像回放
+			MUSIC_BUTTON: 音乐
+			MAP_EDITOR_BUTTON: 地图编辑器
+			ASSET_BROWSER_BUTTON: 资源管理器
+			CREDITS_BUTTON: 鸣谢
+
+			#Map Editor Menu
+			MAP_EDITOR_MENU_TITLE:　地图编辑器
+			NEW_MAP_BUTTON: 新地图
+			LOAD_MAP_BUTTON: 加载地图
+
+			#News
+			NEWS_BUTTON: 战地新闻
+
+			#Update
+			UPDATE_LABEL_A: 您正在运行旧版本的OpenRA
+			UPDATE_LABEL_B: 请从www.openra.net下载最新版
+
+
+		UI_LOBBY:
+			SKIRMISH_MODE-BACK: 返回
+			TEAM_OPTIONS-HUMANS_VS_BOTS: 人类 Vs. 电脑玩家
+

--- a/mods/common/languages/english.yaml
+++ b/mods/common/languages/english.yaml
@@ -1,0 +1,139 @@
+english:
+	Translations:
+		LANGUAGES:
+			english: English
+			chinese: Chinese	
+
+		SETTING:
+			TITLE: Settings
+
+			RESET_BUTTON: Reset
+			BACK_BUTTON: Back
+
+			RESTART_DIANLOGS-TITLE: Restart Now?
+			RESTART_DIANLOGS-TEXT: Some changes will not be applied until\nthe game is restarted. Restart now?
+			RESTART_DIANLOGS-OK_BUTTON-TEXT: Restart Now
+			RESTART_DIANLOGS-CANCEL_BUTTON-TEXT: Restart Later
+
+			DISPLAY_TAB_TEXT: Display
+			LANGUAGE_TAB_TEXT: Language
+			AUDIO_TAB_TEXT: Audio
+			INPUT_TAB_TEXT: Input
+			HOTKEYS_TAB_TEXT: Hotkeys
+			ADVANCED_TAB_TEXT: Advanced
+
+			# Display Panel
+			WINDOW_MODE-WINDOWED: Windowed
+			WINDOW_MODE-FULLSCREEN_LEGSCY: Fullscreen (Legacy)
+			WINDOW_MODE-FULLSCREEN: Fullscreen
+
+			VIDEO_MODE-LABEL: Video Mode:
+
+			FRAME_LIMIT: Enable Frame Limiter
+			
+			STATUS_BAR-STANDARD: Standard
+			STATUS_BAR-SHOW_ON_DAMAGE: Show On Damage
+			STATUS_BAR-ALWAYS_SHOW: Always Show
+			STATUS_BAR-LABEL: Status Bars:
+
+			PLAYER_STANCE_COLORS: Player Stance Colors
+
+			TARGET_LINES-AUTO: Automatic
+			TARGET_LINES-MANUAL: Manual
+			TARGET_LINES-DISABLE: Disabled
+			TARGET_LINES-LABEL: Target Lines:
+
+			#Language Panel
+			LOCALIZATION_TITLE: Localization
+
+			LANGUAGE-LABEL: Language:
+			LANGUAGE-DESC_A: Language changes will be applied after the game is restarted
+			LANGUAGE-DESC_B: Translations apply to text strings only; Speech and build icons will remain in English
+
+			#Audio Panel
+			NO_AUDIO_DEVICE-LABEL: Audio controls require an active sound device
+			AUDIO_DEVICE-LABEL: Audio Device:
+			AUDIO_DEVICE-DESC: Device changes will be applied after the game is restarted
+			CASH_TICKS: Cash Ticks
+			MUTE_SOUND: Mute Sound
+			SOUND_LABEL: Sound Volume:
+			MUSIC_LABEL: Music Volume:
+			VIDEO_LABEL: Video Volume:
+
+			#Input Panel
+			MOUSE_SCROLL-DISABLE: Disabled
+			MOUSE_SCROLL-INVERTED: Inverted
+			MOUSE_SCROLL-JOYSTICK: Joystick
+			MOUSE_SCROLL-STANDARD: Standard
+
+			ZOOM_MODIFIER-NONE: None
+
+			#Hotkeys Panel
+			DEFAULT_NOTICE: This is the default
+			ORIGINAL_NOTICE: The default is "{0}"
+			DUPLICATE_NOTICE: This is already used for "{0}"
+
+			CLEAR_HOTKEY_BUTTON: Clear
+			RESET_HOTKEY_BUTTON: Reset
+
+			#Advanced Panel
+			NAT_DISCOVERY: Enable Network Discovery (UPnP)
+			PERF_TEXT: Show Performance Text
+			PERF_GRAPH: Show Performance Graph
+			FETCH_NEWS: Fetch Community News
+			CHECK_VERSION: Check for Updates
+			SEND_SYS_INFO: Send System Information
+			SEND_SYS_INFO-DESC: Your Operating System, OpenGL and .NET runtime versions, and language settings will be sent along with an anonymous ID to help prioritize future development.
+
+			DEBUG_TITLE: Developer
+			DEBUG_HIDDEN_DESC_A: Additional developer-specific options can be enabled via the
+			DEBUG_HIDDEN_DESC_B: Debug.DisplayDeveloperSettings setting or launch flag
+
+			BOT_DEBUG: Show Bot Debug Messages
+			CHECK_UNSYNCED: Check Sync around Unsynced Code
+			CHECK_BOT_SYNC: Check Sync around BotModule Code
+			LUA_DEBUG: Show Map Debug Messages
+			REPLAY_COMMANDS: Enable Debug Commands in Replays
+
+		UI_MENU:
+			#Main Menu
+			MAIN_MENU_TITLE: OpenRA
+			SINGLEPLAYER_BUTTON: Singleplayer
+			MULTIPLAYER_BUTTON: Multiplayer
+			SETTINGS_BUTTON: Settings
+			EXTRAS_BUTTON: Extras
+			CONTENT_BUTTON: Manage Content
+			QUIT_BUTTON: Quit
+
+			#Single Player Menu
+			SINGLEPLAYER_MENU_TITLE: Singleplayer
+			SKIRMISH_BUTTON: Skirmish
+			MISSIONS_BUTTON: Missions
+			LOAD_BUTTON: Load
+			BACK_BUTTON: Back
+
+			#Extras Menu
+			EXTRAS_MENU_TITLE: Extras
+			REPLAYS_BUTTON: Replays
+			MUSIC_BUTTON: Music
+			MAP_EDITOR_BUTTON: Map Editor
+			ASSET_BROWSER_BUTTON: Asset Browser
+			CREDITS_BUTTON: Credits
+
+			#Map Editor Menu
+			MAP_EDITOR_MENU_TITLE: Map Editor
+			NEW_MAP_BUTTON: New Map
+			LOAD_MAP_BUTTON: Load Map
+
+			#News
+			NEWS_BUTTON: Battlefield News
+
+			#Update
+			UPDATE_LABEL_A: You are running an outdated version of OpenRA.
+			UPDATE_LABEL_B: Download the latest version from www.openra.net
+
+
+		UI_LOBBY:
+			SKIRMISH_MODE-BACK: back
+			TEAM_OPTIONS-HUMANS_VS_BOTS: Humans vs Bots
+

--- a/mods/d2k/languages/chinese.yaml
+++ b/mods/d2k/languages/chinese.yaml
@@ -1,0 +1,36 @@
+chinese:
+
+	Fonts:
+		Tiny:
+			Font: common|SourceHanSansK-Light.ttf
+			Size: 10
+			Ascender: 8
+		TinyBold:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 10
+			Ascender: 8
+		Small:
+			Font: common|SourceHanSansK-Light.ttf
+			Size: 12
+			Ascender: 9
+		Regular:
+			Font: common|SourceHanSansK-Light.ttf
+			Size: 14
+			Ascender: 11
+		Bold:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 14
+			Ascender: 11
+		MediumBold:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 18
+			Ascender: 14
+		BigBold:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 24
+			Ascender: 18
+		Title:
+			Font: d2k|Dune2k.ttf
+			Size: 32
+			Ascender: 23
+	

--- a/mods/d2k/languages/english.yaml
+++ b/mods/d2k/languages/english.yaml
@@ -1,2 +1,36 @@
 english:
-	english: English
+
+	Fonts:
+		Tiny:
+			Font: common|FreeSans.ttf
+			Size: 10
+			Ascender: 8
+		TinyBold:
+			Font: common|FreeSansBold.ttf
+			Size: 10
+			Ascender: 8
+		Small:
+			Font: common|FreeSans.ttf
+			Size: 12
+			Ascender: 9
+		Regular:
+			Font: common|FreeSans.ttf
+			Size: 14
+			Ascender: 11
+		Bold:
+			Font: common|FreeSansBold.ttf
+			Size: 14
+			Ascender: 11
+		MediumBold:
+			Font: common|FreeSansBold.ttf
+			Size: 18
+			Ascender: 14
+		BigBold:
+			Font: common|FreeSansBold.ttf
+			Size: 24
+			Ascender: 18
+		Title:
+			Font: d2k|Dune2k.ttf
+			Size: 32
+			Ascender: 23
+	

--- a/mods/d2k/mod.yaml
+++ b/mods/d2k/mod.yaml
@@ -128,7 +128,10 @@ Music:
 	d2k|audio/music.yaml
 
 Translations:
+	common|languages/english.yaml
+	common|languages/chinese.yaml
 	d2k|languages/english.yaml
+	d2k|languages/chinese.yaml
 
 Hotkeys:
 	common|hotkeys/game.yaml
@@ -153,40 +156,6 @@ ServerTraits:
 ChromeMetrics:
 	common|metrics.yaml
 	d2k|metrics.yaml
-
-Fonts:
-	Tiny:
-		Font: common|FreeSans.ttf
-		Size: 10
-		Ascender: 8
-	TinyBold:
-		Font: common|FreeSansBold.ttf
-		Size: 10
-		Ascender: 8
-	Small:
-		Font: common|FreeSans.ttf
-		Size: 12
-		Ascender: 9
-	Regular:
-		Font: common|FreeSans.ttf
-		Size: 14
-		Ascender: 11
-	Bold:
-		Font: common|FreeSansBold.ttf
-		Size: 14
-		Ascender: 11
-	MediumBold:
-		Font: common|FreeSansBold.ttf
-		Size: 18
-		Ascender: 14
-	BigBold:
-		Font: common|FreeSansBold.ttf
-		Size: 24
-		Ascender: 18
-	Title:
-		Font: d2k|Dune2k.ttf
-		Size: 32
-		Ascender: 23
 
 Missions:
 	d2k|missions.yaml

--- a/mods/modcontent/languages/chinese.yaml
+++ b/mods/modcontent/languages/chinese.yaml
@@ -1,0 +1,27 @@
+chinese:
+
+	Fonts:
+		Tiny:
+			Font: common|SourceHanSansK-Light.ttf
+			Size: 10
+			Ascender: 8
+		TinyBold:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 10
+			Ascender: 8
+		Regular:
+			Font: common|SourceHanSansK-Light.ttf
+			Size: 14
+			Ascender: 11
+		Bold:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 14
+			Ascender: 11
+		MediumBold:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 18
+			Ascender: 14
+		BigBold:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 24
+			Ascender: 18

--- a/mods/modcontent/languages/english.yaml
+++ b/mods/modcontent/languages/english.yaml
@@ -1,0 +1,27 @@
+english:
+
+	Fonts:
+		Tiny:
+			Font: common|FreeSans.ttf
+			Size: 10
+			Ascender: 8
+		TinyBold:
+			Font: common|FreeSansBold.ttf
+			Size: 10
+			Ascender: 8
+		Regular:
+			Font: common|FreeSans.ttf
+			Size: 14
+			Ascender: 11
+		Bold:
+			Font: common|FreeSansBold.ttf
+			Size: 14
+			Ascender: 11
+		MediumBold:
+			Font: common|FreeSansBold.ttf
+			Size: 18
+			Ascender: 14
+		BigBold:
+			Font: common|FreeSansBold.ttf
+			Size: 24
+			Ascender: 18

--- a/mods/modcontent/mod.yaml
+++ b/mods/modcontent/mod.yaml
@@ -35,31 +35,11 @@ ChromeMetrics:
 	common|metrics.yaml
 	modcontent|metrics.yaml
 
-Fonts:
-	Tiny:
-		Font: common|FreeSans.ttf
-		Size: 10
-		Ascender: 8
-	TinyBold:
-		Font: common|FreeSansBold.ttf
-		Size: 10
-		Ascender: 8
-	Regular:
-		Font: common|FreeSans.ttf
-		Size: 14
-		Ascender: 11
-	Bold:
-		Font: common|FreeSansBold.ttf
-		Size: 14
-		Ascender: 11
-	MediumBold:
-		Font: common|FreeSansBold.ttf
-		Size: 18
-		Ascender: 14
-	BigBold:
-		Font: common|FreeSansBold.ttf
-		Size: 24
-		Ascender: 18
+Translations:
+	common|languages/english.yaml
+	common|languages/chinese.yaml
+	modcontent|languages/english.yaml
+	modcontent|languages/chinese.yaml
 
 SoundFormats:
 

--- a/mods/ra/languages/chinese.yaml
+++ b/mods/ra/languages/chinese.yaml
@@ -1,0 +1,42 @@
+chinese:
+	Translations:
+		NAME:
+			E1: 步枪兵
+
+		DESC:
+			E1: 泛用型步兵\n\n 强势对抗：步兵\n 弱势对抗：载具、飞行器
+
+	Fonts:
+		Tiny:
+			Font: common|SourceHanSansK-Light.ttf
+			Size: 10
+			Ascender: 8
+		TinyBold:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 10
+			Ascender: 8
+		Small:
+			Font: common|SourceHanSansK-Light.ttf
+			Size: 12
+			Ascender: 9
+		Regular:
+			Font: common|SourceHanSansK-Light.ttf
+			Size: 14
+			Ascender: 11
+		Bold:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 14
+			Ascender: 11
+		MediumBold:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 18
+			Ascender: 14
+		BigBold:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 24
+			Ascender: 18
+		Title:
+			Font: ra|ZoodRangmah.ttf
+			Size: 48
+			Ascender: 26
+	

--- a/mods/ra/languages/english.yaml
+++ b/mods/ra/languages/english.yaml
@@ -1,2 +1,42 @@
 english:
-	english: English
+	Translations:
+		NAME:
+			E1: Rifle Infantry
+
+		DESC:
+			E1: General-purpose infantry.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft
+
+	Fonts:
+		Tiny:
+			Font: common|FreeSans.ttf
+			Size: 10
+			Ascender: 8
+		TinyBold:
+			Font: common|FreeSansBold.ttf
+			Size: 10
+			Ascender: 8
+		Small:
+			Font: common|FreeSans.ttf
+			Size: 12
+			Ascender: 9
+		Regular:
+			Font: common|FreeSans.ttf
+			Size: 14
+			Ascender: 11
+		Bold:
+			Font: common|FreeSansBold.ttf
+			Size: 14
+			Ascender: 11
+		MediumBold:
+			Font: common|FreeSansBold.ttf
+			Size: 18
+			Ascender: 14
+		BigBold:
+			Font: common|FreeSansBold.ttf
+			Size: 24
+			Ascender: 18
+		Title:
+			Font: ra|ZoodRangmah.ttf
+			Size: 48
+			Ascender: 26
+	

--- a/mods/ra/mod.yaml
+++ b/mods/ra/mod.yaml
@@ -144,7 +144,10 @@ Music:
 	ra|audio/music.yaml
 
 Translations:
+	common|languages/english.yaml
+	common|languages/chinese.yaml
 	ra|languages/english.yaml
+	ra|languages/chinese.yaml
 
 Hotkeys:
 	common|hotkeys/game.yaml
@@ -169,40 +172,6 @@ ServerTraits:
 ChromeMetrics:
 	common|metrics.yaml
 	ra|metrics.yaml
-
-Fonts:
-	Tiny:
-		Font: common|FreeSans.ttf
-		Size: 10
-		Ascender: 8
-	TinyBold:
-		Font: common|FreeSansBold.ttf
-		Size: 10
-		Ascender: 8
-	Small:
-		Font: common|FreeSans.ttf
-		Size: 12
-		Ascender: 9
-	Regular:
-		Font: common|FreeSans.ttf
-		Size: 14
-		Ascender: 11
-	Bold:
-		Font: common|FreeSansBold.ttf
-		Size: 14
-		Ascender: 11
-	MediumBold:
-		Font: common|FreeSansBold.ttf
-		Size: 18
-		Ascender: 14
-	BigBold:
-		Font: common|FreeSansBold.ttf
-		Size: 24
-		Ascender: 18
-	Title:
-		Font: ra|ZoodRangmah.ttf
-		Size: 48
-		Ascender: 26
 
 Missions:
 	ra|missions.yaml

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -73,13 +73,13 @@ E1:
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 10
 		Prerequisites: ~barracks, ~techlevel.infonly
-		Description: General-purpose infantry.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft
+		Description: DESC:E1
 	Selectable:
 		Class: E1
 	Valued:
 		Cost: 100
 	Tooltip:
-		Name: Rifle Infantry
+		Name: NAME:E1
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:

--- a/mods/ts/languages/chinese.yaml
+++ b/mods/ts/languages/chinese.yaml
@@ -1,0 +1,34 @@
+chinese:
+	Fonts:
+		Tiny:
+			Font: common|SourceHanSansK-Light.ttf
+			Size: 10
+			Ascender: 8
+		TinyBold:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 10
+			Ascender: 8
+		Small:
+			Font: common|SourceHanSansK-Light.ttf
+			Size: 12
+			Ascender: 9
+		Regular:
+			Font: common|SourceHanSansK-Light.ttf
+			Size: 14
+			Ascender: 11
+		Bold:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 14
+			Ascender: 11
+		MediumBold:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 18
+			Ascender: 14
+		BigBold:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 24
+			Ascender: 18
+		Title:
+			Font: common|SourceHanSansK-Medium.ttf
+			Size: 32
+			Ascender: 24

--- a/mods/ts/languages/english.yaml
+++ b/mods/ts/languages/english.yaml
@@ -1,2 +1,34 @@
 english:
-	english: English
+	Fonts:
+		Tiny:
+			Font: common|FreeSans.ttf
+			Size: 10
+			Ascender: 8
+		TinyBold:
+			Font: common|FreeSansBold.ttf
+			Size: 10
+			Ascender: 8
+		Small:
+			Font: common|FreeSans.ttf
+			Size: 12
+			Ascender: 9
+		Regular:
+			Font: common|FreeSans.ttf
+			Size: 14
+			Ascender: 11
+		Bold:
+			Font: common|FreeSansBold.ttf
+			Size: 14
+			Ascender: 11
+		MediumBold:
+			Font: common|FreeSansBold.ttf
+			Size: 18
+			Ascender: 14
+		BigBold:
+			Font: common|FreeSansBold.ttf
+			Size: 24
+			Ascender: 18
+		Title:
+			Font: common|FreeSansBold.ttf
+			Size: 32
+			Ascender: 24

--- a/mods/ts/mod.yaml
+++ b/mods/ts/mod.yaml
@@ -186,7 +186,10 @@ Music:
 	ts|audio/music.yaml
 
 Translations:
+	common|languages/english.yaml
+	common|languages/chinese.yaml
 	ts|languages/english.yaml
+	ts|languages/chinese.yaml
 
 Hotkeys:
 	common|hotkeys/game.yaml
@@ -209,40 +212,6 @@ ServerTraits:
 ChromeMetrics:
 	common|metrics.yaml
 	ts|metrics.yaml
-
-Fonts:
-	Tiny:
-		Font: common|FreeSans.ttf
-		Size: 10
-		Ascender: 8
-	TinyBold:
-		Font: common|FreeSansBold.ttf
-		Size: 10
-		Ascender: 8
-	Small:
-		Font: common|FreeSans.ttf
-		Size: 12
-		Ascender: 9
-	Regular:
-		Font: common|FreeSans.ttf
-		Size: 14
-		Ascender: 11
-	Bold:
-		Font: common|FreeSansBold.ttf
-		Size: 14
-		Ascender: 11
-	MediumBold:
-		Font: common|FreeSansBold.ttf
-		Size: 18
-		Ascender: 14
-	BigBold:
-		Font: common|FreeSansBold.ttf
-		Size: 24
-		Ascender: 18
-	Title:
-		Font: common|FreeSansBold.ttf
-		Size: 32
-		Ascender: 24
 
 SupportsMapsFrom: ts
 


### PR DESCRIPTION
#17793
Authored by [CastleJing](https://gitee.com/CastleJing).

This pull request provide localization method and UI, but currently not support LUA (mission text) localization and production line ICON localization.

I guess there will be three question being asked urgently:
**How can I use this to do localization?**
**(For modder) Is there any change I need to do to my mod if this pr is merged? How?**
**What will happen if localization is unfinished?**

---------------------------------

**Q&A. How can I use this to do localization?**

1. Open "/mod" in root directroy of OpenRA.

2. Find and open "/mod/{some mod}"
> {some mod} = mod you need working on

 2.1. Edit the "mod.yaml". Register all the translation files you will make. 

![-3b8302e606af9f76](https://user-images.githubusercontent.com/13763394/76525470-d6d73c00-64a6-11ea-844a-d2f29b083682.png)
    like the picture above, if you need to do Russian localization for mod RA, you can simply add `ra|language/russian.yaml` in "/mod/ra/mod.yaml", and put all text localization in this single file named "russian.yaml". However, it is more recommended to separate the engine localization with mod content localization, in doing so you can reuse engine localization for other mods like cnc, ts, d2k or even sp or rv. Engine localization is recommended to be put in "/mod/common".

 2.2. According to the lines in you add in "mod.yaml" at section 2.1, you need to build localization files which contains font dictionary and localization in key-value format. Common usage font files are also recommended to be put under "/mod/common/" for reuse later in other mods.

![-2d669f5c249ae9eb](https://user-images.githubusercontent.com/13763394/76529363-228ce400-64ad-11ea-83d5-512c6f43309e.png)
Localization in strict key-value format. You can refer other language localization and modder's YAML files to finish your own localization.

![3cc20171054baf9a](https://user-images.githubusercontent.com/13763394/76529765-b8287380-64ad-11ea-8a02-9ea74878994b.png)
Font dictionary restore fonts to define diffirent styles. Due to D2K has its own font to style, it is not recommended to reuse the font dictionary, which means it is better put those lines in "/mod/{some mod}/" instead of "/mod/common/". You can never know what devs/modders will do for the best performance.

---------------------------------

**Q&A. (For modder) Is there any change I need to do to my mod if this pr is merged? How?**

Unfortunately, yes, but it is fortunately only a small work. 

You need to move the font dictionary in your own mod folder "/mod/{your mod}/" (you can see this data struct at picture above) from "mod.yaml" to "{certain language}.yaml" under "/mod/{your mod}/language/". 

Fonts should be bond with language and change with language rather than entire mod, especially when there are other languages. Therefore, there is the change we have to make.

------------------------------------

**Q&A. What will happen if localization is unfinished?**

It is highly recommended to finish the entire font dictionary first (you can see this data struct at picture above, please scroll to the end of Q&A1). When program find localization text without its style to use in the font dictionary, it will look into default Latin fonts of the same style in search of the same char-code. If the char-code is not in default Latin fonts, the game will crash. ([CastleJing](https://gitee.com/CastleJing) will write an exception for it in the future).

However, it is ok that the localization text is unfinished. Unfinished localization text will be replaced by English, or tag name if even English is lacking.
