### PR TITLE
RA Balance changes for March 2020

### DIFF
--- a/mods/ra/rules/aircraft.yaml
+++ b/mods/ra/rules/aircraft.yaml
@@ -64,7 +64,7 @@ MIG:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 7500
+		HP: 10000
 	RevealsShroud:
 		MinRange: 11c0
 		Range: 13c0
@@ -81,6 +81,7 @@ MIG:
 	AttackAircraft:
 		FacingTolerance: 20
 		PersistentTargeting: false
+		OpportunityFire: False
 	Aircraft:
 		CruiseAltitude: 2560
 		InitialFacing: 192
@@ -89,7 +90,6 @@ MIG:
 		RepulsionSpeed: 40
 		MaximumPitch: 56
 	AutoTarget:
-		ScanOnIdle: false
 		InitialStance: HoldFire
 		InitialStanceAI: HoldFire
 	AmmoPool:
@@ -155,6 +155,7 @@ YAK:
 	AttackAircraft:
 		FacingTolerance: 20
 		PersistentTargeting: false
+		OpportunityFire: False
 	Aircraft:
 		CruiseAltitude: 2560
 		InitialFacing: 192
@@ -163,7 +164,6 @@ YAK:
 		RepulsionSpeed: 40
 		MaximumPitch: 56
 	AutoTarget:
-		ScanOnIdle: false
 		InitialStance: HoldFire
 		InitialStanceAI: HoldFire
 	AmmoPool:
@@ -206,7 +206,7 @@ TRAN:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 14000
+		HP: 20000
 	RevealsShroud:
 		MinRange: 6c0
 		Range: 8c0
@@ -281,6 +281,7 @@ HELI:
 		FacingTolerance: 20
 		PersistentTargeting: false
 		AttackType: Hover
+		OpportunityFire: False
 	Aircraft:
 		TurnSpeed: 4
 		Speed: 149
@@ -353,6 +354,7 @@ HIND:
 		FacingTolerance: 20
 		PersistentTargeting: false
 		AttackType: Hover
+		OpportunityFire: False
 	Aircraft:
 		TurnSpeed: 4
 		Speed: 112

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -516,6 +516,8 @@ MNLY:
 		Image: MNLY
 	Rearmable:
 		RearmActors: fix
+	Targetable:
+		TargetTypes: Ground, Vehicle, Mine
 
 TRUK:
 	Inherits: ^Vehicle
@@ -759,11 +761,11 @@ CTNK:
 	UpdatesPlayerStatistics:
 		AddToArmyValue: true
 	Health:
-		HP: 45000
+		HP: 40000
 	Armor:
 		Type: Light
 	Mobile:
-		Speed: 113
+		Speed: 96
 		Locomotor: heavywheeled
 	RevealsShroud:
 		MinRange: 4c0
@@ -861,7 +863,7 @@ STNK:
 		InitialStance: HoldFire
 		InitialStanceAI: ReturnFire
 	Armament:
-		Weapon: APTusk
+		Weapon: APTusk.stnk
 		LocalOffset: 192,0,176
 	Turreted:
 		TurnSpeed: 5
@@ -869,7 +871,7 @@ STNK:
 	WithSpriteTurret:
 	Cargo:
 		Types: Infantry
-		MaxWeight: 4
+		MaxWeight: 5
 		LoadingCondition: notmobile
 	Cloak:
 		InitialDelay: 125

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -72,10 +72,10 @@ Dragon:
 
 HellfireAG:
 	Inherits: ^AntiGroundMissile
-	ReloadDelay: 60
+	ReloadDelay: 30
 	MinRange: 1c256
-	Burst: 4
-	BurstDelays: 14
+	Burst: 2
+	BurstDelays: 7
 	Projectile: Missile
 		Speed: 256
 		HorizontalRateOfTurn: 10
@@ -90,15 +90,17 @@ HellfireAG:
 
 HellfireAA:
 	Inherits: ^AntiAirMissile
-	ReloadDelay: 60
+	ReloadDelay: 30
 	MinRange: 1c256
+	Range: 4c0
 	Burst: 2
 	BurstDelays: 10
 	Projectile: Missile
-		Speed: 384
+		Speed: 492
 		Inaccuracy: 128
-		HorizontalRateOfTurn: 10
+		HorizontalRateOfTurn: 25
 		RangeLimit: 7c0
