### PR TITLE
Move IHealth to mod code

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -59,7 +59,7 @@ namespace OpenRA
 		public ITargetable[] Targetables { get; private set; }
 
 		public bool IsIdle { get { return CurrentActivity == null; } }
-		public bool IsDead { get { return Disposed || (health != null && health.IsDead); } }
+		public bool IsDead { get { return Disposed || (death != null && death.IsDead); } }
 
 		public CPos Location { get { return OccupiesSpace.TopLeft; } }
 		public WPos CenterPosition { get { return OccupiesSpace.CenterPosition; } }
@@ -77,7 +77,7 @@ namespace OpenRA
 		internal SyncHash[] SyncHashes { get; private set; }
 
 		readonly IFacing facing;
-		readonly IHealth health;
+		readonly IActorDeath death;
 		readonly IRenderModifier[] renderModifiers;
 		readonly IRender[] renders;
 		readonly IMouseBounds[] mouseBounds;
@@ -122,7 +122,7 @@ namespace OpenRA
 			// performance-sensitive parts of the core game engine, such as pathfinding, visibility and rendering.
 			EffectiveOwner = TraitOrDefault<IEffectiveOwner>();
 			facing = TraitOrDefault<IFacing>();
-			health = TraitOrDefault<IHealth>();
+			death = TraitOrDefault<IActorDeath>();
 			renderModifiers = TraitsImplementing<IRenderModifier>().ToArray();
 			renders = TraitsImplementing<IRender>().ToArray();
 			mouseBounds = TraitsImplementing<IMouseBounds>().ToArray();

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -387,14 +387,6 @@ namespace OpenRA
 			return (health == null) ? DamageState.Undamaged : health.DamageState;
 		}
 
-		public void InflictDamage(Actor attacker, Damage damage)
-		{
-			if (Disposed || health == null)
-				return;
-
-			health.InflictDamage(this, attacker, damage, false);
-		}
-
 		public void Kill(Actor attacker, BitSet<DamageType> damageTypes = default(BitSet<DamageType>))
 		{
 			if (Disposed || health == null)

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -379,14 +379,6 @@ namespace OpenRA
 				World.Add(this);
 		}
 
-		public void Kill(Actor attacker, BitSet<DamageType> damageTypes = default(BitSet<DamageType>))
-		{
-			if (Disposed || health == null)
-				return;
-
-			health.Kill(this, attacker, damageTypes);
-		}
-
 		public bool CanBeViewedByPlayer(Player player)
 		{
 			// PERF: Avoid LINQ.

--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -379,14 +379,6 @@ namespace OpenRA
 				World.Add(this);
 		}
 
-		public DamageState GetDamageState()
-		{
-			if (Disposed)
-				return DamageState.Dead;
-
-			return (health == null) ? DamageState.Undamaged : health.DamageState;
-		}
-
 		public void Kill(Actor attacker, BitSet<DamageType> damageTypes = default(BitSet<DamageType>))
 		{
 			if (Disposed || health == null)

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -50,7 +50,6 @@ namespace OpenRA.Traits
 
 		public int HP { get; private set; }
 		public DamageState DamageState { get; private set; }
-		readonly IHealth health;
 
 		// The Visible flag is tied directly to the actor visibility under the fog.
 		// If Visible is true, the actor is made invisible (via FrozenUnderFog/IDefaultVisibility)
@@ -102,7 +101,6 @@ namespace OpenRA.Traits
 			CenterPosition = actor.CenterPosition;
 
 			tooltips = actor.TraitsImplementing<ITooltip>().ToArray();
-			health = actor.TraitOrDefault<IHealth>();
 
 			UpdateVisibility();
 		}
@@ -113,18 +111,15 @@ namespace OpenRA.Traits
 		public Actor Actor { get { return !actor.IsDead ? actor : null; } }
 		public Player Viewer { get { return viewer; } }
 
