### PR TITLE
Adjust D2k actor build times

### DIFF
--- a/mods/d2k/rules/aircraft.yaml
+++ b/mods/d2k/rules/aircraft.yaml
@@ -43,8 +43,8 @@ carryall.reinforce:
 		Delay: 3
 		HealIfBelow: 50
 	Buildable:
-		BuildDuration: 648
-		BuildDurationModifier: 40
+		BuildDuration: 750
+		BuildDurationModifier: 100
 		Description: Large winged, planet-bound ship\n  Automatically lifts harvesters from and to Spice.\n  Lifts vehicles to Repair Pads when ordered.
 
 carryall:

--- a/mods/d2k/rules/infantry.yaml
+++ b/mods/d2k/rules/infantry.yaml
@@ -4,8 +4,8 @@ light_inf:
 	Buildable:
 		Queue: Infantry
 		BuildPaletteOrder: 10
-		BuildDuration: 54
-		BuildDurationModifier: 40
+		BuildDuration: 62
+		BuildDurationModifier: 100
 		Description: General-purpose infantry\n  Strong vs Infantry\n  Weak vs Vehicles, Artillery
 	Valued:
 		Cost: 50
@@ -29,8 +29,8 @@ engineer:
 		Queue: Infantry
 		BuildPaletteOrder: 30
 		Prerequisites: upgrade.barracks, ~techlevel.medium
-		BuildDuration: 108
-		BuildDurationModifier: 40
+		BuildDuration: 125
+		BuildDurationModifier: 100
 		Description: Infiltrates and captures enemy structures\n  Strong vs Buildings\n  Weak vs Everything
 	Valued:
 		Cost: 400
@@ -61,8 +61,8 @@ trooper:
 		Queue: Infantry
 		BuildPaletteOrder: 20
 		Prerequisites: upgrade.barracks, ~techlevel.medium
-		BuildDuration: 73
-		BuildDurationModifier: 40
+		BuildDuration: 85
+		BuildDurationModifier: 100
 		Description: Anti-tank infantry\n  Strong vs Tanks\n  Weak vs Infantry, Artillery
 	Valued:
 		Cost: 90
@@ -91,8 +91,8 @@ thumper:
 		Queue: Infantry
 		BuildPaletteOrder: 40
 		Prerequisites: upgrade.barracks, ~techlevel.high
-		BuildDuration: 108
-		BuildDurationModifier: 40
+		BuildDuration: 125
+		BuildDurationModifier: 100
 		Description: Attracts nearby worms when deployed\n  Unarmed
 	Valued:
 		Cost: 200
@@ -182,8 +182,8 @@ grenadier:
 		Queue: Infantry
 		BuildPaletteOrder: 60
 		Prerequisites: ~barracks.atreides, upgrade.barracks, high_tech_factory, ~techlevel.medium
-		BuildDuration: 81 ## Wasn't converted, copied from Sardauker who has same value in TibEd.
-		BuildDurationModifier: 40
+		BuildDuration: 94
+		BuildDurationModifier: 100
 		Description: Infantry armed with grenades. \n  Strong vs Buildings, Infantry\n  Weak vs Vehicles
 	Valued:
 		Cost: 80
@@ -214,8 +214,8 @@ sardaukar:
 		Queue: Infantry
 		BuildPaletteOrder: 50
 		Prerequisites: ~palace.sardaukar, ~techlevel.high
-		BuildDuration: 81
-		BuildDurationModifier: 40
+		BuildDuration: 94
+		BuildDurationModifier: 100
 		Description: Elite assault infantry of Corrino\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery
 	Valued:
 		Cost: 120
@@ -248,7 +248,8 @@ mpsardaukar:
 		Queue: Infantry
 		BuildPaletteOrder: 70
 		Prerequisites: ~barracks.harkonnen, upgrade.barracks, high_tech_factory, ~techlevel.medium
-		BuildDuration: 133
+		BuildDuration: 160
+		BuildDurationModifier: 100
 		Description: Elite assault infantry of Harkonnen\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery
 	Valued:
 		Cost: 200

--- a/mods/d2k/rules/misc.yaml
+++ b/mods/d2k/rules/misc.yaml
@@ -222,8 +222,8 @@ upgrade.conyard:
 		Prerequisites: construction_yard
 		Queue: Upgrade
 		BuildLimit: 1
-		BuildDuration: 590
-		BuildDurationModifier: 40
+		BuildDuration: 625
+		BuildDurationModifier: 100
 		Description: Unlocks additional construction options \n(Large Concrete Slab, Rocket Turret)
 	Valued:
 		Cost: 1000
