### PR TITLE
VXL posture: Aircraft & Vehicle

### DIFF
--- a/OpenRA.Game/Map/MapGrid.cs
+++ b/OpenRA.Game/Map/MapGrid.cs
@@ -79,6 +79,47 @@ namespace OpenRA
 			new[] { 0, 1, 0, 1 }
 		};
 
+		readonly WRot[] slopes = new WRot[]
+		{
+			// Flat
+			new WRot(WAngle.Zero, WAngle.Zero, WAngle.Zero),		// 0
+
+			// Slopes (two corners high)
+			new WRot(new WAngle(-76), new WAngle(-40), WAngle.Zero),	// 1
+			new WRot(new WAngle(76), new WAngle(-40), WAngle.Zero),	// 2
+			new WRot(new WAngle(76), new WAngle(40), WAngle.Zero),	// 3
+			new WRot(new WAngle(-76), new WAngle(40), WAngle.Zero),	// 4
+
+			// Slopes (one corner high)
+			new WRot(WAngle.Zero, new WAngle(-76), WAngle.Zero),	// 5
+			new WRot(new WAngle(76), WAngle.Zero, WAngle.Zero),	// 6
+			new WRot(WAngle.Zero, new WAngle(76), WAngle.Zero),	// 7
+			new WRot(new WAngle(-76), WAngle.Zero, WAngle.Zero),	// 8
+
+			// Slopes (three corners high)
+			new WRot(WAngle.Zero, new WAngle(-76), WAngle.Zero),	// 9
+			new WRot(new WAngle(76), WAngle.Zero, WAngle.Zero),	// 10
+			new WRot(WAngle.Zero, new WAngle(76), WAngle.Zero),	// 11
+			new WRot(new WAngle(-76), WAngle.Zero, WAngle.Zero),	// 12
+
+			// Slopes (two corners high, one corner double high)
+			new WRot(WAngle.Zero, new WAngle(-128), WAngle.Zero),	// 13
+			new WRot(new WAngle(128), WAngle.Zero, WAngle.Zero),	// 14
+			new WRot(WAngle.Zero, new WAngle(128), WAngle.Zero),	// 15
+			new WRot(new WAngle(-128), WAngle.Zero, WAngle.Zero),	// 16
+
+			// Slopes (two corners high, alternating)
+			new WRot(WAngle.Zero, WAngle.Zero, WAngle.Zero),	// 17
+			new WRot(WAngle.Zero, WAngle.Zero, WAngle.Zero),	// 18
+			new WRot(WAngle.Zero, WAngle.Zero, WAngle.Zero),	// 19
+			new WRot(WAngle.Zero, WAngle.Zero, WAngle.Zero) // 20
+		};
+
+		public WRot GetGridSlope(byte rampType)
+		{
+			return slopes[rampType];
+		}
+
 		internal readonly CVec[][] TilesByDistance;
 
 		public MapGrid(MiniYaml yaml)

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -357,6 +357,18 @@ namespace OpenRA.Traits
 
 	public interface IFacingInfo : ITraitInfoInterface { int GetInitialFacing(); }
 
+	public interface IPosture
+	{
+		WRot Posture { get; set; }
+	}
+
+	public interface IPostureInfo : ITraitInfoInterface { WRot GetInitialPosture(); }
+
+	public interface ITerrainSlope
+	{
+		WRot Slope { get; set; }
+	}
+
 	public interface ITraitInfoInterface { }
 	public interface ITraitInfo : ITraitInfoInterface { object Create(ActorInitializer init); }
 

--- a/OpenRA.Game/WAngle.cs
+++ b/OpenRA.Game/WAngle.cs
@@ -79,6 +79,26 @@ namespace OpenRA
 			return new WAngle(aa + (bb - aa) * mul / div);
 		}
 
+		public static WAngle ChangeByStep(WAngle a, WAngle b, WAngle stepSpeed)
+		{
+			if (a == b)
+				return a;
+
+			var aa = a.Angle;
+			var bb = b.Angle;
+			var step = stepSpeed.Angle;
+			if (aa > bb && aa - bb > 512)
+				aa -= 1024;
+
+			if (bb > aa && bb - aa > 512)
+				bb -= 1024;
+
+			if (aa > bb)
+				return aa - step < bb ? new WAngle(bb) : new WAngle(aa - step);
+			else
+				return aa + step > bb ? new WAngle(bb) : new WAngle(aa + step);
+		}
+
 		public static WAngle ArcTan(int y, int x) { return ArcTan(y, x, 1); }
 		public static WAngle ArcTan(int y, int x, int stride)
 		{
@@ -115,6 +135,16 @@ namespace OpenRA
 				bestAngle = 1024 - bestAngle;
 
 			return new WAngle(bestAngle);
+		}
+
+		public static WAngle ArcSin(int d)
+		{
+			return new WAngle((int)(Math.Asin(d / 1024.0) * 512 / Math.PI));
+		}
+
+		public static WAngle ArcCos(int d)
+		{
+			return new WAngle((int)(Math.Acos(d / 1024.0) * 512 / Math.PI));
 		}
 
 		// Must not be used outside rendering code

