### PR TITLE
Convert QuantizeFacing to WAngle.

### DIFF
--- a/OpenRA.Mods.Cnc/Graphics/ClassicSpriteSequence.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ClassicSpriteSequence.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 
 		protected override int GetFacingFrameOffset(WAngle facing)
 		{
-			return useClassicFacings ? Util.ClassicIndexFacing(facing.Facing, Facings) : Common.Util.IndexFacing(facing.Facing, Facings);
+			return useClassicFacings ? Util.ClassicIndexFacing(facing, Facings) : Common.Util.IndexFacing(facing, Facings);
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Graphics/ClassicSpriteSequence.cs
+++ b/OpenRA.Mods.Cnc/Graphics/ClassicSpriteSequence.cs
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Cnc.Graphics
 
 		protected override int GetFacingFrameOffset(WAngle facing)
 		{
-			return Util.ClassicQuantizeFacing(facing.Facing, Facings, useClassicFacings);
+			return useClassicFacings ? Util.ClassicIndexFacing(facing.Facing, Facings) : Common.Util.IndexFacing(facing.Facing, Facings);
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Traits/ClassicFacingBodyOrientation.cs
+++ b/OpenRA.Mods.Cnc/Traits/ClassicFacingBodyOrientation.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	[Desc("Fudge the coordinate system angles like the early games (for sprite sequences that use classic facing fudge).")]
 	public class ClassicFacingBodyOrientationInfo : BodyOrientationInfo
 	{
-		public override int QuantizeFacing(int facing, int facings)
+		public override WAngle QuantizeFacing(WAngle facing, int facings)
 		{
 			return Util.ClassicQuantizeFacing(facing, facings);
 		}

--- a/OpenRA.Mods.Cnc/Traits/ClassicFacingBodyOrientation.cs
+++ b/OpenRA.Mods.Cnc/Traits/ClassicFacingBodyOrientation.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	{
 		public override int QuantizeFacing(int facing, int facings)
 		{
-			return OpenRA.Mods.Cnc.Util.ClassicQuantizeFacing(facing, facings, true) * (256 / facings);
+			return Util.ClassicQuantizeFacing(facing, facings);
 		}
 
 		public override object Create(ActorInitializer init) { return new ClassicFacingBodyOrientation(init, this); }

--- a/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
@@ -85,7 +85,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 				var passengerInits = new TypeDictionary()
 				{
 					new OwnerInit(p.Owner),
-					new DynamicFacingInit(() => body.QuantizeFacing(facing.Facing)),
+					new DynamicFacingInit(() => body.QuantizeFacing(WAngle.FromFacing(facing.Facing)).Facing),
 				};
 
 				foreach (var api in p.TraitsImplementing<IActorPreviewInitModifier>())

--- a/OpenRA.Mods.Cnc/Util.cs
+++ b/OpenRA.Mods.Cnc/Util.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Cnc
 		// This table defines the exclusive maximum facing for the i'th sprite frame.
 		// i.e. sprite frame 1 is used for facings 5-13, sprite frame 2 for 14-21, and so on.
 		// Sprite frame 0 is used for facings smaller than 5 or larger than 249.
-		static readonly int[] SpriteFacings =
+		static readonly int[] SpriteRanges =
 		{
 			5, 14, 22, 33, 39, 46, 53, 60,
 			67, 74, 81, 88, 96, 104, 113, 122,
@@ -25,18 +25,44 @@ namespace OpenRA.Mods.Cnc
 			195, 202, 209, 216, 224, 232, 241, 250
 		};
 
-		public static int ClassicQuantizeFacing(int facing, int numFrames, bool useClassicFacingFudge)
+		// The actual facing associated with each sprite frame.
+		static readonly int[] SpriteFacings =
 		{
-			if (useClassicFacingFudge && numFrames == 32)
+			0, 10, 18, 28, 36, 43, 50, 57,
+			64, 71, 78, 85, 92, 100, 109, 118,
+			128, 138, 147, 156, 164, 171, 178, 185,
+			192, 199, 206, 213, 220, 228, 237, 246
+		};
+
+		/// <summary>
+		/// Calculate the frame index (between 0..numFrames) that
+		/// should be used for the given facing value, accounting
+		/// for the non-linear facing mapping for sprites with 32 directions.
+		/// </summary>
+		public static int ClassicIndexFacing(int facing, int numFrames)
+		{
+			if (numFrames == 32)
 			{
-				for (var i = 0; i < SpriteFacings.Length; i++)
-					if (facing < SpriteFacings[i])
+				for (var i = 0; i < SpriteRanges.Length; i++)
+					if (facing < SpriteRanges[i])
 						return i;
 
 				return 0;
 			}
 
-			return Common.Util.QuantizeFacing(facing, numFrames);
+			return Common.Util.IndexFacing(facing, numFrames);
+		}
+
+		/// <summary>
+		/// Rounds the given facing value to the nearest quantized step,
+		/// accounting for the non-linear facing mapping for sprites with 32 directions.
+		/// </summary>
+		public static int ClassicQuantizeFacing(int facing, int steps)
+		{
+			if (steps == 32)
+				return SpriteFacings[ClassicIndexFacing(facing, steps)];
+
+			return Common.Util.QuantizeFacing(facing, steps);
 		}
 	}
 }

--- a/OpenRA.Mods.Cnc/Util.cs
+++ b/OpenRA.Mods.Cnc/Util.cs
@@ -15,23 +15,23 @@ namespace OpenRA.Mods.Cnc
 	{
 		// TD and RA used a nonlinear mapping between artwork frames and unit facings for units with 32 facings.
 		// This table defines the exclusive maximum facing for the i'th sprite frame.
-		// i.e. sprite frame 1 is used for facings 5-13, sprite frame 2 for 14-21, and so on.
-		// Sprite frame 0 is used for facings smaller than 5 or larger than 249.
+		// i.e. sprite frame 1 is used for facings 20-55, sprite frame 2 for 56-87, and so on.
+		// Sprite frame 0 is used for facings smaller than 20 or larger than 999.
 		static readonly int[] SpriteRanges =
 		{
-			5, 14, 22, 33, 39, 46, 53, 60,
-			67, 74, 81, 88, 96, 104, 113, 122,
-			133, 142, 151, 161, 167, 174, 181, 188,
-			195, 202, 209, 216, 224, 232, 241, 250
+			20, 56, 88, 132, 156, 184, 212, 240,
+			268, 296, 324, 352, 384, 416, 452, 488,
+			532, 568, 604, 644, 668, 696, 724, 752,
+			780, 808, 836, 864, 896, 928, 964, 1000
 		};
 
 		// The actual facing associated with each sprite frame.
-		static readonly int[] SpriteFacings =
+		static readonly WAngle[] SpriteFacings =
 		{
-			0, 10, 18, 28, 36, 43, 50, 57,
-			64, 71, 78, 85, 92, 100, 109, 118,
-			128, 138, 147, 156, 164, 171, 178, 185,
-			192, 199, 206, 213, 220, 228, 237, 246
+			WAngle.Zero, new WAngle(40), new WAngle(74), new WAngle(112), new WAngle(146), new WAngle(172), new WAngle(200), new WAngle(228),
+			new WAngle(256), new WAngle(284), new WAngle(312), new WAngle(340), new WAngle(370), new WAngle(402), new WAngle(436), new WAngle(472),
+			new WAngle(512), new WAngle(552), new WAngle(588), new WAngle(626), new WAngle(658), new WAngle(684), new WAngle(712), new WAngle(740),
+			new WAngle(768), new WAngle(796), new WAngle(824), new WAngle(852), new WAngle(882), new WAngle(914), new WAngle(948), new WAngle(984)
 		};
 
 		/// <summary>
@@ -39,12 +39,13 @@ namespace OpenRA.Mods.Cnc
 		/// should be used for the given facing value, accounting
 		/// for the non-linear facing mapping for sprites with 32 directions.
 		/// </summary>
-		public static int ClassicIndexFacing(int facing, int numFrames)
+		public static int ClassicIndexFacing(WAngle facing, int numFrames)
 		{
 			if (numFrames == 32)
 			{
+				var angle = facing.Angle;
 				for (var i = 0; i < SpriteRanges.Length; i++)
-					if (facing < SpriteRanges[i])
+					if (angle < SpriteRanges[i])
 						return i;
 
 				return 0;
@@ -57,7 +58,7 @@ namespace OpenRA.Mods.Cnc
 		/// Rounds the given facing value to the nearest quantized step,
 		/// accounting for the non-linear facing mapping for sprites with 32 directions.
 		/// </summary>
-		public static int ClassicQuantizeFacing(int facing, int steps)
+		public static WAngle ClassicQuantizeFacing(WAngle facing, int steps)
 		{
 			if (steps == 32)
 				return SpriteFacings[ClassicIndexFacing(facing, steps)];

--- a/OpenRA.Mods.Common/Activities/HarvestResource.cs
+++ b/OpenRA.Mods.Common/Activities/HarvestResource.cs
@@ -72,11 +72,11 @@ namespace OpenRA.Mods.Common.Activities
 			// Turn to one of the harvestable facings
 			if (harvInfo.HarvestFacings != 0)
 			{
-				var current = facing.Facing;
+				var current = WAngle.FromFacing(facing.Facing);
 				var desired = body.QuantizeFacing(current, harvInfo.HarvestFacings);
 				if (desired != current)
 				{
-					QueueChild(new Turn(self, desired));
+					QueueChild(new Turn(self, desired.Facing));
 					return false;
 				}
 			}

--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -395,7 +395,7 @@ namespace OpenRA.Mods.Common.Graphics
 
 		protected virtual int GetFacingFrameOffset(WAngle facing)
 		{
-			return Util.QuantizeFacing(facing.Facing, Facings);
+			return Util.IndexFacing(facing.Facing, Facings);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
+++ b/OpenRA.Mods.Common/Graphics/DefaultSpriteSequence.cs
@@ -395,7 +395,7 @@ namespace OpenRA.Mods.Common.Graphics
 
 		protected virtual int GetFacingFrameOffset(WAngle facing)
 		{
-			return Util.IndexFacing(facing.Facing, Facings);
+			return Util.IndexFacing(facing, Facings);
 		}
 	}
 }

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -176,7 +176,7 @@ namespace OpenRA.Mods.Common.Traits
 					var sequence = a.Info.MuzzleSequence;
 
 					if (a.Info.MuzzleSplitFacings > 0)
-						sequence += Util.QuantizeFacing(muzzleFacing, a.Info.MuzzleSplitFacings).ToString();
+						sequence += Util.IndexFacing(muzzleFacing, a.Info.MuzzleSplitFacings).ToString();
 
 					var muzzleFlash = new AnimationWithOffset(muzzleAnim,
 						() => PortOffset(self, port),

--- a/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackGarrisoned.cs
@@ -176,7 +176,7 @@ namespace OpenRA.Mods.Common.Traits
 					var sequence = a.Info.MuzzleSequence;
 
 					if (a.Info.MuzzleSplitFacings > 0)
-						sequence += Util.IndexFacing(muzzleFacing, a.Info.MuzzleSplitFacings).ToString();
+						sequence += Util.IndexFacing(targetYaw, a.Info.MuzzleSplitFacings).ToString();
 
 					var muzzleFlash = new AnimationWithOffset(muzzleAnim,
 						() => PortOffset(self, port),

--- a/OpenRA.Mods.Common/Traits/BodyOrientation.cs
+++ b/OpenRA.Mods.Common/Traits/BodyOrientation.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual int QuantizeFacing(int facing, int facings)
 		{
-			return Util.QuantizeFacing(facing, facings) * (256 / facings);
+			return Util.QuantizeFacing(facing, facings);
 		}
 
 		public override object Create(ActorInitializer init) { return new BodyOrientation(init, this); }

--- a/OpenRA.Mods.Common/Traits/BodyOrientation.cs
+++ b/OpenRA.Mods.Common/Traits/BodyOrientation.cs
@@ -44,13 +44,13 @@ namespace OpenRA.Mods.Common.Traits
 				return orientation;
 
 			// Map yaw to the closest facing
-			var facing = QuantizeFacing(orientation.Yaw.Angle / 4, facings);
+			var facing = QuantizeFacing(orientation.Yaw, facings);
 
 			// Roll and pitch are always zero if yaw is quantized
-			return new WRot(WAngle.Zero, WAngle.Zero, WAngle.FromFacing(facing));
+			return WRot.FromYaw(facing);
 		}
 
-		public virtual int QuantizeFacing(int facing, int facings)
+		public virtual WAngle QuantizeFacing(WAngle facing, int facings)
 		{
 			return Util.QuantizeFacing(facing, facings);
 		}
@@ -106,12 +106,12 @@ namespace OpenRA.Mods.Common.Traits
 			return info.QuantizeOrientation(orientation, quantizedFacings.Value);
 		}
 
-		public int QuantizeFacing(int facing)
+		public WAngle QuantizeFacing(WAngle facing)
 		{
 			return info.QuantizeFacing(facing, quantizedFacings.Value);
 		}
 
-		public int QuantizeFacing(int facing, int facings)
+		public WAngle QuantizeFacing(WAngle facing, int facings)
 		{
 			return info.QuantizeFacing(facing, facings);
 		}

--- a/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			var sequence = a.Info.MuzzleSequence;
 			if (a.Info.MuzzleSplitFacings > 0)
-				sequence += Util.IndexFacing(getFacing().Facing, a.Info.MuzzleSplitFacings).ToString();
+				sequence += Util.IndexFacing(getFacing(), a.Info.MuzzleSplitFacings).ToString();
 
 			visible[barrel] = true;
 			anims[barrel].Animation.PlayThen(sequence, () => visible[barrel] = false);

--- a/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMuzzleOverlay.cs
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 			var sequence = a.Info.MuzzleSequence;
 			if (a.Info.MuzzleSplitFacings > 0)
-				sequence += Util.QuantizeFacing(getFacing().Facing, a.Info.MuzzleSplitFacings).ToString();
+				sequence += Util.IndexFacing(getFacing().Facing, a.Info.MuzzleSplitFacings).ToString();
 
 			visible[barrel] = true;
 			anims[barrel].Animation.PlayThen(sequence, () => visible[barrel] = false);

--- a/OpenRA.Mods.Common/Traits/Turreted.cs
+++ b/OpenRA.Mods.Common/Traits/Turreted.cs
@@ -215,8 +215,7 @@ namespace OpenRA.Mods.Common.Traits
 
 			// Quantize orientation to match a rendered sprite
 			// Implies no pitch or yaw
-			var facing = body.QuantizeFacing(world.Yaw.Angle / 4, QuantizedFacings);
-			return new WRot(WAngle.Zero, WAngle.Zero, WAngle.FromFacing(facing));
+			return WRot.FromYaw(body.QuantizeFacing(world.Yaw, QuantizedFacings));
 		}
 
 		public void ModifyDeathActorInit(Actor self, TypeDictionary init)

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -50,17 +50,17 @@ namespace OpenRA.Mods.Common
 		/// Calculate the frame index (between 0..numFrames) that
 		/// should be used for the given facing value.
 		/// </summary>
-		public static int IndexFacing(int facing, int numFrames)
+		public static int IndexFacing(WAngle facing, int numFrames)
 		{
-			var step = 256 / numFrames;
-			var a = (facing + step / 2) & 0xff;
+			var step = 1024 / numFrames;
+			var a = (facing.Angle + step / 2) & 1023;
 			return a / step;
 		}
 
 		/// <summary>Rounds the given facing value to the nearest quantized step.</summary>
-		public static int QuantizeFacing(int facing, int steps)
+		public static WAngle QuantizeFacing(WAngle facing, int steps)
 		{
-			return IndexFacing(facing, steps) * (256 / steps);
+			return new WAngle(IndexFacing(facing, steps) * (1024 / steps));
 		}
 
 		/// <summary>Wraps an arbitrary integer facing value into the range 0 - 255</summary>

--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -46,11 +46,21 @@ namespace OpenRA.Mods.Common
 			return facing + turn;
 		}
 
-		public static int QuantizeFacing(int facing, int numFrames)
+		/// <summary>
+		/// Calculate the frame index (between 0..numFrames) that
+		/// should be used for the given facing value.
+		/// </summary>
+		public static int IndexFacing(int facing, int numFrames)
 		{
 			var step = 256 / numFrames;
 			var a = (facing + step / 2) & 0xff;
 			return a / step;
+		}
+
+		/// <summary>Rounds the given facing value to the nearest quantized step.</summary>
+		public static int QuantizeFacing(int facing, int steps)
+		{
+			return IndexFacing(facing, steps) * (256 / steps);
 		}
 
 		/// <summary>Wraps an arbitrary integer facing value into the range 0 - 255</summary>


### PR DESCRIPTION
This PR follows up #18058 with another small step towards converting facings to WAngle. The facing quantization code is particularly fiddly, so this PR focuses just on getting that right.

In addition to converting to WAngle, this also fixes a long-standing bug that nobody had noticed - we were accounting for the non-linear mapping when calculating the sprite frame, but *not* when converting this back to a facing. This caused a small misalignment in muzzle angle at diagonal facings:

Before:
<img src="https://user-images.githubusercontent.com/167819/81498777-b8cb6380-92be-11ea-9004-c165f677b860.png">

After:
<img src="https://user-images.githubusercontent.com/167819/81498786-bec14480-92be-11ea-8279-5ddd261e3c2a.png">