@@ -247,8 +247,8 @@ upgrade.barracks:
 		Prerequisites: barracks
 		Queue: Upgrade
 		BuildLimit: 1
-		BuildDuration: 290
-		BuildDurationModifier: 40
+		BuildDuration: 208
+		BuildDurationModifier: 100
 		Description: Unlocks additional infantry \n(Trooper, Engineer, Thumper Infantry)    \n\nRequired to unlock faction specific infantry \n(Atreides: Grenadier, Harkonnen: Sardaukar)
 	Valued:
 		Cost: 500
@@ -272,8 +272,8 @@ upgrade.light:
 		Prerequisites: light_factory
 		Queue: Upgrade
 		BuildLimit: 1
-		BuildDuration: 215
-		BuildDurationModifier: 40
+		BuildDuration: 268
+		BuildDurationModifier: 100
 		Description: Unlocks additional light unit \n(Missile Quad) \n\nRequired to unlock faction specific light unit \n(Ordos: Stealth Raider Trike)
 	Valued:
 		Cost: 400
@@ -297,8 +297,8 @@ upgrade.heavy:
 		Prerequisites: heavy_factory
 		Queue: Upgrade
 		BuildLimit: 1
-		BuildDuration: 380
-		BuildDurationModifier: 40
+		BuildDuration: 468
+		BuildDurationModifier: 100
 		Description: Unlocks additional construction options    \n(Repair Pad, IX Research Center) \n\nUnlocks additional heavy units \n(Siege Tank, Missile Tank, MCV)
 	Valued:
 		Cost: 800
@@ -323,8 +323,8 @@ upgrade.hightech:
 		Prerequisites: ~hightech.atreides, ~techlevel.superweapons
 		Queue: Upgrade
 		BuildLimit: 1
-		BuildDuration: 720
-		BuildDurationModifier: 40
+		BuildDuration: 937
+		BuildDurationModifier: 100
 		Description: Unlocks the Atreides Air Strike superweapon
 	Valued:
 		Cost: 1500

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -18,6 +18,7 @@ Player:
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 		SpeedUp: true
+		BuildTimeSpeedReduction: 100, 66, 50
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
 		DisplayOrder: 1
@@ -28,6 +29,7 @@ Player:
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 		SpeedUp: true
+		BuildTimeSpeedReduction: 100, 66, 50
 	ClassicProductionQueue@Vehicle:
 		Type: Vehicle
 		DisplayOrder: 2
@@ -38,6 +40,7 @@ Player:
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 		SpeedUp: true
+		BuildTimeSpeedReduction: 100, 66, 50
 	ClassicProductionQueue@Armor:
 		Type: Armor
 		DisplayOrder: 3
@@ -48,6 +51,7 @@ Player:
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 		SpeedUp: true
+		BuildTimeSpeedReduction: 100, 66, 50
 	ClassicProductionQueue@Starport:
 		Type: Starport
 		DisplayOrder: 4
@@ -66,6 +70,7 @@ Player:
 		OnHoldAudio: OnHold
 		CancelledAudio: Cancelled
 		SpeedUp: true
+		BuildTimeSpeedReduction: 100, 66, 50
 	ClassicProductionQueue@Upgrade: # Upgrade is defined after others so it won't be automatically selected by ProductionQueueFromSelection.
 		Type: Upgrade
 		ReadyAudio: NewOptions

--- a/mods/d2k/rules/player.yaml
+++ b/mods/d2k/rules/player.yaml
@@ -11,7 +11,6 @@ Player:
 	ClassicProductionQueue@Building:
 		Type: Building
 		DisplayOrder: 0
-		BuildDurationModifier: 250
 		LowPowerModifier: 300
 		ReadyAudio: BuildingReady
 		BlockedAudio: NoRoom
@@ -22,7 +21,6 @@ Player:
 	ClassicProductionQueue@Infantry:
 		Type: Infantry
 		DisplayOrder: 1
-		BuildDurationModifier: 250
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
 		BlockedAudio: NoRoom
@@ -33,7 +31,6 @@ Player:
 	ClassicProductionQueue@Vehicle:
 		Type: Vehicle
 		DisplayOrder: 2
-		BuildDurationModifier: 250
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
 		BlockedAudio: NoRoom
@@ -44,7 +41,6 @@ Player:
 	ClassicProductionQueue@Armor:
 		Type: Armor
 		DisplayOrder: 3
-		BuildDurationModifier: 250
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
 		BlockedAudio: NoRoom
@@ -63,7 +59,6 @@ Player:
 	ClassicProductionQueue@Aircraft:
 		Type: Aircraft
 		DisplayOrder: 5
