### PR TITLE
check name for Actor.GrantCondition()

### DIFF
--- a/OpenRA.Game/Actor.cs
+++ b/OpenRA.Game/Actor.cs
@@ -528,10 +528,16 @@ namespace OpenRA
 					notify(this, readOnlyConditionCache);
 		}
 
-		/// <summary>Grants a specified condition.</summary>
+		/// <summary>
+		/// Grants a specified condition if it is valid.
+		/// Otherwise, just returns InvalidConditionToken.
+		/// </summary>
 		/// <returns>The token that is used to revoke this condition.</returns>
 		public int GrantCondition(string condition)
 		{
+			if (string.IsNullOrEmpty(condition))
+				return InvalidConditionToken;
+
 			var token = nextConditionToken++;
 			conditionTokens.Add(token, condition);
 			UpdateConditionState(condition, token, false);

--- a/OpenRA.Mods.Cnc/Traits/Attack/AttackLeap.cs
+++ b/OpenRA.Mods.Cnc/Traits/Attack/AttackLeap.cs
@@ -55,8 +55,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public void GrantLeapCondition(Actor self)
 		{
-			if (!string.IsNullOrEmpty(info.LeapCondition))
-				leapToken = self.GrantCondition(info.LeapCondition);
+			leapToken = self.GrantCondition(info.LeapCondition);
 		}
 
 		public void RevokeLeapCondition(Actor self)

--- a/OpenRA.Mods.Cnc/Traits/ConyardChronoReturn.cs
+++ b/OpenRA.Mods.Cnc/Traits/ConyardChronoReturn.cs
@@ -122,7 +122,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		void TriggerVortex()
 		{
-			if (!string.IsNullOrEmpty(info.Condition) && conditionToken == Actor.InvalidConditionToken)
+			if (conditionToken == Actor.InvalidConditionToken)
 				conditionToken = self.GrantCondition(info.Condition);
 
 			triggered = true;

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -221,7 +221,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 			if (Disguised != oldDisguiseSetting)
 			{
-				if (Disguised && disguisedToken == Actor.InvalidConditionToken && !string.IsNullOrEmpty(info.DisguisedCondition))
+				if (Disguised && disguisedToken == Actor.InvalidConditionToken)
 					disguisedToken = self.GrantCondition(info.DisguisedCondition);
 				else if (!Disguised && disguisedToken != Actor.InvalidConditionToken)
 					disguisedToken = self.RevokeCondition(disguisedToken);

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -188,8 +188,7 @@ namespace OpenRA.Mods.Cnc.Traits
 					if (target.Type == TargetType.Invalid)
 						return true;
 
-					if (!string.IsNullOrEmpty(mad.info.DeployedCondition))
-						self.GrantCondition(mad.info.DeployedCondition);
+					self.GrantCondition(mad.info.DeployedCondition);
 
 					self.World.AddFrameEndTask(w => EjectDriver());
 					if (mad.info.ThumpSequence != null)

--- a/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
+++ b/OpenRA.Mods.Common/Activities/Move/AttackMoveActivity.cs
@@ -42,10 +42,10 @@ namespace OpenRA.Mods.Common.Activities
 			if (attackMove == null)
 				return;
 
-			if (!isAssaultMove && !string.IsNullOrEmpty(attackMove.Info.AttackMoveCondition))
-				token = self.GrantCondition(attackMove.Info.AttackMoveCondition);
-			else if (isAssaultMove && !string.IsNullOrEmpty(attackMove.Info.AssaultMoveCondition))
+			if (isAssaultMove)
 				token = self.GrantCondition(attackMove.Info.AssaultMoveCondition);
+			else
+				token = self.GrantCondition(attackMove.Info.AttackMoveCondition);
 		}
 
 		public override bool Tick(Actor self)

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -1114,7 +1114,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			airborne = true;
-			if (!string.IsNullOrEmpty(Info.AirborneCondition) && airborneToken == Actor.InvalidConditionToken)
+			if (airborneToken == Actor.InvalidConditionToken)
 				airborneToken = self.GrantCondition(Info.AirborneCondition);
 		}
 
@@ -1138,7 +1138,7 @@ namespace OpenRA.Mods.Common.Traits
 				return;
 
 			cruising = true;
-			if (!string.IsNullOrEmpty(Info.CruisingCondition) && cruisingToken == Actor.InvalidConditionToken)
+			if (cruisingToken == Actor.InvalidConditionToken)
 				cruisingToken = self.GrantCondition(Info.CruisingCondition);
 		}
 

--- a/OpenRA.Mods.Common/Traits/Attack/AttackCharges.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackCharges.cs
@@ -54,8 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 			var delta = charging ? info.ChargeRate : -info.DischargeRate;
 			ChargeLevel = (ChargeLevel + delta).Clamp(0, info.ChargeLevel);
 
