### PR TITLE
Replace deprecated native OpenAL with OpenAL Soft on macOS.

### DIFF
--- a/packaging/macos/buildpackage.sh
+++ b/packaging/macos/buildpackage.sh
@@ -13,7 +13,7 @@
 #   MACOS_DEVELOPER_PASSWORD: App-specific password for the developer account
 #
 
-LAUNCHER_TAG="osx-launcher-20200306"
+LAUNCHER_TAG="osx-launcher-20200316"
 
 if [ $# -ne "2" ]; then
 	echo "Usage: $(basename "$0") tag outputdir"

--- a/thirdparty/fetch-thirdparty-deps-osx.sh
+++ b/thirdparty/fetch-thirdparty-deps-osx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LAUNCHER_TAG="osx-launcher-20200306"
+LAUNCHER_TAG="osx-launcher-20200316"
 
 download_dir="${0%/*}/download/osx"
 mkdir -p "$download_dir"
@@ -24,4 +24,9 @@ fi
 if [ ! -f libfreetype.6.dylib ]; then
 	echo "Fetching OS X FreeType library from GitHub."
 	curl -LOs https://github.com/OpenRA/OpenRALauncherOSX/releases/download/${LAUNCHER_TAG}/libfreetype.6.dylib
+fi
+
+if [ ! -f libopenal.1.dylib ]; then
+	echo "Fetching OS X OpenAL Soft library from GitHub."
+	curl -LOs https://github.com/OpenRA/OpenRALauncherOSX/releases/download/${LAUNCHER_TAG}/libopenal.1.dylib
 fi

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -71,11 +71,11 @@ fi
 if [ ! -f OpenAL-CS.dll ] || [ ! -f OpenAL-CS.dll.config ]; then
 	echo "Fetching OpenAL-CS from GitHub."
 	if command -v curl >/dev/null 2>&1; then
-		curl -s -L -O https://github.com/OpenRA/OpenAL-CS/releases/download/20190907/OpenAL-CS.dll
-		curl -s -L -O https://github.com/OpenRA/OpenAL-CS/releases/download/20190907/OpenAL-CS.dll.config
+		curl -s -L -O https://github.com/OpenRA/OpenAL-CS/releases/download/20200316/OpenAL-CS.dll
+		curl -s -L -O https://github.com/OpenRA/OpenAL-CS/releases/download/20200316/OpenAL-CS.dll.config
 	else
-		wget -cq https://github.com/OpenRA/OpenAL-CS/releases/download/20190907/OpenAL-CS.dll
-		wget -cq https://github.com/OpenRA/OpenAL-CS/releases/download/20190907/OpenAL-CS.dll.config
+		wget -cq https://github.com/OpenRA/OpenAL-CS/releases/download/20200316/OpenAL-CS.dll
+		wget -cq https://github.com/OpenRA/OpenAL-CS/releases/download/20200316/OpenAL-CS.dll.config
 	fi
 fi
 


### PR DESCRIPTION
Fixes #17052 by pulling in https://github.com/OpenRA/OpenRALauncherOSX/commit/f1f56a5d6b967d38eded7ea8a1763db54327148f and https://github.com/OpenRA/OpenAL-CS/commit/73a327eab2603fc5bc6c4cc50e40251f84726b4a.