### PR TITLE
Restore ability to configure RMB orders + RMB panning.

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -228,7 +228,8 @@ namespace OpenRA
 		public int MouseScrollDeadzone = 8;
 
 		public bool UseClassicMouseStyle = false;
-		public bool ClassicMouseMiddleScroll = false;
+		public bool UseAlternateScrollButton = false;
+
 		public StatusBarsType StatusBars = StatusBarsType.Standard;
 		public TargetLinesType TargetLines = TargetLinesType.Manual;
 		public bool UsePlayerStanceColors = false;

--- a/OpenRA.Mods.Common/Widgets/Logic/IntroductionPromptLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/IntroductionPromptLogic.cs
@@ -77,12 +77,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var mouseControlDescClassic = widget.Get("MOUSE_CONTROL_DESC_CLASSIC");
 			mouseControlDescClassic.IsVisible = () => gs.UseClassicMouseStyle;
 
-			var classicScrollRight = mouseControlDescClassic.Get("DESC_SCROLL_RIGHT");
-			classicScrollRight.IsVisible = () => !gs.ClassicMouseMiddleScroll;
-
-			var classicScrollMiddle = mouseControlDescClassic.Get("DESC_SCROLL_MIDDLE");
-			classicScrollMiddle.IsVisible = () => gs.ClassicMouseMiddleScroll;
-
 			var mouseControlDescModern = widget.Get("MOUSE_CONTROL_DESC_MODERN");
 			mouseControlDescModern.IsVisible = () => !gs.UseClassicMouseStyle;
 
