### PR TITLE
Add "OpenGL Profile" setting with restored support for GL2.1

### DIFF
--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -15,6 +15,12 @@ using OpenRA.Primitives;
 
 namespace OpenRA
 {
+	public enum GLProfile
+	{
+		Modern,
+		Embedded,
+	}
+
 	public interface IPlatform
 	{
 		IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int batchSize, int videoDisplay);

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -23,7 +23,7 @@ namespace OpenRA
 
 	public interface IPlatform
 	{
-		IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int batchSize, int videoDisplay);
+		IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int batchSize, int videoDisplay, GLProfile profile);
 		ISoundEngine CreateSound(string device);
 		IFont CreateFont(byte[] data);
 	}
@@ -70,6 +70,10 @@ namespace OpenRA
 		void SetHardwareCursor(IHardwareCursor cursor);
 		void SetRelativeMouseMode(bool mode);
 		void SetScaleModifier(float scale);
+
+		GLProfile GLProfile { get; }
+
+		GLProfile[] SupportedGLProfiles { get; }
 	}
 
 	public interface IGraphicsContext : IDisposable

--- a/OpenRA.Game/Graphics/PlatformInterfaces.cs
+++ b/OpenRA.Game/Graphics/PlatformInterfaces.cs
@@ -19,6 +19,7 @@ namespace OpenRA
 	{
 		Modern,
 		Embedded,
+		Legacy
 	}
 
 	public interface IPlatform

--- a/OpenRA.Game/Renderer.cs
+++ b/OpenRA.Game/Renderer.cs
@@ -75,7 +75,10 @@ namespace OpenRA
 			this.platform = platform;
 			var resolution = GetResolution(graphicSettings);
 
-			Window = platform.CreateWindow(new Size(resolution.Width, resolution.Height), graphicSettings.Mode, graphicSettings.UIScale, graphicSettings.BatchSize, graphicSettings.VideoDisplay);
+			Window = platform.CreateWindow(new Size(resolution.Width, resolution.Height),
+				graphicSettings.Mode, graphicSettings.UIScale, graphicSettings.BatchSize,
+				graphicSettings.VideoDisplay, graphicSettings.GLProfile);
+
 			Context = Window.Context;
 
 			TempBufferSize = graphicSettings.BatchSize;
@@ -310,6 +313,8 @@ namespace OpenRA
 		public Size NativeResolution { get { return Window.NativeWindowSize; } }
 		public float WindowScale { get { return Window.EffectiveWindowScale; } }
 		public float NativeWindowScale { get { return Window.NativeWindowScale; } }
+		public GLProfile GLProfile { get { return Window.GLProfile; } }
+		public GLProfile[] SupportedGLProfiles { get { return Window.SupportedGLProfiles; } }
 
 		public interface IBatchRenderer { void Flush(); }
 

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -177,7 +177,8 @@ namespace OpenRA
 
 		[Desc("Preferred OpenGL profile to use.",
 			"Modern: OpenGL Core Profile 3.2 or greater.",
-			"Embedded: OpenGL ES 3.0 or greater.")]
+			"Embedded: OpenGL ES 3.0 or greater.",
+			"Legacy: OpenGL 2.1 with framebuffer_object extension.")]
 		public GLProfile GLProfile = GLProfile.Modern;
 
 		public int BatchSize = 8192;

--- a/OpenRA.Game/Settings.cs
+++ b/OpenRA.Game/Settings.cs
@@ -172,11 +172,13 @@ namespace OpenRA
 		[Desc("Disable operating-system provided cursor rendering.")]
 		public bool DisableHardwareCursors = false;
 
-		[Desc("Use OpenGL ES if both ES and regular OpenGL are available.")]
-		public bool PreferGLES = false;
-
 		[Desc("Display index to use in a multi-monitor fullscreen setup.")]
 		public int VideoDisplay = 0;
+
+		[Desc("Preferred OpenGL profile to use.",
+			"Modern: OpenGL Core Profile 3.2 or greater.",
+			"Embedded: OpenGL ES 3.0 or greater.")]
+		public GLProfile GLProfile = GLProfile.Modern;
 
 		public int BatchSize = 8192;
 		public int SheetSize = 2048;

