### PR TITLE
Fix a crash when completing objectives in Allies06 out of order

### DIFF
--- a/mods/ra/maps/allies-06a/allies06a.lua
+++ b/mods/ra/maps/allies-06a/allies06a.lua
@@ -45,7 +45,6 @@ ParadropWaypoints =
 }
 
 SovietTechLabs = { TechLab1, TechLab2, TechLab3 }
-TechLabCams = { TechCam1, TechCam2, TechCam3 }
 
 GroupPatrol = function(units, waypoints, delay)
 	local i = 1
@@ -115,18 +114,22 @@ CaptureRadarDome = function()
 
 	Trigger.OnCapture(RadarDome, function()
 		player.MarkCompletedObjective(CaptureRadarDomeObj)
-		Beacon.New(player, TechLab1.CenterPosition)
-		Beacon.New(player, TechLab2.CenterPosition)
-		Beacon.New(player, TechLab3.CenterPosition)
-		Media.DisplayMessage("Coordinates of the Soviet tech centers discovered.")
-		if Map.LobbyOption("difficulty") ~= "hard" then
-			Utils.Do(TechLabCams, function(a)
-				Actor.Create("TECH.CAM", true, { Owner = player, Location = a.Location })
-			end)
 
-			if Map.LobbyOption("difficulty") == "easy" then
-				Actor.Create("Camera", true, { Owner = player, Location = Weapcam.Location })
+		Utils.Do(SovietTechLabs, function(a)
+			if a.IsDead then
+				return
 			end
+
+			Beacon.New(player, a.CenterPosition)
+			if Map.LobbyOption("difficulty") ~= "hard" then
+				Actor.Create("TECH.CAM", true, { Owner = player, Location = a.Location + CVec.New(1, 1) })
+			end
+		end)
+
+		Media.DisplayMessage("Coordinates of the Soviet tech centers discovered.")
+
+		if Map.LobbyOption("difficulty") == "easy" then
+			Actor.Create("Camera", true, { Owner = player, Location = Weapcam.Location })
 		end
 	end)
 end

--- a/mods/ra/maps/allies-06a/map.yaml
+++ b/mods/ra/maps/allies-06a/map.yaml
@@ -26,10 +26,10 @@ Players:
 		Faction: england
 	PlayerReference@USSR:
 		Name: USSR
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Enemies: USSR, Greece
-		Bot: campaign
 	PlayerReference@Greece:
 		Name: Greece
 		AllowBots: False
@@ -589,15 +589,6 @@ Actors:
 	Weapcam: waypoint
 		Location: 76,94
 		Owner: Neutral
-	TechCam1: waypoint
-		Location: 69,83
-		Owner: Neutral
-	TechCam2: waypoint
-		Location: 94,94
-		Owner: Neutral
-	TechCam3: waypoint
-		Owner: Neutral
-		Location: 94,109
 	AlliedEntry1: waypoint
 		Location: 19,61
 		Owner: Neutral

--- a/mods/ra/maps/allies-06b/allies06b.lua
+++ b/mods/ra/maps/allies-06b/allies06b.lua
@@ -53,8 +53,6 @@ ParadropWaypoints =
 
 SovietTechLabs = { TechLab1, TechLab2 }
 
-TechLabCams = { TechCam1, TechCam2 }
-
 GroupPatrol = function(units, waypoints, delay)
 	local i = 1
 	local stop = false
@@ -126,17 +124,22 @@ CaptureRadarDome = function()
 
 	Trigger.OnCapture(RadarDome, function()
 		player.MarkCompletedObjective(CaptureRadarDomeObj)
-		Beacon.New(player, TechLab1.CenterPosition)
-		Beacon.New(player, TechLab2.CenterPosition)
-		Media.DisplayMessage("Coordinates of the Soviet tech centers discovered.")
-		if Map.LobbyOption("difficulty") ~= "hard" then
-			Utils.Do(TechLabCams, function(a)
-				Actor.Create("TECH.CAM", true, { Owner = player, Location = a.Location })
-			end)
 
-			if Map.LobbyOption("difficulty") == "easy" then
-				Actor.Create("Camera", true, { Owner = player, Location = Weapcam.Location })
+		Utils.Do(SovietTechLabs, function(a)
+			if a.IsDead then
+				return
 			end
+
+			Beacon.New(player, a.CenterPosition)
+			if Map.LobbyOption("difficulty") ~= "hard" then
+				Actor.Create("TECH.CAM", true, { Owner = player, Location = a.Location + CVec.New(1, 1) })
+			end
+		end)
+
+		Media.DisplayMessage("Coordinates of the Soviet tech centers discovered.")
+
+		if Map.LobbyOption("difficulty") == "easy" then
+			Actor.Create("Camera", true, { Owner = player, Location = Weapcam.Location })
 		end
 	end)
 end

--- a/mods/ra/maps/allies-06b/map.yaml
+++ b/mods/ra/maps/allies-06b/map.yaml
@@ -30,10 +30,10 @@ Players:
 		Faction: england
 	PlayerReference@USSR:
 		Name: USSR
+		Bot: campaign
 		Faction: soviet
 		Color: FF1400
 		Enemies: Greece
-		Bot: campaign
 	PlayerReference@Greece:
 		Name: Greece
 		AllowBots: False
@@ -586,12 +586,6 @@ Actors:
 	SovietDefenseCam: waypoint
 		Owner: Neutral
 		Location: 49,91
-	TechCam1: waypoint
-		Owner: Neutral
-		Location: 55,58
-	TechCam2: waypoint
-		Owner: Neutral
-		Location: 91,43
 	Weapcam: waypoint
 		Owner: Neutral
 		Location: 53,47


### PR DESCRIPTION
Fixes the crash reported at https://forum.openra.net/viewtopic.php?p=311534#p311534.

The problem was when a lab was destroyed before the radar dome revealed the lab location. This PR changes this so capturing the radar dome only reveals and pings locations that have an existing lab.