### PR TITLE
Refactor RA TargetTypes

### DIFF
--- a/mods/ra/maps/allies-03a/weapons.yaml
+++ b/mods/ra/maps/allies-03a/weapons.yaml
@@ -1,3 +1,3 @@
 BarrelExplode:
 	Warhead@1Dam: SpreadDamage
-		ValidTargets: Ground, Prisoner
+		ValidTargets: Ground, GroundActor, Prisoner

--- a/mods/ra/maps/allies-03b/rules.yaml
+++ b/mods/ra/maps/allies-03b/rules.yaml
@@ -96,7 +96,7 @@ DOG:
 TRUK:
 	-Demolishable:
 	Targetable:
-		TargetTypes: Ground, Truk
+		TargetTypes: GroundActor, Truk
 	Armor:
 		Type: Truk
 

--- a/mods/ra/maps/allies-03b/weapons.yaml
+++ b/mods/ra/maps/allies-03b/weapons.yaml
@@ -7,4 +7,4 @@ Colt45:
 
 BarrelExplode:
 	Warhead@1Dam: SpreadDamage
-		ValidTargets: Ground, Prisoner
+		ValidTargets: Ground, GroundActor, Prisoner

--- a/mods/ra/maps/allies-03b/weapons.yaml
+++ b/mods/ra/maps/allies-03b/weapons.yaml
@@ -1,5 +1,5 @@
 Colt45:
-	ValidTargets: Ground, Infantry, Truk
+	ValidTargets: Ground, GroundActor, Infantry, Truk
 	Warhead@1Dam: SpreadDamage
 		ValidTargets: Barrel, Infantry, Truk
 		Versus:

--- a/mods/ra/maps/allies-05a/rules.yaml
+++ b/mods/ra/maps/allies-05a/rules.yaml
@@ -35,7 +35,7 @@ SAM:
 LST:
 	-Selectable:
 	Targetable:
-		TargetTypes: Ground, Water
+		TargetTypes: GroundActor, WaterActor
 	Interactable:
 
 LST.IN:
@@ -50,7 +50,7 @@ TRAN:
 	RevealsShroud:
 		Range: 4c0
 	Targetable@GROUND:
-		TargetTypes: Ground
+		TargetTypes: GroundActor
 	Interactable:
 
 TRAN.IN:
@@ -82,14 +82,14 @@ SPY:
 WEAP:
 	-InfiltrateForSupportPower:
 	Targetable:
-		TargetTypes: Ground, C4, DetonateAttack, Structure
+		TargetTypes: GroundActor, C4, DetonateAttack, Structure
 
 WEAP.infiltratable:
 	Inherits: WEAP
 	Buildable:
 		Prerequisites: ~disabled
 	Targetable@Spy:
-		TargetTypes: Ground, C4, DetonateAttack, Structure, Mission Objectives
+		TargetTypes: GroundActor, C4, DetonateAttack, Structure, Mission Objectives
 	RenderSprites:
 		Image: WEAP
 	ProvidesPrerequisite:
@@ -99,7 +99,7 @@ MISS:
 	Tooltip:
 		Name: Prison
 	Targetable:
-		TargetTypes: Ground, C4, DetonateAttack, Structure, Mission Objectives
+		TargetTypes: GroundActor, C4, DetonateAttack, Structure, Mission Objectives
 	AttackOmni:
 	Armament:
 		Weapon: PrisonColt

--- a/mods/ra/maps/allies-05a/weapons.yaml
+++ b/mods/ra/maps/allies-05a/weapons.yaml
@@ -1,4 +1,5 @@
 PrisonColt:
+	ValidTargets: Ground, GroundActor
 	ReloadDelay: 5
 	Report: gun5.aud
 	Projectile: InstantHit

--- a/mods/ra/maps/allies-06a/rules.yaml
+++ b/mods/ra/maps/allies-06a/rules.yaml
@@ -48,7 +48,7 @@ TRUK:
 
 STEK:
 	Targetable:
-		TargetTypes: Ground, Structure, C4, DetonateAttack, SpyInfiltrate
+		TargetTypes: GroundActor, Structure, C4, DetonateAttack, SpyInfiltrate
 
 TECH.CAM:
 	Inherits: CAMERA

--- a/mods/ra/maps/allies-06b/rules.yaml
+++ b/mods/ra/maps/allies-06b/rules.yaml
@@ -50,7 +50,7 @@ TECH.CAM:
 
 STEK:
 	Targetable:
-		TargetTypes: Ground, Structure, C4, DetonateAttack, SpyInfiltrate
+		TargetTypes: GroundActor, Structure, C4, DetonateAttack, SpyInfiltrate
 
 APWR:
 	Buildable:

--- a/mods/ra/maps/fort-lonestar/weapons.yaml
+++ b/mods/ra/maps/fort-lonestar/weapons.yaml
@@ -23,7 +23,7 @@
 MammothTusk:
 	ReloadDelay: 300
 	Range: 10c0
-	ValidTargets: Ground, Air
+	ValidTargets: Ground, GroundActor, AirborneActor
 	Projectile: Missile
 		Blockable: false
 		Speed: 128
@@ -49,7 +49,7 @@ TankNapalm:
 	ReloadDelay: 40
 	Range: 8c0
 	Report: aacanon3.aud
-	ValidTargets: Ground
+	ValidTargets: Ground, GroundActor
 	Burst: 6
 	BurstDelays: 1
 	Projectile: Bullet
@@ -124,7 +124,7 @@ FLAK-23:
 	ReloadDelay: 10
 	Range: 8c0
 	Report: aacanon3.aud
-	ValidTargets: Air, Ground
+	ValidTargets: AirborneActor, Ground, GroundActor
 	Projectile: Bullet
 		Speed: 1c682
 		Blockable: false

--- a/mods/ra/maps/fort-lonestar/weapons.yaml
+++ b/mods/ra/maps/fort-lonestar/weapons.yaml
@@ -34,7 +34,7 @@ MammothTusk:
 		RangeLimit: 12c0
 	Warhead@1Dam: SpreadDamage
 		Spread: 640
-		ValidTargets: Ground, Air
+		ValidTargets: GroundActor, AirborneActor
 		Versus:
 			None: 125
 			Wood: 110
@@ -61,7 +61,7 @@ TankNapalm:
 		Blockable: false
 	Warhead: SpreadDamage
 		Spread: 341
-		ValidTargets: Ground
+		ValidTargets: GroundActor
 		Versus:
 			None: 65
 			Wood: 125
@@ -130,7 +130,7 @@ FLAK-23:
 		Blockable: false
 	Warhead: SpreadDamage
 		Spread: 213
-		ValidTargets: Air, Ground
+		ValidTargets: AirborneActor, GroundActor
 		Versus:
 			None: 32
 			Wood: 28

--- a/mods/ra/maps/infiltration/rules.yaml
+++ b/mods/ra/maps/infiltration/rules.yaml
@@ -33,7 +33,7 @@ World:
 
 MISS:
 	Targetable:
-		TargetTypes: Ground, C4, DetonateAttack, Structure, MissionObjective, NoAutoTarget
+		TargetTypes: GroundActor, C4, DetonateAttack, Structure, MissionObjective, NoAutoTarget
 
 LST.Unselectable.UnloadOnly:
 	Inherits: LST
