### PR TITLE
Convert animation and sequence code to WAngle facings

### DIFF
--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Graphics
 		public bool IsDecoration { get; set; }
 
 		readonly SequenceProvider sequenceProvider;
-		readonly Func<int> facingFunc;
+		readonly Func<WAngle> facingFunc;
 		readonly Func<bool> paused;
 
 		int frame;
@@ -33,15 +33,15 @@ namespace OpenRA.Graphics
 		Action tickFunc = () => { };
 
 		public Animation(World world, string name)
-			: this(world, name, () => 0) { }
+			: this(world, name, () => WAngle.Zero) { }
 
-		public Animation(World world, string name, Func<int> facingFunc)
+		public Animation(World world, string name, Func<WAngle> facingFunc)
 			: this(world, name, facingFunc, null) { }
 
 		public Animation(World world, string name, Func<bool> paused)
-			: this(world, name, () => 0, paused) { }
+			: this(world, name, () => WAngle.Zero, paused) { }
 
-		public Animation(World world, string name, Func<int> facingFunc, Func<bool> paused)
+		public Animation(World world, string name, Func<WAngle> facingFunc, Func<bool> paused)
 		{
 			sequenceProvider = world.Map.Rules.Sequences;
 			Name = name.ToLowerInvariant();
@@ -50,7 +50,7 @@ namespace OpenRA.Graphics
 		}
 
 		public int CurrentFrame { get { return backwards ? CurrentSequence.Length - frame - 1 : frame; } }
-		public Sprite Image { get { return CurrentSequence.GetSprite(CurrentFrame, WAngle.FromFacing(facingFunc())); } }
+		public Sprite Image { get { return CurrentSequence.GetSprite(CurrentFrame, facingFunc()); } }
 
 		public IRenderable[] Render(WPos pos, WVec offset, int zOffset, PaletteReference palette, float scale)
 		{
@@ -58,7 +58,7 @@ namespace OpenRA.Graphics
 
 			if (CurrentSequence.ShadowStart >= 0)
 			{
-				var shadow = CurrentSequence.GetShadow(CurrentFrame, WAngle.FromFacing(facingFunc()));
+				var shadow = CurrentSequence.GetShadow(CurrentFrame, facingFunc());
 				var shadowRenderable = new SpriteRenderable(shadow, pos, offset, CurrentSequence.ShadowZOffset + zOffset, palette, scale, true);
 				return new IRenderable[] { shadowRenderable, imageRenderable };
 			}
@@ -74,7 +74,7 @@ namespace OpenRA.Graphics
 
 			if (CurrentSequence.ShadowStart >= 0)
 			{
-				var shadow = CurrentSequence.GetShadow(CurrentFrame, WAngle.FromFacing(facingFunc()));
+				var shadow = CurrentSequence.GetShadow(CurrentFrame, facingFunc());
 				var shadowPos = pos - new int2((int)(scale * shadow.Size.X / 2), (int)(scale * shadow.Size.Y / 2));
 				var shadowRenderable = new UISpriteRenderable(shadow, WPos.Zero + offset, shadowPos, CurrentSequence.ShadowZOffset + zOffset, palette, scale);
 				return new IRenderable[] { shadowRenderable, imageRenderable };

--- a/OpenRA.Game/Graphics/Animation.cs
+++ b/OpenRA.Game/Graphics/Animation.cs
@@ -50,7 +50,7 @@ namespace OpenRA.Graphics
 		}
 
 		public int CurrentFrame { get { return backwards ? CurrentSequence.Length - frame - 1 : frame; } }
-		public Sprite Image { get { return CurrentSequence.GetSprite(CurrentFrame, facingFunc()); } }
+		public Sprite Image { get { return CurrentSequence.GetSprite(CurrentFrame, WAngle.FromFacing(facingFunc())); } }
 
 		public IRenderable[] Render(WPos pos, WVec offset, int zOffset, PaletteReference palette, float scale)
 		{
@@ -58,7 +58,7 @@ namespace OpenRA.Graphics
 
 			if (CurrentSequence.ShadowStart >= 0)
 			{
-				var shadow = CurrentSequence.GetShadow(CurrentFrame, facingFunc());
+				var shadow = CurrentSequence.GetShadow(CurrentFrame, WAngle.FromFacing(facingFunc()));
 				var shadowRenderable = new SpriteRenderable(shadow, pos, offset, CurrentSequence.ShadowZOffset + zOffset, palette, scale, true);
 				return new IRenderable[] { shadowRenderable, imageRenderable };
 			}
@@ -74,7 +74,7 @@ namespace OpenRA.Graphics
 
 			if (CurrentSequence.ShadowStart >= 0)
 			{
-				var shadow = CurrentSequence.GetShadow(CurrentFrame, facingFunc());
+				var shadow = CurrentSequence.GetShadow(CurrentFrame, WAngle.FromFacing(facingFunc()));
 				var shadowPos = pos - new int2((int)(scale * shadow.Size.X / 2), (int)(scale * shadow.Size.Y / 2));
 				var shadowRenderable = new UISpriteRenderable(shadow, WPos.Zero + offset, shadowPos, CurrentSequence.ShadowZOffset + zOffset, palette, scale);
 				return new IRenderable[] { shadowRenderable, imageRenderable };

--- a/OpenRA.Game/Graphics/SequenceProvider.cs
+++ b/OpenRA.Game/Graphics/SequenceProvider.cs
@@ -34,8 +34,8 @@ namespace OpenRA.Graphics
 		Rectangle Bounds { get; }
 
 		Sprite GetSprite(int frame);
-		Sprite GetSprite(int frame, int facing);
-		Sprite GetShadow(int frame, int facing);
+		Sprite GetSprite(int frame, WAngle facing);
+		Sprite GetShadow(int frame, WAngle facing);
 	}
 
 	public interface ISpriteSequenceLoader

--- a/OpenRA.Mods.Cnc/Graphics/ClassicSpriteSequence.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ClassicSpriteSequence.cs
@@ -42,9 +42,9 @@ namespace OpenRA.Mods.Cnc.Graphics
 					.F(info.Nodes[0].Location, sequence, animation));
 		}
 
