### PR TITLE
Use IP2Location GeoIP database.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ mods/*/*.pdb
 /*.exe
 /*.exe.config
 thirdparty/download/*
-*.mmdb.gz
+IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP
 
 # backup files by various editors
 *~

--- a/AUTHORS
+++ b/AUTHORS
@@ -160,9 +160,6 @@ FreeType License.
 
 Using OpenAL Soft distributed under the GNU LGPL.
 
-Using MaxMind GeoIP2 .NET API distributed under
-the Apache 2.0 license.
-
 Using SDL2-CS and OpenAL-CS created by Ethan
 Lee and released under the zlib license.
 
@@ -181,6 +178,9 @@ Krueger and distributed under the GNU GPL terms.
 
 Using rix0rrr.BeaconLib developed by Rico Huijbers
 distributed under MIT License.
+
+This site or product includes IP2Location LITE data
+available from http://www.ip2location.com.
 
 Finally, special thanks goes to the original teams
 at Westwood Studios and EA for creating the classic

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@
 WHITELISTED_OPENRA_ASSEMBLIES = OpenRA.Game.exe OpenRA.Utility.exe OpenRA.Platforms.Default.dll OpenRA.Mods.Common.dll OpenRA.Mods.Cnc.dll OpenRA.Mods.D2k.dll OpenRA.Game.dll
 
 # These are explicitly shipped alongside our core files by the packaging script
-WHITELISTED_THIRDPARTY_ASSEMBLIES = ICSharpCode.SharpZipLib.dll FuzzyLogicLibrary.dll MaxMind.Db.dll Eluant.dll rix0rrr.BeaconLib.dll Open.Nat.dll SDL2-CS.dll OpenAL-CS.dll 
+WHITELISTED_THIRDPARTY_ASSEMBLIES = ICSharpCode.SharpZipLib.dll FuzzyLogicLibrary.dll Eluant.dll rix0rrr.BeaconLib.dll Open.Nat.dll SDL2-CS.dll OpenAL-CS.dll
 
 # These are shipped in our custom minimal mono runtime and also available in the full system-installed .NET/mono stack
 # This list *must* be kept in sync with the files packaged by the AppImageSupport and OpenRALauncherOSX repositories
@@ -157,10 +157,11 @@ ifeq ($(WIN32), $(filter $(WIN32),true yes y on 1))
 else
 	@$(MSBUILD) -t:build -p:Configuration=Release
 endif
+	@./fetch-geoip.sh
 
 clean:
 	@ $(MSBUILD) -t:clean
-	@-$(RM_F) *.config
+	@-$(RM_F) *.config IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP
 	@-$(RM_F) *.exe *.dll *.dylib ./OpenRA*/*.dll *.pdb mods/**/*.dll mods/**/*.pdb *.resources
 	@-$(RM_RF) ./*/bin ./*/obj
 	@-$(RM_RF) ./thirdparty/download
@@ -218,6 +219,7 @@ install-engine:
 	@$(INSTALL_DATA) VERSION "$(DATA_INSTALL_DIR)/VERSION"
 	@$(INSTALL_DATA) AUTHORS "$(DATA_INSTALL_DIR)/AUTHORS"
 	@$(INSTALL_DATA) COPYING "$(DATA_INSTALL_DIR)/COPYING"
+	@$(INSTALL_DATA) IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP "$(DATA_INSTALL_DIR)/IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP"
 
 	@$(CP_R) glsl "$(DATA_INSTALL_DIR)"
 	@$(CP_R) lua "$(DATA_INSTALL_DIR)"
@@ -227,7 +229,6 @@ install-engine:
 	@$(INSTALL_PROGRAM) ICSharpCode.SharpZipLib.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) FuzzyLogicLibrary.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) Open.Nat.dll "$(DATA_INSTALL_DIR)"
-	@$(INSTALL_PROGRAM) MaxMind.Db.dll "$(DATA_INSTALL_DIR)"
 	@$(INSTALL_PROGRAM) rix0rrr.BeaconLib.dll "$(DATA_INSTALL_DIR)"
 
 install-common-mod-files:

