### PR TITLE
Remove bogus weapon override defintions from TD campaign maps

### DIFF
--- a/mods/cnc/maps/gdi04a/map.yaml
+++ b/mods/cnc/maps/gdi04a/map.yaml
@@ -452,4 +452,3 @@ Actors:
 
 Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml
 
-Weapons: weapons.yaml

--- a/mods/cnc/maps/gdi04b/map.yaml
+++ b/mods/cnc/maps/gdi04b/map.yaml
@@ -529,4 +529,3 @@ Actors:
 
 Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml
 
-Weapons: weapons.yaml

--- a/mods/cnc/maps/gdi05a/map.yaml
+++ b/mods/cnc/maps/gdi05a/map.yaml
@@ -758,4 +758,3 @@ Actors:
 
 Rules: cnc|rules/campaign-maprules.yaml, cnc|rules/campaign-tooltips.yaml, cnc|rules/campaign-palettes.yaml, rules.yaml
 
-Weapons: weapons.yaml


### PR DESCRIPTION
Closes #18125.