-		BuildDurationModifier: 312
 		LowPowerModifier: 300
 		ReadyAudio: UnitReady
 		BlockedAudio: NoRoom
@@ -73,7 +68,6 @@ Player:
 		SpeedUp: true
 	ClassicProductionQueue@Upgrade: # Upgrade is defined after others so it won't be automatically selected by ProductionQueueFromSelection.
 		Type: Upgrade
-		BuildDurationModifier: 250
 		ReadyAudio: NewOptions
 		BlockedAudio: NoRoom
 		QueuedAudio: Upgrading

--- a/mods/d2k/rules/structures.yaml
+++ b/mods/d2k/rules/structures.yaml
@@ -34,8 +34,8 @@ concretea:
 		Cost: 20
 	Buildable:
 		BuildPaletteOrder: 110
-		BuildDuration: 54
-		BuildDurationModifier: 40
+		BuildDuration: 62
+		BuildDurationModifier: 100
 
 concreteb:
 	Inherits: ^concrete
@@ -49,8 +49,8 @@ concreteb:
 	Buildable:
 		BuildPaletteOrder: 210
 		Prerequisites: upgrade.conyard
-		BuildDuration: 81
-		BuildDurationModifier: 40
+		BuildDuration: 94
+		BuildDurationModifier: 100
 
 construction_yard:
 	Inherits: ^Building
@@ -117,8 +117,8 @@ wind_trap:
 	Buildable:
 		Queue: Building
 		BuildPaletteOrder: 120
-		BuildDuration: 180
-		BuildDurationModifier: 40
+		BuildDuration: 208
+		BuildDurationModifier: 100
 		Description: Provides power for other structures.
 	Selectable:
 		Bounds: 64,64
@@ -166,8 +166,8 @@ barracks:
 		Prerequisites: wind_trap
 		Queue: Building
 		BuildPaletteOrder: 220
-		BuildDuration: 231
-		BuildDurationModifier: 40
+		BuildDuration: 268
+		BuildDurationModifier: 100
 		Description: Trains infantry.
 	Selectable:
 		Bounds: 64,64
@@ -233,8 +233,8 @@ refinery:
 		Prerequisites: wind_trap
 		Queue: Building
 		BuildPaletteOrder: 130
-		BuildDuration: 540
-		BuildDurationModifier: 40
+		BuildDuration: 625
+		BuildDurationModifier: 100
 		Description: Harvesters unload Spice here for processing.
 	Selectable:
 		Bounds: 96,64
@@ -302,8 +302,8 @@ silo:
 		Prerequisites: refinery
 		Queue: Building
 		BuildPaletteOrder: 310
-		BuildDuration: 135
-		BuildDurationModifier: 40
+		BuildDuration: 156
+		BuildDurationModifier: 100
 		Description: Stores excess harvested Spice.
 	Selectable:
 		Bounds: 32,32
@@ -357,8 +357,8 @@ light_factory:
 		Prerequisites: refinery
 		Queue: Building
 		BuildPaletteOrder: 230
-		BuildDuration: 277
-		BuildDurationModifier: 40
+		BuildDuration: 321
+		BuildDurationModifier: 100
 		Description: Produces light vehicles.
 	Selectable:
 		Bounds: 96,64
@@ -435,8 +435,8 @@ heavy_factory:
 		Prerequisites: refinery
 		Queue: Building
 		BuildPaletteOrder: 330
-		BuildDuration: 648
-		BuildDurationModifier: 40
+		BuildDuration: 750
+		BuildDurationModifier: 100
 		Description: Produces heavy vehicles.
 	Selectable:
 		Bounds: 96,96
@@ -523,8 +523,8 @@ outpost:
 		Prerequisites: barracks, ~techlevel.medium
 		Queue: Building
 		BuildPaletteOrder: 320
-		BuildDuration: 270
-		BuildDurationModifier: 40
+		BuildDuration: 312
+		BuildDurationModifier: 100
 		Description: Provides a radar map of the battlefield.\n  Requires power to operate.
 	Selectable:
 		Bounds: 96,64
@@ -575,8 +575,8 @@ starport:
 		Prerequisites: heavy_factory, outpost, ~techlevel.high
 		Queue: Building
 		BuildPaletteOrder: 530
-		BuildDuration: 540
-		BuildDurationModifier: 40
+		BuildDuration: 625
+		BuildDurationModifier: 100
 		Description: Dropzone for quick reinforcements, at a price.
 	Valued:
 		Cost: 1500
