### PR TITLE
Add helicopters and move E3 prerequisites to campaign-rules.yaml

### DIFF
--- a/mods/ra/maps/allies-03a/rules.yaml
+++ b/mods/ra/maps/allies-03a/rules.yaml
@@ -175,10 +175,6 @@ KENN:
 	Buildable:
 		Prerequisites: ~disabled
 
-E3:
-	Buildable:
-		Prerequisites: ~disabled
-
 E4:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/allies-03b/rules.yaml
+++ b/mods/ra/maps/allies-03b/rules.yaml
@@ -127,10 +127,6 @@ JEEP.mission:
 		Image: JEEP
 	Interactable:
 
-E3:
-	Buildable:
-		Prerequisites: ~disabled
-
 E4:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/sarin-gas-1-crackdown/rules.yaml
+++ b/mods/ra/maps/sarin-gas-1-crackdown/rules.yaml
@@ -21,10 +21,6 @@ APC:
 	Buildable:
 		Prerequisites: ~vehicles.allies
 
-E3:
-	Buildable:
-		Prerequisites: ~infantry.allies
-
 3TNK:
 	Buildable:
 		Prerequisites: ~vehicles.soviet

--- a/mods/ra/maps/soviet-02a/rules.yaml
+++ b/mods/ra/maps/soviet-02a/rules.yaml
@@ -56,10 +56,6 @@ MSLO:
 	Buildable:
 		Prerequisites: ~disabled
 
-E3:
-	Buildable:
-		Prerequisites: ~disabled
-
 E4:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/soviet-02b/rules.yaml
+++ b/mods/ra/maps/soviet-02b/rules.yaml
@@ -56,10 +56,6 @@ MSLO:
 	Buildable:
 		Prerequisites: ~disabled
 
-E3:
-	Buildable:
-		Prerequisites: ~disabled
-
 E4:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/soviet-04a/rules.yaml
+++ b/mods/ra/maps/soviet-04a/rules.yaml
@@ -46,10 +46,6 @@ BRIK:
 	Buildable:
 		Prerequisites: ~disabled
 
-E3:
-	Buildable:
-		Prerequisites: ~tent
-
 E4:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/soviet-04b/rules.yaml
+++ b/mods/ra/maps/soviet-04b/rules.yaml
@@ -46,10 +46,6 @@ BRIK:
 	Buildable:
 		Prerequisites: ~disabled
 
-E3:
-	Buildable:
-		Prerequisites: ~tent
-
 E4:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/soviet-05/rules.yaml
+++ b/mods/ra/maps/soviet-05/rules.yaml
@@ -114,10 +114,6 @@ BRIK:
 	Buildable:
 		Prerequisites: ~disabled
 
-E3:
-	Buildable:
-		Prerequisites: ~tent
-
 E4:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/soviet-06a/rules.yaml
+++ b/mods/ra/maps/soviet-06a/rules.yaml
@@ -56,10 +56,6 @@ MSLO:
 	Buildable:
 		Prerequisites: ~disabled
 
-E3:
-	Buildable:
-		Prerequisites: ~tent
-
 E7:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/soviet-06b/rules.yaml
+++ b/mods/ra/maps/soviet-06b/rules.yaml
@@ -56,10 +56,6 @@ MSLO:
 	Buildable:
 		Prerequisites: ~disabled
 
-E3:
-	Buildable:
-		Prerequisites: ~tent
-
 E7:
 	Buildable:
 		Prerequisites: ~disabled

--- a/mods/ra/maps/soviet-08a/rules.yaml
+++ b/mods/ra/maps/soviet-08a/rules.yaml
@@ -128,7 +128,3 @@ E7:
 MECH:
 	Buildable:
 		Prerequisites: ~disabled
-
-E3:
-	Buildable:
-		Prerequisites: ~tent

--- a/mods/ra/rules/campaign-rules.yaml
+++ b/mods/ra/rules/campaign-rules.yaml
@@ -75,3 +75,27 @@ Ant:
 Zombie:
 	Buildable:
 		Prerequisites: ~disabled
+
+HPAD:
+	ProvidesPrerequisite@allies:
+		Factions: allies
+		Prerequisite: helicopters.allies
+	ProvidesPrerequisite@soviet:
+		Factions: soviet
+		Prerequisite: helicopters.soviet
+
+MH60:
+	Buildable:
+		Prerequisites: ~disabled
+
+HIND:
+	Buildable:
+		Prerequisites: ~helicopters.soviet
+
+HELI:
+	Buildable:
+		Prerequisites: ~helicopters.allies
+
+TRAN:
+	Buildable:
+		Prerequisites: ~helicopters.allies

--- a/mods/ra/rules/campaign-rules.yaml
+++ b/mods/ra/rules/campaign-rules.yaml
@@ -32,6 +32,10 @@ World:
 		ShortGameCheckboxLocked: True
 		ShortGameCheckboxEnabled: False
 
+E3:
+	Buildable:
+		Prerequisites: ~tent
+
 E7:
 	-Crushable:
 


### PR DESCRIPTION
Split off from #17963. Adding campaign specific helicopter prereqs as we're getting into late-tech missions. Also moving e3 override since almost soviet mission needs it.