### PR TITLE
Increase barrel damage against wood

### DIFF
--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -138,7 +138,7 @@ BarrelExplode:
 		ValidTargets: Ground, Trees
 		Versus:
 			None: 120
-			Wood: 100
+			Wood: 200
 			Light: 50
 			Concrete: 10
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath, Incendiary


### PR DESCRIPTION
Basically reverts #14314 and 'un-breaks' our single player campaign missions (e.g. allies02, allies06b). This was initially done for the competitive community, but @Punsho actually said on Discord he wanted the damage increased again.