### PR TITLE
Add configurable squadrons to AirstrikePower

### DIFF
--- a/OpenRA.Game/IUtilityCommand.cs
+++ b/OpenRA.Game/IUtilityCommand.cs
@@ -18,8 +18,9 @@ namespace OpenRA
 {
 	public class Utility
 	{
-		static readonly ConcurrentCache<Type, FieldInfo[]> TypeFields =
-			new(type => type.GetFields());
+		static readonly ConcurrentCache<Type, FieldInfo[]> TypeFields = new(type => type.GetFields());
+
+		static readonly ConcurrentCache<Type, PropertyInfo[]> TypeProperties = new(type => type.GetProperties());
 
 		static readonly ConcurrentCache<(MemberInfo Member, Type AttributeType), bool> MemberHasAttribute =
 			new(x => Attribute.IsDefined(x.Member, x.AttributeType));
@@ -27,10 +28,9 @@ namespace OpenRA
 		static readonly ConcurrentCache<(MemberInfo Member, Type AttributeType, bool Inherit), object[]> MemberCustomAttributes =
 			new(x => x.Member.GetCustomAttributes(x.AttributeType, x.Inherit));
 
-		public static FieldInfo[] GetFields(Type type)
-		{
-			return TypeFields[type];
-		}
+		public static FieldInfo[] GetFields(Type type) => TypeFields[type];
+
+		public static PropertyInfo[] GetProperties(Type type) => TypeProperties[type];
 
 		public static bool HasAttribute<TAttribute>(MemberInfo member)
 			where TAttribute : Attribute

--- a/OpenRA.Game/Traits/LintAttributes.cs
+++ b/OpenRA.Game/Traits/LintAttributes.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Traits
 		Values = 2
 	}
 
-	[AttributeUsage(AttributeTargets.Field)]
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
 	public sealed class ActorReferenceAttribute : Attribute
 	{
 		public readonly Type[] RequiredTraits;

--- a/OpenRA.Game/Traits/LintAttributes.cs
+++ b/OpenRA.Game/Traits/LintAttributes.cs
@@ -42,7 +42,7 @@ namespace OpenRA.Traits
 		}
 	}
 
-	[AttributeUsage(AttributeTargets.Field)]
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
 	public sealed class WeaponReferenceAttribute : Attribute { }
 
 	[AttributeUsage(AttributeTargets.Field)]

--- a/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
@@ -39,7 +39,8 @@ namespace OpenRA.Mods.Common.Lint
 		static void CheckTrait(Action<string> emitError, ActorInfo actorInfo, TraitInfo traitInfo, Ruleset rules)
 		{
 			var actualType = traitInfo.GetType();
-			foreach (var field in Utility.GetFields(actualType))
+			var members = Utility.GetFields(actualType).Concat(Utility.GetProperties(actualType).Cast<MemberInfo>());
+			foreach (var field in members)
 			{
 				if (Utility.HasAttribute<ActorReferenceAttribute>(field))
 					CheckActorReference(emitError, actorInfo, traitInfo, field, rules.Actors,
@@ -51,20 +52,13 @@ namespace OpenRA.Mods.Common.Lint
 				if (Utility.HasAttribute<VoiceSetReferenceAttribute>(field))
 					CheckVoiceReference(emitError, actorInfo, traitInfo, field, rules.Voices);
 			}
-
-			foreach (var property in actualType.GetProperties())
-			{
-				if (property.HasAttribute<ActorReferenceAttribute>())
-					CheckActorReference(actorInfo, traitInfo, property, rules.Actors,
-						property.GetCustomAttributes<ActorReferenceAttribute>(true)[0]);
-			}
 		}
 
 		static void CheckActorReference(Action<string> emitError, ActorInfo actorInfo, TraitInfo traitInfo,
 			MemberInfo memberInfo, IReadOnlyDictionary<string, ActorInfo> dict, ActorReferenceAttribute attribute)
 		{
-			var values = memberInfo is PropertyInfo
-				? LintExts.GetPropertyValues(traitInfo, (PropertyInfo)memberInfo, attribute.DictionaryReference)
+			var values = memberInfo is PropertyInfo info
+				? LintExts.GetPropertyValues(traitInfo, info, attribute.DictionaryReference)
 				: LintExts.GetFieldValues(traitInfo, (FieldInfo)memberInfo, attribute.DictionaryReference);
 
 			foreach (var value in values)
@@ -90,30 +84,36 @@ namespace OpenRA.Mods.Common.Lint
 		}
 
 		static void CheckWeaponReference(Action<string> emitError, ActorInfo actorInfo, TraitInfo traitInfo,
-			FieldInfo fieldInfo, IReadOnlyDictionary<string, WeaponInfo> dict)
+			MemberInfo memberInfo, IReadOnlyDictionary<string, WeaponInfo> dict)
 		{
-			var values = LintExts.GetFieldValues(traitInfo, fieldInfo);
+			var values = memberInfo is PropertyInfo info
+				? LintExts.GetPropertyValues(traitInfo, info)
+				: LintExts.GetFieldValues(traitInfo, (FieldInfo)memberInfo);
+
 			foreach (var value in values)
 			{
 				if (value == null)
 					continue;
 
 				if (!dict.ContainsKey(value.ToLowerInvariant()))
-					emitError($"`{actorInfo.Name}.{traitInfo.GetType().Name}.{fieldInfo.Name}`: Missing weapon `{value}`.");
+					emitError($"`{actorInfo.Name}.{traitInfo.GetType().Name}.{memberInfo.Name}`: Missing weapon `{value}`.");
 			}
 		}
 
 		static void CheckVoiceReference(Action<string> emitError, ActorInfo actorInfo, TraitInfo traitInfo,
-			FieldInfo fieldInfo, IReadOnlyDictionary<string, SoundInfo> dict)
+			MemberInfo memberInfo, IReadOnlyDictionary<string, SoundInfo> dict)
 		{
-			var values = LintExts.GetFieldValues(traitInfo, fieldInfo);
+			var values = memberInfo is PropertyInfo info
+				? LintExts.GetPropertyValues(traitInfo, info)
+				: LintExts.GetFieldValues(traitInfo, (FieldInfo)memberInfo);
+
 			foreach (var value in values)
 			{
 				if (value == null)
 					continue;
 
 				if (!dict.ContainsKey(value.ToLowerInvariant()))
-					emitError($"`{actorInfo.Name}.{traitInfo.GetType().Name}.{fieldInfo.Name}`: Missing voice `{value}`.");
+					emitError($"`{actorInfo.Name}.{traitInfo.GetType().Name}.{memberInfo.Name}`: Missing voice `{value}`.");
 			}
 		}
 	}

