### PR TITLE
Fix aircraft attack (strafe) runs with sliding behaviour

### DIFF
--- a/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyAttack.cs
@@ -207,8 +207,9 @@ namespace OpenRA.Mods.Common.Activities
 
 	class FlyAttackRun : Activity
 	{
+		readonly WDist exitRange;
+
 		Target target;
-		WDist exitRange;
 		bool targetIsVisibleActor;
 
 		public FlyAttackRun(Actor self, in Target t, WDist exitRange)
@@ -250,9 +251,10 @@ namespace OpenRA.Mods.Common.Activities
 
 	class StrafeAttackRun : Activity
 	{
-		Target target;
-		WDist exitRange;
 		readonly AttackAircraft attackAircraft;
+		readonly WDist exitRange;
+
+		Target target;
 
 		public StrafeAttackRun(Actor self, AttackAircraft attackAircraft, in Target t, WDist exitRange)
 		{

--- a/OpenRA.Mods.Common/Activities/Air/FlyForward.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyForward.cs
@@ -18,13 +18,26 @@ namespace OpenRA.Mods.Common.Activities
 	{
 		readonly Aircraft aircraft;
 		readonly WDist cruiseAltitude;
-		int remainingTicks;
+		readonly int flyTicks;
+		int remainingDistance;
+		int ticks;
 
-		public FlyForward(int ticks, Actor self)
+		FlyForward(Actor self)
 		{
-			remainingTicks = ticks;
 			aircraft = self.Trait<Aircraft>();
 			cruiseAltitude = aircraft.Info.CruiseAltitude;
+		}
+
+		public FlyForward(int ticks, Actor self)
+			: this(self)
+		{
+			flyTicks = ticks;
+		}
+
+		public FlyForward(Actor self, WDist distance)
+			: this(self)
+		{
+			remainingDistance = distance.Length;
 		}
 
 		public override bool Tick(Actor self)
@@ -36,11 +49,15 @@ namespace OpenRA.Mods.Common.Activities
 				return true;
 			}
 
-			if (IsCanceling || remainingTicks-- == 0)
+			// Having flyTicks < 0 is valid and means the actor flies until this activity is canceled
+			if (IsCanceling || (flyTicks > 0 && ticks++ >= flyTicks) || (flyTicks == 0 && remainingDistance <= 0))
 				return true;
 
-			Fly.FlyTick(self, aircraft, aircraft.Facing, cruiseAltitude);
+			// FlyTick moves the aircraft while FlyStep calculates how far we are moving
+			if (remainingDistance != 0)
+				remainingDistance -= aircraft.FlyStep(aircraft.Facing).HorizontalLength;
 
+			Fly.FlyTick(self, aircraft, aircraft.Facing, cruiseAltitude);
 			return false;
 		}
 	}

--- a/OpenRA.Mods.Common/Activities/Air/FlyForward.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyForward.cs
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Activities
 			cruiseAltitude = aircraft.Info.CruiseAltitude;
 		}
 
-		public FlyForward(int ticks, Actor self)
+		public FlyForward(Actor self, int ticks = -1)
 			: this(self)
 		{
 			flyTicks = ticks;

--- a/OpenRA.Mods.Common/Activities/Air/FlyForward.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyForward.cs
@@ -14,13 +14,13 @@ using OpenRA.Mods.Common.Traits;
 
 namespace OpenRA.Mods.Common.Activities
 {
-	public class FlyTimed : Activity
+	public class FlyForward : Activity
 	{
 		readonly Aircraft aircraft;
 		readonly WDist cruiseAltitude;
 		int remainingTicks;
 
-		public FlyTimed(int ticks, Actor self)
+		public FlyForward(int ticks, Actor self)
 		{
 			remainingTicks = ticks;
 			aircraft = self.Trait<Aircraft>();

--- a/OpenRA.Mods.Common/Activities/Air/FlyOffMap.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyOffMap.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (hasTarget)
 			{
 				QueueChild(new Fly(self, target));
-				QueueChild(new FlyForward(-1, self));
+				QueueChild(new FlyForward(self));
 				return;
 			}
 
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (aircraft.Info.VTOL && self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition) != aircraft.Info.CruiseAltitude)
 				QueueChild(new TakeOff(self));
 
-			QueueChild(new FlyForward(-1, self));
+			QueueChild(new FlyForward(self));
 		}
 
 		public override bool Tick(Actor self)

--- a/OpenRA.Mods.Common/Activities/Air/FlyOffMap.cs
+++ b/OpenRA.Mods.Common/Activities/Air/FlyOffMap.cs
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (hasTarget)
 			{
 				QueueChild(new Fly(self, target));
-				QueueChild(new FlyTimed(-1, self));
+				QueueChild(new FlyForward(-1, self));
 				return;
 			}
 
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Activities
 			if (aircraft.Info.VTOL && self.World.Map.DistanceAboveTerrain(aircraft.CenterPosition) != aircraft.Info.CruiseAltitude)
 				QueueChild(new TakeOff(self));
 
-			QueueChild(new FlyTimed(-1, self));
+			QueueChild(new FlyForward(-1, self));
 		}
 
 		public override bool Tick(Actor self)


### PR DESCRIPTION
Having the `Default` or `Strafe` attack types together with `CanSlide: true` produced this
![strafeSlide](https://user-images.githubusercontent.com/7704140/79143261-359d1780-7dbd-11ea-96e5-fdb04f162114.gif)

This PR introduces `FlyDistance` which just flies the distance given in a straight line from the position the activity starts and then uses that new activity to fly the strafing distance instead of relying on edge cases inside the default `Fly`.
