### PR TITLE
Change syrf to syrd on the desert shellmap

### DIFF
--- a/mods/ra/maps/desert-shellmap/map.yaml
+++ b/mods/ra/maps/desert-shellmap/map.yaml
@@ -113,7 +113,7 @@ Actors:
 	Actor27: barl
 		Location: 42,45
 		Owner: Neutral
-	Actor333: syrf
+	Actor333: syrd
 		Location: 67,95
 		Owner: Allies
 	Actor53: brik


### PR DESCRIPTION
Since the fake tag is now visible.