-		public void RefreshState()
+		public void RefreshState(int hp, DamageState damageState)
 		{
 			Owner = actor.Owner;
 			TargetTypes = actor.GetEnabledTargetTypes();
 			TargetablePositions = actor.GetTargetablePositions().ToArray();
 			Hidden = !actor.CanBeViewedByPlayer(viewer);
 
-			if (health != null)
-			{
-				HP = health.HP;
-				DamageState = health.DamageState;
-			}
+			HP = hp;
+			DamageState = damageState;
 
 			var tooltip = tooltips.FirstEnabledTraitOrDefault();
 			if (tooltip != null)

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -49,22 +49,6 @@ namespace OpenRA.Traits
 	/// </summary>
 	public sealed class DamageType { DamageType() { } }
 
-	public interface IHealthInfo : ITraitInfo
-	{
-		int MaxHP { get; }
-	}
-
-	public interface IHealth : IActorDeath
-	{
-		DamageState DamageState { get; }
-		int HP { get; }
-		int MaxHP { get; }
-		int DisplayHP { get; }
-
-		void InflictDamage(Actor self, Actor attacker, Damage damage, bool ignoreModifiers);
-		void Kill(Actor self, Actor attacker, BitSet<DamageType> damageTypes);
-	}
-
 	public interface IActorDeath
 	{
 		bool IsDead { get; }

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -54,16 +54,20 @@ namespace OpenRA.Traits
 		int MaxHP { get; }
 	}
 
-	public interface IHealth
+	public interface IHealth : IActorDeath
 	{
 		DamageState DamageState { get; }
 		int HP { get; }
 		int MaxHP { get; }
 		int DisplayHP { get; }
-		bool IsDead { get; }
 
 		void InflictDamage(Actor self, Actor attacker, Damage damage, bool ignoreModifiers);
 		void Kill(Actor self, Actor attacker, BitSet<DamageType> damageTypes);
+	}
+
+	public interface IActorDeath
+	{
+		bool IsDead { get; }
 	}
 
 	[Flags]

--- a/OpenRA.Mods.Cnc/Activities/Infiltrate.cs
+++ b/OpenRA.Mods.Cnc/Activities/Infiltrate.cs
@@ -11,6 +11,7 @@
 
 using System.Linq;
 using OpenRA.Mods.Cnc.Traits;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.Cnc/Activities/Teleport.cs
+++ b/OpenRA.Mods.Cnc/Activities/Teleport.cs
@@ -13,6 +13,7 @@ using System;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.Mods.Cnc.Traits;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
+++ b/OpenRA.Mods.Cnc/Traits/Chronoshiftable.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using OpenRA.Mods.Cnc.Activities;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;

--- a/OpenRA.Mods.Cnc/Traits/FrozenUnderFogUpdatedByGps.cs
+++ b/OpenRA.Mods.Cnc/Traits/FrozenUnderFogUpdatedByGps.cs
@@ -35,7 +35,17 @@ namespace OpenRA.Mods.Cnc.Traits
 				// HACK: RefreshState updated *all* actor state, not just the owner
 				// This is generally bogus, and specifically breaks cursors and tooltips by setting Hidden to false
 				var hidden = fa.Hidden;
-				fa.RefreshState();
+
+				var hp = 0;
+				var damageState = DamageState.Undamaged;
+				var health = fufubg.self.TraitOrDefault<Health>();
+				if (health != null)
+				{
+					hp = health.HP;
+					damageState = health.DamageState;
+				}
+
+				fa.RefreshState(hp, damageState);
 				fa.Hidden = hidden;
 				fa.NeedRenderables = true;
 			}

--- a/OpenRA.Mods.Cnc/Traits/Mine.cs
+++ b/OpenRA.Mods.Cnc/Traits/Mine.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeOverlay.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeOverlay.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using OpenRA.Graphics;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
+++ b/OpenRA.Mods.Common/Activities/Air/ReturnToBase.cs
@@ -56,7 +56,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (alwaysLand)
 				return true;
 
-			if (repairableInfo != null && repairableInfo.RepairActors.Contains(dest.Info.Name) && self.GetDamageState() != DamageState.Undamaged)
+			if (repairableInfo != null && repairableInfo.RepairActors.Contains(dest.Info.Name) && aircraft.DamageState != DamageState.Undamaged)
 				return true;
 
 			return rearmable != null && rearmable.Info.RearmActors.Contains(dest.Info.Name)

