### PR TITLE
Add Creeps as enemy in all D2k missions

### DIFF
--- a/mods/d2k/maps/atreides-05/map.yaml
+++ b/mods/d2k/maps/atreides-05/map.yaml
@@ -43,7 +43,7 @@ Players:
 		Faction: harkonnen
 		LockColor: True
 		Color: FE0000
-		Enemies: Atreides
+		Enemies: Atreides, Creeps
 		Bot: campaign
 	PlayerReference@Smugglers:
 		Name: Smugglers
@@ -52,7 +52,7 @@ Players:
 		LockColor: True
 		Color: 542209
 		Allies: Mercenaries
-		Enemies: Atreides
+		Enemies: Atreides, Creeps
 		Bot: campaign
 	PlayerReference@Mercenaries:
 		Name: Mercenaries
@@ -61,7 +61,7 @@ Players:
 		LockColor: True
 		Color: DDDD00
 		Allies: Smugglers
-		Enemies: Atreides
+		Enemies: Atreides, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/harkonnen-01a/map.yaml
+++ b/mods/d2k/maps/harkonnen-01a/map.yaml
@@ -42,7 +42,7 @@ Players:
 		Faction: atreides
 		LockColor: True
 		Color: 9191FF
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/harkonnen-01b/map.yaml
+++ b/mods/d2k/maps/harkonnen-01b/map.yaml
@@ -42,7 +42,7 @@ Players:
 		Faction: atreides
 		LockColor: True
 		Color: 9191FF
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/harkonnen-02a/map.yaml
+++ b/mods/d2k/maps/harkonnen-02a/map.yaml
@@ -41,7 +41,7 @@ Players:
 		Faction: atreides
 		LockColor: True
 		Color: 9191FF
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/harkonnen-02b/map.yaml
+++ b/mods/d2k/maps/harkonnen-02b/map.yaml
@@ -41,7 +41,7 @@ Players:
 		Faction: atreides
 		LockColor: True
 		Color: 9191FF
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/harkonnen-03a/map.yaml
+++ b/mods/d2k/maps/harkonnen-03a/map.yaml
@@ -41,7 +41,7 @@ Players:
 		Faction: atreides
 		LockColor: True
 		Color: 9191FF
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/harkonnen-03b/map.yaml
+++ b/mods/d2k/maps/harkonnen-03b/map.yaml
@@ -41,7 +41,7 @@ Players:
 		Faction: atreides
 		LockColor: True
 		Color: 9191FF
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/harkonnen-04/map.yaml
+++ b/mods/d2k/maps/harkonnen-04/map.yaml
@@ -42,7 +42,7 @@ Players:
 		LockColor: True
 		Color: 9191FF
 		Allies: Fremen
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 	PlayerReference@Fremen:
 		Name: Fremen
@@ -51,7 +51,7 @@ Players:
 		LockColor: True
 		Color: DDDDDD
 		Allies: Atreides
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/harkonnen-05/map.yaml
+++ b/mods/d2k/maps/harkonnen-05/map.yaml
@@ -42,7 +42,7 @@ Players:
 		LockColor: True
 		Color: B3EAA5
 		Allies: Ordos Small Base, Corrino
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 	PlayerReference@Ordos Small Base:
 		Name: Ordos Small Base
@@ -51,7 +51,7 @@ Players:
 		LockColor: True
 		Color: B3EAA5
 		Allies: Ordos Main Base, Corrino
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 	PlayerReference@Corrino:
 		Name: Corrino
@@ -60,7 +60,7 @@ Players:
 		LockColor: True
 		Color: 7D00FE
 		Allies: Ordos Main Base, Ordos Small Base
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/harkonnen-06a/map.yaml
+++ b/mods/d2k/maps/harkonnen-06a/map.yaml
@@ -42,7 +42,7 @@ Players:
 		LockColor: True
 		Color: B3EAA5
 		Allies: Ordos Small Base
