### PR TITLE
Fixed PNG frame count calculation

### DIFF
--- a/OpenRA.Mods.Common/SpriteLoaders/PngSheetLoader.cs
+++ b/OpenRA.Mods.Common/SpriteLoaders/PngSheetLoader.cs
@@ -122,7 +122,7 @@ namespace OpenRA.Mods.Common.SpriteLoaders
 				if (png.EmbeddedData.ContainsKey("FrameAmount"))
 					frameAmount = FieldLoader.GetValue<int>("FrameAmount", png.EmbeddedData["FrameAmount"]);
 				else
-					frameAmount = png.Width / frameSize.Width * png.Height / frameSize.Height;
+					frameAmount = (png.Width / frameSize.Width) * (png.Height / frameSize.Height);
 			}
 			else if (png.EmbeddedData.ContainsKey("FrameAmount"))
 			{


### PR DESCRIPTION
This fixes the order of operations and rounding issue, making it columns * rows.