### PR TITLE
Fix build limit icon bug

### DIFF
--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -357,7 +357,7 @@ namespace OpenRA.Mods.Common.Traits
 				if (bi.BuildLimit > 0)
 				{
 					var owned = self.Owner.World.ActorsHavingTrait<Buildable>()
-						.Count(a => a.Info.Name == actor.Name && a.Owner == self.Owner);
+						.Count(a => a.Info.Name == actor.Name && a.Owner == self.Owner && !a.IsDead);
 					if (queueCount + owned >= bi.BuildLimit)
 						return false;
 				}
@@ -400,7 +400,7 @@ namespace OpenRA.Mods.Common.Traits
 						if (bi.BuildLimit > 0)
 						{
 							var inQueue = Queue.Count(pi => pi.Item == order.TargetString);
-							var owned = self.Owner.World.ActorsHavingTrait<Buildable>().Count(a => a.Info.Name == order.TargetString && a.Owner == self.Owner);
+							var owned = self.Owner.World.ActorsHavingTrait<Buildable>().Count(a => a.Info.Name == order.TargetString && a.Owner == self.Owner && !a.IsDead);
 							fromLimit = Math.Min(fromLimit, bi.BuildLimit - (inQueue + owned));
 						}
 

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -356,9 +356,7 @@ namespace OpenRA.Mods.Common.Traits
 
 				if (bi.BuildLimit > 0)
 				{
-					var owned = self.Owner.World.ActorsHavingTrait<Buildable>()
-						.Count(a => a.Info.Name == actor.Name && a.Owner == self.Owner && !a.IsDead);
-					if (queueCount + owned >= bi.BuildLimit)
+					if (techTree.GetAllowedNumber(actor.Name) - queueCount <= 0)
 						return false;
 				}
 			}
@@ -400,8 +398,7 @@ namespace OpenRA.Mods.Common.Traits
 						if (bi.BuildLimit > 0)
 						{
 							var inQueue = Queue.Count(pi => pi.Item == order.TargetString);
-							var owned = self.Owner.World.ActorsHavingTrait<Buildable>().Count(a => a.Info.Name == order.TargetString && a.Owner == self.Owner && !a.IsDead);
-							fromLimit = Math.Min(fromLimit, bi.BuildLimit - (inQueue + owned));
+							fromLimit = Math.Min(fromLimit, techTree.GetAllowedNumber(order.TargetString) - inQueue);
 						}
 
 						if (fromLimit <= 0)

--- a/OpenRA.Mods.Common/Traits/Player/TechTree.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TechTree.cs
@@ -93,15 +93,13 @@ namespace OpenRA.Mods.Common.Traits
 				}
 			}
 
-			// Add buildables that have a build limit set and are not already in the list
-			player.World.ActorsWithTrait<Buildable>()
+			// Add buildables that have a build limit set
+			player.World.ActorsHavingTrait<Buildable>()
 				  .Where(a =>
-					  a.Actor.Owner == player &&
-					  a.Actor.IsInWorld &&
-					  !a.Actor.IsDead &&
-					  !ret.ContainsKey(a.Actor.Info.Name) &&
-					  a.Actor.Info.TraitInfo<BuildableInfo>().BuildLimit > 0)
-				  .Do(b => ret[b.Actor.Info.Name].Add(b.Actor));
+					  a.Owner == player &&
+					  !a.IsDead &&
+					  a.Info.TraitInfo<BuildableInfo>().BuildLimit > 0)
+				  .Do(a => ret[a.Info.Name].Add(a));
 
 			return ret;
 		}

--- a/OpenRA.Mods.Common/Traits/Production.cs
+++ b/OpenRA.Mods.Common/Traits/Production.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using OpenRA.Mods.Common.Activities;
 using OpenRA.Primitives;
 using OpenRA.Traits;
@@ -133,6 +134,20 @@ namespace OpenRA.Mods.Common.Traits
 
 			return mobileInfo == null ||
 				mobileInfo.CanEnterCell(self.World, self, self.Location + s.ExitCell, ignoreActor: self);
+		}
+
+		// Note: there is a same method in ProductionQueue and
+		// refactor is needed.
+		public int GetProductionCost(ActorInfo unit, TechTree techTree, string productionType)
+		{
+			var valued = unit.TraitInfoOrDefault<ValuedInfo>();
+			if (valued == null)
+				return 0;
+
+			var modifiers = unit.TraitInfos<IProductionCostModifierInfo>()
+				.Select(t => t.GetProductionCostModifier(techTree, productionType));
+
+			return Util.ApplyPercentageModifiers(valued.Cost, modifiers);
 		}
 	}
 }


### PR DESCRIPTION
Fix build limit icon bug:

1. Fix build limit performance bug:
    1.1 the icon will turn grey only when build limit is 1,  which means it won't work for build limit > 1
    1.2 the icon will change to avaliable palette when unit enter the transport

2. Add a "Isdead" check for build limit check in ProductionQueue.cs. I guess those fixs can prevent some bugs that not yet found.

Airdrop-product build limit related fix

1. when unit is being delivered, a placeholder will take up build limit to fix icon and buildable bug.

2. when airdrop-pad is destroyed and a transport is in delivering, the fix here will restore the current building number after the transport find it is not able to land and deliver.

3. when airdrop-pad is destroyed and a transport is in delivering, the fix here will refund the unit just built after the transport find it is not able to land and deliver.

4. ProductionQueue.cs build limit check is now using the function in TechTree.cs to improve performance and readability.

Fixes https://github.com/OpenRA/OpenRA/issues/5872.