### PR TITLE
refactor 'GlobalButtonOrderGenerator' 

### DIFF
--- a/OpenRA.Mods.Common/Orders/BeaconOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/BeaconOrderGenerator.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Orders
 {
-	public class BeaconOrderGenerator : OrderGenerator
+	public class BeaconOrderGenerator : GlobalButtonOrderGenerator
 	{
 		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
@@ -25,9 +25,6 @@ namespace OpenRA.Mods.Common.Orders
 				yield return new Order("PlaceBeacon", world.LocalPlayer.PlayerActor, Target.FromCell(world, cell), false) { SuppressVisualFeedback = true };
 		}
 
-		protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
-		protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
-		protected override IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world) { yield break; }
 		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
 			return "ability";

--- a/OpenRA.Mods.Common/Orders/PowerDownOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/PowerDownOrderGenerator.cs
@@ -1,0 +1,56 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System.Collections.Generic;
+using System.Linq;
+using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
+
+namespace OpenRA.Mods.Common.Orders
+{
+	public class PowerDownOrderGenerator : GlobalButtonOrderGenerator
+	{
+		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		{
+			if (mi.Button == MouseButton.Right)
+				world.CancelInputMode();
+
+			return OrderInner(world, mi);
+		}
+
+		protected bool IsValidTrait(ToggleConditionOnOrder t)
+		{
+			return !t.IsTraitDisabled && !t.IsTraitPaused;
+		}
+
+		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		{
+			mi.Button = MouseButton.Left;
+			return OrderInner(world, mi).Any() ? "powerdown" : "powerdown-blocked";
+		}
+
+		protected IEnumerable<Order> OrderInner(World world, MouseInput mi)
+		{
+			if (mi.Button == MouseButton.Left)
+			{
+				var underCursor = world.ScreenMap.ActorsAtMouse(mi)
+					.Select(a => a.Actor)
+					.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.TraitsImplementing<ToggleConditionOnOrder>()
+						.Any(IsValidTrait));
+
+				if (underCursor == null)
+					yield break;
+
+				yield return new Order("PowerDown", underCursor, false);
+			}
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/RepairOrderGenerator.cs
@@ -1,4 +1,4 @@
-#region Copyright & License Information
+﻿#region Copyright & License Information
 /*
  * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
  * This file is part of OpenRA, which is free software. It is made
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Orders
 {
-	public class RepairOrderGenerator : OrderGenerator
+	public class RepairOrderGenerator : GlobalButtonOrderGenerator
 	{
 		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{
@@ -82,10 +82,6 @@ namespace OpenRA.Mods.Common.Orders
 				world.LocalPlayer.WinState != WinState.Undefined)
 				world.CancelInputMode();
 		}
-
-		protected override IEnumerable<IRenderable> Render(WorldRenderer wr, World world) { yield break; }
-		protected override IEnumerable<IRenderable> RenderAboveShroud(WorldRenderer wr, World world) { yield break; }
-		protected override IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World world) { yield break; }
 
 		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
 		{

--- a/OpenRA.Mods.Common/Orders/SellOrderGenerator.cs
+++ b/OpenRA.Mods.Common/Orders/SellOrderGenerator.cs
@@ -1,0 +1,58 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenRA.Mods.Common.Traits;
+
+namespace OpenRA.Mods.Common.Orders
+{
+	public class SellOrderGenerator : GlobalButtonOrderGenerator
+	{
+		protected override IEnumerable<Order> OrderInner(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		{
+			if (mi.Button == MouseButton.Right)
+				world.CancelInputMode();
+
+			return OrderInner(world, mi);
+		}
+
+		protected IEnumerable<Order> OrderInner(World world, MouseInput mi)
+		{
+			if (mi.Button == MouseButton.Left)
+			{
+				var actor = world.ScreenMap.ActorsAtMouse(mi)
+					.Select(a => a.Actor)
+					.FirstOrDefault(a => a.Owner == world.LocalPlayer && a.AppearsFriendlyTo(world.LocalPlayer.PlayerActor)
+						&& a.TraitsImplementing<Sellable>().Any(IsValidTrait));
+
+				if (actor == null)
+					yield break;
+
+				yield return new Order("Sell", actor, false);
+			}
+		}
+
+		protected bool IsValidTrait(Sellable t)
+		{
+			return Exts.IsTraitEnabled(t);
+		}
+
+		protected override string GetCursor(World world, CPos cell, int2 worldPixel, MouseInput mi)
+		{
+			mi.Button = MouseButton.Left;
+			return OrderInner(world, mi).Any() ? "sell" : "sell-blocked";
+		}
+	}
+}


### PR DESCRIPTION
Modify the `GlobalButtonOrderGenerator`, make `RepairOrderGenerator` and `BeaconOrderGenerator` inherit it properly as an global command for global command panel, as well as makes classes which inherit it more readable&extensible.