@@ -45,7 +45,7 @@ LST.Unselectable.UnloadOnly:
 	Cargo:
 		MaxWeight: 0
 	Targetable:
-		TargetTypes: Ground, Water, Repair, NoAutoTarget
+		TargetTypes: GroundActor, Water, Repair, NoAutoTarget
 	Interactable:
 
 SPY.Strong:
@@ -90,7 +90,7 @@ TRUK.Hijackable:
 		PassengerConditions:
 			spy.strong: mobile
 	Targetable:
-		TargetTypes: Ground, Repair, Vehicle, NoAutoTarget
+		TargetTypes: GroundActor, Repair, Vehicle, NoAutoTarget
 	-Huntable:
 	Capturable:
 		Types: MissionObjective

--- a/mods/ra/maps/monster-tank-madness/rules.yaml
+++ b/mods/ra/maps/monster-tank-madness/rules.yaml
@@ -195,7 +195,7 @@ DOME.NoInfiltrate:
 		Image: DOME
 	-InfiltrateForExploration:
 	Targetable:
-		TargetTypes: Ground, Structure, C4, DetonateAttack, MissionObjective
+		TargetTypes: GroundActor, Structure, C4, DetonateAttack, MissionObjective
 	ProvidesPrerequisite:
 		Prerequisite: dome
 

--- a/mods/ra/maps/soviet-soldier-volkov-n-chitzkoi/weapons.yaml
+++ b/mods/ra/maps/soviet-soldier-volkov-n-chitzkoi/weapons.yaml
@@ -10,8 +10,8 @@ VolkovWeapon:
 	Inherits: SilencedPPK
 	ReloadDelay: 25
 	Range: 6c0
-	-ValidTargets:
-	InvalidTargets: Air, Bridge, Structure
+	ValidTargets: Ground, GroundActor, Water, WaterActor
+	InvalidTargets: Bridge, Structure
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Versus:

--- a/mods/ra/rules/civilian.yaml
+++ b/mods/ra/rules/civilian.yaml
@@ -304,7 +304,7 @@ V19:
 	SpawnActorOnDeath:
 		Actor: V19.Husk
 	Targetable:
-		TargetTypes: Ground, C4, DetonateAttack, Structure, NoAutoTarget
+		TargetTypes: GroundActor, C4, DetonateAttack, Structure, NoAutoTarget
 
 V19.Husk:
 	Inherits: ^CivBuilding
@@ -338,7 +338,7 @@ BARL:
 	Armor:
 		Type: None
 	Targetable:
-		TargetTypes: Ground, DemoTruck, Barrel, NoAutoTarget
+		TargetTypes: GroundActor, DemoTruck, Barrel, NoAutoTarget
 	-ShakeOnDeath:
 	-SoundOnDamageTransition:
 	-Demolishable:
@@ -360,7 +360,7 @@ BRL3:
 	Armor:
 		Type: None
 	Targetable:
-		TargetTypes: Ground, DemoTruck, Barrel, NoAutoTarget
+		TargetTypes: GroundActor, DemoTruck, Barrel, NoAutoTarget
 	-ShakeOnDeath:
 	-SoundOnDamageTransition:
 	-Demolishable:

--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -197,7 +197,7 @@
 ^AutoTargetAir:
 	AutoTarget:
 	AutoTargetPriority@DEFAULT:
-		ValidTargets: Air
+		ValidTargets: AirborneActor
 		InvalidTargets: NoAutoTarget
 
 ^AutoTargetAll:
@@ -205,11 +205,11 @@
 		AttackAnythingCondition: stance-attackanything
 	AutoTargetPriority@DEFAULT:
 		RequiresCondition: !stance-attackanything
-		ValidTargets: Infantry, Vehicle, Ship, Underwater, Air, Defense, Mine
+		ValidTargets: Infantry, Vehicle, Ship, Underwater, AirborneActor, Defense, Mine
 		InvalidTargets: NoAutoTarget
 	AutoTargetPriority@ATTACKANYTHING:
 		RequiresCondition: stance-attackanything
-		ValidTargets: Infantry, Vehicle, Ship, Underwater, Air, Structure, Defense, Mine
+		ValidTargets: Infantry, Vehicle, Ship, Underwater, AirborneActor, Structure, Defense, Mine
 		InvalidTargets: NoAutoTarget
 
 ^AutoTargetAllAssaultMove:
@@ -246,7 +246,7 @@
 		Bounds: 24, 24
 	Targetable:
 		RequiresCondition: !parachute
-		TargetTypes: Ground, Vehicle
+		TargetTypes: GroundActor, Vehicle
 	Targetable@REPAIR:
 		RequiresCondition: !parachute && damaged
 		TargetTypes: Repair
@@ -331,7 +331,7 @@
 		DecorationBounds: 12,18,0,-8
 	Targetable:
 		RequiresCondition: !parachute
-		TargetTypes: Ground, Infantry, Disguise
+		TargetTypes: GroundActor, Infantry, Disguise
 	Targetable@HEAL:
 		RequiresCondition: !parachute && damaged
 		TargetTypes: Heal
@@ -490,7 +490,7 @@
 	Selectable:
 		Bounds: 24,24
 	Targetable:
-		TargetTypes: Ground, Water, Ship
+		TargetTypes: WaterActor, Ship
 	Targetable@REPAIR:
 		RequiresCondition: damaged
 		TargetTypes: Repair
@@ -544,10 +544,10 @@
 		AirborneCondition: airborne
 	Targetable@GROUND:
 		RequiresCondition: !airborne
-		TargetTypes: Ground, Vehicle
+		TargetTypes: GroundActor, Vehicle
 	Targetable@AIRBORNE:
 		RequiresCondition: airborne
-		TargetTypes: Air
+		TargetTypes: AirborneActor
 	Targetable@REPAIR:
 		RequiresCondition: !airborne && damaged
 		TargetTypes: Repair
@@ -625,7 +625,7 @@
 	Inherits@bounty: ^GlobalBounty
 	Inherits@selection: ^SelectableBuilding
 	Targetable:
-		TargetTypes: Ground, C4, DetonateAttack, Structure
+		TargetTypes: GroundActor, C4, DetonateAttack, Structure
 	Building:
 		Dimensions: 1,1
 		Footprint: x
@@ -712,7 +712,7 @@
 	Selectable:
 		Bounds: 24,24
 	Targetable:
-		TargetTypes: Ground, C4, DetonateAttack, Structure, Defense
+		TargetTypes: GroundActor, C4, DetonateAttack, Structure, Defense
 	MustBeDestroyed:
 		RequiredForShortGame: false
 	-GivesBuildableArea:
@@ -755,7 +755,7 @@
 	LineBuildNode:
 		Types: wall
 	Targetable:
-		TargetTypes: Ground, DetonateAttack, Wall, NoAutoTarget
+		TargetTypes: GroundActor, DetonateAttack, Wall, NoAutoTarget
 	-GivesExperience:
 	RenderSprites:
 		Palette: effect
@@ -814,7 +814,7 @@
 
 ^InfiltratableFake:
 	Targetable:
-		TargetTypes: Ground, Structure, C4, DetonateAttack, SpyInfiltrate
+		TargetTypes: GroundActor, Structure, C4, DetonateAttack, SpyInfiltrate
 	InfiltrateForDecoration:
 		Types: SpyInfiltrate
 		Position: Top
