### PR TITLE
Unhardcode the cargo plane entry path in ProductionAirdrop

### DIFF
--- a/OpenRA.Game/Map/Map.cs
+++ b/OpenRA.Game/Map/Map.cs
@@ -1264,9 +1264,9 @@ namespace OpenRA
 		public WDist DistanceToEdge(WPos pos, WVec dir)
 		{
 			var projectedPos = pos - new WVec(0, pos.Z, pos.Z);
-			var x = dir.X == 0 ? int.MaxValue : ((dir.X < 0 ? ProjectedTopLeft.X : ProjectedBottomRight.X) - projectedPos.X) / dir.X;
-			var y = dir.Y == 0 ? int.MaxValue : ((dir.Y < 0 ? ProjectedTopLeft.Y : ProjectedBottomRight.Y) - projectedPos.Y) / dir.Y;
-			return new WDist(Math.Min(x, y) * dir.Length);
+			var x = dir.X == 0 ? int.MaxValue : ((dir.X < 0 ? ProjectedTopLeft.X : ProjectedBottomRight.X) - projectedPos.X) * dir.Length / dir.X;
+			var y = dir.Y == 0 ? int.MaxValue : ((dir.Y < 0 ? ProjectedTopLeft.Y : ProjectedBottomRight.Y) - projectedPos.Y) * dir.Length / dir.Y;
+			return new WDist(Math.Min(x, y));
 		}
 
 		// Both ranges are inclusive because everything that calls it is designed for maxRange being inclusive:

--- a/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/ProductionAirdrop.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Cargo aircraft used for delivery. Must have the `Aircraft` trait.")]
 		public readonly string ActorType = null;
 
-		[Desc("The cargo aircraft will spawn at the player baseline (map edge closest to the player spawn)")]
+		[Desc("The cargo aircraft will spawn at the player baseline (map edge directly behind the player spawn)")]
 		public readonly bool BaselineSpawn = false;
 
 		[Desc("Direction the aircraft should face to land.")]


### PR DESCRIPTION
Fixes  #17400

Finally addresses https://github.com/OpenRA/OpenRA/pull/16595#issuecomment-496173941 (It only took a year :stuck_out_tongue: )

Instead of hardcoding the direction of the cargo plane to always be east-west regardless of the specified facing (which only determines the landing direction), the cargo plane should now enter the map from the angle specified by the facing parameter.