--- a/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
+++ b/OpenRA.Mods.Common/LoadScreens/BlankLoadScreen.cs
@@ -122,6 +122,7 @@ namespace OpenRA.Mods.Common.LoadScreens
 			}
 
 			// Saved settings may have been invalidated by a hardware change
+			Game.Settings.Graphics.GLProfile = Game.Renderer.GLProfile;
 			Game.Settings.Graphics.VideoDisplay = Game.Renderer.CurrentDisplay;
 
 			// If a ModContent section is defined then we need to make sure that the

--- a/OpenRA.Platforms.Default/DefaultPlatform.cs
+++ b/OpenRA.Platforms.Default/DefaultPlatform.cs
@@ -16,9 +16,9 @@ namespace OpenRA.Platforms.Default
 {
 	public class DefaultPlatform : IPlatform
 	{
-		public IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int batchSize, int videoDisplay)
+		public IPlatformWindow CreateWindow(Size size, WindowMode windowMode, float scaleModifier, int batchSize, int videoDisplay, GLProfile profile)
 		{
-			return new Sdl2PlatformWindow(size, windowMode, scaleModifier, batchSize, videoDisplay);
+			return new Sdl2PlatformWindow(size, windowMode, scaleModifier, batchSize, videoDisplay, profile);
 		}
 
 		public ISoundEngine CreateSound(string device)

--- a/OpenRA.Platforms.Default/FrameBuffer.cs
+++ b/OpenRA.Platforms.Default/FrameBuffer.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Platforms.Default
 			OpenGL.glBindRenderbuffer(OpenGL.GL_RENDERBUFFER, depth);
 			OpenGL.CheckGLError();
 
-			var glDepth = OpenGL.Features.HasFlag(OpenGL.GLFeatures.GLES) ? OpenGL.GL_DEPTH_COMPONENT16 : OpenGL.GL_DEPTH_COMPONENT;
+			var glDepth = OpenGL.Profile == GLProfile.Embedded ? OpenGL.GL_DEPTH_COMPONENT16 : OpenGL.GL_DEPTH_COMPONENT;
 			OpenGL.glRenderbufferStorage(OpenGL.GL_RENDERBUFFER, glDepth, size.Width, size.Height);
 			OpenGL.CheckGLError();
 

--- a/OpenRA.Platforms.Default/OpenGL.cs
+++ b/OpenRA.Platforms.Default/OpenGL.cs
@@ -513,6 +513,14 @@ namespace OpenRA.Platforms.Default
 					Features ^= GLFeatures.DebugMessagesCallback;
 			}
 
+			// Older Intel on Windows is broken too
+			if (Features.HasFlag(GLFeatures.DebugMessagesCallback) && Platform.CurrentPlatform == PlatformType.Windows)
+			{
+				var renderer = glGetString(GL_RENDERER);
+				if (renderer.Contains("HD Graphics") && !renderer.Contains("UHD Graphics"))
+					Features ^= GLFeatures.DebugMessagesCallback;
+			}
+
 			// Setup the debug message callback handler
 			if (Features.HasFlag(GLFeatures.DebugMessagesCallback))
 			{

--- a/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
+++ b/OpenRA.Platforms.Default/Sdl2GraphicsContext.cs
@@ -35,14 +35,17 @@ namespace OpenRA.Platforms.Default
 			if (context == IntPtr.Zero || SDL.SDL_GL_MakeCurrent(window.Window, context) < 0)
 				throw new InvalidOperationException("Can not create OpenGL context. (Error: {0})".F(SDL.SDL_GetError()));
 
-			OpenGL.Initialize();
+			OpenGL.Initialize(window.GLProfile == GLProfile.Legacy);
+			OpenGL.CheckGLError();
 
-			uint vao;
-			OpenGL.CheckGLError();
-			OpenGL.glGenVertexArrays(1, out vao);
-			OpenGL.CheckGLError();
-			OpenGL.glBindVertexArray(vao);
-			OpenGL.CheckGLError();
+			if (OpenGL.Profile != GLProfile.Legacy)
+			{
+				uint vao;
+				OpenGL.glGenVertexArrays(1, out vao);
+				OpenGL.CheckGLError();
+				OpenGL.glBindVertexArray(vao);
+				OpenGL.CheckGLError();
+			}
 
 			OpenGL.glEnableVertexAttribArray(Shader.VertexPosAttributeIndex);
 			OpenGL.CheckGLError();

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -151,9 +151,9 @@ namespace OpenRA.Platforms.Default
 				// We first need to query the available profiles on Windows/Linux.
 				// On macOS, known/consistent OpenGL support is provided by the OS.
 				if (Platform.CurrentPlatform == PlatformType.OSX)
-					supportedProfiles = new[] { GLProfile.Modern };
+					supportedProfiles = new[] { GLProfile.Modern, GLProfile.Legacy };
 				else
-					supportedProfiles = new[] { GLProfile.Modern, GLProfile.Embedded }
+					supportedProfiles = new[] { GLProfile.Modern, GLProfile.Embedded, GLProfile.Legacy }
 						.Where(CanCreateGLWindow)
 						.ToArray();
 
@@ -486,6 +486,10 @@ namespace OpenRA.Platforms.Default
 					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_MAJOR_VERSION, 3);
 					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_MINOR_VERSION, 0);
 					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_PROFILE_MASK, (int)SDL.SDL_GLprofile.SDL_GL_CONTEXT_PROFILE_ES);