-		protected override int QuantizeFacing(int facing)
+		protected override int GetFacingFrameOffset(WAngle facing)
 		{
-			return OpenRA.Mods.Cnc.Util.ClassicQuantizeFacing(facing, Facings, useClassicFacings);
+			return Util.ClassicQuantizeFacing(facing.Facing, Facings, useClassicFacings);
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Traits/Render/WithEmbeddedTurretSpriteBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithEmbeddedTurretSpriteBody.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 			var wsb = init.Actor.TraitInfos<WithSpriteBodyInfo>().FirstOrDefault();
 
 			// Show the correct turret facing
-			var facing = init.Contains<TurretFacingInit>() ? init.Get<TurretFacingInit>().Value(init.World) : t.InitialFacing;
+			var facing = WAngle.FromFacing(init.Contains<TurretFacingInit>() ? init.Get<TurretFacingInit>().Value(init.World) : t.InitialFacing);
 
 			var anim = new Animation(init.World, image, () => facing);
 			anim.PlayRepeating(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), wsb.Sequence));
@@ -47,11 +47,11 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 	{
 		readonly Turreted turreted;
 
-		static Func<int> MakeTurretFacingFunc(Actor self)
+		static Func<WAngle> MakeTurretFacingFunc(Actor self)
 		{
 			// Turret artwork is baked into the sprite, so only the first turret makes sense.
 			var turreted = self.TraitsImplementing<Turreted>().FirstOrDefault();
-			return () => turreted.TurretFacing;
+			return () => WAngle.FromFacing(turreted.TurretFacing);
 		}
 
 		public WithEmbeddedTurretSpriteBody(ActorInitializer init, WithSpriteBodyInfo info)

--- a/OpenRA.Mods.Cnc/Traits/Render/WithGunboatBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithGunboatBody.cs
@@ -46,11 +46,11 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		readonly IFacing facing;
 		readonly Turreted turret;
 
-		static Func<int> MakeTurretFacingFunc(Actor self)
+		static Func<WAngle> MakeTurretFacingFunc(Actor self)
 		{
 			// Turret artwork is baked into the sprite, so only the first turret makes sense.
 			var turreted = self.TraitsImplementing<Turreted>().FirstOrDefault();
-			return () => turreted.TurretFacing;
+			return () => WAngle.FromFacing(turreted.TurretFacing);
 		}
 
 		public WithGunboatBody(ActorInitializer init, WithGunboatBodyInfo info)

--- a/OpenRA.Mods.Cnc/Traits/Render/WithRoof.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithRoof.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		public WithRoof(Actor self, WithRoofInfo info)
 		{
 			var rs = self.Trait<RenderSprites>();
-			var roof = new Animation(self.World, rs.GetImage(self), () => self.Trait<IFacing>().Facing);
+			var roof = new Animation(self.World, rs.GetImage(self), RenderSprites.MakeFacingFunc(self));
 			roof.Play(info.Sequence);
 			rs.Add(new AnimationWithOffset(roof, null, null, 1024));
 		}

--- a/OpenRA.Mods.Common/Effects/SpriteEffect.cs
+++ b/OpenRA.Mods.Common/Effects/SpriteEffect.cs
@@ -31,14 +31,18 @@ namespace OpenRA.Mods.Common.Effects
 		// Facing is last on these overloads partially for backwards compatibility with previous main ctor revision
 		// and partially because most effects don't need it. The latter is also the reason for placement of 'delay'.
 		public SpriteEffect(WPos pos, World world, string image, string sequence, string palette,
-			bool visibleThroughFog = false, int facing = 0, int delay = 0)
-			: this(() => pos, () => facing, world, image, sequence, palette, visibleThroughFog, delay) { }
+			bool visibleThroughFog = false, int delay = 0)
+			: this(() => pos, () => WAngle.Zero, world, image, sequence, palette, visibleThroughFog, delay) { }
 
 		public SpriteEffect(Actor actor, World world, string image, string sequence, string palette,
-			bool visibleThroughFog = false, int facing = 0, int delay = 0)
-			: this(() => actor.CenterPosition, () => facing, world, image, sequence, palette, visibleThroughFog, delay) { }
+			bool visibleThroughFog = false, int delay = 0)
+			: this(() => actor.CenterPosition, () => WAngle.Zero, world, image, sequence, palette, visibleThroughFog, delay) { }
 