--- a/OpenRA.Game/OpenRA.Game.csproj
+++ b/OpenRA.Game/OpenRA.Game.csproj
@@ -58,10 +58,6 @@
       <HintPath>..\thirdparty\download\ICSharpCode.SharpZipLib.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="MaxMind.Db">
-      <HintPath>..\thirdparty\download\MaxMind.Db.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <ProjectReference Include="..\OpenRA.PostProcess\OpenRA.PostProcess.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -149,7 +149,8 @@ namespace OpenRA.Server
 
 			randomSeed = (int)DateTime.Now.ToBinary();
 
-			GeoIP.Initialize(settings.GeoIPDatabase);
+			if (type != ServerType.Local && settings.EnableGeoIP)
+				GeoIP.Initialize();
 
 			if (UPnP.Status == UPnPStatus.Enabled)
 				UPnP.ForwardPort(Settings.ListenPort, Settings.ListenPort).Wait();

--- a/OpenRA.Game/Server/Server.cs
+++ b/OpenRA.Game/Server/Server.cs
@@ -349,7 +349,7 @@ namespace OpenRA.Server
 				{
 					Name = OpenRA.Settings.SanitizedPlayerName(handshake.Client.Name),
 					IPAddress = ipAddress.ToString(),
-					AnonymizedIPAddress = Settings.ShareAnonymizedIPs ? Session.AnonymizeIP(ipAddress) : null,
+					AnonymizedIPAddress = Type != ServerType.Local && Settings.ShareAnonymizedIPs ? Session.AnonymizeIP(ipAddress) : null,
 					Location = GeoIP.LookupCountry(ipAddress),
 					Index = newConn.PlayerIndex,
 					PreferredColor = handshake.Client.PreferredColor,

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -82,12 +82,11 @@ namespace OpenRA
 		[Desc("Sets the timestamp format. Defaults to the ISO 8601 standard.")]
 		public string TimestampFormat = "yyyy-MM-ddTHH:mm:ss";
 
-		[Desc("Path to a MaxMind GeoLite2 database to use for player geo-location.",
-			"Database files can be downloaded from https://dev.maxmind.com/geoip/geoip2/geolite2/")]
-		public string GeoIPDatabase = null;
-
 		[Desc("Allow clients to see anonymised IPs for other clients.")]
 		public bool ShareAnonymizedIPs = true;
+
+		[Desc("Allow clients to see the country of other clients.")]
+		public bool EnableGeoIP = true;
 
 		public ServerSettings Clone()
 		{

--- a/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/PlayerProfileLogic.cs
@@ -322,8 +322,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 
 			if (client.Location != null)
 			{
+				var locationFont = Game.Renderer.Fonts[locationLabel.Font];
+				var locationWidth = widget.Bounds.Width - 2 * locationLabel.Bounds.X;
+				var location = WidgetUtils.TruncateText(client.Location, locationWidth, locationFont);
 				locationLabel.IsVisible = () => true;
-				locationLabel.GetText = () => client.Location;
+				locationLabel.GetText = () => location;
 				widget.Bounds.Height += locationLabel.Bounds.Height;
 				ipLabel.Bounds.Y += locationLabel.Bounds.Height;
 				adminLabel.Bounds.Y += locationLabel.Bounds.Height;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,7 @@ test_script:
   - nunit3-console OpenRA.Test.dll --result=myresults.xml;format=AppVeyor
 
 after_test:
+  - appveyor DownloadFile "https://download.ip2location.com/lite/IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP" -FileName IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP
   - appveyor DownloadFile "https://raw.githubusercontent.com/wiki/OpenRA/OpenRA/Changelog.md" -FileName Changelog.md
   - make docs
   - ps: dir *.md | % {gc $_ -Raw | .\ConvertFrom-Markdown.ps1 | Out-File -FilePath "$($_.Name.TrimEnd(".md")).html"}

--- a/fetch-geoip.sh
+++ b/fetch-geoip.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Download the IP2Location country database for use by the game server
+
+####
+# This file must stay /bin/sh and POSIX compliant for macOS and BSD portability.
+# Copy-paste the entire script into http://shellcheck.net to check.
+####
+
+# Set the working directory to the location of this script
+cd "$(dirname "$0")" || exit 1
+
+# Database does not exist or is older than 30 days.
+if [ -z "$(find . -path ./IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP -mtime -30 -print)" ]; then
+	rm -f IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP
+	echo "Downloading IP2Location GeoIP database."
+	if command -v curl >/dev/null 2>&1; then
+		curl -s -L -O https://download.ip2location.com/lite/IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP || echo "Warning: Download failed"
+	else
+		wget -cq https://download.ip2location.com/lite/IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP || echo "Warning: Download failed"
+	fi
+fi

--- a/launch-dedicated.cmd
+++ b/launch-dedicated.cmd
@@ -8,20 +8,19 @@ set ListenPort=1234
 set AdvertiseOnline=True
 set Password=""
 
-set GeoIPDatabase=""
-
 set RequireAuthentication=False
 set ProfileIDBlacklist=""
 set ProfileIDWhitelist=""
 
 set EnableSingleplayer=False
 set EnableSyncReports=False
+set EnableGeoIP=True
 set ShareAnonymizedIPs=True
 
 set SupportDir=""
 
 :loop
 
-OpenRA.Server.exe Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.GeoIPDatabase=%GeoIPDatabase% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports% Server.ShareAnonymizedIPs=%ShareAnonymizedIPs% Engine.SupportDir=%SupportDir%
+OpenRA.Server.exe Game.Mod=%Mod% Server.Name=%Name% Server.ListenPort=%ListenPort% Server.AdvertiseOnline=%AdvertiseOnline% Server.EnableSingleplayer=%EnableSingleplayer% Server.Password=%Password% Server.RequireAuthentication=%RequireAuthentication% Server.ProfileIDBlacklist=%ProfileIDBlacklist% Server.ProfileIDWhitelist=%ProfileIDWhitelist% Server.EnableSyncReports=%EnableSyncReports% Server.EnableGeoIP=%EnableGeoIP% Server.ShareAnonymizedIPs=%ShareAnonymizedIPs% Engine.SupportDir=%SupportDir%
 
 goto loop

--- a/launch-dedicated.sh
+++ b/launch-dedicated.sh
@@ -12,14 +12,13 @@ ListenPort="${ListenPort:-"1234"}"
 AdvertiseOnline="${AdvertiseOnline:-"True"}"
 Password="${Password:-""}"
 
-GeoIPDatabase="${GeoIPDatabase:-""}"
-
 RequireAuthentication="${RequireAuthentication:-"False"}"
 ProfileIDBlacklist="${ProfileIDBlacklist:-""}"
 ProfileIDWhitelist="${ProfileIDWhitelist:-""}"
 
 EnableSingleplayer="${EnableSingleplayer:-"False"}"
 EnableSyncReports="${EnableSyncReports:-"False"}"
+EnableGeoIP="${EnableGeoIP:-"True"}"
 ShareAnonymizedIPs="${ShareAnonymizedIPs:-"True"}"
 
 SupportDir="${SupportDir:-""}"
@@ -36,6 +35,7 @@ while true; do
      Server.ProfileIDBlacklist="$ProfileIDBlacklist" \
      Server.ProfileIDWhitelist="$ProfileIDWhitelist" \
      Server.EnableSyncReports="$EnableSyncReports" \
+     Server.EnableGeoIP="$EnableGeoIP" \
      Server.ShareAnonymizedIPs="$ShareAnonymizedIPs" \
      Engine.SupportDir="$SupportDir"
 done

--- a/make.ps1
+++ b/make.ps1
@@ -21,6 +21,13 @@ function All-Command
 	{
 		Write-Host "Build succeeded." -ForegroundColor Green
 	}
+
+	if (!(Test-Path "IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP") -Or (((get-date) - (get-item "IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP").LastWriteTime) -gt (new-timespan -days 30)))
+	{
+		echo "Downloading IP2Location GeoIP database."
+		$target = Join-Path $pwd.ToString() "IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP"
+		(New-Object System.Net.WebClient).DownloadFile("https://download.ip2location.com/lite/IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP", $target)
+	}
 }
 
 function Clean-Command 

--- a/packaging/windows/OpenRA.nsi
+++ b/packaging/windows/OpenRA.nsi
@@ -131,7 +131,7 @@ Section "Game" GAME
 	File "${SRCDIR}\SDL2-CS.dll"
 	File "${SRCDIR}\OpenAL-CS.dll"
 	File "${SRCDIR}\global mix database.dat"
-	File "${SRCDIR}\MaxMind.Db.dll"
+	File "${SRCDIR}\IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP"
 	File "${SRCDIR}\eluant.dll"
 	File "${SRCDIR}\rix0rrr.BeaconLib.dll"
 	File "${DEPSDIR}\soft_oal.dll"
@@ -248,8 +248,7 @@ Function ${UN}Clean
 	Delete $INSTDIR\TiberianDawn.ico
 	Delete $INSTDIR\Dune2000.ico
 	Delete "$INSTDIR\global mix database.dat"
-	Delete $INSTDIR\MaxMind.Db.dll
-	Delete $INSTDIR\KopiLua.dll
+	Delete $INSTDIR\IP2LOCATION-LITE-DB1.IPV6.BIN.ZIP
 	Delete $INSTDIR\soft_oal.dll
 	Delete $INSTDIR\SDL2.dll
 	Delete $INSTDIR\lua51.dll

--- a/thirdparty/fetch-thirdparty-deps.ps1
+++ b/thirdparty/fetch-thirdparty-deps.ps1
@@ -19,14 +19,6 @@ if (!(Test-Path "ICSharpCode.SharpZipLib.dll"))
 	rmdir SharpZipLib -Recurse
 }
 
-if (!(Test-Path "MaxMind.Db.dll"))
-{
-	echo "Fetching MaxMind.Db from NuGet."
-	./nuget.exe install MaxMind.Db -Version 2.0.0 -ExcludeVersion -Verbosity quiet -Source nuget.org
-	cp MaxMind.Db/lib/net45/MaxMind.Db.* .
-	rmdir MaxMind.Db -Recurse
-}
-
 if (!(Test-Path "nunit.framework.dll"))
 {
 	echo "Fetching NUnit from NuGet."

--- a/thirdparty/fetch-thirdparty-deps.sh
+++ b/thirdparty/fetch-thirdparty-deps.sh
@@ -20,13 +20,6 @@ if [ ! -f ICSharpCode.SharpZipLib.dll ]; then
 	rm -rf SharpZipLib
 fi
 
-if [ ! -f MaxMind.Db.dll ]; then
-	echo "Fetching MaxMind.Db from NuGet"
-	../noget.sh MaxMind.Db 2.0.0 -IgnoreDependencies
-	cp ./MaxMind.Db/lib/net45/MaxMind.Db.* .
-	rm -rf MaxMind.Db
-fi
-
 if [ ! -f nunit.framework.dll ]; then
 	echo "Fetching NUnit from NuGet"
 	../noget.sh NUnit 3.0.1


### PR DESCRIPTION
This PR fixes #17893 by changing the GeoIP data source from MaxMind to IP2Location and changing the build scripts to once again download and package the database. It also adds support for IPv6 geolocation, which will be useful once #17571 is ready.

This mitigates the risk from a future IP2Location license change by making sure that the build succeeds with a warning instead of breaking if the source URL ever changes. As mentioned in https://github.com/OpenRA/OpenRA/issues/17893#issuecomment-612436730, we should aim to move the responsibility for downloading the file to the server itself in a future (non-prep) PR to further improve robustness.

This also disables GeoIP and IP display for skirmish games where they can never show useful information.

Test builds with the first two commits can be downloaded from https://github.com/pchote/OpenRA/releases/tag/devtest-20200412. I have tested that the build and packaging scripts are working as expected on macOS/Linux/Windows.

This is going to conflict with #17744, but should be reasonably painless to resolve - the new logic is implemented in the `core` rule rather than the to-be-removed `dependencies`, and the project file/packaging conflicts are mostly because we are both removing the same thing. 