### PR TITLE
Added some basic error handling to png metadata writing

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/PngSheetImportMetadataCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/PngSheetImportMetadataCommand.cs
@@ -10,7 +10,9 @@
 #endregion
 
 using System.IO;
+using System.Linq;
 using OpenRA.FileFormats;
+using OpenRA.Primitives;
 
 namespace OpenRA.Mods.Common.UtilityCommands
 {
@@ -30,7 +32,23 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			using (var pngStream = File.OpenRead(args[1]))
 				png = new Png(pngStream);
 
-			foreach (var node in MiniYaml.FromFile(Path.ChangeExtension(args[1], "yaml")))
+			var yaml = MiniYaml.FromFile(Path.ChangeExtension(args[1], "yaml"));
+
+			var frameSizeField = yaml.Where(y => y.Key == "FrameSize").Select(y => y.Value.Value).FirstOrDefault();
+			if (frameSizeField != null)
+			{
+				var frameSize = FieldLoader.GetValue<Size>("FrameSize", frameSizeField);
+
+				var frameAmountField = yaml.Where(y => y.Key == "FrameAmount").Select(y => y.Value.Value).FirstOrDefault();
+				if (frameAmountField != null)
+				{
+					var frameAmount = FieldLoader.GetValue<int>("FrameAmount", frameAmountField);
+					if (frameAmount > (png.Width / frameSize.Width) * (png.Height / frameSize.Height))
+						throw new InvalidDataException(".png file is too small for given FrameSize and FrameAmount.");
+				}
+			}
+
+			foreach (var node in yaml)
 				png.EmbeddedData[node.Key] = node.Value.Value;
 
 			png.Save(args[1]);


### PR DESCRIPTION
This catches erroneous data at creation time as we give no suitable error message at runtime.