### PR TITLE
D2k damage calculations

### DIFF
--- a/OpenRA.Mods.Common/Warheads/ChangeOwnerWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/ChangeOwnerWarhead.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateEffectWarhead.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Effects;

--- a/OpenRA.Mods.Common/Warheads/CreateResourceWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/CreateResourceWarhead.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;

--- a/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DamageWarhead.cs
@@ -38,26 +38,6 @@ namespace OpenRA.Mods.Common.Warheads
 			return base.IsValidAgainst(victim, firedBy);
 		}
 
-		public virtual int DamageVersus(Actor victim, HitShape shape, WarheadArgs args)
-		{
-			// If no Versus values are defined, DamageVersus would return 100 anyway, so we might as well do that early.
-			if (Versus.Count == 0)
-				return 100;
-
-			var armor = victim.TraitsImplementing<Armor>()
-				.Where(a => !a.IsTraitDisabled && a.Info.Type != null && Versus.ContainsKey(a.Info.Type) &&
-					(shape.Info.ArmorTypes.IsEmpty || shape.Info.ArmorTypes.Contains(a.Info.Type)))
-				.Select(a => Versus[a.Info.Type]);
-
-			return Util.ApplyPercentageModifiers(100, armor);
-		}
-
-		protected virtual void InflictDamage(Actor victim, Actor firedBy, HitShape shape, WarheadArgs args)
-		{
-			var damage = Util.ApplyPercentageModifiers(Damage, args.DamageModifiers.Append(DamageVersus(victim, shape, args)));
-			victim.InflictDamage(firedBy, new Damage(damage, DamageTypes));
-		}
-
 		public override void DoImpact(Target target, WarheadArgs args)
 		{
 			var firedBy = args.SourceActor;
@@ -83,6 +63,26 @@ namespace OpenRA.Mods.Common.Warheads
 				DoImpact(target.CenterPosition, firedBy, args);
 		}
 
-		public abstract void DoImpact(WPos pos, Actor firedBy, WarheadArgs args);
+		protected virtual int DamageVersus(Actor victim, HitShape shape, WarheadArgs args)
+		{
+			// If no Versus values are defined, DamageVersus would return 100 anyway, so we might as well do that early.
+			if (Versus.Count == 0)
+				return 100;
+
+			var armor = victim.TraitsImplementing<Armor>()
+				.Where(a => !a.IsTraitDisabled && a.Info.Type != null && Versus.ContainsKey(a.Info.Type) &&
+					(shape.Info.ArmorTypes.IsEmpty || shape.Info.ArmorTypes.Contains(a.Info.Type)))
+				.Select(a => Versus[a.Info.Type]);
+
+			return Util.ApplyPercentageModifiers(100, armor);
+		}
+
+		protected virtual void InflictDamage(Actor victim, Actor firedBy, HitShape shape, WarheadArgs args)
+		{
+			var damage = Util.ApplyPercentageModifiers(Damage, args.DamageModifiers.Append(DamageVersus(victim, shape, args)));
+			victim.InflictDamage(firedBy, new Damage(damage, DamageTypes));
+		}
+
+		protected abstract void DoImpact(WPos pos, Actor firedBy, WarheadArgs args);
 	}
 }

--- a/OpenRA.Mods.Common/Warheads/DestroyResourceWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/DestroyResourceWarhead.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/FireClusterWarhead.cs
@@ -12,7 +12,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.GameRules;
-using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Warheads

--- a/OpenRA.Mods.Common/Warheads/GrantExternalConditionWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/GrantExternalConditionWarhead.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;

--- a/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/HealthPercentageDamageWarhead.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
 using OpenRA.Traits;

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
@@ -44,7 +43,7 @@ namespace OpenRA.Mods.Common.Warheads
 				Range = Exts.MakeArray(Falloff.Length, i => i * Spread);
 		}
 
