### PR TITLE
Remove DisableWindowsRenderThread and always use the threaded renderer

### DIFF
--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -179,9 +179,6 @@ namespace OpenRA
 		[Desc("At which frames per second to cap the framerate.")]
 		public int MaxFramerate = 60;
 
-		[Desc("Disable separate OpenGL render thread on Windows operating systems.")]
-		public bool DisableWindowsRenderThread = true;
-
 		[Desc("Disable the OpenGL debug message callback feature.")]
 		public bool DisableGLDebugMessageCallback = false;
 

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -288,9 +288,8 @@ namespace OpenRA.Platforms.Default
 			// Run graphics rendering on a dedicated thread.
 			// The calling thread will then have more time to process other tasks, since rendering happens in parallel.
 			// If the calling thread is the main game thread, this means it can run more logic and render ticks.
-			// This is disabled on Windows because it breaks the ability to minimize/restore the window from the taskbar for reasons that we dont understand.
-			var threadedRenderer = Platform.CurrentPlatform != PlatformType.Windows || !Game.Settings.Graphics.DisableWindowsRenderThread;
-			if (!threadedRenderer)
+			// This is disabled when running in windowed mode on Windows because it breaks the ability to minimize/restore the window.
+			if (Platform.CurrentPlatform == PlatformType.Windows && windowMode == WindowMode.Windowed)
 			{
 				var ctx = new Sdl2GraphicsContext(this);
 				ctx.InitializeOpenGL();


### PR DESCRIPTION
Works around the window maximisation/restoring issue on windows by not ticking `RenderTick` while the window is suspended. This should additionally improve performance when the window is suspended. (Not to mention the performance improvement on Windows by using the threaded renderer!)

It turns out our `RenderTick` somehow consumed SDL events before `PumpInput` could restore the window. Skipping the render and explicitly calling `PumpInput` works around that issue.