### PR TITLE
Added adaptive order latency [POC/WIP]

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -585,7 +585,7 @@ namespace OpenRA
 
 					var isNetTick = LocalTick % NetTickScale == 0;
 
-					if (!isNetTick || orderManager.IsReadyForNextFrame())
+					if (!isNetTick || orderManager.CheckIsReadyForNextFrame())
 					{
 						++orderManager.LocalFrameNumber;
 

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -585,7 +585,7 @@ namespace OpenRA
 
 					var isNetTick = LocalTick % NetTickScale == 0;
 
-					if (!isNetTick || orderManager.IsReadyForNextFrame)
+					if (!isNetTick || orderManager.IsReadyForNextFrame())
 					{
 						++orderManager.LocalFrameNumber;
 

--- a/OpenRA.Game/Network/Connection.cs
+++ b/OpenRA.Game/Network/Connection.cs
@@ -89,7 +89,9 @@ namespace OpenRA.Network
 		{
 			if (packet.Length == 0)
 				throw new NotImplementedException();
-			AddPacket(new ReceivedPacket { FromClient = LocalClientId, Data = packet });
+
+			// TODO replace overridden method with acking system
+			// AddPacket(new ReceivedPacket { FromClient = LocalClientId, Data = packet });
 		}
 
 		protected void AddPacket(ReceivedPacket packet)

--- a/OpenRA.Game/Network/FrameData.cs
+++ b/OpenRA.Game/Network/FrameData.cs
@@ -87,7 +87,7 @@ namespace OpenRA.Network
 		public int BufferSizeForClient(int frame, int client)
 		{
 			return framePackets
-				.Where(x => frame < x.Key)
+				.Where(x => x.Key >= frame)
 				.Where(x => x.Value.ContainsKey(client))
 				.Count();
 		}

--- a/OpenRA.Game/Network/FrameData.cs
+++ b/OpenRA.Game/Network/FrameData.cs
@@ -72,10 +72,24 @@ namespace OpenRA.Network
 			var clientData = ClientsPlayingInFrame(frame)
 				.ToDictionary(k => k, v => frameData[v]);
 
-			return clientData
+			var orders = clientData
 				.SelectMany(x => x.Value
 					.ToOrderList(world)
 					.Select(o => new ClientOrder { Client = x.Key, Order = o }));
+
+			// TODO hand off frame packets to SyncReport
+			// TODO consider how to handle clients quitting in this representation
+			// framePackets.Remove(frame);
+			// clientQuitTimes.Remove(frame);
+			return orders;
+		}
+
+		public int BufferSizeForClient(int frame, int client)
+		{
+			return framePackets
+				.Where(x => frame < x.Key)
+				.Where(x => x.Value.ContainsKey(client))
+				.Count();
 		}
 	}
 }

