### PR TITLE
Fix #14912

### DIFF
--- a/mods/cnc/rules/campaign-maprules.yaml
+++ b/mods/cnc/rules/campaign-maprules.yaml
@@ -29,7 +29,7 @@ Player:
 		EarlyGameOver: true
 	Shroud:
 		FogCheckboxLocked: True
-		FogCheckboxEnabled: True
+		FogCheckboxEnabled: False
 		ExploredMapCheckboxLocked: True
 		ExploredMapCheckboxEnabled: False
 	PlayerResources:

--- a/mods/d2k/rules/campaign-rules.yaml
+++ b/mods/d2k/rules/campaign-rules.yaml
@@ -3,7 +3,7 @@ Player:
 	MissionObjectives:
 		EarlyGameOver: true
 	Shroud:
-		FogCheckboxLocked: True
+		FogCheckboxLocked: False
 		FogCheckboxEnabled: True
 		ExploredMapCheckboxLocked: True
 		ExploredMapCheckboxEnabled: False

--- a/mods/ra/rules/campaign-rules.yaml
+++ b/mods/ra/rules/campaign-rules.yaml
@@ -3,7 +3,7 @@ Player:
 	MissionObjectives:
 		EarlyGameOver: true
 	Shroud:
-		FogCheckboxLocked: True
+		FogCheckboxLocked: False
 		FogCheckboxEnabled: True
 		ExploredMapCheckboxLocked: True
 		ExploredMapCheckboxEnabled: False


### PR DESCRIPTION
Disable fog of war for campaign missions in d2k, ra and td.