### PR TITLE
Fix the settings tooltip container being overwritten ingame

### DIFF
--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -634,7 +634,7 @@ Container@SETTINGS_PANEL:
 													Width: 80
 													Height: 25
 													Align: Left
-													TooltipContainer: TOOLTIP_CONTAINER
+													TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 										Container@THREE_COLUMN:
 											Width: 173
 											Height: 25
@@ -650,7 +650,7 @@ Container@SETTINGS_PANEL:
 													Width: 80
 													Height: 25
 													Align: Left
-													TooltipContainer: TOOLTIP_CONTAINER
+													TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 						Background@HOTKEY_DIALOG_ROOT:
 							X: 15
 							Y: 230
@@ -700,7 +700,7 @@ Container@SETTINGS_PANEL:
 									Width: 25
 									Height: 25
 									TooltipText: Unbind the hotkey
-									TooltipContainer: TOOLTIP_CONTAINER
+									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 									TooltipTemplate: SIMPLE_TOOLTIP
 									Children:
 										Image:
@@ -715,7 +715,7 @@ Container@SETTINGS_PANEL:
 									Width: 25
 									Height: 25
 									TooltipText: Reset to default
-									TooltipContainer: TOOLTIP_CONTAINER
+									TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 									TooltipTemplate: SIMPLE_TOOLTIP
 									Children:
 										Image@IMAGE_RELOAD:
@@ -860,4 +860,4 @@ Container@SETTINGS_PANEL:
 			Width: 140
 			Height: 35
 			Text: Reset
-		TooltipContainer@TOOLTIP_CONTAINER:
+		TooltipContainer@SETTINGS_TOOLTIP_CONTAINER:

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -648,7 +648,7 @@ Background@SETTINGS_PANEL:
 													Width: 80
 													Height: 25
 													Align: Left
-													TooltipContainer: TOOLTIP_CONTAINER
+													TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 										Container@THREE_COLUMN:
 											Width: 173
 											Height: 25
@@ -664,7 +664,7 @@ Background@SETTINGS_PANEL:
 													Width: 80
 													Height: 25
 													Align: Left
-													TooltipContainer: TOOLTIP_CONTAINER
+													TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 				Background@HOTKEY_DIALOG_ROOT:
 					X: 15
 					Y: 230
@@ -716,7 +716,7 @@ Background@SETTINGS_PANEL:
 							Text: Clear
 							Font: Bold
 							TooltipText: Unbind the hotkey
-							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 						Button@RESET_HOTKEY_BUTTON:
 							X: PARENT_RIGHT - WIDTH - 20
@@ -726,7 +726,7 @@ Background@SETTINGS_PANEL:
 							Text: Reset
 							Font: Bold
 							TooltipText: Reset to default
-							TooltipContainer: TOOLTIP_CONTAINER
+							TooltipContainer: SETTINGS_TOOLTIP_CONTAINER
 							TooltipTemplate: SIMPLE_TOOLTIP
 		Container@ADVANCED_PANEL:
 			X: 5
@@ -846,4 +846,4 @@ Background@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Enable Debug Commands in Replays
-		TooltipContainer@TOOLTIP_CONTAINER:
+		TooltipContainer@SETTINGS_TOOLTIP_CONTAINER:


### PR DESCRIPTION
Closes #17764.
https://github.com/OpenRA/OpenRA/blob/af5d8a3bbee77dab83fcc06196f64faa2e520582/mods/common/chrome/ingame.yaml#L65 defines its own `TooltipContainer@TOOLTIP_CONTAINER:` which was then used instead of the `TOOLTIP_CONTAINER` from the settings chrome.