### PR TITLE
Added an out of bounds check to GrantConditionOnTerrain

### DIFF
--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnTerrain.cs
@@ -50,13 +50,16 @@ namespace OpenRA.Mods.Common.Traits
 
 		void ITick.Tick(Actor self)
 		{
-			var loc = self.Location;
+			var cell = self.Location;
+			if (!self.World.Map.Contains(cell))
+				return;
+
 			if (conditionManager == null)
 				return;
 
 			// The terrain type may change between ticks without the actor moving
-			var currentTerrain = loc.Layer == 0 ? self.World.Map.GetTerrainInfo(loc).Type :
-					tileSet[self.World.GetCustomMovementLayers()[loc.Layer].GetTerrainIndex(loc)].Type;
+			var currentTerrain = cell.Layer == 0 ? self.World.Map.GetTerrainInfo(cell).Type :
+					tileSet[self.World.GetCustomMovementLayers()[cell.Layer].GetTerrainIndex(cell)].Type;
 
 			var wantsGranted = info.TerrainTypes.Contains(currentTerrain);
 			if (currentTerrain != cachedTerrain)


### PR DESCRIPTION
Fixes a crash reported by @OmegaBolt on Discord.

> Exception of type `System.IndexOutOfRangeException`: Index was outside the bounds of the array.
   at OpenRA.Map.GetTerrainIndex(CPos cell)
   at OpenRA.Map.GetTerrainInfo(CPos cell)
   at OpenRA.Mods.Common.Traits.GrantConditionOnTerrain.OpenRA.Traits.ITick.Tick(Actor self)
   at OpenRA.WorldUtils.DoTimed[T](IEnumerable`1 e, Action`1 a, String text)
   at OpenRA.World.Tick()
   at OpenRA.Game.InnerLogicTick(OrderManager orderManager)
   at OpenRA.Game.LogicTick()
   at OpenRA.Game.Loop()
   at OpenRA.Game.Run()
   at OpenRA.Game.InitializeAndRun(String[] args)
   at OpenRA.Program.Main(String[] args)