### PR TITLE
Fix and simplify ScrollPanelWidget thumb rect calculation.

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ScrollPanelWidget.cs
@@ -146,13 +146,16 @@ namespace OpenRA.Mods.Common.Widgets
 			UpdateSmoothScrolling();
 
 			var rb = RenderBounds;
-
 			var scrollbarHeight = rb.Height - 2 * ScrollbarWidth;
 
-			var thumbHeight = ContentHeight == 0 ? 0 : Math.Max(MinimumThumbSize, (int)(scrollbarHeight * Math.Min(rb.Height * 1f / ContentHeight, 1f)));
-			var thumbOrigin = rb.Y + ScrollbarWidth + (int)((scrollbarHeight - thumbHeight) * (-1f * currentListOffset / (ContentHeight - rb.Height)));
-			if (thumbHeight == scrollbarHeight)
-				thumbHeight = 0;
+			// Scroll thumb is only visible if the content does not fit within the panel bounds
+			var thumbHeight = 0;
+			var thumbOrigin = rb.Y + ScrollbarWidth;
+			if (ContentHeight > rb.Height)
+			{
+				thumbHeight = Math.Max(MinimumThumbSize, scrollbarHeight * rb.Height / ContentHeight);
+				thumbOrigin += (int)((scrollbarHeight - thumbHeight) * currentListOffset / (rb.Height - ContentHeight));
+			}
 
 			switch (ScrollBar)
 			{


### PR DESCRIPTION
Fixes #17797.

de4a7cecf0719aa3249eec5222ed78e5fa53b3df exposed (its not clear exactly how) an underlying divide-by-zero issue in the `thumbOrigin` calculation (when (`ContentHeight == rb.Height`) that resulted in `thumbOrigin.Y` being set to `int.MinValue`. This then triggered a cascade of failures in the rendering code that causes the freeze.

Rewriting the calculation in a more sensible way avoids the problem.

My repro case was to click on the "Control Scheme" dropdown in the TD mod with the UI scale set to 150%.