### PR TITLE
Add some mod options to Delivercash.

### DIFF
--- a/OpenRA.Mods.Common/Traits/AcceptsDeliveredCash.cs
+++ b/OpenRA.Mods.Common/Traits/AcceptsDeliveredCash.cs
@@ -23,6 +23,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Stance the delivering actor needs to enter.")]
 		public readonly Stance ValidStances = Stance.Ally;
 
+		[Desc("If set to true, accepts only delivery actors owned by the same player as the acceptor.")]
+		public readonly bool SamePlayerOnly = false;
+
 		[Desc("Play a randomly selected sound from this list when accepting cash.")]
 		public readonly string[] Sounds = { };
 

--- a/OpenRA.Mods.Common/Traits/DeliversCash.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversCash.cs
@@ -19,8 +19,11 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Donate money to actors with the `AcceptsDeliveredCash` trait.")]
 	class DeliversCashInfo : TraitInfo
 	{
-		[Desc("The amount of cash the owner receives.")]
+		[Desc("The amount of cash the accepting player receives.")]
 		public readonly int Payload = 500;
+
+		[Desc("The percentage of the value of this actor in cash that the accepting player receives.")]
+		public readonly int PercentagePayload = 0;
 
 		[Desc("The amount of experience the donating player receives.")]
 		public readonly int PlayerExperience = 0;
@@ -75,7 +78,15 @@ namespace OpenRA.Mods.Common.Traits
 			if (order.OrderString != "DeliverCash")
 				return;
 
-			self.QueueActivity(order.Queued, new DonateCash(self, order.Target, info.Payload, info.PlayerExperience));
+			var payload = info.Payload;
+			if (info.PercentagePayload != 0)
+			{
+				var valued = self.Info.TraitInfoOrDefault<ValuedInfo>();
+				if (valued != null)
+					payload += info.PercentagePayload * valued.Cost / 100;
+			}
+
+			self.QueueActivity(order.Queued, new DonateCash(self, order.Target, payload, info.PlayerExperience));
 			self.ShowTargetLines();
 		}
 

--- a/OpenRA.Mods.Common/Traits/DeliversCash.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversCash.cs
@@ -20,10 +20,10 @@ namespace OpenRA.Mods.Common.Traits
 	class DeliversCashInfo : TraitInfo
 	{
 		[Desc("The amount of cash the accepting player receives.")]
-		public readonly int Payload = 500;
+		public readonly int Payload = 0;
 
 		[Desc("The percentage of the value of this actor in cash that the accepting player receives.")]
-		public readonly int PercentagePayload = 0;
+		public readonly int PercentagePayload = 100;
 
 		[Desc("The amount of experience the donating player receives.")]
 		public readonly int PlayerExperience = 0;

--- a/OpenRA.Mods.Common/Traits/DeliversCash.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversCash.cs
@@ -98,6 +98,7 @@ namespace OpenRA.Mods.Common.Traits
 				var targetInfo = target.Info.TraitInfoOrDefault<AcceptsDeliveredCashInfo>();
 				return targetInfo != null
 					&& targetInfo.ValidStances.HasStance(target.Owner.Stances[self.Owner])
+					&& (!targetInfo.SamePlayerOnly || target.Owner == self.Owner)
 					&& (targetInfo.ValidTypes.Count == 0
 						|| (!string.IsNullOrEmpty(type) && targetInfo.ValidTypes.Contains(type)));
 			}
@@ -108,6 +109,7 @@ namespace OpenRA.Mods.Common.Traits
 				var targetInfo = target.Info.TraitInfoOrDefault<AcceptsDeliveredCashInfo>();
 				return targetInfo != null
 					&& targetInfo.ValidStances.HasStance(target.Owner.Stances[self.Owner])
+					&& (!targetInfo.SamePlayerOnly || target.Owner == self.Owner)
 					&& (targetInfo.ValidTypes.Count == 0
 						|| (!string.IsNullOrEmpty(type) && targetInfo.ValidTypes.Contains(type)));
 			}

--- a/mods/cnc/rules/vehicles.yaml
+++ b/mods/cnc/rules/vehicles.yaml
@@ -715,7 +715,6 @@ TRUCK:
 	RevealsShroud:
 		Range: 4c0
 	DeliversCash:
-		Payload: 500
 		PlayerExperience: 50
 	SpawnActorOnDeath:
 		Actor: TRUCK.Husk

--- a/mods/ra/rules/vehicles.yaml
+++ b/mods/ra/rules/vehicles.yaml
@@ -545,7 +545,6 @@ TRUK:
 	RevealsShroud:
 		Range: 4c0
 	DeliversCash:
-		Payload: 500
 		PlayerExperience: 50
 	SpawnActorOnDeath:
 		Actor: moneycrate


### PR DESCRIPTION
Closes #18087 

- Adds an option to only deliver to same owner instead of all allies.
- ~Makes the cursor customizable.~
- Adds an option to make the payload a percentage of the unit's cost (or a combination of relative and absolute valued payloads).
- Defaults to the unit's cost.