### PR TITLE
D2k weapon damage spread and falloff

### DIFF
--- a/mods/d2k/weapons/debris.yaml
+++ b/mods/d2k/weapons/debris.yaml
@@ -12,7 +12,7 @@ Debris:
 		BounceRangeModifier: 20
 	Warhead@1Dam: SpreadDamage
 		Damage: 1500
-		Spread: 320
+		Spread: 512
 		Falloff: 100, 0
 		Versus:
 			none: 20
@@ -44,6 +44,7 @@ Debris2:
 		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
 		Damage: 2500
+		Spread: 1c0
 		Versus:
 			none: 90
 			wall: 5

--- a/mods/d2k/weapons/debris.yaml
+++ b/mods/d2k/weapons/debris.yaml
@@ -11,9 +11,9 @@ Debris:
 		BounceCount: 3
 		BounceRangeModifier: 20
 	Warhead@1Dam: SpreadDamage
-		Spread: 320
-		Falloff: 100, 60, 30, 15, 0
 		Damage: 1500
+		Spread: 320
+		Falloff: 100, 0
 		Versus:
 			none: 20
 			wall: 50

--- a/mods/d2k/weapons/largeguns.yaml
+++ b/mods/d2k/weapons/largeguns.yaml
@@ -7,9 +7,9 @@
 		Inaccuracy: 380
 		Image: 120mm
 	Warhead@1Dam: SpreadDamage
-		Spread: 256
-		Falloff: 100, 50, 25, 0
 		Damage: 2700
+		Spread: 256
+		Falloff: 100, 0
 		Versus:
 			none: 20
 			wall: 50
@@ -93,9 +93,8 @@ DevBullet:
 		ContrailLength: 20
 		Image: 155mm
 	Warhead@1Dam: SpreadDamage
-		Spread: 416
-		Falloff: 100, 65, 35, 20, 0
 		Damage: 4500
+		Spread: 416
 		Versus:
 			none: 125
 			wall: 100

--- a/mods/d2k/weapons/largeguns.yaml
+++ b/mods/d2k/weapons/largeguns.yaml
@@ -8,7 +8,7 @@
 		Image: 120mm
 	Warhead@1Dam: SpreadDamage
 		Damage: 2700
-		Spread: 256
+		Spread: 512
 		Falloff: 100, 0
 		Versus:
 			none: 20
@@ -62,7 +62,6 @@ DevBullet:
 		Inaccuracy: 0
 		Image: doubleblastbullet
 	Warhead@1Dam: SpreadDamage
-		Spread: 384
 		Damage: 6500
 		Versus:
 			none: 50
@@ -94,7 +93,7 @@ DevBullet:
 		Image: 155mm
 	Warhead@1Dam: SpreadDamage
 		Damage: 4500
-		Spread: 416
+		Spread: 1c0
 		Versus:
 			none: 125
 			wall: 100

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -11,9 +11,9 @@
 		TrailPalette: effect75alpha
 		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
-		Spread: 192
-		Falloff: 100, 50, 25, 0
 		Damage: 3000
+		Spread: 192
+		Falloff: 100, 0
 		Versus:
 			none: 8
 			wall: 75

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -12,7 +12,7 @@
 		TrailInterval: 1
 	Warhead@1Dam: SpreadDamage
 		Damage: 3000
-		Spread: 192
+		Spread: 512
 		Falloff: 100, 0
 		Versus:
 			none: 8
@@ -52,7 +52,6 @@
 		TrailImage: large_trail
 		Speed: 288
 	Warhead@1Dam: SpreadDamage
-		Spread: 256
 		Damage: 4800
 		Versus:
 			none: 15
@@ -80,7 +79,6 @@ Rocket:
 	Projectile: Bullet
 		Speed: 352
 	Warhead@1Dam: SpreadDamage
-		Spread: 160
 		Damage: 2500
 		Versus:
 			none: 25
@@ -139,6 +137,7 @@ DeviatorMissile:
 		TrailUsePlayerPalette: true
 	Warhead@1Dam: SpreadDamage
 		Damage: 1000
+		Spread: 480
 		Versus:
 			none: 100
 			wall: 100

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -67,9 +67,9 @@ OrniBomb:
 		Acceleration: 0, 0, 0
 		Shadow: true
 	Warhead@1Dam: SpreadDamage
-		Spread: 320
-		Falloff: 100, 0
 		Damage: 7500 #400 in original, reduce when bombers can do multiple passes
+		Spread: 1c0
+		Falloff: 100, 0
 		Versus:
 			none: 90
 			wall: 50
@@ -155,9 +155,9 @@ DeathHandCluster:
 
 CrateExplosion:
 	Warhead@1Dam: SpreadDamage
-		Spread: 320
-		Falloff: 100, 0
 		Damage: 5000
+		Spread: 1c0
+		Falloff: 100, 0
 		Versus:
 			none: 90
 			wall: 5
@@ -217,9 +217,9 @@ grenade:
 		Image: grenade
 		Shadow: true
 	Warhead@1Dam: SpreadDamage
-		Spread: 320
-		Falloff: 100, 0
 		Damage: 1500
+		Spread: 1c0
+		Falloff: 100, 0
 		Versus:
 			none: 125
 			wood: 70
@@ -241,9 +241,9 @@ grenade:
 
 GrenDeath:
 	Warhead@1Dam: SpreadDamage
-		Spread: 320
-		Falloff: 100, 0
 		Damage: 1500