+		CloseEnough: 0c600
 	Warhead@1Dam: SpreadDamage
 		Damage: 4000
 		ValidTargets: Air
@@ -211,14 +213,10 @@ APTusk:
 		TrailImage: smokey
 		HorizontalRateOfTurn: 10
 		RangeLimit: 7c204
-	Warhead@1Dam: SpreadDamage
-		Damage: 2500
-		Versus:
-			None: 28
-			Wood: 88
-			Light: 88
-			Heavy: 120
-			Concrete: 60
+
+APTusk.stnk:
+	Inherits: APTusk
+	ReloadDelay: 100
 
 TorpTube:
 	ReloadDelay: 100

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -3,9 +3,7 @@
 	Range: 8c0
 	Report: aacanon3.aud
 	ValidTargets: Air
-	Projectile: Bullet
-		Speed: 1c682
-		Blockable: false
+	Projectile: InstantHit
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 2000
@@ -27,8 +25,6 @@ ZSU-23:
 	BurstDelays: 0
 	ReloadDelay: 6
 	Range: 10c0
-	Projectile: Bullet
-		Speed: 3c340
 	Warhead@1Dam: SpreadDamage
 		Damage: 1200
 		Versus:
@@ -47,8 +43,8 @@ FLAK-23-AG:
 	Inherits: ^AACannon
 	Range: 6c0
 	ValidTargets: Ground, Water
-	Projectile: Bullet
-		Blockable: True
+	Projectile: InstantHit
+		Blockable: true
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: Air, Ground, Water
 	Warhead@2Eff: CreateEffect
@@ -63,8 +59,8 @@ FLAK-23-AG:
 	ReloadDelay: 30
 	Range: 6c0
 	Report: gun13.aud
-	Projectile: Bullet
-		Speed: 1c682
+	Projectile: InstantHit
+		Blockable: true
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 2500
@@ -211,7 +207,7 @@ ChainGun:
 	ReloadDelay: 10
 	Range: 5c0
 	MinRange: 0c768
-	Projectile: Bullet
+	Projectile: InstantHit
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Versus:
@@ -222,7 +218,7 @@ ChainGun.Yak:
 	ReloadDelay: 3
 	Range: 5c0
 	MinRange: 3c0
-	Projectile: Bullet
+	Projectile: InstantHit
 		Blockable: false
 	Warhead@1Dam: SpreadDamage
 		Damage: 4000
@@ -272,8 +268,8 @@ M60mg:
 	Report: gun5.aud
 	ValidTargets: Ground, Infantry
 	InvalidTargets: Vehicle, Water, Structure, Wall, Husk, Mine
-	Projectile: Bullet
-		Speed: 1c682
+	Projectile: InstantHit
+		Blockable: true
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 15000


### PR DESCRIPTION
## Briefing
These changes have been in the works for a while, they have been playtested and iterated for months. One of the changes hasn't but is a must, removal of opportunity fire from aircraft

### Changing all small-caliber weapons to instant hit
- Bullets take time to travel. The farther a target is, the less damage moving targets receive. As it stands most small caliber weapon ranges are small and unit movement speed is slow enough that the majority of units take full damage regardless of this complex system. This change makes all targets receive full damage regardless of movement and range. It mostly impacts Pillboxes and Mobile Flak anti-air capabilities. Bullets having speed is not mentioned anywhere in the game and very few people are even aware of it. My goal is to remove this unnecessary complexity
- Pillboxes are special because they shoot 6 bursts, but unlike all other assets in the game, they do not retarget in between them. It means that moving targets will still take less damage than stationary ones. The only difference is that damage will no longer depend on distance from the Pillbox to the target nor if the target is on roads. Rangers instead of taking no damage at maximum range, will take a little. Dogs instead of surviving the first pillbox volley, will die. That is about it
- Effect to Mobile Flak anti-air is by far the most significant. In summary Yaks and MiGs are fast, always moving and Mobile Flak has long anti-air range. All of this summed up means that MiGs do not even take damage at Flaks maximum range. Combined with SAM Site having very little effective range against MiGs makes it hard for Soviets to kill them. Whether they die mostly depends on the attentiveness of the person controlling them and not the efforts of the opponent to counter play. With instant-hit Flaks will now be able to properly counter. To substitute for this MiGs are getting a health buff (there is more info on it). This change is also more justifiable considering that AA Guns bullets had already been made faster a long time ago meaning they already have been dealing full damage

