### PR TITLE
Fix and simplify WeatherOverlay

### DIFF
--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -19,6 +19,11 @@ namespace OpenRA.Graphics
 	[Flags]
 	public enum ScrollDirection { None = 0, Up = 1, Left = 2, Down = 4, Right = 8 }
 
+	public interface INotifyViewportZoomExtentsChanged
+	{
+		void ViewportZoomExtentsChanged(float minZoom, float maxZoom);
+	}
+
 	public static class ViewportExts
 	{
 		public static bool Includes(this ScrollDirection d, ScrollDirection s)
@@ -237,6 +242,9 @@ namespace OpenRA.Graphics
 				Zoom = minZoom;
 			else
 				Zoom = Zoom.Clamp(minZoom, maxZoom);
+
+			foreach (var t in worldRenderer.World.WorldActor.TraitsImplementing<INotifyViewportZoomExtentsChanged>())
+				t.ViewportZoomExtentsChanged(minZoom, maxZoom);
 		}
 
 		public CPos ViewToWorld(int2 view)

--- a/OpenRA.Mods.Common/Traits/World/WeatherOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/WeatherOverlay.cs
@@ -147,6 +147,7 @@ namespace OpenRA.Mods.Common.Traits
 			this.world = world;
 			targetWindStrengthIndex = info.ChangingWindLevel ? world.LocalRandom.Next(info.WindLevels.Length) : 0;
 			windUpdateCountdown = world.LocalRandom.Next(info.WindTick[0], info.WindTick[1]);
+			windStrength = info.WindLevels[targetWindStrengthIndex];
 		}
 
 		void INotifyViewportZoomExtentsChanged.ViewportZoomExtentsChanged(float minZoom, float maxZoom)


### PR DESCRIPTION
Fixes #17757 and makes the code much more maintainable.

The only noticable change compared with the last release is that the game starts with the weather effect in force, instead of it fading in over the first couple of seconds. The fade in / (unused) fade out logic added a lot of unnecessary complexity, so I removed it to simplify the cleanup.