### PR TITLE
Fixed LeaveSmudgeWarhead querying invalid targets

### DIFF
--- a/OpenRA.Mods.Common/Warheads/LeaveSmudgeWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/LeaveSmudgeWarhead.cs
@@ -35,6 +35,9 @@ namespace OpenRA.Mods.Common.Warheads
 		public override void DoImpact(Target target, WarheadArgs args)
 		{
 			var firedBy = args.SourceActor;
+			if (!target.IsValidFor(firedBy))
+				return;
+
 			var world = firedBy.World;
 
 			if (Chance < world.LocalRandom.Next(100))


### PR DESCRIPTION
Essentially what https://github.com/AttacqueSuperior/Engine/pull/39 does. This fixes a crash reported by @OmegaBolt.