### PR TITLE
Remove England as playable faction

### DIFF
--- a/mods/ra/maps/ant-01/rules.yaml
+++ b/mods/ra/maps/ant-01/rules.yaml
@@ -55,10 +55,6 @@ SPY:
 	Buildable:
 		Prerequisites: ~disabled
 
-SPY.England:
-	Buildable:
-		Prerequisites: ~disabled
-
 MECH:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/rules/infantry.yaml
+++ b/mods/ra/rules/infantry.yaml
@@ -295,7 +295,7 @@ SPY:
 		Queue: Infantry
 		BuildAtProductionType: Soldier
 		BuildPaletteOrder: 90
-		Prerequisites: ~!infantry.england, dome, ~tent, ~techlevel.medium
+		Prerequisites: dome, ~tent, ~techlevel.medium
 		Description: Infiltrates enemy structures for intel or\nsabotage. Exact effect depends on the\nbuilding infiltrated.\nLoses disguise when attacking.\nCan detect spies.\n  Strong vs Infantry\n  Weak vs Vehicles, Aircraft\n  Special Ability: Disguised
 	Valued:
 		Cost: 500
@@ -342,19 +342,6 @@ SPY:
 		Voice: Move
 	Voiced:
 		VoiceSet: SpyVoice
-
-SPY.England:
-	Inherits: SPY
-	Buildable:
-		Prerequisites: ~infantry.england, dome, ~tent, ~techlevel.medium
-	Valued:
-		Cost: 250
-	GivesExperience:
-		Experience: 500
-	DisguiseTooltip:
-		Name: British Spy
-	RenderSprites:
-		Image: spy
 
 E7:
 	Inherits: ^Soldier

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -554,7 +554,7 @@ MGG:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 330
-		Prerequisites: atek, ~vehicles.england, ~techlevel.high
+		Prerequisites: atek, ~vehicles.germany, ~techlevel.high
 		Description: Regenerates the shroud nearby, \nobscuring the area.\n  Unarmed
 	Valued:
 		Cost: 1000
@@ -755,7 +755,7 @@ CTNK:
 	Buildable:
 		Queue: Vehicle
 		BuildPaletteOrder: 330
-		Prerequisites: atek, ~vehicles.germany, ~techlevel.high
+		Prerequisites: atek, ~vehicles.allies, ~techlevel.high
 		Description: Armed with anti-ground missiles.\nTeleports to areas within range.\n  Strong vs Vehicles, Buildings\n  Weak vs Infantry, Aircraft\n  Special ability: Can teleport
 	Valued:
 		Cost: 1350

--- a/mods/ra/rules/world.yaml
+++ b/mods/ra/rules/world.yaml
@@ -104,7 +104,7 @@
 		Name: England
 		InternalName: england
 		Side: Allies
-		Description: England: Counterintelligence\nSpecial Unit: British Spy\nSpecial Unit: Mobile Gap Generator
+		Selectable: False
 	Faction@2:
 		Name: France
 		InternalName: france
@@ -114,7 +114,7 @@
 		Name: Germany
 		InternalName: germany
 		Side: Allies
-		Description: Germany: Technology\nSpecial Ability: Advanced Chronoshift\nSpecial Unit: Chrono Tank
+		Description: Germany: Technology\nSpecial Ability: Advanced Chronoshift\nSpecial Unit: Mobile Gap Generator
 	Faction@4:
 		Name: Soviet
 		InternalName: soviet
@@ -139,7 +139,7 @@
 	Faction@randomallies:
 		Name: Allies
 		InternalName: RandomAllies
-		RandomFactionMembers: england, france, germany
+		RandomFactionMembers: france, germany
 		Side: Random
 		Description: Random Allied Country\nA random Allied country will be chosen when the game starts.
 	Faction@randomsoviet:


### PR DESCRIPTION
As requested on Discord for feedback:
- Removes the British Spy
- Moves the Mobile Gap Generator to Germany
- Makes the Chrono Tank available to both remaining Allied subfactions

This fixes following issues:
- Allies having one more subfaction available than Soviets
- The British Spy being regarded as rather uninteresting "special unit" since the other factions have spies too
- All Allied subfactions being generally regarded as too weak due to spreaded assets (Chrono Tank)
- Prominent display of "England" with a British flag

I still retained the faction as (a) it is used as default for neutral players and (b) we want to keep an option open for having the faction return once a viable strategy for balancing the Allied subfactions, that still makes play interesting, is available.

CC @Orb370, @netnazgul, @Punsho 