-		Enemies: Harkonnen, Smugglers - Enemy to Ordos, Smugglers - Enemy to Both
+		Enemies: Harkonnen, Smugglers - Enemy to Ordos, Smugglers - Enemy to Both, Creeps
 		Bot: campaign
 	PlayerReference@Ordos Small Base:
 		Name: Ordos Small Base
@@ -51,7 +51,7 @@ Players:
 		LockColor: True
 		Color: B3EAA5
 		Allies: Ordos Main Base
-		Enemies: Harkonnen, Smugglers - Enemy to Ordos, Smugglers - Enemy to Both
+		Enemies: Harkonnen, Smugglers - Enemy to Ordos, Smugglers - Enemy to Both, Creeps
 		Bot: campaign
 	PlayerReference@Smugglers - Neutral:
 		Name: Smugglers - Neutral
@@ -61,6 +61,7 @@ Players:
 		LockColor: True
 		Color: 542209
 		Bot: campaign
+		Enemies: Creeps
 	PlayerReference@Smugglers - Enemy to Harkonnen:
 		Name: Smugglers - Enemy to Harkonnen
 		NonCombatant: True
@@ -68,7 +69,7 @@ Players:
 		Faction: smuggler
 		LockColor: True
 		Color: 542209
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 	PlayerReference@Smugglers - Enemy to Ordos:
 		Name: Smugglers - Enemy to Ordos
@@ -77,7 +78,7 @@ Players:
 		Faction: smuggler
 		LockColor: True
 		Color: 542209
-		Enemies: Ordos Main Base, Ordos Small Base
+		Enemies: Ordos Main Base, Ordos Small Base, Creeps
 		Bot: campaign
 	PlayerReference@Smugglers - Enemy to Both:
 		Name: Smugglers - Enemy to Both
@@ -86,7 +87,7 @@ Players:
 		Faction: smuggler
 		LockColor: True
 		Color: 542209
-		Enemies: Harkonnen, Ordos Main Base, Ordos Small Base
+		Enemies: Harkonnen, Ordos Main Base, Ordos Small Base, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/harkonnen-06b/map.yaml
+++ b/mods/d2k/maps/harkonnen-06b/map.yaml
@@ -42,7 +42,7 @@ Players:
 		LockColor: True
 		Color: B3EAA5
 		Allies: Ordos Small Base
-		Enemies: Harkonnen, Smugglers - Enemy to Ordos, Smugglers - Enemy to Both
+		Enemies: Harkonnen, Smugglers - Enemy to Ordos, Smugglers - Enemy to Both, Creeps
 		Bot: campaign
 	PlayerReference@Ordos Small Base:
 		Name: Ordos Small Base
@@ -51,7 +51,7 @@ Players:
 		LockColor: True
 		Color: B3EAA5
 		Allies: Ordos Main Base
-		Enemies: Harkonnen, Smugglers - Enemy to Ordos, Smugglers - Enemy to Both
+		Enemies: Harkonnen, Smugglers - Enemy to Ordos, Smugglers - Enemy to Both, Creeps
 		Bot: campaign
 	PlayerReference@Smugglers - Neutral:
 		Name: Smugglers - Neutral
@@ -61,6 +61,7 @@ Players:
 		LockColor: True
 		Color: 542209
 		Bot: campaign
+		Enemies: Creeps
 	PlayerReference@Smugglers - Enemy to Harkonnen:
 		Name: Smugglers - Enemy to Harkonnen
 		NonCombatant: True
@@ -68,7 +69,7 @@ Players:
 		Faction: smuggler
 		LockColor: True
 		Color: 542209
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 	PlayerReference@Smugglers - Enemy to Ordos:
 		Name: Smugglers - Enemy to Ordos
@@ -77,7 +78,7 @@ Players:
 		Faction: smuggler
 		LockColor: True
 		Color: 542209
-		Enemies: Ordos Main Base, Ordos Small Base
+		Enemies: Ordos Main Base, Ordos Small Base, Creeps
 		Bot: campaign
 	PlayerReference@Smugglers - Enemy to Both:
 		Name: Smugglers - Enemy to Both
@@ -86,7 +87,7 @@ Players:
 		Faction: smuggler
 		LockColor: True
 		Color: 542209
