### PR TITLE
Reduce order latency locally

### DIFF
--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -585,7 +585,7 @@ namespace OpenRA
 
 					var isNetTick = LocalTick % NetTickScale == 0;
 
-					if (!isNetTick || orderManager.IsReadyForNextFrame)
+					if (!isNetTick || orderManager.SendNetFrameOrdersAndCheckReady())
 					{
 						++orderManager.LocalFrameNumber;
 

--- a/OpenRA.Game/Game.cs
+++ b/OpenRA.Game/Game.cs
@@ -578,26 +578,22 @@ namespace OpenRA
 					orderManager.LastTickTime += integralTickTimestep >= TimestepJankThreshold ? integralTickTimestep : worldTimestep;
 
 					Sound.Tick();
-					Sync.RunUnsynced(Settings.Debug.SyncCheckUnsyncedCode, world, orderManager.TickImmediate);
 
 					if (world == null)
-						return;
-
-					var isNetTick = LocalTick % NetTickScale == 0;
-
-					if (!isNetTick || orderManager.SendNetFrameOrdersAndCheckReady())
 					{
-						++orderManager.LocalFrameNumber;
+						orderManager.TickPreGame();
+						return;
+					}
 
-						Log.Write("debug", "--Tick: {0} ({1})", LocalTick, isNetTick ? "net" : "local");
+					// Collect orders first, we will dispatch them if we can this frame
+					Sync.RunUnsynced(Settings.Debug.SyncCheckUnsyncedCode, world, () =>
+					{
+						world.OrderGenerator.Tick(world);
+					});
 
-						if (isNetTick)
-							orderManager.Tick();
-
-						Sync.RunUnsynced(Settings.Debug.SyncCheckUnsyncedCode, world, () =>
-						{
-							world.OrderGenerator.Tick(world);
-						});
+					if (orderManager.TryTick())
+					{
+						Log.Write("debug", "--Tick: {0} ({1})", LocalTick, orderManager.IsNetTick ? "net" : "local");
 
 						world.Tick();
 

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -36,10 +36,10 @@ namespace OpenRA.Network
 		public bool AuthenticationFailed = false;
 		public ExternalMod ServerExternalMod = null;
 
+		public bool IsNetTick { get { return LocalFrameNumber % Game.NetTickScale == 0; } }
 		public int NetFrameNumber { get; private set; }
 		public int LocalFrameNumber;
 		public int FramesAhead = 0;
-		bool isReadyForNextFrame;
 		int lastFrameSent;
 
 		public long LastTickTime = Game.RunTime;
@@ -50,10 +50,11 @@ namespace OpenRA.Network
 		internal int GameSaveLastFrame = -1;
 		internal int GameSaveLastSyncFrame = -1;
 
-		List<Order> localOrders = new List<Order>();
-		List<Order> localImmediateOrders = new List<Order>();
+		readonly List<Order> localOrders = new List<Order>();
+		readonly List<Order> localImmediateOrders = new List<Order>();
+		readonly List<Pair<int, byte[]>> receivedImmediateOrders = new List<Pair<int, byte[]>>();
 
-		List<ChatLine> chatCache = new List<ChatLine>();
+		readonly List<ChatLine> chatCache = new List<ChatLine>();
 
 		public readonly ReadOnlyList<ChatLine> ChatCache;
 
@@ -79,7 +80,6 @@ namespace OpenRA.Network
 
 			// Technically redundant since we will attempt to send orders before the next frame
 			SendOrders();
-			isReadyForNextFrame = false;
 		}
 
 		public OrderManager(string host, int port, string password, IConnection conn)
@@ -113,14 +113,15 @@ namespace OpenRA.Network
 			chatCache.Add(new ChatLine(name, nameColor, text, textColor));
 		}
 
-		public void TickImmediate()
+		void SendImmediateOrders()
 		{
-			if (localImmediateOrders.Count != 0 && GameSaveLastFrame < NetFrameNumber + FramesAhead)
+			if (localImmediateOrders.Count != 0 && GameSaveLastFrame < NetFrameNumber)
 				Connection.SendImmediate(localImmediateOrders.Select(o => o.Serialize()));
 			localImmediateOrders.Clear();
+		}
 
-			var immediatePackets = new List<Pair<int, byte[]>>();
-
+		void ReceiveAllOrdersAndCheckSync()
+		{
 			Connection.Receive(
 				(clientId, packet) =>
 				{
@@ -130,12 +131,15 @@ namespace OpenRA.Network
 					else if (packet.Length >= 5 && packet[4] == (byte)OrderType.SyncHash)
 						CheckSync(packet);
 					else if (frame == 0)
-						immediatePackets.Add(Pair.New(clientId, packet));
+						receivedImmediateOrders.Add(Pair.New(clientId, packet));
 					else
 						frameData.AddFrameOrders(clientId, frame, packet);
 				});
+		}
 