--- a/OpenRA.Game/Network/LatencyTracker.cs
+++ b/OpenRA.Game/Network/LatencyTracker.cs
@@ -1,0 +1,182 @@
+#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Network
+{
+	public interface ILatencyReporter
+	{
+		int Latency { get; }
+		double Jitter { get; }
+		int PeakJitter { get; }
+	}
+
+	public interface ILatencyTracker
+	{
+		void TrackSend(int frame);
+		void TrackAck(int frame);
+	}
+
+	public class OrderLatencyTracker : ILatencyReporter, ILatencyTracker
+	{
+		const int MaxBufferSize = 1000;
+
+		const int DefaultJitterLength = 1000;
+		const int DefaultPeakJitterHold = 1000;
+
+		struct JitterEntry
+		{
+			public long EntryTime;
+			public int Jitter;
+		}
+
+		readonly Queue<JitterEntry> jitterEntries = new Queue<JitterEntry>();
+
+		struct FrameToAck
+		{
+			public long entryTime;
+			public int frame; // Not strictly required, used for sanity checking
+		}
+
+		readonly Queue<FrameToAck> framesToAck = new Queue<FrameToAck>();
+
+		int lastLatency;
+		readonly int jitterLength;
+		readonly int peakJitterHold;
+
+		public OrderLatencyTracker(int jitterLength = DefaultJitterLength, int peakJitterHold = DefaultPeakJitterHold)
+		{
+			this.jitterLength = jitterLength;
+			this.peakJitterHold = peakJitterHold;
+		}
+
+		public void TrackSend(int frame)
+		{
+			if (framesToAck.Count > MaxBufferSize)
+				return;
+
+			framesToAck.Enqueue(new FrameToAck
+			{
+				entryTime = Game.RunTime,
+				frame = frame
+			});
+		}
+
+		public void TrackAck(int frame)
+		{
+			var currentTime = Game.RunTime;
+
+			var entryToAck = framesToAck.Dequeue();
+			if (frame < entryToAck.frame)
+			{
+				return; // We probably had to drop this frame to avoid overloading the buffer
+			}
+
+			if (frame > entryToAck.frame)
+			{
+				throw new InvalidOperationException("Missed an ack");
+			}
+
+			var currentLatency = (int)(currentTime - entryToAck.entryTime);
+
+			jitterEntries.Enqueue(new JitterEntry
+			{
+				EntryTime = currentTime,
+				Jitter = currentLatency - lastLatency
+			});
+
+			lastLatency = currentLatency;
+		}
+
+		public int Latency
+		{
+			get
+			{
+				if (framesToAck.Count == 0)
+					return lastLatency;
+
+				var currentLatency = (int)(Game.RunTime - framesToAck.Peek().entryTime);
+				if (currentLatency > lastLatency)
+				{
+					return currentLatency;
+				}
+				else
+					return lastLatency;
+			}
+		}
+
+		void DropIrrelevantJitterPackets()
+		{
+			var absoluteCutoff = Game.RunTime - Math.Max(jitterLength, peakJitterHold);
+			var countToDrop = 0;
+			foreach (var e in jitterEntries)
+				if (e.EntryTime < absoluteCutoff)
+					countToDrop++;
+				else
+					break;
+
+			for (int i = 0; i < countToDrop; ++i)
+				jitterEntries.Dequeue();
+		}
+
+		public double Jitter
+		{
+			get
+			{
+				DropIrrelevantJitterPackets();
+				var currentLatency = Latency;
+				var expiryTime = Game.RunTime - jitterLength;
+
+				var selected = 0;
+				var jitterSum = jitterEntries.Where(x => x.EntryTime >= expiryTime).Select(x =>
+				{
+					selected++;
+					return Math.Abs(x.Jitter);
+				}).Sum();
+
+				var currentJitter = (double)(jitterSum + currentLatency - lastLatency) / (selected + 1);
+				if (selected == 0)
+					return currentJitter;
+
+				var realJitter = (double)jitterSum / selected;
+				return currentJitter > realJitter ? currentJitter : realJitter;
+			}
+		}
+
+		public int PeakJitter
+		{
+			get
+			{
+				DropIrrelevantJitterPackets();
+
+				var currentJitter = Latency - lastLatency;
+				var expiryTime = Game.RunTime - peakJitterHold;
+
+				return Math.Max(
+					jitterEntries.Where(x => x.EntryTime >= expiryTime)
+						.Select(x => x.Jitter).DefaultIfEmpty(0).Max(),
+					currentJitter);
+			}
+		}
+	}
+
+	public class EmptyLatencyReporter : ILatencyReporter
+	{
+		public static readonly ILatencyReporter Instance = new EmptyLatencyReporter();
+
+		public int Latency { get { return 0; } }
+		public double Jitter { get { return 0; } }
+		public int PeakJitter { get { return 0; } }
+	}
+}

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -19,7 +19,6 @@ namespace OpenRA.Network
 {
 	public sealed class OrderManager : IDisposable
 	{
-		private static readonly List<byte[]> BLANK = new List<byte[]>();
 		static readonly IEnumerable<Session.Client> NoClients = new Session.Client[] { };
 
 		readonly SyncReport syncReport;
@@ -244,7 +243,7 @@ namespace OpenRA.Network
 			while (NextOrderFrame < NetFrameNumber + OrderLatency)
 			{
 				if (GameSaveLastFrame < NextOrderFrame)
-					Connection.Send(NextOrderFrame, BLANK);
+					Connection.Send(NextOrderFrame, Enumerable.Empty<byte[]>());
 				NextOrderFrame++;
 			}
 		}
@@ -298,7 +297,9 @@ namespace OpenRA.Network
 			foreach (var c in frameData.ClientsPlayingInFrame(NetFrameNumber))
 				buffers.Add(c, frameData.BufferSizeForClient(NetFrameNumber, c));
 
-			NetHistory.Tick(new NetHistoryFrame(NetFrameNumber, OrderLatency, isReadyForNextFrame, buffers));
+			NetHistory.Tick(new NetHistoryFrame(NetFrameNumber, OrderLatency, isReadyForNextFrame, buffers,
+				Connection.LatencyReporter.Latency, Connection.LatencyReporter.Jitter,
+				Connection.LatencyReporter.PeakJitter)); // TODO don't calculate twice
 		}
 
 		public void Dispose()

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -197,6 +197,7 @@ namespace OpenRA.Network
 					// Force us to be unable to attempt to decrease latency until we've seen at least a round-trip
 					catchupCooldown = OrderLatency + 1;
 				}