+					break;
+				case GLProfile.Legacy:
+					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_MINOR_VERSION, 1);
 					break;
 			}
 		}

--- a/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
+++ b/OpenRA.Platforms.Default/Sdl2PlatformWindow.cs
@@ -12,6 +12,7 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 using System.Runtime.InteropServices;
 using OpenRA.Primitives;
 using SDL2;
@@ -34,6 +35,8 @@ namespace OpenRA.Platforms.Default
 		float windowScale = 1f;
 		int2? lockedMousePosition;
 		float scaleModifier;
+		readonly GLProfile profile;
+		readonly GLProfile[] supportedProfiles;
 
 		internal IntPtr Window
 		{
@@ -107,12 +110,31 @@ namespace OpenRA.Platforms.Default
 
 		public bool HasInputFocus { get; internal set; }
 
+		public GLProfile GLProfile
+		{
+			get
+			{
+				lock (syncObject)
+					return profile;
+			}
+		}
+
+		public GLProfile[] SupportedGLProfiles
+		{
+			get
+			{
+				lock (syncObject)
+					return supportedProfiles;
+			}
+		}
+
 		public event Action<float, float, float, float> OnWindowScaleChanged = (oldNative, oldEffective, newNative, newEffective) => { };
 
 		[DllImport("user32.dll")]
 		static extern bool SetProcessDPIAware();
 
-		public Sdl2PlatformWindow(Size requestEffectiveWindowSize, WindowMode windowMode, float scaleModifier, int batchSize, int videoDisplay)
+		public Sdl2PlatformWindow(Size requestEffectiveWindowSize, WindowMode windowMode,
+			float scaleModifier, int batchSize, int videoDisplay, GLProfile requestProfile)
 		{
 			// Lock the Window/Surface properties until initialization is complete
 			lock (syncObject)
@@ -124,31 +146,24 @@ namespace OpenRA.Platforms.Default
 					SetProcessDPIAware();
 
 				SDL.SDL_Init(SDL.SDL_INIT_NOPARACHUTE | SDL.SDL_INIT_VIDEO);
-				SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_DOUBLEBUFFER, 1);
-				SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_RED_SIZE, 8);
-				SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_GREEN_SIZE, 8);
-				SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_BLUE_SIZE, 8);
-				SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_ALPHA_SIZE, 0);
 
-				// Decide between OpenGL and OpenGL ES rendering
-				// Test whether we can use the preferred renderer and fall back to the other if that fails
-				// If neither works we will throw a graphics error later when trying to create the real window
-				bool useGLES;
-				if (Game.Settings.Graphics.PreferGLES)
-					useGLES = CanCreateGLWindow(3, 0, SDL.SDL_GLprofile.SDL_GL_CONTEXT_PROFILE_ES);
+				// Decide which OpenGL profile to use.
+				// We first need to query the available profiles on Windows/Linux.
+				// On macOS, known/consistent OpenGL support is provided by the OS.
+				if (Platform.CurrentPlatform == PlatformType.OSX)
+					supportedProfiles = new[] { GLProfile.Modern };
 				else
