### PR TITLE
AI army state related fix & add

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/SquadManagerBotModule.cs
@@ -126,6 +126,11 @@ namespace OpenRA.Mods.Common.Traits
 				&& !a.GetEnabledTargetTypes().IsEmpty;
 		}
 
+		public bool IsVisibleUnit(Actor a)
+		{
+			return !(a.TraitsImplementing<Cloak>().Where(t => !t.IsTraitDisabled && !t.IsTraitPaused && !t.IsVisible(a, Player)).Any());
+		}
+
 		protected override void Created(Actor self)
 		{
 			// Special case handling is required for the Player actor.
@@ -160,12 +165,14 @@ namespace OpenRA.Mods.Common.Traits
 
 		internal Actor FindClosestEnemy(WPos pos)
 		{
-			return World.Actors.Where(IsEnemyUnit).ClosestTo(pos);
+			var units = World.Actors.Where(IsEnemyUnit);
+			return units.Where(IsVisibleUnit).ClosestTo(pos) ?? units.ClosestTo(pos);
 		}
 
 		internal Actor FindClosestEnemy(WPos pos, WDist radius)
 		{
-			return World.FindActorsInCircle(pos, radius).Where(IsEnemyUnit).ClosestTo(pos);
+			var units = World.FindActorsInCircle(pos, radius).Where(IsEnemyUnit);
+			return units.Where(IsVisibleUnit).ClosestTo(pos);
 		}
 
 		void CleanSquads()

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/AirStates.cs
@@ -20,8 +20,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 	abstract class AirStateBase : StateBase
 	{
 		static readonly BitSet<TargetableType> AirTargetTypes = new BitSet<TargetableType>("Air");
-
-		protected const int MissileUnitMultiplier = 3;
+		protected const int MissileUnitMultiplier = 1;
 
 		protected static int CountAntiAirUnits(IEnumerable<Actor> units)
 		{
@@ -31,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			var missileUnitsCount = 0;
 			foreach (var unit in units)
 			{
-				if (unit == null || unit.Info.HasTraitInfo<AircraftInfo>())
+				if (unit == null)
 					continue;
 
 				foreach (var ab in unit.TraitsImplementing<AttackBase>())
@@ -43,7 +42,10 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 					{
 						if (a.Weapon.IsValidTarget(AirTargetTypes))
 						{
-							missileUnitsCount++;
+							if (unit.Info.HasTraitInfo<AircraftInfo>())
+								missileUnitsCount += 1;
+							else
+								missileUnitsCount += 3;
 							break;
 						}
 					}
@@ -57,7 +59,13 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		{
 			Actor target = null;
 			FindSafePlace(owner, out target, true);
-			return target;
+
+			if (target != null)
+				foreach (var a in owner.Units)
+					if (CanAttackTarget(a, target))
+						return target;
+
+			return null;
 		}
 
 		protected static CPos? FindSafePlace(Squad owner, out Actor detectedEnemyTarget, bool needTarget)
@@ -97,7 +105,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			detectedEnemyTarget = null;
 			var dangerRadius = owner.SquadManager.Info.DangerScanRadius;
 			var unitsAroundPos = owner.World.FindActorsInCircle(loc, WDist.FromCells(dangerRadius))
-				.Where(owner.SquadManager.IsEnemyUnit).ToList();
+				.Where(a => owner.SquadManager.IsEnemyUnit(a) && owner.SquadManager.IsVisibleUnit(a)).ToList();
 
 			if (!unitsAroundPos.Any())
 				return true;
@@ -159,6 +167,57 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		{
 			return ShouldFlee(owner, enemies => CountAntiAirUnits(enemies) * MissileUnitMultiplier > owner.Units.Count);
 		}
+
+		// Retreat units from combat, or for supply only in idle
+		protected void Retreat(Squad owner, bool resupplyonly)
+		{
+			// Reload units.
+			foreach (var a in owner.Units)
+			{
+				if (!ReloadsAutomatically(a) && !FullAmmo(a))
+				{
+					if (IsRearm(a))
+						continue;
+
+					owner.Bot.QueueOrder(new Order("ReturnToBase", a, false));
+					continue;
+				}
+				else if (!resupplyonly)
+					owner.Bot.QueueOrder(new Order("Move", a, Target.FromCell(owner.World, RandomBuildingLocation(owner)), false));
+			}
+
+			// Repair units. One by one to avoid give out mass orders
+			foreach (var a in owner.Units)
+			{
+				if (IsRearm(a))
+					continue;
+
+				Actor repairBuilding = null;
+				var orderId = "Repair";
+
+				if (a.TraitOrDefault<IHealth>() != null && a.TraitOrDefault<IHealth>().DamageState > DamageState.Undamaged)
+				{
+					var repairable = a.TraitOrDefault<Repairable>();
+					if (repairable != null)
+						repairBuilding = repairable.FindRepairBuilding(a);
+					else
+					{
+						var repairableNear = a.TraitOrDefault<RepairableNear>();
+						if (repairableNear != null)
+						{
+							orderId = "RepairNear";
+							repairBuilding = repairableNear.FindRepairBuilding(a);
+						}
+					}
+
+					if (repairBuilding != null)
+					{
+						owner.Bot.QueueOrder(new Order(orderId, a, Target.FromActor(repairBuilding), true));
+						break;
+					}
+				}
+			}
+		}
 	}
 
 	class AirIdleState : AirStateBase, IState
@@ -178,7 +237,10 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 
 			var e = FindDefenselessTarget(owner);
 			if (e == null)
+			{
+				Retreat(owner, true);
 				return;
+			}
 
 			owner.TargetActor = e;
 			owner.FuzzyStateMachine.ChangeState(owner, new AirAttackState(), true);
@@ -209,7 +271,13 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				}
 			}
 
-			if (!NearToPosSafely(owner, owner.TargetActor.CenterPosition))
+			var leader = owner.Units.ClosestTo(owner.TargetActor.CenterPosition);
+
+			var unitsAroundPos = owner.World.FindActorsInCircle(leader.CenterPosition, WDist.FromCells(owner.SquadManager.Info.DangerScanRadius))
+				.Where(a => owner.SquadManager.IsEnemyUnit(a) && owner.SquadManager.IsVisibleUnit(a));
+			var ambushed = CountAntiAirUnits(unitsAroundPos) * MissileUnitMultiplier > owner.Units.Count;
+
+			if ((!NearToPosSafely(owner, owner.TargetActor.CenterPosition)) || ambushed)
 			{
 				owner.FuzzyStateMachine.ChangeState(owner, new AirFleeState(), true);
 				return;
@@ -234,6 +302,8 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 
 				if (CanAttackTarget(a, owner.TargetActor))
 					owner.Bot.QueueOrder(new Order("Attack", a, Target.FromActor(owner.TargetActor), false));
+				else
+					owner.Bot.QueueOrder(new Order("Move", a, Target.FromCell(owner.World, RandomBuildingLocation(owner)), false));
 			}
 		}
 
