### PR TITLE
Fix SpriteEffect updating twice in the first tick.

### DIFF
--- a/OpenRA.Mods.Common/Effects/SpriteEffect.cs
+++ b/OpenRA.Mods.Common/Effects/SpriteEffect.cs
@@ -62,16 +62,18 @@ namespace OpenRA.Mods.Common.Effects
 				world.ScreenMap.Add(this, pos, anim.Image);
 				initialized = true;
 			}
+			else
+			{
+				anim.Tick();
 
-			anim.Tick();
-
-			pos = posFunc();
-			world.ScreenMap.Update(this, pos, anim.Image);
+				pos = posFunc();
+				world.ScreenMap.Update(this, pos, anim.Image);
+			}
 		}
 
 		public IEnumerable<IRenderable> Render(WorldRenderer wr)
 		{
-			if (!visibleThroughFog && world.FogObscures(pos))
+			if (!initialized || (!visibleThroughFog && world.FogObscures(pos)))
 				return SpriteRenderable.None;
 
 			return anim.Render(pos, wr.Palette(palette));


### PR DESCRIPTION
Speculative fix for / closes #17801.
Helps towards #9243.

I didn't notice any obvious regressions when testing crate effects / levelup / missile puffs (ts) / units parachuting into water / smoking terrain / vehicle damage smoke / infantry death animations.