### PR TITLE
Include selection decorations when calculating ScreenMap bounds.

### DIFF
--- a/OpenRA.Mods.Common/Traits/Render/IsometricSelectionDecorations.cs
+++ b/OpenRA.Mods.Common/Traits/Render/IsometricSelectionDecorations.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new IsometricSelectionDecorations(init.Self, this); }
 	}
 
-	public class IsometricSelectionDecorations : SelectionDecorationsBase
+	public class IsometricSelectionDecorations : SelectionDecorationsBase, IRender
 	{
 		readonly IsometricSelectable selectable;
 
@@ -60,6 +60,16 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			var bounds = selectable.DecorationBounds(self, wr);
 			yield return new IsometricSelectionBarsAnnotationRenderable(self, bounds, displayHealth, displayExtra);
+		}
+
+		IEnumerable<IRenderable> IRender.Render(Actor self, WorldRenderer wr)
+		{
+			yield break;
+		}
+
+		IEnumerable<Rectangle> IRender.ScreenBounds(Actor self, WorldRenderer wr)
+		{
+			yield return selectable.DecorationBounds(self, wr).BoundingRect;
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SelectionDecorations.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public override object Create(ActorInitializer init) { return new SelectionDecorations(init.Self, this); }
 	}
 
-	public class SelectionDecorations : SelectionDecorationsBase
+	public class SelectionDecorations : SelectionDecorationsBase, IRender
 	{
 		readonly Interactable interactable;
 
@@ -61,6 +61,16 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			var bounds = interactable.DecorationBounds(self, wr);
 			yield return new SelectionBarsAnnotationRenderable(self, bounds, displayHealth, displayExtra);
+		}
+
+		IEnumerable<IRenderable> IRender.Render(Actor self, WorldRenderer wr)
+		{
+			yield break;
+		}
+
+		IEnumerable<Rectangle> IRender.ScreenBounds(Actor self, WorldRenderer wr)
+		{
+			yield return interactable.DecorationBounds(self, wr);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #17680 and the new isometric selection boxes being cut off when the structure's artwork scrolls off the edge of the screen.