@@ -249,19 +319,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			if (!owner.IsValid)
 				return;
 
-			foreach (var a in owner.Units)
-			{
-				if (!ReloadsAutomatically(a) && !FullAmmo(a))
-				{
-					if (IsRearm(a))
-						continue;
-
-					owner.Bot.QueueOrder(new Order("ReturnToBase", a, false));
-					continue;
-				}
-
-				owner.Bot.QueueOrder(new Order("Move", a, Target.FromCell(owner.World, RandomBuildingLocation(owner)), false));
-			}
+			Retreat(owner, false);
 
 			owner.FuzzyStateMachine.ChangeState(owner, new AirIdleState(), true);
 		}

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/NavyStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/NavyStates.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Linq;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.BotModules.Squads
@@ -50,6 +51,69 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 
 			return owner.SquadManager.FindClosestEnemy(first.CenterPosition);
 		}
+
+		protected static bool IsRearm(Actor a)
+		{
+			if (a.IsIdle)
+				return false;
+
+			var activity = a.CurrentActivity;
+			var type = activity.GetType();
+			if (type == typeof(Resupply))
+				return true;
+
+			var next = activity.NextActivity;
+			if (next == null)
+				return false;
+
+			var nextType = next.GetType();
+			if (nextType == typeof(Resupply))
+				return true;
+
+			return false;
+		}
+
+		// Retreat units from combat, or for supply only in idle
+		protected virtual void Retreat(Squad owner, bool resupplyonly)
+		{
+			// Repair units. One by one to avoid give out mass orders
+			foreach (var a in owner.Units)
+			{
+				if (IsRearm(a))
+					continue;
+
+				Actor repairBuilding = null;
+				var orderId = "Repair";
+				var alreadysend = false;
+
+				if (!alreadysend && a.TraitOrDefault<IHealth>() != null && a.TraitOrDefault<IHealth>().DamageState > DamageState.Undamaged)
+				{
+					var repairable = a.TraitOrDefault<Repairable>();
+					if (repairable != null)
+						repairBuilding = repairable.FindRepairBuilding(a);
+					else
+					{
+						var repairableNear = a.TraitOrDefault<RepairableNear>();
+						if (repairableNear != null)
+						{
+							orderId = "RepairNear";
+							repairBuilding = repairableNear.FindRepairBuilding(a);
+						}
+					}
+
+					if (repairBuilding != null)
+					{
+						owner.Bot.QueueOrder(new Order(orderId, a, Target.FromActor(repairBuilding), false));
+						alreadysend = true;
+						continue;
+					}
+					else if (!resupplyonly)
+						owner.Bot.QueueOrder(new Order("Move", a, Target.FromCell(owner.World, RandomBuildingLocation(owner)), false));
+				}
+				else if (!resupplyonly)
+					owner.Bot.QueueOrder(new Order("Move", a, Target.FromCell(owner.World, RandomBuildingLocation(owner)), false));
+			}
+		}
 	}
 
 	class NavyUnitsIdleState : NavyStateBase, IState
