### PR TITLE
Disable non-neutral owners for player spawns in map editor

### DIFF
--- a/OpenRA.Mods.Common/Traits/World/MPStartLocations.cs
+++ b/OpenRA.Mods.Common/Traits/World/MPStartLocations.cs
@@ -11,7 +11,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
@@ -85,7 +84,7 @@ namespace OpenRA.Mods.Common.Traits
 				.ToArray();
 
 			if (world.LobbyInfo.Clients.Any(c => c.SpawnPoint > spawns.Length))
-				throw new DataException("Failed to obtain available spawns");
+				throw new InvalidOperationException("Failed to obtain available spawns");
 
 			var taken = world.LobbyInfo.Clients.Where(c => c.SpawnPoint != 0 && c.Slot != null)
 					.Select(c => spawns[c.SpawnPoint - 1]).ToList();

--- a/OpenRA.Mods.Common/Traits/World/MPStartLocations.cs
+++ b/OpenRA.Mods.Common/Traits/World/MPStartLocations.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using OpenRA.Graphics;
 using OpenRA.Primitives;
@@ -82,6 +83,9 @@ namespace OpenRA.Mods.Common.Traits
 			var spawns = world.Actors.Where(a => a.Info.Name == "mpspawn")
 				.Select(a => a.Location)
 				.ToArray();
+
+			if (world.LobbyInfo.Clients.Any(c => c.SpawnPoint > spawns.Length))
+				throw new DataException("Failed to obtain available spawns");
 
 			var taken = world.LobbyInfo.Clients.Where(c => c.SpawnPoint != 0 && c.Slot != null)
 					.Select(c => spawns[c.SpawnPoint - 1]).ToList();

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -234,6 +234,25 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					var ownerHandler = new EditorActorOptionActionHandle<PlayerReference>(updateOwner, actor.Owner);
 					editActorPreview.Add(ownerHandler);
 
+					var specificOwnerInfo = actor.Info.TraitInfoOrDefault<RequiresSpecificOwnersInfo>();
+					Dictionary<string, PlayerReference>.ValueCollection owners;
+
+					if (specificOwnerInfo != null)
+					{
+						owners = editorActorLayer.Players.Players.Values.Where(x =>
+								specificOwnerInfo.ValidOwnerNames.Any(y => x.Name == y))
+							.ToDictionary(player => player.Name)
+							.Values;
+						if (owners.Count == 1)
+						{
+							ownerDropdown.IsDisabled = () => true;
+						}
+					}
+					else
+					{
+						owners = editorActorLayer.Players.Players.Values;
+					}
+
 					Func<PlayerReference, ScrollItemWidget, ScrollItemWidget> setupItem = (option, template) =>
 					{
 						var item = ScrollItemWidget.Setup(template, () => selectedOwner == option, () =>
@@ -252,16 +271,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					ownerDropdown.GetColor = () => selectedOwner.Color;
 					ownerDropdown.OnClick = () =>
 					{
-						var specificOwnerInfo = actor.Info.TraitInfoOrDefault<RequiresSpecificOwnersInfo>();
-						var owners = editorActorLayer.Players.Players.Values;
-						if (specificOwnerInfo != null)
-						{
-							owners = editorActorLayer.Players.Players.Values.Where(x =>
-								specificOwnerInfo.ValidOwnerNames.Any(y => x.Name == y))
-								.ToDictionary(player => player.Name)
-								.Values;
-						}
-
 						ownerDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 270, owners, setupItem);
 					};
 

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -252,7 +252,6 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					ownerDropdown.GetColor = () => selectedOwner.Color;
 					ownerDropdown.OnClick = () =>
 					{
-						// Get if this trait requires a specific owner
 						var specificOwnerInfo = actor.Info.TraitInfoOrDefault<RequiresSpecificOwnersInfo>();
 						var owners = editorActorLayer.Players.Players.Values;
 						if (specificOwnerInfo != null)

--- a/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
+++ b/OpenRA.Mods.Common/Widgets/Logic/Editor/ActorEditLogic.cs
@@ -252,7 +252,17 @@ namespace OpenRA.Mods.Common.Widgets.Logic
 					ownerDropdown.GetColor = () => selectedOwner.Color;
 					ownerDropdown.OnClick = () =>
 					{
-						var owners = editorActorLayer.Players.Players.Values.OrderBy(p => p.Name);
+						// Get if this trait requires a specific owner
+						var specificOwnerInfo = actor.Info.TraitInfoOrDefault<RequiresSpecificOwnersInfo>();
+						var owners = editorActorLayer.Players.Players.Values;
+						if (specificOwnerInfo != null)
+						{
+							owners = editorActorLayer.Players.Players.Values.Where(x =>
+								specificOwnerInfo.ValidOwnerNames.Any(y => x.Name == y))
+								.ToDictionary(player => player.Name)
+								.Values;
+						}
+
 						ownerDropdown.ShowDropDown("LABEL_DROPDOWN_TEMPLATE", 270, owners, setupItem);
 					};
 


### PR DESCRIPTION
Fixes #18092 

In my opinion it makes sense to remove other actors from the owners dropdown in map editor since player spawns assigned to anything other than neutral will cause crashes when spawns are unassigned

I've also added a check if we are trying to get a spawn and raise an exception if we do, however this approach is far from ideal and will still crash the entire game. I would really appreciate it If anyone could give me a lead on how could we recover from this state.  