### PR TITLE
Added a bounds check to LeavesTrails

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
+++ b/OpenRA.Mods.Common/Traits/Render/LeavesTrails.cs
@@ -111,6 +111,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (++ticks >= cachedInterval)
 			{
 				var spawnCell = Info.SpawnAtLastPosition ? self.World.Map.CellContaining(cachedPosition) : self.World.Map.CellContaining(self.CenterPosition);
+				if (!self.World.Map.Contains(spawnCell))
+					return;
+
 				var type = self.World.Map.GetTerrainInfo(spawnCell).Type;
 
 				if (++offset >= Info.Offsets.Length)


### PR DESCRIPTION
The trait will otherwise crash when used by an aircraft that flies in from outside the cordon.