--- a/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
@@ -51,14 +51,21 @@ namespace OpenRA.Mods.Common.Lint
 				if (Utility.HasAttribute<VoiceSetReferenceAttribute>(field))
 					CheckVoiceReference(emitError, actorInfo, traitInfo, field, rules.Voices);
 			}
+
+			foreach (var property in actualType.GetProperties())
+			{
+				if (property.HasAttribute<ActorReferenceAttribute>())
+					CheckActorReference(actorInfo, traitInfo, property, rules.Actors,
+						property.GetCustomAttributes<ActorReferenceAttribute>(true)[0]);
+			}
 		}
 
 		static void CheckActorReference(Action<string> emitError, ActorInfo actorInfo, TraitInfo traitInfo,
-			FieldInfo fieldInfo, IReadOnlyDictionary<string, ActorInfo> dict, ActorReferenceAttribute attribute)
+			MemberInfo memberInfo, IReadOnlyDictionary<string, ActorInfo> dict, ActorReferenceAttribute attribute)
 		{
-			var values = LintExts.GetFieldValues(traitInfo, fieldInfo, attribute.DictionaryReference);
-			if (values == null)
-				return;
+			var values = memberInfo is PropertyInfo
+				? LintExts.GetPropertyValues(traitInfo, (PropertyInfo)memberInfo, attribute.DictionaryReference)
+				: LintExts.GetFieldValues(traitInfo, (FieldInfo)memberInfo, attribute.DictionaryReference);
 
 			foreach (var value in values)
 			{
@@ -71,14 +78,14 @@ namespace OpenRA.Mods.Common.Lint
 
 				if (!dict.ContainsKey(v))
 				{
-					emitError($"`{actorInfo.Name}.{traitInfo.GetType().Name}.{fieldInfo.Name}`: Missing actor `{value}`.");
+					emitError($"`{actorInfo.Name}.{traitInfo.GetType().Name}.{memberInfo.Name}`: Missing actor `{value}`.");
 
 					continue;
 				}
 
 				foreach (var requiredTrait in attribute.RequiredTraits)
 					if (!dict[v].TraitsInConstructOrder().Any(t => t.GetType() == requiredTrait || t.GetType().IsSubclassOf(requiredTrait)))
-						emitError($"Actor type `{value}` does not have trait `{requiredTrait.Name}` which is required by `{traitInfo.GetType().Name}.{fieldInfo.Name}`.");
+						emitError($"Actor type `{value}` does not have trait `{requiredTrait.Name}` which is required by `{traitInfo.GetType().Name}.{memberInfo.Name}`.");
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/LintAttributes.cs
+++ b/OpenRA.Mods.Common/Traits/LintAttributes.cs
@@ -13,7 +13,7 @@ using System;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	[AttributeUsage(AttributeTargets.Field)]
+	[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
 	public sealed class VoiceSetReferenceAttribute : Attribute { }
 
 	[AttributeUsage(AttributeTargets.Field)]

--- a/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/AirstrikePower.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.Mods.Common.Activities;
@@ -18,18 +17,29 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
+	public class AirstrikePowerSquadMember
+	{
+		public readonly string UnitType;
+
+		public readonly WVec SpawnOffset;
+
+		public readonly WVec TargetOffset;
+
+		public AirstrikePowerSquadMember(MiniYamlNode yamlNode)
+		{
+			FieldLoader.Load(this, yamlNode.Value);
+		}
+	}
+
 	[Desc("Support power that spawns a group of aircraft and orders them to deliver an airstrike.")]
 	public class AirstrikePowerInfo : DirectionalSupportPowerInfo
 	{
-		[ActorReference(typeof(AircraftInfo))]
-		[Desc("Aircraft used to deliver the airstrike.")]
-		public readonly string UnitType = "badr.bomber";
-
-		[Desc("Number of aircraft to use in an airstrike formation.")]
-		public readonly int SquadSize = 1;
-
-		[Desc("Offset vector between the aircraft in a formation.")]
-		public readonly WVec SquadOffset = new(-1536, 1536, 0);
+		[FieldLoader.LoadUsing(nameof(LoadSquad))]
+		[Desc("A list of aircraft in the squad. Each has configurable "
+			+ nameof(AirstrikePowerSquadMember.UnitType) + ", "
+			+ nameof(AirstrikePowerSquadMember.SpawnOffset) + " and "
+			+ nameof(AirstrikePowerSquadMember.TargetOffset))]
+		public readonly List<AirstrikePowerSquadMember> Squad = [];
 
 		[Desc("Number of different possible facings of the aircraft (used only for choosing a random direction to spawn from.)")]
 		public readonly int QuantizedFacings = 32;
@@ -46,6 +56,21 @@ namespace OpenRA.Mods.Common.Traits
 
 		[Desc("Weapon range offset to apply during the beacon clock calculation.")]
 		public readonly WDist BeaconDistanceOffset = WDist.FromCells(6);
+
+		static object LoadSquad(MiniYaml yaml)
+		{
+			var ret = new List<AirstrikePowerSquadMember>();
+
+			var squadNode = yaml.Nodes.Single(n => n.Key == "Squad");
+			foreach (var d in squadNode.Value.Nodes)
+				ret.Add(new AirstrikePowerSquadMember(d));
+
+			return ret;
+		}
+
+		// This property is specially added so we can still lint-check the actor types.
+		[ActorReference(typeof(AircraftInfo))]
+		public IEnumerable<string> LintSquadActors => Squad.Select(s => s.UnitType);
 
 		public override object Create(ActorInitializer init) { return new AirstrikePower(init.Self, this); }
 	}
@@ -73,13 +98,6 @@ namespace OpenRA.Mods.Common.Traits
 			var aircraft = new List<Actor>();
 			if (!facing.HasValue)
 				facing = new WAngle(1024 * self.World.SharedRandom.Next(info.QuantizedFacings) / info.QuantizedFacings);
-
-			var altitude = self.World.Map.Rules.Actors[info.UnitType].TraitInfo<AircraftInfo>().CruiseAltitude.Length;
-			var attackRotation = WRot.FromYaw(facing.Value);
-			var delta = new WVec(0, -1024, 0).Rotate(attackRotation);
-			target += new WVec(0, 0, altitude);
-			var startEdge = target - (self.World.Map.DistanceToEdge(target, -delta) + info.Cordon).Length * delta / 1024;
-			var finishEdge = target + (self.World.Map.DistanceToEdge(target, delta) + info.Cordon).Length * delta / 1024;
 
 			Actor camera = null;
 			Beacon beacon = null;
@@ -128,66 +146,68 @@ namespace OpenRA.Mods.Common.Traits
 				}
 			}
 
-			// Create the actors immediately so they can be returned
-			for (var i = -info.SquadSize / 2; i <= info.SquadSize / 2; i++)
-			{
-				// Even-sized squads skip the lead plane
-				if (i == 0 && (info.SquadSize & 1) == 0)
-					continue;
+			WPos? startPos = null;
 
-				// Includes the 90 degree rotation between body and world coordinates
-				var so = info.SquadOffset;
-				var spawnOffset = new WVec(i * so.Y, -Math.Abs(i) * so.X, 0).Rotate(attackRotation);
-				var targetOffset = new WVec(i * so.Y, 0, 0).Rotate(attackRotation);
-				var a = self.World.CreateActor(false, info.UnitType,
+			// Create the actors immediately so they can be returned.
+			foreach (var squadMember in info.Squad)
+			{
+				var a = self.World.CreateActor(false, squadMember.UnitType,
 				[
-					new CenterPositionInit(startEdge + spawnOffset),
 					new OwnerInit(self.Owner),
 					new FacingInit(facing.Value),
 				]);
 
 				aircraft.Add(a);
 				aircraftInRange.Add(a, false);
-
-				var attack = a.Trait<AttackBomber>();
-				attack.SetTarget(target + targetOffset);
-				attack.OnEnteredAttackRange += OnEnterRange;
-				attack.OnExitedAttackRange += OnExitRange;
-				attack.OnRemovedFromWorld += OnRemovedFromWorld;
 			}
 
 			self.World.AddFrameEndTask(w =>
 			{
 				PlayLaunchSounds();
 
-				var j = 0;
 				Actor distanceTestActor = null;
-				for (var i = -info.SquadSize / 2; i <= info.SquadSize / 2; i++)
+				for (var i = 0; i < aircraft.Count; i++)
 				{
-					// Even-sized squads skip the lead plane
-					if (i == 0 && (info.SquadSize & 1) == 0)
-						continue;
+					var squadMember = info.Squad[i];
+					var actor = aircraft[i];
 
-					// Includes the 90 degree rotation between body and world coordinates
-					var so = info.SquadOffset;
-					var spawnOffset = new WVec(i * so.Y, -Math.Abs(i) * so.X, 0).Rotate(attackRotation);
+					var altitude = self.World.Map.Rules.Actors[squadMember.UnitType].TraitInfo<AircraftInfo>().CruiseAltitude.Length;
+					var attackRotation = WRot.FromYaw(facing.Value);
+					var delta = new WVec(0, -1024, 0).Rotate(attackRotation);
+					var targetPos = target + new WVec(0, 0, altitude);
+					var startEdge = targetPos - (self.World.Map.DistanceToEdge(target, -delta) + info.Cordon).Length * delta / 1024;
+					var finishEdge = targetPos + (self.World.Map.DistanceToEdge(target, delta) + info.Cordon).Length * delta / 1024;
 
-					var a = aircraft[j++];
-					w.Add(a);
+					startPos = startEdge;
 
-					a.QueueActivity(new Fly(a, Target.FromPos(target + spawnOffset)));
-					a.QueueActivity(new Fly(a, Target.FromPos(finishEdge + spawnOffset)));
-					a.QueueActivity(new RemoveSelf());
-					distanceTestActor = a;
+					// Includes the 90 degree rotation between body and world coordinates.
+					var so = squadMember.SpawnOffset;
+					var to = squadMember.TargetOffset;
+					var spawnOffset = new WVec(so.Y, -1 * so.X, 0).Rotate(attackRotation);
+					var targetOffset = new WVec(to.Y, 0, 0).Rotate(attackRotation);
+
+					actor.Trait<IPositionable>().SetPosition(actor, startEdge + spawnOffset);
+					w.Add(actor);
+
+					var attack = actor.Trait<AttackBomber>();
+					attack.SetTarget(targetPos + targetOffset);
+					attack.OnEnteredAttackRange += OnEnterRange;
+					attack.OnExitedAttackRange += OnExitRange;
+					attack.OnRemovedFromWorld += OnRemovedFromWorld;
+
+					actor.QueueActivity(new Fly(actor, Target.FromPos(target + targetOffset)));
+					actor.QueueActivity(new Fly(actor, Target.FromPos(finishEdge + spawnOffset)));
+					actor.QueueActivity(new RemoveSelf());
+					distanceTestActor = actor;
 				}
 
-				if (Info.DisplayBeacon)
+				if (Info.DisplayBeacon && startPos.HasValue)
 				{
-					var distance = (target - startEdge).HorizontalLength;
+					var distance = (target - startPos.Value).HorizontalLength;
 
 					beacon = new Beacon(
 						self.Owner,
-						target - new WVec(0, 0, altitude),
+						new WPos(target.X, target.Y, 0),
 						Info.BeaconPaletteIsPlayerPalette,
 						Info.BeaconPalette,
 						Info.BeaconImage,

--- a/OpenRA.Mods.Common/UpdateRules/Rules/20250330/ImproveAirstrikePowerConfiguration.cs
+++ b/OpenRA.Mods.Common/UpdateRules/Rules/20250330/ImproveAirstrikePowerConfiguration.cs
@@ -1,0 +1,72 @@
+#region Copyright & License Information
+/*
+ * Copyright (c) The OpenRA Developers and Contributors
+ * This file is part of OpenRA, which is free software. It is made
+ * available to you under the terms of the GNU General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version. For more
+ * information, see COPYING.
+ */
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenRA.Mods.Common.UpdateRules.Rules
+{
+	public class ImproveAirstrikePowerConfiguration : UpdateRule
+	{
+		public override string Name => "Improve AirstrikePower configurability.";
+
+		public override string Description => "Add squadron configuration to AirstrikePower for each individual aircraft.";
+
+		public override IEnumerable<string> UpdateActorNode(ModData modData, MiniYamlNodeBuilder actorNode)
+		{
+			foreach (var airstrike in actorNode.ChildrenMatching("AirstrikePower"))
+			{
+				if (airstrike.Key.StartsWith('-'))
+					continue;
+
+				var prerequisites = airstrike.ChildrenMatching("Prerequisites").FirstOrDefault();
+				if (prerequisites != null && prerequisites.Value.Value == "~disabled")
+					continue;
+
+				var typeNode = airstrike.LastChildMatching("UnitType");
+				var countNode = airstrike.LastChildMatching("SquadSize");
+				var offsetNode = airstrike.LastChildMatching("SquadOffset");
+
+				var unitType = typeNode?.NodeValue<string>() ?? "badr.bomber";
+				var squadSize = countNode?.NodeValue<int>() ?? 1;
+				var offset = offsetNode?.NodeValue<WVec>() ?? new WVec(-1536, 1536, 0);
+
+				var squadNode = new MiniYamlNodeBuilder("Squad", "");
+				for (var i = -squadSize / 2; i <= squadSize / 2; i++)
+				{
+					// Even-sized squads skip the lead plane.
+					if (i == 0 && (squadSize & 1) == 0)
+						continue;
+
+					var squadMemberNodeKey = squadSize == 1 ? "SquadMember" : $"SquadMember@{i + squadSize / 2}";
+					var squadMemberNode = new MiniYamlNodeBuilder(squadMemberNodeKey, "");
+					squadMemberNode.AddNode(new MiniYamlNodeBuilder("UnitType", FieldSaver.FormatValue(unitType)));
+
+					if (i != 0)
+					{
+						squadMemberNode.AddNode(new MiniYamlNodeBuilder("SpawnOffset", FieldSaver.FormatValue(new WVec(Math.Abs(i) * offset.X, i * offset.Y, 0))));
+						squadMemberNode.AddNode(new MiniYamlNodeBuilder("TargetOffset", FieldSaver.FormatValue(new WVec(0, i * offset.Y, 0))));
+					}
+
+					squadNode.AddNode(squadMemberNode);
+				}
+
+				airstrike.AddNode(squadNode);
+				airstrike.RemoveNode(typeNode);
+				airstrike.RemoveNode(countNode);
+				airstrike.RemoveNode(offsetNode);
+			}
+
+			yield break;
+		}
+	}
+}

--- a/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
+++ b/OpenRA.Mods.Common/UpdateRules/UpdatePath.cs
@@ -78,10 +78,8 @@ namespace OpenRA.Mods.Common.UpdateRules
 				new RemoveNegativeSequenceLength(),
 			]),
 
-			new("release-20231010",
+			new("release-20231010", "release-20250330",
 			[
-
-				// bleed only changes here.
 				new RemoveValidRelationsFromCapturable(),
 				new ExtractResourceStorageFromHarvester(),
 				new ReplacePaletteModifiers(),
@@ -97,6 +95,12 @@ namespace OpenRA.Mods.Common.UpdateRules
 				// Execute these rules last to avoid premature yaml merge crashes.
 				new ReplaceCloakPalette(),
 				new AbstractDocking(),
+			]),
+
+			// Only bleed changes here.
+			new("release-20250330",
+			[
+				new ImproveAirstrikePowerConfiguration()
 			]),
 		];
 

--- a/mods/cnc/maps/gdi05a/rules.yaml
+++ b/mods/cnc/maps/gdi05a/rules.yaml
@@ -166,4 +166,7 @@ MoneyCrate:
 
 airstrike.proxy:
 	AirstrikePower:
-		SquadSize: 1
+		-Squad:
+		Squad:
+			SquadMember:
+				UnitType: a10

--- a/mods/cnc/maps/gdi05b/rules.yaml
+++ b/mods/cnc/maps/gdi05b/rules.yaml
@@ -141,4 +141,7 @@ FTNK:
 
 airstrike.proxy:
 	AirstrikePower:
-		SquadSize: 1
+		-Squad:
+		Squad:
+			SquadMember:
+				UnitType: a10

--- a/mods/cnc/maps/gdi05c/rules.yaml
+++ b/mods/cnc/maps/gdi05c/rules.yaml
@@ -171,4 +171,7 @@ FTNK:
 
 airstrike.proxy:
 	AirstrikePower:
-		SquadSize: 1
+		-Squad:
+		Squad:
+			SquadMember:
+				UnitType: a10

--- a/mods/cnc/maps/gdi08a/rules.yaml
+++ b/mods/cnc/maps/gdi08a/rules.yaml
@@ -140,8 +140,16 @@ BRIDGEHUT:
 
 airstrike.proxy:
 	AirstrikePower:
-		SquadSize: 2
-		SquadOffset: -1536, 1024, 0
+		-Squad:
+		Squad:
+			SquadMember@0:
+				UnitType: a10
+				SpawnOffset: 0, -1024, 0
+				TargetOffset: 0, -1024, 0
+			SquadMember@2:
+				UnitType: a10
+				SpawnOffset: 0, 1024, 0
+				TargetOffset: 0, 1024, 0
 
 HQ:
 	Tooltip:

--- a/mods/cnc/maps/gdi08b/rules.yaml
+++ b/mods/cnc/maps/gdi08b/rules.yaml
@@ -161,8 +161,16 @@ GUN:
 
 airstrike.proxy:
 	AirstrikePower:
-		SquadSize: 2
-		SquadOffset: -1536, 1024, 0
+		-Squad:
+		Squad:
+			SquadMember@0:
+				UnitType: a10
+				SpawnOffset: 0, -1024, 0
+				TargetOffset: 0, -1024, 0
+			SquadMember@2:
+				UnitType: a10
+				SpawnOffset: 0, 1024, 0
+				TargetOffset: 0, 1024, 0
 
 HQ:
 	Tooltip:

--- a/mods/cnc/maps/gdi09/rules.yaml
+++ b/mods/cnc/maps/gdi09/rules.yaml
@@ -136,8 +136,16 @@ HQ:
 
 airstrike.proxy:
 	AirstrikePower:
-		SquadSize: 2
-		SquadOffset: -1536, 1024, 0
+		-Squad:
+		Squad:
+			SquadMember@0:
+				UnitType: a10
+				SpawnOffset: 0, -1024, 0
+				TargetOffset: 0, -1024, 0
+			SquadMember@2:
+				UnitType: a10
+				SpawnOffset: 0, 1024, 0
+				TargetOffset: 0, 1024, 0
 
 BOAT:
 	AutoTarget:

--- a/mods/cnc/maps/nod05/rules.yaml
+++ b/mods/cnc/maps/nod05/rules.yaml
@@ -129,7 +129,10 @@ SBAG:
 HQ:
 	AirstrikePower:
 		Prerequisites: gdi
-		SquadSize: 1
+		-Squad:
+		Squad:
+			SquadMember:
+				UnitType: a10
 
 A10:
 	Targetable:

--- a/mods/cnc/maps/nod07a/rules.yaml
+++ b/mods/cnc/maps/nod07a/rules.yaml
@@ -131,7 +131,10 @@ GTWR:
 HQ:
 	AirstrikePower:
 		Prerequisites: gdi
-		SquadSize: 1
+		-Squad:
+		Squad:
+			SquadMember:
+				UnitType: a10
 
 TRAN.IN:
 	Inherits: TRAN

--- a/mods/cnc/maps/nod07b/rules.yaml
+++ b/mods/cnc/maps/nod07b/rules.yaml
@@ -125,4 +125,7 @@ GTWR:
 HQ:
 	AirstrikePower:
 		Prerequisites: gdi
-		SquadSize: 1
+		-Squad:
+		Squad:
+			SquadMember:
+				UnitType: a10

--- a/mods/cnc/maps/nod08a/rules.yaml
+++ b/mods/cnc/maps/nod08a/rules.yaml
@@ -85,7 +85,10 @@ HTNK:
 HQ:
 	AirstrikePower:
 		Prerequisites: gdi
-		SquadSize: 1
+		-Squad:
+		Squad:
+			SquadMember:
+				UnitType: a10
 
 RMBO:
 	Buildable:
@@ -132,7 +135,18 @@ A10.IN:
 
 airstrike.proxy:
 	AirstrikePower:
-		UnitType: a10.in
+		-Squad:
+		Squad:
+			SquadMember@0:
+				UnitType: a10.in
+				SpawnOffset: -1536, -1536, 0
+				TargetOffset: 0, -1536, 0
+			SquadMember@1:
+				UnitType: a10.in
+			SquadMember@2:
+				UnitType: a10.in
+				SpawnOffset: -1536, 1536, 0
+				TargetOffset: 0, 1536, 0
 
 FACT.IN:
 	Inherits: FACT

--- a/mods/cnc/maps/nod08b/rules.yaml
+++ b/mods/cnc/maps/nod08b/rules.yaml
@@ -107,7 +107,10 @@ HTNK:
 HQ:
 	AirstrikePower:
 		Prerequisites: gdi
-		SquadSize: 1
+		-Squad:
+		Squad:
+			SquadMember:
+				UnitType: a10
 
 RMBO:
 	Buildable:
@@ -154,7 +157,18 @@ A10.IN:
 
 airstrike.proxy:
 	AirstrikePower:
-		UnitType: a10.in
+		-Squad:
+		Squad:
+			SquadMember@0:
+				UnitType: a10.in
+				SpawnOffset: -1536, -1536, 0
+				TargetOffset: 0, -1536, 0
+			SquadMember@1:
+				UnitType: a10.in
+			SquadMember@2:
+				UnitType: a10.in
+				SpawnOffset: -1536, 1536, 0
+				TargetOffset: 0, 1536, 0
 
 BOAT:
 	Health:

--- a/mods/cnc/maps/nod09/rules.yaml
+++ b/mods/cnc/maps/nod09/rules.yaml
@@ -127,7 +127,16 @@ SBAG:
 HQ:
 	AirstrikePower:
 		Prerequisites: gdi
-		SquadSize: 2
+		-Squad:
+		Squad:
+			SquadMember@0:
+				UnitType: a10
+				SpawnOffset: 0, -1536, 0
+				TargetOffset: 0, -1536, 0
+			SquadMember@1:
+				UnitType: a10
+				SpawnOffset: 0, 1536, 0
+				TargetOffset: 0, 1536, 0
 
 BOAT:
 	Health:

--- a/mods/cnc/maps/twist-of-fate/rules.yaml
+++ b/mods/cnc/maps/twist-of-fate/rules.yaml
@@ -81,7 +81,6 @@ Astk.proxy:
 		Prerequisites: ~techlevel.superweapons
 		Icon: airstrike
 		ChargeInterval: 5250
-		SquadSize: 3
 		QuantizedFacings: 8
 		Name: actor-hq.airstrikepower-name
 		Description: actor-hq.airstrikepower-description
@@ -93,7 +92,6 @@ Astk.proxy:
 		SelectTargetTextNotification: notification-select-target
 		InsufficientPowerTextNotification: notification-insufficient-power
 		IncomingTextNotification: notification-enemy-planes-approaching
-		UnitType: a10
 		DisplayBeacon: True
 		BeaconPoster: airstrike
 		BeaconPosterPalette: beaconposter
@@ -105,3 +103,14 @@ Astk.proxy:
 		UseDirectionalTarget: True
 		DirectionArrowAnimation: airstrikedirection
 		SupportPowerPaletteOrder: 10
+		Squad:
+			SquadMember@0:
+				UnitType: a10
+				SpawnOffset: -1536, -1536, 0
+				TargetOffset: 0, -1536, 0
+			SquadMember@1:
+				UnitType: a10
+			SquadMember@2:
+				UnitType: a10
+				SpawnOffset: -1536, 1536, 0
+				TargetOffset: 0, 1536, 0

--- a/mods/cnc/rules/campaign-maprules.yaml
+++ b/mods/cnc/rules/campaign-maprules.yaml
@@ -60,7 +60,6 @@ airstrike.proxy:
 		Icon: airstrike
 		StartFullyCharged: True
 		ChargeInterval: 3000
-		SquadSize: 3
 		QuantizedFacings: 8
 		Name: actor-hq.airstrikepower-name
 		Description: actor-hq.airstrikepower-description
@@ -72,7 +71,6 @@ airstrike.proxy:
 		SelectTargetTextNotification: notification-select-target
 		InsufficientPowerTextNotification: notification-insufficient-power
 		IncomingTextNotification: notification-enemy-planes-approaching
-		UnitType: a10
 		DisplayBeacon: True
 		BeaconPoster: airstrike
 		DisplayRadarPing: True
@@ -81,6 +79,17 @@ airstrike.proxy:
 		ClockSequence: clock
 		CircleSequence: circles
 		SupportPowerPaletteOrder: 10
+		Squad:
+			SquadMember@0:
+				UnitType: a10
+				SpawnOffset: -1536, -1536, 0
+				TargetOffset: 0, -1536, 0
+			SquadMember@1:
+				UnitType: a10
+			SquadMember@2:
+				UnitType: a10
+				SpawnOffset: -1536, 1536, 0
+				TargetOffset: 0, 1536, 0
 
 MoneyCrate:
 	Inherits: ^Crate

--- a/mods/cnc/rules/structures.yaml
+++ b/mods/cnc/rules/structures.yaml
@@ -747,7 +747,6 @@ HQ:
 		Prerequisites: ~techlevel.superweapons
 		Icon: airstrike
 		ChargeInterval: 7500
-		SquadSize: 3
 		QuantizedFacings: 8
 		Name: actor-hq.airstrikepower-name
 		Description: actor-hq.airstrikepower-description
@@ -759,7 +758,6 @@ HQ:
 		SelectTargetTextNotification: notification-select-target
 		InsufficientPowerTextNotification: notification-insufficient-power
 		IncomingTextNotification: notification-enemy-planes-approaching
-		UnitType: a10
 		DisplayBeacon: True
 		BeaconPoster: airstrike
 		BeaconPosterPalette: beaconposter
@@ -771,6 +769,17 @@ HQ:
 		UseDirectionalTarget: True
 		DirectionArrowAnimation: airstrikedirection
 		SupportPowerPaletteOrder: 10
+		Squad:
+			SquadMember@0:
+				UnitType: a10
+				SpawnOffset: -1536, -1536, 0
+				TargetOffset: 0, -1536, 0
+			SquadMember@1:
+				UnitType: a10
+			SquadMember@2:
+				UnitType: a10
+				SpawnOffset: -1536, 1536, 0
+				TargetOffset: 0, 1536, 0
 	SupportPowerChargeBar:
 	Power:
 		Amount: -50

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -999,10 +999,7 @@ high_tech_factory:
 		Name: actor-high-tech-factory.airstrikepower-name
 		Prerequisites: ~techlevel.superweapons, upgrade.hightech
 		ChargeInterval: 7500
-		SquadSize: 3
-		SquadOffset: -1536, 1024, 0
 		Description: actor-high-tech-factory.airstrikepower-description
-		UnitType: ornithopter
 		DisplayBeacon: True
 		CameraActor: camera
 		CameraRemoveDelay: 60
@@ -1013,6 +1010,17 @@ high_tech_factory:
 		SupportPowerPaletteOrder: 10
 		EndChargeTextNotification: notification-airstrike-ready
 		SelectTargetTextNotification: notification-select-target
+		Squad:
+			SquadMember@0:
+				UnitType: ornithopter
+				SpawnOffset: -1536, -1024, 0
+				TargetOffset: 0, -1024, 0
+			SquadMember@1:
+				UnitType: ornithopter
+			SquadMember@2:
+				UnitType: ornithopter
+				SpawnOffset: -1536, 1024, 0
+				TargetOffset: 0, 1024, 0
 	Power:
 		Amount: -75
 	GrantConditionOnPrerequisite@UPGRADEABLE:

--- a/mods/ra/maps/top-o-the-world/rules.yaml
+++ b/mods/ra/maps/top-o-the-world/rules.yaml
@@ -63,13 +63,15 @@ powerproxy.spyplane:
 		EndChargeTextNotification: notification-spy-plane-ready
 		CameraActor: camera.spyplane
 		CameraRemoveDelay: 150
-		UnitType: u2
 		QuantizedFacings: 8
 		DisplayBeacon: true
 		BeaconPoster: camicon
 		ArrowSequence: arrow
 		ClockSequence: clock
 		CircleSequence: circles
+		Squad:
+			SquadMember:
+				UnitType: u2
 
 powerproxy.parabombs:
 	AirstrikePower:

--- a/mods/ra/rules/misc.yaml
+++ b/mods/ra/rules/misc.yaml
@@ -350,7 +350,6 @@ powerproxy.parabombs:
 		Description: actor-powerproxy-parabombs.description
 		OneShot: true
 		AllowMultiple: true
-		UnitType: badr.bomber
 		SelectTargetSpeechNotification: SelectTarget
 		SelectTargetTextNotification: notification-select-target
 		QuantizedFacings: 8
@@ -361,6 +360,9 @@ powerproxy.parabombs:
 		ArrowSequence: arrow
 		ClockSequence: clock
 		CircleSequence: circles
+		Squad:
+			SquadMember:
+				UnitType: badr.bomber
 
 powerproxy.sonarpulse:
 	AlwaysVisible:

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -1565,7 +1565,6 @@ AFLD:
 		EndChargeTextNotification: notification-spy-plane-ready
 		CameraActor: camera.spyplane
 		CameraRemoveDelay: 150
-		UnitType: u2
 		QuantizedFacings: 8
 		DisplayBeacon: true
 		BeaconPoster: camicon
@@ -1575,6 +1574,9 @@ AFLD:
 		UseDirectionalTarget: True
 		DirectionArrowAnimation: paradirection
 		SupportPowerPaletteOrder: 60
+		Squad:
+			SquadMember:
+				UnitType: u2
 	ParatroopersPower@paratroopers:
 		OrderName: SovietParatroopers
 		Prerequisites: aircraft.soviet
@@ -1609,18 +1611,18 @@ AFLD:
 		SelectTargetTextNotification: notification-select-target
 		CameraActor: camera
 		CameraRemoveDelay: 150
-		UnitType: badr.bomber
 		QuantizedFacings: 8
 		DisplayBeacon: true
 		BeaconPoster: pbmbicon
-		SquadSize: 1
-		SquadOffset: 1792,1792,0
 		ArrowSequence: arrow
 		ClockSequence: clock
 		CircleSequence: circles
 		UseDirectionalTarget: True
 		DirectionArrowAnimation: paradirection
 		SupportPowerPaletteOrder: 40
+		Squad:
+			SquadMember:
+				UnitType: badr.bomber
 	ProductionBar:
 		ProductionType: Aircraft
 	SupportPowerChargeBar:


### PR DESCRIPTION
This reworks `AirstrikePowerInfo` to allow for per-plane configuration of actor type, spawn offset, target offset ~and spawn delay~.
This way custom mods (because it probably doesn't have much space for that in the official ones) can do some pretty nice squadron formations and interesting airstrikes.
A follow-up PR can also add a configurable exit offset.

I consider this to be the first PR of 3 on the path to getting the D2k Ornithopter airstrike to match the original, with #17827 becoming the second PR in the series and a third PR using the logic from #17834.

Currently there are 3 major issues, 2 of which concern this PR and the 3rd concerning the follow-up PR.
 - ~With the new way planes are set up they are very hard to lint test. A proposed solution was to do the same thing we have for linting `HotkeyReferences`, but I consider that to be too ugly and out of place and also adds a lot more technical debt than it should, so I'm rather inclined to *not* lint test the actor references here.~    _**Fixed.**_
 - ~This probably needs an upgrade rule but I'm not 100% sure it can be completely automated. In case I'm wrong I'm going to need help with that.~    _**Fixed.**_
 - ~On the 3rd day of testing planes suddenly started turning nondeterministically to the left or right when configured for more than 1 pass. That is a big issue for when #17827 comes and I believe I tracked it down to something that sounds like a rounding issue to me. [Discord link to my finding.](https://discordapp.com/channels/153649279762694144/388282819371204608/704082376594030612)~    _**This was also discussed [on Discord](https://discordapp.com/channels/153649279762694144/388282819371204608/708076428536709190) and the planned fix is for a follow-up PR to add a specific trait/activity to handle the complex pathing.**_