### PR TITLE
Add per Player UnitDamage Handicap Dropdown to Lobby

### DIFF
--- a/OpenRA.Game/Network/Session.cs
+++ b/OpenRA.Game/Network/Session.cs
@@ -138,6 +138,7 @@ namespace OpenRA.Network
 			public string Location;
 
 			public ClientState State = ClientState.Invalid;
+			public int Handicap = 100; // could be 50, 60, 70, 80, 90 or 100
 			public int Team;
 			public string Slot; // Slot ID, or null for observer
 			public string Bot; // Bot type, null for real clients

--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -54,6 +54,7 @@ namespace OpenRA
 		public readonly bool NonCombatant = false;
 		public readonly bool Playable = true;
 		public readonly int ClientIndex;
+		public readonly int Handicap = 100;
 		public readonly PlayerReference PlayerReference;
 		public readonly bool IsBot;
 		public readonly string BotType;
@@ -146,6 +147,7 @@ namespace OpenRA
 				BotType = client.Bot;
 				Faction = ChooseFaction(world, client.Faction, !pr.LockFaction);
 				DisplayFaction = ChooseDisplayFaction(world, client.Faction);
+				Handicap = client.Handicap;
 			}
 			else
 			{

--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -170,6 +170,13 @@ namespace OpenRA.Mods.Common.Traits
 					.Concat(damageModifiersPlayer)
 					.Select(t => t.GetDamageModifier(attacker, damage));
 
+				if (attacker.Owner.Handicap > 0)
+				{
+					var list = modifiers.ToList();
+					list.Add(attacker.Owner.Handicap);
+					modifiers = list;
+				}
+
 				damage = new Damage(Util.ApplyPercentageModifiers(damage.Value, modifiers), damage.DamageTypes);
 			}
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyLogic.cs
@@ -194,6 +194,12 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 				};
 			}
 
+			var handicapButton = lobby.GetOrNull<DropDownButtonWidget>("HANDICAP_DROPDOWNBUTTON");
+			if (handicapButton != null)
+			{
+				handicapButton.IsDisabled = () => configurationDisabled();
+			}
+
 			var slotsButton = lobby.GetOrNull<DropDownButtonWidget>("SLOTS_DROPDOWNBUTTON");
 			if (slotsButton != null)
 			{
@@ -618,6 +624,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					LobbyUtils.SetupEditableFactionWidget(template, slot, client, orderManager, factions);
 					LobbyUtils.SetupEditableTeamWidget(template, slot, client, orderManager, map);
 					LobbyUtils.SetupEditableSpawnWidget(template, slot, client, orderManager, map);
+					LobbyUtils.SetupEditableHandicapWidget(template, slot, client, orderManager);
 					LobbyUtils.SetupEditableReadyWidget(template, slot, client, orderManager, map);
 				}
 				else
@@ -629,6 +636,7 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					LobbyUtils.SetupLatencyWidget(template, client, orderManager);
 					LobbyUtils.SetupColorWidget(template, slot, client);
 					LobbyUtils.SetupFactionWidget(template, slot, client, factions);
+					LobbyUtils.SetupHandicapWidget(template, slot, client);
 
 					if (isHost)
 					{

--- a/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Lobby/LobbyUtils.cs
@@ -162,6 +162,23 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			dropdown.ShowDropDown("SPAWN_DROPDOWN_TEMPLATE", 150, spawnPoints, setupItem);
 		}
 
