### PR TITLE
Make all warheads use WarheadArgs

### DIFF
--- a/OpenRA.Game/GameRules/WeaponInfo.cs
+++ b/OpenRA.Game/GameRules/WeaponInfo.cs
@@ -50,6 +50,16 @@ namespace OpenRA.GameRules
 			WeaponTarget = args.GuidedTarget;
 		}
 
+		// For places that only want to update some of the fields (usually DamageModifiers)
+		public WarheadArgs(WarheadArgs args)
+		{
+			Weapon = args.Weapon;
+			DamageModifiers = args.DamageModifiers;
+			Source = args.Source;
+			SourceActor = args.SourceActor;
+			WeaponTarget = args.WeaponTarget;
+		}
+
 		// Default empty constructor for callers that want to initialize fields themselves
 		public WarheadArgs() { }
 	}

--- a/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Warheads
 			return base.IsValidAgainst(victim, firedBy);
 		}
 
-		public int DamageVersus(Actor victim, HitShapeInfo shapeInfo)
+		public virtual int DamageVersus(Actor victim, HitShape shape, WarheadArgs args)
 		{
 			// If no Versus values are defined, DamageVersus would return 100 anyway, so we might as well do that early.
 			if (Versus.Count == 0)
@@ -46,15 +46,15 @@ namespace OpenRA.Mods.Common.Warheads
 
 			var armor = victim.TraitsImplementing<Armor>()
 				.Where(a => !a.IsTraitDisabled && a.Info.Type != null && Versus.ContainsKey(a.Info.Type) &&
-					(shapeInfo.ArmorTypes == default(BitSet<ArmorType>) || shapeInfo.ArmorTypes.Contains(a.Info.Type)))
+					(shape.Info.ArmorTypes == default(BitSet<ArmorType>) || shape.Info.ArmorTypes.Contains(a.Info.Type)))
 				.Select(a => Versus[a.Info.Type]);
 
 			return Util.ApplyPercentageModifiers(100, armor);
 		}
 
-		protected virtual void InflictDamage(Actor victim, Actor firedBy, HitShapeInfo hitshapeInfo, IEnumerable<int> damageModifiers)
+		protected virtual void InflictDamage(Actor victim, Actor firedBy, HitShape shape, WarheadArgs args)
 		{
-			var damage = Util.ApplyPercentageModifiers(Damage, damageModifiers.Append(DamageVersus(victim, hitshapeInfo)));
+			var damage = Util.ApplyPercentageModifiers(Damage, args.DamageModifiers.Append(DamageVersus(victim, shape, args)));
 			victim.InflictDamage(firedBy, new Damage(damage, DamageTypes));
 		}
 
@@ -77,12 +77,12 @@ namespace OpenRA.Mods.Common.Warheads
 				if (closestActiveShape == null)
 					return;
 
-				InflictDamage(victim, firedBy, closestActiveShape.Info, args.DamageModifiers);
+				InflictDamage(victim, firedBy, closestActiveShape, args);
 			}
 			else if (target.Type != TargetType.Invalid)
-				DoImpact(target.CenterPosition, firedBy, args.DamageModifiers);
+				DoImpact(target.CenterPosition, firedBy, args);
 		}
 
-		public abstract void DoImpact(WPos pos, Actor firedBy, IEnumerable<int> damageModifiers);
+		public abstract void DoImpact(WPos pos, Actor firedBy, WarheadArgs args);
 	}
 }

--- a/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
@@ -10,6 +10,7 @@
 #endregion
 
 using System.Collections.Generic;
+using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
@@ -17,10 +18,10 @@ namespace OpenRA.Mods.Common.Warheads
 {
 	public class HealthPercentageDamageWarhead : TargetDamageWarhead
 	{
-		protected override void InflictDamage(Actor victim, Actor firedBy, HitShapeInfo hitshapeInfo, IEnumerable<int> damageModifiers)
+		protected override void InflictDamage(Actor victim, Actor firedBy, HitShape shape, WarheadArgs args)
 		{
 			var healthInfo = victim.Info.TraitInfo<HealthInfo>();
-			var damage = Util.ApplyPercentageModifiers(healthInfo.HP, damageModifiers.Append(Damage, DamageVersus(victim, hitshapeInfo)));
+			var damage = Util.ApplyPercentageModifiers(healthInfo.HP, args.DamageModifiers.Append(Damage, DamageVersus(victim, shape, args)));
 			victim.InflictDamage(firedBy, new Damage(damage, DamageTypes));
 		}
 	}

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Warheads
 				Range = Exts.MakeArray(Falloff.Length, i => i * Spread);
 		}
 
-		public override void DoImpact(WPos pos, Actor firedBy, IEnumerable<int> damageModifiers)
+		public override void DoImpact(WPos pos, Actor firedBy, WarheadArgs args)
 		{
 			var debugVis = firedBy.World.WorldActor.TraitOrDefault<DebugVisualizations>();
 			if (debugVis != null && debugVis.CombatGeometry)
@@ -64,8 +64,13 @@ namespace OpenRA.Mods.Common.Warheads
 				if (closestActiveShape.First == null)
 					continue;
 
-				var localModifiers = damageModifiers.Append(GetDamageFalloff(closestActiveShape.Second.Length));
-				InflictDamage(victim, firedBy, closestActiveShape.First.Info, localModifiers);
+				var localModifiers = args.DamageModifiers.Append(GetDamageFalloff(closestActiveShape.Second.Length));
+				var updatedWarheadArgs = new WarheadArgs(args)
+				{
+					DamageModifiers = localModifiers.ToArray(),
+				};
+
+				InflictDamage(victim, firedBy, closestActiveShape.First, updatedWarheadArgs);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Warheads/TargetDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/TargetDamageWarhead.cs
@@ -11,6 +11,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -22,7 +23,7 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("Damage will be applied to actors in this area. A value of zero means only targeted actor will be damaged.")]
 		public readonly WDist Spread = WDist.Zero;
 
-		public override void DoImpact(WPos pos, Actor firedBy, IEnumerable<int> damageModifiers)
+		public override void DoImpact(WPos pos, Actor firedBy, WarheadArgs args)
 		{
 			if (Spread == WDist.Zero)
 				return;
@@ -45,7 +46,7 @@ namespace OpenRA.Mods.Common.Warheads
 				if (closestActiveShape.First == null || closestActiveShape.Second > Spread)
 					continue;
 
-				InflictDamage(victim, firedBy, closestActiveShape.First.Info, damageModifiers);
+				InflictDamage(victim, firedBy, closestActiveShape.First, args);
 			}
 		}
 	}


### PR DESCRIPTION
Instead of passing `damageModifiers` directly.

Also pass `HitShape` instead of just `HitShapeInfo` for more flexibility (especially downstream), and also pass `WarheadArgs` to `DamageVersus` and make it virtual (both measures with downstream in mind).

Partially taken from #17971.