### PR TITLE
Added more configuration options to ProductionAirdrop and made the CHOAM space frigate come in from the closest map edge cell

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
@@ -51,7 +51,7 @@ namespace OpenRA.Mods.Common.Traits
 		public override object Create(ActorInitializer init) { return new ProductionAirdrop(init, this); }
 	}
 
-	class ProductionAirdrop : Production
+	public class ProductionAirdrop : Production
 	{
 		readonly AircraftInfo aircraftInfo;
 		readonly ProductionAirdropInfo info;

--- a/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
@@ -20,6 +20,8 @@ namespace OpenRA.Mods.Common.Traits
 {
 	public enum EntryType { Fixed, PlayerSpawnClosestEdge, DropSiteClosestEdge }
 
+	public enum ExitType { OppositeToEntry, StraightAhead, SameAsEntry, Closest }
+
 	[Desc("Deliver the unit in production via skylift.")]
 	public class ProductionAirdropInfo : ProductionInfo
 	{
@@ -34,8 +36,14 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The delivery aircraft spawn and entry behaviour.")]
 		public readonly EntryType EntryType = EntryType.Fixed;
 
+		[Desc("The delivery aircraft map exit behaviour.")]
+		public readonly ExitType ExitType = ExitType.OppositeToEntry;
+
 		[Desc("Offset relative to the automatically calculated spawn point.")]
 		public readonly CVec SpawnOffset = CVec.Zero;
+
+		[Desc("Offset relative to the automatically calculated exit point.")]
+		public readonly CVec ExitOffset = CVec.Zero;
 
 		[Desc("Direction the aircraft should face to land. A value of -1 would mean to ignore facing and just land.")]
 		public readonly int LandingFacing = -1;
@@ -95,8 +103,12 @@ namespace OpenRA.Mods.Common.Traits
 					Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", info.ReadyAudio, self.Owner.Faction.InternalName);
 				}));
 
-				actor.QueueActivity(new FlyOffMap(actor, Target.FromCell(w, deliveryPath.ExitPosition)));
-				actor.QueueActivity(new RemoveSelf());
+				actor.QueueActivity(new CallFunc(() =>
+				{
+					var exitPosition = deliveryPath.CalculateExitPosition(actor);
+					actor.QueueActivity(new FlyOffMap(actor, Target.FromCell(w, exitPosition)));
+					actor.QueueActivity(new RemoveSelf());
+				}));
 			});
 
 			return true;
@@ -109,9 +121,8 @@ namespace OpenRA.Mods.Common.Traits
 			var bounds = map.Bounds;
 			var mpStart = owner.World.WorldActor.TraitOrDefault<MPStartLocations>();
 
-			CPos startPos;
-			CPos endPos;
-			int spawnFacing;
+			var startPos = CPos.Zero;
+			var spawnFacing = 0;
 
 			switch (info.EntryType)
 			{
@@ -120,11 +131,9 @@ namespace OpenRA.Mods.Common.Traits
 					// This makes the production timing independent of spawnpoint
 					var loc = self.Location.ToMPos(map);
 					startPos = new MPos(loc.U + map.Bounds.Width, loc.V).ToCPos(map);
-					endPos = new MPos(map.Bounds.Left, loc.V).ToCPos(map);
 
 					spawnFacing = GetSpawnFacing(self.Location, startPos);
-
-					return new DeliveryActorPathInfo(startPos, endPos, spawnFacing, info.LandingFacing);
+					break;
 
 				case EntryType.PlayerSpawnClosestEdge:
 					if (mpStart == null)
@@ -134,11 +143,9 @@ namespace OpenRA.Mods.Common.Traits
 					var center = new MPos(bounds.Left + bounds.Width / 2, bounds.Top + bounds.Height / 2).ToCPos(map);
 					var spawnVec = spawn - center;
 					startPos = spawn + spawnVec * (Exts.ISqrt((bounds.Height * bounds.Height + bounds.Width * bounds.Width) / (4 * spawnVec.LengthSquared)));
-					endPos = startPos;
 
 					spawnFacing = GetSpawnFacing(self.Location, startPos);
-
-					return new DeliveryActorPathInfo(startPos, endPos, spawnFacing, info.LandingFacing);
+					break;
 
 				case EntryType.DropSiteClosestEdge:
 					startPos = self.World.Map.ChooseClosestEdgeCell(self.Location);
@@ -146,14 +153,17 @@ namespace OpenRA.Mods.Common.Traits
 					spawnFacing = GetSpawnFacing(self.Location, startPos);
 
 					bounds = self.World.Map.Bounds;
-					if ((info.SpawnOffset.X != 0 && startPos.X != bounds.X && startPos.X != bounds.X + bounds.Width)
-						|| (info.SpawnOffset.Y != 0 && startPos.Y != bounds.Y && startPos.Y != bounds.Y + bounds.Height))
-						startPos += info.SpawnOffset;
+					if (info.SpawnOffset.X != 0 && startPos.X != bounds.X && startPos.X != bounds.X + bounds.Width)
+						startPos += new CVec(info.SpawnOffset.X, 0);
 
-					return new DeliveryActorPathInfo(startPos, startPos, spawnFacing, info.LandingFacing);
+					if (info.SpawnOffset.Y != 0 && startPos.Y != bounds.Y && startPos.Y != bounds.Y + bounds.Height)
+						startPos += new CVec(0, info.SpawnOffset.Y);
+					break;
 			}
 