@@ -658,8 +658,8 @@ wall:
 		Queue: Building
 		Prerequisites: barracks
 		BuildPaletteOrder: 410
-		BuildDuration: 54
-		BuildDurationModifier: 40
+		BuildDuration: 62
+		BuildDurationModifier: 100
 		Description: Stop units and blocks enemy fire.
 	Valued:
 		Cost: 20
@@ -722,8 +722,8 @@ medium_gun_turret:
 		Queue: Building
 		Prerequisites: barracks
 		BuildPaletteOrder: 510
-		BuildDuration: 231
-		BuildDurationModifier: 40
+		BuildDuration: 268
+		BuildDurationModifier: 100
 		Description: Defensive structure.\n  Strong vs Tanks\n  Weak vs Infantry, Aircraft
 	Valued:
 		Cost: 550
@@ -765,8 +765,8 @@ large_gun_turret:
 		Queue: Building
 		Prerequisites: outpost, upgrade.conyard, ~techlevel.medium
 		BuildPaletteOrder: 610
-		BuildDuration: 270
-		BuildDurationModifier: 40
+		BuildDuration: 312
+		BuildDurationModifier: 100
 		Description: Defensive structure.\n  Strong vs Infantry, Aircraft\n  Weak vs Tanks\n\n  Requires power to operate.
 	Valued:
 		Cost: 750
@@ -804,8 +804,8 @@ repair_pad:
 		Queue: Building
 		Prerequisites: heavy_factory, upgrade.heavy, ~techlevel.medium
 		BuildPaletteOrder: 430
-		BuildDuration: 324
-		BuildDurationModifier: 40
+		BuildDuration: 375
+		BuildDurationModifier: 100
 		Description: Repairs vehicles.\n Allows construction of MCVs
 	Valued:
 		Cost: 800
@@ -860,8 +860,8 @@ high_tech_factory:
 		Prerequisites: outpost, ~techlevel.medium
 		Queue: Building
 		BuildPaletteOrder: 420
-		BuildDuration: 405
-		BuildDurationModifier: 40
+		BuildDuration: 468
+		BuildDurationModifier: 100
 		Description: Unlocks advanced technology.
 	Selectable:
 		Bounds: 96,96
@@ -939,8 +939,8 @@ research_centre:
 		Queue: Building
 		Prerequisites: outpost, heavy_factory, upgrade.heavy, ~techlevel.high
 		BuildPaletteOrder: 520
-		BuildDuration: 270
-		BuildDurationModifier: 40
+		BuildDuration: 312
+		BuildDurationModifier: 100
 		Description: Unlocks advanced tanks.
 	Selectable:
 		Bounds: 96,96
@@ -991,8 +991,8 @@ palace:
 		Prerequisites: research_centre, ~techlevel.high
 		Queue: Building
 		BuildPaletteOrder: 620
-		BuildDuration: 810
-		BuildDurationModifier: 40
+		BuildDuration: 937
+		BuildDurationModifier: 100
 		Description: Unlocks elite infantry and weapons.
 	Selectable:
 		Bounds: 96,96

--- a/mods/d2k/rules/vehicles.yaml
+++ b/mods/d2k/rules/vehicles.yaml
@@ -5,8 +5,8 @@ mcv:
 		Prerequisites: repair_pad, upgrade.heavy, ~techlevel.medium
 		Queue: Armor
 		BuildPaletteOrder: 110
-		BuildDuration: 648
-		BuildDurationModifier: 40
+		BuildDuration: 750
+		BuildDurationModifier: 100
 		Description: Deploys into another Construction Yard\n  Unarmed
 	Valued:
 		Cost: 2000
@@ -54,8 +54,8 @@ harvester:
 		Queue: Armor
 		Prerequisites: refinery
 		BuildPaletteOrder: 10
-		BuildDuration: 540
-		BuildDurationModifier: 40
+		BuildDuration: 625
+		BuildDurationModifier: 100
 		Description: Collects Spice for processing\n  Unarmed
 	Valued:
 		Cost: 1200
@@ -111,8 +111,8 @@ trike:
 		Queue: Vehicle
 		BuildPaletteOrder: 10
 		Prerequisites: ~light.trike
-		BuildDuration: 194
-		BuildDurationModifier: 40
+		BuildDuration: 225
+		BuildDurationModifier: 100
 		Description: Fast scout\n  Strong vs Infantry\n  Weak vs Tanks
 	Valued:
 		Cost: 300
@@ -154,8 +154,8 @@ quad:
 		Queue: Vehicle
 		Prerequisites: upgrade.light, ~techlevel.medium
 		BuildPaletteOrder: 20