-			foreach (var p in immediatePackets)
+		void ProcessImmediateOrders()
+		{
+			foreach (var p in receivedImmediateOrders)
 			{
 				foreach (var o in p.Second.ToOrderList(World))
 				{
@@ -146,6 +150,8 @@ namespace OpenRA.Network
 						return;
 				}
 			}
+
+			receivedImmediateOrders.Clear();
 		}
 
 		Dictionary<int, byte[]> syncForFrame = new Dictionary<int, byte[]>();
@@ -167,7 +173,7 @@ namespace OpenRA.Network
 				syncForFrame.Add(frame, packet);
 		}
 
-		public IEnumerable<Session.Client> GetClientsNotReadyForNextFrame
+		IEnumerable<Session.Client> GetClientsNotReadyForNextFrame
 		{
 			get
 			{
@@ -194,26 +200,12 @@ namespace OpenRA.Network
 			}
 		}
 
-		public bool SendNetFrameOrdersAndCheckReady()
-		{
-			// Send our frame orders if we should
-			SendOrders();
-
-			if (!isReadyForNextFrame)
-				isReadyForNextFrame = NetFrameNumber >= 1 && frameData.IsReadyForFrame(NetFrameNumber);
-
-			return isReadyForNextFrame;
-		}
-
 		/*
 		 * Only available if TickImmediate() is called first and we are ready to dispatch received orders locally.
 		 * Process all incoming orders for this frame, handle sync hashes and step our net frame.
 		 */
-		public void Tick()
+		void ProcessOrders()
 		{
-			if (!isReadyForNextFrame)
-				throw new InvalidOperationException();
-
 			foreach (var order in frameData.OrdersForFrame(World, NetFrameNumber))
 				UnitOrders.ProcessOrder(this, World, order.Client, order.Order);
 
@@ -227,7 +219,52 @@ namespace OpenRA.Network
 					syncReport.UpdateSyncReport();
 
 			++NetFrameNumber;
-			isReadyForNextFrame = false;
+		}
+
+		public void TickPreGame()
+		{
+			SendImmediateOrders();
+
+			ReceiveAllOrdersAndCheckSync();
+
+			Sync.RunUnsynced(Game.Settings.Debug.SyncCheckUnsyncedCode, World, ProcessImmediateOrders);
+		}
+
+		public bool TryTick()
+		{
+			var shouldTick = true;
+
+			if (IsNetTick)
+			{
+				// Check whether or not we will be ready for a tick next frame
+				// We don't need to include ourselves in the equation because we can always generate orders this frame
+				shouldTick = !GetClientsNotReadyForNextFrame.Except(new[] { LocalClient }).Any();
+
+				// Send orders only if we are currently ready, this prevents us sending orders too soon if we are
+				// stalling
+				if (shouldTick)
+					SendOrders();
+			}
+
+			SendImmediateOrders();
+
+			ReceiveAllOrdersAndCheckSync();
+
+			// Always send immediate orders
+			Sync.RunUnsynced(Game.Settings.Debug.SyncCheckUnsyncedCode, World, ProcessImmediateOrders);
+
+			var willTick = shouldTick;
+			if (willTick && IsNetTick)
+			{
+				willTick = frameData.IsReadyForFrame(NetFrameNumber);
+				if (willTick)
+					ProcessOrders();
+			}
+
+			if (willTick)
+				LocalFrameNumber++;
+
+			return willTick;
 		}
 
 		public void Dispose()

--- a/OpenRA.Game/Network/OrderManager.cs
+++ b/OpenRA.Game/Network/OrderManager.cs
@@ -39,6 +39,8 @@ namespace OpenRA.Network
 		public int NetFrameNumber { get; private set; }
 		public int LocalFrameNumber;
 		public int FramesAhead = 0;
+		public bool IsReadyForNextFrame { get; private set; }
+		int lastFrameSent;
 
 		public long LastTickTime = Game.RunTime;
 
@@ -75,9 +77,9 @@ namespace OpenRA.Network
 
 			NetFrameNumber = 1;
 
-			if (GameSaveLastFrame < 0)
-				for (var i = NetFrameNumber; i <= FramesAhead; i++)
-					Connection.Send(i, new List<byte[]>());
+			// Technically redundant since we will attempt to send orders before the next frame
+			SendOrders();
+			IsReadyForNextFrame = false;
 		}
 
 		public OrderManager(string host, int port, string password, IConnection conn)