+		public static void ShowHandicapDropDown(DropDownButtonWidget dropdown, Session.Client client,
+			OrderManager orderManager)
+		{
+			Func<int, ScrollItemWidget, ScrollItemWidget> setupItem = (ii, itemTemplate) =>
+			{
+				var item = ScrollItemWidget.Setup(itemTemplate,
+					() => client.Handicap == ii,
+					() => orderManager.IssueOrder(Order.Command("handicap {0} {1}".F(client.Index, ii))));
+
+				item.Get<LabelWidget>("LABEL").GetText = () => ii.ToString();
+				return item;
+			};
+
+			int[] options = { 100, 90, 80, 70, 60, 50 };
+			dropdown.ShowDropDown("HANDICAP_DROPDOWN_TEMPLATE", 150, options, setupItem);
+		}
+
 		/// <summary>Splits a string into two parts on the first instance of a given token.</summary>
 		static Pair<string, string> SplitOnFirstToken(string input, string token = "\\n")
 		{
@@ -524,6 +541,25 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var factionFlag = parent.Get<ImageWidget>("FACTIONFLAG");
 			factionFlag.GetImageName = () => c.Faction;
 			factionFlag.GetImageCollection = () => "flags";
+		}
+
+		public static void SetupEditableHandicapWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager)
+		{
+			var dropdown = parent.Get<DropDownButtonWidget>("HANDICAP_DROPDOWN");
+			dropdown.IsVisible = () => true;
+			dropdown.IsDisabled = () => orderManager.LocalClient.IsReady;
+			dropdown.OnMouseDown = _ => ShowHandicapDropDown(dropdown, c, orderManager);
+			dropdown.GetText = () => (c.Handicap == 0) ? "-" : c.Handicap.ToString();
+
+			HideChildWidget(parent, "HANDICAP");
+		}
+
+		public static void SetupHandicapWidget(Widget parent, Session.Slot s, Session.Client c)
+		{
+			var team = parent.Get<LabelWidget>("HANDICAP");
+			team.IsVisible = () => true;
+			team.GetText = () => (c.Handicap == 0) ? "-" : c.Handicap.ToString();
+			HideChildWidget(parent, "HANDICAP_DROPDOWN");
 		}
 
 		public static void SetupEditableTeamWidget(Widget parent, Session.Slot s, Session.Client c, OrderManager orderManager, MapPreview map)

--- a/mods/cnc/chrome/dialogs.yaml
+++ b/mods/cnc/chrome/dialogs.yaml
@@ -112,6 +112,22 @@ ScrollPanel@SPAWN_DROPDOWN_TEMPLATE:
 					Height: 25
 					Align: Center
 
+ScrollPanel@HANDICAP_DROPDOWN_TEMPLATE:
+	Width: DROPDOWN_WIDTH
+	Children:
+		ScrollItem@TEMPLATE:
+			Width: PARENT_RIGHT - 27
+			Height: 25
+			X: 2
+			Y: 0
+			Visible: false
+			Children:
+				Label@LABEL:
+					X: 0
+					Width: PARENT_RIGHT
+					Height: 25
+					Align: Center
+
 ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 	Width: DROPDOWN_WIDTH
 	Background: panel-black

--- a/mods/cnc/chrome/lobby-players.yaml
+++ b/mods/cnc/chrome/lobby-players.yaml
@@ -40,24 +40,31 @@ Container@LOBBY_PLAYER_BIN:
 					Width: 50
 					Height: 25
 					Text: Spawn
+					Align: Center
+					Font: Bold
+				Label@HANDICAP:
+					X: 527
+					Width: 91
+					Height: 25
+					Text: Unit Damage
 					Align: Left
 					Font: Bold
 				Label@STATUS:
-					X: 527
+					X: 627
 					Width: 20
 					Height: 25
 					Text: Ready
 					Align: Left
 					Font: Bold
 		ScrollPanel@LOBBY_PLAYERS:
-			Width: PARENT_RIGHT
+			Width: PARENT_RIGHT + 100
 			Height: PARENT_BOTTOM
 			TopBottomSpacing: 5
 			ItemSpacing: 5
 			Children:
 				Container@TEMPLATE_EDITABLE_PLAYER:
 					X: 5
-					Width: 530
+					Width: 630
 					Height: 25
 					Visible: false
 					Children:
@@ -147,8 +154,13 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 50
 							Height: 25
 							Font: Regular
+						DropDownButton@HANDICAP_DROPDOWN:
+							X: 526
+							Width: 95
+							Height: 25
+							Font: Regular
 						Image@STATUS_IMAGE:
-							X: 529
+							X: 629
 							Y: 4
 							Width: 20
 							Height: 20
@@ -156,14 +168,14 @@ Container@LOBBY_PLAYER_BIN:
 							ImageName: checked
 							Visible: false
 						Checkbox@STATUS_CHECKBOX:
-							X: 527
+							X: 627
 							Y: 2
 							Width: 20
 							Height: 20
 							Visible: false
 				Container@TEMPLATE_NONEDITABLE_PLAYER:
 					X: 5
-					Width: 530
+					Width: 630
 					Height: 25
 					Visible: false
 					Children:
@@ -251,6 +263,11 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 25
 							Height: 25
 							Align: Center
+						Label@HANDICAP:
+							X: 529
+							Width: 65
+							Height: 25
+							Align: Center
 						DropDownButton@TEAM_DROPDOWN:
 							X: 416
 							Width: 50
@@ -261,10 +278,15 @@ Container@LOBBY_PLAYER_BIN:
 							X: 471
 							Width: 50
 							Height: 25
+							Visible: false
+						DropDownButton@HANDICAP_DROPDOWN:
+							X: 529
+							Width: 95
+							Height: 25
 							Font: Regular
 							Visible: false
 						Image@STATUS_IMAGE:
-							X: 529
+							X: 629
 							Y: 4
 							Width: 20
 							Height: 20
@@ -273,7 +295,7 @@ Container@LOBBY_PLAYER_BIN:
 							Visible: false
 				Container@TEMPLATE_EMPTY:
 					X: 5
-					Width: 530
+					Width: 630
 					Height: 25
 					Visible: false
 					Children:
@@ -291,7 +313,7 @@ Container@LOBBY_PLAYER_BIN:
 							Visible: false
 						Button@JOIN:
 							X: 210
-							Width: 338
+							Width: 411
 							Height: 25
 							Text: Play in this slot
 							Font: Regular
@@ -340,13 +362,13 @@ Container@LOBBY_PLAYER_BIN:
 									Template: ANONYMOUS_PLAYER_TOOLTIP
 						Label@SPECTATOR:
 							X: 210
-							Width: 341
+							Width: 411
 							Height: 25
 							Text: Spectator
 							Align: Center
 							Font: Bold
 						Image@STATUS_IMAGE:
-							X: 529
+							X: 629
 							Y: 4
 							Width: 20
 							Height: 20
@@ -354,7 +376,7 @@ Container@LOBBY_PLAYER_BIN:
 							ImageName: checked
 							Visible: false
 						Checkbox@STATUS_CHECKBOX:
-							X: 527
+							X: 627
 							Y: 2
 							Width: 20
 							Height: 20
@@ -436,7 +458,7 @@ Container@LOBBY_PLAYER_BIN:
 							Visible: false
 				Container@TEMPLATE_NEW_SPECTATOR:
 					X: 5
-					Width: 529
+					Width: 629
 					Height: 25
 					Visible: false
 					Children:
@@ -448,7 +470,7 @@ Container@LOBBY_PLAYER_BIN:
 							Text: Allow Spectators?
 						Button@SPECTATE:
 							X: 210
-							Width: 338
+							Width: 411
 							Height: 25
 							Text: Spectate
 							Font: Regular

--- a/mods/cnc/chrome/lobby.yaml
+++ b/mods/cnc/chrome/lobby.yaml
@@ -2,7 +2,7 @@ Container@SERVER_LOBBY:
 	Logic: LobbyLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - 560) / 2
-	Width: 800
+	Width: 900
 	Height: 575
 	Children:
 		ColorPreviewManager@COLOR_MANAGER:

--- a/mods/common/chrome/dropdowns.yaml
+++ b/mods/common/chrome/dropdowns.yaml
@@ -74,6 +74,22 @@ ScrollPanel@SPAWN_DROPDOWN_TEMPLATE:
 					Height: 25
 					Align: Center
 
+ScrollPanel@HANDICAP_DROPDOWN_TEMPLATE:
+	Width: DROPDOWN_WIDTH
+	Children:
+		ScrollItem@TEMPLATE:
+			Width: PARENT_RIGHT - 27
+			Height: 25
+			X: 2
+			Y: 0
+			Visible: false
+			Children:
+				Label@LABEL:
+					X: 0
+					Width: PARENT_RIGHT
+					Height: 25
+					Align: Center
+
 ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 	Width: DROPDOWN_WIDTH
 	Background: observer-scrollpanel-button-pressed