-		BuildDuration: 277
-		BuildDurationModifier: 40
+		BuildDuration: 321
+		BuildDurationModifier: 100
 		Description: Missile Scout\n  Strong vs Vehicles\n  Weak vs Infantry
 	Valued:
 		Cost: 400
@@ -192,8 +192,8 @@ siege_tank:
 		Queue: Armor
 		Prerequisites: upgrade.heavy, ~techlevel.medium
 		BuildPaletteOrder: 50
-		BuildDuration: 324
-		BuildDurationModifier: 40
+		BuildDuration: 375
+		BuildDurationModifier: 100
 		Description: Siege Artillery\n  Strong vs Infantry, Buildings\n  Weak vs Tanks
 	Valued:
 		Cost: 700
@@ -248,8 +248,8 @@ missile_tank:
 		Queue: Armor
 		Prerequisites: ~heavy.missile_tank, upgrade.heavy, research_centre, ~techlevel.high
 		BuildPaletteOrder: 60
-		BuildDuration: 441
-		BuildDurationModifier: 40
+		BuildDuration: 512
+		BuildDurationModifier: 100
 		Description: Rocket Artillery\n  Strong vs Vehicles, Buildings, Aircraft\n  Weak vs Infantry
 	Valued:
 		Cost: 900
@@ -288,8 +288,8 @@ sonic_tank:
 		Queue: Armor
 		BuildPaletteOrder: 100
 		Prerequisites: ~heavy.atreides, research_centre, ~techlevel.high
-		BuildDuration: 486
-		BuildDurationModifier: 40
+		BuildDuration: 562
+		BuildDurationModifier: 100
 		Description: Fires sonic shocks\n  Strong vs Infantry, Vehicles\n  Weak vs Artillery
 	Valued:
 		Cost: 1000
@@ -328,8 +328,8 @@ devastator:
 		Queue: Armor
 		BuildPaletteOrder: 100
 		Prerequisites: ~heavy.harkonnen, research_centre, ~techlevel.high
-		BuildDuration: 540
-		BuildDurationModifier: 40
+		BuildDuration: 625
+		BuildDurationModifier: 100
 		Description: Super Heavy Tank\n  Strong vs Tanks\n  Weak vs Artillery
 	Valued:
 		Cost: 1050
@@ -400,8 +400,8 @@ raider:
 		Queue: Vehicle
 		BuildPaletteOrder: 10
 		Prerequisites: ~light.raider
-		BuildDuration: 194
-		BuildDurationModifier: 40
+		BuildDuration: 225
+		BuildDurationModifier: 100
 		Description: Improved Scout\n  Strong vs Infantry, Light Vehicles\n  Weak vs Tanks
 	Valued:
 		Cost: 350
@@ -438,8 +438,8 @@ stealth_raider:
 	Buildable:
 		Prerequisites: ~light.ordos, upgrade.light, high_tech_factory, ~techlevel.medium
 		BuildPaletteOrder: 30
-		BuildDuration: 194 ## Copied from Raider, not included in conversion. Both have same "BuildSpeed" in TibEd
-		BuildDurationModifier: 40
+		BuildDuration: 225
+		BuildDurationModifier: 100
 		Description: Invisible Raider Trike\n  Strong vs Infantry, Light Vehicles\n  Weak vs Tanks
 	Valued:
 		Cost: 400
@@ -475,8 +475,8 @@ deviator:
 		Queue: Armor
 		BuildPaletteOrder: 50
 		Prerequisites: ~heavy.ordos, research_centre, ~techlevel.high
-		BuildDuration: 486
-		BuildDurationModifier: 40
+		BuildDuration: 562
+		BuildDurationModifier: 100
 		Description: Fires a warhead which changes\nthe allegiance of enemy vehicles
 	Mobile:
 		TurnSpeed: 3
@@ -510,8 +510,8 @@ deviator:
 	Buildable:
 		Queue: Armor
 		BuildPaletteOrder: 40
-		BuildDuration: 373
-		BuildDurationModifier: 40
+		BuildDuration: 432
+		BuildDurationModifier: 100
 		Description: Main Battle Tank\n  Strong vs Tanks\n  Weak vs Infantry
 	Valued:
 		Cost: 700


### PR DESCRIPTION
Adjusted actor production times in D2k based on the specifications in #18051. Also cleaned up the D2k part of the mess mentioned in #18119.
This pretty much reverts the work from #9453, but that is also mentioned in the issue.
Power-related production slowdowns will come in a separate PR because those require a tiny bit of engine work (and potentially more than a tiny bit of UI work) and I want to keep these PRs small and simple.