@@ -833,7 +833,7 @@
 	Tooltip:
 		Name: Ammo Box
 	Targetable:
-		TargetTypes: Ground, C4, DetonateAttack, Structure, NoAutoTarget
+		TargetTypes: GroundActor, C4, DetonateAttack, Structure, NoAutoTarget
 	Armor:
 		Type: Light
 	MapEditorData:
@@ -997,7 +997,7 @@
 	WithColoredOverlay@IDISABLE:
 		Palette: disabled
 	Targetable:
-		TargetTypes: Ground, Husk, NoAutoTarget
+		TargetTypes: GroundActor, Husk, NoAutoTarget
 		RequiresForceFire: true
 	Chronoshiftable:
 	Tooltip:
@@ -1048,7 +1048,7 @@
 		Name: Bridge
 		ShowOwnerRow: false
 	Targetable:
-		TargetTypes: Ground, Water, Bridge
+		TargetTypes: GroundActor, WaterActor, Bridge
 		RequiresForceFire: true
 	Building:
 		Footprint: ____ ____
@@ -1157,7 +1157,7 @@
 	Tooltip:
 		Name: Mine
 	Targetable:
-		TargetTypes: Ground, Mine
+		TargetTypes: GroundActor, Mine
 	Immobile:
 		OccupiesSpace: true
 	HitShape:

--- a/mods/ra/rules/fakes.yaml
+++ b/mods/ra/rules/fakes.yaml
@@ -83,7 +83,7 @@ SYRF:
 		GenericVisibility: Enemy
 		GenericStancePrefix: False
 	Targetable:
-		TargetTypes: Ground, Water, Structure, SpyInfiltrate
+		TargetTypes: WaterActor, Structure, SpyInfiltrate
 	Building:
 		Footprint: XXX xxx XXX
 		Dimensions: 3,3
@@ -117,7 +117,7 @@ SPEF:
 	Selectable:
 		Bounds: 72,48
 	Targetable:
-		TargetTypes: Ground, Water, Structure, SpyInfiltrate
+		TargetTypes: WaterActor, Structure, SpyInfiltrate
 	Buildable:
 		BuildPaletteOrder: 890
 		Queue: Defense

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -47,7 +47,7 @@ DOG:
 	AutoTargetPriority@DEFAULT:
 		ValidTargets: Infantry
 	Targetable:
-		TargetTypes: Ground, Infantry
+		TargetTypes: GroundActor, Infantry
 	WithInfantryBody:
 		MoveSequence: walk
 		StandSequences: stand
@@ -763,7 +763,7 @@ Ant:
 	Armament:
 		Weapon: mandible
 	Targetable:
-		TargetTypes: Ground, Infantry, Ant
+		TargetTypes: GroundActor, Infantry, Ant
 	WithDeathAnimation:
 		UseDeathTypeSuffix: false
 	Voiced:

--- a/mods/ra/rules/ships.yaml
+++ b/mods/ra/rules/ships.yaml
@@ -27,7 +27,7 @@ SS:
 	RevealsShroud@GAPGEN:
 		Range: 5c0
 	Targetable:
-		TargetTypes: Ground, Water, Ship, Submarine, Repair
+		TargetTypes: WaterActor, Ship, Submarine, Repair
 		RequiresCondition: !underwater
 	Targetable@UNDERWATER:
 		TargetTypes: Underwater, Submarine
@@ -53,9 +53,9 @@ SS:
 		InitialStance: HoldFire
 		InitialStanceAI: ReturnFire
 	AutoTargetPriority@DEFAULT:
-		ValidTargets: Water, Underwater
+		ValidTargets: WaterActor, Underwater
 	AutoTargetPriority@ATTACKANYTHING:
-		ValidTargets: Water, Underwater
+		ValidTargets: WaterActor, Underwater
 	DetectCloaked:
 		CloakTypes: Underwater
 		Range: 4c0
@@ -96,7 +96,7 @@ MSUB:
 	RevealsShroud@GAPGEN:
 		Range: 5c0
 	Targetable:
-		TargetTypes: Ground, Water, Ship, Submarine, Repair
+		TargetTypes: WaterActor, Ship, Submarine, Repair
 		RequiresCondition: !underwater
 	Targetable@UNDERWATER:
 		TargetTypes: Underwater, Submarine

--- a/mods/ra/rules/structures.yaml
+++ b/mods/ra/rules/structures.yaml
@@ -61,7 +61,7 @@ MSLO:
 	InfiltrateForSupportPowerReset:
 		Types: SpyInfiltrate
 	Targetable:
-		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
+		TargetTypes: GroundActor, C4, DetonateAttack, Structure, SpyInfiltrate
 	Power:
 		Amount: -150
 	MustBeDestroyed:
@@ -133,7 +133,7 @@ SPEN:
 		Prerequisites: anypower, ~structures.soviet, ~techlevel.low
 		Description: Produces and repairs\nsubmarines and transports.
 	Targetable:
-		TargetTypes: Ground, Water, Structure, C4, DetonateAttack, SpyInfiltrate
+		TargetTypes: WaterActor, Structure, C4, DetonateAttack, SpyInfiltrate
 	Building:
 		Footprint: XXX xxx XXX
 		Dimensions: 3,3
@@ -272,7 +272,7 @@ SYRD:
 	Tooltip:
 		Name: Naval Yard
 	Targetable:
-		TargetTypes: Ground, Water, Structure, C4, DetonateAttack, SpyInfiltrate
+		TargetTypes: WaterActor, Structure, C4, DetonateAttack, SpyInfiltrate
 	Building:
 		Footprint: XXX xxx XXX
 		Dimensions: 3,3
@@ -433,7 +433,7 @@ IRON:
 	InfiltrateForSupportPowerReset:
 		Types: SpyInfiltrate
 	Targetable:
-		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
+		TargetTypes: GroundActor, C4, DetonateAttack, Structure, SpyInfiltrate
 	Power:
 		Amount: -200
 	MustBeDestroyed:
@@ -521,7 +521,7 @@ PDOX:
 	InfiltrateForSupportPowerReset:
 		Types: SpyInfiltrate
 	Targetable:
-		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
+		TargetTypes: GroundActor, C4, DetonateAttack, Structure, SpyInfiltrate
 	Power:
 		Amount: -200
 	MustBeDestroyed:
@@ -644,7 +644,7 @@ DOME:
 		Dimensions: 2,3
 		LocalCenterOffset: 0,-512,0
 	Targetable:
-		TargetTypes: Ground, Structure, C4, DetonateAttack, SpyInfiltrate
+		TargetTypes: GroundActor, Structure, C4, DetonateAttack, SpyInfiltrate
 	Health:
 		HP: 100000
 	Armor:
@@ -981,7 +981,7 @@ ATEK:
 	InfiltrateForSupportPowerReset:
 		Types: SpyInfiltrate
 	Targetable:
-		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
+		TargetTypes: GroundActor, C4, DetonateAttack, Structure, SpyInfiltrate
 	Power:
 		Amount: -200
 	ProvidesPrerequisite@buildingname:
@@ -1086,7 +1086,7 @@ WEAP:
 		Amount: -30
 	ProvidesPrerequisite@buildingname:
 	Targetable:
-		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
+		TargetTypes: GroundActor, C4, DetonateAttack, Structure, SpyInfiltrate
 	InfiltrateForSupportPower:
 		Proxy: vehicles.upgraded
 		Types: SpyInfiltrate
