### PR TITLE
Actors can only be built by AI players

### DIFF
--- a/OpenRA.Mods.Common/Traits/Buildable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildable.cs
@@ -34,6 +34,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Force a specific faction variant, overriding the faction of the producing actor.")]
 		public readonly string ForceFaction = null;
 
+		[Desc("Only Bots can produce this actor. Detailed control is possible for bot when just devs just edit the yaml files")]
+		public readonly bool BotOnly = false;
+
 		[SequenceReference]
 		[Desc("Sequence of the actor that contains the icon.")]
 		public readonly string Icon = "icon";

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -259,7 +259,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (developerMode.AllTech)
 				return Producible.Keys;
 
-			return allProducibles;
+			if (self.Owner.IsBot)
+				return allProducibles;
+			else
+				return allProducibles.Select(a => a).Where(a => a.TraitInfo<BuildableInfo>().BotOnly == false);
 		}
 
 		public virtual IEnumerable<ActorInfo> BuildableItems()
@@ -271,7 +274,10 @@ namespace OpenRA.Mods.Common.Traits
 			if (developerMode.AllTech)
 				return Producible.Keys;
 
-			return buildableProducibles;
+			if (self.Owner.IsBot)
+				return buildableProducibles;
+			else
+				return buildableProducibles.Select(a => a).Where(a => a.TraitInfo<BuildableInfo>().BotOnly == false);
 		}
 
 		public bool CanBuild(ActorInfo actor)


### PR DESCRIPTION
Introducing a new factor in `Buildable`, make certain actors can be only built by bot players.

Although there is no usecase for now in RA, This pr can be useful in making AI, and **avoid modifying in engine code** for AI logic support. For example:

1. You can make a copy of a long range attack unit that almost the same only for AI, but its weapon minimum range is longer than orignal one. Then AI will have to use it kiting the player's units within safe distance for the minimum range, and escape before player's units chasing it down. Like a kiting Tesla tank or V2.

2. You can make almost the same SPY unit for AI, but he will both use his disguise tools in a long range, and kill enemy infantary along his way, automatically. 

3. You can make almost the same transport unit but have initial cargos. When attack, it also has a fake weapon triggering deploy when enemy within range. (You can make weapon can't be use if hijacked)

4. You can make almost the same units originaly has spceial skill, but now they will not trigging it by press F, but use it by fake weapon or directly under permission of condition. For example, you can make AI defences powerdown themselves when base is low on power (make them uncapturable), or a Chorno Tank will blink along the way when charging is done.