-		public override void DoImpact(WPos pos, Actor firedBy, WarheadArgs args)
+		protected override void DoImpact(WPos pos, Actor firedBy, WarheadArgs args)
 		{
 			var debugVis = firedBy.World.WorldActor.TraitOrDefault<DebugVisualizations>();
 			if (debugVis != null && debugVis.CombatGeometry)

--- a/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/SpreadDamageWarhead.cs
@@ -59,8 +59,12 @@ namespace OpenRA.Mods.Common.Warheads
 					.Select(s => Pair.New(s, s.DistanceFromEdge(victim, pos)))
 					.MinByOrDefault(s => s.Second);
 
-				// Cannot be damaged without an active HitShape
+				// Cannot be damaged without an active HitShape.
 				if (closestActiveShape.First == null)
+					continue;
+
+				// Cannot be damaged if HitShape is outside Range.
+				if (closestActiveShape.Second > Range[Range.Length - 1])
 					continue;
 
 				var localModifiers = args.DamageModifiers.Append(GetDamageFalloff(closestActiveShape.Second.Length));

--- a/OpenRA.Mods.Common/Warheads/TargetDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/TargetDamageWarhead.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using System.Linq;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Traits;
@@ -23,7 +22,7 @@ namespace OpenRA.Mods.Common.Warheads
 		[Desc("Damage will be applied to actors in this area. A value of zero means only targeted actor will be damaged.")]
 		public readonly WDist Spread = WDist.Zero;
 
-		public override void DoImpact(WPos pos, Actor firedBy, WarheadArgs args)
+		protected override void DoImpact(WPos pos, Actor firedBy, WarheadArgs args)
 		{
 			if (Spread == WDist.Zero)
 				return;

--- a/OpenRA.Mods.Common/Warheads/TargetDamageWarhead.cs
+++ b/OpenRA.Mods.Common/Warheads/TargetDamageWarhead.cs
@@ -41,8 +41,12 @@ namespace OpenRA.Mods.Common.Warheads
 					.Select(s => Pair.New(s, s.DistanceFromEdge(victim, pos)))
 					.MinByOrDefault(s => s.Second);
 
-				// Cannot be damaged without an active HitShape or if HitShape is outside Spread
-				if (closestActiveShape.First == null || closestActiveShape.Second > Spread)
+				// Cannot be damaged without an active HitShape.
+				if (closestActiveShape.First == null)
+					continue;
+
+				// Cannot be damaged if HitShape is outside Spread.
+				if (closestActiveShape.Second > Spread)
 					continue;
 
 				InflictDamage(victim, firedBy, closestActiveShape.First, args);

--- a/OpenRA.Mods.Common/Warheads/Warhead.cs
+++ b/OpenRA.Mods.Common/Warheads/Warhead.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using OpenRA.GameRules;
 using OpenRA.Primitives;
 using OpenRA.Traits;

--- a/OpenRA.Mods.D2k/Warheads/DamagesConcreteWarhead.cs
+++ b/OpenRA.Mods.D2k/Warheads/DamagesConcreteWarhead.cs
@@ -9,7 +9,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
 using OpenRA.GameRules;
 using OpenRA.Mods.Common.Warheads;
 using OpenRA.Mods.D2k.Traits;

--- a/mods/d2k/rules/arrakis.yaml
+++ b/mods/d2k/rules/arrakis.yaml
@@ -63,7 +63,7 @@ spicebloom:
 		Actor: spicebloom.spawnpoint
 	HitShape:
 		Type: Circle
-			Radius: 512
+			Radius: 16
 	MapEditorData:
 		Categories: System
 	Interactable:
@@ -79,7 +79,7 @@ sandworm:
 		HP: 100000
 	HitShape:
 		Type: Circle
-			Radius: 256
+			Radius: 16
 	Armor:
 		Type: heavy
 	Mobile:

--- a/mods/d2k/rules/defaults.yaml
+++ b/mods/d2k/rules/defaults.yaml
@@ -231,6 +231,8 @@
 		Duration: 100
 		Radius: 2c512
 	HitShape:
+		Type: Circle
+			Radius: 16
 	MapEditorData:
 		Categories: Vehicle
 
@@ -254,6 +256,8 @@
 	ScriptTriggers:
 	WithFacingSpriteBody:
 	HitShape:
+		Type: Circle
+			Radius: 16
 	MapEditorData:
 		Categories: Husk
 
@@ -348,7 +352,7 @@
 		Duration: 100
 	HitShape:
 		Type: Circle
-			Radius: 96
+			Radius: 16
 	MapEditorData:
 		Categories: Infantry
 	AttackFrontal:
@@ -372,6 +376,8 @@
 	WithFacingSpriteBody:
 	WithShadow:
 	HitShape:
+		Type: Circle
+			Radius: 16
 	MapEditorData:
 		Categories: Aircraft
 

--- a/mods/d2k/weapons/debris.yaml
+++ b/mods/d2k/weapons/debris.yaml
@@ -26,6 +26,7 @@ Debris:
 			cy: 20
 			harvester: 50
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
+		DamageCalculationType: ClosestTargetablePosition
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater
 		InvalidTargets: Vehicle, Structure

--- a/mods/d2k/weapons/largeguns.yaml
+++ b/mods/d2k/weapons/largeguns.yaml
@@ -20,6 +20,7 @@
 			cy: 20
 			harvester: 50
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
+		DamageCalculationType: ClosestTargetablePosition
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 		InvalidTargets: Vehicle, Structure

--- a/mods/d2k/weapons/missiles.yaml
+++ b/mods/d2k/weapons/missiles.yaml
@@ -25,6 +25,7 @@
 			cy: 20
 			harvester: 50
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
+		DamageCalculationType: ClosestTargetablePosition
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 		InvalidTargets: Vehicle, Structure

--- a/mods/d2k/weapons/other.yaml
+++ b/mods/d2k/weapons/other.yaml
@@ -81,6 +81,7 @@ OrniBomb:
 			cy: 25
 			harvester: 60
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
+		DamageCalculationType: ClosestTargetablePosition
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 		InvalidTargets: Vehicle, Structure
@@ -144,6 +145,7 @@ DeathHandCluster:
 			cy: 25
 			harvester: 60
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+		DamageCalculationType: ClosestTargetablePosition
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 		InvalidTargets: Vehicle, Structure
@@ -170,6 +172,7 @@ CrateExplosion:
 			harvester: 25
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
+		DamageCalculationType: ClosestTargetablePosition
 	Warhead@2Eff: CreateEffect
 		Explosions: large_explosion
 		ImpactSounds: EXPLSML4.WAV
@@ -229,6 +232,7 @@ grenade:
 			cy: 20
 			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+		DamageCalculationType: ClosestTargetablePosition
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater
 		InvalidTargets: Vehicle, Structure
@@ -253,6 +257,7 @@ GrenDeath:
 			cy: 20
 			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+		DamageCalculationType: ClosestTargetablePosition
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -277,6 +282,7 @@ SardDeath:
 			cy: 30
 			harvester: 50
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+		DamageCalculationType: ClosestTargetablePosition
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater, RockCrater
 	Warhead@3Eff: CreateEffect
@@ -308,6 +314,7 @@ SpiceExplosion:
 			cy: 20
 			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+		DamageCalculationType: ClosestTargetablePosition
 		AffectsParent: true
 	Warhead@2Res: CreateResource
 		AddsResourceType: Spice
@@ -335,6 +342,7 @@ BloomExplosion:
 			cy: 20
 			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+		DamageCalculationType: ClosestTargetablePosition
 		AffectsParent: true
 
 PlasmaExplosion:
@@ -349,6 +357,7 @@ PlasmaExplosion:
 			Heavy: 100
 			Concrete: 60
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
+		DamageCalculationType: ClosestTargetablePosition
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: SandCrater
 	Warhead@3Eff: CreateEffect

--- a/mods/d2k/weapons/smallguns.yaml
+++ b/mods/d2k/weapons/smallguns.yaml
@@ -17,6 +17,7 @@
 			cy: 20
 			harvester: 25
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
+		DamageCalculationType: ClosestTargetablePosition
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
 		ImpactActors: false


### PR DESCRIPTION
This implements the fourth and final point on the TODO list in #17972 by adding a `DamageCalculatonType` enum/property to `SpreadDamageWarhead` (the third commit).
_The first two commits are cleanup._