### PR TITLE
AI ProtectionState repair function

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
@@ -25,6 +25,50 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		{
 			return owner.SquadManager.FindClosestEnemy(owner.Units.First().CenterPosition);
 		}
+
+		// Retreat units from combat, or for supply only in idle
+		protected virtual void Retreat(Squad owner, bool resupplyonly)
+		{
+			// Repair units. One by one to avoid give out mass orders
+			var alreadysend = false;
+
+			foreach (var a in owner.Units)
+			{
+				if (IsRearming(a))
+					continue;
+
+				Actor repairBuilding = null;
+				var orderId = "Repair";
+				var health = a.TraitOrDefault<IHealth>();
+
+				if (!alreadysend && health != null && health.DamageState > DamageState.Undamaged)
+				{
+					var repairable = a.TraitOrDefault<Repairable>();
+					if (repairable != null)
+						repairBuilding = repairable.FindRepairBuilding(a);
+					else
+					{
+						var repairableNear = a.TraitOrDefault<RepairableNear>();
+						if (repairableNear != null)
+						{
+							orderId = "RepairNear";
+							repairBuilding = repairableNear.FindRepairBuilding(a);
+						}
+					}
+
+					if (repairBuilding != null)
+					{
+						owner.Bot.QueueOrder(new Order(orderId, a, Target.FromActor(repairBuilding), false));
+						alreadysend = true;
+						continue;
+					}
+					else if (!resupplyonly)
+						owner.Bot.QueueOrder(new Order("Move", a, Target.FromCell(owner.World, RandomBuildingLocation(owner)), false));
+				}
+				else if (!resupplyonly)
+					owner.Bot.QueueOrder(new Order("Move", a, Target.FromCell(owner.World, RandomBuildingLocation(owner)), false));
+			}
+		}
 	}
 
 	class GroundUnitsIdleState : GroundStateBase, IState

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/ProtectionStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/ProtectionStates.cs
@@ -9,18 +9,93 @@
  */
 #endregion
 
+using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 {
-	class UnitsForProtectionIdleState : GroundStateBase, IState
+	abstract class ProtectionStateBase : GroundStateBase
+	{
+		// Retreat units from combat, or for supply only in idle
+		protected override void Retreat(Squad owner, bool resupplyonly)
+		{
+			// Reload units.
+			foreach (var a in owner.Units)
+			{
+				var ammoPools = a.TraitsImplementing<AmmoPool>().ToArray();
+				if (!ReloadsAutomatically(ammoPools, a.TraitOrDefault<Rearmable>()) && !FullAmmo(ammoPools))
+				{
+					if (IsRearming(a))
+						continue;
+
+					owner.Bot.QueueOrder(new Order("ReturnToBase", a, false));
+					continue;
+				}
+				else if (!resupplyonly)
+					owner.Bot.QueueOrder(new Order("Move", a, Target.FromCell(owner.World, RandomBuildingLocation(owner)), false));
+			}
+
+			// Repair units. One by one to avoid give out mass orders
+			foreach (var a in owner.Units)
+			{
+				if (IsRearming(a))
+					continue;
+
+				Actor repairBuilding = null;
+				var orderId = "Repair";
+				var health = a.TraitOrDefault<IHealth>();
+
+				if (health != null && health.DamageState > DamageState.Undamaged)
+				{
+					var repairable = a.TraitOrDefault<Repairable>();
+					if (repairable != null)
+						repairBuilding = repairable.FindRepairBuilding(a);
+					else
+					{
+						var repairableNear = a.TraitOrDefault<RepairableNear>();
+						if (repairableNear != null)
+						{
+							orderId = "RepairNear";
+							repairBuilding = repairableNear.FindRepairBuilding(a);
+						}
+					}
+
+					if (repairBuilding != null)
+					{
+						owner.Bot.QueueOrder(new Order(orderId, a, Target.FromActor(repairBuilding), true));
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	class UnitsForProtectionIdleState : ProtectionStateBase, IState
 	{
 		public void Activate(Squad owner) { }
-		public void Tick(Squad owner) { owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionAttackState(), true); }
+		public void Tick(Squad owner)
+		{
+			if (!owner.IsValid)
+				return;
+
+			if (!owner.IsTargetValid)
+			{
+				owner.TargetActor = owner.SquadManager.FindClosestEnemy(owner.CenterPosition, WDist.FromCells(owner.SquadManager.Info.ProtectionScanRadius));
+
+				if (owner.TargetActor == null)
+				{
+					Retreat(owner, true);
+					return;
+				}
+			}
+
+			owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionAttackState(), true);
+		}
+
 		public void Deactivate(Squad owner) { }
 	}
 
-	class UnitsForProtectionAttackState : GroundStateBase, IState
+	class UnitsForProtectionAttackState : ProtectionStateBase, IState
 	{
 		public const int BackoffTicks = 4;
 		internal int Backoff = BackoffTicks;
@@ -64,7 +139,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		public void Deactivate(Squad owner) { }
 	}
 
-	class UnitsForProtectionFleeState : GroundStateBase, IState
+	class UnitsForProtectionFleeState : ProtectionStateBase, IState
 	{
 		public void Activate(Squad owner) { }
 
@@ -73,7 +148,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			if (!owner.IsValid)
 				return;
 
-			GoToRandomOwnBuilding(owner);
+			Retreat(owner, false);
 			owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionIdleState(), true);
 		}
 


### PR DESCRIPTION
Add Repair behavior for ground & air units when they retreat and IDLE, in protection state.

This one depends on GroundState code a little.