@@ -1227,7 +1227,7 @@ PROC:
 		Bounds: 72,50,0,4
 		DecorationBounds: 72,70,0,-2
 	Targetable:
-		TargetTypes: Ground, Structure, C4, DetonateAttack, ThiefInfiltrate, SpyInfiltrate
+		TargetTypes: GroundActor, Structure, C4, DetonateAttack, ThiefInfiltrate, SpyInfiltrate
 	Health:
 		HP: 90000
 	Armor:
@@ -1300,7 +1300,7 @@ SILO:
 	Valued:
 		Cost: 150
 	Targetable:
-		TargetTypes: Ground, Structure, C4, DetonateAttack, ThiefInfiltrate
+		TargetTypes: GroundActor, Structure, C4, DetonateAttack, ThiefInfiltrate
 	Tooltip:
 		Name: Silo
 	-GivesBuildableArea:
@@ -1415,7 +1415,7 @@ HPAD:
 		Prerequisite: aircraft.germany
 	ProvidesPrerequisite@buildingname:
 	Targetable:
-		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
+		TargetTypes: GroundActor, C4, DetonateAttack, Structure, SpyInfiltrate
 	InfiltrateForSupportPower:
 		Proxy: aircraft.upgraded
 		Types: SpyInfiltrate
@@ -1556,7 +1556,7 @@ AFLD:
 	ProvidesPrerequisite@buildingname:
 		Prerequisite: afld
 	Targetable:
-		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
+		TargetTypes: GroundActor, C4, DetonateAttack, Structure, SpyInfiltrate
 	InfiltrateForSupportPower:
 		Proxy: aircraft.upgraded
 		Types: SpyInfiltrate
@@ -1605,7 +1605,7 @@ POWR:
 	Power:
 		Amount: 100
 	Targetable:
-		TargetTypes: Ground, Structure, C4, DetonateAttack, SpyInfiltrate
+		TargetTypes: GroundActor, Structure, C4, DetonateAttack, SpyInfiltrate
 	ScalePowerWithHealth:
 	WithDeathAnimation:
 		DeathSequence: dead
@@ -1645,7 +1645,7 @@ APWR:
 	Power:
 		Amount: 200
 	Targetable:
-		TargetTypes: Ground, Structure, C4, DetonateAttack, SpyInfiltrate
+		TargetTypes: GroundActor, Structure, C4, DetonateAttack, SpyInfiltrate
 	ScalePowerWithHealth:
 	WithDeathAnimation:
 		DeathSequence: dead
@@ -1771,7 +1771,7 @@ BARR:
 		Proxy: barracks.upgraded
 		Types: SpyInfiltrate
 	Targetable:
-		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
+		TargetTypes: GroundActor, C4, DetonateAttack, Structure, SpyInfiltrate
 
 KENN:
 	Inherits: ^Building
@@ -1938,7 +1938,7 @@ TENT:
 		Proxy: barracks.upgraded
 		Types: SpyInfiltrate
 	Targetable:
-		TargetTypes: Ground, C4, DetonateAttack, Structure, SpyInfiltrate
+		TargetTypes: GroundActor, C4, DetonateAttack, Structure, SpyInfiltrate
 
 FIX:
 	Inherits: ^Building

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -517,7 +517,7 @@ MNLY:
 	Rearmable:
 		RearmActors: fix
 	Targetable:
-		TargetTypes: Ground, Vehicle, Mine
+		TargetTypes: GroundActor, Vehicle, Mine
 	WithAmmoPipsDecoration:
 		Position: BottomLeft
 		Margin: 4, 3
@@ -829,7 +829,7 @@ QTNK:
 		Color: FFFF0080
 		Range: 7c0
 	Targetable:
-		TargetTypes: Ground, MADTank, Vehicle
+		TargetTypes: GroundActor, MADTank, Vehicle
 	Selectable:
 		DecorationBounds: 44,38,0,-4
 

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -10,6 +10,7 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 4000
+		ValidTargets: GroundActor, WaterActor
 		Versus:
 			None: 30
 			Wood: 75
@@ -18,16 +19,16 @@
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
-		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees
+		ValidTargets: Ground, Infantry
 	Warhead@3Eff: CreateEffect
 		Explosions: small_explosion
 		ImpactSounds: kaboom12.aud
-		ValidTargets: Ground, Ship, Trees
+		ValidTargets: Ground, GroundActor, WaterActor, Trees
 	Warhead@4EffWater: CreateEffect
 		Explosions: small_splash
 		ImpactSounds: splash9.aud
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+		InvalidTargets: Bridge
 
 25mm:
 	Inherits: ^Cannon

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -2,6 +2,7 @@
 	ReloadDelay: 50
 	Range: 4c768
 	Report: cannon1.aud
+	ValidTargets: Ground, Water, GroundActor, WaterActor
 	Projectile: Bullet
 		Speed: 682
 		Image: 120MM

--- a/mods/ra/weapons/ballistics.yaml
+++ b/mods/ra/weapons/ballistics.yaml
@@ -207,11 +207,15 @@ DepthCharge:
 		Versus:
 			Light: 75
 		DamageTypes: ExplosionDeath
-	Warhead@4EffWater: CreateEffect
-		Explosions: large_splash
-		ImpactSounds: h2obomb2.aud
-		ValidTargets: Water, Underwater
 	Warhead@3Eff: CreateEffect
-		Explosions: small_explosion
+		Explosions: med_explosion
 		ImpactSounds: kaboom15.aud
 		ValidTargets: Submarine
+		InvalidTargets: Underwater
+	Warhead@4EffWater: CreateEffect
+		Explosions: large_splash
+		ImpactSounds: splash9.aud
+		ValidTargets: Water, Underwater
+	Warhead@5EffSubmergedHitSound: CreateEffect
+		ImpactSounds: h2obomb2.aud
+		ValidTargets: Underwater

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -3,6 +3,7 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 5000
+		ValidTargets: GroundActor, WaterActor
 		Versus:
 			None: 90
 			Wood: 75
@@ -12,16 +13,16 @@
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@Smu: LeaveSmudge
 		SmudgeType: Crater
-		InvalidTargets: Structure, Wall, Trees
+		ValidTargets: Ground, Vehicle, Infantry
 	Warhead@2Eff: CreateEffect
 		Explosions: self_destruct
 		ImpactSounds: kaboom22.aud
-		ValidTargets: Ground, Air, Ship, Trees
+		ValidTargets: Ground, Air, GroundActor, AirborneActor, WaterActor, Trees
 	Warhead@3EffWater: CreateEffect
 		Explosions: large_splash
 		ImpactSounds: splash9.aud
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+		InvalidTargets: Bridge
 
 CrateNapalm:
 	Inherits: ^Explosion
@@ -30,7 +31,7 @@ CrateNapalm:
 		Spread: 170
 		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		ValidTargets: Ground, Trees
+		ValidTargets: GroundActor, WaterActor, Trees
 		Versus:
 			Wood: 100
 			Concrete: 50
@@ -39,7 +40,7 @@ CrateNapalm:
 	Warhead@2Eff: CreateEffect
 		Explosions: napalm
 		ImpactSounds: firebl3.aud