-		public SpriteEffect(Func<WPos> posFunc, Func<int> facingFunc, World world, string image, string sequence, string palette,
+		public SpriteEffect(WPos pos, WAngle facing, World world, string image, string sequence, string palette,
+			bool visibleThroughFog = false, int delay = 0)
+			: this(() => pos, () => facing, world, image, sequence, palette, visibleThroughFog, delay) { }
+
+		public SpriteEffect(Func<WPos> posFunc, Func<WAngle> facingFunc, World world, string image, string sequence, string palette,
 			bool visibleThroughFog = false, int delay = 0)
 		{
 			this.world = world;
@@ -48,7 +52,7 @@ namespace OpenRA.Mods.Common.Effects
 			this.visibleThroughFog = visibleThroughFog;
 			this.delay = delay;
 			pos = posFunc();
-			anim = new Animation(world, image, () => WAngle.FromFacing(facingFunc()));
+			anim = new Animation(world, image, facingFunc);
 		}
 
 		public void Tick(World world)

--- a/OpenRA.Mods.Common/Effects/SpriteEffect.cs
+++ b/OpenRA.Mods.Common/Effects/SpriteEffect.cs
@@ -48,7 +48,7 @@ namespace OpenRA.Mods.Common.Effects
 			this.visibleThroughFog = visibleThroughFog;
 			this.delay = delay;
 			pos = posFunc();
-			anim = new Animation(world, image, facingFunc);
+			anim = new Animation(world, image, () => WAngle.FromFacing(facingFunc()));
 		}
 
 		public void Tick(World world)

--- a/OpenRA.Mods.Common/Graphics/ActorPreview.cs
+++ b/OpenRA.Mods.Common/Graphics/ActorPreview.cs
@@ -67,20 +67,23 @@ namespace OpenRA.Mods.Common.Graphics
 			return () => orientation;
 		}
 
-		public Func<int> GetFacing()
+		public Func<WAngle> GetFacing()
 		{
 			var facingInfo = Actor.TraitInfoOrDefault<IFacingInfo>();
 			if (facingInfo == null)
-				return () => 0;
+				return () => WAngle.Zero;
 
 			// Dynamic facing takes priority
 			var dynamicInit = dict.GetOrDefault<DynamicFacingInit>();
 			if (dynamicInit != null)
-				return dynamicInit.Value(null);
+			{
+				var getFacing = dynamicInit.Value(null);
+				return () => WAngle.FromFacing(getFacing());
+			}
 
 			// Fall back to initial actor facing if an Init isn't available
 			var facingInit = dict.GetOrDefault<FacingInit>();
-			var facing = facingInit != null ? facingInit.Value(null) : facingInfo.GetInitialFacing();
+			var facing = WAngle.FromFacing(facingInit != null ? facingInit.Value(null) : facingInfo.GetInitialFacing());
 			return () => facing;
 		}
 

--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -363,22 +363,22 @@ namespace OpenRA.Mods.Common.Graphics
 
 		public Sprite GetSprite(int frame)
 		{
-			return GetSprite(Start, frame, 0);
+			return GetSprite(Start, frame, WAngle.Zero);
 		}
 
-		public Sprite GetSprite(int frame, int facing)
+		public Sprite GetSprite(int frame, WAngle facing)
 		{
 			return GetSprite(Start, frame, facing);
 		}
 