@@ -92,6 +86,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			foreach (var container in new[] { mouseControlDescClassic, mouseControlDescModern })
 			{
+				var classicScrollRight = container.Get("DESC_SCROLL_RIGHT");
+				classicScrollRight.IsVisible = () => gs.UseClassicMouseStyle ^ gs.UseAlternateScrollButton;
+
+				var classicScrollMiddle = container.Get("DESC_SCROLL_MIDDLE");
+				classicScrollMiddle.IsVisible = () => !gs.UseClassicMouseStyle ^ gs.UseAlternateScrollButton;
+
 				var zoomDesc = container.Get("DESC_ZOOM");
 				zoomDesc.IsVisible = () => gs.ZoomModifier == Modifiers.None;
 

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -505,7 +505,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var gs = Game.Settings.Game;
 
-			BindCheckboxPref(panel, "CLASSIC_MOUSE_MIDDLE_SCROLL_CHECKBOX", gs, "ClassicMouseMiddleScroll");
+			BindCheckboxPref(panel, "ALTERNATE_SCROLL_CHECKBOX", gs, "UseAlternateScrollButton");
 			BindCheckboxPref(panel, "EDGESCROLL_CHECKBOX", gs, "ViewportEdgeScroll");
 			BindCheckboxPref(panel, "LOCKMOUSE_CHECKBOX", gs, "LockMouseWindow");
 			BindSliderPref(panel, "ZOOMSPEED_SLIDER", gs, "ZoomSpeed");
@@ -520,23 +520,20 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			mouseScrollDropdown.OnMouseDown = _ => ShowMouseScrollDropdown(mouseScrollDropdown, gs);
 			mouseScrollDropdown.GetText = () => gs.MouseScroll.ToString();
 
-			var classicMouseMiddleScrollCheckbox = panel.Get<CheckboxWidget>("CLASSIC_MOUSE_MIDDLE_SCROLL_CHECKBOX");
-			classicMouseMiddleScrollCheckbox.IsVisible = () => gs.UseClassicMouseStyle;
-
 			var mouseControlDescClassic = panel.Get("MOUSE_CONTROL_DESC_CLASSIC");
 			mouseControlDescClassic.IsVisible = () => gs.UseClassicMouseStyle;
-
-			var classicScrollRight = mouseControlDescClassic.Get("DESC_SCROLL_RIGHT");
-			classicScrollRight.IsVisible = () => !gs.ClassicMouseMiddleScroll;
-
-			var classicScrollMiddle = mouseControlDescClassic.Get("DESC_SCROLL_MIDDLE");
-			classicScrollMiddle.IsVisible = () => gs.ClassicMouseMiddleScroll;
 
 			var mouseControlDescModern = panel.Get("MOUSE_CONTROL_DESC_MODERN");
 			mouseControlDescModern.IsVisible = () => !gs.UseClassicMouseStyle;
 
 			foreach (var container in new[] { mouseControlDescClassic, mouseControlDescModern })
 			{
+				var classicScrollRight = container.Get("DESC_SCROLL_RIGHT");
+				classicScrollRight.IsVisible = () => gs.UseClassicMouseStyle ^ gs.UseAlternateScrollButton;
+
+				var classicScrollMiddle = container.Get("DESC_SCROLL_MIDDLE");
+				classicScrollMiddle.IsVisible = () => !gs.UseClassicMouseStyle ^ gs.UseAlternateScrollButton;
+
 				var zoomDesc = container.Get("DESC_ZOOM");
 				zoomDesc.IsVisible = () => gs.ZoomModifier == Modifiers.None;
 
@@ -635,7 +632,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			{
 				gs.UseClassicMouseStyle = dgs.UseClassicMouseStyle;
 				gs.MouseScroll = dgs.MouseScroll;
-				gs.ClassicMouseMiddleScroll = dgs.ClassicMouseMiddleScroll;
+				gs.UseAlternateScrollButton = dgs.UseAlternateScrollButton;
 				gs.LockMouseWindow = dgs.LockMouseWindow;
 				gs.ViewportEdgeScroll = dgs.ViewportEdgeScroll;
 				gs.ViewportEdgeScrollStep = dgs.ViewportEdgeScrollStep;

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -318,7 +318,7 @@ namespace OpenRA.Mods.Common.Widgets
 			}
 
 			var gs = Game.Settings.Game;
-			var scrollButton = gs.UseClassicMouseStyle && !gs.ClassicMouseMiddleScroll ? MouseButton.Right : MouseButton.Middle;
+			var scrollButton = gs.UseClassicMouseStyle ^ gs.UseAlternateScrollButton ? MouseButton.Right : MouseButton.Middle;
 			var scrollType = mi.Button.HasFlag(scrollButton) ? gs.MouseScroll : MouseScrollType.Disabled;
 
 			if (scrollType == MouseScrollType.Disabled)

--- a/mods/cnc/chrome/mainmenu-prompts.yaml
+++ b/mods/cnc/chrome/mainmenu-prompts.yaml
@@ -190,7 +190,13 @@ Container@MAINMENU_INTRODUCTION_PROMPT:
 							Height: 16
 							Font: Small
 							Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
-						LabelWithHighlight@DESC_SCROLL:
+						LabelWithHighlight@DESC_SCROLL_RIGHT:
+							X: 265
+							Y: 34
+							Height: 16
+							Font: Small
+							Text: - Pan the battlefield using the {Right} mouse button
+						LabelWithHighlight@DESC_SCROLL_MIDDLE:
 							X: 265
 							Y: 34
 							Height: 16

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -484,7 +484,12 @@ Container@SETTINGS_PANEL:
 									Height: 16
 									Font: Small
 									Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
-								LabelWithHighlight@DESC_SCROLL:
+								LabelWithHighlight@DESC_SCROLL_RIGHT:
+									Y: 85
+									Height: 16
+									Font: Small
+									Text: - Pan the battlefield using the {Right} mouse button
+								LabelWithHighlight@DESC_SCROLL_MIDDLE:
 									Y: 85
 									Height: 16
 									Font: Small
@@ -537,13 +542,13 @@ Container@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Screen Edge Panning
-						Checkbox@CLASSIC_MOUSE_MIDDLE_SCROLL_CHECKBOX:
+						Checkbox@ALTERNATE_SCROLL_CHECKBOX:
 							X: 360
 							Y: 133
 							Width: 180
 							Height: 20
 							Font: Regular
-							Text: Middle Mouse Panning
+							Text: Alternate Mouse Panning
 						Label@SCROLL_SPEED_LABEL:
 							X: 310
 							Y: 210

--- a/mods/common/chrome/mainmenu-prompts.yaml
+++ b/mods/common/chrome/mainmenu-prompts.yaml
@@ -185,7 +185,13 @@ Background@MAINMENU_INTRODUCTION_PROMPT:
 					Height: 16
 					Font: Small
 					Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
-				LabelWithHighlight@DESC_SCROLL:
+				LabelWithHighlight@DESC_SCROLL_RIGHT:
+					X: 265
+					Y: 34
+					Height: 16
+					Font: Small
+					Text: - Pan the battlefield using the {Right} mouse button
+				LabelWithHighlight@DESC_SCROLL_MIDDLE:
 					X: 265
 					Y: 34
 					Height: 16

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -491,7 +491,12 @@ Background@SETTINGS_PANEL:
 							Height: 16
 							Font: Small
 							Text: - Zoom the battlefield using {MODIFIER + Scroll Wheel}
-						LabelWithHighlight@DESC_SCROLL:
+						LabelWithHighlight@DESC_SCROLL_RIGHT:
+							Y: 85
+							Height: 16
+							Font: Small
+							Text: - Pan the battlefield using the {Right} mouse button
+						LabelWithHighlight@DESC_SCROLL_MIDDLE:
 							Y: 85
 							Height: 16
 							Font: Small
@@ -544,13 +549,13 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Screen Edge Panning
-				Checkbox@CLASSIC_MOUSE_MIDDLE_SCROLL_CHECKBOX:
+				Checkbox@ALTERNATE_SCROLL_CHECKBOX:
 					X: 360
 					Y: 133
 					Width: 180
 					Height: 20
 					Font: Regular
-					Text: Middle Mouse Panning
+					Text: Alternate Mouse Panning
 				Label@SCROLL_SPEED_LABEL:
 					X: 305
 					Y: 210


### PR DESCRIPTION
There have been a surprisingly large number of complaints about the removal of this input configuration in the playtest. We don't yet actually need this change, so IMO it is difficult right now to justify ruining the gameplay experience for the people who do use/prefer this.

This PR generalizes the `ClassicMouseMiddleScroll` setting to work in both input modes, toggling between the default (RMB/MMB) and alternate (MMB/RMB) buttons.