### PR TITLE
Add support for ignoring actor types in SquadManagerBotModule

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -74,6 +74,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Radius in cells that protecting squads should scan for enemies around their position.")]
 		public readonly int ProtectionScanRadius = 8;
 
+		[Desc("Unit types that are not chosen as attack target despite being owned by an enemy player.")]
+		public readonly HashSet<string> IgnoredEnemyUnitTypes = new HashSet<string>();
+
 		public override object Create(ActorInitializer init) { return new SquadManagerBotModule(init.Self, this); }
 	}
 
@@ -121,7 +124,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool IsEnemyUnit(Actor a)
 		{
-			return a != null && !a.IsDead && Player.Stances[a.Owner] == Stance.Enemy
+			return a != null && !a.IsDead && !Info.IgnoredEnemyUnitTypes.Contains(a.Info.Name)
+				&& Player.Stances[a.Owner] == Stance.Enemy
 				&& !a.Info.HasTraitInfo<HuskInfo>()
 				&& !a.GetEnabledTargetTypes().IsEmpty;
 		}

--- a/mods/d2k/rules/ai.yaml
+++ b/mods/d2k/rules/ai.yaml
@@ -221,6 +221,7 @@ Player:
 		MaxBaseRadius: 40
 		ExcludeFromSquadsTypes: harvester, mcv
 		ConstructionYardTypes: construction_yard
+		IgnoredEnemyUnitTypes: sandworm
 	UnitBuilderBotModule@omnius:
 		RequiresCondition: enable-omnius-ai
 		UnitQueues: Infantry, Vehicle, Armor, Starport, Aircraft
@@ -264,6 +265,7 @@ Player:
 		MaxBaseRadius: 40
 		ExcludeFromSquadsTypes: harvester, mcv
 		ConstructionYardTypes: construction_yard
+		IgnoredEnemyUnitTypes: sandworm
 	UnitBuilderBotModule@vidious:
 		RequiresCondition: enable-vidious-ai
 		UnitQueues: Infantry, Vehicle, Armor, Starport, Aircraft
@@ -302,6 +304,7 @@ Player:
 		MaxBaseRadius: 40
 		ExcludeFromSquadsTypes: harvester, mcv
 		ConstructionYardTypes: construction_yard
+		IgnoredEnemyUnitTypes: sandworm
 	UnitBuilderBotModule@gladius:
 		RequiresCondition: enable-gladius-ai
 		UnitQueues: Infantry, Vehicle, Armor, Starport, Aircraft


### PR DESCRIPTION
The AIs in D2k were often picking worms as explicit targets which we want to prevent.