### PR TITLE
Removed an unused terrain type

### DIFF
--- a/mods/ra/tilesets/desert.yaml
+++ b/mods/ra/tilesets/desert.yaml
@@ -14,10 +14,6 @@ Terrain:
 		TargetTypes: Ground, Bridge
 		AcceptsSmudgeType: Crater, Scorch
 		Color: 606060
-	TerrainType@Brush:
-		Type: Brush
-		TargetTypes: Ground
-		Color: 1C2024
 	TerrainType@Clear:
 		Type: Clear
 		TargetTypes: Ground


### PR DESCRIPTION
I suspect that I might have planned to add an infantry only terrain type, but apparently that never happened. Cleaning up my own mess here.