### PR TITLE
Make the right edge of the TD Airstrip transitable.

### DIFF
--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -420,7 +420,7 @@ AFLD:
 		Queue: Building.Nod
 		Description: Provides a dropzone\nfor vehicle reinforcements
 	Building:
-		Footprint: XXXX xxxx ====
+		Footprint: XXX+ xxx+ ====
 		Dimensions: 4,3
 		LocalCenterOffset: 0,-512,0
 	Health:


### PR DESCRIPTION
Closes #17820. In addition to allowing units to path over it, units stopped on these cells (including newly produced units) are forced to move off them as soon as they can.

This is more of a workaround than a fix, but IMO seems like a reasonable change for consistency with the service depot.