--- a/mods/common/chrome/lobby-players.yaml
+++ b/mods/common/chrome/lobby-players.yaml
@@ -42,15 +42,22 @@ Container@LOBBY_PLAYER_BIN:
 					Text: Spawn
 					Align: Center
 					Font: Bold
-				Label@LABEL_LOBBY_STATUS:
+				Label@LABEL_LOBBY_HANDICAP:
 					X: 525
+					Width: 91
+					Height: 25
+					Text: Unit Damage
+					Align: Left
+					Font: Bold
+				Label@LABEL_LOBBY_STATUS:
+					X: 625
 					Width: 20
 					Height: 25
 					Text: Ready
 					Align: Left
 					Font: Bold
 		ScrollPanel@LOBBY_PLAYERS:
-			Width: PARENT_RIGHT
+			Width: PARENT_RIGHT + 100
 			Height: PARENT_BOTTOM
 			TopBottomSpacing: 5
 			ItemSpacing: 5
@@ -144,14 +151,19 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 48
 							Height: 25
 							Text: Spawn
-						Checkbox@STATUS_CHECKBOX:
+						DropDownButton@HANDICAP_DROPDOWN:
 							X: 525
+							Width: 91
+							Height: 25
+							Text: Handicap
+						Checkbox@STATUS_CHECKBOX:
+							X: 625
 							Y: 2
 							Width: 20
 							Height: 20
 							Visible: false
 						Image@STATUS_IMAGE:
-							X: 527
+							X: 627
 							Y: 4
 							Width: 20
 							Height: 20
@@ -249,6 +261,11 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 23
 							Height: 25
 							Align: Center
+						Label@HANDICAP:
+							X: 525
+							Width: 66
+							Height: 25
+							Align: Center
 						DropDownButton@TEAM_DROPDOWN:
 							X: 410
 							Width: 48
@@ -259,8 +276,13 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 48
 							Height: 25
 							Visible: false
+						DropDownButton@HANDICAP_DROPDOWN:
+							X: 525
+							Width: 66
+							Height: 25
+							Visible: false
 						Image@STATUS_IMAGE:
-							X: 527
+							X: 627
 							Y: 4
 							Width: 20
 							Height: 20
@@ -287,7 +309,7 @@ Container@LOBBY_PLAYER_BIN:
 						Button@JOIN:
 							X: 190
 							Text: Play in this slot
-							Width: 326
+							Width: 426
 							Height: 25
 				Container@TEMPLATE_EDITABLE_SPECTATOR:
 					X: 5
@@ -333,19 +355,19 @@ Container@LOBBY_PLAYER_BIN:
 									Template: ANONYMOUS_PLAYER_TOOLTIP
 						Label@SPECTATOR:
 							X: 190
-							Width: 326
+							Width: 426
 							Height: 25
 							Text: Spectator
 							Align: Center
 							Font: Bold
 						Checkbox@STATUS_CHECKBOX:
-							X: 525
+							X: 625
 							Y: 2
 							Width: 20
 							Height: 20
 							Visible: false
 						Image@STATUS_IMAGE:
-							X: 527
+							X: 627
 							Y: 4
 							Width: 20
 							Height: 20
@@ -414,13 +436,13 @@ Container@LOBBY_PLAYER_BIN:
 									Template: ANONYMOUS_PLAYER_TOOLTIP
 						Label@SPECTATOR:
 							X: 190
-							Width: 326
+							Width: 426
 							Height: 25
 							Text: Spectator
 							Align: Center
 							Font: Bold
 						Image@STATUS_IMAGE:
-							X: 527
+							X: 627
 							Y: 4
 							Width: 20
 							Height: 20
@@ -429,7 +451,7 @@ Container@LOBBY_PLAYER_BIN:
 							Visible: false
 				Container@TEMPLATE_NEW_SPECTATOR:
 					X: 5
-					Width: 475
+					Width: 575
 					Height: 25
 					Visible: false
 					Children:
@@ -441,7 +463,7 @@ Container@LOBBY_PLAYER_BIN:
 							Text: Allow Spectators?
 						Button@SPECTATE:
 							X: 190
-							Width: 326
+							Width: 426
 							Height: 25
 							Text: Spectate
 							Font: Regular