-		Enemies: Harkonnen, Ordos Main Base, Ordos Small Base
+		Enemies: Harkonnen, Ordos Main Base, Ordos Small Base, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/harkonnen-07/map.yaml
+++ b/mods/d2k/maps/harkonnen-07/map.yaml
@@ -42,7 +42,7 @@ Players:
 		LockColor: True
 		Color: 9191FF
 		Allies: Atreides Small Base, Corrino
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 	PlayerReference@Atreides Small Base:
 		Name: Atreides Small Base
@@ -51,7 +51,7 @@ Players:
 		LockColor: True
 		Color: 9191FF
 		Allies: Atreides Main Base, Corrino
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 	PlayerReference@Corrino:
 		Name: Corrino
@@ -60,7 +60,7 @@ Players:
 		LockColor: True
 		Color: 7D00FE
 		Allies: Atreides Main Base, Atreides Small Base
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/harkonnen-08/map.yaml
+++ b/mods/d2k/maps/harkonnen-08/map.yaml
@@ -43,7 +43,7 @@ Players:
 		LockColor: True
 		Color: 9191FF
 		Allies: Ordos, Ordos Aligned Mercenaries
-		Enemies: Harkonnen, Harkonnen Aligned Mercenaries
+		Enemies: Harkonnen, Harkonnen Aligned Mercenaries, Creeps
 		Bot: campaign
 	PlayerReference@Neutral Atreides:
 		Name: Neutral Atreides
@@ -52,6 +52,7 @@ Players:
 		LockColor: True
 		Color: 9191FF
 		Bot: campaign
+		Enemies: Creeps
 	PlayerReference@Ordos:
 		Name: Ordos
 		LockFaction: True
@@ -59,7 +60,7 @@ Players:
 		LockColor: True
 		Color: B3EAA5
 		Allies: Ordos Aligned Atreides, Ordos Aligned Mercenaries
-		Enemies: Harkonnen, Harkonnen Aligned Mercenaries
+		Enemies: Harkonnen, Harkonnen Aligned Mercenaries, Creeps
 		Bot: campaign
 	PlayerReference@Ordos Aligned Mercenaries:
 		Name: Ordos Aligned Mercenaries
@@ -68,7 +69,7 @@ Players:
 		LockColor: True
 		Color: DDDD00
 		Allies: Ordos, Ordos Aligned Atreides
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 	PlayerReference@Harkonnen Aligned Mercenaries:
 		Name: Harkonnen Aligned Mercenaries
@@ -77,7 +78,7 @@ Players:
 		LockColor: True
 		Color: DDDD00
 		Allies: Harkonnen
-		Enemies: Ordos, Ordos Aligned Atreides
+		Enemies: Ordos, Ordos Aligned Atreides, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/harkonnen-09a/map.yaml
+++ b/mods/d2k/maps/harkonnen-09a/map.yaml
@@ -42,7 +42,7 @@ Players:
 		LockColor: True
 		Color: 9191FF
 		Allies: Atreides Small Base 1, Atreides Small Base 2, Corrino Main Base, Corrino Small Base
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 	PlayerReference@Atreides Small Base 1:
 		Name: Atreides Small Base 1
@@ -51,7 +51,7 @@ Players:
 		LockColor: True
 		Color: 9191FF
 		Allies: Atreides Main Base, Atreides Small Base 2, Corrino Main Base, Corrino Small Base
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 	PlayerReference@Atreides Small Base 2:
 		Name: Atreides Small Base 2
@@ -60,7 +60,7 @@ Players:
 		LockColor: True
 		Color: 9191FF
 		Allies: Atreides Main Base, Atreides Small Base 1, Corrino Main Base, Corrino Small Base
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 	PlayerReference@Corrino Main Base:
 		Name: Corrino Main Base
@@ -69,7 +69,7 @@ Players:
 		LockColor: True
 		Color: 7D00FE
 		Allies: Atreides Main Base, Atreides Small Base 1, Atreides Small Base 2, Corrino Small Base
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 	PlayerReference@Corrino Small Base:
 		Name: Corrino Small Base
