### PR TITLE
Minefield now shows red when out of map bounds and Minelayer now does…

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -115,7 +115,8 @@ namespace OpenRA.Mods.Cnc.Traits
 				var movement = self.Trait<IPositionable>();
 
 				var minefield = GetMinefieldCells(minefieldStart, cell, Info.MinefieldDepth)
-					.Where(c => movement.CanEnterCell(c, null, BlockedByActor.Immovable) || !self.Owner.Shroud.IsVisible(c))
+					.Where(c => movement.CanEnterCell(c, null, BlockedByActor.Immovable)
+						|| (!self.Owner.Shroud.IsVisible(c) && self.World.Map.Contains(c)))
 					.OrderBy(c => (c - minefieldStart).LengthSquared).ToList();
 
 				self.QueueActivity(order.Queued, new LayMines(self, minefield));
@@ -236,7 +237,9 @@ namespace OpenRA.Mods.Cnc.Traits
 				foreach (var c in minefield)
 				{
 					var tile = tileOk;
-					if (world.FogObscures(c))
+					if (!world.Map.Contains(c))
+						tile = tileBlocked;
+					else if (world.FogObscures(c))
 						tile = tileUnknown;
 					else if (!movement.CanEnterCell(c, null, BlockedByActor.Immovable) || (mobile != null && !mobile.CanStayInCell(c)))
 						tile = tileBlocked;


### PR DESCRIPTION
… not get stuck at edge of map.

Bug fix for #18081

I'm worried about removing "!self.Owner.Shroud.IsVisible(c)" but can not make sense of why it is there, and it is why the Minelayer tries to add mines beyond map bounds

Changelog:
Fixed Minelayer trying to add mines outside of the map border