### PR TITLE
AI GroundAttackState fix

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/GroundStates.cs
@@ -25,6 +25,25 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 		{
 			return owner.SquadManager.FindClosestEnemy(owner.Units.First().CenterPosition);
 		}
+
+		protected Actor GetRandomValuableTarget(Squad owner)
+		{
+			var manager = owner.SquadManager;
+			var mustDestroyedEnemy = manager.World.ActorsHavingTrait<MustBeDestroyed>(t => t.Info.RequiredForShortGame)
+					.Where(a => manager.IsPreferredEnemyUnit(a) && manager.IsNotHiddenUnit(a)).ToArray();
+
+			if (!mustDestroyedEnemy.Any())
+				return FindClosestEnemy(owner);
+
+			return mustDestroyedEnemy.Random(owner.World.LocalRandom);
+		}
+
+		protected Actor ThreatScan(Squad owner, Actor teamLeader, WDist scanRadius)
+		{
+			var enemies = owner.World.FindActorsInCircle(teamLeader.CenterPosition, scanRadius)
+					.Where(a => owner.SquadManager.IsPreferredEnemyUnit(a) && owner.SquadManager.IsNotHiddenUnit(a));
+			return enemies.ClosestTo(teamLeader.CenterPosition);
+		}
 	}
 
 	class GroundUnitsIdleState : GroundStateBase, IState
@@ -130,26 +149,52 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 
 		public void Tick(Squad owner)
 		{
+			var cannotRetaliate = false;
+
+			// Basic check
 			if (!owner.IsValid)
 				return;
 
-			if (!owner.IsTargetValid)
+			var teamLeader = owner.Units.FirstOrDefault();
+			if (teamLeader == null)
+				return;
+
+			// Rescan target to prevent being ambushed and die without fight
+			// If there is no threat around, return to AttackMove state for formation
+			var attackScanRadius = WDist.FromCells(owner.SquadManager.Info.AttackScanRadius);
+			var targetActor = ThreatScan(owner, teamLeader, attackScanRadius);
+
+			if (targetActor == null)
 			{
-				var closestEnemy = FindClosestEnemy(owner);
-				if (closestEnemy != null)
-					owner.TargetActor = closestEnemy;
-				else
+				owner.TargetActor = GetRandomValuableTarget(owner);
+				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsAttackMoveState(), true);
+				return;
+			}
+			else
+			{
+				cannotRetaliate = true;
+				owner.TargetActor = targetActor;
+
+				foreach (var a in owner.Units)
 				{
-					owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsFleeState(), true);
-					return;
+					if (!BusyAttack(a))
+					{
+						if (CanAttackTarget(a, targetActor))
+						{
+							owner.Bot.QueueOrder(new Order("Attack", a, Target.FromActor(owner.TargetActor), false));
+							cannotRetaliate = false;
+						}
+						else
+							owner.Bot.QueueOrder(new Order("AttackMove", a, Target.FromCell(owner.World, teamLeader.Location), false));
+					}
+					else
+						cannotRetaliate = false;
 				}
 			}
 
-			foreach (var a in owner.Units)
-				if (!BusyAttack(a))
-					owner.Bot.QueueOrder(new Order("Attack", a, Target.FromActor(owner.TargetActor), false));
-
-			if (ShouldFlee(owner))
+			// Because ShouldFlee(owner) cannot retreat units while they cannot even fight
+			// a unit that they cannot target. Therefore, use `cannotRetaliate` here to solve this bug.
+			if (ShouldFlee(owner) || cannotRetaliate)
 				owner.FuzzyStateMachine.ChangeState(owner, new GroundUnitsFleeState(), true);
 		}
 


### PR DESCRIPTION
1. AI will return to attackMoveState when losing the target

2. AI will detect enemy from leader ~~and tail.~~

3. AI unattackable units will ~~guard~~ AttackMove to the leader if possible.

4.  If all units are unattackable towards target, they will flee.