--- a/OpenRA.Mods.Common/Activities/CaptureActor.cs
+++ b/OpenRA.Mods.Common/Activities/CaptureActor.cs
@@ -97,7 +97,9 @@ namespace OpenRA.Mods.Common.Activities
 					if (100 * (long)health.HP > captures.Info.SabotageThreshold * (long)health.MaxHP)
 					{
 						var damage = (int)((long)health.MaxHP * captures.Info.SabotageHPRemoval / 100);
-						enterActor.InflictDamage(self, new Damage(damage, captures.Info.SabotageDamageTypes));
+
+						// TODO: Investigate whether we really want damage modifiers to affect this
+						health.InflictDamage(enterActor, self, new Damage(damage, captures.Info.SabotageDamageTypes), false);
 
 						if (captures.Info.ConsumedByCapture)
 							self.Dispose();

--- a/OpenRA.Mods.Common/Activities/RepairBuilding.cs
+++ b/OpenRA.Mods.Common/Activities/RepairBuilding.cs
@@ -67,7 +67,8 @@ namespace OpenRA.Mods.Common.Activities
 			if (enterHealth.DamageState == DamageState.Undamaged)
 				return;
 
-			enterActor.InflictDamage(self, new Damage(-enterHealth.MaxHP));
+			// Setting ignoreModifiers to true, otherwise negative damage modifiers might prevent a full recovery
+			enterHealth.InflictDamage(enterActor, self, new Damage(-enterHealth.MaxHP), true);
 			if (!string.IsNullOrEmpty(info.RepairSound))
 				Game.Sound.Play(SoundType.World, info.RepairSound, enterActor.CenterPosition);
 

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -267,7 +267,8 @@ namespace OpenRA.Mods.Common.Activities
 					return;
 				}
 
-				self.InflictDamage(host.Actor, new Damage(-hpToRepair, repairsUnits.Info.RepairDamageTypes));
+				// Setting ignoreModifiers to true, otherwise negative damage modifiers would also slow down repairs!
+				health.InflictDamage(self, host.Actor, new Damage(-hpToRepair, repairsUnits.Info.RepairDamageTypes), true);
 				remainingTicks = repairsUnits.Info.Interval;
 			}
 			else

--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -91,5 +91,15 @@ namespace OpenRA.Mods.Common
 			var health = self.TraitOrDefault<Health>();
 			return health == null ? DamageState.Undamaged : health.DamageState;
 		}
+
+		public static void Kill(this Actor self, Actor attacker, BitSet<DamageType> damageTypes = default(BitSet<DamageType>))
+		{
+			if (self.WillDispose)
+				return;
+
+			var health = self.TraitOrDefault<Health>();
+			if (health != null)
+				health.Kill(self, attacker, damageTypes);
+		}
 	}
 }

--- a/OpenRA.Mods.Common/ActorExts.cs
+++ b/OpenRA.Mods.Common/ActorExts.cs
@@ -82,5 +82,14 @@ namespace OpenRA.Mods.Common
 		{
 			return cells.MinByOrDefault(c => (self.Location - c).LengthSquared);
 		}
+
+		public static DamageState GetDamageState(this Actor self)
+		{
+			if (self.WillDispose)
+				return DamageState.Dead;
+
+			var health = self.TraitOrDefault<Health>();
+			return health == null ? DamageState.Undamaged : health.DamageState;
+		}
 	}
 }

--- a/OpenRA.Mods.Common/Graphics/IsometricSelectionBarsAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/IsometricSelectionBarsAnnotationRenderable.cs
@@ -150,11 +150,8 @@ namespace OpenRA.Mods.Common.Graphics
 
 			var health = actor.TraitOrDefault<IHealth>();
 
-			if (DisplayHealth)
+			if (DisplayHealth && health != null)
 			{
-				if (health == null || health.IsDead)
-					return;
-
 				var displayValue = health.DisplayHP != health.HP ? (float?)health.DisplayHP / health.MaxHP : null;
 				DrawBar(wr, (float)health.HP / health.MaxHP, GetHealthColor(health), 0,  displayValue, Color.OrangeRed);
 			}

