### PR TITLE
D2k inaccuracy

### DIFF
--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -47,6 +47,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Ranges at which each Falloff step is defined.")]
 		public readonly WDist[] Range = { WDist.Zero, new WDist(int.MaxValue) };
 
+		[Desc("The maximum/constant/incremental inaccuracy used in conjunction with the InaccuracyType property.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
 
 		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' - scale from 0 to max with range, 'PerCellIncrement' - scale from 0 with range and 'Absolute' - use set value regardless of range.")]

--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -21,6 +21,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Projectiles
 {
+	public enum InaccuracyType { Maximum, PerCellIncrement }
+
 	public class AreaBeamInfo : IProjectileInfo
 	{
 		[Desc("Projectile speed in WDist / tick, two values indicate a randomly picked velocity per beam.")]
@@ -47,8 +49,10 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Ranges at which each Falloff step is defined.")]
 		public readonly WDist[] Range = { WDist.Zero, new WDist(int.MaxValue) };
 
-		[Desc("Maximum offset at the maximum range.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
+
+		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' and 'PerCellIncrement'.")]
+		public readonly InaccuracyType InaccuracyType = InaccuracyType.Maximum;
 
 		[Desc("Can this projectile be blocked when hitting actors with an IBlocksProjectiles trait.")]
 		public readonly bool Blockable = false;
@@ -129,7 +133,13 @@ namespace OpenRA.Mods.Common.Projectiles
 			if (info.Inaccuracy.Length > 0)
 			{
 				var inaccuracy = Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
-				var maxOffset = inaccuracy * (target - headPos).Length / args.Weapon.Range.Length;
+
+				int maxOffset;
+				if (info.InaccuracyType == InaccuracyType.Maximum)
+					maxOffset = inaccuracy * (target - headPos).Length / args.Weapon.Range.Length;
+				else
+					maxOffset = inaccuracy * (target - headPos).Length / 1024;
+
 				target += WVec.FromPDF(world.SharedRandom, 2) * maxOffset / 1024;
 			}
 

--- a/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
+++ b/OpenRA.Mods.Common/Projectiles/AreaBeam.cs
@@ -21,8 +21,6 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Projectiles
 {
-	public enum InaccuracyType { Maximum, PerCellIncrement, Absolute }
-
 	public class AreaBeamInfo : IProjectileInfo
 	{
 		[Desc("Projectile speed in WDist / tick, two values indicate a randomly picked velocity per beam.")]
@@ -132,23 +130,8 @@ namespace OpenRA.Mods.Common.Projectiles
 			target = args.PassiveTarget;
 			if (info.Inaccuracy.Length > 0)
 			{
-				var inaccuracy = Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
-
-				var maxOffset = 0;
-				switch (info.InaccuracyType)
-				{
-					case InaccuracyType.Maximum:
-						maxOffset = inaccuracy * (target - headPos).Length / args.Weapon.Range.Length;
-						break;
-					case InaccuracyType.PerCellIncrement:
-						maxOffset = inaccuracy * (target - headPos).Length / 1024;
-						break;
-					case InaccuracyType.Absolute:
-						maxOffset = inaccuracy;
-						break;
-				}
-
-				target += WVec.FromPDF(world.SharedRandom, 2) * maxOffset / 1024;
+				var maxInaccuracyOffset = Util.GetProjectileInaccuracy(info.Inaccuracy.Length, info.InaccuracyType, args);
+				target += WVec.FromPDF(world.SharedRandom, 2) * maxInaccuracyOffset / 1024;
 			}
 
 			towardsTargetFacing = (target - headPos).Yaw.Facing;

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -149,24 +149,8 @@ namespace OpenRA.Mods.Common.Projectiles
 			target = args.PassiveTarget;
 			if (info.Inaccuracy.Length > 0)
 			{
-				var inaccuracy = Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
-				var range = Util.ApplyPercentageModifiers(args.Weapon.Range.Length, args.RangeModifiers);
-
-				var maxOffset = 0;
-				switch (info.InaccuracyType)
-				{
-					case InaccuracyType.Maximum:
-						maxOffset = inaccuracy * (target - pos).Length / range;
-						break;
-					case InaccuracyType.PerCellIncrement:
-						maxOffset = inaccuracy * (target - pos).Length / 1024;
-						break;
-					case InaccuracyType.Absolute:
-						maxOffset = inaccuracy;
-						break;
-				}
-
-				target += WVec.FromPDF(world.SharedRandom, 2) * maxOffset / 1024;
+				var maxInaccuracyOffset = Util.GetProjectileInaccuracy(info.Inaccuracy.Length, info.InaccuracyType, args);
+				target += WVec.FromPDF(world.SharedRandom, 2) * maxInaccuracyOffset / 1024;
 			}
 
 			if (info.AirburstAltitude > WDist.Zero)

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		public readonly WDist Inaccuracy = WDist.Zero;
 
-		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' and 'PerCellIncrement'.")]
+		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' - scale from 0 to max with range, 'PerCellIncrement' - scale from 0 with range and 'Absolute' - use set value regardless of range.")]
 		public readonly InaccuracyType InaccuracyType = InaccuracyType.Maximum;
 
 		[Desc("Image to display.")]
@@ -152,11 +152,19 @@ namespace OpenRA.Mods.Common.Projectiles
 				var inaccuracy = Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
 				var range = Util.ApplyPercentageModifiers(args.Weapon.Range.Length, args.RangeModifiers);
 
-				int maxOffset;
-				if (info.InaccuracyType == InaccuracyType.Maximum)
-					maxOffset = inaccuracy * (target - pos).Length / range;
-				else
-					maxOffset = inaccuracy * (target - pos).Length / 1024;
+				var maxOffset = 0;
+				switch (info.InaccuracyType)
+				{
+					case InaccuracyType.Maximum:
+						maxOffset = inaccuracy * (target - pos).Length / range;
+						break;
+					case InaccuracyType.PerCellIncrement:
+						maxOffset = inaccuracy * (target - pos).Length / 1024;
+						break;
+					case InaccuracyType.Absolute:
+						maxOffset = inaccuracy;
+						break;
+				}
 
 				target += WVec.FromPDF(world.SharedRandom, 2) * maxOffset / 1024;
 			}

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -27,6 +27,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Projectile speed in WDist / tick, two values indicate variable velocity.")]
 		public readonly WDist[] Speed = { new WDist(17) };
 
+		[Desc("The maximum/constant/incremental inaccuracy used in conjunction with the InaccuracyType property.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
 
 		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' - scale from 0 to max with range, 'PerCellIncrement' - scale from 0 with range and 'Absolute' - use set value regardless of range.")]

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -27,8 +27,10 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Projectile speed in WDist / tick, two values indicate variable velocity.")]
 		public readonly WDist[] Speed = { new WDist(17) };
 
-		[Desc("Maximum offset at the maximum range.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
+
+		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' and 'PerCellIncrement'.")]
+		public readonly InaccuracyType InaccuracyType = InaccuracyType.Maximum;
 
 		[Desc("Image to display.")]
 		public readonly string Image = null;
@@ -149,7 +151,13 @@ namespace OpenRA.Mods.Common.Projectiles
 			{
 				var inaccuracy = Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
 				var range = Util.ApplyPercentageModifiers(args.Weapon.Range.Length, args.RangeModifiers);
-				var maxOffset = inaccuracy * (target - pos).Length / range;
+
+				int maxOffset;
+				if (info.InaccuracyType == InaccuracyType.Maximum)
+					maxOffset = inaccuracy * (target - pos).Length / range;
+				else
+					maxOffset = inaccuracy * (target - pos).Length / 1024;
+
 				target += WVec.FromPDF(world.SharedRandom, 2) * maxOffset / 1024;
 			}
 

--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Projectiles
 	{
 		public readonly WDist Inaccuracy = WDist.Zero;
 
-		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' and 'PerCellIncrement'.")]
+		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' - scale from 0 to max with range, 'PerCellIncrement' - scale from 0 with range and 'Absolute' - use set value regardless of range.")]
 		public readonly InaccuracyType InaccuracyType = InaccuracyType.Maximum;
 
 		[Desc("Projectile can be blocked.")]
@@ -57,11 +57,19 @@ namespace OpenRA.Mods.Common.Projectiles
 			{
 				var inaccuracy = Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
 
-				int maxOffset;
-				if (info.InaccuracyType == InaccuracyType.Maximum)
-					maxOffset = inaccuracy * (args.PassiveTarget - args.Source).Length / args.Weapon.Range.Length;
-				else
-					maxOffset = inaccuracy * (args.PassiveTarget - args.Source).Length / 1024;
+				var maxOffset = 0;
+				switch (info.InaccuracyType)
+				{
+					case InaccuracyType.Maximum:
+						maxOffset = inaccuracy * (args.PassiveTarget - args.Source).Length / args.Weapon.Range.Length;
+						break;
+					case InaccuracyType.PerCellIncrement:
+						maxOffset = inaccuracy * (args.PassiveTarget - args.Source).Length / 1024;
+						break;
+					case InaccuracyType.Absolute:
+						maxOffset = inaccuracy;
+						break;
+				}
 
 				target = Target.FromPos(args.PassiveTarget + WVec.FromPDF(args.SourceActor.World.SharedRandom, 2) * maxOffset / 1024);
 			}

--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -55,23 +55,9 @@ namespace OpenRA.Mods.Common.Projectiles
 				target = args.GuidedTarget;
 			else if (info.Inaccuracy.Length > 0)
 			{
-				var inaccuracy = Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
-
-				var maxOffset = 0;
-				switch (info.InaccuracyType)
-				{
-					case InaccuracyType.Maximum:
-						maxOffset = inaccuracy * (args.PassiveTarget - args.Source).Length / args.Weapon.Range.Length;
-						break;
-					case InaccuracyType.PerCellIncrement:
-						maxOffset = inaccuracy * (args.PassiveTarget - args.Source).Length / 1024;
-						break;
-					case InaccuracyType.Absolute:
-						maxOffset = inaccuracy;
-						break;
-				}
-
-				target = Target.FromPos(args.PassiveTarget + WVec.FromPDF(args.SourceActor.World.SharedRandom, 2) * maxOffset / 1024);
+				var maxInaccuracyOffset = Util.GetProjectileInaccuracy(info.Inaccuracy.Length, info.InaccuracyType, args);
+				var inaccuracyOffset = WVec.FromPDF(args.SourceActor.World.SharedRandom, 2) * maxInaccuracyOffset / 1024;
+				target = Target.FromPos(args.PassiveTarget + inaccuracyOffset);
 			}
 			else
 				target = Target.FromPos(args.PassiveTarget);

--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -21,6 +21,7 @@ namespace OpenRA.Mods.Common.Projectiles
 	[Desc("Simple, invisible, usually direct-on-target projectile.")]
 	public class InstantHitInfo : IProjectileInfo
 	{
+		[Desc("The maximum/constant/incremental inaccuracy used in conjunction with the InaccuracyType property.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
 
 		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' - scale from 0 to max with range, 'PerCellIncrement' - scale from 0 with range and 'Absolute' - use set value regardless of range.")]

--- a/OpenRA.Mods.Common/Projectiles/InstantHit.cs
+++ b/OpenRA.Mods.Common/Projectiles/InstantHit.cs
@@ -21,8 +21,10 @@ namespace OpenRA.Mods.Common.Projectiles
 	[Desc("Simple, invisible, usually direct-on-target projectile.")]
 	public class InstantHitInfo : IProjectileInfo
 	{
-		[Desc("Maximum offset at the maximum range.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
+
+		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' and 'PerCellIncrement'.")]
+		public readonly InaccuracyType InaccuracyType = InaccuracyType.Maximum;
 
 		[Desc("Projectile can be blocked.")]
 		public readonly bool Blockable = false;
@@ -54,7 +56,13 @@ namespace OpenRA.Mods.Common.Projectiles
 			else if (info.Inaccuracy.Length > 0)
 			{
 				var inaccuracy = Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
-				var maxOffset = inaccuracy * (args.PassiveTarget - args.Source).Length / args.Weapon.Range.Length;
+
+				int maxOffset;
+				if (info.InaccuracyType == InaccuracyType.Maximum)
+					maxOffset = inaccuracy * (args.PassiveTarget - args.Source).Length / args.Weapon.Range.Length;
+				else
+					maxOffset = inaccuracy * (args.PassiveTarget - args.Source).Length / 1024;
+
 				target = Target.FromPos(args.PassiveTarget + WVec.FromPDF(args.SourceActor.World.SharedRandom, 2) * maxOffset / 1024);
 			}
 			else

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -132,23 +132,8 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			if (info.Inaccuracy.Length > 0)
 			{
-				var inaccuracy = Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
-
-				var maxOffset = 0;
-				switch (info.InaccuracyType)
-				{
-					case InaccuracyType.Maximum:
-						maxOffset = inaccuracy * (target - source).Length / args.Weapon.Range.Length;
-						break;
-					case InaccuracyType.PerCellIncrement:
-						maxOffset = inaccuracy * (target - source).Length / 1024;
-						break;
-					case InaccuracyType.Absolute:
-						maxOffset = inaccuracy;
-						break;
-				}
-
-				target += WVec.FromPDF(args.SourceActor.World.SharedRandom, 2) * maxOffset / 1024;
+				var maxInaccuracyOffset = Util.GetProjectileInaccuracy(info.Inaccuracy.Length, info.InaccuracyType, args);
+				target += WVec.FromPDF(args.SourceActor.World.SharedRandom, 2) * maxInaccuracyOffset / 1024;
 			}
 
 			if (!string.IsNullOrEmpty(info.HitAnim))

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -50,8 +50,10 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Beam follows the target.")]
 		public readonly bool TrackTarget = true;
 
-		[Desc("Maximum offset at the maximum range.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
+
+		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' and 'PerCellIncrement'.")]
+		public readonly InaccuracyType InaccuracyType = InaccuracyType.Maximum;
 
 		[Desc("Beam can be blocked.")]
 		public readonly bool Blockable = false;
@@ -130,8 +132,14 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			if (info.Inaccuracy.Length > 0)
 			{
-				var inaccuracy = OpenRA.Mods.Common.Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
-				var maxOffset = inaccuracy * (target - source).Length / args.Weapon.Range.Length;
+				var inaccuracy = Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
+
+				int maxOffset;
+				if (info.InaccuracyType == InaccuracyType.Maximum)
+					maxOffset = inaccuracy * (target - source).Length / args.Weapon.Range.Length;
+				else
+					maxOffset = inaccuracy * (target - source).Length / 1024;
+
 				target += WVec.FromPDF(args.SourceActor.World.SharedRandom, 2) * maxOffset / 1024;
 			}
 

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -50,6 +50,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Beam follows the target.")]
 		public readonly bool TrackTarget = true;
 
+		[Desc("The maximum/constant/incremental inaccuracy used in conjunction with the InaccuracyType property.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
 
 		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' - scale from 0 to max with range, 'PerCellIncrement' - scale from 0 with range and 'Absolute' - use set value regardless of range.")]

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		public readonly WDist Inaccuracy = WDist.Zero;
 
-		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' and 'PerCellIncrement'.")]
+		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' - scale from 0 to max with range, 'PerCellIncrement' - scale from 0 with range and 'Absolute' - use set value regardless of range.")]
 		public readonly InaccuracyType InaccuracyType = InaccuracyType.Maximum;
 
 		[Desc("Beam can be blocked.")]
@@ -134,11 +134,19 @@ namespace OpenRA.Mods.Common.Projectiles
 			{
 				var inaccuracy = Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
 
-				int maxOffset;
-				if (info.InaccuracyType == InaccuracyType.Maximum)
-					maxOffset = inaccuracy * (target - source).Length / args.Weapon.Range.Length;
-				else
-					maxOffset = inaccuracy * (target - source).Length / 1024;
+				var maxOffset = 0;
+				switch (info.InaccuracyType)
+				{
+					case InaccuracyType.Maximum:
+						maxOffset = inaccuracy * (target - source).Length / args.Weapon.Range.Length;
+						break;
+					case InaccuracyType.PerCellIncrement:
+						maxOffset = inaccuracy * (target - source).Length / 1024;
+						break;
+					case InaccuracyType.Absolute:
+						maxOffset = inaccuracy;
+						break;
+				}
 
 				target += WVec.FromPDF(args.SourceActor.World.SharedRandom, 2) * maxOffset / 1024;
 			}

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -238,23 +238,8 @@ namespace OpenRA.Mods.Common.Projectiles
 			var inaccuracy = lockOn && info.LockOnInaccuracy.Length > -1 ? info.LockOnInaccuracy.Length : info.Inaccuracy.Length;
 			if (inaccuracy > 0)
 			{
-				inaccuracy = Util.ApplyPercentageModifiers(inaccuracy, args.InaccuracyModifiers);
-
-				var maxOffset = 0;
-				switch (info.InaccuracyType)
-				{
-					case InaccuracyType.Maximum:
-						maxOffset = inaccuracy * (targetPosition - pos).Length / args.Weapon.Range.Length;
-						break;
-					case InaccuracyType.PerCellIncrement:
-						maxOffset = inaccuracy * (targetPosition - pos).Length / 1024;
-						break;
-					case InaccuracyType.Absolute:
-						maxOffset = inaccuracy;
-						break;
-				}
-
-				offset = WVec.FromPDF(world.SharedRandom, 2) * maxOffset / 1024;
+				var maxInaccuracyOffset = Util.GetProjectileInaccuracy(info.Inaccuracy.Length, info.InaccuracyType, args);
+				offset = WVec.FromPDF(world.SharedRandom, 2) * maxInaccuracyOffset / 1024;
 			}
 
 			DetermineLaunchSpeedAndAngle(world, out speed, out vFacing);

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -73,8 +73,8 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		public readonly WDist Inaccuracy = WDist.Zero;
 
-		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' and 'PerCellIncrement'.")]
-		public readonly InaccuracyType InaccuracyType = InaccuracyType.Maximum;
+		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' - scale from 0 to max with range, 'PerCellIncrement' - scale from 0 with range and 'Absolute' - use set value regardless of range.")]
+		public readonly InaccuracyType InaccuracyType = InaccuracyType.Absolute;
 
 		[Desc("Inaccuracy override when sucessfully locked onto target. Defaults to Inaccuracy if negative.")]
 		public readonly WDist LockOnInaccuracy = new WDist(-1);
@@ -240,9 +240,19 @@ namespace OpenRA.Mods.Common.Projectiles
 			{
 				inaccuracy = Util.ApplyPercentageModifiers(inaccuracy, args.InaccuracyModifiers);
 
-				var maxOffset = inaccuracy;
-				if (info.InaccuracyType == InaccuracyType.PerCellIncrement)
-					maxOffset = inaccuracy * (targetPosition - pos).Length / 1024;
+				var maxOffset = 0;
+				switch (info.InaccuracyType)
+				{
+					case InaccuracyType.Maximum:
+						maxOffset = inaccuracy * (targetPosition - pos).Length / args.Weapon.Range.Length;
+						break;
+					case InaccuracyType.PerCellIncrement:
+						maxOffset = inaccuracy * (targetPosition - pos).Length / 1024;
+						break;
+					case InaccuracyType.Absolute:
+						maxOffset = inaccuracy;
+						break;
+				}
 
 				offset = WVec.FromPDF(world.SharedRandom, 2) * maxOffset / 1024;
 			}

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -71,6 +71,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Width of projectile (used for finding blocking actors).")]
 		public readonly WDist Width = new WDist(1);
 
+		[Desc("The maximum/constant/incremental inaccuracy used in conjunction with the InaccuracyType property.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
 
 		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' - scale from 0 to max with range, 'PerCellIncrement' - scale from 0 with range and 'Absolute' - use set value regardless of range.")]

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -71,8 +71,10 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Width of projectile (used for finding blocking actors).")]
 		public readonly WDist Width = new WDist(1);
 
-		[Desc("Maximum inaccuracy offset at the maximum range")]
 		public readonly WDist Inaccuracy = WDist.Zero;
+
+		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' and 'PerCellIncrement'.")]
+		public readonly InaccuracyType InaccuracyType = InaccuracyType.Maximum;
 
 		[Desc("Inaccuracy override when sucessfully locked onto target. Defaults to Inaccuracy if negative.")]
 		public readonly WDist LockOnInaccuracy = new WDist(-1);
@@ -237,7 +239,12 @@ namespace OpenRA.Mods.Common.Projectiles
 			if (inaccuracy > 0)
 			{
 				inaccuracy = Util.ApplyPercentageModifiers(inaccuracy, args.InaccuracyModifiers);
-				offset = WVec.FromPDF(world.SharedRandom, 2) * inaccuracy / 1024;
+
+				var maxOffset = inaccuracy;
+				if (info.InaccuracyType == InaccuracyType.PerCellIncrement)
+					maxOffset = inaccuracy * (targetPosition - pos).Length / 1024;
+
+				offset = WVec.FromPDF(world.SharedRandom, 2) * maxOffset / 1024;
 			}
 
 			DetermineLaunchSpeedAndAngle(world, out speed, out vFacing);

--- a/OpenRA.Mods.Common/Projectiles/Railgun.cs
+++ b/OpenRA.Mods.Common/Projectiles/Railgun.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		public readonly WDist Inaccuracy = WDist.Zero;
 
-		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' and 'PerCellIncrement'.")]
+		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' - scale from 0 to max with range, 'PerCellIncrement' - scale from 0 with range and 'Absolute' - use set value regardless of range.")]
 		public readonly InaccuracyType InaccuracyType = InaccuracyType.Maximum;
 
 		[Desc("Can this projectile be blocked when hitting actors with an IBlocksProjectiles trait.")]
@@ -136,11 +136,19 @@ namespace OpenRA.Mods.Common.Projectiles
 			{
 				var inaccuracy = Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
 
-				int maxOffset;
-				if (info.InaccuracyType == InaccuracyType.Maximum)
-					maxOffset = inaccuracy * (target - source).Length / args.Weapon.Range.Length;
-				else
-					maxOffset = inaccuracy * (target - source).Length / 1024;
+				var maxOffset = 0;
+				switch (info.InaccuracyType)
+				{
+					case InaccuracyType.Maximum:
+						maxOffset = inaccuracy * (target - source).Length / args.Weapon.Range.Length;
+						break;
+					case InaccuracyType.PerCellIncrement:
+						maxOffset = inaccuracy * (target - source).Length / 1024;
+						break;
+					case InaccuracyType.Absolute:
+						maxOffset = inaccuracy;
+						break;
+				}
 
 				target += WVec.FromPDF(args.SourceActor.World.SharedRandom, 2) * maxOffset / 1024;
 			}

--- a/OpenRA.Mods.Common/Projectiles/Railgun.cs
+++ b/OpenRA.Mods.Common/Projectiles/Railgun.cs
@@ -25,6 +25,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Damage all units hit by the beam instead of just the target?")]
 		public readonly bool DamageActorsInLine = false;
 
+		[Desc("The maximum/constant/incremental inaccuracy used in conjunction with the InaccuracyType property.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
 
 		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' - scale from 0 to max with range, 'PerCellIncrement' - scale from 0 with range and 'Absolute' - use set value regardless of range.")]

--- a/OpenRA.Mods.Common/Projectiles/Railgun.cs
+++ b/OpenRA.Mods.Common/Projectiles/Railgun.cs
@@ -25,8 +25,10 @@ namespace OpenRA.Mods.Common.Projectiles
 		[Desc("Damage all units hit by the beam instead of just the target?")]
 		public readonly bool DamageActorsInLine = false;
 
-		[Desc("Maximum offset at the maximum range.")]
 		public readonly WDist Inaccuracy = WDist.Zero;
+
+		[Desc("Controls the way inaccuracy is calculated. Possible values are 'Maximum' and 'PerCellIncrement'.")]
+		public readonly InaccuracyType InaccuracyType = InaccuracyType.Maximum;
 
 		[Desc("Can this projectile be blocked when hitting actors with an IBlocksProjectiles trait.")]
 		public readonly bool Blockable = false;
@@ -129,6 +131,19 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			BeamColor = beamColor;
 			HelixColor = helixColor;
+
+			if (info.Inaccuracy.Length > 0)
+			{
+				var inaccuracy = Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
+
+				int maxOffset;
+				if (info.InaccuracyType == InaccuracyType.Maximum)
+					maxOffset = inaccuracy * (target - source).Length / args.Weapon.Range.Length;
+				else
+					maxOffset = inaccuracy * (target - source).Length / 1024;
+
+				target += WVec.FromPDF(args.SourceActor.World.SharedRandom, 2) * maxOffset / 1024;
+			}
 
 			if (!string.IsNullOrEmpty(info.HitAnim))
 				hitanim = new Animation(args.SourceActor.World, info.HitAnim);

--- a/OpenRA.Mods.Common/Projectiles/Railgun.cs
+++ b/OpenRA.Mods.Common/Projectiles/Railgun.cs
@@ -108,6 +108,8 @@ namespace OpenRA.Mods.Common.Projectiles
 
 		int ticks;
 		bool animationComplete;
+
+		[Sync]
 		WPos target;
 
 		// Computing these in Railgun instead of RailgunRenderable saves Info.Duration ticks of computation.

--- a/OpenRA.Mods.Common/Projectiles/Railgun.cs
+++ b/OpenRA.Mods.Common/Projectiles/Railgun.cs
@@ -134,23 +134,8 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			if (info.Inaccuracy.Length > 0)
 			{
-				var inaccuracy = Util.ApplyPercentageModifiers(info.Inaccuracy.Length, args.InaccuracyModifiers);
-
-				var maxOffset = 0;
-				switch (info.InaccuracyType)
-				{
-					case InaccuracyType.Maximum:
-						maxOffset = inaccuracy * (target - source).Length / args.Weapon.Range.Length;
-						break;
-					case InaccuracyType.PerCellIncrement:
-						maxOffset = inaccuracy * (target - source).Length / 1024;
-						break;
-					case InaccuracyType.Absolute:
-						maxOffset = inaccuracy;
-						break;
-				}
-
-				target += WVec.FromPDF(args.SourceActor.World.SharedRandom, 2) * maxOffset / 1024;
+				var maxInaccuracyOffset = Util.GetProjectileInaccuracy(info.Inaccuracy.Length, info.InaccuracyType, args);
+				target += WVec.FromPDF(args.SourceActor.World.SharedRandom, 2) * maxInaccuracyOffset / 1024;
 			}
 
 			if (!string.IsNullOrEmpty(info.HitAnim))

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -11,9 +11,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using OpenRA.GameRules;
-using OpenRA.Graphics;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Support;
@@ -21,6 +21,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common
 {
+	public enum InaccuracyType { Maximum, PerCellIncrement, Absolute }
+
 	public static class Util
 	{
 		public static int TickFacing(int facing, int desiredFacing, int rot)
@@ -227,6 +229,23 @@ namespace OpenRA.Mods.Common
 				return "Warhead";
 
 			return t.Name;
+		}
+
+		public static int GetProjectileInaccuracy(int baseInaccuracy, InaccuracyType inaccuracyType, ProjectileArgs args)
+		{
+			var inaccuracy = ApplyPercentageModifiers(baseInaccuracy, args.InaccuracyModifiers);
+			switch (inaccuracyType)
+			{
+				case InaccuracyType.Maximum:
+					var weaponMaxRange = ApplyPercentageModifiers(args.Weapon.Range.Length, args.RangeModifiers);
+					return inaccuracy * (args.PassiveTarget - args.Source).Length / weaponMaxRange;
+				case InaccuracyType.PerCellIncrement:
+					return inaccuracy * (args.PassiveTarget - args.Source).Length / 1024;
+				case InaccuracyType.Absolute:
+					return inaccuracy;
+				default:
+					throw new InvalidEnumArgumentException("inaccuracyType", (int)inaccuracyType, typeof(InaccuracyType));
+			}
 		}
 	}
 }

--- a/mods/d2k/weapons/largeguns.yaml
+++ b/mods/d2k/weapons/largeguns.yaml
@@ -4,7 +4,8 @@
 	Report: MEDTANK1.WAV
 	Projectile: Bullet
 		Speed: 562
-		Inaccuracy: 380
+		Inaccuracy: 128
+		InaccuracyType: PerCellIncrement
 		Image: 120mm
 	Warhead@1Dam: SpreadDamage
 		Damage: 2700
@@ -60,7 +61,6 @@ DevBullet:
 	Report: TANKHVY1.WAV
 	Projectile: Bullet
 		Speed: 281
-		Inaccuracy: 0
 		Image: doubleblastbullet
 	Warhead@1Dam: SpreadDamage
 		Damage: 6500
@@ -89,7 +89,6 @@ DevBullet:
 		Blockable: false
 		Shadow: true
 		LaunchAngle: 62
-		Inaccuracy: 768
 		ContrailLength: 20
 		Image: 155mm
 	Warhead@1Dam: SpreadDamage

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -5,7 +5,8 @@
 	Projectile: Bullet
 		Blockable: false
 		Speed: 281
-		Inaccuracy: 256
+		Inaccuracy: 128
+		InaccuracyType: PerCellIncrement
 		Image: RPG
 		TrailImage: bazooka_trail2
 		TrailPalette: effect75alpha
@@ -45,7 +46,6 @@
 		Shadow: true
 		HorizontalRateOfTurn: 3
 		RangeLimit: 6c614
-		Inaccuracy: 384
 		CruiseAltitude: 1c0
 		MinimumLaunchAngle: 64
 		VerticalRateOfTurn: 10
@@ -117,7 +117,6 @@ mtank_pri:
 	Range: 6c0
 	ValidTargets: Ground, Air
 	Projectile: Missile
-		Inaccuracy: 96
 		RangeLimit: 7c204
 	Warhead@1Dam: SpreadDamage
 		Damage: 6000
@@ -132,6 +131,7 @@ DeviatorMissile:
 	Report: MISSLE1.WAV
 	Projectile: Missile
 		RangeLimit: 6c0
+		Inaccuracy: 96
 		Image: MISSILE
 		TrailImage: deviator_trail
 		TrailPalette: deviatorgas

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -4,6 +4,8 @@ Sound:
 	Report: SONIC1.WAV
 	Projectile: AreaBeam
 		Speed: 0c128
+		Inaccuracy: 128
+		InaccuracyType: PerCellIncrement
 		Duration: 4 # Has a length of 0c512
 		DamageInterval: 3 # Travels 0c384 between impacts, will hit a target roughly three times
 		Width: 0c512
@@ -216,7 +218,8 @@ grenade:
 		Speed: 160
 		Blockable: false
 		LaunchAngle: 128
-		Inaccuracy: 416
+		Inaccuracy: 128
+		InaccuracyType: PerCellIncrement
 		Image: grenade
 		Shadow: true
 	Warhead@1Dam: SpreadDamage

--- a/mods/d2k/weapons/smallguns.yaml
+++ b/mods/d2k/weapons/smallguns.yaml
@@ -3,6 +3,8 @@
 	Range: 2c512
 	Report: MGUN2.WAV
 	Projectile: InstantHit
+		Inaccuracy: 128
+		InaccuracyType: PerCellIncrement
 	Warhead@1Dam: SpreadDamage
 		Damage: 1250
 		Spread: 480


### PR DESCRIPTION
This implements the first point of the TODO list in #17972 - it adds distinct inaccuracy calculation types to projectiles and switches weapons in the D2k mod to the new calculation type (while also adjusting the inaccuracy values to account for it).

P.S.: I didn't know where to put the InaccuracyType  enum so I just plopped it anywhere.