--- a/mods/common/chrome/lobby.yaml
+++ b/mods/common/chrome/lobby.yaml
@@ -2,7 +2,7 @@ Background@SERVER_LOBBY:
 	Logic: LobbyLogic
 	X: (WINDOW_RIGHT - WIDTH) / 2
 	Y: (WINDOW_BOTTOM - HEIGHT) / 2
-	Width: 808
+	Width: 908
 	Height: 600
 	Children:
 		ColorPreviewManager@COLOR_MANAGER:

--- a/mods/d2k/chrome/dropdowns.yaml
+++ b/mods/d2k/chrome/dropdowns.yaml
@@ -74,6 +74,22 @@ ScrollPanel@SPAWN_DROPDOWN_TEMPLATE:
 					Height: 25
 					Align: Center
 
+ScrollPanel@HANDICAP_DROPDOWN_TEMPLATE:
+	Width: DROPDOWN_WIDTH
+	Children:
+		ScrollItem@TEMPLATE:
+			Width: PARENT_RIGHT - 27
+			Height: 25
+			X: 2
+			Y: 0
+			Visible: false
+			Children:
+				Label@LABEL:
+					X: 0
+					Width: PARENT_RIGHT
+					Height: 25
+					Align: Center
+
 ScrollPanel@SPECTATOR_DROPDOWN_TEMPLATE:
 	Width: DROPDOWN_WIDTH
 	Children:

--- a/mods/d2k/chrome/lobby-players.yaml
+++ b/mods/d2k/chrome/lobby-players.yaml
@@ -42,15 +42,22 @@ Container@LOBBY_PLAYER_BIN:
 					Text: Spawn
 					Align: Center
 					Font: Bold
-				Label@LABEL_LOBBY_STATUS:
+				Label@LABEL_LOBBY_HANDICAP:
 					X: 525
+					Width: 91
+					Height: 25
+					Text: Unit Damage
+					Align: Left
+					Font: Bold
+				Label@LABEL_LOBBY_STATUS:
+					X: 625
 					Width: 20
 					Height: 25
 					Text: Ready
 					Align: Left
 					Font: Bold
 		ScrollPanel@LOBBY_PLAYERS:
-			Width: PARENT_RIGHT
+			Width: PARENT_RIGHT + 100
 			Height: PARENT_BOTTOM
 			TopBottomSpacing: 5
 			ItemSpacing: 5
@@ -144,14 +151,19 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 48
 							Height: 25
 							Text: Spawn
-						Checkbox@STATUS_CHECKBOX:
+						DropDownButton@HANDICAP_DROPDOWN:
 							X: 525
+							Width: 91
+							Height: 25
+							Text: Handicap
+						Checkbox@STATUS_CHECKBOX:
+							X: 625
 							Y: 2
 							Width: 20
 							Height: 20
 							Visible: false
 						Image@STATUS_IMAGE:
-							X: 527
+							X: 627
 							Y: 4
 							Width: 20
 							Height: 20
@@ -249,6 +261,11 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 23
 							Height: 25
 							Align: Center
+						Label@HANDICAP:
+							X: 525
+							Width: 66
+							Height: 25
+							Align: Center
 						DropDownButton@TEAM_DROPDOWN:
 							X: 410
 							Width: 48
@@ -259,8 +276,13 @@ Container@LOBBY_PLAYER_BIN:
 							Width: 48
 							Height: 25
 							Visible: false
+						DropDownButton@HANDICAP_DROPDOWN:
+							X: 525
+							Width: 91
+							Height: 25
+							Visible: false
 						Image@STATUS_IMAGE:
-							X: 527
+							X: 627
 							Y: 4
 							Width: 20
 							Height: 20
@@ -286,7 +308,7 @@ Container@LOBBY_PLAYER_BIN:
 							Visible: false
 						Button@JOIN:
 							X: 190
-							Width: 326
+							Width: 426
 							Height: 25
 							Text: Play in this slot
 				Container@TEMPLATE_EDITABLE_SPECTATOR:
@@ -333,19 +355,19 @@ Container@LOBBY_PLAYER_BIN:
 									Template: ANONYMOUS_PLAYER_TOOLTIP
 						Label@SPECTATOR:
 							X: 190