+		Spread: 1c0
+		Falloff: 100, 0
 		Versus:
 			none: 125
 			wood: 70
@@ -264,9 +264,9 @@ GrenDeath:
 
 SardDeath:
 	Warhead@1Dam: SpreadDamage
-		Spread: 256
-		Falloff: 100, 0
 		Damage: 3000
+		Spread: 512
+		Falloff: 100, 0
 		Versus:
 			none: 15
 			wall: 75
@@ -294,9 +294,9 @@ SpiceExplosion:
 		TrailImage: large_trail
 		Image: 120mm
 	Warhead@1Dam: SpreadDamage
-		Spread: 320
-		Falloff: 100, 0
 		Damage: 750
+		Spread: 1c0
+		Falloff: 100, 0
 		Versus:
 			none: 90
 			wall: 5
@@ -321,9 +321,9 @@ BloomExplosion:
 	Range: 0c8
 	Projectile: InstantHit
 	Warhead@1Dam: SpreadDamage
+		Damage: 7500
 		Spread: 320
 		Falloff: 100, 0
-		Damage: 7500
 		Versus:
 			none: 90
 			wall: 5
@@ -339,9 +339,9 @@ BloomExplosion:
 
 PlasmaExplosion:
 	Warhead@1Dam: SpreadDamage
-		Spread: 2c0
-		Falloff: 100, 0
 		Damage: 20000
+		Spread: 3c0
+		Falloff: 100, 0
 		Versus:
 			None: 100
 			Wood: 100

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -68,7 +68,7 @@ OrniBomb:
 		Shadow: true
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
-		Falloff: 100, 60, 30, 15, 0
+		Falloff: 100, 0
 		Damage: 7500 #400 in original, reduce when bombers can do multiple passes
 		Versus:
 			none: 90
@@ -156,7 +156,7 @@ DeathHandCluster:
 CrateExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
-		Falloff: 100, 60, 30, 15, 0
+		Falloff: 100, 0
 		Damage: 5000
 		Versus:
 			none: 90
@@ -218,7 +218,7 @@ grenade:
 		Shadow: true
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
-		Falloff: 100, 65, 35, 20, 0
+		Falloff: 100, 0
 		Damage: 1500
 		Versus:
 			none: 125
@@ -242,7 +242,7 @@ grenade:
 GrenDeath:
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
-		Falloff: 100, 60, 30, 15, 0
+		Falloff: 100, 0
 		Damage: 1500
 		Versus:
 			none: 125
@@ -265,7 +265,7 @@ GrenDeath:
 SardDeath:
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
-		Falloff: 100, 50, 25, 0
+		Falloff: 100, 0
 		Damage: 3000
 		Versus:
 			none: 15
@@ -295,7 +295,7 @@ SpiceExplosion:
 		Image: 120mm
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
-		Falloff: 100, 60, 30, 15, 0
+		Falloff: 100, 0
 		Damage: 750
 		Versus:
 			none: 90
@@ -322,7 +322,7 @@ BloomExplosion:
 	Projectile: InstantHit
 	Warhead@1Dam: SpreadDamage
 		Spread: 320
-		Falloff: 100, 60, 30, 15, 0
+		Falloff: 100, 0
 		Damage: 7500
 		Versus:
 			none: 90
@@ -340,7 +340,7 @@ BloomExplosion:
 PlasmaExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 2c0
-		Falloff: 100, 37, 0
+		Falloff: 100, 0
 		Damage: 20000
 		Versus:
 			None: 100

--- a/mods/d2k/weapons/smallguns.yaml
+++ b/mods/d2k/weapons/smallguns.yaml
@@ -4,9 +4,9 @@
 	Report: MGUN2.WAV
 	Projectile: InstantHit
 	Warhead@1Dam: SpreadDamage
-		Spread: 128
-		Falloff: 100, 50, 25, 0
 		Damage: 1250
+		Spread: 128
+		Falloff: 100, 0
 		Versus:
 			wall: 10
 			building: 25
@@ -81,7 +81,6 @@ HMG:
 	Report: 20MMGUN1.WAV
 	Warhead@1Dam: SpreadDamage
 		Spread: 160
-		Falloff: 100, 60, 30, 0
 		Damage: 1800
 	Warhead@2Concrete: DamagesConcrete
 		Damage: 1800

--- a/mods/d2k/weapons/smallguns.yaml
+++ b/mods/d2k/weapons/smallguns.yaml
@@ -5,7 +5,7 @@
 	Projectile: InstantHit
 	Warhead@1Dam: SpreadDamage
 		Damage: 1250
-		Spread: 128
+		Spread: 480
 		Falloff: 100, 0
 		Versus:
 			wall: 10
@@ -47,8 +47,8 @@ M_HMG:
 	Range: 3c512
 	Report: 20MMGUN1.WAV
 	Warhead@1Dam: SpreadDamage
-		Spread: 192
 		Damage: 2500
+		Spread: 512
 		Versus:
 			none: 25
 			wall: 100
@@ -80,7 +80,6 @@ HMG:
 	Range: 3c0
 	Report: 20MMGUN1.WAV
 	Warhead@1Dam: SpreadDamage
-		Spread: 160
 		Damage: 1800
 	Warhead@2Concrete: DamagesConcrete
 		Damage: 1800


### PR DESCRIPTION
This implements the second and third points of the TODO list in #17972 - it adjusts weapon splash area and falloff to match the original game (with the notable exception of the Sonic tank weapon and the `BloomExplosion` weapon).