--- a/OpenRA.Game/WRot.cs
+++ b/OpenRA.Game/WRot.cs
@@ -36,9 +36,41 @@ namespace OpenRA
 
 		public static bool operator !=(WRot me, WRot other) { return !(me == other); }
 
+		public static WRot RotateOverlay(WRot a, WRot b)
+		{
+			if (a == WRot.Zero)
+				return b;
+
+			if (b == WRot.Zero)
+				return a;
+
+			int x1, y1, z1, w1;
+			int x2, y2, z2, w2;
+			a.AsQuarternion(out x1, out y1, out z1, out w1);
+			b.AsQuarternion(out x2, out y2, out z2, out w2);
+
+			var x3 = (w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2) / 1024;
+			var y3 = (w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2) / 1024;
+			var z3 = (w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2) / 1024;
+			var w3 = (w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2) / 1024;
+
+			var r = FromQuarternion(x3, y3, z3, w3);
+			return r;
+		}
+
 		public WRot WithYaw(WAngle yaw)
 		{
 			return new WRot(Roll, Pitch, yaw);
+		}
+
+		// Inverse operation for AsQuarternion
+		static WRot FromQuarternion(int x, int y, int z, int w)
+		{
+			// Add minus sign to fit function AsQuarternion
+			var roll = WAngle.ArcTan(-2 * (x * w + y * z), 1048576 - 2 * (x * x + y * y));
+			var pitch = WAngle.ArcSin(-2 * (w * y - x * z) / 1024);
+			var yaw = WAngle.ArcTan(-2 * (w * z + x * y), 1048576 - 2 * (y * y + z * z));
+			return new WRot(roll, pitch, yaw);
 		}
 
 		void AsQuarternion(out int x, out int y, out int z, out int w)

--- a/OpenRA.Game/WVec.cs
+++ b/OpenRA.Game/WVec.cs
@@ -74,6 +74,17 @@ namespace OpenRA
 			}
 		}
 
+		public WAngle Pitch
+		{
+			get
+			{
+				if (LengthSquared == 0)
+					return WAngle.Zero;
+
+				return WAngle.ArcTan(Z, HorizontalLength);
+			}
+		}
+
 		public static WVec Lerp(WVec a, WVec b, int mul, int div) { return a + (b - a) * mul / div; }
 
 		public static WVec LerpQuadratic(WVec a, WVec b, WAngle pitch, int mul, int div)

