### PR TITLE
Fix transit-only resupply stuck loop and force fire pathing

### DIFF
--- a/OpenRA.Mods.Common/Activities/Move/Move.cs
+++ b/OpenRA.Mods.Common/Activities/Move/Move.cs
@@ -348,9 +348,14 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override void Cancel(Actor self, bool keepQueue = false)
 		{
+			Cancel(self, keepQueue, false);
+		}
+
+		public void Cancel(Actor self, bool keepQueue, bool forceClearPath)
+		{
 			// We need to clear the path here in order to prevent MovePart queueing new instances of itself
 			// when the unit is making a turn.
-			if (path != null && mobile.CanStayInCell(mobile.ToCell))
+			if (path != null && (forceClearPath || mobile.CanStayInCell(mobile.ToCell)))
 				path.Clear();
 
 			base.Cancel(self, keepQueue);

--- a/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveAdjacentTo.cs
@@ -78,7 +78,8 @@ namespace OpenRA.Mods.Common.Activities
 
 		protected virtual IEnumerable<CPos> CandidateMovementCells(Actor self)
 		{
-			return Util.AdjacentCells(self.World, Target);
+			return Util.AdjacentCells(self.World, Target)
+				.Where(c => Mobile.CanStayInCell(c));
 		}
 
 		protected override void OnFirstRun(Actor self)

--- a/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs
+++ b/OpenRA.Mods.Common/Activities/Move/MoveWithinRange.cs
@@ -33,13 +33,13 @@ namespace OpenRA.Mods.Common.Activities
 		{
 			// We are now in range. Don't move any further!
 			// HACK: This works around the pathfinder not returning the shortest path
-			return AtCorrectRange(self.CenterPosition) && Mobile.CanInteractWithGroundLayer(self);
+			return AtCorrectRange(self.CenterPosition) && Mobile.CanInteractWithGroundLayer(self) && Mobile.CanStayInCell(self.Location);
 		}
 
 		protected override bool ShouldRepath(Actor self, CPos targetLocation)
 		{
 			return lastVisibleTargetLocation != targetLocation && (!AtCorrectRange(self.CenterPosition)
-				|| !Mobile.CanInteractWithGroundLayer(self));
+				|| !Mobile.CanInteractWithGroundLayer(self) || !Mobile.CanStayInCell(self.Location));
 		}
 
 		protected override IEnumerable<CPos> CandidateMovementCells(Actor self)
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Activities
 			var minCells = minRange.Length / 1024;
 
 			return map.FindTilesInAnnulus(lastVisibleTargetLocation, minCells, maxCells)
-				.Where(c => AtCorrectRange(map.CenterOfSubCell(c, Mobile.FromSubCell)));
+				.Where(c => Mobile.CanStayInCell(c) && AtCorrectRange(map.CenterOfSubCell(c, Mobile.FromSubCell)));
 		}
 
 		bool AtCorrectRange(WPos origin)

--- a/OpenRA.Mods.Common/Activities/Resupply.cs
+++ b/OpenRA.Mods.Common/Activities/Resupply.cs
@@ -171,6 +171,12 @@ namespace OpenRA.Mods.Common.Activities
 
 		public override void Cancel(Actor self, bool keepQueue = false)
 		{
+			// HACK: force move activities to ignore the transit-only cells when cancelling
+			// The idle handler will take over and move them into a safe cell
+			if (ChildActivity != null)
+				foreach (var c in ChildActivity.ActivitiesImplementing<Move>())
+					c.Cancel(self, false, true);
+
 			foreach (var t in transportCallers)
 				t.MovementCancelled(self);
 

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -866,7 +866,13 @@ namespace OpenRA.Mods.Common.Traits
 		void INotifyBecomingIdle.OnBecomingIdle(Actor self)
 		{
 			if (self.Location.Layer == 0)
+			{
+				// Make sure that units aren't left idling in a transit-only cell
+				// HACK: activities should be making sure that this can't happen in the first place!
+				if (!Locomotor.CanStayInCell(self.Location))
+					self.QueueActivity(MoveTo(self.Location, evaluateNearestMovableCell: true));
 				return;
+			}
 
 			var cml = self.World.WorldActor.TraitsImplementing<ICustomMovementLayer>()
 				.First(l => l.Index == self.Location.Layer);


### PR DESCRIPTION
fix #17889

* Attacking whilst pathing over transit tiles prevents unit from stopping on a transit tile.
* Move orders can be cancelled on a transit-only tile.
* Idling on a transit only tile causes the unit to move away if it can.

This has potential to introduce regressions that relied on Move not being able to be cancelled on a transit-only tile unless it was marked as destination, although I'm not sure that destination tiles can be transit-only from regular move orders.