### PR TITLE
Fixed a crash when multiple ResourceRenderer traits are used

### DIFF
--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -87,14 +87,15 @@ namespace OpenRA.Mods.Common.Widgets
 		};
 
 		readonly Lazy<TooltipContainerWidget> tooltipContainer;
+		readonly World world;
+		readonly WorldRenderer worldRenderer;
+
 		int2? joystickScrollStart, joystickScrollEnd;
 		int2? standardScrollStart;
 		bool isStandardScrolling;
 
 		ScrollDirection keyboardDirections;
 		ScrollDirection edgeDirections;
-		readonly World world;
-		readonly WorldRenderer worldRenderer;
 
 		HotkeyReference[] saveBookmarkHotkeys;
 		HotkeyReference[] restoreBookmarkHotkeys;

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Widgets
 	public class ViewportControllerWidget : Widget
 	{
 		readonly ModData modData;
-		readonly ResourceRenderer resourceRenderer;
+		readonly IEnumerable<ResourceRenderer> resourceRenderers;
 
 		public readonly HotkeyReference ZoomInKey = new HotkeyReference();
 		public readonly HotkeyReference ZoomOutKey = new HotkeyReference();
@@ -144,7 +144,7 @@ namespace OpenRA.Mods.Common.Widgets
 			tooltipContainer = Exts.Lazy(() =>
 				Ui.Root.Get<TooltipContainerWidget>(TooltipContainer));
 
-			resourceRenderer = world.WorldActor.TraitOrDefault<ResourceRenderer>();
+			resourceRenderers = world.WorldActor.TraitsImplementing<ResourceRenderer>().ToArray();
 		}
 
 		public override void Initialize(WidgetArgs args)
@@ -266,13 +266,14 @@ namespace OpenRA.Mods.Common.Widgets
 				return;
 			}
 
-			if (resourceRenderer != null)
+			foreach (var resourceRenderer in resourceRenderers)
 			{
 				var resource = resourceRenderer.GetRenderedResourceType(cell);
 				if (resource != null)
 				{
 					TooltipType = WorldTooltipType.Resource;
 					ResourceTooltip = resource;
+					break;
 				}
 			}
 		}

--- a/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/ViewportControllerWidget.cs
@@ -86,15 +86,15 @@ namespace OpenRA.Mods.Common.Widgets
 			{ ScrollDirection.Right, new float2(1, 0) },
 		};
 
-		Lazy<TooltipContainerWidget> tooltipContainer;
+		readonly Lazy<TooltipContainerWidget> tooltipContainer;
 		int2? joystickScrollStart, joystickScrollEnd;
 		int2? standardScrollStart;
 		bool isStandardScrolling;
 
 		ScrollDirection keyboardDirections;
 		ScrollDirection edgeDirections;
-		World world;
-		WorldRenderer worldRenderer;
+		readonly World world;
+		readonly WorldRenderer worldRenderer;
 
 		HotkeyReference[] saveBookmarkHotkeys;
 		HotkeyReference[] restoreBookmarkHotkeys;


### PR DESCRIPTION
Required for https://github.com/OpenRA/OpenRA/issues/9688 and useful for modding.