### PR TITLE
Determine stance for spectators based on shroud selection

### DIFF
--- a/OpenRA.Game/Player.cs
+++ b/OpenRA.Game/Player.cs
@@ -225,7 +225,11 @@ namespace OpenRA
 		public Dictionary<Player, Stance> Stances = new Dictionary<Player, Stance>();
 		public bool IsAlliedWith(Player p)
 		{
-			// Observers are considered allies to active combatants
+			// Current shroud selection is used to determine stance for spectators
+			if (p != null && p.Spectating && !NonCombatant && p.World.RenderPlayer != null)
+				return Stances[p.World.RenderPlayer] == Stance.Ally;
+
+			// Observers are considered allies if RenderPlayer property is null
 			return p == null || Stances[p] == Stance.Ally || (p.Spectating && !NonCombatant);
 		}
 


### PR DESCRIPTION
Fixes #17858.
Fixes #17041.

`IsAlliedWith` considered all observers as allies to any player before resulting in incorrect visibility of objects that were meant to be hidden behind the fog of war (e.g Rally Point indicator for buildings) based on shroud selection from the dropdown