### PR TITLE
Un-hardcode target cursors for various traits

### DIFF
--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -93,6 +93,9 @@ namespace OpenRA.Mods.Cnc.Traits
 			"A dictionary of [actor id]: [condition].")]
 		public readonly Dictionary<string, string> DisguisedAsConditions = new Dictionary<string, string>();
 
+		[Desc("Cursor to show when hovering over a valid actor to disguise as.")]
+		public readonly string Cursor = "ability";
+
 		[GrantedConditionReference]
 		public IEnumerable<string> LinterConditions { get { return DisguisedAsConditions.Values; } }
 
@@ -284,7 +287,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		readonly DisguiseInfo info;
 
 		public DisguiseOrderTargeter(DisguiseInfo info)
-			: base("Disguise", 7, "ability", true, true)
+			: base("Disguise", 7, info.Cursor, true, true)
 		{
 			this.info = info;
 			ForceAttack = false;

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -93,7 +93,7 @@ namespace OpenRA.Mods.Cnc.Traits
 			"A dictionary of [actor id]: [condition].")]
 		public readonly Dictionary<string, string> DisguisedAsConditions = new Dictionary<string, string>();
 
-		[Desc("Cursor to show when hovering over a valid actor to disguise as.")]
+		[Desc("Cursor to display when hovering over a valid actor to disguise as.")]
 		public readonly string Cursor = "ability";
 
 		[GrantedConditionReference]

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/Infiltrates.cs
@@ -42,6 +42,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Experience to grant to the infiltrating player.")]
 		public readonly int PlayerExperience = 0;
 
+		[Desc("Cursor to display when able to infiltrate the target actor.")]
 		public readonly string EnterCursor = "enter";
 
 		public override object Create(ActorInitializer init) { return new Infiltrates(this); }

--- a/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/SupportPowers/ChronoshiftPower.cs
@@ -49,13 +49,13 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public readonly bool KillCargo = true;
 
-		[Desc("Cursor sequence to use when selecting targets for the chronoshift.")]
+		[Desc("Cursor to display when selecting targets for the chronoshift.")]
 		public readonly string SelectionCursor = "chrono-select";
 
-		[Desc("Cursor sequence to use when targeting an area for the chronoshift.")]
+		[Desc("Cursor to display when targeting an area for the chronoshift.")]
 		public readonly string TargetCursor = "chrono-target";
 
-		[Desc("Cursor sequence to use when the targeted area is blocked.")]
+		[Desc("Cursor to display when the targeted area is blocked.")]
 		public readonly string TargetBlockedCursor = "move-blocked";
 
 		public override object Create(ActorInitializer init) { return new ChronoshiftPower(init.Self, this); }