--- a/OpenRA.Mods.Common/Graphics/IsometricSelectionBarsAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/IsometricSelectionBarsAnnotationRenderable.cs
@@ -11,6 +11,7 @@
 
 using System;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Graphics/SelectionBarsAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBarsAnnotationRenderable.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using OpenRA.Graphics;
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Graphics/SelectionBarsAnnotationRenderable.cs
+++ b/OpenRA.Mods.Common/Graphics/SelectionBarsAnnotationRenderable.cs
@@ -99,9 +99,6 @@ namespace OpenRA.Mods.Common.Graphics
 
 		void DrawHealthBar(WorldRenderer wr, IHealth health, float2 start, float2 end)
 		{
-			if (health == null || health.IsDead)
-				return;
-
 			var c = Color.FromArgb(128, 30, 30, 30);
 			var c2 = Color.FromArgb(128, 10, 10, 10);
 			var p = new float2(0, -4);
@@ -152,7 +149,7 @@ namespace OpenRA.Mods.Common.Graphics
 			var start = wr.Viewport.WorldToViewPx(new float2(decorationBounds.Left + 1, decorationBounds.Top));
 			var end = wr.Viewport.WorldToViewPx(new float2(decorationBounds.Right - 1, decorationBounds.Top));
 
-			if (DisplayHealth)
+			if (DisplayHealth && health != null)
 				DrawHealthBar(wr, health, start, end);
 
 			if (DisplayExtra)

--- a/OpenRA.Mods.Common/Scripting/Properties/HealthProperties.cs
+++ b/OpenRA.Mods.Common/Scripting/Properties/HealthProperties.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using OpenRA.Mods.Common.Traits;
 using OpenRA.Scripting;
 using OpenRA.Traits;
 

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -193,6 +193,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		readonly Actor self;
 
+		IHealth health;
 		Repairable repairable;
 		Rearmable rearmable;
 		IAircraftCenterPositionOffset[] positionOffsets;
@@ -214,6 +215,8 @@ namespace OpenRA.Mods.Common.Traits
 		public Actor ReservedActor { get; private set; }
 		public bool MayYieldReservation { get; private set; }
 		public bool ForceLanding { get; private set; }
+
+		public DamageState DamageState { get { return health != null ? health.DamageState : self.GetDamageState(); } }
 
 		IEnumerable<CPos> landingCells = Enumerable.Empty<CPos>();
 		bool requireForceMove;
@@ -291,6 +294,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		protected override void Created(Actor self)
 		{
+			health = self.TraitOrDefault<IHealth>();
 			repairable = self.TraitOrDefault<Repairable>();
 			rearmable = self.TraitOrDefault<Rearmable>();
 			conditionManager = self.TraitOrDefault<ConditionManager>();
@@ -536,7 +540,7 @@ namespace OpenRA.Mods.Common.Traits
 			var canRepairAtActor = repairable != null && repairable.Info.RepairActors.Contains(a.Info.Name);
 
 			var allowedToEnterRearmer = canRearmAtActor && (allowedToForceEnter || rearmable.RearmableAmmoPools.Any(p => !p.HasFullAmmo));
-			var allowedToEnterRepairer = canRepairAtActor && (allowedToForceEnter || self.GetDamageState() != DamageState.Undamaged);
+			var allowedToEnterRepairer = canRepairAtActor && (allowedToForceEnter || DamageState != DamageState.Undamaged);
 
 			return allowedToEnterRearmer || allowedToEnterRepairer;
 		}
@@ -654,7 +658,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool CanRepairAt(Actor host)
 		{
-			return repairable != null && repairable.Info.RepairActors.Contains(host.Info.Name) && self.GetDamageState() != DamageState.Undamaged;
+			return repairable != null && repairable.Info.RepairActors.Contains(host.Info.Name) && DamageState != DamageState.Undamaged;
 		}
 
 		public void ModifyDeathActorInit(Actor self, TypeDictionary init)

--- a/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
@@ -123,7 +123,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 
 		string IBridgeSegment.Type { get { return Info.Type; } }
-		DamageState IBridgeSegment.DamageState { get { return self.GetDamageState(); } }
+		DamageState IBridgeSegment.DamageState { get { return health.DamageState; } }
 		bool IBridgeSegment.Valid { get { return self.IsInWorld; } }
 		CVec[] IBridgeSegment.NeighbourOffsets { get { return Info.NeighbourOffsets; } }
 		CPos IBridgeSegment.Location { get { return self.Location; } }

--- a/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RepairableBuilding.cs
@@ -170,7 +170,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				// activePlayers won't cause IndexOutOfRange because we capped the max amount of players
 				// to the length of the array
-				self.InflictDamage(self, new Damage(-(hpToRepair * Info.RepairBonuses[activePlayers - 1] / 100), Info.RepairDamageTypes));
+				health.InflictDamage(self, self, new Damage(-(hpToRepair * Info.RepairBonuses[activePlayers - 1] / 100), Info.RepairDamageTypes), false);
 
 				if (health.DamageState == DamageState.Undamaged)
 				{

--- a/OpenRA.Mods.Common/Traits/Burns.cs
+++ b/OpenRA.Mods.Common/Traits/Burns.cs
@@ -25,9 +25,11 @@ namespace OpenRA.Mods.Common.Traits
 		public object Create(ActorInitializer init) { return new Burns(init.Self, this); }
 	}
 
-	class Burns : ITick, ISync
+	class Burns : ITick, ISync, INotifyCreated
 	{
 		readonly BurnsInfo info;
+		IHealth health;
+
 		[Sync]
 		int ticks;
 
@@ -41,11 +43,16 @@ namespace OpenRA.Mods.Common.Traits
 			self.Trait<RenderSprites>().Add(anim);
 		}
 
+		void INotifyCreated.Created(Actor self)
+		{
+			health = self.TraitOrDefault<IHealth>();
+		}
+
 		void ITick.Tick(Actor self)
 		{
-			if (--ticks <= 0)
+			if (health != null && --ticks <= 0)
 			{
-				self.InflictDamage(self, new Damage(info.Damage));
+				health.InflictDamage(self, self, new Damage(info.Damage), false);
 				ticks = info.Interval;
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/DamagedByTerrain.cs
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Actors start with maximum damage applied
 			var delta = health.HP - damageThreshold;
 			if (delta > 0)
-				self.InflictDamage(self.World.WorldActor, new Damage(delta, Info.DamageTypes));
+				health.InflictDamage(self, self.World.WorldActor, new Damage(delta, Info.DamageTypes), false);
 		}
 
 		void ITick.Tick(Actor self)
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!Info.Terrain.Contains(t.Type))
 				return;
 
-			self.InflictDamage(self.World.WorldActor, new Damage(Info.Damage, Info.DamageTypes));
+			health.InflictDamage(self, self.World.WorldActor, new Damage(Info.Damage, Info.DamageTypes), false);
 			damageTicks = Info.DamageInterval;
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -80,6 +80,8 @@ namespace OpenRA.Mods.Common.Traits
 		public int MaxHP { get; private set; }
 
 		public bool IsDead { get { return hp <= 0; } }
+		bool IActorDeath.IsDead { get { return IsDead; } }
+
 		public bool RemoveOnDeath = true;
 
 		public DamageState DamageState

--- a/OpenRA.Mods.Common/Traits/HitShape.cs
+++ b/OpenRA.Mods.Common/Traits/HitShape.cs
@@ -71,6 +71,7 @@ namespace OpenRA.Mods.Common.Traits
 		BodyOrientation orientation;
 		ITargetableCells targetableCells;
 		Turreted turret;
+		Health health;
 
 		public HitShape(Actor self, HitShapeInfo info)
 			: base(info) { }
@@ -80,9 +81,13 @@ namespace OpenRA.Mods.Common.Traits
 			orientation = self.Trait<BodyOrientation>();
 			targetableCells = self.TraitOrDefault<ITargetableCells>();
 			turret = self.TraitsImplementing<Turreted>().FirstOrDefault(t => t.Name == Info.Turret);
+			health = self.TraitOrDefault<Health>();
 
 			base.Created(self);
 		}
