### PR TITLE
Remove DeathSounds overwrites from the desert shellmap

### DIFF
--- a/mods/ra/maps/desert-shellmap/rules.yaml
+++ b/mods/ra/maps/desert-shellmap/rules.yaml
@@ -36,12 +36,6 @@ World:
 		Condition: unkillable
 
 ^Infantry:
-	DeathSounds@NORMAL:
-		VolumeMultiplier: 0.1
-	DeathSounds@BURNED:
-		VolumeMultiplier: 0.1
-	DeathSounds@ZAPPED:
-		VolumeMultiplier: 0.1
 	DamageMultiplier@UNKILLABLE:
 		RequiresCondition: unkillable
 		Modifier: 0

--- a/mods/ra/maps/desert-shellmap/rules.yaml
+++ b/mods/ra/maps/desert-shellmap/rules.yaml
@@ -27,36 +27,6 @@ World:
 ^ExistsInWorld:
 	GivesExperience:
 		ActorExperienceModifier: 0
-
-^Vehicle:
-	DamageMultiplier@UNKILLABLE:
-		RequiresCondition: unkillable
-		Modifier: 0
-	ExternalCondition@UNKILLABLE:
-		Condition: unkillable
-
-^Infantry:
-	DamageMultiplier@UNKILLABLE:
-		RequiresCondition: unkillable
-		Modifier: 0
-	ExternalCondition@UNKILLABLE:
-		Condition: unkillable
-
-^Ship:
-	DamageMultiplier@UNKILLABLE:
-		RequiresCondition: unkillable
-		Modifier: 0
-	ExternalCondition@UNKILLABLE:
-		Condition: unkillable
-
-^Plane:
-	DamageMultiplier@UNKILLABLE:
-		RequiresCondition: unkillable
-		Modifier: 0
-	ExternalCondition@UNKILLABLE:
-		Condition: unkillable
-
-^Building:
 	DamageMultiplier@UNKILLABLE:
 		RequiresCondition: unkillable
 		Modifier: 0

--- a/mods/ra/maps/desert-shellmap/rules.yaml
+++ b/mods/ra/maps/desert-shellmap/rules.yaml
@@ -93,9 +93,6 @@ Ant:
 	Health:
 		HP: 20000
 
-E7:
-	-AnnounceOnKill:
-
 powerproxy.paratroopers:
 	ParatroopersPower:
 		DisplayBeacon: false


### PR DESCRIPTION
The shellmap is already muted, so there is no point in having them.