--- a/OpenRA.Mods.Common/Traits/AffectedBySlope.cs
+++ b/OpenRA.Mods.Common/Traits/AffectedBySlope.cs
@@ -1,0 +1,55 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Traits;
+
+namespace OpenRA.Mods.Common.Traits
+{
+	[Desc("This actor will be affected by the slope of the terrain")]
+	class AffectedBySlopeInfo : ConditionalTraitInfo, Requires<BodyOrientationInfo>
+	{
+		public override object Create(ActorInitializer init) { return new AffectedBySlope(init.Self, this); }
+	}
+
+	class AffectedBySlope : ConditionalTrait<AffectedBySlopeInfo>, ITick, ISync, ITerrainSlope
+	{
+		public WRot Slope { get; set; }
+		CPos lastLocation;
+		readonly WAngle rotStep;
+		WRot targetSlope;
+
+		public AffectedBySlope(Actor self, AffectedBySlopeInfo info)
+			: base(info)
+		{
+			Slope = WRot.Zero;
+			targetSlope = WRot.Zero;
+			lastLocation = self.Location;
+			rotStep = WAngle.FromDegrees(1);
+		}
+
+		void ITick.Tick(Actor self)
+		{
+			if (self.Location != lastLocation)
+			{
+				var rampType = self.World.Map.Rules.TileSet.GetTileInfo(self.World.Map.Tiles[self.Location]).RampType;
+				targetSlope = self.World.Map.Grid.GetGridSlope(rampType);
+				lastLocation = self.Location;
+			}
+
+			if (Slope != targetSlope)
+			{
+				Slope = new WRot(WAngle.ChangeByStep(Slope.Roll, targetSlope.Roll, rotStep),
+				WAngle.ChangeByStep(Slope.Pitch, targetSlope.Pitch, rotStep),
+				WAngle.ChangeByStep(Slope.Yaw, targetSlope.Yaw, rotStep));
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -141,7 +141,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public int GetInitialFacing() { return InitialFacing; }
 		public WDist GetCruiseAltitude() { return CruiseAltitude; }
-
+		[Desc("The ratio of the aircraft's tilt to the angular velocity when turning")]
+		public readonly int TurnInclinationRatio = 0;
 		public override object Create(ActorInitializer init) { return new Aircraft(init, this); }
 
 		IEnumerable<object> IActorPreviewInitInfo.ActorPreviewInits(ActorInfo ai, ActorPreviewType type)

--- a/OpenRA.Mods.Common/Traits/BodyOrientation.cs
+++ b/OpenRA.Mods.Common/Traits/BodyOrientation.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class BodyOrientationInfo : ITraitInfo
+	public class BodyOrientationInfo : ITraitInfo, IPostureInfo
 	{
 		[Desc("Number of facings for gameplay calculations. -1 indicates auto-detection from another trait")]
 		public readonly int QuantizedFacings = -1;
@@ -28,6 +28,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Fudge the coordinate system angles like the early games.")]
 		public readonly bool UseClassicFacingFudge = false;
+
+		[Desc("Initisl posture of actor")]
+		public readonly WRot InitialPosture = WRot.Zero;
+
+		public WRot GetInitialPosture()
+		{
+			return InitialPosture;
+		}
 
 		public WVec LocalToWorld(WVec vec)
 		{
@@ -61,10 +69,15 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new BodyOrientation(init, this); }
 	}
 
-	public class BodyOrientation : ISync
+	public class BodyOrientation : ISync, IPosture
 	{
 		readonly BodyOrientationInfo info;
 		readonly Lazy<int> quantizedFacings;
+		public WRot Posture { get; set; }
+		public WRot InitialPosture
+		{
+			get { return info.GetInitialPosture(); }
+		}
 
 		[Sync]
 		public int QuantizedFacings { get { return quantizedFacings.Value; } }
@@ -72,6 +85,7 @@ namespace OpenRA.Mods.Common.Traits
 		public BodyOrientation(ActorInitializer init, BodyOrientationInfo info)
 		{
 			this.info = info;
+			Posture = info.GetInitialPosture();
 			var self = init.Self;
 			var faction = init.Contains<FactionInit>() ? init.Get<FactionInit, string>() : self.Owner.Faction.InternalName;
 

--- a/mods/ts/rules/aircraft.yaml
+++ b/mods/ts/rules/aircraft.yaml
@@ -91,6 +91,8 @@ ORCA:
 		AltitudeVelocity: 128
 		CanSlide: false
 		TakeOffOnResupply: true
+		TurnInclinationRatio: 5
+		InitialFacing: 80
 	Health:
 		HP: 20000
 	Armor:
@@ -122,6 +124,8 @@ ORCA:
 		RequiresCondition: empdisable
 	Rearmable:
 		RearmActors: gahpad, nahpad
+	BodyOrientation:
+		InitialPosture: 0, -60, 00
 
 ORCAB:
 	Inherits: ^EMPableAircraft
@@ -149,6 +153,7 @@ ORCAB:
 		LandingSounds: orcadwn1.aud
 		CanHover: false
 		CanSlide: false
+		TurnInclinationRatio: 5
 	Health:
 		HP: 26000
 	Armor:
@@ -206,6 +211,7 @@ ORCATRAN:
 		TakeoffSounds: orcaup1.aud
 		LandingSounds: orcadwn1.aud
 		IdealSeparation: 1275
+		TurnInclinationRatio: 2
 	Health:
 		HP: 20000
 	Armor:
@@ -295,6 +301,7 @@ SCRIN:
 		LandingSounds: dropdwn1.aud
 		CanHover: false
 		CanSlide: false
+		TurnInclinationRatio: 10
 	Health:
 		HP: 28000
 	Armor:

--- a/mods/ts/rules/defaults.yaml
+++ b/mods/ts/rules/defaults.yaml
@@ -845,6 +845,7 @@
 		QuantizedFacings: 0
 	RenderVoxels:
 	WithVoxelBody:
+	AffectedBySlope:
 
 ^CivilianVoxelVehicle:
 	Inherits: ^Vehicle

--- a/mods/ts/rules/gdi-vehicles.yaml
+++ b/mods/ts/rules/gdi-vehicles.yaml
@@ -258,6 +258,7 @@ HMEC:
 		Bounds: 40, 40, 0, -8
 	Carryable:
 		LocalOffset: 0,0,509
+	-AffectedBySlope:
 
 SONIC:
 	Inherits: ^Tank


### PR DESCRIPTION
Edit:

see #17795

Authored by [CastleJing](https://gitee.com/CastleJing).

![-4648031db2d19297](https://user-images.githubusercontent.com/13763394/76542034-67ba1180-64bf-11ea-8272-282de1ff1812.gif)
Aircraft (we suggest if you use a SHP helix and a VXL helicopter, not to use this function)

![-2517c82497d467fa](https://user-images.githubusercontent.com/13763394/76955924-0c1fd600-694e-11ea-8233-bf5a6199fe24.gif)
Vehicle (we suggest if you use a SHP body and a VXL turret, not to use this function)

Closes https://github.com/OpenRA/OpenRA/issues/9012.

Now TS or other mods can have better VXL visual details. Aircraft part is even better than orignal game of TS and RA2.

Finally make all VXL rotate correctly due to the angular velocity or terrain angle. 