-		public Sprite GetShadow(int frame, int facing)
+		public Sprite GetShadow(int frame, WAngle facing)
 		{
 			return ShadowStart >= 0 ? GetSprite(ShadowStart, frame, facing) : null;
 		}
 
-		protected virtual Sprite GetSprite(int start, int frame, int facing)
+		protected virtual Sprite GetSprite(int start, int frame, WAngle facing)
 		{
-			var f = QuantizeFacing(facing);
+			var f = GetFacingFrameOffset(facing);
 			if (reverseFacings)
 				f = (Facings - f) % Facings;
 
@@ -393,9 +393,9 @@ namespace OpenRA.Mods.Common.Graphics
 			return sprites[j];
 		}
 
-		protected virtual int QuantizeFacing(int facing)
+		protected virtual int GetFacingFrameOffset(WAngle facing)
 		{
-			return Util.QuantizeFacing(facing, Facings);
+			return Util.QuantizeFacing(facing.Facing, Facings);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -212,8 +212,8 @@ namespace OpenRA.Mods.Common.Projectiles
 			if (!string.IsNullOrEmpty(info.TrailImage) && --smokeTicks < 0)
 			{
 				var delayedPos = WPos.LerpQuadratic(source, target, angle, ticks - info.TrailDelay, length);
-				world.AddFrameEndTask(w => w.Add(new SpriteEffect(delayedPos, w, info.TrailImage, info.TrailSequences.Random(world.SharedRandom),
-					trailPalette, facing: GetEffectiveFacing().Facing)));
+				world.AddFrameEndTask(w => w.Add(new SpriteEffect(delayedPos, GetEffectiveFacing(), w,
+					info.TrailImage, info.TrailSequences.Random(world.SharedRandom), trailPalette)));
 
 				smokeTicks = info.TrailInterval;
 			}

--- a/OpenRA.Mods.Common/Projectiles/Bullet.cs
+++ b/OpenRA.Mods.Common/Projectiles/Bullet.cs
@@ -158,7 +158,7 @@ namespace OpenRA.Mods.Common.Projectiles
 
 			if (!string.IsNullOrEmpty(info.Image))
 			{
-				anim = new Animation(world, info.Image, new Func<int>(GetEffectiveFacing));
+				anim = new Animation(world, info.Image, new Func<WAngle>(GetEffectiveFacing));
 				anim.PlayRepeating(info.Sequences.Random(world.SharedRandom));
 			}
 
@@ -176,7 +176,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			remainingBounces = info.BounceCount;
 		}
 
-		int GetEffectiveFacing()
+		WAngle GetEffectiveFacing()
 		{
 			var at = (float)ticks / (length - 1);
 			var attitude = angle.Tan() * (1 - 2 * at) / (4 * 1024);
@@ -184,9 +184,11 @@ namespace OpenRA.Mods.Common.Projectiles
 			var u = (facing % 128) / 128f;
 			var scale = 512 * u * (1 - u);
 
-			return (int)(facing < 128
+			var effective = (int)(facing < 128
 				? facing - scale * attitude
 				: facing + scale * attitude);
+
+			return WAngle.FromFacing(effective);
 		}
 
 		public void Tick(World world)
@@ -211,7 +213,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			{
 				var delayedPos = WPos.LerpQuadratic(source, target, angle, ticks - info.TrailDelay, length);
 				world.AddFrameEndTask(w => w.Add(new SpriteEffect(delayedPos, w, info.TrailImage, info.TrailSequences.Random(world.SharedRandom),
-					trailPalette, facing: GetEffectiveFacing())));
+					trailPalette, facing: GetEffectiveFacing().Facing)));
 
 				smokeTicks = info.TrailInterval;
 			}

--- a/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
+++ b/OpenRA.Mods.Common/Projectiles/GravityBomb.cs
@@ -65,13 +65,14 @@ namespace OpenRA.Mods.Common.Projectiles
 			this.info = info;
 			this.args = args;
 			pos = args.Source;
+			var facing = WAngle.FromFacing(args.Facing);
 			var convertedVelocity = new WVec(info.Velocity.Y, -info.Velocity.X, info.Velocity.Z);