-		ValidTargets: Ground, Water, Air, Trees
+		ValidTargets: Ground, Water, Air, GroundActor, AirborneActor, WaterActor, Trees
 	-Warhead@3EffWater:
 	Warhead@Smu: LeaveSmudge
 		SmudgeType: Scorch
@@ -50,7 +51,7 @@ CrateExplosion:
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		AffectsParent: true
 	Warhead@2Eff: CreateEffect
-		ValidTargets: Ground, Water, Air
+		ValidTargets: Ground, Water, Air, GroundActor, AirborneActor, WaterActor, Trees
 	-Warhead@3EffWater:
 
 UnitExplode:
@@ -82,6 +83,7 @@ UnitExplodeShip:
 		Explosions: building
 		ImpactSounds: kaboom25.aud
 		ValidTargets: Ground, Water
+		ImpactActors: false
 
 UnitExplodeSubmarine:
 	Inherits: ^Explosion
@@ -90,6 +92,7 @@ UnitExplodeSubmarine:
 		Explosions: large_splash
 		ImpactSounds: splash9.aud
 		ValidTargets: Ground, Water
+		ImpactActors: false
 
 UnitExplodeSmall:
 	Inherits: ^Explosion
@@ -117,7 +120,8 @@ BuildingExplode:
 		Explosions: building, building_napalm, large_explosion, self_destruct, large_napalm
 	Warhead@Smu: LeaveSmudge
 		SmudgeType: Crater
-		InvalidTargets: Wall, Trees
+		ValidTargets: GroundActor
+		InvalidTargets: Wall
 
 SmallBuildingExplode:
 	Inherits: BuildingExplode
@@ -127,6 +131,7 @@ SmallBuildingExplode:
 CivPanicExplosion:
 	ValidTargets: Ground, GroundActor
 	Warhead@1Dam: SpreadDamage # Used to panic civilians which are emitted from a killed CivBuilding
+		ValidTargets: Infantry
 		Falloff: 100, 100
 		Range: 0, 128
 		Damage: 1
@@ -160,14 +165,17 @@ ATMine:
 		Spread: 256
 		Damage: 40000
 		AffectsParent: true
+		ValidTargets: GroundActor, WaterActor
 		InvalidTargets: Mine
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: large_explosion
 		ImpactSounds: mineblo1.aud
+		ImpactActors: false
 	Warhead@Smu: LeaveSmudge
 		SmudgeType: Crater
-		InvalidTargets: Structure, Wall, Trees
+		ValidTargets: Ground, GroundActor
+		InvalidTargets: Structure, Wall
 
 APMine:
 	Inherits: ATMine
@@ -184,6 +192,7 @@ OreExplosion:
 	Warhead@1Dam: SpreadDamage
 		Spread: 9
 		Damage: 1000
+		ValidTargets: GroundActor, WaterActor
 		Versus:
 			None: 90
 			Wood: 70
@@ -196,6 +205,7 @@ OreExplosion:
 	Warhead@2Eff: CreateEffect
 		Explosions: med_explosion
 		ImpactSounds: kaboom25.aud
+		ImpactActors: false
 
 CrateNuke:
 	ValidTargets: Ground, GroundActor, Trees, Water, WaterActor, Underwater, Air, AirborneActor
@@ -203,7 +213,7 @@ CrateNuke:
 		Spread: 1c0
 		Damage: 10000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		ValidTargets: Ground, Trees, Water, Air
+		ValidTargets: GroundActor, Trees, WaterActor, AirborneActor
 		Versus:
 			Concrete: 25
 		AffectsParent: true
@@ -218,7 +228,7 @@ CrateNuke:
 		Damage: 6000
 		Falloff: 1000, 600, 400, 250, 150, 100, 0
 		Delay: 5
-		ValidTargets: Ground, Water, Air
+		ValidTargets: GroundActor, WaterActor, AirborneActor
 		Versus:
 			Concrete: 25
 		AffectsParent: true
@@ -232,7 +242,7 @@ CrateNuke:
 		ImpactActors: false
 	Warhead@6Smu_areanuke1: LeaveSmudge
 		SmudgeType: Scorch
-		InvalidTargets: Vehicle, Structure, Wall, Trees
+		ValidTargets: Ground, Infantry
 		Size: 4
 		Delay: 5
 	Warhead@TREEKILL: SpreadDamage
@@ -249,7 +259,7 @@ MiniNuke:
 		Spread: 1c0
 		Damage: 15000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		ValidTargets: Ground, Trees, Water, Air
+		ValidTargets: GroundActor, Trees, WaterActor, Underwater, AirborneActor
 		Versus:
 			Wood: 25
 			Concrete: 25
@@ -266,7 +276,7 @@ MiniNuke:
 		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 5
-		ValidTargets: Ground, Trees, Water, Underwater, Air
+		ValidTargets: GroundActor, Trees, WaterActor, Underwater, AirborneActor
 		Versus:
 			Wood: 50
 			Concrete: 25
@@ -284,7 +294,7 @@ MiniNuke:
 		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 10
-		ValidTargets: Ground, Water, Underwater, Air
+		ValidTargets: GroundActor, WaterActor, Underwater, AirborneActor
 		Versus:
 			Wood: 50
 			Concrete: 25
@@ -305,7 +315,7 @@ MiniNuke:
 		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 15
-		ValidTargets: Ground, Water, Underwater
+		ValidTargets: GroundActor, WaterActor, Underwater
 		Versus:
 			Concrete: 25
 		AffectsParent: true
@@ -322,6 +332,6 @@ MiniNuke:
 		Delay: 15
 	Warhead@13Smu_areanuke3: LeaveSmudge
 		SmudgeType: Scorch
-		InvalidTargets: Vehicle, Structure, Wall, Trees
+		ValidTargets: Ground, Infantry
 		Size: 4
 		Delay: 15

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -84,6 +84,9 @@ UnitExplodeShip:
 		ImpactSounds: kaboom25.aud
 		ValidTargets: Ground, Water
 		ImpactActors: false
+	Warhead@3EffWater: CreateEffect
+		ValidTargets: Water
+		ImpactActors: false
 
 UnitExplodeSubmarine:
 	Inherits: ^Explosion
@@ -91,8 +94,9 @@ UnitExplodeSubmarine:
 	Warhead@2Eff: CreateEffect
 		Explosions: large_splash
 		ImpactSounds: splash9.aud
-		ValidTargets: Ground, Water
+		ValidTargets: Water
 		ImpactActors: false
+	-Warhead@3EffWater:
 
 UnitExplodeSmall:
 	Inherits: ^Explosion

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -1,5 +1,5 @@
 ^Explosion:
-	ValidTargets: Ground, Water, Air
+	ValidTargets: Ground, Water, Air, GroundActor, WaterActor, AirborneActor
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 5000
@@ -25,7 +25,7 @@
 
 CrateNapalm:
 	Inherits: ^Explosion
-	ValidTargets: Ground, Trees
+	ValidTargets: Ground, GroundActor, WaterActor, Trees
 	Warhead@1Dam: SpreadDamage
 		Spread: 170
 		Damage: 6000
@@ -112,6 +112,7 @@ V2Explode:
 	-Report:
 
 BuildingExplode:
+	ValidTargets: Ground, Water, GroundActor, WaterActor
 	Warhead@2Eff: CreateEffect
 		Explosions: building, building_napalm, large_explosion, self_destruct, large_napalm
 	Warhead@Smu: LeaveSmudge
