### PR TITLE
Add Tree armor type and remove tree-only warheads from RA nukes

### DIFF
--- a/mods/ra/rules/defaults.yaml
+++ b/mods/ra/rules/defaults.yaml
@@ -898,7 +898,7 @@
 	Health:
 		HP: 50000
 	Armor:
-		Type: Wood
+		Type: Tree
 	Targetable:
 		TargetTypes: Trees
 	WithDamageOverlay@SmallBurn:

--- a/mods/ra/weapons/explosions.yaml
+++ b/mods/ra/weapons/explosions.yaml
@@ -232,8 +232,9 @@ CrateNuke:
 		Damage: 6000
 		Falloff: 1000, 600, 400, 250, 150, 100, 0
 		Delay: 5
-		ValidTargets: GroundActor, WaterActor, AirborneActor
+		ValidTargets: GroundActor, Trees, WaterActor, AirborneActor
 		Versus:
+			Tree: 200
 			Concrete: 25
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
@@ -249,13 +250,6 @@ CrateNuke:
 		ValidTargets: Ground, Infantry
 		Size: 4
 		Delay: 5
-	Warhead@TREEKILL: SpreadDamage
-		Spread: 1c0
-		Damage: 12000
-		Falloff: 1000, 600, 400, 250, 150, 100, 0
-		Delay: 5
-		ValidTargets: Trees
-		DamageTypes: Incendiary
 
 MiniNuke:
 	ValidTargets: Ground, GroundActor, Trees, Water, WaterActor, Underwater, Air, AirborneActor
@@ -298,19 +292,13 @@ MiniNuke:
 		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 10
-		ValidTargets: GroundActor, WaterActor, Underwater, AirborneActor
+		ValidTargets: GroundActor, Trees, WaterActor, Underwater, AirborneActor
 		Versus:
 			Wood: 50
+			Tree: 200
 			Concrete: 25
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
-	Warhead@8Dam_areanuke2: SpreadDamage
-		Spread: 3c0
-		Damage: 12000
-		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		Delay: 10
-		ValidTargets: Trees
-		DamageTypes: Incendiary
 	Warhead@9Res_areanuke2: DestroyResource
 		Size: 3
 		Delay: 10
@@ -319,18 +307,12 @@ MiniNuke:
 		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 15
-		ValidTargets: GroundActor, WaterActor, Underwater
+		ValidTargets: GroundActor, Trees, WaterActor, Underwater
 		Versus:
+			Tree: 300
 			Concrete: 25
 		AffectsParent: true
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
-	Warhead@11Dam_areanuke3: SpreadDamage
-		Spread: 4c0
-		Damage: 18000
-		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		Delay: 15
-		ValidTargets: Trees
-		DamageTypes: Incendiary
 	Warhead@12Res_areanuke3: DestroyResource
 		Size: 4
 		Delay: 15

--- a/mods/ra/weapons/missiles.yaml
+++ b/mods/ra/weapons/missiles.yaml
@@ -333,6 +333,7 @@ SCUD:
 		Versus:
 			None: 90
 			Wood: 75
+			Tree: 75
 			Light: 70
 			Heavy: 40
 			Concrete: 100

--- a/mods/ra/weapons/other.yaml
+++ b/mods/ra/weapons/other.yaml
@@ -9,6 +9,7 @@
 		Versus:
 			None: 90
 			Wood: 50
+			Tree: 50
 			Light: 60
 			Heavy: 25
 			Concrete: 20
@@ -50,6 +51,7 @@ Flamer:
 		Versus:
 			None: 70
 			Wood: 80
+			Tree: 80
 			Light: 40
 			Heavy: 20
 			Concrete: 10

--- a/mods/ra/weapons/superweapons.yaml
+++ b/mods/ra/weapons/superweapons.yaml
@@ -80,18 +80,12 @@ Atomic:
 		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 10
-		ValidTargets: GroundActor, WaterActor, Underwater, AirborneActor
+		ValidTargets: GroundActor, Trees, WaterActor, Underwater, AirborneActor
 		Versus:
 			Wood: 50
+			Tree: 200
 			Concrete: 25
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
-	Warhead@10Dam_areanuke2: SpreadDamage
-		Spread: 3c0
-		Damage: 12000
-		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		Delay: 15
-		ValidTargets: Trees
-		DamageTypes: Incendiary
 	Warhead@11Res_areanuke2: DestroyResource
 		Size: 3
 		Delay: 10
@@ -105,17 +99,11 @@ Atomic:
 		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 15
-		ValidTargets: GroundActor, WaterActor, Underwater, AirborneActor
+		ValidTargets: GroundActor, Trees, WaterActor, Underwater, AirborneActor
 		Versus:
+			Tree: 200
 			Concrete: 25
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
-	Warhead@14Dam_areanuke3: SpreadDamage
-		Spread: 4c0
-		Damage: 12000
-		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		Delay: 15
-		ValidTargets: Trees
-		DamageTypes: Incendiary
 	Warhead@15Res_areanuke3: DestroyResource
 		Size: 4
 		Delay: 15
@@ -129,17 +117,11 @@ Atomic:
 		Damage: 6000
 		Falloff: 1000, 368, 135, 50, 18, 7, 0
 		Delay: 20
-		ValidTargets: GroundActor, WaterActor, Underwater, AirborneActor
+		ValidTargets: GroundActor, Trees, WaterActor, Underwater, AirborneActor
 		Versus:
+			Tree: 200
 			Concrete: 25
 		DamageTypes: Prone50Percent, TriggerProne, FireDeath, Incendiary
-	Warhead@18Dam_areanuke4: SpreadDamage
-		Spread: 5c0
-		Damage: 12000
-		Falloff: 1000, 368, 135, 50, 18, 7, 0
-		Delay: 20
-		ValidTargets: Trees
-		DamageTypes: Incendiary
 	Warhead@19Res_areanuke4: DestroyResource
 		Size: 5
 		Delay: 20


### PR DESCRIPTION
This simplifies #12467.
Using a tree-exclusive amor type is far more efficient than adding more `SpreadDamage` warheads, which cost some performance due to their huge Spread (this halves the number of actor look-ups at a given Delay, with one exception mentioned below).

This also restores the 100% efficiency vs. trees for some of the regular nuke damage warheads (which have had reduced efficiency vs. `Wood` since #13643).

Note: `Atomic` had two tree-only warheads with `Delay: 15`, I believe the first one to be a copy-paste error and moved the damage to the regular `SpreadDamageWarhead` with a Delay of 10.

Depends on #18068.