### PR TITLE
Replace ITraitInfo interface with TraitInfo class.

### DIFF
--- a/OpenRA.Game/GameRules/ActorInfo.cs
+++ b/OpenRA.Game/GameRules/ActorInfo.cs
@@ -32,7 +32,7 @@ namespace OpenRA
 		/// </summary>
 		public readonly string Name;
 		readonly TypeDictionary traits = new TypeDictionary();
-		List<ITraitInfo> constructOrderCache = null;
+		List<TraitInfo> constructOrderCache = null;
 
 		public ActorInfo(ObjectCreator creator, string name, MiniYaml node)
 		{
@@ -64,7 +64,7 @@ namespace OpenRA
 			}
 		}
 
-		public ActorInfo(string name, params ITraitInfo[] traitInfos)
+		public ActorInfo(string name, params TraitInfo[] traitInfos)
 		{
 			Name = name;
 			foreach (var t in traitInfos)
@@ -72,7 +72,7 @@ namespace OpenRA
 			traits.TrimExcess();
 		}
 
-		static ITraitInfo LoadTraitInfo(ObjectCreator creator, string traitName, MiniYaml my)
+		static TraitInfo LoadTraitInfo(ObjectCreator creator, string traitName, MiniYaml my)
 		{
 			if (!string.IsNullOrEmpty(my.Value))
 				throw new YamlException("Junk value `{0}` on trait node {1}"
@@ -80,7 +80,7 @@ namespace OpenRA
 
 			// HACK: The linter does not want to crash when a trait doesn't exist but only print an error instead
 			// ObjectCreator will only return null to signal us to abort here if the linter is running
-			var info = creator.CreateObject<ITraitInfo>(traitName + "Info");
+			var info = creator.CreateObject<TraitInfo>(traitName + "Info");
 			if (info == null)
 				return null;
 
@@ -97,12 +97,12 @@ namespace OpenRA
 			return info;
 		}
 
-		public IEnumerable<ITraitInfo> TraitsInConstructOrder()
+		public IEnumerable<TraitInfo> TraitsInConstructOrder()
 		{
 			if (constructOrderCache != null)
 				return constructOrderCache;
 
-			var source = traits.WithInterface<ITraitInfo>().Select(i => new
+			var source = traits.WithInterface<TraitInfo>().Select(i => new
 			{
 				Trait = i,
 				Type = i.GetType(),
@@ -148,7 +148,7 @@ namespace OpenRA
 			return constructOrderCache;
 		}
 
-		public static IEnumerable<Type> PrerequisitesOf(ITraitInfo info)
+		public static IEnumerable<Type> PrerequisitesOf(TraitInfo info)
 		{
 			return info
 				.GetType()

--- a/OpenRA.Game/Traits/DebugPauseState.cs
+++ b/OpenRA.Game/Traits/DebugPauseState.cs
@@ -12,9 +12,9 @@
 namespace OpenRA.Traits
 {
 	[Desc("Checks for pause related desyncs. Attach this to the world actor.")]
-	public class DebugPauseStateInfo : ITraitInfo
+	public class DebugPauseStateInfo : TraitInfo
 	{
-		public object Create(ActorInitializer init) { return new DebugPauseState(init.World); }
+		public override object Create(ActorInitializer init) { return new DebugPauseState(init.World); }
 	}
 
 	public class DebugPauseState : ISync

--- a/OpenRA.Game/Traits/Player/FixedColorPalette.cs
+++ b/OpenRA.Game/Traits/Player/FixedColorPalette.cs
@@ -15,7 +15,7 @@ using OpenRA.Primitives;
 namespace OpenRA.Traits
 {
 	[Desc("Add this to the World actor definition.")]
-	public class FixedColorPaletteInfo : ITraitInfo
+	public class FixedColorPaletteInfo : TraitInfo
 	{
 		[PaletteReference]
 		[Desc("The name of the palette to base off.")]
@@ -37,7 +37,7 @@ namespace OpenRA.Traits
 		[Desc("Allow palette modifiers to change the palette.")]
 		public readonly bool AllowModifiers = true;
 
-		public object Create(ActorInitializer init) { return new FixedColorPalette(this); }
+		public override object Create(ActorInitializer init) { return new FixedColorPalette(this); }
 	}
 
 	public class FixedColorPalette : ILoadsPalettes

--- a/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
+++ b/OpenRA.Game/Traits/Player/FrozenActorLayer.cs
@@ -23,12 +23,12 @@ namespace OpenRA.Traits
 	}
 
 	[Desc("Required for FrozenUnderFog to work. Attach this to the player actor.")]
-	public class FrozenActorLayerInfo : Requires<ShroudInfo>, ITraitInfo
+	public class FrozenActorLayerInfo : TraitInfo, Requires<ShroudInfo>
 	{
 		[Desc("Size of partition bins (cells)")]
 		public readonly int BinSize = 10;
 
-		public object Create(ActorInitializer init) { return new FrozenActorLayer(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new FrozenActorLayer(init.Self, this); }
 	}
 
 	public class FrozenActor

--- a/OpenRA.Game/Traits/Player/IndexedPlayerPalette.cs
+++ b/OpenRA.Game/Traits/Player/IndexedPlayerPalette.cs
@@ -17,7 +17,7 @@ using OpenRA.Primitives;
 namespace OpenRA.Traits
 {
 	[Desc("Define a player palette by swapping palette indices.")]
-	public class IndexedPlayerPaletteInfo : ITraitInfo, IRulesetLoaded
+	public class IndexedPlayerPaletteInfo : TraitInfo, IRulesetLoaded
 	{
 		[PaletteReference]
 		[Desc("The name of the palette to base off.")]
@@ -35,7 +35,7 @@ namespace OpenRA.Traits
 
 		public readonly Dictionary<string, int[]> PlayerIndex;
 
-		public object Create(ActorInitializer init) { return new IndexedPlayerPalette(this); }
+		public override object Create(ActorInitializer init) { return new IndexedPlayerPalette(this); }
 
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{

--- a/OpenRA.Game/Traits/Player/PlayerColorPalette.cs
+++ b/OpenRA.Game/Traits/Player/PlayerColorPalette.cs
@@ -15,7 +15,7 @@ using OpenRA.Primitives;
 namespace OpenRA.Traits
 {
 	[Desc("Add this to the Player actor definition.")]
-	public class PlayerColorPaletteInfo : ITraitInfo
+	public class PlayerColorPaletteInfo : TraitInfo
 	{
 		[PaletteReference]
 		[Desc("The name of the palette to base off.")]
@@ -34,7 +34,7 @@ namespace OpenRA.Traits
 		[Desc("Allow palette modifiers to change the palette.")]
 		public readonly bool AllowModifiers = true;
 
-		public object Create(ActorInitializer init) { return new PlayerColorPalette(this); }
+		public override object Create(ActorInitializer init) { return new PlayerColorPalette(this); }
 	}
 
 	public class PlayerColorPalette : ILoadsPlayerPalettes

--- a/OpenRA.Game/Traits/Player/PlayerHighlightPalette.cs
+++ b/OpenRA.Game/Traits/Player/PlayerHighlightPalette.cs
@@ -16,7 +16,7 @@ using OpenRA.Primitives;
 namespace OpenRA.Traits
 {
 	[Desc("Add this to the Player actor definition.")]
-	public class PlayerHighlightPaletteInfo : ITraitInfo
+	public class PlayerHighlightPaletteInfo : TraitInfo
 	{
 		[PaletteDefinition(true)]
 		[Desc("The prefix for the resulting player palettes")]
@@ -25,7 +25,7 @@ namespace OpenRA.Traits
 		[Desc("Index set to be fully transparent/invisible.")]
 		public readonly int TransparentIndex = 0;
 
-		public object Create(ActorInitializer init) { return new PlayerHighlightPalette(this); }
+		public override object Create(ActorInitializer init) { return new PlayerHighlightPalette(this); }
 	}
 
 	public class PlayerHighlightPalette : ILoadsPlayerPalettes

--- a/OpenRA.Game/Traits/Player/Shroud.cs
+++ b/OpenRA.Game/Traits/Player/Shroud.cs
@@ -15,7 +15,7 @@ using System.Collections.Generic;
 namespace OpenRA.Traits
 {
 	[Desc("Required for shroud and fog visibility checks. Add this to the player actor.")]
-	public class ShroudInfo : ITraitInfo, ILobbyOptions
+	public class ShroudInfo : TraitInfo, ILobbyOptions
 	{
 		[Translate]
 		[Desc("Descriptive label for the fog checkbox in the lobby.")]
@@ -65,7 +65,7 @@ namespace OpenRA.Traits
 				FogCheckboxVisible, FogCheckboxDisplayOrder, FogCheckboxEnabled, FogCheckboxLocked);
 		}
 
-		public object Create(ActorInitializer init) { return new Shroud(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new Shroud(init.Self, this); }
 	}
 
 	public class Shroud : ISync, INotifyCreated, ITick

--- a/OpenRA.Game/Traits/TraitsInterfaces.cs
+++ b/OpenRA.Game/Traits/TraitsInterfaces.cs
@@ -49,7 +49,7 @@ namespace OpenRA.Traits
 	/// </summary>
 	public sealed class DamageType { DamageType() { } }
 
-	public interface IHealthInfo : ITraitInfo
+	public interface IHealthInfo : ITraitInfoInterface
 	{
 		int MaxHP { get; }
 	}
@@ -324,9 +324,17 @@ namespace OpenRA.Traits
 	public interface IFacingInfo : ITraitInfoInterface { int GetInitialFacing(); }
 
 	public interface ITraitInfoInterface { }
-	public interface ITraitInfo : ITraitInfoInterface { object Create(ActorInitializer init); }
 
-	public class TraitInfo<T> : ITraitInfo where T : new() { public virtual object Create(ActorInitializer init) { return new T(); } }
+	public abstract class TraitInfo : ITraitInfoInterface
+	{
+		public abstract object Create(ActorInitializer init);
+	}
+
+	public class TraitInfo<T> : TraitInfo where T : new()
+	{
+		public override object Create(ActorInitializer init) { return new T(); }
+	}
+
 	public interface ILobbyCustomRulesIgnore { }
 
 	[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1302:InterfaceNamesMustBeginWithI", Justification = "Not a real interface, but more like a tag.")]
@@ -541,7 +549,7 @@ namespace OpenRA.Traits
 	public interface ICreationActivity { Activity GetCreationActivity(); }
 
 	[RequireExplicitImplementation]
-	public interface IObservesVariablesInfo : ITraitInfo { }
+	public interface IObservesVariablesInfo : ITraitInfoInterface { }
 
 	public delegate void VariableObserverNotifier(Actor self, IReadOnlyDictionary<string, int> variables);
 	public struct VariableObserver

--- a/OpenRA.Game/Traits/World/ScreenMap.cs
+++ b/OpenRA.Game/Traits/World/ScreenMap.cs
@@ -30,12 +30,12 @@ namespace OpenRA.Traits
 		public override string ToString() { return "{0}->{1}".F(Actor.Info.Name, Bounds.GetType().Name); }
 	}
 
-	public class ScreenMapInfo : ITraitInfo
+	public class ScreenMapInfo : TraitInfo
 	{
 		[Desc("Size of partition bins (world pixels)")]
 		public readonly int BinSize = 250;
 
-		public object Create(ActorInitializer init) { return new ScreenMap(init.World, this); }
+		public override object Create(ActorInitializer init) { return new ScreenMap(init.World, this); }
 	}
 
 	public class ScreenMap : IWorldLoaded

--- a/OpenRA.Game/Traits/World/ScreenShaker.cs
+++ b/OpenRA.Game/Traits/World/ScreenShaker.cs
@@ -16,12 +16,12 @@ using OpenRA.Graphics;
 
 namespace OpenRA.Traits
 {
-	public class ScreenShakerInfo : ITraitInfo
+	public class ScreenShakerInfo : TraitInfo
 	{
 		public readonly float2 MinMultiplier = new float2(-3, -3);
 		public readonly float2 MaxMultiplier = new float2(3, 3);
 
-		public object Create(ActorInitializer init) { return new ScreenShaker(this); }
+		public override object Create(ActorInitializer init) { return new ScreenShaker(this); }
 	}
 
 	public class ScreenShaker : ITick, IWorldLoaded

--- a/OpenRA.Mods.Cnc/Traits/ConyardChronoReturn.cs
+++ b/OpenRA.Mods.Cnc/Traits/ConyardChronoReturn.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	[Desc("Implements the special case handling for the Chronoshiftable return on a construction yard.",
 		"If ReturnOriginalActorOnCondition evaluates true and the actor is not being sold then OriginalActor will be returned to the origin.",
 		"Otherwise, a vortex animation is played and damage is dealt each tick, ignoring modifiers.")]
-	public class ConyardChronoReturnInfo : IObservesVariablesInfo, Requires<HealthInfo>, Requires<WithSpriteBodyInfo>
+	public class ConyardChronoReturnInfo : TraitInfo, Requires<HealthInfo>, Requires<WithSpriteBodyInfo>, IObservesVariablesInfo
 	{
 		[SequenceReference]
 		[Desc("Sequence name with the baked-in vortex animation")]
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("The color the bar of the 'return-to-origin' logic has.")]
 		public readonly Color TimeBarColor = Color.White;
 
-		public object Create(ActorInitializer init) { return new ConyardChronoReturn(init, this); }
+		public override object Create(ActorInitializer init) { return new ConyardChronoReturn(init, this); }
 	}
 
 	public class ConyardChronoReturn : ITick, ISync, IObservesVariables, ISelectionBar, INotifySold,

--- a/OpenRA.Mods.Cnc/Traits/Disguise.cs
+++ b/OpenRA.Mods.Cnc/Traits/Disguise.cs
@@ -70,7 +70,7 @@ namespace OpenRA.Mods.Cnc.Traits
 	}
 
 	[Desc("Provides access to the disguise command, which makes the actor appear to be another player's actor.")]
-	class DisguiseInfo : ITraitInfo
+	class DisguiseInfo : TraitInfo
 	{
 		[VoiceReference]
 		public readonly string Voice = "Action";
@@ -96,7 +96,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[GrantedConditionReference]
 		public IEnumerable<string> LinterConditions { get { return DisguisedAsConditions.Values; } }
 
-		public object Create(ActorInitializer init) { return new Disguise(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new Disguise(init.Self, this); }
 	}
 
 	class Disguise : IEffectiveOwner, IIssueOrder, IResolveOrder, IOrderVoice, IRadarColorModifier, INotifyAttack,

--- a/OpenRA.Mods.Cnc/Traits/FrozenUnderFogUpdatedByGps.cs
+++ b/OpenRA.Mods.Cnc/Traits/FrozenUnderFogUpdatedByGps.cs
@@ -19,9 +19,9 @@ namespace OpenRA.Mods.Cnc.Traits
 	using FrozenActorAction = Action<FrozenUnderFogUpdatedByGps, FrozenActorLayer, GpsWatcher, FrozenActor>;
 
 	[Desc("Updates frozen actors of actors that change owners, are sold or die whilst having an active GPS power.")]
-	public class FrozenUnderFogUpdatedByGpsInfo : ITraitInfo, Requires<FrozenUnderFogInfo>
+	public class FrozenUnderFogUpdatedByGpsInfo : TraitInfo, Requires<FrozenUnderFogInfo>
 	{
-		public object Create(ActorInitializer init) { return new FrozenUnderFogUpdatedByGps(init); }
+		public override object Create(ActorInitializer init) { return new FrozenUnderFogUpdatedByGps(init); }
 	}
 
 	public class FrozenUnderFogUpdatedByGps : INotifyOwnerChanged, INotifyActorDisposing, IOnGpsRefreshed

--- a/OpenRA.Mods.Cnc/Traits/GpsDot.cs
+++ b/OpenRA.Mods.Cnc/Traits/GpsDot.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Show an indicator revealing the actor underneath the fog when a GPSWatcher is activated.")]
-	class GpsDotInfo : ITraitInfo
+	class GpsDotInfo : TraitInfo
 	{
 		[Desc("Sprite collection for symbols.")]
 		public readonly string Image = "gpsdot";
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[PaletteReference(true)]
 		public readonly string IndicatorPalettePrefix = "player";
 
-		public object Create(ActorInitializer init) { return new GpsDot(this); }
+		public override object Create(ActorInitializer init) { return new GpsDot(this); }
 	}
 
 	class GpsDot : INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld

--- a/OpenRA.Mods.Cnc/Traits/GpsWatcher.cs
+++ b/OpenRA.Mods.Cnc/Traits/GpsWatcher.cs
@@ -17,9 +17,9 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Required for `GpsPower`. Attach this to the player actor.")]
-	class GpsWatcherInfo : ITraitInfo
+	class GpsWatcherInfo : TraitInfo
 	{
-		public object Create(ActorInitializer init) { return new GpsWatcher(init.Self.Owner); }
+		public override object Create(ActorInitializer init) { return new GpsWatcher(init.Self.Owner); }
 	}
 
 	interface IOnGpsRefreshed { void OnGpsRefresh(Actor self, Player player); }

--- a/OpenRA.Mods.Cnc/Traits/HarvesterHuskModifier.cs
+++ b/OpenRA.Mods.Cnc/Traits/HarvesterHuskModifier.cs
@@ -14,13 +14,13 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	public class HarvesterHuskModifierInfo : ITraitInfo, Requires<HarvesterInfo>
+	public class HarvesterHuskModifierInfo : TraitInfo, Requires<HarvesterInfo>
 	{
 		[ActorReference]
 		public readonly string FullHuskActor = null;
 		public readonly int FullnessThreshold = 50;
 
-		public object Create(ActorInitializer init) { return new HarvesterHuskModifier(this); }
+		public override object Create(ActorInitializer init) { return new HarvesterHuskModifier(this); }
 	}
 
 	public class HarvesterHuskModifier : IHuskModifier

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForCash.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForCash.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Funds are transferred from the owner to the infiltrator.")]
-	class InfiltrateForCashInfo : ITraitInfo
+	class InfiltrateForCashInfo : TraitInfo
 	{
 		[Desc("The `TargetTypes` from `Targetable` that are allowed to enter.")]
 		public readonly BitSet<TargetableType> Types = default(BitSet<TargetableType>);
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Whether to show the cash tick indicators rising from the actor.")]
 		public readonly bool ShowTicks = true;
 
-		public object Create(ActorInitializer init) { return new InfiltrateForCash(this); }
+		public override object Create(ActorInitializer init) { return new InfiltrateForCash(this); }
 	}
 
 	class InfiltrateForCash : INotifyInfiltrated

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForExploration.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForExploration.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Steal and reset the owner's exploration.")]
-	class InfiltrateForExplorationInfo : ITraitInfo
+	class InfiltrateForExplorationInfo : TraitInfo
 	{
 		[Desc("The `TargetTypes` from `Targetable` that are allowed to enter.")]
 		public readonly BitSet<TargetableType> Types = default(BitSet<TargetableType>);
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sound the perpetrator will hear after successful infiltration.")]
 		public readonly string InfiltrationNotification = null;
 
-		public object Create(ActorInitializer init) { return new InfiltrateForExploration(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new InfiltrateForExploration(init.Self, this); }
 	}
 
 	class InfiltrateForExploration : INotifyInfiltrated

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForPowerOutage.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForPowerOutage.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	class InfiltrateForPowerOutageInfo : ITraitInfo
+	class InfiltrateForPowerOutageInfo : TraitInfo
 	{
 		[Desc("The `TargetTypes` from `Targetable` that are allowed to enter.")]
 		public readonly BitSet<TargetableType> Types = default(BitSet<TargetableType>);
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sound the perpetrator will hear after successful infiltration.")]
 		public readonly string InfiltrationNotification = null;
 
-		public object Create(ActorInitializer init) { return new InfiltrateForPowerOutage(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new InfiltrateForPowerOutage(init.Self, this); }
 	}
 
 	class InfiltrateForPowerOutage : INotifyOwnerChanged, INotifyInfiltrated

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPower.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPower.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	class InfiltrateForSupportPowerInfo : ITraitInfo
+	class InfiltrateForSupportPowerInfo : TraitInfo
 	{
 		[ActorReference]
 		[FieldLoader.Require]
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sound the perpetrator will hear after successful infiltration.")]
 		public readonly string InfiltrationNotification = null;
 
-		public object Create(ActorInitializer init) { return new InfiltrateForSupportPower(this); }
+		public override object Create(ActorInitializer init) { return new InfiltrateForSupportPower(this); }
 	}
 
 	class InfiltrateForSupportPower : INotifyInfiltrated

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPowerReset.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForSupportPowerReset.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	class InfiltrateForSupportPowerResetInfo : ITraitInfo
+	class InfiltrateForSupportPowerResetInfo : TraitInfo
 	{
 		[Desc("The `TargetTypes` from `Targetable` that are allowed to enter.")]
 		public readonly BitSet<TargetableType> Types = default(BitSet<TargetableType>);
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sound the perpetrator will hear after successful infiltration.")]
 		public readonly string InfiltrationNotification = null;
 
-		public object Create(ActorInitializer init) { return new InfiltrateForSupportPowerReset(this); }
+		public override object Create(ActorInitializer init) { return new InfiltrateForSupportPowerReset(this); }
 	}
 
 	class InfiltrateForSupportPowerReset : INotifyInfiltrated

--- a/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForTransform.cs
+++ b/OpenRA.Mods.Cnc/Traits/Infiltration/InfiltrateForTransform.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Transform into a different actor type.")]
-	class InfiltrateForTransformInfo : ITraitInfo
+	class InfiltrateForTransformInfo : TraitInfo
 	{
 		[ActorReference]
 		[FieldLoader.Require]
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("The `TargetTypes` from `Targetable` that are allowed to enter.")]
 		public readonly BitSet<TargetableType> Types = default(BitSet<TargetableType>);
 
-		public object Create(ActorInitializer init) { return new InfiltrateForTransform(init, this); }
+		public override object Create(ActorInitializer init) { return new InfiltrateForTransform(init, this); }
 	}
 
 	class InfiltrateForTransform : INotifyInfiltrated

--- a/OpenRA.Mods.Cnc/Traits/MadTank.cs
+++ b/OpenRA.Mods.Cnc/Traits/MadTank.cs
@@ -23,7 +23,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	class MadTankInfo : ITraitInfo, IRulesetLoaded, Requires<ExplodesInfo>, Requires<WithFacingSpriteBodyInfo>
+	class MadTankInfo : TraitInfo, IRulesetLoaded, Requires<ExplodesInfo>, Requires<WithFacingSpriteBodyInfo>
 	{
 		[SequenceReference]
 		public readonly string ThumpSequence = "piston";
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Types of damage that this trait causes to self while self-destructing. Leave empty for no damage types.")]
 		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
 
-		public object Create(ActorInitializer init) { return new MadTank(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new MadTank(init.Self, this); }
 
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{

--- a/OpenRA.Mods.Cnc/Traits/Mine.cs
+++ b/OpenRA.Mods.Cnc/Traits/Mine.cs
@@ -15,14 +15,14 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	class MineInfo : ITraitInfo
+	class MineInfo : TraitInfo
 	{
 		public readonly BitSet<CrushClass> CrushClasses = default(BitSet<CrushClass>);
 		public readonly bool AvoidFriendly = true;
 		public readonly bool BlockFriendly = true;
 		public readonly BitSet<CrushClass> DetonateClasses = default(BitSet<CrushClass>);
 
-		public object Create(ActorInitializer init) { return new Mine(this); }
+		public override object Create(ActorInitializer init) { return new Mine(this); }
 	}
 
 	class Mine : ICrushable, INotifyCrushed

--- a/OpenRA.Mods.Cnc/Traits/Minelayer.cs
+++ b/OpenRA.Mods.Cnc/Traits/Minelayer.cs
@@ -21,7 +21,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	public class MinelayerInfo : ITraitInfo, Requires<RearmableInfo>
+	public class MinelayerInfo : TraitInfo, Requires<RearmableInfo>
 	{
 		[ActorReference]
 		public readonly string Mine = "minv";
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Sprite overlay to use for minefield cells hidden behind fog or shroud.")]
 		public readonly string TileUnknownName = "build-unknown";
 
-		public object Create(ActorInitializer init) { return new Minelayer(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new Minelayer(init.Self, this); }
 	}
 
 	public class Minelayer : IIssueOrder, IResolveOrder, ISync, IIssueDeployOrder, IOrderVoice, ITick

--- a/OpenRA.Mods.Cnc/Traits/PaletteEffects/ChronoshiftPaletteEffect.cs
+++ b/OpenRA.Mods.Cnc/Traits/PaletteEffects/ChronoshiftPaletteEffect.cs
@@ -16,12 +16,12 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Apply palette full screen rotations during chronoshifts. Add this to the world actor.")]
-	public class ChronoshiftPaletteEffectInfo : ITraitInfo
+	public class ChronoshiftPaletteEffectInfo : TraitInfo
 	{
 		[Desc("Measured in ticks.")]
 		public readonly int ChronoEffectLength = 60;
 
-		public object Create(ActorInitializer init) { return new ChronoshiftPaletteEffect(this); }
+		public override object Create(ActorInitializer init) { return new ChronoshiftPaletteEffect(this); }
 	}
 
 	public class ChronoshiftPaletteEffect : IPaletteModifier, ITick

--- a/OpenRA.Mods.Cnc/Traits/PaletteEffects/LightPaletteRotator.cs
+++ b/OpenRA.Mods.Cnc/Traits/PaletteEffects/LightPaletteRotator.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Palette effect used for blinking \"animations\" on actors.")]
-	class LightPaletteRotatorInfo : ITraitInfo
+	class LightPaletteRotatorInfo : TraitInfo
 	{
 		[Desc("Palettes this effect should not apply to.")]
 		public readonly HashSet<string> ExcludePalettes = new HashSet<string>();
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Palette indices to rotate through.")]
 		public readonly int[] RotationIndices = { 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 238, 237, 236, 235, 234, 233, 232, 231 };
 
-		public object Create(ActorInitializer init) { return new LightPaletteRotator(this); }
+		public override object Create(ActorInitializer init) { return new LightPaletteRotator(this); }
 	}
 
 	class LightPaletteRotator : ITick, IPaletteModifier

--- a/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
+++ b/OpenRA.Mods.Cnc/Traits/PortableChrono.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	class PortableChronoInfo : ITraitInfo, Requires<IMoveInfo>
+	class PortableChronoInfo : TraitInfo, Requires<IMoveInfo>
 	{
 		[Desc("Cooldown in ticks until the unit can teleport.")]
 		public readonly int ChargeDelay = 500;
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
-		public object Create(ActorInitializer init) { return new PortableChrono(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new PortableChrono(init.Self, this); }
 	}
 
 	class PortableChrono : IIssueOrder, IResolveOrder, ITick, ISelectionBar, IOrderVoice, ISync

--- a/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithBuildingBib.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	public class WithBuildingBibInfo : ITraitInfo, Requires<BuildingInfo>, IRenderActorPreviewSpritesInfo, IActorPreviewInitInfo, Requires<RenderSpritesInfo>
+	public class WithBuildingBibInfo : TraitInfo, Requires<BuildingInfo>, IRenderActorPreviewSpritesInfo, IActorPreviewInitInfo, Requires<RenderSpritesInfo>
 	{
 		[SequenceReference]
 		public readonly string Sequence = "bib";
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Cnc.Traits
 
 		public readonly bool HasMinibib = false;
 
-		public object Create(ActorInitializer init) { return new WithBuildingBib(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithBuildingBib(init.Self, this); }
 
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{

--- a/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithCargo.cs
@@ -21,7 +21,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits.Render
 {
 	[Desc("Renders the cargo loaded into the unit.")]
-	public class WithCargoInfo : ITraitInfo, Requires<CargoInfo>, Requires<BodyOrientationInfo>
+	public class WithCargoInfo : TraitInfo, Requires<CargoInfo>, Requires<BodyOrientationInfo>
 	{
 		[Desc("Cargo position relative to turret or body in (forward, right, up) triples. The default offset should be in the middle of the list.")]
 		public readonly WVec[] LocalOffset = { WVec.Zero };
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		[Desc("Passenger CargoType to display.")]
 		public readonly HashSet<string> DisplayTypes = new HashSet<string>();
 
-		public object Create(ActorInitializer init) { return new WithCargo(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithCargo(init.Self, this); }
 	}
 
 	public class WithCargo : ITick, IRender, INotifyPassengerEntered, INotifyPassengerExited

--- a/OpenRA.Mods.Cnc/Traits/Render/WithLandingCraftAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithLandingCraftAnimation.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits.Render
 {
-	public class WithLandingCraftAnimationInfo : ITraitInfo, Requires<IMoveInfo>, Requires<WithSpriteBodyInfo>, Requires<CargoInfo>
+	public class WithLandingCraftAnimationInfo : TraitInfo, Requires<IMoveInfo>, Requires<WithSpriteBodyInfo>, Requires<CargoInfo>
 	{
 		public readonly HashSet<string> OpenTerrainTypes = new HashSet<string> { "Clear" };
 
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		[Desc("Which sprite body to play the animation on.")]
 		public readonly string Body = "body";
 
-		public object Create(ActorInitializer init) { return new WithLandingCraftAnimation(init, this); }
+		public override object Create(ActorInitializer init) { return new WithLandingCraftAnimation(init, this); }
 	}
 
 	public class WithLandingCraftAnimation : ITick

--- a/OpenRA.Mods.Cnc/Traits/Render/WithRoof.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithRoof.cs
@@ -16,12 +16,12 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits.Render
 {
 	[Desc("Provides an overlay for the Tiberian Dawn hover craft.")]
-	public class WithRoofInfo : ITraitInfo, Requires<RenderSpritesInfo>
+	public class WithRoofInfo : TraitInfo, Requires<RenderSpritesInfo>
 	{
 		[SequenceReference]
 		public readonly string Sequence = "roof";
 
-		public object Create(ActorInitializer init) { return new WithRoof(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithRoof(init.Self, this); }
 	}
 
 	public class WithRoof

--- a/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeAnimation.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeAnimation.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits.Render
 {
 	[Desc("This actor displays a charge-up animation before firing.")]
-	public class WithTeslaChargeAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<RenderSpritesInfo>
+	public class WithTeslaChargeAnimationInfo : TraitInfo, Requires<WithSpriteBodyInfo>, Requires<RenderSpritesInfo>
 	{
 		[SequenceReference]
 		[Desc("Sequence to use for charge animation.")]
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		[Desc("Which sprite body to play the animation on.")]
 		public readonly string Body = "body";
 
-		public object Create(ActorInitializer init) { return new WithTeslaChargeAnimation(init, this); }
+		public override object Create(ActorInitializer init) { return new WithTeslaChargeAnimation(init, this); }
 	}
 
 	public class WithTeslaChargeAnimation : INotifyTeslaCharging

--- a/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeOverlay.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithTeslaChargeOverlay.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits.Render
 {
 	[Desc("Rendered together with AttackCharge.")]
-	public class WithTeslaChargeOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>
+	public class WithTeslaChargeOverlayInfo : TraitInfo, Requires<RenderSpritesInfo>
 	{
 		[SequenceReference]
 		[Desc("Sequence name to use")]
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		[Desc("Custom palette is a player palette BaseName")]
 		public readonly bool IsPlayerPalette = false;
 
-		public object Create(ActorInitializer init) { return new WithTeslaChargeOverlay(init, this); }
+		public override object Create(ActorInitializer init) { return new WithTeslaChargeOverlay(init, this); }
 	}
 
 	public class WithTeslaChargeOverlay : INotifyTeslaCharging, INotifyDamageStateChanged, INotifySold

--- a/OpenRA.Mods.Cnc/Traits/Render/WithVoxelUnloadBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithVoxelUnloadBody.cs
@@ -21,7 +21,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits.Render
 {
 	// TODO: This trait is hacky and should go away as soon as we support granting a condition on docking, in favor of toggling two regular WithVoxelBodies
-	public class WithVoxelUnloadBodyInfo : ITraitInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>
+	public class WithVoxelUnloadBodyInfo : TraitInfo, IRenderActorPreviewVoxelsInfo, Requires<RenderVoxelsInfo>
 	{
 		[Desc("Voxel sequence name to use when docked to a refinery.")]
 		public readonly string UnloadSequence = "unload";
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 		[Desc("Defines if the Voxel should have a shadow.")]
 		public readonly bool ShowShadow = true;
 
-		public object Create(ActorInitializer init) { return new WithVoxelUnloadBody(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithVoxelUnloadBody(init.Self, this); }
 
 		public IEnumerable<ModelAnimation> RenderPreviewVoxels(
 			ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, Func<WRot> orientation, int facings, PaletteReference p)

--- a/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
+++ b/OpenRA.Mods.Cnc/Traits/Render/WithVoxelWalkerBody.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits.Render
 {
-	public class WithVoxelWalkerBodyInfo : ITraitInfo, IRenderActorPreviewVoxelsInfo,  Requires<RenderVoxelsInfo>, Requires<IMoveInfo>, Requires<IFacingInfo>
+	public class WithVoxelWalkerBodyInfo : TraitInfo, IRenderActorPreviewVoxelsInfo,  Requires<RenderVoxelsInfo>, Requires<IMoveInfo>, Requires<IFacingInfo>
 	{
 		public readonly string Sequence = "idle";
 
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Cnc.Traits.Render
 
 		[Desc("Defines if the Voxel should have a shadow.")]
 		public readonly bool ShowShadow = true;
-		public object Create(ActorInitializer init) { return new WithVoxelWalkerBody(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithVoxelWalkerBody(init.Self, this); }
 
 		public IEnumerable<ModelAnimation> RenderPreviewVoxels(
 			ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, Func<WRot> orientation, int facings, PaletteReference p)

--- a/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
+++ b/OpenRA.Mods.Cnc/Traits/TDGunboat.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	public class TDGunboatInfo : ITraitInfo, IPositionableInfo, IFacingInfo, IMoveInfo, IActorPreviewInitInfo
+	public class TDGunboatInfo : TraitInfo, IPositionableInfo, IFacingInfo, IMoveInfo, IActorPreviewInitInfo
 	{
 		public readonly int Speed = 28;
 
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Facing to use for actor previews (map editor, color picker, etc). Only 64 and 192 supported.")]
 		public readonly int PreviewFacing = 64;
 
-		public virtual object Create(ActorInitializer init) { return new TDGunboat(init, this); }
+		public override object Create(ActorInitializer init) { return new TDGunboat(init, this); }
 
 		public int GetInitialFacing() { return InitialFacing; }
 

--- a/OpenRA.Mods.Cnc/Traits/TransferTimedExternalConditionOnTransform.cs
+++ b/OpenRA.Mods.Cnc/Traits/TransferTimedExternalConditionOnTransform.cs
@@ -18,13 +18,13 @@ namespace OpenRA.Mods.Cnc.Traits
 	[Desc("A special case trait that re-grants a timed external condition when this actor transforms.",
 		"This trait does not work with permanently granted external conditions.",
 		"This trait changes the external condition source, so cannot be used for conditions that may later be revoked")]
-	public class TransferTimedExternalConditionOnTransformInfo : ITraitInfo, Requires<TransformsInfo>
+	public class TransferTimedExternalConditionOnTransformInfo : TraitInfo, Requires<TransformsInfo>
 	{
 		[FieldLoader.Require]
 		[Desc("External condition to transfer")]
 		public readonly string Condition = null;
 
-		public object Create(ActorInitializer init) { return new TransferTimedExternalConditionOnTransform(this); }
+		public override object Create(ActorInitializer init) { return new TransferTimedExternalConditionOnTransform(this); }
 	}
 
 	public class TransferTimedExternalConditionOnTransform : IConditionTimerWatcher, INotifyTransform

--- a/OpenRA.Mods.Cnc/Traits/World/ShroudPalette.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/ShroudPalette.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Adds the hard-coded shroud palette to the game")]
-	class ShroudPaletteInfo : ITraitInfo
+	class ShroudPaletteInfo : TraitInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Palette type")]
 		public readonly bool Fog = false;
 
-		public object Create(ActorInitializer init) { return new ShroudPalette(this); }
+		public override object Create(ActorInitializer init) { return new ShroudPalette(this); }
 	}
 
 	class ShroudPalette : ILoadsPalettes, IProvidesAssetBrowserPalettes

--- a/OpenRA.Mods.Cnc/Traits/World/TSShroudPalette.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/TSShroudPalette.cs
@@ -19,14 +19,14 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Cnc.Traits
 {
 	[Desc("Adds the hard-coded shroud palette to the game")]
-	class TSShroudPaletteInfo : ITraitInfo
+	class TSShroudPaletteInfo : TraitInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
 		[Desc("Internal palette name")]
 		public readonly string Name = "shroud";
 
-		public object Create(ActorInitializer init) { return new TSShroudPalette(this); }
+		public override object Create(ActorInitializer init) { return new TSShroudPalette(this); }
 	}
 
 	class TSShroudPalette : ILoadsPalettes, IProvidesAssetBrowserPalettes

--- a/OpenRA.Mods.Cnc/Traits/World/VoxelNormalsPalette.cs
+++ b/OpenRA.Mods.Cnc/Traits/World/VoxelNormalsPalette.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Cnc.Traits
 {
-	public class VoxelNormalsPaletteInfo : ITraitInfo
+	public class VoxelNormalsPaletteInfo : TraitInfo
 	{
 		[PaletteDefinition]
 		public readonly string Name = "normals";
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Cnc.Traits
 		[Desc("Can be TiberianSun or RedAlert2")]
 		public readonly NormalType Type = NormalType.TiberianSun;
 
-		public object Create(ActorInitializer init) { return new VoxelNormalsPalette(this); }
+		public override object Create(ActorInitializer init) { return new VoxelNormalsPalette(this); }
 	}
 
 	public class VoxelNormalsPalette : ILoadsPalettes

--- a/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckActorReferences.cs
@@ -26,11 +26,11 @@ namespace OpenRA.Mods.Common.Lint
 			this.emitError = emitError;
 
 			foreach (var actorInfo in rules.Actors)
-				foreach (var traitInfo in actorInfo.Value.TraitInfos<ITraitInfo>())
+				foreach (var traitInfo in actorInfo.Value.TraitInfos<TraitInfo>())
 					CheckTrait(actorInfo.Value, traitInfo, rules);
 		}
 
-		void CheckTrait(ActorInfo actorInfo, ITraitInfo traitInfo, Ruleset rules)
+		void CheckTrait(ActorInfo actorInfo, TraitInfo traitInfo, Ruleset rules)
 		{
 			var actualType = traitInfo.GetType();
 			foreach (var field in actualType.GetFields())
@@ -50,7 +50,7 @@ namespace OpenRA.Mods.Common.Lint
 		}
 
 		void CheckActorReference(ActorInfo actorInfo,
-			ITraitInfo traitInfo,
+			TraitInfo traitInfo,
 			FieldInfo fieldInfo,
 			IReadOnlyDictionary<string, ActorInfo> dict,
 			ActorReferenceAttribute attribute)
@@ -81,7 +81,7 @@ namespace OpenRA.Mods.Common.Lint
 		}
 
 		void CheckWeaponReference(ActorInfo actorInfo,
-			ITraitInfo traitInfo,
+			TraitInfo traitInfo,
 			FieldInfo fieldInfo,
 			IReadOnlyDictionary<string, WeaponInfo> dict,
 			WeaponReferenceAttribute attribute)
@@ -99,7 +99,7 @@ namespace OpenRA.Mods.Common.Lint
 		}
 
 		void CheckVoiceReference(ActorInfo actorInfo,
-			ITraitInfo traitInfo,
+			TraitInfo traitInfo,
 			FieldInfo fieldInfo,
 			IReadOnlyDictionary<string, SoundInfo> dict,
 			VoiceSetReferenceAttribute attribute)

--- a/OpenRA.Mods.Common/Lint/CheckConditions.cs
+++ b/OpenRA.Mods.Common/Lint/CheckConditions.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Lint
 				var granted = new HashSet<string>();
 				var consumed = new HashSet<string>();
 
-				foreach (var trait in actorInfo.Value.TraitInfos<ITraitInfo>())
+				foreach (var trait in actorInfo.Value.TraitInfos<TraitInfo>())
 				{
 					var fieldConsumed = trait.GetType().GetFields()
 						.Where(x => x.HasAttribute<ConsumedConditionReferenceAttribute>())

--- a/OpenRA.Mods.Common/Lint/CheckLocomotorReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckLocomotorReferences.cs
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Lint
 
 			foreach (var actorInfo in rules.Actors)
 			{
-				foreach (var traitInfo in actorInfo.Value.TraitInfos<ITraitInfo>())
+				foreach (var traitInfo in actorInfo.Value.TraitInfos<TraitInfo>())
 				{
 					var fields = traitInfo.GetType().GetFields().Where(f => f.HasAttribute<LocomotorReferenceAttribute>());
 					foreach (var field in fields)

--- a/OpenRA.Mods.Common/Lint/CheckNotifications.cs
+++ b/OpenRA.Mods.Common/Lint/CheckNotifications.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Lint
 		{
 			foreach (var actorInfo in rules.Actors)
 			{
-				foreach (var traitInfo in actorInfo.Value.TraitInfos<ITraitInfo>())
+				foreach (var traitInfo in actorInfo.Value.TraitInfos<TraitInfo>())
 				{
 					var fields = traitInfo.GetType().GetFields();
 					foreach (var field in fields.Where(x => x.HasAttribute<NotificationReferenceAttribute>()))

--- a/OpenRA.Mods.Common/Lint/CheckPalettes.cs
+++ b/OpenRA.Mods.Common/Lint/CheckPalettes.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Lint
 
 			foreach (var actorInfo in rules.Actors)
 			{
-				foreach (var traitInfo in actorInfo.Value.TraitInfos<ITraitInfo>())
+				foreach (var traitInfo in actorInfo.Value.TraitInfos<TraitInfo>())
 				{
 					var fields = traitInfo.GetType().GetFields();
 					foreach (var field in fields.Where(x => x.HasAttribute<PaletteReferenceAttribute>()))
@@ -115,7 +115,7 @@ namespace OpenRA.Mods.Common.Lint
 		{
 			foreach (var actorInfo in rules.Actors)
 			{
-				foreach (var traitInfo in actorInfo.Value.TraitInfos<ITraitInfo>())
+				foreach (var traitInfo in actorInfo.Value.TraitInfos<TraitInfo>())
 				{
 					var fields = traitInfo.GetType().GetFields();
 					foreach (var field in fields.Where(x => x.HasAttribute<PaletteDefinitionAttribute>()))

--- a/OpenRA.Mods.Common/Lint/CheckSequences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckSequences.cs
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Lint
 					}
 				}
 
-				foreach (var traitInfo in actorInfo.Value.TraitInfos<ITraitInfo>())
+				foreach (var traitInfo in actorInfo.Value.TraitInfos<TraitInfo>())
 				{
 					var fields = traitInfo.GetType().GetFields();
 					foreach (var field in fields)
@@ -152,7 +152,7 @@ namespace OpenRA.Mods.Common.Lint
 		}
 
 		void CheckDefinitions(string image, SequenceReferenceAttribute sequenceReference,
-			KeyValuePair<string, ActorInfo> actorInfo, string sequence, string faction, FieldInfo field, ITraitInfo traitInfo)
+			KeyValuePair<string, ActorInfo> actorInfo, string sequence, string faction, FieldInfo field, TraitInfo traitInfo)
 		{
 			var definitions = sequenceDefinitions.FirstOrDefault(n => n.Key == image.ToLowerInvariant());
 			if (definitions != null)

--- a/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
+++ b/OpenRA.Mods.Common/Lint/CheckVoiceReferences.cs
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Lint
 		{
 			foreach (var actorInfo in rules.Actors)
 			{
-				foreach (var traitInfo in actorInfo.Value.TraitInfos<ITraitInfo>())
+				foreach (var traitInfo in actorInfo.Value.TraitInfos<TraitInfo>())
 				{
 					var fields = traitInfo.GetType().GetFields().Where(f => f.HasAttribute<VoiceSetReferenceAttribute>());
 					foreach (var field in fields)
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Lint
 		{
 			var soundInfo = rules.Voices[voiceSet.ToLowerInvariant()];
 
-			foreach (var traitInfo in actorInfo.TraitInfos<ITraitInfo>())
+			foreach (var traitInfo in actorInfo.TraitInfos<TraitInfo>())
 			{
 				var fields = traitInfo.GetType().GetFields().Where(f => f.HasAttribute<VoiceReferenceAttribute>());
 				foreach (var field in fields)

--- a/OpenRA.Mods.Common/Orders/EnterAlliedActorTargeter.cs
+++ b/OpenRA.Mods.Common/Orders/EnterAlliedActorTargeter.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Orders
 {
-	public class EnterAlliedActorTargeter<T> : UnitOrderTargeter where T : ITraitInfo
+	public class EnterAlliedActorTargeter<T> : UnitOrderTargeter where T : ITraitInfoInterface
 	{
 		readonly Func<Actor, TargetModifiers, bool> canTarget;
 		readonly Func<Actor, bool> useEnterCursor;

--- a/OpenRA.Mods.Common/Scripting/LuaScript.cs
+++ b/OpenRA.Mods.Common/Scripting/LuaScript.cs
@@ -19,11 +19,11 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Scripting
 {
 	[Desc("Part of the new Lua API.")]
-	public class LuaScriptInfo : ITraitInfo, Requires<SpawnMapActorsInfo>
+	public class LuaScriptInfo : TraitInfo, Requires<SpawnMapActorsInfo>
 	{
 		public readonly HashSet<string> Scripts = new HashSet<string>();
 
-		public object Create(ActorInitializer init) { return new LuaScript(this); }
+		public override object Create(ActorInitializer init) { return new LuaScript(this); }
 	}
 
 	public class LuaScript : ITick, IWorldLoaded, INotifyActorDisposing

--- a/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
+++ b/OpenRA.Mods.Common/Scripting/ScriptTriggers.cs
@@ -28,9 +28,9 @@ namespace OpenRA.Mods.Common.Scripting
 	}
 
 	[Desc("Allows map scripts to attach triggers to this actor via the Triggers global.")]
-	public class ScriptTriggersInfo : ITraitInfo
+	public class ScriptTriggersInfo : TraitInfo
 	{
-		public object Create(ActorInitializer init) { return new ScriptTriggers(init.World, init.Self); }
+		public override object Create(ActorInitializer init) { return new ScriptTriggers(init.World, init.Self); }
 	}
 
 	public sealed class ScriptTriggers : INotifyIdle, INotifyDamage, INotifyKilled, INotifyProduction, INotifyOtherProduction,

--- a/OpenRA.Mods.Common/Traits/AcceptsDeliveredCash.cs
+++ b/OpenRA.Mods.Common/Traits/AcceptsDeliveredCash.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Tag trait for actors with `DeliversCash`.")]
-	public class AcceptsDeliveredCashInfo : ITraitInfo
+	public class AcceptsDeliveredCashInfo : TraitInfo
 	{
 		[Desc("Accepted `DeliversCash` types. Leave empty to accept all types.")]
 		public readonly HashSet<string> ValidTypes = new HashSet<string>();
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Play a randomly selected sound from this list when accepting cash.")]
 		public readonly string[] Sounds = { };
 
-		public object Create(ActorInitializer init) { return new AcceptsDeliveredCash(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new AcceptsDeliveredCash(init.Self, this); }
 	}
 
 	public class AcceptsDeliveredCash : INotifyCashTransfer

--- a/OpenRA.Mods.Common/Traits/AcceptsDeliveredExperience.cs
+++ b/OpenRA.Mods.Common/Traits/AcceptsDeliveredExperience.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Tag trait for actors with `DeliversExperience`.")]
-	public class AcceptsDeliveredExperienceInfo : ITraitInfo, Requires<GainsExperienceInfo>
+	public class AcceptsDeliveredExperienceInfo : TraitInfo, Requires<GainsExperienceInfo>
 	{
 		[Desc("Accepted `DeliversExperience` types. Leave empty to accept all types.")]
 		public readonly HashSet<string> ValidTypes = new HashSet<string>();
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Stance the delivering actor needs to enter.")]
 		public readonly Stance ValidStances = Stance.Ally;
 
-		public object Create(ActorInitializer init) { return new AcceptsDeliveredExperience(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new AcceptsDeliveredExperience(init.Self, this); }
 	}
 
 	public class AcceptsDeliveredExperience

--- a/OpenRA.Mods.Common/Traits/Air/FallsToEarth.cs
+++ b/OpenRA.Mods.Common/Traits/Air/FallsToEarth.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Causes aircraft husks that are spawned in the air to crash to the ground.")]
-	public class FallsToEarthInfo : ITraitInfo, IRulesetLoaded, Requires<AircraftInfo>
+	public class FallsToEarthInfo : TraitInfo, IRulesetLoaded, Requires<AircraftInfo>
 	{
 		[WeaponReference]
 		[Desc("Explosion weapon that triggers when hitting ground.")]
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public WeaponInfo ExplosionWeapon { get; private set; }
 
-		public object Create(ActorInitializer init) { return new FallsToEarth(init, this); }
+		public override object Create(ActorInitializer init) { return new FallsToEarth(init, this); }
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{
 			if (string.IsNullOrEmpty(Explosion))

--- a/OpenRA.Mods.Common/Traits/AmmoPool.cs
+++ b/OpenRA.Mods.Common/Traits/AmmoPool.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Actor has a limited amount of ammo, after using it all the actor must reload in some way.")]
-	public class AmmoPoolInfo : ITraitInfo
+	public class AmmoPoolInfo : TraitInfo
 	{
 		[Desc("Name of this ammo pool, used to link reload traits to this pool.")]
 		public readonly string Name = "primary";
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The condition to grant to self for each ammo point in this pool.")]
 		public readonly string AmmoCondition = null;
 
-		public object Create(ActorInitializer init) { return new AmmoPool(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new AmmoPool(init.Self, this); }
 	}
 
 	public class AmmoPool : INotifyCreated, INotifyAttack, ISync

--- a/OpenRA.Mods.Common/Traits/AttackMove.cs
+++ b/OpenRA.Mods.Common/Traits/AttackMove.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Provides access to the attack-move command, which will make the actor automatically engage viable targets while moving to the destination.")]
-	class AttackMoveInfo : ITraitInfo, Requires<IMoveInfo>
+	class AttackMoveInfo : TraitInfo, Requires<IMoveInfo>
 	{
 		[VoiceReference]
 		public readonly string Voice = "Action";
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Can the actor be ordered to move in to shroud?")]
 		public readonly bool MoveIntoShroud = true;
 
-		public object Create(ActorInitializer init) { return new AttackMove(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new AttackMove(init.Self, this); }
 	}
 
 	class AttackMove : IResolveOrder, IOrderVoice

--- a/OpenRA.Mods.Common/Traits/BodyOrientation.cs
+++ b/OpenRA.Mods.Common/Traits/BodyOrientation.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class BodyOrientationInfo : ITraitInfo
+	public class BodyOrientationInfo : TraitInfo
 	{
 		[Desc("Number of facings for gameplay calculations. -1 indicates auto-detection from another trait.")]
 		public readonly int QuantizedFacings = -1;
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 			return Util.QuantizeFacing(facing, facings) * (256 / facings);
 		}
 
-		public virtual object Create(ActorInitializer init) { return new BodyOrientation(init, this); }
+		public override object Create(ActorInitializer init) { return new BodyOrientation(init, this); }
 	}
 
 	public class BodyOrientation : ISync

--- a/OpenRA.Mods.Common/Traits/BotModules/Squads/AttackOrFleeFuzzy.cs
+++ b/OpenRA.Mods.Common/Traits/BotModules/Squads/AttackOrFleeFuzzy.cs
@@ -243,7 +243,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			return relative.Clamp(0.0f, 999.0f);
 		}
 
-		static float SumOfValues<TTraitInfo>(IEnumerable<Actor> actors, Func<Actor, int> getValue) where TTraitInfo : ITraitInfo
+		static float SumOfValues<TTraitInfo>(IEnumerable<Actor> actors, Func<Actor, int> getValue) where TTraitInfo : ITraitInfoInterface
 		{
 			var sum = 0;
 			foreach (var a in actors)
@@ -253,7 +253,7 @@ namespace OpenRA.Mods.Common.Traits.BotModules.Squads
 			return sum;
 		}
 
-		static float Average<TTraitInfo>(IEnumerable<Actor> actors, Func<Actor, int> getValue) where TTraitInfo : ITraitInfo
+		static float Average<TTraitInfo>(IEnumerable<Actor> actors, Func<Actor, int> getValue) where TTraitInfo : ITraitInfoInterface
 		{
 			var sum = 0;
 			var countActors = 0;

--- a/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Bridge.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class BridgeInfo : ITraitInfo, IRulesetLoaded, Requires<HealthInfo>, Requires<BuildingInfo>
+	class BridgeInfo : TraitInfo, IRulesetLoaded, Requires<HealthInfo>, Requires<BuildingInfo>
 	{
 		public readonly bool Long = false;
 
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Types of damage that this bridge causes to units over/in path of it while being destroyed/repaired. Leave empty for no damage types.")]
 		public readonly BitSet<DamageType> DamageTypes = default(BitSet<DamageType>);
 
-		public object Create(ActorInitializer init) { return new Bridge(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new Bridge(init.Self, this); }
 
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{

--- a/OpenRA.Mods.Common/Traits/Buildings/BridgeHut.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BridgeHut.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Allows bridges to be targeted for demolition and repair.")]
-	class BridgeHutInfo : IDemolishableInfo, ITraitInfo
+	class BridgeHutInfo : TraitInfo, IDemolishableInfo
 	{
 		[Desc("Bridge types to act on")]
 		public readonly string[] Types = { "GroundLevelBridge" };
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public bool IsValidTarget(ActorInfo actorInfo, Actor saboteur) { return false; } // TODO: bridges don't support frozen under fog
 
-		public object Create(ActorInitializer init) { return new BridgeHut(init.World, this); }
+		public override object Create(ActorInitializer init) { return new BridgeHut(init.World, this); }
 	}
 
 	class BridgeHut : INotifyCreated, IDemolishable, ITick

--- a/OpenRA.Mods.Common/Traits/Buildings/BridgePlaceholder.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BridgePlaceholder.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Placeholder actor used for dead segments and bridge end ramps.")]
-	class BridgePlaceholderInfo : ITraitInfo
+	class BridgePlaceholderInfo : TraitInfo
 	{
 		public readonly string Type = "GroundLevelBridge";
 
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly CVec[] NeighbourOffsets = { };
 
-		public object Create(ActorInitializer init) { return new BridgePlaceholder(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new BridgePlaceholder(init.Self, this); }
 	}
 
 	class BridgePlaceholder : IBridgeSegment, INotifyAddedToWorld, INotifyRemovedFromWorld

--- a/OpenRA.Mods.Common/Traits/Buildings/Building.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Building.cs
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		OccupiedPassableTransitOnly = '+'
 	}
 
-	public class BuildingInfo : ITraitInfo, IOccupySpaceInfo, IPlaceBuildingDecorationInfo
+	public class BuildingInfo : TraitInfo, IOccupySpaceInfo, IPlaceBuildingDecorationInfo
 	{
 		[Desc("Where you are allowed to place the building (Water, Clear, ...)")]
 		public readonly HashSet<string> TerrainTypes = new HashSet<string>();
@@ -61,7 +61,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly string[] UndeploySounds = { };
 
-		public virtual object Create(ActorInitializer init) { return new Building(init, this); }
+		public override object Create(ActorInitializer init) { return new Building(init, this); }
 
 		protected static object LoadFootprint(MiniYaml yaml)
 		{

--- a/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/BuildingInfluence.cs
@@ -15,9 +15,9 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("A dictionary of buildings placed on the map. Attach this to the world actor.")]
-	public class BuildingInfluenceInfo : ITraitInfo
+	public class BuildingInfluenceInfo : TraitInfo
 	{
-		public object Create(ActorInitializer init) { return new BuildingInfluence(init.World); }
+		public override object Create(ActorInitializer init) { return new BuildingInfluence(init.World); }
 	}
 
 	public class BuildingInfluence

--- a/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/GroundLevelBridge.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Bridge actor that can't be passed underneath.")]
-	class GroundLevelBridgeInfo : ITraitInfo, IRulesetLoaded, Requires<BuildingInfo>, Requires<IHealthInfo>
+	class GroundLevelBridgeInfo : TraitInfo, IRulesetLoaded, Requires<BuildingInfo>, Requires<IHealthInfo>
 	{
 		public readonly string TerrainType = "Bridge";
 
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.Traits
 			DemolishWeaponInfo = weapon;
 		}
 
-		public object Create(ActorInitializer init) { return new GroundLevelBridge(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new GroundLevelBridge(init.Self, this); }
 	}
 
 	class GroundLevelBridge : IBridgeSegment, INotifyAddedToWorld, INotifyRemovedFromWorld

--- a/OpenRA.Mods.Common/Traits/Buildings/LegacyBridgeHut.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/LegacyBridgeHut.cs
@@ -16,11 +16,11 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Allows bridges to be targeted for demolition and repair.")]
-	class LegacyBridgeHutInfo : IDemolishableInfo, ITraitInfo
+	class LegacyBridgeHutInfo : TraitInfo, IDemolishableInfo
 	{
 		public bool IsValidTarget(ActorInfo actorInfo, Actor saboteur) { return false; } // TODO: bridges don't support frozen under fog
 
-		public object Create(ActorInitializer init) { return new LegacyBridgeHut(init); }
+		public override object Create(ActorInitializer init) { return new LegacyBridgeHut(init); }
 	}
 
 	class LegacyBridgeHut : IDemolishable

--- a/OpenRA.Mods.Common/Traits/Buildings/LineBuild.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/LineBuild.cs
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[Desc("Place the second actor in line to build more of the same at once (used for walls).")]
-	public class LineBuildInfo : ITraitInfo
+	public class LineBuildInfo : TraitInfo
 	{
 		[Desc("The maximum allowed length of the line.")]
 		public readonly int Range = 5;
@@ -67,7 +67,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Delete generated segments when destroyed or sold.")]
 		public readonly bool SegmentsRequireNode = false;
 
-		public object Create(ActorInitializer init) { return new LineBuild(init, this); }
+		public override object Create(ActorInitializer init) { return new LineBuild(init, this); }
 	}
 
 	public class LineBuild : INotifyKilled, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyLineBuildSegmentsChanged

--- a/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/RallyPoint.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Used to waypoint units after production or repair is finished.")]
-	public class RallyPointInfo : ITraitInfo
+	public class RallyPointInfo : TraitInfo
 	{
 		public readonly string Image = "rallypoint";
 
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The speech notification to play when setting a new rallypoint.")]
 		public readonly string Notification = null;
 
-		public object Create(ActorInitializer init) { return new RallyPoint(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new RallyPoint(init.Self, this); }
 	}
 
 	public class RallyPoint : IIssueOrder, IResolveOrder, INotifyOwnerChanged, INotifyCreated

--- a/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
+++ b/OpenRA.Mods.Common/Traits/Buildings/Refinery.cs
@@ -21,7 +21,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class RefineryInfo : IAcceptResourcesInfo, Requires<WithSpriteBodyInfo>
+	public class RefineryInfo : TraitInfo, Requires<WithSpriteBodyInfo>, IAcceptResourcesInfo
 	{
 		[Desc("Actual harvester facing when docking, 0-255 counter-clock-wise.")]
 		public readonly int DockAngle = 0;
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int TickVelocity = 2;
 		public readonly int TickRate = 10;
 
-		public virtual object Create(ActorInitializer init) { return new Refinery(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new Refinery(init.Self, this); }
 	}
 
 	public class Refinery : INotifyCreated, ITick, IAcceptResources, INotifySold, INotifyCapture,

--- a/OpenRA.Mods.Common/Traits/Burns.cs
+++ b/OpenRA.Mods.Common/Traits/Burns.cs
@@ -16,13 +16,13 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor will play a fire animation over its body and take damage over time.")]
-	class BurnsInfo : ITraitInfo, Requires<RenderSpritesInfo>
+	class BurnsInfo : TraitInfo, Requires<RenderSpritesInfo>
 	{
 		public readonly string Anim = "1";
 		public readonly int Damage = 1;
 		public readonly int Interval = 8;
 
-		public object Create(ActorInitializer init) { return new Burns(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new Burns(init.Self, this); }
 	}
 
 	class Burns : ITick, ISync

--- a/OpenRA.Mods.Common/Traits/CaptureManager.cs
+++ b/OpenRA.Mods.Common/Traits/CaptureManager.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[Desc("Manages Captures and Capturable traits on an actor.")]
-	public class CaptureManagerInfo : ITraitInfo
+	public class CaptureManagerInfo : TraitInfo
 	{
 		[GrantedConditionReference]
 		[Desc("Condition granted when capturing an actor.")]
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Should units friendly to the capturing actor auto-target this actor while it is being captured?")]
 		public readonly bool PreventsAutoTarget = true;
 
-		public virtual object Create(ActorInitializer init) { return new CaptureManager(this); }
+		public override object Create(ActorInitializer init) { return new CaptureManager(this); }
 
 		public bool CanBeTargetedBy(FrozenActor frozenActor, Actor captor, Captures captures)
 		{

--- a/OpenRA.Mods.Common/Traits/Cargo.cs
+++ b/OpenRA.Mods.Common/Traits/Cargo.cs
@@ -21,7 +21,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor can transport Passenger actors.")]
-	public class CargoInfo : ITraitInfo, Requires<IOccupySpaceInfo>
+	public class CargoInfo : TraitInfo, Requires<IOccupySpaceInfo>
 	{
 		[Desc("The maximum sum of Passenger.Weight that this actor can support.")]
 		public readonly int MaxWeight = 0;
@@ -82,7 +82,7 @@ namespace OpenRA.Mods.Common.Traits
 		[GrantedConditionReference]
 		public IEnumerable<string> LinterPassengerConditions { get { return PassengerConditions.Values; } }
 
-		public object Create(ActorInitializer init) { return new Cargo(init, this); }
+		public override object Create(ActorInitializer init) { return new Cargo(init, this); }
 	}
 
 	public class Cargo : IIssueOrder, IResolveOrder, IOrderVoice, INotifyCreated, INotifyKilled,

--- a/OpenRA.Mods.Common/Traits/CarryableHarvester.cs
+++ b/OpenRA.Mods.Common/Traits/CarryableHarvester.cs
@@ -15,9 +15,9 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class CarryableHarvesterInfo : ITraitInfo
+	public class CarryableHarvesterInfo : TraitInfo
 	{
-		public object Create(ActorInitializer init) { return new CarryableHarvester(); }
+		public override object Create(ActorInitializer init) { return new CarryableHarvester(); }
 	}
 
 	public class CarryableHarvester : INotifyCreated, INotifyHarvesterAction

--- a/OpenRA.Mods.Common/Traits/Carryall.cs
+++ b/OpenRA.Mods.Common/Traits/Carryall.cs
@@ -21,7 +21,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Transports actors with the `Carryable` trait.")]
-	public class CarryallInfo : ITraitInfo, Requires<BodyOrientationInfo>, Requires<AircraftInfo>
+	public class CarryallInfo : TraitInfo, Requires<BodyOrientationInfo>, Requires<AircraftInfo>
 	{
 		[Desc("Delay (in ticks) on the ground while attaching an actor to the carryall.")]
 		public readonly int BeforeLoadDelay = 0;
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
-		public virtual object Create(ActorInitializer init) { return new Carryall(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new Carryall(init.Self, this); }
 	}
 
 	public class Carryall : INotifyKilled, ISync, ITick, IRender, INotifyActorDisposing, IIssueOrder, IResolveOrder,

--- a/OpenRA.Mods.Common/Traits/ChangesTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/ChangesTerrain.cs
@@ -14,12 +14,12 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Modifies the terrain type underneath the actors location.")]
-	class ChangesTerrainInfo : ITraitInfo, Requires<ImmobileInfo>
+	class ChangesTerrainInfo : TraitInfo, Requires<ImmobileInfo>
 	{
 		[FieldLoader.Require]
 		public readonly string TerrainType = null;
 
-		public object Create(ActorInitializer init) { return new ChangesTerrain(this); }
+		public override object Create(ActorInitializer init) { return new ChangesTerrain(this); }
 	}
 
 	class ChangesTerrain : INotifyAddedToWorld, INotifyRemovedFromWorld

--- a/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/CombatDebugOverlay.cs
@@ -21,9 +21,9 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Displays fireports, muzzle offsets, and hit areas in developer mode.")]
-	public class CombatDebugOverlayInfo : ITraitInfo
+	public class CombatDebugOverlayInfo : TraitInfo
 	{
-		public object Create(ActorInitializer init) { return new CombatDebugOverlay(init.Self); }
+		public override object Create(ActorInitializer init) { return new CombatDebugOverlay(init.Self); }
 	}
 
 	public class CombatDebugOverlay : IRenderAnnotations, INotifyDamage, INotifyCreated

--- a/OpenRA.Mods.Common/Traits/Conditions/ConditionalTrait.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ConditionalTrait.cs
@@ -16,13 +16,11 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	/// <summary>Use as base class for *Info to subclass of ConditionalTrait. (See ConditionalTrait.)</summary>
-	public abstract class ConditionalTraitInfo : IObservesVariablesInfo, IRulesetLoaded
+	public abstract class ConditionalTraitInfo : TraitInfo, IObservesVariablesInfo, IRulesetLoaded
 	{
 		[ConsumedConditionReference]
 		[Desc("Boolean expression defining the condition to enable this trait.")]
 		public readonly BooleanExpression RequiresCondition = null;
-
-		public abstract object Create(ActorInitializer init);
 
 		// HACK: A shim for all the ActorPreview code that used to query UpgradeMinEnabledLevel directly
 		// This can go away after we introduce an InitialConditions ActorInit and have the traits query the

--- a/OpenRA.Mods.Common/Traits/Conditions/ExternalCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/ExternalCondition.cs
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[Desc("Allows a condition to be granted from an external source (Lua, warheads, etc).")]
-	public class ExternalConditionInfo : ITraitInfo
+	public class ExternalConditionInfo : TraitInfo
 	{
 		[GrantedConditionReference]
 		[FieldLoader.Require]
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("If > 0, restrict the number of times that this condition can be granted by any source.")]
 		public readonly int TotalCap = 0;
 
-		public object Create(ActorInitializer init) { return new ExternalCondition(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new ExternalCondition(init.Self, this); }
 	}
 
 	public class ExternalCondition : ITick, INotifyCreated

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnBotOwner.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Grants a condition to this actor when it is owned by an AI bot.")]
-	public class GrantConditionOnBotOwnerInfo : ITraitInfo
+	public class GrantConditionOnBotOwnerInfo : TraitInfo
 	{
 		[FieldLoader.Require]
 		[GrantedConditionReference]
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Bot types that trigger the condition.")]
 		public readonly string[] Bots = { };
 
-		public object Create(ActorInitializer init) { return new GrantConditionOnBotOwner(init, this); }
+		public override object Create(ActorInitializer init) { return new GrantConditionOnBotOwner(init, this); }
 	}
 
 	public class GrantConditionOnBotOwner : INotifyCreated, INotifyOwnerChanged

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDamageState.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnDamageState.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Applies a condition to the actor at specified damage states.")]
-	public class GrantConditionOnDamageStateInfo : ITraitInfo, Requires<IHealthInfo>
+	public class GrantConditionOnDamageStateInfo : TraitInfo, Requires<IHealthInfo>
 	{
 		[FieldLoader.Require]
 		[GrantedConditionReference]
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Is the condition irrevocable once it has been activated?")]
 		public readonly bool GrantPermanently = false;
 
-		public object Create(ActorInitializer init) { return new GrantConditionOnDamageState(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new GrantConditionOnDamageState(init.Self, this); }
 	}
 
 	public class GrantConditionOnDamageState : INotifyDamageStateChanged, INotifyCreated

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnHealth.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnHealth.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Applies a condition to the actor at when its health is between 2 specific values.")]
-	public class GrantConditionOnHealthInfo : ITraitInfo, IRulesetLoaded, Requires<IHealthInfo>
+	public class GrantConditionOnHealthInfo : TraitInfo, IRulesetLoaded, Requires<IHealthInfo>
 	{
 		[FieldLoader.Require]
 		[GrantedConditionReference]
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Is the condition irrevokable once it has been granted?")]
 		public readonly bool GrantPermanently = false;
 
-		public object Create(ActorInitializer init) { return new GrantConditionOnHealth(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new GrantConditionOnHealth(init.Self, this); }
 
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLineBuildDirection.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnLineBuildDirection.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class GrantConditionOnLineBuildDirectionInfo : ITraitInfo, Requires<LineBuildInfo>
+	public class GrantConditionOnLineBuildDirectionInfo : TraitInfo, Requires<LineBuildInfo>
 	{
 		[FieldLoader.Require]
 		[GrantedConditionReference]
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Line build direction to trigger the condition.")]
 		public readonly LineBuildDirection Direction = LineBuildDirection.X;
 
-		public object Create(ActorInitializer init) { return new GrantConditionOnLineBuildDirection(init, this); }
+		public override object Create(ActorInitializer init) { return new GrantConditionOnLineBuildDirection(init, this); }
 	}
 
 	public class GrantConditionOnLineBuildDirection : INotifyCreated

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPlayerResources.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Grants a condition to this actor when the player has stored resources.")]
-	public class GrantConditionOnPlayerResourcesInfo : ITraitInfo
+	public class GrantConditionOnPlayerResourcesInfo : TraitInfo
 	{
 		[FieldLoader.Require]
 		[GrantedConditionReference]
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Enable condition when the amount of stored resources is greater than this.")]
 		public readonly int Threshold = 0;
 
-		public object Create(ActorInitializer init) { return new GrantConditionOnPlayerResources(this); }
+		public override object Create(ActorInitializer init) { return new GrantConditionOnPlayerResources(this); }
 	}
 
 	public class GrantConditionOnPlayerResources : INotifyCreated, INotifyOwnerChanged, ITick

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnPrerequisite.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Grants a condition to the actor this is attached to when prerequisites are available.")]
-	public class GrantConditionOnPrerequisiteInfo : ITraitInfo
+	public class GrantConditionOnPrerequisiteInfo : TraitInfo
 	{
 		[FieldLoader.Require]
 		[GrantedConditionReference]
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("List of required prerequisites.")]
 		public readonly string[] Prerequisites = { };
 
-		public object Create(ActorInitializer init) { return new GrantConditionOnPrerequisite(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new GrantConditionOnPrerequisite(init.Self, this); }
 	}
 
 	public class GrantConditionOnPrerequisite : INotifyCreated, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyOwnerChanged

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnProduction.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnProduction.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Grants a condition when this actor produces a specific actor.")]
-	public class GrantConditionOnProductionInfo : ITraitInfo
+	public class GrantConditionOnProductionInfo : TraitInfo
 	{
 		[FieldLoader.Require]
 		[GrantedConditionReference]
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly bool ShowSelectionBar = true;
 		public readonly Color SelectionBarColor = Color.Magenta;
 
-		public object Create(ActorInitializer init) { return new GrantConditionOnProduction(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new GrantConditionOnProduction(init.Self, this); }
 	}
 
 	public class GrantConditionOnProduction : INotifyProduction, ITick, ISync, ISelectionBar

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionOnTerrain.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class GrantConditionOnTerrainInfo : ITraitInfo
+	public class GrantConditionOnTerrainInfo : TraitInfo
 	{
 		[FieldLoader.Require]
 		[GrantedConditionReference]
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Terrain names to trigger the condition.")]
 		public readonly string[] TerrainTypes = { };
 
-		public object Create(ActorInitializer init) { return new GrantConditionOnTerrain(init, this); }
+		public override object Create(ActorInitializer init) { return new GrantConditionOnTerrain(init, this); }
 	}
 
 	public class GrantConditionOnTerrain : ITick

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantConditionWhileAiming.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantConditionWhileAiming.cs
@@ -13,14 +13,14 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class GrantConditionWhileAimingInfo : ITraitInfo
+	public class GrantConditionWhileAimingInfo : TraitInfo
 	{
 		[FieldLoader.Require]
 		[GrantedConditionReference]
 		[Desc("The condition to grant while aiming.")]
 		public readonly string Condition = null;
 
-		object ITraitInfo.Create(ActorInitializer init) { return new GrantConditionWhileAiming(this); }
+		public override object Create(ActorInitializer init) { return new GrantConditionWhileAiming(this); }
 	}
 
 	public class GrantConditionWhileAiming : INotifyAiming

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantExternalConditionToCrusher.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantExternalConditionToCrusher.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Grant a condition to the crushing actor.")]
-	public class GrantExternalConditionToCrusherInfo : ITraitInfo
+	public class GrantExternalConditionToCrusherInfo : TraitInfo
 	{
 		[Desc("The condition to apply on a crush attempt. Must be included among the crusher actor's ExternalCondition traits.")]
 		public readonly string WarnCrushCondition = null;
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Duration of the condition applied on a successful crush (in ticks). Set to 0 for a permanent condition.")]
 		public readonly int OnCrushDuration = 0;
 
-		public virtual object Create(ActorInitializer init) { return new GrantExternalConditionToCrusher(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new GrantExternalConditionToCrusher(init.Self, this); }
 	}
 
 	public class GrantExternalConditionToCrusher : INotifyCrushed

--- a/OpenRA.Mods.Common/Traits/Conditions/GrantRandomCondition.cs
+++ b/OpenRA.Mods.Common/Traits/Conditions/GrantRandomCondition.cs
@@ -15,14 +15,14 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Conditions
 {
 	[Desc("Grants a random condition from a predefined list to the actor when created.")]
-	public class GrantRandomConditionInfo : ITraitInfo
+	public class GrantRandomConditionInfo : TraitInfo
 	{
 		[FieldLoader.Require]
 		[GrantedConditionReference]
 		[Desc("List of conditions to grant from.")]
 		public readonly string[] Conditions = null;
 
-		public object Create(ActorInitializer init) { return new GrantRandomCondition(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new GrantRandomCondition(init.Self, this); }
 	}
 
 	public class GrantRandomCondition : INotifyCreated

--- a/OpenRA.Mods.Common/Traits/Contrail.cs
+++ b/OpenRA.Mods.Common/Traits/Contrail.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Draw a colored contrail behind this actor when they move.")]
-	class ContrailInfo : ITraitInfo, Requires<BodyOrientationInfo>
+	class ContrailInfo : TraitInfo, Requires<BodyOrientationInfo>
 	{
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Use player remap color instead of a custom color?")]
 		public readonly bool UsePlayerColor = true;
 
-		public object Create(ActorInitializer init) { return new Contrail(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new Contrail(init.Self, this); }
 	}
 
 	class Contrail : ITick, IRender, INotifyAddedToWorld

--- a/OpenRA.Mods.Common/Traits/Crates/Crate.cs
+++ b/OpenRA.Mods.Common/Traits/Crates/Crate.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class CrateInfo : ITraitInfo, IPositionableInfo, Requires<RenderSpritesInfo>
+	public class CrateInfo : TraitInfo, IPositionableInfo, Requires<RenderSpritesInfo>
 	{
 		[Desc("Length of time (in seconds) until the crate gets removed automatically. " +
 			"A value of zero disables auto-removal.")]
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Define actors that can collect crates by setting this into the Crushes field from the Mobile trait.")]
 		public readonly string CrushClass = "crate";
 
-		public object Create(ActorInitializer init) { return new Crate(init, this); }
+		public override object Create(ActorInitializer init) { return new Crate(init, this); }
 
 		public IReadOnlyDictionary<CPos, SubCell> OccupiedCells(ActorInfo info, CPos location, SubCell subCell = SubCell.Any)
 		{

--- a/OpenRA.Mods.Common/Traits/DeliversCash.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversCash.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Donate money to actors with the `AcceptsDeliveredCash` trait.")]
-	class DeliversCashInfo : ITraitInfo
+	class DeliversCashInfo : TraitInfo
 	{
 		[Desc("The amount of cash the owner receives.")]
 		public readonly int Payload = 500;
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
-		public object Create(ActorInitializer init) { return new DeliversCash(this); }
+		public override object Create(ActorInitializer init) { return new DeliversCash(this); }
 	}
 
 	class DeliversCash : IIssueOrder, IResolveOrder, IOrderVoice, INotifyCashTransfer

--- a/OpenRA.Mods.Common/Traits/DeliversExperience.cs
+++ b/OpenRA.Mods.Common/Traits/DeliversExperience.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor can grant experience levels equal to it's own current level via entering to other actors with the `AcceptsDeliveredExperience` trait.")]
-	class DeliversExperienceInfo : ITraitInfo, Requires<GainsExperienceInfo>
+	class DeliversExperienceInfo : TraitInfo, Requires<GainsExperienceInfo>
 	{
 		[Desc("The amount of experience the donating player receives.")]
 		public readonly int PlayerExperience = 0;
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
-		public object Create(ActorInitializer init) { return new DeliversExperience(init, this); }
+		public override object Create(ActorInitializer init) { return new DeliversExperience(init, this); }
 	}
 
 	class DeliversExperience : IIssueOrder, IResolveOrder, IOrderVoice

--- a/OpenRA.Mods.Common/Traits/Demolishable.cs
+++ b/OpenRA.Mods.Common/Traits/Demolishable.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Handle demolitions from C4 explosives.")]
-	public class DemolishableInfo : ConditionalTraitInfo, IDemolishableInfo, ITraitInfo
+	public class DemolishableInfo : ConditionalTraitInfo, IDemolishableInfo
 	{
 		public bool IsValidTarget(ActorInfo actorInfo, Actor saboteur) { return true; }
 

--- a/OpenRA.Mods.Common/Traits/Demolition.cs
+++ b/OpenRA.Mods.Common/Traits/Demolition.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class DemolitionInfo : ITraitInfo
+	class DemolitionInfo : TraitInfo
 	{
 		[Desc("Delay to demolish the target once the explosive device is planted. " +
 			"Measured in game ticks. Default is 1.8 seconds.")]
@@ -46,7 +46,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly string Cursor = "c4";
 
-		public object Create(ActorInitializer init) { return new Demolition(this); }
+		public override object Create(ActorInitializer init) { return new Demolition(this); }
 	}
 
 	class Demolition : IIssueOrder, IResolveOrder, IOrderVoice

--- a/OpenRA.Mods.Common/Traits/EntersTunnels.cs
+++ b/OpenRA.Mods.Common/Traits/EntersTunnels.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor can interact with TunnelEntrances to move through TerrainTunnels.")]
-	public class EntersTunnelsInfo : ITraitInfo, Requires<IMoveInfo>, IObservesVariablesInfo
+	public class EntersTunnelsInfo : TraitInfo, Requires<IMoveInfo>, IObservesVariablesInfo
 	{
 		public readonly string EnterCursor = "enter";
 		public readonly string EnterBlockedCursor = "enter-blocked";
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Boolean expression defining the condition under which the regular (non-force) enter cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;
 
-		public object Create(ActorInitializer init) { return new EntersTunnels(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new EntersTunnels(init.Self, this); }
 	}
 
 	public class EntersTunnels : IIssueOrder, IResolveOrder, IOrderVoice, IObservesVariables

--- a/OpenRA.Mods.Common/Traits/ExitsDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/ExitsDebugOverlay.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Displays `Exit` data for factories.")]
-	public class ExitsDebugOverlayInfo : ITraitInfo, Requires<ExitInfo>
+	public class ExitsDebugOverlayInfo : TraitInfo, Requires<ExitInfo>
 	{
 		[Desc("Should cell vectors be drawn for each perimeter cell?")]
 		public readonly bool DrawPerimiterCellVectors = true;
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Should lines be drawn for each exit (from spawn offset to the center of the exit cell)?")]
 		public readonly bool DrawSpawnOffsetLines = true;
 
-		object ITraitInfo.Create(ActorInitializer init) { return new ExitsDebugOverlay(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new ExitsDebugOverlay(init.Self, this); }
 	}
 
 	public class ExitsDebugOverlay : IRenderAnnotationsWhenSelected

--- a/OpenRA.Mods.Common/Traits/ExplosionOnDamageTransition.cs
+++ b/OpenRA.Mods.Common/Traits/ExplosionOnDamageTransition.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor triggers an explosion on itself when transitioning to a specific damage state.")]
-	public class ExplosionOnDamageTransitionInfo : ITraitInfo, IRulesetLoaded, Requires<IHealthInfo>
+	public class ExplosionOnDamageTransitionInfo : TraitInfo, IRulesetLoaded, Requires<IHealthInfo>
 	{
 		[WeaponReference]
 		[FieldLoader.Require]
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public WeaponInfo WeaponInfo { get; private set; }
 
-		public object Create(ActorInitializer init) { return new ExplosionOnDamageTransition(this, init.Self); }
+		public override object Create(ActorInitializer init) { return new ExplosionOnDamageTransition(this, init.Self); }
 
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{

--- a/OpenRA.Mods.Common/Traits/GainsExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GainsExperience.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor's experience increases when it has killed a GivesExperience actor.")]
-	public class GainsExperienceInfo : ITraitInfo
+	public class GainsExperienceInfo : TraitInfo
 	{
 		[FieldLoader.Require]
 		[Desc("Condition to grant at each level.",
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Sounds")]
 		public readonly string LevelUpNotification = null;
 
-		public object Create(ActorInitializer init) { return new GainsExperience(init, this); }
+		public override object Create(ActorInitializer init) { return new GainsExperience(init, this); }
 	}
 
 	public class GainsExperience : INotifyCreated, ISync, IResolveOrder, ITransformActorInitModifier

--- a/OpenRA.Mods.Common/Traits/GivesExperience.cs
+++ b/OpenRA.Mods.Common/Traits/GivesExperience.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor gives experience to a GainsExperience actor when they are killed.")]
-	class GivesExperienceInfo : ITraitInfo
+	class GivesExperienceInfo : TraitInfo
 	{
 		[Desc("If -1, use the value of the unit cost.")]
 		public readonly int Experience = -1;
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Percentage of the `Experience` value that is being granted to the player owning the killing actor.")]
 		public readonly int PlayerExperienceModifier = 0;
 
-		public object Create(ActorInitializer init) { return new GivesExperience(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new GivesExperience(init.Self, this); }
 	}
 
 	class GivesExperience : INotifyKilled

--- a/OpenRA.Mods.Common/Traits/Guard.cs
+++ b/OpenRA.Mods.Common/Traits/Guard.cs
@@ -16,12 +16,12 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("The player can give this unit the order to follow and protect friendly units with the Guardable trait.")]
-	public class GuardInfo : ITraitInfo, Requires<IMoveInfo>
+	public class GuardInfo : TraitInfo, Requires<IMoveInfo>
 	{
 		[VoiceReference]
 		public readonly string Voice = "Action";
 
-		public object Create(ActorInitializer init) { return new Guard(this); }
+		public override object Create(ActorInitializer init) { return new Guard(this); }
 	}
 
 	public class Guard : IResolveOrder, IOrderVoice, INotifyCreated

--- a/OpenRA.Mods.Common/Traits/Harvester.cs
+++ b/OpenRA.Mods.Common/Traits/Harvester.cs
@@ -21,7 +21,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class HarvesterInfo : ITraitInfo, Requires<MobileInfo>
+	public class HarvesterInfo : TraitInfo, Requires<MobileInfo>
 	{
 		public readonly HashSet<string> DeliveryBuildings = new HashSet<string>();
 
@@ -84,7 +84,7 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference]
 		public readonly string DeliverVoice = "Action";
 
-		public object Create(ActorInitializer init) { return new Harvester(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new Harvester(init.Self, this); }
 	}
 
 	public class Harvester : IIssueOrder, IResolveOrder, IOrderVoice,

--- a/OpenRA.Mods.Common/Traits/Health.cs
+++ b/OpenRA.Mods.Common/Traits/Health.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class HealthInfo : IHealthInfo, IRulesetLoaded, IEditorActorOptions
+	public class HealthInfo : TraitInfo, IHealthInfo, IRulesetLoaded, IEditorActorOptions
 	{
 		[Desc("HitPoints")]
 		public readonly int HP = 0;
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Display order for the health slider in the map editor")]
 		public readonly int EditorHealthDisplayOrder = 2;
 
-		public virtual object Create(ActorInitializer init) { return new Health(init, this); }
+		public override object Create(ActorInitializer init) { return new Health(init, this); }
 
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{

--- a/OpenRA.Mods.Common/Traits/Husk.cs
+++ b/OpenRA.Mods.Common/Traits/Husk.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Spawns remains of a husk actor with the correct facing.")]
-	public class HuskInfo : ITraitInfo, IPositionableInfo, IFacingInfo, IActorPreviewInitInfo
+	public class HuskInfo : TraitInfo, IPositionableInfo, IFacingInfo, IActorPreviewInitInfo
 	{
 		public readonly HashSet<string> AllowedTerrain = new HashSet<string>();
 
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 			yield return new FacingInit(PreviewFacing);
 		}
 
-		public object Create(ActorInitializer init) { return new Husk(init, this); }
+		public override object Create(ActorInitializer init) { return new Husk(init, this); }
 
 		public int GetInitialFacing() { return 128; }
 

--- a/OpenRA.Mods.Common/Traits/Immobile.cs
+++ b/OpenRA.Mods.Common/Traits/Immobile.cs
@@ -15,10 +15,10 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class ImmobileInfo : ITraitInfo, IOccupySpaceInfo
+	class ImmobileInfo : TraitInfo, IOccupySpaceInfo
 	{
 		public readonly bool OccupiesSpace = true;
-		public object Create(ActorInitializer init) { return new Immobile(init, this); }
+		public override object Create(ActorInitializer init) { return new Immobile(init, this); }
 
 		public IReadOnlyDictionary<CPos, SubCell> OccupiedCells(ActorInfo info, CPos location, SubCell subCell = SubCell.Any)
 		{

--- a/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/ScaredyCat.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Makes the unit automatically run around when taking damage.")]
-	class ScaredyCatInfo : ITraitInfo, Requires<MobileInfo>
+	class ScaredyCatInfo : TraitInfo, Requires<MobileInfo>
 	{
 		[Desc("Chance (out of 100) the unit has to enter panic mode when attacked.")]
 		public readonly int PanicChance = 100;
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		[SequenceReference(null, true)]
 		public readonly string PanicSequencePrefix = "panic-";
 
-		public object Create(ActorInitializer init) { return new ScaredyCat(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new ScaredyCat(init.Self, this); }
 	}
 
 	class ScaredyCat : ITick, INotifyIdle, INotifyDamage, INotifyAttack, ISpeedModifier, ISync, IRenderInfantrySequenceModifier

--- a/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
+++ b/OpenRA.Mods.Common/Traits/Infantry/TerrainModifiesDamage.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class TerrainModifiesDamageInfo : ITraitInfo
+	public class TerrainModifiesDamageInfo : TraitInfo
 	{
 		[FieldLoader.Require]
 		[Desc("Damage percentage for specific terrain types. 120 = 120%, 80 = 80%, etc.")]
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Modify healing damage? For example: A friendly medic.")]
 		public readonly bool ModifyHealing = false;
 
-		public object Create(ActorInitializer init) { return new TerrainModifiesDamage(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new TerrainModifiesDamage(init.Self, this); }
 	}
 
 	public class TerrainModifiesDamage : IDamageModifier

--- a/OpenRA.Mods.Common/Traits/Interactable.cs
+++ b/OpenRA.Mods.Common/Traits/Interactable.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Used to enable mouse interaction on actors that are not Selectable.")]
-	public class InteractableInfo : ITraitInfo, IMouseBoundsInfo
+	public class InteractableInfo : TraitInfo, IMouseBoundsInfo
 	{
 		[Desc("Defines a custom rectangle for mouse interaction with the actor.",
 			"If null, the engine will guess an appropriate size based on the With*Body trait.",
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 			"If null, Bounds will be used instead")]
 		public readonly int[] DecorationBounds = null;
 
-		public virtual object Create(ActorInitializer init) { return new Interactable(this); }
+		public override object Create(ActorInitializer init) { return new Interactable(this); }
 	}
 
 	public class Interactable : INotifyCreated, IMouseBounds

--- a/OpenRA.Mods.Common/Traits/IsometricSelectable.cs
+++ b/OpenRA.Mods.Common/Traits/IsometricSelectable.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor is selectable. Defines bounds of selectable area, selection class, selection priority and selection priority modifiers.")]
-	public class IsometricSelectableInfo : ITraitInfo, IMouseBoundsInfo, ISelectableInfo, IRulesetLoaded, Requires<BuildingInfo>
+	public class IsometricSelectableInfo : TraitInfo, IMouseBoundsInfo, ISelectableInfo, IRulesetLoaded, Requires<BuildingInfo>
 	{
 		[Desc("Defines a custom rectangle for mouse interaction with the actor.",
 			"If null, the engine will guess an appropriate size based on the building's footprint.",
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 		[VoiceReference]
 		public readonly string Voice = "Select";
 
-		public object Create(ActorInitializer init) { return new IsometricSelectable(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new IsometricSelectable(init.Self, this); }
 
 		int ISelectableInfo.Priority { get { return Priority; } }
 		SelectionPriorityModifiers ISelectableInfo.PriorityModifiers { get { return PriorityModifiers; } }

--- a/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/FrozenUnderFog.cs
@@ -19,12 +19,12 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor will remain visible (but not updated visually) under fog, once discovered.")]
-	public class FrozenUnderFogInfo : ITraitInfo, Requires<BuildingInfo>, IDefaultVisibilityInfo
+	public class FrozenUnderFogInfo : TraitInfo, Requires<BuildingInfo>, IDefaultVisibilityInfo
 	{
 		[Desc("Players with these stances can always see the actor.")]
 		public readonly Stance AlwaysVisibleStances = Stance.Ally;
 
-		public object Create(ActorInitializer init) { return new FrozenUnderFog(init, this); }
+		public override object Create(ActorInitializer init) { return new FrozenUnderFog(init, this); }
 	}
 
 	public class FrozenUnderFog : ICreatesFrozenActors, IRenderModifier, IDefaultVisibility, ITick, ITickRender, ISync, INotifyCreated, INotifyOwnerChanged, INotifyActorDisposing

--- a/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderShroud.cs
+++ b/OpenRA.Mods.Common/Traits/Modifiers/HiddenUnderShroud.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("The actor stays invisible under the shroud.")]
-	public class HiddenUnderShroudInfo : ITraitInfo, IDefaultVisibilityInfo
+	public class HiddenUnderShroudInfo : TraitInfo, IDefaultVisibilityInfo
 	{
 		[Desc("Players with these stances can always see the actor.")]
 		public readonly Stance AlwaysVisibleStances = Stance.Ally;
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 			"Footprint (reveal when any footprint cell is visible).")]
 		public readonly VisibilityType Type = VisibilityType.Footprint;
 
-		public virtual object Create(ActorInitializer init) { return new HiddenUnderShroud(this); }
+		public override object Create(ActorInitializer init) { return new HiddenUnderShroud(this); }
 	}
 
 	public class HiddenUnderShroud : IDefaultVisibility, IRenderModifier

--- a/OpenRA.Mods.Common/Traits/MustBeDestroyed.cs
+++ b/OpenRA.Mods.Common/Traits/MustBeDestroyed.cs
@@ -14,12 +14,12 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Actors with this trait must be destroyed for a game to end.")]
-	public class MustBeDestroyedInfo : ITraitInfo
+	public class MustBeDestroyedInfo : TraitInfo
 	{
 		[Desc("In a short game only actors that have this value set to true need to be destroyed.")]
 		public bool RequiredForShortGame = false;
 
-		public object Create(ActorInitializer init) { return new MustBeDestroyed(this); }
+		public override object Create(ActorInitializer init) { return new MustBeDestroyed(this); }
 	}
 
 	public class MustBeDestroyed

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/FlashPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/FlashPaletteEffect.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 	using GUtil = OpenRA.Graphics.Util;
 
 	[Desc("Used for bursted one-colored whole screen effects. Add this to the world actor.")]
-	public class FlashPaletteEffectInfo : ITraitInfo
+	public class FlashPaletteEffectInfo : TraitInfo
 	{
 		public readonly HashSet<string> ExcludePalettes = new HashSet<string> { "cursor", "chrome", "colorpicker", "fog", "shroud" };
 
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Set this when using multiple independent flash effects.")]
 		public readonly string Type = null;
 
-		public object Create(ActorInitializer init) { return new FlashPaletteEffect(this); }
+		public override object Create(ActorInitializer init) { return new FlashPaletteEffect(this); }
 	}
 
 	public class FlashPaletteEffect : IPaletteModifier, ITick

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/GlobalLightingPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/GlobalLightingPaletteEffect.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Used for day/night effects.")]
-	public class GlobalLightingPaletteEffectInfo : ITraitInfo, ILobbyCustomRulesIgnore
+	public class GlobalLightingPaletteEffectInfo : TraitInfo, ILobbyCustomRulesIgnore
 	{
 		[Desc("Do not modify graphics that use any palette in this list.")]
 		public readonly HashSet<string> ExcludePalettes = new HashSet<string> { "cursor", "chrome", "colorpicker", "fog", "shroud", "alpha" };
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly float Blue = 1f;
 		public readonly float Ambient = 1f;
 
-		public object Create(ActorInitializer init) { return new GlobalLightingPaletteEffect(this); }
+		public override object Create(ActorInitializer init) { return new GlobalLightingPaletteEffect(this); }
 	}
 
 	public class GlobalLightingPaletteEffect : IPaletteModifier

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/MenuPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/MenuPaletteEffect.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Fades the world from/to black at the start/end of the game, and can (optionally) desaturate the world")]
-	public class MenuPaletteEffectInfo : ITraitInfo
+	public class MenuPaletteEffectInfo : TraitInfo
 	{
 		[Desc("Time (in ticks) to fade between states")]
 		public readonly int FadeLength = 10;
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Effect style to fade to when opening the in-game menu. Accepts values of None, Black or Desaturated.")]
 		public readonly MenuPaletteEffect.EffectType MenuEffect = MenuPaletteEffect.EffectType.None;
 
-		public object Create(ActorInitializer init) { return new MenuPaletteEffect(this); }
+		public override object Create(ActorInitializer init) { return new MenuPaletteEffect(this); }
 	}
 
 	public class MenuPaletteEffect : IPaletteModifier, IRender, IWorldLoaded, INotifyGameLoaded

--- a/OpenRA.Mods.Common/Traits/PaletteEffects/RotationPaletteEffect.cs
+++ b/OpenRA.Mods.Common/Traits/PaletteEffects/RotationPaletteEffect.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Palette effect used for sprinkle \"animations\".")]
-	class RotationPaletteEffectInfo : ITraitInfo
+	class RotationPaletteEffectInfo : TraitInfo
 	{
 		[Desc("Defines to which palettes this effect should be applied to.",
 			"If none specified, it applies to all palettes not explicitly excluded.")]
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Step towards next color index per tick.")]
 		public readonly float RotationStep = .25f;
 
-		public object Create(ActorInitializer init) { return new RotationPaletteEffect(init.World, this); }
+		public override object Create(ActorInitializer init) { return new RotationPaletteEffect(init.World, this); }
 	}
 
 	class RotationPaletteEffect : ITick, IPaletteModifier

--- a/OpenRA.Mods.Common/Traits/ParaDrop.cs
+++ b/OpenRA.Mods.Common/Traits/ParaDrop.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This unit can spawn and eject other actors while flying.")]
-	public class ParaDropInfo : ITraitInfo, Requires<CargoInfo>
+	public class ParaDropInfo : TraitInfo, Requires<CargoInfo>
 	{
 		[Desc("Distance around the drop-point to unload troops.")]
 		public readonly WDist DropRange = WDist.FromCells(4);
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sound to play when dropping.")]
 		public readonly string ChuteSound = null;
 
-		public object Create(ActorInitializer init) { return new ParaDrop(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new ParaDrop(init.Self, this); }
 	}
 
 	public class ParaDrop : ITick, ISync, INotifyRemovedFromWorld

--- a/OpenRA.Mods.Common/Traits/Parachutable.cs
+++ b/OpenRA.Mods.Common/Traits/Parachutable.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Can be paradropped by a ParaDrop actor.")]
-	public class ParachutableInfo : ITraitInfo, Requires<IPositionableInfo>
+	public class ParachutableInfo : TraitInfo, Requires<IPositionableInfo>
 	{
 		[Desc("If we land on invalid terrain for my actor type should we be killed?")]
 		public readonly bool KilledOnImpassableTerrain = true;
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The condition to grant to self while parachuting.")]
 		public readonly string ParachutingCondition = null;
 
-		public object Create(ActorInitializer init) { return new Parachutable(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new Parachutable(init.Self, this); }
 	}
 
 	public class Parachutable : INotifyParachute

--- a/OpenRA.Mods.Common/Traits/Passenger.cs
+++ b/OpenRA.Mods.Common/Traits/Passenger.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor can enter Cargo actors.")]
-	public class PassengerInfo : ITraitInfo, IObservesVariablesInfo
+	public class PassengerInfo : TraitInfo, IObservesVariablesInfo
 	{
 		public readonly string CargoType = null;
 
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Boolean expression defining the condition under which the regular (non-force) enter cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;
 
-		public object Create(ActorInitializer init) { return new Passenger(this); }
+		public override object Create(ActorInitializer init) { return new Passenger(this); }
 	}
 
 	public class Passenger : IIssueOrder, IResolveOrder, IOrderVoice, INotifyRemovedFromWorld, INotifyEnteredCargo, INotifyExitedCargo, INotifyKilled, IObservesVariables

--- a/OpenRA.Mods.Common/Traits/Player/BaseAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/BaseAttackNotifier.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Plays an audio notification and shows a radar ping when a building is attacked.",
 		"Attach this to the player actor.")]
-	public class BaseAttackNotifierInfo : ITraitInfo
+	public class BaseAttackNotifierInfo : TraitInfo
 	{
 		[Desc("Minimum duration (in seconds) between notification events.")]
 		public readonly int NotifyInterval = 30;
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 			"Won't play a notification to allies if this is null.")]
 		public string AllyNotification = null;
 
-		public object Create(ActorInitializer init) { return new BaseAttackNotifier(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new BaseAttackNotifier(init.Self, this); }
 	}
 
 	public class BaseAttackNotifier : INotifyDamage

--- a/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ConquestVictoryConditions.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class ConquestVictoryConditionsInfo : ITraitInfo, Requires<MissionObjectivesInfo>
+	public class ConquestVictoryConditionsInfo : TraitInfo, Requires<MissionObjectivesInfo>
 	{
 		[Desc("Delay for the end game notification in milliseconds.")]
 		public readonly int NotificationDelay = 1500;
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Disable the win/loss messages and audio notifications?")]
 		public readonly bool SuppressNotifications = false;
 
-		public object Create(ActorInitializer init) { return new ConquestVictoryConditions(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new ConquestVictoryConditions(init.Self, this); }
 	}
 
 	public class ConquestVictoryConditions : ITick, INotifyWinStateChanged, INotifyTimeLimit

--- a/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DeveloperMode.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Attach this to the player actor.")]
-	public class DeveloperModeInfo : ITraitInfo, ILobbyOptions
+	public class DeveloperModeInfo : TraitInfo, ILobbyOptions
 	{
 		[Translate]
 		[Desc("Descriptive label for the developer mode checkbox in the lobby.")]
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 			yield return new LobbyBooleanOption("cheats", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
 		}
 
-		public object Create(ActorInitializer init) { return new DeveloperMode(this); }
+		public override object Create(ActorInitializer init) { return new DeveloperMode(this); }
 	}
 
 	public class DeveloperMode : IResolveOrder, ISync, INotifyCreated, IUnlocksRenderPlayer

--- a/OpenRA.Mods.Common/Traits/Player/DummyBot.cs
+++ b/OpenRA.Mods.Common/Traits/Player/DummyBot.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("A placeholder bot that doesn't do anything.")]
-	public sealed class DummyBotInfo : ITraitInfo, IBotInfo
+	public sealed class DummyBotInfo : TraitInfo, IBotInfo
 	{
 		[Desc("Human-readable name this bot uses.")]
 		public readonly string Name = "Unnamed Bot";
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		string IBotInfo.Name { get { return Name; } }
 
-		public object Create(ActorInitializer init) { return new DummyBot(this); }
+		public override object Create(ActorInitializer init) { return new DummyBot(this); }
 	}
 
 	public sealed class DummyBot : IBot

--- a/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
+++ b/OpenRA.Mods.Common/Traits/Player/EnemyWatcher.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Tracks neutral and enemy actors' visibility and notifies the player.",
 		"Attach this to the player actor. The actors to track need the 'AnnounceOnSeen' trait.")]
-	class EnemyWatcherInfo : ITraitInfo
+	class EnemyWatcherInfo : TraitInfo
 	{
 		[Desc("Interval in ticks between scanning for enemies.")]
 		public readonly int ScanInterval = 25;
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Minimal ticks in-between notifications.")]
 		public readonly int NotificationInterval = 750;
 
-		public object Create(ActorInitializer init) { return new EnemyWatcher(this); }
+		public override object Create(ActorInitializer init) { return new EnemyWatcher(this); }
 	}
 
 	class EnemyWatcher : ITick

--- a/OpenRA.Mods.Common/Traits/Player/GrantConditionOnPrerequisiteManager.cs
+++ b/OpenRA.Mods.Common/Traits/Player/GrantConditionOnPrerequisiteManager.cs
@@ -17,9 +17,9 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Attach this to the player actor.")]
-	public class GrantConditionOnPrerequisiteManagerInfo : ITraitInfo, Requires<TechTreeInfo>
+	public class GrantConditionOnPrerequisiteManagerInfo : TraitInfo, Requires<TechTreeInfo>
 	{
-		public object Create(ActorInitializer init) { return new GrantConditionOnPrerequisiteManager(init); }
+		public override object Create(ActorInitializer init) { return new GrantConditionOnPrerequisiteManager(init); }
 	}
 
 	public class GrantConditionOnPrerequisiteManager : ITechTreeElement

--- a/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
+++ b/OpenRA.Mods.Common/Traits/Player/HarvesterAttackNotifier.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Plays an audio notification and shows a radar ping when a harvester is attacked.",
 		"Attach this to the player actor.")]
-	public class HarvesterAttackNotifierInfo : ITraitInfo
+	public class HarvesterAttackNotifierInfo : TraitInfo
 	{
 		[Desc("Minimum duration (in seconds) between notification events.")]
 		public readonly int NotifyInterval = 30;
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The audio notification type to play.")]
 		public string Notification = "HarvesterAttack";
 
-		public object Create(ActorInitializer init) { return new HarvesterAttackNotifier(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new HarvesterAttackNotifier(init.Self, this); }
 	}
 
 	public class HarvesterAttackNotifier : INotifyDamage

--- a/OpenRA.Mods.Common/Traits/Player/MissionObjectives.cs
+++ b/OpenRA.Mods.Common/Traits/Player/MissionObjectives.cs
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 		}
 	}
 
-	public class MissionObjectivesInfo : ITraitInfo
+	public class MissionObjectivesInfo : TraitInfo
 	{
 		[Desc("Set this to true if multiple cooperative players have a distinct set of " +
 			"objectives that each of them has to complete to win the game. This is mainly " +
@@ -58,7 +58,7 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Speech")]
 		public readonly string LeaveNotification = null;
 
-		public object Create(ActorInitializer init) { return new MissionObjectives(init.World, this); }
+		public override object Create(ActorInitializer init) { return new MissionObjectives(init.World, this); }
 	}
 
 	public class MissionObjectives : INotifyWinStateChanged, ISync, IResolveOrder
@@ -259,14 +259,14 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Provides game mode progress information for players.",
 		"Goes on WorldActor - observers don't have a player it can live on.",
 		"Current options for PanelName are 'SKIRMISH_STATS' and 'MISSION_OBJECTIVES'.")]
-	public class ObjectivesPanelInfo : ITraitInfo
+	public class ObjectivesPanelInfo : TraitInfo
 	{
 		public string PanelName = null;
 
 		[Desc("in ms")]
 		public int ExitDelay = 1400;
 
-		public object Create(ActorInitializer init) { return new ObjectivesPanel(this); }
+		public override object Create(ActorInitializer init) { return new ObjectivesPanel(this); }
 	}
 
 	public class ObjectivesPanel : IObjectivesPanel

--- a/OpenRA.Mods.Common/Traits/Player/ModularBot.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ModularBot.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Bot that uses BotModules.")]
-	public sealed class ModularBotInfo : IBotInfo, ITraitInfo
+	public sealed class ModularBotInfo : TraitInfo, IBotInfo
 	{
 		[FieldLoader.Require]
 		[Desc("Internal id for this bot.")]
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		string IBotInfo.Name { get { return Name; } }
 
-		public object Create(ActorInitializer init) { return new ModularBot(this, init); }
+		public override object Create(ActorInitializer init) { return new ModularBot(this, init); }
 	}
 
 	public sealed class ModularBot : ITick, IBot, INotifyDamage

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBeacon.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("A beacon that is constructed from a circle sprite that is animated once and a moving arrow sprite.")]
-	public class PlaceBeaconInfo : ITraitInfo
+	public class PlaceBeaconInfo : TraitInfo
 	{
 		public readonly int Duration = 30 * 25;
 
@@ -40,7 +40,7 @@ namespace OpenRA.Mods.Common.Traits
 		[SequenceReference("BeaconImage")]
 		public readonly string CircleSequence = "circles";
 
-		public object Create(ActorInitializer init) { return new PlaceBeacon(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new PlaceBeacon(init.Self, this); }
 	}
 
 	public class PlaceBeacon : IResolveOrder

--- a/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlaceBuilding.cs
@@ -19,7 +19,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class PlaceBuildingInit : IActorInit { }
 
 	[Desc("Allows the player to execute build orders.", " Attach this to the player actor.")]
-	public class PlaceBuildingInfo : ITraitInfo
+	public class PlaceBuildingInfo : TraitInfo
 	{
 		[Desc("Play NewOptionsNotification this many ticks after building placement.")]
 		public readonly int NewOptionsNotificationDelay = 10;
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Hotkey to toggle between PlaceBuildingVariants when placing a structure.")]
 		public HotkeyReference ToggleVariantKey = new HotkeyReference();
 
-		public object Create(ActorInitializer init) { return new PlaceBuilding(this); }
+		public override object Create(ActorInitializer init) { return new PlaceBuilding(this); }
 	}
 
 	public class PlaceBuilding : IResolveOrder, ITick

--- a/OpenRA.Mods.Common/Traits/Player/PlayerExperience.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerExperience.cs
@@ -16,9 +16,9 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("This trait can be used to track player experience based on units killed with the `GivesExperience` trait.",
 		"It can also be used as a point score system in scripted maps, for example.",
 		"Attach this to the player actor.")]
-	public class PlayerExperienceInfo : ITraitInfo
+	public class PlayerExperienceInfo : TraitInfo
 	{
-		public object Create(ActorInitializer init) { return new PlayerExperience(); }
+		public override object Create(ActorInitializer init) { return new PlayerExperience(); }
 	}
 
 	public class PlayerExperience : ISync

--- a/OpenRA.Mods.Common/Traits/Player/PlayerRadarTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerRadarTerrain.cs
@@ -17,9 +17,9 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class PlayerRadarTerrainInfo : ITraitInfo, Requires<ShroudInfo>
+	public class PlayerRadarTerrainInfo : TraitInfo, Requires<ShroudInfo>
 	{
-		public object Create(ActorInitializer init)
+		public override object Create(ActorInitializer init)
 		{
 			return new PlayerRadarTerrain(init.Self);
 		}

--- a/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerResources.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class PlayerResourcesInfo : ITraitInfo, ILobbyOptions
+	public class PlayerResourcesInfo : TraitInfo, ILobbyOptions
 	{
 		[Translate]
 		[Desc("Descriptive label for the starting cash option in the lobby.")]
@@ -63,7 +63,7 @@ namespace OpenRA.Mods.Common.Traits
 					new ReadOnlyDictionary<string, string>(startingCash), DefaultCash.ToString(), DefaultCashDropdownLocked);
 		}
 
-		public object Create(ActorInitializer init) { return new PlayerResources(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new PlayerResources(init.Self, this); }
 	}
 
 	public class PlayerResources : ISync

--- a/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
+++ b/OpenRA.Mods.Common/Traits/Player/PlayerStatistics.cs
@@ -20,9 +20,9 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Attach this to the player actor to collect observer stats.")]
-	public class PlayerStatisticsInfo : ITraitInfo
+	public class PlayerStatisticsInfo : TraitInfo
 	{
-		public object Create(ActorInitializer init) { return new PlayerStatistics(init.Self); }
+		public override object Create(ActorInitializer init) { return new PlayerStatistics(init.Self); }
 	}
 
 	public class PlayerStatistics : ITick, IResolveOrder, INotifyCreated, IWorldLoaded
@@ -200,7 +200,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[Desc("Attach this to a unit to update observer stats.")]
-	public class UpdatesPlayerStatisticsInfo : ITraitInfo
+	public class UpdatesPlayerStatisticsInfo : TraitInfo
 	{
 		[Desc("Add to army value in statistics")]
 		public bool AddToArmyValue = false;
@@ -209,7 +209,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Count this actor as a different type in the spectator army display.")]
 		public string OverrideActor = null;
 
-		public object Create(ActorInitializer init) { return new UpdatesPlayerStatistics(this, init.Self); }
+		public override object Create(ActorInitializer init) { return new UpdatesPlayerStatistics(this, init.Self); }
 	}
 
 	public class UpdatesPlayerStatistics : INotifyKilled, INotifyCreated, INotifyOwnerChanged, INotifyActorDisposing

--- a/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProductionQueue.cs
@@ -20,7 +20,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Attach this to an actor (usually a building) to let it produce units or construct buildings.",
 		"If one builds another actor of this type, he will get a separate queue to create two actors",
 		"at the same time. Will only work together with the Production: trait.")]
-	public class ProductionQueueInfo : ITraitInfo
+	public class ProductionQueueInfo : TraitInfo
 	{
 		[FieldLoader.Require]
 		[Desc("What kind of production will be added (e.g. Building, Infantry, Vehicle, ...)")]
@@ -88,7 +88,7 @@ namespace OpenRA.Mods.Common.Traits
 			"The filename of the audio is defined per faction in notifications.yaml.")]
 		public readonly string CancelledAudio = null;
 
-		public virtual object Create(ActorInitializer init) { return new ProductionQueue(init, init.Self.Owner.PlayerActor, this); }
+		public override object Create(ActorInitializer init) { return new ProductionQueue(init, init.Self.Owner.PlayerActor, this); }
 
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{

--- a/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ProvidesTechPrerequisite.cs
@@ -10,10 +10,11 @@
 #endregion
 
 using System.Collections.Generic;
+using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class ProvidesTechPrerequisiteInfo : ITechTreePrerequisiteInfo
+	public class ProvidesTechPrerequisiteInfo : TraitInfo, ITechTreePrerequisiteInfo
 	{
 		[Desc("Internal id for this tech level.")]
 		public readonly string Id;
@@ -27,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		IEnumerable<string> ITechTreePrerequisiteInfo.Prerequisites(ActorInfo info) { return Prerequisites; }
 
-		public object Create(ActorInitializer init) { return new ProvidesTechPrerequisite(this, init); }
+		public override object Create(ActorInitializer init) { return new ProvidesTechPrerequisite(this, init); }
 	}
 
 	public class ProvidesTechPrerequisite : ITechTreePrerequisite

--- a/OpenRA.Mods.Common/Traits/Player/ResourceStorageWarning.cs
+++ b/OpenRA.Mods.Common/Traits/Player/ResourceStorageWarning.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Provides the player with an audible warning when their storage is nearing full.")]
-	public class ResourceStorageWarningInfo : ITraitInfo, Requires<PlayerResourcesInfo>
+	public class ResourceStorageWarningInfo : TraitInfo, Requires<PlayerResourcesInfo>
 	{
 		[Desc("Interval, in seconds, at which to check if more storage is needed.")]
 		public readonly int AdviceInterval = 20;
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("The speech to play for the warning.")]
 		public readonly string Notification = "SilosNeeded";
 
-		public object Create(ActorInitializer init) { return new ResourceStorageWarning(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new ResourceStorageWarning(init.Self, this); }
 	}
 
 	public class ResourceStorageWarning : ITick

--- a/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
+++ b/OpenRA.Mods.Common/Traits/Player/StrategicVictoryConditions.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits
 	public class StrategicPoint { }
 
 	[Desc("Allows King of the Hill (KotH) style gameplay.")]
-	public class StrategicVictoryConditionsInfo : ITraitInfo, Requires<MissionObjectivesInfo>
+	public class StrategicVictoryConditionsInfo : TraitInfo, Requires<MissionObjectivesInfo>
 	{
 		[Desc("Amount of time (in game ticks) that the player has to hold all the strategic points.", "Defaults to 7500 ticks (5 minutes at default speed).")]
 		public readonly int HoldDuration = 7500;
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Disable the win/loss messages and audio notifications?")]
 		public readonly bool SuppressNotifications = false;
 
-		public object Create(ActorInitializer init) { return new StrategicVictoryConditions(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new StrategicVictoryConditions(init.Self, this); }
 	}
 
 	public class StrategicVictoryConditions : ITick, ISync, INotifyWinStateChanged, INotifyTimeLimit

--- a/OpenRA.Mods.Common/Traits/Player/TechTree.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TechTree.cs
@@ -18,9 +18,9 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Manages build limits and pre-requisites.", " Attach this to the player actor.")]
-	public class TechTreeInfo : ITraitInfo
+	public class TechTreeInfo : TraitInfo
 	{
-		public object Create(ActorInitializer init) { return new TechTree(init); }
+		public override object Create(ActorInitializer init) { return new TechTree(init); }
 	}
 
 	public class TechTree

--- a/OpenRA.Mods.Common/Traits/Player/TimeLimitManager.cs
+++ b/OpenRA.Mods.Common/Traits/Player/TimeLimitManager.cs
@@ -20,7 +20,7 @@ using OpenRA.Widgets;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This trait allows setting a time limit on matches. Attach this to the World actor.")]
-	public class TimeLimitManagerInfo : ITraitInfo, ILobbyOptions, IRulesetLoaded
+	public class TimeLimitManagerInfo : TraitInfo, ILobbyOptions, IRulesetLoaded
 	{
 		[Desc("Label that will be shown for the time limit option in the lobby.")]
 		public readonly string TimeLimitLabel = "Time Limit";
@@ -89,7 +89,7 @@ namespace OpenRA.Mods.Common.Traits
 				new ReadOnlyDictionary<string, string>(timelimits), TimeLimitDefault.ToString(), TimeLimitLocked);
 		}
 
-		public object Create(ActorInitializer init) { return new TimeLimitManager(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new TimeLimitManager(init.Self, this); }
 	}
 
 	public class TimeLimitManager : INotifyTimeLimit, ITick, IWorldLoaded

--- a/OpenRA.Mods.Common/Traits/Pluggable.cs
+++ b/OpenRA.Mods.Common/Traits/Pluggable.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class PluggableInfo : ITraitInfo
+	public class PluggableInfo : TraitInfo
 	{
 		[Desc("Footprint cell offset where a plug can be placed.")]
 		public readonly CVec Offset = CVec.Zero;
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 			get { return Requirements.Values.SelectMany(r => r.Variables).Distinct(); }
 		}
 
-		public object Create(ActorInitializer init) { return new Pluggable(init, this); }
+		public override object Create(ActorInitializer init) { return new Pluggable(init, this); }
 	}
 
 	public class Pluggable : IObservesVariables, INotifyCreated

--- a/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/Power/Player/PowerManager.cs
@@ -16,14 +16,14 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Attach this to the player actor.")]
-	public class PowerManagerInfo : ITraitInfo, Requires<DeveloperModeInfo>
+	public class PowerManagerInfo : TraitInfo, Requires<DeveloperModeInfo>
 	{
 		public readonly int AdviceInterval = 250;
 
 		[NotificationReference("Speech")]
 		public readonly string SpeechNotification = null;
 
-		public object Create(ActorInitializer init) { return new PowerManager(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new PowerManager(init.Self, this); }
 	}
 
 	public class PowerManager : INotifyCreated, ITick, ISync, IResolveOrder

--- a/OpenRA.Mods.Common/Traits/Power/ScalePowerWithHealth.cs
+++ b/OpenRA.Mods.Common/Traits/Power/ScalePowerWithHealth.cs
@@ -14,9 +14,9 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Scale power amount with the current health.")]
-	public class ScalePowerWithHealthInfo : ITraitInfo, Requires<PowerInfo>, Requires<IHealthInfo>
+	public class ScalePowerWithHealthInfo : TraitInfo, Requires<PowerInfo>, Requires<IHealthInfo>
 	{
-		public object Create(ActorInitializer init) { return new ScalePowerWithHealth(init.Self); }
+		public override object Create(ActorInitializer init) { return new ScalePowerWithHealth(init.Self); }
 	}
 
 	public class ScalePowerWithHealth : IPowerModifier, INotifyDamage, INotifyOwnerChanged

--- a/OpenRA.Mods.Common/Traits/PowerTooltip.cs
+++ b/OpenRA.Mods.Common/Traits/PowerTooltip.cs
@@ -14,9 +14,9 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Shown power info on the build palette widget.")]
-	public class PowerTooltipInfo : ITraitInfo
+	public class PowerTooltipInfo : TraitInfo
 	{
-		public object Create(ActorInitializer init) { return new PowerTooltip(init.Self); }
+		public override object Create(ActorInitializer init) { return new PowerTooltip(init.Self); }
 	}
 
 	public class PowerTooltip : IProvideTooltipInfo, INotifyOwnerChanged

--- a/OpenRA.Mods.Common/Traits/ProducibleWithLevel.cs
+++ b/OpenRA.Mods.Common/Traits/ProducibleWithLevel.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.Traits
 	[Desc("Actors possessing this trait should define the GainsExperience trait. When the prerequisites are fulfilled, ",
 		"this trait grants a level-up to newly spawned actors. If additionally the actor's owning player defines the ProductionIconOverlay ",
 		"trait, the production queue icon renders with an overlay defined in that trait.")]
-	public class ProducibleWithLevelInfo : ITraitInfo, Requires<GainsExperienceInfo>
+	public class ProducibleWithLevelInfo : TraitInfo, Requires<GainsExperienceInfo>
 	{
 		public readonly string[] Prerequisites = { };
 
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Should the level-up animation be suppressed when actor is created?")]
 		public readonly bool SuppressLevelupAnimation = true;
 
-		public object Create(ActorInitializer init) { return new ProducibleWithLevel(init, this); }
+		public override object Create(ActorInitializer init) { return new ProducibleWithLevel(init, this); }
 	}
 
 	public class ProducibleWithLevel : INotifyCreated

--- a/OpenRA.Mods.Common/Traits/ProductionQueueFromSelection.cs
+++ b/OpenRA.Mods.Common/Traits/ProductionQueueFromSelection.cs
@@ -17,12 +17,12 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class ProductionQueueFromSelectionInfo : ITraitInfo
+	class ProductionQueueFromSelectionInfo : TraitInfo
 	{
 		public string ProductionTabsWidget = null;
 		public string ProductionPaletteWidget = null;
 
-		public object Create(ActorInitializer init) { return new ProductionQueueFromSelection(init.World, this); }
+		public override object Create(ActorInitializer init) { return new ProductionQueueFromSelection(init.World, this); }
 	}
 
 	class ProductionQueueFromSelection : INotifySelection

--- a/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
+++ b/OpenRA.Mods.Common/Traits/ProximityCapturable.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Actor can be captured by units in a specified proximity.")]
-	public class ProximityCapturableInfo : ITraitInfo, IRulesetLoaded
+	public class ProximityCapturableInfo : TraitInfo, IRulesetLoaded
 	{
 		[Desc("Maximum range at which a ProximityCaptor actor can initiate the capture.")]
 		public readonly WDist Range = WDist.FromCells(5);
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 				throw new YamlException("ProximityCapturable requires the `Player` actor to have the ProximityCaptor trait.");
 		}
 
-		public object Create(ActorInitializer init) { return new ProximityCapturable(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new ProximityCapturable(init.Self, this); }
 	}
 
 	public class ProximityCapturable : ITick, INotifyAddedToWorld, INotifyRemovedFromWorld, INotifyOwnerChanged

--- a/OpenRA.Mods.Common/Traits/Radar/RadarColorFromTerrain.cs
+++ b/OpenRA.Mods.Common/Traits/Radar/RadarColorFromTerrain.cs
@@ -14,12 +14,12 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Radar
 {
-	public class RadarColorFromTerrainInfo : ITraitInfo
+	public class RadarColorFromTerrainInfo : TraitInfo
 	{
 		[FieldLoader.Require]
 		public readonly string Terrain;
 
-		public object Create(ActorInitializer init) { return new RadarColorFromTerrain(init.Self, Terrain); }
+		public override object Create(ActorInitializer init) { return new RadarColorFromTerrain(init.Self, Terrain); }
 	}
 
 	public class RadarColorFromTerrain : IRadarColorModifier

--- a/OpenRA.Mods.Common/Traits/Rearmable.cs
+++ b/OpenRA.Mods.Common/Traits/Rearmable.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class RearmableInfo : ITraitInfo
+	public class RearmableInfo : TraitInfo
 	{
 		[ActorReference]
 		[FieldLoader.Require]
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Name(s) of AmmoPool(s) that use this trait to rearm.")]
 		public readonly HashSet<string> AmmoPools = new HashSet<string> { "primary" };
 
-		public object Create(ActorInitializer init) { return new Rearmable(this); }
+		public override object Create(ActorInitializer init) { return new Rearmable(this); }
 	}
 
 	public class Rearmable : INotifyCreated, INotifyResupply

--- a/OpenRA.Mods.Common/Traits/Render/CashTricklerBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/CashTricklerBar.cs
@@ -17,14 +17,14 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Display the time remaining until the next cash is given by actor's CashTrickler trait.")]
-	class CashTricklerBarInfo : ITraitInfo, Requires<CashTricklerInfo>
+	class CashTricklerBarInfo : TraitInfo, Requires<CashTricklerInfo>
 	{
 		[Desc("Defines to which players the bar is to be shown.")]
 		public readonly Stance DisplayStances = Stance.Ally;
 
 		public readonly Color Color = Color.Magenta;
 
-		public object Create(ActorInitializer init) { return new CashTricklerBar(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new CashTricklerBar(init.Self, this); }
 	}
 
 	class CashTricklerBar : ISelectionBar

--- a/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/CustomTerrainDebugOverlay.cs
@@ -18,11 +18,11 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Displays custom terrain types.")]
-	class CustomTerrainDebugOverlayInfo : ITraitInfo
+	class CustomTerrainDebugOverlayInfo : TraitInfo
 	{
 		public readonly string Font = "TinyBold";
 
-		public object Create(ActorInitializer init) { return new CustomTerrainDebugOverlay(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new CustomTerrainDebugOverlay(init.Self, this); }
 	}
 
 	class CustomTerrainDebugOverlay : IWorldLoaded, IChatCommand, IRenderAnnotations

--- a/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
+++ b/OpenRA.Mods.Common/Traits/Render/DrawLineToTarget.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Renders target lines between order waypoints.")]
-	public class DrawLineToTargetInfo : ITraitInfo
+	public class DrawLineToTargetInfo : TraitInfo
 	{
 		[Desc("Delay (in ticks) before the target lines disappear.")]
 		public readonly int Delay = 60;
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Width (in pixels) of the queued end node markers.")]
 		public readonly int QueuedMarkerWidth = 2;
 
-		public virtual object Create(ActorInitializer init) { return new DrawLineToTarget(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new DrawLineToTarget(init.Self, this); }
 	}
 
 	public class DrawLineToTarget : IRenderAboveShroud, IRenderAnnotationsWhenSelected, INotifySelected

--- a/OpenRA.Mods.Common/Traits/Render/ReloadArmamentsBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/ReloadArmamentsBar.cs
@@ -17,14 +17,14 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Visualizes the minimum remaining time for reloading the armaments.")]
-	class ReloadArmamentsBarInfo : ITraitInfo
+	class ReloadArmamentsBarInfo : TraitInfo
 	{
 		[Desc("Armament names")]
 		public readonly string[] Armaments = { "primary", "secondary" };
 
 		public readonly Color Color = Color.Red;
 
-		public object Create(ActorInitializer init) { return new ReloadArmamentsBar(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new ReloadArmamentsBar(init.Self, this); }
 	}
 
 	class ReloadArmamentsBar : ISelectionBar, INotifyCreated

--- a/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDebugState.cs
@@ -19,11 +19,11 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Displays the actor's type and ID above the actor.")]
-	class RenderDebugStateInfo : ITraitInfo
+	class RenderDebugStateInfo : TraitInfo
 	{
 		public readonly string Font = "TinyBold";
 
-		public object Create(ActorInitializer init) { return new RenderDebugState(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new RenderDebugState(init.Self, this); }
 	}
 
 	class RenderDebugState : INotifyAddedToWorld, INotifyOwnerChanged, INotifyCreated, IRenderAnnotationsWhenSelected

--- a/OpenRA.Mods.Common/Traits/Render/RenderDetectionCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderDetectionCircle.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
 {
-	class RenderDetectionCircleInfo : ITraitInfo, Requires<DetectCloakedInfo>
+	class RenderDetectionCircleInfo : TraitInfo, Requires<DetectCloakedInfo>
 	{
 		[Desc("WAngle the Radar update line advances per tick.")]
 		public readonly WAngle UpdateLineTick = new WAngle(-1);
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Contrast color of the circle and scanner update line.")]
 		public readonly Color ContrastColor = Color.FromArgb(96, Color.Black);
 
-		public object Create(ActorInitializer init) { return new RenderDetectionCircle(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new RenderDetectionCircle(init.Self, this); }
 	}
 
 	class RenderDetectionCircle : ITick, IRenderAnnotationsWhenSelected

--- a/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderRangeCircle.cs
@@ -22,7 +22,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 	public enum RangeCircleMode { Maximum, Minimum }
 
 	[Desc("Draw a circle indicating my weapon's range.")]
-	class RenderRangeCircleInfo : ITraitInfo, IPlaceBuildingDecorationInfo, IRulesetLoaded, Requires<AttackBaseInfo>
+	class RenderRangeCircleInfo : TraitInfo, IPlaceBuildingDecorationInfo, IRulesetLoaded, Requires<AttackBaseInfo>
 	{
 		public readonly string RangeCircleType = null;
 
@@ -60,7 +60,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 			return otherRanges.Append(localRange);
 		}
 
-		public object Create(ActorInitializer init) { return new RenderRangeCircle(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new RenderRangeCircle(init.Self, this); }
 
 		public void RulesetLoaded(Ruleset rules, ActorInfo ai)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/RenderShroudCircle.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderShroudCircle.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class RenderShroudCircleInfo : ITraitInfo, IPlaceBuildingDecorationInfo
+	class RenderShroudCircleInfo : TraitInfo, IPlaceBuildingDecorationInfo
 	{
 		[Desc("Color of the circle.")]
 		public readonly Color Color = Color.FromArgb(128, Color.Cyan);
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.Common.Traits
 			return otherRangeRenderables.Append(localRangeRenderable);
 		}
 
-		public object Create(ActorInitializer init) { return new RenderShroudCircle(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new RenderShroudCircle(init.Self, this); }
 	}
 
 	class RenderShroudCircle : INotifyCreated, IRenderAnnotationsWhenSelected

--- a/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderSprites.cs
@@ -19,13 +19,13 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
 {
-	public interface IRenderActorPreviewSpritesInfo : ITraitInfo
+	public interface IRenderActorPreviewSpritesInfo : ITraitInfoInterface
 	{
 		IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p);
 	}
 
 	[Desc("Render trait fundament that won't work without additional With* render traits.")]
-	public class RenderSpritesInfo : IRenderActorPreviewInfo, ITraitInfo
+	public class RenderSpritesInfo : TraitInfo, IRenderActorPreviewInfo
 	{
 		[Desc("The sequence name that defines the actor sprites. Defaults to the actor name.")]
 		public readonly string Image = null;
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Change the sprite image size.")]
 		public readonly float Scale = 1f;
 
-		public virtual object Create(ActorInitializer init) { return new RenderSprites(init, this); }
+		public override object Create(ActorInitializer init) { return new RenderSprites(init, this); }
 
 		public IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
+++ b/OpenRA.Mods.Common/Traits/Render/RenderVoxels.cs
@@ -19,13 +19,13 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
 {
-	public interface IRenderActorPreviewVoxelsInfo : ITraitInfo
+	public interface IRenderActorPreviewVoxelsInfo : ITraitInfoInterface
 	{
 		IEnumerable<ModelAnimation> RenderPreviewVoxels(
 			ActorPreviewInitializer init, RenderVoxelsInfo rv, string image, Func<WRot> orientation, int facings, PaletteReference p);
 	}
 
-	public class RenderVoxelsInfo : ITraitInfo, IRenderActorPreviewInfo, Requires<BodyOrientationInfo>
+	public class RenderVoxelsInfo : TraitInfo, IRenderActorPreviewInfo, Requires<BodyOrientationInfo>
 	{
 		[Desc("Defaults to the actor name.")]
 		public readonly string Image = null;
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly float[] LightAmbientColor = { 0.6f, 0.6f, 0.6f };
 		public readonly float[] LightDiffuseColor = { 0.4f, 0.4f, 0.4f };
 
-		public virtual object Create(ActorInitializer init) { return new RenderVoxels(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new RenderVoxels(init.Self, this); }
 
 		public virtual IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/SelectionDecorationsBase.cs
+++ b/OpenRA.Mods.Common/Traits/Render/SelectionDecorationsBase.cs
@@ -17,11 +17,9 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
 {
-	public abstract class SelectionDecorationsBaseInfo : ITraitInfo
+	public abstract class SelectionDecorationsBaseInfo : TraitInfo
 	{
 		public readonly Color SelectionBoxColor = Color.White;
-
-		public abstract object Create(ActorInitializer init);
 	}
 
 	public abstract class SelectionDecorationsBase : ISelectionDecorations, IRenderAnnotations, INotifyCreated

--- a/OpenRA.Mods.Common/Traits/Render/TimedConditionBar.cs
+++ b/OpenRA.Mods.Common/Traits/Render/TimedConditionBar.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Visualizes the remaining time for a condition.")]
-	class TimedConditionBarInfo : ITraitInfo
+	class TimedConditionBarInfo : TraitInfo
 	{
 		[FieldLoader.Require]
 		[Desc("Condition that this bar corresponds to")]
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 
 		public readonly Color Color = Color.Red;
 
-		public object Create(ActorInitializer init) { return new TimedConditionBar(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new TimedConditionBar(init.Self, this); }
 	}
 
 	class TimedConditionBar : ISelectionBar, IConditionTimerWatcher

--- a/OpenRA.Mods.Common/Traits/Render/VeteranProductionIconOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/VeteranProductionIconOverlay.cs
@@ -18,7 +18,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 	[Desc("Attach this to the player actor. When attached, enables all actors possessing the ProducibleWithLevel ",
 		"trait to have their production queue icons render with an overlay defined in this trait. ",
 		"The icon change occurs when ProducibleWithLevel.Prerequisites are met.")]
-	public class VeteranProductionIconOverlayInfo : ITraitInfo, Requires<TechTreeInfo>
+	public class VeteranProductionIconOverlayInfo : TraitInfo, Requires<TechTreeInfo>
 	{
 		[FieldLoader.Require]
 		[Desc("Image used for the overlay.")]
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Palette to render the sprite in. Reference the world actor's PaletteFrom* traits.")]
 		public readonly string Palette = "chrome";
 
-		public object Create(ActorInitializer init) { return new VeteranProductionIconOverlay(init, this); }
+		public override object Create(ActorInitializer init) { return new VeteranProductionIconOverlay(init, this); }
 	}
 
 	public class VeteranProductionIconOverlay : ITechTreeElement, IProductionIconOverlay

--- a/OpenRA.Mods.Common/Traits/Render/WithAttackOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithAttackOverlay.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Rendered together with an attack.")]
-	public class WithAttackOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>
+	public class WithAttackOverlayInfo : TraitInfo, Requires<RenderSpritesInfo>
 	{
 		[SequenceReference]
 		[FieldLoader.Require]
@@ -35,7 +35,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Should the overlay be delayed relative to preparation or actual attack?")]
 		public readonly AttackDelayType DelayRelativeTo = AttackDelayType.Preparation;
 
-		public object Create(ActorInitializer init) { return new WithAttackOverlay(init, this); }
+		public override object Create(ActorInitializer init) { return new WithAttackOverlay(init, this); }
 	}
 
 	public class WithAttackOverlay : INotifyAttack, ITick

--- a/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithCrateBody.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Renders crates with both water and land variants.")]
-	class WithCrateBodyInfo : ITraitInfo, Requires<RenderSpritesInfo>, IRenderActorPreviewSpritesInfo
+	class WithCrateBodyInfo : TraitInfo, Requires<RenderSpritesInfo>, IRenderActorPreviewSpritesInfo
 	{
 		[Desc("Easteregg sequences to use in December.")]
 		public readonly string[] XmasImages = { };
@@ -36,7 +36,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[SequenceReference]
 		public readonly string LandSequence = null;
 
-		public object Create(ActorInitializer init) { return new WithCrateBody(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithCrateBody(init.Self, this); }
 
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{

--- a/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithDamageOverlay.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Renders an overlay when the actor is taking heavy damage.")]
-	public class WithDamageOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>
+	public class WithDamageOverlayInfo : TraitInfo, Requires<RenderSpritesInfo>
 	{
 		public readonly string Image = "smoke_m";
 
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		public readonly DamageState MinimumDamageState = DamageState.Heavy;
 		public readonly DamageState MaximumDamageState = DamageState.Dead;
 
-		public object Create(ActorInitializer init) { return new WithDamageOverlay(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithDamageOverlay(init.Self, this); }
 	}
 
 	public class WithDamageOverlay : INotifyDamage

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestAnimation.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Render
 {
-	public class WithHarvestAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<HarvesterInfo>
+	public class WithHarvestAnimationInfo : TraitInfo, Requires<WithSpriteBodyInfo>, Requires<HarvesterInfo>
 	{
 		[SequenceReference]
 		[Desc("Displayed while harvesting.")]
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Which sprite body to play the animation on.")]
 		public readonly string Body = "body";
 
-		public object Create(ActorInitializer init) { return new WithHarvestAnimation(init, this); }
+		public override object Create(ActorInitializer init) { return new WithHarvestAnimation(init, this); }
 	}
 
 	public class WithHarvestAnimation : INotifyHarvesterAction

--- a/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithHarvestOverlay.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Displays an overlay whenever resources are harvested by the actor.")]
-	class WithHarvestOverlayInfo : ITraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
+	class WithHarvestOverlayInfo : TraitInfo, Requires<RenderSpritesInfo>, Requires<BodyOrientationInfo>
 	{
 		[SequenceReference]
 		[Desc("Sequence name to use")]
@@ -28,7 +28,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[PaletteReference]
 		public readonly string Palette = "effect";
 
-		public object Create(ActorInitializer init) { return new WithHarvestOverlay(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithHarvestOverlay(init.Self, this); }
 	}
 
 	class WithHarvestOverlay : INotifyHarvesterAction

--- a/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithMakeAnimation.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Replaces the sprite during construction/deploy/undeploy.")]
-	public class WithMakeAnimationInfo : ITraitInfo, Requires<WithSpriteBodyInfo>
+	public class WithMakeAnimationInfo : TraitInfo, Requires<WithSpriteBodyInfo>
 	{
 		[SequenceReference]
 		[Desc("Sequence name to use.")]
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Apply to sprite bodies with these names.")]
 		public readonly string[] BodyNames = { "body" };
 
-		public object Create(ActorInitializer init) { return new WithMakeAnimation(init, this); }
+		public override object Create(ActorInitializer init) { return new WithMakeAnimation(init, this); }
 	}
 
 	public class WithMakeAnimation : INotifyCreated, INotifyDeployTriggered

--- a/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithSpriteControlGroupDecoration.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Renders Ctrl groups using pixel art.")]
-	public class WithSpriteControlGroupDecorationInfo : ITraitInfo
+	public class WithSpriteControlGroupDecorationInfo : TraitInfo
 	{
 		[PaletteReference]
 		public readonly string Palette = "chrome";
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 		[Desc("Offset sprite center position from the selection box edge.")]
 		public readonly int2 Margin = int2.Zero;
 
-		public object Create(ActorInitializer init) { return new WithSpriteControlGroupDecoration(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithSpriteControlGroupDecoration(init.Self, this); }
 	}
 
 	public class WithSpriteControlGroupDecoration : IDecoration

--- a/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
+++ b/OpenRA.Mods.Common/Traits/Render/WithTextControlGroupDecoration.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Render
 {
 	[Desc("Renders Ctrl groups using typeface.")]
-	public class WithTextControlGroupDecorationInfo : ITraitInfo, IRulesetLoaded
+	public class WithTextControlGroupDecorationInfo : TraitInfo, IRulesetLoaded
 	{
 		public readonly string Font = "TinyBold";
 
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits.Render
 				throw new YamlException("Font '{0}' is not listed in the mod.yaml's Fonts section".F(Font));
 		}
 
-		public object Create(ActorInitializer init) { return new WithTextControlGroupDecoration(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new WithTextControlGroupDecoration(init.Self, this); }
 	}
 
 	public class WithTextControlGroupDecoration : IDecoration, INotifyOwnerChanged

--- a/OpenRA.Mods.Common/Traits/Repairable.cs
+++ b/OpenRA.Mods.Common/Traits/Repairable.cs
@@ -21,7 +21,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor can be sent to a structure for repairs.")]
-	public class RepairableInfo : ITraitInfo, Requires<IHealthInfo>, Requires<IMoveInfo>, IObservesVariablesInfo
+	public class RepairableInfo : TraitInfo, Requires<IHealthInfo>, Requires<IMoveInfo>, IObservesVariablesInfo
 	{
 		[ActorReference]
 		[FieldLoader.Require]
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Boolean expression defining the condition under which the regular (non-force) enter cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;
 
-		public virtual object Create(ActorInitializer init) { return new Repairable(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new Repairable(init.Self, this); }
 	}
 
 	public class Repairable : IIssueOrder, IResolveOrder, IOrderVoice, INotifyCreated, IObservesVariables

--- a/OpenRA.Mods.Common/Traits/RepairableNear.cs
+++ b/OpenRA.Mods.Common/Traits/RepairableNear.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class RepairableNearInfo : ITraitInfo, Requires<IHealthInfo>, Requires<IMoveInfo>, IObservesVariablesInfo
+	class RepairableNearInfo : TraitInfo, Requires<IHealthInfo>, Requires<IMoveInfo>, IObservesVariablesInfo
 	{
 		[ActorReference]
 		[FieldLoader.Require]
@@ -34,7 +34,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Boolean expression defining the condition under which the regular (non-force) enter cursor is disabled.")]
 		public readonly BooleanExpression RequireForceMoveCondition = null;
 
-		public object Create(ActorInitializer init) { return new RepairableNear(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new RepairableNear(init.Self, this); }
 	}
 
 	class RepairableNear : IIssueOrder, IResolveOrder, IOrderVoice, IObservesVariables

--- a/OpenRA.Mods.Common/Traits/RepairsBridges.cs
+++ b/OpenRA.Mods.Common/Traits/RepairsBridges.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Can enter a BridgeHut or LegacyBridgeHut to trigger a repair.")]
-	class RepairsBridgesInfo : ITraitInfo
+	class RepairsBridgesInfo : TraitInfo
 	{
 		[VoiceReference]
 		public readonly string Voice = "Action";
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speech notification to play when a bridge is repaired.")]
 		public readonly string RepairNotification = null;
 
-		public object Create(ActorInitializer init) { return new RepairsBridges(this); }
+		public override object Create(ActorInitializer init) { return new RepairsBridges(this); }
 	}
 
 	class RepairsBridges : IIssueOrder, IResolveOrder, IOrderVoice

--- a/OpenRA.Mods.Common/Traits/Replaceable.cs
+++ b/OpenRA.Mods.Common/Traits/Replaceable.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class ReplaceableInfo : ConditionalTraitInfo, ITraitInfo
+	public class ReplaceableInfo : ConditionalTraitInfo
 	{
 		[FieldLoader.Require]
 		[Desc("Replacement types this Relpaceable actor accepts.")]

--- a/OpenRA.Mods.Common/Traits/ScriptTags.cs
+++ b/OpenRA.Mods.Common/Traits/ScriptTags.cs
@@ -15,9 +15,9 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Allows this actor to be 'tagged' with arbitrary strings. Tags must be unique or they will be rejected.")]
-	public class ScriptTagsInfo : ITraitInfo
+	public class ScriptTagsInfo : TraitInfo
 	{
-		object ITraitInfo.Create(ActorInitializer init) { return new ScriptTags(init, this); }
+		public override object Create(ActorInitializer init) { return new ScriptTags(init, this); }
 	}
 
 	public class ScriptTags

--- a/OpenRA.Mods.Common/Traits/ShakeOnDeath.cs
+++ b/OpenRA.Mods.Common/Traits/ShakeOnDeath.cs
@@ -13,11 +13,11 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class ShakeOnDeathInfo : ITraitInfo
+	public class ShakeOnDeathInfo : TraitInfo
 	{
 		public readonly int Duration = 10;
 		public readonly int Intensity = 1;
-		public object Create(ActorInitializer init) { return new ShakeOnDeath(this); }
+		public override object Create(ActorInitializer init) { return new ShakeOnDeath(this); }
 	}
 
 	public class ShakeOnDeath : INotifyKilled

--- a/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
+++ b/OpenRA.Mods.Common/Traits/SmokeTrailWhenDamaged.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class SmokeTrailWhenDamagedInfo : ITraitInfo, Requires<BodyOrientationInfo>
+	class SmokeTrailWhenDamagedInfo : TraitInfo, Requires<BodyOrientationInfo>
 	{
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
@@ -32,7 +32,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly DamageState MinDamage = DamageState.Heavy;
 
-		public object Create(ActorInitializer init) { return new SmokeTrailWhenDamaged(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new SmokeTrailWhenDamaged(init.Self, this); }
 	}
 
 	class SmokeTrailWhenDamaged : ITick

--- a/OpenRA.Mods.Common/Traits/Sound/ActorLostNotification.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/ActorLostNotification.cs
@@ -13,14 +13,14 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Sound
 {
-	class ActorLostNotificationInfo : ITraitInfo
+	class ActorLostNotificationInfo : TraitInfo
 	{
 		[NotificationReference("Speech")]
 		public readonly string Notification = "UnitLost";
 
 		public readonly bool NotifyAll = false;
 
-		public object Create(ActorInitializer init) { return new ActorLostNotification(this); }
+		public override object Create(ActorInitializer init) { return new ActorLostNotification(this); }
 	}
 
 	class ActorLostNotification : INotifyKilled

--- a/OpenRA.Mods.Common/Traits/Sound/AnnounceOnKill.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AnnounceOnKill.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits.Sound
 {
 	[Desc("Play the Kill voice of this actor when eliminating enemies.")]
-	public class AnnounceOnKillInfo : ITraitInfo
+	public class AnnounceOnKillInfo : TraitInfo
 	{
 		[Desc("Minimum duration (in seconds) between sound events.")]
 		public readonly int Interval = 5;
@@ -23,7 +23,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		[Desc("Voice to use when killing something.")]
 		public readonly string Voice = "Kill";
 
-		public object Create(ActorInitializer init) { return new AnnounceOnKill(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new AnnounceOnKill(init.Self, this); }
 	}
 
 	public class AnnounceOnKill : INotifyAppliedDamage

--- a/OpenRA.Mods.Common/Traits/Sound/AnnounceOnSeen.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/AnnounceOnSeen.cs
@@ -17,7 +17,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 {
 	[Desc("Players will be notified when this actor becomes visible to them.",
 		"Requires the 'EnemyWatcher' trait on the player actor.")]
-	public class AnnounceOnSeenInfo : ITraitInfo
+	public class AnnounceOnSeenInfo : TraitInfo
 	{
 		[Desc("Should there be a radar ping on enemies' radar at the actor's location when they see him")]
 		public readonly bool PingRadar = false;
@@ -27,7 +27,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 
 		public readonly bool AnnounceNeutrals = false;
 
-		public object Create(ActorInitializer init) { return new AnnounceOnSeen(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new AnnounceOnSeen(init.Self, this); }
 	}
 
 	public class AnnounceOnSeen : INotifyDiscovered

--- a/OpenRA.Mods.Common/Traits/Sound/CaptureNotification.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/CaptureNotification.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Sound
 {
-	public class CaptureNotificationInfo : ITraitInfo
+	public class CaptureNotificationInfo : TraitInfo
 	{
 		[NotificationReference("Speech")]
 		[Desc("The speech notification to play to the new owner.")]
@@ -30,7 +30,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		[Desc("Specifies if LoseNotification is played with the voice of the new owners faction.")]
 		public readonly bool LoseNewOwnerVoice = false;
 
-		public object Create(ActorInitializer init) { return new CaptureNotification(this); }
+		public override object Create(ActorInitializer init) { return new CaptureNotification(this); }
 	}
 
 	public class CaptureNotification : INotifyCapture

--- a/OpenRA.Mods.Common/Traits/Sound/SoundOnDamageTransition.cs
+++ b/OpenRA.Mods.Common/Traits/Sound/SoundOnDamageTransition.cs
@@ -13,7 +13,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits.Sound
 {
-	public class SoundOnDamageTransitionInfo : ITraitInfo
+	public class SoundOnDamageTransitionInfo : TraitInfo
 	{
 		[Desc("Play a random sound from this list when damaged.")]
 		public readonly string[] DamagedSounds = { };
@@ -21,7 +21,7 @@ namespace OpenRA.Mods.Common.Traits.Sound
 		[Desc("Play a random sound from this list when destroyed.")]
 		public readonly string[] DestroyedSounds = { };
 
-		public object Create(ActorInitializer init) { return new SoundOnDamageTransition(this); }
+		public override object Create(ActorInitializer init) { return new SoundOnDamageTransition(this); }
 	}
 
 	public class SoundOnDamageTransition : INotifyDamageStateChanged

--- a/OpenRA.Mods.Common/Traits/StoresResources.cs
+++ b/OpenRA.Mods.Common/Traits/StoresResources.cs
@@ -17,12 +17,12 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Adds capacity to a player's harvested resource limit.")]
-	public class StoresResourcesInfo : ITraitInfo
+	public class StoresResourcesInfo : TraitInfo
 	{
 		[FieldLoader.Require]
 		public readonly int Capacity = 0;
 
-		public object Create(ActorInitializer init) { return new StoresResources(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new StoresResources(init.Self, this); }
 	}
 
 	public class StoresResources : INotifyOwnerChanged, INotifyCapture, IStoreResources, ISync, INotifyKilled, INotifyAddedToWorld, INotifyRemovedFromWorld

--- a/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
+++ b/OpenRA.Mods.Common/Traits/SupportPowers/SupportPowerManager.cs
@@ -19,9 +19,9 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Attach this to the player actor.")]
-	public class SupportPowerManagerInfo : ITraitInfo, Requires<DeveloperModeInfo>, Requires<TechTreeInfo>
+	public class SupportPowerManagerInfo : TraitInfo, Requires<DeveloperModeInfo>, Requires<TechTreeInfo>
 	{
-		public object Create(ActorInitializer init) { return new SupportPowerManager(init); }
+		public override object Create(ActorInitializer init) { return new SupportPowerManager(init); }
 	}
 
 	public class SupportPowerManager : ITick, IResolveOrder, ITechTreeElement

--- a/OpenRA.Mods.Common/Traits/TemporaryOwnerManager.cs
+++ b/OpenRA.Mods.Common/Traits/TemporaryOwnerManager.cs
@@ -16,11 +16,11 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Interacts with the ChangeOwner warhead.",
 		"Displays a bar how long this actor is affected and reverts back to the old owner on temporary changes.")]
-	public class TemporaryOwnerManagerInfo : ITraitInfo
+	public class TemporaryOwnerManagerInfo : TraitInfo
 	{
 		public readonly Color BarColor = Color.Orange;
 
-		public object Create(ActorInitializer init) { return new TemporaryOwnerManager(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new TemporaryOwnerManager(init.Self, this); }
 	}
 
 	public class TemporaryOwnerManager : ISelectionBar, ITick, ISync, INotifyOwnerChanged

--- a/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
+++ b/OpenRA.Mods.Common/Traits/ThrowsParticle.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class ThrowsParticleInfo : ITraitInfo, Requires<WithSpriteBodyInfo>, Requires<BodyOrientationInfo>
+	class ThrowsParticleInfo : TraitInfo, Requires<WithSpriteBodyInfo>, Requires<BodyOrientationInfo>
 	{
 		[FieldLoader.Require]
 		public readonly string Anim = null;
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Speed at which the particle turns.")]
 		public readonly int TurnSpeed = 15;
 
-		public object Create(ActorInitializer init) { return new ThrowsParticle(init, this); }
+		public override object Create(ActorInitializer init) { return new ThrowsParticle(init, this); }
 	}
 
 	class ThrowsParticle : ITick

--- a/OpenRA.Mods.Common/Traits/TransformCrusherOnCrush.cs
+++ b/OpenRA.Mods.Common/Traits/TransformCrusherOnCrush.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Put this on the actor that gets crushed to replace the crusher with a new actor.")]
-	public class TransformCrusherOnCrushInfo : ITraitInfo
+	public class TransformCrusherOnCrushInfo : TraitInfo
 	{
 		[ActorReference]
 		[FieldLoader.Require]
@@ -26,7 +26,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public readonly BitSet<CrushClass> CrushClasses = default(BitSet<CrushClass>);
 
-		public virtual object Create(ActorInitializer init) { return new TransformCrusherOnCrush(init, this); }
+		public override object Create(ActorInitializer init) { return new TransformCrusherOnCrush(init, this); }
 	}
 
 	public class TransformCrusherOnCrush : INotifyCrushed

--- a/OpenRA.Mods.Common/Traits/TransformOnCapture.cs
+++ b/OpenRA.Mods.Common/Traits/TransformOnCapture.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Replaces the captured actor with a new one.")]
-	public class TransformOnCaptureInfo : ITraitInfo
+	public class TransformOnCaptureInfo : TraitInfo
 	{
 		[ActorReference]
 		[FieldLoader.Require]
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Transform only if the capturer's CaptureTypes overlap with these types. Leave empty to allow all types.")]
 		public readonly BitSet<CaptureType> CaptureTypes = default(BitSet<CaptureType>);
 
-		public virtual object Create(ActorInitializer init) { return new TransformOnCapture(init, this); }
+		public override object Create(ActorInitializer init) { return new TransformOnCapture(init, this); }
 	}
 
 	public class TransformOnCapture : INotifyCapture

--- a/OpenRA.Mods.Common/Traits/TunnelEntrance.cs
+++ b/OpenRA.Mods.Common/Traits/TunnelEntrance.cs
@@ -16,7 +16,7 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Provides a target for players to issue orders for units to move through a TerrainTunnel.",
 		"The host actor should be placed so that the Sensor position overlaps one of the TerrainTunnel portal cells.")]
-	public class TunnelEntranceInfo : ITraitInfo
+	public class TunnelEntranceInfo : TraitInfo
 	{
 		[FieldLoader.Require]
 		[Desc("Offset to use as a staging point for actors entering or exiting the tunnel.",
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Offset to check for the corresponding TerrainTunnel portal cell(s).")]
 		public readonly CVec Sensor = CVec.Zero;
 
-		public object Create(ActorInitializer init) { return new TunnelEntrance(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new TunnelEntrance(init.Self, this); }
 	}
 
 	public class TunnelEntrance : INotifyCreated

--- a/OpenRA.Mods.Common/Traits/Voiced.cs
+++ b/OpenRA.Mods.Common/Traits/Voiced.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("This actor has a voice.")]
-	public class VoicedInfo : ITraitInfo
+	public class VoicedInfo : TraitInfo
 	{
 		[VoiceSetReference]
 		[FieldLoader.Require]
@@ -24,7 +24,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Multiply volume with this factor.")]
 		public readonly float Volume = 1f;
 
-		public object Create(ActorInitializer init) { return new Voiced(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new Voiced(init.Self, this); }
 	}
 
 	public class Voiced : IVoiced

--- a/OpenRA.Mods.Common/Traits/World/ActorMap.cs
+++ b/OpenRA.Mods.Common/Traits/World/ActorMap.cs
@@ -18,12 +18,12 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class ActorMapInfo : ITraitInfo
+	public class ActorMapInfo : TraitInfo
 	{
 		[Desc("Size of partition bins (cells)")]
 		public readonly int BinSize = 10;
 
-		public object Create(ActorInitializer init) { return new ActorMap(init.World, this); }
+		public override object Create(ActorInitializer init) { return new ActorMap(init.World, this); }
 	}
 
 	public class ActorMap : IActorMap, ITick, INotifyCreated

--- a/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/BridgeLayer.cs
@@ -25,9 +25,9 @@ namespace OpenRA.Mods.Common.Traits
 		CPos Location { get; }
 	}
 
-	class BridgeLayerInfo : ITraitInfo
+	class BridgeLayerInfo : TraitInfo
 	{
-		public object Create(ActorInitializer init) { return new BridgeLayer(init.World); }
+		public override object Create(ActorInitializer init) { return new BridgeLayer(init.World); }
 	}
 
 	class BridgeLayer

--- a/OpenRA.Mods.Common/Traits/World/CliffBackImpassabilityLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/CliffBackImpassabilityLayer.cs
@@ -17,11 +17,11 @@ namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Sets a custom terrain type for cells that are obscured by back-facing cliffs.",
 		"This trait replicates the default CliffBackImpassability=2 behaviour from the TS/RA2 rules.ini.")]
-	class CliffBackImpassabilityLayerInfo : ITraitInfo
+	class CliffBackImpassabilityLayerInfo : TraitInfo
 	{
 		public readonly string TerrainType = "Impassable";
 
-		public object Create(ActorInitializer init) { return new CliffBackImpassabilityLayer(this); }
+		public override object Create(ActorInitializer init) { return new CliffBackImpassabilityLayer(this); }
 	}
 
 	class CliffBackImpassabilityLayer : IWorldLoaded

--- a/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
+++ b/OpenRA.Mods.Common/Traits/World/CrateSpawner.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class CrateSpawnerInfo : ITraitInfo, ILobbyOptions
+	public class CrateSpawnerInfo : TraitInfo, ILobbyOptions
 	{
 		[Translate]
 		[Desc("Descriptive label for the crates checkbox in the lobby.")]
@@ -83,7 +83,7 @@ namespace OpenRA.Mods.Common.Traits
 			yield return new LobbyBooleanOption("crates", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
 		}
 
-		public object Create(ActorInitializer init) { return new CrateSpawner(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new CrateSpawner(init.Self, this); }
 	}
 
 	public class CrateSpawner : ITick, INotifyCreated

--- a/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorActorLayer.cs
@@ -20,12 +20,12 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Required for the map editor to work. Attach this to the world actor.")]
-	public class EditorActorLayerInfo : ITraitInfo
+	public class EditorActorLayerInfo : TraitInfo
 	{
 		[Desc("Size of partition bins (world pixels)")]
 		public readonly int BinSize = 250;
 
-		public object Create(ActorInitializer init) { return new EditorActorLayer(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new EditorActorLayer(init.Self, this); }
 	}
 
 	public class EditorActorLayer : IWorldLoaded, ITickRender, IRender, IRadarSignature, ICreatePlayers, IRenderAnnotations

--- a/OpenRA.Mods.Common/Traits/World/EditorCursorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorCursorLayer.cs
@@ -19,11 +19,11 @@ namespace OpenRA.Mods.Common.Traits
 	public enum EditorCursorType { None, Actor, TerrainTemplate, Resource }
 
 	[Desc("Required for the map editor to work. Attach this to the world actor.")]
-	public class EditorCursorLayerInfo : ITraitInfo, Requires<EditorActorLayerInfo>
+	public class EditorCursorLayerInfo : TraitInfo, Requires<EditorActorLayerInfo>
 	{
 		public readonly int PreviewFacing = 96;
 
-		public object Create(ActorInitializer init) { return new EditorCursorLayer(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new EditorCursorLayer(init.Self, this); }
 	}
 
 	public class EditorCursorLayer : ITickRender, IRenderAboveShroud, IRenderAnnotations

--- a/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorResourceLayer.cs
@@ -21,9 +21,9 @@ namespace OpenRA.Mods.Common.Traits
 	using CellContents = ResourceLayer.CellContents;
 
 	[Desc("Required for the map editor to work. Attach this to the world actor.")]
-	public class EditorResourceLayerInfo : ITraitInfo, Requires<ResourceTypeInfo>
+	public class EditorResourceLayerInfo : TraitInfo, Requires<ResourceTypeInfo>
 	{
-		public virtual object Create(ActorInitializer init) { return new EditorResourceLayer(init.Self); }
+		public override object Create(ActorInitializer init) { return new EditorResourceLayer(init.Self); }
 	}
 
 	public class EditorResourceLayer : IWorldLoaded, IRenderOverlay, INotifyActorDisposing

--- a/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/EditorSelectionLayer.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Required for the map editor to work. Attach this to the world actor.")]
-	public class EditorSelectionLayerInfo : ITraitInfo
+	public class EditorSelectionLayerInfo : TraitInfo
 	{
 		[PaletteReference]
 		[Desc("Palette to use for rendering the placement sprite.")]
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Sequence to use for the paste overlay.")]
 		public readonly string PasteSequence = "paste";
 
-		public virtual object Create(ActorInitializer init) { return new EditorSelectionLayer(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new EditorSelectionLayer(init.Self, this); }
 	}
 
 	public class EditorSelectionLayer : IWorldLoaded, IRenderAboveShroud

--- a/OpenRA.Mods.Common/Traits/World/ElevatedBridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ElevatedBridgeLayer.cs
@@ -15,12 +15,12 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class ElevatedBridgeLayerInfo : ITraitInfo, Requires<DomainIndexInfo>, ILobbyCustomRulesIgnore
+	public class ElevatedBridgeLayerInfo : TraitInfo, Requires<DomainIndexInfo>, ILobbyCustomRulesIgnore
 	{
 		[Desc("Terrain type used by cells outside any elevated bridge footprint.")]
 		public readonly string ImpassableTerrainType = "Impassable";
 
-		public object Create(ActorInitializer init) { return new ElevatedBridgeLayer(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new ElevatedBridgeLayer(init.Self, this); }
 	}
 
 	// For now this is mostly copies TerrainTunnelLayer. This will change once bridge destruction is implemented

--- a/OpenRA.Mods.Common/Traits/World/ExitsDebugOverlayManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/ExitsDebugOverlayManager.cs
@@ -15,12 +15,12 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class ExitsDebugOverlayManagerInfo : ITraitInfo
+	public class ExitsDebugOverlayManagerInfo : TraitInfo
 	{
 		[Desc("The font used to draw cell vectors. Should match the value as-is in the Fonts section of the mod manifest (do not convert to lowercase).")]
 		public readonly string Font = "TinyBold";
 
-		object ITraitInfo.Create(ActorInitializer init) { return new ExitsDebugOverlayManager(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new ExitsDebugOverlayManager(init.Self, this); }
 	}
 
 	public class ExitsDebugOverlayManager : IWorldLoaded, IChatCommand

--- a/OpenRA.Mods.Common/Traits/World/GameSaveViewportManager.cs
+++ b/OpenRA.Mods.Common/Traits/World/GameSaveViewportManager.cs
@@ -16,9 +16,9 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class GameSaveViewportManagerInfo : ITraitInfo
+	public class GameSaveViewportManagerInfo : TraitInfo
 	{
-		public object Create(ActorInitializer init) { return new GameSaveViewportManager(); }
+		public override object Create(ActorInitializer init) { return new GameSaveViewportManager(); }
 	}
 
 	public class GameSaveViewportManager : IWorldLoaded, IGameSaveTraitData

--- a/OpenRA.Mods.Common/Traits/World/JumpjetActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/JumpjetActorLayer.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class JumpjetActorLayerInfo : ITraitInfo
+	public class JumpjetActorLayerInfo : TraitInfo
 	{
 		[Desc("Terrain type of the airborne layer.")]
 		public readonly string TerrainType = "Jumpjet";
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Cell radius for smoothing adjacent cell heights.")]
 		public readonly int SmoothingRadius = 2;
 
-		public object Create(ActorInitializer init) { return new JumpjetActorLayer(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new JumpjetActorLayer(init.Self, this); }
 	}
 
 	public class JumpjetActorLayer : ICustomMovementLayer

--- a/OpenRA.Mods.Common/Traits/World/LegacyBridgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/LegacyBridgeLayer.cs
@@ -17,12 +17,12 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class LegacyBridgeLayerInfo : ITraitInfo
+	class LegacyBridgeLayerInfo : TraitInfo
 	{
 		[ActorReference]
 		public readonly string[] Bridges = { "bridge1", "bridge2" };
 
-		public object Create(ActorInitializer init) { return new LegacyBridgeLayer(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new LegacyBridgeLayer(init.Self, this); }
 	}
 
 	class LegacyBridgeLayer : IWorldLoaded

--- a/OpenRA.Mods.Common/Traits/World/LoadWidgetAtGameStart.cs
+++ b/OpenRA.Mods.Common/Traits/World/LoadWidgetAtGameStart.cs
@@ -16,7 +16,7 @@ using OpenRA.Widgets;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class LoadWidgetAtGameStartInfo : ITraitInfo
+	public class LoadWidgetAtGameStartInfo : TraitInfo
 	{
 		[Desc("The widget tree to open when a shellmap is loaded (i.e. the main menu).")]
 		public readonly string ShellmapRoot = "MAINMENU";
@@ -33,7 +33,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Remove any existing UI when a map is loaded.")]
 		public readonly bool ClearRoot = true;
 
-		public object Create(ActorInitializer init) { return new LoadWidgetAtGameStart(this); }
+		public override object Create(ActorInitializer init) { return new LoadWidgetAtGameStart(this); }
 	}
 
 	public class LoadWidgetAtGameStart : IWorldLoaded, INotifyGameLoading, INotifyGameLoaded

--- a/OpenRA.Mods.Common/Traits/World/LobbyPrerequisiteCheckbox.cs
+++ b/OpenRA.Mods.Common/Traits/World/LobbyPrerequisiteCheckbox.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Enables defined prerequisites at game start for all players if the checkbox is enabled.")]
-	public class LobbyPrerequisiteCheckboxInfo : ITraitInfo, ILobbyOptions, ITechTreePrerequisiteInfo
+	public class LobbyPrerequisiteCheckboxInfo : TraitInfo, ILobbyOptions, ITechTreePrerequisiteInfo
 	{
 		[FieldLoader.Require]
 		[Desc("Internal id for this checkbox.")]
@@ -52,7 +52,7 @@ namespace OpenRA.Mods.Common.Traits
 				Visible, DisplayOrder, Enabled, Locked);
 		}
 
-		public object Create(ActorInitializer init) { return new LobbyPrerequisiteCheckbox(this); }
+		public override object Create(ActorInitializer init) { return new LobbyPrerequisiteCheckbox(this); }
 	}
 
 	public class LobbyPrerequisiteCheckbox : INotifyCreated, ITechTreePrerequisite

--- a/OpenRA.Mods.Common/Traits/World/Locomotor.cs
+++ b/OpenRA.Mods.Common/Traits/World/Locomotor.cs
@@ -55,7 +55,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[Desc("Used by Mobile. Attach these to the world actor. You can have multiple variants by adding @suffixes.")]
-	public class LocomotorInfo : ITraitInfo
+	public class LocomotorInfo : TraitInfo
 	{
 		[Desc("Locomotor ID.")]
 		public readonly string Name = "default";
@@ -184,7 +184,7 @@ namespace OpenRA.Mods.Common.Traits
 
 		public virtual bool DisableDomainPassabilityCheck { get { return false; } }
 
-		public virtual object Create(ActorInitializer init) { return new Locomotor(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new Locomotor(init.Self, this); }
 	}
 
 	public class Locomotor : IWorldLoaded

--- a/OpenRA.Mods.Common/Traits/World/MPStartLocations.cs
+++ b/OpenRA.Mods.Common/Traits/World/MPStartLocations.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Allows the map to have working spawnpoints. Also controls the 'Separate Team Spawns' checkbox in the lobby options.")]
-	public class MPStartLocationsInfo : ITraitInfo, ILobbyOptions
+	public class MPStartLocationsInfo : TraitInfo, ILobbyOptions
 	{
 		public readonly WDist InitialExploreRange = WDist.FromCells(5);
 
@@ -43,7 +43,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Display order for the spawn positions checkbox in the lobby.")]
 		public readonly int SeparateTeamSpawnsCheckboxDisplayOrder = 0;
 
-		public virtual object Create(ActorInitializer init) { return new MPStartLocations(this); }
+		public override object Create(ActorInitializer init) { return new MPStartLocations(this); }
 
 		IEnumerable<LobbyOption> ILobbyOptions.LobbyOptions(Ruleset rules)
 		{

--- a/OpenRA.Mods.Common/Traits/World/MapBuildRadius.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapBuildRadius.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Controls the build radius checkboxes in the lobby options.")]
-	public class MapBuildRadiusInfo : ITraitInfo, ILobbyOptions
+	public class MapBuildRadiusInfo : TraitInfo, ILobbyOptions
 	{
 		[Translate]
 		[Desc("Descriptive label for the ally build radius checkbox in the lobby.")]
@@ -66,7 +66,7 @@ namespace OpenRA.Mods.Common.Traits
 				BuildRadiusCheckboxVisible, BuildRadiusCheckboxDisplayOrder, BuildRadiusCheckboxEnabled, BuildRadiusCheckboxLocked);
 		}
 
-		public object Create(ActorInitializer init) { return new MapBuildRadius(this); }
+		public override object Create(ActorInitializer init) { return new MapBuildRadius(this); }
 	}
 
 	public class MapBuildRadius : INotifyCreated

--- a/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapCreeps.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Controls the 'Creeps' checkbox in the lobby options.")]
-	public class MapCreepsInfo : ITraitInfo, ILobbyOptions
+	public class MapCreepsInfo : TraitInfo, ILobbyOptions
 	{
 		[Translate]
 		[Desc("Descriptive label for the creeps checkbox in the lobby.")]
@@ -42,7 +42,7 @@ namespace OpenRA.Mods.Common.Traits
 			yield return new LobbyBooleanOption("creeps", CheckboxLabel, CheckboxDescription, CheckboxVisible, CheckboxDisplayOrder, CheckboxEnabled, CheckboxLocked);
 		}
 
-		public object Create(ActorInitializer init) { return new MapCreeps(this); }
+		public override object Create(ActorInitializer init) { return new MapCreeps(this); }
 	}
 
 	public class MapCreeps : INotifyCreated

--- a/OpenRA.Mods.Common/Traits/World/MapOptions.cs
+++ b/OpenRA.Mods.Common/Traits/World/MapOptions.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Controls the game speed, tech level, and short game lobby options.")]
-	public class MapOptionsInfo : ITraitInfo, ILobbyOptions, IRulesetLoaded
+	public class MapOptionsInfo : TraitInfo, ILobbyOptions, IRulesetLoaded
 	{
 		[Translate]
 		[Desc("Descriptive label for the short game checkbox in the lobby.")]
@@ -105,7 +105,7 @@ namespace OpenRA.Mods.Common.Traits
 				throw new YamlException("Invalid default game speed '{0}'.".F(GameSpeed));
 		}
 
-		public object Create(ActorInitializer init) { return new MapOptions(this); }
+		public override object Create(ActorInitializer init) { return new MapOptions(this); }
 	}
 
 	public class MapOptions : INotifyCreated

--- a/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
+++ b/OpenRA.Mods.Common/Traits/World/MusicPlaylist.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Trait for music handling. Attach this to the world actor.")]
-	public class MusicPlaylistInfo : ITraitInfo
+	public class MusicPlaylistInfo : TraitInfo
 	{
 		[Desc("Music to play when the map starts.", "Plays the first song on the playlist when undefined.")]
 		public readonly string StartingMusic = null;
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Disable all world sounds (combat etc).")]
 		public readonly bool DisableWorldSounds = false;
 
-		public object Create(ActorInitializer init) { return new MusicPlaylist(init.World, this); }
+		public override object Create(ActorInitializer init) { return new MusicPlaylist(init.World, this); }
 	}
 
 	public class MusicPlaylist : INotifyActorDisposing, IGameOver, IWorldLoaded, INotifyGameLoaded

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromEmbeddedSpritePalette.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromEmbeddedSpritePalette.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class PaletteFromEmbeddedSpritePaletteInfo : ITraitInfo, IProvidesCursorPaletteInfo
+	public class PaletteFromEmbeddedSpritePaletteInfo : TraitInfo, IProvidesCursorPaletteInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Whether this palette is available for cursors.")]
 		public readonly bool CursorPalette = false;
 
-		public object Create(ActorInitializer init) { return new PaletteFromEmbeddedSpritePalette(this); }
+		public override object Create(ActorInitializer init) { return new PaletteFromEmbeddedSpritePalette(this); }
 
 		string IProvidesCursorPaletteInfo.Palette { get { return CursorPalette ? Name : null; } }
 

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromFile.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromFile.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Load VGA palette (.pal) registers.")]
-	class PaletteFromFileInfo : ITraitInfo, IProvidesCursorPaletteInfo
+	class PaletteFromFileInfo : TraitInfo, IProvidesCursorPaletteInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Whether this palette is available for cursors.")]
 		public readonly bool CursorPalette = false;
 
-		public object Create(ActorInitializer init) { return new PaletteFromFile(init.World, this); }
+		public override object Create(ActorInitializer init) { return new PaletteFromFile(init.World, this); }
 
 		string IProvidesCursorPaletteInfo.Palette { get { return CursorPalette ? Name : null; } }
 

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromGimpOrJascFile.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromGimpOrJascFile.cs
@@ -20,7 +20,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Load a GIMP .gpl or JASC .pal palette file. Supports per-color alpha.")]
-	class PaletteFromGimpOrJascFileInfo : ITraitInfo, IProvidesCursorPaletteInfo
+	class PaletteFromGimpOrJascFileInfo : TraitInfo, IProvidesCursorPaletteInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -49,7 +49,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Whether this palette is available for cursors.")]
 		public readonly bool CursorPalette = false;
 
-		public object Create(ActorInitializer init) { return new PaletteFromGimpOrJascFile(init.World, this); }
+		public override object Create(ActorInitializer init) { return new PaletteFromGimpOrJascFile(init.World, this); }
 
 		string IProvidesCursorPaletteInfo.Palette { get { return CursorPalette ? Name : null; } }
 

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromPaletteWithAlpha.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromPaletteWithAlpha.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Create a palette by applying alpha transparency to another palette.")]
-	class PaletteFromPaletteWithAlphaInfo : ITraitInfo
+	class PaletteFromPaletteWithAlphaInfo : TraitInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -38,7 +38,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Premultiply color by the alpha component.")]
 		public readonly bool Premultiply = true;
 
-		public object Create(ActorInitializer init) { return new PaletteFromPaletteWithAlpha(this); }
+		public override object Create(ActorInitializer init) { return new PaletteFromPaletteWithAlpha(this); }
 	}
 
 	class PaletteFromPaletteWithAlpha : ILoadsPalettes, IProvidesAssetBrowserPalettes

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromPlayerPaletteWithAlpha.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromPlayerPaletteWithAlpha.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Create player palettes by applying alpha transparency to another player palette.")]
-	class PaletteFromPlayerPaletteWithAlphaInfo : ITraitInfo
+	class PaletteFromPlayerPaletteWithAlphaInfo : TraitInfo
 	{
 		[FieldLoader.Require]
 		[PaletteDefinition(true)]
@@ -37,7 +37,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Premultiply color by the alpha component.")]
 		public readonly bool Premultiply = true;
 
-		public object Create(ActorInitializer init) { return new PaletteFromPlayerPaletteWithAlpha(this); }
+		public override object Create(ActorInitializer init) { return new PaletteFromPlayerPaletteWithAlpha(this); }
 	}
 
 	class PaletteFromPlayerPaletteWithAlpha : ILoadsPlayerPalettes

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromPng.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromPng.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Load a PNG and use its embedded palette.")]
-	class PaletteFromPngInfo : ITraitInfo, IProvidesCursorPaletteInfo
+	class PaletteFromPngInfo : TraitInfo, IProvidesCursorPaletteInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -41,7 +41,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Whether this palette is available for cursors.")]
 		public readonly bool CursorPalette = false;
 
-		public object Create(ActorInitializer init) { return new PaletteFromPng(init.World, this); }
+		public override object Create(ActorInitializer init) { return new PaletteFromPng(init.World, this); }
 
 		string IProvidesCursorPaletteInfo.Palette { get { return CursorPalette ? Name : null; } }
 

--- a/OpenRA.Mods.Common/Traits/World/PaletteFromRGBA.cs
+++ b/OpenRA.Mods.Common/Traits/World/PaletteFromRGBA.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Creates a single color palette without any base palette file.")]
-	class PaletteFromRGBAInfo : ITraitInfo
+	class PaletteFromRGBAInfo : TraitInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -44,7 +44,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Index set to be fully transparent/invisible.")]
 		public readonly int TransparentIndex = 0;
 
-		public object Create(ActorInitializer init) { return new PaletteFromRGBA(init.World, this); }
+		public override object Create(ActorInitializer init) { return new PaletteFromRGBA(init.World, this); }
 	}
 
 	class PaletteFromRGBA : ILoadsPalettes

--- a/OpenRA.Mods.Common/Traits/World/PathFinder.cs
+++ b/OpenRA.Mods.Common/Traits/World/PathFinder.cs
@@ -19,9 +19,9 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Calculates routes for mobile units based on the A* search algorithm.", " Attach this to the world actor.")]
-	public class PathFinderInfo : ITraitInfo, Requires<LocomotorInfo>
+	public class PathFinderInfo : TraitInfo, Requires<LocomotorInfo>
 	{
-		public object Create(ActorInitializer init)
+		public override object Create(ActorInitializer init)
 		{
 			return new PathFinderUnitPathCacheDecorator(new PathFinder(init.World), new PathCacheStorage(init.World));
 		}

--- a/OpenRA.Mods.Common/Traits/World/RadarPings.cs
+++ b/OpenRA.Mods.Common/Traits/World/RadarPings.cs
@@ -16,14 +16,14 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class RadarPingsInfo : ITraitInfo
+	public class RadarPingsInfo : TraitInfo
 	{
 		public readonly int FromRadius = 200;
 		public readonly int ToRadius = 15;
 		public readonly int ShrinkSpeed = 4;
 		public readonly float RotationSpeed = 0.12f;
 
-		public object Create(ActorInitializer init) { return new RadarPings(this); }
+		public override object Create(ActorInitializer init) { return new RadarPings(this); }
 	}
 
 	public class RadarPings : ITick

--- a/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceLayer.cs
@@ -19,9 +19,9 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Attach this to the world actor.", "Order of the layers defines the Z sorting.")]
-	public class ResourceLayerInfo : ITraitInfo, Requires<ResourceTypeInfo>, Requires<BuildingInfluenceInfo>
+	public class ResourceLayerInfo : TraitInfo, Requires<ResourceTypeInfo>, Requires<BuildingInfluenceInfo>
 	{
-		public virtual object Create(ActorInitializer init) { return new ResourceLayer(init.Self); }
+		public override object Create(ActorInitializer init) { return new ResourceLayer(init.Self); }
 	}
 
 	public class ResourceLayer : IWorldLoaded

--- a/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceRenderer.cs
@@ -18,13 +18,13 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Visualizes the state of the `ResourceLayer`.", " Attach this to the world actor.")]
-	public class ResourceRendererInfo : ITraitInfo, Requires<ResourceLayerInfo>
+	public class ResourceRendererInfo : TraitInfo, Requires<ResourceLayerInfo>
 	{
 		[FieldLoader.Require]
 		[Desc("Only render these ResourceType names.")]
 		public readonly string[] RenderTypes = null;
 
-		public virtual object Create(ActorInitializer init) { return new ResourceRenderer(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new ResourceRenderer(init.Self, this); }
 	}
 
 	public class ResourceRenderer : IWorldLoaded, IRenderOverlay, ITickRender, INotifyActorDisposing

--- a/OpenRA.Mods.Common/Traits/World/ResourceType.cs
+++ b/OpenRA.Mods.Common/Traits/World/ResourceType.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class ResourceTypeInfo : ITraitInfo, IMapPreviewSignatureInfo
+	public class ResourceTypeInfo : TraitInfo, IMapPreviewSignatureInfo
 	{
 		[Desc("Sequence image that holds the different variants.")]
 		public readonly string Image = "resources";
@@ -79,7 +79,7 @@ namespace OpenRA.Mods.Common.Traits
 			}
 		}
 
-		public object Create(ActorInitializer init) { return new ResourceType(this, init.World); }
+		public override object Create(ActorInitializer init) { return new ResourceType(this, init.World); }
 	}
 
 	public class ResourceType : IWorldLoaded

--- a/OpenRA.Mods.Common/Traits/World/ScriptLobbyDropdown.cs
+++ b/OpenRA.Mods.Common/Traits/World/ScriptLobbyDropdown.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Controls the map difficulty, tech level, and short game lobby options.")]
-	public class ScriptLobbyDropdownInfo : ITraitInfo, ILobbyOptions
+	public class ScriptLobbyDropdownInfo : TraitInfo, ILobbyOptions
 	{
 		[FieldLoader.Require]
 		[Desc("Internal id for this option.")]
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 				new ReadOnlyDictionary<string, string>(Values), Default, Locked);
 		}
 
-		public object Create(ActorInitializer init) { return new ScriptLobbyDropdown(this); }
+		public override object Create(ActorInitializer init) { return new ScriptLobbyDropdown(this); }
 	}
 
 	public class ScriptLobbyDropdown : INotifyCreated

--- a/OpenRA.Mods.Common/Traits/World/Selection.cs
+++ b/OpenRA.Mods.Common/Traits/World/Selection.cs
@@ -17,9 +17,9 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class SelectionInfo : ITraitInfo
+	public class SelectionInfo : TraitInfo
 	{
-		public object Create(ActorInitializer init) { return new Selection(this); }
+		public override object Create(ActorInitializer init) { return new Selection(this); }
 	}
 
 	public class Selection : ISelection, INotifyCreated, INotifyOwnerChanged, ITick, IGameSaveTraitData

--- a/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/ShroudRenderer.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class ShroudRendererInfo : ITraitInfo
+	public class ShroudRendererInfo : TraitInfo
 	{
 		public readonly string Sequence = "shroud";
 		[SequenceReference("Sequence")]
@@ -54,7 +54,7 @@ namespace OpenRA.Mods.Common.Traits
 		public readonly int OverrideFogIndex = 15;
 
 		public readonly BlendMode ShroudBlend = BlendMode.Alpha;
-		public object Create(ActorInitializer init) { return new ShroudRenderer(init.World, this); }
+		public override object Create(ActorInitializer init) { return new ShroudRenderer(init.World, this); }
 	}
 
 	public sealed class ShroudRenderer : IRenderShroud, IWorldLoaded, INotifyActorDisposing

--- a/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SmudgeLayer.cs
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[Desc("Attach this to the world actor.", "Order of the layers defines the Z sorting.")]
-	public class SmudgeLayerInfo : ITraitInfo
+	public class SmudgeLayerInfo : TraitInfo
 	{
 		public readonly string Type = "Scorch";
 
@@ -73,7 +73,7 @@ namespace OpenRA.Mods.Common.Traits
 			return smudges;
 		}
 
-		public object Create(ActorInitializer init) { return new SmudgeLayer(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new SmudgeLayer(init.Self, this); }
 	}
 
 	public class SmudgeLayer : IRenderOverlay, IWorldLoaded, ITickRender, INotifyActorDisposing

--- a/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
+++ b/OpenRA.Mods.Common/Traits/World/SpawnMPUnits.cs
@@ -19,7 +19,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Spawn base actor at the spawnpoint and support units in an annulus around the base actor. Both are defined at MPStartUnits. Attach this to the world actor.")]
-	public class SpawnMPUnitsInfo : ITraitInfo, Requires<MPStartLocationsInfo>, Requires<MPStartUnitsInfo>, ILobbyOptions
+	public class SpawnMPUnitsInfo : TraitInfo, Requires<MPStartLocationsInfo>, Requires<MPStartUnitsInfo>, ILobbyOptions
 	{
 		public readonly string StartingUnitsClass = "none";
 
@@ -53,7 +53,7 @@ namespace OpenRA.Mods.Common.Traits
 					new ReadOnlyDictionary<string, string>(startingUnits), StartingUnitsClass, DropdownLocked);
 		}
 
-		public object Create(ActorInitializer init) { return new SpawnMPUnits(this); }
+		public override object Create(ActorInitializer init) { return new SpawnMPUnits(this); }
 	}
 
 	public class SpawnMPUnits : IWorldLoaded

--- a/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
+++ b/OpenRA.Mods.Common/Traits/World/StartGameNotification.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	class StartGameNotificationInfo : ITraitInfo
+	class StartGameNotificationInfo : TraitInfo
 	{
 		[NotificationReference("Speech")]
 		public readonly string Notification = "StartGame";
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		[NotificationReference("Speech")]
 		public readonly string SavedNotification = "GameSaved";
 
-		public object Create(ActorInitializer init) { return new StartGameNotification(this); }
+		public override object Create(ActorInitializer init) { return new StartGameNotification(this); }
 	}
 
 	class StartGameNotification : IWorldLoaded, INotifyGameLoaded, INotifyGameSaved

--- a/OpenRA.Mods.Common/Traits/World/SubterraneanActorLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/SubterraneanActorLayer.cs
@@ -14,7 +14,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class SubterraneanActorLayerInfo : ITraitInfo
+	public class SubterraneanActorLayerInfo : TraitInfo
 	{
 		[Desc("Terrain type of the underground layer.")]
 		public readonly string TerrainType = "Subterranean";
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Cell radius for smoothing adjacent cell heights.")]
 		public readonly int SmoothingRadius = 2;
 
-		public object Create(ActorInitializer init) { return new SubterraneanActorLayer(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new SubterraneanActorLayer(init.Self, this); }
 	}
 
 	public class SubterraneanActorLayer : ICustomMovementLayer

--- a/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainRenderer.cs
@@ -15,9 +15,9 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class TerrainRendererInfo : ITraitInfo
+	public class TerrainRendererInfo : TraitInfo
 	{
-		public object Create(ActorInitializer init) { return new TerrainRenderer(init.World); }
+		public override object Create(ActorInitializer init) { return new TerrainRenderer(init.World); }
 	}
 
 	public sealed class TerrainRenderer : IRenderTerrain, IWorldLoaded, INotifyActorDisposing

--- a/OpenRA.Mods.Common/Traits/World/TerrainTunnelLayer.cs
+++ b/OpenRA.Mods.Common/Traits/World/TerrainTunnelLayer.cs
@@ -15,12 +15,12 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.Common.Traits
 {
-	public class TerrainTunnelLayerInfo : ITraitInfo, Requires<DomainIndexInfo>, ILobbyCustomRulesIgnore
+	public class TerrainTunnelLayerInfo : TraitInfo, Requires<DomainIndexInfo>, ILobbyCustomRulesIgnore
 	{
 		[Desc("Terrain type used by cells outside any tunnel footprint.")]
 		public readonly string ImpassableTerrainType = "Impassable";
 
-		public object Create(ActorInitializer init) { return new TerrainTunnelLayer(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new TerrainTunnelLayer(init.Self, this); }
 	}
 
 	public class TerrainTunnelLayer : ICustomMovementLayer, IWorldLoaded

--- a/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/WarheadDebugOverlay.cs
@@ -18,11 +18,11 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Part of the combat overlay from DeveloperMode. Attach this to the world actor.")]
-	public class WarheadDebugOverlayInfo : ITraitInfo
+	public class WarheadDebugOverlayInfo : TraitInfo
 	{
 		public readonly int DisplayDuration = 25;
 
-		public object Create(ActorInitializer init) { return new WarheadDebugOverlay(this); }
+		public override object Create(ActorInitializer init) { return new WarheadDebugOverlay(this); }
 	}
 
 	public class WarheadDebugOverlay : IRenderAnnotations

--- a/OpenRA.Mods.Common/Traits/World/WeatherOverlay.cs
+++ b/OpenRA.Mods.Common/Traits/World/WeatherOverlay.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.Common.Traits
 {
 	[Desc("Adds a particle-based overlay.")]
-	public class WeatherOverlayInfo : ITraitInfo, ILobbyCustomRulesIgnore
+	public class WeatherOverlayInfo : TraitInfo, ILobbyCustomRulesIgnore
 	{
 		[Desc("Average number of particles per 100x100 px square.")]
 		public readonly int ParticleDensityFactor = 8;
@@ -68,7 +68,7 @@ namespace OpenRA.Mods.Common.Traits
 		[Desc("Works only with line enabled and can be used to fade out the tail of the line like a contrail.")]
 		public readonly byte LineTailAlphaValue = 200;
 
-		public object Create(ActorInitializer init) { return new WeatherOverlay(init.World, this); }
+		public override object Create(ActorInitializer init) { return new WeatherOverlay(init.World, this); }
 	}
 
 	public class WeatherOverlay : ITick, IRenderAboveWorld, INotifyViewportZoomExtentsChanged

--- a/OpenRA.Mods.Common/TraitsInterfaces.cs
+++ b/OpenRA.Mods.Common/TraitsInterfaces.cs
@@ -32,12 +32,12 @@ namespace OpenRA.Mods.Common.Traits
 		Repair = 2
 	}
 
-	public interface IQuantizeBodyOrientationInfo : ITraitInfo
+	public interface IQuantizeBodyOrientationInfo : ITraitInfoInterface
 	{
 		int QuantizedBodyFacings(ActorInfo ai, SequenceProvider sequenceProvider, string race);
 	}
 
-	public interface IPlaceBuildingDecorationInfo : ITraitInfo
+	public interface IPlaceBuildingDecorationInfo : ITraitInfoInterface
 	{
 		IEnumerable<IRenderable> RenderAnnotations(WorldRenderer wr, World w, ActorInfo ai, WPos centerPosition);
 	}
@@ -150,8 +150,8 @@ namespace OpenRA.Mods.Common.Traits
 	[RequireExplicitImplementation]
 	public interface INotifyCapture { void OnCapture(Actor self, Actor captor, Player oldOwner, Player newOwner, BitSet<CaptureType> captureTypes); }
 	public interface INotifyDiscovered { void OnDiscovered(Actor self, Player discoverer, bool playNotification); }
-	public interface IRenderActorPreviewInfo : ITraitInfo { IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init); }
-	public interface ICruiseAltitudeInfo : ITraitInfo { WDist GetCruiseAltitude(); }
+	public interface IRenderActorPreviewInfo : ITraitInfoInterface { IEnumerable<IActorPreview> RenderPreview(ActorPreviewInitializer init); }
+	public interface ICruiseAltitudeInfo : ITraitInfoInterface { WDist GetCruiseAltitude(); }
 
 	public interface IHuskModifier { string HuskActor(Actor self); }
 
@@ -203,7 +203,7 @@ namespace OpenRA.Mods.Common.Traits
 		void Infiltrating(Actor self);
 	}
 
-	public interface ITechTreePrerequisiteInfo : ITraitInfo
+	public interface ITechTreePrerequisiteInfo : ITraitInfoInterface
 	{
 		IEnumerable<string> Prerequisites(ActorInfo info);
 	}
@@ -248,7 +248,7 @@ namespace OpenRA.Mods.Common.Traits
 		void Undeploy(Actor self, bool skipMakeAnim);
 	}
 
-	public interface IAcceptResourcesInfo : ITraitInfo { }
+	public interface IAcceptResourcesInfo : ITraitInfoInterface { }
 	public interface IAcceptResources
 	{
 		void OnDock(Actor harv, DeliverResources dockOrder);
@@ -322,10 +322,10 @@ namespace OpenRA.Mods.Common.Traits
 	}
 
 	[RequireExplicitImplementation]
-	public interface IProductionCostModifierInfo : ITraitInfo { int GetProductionCostModifier(TechTree techTree, string queue); }
+	public interface IProductionCostModifierInfo : ITraitInfoInterface { int GetProductionCostModifier(TechTree techTree, string queue); }
 
 	[RequireExplicitImplementation]
-	public interface IProductionTimeModifierInfo : ITraitInfo { int GetProductionTimeModifier(TechTree techTree, string queue); }
+	public interface IProductionTimeModifierInfo : ITraitInfoInterface { int GetProductionTimeModifier(TechTree techTree, string queue); }
 
 	[RequireExplicitImplementation]
 	public interface ICashTricklerModifier { int GetCashTricklerModifier(); }
@@ -398,7 +398,7 @@ namespace OpenRA.Mods.Common.Traits
 	public enum ActorPreviewType { PlaceBuilding, ColorPicker, MapEditorSidebar }
 
 	[RequireExplicitImplementation]
-	public interface IActorPreviewInitInfo : ITraitInfo
+	public interface IActorPreviewInitInfo : ITraitInfoInterface
 	{
 		IEnumerable<object> ActorPreviewInits(ActorInfo ai, ActorPreviewType type);
 	}

--- a/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
+++ b/OpenRA.Mods.Common/UtilityCommands/ExtractTraitDocsCommand.cs
@@ -45,7 +45,7 @@ namespace OpenRA.Mods.Common.UtilityCommands
 			var doc = new StringBuilder();
 			var currentNamespace = "";
 
-			foreach (var t in Game.ModData.ObjectCreator.GetTypesImplementing<ITraitInfo>().OrderBy(t => t.Namespace))
+			foreach (var t in Game.ModData.ObjectCreator.GetTypesImplementing<TraitInfo>().OrderBy(t => t.Namespace))
 			{
 				if (t.ContainsGenericParameters || t.IsAbstract)
 					continue; // skip helpers like TraitInfo<T>

--- a/OpenRA.Mods.D2k/Traits/Buildings/LaysTerrain.cs
+++ b/OpenRA.Mods.D2k/Traits/Buildings/LaysTerrain.cs
@@ -15,7 +15,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits
 {
-	public class LaysTerrainInfo : ITraitInfo, Requires<BuildingInfo>
+	public class LaysTerrainInfo : TraitInfo, Requires<BuildingInfo>
 	{
 		[Desc("The terrain template to place. If the template is PickAny, then " +
 			"the actor footprint will be filled with this tile.")]
@@ -29,7 +29,7 @@ namespace OpenRA.Mods.D2k.Traits
 			"Tiles being offset out of the actor's footprint will not be placed.")]
 		public readonly CVec Offset = CVec.Zero;
 
-		public object Create(ActorInitializer init) { return new LaysTerrain(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new LaysTerrain(init.Self, this); }
 	}
 
 	public class LaysTerrain : INotifyAddedToWorld

--- a/OpenRA.Mods.D2k/Traits/Player/HarvesterInsurance.cs
+++ b/OpenRA.Mods.D2k/Traits/Player/HarvesterInsurance.cs
@@ -16,9 +16,9 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.D2k.Traits
 {
 	[Desc("A player with this trait will receive a free harvester when his last one gets eaten by a sandworm, provided he has at least one refinery.")]
-	public class HarvesterInsuranceInfo : ITraitInfo
+	public class HarvesterInsuranceInfo : TraitInfo
 	{
-		public object Create(ActorInitializer init) { return new HarvesterInsurance(init.Self); }
+		public override object Create(ActorInitializer init) { return new HarvesterInsurance(init.Self); }
 	}
 
 	public class HarvesterInsurance

--- a/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
+++ b/OpenRA.Mods.D2k/Traits/SpiceBloom.cs
@@ -21,7 +21,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.D2k.Traits
 {
 	[Desc("Seeds resources by explosive eruptions after accumulation times.")]
-	public class SpiceBloomInfo : ITraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>
+	public class SpiceBloomInfo : TraitInfo, IRenderActorPreviewSpritesInfo, Requires<RenderSpritesInfo>
 	{
 		[SequenceReference]
 		public readonly string[] GrowthSequences = { "grow1", "grow2", "grow3" };
@@ -47,7 +47,7 @@ namespace OpenRA.Mods.D2k.Traits
 		[Desc("The maximum distance in cells that spice may be expelled.")]
 		public readonly int Range = 5;
 
-		public object Create(ActorInitializer init) { return new SpiceBloom(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new SpiceBloom(init.Self, this); }
 
 		public IEnumerable<IActorPreview> RenderPreviewSprites(ActorPreviewInitializer init, RenderSpritesInfo rs, string image, int facings, PaletteReference p)
 		{

--- a/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
+++ b/OpenRA.Mods.D2k/Traits/World/BuildableTerrainLayer.cs
@@ -17,7 +17,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.D2k.Traits
 {
 	[Desc("Attach this to the world actor. Required for LaysTerrain to work.")]
-	public class BuildableTerrainLayerInfo : ITraitInfo
+	public class BuildableTerrainLayerInfo : TraitInfo
 	{
 		[Desc("Palette to render the layer sprites in.")]
 		public readonly string Palette = TileSet.TerrainPaletteInternalName;
@@ -25,7 +25,7 @@ namespace OpenRA.Mods.D2k.Traits
 		[Desc("The hitpoints, which can be reduced by the DamagesConcreteWarhead.")]
 		public readonly int MaxStrength = 9000;
 
-		public object Create(ActorInitializer init) { return new BuildableTerrainLayer(init.Self, this); }
+		public override object Create(ActorInitializer init) { return new BuildableTerrainLayer(init.Self, this); }
 	}
 
 	public class BuildableTerrainLayer : IRenderOverlay, IWorldLoaded, ITickRender, INotifyActorDisposing

--- a/OpenRA.Mods.D2k/Traits/World/D2kFogPalette.cs
+++ b/OpenRA.Mods.D2k/Traits/World/D2kFogPalette.cs
@@ -16,7 +16,7 @@ using OpenRA.Traits;
 
 namespace OpenRA.Mods.D2k.Traits
 {
-	class D2kFogPaletteInfo : ITraitInfo
+	class D2kFogPaletteInfo : TraitInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -31,7 +31,7 @@ namespace OpenRA.Mods.D2k.Traits
 		[Desc("Allow palette modifiers to change the palette.")]
 		public readonly bool AllowModifiers = true;
 
-		public object Create(ActorInitializer init) { return new D2kFogPalette(this); }
+		public override object Create(ActorInitializer init) { return new D2kFogPalette(this); }
 	}
 
 	class D2kFogPalette : ILoadsPalettes, IProvidesAssetBrowserPalettes

--- a/OpenRA.Mods.D2k/Traits/World/PaletteFromScaledPalette.cs
+++ b/OpenRA.Mods.D2k/Traits/World/PaletteFromScaledPalette.cs
@@ -18,7 +18,7 @@ using OpenRA.Traits;
 namespace OpenRA.Mods.D2k.Traits
 {
 	[Desc("Create a palette by applying a scale and offset to the colors in another palette.")]
-	class PaletteFromScaledPaletteInfo : ITraitInfo
+	class PaletteFromScaledPaletteInfo : TraitInfo
 	{
 		[PaletteDefinition]
 		[FieldLoader.Require]
@@ -39,7 +39,7 @@ namespace OpenRA.Mods.D2k.Traits
 		[Desc("Amount to offset the base palette colors by.")]
 		public readonly int Offset = 0;
 
-		public object Create(ActorInitializer init) { return new PaletteFromScaledPalette(this); }
+		public override object Create(ActorInitializer init) { return new PaletteFromScaledPalette(this); }
 	}
 
 	class PaletteFromScaledPalette : ILoadsPalettes, IProvidesAssetBrowserPalettes

--- a/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
+++ b/OpenRA.Test/OpenRA.Game/ActorInfoTest.cs
@@ -15,8 +15,8 @@ using OpenRA.Traits;
 
 namespace OpenRA.Test
 {
-	interface IMock : ITraitInfo { }
-	class MockTraitInfo : ITraitInfo { public object Create(ActorInitializer init) { return null; } }
+	interface IMock : ITraitInfoInterface { }
+	class MockTraitInfo : TraitInfo { public override object Create(ActorInitializer init) { return null; } }
 	class MockInheritInfo : MockTraitInfo { }
 	class MockAInfo : MockInheritInfo, IMock { }
 	class MockBInfo : MockTraitInfo, Requires<MockAInfo>, Requires<IMock>, Requires<MockInheritInfo> { }
@@ -31,7 +31,7 @@ namespace OpenRA.Test
 		[TestCase(TestName = "Trait ordering sorts in dependency order correctly")]
 		public void TraitOrderingSortsCorrectly()
 		{
-			var unorderedTraits = new ITraitInfo[] { new MockBInfo(), new MockCInfo(), new MockAInfo(), new MockBInfo() };
+			var unorderedTraits = new TraitInfo[] { new MockBInfo(), new MockCInfo(), new MockAInfo(), new MockBInfo() };
 			var actorInfo = new ActorInfo("test", unorderedTraits);
 			var orderedTraits = actorInfo.TraitsInConstructOrder().ToArray();
 


### PR DESCRIPTION
This PR swaps out the `ITraitInfo` interface with a new empty abstract `TraitInfo` class as the first step towards #18118. I have avoided any actual logic changes here so we can get this reviewed and merged ASAP to reduce merge conflict pain. This should be an easy review because any mistakes or missed traits will cause a compile error rather than broken logic ingame.