-					useGLES = !CanCreateGLWindow(3, 2, SDL.SDL_GLprofile.SDL_GL_CONTEXT_PROFILE_CORE);
+					supportedProfiles = new[] { GLProfile.Modern, GLProfile.Embedded }
+						.Where(CanCreateGLWindow)
+						.ToArray();
 
-				var glMajor = 3;
-				var glMinor = useGLES ? 0 : 2;
-				var glProfile = useGLES ? SDL.SDL_GLprofile.SDL_GL_CONTEXT_PROFILE_ES : SDL.SDL_GLprofile.SDL_GL_CONTEXT_PROFILE_CORE;
+				if (!supportedProfiles.Any())
+					throw new InvalidOperationException("No supported OpenGL profiles were found.");
 
-				SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_MAJOR_VERSION, glMajor);
-				SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_MINOR_VERSION, glMinor);
-				SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_PROFILE_MASK, (int)glProfile);
+				profile = supportedProfiles.Contains(requestProfile) ? requestProfile : supportedProfiles.First();
+				SetSDLAttributes(profile);
 
-				Console.WriteLine("Using SDL 2 with OpenGL{0} renderer", useGLES ? " ES" : "");
-
+				Console.WriteLine("Using SDL 2 with OpenGL ({0}) renderer", profile);
 				if (videoDisplay < 0 || videoDisplay >= DisplayCount)
 					videoDisplay = 0;
 
@@ -451,12 +466,34 @@ namespace OpenRA.Platforms.Default
 			return input.SetClipboardText(text);
 		}
 
-		static bool CanCreateGLWindow(int major, int minor, SDL.SDL_GLprofile profile)
+		static void SetSDLAttributes(GLProfile profile)
+		{
+			SDL.SDL_GL_ResetAttributes();
+			SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_DOUBLEBUFFER, 1);
+			SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_RED_SIZE, 8);
+			SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_GREEN_SIZE, 8);
+			SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_BLUE_SIZE, 8);
+			SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_ALPHA_SIZE, 0);
+
+			switch (profile)
+			{
+				case GLProfile.Modern:
+					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_MINOR_VERSION, 2);
+					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_PROFILE_MASK, (int)SDL.SDL_GLprofile.SDL_GL_CONTEXT_PROFILE_CORE);
+					break;
+				case GLProfile.Embedded:
+					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_MINOR_VERSION, 0);
+					SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_PROFILE_MASK, (int)SDL.SDL_GLprofile.SDL_GL_CONTEXT_PROFILE_ES);
+					break;
+			}
+		}
+
+		static bool CanCreateGLWindow(GLProfile profile)
 		{
 			// Implementation inspired by TestIndividualGLVersion from Veldrid
-			SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_MAJOR_VERSION, major);
-			SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_MINOR_VERSION, minor);
-			SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_PROFILE_MASK, (int)profile);
+			SetSDLAttributes(profile);
 
 			var flags = SDL.SDL_WindowFlags.SDL_WINDOW_HIDDEN | SDL.SDL_WindowFlags.SDL_WINDOW_OPENGL;
 			var window = SDL.SDL_CreateWindow("", 0, 0, 1, 1, flags);

--- a/OpenRA.Platforms.Default/Shader.cs
+++ b/OpenRA.Platforms.Default/Shader.cs
@@ -23,6 +23,7 @@ namespace OpenRA.Platforms.Default
 		public const int TexMetadataAttributeIndex = 2;
 
 		readonly Dictionary<string, int> samplers = new Dictionary<string, int>();
+		readonly Dictionary<int, int> legacySizeUniforms = new Dictionary<int, int>();
 		readonly Dictionary<int, ITexture> textures = new Dictionary<int, ITexture>();
 		readonly Queue<int> unbindTextures = new Queue<int>();
 		readonly uint program;
@@ -33,7 +34,9 @@ namespace OpenRA.Platforms.Default
 			var filename = Path.Combine(Platform.GameDir, "glsl", name + "." + ext);
 			var code = File.ReadAllText(filename);
 
-			var version = OpenGL.Profile == GLProfile.Embedded ? "300 es" : "140";
+			var version = OpenGL.Profile == GLProfile.Embedded ? "300 es" :
+				OpenGL.Profile == GLProfile.Legacy ? "120" : "140";
+
 			code = code.Replace("{VERSION}", version);
 
 			var shader = OpenGL.glCreateShader(type);
