### PR TITLE
Only apply percentages other than 100

### DIFF
--- a/OpenRA.Mods.Common/Util.cs
+++ b/OpenRA.Mods.Common/Util.cs
@@ -139,7 +139,8 @@ namespace OpenRA.Mods.Common
 			// See the comments of PR#6079 for a faster algorithm if this becomes a performance bottleneck
 			var a = (decimal)number;
 			foreach (var p in percentages)
-				a *= p / 100m;
+				if (p != 100)
+					a *= p / 100m;
 
 			return (int)a;
 		}


### PR DESCRIPTION
Terrain needs speeds to be listed to be traversable, and mods sometimes explicitly list damage warhead `Versus` values of 100 for readability reasons.
Similiar cases may exist elsewhere, too.

Skipping values of 100 in `ApplyPercentageModifiers` may save us at least 1 multiplication and 1 division in those cases.