+
+		// Mostly serves to avoid Health look-ups in warheads
+		public Health Health { get { return health; } }
 
 		bool ITargetablePositions.AlwaysEnabled { get { return Info.RequiresCondition == null; } }
 

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -36,9 +36,13 @@ namespace OpenRA.Mods.Common.Traits
 		readonly bool startsRevealed;
 		readonly PPos[] footprint;
 
+		IHealth health;
 		PlayerDictionary<FrozenState> frozenStates;
 		bool isRendering;
 		bool created;
+
+		int hp;
+		DamageState damageState;
 
 		class FrozenState
 		{
@@ -67,6 +71,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyCreated.Created(Actor self)
 		{
+			health = self.TraitOrDefault<IHealth>();
+
 			frozenStates = new PlayerDictionary<FrozenState>(self.World, (player, playerIndex) =>
 			{
 				var frozenActor = new FrozenActor(self, this, footprint, player, startsRevealed);
@@ -78,7 +84,14 @@ namespace OpenRA.Mods.Common.Traits
 		void UpdateFrozenActor(Actor self, FrozenActor frozenActor, int playerIndex)
 		{
 			VisibilityHash |= 1 << (playerIndex % 32);
-			frozenActor.RefreshState();
+
+			if (health != null)
+			{
+				hp = health.HP;
+				damageState = health.DamageState;
+			}
+
+			frozenActor.RefreshState(hp, damageState);
 		}
 
 		void ICreatesFrozenActors.OnVisibilityChanged(FrozenActor frozen)

--- a/OpenRA.Mods.Common/Traits/Render/SelectionDecorationsBase.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SelectionDecorationsBase.cs
@@ -29,6 +29,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 		Dictionary<DecorationPosition, IDecoration[]> decorations;
 		Dictionary<DecorationPosition, IDecoration[]> selectedDecorations;
 
+		IHealth health;
+
 		protected readonly SelectionDecorationsBaseInfo info;
 
 		public SelectionDecorationsBase(SelectionDecorationsBaseInfo info)
@@ -54,6 +56,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 			selectedDecorations = groupedSelectionDecorations.ToDictionary(
 				d => d.Key,
 				d => d.Value.ToArray());
+
+			health = self.TraitOrDefault<IHealth>();
 		}
 
 		IEnumerable<WPos> ActivityTargetPath(Actor self)
@@ -94,7 +98,8 @@ namespace OpenRA.Mods.Common.Traits.Render
 			//  * status bar preference is set to "always show"
 			//  * status bar preference is set to "when damaged" and actor is damaged
 			var displayHealth = selected || rollover || (regularWorld && statusBars == StatusBarsType.AlwaysShow)
-				|| (regularWorld && statusBars == StatusBarsType.DamageShow && self.GetDamageState() != DamageState.Undamaged);
+				|| (regularWorld && statusBars == StatusBarsType.DamageShow
+					&& (health != null ? health.DamageState != DamageState.Undamaged : self.GetDamageState() != DamageState.Undamaged));
 
 			// Extra bars are shown when:
 			//  * actor is selected / in active drag rectangle / under the mouse

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
@@ -70,6 +70,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		readonly Armament armament;
 		readonly Turreted turreted;
 		readonly BodyOrientation body;
+		IHealth health;
 
 		public WithSpriteBarrel(Actor self, WithSpriteBarrelInfo info)
 			: base(info)
@@ -91,9 +92,16 @@ namespace OpenRA.Mods.Common.Traits.Render
 			turreted.QuantizedFacings = DefaultAnimation.CurrentSequence.Facings;
 		}
 
+		protected override void Created(Actor self)
+		{
+			health = self.TraitOrDefault<IHealth>();
+			base.Created(self);
+		}
+
 		public string NormalizeSequence(Actor self, string sequence)
 		{
-			return RenderSprites.NormalizeSequence(DefaultAnimation, self.GetDamageState(), sequence);
+			var damageState = health != null ? health.DamageState : self.GetDamageState();
+			return RenderSprites.NormalizeSequence(DefaultAnimation, damageState, sequence);
 		}
 
 		WVec BarrelOffset()

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -54,6 +54,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly Animation DefaultAnimation;
 		readonly RenderSprites rs;
 		readonly Animation boundsAnimation;
+		IHealth health;
 
 		public WithSpriteBody(ActorInitializer init, WithSpriteBodyInfo info)
 			: this(init, info, () => 0) { }
@@ -78,9 +79,16 @@ namespace OpenRA.Mods.Common.Traits.Render
 			boundsAnimation.PlayRepeating(info.Sequence);
 		}
 
+		protected override void Created(Actor self)
+		{
+			health = self.TraitOrDefault<IHealth>();
+			base.Created(self);
+		}
+
 		public string NormalizeSequence(Actor self, string sequence)
 		{
-			return RenderSprites.NormalizeSequence(DefaultAnimation, self.GetDamageState(), sequence);
+			var damageState = health != null ? health.DamageState : self.GetDamageState();
+			return RenderSprites.NormalizeSequence(DefaultAnimation, damageState, sequence);
 		}
 
 		protected override void TraitEnabled(Actor self)

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -79,6 +79,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		readonly BodyOrientation body;
 		readonly Turreted t;
 		readonly Armament[] arms;
+		IHealth health;
 
 		public WithSpriteTurret(Actor self, WithSpriteTurretInfo info)
 			: base(info)
@@ -112,9 +113,16 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return t.Position(self) + body.LocalToWorld(localOffset.Rotate(quantizedWorldTurret));
 		}
 