-			throw new ArgumentOutOfRangeException("info.EntryType", info.EntryType, "Unsupported value for delivery actor entry type!");
+			var exitPositionFunc = GetExitPositionFunc(self, startPos, spawnFacing);
+
+			return new DeliveryActorPathInfo(startPos, spawnFacing, info.LandingFacing, exitPositionFunc);
 		}
 
 		static int GetSpawnFacing(CPos targetLocation, CPos spawnLocation)
@@ -163,19 +173,71 @@ namespace OpenRA.Mods.Common.Traits
 			return spawnDirection.Yaw.Facing;
 		}
 
+		Func<Actor, CPos> GetExitPositionFunc(Actor self, CPos startPos, int spawnFacing)
+		{
+			Func<Actor, CPos> exitPositionFunc = actor => CPos.Zero;
+			switch (info.ExitType)
+			{
+				case ExitType.OppositeToEntry:
+					exitPositionFunc = actor =>
+					{
+						var rotation = WRot.FromFacing(spawnFacing);
+						var delta = new WVec(0, -1024, 0).Rotate(rotation);
+						var finishEdge = actor.CenterPosition + self.World.Map.DistanceToEdge(actor.CenterPosition, delta).Length * delta / 1024;
+						return new CPos(finishEdge.X / 1024, finishEdge.Y / 1024, 0);
+					};
+
+					break;
+
+				case ExitType.StraightAhead:
+					exitPositionFunc = actor =>
+					{
+						var rotation = WRot.FromFacing(actor.Orientation.Yaw.Facing);
+						var delta = new WVec(0, -1024, 0).Rotate(rotation);
+						var finishEdge = actor.CenterPosition + self.World.Map.DistanceToEdge(actor.CenterPosition, delta).Length * delta / 1024;
+						return new CPos(finishEdge.X / 1024, finishEdge.Y / 1024, 0);
+					};
+
+					break;
+
+				case ExitType.SameAsEntry:
+					exitPositionFunc = actor => startPos;
+					break;
+
+				case ExitType.Closest:
+					exitPositionFunc = actor =>
+					{
+						// By the time the func gets executed the map bounds could have changed, so fetching them fresh.
+						var mapBounds = self.World.Map.Bounds;
+						var exitCell = self.World.Map.ChooseClosestEdgeCell(actor.Location);
+						if (info.ExitOffset.X != 0 && exitCell.X != mapBounds.X && exitCell.X != mapBounds.X + mapBounds.Width)
+							exitCell += new CVec(info.ExitOffset.X, 0);
+
+						if (info.ExitOffset.Y != 0 && exitCell.Y != mapBounds.Y && exitCell.Y != mapBounds.Y + mapBounds.Height)
+							exitCell += new CVec(0, info.ExitOffset.Y);
+
+						return exitCell;
+					};
+
+					break;
+			}
+
+			return exitPositionFunc;
+		}
+
 		class DeliveryActorPathInfo
 		{
 			public readonly CPos EntryPosition;
-			public readonly CPos ExitPosition;
 			public readonly int SpawnFacing;
 			public readonly int LandingFacing;
+			public readonly Func<Actor, CPos> CalculateExitPosition;
 
-			public DeliveryActorPathInfo(CPos entryPosition, CPos exitPosition, int spawnFacing, int landingFacing)
+			public DeliveryActorPathInfo(CPos entryPosition, int spawnFacing, int landingFacing, Func<Actor, CPos> calculateExitPosition)
 			{
 				EntryPosition = entryPosition;
-				ExitPosition = exitPosition;
 				SpawnFacing = spawnFacing;
 				LandingFacing = landingFacing;
+				CalculateExitPosition = calculateExitPosition;
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
@@ -112,7 +112,6 @@ namespace OpenRA.Mods.Common.Traits
 			CPos startPos;
 			CPos endPos;
 			int spawnFacing;
-			WVec spawnDirection;
 
 			switch (info.EntryType)
 			{
@@ -122,7 +121,8 @@ namespace OpenRA.Mods.Common.Traits
 					var loc = self.Location.ToMPos(map);
 					startPos = new MPos(loc.U + map.Bounds.Width, loc.V).ToCPos(map);
 					endPos = new MPos(map.Bounds.Left, loc.V).ToCPos(map);
-					spawnFacing = info.Facing;
+
+					spawnFacing = GetSpawnFacing(self.Location, startPos);
 
 					return new DeliveryActorPathInfo(startPos, endPos, spawnFacing, info.Facing);
 
@@ -135,16 +135,15 @@ namespace OpenRA.Mods.Common.Traits
 					var spawnVec = spawn - center;
 					startPos = spawn + spawnVec * (Exts.ISqrt((bounds.Height * bounds.Height + bounds.Width * bounds.Width) / (4 * spawnVec.LengthSquared)));
 					endPos = startPos;
-					spawnDirection = new WVec((self.Location - startPos).X, (self.Location - startPos).Y, 0);
-					spawnFacing = spawnDirection.Yaw.Facing;
+
+					spawnFacing = GetSpawnFacing(self.Location, startPos);
 
 					return new DeliveryActorPathInfo(startPos, endPos, spawnFacing, info.Facing);
 
 				case EntryType.DropSiteClosestEdge:
 					startPos = self.World.Map.ChooseClosestEdgeCell(self.Location);
 
-					spawnDirection = new WVec((self.Location - startPos).X, (self.Location - startPos).Y, 0);
-					spawnFacing = spawnDirection.Yaw.Facing;
+					spawnFacing = GetSpawnFacing(self.Location, startPos);
 
 					bounds = self.World.Map.Bounds;
 					if ((info.SpawnOffset.X != 0 && startPos.X != bounds.X && startPos.X != bounds.X + bounds.Width)
@@ -155,6 +154,13 @@ namespace OpenRA.Mods.Common.Traits
 			}
 
 			throw new ArgumentOutOfRangeException("info.EntryType", info.EntryType, "Unsupported value for delivery actor entry type!");
+		}
+
+		static int GetSpawnFacing(CPos targetLocation, CPos spawnLocation)
+		{
+			var direction = targetLocation - spawnLocation;
+			var spawnDirection = new WVec(direction.X, direction.Y, 0);
+			return spawnDirection.Yaw.Facing;
 		}
 
 		class DeliveryActorPathInfo

--- a/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
@@ -12,7 +12,6 @@
 using System;
 using System.Linq;
 using OpenRA.Activities;
-using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -41,18 +40,23 @@ namespace OpenRA.Mods.Common.Traits
 
 	class ProductionAirdrop : Production
 	{
+		readonly AircraftInfo aircraftInfo;
+		readonly ProductionAirdropInfo info;
+
 		public ProductionAirdrop(ActorInitializer init, ProductionAirdropInfo info)
-			: base(init, info) { }
+			: base(init, info)
+		{
+			aircraftInfo = init.Self.World.Map.Rules.Actors[info.ActorType].TraitInfo<AircraftInfo>();
+			this.info = info;
+		}
 
 		public override bool Produce(Actor self, ActorInfo producee, string productionType, TypeDictionary inits)
 		{
 			if (IsTraitDisabled || IsTraitPaused)
 				return false;
 
-			var info = (ProductionAirdropInfo)Info;
 			var owner = self.Owner;
 			var map = owner.World.Map;
-			var aircraftInfo = self.World.Map.Rules.Actors[info.ActorType].TraitInfo<AircraftInfo>();
 			var mpStart = owner.World.WorldActor.TraitOrDefault<MPStartLocations>();
 
 			CPos startPos;

--- a/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
@@ -37,8 +37,8 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Offset relative to the automatically calculated spawn point.")]
 		public readonly CVec SpawnOffset = CVec.Zero;
 
-		[Desc("Direction the aircraft should face to land.")]
-		public readonly int Facing = 64;
+		[Desc("Direction the aircraft should face to land. A value of -1 would mean to ignore facing and just land.")]
+		public readonly int LandingFacing = -1;
 
 		public override object Create(ActorInitializer init) { return new ProductionAirdrop(init, this); }
 	}
@@ -124,7 +124,7 @@ namespace OpenRA.Mods.Common.Traits
 
 					spawnFacing = GetSpawnFacing(self.Location, startPos);
 
-					return new DeliveryActorPathInfo(startPos, endPos, spawnFacing, info.Facing);
+					return new DeliveryActorPathInfo(startPos, endPos, spawnFacing, info.LandingFacing);
 
 				case EntryType.PlayerSpawnClosestEdge:
 					if (mpStart == null)
@@ -138,7 +138,7 @@ namespace OpenRA.Mods.Common.Traits
 
 					spawnFacing = GetSpawnFacing(self.Location, startPos);
 
-					return new DeliveryActorPathInfo(startPos, endPos, spawnFacing, info.Facing);
+					return new DeliveryActorPathInfo(startPos, endPos, spawnFacing, info.LandingFacing);
 
 				case EntryType.DropSiteClosestEdge:
 					startPos = self.World.Map.ChooseClosestEdgeCell(self.Location);
@@ -150,7 +150,7 @@ namespace OpenRA.Mods.Common.Traits
 						|| (info.SpawnOffset.Y != 0 && startPos.Y != bounds.Y && startPos.Y != bounds.Y + bounds.Height))
 						startPos += info.SpawnOffset;
 
-					return new DeliveryActorPathInfo(startPos, startPos, spawnFacing, info.Facing);
+					return new DeliveryActorPathInfo(startPos, startPos, spawnFacing, info.LandingFacing);
 			}
 
 			throw new ArgumentOutOfRangeException("info.EntryType", info.EntryType, "Unsupported value for delivery actor entry type!");

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20200202/ImproveProductionAirdrop.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20200202/ImproveProductionAirdrop.cs
@@ -1,0 +1,58 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class ImproveProductionAirdrop : UpdateRule
+	{
+		public override string Name { get { return "Add more options to ProductionAirdrop."; } }
+
+		public override string Description
+		{
+			get
+			{
+				return "The ProductionAirdrop trait received some new properties to allow for better control over the delivery aircraft's behaviour.";
+			}
+		}
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNode actorNode)
+		{
+			var productionAirdropTraits = actorNode.ChildrenMatching("ProductionAirdrop");
+
+			foreach (var productionAirdropTrait in productionAirdropTraits)
+			{
+				var facingNode = productionAirdropTrait.ChildrenMatching("Facing").FirstOrDefault();
+				if (facingNode != null)
+					facingNode.Key = "LandingFacing";
+				else
+					productionAirdropTrait.AddNode("LandingFacing", 64);    // The previously hardcoded value was 64.
+
+				var baselineSpawnNode = productionAirdropTrait.ChildrenMatching("BaselineSpawn").FirstOrDefault();
+				if (baselineSpawnNode != null)
+				{
+					if (baselineSpawnNode.Value.Value == "true")
+					{
+						// Values here are designed to keep the same behaviour.
+						productionAirdropTrait.AddNode("EntryType", "PlayerSpawnClosestEdge");
+						productionAirdropTrait.AddNode("ExitType", "SameAsEntry");
+					}
+
+					productionAirdropTrait.RemoveNode(baselineSpawnNode);
+				}
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -81,6 +81,7 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new AddPipDecorationTraits(),
 				new ModernizeDecorationTraits(),
 				new RenameInfiltrationNotifications(),
+				new ImproveProductionAirdrop(),
 			})
 		};
 

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -434,6 +434,7 @@ AFLD:
 	ProductionAirdrop:
 		Produces: Vehicle.Nod
 		ActorType: c17
+		LandingFacing: 64
 	WithBuildingBib:
 	WithIdleOverlay@DISH:
 		RequiresCondition: !build-incomplete

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -609,6 +609,7 @@ starport:
 	ProductionAirdrop:
 		Produces: Starport
 		ActorType: frigate
+		LandingFacing: 64
 	RenderSprites:
 		Image: starport.ordos
 		FactionImages:

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -609,7 +609,10 @@ starport:
 	ProductionAirdrop:
 		Produces: Starport
 		ActorType: frigate
-		LandingFacing: 64
+		EntryType: DropSiteClosestEdge
+		ExitType: OppositeToEntry
+		SpawnOffset: 1,1
+		LandingFacing: -1
 	RenderSprites:
 		Image: starport.ordos
 		FactionImages:


### PR DESCRIPTION
Inspired by #17825 and now supersedes it.
Unfortunately #16595 wasn't doing the job it needed to do for this (and I still find its behaviour questionable).
This could also open a bunch of interesting options for the TD Airstrip (although I doubt they'll be accepted) and for third-party mods when one plays around with the new controls.

The last commit makes the CHOAM frigate in D2k come from the closest map edge and continue in a straight line after unloading its cargo.

(_P.S.: Admittedly today wasn't a great name for naming things._)