+
 				isReadyForNextFrame = false;
 			}
 
@@ -253,7 +254,7 @@ namespace OpenRA.Network
 			// When we are lowering latency, we buffer orders
 			if (NextOrderFrame > NetFrameNumber + OrderLatency)
 				return;
-			
+
 			SendLatencyCompensation();
 
 			Connection.Send(NextOrderFrame, localOrders.Select(o => o.Serialize()).ToList());

--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -125,7 +125,7 @@ namespace OpenRA.Network
 				}
 			}
 
-			ordersFrame = LobbyInfo.GlobalSettings.OrderLatency;
+			ordersFrame = LobbyInfo.GlobalSettings.OrderLatency; // TODO Fix when adaptive order latency is on
 		}
 
 		// Do nothing: ignore locally generated orders
@@ -154,6 +154,11 @@ namespace OpenRA.Network
 			while (chunks.Count != 0 && chunks.Peek().Frame <= ordersFrame)
 				foreach (var o in chunks.Dequeue().Packets)
 					packetFn(o.First, o.Second);
+		}
+
+		public int LastAckedFrame
+		{
+			get { return ordersFrame;  }
 		}
 
 		public void Dispose() { }

--- a/OpenRA.Game/Network/ReplayConnection.cs
+++ b/OpenRA.Game/Network/ReplayConnection.cs
@@ -38,6 +38,11 @@ namespace OpenRA.Network
 		public readonly Session LobbyInfo;
 		public readonly string Filename;
 
+		public ILatencyReporter LatencyReporter
+		{
+			get { return EmptyLatencyReporter.Instance; }
+		}
+
 		public ReplayConnection(string replayFilename)
 		{
 			Filename = replayFilename;
@@ -124,7 +129,7 @@ namespace OpenRA.Network
 		}
 
 		// Do nothing: ignore locally generated orders
-		public void Send(int frame, List<byte[]> orders) { }
+		public void Send(int frame, IEnumerable<byte[]> orders) { }
 		public void SendImmediate(IEnumerable<byte[]> orders) { }
 
 		public void SendSync(int frame, byte[] syncData)

--- a/OpenRA.Game/Network/UnitOrders.cs
+++ b/OpenRA.Game/Network/UnitOrders.cs
@@ -352,9 +352,9 @@ namespace OpenRA.Network
 
 		static void SetOrderLag(OrderManager o)
 		{
-			if (o.FramesAhead != o.LobbyInfo.GlobalSettings.OrderLatency && !o.GameStarted)
+			if (o.OrderLatency != o.LobbyInfo.GlobalSettings.OrderLatency && !o.GameStarted)
 			{
-				o.FramesAhead = o.LobbyInfo.GlobalSettings.OrderLatency;
+				o.OrderLatency = o.LobbyInfo.GlobalSettings.OrderLatency;
 				Log.Write("server", "Order lag is now {0} frames.", o.LobbyInfo.GlobalSettings.OrderLatency);
 			}
 		}

--- a/OpenRA.Game/Server/ProtocolVersion.cs
+++ b/OpenRA.Game/Server/ProtocolVersion.cs
@@ -34,6 +34,11 @@ namespace OpenRA.Server
 		//   - OrderFields enum encoded as a byte: specifies the data included in the rest of the order
 		//   - Order-specific data - see OpenRA.Game/Server/Order.cs for details
 		//
+		// When the frame of a packet is 0, it is an immediate order, and may or may not be relayed to clients e.g. chat
+		//
+		// When the frame is not 0, it will always be relayed to all clients
+		// and a blank packet sent to the sender to act as an ack (used by adaptive order latency)
+		//
 		// A connection handshake begins when a client opens a connection to the server:
 		// - Server sends:
 		//   - Int32 specifying the handshake protocol version