+		protected override void Created(Actor self)
+		{
+			health = self.TraitOrDefault<IHealth>();
+			base.Created(self);
+		}
+
 		public string NormalizeSequence(Actor self, string sequence)
 		{
-			return RenderSprites.NormalizeSequence(DefaultAnimation, self.GetDamageState(), sequence);
+			var damageState = health != null ? health.DamageState : self.GetDamageState();
+			return RenderSprites.NormalizeSequence(DefaultAnimation, damageState, sequence);
 		}
 
 		protected virtual void DamageStateChanged(Actor self)

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -41,12 +41,14 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		public readonly RepairableNearInfo Info;
 		readonly Actor self;
+		readonly IHealth health;
 		bool requireForceMove;
 
 		public RepairableNear(Actor self, RepairableNearInfo info)
 		{
 			this.self = self;
 			Info = info;
+			health = self.Trait<IHealth>();
 		}
 
 		IEnumerable<IOrderTargeter> IIssueOrder.Orders
@@ -81,7 +83,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		bool ShouldRepair()
 		{
-			return self.GetDamageState() > DamageState.Undamaged;
+			return health.DamageState > DamageState.Undamaged;
 		}
 
 		string IOrderVoice.VoicePhraseForOrder(Actor self, Order order)

--- a/OpenRA.Mods.Common/Traits/SelfHealing.cs
+++ b/OpenRA.Mods.Common/Traits/SelfHealing.cs
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 				ticks = Info.Delay;
 
 				// Cast to long to avoid overflow when multiplying by the health