@@ -80,8 +83,12 @@ namespace OpenRA.Platforms.Default
 			OpenGL.CheckGLError();
 			OpenGL.glBindAttribLocation(program, TexMetadataAttributeIndex, "aVertexTexMetadata");
 			OpenGL.CheckGLError();
-			OpenGL.glBindFragDataLocation(program, 0, "fragColor");
-			OpenGL.CheckGLError();
+
+			if (OpenGL.Profile != GLProfile.Legacy)
+			{
+				OpenGL.glBindFragDataLocation(program, 0, "fragColor");
+				OpenGL.CheckGLError();
+			}
 
 			OpenGL.glAttachShader(program, vertexShader);
 			OpenGL.CheckGLError();
@@ -132,6 +139,13 @@ namespace OpenRA.Platforms.Default
 					OpenGL.glUniform1i(loc, nextTexUnit);
 					OpenGL.CheckGLError();
 
+					if (OpenGL.Profile == GLProfile.Legacy)
+					{
+						var sizeLoc = OpenGL.glGetUniformLocation(program, sampler + "Size");
+						if (sizeLoc >= 0)
+							legacySizeUniforms.Add(nextTexUnit, sizeLoc);
+					}
+
 					nextTexUnit++;
 				}
 			}
@@ -146,13 +160,21 @@ namespace OpenRA.Platforms.Default
 			// bind the textures
 			foreach (var kv in textures)
 			{
-				var id = ((ITextureInternal)kv.Value).ID;
+				var texture = (ITextureInternal)kv.Value;
 
 				// Evict disposed textures from the cache
-				if (OpenGL.glIsTexture(id))
+				if (OpenGL.glIsTexture(texture.ID))
 				{
 					OpenGL.glActiveTexture(OpenGL.GL_TEXTURE0 + kv.Key);
-					OpenGL.glBindTexture(OpenGL.GL_TEXTURE_2D, id);
+					OpenGL.glBindTexture(OpenGL.GL_TEXTURE_2D, texture.ID);
+
+					// Work around missing textureSize GLSL function by explicitly tracking sizes in a uniform
+					int param;
+					if (OpenGL.Profile == GLProfile.Legacy && legacySizeUniforms.TryGetValue(kv.Key, out param))
+					{
+						OpenGL.glUniform2f(param, texture.Size.Width, texture.Size.Height);
+						OpenGL.CheckGLError();
+					}
 				}
 				else
 					unbindTextures.Enqueue(kv.Key);

--- a/OpenRA.Platforms.Default/Shader.cs
+++ b/OpenRA.Platforms.Default/Shader.cs
@@ -33,7 +33,7 @@ namespace OpenRA.Platforms.Default
 			var filename = Path.Combine(Platform.GameDir, "glsl", name + "." + ext);
 			var code = File.ReadAllText(filename);
 
-			var version = OpenGL.Features.HasFlag(OpenGL.GLFeatures.GLES) ? "300 es" : "140";
+			var version = OpenGL.Profile == GLProfile.Embedded ? "300 es" : "140";
 			code = code.Replace("{VERSION}", version);
 
 			var shader = OpenGL.glCreateShader(type);

--- a/OpenRA.Platforms.Default/Texture.cs
+++ b/OpenRA.Platforms.Default/Texture.cs
@@ -75,7 +75,7 @@ namespace OpenRA.Platforms.Default
 		void SetData(IntPtr data, int width, int height)
 		{
 			PrepareTexture();
-			var glInternalFormat = OpenGL.Features.HasFlag(OpenGL.GLFeatures.GLES) ? OpenGL.GL_BGRA : OpenGL.GL_RGBA8;
+			var glInternalFormat = OpenGL.Profile == GLProfile.Embedded ? OpenGL.GL_BGRA : OpenGL.GL_RGBA8;
 			OpenGL.glTexImage2D(OpenGL.GL_TEXTURE_2D, 0, glInternalFormat, width, height,
 				0, OpenGL.GL_BGRA, OpenGL.GL_UNSIGNED_BYTE, data);
 			OpenGL.CheckGLError();
@@ -119,7 +119,7 @@ namespace OpenRA.Platforms.Default
 			var data = new byte[4 * Size.Width * Size.Height];
 
 			// GLES doesn't support glGetTexImage so data must be read back via a frame buffer
-			if (OpenGL.Features.HasFlag(OpenGL.GLFeatures.GLES))
+			if (OpenGL.Profile == GLProfile.Embedded)
 			{
 				// Query the active framebuffer so we can restore it afterwards
 				int lastFramebuffer;

--- a/glsl/combined.vert
+++ b/glsl/combined.vert
@@ -3,6 +3,21 @@
 uniform vec3 Scroll;
 uniform vec3 r1, r2;
 
+#if __VERSION__ == 120
+attribute vec4 aVertexPosition;
+attribute vec4 aVertexTexCoord;
+attribute vec2 aVertexTexMetadata;
+
+varying vec4 vTexCoord;
+varying vec2 vTexMetadata;
+varying vec4 vChannelMask;
+varying vec4 vDepthMask;
+varying vec2 vTexSampler;
+
+varying vec4 vColorFraction;
+varying vec4 vRGBAFraction;
+varying vec4 vPalettedFraction;
+#else
 in vec4 aVertexPosition;
 in vec4 aVertexTexCoord;
 in vec2 aVertexTexMetadata;
@@ -16,6 +31,7 @@ out vec2 vTexSampler;
 out vec4 vColorFraction;
 out vec4 vRGBAFraction;
 out vec4 vPalettedFraction;
+#endif
 
 vec4 UnpackChannelAttributes(float x)
 {

--- a/glsl/model.frag
+++ b/glsl/model.frag
@@ -9,13 +9,30 @@ uniform vec2 PaletteRows;
 uniform vec4 LightDirection;
 uniform vec3 AmbientLight, DiffuseLight;
 
+#if __VERSION__ == 120
+varying vec4 vTexCoord;
+varying vec4 vChannelMask;
+varying vec4 vNormalsMask;
+#else
 in vec4 vTexCoord;
 in vec4 vChannelMask;
 in vec4 vNormalsMask;
 out vec4 fragColor;
+#endif
 
 void main()
 {
+	#if __VERSION__ == 120
+	vec4 x = texture2D(DiffuseTexture, vTexCoord.st);
+	vec4 color = texture2D(Palette, vec2(dot(x, vChannelMask), PaletteRows.x));
+	if (color.a < 0.01)
+		discard;
+
+	vec4 y = texture2D(DiffuseTexture, vTexCoord.pq);
+	vec4 normal = (2.0 * texture2D(Palette, vec2(dot(y, vNormalsMask), PaletteRows.y)) - 1.0);
+	vec3 intensity = AmbientLight + DiffuseLight * max(dot(normal, LightDirection), 0.0);
+	gl_FragColor = vec4(intensity * color.rgb, color.a);
+	#else
 	vec4 x = texture(DiffuseTexture, vTexCoord.st);
 	vec4 color = texture(Palette, vec2(dot(x, vChannelMask), PaletteRows.x));
 	if (color.a < 0.01)
@@ -25,4 +42,5 @@ void main()
 	vec4 normal = (2.0 * texture(Palette, vec2(dot(y, vNormalsMask), PaletteRows.y)) - 1.0);
 	vec3 intensity = AmbientLight + DiffuseLight * max(dot(normal, LightDirection), 0.0);
 	fragColor = vec4(intensity * color.rgb, color.a);
+	#endif
 }

--- a/glsl/model.vert
+++ b/glsl/model.vert
@@ -3,12 +3,21 @@
 uniform mat4 View;
 uniform mat4 TransformMatrix;
 
+#if __VERSION__ == 120
+attribute vec4 aVertexPosition;
+attribute vec4 aVertexTexCoord;
+attribute vec2 aVertexTexMetadata;
+varying vec4 vTexCoord;
+varying vec4 vChannelMask;
+varying vec4 vNormalsMask;
+#else
 in vec4 aVertexPosition;
 in vec4 aVertexTexCoord;
 in vec2 aVertexTexMetadata;
 out vec4 vTexCoord;
 out vec4 vChannelMask;
 out vec4 vNormalsMask;
+#endif
 
 vec4 DecodeMask(float x)
 {

--- a/mods/cnc/chrome/settings.yaml
+++ b/mods/cnc/chrome/settings.yaml
@@ -228,13 +228,6 @@ Container@SETTINGS_PANEL:
 									Height: 25
 									MaxLength: 5
 									Type: Integer
-								Label@WINDOW_CHANGES_DESC:
-									X: 60
-									Y: 27
-									Width: 200
-									Height: 15
-									Font: Tiny
-									Text: Video mode and window size changes require restart
 						Container@DISPLAY_SELECTION:
 							Y: 240
 							Children:
@@ -249,13 +242,6 @@ Container@SETTINGS_PANEL:
 									Width: 160
 									Height: 25
 									Font: Regular
-								Label@MODE_CHANGES_DESC:
-									X: 60
-									Y: 27
-									Width: 200
-									Height: 15
-									Font: Tiny
-									Text: Video mode and display changes require restart
 						Checkbox@VSYNC_CHECKBOX:
 							X: 310
 							Y: 210
@@ -278,6 +264,27 @@ Container@SETTINGS_PANEL:
 							Ticks: 20
 							MinimumValue: 50
 							MaximumValue: 240
+						Label@GL_PROFILE:
+							X: 15
+							Y: 270
+							Width: 120
+							Height: 25
+							Align: Right
+							Text: OpenGL Profile:
+						DropDownButton@GL_PROFILE_DROPDOWN:
+							X: 140
+							Y: 270
+							Width: 160
+							Height: 25
+							Font: Regular
+						Label@RESTART_REQUIRED_DESC:
+							X: 300
+							Y: PARENT_BOTTOM + 10
+							Width: PARENT_RIGHT - 300
+							Height: 15
+							Font: TinyBold
+							Text: Display and OpenGL changes require restart
+							Align: Center
 				Container@AUDIO_PANEL:
 					Width: PARENT_RIGHT
 					Height: PARENT_BOTTOM

--- a/mods/common/chrome/settings.yaml
+++ b/mods/common/chrome/settings.yaml
@@ -91,7 +91,7 @@ Background@SETTINGS_PANEL:
 			X: 5
 			Y: 50
 			Width: PARENT_RIGHT - 10
-			Height: PARENT_BOTTOM
+			Height: PARENT_BOTTOM - 50
 			Children:
 				Label@PLAYER:
 					Text: Player Name:
@@ -249,13 +249,6 @@ Background@SETTINGS_PANEL:
 							Height: 25
 							MaxLength: 5
 							Type: Integer
-						Label@WINDOW_CHANGES_DESC:
-							X: 60
-							Y: 27
-							Width: 200
-							Height: 15
-							Font: Tiny
-							Text: Video mode and window size changes require restart
 				Container@DISPLAY_SELECTION:
 					Y: 240
 					Children:
@@ -271,13 +264,6 @@ Background@SETTINGS_PANEL:
 							Height: 25
 							Font: Regular
 							Text: Standard
-						Label@MODE_CHANGES_DESC:
-							X: 60
-							Y: 27
-							Width: 200
-							Height: 15
-							Font: Tiny
-							Text: Video mode and display changes require restart
 				Checkbox@FRAME_LIMIT_CHECKBOX:
 					X: 310
 					Y: 243
@@ -293,6 +279,26 @@ Background@SETTINGS_PANEL:
 					Ticks: 20
 					MinimumValue: 50
 					MaximumValue: 240
+				Label@GL_PROFILE:
+					X: 15
+					Y: 270
+					Width: 120
+					Height: 25
+					Align: Right
+					Text: OpenGL Profile:
+				DropDownButton@GL_PROFILE_DROPDOWN:
+					X: 140
+					Y: 270
+					Width: 160
+					Height: 25
+					Font: Regular
+				Label@RESTART_REQUIRED_DESC:
+					Y: PARENT_BOTTOM - 40
+					Width: PARENT_RIGHT
+					Height: 15
+					Font: Tiny
+					Text: Display and OpenGL changes require restart
+					Align: Center
 		Container@AUDIO_PANEL:
 			X: 5
 			Y: 50


### PR DESCRIPTION
As discussed on IRC and Discord, this PR temporarily restores the OpenGL 2.1 support removed by #17010 as an optional (and disabled by default) rendering mode that can be used by the few people still suffering from GPU driver issues. This will need to be removed again in the future, but hopefully at that point we will be able to support Direct X (either directly or via ANGLE) as an alternative.