--- a/OpenRA.Game/Server/ProtocolVersion.cs
+++ b/OpenRA.Game/Server/ProtocolVersion.cs
@@ -66,6 +66,6 @@ namespace OpenRA.Server
 		// The protocol for server and world orders
 		// This applies after the handshake has completed, and is provided to support
 		// alternative server implementations that wish to support multiple versions in parallel
-		public const int Orders = 10;
+		public const int Orders = 11;
 	}
 }

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -592,8 +592,12 @@ namespace OpenRA.Server
 		public void DispatchOrdersToClients(Connection conn, int frame, byte[] data)
 		{
 			var from = conn != null ? conn.PlayerIndex : 0;
-			foreach (var c in Conns.Except(conn).ToList())
+
+			// foreach (var c in Conns.Except(conn).ToList())
+			foreach (var c in Conns.ToList())
 				DispatchOrdersToClient(c, from, frame, data);
+
+			// TODO just ack with blank packet rather than relaying all data
 		}
 
 		public void DispatchOrders(Connection conn, int frame, byte[] data)

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -103,6 +103,12 @@ namespace OpenRA
 		[Desc("Display a graph with various profiling traces")]
 		public bool PerfGraph = false;
 
+		[Desc("Display net text")]
+		public bool NetText = false;
+
+		[Desc("Display a graph with various network state information")]
+		public bool NetGraph = false;
+
 		[Desc("Numer of samples to average over when calculating tick and render times.")]
 		public int Samples = 25;
 

--- a/OpenRA.Game/Support/NetHistory.cs
+++ b/OpenRA.Game/Support/NetHistory.cs
@@ -56,18 +56,30 @@ namespace OpenRA.Support
 		public Dictionary<int, int> ClientBufferSizes;
 		public int OrderLatency;
 		public bool Ticked;
+		public int MeasuredLatency;
+		public double MeasuredJitter;
+		public int PeakJitter;
 
 		public int CurrentClientBufferSize
 		{
 			get { return ClientBufferSizes[NetHistory.CurrentClientId]; }
 		}
 
-		public NetHistoryFrame(int netFrameNumber, int orderLatency, bool ticked, Dictionary<int, int> clientBufferSizes)
+		public NetHistoryFrame(int netFrameNumber,
+			int orderLatency,
+			bool ticked,
+			Dictionary<int, int> clientBufferSizes,
+			int measuredLatency,
+			double measuredJitter,
+			int peakJitter)
 		{
 			NetFrameNumber = netFrameNumber;
 			OrderLatency = orderLatency;
 			Ticked = ticked;
 			ClientBufferSizes = clientBufferSizes;
+			MeasuredLatency = measuredLatency;
+			MeasuredJitter = measuredJitter;
+			PeakJitter = peakJitter;
 		}
 	}
 }

--- a/OpenRA.Game/Support/NetHistory.cs
+++ b/OpenRA.Game/Support/NetHistory.cs
@@ -56,6 +56,7 @@ namespace OpenRA.Support
 		public Dictionary<int, int> ClientBufferSizes;
 		public int OrderLatency;
 		public bool Ticked;
+		public int CatchUpNetFrames;
 		public int MeasuredLatency;
 		public double MeasuredJitter;
 		public int PeakJitter;