-				self.InflictDamage(self, new Damage((int)(-(Info.Step + Info.PercentageStep * (long)health.MaxHP / 100)), Info.DamageTypes));
+				health.InflictDamage(self, self, new Damage((int)(-(Info.Step + Info.PercentageStep * (long)health.MaxHP / 100)), Info.DamageTypes), false);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
+++ b/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class SmokeTrailWhenDamagedInfo : ITraitInfo, Requires<BodyOrientationInfo>
+	class SmokeTrailWhenDamagedInfo : ITraitInfo, Requires<BodyOrientationInfo>, Requires<IHealthInfo>
 	{
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
@@ -37,6 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly SmokeTrailWhenDamagedInfo info;
 		readonly BodyOrientation body;
+		readonly IHealth health;
 		readonly int getFacing;
 		int ticks;
 
@@ -44,6 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.info = info;
 			body = self.Trait<BodyOrientation>();
+			health = self.Trait<IHealth>();
 			var facing = self.TraitOrDefault<IFacing>();
 
 			if (facing != null)
@@ -57,7 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (--ticks <= 0)
 			{
 				var position = self.CenterPosition;
-				if (position.Z > 0 && self.GetDamageState() >= info.MinDamage && !self.World.FogObscures(self))
+				if (position.Z > 0 && health.DamageState >= info.MinDamage && !self.World.FogObscures(self))
 				{
 					var offset = info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation));
 					var pos = position + body.LocalToWorld(offset);

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -679,4 +679,20 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 	}
+
+	public interface IHealthInfo : ITraitInfo
+	{
+		int MaxHP { get; }
+	}
+
+	public interface IHealth : IActorDeath
+	{
+		DamageState DamageState { get; }
+		int HP { get; }
+		int MaxHP { get; }
+		int DisplayHP { get; }
+
+		void InflictDamage(Actor self, Actor attacker, Damage damage, bool ignoreModifiers);
+		void Kill(Actor self, Actor attacker, BitSet<DamageType> damageTypes);
+	}
 }

--- a/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Warheads
 			return base.IsValidAgainst(victim, firedBy);
 		}
 
-		public int DamageVersus(Actor victim, HitShapeInfo shapeInfo)
+		public int DamageVersus(Actor victim, HitShape shape)
 		{
 			// If no Versus values are defined, DamageVersus would return 100 anyway, so we might as well do that early.
 			if (Versus.Count == 0)
@@ -46,16 +46,19 @@ namespace OpenRA.Mods.Common.Warheads
 
 			var armor = victim.TraitsImplementing<Armor>()
 				.Where(a => !a.IsTraitDisabled && a.Info.Type != null && Versus.ContainsKey(a.Info.Type) &&
-					(shapeInfo.ArmorTypes == default(BitSet<ArmorType>) || shapeInfo.ArmorTypes.Contains(a.Info.Type)))
+					(shape.Info.ArmorTypes == default(BitSet<ArmorType>) || shape.Info.ArmorTypes.Contains(a.Info.Type)))
 				.Select(a => Versus[a.Info.Type]);
 
 			return Util.ApplyPercentageModifiers(100, armor);
 		}
 
