### PR TITLE
Hide selection decorations when spectators zoom too far out.

### DIFF
--- a/OpenRA.Game/Graphics/Viewport.cs
+++ b/OpenRA.Game/Graphics/Viewport.cs
@@ -89,6 +89,8 @@ namespace OpenRA.Graphics
 			}
 		}
 
+		public float MinZoom { get { return minZoom; } }
+
 		public void AdjustZoom(float dz)
 		{
 			// Exponential ensures that equal positive and negative steps have the same effect

--- a/OpenRA.Mods.Common/Traits/Render/SelectionDecorationsBase.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SelectionDecorationsBase.cs
@@ -109,6 +109,14 @@ namespace OpenRA.Mods.Common.Traits.Render
 				foreach (var r in RenderSelectionBars(self, wr, displayHealth, displayExtra))
 					yield return r;
 
+			if (selected && self.World.LocalPlayer != null && self.World.LocalPlayer.PlayerActor.Trait<DeveloperMode>().PathDebug)
+				yield return new TargetLineRenderable(ActivityTargetPath(self), Color.Green);
+
+			// Hide decorations for spectators that zoom out further than the normal minimum level
+			// This avoids graphical glitches with pip rows and icons overlapping the selection box
+			if (wr.Viewport.Zoom < wr.Viewport.MinZoom)
+				yield break;
+
 			var renderDecorations = self.World.Selection.Contains(self) ? selectedDecorations : decorations;
 			foreach (var kv in renderDecorations)
 			{
@@ -117,13 +125,6 @@ namespace OpenRA.Mods.Common.Traits.Render
 					foreach (var rr in r.RenderDecoration(self, wr, pos))
 						yield return rr;
 			}
-
-			// Target lines and pips are always only displayed for selected allied actors
-			if (!selected || !self.Owner.IsAlliedWith(wr.World.RenderPlayer))
-				yield break;
-
-			if (self.World.LocalPlayer != null && self.World.LocalPlayer.PlayerActor.Trait<DeveloperMode>().PathDebug)
-				yield return new TargetLineRenderable(ActivityTargetPath(self), Color.Green);
 		}
 
 		IEnumerable<IRenderable> ISelectionDecorations.RenderSelectionAnnotations(Actor self, WorldRenderer worldRenderer, Color color)


### PR DESCRIPTION
Before:
<img src="https://user-images.githubusercontent.com/167819/80490033-ac5b1880-8958-11ea-8b2d-3d993540d1f6.png">
After:
<img src="https://user-images.githubusercontent.com/167819/80490060-b54bea00-8958-11ea-878f-9d291dfab933.png">