@@ -111,8 +113,17 @@ namespace OpenRA.Network
 			chatCache.Add(new ChatLine(name, nameColor, text, textColor));
 		}
 
+		/*
+		 * Send all frame orders that are ready if we can (game is started and our next available send frame is free),
+		 * Send all immediate orders,
+		 * Receive and dispatch immediate orders, check incoming sync matchs, and buffer received frame orders,
+		 * Update our ready status for the next frame for Tick().
+		 */
 		public void TickImmediate()
 		{
+			// Send our frame orders if we should
+			SendOrders();
+
 			if (localImmediateOrders.Count != 0 && GameSaveLastFrame < NetFrameNumber + FramesAhead)
 				Connection.SendImmediate(localImmediateOrders.Select(o => o.Serialize()));
 			localImmediateOrders.Clear();
@@ -144,6 +155,9 @@ namespace OpenRA.Network
 						return;
 				}
 			}
+
+			if (!IsReadyForNextFrame)
+				IsReadyForNextFrame = NetFrameNumber >= 1 && frameData.IsReadyForFrame(NetFrameNumber);
 		}
 
 		Dictionary<int, byte[]> syncForFrame = new Dictionary<int, byte[]>();
@@ -165,11 +179,6 @@ namespace OpenRA.Network
 				syncForFrame.Add(frame, packet);
 		}
 
-		public bool IsReadyForNextFrame
-		{
-			get { return NetFrameNumber >= 1 && frameData.IsReadyForFrame(NetFrameNumber); }
-		}
-
 		public IEnumerable<Session.Client> GetClientsNotReadyForNextFrame
 		{
 			get
@@ -181,15 +190,30 @@ namespace OpenRA.Network
 			}
 		}
 
+		void SendOrders()
+		{
+			if (NetFrameNumber < 1)
+				return;
+
+			// Loop exists to ensure we never miss a frame, since that would stall the game.
+			// This loop also sends the initial blank frames to get to the correct order latency.
+			while (lastFrameSent < NetFrameNumber + FramesAhead)
+			{
+				lastFrameSent++;
+				if (GameSaveLastFrame < NetFrameNumber + FramesAhead)
+					Connection.Send(lastFrameSent, localOrders.Select(o => o.Serialize()).ToList());
+				localOrders.Clear();
+			}
+		}
+
+		/*
+		 * Only available if TickImmediate() is called first and we are ready to dispatch received orders locally.
+		 * Process all incoming orders for this frame, handle sync hashes and step our net frame.
+		 */
 		public void Tick()
 		{
 			if (!IsReadyForNextFrame)
 				throw new InvalidOperationException();
-
-			if (GameSaveLastFrame < NetFrameNumber + FramesAhead)
-				Connection.Send(NetFrameNumber + FramesAhead, localOrders.Select(o => o.Serialize()).ToList());
-
-			localOrders.Clear();
 
 			foreach (var order in frameData.OrdersForFrame(World, NetFrameNumber))
 				UnitOrders.ProcessOrder(this, World, order.Client, order.Order);
@@ -204,6 +228,7 @@ namespace OpenRA.Network
 					syncReport.UpdateSyncReport();
 
 			++NetFrameNumber;
+			IsReadyForNextFrame = false;
 		}
 
 		public void Dispose()

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -966,7 +966,7 @@ namespace OpenRA.Server
 
 			// HACK: Turn down the latency if there is only one real player
 			if (LobbyInfo.NonBotClients.Count() == 1)
-				LobbyInfo.GlobalSettings.OrderLatency = 1;
+				LobbyInfo.GlobalSettings.OrderLatency = 0;
 
 			// Enable game saves for singleplayer missions only
 			// TODO: Enable for multiplayer (non-dedicated servers only) once the lobby UI has been created


### PR DESCRIPTION
This is a fairly straightforward change that allows us to drop the order latency to 0 in local games.

By submitting orders when we are _ready to check_ that we are ready for the next net frame, locally we will always see our own orders immediately rather than needing to wait another net frame to get them.

Previously, real input latency was 3-6 sim ticks (120-240ms on normal), whereas now it should be 0-3 (0-120ms). (If you test locally, you will notice that the input is occasionally immediate!)

This opens up a further question about net ticks in general: if we numbered net ticks by their regular tick number, we could process orders per sim locally (reducing input latency to 1 frame, 0-40ms) and then have a "net batch" scale, where we send the orders and sync hash at a 3 tick interval like we do now. Since the connections can be assumed to be reliable, we can skip empty frames except the last in the batch, avoiding an increase in network overhead.

 (the original commit introducing 3-tick net ticks is commented as "reduce bandwidth by 3x")