@@ -124,6 +125,7 @@ SmallBuildingExplode:
 		Explosions: building, building_napalm, large_explosion, self_destruct
 
 CivPanicExplosion:
+	ValidTargets: Ground, GroundActor
 	Warhead@1Dam: SpreadDamage # Used to panic civilians which are emitted from a killed CivBuilding
 		Falloff: 100, 100
 		Range: 0, 128
@@ -153,6 +155,7 @@ BarrelExplode:
 		Delay: 5
 
 ATMine:
+	ValidTargets: Ground, Water, GroundActor, WaterActor
 	Warhead@1Dam: SpreadDamage
 		Spread: 256
 		Damage: 40000
@@ -177,6 +180,7 @@ APMine:
 		SmudgeType: Scorch
 
 OreExplosion:
+	ValidTargets: Ground, Water, GroundActor, WaterActor
 	Warhead@1Dam: SpreadDamage
 		Spread: 9
 		Damage: 1000
@@ -194,7 +198,7 @@ OreExplosion:
 		ImpactSounds: kaboom25.aud
 
 CrateNuke:
-	ValidTargets: Ground, Trees, Water, Air
+	ValidTargets: Ground, GroundActor, Trees, Water, WaterActor, Underwater, Air, AirborneActor
 	Warhead@1Dam_impact: SpreadDamage
 		Spread: 1c0
 		Damage: 10000
@@ -240,7 +244,7 @@ CrateNuke:
 		DamageTypes: Incendiary
 
 MiniNuke:
-	ValidTargets: Ground, Trees, Water, Underwater, Air
+	ValidTargets: Ground, GroundActor, Trees, Water, WaterActor, Underwater, Air, AirborneActor
 	Warhead@1Dam_impact: SpreadDamage
 		Spread: 1c0
 		Damage: 15000

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -17,7 +17,7 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 5000
-		ValidTargets: Ground, Water, Air
+		ValidTargets: GroundActor, WaterActor, AirborneActor
 		Versus:
 			None: 10
 			Wood: 74
@@ -27,16 +27,16 @@
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
-		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees
+		ValidTargets: Ground, Infantry
 	Warhead@3Eff: CreateEffect
 		Explosions: med_explosion
 		ImpactSounds: kaboom25.aud
-		ValidTargets: Ground, Air, Ship, Trees
+		ValidTargets: Ground, Air, GroundActor, AirborneActor, WaterActor, Trees
 	Warhead@4EffWater: CreateEffect
 		Explosions: med_splash
 		ImpactSounds: splash9.aud
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+		InvalidTargets: Bridge
 
 ^AntiAirMissile:
 	Inherits: ^AntiGroundMissile
@@ -104,7 +104,7 @@ HellfireAA:
 		CloseEnough: 0c600
 	Warhead@1Dam: SpreadDamage
 		Damage: 4000
-		ValidTargets: Air
+		ValidTargets: AirborneActor
 		Versus:
 			Wood: 75
 			Light: 75
@@ -132,11 +132,11 @@ MammothTusk:
 		DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 	Warhead@3Eff: CreateEffect
 		ImpactSounds: kaboom12.aud
-		ValidTargets: Ground, Trees
+		ValidTargets: Ground, GroundActor, Trees
 	Warhead@5EffAir: CreateEffect
 		Explosions: med_explosion_air
 		ImpactSounds: kaboom25.aud
-		ValidTargets: Air
+		ValidTargets: Air, AirborneActor
 
 Nike:
 	Inherits: ^AntiAirMissile
@@ -152,7 +152,7 @@ Nike:
 		Speed: 341
 	Warhead@1Dam: SpreadDamage
 		Damage: 5000
-		ValidTargets: Air
+		ValidTargets: AirborneActor
 		Versus:
 			Light: 90
 	Warhead@3Eff: CreateEffect
@@ -168,7 +168,7 @@ RedEye:
 		Speed: 298
 	Warhead@1Dam: SpreadDamage
 		Damage: 4000
-		ValidTargets: Air
+		ValidTargets: AirborneActor
 		Versus:
 			Light: 60
 
@@ -240,7 +240,7 @@ TorpTube:
 	Warhead@1Dam: SpreadDamage
 		Spread: 426
 		Damage: 18000
-		ValidTargets: Water, Underwater, Bridge
+		ValidTargets: WaterActor, Underwater, Bridge
 		Versus:
 			Wood: 75
 			Light: 75
@@ -250,12 +250,12 @@ TorpTube:
 	Warhead@3Eff: CreateEffect
 		Explosions: artillery_explosion
 		ImpactSounds: kaboom15.aud
-		ValidTargets: Ship, Structure, Underwater, Ground, Bridge
+		ValidTargets: Ground, WaterActor, Underwater, GroundActor, Bridge
 	Warhead@4EffWater: CreateEffect
 		Explosions: large_splash
 		ImpactSounds: splash9.aud
 		ValidTargets: Water
-		InvalidTargets: Ship, Structure, Underwater, Bridge
+		InvalidTargets: Bridge
 
 ^SubMissileDefault:
 	Inherits: ^AntiGroundMissile
@@ -329,7 +329,7 @@ SCUD:
 		Spread: 341
 		Damage: 4500
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		ValidTargets: Ground, Water, Trees
+		ValidTargets: GroundActor, WaterActor, Trees
 		Versus:
 			None: 90
 			Wood: 75

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -3,6 +3,7 @@
 	Range: 5c0
 	MinRange: 0c512
 	Report: missile6.aud
+	ValidTargets: Ground, Water, GroundActor, WaterActor
 	Projectile: Missile
 		Speed: 213
 		Arm: 2
@@ -39,7 +40,7 @@
 
 ^AntiAirMissile:
 	Inherits: ^AntiGroundMissile
-	ValidTargets: Air
+	ValidTargets: AirborneActor
 	Warhead@3Eff: CreateEffect
 		ImpactActors: false
 
@@ -115,7 +116,7 @@ MammothTusk:
 	ReloadDelay: 60
 	Range: 6c512
 	Burst: 2
-	ValidTargets: Air, Infantry
+	ValidTargets: AirborneActor, Infantry
 	Projectile: Missile
 		Speed: 341
 		HorizontalRateOfTurn: 15
@@ -196,7 +197,7 @@ Stinger:
 
 StingerAA:
 	Inherits: Stinger
-	ValidTargets: Air
+	ValidTargets: AirborneActor
 	Projectile: Missile
 		Speed: 255
 		CloseEnough: 298
@@ -222,7 +223,7 @@ TorpTube:
 	ReloadDelay: 100
 	Range: 9c0
 	Report: torpedo1.aud
-	ValidTargets: Water, Underwater, Bridge
+	ValidTargets: Water, WaterActor, Underwater, Bridge
 	Burst: 2
 	BurstDelays: 20
 	Projectile: Missile
@@ -304,7 +305,7 @@ SubMissile:
 
 SubMissileAA:
 	Inherits: ^SubMissileDefault
-	ValidTargets: Air
+	ValidTargets: AirborneActor
 	Warhead@1Dam: SpreadDamage
 		Damage: 1500
 

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -5,7 +5,7 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 15000
-		ValidTargets: Ground, Water, Trees
+		ValidTargets: GroundActor, WaterActor, Trees
 		Versus:
 			None: 90
 			Wood: 50