@@ -71,10 +135,13 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			}
 
 			var enemyUnits = owner.World.FindActorsInCircle(owner.TargetActor.CenterPosition, WDist.FromCells(owner.SquadManager.Info.IdleScanRadius))
-				.Where(owner.SquadManager.IsEnemyUnit).ToList();
+				.Where(a => owner.SquadManager.IsEnemyUnit(a) && owner.SquadManager.IsVisibleUnit(a)).ToList();
 
 			if (enemyUnits.Count == 0)
+			{
+				Retreat(owner, true);
 				return;
+			}
 
 			if (AttackOrFleeFuzzy.Default.CanAttack(owner.Units, enemyUnits))
 			{
@@ -130,7 +197,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			else
 			{
 				var enemies = owner.World.FindActorsInCircle(leader.CenterPosition, WDist.FromCells(owner.SquadManager.Info.AttackScanRadius))
-					.Where(owner.SquadManager.IsEnemyUnit);
+					.Where(a => owner.SquadManager.IsEnemyUnit(a) && owner.SquadManager.IsVisibleUnit(a));
 				var target = enemies.ClosestTo(leader.CenterPosition);
 				if (target != null)
 				{
@@ -190,7 +257,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			if (!owner.IsValid)
 				return;
 
-			GoToRandomOwnBuilding(owner);
+			Retreat(owner, false);
 			owner.FuzzyStateMachine.ChangeState(owner, new NavyUnitsIdleState(), true);
 		}
 

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/ProtectionStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/ProtectionStates.cs
@@ -9,18 +9,96 @@
  */
 #endregion
 
+using System.Linq;
+using OpenRA.Mods.Common.Activities;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 {
-	class UnitsForProtectionIdleState : GroundStateBase, IState
+	class ProtectionStateBase : GroundStateBase
+	{
+		protected static bool FullAmmo(Actor a)
+		{
+			var ammoPools = a.TraitsImplementing<AmmoPool>();
+			return ammoPools.All(x => x.HasFullAmmo);
+		}
+
+		protected static bool HasAmmo(Actor a)
+		{
+			var ammoPools = a.TraitsImplementing<AmmoPool>();
+			return ammoPools.All(x => x.HasAmmo);
+		}
+
+		protected static bool ReloadsAutomatically(Actor a)
+		{
+			var ammoPools = a.TraitsImplementing<AmmoPool>();
+			var rearmable = a.TraitOrDefault<Rearmable>();
+			if (rearmable == null)
+				return true;
+
+			return ammoPools.All(ap => !rearmable.Info.AmmoPools.Contains(ap.Info.Name));
+		}
+
+		// Retreat units from combat, or for supply only in idle
+		protected override void Retreat(Squad owner, bool resupplyonly = false)
+		{
+			// Reload units.
+			foreach (var a in owner.Units)
+			{
+				if (!ReloadsAutomatically(a) && !FullAmmo(a))
+				{
+					if (IsRearm(a))
+						continue;
+
+					owner.Bot.QueueOrder(new Order("ReturnToBase", a, false));
+					continue;
+				}
+				else if (!resupplyonly)
+					owner.Bot.QueueOrder(new Order("Move", a, Target.FromCell(owner.World, RandomBuildingLocation(owner)), false));
+			}
+
+			// Repair units. One by one to avoid give out mass orders
+			foreach (var a in owner.Units)
+			{
+				if (IsRearm(a))
+					continue;
+
+				Actor repairBuilding = null;
+				var orderId = "Repair";
+
+				if (a.TraitOrDefault<IHealth>() != null && a.TraitOrDefault<IHealth>().DamageState > DamageState.Undamaged)
+				{
+					var repairable = a.TraitOrDefault<Repairable>();
+					if (repairable != null)
+						repairBuilding = repairable.FindRepairBuilding(a);
+					else
+					{
+						var repairableNear = a.TraitOrDefault<RepairableNear>();
+						if (repairableNear != null)
+						{
+							orderId = "RepairNear";
+							repairBuilding = repairableNear.FindRepairBuilding(a);
+						}
+					}
+
+					if (repairBuilding != null)
+					{
+						owner.Bot.QueueOrder(new Order(orderId, a, Target.FromActor(repairBuilding), true));
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	class UnitsForProtectionIdleState : ProtectionStateBase, IState
 	{
 		public void Activate(Squad owner) { }
 		public void Tick(Squad owner) { owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionAttackState(), true); }
 		public void Deactivate(Squad owner) { }
 	}
 
-	class UnitsForProtectionAttackState : GroundStateBase, IState
+	class UnitsForProtectionAttackState : ProtectionStateBase, IState
 	{
 		public const int BackoffTicks = 4;
 		internal int Backoff = BackoffTicks;
@@ -43,6 +121,14 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 				}
 			}
 
+			// rescan target to prevent being ambushed and die without fight
+			var leader = owner.Units.ClosestTo(owner.TargetActor.CenterPosition);
+			var enemies = owner.World.FindActorsInCircle(leader.CenterPosition, WDist.FromCells(owner.SquadManager.Info.AttackScanRadius))
+				.Where(a => owner.SquadManager.IsEnemyUnit(a) && owner.SquadManager.IsVisibleUnit(a));
+			var target = enemies.ClosestTo(leader.CenterPosition);
+			if (target != null)
+				owner.TargetActor = target;
+
 			if (!owner.IsTargetVisible)
 			{
 				if (Backoff < 0)
@@ -57,14 +143,45 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			else
 			{
 				foreach (var a in owner.Units)
-					owner.Bot.QueueOrder(new Order("AttackMove", a, Target.FromCell(owner.World, owner.TargetActor.Location), false));
+				{
+					if (a.Info.HasTraitInfo<AircraftInfo>() && a.TraitsImplementing<AmmoPool>().Any())
+					{
+						if (BusyAttack(a))
+							continue;
+
+						if (!ReloadsAutomatically(a))
+						{
+							if (IsRearm(a))
+								continue;
+
+							if (!HasAmmo(a))
+							{
+								owner.Bot.QueueOrder(new Order("ReturnToBase", a, false));
+								continue;
+							}
+						}
+
+						// avoid AttackMove, since AttackMove will let fragile unit walk on the face of enemy
+						if (CanAttackTarget(a, owner.TargetActor))
+							owner.Bot.QueueOrder(new Order("Attack", a, Target.FromActor(owner.TargetActor), false));
+						else
+							owner.Bot.QueueOrder(new Order("Guard", a, Target.FromActor(leader), false));
+					}
+					else
+					{
+						if (CanAttackTarget(a, owner.TargetActor))
+							owner.Bot.QueueOrder(new Order("Attack", a, Target.FromActor(owner.TargetActor), false));
+						else
+							owner.Bot.QueueOrder(new Order("Guard", a, Target.FromActor(leader), false));
+					}
+				}
 			}
 		}
 
 		public void Deactivate(Squad owner) { }
 	}
 
-	class UnitsForProtectionFleeState : GroundStateBase, IState
+	class UnitsForProtectionFleeState : ProtectionStateBase, IState
 	{
 		public void Activate(Squad owner) { }
 
@@ -73,7 +190,8 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			if (!owner.IsValid)
 				return;
 
-			GoToRandomOwnBuilding(owner);
+			Retreat(owner);
+
 			owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionIdleState(), true);
 		}
 


### PR DESCRIPTION
1.  AI ammo-based aircraft will reload when no ammo in protect team, instead of staying above the enemy.

2.  AI rush/air/protect team units will no longer chase down fast move units (especially air units) until death without even caring about surrounding, which is fatal for slow movement units.

update:

3.  AI rush/protect team units will no longer break formation when against air units. Those who cannot attack air will guard team leader.

4. AI naval/rush/protect/air team will not search and stuck (try attack behaivior) at undetected cloaked enemy actors (like mines), until there is no visible targets. Only then they will try to get close/attack to invisible target.
Fixes #3763.

5. Apply repair order when flee&idle for damaged AI actors (naval/rush/protect/air team). Because repairpad don't have the same logic and optimized like helipad so I add a restriction to army to only allow one recieve repair order per `Tick()`. If this one is imporved, we can delete `alreadysend` and `break` to make it behave normally.