-			velocity = convertedVelocity.Rotate(WRot.FromFacing(args.Facing));
+			velocity = convertedVelocity.Rotate(WRot.FromYaw(facing));
 			acceleration = new WVec(info.Acceleration.Y, -info.Acceleration.X, info.Acceleration.Z);
 
 			if (!string.IsNullOrEmpty(info.Image))
 			{
-				anim = new Animation(args.SourceActor.World, info.Image, () => args.Facing);
+				anim = new Animation(args.SourceActor.World, info.Image, () => facing);
 
 				if (!string.IsNullOrEmpty(info.OpenSequence))
 					anim.PlayThen(info.OpenSequence, () => anim.PlayRepeating(info.Sequences.Random(args.SourceActor.World.SharedRandom)));

--- a/OpenRA.Mods.Common/Projectiles/LaserZap.cs
+++ b/OpenRA.Mods.Common/Projectiles/LaserZap.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using OpenRA.GameRules;
 using OpenRA.Graphics;
@@ -148,8 +149,11 @@ namespace OpenRA.Mods.Common.Projectiles
 			source = args.CurrentSource();
 
 			if (hasLaunchEffect && ticks == 0)
-				world.AddFrameEndTask(w => w.Add(new SpriteEffect(args.CurrentSource, args.CurrentMuzzleFacing, world,
+			{
+				Func<WAngle> getMuzzleFacing = () => WAngle.FromFacing(args.CurrentMuzzleFacing());
+				world.AddFrameEndTask(w => w.Add(new SpriteEffect(args.CurrentSource, getMuzzleFacing, world,
 					info.LaunchEffectImage, info.LaunchEffectSequence, info.LaunchEffectPalette)));
+			}
 
 			// Beam tracks target
 			if (info.TrackTarget && args.GuidedTarget.IsValidFor(args.SourceActor))

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -203,7 +203,7 @@ namespace OpenRA.Mods.Common.Projectiles
 		WDist distanceCovered;
 		WDist rangeLimit;
 
-		int renderFacing;
+		WAngle renderFacing;
 
 		[Sync]
 		int hFacing;
@@ -835,7 +835,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			else
 				move = HomingTick(world, tarDistVec, relTarHorDist);
 
-			renderFacing = new WVec(move.X, move.Y - move.Z, 0).Yaw.Facing;
+			renderFacing = new WVec(move.X, move.Y - move.Z, 0).Yaw;
 
 			// Move the missile
 			var lastPos = pos;
@@ -858,7 +858,7 @@ namespace OpenRA.Mods.Common.Projectiles
 			if (!string.IsNullOrEmpty(info.TrailImage) && --ticksToNextSmoke < 0 && (state != States.Freefall || info.TrailWhenDeactivated))
 			{
 				world.AddFrameEndTask(w => w.Add(new SpriteEffect(pos - 3 * move / 2, w, info.TrailImage, info.TrailSequences.Random(world.SharedRandom),
-					trailPalette, facing: renderFacing)));
+					trailPalette, facing: renderFacing.Facing)));
 
 				ticksToNextSmoke = info.TrailInterval;
 			}

--- a/OpenRA.Mods.Common/Projectiles/Missile.cs
+++ b/OpenRA.Mods.Common/Projectiles/Missile.cs
@@ -9,6 +9,7 @@
  */
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using OpenRA.GameRules;
@@ -857,8 +858,8 @@ namespace OpenRA.Mods.Common.Projectiles
 			// Create the sprite trail effect
 			if (!string.IsNullOrEmpty(info.TrailImage) && --ticksToNextSmoke < 0 && (state != States.Freefall || info.TrailWhenDeactivated))
 			{
-				world.AddFrameEndTask(w => w.Add(new SpriteEffect(pos - 3 * move / 2, w, info.TrailImage, info.TrailSequences.Random(world.SharedRandom),
-					trailPalette, facing: renderFacing.Facing)));
+				world.AddFrameEndTask(w => w.Add(new SpriteEffect(pos - 3 * move / 2, renderFacing, w,
+					info.TrailImage, info.TrailSequences.Random(world.SharedRandom), trailPalette)));
 
 				ticksToNextSmoke = info.TrailInterval;
 			}

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -161,7 +161,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (port == null)
 					return;
 
-				var muzzleFacing = targetYaw.Angle / 4;
+				var muzzleFacing = targetYaw.Facing;
 				paxFacing[a.Actor].Facing = muzzleFacing;
 				paxPos[a.Actor].SetVisualPosition(a.Actor, pos + PortOffset(self, port));
 
@@ -172,7 +172,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (a.Info.MuzzleSequence != null)
 				{
 					// Muzzle facing is fixed once the firing starts
-					var muzzleAnim = new Animation(self.World, paxRender[a.Actor].GetImage(a.Actor), () => muzzleFacing);
+					var muzzleAnim = new Animation(self.World, paxRender[a.Actor].GetImage(a.Actor), () => targetYaw);
 					var sequence = a.Info.MuzzleSequence;
 
 					if (a.Info.MuzzleSplitFacings > 0)

--- a/OpenRA.Mods.Common/Traits/Burns.cs
+++ b/OpenRA.Mods.Common/Traits/Burns.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			this.info = info;
 
-			var anim = new Animation(self.World, "fire", () => 0);
+			var anim = new Animation(self.World, "fire");
 			anim.IsDecoration = true;
 			anim.PlayRepeating(info.Anim);
 			self.Trait<RenderSprites>().Add(anim);

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -157,11 +157,13 @@ namespace OpenRA.Mods.Common.Traits.Render
 		readonly List<AnimationWrapper> anims = new List<AnimationWrapper>();
 		string cachedImage;
 
-		public static Func<int> MakeFacingFunc(Actor self)
+		public static Func<WAngle> MakeFacingFunc(Actor self)
 		{
 			var facing = self.TraitOrDefault<IFacing>();
-			if (facing == null) return () => 0;
-			return () => facing.Facing;
+			if (facing == null)
+				return () => WAngle.Zero;
+
+			return () => WAngle.FromFacing(facing.Facing);
 		}
 
 		public RenderSprites(ActorInitializer init, RenderSpritesInfo info)

--- a/OpenRA.Mods.Common/Traits/Render/WithBridgeSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithBridgeSpriteBody.cs
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		readonly Actor self;
 
 		public WithBridgeSpriteBody(ActorInitializer init, WithBridgeSpriteBodyInfo info)
-			: base(init, info, () => 0)
+			: base(init, info)
 		{
 			self = init.Self;
 			bridgeInfo = info;

--- a/OpenRA.Mods.Common/Traits/Render/WithChargeSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithChargeSpriteBody.cs
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		readonly AttackCharges attackCharges;
 
 		public WithChargeSpriteBody(ActorInitializer init, WithChargeSpriteBodyInfo info)
-			: base(init, info, () => 0)
+			: base(init, info)
 		{
 			attackCharges = init.Self.Trait<AttackCharges>();
 			ConfigureAnimation(init.Self);

--- a/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{
-			var anim = new Animation(init.World, rs.Image, () => 0);
+			var anim = new Animation(init.World, rs.Image);
 			anim.PlayRepeating(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), IdleSequence));
 			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, p, rs.Scale);
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithDeadBridgeSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDeadBridgeSpriteBody.cs
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		readonly BridgeLayer bridgeLayer;
 
 		public WithDeadBridgeSpriteBody(ActorInitializer init, WithDeadBridgeSpriteBodyInfo info)
-			: base(init, info, () => 0)
+			: base(init, info)
 		{
 			bridgeInfo = info;
 			bridgeLayer = init.World.WorldActor.Trait<BridgeLayer>();

--- a/OpenRA.Mods.Common/Traits/Render/WithGateSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithGateSpriteBody.cs
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		bool renderOpen;
 
 		public WithGateSpriteBody(ActorInitializer init, WithGateSpriteBodyInfo info)
-			: base(init, info, () => 0)
+			: base(init, info)
 		{
 			gateBodyInfo = info;
 			gate = init.Self.Trait<Gate>();

--- a/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithIdleOverlay.cs
@@ -48,12 +48,15 @@ namespace OpenRA.Mods.Common.Traits.Render
 			if (Palette != null)
 				p = init.WorldRenderer.Palette(Palette);
 
-			Func<int> facing;
+			Func<WAngle> facing;
 			if (init.Contains<DynamicFacingInit>())
-				facing = init.Get<DynamicFacingInit, Func<int>>();
+			{
+				var getFacing = init.Get<DynamicFacingInit, Func<int>>();
+				facing = () => WAngle.FromFacing(getFacing());
+			}
 			else
 			{
-				var f = init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : 0;
+				var f = WAngle.FromFacing(init.Contains<FacingInit>() ? init.Get<FacingInit, int>() : 0);
 				facing = () => f;
 			}
 
@@ -61,7 +64,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			anim.PlayRepeating(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence));
 
 			var body = init.Actor.TraitInfo<BodyOrientationInfo>();
-			Func<WRot> orientation = () => body.QuantizeOrientation(WRot.FromFacing(facing()), facings);
+			Func<WRot> orientation = () => body.QuantizeOrientation(WRot.FromYaw(facing()), facings);
 			Func<WVec> offset = () => body.LocalToWorld(Offset.Rotate(orientation()));
 			Func<int> zOffset = () =>
 			{

--- a/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 	{
 		readonly Dictionary<Barrel, bool> visible = new Dictionary<Barrel, bool>();
 		readonly Dictionary<Barrel, AnimationWithOffset> anims = new Dictionary<Barrel, AnimationWithOffset>();
-		readonly Func<int> getFacing;
+		readonly Func<WAngle> getFacing;
 		readonly Armament[] armaments;
 
 		public WithMuzzleOverlay(Actor self, WithMuzzleOverlayInfo info)
@@ -55,11 +55,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 					// Workaround for broken ternary operators in certain versions of mono (3.10 and
 					// certain versions of the 3.8 series): https://bugzilla.xamarin.com/show_bug.cgi?id=23319
 					if (turreted != null)
-						getFacing = () => turreted.TurretFacing;
+						getFacing = () => WAngle.FromFacing(turreted.TurretFacing);
 					else if (facing != null)
-						getFacing = () => facing.Facing;
+						getFacing = () => WAngle.FromFacing(facing.Facing);
 					else
-						getFacing = () => 0;
+						getFacing = () => WAngle.Zero;
 
 					var muzzleFlash = new Animation(self.World, render.GetImage(self), getFacing);
 					visible.Add(barrel, false);
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			var sequence = a.Info.MuzzleSequence;
 			if (a.Info.MuzzleSplitFacings > 0)
-				sequence += Util.QuantizeFacing(getFacing(), a.Info.MuzzleSplitFacings).ToString();
+				sequence += Util.QuantizeFacing(getFacing().Facing, a.Info.MuzzleSplitFacings).ToString();
 
 			visible[barrel] = true;
 			anims[barrel].Animation.PlayThen(sequence, () => visible[barrel] = false);

--- a/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithProductionDoorOverlay.cs
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{
-			var anim = new Animation(init.World, image, () => 0);
+			var anim = new Animation(init.World, image);
 			anim.PlayFetchIndex(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence), () => 0);
 
 			var bi = init.Actor.TraitInfo<BuildingInfo>();

--- a/OpenRA.Mods.Common/Traits/Render/WithResourceLevelSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithResourceLevelSpriteBody.cs
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		PlayerResources playerResources;
 
 		public WithResourceLevelSpriteBody(ActorInitializer init, WithResourceLevelSpriteBodyInfo info)
-			: base(init, info, () => 0)
+			: base(init, info)
 		{
 			this.info = info;
 			playerResources = init.Self.Owner.PlayerActor.Trait<PlayerResources>();

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBarrel.cs
@@ -46,11 +46,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 				.First(tt => tt.Turret == armament.Turret);
 
 			var turretFacing = Turreted.TurretFacingFromInit(init, t.InitialFacing, armament.Turret);
-			var anim = new Animation(init.World, image, turretFacing);
+			var anim = new Animation(init.World, image, () => WAngle.FromFacing(turretFacing()));
 			anim.Play(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence));
 
-			Func<int> facing = init.GetFacing();
-			Func<WRot> orientation = () => body.QuantizeOrientation(WRot.FromFacing(facing()), facings);
+			var facing = init.GetFacing();
+			Func<WRot> orientation = () => body.QuantizeOrientation(WRot.FromYaw(facing()), facings);
 			Func<WVec> turretOffset = () => body.LocalToWorld(t.Offset.Rotate(orientation()));
 			Func<int> zOffset = () =>
 			{
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				.First(tt => tt.Name == armament.Info.Turret);
 
 			rs = self.Trait<RenderSprites>();
-			DefaultAnimation = new Animation(self.World, rs.GetImage(self), () => turreted.TurretFacing);
+			DefaultAnimation = new Animation(self.World, rs.GetImage(self), () => WAngle.FromFacing(turreted.TurretFacing));
 			DefaultAnimation.PlayRepeating(NormalizeSequence(self, Info.Sequence));
 			rs.Add(new AnimationWithOffset(
 				DefaultAnimation, () => BarrelOffset(), () => IsTraitDisabled, p => RenderUtils.ZOffsetFromCenter(self, p, 0)));

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteBody.cs
@@ -56,9 +56,9 @@ namespace OpenRA.Mods.Common.Traits.Render
 		readonly Animation boundsAnimation;
 
 		public WithSpriteBody(ActorInitializer init, WithSpriteBodyInfo info)
-			: this(init, info, () => 0) { }
+			: this(init, info, () => WAngle.Zero) { }
 
-		protected WithSpriteBody(ActorInitializer init, WithSpriteBodyInfo info, Func<int> baseFacing)
+		protected WithSpriteBody(ActorInitializer init, WithSpriteBodyInfo info, Func<WAngle> baseFacing)
 			: base(info)
 		{
 			rs = init.Self.Trait<RenderSprites>();

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteTurret.cs
@@ -51,11 +51,11 @@ namespace OpenRA.Mods.Common.Traits.Render
 				.First(tt => tt.Turret == Turret);
 
 			var turretFacing = Turreted.TurretFacingFromInit(init, t.InitialFacing, Turret);
-			var anim = new Animation(init.World, image, turretFacing);
+			var anim = new Animation(init.World, image, () => WAngle.FromFacing(turretFacing()));
 			anim.Play(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence));
 
-			Func<int> facing = init.GetFacing();
-			Func<WRot> orientation = () => body.QuantizeOrientation(WRot.FromFacing(facing()), facings);
+			var facing = init.GetFacing();
+			Func<WRot> orientation = () => body.QuantizeOrientation(WRot.FromYaw(facing()), facings);
 			Func<WVec> offset = () => body.LocalToWorld(t.Offset.Rotate(orientation()));
 			Func<int> zOffset = () =>
 			{
@@ -90,7 +90,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			arms = self.TraitsImplementing<Armament>()
 				.Where(w => w.Info.Turret == info.Turret).ToArray();
 
-			DefaultAnimation = new Animation(self.World, rs.GetImage(self), () => t.TurretFacing);
+			DefaultAnimation = new Animation(self.World, rs.GetImage(self), () => WAngle.FromFacing(t.TurretFacing));
 			DefaultAnimation.PlayRepeating(NormalizeSequence(self, info.Sequence));
 			rs.Add(new AnimationWithOffset(DefaultAnimation,
 				() => TurretOffset(self),

--- a/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithWallSpriteBody.cs
@@ -72,7 +72,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				}
 			}
 
-			var anim = new Animation(init.World, image, () => 0);
+			var anim = new Animation(init.World, image);
 			anim.PlayFetchIndex(RenderSprites.NormalizeSequence(anim, init.GetDamageState(), Sequence), () => adjacent);
 
 			yield return new SpriteActorPreview(anim, () => WVec.Zero, () => 0, p, rs.Scale);
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		void IWallConnector.SetDirty() { dirty = true; }
 
 		public WithWallSpriteBody(ActorInitializer init, WithWallSpriteBodyInfo info)
-			: base(init, info, () => 0)
+			: base(init, info)
 		{
 			wallInfo = info;
 		}

--- a/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
+++ b/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
@@ -9,7 +9,9 @@
  */
 #endregion
 
+using System;
 using OpenRA.Mods.Common.Effects;
+using OpenRA.Mods.Common.Traits.Render;
 using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
@@ -37,19 +39,14 @@ namespace OpenRA.Mods.Common.Traits
 	{
 		readonly SmokeTrailWhenDamagedInfo info;
 		readonly BodyOrientation body;
-		readonly int getFacing;
+		readonly Func<WAngle> getFacing;
 		int ticks;
 
 		public SmokeTrailWhenDamaged(Actor self, SmokeTrailWhenDamagedInfo info)
 		{
 			this.info = info;
 			body = self.Trait<BodyOrientation>();
-			var facing = self.TraitOrDefault<IFacing>();
-
-			if (facing != null)
-				getFacing = facing.Facing;
-			else
-				getFacing = 0;
+			getFacing = RenderSprites.MakeFacingFunc(self);
 		}
 
 		void ITick.Tick(Actor self)
@@ -61,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 				{
 					var offset = info.Offset.Rotate(body.QuantizeOrientation(self, self.Orientation));
 					var pos = position + body.LocalToWorld(offset);
-					self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, w, info.Sprite, info.Sequence, info.Palette, facing: getFacing)));
+					self.World.AddFrameEndTask(w => w.Add(new SpriteEffect(pos, getFacing(), w, info.Sprite, info.Sequence, info.Palette)));
 				}
 
 				ticks = info.Interval;

--- a/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Traits
 			// Facing rotation
 			rotation = WAngle.FromFacing(WDist.FromPDF(Game.CosmeticRandom, 2).Length * info.TurnSpeed / 1024);
 
-			var anim = new Animation(init.World, rs.GetImage(self), () => facing.Angle / 4);
+			var anim = new Animation(init.World, rs.GetImage(self), () => facing);
 			anim.PlayRepeating(info.Anim);
 			rs.Add(new AnimationWithOffset(anim, () => pos, null));
 		}


### PR DESCRIPTION
This PR takes a step towards #15196, #15843, and voxel orientations by converting sequences/Animation/SpriteEffect facings to WAngle. Future PRs will remove the conversions introduced here, pushing the conversion boundries further back until all of the facing code is using WAngle.

Most of the lines of changes here (type changes and `int` &lrarr; `WAngle` conversions) are confirmed to be correct by the compiler, so reviewing can focus on the few places where I change logic.

I strongly recommend reviewing by commit.