### PR TITLE
Added server name to GameInfoLogic menu

### DIFF
--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -133,9 +133,11 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			if (firstCategory != null)
 				mapTitle = firstCategory + ": " + mapTitle;
 			var serverTitle = world.LobbyInfo.GlobalSettings.ServerName;
+			if (world.LobbyInfo.NonBotClients.Count() == 1)
+				serverTitle = "Singleplayer Game";
 
 			titleText.IsVisible = () => numTabs > 1 || (numTabs == 1 && titleTextNoTabs == null);
-			titleText.GetText = () => mapTitle;
+			titleText.GetText = () => mapTitle + "\n" + serverTitle;
 			if (titleTextNoTabs != null)
 			{
 				titleTextNoTabs.IsVisible = () => numTabs == 1;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -128,17 +128,20 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var titleText = widget.Get<LabelWidget>("TITLE");
 			var titleTextNoTabs = widget.GetOrNull<LabelWidget>("TITLE_NO_TABS");
 
+			// ADDED
+			var serverTitle = world.LobbyInfo.GlobalSettings.ServerName;
+
 			var mapTitle = world.Map.Title;
 			var firstCategory = world.Map.Categories.FirstOrDefault();
 			if (firstCategory != null)
 				mapTitle = firstCategory + ": " + mapTitle;
 
 			titleText.IsVisible = () => numTabs > 1 || (numTabs == 1 && titleTextNoTabs == null);
-			titleText.GetText = () => mapTitle;
+			titleText.GetText = () => (serverTitle + "\n" + mapTitle);
 			if (titleTextNoTabs != null)
 			{
 				titleTextNoTabs.IsVisible = () => numTabs == 1;
-				titleTextNoTabs.GetText = () => mapTitle;
+				titleTextNoTabs.GetText = () => serverTitle + "\n" + mapTitle;
 			}
 
 			var bg = widget.Get<BackgroundWidget>("BACKGROUND");

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -132,10 +132,10 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var firstCategory = world.Map.Categories.FirstOrDefault();
 			if (firstCategory != null)
 				mapTitle = firstCategory + ": " + mapTitle;
-			var serverTitle = "Server: " + world.LobbyInfo.GlobalSettings.ServerName;
+			var serverTitle = world.LobbyInfo.GlobalSettings.ServerName;
 
 			titleText.IsVisible = () => numTabs > 1 || (numTabs == 1 && titleTextNoTabs == null);
-			titleText.GetText = () => serverTitle + "\n" + mapTitle;
+			titleText.GetText = () => mapTitle;
 			if (titleTextNoTabs != null)
 			{
 				titleTextNoTabs.IsVisible = () => numTabs == 1;

--- a/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Ingame/GameInfoLogic.cs
@@ -128,20 +128,18 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 			var titleText = widget.Get<LabelWidget>("TITLE");
 			var titleTextNoTabs = widget.GetOrNull<LabelWidget>("TITLE_NO_TABS");
 
-			// ADDED
-			var serverTitle = world.LobbyInfo.GlobalSettings.ServerName;
-
 			var mapTitle = world.Map.Title;
 			var firstCategory = world.Map.Categories.FirstOrDefault();
 			if (firstCategory != null)
 				mapTitle = firstCategory + ": " + mapTitle;
+			var serverTitle = "Server: " + world.LobbyInfo.GlobalSettings.ServerName;
 
 			titleText.IsVisible = () => numTabs > 1 || (numTabs == 1 && titleTextNoTabs == null);
-			titleText.GetText = () => (serverTitle + "\n" + mapTitle);
+			titleText.GetText = () => serverTitle + "\n" + mapTitle;
 			if (titleTextNoTabs != null)
 			{
 				titleTextNoTabs.IsVisible = () => numTabs == 1;
-				titleTextNoTabs.GetText = () => serverTitle + "\n" + mapTitle;
+				titleTextNoTabs.GetText = () => mapTitle + "\n" + serverTitle;
 			}
 
 			var bg = widget.Get<BackgroundWidget>("BACKGROUND");

--- a/mods/cnc/chrome/ingame-info.yaml
+++ b/mods/cnc/chrome/ingame-info.yaml
@@ -8,14 +8,14 @@ Container@GAME_INFO_PANEL:
 	Children:
 		Label@TITLE:
 			Width: PARENT_RIGHT
-			Y: 0 - 17
+			Y: 0 - 23
 			Text: Game Information
 			Align: Center
 			Font: BigBold
 			Contrast: true
 		Label@TITLE_NO_TABS:
 			Width: PARENT_RIGHT
-			Y: 18
+			Y: 12
 			Text: Game Information
 			Align: Center
 			Font: BigBold


### PR DESCRIPTION
- Added the server name to the match escape menu, below the map name, when it is opened in a multiplayer game
- If not in a multiplayer game (world.LobbyInfo.NonBotClients.Count() == 1) then "Singleplayer Game" is shown instead
- Moved the TITLE and TITLE_NO_TABS text widgets up by 6 units in Cnc/Tiberian Dawn so that it is not blocked by the menu (mods/cnc/chrome/ingame-info.yaml

Closes #12349