-			if (ChargeLevel > 0 && !string.IsNullOrEmpty(info.ChargingCondition)
-					&& chargingToken == Actor.InvalidConditionToken)
+			if (ChargeLevel > 0 && chargingToken == Actor.InvalidConditionToken)
 				chargingToken = self.GrantCondition(info.ChargingCondition);
 
 			if (ChargeLevel == 0 && chargingToken != Actor.InvalidConditionToken)

--- a/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/PrimaryBuilding.cs
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.Common.Traits
 						b.Trait.SetPrimaryProducer(b.Actor, false);
 				}
 
-				if (primaryToken == Actor.InvalidConditionToken && !string.IsNullOrEmpty(Info.PrimaryCondition))
+				if (primaryToken == Actor.InvalidConditionToken)
 					primaryToken = self.GrantCondition(Info.PrimaryCondition);
 
 				Game.Sound.PlayNotification(self.World.Map.Rules, self.Owner, "Speech", Info.SelectionNotification, self.Owner.Faction.InternalName);

--- a/OpenRA.Mods.Common/Traits/CaptureManager.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureManager.cs
@@ -204,12 +204,10 @@ namespace OpenRA.Mods.Common.Traits
 			else
 				currentTargetDelay += 1;
 
-			if (!string.IsNullOrEmpty(info.CapturingCondition) &&
-					capturingToken == Actor.InvalidConditionToken)
+			if (capturingToken == Actor.InvalidConditionToken)
 				capturingToken = self.GrantCondition(info.CapturingCondition);
 
-			if (!string.IsNullOrEmpty(targetManager.info.BeingCapturedCondition) &&
-					targetManager.beingCapturedToken == Actor.InvalidConditionToken)
+			if (targetManager.beingCapturedToken == Actor.InvalidConditionToken)
 				targetManager.beingCapturedToken = target.GrantCondition(targetManager.info.BeingCapturedCondition);
 
 			captures = enabledCaptures

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -262,7 +262,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (!HasSpace(w))
 				return false;
 
-			if (loadingToken == Actor.InvalidConditionToken && !string.IsNullOrEmpty(Info.LoadingCondition))
+			if (loadingToken == Actor.InvalidConditionToken)
 				loadingToken = self.GrantCondition(Info.LoadingCondition);
 
 			reserves.Add(a);

--- a/OpenRA.Mods.Common/Traits/Carryable.cs
+++ b/OpenRA.Mods.Common/Traits/Carryable.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			attached = true;
 
-			if (carriedToken == Actor.InvalidConditionToken && !string.IsNullOrEmpty(Info.CarriedCondition))
+			if (carriedToken == Actor.InvalidConditionToken)
 				carriedToken = self.GrantCondition(Info.CarriedCondition);
 		}
 
@@ -102,7 +102,7 @@ namespace OpenRA.Mods.Common.Traits
 			state = State.Reserved;
 			Carrier = carrier;
 
-			if (reservedToken == Actor.InvalidConditionToken && !string.IsNullOrEmpty(Info.ReservedCondition))
+			if (reservedToken == Actor.InvalidConditionToken)
 				reservedToken = self.GrantCondition(Info.ReservedCondition);
 
 			return true;
@@ -134,7 +134,7 @@ namespace OpenRA.Mods.Common.Traits
 				state = State.Locked;
 				Carrier = carrier;
 
-				if (lockedToken == Actor.InvalidConditionToken && !string.IsNullOrEmpty(Info.LockedCondition))
+				if (lockedToken == Actor.InvalidConditionToken)
 					lockedToken = self.GrantCondition(Info.LockedCondition);
 			}
 

--- a/OpenRA.Mods.Common/Traits/Cloak.cs
+++ b/OpenRA.Mods.Common/Traits/Cloak.cs
@@ -95,7 +95,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (Cloaked)
 			{
 				wasCloaked = true;
-				if (cloakedToken == Actor.InvalidConditionToken && !string.IsNullOrEmpty(Info.CloakedCondition))
+				if (cloakedToken == Actor.InvalidConditionToken)
 					cloakedToken = self.GrantCondition(Info.CloakedCondition);
 			}
 