-							Width: 326
+							Width: 426
 							Height: 25
 							Text: Spectator
 							Align: Center
 							Font: Bold
 						Checkbox@STATUS_CHECKBOX:
-							X: 525
+							X: 625
 							Y: 2
 							Width: 20
 							Height: 20
 							Visible: false
 						Image@STATUS_IMAGE:
-							X: 527
+							X: 627
 							Y: 4
 							Width: 20
 							Height: 20
@@ -414,13 +436,13 @@ Container@LOBBY_PLAYER_BIN:
 									Template: ANONYMOUS_PLAYER_TOOLTIP
 						Label@SPECTATOR:
 							X: 190
-							Width: 326
+							Width: 426
 							Height: 25
 							Text: Spectator
 							Align: Center
 							Font: Bold
 						Image@STATUS_IMAGE:
-							X: 527
+							X: 627
 							Y: 4
 							Width: 20
 							Height: 20
@@ -429,7 +451,7 @@ Container@LOBBY_PLAYER_BIN:
 							Visible: false
 				Container@TEMPLATE_NEW_SPECTATOR:
 					X: 5
-					Width: 475
+					Width: 575
 					Height: 25
 					Visible: false
 					Children:
@@ -441,7 +463,7 @@ Container@LOBBY_PLAYER_BIN:
 							Font: Regular
 						Button@SPECTATE:
 							X: 190
-							Width: 326
+							Width: 426
 							Height: 25
 							Text: Spectate
 							Font: Regular

--- a/mods/ts/chrome/dropdowns.yaml
+++ b/mods/ts/chrome/dropdowns.yaml
@@ -58,6 +58,22 @@ ScrollPanel@SPAWN_DROPDOWN_TEMPLATE:
 					Height: 25
 					Align: Center
 
+ScrollPanel@HANDICAP_DROPDOWN_TEMPLATE:
+	Width: DROPDOWN_WIDTH
+	Children:
+		ScrollItem@TEMPLATE:
+			Width: PARENT_RIGHT - 27
+			Height: 25
+			X: 2
+			Y: 0
+			Visible: false
+			Children:
+				Label@LABEL:
+					X: 0
+					Width: PARENT_RIGHT
+					Height: 25
+					Align: Center
+
 ScrollPanel@PLAYERACTION_DROPDOWN_TEMPLATE:
 	Width: DROPDOWN_WIDTH
 	Children:


### PR DESCRIPTION
This PR adds the option for players to choose a lower than usual unit damage output in the game lobby.

<img width="1054" alt="OpenRA with Handicap" src="https://user-images.githubusercontent.com/84460/79159142-da2c5300-7dd7-11ea-9062-411e381a8013.png">

This is useful when playing with players of different skillset. It is also a nice way to make the game against bots harder for you.

I'm sure the code can be improved in various ways (especially as I'm not very familiar with C#, .Net or the OpenRA code base). So I consider this a first draft and happily will incorporate any feedback if the maintainers are interested in having this feature. 

### Todos/Open Questions:

* [ ] Should `Handicap` even be a Property on the `Player` and `Session`? I put it there as this was ...
  * most similar to other lobby dropdowns
  * the most straight forward (read easiest) solution
  * ensures that it doesn't get confused with `Health.damageModifiersPlayer`
* [ ] How do I measure the performance impact (but I guess it might be negligible)?
* [ ] Is there a more idiomatic way than what I did in [`Health.InflictDamage`](https://github.com/OpenRA/OpenRA/pull/17937/files#diff-e107107188001ae1afb408ff1ad5821cR173-R178)?
* [ ] What about chases where `Health.InflictDamage` gets called with `ignoreModifiers = true`? I briefly looked at all of them but cannot confidently tell that there isn't an edge case I missed.
* [ ] Align lobby tabs. The Players tab content is now wider than the other tab pages. It kinda looks ok so I would love some feedback if we should change the UI further.
  * [ ] options
  * [ ] music
  * [ ] server
  
For the changelog I probably would add something along the lines of `Added "Unit Damage" handicap dropdown in the game lobby`

### Relates to

* https://github.com/OpenRA/OpenRA/issues/6829 - per player handicap
* https://github.com/OpenRA/OpenRA/issues/6103 - production handicap
