### PR TITLE
Added an option to allow placing buildings on resources

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -46,6 +46,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly bool AllowInvalidPlacement = false;
 
+		public readonly bool AllowPlacementOnResources = false;
+
 		[Desc("Clear smudges from underneath the building footprint.")]
 		public readonly bool RemoveSmudgesOnBuild = true;
 

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingUtils.cs
@@ -55,8 +55,8 @@ namespace OpenRA.Mods.Common.Traits
 				return true;
 
 			var res = world.WorldActor.TraitOrDefault<ResourceLayer>();
-			return bi.Tiles(cell).All(
-				t => world.Map.Contains(t) && (res == null || res.GetResourceType(t) == null) &&
+			return bi.Tiles(cell).All(t => world.Map.Contains(t) &&
+				(bi.AllowPlacementOnResources || res == null || res.GetResourceType(t) == null) &&
 					world.IsCellBuildable(t, ai, bi, toIgnore));
 		}
 


### PR DESCRIPTION
The assumption that it is always forbidden is valid for basically all C&C games. It is however undocumented and hard-coded into the engine. The only choice for mods at the moment is to go with `AllowInvalidPlacement` which disables all checks in place if they want to try out something new.