--- a/OpenRA.Mods.Common/Orders/EnterAlliedActorTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/EnterAlliedActorTargeter.cs
@@ -16,13 +16,17 @@ namespace OpenRA.Mods.Common.Orders
 {
 	public class EnterAlliedActorTargeter<T> : UnitOrderTargeter where T : ITraitInfoInterface
 	{
+		readonly string enterCursor;
+		readonly string enterBlockedCursor;
 		readonly Func<Actor, TargetModifiers, bool> canTarget;
 		readonly Func<Actor, bool> useEnterCursor;
 
-		public EnterAlliedActorTargeter(string order, int priority,
+		public EnterAlliedActorTargeter(string order, int priority, string enterCursor, string enterBlockedCursor,
 			Func<Actor, TargetModifiers, bool> canTarget, Func<Actor, bool> useEnterCursor)
-			: base(order, priority, "enter", false, true)
+			: base(order, priority, enterCursor, false, true)
 		{
+			this.enterCursor = enterCursor;
+			this.enterBlockedCursor = enterBlockedCursor;
 			this.canTarget = canTarget;
 			this.useEnterCursor = useEnterCursor;
 		}
@@ -32,7 +36,7 @@ namespace OpenRA.Mods.Common.Orders
 			if (!self.Owner.IsAlliedWith(target.Owner) || !target.Info.HasTraitInfo<T>() || !canTarget(target, modifiers))
 				return false;
 
-			cursor = useEnterCursor(target) ? "enter" : "enter-blocked";
+			cursor = useEnterCursor(target) ? enterCursor : enterBlockedCursor;
 			return true;
 		}
 

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -139,7 +139,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Boolean expression defining the condition under which the regular (non-force) move cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;
 
+		[Desc("Cursor to display when able to land at target building.")]
 		public readonly string EnterCursor = "enter";
+
+		[Desc("Cursor to display when unable to land at target building.")]
 		public readonly string EnterBlockedCursor = "enter-blocked";
 
 		public int GetInitialFacing() { return InitialFacing; }

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -940,11 +940,19 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				yield return new EnterAlliedActorTargeter<BuildingInfo>("ForceEnter", 6, Info.EnterCursor, Info.EnterBlockedCursor,
+				yield return new EnterAlliedActorTargeter<BuildingInfo>(
+					"ForceEnter",
+					6,
+					Info.EnterCursor,
+					Info.EnterBlockedCursor,
 					(target, modifiers) => Info.CanForceLand && modifiers.HasModifier(TargetModifiers.ForceMove) && AircraftCanEnter(target),
 					target => Reservable.IsAvailableFor(target, self) && AircraftCanResupplyAt(target, true));
 
-				yield return new EnterAlliedActorTargeter<BuildingInfo>("Enter", 5, Info.EnterCursor, Info.EnterBlockedCursor,
+				yield return new EnterAlliedActorTargeter<BuildingInfo>(
+					"Enter",
+					5,
+					Info.EnterCursor,
+					Info.EnterBlockedCursor,
 					AircraftCanEnter,
 					target => Reservable.IsAvailableFor(target, self) && AircraftCanResupplyAt(target, !Info.TakeOffOnResupply));
 

--- a/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Air/Aircraft.cs
@@ -139,6 +139,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Boolean expression defining the condition under which the regular (non-force) move cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;
 
+		public readonly string EnterCursor = "enter";
+		public readonly string EnterBlockedCursor = "enter-blocked";
+
 		public int GetInitialFacing() { return InitialFacing; }
 		public WDist GetCruiseAltitude() { return CruiseAltitude; }
 
@@ -937,11 +940,11 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				yield return new EnterAlliedActorTargeter<BuildingInfo>("ForceEnter", 6,
+				yield return new EnterAlliedActorTargeter<BuildingInfo>("ForceEnter", 6, Info.EnterCursor, Info.EnterBlockedCursor,
 					(target, modifiers) => Info.CanForceLand && modifiers.HasModifier(TargetModifiers.ForceMove) && AircraftCanEnter(target),
 					target => Reservable.IsAvailableFor(target, self) && AircraftCanResupplyAt(target, true));
 
-				yield return new EnterAlliedActorTargeter<BuildingInfo>("Enter", 5,
+				yield return new EnterAlliedActorTargeter<BuildingInfo>("Enter", 5, Info.EnterCursor, Info.EnterBlockedCursor,
 					AircraftCanEnter,
 					target => Reservable.IsAvailableFor(target, self) && AircraftCanResupplyAt(target, !Info.TakeOffOnResupply));
 

--- a/OpenRA.Mods.Common/Traits/Armament.cs
+++ b/OpenRA.Mods.Common/Traits/Armament.cs
@@ -76,9 +76,11 @@ namespace OpenRA.Mods.Common.Traits
 		// TODO: instead of having multiple Armaments and unique AttackBase,
 		// an actor should be able to have multiple AttackBases with
 		// a single corresponding Armament each
+		[Desc("Cursor to display when hovering over a valid target.")]
 		public readonly string Cursor = "attack";
 
 		// TODO: same as above
+		[Desc("Cursor to display when hovering over a valid target that is outside of range.")]
 		public readonly string OutsideRangeCursor = "attackoutsiderange";
 
 		public override object Create(ActorInitializer init) { return new Armament(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
+++ b/OpenRA.Mods.Common/Traits/Attack/AttackBase.cs
@@ -28,8 +28,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Armament names")]
 		public readonly string[] Armaments = { "primary", "secondary" };
 
+		[Desc("Cursor to display when hovering over a valid target.")]
 		public readonly string Cursor = null;
 
+		[Desc("Cursor to display when hovering over a valid target that is outside of range.")]
 		public readonly string OutsideRangeCursor = null;
 
 		[Desc("Color to use for the target line.")]

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -30,6 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 		[SequenceReference("Image")]
 		public readonly string CirclesSequence = "circles";
 
+		[Desc("Cursor to display when rally point can be set.")]
 		public readonly string Cursor = "ability";
 
 		[PaletteReference("IsPlayerPalette")]

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
@@ -36,6 +36,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Require the force-move modifier to display the move cursor.")]
 		public readonly bool RequiresForceMove = false;
 
+		public readonly string EnterCursor = "enter";
+		public readonly string EnterBlockedCursor = "enter-blocked";
+
 		public override object Create(ActorInitializer init) { return new TransformsIntoAircraft(init, this); }
 	}
 
@@ -62,7 +65,7 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				if (!IsTraitDisabled)
 				{
-					yield return new EnterAlliedActorTargeter<BuildingInfo>("Enter", 5, AircraftCanEnter,
+					yield return new EnterAlliedActorTargeter<BuildingInfo>("Enter", 5, Info.EnterCursor, Info.EnterBlockedCursor, AircraftCanEnter,
 						target => Reservable.IsAvailableFor(target, self));
 
 					yield return new AircraftMoveOrderTargeter(self, this);

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
@@ -65,7 +65,12 @@ namespace OpenRA.Mods.Common.Traits
 			{
 				if (!IsTraitDisabled)
 				{
-					yield return new EnterAlliedActorTargeter<BuildingInfo>("Enter", 5, Info.EnterCursor, Info.EnterBlockedCursor, AircraftCanEnter,
+					yield return new EnterAlliedActorTargeter<BuildingInfo>(
+						"Enter",
+						5,
+						Info.EnterCursor,
+						Info.EnterBlockedCursor,
+						AircraftCanEnter,
 						target => Reservable.IsAvailableFor(target, self));
 
 					yield return new AircraftMoveOrderTargeter(self, this);

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoAircraft.cs
@@ -36,7 +36,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Require the force-move modifier to display the move cursor.")]
 		public readonly bool RequiresForceMove = false;
 
+		[Desc("Cursor to display when able to land at target building.")]
 		public readonly string EnterCursor = "enter";
+
+		[Desc("Cursor to display when unable to land at target building.")]
 		public readonly string EnterBlockedCursor = "enter-blocked";
 
 		public override object Create(ActorInitializer init) { return new TransformsIntoAircraft(init, this); }

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoEntersTunnels.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoEntersTunnels.cs
@@ -23,7 +23,10 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Add to a building to expose a move cursor that triggers Transforms and issues an enter tunnel order to the transformed actor.")]
 	public class TransformsIntoEntersTunnelsInfo : ConditionalTraitInfo, Requires<TransformsInfo>
 	{
+		[Desc("Cursor to display when able to enter target tunnel.")]
 		public readonly string EnterCursor = "enter";
+
+		[Desc("Cursor to display when unable to enter target tunnel.")]
 		public readonly string EnterBlockedCursor = "enter-blocked";
 
 		[VoiceReference]

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoMobile.cs
@@ -27,7 +27,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Locomotor used by the transformed actor. Must be defined on the World actor.")]
 		public readonly string Locomotor = null;
 
+		[Desc("Cursor to display when a move order can be issued at target location.")]
 		public readonly string Cursor = "move";
+
+		[Desc("Cursor to display when a move order cannot be issued at target location.")]
 		public readonly string BlockedCursor = "move-blocked";
 
 		[VoiceReference]

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoPassenger.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoPassenger.cs
@@ -60,7 +60,13 @@ namespace OpenRA.Mods.Common.Traits
 			get
 			{
 				if (!IsTraitDisabled)
-					yield return new EnterAlliedActorTargeter<CargoInfo>("EnterTransport", 5, Info.EnterCursor, Info.EnterBlockedCursor, IsCorrectCargoType, CanEnter);
+					yield return new EnterAlliedActorTargeter<CargoInfo>(
+						"EnterTransport",
+						5,
+						Info.EnterCursor,
+						Info.EnterBlockedCursor,
+						IsCorrectCargoType,
+						CanEnter);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoPassenger.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoPassenger.cs
@@ -32,7 +32,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Require the force-move modifier to display the enter cursor.")]
 		public readonly bool RequiresForceMove = false;
 
+		[Desc("Cursor to display when able to enter target actor.")]
 		public readonly string EnterCursor = "enter";
+
+		[Desc("Cursor to display when unable to enter target actor.")]
 		public readonly string EnterBlockedCursor = "enter-blocked";
 
 		public override object Create(ActorInitializer init) { return new TransformsIntoPassenger(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoPassenger.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoPassenger.cs
@@ -32,6 +32,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Require the force-move modifier to display the enter cursor.")]
 		public readonly bool RequiresForceMove = false;
 
+		public readonly string EnterCursor = "enter";
+		public readonly string EnterBlockedCursor = "enter-blocked";
+
 		public override object Create(ActorInitializer init) { return new TransformsIntoPassenger(init.Self, this); }
 	}
 
@@ -57,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits
 			get
 			{
 				if (!IsTraitDisabled)
-					yield return new EnterAlliedActorTargeter<CargoInfo>("EnterTransport", 5, IsCorrectCargoType, CanEnter);
+					yield return new EnterAlliedActorTargeter<CargoInfo>("EnterTransport", 5, Info.EnterCursor, Info.EnterBlockedCursor, IsCorrectCargoType, CanEnter);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoRepairable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoRepairable.cs
@@ -33,6 +33,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Require the force-move modifier to display the enter cursor.")]
 		public readonly bool RequiresForceMove = false;
 
+		public readonly string EnterCursor = "enter";
+		public readonly string EnterBlockedCursor = "enter-blocked";
+
 		public override object Create(ActorInitializer init) { return new TransformsIntoRepairable(init.Self, this); }
 	}
 
@@ -60,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 			get
 			{
 				if (!IsTraitDisabled)
-					yield return new EnterAlliedActorTargeter<BuildingInfo>("Repair", 5, CanRepairAt, _ => CanRepair());
+					yield return new EnterAlliedActorTargeter<BuildingInfo>("Repair", 5, Info.EnterCursor, Info.EnterBlockedCursor, CanRepairAt, _ => CanRepair());
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoRepairable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoRepairable.cs
@@ -63,7 +63,13 @@ namespace OpenRA.Mods.Common.Traits
 			get
 			{
 				if (!IsTraitDisabled)
-					yield return new EnterAlliedActorTargeter<BuildingInfo>("Repair", 5, Info.EnterCursor, Info.EnterBlockedCursor, CanRepairAt, _ => CanRepair());
+					yield return new EnterAlliedActorTargeter<BuildingInfo>(
+						"Repair",
+						5,
+						Info.EnterCursor,
+						Info.EnterBlockedCursor,
+						CanRepairAt,
+						_ => CanRepair());
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoRepairable.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/TransformsIntoRepairable.cs
@@ -33,7 +33,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Require the force-move modifier to display the enter cursor.")]
 		public readonly bool RequiresForceMove = false;
 
+		[Desc("Cursor to display when able to be repaired at target actor.")]
 		public readonly string EnterCursor = "enter";
+
+		[Desc("Cursor to display when unable to be repaired at target actor.")]
 		public readonly string EnterBlockedCursor = "enter-blocked";
 
 		public override object Create(ActorInitializer init) { return new TransformsIntoRepairable(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/Captures.cs
+++ b/OpenRA.Mods.Common/Traits/Captures.cs
@@ -46,8 +46,13 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Stance that the structure's previous owner needs to have for the capturing player to receive Experience.")]
 		public readonly Stance PlayerExperienceStances = Stance.Enemy;
 
+		[Desc("Cursor to display when the health of the target actor is above the sabotage threshold.")]
 		public readonly string SabotageCursor = "capture";
+
+		[Desc("Cursor to display when able to capture the target actor.")]
 		public readonly string EnterCursor = "enter";
+
+		[Desc("Cursor to display when unable to capture the target actor.")]
 		public readonly string EnterBlockedCursor = "enter-blocked";
 
 		[VoiceReference]

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -50,6 +50,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Cursor to display when unable to drop off the passengers at location.")]
 		public readonly string DropOffBlockedCursor = "move-blocked";
 
+		[Desc("Cursor to display when picking up the passengers.")]
+		public readonly string PickUpCursor = "ability";
+
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
@@ -266,7 +269,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				yield return new CarryallPickupOrderTargeter();
+				yield return new CarryallPickupOrderTargeter(Info);
 				yield return new DeployOrderTargeter("Unload", 10,
 				() => CanUnload() ? Info.UnloadCursor : Info.UnloadBlockedCursor);
 				yield return new CarryallDeliverUnitTargeter(aircraftInfo, Info);
@@ -332,8 +335,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		class CarryallPickupOrderTargeter : UnitOrderTargeter
 		{
-			public CarryallPickupOrderTargeter()
-				: base("PickupUnit", 5, "ability", false, true)
+			public CarryallPickupOrderTargeter(CarryallInfo info)
+				: base("PickupUnit", 5, info.PickUpCursor, false, true)
 			{
 			}
 

--- a/OpenRA.Mods.Common/Traits/DeliversCash.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversCash.cs
@@ -32,6 +32,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sound to play when delivering cash")]
 		public readonly string[] Sounds = { };
 
+		[Desc("Cursor to show when hovering over a valid actor to deliver cash to.")]
+		public readonly string Cursor = "enter";
+
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
@@ -49,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public IEnumerable<IOrderTargeter> Orders
 		{
-			get { yield return new DeliversCashOrderTargeter(); }
+			get { yield return new DeliversCashOrderTargeter(info); }
 		}
 
 		public Order IssueOrder(Actor self, IOrderTargeter order, Target target, bool queued)
@@ -87,8 +90,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public class DeliversCashOrderTargeter : UnitOrderTargeter
 		{
-			public DeliversCashOrderTargeter()
-				: base("DeliverCash", 5, "enter", false, true) { }
+			public DeliversCashOrderTargeter(DeliversCashInfo info)
+				: base("DeliverCash", 5, info.Cursor, false, true) { }
 
 			public override bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor)
 			{

--- a/OpenRA.Mods.Common/Traits/DeliversCash.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversCash.cs
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sound to play when delivering cash")]
 		public readonly string[] Sounds = { };
 
-		[Desc("Cursor to show when hovering over a valid actor to deliver cash to.")]
+		[Desc("Cursor to display when hovering over a valid actor to deliver cash to.")]
 		public readonly string Cursor = "enter";
 
 		[VoiceReference]

--- a/OpenRA.Mods.Common/Traits/DeliversExperience.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversExperience.cs
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Identifier checked against AcceptsDeliveredExperience.ValidTypes. Only needed if the latter is not empty.")]
 		public readonly string Type = null;
 
-		[Desc("Cursor to show when hovering over a valid actor to deliver experience to.")]
+		[Desc("Cursor to display when hovering over a valid actor to deliver experience to.")]
 		public readonly string Cursor = "enter";
 
 		[VoiceReference]

--- a/OpenRA.Mods.Common/Traits/DeliversExperience.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversExperience.cs
@@ -26,6 +26,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Identifier checked against AcceptsDeliveredExperience.ValidTypes. Only needed if the latter is not empty.")]
 		public readonly string Type = null;
 
+		[Desc("Cursor to show when hovering over a valid actor to deliver experience to.")]
+		public readonly string Cursor = "enter";
+
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
@@ -50,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 			get
 			{
 				if (gainsExperience.Level != 0)
-					yield return new DeliversExperienceOrderTargeter();
+					yield return new DeliversExperienceOrderTargeter(info);
 			}
 		}
 
@@ -90,8 +93,8 @@ namespace OpenRA.Mods.Common.Traits
 
 		public class DeliversExperienceOrderTargeter : UnitOrderTargeter
 		{
-			public DeliversExperienceOrderTargeter()
-				: base("DeliverExperience", 5, "enter", true, true) { }
+			public DeliversExperienceOrderTargeter(DeliversExperienceInfo info)
+				: base("DeliverExperience", 5, info.Cursor, true, true) { }
 
 			public override bool CanTargetActor(Actor self, Actor target, TargetModifiers modifiers, ref string cursor)
 			{

--- a/OpenRA.Mods.Common/Traits/Demolition.cs
+++ b/OpenRA.Mods.Common/Traits/Demolition.cs
@@ -44,6 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly Stance TargetStances = Stance.Enemy | Stance.Neutral;
 		public readonly Stance ForceTargetStances = Stance.Enemy | Stance.Neutral | Stance.Ally;
 
+		[Desc("Cursor to display when hovering over a demolishable target.")]
 		public readonly string Cursor = "c4";
 
 		public override object Create(ActorInitializer init) { return new Demolition(this); }

--- a/OpenRA.Mods.Common/Traits/EngineerRepair.cs
+++ b/OpenRA.Mods.Common/Traits/EngineerRepair.cs
@@ -37,10 +37,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sound to play when repairing is done.")]
 		public readonly string RepairSound = null;
 
-		[Desc("Cursor to show when hovering over a valid actor to repair.")]
+		[Desc("Cursor to display when hovering over a valid actor to repair.")]
 		public readonly string Cursor = "goldwrench";
 
-		[Desc("Cursor to show when target actor has full health so it can't be repaired.")]
+		[Desc("Cursor to display when target actor has full health so it can't be repaired.")]
 		public readonly string RepairBlockedCursor = "goldwrench-blocked";
 
 		public override object Create(ActorInitializer init) { return new EngineerRepair(init, this); }

--- a/OpenRA.Mods.Common/Traits/EntersTunnels.cs
+++ b/OpenRA.Mods.Common/Traits/EntersTunnels.cs
@@ -22,7 +22,10 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("This actor can interact with TunnelEntrances to move through TerrainTunnels.")]
 	public class EntersTunnelsInfo : TraitInfo, Requires<IMoveInfo>, IObservesVariablesInfo
 	{
+		[Desc("Cursor to display when able to enter target tunnel.")]
 		public readonly string EnterCursor = "enter";
+
+		[Desc("Cursor to display when unable to enter target tunnel.")]
 		public readonly string EnterBlockedCursor = "enter-blocked";
 
 		[VoiceReference]

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -84,7 +84,10 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference]
 		public readonly string DeliverVoice = "Action";
 
+		[Desc("Cursor to display when able to unload at target actor.")]
 		public readonly string EnterCursor = "enter";
+
+		[Desc("Cursor to display when unable to unload at target actor.")]
 		public readonly string EnterBlockedCursor = "enter-blocked";
 
 		public override object Create(ActorInitializer init) { return new Harvester(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -281,7 +281,11 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				yield return new EnterAlliedActorTargeter<IAcceptResourcesInfo>("Deliver", 5, Info.EnterCursor, Info.EnterBlockedCursor,
+				yield return new EnterAlliedActorTargeter<IAcceptResourcesInfo>(
+					"Deliver",
+					5,
+					Info.EnterCursor,
+					Info.EnterBlockedCursor,
 					(proc, _) => IsAcceptableProcType(proc),
 					proc => proc.Trait<IAcceptResources>().AllowDocking);
 				yield return new HarvestOrderTargeter();

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -84,6 +84,9 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference]
 		public readonly string DeliverVoice = "Action";
 
+		public readonly string EnterCursor = "enter";
+		public readonly string EnterBlockedCursor = "enter-blocked";
+
 		public override object Create(ActorInitializer init) { return new Harvester(init.Self, this); }
 	}
 
@@ -278,7 +281,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				yield return new EnterAlliedActorTargeter<IAcceptResourcesInfo>("Deliver", 5,
+				yield return new EnterAlliedActorTargeter<IAcceptResourcesInfo>("Deliver", 5, Info.EnterCursor, Info.EnterBlockedCursor,
 					(proc, _) => IsAcceptableProcType(proc),
 					proc => proc.Trait<IAcceptResources>().AllowDocking);
 				yield return new HarvestOrderTargeter();

--- a/OpenRA.Mods.Common/Traits/Mobile.cs
+++ b/OpenRA.Mods.Common/Traits/Mobile.cs
@@ -37,7 +37,10 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly int Speed = 1;
 
+		[Desc("Cursor to display when a move order can be issued at target location.")]
 		public readonly string Cursor = "move";
+
+		[Desc("Cursor to display when a move order cannot be issued at target location.")]
 		public readonly string BlockedCursor = "move-blocked";
 
 		[VoiceReference]

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -47,6 +47,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Boolean expression defining the condition under which the regular (non-force) enter cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;
 
+		public readonly string EnterCursor = "enter";
+		public readonly string EnterBlockedCursor = "enter-blocked";
+
 		public override object Create(ActorInitializer init) { return new Passenger(this); }
 	}
 
@@ -70,7 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				yield return new EnterAlliedActorTargeter<CargoInfo>("EnterTransport", 5, IsCorrectCargoType, CanEnter);
+				yield return new EnterAlliedActorTargeter<CargoInfo>("EnterTransport", 5, Info.EnterCursor, Info.EnterBlockedCursor, IsCorrectCargoType, CanEnter);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -73,7 +73,13 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				yield return new EnterAlliedActorTargeter<CargoInfo>("EnterTransport", 5, Info.EnterCursor, Info.EnterBlockedCursor, IsCorrectCargoType, CanEnter);
+				yield return new EnterAlliedActorTargeter<CargoInfo>(
+					"EnterTransport",
+					5,
+					Info.EnterCursor,
+					Info.EnterBlockedCursor,
+					IsCorrectCargoType,
+					CanEnter);
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -47,7 +47,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Boolean expression defining the condition under which the regular (non-force) enter cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;
 
+		[Desc("Cursor to display when able to enter target actor.")]
 		public readonly string EnterCursor = "enter";
+
+		[Desc("Cursor to display when unable to enter target actor.")]
 		public readonly string EnterBlockedCursor = "enter-blocked";
 
 		public override object Create(ActorInitializer init) { return new Passenger(this); }

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -37,6 +37,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Boolean expression defining the condition under which the regular (non-force) enter cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;
 
+		public readonly string EnterCursor = "enter";
+		public readonly string EnterBlockedCursor = "enter-blocked";
+
 		public override object Create(ActorInitializer init) { return new Repairable(init.Self, this); }
 	}
 
@@ -65,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 			get
 			{
 				if (!isAircraft)
-					yield return new EnterAlliedActorTargeter<BuildingInfo>("Repair", 5, CanRepairAt, _ => CanRepair() || CanRearm());
+					yield return new EnterAlliedActorTargeter<BuildingInfo>("Repair", 5, Info.EnterCursor, Info.EnterBlockedCursor, CanRepairAt, _ => CanRepair() || CanRearm());
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -68,7 +68,13 @@ namespace OpenRA.Mods.Common.Traits
 			get
 			{
 				if (!isAircraft)
-					yield return new EnterAlliedActorTargeter<BuildingInfo>("Repair", 5, Info.EnterCursor, Info.EnterBlockedCursor, CanRepairAt, _ => CanRepair() || CanRearm());
+					yield return new EnterAlliedActorTargeter<BuildingInfo>(
+						"Repair",
+						5,
+						Info.EnterCursor,
+						Info.EnterBlockedCursor,
+						CanRepairAt,
+						_ => CanRepair() || CanRearm());
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -37,7 +37,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Boolean expression defining the condition under which the regular (non-force) enter cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;
 
+		[Desc("Cursor to display when able to be repaired at target actor.")]
 		public readonly string EnterCursor = "enter";
+
+		[Desc("Cursor to display when unable to be repaired at target actor.")]
 		public readonly string EnterBlockedCursor = "enter-blocked";
 
 		public override object Create(ActorInitializer init) { return new Repairable(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -34,6 +34,9 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Boolean expression defining the condition under which the regular (non-force) enter cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;
 
+		public readonly string EnterCursor = "enter";
+		public readonly string EnterBlockedCursor = "enter-blocked";
+
 		public override object Create(ActorInitializer init) { return new RepairableNear(init.Self, this); }
 	}
 
@@ -53,7 +56,7 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				yield return new EnterAlliedActorTargeter<BuildingInfo>("RepairNear", 5,
+				yield return new EnterAlliedActorTargeter<BuildingInfo>("RepairNear", 5, Info.EnterCursor, Info.EnterBlockedCursor,
 					CanRepairAt, _ => ShouldRepair());
 			}
 		}

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -34,7 +34,10 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Boolean expression defining the condition under which the regular (non-force) enter cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;
 
+		[Desc("Cursor to display when able to be repaired near target actor.")]
 		public readonly string EnterCursor = "enter";
+
+		[Desc("Cursor to display when unable to be repaired near target actor.")]
 		public readonly string EnterBlockedCursor = "enter-blocked";
 
 		public override object Create(ActorInitializer init) { return new RepairableNear(init.Self, this); }

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -56,8 +56,13 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			get
 			{
-				yield return new EnterAlliedActorTargeter<BuildingInfo>("RepairNear", 5, Info.EnterCursor, Info.EnterBlockedCursor,
-					CanRepairAt, _ => ShouldRepair());
+				yield return new EnterAlliedActorTargeter<BuildingInfo>(
+					"RepairNear",
+					5,
+					Info.EnterCursor,
+					Info.EnterBlockedCursor,
+					CanRepairAt,
+					_ => ShouldRepair());
 			}
 		}
 

--- a/OpenRA.Mods.Common/Traits/RepairsBridges.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsBridges.cs
@@ -27,10 +27,10 @@ namespace OpenRA.Mods.Common.Traits
 			"Possible values are Exit, Suicide, Dispose.")]
 		public readonly EnterBehaviour EnterBehaviour = EnterBehaviour.Dispose;
 
-		[Desc("Cursor to use when targeting an unrepaired bridge.")]
+		[Desc("Cursor to display when targeting an unrepaired bridge.")]
 		public readonly string TargetCursor = "goldwrench";
 
-		[Desc("Cursor to use when repairing is denied.")]
+		[Desc("Cursor to display when repairing is denied.")]
 		public readonly string TargetBlockedCursor = "goldwrench-blocked";
 
 		[NotificationReference("Speech")]

--- a/OpenRA.Mods.Common/Traits/Sellable.cs
+++ b/OpenRA.Mods.Common/Traits/Sellable.cs
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Skip playing (reversed) make animation.")]
 		public readonly bool SkipMakeAnimation = false;
 
-		[Desc("Cursor type to use when the sell order generator hovers over this actor.")]
+		[Desc("Cursor to display when the sell order generator hovers over this actor.")]
 		public readonly string Cursor = "sell";
 
 		public override object Create(ActorInitializer init) { return new Sellable(init.Self, this); }


### PR DESCRIPTION
As mentioned in #18087 the target cursor for `DeliversCash` is not configurable. I set out to fix that but noticed that there are many more hard-coded cursors in various traits so I took a pass at all of them.

The last commit before the testcase is just formatting because the changes to `EnterAlliedActorTargeter` resulted in very long argument lists.

The testcase changes all target cursors of affected traits to `goldwrench` and `goldwrench-blocked`.