@@ -80,6 +80,7 @@ Napalm:
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 10000
+		ValidTargets: GroundActor, WaterActor
 		Versus:
 			None: 1000
 		DamageTypes: Prone50Percent, TriggerProne, ElectricityDeath
@@ -144,6 +145,7 @@ Demolish:
 	ValidTargets: GroundActor, WaterActor
 	Warhead@1Dam: SpreadDamage
 		DamageTypes: DefaultDeath
+		ValidTargets: GroundActor, WaterActor
 	Warhead@2Eff: CreateEffect
 		Explosions: building
 		ImpactSounds: kaboom25.aud
@@ -157,6 +159,7 @@ Claw:
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 3000
+		ValidTargets: GroundActor, WaterActor
 		Versus:
 			None: 97
 			Wood: 10
@@ -224,6 +227,7 @@ MADTankThump:
 	Warhead@1Dam: HealthPercentageDamage
 		Spread: 7c0
 		Damage: 1
+		ValidTargets: GroundActor, WaterActor
 		InvalidTargets: MADTank, Infantry
 	Warhead@Shake: ShakeScreen
 		Duration: 10
@@ -236,6 +240,7 @@ MADTankDetonate:
 	Warhead@1Dam: HealthPercentageDamage
 		Spread: 7c0
 		Damage: 19
+		ValidTargets: GroundActor, WaterActor
 		InvalidTargets: MADTank, Infantry
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -1,5 +1,5 @@
 ^FireWeapon:
-	ValidTargets: Ground, Water, Trees
+	ValidTargets: Ground, Water, GroundActor, WaterActor, Trees
 	ReloadDelay: 65
 	Range: 5c0
 	Warhead@1Dam: SpreadDamage
@@ -76,6 +76,7 @@ Napalm:
 	Range: 8c0
 	Report: tesla1.aud
 	Projectile: TeslaZap
+	ValidTargets: Ground, Water, GroundActor, WaterActor
 	Warhead@1Dam: SpreadDamage
 		Spread: 42
 		Damage: 10000
@@ -140,6 +141,7 @@ Repair:
 		ValidTargets: Repair
 
 Demolish:
+	ValidTargets: GroundActor, WaterActor
 	Warhead@1Dam: SpreadDamage
 		DamageTypes: DefaultDeath
 	Warhead@2Eff: CreateEffect
@@ -149,6 +151,7 @@ Demolish:
 Claw:
 	ReloadDelay: 30
 	Range: 1c512
+	ValidTargets: Ground, Water, GroundActor, WaterActor
 	Projectile: Bullet
 		Speed: 1c682
 	Warhead@1Dam: SpreadDamage
@@ -216,6 +219,7 @@ DemoTruckTargeting:
 		ValidTargets: DetonateAttack
 
 MADTankThump:
+	ValidTargets: GroundActor, WaterActor
 	InvalidTargets: MADTank, Infantry
 	Warhead@1Dam: HealthPercentageDamage
 		Spread: 7c0
@@ -227,6 +231,7 @@ MADTankThump:
 		Multiplier: 1,0
 
 MADTankDetonate:
+	ValidTargets: GroundActor, WaterActor
 	InvalidTargets: MADTank, Infantry
 	Warhead@1Dam: HealthPercentageDamage
 		Spread: 7c0

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -7,7 +7,7 @@
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
 		Damage: 2000
-		ValidTargets: Air
+		ValidTargets: AirborneActor
 		Versus:
 			None: 40
 			Wood: 10
@@ -37,23 +37,23 @@ ZSU-23:
 FLAK-23-AA:
 	Inherits: ^AACannon
 	Warhead@1Dam: SpreadDamage
-		ValidTargets: Air, Ground, Water
+		ValidTargets: AirborneActor, GroundActor, WaterActor
 
 FLAK-23-AG:
 	Inherits: ^AACannon
 	Range: 6c0
-	ValidTargets: Ground, Water
+	ValidTargets: Ground, Water, GroundActor, WaterActor
 	Projectile: InstantHit
 		Blockable: true
 	Warhead@1Dam: SpreadDamage
-		ValidTargets: Air, Ground, Water
+		ValidTargets: AirborneActor, GroundActor, WaterActor
 	Warhead@2Eff: CreateEffect
 		Explosions: flak_explosion_ground
-		ValidTargets: Ground, Ship, Air, Trees
+		ValidTargets: Ground, GroundActor, Air, AirborneActor, WaterActor, Trees
 	Warhead@3EffWater: CreateEffect
 		Explosions: small_splash
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+		InvalidTargets: Bridge
 
 ^HeavyMG:
 	ReloadDelay: 30
@@ -65,6 +65,7 @@ FLAK-23-AG:
 	Warhead@1Dam: SpreadDamage
 		Spread: 128
 		Damage: 2500
+		ValidTargets: GroundActor, WaterActor
 		Versus:
 			None: 120
 			Wood: 60
@@ -74,11 +75,12 @@ FLAK-23-AG:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground, Ship, Air, Trees
+		ValidTargets: Ground, Air
+		ImpactActors: false
 	Warhead@3EffWater: CreateEffect
 		Explosions: water_piffs
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+		InvalidTargets: Bridge
 
 ^LightMG:
 	Inherits: ^HeavyMG
@@ -115,12 +117,13 @@ Vulcan:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@4Eff_2: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground, Ship, Trees
+		ValidTargets: Ground
+		ImpactActors: false
 		Delay: 2
 	Warhead@4Eff_2Water: CreateEffect
 		Explosions: water_piffs
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+		InvalidTargets: Bridge
 		Delay: 2
 	Warhead@5Dam_3: SpreadDamage
 		Spread: 128
@@ -135,12 +138,13 @@ Vulcan:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@6Eff_3: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground, Ship, Trees
+		ValidTargets: Ground
+		ImpactActors: false
 		Delay: 4
 	Warhead@6Eff_3Water: CreateEffect
 		Explosions: water_piffs
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+		InvalidTargets: Bridge
 		Delay: 4
 	Warhead@7Dam_4: SpreadDamage
 		Spread: 128
@@ -155,12 +159,13 @@ Vulcan:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@8Eff_4: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground, Ship, Trees
+		ValidTargets: Ground
+		ImpactActors: false
 		Delay: 6
 	Warhead@8Eff_4Water: CreateEffect
 		Explosions: water_piffs
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+		InvalidTargets: Bridge
 		Delay: 6
 	Warhead@9Dam_5: SpreadDamage
 		Spread: 128
@@ -175,12 +180,13 @@ Vulcan:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@10Eff_5: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground, Ship, Trees
+		ValidTargets: Ground
+		ImpactActors: false
 		Delay: 8
 	Warhead@10Eff_5Water: CreateEffect
 		Explosions: water_piffs
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+		InvalidTargets: Bridge
 		Delay: 8
 	Warhead@11Dam_6: SpreadDamage
 		Spread: 128
@@ -195,12 +201,13 @@ Vulcan:
 		DamageTypes: Prone50Percent, TriggerProne, BulletDeath
 	Warhead@12Eff_6: CreateEffect
 		Explosions: piffs
-		ValidTargets: Ground, Ship, Trees
+		ValidTargets: Ground
+		ImpactActors: false
 		Delay: 10
 	Warhead@12Eff_6Water: CreateEffect
 		Explosions: water_piffs
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure, Bridge
+		InvalidTargets: Bridge
 		Delay: 10
 
 ChainGun:

--- a/mods/ra/weapons/smallcaliber.yaml
+++ b/mods/ra/weapons/smallcaliber.yaml
@@ -2,7 +2,7 @@
 	ReloadDelay: 10
 	Range: 8c0
 	Report: aacanon3.aud
-	ValidTargets: Air
+	ValidTargets: AirborneActor
 	Projectile: InstantHit
 	Warhead@1Dam: SpreadDamage
 		Spread: 213
@@ -59,6 +59,7 @@ FLAK-23-AG:
 	ReloadDelay: 30
 	Range: 6c0
 	Report: gun13.aud
+	ValidTargets: Ground, Water, GroundActor, WaterActor
 	Projectile: InstantHit
 		Blockable: true
 	Warhead@1Dam: SpreadDamage
@@ -267,7 +268,6 @@ M60mg:
 	Range: 2c512
 	Report: gun5.aud
 	ValidTargets: Ground, Infantry
-	InvalidTargets: Vehicle, Water, Structure, Wall, Husk, Mine
 	Projectile: InstantHit
 		Blockable: true
 	Warhead@1Dam: SpreadDamage

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -12,6 +12,7 @@ ParaBomb:
 	Warhead@1Dam: SpreadDamage
 		Spread: 768
 		Damage: 30000
+		ValidTargets: GroundActor, WaterActor
 		Versus:
 			None: 30
 			Wood: 30
@@ -20,24 +21,23 @@ ParaBomb:
 		DamageTypes: Prone50Percent, TriggerProne, ExplosionDeath
 	Warhead@2Smu: LeaveSmudge
 		SmudgeType: Crater
-		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees
+		ValidTargets: Ground, Infantry
 	Warhead@3Eff: CreateEffect
 		Explosions: artillery_explosion
 		ImpactSounds: kaboom15.aud
-		ValidTargets: Ground, Ship, Trees
+		ValidTargets: Ground, GroundActor, WaterActor, Trees
 	Warhead@4EffWater: CreateEffect
 		Explosions: small_splash
 		ImpactSounds: splash9.aud
 		ValidTargets: Water, Underwater
-		InvalidTargets: Ship, Structure
 
 Atomic:
-	ValidTargets: Ground, GroundActor, Trees, Water, WaterActor, Underwater, Air, AirborneActor
+	ValidTargets: Ground, Water, GroundActor, WaterActor, Underwater, AirborneActor, Trees
 	Warhead@1Dam_impact: SpreadDamage
 		Spread: 1c0
 		Damage: 15000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		ValidTargets: Ground, Trees, Water, Underwater, Air
+		ValidTargets: GroundActor, WaterActor, Underwater, AirborneActor, Trees
 		Versus:
 			Wood: 25
 			Concrete: 25
@@ -46,7 +46,7 @@ Atomic:
 		Size: 1
 	Warhead@3Smu_impact: LeaveSmudge
 		SmudgeType: Scorch
-		InvalidTargets: Vehicle, Structure, Wall
+		ValidTargets: Ground, Infantry
 		Size: 1
 	Warhead@4Eff_impact: CreateEffect
 		Explosions: nuke
@@ -58,7 +58,7 @@ Atomic:
 		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 5
-		ValidTargets: Ground, Trees, Water, Underwater, Air
+		ValidTargets: GroundActor, WaterActor, Underwater, AirborneActor, Trees
 		Versus:
 			Wood: 25
 			Concrete: 25
@@ -68,7 +68,7 @@ Atomic:
 		Delay: 5
 	Warhead@7Smu_areanuke1: LeaveSmudge
 		SmudgeType: Scorch
-		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees
+		ValidTargets: Ground, Infantry
 		Size: 2
 		Delay: 5
 	Warhead@8Eff_areanuke1: CreateEffect
@@ -80,7 +80,7 @@ Atomic:
 		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 10
-		ValidTargets: Ground, Water, Underwater, Air
+		ValidTargets: GroundActor, WaterActor, Underwater, AirborneActor
 		Versus:
 			Wood: 50
 			Concrete: 25
@@ -97,7 +97,7 @@ Atomic:
 		Delay: 10
 	Warhead@12Smu_areanuke2: LeaveSmudge
 		SmudgeType: Scorch
-		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees
+		ValidTargets: Ground, Infantry
 		Size: 3
 		Delay: 10
 	Warhead@13Dam_areanuke3: SpreadDamage
@@ -105,7 +105,7 @@ Atomic:
 		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 15
-		ValidTargets: Ground, Water, Underwater, Air
+		ValidTargets: GroundActor, WaterActor, Underwater, AirborneActor
 		Versus:
 			Concrete: 25
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
@@ -121,7 +121,7 @@ Atomic:
 		Delay: 15
 	Warhead@16Smu_areanuke3: LeaveSmudge
 		SmudgeType: Scorch
-		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees
+		ValidTargets: Ground, Infantry
 		Size: 4
 		Delay: 15
 	Warhead@17Dam_areanuke4: SpreadDamage
@@ -129,7 +129,7 @@ Atomic:
 		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 20
-		ValidTargets: Ground, Water, Underwater, Air
+		ValidTargets: GroundActor, WaterActor, Underwater, AirborneActor
 		Versus:
 			Concrete: 25
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
@@ -145,7 +145,7 @@ Atomic:
 		Delay: 20
 	Warhead@20Smu_areanuke4: LeaveSmudge
 		SmudgeType: Scorch
-		InvalidTargets: Vehicle, Structure, Wall, Husk, Trees
+		ValidTargets: Ground, Infantry
 		Size: 5
 		Delay: 20
 	Warhead@21Shake: ShakeScreen

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -2,6 +2,7 @@ ParaBomb:
 	ReloadDelay: 8
 	Range: 3c0
 	Report: chute1.aud
+	ValidTargets: Ground, Water, GroundActor, WaterActor
 	Projectile: GravityBomb
 		Image: PARABOMB
 		OpenSequence: open
@@ -31,7 +32,7 @@ ParaBomb:
 		InvalidTargets: Ship, Structure
 
 Atomic:
-	ValidTargets: Ground, Trees, Water, Underwater, Air
+	ValidTargets: Ground, GroundActor, Trees, Water, WaterActor, Underwater, Air, AirborneActor
 	Warhead@1Dam_impact: SpreadDamage
 		Spread: 1c0
 		Damage: 15000


### PR DESCRIPTION
One of the main reasons why past attempts to refactor and simplify `CreateEffectWarhead` without dropping support for any edge cases failed was that RA sharing TargetTypes between terrain and actors made things a nightmare once, for example, an effect warhead was meant to trigger on `Water` actors, but not `Water` terrain.
`InvalidTargets` would in that case be insufficient, since terrain most of the time has only one TargetType, while listing all individual actor TargetTypes like `Vehicle`, `Ship` etc. was prone to forgetting one or two.

Cleanly separating between terrain and actors in RA's `TargetTypes`, introducing general `GroundActor` and `WaterActor` target types, as well as not using the `GroundActor` target type on naval units and buildings, makes RA's setup fit for avoiding such issues with the upcoming `CreateEffectWarhead` code simplification.

Also added some minor effect polish in a few cases (`DepthCharge`, ship explosions, `Sniper` weapon).

~Depends on #18066.~