### PR TITLE
Reset filters after selected text is removed

### DIFF
--- a/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
@@ -531,6 +531,7 @@ namespace OpenRA.Mods.Common.Widgets
 				ClearSelection();
 
 				CursorPosition = lowestIndex;
+				OnTextEdited();
 			}
 		}
 

--- a/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
+++ b/OpenRA.Mods.Common/Widgets/TextFieldWidget.cs
@@ -365,7 +365,6 @@ namespace OpenRA.Mods.Common.Widgets
 						Game.Renderer.SetClipboardText(Text.Substring(lowestIndex, highestIndex - lowestIndex));
 
 						RemoveSelectedText();
-						OnTextEdited();
 					}
 
 					break;


### PR DESCRIPTION
Address an issue with the Map Editor when removing selected text from `TextFieldWidget` didn't call `OnTextEdited()` resulting in filtering not being reset