### PR TITLE
Moved Render*Circle traits to their base traits

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/RenderJammerCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderJammerCircle.cs
@@ -12,11 +12,10 @@
 using System.Collections.Generic;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.Cnc.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	// TODO: remove all the Render*Circle duplication
 	class RenderJammerCircleInfo : TraitInfo<RenderJammerCircle>, IPlaceBuildingDecorationInfo

--- a/OpenRA.Mods.Common/Traits/Render/RenderShroudCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderShroudCircle.cs
@@ -13,11 +13,10 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Mods.Common.Graphics;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
 
-namespace OpenRA.Mods.Cnc.Traits
+namespace OpenRA.Mods.Common.Traits
 {
 	class RenderShroudCircleInfo : ITraitInfo, IPlaceBuildingDecorationInfo
 	{


### PR DESCRIPTION
As discussed on Discord separating the circle rendering traits was an accident.