@@ -68,6 +69,7 @@ namespace OpenRA.Support
 		public NetHistoryFrame(int netFrameNumber,
 			int orderLatency,
 			bool ticked,
+			int catchUpNetFrames,
 			Dictionary<int, int> clientBufferSizes,
 			int measuredLatency,
 			double measuredJitter,
@@ -76,6 +78,7 @@ namespace OpenRA.Support
 			NetFrameNumber = netFrameNumber;
 			OrderLatency = orderLatency;
 			Ticked = ticked;
+			CatchUpNetFrames = catchUpNetFrames;
 			ClientBufferSizes = clientBufferSizes;
 			MeasuredLatency = measuredLatency;
 			MeasuredJitter = measuredJitter;

--- a/OpenRA.Game/Support/NetHistory.cs
+++ b/OpenRA.Game/Support/NetHistory.cs
@@ -1,0 +1,73 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+
+namespace OpenRA.Support
+{
+	public class NetHistory
+	{
+		public const int DefaultNetHistoryLength = 100;
+
+		public static int CurrentClientId { get; protected set; }
+		public static int NetHistoryLength { get; protected set; }
+
+		private static int head = 0, currentLength;
+
+		private static NetHistoryFrame[] frameHistory;
+
+		public static void Restart(int currentClientId, int historyLength = DefaultNetHistoryLength)
+		{
+			CurrentClientId = currentClientId;
+			NetHistoryLength = historyLength;
+			frameHistory = new NetHistoryFrame[NetHistoryLength];
+			head = 0;
+			currentLength = 0;
+		}
+
+		public static void Tick(NetHistoryFrame netHistoryFrame)
+		{
+			frameHistory[head] = netHistoryFrame;
+			if (++head >= NetHistoryLength)
+				head = 0;
+			if (++currentLength >= NetHistoryLength)
+				currentLength = NetHistoryLength - 1;
+		}
+
+		public static IEnumerable<NetHistoryFrame> GetHistory()
+		{
+			for (int i = head - 1; i >= head - currentLength; i--)
+				yield return frameHistory[i < 0 ? i + NetHistoryLength : i];
+		}
+	}
+
+	public class NetHistoryFrame
+	{
+		public int NetFrameNumber;
+		public Dictionary<int, int> ClientBufferSizes;
+		public int OrderLatency;
+		public bool Ticked;
+
+		public int CurrentClientBufferSize
+		{
+			get { return ClientBufferSizes[NetHistory.CurrentClientId]; }
+		}
+
+		public NetHistoryFrame(int netFrameNumber, int orderLatency, bool ticked, Dictionary<int, int> clientBufferSizes)
+		{
+			NetFrameNumber = netFrameNumber;
+			OrderLatency = orderLatency;
+			Ticked = ticked;
+			ClientBufferSizes = clientBufferSizes;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePerfLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/LoadIngamePerfLogic.cs
@@ -20,6 +20,9 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 		{
 			var perfRoot = widget.Get("PERF_ROOT");
 			Game.LoadWidget(world, "PERF_WIDGETS", perfRoot, new WidgetArgs());
+
+			var netRoot = widget.Get("NET_ROOT");
+			Game.LoadWidget(world, "NET_WIDGETS", netRoot, new WidgetArgs());
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Widgets/Logic/NetDebugLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/NetDebugLogic.cs
@@ -36,11 +36,13 @@ namespace OpenRA.Mods.Common.Widgets.Logic
                         var history = historyE.Current;
                         return String.Format("Order latency: {0}\n" +
                             "Ticked: {1}\n" +
-                            "Self buffer size: {2}\n" +
-	                        "{3}ms (+/- {4:F1}ms)\n" +
-                            "peak+delta: {5}ms",
+                            "To Catchup: {2}\n" +
+                            "Self buffer size: {3}\n" +
+	                        "{4}ms (+/- {5:F1}ms)\n" +
+                            "peak+delta: {6}ms",
                             history.OrderLatency,
                             history.Ticked,
+                            history.CatchUpNetFrames,
                             history.CurrentClientBufferSize,
                             history.MeasuredLatency,
                             history.MeasuredJitter,

--- a/OpenRA.Mods.Common/Widgets/Logic/NetDebugLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/NetDebugLogic.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System;
+using OpenRA.Mods.Common.UtilityCommands;
 using OpenRA.Support;
 using OpenRA.Widgets;
 
@@ -33,12 +34,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
                     if (historyE.MoveNext())
                     {
                         var history = historyE.Current;
-                        return string.Format("Order latency: {0}\n" +
+                        return String.Format("Order latency: {0}\n" +
                             "Ticked: {1}\n" +
-                            "Self buffer size: {2}",
+                            "Self buffer size: {2}\n" +
+	                        "{3}ms (+/- {4:F1}ms)\n" +
+                            "peak+delta: {5}ms",
                             history.OrderLatency,
                             history.Ticked,
-                            history.CurrentClientBufferSize);
+                            history.CurrentClientBufferSize,
+                            history.MeasuredLatency,
+                            history.MeasuredJitter,
+                            history.PeakJitter);
                     }
                     else
                         return "Waiting for net history";

--- a/OpenRA.Mods.Common/Widgets/Logic/NetDebugLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/NetDebugLogic.cs
@@ -1,0 +1,49 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using OpenRA.Support;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common.Widgets.Logic
+{
+    public class NetDebugLogic : ChromeLogic
+    {
+        [ObjectCreator.UseCtor]
+        public NetDebugLogic(Widget widget)
+        {
+            var netGraph = widget.Get("GRAPH_BG");
+            netGraph.IsVisible = () => Game.Settings.Debug.NetGraph;
+
+            var netText = widget.Get<LabelWidget>("NET_TEXT");
+            netText.IsVisible = () => Game.Settings.Debug.NetText;
+
+            netText.GetText = () =>
+            {
+                using (var historyE = NetHistory.GetHistory().GetEnumerator())
+                {
+                    if (historyE.MoveNext())
+                    {
+                        var history = historyE.Current;
+                        return string.Format("Order latency: {0}\n" +
+                            "Ticked: {1}\n" +
+                            "Self buffer size: {2}",
+                            history.OrderLatency,
+                            history.Ticked,
+                            history.CurrentClientBufferSize);
+                    }
+                    else
+                        return "Waiting for net history";
+                }
+            };
+        }
+    }
+}

--- a/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/SettingsLogic.cs
@@ -669,6 +669,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			BindCheckboxPref(panel, "NAT_DISCOVERY", ss, "DiscoverNatDevices");
 			BindCheckboxPref(panel, "PERFTEXT_CHECKBOX", ds, "PerfText");
 			BindCheckboxPref(panel, "PERFGRAPH_CHECKBOX", ds, "PerfGraph");
+			BindCheckboxPref(panel, "NETTEXT_CHECKBOX", ds, "NetText");
+			BindCheckboxPref(panel, "NETGRAPH_CHECKBOX", ds, "NetGraph");
 			BindCheckboxPref(panel, "FETCH_NEWS_CHECKBOX", gs, "FetchNews");
 			BindCheckboxPref(panel, "SENDSYSINFO_CHECKBOX", ds, "SendSystemInformation");
 			BindCheckboxPref(panel, "CHECK_VERSION_CHECKBOX", ds, "CheckVersion");
@@ -701,6 +703,8 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				ss.DiscoverNatDevices = dss.DiscoverNatDevices;
 				ds.PerfText = dds.PerfText;
 				ds.PerfGraph = dds.PerfGraph;
+				ds.NetText = dds.NetText;
+				ds.NetGraph = dds.NetGraph;
 				ds.SyncCheckUnsyncedCode = dds.SyncCheckUnsyncedCode;
 				ds.SyncCheckBotModuleCode = dds.SyncCheckBotModuleCode;
 				ds.BotDebug = dds.BotDebug;

--- a/OpenRA.Mods.Common/Widgets/NetGraphWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/NetGraphWidget.cs
@@ -45,10 +45,18 @@ namespace OpenRA.Mods.Common
 
 					for (int i = 0; it.MoveNext(); i++)
 					{
+						// Catchup
+						cr.DrawLine(
+							u + new float2(i, previous.CatchUpNetFrames) * basis,
+							u + new float2(i + 1, it.Current.CatchUpNetFrames) * basis,
+							1, Color.Aqua);
+
+						// Order latency
 						cr.DrawLine(
 							u + new float2(i, previous.OrderLatency) * basis,
 							u + new float2(i + 1, it.Current.OrderLatency) * basis,
 							1, it.Current.Ticked ? Color.Green : (it.Current.CurrentClientBufferSize > 0 ? Color.Orange : Color.Red));
+
 						previous = it.Current;
 					}
 				}

--- a/OpenRA.Mods.Common/Widgets/NetGraphWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/NetGraphWidget.cs
@@ -1,0 +1,58 @@
+﻿#region Copyright & License Information
+/*
+ * Copyright 2007-2020 The OpenRA Developers (see AUTHORS)
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using OpenRA.Primitives;
+using OpenRA.Support;
+using OpenRA.Widgets;
+
+namespace OpenRA.Mods.Common
+{
+	public class NetGraphWidget : Widget
+	{
+		private const float OrderLatencyScale = 25;
+
+		public override void Draw()
+		{
+			var cr = Game.Renderer.RgbaColorRenderer;
+			var rect = RenderBounds;
+			var origin = new float2(rect.Right, rect.Bottom);
+			var basis = new float2(
+				(float)rect.Width / (float)NetHistory.NetHistoryLength,
+				-(float)rect.Height / OrderLatencyScale);
+
+			cr.DrawLine(new[]
+			{
+				new float3(rect.Left, rect.Top, 0),
+				new float3(rect.Left, rect.Bottom, 0),
+				new float3(rect.Right, rect.Bottom, 0)
+			}, 1, Color.White);
+
+			var u = new float2(rect.Left, rect.Bottom);
+
+			using (var it = NetHistory.GetHistory().GetEnumerator())
+			{
+				if (it.MoveNext())
+				{
+					var previous = it.Current;
+
+					for (int i = 0; it.MoveNext(); i++)
+					{
+						cr.DrawLine(
+							u + new float2(i, previous.OrderLatency) * basis,
+							u + new float2(i + 1, it.Current.OrderLatency) * basis,
+							1, it.Current.Ticked ? Color.Green : (it.Current.CurrentClientBufferSize > 0 ? Color.Orange : Color.Red));
+						previous = it.Current;
+					}
+				}
+			}
+		}
+	}
+}

--- a/mods/cnc/chrome/ingame.yaml
+++ b/mods/cnc/chrome/ingame.yaml
@@ -38,6 +38,7 @@ Container@INGAME_ROOT:
 					X: WINDOW_RIGHT / 2
 					Y: 40
 				Container@PERF_ROOT:
+				Container@NET_ROOT:
 				WorldInteractionController@INTERACTION_CONTROLLER:
 					Width: WINDOW_RIGHT
 					Height: WINDOW_BOTTOM
@@ -68,6 +69,29 @@ Container@PERF_WIDGETS:
 				PerfGraph@GRAPH:
 					X: 10
 					Y: 10
+					Width: 200
+					Height: 200
+
+Container@NET_WIDGETS:
+	Logic: NetDebugLogic
+	Children:
+		Label@NET_TEXT:
+			X: 10
+			Y: 420
+			Width: 170
+			Height: 40
+			Contrast: true
+		Background@GRAPH_BG:
+			ClickThrough: true
+			Background: dialog4
+			X: 10
+			Y: 200
+			Width: 210
+			Height: 210
+			Children:
+				NetGraph@GRAPH:
+					X: 5
+					Y: 5
 					Width: 200
 					Height: 200
 

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -762,6 +762,20 @@ Container@SETTINGS_PANEL:
 							Height: 20
 							Font: Regular
 							Text: Show Performance Graph
+						Checkbox@NETTEXT_CHECKBOX:
+							X: 15
+							Y: 133
+							Width: 300
+							Height: 20
+							Font: Regular
+							Text: Show Network Text
+						Checkbox@NETGRAPH_CHECKBOX:
+							X: 15
+							Y: 163
+							Width: 300
+							Height: 20
+							Font: Regular
+							Text: Show Network Graph
 						Checkbox@FETCH_NEWS_CHECKBOX:
 							X: 310
 							Y: 43

--- a/mods/common/chrome/ingame.yaml
+++ b/mods/common/chrome/ingame.yaml
@@ -61,6 +61,7 @@ Container@INGAME_ROOT:
 					Y: 40
 				Container@PLAYER_ROOT:
 				Container@PERF_ROOT:
+				Container@NET_ROOT:
 		Container@MENU_ROOT:
 		TooltipContainer@TOOLTIP_CONTAINER:
 		MouseAttachment@MOUSE_ATTATCHMENT:

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -760,6 +760,20 @@ Background@SETTINGS_PANEL:
 					Height: 20
 					Font: Regular
 					Text: Show Performance Graph
+				Checkbox@NETTEXT_CHECKBOX:
+					X: 15
+					Y: 133
+					Width: 300
+					Height: 20
+					Font: Regular
+					Text: Show Network Text
+				Checkbox@NETGRAPH_CHECKBOX:
+					X: 15
+					Y: 163
+					Width: 300
+					Height: 20
+					Font: Regular
+					Text: Show Network Graph
 				Checkbox@FETCH_NEWS_CHECKBOX:
 					X: 310
 					Y: 43


### PR DESCRIPTION
fix #17882 

Opening a draft pull request so people can find this POC easily.

This is a quick nightly hack to add adaptive order latency, but it works very well already. After a brief stabilization period, clients with over 1 sec of latency stop causing slowdown and everyone can run at full speed again. It appears to be able to stabilise at only 1 frame of order latency too, so players with good connections stand to benefit from minimal latency in most games.

I experimented with both approaches in the issue description and discovered that clients basing their order latency on their round-trip to the server was indeed much more stable and easier to reason about when debugging. The current implementation changes a couple of lines to cause the client to actually wait for a full echo of their own data.

My plan is to replace this with empty acks (server echos an empty order frame rather than a full echo and client buffers their data in the connection until received) and then work on improving the algorithm to decrease stabilisation time and effect of jitter (currently performs okay under jitter). I am also considering whether or not to add catch-up now.