@@ -163,7 +163,7 @@ namespace OpenRA.Mods.Common.Traits
 			var isCloaked = Cloaked;
 			if (isCloaked && !wasCloaked)
 			{
-				if (cloakedToken == Actor.InvalidConditionToken && !string.IsNullOrEmpty(Info.CloakedCondition))
+				if (cloakedToken == Actor.InvalidConditionToken)
 					cloakedToken = self.GrantCondition(Info.CloakedCondition);
 
 				// Sounds shouldn't play if the actor starts cloaked

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDeploy.cs
@@ -323,7 +323,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void OnDeployCompleted()
 		{
-			if (!string.IsNullOrEmpty(Info.DeployedCondition) && deployedToken == Actor.InvalidConditionToken)
+			if (deployedToken == Actor.InvalidConditionToken)
 				deployedToken = self.GrantCondition(Info.DeployedCondition);
 
 			deployState = DeployState.Deployed;
@@ -339,7 +339,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void OnUndeployCompleted()
 		{
-			if (!string.IsNullOrEmpty(Info.UndeployedCondition) && undeployedToken == Actor.InvalidConditionToken)
+			if (undeployedToken == Actor.InvalidConditionToken)
 				undeployedToken = self.GrantCondition(Info.UndeployedCondition);
 
 			deployState = DeployState.Undeployed;

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLineBuildDirection.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLineBuildDirection.cs
@@ -40,10 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		void INotifyCreated.Created(Actor self)
 		{
-			if (direction != info.Direction)
-				return;
-
-			if (!string.IsNullOrEmpty(info.Condition))
+			if (direction == info.Direction)
 				self.GrantCondition(info.Condition);
 		}
 	}

--- a/OpenRA.Mods.Common/Traits/Demolishable.cs
+++ b/OpenRA.Mods.Common/Traits/Demolishable.cs
@@ -59,10 +59,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (IsTraitDisabled)
 				return;
 
-			var token = Actor.InvalidConditionToken;
-			if (!string.IsNullOrEmpty(Info.Condition))
-				token = self.GrantCondition(Info.Condition);
-
+			var token = self.GrantCondition(Info.Condition);
 			actions.Add(new DemolishAction(saboteur, delay, token));
 		}
 

--- a/OpenRA.Mods.Common/Traits/KillsSelf.cs
+++ b/OpenRA.Mods.Common/Traits/KillsSelf.cs
@@ -73,8 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (self.IsDead)
 				return;
 
-			if (!string.IsNullOrEmpty(Info.GrantsCondition))
-				self.GrantCondition(Info.GrantsCondition);
+			self.GrantCondition(Info.GrantsCondition);
 
 			if (Info.RemoveInstead || !self.Info.HasTraitInfo<IHealthInfo>())
 				self.Dispose();

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -78,7 +78,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			IsInAir = true;
 
-			if (parachutingToken == Actor.InvalidConditionToken && !string.IsNullOrEmpty(info.ParachutingCondition))
+			if (parachutingToken == Actor.InvalidConditionToken)
 				parachutingToken = self.GrantCondition(info.ParachutingCondition);
 
 			self.NotifyBlocker(self.Location);

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -121,7 +121,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			string specificCargoCondition;
 
-			if (anyCargoToken == Actor.InvalidConditionToken && !string.IsNullOrEmpty(Info.CargoCondition))
+			if (anyCargoToken == Actor.InvalidConditionToken)
 				anyCargoToken = self.GrantCondition(Info.CargoCondition);
 
 			if (specificCargoToken == Actor.InvalidConditionToken && Info.CargoConditions.TryGetValue(cargo.Info.Name, out specificCargoCondition))

--- a/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
@@ -57,7 +57,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public void Forward(Actor self, Action onComplete)
 		{
-			if (!string.IsNullOrEmpty(info.Condition) && token == Actor.InvalidConditionToken)
+			if (token == Actor.InvalidConditionToken)
 				token = self.GrantCondition(info.Condition);
 
 			var wsb = wsbs.FirstEnabledTraitOrDefault();
@@ -80,7 +80,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public void Reverse(Actor self, Action onComplete)
 		{
-			if (!string.IsNullOrEmpty(info.Condition) && token == Actor.InvalidConditionToken)
+			if (token == Actor.InvalidConditionToken)
 				token = self.GrantCondition(info.Condition);
 
 			var wsb = wsbs.FirstEnabledTraitOrDefault();
@@ -114,8 +114,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				if (wsb != null)
 					wsb.DefaultAnimation.PlayFetchIndex(info.Sequence, () => 0);
 
-				if (!string.IsNullOrEmpty(info.Condition))
-					token = self.GrantCondition(info.Condition);
+				token = self.GrantCondition(info.Condition);
 
 				self.QueueActivity(queued, activity);
 			});

--- a/OpenRA.Mods.D2k/Activities/SwallowActor.cs
+++ b/OpenRA.Mods.D2k/Activities/SwallowActor.cs
@@ -101,8 +101,9 @@ namespace OpenRA.Mods.D2k.Activities
 					stance = AttackState.Burrowed;
 					countdown = swallow.Info.AttackDelay;
 					burrowLocation = self.Location;
-					if (attackingToken == Actor.InvalidConditionToken && !string.IsNullOrEmpty(swallow.Info.AttackingCondition))
+					if (attackingToken == Actor.InvalidConditionToken)
 						attackingToken = self.GrantCondition(swallow.Info.AttackingCondition);
+
 					break;
 				case AttackState.Burrowed:
 					if (--countdown > 0)


### PR DESCRIPTION
I noticed that most calls to `GrantCondition` used a `IsNullOrEmpty` check and that the token is invalid anyways. I suspect that the cases where the check is missing are oversights. This prevents that oversight and made my condition reference branch easier to write.