### PR TITLE
Treat transit-only tiles as invalid locations for minelayers

### DIFF
--- a/OpenRA.Mods.Cnc/Activities/LayMines.cs
+++ b/OpenRA.Mods.Cnc/Activities/LayMines.cs
@@ -107,9 +107,11 @@ namespace OpenRA.Mods.Cnc.Activities
 			if (minefield != null)
 			{
 				var positionable = (IPositionable)movement;
+				var mobile = positionable as Mobile;
 				minefield.RemoveAll(c => self.World.ActorMap.GetActorsAt(c)
 					.Any(a => a.Info.Name == minelayer.Info.Mine.ToLowerInvariant() && a.CanBeViewedByPlayer(self.Owner)) ||
-						(!positionable.CanEnterCell(c, null, BlockedByActor.Immovable) && self.Owner.Shroud.IsVisible(c)));
+						((!positionable.CanEnterCell(c, null, BlockedByActor.Immovable) || (mobile != null && !mobile.CanStayInCell(c)))
+						&& self.Owner.Shroud.IsVisible(c)));
 			}
 		}
 

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -231,13 +231,14 @@ namespace OpenRA.Mods.Cnc.Traits
 					minelayers.Max(m => m.Info.TraitInfo<MinelayerInfo>().MinefieldDepth));
 
 				var movement = minelayer.Trait<IPositionable>();
+				var mobile = movement as Mobile;
 				var pal = wr.Palette(TileSet.TerrainPaletteInternalName);
 				foreach (var c in minefield)
 				{
 					var tile = tileOk;
 					if (world.FogObscures(c))
 						tile = tileUnknown;
-					else if (!movement.CanEnterCell(c, null, BlockedByActor.Immovable))
+					else if (!movement.CanEnterCell(c, null, BlockedByActor.Immovable) || (mobile != null && !mobile.CanStayInCell(c)))
 						tile = tileBlocked;
 
 					yield return new SpriteRenderable(tile, world.Map.CenterOfCell(c),


### PR DESCRIPTION
Closes #17932. The transit-only cells of the SD in RA are no longer marked as valid locations.