### PR TITLE
Fixed the component tower locking up when fired upon during the make animation.

### DIFF
--- a/mods/ts/rules/gdi-support.yaml
+++ b/mods/ts/rules/gdi-support.yaml
@@ -45,8 +45,13 @@ GACTWR:
 	Inherits: ^Defense
 	Inherits@IDISABLE: ^DisableOnPowerDown
 	Inherits@AUTOTARGET: ^AutoTargetAll
-	-WithSpriteBody:
+	WithMakeAnimation:
+		BodyNames: make
+	WithSpriteBody:
+		Name: make
+		Sequence: invisible
 	WithWallSpriteBody:
+		RequiresCondition: !build-incomplete
 		Type: wall
 	Valued:
 		Cost: 200

--- a/mods/ts/sequences/structures.yaml
+++ b/mods/ts/sequences/structures.yaml
@@ -1192,6 +1192,8 @@ gactwr:
 		Start: 2
 		ShadowStart: 5
 		Tick: 400
+	invisible: null
+		UseTilesetCode: false
 	idle-lights: gtctwr_a
 		Length: 6
 		Tick: 200


### PR DESCRIPTION
Closes https://github.com/OpenRA/OpenRA/issues/11349.