### PR TITLE
Move selectableActor check inside InputOverridesSelection.

### DIFF
--- a/OpenRA.Game/Orders/UnitOrderGenerator.cs
+++ b/OpenRA.Game/Orders/UnitOrderGenerator.cs
@@ -96,7 +96,7 @@ namespace OpenRA.Orders
 		public virtual bool InputOverridesSelection(World world, int2 xy, MouseInput mi)
 		{
 			var actor = world.ScreenMap.ActorsAtMouse(xy)
-				.Where(a => !a.Actor.IsDead)
+				.Where(a => !a.Actor.IsDead && a.Actor.Info.HasTraitInfo<ISelectableInfo>() && (a.Actor.Owner.IsAlliedWith(world.RenderPlayer) || !world.FogObscures(a.Actor)))
 				.WithHighestSelectionPriority(xy, mi.Modifiers);
 
 			if (actor == null)

--- a/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/WorldInteractionControllerWidget.cs
@@ -117,19 +117,13 @@ namespace OpenRA.Mods.Common.Widgets
 			{
 				if (useClassicMouseStyle && HasMouseFocus)
 				{
-					if (!IsValidDragbox && World.Selection.Actors.Any() && !multiClick)
+					if (!IsValidDragbox && World.Selection.Actors.Any() && !multiClick && uog.InputOverridesSelection(World, mousePos, mi))
 					{
-						var selectableActor = World.ScreenMap.ActorsAtMouse(mousePos).Select(a => a.Actor).Any(x =>
-							x.Info.HasTraitInfo<ISelectableInfo>() && (x.Owner.IsAlliedWith(World.RenderPlayer) || !World.FogObscures(x)));
-
-						if (!selectableActor || uog.InputOverridesSelection(World, mousePos, mi))
-						{
-							// Order units instead of selecting
-							ApplyOrders(World, mi);
-							isDragging = false;
-							YieldMouseFocus(mi);
-							return true;
-						}
+						// Order units instead of selecting
+						ApplyOrders(World, mi);
+						isDragging = false;
+						YieldMouseFocus(mi);
+						return true;
 					}
 				}
 


### PR DESCRIPTION
Fixes #17850 by improving the consistency between the cursor and click handling code.