### Yak
- Loses opportunity fire
   - Currently Yaks are overperforming. Although the way Yak works is fun, it is really hard to balance them. They can not be at the same time a good sniper unit and an infantry mass murderer. As Yaks are planned to be reworked in the next +1 release, we decided not to try and mix those two roles together and just revert the change

### Longbow
- Loses opportunity fire
   - So it would be consistent between all aircraft. Opportunity fire does not really affect Longbow in meaningful ways
- Reload delay from 60 to 30
- Anti-air missiles
   - Speed from 384 to 492
   - Horizontal rate of turn from 10 to 25
   - Near enough from 0c298 to 0c596
   - Range from 5 to 4 cells
      - Longbows will no longer miss planes, once fired missiles instead of sometimes exploding due to bad tracking will always connect, they already did versus helicopters 
- Anti-ground missiles
   - Burst amount from 4 to 2
   - Burst delay from 14 to 7
      - Missiles will be burstier and will overkill less in big groups. Total ammo empties by about 1 second faster. This makes burstiness the same between air / ground weapons. Burst delay is done in a way that if Longbow fired at stationary target no ammo would be wasted

### MiG
- Health from 7500 to 10000
   - MiGs will take a lot more damage from Flaks because of the insta-hit changes, additionally Longbow gets an upgrade vs planes. It is a counter buff, additionally the damage from AA Guns make MiGs a very risky unit in SvA matchup. A health buff will make them more viable
   - It will be killed by 5 Rocket Soldier rockets instead of 4
- Loses opportunity fire
   - So it would be consistent between aircraft. Opportunity fire does not really affect MiG in meaningful ways

### Black Hawk 
- Loses opportunity fire
   - So it would be consistent between aircraft. Opportunity fire does not really affect BH in meaningful ways

### Chinook
Health from 14000 to 20000
   - They have lower vision than AA Guns have weapon range. This change increases the much needed time for reaction
   - As a consequence It can barely land 4 cells in front of a vision supported AA Gun for a one way trip. If you go deeper Chinook dies

### Chrono Tank
- Rocket damage made the same as of Rocket Soldier
   - Damage from 2500 to 5000
   - Versus
      - none from 28% to 10%
      - wood from 88% to 74%
      - light from 88% to 34%
      - heavy from 120% to 100%
      - concrete from 60% to 50%
- Movement speed from 113 to 96
   - Medium Tank has Speed 82, Mobile Flak & Light Tank 118
      - Its counters will relatively become much faster than it. The portable chono ability will be the only way to outmaneuver its hunters. CTanks will have a harder time escaping after blinking aggressively 
- Health from 45000 to 40000
   - Instead of needing a second aircraft, you will need to use just 1 full ammo clip to kill it. This change was supposed to go with the Tesla Tank health nerf, but none of the Chrono Tank changes were implemented last release, they still lacked testing. This time with some minor adjustments we are more confident

Currently Chrono Tank has no role to fill, everything they do Allies can do better and more reliably with other units. With these changes Chrono Tank becomes the best ground anti-armour unit. It deals incredible damage to heavy armour, can chase anything with the Portable Chrono ability, it receives reduced damage from most of the heavy armoured units as it has light armour itself, and a decent sized health pool.

Apart from aircraft Mobile Flaks are the best Soviet hard counter, although 1 Flak (700) barely loses to 1 Chrono Tank (1350) as the numbers of units rise the better Flaks become. They are much less bursty and can shoot while moving / turning giving them an edge in those engagements

Apart from aircraft Allies can counter with Light Tanks and Rangers, they do not trade as well as Flaks but still do it cost efficiently. It is important to focus fire CTanks with them. Additionally Allies have MRJs which can completely nullify CTank rockets

### Phase Transport
- Carry size from 4 to 5
   - To be more effective at dropping, it will not impact the game significantly
- Same damage buffs / nerfs as Chrono Tank as they both share the same weapon
- Splitting weapon from CTank and increasing reload delay from 60 to 100
   - In tests they were proven to be able to kill tanks cost efficiently in larger numbers. It is not the role this unit is supposed to have. 
   - Reload delay will be twice as much as Rocket Soldiers

### Minelayer 
- Will not receive damage from mines
   - When a Minelayer is caught laying mines it can be insta-killed as any shots to it will also damage mines beneath it. As of this change mines will explode but they will not kill the Minelayer. Current behaviour seems like a bug rather than a feature