### PR TITLE
Make AI air squad target selection less predictable

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -78,6 +78,14 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Enemy target types to never target.")]
 		public readonly BitSet<TargetableType> IgnoredEnemyTargetTypes = default(BitSet<TargetableType>);
 
+		public override void RulesetLoaded(Ruleset rules, ActorInfo ai)
+		{
+			base.RulesetLoaded(rules, ai);
+
+			if (DangerScanRadius <= 0)
+				throw new YamlException("DangerScanRadius must be greater than zero.");
+		}
+
 		public override object Create(ActorInitializer init) { return new SquadManagerBotModule(init.Self, this); }
 	}
 

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
@@ -65,21 +65,19 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			var map = owner.World.Map;
 			var dangerRadius = owner.SquadManager.Info.DangerScanRadius;
 			detectedEnemyTarget = null;
-			var x = (map.MapSize.X % dangerRadius) == 0 ? map.MapSize.X : map.MapSize.X + dangerRadius;
-			var y = (map.MapSize.Y % dangerRadius) == 0 ? map.MapSize.Y : map.MapSize.Y + dangerRadius;
 
-			for (var i = 0; i < x; i += dangerRadius * 2)
+			var columnCount = (map.MapSize.X + dangerRadius - 1) / dangerRadius;
+			var rowCount = (map.MapSize.Y + dangerRadius - 1) / dangerRadius;
+			var checkIndices = Exts.MakeArray(columnCount * rowCount, i => i).Shuffle(owner.World.LocalRandom);
+			foreach (var i in checkIndices)
 			{
-				for (var j = 0; j < y; j += dangerRadius * 2)
+				var pos = new CPos((i % columnCount) * dangerRadius + dangerRadius / 2, (i / columnCount) * dangerRadius + dangerRadius / 2);
+				if (NearToPosSafely(owner, map.CenterOfCell(pos), out detectedEnemyTarget))
 				{
-					var pos = new CPos(i, j);
-					if (NearToPosSafely(owner, map.CenterOfCell(pos), out detectedEnemyTarget))
-					{
-						if (needTarget && detectedEnemyTarget == null)
-							continue;
+					if (needTarget && detectedEnemyTarget == null)
+						continue;
 
-						return pos;
-					}
+					return pos;
 				}
 			}
 


### PR DESCRIPTION
Currently, when looking for a target for its air squads, the AI will scan through the map starting at coordinates 0,0 column by column until finding a suitably unprotected target. This means these squads will overwhelmingly target actors to the left of all others, and tend to target actors nearer the top of the map if they happen to be at a similar y coordinate.

In team comp stomps it's particularly noticeable, as whichever player is on the left side tends to get all the air attacks.

This change makes the scan start at a random coordinate, continue to the bottom right corner, then go back to 0,0, continuing until it gets back to where it started. The result is that the AI will send out air squads in all directions.

Update: The change has been improved so that each scan will be done in a random direction (i.e. left & up, left & down, right & up or right & down).