### PR TITLE
Correct the support dir location in ExtractSettingsDocsCommand

### DIFF
--- a/OpenRA.Mods.Common/UtilityCommands/ExtractSettingsDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractSettingsDocsCommand.cs
@@ -40,8 +40,14 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			Console.WriteLine("All settings can be changed by starting the game via a command-line parameter like `Game.Mod=ra`.");
 			Console.WriteLine();
 			Console.WriteLine("## Location");
-			Console.WriteLine("* Windows: `My Documents\\OpenRA\\settings.yaml`");
+			Console.WriteLine("* Windows: `%APPDATA%\\OpenRA\\settings.yaml`");
 			Console.WriteLine("* Mac OS X: `~/Library/Application Support/OpenRA/settings.yaml`");
+			Console.WriteLine("* Linux `~/.config/openra/settings.yaml`");
+			Console.WriteLine();
+			Console.WriteLine(
+				"Older releases (before playtest-20190825) used different locations, " +
+				"which newer versions may continue to use in some circumstances:");
+			Console.WriteLine("* Windows: `%USERPROFILE%\\Documents\\OpenRA\\settings.yaml`");
 			Console.WriteLine("* Linux `~/.openra/settings.yaml`");
 			Console.WriteLine();
 			Console.WriteLine(


### PR DESCRIPTION
That changed some time ago. I already manually fixed https://github.com/OpenRA/OpenRA/wiki/Settings as quick workaround until this is merged and the page is generated again.