@@ -78,7 +78,7 @@ Players:
 		LockColor: True
 		Color: 7D00FE
 		Allies: Atreides Main Base, Atreides Small Base 1, Atreides Small Base 2, Corrino Main Base
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/harkonnen-09b/map.yaml
+++ b/mods/d2k/maps/harkonnen-09b/map.yaml
@@ -42,7 +42,7 @@ Players:
 		LockColor: True
 		Color: 9191FF
 		Allies: Atreides Small Base, Corrino Main Base, Corrino Small Base
-		Enemies: Harkonnen, Smugglers - Enemy to AI, Smugglers - Enemy to Both
+		Enemies: Harkonnen, Smugglers - Enemy to AI, Smugglers - Enemy to Both, Creeps
 		Bot: campaign
 	PlayerReference@Atreides Small Base:
 		Name: Atreides Small Base
@@ -51,7 +51,7 @@ Players:
 		LockColor: True
 		Color: 9191FF
 		Allies: Atreides Main Base, Corrino Main Base, Corrino Small Base
-		Enemies: Harkonnen, Smugglers - Enemy to AI, Smugglers - Enemy to Both
+		Enemies: Harkonnen, Smugglers - Enemy to AI, Smugglers - Enemy to Both, Creeps
 		Bot: campaign
 	PlayerReference@Corrino Main Base:
 		Name: Corrino Main Base
@@ -60,7 +60,7 @@ Players:
 		LockColor: True
 		Color: 7D00FE
 		Allies: Atreides Main Base, Atreides Small Base, Corrino Small Base
-		Enemies: Harkonnen, Smugglers - Enemy to AI, Smugglers - Enemy to Both
+		Enemies: Harkonnen, Smugglers - Enemy to AI, Smugglers - Enemy to Both, Creeps
 		Bot: campaign
 	PlayerReference@Corrino Small Base:
 		Name: Corrino Small Base
@@ -69,7 +69,7 @@ Players:
 		LockColor: True
 		Color: 7D00FE
 		Allies: Atreides Main Base, Atreides Small Base, Corrino Main Base
-		Enemies: Harkonnen, Smugglers - Enemy to AI, Smugglers - Enemy to Both
+		Enemies: Harkonnen, Smugglers - Enemy to AI, Smugglers - Enemy to Both, Creeps
 		Bot: campaign
 	PlayerReference@Smugglers - Neutral:
 		Name: Smugglers - Neutral
@@ -79,6 +79,7 @@ Players:
 		LockColor: True
 		Color: 542209
 		Bot: campaign
+		Enemies: Creeps
 	PlayerReference@Smugglers - Enemy to Harkonnen:
 		Name: Smugglers - Enemy to Harkonnen
 		NonCombatant: True
@@ -86,7 +87,7 @@ Players:
 		Faction: smuggler
 		LockColor: True
 		Color: 542209
-		Enemies: Harkonnen
+		Enemies: Harkonnen, Creeps
 		Bot: campaign
 	PlayerReference@Smugglers - Enemy to AI:
 		Name: Smugglers - Enemy to AI
@@ -95,7 +96,7 @@ Players:
 		Faction: smuggler
 		LockColor: True
 		Color: 542209
-		Enemies: Atreides Main Base, Atreides Small Base, Corrino Main Base, Corrino Small Base
+		Enemies: Atreides Main Base, Atreides Small Base, Corrino Main Base, Corrino Small Base, Creeps
 		Bot: campaign
 	PlayerReference@Smugglers - Enemy to Both:
 		Name: Smugglers - Enemy to Both
@@ -104,7 +105,7 @@ Players:
 		Faction: smuggler
 		LockColor: True
 		Color: 542209
-		Enemies: Harkonnen, Atreides Main Base, Atreides Small Base, Corrino Main Base, Corrino Small Base
+		Enemies: Harkonnen, Atreides Main Base, Atreides Small Base, Corrino Main Base, Corrino Small Base, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/ordos-01a/map.yaml
+++ b/mods/d2k/maps/ordos-01a/map.yaml
@@ -43,7 +43,7 @@ Players:
 		Faction: harkonnen
 		LockColor: True
 		Color: FE0000
