### PR TITLE
AI ProtectionAttackState fix

### DIFF
--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/States/ProtectionStates.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/States/ProtectionStates.cs
@@ -9,18 +9,21 @@
  */
 #endregion
 
+using System.Linq;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 {
-	class UnitsForProtectionIdleState : GroundStateBase, IState
+	abstract class ProtectionStateBase : GroundStateBase { }
+
+	class UnitsForProtectionIdleState : ProtectionStateBase, IState
 	{
 		public void Activate(Squad owner) { }
 		public void Tick(Squad owner) { owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionAttackState(), true); }
 		public void Deactivate(Squad owner) { }
 	}
 
-	class UnitsForProtectionAttackState : GroundStateBase, IState
+	class UnitsForProtectionAttackState : ProtectionStateBase, IState
 	{
 		public const int BackoffTicks = 4;
 		internal int Backoff = BackoffTicks;
@@ -38,16 +41,28 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 
 				if (owner.TargetActor == null)
 				{
-					owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionFleeState(), true);
+					owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionFleeState(), false);
 					return;
 				}
 			}
+
+			// rescan target to prevent being ambushed and die without fight
+			// return to AttackMove state for formation
+			var leader = owner.Units.ClosestTo(owner.TargetActor.CenterPosition);
+			if (leader == null)
+				return;
+			var protectionScanRadius = WDist.FromCells(owner.SquadManager.Info.ProtectionScanRadius);
+			var targetActor = owner.SquadManager.FindClosestEnemy(leader.CenterPosition, protectionScanRadius);
+			var cannotRetaliate = false;
+
+			if (targetActor != null)
+				owner.TargetActor = targetActor;
 
 			if (!owner.IsTargetVisible)
 			{
 				if (Backoff < 0)
 				{
-					owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionFleeState(), true);
+					owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionFleeState(), false);
 					Backoff = BackoffTicks;
 					return;
 				}
@@ -56,15 +71,63 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			}
 			else
 			{
+				cannotRetaliate = true;
+
 				foreach (var a in owner.Units)
-					owner.Bot.QueueOrder(new Order("AttackMove", a, Target.FromCell(owner.World, owner.TargetActor.Location), false));
+				{
+					// Air units control:
+					var ammoPools = a.TraitsImplementing<AmmoPool>().ToArray();
+					if (a.Info.HasTraitInfo<AircraftInfo>() && ammoPools.Any())
+					{
+						if (BusyAttack(a))
+						{
+							cannotRetaliate = false;
+							continue;
+						}
+
+						if (!ReloadsAutomatically(ammoPools, a.TraitOrDefault<Rearmable>()))
+						{
+							if (IsRearming(a))
+								continue;
+
+							if (!HasAmmo(ammoPools))
+							{
+								owner.Bot.QueueOrder(new Order("ReturnToBase", a, false));
+								continue;
+							}
+						}
+
+						if (CanAttackTarget(a, owner.TargetActor))
+						{
+							owner.Bot.QueueOrder(new Order("Attack", a, Target.FromActor(owner.TargetActor), false));
+							cannotRetaliate = false;
+						}
+						else
+							owner.Bot.QueueOrder(new Order("AttackMove", a, Target.FromCell(owner.World, leader.Location), false));
+					}
+
+					// Ground/naval units control:
+					else
+					{
+						if (CanAttackTarget(a, owner.TargetActor))
+						{
+							owner.Bot.QueueOrder(new Order("Attack", a, Target.FromActor(owner.TargetActor), false));
+							cannotRetaliate = false;
+						}
+						else
+							owner.Bot.QueueOrder(new Order("AttackMove", a, Target.FromCell(owner.World, leader.Location), false));
+					}
+				}
 			}
+
+			if (cannotRetaliate)
+				owner.FuzzyStateMachine.ChangeState(owner, new UnitsForProtectionFleeState(), false);
 		}
 
 		public void Deactivate(Squad owner) { }
 	}
 
-	class UnitsForProtectionFleeState : GroundStateBase, IState
+	class UnitsForProtectionFleeState : ProtectionStateBase, IState
 	{
 		public void Activate(Squad owner) { }
 


### PR DESCRIPTION
1. AI use Attack instead of AM to avoid run into the face of enemy.

2. AI will detect enemy from leader and tail.

3. AI unattackable units will guard the leader if possible.

4.  If all units are unattackable towards target, they will flee.

5.  Aircrafts need reloading will reload instead of stay above enemy and doing nothing. 

**~~This one depends on GroundState code a little.~~**

Update: may fixes #6316