-		protected virtual void InflictDamage(Actor victim, Actor firedBy, HitShapeInfo hitshapeInfo, IEnumerable<int> damageModifiers)
+		protected virtual void InflictDamage(Actor victim, Actor firedBy, HitShape shape, IEnumerable<int> damageModifiers)
 		{
-			var damage = Util.ApplyPercentageModifiers(Damage, damageModifiers.Append(DamageVersus(victim, hitshapeInfo)));
-			victim.InflictDamage(firedBy, new Damage(damage, DamageTypes));
+			if (shape.Health == null)
+				return;
+
+			var damage = Util.ApplyPercentageModifiers(Damage, damageModifiers.Append(DamageVersus(victim, shape)));
+			shape.Health.InflictDamage(victim, firedBy, new Damage(damage, DamageTypes), false);
 		}
 
 		public override void DoImpact(Target target, WarheadArgs args)
@@ -77,7 +80,7 @@ namespace OpenRA.Mods.Common.Warheads
 				if (closestActiveShape == null)
 					return;
 
-				InflictDamage(victim, firedBy, closestActiveShape.Info, args.DamageModifiers);
+				InflictDamage(victim, firedBy, closestActiveShape, args.DamageModifiers);
 			}
 			else if (target.Type != TargetType.Invalid)
 				DoImpact(target.CenterPosition, firedBy, args.DamageModifiers);

--- a/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
@@ -17,11 +17,13 @@ namespace OpenRA.Mods.Common.Warheads
 {
 	public class HealthPercentageDamageWarhead : TargetDamageWarhead
 	{
-		protected override void InflictDamage(Actor victim, Actor firedBy, HitShapeInfo hitshapeInfo, IEnumerable<int> damageModifiers)
+		protected override void InflictDamage(Actor victim, Actor firedBy, HitShape shape, IEnumerable<int> damageModifiers)
 		{
-			var healthInfo = victim.Info.TraitInfo<HealthInfo>();
-			var damage = Util.ApplyPercentageModifiers(healthInfo.HP, damageModifiers.Append(Damage, DamageVersus(victim, hitshapeInfo)));
-			victim.InflictDamage(firedBy, new Damage(damage, DamageTypes));
+			if (shape.Health == null)
+				return;
+
+			var damage = Util.ApplyPercentageModifiers(shape.Health.Info.HP, damageModifiers.Append(Damage, DamageVersus(victim, shape)));
+			shape.Health.InflictDamage(victim, firedBy, new Damage(damage, DamageTypes), false);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -65,7 +65,7 @@ namespace OpenRA.Mods.Common.Warheads
 					continue;
 
 				var localModifiers = damageModifiers.Append(GetDamageFalloff(closestActiveShape.Second.Length));
-				InflictDamage(victim, firedBy, closestActiveShape.First.Info, localModifiers);
+				InflictDamage(victim, firedBy, closestActiveShape.First, localModifiers);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Warheads/TargetDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/TargetDamageWarhead.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Warheads
 				if (closestActiveShape.First == null || closestActiveShape.Second > Spread)
 					continue;
 
-				InflictDamage(victim, firedBy, closestActiveShape.First.Info, damageModifiers);
+				InflictDamage(victim, firedBy, closestActiveShape.First, damageModifiers);
 			}
 		}
 	}

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Activities;
 using OpenRA.GameRules;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Effects;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.D2k.Traits;

--- a/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
+++ b/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
+using OpenRA.Mods.Common;
 using OpenRA.Mods.Common.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Mods.Common.Traits.Render;


### PR DESCRIPTION
Adds `IActorDeath` interface housing `IsDead` for backwards-compatibility, moves `IHealth(Info)` interfaces as well as `GetDamageState()` and `Kill` extensions to Mods.Common, gets rid of `Actor.InflictDamage` entirely.

I thought about splitting into multiple PRs, but none of the commits are really huge or complex. Reviewing commit by commit highly recommended.
Commit order may look a bit confusing though (here on gh at least), since I reordered and updated some commits right before pushing.