-		Enemies: Ordos
+		Enemies: Ordos, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/ordos-01b/map.yaml
+++ b/mods/d2k/maps/ordos-01b/map.yaml
@@ -43,7 +43,7 @@ Players:
 		Faction: harkonnen
 		LockColor: True
 		Color: FE0000
-		Enemies: Ordos
+		Enemies: Ordos, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/ordos-02a/map.yaml
+++ b/mods/d2k/maps/ordos-02a/map.yaml
@@ -43,7 +43,7 @@ Players:
 		Faction: harkonnen
 		LockColor: True
 		Color: FE0000
-		Enemies: Ordos
+		Enemies: Ordos, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/ordos-02b/map.yaml
+++ b/mods/d2k/maps/ordos-02b/map.yaml
@@ -43,7 +43,7 @@ Players:
 		Faction: harkonnen
 		LockColor: True
 		Color: FE0000
-		Enemies: Ordos
+		Enemies: Ordos, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/ordos-03a/map.yaml
+++ b/mods/d2k/maps/ordos-03a/map.yaml
@@ -43,7 +43,7 @@ Players:
 		Faction: harkonnen
 		LockColor: True
 		Color: FE0000
-		Enemies: Ordos
+		Enemies: Ordos, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/ordos-03b/map.yaml
+++ b/mods/d2k/maps/ordos-03b/map.yaml
@@ -43,7 +43,7 @@ Players:
 		Faction: harkonnen
 		LockColor: True
 		Color: FE0000
-		Enemies: Ordos
+		Enemies: Ordos, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/ordos-04/map.yaml
+++ b/mods/d2k/maps/ordos-04/map.yaml
@@ -44,7 +44,7 @@ Players:
 		LockColor: True
 		Color: FE0000
 		Allies: Smugglers
-		Enemies: Ordos
+		Enemies: Ordos, Creeps
 		Bot: campaign
 	PlayerReference@Smugglers:
 		Name: Smugglers
@@ -53,7 +53,7 @@ Players:
 		LockColor: True
 		Color: 542209
 		Allies: Harkonnen
-		Enemies: Ordos
+		Enemies: Ordos, Creeps
 		Bot: campaign
 
 Actors:

--- a/mods/d2k/maps/ordos-05/map.yaml
+++ b/mods/d2k/maps/ordos-05/map.yaml
@@ -44,7 +44,7 @@ Players:
 		LockColor: True
 		Color: 9191FF
 		Allies: AtreidesSmallBase1, AtreidesSmallBase2
-		Enemies: Ordos
+		Enemies: Ordos, Creeps
 		Bot: campaign
 	PlayerReference@AtreidesSmallBase1:
 		Name: AtreidesSmallBase1
@@ -53,7 +53,7 @@ Players:
 		LockColor: True
 		Color: 9191FF
 		Allies: AtreidesMainBase, AtreidesSmallBase2, AtreidesSmallBase3
-		Enemies: Ordos
+		Enemies: Ordos, Creeps
 		Bot: campaign
 	PlayerReference@AtreidesSmallBase2:
 		Name: AtreidesSmallBase2
@@ -62,7 +62,7 @@ Players:
 		LockColor: True
 		Color: 9191FF
 		Allies: AtreidesMainBase, AtreidesSmallBase1, AtreidesSmallBase3
-		Enemies: Ordos
+		Enemies: Ordos, Creeps
 		Bot: campaign
 	PlayerReference@AtreidesSmallBase3:
 		Name: AtreidesSmallBase3
@@ -71,7 +71,7 @@ Players:
 		LockColor: True
 		Color: 9191FF
 		Allies: AtreidesMainBase, AtreidesSmallBase1, AtreidesSmallBase2
-		Enemies: Ordos
+		Enemies: Ordos, Creeps
 		Bot: campaign
 
 Actors:


### PR DESCRIPTION
Otherwise units of those players will not (be able to) attack sandworms.