### PR TITLE
Fixed Red Alert 2 bots not building Navy

### DIFF
--- a/OpenRA.Mods.Common/AIUtils.cs
+++ b/OpenRA.Mods.Common/AIUtils.cs
@@ -22,8 +22,10 @@ namespace OpenRA.Mods.Common
 
 	public static class AIUtils
 	{
-		public static bool IsAreaAvailable<T>(World world, Player player, Map map, int radius, HashSet<string> terrainTypes)
+		public static bool IsAreaAvailable<T>(World world, Player player, Map map, BaseBuilderBotModule baseBuilder)
 		{
+			var radius = baseBuilder.Info.MaxBaseRadius;
+			var terrainTypes = baseBuilder.Info.WaterTerrainTypes;
 			var cells = world.ActorsHavingTrait<T>().Where(a => a.Owner == player);
 
 			// TODO: Properly check building foundation rather than 3x3 area.

--- a/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BaseBuilderBotModule.cs
@@ -9,11 +9,9 @@
  */
 #endregion
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using OpenRA.Support;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (waterState == WaterCheck.NotChecked)
 			{
-				if (AIUtils.IsAreaAvailable<BaseBuilding>(world, player, world.Map, baseBuilder.Info.MaxBaseRadius, baseBuilder.Info.WaterTerrainTypes))
+				if (AIUtils.IsAreaAvailable<BaseBuilding>(world, player, world.Map, baseBuilder))
 					waterState = WaterCheck.EnoughWater;
 				else
 				{
@@ -255,7 +255,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Only consider building this if there is enough water inside the base perimeter and there are close enough adjacent buildings
 			if (waterState == WaterCheck.EnoughWater && baseBuilder.Info.NewProductionCashThreshold > 0
 				&& playerResources.Resources > baseBuilder.Info.NewProductionCashThreshold
-				&& AIUtils.IsAreaAvailable<GivesBuildableArea>(world, player, world.Map, baseBuilder.Info.CheckForWaterRadius, baseBuilder.Info.WaterTerrainTypes))
+				&& AIUtils.IsAreaAvailable<GivesBuildableArea>(world, player, world.Map, baseBuilder))
 			{
 				var navalproduction = GetProducibleBuilding(baseBuilder.Info.NavalProductionTypes, buildableThings);
 				if (navalproduction != null && HasSufficientPowerForActor(navalproduction))
@@ -316,7 +316,7 @@ namespace OpenRA.Mods.Common.Traits
 				// TODO: Extend this check to cover any naval structure, not just production.
 				if (baseBuilder.Info.NavalProductionTypes.Contains(name)
 					&& (waterState == WaterCheck.NotEnoughWater
-						|| !AIUtils.IsAreaAvailable<GivesBuildableArea>(world, player, world.Map, baseBuilder.Info.CheckForWaterRadius, baseBuilder.Info.WaterTerrainTypes)))
+						|| !AIUtils.IsAreaAvailable<GivesBuildableArea>(world, player, world.Map, baseBuilder)))
 					continue;
 
 				// Will this put us into low power?

--- a/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/BotModuleLogic/BaseBuilderQueueManager.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (waterState == WaterCheck.NotChecked)
 			{
-				if (AIUtils.IsAreaAvailable<BaseProvider>(world, player, world.Map, baseBuilder.Info.MaxBaseRadius, baseBuilder.Info.WaterTerrainTypes))
+				if (AIUtils.IsAreaAvailable<BaseBuilding>(world, player, world.Map, baseBuilder.Info.MaxBaseRadius, baseBuilder.Info.WaterTerrainTypes))
 					waterState = WaterCheck.EnoughWater;
 				else
 				{
@@ -83,8 +83,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			if (waterState == WaterCheck.NotEnoughWater && --checkForBasesTicks <= 0)
 			{
-				var currentBases = world.ActorsHavingTrait<BaseProvider>().Count(a => a.Owner == player);
-
+				var currentBases = world.ActorsHavingTrait<BaseBuilding>().Count(a => a.Owner == player);
 				if (currentBases > cachedBases)
 				{
 					cachedBases = currentBases;


### PR DESCRIPTION
Addresses https://github.com/OpenRA/ra2/issues/695.

![image](https://user-images.githubusercontent.com/756669/77796553-ce1e6280-706f-11ea-94ab-2ae3fa079af7.png)

The issue turns out simple. The RA2 mod does not use `BaseProvider` to restrict players so this trait is missing from the construction yard. I therefore fall back to `BaseBuilding` which immediately fixes the issue.